### PR TITLE
feat(config): PUBLIC_BASE_URL takes precedence over ngrok URLs

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -20,6 +20,9 @@ TZ=America/New_York
 API_PORT=8000
 # Multi-worker uvicorn in prod: (2 * CPU_CORES) + 1 is a reasonable ceiling.
 API_WORKERS=3
+# Public base URL the app is served at (scheme+host, no port, no trailing slash).
+# Used to build asset/redirect URLs; takes precedence over any ngrok settings.
+PUBLIC_BASE_URL=https://CHANGE_ME.example.com
 CQC_LEM_CHECK_SCHEDULE_DELTA_MINUTES=5
 CQC_LEM_POST_TIME_DELTA_MINUTES=20
 ADMIN_SECRET=CHANGE_ME_strong_random_secret

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -71,14 +71,27 @@ NGROK_CUSTOM_DOMAIN=get_constant_from_env('NGROK_CUSTOM_DOMAIN')
 NGROK_FREE_DOMAIN=get_constant_from_env('NGROK_FREE_DOMAIN')
 NGROK_API_PREFIX=get_constant_from_env('NGROK_API_PREFIX')
 
-# Dynamic LinkedIn redirect URL: NGROK_CUSTOM_DOMAIN takes precedence over static LI_REDIRECT_URL
-# when running in a dev/ngrok environment (the ngrok domain is registered in the LinkedIn developer app)
-if NGROK_CUSTOM_DOMAIN:
+# Production public base URL — full scheme+host, no port, no trailing slash
+# (e.g. https://lem.example.com). Canonical prod setting; takes precedence over
+# all ngrok-derived URLs (use this when NGROK_PLAN=off).
+PUBLIC_BASE_URL=get_constant_from_env('PUBLIC_BASE_URL')
+if PUBLIC_BASE_URL:
+    PUBLIC_BASE_URL = PUBLIC_BASE_URL.rstrip('/')
+
+# Dynamic LinkedIn redirect URL precedence:
+#   PUBLIC_BASE_URL (prod) > NGROK_CUSTOM_DOMAIN (dev/ngrok) > static LI_REDIRECT_URL env.
+if PUBLIC_BASE_URL:
+    LI_REDIRECT_URL = f"{PUBLIC_BASE_URL}/auth/linkedin/callback"
+elif NGROK_CUSTOM_DOMAIN:
     LI_REDIRECT_URL = f"https://{NGROK_CUSTOM_DOMAIN}/auth/linkedin/callback"
 
-# NGROK_CUSTOM_DOMAIN (full domain) takes precedence; fallback to PREFIX.FREE_DOMAIN form;
-# final fallback to API_BASE_URL env var with port.
-if NGROK_CUSTOM_DOMAIN:
+# API base URL precedence:
+#   PUBLIC_BASE_URL (prod, port-less) > NGROK_CUSTOM_DOMAIN > PREFIX.FREE_DOMAIN
+#   > API_BASE_URL env with :PORT (local dev fallback).
+if PUBLIC_BASE_URL:
+    API_BASE_URL = PUBLIC_BASE_URL
+    API_URL_FINAL = PUBLIC_BASE_URL
+elif NGROK_CUSTOM_DOMAIN:
     API_BASE_URL = f"https://{NGROK_CUSTOM_DOMAIN}"
     API_URL_FINAL = API_BASE_URL
 elif NGROK_FREE_DOMAIN and NGROK_API_PREFIX:


### PR DESCRIPTION
Adds a canonical, prod-appropriate **PUBLIC_BASE_URL** (scheme+host, port-less) used to build asset and LinkedIn-redirect URLs. Takes precedence over `NGROK_CUSTOM_DOMAIN`/`NGROK_FREE_DOMAIN` — the right setting when `NGROK_PLAN=off`. Previously `API_URL_FINAL` fell back to `http://localhost:8000` on prod, so post assets pointed at localhost. Documented in `.env.prod.example`.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>