### PR TITLE
ci: auto-trigger build on release + purge Cloudflare cache after deploy

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -61,9 +61,12 @@ jobs:
     name: Deploy to Hostinger VPS
     needs: build-and-push
     runs-on: ubuntu-latest
-    # Protected environment — configure required reviewers in repo settings to
-    # require manual approval before the live box is updated.
+    # Protected environment. The required-reviewer gate was removed so green
+    # releases auto-deploy; re-add reviewers in repo settings to restore it.
     environment: production
+    env:
+      CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+      CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
     steps:
       - name: Deploy over SSH
         uses: appleboy/ssh-action@v1
@@ -79,3 +82,19 @@ jobs:
         env:
           GHCR_USER: ${{ github.actor }}
           GHCR_PAT: ${{ secrets.GHCR_PAT }}
+
+      # Purge the CDN so users get the new index.html shell immediately instead
+      # of a cached one pointing at the previous (hashed) bundle. Skips cleanly
+      # if the Cloudflare secrets aren't configured.
+      - name: Purge Cloudflare cache
+        if: ${{ env.CF_API_TOKEN != '' && env.CF_ZONE_ID != '' }}
+        run: |
+          resp=$(curl -sf -X POST \
+            "https://api.cloudflare.com/client/v4/zones/${CF_ZONE_ID}/purge_cache" \
+            -H "Authorization: Bearer ${CF_API_TOKEN}" \
+            -H "Content-Type: application/json" \
+            --data '{"purge_everything":true}')
+          echo "$resp"
+          echo "$resp" | grep -q '"success":true' \
+            && echo "Cloudflare cache purged" \
+            || { echo "Cloudflare purge failed"; exit 1; }

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   release-please:
@@ -19,8 +20,21 @@ jobs:
         with:
           release-type: python
           # Manages the version in pyproject.toml + maintains CHANGELOG.md.
-          # Merging the release PR creates a tag + GitHub Release (vX.Y.Z),
-          # which triggers build-and-push.yml and deploy-vps.yml.
+          # Merging the release PR creates a tag + GitHub Release (vX.Y.Z).
+
+      # The GitHub Release is published by GITHUB_TOKEN, which (by design) does
+      # NOT trigger build-and-push.yml's `release: published` event. Explicitly
+      # dispatch the build so a merged release auto-builds + auto-deploys.
+      # If GITHUB_TOKEN can't dispatch across the boundary, set RELEASE_DISPATCH_TOKEN
+      # (a PAT with actions:write) and it will be used instead.
+      - name: Trigger build & deploy for the new release
+        if: ${{ steps.release.outputs.release_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-and-push.yml \
+            --repo "${{ github.repository }}" \
+            --ref "${{ steps.release.outputs.tag_name }}"
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}


### PR DESCRIPTION
## Why
Releases were deploying to the container correctly, but two gaps stopped them from reaching users hands-free:
1. The GitHub Release is published by `GITHUB_TOKEN`, which (by design) does **not** fire `build-and-push.yml`'s `release: published` event — so the build had to be triggered manually each time.
2. After deploy, Cloudflare kept serving a **stale `index.html` shell** pointing at the previous bundle hash.

Plus the manual production approval gate (now removed in repo settings) stalled every release.

## Changes
- **`release-please.yml`**: on `release_created`, explicitly `gh workflow run build-and-push.yml --ref <tag>`. Uses `RELEASE_DISPATCH_TOKEN` (PAT, actions:write) if set, else `GITHUB_TOKEN`. Adds `actions: write` permission.
- **`build-and-push.yml`**: after the SSH deploy, **purge the Cloudflare cache** (`purge_everything`). Gated on `CF_API_TOKEN` + `CF_ZONE_ID` env so it **skips cleanly** when the secrets aren't set.

## Action required to fully enable
Add repo secrets:
- `CF_API_TOKEN` — Cloudflare token scoped to **Zone → Cache Purge** for the zone.
- `CF_ZONE_ID` — the zone ID.
- *(optional)* `RELEASE_DISPATCH_TOKEN` — a PAT with `actions:write` if `GITHUB_TOKEN` can't dispatch the build across the token boundary.

Net effect once merged + secrets set: a green release → auto build → auto deploy (no gate) → auto CDN purge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)