### PR TITLE
feat(api): structured inputs + dual-auth on engagement test endpoints; doc/Postman polish

### DIFF
--- a/docs/TESTING_ENGAGEMENT_API.md
+++ b/docs/TESTING_ENGAGEMENT_API.md
@@ -1,8 +1,8 @@
 # Testing LinkedIn Engagement (Comment / Reply / DM) via the API
 
 This guide shows how to **trigger a single engagement task on demand** and
-**watch the Chrome browser do it live** over VNC. It's meant for manual
-verification — e.g. "does commenting actually work for my account now?"
+**watch the Chrome browser do it live** over VNC — e.g. "does commenting actually
+work for my account now?"
 
 ---
 
@@ -10,153 +10,123 @@ verification — e.g. "does commenting actually work for my account now?"
 
 | What | URL |
 |---|---|
-| App (SPA + API) | `https://lem.christopherqueenconsulting.com` |
-| API base prefix | `https://lem.christopherqueenconsulting.com/api` |
-| Interactive API docs (Swagger) | `https://lem.christopherqueenconsulting.com/docs` |
-| OpenAPI schema (import into Postman) | `https://lem.christopherqueenconsulting.com/openapi.json` |
-| Live browser (VNC, via SSH tunnel) | `http://localhost:7900/?autoconnect=1` (after tunnel — see §5) |
+| App (SPA + API) | <https://lem.christopherqueenconsulting.com> |
+| API base prefix | <https://lem.christopherqueenconsulting.com/api> |
+| **Interactive API docs (Swagger)** | <https://lem.christopherqueenconsulting.com/docs> |
+| OpenAPI schema (import into Postman) | <https://lem.christopherqueenconsulting.com/openapi.json> |
+| **Live browser (VNC)** | <https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret> |
+
+> The VNC link auto-connects and passes the noVNC password (`secret`) in the
+> query string, so it opens straight into the live Chrome session. It's gated by
+> Cloudflare Access, so you'll sign in with your Cloudflare identity first.
 
 ---
 
-## 2. Authentication — two headers
+## 2. Authentication — BOTH headers are required
 
-Engagement test endpoints live under `/api/admin/*` and require **both**:
+The engagement test endpoints (`/api/admin/*`) require **two** credentials at the
+same time. Sending only one returns 401 or 403.
 
 | Header | Value | Where to find it (on the VPS) |
 |---|---|---|
 | `Authorization` | `Bearer <API_ACCESS_TOKEN>` | `API_ACCESS_TOKENS=` in `/opt/lem/.env` (comma-separated; use any one) |
 | `X-Admin-Secret` | `<ADMIN_SECRET>` | `ADMIN_SECRET=` in `/opt/lem/.env` |
 
