### PR TITLE
feat(api): admin test-run endpoints for comment/reply/DM + Postman & VNC guide

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -115,7 +115,12 @@ services:
 
   selenium-chrome:
     # already restart: unless-stopped + 2cpu/4g in the base file
-    ports: !reset []
+    # Bind noVNC (7900) to loopback only so the live browser can be watched via an
+    # SSH tunnel (ssh -L 7900:localhost:7900 …) without exposing it publicly. The
+    # Selenium hub (4444) stays internal to the compose network. For browser-based
+    # access instead, add a vnc.<domain> public hostname in the Cloudflare Zero
+    # Trust dashboard pointing at http://selenium-chrome:7900 (gate with Access).
+    ports: !override ["127.0.0.1:7900:7900"]
 
   litellm:
     # already restart: unless-stopped in the base file

--- a/docs/TESTING_ENGAGEMENT_API.md
+++ b/docs/TESTING_ENGAGEMENT_API.md
@@ -1,0 +1,162 @@
+# Testing LinkedIn Engagement (Comment / Reply / DM) via the API
+
+This guide shows how to **trigger a single engagement task on demand** and
+**watch the Chrome browser do it live** over VNC. It's meant for manual
+verification — e.g. "does commenting actually work for my account now?"
+
+---
+
+## 1. URLs at a glance
+
+| What | URL |
+|---|---|
+| App (SPA + API) | `https://lem.christopherqueenconsulting.com` |
+| API base prefix | `https://lem.christopherqueenconsulting.com/api` |
+| Interactive API docs (Swagger) | `https://lem.christopherqueenconsulting.com/docs` |
+| OpenAPI schema (import into Postman) | `https://lem.christopherqueenconsulting.com/openapi.json` |
+| Live browser (VNC, via SSH tunnel) | `http://localhost:7900/?autoconnect=1` (after tunnel — see §5) |
+
+---
+
+## 2. Authentication — two headers
+
+Engagement test endpoints live under `/api/admin/*` and require **both**:
+
+| Header | Value | Where to find it (on the VPS) |
+|---|---|---|
+| `Authorization` | `Bearer <API_ACCESS_TOKEN>` | `API_ACCESS_TOKENS=` in `/opt/lem/.env` (comma-separated; use any one) |
+| `X-Admin-Secret` | `<ADMIN_SECRET>` | `ADMIN_SECRET=` in `/opt/lem/.env` |
+
+- The **bearer token** gates every `/api/*` route (except auth/webhook/assets).
+- The **admin secret** additionally gates the `/api/admin/*` endpoints.
+
+> Get the values: `sudo grep -E '^API_ACCESS_TOKENS=|^ADMIN_SECRET=' /opt/lem/.env`
+
+---
+
+## 3. The test-run endpoints
+
+All are `POST` with a JSON body and return a Celery `task_id` you can poll.
+Your only LinkedIn account is **`user_id = 1`** (christopher.queen@gmail.com).
+
+### Comment on feed posts
+```
+POST /api/admin/test/comment
+{ "user_id": 1, "loop_for_duration": 300 }
+```
+Runs `automate_commenting` — the bot scrolls its feed and comments on posts.
+
+### Reply to comments on one of your posts
+```
+POST /api/admin/test/reply
+{ "post_id": 42, "loop_for_duration": 300, "future_forward": 0 }
+```
+Runs `automate_reply_commenting` for that post (user is derived from the post).
+
+### Appreciation DMs to recent profile viewers
+```
+POST /api/admin/test/dm
+{ "user_id": 1, "loop_for_duration": 300 }
+```
+Runs `automate_appreciation_dms_for_user` — DMs people who viewed your profile.
+
+### Send ONE direct DM (most deterministic to watch)
+```
+POST /api/admin/test/dm-direct
+{ "user_id": 1,
+  "profile_url": "https://www.linkedin.com/in/some-person/",
+  "message": "Hi — testing my outreach automation, please ignore." }
+```
+Runs `send_private_dm`. Best for watching the messaging flow start-to-finish.
+
+### Poll a task's status
+```
+GET /api/admin/task-status/{task_id}
+```
+Returns `{ "state": "PENDING|STARTED|SUCCESS|FAILURE", "result": "..." }`.
+
+`loop_for_duration` is in **seconds** and defaults to **300** so a test run
+ends on its own instead of running for an hour.
+
+---
+
+## 4. Postman setup
+
+### a) Create an Environment
+Postman → **Environments → +**. Name it `LEM Prod` and add variables:
+
+| Variable | Initial value |
+|---|---|
+| `base_url` | `https://lem.christopherqueenconsulting.com` |
+| `api_token` | *(your API_ACCESS_TOKENS value)* |
+| `admin_secret` | *(your ADMIN_SECRET value)* |
+| `user_id` | `1` |
+
+Mark `api_token` and `admin_secret` as **secret** type. Select this
+environment in the top-right dropdown.
+
+### b) Import the ready-made collection
+Import `docs/postman/LEM_Engagement_Tests.postman_collection.json` (in this
+repo) — it already contains all five requests with the two auth headers wired
+to `{{api_token}}` / `{{admin_secret}}` and bodies using `{{user_id}}`.
+
+**Or** import live from `…/openapi.json` (every endpoint, no bodies/headers
+pre-filled).
+
+### c) Per request, confirm these headers
+```
+Authorization: Bearer {{api_token}}
+X-Admin-Secret: {{admin_secret}}
+Content-Type: application/json
+```
+
+### d) Run it
+1. Open the **VNC** first (§5) so you can watch.
+2. Send e.g. **DM (direct)**. You'll get `{ "detail": { "task_id": "…" } }`.
+3. Switch to the VNC tab — within a few seconds Chrome opens LinkedIn, logs in
+   (or reuses cookies), navigates, and performs the action.
+4. Poll **Task status** with the returned `task_id` until `SUCCESS`/`FAILURE`.
+
+---
+
+## 5. Watching it live in VNC
+
+The Selenium Chrome container runs a noVNC server on port **7900**. In prod it's
+bound to the VPS **loopback only** (not public), so reach it through an SSH
+tunnel from your laptop:
+
+```bash
+ssh -L 7900:localhost:7900 <your-vps-user>@<your-vps-host>
+```
+Leave that session open, then browse to:
+```
+http://localhost:7900/?autoconnect=1
+```
+noVNC password: **`secret`** (Selenium standalone default).
+
+You'll see the live Chrome session. Trigger a test request (§4) and watch the
+automation drive the browser in real time.
+
+### Optional: browser access without SSH
+Add a public hostname in the **Cloudflare Zero Trust dashboard** →
+Tunnels → your tunnel → Public Hostname:
+`vnc.christopherqueenconsulting.com` → `http://selenium-chrome:7900`, and put a
+**Cloudflare Access** policy in front of it (email allow-list). Then just open
+that URL — no SSH needed. (Keep it gated; never expose VNC unauthenticated.)
+
+---
+
+## 6. Troubleshooting
+
+- **403 Forbidden** → missing/wrong `X-Admin-Secret`.
+- **401 Unauthorized** → missing/wrong `Authorization: Bearer` token.
+- **Task goes to FAILURE / nothing happens in VNC** → almost always a LinkedIn
+  login problem (no stored password/cookies, or a "new location" security
+  challenge). Set your **Login Location** in Account first
+  (Account → Login Location → "Use my current location") and ensure the LinkedIn
+  password is saved.
+- **VNC shows a blank/again-login screen** → the session may have ended
+  (`loop_for_duration` elapsed). Re-trigger and watch immediately.
+- **Nothing on `localhost:7900`** → the SSH tunnel isn't up, or this change
+  (loopback port bind) hasn't deployed yet — confirm the running release ≥ the
+  one that adds `127.0.0.1:7900:7900`.

