### PR TITLE
fix(assets): reliable worker media writes + missing-asset backfill

### DIFF
--- a/compose/local/entrypoint
+++ b/compose/local/entrypoint
@@ -7,4 +7,15 @@ set -o pipefail
 # exits if any of your variables is not set
 set -o nounset
 
+# The shared "assets" named volume mounts over /app/src/cqc_lem/assets at runtime, so the
+# image-time COPY --chown doesn't cover it. The celery workers run as the non-root user
+# "celeryworker" (uid 1000); without this they cannot write generated images/videos to the
+# volume (web_app runs as root and created the dirs root-owned), so asset generation
+# silently fails and video/carousel posts get approved with no media. Re-own the volume to
+# celeryworker on every container start. Runs as root (entrypoint); best-effort so a
+# transient error never blocks boot.
+if [ -d /app/src/cqc_lem/assets ]; then
+  chown -R celeryworker:celeryworker /app/src/cqc_lem/assets 2>/dev/null || true
+fi
+
 exec "$@"

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -74,6 +74,10 @@ app.conf.update(
             'task': 'cqc_lem.app.run_content_plan.auto_create_weekly_content',
             'schedule': crontab(hour='1', minute='30')  # Run every day at 1:30 AM
         },
+        'backfill-missing-assets': {
+            'task': 'cqc_lem.app.run_scheduler.auto_backfill_missing_assets',
+            'schedule': crontab(minute='15', hour='*/3')  # Every 3 hours — regen any missing video/carousel media
+        },
         'clean-up-stale-invites': {
             'task': 'cqc_lem.app.run_scheduler.auto_clean_stale_invites',
             'schedule': crontab(hour='2', minute='0', )  # Run every day at 2:00 AM

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -312,6 +312,19 @@ def _extract_slide_texts(carousel_obj) -> list[str]:
     return texts
 
 
+def _post_missing_required_asset(post_id: int, post_type, video_url) -> bool:
+    """True when a video post has no video or a carousel post has no slides — used to
+    hold such posts PENDING instead of approving them to publish with no media."""
+    pt = str(post_type).lower()
+    if pt == PostType.VIDEO.value:
+        return not video_url
+    if pt == PostType.CAROUSEL.value:
+        from cqc_lem.utilities.db import get_post_carousel_slides
+        slides = get_post_carousel_slides(post_id)
+        return not slides or str(slides).strip() in ("", "[]")
+    return False
+
+
 def _apply_ai_disclosure(content: str) -> str:
     """Append the AI-visuals disclosure line to a caption (idempotent)."""
     if not AI_DISCLOSURE_ENABLED or not content:
@@ -446,6 +459,21 @@ def regenerate_video_for_post(post_id: int) -> Optional[str]:
 def regenerate_post_video_task(post_id: int):
     """Celery wrapper so premium-video upgrades run async (Veo can take minutes)."""
     return regenerate_video_for_post(post_id)
+
+
+@shared_task.task
+def regenerate_post_carousel_task(post_id: int):
+    """Regenerate a carousel post's slide images (used by the asset-backfill safety net)."""
+    from cqc_lem.utilities.db import get_post_user_id, get_post_buyer_stage, update_db_post_content
+    user_id = get_post_user_id(post_id)
+    if not user_id:
+        myprint(f"regenerate_post_carousel_task: no user for post_id={post_id}")
+        return None
+    stage = get_post_buyer_stage(post_id) or "awareness"
+    content = create_carousel_content(user_id, stage, post_id)
+    if content:
+        update_db_post_content(post_id, content)
+    return content
 
 
 def create_text_post(user_id: int, stage: str, post_type: str = None, user_profile: LinkedInProfile=None,
@@ -963,6 +991,14 @@ def auto_create_weekly_content(user_id: int = None):
         prefs = _prefs_cache[user_id]
         auto_schedule = bool(prefs.get("auto_schedule_posts", True))
         new_status = PostStatus.APPROVED if auto_schedule else PostStatus.PENDING
+
+        # Never auto-approve a video/carousel post whose media failed to generate — hold it
+        # PENDING so the backfill task (or manual review) can complete the asset before it
+        # can be scheduled/posted. Prevents assetless posts going out.
+        if _post_missing_required_asset(post_id, post_type, video_url):
+            new_status = PostStatus.PENDING
+            myprint(f"post_id {post_id}: required media asset missing — holding PENDING")
+
         myprint(f"Updating post_id: {post_id} Status={new_status}")
         update_db_post_status(post_id, new_status)
 

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -107,6 +107,31 @@ def auto_appreciate_dms():
 
 
 @shared_task.task
+def auto_backfill_missing_assets():
+    """Safety net: regenerate missing media for unposted video/carousel posts before they
+    publish, so a post never reaches its scheduled time without its asset (e.g. when the
+    original generation failed)."""
+    from cqc_lem.utilities.db import get_unposted_posts_missing_assets
+    from cqc_lem.app.run_content_plan import regenerate_post_video_task, regenerate_post_carousel_task
+
+    posts = get_unposted_posts_missing_assets()
+    queued = 0
+    for post_id, user_id, post_type, buyer_stage, scheduled_time in posts:
+        pt = str(post_type).lower()
+        if pt == 'video':
+            regenerate_post_video_task.apply_async(kwargs={'post_id': post_id})
+            queued += 1
+        elif pt == 'carousel':
+            regenerate_post_carousel_task.apply_async(kwargs={'post_id': post_id})
+            queued += 1
+        log_warning("Backfilling missing media asset for unposted post",
+                    post_id=post_id, user_id=user_id, task_name="auto_backfill_missing_assets")
+    log_info(f"Asset backfill: queued {queued} regeneration(s) across {len(posts)} post(s)",
+             task_name="auto_backfill_missing_assets")
+    return f"Queued {queued} asset regeneration(s)"
+
+
+@shared_task.task
 def auto_clean_stale_invites():
     """Cleans up stale invites for each active user"""
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2175,6 +2175,49 @@ def update_post_video_quality(post_id: int, quality: str) -> bool:
         connection.close()
 
 
+def get_post_carousel_slides(post_id: int):
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute("SELECT carousel_slides FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+        return row["carousel_slides"] if row else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not get carousel_slides for post {post_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_unposted_posts_missing_assets(within_days: int = 14) -> list:
+    """Posts not yet posted, due within `within_days`, whose required media asset is
+    missing: video posts with no video_url, or carousel posts with no slides. Used by the
+    backfill safety net. Returns (id, user_id, post_type, buyer_stage, scheduled_time)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("""
+            SELECT id, user_id, post_type, buyer_stage, scheduled_time
+            FROM posts
+            WHERE status IN ('approved', 'pending', 'scheduled')
+              AND scheduled_time > NOW()
+              AND scheduled_time <= NOW() + INTERVAL %s DAY
+              AND (
+                    (post_type = 'video'    AND (video_url IS NULL OR video_url = ''))
+                 OR (post_type = 'carousel' AND (carousel_slides IS NULL OR carousel_slides = '' OR carousel_slides = '[]'))
+              )
+            ORDER BY scheduled_time
+        """, (within_days,))
+        return cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get unposted posts missing assets | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
 # ---------------------------------------------------------------------------
 # Avatar training records
 # ---------------------------------------------------------------------------

--- a/tests/unit/app/test_asset_backfill.py
+++ b/tests/unit/app/test_asset_backfill.py
@@ -1,0 +1,68 @@
+"""Unit tests for the asset-backfill safety net + missing-asset guard."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+
+def _db(fetchone=None, fetchall=None):
+    cur = MagicMock()
+    cur.fetchone.return_value = fetchone
+    cur.fetchall.return_value = fetchall or []
+    conn = MagicMock()
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestDbQueries:
+    def test_missing_assets_query(self):
+        rows = [(6, 1, 'video', 'awareness', 't'), (5, 1, 'carousel', 'awareness', 't')]
+        conn, _ = _db(fetchall=rows)
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_unposted_posts_missing_assets
+            assert get_unposted_posts_missing_assets() == rows
+
+    def test_carousel_slides_getter(self):
+        conn, _ = _db(fetchone={"carousel_slides": '["a"]'})
+        with patch("cqc_lem.utilities.db.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_carousel_slides
+            assert get_post_carousel_slides(5) == '["a"]'
+
+
+class TestMissingAssetGuard:
+    def test_video_without_url_is_missing(self):
+        from cqc_lem.app.run_content_plan import _post_missing_required_asset
+        assert _post_missing_required_asset(6, "video", None) is True
+        assert _post_missing_required_asset(6, "video", "https://x.mp4") is False
+
+    def test_carousel_slides_states(self):
+        from cqc_lem.app.run_content_plan import _post_missing_required_asset
+        for val, missing in [(None, True), ('[]', True), ('', True), ('["url"]', False)]:
+            with patch("cqc_lem.utilities.db.get_post_carousel_slides", return_value=val):
+                assert _post_missing_required_asset(5, "carousel", None) is missing
+
+    def test_text_never_missing(self):
+        from cqc_lem.app.run_content_plan import _post_missing_required_asset
+        assert _post_missing_required_asset(4, "text", None) is False
+
+
+class TestBackfillTask:
+    def test_enqueues_regen_per_type(self):
+        rows = [(6, 1, 'video', 'awareness', 't'),
+                (5, 1, 'carousel', 'awareness', 't'),
+                (4, 1, 'text', 'awareness', 't')]
+        vid, car = MagicMock(), MagicMock()
+        with patch("cqc_lem.utilities.db.get_unposted_posts_missing_assets", return_value=rows), \
+             patch("cqc_lem.app.run_content_plan.regenerate_post_video_task", vid), \
+             patch("cqc_lem.app.run_content_plan.regenerate_post_carousel_task", car):
+            from cqc_lem.app.run_scheduler import auto_backfill_missing_assets
+            result = auto_backfill_missing_assets()
+        vid.apply_async.assert_called_once_with(kwargs={'post_id': 6})
+        car.apply_async.assert_called_once_with(kwargs={'post_id': 5})
+        assert "Queued 2" in result
+
+    def test_no_missing_posts(self):
+        with patch("cqc_lem.utilities.db.get_unposted_posts_missing_assets", return_value=[]):
+            from cqc_lem.app.run_scheduler import auto_backfill_missing_assets
+            assert "Queued 0" in auto_backfill_missing_assets()


### PR DESCRIPTION
## What happened (root cause)
Your approved video posts had **no video** because the **celery workers run as the non‑root user `celeryworker` (uid 1000)**, but the shared `assets` Docker volume is **root‑owned** (`web_app` runs as root and created the dirs). So the worker hit `PermissionError` writing every generated image/video, the Pexels fallback also couldn't write, and `create_video_content` returned nothing — **but the pipeline approved the post anyway** (`video_url = NULL`). My earlier manual regen worked only because it ran inside `web_app` (root).

Confirmed live: worker process = uid 1000, volume dirs = root:root 755, uid‑1000 write = denied.

## The fix (three parts)
1. **Durable permission fix** — the shared **entrypoint** now `chown -R`s `/app/src/cqc_lem/assets` to `celeryworker` on every container start (runs as root). The image‑time `COPY --chown` can't cover the runtime volume mount, and the old worker‑script chown was commented out. Scoped to the assets dir, best‑effort, survives deploys. *(No world‑writable `777` — just correct ownership.)*
2. **Don't approve assetless posts** — a video/carousel post whose media failed to generate is held **PENDING** (needs‑attention) instead of approved, so it can never publish without its asset.
3. **Asset‑backfill safety net** — new `auto_backfill_missing_assets` beat task (**every 3h**) finds not‑yet‑posted video/carousel posts with a missing asset and regenerates it **before** the scheduled publish time. Adds `get_unposted_posts_missing_assets` / `get_post_carousel_slides` and a `regenerate_post_carousel_task`.

## After deploy
Once this deploys, the entrypoint fixes the volume ownership, and the backfill task (or me, manually) will regenerate posts **6–10**'s videos — which will now succeed in the worker. No DB migration needed.

## Tests
7 new unit tests (missing‑assets query, slides getter, the missing‑asset guard for video/carousel/text, backfill enqueue per type). Full unit suite green (865 passed locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)