### PR TITLE
feat(ui+prod): app title + run celery/flower from image

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -52,6 +52,9 @@ services:
   celery_worker:
     image: "${DOCKER_IMAGE_NAME}:${IMAGE_TAG:-latest}"
     restart: unless-stopped
+    volumes: !override
+      - ./logs:/app/logs
+      - ~/.aws:/home/celeryworker/.aws:ro
     deploy:
       resources:
         limits:
@@ -63,6 +66,9 @@ services:
   celery_worker_selenium:
     image: "${DOCKER_IMAGE_NAME}:${IMAGE_TAG:-latest}"
     restart: unless-stopped
+    volumes: !override
+      - ./logs:/app/logs
+      - ~/.aws:/home/celeryworker/.aws:ro
     deploy:
       resources:
         limits:
@@ -74,6 +80,8 @@ services:
   celery_beat:
     image: "${DOCKER_IMAGE_NAME}:${IMAGE_TAG:-latest}"
     restart: unless-stopped
+    volumes: !override
+      - ./logs:/app/logs
     deploy:
       resources:
         limits:
@@ -83,6 +91,9 @@ services:
     image: "${DOCKER_IMAGE_NAME}:${IMAGE_TAG:-latest}"
     restart: unless-stopped
     ports: !reset []
+    volumes: !override
+      - ./logs:/app/logs
+      - flower_db:/data
     environment:
       # Replace the dev unauthenticated mode with basic auth + persistence.
       # Kept behind Cloudflare Access as well (see cloudflared/config.yml).

--- a/src/cqc_lem/ui/index.html
+++ b/src/cqc_lem/ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>ui</title>
+    <title>LEM - LinkedIn Engagement Manager</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
- SPA tab title → **LEM - LinkedIn Engagement Manager**.
- Extend `volumes: !override` to all celery/flower services so prod runs **image code** (drops the dev `./src`/`./tests` bind-mounts), keeping each service's needed mounts (`~/.aws` for workers, `flower_db` for flower). Completes the prod-overlay intent started in the web_app fix.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>