--- a/docs/postman/LEM_Engagement_Tests.postman_collection.json
+++ b/docs/postman/LEM_Engagement_Tests.postman_collection.json
@@ -1,0 +1,88 @@
+{
+  "info": {
+    "name": "LEM Engagement Tests",
+    "description": "Trigger comment/reply/DM automation on demand and poll task status. Requires the LEM Prod environment (base_url, api_token, admin_secret, user_id). See docs/TESTING_ENGAGEMENT_API.md.",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "auth": {
+    "type": "bearer",
+    "bearer": [{ "key": "token", "value": "{{api_token}}", "type": "string" }]
+  },
+  "variable": [],
+  "item": [
+    {
+      "name": "Comment on feed",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "X-Admin-Secret", "value": "{{admin_secret}}" }
+        ],
+        "url": { "raw": "{{base_url}}/api/admin/test/comment", "host": ["{{base_url}}"], "path": ["api", "admin", "test", "comment"] },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"user_id\": {{user_id}},\n  \"loop_for_duration\": 300\n}"
+        }
+      }
+    },
+    {
+      "name": "Reply to comments on a post",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "X-Admin-Secret", "value": "{{admin_secret}}" }
+        ],
+        "url": { "raw": "{{base_url}}/api/admin/test/reply", "host": ["{{base_url}}"], "path": ["api", "admin", "test", "reply"] },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"post_id\": 42,\n  \"loop_for_duration\": 300,\n  \"future_forward\": 0\n}"
+        }
+      }
+    },
+    {
+      "name": "Appreciation DMs to profile viewers",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "X-Admin-Secret", "value": "{{admin_secret}}" }
+        ],
+        "url": { "raw": "{{base_url}}/api/admin/test/dm", "host": ["{{base_url}}"], "path": ["api", "admin", "test", "dm"] },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"user_id\": {{user_id}},\n  \"loop_for_duration\": 300\n}"
+        }
+      }
+    },
+    {
+      "name": "DM (direct, single profile)",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Content-Type", "value": "application/json" },
+          { "key": "X-Admin-Secret", "value": "{{admin_secret}}" }
+        ],
+        "url": { "raw": "{{base_url}}/api/admin/test/dm-direct", "host": ["{{base_url}}"], "path": ["api", "admin", "test", "dm-direct"] },
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"user_id\": {{user_id}},\n  \"profile_url\": \"https://www.linkedin.com/in/some-person/\",\n  \"message\": \"Hi — testing my outreach automation, please ignore.\"\n}"
+        }
+      }
+    },
+    {
+      "name": "Task status",
+      "request": {
+        "method": "GET",
+        "header": [
+          { "key": "X-Admin-Secret", "value": "{{admin_secret}}" }
+        ],
+        "url": {
+          "raw": "{{base_url}}/api/admin/task-status/{{task_id}}",
+          "host": ["{{base_url}}"],
+          "path": ["api", "admin", "task-status", "{{task_id}}"]
+        }
+      }
+    }
+  ]
+}