-- The **bearer token** gates every `/api/*` route (except auth/webhook/assets).
-- The **admin secret** additionally gates the `/api/admin/*` endpoints.
+- **`Authorization` bearer** gates every `/api/*` route (set globally).
+- **`X-Admin-Secret`** additionally gates the `/api/admin/*` endpoints.
+- In the [Swagger page](https://lem.christopherqueenconsulting.com/docs), click
+  **Authorize** — it now presents **both** schemes (`HTTPBearer` and
+  `X-Admin-Secret`). Fill in both, then every endpoint's **Try it out** works.
 
-> Get the values: `sudo grep -E '^API_ACCESS_TOKENS=|^ADMIN_SECRET=' /opt/lem/.env`
+> Print the values:
+> ```bash
+> sudo grep -E '^API_ACCESS_TOKENS=|^ADMIN_SECRET=' /opt/lem/.env
+> ```
 
 ---
 
 ## 3. The test-run endpoints
 
-All are `POST` with a JSON body and return a Celery `task_id` you can poll.
-Your only LinkedIn account is **`user_id = 1`** (christopher.queen@gmail.com).
+All take **typed query parameters** (so Swagger renders individual input fields,
+not a raw JSON body) and return a Celery `task_id` you can poll. Your only
+LinkedIn account is **`user_id = 1`** (christopher.queen@gmail.com).
 
-### Comment on feed posts
-```
-POST /api/admin/test/comment
-{ "user_id": 1, "loop_for_duration": 300 }
-```
-Runs `automate_commenting` — the bot scrolls its feed and comments on posts.
+| Method & path | Params | Task |
+|---|---|---|
+| `POST /api/admin/test/comment` | `user_id`, `loop_for_duration=300` | comment on your feed |
+| `POST /api/admin/test/reply` | `post_id`, `loop_for_duration=300`, `future_forward=0` | reply to comments on a post |
+| `POST /api/admin/test/dm` | `user_id`, `loop_for_duration=300` | DM recent profile viewers |
+| `POST /api/admin/test/dm-direct` | `user_id`, `profile_url`, `message` | send ONE direct DM (most watchable) |
+| `GET /api/admin/task-status/{task_id}` | — | poll PENDING/STARTED/SUCCESS/FAILURE |
 
-### Reply to comments on one of your posts
-```
-POST /api/admin/test/reply
-{ "post_id": 42, "loop_for_duration": 300, "future_forward": 0 }
-```
-Runs `automate_reply_commenting` for that post (user is derived from the post).
+`loop_for_duration` is in **seconds** (default **300**) so a test run ends on its
+own instead of running for an hour.
 
-### Appreciation DMs to recent profile viewers
-```
-POST /api/admin/test/dm
-{ "user_id": 1, "loop_for_duration": 300 }
-```
-Runs `automate_appreciation_dms_for_user` — DMs people who viewed your profile.
+### Easiest: use Swagger
+1. Open <https://lem.christopherqueenconsulting.com/docs> → **Authorize** (fill both).
+2. Expand e.g. `POST /api/admin/test/dm-direct` → **Try it out** → fill the fields →
+   **Execute**. You'll get `{ "detail": { "task_id": "…" } }`.
 
-### Send ONE direct DM (most deterministic to watch)
+### Or curl (query params, both headers)
+```bash
+BASE=https://lem.christopherqueenconsulting.com
+curl -X POST "$BASE/api/admin/test/dm-direct?user_id=1&profile_url=https%3A%2F%2Fwww.linkedin.com%2Fin%2Fsome-person%2F&message=Hi%20there" \
+  -H "Authorization: Bearer $API_ACCESS_TOKEN" \
+  -H "X-Admin-Secret: $ADMIN_SECRET"
 ```
-POST /api/admin/test/dm-direct
-{ "user_id": 1,
-  "profile_url": "https://www.linkedin.com/in/some-person/",
-  "message": "Hi — testing my outreach automation, please ignore." }
-```
-Runs `send_private_dm`. Best for watching the messaging flow start-to-finish.
-
-### Poll a task's status
-```
-GET /api/admin/task-status/{task_id}
-```
-Returns `{ "state": "PENDING|STARTED|SUCCESS|FAILURE", "result": "..." }`.
-
-`loop_for_duration` is in **seconds** and defaults to **300** so a test run
-ends on its own instead of running for an hour.
 
 ---
 
 ## 4. Postman setup
 
-### a) Create an Environment
-Postman → **Environments → +**. Name it `LEM Prod` and add variables:
+Files live in [`docs/postman/`](postman/). See
+[`docs/postman/README.md`](postman/README.md) for the full walkthrough. In short:
 
-| Variable | Initial value |
-|---|---|
-| `base_url` | `https://lem.christopherqueenconsulting.com` |
-| `api_token` | *(your API_ACCESS_TOKENS value)* |
-| `admin_secret` | *(your ADMIN_SECRET value)* |
-| `user_id` | `1` |
-
-Mark `api_token` and `admin_secret` as **secret** type. Select this
-environment in the top-right dropdown.
-
-### b) Import the ready-made collection
-Import `docs/postman/LEM_Engagement_Tests.postman_collection.json` (in this
-repo) — it already contains all five requests with the two auth headers wired
-to `{{api_token}}` / `{{admin_secret}}` and bodies using `{{user_id}}`.
-
-**Or** import live from `…/openapi.json` (every endpoint, no bodies/headers
-pre-filled).
-
-### c) Per request, confirm these headers
-```
-Authorization: Bearer {{api_token}}
-X-Admin-Secret: {{admin_secret}}
-Content-Type: application/json
-```
-
-### d) Run it
-1. Open the **VNC** first (§5) so you can watch.
-2. Send e.g. **DM (direct)**. You'll get `{ "detail": { "task_id": "…" } }`.
-3. Switch to the VNC tab — within a few seconds Chrome opens LinkedIn, logs in
-   (or reuses cookies), navigates, and performs the action.
-4. Poll **Task status** with the returned `task_id` until `SUCCESS`/`FAILURE`.
+1. **Import the collection** —
+   [`LEM_Engagement_Tests.postman_collection.json`](postman/LEM_Engagement_Tests.postman_collection.json).
+2. **Import an environment** and pick it (top-right dropdown):
+   - **Prod** → [`LEM_Prod.postman_environment.json`](postman/LEM_Prod.postman_environment.json)
+     (`base_url = https://lem.christopherqueenconsulting.com`)
+   - **Local/Dev** → [`LEM_Local.postman_environment.json`](postman/LEM_Local.postman_environment.json)
+     (`base_url = http://localhost:8000`)
+3. Fill the env's `api_token` and `admin_secret` (both marked *secret*).
+4. Send a request — the collection passes both headers automatically and **saves
+   the returned `task_id`** into the environment, so **Task status** just works.
 
 ---
 
 ## 5. Watching it live in VNC
 
-The Selenium Chrome container runs a noVNC server on port **7900**. In prod it's
-bound to the VPS **loopback only** (not public), so reach it through an SSH
-tunnel from your laptop:
+The Selenium Chrome container runs a noVNC server. The simplest way to watch:
 
+**Open** <https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret>
+(sign in via Cloudflare Access). You'll land directly in the live Chrome session —
+trigger a test request (§3/§4) and watch the automation drive the browser in real
+time.
+
+### Alternative: SSH tunnel (no public hostname needed)
+noVNC is also bound to the VPS loopback on port `7900`:
 ```bash
 ssh -L 7900:localhost:7900 <your-vps-user>@<your-vps-host>
 ```
-Leave that session open, then browse to:
-```
-http://localhost:7900/?autoconnect=1
-```
-noVNC password: **`secret`** (Selenium standalone default).
+then open <http://localhost:7900/?autoconnect=1&password=secret>.
 
-You'll see the live Chrome session. Trigger a test request (§4) and watch the
-automation drive the browser in real time.
-
-### Optional: browser access without SSH
-Add a public hostname in the **Cloudflare Zero Trust dashboard** →
-Tunnels → your tunnel → Public Hostname:
-`vnc.christopherqueenconsulting.com` → `http://selenium-chrome:7900`, and put a
-**Cloudflare Access** policy in front of it (email allow-list). Then just open
-that URL — no SSH needed. (Keep it gated; never expose VNC unauthenticated.)
+> Keep the public VNC hostname behind Cloudflare Access — never expose it
+> unauthenticated.
 
 ---
 
 ## 6. Troubleshooting
 
-- **403 Forbidden** → missing/wrong `X-Admin-Secret`.
-- **401 Unauthorized** → missing/wrong `Authorization: Bearer` token.
+- **401 Unauthorized** → missing/invalid `Authorization: Bearer` token.
+- **403 Forbidden** → missing/invalid `X-Admin-Secret`. (Both headers are required.)
+- **422 Unprocessable Entity** → a required query param is missing (e.g. `user_id`).
 - **Task goes to FAILURE / nothing happens in VNC** → almost always a LinkedIn
   login problem (no stored password/cookies, or a "new location" security
-  challenge). Set your **Login Location** in Account first
-  (Account → Login Location → "Use my current location") and ensure the LinkedIn
-  password is saved.
-- **VNC shows a blank/again-login screen** → the session may have ended
+  challenge). Set your **Login Location** first
+  (Account → Login Location → "Use my current location") and make sure your
+  LinkedIn password is saved.
+- **VNC shows a login/blank screen** → the session may have ended
   (`loop_for_duration` elapsed). Re-trigger and watch immediately.
