### PR TITLE
fix(ci): correct trivy-action tag (v0.28.0) in release workflow

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Scan image (advisory)
         continue-on-error: true
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@v0.28.0
         with:
           image-ref: ${{ env.IMAGE }}:${{ steps.ver.outputs.tag }}
           format: table


### PR DESCRIPTION
The release workflow referenced `aquasecurity/trivy-action@0.28.0`, but the tag is published as `v0.28.0`. The unprefixed ref fails action resolution at job setup, which sinks the entire **Build & Push to GHCR** job before the image build runs — and because it fails during "prepare actions", the step's `continue-on-error: true` can't catch it. This blocked the first `v0.1.0` release build.

One-char fix: `@0.28.0` → `@v0.28.0`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>