### PR TITLE
fix(linkedin): repair login selectors for redesigned login page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -171,6 +171,12 @@ SMTP_PASSWORD=your_gmail_app_password
 # If absent or empty, CAPTCHA challenges are logged as warnings and aborted gracefully.
 CAPSOLVER_API_KEY=
 
+# Seconds login_to_linkedin waits for a mobile-app device-approval challenge
+# ("Check your LinkedIn app → tap Yes") to be approved before aborting. Watch via
+# lemvnc and tap Yes within this window; once the device is recognized, stored
+# cookies skip the challenge next time. Set 0 to never wait. Default: 120.
+LINKEDIN_APPROVAL_WAIT_SECONDS=120
+
 # Observability & CI
 # =============================================================================
 

--- a/.env.example
+++ b/.env.example
@@ -176,6 +176,11 @@ CAPSOLVER_API_KEY=
 # lemvnc and tap Yes within this window; once the device is recognized, stored
 # cookies skip the challenge next time. Set 0 to never wait. Default: 120.
 LINKEDIN_APPROVAL_WAIT_SECONDS=120
+# When a device-approval challenge is hit, email the user (high priority) so they can
+# approve from their phone instead of the run stalling silently. Set false to disable.
+LINKEDIN_APPROVAL_EMAIL_ENABLED=true
+# Link included in that email (and docs) for watching the live browser session.
+LEMVNC_URL=https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret
 
 # Observability & CI
 # =============================================================================

--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,12 @@
+{
+  "_comment": "Copy to .mcp.json (gitignored) to enable the Selenium MCP server. Requires `poetry install --with mcp`. SE_REMOTE_URL points at the loopback-mapped selenium-chrome hub on the VPS; tunnel 4444 from a laptop. See docs/SELENIUM_DEBUGGING.md.",
+  "mcpServers": {
+    "selenium-lem": {
+      "command": "poetry",
+      "args": ["run", "python", "tools/selenium_mcp_server.py"],
+      "env": {
+        "SE_REMOTE_URL": "http://127.0.0.1:4444"
+      }
+    }
+  }
+}

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -115,12 +115,13 @@ services:
 
   selenium-chrome:
     # already restart: unless-stopped + 2cpu/4g in the base file
-    # Bind noVNC (7900) to loopback only so the live browser can be watched via an
-    # SSH tunnel (ssh -L 7900:localhost:7900 …) without exposing it publicly. The
-    # Selenium hub (4444) stays internal to the compose network. For browser-based
-    # access instead, add a vnc.<domain> public hostname in the Cloudflare Zero
-    # Trust dashboard pointing at http://selenium-chrome:7900 (gate with Access).
-    ports: !override ["127.0.0.1:7900:7900"]
+    # Bind noVNC (7900) and the Selenium hub (4444) to loopback only. 7900 lets the
+    # live browser be watched via an SSH tunnel (ssh -L 7900:localhost:7900 …) or the
+    # lemvnc.<domain> Cloudflare hostname; 4444 lets host-side tooling — notably the
+    # Selenium MCP server (tools/selenium_mcp_server.py) — drive that same browser for
+    # interactive debugging. Neither is exposed publicly (loopback + host firewall);
+    # for browser access add a public hostname in Cloudflare Zero Trust (gate with Access).
+    ports: !override ["127.0.0.1:7900:7900", "127.0.0.1:4444:4444"]
 
   litellm:
     # already restart: unless-stopped in the base file

