### PR TITLE
feat(deploy): Hostinger VPS deploy pipeline with Cloudflare Tunnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ CQC_LEM_CHECK_SCHEDULE_DELTA_MINUTES=5
 CQC_LEM_POST_TIME_DELTA_MINUTES=20
 # Secret key required in X-Admin-Secret header for admin endpoints
 ADMIN_SECRET=change_me_to_a_strong_random_secret
+# Comma-separated bearer tokens accepted on /api routes (Authorization: Bearer ...).
+# Leave EMPTY for local/dev to disable the gate. Set on internet-facing deploys.
+API_ACCESS_TOKENS=
 
 
 # =============================================================================

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,154 @@
+# =============================================================================
+# PRODUCTION env template for the Hostinger VPS.
+#
+# Copy to /opt/lem/.env on the server, fill in real values, chmod 600.
+# NEVER commit the filled-in file. scripts/check_env.sh validates that the
+# server .env defines every key listed here before each deploy.
+#
+# Differences from .env.example (local/dev):
+#   - DOCKER_IMAGE_NAME points at GHCR; IMAGE_TAG selects the released image.
+#   - NGROK_PLAN=off (Cloudflare Tunnel replaces ngrok).
+#   - API_ACCESS_TOKENS set (bearer gate on /api is enforced).
+#   - Stripe/SendGrid are LIVE credentials.
+#   - TUNNEL_TOKEN + Flower basic-auth creds added.
+# =============================================================================
+
+# =============================================================================
+# Core Application
+# =============================================================================
+TZ=America/New_York
+API_PORT=8000
+# Multi-worker uvicorn in prod: (2 * CPU_CORES) + 1 is a reasonable ceiling.
+API_WORKERS=3
+CQC_LEM_CHECK_SCHEDULE_DELTA_MINUTES=5
+CQC_LEM_POST_TIME_DELTA_MINUTES=20
+ADMIN_SECRET=CHANGE_ME_strong_random_secret
+# Bearer token(s) the SPA and API clients must send. Comma-separated to rotate.
+# Must match the UI build's VITE_API_TOKEN.
+API_ACCESS_TOKENS=CHANGE_ME_long_random_api_token
+
+# =============================================================================
+# Docker image (GHCR)
+# =============================================================================
+DOCKER_IMAGE_NAME=ghcr.io/gitchrisqueen/cqc-lem
+# Overridden per-deploy by scripts/deploy.sh; latest is the fallback.
+IMAGE_TAG=latest
+INSTALL_DEV_DEPS=false
+
+# =============================================================================
+# Cloudflare Tunnel
+# =============================================================================
+# Token for the named tunnel (Zero Trust > Networks > Tunnels). Ingress
+# hostnames (app/flower/litellm/vnc) are managed in the dashboard.
+TUNNEL_TOKEN=CHANGE_ME_cloudflare_tunnel_token
+
+# =============================================================================
+# Database (MySQL)
+# =============================================================================
+MYSQL_ROOT_PASSWORD=CHANGE_ME_strong_root_password
+MYSQL_USER=lem_prod
+MYSQL_PASSWORD=CHANGE_ME_strong_db_password
+MYSQL_DATABASE=linkedin_manager
+MYSQL_PORT=3306
+MYSQL_HOST=mysql_db
+
+# =============================================================================
+# Cache & Task Queue (Redis + Celery)
+# =============================================================================
+REDIS_PORT=6379
+CELERY_BROKER_URL=redis://redis:6379/0
+CELERY_RESULT_BACKEND=redis://redis:6379/1
+CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP=True
+CELERY_RESULT_EXTENDED=True
+CELERY_FLOWER_PORT=8555
+# Flower basic auth (also gated by Cloudflare Access).
+CELERY_FLOWER_USER=admin
+CELERY_FLOWER_PASSWORD=CHANGE_ME_strong_flower_password
+CELERY_FLOWER_STATE_SAVE_INTERVAL=5000
+CELERY_WORKER_HOST=celery-worker-host
+CELERY_WORKER_NAME=worker@%h
+
+# =============================================================================
+# LinkedIn API (OAuth)
+# =============================================================================
+LI_CLIENT_ID=CHANGE_ME
+LI_CLIENT_SECRET=CHANGE_ME
+# Must match the public app hostname + the LinkedIn Developer Console redirect.
+LI_REDIRECT_URL=https://app.example.com/auth/linkedin/callback
+LI_STATE_SALT=CHANGE_ME_state_salt
+LI_API_VERSION=202501
+LI_USERINFO_RESOURCE=/userinfo
+LI_POSTS_RESOURCE=/posts
+
+# =============================================================================
+# AI / LLM Providers
+# =============================================================================
+LITELLM_MASTER_KEY=CHANGE_ME_litellm_master_key
+LITELLM_BASE_URL=http://litellm:4000
+OPENAI_API_KEY=CHANGE_ME
+# ANTHROPIC_API_KEY=CHANGE_ME
+OPENROUTER_API_KEY=CHANGE_ME
+PERPLEXITY_API_KEY=CHANGE_ME
+OLLAMA_API_KEY=CHANGE_ME
+OLLAMA_CLOUD_API_KEY=CHANGE_ME
+OLLAMA_BASE_URL=http://127.0.0.1:11434/v1
+OLLAMA_CLOUD_URL=https://ollama.com/v1
+
+# =============================================================================
+# Image / Video Generation
+# =============================================================================
+PEXELS_API_KEY=CHANGE_ME
+HF_TOKEN=CHANGE_ME
+REPLICATE_API_TOKEN=CHANGE_ME
+REPLICATE_USERNAME=CHANGE_ME
+RUNWAYML_API_SECRET=CHANGE_ME
+
+# =============================================================================
+# Billing (Stripe — LIVE)
+# =============================================================================
+FREE_TRIAL_DAYS=14
+STRIPE_API_KEY=sk_live_CHANGE_ME
+STRIPE_WEBHOOK_SECRET=whsec_CHANGE_ME
+STRIPE_PRICE_ID_STARTER=price_CHANGE_ME
+STRIPE_PRICE_ID_PROFESSIONAL=price_CHANGE_ME
+STRIPE_PRICE_ID_ENTERPRISE=price_CHANGE_ME
+
+# =============================================================================
+# Email / Notifications
+# =============================================================================
+SENDGRID_API_KEY=CHANGE_ME
+SENDGRID_FROM_EMAIL=no-reply@example.com
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=CHANGE_ME@gmail.com
+SMTP_PASSWORD=CHANGE_ME_app_password
+
+# =============================================================================
+# CAPTCHA Solving
+# =============================================================================
+CAPSOLVER_API_KEY=
+
+# =============================================================================
+# Observability
+# =============================================================================
+POSTHOG_API_KEY=CHANGE_ME
+POSTHOG_HOST=https://us.i.posthog.com
+POSTHOG_LOG_LEVEL=ERROR
+
+# =============================================================================
+# Tunnel & Networking (Ngrok) — DISABLED in prod (Cloudflare Tunnel is used)
+# =============================================================================
+NGROK_PLAN=off
+
+# =============================================================================
+# Browser Automation (Selenium)
+# =============================================================================
+SELENIUM_HUB_HOST=selenium-chrome
+SELENIUM_HUB_PORT=4444
+SELENIUM_KEEP_VIDEOS_X_DAYS=7
+
+# =============================================================================
+# Maintenance toggles
+# =============================================================================
+PURGE_TASKS=False
+CLEAR_SELENIUM_SESSIONS=True

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -30,7 +30,7 @@ API_ACCESS_TOKENS=CHANGE_ME_long_random_api_token
 # =============================================================================
 # Docker image (GHCR)
 # =============================================================================
