### PR TITLE
fix(auth/ui/infra): account save, OAuth email handoff, Docker UI build, DM/carousel features

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,6 +27,12 @@ pip-delete-this-directory.txt
 src/cqc_lem/assets/
 src/cqc_lem/aws/
 compose/local/linkedinpreview/
+# Streamlit UI replaced by React SPA — not run in Docker
+src/cqc_lem/streamlit/
+# React source is only needed by the ui-builder stage (node:22-slim).
+# The Python builder stage gets the compiled dist via COPY --from=ui-builder.
+# node_modules must be excluded to prevent gigabytes from leaking into the build context.
+src/cqc_lem/ui/node_modules/
 
 # Development and IDE
 .git/

--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ LI_CLIENT_SECRET=your-client-secret
 # LI_REDIRECT_URL is auto-overridden by NGROK_CUSTOM_DOMAIN when set (see env_constants.py)
 LI_REDIRECT_URL=https://your.redirecturl.com/auth/linkedin/callback
 LI_STATE_SALT=your_salt_text
-LI_API_VERSION=202401
+LI_API_VERSION=202501
 LI_USERINFO_RESOURCE=/userinfo
 LI_POSTS_RESOURCE=/posts
 
@@ -44,6 +44,27 @@ OLLAMA_CLOUD_API_KEY=your_ollama_cloud_api_key
 # PostHog Observability (LLM usage, task metrics, API latency)
 POSTHOG_API_KEY=your_posthog_api_key
 POSTHOG_HOST=https://us.i.posthog.com
+
+# SendGrid (PIN email delivery for login/signup — primary provider)
+SENDGRID_API_KEY=your_sendgrid_api_key
+SENDGRID_FROM_EMAIL=noreply@yourapp.com
+
+# SMTP fallback (Gmail or any STARTTLS server — used if SendGrid is unset or fails)
+# For Gmail, generate an App Password at https://myaccount.google.com/apppasswords
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=your_gmail@gmail.com
+SMTP_PASSWORD=your_gmail_app_password
+
+# Stripe (subscription billing — use sk_test_* keys for test mode, sk_live_* for production)
+STRIPE_API_KEY=sk_test_your_stripe_secret_key
+STRIPE_WEBHOOK_SECRET=whsec_your_webhook_signing_secret
+# Create these price IDs in your Stripe dashboard under Products → Pricing
+STRIPE_PRICE_ID_STARTER=price_starter_test
+STRIPE_PRICE_ID_PROFESSIONAL=price_professional_test
+STRIPE_PRICE_ID_ENTERPRISE=price_enterprise_test
+# Free trial length in days (default: 14)
+FREE_TRIAL_DAYS=14
 
 # Pexels Credentials (free stock photos for carousel slides)
 PEXELS_API_KEY=your_pexels_api_key

--- a/README.md
+++ b/README.md
@@ -2,62 +2,90 @@
 
 ## Overview
 
-LinkedIn Engagement Manager (LEM) is an automated solution for managing engagement and post interactions on LinkedIn. This tool allows users to automate the process of commenting, sending direct messages (DMs), responding to comments, and scheduling posts. All content (text, carousels, videos) is AI-generated and passes through sentiment analysis for appropriateness. LEM also includes a preview and approval system, enabling manual or automated approval of content.
+LinkedIn Engagement Manager (LEM) is an automated solution for managing engagement and post interactions on LinkedIn. This tool automates commenting, sending direct messages (DMs), responding to comments, and scheduling posts. All content (text, carousels, videos) is AI-generated via a LiteLLM proxy and passes through sentiment analysis for appropriateness. LEM includes a preview and approval system enabling manual or automated content approval before publishing.
 
 ## Key Features
 - **Automated Engagement**: Commenting, messaging profile viewers, and replying to post comments with scheduled engagement tasks.
-- **AI-Generated Content**: Modular AI services generate carousel, text, and video content.
-- **Sentiment Analysis**: Ensures content is appropriate, aligned with user preferences.
-- **Approval Workflow**: Preview and approve content before publishing or allow for automatic approval.
+- **AI-Generated Content**: LiteLLM-proxied AI services generate carousel, text, and video content with tiered model routing (`lem-simple`, `lem-medium`, `lem-complex`).
+- **Sentiment Analysis**: Ensures content is appropriate and aligned with user preferences.
+- **Approval Workflow**: Preview and approve content before publishing or allow automatic approval.
 - **Video Creation**: Generate videos from prompts using AI.
 - **Summarizing Recent Activity**: Summarize recent LinkedIn activities and craft personalized responses.
 - **Date-Time Picker for Scheduled Posts**: Edit scheduled posts with a date-time picker for easy scheduling.
-- **Dockerized Environment**: Easily deployable to the cloud using Docker containers.
-- **Modular Design**: Content generation modules can be swapped out for any SaaS services.
-- **User Dashboard**: Mobile and web-friendly dashboard for monitoring and controlling the engagement process.
+- **Dockerized Environment**: Easily deployable locally or to the cloud using Docker Compose.
+- **Modular Design**: Content generation modules can be swapped out for any SaaS services via LiteLLM aliases.
+- **React SPA Dashboard**: Mobile and web-friendly React dashboard for monitoring and controlling the engagement process.
+- **Observability**: PostHog-based LLM usage tracking, Celery task metrics, and API latency monitoring.
 
 ## Tech Stack
-- **Python** with **Selenium** for automation tasks.
-- **MySQL** as the relational database.
-- **Docker** to containerize the application for local development and cloud deployment.
-- **AI Services**: Integrated AI models to generate content and perform sentiment analysis.
-- **Streamlit** for the user interface.
+- **Python 3.12+** with **FastAPI** for the backend API.
+- **React 18 + Vite + TailwindCSS** for the single-page frontend.
+- **Selenium 4** (`selenium/standalone-chrome`) for LinkedIn browser automation.
+- **Celery + Redis** for distributed task scheduling and execution.
+- **MySQL 8** as the relational database.
+- **LiteLLM** (port 4000) as an AI proxy routing to OpenAI, Anthropic, Ollama, and OpenRouter.
+- **Docker Compose** for local orchestration; **AWS CDK** for cloud deployment.
+- **PostHog** for observability (LLM cost, task metrics, API latency).
+- **Poetry** for Python dependency management.
 
 ## Getting Started
 
 ### Prerequisites
 1. **Docker** installed on your system.
-2. **Python 3.9+** for local development.
-3. **MySQL 8.0** or above (can be run inside Docker).
-4. **Streamlit** for running the user interface.
-5. Necessary API keys for AI services (e.g., OpenAI API key).
+2. **Python 3.12+** for local development (managed via Poetry).
+3. **Poetry** for Python package management (`pip install poetry`).
+4. **Node.js 18+** for frontend development (only needed if editing the React UI).
+5. API keys for AI services (OpenAI, Anthropic, and/or OpenRouter — at least one required).
+6. (Optional) **ngrok** for exposing local services publicly:
+   ```bash
+   brew install ngrok/ngrok/ngrok
+   ```
 
 ### Installation
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/your-username/linkedin-engagement-manager.git
+   git clone https://github.com/gitchrisqueen/linkedin-engagement-manager.git
    cd linkedin-engagement-manager
    ```
 
 2. Set up the environment:
    ```bash
    cp .env.example .env
-   # Fill in necessary API keys, MySQL credentials, etc.
+   # Fill in required values: MySQL credentials, LinkedIn credentials,
+   # AI API keys, LiteLLM master key, Docker image name, etc.
    ```
 
-3. (Optional) Install ngrok via Homebrew with the following command:
-   ```bash
-   brew install ngrok/ngrok/ngrok
-   ```
+3. (Optional) Configure ngrok by setting `NGROK_AUTH_TOKEN`, `NGROK_CUSTOM_DOMAIN`,
+   `NGROK_EDGE_TOKEN`, and the `NGROK_*_PREFIX` variables in your `.env` file.
 
-4. Build and run the Docker containers via shell scriopt:
+4. Build and run the Docker containers:
    ```bash
    ./run.sh
    ```
+   The script will prompt whether to build and push the Docker image, then start all
+   services and print a table of local (or ngrok) URLs.
 
-4. Access the web dashboard:
-   Open the urls printed in the console in your browser.
+5. Access the services at the URLs printed in the console.
+
+### Docker Image
+
+The main application image (`${DOCKER_IMAGE_NAME}:latest`) is shared by the `web_app`,
+`api`, `celery_worker`, `celery_beat`, and `flower` services. The `run.sh` script
+handles building and optionally pushing this image to Docker Hub.
+
+### AI Proxy (LiteLLM)
+
+All LLM calls are routed through the LiteLLM proxy at `http://litellm:4000`. Model tier
+aliases are defined in `.litellm/config.yaml`:
+
+| Alias | Use case |
+|---|---|
+| `lem-simple` | Short outputs ≤300 chars |
+| `lem-medium` | Balanced: comments, post refinement |
+| `lem-complex` | Long-form: thought leadership, personal story |
+| `lem-image` | Image generation (DALL-E 3) |
+| `lem-router` | Auto-routes by prompt complexity |
 
 ## Testing
 
@@ -83,14 +111,13 @@ This project uses pytest for testing with comprehensive unit, integration, and e
 4. **Run specific test categories:**
    ```bash
    # Run only unit tests
-   poetry run pytest tests/unit -v
-   
-   # Run only integration tests
+   poetry run pytest tests/unit -v --tb=short
+
+   # Run only integration tests (requires MySQL + Redis)
    poetry run pytest tests/integration -v
-   
-   # Run tests by marker
-   poetry run pytest -m "unit" -v
-   poetry run pytest -m "not slow" -v
+
+   # Run end-to-end tests (requires selenium/standalone-chrome)
+   poetry run pytest tests/e2e -v
    ```
 
 5. **Run specific test file:**
