### PR TITLE
fix(security): resolve open CodeQL alerts

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -12,7 +12,7 @@ from cqc_lem.app.aws_test_celery_task import test_get_my_profile
 from cqc_lem.app.run_automation import (
     automate_invites_to_company_page_for_user, automate_reply_commenting,
     automate_commenting, automate_appreciation_dms_for_user,
-    automate_profile_viewer_engagement, send_private_dm,
+    send_private_dm,
 )
 from celery import chain as celery_chain
 from cqc_lem.app.run_content_plan import auto_create_weekly_content, plan_content_for_user

--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -120,8 +120,8 @@ def setup_aws_sqs_config():
             session = boto3.session.Session(region_name=aws_region)
             aws_access_key = safequote(session.get_credentials().access_key)
             aws_secret_key = safequote(session.get_credentials().secret_key)
-            print(f"Session Access Key: {session.get_credentials().access_key}")
-            print(f"Session Secret Key: {session.get_credentials().secret_key}")
+            # Never log AWS credentials in clear text — only confirm presence + region.
+            print(f"Session credentials loaded: {bool(aws_access_key and aws_secret_key)}")
             print(f"Session Region: {session.region_name}")
 
             if sqs_queue_name:

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -21,7 +21,7 @@ from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, upda
     get_user_blog_url, get_user_sitemap_url, get_active_user_ids, get_planned_posts_for_next_week, PostStatus, \
     update_db_post_video_url, update_db_post_status, PostType, get_user_preferences, \
     update_db_post_carousel_slides, get_post_content
-from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_MODEL, DEFAULT_VIDEO_RATIO, \
+from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_RATIO, \
     DEFAULT_IMAGE_RATIO, AI_DISCLOSURE_ENABLED, AI_DISCLOSURE_TEXT, \
     STANDARD_VIDEO_MODEL, PREMIUM_VIDEO_MODEL, PREMIUM_TOP_VIDEO_MODEL, \
     PREMIUM_VIDEO_CREDITS, PREMIUM_TOP_VIDEO_CREDITS

