### PR TITLE
fix(observability): repair PostHog event delivery and LinkedIn login error visibility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,6 +146,8 @@ SMTP_PASSWORD=your_gmail_app_password
 # --- PostHog (analytics) ---
 POSTHOG_API_KEY=your_posthog_api_key
 POSTHOG_HOST=https://us.i.posthog.com
+# Minimum log level forwarded to PostHog (DEBUG/INFO/WARNING/ERROR/CRITICAL). Default: ERROR
+POSTHOG_LOG_LEVEL=ERROR
 
 # --- Codecov (coverage reporting) ---
 CODECOV_TOKEN=your_codecov_token

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -167,6 +167,14 @@ def get_queue_metric(name_space: str = 'cqc-lem/celery_queue/celery', metric_nam
 _task_start_times: dict = {}
 
 
+@worker_process_init.connect(weak=False)
+def configure_posthog_for_worker(**kwargs) -> None:
+    # Celery forks worker processes; the PostHog background Consumer thread does not
+    # survive fork. Sync mode sends each capture immediately instead of queuing.
+    import posthog as _posthog
+    _posthog.sync_mode = True
+
+
 @task_prerun.connect(weak=False)
 def on_task_prerun(task_id: str = None, task=None, **kwargs) -> None:
     _task_start_times[task_id] = _time.time()

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -898,7 +898,14 @@ def automate_profile_viewer_engagement(self, user_id: int, loop_for_duration: in
 
     myprint(f"Starting Profile Viewer DMs")
 
-    driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Profile Viewer DMs")
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Profile Viewer DMs")
+    except Exception as e:
+        log_error(
+            "Failed to get profile for profile viewer engagement",
+            exc=e, user_id=user_id, task_name="automate_profile_viewer_engagement",
+        )
+        raise
 
     result = "Profile Viewer DMs Started"
 

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -6,7 +6,7 @@ from cqc_lem.utilities.db import get_cookies, store_cookies, get_linked_in_profi
     get_linked_in_profile_by_url, get_linked_in_profile_by_user_id
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.linkedin.scrapper import returnProfileInfo
-from cqc_lem.utilities.logger import myprint
+from cqc_lem.utilities.logger import myprint, log_warning, log_error
 from cqc_lem.utilities.selenium_util import load_cookies, click_element_wait_retry, get_element_wait_retry, getText
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -34,6 +34,19 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
     # Wait for the login page to load
     time.sleep(2)
 
+    _LINKEDIN_CHALLENGE_PATHS = ('/checkpoint/', '/authwall/', '/uas/login', '/challenge/')
+
+    def _is_challenge_url(url: str) -> bool:
+        return any(p in url for p in _LINKEDIN_CHALLENGE_PATHS)
+
+    if _is_challenge_url(driver.current_url):
+        log_error(
+            "LinkedIn security challenge detected after loading cookies — login blocked",
+            action_type="login",
+            error_message=f"Redirected to: {driver.current_url}",
+        )
+        raise RuntimeError(f"LinkedIn security challenge at {driver.current_url}")
+
     if "feed" in driver.current_url:
         myprint("Already Logged in!")
 
@@ -50,6 +63,14 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
 
         # Wait for the login page to load
         # time.sleep(2)
+
+        if _is_challenge_url(driver.current_url):
+            log_error(
+                "LinkedIn security challenge detected after Sign In redirect — login blocked",
+                action_type="login",
+                error_message=f"Redirected to: {driver.current_url}",
+            )
+            raise RuntimeError(f"LinkedIn security challenge at {driver.current_url}")
 
         # Find the username and password input fields and log in
         username_field = get_element_wait_retry(driver, wait, 'username', "Finding Username Field", By.ID)

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -8,8 +8,11 @@ import posthog
 posthog.api_key = os.getenv("POSTHOG_API_KEY", "")
 posthog.host = os.getenv("POSTHOG_HOST", "https://us.i.posthog.com")
 
-# Suppress API errors (e.g. 401 from personal vs project key mismatch) silently
-posthog.on_error = lambda e, items: None
+def _posthog_on_error(e, items) -> None:
+    import sys
+    print(f"[PostHog] delivery error: {e}", file=sys.stderr)
+
+posthog.on_error = _posthog_on_error
 
 # Disable PostHog when no key configured (local dev without key)
 if not posthog.api_key:


### PR DESCRIPTION
## Summary

- **PostHog Celery fork bug (critical):** The PostHog SDK's background `Consumer` thread doesn't survive Celery's `fork()`. Events captured in `ForkPoolWorker-*` processes were queued but never sent — the reason zero events appeared in PostHog. A `worker_process_init` signal in `my_celery.py` now sets `posthog.sync_mode = True` in each forked worker so captures send synchronously without needing a background thread.
- **Silent PostHog error suppression:** `posthog.on_error` was a no-op lambda that dropped all delivery failures (401s, network errors). It now prints to stderr so failures surface in container logs.
- **LinkedIn security challenge detection:** `login_to_linkedin` in `helper.py` now detects checkpoint/authwall/CAPTCHA redirects at two points before attempting to find `#username`, replacing a cryptic `TimeoutException` with a descriptive `log_error` carrying the redirect URL.
- **Task error visibility:** `automate_profile_viewer_engagement` was calling `get_current_profile()` outside its `try` block, so failures surfaced as Celery "raised unexpected" with no task-level log context. It's now wrapped in try/except with structured logging.
- **Docs:** Added `POSTHOG_LOG_LEVEL` to `.env.example` (the env var existed in `logger.py` but was undocumented).

## Test plan

- [ ] All 338 unit tests pass (`poetry run pytest tests/unit -v`)
- [ ] Restart `celery_worker` container; after next `auto_check_scheduled_posts` run verify `celery_task` events appear in PostHog UI
- [ ] Trigger a failed LinkedIn task; confirm PostHog receives the `log_event` with `level=error` and `task_name` property
- [ ] If LinkedIn shows a checkpoint page, logs now show `"LinkedIn security challenge detected"` instead of `TimeoutException`

🤖 Generated with [Claude Code](https://claude.com/claude-code)