### PR TITLE
feat(automation): per-user geo/timezone/locale spoofing for LinkedIn login

### DIFF
--- a/compose/local/database/migrations/V31__add_user_location_fields.sql
+++ b/compose/local/database/migrations/V31__add_user_location_fields.sql
@@ -1,0 +1,9 @@
+-- Per-user location for Selenium geo spoofing (city/country/locale) + capture source.
+-- latitude/longitude (V18) and timezone (V28) already exist; these complete the set
+-- so the browser's reported geolocation, timezone and locale match where the user
+-- normally logs in, reducing LinkedIn "new location" login challenges.
+ALTER TABLE users
+  ADD COLUMN city            VARCHAR(120) NULL AFTER longitude,
+  ADD COLUMN country         VARCHAR(2)   NULL AFTER city,
+  ADD COLUMN locale          VARCHAR(10)  NULL AFTER country,
+  ADD COLUMN location_source ENUM('manual', 'ip_autocapture') NULL AFTER locale;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -32,6 +32,7 @@ from cqc_lem.utilities.db import (
     update_avatar_training_status, set_active_avatar,
     get_avatar_trainings, get_active_avatar,
     get_user_timezone, update_user_timezone,
+    get_user_geo, update_user_location,
     replace_video_url_base, get_post_type, get_post_buyer_stage,
     update_db_post_carousel_slides,
     get_post_url_from_log_for_user,
@@ -42,7 +43,8 @@ from cqc_lem.utilities.linkedin.token_refresh import (
 )
 from cqc_lem.utilities.env_constants import LI_CLIENT_ID, LI_CLIENT_SECRET, LI_REDIRECT_URL, LI_STATE_SALT, ADMIN_SECRET, API_ACCESS_TOKENS, \
     DEFAULT_IMAGE_MODEL, DEFAULT_VIDEO_MODEL, DEFAULT_VIDEO_RATIO
-from cqc_lem.utilities.logger import myprint
+import requests
+from cqc_lem.utilities.logger import myprint, log_warning
 from cqc_lem.utilities.mime_type_helper import get_file_mime_type
 from cqc_lem.utilities.observability import track_api_call
 from cqc_lem.utilities.utils import get_file_extension_from_filepath
@@ -250,6 +252,20 @@ class LinkedInPasswordRequest(BaseModel):
 class TimezoneRequest(BaseModel):
     session_token: str
     timezone: str
+
+
+class LocationRequest(BaseModel):
+    session_token: str
+    latitude: float
+    longitude: float
+    city: Optional[str] = None
+    country: Optional[str] = None
+    locale: Optional[str] = None
+    timezone: Optional[str] = None
+
+
+class LocationAutocaptureRequest(BaseModel):
+    session_token: str
 
 
 class AdminFixVideoUrlsRequest(BaseModel):
@@ -961,6 +977,80 @@ def update_user_timezone_endpoint(request: TimezoneRequest) -> ResponseModel:
     if not saved:
         raise HTTPException(status_code=500, detail="Could not update timezone")
     return ResponseModel(status_code=200, detail="Timezone updated")
+
+
+@router.get("/user/location")
+def get_user_location_endpoint(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail=get_user_geo(user_id) or {})
+
+
+@router.put("/user/location")
+def update_user_location_endpoint(request: LocationRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if not (-90 <= request.latitude <= 90) or not (-180 <= request.longitude <= 180):
+        raise HTTPException(status_code=422, detail="Invalid latitude/longitude")
+    if request.country and len(request.country) != 2:
+        raise HTTPException(status_code=422, detail="country must be an ISO-3166 alpha-2 code")
+    saved = update_user_location(
+        user_id, request.latitude, request.longitude,
+        city=request.city, country=request.country, locale=request.locale,
+        timezone=request.timezone, source="manual",
+    )
+    if not saved:
+        raise HTTPException(status_code=500, detail="Could not update location")
+    return ResponseModel(status_code=200, detail="Location updated")
+
+
+@router.post("/user/location/autocapture")
+def autocapture_user_location_endpoint(request: LocationAutocaptureRequest, http_request: Request) -> ResponseModel:
+    """Geolocate the caller's real IP and persist it as their login location.
+    The app sits behind a Cloudflare tunnel, so the client IP arrives in
+    CF-Connecting-IP / X-Forwarded-For — never trust the immediate peer."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    client_ip = (
+        http_request.headers.get("cf-connecting-ip")
+        or (http_request.headers.get("x-forwarded-for") or "").split(",")[0].strip()
+        or (http_request.client.host if http_request.client else None)
+    )
+    if not client_ip:
+        raise HTTPException(status_code=400, detail="Could not determine client IP")
+
+    try:
+        resp = requests.get(f"https://ipapi.co/{client_ip}/json/", timeout=8)
+        resp.raise_for_status()
+        data = resp.json()
+        if data.get("error"):
+            raise ValueError(data.get("reason", "ip geolocation failed"))
+        lat, lng = float(data["latitude"]), float(data["longitude"])
+    except Exception as e:
+        log_warning("IP geolocation failed", exc=e, user_id=user_id)
+        raise HTTPException(status_code=502, detail="IP geolocation service unavailable")
+
+    locale = None
+    languages = data.get("languages")  # e.g. "en-US,es"
+    if languages:
+        locale = languages.split(",")[0]
+
+    saved = update_user_location(
+        user_id, lat, lng,
+        city=data.get("city"), country=data.get("country_code") or data.get("country"),
+        locale=locale, timezone=data.get("timezone"), source="ip_autocapture",
+    )
+    if not saved:
+        raise HTTPException(status_code=500, detail="Could not save captured location")
+    return ResponseModel(status_code=200, detail={
+        "latitude": lat, "longitude": lng,
+        "city": data.get("city"), "country": data.get("country_code") or data.get("country"),
+        "timezone": data.get("timezone"), "locale": locale,
+    })
 
 
 @router.post("/billing/create-checkout-session")

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1433,7 +1433,7 @@ def get_current_profile(user_id: int, session_name: str = "Get Current Profile")
 
     user_email, user_password = get_user_password_pair_by_id(user_id)
 
-    driver, wait = get_driver_wait_pair(session_name=session_name)
+    driver, wait = get_driver_wait_pair(session_name=session_name, user_id=user_id)
 
     try:
 

--- a/src/cqc_lem/ui/src/pages/Account.tsx
+++ b/src/cqc_lem/ui/src/pages/Account.tsx
@@ -115,6 +115,7 @@ export default function Account() {
   const [timezone, setTimezone] = useState('America/New_York')
   const [tzInitialised, setTzInitialised] = useState(false)
   const [tzSavedMsg, setTzSavedMsg] = useState<string | null>(null)
+  const [locationMsg, setLocationMsg] = useState<{ ok: boolean; text: string } | null>(null)
 
   // Handle LinkedIn OAuth callback: ?li_connected=1 or ?li_error=... in URL
   useEffect(() => {
@@ -309,6 +310,37 @@ export default function Account() {
     onError: () => {
       setTzSavedMsg('Save failed — please try again.')
       setTimeout(() => setTzSavedMsg(null), 5000)
+    },
+  })
+
+  // Login location — used so the automation browser appears to log in from where
+  // you normally do, reducing LinkedIn "new location" challenges.
+  const { data: locationData } = useQuery({
+    queryKey: ['user-location', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/location?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as {
+          latitude?: number; longitude?: number; city?: string; country?: string; timezone?: string
+        }),
+    enabled: !!sessionToken,
+  })
+
+  const autocaptureLocationMutation = useMutation({
+    mutationFn: () =>
+      api
+        .post('/user/location/autocapture', { session_token: sessionToken })
+        .then((r) => r.data.detail),
+    onSuccess: (d: { city?: string; country?: string }) => {
+      queryClient.invalidateQueries({ queryKey: ['user-location'] })
+      queryClient.invalidateQueries({ queryKey: ['user-timezone'] })
+      const where = [d?.city, d?.country].filter(Boolean).join(', ')
+      setLocationMsg({ ok: true, text: where ? `Location set to ${where}.` : 'Location detected.' })
+      setTimeout(() => setLocationMsg(null), 4000)
+    },
+    onError: () => {
+      setLocationMsg({ ok: false, text: 'Could not detect your location — try again.' })
+      setTimeout(() => setLocationMsg(null), 5000)
     },
   })
 
@@ -810,6 +842,38 @@ export default function Account() {
           {tzMutation.isPending ? 'Saving…' : 'Save Timezone'}
         </button>
       </form>
+
+      {/* Login location card */}
+      <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+        <h2 className="text-base font-semibold text-gray-700">Login Location</h2>
+        <p className="text-xs text-gray-500">
+          The automation logs into LinkedIn from our servers. Setting your location makes the
+          browser appear to come from where you normally log in, which reduces LinkedIn
+          "new location" security challenges.
+        </p>
+
+        <div className="text-sm text-gray-700">
+          <span className="font-medium text-gray-600">Current: </span>
+          {locationData?.latitude != null
+            ? `${[locationData.city, locationData.country].filter(Boolean).join(', ') || 'Set'} (${locationData.latitude.toFixed(3)}, ${locationData.longitude?.toFixed(3)})`
+            : 'Not set'}
+        </div>
+
+        {locationMsg && (
+          <p className={`text-sm font-medium ${locationMsg.ok ? 'text-green-600' : 'text-red-600'}`}>
+            {locationMsg.text}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={() => autocaptureLocationMutation.mutate()}
+          disabled={autocaptureLocationMutation.isPending}
+          className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+        >
+          {autocaptureLocationMutation.isPending ? 'Detecting…' : 'Use my current location'}
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1893,6 +1893,69 @@ def update_user_preferences(
         connection.close()
 
 
+def get_user_geo(user_id: int) -> Optional[dict]:
+    """Return the user's full geo profile for Selenium spoofing.
+
+    Keys: latitude, longitude (floats or None), timezone, locale, city, country.
+    Returns None only if the user row is missing.
+    """
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT latitude, longitude, timezone, locale, city, country FROM users WHERE id = %s",
+            (user_id,),
+        )
+        row = cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get user geo for user_id {user_id} | Error: {err}")
+        row = None
+    finally:
+        cursor.close()
+        connection.close()
+    if not row:
+        return None
+    return {
+        "latitude": float(row[0]) if row[0] is not None else None,
+        "longitude": float(row[1]) if row[1] is not None else None,
+        "timezone": row[2],
+        "locale": row[3],
+        "city": row[4],
+        "country": row[5],
+    }
+
+
+def update_user_location(user_id: int, latitude: float, longitude: float,
+                         city: Optional[str] = None, country: Optional[str] = None,
+                         locale: Optional[str] = None, timezone: Optional[str] = None,
+                         source: str = "manual") -> bool:
+    """Persist the user's location. timezone is updated only when provided so the
+    user's display-timezone preference is preserved unless autocapture supplies one."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        if timezone:
+            cursor.execute(
+                "UPDATE users SET latitude=%s, longitude=%s, city=%s, country=%s, "
+                "locale=%s, timezone=%s, location_source=%s WHERE id=%s",
+                (latitude, longitude, city, country, locale, timezone, source, user_id),
+            )
+        else:
+            cursor.execute(
+                "UPDATE users SET latitude=%s, longitude=%s, city=%s, country=%s, "
+                "locale=%s, location_source=%s WHERE id=%s",
+                (latitude, longitude, city, country, locale, source, user_id),
+            )
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update location for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_user_timezone(user_id: int) -> str:
     """Return the IANA timezone string for the user, defaulting to UTC."""
     connection = get_db_connection()

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -91,13 +91,29 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
         _wait_for_selenium_ready(SELENIUM_HUB_HOST, SELENIUM_HUB_PORT)
         remote_url = f"http://{SELENIUM_HUB_HOST}:{SELENIUM_HUB_PORT}/wd/hub"
 
+    # Per-user geo profile: make the browser's reported location/timezone/locale match
+    # where the user normally logs in, to reduce LinkedIn "new location" challenges.
+    user_timezone = TZ
+    user_locale = "en-US"
+    if user_id is not None:
+        from cqc_lem.utilities.db import get_user_geo
+        geo = get_user_geo(user_id)
+        if geo:
+            if lat is None and geo.get("latitude") is not None:
+                lat, lng = geo["latitude"], geo["longitude"]
+            if geo.get("timezone"):
+                user_timezone = geo["timezone"]
+            if geo.get("locale"):
+                user_locale = geo["locale"]
+
     options = getBaseOptions()
     options.add_argument("--ignore-ssl-errors=yes")
     options.add_argument("--ignore-certificate-errors")
+    options.add_argument(f"--lang={user_locale}")
     if headless:
         options = add_headless_options(options)
 
-    options.set_capability("se:timeZone", TZ)
+    options.set_capability("se:timeZone", user_timezone)
     options.set_capability("se:screenResolution", "1920x1080")
     options.set_capability("se:name", f"CQC_LEM ({session_name})")
 
@@ -105,17 +121,19 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
     driver.set_window_size(1920, 1080)
 
     if coordinates is None:
-        if lat is None and user_id is not None:
-            from cqc_lem.utilities.db import get_user_location
-            location = get_user_location(user_id)
-            if location:
-                lat, lng = location
         coordinates = {
             "latitude": lat if lat is not None else 30.3321,
             "longitude": lng if lng is not None else -81.6556,
             "accuracy": 100,
         }
+    # Apply geo, timezone and locale overrides at the CDP layer so JS fingerprint
+    # signals (geolocation API, Intl/Date timezone, navigator.language) are consistent.
     driver.execute_cdp_cmd("Emulation.setGeolocationOverride", coordinates)
+    try:
+        driver.execute_cdp_cmd("Emulation.setTimezoneOverride", {"timezoneId": user_timezone})
+        driver.execute_cdp_cmd("Emulation.setLocaleOverride", {"locale": user_locale})
+    except Exception as e:
+        myprint(f"Could not apply timezone/locale override | Error: {e}")
 
     return driver
 
@@ -362,13 +380,13 @@ def get_driver_wait(driver, wait_time: int = None):
                          ])
 
 