--- a/docs/postman/LEM_Prod.postman_environment.json
+++ b/docs/postman/LEM_Prod.postman_environment.json
@@ -1,0 +1,11 @@
+{
+  "name": "LEM Prod",
+  "values": [
+    { "key": "base_url", "value": "https://lem.christopherqueenconsulting.com", "type": "default", "enabled": true },
+    { "key": "api_token", "value": "REPLACE_WITH_API_ACCESS_TOKEN", "type": "secret", "enabled": true },
+    { "key": "admin_secret", "value": "REPLACE_WITH_ADMIN_SECRET", "type": "secret", "enabled": true },
+    { "key": "user_id", "value": "1", "type": "default", "enabled": true },
+    { "key": "task_id", "value": "", "type": "default", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -9,7 +9,11 @@ from urllib.parse import urlparse, urlunparse
 
 from cqc_lem import assets_dir
 from cqc_lem.app.aws_test_celery_task import test_get_my_profile
-from cqc_lem.app.run_automation import automate_invites_to_company_page_for_user, automate_reply_commenting
+from cqc_lem.app.run_automation import (
+    automate_invites_to_company_page_for_user, automate_reply_commenting,
+    automate_commenting, automate_appreciation_dms_for_user,
+    automate_profile_viewer_engagement, send_private_dm,
+)
 from celery import chain as celery_chain
 from cqc_lem.app.run_content_plan import auto_create_weekly_content, plan_content_for_user
 from cqc_lem.utilities.db import (
@@ -283,6 +287,28 @@ class AdminRegenerateCarouselRequest(BaseModel):
 class AdminRegenerateVideoRequest(BaseModel):
     post_id: int
     user_id: int
+
+
+class AdminTestCommentRequest(BaseModel):
+    user_id: int
+    loop_for_duration: int = 300  # seconds; short window so a test run ends on its own
+
+
+class AdminTestReplyRequest(BaseModel):
+    post_id: int
+    loop_for_duration: int = 300
+    future_forward: int = 0
+
+
+class AdminTestDMRequest(BaseModel):
+    user_id: int
+    loop_for_duration: int = 300
+
+
+class AdminTestDirectDMRequest(BaseModel):
+    user_id: int
+    profile_url: str
+    message: str
 
 
 class VariantCombo(BaseModel):
@@ -1670,6 +1696,119 @@ def admin_generate_media_variants(
     myprint(f"admin/generate-media-variants: batch={payload['batch_id']} "
             f"variants={len(payload['variants'])} est=${payload['total_estimated_cost_usd']}")
     return ResponseModel(status_code=200, detail=payload)
+
+
+# ---------------------------------------------------------------------------
+# Admin test-run endpoints — kick a single engagement task on the selenium
+# worker so you can watch it live in the Chrome VNC. All require X-Admin-Secret.
+# ---------------------------------------------------------------------------
+
+@router.post("/admin/test/comment", responses={
+    200: {"description": "Commenting test run queued"},
+    403: {"description": "Forbidden"},
+})
+def admin_test_comment(
+    request: AdminTestCommentRequest,
+    x_admin_secret: Optional[str] = Header(default=None),
+) -> ResponseModel:
+    """Run the feed-commenting automation for a user (comments on posts in their feed)."""
+    _require_admin(x_admin_secret)
+    result = automate_commenting.apply_async(kwargs={
+        "user_id": request.user_id,
+        "loop_for_duration": request.loop_for_duration,
+    }, queue="selenium")
+    myprint(f"admin/test/comment: queued task={result.id} user_id={request.user_id}")
+    return ResponseModel(status_code=200, detail={
+        "task_id": result.id, "task": "automate_commenting", "user_id": request.user_id,
+    })
+
+
+@router.post("/admin/test/reply", responses={
+    200: {"description": "Reply test run queued"},
+    403: {"description": "Forbidden"},
+})
+def admin_test_reply(
+    request: AdminTestReplyRequest,
+    x_admin_secret: Optional[str] = Header(default=None),
+) -> ResponseModel:
+    """Run the reply-to-comments automation for a specific (already-posted) post."""
+    _require_admin(x_admin_secret)
+    user_id = get_post_user_id(request.post_id)
+    if not user_id:
+        raise HTTPException(status_code=404, detail="User for post not found")
+    result = automate_reply_commenting.apply_async(kwargs={
+        "user_id": user_id,
+        "post_id": request.post_id,
+        "loop_for_duration": request.loop_for_duration,
+        "future_forward": request.future_forward,
+    }, queue="selenium")
+    myprint(f"admin/test/reply: queued task={result.id} post_id={request.post_id}")
+    return ResponseModel(status_code=200, detail={
+        "task_id": result.id, "task": "automate_reply_commenting",
+        "post_id": request.post_id, "user_id": user_id,
+    })
+
+
+@router.post("/admin/test/dm", responses={
+    200: {"description": "DM test run queued"},
+    403: {"description": "Forbidden"},
+})
+def admin_test_dm(
+    request: AdminTestDMRequest,
+    x_admin_secret: Optional[str] = Header(default=None),
+) -> ResponseModel:
+    """Run the appreciation-DM automation (DMs people who recently viewed the profile)."""
+    _require_admin(x_admin_secret)
+    result = automate_appreciation_dms_for_user.apply_async(kwargs={
+        "user_id": request.user_id,
+        "loop_for_duration": request.loop_for_duration,
+    }, queue="selenium")
+    myprint(f"admin/test/dm: queued task={result.id} user_id={request.user_id}")
+    return ResponseModel(status_code=200, detail={
+        "task_id": result.id, "task": "automate_appreciation_dms_for_user",
+        "user_id": request.user_id,
+    })
+
+
+@router.post("/admin/test/dm-direct", responses={
+    200: {"description": "Direct DM queued"},
+    403: {"description": "Forbidden"},
+})
+def admin_test_dm_direct(
+    request: AdminTestDirectDMRequest,
+    x_admin_secret: Optional[str] = Header(default=None),
+) -> ResponseModel:
+    """Send ONE direct DM to a specific profile URL — the most deterministic way to
+    watch the messaging flow end-to-end in the VNC."""
+    _require_admin(x_admin_secret)
+    result = send_private_dm.apply_async(kwargs={
+        "user_id": request.user_id,
+        "profile_url": request.profile_url,
+        "message": request.message,
+    }, queue="selenium")
+    myprint(f"admin/test/dm-direct: queued task={result.id} user_id={request.user_id} -> {request.profile_url}")
+    return ResponseModel(status_code=200, detail={
+        "task_id": result.id, "task": "send_private_dm",
+        "user_id": request.user_id, "profile_url": request.profile_url,
+    })
+
+
+@router.get("/admin/task-status/{task_id}", responses={
+    200: {"description": "Task status"},
+    403: {"description": "Forbidden"},
+})
+def admin_task_status(
+    task_id: str,
+    x_admin_secret: Optional[str] = Header(default=None),
+) -> ResponseModel:
+    """Poll a queued test task's state (PENDING/STARTED/SUCCESS/FAILURE)."""
+    _require_admin(x_admin_secret)
+    from cqc_lem.app.my_celery import app as celery_app
+    res = celery_app.AsyncResult(task_id)
+    detail = {"task_id": task_id, "state": res.state}
+    if res.ready():
+        detail["result"] = str(res.result)[:500]
+    return ResponseModel(status_code=200, detail=detail)
 
 
 @router.get("/carousel-templates", responses={200: {"description": "Available carousel templates"}})

--- a/tests/unit/api/test_admin_engagement_test_runs.py
+++ b/tests/unit/api/test_admin_engagement_test_runs.py
@@ -1,0 +1,124 @@
+"""Unit tests for the /api/admin/test/* engagement test-run endpoints."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_SECRET = "s3cret"
+
+
+def _async_result(task_id="task-123"):
+    m = MagicMock()
+    m.id = task_id
+    return m
+
+
+class TestComment:
+    def test_forbidden_without_secret(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET):
+            r = client.post("/api/admin/test/comment", json={"user_id": 1})
+        assert r.status_code == 403
+
+    def test_queues_task(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
+             patch("cqc_lem.api.main.automate_commenting.apply_async", return_value=_async_result()) as t:
+            r = client.post("/api/admin/test/comment", json={"user_id": 7},
+                            headers={"x-admin-secret": _SECRET})
+        assert r.status_code == 200
+        assert r.json()["detail"]["task_id"] == "task-123"
+        assert t.call_args.kwargs["kwargs"]["user_id"] == 7
+
+
+class TestReply:
+    def test_404_when_post_user_missing(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=None):
+            r = client.post("/api/admin/test/reply", json={"post_id": 99},
+                            headers={"x-admin-secret": _SECRET})
+        assert r.status_code == 404
+
+    def test_queues_task(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=5), \
+             patch("cqc_lem.api.main.automate_reply_commenting.apply_async", return_value=_async_result()) as t:
+            r = client.post("/api/admin/test/reply", json={"post_id": 12},
+                            headers={"x-admin-secret": _SECRET})
+        assert r.status_code == 200
+        assert t.call_args.kwargs["kwargs"]["post_id"] == 12
+        assert r.json()["detail"]["user_id"] == 5
+
+
+class TestDM:
+    def test_forbidden_without_secret(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET):
+            r = client.post("/api/admin/test/dm", json={"user_id": 1})
+        assert r.status_code == 403
+
+    def test_queues_appreciation_dm(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
+             patch("cqc_lem.api.main.automate_appreciation_dms_for_user.apply_async",
+                   return_value=_async_result()) as t:
+            r = client.post("/api/admin/test/dm", json={"user_id": 3},
+                            headers={"x-admin-secret": _SECRET})
+        assert r.status_code == 200
+        assert t.call_args.kwargs["kwargs"]["user_id"] == 3
+
+
+class TestDirectDM:
+    def test_queues_direct_dm(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
+             patch("cqc_lem.api.main.send_private_dm.apply_async", return_value=_async_result()) as t:
+            r = client.post("/api/admin/test/dm-direct",
+                            json={"user_id": 1, "profile_url": "https://linkedin.com/in/x",
+                                  "message": "Hi there"},
+                            headers={"x-admin-secret": _SECRET})
+        assert r.status_code == 200
+        assert t.call_args.kwargs["kwargs"]["profile_url"] == "https://linkedin.com/in/x"
+        assert t.call_args.kwargs["kwargs"]["message"] == "Hi there"
+
+    def test_forbidden_without_secret(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET):
+            r = client.post("/api/admin/test/dm-direct",
+                            json={"user_id": 1, "profile_url": "u", "message": "m"})
+        assert r.status_code == 403
+
+
+class TestTaskStatus:
+    def test_returns_state(self, client):
+        res = MagicMock()
+        res.state = "SUCCESS"
+        res.ready.return_value = True
+        res.result = "done"
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
+             patch("cqc_lem.app.my_celery.app.AsyncResult", return_value=res):
+            r = client.get("/api/admin/task-status/task-123",
+                           headers={"x-admin-secret": _SECRET})
+        assert r.status_code == 200
+        assert r.json()["detail"]["state"] == "SUCCESS"
+        assert r.json()["detail"]["result"] == "done"
+
+    def test_forbidden_without_secret(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET):
+            r = client.get("/api/admin/task-status/task-123")
+        assert r.status_code == 403


### PR DESCRIPTION
## Summary
Adds a way to **trigger comment/reply/DM automation on demand via the API** and **watch it live in the Chrome VNC**, plus a Postman + VNC setup guide.

## New endpoints (admin-guarded: `X-Admin-Secret` + bearer token)
| Endpoint | Task | Notes |
|---|---|---|
| `POST /api/admin/test/comment` | `automate_commenting` | comments on the user's feed |
| `POST /api/admin/test/reply` | `automate_reply_commenting` | replies to comments on a post |
| `POST /api/admin/test/dm` | `automate_appreciation_dms_for_user` | DMs recent profile viewers |
| `POST /api/admin/test/dm-direct` | `send_private_dm` | one DM to a given profile — most watchable |
| `GET /api/admin/task-status/{id}` | — | poll PENDING/STARTED/SUCCESS/FAILURE |

Each returns the Celery `task_id`. `loop_for_duration` defaults to **300s** so a test run self-terminates.

## VNC
Prod previously stripped all selenium-chrome ports (`ports: !reset []`). Now binds **noVNC `7900` to the VPS loopback** (`127.0.0.1:7900:7900`, same pattern as MySQL) so the live browser is reachable via an SSH tunnel without public exposure. The guide also documents an optional Cloudflare-Access-gated `vnc.<domain>` public hostname.

## Docs
- `docs/TESTING_ENGAGEMENT_API.md` — URLs (app/API/Swagger/VNC), the two auth headers + where to find them, every endpoint with example bodies, Postman setup, the SSH-tunnel VNC steps, troubleshooting.
- `docs/postman/LEM_Engagement_Tests.postman_collection.json` — importable collection (all 5 requests, headers pre-wired to env vars).
- `docs/postman/LEM_Prod.postman_environment.json` — environment template.

## Testing
10 new unit tests (403 without secret, task queued with correct kwargs, 404 for missing post user, task-status). Full API unit suite: **160 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)