### PR TITLE
test(perf): mock time.sleep in login unit tests (37.7s -> 2.1s)

### DIFF
--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -8,6 +8,14 @@ pytestmark = pytest.mark.unit
 _MODULE = "cqc_lem.utilities.linkedin.helper"
 
 
+@pytest.fixture(autouse=True)
+def _no_real_sleep():
+    """Login flow uses real time.sleep() between mocked Selenium steps — those
+    seconds are dead wait in unit tests (drivers are mocked, not timing-dependent)."""
+    with patch(f"{_MODULE}.time.sleep"):
+        yield
+
+
 def _make_driver(url: str) -> MagicMock:
     driver = MagicMock()
     driver.current_url = url


### PR DESCRIPTION
## Why
The `login_to_linkedin` unit tests in `test_helper.py` ran the **real `time.sleep()`** calls in the login flow (7 of them, 2–6s each) even though the Selenium driver is fully mocked — pure dead wait, not timing-dependent.

## What
An autouse fixture mocks `cqc_lem.utilities.linkedin.helper.time.sleep` for that module's tests.

| | Before | After |
|---|---|---|
| `test_helper.py` | 37.7s | **2.1s** |
| Full unit suite | ~42s | **~5.4s** |
| CI "Unit Tests" gate (incl. install) | ~93s | **~40s** |

All 824 unit tests still pass. No production code changed — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)