--- a/docs/SELENIUM_DEBUGGING.md
+++ b/docs/SELENIUM_DEBUGGING.md
@@ -1,0 +1,70 @@
+# Debugging the live browser (Selenium MCP + lemvnc)
+
+LEM's automation logs into LinkedIn and engages through a headful Chrome running in
+the `selenium-chrome` container. When LinkedIn changes its DOM (login fields, buttons)
+the automation starts failing — this guide is how to drive and watch that exact
+browser to find out why.
+
+Two cooperating surfaces:
+
+| Port | What | Exposure |
+|---|---|---|
+| `4444` | Selenium WebDriver hub — programmatic control | loopback (`127.0.0.1:4444`) |
+| `7900` | noVNC — *watch* the browser | loopback (`127.0.0.1:7900`) + [`lemvnc.christopherqueenconsulting.com`](https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret) |
+
+You **drive** via 4444 and **watch** via 7900 at the same time.
+
+## Watch: lemvnc
+
+Open [`https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret`](https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret)
+(behind Cloudflare Access). No Cloudflare hostname yet? Tunnel and use the local URL:
+
+```bash
+ssh -L 7900:localhost:7900 -L 4444:localhost:4444 <vps>
+# then open http://localhost:7900/?autoconnect=1&password=secret
+```
+
+## Drive: the Selenium MCP server
+
+Defined by [`tools/selenium_mcp_server.py`](../tools/selenium_mcp_server.py), which
+*attaches to the live grid* (not a throwaway local browser), so its actions appear in
+lemvnc. `.mcp.json` is gitignored, so enable it from the tracked template:
+
+```bash
+cp .mcp.json.example .mcp.json   # registers the `selenium-lem` server
+poetry install --with mcp        # one-time: pulls the `mcp` SDK
+```
+
+It picks up `SE_REMOTE_URL` (default `http://127.0.0.1:4444`). On the VPS that's the
+loopback-mapped hub; from a laptop, the SSH tunnel above makes it reach the box.
+Restart Claude Code after editing `.mcp.json` — MCP servers load at session start.
+
+Tools: `start_browser`, `navigate`, `current_state`, `list_inputs`, `list_buttons`,
+`type_into`, `click`, `screenshot`, `page_source`, `execute_js`, `quit_browser`.
+`list_inputs` is the workhorse — it prints every input's `id`/`type`/`autocomplete`/
+`displayed`, which is how you spot that LinkedIn dropped `id="username"`.
+
+## Drive (no MCP): the in-container harness
+
+Same browser, scriptable, runs inside the worker that already reaches the grid:
+
+```bash
+sudo docker cp tools/debug_linkedin_login.py celery_worker_selenium:/tmp/dbg.py
+sudo docker exec celery_worker_selenium python /tmp/dbg.py --inspect            # dump DOM + screenshot
+sudo docker exec celery_worker_selenium python /tmp/dbg.py --login --user-id 1  # real login_to_linkedin
+```
+
+## What the login selectors look for now
+
+LinkedIn's redesigned login page uses **ephemeral React ids** (e.g. `«Refvd3ksopa55j6»`)
+and a `<button type="button"><span>Sign in</span></button>` — so the old
+`id="username"` / `id="password"` / `[type=submit]` selectors all match nothing, and it
+renders **duplicate hidden+visible** copies of every field. `login_to_linkedin` therefore
+matches on stable `type`/`autocomplete` attributes (+ the button's visible text) and
+picks the *displayed* copy via `get_visible_element_wait_retry`.
+
+After a successful credential submit LinkedIn often shows **"Check your LinkedIn app →
+tap Yes"** — a device-approval 2FA challenge (not Arkose, so it can't be auto-solved).
+`login_to_linkedin` waits up to `LINKEDIN_APPROVAL_WAIT_SECONDS` (default 120) for you to
+approve from your phone while watching via lemvnc; "Recognize this device" is pre-checked,
+so once approved the stored cookies skip the challenge next time.

--- a/docs/SELENIUM_DEBUGGING.md
+++ b/docs/SELENIUM_DEBUGGING.md
@@ -67,4 +67,22 @@ After a successful credential submit LinkedIn often shows **"Check your LinkedIn
 tap Yes"** — a device-approval 2FA challenge (not Arkose, so it can't be auto-solved).
 `login_to_linkedin` waits up to `LINKEDIN_APPROVAL_WAIT_SECONDS` (default 120) for you to
 approve from your phone while watching via lemvnc; "Recognize this device" is pre-checked,
-so once approved the stored cookies skip the challenge next time.
+so once approved the stored cookies skip the challenge next time. The moment that challenge
+appears the user is sent a **high-priority email** (`LINKEDIN_APPROVAL_EMAIL_ENABLED`,
+`LEMVNC_URL`) so a human can act instead of the run stalling silently.
+
+## Reducing bot/anomaly flags
+
+`get_docker_driver` applies a stealth profile so LinkedIn is less likely to flag the
+session as automation: `--disable-blink-features=AutomationControlled`,
+`excludeSwitches=[enable-automation]` + `useAutomationExtension=false`, a realistic
+desktop user-agent, and a CDP init script that sets `navigator.webdriver=undefined`,
+aligns `navigator.languages` to the user's locale, and ensures `window.chrome` exists.
+Combined with the per-user geo/timezone/locale overrides, the JS fingerprint is
+consistent and non-automated-looking.
+
+**Honest limitation:** the dominant "logging in from a new location" signal is the
+**egress IP**, not the browser fingerprint. Stealth removes the *automation* tells but a
+datacenter/VPS IP geographically far from where the user normally logs in will still draw
+device-approval challenges. The durable fix is a per-user **residential proxy / VPN egress**
+matched to the user's location (schema groundwork is already in place via the geo fields).

--- a/poetry.lock
+++ b/poetry.lock
@@ -58,7 +58,7 @@ version = "0.7.0"
 description = "Reusable constraint types to use with typing.Annotated"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "mcp"]
 files = [
     {file = "annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"},
     {file = "annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89"},
@@ -70,7 +70,7 @@ version = "4.14.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev", "streamlit"]
+groups = ["main", "dev", "mcp", "streamlit"]
 files = [
     {file = "anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9"},
     {file = "anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89"},
@@ -222,7 +222,7 @@ version = "26.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "streamlit"]
+groups = ["main", "dev", "mcp", "streamlit"]
 files = [
     {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
     {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
@@ -670,7 +670,7 @@ version = "2026.6.17"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev", "streamlit", "test"]
+groups = ["main", "dev", "mcp", "streamlit", "test"]
 files = [
     {file = "certifi-2026.6.17-py3-none-any.whl", hash = "sha256:2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"},
     {file = "certifi-2026.6.17.tar.gz", hash = "sha256:024c88eeec92ca068db80f02b8b07c9cef7b9fe261d1d535abfd5abd6f6af432"},
@@ -682,7 +682,7 @@ version = "2.0.0"
 description = "Foreign Function Interface for Python calling C code."
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev"]
+groups = ["main", "dev", "mcp"]
 files = [
     {file = "cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44"},
     {file = "cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49"},
@@ -769,7 +769,7 @@ files = [
     {file = "cffi-2.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9"},
     {file = "cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529"},
 ]
-markers = {main = "os_name == \"nt\" and implementation_name != \"pypy\" or platform_python_implementation != \"PyPy\""}
+markers = {main = "os_name == \"nt\" and implementation_name != \"pypy\" or platform_python_implementation != \"PyPy\"", mcp = "platform_python_implementation != \"PyPy\""}
 
 [package.dependencies]
 pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
@@ -919,11 +919,12 @@ version = "8.4.1"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "streamlit"]
+groups = ["main", "mcp", "streamlit"]
 files = [
     {file = "click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2"},
     {file = "click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"},
 ]
+markers = {mcp = "sys_platform != \"emscripten\""}
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -998,12 +999,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev", "streamlit", "test"]
+groups = ["main", "dev", "mcp", "streamlit", "test"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", streamlit = "platform_system == \"Windows\"", test = "sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\"", mcp = "sys_platform != \"emscripten\" and platform_system == \"Windows\"", streamlit = "platform_system == \"Windows\"", test = "sys_platform == \"win32\""}
 
 [[package]]
 name = "comm"
@@ -1162,7 +1163,7 @@ version = "49.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
-groups = ["main"]
+groups = ["main", "mcp"]
 files = [
     {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
     {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
@@ -1752,7 +1753,7 @@ version = "0.16.0"
 description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev", "streamlit"]
+groups = ["main", "dev", "mcp", "streamlit"]
 files = [
     {file = "h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"},
     {file = "h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1"},
@@ -1764,7 +1765,7 @@ version = "1.0.9"
 description = "A minimal low-level HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "mcp"]
 files = [
     {file = "httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55"},
     {file = "httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8"},
@@ -1846,7 +1847,7 @@ version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
-groups = ["main", "dev"]
+groups = ["main", "dev", "mcp"]
 files = [
     {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
     {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
@@ -1864,6 +1865,18 @@ cli = ["click (==8.*)", "pygments (==2.*)", "rich (>=10,<14)"]
 http2 = ["h2 (>=3,<5)"]
 socks = ["socksio (==1.*)"]
 zstd = ["zstandard (>=0.18.0)"]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+description = "Consume Server-Sent Event (SSE) messages with HTTPX."
+optional = false
+python-versions = ">=3.9"
+groups = ["mcp"]
+files = [
+    {file = "httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc"},
+    {file = "httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d"},
+]
 
 [[package]]
 name = "humanize"
@@ -1886,7 +1899,7 @@ version = "3.18"
 description = "Internationalized Domain Names in Applications (IDNA)"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "streamlit", "test"]
+groups = ["main", "dev", "mcp", "streamlit", "test"]
 files = [
     {file = "idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"},
     {file = "idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848"},
@@ -2292,7 +2305,7 @@ version = "4.26.0"
 description = "An implementation of JSON Schema validation for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev", "streamlit"]
+groups = ["dev", "mcp", "streamlit"]
 files = [
     {file = "jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce"},
     {file = "jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326"},
@@ -2323,7 +2336,7 @@ version = "2025.9.1"
 description = "The JSON Schema meta-schemas and vocabularies, exposed as a Registry"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev", "streamlit"]
+groups = ["dev", "mcp", "streamlit"]
 files = [
     {file = "jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe"},
     {file = "jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d"},
@@ -2990,6 +3003,48 @@ traitlets = "*"
 
 [package.extras]
 test = ["flake8", "matplotlib", "nbdime", "nbval", "notebook", "pytest"]
+
+[[package]]
+name = "mcp"
+version = "1.28.1"
+description = "Model Context Protocol SDK"
+optional = false
+python-versions = ">=3.10"
+groups = ["mcp"]
+files = [
+    {file = "mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df"},
+    {file = "mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683"},
+]
+
+[package.dependencies]
+anyio = ">=4.5"
+httpx = ">=0.27.1,<1.0.0"
+httpx-sse = ">=0.4"
+jsonschema = ">=4.20.0"
+pydantic = [
+    {version = ">=2.11.0,<3.0.0", markers = "python_version < \"3.14\""},
+    {version = ">=2.12.0,<3.0.0", markers = "python_version >= \"3.14\""},
+]
+pydantic-settings = ">=2.5.2"
+pyjwt = {version = ">=2.10.1", extras = ["crypto"]}
+python-multipart = ">=0.0.9"
+pywin32 = [
+    {version = ">=310", markers = "sys_platform == \"win32\" and python_version < \"3.14\""},
+    {version = ">=311", markers = "sys_platform == \"win32\" and python_version >= \"3.14\""},
+]
+sse-starlette = ">=1.6.1"
+starlette = [
+    {version = ">=0.27", markers = "python_version < \"3.14\""},
+    {version = ">=0.48.0", markers = "python_version >= \"3.14\""},
+]
+typing-extensions = ">=4.9.0"
+typing-inspection = ">=0.4.1"
+uvicorn = {version = ">=0.31.1", markers = "sys_platform != \"emscripten\""}
+
+[package.extras]
+cli = ["python-dotenv (>=1.0.0)", "typer (>=0.16.0)"]
+rich = ["rich (>=13.9.4)"]
+ws = ["websockets (>=15.0.1)"]
 
 [[package]]
 name = "mistune"
@@ -4146,12 +4201,12 @@ version = "3.0"
 description = "C parser in Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "dev"]
+groups = ["main", "dev", "mcp"]
 files = [
     {file = "pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"},
     {file = "pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29"},
 ]
-markers = {main = "(os_name == \"nt\" and implementation_name != \"pypy\" or platform_python_implementation != \"PyPy\") and implementation_name != \"PyPy\"", dev = "implementation_name != \"PyPy\""}
+markers = {main = "(os_name == \"nt\" and implementation_name != \"pypy\" or platform_python_implementation != \"PyPy\") and implementation_name != \"PyPy\"", dev = "implementation_name != \"PyPy\"", mcp = "platform_python_implementation != \"PyPy\" and implementation_name != \"PyPy\""}
 
 [[package]]
 name = "pycurl"
@@ -4212,7 +4267,7 @@ version = "2.13.4"
 description = "Data validation using Python type hints"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "mcp"]
 files = [
     {file = "pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"},
     {file = "pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6"},
@@ -4234,7 +4289,7 @@ version = "2.46.4"
 description = "Core functionality for Pydantic validation and serialization"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "mcp"]
 files = [
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4"},
     {file = "pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5"},
@@ -4388,6 +4443,30 @@ semver = ["semver (>=3.0.2)"]
 uuid-utils = ["uuid-utils (>=0.6.0) ; python_version < \"3.14\""]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.2"
+description = "Settings management using Pydantic"
+optional = false
+python-versions = ">=3.10"
+groups = ["mcp"]
+files = [
+    {file = "pydantic_settings-2.14.2-py3-none-any.whl", hash = "sha256:a20c97b37910b6550d5ea50fbcc2d4187defe58cd57070b73863d069419c9440"},
+    {file = "pydantic_settings-2.14.2.tar.gz", hash = "sha256:c19dd64b19097f1de80184f0cc7b0272a13ae6e170cbf240a3e27e381ed14a5f"},
+]
+
+[package.dependencies]
+pydantic = ">=2.7.0"
+python-dotenv = ">=0.21.0"
+typing-inspection = ">=0.4.0"
+
+[package.extras]
+aws-secrets-manager = ["boto3 (>=1.35.0)", "types-boto3[secretsmanager]"]
+azure-key-vault = ["azure-identity (>=1.16.0)", "azure-keyvault-secrets (>=4.8.0)"]
+gcp-secret-manager = ["google-cloud-secret-manager (>=2.23.1)"]
+toml = ["tomli (>=2.0.1)"]
+yaml = ["pyyaml (>=6.0.1)"]
+
+[[package]]
 name = "pydeck"
 version = "0.9.2"
 description = "Widget for deck.gl maps"
@@ -4439,6 +4518,24 @@ files = [
 
 [package.extras]
 windows-terminal = ["colorama (>=0.4.6)"]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["mcp"]
+files = [
+    {file = "pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728"},
+    {file = "pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423"},
+]
+
+[package.dependencies]
+cryptography = {version = ">=3.4.0", optional = true, markers = "extra == \"crypto\""}
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
 
 [[package]]
 name = "pyparsing"
@@ -4650,7 +4747,7 @@ version = "1.2.2"
 description = "Read key-value pairs from a .env file and set them as environment variables"
 optional = false
 python-versions = ">=3.10"
-groups = ["main"]
+groups = ["main", "mcp"]
 files = [
     {file = "python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"},
     {file = "python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3"},
@@ -4692,7 +4789,7 @@ version = "0.0.32"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "streamlit"]
+groups = ["main", "mcp", "streamlit"]
 files = [
     {file = "python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23"},
     {file = "python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e"},
@@ -4744,6 +4841,38 @@ groups = ["main"]
 files = [
     {file = "pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126"},
     {file = "pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a"},
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+description = "Python for Windows Extensions"
+optional = false
+python-versions = ">=3.9"
+groups = ["mcp"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "pywin32-312-cp310-cp310-win32.whl", hash = "sha256:772235332b5d1024c696f11cea1ae4be7930f0a8b894bb43db14e3f435f1ff7e"},
+    {file = "pywin32-312-cp310-cp310-win_amd64.whl", hash = "sha256:5dbc35d2b5320dc07f25fa31269cfb767471002b17de5eb067d03da68c7cb2db"},
+    {file = "pywin32-312-cp310-cp310-win_arm64.whl", hash = "sha256:3020656e34f1cf7faeb7bccd2b84653a607c6ff0c55ada85e6487d61716deabd"},
+    {file = "pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c"},
+    {file = "pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a"},
+    {file = "pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47"},
+    {file = "pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b"},
+    {file = "pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc"},
+    {file = "pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950"},
+    {file = "pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c"},
+    {file = "pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9"},
+    {file = "pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831"},
+    {file = "pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b"},
+    {file = "pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e"},
+    {file = "pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa"},
+    {file = "pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed"},
+    {file = "pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5"},
+    {file = "pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9"},
+    {file = "pywin32-312-cp39-cp39-win32.whl", hash = "sha256:d620900033cc7531e50727c3c8333091df5dd3ffe6d68cdca38c03f5821408d5"},
+    {file = "pywin32-312-cp39-cp39-win_amd64.whl", hash = "sha256:dc90147579a905b8635e1b0ec6514967dcb07e6e0d9c42f1477feef14cac23bb"},
+    {file = "pywin32-312-cp39-cp39-win_arm64.whl", hash = "sha256:02ebca0f0242b75292e218065004310d6a477407c09fa449bfe4f6022bc0c0fc"},
 ]
 
 [[package]]
@@ -4983,7 +5112,7 @@ version = "0.37.0"
 description = "JSON Referencing + Python"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev", "streamlit"]
+groups = ["dev", "mcp", "streamlit"]
 files = [
     {file = "referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231"},
     {file = "referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8"},
@@ -5224,7 +5353,7 @@ version = "2026.5.1"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.11"
-groups = ["dev", "streamlit"]
+groups = ["dev", "mcp", "streamlit"]
 files = [
     {file = "rpds_py-2026.5.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:3397a5ed7174dc2786bb214030232fc36fe8e5584fec43a9952cc542b1a12036"},
     {file = "rpds_py-2026.5.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:99ab6ba7bfa2cb0f96a04e3652355bf04e3f51aceb1e943b8541dab7ba4828cc"},
@@ -5562,6 +5691,29 @@ files = [
 ]
 
 [[package]]
+name = "sse-starlette"
+version = "3.4.5"
+description = "SSE plugin for Starlette"
+optional = false
+python-versions = ">=3.10"
+groups = ["mcp"]
+files = [
+    {file = "sse_starlette-3.4.5-py3-none-any.whl", hash = "sha256:e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296"},
+    {file = "sse_starlette-3.4.5.tar.gz", hash = "sha256:83072538bc211a2f68b7b0422226c4af3e9b62e106e07034664b832ca019842a"},
+]
+
+[package.dependencies]
+anyio = ">=4.7.0"
+starlette = ">=0.49.1"
+
+[package.extras]
+daphne = ["daphne (>=4.2.0)"]
+examples = ["fastapi (>=0.115.12)", "pydantic (>=2)", "uvicorn (>=0.34.0)"]
+examples-db = ["aiosqlite (>=0.21.0)", "sqlalchemy[asyncio] (>=2.0.41)"]
+granian = ["granian (>=2.3.1)"]
+uvicorn = ["uvicorn (>=0.34.0)"]
+
+[[package]]
 name = "stack-data"
 version = "0.6.3"
 description = "Extract data from python stack frames and tracebacks for informative displays"
@@ -5587,7 +5739,7 @@ version = "1.3.1"
 description = "The little ASGI library that shines."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "streamlit"]
+groups = ["main", "mcp", "streamlit"]
 files = [
     {file = "starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"},
     {file = "starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0"},
@@ -5952,7 +6104,7 @@ version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main", "dev", "streamlit", "test"]
+groups = ["main", "dev", "mcp", "streamlit", "test"]
 files = [
     {file = "typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"},
     {file = "typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466"},
@@ -5964,7 +6116,7 @@ version = "0.4.2"
 description = "Runtime typing introspection tools"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "mcp"]
 files = [
     {file = "typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"},
     {file = "typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464"},
@@ -6047,11 +6199,12 @@ version = "0.49.0"
 description = "The lightning-fast ASGI server."
 optional = false
 python-versions = ">=3.10"
-groups = ["main", "streamlit"]
+groups = ["main", "mcp", "streamlit"]
 files = [
     {file = "uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f"},
     {file = "uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3"},
 ]
+markers = {mcp = "sys_platform != \"emscripten\""}
 
 [package.dependencies]
 click = ">=7.0"
@@ -6426,4 +6579,4 @@ type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "19396fe7c92574d3cdcf0dbde237804882f827fb29d04c0fdd1477042c99aad2"
+content-hash = "84b4c9b606c95f5f9cf7cd928dca9f5f46964aa6fa1e9e82adf7f630209a518c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,15 @@ optional = true
 [tool.poetry.group.lint.dependencies]
 ruff = ">=0.1.5,<0.16.0"
 
+[tool.poetry.group.mcp]
+optional = true
+
+[tool.poetry.group.mcp.dependencies]
+# Powers tools/selenium_mcp_server.py — an MCP server that drives the live
+# selenium-chrome browser (watchable via lemvnc) for interactive debugging.
+# Install with: poetry install --with mcp
+mcp = ">=1.2.0"
+
 [tool.poetry.group.test]
 optional = true
 

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -75,6 +75,91 @@ def _send_via_smtp(to_email: str, html_content: str) -> bool:
         return False
 
 
+def _build_approval_html(vnc_url: str | None) -> str:
+    watch = (
+        f'<p>Want to watch it happen live? <a href="{vnc_url}">Open the session viewer</a>.</p>'
+        if vnc_url else ""
+    )
+    return f"""
+    <html><body>
+    <h2>Action needed: approve your LinkedIn sign-in</h2>
+    <p>LinkedIn Engagement Manager is signing in to LinkedIn on your behalf, and
+    LinkedIn asked to <strong>verify this sign-in from your device</strong>.</p>
+    <ol>
+      <li>Open the <strong>LinkedIn mobile app</strong>.</li>
+      <li>You'll see a "Did you just try to sign in?" prompt — tap <strong>Yes</strong>.</li>
+    </ol>
+    <p>This is expected and safe — it's our automation, not someone else. Approving once
+    lets LinkedIn remember the device so you won't be asked every time.</p>
+    {watch}
+    <p style="color:#888;font-size:12px;">If you were not expecting any automation activity,
+    do not approve, and change your LinkedIn password.</p>
+    </body></html>
+    """
+
+
+def send_login_approval_email(to_email: str, vnc_url: str | None = None) -> bool:
+    """Send a HIGH-PRIORITY email asking the user to approve a LinkedIn device sign-in.
+
+    LinkedIn's "Check your LinkedIn app → tap Yes" challenge can't be solved
+    programmatically, so the automation pauses briefly waiting for approval. This
+    notifies the user immediately (flagged high priority) so they can act instead of
+    the run silently stalling. Best-effort: returns True only if an email was dispatched.
+    """
+    has_sendgrid = bool(SENDGRID_API_KEY)
+    has_smtp = bool(SMTP_USER) and bool(SMTP_PASSWORD)
+    if not has_sendgrid and not has_smtp:
+        myprint("No email provider configured — cannot send login-approval notice")
+        return False
+
+    subject = "⚠️ Action needed: approve your LinkedIn sign-in"
+    html = _build_approval_html(vnc_url)
+
+    if has_sendgrid:
+        try:
+            from sendgrid import SendGridAPIClient
+            from sendgrid.helpers.mail import Header, Mail
+
+            message = Mail(
+                from_email=SENDGRID_FROM_EMAIL,
+                to_emails=to_email,
+                subject=subject,
+                html_content=html,
+            )
+            # High-priority headers (Outlook/Gmail honor these)
+            message.header = Header("X-Priority", "1")
+            message.header = Header("X-MSMail-Priority", "High")
+            message.header = Header("Importance", "High")
+            SendGridAPIClient(SENDGRID_API_KEY).send(message)
+            myprint(f"Login-approval email sent via SendGrid to {to_email}")
+            return True
+        except Exception as e:
+            myprint(f"SendGrid login-approval send failed for {to_email}: {e}")
+
+    if has_smtp:
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = subject
+        msg["From"] = SMTP_USER
+        msg["To"] = to_email
+        msg["X-Priority"] = "1"
+        msg["X-MSMail-Priority"] = "High"
+        msg["Importance"] = "High"
+        msg.attach(MIMEText(html, "html"))
+        try:
+            with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=15) as server:
+                server.ehlo()
+                server.starttls()
+                server.login(SMTP_USER, SMTP_PASSWORD)
+                server.sendmail(SMTP_USER, to_email, msg.as_string())
+            myprint(f"Login-approval email sent via SMTP to {to_email}")
+            return True
+        except Exception as e:
+            myprint(f"SMTP login-approval send failed for {to_email}: {e}")
+            return False
+
+    return False
+
+
 def send_pin_email(
     to_email: str,
     pin: str,

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -155,14 +155,26 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
         give them a configurable window before giving up.
         """
         timeout = int(os.getenv("LINKEDIN_APPROVAL_WAIT_SECONDS", "120"))
-        if timeout <= 0:
-            return False
         log_warning(
             "LinkedIn device-approval required — open your LinkedIn mobile app and tap "
             "'Yes' to confirm this sign-in (watch via VNC). Waiting up to "
             f"{timeout}s for approval.",
             action_type="login",
         )
+        # Notify the user immediately (high priority) so a human can approve instead of
+        # the run silently stalling. Best-effort — never let email problems break login.
+        if os.getenv("LINKEDIN_APPROVAL_EMAIL_ENABLED", "true").lower() != "false":
+            try:
+                from cqc_lem.utilities.email import send_login_approval_email
+                vnc_url = os.getenv(
+                    "LEMVNC_URL",
+                    "https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret",
+                )
+                send_login_approval_email(user_email, vnc_url=vnc_url)
+            except Exception as e:
+                log_warning("Failed to send login-approval email", exc=e, action_type="login")
+        if timeout <= 0:
+            return False
         deadline = time.time() + timeout
         while time.time() < deadline:
             time.sleep(5)

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -8,7 +8,9 @@ from cqc_lem.utilities.db import get_cookies, store_cookies, get_linked_in_profi
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.linkedin.scrapper import returnProfileInfo
 from cqc_lem.utilities.logger import myprint, log_warning, log_error
-from cqc_lem.utilities.selenium_util import load_cookies, click_element_wait_retry, get_element_wait_retry, getText
+from cqc_lem.utilities.selenium_util import load_cookies, get_element_wait_retry, \
+    get_visible_element_wait_retry, getText
+from selenium.common.exceptions import WebDriverException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.support import expected_conditions as EC
@@ -143,13 +145,52 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
     def _is_logged_in(url: str) -> bool:
         return any(p in url for p in _LOGGED_IN_PATHS)
 
+    def _wait_for_manual_approval() -> bool:
+        """Poll for a device-approval / 2FA checkpoint to clear.
+
+        LinkedIn's "Check your LinkedIn app — tap Yes" challenge cannot be solved
+        programmatically; it needs a one-time tap in the user's mobile app (the
+        "Recognize this device" box is pre-checked, so cookies persist afterward).
+        When someone is watching the session over VNC they can approve in real time —
+        give them a configurable window before giving up.
+        """
+        timeout = int(os.getenv("LINKEDIN_APPROVAL_WAIT_SECONDS", "120"))
+        if timeout <= 0:
+            return False
+        log_warning(
+            "LinkedIn device-approval required — open your LinkedIn mobile app and tap "
+            "'Yes' to confirm this sign-in (watch via VNC). Waiting up to "
+            f"{timeout}s for approval.",
+            action_type="login",
+        )
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            time.sleep(5)
+            current = driver.current_url
+            if _is_logged_in(current):
+                myprint("Device-approval confirmed — login proceeding")
+                return True
+            if not _is_challenge_url(current):
+                # Left the checkpoint; give the post-approval redirect a moment to settle
+                time.sleep(3)
+                if _is_logged_in(driver.current_url):
+                    myprint("Device-approval confirmed — login proceeding")
+                    return True
+        return False
+
     def _handle_challenge(label: str) -> None:
-        """Try to solve an Arkose challenge; raise if unsolvable."""
+        """Clear a login challenge or raise if it can't be cleared.
+
+        Order: try the automated Arkose/FunCaptcha solver, then fall back to
+        waiting for a manual mobile-app device approval.
+        """
         if solve_arkose_challenge(driver, wait):
             myprint(f"CAPTCHA solved at {label} — continuing login")
             time.sleep(2)
-        else:
-            raise RuntimeError(f"Unsolvable LinkedIn challenge at {label}: {driver.current_url}")
+            return
+        if _wait_for_manual_approval():
+            return
+        raise RuntimeError(f"Unsolvable LinkedIn challenge at {label}: {driver.current_url}")
 
     # Load base domain first so cookies can be set against the right origin
     driver.get(linked_url)
@@ -187,12 +228,44 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
     if _is_challenge_url(driver.current_url):
         _handle_challenge("login-page")
 
-    username_field = get_element_wait_retry(driver, wait, 'username', "Finding Username Field", By.ID)
-    password_field = get_element_wait_retry(driver, wait, 'password', "Finding Password Field", By.ID)
+    # LinkedIn's redesigned login page no longer uses stable id="username"/id="password"
+    # or a [type=submit] button — fields now carry ephemeral React ids and the sign-in
+    # control is a <button type="button"><span>Sign in</span></button>. Match on stable
+    # type/autocomplete attributes (and visible text for the button), keeping the legacy
+    # selectors as fallbacks for any A/B variant still serving the old form. The page also
+    # renders duplicate hidden+visible copies, so we must select the displayed one.
+    username_field = get_visible_element_wait_retry(
+        driver, wait,
+        [(By.CSS_SELECTOR, "input[autocomplete~='username']"),
+         (By.CSS_SELECTOR, "input[name='session_key']"),
+         (By.ID, "username"),
+         (By.CSS_SELECTOR, "input[type='email']")],
+        "Finding Username Field")
+    password_field = get_visible_element_wait_retry(
+        driver, wait,
+        [(By.CSS_SELECTOR, "input[autocomplete~='current-password']"),
+         (By.CSS_SELECTOR, "input[name='session_password']"),
+         (By.ID, "password"),
+         (By.CSS_SELECTOR, "input[type='password']")],
+        "Finding Password Field")
 
+    username_field.clear()
     username_field.send_keys(user_email)
+    password_field.clear()
     password_field.send_keys(user_password)
-    click_element_wait_retry(driver, wait, '//*[@type="submit"]', "Finding Login Button", use_action_chain=True)
+
+    sign_in_button = get_visible_element_wait_retry(
+        driver, wait,
+        [(By.XPATH, "//button[normalize-space()='Sign in']"),
+         (By.CSS_SELECTOR, "button[type='submit']"),
+         (By.CSS_SELECTOR, "button[aria-label='Sign in']"),
+         (By.XPATH, "//*[@type='submit']")],
+        "Finding Sign in Button")
+    wait.until(EC.element_to_be_clickable(sign_in_button))
+    try:
+        sign_in_button.click()
+    except WebDriverException:
+        driver.execute_script("arguments[0].click();", sign_in_button)
 
     # Allow the post-submit redirect to settle, then check for security challenges
     # before waiting for the feed (avoids TimeoutException on 2FA/CAPTCHA pages)

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -120,6 +120,20 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
     driver = webdriver.Remote(command_executor=remote_url, options=options)
     driver.set_window_size(1920, 1080)
 
+    # Stealth: scrub the most-checked automation tells before any page script runs.
+    # navigator.webdriver=undefined (the #1 signal), a realistic navigator.languages
+    # matching the user's locale, and a present window.chrome. Best-effort.
+    primary_lang = user_locale.split("-")[0] if user_locale else "en"
+    stealth_js = (
+        "Object.defineProperty(navigator,'webdriver',{get:()=>undefined});"
+        f"Object.defineProperty(navigator,'languages',{{get:()=>['{user_locale}','{primary_lang}']}});"
+        "window.chrome=window.chrome||{runtime:{}};"
+    )
+    try:
+        driver.execute_cdp_cmd("Page.addScriptToEvaluateOnNewDocument", {"source": stealth_js})
+    except Exception as e:
+        myprint(f"Could not apply stealth init script | Error: {e}")
+
     if coordinates is None:
         coordinates = {
             "latitude": lat if lat is not None else 30.3321,
@@ -149,15 +163,17 @@ def add_headless_options(options: Options) -> Options:
     options.add_argument('--disable-popup-blocking')  # Working
     options.add_argument('--incognito')  # Working
     options.add_argument('--no-sandbox')  # Working
-    options.add_argument('--enable-automation')  # Working
     options.add_argument('--disable-gpu')  # Working
     options.add_argument('--disable-extensions')  # Working
     options.add_argument('--disable-infobars')  # Working
+    # NOTE: deliberately NOT adding --enable-automation — it advertises automation
+    # (sets navigator.webdriver=true), which is exactly what we want to avoid.
     options.add_argument('--disable-browser-side-navigation')  # Working
     options.add_argument('--disable-dev-shm-usage')  # Working
     options.add_argument('--disable-features=VizDisplayCompositor')  # Working
     options.add_argument('--dns-prefetch-disable')  # Working
     options.add_argument("--force-device-scale-factor=1")  # Working
+    options.add_argument("--disable-blink-features=AutomationControlled")  # stealth
 
     options.set_capability('goog:loggingPrefs', {'performance': 'ALL'})
 
@@ -180,6 +196,15 @@ def getBaseOptions(base_download_directory: str = None):
     options.add_argument('--disable-dev-shm-usage')
 
     # Options to make us undetectable (Review https://amiunique.org/fingerprint from the browser to verify)
+    # Stealth flags: stop Chrome advertising automation. --disable-blink-features=
+    # AutomationControlled keeps navigator.webdriver from being forced to true, and the
+    # excludeSwitches/useAutomationExtension pair removes the "controlled by automated
+    # test software" banner and the cdc_ automation extension — both are signals LinkedIn
+    # uses to flag a session as a bot. (Note: the dominant "new device/location" signal is
+    # still the egress IP; these reduce the automation fingerprint, not the IP geo.)
+    options.add_argument("--disable-blink-features=AutomationControlled")
+    options.add_experimental_option("excludeSwitches", ["enable-automation"])
+    options.add_experimental_option("useAutomationExtension", False)
     options.add_argument("window-size=1920x1080")
     options.add_argument(
         # "user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -284,6 +284,45 @@ def get_element_wait_retry(driver: WebDriver, wait: WebDriverWait, find_by_value
     return element
 
 
+def get_visible_element_wait_retry(driver: WebDriver, wait: WebDriverWait,
+                                   locators: list[tuple[str, str]], wait_text: str,
+                                   max_try: int = MAX_WAIT_RETRY,
+                                   element_always_expected: bool = True) -> WebElement | None:
+    """Return the first *displayed* element matching any of `locators`.
+
+    `locators` is an ordered list of (By, value) pairs tried in turn. Some pages
+    (e.g. LinkedIn's redesigned login) render duplicate hidden+visible copies of
+    the same field, so matching on presence alone can return an invisible element —
+    we must pick the one the user actually sees.
+    """
+
+    def _find_visible(d):
+        for find_by, value in locators:
+            try:
+                for el in d.find_elements(find_by, value):
+                    try:
+                        if el.is_displayed():
+                            return el
+                    except StaleElementReferenceException:
+                        continue
+            except (StaleElementReferenceException, NoSuchElementException):
+                continue
+        return False
+
+    try:
+        return wait.until(_find_visible, wait_text)
+    except (StaleElementReferenceException, TimeoutException) as se:
+        if max_try > 1:
+            myprint(wait_text + " | Not visible | .....retrying")
+            time.sleep(5)
+            return get_visible_element_wait_retry(driver, wait, locators, wait_text,
+                                                  max_try - 1, element_always_expected)
+        if element_always_expected:
+            raise se
+        myprint(f"Failed to find visible element: {wait_text}")
+        return None
+
+
 def get_elements_as_list_wait_stale(wait: WebDriverWait, find_by_value: str, wait_text: str,
                                     find_by: str = By.XPATH, max_retry=3) -> list[WebElement]:
     elements = []

--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -16,6 +16,13 @@ def _no_real_sleep():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _no_approval_wait(monkeypatch):
+    """Disable the device-approval wait loop by default — it polls real wall-clock
+    for minutes. Tests that exercise the approval path opt back in explicitly."""
+    monkeypatch.setenv("LINKEDIN_APPROVAL_WAIT_SECONDS", "0")
+
+
 def _make_driver(url: str) -> MagicMock:
     driver = MagicMock()
     driver.current_url = url
@@ -127,8 +134,7 @@ class TestLoginToLinkedinCookiePath:
         with patch(f"{_MODULE}.get_cookies", return_value=None), \
              patch(f"{_MODULE}.load_cookies"), \
              patch(f"{_MODULE}.store_cookies") as mock_store, \
-             patch(f"{_MODULE}.get_element_wait_retry", return_value=mock_field), \
-             patch(f"{_MODULE}.click_element_wait_retry"):
+             patch(f"{_MODULE}.get_visible_element_wait_retry", return_value=mock_field):
             from cqc_lem.utilities.linkedin.helper import login_to_linkedin
             login_to_linkedin(driver, wait, "user@e.com", "pw")
 
@@ -296,14 +302,52 @@ class TestLoginToLinkedinPostSubmitChallenge:
         with patch(f"{_MODULE}.get_cookies", return_value=None), \
              patch(f"{_MODULE}.load_cookies"), \
              patch(f"{_MODULE}.store_cookies"), \
-             patch(f"{_MODULE}.get_element_wait_retry", return_value=mock_field), \
-             patch(f"{_MODULE}.click_element_wait_retry", side_effect=advance_url), \
+             patch(f"{_MODULE}.get_visible_element_wait_retry", return_value=mock_field), \
              patch(f"{_MODULE}.solve_arkose_challenge", return_value=False) as mock_solve:
             with pytest.raises(RuntimeError, match="Unsolvable LinkedIn challenge"):
                 from cqc_lem.utilities.linkedin.helper import login_to_linkedin
                 login_to_linkedin(driver, wait, "user@e.com", "pw")
 
         mock_solve.assert_called_once()
+
+    def test_manual_approval_clears_checkpoint_and_logs_in(self, monkeypatch):
+        """Device-approval checkpoint that clears mid-wait (user taps 'Yes' in the
+        mobile app) → login completes and cookies are persisted."""
+        monkeypatch.setenv("LINKEDIN_APPROVAL_WAIT_SECONDS", "30")
+
+        # url is driven by side effects: gets land on /login, the Sign-in click moves
+        # to the checkpoint, and the first sleep *inside* challenge handling flips to /feed.
+        state = {"url": "https://www.linkedin.com", "handling": False}
+        driver = MagicMock()
+        driver.get_cookies.return_value = [{"name": "li_at"}]
+        driver.find_elements.return_value = []
+        type(driver).current_url = property(lambda self: state["url"])
+        driver.get.side_effect = lambda u: state.__setitem__("url", "https://www.linkedin.com/login")
+
+        mock_field = MagicMock()
+        mock_field.click.side_effect = lambda: state.__setitem__(
+            "url", "https://www.linkedin.com/checkpoint/challenge")
+
+        def fake_solve(*_a, **_k):
+            state["handling"] = True  # entered challenge handling
+            return False
+
+        def sleep_flip(*_a, **_k):
+            if state["handling"]:  # first poll inside the approval wait → user approved
+                state["url"] = "https://www.linkedin.com/feed/"
+
+        wait = _make_wait()
+        with patch(f"{_MODULE}.get_cookies", return_value=None), \
+             patch(f"{_MODULE}.load_cookies"), \
+             patch(f"{_MODULE}.store_cookies") as mock_store, \
+             patch(f"{_MODULE}.get_visible_element_wait_retry", return_value=mock_field), \
+             patch(f"{_MODULE}.solve_arkose_challenge", side_effect=fake_solve) as mock_solve, \
+             patch(f"{_MODULE}.time.sleep", side_effect=sleep_flip):
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "user@e.com", "pw")
+
+        mock_solve.assert_called_once()
+        mock_store.assert_called_once()
 
     def test_new_challenge_paths_detected(self):
         """Newly added challenge paths (/captcha/, /security-verification) are caught."""

--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -23,6 +23,14 @@ def _no_approval_wait(monkeypatch):
     monkeypatch.setenv("LINKEDIN_APPROVAL_WAIT_SECONDS", "0")
 
 
+@pytest.fixture(autouse=True)
+def _stub_approval_email():
+    """Stub the high-priority approval email (lazily imported inside the login flow)
+    so tests never touch a real provider; tests can assert on the returned mock."""
+    with patch("cqc_lem.utilities.email.send_login_approval_email", return_value=True) as m:
+        yield m
+
+
 def _make_driver(url: str) -> MagicMock:
     driver = MagicMock()
     driver.current_url = url
@@ -309,6 +317,37 @@ class TestLoginToLinkedinPostSubmitChallenge:
                 login_to_linkedin(driver, wait, "user@e.com", "pw")
 
         mock_solve.assert_called_once()
+
+    def test_device_approval_emails_user_high_priority(self, _stub_approval_email):
+        """When the post-submit device-approval challenge is hit, the user is emailed."""
+        url_seq = [
+            "https://www.linkedin.com",
+            "https://www.linkedin.com/login",
+            "https://www.linkedin.com/checkpoint/challenge",
+        ]
+        idx = [0]
+        driver = MagicMock()
+        driver.get_cookies.return_value = [{"name": "li_at"}]
+        driver.find_elements.return_value = []
+
+        def advance_url(url=None):
+            idx[0] = min(idx[0] + 1, len(url_seq) - 1)
+
+        type(driver).current_url = property(lambda self: url_seq[idx[0]])
+        driver.get.side_effect = advance_url
+
+        wait = _make_wait()
+        with patch(f"{_MODULE}.get_cookies", return_value=None), \
+             patch(f"{_MODULE}.load_cookies"), \
+             patch(f"{_MODULE}.store_cookies"), \
+             patch(f"{_MODULE}.get_visible_element_wait_retry", return_value=MagicMock()), \
+             patch(f"{_MODULE}.solve_arkose_challenge", return_value=False), \
+             pytest.raises(RuntimeError):
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "approver@e.com", "pw")
+
+        _stub_approval_email.assert_called_once()
+        assert _stub_approval_email.call_args[0][0] == "approver@e.com"
 
     def test_manual_approval_clears_checkpoint_and_logs_in(self, monkeypatch):
         """Device-approval checkpoint that clears mid-wait (user taps 'Yes' in the

--- a/tests/unit/utilities/test_email.py
+++ b/tests/unit/utilities/test_email.py
@@ -153,3 +153,59 @@ class TestSendPinEmailBypass:
         assert success is True
         assert bypassed is True
         mock_smtp_class.assert_not_called()
+
+
+class TestSendLoginApprovalEmail:
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", None)
+    @patch("cqc_lem.utilities.email.SMTP_USER", None)
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", None)
+    def test_returns_false_when_no_provider(self):
+        from cqc_lem.utilities.email import send_login_approval_email
+        assert send_login_approval_email("u@e.com") is False
+
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", "sg_test_key")
+    @patch("cqc_lem.utilities.email.SMTP_USER", None)
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", None)
+    @patch("sendgrid.SendGridAPIClient")
+    def test_sendgrid_sets_high_priority_headers(self, mock_sg_class):
+        from cqc_lem.utilities.email import send_login_approval_email
+        mock_sg = MagicMock()
+        mock_sg_class.return_value = mock_sg
+
+        sent_messages = []
+        mock_sg.send.side_effect = lambda m: sent_messages.append(m)
+
+        result = send_login_approval_email("u@e.com", vnc_url="https://vnc.example/?x=1")
+
+        assert result is True
+        mock_sg.send.assert_called_once()
+        # High-priority headers must be attached
+        header_blob = str(sent_messages[0].get())
+        assert "X-Priority" in header_blob and "1" in header_blob
+        assert "Importance" in header_blob
+
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", None)
+    @patch("cqc_lem.utilities.email.SMTP_USER", "user@gmail.com")
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", "app_password")
+    @patch("cqc_lem.utilities.email.smtplib.SMTP")
+    def test_smtp_sets_high_priority_headers(self, mock_smtp_class):
+        from cqc_lem.utilities.email import send_login_approval_email
+        sent = {}
+        server = MagicMock()
+        server.sendmail.side_effect = lambda frm, to, body: sent.update(body=body)
+        mock_smtp_class.return_value.__enter__.return_value = server
+
+        result = send_login_approval_email("u@e.com")
+
+        assert result is True
+        assert "X-Priority: 1" in sent["body"]
+        assert "Importance: High" in sent["body"]
+
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", None)
+    @patch("cqc_lem.utilities.email.SMTP_USER", "user@gmail.com")
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", "app_password")
+    @patch("cqc_lem.utilities.email.smtplib.SMTP")
+    def test_smtp_failure_returns_false(self, mock_smtp_class):
+        from cqc_lem.utilities.email import send_login_approval_email
+        mock_smtp_class.side_effect = Exception("SMTP refused")
+        assert send_login_approval_email("u@e.com") is False

--- a/tests/unit/utilities/test_selenium_visible_element.py
+++ b/tests/unit/utilities/test_selenium_visible_element.py
@@ -1,0 +1,86 @@
+"""Unit tests for selenium_util.get_visible_element_wait_retry.
+
+LinkedIn's redesigned login renders duplicate hidden+visible copies of each field,
+so the finder must skip invisible matches and try locators in order.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from selenium.common.exceptions import TimeoutException
+from selenium.webdriver.common.by import By
+
+from cqc_lem.utilities.selenium_util import get_visible_element_wait_retry
+
+pytestmark = pytest.mark.unit
+
+_MODULE = "cqc_lem.utilities.selenium_util"
+
+
+def _el(displayed: bool, tag: str = "el") -> MagicMock:
+    e = MagicMock(name=tag)
+    e.is_displayed.return_value = displayed
+    return e
+
+
+class _FakeWait:
+    """Minimal WebDriverWait stand-in: evaluates the predicate; raises on falsey."""
+
+    def __init__(self, driver):
+        self.driver = driver
+
+    def until(self, method, message=""):
+        result = method(self.driver)
+        if result:
+            return result
+        raise TimeoutException(message)
+
+
+def _driver_with(mapping):
+    """mapping: {(by, value): [elements]} → driver.find_elements lookups."""
+    driver = MagicMock()
+    driver.find_elements.side_effect = lambda by, value: mapping.get((by, value), [])
+    return driver
+
+
+def test_returns_first_displayed_skipping_hidden():
+    hidden, visible = _el(False, "hidden"), _el(True, "visible")
+    loc = (By.CSS_SELECTOR, "input[type='password']")
+    driver = _driver_with({loc: [hidden, visible]})
+
+    result = get_visible_element_wait_retry(driver, _FakeWait(driver), [loc], "pw")
+
+    assert result is visible
+    hidden.is_displayed.assert_called()
+
+
+def test_tries_locators_in_order():
+    visible = _el(True, "second")
+    loc1 = (By.ID, "username")            # legacy — absent
+    loc2 = (By.CSS_SELECTOR, "input[autocomplete~='username']")  # modern — present
+    driver = _driver_with({loc1: [], loc2: [visible]})
+
+    result = get_visible_element_wait_retry(driver, _FakeWait(driver), [loc1, loc2], "user")
+
+    assert result is visible
+
+
+def test_raises_when_none_visible_and_expected():
+    loc = (By.CSS_SELECTOR, "input[type='email']")
+    driver = _driver_with({loc: [_el(False)]})  # only a hidden copy
+
+    with patch(f"{_MODULE}.time.sleep"), \
+         pytest.raises(TimeoutException):
+        get_visible_element_wait_retry(driver, _FakeWait(driver), [loc], "user", max_try=1)
+
+
+def test_returns_none_when_not_expected():
+    loc = (By.CSS_SELECTOR, "input[type='email']")
+    driver = _driver_with({loc: []})
+
+    with patch(f"{_MODULE}.time.sleep"):
+        result = get_visible_element_wait_retry(
+            driver, _FakeWait(driver), [loc], "user",
+            max_try=1, element_always_expected=False)
+
+    assert result is None

--- a/tools/debug_linkedin_login.py
+++ b/tools/debug_linkedin_login.py
@@ -1,0 +1,85 @@
+"""Reproducible LinkedIn-login debug harness.
+
+Drives the live selenium-chrome browser through the app's own driver so what you
+inspect is exactly what runs in production (and what lemvnc shows). Use it whenever
+LinkedIn changes its login DOM and the credential step starts timing out.
+
+Run it inside the selenium worker (it reaches selenium-chrome:4444 over the compose
+network):
+
+    sudo docker cp tools/debug_linkedin_login.py celery_worker_selenium:/tmp/dbg.py
+    sudo docker exec celery_worker_selenium python /tmp/dbg.py --inspect            # non-destructive
+    sudo docker exec celery_worker_selenium python /tmp/dbg.py --login --user-id 1  # real submit
+
+--inspect dumps the login page's input fields + a screenshot so you can confirm the
+selectors used by login_to_linkedin still match. --login exercises the real
+login_to_linkedin() end-to-end (set LINKEDIN_APPROVAL_WAIT_SECONDS to control how
+long it waits for the mobile-app device approval).
+"""
+
+import argparse
+import json
+import time
+
+from selenium.webdriver.common.by import By
+
+from cqc_lem.utilities.db import get_cookies, get_user_password_pair_by_id
+from cqc_lem.utilities.selenium_util import get_driver_wait_pair
+
+LOGIN_URL = "https://www.linkedin.com/login"
+
+
+def inspect(user_id: int, out: str) -> None:
+    email, password = get_user_password_pair_by_id(user_id)
+    print(f"[creds] user_id={user_id} email={email!r} "
+          f"password={'<EMPTY>' if not password else f'set(len={len(password)})'}")
+    cookies = get_cookies("https://www.linkedin.com", email) if email else None
+    print(f"[cookies] count={len(cookies) if cookies else 0}")
+
+    driver, _ = get_driver_wait_pair(headless=False, session_name="login-debug", user_id=user_id)
+    try:
+        driver.get(LOGIN_URL)
+        time.sleep(3)
+        print(f"[page] url={driver.current_url!r} title={driver.title!r}")
+        for el in driver.find_elements(By.TAG_NAME, "input"):
+            try:
+                print("  input:", json.dumps({
+                    "id": el.get_attribute("id"),
+                    "type": el.get_attribute("type"),
+                    "autocomplete": el.get_attribute("autocomplete"),
+                    "displayed": el.is_displayed(),
+                }, ensure_ascii=False))
+            except Exception as e:  # noqa: BLE001
+                print("  input: <err>", e)
+        driver.save_screenshot(out)
+        print(f"[screenshot] {out}")
+    finally:
+        driver.quit()
+
+
+def attempt_login(user_id: int) -> None:
+    from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+    email, password = get_user_password_pair_by_id(user_id)
+    driver, wait = get_driver_wait_pair(headless=False, session_name="login-attempt", user_id=user_id)
+    try:
+        login_to_linkedin(driver, wait, email, password)
+        print(f"[login] returned; url={driver.current_url}")
+    except Exception as e:  # noqa: BLE001
+        print(f"[login] raised: {e}")
+        print(f"[login] final url={driver.current_url}")
+    finally:
+        driver.quit()
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--user-id", type=int, default=1)
+    ap.add_argument("--inspect", action="store_true", help="dump login DOM (non-destructive)")
+    ap.add_argument("--login", action="store_true", help="run the real login_to_linkedin flow")
+    ap.add_argument("--screenshot", default="/tmp/login_debug.png")
+    args = ap.parse_args()
+
+    if args.login:
+        attempt_login(args.user_id)
+    else:  # default: inspect
+        inspect(args.user_id, args.screenshot)

--- a/tools/selenium_mcp_server.py
+++ b/tools/selenium_mcp_server.py
@@ -1,0 +1,179 @@
+"""Selenium MCP server for LEM.
+
+Drives the *live* `selenium-chrome` browser over the WebDriver hub so you can
+inspect/debug pages (e.g. LinkedIn login) interactively while watching the same
+session in lemvnc. It deliberately attaches to the remote grid rather than
+spawning a local browser, so what the tools touch is exactly what VNC shows.
+
+Run (registered in .mcp.json):
+    poetry install --with mcp
+    SE_REMOTE_URL=http://127.0.0.1:4444 poetry run python tools/selenium_mcp_server.py
+
+The hub (4444) is bound to host loopback by docker-compose.prod.yml. When working
+from your laptop instead of the VPS, tunnel it first:
+    ssh -L 4444:localhost:4444 -L 7900:localhost:7900 <vps>
+then open http://localhost:7900/?autoconnect=1&password=secret to watch.
+"""
+
+import json
+import os
+
+from mcp.server.fastmcp import FastMCP
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+from selenium.webdriver.common.by import By
+
+mcp = FastMCP("selenium-lem")
+
+_BY = {
+    "css": By.CSS_SELECTOR,
+    "xpath": By.XPATH,
+    "id": By.ID,
+    "name": By.NAME,
+    "tag": By.TAG_NAME,
+}
+
+_state: dict = {"driver": None}
+
+
+def _remote_url() -> str:
+    url = os.getenv("SE_REMOTE_URL", "http://127.0.0.1:4444").rstrip("/")
+    return url if url.endswith("/wd/hub") else f"{url}/wd/hub"
+
+
+def _driver():
+    if _state["driver"] is None:
+        raise RuntimeError("No browser session. Call start_browser first.")
+    return _state["driver"]
+
+
+@mcp.tool()
+def start_browser() -> str:
+    """Attach to the live selenium-chrome grid (the browser lemvnc displays)."""
+    if _state["driver"] is not None:
+        return f"Session already open at {_driver().current_url}"
+    options = Options()
+    options.set_capability("se:timeZone", os.getenv("SE_TIMEZONE", "America/New_York"))
+    _state["driver"] = webdriver.Remote(command_executor=_remote_url(), options=options)
+    _state["driver"].set_window_size(1920, 1080)
+    return f"Connected to {_remote_url()}"
+
+
+@mcp.tool()
+def navigate(url: str) -> str:
+    """Navigate the live browser to a URL and report the resulting URL + title."""
+    d = _driver()
+    d.get(url)
+    return json.dumps({"url": d.current_url, "title": d.title})
+
+
+@mcp.tool()
+def current_state() -> str:
+    """Return the current URL and page title."""
+    d = _driver()
+    return json.dumps({"url": d.current_url, "title": d.title})
+
+
+@mcp.tool()
+def list_inputs() -> str:
+    """List every <input> with its id/name/type/autocomplete/displayed — the fastest
+    way to see which selectors a redesigned login/form actually exposes."""
+    out = []
+    for el in _driver().find_elements(By.TAG_NAME, "input"):
+        try:
+            out.append({
+                "id": el.get_attribute("id"),
+                "name": el.get_attribute("name"),
+                "type": el.get_attribute("type"),
+                "autocomplete": el.get_attribute("autocomplete"),
+                "aria_label": el.get_attribute("aria-label"),
+                "displayed": el.is_displayed(),
+            })
+        except Exception as e:  # noqa: BLE001 — surface stale elements, don't abort
+            out.append({"error": str(e)})
+    return json.dumps(out, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+def list_buttons() -> str:
+    """List visible <button> elements by text/aria-label (e.g. to find 'Sign in')."""
+    out = []
+    for el in _driver().find_elements(By.TAG_NAME, "button"):
+        try:
+            if el.is_displayed():
+                out.append({
+                    "text": (el.text or "").strip(),
+                    "aria_label": el.get_attribute("aria-label"),
+                    "type": el.get_attribute("type"),
+                })
+        except Exception:  # noqa: BLE001
+            continue
+    return json.dumps(out, ensure_ascii=False, indent=2)
+
+
+@mcp.tool()
+def type_into(strategy: str, selector: str, text: str, only_visible: bool = True) -> str:
+    """Type text into the first (visible) element matched by strategy/selector.
+
+    strategy: one of css, xpath, id, name, tag.
+    """
+    by = _BY[strategy]
+    for el in _driver().find_elements(by, selector):
+        if not only_visible or el.is_displayed():
+            el.clear()
+            el.send_keys(text)
+            return f"Typed into ({strategy}, {selector!r})"
+    return f"No matching {'visible ' if only_visible else ''}element for ({strategy}, {selector!r})"
+
+
+@mcp.tool()
+def click(strategy: str, selector: str, only_visible: bool = True) -> str:
+    """Click the first (visible) element matched by strategy/selector."""
+    by = _BY[strategy]
+    for el in _driver().find_elements(by, selector):
+        if not only_visible or el.is_displayed():
+            try:
+                el.click()
+            except Exception:  # noqa: BLE001 — fall back to a JS click
+                _driver().execute_script("arguments[0].click();", el)
+            return f"Clicked ({strategy}, {selector!r})"
+    return f"No matching {'visible ' if only_visible else ''}element for ({strategy}, {selector!r})"
+
+
+@mcp.tool()
+def screenshot(path: str = "/tmp/selenium_mcp.png") -> str:
+    """Save a PNG screenshot of the live browser to `path`."""
+    _driver().save_screenshot(path)
+    return f"Saved screenshot to {path}"
+
+
+@mcp.tool()
+def page_source(limit: int = 4000) -> str:
+    """Return the page HTML (truncated to `limit` chars)."""
+    src = _driver().page_source
+    return src[:limit]
+
+
+@mcp.tool()
+def execute_js(script: str) -> str:
+    """Run JavaScript in the page and return the JSON-serialized result."""
+    try:
+        return json.dumps(_driver().execute_script(script))
+    except Exception as e:  # noqa: BLE001
+        return json.dumps({"error": str(e)})
+
+
+@mcp.tool()
+def quit_browser() -> str:
+    """Close the WebDriver session."""
+    if _state["driver"] is not None:
+        try:
+            _state["driver"].quit()
+        finally:
+            _state["driver"] = None
+        return "Session closed"
+    return "No session to close"
+
+
+if __name__ == "__main__":
+    mcp.run()


### PR DESCRIPTION
## Why login was failing (verified live for user 1, via the live selenium-chrome browser)

LinkedIn replaced its login form. `id="username"`, `id="password"` and `[type=submit]` **no longer match anything** — fields now carry ephemeral React ids (e.g. `«Refvd3ksopa55j6»`) and the submit control is `<button type="button"><span>Sign in</span></button>`. The page also renders **duplicate hidden+visible** copies of each field. `login_to_linkedin` was timing out at *"Finding Username Field"* and never even submitting credentials.

A second, separate blocker sits behind it: after a *successful* submit LinkedIn shows a **device-approval 2FA challenge** ("Check your LinkedIn app → tap Yes"). Not Arkose, can't be auto-solved — this is the geo/anomaly flag.

## Changes

**Login selectors (the core fix)**
- `selenium_util.get_visible_element_wait_retry` — ordered locators, returns the first **displayed** match (skips hidden copies).
- `login_to_linkedin` matches on stable `type`/`autocomplete` attributes + the button's visible text; legacy selectors kept as fallbacks.

**Don't stall silently on device approval**
- `send_login_approval_email` — **high-priority** email (X-Priority/Importance, SendGrid+SMTP) telling the user to open the LinkedIn app and tap Yes, with a link to watch via lemvnc. Sent the moment the checkpoint appears.
- Configurable wait `LINKEDIN_APPROVAL_WAIT_SECONDS` (default 120) so it can be approved live; `LINKEDIN_APPROVAL_EMAIL_ENABLED`, `LEMVNC_URL`.

**Browser anti-detection** (verified live: `navigator.webdriver` → undefined)
- `--disable-blink-features=AutomationControlled`, `excludeSwitches=[enable-automation]`, `useAutomationExtension=false`; dropped the counterproductive `--enable-automation`.
- CDP init script: `navigator.webdriver=undefined`, `navigator.languages` aligned to locale, `window.chrome` present — consistent with the existing per-user geo/timezone overrides.
- **Honest limitation:** the dominant "new location" signal is the **egress IP**, not the fingerprint — a per-user residential proxy/VPN remains the durable fix (geo schema already in place).

**Tooling for future debugging**
- `tools/selenium_mcp_server.py` + `.mcp.json.example`: a Selenium MCP server that attaches to the live `selenium-chrome` grid (the browser lemvnc shows). Hub exposed on `127.0.0.1:4444`.
- `tools/debug_linkedin_login.py` harness + `docs/SELENIUM_DEBUGGING.md`.

## Tests
New coverage: `get_visible_element_wait_retry`, the manual-approval success path, the approval email (provider selection + high-priority headers) and that the login flow emails the user when the checkpoint appears. **906 unit tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)