### PR TITLE
fix(api): never cache the SPA index.html shell

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1779,13 +1779,27 @@ async def assets_compat_redirect(request: Request, file_name: Optional[str] = No
 if os.path.isdir(_ui_dist):
     _spa_index = os.path.join(_ui_dist, "index.html")
 
+    class _ImmutableStaticFiles(StaticFiles):
+        # Vite emits content-hashed filenames, so assets can be cached forever.
+        async def get_response(self, path, scope):
+            response = await super().get_response(path, scope)
+            response.headers["Cache-Control"] = "public, max-age=31536000, immutable"
+            return response
+
     # Serve static assets (JS/CSS/icons) from the dist root
-    app.mount("/assets", StaticFiles(directory=os.path.join(_ui_dist, "assets")), name="spa-assets")
+    app.mount("/assets", _ImmutableStaticFiles(directory=os.path.join(_ui_dist, "assets")), name="spa-assets")
 
     @app.get("/{full_path:path}", response_class=HTMLResponse, include_in_schema=False)
     def serve_spa(full_path: str):
         with open(_spa_index) as fh:
-            return HTMLResponse(content=fh.read())
+            # The HTML shell references hashed asset filenames, so it must NEVER be
+            # cached by browsers or the CDN — otherwise a stale shell points at an
+            # old bundle after every deploy. (Cloudflare must respect this; if a
+            # "Cache Everything" rule overrides it, the rule needs an HTML bypass.)
+            return HTMLResponse(content=fh.read(), headers={
+                "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
+                "Pragma": "no-cache",
+            })
 
 
 def send_bytes_range_requests(


### PR DESCRIPTION
## Problem
Deploys were shipping fine to the container, but users kept seeing **old** UI (no video/carousel previews, no geo location card) after each release.

Root cause: Cloudflare was caching the SPA **`index.html` shell** (`cf-cache-status: HIT`, ~40min age). The shell references content-hashed asset filenames (`/assets/index-<hash>.js`), so a stale shell points at the *previous* bundle. The container served the correct new bundle; the CDN served stale HTML pointing at the old one.

## Fix
- `index.html` (serve_spa) now returns `Cache-Control: no-store, no-cache, must-revalidate, max-age=0` + `Pragma: no-cache` — the shell must always revalidate.
- `/assets/*` (content-hashed, immutable) now return `Cache-Control: public, max-age=31536000, immutable` — safe to cache forever since the filename changes per build.

## Note on Cloudflare
If a "Cache Everything" cache/page rule is configured on the zone, it can override origin `no-store` — in that case the rule needs an HTML/`/` bypass, or set Edge Cache TTL to "Respect existing headers". A one-time **cache purge** is needed for the currently-cached shell.

## Testing
`serve_spa` / the `/assets` mount are conditionally registered only when a built `dist/` exists (absent in the unit env), so this is verified live post-deploy (check response headers on `/` and `/assets/*.js`). codecov is not a required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)