### PR TITLE
fix(ci): remove advisory Trivy scan blocking the release build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -57,14 +57,6 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
-      - name: Scan image (advisory)
-        continue-on-error: true
-        uses: aquasecurity/trivy-action@v0.28.0
-        with:
-          image-ref: ${{ env.IMAGE }}:${{ steps.ver.outputs.tag }}
-          format: table
-          severity: HIGH,CRITICAL
-
   deploy:
     name: Deploy to Hostinger VPS
     needs: build-and-push


### PR DESCRIPTION
trivy-action@v0.28.0 transitively requires `setup-trivy@v0.2.1`, which no longer exists; resolution fails at job setup (before any step), so `continue-on-error` can't catch it and the whole Build & Push job dies. Removing the advisory, non-gating scan unblocks the v0.1.0 release build. CodeQL + GitGuardian still run. Re-add Trivy later with a verified pin.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>