### PR TITLE
fix(prod): drop dev src bind-mount that masked the built SPA

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,10 @@ services:
     command: /start-fastapi-cloud
     restart: unless-stopped
     # Ship code in the image — drop the dev source/test bind-mounts.
-    volumes:
+    # !override REPLACES the base volume list (a plain key would MERGE, leaving
+    # the dev ./src:/app/src mount which masks the image's built SPA at
+    # /app/src/cqc_lem/ui/dist and makes FastAPI 404 "/").
+    volumes: !override
       - ./logs:/app/logs
     ports: !reset []
     deploy:


### PR DESCRIPTION
The prod overlay's `web_app.volumes` MERGED with the base list (Compose default), so the dev `./src:/app/src` bind-mount survived into prod and **masked the image's built SPA** (`/app/src/cqc_lem/ui/dist`) → FastAPI 404'd `/`. Use `volumes: !override` to replace the list so prod runs image code. Validated live: `/` now returns 200 and serves the SPA.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>