-- **Nothing on `localhost:7900`** → the SSH tunnel isn't up, or this change
-  (loopback port bind) hasn't deployed yet — confirm the running release ≥ the
-  one that adds `127.0.0.1:7900:7900`.
+- **Nothing at `localhost:7900`** (SSH path) → the tunnel isn't up, or the running
+  release predates the `127.0.0.1:7900:7900` bind.

--- a/docs/postman/LEM_Engagement_Tests.postman_collection.json
+++ b/docs/postman/LEM_Engagement_Tests.postman_collection.json
@@ -1,27 +1,42 @@
 {
   "info": {
     "name": "LEM Engagement Tests",
-    "description": "Trigger comment/reply/DM automation on demand and poll task status. Requires the LEM Prod environment (base_url, api_token, admin_secret, user_id). See docs/TESTING_ENGAGEMENT_API.md.",
+    "description": "Trigger comment/reply/DM automation on demand and poll task status. Inputs are query params; auth uses BOTH a bearer token ({{api_token}}) and the X-Admin-Secret header ({{admin_secret}}). Select an environment first: 'LEM — Prod' or 'LEM — Local/Dev'. See docs/TESTING_ENGAGEMENT_API.md.",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "auth": {
     "type": "bearer",
     "bearer": [{ "key": "token", "value": "{{api_token}}", "type": "string" }]
   },
-  "variable": [],
+  "event": [
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "// Save the returned task_id so the 'Task status' request can poll it.",
+          "try {",
+          "  const id = pm.response.json().detail.task_id;",
+          "  if (id) { pm.environment.set('task_id', id); console.log('task_id =', id); }",
+          "} catch (e) {}"
+        ]
+      }
+    }
+  ],
   "item": [
     {
       "name": "Comment on feed",
       "request": {
         "method": "POST",
-        "header": [
-          { "key": "Content-Type", "value": "application/json" },
-          { "key": "X-Admin-Secret", "value": "{{admin_secret}}" }
-        ],
-        "url": { "raw": "{{base_url}}/api/admin/test/comment", "host": ["{{base_url}}"], "path": ["api", "admin", "test", "comment"] },
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"user_id\": {{user_id}},\n  \"loop_for_duration\": 300\n}"
+        "header": [{ "key": "X-Admin-Secret", "value": "{{admin_secret}}" }],
+        "url": {
+          "raw": "{{base_url}}/api/admin/test/comment?user_id={{user_id}}&loop_for_duration=300",
+          "host": ["{{base_url}}"],
+          "path": ["api", "admin", "test", "comment"],
+          "query": [
+            { "key": "user_id", "value": "{{user_id}}" },
+            { "key": "loop_for_duration", "value": "300", "description": "seconds; run self-terminates" }
+          ]
         }
       }
     },
@@ -29,14 +44,16 @@
       "name": "Reply to comments on a post",
       "request": {
         "method": "POST",
-        "header": [
-          { "key": "Content-Type", "value": "application/json" },
-          { "key": "X-Admin-Secret", "value": "{{admin_secret}}" }
-        ],
-        "url": { "raw": "{{base_url}}/api/admin/test/reply", "host": ["{{base_url}}"], "path": ["api", "admin", "test", "reply"] },
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"post_id\": 42,\n  \"loop_for_duration\": 300,\n  \"future_forward\": 0\n}"
+        "header": [{ "key": "X-Admin-Secret", "value": "{{admin_secret}}" }],
+        "url": {
+          "raw": "{{base_url}}/api/admin/test/reply?post_id=42&loop_for_duration=300&future_forward=0",
+          "host": ["{{base_url}}"],
+          "path": ["api", "admin", "test", "reply"],
+          "query": [
+            { "key": "post_id", "value": "42", "description": "an already-posted post id" },
+            { "key": "loop_for_duration", "value": "300" },
+            { "key": "future_forward", "value": "0" }
+          ]
         }
       }
     },
