### PR TITLE
feat(video): premium video tiers with a credit system

### DIFF
--- a/compose/local/database/migrations/V30__add_video_credit_ledger_and_post_quality.sql
+++ b/compose/local/database/migrations/V30__add_video_credit_ledger_and_post_quality.sql
@@ -1,0 +1,16 @@
+-- Premium video credits: a ledger (balance = SUM(delta)) mirroring avatar_credit_ledger,
+-- plus a per-post chosen video quality tier.
+CREATE TABLE IF NOT EXISTS video_credit_ledger (
+    id                INT AUTO_INCREMENT PRIMARY KEY,
+    user_id           INT          NOT NULL,
+    delta             INT          NOT NULL,  -- positive for purchases/refunds, negative for premium renders
+    reason            VARCHAR(128) NOT NULL,  -- e.g. "purchase_pack_15", "premium_video", "premium_video_refund"
+    stripe_session_id VARCHAR(255) NULL,      -- for idempotent webhook processing
+    post_id           INT          NULL,      -- links a debit/refund to the post it rendered
+    created_at        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Desired video quality tier for a post: 'standard' (free), 'premium' (veo3.1_fast, 1 credit),
+-- or 'premium_top' (veo3.1, 3 credits).
+ALTER TABLE posts ADD COLUMN video_quality VARCHAR(32) NOT NULL DEFAULT 'standard';

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -26,6 +26,8 @@ from cqc_lem.utilities.db import (
     get_user_blog_url, get_user_sitemap_url,
     get_user_by_stripe_customer_id, get_avatar_credit_ledger_entry_by_session,
     get_avatar_credit_balance, add_avatar_credits,
+    get_video_credit_balance, add_video_credits,
+    get_video_credit_ledger_entry_by_session, update_post_video_quality,
     deduct_avatar_credit, insert_avatar_training,
     update_avatar_training_status, set_active_avatar,
     get_avatar_trainings, get_active_avatar,
@@ -154,6 +156,7 @@ class PostRequest(BaseModel):
     status: Optional[PostStatus] = PostStatus.PENDING
     carousel_slides: Optional[List[str]] = None
     use_avatar: Optional[bool] = False
+    video_quality: Optional[str] = "standard"  # standard | premium | premium_top
 
 
 class AvatarCreditCheckoutRequest(BaseModel):
@@ -161,6 +164,19 @@ class AvatarCreditCheckoutRequest(BaseModel):
     package: str
     success_url: str
     cancel_url: str
+
+
+class VideoCreditCheckoutRequest(BaseModel):
+    session_token: str
+    package: str        # "small" | "medium" | "large" | "max"
+    success_url: str
+    cancel_url: str
+
+
+class UpgradeVideoRequest(BaseModel):
+    session_token: str
+    post_id: int
+    tier: str = "premium"  # "premium" (1 credit) or "premium_top" (3 credits)
 
 
 class AvatarActivateRequest(BaseModel):
@@ -415,7 +431,8 @@ def schedule_post(post: PostRequest) -> ResponseModel:
         raise HTTPException(status_code=403, detail="User not found")
 
     if insert_post(post.email, post.content, post.scheduled_datetime, post.post_type,
-                   video_url=post.video_url, carousel_slides=post.carousel_slides):
+                   video_url=post.video_url, carousel_slides=post.carousel_slides,
+                   video_quality=post.video_quality or "standard"):
         return ResponseModel(status_code=200, detail="Post scheduled successfully")
     else:
         raise HTTPException(status_code=404, detail="Could not schedule post")
@@ -1147,6 +1164,27 @@ async def billing_webhook(request: Request) -> dict:
             else:
                 myprint(f"Avatar credits webhook: no user found for customer={stripe_customer_id}")
 
+        elif meta.get("type") == "video_credits":
+            if data.get("payment_status") != "paid":
+                myprint(f"video_credits checkout: payment_status={data.get('payment_status')} — skipping")
+                return {"received": True}
+            stripe_customer_id = data.get("customer")
+            stripe_session_id = data.get("id")
+            credits = int(meta.get("credits", 0))
+            package = meta.get("package", "unknown")
+            if not stripe_customer_id or credits <= 0:
+                myprint("Video credits webhook: missing customer or zero credits — skipping")
+                return {"received": True}
+            if get_video_credit_ledger_entry_by_session(stripe_session_id):
+                myprint(f"Video credits already granted for session={stripe_session_id} — skipping duplicate")
+                return {"received": True}
+            user_row = get_user_by_stripe_customer_id(stripe_customer_id)
+            if user_row:
+                add_video_credits(user_row["id"], credits, f"purchase_{package}", stripe_session_id)
+                myprint(f"Added {credits} video credit(s) for user_id={user_row['id']} via session={stripe_session_id}")
+            else:
+                myprint(f"Video credits webhook: no user found for customer={stripe_customer_id}")
+
     elif event_type == "charge.refunded":
         payment_intent_id = data.get("payment_intent")
         stripe_customer_id = data.get("customer")
@@ -1173,31 +1211,32 @@ async def billing_webhook(request: Request) -> dict:
             return {"received": True}
 
         session_meta = session.get("metadata", {})
-        if session_meta.get("type") != "avatar_credits":
-            myprint(f"charge.refunded: not an avatar credits charge — ignoring")
+        credit_type = session_meta.get("type")
+        if credit_type not in ("avatar_credits", "video_credits"):
+            myprint(f"charge.refunded: not a credits charge — ignoring")
             return {"received": True}
+
+        # Route to the right ledger based on what was purchased.
+        if credit_type == "avatar_credits":
+            entry_fn, add_fn, label = get_avatar_credit_ledger_entry_by_session, add_avatar_credits, "avatar"
+        else:
+            entry_fn, add_fn, label = get_video_credit_ledger_entry_by_session, add_video_credits, "video"
 
         stripe_session_id = session.get("id")
-        original_entry = get_avatar_credit_ledger_entry_by_session(stripe_session_id)
+        original_entry = entry_fn(stripe_session_id)
         if not original_entry:
-            myprint(f"charge.refunded: no credit ledger entry found for session={stripe_session_id} — nothing to deduct")
+            myprint(f"charge.refunded: no {label} credit ledger entry for session={stripe_session_id} — nothing to deduct")
             return {"received": True}
 
-        # Guard against double-refund: check if a refund entry already exists for this session.
         user_row = get_user_by_stripe_customer_id(stripe_customer_id)
         if not user_row:
             myprint(f"charge.refunded: no user found for customer={stripe_customer_id}")
             return {"received": True}
 
         credits_to_deduct = original_entry["delta"]
-        add_avatar_credits(
-            user_row["id"],
-            -credits_to_deduct,
-            f"refund_{stripe_session_id}",
-            stripe_session_id=None,
-        )
+        add_fn(user_row["id"], -credits_to_deduct, f"refund_{stripe_session_id}", stripe_session_id=None)
         myprint(
-            f"Deducted {credits_to_deduct} avatar credit(s) for user_id={user_row['id']} "
+            f"Deducted {credits_to_deduct} {label} credit(s) for user_id={user_row['id']} "
             f"due to full refund of session={stripe_session_id}"
         )
 
@@ -1248,6 +1287,74 @@ def avatar_credits_checkout(request: AvatarCreditCheckoutRequest) -> ResponseMod
     if not url:
         raise HTTPException(status_code=500, detail="Could not create Stripe checkout session")
     return ResponseModel(status_code=200, detail={"checkout_url": url})
+
+
+@router.get("/video/credits", responses={
+    200: {"description": "Video credit balance returned"},
+    **{k: v for k, v in error_responses.items() if k in [401]}
+})
+def get_video_credits_endpoint(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail={"balance": get_video_credit_balance(user_id)})
+
+
+@router.post("/video/credits/checkout", responses={
+    200: {"description": "Stripe checkout URL returned"},
+    **{k: v for k, v in error_responses.items() if k in [400, 401]}
+})
+def video_credits_checkout(request: VideoCreditCheckoutRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    subscription = get_user_subscription_info(user_id)
+    stripe_customer_id = subscription.get("stripe_customer_id") if subscription else None
+    if not stripe_customer_id:
+        raise HTTPException(status_code=400, detail="No Stripe customer record — contact support")
+    from cqc_lem.utilities.stripe_util import create_video_credits_checkout, VIDEO_CREDIT_PACKAGES
+    if request.package not in VIDEO_CREDIT_PACKAGES:
+        raise HTTPException(status_code=400, detail=f"Unknown package '{request.package}'")
+    url = create_video_credits_checkout(
+        stripe_customer_id, request.package, request.success_url, request.cancel_url)
+    if not url:
+        raise HTTPException(status_code=500, detail="Could not create Stripe checkout session")
+    return ResponseModel(status_code=200, detail={"checkout_url": url})
+
+
+@router.post("/video/upgrade", responses={
+    200: {"description": "Premium video regeneration queued"},
+    **{k: v for k, v in error_responses.items() if k in [400, 401, 403, 404]},
+    402: {"description": "Insufficient video credits"},
+})
+def upgrade_video(request: UpgradeVideoRequest) -> ResponseModel:
+    """Upgrade a video post to a premium tier — regenerates the video at premium
+    quality (Veo + audio), charging credits at render time (refunded on failure)."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if get_post_user_id(request.post_id) != user_id:
+        raise HTTPException(status_code=403, detail="Not your post")
+    if get_post_type(request.post_id) != PostType.VIDEO:
+        raise HTTPException(status_code=404, detail="Post not found or not a video post")
+
+    from cqc_lem.utilities.env_constants import PREMIUM_VIDEO_CREDITS, PREMIUM_TOP_VIDEO_CREDITS
+    tier_credits = {"premium": PREMIUM_VIDEO_CREDITS, "premium_top": PREMIUM_TOP_VIDEO_CREDITS}
+    if request.tier not in tier_credits:
+        raise HTTPException(status_code=400, detail=f"Unknown tier '{request.tier}'")
+    needed = tier_credits[request.tier]
+    if get_video_credit_balance(user_id) < needed:
+        raise HTTPException(status_code=402,
+                            detail=f"Insufficient video credits (need {needed}). Buy credits to use premium video.")
+
+    update_post_video_quality(request.post_id, request.tier)
+    from cqc_lem.app.run_content_plan import regenerate_post_video_task
+    regenerate_post_video_task.apply_async(kwargs={"post_id": request.post_id})
+    myprint(f"video/upgrade: queued post_id={request.post_id} tier={request.tier} for user_id={user_id}")
+    return ResponseModel(status_code=200, detail={
+        "post_id": request.post_id, "tier": request.tier,
+        "credits_required": needed, "status": "queued",
+    })
 
 
 @router.post("/avatar/training", responses={

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -22,7 +22,9 @@ from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, upda
     update_db_post_video_url, update_db_post_status, PostType, get_user_preferences, \
     update_db_post_carousel_slides, get_post_content
 from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_MODEL, DEFAULT_VIDEO_RATIO, \
-    DEFAULT_IMAGE_RATIO, AI_DISCLOSURE_ENABLED, AI_DISCLOSURE_TEXT
+    DEFAULT_IMAGE_RATIO, AI_DISCLOSURE_ENABLED, AI_DISCLOSURE_TEXT, \
+    STANDARD_VIDEO_MODEL, PREMIUM_VIDEO_MODEL, PREMIUM_TOP_VIDEO_MODEL, \
+    PREMIUM_VIDEO_CREDITS, PREMIUM_TOP_VIDEO_CREDITS
 from cqc_lem.utilities.linkedin.helper import get_my_profile, load_profile_for_user
 from cqc_lem.utilities.linkedin_formatter import sanitize_for_linkedin
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
@@ -203,7 +205,7 @@ def create_content(user_id: int, post_type: str, stage: str, post_id: int = None
     content = None
 
     if post_type == "video":
-        content, video_url = create_video_content(user_id, stage)
+        content, video_url = create_video_content(user_id, stage, post_id=post_id)
     elif post_type == "carousel":
         content = create_carousel_content(user_id, stage, post_id)
     else:
@@ -320,47 +322,79 @@ def _apply_ai_disclosure(content: str) -> str:
     return content + AI_DISCLOSURE_TEXT
 
 
-def create_video_content(user_id: int, stage: str) -> tuple[str, str | None]:
-    # Get Text Content
-    text_content = create_text_post(user_id, stage)
+def _premium_tier_for_quality(quality: str):
+    """Map a post's video_quality to (model, credits, audio); None for standard/free."""
+    if quality == "premium":
+        return (PREMIUM_VIDEO_MODEL, PREMIUM_VIDEO_CREDITS, True)
+    if quality == "premium_top":
+        return (PREMIUM_TOP_VIDEO_MODEL, PREMIUM_TOP_VIDEO_CREDITS, True)
+    return None
 
-    # Load profile once so the image prompt is brand/role-aligned
-    user_profile = load_profile_for_user(user_id)
+
+def _generate_video_src(user_id: int, text_content: str, profile, post_id: int = None):
+    """Generate a video source URL honoring the post's quality tier + video credits.
+
+    Standard (free) = gen4_turbo image->video. Premium = Veo (+audio): with an active
+    avatar it runs Veo image->video on the avatar image to preserve the likeness, else
+    Veo text->video. Premium credits are reserved up-front and refunded on failure;
+    falls back to standard when the user has no credits, and to Pexels stock on error.
+    Returns the remote Runway URL (http) or a local Pexels path, or None.
+    """
+    from cqc_lem.utilities.ai.video_models import is_premium
+    from cqc_lem.utilities.db import (get_post_video_quality, get_video_credit_balance,
+                                      deduct_video_credits, refund_video_credits, get_active_avatar)
+
+    quality = get_post_video_quality(post_id) if post_id else "standard"
+    tier = _premium_tier_for_quality(quality)
+
+    model, audio, deducted = STANDARD_VIDEO_MODEL, False, 0
+    if tier and user_id:
+        pmodel, pcredits, paudio = tier
+        if get_video_credit_balance(user_id) >= pcredits and \
+                deduct_video_credits(user_id, pcredits, post_id, reason=f"premium_video_{pmodel}"):
+            model, audio, deducted = pmodel, paudio, pcredits
+        else:
+            myprint(f"Premium video requested but no credits for user {user_id} — using standard")
 
     try:
-        # Create an image prompt from the text content (profile-aligned, square)
-        image_prompt = get_flux_image_prompt_from_ai(
-            text_content, profile=user_profile, ratio=DEFAULT_IMAGE_RATIO)
-        myprint(f"Generated AI Image Prompt: {image_prompt[:100]}...")
-
-        # Create the image from the image prompt using flux1 (matches video ratio)
-        image_path = generate_flux1_image_from_prompt(image_prompt, ratio=DEFAULT_IMAGE_RATIO)
-        myprint(f"Generated Image From Prompt | Path: {image_path}")
-
-        # Create a motion-first video prompt for the configured Gen-4 model
-        video_prompt = get_runway_ml_video_prompt_from_ai(
-            text_content, image_prompt, model=DEFAULT_VIDEO_MODEL)
-        video_prompt = video_prompt[:512]
-
-        # Create a video from the image and video prompt using Runway ML
-        video_url = create_runway_video(
-            image_path, video_prompt, model=DEFAULT_VIDEO_MODEL, ratio=DEFAULT_VIDEO_RATIO)
-        myprint(f"Generated Video URL: {video_url}")
+        image_prompt = get_flux_image_prompt_from_ai(text_content, profile=profile, ratio=DEFAULT_IMAGE_RATIO)
+        motion = get_runway_ml_video_prompt_from_ai(text_content, image_prompt, model=model)[:512]
+        if is_premium(model):
+            avatar = get_active_avatar(user_id) if user_id else None
+            if avatar and avatar.get("status") == "succeeded" and avatar.get("model_ref"):
+                from cqc_lem.utilities.ai.ai_helper import generate_post_image
+                image_path = generate_post_image(image_prompt, user_id, ratio="9:16")
+                src = create_runway_video(image_path, motion, model=model, ratio="9:16", audio=audio)
+            else:
+                combined = (image_prompt[:700] + " Motion: " + motion)[:980]
+                src = create_runway_video(None, combined, model=model, ratio="9:16", audio=audio)
+        else:
+            image_path = generate_flux1_image_from_prompt(image_prompt, ratio=DEFAULT_IMAGE_RATIO)
+            src = create_runway_video(image_path, motion, model=model, ratio=DEFAULT_VIDEO_RATIO)
+        if not src:
+            raise RuntimeError("no video output")
+        myprint(f"_generate_video_src: model={model} audio={audio} -> {str(src)[:60]}")
+        return src
     except Exception as e:
-        myprint(f"Video generation failed ({type(e).__name__}: {e}) — trying Pexels stock video")
+        myprint(f"_generate_video_src failed ({type(e).__name__}: {e}) — refunding any credits, trying Pexels")
+        if deducted and user_id:
+            refund_video_credits(user_id, deducted, post_id)
         try:
             from cqc_lem.utilities.pexels_helper import download_pexels_video
             videos_dir = os.path.join(assets_dir, 'videos', 'pexels')
             create_folder_if_not_exists(videos_dir)
-            video_url = download_pexels_video(text_content[:50], videos_dir)
-            if video_url:
-                myprint(f"Pexels fallback video saved: {video_url}")
-            else:
-                myprint("Pexels returned no results — publishing text content without video")
+            return download_pexels_video(text_content[:50], videos_dir)
         except Exception as pe:
-            myprint(f"Pexels fallback also failed ({type(pe).__name__}: {pe}) — publishing text content without video")
-            video_url = None
+            myprint(f"_generate_video_src: Pexels fallback failed ({type(pe).__name__}: {pe})")
+            return None
 
+
+def create_video_content(user_id: int, stage: str, post_id: int = None) -> tuple[str, str | None]:
+    # Get Text Content
+    text_content = create_text_post(user_id, stage)
+    # Load profile once so the image prompt is brand/role-aligned
+    user_profile = load_profile_for_user(user_id)
+    video_url = _generate_video_src(user_id, text_content, user_profile, post_id)
     return text_content, video_url
 
 
@@ -377,33 +411,17 @@ def regenerate_video_for_post(post_id: int) -> Optional[str]:
         myprint(f"regenerate_video_for_post: no content for post_id={post_id}")
         return None
 
+    user_id = None
     user_profile = None
     try:
         from cqc_lem.utilities.db import get_post_user_id
-        user_profile = load_profile_for_user(get_post_user_id(post_id))
+        user_id = get_post_user_id(post_id)
+        user_profile = load_profile_for_user(user_id)
     except Exception as e:
         myprint(f"regenerate_video_for_post: profile load skipped: {e}")
 
-    video_src_url = None
-    try:
-        image_prompt = get_flux_image_prompt_from_ai(
-            text_content, profile=user_profile, ratio=DEFAULT_IMAGE_RATIO)
-        image_path = generate_flux1_image_from_prompt(image_prompt, ratio=DEFAULT_IMAGE_RATIO)
-        video_prompt = get_runway_ml_video_prompt_from_ai(
-            text_content, image_prompt, model=DEFAULT_VIDEO_MODEL)[:512]
-        video_src_url = create_runway_video(
-            image_path, video_prompt, model=DEFAULT_VIDEO_MODEL, ratio=DEFAULT_VIDEO_RATIO)
-    except Exception as e:
-        myprint(f"regenerate_video_for_post: RunwayML failed ({type(e).__name__}: {e}) — trying Pexels")
-        try:
-            from cqc_lem.utilities.pexels_helper import download_pexels_video
-            pexels_dir = os.path.join(assets_dir, 'videos', 'pexels')
-            create_folder_if_not_exists(pexels_dir)
-            video_src_url = download_pexels_video(text_content[:50], pexels_dir)
-        except Exception as pe:
-            myprint(f"regenerate_video_for_post: Pexels fallback failed ({type(pe).__name__}: {pe})")
-            video_src_url = None
-
+    # Honors the post's video_quality tier + premium video credits (deduct/refund).
+    video_src_url = _generate_video_src(user_id, text_content, user_profile, post_id)
     if not video_src_url:
         return None
 
@@ -422,6 +440,12 @@ def regenerate_video_for_post(post_id: int) -> Optional[str]:
     update_db_post_video_url(post_id, api_video_url)
     myprint(f"regenerate_video_for_post: post_id={post_id} -> {api_video_url}")
     return api_video_url
+
+
+@shared_task.task
+def regenerate_post_video_task(post_id: int):
+    """Celery wrapper so premium-video upgrades run async (Veo can take minutes)."""
+    return regenerate_video_for_post(post_id)
 
 
 def create_text_post(user_id: int, stage: str, post_type: str = None, user_profile: LinkedInProfile=None,

--- a/src/cqc_lem/ui/src/pages/Account.tsx
+++ b/src/cqc_lem/ui/src/pages/Account.tsx
@@ -20,6 +20,13 @@ const TIER_COLORS: Record<string, string> = {
   enterprise: 'bg-yellow-100 text-yellow-800',
 }
 
+const VIDEO_PACKAGES = [
+  { key: 'small', price: '$12', label: '5 credits' },
+  { key: 'medium', price: '$30', label: '15 credits' },
+  { key: 'large', price: '$70', label: '40 credits' },
+  { key: 'max', price: '$150', label: '100 credits' },
+]
+
 const COMMON_TIMEZONES = [
   'America/New_York',
   'America/Chicago',
@@ -189,6 +196,29 @@ export default function Account() {
         .then((r) => r.data.detail as { timezone: string }),
     enabled: !!sessionToken,
     staleTime: 5 * 60 * 1000,
+  })
+
+  const { data: videoCreditData } = useQuery({
+    queryKey: ['video-credits', sessionToken],
+    queryFn: () =>
+      api
+        .get('/video/credits', { params: { session_token: sessionToken } })
+        .then((r) => r.data.detail as { balance: number }),
+    enabled: !!sessionToken,
+  })
+  const videoCredits = videoCreditData?.balance ?? 0
+
+  const buyVideoCreditsMutation = useMutation({
+    mutationFn: async (pkg: string) => {
+      const r = await api.post('/video/credits/checkout', {
+        session_token: sessionToken,
+        package: pkg,
+        success_url: `${window.location.origin}/account?video_credits=purchased`,
+        cancel_url: `${window.location.origin}/account`,
+      })
+      return r.data.detail.checkout_url as string
+    },
+    onSuccess: (url) => { window.location.href = url },
   })
 
   useEffect(() => {
@@ -448,6 +478,38 @@ export default function Account() {
             Billing not yet configured for your account. Contact support if you need help.
           </p>
         )}
+      </div>
+
+      {/* Premium video credits */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-base font-semibold text-gray-700">Premium Video Credits</h2>
+          <span className="text-2xl font-bold text-blue-900" data-testid="video-credit-balance">{videoCredits}</span>
+        </div>
+        <p className="text-sm text-gray-500">
+          Premium videos use Google Veo (realistic motion + native audio): 1 credit per premium video,
+          3 for top realism. Standard videos are always free with your plan.
+        </p>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          {VIDEO_PACKAGES.map((pkg) => (
+            <div
+              key={pkg.key}
+              className={`relative border rounded-xl p-4 flex flex-col items-center gap-1 ${
+                pkg.key === 'medium' ? 'border-blue-400 bg-blue-50' : 'border-gray-200 bg-white'
+              }`}
+            >
+              <span className="text-xl font-bold text-gray-900">{pkg.price}</span>
+              <span className="text-xs font-medium text-gray-600 text-center">{pkg.label}</span>
+              <button
+                onClick={() => buyVideoCreditsMutation.mutate(pkg.key)}
+                disabled={buyVideoCreditsMutation.isPending}
+                className="mt-2 w-full py-1.5 rounded-lg bg-blue-600 hover:bg-blue-700 text-white text-sm font-medium disabled:opacity-50 transition-colors"
+              >
+                {buyVideoCreditsMutation.isPending ? '…' : 'Buy'}
+              </button>
+            </div>
+          ))}
+        </div>
       </div>
 
       {/* LinkedIn connection — hidden when connected and token healthy */}

--- a/src/cqc_lem/ui/src/pages/ScheduleContent.tsx
+++ b/src/cqc_lem/ui/src/pages/ScheduleContent.tsx
@@ -52,6 +52,7 @@ export default function ScheduleContent() {
   const [submitting, setSubmitting] = useState(false)
   const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null)
   const [useAvatar, setUseAvatar] = useState(false)
+  const [videoQuality, setVideoQuality] = useState<'standard' | 'premium' | 'premium_top'>('standard')
 
   // Carousel AI generation state
   const [carouselMode, setCarouselMode] = useState<'manual' | 'ai'>('ai')
@@ -71,6 +72,16 @@ export default function ScheduleContent() {
     },
     enabled: !!sessionToken,
   })
+
+  const { data: videoCreditData } = useQuery({
+    queryKey: ['video-credits', sessionToken],
+    queryFn: async () => {
+      const r = await api.get('/video/credits', { params: { session_token: sessionToken } })
+      return r.data.detail as { balance: number }
+    },
+    enabled: !!sessionToken,
+  })
+  const videoCredits = videoCreditData?.balance ?? 0
 
   const { data: templatesData } = useQuery({
     queryKey: ['carousel-templates'],
@@ -156,6 +167,7 @@ export default function ScheduleContent() {
       }
       if (postType === 'VIDEO') {
         payload.video_url = videoUrl || null
+        payload.video_quality = videoQuality
       }
       if (postType === 'CAROUSEL') {
         payload.carousel_slides = carouselMode === 'ai'
@@ -254,6 +266,55 @@ export default function ScheduleContent() {
                 placeholder="https://example.com/video.mp4"
               />
               <p className="mt-1 text-xs text-gray-400">Direct URL to the video file that will be uploaded to LinkedIn.</p>
+            </div>
+          )}
+
+          {/* VIDEO: quality tier (premium tiers spend video credits when LEM generates the video) */}
+          {postType === 'VIDEO' && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Video Quality</label>
+              <div className="space-y-2">
+                {[
+                  { key: 'standard' as const, label: 'Standard', desc: 'Included free with your plan', cost: 0 },
+                  { key: 'premium' as const, label: 'Premium — Veo + audio', desc: 'Realistic video with native sound', cost: 1 },
+                  { key: 'premium_top' as const, label: 'Premium Max — top realism', desc: 'Highest-realism Veo + audio', cost: 3 },
+                ].map((opt) => {
+                  const affordable = opt.cost === 0 || videoCredits >= opt.cost
+                  return (
+                    <label
+                      key={opt.key}
+                      className={`flex items-center gap-3 border rounded-lg px-3 py-2 cursor-pointer transition-colors ${
+                        videoQuality === opt.key ? 'border-blue-500 bg-blue-50' : 'border-gray-200'
+                      } ${!affordable ? 'opacity-50' : ''}`}
+                    >
+                      <input
+                        type="radio"
+                        name="videoQuality"
+                        value={opt.key}
+                        checked={videoQuality === opt.key}
+                        disabled={!affordable}
+                        onChange={() => setVideoQuality(opt.key)}
+                      />
+                      <div className="flex-1">
+                        <p className="text-sm font-medium text-gray-800">
+                          {opt.label}
+                          {opt.cost > 0 && (
+                            <span className="ml-2 text-xs text-blue-700">
+                              {opt.cost} credit{opt.cost > 1 ? 's' : ''}
+                            </span>
+                          )}
+                        </p>
+                        <p className="text-xs text-gray-500">{opt.desc}</p>
+                      </div>
+                    </label>
+                  )
+                })}
+              </div>
+              <p className="mt-1 text-xs text-gray-400">
+                You have <span className="font-semibold">{videoCredits}</span> premium video credit
+                {videoCredits === 1 ? '' : 's'}.{' '}
+                <a href="/account" className="text-blue-600 hover:underline">Buy more</a>
+              </p>
             </div>
           )}
 

--- a/src/cqc_lem/utilities/ai/video_models.py
+++ b/src/cqc_lem/utilities/ai/video_models.py
@@ -1,9 +1,13 @@
 """RunwayML video-model abstraction.
 
-Isolates the RunwayML SDK shape so model migration lives in one place. gen3a_turbo
-(the previous default) is deliberately absent — Runway sunsets it on 2026-07-30.
-gen4_turbo is the drop-in successor; gen4.5 and veo3.1 are opt-in higher tiers
-reachable through the same SDK client.
+Isolates the RunwayML SDK shape so model selection lives in one place. gen3a_turbo
+(the previous default) is deliberately absent — Runway sunset it on 2026-07-30.
+
+Two quality tiers:
+- STANDARD (credits=0, free): gen4_turbo / gen4.5 image->video, no audio.
+- PREMIUM (credits>0): Veo (veo3.1_fast=1 credit, veo3.1=3 credits) with native
+  audio. Veo supports BOTH image->video (used to preserve an avatar's likeness)
+  and text->video (when there's no base image / an abstract concept fits better).
 """
 import base64
 import time
@@ -18,18 +22,22 @@ from cqc_lem.utilities.logger import log_debug, log_warning
 
 @dataclass(frozen=True)
 class VideoModelSpec:
-    sdk_model: str           # value passed to the SDK 'model' kwarg
-    endpoint: str            # RunwayML client attribute, e.g. 'image_to_video'
-    cost_per_second: float   # USD, for cost estimates
-    supports_prompt_image: bool
-    default_ratio: str
+    sdk_model: str               # value passed to the SDK 'model' kwarg
+    cost_per_second: float       # USD (premium values assume audio on)
+    credits: int                 # video credits charged (0 = free/standard tier)
+    supports_audio: bool
+    valid_durations: tuple       # durations the API accepts for this model
+    default_duration: int
 
 
-# Runway API models reachable through the same RunwayML() client.
+# Runway API models reachable through the same RunwayML() client. Veo only accepts
+# 4/6/8s durations; gen4/seedance accept 5/10.
 VIDEO_MODELS: dict[str, VideoModelSpec] = {
-    "gen4_turbo": VideoModelSpec("gen4_turbo", "image_to_video", 0.05, True, "960:960"),
-    "gen4.5":     VideoModelSpec("gen4.5",     "image_to_video", 0.12, True, "960:960"),
-    "veo3.1":     VideoModelSpec("veo3.1",     "image_to_video", 0.30, True, "1280:720"),
+    "gen4_turbo":     VideoModelSpec("gen4_turbo",     0.05, 0, False, (5, 10), 5),
+    "gen4.5":         VideoModelSpec("gen4.5",         0.12, 0, False, (5, 10), 5),
+    "veo3.1_fast":    VideoModelSpec("veo3.1_fast",    0.15, 1, True,  (4, 6, 8), 6),
+    "veo3.1":         VideoModelSpec("veo3.1",         0.40, 3, True,  (4, 6, 8), 6),
+    "seedance2_fast": VideoModelSpec("seedance2_fast", 0.29, 1, False, (5, 10), 5),
 }
 
 DEFAULT_VIDEO_DURATION = 5
@@ -52,6 +60,24 @@ def resolve_ratio(ratio: str) -> str:
     return RATIO_ALIASES.get(ratio, ratio)
 
 
+def model_credits(model: str) -> int:
+    spec = VIDEO_MODELS.get(model)
+    return spec.credits if spec else 0
+
+
+def is_premium(model: str) -> bool:
+    return model_credits(model) > 0
+
+
+def resolve_duration(model: str, duration: Optional[int]) -> int:
+    spec = VIDEO_MODELS.get(model)
+    if not spec:
+        return duration or DEFAULT_VIDEO_DURATION
+    if duration in spec.valid_durations:
+        return duration
+    return spec.default_duration
+
+
 def estimate_video_cost(model: str, duration: int = DEFAULT_VIDEO_DURATION) -> float:
     spec = VIDEO_MODELS.get(model)
     return round(spec.cost_per_second * duration, 3) if spec else 0.0
@@ -68,7 +94,7 @@ def _to_prompt_image(image_path_or_url: str) -> str:
 
 def _create_task(endpoint, create_kwargs: dict):
     """Call endpoint.create, retrying without optional kwargs if the pinned SDK
-    version rejects them (resilience across runwayml >=2.1,<5.0)."""
+    version rejects them (resilience across runwayml versions)."""
     try:
         return endpoint.create(**create_kwargs)
     except TypeError:
@@ -77,39 +103,50 @@ def _create_task(endpoint, create_kwargs: dict):
 
 
 def create_runway_video(
-    image_path_or_url: str,
-    prompt: str,
+    image_path_or_url: Optional[str] = None,
+    prompt: str = "",
     *,
     model: str = DEFAULT_VIDEO_MODEL,
     ratio: str = DEFAULT_VIDEO_RATIO,
-    duration: int = DEFAULT_VIDEO_DURATION,
+    duration: Optional[int] = None,
     seed: Optional[int] = None,
+    audio: bool = False,
 ) -> Optional[str]:
-    """Create a video from an image via the RunwayML API and return its URL.
+    """Create a video via the RunwayML API and return its URL.
 
+    If ``image_path_or_url`` is provided -> image->video; if it's None -> text->video
+    (the model must support it). ``audio`` is honored only for audio-capable models.
     Backwards compatible with the old positional ``(image_path, prompt)`` call.
-    Raises on creation failure so callers' Pexels fallback can trigger; returns
-    None only when the task itself reports FAILED / produces no output.
+    Raises on creation failure (so callers' fallback can trigger); returns None only
+    when the task itself reports FAILED / produces no output.
     """
     spec = VIDEO_MODELS.get(model)
     if spec is None:
         raise ValueError(f"Unknown video model {model!r}. Known: {sorted(VIDEO_MODELS)}")
 
     runway_client = RunwayML()
+    use_text = not image_path_or_url
+    endpoint_name = "text_to_video" if use_text else "image_to_video"
     resolved_ratio = resolve_ratio(ratio)
+    dur = resolve_duration(model, duration)
+
     create_kwargs = {
         "model": spec.sdk_model,
-        "prompt_image": _to_prompt_image(image_path_or_url),
         "prompt_text": prompt,
         "ratio": resolved_ratio,
-        "duration": duration,
+        "duration": dur,
     }
+    if not use_text:
+        create_kwargs["prompt_image"] = _to_prompt_image(image_path_or_url)
+    if audio and spec.supports_audio:
+        create_kwargs["audio"] = True
     if seed is not None:
         create_kwargs["seed"] = seed
 
-    endpoint = getattr(runway_client, spec.endpoint)
+    endpoint = getattr(runway_client, endpoint_name)
     log_debug(
-        f"Runway create model={spec.sdk_model} ratio={resolved_ratio} duration={duration}s",
+        f"Runway {endpoint_name} model={spec.sdk_model} ratio={resolved_ratio} "
+        f"duration={dur}s audio={audio and spec.supports_audio}",
         ai_model=spec.sdk_model,
     )
     try:

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -270,7 +270,8 @@ def get_user_id(email: str):
 
 
 def insert_post(email: str, content: str, scheduled_time: datetime, post_type: PostType,
-                video_url: Optional[str] = None, carousel_slides: Optional[list[str]] = None) -> bool:
+                video_url: Optional[str] = None, carousel_slides: Optional[list[str]] = None,
+                video_quality: str = "standard") -> bool:
     user_id = get_user_id(email)
 
     success = False
@@ -291,9 +292,10 @@ def insert_post(email: str, content: str, scheduled_time: datetime, post_type: P
         slides_json = json.dumps(carousel_slides) if carousel_slides else None
 
         cursor.execute("""
-            INSERT INTO posts (content, scheduled_time, post_type, user_id, video_url, carousel_slides)
-            VALUES (%s, %s, %s, %s, %s, %s)
-        """, (content, scheduled_time, post_type.value, user_id, video_url, slides_json))
+            INSERT INTO posts (content, scheduled_time, post_type, user_id, video_url, carousel_slides, video_quality)
+            VALUES (%s, %s, %s, %s, %s, %s, %s)
+        """, (content, scheduled_time, post_type.value, user_id, video_url, slides_json,
+              video_quality or "standard"))
 
         connection.commit()
         success = cursor.rowcount == 1
@@ -2037,6 +2039,136 @@ def refund_avatar_credit(user_id: int, training_id: str) -> bool:
         return True
     except mysql.connector.Error as err:
         myprint(f"Could not refund avatar credit for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+# ---------------------------------------------------------------------------
+# Premium video credits (mirrors avatar_credit_ledger; balance = SUM(delta))
+# ---------------------------------------------------------------------------
+
+def get_video_credit_balance(user_id: int) -> int:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT COALESCE(SUM(delta), 0) AS balance FROM video_credit_ledger WHERE user_id = %s",
+            (user_id,),
+        )
+        row = cursor.fetchone()
+        return int(row["balance"]) if row else 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not get video credit balance for user_id {user_id} | Error: {err}")
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_video_credit_ledger_entry_by_session(stripe_session_id: str) -> Optional[dict]:
+    """Return an existing purchase ledger entry for a Stripe session (idempotency check)."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT id, user_id, delta FROM video_credit_ledger WHERE stripe_session_id = %s AND delta > 0 LIMIT 1",
+            (stripe_session_id,),
+        )
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not look up video credit ledger by session | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def add_video_credits(user_id: int, amount: int, reason: str,
+                      stripe_session_id: Optional[str] = None) -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            """INSERT INTO video_credit_ledger (user_id, delta, reason, stripe_session_id)
+               VALUES (%s, %s, %s, %s)""",
+            (user_id, amount, reason, stripe_session_id),
+        )
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not add video credits for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def deduct_video_credits(user_id: int, amount: int, post_id: Optional[int] = None,
+                         reason: str = "premium_video") -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            """INSERT INTO video_credit_ledger (user_id, delta, reason, post_id)
+               VALUES (%s, %s, %s, %s)""",
+            (user_id, -abs(amount), reason, post_id),
+        )
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not deduct video credits for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def refund_video_credits(user_id: int, amount: int, post_id: Optional[int] = None,
+                         reason: str = "premium_video_refund") -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            """INSERT INTO video_credit_ledger (user_id, delta, reason, post_id)
+               VALUES (%s, %s, %s, %s)""",
+            (user_id, abs(amount), reason, post_id),
+        )
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not refund video credits for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_post_video_quality(post_id: int) -> str:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute("SELECT video_quality FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+        return (row["video_quality"] if row and row.get("video_quality") else "standard")
+    except mysql.connector.Error as err:
+        myprint(f"Could not get video_quality for post {post_id} | Error: {err}")
+        return "standard"
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_post_video_quality(post_id: int, quality: str) -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute("UPDATE posts SET video_quality = %s WHERE id = %s", (quality, post_id))
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update video_quality for post {post_id} | Error: {err}")
         return False
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -50,6 +50,16 @@ DEFAULT_VIDEO_RATIO = get_constant_from_env('DEFAULT_VIDEO_RATIO', default_value
 DEFAULT_IMAGE_MODEL = get_constant_from_env('DEFAULT_IMAGE_MODEL', default_value='black-forest-labs/flux-dev')
 DEFAULT_IMAGE_RATIO = get_constant_from_env('DEFAULT_IMAGE_RATIO', default_value='1:1')
 
+# Video quality tiers. STANDARD is free (included in every plan); PREMIUM tiers cost
+# video credits (deducted on a successful premium render, refunded on failure).
+# Premium uses Veo (realism + native audio); with an active avatar it runs Veo
+# image->video on the avatar image to keep the user's likeness, else text->video.
+STANDARD_VIDEO_MODEL = get_constant_from_env('STANDARD_VIDEO_MODEL', default_value='gen4_turbo')
+PREMIUM_VIDEO_MODEL = get_constant_from_env('PREMIUM_VIDEO_MODEL', default_value='veo3.1_fast')   # 1 credit
+PREMIUM_TOP_VIDEO_MODEL = get_constant_from_env('PREMIUM_TOP_VIDEO_MODEL', default_value='veo3.1')  # 3 credits
+PREMIUM_VIDEO_CREDITS = int(get_constant_from_env('PREMIUM_VIDEO_CREDITS', default_value='1'))
+PREMIUM_TOP_VIDEO_CREDITS = int(get_constant_from_env('PREMIUM_TOP_VIDEO_CREDITS', default_value='3'))
+
 # AI disclosure: append a short caption line to AI-visual posts. Guaranteed-visible
 # fallback for C2PA (which self-signed certs can't make LinkedIn trust yet).
 AI_DISCLOSURE_ENABLED = isTrue(get_constant_from_env('AI_DISCLOSURE_ENABLED', default_value='True'))

--- a/src/cqc_lem/utilities/stripe_util.py
+++ b/src/cqc_lem/utilities/stripe_util.py
@@ -286,6 +286,69 @@ def create_avatar_credits_checkout(
         return None
 
 
+# Premium video credits (~$2/credit). 1 credit = 1 veo3.1_fast video; veo3.1 = 3 credits.
+VIDEO_CREDIT_PACKAGES: dict[str, dict] = {
+    "small":  {"credits": 5,   "amount_cents": 1200,  "label": "5 premium videos"},
+    "medium": {"credits": 15,  "amount_cents": 3000,  "label": "15 premium videos — save 17%"},
+    "large":  {"credits": 40,  "amount_cents": 7000,  "label": "40 premium videos — save 27%"},
+    "max":    {"credits": 100, "amount_cents": 15000, "label": "100 premium videos — save 38%"},
+}
+
+
+def create_video_credits_checkout(
+    stripe_customer_id: str,
+    package: str,
+    success_url: str,
+    cancel_url: str,
+) -> Optional[str]:
+    """Create a one-time Stripe Checkout session for premium video credits.
+    Uses inline price_data so no Stripe products need to be pre-created.
+    Returns the checkout URL, or None on failure.
+    """
+    pkg = VIDEO_CREDIT_PACKAGES.get(package)
+    if not pkg:
+        myprint(f"Unknown video credit package '{package}'")
+        return None
+    if not STRIPE_API_KEY:
+        myprint("STRIPE_API_KEY not set — cannot create video credits checkout")
+        return None
+
+    stripe = _get_stripe()
+    try:
+        session = stripe.checkout.Session.create(
+            customer=stripe_customer_id,
+            payment_method_types=["card"],
+            line_items=[
+                {
+                    "price_data": {
+                        "currency": "usd",
+                        "unit_amount": pkg["amount_cents"],
+                        "product_data": {
+                            "name": f"Premium Video Credits — {pkg['label']}",
+                            "description": (
+                                "Use these credits to generate premium AI videos "
+                                "(Veo realism + native audio). 1 credit per premium video."
+                            ),
+                        },
+                    },
+                    "quantity": 1,
+                }
+            ],
+            mode="payment",
+            success_url=success_url,
+            cancel_url=cancel_url,
+            metadata={
+                "type": "video_credits",
+                "package": package,
+                "credits": str(pkg["credits"]),
+            },
+        )
+        return session.url
+    except Exception as e:
+        myprint(f"Video credits checkout failed for customer={stripe_customer_id}: {e}")
+        return None
+
+
 def get_checkout_session_by_payment_intent(payment_intent_id: str) -> Optional[dict]:
     """Return the first Checkout Session associated with a PaymentIntent, or None."""
     if not STRIPE_API_KEY:

--- a/tests/unit/api/test_video_credits_api.py
+++ b/tests/unit/api/test_video_credits_api.py
@@ -1,0 +1,131 @@
+"""Unit tests for video credit + upgrade API endpoints."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from cqc_lem.utilities.db import PostType
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+class TestBalance:
+    def test_401(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            r = client.get("/api/video/credits", params={"session_token": "x"})
+        assert r.status_code == 401
+
+    def test_200(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_video_credit_balance", return_value=12):
+            r = client.get("/api/video/credits", params={"session_token": "x"})
+        assert r.status_code == 200 and r.json()["detail"]["balance"] == 12
+
+
+class TestCheckout:
+    def test_200(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_user_subscription_info", return_value={"stripe_customer_id": "cus_1"}), \
+             patch("cqc_lem.utilities.stripe_util.create_video_credits_checkout", return_value="https://stripe"):
+            r = client.post("/api/video/credits/checkout",
+                            json={"session_token": "x", "package": "medium", "success_url": "a", "cancel_url": "b"})
+        assert r.status_code == 200 and r.json()["detail"]["checkout_url"] == "https://stripe"
+
+    def test_unknown_package_400(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_user_subscription_info", return_value={"stripe_customer_id": "cus_1"}):
+            r = client.post("/api/video/credits/checkout",
+                            json={"session_token": "x", "package": "nope", "success_url": "a", "cancel_url": "b"})
+        assert r.status_code == 400
+
+    def test_no_customer_400(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_user_subscription_info", return_value={"stripe_customer_id": None}):
+            r = client.post("/api/video/credits/checkout",
+                            json={"session_token": "x", "package": "medium", "success_url": "a", "cancel_url": "b"})
+        assert r.status_code == 400
+
+
+class TestUpgrade:
+    def test_not_owner_403(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=2):
+            r = client.post("/api/video/upgrade", json={"session_token": "x", "post_id": 9, "tier": "premium"})
+        assert r.status_code == 403
+
+    def test_not_video_404(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_post_type", return_value=PostType.TEXT):
+            r = client.post("/api/video/upgrade", json={"session_token": "x", "post_id": 9, "tier": "premium"})
+        assert r.status_code == 404
+
+    def test_insufficient_402(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_post_type", return_value=PostType.VIDEO), \
+             patch("cqc_lem.api.main.get_video_credit_balance", return_value=0):
+            r = client.post("/api/video/upgrade", json={"session_token": "x", "post_id": 9, "tier": "premium"})
+        assert r.status_code == 402
+
+    def test_queues_200(self, client):
+        task = MagicMock()
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=1), \
+             patch("cqc_lem.api.main.get_post_type", return_value=PostType.VIDEO), \
+             patch("cqc_lem.api.main.get_video_credit_balance", return_value=5), \
+             patch("cqc_lem.api.main.update_post_video_quality", return_value=True), \
+             patch("cqc_lem.app.run_content_plan.regenerate_post_video_task", task):
+            r = client.post("/api/video/upgrade", json={"session_token": "x", "post_id": 9, "tier": "premium_top"})
+        assert r.status_code == 200
+        assert r.json()["detail"]["status"] == "queued" and r.json()["detail"]["credits_required"] == 3
+        task.apply_async.assert_called_once()
+
+
+class TestWebhookFulfillment:
+    def test_video_credits_granted_on_paid(self, client):
+        event = {"type": "checkout.session.completed", "data": {"object": {
+            "payment_status": "paid", "customer": "cus_1", "id": "sess_1",
+            "metadata": {"type": "video_credits", "package": "medium", "credits": "15"},
+        }}}
+        with patch("cqc_lem.utilities.stripe_util.validate_webhook", return_value=event), \
+             patch("cqc_lem.api.main.get_video_credit_ledger_entry_by_session", return_value=None), \
+             patch("cqc_lem.api.main.get_user_by_stripe_customer_id", return_value={"id": 7}), \
+             patch("cqc_lem.api.main.add_video_credits") as add:
+            resp = client.post("/api/billing/webhook", content=b"{}",
+                               headers={"Stripe-Signature": "sig", "Content-Type": "application/json"})
+        assert resp.status_code == 200
+        add.assert_called_once()
+        assert add.call_args[0][0] == 7 and add.call_args[0][1] == 15
+
+    def test_video_credits_idempotent_skips_duplicate(self, client):
+        event = {"type": "checkout.session.completed", "data": {"object": {
+            "payment_status": "paid", "customer": "cus_1", "id": "sess_dup",
+            "metadata": {"type": "video_credits", "package": "small", "credits": "5"},
+        }}}
+        with patch("cqc_lem.utilities.stripe_util.validate_webhook", return_value=event), \
+             patch("cqc_lem.api.main.get_video_credit_ledger_entry_by_session", return_value={"id": 1}), \
+             patch("cqc_lem.api.main.add_video_credits") as add:
+            resp = client.post("/api/billing/webhook", content=b"{}",
+                               headers={"Stripe-Signature": "sig", "Content-Type": "application/json"})
+        assert resp.status_code == 200
+        add.assert_not_called()

--- a/tests/unit/app/test_run_content_plan.py
+++ b/tests/unit/app/test_run_content_plan.py
@@ -300,7 +300,7 @@ class TestCreateContent:
         content, video_url = create_content(user_id=1, post_type="video", stage="decision")
         assert content == "Video post content"
         assert video_url == "https://video.url"
-        mock_video.assert_called_once_with(1, "decision")
+        mock_video.assert_called_once_with(1, "decision", post_id=None)
 
     @patch("cqc_lem.app.run_content_plan.create_text_post", return_value="  Trimmed content  ")
     def test_text_content_is_stripped(self, mock_text):

--- a/tests/unit/app/test_video_tier_pipeline.py
+++ b/tests/unit/app/test_video_tier_pipeline.py
@@ -1,0 +1,83 @@
+"""Unit tests for tier selection + credit lifecycle in the video pipeline."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+class TestPremiumTier:
+    def test_mapping(self):
+        from cqc_lem.app.run_content_plan import _premium_tier_for_quality
+        assert _premium_tier_for_quality("standard") is None
+        assert _premium_tier_for_quality("unknown") is None
+        m, c, a = _premium_tier_for_quality("premium")
+        assert c == 1 and a is True
+        m, c, a = _premium_tier_for_quality("premium_top")
+        assert c == 3 and a is True
+
+
+class TestGenerateVideoSrc:
+    def test_premium_no_credits_falls_back_to_standard(self):
+        with patch("cqc_lem.utilities.db.get_post_video_quality", return_value="premium"), \
+             patch("cqc_lem.utilities.db.get_video_credit_balance", return_value=0), \
+             patch("cqc_lem.utilities.db.deduct_video_credits") as ded, \
+             patch("cqc_lem.utilities.db.get_active_avatar", return_value=None), \
+             patch("cqc_lem.app.run_content_plan.get_flux_image_prompt_from_ai", return_value="scene"), \
+             patch("cqc_lem.app.run_content_plan.generate_flux1_image_from_prompt", return_value="/tmp/i.png"), \
+             patch("cqc_lem.app.run_content_plan.get_runway_ml_video_prompt_from_ai", return_value="motion"), \
+             patch("cqc_lem.app.run_content_plan.create_runway_video", return_value="https://x.mp4") as crv:
+            from cqc_lem.app.run_content_plan import _generate_video_src
+            src = _generate_video_src(1, "text", None, post_id=9)
+        ded.assert_not_called()
+        assert src == "https://x.mp4"
+        assert crv.call_args[1]["model"] == "gen4_turbo"  # standard fallback
+
+    def test_premium_success_deducts_not_refunds(self):
+        with patch("cqc_lem.utilities.db.get_post_video_quality", return_value="premium"), \
+             patch("cqc_lem.utilities.db.get_video_credit_balance", return_value=5), \
+             patch("cqc_lem.utilities.db.deduct_video_credits", return_value=True) as ded, \
+             patch("cqc_lem.utilities.db.refund_video_credits") as ref, \
+             patch("cqc_lem.utilities.db.get_active_avatar", return_value=None), \
+             patch("cqc_lem.app.run_content_plan.get_flux_image_prompt_from_ai", return_value="scene"), \
+             patch("cqc_lem.app.run_content_plan.get_runway_ml_video_prompt_from_ai", return_value="motion"), \
+             patch("cqc_lem.app.run_content_plan.create_runway_video", return_value="https://x.mp4") as crv:
+            from cqc_lem.app.run_content_plan import _generate_video_src
+            src = _generate_video_src(1, "text", None, post_id=9)
+        assert src == "https://x.mp4"
+        ded.assert_called_once()
+        ref.assert_not_called()
+        # premium + no avatar -> text->video (first positional image arg is None) with audio
+        assert crv.call_args[0][0] is None
+        assert crv.call_args[1]["model"] == "veo3.1_fast" and crv.call_args[1]["audio"] is True
+
+    def test_failure_refunds_and_pexels_fallback(self):
+        with patch("cqc_lem.utilities.db.get_post_video_quality", return_value="premium"), \
+             patch("cqc_lem.utilities.db.get_video_credit_balance", return_value=5), \
+             patch("cqc_lem.utilities.db.deduct_video_credits", return_value=True), \
+             patch("cqc_lem.utilities.db.refund_video_credits") as ref, \
+             patch("cqc_lem.utilities.db.get_active_avatar", return_value=None), \
+             patch("cqc_lem.app.run_content_plan.get_flux_image_prompt_from_ai", return_value="scene"), \
+             patch("cqc_lem.app.run_content_plan.get_runway_ml_video_prompt_from_ai", return_value="motion"), \
+             patch("cqc_lem.app.run_content_plan.create_runway_video", side_effect=RuntimeError("boom")), \
+             patch("cqc_lem.app.run_content_plan.create_folder_if_not_exists"), \
+             patch("cqc_lem.utilities.pexels_helper.download_pexels_video", return_value="/tmp/p.mp4", create=True):
+            from cqc_lem.app.run_content_plan import _generate_video_src
+            src = _generate_video_src(1, "text", None, post_id=9)
+        ref.assert_called_once()
+        assert src == "/tmp/p.mp4"
+
+    def test_standard_quality_no_credit_calls(self):
+        with patch("cqc_lem.utilities.db.get_post_video_quality", return_value="standard"), \
+             patch("cqc_lem.utilities.db.get_video_credit_balance") as bal, \
+             patch("cqc_lem.utilities.db.deduct_video_credits") as ded, \
+             patch("cqc_lem.utilities.db.get_active_avatar", return_value=None), \
+             patch("cqc_lem.app.run_content_plan.get_flux_image_prompt_from_ai", return_value="scene"), \
+             patch("cqc_lem.app.run_content_plan.generate_flux1_image_from_prompt", return_value="/tmp/i.png"), \
+             patch("cqc_lem.app.run_content_plan.get_runway_ml_video_prompt_from_ai", return_value="motion"), \
+             patch("cqc_lem.app.run_content_plan.create_runway_video", return_value="https://x.mp4") as crv:
+            from cqc_lem.app.run_content_plan import _generate_video_src
+            src = _generate_video_src(1, "text", None, post_id=9)
+        bal.assert_not_called()
+        ded.assert_not_called()
+        assert crv.call_args[1]["model"] == "gen4_turbo"

--- a/tests/unit/utilities/ai/test_video_models_premium.py
+++ b/tests/unit/utilities/ai/test_video_models_premium.py
@@ -1,0 +1,50 @@
+"""Unit tests for premium tiers + text->video + audio in video_models."""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestTiers:
+    def test_credits_and_premium(self):
+        from cqc_lem.utilities.ai.video_models import model_credits, is_premium
+        assert model_credits("gen4_turbo") == 0 and is_premium("gen4_turbo") is False
+        assert model_credits("veo3.1_fast") == 1 and is_premium("veo3.1_fast") is True
+        assert model_credits("veo3.1") == 3 and is_premium("veo3.1") is True
+
+    def test_resolve_duration(self):
+        from cqc_lem.utilities.ai.video_models import resolve_duration
+        assert resolve_duration("gen4_turbo", 5) == 5
+        assert resolve_duration("veo3.1_fast", 5) == 6   # 5 invalid for veo -> default 6
+        assert resolve_duration("veo3.1_fast", 8) == 8   # 8 is valid
+
+    def test_estimate_cost_veo(self):
+        from cqc_lem.utilities.ai.video_models import estimate_video_cost
+        assert estimate_video_cost("veo3.1", 6) == 2.4
+        assert estimate_video_cost("gen4_turbo", 5) == 0.25
+
+
+class TestEndpointSelection:
+    def test_text_to_video_when_no_image(self, mock_runwayml):
+        from cqc_lem.utilities.ai.video_models import create_runway_video
+        url = create_runway_video(None, "a scene with motion", model="veo3.1_fast", audio=True)
+        assert url == "https://runway.example/video.mp4"
+        # used the text_to_video endpoint, not image_to_video
+        assert mock_runwayml["client"].text_to_video.create.called
+        assert not mock_runwayml["client"].image_to_video.create.called
+        kw = mock_runwayml["client"].text_to_video.create.call_args[1]
+        assert kw["model"] == "veo3.1_fast" and kw["audio"] is True
+        assert kw["duration"] == 6 and "prompt_image" not in kw
+
+    def test_image_to_video_when_image_given(self, mock_runwayml):
+        from cqc_lem.utilities.ai.video_models import create_runway_video
+        create_runway_video("https://img/x.png", "move", model="veo3.1", audio=True)
+        assert mock_runwayml["client"].image_to_video.create.called
+        kw = mock_runwayml["client"].image_to_video.create.call_args[1]
+        assert kw["prompt_image"] == "https://img/x.png" and kw["audio"] is True
+
+    def test_audio_omitted_for_non_audio_model(self, mock_runwayml):
+        from cqc_lem.utilities.ai.video_models import create_runway_video
+        create_runway_video("https://img/x.png", "move", model="gen4_turbo", audio=True)
+        kw = mock_runwayml["client"].image_to_video.create.call_args[1]
+        assert "audio" not in kw  # gen4_turbo doesn't support audio

--- a/tests/unit/utilities/test_stripe_video_credits.py
+++ b/tests/unit/utilities/test_stripe_video_credits.py
@@ -1,0 +1,33 @@
+"""Unit tests for video credit Stripe packages + checkout."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+
+def test_packages_present():
+    from cqc_lem.utilities.stripe_util import VIDEO_CREDIT_PACKAGES
+    assert set(VIDEO_CREDIT_PACKAGES) == {"small", "medium", "large", "max"}
+    assert VIDEO_CREDIT_PACKAGES["medium"]["credits"] == 15
+
+
+def test_creates_session_with_video_metadata():
+    fake_session = MagicMock()
+    fake_session.url = "https://stripe/checkout"
+    stripe_mock = MagicMock()
+    stripe_mock.checkout.Session.create.return_value = fake_session
+    with patch("cqc_lem.utilities.stripe_util.STRIPE_API_KEY", "sk_test"), \
+         patch("cqc_lem.utilities.stripe_util._get_stripe", return_value=stripe_mock):
+        from cqc_lem.utilities.stripe_util import create_video_credits_checkout
+        url = create_video_credits_checkout("cus_1", "medium", "ok", "cancel")
+    assert url == "https://stripe/checkout"
+    kwargs = stripe_mock.checkout.Session.create.call_args[1]
+    assert kwargs["metadata"]["type"] == "video_credits"
+    assert kwargs["metadata"]["credits"] == "15"
+
+
+def test_unknown_package_returns_none():
+    with patch("cqc_lem.utilities.stripe_util.STRIPE_API_KEY", "sk_test"):
+        from cqc_lem.utilities.stripe_util import create_video_credits_checkout
+        assert create_video_credits_checkout("cus_1", "nope", "a", "b") is None

--- a/tests/unit/utilities/test_video_credits_db.py
+++ b/tests/unit/utilities/test_video_credits_db.py
@@ -1,0 +1,82 @@
+"""Unit tests for premium video credit + post-quality DB functions."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+
+def _db(fetchone=None, rowcount=1):
+    cur = MagicMock()
+    cur.fetchone.return_value = fetchone
+    cur.rowcount = rowcount
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestVideoCreditBalance:
+    def test_sum(self):
+        conn, _ = _db(fetchone={"balance": 7})
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_video_credit_balance
+            assert get_video_credit_balance(1) == 7
+
+    def test_zero_on_error(self):
+        conn, cur = _db()
+        cur.execute.side_effect = __import__("mysql.connector", fromlist=["c"]).Error("x")
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_video_credit_balance
+            assert get_video_credit_balance(1) == 0
+
+
+class TestVideoCreditMutations:
+    def test_add_inserts_positive(self):
+        conn, cur = _db()
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import add_video_credits
+            assert add_video_credits(1, 15, "purchase_medium", "sess_1") is True
+        sql, params = cur.execute.call_args[0]
+        assert "INSERT INTO video_credit_ledger" in sql and params[1] == 15
+
+    def test_deduct_inserts_negative(self):
+        conn, cur = _db()
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import deduct_video_credits
+            assert deduct_video_credits(1, 3, post_id=9, reason="premium_video_veo3.1") is True
+        params = cur.execute.call_args[0][1]
+        assert params[1] == -3 and params[3] == 9
+
+    def test_refund_inserts_positive(self):
+        conn, cur = _db()
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import refund_video_credits
+            assert refund_video_credits(1, 3, post_id=9) is True
+        assert cur.execute.call_args[0][1][1] == 3
+
+    def test_ledger_by_session(self):
+        conn, _ = _db(fetchone={"id": 1, "user_id": 1, "delta": 15})
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_video_credit_ledger_entry_by_session
+            assert get_video_credit_ledger_entry_by_session("sess_1")["delta"] == 15
+
+
+class TestPostVideoQuality:
+    def test_get_defaults_standard(self):
+        conn, _ = _db(fetchone=None)
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_video_quality
+            assert get_post_video_quality(5) == "standard"
+
+    def test_get_returns_value(self):
+        conn, _ = _db(fetchone={"video_quality": "premium"})
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_video_quality
+            assert get_post_video_quality(5) == "premium"
+
+    def test_update(self):
+        conn, cur = _db(rowcount=1)
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_post_video_quality
+            assert update_post_video_quality(5, "premium_top") is True
+        assert "UPDATE posts SET video_quality" in cur.execute.call_args[0][0]


### PR DESCRIPTION
## Why
You asked to offer both the cheap image→video models (free) **and** the higher‑quality `veo3.1_fast`‑with‑audio you preferred, behind a **credit system** — cheap included in any plan, premium costs credits (1 each). This implements exactly that, mirroring the existing avatar‑credit infrastructure.

## Decisions (confirmed)
- **Standard (free):** `gen4_turbo` image→video — included in every plan.
- **Premium:** two tiers — **`veo3.1_fast` = 1 credit**, **`veo3.1` (top realism) = 3 credits**, both with native audio.
- **Pricing:** ~$2/credit — 5/$12, 15/$30, 40/$70, 100/$150.

## Avatar + text→video — the path you asked about
Pure text→video can't embed a trained LoRA likeness. So **premium with an active avatar runs Veo *image*→video on the avatar image** (keeps the user's face *and* adds audio); without an avatar it uses Veo text→video. The pipeline already branches on avatar presence.

## What's included
- **`video_models`**: Veo + `audio` + `text_to_video`, per‑model durations (Veo needs 4/6/8s), `model_credits`/`is_premium`.
- **DB (V30)**: `video_credit_ledger` (balance = `SUM(delta)`) + `posts.video_quality`; get/add/deduct/refund helpers.
- **Stripe**: `VIDEO_CREDIT_PACKAGES` + checkout; idempotent webhook fulfillment + full‑refund handling.
- **API**: `GET /video/credits`, `POST /video/credits/checkout`, `POST /video/upgrade` (async premium regen; **402 when out of credits**).
- **Pipeline**: tier chosen from `posts.video_quality`; **credits reserved up‑front, refunded on failure**; falls back to standard (then Pexels) when there are no credits.
- **UI**: a **Premium Video Credits** buy/balance card on Account + a **video‑quality selector** on the schedule form, gated on balance.

## Safety / cost
- Credits are only spent on a **successful premium render** (reserved then refunded on any failure) — same guarantee as avatar trainings.
- No new Python deps (poetry.lock unchanged). New env vars all have safe defaults.

## Tests
34 new unit tests (DB ledger, Stripe checkout, webhook fulfillment + idempotency, all endpoints incl. 402/403/404, pipeline tier selection + credit lifecycle, Veo/text→video/audio). **Full unit suite green (858 passed locally).**

## Deploy note
V30 migration adds the ledger table + `posts.video_quality` (default `standard`, safe for existing rows) — runs via Flyway on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)