-DOCKER_IMAGE_NAME=ghcr.io/gitchrisqueen/cqc-lem
+DOCKER_IMAGE_NAME=ghcr.io/christopherqueenconsulting/cqc-lem
 # Overridden per-deploy by scripts/deploy.sh; latest is the fallback.
 IMAGE_TAG=latest
 INSTALL_DEV_DEPS=false

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,0 +1,89 @@
+name: Build & Deploy Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to build & deploy (defaults to the ref)"
+        required: false
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/cqc-lem
+
+jobs:
+  build-and-push:
+    name: Build & Push to GHCR
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.ver.outputs.tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Resolve version tag
+        id: ver
+        run: |
+          TAG="${{ github.event.release.tag_name || github.event.inputs.tag || github.ref_name }}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./compose/local/Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ steps.ver.outputs.tag }}
+            ${{ env.IMAGE }}:latest
+          build-args: |
+            INSTALL_DEV_DEPS=false
+            VITE_API_TOKEN=${{ secrets.UI_API_TOKEN }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Scan image (advisory)
+        continue-on-error: true
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          image-ref: ${{ env.IMAGE }}:${{ steps.ver.outputs.tag }}
+          format: table
+          severity: HIGH,CRITICAL
+
+  deploy:
+    name: Deploy to Hostinger VPS
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    # Protected environment — configure required reviewers in repo settings to
+    # require manual approval before the live box is updated.
+    environment: production
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script_stop: true
+          envs: GHCR_USER,GHCR_PAT
+          script: |
+            cd /opt/lem
+            ./scripts/deploy.sh "${{ needs.build-and-push.outputs.tag }}"
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -1,0 +1,42 @@
+name: Redeploy / Rollback VPS
+
+# Manual-only: redeploy or roll back the VPS to any existing image tag without
+# rebuilding. The image must already exist in GHCR (built by a prior release).
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing image tag to deploy (e.g. v1.2.2)"
+        required: true
+      rollback:
+        description: "Use rollback.sh instead of deploy.sh (skips migrations)"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  redeploy:
+    name: Redeploy to Hostinger VPS
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Deploy over SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          script_stop: true
+          envs: GHCR_USER,GHCR_PAT
+          script: |
+            cd /opt/lem
+            if [ "${{ github.event.inputs.rollback }}" = "true" ]; then
+              ./scripts/rollback.sh "${{ github.event.inputs.tag }}"
+            else
+              ./scripts/deploy.sh "${{ github.event.inputs.tag }}"
+            fi
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,10 @@
 name: Deploy CDK Stack to AWS
 
+# Manual-only. The primary deploy path is the Hostinger VPS (build-and-push.yml
+# → deploy). This AWS/CDK workflow is retained for the optional cloud path and
+# no longer runs automatically on pushes to main.
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 env:
   CDK_VERSION: ${{ vars.CDK_VERSION }}
   AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,26 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    name: Release Please
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          release-type: python
+          # Manages the version in pyproject.toml + maintains CHANGELOG.md.
+          # Merging the release PR creates a tag + GitHub Release (vX.Y.Z),
+          # which triggers build-and-push.yml and deploy-vps.yml.
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -214,6 +214,20 @@ poetry run ruff check --fix src/ tests/
 
 ## Pull Request Process
 
+### Commit Messages (Conventional Commits — required)
+
+Releases are automated by [release-please](https://github.com/googleapis/release-please),
+which derives the next version and the `CHANGELOG.md` from commit messages on
+`main`. Use [Conventional Commits](https://www.conventionalcommits.org/):
+
+- `feat: ...` → minor version bump (new feature)
+- `fix: ...` → patch version bump (bug fix)
+- `feat!: ...` or a `BREAKING CHANGE:` footer → major version bump
+- `chore: / docs: / refactor: / test: / ci:` → no release on their own
+
+Scopes are encouraged (e.g. `fix(carousel): ...`). When a PR squash-merges, the
+PR title becomes the commit — make it a valid Conventional Commit.
+
 ### Before Submitting
 
 1. **Update your branch** with the latest changes from main:

--- a/cloudflared/config.yml
+++ b/cloudflared/config.yml
@@ -1,0 +1,34 @@
+# Cloudflare Tunnel ingress (file-managed alternative).
+#
+# By default the prod stack runs cloudflared in TOKEN mode (TUNNEL_TOKEN in the
+# VPS .env), and ingress hostnames are managed in the Cloudflare Zero Trust
+# dashboard — this file is NOT read in that mode.
+#
+# To manage ingress from the repo instead, create a named tunnel locally:
+#   cloudflared tunnel login
+#   cloudflared tunnel create lem
+#   cloudflared tunnel route dns lem app.example.com   (repeat per hostname)
+# then mount this file + the tunnel credentials into the container and switch
+# the compose command to:  tunnel --config /etc/cloudflared/config.yml run lem
+# (drop TUNNEL_TOKEN). Replace example.com with your zone.
+#
+# Service targets use compose service hostnames on the shared network.
+
+tunnel: lem
+credentials-file: /etc/cloudflared/credentials.json
+
+ingress:
+  # Public: React SPA + FastAPI (API routes require a bearer token, see Part 3).
+  - hostname: app.example.com
+    service: http://web_app:8000
+
+  # Ops tools — keep behind Cloudflare Access policies in the dashboard.
+  - hostname: flower.example.com
+    service: http://flower:8555
+  - hostname: litellm.example.com
+    service: http://litellm:4000
+  - hostname: vnc.example.com
+    service: http://selenium-chrome:7900
+
+  # Required catch-all.
+  - service: http_status:404

--- a/compose/local/Dockerfile
+++ b/compose/local/Dockerfile
@@ -27,6 +27,10 @@ WORKDIR /app
 FROM node:22-slim AS ui-builder
 
 WORKDIR /ui
+# Build-time API bearer token baked into the SPA bundle (Vite reads VITE_*).
+# Empty by default so dev images stay tokenless; CI passes the prod token.
+ARG VITE_API_TOKEN=""
+ENV VITE_API_TOKEN=${VITE_API_TOKEN}
 COPY ./src/cqc_lem/ui/package.json ./src/cqc_lem/ui/package-lock.json ./
 RUN npm ci
 COPY ./src/cqc_lem/ui ./

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,116 @@
+# Production overlay for the Hostinger VPS.
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d
+#
+# Differences from the dev base (docker-compose.yml):
+#   - Runs prebuilt GHCR images by tag (no local build, no ./src bind-mount).
+#   - FastAPI runs multi-worker with no --reload (/start-fastapi-cloud).
+#   - No internal ports published to the host — Cloudflare Tunnel reaches
+#     services over the compose network instead.
+#   - Flower requires basic auth; cloudflared is added to expose the stack.
+#   - restart: unless-stopped + resource caps on everything long-running.
+#
+# DOCKER_IMAGE_NAME=ghcr.io/gitchrisqueen/cqc-lem and IMAGE_TAG are set in the
+# VPS .env (IMAGE_TAG is overridden per-deploy by scripts/deploy.sh).
+
+services:
+  web_app:
+    build: !reset null
+    image: "${DOCKER_IMAGE_NAME}:${IMAGE_TAG:-latest}"
+    command: /start-fastapi-cloud
+    restart: unless-stopped
+    # Ship code in the image — drop the dev source/test bind-mounts.
+    volumes:
+      - ./logs:/app/logs
+    ports: !reset []
+    deploy:
+      resources:
+        limits:
+          cpus: '2'
+          memory: 2g
+
+  redis:
+    restart: unless-stopped
+    ports: !reset []
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+
+  mysql:
+    restart: unless-stopped
+    ports: !reset []
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+
+  celery_worker:
+    image: "${DOCKER_IMAGE_NAME}:${IMAGE_TAG:-latest}"
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '3'
+          memory: 4g
+        reservations:
+          cpus: '1'
+
+  celery_worker_selenium:
+    image: "${DOCKER_IMAGE_NAME}:${IMAGE_TAG:-latest}"
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 2g
+        reservations:
+          cpus: '0.5'
+
+  celery_beat:
+    image: "${DOCKER_IMAGE_NAME}:${IMAGE_TAG:-latest}"
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+
+  flower:
+    image: "${DOCKER_IMAGE_NAME}:${IMAGE_TAG:-latest}"
+    restart: unless-stopped
+    ports: !reset []
+    environment:
+      # Replace the dev unauthenticated mode with basic auth + persistence.
+      # Kept behind Cloudflare Access as well (see cloudflared/config.yml).
+      - FLOWER_BASIC_AUTH=${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}
+      - FLOWER_PERSISTENT=True
+      - CELERY_TIMEZONE=${TZ:-UTC}
+    deploy:
+      resources:
+        limits:
+          memory: 512m
+
+  selenium-chrome:
+    # already restart: unless-stopped + 2cpu/4g in the base file
+    ports: !reset []
+
+  litellm:
+    # already restart: unless-stopped in the base file
+    ports: !reset []
+    deploy:
+      resources:
+        limits:
+          memory: 1g
+
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: cloudflared
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      - TUNNEL_TOKEN=${TUNNEL_TOKEN}
+    depends_on:
+      - web_app
+    deploy:
+      resources:
+        limits:
+          memory: 256m

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,166 @@
+# VPS Deployment Runbook
+
+Live/dev instance of LEM on a Hostinger VPS, running the same Docker stack as
+local, exposed through a Cloudflare Tunnel, deployed automatically from GitHub
+releases.
+
+```
+local dev → PR to main → CI gates → release-please tags vX.Y.Z
+   → build-and-push.yml builds image → GHCR → SSH deploy to VPS → migrate + up
+```
+
+## Architecture
+
+| Concern | Choice |
+|---|---|
+| Registry | GHCR — `ghcr.io/gitchrisqueen/cqc-lem:<tag>` |
+| Delivery | GitHub Action SSHes to the VPS, pulls the tag, `docker compose up -d` |
+| Ingress | Cloudflare Tunnel (`cloudflared` container) — no inbound ports |
+| Releases | release-please (Conventional Commits → release PR → tag) |
+| Prod overlay | `docker-compose.prod.yml` on top of `docker-compose.yml` |
+
+Public surface:
+
+| Hostname | Service | Protection |
+|---|---|---|
+| `app.<domain>` | web_app:8000 (SPA + API) | Public; API routes require a bearer token |
+| `flower.<domain>` | flower:8555 | Cloudflare Access + Flower basic auth |
+| `litellm.<domain>` | litellm:4000 | Cloudflare Access + `LITELLM_MASTER_KEY` |
+| `vnc.<domain>` | selenium-chrome:7900 | Cloudflare Access |
+
+## Sizing
+
+Selenium/Chrome reserves 2 vCPU / 4 GB on its own; with MySQL, Redis, two Celery
+workers, LiteLLM and FastAPI, target **8 vCPU / 16 GB** (Hostinger KVM 8). 4 vCPU
+/ 8 GB is the bare minimum. `vps_bootstrap.sh` adds a 4 GB swapfile.
+
+## One-time setup
+
+### 1. Provision the VPS
+
+```bash
+# As root on a fresh Ubuntu VPS:
+scp scripts/vps_bootstrap.sh root@<vps>:/root/
+ssh root@<vps> 'REPO_URL=https://github.com/gitchrisqueen/linkedin_engagement_manager.git bash /root/vps_bootstrap.sh'
+```
+
+This installs Docker + Compose, creates the `deploy` user, clones the repo to
+`/opt/lem`, locks down SSH + ufw (SSH-only inbound), enables Docker log
+rotation, and adds swap.
+
+### 2. CI deploy key
+
+Generate a dedicated keypair; add the **public** key to
+`/home/deploy/.ssh/authorized_keys`, and store the **private** key as the
+`VPS_SSH_KEY` repo secret.
+
+### 3. Server env
+
+```bash
+ssh deploy@<vps>
+cd /opt/lem
+cp .env.prod.example .env
+nano .env          # fill in real secrets
+chmod 600 .env
+```
+
+### 4. Cloudflare Tunnel
+
+1. Zero Trust → Networks → Tunnels → **Create a tunnel** (named `lem`).
+2. Copy the tunnel **token** into `TUNNEL_TOKEN` in `/opt/lem/.env`.
+3. Add public hostnames mapping to the internal services in the table above
+   (e.g. `app.<domain>` → `http://web_app:8000`).
+4. Zero Trust → Access → Applications → add self-hosted apps for
+   `flower/litellm/vnc.<domain>` restricted to your email/SSO.
+5. Register `https://app.<domain>/auth/linkedin/callback` in the LinkedIn
+   Developer Console and set it as `LI_REDIRECT_URL`. Keep `NGROK_PLAN=off`.
+
+Alternatively manage ingress from the repo via `cloudflared/config.yml` (see the
+header of that file) instead of the dashboard.
+
+### 5. GitHub repo configuration
+
+**Secrets:** `VPS_HOST`, `VPS_USER`, `VPS_SSH_KEY`, `GHCR_PAT`
+(a PAT with `read:packages` for the VPS pull), `UI_API_TOKEN` (must equal one of
+the `API_ACCESS_TOKENS` values in the server `.env`), plus existing
+`GITGUARDIAN_API_KEY`, `ANTHROPIC_API_KEY`, `CODECOV_TOKEN`. GHCR **push** uses
+the built-in `GITHUB_TOKEN`.
+
+**Environment:** create a `production` environment with required reviewers to
+gate the deploy job.
+
+**Branch protection (main):** require `CI / Unit Tests`,
+`CI / Integration Test w/ Coverage`, `CodeQL Security Analysis`,
+`GitGuardian Security Scan`, and ≥1 review.
+
+### 6. First deploy
+
+```bash
+ssh deploy@<vps> 'cd /opt/lem && ./scripts/deploy.sh latest'
+```
+
+## Routine deploys
+
+Merge work to `main` with Conventional Commit messages → release-please opens a
+"chore: release X.Y.Z" PR. Merge it → a `vX.Y.Z` tag + GitHub Release →
+`Build & Deploy Release` builds/pushes the image and (after `production`
+approval) SSHes in and runs `scripts/deploy.sh vX.Y.Z`, which:
+
+1. checks out the tag (syncs compose + Flyway migrations),
+2. validates the server `.env` (`check_env.sh`),
+3. pulls the GHCR image,
+4. runs Flyway migrations (idempotent),
+5. `docker compose up -d`,
+6. waits for `/health`, **auto-rolls-back** to `.last_good_tag` on failure.
+
+## Manual redeploy / rollback
+
+Use the **Redeploy / Rollback VPS** workflow (Actions → Run workflow) with a
+tag, ticking `rollback` to skip migrations. Or on the box:
+
+```bash
+cd /opt/lem
+./scripts/rollback.sh v1.2.2      # re-up a prior tag
+```
+
+## Backups
+
+Cron on the VPS:
+
+```cron
+0 3 * * * cd /opt/lem && ./scripts/backup.sh >> logs/backup.log 2>&1
+```
+
+Dumps `linkedin_manager` (gzipped) + the `chrome-profile` volume to
+`/opt/lem/backups`, retains `RETAIN_DAYS` (default 7), and optionally `rclone`s
+to `BACKUP_REMOTE` (e.g. Cloudflare R2). Restore:
+
+```bash
+gunzip -c backups/db-<stamp>.sql.gz | docker exec -i mysql_db \
+  mysql -u root -p"$MYSQL_ROOT_PASSWORD" linkedin_manager
+```
+
+## Persistent state
+
+Named volumes survive deploys: `db_data` (MySQL), `redis_data`, `flower_db`,
+`chrome-profile` (LinkedIn session — losing it forces re-login/2FA). Generated
+media under `src/cqc_lem/assets/` lives **inside the image** in prod; if it must
+persist across deploys, add a named volume for `/app/src/cqc_lem/assets` to the
+prod overlay.
+
+## Observability
+
+- PostHog already receives `log_error`/`log_critical`; set `POSTHOG_API_KEY`.
+- Container logs: `docker compose logs -f <service>` (rotated, 20 MB × 5).
+- Queue/tasks: `flower.<domain>`. Live browser: `vnc.<domain>`.
+- Uptime: monitor `https://app.<domain>/health`.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| Deploy rolls back | `docker compose logs web_app`; `/health` not reachable |
+| 401 on the SPA | `UI_API_TOKEN` (build) ≠ `API_ACCESS_TOKENS` (server) |
+| Migrations fail | `docker compose run --rm flyway`; inspect Flyway output |
+| Tunnel down | `docker compose logs cloudflared`; verify `TUNNEL_TOKEN` |
+| OAuth fails | `LI_REDIRECT_URL` matches the LinkedIn app + `app.<domain>` |

--- a/docs/SETUP_CHECKLIST.md
+++ b/docs/SETUP_CHECKLIST.md
@@ -27,15 +27,18 @@ Legend: 🖱️ click-ops in a web console · ⌨️ run a command · ⏱️ rou
       scp scripts/vps_bootstrap.sh root@<vps-ip>:/root/
       ssh root@<vps-ip> 'REPO_URL=https://github.com/christopherqueenconsulting/linkedin_engagement_manager.git bash /root/vps_bootstrap.sh'
       ```
-- [ ] ⌨️ Generate a **CI deploy keypair** (do this on your laptop):
+- [ ] ⌨️ Generate a **CI deploy keypair** (do this on your laptop) **before**
+      running bootstrap so you can pre-seed the public key:
       ```
       ssh-keygen -t ed25519 -C "lem-ci-deploy" -f ~/.ssh/lem_ci_deploy -N ""
       ```
-- [ ] ⌨️ Install the **public** key for the deploy user:
+      Then the bootstrap command above can install it automatically by passing
+      `CI_DEPLOY_PUBKEY="$(cat ~/.ssh/lem_ci_deploy.pub)"` in front of `bash ...`.
+      (If you already ran bootstrap, add it manually:)
       ```
-      ssh root@<vps-ip> "mkdir -p /home/deploy/.ssh && \
+      ssh root@<vps-ip> "install -d -m700 -o deploy -g deploy /home/deploy/.ssh && \
         echo '$(cat ~/.ssh/lem_ci_deploy.pub)' >> /home/deploy/.ssh/authorized_keys && \
-        chown -R deploy:deploy /home/deploy/.ssh && chmod 600 /home/deploy/.ssh/authorized_keys"
+        chown deploy:deploy /home/deploy/.ssh/authorized_keys && chmod 600 /home/deploy/.ssh/authorized_keys"
       ```
 - [ ] ⌨️ Verify: `ssh -i ~/.ssh/lem_ci_deploy deploy@<vps-ip> 'docker ps'`
 

--- a/docs/SETUP_CHECKLIST.md
+++ b/docs/SETUP_CHECKLIST.md
@@ -1,0 +1,119 @@
+# VPS Go-Live Checklist (manual actions)
+
+Things **you** must do by hand to bring the live/dev VPS online. The repo
+provides the automation (`scripts/`, compose overlay, CI); this list is the
+human glue — accounts, secrets, DNS, approvals. Work top to bottom.
+
+Legend: 🖱️ click-ops in a web console · ⌨️ run a command · ⏱️ rough time.
+
+---
+
+## 0. Prerequisites (before buying the VPS) ⏱️ ~30 min
+- [ ] 🖱️ Own a domain in **Cloudflare** (free plan is fine). Note the zone, e.g. `example.com`.
+- [ ] 🖱️ Decide subdomains: `app`, `flower`, `litellm`, `vnc` (defaults in the docs).
+- [ ] 🖱️ Confirm **GitHub** repo admin access (you'll set secrets + branch protection).
+- [ ] 🖱️ Have **production** credentials ready: LinkedIn OAuth app, live Stripe keys, SendGrid, OpenAI/OpenRouter/Ollama, Pexels/Replicate/RunwayML, PostHog, CapSolver.
+
+## 1. Buy + access the VPS ⏱️ ~15 min
+- [ ] 🖱️ Buy a **Hostinger KVM 8** (8 vCPU / 16 GB) — or KVM 4 minimum. Pick Ubuntu 24.04.
+- [ ] 🖱️ Add your SSH public key in the Hostinger panel (or note the root password).
+- [ ] ⌨️ Confirm access: `ssh root@<vps-ip>`
+
+## 2. Provision the box ⏱️ ~10 min (mostly automated)
+- [ ] ⌨️ Copy the bootstrap script up and run it (installs Docker, creates the
+      `deploy` user, clones the repo to `/opt/lem`, firewall, SSH hardening,
+      log rotation, swap):
+      ```
+      scp scripts/vps_bootstrap.sh root@<vps-ip>:/root/
+      ssh root@<vps-ip> 'REPO_URL=https://github.com/christopherqueenconsulting/linkedin_engagement_manager.git bash /root/vps_bootstrap.sh'
+      ```
+- [ ] ⌨️ Generate a **CI deploy keypair** (do this on your laptop):
+      ```
+      ssh-keygen -t ed25519 -C "lem-ci-deploy" -f ~/.ssh/lem_ci_deploy -N ""
+      ```
+- [ ] ⌨️ Install the **public** key for the deploy user:
+      ```
+      ssh root@<vps-ip> "mkdir -p /home/deploy/.ssh && \
+        echo '$(cat ~/.ssh/lem_ci_deploy.pub)' >> /home/deploy/.ssh/authorized_keys && \
+        chown -R deploy:deploy /home/deploy/.ssh && chmod 600 /home/deploy/.ssh/authorized_keys"
+      ```
+- [ ] ⌨️ Verify: `ssh -i ~/.ssh/lem_ci_deploy deploy@<vps-ip> 'docker ps'`
+
+## 3. Server secrets (`/opt/lem/.env`) ⏱️ ~20 min
+- [ ] ⌨️ `ssh deploy@<vps-ip>` then `cd /opt/lem && cp .env.prod.example .env`
+- [ ] ⌨️ Fill in every `CHANGE_ME` in `.env` (DB passwords, ADMIN_SECRET,
+      API_ACCESS_TOKENS, all API keys, live Stripe, SendGrid). Use strong random
+      values: `openssl rand -hex 32`.
+- [ ] ⌨️ `chmod 600 .env`
+- [ ] 📝 Record the value you put in **`API_ACCESS_TOKENS`** — you'll reuse it as
+      the GitHub `UI_API_TOKEN` secret (they must match).
+- [ ] ⌨️ Sanity check: `./scripts/check_env.sh`
+
+## 4. Cloudflare Tunnel + Access ⏱️ ~25 min
+- [ ] 🖱️ Cloudflare **Zero Trust → Networks → Tunnels → Create tunnel** (Cloudflared), name it `lem`.
+- [ ] 📝 Copy the tunnel **token** → paste into `TUNNEL_TOKEN` in `/opt/lem/.env`.
+- [ ] 🖱️ Add **Public Hostnames** on the tunnel:
+      - `app.<domain>` → `http://web_app:8000`
+      - `flower.<domain>` → `http://flower:8555`
+      - `litellm.<domain>` → `http://litellm:4000`
+      - `vnc.<domain>` → `http://selenium-chrome:7900`
+- [ ] 🖱️ **Zero Trust → Access → Applications**: add self-hosted apps for
+      `flower`, `litellm`, `vnc` subdomains, policy = allow only your email/SSO.
+- [ ] 🖱️ (Optional) Enable WAF / rate limiting on `app.<domain>`.
+
+## 5. LinkedIn OAuth ⏱️ ~10 min
+- [ ] 🖱️ LinkedIn Developer Console → your app → **Auth** → add redirect URL:
+      `https://app.<domain>/auth/linkedin/callback`
+- [ ] ⌨️ Ensure `LI_REDIRECT_URL` in `/opt/lem/.env` matches exactly, and `NGROK_PLAN=off`.
+
+## 6. GitHub repo configuration ⏱️ ~20 min
+- [ ] ⌨️ **Unblock the CI workflow files** (the PR could not push them — token
+      lacked the scope). Once, on your laptop:
+      ```
+      gh auth refresh -h github.com -s workflow
+      git -C <repo> push        # pushes the held-back "ci(deploy)" commit
+      ```
+- [ ] 🖱️ **Settings → Secrets and variables → Actions → New secret** (repo):
+      - `VPS_HOST` = `<vps-ip>`
+      - `VPS_USER` = `deploy`
+      - `VPS_SSH_KEY` = contents of `~/.ssh/lem_ci_deploy` (the **private** key)
+      - `GHCR_PAT` = a Personal Access Token with `read:packages` (for the VPS pull)
+      - `UI_API_TOKEN` = the same value as `API_ACCESS_TOKENS` on the server
+      - (verify existing: `GITGUARDIAN_API_KEY`, `ANTHROPIC_API_KEY`, `CODECOV_TOKEN`)
+- [ ] 🖱️ **Settings → Environments → New environment** `production` → add yourself
+      as a **Required reviewer** (gates the deploy job).
+- [ ] 🖱️ **Settings → Branches → Add branch ruleset** for `main`: require PR +
+      ≥1 review + status checks: `CI / Unit Tests`,
+      `CI / Integration Test w/ Coverage`, `CodeQL Security Analysis`,
+      `GitGuardian Security Scan`.
+- [ ] 🖱️ **Settings → Actions → General**: ensure Actions can write packages
+      (GHCR push uses the built-in token).
+
+## 7. First deploy ⏱️ ~15 min
+- [ ] 🖱️ Merge PR #126 (after the workflow commit is pushed in step 6).
+- [ ] 🖱️ Merge the **release-please** PR it opens → creates tag `vX.Y.Z` →
+      `Build & Deploy Release` runs → approve the `production` gate.
+      _Or_ bootstrap manually first:
+      `ssh deploy@<vps-ip> 'cd /opt/lem && ./scripts/deploy.sh latest'`
+- [ ] ⌨️ Verify: `curl https://app.<domain>/health` → `{"status":"healthy"}`
+- [ ] 🖱️ Load `https://app.<domain>` (SPA), then `flower.<domain>` (should force
+      Cloudflare Access login).
+- [ ] ⌨️ Confirm API gate: `curl https://app.<domain>/api/posts` → 401;
+      with `-H "Authorization: Bearer <token>"` → not 401.
+
+## 8. Backups + ops ⏱️ ~10 min
+- [ ] ⌨️ Add the nightly backup cron on the VPS:
+      ```
+      ssh deploy@<vps-ip> 'crontab -l 2>/dev/null; echo "0 3 * * * cd /opt/lem && ./scripts/backup.sh >> logs/backup.log 2>&1" | crontab -'
+      ```
+- [ ] 🖱️ (Optional) Configure `rclone` + `BACKUP_REMOTE` for off-box backups (Cloudflare R2 / S3).
+- [ ] 🖱️ (Optional) External uptime monitor on `https://app.<domain>/health`.
+- [ ] ⌨️ Test rollback once: `ssh deploy@<vps-ip> 'cd /opt/lem && ./scripts/rollback.sh <prev-tag>'`
+
+---
+
+### Rollback / redeploy later
+GitHub → Actions → **Redeploy / Rollback VPS** → run with a tag (tick `rollback`
+to skip migrations). Or on the box: `cd /opt/lem && ./scripts/rollback.sh <tag>`.
+
+See `docs/DEPLOYMENT.md` for the full runbook and troubleshooting table.

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Nightly backup of the MySQL database + Chrome profile volume.
+# Run from cron on the VPS, e.g.:
+#   0 3 * * * cd /opt/lem && ./scripts/backup.sh >> logs/backup.log 2>&1
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+# Load env for DB creds (MYSQL_*).
+set -a; [[ -f .env ]] && . ./.env; set +a
+
+BACKUP_DIR="${BACKUP_DIR:-${ROOT_DIR}/backups}"
+RETAIN_DAYS="${RETAIN_DAYS:-7}"
+STAMP="$(date -u +%Y%m%d-%H%M%S)"
+mkdir -p "$BACKUP_DIR"
+
+echo "[backup ${STAMP}] dumping MySQL ${MYSQL_DATABASE}"
+docker exec "${MYSQL_HOST:-mysql_db}" \
+  mysqldump --single-transaction --quick --routines --triggers \
+  -u root -p"${MYSQL_ROOT_PASSWORD}" "${MYSQL_DATABASE}" \
+  | gzip > "${BACKUP_DIR}/db-${STAMP}.sql.gz"
+
+echo "[backup ${STAMP}] archiving chrome-profile volume"
+docker run --rm \
+  -v linkedin_engagement_manager_chrome-profile:/data:ro \
+  -v "${BACKUP_DIR}:/backup" \
+  alpine tar czf "/backup/chrome-profile-${STAMP}.tar.gz" -C /data . 2>/dev/null || \
+  echo "[backup] chrome-profile volume not found (named differently?) — skipping"
+
+echo "[backup ${STAMP}] pruning backups older than ${RETAIN_DAYS} days"
+find "$BACKUP_DIR" -name '*.gz' -mtime "+${RETAIN_DAYS}" -delete
+
+# Optional: push to Cloudflare R2 / S3 if rclone is configured.
+if command -v rclone >/dev/null 2>&1 && [[ -n "${BACKUP_REMOTE:-}" ]]; then
+  echo "[backup ${STAMP}] syncing to ${BACKUP_REMOTE}"
+  rclone copy "$BACKUP_DIR" "$BACKUP_REMOTE" --max-age "${RETAIN_DAYS}d"
+fi
+echo "[backup ${STAMP}] done"

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Verify the server .env defines every key listed in .env.prod.example.
+# Catches "new env var added in a release but never set on the server".
+#
+# Usage: scripts/check_env.sh [path-to-env] [path-to-template]
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${1:-${ROOT_DIR}/.env}"
+TEMPLATE="${2:-${ROOT_DIR}/.env.prod.example}"
+
+[[ -f "$ENV_FILE" ]] || { echo "ERROR: env file not found: $ENV_FILE" >&2; exit 1; }
+[[ -f "$TEMPLATE" ]] || { echo "ERROR: template not found: $TEMPLATE" >&2; exit 1; }
+
+# Extract KEY names (strip comments/blank lines, take text before first '=').
+keys_of() {
+  grep -vE '^[[:space:]]*(#|$)' "$1" | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=.*/\1/' | sort -u
+}
+
+missing=()
+while IFS= read -r key; do
+  [[ -z "$key" ]] && continue
+  if ! grep -qE "^[[:space:]]*${key}=" "$ENV_FILE"; then
+    missing+=("$key")
+  fi
+done < <(keys_of "$TEMPLATE")
+
+if (( ${#missing[@]} > 0 )); then
+  echo "ERROR: ${ENV_FILE} is missing required keys:" >&2
+  printf '  - %s\n' "${missing[@]}" >&2
+  exit 1
+fi
+
+echo "OK: ${ENV_FILE} defines all keys from $(basename "$TEMPLATE")."

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Deploy a released image tag to the VPS. Invoked by CI over SSH:
+#   ssh deploy@vps 'cd /opt/lem && ./scripts/deploy.sh v1.2.3'
+#
+# Pulls the tag from GHCR, runs Flyway migrations, recreates the stack, waits
+# for health, and rolls back to the last-good tag if health never comes up.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TAG="${1:?Usage: deploy.sh <image-tag>}"
+COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.yml"
+LAST_GOOD_FILE="${ROOT_DIR}/.last_good_tag"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
+
+log() { echo "[deploy $(date -u +%H:%M:%S)] $*"; }
+
+# 1. Sync compose files + Flyway migrations to the released ref.
+log "Fetching git ref ${TAG}"
+git fetch --tags --quiet origin
+git checkout --quiet "${TAG}" 2>/dev/null || git checkout --quiet "tags/${TAG}"
+
+# 2. Validate env before touching containers.
+./scripts/check_env.sh
+
+# 3. GHCR login (CI passes GHCR_USER/GHCR_PAT through the SSH env, or use a
+#    long-lived login already present on the box).
+if [[ -n "${GHCR_PAT:-}" && -n "${GHCR_USER:-}" ]]; then
+  echo "${GHCR_PAT}" | docker login ghcr.io -u "${GHCR_USER}" --password-stdin
+fi
+
+export IMAGE_TAG="${TAG}"
+
+# 4. Pull the exact app image tag (+ any updated third-party images).
+log "Pulling images for IMAGE_TAG=${TAG}"
+${COMPOSE} pull
+
+# 5. Migrations first — Flyway is idempotent (repair + migrate, baselineOnMigrate).
+log "Running database migrations"
+${COMPOSE} up -d mysql
+${COMPOSE} run --rm flyway
+
+# 6. Recreate changed services.
+log "Starting stack"
+${COMPOSE} up -d --remove-orphans
+
+# 7. Wait for the web app to report healthy; roll back on failure.
+log "Waiting up to ${HEALTH_TIMEOUT}s for web_app health"
+deadline=$(( $(date +%s) + HEALTH_TIMEOUT ))
+healthy=false
+while (( $(date +%s) < deadline )); do
+  if docker exec web_app curl -fsS "http://localhost:${API_PORT:-8000}/health" >/dev/null 2>&1; then
+    healthy=true
+    break
+  fi
+  sleep 5
+done
+
+if [[ "${healthy}" != true ]]; then
+  log "ERROR: web_app did not become healthy."
+  if [[ -f "${LAST_GOOD_FILE}" ]]; then
+    prev="$(cat "${LAST_GOOD_FILE}")"
+    log "Rolling back to ${prev}"
+    git checkout --quiet "${prev}" 2>/dev/null || git checkout --quiet "tags/${prev}" || true
+    export IMAGE_TAG="${prev}"
+    ${COMPOSE} up -d --remove-orphans
+  fi
+  exit 1
+fi
+
+# 8. Record the new good tag and prune old artifacts.
+echo "${TAG}" > "${LAST_GOOD_FILE}"
+log "Deploy of ${TAG} OK. Pruning old images/build cache (>168h)."
+docker image prune -af --filter "until=168h" >/dev/null 2>&1 || true
+docker builder prune -af --filter "until=168h" >/dev/null 2>&1 || true
+log "Done."

--- a/scripts/rollback.sh
+++ b/scripts/rollback.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Manual rollback to a previously deployed image tag.
+#   ssh deploy@vps 'cd /opt/lem && ./scripts/rollback.sh v1.2.2'
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+TAG="${1:?Usage: rollback.sh <image-tag>}"
+COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.yml"
+
+echo "[rollback] checking out ${TAG}"
+git fetch --tags --quiet origin
+git checkout --quiet "${TAG}" 2>/dev/null || git checkout --quiet "tags/${TAG}"
+
+export IMAGE_TAG="${TAG}"
+${COMPOSE} pull
+${COMPOSE} up -d --remove-orphans
+echo "${TAG}" > "${ROOT_DIR}/.last_good_tag"
+echo "[rollback] now running ${TAG}"

--- a/scripts/vps_bootstrap.sh
+++ b/scripts/vps_bootstrap.sh
@@ -1,42 +1,86 @@
 #!/usr/bin/env bash
-# One-time provisioning for a fresh Hostinger VPS (Ubuntu 22.04/24.04).
-# Run as root (or with sudo). Idempotent where practical.
+# Guided one-time provisioning for a fresh Hostinger VPS (Ubuntu 22.04/24.04).
+# Run as root (or with sudo). Idempotent — safe to re-run.
 #
-#   curl -fsSL .../vps_bootstrap.sh | bash   (or scp + run)
+#   scp scripts/vps_bootstrap.sh root@<vps>:/root/ && ssh root@<vps> 'bash /root/vps_bootstrap.sh'
+#   # or non-interactively, pre-seeding everything:
+#   REPO_URL=... CI_DEPLOY_PUBKEY="ssh-ed25519 AAAA..." ASSUME_YES=1 bash vps_bootstrap.sh
 #
-# After this: place the repo in /opt/lem, create /opt/lem/.env from
-# .env.prod.example, then deploy with scripts/deploy.sh.
+# What it does: installs Docker, hardens the box, clones the repo to /opt/lem,
+# installs the CI deploy key, scaffolds .env, and (optionally) runs the first
+# deploy. Anything it can't do for you is printed as a checklist at the end.
 set -euo pipefail
 
+# --- Config (override via env) ------------------------------------------------
 DEPLOY_USER="${DEPLOY_USER:-deploy}"
-APP_DIR="/opt/lem"
-REPO_URL="${REPO_URL:-https://github.com/gitchrisqueen/linkedin_engagement_manager.git}"
+APP_DIR="${APP_DIR:-/opt/lem}"
+REPO_URL="${REPO_URL:-https://github.com/christopherqueenconsulting/linkedin_engagement_manager.git}"
+REPO_BRANCH="${REPO_BRANCH:-main}"
+SWAP_SIZE="${SWAP_SIZE:-4G}"
+CI_DEPLOY_PUBKEY="${CI_DEPLOY_PUBKEY:-}"   # paste the CI public key to auto-install
+ASSUME_YES="${ASSUME_YES:-0}"              # 1 = answer "yes" to every prompt
+RUN_FIRST_DEPLOY="${RUN_FIRST_DEPLOY:-ask}" # ask | yes | no
+MIN_CORES=4
+MIN_RAM_GB=8
 
-log() { echo "[bootstrap] $*"; }
+# --- Pretty output ------------------------------------------------------------
+if [[ -t 1 ]]; then BOLD=$'\e[1m'; GRN=$'\e[32m'; YLW=$'\e[33m'; RED=$'\e[31m'; RST=$'\e[0m'
+else BOLD=""; GRN=""; YLW=""; RED=""; RST=""; fi
+STEP=0
+step() { STEP=$((STEP+1)); echo; echo "${BOLD}${GRN}[${STEP}] $*${RST}"; }
+info() { echo "    $*"; }
+warn() { echo "${YLW}    ! $*${RST}"; }
+err()  { echo "${RED}    x $*${RST}" >&2; }
 
-[[ "$(id -u)" -eq 0 ]] || { echo "Run as root/sudo." >&2; exit 1; }
+# Prompt yes/no. Non-interactive (piped) or ASSUME_YES → use the default.
+ask() {
+  local prompt="$1" default="${2:-N}" reply
+  if [[ "$ASSUME_YES" == "1" ]]; then reply="y"
+  elif [[ -e /dev/tty ]]; then
+    read -r -p "    ${prompt} [$([[ $default == Y ]] && echo Y/n || echo y/N)] " reply </dev/tty || reply=""
+  else reply=""; fi
+  reply="${reply:-$default}"
+  [[ "$reply" =~ ^[Yy] ]]
+}
 
-log "Installing base packages"
+[[ "$(id -u)" -eq 0 ]] || { err "Run as root (or with sudo)."; exit 1; }
+
+# --- 0. Preflight: sizing -----------------------------------------------------
+step "Preflight checks"
+CORES="$(nproc)"
+RAM_GB="$(awk '/MemTotal/ {printf "%d", $2/1024/1024}' /proc/meminfo)"
+DISK_GB="$(df -BG --output=avail / | tail -1 | tr -dc '0-9')"
+info "CPU cores: ${CORES} | RAM: ${RAM_GB} GB | free disk: ${DISK_GB} GB"
+(( CORES >= MIN_CORES ))   || warn "Below recommended ${MIN_CORES} cores — Selenium/Chrome will be tight."
+(( RAM_GB >= MIN_RAM_GB )) || warn "Below recommended ${MIN_RAM_GB} GB RAM — relying on swap; consider a bigger plan."
+(( DISK_GB >= 20 ))        || warn "Low free disk (${DISK_GB} GB) — images + volumes may fill it."
+if ! grep -qiE 'ubuntu' /etc/os-release; then warn "Not Ubuntu — apt/docker steps may differ."; fi
+
+# --- 1. Base packages ---------------------------------------------------------
+step "Installing base packages"
 export DEBIAN_FRONTEND=noninteractive
-apt-get update -y
-apt-get install -y ca-certificates curl git ufw gnupg
+apt-get update -y -qq
+apt-get install -y -qq ca-certificates curl git ufw gnupg
+info "ok"
 
-# --- Docker Engine + Compose v2 plugin (official repo) ---
+# --- 2. Docker Engine + Compose v2 --------------------------------------------
+step "Installing Docker Engine + Compose"
 if ! command -v docker >/dev/null 2>&1; then
-  log "Installing Docker Engine"
   install -m 0755 -d /etc/apt/keyrings
   curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
   chmod a+r /etc/apt/keyrings/docker.asc
   echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
 https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
     > /etc/apt/sources.list.d/docker.list
-  apt-get update -y
-  apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  apt-get update -y -qq
+  apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+  info "installed $(docker --version)"
+else
+  info "already present: $(docker --version)"
 fi
-systemctl enable --now docker
+systemctl enable --now docker >/dev/null 2>&1 || true
 
-# --- Docker log rotation (the app logs to stdout heavily) ---
-log "Configuring Docker log rotation + live-restore"
+step "Configuring Docker (log rotation + live-restore)"
 mkdir -p /etc/docker
 cat > /etc/docker/daemon.json <<'JSON'
 {
@@ -46,48 +90,130 @@ cat > /etc/docker/daemon.json <<'JSON'
 }
 JSON
 systemctl restart docker
+info "ok"
 
-# --- Deploy user ---
+# --- 3. Deploy user -----------------------------------------------------------
+step "Creating ${DEPLOY_USER} user"
 if ! id "$DEPLOY_USER" >/dev/null 2>&1; then
-  log "Creating ${DEPLOY_USER} user"
   useradd -m -s /bin/bash "$DEPLOY_USER"
+  info "created"
+else
+  info "already exists"
 fi
 usermod -aG docker "$DEPLOY_USER"
 
-# --- App directory ---
-log "Preparing ${APP_DIR}"
+# --- 4. CI deploy key ---------------------------------------------------------
+step "CI deploy SSH key"
+SSH_DIR="/home/${DEPLOY_USER}/.ssh"
+AUTH_KEYS="${SSH_DIR}/authorized_keys"
+install -d -m 700 -o "$DEPLOY_USER" -g "$DEPLOY_USER" "$SSH_DIR"
+touch "$AUTH_KEYS"
+if [[ -n "$CI_DEPLOY_PUBKEY" ]]; then
+  if grep -qF "$CI_DEPLOY_PUBKEY" "$AUTH_KEYS" 2>/dev/null; then
+    info "key already authorized"
+  else
+    echo "$CI_DEPLOY_PUBKEY" >> "$AUTH_KEYS"
+    info "installed provided CI public key"
+  fi
+else
+  warn "No CI_DEPLOY_PUBKEY provided — add the CI public key to ${AUTH_KEYS} later"
+  warn "(it becomes the GitHub VPS_SSH_KEY secret's matching public half)."
+fi
+chown -R "$DEPLOY_USER:$DEPLOY_USER" "$SSH_DIR"
+chmod 600 "$AUTH_KEYS"
+
+# --- 5. Repo -----------------------------------------------------------------
+step "Cloning repo to ${APP_DIR} (branch ${REPO_BRANCH})"
 mkdir -p "$APP_DIR"
 if [[ ! -d "${APP_DIR}/.git" ]]; then
-  git clone "$REPO_URL" "$APP_DIR"
+  git clone --branch "$REPO_BRANCH" "$REPO_URL" "$APP_DIR"
+  info "cloned"
+else
+  git -C "$APP_DIR" fetch --quiet origin "$REPO_BRANCH" && git -C "$APP_DIR" checkout --quiet "$REPO_BRANCH" || true
+  info "already cloned (fetched latest ${REPO_BRANCH})"
 fi
+mkdir -p "${APP_DIR}/logs"
 chown -R "$DEPLOY_USER:$DEPLOY_USER" "$APP_DIR"
 
-# --- Firewall: only SSH inbound. Cloudflare Tunnel dials OUT, so no 80/443. ---
-log "Configuring ufw (SSH only inbound)"
-ufw allow OpenSSH
-ufw --force enable
+# --- 6. Firewall + SSH hardening ---------------------------------------------
+step "Firewall (SSH-only inbound; Cloudflare Tunnel dials out)"
+ufw allow OpenSSH >/dev/null
+ufw --force enable >/dev/null
+info "ufw enabled"
 
-# --- SSH hardening ---
-log "Hardening SSH (key-only, no root login)"
+step "Hardening SSH (key-only auth, no root login)"
 sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
 sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
-systemctl reload ssh || systemctl reload sshd || true
+systemctl reload ssh 2>/dev/null || systemctl reload sshd 2>/dev/null || true
+warn "Confirm you can SSH as ${DEPLOY_USER} with a key BEFORE closing this session."
 
-# --- Swap (Selenium/Chrome is memory-hungry) ---
+# --- 7. Swap ------------------------------------------------------------------
+step "Swap (${SWAP_SIZE}) for memory-heavy Selenium/Chrome"
 if [[ ! -f /swapfile ]]; then
-  log "Creating 4G swapfile"
-  fallocate -l 4G /swapfile
+  fallocate -l "$SWAP_SIZE" /swapfile || dd if=/dev/zero of=/swapfile bs=1M count="$(( ${SWAP_SIZE%G} * 1024 ))"
   chmod 600 /swapfile
-  mkswap /swapfile
+  mkswap /swapfile >/dev/null
   swapon /swapfile
-  echo '/swapfile none swap sw 0 0' >> /etc/fstab
+  grep -q '^/swapfile' /etc/fstab || echo '/swapfile none swap sw 0 0' >> /etc/fstab
+  info "created and enabled"
+else
+  info "swapfile already present"
 fi
 
+# --- 8. Env scaffold ----------------------------------------------------------
+step "Environment file (${APP_DIR}/.env)"
+ENV_FILE="${APP_DIR}/.env"
+if [[ -f "$ENV_FILE" ]]; then
+  info ".env already exists — leaving it untouched"
+else
+  cp "${APP_DIR}/.env.prod.example" "$ENV_FILE"
+  chown "$DEPLOY_USER:$DEPLOY_USER" "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+  info "created from .env.prod.example (chmod 600)"
+  warn "Fill in every CHANGE_ME value (DB, ADMIN_SECRET, API_ACCESS_TOKENS, TUNNEL_TOKEN, API keys, live Stripe)."
+  if ask "Open ${ENV_FILE} in an editor now?" N; then
+    "${EDITOR:-nano}" "$ENV_FILE" </dev/tty >/dev/tty 2>&1 || true
+  fi
+fi
+
+# Validate keys present (non-fatal — secrets may still be placeholders).
+if [[ -x "${APP_DIR}/scripts/check_env.sh" ]]; then
+  if "${APP_DIR}/scripts/check_env.sh" "$ENV_FILE" "${APP_DIR}/.env.prod.example" >/dev/null 2>&1; then
+    info "check_env: all required keys present"
+  else
+    warn "check_env: some keys are missing — run ${APP_DIR}/scripts/check_env.sh to see which."
+  fi
+fi
+
+# --- 9. Optional first deploy -------------------------------------------------
+step "First deploy"
+do_deploy=false
+case "$RUN_FIRST_DEPLOY" in
+  yes) do_deploy=true ;;
+  no)  do_deploy=false ;;
+  *)   if grep -q 'CHANGE_ME' "$ENV_FILE" 2>/dev/null; then
+         warn "Skipping — .env still has CHANGE_ME placeholders. Finish secrets first."
+       elif ask "Run ./scripts/deploy.sh latest now (as ${DEPLOY_USER})?" N; then
+         do_deploy=true
+       fi ;;
+esac
+if $do_deploy; then
+  info "Deploying latest…"
+  su - "$DEPLOY_USER" -c "cd '${APP_DIR}' && ./scripts/deploy.sh latest" || err "Deploy failed — see output above."
+else
+  info "Deferred. Run later:  su - ${DEPLOY_USER} -c 'cd ${APP_DIR} && ./scripts/deploy.sh latest'"
+fi
+
+# --- Summary ------------------------------------------------------------------
 cat <<EOF
 
-[bootstrap] Done. Next steps:
-  1. Add the CI deploy public key to /home/${DEPLOY_USER}/.ssh/authorized_keys
-  2. cp ${APP_DIR}/.env.prod.example ${APP_DIR}/.env && edit it && chmod 600 ${APP_DIR}/.env
-  3. Create the Cloudflare Tunnel + set TUNNEL_TOKEN in .env
-  4. As ${DEPLOY_USER}:  cd ${APP_DIR} && ./scripts/deploy.sh <tag>
+${BOLD}${GRN}Bootstrap complete.${RST} Remaining manual steps (see docs/SETUP_CHECKLIST.md):
+  ${CI_DEPLOY_PUBKEY:+✓}${CI_DEPLOY_PUBKEY:-•} CI deploy key on ${DEPLOY_USER}@host  ${CI_DEPLOY_PUBKEY:+(done)}
+  • Fill secrets in ${ENV_FILE} (esp. TUNNEL_TOKEN, API_ACCESS_TOKENS)
+  • Create the Cloudflare Tunnel + Access policies; map app/flower/litellm/vnc
+  • LinkedIn redirect → https://app.<domain>/auth/linkedin/callback
+  • GitHub: secrets (VPS_HOST/USER/SSH_KEY, GHCR_PAT, UI_API_TOKEN),
+    'production' environment, branch protection on main
+  • Add nightly backup cron:
+      su - ${DEPLOY_USER} -c 'crontab -l 2>/dev/null; echo "0 3 * * * cd ${APP_DIR} && ./scripts/backup.sh >> logs/backup.log 2>&1" | crontab -'
 EOF

--- a/scripts/vps_bootstrap.sh
+++ b/scripts/vps_bootstrap.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# One-time provisioning for a fresh Hostinger VPS (Ubuntu 22.04/24.04).
+# Run as root (or with sudo). Idempotent where practical.
+#
+#   curl -fsSL .../vps_bootstrap.sh | bash   (or scp + run)
+#
+# After this: place the repo in /opt/lem, create /opt/lem/.env from
+# .env.prod.example, then deploy with scripts/deploy.sh.
+set -euo pipefail
+
+DEPLOY_USER="${DEPLOY_USER:-deploy}"
+APP_DIR="/opt/lem"
+REPO_URL="${REPO_URL:-https://github.com/gitchrisqueen/linkedin_engagement_manager.git}"
+
+log() { echo "[bootstrap] $*"; }
+
+[[ "$(id -u)" -eq 0 ]] || { echo "Run as root/sudo." >&2; exit 1; }
+
+log "Installing base packages"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y ca-certificates curl git ufw gnupg
+
+# --- Docker Engine + Compose v2 plugin (official repo) ---
+if ! command -v docker >/dev/null 2>&1; then
+  log "Installing Docker Engine"
+  install -m 0755 -d /etc/apt/keyrings
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] \
+https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+    > /etc/apt/sources.list.d/docker.list
+  apt-get update -y
+  apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+fi
+systemctl enable --now docker
+
+# --- Docker log rotation (the app logs to stdout heavily) ---
+log "Configuring Docker log rotation + live-restore"
+mkdir -p /etc/docker
+cat > /etc/docker/daemon.json <<'JSON'
+{
+  "log-driver": "json-file",
+  "log-opts": { "max-size": "20m", "max-file": "5" },
+  "live-restore": true
+}
+JSON
+systemctl restart docker
+
+# --- Deploy user ---
+if ! id "$DEPLOY_USER" >/dev/null 2>&1; then
+  log "Creating ${DEPLOY_USER} user"
+  useradd -m -s /bin/bash "$DEPLOY_USER"
+fi
+usermod -aG docker "$DEPLOY_USER"
+
+# --- App directory ---
+log "Preparing ${APP_DIR}"
+mkdir -p "$APP_DIR"
+if [[ ! -d "${APP_DIR}/.git" ]]; then
+  git clone "$REPO_URL" "$APP_DIR"
+fi
+chown -R "$DEPLOY_USER:$DEPLOY_USER" "$APP_DIR"
+
+# --- Firewall: only SSH inbound. Cloudflare Tunnel dials OUT, so no 80/443. ---
+log "Configuring ufw (SSH only inbound)"
+ufw allow OpenSSH
+ufw --force enable
+
+# --- SSH hardening ---
+log "Hardening SSH (key-only, no root login)"
+sed -i 's/^#\?PasswordAuthentication.*/PasswordAuthentication no/' /etc/ssh/sshd_config
+sed -i 's/^#\?PermitRootLogin.*/PermitRootLogin no/' /etc/ssh/sshd_config
+systemctl reload ssh || systemctl reload sshd || true
+
+# --- Swap (Selenium/Chrome is memory-hungry) ---
+if [[ ! -f /swapfile ]]; then
+  log "Creating 4G swapfile"
+  fallocate -l 4G /swapfile
+  chmod 600 /swapfile
+  mkswap /swapfile
+  swapon /swapfile
+  echo '/swapfile none swap sw 0 0' >> /etc/fstab
+fi
+
+cat <<EOF
+
+[bootstrap] Done. Next steps:
+  1. Add the CI deploy public key to /home/${DEPLOY_USER}/.ssh/authorized_keys
+  2. cp ${APP_DIR}/.env.prod.example ${APP_DIR}/.env && edit it && chmod 600 ${APP_DIR}/.env
+  3. Create the Cloudflare Tunnel + set TUNNEL_TOKEN in .env
+  4. As ${DEPLOY_USER}:  cd ${APP_DIR} && ./scripts/deploy.sh <tag>
+EOF

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -38,7 +38,7 @@ from cqc_lem.utilities.email import generate_pin, hash_pin, send_pin_email
 from cqc_lem.utilities.linkedin.token_refresh import (
     get_token_expiry, is_token_expired, is_token_expiring_soon, attempt_token_refresh,
 )
-from cqc_lem.utilities.env_constants import LI_CLIENT_ID, LI_CLIENT_SECRET, LI_REDIRECT_URL, LI_STATE_SALT, ADMIN_SECRET
+from cqc_lem.utilities.env_constants import LI_CLIENT_ID, LI_CLIENT_SECRET, LI_REDIRECT_URL, LI_STATE_SALT, ADMIN_SECRET, API_ACCESS_TOKENS
 from cqc_lem.utilities.logger import myprint
 from cqc_lem.utilities.mime_type_helper import get_file_mime_type
 from cqc_lem.utilities.observability import track_api_call
@@ -46,6 +46,7 @@ from cqc_lem.utilities.utils import get_file_extension_from_filepath
 from fastapi import FastAPI, HTTPException, Request, status, APIRouter, Header
 from fastapi import File, Form, Query, UploadFile
 from fastapi.responses import FileResponse
+from fastapi.responses import JSONResponse
 from fastapi.responses import HTMLResponse
 from fastapi.responses import RedirectResponse
 from fastapi.responses import StreamingResponse
@@ -76,6 +77,38 @@ async def observability_middleware(request: Request, call_next):
             status_code=status_code,
             latency_ms=int((time.time() - start) * 1000),
         )
+
+
+# Bearer-token gate for /api routes. Active only when API_ACCESS_TOKENS is set,
+# so local/dev (and existing tests) run open. Login and the Stripe webhook stay
+# public; everything else under /api requires a valid bearer token. Routes served
+# outside /api (SPA, /health, /docs, /auth/linkedin/*) are never gated here.
+_API_ACCESS_TOKEN_SET = {t.strip() for t in API_ACCESS_TOKENS.split(",") if t.strip()}
+_PUBLIC_API_PREFIXES = ("/api/auth/", "/api/billing/webhook")
+
+
+def _api_token_required(path: str) -> bool:
+    if not _API_ACCESS_TOKEN_SET or not path.startswith("/api/"):
+        return False
+    return not any(path.startswith(p) for p in _PUBLIC_API_PREFIXES)
+
+
+def _bearer_token(authorization: Optional[str]) -> Optional[str]:
+    if not authorization:
+        return None
+    scheme, _, token = authorization.partition(" ")
+    if scheme.lower() != "bearer" or not token.strip():
+        return None
+    return token.strip()
+
+
+@app.middleware("http")
+async def api_token_middleware(request: Request, call_next):
+    if _api_token_required(request.url.path):
+        token = _bearer_token(request.headers.get("Authorization"))
+        if token not in _API_ACCESS_TOKEN_SET:
+            return JSONResponse(status_code=401, content={"status_code": 401, "detail": "Unauthorized"})
+    return await call_next(request)
 
 
 _ui_dist = os.path.join(os.path.dirname(__file__), "..", "ui", "dist")

--- a/src/cqc_lem/ui/src/api/client.ts
+++ b/src/cqc_lem/ui/src/api/client.ts
@@ -5,7 +5,14 @@ const api = axios.create({
   headers: { 'Content-Type': 'application/json' },
 })
 
+// Build-time API access token. Empty in local/dev (gate disabled server-side);
+// set via VITE_API_TOKEN for deployments that enforce bearer auth on /api.
+const apiToken = import.meta.env.VITE_API_TOKEN
+
 api.interceptors.request.use((config) => {
+  if (apiToken) {
+    config.headers['Authorization'] = `Bearer ${apiToken}`
+  }
   const token = localStorage.getItem('lem_session')
   if (token) {
     config.headers['X-Session-Token'] = token

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -112,5 +112,9 @@ else:
 
 ADMIN_SECRET = get_constant_from_env('ADMIN_SECRET')
 
+# Comma-separated bearer tokens accepted on /api routes. Empty disables the gate
+# (local/dev) so only deployments that set it enforce token auth.
+API_ACCESS_TOKENS = get_constant_from_env('API_ACCESS_TOKENS', default_value='')
+
 # Set other constants here
 USE_DOCKER_BROWSER = isTrue(get_constant_from_env('USE_DOCKER_BROWSER', default_value='True'))

--- a/tests/unit/api/test_api_token_gate.py
+++ b/tests/unit/api/test_api_token_gate.py
@@ -1,0 +1,106 @@
+"""Unit tests for the /api bearer-token gate in cqc_lem.api.main."""
+
+from unittest.mock import patch
+
+import pytest
+
+from cqc_lem.api import main
+from cqc_lem.api.main import _api_token_required, _bearer_token
+
+pytestmark = pytest.mark.unit
+
+# ---------------------------------------------------------------------------
+# _bearer_token — Authorization header parsing
+# ---------------------------------------------------------------------------
+
+class TestBearerTokenParsing:
+    @pytest.mark.parametrize("header,expected", [
+        (None, None),
+        ("", None),
+        ("Bearer abc123", "abc123"),
+        ("bearer abc123", "abc123"),  # scheme is case-insensitive
+        ("Bearer   ", None),           # empty token
+        ("Basic abc123", None),        # wrong scheme
+        ("abc123", None),              # no scheme
+    ])
+    def test_parses_header(self, header, expected):
+        assert _bearer_token(header) == expected
+
+
+# ---------------------------------------------------------------------------
+# _api_token_required — which paths are gated
+# ---------------------------------------------------------------------------
+
+class TestApiTokenRequired:
+    def test_disabled_when_no_tokens_configured(self):
+        with patch.object(main, "_API_ACCESS_TOKEN_SET", set()):
+            assert _api_token_required("/api/posts") is False
+
+    @pytest.mark.parametrize("path", [
+        "/api/posts",
+        "/api/assets",
+        "/api/avatar/training",
+    ])
+    def test_business_routes_gated(self, path):
+        with patch.object(main, "_API_ACCESS_TOKEN_SET", {"tok"}):
+            assert _api_token_required(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "/api/auth/email/init",   # login flow
+        "/api/auth/email/verify",
+        "/api/auth/session",
+        "/api/billing/webhook",   # Stripe (signature-verified)
+        "/health",                # non-/api
+        "/auth/linkedin/callback",
+        "/assets/index.js",       # SPA static
+    ])
+    def test_public_routes_not_gated(self, path):
+        with patch.object(main, "_API_ACCESS_TOKEN_SET", {"tok"}):
+            assert _api_token_required(path) is False
+
+
+# ---------------------------------------------------------------------------
+# Middleware behavior via TestClient
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def client():
+    with patch("cqc_lem.utilities.observability.track_api_call"):
+        from fastapi.testclient import TestClient
+
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+
+
+class TestGateMiddleware:
+    TOKEN = "secret-token-xyz"
+
+    def test_guarded_route_without_token_is_401(self, client):
+        with patch.object(main, "_API_ACCESS_TOKEN_SET", {self.TOKEN}):
+            resp = client.get("/api/assets", params={"file_name": "x.png"})
+        assert resp.status_code == 401
+
+    def test_guarded_route_wrong_token_is_401(self, client):
+        with patch.object(main, "_API_ACCESS_TOKEN_SET", {self.TOKEN}):
+            resp = client.get(
+                "/api/assets",
+                params={"file_name": "x.png"},
+                headers={"Authorization": "Bearer wrong"},
+            )
+        assert resp.status_code == 401
+
+    def test_guarded_route_valid_token_passes_gate(self, client):
+        # Valid token clears the gate; the handler then 404s on the missing file.
+        with patch.object(main, "_API_ACCESS_TOKEN_SET", {self.TOKEN}):
+            resp = client.get(
+                "/api/assets",
+                params={"file_name": "x.png"},
+                headers={"Authorization": f"Bearer {self.TOKEN}"},
+            )
+        assert resp.status_code != 401
+
+    def test_gate_disabled_allows_unauthenticated(self, client):
+        with patch.object(main, "_API_ACCESS_TOKEN_SET", set()):
+            resp = client.get("/api/assets", params={"file_name": "x.png"})
+        assert resp.status_code != 401

--- a/tests/unit/api/test_api_token_gate.py
+++ b/tests/unit/api/test_api_token_gate.py
@@ -4,10 +4,27 @@ from unittest.mock import patch
 
 import pytest
 
-from cqc_lem.api import main
-from cqc_lem.api.main import _api_token_required, _bearer_token
-
 pytestmark = pytest.mark.unit
+
+
+# Import cqc_lem.api.main lazily (inside fixtures), not at module scope: importing
+# it builds the OpenAI client, which needs OPENAI_API_KEY — set by the session
+# autouse fixture in tests/conftest.py, which runs *after* collection.
+@pytest.fixture(scope="module")
+def main_mod():
+    from cqc_lem.api import main
+    return main
+
+
+@pytest.fixture(scope="module")
+def client():
+    with patch("cqc_lem.utilities.observability.track_api_call"):
+        from fastapi.testclient import TestClient
+
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+
 
 # ---------------------------------------------------------------------------
 # _bearer_token — Authorization header parsing
@@ -23,8 +40,8 @@ class TestBearerTokenParsing:
         ("Basic abc123", None),        # wrong scheme
         ("abc123", None),              # no scheme
     ])
-    def test_parses_header(self, header, expected):
-        assert _bearer_token(header) == expected
+    def test_parses_header(self, main_mod, header, expected):
+        assert main_mod._bearer_token(header) == expected
 
 
 # ---------------------------------------------------------------------------
@@ -32,18 +49,18 @@ class TestBearerTokenParsing:
 # ---------------------------------------------------------------------------
 
 class TestApiTokenRequired:
-    def test_disabled_when_no_tokens_configured(self):
-        with patch.object(main, "_API_ACCESS_TOKEN_SET", set()):
-            assert _api_token_required("/api/posts") is False
+    def test_disabled_when_no_tokens_configured(self, main_mod):
+        with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", set()):
+            assert main_mod._api_token_required("/api/posts") is False
 
     @pytest.mark.parametrize("path", [
         "/api/posts",
         "/api/assets",
         "/api/avatar/training",
     ])
-    def test_business_routes_gated(self, path):
-        with patch.object(main, "_API_ACCESS_TOKEN_SET", {"tok"}):
-            assert _api_token_required(path) is True
+    def test_business_routes_gated(self, main_mod, path):
+        with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", {"tok"}):
+            assert main_mod._api_token_required(path) is True
 
     @pytest.mark.parametrize("path", [
         "/api/auth/email/init",   # login flow
@@ -54,35 +71,25 @@ class TestApiTokenRequired:
         "/auth/linkedin/callback",
         "/assets/index.js",       # SPA static
     ])
-    def test_public_routes_not_gated(self, path):
-        with patch.object(main, "_API_ACCESS_TOKEN_SET", {"tok"}):
-            assert _api_token_required(path) is False
+    def test_public_routes_not_gated(self, main_mod, path):
+        with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", {"tok"}):
+            assert main_mod._api_token_required(path) is False
 
 
 # ---------------------------------------------------------------------------
 # Middleware behavior via TestClient
 # ---------------------------------------------------------------------------
 
-@pytest.fixture(scope="module")
-def client():
-    with patch("cqc_lem.utilities.observability.track_api_call"):
-        from fastapi.testclient import TestClient
-
-        from cqc_lem.api.main import app
-        with TestClient(app, raise_server_exceptions=False) as tc:
-            yield tc
-
-
 class TestGateMiddleware:
     TOKEN = "secret-token-xyz"
 
-    def test_guarded_route_without_token_is_401(self, client):
-        with patch.object(main, "_API_ACCESS_TOKEN_SET", {self.TOKEN}):
+    def test_guarded_route_without_token_is_401(self, main_mod, client):
+        with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", {self.TOKEN}):
             resp = client.get("/api/assets", params={"file_name": "x.png"})
         assert resp.status_code == 401
 
-    def test_guarded_route_wrong_token_is_401(self, client):
-        with patch.object(main, "_API_ACCESS_TOKEN_SET", {self.TOKEN}):
+    def test_guarded_route_wrong_token_is_401(self, main_mod, client):
+        with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", {self.TOKEN}):
             resp = client.get(
                 "/api/assets",
                 params={"file_name": "x.png"},
@@ -90,9 +97,9 @@ class TestGateMiddleware:
             )
         assert resp.status_code == 401
 
-    def test_guarded_route_valid_token_passes_gate(self, client):
+    def test_guarded_route_valid_token_passes_gate(self, main_mod, client):
         # Valid token clears the gate; the handler then 404s on the missing file.
-        with patch.object(main, "_API_ACCESS_TOKEN_SET", {self.TOKEN}):
+        with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", {self.TOKEN}):
             resp = client.get(
                 "/api/assets",
                 params={"file_name": "x.png"},
@@ -100,7 +107,7 @@ class TestGateMiddleware:
             )
         assert resp.status_code != 401
 
-    def test_gate_disabled_allows_unauthenticated(self, client):
-        with patch.object(main, "_API_ACCESS_TOKEN_SET", set()):
+    def test_gate_disabled_allows_unauthenticated(self, main_mod, client):
+        with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", set()):
             resp = client.get("/api/assets", params={"file_name": "x.png"})
         assert resp.status_code != 401


### PR DESCRIPTION
## Context
Adds a production deploy path so LEM runs the same Docker stack on a Hostinger VPS (live/dev), exposed via **Cloudflare Tunnel** (replacing ngrok), deployed from GitHub releases:

`local dev → PR to main → CI gates → release-please tag → GHCR image → SSH deploy to VPS → migrate + up`

Architecture decisions: SSH deploy + registry pull, **GHCR**, UI/API public with **API bearer tokens**, ops tools behind **Cloudflare Access**, **release-please** for versioning/changelog.

## What's here
- **`docker-compose.prod.yml`** overlay — GHCR images by tag, no dev bind-mounts, multi-worker uvicorn, **no published host ports**, `cloudflared` service, Flower basic auth, restart policies + resource caps.
- **`cloudflared/config.yml`** — ingress for `app/flower/litellm/vnc`.
- **API bearer-token gate** (`api/main.py`, `env_constants.py`) on `/api/*`, active only when `API_ACCESS_TOKENS` is set (local/dev untouched). Login + Stripe webhook exempt. SPA sends `VITE_API_TOKEN` (baked at image build). **22 new unit tests**.
- **`.env.prod.example`** + **`scripts/check_env.sh`** validator.
- **`scripts/`** — `vps_bootstrap.sh`, `deploy.sh` (checkout tag → Flyway → up → health-gate → auto-rollback), `rollback.sh`, `backup.sh`.
- **`docs/DEPLOYMENT.md`** runbook + CONTRIBUTING Conventional Commits note.

## ⚠️ Follow-up: CI workflow files
The 4 CI workflow files (`release-please.yml`, `build-and-push.yml`, `deploy-vps.yml`, AWS `deploy.yml`→manual) are committed locally but **could not be pushed** — the available tokens lack the `workflow` OAuth scope. To add them:
```
gh auth refresh -h github.com -s workflow
git push    # pushes the held-back ci(deploy) commit
```

## Verification
- `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` renders clean; base dev compose still valid.
- Full unit suite: **792 passed**; new test file ruff-clean.

## Reviewer setup notes (post-merge, outside repo)
Repo secrets `VPS_HOST/VPS_USER/VPS_SSH_KEY/GHCR_PAT/UI_API_TOKEN`, a protected `production` environment, branch protection on `main`. See `docs/DEPLOYMENT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)