@@ -44,14 +61,15 @@
       "name": "Appreciation DMs to profile viewers",
       "request": {
         "method": "POST",
-        "header": [
-          { "key": "Content-Type", "value": "application/json" },
-          { "key": "X-Admin-Secret", "value": "{{admin_secret}}" }
-        ],
-        "url": { "raw": "{{base_url}}/api/admin/test/dm", "host": ["{{base_url}}"], "path": ["api", "admin", "test", "dm"] },
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"user_id\": {{user_id}},\n  \"loop_for_duration\": 300\n}"
+        "header": [{ "key": "X-Admin-Secret", "value": "{{admin_secret}}" }],
+        "url": {
+          "raw": "{{base_url}}/api/admin/test/dm?user_id={{user_id}}&loop_for_duration=300",
+          "host": ["{{base_url}}"],
+          "path": ["api", "admin", "test", "dm"],
+          "query": [
+            { "key": "user_id", "value": "{{user_id}}" },
+            { "key": "loop_for_duration", "value": "300" }
+          ]
         }
       }
     },
@@ -59,14 +77,16 @@
       "name": "DM (direct, single profile)",
       "request": {
         "method": "POST",
-        "header": [
-          { "key": "Content-Type", "value": "application/json" },
-          { "key": "X-Admin-Secret", "value": "{{admin_secret}}" }
-        ],
-        "url": { "raw": "{{base_url}}/api/admin/test/dm-direct", "host": ["{{base_url}}"], "path": ["api", "admin", "test", "dm-direct"] },
-        "body": {
-          "mode": "raw",
-          "raw": "{\n  \"user_id\": {{user_id}},\n  \"profile_url\": \"https://www.linkedin.com/in/some-person/\",\n  \"message\": \"Hi — testing my outreach automation, please ignore.\"\n}"
+        "header": [{ "key": "X-Admin-Secret", "value": "{{admin_secret}}" }],
+        "url": {
+          "raw": "{{base_url}}/api/admin/test/dm-direct?user_id={{user_id}}&profile_url=https://www.linkedin.com/in/some-person/&message=Hi — testing my outreach automation, please ignore.",
+          "host": ["{{base_url}}"],
+          "path": ["api", "admin", "test", "dm-direct"],
+          "query": [
+            { "key": "user_id", "value": "{{user_id}}" },
+            { "key": "profile_url", "value": "https://www.linkedin.com/in/some-person/" },
+            { "key": "message", "value": "Hi — testing my outreach automation, please ignore." }
+          ]
         }
       }
     },
