### PR TITLE
fix(prod): shared persistent volume for generated assets

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -24,6 +24,8 @@ services:
     # /app/src/cqc_lem/ui/dist and makes FastAPI 404 "/").
     volumes: !override
       - ./logs:/app/logs
+      # Shared, persistent generated-media store (served at /api/assets).
+      - assets:/app/src/cqc_lem/assets
     ports: !reset []
     deploy:
       resources:
@@ -55,6 +57,8 @@ services:
     volumes: !override
       - ./logs:/app/logs
       - ~/.aws:/home/celeryworker/.aws:ro
+      # Shared, persistent store so generated assets are visible to web_app.
+      - assets:/app/src/cqc_lem/assets
     deploy:
       resources:
         limits:
@@ -69,6 +73,8 @@ services:
     volumes: !override
       - ./logs:/app/logs
       - ~/.aws:/home/celeryworker/.aws:ro
+      # Shared, persistent store so generated assets are visible to web_app.
+      - assets:/app/src/cqc_lem/assets
     deploy:
       resources:
         limits:
@@ -82,6 +88,8 @@ services:
     restart: unless-stopped
     volumes: !override
       - ./logs:/app/logs
+      # Shared, persistent store so generated assets are visible to web_app.
+      - assets:/app/src/cqc_lem/assets
     deploy:
       resources:
         limits:
@@ -130,3 +138,9 @@ services:
       resources:
         limits:
           memory: 256m
+
+# Persistent, shared store for generated post media (videos/images) served at
+# /api/assets. Mounted on web_app + celery workers so the generator and the
+# server share one location that survives container recreates.
+volumes:
+  assets:


### PR DESCRIPTION
Generated post media is written to `/app/src/cqc_lem/assets` by celery workers and served by web_app at `/api/assets`, but nothing mounted that dir → assets were **ephemeral** (lost on recreate) and **not shared** between the generating worker and web_app (so they 404'd in prod; dev only worked via the `./src` bind-mount). Add a named `assets` volume mounted on web_app + all celery workers. Assets generated before this need regeneration.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>