### PR TITLE
fix(build): SPA dist missing from image + MySQL loopback for DB GUI

### DIFF
--- a/compose/local/Dockerfile
+++ b/compose/local/Dockerfile
@@ -86,6 +86,13 @@ RUN useradd -m -s /bin/bash celeryworker && \
 COPY --chown=celeryworker:celeryworker --from=builder /app/.venv /app/.venv
 COPY --chown=celeryworker:celeryworker --from=builder /app/src /app/src
 
+# Copy the built SPA straight from the ui-builder stage so it is guaranteed to
+# land in the final image (the builder->final /app/src copy was dropping it,
+# leaving FastAPI to 404 "/"). Assert it is present so this can't silently break.
+COPY --chown=celeryworker:celeryworker --from=ui-builder /ui/dist /app/src/cqc_lem/ui/dist
+RUN test -f /app/src/cqc_lem/ui/dist/index.html \
+    || (echo "FATAL: SPA dist missing from image (ui build did not land)" && exit 1)
+
 # Start scripts live at / so they are not inside the chowned /app tree
 COPY ./compose/local/entrypoint /entrypoint
 COPY ./compose/local/wait-for-it /wait-for-it

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -38,7 +38,9 @@ services:
 
   mysql:
     restart: unless-stopped
-    ports: !reset []
+    # Loopback-only publish so DB GUIs (e.g. Sequel Ace) can reach it via an SSH
+    # tunnel to the VPS; never exposed to the WAN (127.0.0.1 bind + ufw).
+    ports: !override ["127.0.0.1:3306:3306"]
     deploy:
       resources:
         limits:


### PR DESCRIPTION
**SPA fix:** the built `ui/dist` wasn't in the final image, so FastAPI 404'd `/` (`{"detail":"Not Found"}`) — the API/SPA share the URL by design but the static files were absent. Copy `dist` directly from the `ui-builder` stage into the final image + assert `index.html` exists at build time (fails loudly on regression).

**MySQL loopback:** publish `127.0.0.1:3306` (prod overlay) so Sequel Ace can connect via SSH tunnel; not WAN-exposed.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>