@@ -103,38 +130,39 @@ This project uses pytest for testing with comprehensive unit, integration, and e
    poetry run pytest -k "test_database" -v
    ```
 
-7. **Run tests with detailed output:**
-   ```bash
-   poetry run pytest -v --tb=short
-   ```
-
 ### Test Markers
 
 Tests are organized with the following markers:
-- `unit` - Fast unit tests with mocked dependencies
-- `integration` - Integration tests requiring multiple components
-- `e2e` - End-to-end tests
-- `slow` - Tests that take longer to execute
-- `requires_openai` - Tests requiring OpenAI API access
-- `requires_database` - Tests requiring database connection
-- `requires_selenium` - Tests requiring browser automation
+- `unit` — Fast tests with all external I/O mocked
+- `integration` — Require real MySQL + Redis service containers
+- `e2e` — Require `selenium/standalone-chrome` container
+- `slow` — Tests that take longer to execute
+- `requires_openai` — Tests requiring OpenAI API access
+- `requires_database` — Tests requiring a database connection
+- `requires_selenium` — Tests requiring browser automation
 
-### Test Coverage Goals
+### Test Coverage Requirements
 
-- **Minimum Coverage**: 70% of core modules
+- **Minimum Coverage**: 80% of changed code (enforced by Codecov on every PR)
 - **Target Coverage**: 85%+ of core modules
 - **CI/CD**: Automated test execution on all pull requests
 
 ### Continuous Integration
 
-Tests are automatically run on:
-- Every push to `main`, `develop`, or `copilot/**` branches
-- All pull requests to `main` or `develop` branches
+All of the following CI gates must pass before merging any PR:
+- `CI / Unit Tests`
+- `CI / Integration Test w/ Coverage`
+- `CodeQL Security Analysis`
+- `GitGuardian Security Scan`
+
+Tests run automatically on:
+- Every push to `main` or `develop` branches
+- All pull requests targeting `main` or `develop`
 
 View test results in the GitHub Actions tab of the repository.
 
-### Contributing
-We welcome contributions to the project. Please submit a pull request with clear documentation of any changes.
+## Contributing
+We welcome contributions to the project. Please submit a pull request with clear documentation of any changes. All CI gates must pass before review.
 
 ## License
 MIT License.

--- a/README.md
+++ b/README.md
@@ -59,14 +59,27 @@ LinkedIn Engagement Manager (LEM) is an automated solution for managing engageme
 3. (Optional) Configure ngrok by setting `NGROK_AUTH_TOKEN`, `NGROK_CUSTOM_DOMAIN`,
    `NGROK_EDGE_TOKEN`, and the `NGROK_*_PREFIX` variables in your `.env` file.
 
-4. Build and run the Docker containers:
+4. Set up Stripe for subscription billing — see **[docs/stripe-setup-guide.md](docs/stripe-setup-guide.md)** for
+   the full walkthrough. At minimum you need:
+   ```env
+   STRIPE_API_KEY=sk_test_...
+   STRIPE_PRICE_ID_STARTER=price_...
+   STRIPE_PRICE_ID_PROFESSIONAL=price_...
+   STRIPE_PRICE_ID_ENTERPRISE=price_...
+   STRIPE_WEBHOOK_SECRET=whsec_...
+   ```
+   The webhook secret comes from registering your ngrok URL as a Stripe webhook endpoint
+   (same pattern as the LinkedIn OAuth redirect URL). Do **not** use `stripe listen` inside
+   Docker — it generates an ephemeral secret that breaks on every restart.
+
+5. Build and run the Docker containers:
    ```bash
    ./run.sh
    ```
    The script will prompt whether to build and push the Docker image, then start all
    services and print a table of local (or ngrok) URLs.
 
-5. Access the services at the URLs printed in the console.
+6. Access the services at the URLs printed in the console.
 
 ### Docker Image
 

--- a/compose/local/Dockerfile
+++ b/compose/local/Dockerfile
@@ -20,6 +20,18 @@ RUN python3 -m pip install --upgrade pip
 
 WORKDIR /app
 
+# ---------------------------------------------------------------------------
+# Stage: build the React SPA so the dist/ folder exists inside the image.
+# The dist/ directory is .gitignored, so it must be built here.
+# ---------------------------------------------------------------------------
+FROM node:22-slim AS ui-builder
+
+WORKDIR /ui
+COPY ./src/cqc_lem/ui/package.json ./src/cqc_lem/ui/package-lock.json ./
+RUN npm ci
+COPY ./src/cqc_lem/ui ./
+RUN npm run build
+
 FROM base AS builder
 
 # Create arg to install dev dependencies
@@ -43,8 +55,9 @@ ENV PIP_DEFAULT_TIMEOUT=100 \
     PIP_NO_CACHE_DIR=1
 
 
-# Install poetry and make sure the export plugin is included
-RUN pip install "poetry==$POETRY_VERSION" && poetry self add poetry-plugin-export
+# Install poetry and the export plugin into the same pip environment.
+# poetry self add does not work reliably when poetry is pip-installed (vs official installer).
+RUN pip install "poetry==$POETRY_VERSION" poetry-plugin-export
 
 # Copy the poetry.lock and pyproject.toml
 COPY ./pyproject.toml ./poetry.lock ./
@@ -70,6 +83,9 @@ ENV PATH="/app/.venv/bin:$PATH"
 COPY ./src ./src
 COPY ./README.md ./README.md
 
+# Inject the pre-built React SPA dist so FastAPI can serve it
+COPY --from=ui-builder /ui/dist ./src/cqc_lem/ui/dist
+
 # Install our package and clear the cache afterwards.
 #   This may save some MBs.
 RUN if [ "$INSTALL_DEV_DEPS" = "true" ]; then \
@@ -83,7 +99,6 @@ FROM my_app_code AS final
 # Copy and set permissions for entrypoint and other scripts
 COPY ./compose/local/entrypoint /entrypoint
 COPY ./compose/local/wait-for-it /wait-for-it
-COPY ./compose/local/streamlit/start /start-streamlit
 COPY ./compose/local/fastapi/start /start-fastapi
 COPY ./compose/local/fastapi/start-cloud /start-fastapi-cloud
 COPY ./compose/local/celery/worker/start /start-celeryworker
@@ -93,7 +108,7 @@ COPY ./compose/local/celery/flower/start /start-flower
 COPY ./compose/local/celery/flower/start-no-wait /start-flower-no-wait
 
 # Set permissions and create logs directory
-RUN chmod +x /entrypoint /wait-for-it /start-streamlit /start-fastapi \
+RUN chmod +x /entrypoint /wait-for-it /start-fastapi \
     /start-fastapi-cloud /start-celeryworker /start-celeryworker-solo \
     /start-celerybeat /start-flower /start-flower-no-wait && \
     mkdir -p /app/logs

--- a/compose/local/Dockerfile
+++ b/compose/local/Dockerfile
@@ -34,69 +34,55 @@ RUN npm run build
 
 FROM base AS builder
 
-# Create arg to install dev dependencies
 ARG INSTALL_DEV_DEPS=false
-# Set the env variable to use in the next stage
-ENV INSTALL_DEV_DEPS=${INSTALL_DEV_DEPS}
-
-# --- Install Poetry ---
 ARG POETRY_VERSION=2.0
 
 ENV POETRY_HOME=/opt/poetry \
     POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_IN_PROJECT=1 \
     POETRY_VIRTUALENVS_CREATE=1 \
-    # Tell Poetry where to place its cache and virtual environment
-    POETRY_CACHE_DIR=/opt/.cache
-
-# Pip Configuration
-ENV PIP_DEFAULT_TIMEOUT=100 \
+    POETRY_CACHE_DIR=/opt/.cache \
+    PIP_DEFAULT_TIMEOUT=100 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1
 
-
-# Install poetry and the export plugin into the same pip environment.
-# poetry self add does not work reliably when poetry is pip-installed (vs official installer).
 RUN pip install "poetry==$POETRY_VERSION" poetry-plugin-export
 
-# Copy the poetry.lock and pyproject.toml
+# Install deps first (cached layer — only busts when pyproject.toml/poetry.lock change)
 COPY ./pyproject.toml ./poetry.lock ./
-
-# Install the dependencies and clear the cache afterwards.
-#   This may save some MBs.
 RUN if [ "$INSTALL_DEV_DEPS" = "true" ]; then \
-    poetry install --with dev --no-root  && rm -rf $POETRY_CACHE_DIR; \
+    poetry install --with dev --no-root && rm -rf $POETRY_CACHE_DIR; \
     else \
-    poetry install --only main --no-root  && rm -rf $POETRY_CACHE_DIR; \
+    poetry install --only main --no-root && rm -rf $POETRY_CACHE_DIR; \
     fi
 
-
-
-# Now let's build the runtime image from the builder.
-#   We'll just copy the env and the PATH reference.
-FROM builder AS my_app_code
-
-ENV VIRTUAL_ENV=/app/.venv
-ENV PATH="/app/.venv/bin:$PATH"
-
-# Copy app src files
-COPY ./src ./src
+# Copy source and install the project package (busts when src changes)
 COPY ./README.md ./README.md
-
-# Inject the pre-built React SPA dist so FastAPI can serve it
+COPY ./src ./src
 COPY --from=ui-builder /ui/dist ./src/cqc_lem/ui/dist
-
-# Install our package and clear the cache afterwards.
-#   This may save some MBs.
 RUN if [ "$INSTALL_DEV_DEPS" = "true" ]; then \
     poetry install --with dev && rm -rf $POETRY_CACHE_DIR; \
     else \
     poetry install --only main && rm -rf $POETRY_CACHE_DIR; \
     fi
 
-FROM my_app_code AS final
+# Clean runtime image — no Poetry, no pip build tools, just the venv and source
+FROM base AS final
 
-# Copy and set permissions for entrypoint and other scripts
+ENV VIRTUAL_ENV=/app/.venv \
+    PATH="/app/.venv/bin:$PATH"
+
+# Create user BEFORE any COPY so we can use --chown at copy time instead of
+# a separate RUN chown -R /app (which would duplicate every file in a new layer).
+RUN useradd -m -s /bin/bash celeryworker && \
+    mkdir -p /home/celeryworker/.aws /app/logs && \
+    chown celeryworker:celeryworker /home/celeryworker/.aws /app/logs && \
+    chmod 755 /app/logs
+
+COPY --chown=celeryworker:celeryworker --from=builder /app/.venv /app/.venv
+COPY --chown=celeryworker:celeryworker --from=builder /app/src /app/src
+
+# Start scripts live at / so they are not inside the chowned /app tree
 COPY ./compose/local/entrypoint /entrypoint
 COPY ./compose/local/wait-for-it /wait-for-it
 COPY ./compose/local/fastapi/start /start-fastapi
@@ -107,22 +93,8 @@ COPY ./compose/local/celery/beat/start /start-celerybeat
 COPY ./compose/local/celery/flower/start /start-flower
 COPY ./compose/local/celery/flower/start-no-wait /start-flower-no-wait
 
-# Set permissions and create logs directory
 RUN chmod +x /entrypoint /wait-for-it /start-fastapi \
     /start-fastapi-cloud /start-celeryworker /start-celeryworker-solo \
-    /start-celerybeat /start-flower /start-flower-no-wait && \
-    mkdir -p /app/logs
-
-
-# Create non-root user during build
-RUN useradd -m -s /bin/bash celeryworker
-
-# Create the .aws directory for the non-root user and set correct ownership during build
-RUN chown -R celeryworker:celeryworker /app && \
-    mkdir -p /home/celeryworker/.aws && \
-    chown -R celeryworker:celeryworker /home/celeryworker/.aws && \
-    mkdir -p /app/logs && \
-    chown -R celeryworker:celeryworker /app/logs && \
-    chmod 755 /app/logs
+    /start-celerybeat /start-flower /start-flower-no-wait
 
 ENTRYPOINT ["/entrypoint"]

--- a/compose/local/celery/flower/start
+++ b/compose/local/celery/flower/start
@@ -18,7 +18,7 @@ celery --app cqc_lem.app.my_celery \
   flower \
   --broker-api="${CELERY_BROKER_URL}" \
   --logging="DEBUG" \
-  --logfile="/app/logs" \
+  --logfile="/app/logs/flower.log" \
   --debug=True \
   --state_save_interval="${CELERY_FLOWER_STATE_SAVE_INTERVAL}" \
   --persistent=True \

--- a/compose/local/celery/flower/start-no-wait
+++ b/compose/local/celery/flower/start-no-wait
@@ -4,29 +4,12 @@ set -o errexit
 set -o nounset
 
 celery --app cqc_lem.app.my_celery \
-  --broker="${CELERY_BROKER_URL}" \
   flower \
   --port="${CELERY_FLOWER_PORT}" \
+  --address=0.0.0.0 \
+  --broker="${CELERY_BROKER_URL}" \
   --broker-api="${CELERY_BROKER_URL}" \
-  --logging="DEBUG" \
-  --logfile="/app/logs" \
-  --debug=True &
-
-  #--basic_auth=admin:${CELERY_FLOWER_PASSWORD} \
-
-  #-Q (your queue name)
-
-# Function to check if Celery worker is ready
-worker_ready() {
-    celery --app cqc_lem.app.my_celery inspect ping
-}
-
-# Wait for Celery worker to be ready
-until worker_ready; do
-  >&2 echo 'Celery workers not available'
-  sleep 5
-done
->&2 echo 'Celery workers are available'
-
-# Keep the script running
-wait
+  --logging="INFO" \
+  --logfile="/app/logs/flower.log" \
+  --state_save_interval="${CELERY_FLOWER_STATE_SAVE_INTERVAL}"
+  #--basic_auth=admin:${CELERY_FLOWER_PASSWORD}

--- a/compose/local/celery/worker/start
+++ b/compose/local/celery/worker/start
@@ -23,7 +23,9 @@ CELERY_USER=celeryworker
 #printf "Changing ownership of the application directory to: %s\n" "$CELERY_USER"
 #chown -R $CELERY_USER:$CELERY_USER /app
 
-# Start Celery worker
+# Explicitly pass VIRTUAL_ENV and PATH: 'su' on Debian Bookworm resets PATH to
+# the system default, stripping /app/.venv/bin even when Docker ENV is set.
+VENV_ACTIVATE="VIRTUAL_ENV=/app/.venv PATH=/app/.venv/bin:/usr/local/bin:/usr/bin:/bin"
+
 printf "Starting Celery Worker as: %s\n" "$CELERY_USER"
-su $CELERY_USER -c "celery --app cqc_lem.app.my_celery worker --loglevel=INFO --autoscale=4,2 -E"
-#celery --skip-checks --app cqc_lem.app.my_celery worker --loglevel=DEBUG -E
+su $CELERY_USER -c "$VENV_ACTIVATE celery --app cqc_lem.app.my_celery worker --loglevel=INFO --autoscale=4,2 -E"

--- a/compose/local/celery/worker/start-solo-pool
+++ b/compose/local/celery/worker/start-solo-pool
@@ -26,7 +26,9 @@ CELERY_USER=celeryworker
 #    chmod 755 /app/logs
 
 
-# Start Celery worker
+# Explicitly pass VIRTUAL_ENV and PATH: 'su' on Debian Bookworm resets PATH to
+# the system default, stripping /app/.venv/bin even when Docker ENV is set.
+VENV_ACTIVATE="VIRTUAL_ENV=/app/.venv PATH=/app/.venv/bin:/usr/local/bin:/usr/bin:/bin"
+
 printf "Starting Celery Worker as: %s\n" "$CELERY_USER"
-su $CELERY_USER -c "celery --app cqc_lem.app.my_celery worker --pool=solo --concurrency=1 --queues=$CELERY_QUEUE --loglevel=INFO -E"
-#celery --skip-checks --app cqc_lem.app.my_celery worker --loglevel=DEBUG -E
+su $CELERY_USER -c "$VENV_ACTIVATE celery --app cqc_lem.app.my_celery worker --pool=solo --concurrency=1 --queues=$CELERY_QUEUE --loglevel=INFO -E"

--- a/compose/local/database/migrations/V19__add_carousel_slides_to_posts.sql
+++ b/compose/local/database/migrations/V19__add_carousel_slides_to_posts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE posts ADD COLUMN carousel_slides JSON NULL;

--- a/compose/local/database/migrations/V20__add_email_pin_auth_table.sql
+++ b/compose/local/database/migrations/V20__add_email_pin_auth_table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS email_pin_auth (
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    email       VARCHAR(255) NOT NULL,
+    pin         CHAR(64) NOT NULL,
+    expires_at  TIMESTAMP NOT NULL,
+    used        TINYINT(1) DEFAULT 0,
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_email_pin (email, pin),
+    INDEX idx_expires (expires_at)
+);

--- a/compose/local/database/migrations/V21__add_sessions_table.sql
+++ b/compose/local/database/migrations/V21__add_sessions_table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS sessions (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    session_token VARCHAR(64) NOT NULL UNIQUE,
+    user_id       INT NOT NULL,
+    expires_at    TIMESTAMP NOT NULL,
+    created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_token (session_token),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/compose/local/database/migrations/V22__add_subscription_and_preferences.sql
+++ b/compose/local/database/migrations/V22__add_subscription_and_preferences.sql
@@ -1,0 +1,26 @@
+-- Subscription tracking
+ALTER TABLE users
+    ADD COLUMN subscription_tier ENUM('free_trial', 'starter', 'professional', 'enterprise') NULL AFTER subscription_status,
+    ADD COLUMN trial_started_at TIMESTAMP NULL AFTER subscription_tier,
+    ADD COLUMN trial_ends_at   TIMESTAMP NULL AFTER trial_started_at,
+    ADD COLUMN stripe_customer_id      VARCHAR(255) NULL UNIQUE AFTER trial_ends_at,
+    ADD COLUMN stripe_subscription_id  VARCHAR(255) NULL AFTER stripe_customer_id;
+
+-- LinkedIn connection state (derived + stored for fast queries)
+ALTER TABLE users
+    ADD COLUMN linkedin_connection_status ENUM('connected', 'expired', 'disconnected') NOT NULL DEFAULT 'disconnected' AFTER stripe_subscription_id;
+
+-- User preferences
+ALTER TABLE users
+    ADD COLUMN last_login_inactivate_delay INT NULL DEFAULT 90 AFTER linkedin_connection_status,
+    ADD COLUMN auto_schedule_posts TINYINT(1) NOT NULL DEFAULT 0 AFTER last_login_inactivate_delay;
+
+-- Migrate existing connected users: give them an active trial starting now
+UPDATE users
+SET subscription_status    = 'trial',
+    subscription_tier      = 'free_trial',
+    trial_started_at       = NOW(),
+    trial_ends_at          = NOW() + INTERVAL 14 DAY,
+    linkedin_connection_status = 'connected'
+WHERE access_token IS NOT NULL
+  AND subscription_status = 'inactive';

--- a/compose/local/database/migrations/V23__add_linkedin_email_and_profile_user_id.sql
+++ b/compose/local/database/migrations/V23__add_linkedin_email_and_profile_user_id.sql
@@ -1,0 +1,8 @@
+-- Store the LinkedIn account's primary email (from /userinfo) separately from the app login email.
+-- This lets Selenium automation use the correct LinkedIn credential even when the two emails differ.
+ALTER TABLE users ADD COLUMN linkedin_email VARCHAR(255) NULL AFTER email;
+
+-- Key the "own profile" cache by user_id instead of email so it survives email changes.
+ALTER TABLE profiles ADD COLUMN user_id INT NULL AFTER id;
+ALTER TABLE profiles ADD CONSTRAINT fk_profiles_user_id FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE;
+ALTER TABLE profiles ADD UNIQUE KEY uniq_profiles_user_id (user_id);

--- a/compose/local/database/migrations/V24__add_subscription_past_due_period_end.sql
+++ b/compose/local/database/migrations/V24__add_subscription_past_due_period_end.sql
@@ -1,0 +1,9 @@
+-- Add 'past_due' to subscription_status ENUM so we can represent payment-failed-but-retrying
+ALTER TABLE users
+    MODIFY COLUMN subscription_status
+        ENUM('active', 'inactive', 'trial', 'cancelled', 'past_due') DEFAULT 'inactive';
+
+-- Track when the current billing period ends (used by the daily sync task)
+ALTER TABLE users
+    ADD COLUMN subscription_current_period_end TIMESTAMP NULL
+        AFTER stripe_subscription_id;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       redis:
         condition: service_healthy
     volumes:
+      - ./src:/app/src
       - ./tests:/app/tests
       - ./logs:/app/logs
     env_file:
@@ -93,6 +94,12 @@ services:
         condition: service_healthy
       selenium-chrome:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "celery --app cqc_lem.app.my_celery inspect ping -t 5 || exit 1"]
+      interval: 30s
+      timeout: 15s
+      retries: 3
+      start_period: 30s
 
   celery_beat:
     image: ${DOCKER_IMAGE_NAME}
@@ -109,6 +116,12 @@ services:
         condition: service_healthy
       selenium-chrome:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "pgrep -f 'celery.*beat' || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   flower:
     image: ${DOCKER_IMAGE_NAME}
@@ -125,12 +138,18 @@ services:
       - FLOWER_UNAUTHENTICATED_API=True
       - FLOWER_PERSISTENT=False
     ports:
-      - "${CELERY_FLOWER_PORT}:5555"
+      - "${CELERY_FLOWER_PORT}:${CELERY_FLOWER_PORT}"
     depends_on:
       redis:
         condition: service_healthy
       mysql:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "curl -f http://localhost:${CELERY_FLOWER_PORT}/metrics || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
 
   selenium-chrome:
     image: selenium/standalone-chrome:latest

--- a/docs/celery-flower-guide.md
+++ b/docs/celery-flower-guide.md
@@ -1,0 +1,230 @@
+# Celery & Flower Operations Guide
+
+## Architecture Overview
+
+The task queue system has three services that communicate through Redis:
+
+```
+celery_beat  ──schedules──▶  Redis (broker)  ──dispatches──▶  celery_worker
+                                                                     │
+celery_flower ──reads events from broker──────────────────────────────┘
+```
+
+| Service | Container | Role |
+|---|---|---|
+| `celery_worker` | `celery_worker` | Executes tasks; autoscales 2–4 processes |
+| `celery_beat` | `celery_beat` | Fires scheduled tasks on cron schedule |
+| `flower` | `celery_flower` | Read-only monitoring UI and API |
+| Redis | `redis` | Broker (DB 0) and result backend (DB 1) |
+
+**PostHog** receives a `celery_task` event for every task that starts and completes (via `task_prerun` / `task_postrun` signals in `my_celery.py`).
+
+---
+
+## Accessing Flower
+
+**Local (no ngrok):** `http://localhost:8555` (or whatever `CELERY_FLOWER_PORT` is set to in `.env`)
+
+**Ngrok paid plan:** `https://${NGROK_FLOWER_PREFIX}.${NGROK_FREE_DOMAIN}` — a static subdomain of your reserved ngrok domain. Set `NGROK_FLOWER_PREFIX` and `NGROK_FREE_DOMAIN` in `.env` to match the domain reserved in your ngrok dashboard.
+
+**Ngrok free plan:** Flower gets a random dynamic URL. `run.sh` queries the ngrok API (`/api/tunnels`) after startup and prints the live URL in the URL summary table. If the API query fails, it falls back to "Dynamic — see http://localhost:${NGROK_UI_PORT}" where you can find it under the `lem-flower` tunnel.
+
+Flower exposes no authentication by default (`FLOWER_UNAUTHENTICATED_API=True`). To enable basic auth, uncomment the `--basic_auth` line in `compose/local/celery/flower/start-no-wait` and set `CELERY_FLOWER_PASSWORD` in `.env`.
+
+### Flower Tabs
+
+| Tab | What it shows |
+|---|---|
+| **Dashboard** | Active workers, their status, concurrency, tasks processed |
+| **Tasks** | Live and historical task list with state, runtime, args |
+| **Broker** | Redis queue lengths per queue name |
+| **Monitor** | Real-time task rate graphs |
+| **Workers** | Per-worker stats: processed, failed, retried |
+
+**Idle workers are normal.** Most beat tasks run between 1–8 AM ET. Workers show "Idle" when no task is currently executing — that is expected outside scheduled windows. `check-scheduled-posts` runs every 30 minutes and completes in under a second if no posts are pending.
+
+---
+
+## Beat Schedule
+
+All times are in the timezone set by the `TZ` env var (default `America/New_York`).
+
+| Schedule key | Task | When |
+|---|---|---|
+| `check-scheduled-posts` | `auto_check_scheduled_posts` | :00 and :30 of every hour |
+| `generate-content-plan` | `auto_generate_content` | Daily 1:00 AM |
+| `create-content-from-plan` | `auto_create_weekly_content` | Daily 1:30 AM |
+| `clean-up-stale-invites` | `auto_clean_stale_invites` | Daily 2:00 AM |
+| `clen-up-stale-profiles` | `auto_clean_stale_profiles` | Daily 3:00 AM |
+| `invite_to_company_pages` | `auto_invite_to_company_pages` | 1st of month 5:00 AM |
+| `send-appreciation-dms` | `auto_appreciate_dms` | Daily 8:00 AM |
+
+---
+
+## Checking Worker Health
+
+### Quick status
+```bash
+docker compose ps celery_worker celery_beat flower
+```
+
+Expected state: all three `Up (healthy)` after startup completes.
+
+### Ping a worker directly
+```bash
+docker compose exec celery_worker celery --app cqc_lem.app.my_celery inspect ping
+```
+
+Successful response: `celery@celery-worker-host: OK` with a pong.
+
+### Stream worker logs
+```bash
+docker compose logs -f celery_worker
+docker compose logs -f celery_beat
+docker compose logs -f celery_flower
+```
+
+Worker logs are also written to `logs/cqc_lem_YYYY_MM_DD.log` (rotated daily, kept 10 days).
+Flower logs go to `logs/flower.log`.
+
+### Check active tasks
+```bash
+docker compose exec celery_worker celery --app cqc_lem.app.my_celery inspect active
+```
+
+### Check reserved (queued but not started) tasks
+```bash
+docker compose exec celery_worker celery --app cqc_lem.app.my_celery inspect reserved
+```
+
+### Check scheduled (ETA) tasks
+```bash
+docker compose exec celery_worker celery --app cqc_lem.app.my_celery inspect scheduled
+```
+
+---
+
+## Checking Beat Health
+
+Beat does not respond to `inspect ping`. Check it via its log output:
+
+```bash
+docker compose logs celery_beat | tail -40
+```
+
+A healthy beat log looks like:
+```
+[2025-01-01 00:30:00,000: INFO/MainProcess] Scheduler: Sending due task check-scheduled-posts (cqc_lem.app.run_scheduler.auto_check_scheduled_posts)
+```
+
+If you see no `Sending due task` lines and the container is running, beat may have lost its Redis connection. Restart it:
+```bash
+docker compose restart celery_beat
+```
+
+---
+
+## Manual Task Triggering
+
+Trigger any task directly from inside the worker container for debugging:
+
+```bash
+# Trigger check-scheduled-posts immediately
+docker compose exec celery_worker python -c "
+from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+result = auto_check_scheduled_posts.apply_async()
+print('Task ID:', result.id)
+"
+```
+
+Or use the Celery CLI:
+```bash
+docker compose exec celery_worker celery --app cqc_lem.app.my_celery call \
+  cqc_lem.app.run_scheduler.auto_check_scheduled_posts
+```
+
+---
+
+## PostHog Task Events
+
+Every task execution sends a `celery_task` event to PostHog with these properties:
+
+| Property | Description |
+|---|---|
+| `task` | Full task name (e.g. `cqc_lem.app.run_scheduler.auto_check_scheduled_posts`) |
+| `duration_ms` | Wall-clock time from task start to completion |
+| `success` | `true` if state is `SUCCESS`, `false` otherwise |
+| `state` | Celery final state: `SUCCESS`, `FAILURE`, `REVOKED` |
+
+To find them in PostHog: filter by `Event = celery_task`. Use `task` as a breakdown to see per-task throughput and failure rates.
+
+LLM calls made inside tasks also emit a separate `llm_call` event (tracked by `@llm_tracked` decorator in `ai_helper.py`).
+
+---
+
+## Common Failure Modes
+
+### Flower URL returns "connection refused"
+
+1. Confirm `CELERY_FLOWER_PORT` in `.env` (default `8555`)
+2. Check container is running: `docker compose ps flower`
+3. Check logs: `docker compose logs celery_flower`
+4. Verify port mapping: `docker compose port celery_flower 8555` — should return `0.0.0.0:8555`
+
+### Workers show as "offline" in Flower
+
+Workers publish heartbeats via Redis broker events. If they appear offline:
+1. Confirm the worker is running: `docker compose ps celery_worker`
+2. Run `inspect ping` (see above) — if this times out, the worker has lost its broker connection
+3. Check Redis is healthy: `docker compose ps redis`
+4. Restart the worker: `docker compose restart celery_worker`
+
+### Beat tasks not firing
+
+1. Verify beat log shows `Sending due task` lines at expected times
+2. Confirm system clock/timezone: `docker compose exec celery_beat date`
+3. Check `TZ` env var matches your expectation — beat schedule times are in this timezone
+4. If using `PURGE_TASKS=True`, beat purges queued tasks on startup; tasks queued before restart are lost
+
+### Task stuck in STARTED state
+
+The worker likely crashed mid-task. Because `task_acks_late = True`, the message is re-queued automatically after `broker_transport_options.visibility_timeout` (3660s). To force immediate re-queue:
+```bash
+docker compose restart celery_worker
+```
+
+### PostHog shows no celery_task events
+
+1. Confirm `POSTHOG_API_KEY` is set in `.env` (missing key silently disables PostHog)
+2. Trigger a task manually (see above) and wait ~30 seconds for event ingestion
+3. In PostHog, check the Live Events feed for `celery_task`
+
+---
+
+## Debugging Checklist
+
+Work through this in order when workers appear idle or broken:
+
+1. `docker compose ps` — all Celery services should be `Up (healthy)`
+2. `docker compose logs celery_worker | tail -20` — look for Python tracebacks
+3. `docker compose logs celery_flower | tail -20` — look for startup errors
+4. `docker compose exec celery_worker celery --app cqc_lem.app.my_celery inspect ping` — confirms broker connectivity
+5. `docker compose logs celery_beat | grep 'Sending due'` — confirms beat is scheduling
+6. Flower UI at `http://localhost:8555` → Workers tab → confirm worker is registered
+7. Flower UI → Broker tab → check queue depth (high depth = tasks queued but worker stuck)
+8. Flower UI → Tasks tab → filter by FAILURE state to find erroring tasks
+9. PostHog `celery_task` events → filter `success = false` for failure patterns
+
+---
+
+## Restarting Services
+
+```bash
+# Restart all three Celery services
+docker compose restart celery_worker celery_beat flower
+
+# Full rebuild after code changes
+docker compose build && docker compose up -d
+```
+
+After a full rebuild, allow ~30 seconds for all healthchecks to pass before expecting tasks to run.

--- a/docs/stripe-setup-guide.md
+++ b/docs/stripe-setup-guide.md
@@ -1,0 +1,146 @@
+# Stripe Billing Setup Guide
+
+LEM uses Stripe for subscription management. This guide covers everything from creating products to wiring up webhooks — for both local development and production.
+
+---
+
+## Why not Stripe CLI inside Docker?
+
+A common instinct is to run `stripe listen` inside the Docker stack. Don't — it generates a **new ephemeral signing secret on every startup**, making it impossible to pre-configure `STRIPE_WEBHOOK_SECRET` in `.env`. The approach below gives you a **fixed, reusable secret** that survives restarts.
+
+---
+
+## Step 1 — Create a Stripe account and get your API key
+
+1. Sign up at [stripe.com](https://stripe.com) (test mode is free and has no card requirements).
+2. In the Dashboard: **Developers** → **API keys**
+3. Copy the **Secret key**:
+   - Test: `sk_test_...` (safe for local dev — no real charges)
+   - Live: `sk_live_...` (use only when you go to production)
+
+```env
+STRIPE_API_KEY=sk_test_...
+```
+
+---
+
+## Step 2 — Create subscription products and prices
+
+1. Dashboard → **Product catalog** → **+ Add product**
+2. Create three products:
+
+| Product name | Price | Billing |
+|---|---|---|
+| LEM Starter | $29 | Monthly recurring |
+| LEM Professional | $79 | Monthly recurring |
+| LEM Enterprise | $199 | Monthly recurring |
+
+3. After saving each product, click the price row and copy its **Price ID** (`price_1Abc...`):
+
+```env
+STRIPE_PRICE_ID_STARTER=price_1Abc...
+STRIPE_PRICE_ID_PROFESSIONAL=price_1Def...
+STRIPE_PRICE_ID_ENTERPRISE=price_1Ghi...
+```
+
+> These two steps are enough to make the **Upgrade Your Plan** buttons work and redirect users to Stripe Checkout. The webhook (Step 3) is required for the subscription to activate in LEM's database after payment.
+
+---
+
+## Step 3 — Register the webhook endpoint
+
+The webhook endpoint (`/api/billing/webhook`) tells LEM when a subscription has been created, upgraded, or cancelled. Register it once in the Stripe Dashboard and you get a fixed signing secret that never changes.
+
+### Local development (ngrok)
+
+LEM already runs ngrok to expose the local server. Use the same domain for Stripe that you registered for LinkedIn OAuth.
+
+1. Start LEM (`./run.sh`) and note your ngrok URL, e.g. `https://your-domain.ngrok-free.app`
+2. Dashboard → **Developers** → **Webhooks** → **+ Add endpoint**
+3. **Endpoint URL**: use your **stable custom ngrok domain** (e.g. `https://your-custom-domain.ngrok-free.dev/api/billing/webhook`), NOT a temporary `ngrok-free.app` URL — those change on every restart and will break webhook delivery.
+4. **Events to listen for** — select all five:
+   - `customer.subscription.created`
+   - `customer.subscription.updated`
+   - `customer.subscription.deleted`
+   - `invoice.payment_succeeded`
+   - `invoice.payment_failed`
+5. Click **Add endpoint**, then open the endpoint detail page
+6. Copy the **Signing secret** (`whsec_...`):
+
+```env
+STRIPE_WEBHOOK_SECRET=whsec_...
+```
+
+> This secret is tied to the registered URL, not to any running process. It stays valid indefinitely as long as the endpoint registration exists in the Dashboard. You do not need to re-generate it when you restart Docker.
+
+### Production
+
+Same steps as above, using your production domain:
+
+1. Dashboard → **Developers** → **Webhooks** → **+ Add endpoint**
+2. **Endpoint URL**: `https://your-production-domain.com/api/billing/webhook`
+3. Same three events as above
+4. Copy the **Signing secret** and add it to your production environment
+
+---
+
+## Step 4 — Free trial setup (optional)
+
+`FREE_TRIAL_DAYS` controls how many days a new user gets before they need to upgrade. Default is 14:
+
+```env
+FREE_TRIAL_DAYS=14
+```
+
+New users created via the email PIN flow are automatically assigned a trial subscription when their account is created.
+
+---
+
+## Complete `.env` Stripe block
+
+```env
+STRIPE_API_KEY=sk_test_...
+STRIPE_WEBHOOK_SECRET=whsec_...
+STRIPE_PRICE_ID_STARTER=price_1Abc...
+STRIPE_PRICE_ID_PROFESSIONAL=price_1Def...
+STRIPE_PRICE_ID_ENTERPRISE=price_1Ghi...
+FREE_TRIAL_DAYS=14
+```
+
+---
+
+## End-to-end payment flow (what happens when a user upgrades)
+
+```
+User clicks "Upgrade Your Plan"
+  → POST /api/billing/create-checkout-session
+  → FastAPI creates a Stripe Checkout session (needs STRIPE_API_KEY + price IDs)
+  → Browser redirects to stripe.com/checkout/...
+  → User enters card details on Stripe's hosted page
+  → Payment succeeds
+  → Stripe redirects user back to /account?upgraded=1
+  → Stripe also POSTs to /api/billing/webhook (needs STRIPE_WEBHOOK_SECRET)
+  → FastAPI validates signature and updates user's subscription_status in MySQL
+  → User now has an active subscription
+```
+
+---
+
+## Switching from test to production
+
+1. Replace `sk_test_...` with `sk_live_...` in `STRIPE_API_KEY`
+2. Re-create the products and prices in Stripe's **live mode** (test-mode price IDs don't work in live mode)
+3. Update `STRIPE_PRICE_ID_*` with the live price IDs
+4. Register a new webhook endpoint using your production URL (live mode has separate webhooks from test mode)
+5. Update `STRIPE_WEBHOOK_SECRET` with the live webhook signing secret
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| Upgrade button returns "Could not start checkout" | `STRIPE_API_KEY` invalid, or `STRIPE_PRICE_ID_*` not set / set to placeholder values |
+| Checkout redirects but subscription never activates | `STRIPE_WEBHOOK_SECRET` wrong or webhook endpoint not registered |
+| Webhook returns 400 "Invalid Stripe webhook signature" | `STRIPE_WEBHOOK_SECRET` doesn't match the registered endpoint's signing secret |
+| User sees "Billing not yet configured" | `stripe_customer_id` is null in DB — Stripe customer creation failed at sign-up time, likely due to missing `STRIPE_API_KEY` when the user first logged in |

--- a/generate-ngrok-config.sh
+++ b/generate-ngrok-config.sh
@@ -3,10 +3,21 @@
 # Load environment variables from .env file
 export $(grep -v '^#' .env | xargs)
 
-# Get the directory of the current script
 SCRIPT_DIR=$(dirname "$0")
+NGROK_PLAN="${NGROK_PLAN:-off}"
 
-# Replace environment variables in the template and create ngrok-config.yml
-envsubst < "$SCRIPT_DIR/ngrok-config-template.yml" > "$SCRIPT_DIR/ngrok-config.yml"
+case "$NGROK_PLAN" in
+  free)
+    TEMPLATE="$SCRIPT_DIR/ngrok-config-template-free.yml"
+    ;;
+  paid)
+    TEMPLATE="$SCRIPT_DIR/ngrok-config-template.yml"
+    ;;
+  *)
+    echo "NGROK_PLAN=${NGROK_PLAN} — skipping ngrok config generation."
+    exit 0
+    ;;
+esac
 
-echo "Ngrok config file has been generated."
+envsubst < "$TEMPLATE" > "$SCRIPT_DIR/ngrok-config.yml"
+echo "Ngrok config generated from ${TEMPLATE} (plan: ${NGROK_PLAN})."

--- a/poetry.lock
+++ b/poetry.lock
@@ -6,7 +6,7 @@ version = "5.5.0"
 description = "Vega-Altair: A declarative statistical visualization library for Python."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "altair-5.5.0-py3-none-any.whl", hash = "sha256:91a310b926508d560fe0148d02a194f38b824122641ef528113d029fcd129f8c"},
     {file = "altair-5.5.0.tar.gz", hash = "sha256:d960ebe6178c56de3855a68c47b516be38640b73fb3b5111c2a9ca90546dd73d"},
@@ -58,7 +58,7 @@ version = "4.8.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a"},
     {file = "anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a"},
@@ -215,7 +215,7 @@ version = "25.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "attrs-25.1.0-py3-none-any.whl", hash = "sha256:c75a69e28a550a7e93789579c22aa26b0f5b83b75dc4e08fe092980051e1090a"},
     {file = "attrs-25.1.0.tar.gz", hash = "sha256:1c97078a80c814273a76b2a298a932eb681c87415c11dee0a6921de7f1b02c3e"},
@@ -425,7 +425,7 @@ version = "1.9.0"
 description = "Fast, simple object-to-object and broadcast signaling"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc"},
     {file = "blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf"},
@@ -492,7 +492,7 @@ version = "5.5.2"
 description = "Extensible memoizing collections and decorators"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "cachetools-5.5.2-py3-none-any.whl", hash = "sha256:d26a22bcc62eb95c3beabd9f1ee5e820d3d2704fe2967cbe350e20c8ffcd3f0a"},
     {file = "cachetools-5.5.2.tar.gz", hash = "sha256:1a661caa9175d26759571b2e19580f9d6393969e5dfca11fdb1f947a23e640d4"},
@@ -629,7 +629,7 @@ version = "2025.1.31"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe"},
     {file = "certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651"},
@@ -637,84 +637,101 @@ files = [
 
 [[package]]
 name = "cffi"
-version = "1.17.1"
+version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main", "dev"]
 files = [
-    {file = "cffi-1.17.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:df8b1c11f177bc2313ec4b2d46baec87a5f3e71fc8b45dab2ee7cae86d9aba14"},
-    {file = "cffi-1.17.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8f2cdc858323644ab277e9bb925ad72ae0e67f69e804f4898c070998d50b1a67"},
-    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:edae79245293e15384b51f88b00613ba9f7198016a5948b5dddf4917d4d26382"},
-    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45398b671ac6d70e67da8e4224a065cec6a93541bb7aebe1b198a61b58c7b702"},
-    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ad9413ccdeda48c5afdae7e4fa2192157e991ff761e7ab8fdd8926f40b160cc3"},
-    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5da5719280082ac6bd9aa7becb3938dc9f9cbd57fac7d2871717b1feb0902ab6"},
-    {file = "cffi-1.17.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb1a08b8008b281856e5971307cc386a8e9c5b625ac297e853d36da6efe9c17"},
-    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:045d61c734659cc045141be4bae381a41d89b741f795af1dd018bfb532fd0df8"},
-    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6883e737d7d9e4899a8a695e00ec36bd4e5e4f18fabe0aca0efe0a4b44cdb13e"},
-    {file = "cffi-1.17.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:6b8b4a92e1c65048ff98cfe1f735ef8f1ceb72e3d5f0c25fdb12087a23da22be"},
-    {file = "cffi-1.17.1-cp310-cp310-win32.whl", hash = "sha256:c9c3d058ebabb74db66e431095118094d06abf53284d9c81f27300d0e0d8bc7c"},
-    {file = "cffi-1.17.1-cp310-cp310-win_amd64.whl", hash = "sha256:0f048dcf80db46f0098ccac01132761580d28e28bc0f78ae0d58048063317e15"},
-    {file = "cffi-1.17.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a45e3c6913c5b87b3ff120dcdc03f6131fa0065027d0ed7ee6190736a74cd401"},
-    {file = "cffi-1.17.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:30c5e0cb5ae493c04c8b42916e52ca38079f1b235c2f8ae5f4527b963c401caf"},
-    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f75c7ab1f9e4aca5414ed4d8e5c0e303a34f4421f8a0d47a4d019ceff0ab6af4"},
-    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a1ed2dd2972641495a3ec98445e09766f077aee98a1c896dcb4ad0d303628e41"},
-    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:46bf43160c1a35f7ec506d254e5c890f3c03648a4dbac12d624e4490a7046cd1"},
-    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a24ed04c8ffd54b0729c07cee15a81d964e6fee0e3d4d342a27b020d22959dc6"},
-    {file = "cffi-1.17.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:610faea79c43e44c71e1ec53a554553fa22321b65fae24889706c0a84d4ad86d"},
-    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:a9b15d491f3ad5d692e11f6b71f7857e7835eb677955c00cc0aefcd0669adaf6"},
-    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:de2ea4b5833625383e464549fec1bc395c1bdeeb5f25c4a3a82b5a8c756ec22f"},
-    {file = "cffi-1.17.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:fc48c783f9c87e60831201f2cce7f3b2e4846bf4d8728eabe54d60700b318a0b"},
-    {file = "cffi-1.17.1-cp311-cp311-win32.whl", hash = "sha256:85a950a4ac9c359340d5963966e3e0a94a676bd6245a4b55bc43949eee26a655"},
-    {file = "cffi-1.17.1-cp311-cp311-win_amd64.whl", hash = "sha256:caaf0640ef5f5517f49bc275eca1406b0ffa6aa184892812030f04c2abf589a0"},
-    {file = "cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4"},
-    {file = "cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c"},
-    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36"},
-    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5"},
-    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff"},
-    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99"},
-    {file = "cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93"},
-    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3"},
-    {file = "cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8"},
-    {file = "cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65"},
-    {file = "cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903"},
-    {file = "cffi-1.17.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f3a2b4222ce6b60e2e8b337bb9596923045681d71e5a082783484d845390938e"},
-    {file = "cffi-1.17.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0984a4925a435b1da406122d4d7968dd861c1385afe3b45ba82b750f229811e2"},
-    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d01b12eeeb4427d3110de311e1774046ad344f5b1a7403101878976ecd7a10f3"},
-    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:706510fe141c86a69c8ddc029c7910003a17353970cff3b904ff0686a5927683"},
-    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de55b766c7aa2e2a3092c51e0483d700341182f08e67c63630d5b6f200bb28e5"},
-    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c59d6e989d07460165cc5ad3c61f9fd8f1b4796eacbd81cee78957842b834af4"},
-    {file = "cffi-1.17.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd398dbc6773384a17fe0d3e7eeb8d1a21c2200473ee6806bb5e6a8e62bb73dd"},
-    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3edc8d958eb099c634dace3c7e16560ae474aa3803a5df240542b305d14e14ed"},
-    {file = "cffi-1.17.1-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:72e72408cad3d5419375fc87d289076ee319835bdfa2caad331e377589aebba9"},
-    {file = "cffi-1.17.1-cp313-cp313-win32.whl", hash = "sha256:e03eab0a8677fa80d646b5ddece1cbeaf556c313dcfac435ba11f107ba117b5d"},
-    {file = "cffi-1.17.1-cp313-cp313-win_amd64.whl", hash = "sha256:f6a16c31041f09ead72d69f583767292f750d24913dadacf5756b966aacb3f1a"},
-    {file = "cffi-1.17.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:636062ea65bd0195bc012fea9321aca499c0504409f413dc88af450b57ffd03b"},
-    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7eac2ef9b63c79431bc4b25f1cd649d7f061a28808cbc6c47b534bd789ef964"},
-    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e221cf152cff04059d011ee126477f0d9588303eb57e88923578ace7baad17f9"},
-    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:31000ec67d4221a71bd3f67df918b1f88f676f1c3b535a7eb473255fdc0b83fc"},
-    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f17be4345073b0a7b8ea599688f692ac3ef23ce28e5df79c04de519dbc4912c"},
-    {file = "cffi-1.17.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e2b1fac190ae3ebfe37b979cc1ce69c81f4e4fe5746bb401dca63a9062cdaf1"},
-    {file = "cffi-1.17.1-cp38-cp38-win32.whl", hash = "sha256:7596d6620d3fa590f677e9ee430df2958d2d6d6de2feeae5b20e82c00b76fbf8"},
-    {file = "cffi-1.17.1-cp38-cp38-win_amd64.whl", hash = "sha256:78122be759c3f8a014ce010908ae03364d00a1f81ab5c7f4a7a5120607ea56e1"},
-    {file = "cffi-1.17.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b2ab587605f4ba0bf81dc0cb08a41bd1c0a5906bd59243d56bad7668a6fc6c16"},
-    {file = "cffi-1.17.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:28b16024becceed8c6dfbc75629e27788d8a3f9030691a1dbf9821a128b22c36"},
-    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d599671f396c4723d016dbddb72fe8e0397082b0a77a4fab8028923bec050e8"},
-    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca74b8dbe6e8e8263c0ffd60277de77dcee6c837a3d0881d8c1ead7268c9e576"},
-    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f7f5baafcc48261359e14bcd6d9bff6d4b28d9103847c9e136694cb0501aef87"},
-    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98e3969bcff97cae1b2def8ba499ea3d6f31ddfdb7635374834cf89a1a08ecf0"},
-    {file = "cffi-1.17.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdf5ce3acdfd1661132f2a9c19cac174758dc2352bfe37d98aa7512c6b7178b3"},
-    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9755e4345d1ec879e3849e62222a18c7174d65a6a92d5b346b1863912168b595"},
-    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:f1e22e8c4419538cb197e4dd60acc919d7696e5ef98ee4da4e01d3f8cfa4cc5a"},
-    {file = "cffi-1.17.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:c03e868a0b3bc35839ba98e74211ed2b05d2119be4e8a0f224fba9384f1fe02e"},
-    {file = "cffi-1.17.1-cp39-cp39-win32.whl", hash = "sha256:e31ae45bc2e29f6b2abd0de1cc3b9d5205aa847cafaecb8af1476a609a2f6eb7"},
-    {file = "cffi-1.17.1-cp39-cp39-win_amd64.whl", hash = "sha256:d016c76bdd850f3c626af19b0542c9677ba156e4ee4fccfdd7848803533ef662"},
-    {file = "cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
+    {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4"},
+    {file = "cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5"},
+    {file = "cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb"},
+    {file = "cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a"},
+    {file = "cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe"},
+    {file = "cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664"},
+    {file = "cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414"},
+    {file = "cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743"},
+    {file = "cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5"},
+    {file = "cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d"},
+    {file = "cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037"},
+    {file = "cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94"},
+    {file = "cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187"},
+    {file = "cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18"},
+    {file = "cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5"},
+    {file = "cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb"},
+    {file = "cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3"},
+    {file = "cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c"},
+    {file = "cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b"},
+    {file = "cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27"},
+    {file = "cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75"},
+    {file = "cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5"},
+    {file = "cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef"},
+    {file = "cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205"},
+    {file = "cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1"},
+    {file = "cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f"},
+    {file = "cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25"},
+    {file = "cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9"},
+    {file = "cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc"},
+    {file = "cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512"},
+    {file = "cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4"},
+    {file = "cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6"},
+    {file = "cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf"},
+    {file = "cffi-2.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f"},
+    {file = "cffi-2.0.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65"},
+    {file = "cffi-2.0.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322"},
+    {file = "cffi-2.0.0-cp39-cp39-win32.whl", hash = "sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a"},
+    {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
+    {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {main = "os_name == \"nt\" and implementation_name != \"pypy\""}
+markers = {main = "os_name == \"nt\" and implementation_name != \"pypy\" or platform_python_implementation != \"PyPy\""}
 
 [package.dependencies]
-pycparser = "*"
+pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "charset-normalizer"
@@ -722,7 +739,7 @@ version = "3.4.1"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de"},
     {file = "charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176"},
@@ -824,7 +841,7 @@ version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "streamlit"]
 files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
     {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
@@ -903,12 +920,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev", "test"]
+groups = ["main", "dev", "streamlit", "test"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", test = "sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", streamlit = "platform_system == \"Windows\"", test = "sys_platform == \"win32\""}
 
 [[package]]
 name = "comm"
@@ -1051,6 +1068,86 @@ files = [
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
+name = "cryptography"
+version = "46.0.0"
+description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
+optional = false
+python-versions = "!=3.9.0,!=3.9.1,>=3.8"
+groups = ["main"]
+files = [
+    {file = "cryptography-46.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:c9c4121f9a41cc3d02164541d986f59be31548ad355a5c96ac50703003c50fb7"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4f70cbade61a16f5e238c4b0eb4e258d177a2fcb59aa0aae1236594f7b0ae338"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d1eccae15d5c28c74b2bea228775c63ac5b6c36eedb574e002440c0bc28750d3"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1b4fba84166d906a22027f0d958e42f3a4dbbb19c28ea71f0fb7812380b04e3c"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:523153480d7575a169933f083eb47b1edd5fef45d87b026737de74ffeb300f69"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:f09a3a108223e319168b7557810596631a8cb864657b0c16ed7a6017f0be9433"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c1f6ccd6f2eef3b2eb52837f0463e853501e45a916b3fc42e5d93cf244a4b97b"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:80a548a5862d6912a45557a101092cd6c64ae1475b82cef50ee305d14a75f598"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6c39fd5cd9b7526afa69d64b5e5645a06e1b904f342584b3885254400b63f1b3"},
+    {file = "cryptography-46.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:d5c0cbb2fb522f7e39b59a5482a1c9c5923b7c506cfe96a1b8e7368c31617ac0"},
+    {file = "cryptography-46.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:6d8945bc120dcd90ae39aa841afddaeafc5f2e832809dc54fb906e3db829dfdc"},
+    {file = "cryptography-46.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:88c09da8a94ac27798f6b62de6968ac78bb94805b5d272dbcfd5fdc8c566999f"},
+    {file = "cryptography-46.0.0-cp311-abi3-win32.whl", hash = "sha256:3738f50215211cee1974193a1809348d33893696ce119968932ea117bcbc9b1d"},
+    {file = "cryptography-46.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bbaa5eef3c19c66613317dc61e211b48d5f550db009c45e1c28b59d5a9b7812a"},
+    {file = "cryptography-46.0.0-cp311-abi3-win_arm64.whl", hash = "sha256:16b5ac72a965ec9d1e34d9417dbce235d45fa04dac28634384e3ce40dfc66495"},
+    {file = "cryptography-46.0.0-cp314-abi3-macosx_10_9_universal2.whl", hash = "sha256:91585fc9e696abd7b3e48a463a20dda1a5c0eeeca4ba60fa4205a79527694390"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:65e9117ebed5b16b28154ed36b164c20021f3a480e9cbb4b4a2a59b95e74c25d"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:da7f93551d39d462263b6b5c9056c49f780b9200bf9fc2656d7c88c7bdb9b363"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:be7479f9504bfb46628544ec7cb4637fe6af8b70445d4455fbb9c395ad9b7290"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f85e6a7d42ad60024fa1347b1d4ef82c4df517a4deb7f829d301f1a92ded038c"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:d349af4d76a93562f1dce4d983a4a34d01cb22b48635b0d2a0b8372cdb4a8136"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:35aa1a44bd3e0efc3ef09cf924b3a0e2a57eda84074556f4506af2d294076685"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:c457ad3f151d5fb380be99425b286167b358f76d97ad18b188b68097193ed95a"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:399ef4c9be67f3902e5ca1d80e64b04498f8b56c19e1bc8d0825050ea5290410"},
+    {file = "cryptography-46.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:378eff89b040cbce6169528f130ee75dceeb97eef396a801daec03b696434f06"},
+    {file = "cryptography-46.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c3648d6a5878fd1c9a22b1d43fa75efc069d5f54de12df95c638ae7ba88701d0"},
+    {file = "cryptography-46.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2fc30be952dd4334801d345d134c9ef0e9ccbaa8c3e1bc18925cbc4247b3e29c"},
+    {file = "cryptography-46.0.0-cp314-cp314t-win32.whl", hash = "sha256:b8e7db4ce0b7297e88f3d02e6ee9a39382e0efaf1e8974ad353120a2b5a57ef7"},
+    {file = "cryptography-46.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:40ee4ce3c34acaa5bc347615ec452c74ae8ff7db973a98c97c62293120f668c6"},
+    {file = "cryptography-46.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:07a1be54f995ce14740bf8bbe1cc35f7a37760f992f73cf9f98a2a60b9b97419"},
+    {file = "cryptography-46.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:1d2073313324226fd846e6b5fc340ed02d43fd7478f584741bd6b791c33c9fee"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:83af84ebe7b6e9b6de05050c79f8cc0173c864ce747b53abce6a11e940efdc0d"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c3cd09b1490c1509bf3892bde9cef729795fae4a2fee0621f19be3321beca7e4"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d14eaf1569d6252280516bedaffdd65267428cdbc3a8c2d6de63753cf0863d5e"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:ab3a14cecc741c8c03ad0ad46dfbf18de25218551931a23bca2731d46c706d83"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8e8b222eb54e3e7d3743a7c2b1f7fa7df7a9add790307bb34327c88ec85fe087"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:7f3f88df0c9b248dcc2e76124f9140621aca187ccc396b87bc363f890acf3a30"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:9aa85222f03fdb30defabc7a9e1e3d4ec76eb74ea9fe1504b2800844f9c98440"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f9aaf2a91302e1490c068d2f3af7df4137ac2b36600f5bd26e53d9ec320412d3"},
+    {file = "cryptography-46.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:32670ca085150ff36b438c17f2dfc54146fe4a074ebf0a76d72fb1b419a974bc"},
+    {file = "cryptography-46.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0f58183453032727a65e6605240e7a3824fd1d6a7e75d2b537e280286ab79a52"},
+    {file = "cryptography-46.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:4bc257c2d5d865ed37d0bd7c500baa71f939a7952c424f28632298d80ccd5ec1"},
+    {file = "cryptography-46.0.0-cp38-abi3-win32.whl", hash = "sha256:df932ac70388be034b2e046e34d636245d5eeb8140db24a6b4c2268cd2073270"},
+    {file = "cryptography-46.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:274f8b2eb3616709f437326185eb563eb4e5813d01ebe2029b61bfe7d9995fbb"},
+    {file = "cryptography-46.0.0-cp38-abi3-win_arm64.whl", hash = "sha256:249c41f2bbfa026615e7bdca47e4a66135baa81b08509ab240a2e666f6af5966"},
+    {file = "cryptography-46.0.0-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:fe9ff1139b2b1f59a5a0b538bbd950f8660a39624bbe10cf3640d17574f973bb"},
+    {file = "cryptography-46.0.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:77e3bd53c9c189cea361bc18ceb173959f8b2dd8f8d984ae118e9ac641410252"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:75d2ddde8f1766ab2db48ed7f2aa3797aeb491ea8dfe9b4c074201aec00f5c16"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:f9f85d9cf88e3ba2b2b6da3c2310d1cf75bdf04a5bc1a2e972603054f82c4dd5"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:834af45296083d892e23430e3b11df77e2ac5c042caede1da29c9bf59016f4d2"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:c39f0947d50f74b1b3523cec3931315072646286fb462995eb998f8136779319"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:6460866a92143a24e3ed68eaeb6e98d0cedd85d7d9a8ab1fc293ec91850b1b38"},
+    {file = "cryptography-46.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:bf1961037309ee0bdf874ccba9820b1c2f720c2016895c44d8eb2316226c1ad5"},
+    {file = "cryptography-46.0.0.tar.gz", hash = "sha256:99f64a6d15f19f3afd78720ad2978f6d8d4c68cd4eb600fab82ab1a7c2071dca"},
+]
+
+[package.dependencies]
+cffi = [
+    {version = ">=1.14", markers = "python_full_version < \"3.14.0\" and platform_python_implementation != \"PyPy\""},
+    {version = ">=2.0.0", markers = "python_full_version >= \"3.14.0\" and platform_python_implementation != \"PyPy\""},
+]
+
+[package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox[uv] (>=2024.4.15)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
+sdist = ["build (>=1.0.0)"]
+ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.0)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
+
+[[package]]
 name = "dateparser"
 version = "1.4.1"
 description = "Date parsing library designed to parse dates from HTML pages"
@@ -1071,22 +1168,6 @@ tzlocal = ">=0.2"
 [package.extras]
 calendars = ["convertdate (>=2.2.1)", "hijridate"]
 langdetect = ["langdetect (>=1.0.0)"]
-
-[[package]]
-name = "datetime"
-version = "5.5"
-description = "This package provides a DateTime data type, as known from Zope. Unless you need to communicate with Zope APIs, you're probably better off using Python's built-in datetime module."
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-files = [
-    {file = "DateTime-5.5-py3-none-any.whl", hash = "sha256:0abf6c51cb4ba7cee775ca46ccc727f3afdde463be28dbbe8803631fefd4a120"},
-    {file = "DateTime-5.5.tar.gz", hash = "sha256:21ec6331f87a7fcb57bd7c59e8a68bfffe6fcbf5acdbbc7b356d6a9a020191d3"},
-]
-
-[package.dependencies]
-pytz = "*"
-"zope.interface" = "*"
 
 [[package]]
 name = "debugpy"
@@ -1214,7 +1295,7 @@ version = "0.1.71"
 description = "An all-in-one place, to find complex or just natively unavailable components on streamlit."
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "extra_streamlit_components-0.1.71-py3-none-any.whl", hash = "sha256:c8e6f98446adecd3002756362e50d0669693b7673afaa89cebfced6415cc6bd3"},
     {file = "extra_streamlit_components-0.1.71.tar.gz", hash = "sha256:d18314cf2ed009f95641882b50aa3bdb11b6a0eb6403fb43dbc8af1722419617"},
@@ -1339,7 +1420,7 @@ version = "4.0.12"
 description = "Git Object Database"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf"},
     {file = "gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571"},
@@ -1354,7 +1435,7 @@ version = "3.1.44"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "GitPython-3.1.44-py3-none-any.whl", hash = "sha256:9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110"},
     {file = "gitpython-3.1.44.tar.gz", hash = "sha256:c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269"},
@@ -1506,7 +1587,7 @@ version = "0.14.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761"},
     {file = "h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d"},
@@ -1540,7 +1621,7 @@ version = "0.8.0"
 description = "A collection of framework independent HTTP protocol utils."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "httptools-0.8.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:bf3b6f807c8541503cecfbb8a8dffb385640d0d96102f3d112aa8740f9b7c826"},
     {file = "httptools-0.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da684f2e1aa2ee9bdcb083f3f3a68c5956750b375bc5df864d3a5f0c42a40b77"},
@@ -1640,7 +1721,7 @@ version = "3.10"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.6"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3"},
     {file = "idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9"},
@@ -1809,7 +1890,7 @@ version = "2.2.0"
 description = "Safely pass data to untrusted environments and back."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef"},
     {file = "itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173"},
@@ -1841,7 +1922,7 @@ version = "3.1.5"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["dev", "streamlit"]
 files = [
     {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
     {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
@@ -2016,7 +2097,7 @@ version = "4.23.0"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev", "streamlit"]
 files = [
     {file = "jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566"},
     {file = "jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4"},
@@ -2046,7 +2127,7 @@ version = "2024.10.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev", "streamlit"]
 files = [
     {file = "jsonschema_specifications-2024.10.1-py3-none-any.whl", hash = "sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf"},
     {file = "jsonschema_specifications-2024.10.1.tar.gz", hash = "sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272"},
@@ -2571,7 +2652,7 @@ version = "3.0.2"
 description = "Safely add untrusted strings to HTML/XML markup."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:7e94c425039cde14257288fd61dcfb01963e658efbc0ff54f5306b06054700f8"},
     {file = "MarkupSafe-3.0.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9e2d922824181480953426608b81967de705c3cef4d1af983af849d7bd619158"},
@@ -2723,7 +2804,7 @@ version = "1.29.0"
 description = "Extremely lightweight compatibility layer between dataframe libraries"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "narwhals-1.29.0-py3-none-any.whl", hash = "sha256:653aa8e5eb435816e7b50c8def17e7e5e3324c2ffd8a3eec03fef85792e9cf5e"},
     {file = "narwhals-1.29.0.tar.gz", hash = "sha256:1021c345d56c66ff0cc8e6d03ca8c543d01ffc411630973a5cb69ee86824d823"},
@@ -2915,7 +2996,7 @@ version = "2.2.3"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "numpy-2.2.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cbc6472e01952d3d1b2772b720428f8b90e2deea8344e854df22b0618e9cce71"},
     {file = "numpy-2.2.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:cdfe0c22692a30cd830c0755746473ae66c4a8f2e7bd508b35fb3b6a0813d787"},
@@ -3232,20 +3313,6 @@ files = [
 ]
 
 [[package]]
-name = "os-env"
-version = "0.3"
-description = ""
-optional = false
-python-versions = "*"
-groups = ["main"]
-files = [
-    {file = "os_env-0.3.tar.gz", hash = "sha256:5000faf1485235447981bfd3fd4f796b5a6abfcb7e38ed797bf7e5ac62c2f851"},
-]
-
-[package.dependencies]
-python-dotenv = "*"
-
-[[package]]
 name = "outcome"
 version = "1.3.0.post0"
 description = "Capture the outcome of Python function calls."
@@ -3278,7 +3345,7 @@ version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "test"]
+groups = ["main", "dev", "streamlit", "test"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
@@ -3290,7 +3357,7 @@ version = "2.3.3"
 description = "Powerful data structures for data analysis, time series, and statistics"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "pandas-2.3.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:376c6446ae31770764215a6c937f72d917f214b43560603cd60da6408f183b6c"},
     {file = "pandas-2.3.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e19d192383eab2f4ceb30b412b22ea30690c9e618f78870357ae1d682912015a"},
@@ -3445,7 +3512,7 @@ version = "11.1.0"
 description = "Python Imaging Library (Fork)"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "streamlit"]
 files = [
     {file = "pillow-11.1.0-cp310-cp310-macosx_10_10_x86_64.whl", hash = "sha256:e1abe69aca89514737465752b4bcaf8016de61b3be1397a8fc260ba33321b3a8"},
     {file = "pillow-11.1.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c640e5a06869c75994624551f45e5506e4256562ead981cce820d5ab39ae2192"},
@@ -3623,7 +3690,7 @@ version = "5.29.3"
 description = ""
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["dev", "streamlit"]
 files = [
     {file = "protobuf-5.29.3-cp310-abi3-win32.whl", hash = "sha256:3ea51771449e1035f26069c4c7fd51fba990d07bc55ba80701c78f886bf9c888"},
     {file = "protobuf-5.29.3-cp310-abi3-win_amd64.whl", hash = "sha256:a4fa6f80816a9a0678429e84973f2f98cbc218cca434abe8db2ad0bffc98503a"},
@@ -3708,7 +3775,7 @@ version = "19.0.1"
 description = "Python library for Apache Arrow"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "pyarrow-19.0.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:fc28912a2dc924dddc2087679cc8b7263accc71b9ff025a1362b004711661a69"},
     {file = "pyarrow-19.0.1-cp310-cp310-macosx_12_0_x86_64.whl", hash = "sha256:fca15aabbe9b8355800d923cc2e82c8ef514af321e18b437c3d782aa884eaeec"},
@@ -3768,7 +3835,7 @@ files = [
     {file = "pycparser-2.22-py3-none-any.whl", hash = "sha256:c3702b6d3dd8c7abc1afa565d7e63d53a1d0bd86cdc24edd75470f4de499cfcc"},
     {file = "pycparser-2.22.tar.gz", hash = "sha256:491c8be9c040f5390f5bf44a5b07752bd07f56edf992381b05c701439eec10f6"},
 ]
-markers = {main = "os_name == \"nt\" and implementation_name != \"pypy\""}
+markers = {main = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\" or os_name == \"nt\" and implementation_name != \"pypy\" and implementation_name != \"PyPy\"", dev = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pycurl"
@@ -3975,7 +4042,7 @@ version = "0.9.1"
 description = "Widget for deck.gl maps"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "pydeck-0.9.1-py2.py3-none-any.whl", hash = "sha256:b3f75ba0d273fc917094fa61224f3f6076ca8752b93d46faf3bcfd9f9d59b038"},
     {file = "pydeck-0.9.1.tar.gz", hash = "sha256:f74475ae637951d63f2ee58326757f8d4f9cd9f2a457cf42950715003e2cb605"},
@@ -4162,7 +4229,7 @@ version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "dev", "test"]
+groups = ["main", "dev", "streamlit", "test"]
 files = [
     {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
     {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
@@ -4177,7 +4244,7 @@ version = "3.8"
 description = "Strict separation of settings from code."
 optional = false
 python-versions = "*"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "python-decouple-3.8.tar.gz", hash = "sha256:ba6e2657d4f376ecc46f77a3a615e058d93ba5e465c01bbe57289bfb7cce680f"},
     {file = "python_decouple-3.8-py3-none-any.whl", hash = "sha256:d0d45340815b25f4de59c974b855bb38d03151d81b037d9e3f463b0c9f8cbd66"},
@@ -4197,6 +4264,18 @@ files = [
 
 [package.extras]
 cli = ["click (>=5.0)"]
+
+[[package]]
+name = "python-http-client"
+version = "3.3.7"
+description = "HTTP REST client, simplified for Python"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+groups = ["main"]
+files = [
+    {file = "python_http_client-3.3.7-py3-none-any.whl", hash = "sha256:ad371d2bbedc6ea15c26179c6222a78bc9308d272435ddf1d5c84f068f249a36"},
+    {file = "python_http_client-3.3.7.tar.gz", hash = "sha256:bf841ee45262747e00dec7ee9971dfb8c7d83083f5713596488d67739170cea0"},
+]
 
 [[package]]
 name = "python-json-logger"
@@ -4219,7 +4298,7 @@ version = "0.0.32"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23"},
     {file = "python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e"},
@@ -4249,7 +4328,7 @@ version = "2025.1"
 description = "World timezone definitions, modern and historical"
 optional = false
 python-versions = "*"
-groups = ["main"]
+groups = ["main", "streamlit"]
 files = [
     {file = "pytz-2025.1-py2.py3-none-any.whl", hash = "sha256:89dd22dca55b46eac6eda23b2d72721bf1bdfef212645d81513ef5d03038de57"},
     {file = "pytz-2025.1.tar.gz", hash = "sha256:c2db42be2a2518b28e65f9207c4d05e6ff547d1efa4086469ef855e4ab70178e"},
@@ -4512,7 +4591,7 @@ version = "0.36.2"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev", "streamlit"]
 files = [
     {file = "referencing-0.36.2-py3-none-any.whl", hash = "sha256:e8699adbbf8b5c7de96d8ffa0eb5c158b3beafce084968e2ea8bb08c6794dcd0"},
     {file = "referencing-0.36.2.tar.gz", hash = "sha256:df2e89862cd09deabbdba16944cc3f10feb6b3e6f18e902f7cc25609a34775aa"},
@@ -4651,7 +4730,7 @@ version = "2.34.2"
 description = "Python HTTP for Humans."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"},
     {file = "requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed"},
@@ -4715,7 +4794,7 @@ version = "0.23.1"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["dev", "streamlit"]
 files = [
     {file = "rpds_py-0.23.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2a54027554ce9b129fc3d633c92fa33b30de9f08bc61b32c053dc9b537266fed"},
     {file = "rpds_py-0.23.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b5ef909a37e9738d146519657a1aab4584018746a18f71c692f2f22168ece40c"},
@@ -4925,12 +5004,29 @@ objc = ["pyobjc-framework-Cocoa ; sys_platform == \"darwin\""]
 win32 = ["pywin32 ; sys_platform == \"win32\""]
 
 [[package]]
+name = "sendgrid"
+version = "6.12.5"
+description = "Twilio SendGrid library for Python"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+groups = ["main"]
+files = [
+    {file = "sendgrid-6.12.5-py3-none-any.whl", hash = "sha256:96f92cc91634bf552fdb766b904bbb53968018da7ae41fdac4d1090dc0311ca8"},
+    {file = "sendgrid-6.12.5.tar.gz", hash = "sha256:ea9aae30cd55c332e266bccd11185159482edfc07c149b6cd15cf08869fabdb7"},
+]
+
+[package.dependencies]
+cryptography = ">=45.0.6"
+python-http-client = ">=3.2.1"
+werkzeug = {version = ">=2.3.5", markers = "python_version >= \"3.12\""}
+
+[[package]]
 name = "setuptools"
 version = "67.8.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["dev"]
 files = [
     {file = "setuptools-67.8.0-py3-none-any.whl", hash = "sha256:5df61bf30bb10c6f756eb19e7c9f3b473051f48db77fddbe06ff2ca307df9a6f"},
     {file = "setuptools-67.8.0.tar.gz", hash = "sha256:62642358adc77ffa87233bc4d2354c4b2682d214048f500964dbe760ccedf102"},
@@ -4947,7 +5043,7 @@ version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-groups = ["main", "dev", "test"]
+groups = ["main", "dev", "streamlit", "test"]
 files = [
     {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
     {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
@@ -4959,7 +5055,7 @@ version = "5.0.2"
 description = "A pure Python implementation of a sliding window memory map manager"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "smmap-5.0.2-py3-none-any.whl", hash = "sha256:b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e"},
     {file = "smmap-5.0.2.tar.gz", hash = "sha256:26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5"},
@@ -4971,7 +5067,7 @@ version = "1.3.1"
 description = "Sniff out which async library your code is running under"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2"},
     {file = "sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc"},
@@ -5027,7 +5123,7 @@ version = "0.46.0"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "streamlit"]
 files = [
     {file = "starlette-0.46.0-py3-none-any.whl", hash = "sha256:913f0798bd90ba90a9156383bcf1350a17d6259451d0d8ee27fc0cf2db609038"},
     {file = "starlette-0.46.0.tar.gz", hash = "sha256:b359e4567456b28d473d0193f34c0de0ed49710d75ef183a74a5ce0499324f50"},
@@ -5045,7 +5141,7 @@ version = "1.58.0"
 description = "A faster way to build and share data apps"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "streamlit-1.58.0-py3-none-any.whl", hash = "sha256:4ca8a7afc5bd16a5f176ccf4be1e34e8121cad0240becd127fb58a103ea3178d"},
     {file = "streamlit-1.58.0.tar.gz", hash = "sha256:78a22e7085b053af7ce544442bf4b670771e68c509ba1bdaa056ba0708f49c3d"},
@@ -5092,7 +5188,7 @@ version = "1.1.0"
 description = "Streamlit component implementation of ag-grid"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "streamlit_aggrid-1.1.0-py3-none-any.whl", hash = "sha256:216b3880a325f1e900b3a43d840503a33031e9ef9d94178c2d22628ada17f946"},
     {file = "streamlit_aggrid-1.1.0.tar.gz", hash = "sha256:4541d135de98acc5796676bc1ed9564612ef6a88ec0cd99a0875f20c0f1fecc8"},
@@ -5109,7 +5205,7 @@ version = "0.1.0"
 description = "React Components for Streamlit."
 optional = false
 python-versions = ">=3.6"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "streamlit-elements-0.1.0.tar.gz", hash = "sha256:5f9f116f22df3ce4a8636b1dee7c2fd3dc3cb0c66267fd28c3e0314aa1d303a7"},
     {file = "streamlit_elements-0.1.0-py3-none-any.whl", hash = "sha256:593c4b88c399c55879aa76f7f42970f30106f66acaa4baada6338ae5571790df"},
@@ -5124,7 +5220,7 @@ version = "0.1.15"
 description = "Small handy widgets for streamlit, e.g. download button which won't cause rerun, set page width"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "streamlit_ext-0.1.15-py3-none-any.whl", hash = "sha256:3e7dd4c77528958003a58df5dc2108862b76cf3507c524af66bb9365dd1c53f2"},
     {file = "streamlit_ext-0.1.15.tar.gz", hash = "sha256:4b89bf84aea499d9a1e9c90bd85a19e03416ffa8ad547583e79c85eb4e54763d"},
@@ -5137,6 +5233,25 @@ streamlit = ">=1.30.0"
 [package.extras]
 dev = ["black (>=22.6.0)", "flake8 (>=4.0,<5.0)", "isort (>=5.10.1)", "mypy", "pandas-stubs (>=1.4.3)"]
 test = ["openpyxl", "pandas", "pytest (>=7.1)", "pytest-cov (>=3.0.0)"]
+
+[[package]]
+name = "stripe"
+version = "15.2.1"
+description = "Python bindings for the Stripe API"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "stripe-15.2.1-py3-none-any.whl", hash = "sha256:49571ffbfd7944daae4000e33d3b42705012ee7aae003b7b67868c1e59d442f5"},
+    {file = "stripe-15.2.1.tar.gz", hash = "sha256:5821a802abf70be900d7b1b6bb609697cc25c9aa521eb86430e68b994dac9f78"},
+]
+
+[package.dependencies]
+requests = ">=2.20"
+typing_extensions = ">=4.7.0"
+
+[package.extras]
+async = ["httpx"]
 
 [[package]]
 name = "syrupy"
@@ -5159,7 +5274,7 @@ version = "9.0.0"
 description = "Retry code until it succeeds"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539"},
     {file = "tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b"},
@@ -5238,7 +5353,7 @@ version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
@@ -5374,7 +5489,7 @@ version = "4.12.2"
 description = "Backported and Experimental Type Hints for Python 3.8+"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d"},
     {file = "typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"},
@@ -5386,7 +5501,7 @@ version = "2026.2"
 description = "Provider of IANA time zone data"
 optional = false
 python-versions = ">=2"
-groups = ["main"]
+groups = ["main", "streamlit"]
 files = [
     {file = "tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7"},
     {file = "tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10"},
@@ -5431,7 +5546,7 @@ version = "2.3.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "dev", "streamlit"]
 files = [
     {file = "urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df"},
     {file = "urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"},
@@ -5452,7 +5567,7 @@ version = "0.49.0"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "streamlit"]
 files = [
     {file = "uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f"},
     {file = "uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3"},
@@ -5483,7 +5598,7 @@ version = "5.0.3"
 description = "Filesystem events monitoring"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "test"]
+groups = ["dev", "streamlit", "test"]
 files = [
     {file = "watchdog-5.0.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:85527b882f3facda0579bce9d743ff7f10c3e1e0db0a0d0e28170a7d0e5ce2ea"},
     {file = "watchdog-5.0.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:53adf73dcdc0ef04f7735066b4a57a4cd3e49ef135daae41d77395f0b5b692cb"},
@@ -5516,7 +5631,7 @@ files = [
     {file = "watchdog-5.0.3-py3-none-win_ia64.whl", hash = "sha256:49f4d36cb315c25ea0d946e018c01bb028048023b9e103d3d3943f58e109dd45"},
     {file = "watchdog-5.0.3.tar.gz", hash = "sha256:108f42a7f0345042a854d4d0ad0834b741d421330d5f575b81cb27b883500176"},
 ]
-markers = {main = "platform_system != \"Darwin\""}
+markers = {streamlit = "platform_system != \"Darwin\""}
 
 [package.extras]
 watchmedo = ["PyYAML (>=3.10)"]
@@ -5580,7 +5695,7 @@ version = "16.0"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["streamlit"]
 files = [
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:04cdd5d2d1dacbad0a7bf36ccbcd3ccd5a30ee188f2560b7a62a30d14107b31a"},
     {file = "websockets-16.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:8ff32bb86522a9e5e31439a58addbb0166f0204d64066fb955265c4e214160f0"},
@@ -5644,6 +5759,24 @@ files = [
     {file = "websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec"},
     {file = "websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5"},
 ]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+description = "The comprehensive WSGI web application library."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50"},
+    {file = "werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44"},
+]
+
+[package.dependencies]
+markupsafe = ">=2.1.1"
+
+[package.extras]
+watchdog = ["watchdog (>=2.3)"]
 
 [[package]]
 name = "widgetsnbextension"
@@ -5793,62 +5926,7 @@ enabler = ["pytest-enabler (>=2.2)"]
 test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
 type = ["pytest-mypy"]
 
-[[package]]
-name = "zope-interface"
-version = "7.2"
-description = "Interfaces for Python"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "zope.interface-7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:ce290e62229964715f1011c3dbeab7a4a1e4971fd6f31324c4519464473ef9f2"},
-    {file = "zope.interface-7.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:05b910a5afe03256b58ab2ba6288960a2892dfeef01336dc4be6f1b9ed02ab0a"},
-    {file = "zope.interface-7.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:550f1c6588ecc368c9ce13c44a49b8d6b6f3ca7588873c679bd8fd88a1b557b6"},
-    {file = "zope.interface-7.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0ef9e2f865721553c6f22a9ff97da0f0216c074bd02b25cf0d3af60ea4d6931d"},
-    {file = "zope.interface-7.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:27f926f0dcb058211a3bb3e0e501c69759613b17a553788b2caeb991bed3b61d"},
-    {file = "zope.interface-7.2-cp310-cp310-win_amd64.whl", hash = "sha256:144964649eba4c5e4410bb0ee290d338e78f179cdbfd15813de1a664e7649b3b"},
-    {file = "zope.interface-7.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1909f52a00c8c3dcab6c4fad5d13de2285a4b3c7be063b239b8dc15ddfb73bd2"},
-    {file = "zope.interface-7.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:80ecf2451596f19fd607bb09953f426588fc1e79e93f5968ecf3367550396b22"},
-    {file = "zope.interface-7.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:033b3923b63474800b04cba480b70f6e6243a62208071fc148354f3f89cc01b7"},
-    {file = "zope.interface-7.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a102424e28c6b47c67923a1f337ede4a4c2bba3965b01cf707978a801fc7442c"},
-    {file = "zope.interface-7.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:25e6a61dcb184453bb00eafa733169ab6d903e46f5c2ace4ad275386f9ab327a"},
-    {file = "zope.interface-7.2-cp311-cp311-win_amd64.whl", hash = "sha256:3f6771d1647b1fc543d37640b45c06b34832a943c80d1db214a37c31161a93f1"},
-    {file = "zope.interface-7.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:086ee2f51eaef1e4a52bd7d3111a0404081dadae87f84c0ad4ce2649d4f708b7"},
-    {file = "zope.interface-7.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:21328fcc9d5b80768bf051faa35ab98fb979080c18e6f84ab3f27ce703bce465"},
-    {file = "zope.interface-7.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f6dd02ec01f4468da0f234da9d9c8545c5412fef80bc590cc51d8dd084138a89"},
-    {file = "zope.interface-7.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e7da17f53e25d1a3bde5da4601e026adc9e8071f9f6f936d0fe3fe84ace6d54"},
-    {file = "zope.interface-7.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cab15ff4832580aa440dc9790b8a6128abd0b88b7ee4dd56abacbc52f212209d"},
-    {file = "zope.interface-7.2-cp312-cp312-win_amd64.whl", hash = "sha256:29caad142a2355ce7cfea48725aa8bcf0067e2b5cc63fcf5cd9f97ad12d6afb5"},
-    {file = "zope.interface-7.2-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:3e0350b51e88658d5ad126c6a57502b19d5f559f6cb0a628e3dc90442b53dd98"},
-    {file = "zope.interface-7.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:15398c000c094b8855d7d74f4fdc9e73aa02d4d0d5c775acdef98cdb1119768d"},
-    {file = "zope.interface-7.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:802176a9f99bd8cc276dcd3b8512808716492f6f557c11196d42e26c01a69a4c"},
-    {file = "zope.interface-7.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eb23f58a446a7f09db85eda09521a498e109f137b85fb278edb2e34841055398"},
-    {file = "zope.interface-7.2-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a71a5b541078d0ebe373a81a3b7e71432c61d12e660f1d67896ca62d9628045b"},
-    {file = "zope.interface-7.2-cp313-cp313-win_amd64.whl", hash = "sha256:4893395d5dd2ba655c38ceb13014fd65667740f09fa5bb01caa1e6284e48c0cd"},
-    {file = "zope.interface-7.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d3a8ffec2a50d8ec470143ea3d15c0c52d73df882eef92de7537e8ce13475e8a"},
-    {file = "zope.interface-7.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:31d06db13a30303c08d61d5fb32154be51dfcbdb8438d2374ae27b4e069aac40"},
-    {file = "zope.interface-7.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e204937f67b28d2dca73ca936d3039a144a081fc47a07598d44854ea2a106239"},
-    {file = "zope.interface-7.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:224b7b0314f919e751f2bca17d15aad00ddbb1eadf1cb0190fa8175edb7ede62"},
-    {file = "zope.interface-7.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:baf95683cde5bc7d0e12d8e7588a3eb754d7c4fa714548adcd96bdf90169f021"},
-    {file = "zope.interface-7.2-cp38-cp38-win_amd64.whl", hash = "sha256:7dc5016e0133c1a1ec212fc87a4f7e7e562054549a99c73c8896fa3a9e80cbc7"},
-    {file = "zope.interface-7.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7bd449c306ba006c65799ea7912adbbfed071089461a19091a228998b82b1fdb"},
-    {file = "zope.interface-7.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a19a6cc9c6ce4b1e7e3d319a473cf0ee989cbbe2b39201d7c19e214d2dfb80c7"},
-    {file = "zope.interface-7.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:72cd1790b48c16db85d51fbbd12d20949d7339ad84fd971427cf00d990c1f137"},
-    {file = "zope.interface-7.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:52e446f9955195440e787596dccd1411f543743c359eeb26e9b2c02b077b0519"},
-    {file = "zope.interface-7.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ad9913fd858274db8dd867012ebe544ef18d218f6f7d1e3c3e6d98000f14b75"},
-    {file = "zope.interface-7.2-cp39-cp39-win_amd64.whl", hash = "sha256:1090c60116b3da3bfdd0c03406e2f14a1ff53e5771aebe33fec1edc0a350175d"},
-    {file = "zope.interface-7.2.tar.gz", hash = "sha256:8b49f1a3d1ee4cdaf5b32d2e738362c7f5e40ac8b46dd7d1a65e82a4872728fe"},
-]
-
-[package.dependencies]
-setuptools = "*"
-
-[package.extras]
-docs = ["Sphinx", "furo", "repoze.sphinx.autointerface"]
-test = ["coverage[toml]", "zope.event", "zope.testing"]
-testing = ["coverage[toml]", "zope.event", "zope.testing"]
-
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "527bbb0e7fbb2b87ca262df19b13bcb8078ab50b88d2964d67614feee45ef438"
+content-hash = "1426378b7b873ca6a1ad2d0c81e15137b5ce53042e4ff63a0e6dde33d62812d6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,31 +10,38 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"
-# Core Application Dependencies
-selenium = "^4.25"
-mysql-connector-python = "^9.1"
-python-dotenv = "^1.0"
-openai = "^1.52.2"
+
+# --- Web / API ---
 fastapi = "^0.115.4"
-linkedin-api-client = "^0.3.0"
 uvicorn = ">=0.32,<0.50"
+pydantic-extra-types = "^2.10.0"
+python-dotenv = "^1.0"
+requests = "^2.32.3"
+typing-extensions = "^4.12.2"
+
+# --- Task queue ---
 celery = {version = "^5.4.0", extras = ["redis"]}
 redis = "^5.2.0"
-bs4 = "^0.0.2"
-pandas = "^2.2.3"
-dateparser = "^1.2.0"
-requests = "^2.32.3"
-pydantic-extra-types = "^2.10.0"
 celery-once = {git = "https://github.com/gitchrisqueen/celery-once.git"}
+flower = "^2.0.1"
 
-# Frontend/UI Dependencies
-streamlit = ">=1.39,<1.40.0 || >1.40.1,<2.0"
-streamlit-ext = "^0.1"
-streamlit-elements = "^0.1"
-extra-streamlit-components = "^0.1"
-streamlit-aggrid = "^1.0"
+# --- Database ---
+mysql-connector-python = "^9.1"
 
-# Content Processing
+# --- LinkedIn automation ---
+selenium = "^4.25"
+linkedin-api-client = "^0.3.0"
+bs4 = "^0.0.2"
+pycurl = "^7.45.4"
+
+# --- AI / external APIs ---
+openai = "^1.52.2"
+googlenews = "^1.6.15"
+runwayml = "^2.1.0"
+replicate = "^1.0.4"
+pexels-api = "^1.0.1"
+
+# --- Content processing ---
 markdownify = "^0.13.1"
 tldextract = "^5.1.2"
 nltk = "^3.9.1"
@@ -42,26 +49,33 @@ fpdf = "^1.7.2"
 python-pptx = "^1.0.2"
 mammoth = "^1.8.0"
 docx = "^0.2.4"
-pycurl = "^7.45.4"
-typing-extensions = "^4.12.2"
-os-env = "^0.3"  # Redundant with python-dotenv
-datetime = "^5.5"  # Built-in module
+dateparser = "^1.2.0"
 
+# --- Observability ---
+posthog = "^3.7"
 
-# AI/ML Development Tools
-googlenews = "^1.6.15"
-runwayml = "^2.1.0"
-#huggingface-hub = "^0.26.2"
-#gradio-client = "^1.4.3"
-replicate = "^1.0.4"
-pexels-api = "^1.0.1"
-
-# Monitoring
-flower = "^2.0.1"  # Celery monitoring
-posthog = "^3.7"   # LLM usage + system observability
-
-# AWS
+# --- AWS / payments ---
 boto3 = "^1.36.7"
+sendgrid = "^6.12.5"
+stripe = "^15.2.1"
+
+# ---------------------------------------------------------------------------
+# streamlit group — legacy Streamlit UI (replaced by React SPA).
+# NOT installed in Docker. Install locally with:
+#   poetry install --with streamlit
+# Add packages here if they are only needed for Streamlit pages.
+# ---------------------------------------------------------------------------
+[tool.poetry.group.streamlit]
+optional = true
+
+[tool.poetry.group.streamlit.dependencies]
+streamlit = ">=1.39,<1.40.0 || >1.40.1,<2.0"
+streamlit-ext = "^0.1"
+streamlit-elements = "^0.1"
+extra-streamlit-components = "^0.1"
+streamlit-aggrid = "^1.0"
+# pandas is only imported in src/cqc_lem/streamlit/ — keep here, not in main
+pandas = "^2.2.3"
 
 [tool.poetry.group.dev]
 optional = true
@@ -71,7 +85,6 @@ optional = true
 jupyter = "^1.0.0"
 setuptools = "^67.6.1"
 grandalf = "^0.8"
-#flower = "^2.0.1"  # Celery monitoring
 watchdog = "^5.0.3"
 
 #AWS

--- a/run.sh
+++ b/run.sh
@@ -1,11 +1,22 @@
 #!/bin/bash
 
-# Load the .env file (optional, Docker Compose will load this automatically if the .env is in the root)
+# Load the .env file (Docker Compose also loads this automatically)
 export $(grep -v '^#' .env | xargs)
 
 NGROK_PLAN="${NGROK_PLAN:-off}"
+UI_SRC_DIR="src/cqc_lem/ui/src"
+UI_DIST_REF="src/cqc_lem/ui/dist/index.html"
 
-# Step 1: Prompt the user if they want to build the latest docker image
+# ─── Current container status ────────────────────────────────────────────────
+printf "Current container status:\n"
+if docker compose ps 2>/dev/null | grep -q "running\|Up\|healthy"; then
+    docker compose ps
+else
+    printf "  (no containers running)\n"
+fi
+printf "\n"
+
+# ─── Step 1: Build Docker image ──────────────────────────────────────────────
 read -p "Do you want to build the latest Docker image(s)? (y/n): " build_image
 if [ "$build_image" == "y" ]; then
     echo "Building Docker images (${DOCKER_IMAGE_NAME}:latest)..."
@@ -17,11 +28,67 @@ if [ "$build_image" == "y" ]; then
     fi
 fi
 
-# Step 2: Run the Docker containers
+# ─── Step 1b: React UI — rebuild if source changed since last build ──────────
+# dist/ is volume-mounted (./src:/app/src) so a local npm build is picked up
+# by the running container immediately — no Docker rebuild needed.
+NEEDS_UI_BUILD=false
+if [ ! -f "$UI_DIST_REF" ]; then
+    printf "\nWarning: React dist/ not found — the UI will be blank until it is built.\n"
+    NEEDS_UI_BUILD=true
+elif [ -d "$UI_SRC_DIR" ] && \
+     find "$UI_SRC_DIR" -newer "$UI_DIST_REF" \
+         \( -name "*.tsx" -o -name "*.ts" -o -name "*.css" -o -name "*.json" \) \
+         2>/dev/null | grep -q .; then
+    printf "\nReact UI source has changed since the last build.\n"
+    NEEDS_UI_BUILD=true
+fi
+
+if [ "$NEEDS_UI_BUILD" = "true" ]; then
+    read -p "Rebuild React UI now? (y/n): " rebuild_ui
+    if [ "$rebuild_ui" = "y" ]; then
+        printf "Building React UI...\n"
+        (cd src/cqc_lem/ui && npm run build)
+    fi
+fi
+
+# ─── Step 2: Start containers ────────────────────────────────────────────────
 echo "Starting Docker Containers..."
 docker compose up -d --remove-orphans
 
-# Step 3: Clean up old images and build cache
+# ─── Step 2b: Status after startup ───────────────────────────────────────────
+printf "\nContainer status:\n"
+docker compose ps
+printf "\n"
+
+# ─── Step 2c: Celery — restart if task files changed since worker started ────
+# Python API changes auto-reload via uvicorn --reload (no action needed).
+# Celery workers do NOT auto-reload; this detects stale task code and prompts.
+CELERY_RUNNING=$(docker ps -q -f "name=^celery_worker$" 2>/dev/null)
+if [ -n "$CELERY_RUNNING" ]; then
+    NEEDS_CELERY_RESTART=$(docker inspect --format='{{.State.StartedAt}}' celery_worker 2>/dev/null | \
+        python3 -c "
+import sys, os
+from datetime import datetime, timezone
+try:
+    ts = sys.stdin.read().strip()[:19]
+    start = datetime.strptime(ts, '%Y-%m-%dT%H:%M:%S').replace(tzinfo=timezone.utc).timestamp()
+    for root, _, files in os.walk('src/cqc_lem/app'):
+        for f in files:
+            if f.endswith('.py') and os.path.getmtime(os.path.join(root, f)) > start:
+                print('yes'); sys.exit(0)
+except Exception:
+    pass
+" 2>/dev/null)
+    if [ "$NEEDS_CELERY_RESTART" = "yes" ]; then
+        printf "Celery task files in src/cqc_lem/app/ changed since the worker last started.\n"
+        read -p "Restart celery_worker now? (y/n): " restart_celery
+        if [ "$restart_celery" = "y" ]; then
+            docker compose restart celery_worker
+        fi
+    fi
+fi
+
+# ─── Step 3: Clean up old images and build cache ─────────────────────────────
 echo "Cleaning up old Docker images older than 7 days..."
 docker image prune -a --filter "until=168h" -f
 
@@ -30,7 +97,7 @@ docker builder prune --filter "until=168h" -f
 
 printf "\nExecution completed!\n\n"
 
-# Step 4 and Step 5: Start NGrok Tunnels based on NGROK_PLAN
+# ─── Step 4 + 5: NGrok tunnels ───────────────────────────────────────────────
 if [ "$NGROK_PLAN" != "off" ]; then
     if [ -z "$NGROK_AUTH_TOKEN" ]; then
         printf "Warning: NGROK_PLAN=%s but NGROK_AUTH_TOKEN is not set — skipping NGrok.\n" "$NGROK_PLAN"
@@ -60,7 +127,26 @@ if [ "$NGROK_PLAN" != "off" ]; then
     fi
 fi
 
-# Step 6: Build URL display arrays based on NGROK_PLAN
+# ─── Step 6: Build URL display ───────────────────────────────────────────────
+
+# For the free plan, the Flower tunnel has no reserved domain so it gets a random URL.
+# Query the ngrok API to surface the actual live URL instead of sending users to the UI.
+FLOWER_NGROK_URL=""
+if [ "$NGROK_PLAN" = "free" ]; then
+    FLOWER_NGROK_URL=$(curl -sf "http://localhost:${NGROK_UI_PORT}/api/tunnels" 2>/dev/null | \
+        python3 -c "
+import sys, json
+try:
+    tunnels = json.load(sys.stdin).get('tunnels', [])
+    for t in tunnels:
+        if 'flower' in t.get('name', '').lower():
+            print(t['public_url'])
+            break
+except Exception:
+    pass
+" 2>/dev/null || echo "")
+fi
+
 titles=("React Web App" "API Docs" "Flower Celery Monitoring" "Docker Chrome VNC")
 
 case "$NGROK_PLAN" in
@@ -75,11 +161,12 @@ case "$NGROK_PLAN" in
     urls+=("http://localhost:${NGROK_UI_PORT}")
     ;;
   free)
-    # Free plan: 2 tunnels (app=static domain, flower=dynamic; chrome=local only)
+    # Free plan: lem-app uses static domain; lem-flower gets a dynamic URL (fetched above).
+    # lem-chrome is excluded to stay within the 3-tunnel free-plan limit.
     urls=(
       "https://${NGROK_CUSTOM_DOMAIN}"
       "https://${NGROK_CUSTOM_DOMAIN}/docs"
-      "Dynamic — see http://localhost:${NGROK_UI_PORT}"
+      "${FLOWER_NGROK_URL:-Dynamic — see http://localhost:${NGROK_UI_PORT}}"
       "http://localhost:7900 (local only)"
     )
     titles+=("Ngrok Web Interface")
@@ -143,6 +230,14 @@ print_urls() {
 }
 
 print_urls "titles[@]" "urls[@]"
+
+# ─── Dev workflow quick reference ────────────────────────────────────────────
+printf "Dev workflow (no Docker rebuild needed):\n"
+printf "  Python changes  → auto-reloaded by uvicorn  (no action needed)\n"
+printf "  React UI change → cd src/cqc_lem/ui && npm run build\n"
+printf "  Celery changes  → docker compose restart celery_worker\n"
+printf "  View logs       → docker compose logs -f <service>\n"
+printf "  Stop all        → docker compose down\n\n"
 
 # Remove Dangling Images
 docker image prune -f --filter "dangling=true"

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -181,9 +181,12 @@ def update_user_endpoint(settings: UserSettingsRequest) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=403, detail="User not found")
 
+    if not any([settings.new_email, settings.blog_url, settings.sitemap_url]):
+        return ResponseModel(status_code=200, detail="User settings unchanged")
+
     updated = update_user(user_id, email=settings.new_email, blog_url=settings.blog_url, sitemap_url=settings.sitemap_url)
     if not updated:
-        raise HTTPException(status_code=404, detail="No fields to update or update failed")
+        raise HTTPException(status_code=404, detail="Update failed")
     return ResponseModel(status_code=200, detail="User updated successfully")
 
 
@@ -396,13 +399,19 @@ def linkedin_callback(code: str, state: str = None) -> Union[ResponseModel, Redi
         access_token_response.refresh_token_expires_in,
     )
 
-    # Redirect to React account page (React Router path)
+    # Redirect to React account page, passing the authenticated email so the
+    # frontend can persist it to localStorage without requiring the user to re-type it.
+    user_email = response.entity.get('email', '')
+    from urllib.parse import quote, urlencode
+    qs = urlencode({'email': user_email, 'li_connected': '1'}) if user_email else 'li_connected=1'
+
     parsed_url = urlparse(LI_REDIRECT_URL)
-    netloc = parsed_url.netloc.split(':')[0]
-    final_redirect_url = urlunparse((parsed_url.scheme, netloc, '/account', '', '', ''))
+    base_host = f"{parsed_url.scheme}://{parsed_url.netloc.split(':')[0]}"
 
     if os.environ.get('NGROK_CUSTOM_DOMAIN'):
-        final_redirect_url = "https://" + os.environ.get('NGROK_CUSTOM_DOMAIN') + '/account'
+        base_host = "https://" + os.environ.get('NGROK_CUSTOM_DOMAIN')
+
+    final_redirect_url = f"{base_host}/account?{qs}"
 
     return RedirectResponse(url=final_redirect_url)
 

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1,3 +1,4 @@
+import json
 import os
 import time
 from datetime import datetime
@@ -13,7 +14,17 @@ from cqc_lem.app.run_content_plan import auto_create_weekly_content
 from cqc_lem.utilities.db import (
     insert_post, get_post_by_email, get_user_id, update_db_post, get_post_user_id,
     add_user_with_access_token, update_user, PostType, PostStatus, get_posts,
-    get_recent_logs,
+    get_recent_logs, bulk_update_posts, soft_delete_posts,
+    create_pin_for_email, verify_pin_for_email,
+    create_session, get_session_user_id, delete_session,
+    add_user_by_email, get_user_email, get_user_token_info,
+    get_user_subscription_info, get_user_preferences, update_user_preferences,
+    update_subscription_from_stripe, update_user_linkedin_token,
+    get_users_with_stripe_subscriptions,
+)
+from cqc_lem.utilities.email import generate_pin, hash_pin, send_pin_email
+from cqc_lem.utilities.linkedin.token_refresh import (
+    get_token_expiry, is_token_expired, is_token_expiring_soon, attempt_token_refresh,
 )
 from cqc_lem.utilities.env_constants import LI_CLIENT_ID, LI_CLIENT_SECRET, LI_REDIRECT_URL, LI_STATE_SALT
 from cqc_lem.utilities.logger import myprint
@@ -29,6 +40,7 @@ from fastapi.responses import StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from linkedin_api.clients.auth.client import AuthClient
 from linkedin_api.clients.restli.client import RestliClient
+from linkedin_api.common.errors import ResponseFormattingError
 from pydantic import BaseModel, computed_field
 
 app = FastAPI()
@@ -40,14 +52,18 @@ router = APIRouter(prefix="/api")
 @app.middleware("http")
 async def observability_middleware(request: Request, call_next):
     start = time.time()
-    response = await call_next(request)
-    track_api_call(
-        route=request.url.path,
-        method=request.method,
-        status_code=response.status_code,
-        latency_ms=int((time.time() - start) * 1000),
-    )
-    return response
+    status_code = 500
+    try:
+        response = await call_next(request)
+        status_code = response.status_code
+        return response
+    finally:
+        track_api_call(
+            route=request.url.path,
+            method=request.method,
+            status_code=status_code,
+            latency_ms=int((time.time() - start) * 1000),
+        )
 
 
 _ui_dist = os.path.join(os.path.dirname(__file__), "..", "ui", "dist")
@@ -67,6 +83,18 @@ class ResponseModel(BaseModel):
     detail: Any
 
 
+def _parse_slides(raw) -> Optional[List[str]]:
+    if not raw:
+        return None
+    if isinstance(raw, list):
+        return raw
+    try:
+        result = json.loads(raw)
+        return result if isinstance(result, list) else None
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
 class PostRequest(BaseModel):
     content: str
     video_url: Optional[str] = None
@@ -74,6 +102,7 @@ class PostRequest(BaseModel):
     scheduled_datetime: datetime
     email: Optional[str] = None
     status: Optional[PostStatus] = PostStatus.PENDING
+    carousel_slides: Optional[List[str]] = None
 
     @property
     def post_json(self):
@@ -87,11 +116,52 @@ class PostRequest(BaseModel):
         return self.scheduled_datetime.isoformat()
 
 
+class BulkUpdateRequest(BaseModel):
+    post_ids: List[int]
+    status: Optional[PostStatus] = None
+    scheduled_datetime: Optional[datetime] = None
+
+
+class BulkDeleteRequest(BaseModel):
+    post_ids: List[int]
+
+
 class UserSettingsRequest(BaseModel):
     email: str
     new_email: Optional[str] = None
     blog_url: Optional[str] = None
     sitemap_url: Optional[str] = None
+
+
+class AuthInitRequest(BaseModel):
+    email: str
+
+
+class AuthVerifyRequest(BaseModel):
+    email: str
+    pin: str
+
+
+class LogoutRequest(BaseModel):
+    session_token: str
+
+
+class CheckoutSessionRequest(BaseModel):
+    session_token: str
+    tier: str
+    success_url: str
+    cancel_url: str
+
+
+class PortalSessionRequest(BaseModel):
+    session_token: str
+    return_url: str
+
+
+class UserPreferencesRequest(BaseModel):
+    session_token: str
+    last_login_inactivate_delay: Optional[int] = 90
+    auto_schedule_posts: bool = False
 
 
 class FutureForwardValues(IntEnum):
@@ -120,7 +190,7 @@ def get_dashboard_stats(email: str) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=403, detail="User not found")
 
-    posts = get_posts(user_id) or []
+    posts, _ = get_posts(user_id)
     now = datetime.now()
     week_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     week_start = week_start.replace(day=week_start.day - week_start.weekday())
@@ -226,7 +296,8 @@ def schedule_post(post: PostRequest) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=403, detail="User not found")
 
-    if insert_post(post.email, post.content, post.scheduled_datetime, post.post_type):
+    if insert_post(post.email, post.content, post.scheduled_datetime, post.post_type,
+                   video_url=post.video_url, carousel_slides=post.carousel_slides):
         return ResponseModel(status_code=200, detail="Post scheduled successfully")
     else:
         raise HTTPException(status_code=404, detail="Could not schedule post")
@@ -293,13 +364,21 @@ def get_user_id_from_email(email: str) -> ResponseModel:
     200: {"description": "Posts retrieved successfully"},
     **{k: v for k, v in error_responses.items() if k in [400, 404]}
 })
-def get_posts_for_email(email: str) -> ResponseModel:
+def get_posts_for_email(
+    email: str,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=10, ge=1, le=200),
+    sort_order: str = Query(default='asc', pattern='^(asc|desc)$'),
+    status_filter: Optional[str] = Query(default=None),
+) -> ResponseModel:
     if not email:
         raise HTTPException(status_code=400, detail="Email is required")
 
-    posts = get_post_by_email(email)
-    if not posts:
-        raise HTTPException(status_code=404, detail="No posts found for the given email")
+    offset = (page - 1) * page_size
+    posts, total = get_post_by_email(
+        email, limit=page_size, offset=offset,
+        sort_order=sort_order, status_filter=status_filter
+    )
 
     posts_list = [
         {
@@ -308,11 +387,45 @@ def get_posts_for_email(email: str) -> ResponseModel:
             "video_url": post["video_url"],
             "scheduled_time": post["scheduled_time"],
             "post_type": post["post_type"],
-            "status": post['status'],
+            "status": post["status"],
+            "carousel_slides": _parse_slides(post.get("carousel_slides")),
         }
         for post in posts
     ]
-    return ResponseModel(status_code=200, detail=posts_list)
+    return ResponseModel(status_code=200, detail={
+        "posts": posts_list,
+        "total": total,
+        "page": page,
+        "page_size": page_size,
+    })
+
+
+@router.post("/posts/bulk_update/", responses={
+    200: {"description": "Posts updated successfully"},
+    **{k: v for k, v in error_responses.items() if k in [400, 405]}
+})
+def bulk_update_posts_endpoint(request: BulkUpdateRequest) -> ResponseModel:
+    if not request.post_ids:
+        raise HTTPException(status_code=400, detail="post_ids is required")
+
+    if bulk_update_posts(request.post_ids, status=request.status, scheduled_time=request.scheduled_datetime):
+        return ResponseModel(status_code=200, detail="Posts updated successfully")
+    else:
+        raise HTTPException(status_code=405, detail="Posts could not be updated")
+
+
+@router.delete("/posts/", responses={
+    200: {"description": "Posts deleted (soft) successfully"},
+    **{k: v for k, v in error_responses.items() if k in [400, 405]}
+})
+def delete_posts_endpoint(request: BulkDeleteRequest) -> ResponseModel:
+    if not request.post_ids:
+        raise HTTPException(status_code=400, detail="post_ids is required")
+
+    if soft_delete_posts(request.post_ids):
+        return ResponseModel(status_code=200, detail="Posts deleted successfully")
+    else:
+        raise HTTPException(status_code=405, detail="Posts could not be deleted")
 
 
 @router.post("/update_post/", responses={
@@ -355,12 +468,136 @@ def get_assets(file_name: str, content_type: Optional[str] = None,
 
 
 # LinkedIn OAuth initiation — builds the authorization URL and redirects user to LinkedIn
+@router.post("/auth/email/init")
+def auth_email_init(request: AuthInitRequest) -> ResponseModel:
+    email = request.email.strip().lower()
+    if not email:
+        raise HTTPException(status_code=400, detail="Email is required")
+
+    user_exists = bool(get_user_id(email))
+    pin = generate_pin()
+    pin_hash = hash_pin(pin, email)
+
+    sent, bypassed = send_pin_email(email, pin, is_new_user=not user_exists)
+
+    if bypassed:
+        # No email provider configured — create user + session immediately, skip PIN step
+        user_id = get_user_id(email)
+        is_new_user = user_id is None
+        if is_new_user:
+            user_id = add_user_by_email(email)
+            if not user_id:
+                raise HTTPException(status_code=500, detail="Could not create user record")
+        session_token = create_session(user_id)
+        if not session_token:
+            raise HTTPException(status_code=500, detail="Could not create session")
+        return ResponseModel(status_code=200, detail={
+            "bypass": True,
+            "session_token": session_token,
+            "email": email,
+            "is_new_user": is_new_user,
+        })
+
+    if not sent:
+        raise HTTPException(status_code=500, detail="Could not send PIN email — check email provider settings")
+
+    if not create_pin_for_email(email, pin_hash):
+        raise HTTPException(status_code=500, detail="Could not create PIN")
+
+    return ResponseModel(status_code=200, detail={"bypass": False, "user_exists": user_exists, "message": "PIN sent to email"})
+
+
+@router.post("/auth/email/verify")
+def auth_email_verify(request: AuthVerifyRequest) -> ResponseModel:
+    email = request.email.strip().lower()
+    pin = request.pin.strip()
+    if not email or not pin:
+        raise HTTPException(status_code=400, detail="Email and PIN are required")
+
+    pin_hash = hash_pin(pin, email)
+    if not verify_pin_for_email(email, pin_hash):
+        raise HTTPException(status_code=401, detail="Invalid or expired PIN")
+
+    user_id = get_user_id(email)
+    is_new_user = user_id is None
+    if is_new_user:
+        user_id = add_user_by_email(email)
+        if not user_id:
+            raise HTTPException(status_code=500, detail="Could not create user record")
+
+    session_token = create_session(user_id)
+    if not session_token:
+        raise HTTPException(status_code=500, detail="Could not create session")
+
+    return ResponseModel(
+        status_code=200,
+        detail={"session_token": session_token, "email": email, "is_new_user": is_new_user},
+    )
+
+
+@router.post("/auth/logout")
+def auth_logout(request: LogoutRequest) -> ResponseModel:
+    delete_session(request.session_token)
+    return ResponseModel(status_code=200, detail="Logged out")
+
+
+@router.get("/auth/session")
+def auth_check_session(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    email = get_user_email(user_id)
+    return ResponseModel(status_code=200, detail={"user_id": user_id, "email": email})
+
+
+@router.get("/user/token_status")
+def get_user_token_status(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    token_info = get_user_token_info(user_id)
+    if not token_info or not token_info.get('access_token'):
+        return ResponseModel(status_code=200, detail={
+            "token_expiry_date": None,
+            "is_expiring_soon": True,
+            "is_expired": True,
+            "refresh_attempted": False,
+            "refresh_succeeded": False,
+        })
+
+    expiring_soon = is_token_expiring_soon(token_info)
+    expired = is_token_expired(token_info)
+    refresh_attempted = False
+    refresh_succeeded = False
+
+    if expiring_soon and token_info.get('refresh_token'):
+        refresh_attempted = True
+        refresh_succeeded, _ = attempt_token_refresh(user_id)
+        if refresh_succeeded:
+            token_info = get_user_token_info(user_id)
+            expiring_soon = is_token_expiring_soon(token_info)
+            expired = is_token_expired(token_info)
+
+    expiry = get_token_expiry(token_info)
+    return ResponseModel(status_code=200, detail={
+        "token_expiry_date": expiry.isoformat() if expiry else None,
+        "is_expiring_soon": expiring_soon,
+        "is_expired": expired,
+        "refresh_attempted": refresh_attempted,
+        "refresh_succeeded": refresh_succeeded,
+    })
+
+
 @app.get("/auth/linkedin/", response_model=None, include_in_schema=False)
 @router.get("/auth/linkedin/", response_model=None, include_in_schema=False)
-def linkedin_auth_init(email: str = None) -> RedirectResponse:
+def linkedin_auth_init(email: str = None, session_token: str = None) -> RedirectResponse:
     client = AuthClient(LI_CLIENT_ID, LI_CLIENT_SECRET, LI_REDIRECT_URL)
+    # Embed the session_token in state so the callback can find the right user,
+    # even when the LinkedIn account email differs from the login email.
+    state = f"{LI_STATE_SALT}:{session_token}" if session_token else LI_STATE_SALT
     auth_url = client.generate_member_auth_url(
-        state=LI_STATE_SALT,
+        state=state,
         scopes=["openid", "profile", "email", "w_member_social"]
     )
     return RedirectResponse(url=auth_url)
@@ -369,51 +606,268 @@ def linkedin_auth_init(email: str = None) -> RedirectResponse:
 # LinkedIn OAuth callback lives outside /api since LinkedIn redirects here
 @app.get("/auth/linkedin/callback", response_model=None)
 def linkedin_callback(code: str, state: str = None) -> Union[ResponseModel, RedirectResponse]:
-    if state is not None and state != LI_STATE_SALT:
-        raise HTTPException(status_code=400, detail="Invalid state parameter")
+    from urllib.parse import urlencode
 
-    resource_path = '/userinfo'
+    def _account_redirect(params: dict) -> RedirectResponse:
+        parsed_url = urlparse(LI_REDIRECT_URL)
+        base_host = f"{parsed_url.scheme}://{parsed_url.netloc.split(':')[0]}"
+        if os.environ.get('NGROK_CUSTOM_DOMAIN'):
+            base_host = "https://" + os.environ.get('NGROK_CUSTOM_DOMAIN')
+        return RedirectResponse(url=f"{base_host}/account?{urlencode(params)}")
+
+    # State format: "{LI_STATE_SALT}:{session_token}" or just "{LI_STATE_SALT}"
+    session_token_from_state: Optional[str] = None
+    if state is not None:
+        if ':' in state:
+            salt_part, session_token_from_state = state.split(':', 1)
+            if salt_part != LI_STATE_SALT:
+                raise HTTPException(status_code=400, detail="Invalid state parameter")
+        elif state != LI_STATE_SALT:
+            raise HTTPException(status_code=400, detail="Invalid state parameter")
+
     client = AuthClient(LI_CLIENT_ID, LI_CLIENT_SECRET, LI_REDIRECT_URL)
-    access_token_response = client.exchange_auth_code_for_access_token(code)
+    try:
+        access_token_response = client.exchange_auth_code_for_access_token(code)
+    except (ResponseFormattingError, Exception) as exc:
+        myprint(f"LinkedIn token exchange failed: {exc}")
+        return _account_redirect({'li_error': 'token_exchange_failed'})
 
     myprint("Access token Response from api call")
     for key, value in access_token_response.__dict__.items():
         myprint(f"{key}: {value}")
 
-    restli_client = RestliClient()
-    response = restli_client.get(
-        resource_path=resource_path,
-        access_token=access_token_response.access_token,
-    )
+    if not access_token_response.access_token:
+        myprint("LinkedIn token exchange returned no access_token")
+        return _account_redirect({'li_error': 'no_access_token'})
 
-    myprint(f"Response from {resource_path} api call:")
-    for key, value in response.__dict__.items():
-        myprint(f"{key}: {value}")
+    try:
+        restli_client = RestliClient()
+        response = restli_client.get(
+            resource_path='/userinfo',
+            access_token=access_token_response.access_token,
+        )
+        myprint("Response from /userinfo api call:")
+        for key, value in response.__dict__.items():
+            myprint(f"{key}: {value}")
+    except Exception as exc:
+        myprint(f"LinkedIn /userinfo call failed: {exc}")
+        return _account_redirect({'li_error': 'userinfo_failed'})
 
-    add_user_with_access_token(
-        response.entity['email'],
-        response.entity['sub'],
-        access_token_response.access_token,
-        access_token_response.expires_in,
-        access_token_response.refresh_token,
-        access_token_response.refresh_token_expires_in,
-    )
-
-    # Redirect to React account page, passing the authenticated email so the
-    # frontend can persist it to localStorage without requiring the user to re-type it.
     user_email = response.entity.get('email', '')
-    from urllib.parse import quote, urlencode
-    qs = urlencode({'email': user_email, 'li_connected': '1'}) if user_email else 'li_connected=1'
+    linked_sub_id = response.entity.get('sub', '')
 
-    parsed_url = urlparse(LI_REDIRECT_URL)
-    base_host = f"{parsed_url.scheme}://{parsed_url.netloc.split(':')[0]}"
+    # Prefer updating the logged-in user's record directly (handles the case where
+    # the LinkedIn account email differs from the app login email).
+    user_id = get_session_user_id(session_token_from_state) if session_token_from_state else None
+    if user_id:
+        myprint(f"Updating LinkedIn token for session user_id={user_id}")
+        update_user_linkedin_token(
+            user_id,
+            linked_sub_id,
+            access_token_response.access_token,
+            access_token_response.expires_in,
+            access_token_response.refresh_token,
+            access_token_response.refresh_token_expires_in,
+            linkedin_email=user_email or None,
+        )
+    else:
+        if not user_email:
+            myprint("LinkedIn /userinfo returned no email and no valid session")
+            return _account_redirect({'li_error': 'no_email'})
+        myprint(f"No session in state — upserting by LinkedIn email {user_email}")
+        add_user_with_access_token(
+            user_email,
+            linked_sub_id,
+            access_token_response.access_token,
+            access_token_response.expires_in,
+            access_token_response.refresh_token,
+            access_token_response.refresh_token_expires_in,
+        )
 
-    if os.environ.get('NGROK_CUSTOM_DOMAIN'):
-        base_host = "https://" + os.environ.get('NGROK_CUSTOM_DOMAIN')
+    return _account_redirect({'email': user_email, 'li_connected': '1'})
 
-    final_redirect_url = f"{base_host}/account?{qs}"
 
-    return RedirectResponse(url=final_redirect_url)
+@router.get("/user/settings")
+def get_user_settings(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    subscription = get_user_subscription_info(user_id)
+    preferences = get_user_preferences(user_id)
+
+    def _iso(dt):
+        return dt.isoformat() if dt else None
+
+    return ResponseModel(status_code=200, detail={
+        "subscription": {
+            "status": subscription.get("subscription_status") if subscription else None,
+            "tier": subscription.get("subscription_tier") if subscription else None,
+            "trial_started_at": _iso(subscription.get("trial_started_at")) if subscription else None,
+            "trial_ends_at": _iso(subscription.get("trial_ends_at")) if subscription else None,
+            "stripe_customer_id": subscription.get("stripe_customer_id") if subscription else None,
+        } if subscription else None,
+        "preferences": {
+            "last_login_inactivate_delay": preferences.get("last_login_inactivate_delay") if preferences else 90,
+            "auto_schedule_posts": bool(preferences.get("auto_schedule_posts")) if preferences else False,
+        } if preferences else None,
+    })
+
+
+@router.put("/user/settings")
+def update_user_settings_endpoint(request: UserPreferencesRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    updated = update_user_preferences(
+        user_id,
+        inactivate_delay=request.last_login_inactivate_delay,
+        auto_schedule_posts=request.auto_schedule_posts,
+    )
+    if not updated:
+        raise HTTPException(status_code=500, detail="Could not update preferences")
+    return ResponseModel(status_code=200, detail="Preferences updated")
+
+
+@router.post("/billing/create-checkout-session")
+def billing_create_checkout_session(request: CheckoutSessionRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    subscription = get_user_subscription_info(user_id)
+    stripe_customer_id = subscription.get("stripe_customer_id") if subscription else None
+    if not stripe_customer_id:
+        raise HTTPException(status_code=400, detail="No Stripe customer record — contact support")
+
+    from cqc_lem.utilities.stripe_util import create_checkout_session
+    url = create_checkout_session(
+        stripe_customer_id,
+        request.tier,
+        request.success_url,
+        request.cancel_url,
+    )
+    if not url:
+        raise HTTPException(status_code=500, detail="Could not create Stripe checkout session")
+    return ResponseModel(status_code=200, detail={"checkout_url": url})
+
+
+@router.post("/billing/create-portal-session")
+def billing_create_portal_session(request: PortalSessionRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    subscription = get_user_subscription_info(user_id)
+    stripe_customer_id = subscription.get("stripe_customer_id") if subscription else None
+    if not stripe_customer_id:
+        raise HTTPException(status_code=400, detail="No Stripe customer record — contact support")
+
+    from cqc_lem.utilities.stripe_util import create_portal_session
+    url = create_portal_session(stripe_customer_id, request.return_url)
+    if not url:
+        raise HTTPException(status_code=500, detail="Could not create Stripe portal session")
+    return ResponseModel(status_code=200, detail={"portal_url": url})
+
+
+@router.post("/billing/webhook")
+async def billing_webhook(request: Request) -> dict:
+    payload = await request.body()
+    sig_header = request.headers.get("Stripe-Signature", "")
+
+    from cqc_lem.utilities.stripe_util import (
+        validate_webhook, get_subscription_tier_from_price, stripe_status_to_db,
+    )
+    event = validate_webhook(payload, sig_header)
+    if event is None:
+        raise HTTPException(status_code=400, detail="Invalid Stripe webhook signature")
+
+    event_type = event.get("type", "")
+    data = event.get("data", {}).get("object", {})
+    myprint(f"Stripe webhook received: {event_type}")
+
+    # --- Subscription lifecycle events ---
+    if event_type in (
+        "customer.subscription.created",
+        "customer.subscription.updated",
+    ):
+        stripe_customer_id = data.get("customer")
+        stripe_subscription_id = data.get("id")
+        sub_status = data.get("status", "")
+        db_status = stripe_status_to_db(sub_status)
+
+        # Determine tier from the first line item's price
+        price_id = None
+        items = data.get("items", {}).get("data", [])
+        if items:
+            price_id = items[0].get("price", {}).get("id")
+        tier = get_subscription_tier_from_price(price_id) if price_id else None
+
+        # Period end (Unix timestamp → datetime)
+        period_end_ts = data.get("current_period_end")
+        period_end = (
+            datetime.fromtimestamp(period_end_ts) if period_end_ts else None
+        )
+
+        myprint(
+            f"Subscription {stripe_subscription_id}: stripe_status={sub_status} "
+            f"→ db_status={db_status}, tier={tier}, period_end={period_end}"
+        )
+        update_subscription_from_stripe(
+            stripe_customer_id, db_status, tier, stripe_subscription_id, period_end
+        )
+
+    elif event_type == "customer.subscription.deleted":
+        stripe_customer_id = data.get("customer")
+        stripe_subscription_id = data.get("id")
+        myprint(f"Subscription {stripe_subscription_id} deleted for customer {stripe_customer_id}")
+        # tier=None preserves the historical tier in the DB
+        update_subscription_from_stripe(
+            stripe_customer_id, "cancelled", None, stripe_subscription_id
+        )
+
+    # --- Invoice / payment events (fired on every billing cycle renewal) ---
+    elif event_type == "invoice.payment_succeeded":
+        stripe_customer_id = data.get("customer")
+        stripe_subscription_id = data.get("subscription")
+        if stripe_subscription_id:
+            myprint(
+                f"Invoice payment succeeded for customer={stripe_customer_id}, "
+                f"subscription={stripe_subscription_id} — marking active"
+            )
+            # Re-fetch the subscription to get the current tier and period end
+            from cqc_lem.utilities.stripe_util import fetch_subscription
+            sub = fetch_subscription(stripe_subscription_id)
+            if sub:
+                price_id = None
+                items = sub.get("items", {}).get("data", [])
+                if items:
+                    price_id = items[0].get("price", {}).get("id")
+                tier = get_subscription_tier_from_price(price_id) if price_id else None
+                period_end_ts = sub.get("current_period_end")
+                period_end = datetime.fromtimestamp(period_end_ts) if period_end_ts else None
+                update_subscription_from_stripe(
+                    stripe_customer_id, "active", tier, stripe_subscription_id, period_end
+                )
+
+    elif event_type == "invoice.payment_failed":
+        stripe_customer_id = data.get("customer")
+        stripe_subscription_id = data.get("subscription")
+        if stripe_subscription_id:
+            myprint(
+                f"Invoice payment FAILED for customer={stripe_customer_id}, "
+                f"subscription={stripe_subscription_id} — marking past_due"
+            )
+            # tier=None preserves existing tier; status → past_due
+            update_subscription_from_stripe(
+                stripe_customer_id, "past_due", None, stripe_subscription_id
+            )
+
+    else:
+        myprint(f"Stripe webhook event ignored: {event_type}")
+
+    return {"received": True}
 
 
 # Register the /api router

--- a/src/cqc_lem/app/aws_test_celery_task.py
+++ b/src/cqc_lem/app/aws_test_celery_task.py
@@ -1,6 +1,6 @@
 import time
 from cqc_lem.app.my_celery import app as shared_task
-from cqc_lem.utilities.db import get_user_password_pair_by_id, remove_linked_in_profile_by_email
+from cqc_lem.utilities.db import get_user_password_pair_by_id, remove_linked_in_profile_by_user_id
 from cqc_lem.utilities.linkedin.helper import get_my_profile
 from cqc_lem.utilities.selenium_util import get_driver_wait_pair, quit_gracefully
 
@@ -12,22 +12,22 @@ def test_task(seconds):
 
 
 @shared_task.task
-def test_get_my_profile(user_id:int):
+def test_get_my_profile(user_id: int):
     user_email, user_password = get_user_password_pair_by_id(user_id)
-    driver, wait = get_driver_wait_pair(headless=True,session_name="AWS Test Get My Profile")
+    driver, wait = get_driver_wait_pair(headless=True, session_name="AWS Test Get My Profile")
 
     try:
 
         # Remove old profiles
-        remove_linked_in_profile_by_email(user_email)
+        remove_linked_in_profile_by_user_id(user_id)
 
         # Keep track of current time for benchmark
         start_time = time.time()
-        get_my_profile(driver, wait, user_email, user_password)
+        get_my_profile(driver, wait, user_email, user_password, user_id=user_id)
         # Track time 1 after this function is done
         end_time = time.time()
         print(f"1st Time to get profile: {end_time - start_time}")
-        get_my_profile(driver, wait, user_email, user_password)
+        get_my_profile(driver, wait, user_email, user_password, user_id=user_id)
         # Track time 2 after this function is done
         end_time2 = time.time()
         print(f"2nd Time to get profile: {end_time2 - end_time}")

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -1,9 +1,10 @@
+import time as _time
 from datetime import datetime, timedelta
 
 from celery import Celery
 from celery import current_app
 from celery.schedules import crontab
-from celery.signals import worker_process_init, task_received, task_success, task_sent
+from celery.signals import worker_process_init, task_received, task_success, task_sent, task_prerun, task_postrun
 from celery.app.control import Inspect
 
 from cqc_lem.app import celeryconfig
@@ -11,6 +12,7 @@ from cqc_lem.app.celeryconfig import broker_url
 from cqc_lem.utilities.env_constants import CODE_TRACING, AWS_REGION
 from cqc_lem.utilities.jaeger_tracer_helper import get_jaeger_tracer
 from cqc_lem.utilities.logger import myprint, logger
+from cqc_lem.utilities.observability import track_task
 from cqc_lem.utilities.utils import get_cloudwatch_client
 
 # AWS deployment: uses SQS as broker (see celeryconfig.py CELERY_BROKER_URL)
@@ -91,7 +93,11 @@ app.conf.update(
         'send-appreciation-dms': {
             'task': 'cqc_lem.app.run_scheduler.auto_appreciate_dms',
             'schedule': crontab(hour='8', minute='0')  # Run every day at 8:00 AM
-        }
+        },
+        'sync-stripe-subscriptions': {
+            'task': 'cqc_lem.app.run_scheduler.sync_stripe_subscriptions',
+            'schedule': crontab(hour='6', minute='0')  # Daily at 6:00 AM — safety-net for missed webhooks
+        },
 
     }
 )
@@ -156,6 +162,25 @@ def get_queue_metric(name_space: str = 'cqc-lem/celery_queue/celery', metric_nam
     except Exception as e:
         logger.error(f"Failed to get metric: {str(e)}")
         return 0
+
+
+_task_start_times: dict = {}
+
+
+@task_prerun.connect(weak=False)
+def on_task_prerun(task_id: str = None, task=None, **kwargs) -> None:
+    _task_start_times[task_id] = _time.time()
+
+
+@task_postrun.connect(weak=False)
+def on_task_postrun(task_id: str = None, task=None, state: str = None, **kwargs) -> None:
+    start = _task_start_times.pop(task_id, _time.time())
+    track_task(
+        task_name=task.name,
+        duration_ms=int((_time.time() - start) * 1000),
+        success=(state == "SUCCESS"),
+        state=state or "UNKNOWN",
+    )
 
 
 @task_sent.connect

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -15,11 +15,11 @@ from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
     LogResultType, has_user_commented_on_post_url, get_post_url_from_log_for_user, get_post_message_from_log_for_user, \
-    has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, \
-    get_dm_history_for_profile, get_post_status, get_user_blog_url
+    has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, PostType, \
+    get_dm_history_for_profile, get_post_status, get_user_blog_url, get_post_type, get_carousel_slides
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url
-from cqc_lem.utilities.linkedin.poster import share_on_linkedin
+from cqc_lem.utilities.linkedin.poster import share_on_linkedin, share_carousel_on_linkedin
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.logger import myprint
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
@@ -1413,7 +1413,7 @@ def get_current_profile(user_id: int, session_name: str = "Get Current Profile")
     try:
 
         login_to_linkedin(driver, wait, user_email, user_password)
-        my_profile = get_my_profile(driver, wait, user_email, user_password)
+        my_profile = get_my_profile(driver, wait, user_email, user_password, user_id=user_id)
 
     except Exception as e:
         myprint(f"Error while getting updated profile: {e}")
@@ -1467,14 +1467,20 @@ def post_to_linkedin(self, user_id: int, post_id: int):
     content = get_post_content(post_id)
     myprint(f"Posting to LinkedIn: {content}")
 
-    # Get the post video url
-    video_url = get_post_video_url(post_id)
+    post_type = get_post_type(post_id)
+    myprint(f"Post type: {post_type}")
 
-    # Add the query param content_type to the url
-    if video_url:
-        myprint(f"Adding to Post | Video URL: {video_url}")
-
-    urn = share_on_linkedin(user_id, content, video_url)
+    if post_type == PostType.CAROUSEL:
+        slides = get_carousel_slides(post_id)
+        myprint(f"Carousel slides ({len(slides)}): {slides}")
+        urn = share_carousel_on_linkedin(user_id, content, slides)
+    elif post_type == PostType.VIDEO:
+        video_url = get_post_video_url(post_id)
+        if video_url:
+            myprint(f"Adding to Post | Video URL: {video_url}")
+        urn = share_on_linkedin(user_id, content, video_url)
+    else:
+        urn = share_on_linkedin(user_id, content)
 
     if urn:
         post_url = f"https://www.linkedin.com/feed/update/{urn}/"

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import random
 import sys
 import threading
@@ -9,11 +10,13 @@ from urllib.parse import urlparse
 
 from celery_once import QueueOnce
 from cqc_lem.app.my_celery import app as shared_task
-from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_refinement, summarize_recent_activity
+from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_refinement, summarize_recent_activity, \
+    ai_check_message_history
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
     LogResultType, has_user_commented_on_post_url, get_post_url_from_log_for_user, get_post_message_from_log_for_user, \
-    has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus
+    has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, \
+    get_dm_history_for_profile, get_post_status, get_user_blog_url
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url
 from cqc_lem.utilities.linkedin.poster import share_on_linkedin
@@ -721,6 +724,24 @@ def accept_connection_request(user_id: int):
     return invitation_data
 
 
+def get_recent_recommendations(driver, wait) -> dict[str, str]:
+    """Return {profile_url: name} for users who recently recommended the current user.
+
+    Scrapin the LinkedIn Recommendations Received section is not yet implemented;
+    returns an empty dict until a scraper is added here.
+    """
+    return {}
+
+
+def get_recent_collaborators(driver, wait) -> dict[str, str]:
+    """Return {profile_url: name} for recent collaborators to thank.
+
+    No structured LinkedIn data source exists for this yet; returns an empty dict
+    until a notification-scraper is added here.
+    """
+    return {}
+
+
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
                   reject_on_worker_lost=True,
                   rate_limit='2/m')
@@ -740,23 +761,32 @@ def automate_appreciation_dms_for_user(self, user_id: int, loop_for_duration: in
 
         # After Accepting a Connection Request:
         invitations_accepted = accept_connection_request(user_id)
-        # Send a private DM for each invitation
         for profile_url, name in invitations_accepted.items():
-            message = f"Hi {name}, I appreciate you connecting with me on LinkedIn. I look forward to learning more about you and your work."
+            first_name = name.split(" ")[0]
+            message = f"Hi {first_name}, I appreciate you connecting with me on LinkedIn. I look forward to learning more about you and your work."
             send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url, "message": message})
 
-        # TODO: After Receiving a Recommendation:
+        # After Receiving a Recommendation — thank the recommender
+        recommendations_received = get_recent_recommendations(driver, wait)
+        for profile_url, name in recommendations_received.items():
+            first_name = name.split(" ")[0]
+            message = (
+                f"Hi {first_name}, thank you so much for the kind recommendation on LinkedIn! "
+                "I really appreciate you taking the time to share your experience working with me. "
+                "I hope we have the opportunity to collaborate again in the future."
+            )
+            send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url, "message": message})
 
-        # TODO: After an Interview:
-
-        # TODO: For a Successful Collaboration:
-
-        # General Appreciation:
-        # "Hi [Name], I really appreciate your insights on [topic]. Your perspective helped me see things differently, and I'm grateful for the opportunity to learn from you."
-
-        # profile_url = '' # TODO: Update
-        # message = '' # TODO: Update
-        # TODO: Use this line #send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url, "message": message})
+        # After a Successful Collaboration — express gratitude and offer to connect further
+        recent_collaborators = get_recent_collaborators(driver, wait)
+        for profile_url, name in recent_collaborators.items():
+            first_name = name.split(" ")[0]
+            message = (
+                f"Hi {first_name}, it was a pleasure collaborating with you! "
+                "Your contributions made a real difference and I'm grateful for the opportunity. "
+                "Let's stay in touch — I'd love to explore future opportunities to work together."
+            )
+            send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url, "message": message})
 
         # Re-schedule the task in the queue for the future
         if loop_for_duration:
@@ -1071,30 +1101,36 @@ def engage_with_profile_viewer(self, user_id: int, viewer_url, viewer_name):
                     if not able_to_comment:
                         myprint("No activities, unable to or already left comment")
 
-                        # TODO: Send DM - offer something of value—whether it's insights, resources, or potential collaboration opportunities.
-                        # TODO: Generate something of value to offer
-
-                        # Get the first name from the view_name by splitting on space
                         first_name = viewer_name.split(" ")[0]
+                        profile_url_str = str(profile.profile_url)
+                        acting_user_id = get_user_id(my_profile.email)
 
-                        # TODO : Review/Retrieve previous messages with user first.
-                        message_history = []
+                        # Retrieve past DM history with this profile to avoid repeating messages
+                        past_dms = get_dm_history_for_profile(acting_user_id, profile_url_str)
+                        message_history_json = json.dumps(past_dms)
 
-                        # TODO: Check user profile to find what type of focus the message should have to then send.
-                        main_focus = "I'd like to connect with LinkedIn users to discuss my project and see if they would be interested in it."
+                        # Use user's blog URL to personalise the focus when available
+                        blog_url = get_user_blog_url(acting_user_id)
+                        if blog_url:
+                            main_focus = f"Offer insights from my blog at {blog_url} and invite the viewer to discuss topics relevant to their work."
+                        else:
+                            main_focus = "Offer something of value—insights, resources, or potential collaboration—to the viewer and start a genuine conversation."
 
-                        # TODO: Get initial message from user profile
-                        message = f"Hi {first_name}, I noticed we're connected on LinkedIn and wanted to reach out. I'm currently working on a project that I think you might find interesting. Would you be open to a quick chat to discuss it further?"
+                        message = (
+                            f"Hi {first_name}, I noticed you viewed my LinkedIn profile and wanted to reach out. "
+                            f"I share insights on {my_profile.headline or 'my professional field'} and thought there might be synergy between our work. "
+                            "Would love to connect more directly — feel free to share what you're working on!"
+                        )
 
-                        # If message was already sent do not send again
-                        message = ai_check_message_history(message_history, main_focus, message)
+                        # Skip if an equivalent message has already been sent to this person
+                        message = ai_check_message_history(message_history_json, main_focus, message, user_name=first_name)
 
 
                         if message:
 
                             # Send actual DM
-                            kwargs = {'user_id': get_user_id(my_profile.email),
-                                      'profile_url': str(profile.profile_url),
+                            kwargs = {'user_id': acting_user_id,
+                                      'profile_url': profile_url_str,
                                       'message': message}
                             send_private_dm.apply_async(kwargs=kwargs)
                             result = f"Profile Viewer Engagement Completed. Sent DM to {viewer_name}"
@@ -1415,11 +1451,13 @@ if __name__ == "__main__":
 def post_to_linkedin(self, user_id: int, post_id: int):
     """Posts to LinkedIn using the LinkedIn API - https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/share-on-linkedin#creating-a-share-on-linkedin"""
 
-    # TODO: If this is still running 4 times then add de-duplication logic
     task_id = f"{self.request.id}-{user_id}-{post_id}"
     myprint(f"Post To LinkedIn | Task ID: {task_id}")
-    # Mark the task as executed
-    # TaskExecution.objects.create(task_id=task_id)
+
+    # Skip if already posted — prevents duplicate posts when the task is re-queued
+    if get_post_status(post_id) == PostStatus.POSTED.value:
+        myprint(f"Post {post_id} already posted. Skipping duplicate execution.")
+        return f"Post {post_id} already posted — skipped"
 
     # Login and publish post to LinkedIn
     user_email, user_password = get_user_password_pair_by_id(user_id)

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -19,7 +19,7 @@ from cqc_lem.utilities.ai.ai_helper import get_thought_leadership_post_from_ai, 
 from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, update_db_post_content, \
     get_planned_posts_for_current_week, get_last_planned_post_date_for_user, get_user_password_pair_by_id, \
     get_user_blog_url, get_user_sitemap_url, get_active_user_ids, get_planned_posts_for_next_week, PostStatus, \
-    update_db_post_video_url, update_db_post_status, PostType
+    update_db_post_video_url, update_db_post_status, PostType, get_user_preferences
 from cqc_lem.utilities.env_constants import API_URL_FINAL
 from cqc_lem.utilities.linkedin.helper import get_my_profile
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
@@ -193,6 +193,7 @@ def create_content(user_id: int, post_type: str, stage: str):
     """Create content based on the specified post type and buyer journey stage."""
 
     video_url = None
+    content = None
 
     if post_type == "video":
         content, video_url = create_video_content(user_id, stage)
@@ -200,8 +201,8 @@ def create_content(user_id: int, post_type: str, stage: str):
         content = f"Content created for {post_type} in the {stage} stage. However, this is unfinished"
     else:
         content = create_text_post(user_id, stage)
-        # Strip leading and ending white spaces
-        content = content.strip()
+        if content:
+            content = content.strip()
 
     return content, video_url
 
@@ -265,7 +266,7 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
         user_email, user_password = get_user_password_pair_by_id(user_id)
         driver, wait = get_driver_wait_pair(session_name='Create Text Post')
         try:
-            user_profile = get_my_profile(driver, wait, user_email, user_password)
+            user_profile = get_my_profile(driver, wait, user_email, user_password, user_id=user_id)
         except Exception as e:
             myprint(f"Error getting user profile: {e}")
             # Create empty dummy user profile
@@ -689,6 +690,10 @@ def auto_create_weekly_content(user_id: int = None):
     else:
         planned_posts = get_planned_posts_for_current_week(user_id)
 
+    if not planned_posts:
+        myprint("No planned posts found for this period. Skipping content creation.")
+        return
+
     for post in planned_posts:
         user_id = post['user_id']
         post_id = post['id']
@@ -697,6 +702,10 @@ def auto_create_weekly_content(user_id: int = None):
 
         # For each content create it
         content, video_url = create_content(user_id, post_type, stage)
+
+        if content is None:
+            myprint(f"Skipping post_id {post_id}: content generation returned None")
+            continue
 
         # Copy the video from url to our assets/video folder and store it to the database for later retrieval via api call
         if video_url:
@@ -719,10 +728,13 @@ def auto_create_weekly_content(user_id: int = None):
         myprint(f"Updating content for post_id: {post_id}")
         update_db_post_content(post_id, content)
 
-        # Update the status of the post in the db to pending
-        myprint(f"Updating post_id: {post_id} Status={PostStatus.PENDING}")
-
-        update_db_post_status(post_id, PostStatus.PENDING)
+        # Respect the user's auto_schedule_posts preference:
+        # True → APPROVED (Celery will pick it up); False → PENDING (manual review required)
+        prefs = get_user_preferences(user_id)
+        auto_schedule = bool(prefs.get("auto_schedule_posts")) if prefs else False
+        new_status = PostStatus.APPROVED if auto_schedule else PostStatus.PENDING
+        myprint(f"Updating post_id: {post_id} Status={new_status}")
+        update_db_post_status(post_id, new_status)
 
 
 def is_blog_post(url):

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -10,7 +10,10 @@ from cqc_lem.app.run_automation import automate_commenting, automate_profile_vie
     automate_appreciation_dms_for_user, clean_stale_invites, update_stale_profile, post_to_linkedin, \
     automate_invites_to_company_page_for_user
 from cqc_lem.utilities.date import convert_datetime_to_local_tz
-from cqc_lem.utilities.db import get_ready_to_post_posts, update_db_post_status, get_active_user_ids, PostStatus
+from cqc_lem.utilities.db import (
+    get_ready_to_post_posts, update_db_post_status, get_active_user_ids, PostStatus,
+    get_users_with_stripe_subscriptions, update_subscription_from_stripe,
+)
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES
 from cqc_lem.utilities.logger import myprint
 
@@ -225,6 +228,53 @@ def organize_videos_by_name_and_timestamp():
             moved_videos += 1
 
     return moved_videos
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True})
+def sync_stripe_subscriptions(self):
+    """Daily safety-net: fetch every active/past_due subscription from Stripe and
+    reconcile against our DB. Catches any webhook events that were missed due to
+    downtime, URL mismatches, or signature errors.
+    """
+    from cqc_lem.utilities.stripe_util import (
+        fetch_subscription, get_subscription_tier_from_price, stripe_status_to_db,
+    )
+
+    rows = get_users_with_stripe_subscriptions()
+    myprint(f"Stripe subscription sync: checking {len(rows)} subscriber(s)")
+
+    for row in rows:
+        sub_id = row.get("stripe_subscription_id")
+        customer_id = row.get("stripe_customer_id")
+        if not sub_id:
+            continue
+
+        sub = fetch_subscription(sub_id)
+        if not sub:
+            myprint(f"  Could not fetch subscription {sub_id} — skipping")
+            continue
+
+        stripe_status = sub.get("status", "")
+        db_status = stripe_status_to_db(stripe_status)
+
+        price_id = None
+        items = sub.get("items", {}).get("data", [])
+        if items:
+            price_id = items[0].get("price", {}).get("id")
+        tier = get_subscription_tier_from_price(price_id) if price_id else None
+
+        period_end_ts = sub.get("current_period_end")
+        period_end = datetime.fromtimestamp(period_end_ts) if period_end_ts else None
+
+        current_db_status = row.get("subscription_status")
+        if current_db_status != db_status or (tier and tier != row.get("subscription_tier")):
+            myprint(
+                f"  Syncing user {row['id']}: DB={current_db_status}/{row.get('subscription_tier')} "
+                f"→ Stripe={db_status}/{tier}"
+            )
+            update_subscription_from_stripe(customer_id, db_status, tier, sub_id, period_end)
+        else:
+            myprint(f"  User {row['id']} subscription up-to-date ({db_status}/{tier})")
 
 
 if __name__ == "__main__":

--- a/src/cqc_lem/ui/src/App.tsx
+++ b/src/cqc_lem/ui/src/App.tsx
@@ -1,6 +1,9 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { AuthProvider, useAuth } from './contexts/AuthContext'
 import Layout from './components/Layout'
+import ProtectedRoute from './components/ProtectedRoute'
+import LoginModal from './components/LoginModal'
 import Dashboard from './pages/Dashboard'
 import Account from './pages/Account'
 import ScheduleContent from './pages/ScheduleContent'
@@ -9,23 +12,40 @@ import Landing from './pages/Landing'
 
 const queryClient = new QueryClient()
 
-function GuestOrDashboard() {
-  const email = localStorage.getItem('lem_email')
-  return email ? <Dashboard /> : <Landing />
+function AppRoutes() {
+  const { user, isLoginModalOpen } = useAuth()
+
+  return (
+    <>
+      {isLoginModalOpen && <LoginModal />}
+      <Routes>
+        <Route path="/" element={<Layout />}>
+          <Route index element={user ? <Dashboard /> : <Landing />} />
+          <Route
+            path="account"
+            element={<ProtectedRoute><Account /></ProtectedRoute>}
+          />
+          <Route
+            path="schedule"
+            element={<ProtectedRoute><ScheduleContent /></ProtectedRoute>}
+          />
+          <Route
+            path="review"
+            element={<ProtectedRoute><ReviewSchedule /></ProtectedRoute>}
+          />
+        </Route>
+      </Routes>
+    </>
+  )
 }
 
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Layout />}>
-            <Route index element={<GuestOrDashboard />} />
-            <Route path="account" element={<Account />} />
-            <Route path="schedule" element={<ScheduleContent />} />
-            <Route path="review" element={<ReviewSchedule />} />
-          </Route>
-        </Routes>
+        <AuthProvider>
+          <AppRoutes />
+        </AuthProvider>
       </BrowserRouter>
     </QueryClientProvider>
   )

--- a/src/cqc_lem/ui/src/api/client.ts
+++ b/src/cqc_lem/ui/src/api/client.ts
@@ -5,4 +5,24 @@ const api = axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('lem_session')
+  if (token) {
+    config.headers['X-Session-Token'] = token
+  }
+  return config
+})
+
+api.interceptors.response.use(
+  (r) => r,
+  (error) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('lem_session')
+      localStorage.removeItem('lem_email')
+      window.location.href = '/'
+    }
+    return Promise.reject(error)
+  }
+)
+
 export default api

--- a/src/cqc_lem/ui/src/components/Layout.tsx
+++ b/src/cqc_lem/ui/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import { NavLink, Outlet, useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
 
 const navLinks = [
   { to: '/', label: 'Home', end: true },
@@ -8,12 +9,12 @@ const navLinks = [
 ]
 
 export default function Layout() {
-  const email = localStorage.getItem('lem_email') || ''
+  const { user, logout, openLoginModal } = useAuth()
   const navigate = useNavigate()
 
-  function handleLogout() {
-    localStorage.removeItem('lem_email')
-    window.location.reload()
+  async function handleLogout() {
+    await logout()
+    navigate('/')
   }
 
   return (
@@ -21,7 +22,7 @@ export default function Layout() {
       <nav className="bg-white border-b border-gray-200 sticky top-0 z-10">
         <div className="max-w-5xl mx-auto px-4 flex items-center gap-6 h-14">
           <span className="font-bold text-blue-600 text-lg">LEM</span>
-          {navLinks.map(({ to, label, end }) => (
+          {user && navLinks.map(({ to, label, end }) => (
             <NavLink
               key={to}
               to={to}
@@ -38,10 +39,10 @@ export default function Layout() {
             </NavLink>
           ))}
           <div className="ml-auto flex items-center gap-3">
-            {email && (
+            {user ? (
               <>
                 <span className="text-xs text-gray-500 hidden sm:inline">
-                  Logged in as: <span className="font-medium text-gray-700">{email}</span>
+                  Logged in as: <span className="font-medium text-gray-700">{user.email}</span>
                 </span>
                 <button
                   onClick={handleLogout}
@@ -50,13 +51,12 @@ export default function Layout() {
                   Log out
                 </button>
               </>
-            )}
-            {!email && (
+            ) : (
               <button
-                onClick={() => navigate('/account')}
+                onClick={openLoginModal}
                 className="text-xs text-blue-600 hover:text-blue-800 font-medium border border-blue-200 hover:border-blue-400 px-2.5 py-1 rounded transition-colors"
               >
-                Set up account
+                Login / Sign Up
               </button>
             )}
           </div>

--- a/src/cqc_lem/ui/src/components/LoginModal.tsx
+++ b/src/cqc_lem/ui/src/components/LoginModal.tsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+import api from '../api/client'
+
+type Step = 'email' | 'pin'
+
+export default function LoginModal() {
+  const { closeLoginModal, login } = useAuth()
+  const [step, setStep] = useState<Step>('email')
+  const [email, setEmail] = useState('')
+  const [pin, setPin] = useState('')
+  const [isNewUser, setIsNewUser] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleEmailSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      const r = await api.post('/auth/email/init', { email: email.trim().toLowerCase() })
+      const detail = r.data.detail
+
+      if (detail.bypass) {
+        // No email provider — session already created server-side, log in immediately
+        login(detail.session_token, detail.email)
+        return
+      }
+
+      setIsNewUser(detail.user_exists === false)
+      setStep('pin')
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+      setError(msg ?? 'Failed to send code. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handlePinSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      const r = await api.post('/auth/email/verify', { email, pin })
+      const { session_token, email: verifiedEmail } = r.data.detail
+      login(session_token, verifiedEmail)
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+      setError(msg ?? 'Invalid or expired code. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4"
+      onClick={(e) => { if (e.target === e.currentTarget) closeLoginModal() }}
+    >
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-md p-8 relative">
+        <button
+          onClick={closeLoginModal}
+          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600 text-2xl leading-none"
+          aria-label="Close"
+        >
+          ×
+        </button>
+
+        {step === 'email' && (
+          <>
+            <h2 className="text-xl font-bold text-gray-800 mb-1">Sign in / Sign up</h2>
+            <p className="text-sm text-gray-500 mb-6">
+              Enter your email and we'll send you a 6-digit code to continue.
+            </p>
+            <form onSubmit={handleEmailSubmit} className="space-y-4">
+              <input
+                type="email"
+                required
+                autoFocus
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="your@email.com"
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              {error && <p className="text-xs text-red-600">{error}</p>}
+              <button
+                type="submit"
+                disabled={loading || !email.trim()}
+                className="w-full bg-blue-600 text-white py-2.5 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              >
+                {loading ? 'Sending code…' : 'Continue'}
+              </button>
+            </form>
+          </>
+        )}
+
+        {step === 'pin' && (
+          <>
+            <h2 className="text-xl font-bold text-gray-800 mb-1">
+              {isNewUser ? 'Verify your email' : 'Enter your code'}
+            </h2>
+            <p className="text-sm text-gray-500 mb-6">
+              We sent a 6-digit code to <strong>{email}</strong>.
+              {isNewUser && ' Confirming will create your account.'}
+            </p>
+            <form onSubmit={handlePinSubmit} className="space-y-4">
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]{6}"
+                maxLength={6}
+                required
+                autoFocus
+                value={pin}
+                onChange={(e) => setPin(e.target.value.replace(/\D/g, ''))}
+                placeholder="123456"
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm text-center tracking-widest font-mono text-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              {error && <p className="text-xs text-red-600">{error}</p>}
+              <button
+                type="submit"
+                disabled={loading || pin.length !== 6}
+                className="w-full bg-blue-600 text-white py-2.5 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              >
+                {loading ? 'Verifying…' : isNewUser ? 'Create Account' : 'Sign In'}
+              </button>
+              <button
+                type="button"
+                onClick={() => { setStep('email'); setPin(''); setError(null) }}
+                className="w-full text-xs text-gray-500 hover:text-gray-700"
+              >
+                ← Use a different email
+              </button>
+            </form>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/components/ProtectedRoute.tsx
+++ b/src/cqc_lem/ui/src/components/ProtectedRoute.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+export default function ProtectedRoute({ children }: { children: React.ReactNode }) {
+  const { user, isLoading, openLoginModal } = useAuth()
+
+  useEffect(() => {
+    if (!isLoading && !user) {
+      openLoginModal()
+    }
+  }, [isLoading, user, openLoginModal])
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-40 text-gray-400">
+        Loading…
+      </div>
+    )
+  }
+
+  if (!user) {
+    return <Navigate to="/" replace />
+  }
+
+  return <>{children}</>
+}

--- a/src/cqc_lem/ui/src/contexts/AuthContext.tsx
+++ b/src/cqc_lem/ui/src/contexts/AuthContext.tsx
@@ -1,0 +1,95 @@
+import { createContext, useContext, useState, useEffect } from 'react'
+import type { ReactNode } from 'react'
+import api from '../api/client'
+
+interface AuthUser {
+  email: string
+  userId?: number
+}
+
+interface AuthContextValue {
+  user: AuthUser | null
+  sessionToken: string | null
+  isLoading: boolean
+  login: (token: string, email: string) => void
+  logout: () => Promise<void>
+  openLoginModal: () => void
+  closeLoginModal: () => void
+  isLoginModalOpen: boolean
+}
+
+const AuthContext = createContext<AuthContextValue | null>(null)
+
+const SESSION_KEY = 'lem_session'
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<AuthUser | null>(null)
+  const [sessionToken, setSessionToken] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
+
+  useEffect(() => {
+    const storedToken = localStorage.getItem(SESSION_KEY)
+    if (!storedToken) {
+      setIsLoading(false)
+      return
+    }
+    api
+      .get(`/auth/session?session_token=${encodeURIComponent(storedToken)}`)
+      .then((r) => {
+        const { email, user_id } = r.data.detail
+        setSessionToken(storedToken)
+        setUser({ email, userId: user_id })
+      })
+      .catch(() => {
+        localStorage.removeItem(SESSION_KEY)
+        localStorage.removeItem('lem_email')
+      })
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  function login(token: string, email: string) {
+    localStorage.setItem(SESSION_KEY, token)
+    localStorage.setItem('lem_email', email)
+    setSessionToken(token)
+    setUser({ email })
+    setIsLoginModalOpen(false)
+  }
+
+  async function logout() {
+    const token = sessionToken
+    if (token) {
+      await api.post('/auth/logout', { session_token: token }).catch(() => {})
+    }
+    localStorage.removeItem(SESSION_KEY)
+    localStorage.removeItem('lem_email')
+    localStorage.removeItem('lem_li_connected')
+    localStorage.removeItem('lem_blog_url')
+    localStorage.removeItem('lem_sitemap_url')
+    setSessionToken(null)
+    setUser(null)
+  }
+
+  return (
+    <AuthContext.Provider
+      value={{
+        user,
+        sessionToken,
+        isLoading,
+        login,
+        logout,
+        openLoginModal: () => setIsLoginModalOpen(true),
+        closeLoginModal: () => setIsLoginModalOpen(false),
+        isLoginModalOpen,
+      }}
+    >
+      {children}
+    </AuthContext.Provider>
+  )
+}
+
+export function useAuth() {
+  const ctx = useContext(AuthContext)
+  if (!ctx) throw new Error('useAuth must be used within AuthProvider')
+  return ctx
+}

--- a/src/cqc_lem/ui/src/pages/Account.tsx
+++ b/src/cqc_lem/ui/src/pages/Account.tsx
@@ -1,9 +1,33 @@
 import { useState, useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { useMutation, useQuery } from '@tanstack/react-query'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import api from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
 
 const LI_AUTH_URL = '/api/auth/linkedin/'
+
+const TIER_LABELS: Record<string, string> = {
+  free_trial: 'Free Trial',
+  starter: 'Starter',
+  professional: 'Professional',
+  enterprise: 'Enterprise',
+}
+
+const TIER_COLORS: Record<string, string> = {
+  free_trial: 'bg-gray-100 text-gray-700',
+  starter: 'bg-blue-100 text-blue-800',
+  professional: 'bg-purple-100 text-purple-800',
+  enterprise: 'bg-yellow-100 text-yellow-800',
+}
+
+const INACTIVATE_OPTIONS = [
+  { label: '30 days', value: 30 },
+  { label: '60 days', value: 60 },
+  { label: '90 days (default)', value: 90 },
+  { label: '120 days', value: 120 },
+  { label: '365 days', value: 365 },
+  { label: 'Never', value: null },
+]
 
 function StepBadge({ n, active, done }: { n: number; active: boolean; done: boolean }) {
   return (
@@ -21,209 +45,506 @@ function StepBadge({ n, active, done }: { n: number; active: boolean; done: bool
   )
 }
 
+function daysUntil(iso: string | null | undefined): number | null {
+  if (!iso) return null
+  const diff = new Date(iso).getTime() - Date.now()
+  return Math.max(0, Math.floor(diff / (1000 * 60 * 60 * 24)))
+}
+
 export default function Account() {
+  const { user, sessionToken } = useAuth()
+  const email = user?.email ?? ''
+  const queryClient = useQueryClient()
+
   const [searchParams, setSearchParams] = useSearchParams()
-  const [email, setEmail] = useState(localStorage.getItem('lem_email') || '')
   const [blogUrl, setBlogUrl] = useState(localStorage.getItem('lem_blog_url') || '')
   const [sitemapUrl, setSitemapUrl] = useState(localStorage.getItem('lem_sitemap_url') || '')
+  const [liConnectedLocal, setLiConnectedLocal] = useState(
+    localStorage.getItem('lem_li_connected') === '1'
+  )
   const [savedMsg, setSavedMsg] = useState<string | null>(null)
+  const [prefsSavedMsg, setPrefsSavedMsg] = useState<string | null>(null)
+  const [checkoutMsg, setCheckoutMsg] = useState<{ ok: boolean; text: string } | null>(null)
 
-  // Persist OAuth callback params to localStorage and clear from URL
+  // Preferences local state — initialised from query once loaded
+  const [inactivateDelay, setInactivateDelay] = useState<number | null>(90)
+  const [autoSchedule, setAutoSchedule] = useState(false)
+  const [prefsInitialised, setPrefsInitialised] = useState(false)
+
+  // Handle LinkedIn OAuth callback: ?li_connected=1 or ?li_error=... in URL
   useEffect(() => {
-    const oauthEmail = searchParams.get('email')
     const liConnected = searchParams.get('li_connected')
-    if (oauthEmail) {
-      localStorage.setItem('lem_email', oauthEmail)
-      setEmail(oauthEmail)
-    }
+    const liError = searchParams.get('li_error')
     if (liConnected === '1') {
       localStorage.setItem('lem_li_connected', '1')
-    }
-    if (oauthEmail || liConnected) {
+      setLiConnectedLocal(true)
+      // Force refetch so the fresh token is reflected immediately
+      queryClient.invalidateQueries({ queryKey: ['token-status'] })
       setSearchParams({}, { replace: true })
-      setSavedMsg('LinkedIn connected! Your account has been set up.')
+      setSavedMsg('LinkedIn connected successfully!')
       setTimeout(() => setSavedMsg(null), 5000)
+    } else if (liError) {
+      setSavedMsg('LinkedIn connection failed — please try again.')
+      setSearchParams({}, { replace: true })
+      setTimeout(() => setSavedMsg(null), 8000)
     }
     setBlogUrl(localStorage.getItem('lem_blog_url') || '')
     setSitemapUrl(localStorage.getItem('lem_sitemap_url') || '')
   }, [])
 
-  const { data: userIdData, refetch: refetchUser } = useQuery<{ detail: number }>({
-    queryKey: ['user-id', email],
-    queryFn: () => api.get(`/user_id/?email=${encodeURIComponent(email)}`).then((r) => r.data),
-    enabled: !!email,
-    retry: false,
+  // LinkedIn token status
+  const { data: tokenStatusData } = useQuery({
+    queryKey: ['token-status', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/token_status?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as {
+          token_expiry_date: string | null
+          is_expiring_soon: boolean
+          is_expired: boolean
+          refresh_attempted: boolean
+          refresh_succeeded: boolean
+        }),
+    enabled: !!sessionToken,
+    staleTime: 5 * 60 * 1000,
   })
 
-  const userExists = !!userIdData?.detail
+  // Subscription + preferences
+  const { data: settingsData } = useQuery({
+    queryKey: ['user-settings', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/settings?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as {
+          subscription: {
+            status: string | null
+            tier: string | null
+            trial_started_at: string | null
+            trial_ends_at: string | null
+            stripe_customer_id: string | null
+          } | null
+          preferences: {
+            last_login_inactivate_delay: number | null
+            auto_schedule_posts: boolean
+          } | null
+        }),
+    enabled: !!sessionToken,
+    staleTime: 60 * 1000,
+  })
 
+  useEffect(() => {
+    if (settingsData?.preferences && !prefsInitialised) {
+      setInactivateDelay(settingsData.preferences.last_login_inactivate_delay)
+      setAutoSchedule(settingsData.preferences.auto_schedule_posts)
+      setPrefsInitialised(true)
+    }
+  }, [settingsData, prefsInitialised])
+
+  const subscription = settingsData?.subscription
+  const tier = subscription?.tier ?? 'free_trial'
+  const trialDays = daysUntil(subscription?.trial_ends_at)
+  const isOnTrial = subscription?.status === 'trial'
+  const isPaidPlan = subscription?.status === 'active'
+  const hasStripeCustomer = !!subscription?.stripe_customer_id
+
+  const hasValidToken = tokenStatusData ? !tokenStatusData.is_expired : false
+  const isLinkedInConnected = liConnectedLocal || hasValidToken
+  const tokenExpiringSoon = tokenStatusData?.is_expiring_soon ?? false
+  const tokenExpired = tokenStatusData?.is_expired ?? false
+
+  const step1Done = true
+  const step2Done = isLinkedInConnected
+  const step3Done = !!(blogUrl || sitemapUrl)
+  const allStepsDone = step1Done && step2Done
+
+  const showLinkedInSection = !isLinkedInConnected || tokenExpiringSoon || tokenExpired
+
+  // Profile save
   const saveMutation = useMutation({
     mutationFn: () =>
       api.put('/user/', { email, blog_url: blogUrl || null, sitemap_url: sitemapUrl || null }),
     onSuccess: () => {
-      localStorage.setItem('lem_email', email)
       localStorage.setItem('lem_blog_url', blogUrl)
       localStorage.setItem('lem_sitemap_url', sitemapUrl)
       setSavedMsg('Settings saved!')
-      refetchUser()
       setTimeout(() => setSavedMsg(null), 3000)
     },
     onError: () => {
-      setSavedMsg('Save failed — ensure your email matches an existing account.')
+      setSavedMsg('Save failed — please try again.')
       setTimeout(() => setSavedMsg(null), 5000)
     },
   })
 
+  // Preferences save
+  const prefsMutation = useMutation({
+    mutationFn: () =>
+      api.put('/user/settings', {
+        session_token: sessionToken,
+        last_login_inactivate_delay: inactivateDelay,
+        auto_schedule_posts: autoSchedule,
+      }),
+    onSuccess: () => {
+      setPrefsSavedMsg('Preferences saved!')
+      setTimeout(() => setPrefsSavedMsg(null), 3000)
+    },
+    onError: () => {
+      setPrefsSavedMsg('Save failed — please try again.')
+      setTimeout(() => setPrefsSavedMsg(null), 5000)
+    },
+  })
+
+  // Stripe checkout redirect
+  const checkoutMutation = useMutation({
+    mutationFn: (tier: string) =>
+      api
+        .post('/billing/create-checkout-session', {
+          session_token: sessionToken,
+          tier,
+          success_url: `${window.location.origin}/account?upgraded=1`,
+          cancel_url: `${window.location.origin}/account`,
+        })
+        .then((r) => r.data.detail.checkout_url as string),
+    onSuccess: (url) => { window.location.href = url },
+    onError: () => {
+      setCheckoutMsg({ ok: false, text: 'Could not start checkout — please try again.' })
+      setTimeout(() => setCheckoutMsg(null), 6000)
+    },
+  })
+
+  // Stripe portal redirect
+  const portalMutation = useMutation({
+    mutationFn: () =>
+      api
+        .post('/billing/create-portal-session', {
+          session_token: sessionToken,
+          return_url: `${window.location.origin}/account`,
+        })
+        .then((r) => r.data.detail.portal_url as string),
+    onSuccess: (url) => { window.location.href = url },
+    onError: () => setSavedMsg('Could not open billing portal — please try again.'),
+  })
+
   function handleSave(e: React.FormEvent) {
     e.preventDefault()
-    localStorage.setItem('lem_email', email)
-    if (userExists) {
-      saveMutation.mutate()
-    } else {
-      localStorage.setItem('lem_blog_url', blogUrl)
-      localStorage.setItem('lem_sitemap_url', sitemapUrl)
-      setSavedMsg('Email saved locally. Connect LinkedIn below to create your account.')
-      setTimeout(() => setSavedMsg(null), 4000)
-    }
+    saveMutation.mutate()
   }
 
-  const isLinkedInConnected = !!localStorage.getItem('lem_li_connected') || userExists
-
-  const step1Done = !!email
-  const step2Done = isLinkedInConnected
-  const step3Done = !!(blogUrl || sitemapUrl)
+  function handlePrefsSave(e: React.FormEvent) {
+    e.preventDefault()
+    prefsMutation.mutate()
+  }
 
   return (
     <div className="max-w-2xl space-y-6">
       <h1 className="text-2xl font-bold text-gray-800">Account Settings</h1>
 
-      {/* Setup steps */}
-      <div className="bg-blue-50 rounded-lg border border-blue-100 p-4">
-        <p className="text-sm font-semibold text-blue-800 mb-3">Setup Steps</p>
-        <div className="space-y-3">
-          {[
-            { n: 1, label: 'Enter your email and save', done: step1Done },
-            { n: 2, label: 'Connect your LinkedIn account', done: step2Done },
-            { n: 3, label: '(Optional) Add your blog / sitemap for AI content ideas', done: step3Done },
-          ].map(({ n, label, done }) => {
-            const active =
-              n === 1 ? !step1Done : n === 2 ? step1Done && !step2Done : step2Done && !step3Done
-            return (
-              <div key={n} className="flex items-center gap-3">
-                <StepBadge n={n} active={active || n === 1} done={done} />
-                <span className={`text-sm ${done ? 'line-through text-gray-400' : 'text-gray-700'}`}>
-                  {label}
-                </span>
-              </div>
-            )
-          })}
+      {/* Setup steps — hidden once all required steps are done */}
+      {!allStepsDone && (
+        <div className="bg-blue-50 rounded-lg border border-blue-100 p-4">
+          <p className="text-sm font-semibold text-blue-800 mb-3">Setup Steps</p>
+          <div className="space-y-3">
+            {[
+              { n: 1, label: 'Sign in with your email (done)', done: step1Done },
+              { n: 2, label: 'Connect your LinkedIn account', done: step2Done },
+              { n: 3, label: '(Optional) Add your blog / sitemap for AI content ideas', done: step3Done },
+            ].map(({ n, label, done }) => {
+              const active =
+                n === 1 ? !step1Done : n === 2 ? step1Done && !step2Done : step2Done && !step3Done
+              return (
+                <div key={n} className="flex items-center gap-3">
+                  <StepBadge n={n} active={active || n === 1} done={done} />
+                  <span className={`text-sm ${done ? 'line-through text-gray-400' : 'text-gray-700'}`}>
+                    {label}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
         </div>
+      )}
+
+      {/* Subscription card */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold text-gray-700">Subscription</h2>
+          <span className={`text-xs font-semibold px-2.5 py-1 rounded-full ${TIER_COLORS[tier] ?? TIER_COLORS.free_trial}`}>
+            {TIER_LABELS[tier] ?? tier}
+          </span>
+        </div>
+
+        {isOnTrial && trialDays !== null && (
+          <div className={`rounded-lg p-3 text-sm ${trialDays <= 3 ? 'bg-red-50 text-red-800 border border-red-200' : 'bg-yellow-50 text-yellow-800 border border-yellow-200'}`}>
+            {trialDays === 0
+              ? 'Your free trial has expired. Upgrade to keep using LEM.'
+              : `Free trial: ${trialDays} day${trialDays === 1 ? '' : 's'} remaining.`}
+          </div>
+        )}
+
+        {isPaidPlan && (
+          <p className="text-sm text-green-700">Your subscription is active.</p>
+        )}
+
+        {/* Upgrade options — shown to trial users without a paid plan */}
+        {!isPaidPlan && hasStripeCustomer && (
+          <div className="space-y-2">
+            <p className="text-xs text-gray-500 font-medium uppercase tracking-wide">Upgrade your plan</p>
+            <div className="grid grid-cols-3 gap-2">
+              {[
+                { tier: 'starter', label: 'Starter', price: '$29/mo' },
+                { tier: 'professional', label: 'Professional', price: '$79/mo' },
+                { tier: 'enterprise', label: 'Enterprise', price: '$199/mo' },
+              ].map(({ tier: t, label, price }) => (
+                <button
+                  key={t}
+                  onClick={() => checkoutMutation.mutate(t)}
+                  disabled={checkoutMutation.isPending}
+                  className="flex flex-col items-center border border-blue-200 rounded-lg p-3 hover:bg-blue-50 transition-colors disabled:opacity-50 text-center"
+                >
+                  <span className="text-sm font-semibold text-blue-800">{label}</span>
+                  <span className="text-xs text-gray-500">{price}</span>
+                </button>
+              ))}
+            </div>
+            {checkoutMutation.isPending && (
+              <p className="text-xs text-blue-600">Redirecting to checkout…</p>
+            )}
+            {checkoutMsg && (
+              <p className={`text-sm font-medium ${checkoutMsg.ok ? 'text-green-600' : 'text-red-600'}`}>
+                {checkoutMsg.text}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Billing portal — shown to paid subscribers */}
+        {isPaidPlan && hasStripeCustomer && (
+          <button
+            onClick={() => portalMutation.mutate()}
+            disabled={portalMutation.isPending}
+            className="text-sm text-blue-600 hover:underline disabled:opacity-50"
+          >
+            Manage billing →
+          </button>
+        )}
+
+        {!hasStripeCustomer && (
+          <p className="text-xs text-gray-400">
+            Billing not yet configured for your account. Contact support if you need help.
+          </p>
+        )}
       </div>
 
-      {/* Profile form */}
-      <form onSubmit={handleSave} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
-        <h2 className="text-base font-semibold text-gray-700">Profile</h2>
+      {/* LinkedIn connection — hidden when connected and token healthy */}
+      {showLinkedInSection && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+          <h2 className="text-base font-semibold text-gray-700">LinkedIn Connection</h2>
+
+          {isLinkedInConnected && tokenExpiringSoon && !tokenExpired && (
+            <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 text-sm text-yellow-800">
+              Your LinkedIn token is expiring soon. Please reconnect to keep posting.
+              {tokenStatusData?.refresh_attempted && !tokenStatusData?.refresh_succeeded && (
+                <span className="ml-1 text-xs">(Auto-refresh failed — manual reconnect required.)</span>
+              )}
+            </div>
+          )}
+
+          {tokenExpired && isLinkedInConnected && (
+            <div className="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-800">
+              Your LinkedIn connection has expired. Please reconnect to continue posting.
+            </div>
+          )}
+
+          <div className="flex items-center gap-3">
+            <div
+              className={`w-3 h-3 rounded-full flex-shrink-0 ${
+                isLinkedInConnected && !tokenExpired ? 'bg-green-500' : 'bg-gray-300'
+              }`}
+            />
+            <span className="text-sm text-gray-600">
+              {isLinkedInConnected && !tokenExpired ? 'Connected to LinkedIn' : 'Not connected'}
+            </span>
+          </div>
+
+          <p className="text-xs text-gray-500">
+            Connecting allows LEM to post on your behalf, send DMs, reply to comments, and engage with your network automatically.
+          </p>
+
+          <a
+            href={`${LI_AUTH_URL}?email=${encodeURIComponent(email)}&session_token=${encodeURIComponent(sessionToken ?? '')}`}
+            className="inline-block w-full text-center py-2 rounded-lg text-sm font-semibold bg-blue-700 text-white hover:bg-blue-800 cursor-pointer transition-colors"
+          >
+            {isLinkedInConnected ? 'Reconnect LinkedIn' : 'Connect LinkedIn'}
+          </a>
+        </div>
+      )}
+
+      {/* Blog/sitemap inputs — shown during setup, before all steps complete */}
+      {!allStepsDone && (
+        <form onSubmit={handleSave} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+          <h2 className="text-base font-semibold text-gray-700">Optional Setup</h2>
+          <p className="text-sm text-gray-500">
+            Signed in as <span className="font-medium text-gray-800">{email}</span>
+          </p>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Blog URL</label>
+            <input
+              type="url"
+              value={blogUrl}
+              onChange={(e) => setBlogUrl(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="https://yourblog.com"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Sitemap URL</label>
+            <input
+              type="url"
+              value={sitemapUrl}
+              onChange={(e) => setSitemapUrl(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="https://yourblog.com/sitemap.xml"
+            />
+            <p className="text-xs text-gray-400 mt-1">Used by AI to generate content ideas from your existing posts.</p>
+          </div>
+
+          {savedMsg && (
+            <p className={`text-sm font-medium ${saveMutation.isError ? 'text-red-600' : 'text-green-600'}`}>
+              {savedMsg}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={saveMutation.isPending}
+            className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {saveMutation.isPending ? 'Saving…' : 'Save'}
+          </button>
+        </form>
+      )}
+
+      {/* Full Profile card — shown only when all setup steps are complete */}
+      {allStepsDone && (
+        <form onSubmit={handleSave} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+          <h2 className="text-base font-semibold text-gray-700">Profile</h2>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <p className="text-sm text-gray-800 bg-gray-50 border border-gray-200 rounded-lg px-3 py-2">
+              {email}
+            </p>
+            <p className="text-xs text-green-600 mt-1">✓ Verified email</p>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Blog URL</label>
+            <input
+              type="url"
+              value={blogUrl}
+              onChange={(e) => setBlogUrl(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="https://yourblog.com"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Sitemap URL</label>
+            <input
+              type="url"
+              value={sitemapUrl}
+              onChange={(e) => setSitemapUrl(e.target.value)}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="https://yourblog.com/sitemap.xml"
+            />
+            <p className="text-xs text-gray-400 mt-1">Used by AI to generate content ideas from your existing posts.</p>
+          </div>
+
+          {savedMsg && (
+            <p className={`text-sm font-medium ${saveMutation.isError ? 'text-red-600' : 'text-green-600'}`}>
+              {savedMsg}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={saveMutation.isPending}
+            className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {saveMutation.isPending ? 'Saving…' : 'Save Settings'}
+          </button>
+        </form>
+      )}
+
+      {/* Preferences card */}
+      <form onSubmit={handlePrefsSave} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-5">
+        <h2 className="text-base font-semibold text-gray-700">Preferences</h2>
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
-            Email <span className="text-red-500">*</span>
+            Inactivity auto-stop delay
           </label>
-          <input
-            type="email"
-            required
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
+          <select
+            value={inactivateDelay === null ? 'never' : String(inactivateDelay)}
+            onChange={(e) =>
+              setInactivateDelay(e.target.value === 'never' ? null : Number(e.target.value))
+            }
             className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            placeholder="your@email.com"
-          />
-          {email && (
-            <p className={`text-xs mt-1 ${userExists ? 'text-green-600' : 'text-gray-400'}`}>
-              {userExists ? '✓ Account found in database' : 'No account yet — connect LinkedIn to create one'}
-            </p>
-          )}
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Blog URL</label>
-          <input
-            type="url"
-            value={blogUrl}
-            onChange={(e) => setBlogUrl(e.target.value)}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            placeholder="https://yourblog.com"
-          />
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">Sitemap URL</label>
-          <input
-            type="url"
-            value={sitemapUrl}
-            onChange={(e) => setSitemapUrl(e.target.value)}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-            placeholder="https://yourblog.com/sitemap.xml"
-          />
+          >
+            {INACTIVATE_OPTIONS.map(({ label, value }) => (
+              <option key={String(value)} value={value === null ? 'never' : String(value)}>
+                {label}
+              </option>
+            ))}
+          </select>
           <p className="text-xs text-gray-400 mt-1">
-            Used by AI to generate content ideas from your existing posts.
+            If you haven't logged in within this window, LEM will pause automated posting and LinkedIn activity to avoid acting on your behalf unintentionally.
+            Set to "Never" to keep automation running regardless of login activity.
           </p>
         </div>
 
-        {savedMsg && (
-          <p
-            className={`text-sm font-medium ${
-              saveMutation.isError ? 'text-red-600' : 'text-green-600'
-            }`}
-          >
-            {savedMsg}
+        <div>
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-gray-700">Auto-schedule AI posts</p>
+              <p className="text-xs text-gray-400 mt-0.5">
+                When on, AI-generated posts are automatically approved and queued for posting.
+                When off, each post waits for your manual approval in the Review tab.
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setAutoSchedule((v) => !v)}
+              className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${
+                autoSchedule ? 'bg-blue-600' : 'bg-gray-200'
+              }`}
+              role="switch"
+              aria-checked={autoSchedule}
+            >
+              <span
+                className={`pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${
+                  autoSchedule ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+
+        {prefsSavedMsg && (
+          <p className={`text-sm font-medium ${prefsMutation.isError ? 'text-red-600' : 'text-green-600'}`}>
+            {prefsSavedMsg}
           </p>
         )}
 
         <button
           type="submit"
-          disabled={saveMutation.isPending}
+          disabled={prefsMutation.isPending}
           className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
         >
-          {saveMutation.isPending ? 'Saving…' : 'Save Settings'}
+          {prefsMutation.isPending ? 'Saving…' : 'Save Preferences'}
         </button>
       </form>
-
-      {/* LinkedIn connection */}
-      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
-        <h2 className="text-base font-semibold text-gray-700">LinkedIn Connection</h2>
-
-        <div className="flex items-center gap-3">
-          <div
-            className={`w-3 h-3 rounded-full flex-shrink-0 ${
-              isLinkedInConnected ? 'bg-green-500' : 'bg-gray-300'
-            }`}
-          />
-          <span className="text-sm text-gray-600">
-            {isLinkedInConnected ? 'Connected to LinkedIn' : 'Not connected'}
-          </span>
-        </div>
-
-        {!step1Done && (
-          <p className="text-xs text-yellow-700 bg-yellow-50 rounded p-2 border border-yellow-200">
-            Save your email first before connecting LinkedIn.
-          </p>
-        )}
-
-        <p className="text-xs text-gray-500">
-          Connecting allows LEM to post on your behalf, send DMs, reply to comments, and engage with your network automatically.
-        </p>
-
-        <a
-          href={step1Done ? `${LI_AUTH_URL}?email=${encodeURIComponent(email)}` : undefined}
-          onClick={!step1Done ? (e) => e.preventDefault() : undefined}
-          className={`inline-block w-full text-center py-2 rounded-lg text-sm font-semibold transition-colors ${
-            step1Done
-              ? 'bg-blue-700 text-white hover:bg-blue-800 cursor-pointer'
-              : 'bg-gray-200 text-gray-400 cursor-not-allowed'
-          }`}
-        >
-          {isLinkedInConnected ? 'Reconnect LinkedIn' : 'Connect LinkedIn'}
-        </a>
-      </div>
     </div>
   )
 }

--- a/src/cqc_lem/ui/src/pages/Account.tsx
+++ b/src/cqc_lem/ui/src/pages/Account.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useMutation, useQuery } from '@tanstack/react-query'
 import api from '../api/client'
 
@@ -21,10 +22,31 @@ function StepBadge({ n, active, done }: { n: number; active: boolean; done: bool
 }
 
 export default function Account() {
+  const [searchParams, setSearchParams] = useSearchParams()
   const [email, setEmail] = useState(localStorage.getItem('lem_email') || '')
   const [blogUrl, setBlogUrl] = useState(localStorage.getItem('lem_blog_url') || '')
   const [sitemapUrl, setSitemapUrl] = useState(localStorage.getItem('lem_sitemap_url') || '')
   const [savedMsg, setSavedMsg] = useState<string | null>(null)
+
+  // Persist OAuth callback params to localStorage and clear from URL
+  useEffect(() => {
+    const oauthEmail = searchParams.get('email')
+    const liConnected = searchParams.get('li_connected')
+    if (oauthEmail) {
+      localStorage.setItem('lem_email', oauthEmail)
+      setEmail(oauthEmail)
+    }
+    if (liConnected === '1') {
+      localStorage.setItem('lem_li_connected', '1')
+    }
+    if (oauthEmail || liConnected) {
+      setSearchParams({}, { replace: true })
+      setSavedMsg('LinkedIn connected! Your account has been set up.')
+      setTimeout(() => setSavedMsg(null), 5000)
+    }
+    setBlogUrl(localStorage.getItem('lem_blog_url') || '')
+    setSitemapUrl(localStorage.getItem('lem_sitemap_url') || '')
+  }, [])
 
   const { data: userIdData, refetch: refetchUser } = useQuery<{ detail: number }>({
     queryKey: ['user-id', email],
@@ -34,11 +56,6 @@ export default function Account() {
   })
 
   const userExists = !!userIdData?.detail
-
-  useEffect(() => {
-    setBlogUrl(localStorage.getItem('lem_blog_url') || '')
-    setSitemapUrl(localStorage.getItem('lem_sitemap_url') || '')
-  }, [])
 
   const saveMutation = useMutation({
     mutationFn: () =>

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import api from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
 
 interface DashboardStats {
   scheduled_this_week: number
@@ -52,7 +53,8 @@ function StatCard({ label, value, color }: { label: string; value: number; color
 }
 
 export default function Dashboard() {
-  const email = localStorage.getItem('lem_email') || ''
+  const { user } = useAuth()
+  const email = user?.email ?? ''
 
   const { data: statsData } = useQuery<{ detail: DashboardStats }>({
     queryKey: ['dashboard-stats', email],
@@ -61,9 +63,9 @@ export default function Dashboard() {
     refetchInterval: 30_000,
   })
 
-  const { data: postsData } = useQuery<{ detail: Post[] }>({
-    queryKey: ['posts', email],
-    queryFn: () => api.get(`/posts/?email=${encodeURIComponent(email)}`).then((r) => r.data),
+  const { data: postsData } = useQuery<{ detail: { posts: Post[]; total: number } }>({
+    queryKey: ['dashboard-posts', email],
+    queryFn: () => api.get(`/posts/?email=${encodeURIComponent(email)}&page_size=50`).then((r) => r.data),
     enabled: !!email,
     refetchInterval: 30_000,
   })
@@ -77,39 +79,13 @@ export default function Dashboard() {
 
   const stats = statsData?.detail ?? { scheduled_this_week: 0, pending_review: 0, posted_total: 0 }
 
-  const allPosts = postsData?.detail ?? []
+  const allPosts = postsData?.detail?.posts ?? []
   const upcoming = allPosts
     .filter((p) => p.status !== 'POSTED')
     .sort((a, b) => new Date(a.scheduled_time).getTime() - new Date(b.scheduled_time).getTime())
     .slice(0, 5)
 
   const activity = activityData?.detail ?? []
-
-  if (!email) {
-    return (
-      <div className="text-center py-16">
-        <p className="text-gray-500 mb-2">Enter your email to get started.</p>
-        <p className="text-xs text-gray-400 mb-4">
-          Then go to{' '}
-          <Link to="/account" className="text-blue-600 hover:underline">
-            Account Settings
-          </Link>{' '}
-          to connect LinkedIn.
-        </p>
-        <input
-          type="email"
-          placeholder="your@email.com"
-          className="border border-gray-300 rounded-lg px-4 py-2 text-sm w-72 focus:outline-none focus:ring-2 focus:ring-blue-500"
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              localStorage.setItem('lem_email', (e.target as HTMLInputElement).value)
-              window.location.reload()
-            }
-          }}
-        />
-      </div>
-    )
-  }
 
   return (
     <div className="space-y-6">

--- a/src/cqc_lem/ui/src/pages/Landing.tsx
+++ b/src/cqc_lem/ui/src/pages/Landing.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
 
 function FaqItem({ question, answer }: { question: string; answer: string }) {
   const [open, setOpen] = useState(false)
@@ -23,7 +23,7 @@ function FaqItem({ question, answer }: { question: string; answer: string }) {
 }
 
 export default function Landing() {
-  const navigate = useNavigate()
+  const { openLoginModal } = useAuth()
 
   function scrollToFeatures() {
     document.getElementById('features')?.scrollIntoView({ behavior: 'smooth' })
@@ -36,7 +36,7 @@ export default function Landing() {
         <div className="max-w-6xl mx-auto px-4 flex items-center justify-between h-14">
           <span className="font-bold text-blue-600 text-lg">LEM</span>
           <button
-            onClick={() => navigate('/account')}
+            onClick={() => openLoginModal()}
             className="bg-blue-600 text-white px-4 py-1.5 rounded-lg text-sm font-semibold hover:bg-blue-700 transition-colors"
           >
             Get Started Free
@@ -59,7 +59,7 @@ export default function Landing() {
           </p>
           <div className="flex flex-col sm:flex-row gap-4 justify-center">
             <button
-              onClick={() => navigate('/account')}
+              onClick={() => openLoginModal()}
               className="bg-white text-blue-700 px-8 py-3 rounded-lg font-bold text-base hover:bg-blue-50 transition-colors shadow-lg"
             >
               Get Started Free
@@ -158,7 +158,7 @@ export default function Landing() {
                 <li className="flex items-start gap-2"><span className="text-red-400">✗</span><span className="text-gray-400">Analytics dashboard</span></li>
               </ul>
               <button
-                onClick={() => navigate('/account')}
+                onClick={() => openLoginModal()}
                 className="mt-6 w-full border border-blue-600 text-blue-600 py-2 rounded-lg text-sm font-semibold hover:bg-blue-50 transition-colors"
               >
                 Get Started
@@ -183,7 +183,7 @@ export default function Landing() {
                 <li className="flex items-start gap-2"><span className="text-red-400">✗</span><span className="text-gray-400">Advanced analytics</span></li>
               </ul>
               <button
-                onClick={() => navigate('/account')}
+                onClick={() => openLoginModal()}
                 className="mt-6 w-full bg-green-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-green-700 transition-colors"
               >
                 Get Started
@@ -211,7 +211,7 @@ export default function Landing() {
                 <li className="flex items-start gap-2"><span className="text-green-500">✓</span><span>Priority support</span></li>
               </ul>
               <button
-                onClick={() => navigate('/account')}
+                onClick={() => openLoginModal()}
                 className="mt-6 w-full bg-yellow-400 text-black py-2 rounded-lg text-sm font-bold hover:bg-yellow-500 transition-colors"
               >
                 Get Started
@@ -236,7 +236,7 @@ export default function Landing() {
                 <li className="flex items-start gap-2"><span className="text-green-500">✓</span><span>Dedicated support</span></li>
               </ul>
               <button
-                onClick={() => navigate('/account')}
+                onClick={() => openLoginModal()}
                 className="mt-6 w-full bg-purple-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-purple-700 transition-colors"
               >
                 Get Started
@@ -279,7 +279,7 @@ export default function Landing() {
             Join thousands of professionals who are already automating their LinkedIn success.
           </p>
           <button
-            onClick={() => navigate('/account')}
+            onClick={() => openLoginModal()}
             className="bg-white text-blue-700 px-10 py-3 rounded-lg font-bold text-base hover:bg-blue-50 transition-colors shadow-lg"
           >
             Start Free Trial

--- a/src/cqc_lem/ui/src/pages/ReviewSchedule.tsx
+++ b/src/cqc_lem/ui/src/pages/ReviewSchedule.tsx
@@ -2,9 +2,19 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../api/client'
 import LinkedInPostPreview from '../components/LinkedInPostPreview'
+import { useAuth } from '../contexts/AuthContext'
 
-type Status = 'ALL' | 'PENDING' | 'APPROVED' | 'SCHEDULED' | 'POSTED'
-const STATUSES: Status[] = ['ALL', 'PENDING', 'APPROVED', 'SCHEDULED', 'POSTED']
+type Status = 'ALL' | 'pending' | 'approved' | 'scheduled' | 'posted' | 'rejected'
+const STATUSES: { label: string; value: Status }[] = [
+  { label: 'ALL', value: 'ALL' },
+  { label: 'PENDING', value: 'pending' },
+  { label: 'APPROVED', value: 'approved' },
+  { label: 'SCHEDULED', value: 'scheduled' },
+  { label: 'POSTED', value: 'posted' },
+  { label: 'REJECTED', value: 'rejected' },
+]
+
+const PAGE_SIZE_OPTIONS = [10, 25, 50]
 
 interface Post {
   post_id: number
@@ -13,19 +23,63 @@ interface Post {
   scheduled_time: string
   post_type: string
   status: string
+  carousel_slides: string[] | null
+}
+
+interface PostsResponse {
+  posts: Post[]
+  total: number
+  page: number
+  page_size: number
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  approved: 'bg-green-100 text-green-700',
+  pending: 'bg-yellow-100 text-yellow-700',
+  posted: 'bg-blue-100 text-blue-700',
+  rejected: 'bg-red-100 text-red-700',
+  scheduled: 'bg-purple-100 text-purple-700',
 }
 
 export default function ReviewSchedule() {
-  const email = localStorage.getItem('lem_email') || ''
-  const [filterStatus, setFilterStatus] = useState<Status>('ALL')
-  const [editingPost, setEditingPost] = useState<Post | null>(null)
+  const { user } = useAuth()
+  const email = user?.email ?? ''
   const qc = useQueryClient()
 
-  const { data, isLoading } = useQuery<{ detail: Post[] }>({
-    queryKey: ['posts', email],
-    queryFn: () => api.get(`/posts/?email=${encodeURIComponent(email)}`).then((r) => r.data),
+  // Filter / sort / pagination state
+  const [filterStatus, setFilterStatus] = useState<Status>('ALL')
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
+  const [page, setPage] = useState(1)
+  const [pageSize, setPageSize] = useState(10)
+
+  // Selection / bulk state
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [bulkStatus, setBulkStatus] = useState<string>('approved')
+  const [bulkDate, setBulkDate] = useState<string>('')
+
+  // Single-post edit state
+  const [editingPost, setEditingPost] = useState<Post | null>(null)
+
+  const queryKey = ['posts', email, page, pageSize, sortOrder, filterStatus]
+
+  const { data, isLoading } = useQuery<{ detail: PostsResponse }>({
+    queryKey,
+    queryFn: () => {
+      const params = new URLSearchParams({
+        email,
+        page: String(page),
+        page_size: String(pageSize),
+        sort_order: sortOrder,
+      })
+      if (filterStatus !== 'ALL') params.set('status_filter', filterStatus)
+      return api.get(`/posts/?${params.toString()}`).then((r) => r.data)
+    },
     enabled: !!email,
   })
+
+  const posts = data?.detail?.posts ?? []
+  const total = data?.detail?.total ?? 0
+  const totalPages = Math.max(1, Math.ceil(total / pageSize))
 
   const updateMutation = useMutation({
     mutationFn: (post: Post) =>
@@ -43,6 +97,24 @@ export default function ReviewSchedule() {
     },
   })
 
+  const bulkUpdateMutation = useMutation({
+    mutationFn: (body: { post_ids: number[]; status?: string; scheduled_datetime?: string }) =>
+      api.post('/posts/bulk_update/', body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['posts', email] })
+      setSelectedIds(new Set())
+      setBulkDate('')
+    },
+  })
+
+  const bulkDeleteMutation = useMutation({
+    mutationFn: (post_ids: number[]) => api.delete('/posts/', { data: { post_ids } }),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['posts', email] })
+      setSelectedIds(new Set())
+    },
+  })
+
   const weeklyMutation = useMutation({
     mutationFn: () =>
       api.get(`/user_id/?email=${encodeURIComponent(email)}`).then((r) =>
@@ -50,11 +122,43 @@ export default function ReviewSchedule() {
       ),
   })
 
-  const posts = data?.detail ?? []
-  const filtered = filterStatus === 'ALL' ? posts : posts.filter((p) => p.status === filterStatus)
+  // Selection helpers
+  function toggleSelect(id: number) {
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      next.has(id) ? next.delete(id) : next.add(id)
+      return next
+    })
+  }
+
+  function toggleSelectAll() {
+    if (posts.every((p) => selectedIds.has(p.post_id))) {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        posts.forEach((p) => next.delete(p.post_id))
+        return next
+      })
+    } else {
+      setSelectedIds((prev) => {
+        const next = new Set(prev)
+        posts.forEach((p) => next.add(p.post_id))
+        return next
+      })
+    }
+  }
+
+  function resetPage(newFilter?: Status) {
+    setPage(1)
+    setSelectedIds(new Set())
+    setEditingPost(null)
+    if (newFilter !== undefined) setFilterStatus(newFilter)
+  }
+
+  const allOnPageSelected = posts.length > 0 && posts.every((p) => selectedIds.has(p.post_id))
 
   return (
     <div className="space-y-4">
+      {/* Header */}
       <div className="flex items-center justify-between flex-wrap gap-3">
         <h1 className="text-2xl font-bold text-gray-800">Review Posts</h1>
         <button
@@ -62,7 +166,7 @@ export default function ReviewSchedule() {
           disabled={weeklyMutation.isPending}
           className="bg-green-600 text-white px-4 py-2 rounded-lg text-sm font-semibold hover:bg-green-700 disabled:opacity-50 transition-colors"
         >
-          {weeklyMutation.isPending ? 'Generating content (this may take a minute)…' : 'Generate Weekly Content'}
+          {weeklyMutation.isPending ? 'Generating content…' : 'Generate Weekly Content'}
         </button>
       </div>
 
@@ -70,44 +174,139 @@ export default function ReviewSchedule() {
       <div className="flex gap-2 flex-wrap">
         {STATUSES.map((s) => (
           <button
-            key={s}
-            onClick={() => setFilterStatus(s)}
+            key={s.value}
+            onClick={() => resetPage(s.value)}
             className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
-              filterStatus === s
+              filterStatus === s.value
                 ? 'bg-blue-600 text-white'
                 : 'bg-white text-gray-600 border border-gray-300 hover:border-blue-400'
             }`}
           >
-            {s}
+            {s.label}
           </button>
         ))}
       </div>
+
+      {/* Sort + page-size controls */}
+      <div className="flex items-center gap-3 flex-wrap text-sm">
+        <button
+          onClick={() => { setSortOrder((o) => (o === 'asc' ? 'desc' : 'asc')); resetPage() }}
+          className="flex items-center gap-1 text-gray-600 border border-gray-300 rounded-lg px-3 py-1.5 hover:border-blue-400 transition-colors text-xs font-medium"
+        >
+          {sortOrder === 'asc' ? '↑ Oldest first' : '↓ Newest first'}
+        </button>
+        <div className="flex items-center gap-1.5 text-xs text-gray-600">
+          <span>Show</span>
+          {PAGE_SIZE_OPTIONS.map((n) => (
+            <button
+              key={n}
+              onClick={() => { setPageSize(n); resetPage() }}
+              className={`px-2 py-1 rounded border transition-colors ${
+                pageSize === n ? 'bg-blue-600 text-white border-blue-600' : 'border-gray-300 hover:border-blue-400'
+              }`}
+            >
+              {n}
+            </button>
+          ))}
+          <span>per page</span>
+        </div>
+        <span className="text-xs text-gray-400">{total} total posts</span>
+      </div>
+
+      {/* Bulk action bar */}
+      {selectedIds.size > 0 && (
+        <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-3 flex flex-wrap items-center gap-3">
+          <span className="text-sm font-semibold text-blue-800">{selectedIds.size} selected</span>
+
+          <div className="flex items-center gap-2">
+            <select
+              value={bulkStatus}
+              onChange={(e) => setBulkStatus(e.target.value)}
+              className="border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500"
+            >
+              {['pending', 'approved', 'scheduled', 'posted', 'rejected'].map((s) => (
+                <option key={s} value={s}>{s.toUpperCase()}</option>
+              ))}
+            </select>
+            <button
+              onClick={() => bulkUpdateMutation.mutate({ post_ids: Array.from(selectedIds), status: bulkStatus })}
+              disabled={bulkUpdateMutation.isPending}
+              className="bg-blue-600 text-white px-3 py-1 rounded text-xs font-semibold hover:bg-blue-700 disabled:opacity-50"
+            >
+              Apply Status
+            </button>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <input
+              type="datetime-local"
+              value={bulkDate}
+              onChange={(e) => setBulkDate(e.target.value)}
+              className="border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+            <button
+              onClick={() => {
+                if (!bulkDate) return
+                bulkUpdateMutation.mutate({
+                  post_ids: Array.from(selectedIds),
+                  scheduled_datetime: new Date(bulkDate).toISOString(),
+                })
+              }}
+              disabled={!bulkDate || bulkUpdateMutation.isPending}
+              className="bg-blue-600 text-white px-3 py-1 rounded text-xs font-semibold hover:bg-blue-700 disabled:opacity-50"
+            >
+              Apply Date
+            </button>
+          </div>
+
+          <button
+            onClick={() => bulkDeleteMutation.mutate(Array.from(selectedIds))}
+            disabled={bulkDeleteMutation.isPending}
+            className="ml-auto bg-red-500 text-white px-3 py-1 rounded text-xs font-semibold hover:bg-red-600 disabled:opacity-50"
+          >
+            {bulkDeleteMutation.isPending ? 'Deleting…' : 'Delete Selected'}
+          </button>
+        </div>
+      )}
 
       {isLoading && <p className="text-gray-400 text-sm">Loading posts…</p>}
 
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
         <div className="space-y-3">
-          {filtered.length === 0 && !isLoading && posts.length === 0 && (
+          {/* Select-all header */}
+          {posts.length > 0 && (
+            <label className="flex items-center gap-2 text-xs text-gray-500 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={allOnPageSelected}
+                onChange={toggleSelectAll}
+                className="rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              Select all on this page
+            </label>
+          )}
+
+          {posts.length === 0 && !isLoading && (
             <div className="flex flex-col items-center text-center py-12 px-4 bg-white rounded-lg border border-gray-200">
               <div className="text-4xl mb-4">📅</div>
               <p className="text-gray-600 text-sm mb-6 max-w-xs">
-                Your scheduled posts will appear here. Generate your first week of content to get started.
+                {filterStatus === 'ALL'
+                  ? 'Your scheduled posts will appear here. Generate your first week of content to get started.'
+                  : 'No posts match this filter.'}
               </p>
-              <button
-                onClick={() => weeklyMutation.mutate()}
-                disabled={weeklyMutation.isPending}
-                className="bg-green-600 text-white px-6 py-2.5 rounded-lg text-sm font-semibold hover:bg-green-700 disabled:opacity-50 transition-colors"
-              >
-                {weeklyMutation.isPending
-                  ? 'Generating content (this may take a minute)…'
-                  : 'Generate Weekly Content'}
-              </button>
+              {filterStatus === 'ALL' && (
+                <button
+                  onClick={() => weeklyMutation.mutate()}
+                  disabled={weeklyMutation.isPending}
+                  className="bg-green-600 text-white px-6 py-2.5 rounded-lg text-sm font-semibold hover:bg-green-700 disabled:opacity-50 transition-colors"
+                >
+                  {weeklyMutation.isPending ? 'Generating content…' : 'Generate Weekly Content'}
+                </button>
+              )}
             </div>
           )}
-          {filtered.length === 0 && !isLoading && posts.length > 0 && (
-            <p className="text-sm text-gray-400 py-4">No posts match this filter.</p>
-          )}
-          {filtered.map((post) => (
+
+          {posts.map((post) => (
             <div
               key={post.post_id}
               onClick={() => setEditingPost(post)}
@@ -115,20 +314,55 @@ export default function ReviewSchedule() {
                 editingPost?.post_id === post.post_id ? 'border-blue-500 ring-1 ring-blue-500' : 'border-gray-200'
               }`}
             >
-              <div className="flex items-center justify-between mb-2">
-                <span className="text-xs text-gray-400">{new Date(post.scheduled_time).toLocaleString()}</span>
-                <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${
-                  post.status === 'APPROVED' ? 'bg-green-100 text-green-700' :
-                  post.status === 'PENDING' ? 'bg-yellow-100 text-yellow-700' :
-                  post.status === 'POSTED' ? 'bg-blue-100 text-blue-700' :
-                  'bg-gray-100 text-gray-600'
-                }`}>
-                  {post.status}
-                </span>
+              <div className="flex items-start gap-3">
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(post.post_id)}
+                  onChange={(e) => { e.stopPropagation(); toggleSelect(post.post_id) }}
+                  onClick={(e) => e.stopPropagation()}
+                  className="mt-1 rounded border-gray-300 text-blue-600 focus:ring-blue-500 shrink-0"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center justify-between mb-1 gap-2">
+                    <span className="text-xs text-gray-400 truncate">
+                      {new Date(post.scheduled_time).toLocaleString()}
+                    </span>
+                    <div className="flex items-center gap-1.5 shrink-0">
+                      <span className="text-xs text-gray-400 uppercase">{post.post_type}</span>
+                      <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[post.status] ?? 'bg-gray-100 text-gray-600'}`}>
+                        {post.status.toUpperCase()}
+                      </span>
+                    </div>
+                  </div>
+                  <p className="text-sm text-gray-700 line-clamp-2">{post.content}</p>
+                  {post.post_type === 'carousel' && post.carousel_slides && (
+                    <p className="text-xs text-gray-400 mt-1">{post.carousel_slides.length} slides</p>
+                  )}
+                </div>
               </div>
-              <p className="text-sm text-gray-700 line-clamp-2">{post.content}</p>
             </div>
           ))}
+
+          {/* Pagination */}
+          {totalPages > 1 && (
+            <div className="flex items-center justify-between pt-2">
+              <button
+                onClick={() => setPage((p) => Math.max(1, p - 1))}
+                disabled={page <= 1}
+                className="px-3 py-1.5 border border-gray-300 rounded-lg text-xs text-gray-600 hover:border-blue-400 disabled:opacity-40 transition-colors"
+              >
+                ← Prev
+              </button>
+              <span className="text-xs text-gray-500">Page {page} of {totalPages}</span>
+              <button
+                onClick={() => setPage((p) => Math.min(totalPages, p + 1))}
+                disabled={page >= totalPages}
+                className="px-3 py-1.5 border border-gray-300 rounded-lg text-xs text-gray-600 hover:border-blue-400 disabled:opacity-40 transition-colors"
+              >
+                Next →
+              </button>
+            </div>
+          )}
         </div>
 
         {editingPost && (
@@ -143,6 +377,34 @@ export default function ReviewSchedule() {
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
               />
 
+              {editingPost.post_type === 'video' && (
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Video URL</label>
+                  <input
+                    type="url"
+                    value={editingPost.video_url ?? ''}
+                    onChange={(e) => setEditingPost({ ...editingPost, video_url: e.target.value || null })}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                    placeholder="https://example.com/video.mp4"
+                  />
+                </div>
+              )}
+
+              {editingPost.post_type === 'carousel' && editingPost.carousel_slides && (
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">
+                    Slides ({editingPost.carousel_slides.length})
+                  </label>
+                  <ul className="space-y-1">
+                    {editingPost.carousel_slides.map((slide, i) => (
+                      <li key={i} className="text-xs text-gray-600 bg-gray-50 rounded px-2 py-1">
+                        <span className="text-gray-400 mr-1">{i + 1}.</span>{slide}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+
               <div className="grid grid-cols-2 gap-3">
                 <div>
                   <label className="block text-xs font-medium text-gray-600 mb-1">Status</label>
@@ -151,8 +413,8 @@ export default function ReviewSchedule() {
                     onChange={(e) => setEditingPost({ ...editingPost, status: e.target.value })}
                     className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
-                    {['PENDING', 'APPROVED', 'SCHEDULED', 'POSTED'].map((s) => (
-                      <option key={s} value={s}>{s}</option>
+                    {['pending', 'approved', 'scheduled', 'posted', 'rejected'].map((s) => (
+                      <option key={s} value={s}>{s.toUpperCase()}</option>
                     ))}
                   </select>
                 </div>
@@ -160,7 +422,7 @@ export default function ReviewSchedule() {
                   <label className="block text-xs font-medium text-gray-600 mb-1">Scheduled Time</label>
                   <input
                     type="datetime-local"
-                    value={editingPost.scheduled_time.slice(0, 16)}
+                    value={editingPost.scheduled_time?.slice(0, 16) ?? ''}
                     onChange={(e) => setEditingPost({ ...editingPost, scheduled_time: e.target.value })}
                     className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                   />

--- a/src/cqc_lem/ui/src/pages/ScheduleContent.tsx
+++ b/src/cqc_lem/ui/src/pages/ScheduleContent.tsx
@@ -2,16 +2,15 @@ import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import api from '../api/client'
 import LinkedInPostPreview from '../components/LinkedInPostPreview'
+import { useAuth } from '../contexts/AuthContext'
 
-const POST_TYPES = ['TEXT', 'IMAGE', 'VIDEO', 'CAROUSEL'] as const
+const POST_TYPES = ['TEXT', 'VIDEO', 'CAROUSEL'] as const
 type PostType = typeof POST_TYPES[number]
 
 const DAY_NAMES = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday']
 
-// Returns best posting time as "HH:MM" string for a given JS Date
-// Mon(1)=08:00, Fri(5)=08:00, Tue(2)/Wed(3)/Thu(4)=07:00, Sat(6)/Sun(0)=10:00
 function getBestPostingTime(date: Date): { time: string; display: string; dayName: string } {
-  const day = date.getDay() // 0=Sun,1=Mon,...,6=Sat
+  const day = date.getDay()
   let hour: number
   if (day === 1 || day === 5) {
     hour = 8
@@ -27,26 +26,37 @@ function getBestPostingTime(date: Date): { time: string; display: string; dayNam
 }
 
 export default function ScheduleContent() {
+  const { user } = useAuth()
+  const email = user?.email ?? ''
+
   const [content, setContent] = useState('')
   const [postType, setPostType] = useState<PostType>('TEXT')
+  const [videoUrl, setVideoUrl] = useState('')
+  const [slides, setSlides] = useState<string[]>([''])
   const [scheduledAt, setScheduledAt] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null)
-
-  const email = localStorage.getItem('lem_email') || ''
   const MAX_CHARS = 3000
   const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
-  // Compute best time suggestion whenever a date is selected
-  const bestTimeSuggestion = scheduledAt
-    ? getBestPostingTime(new Date(scheduledAt))
-    : null
+  const bestTimeSuggestion = scheduledAt ? getBestPostingTime(new Date(scheduledAt)) : null
 
   function applyBestTime() {
     if (!scheduledAt || !bestTimeSuggestion) return
-    // Replace the time portion of the datetime-local value (YYYY-MM-DDTHH:MM)
     const datePart = scheduledAt.slice(0, 10)
     setScheduledAt(`${datePart}T${bestTimeSuggestion.time}`)
+  }
+
+  function addSlide() {
+    setSlides((prev) => [...prev, ''])
+  }
+
+  function removeSlide(idx: number) {
+    setSlides((prev) => prev.filter((_, i) => i !== idx))
+  }
+
+  function updateSlide(idx: number, value: string) {
+    setSlides((prev) => prev.map((s, i) => (i === idx ? value : s)))
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -54,19 +64,32 @@ export default function ScheduleContent() {
     if (!email) { setResult({ ok: false, msg: 'Set your email in Account settings first.' }); return }
     if (!content.trim()) { setResult({ ok: false, msg: 'Post content is required.' }); return }
     if (!scheduledAt) { setResult({ ok: false, msg: 'Scheduled date/time is required.' }); return }
+    if (postType === 'CAROUSEL' && slides.every((s) => !s.trim())) {
+      setResult({ ok: false, msg: 'At least one slide with text is required.' })
+      return
+    }
 
     setSubmitting(true)
     setResult(null)
     try {
-      await api.post('/schedule_post/', {
+      const payload: Record<string, unknown> = {
         content,
         post_type: postType,
         scheduled_datetime: new Date(scheduledAt).toISOString(),
         email,
-        status: 'PENDING',
-      })
+        status: 'pending',
+      }
+      if (postType === 'VIDEO') {
+        payload.video_url = videoUrl || null
+      }
+      if (postType === 'CAROUSEL') {
+        payload.carousel_slides = slides.filter((s) => s.trim())
+      }
+      await api.post('/schedule_post/', payload)
       setResult({ ok: true, msg: 'Post scheduled successfully!' })
       setContent('')
+      setVideoUrl('')
+      setSlides([''])
       setScheduledAt('')
     } catch {
       setResult({ ok: false, msg: 'Failed to schedule post. Please try again.' })
@@ -74,6 +97,11 @@ export default function ScheduleContent() {
       setSubmitting(false)
     }
   }
+
+  const previewContent =
+    postType === 'CAROUSEL'
+      ? slides.filter((s) => s.trim()).join('\n---\n') || 'Your carousel slides will appear here…'
+      : content || 'Your post content will appear here…'
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
@@ -95,23 +123,7 @@ export default function ScheduleContent() {
         </div>
 
         <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
-          <div>
-            <div className="flex justify-between mb-1">
-              <label className="text-sm font-medium text-gray-700">Post Content</label>
-              <span className={`text-xs ${content.length > MAX_CHARS ? 'text-red-500' : 'text-gray-400'}`}>
-                {content.length} / {MAX_CHARS}
-              </span>
-            </div>
-            <textarea
-              value={content}
-              onChange={(e) => setContent(e.target.value)}
-              rows={8}
-              maxLength={MAX_CHARS}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
-              placeholder="What would you like to share?"
-            />
-          </div>
-
+          {/* Post type selector */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Post Type</label>
             <div className="flex gap-2 flex-wrap">
@@ -132,6 +144,79 @@ export default function ScheduleContent() {
             </div>
           </div>
 
+          {/* Content — caption for all types */}
+          <div>
+            <div className="flex justify-between mb-1">
+              <label className="text-sm font-medium text-gray-700">
+                {postType === 'CAROUSEL' ? 'Caption / Intro Text' : 'Post Content'}
+              </label>
+              <span className={`text-xs ${content.length > MAX_CHARS ? 'text-red-500' : 'text-gray-400'}`}>
+                {content.length} / {MAX_CHARS}
+              </span>
+            </div>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              rows={postType === 'CAROUSEL' ? 3 : 8}
+              maxLength={MAX_CHARS}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              placeholder={postType === 'CAROUSEL' ? 'Optional intro text for the carousel post…' : 'What would you like to share?'}
+            />
+          </div>
+
+          {/* VIDEO: video URL field */}
+          {postType === 'VIDEO' && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Video URL</label>
+              <input
+                type="url"
+                value={videoUrl}
+                onChange={(e) => setVideoUrl(e.target.value)}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                placeholder="https://example.com/video.mp4"
+              />
+              <p className="mt-1 text-xs text-gray-400">Direct URL to the video file that will be uploaded to LinkedIn.</p>
+            </div>
+          )}
+
+          {/* CAROUSEL: slide builder */}
+          {postType === 'CAROUSEL' && (
+            <div className="space-y-3">
+              <label className="block text-sm font-medium text-gray-700">
+                Slides <span className="text-gray-400 font-normal text-xs">(images auto-fetched from Pexels at post time)</span>
+              </label>
+              {slides.map((slide, idx) => (
+                <div key={idx} className="flex gap-2 items-start">
+                  <span className="mt-2 text-xs text-gray-400 font-medium w-5 shrink-0">{idx + 1}.</span>
+                  <textarea
+                    rows={2}
+                    value={slide}
+                    onChange={(e) => updateSlide(idx, e.target.value)}
+                    className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                    placeholder={`Slide ${idx + 1} text…`}
+                  />
+                  {slides.length > 1 && (
+                    <button
+                      type="button"
+                      onClick={() => removeSlide(idx)}
+                      className="mt-1.5 text-red-400 hover:text-red-600 text-xs font-semibold px-2 py-1 rounded border border-red-200 hover:border-red-400 transition-colors"
+                    >
+                      Remove
+                    </button>
+                  )}
+                </div>
+              ))}
+              <button
+                type="button"
+                onClick={addSlide}
+                className="text-sm text-blue-600 font-semibold hover:text-blue-800 transition-colors"
+              >
+                + Add Slide
+              </button>
+            </div>
+          )}
+
+          {/* Schedule date/time */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Schedule Date &amp; Time</label>
             <input
@@ -175,7 +260,7 @@ export default function ScheduleContent() {
       <div className="space-y-4">
         <h2 className="text-xl font-semibold text-gray-700">Preview</h2>
         <LinkedInPostPreview
-          content={content || 'Your post content will appear here…'}
+          content={previewContent}
           author={email.split('@')[0] || 'You'}
           headline="LinkedIn Member"
         />

--- a/src/cqc_lem/utilities/carousel_creator.py
+++ b/src/cqc_lem/utilities/carousel_creator.py
@@ -1,5 +1,7 @@
 import os
 import random
+import tempfile
+import urllib.request
 from datetime import datetime
 from typing import Optional, Union
 
@@ -189,6 +191,24 @@ def get_default_image_path() -> str:
     return default_image_path
 
 
+def get_pexels_image_path(query: str, default_path: str) -> str:
+    """Download a Pexels image matching *query* to a temp file and return its path.
+
+    Falls back to *default_path* when PEXELS_API_KEY is absent or the request
+    fails so that carousel creation never hard-crashes on a network error.
+    """
+    try:
+        from cqc_lem.utilities.pexels_helper import get_photo
+        photo = get_photo(query)
+        url = photo.medium  # medium-size JPEG is a good balance for slides
+        suffix = ".jpg"
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
+        urllib.request.urlretrieve(url, tmp.name)
+        return tmp.name
+    except Exception:
+        return default_path
+
+
 def create_ppt_educational_content_carousel(prs: Presentation, carousel: EducationalContentCarousel) -> Presentation:
     """
     Create a PowerPoint presentation for Educational Content Carousel.
@@ -226,8 +246,10 @@ def create_ppt_educational_content_carousel(prs: Presentation, carousel: Educati
     for content in carousel.contents:
         content_slide_args["title"] = content.title
         content_slide_args["body_text"] = content.content
-        content_slide_args["image_path"] = getattr(content, "image_path",
-                                                   default_image_path)  # TODO: Update this with something from pexels or other image grabber function
+        image_path = getattr(content, "image_path", None)
+        content_slide_args["image_path"] = image_path or get_pexels_image_path(
+            content.title or "professional", default_image_path
+        )
         content_slide = random.choice(content_layouts)(
             **content_slide_args
         )
@@ -235,14 +257,15 @@ def create_ppt_educational_content_carousel(prs: Presentation, carousel: Educati
     # Slide 6: Conclusion
     conclusion_layouts = [create_section_title_and_description_layout_slide, create_custom_3_1_layout_slide,
                           create_caption_only_layout_slide]
+    cta_image_path = getattr(carousel.call_to_action, "image_path", None) or get_pexels_image_path(
+        carousel.call_to_action.title or "success", default_image_path
+    )
     conclusion_slide_args = {
         "prs": prs,
         "title": carousel.call_to_action.title,
         "description": carousel.call_to_action.content,
         "subtitle": carousel.call_to_action.content,
-        "image_path": getattr(carousel.call_to_action, "image_path",
-                              default_image_path),
-        # TODO: Update this with something from pexels or other image grabber function
+        "image_path": cta_image_path,
     }
     conclusion_slide = random.choice(conclusion_layouts)(
         **conclusion_slide_args
@@ -276,7 +299,9 @@ def create_ppt_case_study_carousel(prs: Presentation, case_study_carousel: CaseS
         'prs': prs,
         'title': case_study_carousel.challenge.title,
         'body_text': case_study_carousel.challenge.content,
-        'image_path': getattr(case_study_carousel.challenge, 'image_path', get_default_image_path())
+        'image_path': getattr(case_study_carousel.challenge, 'image_path', None) or get_pexels_image_path(
+            case_study_carousel.challenge.title or "challenge", get_default_image_path()
+        ),
     }
     challenge_slide = random.choice(challenge_layouts)(**challenge_kwargs)
 
@@ -298,9 +323,11 @@ def create_ppt_case_study_carousel(prs: Presentation, case_study_carousel: CaseS
         'prs': prs,
         'title': case_study_carousel.results.title,
         'body_text': case_study_carousel.results.content,
-        'image_path': getattr(case_study_carousel.results, 'image_path', get_default_image_path()),
+        'image_path': getattr(case_study_carousel.results, 'image_path', None) or get_pexels_image_path(
+            case_study_carousel.results.title or "results", get_default_image_path()
+        ),
         'big_number': getattr(case_study_carousel.results, 'big_number', ''),
-        'subtitle': getattr(case_study_carousel.results, 'subtitle', case_study_carousel.results.content)
+        'subtitle': getattr(case_study_carousel.results, 'subtitle', case_study_carousel.results.content),
     }
     results_slide = random.choice(results_layouts)(**results_kwargs)
 
@@ -342,7 +369,9 @@ def create_ppt_personal_story_carousel(prs: Presentation, carousel: PersonalStor
     for slide_data in carousel.story_slides:
         random.choice(story_layouts)(
             prs=prs, title=slide_data.title, body_text=slide_data.content,
-            image_path=getattr(slide_data, "image_path", default_image)
+            image_path=getattr(slide_data, "image_path", None) or get_pexels_image_path(
+                slide_data.title or "story", default_image
+            ),
         )
 
     create_title_and_body_1_layout_slide(
@@ -369,7 +398,9 @@ def create_ppt_industry_insights_carousel(prs: Presentation, carousel: IndustryI
     for insight in carousel.insights:
         random.choice(insight_layouts)(
             prs=prs, title=insight.title, body_text=insight.content,
-            image_path=getattr(insight, "image_path", default_image)
+            image_path=getattr(insight, "image_path", None) or get_pexels_image_path(
+                insight.title or "industry", default_image
+            ),
         )
 
     cta_layouts = [create_section_title_and_description_layout_slide, create_custom_3_1_layout_slide]
@@ -393,7 +424,9 @@ def create_ppt_event_recap_carousel(prs: Presentation, carousel: EventRecapCarou
     for moment in carousel.key_moments:
         random.choice(moment_layouts)(
             prs=prs, title=moment.title, body_text=moment.content,
-            image_path=getattr(moment, "image_path", default_image)
+            image_path=getattr(moment, "image_path", None) or get_pexels_image_path(
+                moment.title or "event", default_image
+            ),
         )
 
     cta_layouts = [create_section_title_and_description_layout_slide, create_custom_3_1_layout_slide]
@@ -436,13 +469,17 @@ def create_ppt_product_demo_carousel(prs: Presentation, carousel: ProductDemoCar
     feature_layouts = [create_title_and_body_layout_slide, create_one_column_text_layout_slide]
     random.choice(feature_layouts)(
         prs=prs, title=carousel.main_feature.title, body_text=carousel.main_feature.content,
-        image_path=getattr(carousel.main_feature, "image_path", default_image)
+        image_path=getattr(carousel.main_feature, "image_path", None) or get_pexels_image_path(
+            carousel.main_feature.title or "product", default_image
+        ),
     )
 
     for feature in carousel.additional_features:
         random.choice(feature_layouts)(
             prs=prs, title=feature.title, body_text=feature.content,
-            image_path=getattr(feature, "image_path", default_image)
+            image_path=getattr(feature, "image_path", None) or get_pexels_image_path(
+                feature.title or "feature", default_image
+            ),
         )
 
     cta_layouts = [create_section_title_and_description_layout_slide, create_custom_3_1_layout_slide]

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1,6 +1,8 @@
+import json
 import os
 from datetime import datetime, timedelta, timezone
 from enum import StrEnum
+from typing import Optional
 
 import mysql.connector
 from cqc_lem.utilities.env_constants import AWS_MYSQL_SECRET_NAME, AWS_REGION
@@ -175,8 +177,8 @@ def add_user_with_access_token(email: str, linked_sub_id: str, access_token: str
         refresh_token_created_at = None
 
     try:
-        cursor.execute("""INSERT INTO users (email, linked_sub_id, access_token, access_token_expires_in, access_token_created_at, refresh_token, refresh_token_expires_in, refresh_token_created_at) 
-        VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+        cursor.execute("""INSERT INTO users (email, linked_sub_id, access_token, access_token_expires_in, access_token_created_at, refresh_token, refresh_token_expires_in, refresh_token_created_at, last_login, linkedin_connection_status)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, 'connected')
         ON DUPLICATE KEY UPDATE
                 linked_sub_id = VALUES(linked_sub_id),
                 access_token = VALUES(access_token),
@@ -184,13 +186,16 @@ def add_user_with_access_token(email: str, linked_sub_id: str, access_token: str
                 access_token_created_at = VALUES(access_token_created_at),
                 refresh_token = VALUES(refresh_token),
                 refresh_token_expires_in = VALUES(refresh_token_expires_in),
-                refresh_token_created_at = VALUES(refresh_token_created_at)
-                
+                refresh_token_created_at = VALUES(refresh_token_created_at),
+                last_login = VALUES(last_login),
+                linkedin_connection_status = 'connected'
+
         """, (
             email,
             linked_sub_id,
             access_token, access_token_expires_in, access_token_created_at,
-            refresh_token, refresh_token_expires_in, refresh_token_created_at))
+            refresh_token, refresh_token_expires_in, refresh_token_created_at,
+            datetime.now(timezone.utc)))
         connection.commit()
     except mysql.connector.Error as e:
         if e.errno == errorcode.ER_DUP_ENTRY:
@@ -259,7 +264,8 @@ def get_user_id(email: str):
     return user_id['id'] if user_id else None
 
 
-def insert_post(email: str, content: str, scheduled_time: datetime, post_type: PostType) -> bool:
+def insert_post(email: str, content: str, scheduled_time: datetime, post_type: PostType,
+                video_url: Optional[str] = None, carousel_slides: Optional[list[str]] = None) -> bool:
     user_id = get_user_id(email)
 
     success = False
@@ -272,16 +278,17 @@ def insert_post(email: str, content: str, scheduled_time: datetime, post_type: P
     cursor = connection.cursor()
 
     try:
-        # Convert scheduled_time to UTC
         if scheduled_time.tzinfo is None:
             scheduled_time = scheduled_time.replace(tzinfo=timezone.utc)
         else:
             scheduled_time = scheduled_time.astimezone(timezone.utc)
 
+        slides_json = json.dumps(carousel_slides) if carousel_slides else None
+
         cursor.execute("""
-            INSERT INTO posts (content, scheduled_time, post_type, user_id)
-            VALUES (%s, %s, %s, %s)
-        """, (content, scheduled_time, post_type.value, user_id))
+            INSERT INTO posts (content, scheduled_time, post_type, user_id, video_url, carousel_slides)
+            VALUES (%s, %s, %s, %s, %s, %s)
+        """, (content, scheduled_time, post_type.value, user_id, video_url, slides_json))
 
         connection.commit()
         success = cursor.rowcount == 1
@@ -429,23 +436,41 @@ def update_db_post_status(post_id: int, post_status: PostStatus) -> bool:
     return success
 
 
-def get_posts(user_id: int):
+def get_posts(user_id: int, limit: int = 10, offset: int = 0,
+              sort_order: str = 'asc', status_filter: Optional[str] = None) -> tuple[list, int]:
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
 
+    order = 'ASC' if sort_order.lower() != 'desc' else 'DESC'
+
     try:
+        where = "WHERE user_id = %s"
+        params: list = [user_id]
+        if status_filter:
+            where += " AND status = %s"
+            params.append(status_filter.lower())
+
         cursor.execute(
-            "SELECT id, content, video_url, scheduled_time, post_type, status FROM posts WHERE user_id = %s ORDER BY scheduled_time asc",
-            (user_id,))
+            f"SELECT COUNT(*) AS total FROM posts {where}",
+            params
+        )
+        total = cursor.fetchone()['total']
+
+        cursor.execute(
+            f"SELECT id, content, video_url, scheduled_time, post_type, status, carousel_slides "
+            f"FROM posts {where} ORDER BY scheduled_time {order} LIMIT %s OFFSET %s",
+            params + [limit, offset]
+        )
         posts = cursor.fetchall()
     except mysql.connector.Error as err:
         myprint(f"Could not get posts for user id: {user_id} | Error: {err}")
-        posts = None
+        posts = []
+        total = 0
     finally:
         cursor.close()
         connection.close()
 
-    return posts
+    return posts, total
 
 
 def get_posted_posts(user_id: int):
@@ -468,14 +493,15 @@ def get_posted_posts(user_id: int):
     return posts
 
 
-def get_post_by_email(email: str):
+def get_post_by_email(email: str, limit: int = 10, offset: int = 0,
+                      sort_order: str = 'asc', status_filter: Optional[str] = None) -> tuple[list, int]:
     user_id = get_user_id(email)
 
     if not user_id:
         print(f"User with email {email} not found.")
-        return
+        return [], 0
 
-    return get_posts(user_id)
+    return get_posts(user_id, limit=limit, offset=offset, sort_order=sort_order, status_filter=status_filter)
 
 
 def get_post_content(post_id: int):
@@ -530,6 +556,103 @@ def get_post_video_url(post_id: int):
         connection.close()
 
     return post['video_url'] if post else None
+
+
+def get_post_type(post_id: int) -> Optional[PostType]:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+
+    try:
+        cursor.execute("SELECT post_type FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get post_type for post id: {post_id} | Error: {err}")
+        row = None
+    finally:
+        cursor.close()
+        connection.close()
+
+    if row:
+        try:
+            return PostType(row['post_type'])
+        except ValueError:
+            return None
+    return None
+
+
+def get_carousel_slides(post_id: int) -> list[str]:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+
+    try:
+        cursor.execute("SELECT carousel_slides FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get carousel_slides for post id: {post_id} | Error: {err}")
+        row = None
+    finally:
+        cursor.close()
+        connection.close()
+
+    if row and row['carousel_slides']:
+        try:
+            slides = row['carousel_slides']
+            if isinstance(slides, str):
+                slides = json.loads(slides)
+            return slides if isinstance(slides, list) else []
+        except (json.JSONDecodeError, TypeError):
+            return []
+    return []
+
+
+def bulk_update_posts(post_ids: list[int], status: Optional[PostStatus] = None,
+                      scheduled_time: Optional[datetime] = None) -> bool:
+    if not post_ids:
+        return False
+
+    connection = get_db_connection()
+    cursor = connection.cursor()
+
+    success = False
+    try:
+        sets = []
+        params: list = []
+
+        if status is not None:
+            sets.append("status = %s")
+            params.append(status.value)
+        if scheduled_time is not None:
+            if scheduled_time.tzinfo is None:
+                scheduled_time = scheduled_time.replace(tzinfo=timezone.utc)
+            else:
+                scheduled_time = scheduled_time.astimezone(timezone.utc)
+            sets.append("scheduled_time = %s")
+            params.append(scheduled_time)
+
+        if not sets:
+            return False
+
+        placeholders = ', '.join(['%s'] * len(post_ids))
+        params.extend(post_ids)
+
+        cursor.execute(
+            f"UPDATE posts SET {', '.join(sets)} WHERE id IN ({placeholders})",
+            params
+        )
+        connection.commit()
+        success = cursor.rowcount > 0
+    except mysql.connector.Error as e:
+        myprint(f"Could not bulk update posts. An error occurred: {e}")
+        success = False
+    finally:
+        cursor.close()
+        connection.close()
+
+    return success
+
+
+def soft_delete_posts(post_ids: list[int]) -> bool:
+    return bulk_update_posts(post_ids, status=PostStatus.REJECTED)
 
 
 def get_ready_to_post_posts(pre_post_time: datetime = None, post_time_delta_minutes=20) -> list:
@@ -606,19 +729,20 @@ def get_active_user_password_pairs():
     return user_password_pairs
 
 
-def add_linkedin_profile(profile: LinkedInProfile):
+def add_linkedin_profile(profile: LinkedInProfile, user_id: Optional[int] = None):
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         cursor.execute("""
-            INSERT INTO profiles (profile_url, email, data) 
-            VALUES (%s, %s, %s)
+            INSERT INTO profiles (profile_url, email, data, user_id)
+            VALUES (%s, %s, %s, %s)
             ON DUPLICATE KEY UPDATE
                     profile_url = VALUES(profile_url),
                     email = VALUES(email),
-                    data = VALUES(data)
+                    data = VALUES(data),
+                    user_id = COALESCE(VALUES(user_id), user_id)
             """,
-                       (str(profile.profile_url), profile.email, profile.model_dump_json()))
+                       (str(profile.profile_url), profile.email, profile.model_dump_json(), user_id))
 
         connection.commit()
         success = True
@@ -669,6 +793,41 @@ def get_linked_in_profile_by_email(profile_email: str, updated_less_than_days_ag
         connection.close()
 
     return profile_data
+
+
+def get_linked_in_profile_by_user_id(user_id: int, updated_less_than_days_ago: int = 1):
+    connection = get_db_connection()
+    cursor = connection.cursor()
+
+    try:
+        cursor.execute("SELECT data FROM profiles WHERE user_id = %s AND updated_at > NOW() - INTERVAL %s DAY",
+                       (user_id, updated_less_than_days_ago))
+        profile_data = cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get linkedin profile data by user_id | Error: {err}")
+        profile_data = None
+    finally:
+        cursor.close()
+        connection.close()
+
+    return profile_data
+
+
+def remove_linked_in_profile_by_user_id(user_id: int):
+    connection = get_db_connection()
+    cursor = connection.cursor()
+
+    try:
+        cursor.execute("DELETE FROM profiles WHERE user_id = %s", (user_id,))
+        connection.commit()
+        success = True
+    except mysql.connector.Error as err:
+        myprint(f"Could not remove linkedin profile by user_id | Error: {err}")
+        success = False
+    finally:
+        cursor.close()
+        connection.close()
+    return success
 
 
 def remove_linked_in_profile_by_url(profile_url: str):
@@ -735,11 +894,11 @@ def get_planned_posts_for_current_week(user_id: int = None):
 
     try:
         cursor.execute(
-            f"SELECT user_id, id, post_type, buyer_stage FROM posts WHERE status = 'planning' {where_clause} AND WEEK(scheduled_time) = WEEK(NOW())")
+            f"SELECT user_id, id, post_type, buyer_stage FROM posts WHERE status = 'planning' {where_clause} AND YEARWEEK(scheduled_time, 1) = YEARWEEK(NOW(), 1)")
         planned_content = cursor.fetchall()
     except mysql.connector.Error as err:
         myprint(f"Could not get planned post for current week | Error: {err}")
-        planned_content = None
+        planned_content = []
     finally:
         cursor.close()
         connection.close()
@@ -758,11 +917,11 @@ def get_planned_posts_for_next_week(user_id: int = None):
 
     try:
         cursor.execute(
-            f"SELECT user_id, id, post_type, buyer_stage FROM posts WHERE status = 'planning' {where_clause} AND WEEK(scheduled_time) = WEEK(NOW()) +1")
+            f"SELECT user_id, id, post_type, buyer_stage FROM posts WHERE status = 'planning' {where_clause} AND YEARWEEK(scheduled_time, 1) = YEARWEEK(NOW() + INTERVAL 7 DAY, 1)")
         planned_content = cursor.fetchall()
     except mysql.connector.Error as err:
         myprint(f"Could not get planned post for next week | Error: {err}")
-        planned_content = None
+        planned_content = []
     finally:
         cursor.close()
         connection.close()
@@ -855,14 +1014,45 @@ def update_user(user_id: int, email: str = None, blog_url: str = None, sitemap_u
 
 
 def get_active_user_ids():
-    """Query the database to get the user ids of active users."""
+    """Return user IDs eligible for automated posting/engagement.
+
+    A user is active when ALL of:
+      1. Has a valid LinkedIn connection (linkedin_connection_status = 'connected'
+         AND access_token not expired)
+      2. Has an active subscription OR an unexpired trial
+      3. Has logged in within their configured inactivate delay
+         (NULL delay = never auto-inactivate)
+    """
     connection = get_db_connection()
     cursor = connection.cursor()
-
     try:
-        cursor.execute(
-            "SELECT id FROM users WHERE last_login >= NOW() - INTERVAL 30 DAY OR subscription_status = 'active'"
-        )
+        cursor.execute("""
+            SELECT id FROM users
+            WHERE
+                -- Must have a live LinkedIn token
+                linkedin_connection_status = 'connected'
+                AND access_token IS NOT NULL
+                AND access_token_created_at IS NOT NULL
+                AND access_token_created_at + INTERVAL access_token_expires_in SECOND > NOW()
+
+                -- Must have an active or unexpired trial subscription
+                AND (
+                    subscription_status = 'active'
+                    OR (
+                        subscription_status = 'trial'
+                        AND (trial_ends_at IS NULL OR trial_ends_at > NOW())
+                    )
+                )
+
+                -- Must have logged in within their configured inactivity window
+                AND (
+                    last_login_inactivate_delay IS NULL
+                    OR (
+                        last_login IS NOT NULL
+                        AND last_login >= NOW() - INTERVAL last_login_inactivate_delay DAY
+                    )
+                )
+        """)
         active_user_ids = [row[0] for row in cursor.fetchall()]
     except mysql.connector.Error as err:
         myprint(f"Could not get active user ids | Error: {err}")
@@ -1084,3 +1274,439 @@ def update_user_settings(user_id: int, blog_url: str = None, sitemap_url: str = 
         connection.close()
 
     return success
+
+
+# ---------------------------------------------------------------------------
+# PIN authentication
+# ---------------------------------------------------------------------------
+
+def create_pin_for_email(email: str, pin_hash: str) -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("DELETE FROM email_pin_auth WHERE email = %s AND used = 0", (email,))
+        expires_at = datetime.now(timezone.utc) + timedelta(minutes=10)
+        cursor.execute(
+            "INSERT INTO email_pin_auth (email, pin, expires_at) VALUES (%s, %s, %s)",
+            (email, pin_hash, expires_at),
+        )
+        connection.commit()
+        return cursor.rowcount == 1
+    except mysql.connector.Error as err:
+        myprint(f"Could not create PIN for {email} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def verify_pin_for_email(email: str, pin_hash: str) -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            """SELECT id FROM email_pin_auth
+               WHERE email = %s AND pin = %s AND used = 0 AND expires_at > %s
+               ORDER BY id DESC LIMIT 1""",
+            (email, pin_hash, datetime.now(timezone.utc)),
+        )
+        row = cursor.fetchone()
+        if row:
+            cursor.execute("UPDATE email_pin_auth SET used = 1 WHERE id = %s", (row['id'],))
+            connection.commit()
+            return True
+        return False
+    except mysql.connector.Error as err:
+        myprint(f"Could not verify PIN for {email} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+# ---------------------------------------------------------------------------
+# Session management
+# ---------------------------------------------------------------------------
+
+def create_session(user_id: int) -> Optional[str]:
+    import secrets
+    token = secrets.token_hex(32)
+    now = datetime.now(timezone.utc)
+    expires_at = now + timedelta(hours=24)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO sessions (session_token, user_id, expires_at) VALUES (%s, %s, %s)",
+            (token, user_id, expires_at),
+        )
+        cursor.execute(
+            "UPDATE users SET last_login = %s WHERE id = %s",
+            (now, user_id),
+        )
+        connection.commit()
+        return token
+    except mysql.connector.Error as err:
+        myprint(f"Could not create session for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_session_user_id(token: str) -> Optional[int]:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT user_id FROM sessions WHERE session_token = %s AND expires_at > %s",
+            (token, datetime.now(timezone.utc)),
+        )
+        row = cursor.fetchone()
+        return row['user_id'] if row else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not validate session token | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def delete_session(token: str) -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("DELETE FROM sessions WHERE session_token = %s", (token,))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not delete session | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+# ---------------------------------------------------------------------------
+# User helpers
+# ---------------------------------------------------------------------------
+
+def add_user_by_email(email: str) -> Optional[int]:
+    from cqc_lem.utilities.env_constants import FREE_TRIAL_DAYS
+    now = datetime.now(timezone.utc)
+    trial_ends = now + timedelta(days=FREE_TRIAL_DAYS)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            """INSERT INTO users
+               (email, subscription_status, subscription_tier, trial_started_at, trial_ends_at)
+               VALUES (%s, 'trial', 'free_trial', %s, %s)""",
+            (email, now, trial_ends),
+        )
+        connection.commit()
+        user_id = cursor.lastrowid
+        # Create a Stripe customer in the background (non-fatal if it fails)
+        try:
+            from cqc_lem.utilities.stripe_util import create_stripe_customer
+            stripe_cid = create_stripe_customer(email, user_id)
+            if stripe_cid:
+                cursor.execute(
+                    "UPDATE users SET stripe_customer_id = %s WHERE id = %s",
+                    (stripe_cid, user_id),
+                )
+                connection.commit()
+        except Exception as se:
+            myprint(f"Stripe customer creation non-fatal error for {email}: {se}")
+        return user_id
+    except mysql.connector.Error as err:
+        if err.errno == errorcode.ER_DUP_ENTRY:
+            return get_user_id(email)
+        myprint(f"Could not create user for {email} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_user_email(user_id: int) -> Optional[str]:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute("SELECT email FROM users WHERE id = %s", (user_id,))
+        row = cursor.fetchone()
+        return row['email'] if row else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not get email for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_user_token_info(user_id: int) -> Optional[dict]:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            """SELECT access_token, access_token_expires_in, access_token_created_at,
+                      refresh_token, refresh_token_expires_in, refresh_token_created_at
+               FROM users WHERE id = %s""",
+            (user_id,),
+        )
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get token info for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_user_access_token(
+    user_id: int,
+    access_token: str,
+    expires_in: int,
+    refresh_token: Optional[str] = None,
+    refresh_token_expires_in: Optional[int] = None,
+) -> bool:
+    now = datetime.now(timezone.utc)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        if refresh_token:
+            cursor.execute(
+                """UPDATE users SET
+                       access_token = %s,
+                       access_token_expires_in = %s,
+                       access_token_created_at = %s,
+                       refresh_token = %s,
+                       refresh_token_expires_in = %s,
+                       refresh_token_created_at = %s
+                   WHERE id = %s""",
+                (access_token, expires_in, now,
+                 refresh_token, refresh_token_expires_in, now, user_id),
+            )
+        else:
+            cursor.execute(
+                """UPDATE users SET
+                       access_token = %s,
+                       access_token_expires_in = %s,
+                       access_token_created_at = %s
+                   WHERE id = %s""",
+                (access_token, expires_in, now, user_id),
+            )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update access token for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_user_linkedin_token(
+    user_id: int,
+    linked_sub_id: str,
+    access_token: str,
+    expires_in: int,
+    refresh_token: Optional[str] = None,
+    refresh_token_expires_in: Optional[int] = None,
+    linkedin_email: Optional[str] = None,
+) -> bool:
+    """Write a fresh LinkedIn OAuth token to the user identified by user_id.
+
+    Called from the OAuth callback so the token is always attached to the
+    logged-in user, regardless of which email LinkedIn returns.
+    """
+    now = datetime.now(timezone.utc)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        if refresh_token:
+            cursor.execute(
+                """UPDATE users SET
+                       linked_sub_id = %s,
+                       linkedin_email = %s,
+                       access_token = %s,
+                       access_token_expires_in = %s,
+                       access_token_created_at = %s,
+                       refresh_token = %s,
+                       refresh_token_expires_in = %s,
+                       refresh_token_created_at = %s,
+                       linkedin_connection_status = 'connected'
+                   WHERE id = %s""",
+                (linked_sub_id, linkedin_email or None, access_token, expires_in, now,
+                 refresh_token, refresh_token_expires_in, now, user_id),
+            )
+        else:
+            cursor.execute(
+                """UPDATE users SET
+                       linked_sub_id = %s,
+                       linkedin_email = %s,
+                       access_token = %s,
+                       access_token_expires_in = %s,
+                       access_token_created_at = %s,
+                       linkedin_connection_status = 'connected'
+                   WHERE id = %s""",
+                (linked_sub_id, linkedin_email or None, access_token, expires_in, now, user_id),
+            )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update LinkedIn token for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_linkedin_connection_status(user_id: int, status: str) -> bool:
+    """Set linkedin_connection_status to 'connected', 'expired', or 'disconnected'."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE users SET linkedin_connection_status = %s WHERE id = %s",
+            (status, user_id),
+        )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update linkedin_connection_status for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_user_subscription_info(user_id: int) -> Optional[dict]:
+    """Return subscription fields for the given user."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            """SELECT subscription_status, subscription_tier,
+                      trial_started_at, trial_ends_at,
+                      stripe_customer_id, stripe_subscription_id
+               FROM users WHERE id = %s""",
+            (user_id,),
+        )
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get subscription info for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_subscription_from_stripe(
+    stripe_customer_id: str,
+    status: str,
+    tier: Optional[str],
+    subscription_id: Optional[str],
+    current_period_end: Optional[datetime] = None,
+) -> bool:
+    """Called from Stripe webhook handler to sync subscription state.
+
+    When tier is None (e.g. subscription deleted) we preserve the existing tier so
+    historical data is retained. Pass an explicit empty string to clear it.
+    """
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        if tier is not None:
+            cursor.execute(
+                """UPDATE users
+                   SET subscription_status = %s,
+                       subscription_tier = %s,
+                       stripe_subscription_id = %s,
+                       subscription_current_period_end = %s
+                   WHERE stripe_customer_id = %s""",
+                (status, tier, subscription_id, current_period_end, stripe_customer_id),
+            )
+        else:
+            # Don't overwrite the tier — preserve it for historical reference
+            cursor.execute(
+                """UPDATE users
+                   SET subscription_status = %s,
+                       stripe_subscription_id = %s,
+                       subscription_current_period_end = %s
+                   WHERE stripe_customer_id = %s""",
+                (status, subscription_id, current_period_end, stripe_customer_id),
+            )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update subscription from Stripe for customer {stripe_customer_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_users_with_stripe_subscriptions() -> list[dict]:
+    """Return all users that have a Stripe subscription ID (for periodic sync)."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            """SELECT id, stripe_customer_id, stripe_subscription_id,
+                      subscription_status, subscription_tier
+               FROM users
+               WHERE stripe_subscription_id IS NOT NULL
+                 AND subscription_status IN ('active', 'past_due')"""
+        )
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        myprint(f"Could not fetch Stripe subscribers | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_user_preferences(user_id: int) -> Optional[dict]:
+    """Return user preference fields: last_login_inactivate_delay and auto_schedule_posts."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT last_login_inactivate_delay, auto_schedule_posts FROM users WHERE id = %s",
+            (user_id,),
+        )
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get preferences for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_user_preferences(
+    user_id: int,
+    inactivate_delay: Optional[int],
+    auto_schedule_posts: bool,
+) -> bool:
+    """Persist user-configurable inactivity delay (None = never) and auto-schedule flag."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            """UPDATE users
+               SET last_login_inactivate_delay = %s,
+                   auto_schedule_posts = %s
+               WHERE id = %s""",
+            (inactivate_delay, 1 if auto_schedule_posts else 0, user_id),
+        )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update preferences for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -992,6 +992,41 @@ def has_engaged_url_with_x_days(user_id: int, post_url: str, days: int):
     return count > 0
 
 
+def get_dm_history_for_profile(user_id: int, profile_url: str) -> list[str]:
+    """Return all DM messages previously sent by user_id to profile_url, oldest first."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT message FROM logs WHERE user_id = %s AND post_url = %s AND action_type = %s ORDER BY created_at ASC",
+            (user_id, profile_url, LogActionType.DM.value),
+        )
+        rows = cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get DM history for profile | Error: {err}")
+        rows = []
+    finally:
+        cursor.close()
+        connection.close()
+    return [row[0] for row in rows if row[0]]
+
+
+def get_post_status(post_id: int) -> str | None:
+    """Return the current status string of a post, or None if not found."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT status FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get post status | Error: {err}")
+        row = None
+    finally:
+        cursor.close()
+        connection.close()
+    return row[0] if row else None
+
+
 def get_company_linked_in_url_for_user(user_id: int):
     connection = get_db_connection()
     cursor = connection.cursor()

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -1,0 +1,107 @@
+import hashlib
+import random
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Tuple
+
+from cqc_lem.utilities.env_constants import (
+    SENDGRID_API_KEY,
+    SENDGRID_FROM_EMAIL,
+    SMTP_HOST,
+    SMTP_PASSWORD,
+    SMTP_PORT,
+    SMTP_USER,
+)
+from cqc_lem.utilities.logger import myprint
+
+
+def generate_pin() -> str:
+    return str(random.randint(0, 999999)).zfill(6)
+
+
+def hash_pin(pin: str, email: str) -> str:
+    return hashlib.sha256(f"{pin}{email}".encode()).hexdigest()
+
+
+def _build_html(pin: str, action: str) -> str:
+    return f"""
+    <html><body>
+    <h2>Your LinkedIn Engagement Manager Verification Code</h2>
+    <p>Enter the following code to {action}:</p>
+    <h1 style="letter-spacing:0.3em;font-family:monospace;">{pin}</h1>
+    <p>This code expires in <strong>10 minutes</strong>.</p>
+    <p style="color:#888;font-size:12px;">If you did not request this, you can safely ignore this email.</p>
+    </body></html>
+    """
+
+
+def _send_via_sendgrid(to_email: str, html_content: str) -> bool:
+    from sendgrid import SendGridAPIClient
+    from sendgrid.helpers.mail import Mail
+
+    message = Mail(
+        from_email=SENDGRID_FROM_EMAIL,
+        to_emails=to_email,
+        subject="Your LEM Verification Code",
+        html_content=html_content,
+    )
+    try:
+        sg = SendGridAPIClient(SENDGRID_API_KEY)
+        sg.send(message)
+        myprint(f"PIN email sent via SendGrid to {to_email}")
+        return True
+    except Exception as e:
+        myprint(f"SendGrid send failed for {to_email}: {e}")
+        return False
+
+
+def _send_via_smtp(to_email: str, html_content: str) -> bool:
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "Your LEM Verification Code"
+    msg["From"] = SMTP_USER
+    msg["To"] = to_email
+    msg.attach(MIMEText(html_content, "html"))
+    try:
+        with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=15) as server:
+            server.ehlo()
+            server.starttls()
+            server.login(SMTP_USER, SMTP_PASSWORD)
+            server.sendmail(SMTP_USER, to_email, msg.as_string())
+        myprint(f"PIN email sent via SMTP to {to_email}")
+        return True
+    except Exception as e:
+        myprint(f"SMTP send failed for {to_email}: {e}")
+        return False
+
+
+def send_pin_email(to_email: str, pin: str, is_new_user: bool = False) -> Tuple[bool, bool]:
+    """Send a PIN email using the best available provider.
+
+    Returns (success, bypassed):
+      - (True, False)  — email was sent successfully
+      - (False, False) — a provider is configured but the send failed
+      - (True, True)   — no provider is configured; PIN step should be skipped
+    """
+    action = "create your account" if is_new_user else "sign in"
+    html = _build_html(pin, action)
+
+    has_sendgrid = bool(SENDGRID_API_KEY)
+    has_smtp = bool(SMTP_USER) and bool(SMTP_PASSWORD)
+
+    if not has_sendgrid and not has_smtp:
+        myprint("No email provider configured — bypassing PIN verification")
+        return True, True
+
+    if has_sendgrid:
+        sent = _send_via_sendgrid(to_email, html)
+        if sent:
+            return True, False
+        myprint("SendGrid failed — trying SMTP fallback")
+
+    if has_smtp:
+        sent = _send_via_smtp(to_email, html)
+        return sent, False
+
+    # SendGrid was configured but failed; no SMTP fallback available
+    return False, False

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -33,7 +33,7 @@ LI_CLIENT_ID = get_constant_from_env('LI_CLIENT_ID')
 LI_CLIENT_SECRET = get_constant_from_env('LI_CLIENT_SECRET')
 LI_REDIRECT_URL = get_constant_from_env('LI_REDIRECT_URL')
 LI_STATE_SALT = get_constant_from_env('LI_STATE_SALT')
-LI_API_VERSION = get_constant_from_env('LI_API_VERSION', default_value='202401')
+LI_API_VERSION = get_constant_from_env('LI_API_VERSION', default_value='202501')
 PEXELS_API_KEY = get_constant_from_env('PEXELS_API_KEY')
 HF_TOKEN = get_constant_from_env('HF_TOKEN')
 REPLICATE_API_TOKEN = get_constant_from_env('REPLICATE_API_TOKEN')
@@ -81,6 +81,22 @@ if NGROK_FREE_DOMAIN and NGROK_API_PREFIX:
 else:
     API_BASE_URL = get_constant_from_env('API_BASE_URL', default_value='http://localhost')
     API_URL_FINAL = f"{API_BASE_URL}:{API_PORT}"
+
+SENDGRID_API_KEY     = get_constant_from_env('SENDGRID_API_KEY')
+SENDGRID_FROM_EMAIL  = get_constant_from_env('SENDGRID_FROM_EMAIL', default_value='noreply@example.com')
+
+# SMTP fallback (Gmail or any STARTTLS-capable server)
+SMTP_HOST     = get_constant_from_env('SMTP_HOST', default_value='smtp.gmail.com')
+SMTP_PORT     = int(get_constant_from_env('SMTP_PORT', default_value='587'))
+SMTP_USER     = get_constant_from_env('SMTP_USER')
+SMTP_PASSWORD = get_constant_from_env('SMTP_PASSWORD')
+
+STRIPE_API_KEY            = get_constant_from_env('STRIPE_API_KEY')
+STRIPE_WEBHOOK_SECRET     = get_constant_from_env('STRIPE_WEBHOOK_SECRET')
+STRIPE_PRICE_ID_STARTER       = get_constant_from_env('STRIPE_PRICE_ID_STARTER')
+STRIPE_PRICE_ID_PROFESSIONAL  = get_constant_from_env('STRIPE_PRICE_ID_PROFESSIONAL')
+STRIPE_PRICE_ID_ENTERPRISE    = get_constant_from_env('STRIPE_PRICE_ID_ENTERPRISE')
+FREE_TRIAL_DAYS           = int(get_constant_from_env('FREE_TRIAL_DAYS', default_value='14'))
 
 NGROK_LIPREVIEW_PREFIX=get_constant_from_env('NGROK_LIPREVIEW_PREFIX')
 if NGROK_FREE_DOMAIN and NGROK_LIPREVIEW_PREFIX:

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -1,8 +1,9 @@
 import time
+from typing import Optional
 
 from cqc_lem.utilities.ai.ai_helper import get_industries_of_profile_from_ai
 from cqc_lem.utilities.db import get_cookies, store_cookies, get_linked_in_profile_by_email, add_linkedin_profile, \
-    get_linked_in_profile_by_url
+    get_linked_in_profile_by_url, get_linked_in_profile_by_user_id
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.linkedin.scrapper import returnProfileInfo
 from cqc_lem.utilities.logger import myprint
@@ -77,11 +78,14 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
             # are_you_satisfied()
 
 
-def get_my_profile(driver, wait, user_email: str, user_password: str) -> LinkedInProfile:
+def get_my_profile(driver, wait, user_email: str, user_password: str, user_id: Optional[int] = None) -> LinkedInProfile:
     profile = None
 
-    # Check DB for serialized instance of profile
-    profile_json = get_linked_in_profile_by_email(user_email)
+    # Prefer user_id-based cache key; fall back to email for backward compat.
+    if user_id is not None:
+        profile_json = get_linked_in_profile_by_user_id(user_id)
+    else:
+        profile_json = get_linked_in_profile_by_email(user_email)
 
     if profile_json is None:
         myprint(f"Previous Profile not found (or stale) in DB: {user_email}")
@@ -102,7 +106,7 @@ def get_my_profile(driver, wait, user_email: str, user_password: str) -> LinkedI
             profile.password = user_password
 
             # Add profile to DB for faster future retrieval
-            if add_linkedin_profile(profile):
+            if add_linkedin_profile(profile, user_id=user_id):
                 myprint(f"Profile saved to DB: {profile.full_name}")
             else:
                 myprint(f"Failed to save profile to DB: {profile.full_name}")

--- a/src/cqc_lem/utilities/linkedin/poster.py
+++ b/src/cqc_lem/utilities/linkedin/poster.py
@@ -205,3 +205,67 @@ def share_on_linkedin(user_id: int, content: str,
 
     return urn
 
+
+def share_carousel_on_linkedin(user_id: int, content: str, slide_texts: list[str]) -> Optional[str]:
+    """Post a multi-image carousel to LinkedIn.
+
+    Each slide text is used to fetch a contextual image from Pexels. All images
+    are uploaded individually and included as a multi-image ugcPost.
+    """
+    import os
+    from cqc_lem.utilities.carousel_creator import get_pexels_image_path
+
+    restli_client = RestliClient()
+    restli_client.session.hooks["response"].append(lambda r: r.raise_for_status())
+
+    linked_sub_id = get_user_linked_sub_id(user_id)
+    access_token = get_user_access_token(user_id)
+
+    if not linked_sub_id or not access_token:
+        myprint(f"No LinkedIn credentials found for user {user_id} — cannot post carousel")
+        return None
+
+    file_dir = os.path.dirname(os.path.abspath(__file__))
+    default_image_path = os.path.join(file_dir, "..", "carousel_creator", "images", "image.png")
+
+    media_urns = []
+    for slide_text in slide_texts:
+        image_path = get_pexels_image_path(slide_text, default_image_path)
+        myprint(f"Carousel slide image: {image_path}")
+        urn = upload_media(access_token, linked_sub_id, image_path, "IMAGE")
+        if urn:
+            media_urns.append(urn)
+
+    if not media_urns:
+        myprint("No images uploaded for carousel — falling back to text-only post")
+        return share_on_linkedin(user_id, content)
+
+    media_objects = [ShareMedia(status="READY", media=urn).model_dump() for urn in media_urns]
+
+    share_content = ShareContent(
+        shareCommentary={"text": content},
+        shareMediaCategory="IMAGE",
+        media=media_objects,
+    ).model_dump()
+
+    posts_create_response = restli_client.create(
+        resource_path="/ugcPosts",
+        entity={
+            "author": f"urn:li:person:{linked_sub_id}",
+            "lifecycleState": "PUBLISHED",
+            "specificContent": {
+                "com.linkedin.ugc.ShareContent": {
+                    **share_content
+                }
+            },
+            "visibility": {
+                "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+            },
+        },
+        access_token=access_token,
+    )
+
+    urn = posts_create_response.entity_id
+    myprint(f"Carousel shared on LinkedIn: https://www.linkedin.com/feed/update/{urn}")
+    return urn
+

--- a/src/cqc_lem/utilities/linkedin/token_refresh.py
+++ b/src/cqc_lem/utilities/linkedin/token_refresh.py
@@ -1,0 +1,96 @@
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Tuple
+
+import requests
+
+from cqc_lem.utilities.env_constants import LI_CLIENT_ID, LI_CLIENT_SECRET
+from cqc_lem.utilities.logger import myprint
+
+LINKEDIN_TOKEN_URL = "https://www.linkedin.com/oauth/v2/accessToken"
+EXPIRY_WARNING_DAYS = 30
+
+
+def get_token_expiry(token_info: dict) -> Optional[datetime]:
+    created_at = token_info.get('access_token_created_at')
+    expires_in = token_info.get('access_token_expires_in')
+    if not created_at or not expires_in:
+        return None
+    if created_at.tzinfo is None:
+        created_at = created_at.replace(tzinfo=timezone.utc)
+    return created_at + timedelta(seconds=int(expires_in))
+
+
+def is_token_expired(token_info: dict) -> bool:
+    expiry = get_token_expiry(token_info)
+    if expiry is None:
+        return True
+    return expiry <= datetime.now(timezone.utc)
+
+
+def is_token_expiring_soon(token_info: dict, days: int = EXPIRY_WARNING_DAYS) -> bool:
+    expiry = get_token_expiry(token_info)
+    if expiry is None:
+        return True
+    return expiry <= datetime.now(timezone.utc) + timedelta(days=days)
+
+
+def attempt_token_refresh(user_id: int) -> Tuple[bool, Optional[str]]:
+    # Import here to avoid circular imports at module load
+    from cqc_lem.utilities.db import get_user_token_info, update_user_access_token
+
+    token_info = get_user_token_info(user_id)
+    if not token_info:
+        return False, None
+
+    refresh_token = token_info.get('refresh_token')
+    if not refresh_token:
+        myprint(f"No refresh_token for user_id {user_id} — cannot auto-refresh")
+        return False, None
+
+    refresh_created = token_info.get('refresh_token_created_at')
+    refresh_expires_in = token_info.get('refresh_token_expires_in')
+    if refresh_created and refresh_expires_in:
+        if refresh_created.tzinfo is None:
+            refresh_created = refresh_created.replace(tzinfo=timezone.utc)
+        refresh_expiry = refresh_created + timedelta(seconds=int(refresh_expires_in))
+        if refresh_expiry <= datetime.now(timezone.utc):
+            myprint(f"refresh_token expired for user_id {user_id}")
+            return False, None
+
+    try:
+        resp = requests.post(
+            LINKEDIN_TOKEN_URL,
+            data={
+                'grant_type': 'refresh_token',
+                'refresh_token': refresh_token,
+                'client_id': LI_CLIENT_ID,
+                'client_secret': LI_CLIENT_SECRET,
+            },
+            headers={'Content-Type': 'application/x-www-form-urlencoded'},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        new_access_token = data.get('access_token')
+        expires_in = data.get('expires_in')
+        new_refresh_token = data.get('refresh_token')
+        new_refresh_expires_in = data.get('refresh_token_expires_in')
+
+        if not new_access_token:
+            myprint(f"Token refresh response missing access_token for user_id {user_id}")
+            return False, None
+
+        update_user_access_token(
+            user_id,
+            new_access_token,
+            expires_in,
+            refresh_token=new_refresh_token,
+            refresh_token_expires_in=new_refresh_expires_in,
+        )
+        myprint(f"Token refreshed for user_id {user_id}")
+        return True, new_access_token
+
+    except requests.RequestException as e:
+        myprint(f"Token refresh request failed for user_id {user_id}: {e}")
+        return False, None

--- a/src/cqc_lem/utilities/stripe_util.py
+++ b/src/cqc_lem/utilities/stripe_util.py
@@ -1,0 +1,175 @@
+"""
+Stripe billing integration.
+
+Test mode:  set STRIPE_API_KEY=sk_test_... in .env
+Live mode:  set STRIPE_API_KEY=sk_live_... in .env (switch when ready for production)
+
+Create products and prices in the Stripe dashboard, then copy the price IDs
+into STRIPE_PRICE_ID_STARTER / _PROFESSIONAL / _ENTERPRISE in .env.
+
+Webhook:
+  1. Run `stripe listen --forward-to localhost:8000/api/billing/webhook` during local dev
+  2. Copy the printed signing secret into STRIPE_WEBHOOK_SECRET in .env
+  3. In production, set the endpoint URL in your Stripe dashboard and use that secret
+"""
+import json
+from typing import Optional
+
+from cqc_lem.utilities.env_constants import (
+    STRIPE_API_KEY,
+    STRIPE_PRICE_ID_ENTERPRISE,
+    STRIPE_PRICE_ID_PROFESSIONAL,
+    STRIPE_PRICE_ID_STARTER,
+    STRIPE_WEBHOOK_SECRET,
+)
+from cqc_lem.utilities.logger import myprint
+
+# Map tier names → Stripe price IDs (populated from env at import time)
+TIER_PRICE_MAP: dict[str, Optional[str]] = {
+    "starter": STRIPE_PRICE_ID_STARTER,
+    "professional": STRIPE_PRICE_ID_PROFESSIONAL,
+    "enterprise": STRIPE_PRICE_ID_ENTERPRISE,
+}
+
+
+def _get_stripe():
+    """Return the stripe module with the API key configured.
+    Lazy import so the module loads even when STRIPE_API_KEY is unset (e.g. tests).
+    """
+    import stripe as _stripe
+    _stripe.api_key = STRIPE_API_KEY
+    return _stripe
+
+
+def create_stripe_customer(email: str, user_id: int) -> Optional[str]:
+    """Create a Stripe customer for a new user. Returns the customer ID or None on failure."""
+    if not STRIPE_API_KEY:
+        myprint("STRIPE_API_KEY not set — skipping Stripe customer creation")
+        return None
+    stripe = _get_stripe()
+    try:
+        customer = stripe.Customer.create(
+            email=email,
+            metadata={"user_id": str(user_id)},
+        )
+        myprint(f"Stripe customer created: {customer.id} for user_id={user_id}")
+        return customer.id
+    except Exception as e:
+        myprint(f"Stripe customer creation failed for user_id={user_id}: {e}")
+        return None
+
+
+def create_checkout_session(
+    stripe_customer_id: str,
+    tier: str,
+    success_url: str,
+    cancel_url: str,
+) -> Optional[str]:
+    """Create a Stripe Checkout session for a subscription upgrade.
+    Returns the checkout session URL, or None on failure.
+    """
+    price_id = TIER_PRICE_MAP.get(tier)
+    if not price_id:
+        myprint(f"No Stripe price ID configured for tier '{tier}'")
+        return None
+    if not STRIPE_API_KEY:
+        myprint("STRIPE_API_KEY not set — cannot create checkout session")
+        return None
+
+    stripe = _get_stripe()
+    try:
+        session = stripe.checkout.Session.create(
+            customer=stripe_customer_id,
+            payment_method_types=["card"],
+            line_items=[{"price": price_id, "quantity": 1}],
+            mode="subscription",
+            success_url=success_url,
+            cancel_url=cancel_url,
+        )
+        return session.url
+    except Exception as e:
+        myprint(f"Stripe checkout session creation failed for customer={stripe_customer_id}: {e}")
+        return None
+
+
+def create_portal_session(stripe_customer_id: str, return_url: str) -> Optional[str]:
+    """Create a Stripe Billing Portal session so users can manage their subscription.
+    Returns the portal URL, or None on failure.
+    """
+    if not STRIPE_API_KEY:
+        myprint("STRIPE_API_KEY not set — cannot create portal session")
+        return None
+    stripe = _get_stripe()
+    try:
+        session = stripe.billing_portal.Session.create(
+            customer=stripe_customer_id,
+            return_url=return_url,
+        )
+        return session.url
+    except Exception as e:
+        myprint(f"Stripe portal session creation failed for customer={stripe_customer_id}: {e}")
+        return None
+
+
+def validate_webhook(payload: bytes, sig_header: str) -> Optional[dict]:
+    """Validate a Stripe webhook event using the signing secret.
+    Returns the event as a plain Python dict on success, None on failure.
+
+    The Stripe SDK v5+ returns a StripeObject (not a dict), which doesn't
+    support .get(). We validate the signature via the SDK, then parse the
+    raw payload as a dict so callers can use normal dict access.
+    """
+    if not STRIPE_WEBHOOK_SECRET:
+        myprint("STRIPE_WEBHOOK_SECRET not set — cannot validate webhook")
+        return None
+    stripe = _get_stripe()
+    try:
+        # Raises on invalid signature — this is the only thing we need the SDK for here
+        stripe.Webhook.construct_event(payload, sig_header, STRIPE_WEBHOOK_SECRET)
+        # Return the raw payload as a plain dict for consistent .get() access
+        return json.loads(payload.decode("utf-8"))
+    except stripe.error.SignatureVerificationError as e:
+        myprint(f"Stripe webhook signature invalid: {e}")
+        return None
+    except Exception as e:
+        myprint(f"Stripe webhook validation failed: {e}")
+        return None
+
+
+def get_subscription_tier_from_price(price_id: str) -> Optional[str]:
+    """Reverse-map a Stripe price ID back to our tier name."""
+    for tier, pid in TIER_PRICE_MAP.items():
+        if pid and pid == price_id:
+            return tier
+    return None
+
+
+# Stripe subscription status → our DB status
+_STRIPE_STATUS_MAP: dict[str, str] = {
+    "active": "active",
+    "trialing": "trial",
+    "past_due": "past_due",
+    "unpaid": "past_due",
+    "canceled": "cancelled",
+    "incomplete": "inactive",
+    "incomplete_expired": "inactive",
+    "paused": "inactive",
+}
+
+
+def stripe_status_to_db(stripe_status: str) -> str:
+    """Convert a Stripe subscription status string to our DB enum value."""
+    return _STRIPE_STATUS_MAP.get(stripe_status, "inactive")
+
+
+def fetch_subscription(stripe_subscription_id: str) -> Optional[dict]:
+    """Retrieve a Stripe subscription object. Returns None on failure."""
+    if not STRIPE_API_KEY:
+        return None
+    stripe = _get_stripe()
+    try:
+        sub = stripe.Subscription.retrieve(stripe_subscription_id)
+        return sub
+    except Exception as e:
+        myprint(f"Could not fetch Stripe subscription {stripe_subscription_id}: {e}")
+        return None

--- a/tests/unit/app/test_run_automation_posting.py
+++ b/tests/unit/app/test_run_automation_posting.py
@@ -1,0 +1,97 @@
+"""Unit tests for post_to_linkedin task — post-type branching."""
+
+import pytest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+
+BASE_PATCHES = [
+    ("cqc_lem.app.run_automation.get_post_status", {"return_value": "approved"}),
+    ("cqc_lem.app.run_automation.get_user_password_pair_by_id", {"return_value": ("u@example.com", "pw")}),
+    ("cqc_lem.app.run_automation.get_post_content", {"return_value": "Post text"}),
+    ("cqc_lem.app.run_automation.insert_new_log", {}),
+    ("cqc_lem.app.run_automation.update_db_post_status", {}),
+    ("cqc_lem.app.run_automation.automate_reply_commenting", {}),
+]
+
+
+@pytest.mark.unit
+class TestPostToLinkedinTypeBranching:
+
+    def test_text_post_calls_share_on_linkedin(self):
+        from cqc_lem.utilities.db import PostType
+        from cqc_lem.app.run_automation import post_to_linkedin
+
+        with ExitStack() as stack:
+            for target, kwargs in BASE_PATCHES:
+                stack.enter_context(patch(target, **kwargs))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_post_type", return_value=PostType.TEXT))
+            mock_share = stack.enter_context(
+                patch("cqc_lem.app.run_automation.share_on_linkedin", return_value="urn:li:ugcPost:1")
+            )
+            mock_carousel = stack.enter_context(
+                patch("cqc_lem.app.run_automation.share_carousel_on_linkedin")
+            )
+
+            post_to_linkedin.run(1, 10)
+
+            mock_share.assert_called_once_with(1, "Post text")
+            mock_carousel.assert_not_called()
+
+    def test_video_post_calls_share_on_linkedin_with_url(self):
+        from cqc_lem.utilities.db import PostType
+        from cqc_lem.app.run_automation import post_to_linkedin
+
+        with ExitStack() as stack:
+            for target, kwargs in BASE_PATCHES:
+                stack.enter_context(patch(target, **kwargs))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_post_type", return_value=PostType.VIDEO))
+            stack.enter_context(
+                patch("cqc_lem.app.run_automation.get_post_video_url", return_value="https://cdn.example.com/v.mp4")
+            )
+            mock_share = stack.enter_context(
+                patch("cqc_lem.app.run_automation.share_on_linkedin", return_value="urn:li:ugcPost:2")
+            )
+            mock_carousel = stack.enter_context(
+                patch("cqc_lem.app.run_automation.share_carousel_on_linkedin")
+            )
+
+            post_to_linkedin.run(1, 20)
+
+            mock_share.assert_called_once_with(1, "Post text", "https://cdn.example.com/v.mp4")
+            mock_carousel.assert_not_called()
+
+    def test_carousel_post_calls_share_carousel_on_linkedin(self):
+        from cqc_lem.utilities.db import PostType
+        from cqc_lem.app.run_automation import post_to_linkedin
+
+        slides = ["Slide one", "Slide two"]
+        with ExitStack() as stack:
+            for target, kwargs in BASE_PATCHES:
+                stack.enter_context(patch(target, **kwargs))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_post_type", return_value=PostType.CAROUSEL))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_carousel_slides", return_value=slides))
+            mock_carousel = stack.enter_context(
+                patch("cqc_lem.app.run_automation.share_carousel_on_linkedin", return_value="urn:li:ugcPost:3")
+            )
+            mock_share = stack.enter_context(
+                patch("cqc_lem.app.run_automation.share_on_linkedin")
+            )
+
+            post_to_linkedin.run(1, 30)
+
+            mock_carousel.assert_called_once_with(1, "Post text", slides)
+            mock_share.assert_not_called()
+
+    def test_skips_already_posted(self):
+        from cqc_lem.app.run_automation import post_to_linkedin
+
+        with patch("cqc_lem.app.run_automation.get_post_status", return_value="posted"), \
+             patch("cqc_lem.app.run_automation.share_on_linkedin") as mock_share, \
+             patch("cqc_lem.app.run_automation.share_carousel_on_linkedin") as mock_carousel:
+
+            result = post_to_linkedin.run(1, 99)
+
+            assert "already posted" in result.lower()
+            mock_share.assert_not_called()
+            mock_carousel.assert_not_called()

--- a/tests/unit/app/test_run_content_plan.py
+++ b/tests/unit/app/test_run_content_plan.py
@@ -1,0 +1,82 @@
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+
+class TestAutoCreateWeeklyContent:
+    """Tests for auto_create_weekly_content — verifies None/empty guards and content-None skip."""
+
+    @patch('cqc_lem.app.run_content_plan.get_planned_posts_for_next_week', return_value=None)
+    @patch('cqc_lem.app.run_content_plan.get_planned_posts_for_current_week', return_value=None)
+    def test_does_not_crash_when_planned_posts_is_none(self, mock_current, mock_next):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        # Should not raise TypeError: 'NoneType' is not iterable
+        auto_create_weekly_content(user_id=1)
+
+    @patch('cqc_lem.app.run_content_plan.get_planned_posts_for_current_week', return_value=[])
+    def test_does_not_crash_when_planned_posts_is_empty(self, mock_current):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        auto_create_weekly_content(user_id=1)
+
+    @patch('cqc_lem.app.run_content_plan.update_db_post_status')
+    @patch('cqc_lem.app.run_content_plan.update_db_post_content')
+    @patch('cqc_lem.app.run_content_plan.create_content', return_value=(None, None))
+    @patch('cqc_lem.app.run_content_plan.get_planned_posts_for_current_week')
+    def test_skips_post_when_content_is_none(
+        self, mock_current, mock_create, mock_update_content, mock_update_status
+    ):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        mock_current.return_value = [
+            {'user_id': 1, 'id': 42, 'post_type': 'text', 'buyer_stage': 'awareness'}
+        ]
+        auto_create_weekly_content(user_id=1)
+        mock_update_content.assert_not_called()
+        mock_update_status.assert_not_called()
+
+    @patch('cqc_lem.app.run_content_plan.get_user_preferences', return_value={'auto_schedule_posts': 0})
+    @patch('cqc_lem.app.run_content_plan.update_db_post_status')
+    @patch('cqc_lem.app.run_content_plan.update_db_post_content')
+    @patch('cqc_lem.app.run_content_plan.create_content', return_value=('Great post content', None))
+    @patch('cqc_lem.app.run_content_plan.get_planned_posts_for_current_week')
+    def test_updates_db_when_content_is_valid(
+        self, mock_current, mock_create, mock_update_content, mock_update_status, mock_prefs
+    ):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        mock_current.return_value = [
+            {'user_id': 1, 'id': 42, 'post_type': 'text', 'buyer_stage': 'awareness'}
+        ]
+        auto_create_weekly_content(user_id=1)
+        mock_update_content.assert_called_once_with(42, 'Great post content')
+        mock_update_status.assert_called_once()
+
+    @patch('cqc_lem.app.run_content_plan.get_user_preferences', return_value={'auto_schedule_posts': 0})
+    @patch('cqc_lem.app.run_content_plan.update_db_post_status')
+    @patch('cqc_lem.app.run_content_plan.update_db_post_content')
+    @patch('cqc_lem.app.run_content_plan.create_content', return_value=('Auto-off content', None))
+    @patch('cqc_lem.app.run_content_plan.get_planned_posts_for_current_week')
+    def test_status_is_pending_when_auto_schedule_off(
+        self, mock_current, mock_create, mock_update_content, mock_update_status, mock_prefs
+    ):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        from cqc_lem.utilities.db import PostStatus
+        mock_current.return_value = [
+            {'user_id': 1, 'id': 55, 'post_type': 'text', 'buyer_stage': 'awareness'}
+        ]
+        auto_create_weekly_content(user_id=1)
+        mock_update_status.assert_called_once_with(55, PostStatus.PENDING)
+
+    @patch('cqc_lem.app.run_content_plan.get_user_preferences', return_value={'auto_schedule_posts': 1})
+    @patch('cqc_lem.app.run_content_plan.update_db_post_status')
+    @patch('cqc_lem.app.run_content_plan.update_db_post_content')
+    @patch('cqc_lem.app.run_content_plan.create_content', return_value=('Auto-on content', None))
+    @patch('cqc_lem.app.run_content_plan.get_planned_posts_for_current_week')
+    def test_status_is_approved_when_auto_schedule_on(
+        self, mock_current, mock_create, mock_update_content, mock_update_status, mock_prefs
+    ):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        from cqc_lem.utilities.db import PostStatus
+        mock_current.return_value = [
+            {'user_id': 2, 'id': 77, 'post_type': 'text', 'buyer_stage': 'decision'}
+        ]
+        auto_create_weekly_content(user_id=2)
+        mock_update_status.assert_called_once_with(77, PostStatus.APPROVED)

--- a/tests/unit/utilities/linkedin/test_token_refresh.py
+++ b/tests/unit/utilities/linkedin/test_token_refresh.py
@@ -1,0 +1,146 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cqc_lem.utilities.linkedin.token_refresh import (
+    attempt_token_refresh,
+    get_token_expiry,
+    is_token_expired,
+    is_token_expiring_soon,
+)
+
+
+def make_token_info(
+    seconds_until_expiry: int,
+    refresh_token: str | None = None,
+    refresh_seconds_remaining: int = 60 * 60 * 24 * 60,
+):
+    now = datetime.now(timezone.utc)
+    info: dict = {
+        'access_token': 'tok_abc',
+        'access_token_created_at': now,
+        'access_token_expires_in': seconds_until_expiry,
+        'refresh_token': refresh_token,
+        'refresh_token_created_at': now if refresh_token else None,
+        'refresh_token_expires_in': refresh_seconds_remaining if refresh_token else None,
+    }
+    return info
+
+
+class TestGetTokenExpiry:
+    def test_returns_correct_expiry(self):
+        now = datetime.now(timezone.utc)
+        info = {'access_token_created_at': now, 'access_token_expires_in': 3600}
+        expiry = get_token_expiry(info)
+        delta = abs((expiry - (now + timedelta(seconds=3600))).total_seconds())
+        assert delta < 1
+
+    def test_returns_none_when_missing_fields(self):
+        assert get_token_expiry({'access_token_created_at': None, 'access_token_expires_in': None}) is None
+        assert get_token_expiry({}) is None
+
+    def test_handles_naive_datetime(self):
+        naive = datetime.utcnow()
+        info = {'access_token_created_at': naive, 'access_token_expires_in': 3600}
+        expiry = get_token_expiry(info)
+        assert expiry is not None
+
+
+class TestIsTokenExpired:
+    def test_fresh_token_not_expired(self):
+        info = make_token_info(seconds_until_expiry=3600)
+        assert not is_token_expired(info)
+
+    def test_expired_token(self):
+        info = make_token_info(seconds_until_expiry=-1)
+        assert is_token_expired(info)
+
+    def test_none_expiry_treated_as_expired(self):
+        assert is_token_expired({})
+
+
+class TestIsTokenExpiringSoon:
+    def test_60_days_not_expiring_soon(self):
+        info = make_token_info(seconds_until_expiry=60 * 24 * 3600)
+        assert not is_token_expiring_soon(info)
+
+    def test_15_days_is_expiring_soon(self):
+        info = make_token_info(seconds_until_expiry=15 * 24 * 3600)
+        assert is_token_expiring_soon(info)
+
+    def test_custom_days_threshold(self):
+        info = make_token_info(seconds_until_expiry=45 * 24 * 3600)
+        assert not is_token_expiring_soon(info, days=30)
+        assert is_token_expiring_soon(info, days=60)
+
+    def test_none_treated_as_expiring_soon(self):
+        assert is_token_expiring_soon({})
+
+
+class TestAttemptTokenRefresh:
+    # The DB functions are imported inside attempt_token_refresh to avoid circular
+    # imports, so we patch them at their source module (cqc_lem.utilities.db).
+
+    @patch('cqc_lem.utilities.linkedin.token_refresh.requests.post')
+    @patch('cqc_lem.utilities.db.update_user_access_token')
+    @patch('cqc_lem.utilities.db.get_user_token_info')
+    def test_successful_refresh(self, mock_get_info, mock_update, mock_post):
+        mock_get_info.return_value = make_token_info(
+            seconds_until_expiry=3600, refresh_token='refresh_tok'
+        )
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            'access_token': 'new_tok',
+            'expires_in': 7200,
+            'refresh_token': 'new_refresh',
+            'refresh_token_expires_in': 60 * 24 * 3600,
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        success, token = attempt_token_refresh(user_id=1)
+        assert success is True
+        assert token == 'new_tok'
+        mock_update.assert_called_once()
+
+    @patch('cqc_lem.utilities.db.get_user_token_info')
+    def test_no_refresh_token_returns_false(self, mock_get_info):
+        mock_get_info.return_value = make_token_info(
+            seconds_until_expiry=3600, refresh_token=None
+        )
+        success, token = attempt_token_refresh(user_id=1)
+        assert success is False
+        assert token is None
+
+    @patch('cqc_lem.utilities.db.get_user_token_info')
+    def test_no_token_info_returns_false(self, mock_get_info):
+        mock_get_info.return_value = None
+        success, token = attempt_token_refresh(user_id=1)
+        assert success is False
+
+    @patch('cqc_lem.utilities.linkedin.token_refresh.requests.post')
+    @patch('cqc_lem.utilities.db.get_user_token_info')
+    def test_network_error_returns_false(self, mock_get_info, mock_post):
+        import requests as req
+        mock_get_info.return_value = make_token_info(
+            seconds_until_expiry=3600, refresh_token='refresh_tok'
+        )
+        mock_post.side_effect = req.RequestException("timeout")
+        success, token = attempt_token_refresh(user_id=1)
+        assert success is False
+        assert token is None
+
+    @patch('cqc_lem.utilities.db.get_user_token_info')
+    def test_expired_refresh_token_returns_false(self, mock_get_info):
+        now = datetime.now(timezone.utc)
+        mock_get_info.return_value = {
+            'access_token': 'tok',
+            'access_token_created_at': now,
+            'access_token_expires_in': 3600,
+            'refresh_token': 'expired_refresh',
+            'refresh_token_created_at': now - timedelta(days=90),
+            'refresh_token_expires_in': 60 * 24 * 3600,  # 60 days, but created 90 days ago
+        }
+        success, token = attempt_token_refresh(user_id=1)
+        assert success is False

--- a/tests/unit/utilities/test_db.py
+++ b/tests/unit/utilities/test_db.py
@@ -118,36 +118,51 @@ class TestUpdateDbPostVideoUrl:
 
 @pytest.mark.unit
 class TestGetPosts:
-    def test_returns_list_from_cursor(self, mock_database_connection):
+    def test_returns_tuple_of_list_and_total(self, mock_database_connection):
         from cqc_lem.utilities.db import get_posts
 
         with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
             mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"total": 1}
             mock_database_connection["cursor"].fetchall.return_value = [
-                (1, 60, "Test content", "pending", None, "2024-01-01 12:00:00", "text", None)
-            ]
-            mock_database_connection["cursor"].description = [
-                ("id",), ("user_id",), ("content",), ("status",),
-                ("video_url",), ("scheduled_time",), ("post_type",), ("media_url",)
+                {"id": 1, "content": "Test", "status": "pending", "post_type": "text",
+                 "scheduled_time": "2024-01-01 12:00:00", "video_url": None, "carousel_slides": None}
             ]
 
-            posts = get_posts(60)
+            posts, total = get_posts(60)
 
-            assert mock_database_connection["cursor"].execute.called
             assert isinstance(posts, list)
+            assert total == 1
 
-    def test_query_filters_by_user_id(self, mock_database_connection):
+    def test_pagination_params_forwarded(self, mock_database_connection):
         from cqc_lem.utilities.db import get_posts
 
         with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
             mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"total": 0}
             mock_database_connection["cursor"].fetchall.return_value = []
-            mock_database_connection["cursor"].description = []
 
-            get_posts(42)
+            get_posts(42, limit=25, offset=50, sort_order='desc', status_filter='pending')
 
-            execute_args = mock_database_connection["cursor"].execute.call_args[0]
-            assert 42 in execute_args[1]
+            calls = mock_database_connection["cursor"].execute.call_args_list
+            # Second call is the data query; it should contain LIMIT/OFFSET params
+            data_call_args = calls[1][0][1]
+            assert 25 in data_call_args  # limit
+            assert 50 in data_call_args  # offset
+
+    def test_status_filter_applied(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_posts
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"total": 0}
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            get_posts(42, status_filter='approved')
+
+            calls = mock_database_connection["cursor"].execute.call_args_list
+            count_call_params = calls[0][0][1]
+            assert 'approved' in count_call_params
 
 
 @pytest.mark.unit
@@ -212,3 +227,343 @@ class TestGetUserId:
             result = get_user_id("nobody@example.com")
 
             assert result is None
+
+
+@pytest.mark.unit
+class TestInsertPostExtended:
+    def test_inserts_with_video_url(self, mock_database_connection):
+        from cqc_lem.utilities.db import insert_post, PostType
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
+             patch("cqc_lem.utilities.db.get_user_id") as mock_uid:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_uid.return_value = 10
+            mock_database_connection["cursor"].rowcount = 1
+
+            result = insert_post(
+                "test@example.com",
+                "Video post",
+                datetime(2025, 6, 1, 12, 0, tzinfo=timezone.utc),
+                PostType.VIDEO,
+                video_url="https://cdn.example.com/video.mp4",
+            )
+
+            assert result is True
+            call_args = mock_database_connection["cursor"].execute.call_args[0]
+            assert "https://cdn.example.com/video.mp4" in call_args[1]
+
+    def test_inserts_with_carousel_slides(self, mock_database_connection):
+        from cqc_lem.utilities.db import insert_post, PostType
+        import json
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
+             patch("cqc_lem.utilities.db.get_user_id") as mock_uid:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_uid.return_value = 10
+            mock_database_connection["cursor"].rowcount = 1
+
+            slides = ["Slide one text", "Slide two text"]
+            result = insert_post(
+                "test@example.com",
+                "Carousel caption",
+                datetime(2025, 6, 1, 12, 0, tzinfo=timezone.utc),
+                PostType.CAROUSEL,
+                carousel_slides=slides,
+            )
+
+            assert result is True
+            call_args = mock_database_connection["cursor"].execute.call_args[0]
+            # carousel_slides should be serialized as JSON
+            assert json.dumps(slides) in call_args[1]
+
+
+@pytest.mark.unit
+class TestGetPostType:
+    def test_returns_post_type_enum(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_type, PostType
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"post_type": "carousel"}
+
+            result = get_post_type(5)
+
+            assert result == PostType.CAROUSEL
+
+    def test_returns_none_when_not_found(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_type
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = None
+
+            result = get_post_type(999)
+
+            assert result is None
+
+
+@pytest.mark.unit
+class TestGetCarouselSlides:
+    def test_returns_parsed_slides(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_carousel_slides
+        import json
+
+        slides = ["First slide", "Second slide"]
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {
+                "carousel_slides": json.dumps(slides)
+            }
+
+            result = get_carousel_slides(5)
+
+            assert result == slides
+
+    def test_returns_empty_list_when_null(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_carousel_slides
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"carousel_slides": None}
+
+            result = get_carousel_slides(5)
+
+            assert result == []
+
+
+@pytest.mark.unit
+class TestBulkUpdatePosts:
+    def test_updates_status_for_multiple_ids(self, mock_database_connection):
+        from cqc_lem.utilities.db import bulk_update_posts, PostStatus
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].rowcount = 3
+
+            result = bulk_update_posts([1, 2, 3], status=PostStatus.APPROVED)
+
+            assert result is True
+            call_args = mock_database_connection["cursor"].execute.call_args[0]
+            assert "approved" in call_args[1]
+            mock_database_connection["connection"].commit.assert_called_once()
+
+    def test_returns_false_for_empty_list(self, mock_database_connection):
+        from cqc_lem.utilities.db import bulk_update_posts
+
+        result = bulk_update_posts([])
+
+        assert result is False
+
+    def test_returns_false_when_no_fields_provided(self, mock_database_connection):
+        from cqc_lem.utilities.db import bulk_update_posts
+
+        result = bulk_update_posts([1, 2])
+
+        assert result is False
+
+
+@pytest.mark.unit
+class TestSoftDeletePosts:
+    def test_sets_status_to_rejected(self, mock_database_connection):
+        from cqc_lem.utilities.db import soft_delete_posts
+
+        with patch("cqc_lem.utilities.db.bulk_update_posts") as mock_bulk:
+            mock_bulk.return_value = True
+
+            result = soft_delete_posts([10, 11])
+
+            assert result is True
+            mock_bulk.assert_called_once()
+            _, kwargs = mock_bulk.call_args
+            assert kwargs["status"].value == "rejected"
+
+
+@pytest.mark.unit
+class TestUpdateLinkedinConnectionStatus:
+    def test_updates_status(self, mock_database_connection):
+        from cqc_lem.utilities.db import update_linkedin_connection_status
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].rowcount = 1
+
+            result = update_linkedin_connection_status(42, "connected")
+
+            assert result is True
+            args = mock_database_connection["cursor"].execute.call_args[0]
+            assert "connected" in args[1]
+            assert 42 in args[1]
+
+    def test_returns_false_on_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import update_linkedin_connection_status
+        import mysql.connector
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
+
+            assert update_linkedin_connection_status(42, "disconnected") is False
+
+
+@pytest.mark.unit
+class TestGetUserSubscriptionInfo:
+    def test_returns_subscription_dict(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_user_subscription_info
+
+        expected = {
+            "subscription_status": "trial",
+            "subscription_tier": "free_trial",
+            "trial_started_at": None,
+            "trial_ends_at": None,
+            "stripe_customer_id": None,
+            "stripe_subscription_id": None,
+        }
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = expected
+
+            result = get_user_subscription_info(7)
+
+            assert result == expected
+
+    def test_returns_none_on_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_user_subscription_info
+        import mysql.connector
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
+
+            assert get_user_subscription_info(7) is None
+
+
+@pytest.mark.unit
+class TestUpdateSubscriptionFromStripe:
+    def test_updates_matching_customer(self, mock_database_connection):
+        from cqc_lem.utilities.db import update_subscription_from_stripe
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].rowcount = 1
+
+            result = update_subscription_from_stripe("cus_123", "active", "starter", "sub_456")
+
+            assert result is True
+            args = mock_database_connection["cursor"].execute.call_args[0]
+            assert "cus_123" in args[1]
+            assert "active" in args[1]
+
+    def test_returns_false_on_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import update_subscription_from_stripe
+        import mysql.connector
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
+
+            assert update_subscription_from_stripe("cus_123", "active", None, None) is False
+
+
+@pytest.mark.unit
+class TestGetUserPreferences:
+    def test_returns_preferences(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_user_preferences
+
+        expected = {"last_login_inactivate_delay": 90, "auto_schedule_posts": 0}
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = expected
+
+            result = get_user_preferences(5)
+
+            assert result == expected
+
+    def test_returns_none_on_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_user_preferences
+        import mysql.connector
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
+
+            assert get_user_preferences(5) is None
+
+
+@pytest.mark.unit
+class TestUpdateUserPreferences:
+    def test_updates_with_delay_and_auto_schedule(self, mock_database_connection):
+        from cqc_lem.utilities.db import update_user_preferences
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].rowcount = 1
+
+            result = update_user_preferences(10, 60, True)
+
+            assert result is True
+            args = mock_database_connection["cursor"].execute.call_args[0]
+            assert 60 in args[1]
+            assert 1 in args[1]   # auto_schedule_posts=True → 1
+            assert 10 in args[1]
+
+    def test_null_delay_for_never(self, mock_database_connection):
+        from cqc_lem.utilities.db import update_user_preferences
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].rowcount = 1
+
+            result = update_user_preferences(10, None, False)
+
+            assert result is True
+            args = mock_database_connection["cursor"].execute.call_args[0]
+            assert None in args[1]
+            assert 0 in args[1]   # auto_schedule_posts=False → 0
+
+    def test_returns_false_on_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import update_user_preferences
+        import mysql.connector
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
+
+            assert update_user_preferences(10, 90, False) is False
+
+
+@pytest.mark.unit
+class TestGetActiveUserIds:
+    def test_returns_user_ids_from_query(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_active_user_ids
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchall.return_value = [(1,), (2,), (3,)]
+
+            result = get_active_user_ids()
+
+            assert result == [1, 2, 3]
+
+    def test_returns_empty_list_on_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_active_user_ids
+        import mysql.connector
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
+
+            assert get_active_user_ids() == []
+
+    def test_query_includes_linkedin_and_subscription_checks(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_active_user_ids
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            get_active_user_ids()
+
+            sql = mock_database_connection["cursor"].execute.call_args[0][0]
+            assert "linkedin_connection_status" in sql
+            assert "subscription_status" in sql
+            assert "last_login_inactivate_delay" in sql

--- a/tests/unit/utilities/test_email.py
+++ b/tests/unit/utilities/test_email.py
@@ -1,0 +1,155 @@
+from unittest.mock import MagicMock, patch
+
+from cqc_lem.utilities.email import generate_pin, hash_pin, send_pin_email
+
+
+class TestGeneratePin:
+    def test_is_six_digits(self):
+        pin = generate_pin()
+        assert len(pin) == 6
+        assert pin.isdigit()
+
+    def test_zero_padded(self):
+        pin = generate_pin()
+        assert len(pin) == 6
+
+    def test_returns_string(self):
+        assert isinstance(generate_pin(), str)
+
+
+class TestHashPin:
+    def test_deterministic(self):
+        h1 = hash_pin("123456", "test@example.com")
+        h2 = hash_pin("123456", "test@example.com")
+        assert h1 == h2
+
+    def test_different_pins_produce_different_hashes(self):
+        h1 = hash_pin("000000", "test@example.com")
+        h2 = hash_pin("999999", "test@example.com")
+        assert h1 != h2
+
+    def test_different_emails_produce_different_hashes(self):
+        h1 = hash_pin("123456", "a@example.com")
+        h2 = hash_pin("123456", "b@example.com")
+        assert h1 != h2
+
+    def test_returns_64_char_hex(self):
+        h = hash_pin("123456", "test@example.com")
+        assert len(h) == 64
+        assert all(c in "0123456789abcdef" for c in h)
+
+
+class TestSendPinEmailSendGrid:
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", "sg_test_key")
+    @patch("cqc_lem.utilities.email.SMTP_USER", None)
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", None)
+    @patch("sendgrid.SendGridAPIClient")
+    def test_sendgrid_success_returns_true_not_bypassed(self, mock_sg_class):
+        mock_sg = MagicMock()
+        mock_sg.send.return_value = MagicMock(status_code=202)
+        mock_sg_class.return_value = mock_sg
+
+        success, bypassed = send_pin_email("test@example.com", "123456")
+
+        assert success is True
+        assert bypassed is False
+        mock_sg.send.assert_called_once()
+
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", "sg_test_key")
+    @patch("cqc_lem.utilities.email.SMTP_USER", None)
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", None)
+    @patch("sendgrid.SendGridAPIClient")
+    def test_sendgrid_failure_returns_false_not_bypassed(self, mock_sg_class):
+        mock_sg = MagicMock()
+        mock_sg.send.side_effect = Exception("Network error")
+        mock_sg_class.return_value = mock_sg
+
+        success, bypassed = send_pin_email("test@example.com", "123456")
+
+        assert success is False
+        assert bypassed is False
+
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", "sg_test_key")
+    @patch("cqc_lem.utilities.email.SMTP_USER", None)
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", None)
+    @patch("sendgrid.SendGridAPIClient")
+    def test_new_user_flag_does_not_crash(self, mock_sg_class):
+        mock_sg = MagicMock()
+        mock_sg_class.return_value = mock_sg
+
+        send_pin_email("new@example.com", "000001", is_new_user=True)
+
+        mock_sg.send.assert_called_once()
+
+
+class TestSendPinEmailSmtpFallback:
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", None)
+    @patch("cqc_lem.utilities.email.SMTP_USER", "user@gmail.com")
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", "app_password")
+    @patch("cqc_lem.utilities.email.smtplib.SMTP")
+    def test_smtp_success_when_sendgrid_missing(self, mock_smtp_class):
+        mock_server = MagicMock()
+        mock_smtp_class.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        success, bypassed = send_pin_email("test@example.com", "654321")
+
+        assert success is True
+        assert bypassed is False
+
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", "sg_key")
+    @patch("cqc_lem.utilities.email.SMTP_USER", "user@gmail.com")
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", "app_password")
+    @patch("cqc_lem.utilities.email.smtplib.SMTP")
+    @patch("sendgrid.SendGridAPIClient")
+    def test_smtp_fallback_used_when_sendgrid_fails(self, mock_sg_class, mock_smtp_class):
+        mock_sg = MagicMock()
+        mock_sg.send.side_effect = Exception("SendGrid down")
+        mock_sg_class.return_value = mock_sg
+
+        mock_server = MagicMock()
+        mock_smtp_class.return_value.__enter__ = MagicMock(return_value=mock_server)
+        mock_smtp_class.return_value.__exit__ = MagicMock(return_value=False)
+
+        success, bypassed = send_pin_email("test@example.com", "654321")
+
+        assert success is True
+        assert bypassed is False
+
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", None)
+    @patch("cqc_lem.utilities.email.SMTP_USER", "user@gmail.com")
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", "app_password")
+    @patch("cqc_lem.utilities.email.smtplib.SMTP")
+    def test_smtp_failure_returns_false(self, mock_smtp_class):
+        mock_smtp_class.side_effect = Exception("SMTP connection refused")
+
+        success, bypassed = send_pin_email("test@example.com", "654321")
+
+        assert success is False
+        assert bypassed is False
+
+
+class TestSendPinEmailBypass:
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", None)
+    @patch("cqc_lem.utilities.email.SMTP_USER", None)
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", None)
+    def test_bypass_when_no_provider_configured(self):
+        success, bypassed = send_pin_email("test@example.com", "123456")
+
+        assert success is True
+        assert bypassed is True
+
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", None)
+    @patch("cqc_lem.utilities.email.SMTP_USER", "user@gmail.com")
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", None)
+    @patch("cqc_lem.utilities.email.smtplib.SMTP")
+    def test_no_bypass_when_smtp_user_set_but_password_missing(self, mock_smtp_class):
+        # SMTP_USER without SMTP_PASSWORD → treated as no SMTP provider → bypass
+        mock_smtp_class.side_effect = Exception("Should not be called")
+
+        success, bypassed = send_pin_email("test@example.com", "123456")
+
+        # No provider configured (password missing), so bypass
+        assert success is True
+        assert bypassed is True
+        mock_smtp_class.assert_not_called()


### PR DESCRIPTION
## Summary

### Auth & Account page (the broken flows you reported)
- **Account not saving**: `PUT /user/` returned 404 when no optional fields were sent — now returns 200 no-op
- **LinkedIn OAuth email not persisting**: The callback now redirects to `/account?email=X&li_connected=1` so the frontend can auto-detect the authenticated user without the user re-typing their email
- **Account.tsx** reads those URL params on mount and saves to localStorage; shows a "LinkedIn connected!" banner

### Docker / infrastructure
- **Blank homepage in Docker**: Added a `node:22-slim` build stage to the Dockerfile that compiles the React SPA (`npm run build`) and copies `dist/` into the image — the `dist/` folder is gitignored so it previously wasn't available inside Docker at all
- Removed the dead `/start-streamlit` copy from Dockerfile (Streamlit was replaced by React)
- `generate-ngrok-config.sh` is now plan-aware (free/paid/off) and uses the correct template
- Fixed `poetry self add` → `pip install poetry poetry-plugin-export` (more reliable when poetry is pip-installed)

### Feature completions (closes #41, closes #43)
**Issue #41 — carousel Pexels integration**
- Added `get_pexels_image_path(query, fallback)` helper: downloads a contextual Pexels image to a temp file; all carousel type handlers now call it for slides without an explicit `image_path`, falling back gracefully when `PEXELS_API_KEY` is absent or the request fails

**Issue #43 — DM automation**
- Fixed missing `import json` and `from ai_helper import ai_check_message_history` (was used but not imported — would have crashed at runtime)
- Profile-viewer DM now retrieves real message history via new `get_dm_history_for_profile()` (added to `db.py`) and passes it as JSON to `ai_check_message_history()`; fixes `TypeError` from passing a list instead of a string
- Profile-viewer DM uses user's blog URL (via `get_user_blog_url()`) to build a personalised `main_focus`
- `automate_appreciation_dms_for_user` now handles Recommendation and Collaboration DM types via `get_recent_recommendations()` / `get_recent_collaborators()` stubs (ready for scraper implementation) with proper message construction
- `post_to_linkedin` now checks `get_post_status()` (added to `db.py`) before posting to prevent duplicate posts when the task is re-queued

### Docs
- Updated README to reflect React/FastAPI/LiteLLM/PostHog tech stack

## Test plan
- [ ] Run `./run.sh` locally → confirm the homepage loads (React SPA served, not just API 404)
- [ ] Visit `/account` → enter email → click **Save Settings** → confirm no error even without blog/sitemap filled in
- [ ] Click **Connect LinkedIn** → complete OAuth → confirm redirect to `/account?email=X&li_connected=1` → confirm email auto-populated and "LinkedIn connected!" banner shown
- [ ] Visit `/account` after OAuth → confirm "✓ Account found in database" badge appears
- [ ] All 88 unit tests pass: `poetry run pytest tests/unit -v --tb=short`

🤖 Generated with [Claude Code](https://claude.com/claude-code)