### PR TITLE
fix(ops): logs dir ACL for mixed-uid containers + dynamic backup volume name

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -22,11 +22,18 @@ docker exec "${MYSQL_HOST:-mysql_db}" \
   | gzip > "${BACKUP_DIR}/db-${STAMP}.sql.gz"
 
 echo "[backup ${STAMP}] archiving chrome-profile volume"
-docker run --rm \
-  -v linkedin_engagement_manager_chrome-profile:/data:ro \
-  -v "${BACKUP_DIR}:/backup" \
-  alpine tar czf "/backup/chrome-profile-${STAMP}.tar.gz" -C /data . 2>/dev/null || \
-  echo "[backup] chrome-profile volume not found (named differently?) — skipping"
+# The volume is Compose-project-prefixed (e.g. lem_chrome-profile), so detect it
+# rather than hardcoding a name — a wrong name makes docker create an empty
+# volume and silently back up nothing.
+CHROME_VOL="$(docker volume ls --format '{{.Name}}' | grep -E '_chrome-profile$' | head -1)"
+if [[ -n "$CHROME_VOL" ]]; then
+  docker run --rm \
+    -v "${CHROME_VOL}:/data:ro" \
+    -v "${BACKUP_DIR}:/backup" \
+    alpine tar czf "/backup/chrome-profile-${STAMP}.tar.gz" -C /data . 2>/dev/null
+else
+  echo "[backup] no *_chrome-profile volume found — skipping"
+fi
 
 echo "[backup ${STAMP}] pruning backups older than ${RETAIN_DAYS} days"
 find "$BACKUP_DIR" -name '*.gz' -mtime "+${RETAIN_DAYS}" -delete

--- a/scripts/vps_bootstrap.sh
+++ b/scripts/vps_bootstrap.sh
@@ -60,7 +60,7 @@ if ! grep -qiE 'ubuntu' /etc/os-release; then warn "Not Ubuntu — apt/docker st
 step "Installing base packages"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y -qq
-apt-get install -y -qq ca-certificates curl git ufw gnupg
+apt-get install -y -qq ca-certificates curl git ufw gnupg acl
 info "ok"
 
 # --- 2. Docker Engine + Compose v2 --------------------------------------------
@@ -134,6 +134,14 @@ else
 fi
 mkdir -p "${APP_DIR}/logs"
 chown -R "$DEPLOY_USER:$DEPLOY_USER" "$APP_DIR"
+# Some containers run as root, others as celeryworker (uid 1000), but they
+# share the bind-mounted logs dir and a single daily logfile. A default ACL
+# lets uid 1000 write even when a root service creates the file first
+# (otherwise the celery workers crash-loop on PermissionError).
+if command -v setfacl >/dev/null 2>&1; then
+  setfacl -R  -m u:1000:rwX "${APP_DIR}/logs" || true
+  setfacl -dR -m u:1000:rwX "${APP_DIR}/logs" || true
+fi
 
 # --- 6. Firewall + SSH hardening ---------------------------------------------
 step "Firewall (SSH-only inbound; Cloudflare Tunnel dials out)"


### PR DESCRIPTION
Two bugs surfaced during the first VPS go-live and were fixed live on the box; committing so re-provisions don't reintroduce them.

**1. Celery workers crash-loop on `PermissionError` writing logs.** `web_app`/`flower`/`beat` run as root and create the shared daily logfile `root:644`; `celery_worker`/`celery_worker_selenium` run as `celeryworker` (uid 1000) and can't write it. Fix: default ACL `u:1000:rwX` on `logs/` in `vps_bootstrap.sh` so uid 1000 can always write, even across the daily rollover.

**2. backup.sh silently backs up an empty chrome-profile.** It hardcoded `linkedin_engagement_manager_chrome-profile`, but Compose names it `<projectdir>_chrome-profile` (`lem_chrome-profile`). The wrong name made Docker create an empty volume and archive nothing. Fix: detect the `*_chrome-profile` volume dynamically.

Follow-up worth considering: make all containers run as a consistent user so the ACL workaround isn't needed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>