### PR TITLE
fix(security): drop password entirely from debug harness log

### DIFF
--- a/tools/debug_linkedin_login.py
+++ b/tools/debug_linkedin_login.py
@@ -30,10 +30,9 @@ LOGIN_URL = "https://www.linkedin.com/login"
 
 
 def inspect(user_id: int, out: str) -> None:
-    email, password = get_user_password_pair_by_id(user_id)
-    # Log only whether a password exists — never anything derived from its value.
-    has_password = bool(password)
-    print(f"[creds] user_id={user_id} email={email!r} password_set={has_password}")
+    # Discard the password — never let it (or anything derived from it) reach a log.
+    email, _ = get_user_password_pair_by_id(user_id)
+    print(f"[creds] user_id={user_id} email={email!r}")
     cookies = get_cookies("https://www.linkedin.com", email) if email else None
     print(f"[cookies] count={len(cookies) if cookies else 0}")
 


### PR DESCRIPTION
CodeQL's `py/clear-text-logging-sensitive-data` taints **any** value derived from the password — including `bool(password)` — so the earlier `password_set` attempt still flagged. This discards the password into `_` and logs only `user_id` + `email`, removing the data-flow to the log sink entirely.

Clears CodeQL alert #2445 on `tools/debug_linkedin_login.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)