### PR TITLE
fix(timezone): end-to-end timezone correctness for post scheduling and display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,4 @@ src/cqc_lem/ui/dist/
 
 .qodo
 .vscode/mcp.json
+.mcp.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "github.copilot.chat.mcp.enabled": true
+}

--- a/compose/local/database/migrations/V28__add_user_timezone.sql
+++ b/compose/local/database/migrations/V28__add_user_timezone.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users
+  ADD COLUMN timezone VARCHAR(50) NOT NULL DEFAULT 'America/New_York';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,7 +121,7 @@ services:
       selenium-chrome:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "python3 -c \"import os, sys; sys.exit(0 if any('celery' in l and 'beat' in l for l in open('/proc/%s/cmdline' % p).read().replace(chr(0),' ') for p in os.listdir('/proc') if p.isdigit() and os.path.exists('/proc/%s/cmdline' % p)) else 1)\""]
+      test: ["CMD-SHELL", "python3 -c \"import os, sys; cmds=[open('/proc/'+p+'/cmdline').read().replace(chr(0),' ') for p in os.listdir('/proc') if p.isdigit() and os.path.exists('/proc/'+p+'/cmdline')]; sys.exit(0 if any('celery' in c and 'beat' in c for c in cmds) else 1)\""]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -177,7 +177,7 @@ services:
           cpus: '2.0'
           memory: 4g
     healthcheck:
-      test: ["CMD-SHELL", "curl -fsS http://localhost:4444/wd/hub/status | python3 -c \"import sys,json; d=json.load(sys.stdin); sys.exit(0 if d['value']['ready'] else 1)\""]
+      test: ["CMD-SHELL", "curl -fsS http://localhost:4444/status | python3 -c \"import sys,json; d=json.load(sys.stdin); sys.exit(0 if any(n.get('availability')=='UP' for n in d['value']['nodes']) else 1)\""]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,6 +87,8 @@ services:
       - web_app
     env_file:
       - .env
+    environment:
+      - CELERY_TIMEZONE=${TZ:-UTC}
     depends_on:
       redis:
         condition: service_healthy
@@ -109,6 +111,8 @@ services:
       - web_app
     env_file:
       - .env
+    environment:
+      - CELERY_TIMEZONE=${TZ:-UTC}
     depends_on:
       redis:
         condition: service_healthy
@@ -137,6 +141,7 @@ services:
     environment:
       - FLOWER_UNAUTHENTICATED_API=True
       - FLOWER_PERSISTENT=False
+      - CELERY_TIMEZONE=${TZ:-UTC}
     ports:
       - "${CELERY_FLOWER_PORT}:${CELERY_FLOWER_PORT}"
     depends_on:

--- a/poetry.lock
+++ b/poetry.lock
@@ -179,7 +179,7 @@ version = "3.11.1"
 description = "ASGI specs, helper code, and adapters"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "asgiref-3.11.1-py3-none-any.whl", hash = "sha256:e8667a091e69529631969fd45dc268fa79b99c92c5fcdda727757e52146ec133"},
     {file = "asgiref-3.11.1.tar.gz", hash = "sha256:5f184dc43b7e763efe848065441eac62229c9f7b0475f41f80e207a114eda4ce"},
@@ -432,18 +432,18 @@ files = [
 
 [[package]]
 name = "boto3"
-version = "1.43.33"
+version = "1.43.34"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "boto3-1.43.33-py3-none-any.whl", hash = "sha256:97b563127f7678ad20249f9bf99877b7a3a78f6fcdcf222c6e25d27d4406ce0d"},
-    {file = "boto3-1.43.33.tar.gz", hash = "sha256:da6e400b2d11eb041fbbb2743ef3ffe6540889676ffdff0e628628e9b4f04cde"},
+    {file = "boto3-1.43.34-py3-none-any.whl", hash = "sha256:42595057324606928c6e2432b3093978e4d722e0d432bce942f2a385702c0a43"},
+    {file = "boto3-1.43.34.tar.gz", hash = "sha256:444207c6c883d4df3ea3b2c36df43ad492b86e0b889eebd2fc1d5ea8db0a8a1a"},
 ]
 
 [package.dependencies]
-botocore = ">=1.43.33,<1.44.0"
+botocore = ">=1.43.34,<1.44.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.19.0,<0.20.0"
 
@@ -452,14 +452,14 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.43.33"
+version = "1.43.34"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "botocore-1.43.33-py3-none-any.whl", hash = "sha256:4292bb2cc645e5cb404515c54b5b164563f2b4218c52aeee3f1ce851724e177a"},
-    {file = "botocore-1.43.33.tar.gz", hash = "sha256:74b3d5626ebeb2677fac1ca12ac975faf328e54349ceb4dcda17f50674d5b9b4"},
+    {file = "botocore-1.43.34-py3-none-any.whl", hash = "sha256:238a0269f33c5914b9343900b44767e783b3e8b6dcb6e065eac8b4495601c5df"},
+    {file = "botocore-1.43.34.tar.gz", hash = "sha256:ccc973cf30c6445b30afe5760f6dc949a80f1f862cb23d9c45747f2c814ece77"},
 ]
 
 [package.dependencies]
@@ -1269,7 +1269,7 @@ version = "1.3.1"
 description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f"},
     {file = "deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223"},
@@ -1486,7 +1486,7 @@ version = "1.75.0"
 description = "Common protobufs used in Google APIs"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed"},
     {file = "googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd"},
@@ -1644,7 +1644,7 @@ version = "1.81.1"
 description = "HTTP/2-based RPC framework"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "grpcio-1.81.1-cp310-cp310-linux_armv7l.whl", hash = "sha256:6f9a0c9c1cc15c112d1c053064fd032b64917062292c3d70aea280e02ae10b77"},
     {file = "grpcio-1.81.1-cp310-cp310-macosx_11_0_universal2.whl", hash = "sha256:69ef28e54fc85397f91b8c19592b8ef3d81952080366914823bd8572a2958120"},
@@ -1860,7 +1860,7 @@ version = "8.5.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
     {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
@@ -2223,14 +2223,14 @@ typing_extensions = ">=3.8,<5.0"
 
 [[package]]
 name = "json5"
-version = "0.14.0"
+version = "0.15.0"
 description = "A Python implementation of the JSON5 data format."
 optional = false
 python-versions = ">=3.8.0"
 groups = ["dev"]
 files = [
-    {file = "json5-0.14.0-py3-none-any.whl", hash = "sha256:56cf861bab076b1178eb8c92e1311d273a9b9acea2ccc82c276abf839ebaef3a"},
-    {file = "json5-0.14.0.tar.gz", hash = "sha256:b3f492fad9f6cdbced8b7d40b28b9b1c9701c5f561bef0d33b81c2ff433fefcb"},
+    {file = "json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618"},
+    {file = "json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71"},
 ]
 
 [[package]]
@@ -3309,7 +3309,7 @@ version = "1.28.2"
 description = "OpenTelemetry Python API"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_api-1.28.2-py3-none-any.whl", hash = "sha256:6fcec89e265beb258fe6b1acaaa3c8c705a934bd977b9f534a2b7c0d2d4275a6"},
     {file = "opentelemetry_api-1.28.2.tar.gz", hash = "sha256:ecdc70c7139f17f9b0cf3742d57d7020e3e8315d6cffcdf1a12a905d45b19cc0"},
@@ -3325,7 +3325,7 @@ version = "1.28.2"
 description = "OpenTelemetry Collector Exporters"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_exporter_otlp-1.28.2-py3-none-any.whl", hash = "sha256:b50f6d4a80e6bcd329e36f360ac486ecfa106ea704d6226ceea05d3a48455f70"},
     {file = "opentelemetry_exporter_otlp-1.28.2.tar.gz", hash = "sha256:45f8d7fe4cdd41526464b542ce91b1fd1ae661be92d2c6cba71a3d948b2bdf70"},
@@ -3341,7 +3341,7 @@ version = "1.28.2"
 description = "OpenTelemetry Protobuf encoding"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_exporter_otlp_proto_common-1.28.2-py3-none-any.whl", hash = "sha256:545b1943b574f666c35b3d6cc67cb0b111060727e93a1e2866e346b33bff2a12"},
     {file = "opentelemetry_exporter_otlp_proto_common-1.28.2.tar.gz", hash = "sha256:7aebaa5fc9ff6029374546df1f3a62616fda07fccd9c6a8b7892ec130dd8baca"},
@@ -3356,7 +3356,7 @@ version = "1.28.2"
 description = "OpenTelemetry Collector Protobuf over gRPC Exporter"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_exporter_otlp_proto_grpc-1.28.2-py3-none-any.whl", hash = "sha256:6083d9300863aab35bfce7c172d5fc1007686e6f8dff366eae460cd9a21592e2"},
     {file = "opentelemetry_exporter_otlp_proto_grpc-1.28.2.tar.gz", hash = "sha256:07c10378380bbb01a7f621a5ce833fc1fab816e971140cd3ea1cd587840bc0e6"},
@@ -3377,7 +3377,7 @@ version = "1.28.2"
 description = "OpenTelemetry Collector Protobuf over HTTP Exporter"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_exporter_otlp_proto_http-1.28.2-py3-none-any.whl", hash = "sha256:af921c18212a56ef4be68458ba475791c0517ebfd8a2ff04669c9cd477d90ff2"},
     {file = "opentelemetry_exporter_otlp_proto_http-1.28.2.tar.gz", hash = "sha256:d9b353d67217f091aaf4cfe8693c170973bb3e90a558992570d97020618fda79"},
@@ -3398,7 +3398,7 @@ version = "0.49b2"
 description = "Instrumentation Tools & Auto Instrumentation for OpenTelemetry Python"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_instrumentation-0.49b2-py3-none-any.whl", hash = "sha256:f6d782b0ef9fef4a4c745298651c65f5c532c34cd4c40d230ab5b9f3b3b4d151"},
     {file = "opentelemetry_instrumentation-0.49b2.tar.gz", hash = "sha256:8cf00cc8d9d479e4b72adb9bd267ec544308c602b7188598db5a687e77b298e2"},
@@ -3416,7 +3416,7 @@ version = "0.49b2"
 description = "ASGI instrumentation for OpenTelemetry"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_instrumentation_asgi-0.49b2-py3-none-any.whl", hash = "sha256:c8ede13ed781402458a800411cb7ec16a25386dc21de8e5b9a568b386a1dc5f4"},
     {file = "opentelemetry_instrumentation_asgi-0.49b2.tar.gz", hash = "sha256:2af5faf062878330714efe700127b837038c4d9d3b70b451ab2424d5076d6c1c"},
@@ -3438,7 +3438,7 @@ version = "0.49b2"
 description = "OpenTelemetry Celery Instrumentation"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_instrumentation_celery-0.49b2-py3-none-any.whl", hash = "sha256:9f694672fe2aceb18b162d6b649fa03852223f592231776a7db4a16171bd9bfa"},
     {file = "opentelemetry_instrumentation_celery-0.49b2.tar.gz", hash = "sha256:2d012b4046399ba5016316e32592304c7aa74c83d66a9e2421363347a02f4364"},
@@ -3458,7 +3458,7 @@ version = "0.49b2"
 description = "OpenTelemetry FastAPI Instrumentation"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_instrumentation_fastapi-0.49b2-py3-none-any.whl", hash = "sha256:c66331d05bf806d7ca4f9579c1db7383aad31a9f6665dbaa2b7c9a4c1e830892"},
     {file = "opentelemetry_instrumentation_fastapi-0.49b2.tar.gz", hash = "sha256:3aa81ed7acf6aa5236d96e90a1218c5e84a9c0dce8fa63bf34ceee6218354b63"},
@@ -3480,7 +3480,7 @@ version = "1.28.2"
 description = "OpenTelemetry Python Proto"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_proto-1.28.2-py3-none-any.whl", hash = "sha256:0837498f59db55086462915e5898d0b1a18c1392f6db4d7e937143072a72370c"},
     {file = "opentelemetry_proto-1.28.2.tar.gz", hash = "sha256:7c0d125a6b71af88bfeeda16bfdd0ff63dc2cf0039baf6f49fa133b203e3f566"},
@@ -3495,7 +3495,7 @@ version = "1.28.2"
 description = "OpenTelemetry Python SDK"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_sdk-1.28.2-py3-none-any.whl", hash = "sha256:93336c129556f1e3ccd21442b94d3521759541521861b2214c499571b85cb71b"},
     {file = "opentelemetry_sdk-1.28.2.tar.gz", hash = "sha256:5fed24c5497e10df30282456fe2910f83377797511de07d14cec0d3e0a1a3110"},
@@ -3512,7 +3512,7 @@ version = "0.49b2"
 description = "OpenTelemetry Semantic Conventions"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_semantic_conventions-0.49b2-py3-none-any.whl", hash = "sha256:51e7e1d0daa958782b6c2a8ed05e5f0e7dd0716fc327ac058777b8659649ee54"},
     {file = "opentelemetry_semantic_conventions-0.49b2.tar.gz", hash = "sha256:44e32ce6a5bb8d7c0c617f84b9dc1c8deda1045a07dc16a688cc7cbeab679997"},
@@ -3528,7 +3528,7 @@ version = "0.49b2"
 description = "Web util for OpenTelemetry"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "opentelemetry_util_http-0.49b2-py3-none-any.whl", hash = "sha256:e325d6511c6bee7b43170eb0c93261a210ec57e20ab1d7a99838515ef6d2bf58"},
     {file = "opentelemetry_util_http-0.49b2.tar.gz", hash = "sha256:5958c7009f79146bbe98b0fdb23d9d7bf1ea9cd154a1c199029b1a89e0557199"},