-def get_driver_wait_pair(headless=False, session_name: str = "ChromeTests", max_retry=3, coordinates: dict = None):
-    # TODO: Get the coordinates from the user's entry in the database for methods calling
-
-    # Create the driver
+def get_driver_wait_pair(headless=False, session_name: str = "ChromeTests", max_retry=3, coordinates: dict = None,
+                         user_id: int = None):
+    # Create the driver. Passing user_id applies that user's geo/timezone/locale spoofing.
     for attempt in range(max_retry):
         try:
-            driver = get_docker_driver(headless=headless, session_name=session_name, coordinates=coordinates)
+            driver = get_docker_driver(headless=headless, session_name=session_name, coordinates=coordinates,
+                                       user_id=user_id)
             break  # Exit the loop if successful
         except SessionNotCreatedException as e:
             if attempt == max_retry - 1:

--- a/tests/unit/api/test_api_location.py
+++ b/tests/unit/api/test_api_location.py
@@ -1,0 +1,119 @@
+"""Unit tests for the /api/user/location endpoints (get / put / autocapture)."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_SESSION = "tok_test"
+_USER_ID = 42
+
+
+class TestGetLocation:
+    def test_returns_geo(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.get_user_geo", return_value={"latitude": 1.0, "longitude": 2.0}):
+            resp = client.get(f"/api/user/location?session_token={_SESSION}")
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["latitude"] == 1.0
+
+    def test_401_invalid_session(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.get("/api/user/location?session_token=bad")
+        assert resp.status_code == 401
+
+
+class TestPutLocation:
+    def test_updates_valid_location(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.update_user_location", return_value=True) as upd:
+            resp = client.put("/api/user/location", json={
+                "session_token": _SESSION, "latitude": 40.0, "longitude": -73.0,
+                "city": "NYC", "country": "US", "locale": "en-US",
+            })
+        assert resp.status_code == 200
+        assert upd.called
+
+    def test_rejects_out_of_range_coords(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID):
+            resp = client.put("/api/user/location", json={
+                "session_token": _SESSION, "latitude": 200.0, "longitude": 0.0,
+            })
+        assert resp.status_code == 422
+
+    def test_rejects_bad_country_code(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID):
+            resp = client.put("/api/user/location", json={
+                "session_token": _SESSION, "latitude": 1.0, "longitude": 2.0, "country": "USA",
+            })
+        assert resp.status_code == 422
+
+    def test_401_invalid_session(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.put("/api/user/location", json={
+                "session_token": "bad", "latitude": 1.0, "longitude": 2.0,
+            })
+        assert resp.status_code == 401
+
+
+class TestAutocaptureLocation:
+    def _ipapi_response(self):
+        m = MagicMock()
+        m.raise_for_status.return_value = None
+        m.json.return_value = {
+            "latitude": 40.71, "longitude": -74.0, "city": "New York",
+            "country_code": "US", "timezone": "America/New_York", "languages": "en-US,es",
+        }
+        return m
+
+    def test_captures_from_client_ip_header(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.update_user_location", return_value=True) as upd, \
+             patch("cqc_lem.api.main.requests.get", return_value=self._ipapi_response()) as rget:
+            resp = client.post(
+                "/api/user/location/autocapture",
+                json={"session_token": _SESSION},
+                headers={"CF-Connecting-IP": "203.0.113.7"},
+            )
+        assert resp.status_code == 200
+        assert "203.0.113.7" in rget.call_args[0][0]
+        # source must be ip_autocapture
+        assert upd.call_args.kwargs["source"] == "ip_autocapture"
+        assert resp.json()["detail"]["city"] == "New York"
+
+    def test_502_when_geolocation_fails(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.requests.get", side_effect=Exception("boom")):
+            resp = client.post(
+                "/api/user/location/autocapture",
+                json={"session_token": _SESSION},
+                headers={"X-Forwarded-For": "203.0.113.9"},
+            )
+        assert resp.status_code == 502
+
+    def test_401_invalid_session(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.post("/api/user/location/autocapture", json={"session_token": "bad"})
+        assert resp.status_code == 401

--- a/tests/unit/utilities/test_db_location.py
+++ b/tests/unit/utilities/test_db_location.py
@@ -1,0 +1,81 @@
+"""Unit tests for per-user location database functions."""
+
+import pytest
+import mysql.connector
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_GET_CONN = "cqc_lem.utilities.db.get_db_connection"
+
+
+class TestGetUserGeo:
+    def test_returns_full_geo_dict(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = (
+                30.3321, -81.6556, "America/New_York", "en-US", "Jacksonville", "US",
+            )
+            from cqc_lem.utilities.db import get_user_geo
+            result = get_user_geo(1)
+        assert result["latitude"] == pytest.approx(30.3321)
+        assert result["longitude"] == pytest.approx(-81.6556)
+        assert result["timezone"] == "America/New_York"
+        assert result["locale"] == "en-US"
+        assert result["city"] == "Jacksonville"
+        assert result["country"] == "US"
+
+    def test_returns_none_when_no_row(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = None
+            from cqc_lem.utilities.db import get_user_geo
+            assert get_user_geo(99) is None
+
+    def test_handles_null_latlng(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = (
+                None, None, "UTC", None, None, None,
+            )
+            from cqc_lem.utilities.db import get_user_geo
+            result = get_user_geo(2)
+        assert result["latitude"] is None
+        assert result["longitude"] is None
+        assert result["timezone"] == "UTC"
+
+    def test_returns_none_on_db_error(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("fail")
+            from cqc_lem.utilities.db import get_user_geo
+            assert get_user_geo(7) is None
+
+
+class TestUpdateUserLocation:
+    def test_update_without_timezone_omits_tz_column(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].rowcount = 1
+            from cqc_lem.utilities.db import update_user_location
+            result = update_user_location(3, 40.0, -73.0, city="NYC", country="US", locale="en-US")
+        assert result is True
+        sql = mock_database_connection["cursor"].execute.call_args[0][0]
+        assert "timezone" not in sql.lower()
+        assert "location_source" in sql.lower()
+        mock_database_connection["connection"].commit.assert_called_once()
+
+    def test_update_with_timezone_includes_tz_column(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].rowcount = 1
+            from cqc_lem.utilities.db import update_user_location
+            result = update_user_location(
+                3, 40.0, -73.0, city="NYC", country="US",
+                locale="en-US", timezone="America/New_York", source="ip_autocapture",
+            )
+        assert result is True
+        args = mock_database_connection["cursor"].execute.call_args[0]
+        assert "timezone" in args[0].lower()
+        assert "America/New_York" in args[1]
+        assert "ip_autocapture" in args[1]
+
+    def test_returns_false_on_db_error(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("fail")
+            from cqc_lem.utilities.db import update_user_location
+            assert update_user_location(3, 1.0, 2.0) is False

--- a/tests/unit/utilities/test_selenium_geo.py
+++ b/tests/unit/utilities/test_selenium_geo.py
@@ -1,0 +1,47 @@
+"""Unit tests for per-user geo/timezone/locale spoofing in get_docker_driver."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.selenium_util"
+
+
+def _run(user_id=None, geo=None, headless=False):
+    fake_driver = MagicMock()
+    cdp_calls = {}
+
+    def _cdp(cmd, params):
+        cdp_calls[cmd] = params
+
+    fake_driver.execute_cdp_cmd.side_effect = _cdp
+    with patch(f"{_MOD}._wait_for_selenium_ready"), \
+         patch(f"{_MOD}.DEVICE_FARM_PROJECT_ARN", None), \
+         patch(f"{_MOD}.TEST_GRID_PROJECT_ARN", None), \
+         patch(f"{_MOD}.webdriver.Remote", return_value=fake_driver), \
+         patch("cqc_lem.utilities.db.get_user_geo", return_value=geo):
+        from cqc_lem.utilities.selenium_util import get_docker_driver
+        get_docker_driver(headless=headless, user_id=user_id)
+    return cdp_calls
+
+
+class TestPerUserGeo:
+    def test_applies_user_geo_timezone_locale(self):
+        geo = {"latitude": 51.5, "longitude": -0.12, "timezone": "Europe/London",
+               "locale": "en-GB", "city": "London", "country": "GB"}
+        calls = _run(user_id=5, geo=geo)
+        assert calls["Emulation.setGeolocationOverride"]["latitude"] == pytest.approx(51.5)
+        assert calls["Emulation.setGeolocationOverride"]["longitude"] == pytest.approx(-0.12)
+        assert calls["Emulation.setTimezoneOverride"]["timezoneId"] == "Europe/London"
+        assert calls["Emulation.setLocaleOverride"]["locale"] == "en-GB"
+
+    def test_falls_back_to_default_when_no_user(self):
+        calls = _run(user_id=None, geo=None)
+        # Default Jacksonville coordinates when no per-user geo is available
+        assert calls["Emulation.setGeolocationOverride"]["latitude"] == pytest.approx(30.3321)
+        assert calls["Emulation.setLocaleOverride"]["locale"] == "en-US"
+
+    def test_user_without_stored_geo_uses_defaults(self):
+        calls = _run(user_id=7, geo=None)
+        assert calls["Emulation.setGeolocationOverride"]["latitude"] == pytest.approx(30.3321)