@@ -74,9 +94,7 @@
       "name": "Task status",
       "request": {
         "method": "GET",
-        "header": [
-          { "key": "X-Admin-Secret", "value": "{{admin_secret}}" }
-        ],
+        "header": [{ "key": "X-Admin-Secret", "value": "{{admin_secret}}" }],
         "url": {
           "raw": "{{base_url}}/api/admin/task-status/{{task_id}}",
           "host": ["{{base_url}}"],

--- a/docs/postman/LEM_Local.postman_environment.json
+++ b/docs/postman/LEM_Local.postman_environment.json
@@ -1,0 +1,11 @@
+{
+  "name": "LEM — Local/Dev",
+  "values": [
+    { "key": "base_url", "value": "http://localhost:8000", "type": "default", "enabled": true },
+    { "key": "api_token", "value": "REPLACE_WITH_LOCAL_API_ACCESS_TOKEN", "type": "secret", "enabled": true },
+    { "key": "admin_secret", "value": "REPLACE_WITH_LOCAL_ADMIN_SECRET", "type": "secret", "enabled": true },
+    { "key": "user_id", "value": "1", "type": "default", "enabled": true },
+    { "key": "task_id", "value": "", "type": "default", "enabled": true }
+  ],
+  "_postman_variable_scope": "environment"
+}

--- a/docs/postman/LEM_Prod.postman_environment.json
+++ b/docs/postman/LEM_Prod.postman_environment.json
@@ -1,5 +1,5 @@
 {
-  "name": "LEM Prod",
+  "name": "LEM — Prod",
   "values": [
     { "key": "base_url", "value": "https://lem.christopherqueenconsulting.com", "type": "default", "enabled": true },
     { "key": "api_token", "value": "REPLACE_WITH_API_ACCESS_TOKEN", "type": "secret", "enabled": true },

--- a/docs/postman/README.md
+++ b/docs/postman/README.md
@@ -1,0 +1,51 @@
+# Postman — LEM Engagement Tests
+
+Files in this folder:
+
+| File | What it is |
+|---|---|
+| `LEM_Engagement_Tests.postman_collection.json` | The requests (comment / reply / DM / dm-direct / task-status) |
+| `LEM_Prod.postman_environment.json` | **Prod** environment → `https://lem.christopherqueenconsulting.com` |
+| `LEM_Local.postman_environment.json` | **Local/Dev** environment → `http://localhost:8000` |
+
+## Import (one time)
+
+1. Postman → **Import** (top-left) → drag in **all three** JSON files (the
+   collection + both environments). Postman detects which is a collection and
+   which are environments automatically.
+2. Top-right **environment dropdown** → pick the one you want:
+   - **LEM — Prod** to hit the live VPS.
+   - **LEM — Local/Dev** to hit a stack you're running locally
+     (`docker compose up`, API on `http://localhost:8000`).
+
+## Fill in the secrets (per environment)
+
+Click the **eye icon** (top-right) → **Edit** the selected environment and set:
+
+| Variable | Prod value | Local value |
+|---|---|---|
+| `api_token` | one of `API_ACCESS_TOKENS` from `/opt/lem/.env` on the VPS | one of `API_ACCESS_TOKENS` from your local `.env` |
+| `admin_secret` | `ADMIN_SECRET` from `/opt/lem/.env` | `ADMIN_SECRET` from your local `.env` |
+| `user_id` | `1` (already set) | your local user id |
+
+`base_url` and `task_id` are pre-filled; leave them. `task_id` is set
+automatically from each request's response so the **Task status** call just works.
+
+> Both `api_token` and `admin_secret` are required on every request — the
+> collection sends `Authorization: Bearer {{api_token}}` and
+> `X-Admin-Secret: {{admin_secret}}` for you.
+
+## Run
+
+1. (Optional) open the VNC to watch — see the main guide,
+   [`../TESTING_ENGAGEMENT_API.md`](../TESTING_ENGAGEMENT_API.md).
+2. Send e.g. **DM (direct, single profile)** — fill the `profile_url`/`message`
+   query params first.
+3. Send **Task status** to poll the result (it reuses the saved `task_id`).
+
+## Distinguishing Prod vs Local at a glance
+
+The active environment name shows in the top-right dropdown (**LEM — Prod** vs
+**LEM — Local/Dev**), and every request's URL resolves `{{base_url}}` to either
+the public domain or `localhost:8000`. Double-check the dropdown before firing a
+request so you don't run automation against the wrong stack.

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -52,8 +52,9 @@ from cqc_lem.utilities.logger import myprint, log_warning
 from cqc_lem.utilities.mime_type_helper import get_file_mime_type
 from cqc_lem.utilities.observability import track_api_call
 from cqc_lem.utilities.utils import get_file_extension_from_filepath
-from fastapi import FastAPI, HTTPException, Request, status, APIRouter, Header
+from fastapi import FastAPI, HTTPException, Request, status, APIRouter, Header, Depends
 from fastapi import File, Form, Query, UploadFile
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials, APIKeyHeader
 from fastapi.responses import FileResponse
 from fastapi.responses import JSONResponse
 from fastapi.responses import HTMLResponse
@@ -287,28 +288,6 @@ class AdminRegenerateCarouselRequest(BaseModel):
 class AdminRegenerateVideoRequest(BaseModel):
     post_id: int
     user_id: int
-
-
-class AdminTestCommentRequest(BaseModel):
-    user_id: int
-    loop_for_duration: int = 300  # seconds; short window so a test run ends on its own
-
-
-class AdminTestReplyRequest(BaseModel):
-    post_id: int
-    loop_for_duration: int = 300
-    future_forward: int = 0
-
-
-class AdminTestDMRequest(BaseModel):
-    user_id: int
-    loop_for_duration: int = 300
-
-
-class AdminTestDirectDMRequest(BaseModel):
-    user_id: int
-    profile_url: str
-    message: str
 
 
 class VariantCombo(BaseModel):
@@ -1587,6 +1566,31 @@ def _require_admin(x_admin_secret: Optional[str] = Header(default=None)) -> None
         raise HTTPException(status_code=403, detail="Forbidden")
 
 
+# Declared security schemes so Swagger (/docs) shows BOTH required credentials in
+# the Authorize dialog: the bearer API token AND the admin secret. Both are needed.
+_bearer_scheme = HTTPBearer(
+    auto_error=False,
+    description="API access token — one of API_ACCESS_TOKENS. Sent as 'Authorization: Bearer <token>'.",
+)
+_admin_secret_scheme = APIKeyHeader(
+    name="X-Admin-Secret", auto_error=False,
+    description="Admin secret — the ADMIN_SECRET env var.",
+)
+
+
+def _require_api_and_admin(
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme),
+    x_admin_secret: Optional[str] = Depends(_admin_secret_scheme),
+) -> None:
+    """Require BOTH the bearer API token and the admin secret. Used by the
+    /admin/test/* endpoints so the docs page presents and enforces both."""
+    token = credentials.credentials if credentials else None
+    if _API_ACCESS_TOKEN_SET and token not in _API_ACCESS_TOKEN_SET:
+        raise HTTPException(status_code=401, detail="Unauthorized — missing or invalid bearer token")
+    if not ADMIN_SECRET or x_admin_secret != ADMIN_SECRET:
+        raise HTTPException(status_code=403, detail="Forbidden — missing or invalid X-Admin-Secret")
+
+
 @router.post("/admin/fix-video-urls", responses={
     200: {"description": "Video URLs updated"},
     403: {"description": "Forbidden"},
@@ -1700,109 +1704,116 @@ def admin_generate_media_variants(
 
 # ---------------------------------------------------------------------------
 # Admin test-run endpoints — kick a single engagement task on the selenium
-# worker so you can watch it live in the Chrome VNC. All require X-Admin-Secret.
+# worker so you can watch it live in the Chrome VNC. Inputs are typed query
+# params (so /docs renders individual fields, not a raw JSON body). BOTH the
+# bearer API token AND X-Admin-Secret are required (see _require_api_and_admin).
 # ---------------------------------------------------------------------------
 
 @router.post("/admin/test/comment", responses={
     200: {"description": "Commenting test run queued"},
-    403: {"description": "Forbidden"},
+    401: {"description": "Missing/invalid bearer token"},
+    403: {"description": "Missing/invalid admin secret"},
 })
 def admin_test_comment(
-    request: AdminTestCommentRequest,
-    x_admin_secret: Optional[str] = Header(default=None),
+    user_id: int = Query(..., description="LinkedIn account user id", examples=[1]),
+    loop_for_duration: int = Query(300, ge=10, le=3600,
+                                   description="Seconds before the run self-terminates"),
+    _: None = Depends(_require_api_and_admin),
 ) -> ResponseModel:
     """Run the feed-commenting automation for a user (comments on posts in their feed)."""
-    _require_admin(x_admin_secret)
     result = automate_commenting.apply_async(kwargs={
-        "user_id": request.user_id,
-        "loop_for_duration": request.loop_for_duration,
+        "user_id": user_id, "loop_for_duration": loop_for_duration,
     }, queue="selenium")
-    myprint(f"admin/test/comment: queued task={result.id} user_id={request.user_id}")
+    myprint(f"admin/test/comment: queued task={result.id} user_id={user_id}")
     return ResponseModel(status_code=200, detail={
-        "task_id": result.id, "task": "automate_commenting", "user_id": request.user_id,
+        "task_id": result.id, "task": "automate_commenting", "user_id": user_id,
     })
 
 
 @router.post("/admin/test/reply", responses={
     200: {"description": "Reply test run queued"},
-    403: {"description": "Forbidden"},
+    401: {"description": "Missing/invalid bearer token"},
+    403: {"description": "Missing/invalid admin secret"},
+    404: {"description": "User for post not found"},
 })
 def admin_test_reply(
-    request: AdminTestReplyRequest,
-    x_admin_secret: Optional[str] = Header(default=None),
+    post_id: int = Query(..., description="Id of an already-posted post to reply on", examples=[42]),
+    loop_for_duration: int = Query(300, ge=10, le=3600,
+                                   description="Seconds before the run self-terminates"),
+    future_forward: int = Query(0, ge=0, le=5, description="Forward index (0-5)"),
+    _: None = Depends(_require_api_and_admin),
 ) -> ResponseModel:
     """Run the reply-to-comments automation for a specific (already-posted) post."""
-    _require_admin(x_admin_secret)
-    user_id = get_post_user_id(request.post_id)
+    user_id = get_post_user_id(post_id)
     if not user_id:
         raise HTTPException(status_code=404, detail="User for post not found")
     result = automate_reply_commenting.apply_async(kwargs={
-        "user_id": user_id,
-        "post_id": request.post_id,
-        "loop_for_duration": request.loop_for_duration,
-        "future_forward": request.future_forward,
+        "user_id": user_id, "post_id": post_id,
+        "loop_for_duration": loop_for_duration, "future_forward": future_forward,
     }, queue="selenium")
-    myprint(f"admin/test/reply: queued task={result.id} post_id={request.post_id}")
+    myprint(f"admin/test/reply: queued task={result.id} post_id={post_id}")
     return ResponseModel(status_code=200, detail={
         "task_id": result.id, "task": "automate_reply_commenting",
-        "post_id": request.post_id, "user_id": user_id,
+        "post_id": post_id, "user_id": user_id,
     })
 
 
 @router.post("/admin/test/dm", responses={
     200: {"description": "DM test run queued"},
-    403: {"description": "Forbidden"},
+    401: {"description": "Missing/invalid bearer token"},
+    403: {"description": "Missing/invalid admin secret"},
 })
 def admin_test_dm(
-    request: AdminTestDMRequest,
-    x_admin_secret: Optional[str] = Header(default=None),
+    user_id: int = Query(..., description="LinkedIn account user id", examples=[1]),
+    loop_for_duration: int = Query(300, ge=10, le=3600,
+                                   description="Seconds before the run self-terminates"),
+    _: None = Depends(_require_api_and_admin),
 ) -> ResponseModel:
     """Run the appreciation-DM automation (DMs people who recently viewed the profile)."""
-    _require_admin(x_admin_secret)
     result = automate_appreciation_dms_for_user.apply_async(kwargs={
-        "user_id": request.user_id,
-        "loop_for_duration": request.loop_for_duration,
+        "user_id": user_id, "loop_for_duration": loop_for_duration,
     }, queue="selenium")
-    myprint(f"admin/test/dm: queued task={result.id} user_id={request.user_id}")
+    myprint(f"admin/test/dm: queued task={result.id} user_id={user_id}")
     return ResponseModel(status_code=200, detail={
         "task_id": result.id, "task": "automate_appreciation_dms_for_user",
-        "user_id": request.user_id,
+        "user_id": user_id,
     })
 
 
 @router.post("/admin/test/dm-direct", responses={
     200: {"description": "Direct DM queued"},
-    403: {"description": "Forbidden"},
+    401: {"description": "Missing/invalid bearer token"},
+    403: {"description": "Missing/invalid admin secret"},
 })
 def admin_test_dm_direct(
-    request: AdminTestDirectDMRequest,
-    x_admin_secret: Optional[str] = Header(default=None),
+    user_id: int = Query(..., description="LinkedIn account user id", examples=[1]),
+    profile_url: str = Query(..., description="LinkedIn profile URL to message",
+                             examples=["https://www.linkedin.com/in/some-person/"]),
+    message: str = Query(..., description="Message body to send", examples=["Hi — testing, please ignore."]),
+    _: None = Depends(_require_api_and_admin),
 ) -> ResponseModel:
     """Send ONE direct DM to a specific profile URL — the most deterministic way to
     watch the messaging flow end-to-end in the VNC."""
-    _require_admin(x_admin_secret)
     result = send_private_dm.apply_async(kwargs={
-        "user_id": request.user_id,
-        "profile_url": request.profile_url,
-        "message": request.message,
+        "user_id": user_id, "profile_url": profile_url, "message": message,
     }, queue="selenium")
-    myprint(f"admin/test/dm-direct: queued task={result.id} user_id={request.user_id} -> {request.profile_url}")
+    myprint(f"admin/test/dm-direct: queued task={result.id} user_id={user_id} -> {profile_url}")
     return ResponseModel(status_code=200, detail={
         "task_id": result.id, "task": "send_private_dm",
-        "user_id": request.user_id, "profile_url": request.profile_url,
+        "user_id": user_id, "profile_url": profile_url,
     })
 
 
 @router.get("/admin/task-status/{task_id}", responses={
     200: {"description": "Task status"},
-    403: {"description": "Forbidden"},
+    401: {"description": "Missing/invalid bearer token"},
+    403: {"description": "Missing/invalid admin secret"},
 })
 def admin_task_status(
     task_id: str,
-    x_admin_secret: Optional[str] = Header(default=None),
+    _: None = Depends(_require_api_and_admin),
 ) -> ResponseModel:
     """Poll a queued test task's state (PENDING/STARTED/SUCCESS/FAILURE)."""
-    _require_admin(x_admin_secret)
     from cqc_lem.app.my_celery import app as celery_app
     res = celery_app.AsyncResult(task_id)
     detail = {"task_id": task_id, "state": res.state}

--- a/tests/unit/api/test_admin_engagement_test_runs.py
+++ b/tests/unit/api/test_admin_engagement_test_runs.py
@@ -1,4 +1,9 @@
-"""Unit tests for the /api/admin/test/* engagement test-run endpoints."""
+"""Unit tests for the /api/admin/test/* engagement test-run endpoints.
+
+Inputs are typed query params; auth requires BOTH a bearer token and the
+X-Admin-Secret header (the bearer check is a no-op in tests because
+API_ACCESS_TOKENS is unset, so only the admin secret is exercised here).
+"""
 
 import pytest
 from unittest.mock import patch, MagicMock
@@ -26,6 +31,7 @@ def client():
 
 
 _SECRET = "s3cret"
+_ADMIN_HEADER = {"x-admin-secret": _SECRET}
 
 
 def _async_result(task_id="task-123"):
@@ -37,33 +43,35 @@ def _async_result(task_id="task-123"):
 class TestComment:
     def test_forbidden_without_secret(self, client):
         with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET):
-            r = client.post("/api/admin/test/comment", json={"user_id": 1})
+            r = client.post("/api/admin/test/comment", params={"user_id": 1})
         assert r.status_code == 403
 
     def test_queues_task(self, client):
         with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
              patch("cqc_lem.api.main.automate_commenting.apply_async", return_value=_async_result()) as t:
-            r = client.post("/api/admin/test/comment", json={"user_id": 7},
-                            headers={"x-admin-secret": _SECRET})
+            r = client.post("/api/admin/test/comment", params={"user_id": 7}, headers=_ADMIN_HEADER)
         assert r.status_code == 200
         assert r.json()["detail"]["task_id"] == "task-123"
         assert t.call_args.kwargs["kwargs"]["user_id"] == 7
+
+    def test_missing_required_user_id_is_422(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET):
+            r = client.post("/api/admin/test/comment", headers=_ADMIN_HEADER)
+        assert r.status_code == 422
 
 
 class TestReply:
     def test_404_when_post_user_missing(self, client):
         with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
              patch("cqc_lem.api.main.get_post_user_id", return_value=None):
-            r = client.post("/api/admin/test/reply", json={"post_id": 99},
-                            headers={"x-admin-secret": _SECRET})
+            r = client.post("/api/admin/test/reply", params={"post_id": 99}, headers=_ADMIN_HEADER)
         assert r.status_code == 404
 
     def test_queues_task(self, client):
         with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
              patch("cqc_lem.api.main.get_post_user_id", return_value=5), \
              patch("cqc_lem.api.main.automate_reply_commenting.apply_async", return_value=_async_result()) as t:
-            r = client.post("/api/admin/test/reply", json={"post_id": 12},
-                            headers={"x-admin-secret": _SECRET})
+            r = client.post("/api/admin/test/reply", params={"post_id": 12}, headers=_ADMIN_HEADER)
         assert r.status_code == 200
         assert t.call_args.kwargs["kwargs"]["post_id"] == 12
         assert r.json()["detail"]["user_id"] == 5
@@ -72,15 +80,14 @@ class TestReply:
 class TestDM:
     def test_forbidden_without_secret(self, client):
         with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET):
-            r = client.post("/api/admin/test/dm", json={"user_id": 1})
+            r = client.post("/api/admin/test/dm", params={"user_id": 1})
         assert r.status_code == 403
 
     def test_queues_appreciation_dm(self, client):
         with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
              patch("cqc_lem.api.main.automate_appreciation_dms_for_user.apply_async",
                    return_value=_async_result()) as t:
-            r = client.post("/api/admin/test/dm", json={"user_id": 3},
-                            headers={"x-admin-secret": _SECRET})
+            r = client.post("/api/admin/test/dm", params={"user_id": 3}, headers=_ADMIN_HEADER)
         assert r.status_code == 200
         assert t.call_args.kwargs["kwargs"]["user_id"] == 3
 
@@ -90,9 +97,9 @@ class TestDirectDM:
         with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
              patch("cqc_lem.api.main.send_private_dm.apply_async", return_value=_async_result()) as t:
             r = client.post("/api/admin/test/dm-direct",
-                            json={"user_id": 1, "profile_url": "https://linkedin.com/in/x",
-                                  "message": "Hi there"},
-                            headers={"x-admin-secret": _SECRET})
+                            params={"user_id": 1, "profile_url": "https://linkedin.com/in/x",
+                                    "message": "Hi there"},
+                            headers=_ADMIN_HEADER)
         assert r.status_code == 200
         assert t.call_args.kwargs["kwargs"]["profile_url"] == "https://linkedin.com/in/x"
         assert t.call_args.kwargs["kwargs"]["message"] == "Hi there"
@@ -100,7 +107,7 @@ class TestDirectDM:
     def test_forbidden_without_secret(self, client):
         with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET):
             r = client.post("/api/admin/test/dm-direct",
-                            json={"user_id": 1, "profile_url": "u", "message": "m"})
+                            params={"user_id": 1, "profile_url": "u", "message": "m"})
         assert r.status_code == 403
 
 
@@ -112,8 +119,7 @@ class TestTaskStatus:
         res.result = "done"
         with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
              patch("cqc_lem.app.my_celery.app.AsyncResult", return_value=res):
-            r = client.get("/api/admin/task-status/task-123",
-                           headers={"x-admin-secret": _SECRET})
+            r = client.get("/api/admin/task-status/task-123", headers=_ADMIN_HEADER)
         assert r.status_code == 200
         assert r.json()["detail"]["state"] == "SUCCESS"
         assert r.json()["detail"]["result"] == "done"
@@ -122,3 +128,15 @@ class TestTaskStatus:
         with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET):
             r = client.get("/api/admin/task-status/task-123")
         assert r.status_code == 403
