### PR TITLE
fix(docker): disable flower persistence to fix corrupted shelve DB crash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,8 +123,7 @@ services:
       - .env
     environment:
       - FLOWER_UNAUTHENTICATED_API=True
-      - FLOWER_PERSISTENT=True
-      - FLOWER_SAVE_STATE_INTERVAL=${CELERY_FLOWER_STATE_SAVE_INTERVAL}
+      - FLOWER_PERSISTENT=False
     ports:
       - "${CELERY_FLOWER_PORT}:5555"
     depends_on:


### PR DESCRIPTION
## Summary

- Flower was crashing on startup with `dbm.error: db type could not be determined` — the `flower_db` volume contained a shelve file from a different Python/dbm implementation that could not be read
- Set `FLOWER_PERSISTENT=False` so flower no longer tries to read/write the incompatible shelve file
- Removed `FLOWER_SAVE_STATE_INTERVAL` which is only relevant when persistence is enabled

## Test plan

- [ ] `docker compose up celery_flower` starts and stays running
- [ ] Flower UI accessible at configured `CELERY_FLOWER_PORT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)