### PR TITLE
fix(flower): remove hardcoded persistence flags causing startup crash

### DIFF
--- a/compose/local/celery/flower/start-no-wait
+++ b/compose/local/celery/flower/start-no-wait
@@ -6,19 +6,12 @@ set -o nounset
 celery --app cqc_lem.app.my_celery \
   --broker="${CELERY_BROKER_URL}" \
   flower \
-  ---port="${CELERY_FLOWER_PORT}" \
+  --port="${CELERY_FLOWER_PORT}" \
   --broker-api="${CELERY_BROKER_URL}" \
   --logging="DEBUG" \
   --logfile="/app/logs" \
-  --state_save_interval="${CELERY_FLOWER_STATE_SAVE_INTERVAL}" \
-  --persistent=True \
-  --db=/data/flower.db \
   --debug=True &
 
-  # TODO: Get the db state working
-  #--persistent=True \
-  #--state_save_interval=180 \
-  #--db=/data/flower.db &
   #--basic_auth=admin:${CELERY_FLOWER_PASSWORD} \
 
   #-Q (your queue name)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,8 +123,7 @@ services:
       - .env
     environment:
       - FLOWER_UNAUTHENTICATED_API=True
-      - FLOWER_PERSISTENT=True
-      - FLOWER_SAVE_STATE_INTERVAL=${CELERY_FLOWER_STATE_SAVE_INTERVAL}
+      - FLOWER_PERSISTENT=False
     ports:
       - "${CELERY_FLOWER_PORT}:5555"
     depends_on:


### PR DESCRIPTION
## Summary

- The `start-no-wait` script hardcoded `--persistent=True --db=/data/flower.db` — these flags override any `FLOWER_PERSISTENT` env var and caused a crash when the shelve db file was incompatible with the current Python/dbm version
- Fixed the `---port` typo (triple dash) that was silently breaking the port flag
- Removed `--state_save_interval` reference (CELERY_FLOWER_STATE_SAVE_INTERVAL was also removed from docker-compose environment)

## Test plan

- [ ] `docker compose up flower` starts and stays running
- [ ] Flower UI is accessible at `http://localhost:{CELERY_FLOWER_PORT}`
- [ ] Celery workers visible in Flower UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)