### PR TITLE
fix(security): don't log password-derived data in debug harness

### DIFF
--- a/tools/debug_linkedin_login.py
+++ b/tools/debug_linkedin_login.py
@@ -31,8 +31,9 @@ LOGIN_URL = "https://www.linkedin.com/login"
 
 def inspect(user_id: int, out: str) -> None:
     email, password = get_user_password_pair_by_id(user_id)
-    print(f"[creds] user_id={user_id} email={email!r} "
-          f"password={'<EMPTY>' if not password else f'set(len={len(password)})'}")
+    # Log only whether a password exists — never anything derived from its value.
+    has_password = bool(password)
+    print(f"[creds] user_id={user_id} email={email!r} password_set={has_password}")
     cookies = get_cookies("https://www.linkedin.com", email) if email else None
     print(f"[cookies] count={len(cookies) if cookies else 0}")
 


### PR DESCRIPTION
Re-applies the CodeQL fix that was orphaned when #183 auto-merged at `9a284e9` (before the fix commit `758dd4e` landed). `tools/debug_linkedin_login.py` logged `len(password)`; CodeQL's `py/clear-text-logging-sensitive-data` taints anything derived from the password value. Now logs only a boolean `password_set`.

Clears the open high-severity code-scanning alert on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)