+
+
+class TestAuthSchemeInOpenAPI:
+    """Both security schemes must be advertised so /docs shows both credentials."""
+    def test_both_schemes_present(self, client):
+        schema = client.get("/openapi.json").json()
+        schemes = schema.get("components", {}).get("securitySchemes", {})
+        names = set(schemes.keys())
+        # HTTPBearer + APIKeyHeader(name="X-Admin-Secret")
+        assert any(s.get("type") == "http" and s.get("scheme") == "bearer" for s in schemes.values())
+        assert any(s.get("type") == "apiKey" and s.get("name") == "X-Admin-Secret" for s in schemes.values())
+        assert names  # non-empty


### PR DESCRIPTION
Follow-up to the engagement test API, addressing the review feedback.

## Changes
- **Structured inputs in Swagger** — `/api/admin/test/*` now take typed **query parameters** (with defaults/bounds) instead of JSON body models, so [/docs](https://lem.christopherqueenconsulting.com/docs) renders individual input fields, not a raw JSON box.
- **Both credentials shown & enforced** — declared two security schemes (`HTTPBearer` + `X-Admin-Secret` APIKeyHeader). The docs **Authorize** dialog now presents **both**, and the endpoints require both (401 without bearer, 403 without admin secret). Removes the earlier ambiguity about which header is needed.
- **Docs** (`TESTING_ENGAGEMENT_API.md`):
  - All URLs are clickable markdown links (GitHub-friendly).
  - VNC uses the official `https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret` (with SSH-tunnel fallback).
  - Explicitly states both `Authorization` and `X-Admin-Secret` are required.
- **Postman** — clearly named **"LEM — Prod"** and new **"LEM — Local/Dev"** (`localhost:8000`) environments; requests use query params; the collection **auto-saves `task_id`** so Task-status just works; added `docs/postman/README.md` with import instructions and a prod-vs-local section.

## Testing
12 endpoint tests (incl. a check that both security schemes appear in OpenAPI and that inputs are query params). Full API unit suite: **162 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)