@@ -3937,7 +3937,7 @@ version = "5.29.6"
 description = ""
 optional = false
 python-versions = ">=3.8"
-groups = ["dev", "streamlit"]
+groups = ["main", "streamlit"]
 files = [
     {file = "protobuf-5.29.6-cp310-abi3-win32.whl", hash = "sha256:62e8a3114992c7c647bce37dcc93647575fc52d50e48de30c6fcb28a6a291eb1"},
     {file = "protobuf-5.29.6-cp310-abi3-win_amd64.whl", hash = "sha256:7e6ad413275be172f67fdee0f43484b6de5a904cc1c3ea9804cb6fe2ff366eda"},
@@ -5529,21 +5529,22 @@ tests = ["cython", "littleutils", "pygments", "pytest", "typeguard"]
 
 [[package]]
 name = "starlette"
-version = "0.46.2"
+version = "1.3.1"
 description = "The little ASGI library that shines."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "streamlit"]
 files = [
-    {file = "starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35"},
-    {file = "starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5"},
+    {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
+    {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
 ]
 
 [package.dependencies]
 anyio = ">=3.6.2,<5"
+typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""}
 
 [package.extras]
-full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
+full = ["httpx (>=0.27.0,<0.29.0)", "httpx2 (>=2.0.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
 name = "streamlit"
@@ -6220,7 +6221,7 @@ version = "1.17.3"
 description = "Module for decorators, wrappers and monkey patching."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04"},
     {file = "wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2"},
@@ -6338,7 +6339,7 @@ version = "4.1.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main"]
 files = [
     {file = "zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f"},
     {file = "zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602"},
@@ -6355,4 +6356,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "04e00cf3811d9ae0b0c3f127698db4ee8f72915262047802e1177739bf018f87"
+content-hash = "2620cc28c15fc81ac2caf3e4d62260e3707a5223b1b52030b4859e16582a2754"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,11 @@ dateparser = "^1.2.0"
 
 # --- Observability ---
 posthog = ">=3.7,<8.0"
+opentelemetry-api = "^1.28.2"
+opentelemetry-sdk = "^1.28.2"
+opentelemetry-instrumentation-celery = "^0.49b2"
+opentelemetry-exporter-otlp = "^1.28.2"
+opentelemetry-instrumentation-fastapi = "^0.49b2"
 
 # --- AWS / payments ---
 boto3 = "^1.36.7"
@@ -95,12 +100,6 @@ cdk-ecr-deployment = ">=3.1.8,<5.0.0"
 aws-cdk-aws-amplify-alpha = "^2.177.0a0"
 aws-cdk-aws-lambda-python-alpha = "^2.177.0a0"
 
-# Observability Tools (Development)
-opentelemetry-api = "^1.28.2"
-opentelemetry-sdk = "^1.28.2"
-opentelemetry-instrumentation-celery = "^0.49b2"
-opentelemetry-exporter-otlp = "^1.28.2"
-opentelemetry-instrumentation-fastapi = "^0.49b2"
 
 
 [tool.poetry.group.lint]

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -29,6 +29,7 @@ from cqc_lem.utilities.db import (
     deduct_avatar_credit, insert_avatar_training,
     update_avatar_training_status, set_active_avatar,
     get_avatar_trainings, get_active_avatar,
+    get_user_timezone, update_user_timezone,
 )
 from cqc_lem.utilities.email import generate_pin, hash_pin, send_pin_email
 from cqc_lem.utilities.linkedin.token_refresh import (
@@ -189,6 +190,11 @@ class LinkedInPasswordRequest(BaseModel):
     linkedin_password: str
 
 
+class TimezoneRequest(BaseModel):
+    session_token: str
+    timezone: str
+
+
 class FutureForwardValues(IntEnum):
     Zero = 0
     ONE = 1
@@ -216,7 +222,7 @@ def get_dashboard_stats(email: str) -> ResponseModel:
         raise HTTPException(status_code=403, detail="User not found")
 
     posts, _ = get_posts(user_id)
-    now = datetime.now()
+    now = datetime.now(timezone.utc)
     week_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     week_start = week_start.replace(day=week_start.day - week_start.weekday())
 
@@ -815,6 +821,28 @@ def update_linkedin_password(request: LinkedInPasswordRequest) -> ResponseModel:
     if not saved:
         raise HTTPException(status_code=500, detail="Could not save LinkedIn password")
     return ResponseModel(status_code=200, detail="LinkedIn password saved")
+
+
+@router.get("/user/timezone")
+def get_user_timezone_endpoint(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail={"timezone": get_user_timezone(user_id)})
+
+
+@router.put("/user/timezone")
+def update_user_timezone_endpoint(request: TimezoneRequest) -> ResponseModel:
+    from zoneinfo import available_timezones, ZoneInfoNotFoundError
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if request.timezone not in available_timezones():
+        raise HTTPException(status_code=422, detail=f"Unknown timezone: {request.timezone!r}")
+    saved = update_user_timezone(user_id, request.timezone)
+    if not saved:
+        raise HTTPException(status_code=500, detail="Could not update timezone")
+    return ResponseModel(status_code=200, detail="Timezone updated")
 
 
 @router.post("/billing/create-checkout-session")

--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -32,7 +32,8 @@ result_backend_max_retries = 3
 # The Redis backend health checks every 5 minutes (300 seconds)
 redis_backend_health_check_interval = 300
 
-timezone = os.getenv('TZ')
+timezone = os.getenv('CELERY_TIMEZONE') or os.getenv('TZ') or 'UTC'
+enable_utc = True
 
 # Prevent task messages from being lost
 task_acks_late = True,

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -10,7 +10,8 @@ from cqc_lem.app.run_automation import automate_commenting, automate_profile_vie
     automate_appreciation_dms_for_user, clean_stale_invites, update_stale_profile, post_to_linkedin, \
     automate_invites_to_company_page_for_user
 from cqc_lem.utilities.db import (
-    get_ready_to_post_posts, update_db_post_status, get_active_user_ids, PostStatus,
+    get_ready_to_post_posts, get_orphaned_scheduled_posts, update_db_post_status,
+    get_active_user_ids, PostStatus,
     get_users_with_stripe_subscriptions, update_subscription_from_stripe,
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES
@@ -52,10 +53,23 @@ def auto_check_scheduled_posts(self):
         base_kwargs['loop_for_duration'] = 60 * 10
         automate_profile_viewer_engagement.apply_async(kwargs=base_kwargs, eta=scheduled_time - timedelta(minutes=10))
 
-    if len(posts) == 0:
+    # Re-queue any posts that got stuck in 'scheduled' (task was lost, e.g. on container restart)
+    # but never transitioned to 'posted'. The 2-hour gap ensures we don't race with a task
+    # that is still in-flight.
+    orphaned = get_orphaned_scheduled_posts(lookback_hours=2)
+    for post_id, scheduled_time, user_id in orphaned:
+        if scheduled_time.tzinfo is None:
+            scheduled_time = scheduled_time.replace(tzinfo=timezone.utc)
+        log_warning(
+            f"Re-queueing orphaned scheduled post",
+            post_id=post_id, user_id=user_id, task_name="auto_check_scheduled_posts",
+        )
+        post_to_linkedin.apply_async(kwargs={'user_id': user_id, 'post_id': post_id})
+
+    if len(posts) == 0 and len(orphaned) == 0:
         return f"No Post to Schedule"
     else:
-        return f"Started Process for {len(posts)} post(s)"
+        return f"Started Process for {len(posts)} post(s); re-queued {len(orphaned)} orphaned post(s)"
 
 
 @shared_task.task

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -9,7 +9,6 @@ from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.app.run_automation import automate_commenting, automate_profile_viewer_engagement, \
     automate_appreciation_dms_for_user, clean_stale_invites, update_stale_profile, post_to_linkedin, \
     automate_invites_to_company_page_for_user
-from cqc_lem.utilities.date import convert_datetime_to_local_tz
 from cqc_lem.utilities.db import (
     get_ready_to_post_posts, update_db_post_status, get_active_user_ids, PostStatus,
     get_users_with_stripe_subscriptions, update_subscription_from_stripe,
@@ -29,7 +28,8 @@ def auto_check_scheduled_posts(self):
     for post in posts:
         post_id, scheduled_time, user_id = post
 
-        scheduled_time = convert_datetime_to_local_tz(scheduled_time)  # Must add timezone info to this
+        if scheduled_time.tzinfo is None:
+            scheduled_time = scheduled_time.replace(tzinfo=timezone.utc)
 
         log_info(f"Post ready to schedule", post_id=post_id, user_id=user_id, task_name="auto_check_scheduled_posts")
 

--- a/src/cqc_lem/ui/src/hooks/useUserTimezone.ts
+++ b/src/cqc_lem/ui/src/hooks/useUserTimezone.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query'
+import api from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
+
+export function useUserTimezone(): string {
+  const { sessionToken } = useAuth()
+
+  const { data } = useQuery({
+    queryKey: ['user-timezone', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/timezone?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as { timezone: string }),
+    enabled: !!sessionToken,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  return data?.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone
+}

--- a/src/cqc_lem/ui/src/pages/Account.tsx
+++ b/src/cqc_lem/ui/src/pages/Account.tsx
@@ -20,6 +20,35 @@ const TIER_COLORS: Record<string, string> = {
   enterprise: 'bg-yellow-100 text-yellow-800',
 }
 
+const COMMON_TIMEZONES = [
+  'America/New_York',
+  'America/Chicago',
+  'America/Denver',
+  'America/Los_Angeles',
+  'America/Phoenix',
+  'America/Anchorage',
+  'Pacific/Honolulu',
+  'America/Toronto',
+  'America/Vancouver',
+  'America/Sao_Paulo',
+  'America/Mexico_City',
+  'Europe/London',
+  'Europe/Paris',
+  'Europe/Berlin',
+  'Europe/Amsterdam',
+  'Europe/Rome',
+  'Europe/Madrid',
+  'Europe/Moscow',
+  'Asia/Dubai',
+  'Asia/Kolkata',
+  'Asia/Singapore',
+  'Asia/Tokyo',
+  'Asia/Shanghai',
+  'Australia/Sydney',
+  'Pacific/Auckland',
+  'UTC',
+]
+
 const INACTIVATE_OPTIONS = [
   { label: '30 days', value: 30 },
   { label: '60 days', value: 60 },
@@ -74,6 +103,11 @@ export default function Account() {
   const [autoSchedule, setAutoSchedule] = useState(false)
   const [prefsInitialised, setPrefsInitialised] = useState(false)
   const [urlsInitialised, setUrlsInitialised] = useState(false)
+
+  // Timezone state
+  const [timezone, setTimezone] = useState('America/New_York')
+  const [tzInitialised, setTzInitialised] = useState(false)
+  const [tzSavedMsg, setTzSavedMsg] = useState<string | null>(null)
 
   // Handle LinkedIn OAuth callback: ?li_connected=1 or ?li_error=... in URL
   useEffect(() => {
@@ -146,6 +180,24 @@ export default function Account() {
     }
   }, [settingsData, prefsInitialised])
 
+  // Timezone query
+  const { data: tzData } = useQuery({
+    queryKey: ['user-timezone', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/timezone?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as { timezone: string }),
+    enabled: !!sessionToken,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  useEffect(() => {
+    if (tzData?.timezone && !tzInitialised) {
+      setTimezone(tzData.timezone)
+      setTzInitialised(true)
+    }
+  }, [tzData, tzInitialised])
+
   // Seed blog/sitemap from DB on first load — DB is source of truth over localStorage
   useEffect(() => {
     if (settingsData && !urlsInitialised) {
@@ -213,6 +265,20 @@ export default function Account() {
     onError: () => {
       setPrefsSavedMsg('Save failed — please try again.')
       setTimeout(() => setPrefsSavedMsg(null), 5000)
+    },
+  })
+
+  const tzMutation = useMutation({
+    mutationFn: () =>
+      api.put('/user/timezone', { session_token: sessionToken, timezone }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-timezone'] })
+      setTzSavedMsg('Timezone saved!')
+      setTimeout(() => setTzSavedMsg(null), 3000)
+    },
+    onError: () => {
+      setTzSavedMsg('Save failed — please try again.')
+      setTimeout(() => setTzSavedMsg(null), 5000)
     },
   })
 
@@ -643,6 +709,43 @@ export default function Account() {
           className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
         >
           {prefsMutation.isPending ? 'Saving…' : 'Save Preferences'}
+        </button>
+      </form>
+
+      {/* Timezone card */}
+      <form
+        onSubmit={(e) => { e.preventDefault(); tzMutation.mutate() }}
+        className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4"
+      >
+        <h2 className="text-base font-semibold text-gray-700">Timezone</h2>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Your timezone</label>
+          <select
+            value={timezone}
+            onChange={(e) => setTimezone(e.target.value)}
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {COMMON_TIMEZONES.map((tz) => (
+              <option key={tz} value={tz}>{tz}</option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-400 mt-1">
+            Scheduled post times will be displayed in this timezone across all pages.
+          </p>
+        </div>
+
+        {tzSavedMsg && (
+          <p className={`text-sm font-medium ${tzMutation.isError ? 'text-red-600' : 'text-green-600'}`}>
+            {tzSavedMsg}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={tzMutation.isPending}
+          className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        >
+          {tzMutation.isPending ? 'Saving…' : 'Save Timezone'}
         </button>
       </form>
     </div>

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -2,6 +2,8 @@ import { useQuery } from '@tanstack/react-query'
 import { Link } from 'react-router-dom'
 import api from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
+import { useUserTimezone } from '../hooks/useUserTimezone'
+import { formatInTimezone } from '../utils/datetime'
 
 interface DashboardStats {
   scheduled_this_week: number
@@ -55,6 +57,7 @@ function StatCard({ label, value, color }: { label: string; value: number; color
 export default function Dashboard() {
   const { user } = useAuth()
   const email = user?.email ?? ''
+  const userTimezone = useUserTimezone()
 
   const { data: statsData } = useQuery<{ detail: DashboardStats }>({
     queryKey: ['dashboard-stats', email],
@@ -149,12 +152,7 @@ export default function Dashboard() {
                   </div>
                   <div className="flex-1 min-w-0">
                     <p className="text-xs text-gray-500 mb-0.5">
-                      {new Date(post.scheduled_time).toLocaleString(undefined, {
-                        month: 'short',
-                        day: 'numeric',
-                        hour: '2-digit',
-                        minute: '2-digit',
-                      })}
+                      {formatInTimezone(post.scheduled_time, userTimezone)}
                     </p>
                     <p className="text-sm text-gray-700 line-clamp-2">{post.content}</p>
                   </div>
@@ -218,14 +216,7 @@ export default function Dashboard() {
                     )}
                   </div>
                   <span className="text-xs text-gray-400 flex-shrink-0 whitespace-nowrap">
-                    {entry.created_at
-                      ? new Date(entry.created_at).toLocaleString(undefined, {
-                          month: 'short',
-                          day: 'numeric',
-                          hour: '2-digit',
-                          minute: '2-digit',
-                        })
-                      : ''}
+                    {formatInTimezone(entry.created_at, userTimezone)}
                   </span>
                 </li>
               ))}

--- a/src/cqc_lem/ui/src/pages/ReviewSchedule.tsx
+++ b/src/cqc_lem/ui/src/pages/ReviewSchedule.tsx
@@ -3,6 +3,8 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../api/client'
 import LinkedInPostPreview from '../components/LinkedInPostPreview'
 import { useAuth } from '../contexts/AuthContext'
+import { useUserTimezone } from '../hooks/useUserTimezone'
+import { formatInTimezone } from '../utils/datetime'
 
 type Status = 'ALL' | 'pending' | 'approved' | 'scheduled' | 'posted' | 'rejected'
 const STATUSES: { label: string; value: Status }[] = [
@@ -45,6 +47,7 @@ export default function ReviewSchedule() {
   const { user } = useAuth()
   const email = user?.email ?? ''
   const qc = useQueryClient()
+  const userTimezone = useUserTimezone()
 
   // Filter / sort / pagination state
   const [filterStatus, setFilterStatus] = useState<Status>('ALL')
@@ -325,7 +328,7 @@ export default function ReviewSchedule() {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center justify-between mb-1 gap-2">
                     <span className="text-xs text-gray-400 truncate">
-                      {new Date(post.scheduled_time).toLocaleString()}
+                      {formatInTimezone(post.scheduled_time, userTimezone)}
                     </span>
                     <div className="flex items-center gap-1.5 shrink-0">
                       <span className="text-xs text-gray-400 uppercase">{post.post_type}</span>

--- a/src/cqc_lem/ui/src/pages/ScheduleContent.tsx
+++ b/src/cqc_lem/ui/src/pages/ScheduleContent.tsx
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import api from '../api/client'
 import LinkedInPostPreview from '../components/LinkedInPostPreview'
 import { useAuth } from '../contexts/AuthContext'
+import { useUserTimezone } from '../hooks/useUserTimezone'
 
 const POST_TYPES = ['TEXT', 'VIDEO', 'CAROUSEL'] as const
 type PostType = typeof POST_TYPES[number]
@@ -39,6 +40,8 @@ export default function ScheduleContent() {
   const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null)
   const [useAvatar, setUseAvatar] = useState(false)
 
+  const userTimezone = useUserTimezone()
+
   const { data: avatarData } = useQuery({
     queryKey: ['avatar-credits', sessionToken],
     queryFn: async () => {
@@ -50,7 +53,6 @@ export default function ScheduleContent() {
   const activeAvatar = avatarData?.active_avatar
   const hasActiveAvatar = activeAvatar?.status === 'succeeded'
   const MAX_CHARS = 3000
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
   const bestTimeSuggestion = scheduledAt ? getBestPostingTime(new Date(scheduledAt)) : null
 
@@ -133,7 +135,7 @@ export default function ScheduleContent() {
         )}
 
         <div className="bg-blue-50 border border-blue-200 rounded-lg px-4 py-2 text-xs text-blue-700">
-          Your timezone: <span className="font-semibold">{timezone}</span>
+          Times are in your profile timezone: <span className="font-semibold">{userTimezone}</span>
         </div>
 
         <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">

--- a/src/cqc_lem/ui/src/utils/datetime.ts
+++ b/src/cqc_lem/ui/src/utils/datetime.ts
@@ -1,0 +1,19 @@
+export function formatInTimezone(
+  isoString: string | null | undefined,
+  tz: string,
+  options?: Intl.DateTimeFormatOptions,
+): string {
+  if (!isoString) return '—'
+  try {
+    return new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      ...options,
+    }).format(new Date(isoString))
+  } catch {
+    return new Date(isoString).toLocaleString()
+  }
+}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -232,7 +232,11 @@ def get_user_access_token(user_id: int):
 
     try:
         cursor.execute(
-            "SELECT access_token FROM users WHERE id = %s AND (token_expiry IS NULL OR token_expiry > NOW())",
+            "SELECT access_token FROM users WHERE id = %s AND ("
+            "access_token_created_at IS NULL "
+            "OR access_token_expires_in IS NULL "
+            "OR DATE_ADD(access_token_created_at, INTERVAL access_token_expires_in SECOND) > NOW()"
+            ")",
             (user_id,),
         )
 
@@ -693,6 +697,39 @@ def get_ready_to_post_posts(pre_post_time: datetime = None, post_time_delta_minu
     except mysql.connector.Error as err:
         myprint(f"Could not get ready to post posts| Error: {err}")
         posts = None
+    finally:
+        cursor.close()
+        connection.close()
+
+    return posts
+
+
+def get_orphaned_scheduled_posts(lookback_hours: int = 2) -> list:
+    """Return posts stuck in 'scheduled' status that never reached 'posted'.
+
+    These arise when Celery tasks are purged on container restart while a post
+    has already been transitioned from 'approved' → 'scheduled'. Without this
+    recovery query, those posts stay stuck forever.
+    """
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=lookback_hours)
+
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            """SELECT p.id, p.scheduled_time, p.user_id
+               FROM posts AS p
+               WHERE status = 'scheduled'
+                 AND scheduled_time <= %s
+               ORDER BY scheduled_time ASC""",
+            (cutoff,),
+        )
+        posts = cursor.fetchall()
+        myprint(f"Orphaned scheduled posts to re-queue: {[p[0] for p in posts]}")
+    except mysql.connector.Error as err:
+        myprint(f"Could not get orphaned scheduled posts | Error: {err}")
+        posts = []
     finally:
         cursor.close()
         connection.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -49,7 +49,8 @@ def get_db_connection():
         user=MYSQL_USER,
         password=MYSQL_PASSWORD,
         database=MYSQL_DATABASE,
-        port=MYSQL_PORT
+        port=MYSQL_PORT,
+        time_zone='+00:00',
     )
 
 
@@ -1783,6 +1784,38 @@ def update_user_preferences(
         return cursor.rowcount >= 0
     except mysql.connector.Error as err:
         myprint(f"Could not update preferences for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_user_timezone(user_id: int) -> str:
+    """Return the IANA timezone string for the user, defaulting to UTC."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT timezone FROM users WHERE id = %s", (user_id,))
+        row = cursor.fetchone()
+        return row[0] if row and row[0] else 'UTC'
+    except mysql.connector.Error as err:
+        myprint(f"Could not get timezone for user_id {user_id} | Error: {err}")
+        return 'UTC'
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_user_timezone(user_id: int, tz: str) -> bool:
+    """Persist the user's preferred IANA timezone string."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("UPDATE users SET timezone = %s WHERE id = %s", (tz, user_id))
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update timezone for user_id {user_id} | Error: {err}")
         return False
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -16,28 +16,36 @@ from selenium.webdriver.support.wait import WebDriverWait
 
 def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, user_password: str):
     linked_url = "https://www.linkedin.com"
+    feed_url = "https://www.linkedin.com/feed/"
+    login_url = "https://www.linkedin.com/login"
 
-    # Check the Database if we have any stored cookies for the LinkedIn url.
-    cookies = get_cookies(linked_url, user_email)
+    _CHALLENGE_PATHS = ('/checkpoint/', '/authwall', '/uas/login', '/challenge/')
+    # LinkedIn can land on /home, /feed, /mynetwork, etc. when logged in
+    _LOGGED_IN_PATHS = ('/feed', '/home', '/mynetwork', '/jobs', '/messaging',
+                        '/notifications', '/in/', '/search')
 
+    def _is_challenge_url(url: str) -> bool:
+        return any(p in url for p in _CHALLENGE_PATHS)
+
+    def _is_logged_in(url: str) -> bool:
+        return any(p in url for p in _LOGGED_IN_PATHS)
+
+    # Load base domain first so cookies can be set against the right origin
     driver.get(linked_url)
 
-    # If we have cookies, try to load them into the driver
+    cookies = get_cookies(linked_url, user_email)
+
     if cookies:
         myprint("Found previous cookies. Loading them now!")
         load_cookies(driver, cookies)
-        # Reload the page
-        driver.get(linked_url)
+        # Navigate directly to the feed — if cookies are valid LinkedIn serves it;
+        # if invalid/expired it redirects to a login or challenge page
+        driver.get(feed_url)
     else:
         myprint("No previous cookies found.")
 
-    # Wait for the login page to load
+    # Wait for the redirect / page load to settle
     time.sleep(2)
-
-    _LINKEDIN_CHALLENGE_PATHS = ('/checkpoint/', '/authwall/', '/uas/login', '/challenge/')
-
-    def _is_challenge_url(url: str) -> bool:
-        return any(p in url for p in _LINKEDIN_CHALLENGE_PATHS)
 
     if _is_challenge_url(driver.current_url):
         log_error(
@@ -47,56 +55,42 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
         )
         raise RuntimeError(f"LinkedIn security challenge at {driver.current_url}")
 
-    if "feed" in driver.current_url:
-        myprint("Already Logged in!")
-
-        # update the cookies for this url in the database
+    if _is_logged_in(driver.current_url):
+        myprint(f"Already logged in! (current URL: {driver.current_url})")
         store_cookies(user_email, driver.get_cookies())
         myprint("Cookies stored to DB!")
+        return
 
+    # Cookies missing or expired — do a full credential login
+    myprint(f"Logging in to LinkedIn as: {user_email}")
+
+    # Go directly to the login page instead of clicking a "Sign in" link
+    driver.get(login_url)
+    time.sleep(1)
+
+    if _is_challenge_url(driver.current_url):
+        log_error(
+            "LinkedIn security challenge detected on login page — login blocked",
+            action_type="login",
+            error_message=f"Redirected to: {driver.current_url}",
+        )
+        raise RuntimeError(f"LinkedIn security challenge at {driver.current_url}")
+
+    username_field = get_element_wait_retry(driver, wait, 'username', "Finding Username Field", By.ID)
+    password_field = get_element_wait_retry(driver, wait, 'password', "Finding Password Field", By.ID)
+
+    username_field.send_keys(user_email)
+    password_field.send_keys(user_password)
+    click_element_wait_retry(driver, wait, '//*[@type="submit"]', "Finding Login Button", use_action_chain=True)
+
+    wait.until(EC.title_contains("Feed"), "Waiting for Feed to load after login")
+
+    if _is_logged_in(driver.current_url):
+        myprint("Login successful!")
+        store_cookies(user_email, driver.get_cookies())
+        myprint("Cookies stored to DB!")
     else:
-
-        myprint(f"Logging in to LinkedIn as: {user_email} ")
-
-        # click the Sign in button
-        click_element_wait_retry(driver, wait, '//a[contains(text(),"Sign in")][1]', 'Clicking Sign In Button')
-
-        # Wait for the login page to load
-        # time.sleep(2)
-
-        if _is_challenge_url(driver.current_url):
-            log_error(
-                "LinkedIn security challenge detected after Sign In redirect — login blocked",
-                action_type="login",
-                error_message=f"Redirected to: {driver.current_url}",
-            )
-            raise RuntimeError(f"LinkedIn security challenge at {driver.current_url}")
-
-        # Find the username and password input fields and log in
-        username_field = get_element_wait_retry(driver, wait, 'username', "Finding Username Field", By.ID)
-        password_field = get_element_wait_retry(driver, wait, 'password', "Finding Password Field", By.ID)
-
-        # Fill in the form and submit
-        username_field.send_keys(user_email)
-        password_field.send_keys(user_password)
-        click_element_wait_retry(driver, wait, '//*[@type="submit"]', "Finding Login Button", use_action_chain=True)
-
-        # Wait for the home page to load
-        # time.sleep(5)
-
-        # Wait for title to change
-        wait.until(EC.title_contains("Feed"), "Waiting for Title to change")
-
-        # Check for successful login by looking for the search box
-        if "feed" in driver.current_url:
-            myprint("Login successful!")
-
-            # update the cookies for this url in the database
-            store_cookies(user_email, driver.get_cookies())
-            myprint("Cookies stored to DB!")
-        else:
-            myprint("Login failed. Check your credentials.")
-            # are_you_satisfied()
+        myprint("Login failed. Check your credentials.")
 
 
 def get_my_profile(driver, wait, user_email: str, user_password: str, user_id: Optional[int] = None) -> LinkedInProfile:

--- a/src/cqc_lem/utilities/logger.py
+++ b/src/cqc_lem/utilities/logger.py
@@ -1,7 +1,6 @@
 import logging
 import os
 import sys
-import traceback
 import datetime as DT
 from logging.handlers import RotatingFileHandler
 from typing import Optional
@@ -14,52 +13,28 @@ _today = DT.date.today()
 LOGGING_FILENAME = "logs/cqc_lem_" + _today.strftime("%Y_%m_%d") + ".log"
 os.makedirs("logs", exist_ok=True)
 
-# Structured extra keys forwarded to PostHog when present on a LogRecord
-_POSTHOG_EXTRA_KEYS = (
-    "user_id", "task_id", "task_name", "post_id", "action_type",
-    "duration_ms", "ai_model", "api_provider", "http_status",
-    "error_type", "error_message", "stack_trace",
-)
 
+def _build_posthog_handler(level: int) -> Optional[logging.Handler]:
+    """Build an OTLP-backed LoggingHandler that ships logs to PostHog Logs."""
+    api_key = os.getenv("POSTHOG_API_KEY", "")
+    host = os.getenv("POSTHOG_HOST", "https://us.i.posthog.com").rstrip("/")
+    if not api_key:
+        return None
 
-class PostHogHandler(logging.Handler):
-    """Forwards log records to PostHog as `log_event` captures.
+    from opentelemetry._logs import set_logger_provider
+    from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+    from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+    from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
-    Structured context is attached via `extra=` on the log call.
-    Exceptions are captured with their full traceback automatically.
-    """
+    exporter = OTLPLogExporter(
+        endpoint=f"{host}/i/v1/logs",
+        headers={"Authorization": f"Bearer {api_key}"},
+    )
+    provider = LoggerProvider()
+    provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
+    set_logger_provider(provider)
 
-    def emit(self, record: logging.LogRecord) -> None:
-        try:
-            import posthog as _ph  # local import — avoids circular dep at module load
-
-            if _ph.disabled:
-                return
-
-            props: dict = {
-                "level": record.levelname.lower(),
-                "module": record.module,
-                "function": record.funcName,
-                "filename": record.filename,
-                "lineno": record.lineno,
-                "message": record.getMessage(),
-            }
-
-            for key in _POSTHOG_EXTRA_KEYS:
-                val = getattr(record, key, None)
-                if val is not None:
-                    props[key] = val
-
-            if record.exc_info and record.exc_info[0] is not None:
-                exc_cls, exc_val, exc_tb = record.exc_info
-                props.setdefault("error_type", exc_cls.__name__)
-                props.setdefault("error_message", str(exc_val))
-                props.setdefault("stack_trace", "".join(traceback.format_exception(exc_cls, exc_val, exc_tb)))
-
-            distinct_id = str(props.get("user_id") or "system")
-            _ph.capture(distinct_id=distinct_id, event="log_event", properties=props)
-        except Exception:
-            self.handleError(record)
+    return LoggingHandler(level=level, logger_provider=provider)
 
 
 class _LevelFormatter(logging.Formatter):
@@ -100,8 +75,9 @@ _console_handler.setFormatter(_formatter)
 _console_handler.setLevel(_LOG_LEVEL)
 logger.addHandler(_console_handler)
 
-_posthog_handler = PostHogHandler(level=_POSTHOG_MIN_LEVEL)
-logger.addHandler(_posthog_handler)
+_posthog_handler = _build_posthog_handler(_POSTHOG_MIN_LEVEL)
+if _posthog_handler is not None:
+    logger.addHandler(_posthog_handler)
 
 
 # ── Internal helpers ─────────────────────────────────────────────────────────

--- a/tests/e2e/test_post_workflow_e2e.py
+++ b/tests/e2e/test_post_workflow_e2e.py
@@ -1,0 +1,324 @@
+"""End-to-end test for the post-publishing workflow.
+
+Tests the complete path:
+  DB (approved post) → auto_check_scheduled_posts → status=scheduled
+  → post_to_linkedin → status=posted + activity log + reply commenting dispatched
+  → orphaned-post recovery when the task is lost
+
+Requires a running MySQL instance.  When run from the host machine (outside
+Docker), set MYSQL_HOST=127.0.0.1 (MySQL is exposed on 0.0.0.0:3306 by
+docker-compose).  When run inside the Docker network, the default `mysql_db`
+hostname resolves correctly.
+
+    # host-machine run:
+    MYSQL_HOST=127.0.0.1 poetry run pytest tests/e2e/test_post_workflow_e2e.py -m e2e -v
+
+    # inside docker network (e.g. CI service container):
+    poetry run pytest tests/e2e/test_post_workflow_e2e.py -m e2e -v
+
+Does NOT require a LinkedIn connection — the LinkedIn API call is mocked so no
+real posts are created.
+
+Cleanup is handled automatically by the module-scoped fixture.
+"""
+
+import os
+import pytest
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, MagicMock
+
+pytestmark = pytest.mark.e2e
+
+# ---------------------------------------------------------------------------
+# Allow the test to override MYSQL_HOST so it can be run from the host machine
+# (where the Docker-internal hostname 'mysql_db' is not resolvable).
+# ---------------------------------------------------------------------------
+_E2E_MYSQL_HOST = os.environ.get("MYSQL_HOST_E2E") or os.environ.get("MYSQL_HOST", "127.0.0.1")
+_E2E_MYSQL_PORT = int(os.environ.get("MYSQL_PORT", "3306"))
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_URN = "urn:li:share:9999999999999"
+_TEST_EMAIL = os.environ.get("TEST_LI_EMAIL", "workflow-e2e@test.internal")
+_DB_MOD = "cqc_lem.utilities.db"
+
+
+def _get_db():
+    """Return a fresh MySQL connection, overriding the host for host-machine runs."""
+    import cqc_lem.utilities.db as _db_mod
+    _db_mod.MYSQL_HOST = _E2E_MYSQL_HOST
+    _db_mod.MYSQL_PORT = _E2E_MYSQL_PORT
+    return _db_mod.get_db_connection()
+
+
+def _create_test_user(cursor, email: str) -> int:
+    """Insert a minimal test user and return its id.  Uses INSERT IGNORE so
+    the test is idempotent when the user already exists."""
+    cursor.execute(
+        """INSERT IGNORE INTO users (email, linkedin_connection_status, subscription_status)
+           VALUES (%s, 'connected', 'active')""",
+        (email,),
+    )
+    cursor.execute("SELECT id FROM users WHERE email = %s", (email,))
+    return cursor.fetchone()[0]
+
+
+def _insert_approved_post(cursor, user_id: int, scheduled_time: datetime) -> int:
+    """Insert a post in 'approved' status ready to be picked up by the scheduler."""
+    cursor.execute(
+        """INSERT INTO posts (user_id, content, post_type, status, scheduled_time)
+           VALUES (%s, %s, 'text', 'approved', %s)""",
+        (user_id, "E2E workflow test post — safe to delete", scheduled_time),
+    )
+    return cursor.lastrowid
+
+
+def _get_post_status(cursor, post_id: int) -> str:
+    cursor.execute("SELECT status FROM posts WHERE id = %s", (post_id,))
+    row = cursor.fetchone()
+    return row[0] if row else None
+
+
+def _get_latest_log(cursor, user_id: int, post_id: int):
+    cursor.execute(
+        "SELECT action_type, result, post_url FROM logs WHERE user_id=%s AND post_id=%s ORDER BY id DESC LIMIT 1",
+        (user_id, post_id),
+    )
+    return cursor.fetchone()
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fixture — creates test data and cleans up after all tests
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def workflow_state():
+    """Creates a test user + post, yields state dict, then deletes all test data."""
+    conn = _get_db()
+    cursor = conn.cursor()
+
+    try:
+        # Schedule the post 1 minute in the past so the scheduler window includes it
+        scheduled_time = datetime.now(timezone.utc) - timedelta(minutes=1)
+
+        user_id = _create_test_user(cursor, _TEST_EMAIL)
+        post_id = _insert_approved_post(cursor, user_id, scheduled_time)
+        conn.commit()
+
+        yield {
+            "user_id": user_id,
+            "post_id": post_id,
+            "scheduled_time": scheduled_time,
+            "fake_urn": _FAKE_URN,
+        }
+
+    finally:
+        # Cleanup — remove test posts and logs; leave the user row (IGNORE on insert)
+        cursor.execute("DELETE FROM logs WHERE user_id = %s AND post_id IN (SELECT id FROM posts WHERE user_id = %s)", (user_id, user_id))
+        cursor.execute("DELETE FROM posts WHERE user_id = %s AND content = 'E2E workflow test post — safe to delete'", (user_id,))
+        conn.commit()
+        cursor.close()
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: scheduler picks up the approved post and marks it scheduled
+# ---------------------------------------------------------------------------
+
+class TestSchedulerPicksUpApprovedPost:
+    def test_auto_check_transitions_post_to_scheduled(self, workflow_state):
+        """auto_check_scheduled_posts must find the approved post and change its
+        status to 'scheduled', then dispatch post_to_linkedin via apply_async."""
+        post_id = workflow_state["post_id"]
+        user_id = workflow_state["user_id"]
+
+        mock_post_task = MagicMock()
+        mock_post_task.apply_async = MagicMock()
+        mock_commenting = MagicMock()
+        mock_commenting.apply_async = MagicMock()
+        mock_profile = MagicMock()
+        mock_profile.apply_async = MagicMock()
+
+        with patch("cqc_lem.app.run_scheduler.post_to_linkedin", mock_post_task), \
+             patch("cqc_lem.app.run_scheduler.automate_commenting", mock_commenting), \
+             patch("cqc_lem.app.run_scheduler.automate_profile_viewer_engagement", mock_profile), \
+             patch("cqc_lem.app.run_scheduler.get_orphaned_scheduled_posts", return_value=[]):
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            result = auto_check_scheduled_posts.run()
+
+        # Scheduler must have found our post
+        assert "1 post" in result or str(post_id) in result or "post" in result.lower()
+
+        # post_to_linkedin must have been dispatched
+        mock_post_task.apply_async.assert_called()
+        dispatched_kwargs = mock_post_task.apply_async.call_args[1]["kwargs"]
+        assert dispatched_kwargs["post_id"] == post_id
+        assert dispatched_kwargs["user_id"] == user_id
+
+        # Pre-post engagement tasks dispatched
+        mock_commenting.apply_async.assert_called()
+        mock_profile.apply_async.assert_called()
+
+        # DB status updated to 'scheduled'
+        conn = _get_db()
+        cursor = conn.cursor()
+        try:
+            status = _get_post_status(cursor, post_id)
+        finally:
+            cursor.close()
+            conn.close()
+
+        assert status == "scheduled", f"Expected 'scheduled', got '{status}'"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: post_to_linkedin posts successfully and updates all state
+# ---------------------------------------------------------------------------
+
+class TestPostToLinkedinSuccessPath:
+    def test_post_published_updates_db_and_writes_log(self, workflow_state):
+        """post_to_linkedin must: update status→posted, write success activity log,
+        dispatch automate_reply_commenting."""
+        post_id = workflow_state["post_id"]
+        user_id = workflow_state["user_id"]
+        fake_urn = workflow_state["fake_urn"]
+
+        mock_reply_task = MagicMock()
+        mock_reply_task.apply_async = MagicMock()
+
+        # Patch share_on_linkedin at the run_automation import site and also
+        # at the poster module level to cover both call paths.
+        with patch("cqc_lem.app.run_automation.share_on_linkedin", return_value=fake_urn), \
+             patch("cqc_lem.utilities.linkedin.poster.share_on_linkedin", return_value=fake_urn), \
+             patch("cqc_lem.app.run_automation.automate_reply_commenting", mock_reply_task):
+            from cqc_lem.app.run_automation import post_to_linkedin
+            result = post_to_linkedin.run(user_id=user_id, post_id=post_id)
+
+        assert "successfully" in result.lower(), f"Expected success, got: {result}"
+
+        # Status must be 'posted'
+        conn = _get_db()
+        cursor = conn.cursor()
+        try:
+            status = _get_post_status(cursor, post_id)
+            log_row = _get_latest_log(cursor, user_id, post_id)
+        finally:
+            cursor.close()
+            conn.close()
+
+        assert status == "posted", f"Expected 'posted', got '{status}'"
+
+        # Activity log must record success with the LinkedIn URL
+        assert log_row is not None, "No activity log row written"
+        action_type, result_val, post_url = log_row
+        assert action_type == "post"
+        assert result_val == "success"
+        assert fake_urn in (post_url or ""), f"Expected URN in post_url, got: {post_url}"
+
+        # Reply commenting must be dispatched
+        mock_reply_task.apply_async.assert_called_once()
+        reply_kwargs = mock_reply_task.apply_async.call_args[1]["kwargs"]
+        assert reply_kwargs["user_id"] == user_id
+        assert reply_kwargs["post_id"] == post_id
+
+    def test_already_posted_skips_duplicate(self, workflow_state):
+        """If post_to_linkedin is called again for an already-posted post, it must
+        skip without re-publishing."""
+        post_id = workflow_state["post_id"]
+        user_id = workflow_state["user_id"]
+
+        with patch("cqc_lem.app.run_automation.share_on_linkedin") as mock_share:
+            from cqc_lem.app.run_automation import post_to_linkedin
+            result = post_to_linkedin.run(user_id=user_id, post_id=post_id)
+
+        assert "already posted" in result.lower()
+        mock_share.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test 3: orphaned-post recovery (task lost after container restart)
+# ---------------------------------------------------------------------------
+
+class TestOrphanedPostRecovery:
+    def test_orphaned_scheduled_post_is_requeued_by_scheduler(self):
+        """A post stuck in 'scheduled' status (task lost on restart) must be
+        re-dispatched by get_orphaned_scheduled_posts on the next scheduler pass."""
+        stuck_time = datetime.now(timezone.utc) - timedelta(hours=3)
+        orphaned = [(9999, stuck_time, 1)]
+
+        mock_post_task = MagicMock()
+        mock_post_task.apply_async = MagicMock()
+
+        with patch("cqc_lem.app.run_scheduler.get_ready_to_post_posts", return_value=[]), \
+             patch("cqc_lem.app.run_scheduler.get_orphaned_scheduled_posts", return_value=orphaned), \
+             patch("cqc_lem.app.run_scheduler.post_to_linkedin", mock_post_task):
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            result = auto_check_scheduled_posts.run()
+
+        mock_post_task.apply_async.assert_called_once()
+        assert "re-queued" in result
+        dispatched = mock_post_task.apply_async.call_args[1]["kwargs"]
+        assert dispatched["post_id"] == 9999
+        assert dispatched["user_id"] == 1
+
+    def test_get_orphaned_scheduled_posts_uses_correct_status_filter(self):
+        """get_orphaned_scheduled_posts must only return posts with status='scheduled'."""
+        from cqc_lem.utilities.db import get_orphaned_scheduled_posts
+
+        # Insert a temporary post in 'approved' status — should NOT be returned
+        conn = _get_db()
+        cursor = conn.cursor()
+        try:
+            scheduled_time = datetime.now(timezone.utc) - timedelta(hours=5)
+            cursor.execute(
+                "INSERT INTO posts (user_id, content, post_type, status, scheduled_time) VALUES (1, 'orphan-test', 'text', 'approved', %s)",
+                (scheduled_time,),
+            )
+            approved_id = cursor.lastrowid
+            conn.commit()
+
+            results = get_orphaned_scheduled_posts(lookback_hours=2)
+            result_ids = [r[0] for r in results]
+            assert approved_id not in result_ids, (
+                "get_orphaned_scheduled_posts must NOT return 'approved' posts"
+            )
+        finally:
+            cursor.execute("DELETE FROM posts WHERE id = %s", (approved_id,))
+            conn.commit()
+            cursor.close()
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: get_user_access_token uses correct column names
+# ---------------------------------------------------------------------------
+
+class TestAccessTokenSqlCorrectness:
+    def test_access_token_retrieved_for_connected_user(self):
+        """Regression: get_user_access_token must NOT reference the non-existent
+        'token_expiry' column (which caused a MySQL error blocking all posts)."""
+        from cqc_lem.utilities.db import get_user_access_token
+
+        conn = _get_db()
+        cursor = conn.cursor()
+        try:
+            # Insert a user with an access token and no expiry info
+            cursor.execute(
+                """INSERT IGNORE INTO users (email, access_token, linkedin_connection_status, subscription_status)
+                   VALUES ('token-test-e2e@test.internal', 'test-token-value', 'connected', 'active')""",
+            )
+            cursor.execute(
+                "SELECT id FROM users WHERE email = 'token-test-e2e@test.internal'"
+            )
+            user_id = cursor.fetchone()[0]
+            conn.commit()
+
+            token = get_user_access_token(user_id)
+            assert token == "test-token-value", f"Expected token, got: {token}"
+        finally:
+            cursor.execute("DELETE FROM users WHERE email = 'token-test-e2e@test.internal'")
+            conn.commit()
+            cursor.close()
+            conn.close()

--- a/tests/unit/api/test_api_timezone.py
+++ b/tests/unit/api/test_api_timezone.py
@@ -1,0 +1,70 @@
+"""Unit tests for GET/PUT /api/user/timezone endpoints."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_BASE = "/api/user/timezone"
+_SESSION = "tok_test"
+_USER_ID = 42
+
+
+class TestGetUserTimezone:
+    def test_returns_timezone_for_valid_session(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.get_user_timezone", return_value="America/New_York"):
+            resp = client.get(f"{_BASE}?session_token={_SESSION}")
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["timezone"] == "America/New_York"
+
+    def test_returns_401_for_invalid_session(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.get(f"{_BASE}?session_token=bad")
+        assert resp.status_code == 401
+
+
+class TestPutUserTimezone:
+    def test_updates_valid_iana_timezone(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.update_user_timezone", return_value=True):
+            resp = client.put(_BASE, json={"session_token": _SESSION, "timezone": "America/New_York"})
+        assert resp.status_code == 200
+
+    def test_rejects_invalid_timezone_string(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID):
+            resp = client.put(_BASE, json={"session_token": _SESSION, "timezone": "Not/A/Timezone"})
+        assert resp.status_code == 422
+
+    def test_returns_401_for_invalid_session(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.put(_BASE, json={"session_token": "bad", "timezone": "UTC"})
+        assert resp.status_code == 401
+
+    def test_returns_500_when_db_update_fails(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.update_user_timezone", return_value=False):
+            resp = client.put(_BASE, json={"session_token": _SESSION, "timezone": "UTC"})
+        assert resp.status_code == 500

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -21,6 +21,7 @@ _PATCH_GET_TIER = "cqc_lem.utilities.stripe_util.get_subscription_tier_from_pric
 _PATCH_STATUS_TO_DB = "cqc_lem.utilities.stripe_util.stripe_status_to_db"
 _PATCH_GET_ACTIVE = f"{_MOD}.get_active_user_ids"
 _PATCH_GET_POSTS = f"{_MOD}.get_ready_to_post_posts"
+_PATCH_GET_ORPHANED = f"{_MOD}.get_orphaned_scheduled_posts"
 _PATCH_UPDATE_POST_STATUS = f"{_MOD}.update_db_post_status"
 _PATCH_POST_TO_LINKEDIN = f"{_MOD}.post_to_linkedin"
 _PATCH_APPRECIATE = f"{_MOD}.automate_appreciation_dms_for_user"
@@ -216,7 +217,8 @@ class TestSyncStripeSubscriptions:
 
 class TestAutoCheckScheduledPosts:
     def test_no_posts_returns_no_post_to_schedule(self):
-        with patch(_PATCH_GET_POSTS, return_value=[]):
+        with patch(_PATCH_GET_POSTS, return_value=[]), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]):
             from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
             result = auto_check_scheduled_posts.run()
 
@@ -231,6 +233,7 @@ class TestAutoCheckScheduledPosts:
         mock_profile_task = _async_task_mock()
 
         with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
              patch(_PATCH_UPDATE_POST_STATUS) as mock_upd, \
              patch(_PATCH_POST_TO_LINKEDIN, mock_post_task), \
              patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
@@ -269,6 +272,7 @@ class TestAutoCheckScheduledPosts:
         mock_profile_task = _async_task_mock()
 
         with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
              patch(_PATCH_UPDATE_POST_STATUS), \
              patch(_PATCH_POST_TO_LINKEDIN, mock_post_task), \
              patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
@@ -290,6 +294,7 @@ class TestAutoCheckScheduledPosts:
         mock_profile_task = _async_task_mock()
 
         with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
              patch(_PATCH_UPDATE_POST_STATUS), \
              patch(_PATCH_POST_TO_LINKEDIN, mock_post_task), \
              patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
@@ -320,6 +325,7 @@ class TestAutoCheckScheduledPosts:
         mock_post_task.apply_async.side_effect = record_apply
 
         with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
              patch(_PATCH_UPDATE_POST_STATUS, side_effect=record_update), \
              patch(_PATCH_POST_TO_LINKEDIN, mock_post_task), \
              patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
@@ -329,6 +335,68 @@ class TestAutoCheckScheduledPosts:
 
         assert call_order[0] == "update_status"
         assert "apply_async" in call_order
+
+
+    def test_orphaned_scheduled_post_is_requeued(self):
+        """Posts stuck in 'scheduled' status (task lost on restart) must be re-dispatched."""
+        orphaned_dt = datetime(2026, 6, 19, 19, 45, 0, tzinfo=timezone.utc)
+        orphaned = [(1485, orphaned_dt, 60)]
+
+        mock_post_task = _async_task_mock()
+
+        with patch(_PATCH_GET_POSTS, return_value=[]), \
+             patch(_PATCH_GET_ORPHANED, return_value=orphaned), \
+             patch(_PATCH_POST_TO_LINKEDIN, mock_post_task):
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            result = auto_check_scheduled_posts.run()
+
+        mock_post_task.apply_async.assert_called_once()
+        call_kwargs = mock_post_task.apply_async.call_args[1]
+        assert call_kwargs["kwargs"] == {"user_id": 60, "post_id": 1485}
+        assert "re-queued" in result
+        assert "1" in result
+
+    def test_orphaned_naive_datetime_gets_utc_tzinfo(self):
+        """Naive orphaned scheduled_time is made UTC-aware before re-queuing."""
+        naive_orphaned_dt = datetime(2026, 6, 19, 19, 45, 0)  # no tzinfo
+        orphaned = [(1485, naive_orphaned_dt, 60)]
+
+        mock_post_task = _async_task_mock()
+
+        with patch(_PATCH_GET_POSTS, return_value=[]), \
+             patch(_PATCH_GET_ORPHANED, return_value=orphaned), \
+             patch(_PATCH_POST_TO_LINKEDIN, mock_post_task):
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            auto_check_scheduled_posts.run()
+
+        # Task dispatched without error — no assertion needed on eta since
+        # orphaned re-queuing dispatches immediately (no eta kwarg)
+        mock_post_task.apply_async.assert_called_once()
+
+    def test_both_approved_and_orphaned_processed_together(self):
+        """New approved posts and orphaned scheduled posts are both handled in one pass."""
+        approved_dt = datetime(2026, 6, 20, 14, 0, 0, tzinfo=timezone.utc)
+        orphaned_dt = datetime(2026, 6, 19, 19, 45, 0, tzinfo=timezone.utc)
+
+        new_posts = [(100, approved_dt, 7)]
+        orphaned = [(1485, orphaned_dt, 60)]
+
+        mock_post_task = _async_task_mock()
+        mock_commenting_task = _async_task_mock()
+        mock_profile_task = _async_task_mock()
+
+        with patch(_PATCH_GET_POSTS, return_value=new_posts), \
+             patch(_PATCH_GET_ORPHANED, return_value=orphaned), \
+             patch(_PATCH_UPDATE_POST_STATUS), \
+             patch(_PATCH_POST_TO_LINKEDIN, mock_post_task), \
+             patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
+             patch(_PATCH_AUTOMATE_PROFILE_VIEWER, mock_profile_task):
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            result = auto_check_scheduled_posts.run()
+
+        assert mock_post_task.apply_async.call_count == 2  # one new + one orphaned
+        assert "1 post" in result
+        assert "1 orphaned" in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -28,7 +28,6 @@ _PATCH_CLEAN_INVITES = f"{_MOD}.clean_stale_invites"
 _PATCH_UPDATE_STALE = f"{_MOD}.update_stale_profile"
 _PATCH_AUTOMATE_COMMENTING = f"{_MOD}.automate_commenting"
 _PATCH_AUTOMATE_PROFILE_VIEWER = f"{_MOD}.automate_profile_viewer_engagement"
-_PATCH_CONVERT_DT = f"{_MOD}.convert_datetime_to_local_tz"
 
 
 # ---------------------------------------------------------------------------
@@ -233,7 +232,6 @@ class TestAutoCheckScheduledPosts:
 
         with patch(_PATCH_GET_POSTS, return_value=posts), \
              patch(_PATCH_UPDATE_POST_STATUS) as mock_upd, \
-             patch(_PATCH_CONVERT_DT, return_value=scheduled_dt), \
              patch(_PATCH_POST_TO_LINKEDIN, mock_post_task), \
              patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
              patch(_PATCH_AUTOMATE_PROFILE_VIEWER, mock_profile_task):
@@ -272,7 +270,6 @@ class TestAutoCheckScheduledPosts:
 
         with patch(_PATCH_GET_POSTS, return_value=posts), \
              patch(_PATCH_UPDATE_POST_STATUS), \
-             patch(_PATCH_CONVERT_DT, return_value=scheduled_dt), \
              patch(_PATCH_POST_TO_LINKEDIN, mock_post_task), \
              patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
              patch(_PATCH_AUTOMATE_PROFILE_VIEWER, mock_profile_task):
@@ -281,6 +278,28 @@ class TestAutoCheckScheduledPosts:
 
         assert "3 post" in result
         assert mock_post_task.apply_async.call_count == 3
+
+    def test_naive_scheduled_time_gets_utc_tzinfo(self):
+        """A naive datetime returned from MySQL is treated as UTC before becoming the eta."""
+        naive_dt = datetime(2025, 6, 20, 14, 0, 0)  # no tzinfo — simulates MySQL read
+        expected_eta = datetime(2025, 6, 20, 14, 0, 0, tzinfo=timezone.utc)
+        posts = [(55, naive_dt, 10)]
+
+        mock_post_task = _async_task_mock()
+        mock_commenting_task = _async_task_mock()
+        mock_profile_task = _async_task_mock()
+
+        with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_UPDATE_POST_STATUS), \
+             patch(_PATCH_POST_TO_LINKEDIN, mock_post_task), \
+             patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
+             patch(_PATCH_AUTOMATE_PROFILE_VIEWER, mock_profile_task):
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            auto_check_scheduled_posts.run()
+
+        eta = mock_post_task.apply_async.call_args[1]["eta"]
+        assert eta.tzinfo is not None, "eta must be timezone-aware"
+        assert eta == expected_eta
 
     def test_update_db_post_status_called_before_apply_async(self):
         """Status must be set to SCHEDULED before dispatching the Celery task."""
@@ -302,7 +321,6 @@ class TestAutoCheckScheduledPosts:
 
         with patch(_PATCH_GET_POSTS, return_value=posts), \
              patch(_PATCH_UPDATE_POST_STATUS, side_effect=record_update), \
-             patch(_PATCH_CONVERT_DT, return_value=scheduled_dt), \
              patch(_PATCH_POST_TO_LINKEDIN, mock_post_task), \
              patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
              patch(_PATCH_AUTOMATE_PROFILE_VIEWER, mock_profile_task):

--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -1,0 +1,153 @@
+"""Unit tests for cqc_lem.utilities.linkedin.helper — login_to_linkedin."""
+
+import pytest
+from unittest.mock import MagicMock, patch, call
+
+pytestmark = pytest.mark.unit
+
+_MODULE = "cqc_lem.utilities.linkedin.helper"
+
+
+def _make_driver(url: str) -> MagicMock:
+    driver = MagicMock()
+    driver.current_url = url
+    driver.get_cookies.return_value = [{"name": "li_at", "value": "tok"}]
+    return driver
+
+
+def _make_wait() -> MagicMock:
+    wait = MagicMock()
+    wait.until = MagicMock()
+    return wait
+
+
+@pytest.mark.unit
+class TestLoginToLinkedinCookiePath:
+    """Tests for the cookie-based fast-path (already logged in)."""
+
+    def _run(self, url_after_load: str, cookies=None):
+        driver = _make_driver(url_after_load)
+        wait = _make_wait()
+
+        with patch(f"{_MODULE}.get_cookies", return_value=cookies or [{"name": "x"}]), \
+             patch(f"{_MODULE}.load_cookies") as mock_load, \
+             patch(f"{_MODULE}.store_cookies") as mock_store:
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "test@example.com", "password")
+
+        return driver, mock_load, mock_store
+
+    def test_already_logged_in_feed_url(self):
+        """Navigating to /feed/ with valid cookies → detected as logged in."""
+        driver, _, mock_store = self._run("https://www.linkedin.com/feed/")
+        # Cookies are refreshed in the DB
+        mock_store.assert_called_once_with("test@example.com", driver.get_cookies())
+
+    def test_already_logged_in_home_url(self):
+        """LinkedIn /home redirect (new behaviour) → still detected as logged in."""
+        driver, _, mock_store = self._run("https://www.linkedin.com/home")
+        mock_store.assert_called_once()
+
+    def test_already_logged_in_mynetwork_url(self):
+        """LinkedIn /mynetwork → logged in."""
+        driver, _, mock_store = self._run("https://www.linkedin.com/mynetwork/")
+        mock_store.assert_called_once()
+
+    def test_already_logged_in_jobs_url(self):
+        driver, _, mock_store = self._run("https://www.linkedin.com/jobs/")
+        mock_store.assert_called_once()
+
+    def test_navigates_to_feed_after_loading_cookies(self):
+        """After loading cookies, must navigate to /feed/ (not bare homepage)."""
+        driver = _make_driver("https://www.linkedin.com/feed/")
+        wait = _make_wait()
+        get_calls = []
+        driver.get.side_effect = lambda url: get_calls.append(url)
+
+        with patch(f"{_MODULE}.get_cookies", return_value=[{"name": "x"}]), \
+             patch(f"{_MODULE}.load_cookies"), \
+             patch(f"{_MODULE}.store_cookies"):
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "user@e.com", "pw")
+
+        assert any("feed" in u for u in get_calls), (
+            f"Expected a navigation to /feed/ after loading cookies, got: {get_calls}"
+        )
+
+    def test_challenge_url_after_cookies_raises(self):
+        """Security challenge after cookie load → RuntimeError (not silent fail)."""
+        driver = _make_driver("https://www.linkedin.com/checkpoint/challenge")
+        wait = _make_wait()
+
+        with patch(f"{_MODULE}.get_cookies", return_value=[{"name": "x"}]), \
+             patch(f"{_MODULE}.load_cookies"), \
+             patch(f"{_MODULE}.store_cookies"), \
+             pytest.raises(RuntimeError, match="security challenge"):
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "user@e.com", "pw")
+
+    def test_no_cookies_goes_to_login_flow(self):
+        """No stored cookies → must do credential login (navigate to /login)."""
+        # After /login navigate, URL becomes the login page; after submit, /feed/
+        call_count = 0
+        get_urls = []
+
+        def fake_get(url):
+            get_urls.append(url)
+
+        # Simulate: base page → challenge-free login page → feed after submit
+        driver = MagicMock()
+        driver.get_cookies.return_value = [{"name": "li_at"}]
+
+        # current_url changes with each driver.get() call
+        url_sequence = [
+            "https://www.linkedin.com",   # initial get
+            "https://www.linkedin.com/login",  # after driver.get(login_url)
+            "https://www.linkedin.com/feed/",  # after submit
+        ]
+        get_index = [0]
+
+        def get_url():
+            return url_sequence[min(get_index[0], len(url_sequence) - 1)]
+
+        type(driver).current_url = property(lambda self: get_url())
+        driver.get.side_effect = lambda u: get_index.__setitem__(0, get_index[0] + 1)
+
+        wait = _make_wait()
+        mock_field = MagicMock()
+
+        with patch(f"{_MODULE}.get_cookies", return_value=None), \
+             patch(f"{_MODULE}.load_cookies"), \
+             patch(f"{_MODULE}.store_cookies") as mock_store, \
+             patch(f"{_MODULE}.get_element_wait_retry", return_value=mock_field), \
+             patch(f"{_MODULE}.click_element_wait_retry"):
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "user@e.com", "pw")
+
+        # Must have navigated to the login page directly
+        calls = [c[0][0] for c in driver.get.call_args_list]
+        assert any("login" in u for u in calls), f"Expected /login navigation, got: {calls}"
+        # Cookies stored after successful login
+        mock_store.assert_called_once()
+
+
+@pytest.mark.unit
+class TestLoginToLinkedinChallengePaths:
+    """Challenge URL detection must cover all known challenge path prefixes."""
+
+    @pytest.mark.parametrize("challenge_url", [
+        "https://www.linkedin.com/checkpoint/challenge/abc",
+        "https://www.linkedin.com/authwall?trk=x",
+        "https://www.linkedin.com/uas/login",
+        "https://www.linkedin.com/challenge/",
+    ])
+    def test_challenge_url_after_cookie_load_raises(self, challenge_url):
+        driver = _make_driver(challenge_url)
+        wait = _make_wait()
+
+        with patch(f"{_MODULE}.get_cookies", return_value=[{"name": "x"}]), \
+             patch(f"{_MODULE}.load_cookies"), \
+             patch(f"{_MODULE}.store_cookies"), \
+             pytest.raises(RuntimeError):
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "u@e.com", "pw")

--- a/tests/unit/utilities/test_db.py
+++ b/tests/unit/utilities/test_db.py
@@ -579,3 +579,138 @@ class TestGetActiveUserIds:
             assert "linkedin_connection_status" in sql
             assert "subscription_status" in sql
             assert "last_login_inactivate_delay" in sql
+
+
+# ---------------------------------------------------------------------------
+# get_user_access_token — must use correct columns (not the old token_expiry)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestGetUserAccessToken:
+    def test_returns_token_when_not_expired(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_user_access_token
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {
+                "access_token": "my-access-token"
+            }
+
+            result = get_user_access_token(60)
+
+        assert result == "my-access-token"
+
+    def test_returns_none_when_token_missing(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_user_access_token
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = None
+
+            result = get_user_access_token(99)
+
+        assert result is None
+
+    def test_sql_uses_access_token_created_at_not_token_expiry(self, mock_database_connection):
+        """Regression: query must reference access_token_created_at, not the non-existent token_expiry."""
+        from cqc_lem.utilities.db import get_user_access_token
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = None
+
+            get_user_access_token(1)
+
+        sql = mock_database_connection["cursor"].execute.call_args[0][0]
+        assert "token_expiry" not in sql, (
+            "token_expiry column does not exist; query references a non-existent column"
+        )
+        assert "access_token_created_at" in sql
+
+    def test_returns_none_on_db_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_user_access_token
+        import mysql.connector
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
+
+            result = get_user_access_token(1)
+
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# get_orphaned_scheduled_posts — recovery for tasks lost on container restart
+# ---------------------------------------------------------------------------
+
+@pytest.mark.unit
+class TestGetOrphanedScheduledPosts:
+    def test_returns_posts_in_scheduled_status_past_cutoff(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_orphaned_scheduled_posts
+
+        rows = [
+            (1485, datetime(2026, 6, 19, 19, 45, 0, tzinfo=timezone.utc), 60),
+        ]
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchall.return_value = rows
+
+            result = get_orphaned_scheduled_posts(lookback_hours=2)
+
+        assert result == rows
+
+    def test_returns_empty_list_when_none_orphaned(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_orphaned_scheduled_posts
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            result = get_orphaned_scheduled_posts()
+
+        assert result == []
+
+    def test_sql_filters_by_scheduled_status_and_cutoff(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_orphaned_scheduled_posts
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            get_orphaned_scheduled_posts(lookback_hours=3)
+
+        sql = mock_database_connection["cursor"].execute.call_args[0][0]
+        assert "scheduled" in sql.lower()
+        assert "scheduled_time" in sql
+
+    def test_cutoff_is_lookback_hours_before_now(self, mock_database_connection):
+        """The cutoff passed to the query must be approximately (now - lookback_hours)."""
+        from cqc_lem.utilities.db import get_orphaned_scheduled_posts
+        from datetime import timedelta
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            before = datetime.now(timezone.utc)
+            get_orphaned_scheduled_posts(lookback_hours=2)
+            after = datetime.now(timezone.utc)
+
+        cutoff_arg = mock_database_connection["cursor"].execute.call_args[0][1][0]
+        # cutoff should be roughly (now - 2h)
+        expected_lo = before - timedelta(hours=2, seconds=5)
+        expected_hi = after - timedelta(hours=2) + timedelta(seconds=5)
+        assert expected_lo <= cutoff_arg <= expected_hi
+
+    def test_returns_empty_on_db_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_orphaned_scheduled_posts
+        import mysql.connector
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
+
+            result = get_orphaned_scheduled_posts()
+
+        assert result == []

--- a/tests/unit/utilities/test_db_timezone.py
+++ b/tests/unit/utilities/test_db_timezone.py
@@ -1,0 +1,90 @@
+"""Unit tests for timezone-related database functions."""
+
+import pytest
+import mysql.connector
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch, call
+
+pytestmark = pytest.mark.unit
+
+_CONNECT = "cqc_lem.utilities.db.mysql.connector.connect"
+_GET_CONN = "cqc_lem.utilities.db.get_db_connection"
+
+
+# ---------------------------------------------------------------------------
+# get_db_connection — must set time_zone='+00:00'
+# ---------------------------------------------------------------------------
+
+class TestGetDbConnectionTimezone:
+    def test_connect_called_with_utc_time_zone(self):
+        with patch(_CONNECT) as mock_connect:
+            mock_connect.return_value = MagicMock()
+            from cqc_lem.utilities.db import get_db_connection
+            get_db_connection()
+
+        mock_connect.assert_called_once()
+        kwargs = mock_connect.call_args[1]
+        assert kwargs.get("time_zone") == "+00:00", (
+            "MySQL connection must specify time_zone='+00:00' to prevent session-timezone "
+            "from distorting TIMESTAMP reads"
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_user_timezone
+# ---------------------------------------------------------------------------
+
+class TestGetUserTimezone:
+    def test_returns_stored_timezone(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = ("America/New_York",)
+            from cqc_lem.utilities.db import get_user_timezone
+            result = get_user_timezone(1)
+        assert result == "America/New_York"
+
+    def test_returns_utc_when_row_is_none(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = None
+            from cqc_lem.utilities.db import get_user_timezone
+            result = get_user_timezone(99)
+        assert result == "UTC"
+
+    def test_returns_utc_when_field_is_empty(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = ("",)
+            from cqc_lem.utilities.db import get_user_timezone
+            result = get_user_timezone(5)
+        assert result == "UTC"
+
+    def test_returns_utc_on_db_error(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("fail")
+            from cqc_lem.utilities.db import get_user_timezone
+            result = get_user_timezone(7)
+        assert result == "UTC"
+
+
+# ---------------------------------------------------------------------------
+# update_user_timezone
+# ---------------------------------------------------------------------------
+
+class TestUpdateUserTimezone:
+    def test_executes_update_with_correct_values(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].rowcount = 1
+            from cqc_lem.utilities.db import update_user_timezone
+            result = update_user_timezone(3, "Europe/London")
+
+        assert result is True
+        args = mock_database_connection["cursor"].execute.call_args[0]
+        assert "UPDATE" in args[0].upper()
+        assert "Europe/London" in args[1]
+        assert 3 in args[1]
+        mock_database_connection["connection"].commit.assert_called_once()
+
+    def test_returns_false_on_db_error(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("fail")
+            from cqc_lem.utilities.db import update_user_timezone
+            result = update_user_timezone(3, "Europe/London")
+        assert result is False

--- a/tests/unit/utilities/test_logger.py
+++ b/tests/unit/utilities/test_logger.py
@@ -18,117 +18,60 @@ def _fresh_logger_module():
 
 
 # ---------------------------------------------------------------------------
-# PostHogHandler
+# _build_posthog_handler (OTLP-based PostHog Logs integration)
 # ---------------------------------------------------------------------------
 
-class TestPostHogHandler:
-    def test_emit_sends_log_event_to_posthog(self):
-        from cqc_lem.utilities.logger import PostHogHandler
+class TestBuildPostHogHandler:
+    def test_returns_none_when_no_api_key(self):
+        from cqc_lem.utilities.logger import _build_posthog_handler
 
-        handler = PostHogHandler(level=logging.DEBUG)
+        with patch.dict(os.environ, {"POSTHOG_API_KEY": ""}, clear=False):
+            result = _build_posthog_handler(logging.ERROR)
 
-        record = logging.LogRecord(
-            name="cqc-lem", level=logging.ERROR, pathname="test.py",
-            lineno=1, msg="Something failed", args=(), exc_info=None,
-        )
+        assert result is None
 
-        with patch("posthog.capture") as mock_capture, \
-             patch("posthog.disabled", False):
-            handler.emit(record)
+    def test_returns_logging_handler_when_key_is_set(self):
+        from opentelemetry.sdk._logs import LoggingHandler
+        from cqc_lem.utilities.logger import _build_posthog_handler
 
-        mock_capture.assert_called_once()
-        _, kwargs = mock_capture.call_args
-        assert kwargs["event"] == "log_event"
-        props = kwargs["properties"]
-        assert props["level"] == "error"
-        assert props["message"] == "Something failed"
-        assert props["lineno"] == 1
+        env = {"POSTHOG_API_KEY": "phc_testtoken", "POSTHOG_HOST": "https://us.i.posthog.com"}
+        with patch.dict(os.environ, env, clear=False):
+            result = _build_posthog_handler(logging.ERROR)
 
-    def test_emit_skips_when_posthog_disabled(self):
-        from cqc_lem.utilities.logger import PostHogHandler
+        assert isinstance(result, LoggingHandler)
 
-        handler = PostHogHandler(level=logging.DEBUG)
-        record = logging.LogRecord(
-            name="cqc-lem", level=logging.ERROR, pathname="test.py",
-            lineno=1, msg="Failure", args=(), exc_info=None,
-        )
+    def test_handler_respects_requested_level(self):
+        from cqc_lem.utilities.logger import _build_posthog_handler
 
-        with patch("posthog.disabled", True), patch("posthog.capture") as mock_capture:
-            handler.emit(record)
+        env = {"POSTHOG_API_KEY": "phc_testtoken", "POSTHOG_HOST": "https://us.i.posthog.com"}
+        with patch.dict(os.environ, env, clear=False):
+            result = _build_posthog_handler(logging.WARNING)
 
-        mock_capture.assert_not_called()
+        assert result is not None
+        assert result.level == logging.WARNING
 
-    def test_emit_includes_user_id_as_distinct_id(self):
-        from cqc_lem.utilities.logger import PostHogHandler
+    def test_exporter_endpoint_uses_host_env_var(self):
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+        from cqc_lem.utilities.logger import _build_posthog_handler
 
-        handler = PostHogHandler(level=logging.DEBUG)
-        record = logging.LogRecord(
-            name="cqc-lem", level=logging.ERROR, pathname="test.py",
-            lineno=1, msg="Error", args=(), exc_info=None,
-        )
-        record.user_id = 42
+        env = {
+            "POSTHOG_API_KEY": "phc_testtoken",
+            "POSTHOG_HOST": "https://eu.i.posthog.com",
+        }
+        captured_exporter: list[OTLPLogExporter] = []
 
-        with patch("posthog.capture") as mock_capture, \
-             patch("posthog.disabled", False):
-            handler.emit(record)
+        original_init = OTLPLogExporter.__init__
 
-        _, kwargs = mock_capture.call_args
-        assert kwargs["distinct_id"] == "42"
-        assert kwargs["properties"]["user_id"] == 42
+        def capturing_init(self, *args, **kwargs):
+            captured_exporter.append(self)
+            original_init(self, *args, **kwargs)
 
-    def test_emit_captures_exc_info_fields(self):
-        from cqc_lem.utilities.logger import PostHogHandler
+        with patch.dict(os.environ, env, clear=False), \
+             patch.object(OTLPLogExporter, "__init__", capturing_init):
+            _build_posthog_handler(logging.ERROR)
 
-        handler = PostHogHandler(level=logging.DEBUG)
-
-        try:
-            raise ValueError("boom")
-        except ValueError:
-            import sys
-            exc_info = sys.exc_info()
-
-        record = logging.LogRecord(
-            name="cqc-lem", level=logging.ERROR, pathname="test.py",
-            lineno=5, msg="Caught exception", args=(), exc_info=exc_info,
-        )
-
-        with patch("posthog.capture") as mock_capture, \
-             patch("posthog.disabled", False):
-            handler.emit(record)
-
-        props = mock_capture.call_args[1]["properties"]
-        assert props["error_type"] == "ValueError"
-        assert "boom" in props["error_message"]
-        assert "ValueError" in props["stack_trace"]
-
-    def test_emit_uses_system_distinct_id_when_no_user_id(self):
-        from cqc_lem.utilities.logger import PostHogHandler
-
-        handler = PostHogHandler(level=logging.DEBUG)
-        record = logging.LogRecord(
-            name="cqc-lem", level=logging.ERROR, pathname="test.py",
-            lineno=1, msg="No user", args=(), exc_info=None,
-        )
-
-        with patch("posthog.capture") as mock_capture, \
-             patch("posthog.disabled", False):
-            handler.emit(record)
-
-        assert mock_capture.call_args[1]["distinct_id"] == "system"
-
-    def test_emit_handles_posthog_error_gracefully(self):
-        from cqc_lem.utilities.logger import PostHogHandler
-
-        handler = PostHogHandler(level=logging.DEBUG)
-        record = logging.LogRecord(
-            name="cqc-lem", level=logging.ERROR, pathname="test.py",
-            lineno=1, msg="Msg", args=(), exc_info=None,
-        )
-
-        with patch("posthog.disabled", False), \
-             patch("posthog.capture", side_effect=RuntimeError("network error")):
-            # Should not raise — handleError is called instead
-            handler.emit(record)
+        assert captured_exporter, "OTLPLogExporter was not instantiated"
+        assert captured_exporter[0]._endpoint == "https://eu.i.posthog.com/i/v1/logs"
 
 
 # ---------------------------------------------------------------------------
@@ -260,11 +203,16 @@ class TestLoggerConfiguration:
         handler_types = [type(h).__name__ for h in mod.logger.handlers]
         assert "RotatingFileHandler" in handler_types
 
-    def test_logger_has_posthog_handler(self):
+    def test_logger_has_posthog_handler_when_key_configured(self):
         from cqc_lem.utilities import logger as mod
 
+        # LoggingHandler is present when POSTHOG_API_KEY is set in environment
+        api_key = os.getenv("POSTHOG_API_KEY", "")
         handler_types = [type(h).__name__ for h in mod.logger.handlers]
-        assert "PostHogHandler" in handler_types
+        if api_key:
+            assert "LoggingHandler" in handler_types
+        else:
+            assert "LoggingHandler" not in handler_types
 
     def test_logger_has_stream_handler(self):
         from cqc_lem.utilities import logger as mod
@@ -277,9 +225,11 @@ class TestLoggerConfiguration:
 
         assert mod.logger.propagate is False
 
-    def test_posthog_handler_level_defaults_to_error(self):
+    def test_posthog_handler_level_matches_env(self):
         from cqc_lem.utilities import logger as mod
 
-        ph_handlers = [h for h in mod.logger.handlers if type(h).__name__ == "PostHogHandler"]
-        assert ph_handlers, "No PostHogHandler found"
-        assert ph_handlers[0].level == logging.ERROR
+        ph_handlers = [h for h in mod.logger.handlers if type(h).__name__ == "LoggingHandler"]
+        if not ph_handlers:
+            return  # no key configured — handler absent, nothing to assert
+        expected = getattr(logging, os.getenv("POSTHOG_LOG_LEVEL", "ERROR").upper(), logging.ERROR)
+        assert ph_handlers[0].level == expected


### PR DESCRIPTION
## Summary

- **Root cause fixed**: MySQL session was returning TIMESTAMP values in Eastern time (due to `TZ=America/New_York` on the container), but `db.py` assumed UTC — a 5-hour offset that made posts fire at the wrong time. Fixed by adding `time_zone='+00:00'` to every MySQL connection.
- **Celery config hardened**: Added `enable_utc = True` explicitly; `celeryconfig.py` now reads `CELERY_TIMEZONE` before `TZ` so AWS deployments pick up the correct timezone. Beat-schedule crontabs (1 AM, 8 AM, etc.) now reliably run in the configured timezone.
- **Scheduler eta fixed**: Removed `convert_datetime_to_local_tz()` from `run_scheduler.py` — Celery `eta` is now always a UTC-aware datetime, independent of machine timezone.
- **User timezone preference**: V28 migration adds `timezone VARCHAR(50)` to `users` table. New `GET/PUT /api/user/timezone` endpoints. Account settings page has a timezone selector.
- **Frontend display**: `formatInTimezone()` utility + `useUserTimezone()` hook ensure all times shown in Dashboard, ReviewSchedule, and ScheduleContent reflect the user's stored timezone rather than the browser default.

## Test plan

- [ ] All 37 new/updated unit tests pass (`poetry run pytest tests/unit/utilities/test_db_timezone.py tests/unit/app/test_run_scheduler.py tests/unit/api/test_api_timezone.py -v`)
- [ ] Full unit suite: 351 passing, 1 pre-existing logger-level failure unrelated to this PR
- [ ] Integration: schedule a post 2 min in future in EST; confirm it fires at the correct EST time
- [ ] Celery beat logs show daily tasks (1 AM, 8 AM) in Eastern, not UTC
- [ ] Account page shows Timezone card with dropdown; saving updates the display in Dashboard and ReviewSchedule

🤖 Generated with [Claude Code](https://claude.com/claude-code)