### PR TITLE
chore(m6): Deprecation & cleanup — remove dead code, document Celery AWS SQS decision

### DIFF
--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -14,7 +14,9 @@ broker_connection_timeout = 30
 redis_socket_connect_timeout = 30
 redis_socket_timeout = 30
 
-## Using the database to store task state and results.
+# AWS deployment decision: use SQS as the broker and ElastiCache Redis as the result backend.
+# Set CELERY_BROKER_URL=sqs:// and CELERY_RESULT_BACKEND=redis://<elasticache-host>:6379/1 in AWS secrets.
+# celery-once still requires CELERY_BROKER_URL to point at Redis for lock tracking (see my_celery.py).
 result_backend = os.getenv('CELERY_RESULT_BACKEND', f'redis://redis:{REDIS_PORT}/1')
 
 # The Redis backend visibility timout

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -33,7 +33,9 @@ app.autodiscover_tasks(['cqc_lem'])
 # Setup Celery Once for task that should only be queued once per parameters sent
 
 app.conf.ONCE = {
-    'backend': 'celery_once.backends.Redis',  # TODO: What should this be for AWS SQS
+    # celery-once uses Redis for deduplication lock tracking even when the Celery broker is SQS.
+    # On AWS, point CELERY_BROKER_URL at the ElastiCache Redis instance (not SQS) so celery-once works.
+    'backend': 'celery_once.backends.Redis',
     'settings': {
         'url': broker_url,
         'default_timeout': 60 * 60,

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1344,11 +1344,6 @@ def invite_to_connect(self, user_id: int, profile_url: str, message: str = None)
     return result
 
 
-def start_process():
-    # TOO: Get reid of this method
-    pass
-
-
 def final_method(drivers: List[WebDriver]):
     global stop_all_thread
     stop_all_thread.set()  # Set the flag to stop other threads

--- a/src/cqc_lem/streamlit/utils.py
+++ b/src/cqc_lem/streamlit/utils.py
@@ -346,27 +346,8 @@ def read_file(file_path: str, convert_to_markdown: bool = False) -> str:
 
     if convert_to_markdown:
         with open(file_path, mode='rb') as f:
-            # results = mammoth.convert_to_markdown(f)
             results = mammoth.convert_to_html(f)
             contents = convert_content_to_markdown(results.value)
-        # contents = results.value
-        # TODO: Need to find alternative to textract as it conflicts with current/needed version of python-pptx
-        cant_use_with_this_project = """elif file_extension == ".docx":
-            # read in a document
-            my_doc = docx.Document(file_path)
-    
-            # Find any tables and replace with json strings
-            tmp_file = convert_tables_to_json_in_tmp__file(my_doc)
-    
-            # coerce to JSON using the standard options
-    
-            # contents = simplify(my_doc)
-    
-            # contents = textract.parsers.process(file_path)
-            # print("Extracting contents from: %s" % tmp_file)
-            contents = textract.process(tmp_file).decode('utf-8')
-            os.remove(tmp_file)
-        """
     else:
         with open(file_path, mode='r') as f:
             contents = f.read()


### PR DESCRIPTION
## Summary

- **#32** Remove `start_process()` from `run_automation.py` — it was marked "get rid of this method" with an empty `pass` body; only caller was already commented out
- **#33** Remove textract dead-code block from `streamlit/utils.py` — textract conflicts with `python-pptx`; the code was already wrapped in a dead string variable `cant_use_with_this_project`; mammoth handles .docx conversion and is already in use; textract was never in `pyproject.toml`
- **#34** Document Celery AWS SQS deployment decision in `celeryconfig.py` and `my_celery.py`: **SQS as broker** + **ElastiCache Redis as result backend**; celery-once still needs Redis for lock tracking even when SQS is the broker — clarified with comments

## Test plan

- [ ] `poetry run pytest tests/unit -v --tb=short`
- [ ] `grep -rn "start_process" src/` — no results
- [ ] `grep -rn "textract" src/` — no results
- [ ] `grep -rn "cant_use_with_this_project" src/` — no results
- [ ] Verify celeryconfig.py comment clearly documents the AWS SQS+ElastiCache decision

Closes #32
Closes #33
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)