### PR DESCRIPTION
## Summary
LinkedIn flags automation logins that appear to come from a different geographic location than where the user normally signs in. The Selenium browser runs on the VPS, so its reported geolocation/timezone/locale didn't match the user. This adds per-user browser geo spoofing and a user **Login Location** field with IP auto-capture.

> **Scope decision:** browser-spoof-only for now (per user direction). Browser-level spoofing fixes fingerprint mismatch (geolocation API, `Intl`/timezone, `navigator.language`) but does **not** change the source IP — a per-user residential proxy / VPN egress is the planned follow-up if flags persist. Designed for SaaS scale.

## Changes
- **Dead-code fix (the important one):** `get_driver_wait_pair()` never passed `user_id` to `get_docker_driver()`, so the existing per-user geolocation override never ran — every session fell back to a hardcoded Jacksonville, FL. Thread `user_id` through the shared auth helper `get_current_profile()`, which covers all three automation tasks (`automate_commenting`, `automate_reply_commenting`, `automate_profile_viewer_engagement`) **and** their fan-out subtasks.
- **Per-user CDP overrides:** apply `Emulation.setTimezoneOverride` + `Emulation.setLocaleOverride` and `--lang`, alongside the existing geolocation override, using the user's stored geo.
- **User location field:**
  - `V31` migration — `city`, `country`, `locale`, `location_source` (lat/long from V18, timezone from V28 already existed).
  - `db.get_user_geo()` / `db.update_user_location()`.
  - `GET/PUT /user/location` and `POST /user/location/autocapture` — geolocates the caller's **real** IP from `CF-Connecting-IP`/`X-Forwarded-For` (app is behind the Cloudflare tunnel) via keyless ipapi.co.
  - Account page **"Login Location"** card with one-click "Use my current location".

## Review of the 3 failing automation tasks
All three obtain their driver+auth via the shared `get_current_profile` → `get_driver_wait_pair` → `login_to_linkedin`. A "suspicious location" challenge surfaces as a `TimeoutException`/`RuntimeError` that the per-task try/except turns into a soft-fail string (already logged via `log_error` → PostHog). Fixing geo at the shared helper addresses all three with one change. With the LinkedIn password now stored, the next barrier was exactly this location challenge.

## Testing
- 19 new unit tests (db location accessors, geo CDP wiring, the 3 endpoints incl. IP-header parsing + 502 fallback). Full unit suite: **742 passed**.
- UI `tsc -b` + `vite build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)