--- a/src/cqc_lem/streamlit/pages/3_Review_Schedule.py
+++ b/src/cqc_lem/streamlit/pages/3_Review_Schedule.py
@@ -57,7 +57,7 @@ with (tracer.start_as_current_span("review_schedule") if tracer else nullcontext
         st.session_state.email = email
 
         # Get the user id
-        response = requests.get(f"{GET_USER_ID_URL}?email={st.session_state.email}")
+        response = requests.get(GET_USER_ID_URL, params={"email": st.session_state.email})
         if response.status_code == 200:
             # st.success(f"User id fetched successfully: {str(response.json())}")
             st.session_state.user_id = response.json()['detail']
@@ -67,7 +67,7 @@ with (tracer.start_as_current_span("review_schedule") if tracer else nullcontext
             st.error(
                 f"Failed to get user id. Error ({response.status_code}): {response.json()['detail']}")
 
-        response = requests.get(f"{GET_POSTS_URL}?email={email}")
+        response = requests.get(GET_POSTS_URL, params={"email": email})
 
         if response.status_code == 200:
             st.success("Posts fetched successfully")

--- a/src/cqc_lem/ui/src/components/LinkedInPostPreview.tsx
+++ b/src/cqc_lem/ui/src/components/LinkedInPostPreview.tsx
@@ -14,6 +14,22 @@ function isUrl(value: string): boolean {
   return /^(https?:)?\/\//.test(value) || value.startsWith('/api/') || value.startsWith('/assets')
 }
 
+// Only allow safe schemes to reach a media `src` — blocks javascript:/vbscript:/etc.
+// so post-derived URLs can't become a DOM-based XSS sink.
+function safeMediaUrl(value: string | null | undefined): string | undefined {
+  if (!value) return undefined
+  if (
+    /^(https?:)?\/\//i.test(value) ||
+    value.startsWith('/api/') ||
+    value.startsWith('/assets') ||
+    value.startsWith('blob:') ||
+    /^data:(image|video)\//i.test(value)
+  ) {
+    return value
+  }
+  return undefined
+}
+
 function CarouselPreview({ slides }: { slides: string[] }) {
   const [index, setIndex] = useState(0)
   const total = slides.length
@@ -26,7 +42,7 @@ function CarouselPreview({ slides }: { slides: string[] }) {
       <div className="aspect-square w-full flex items-center justify-center overflow-hidden">
         {isUrl(current) ? (
           <img
-            src={current}
+            src={safeMediaUrl(current)}
             alt={`Slide ${index + 1} of ${total}`}
             className="w-full h-full object-contain"
           />
@@ -139,7 +155,7 @@ export default function LinkedInPostPreview({
         <div className="bg-black">
           <video
             key={videoUrl ?? undefined}
-            src={videoUrl ?? undefined}
+            src={safeMediaUrl(videoUrl)}
             controls
             playsInline
             preload="metadata"
@@ -150,7 +166,7 @@ export default function LinkedInPostPreview({
       {showCarousel && <CarouselPreview slides={slides!} />}
       {showImage && (
         <div className="bg-gray-100 aspect-video overflow-hidden">
-          <img src={mediaUrl} alt="Post media" className="w-full h-full object-cover" />
+          <img src={safeMediaUrl(mediaUrl)} alt="Post media" className="w-full h-full object-cover" />
         </div>
       )}
 

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -13,7 +13,8 @@ from cqc_lem.utilities.utils import create_folder_if_not_exists, save_video_url_
 from cqc_lem.utilities.env_constants import DEFAULT_VIDEO_MODEL, DEFAULT_IMAGE_MODEL, DEFAULT_IMAGE_RATIO
 # create_runway_video lives in video_models (model abstraction); re-exported here
 # so existing `from ai_helper import create_runway_video` imports keep working.
-from cqc_lem.utilities.ai.video_models import create_runway_video  # noqa: F401
+# The redundant `as create_runway_video` alias marks it an intentional re-export.
+from cqc_lem.utilities.ai.video_models import create_runway_video as create_runway_video  # noqa: F401
 from dotenv import load_dotenv
 
 # Load .env file

--- a/src/cqc_lem/utilities/c2pa_helper.py
+++ b/src/cqc_lem/utilities/c2pa_helper.py
@@ -91,5 +91,5 @@ def add_ai_content_credentials(file_path: str) -> bool:
             if os.path.exists(tmp_out):
                 os.remove(tmp_out)
         except OSError:
-            pass
+            pass  # best-effort temp-file cleanup; ignore if it can't be removed
         return False

--- a/tests/unit/app/test_my_celery.py
+++ b/tests/unit/app/test_my_celery.py
@@ -1,7 +1,7 @@
 """Unit tests for cqc_lem.app.my_celery CloudWatch guard logic."""
 
 import pytest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/app/test_video_tier_pipeline.py
+++ b/tests/unit/app/test_video_tier_pipeline.py
@@ -77,7 +77,7 @@ class TestGenerateVideoSrc:
              patch("cqc_lem.app.run_content_plan.get_runway_ml_video_prompt_from_ai", return_value="motion"), \
              patch("cqc_lem.app.run_content_plan.create_runway_video", return_value="https://x.mp4") as crv:
             from cqc_lem.app.run_content_plan import _generate_video_src
-            src = _generate_video_src(1, "text", None, post_id=9)
+            _generate_video_src(1, "text", None, post_id=9)
         bal.assert_not_called()
         ded.assert_not_called()
         assert crv.call_args[1]["model"] == "gen4_turbo"

--- a/tests/unit/utilities/ai/test_video_models.py
+++ b/tests/unit/utilities/ai/test_video_models.py
@@ -1,7 +1,6 @@
 """Unit tests for the RunwayML video-model abstraction."""
 
 import pytest
-from unittest.mock import patch
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/utilities/linkedin/test_poster.py
+++ b/tests/unit/utilities/linkedin/test_poster.py
@@ -1,7 +1,7 @@
 """Unit tests for LinkedIn poster utilities."""
 
 import pytest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 
 @pytest.mark.unit

--- a/tests/unit/utilities/test_c2pa_helper.py
+++ b/tests/unit/utilities/test_c2pa_helper.py
@@ -60,7 +60,10 @@ class TestAddCredentials:
         fake_c2pa = MagicMock()
         fake_c2pa.Signer.from_callback.return_value = _cm(MagicMock())
         builder = MagicMock()
-        builder.sign_file.side_effect = lambda src, out, signer: open(out, "wb").write(b"signed")
+        def _sign_file(src, out, signer):
+            with open(out, "wb") as fh:
+                fh.write(b"signed")
+        builder.sign_file.side_effect = _sign_file
         fake_c2pa.Builder.return_value = _cm(builder)
 
         with patch("cqc_lem.utilities.c2pa_helper.C2PA_ENABLED", True), \

--- a/tests/unit/utilities/test_date.py
+++ b/tests/unit/utilities/test_date.py
@@ -3,7 +3,6 @@
 import datetime
 from datetime import timedelta
 import pytest
-from unittest.mock import patch, MagicMock
 
 from cqc_lem.utilities.date import (
     convert_datetime_to_local_tz, format_year, get_datetime,

--- a/tests/unit/utilities/test_stripe_util.py
+++ b/tests/unit/utilities/test_stripe_util.py
@@ -493,7 +493,6 @@ class TestFetchSubscription:
 
     def test_stripe_object_non_dict_is_converted_to_dict(self):
         """Stripe SDK v5+ returns StripeObject, not dict; fetch_subscription must convert it."""
-        import json
 
         class _FakeStripeObject:
             """Minimal stand-in for stripe.StripeObject (not a dict subclass)."""


### PR DESCRIPTION
Clears the open CodeQL alerts on `main`.

**Security (high/critical)**
- `celeryconfig.py` — was `print()`ing the AWS **access key + secret key** in clear text. Now logs only presence + region.
- `LinkedInPostPreview.tsx` — `js/xss-through-dom`: post-derived URLs flowed unsanitized into `<img>/<video src>`. Added `safeMediaUrl()` (allows only http(s)/relative/blob/`data:image|video`), applied to all three media src bindings.
- `streamlit/pages/3_Review_Schedule.py` — `py/partial-ssrf`: user `email` was interpolated into the request URL. Now passed via `requests(..., params=...)`.

**Code quality (low)**
- `ai_helper.py` intentional re-export via redundant alias; dropped unused imports in `run_content_plan.py` / `main.py`; commented the best-effort empty `except` in `c2pa_helper.py`; test-file unused-import/var cleanups + one file-handle closed via context manager.

906 unit tests pass. (The 2 streamlit `partial-ssrf` are in the legacy, non-deployed Streamlit UI but fixed anyway since the change is trivial and correct.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)