### PR TITLE
fix(infra/auth): litellm healthcheck, LinkedIn OAuth dynamic URL, PostHog error silencing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ LI_PASSWORD=yourpassword
 # LinkedIn API Credentials
 LI_CLIENT_ID=your-client-id
 LI_CLIENT_SECRET=your-client-secret
+# LI_REDIRECT_URL is auto-overridden by NGROK_CUSTOM_DOMAIN when set (see env_constants.py)
 LI_REDIRECT_URL=https://your.redirecturl.com/auth/linkedin/callback
 LI_STATE_SALT=your_salt_text
 LI_API_VERSION=202401
@@ -76,10 +77,14 @@ CELERY_WORKER_NAME=worker@%h
 TZ=America/New_York
 
 # Ngrok Auth Credentials (optional tunneling for local dev)
+# NGROK_PLAN controls tunnel behavior:
+#   off  — ngrok is disabled (default)
+#   free — one static domain (NGROK_CUSTOM_DOMAIN) for the app; other tunnels get dynamic random URLs
+#   paid — all services get custom subdomains (requires a paid ngrok plan)
+NGROK_PLAN=off
 NGROK_UI_PORT=4040
 NGROK_AUTH_TOKEN=your_token
 NGROK_CUSTOM_DOMAIN=your_custom_domain
-NGROK_EDGE_TOKEN=your_edge_token
 NGROK_FREE_DOMAIN=ngrok-free.dev
 NGROK_API_PREFIX=your_api_prefix
 NGROK_FLOWER_PREFIX=your_flower_prefix

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
       - OLLAMA_CLOUD_API_KEY=${OLLAMA_CLOUD_API_KEY}
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:4000/health/liveliness >/dev/null || exit 1"]
+      test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')\" 2>/dev/null || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -351,6 +351,18 @@ def get_assets(file_name: str, content_type: Optional[str] = None,
         return FileResponse(status_code=200, path=file_path, media_type=mim_type, content_disposition_type=content_type)
 
 
+# LinkedIn OAuth initiation — builds the authorization URL and redirects user to LinkedIn
+@app.get("/auth/linkedin/", response_model=None, include_in_schema=False)
+@router.get("/auth/linkedin/", response_model=None, include_in_schema=False)
+def linkedin_auth_init(email: str = None) -> RedirectResponse:
+    client = AuthClient(LI_CLIENT_ID, LI_CLIENT_SECRET, LI_REDIRECT_URL)
+    auth_url = client.generate_member_auth_url(
+        state=LI_STATE_SALT,
+        scopes=["openid", "profile", "email", "w_member_social"]
+    )
+    return RedirectResponse(url=auth_url)
+
+
 # LinkedIn OAuth callback lives outside /api since LinkedIn redirects here
 @app.get("/auth/linkedin/callback", response_model=None)
 def linkedin_callback(code: str, state: str = None) -> Union[ResponseModel, RedirectResponse]:
@@ -390,7 +402,7 @@ def linkedin_callback(code: str, state: str = None) -> Union[ResponseModel, Redi
     final_redirect_url = urlunparse((parsed_url.scheme, netloc, '/account', '', '', ''))
 
     if os.environ.get('NGROK_CUSTOM_DOMAIN'):
-        final_redirect_url = "http://" + os.environ.get('NGROK_CUSTOM_DOMAIN') + '/account'
+        final_redirect_url = "https://" + os.environ.get('NGROK_CUSTOM_DOMAIN') + '/account'
 
     return RedirectResponse(url=final_redirect_url)
 

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -65,8 +65,15 @@ AWS_ENV_TAG=get_constant_from_env('AWS_ENV_TAG', default_value='dev')
 AWS_REGION=get_constant_from_env('AWS_REGION')
 AWS_MYSQL_SECRET_NAME=get_constant_from_env('AWS_MYSQL_SECRET_NAME')
 
+NGROK_CUSTOM_DOMAIN=get_constant_from_env('NGROK_CUSTOM_DOMAIN')
 NGROK_FREE_DOMAIN=get_constant_from_env('NGROK_FREE_DOMAIN')
 NGROK_API_PREFIX=get_constant_from_env('NGROK_API_PREFIX')
+
+# Dynamic LinkedIn redirect URL: NGROK_CUSTOM_DOMAIN takes precedence over static LI_REDIRECT_URL
+# when running in a dev/ngrok environment (the ngrok domain is registered in the LinkedIn developer app)
+if NGROK_CUSTOM_DOMAIN:
+    LI_REDIRECT_URL = f"https://{NGROK_CUSTOM_DOMAIN}/auth/linkedin/callback"
+
 # If both NGROK_FREE_DOMAIN and NGROK_API_PREFIX are not None then set API_BASE_URL as the concatenation of both
 if NGROK_FREE_DOMAIN and NGROK_API_PREFIX:
     API_BASE_URL = f"https://{NGROK_API_PREFIX}.{NGROK_FREE_DOMAIN}"

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -8,6 +8,9 @@ import posthog
 posthog.api_key = os.getenv("POSTHOG_API_KEY", "")
 posthog.host = os.getenv("POSTHOG_HOST", "https://us.i.posthog.com")
 
+# Suppress API errors (e.g. 401 from personal vs project key mismatch) silently
+posthog.on_error = lambda e, items: None
+
 # Disable PostHog when no key configured (local dev without key)
 if not posthog.api_key:
     posthog.disabled = True


### PR DESCRIPTION
## Summary

- **litellm healthcheck**: replaced `curl` (not in litellm image) with `python3 urllib` — fixes `(unhealthy)` status that was causing `FailingStreak: 95` in logs
- **LinkedIn OAuth initiation**: added `GET /auth/linkedin/` and `GET /api/auth/linkedin/` routes that call `AuthClient.generate_member_auth_url()` — the Account page "Connect LinkedIn" button now works
- **Dynamic LinkedIn redirect URL**: `NGROK_CUSTOM_DOMAIN` in `.env` now automatically overrides `LI_REDIRECT_URL` to `https://{NGROK_CUSTOM_DOMAIN}/auth/linkedin/callback` — no manual update needed when ngrok restarts
- **Post-auth redirect**: fixed `http://` → `https://` when redirecting back to `/account` after LinkedIn OAuth with ngrok
- **PostHog error silencing**: added `posthog.on_error = lambda e, items: None` to suppress repeated 401 log spam from personal API key (`phx_`) mismatch

## Test plan

- [ ] Restart litellm container — healthcheck should pass within 60s
- [ ] Navigate to Account page → "Connect LinkedIn" button redirects to LinkedIn OAuth
- [ ] With `NGROK_CUSTOM_DOMAIN=relegable-preroyally-marti.ngrok-free.dev` set, `/api/auth/linkedin/` uses the ngrok callback URL
- [ ] No PostHog 401 errors in `web_app` or `celery_worker` logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)