### PR TITLE
feat(proxy): zero-setup region-based egress proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -225,9 +225,14 @@ NGROK_JAEGER_PREFIX=your-app-jaeger
 SELENIUM_HUB_HOST=selenium-chrome
 SELENIUM_HUB_PORT=4444
 SELENIUM_KEEP_VIDEOS_X_DAYS=7
-# Optional box-wide egress proxy for the automation browser (scheme://host:port).
-# Per-user proxies (users.proxy_url) take precedence; this is the fallback default.
-# Leave blank to egress straight from the host. See docs/PER_USER_PROXY.md.
+# Egress proxy for the automation browser. Resolution order (zero user setup):
+#   1. per-user override users.proxy_url
+#   2. REGION_PROXIES matched to the user's stored country (auto — no user action)
+#   3. PROXY_URL (global default)   4. none (direct egress)
+# REGION_PROXIES maps ISO-3166 country codes (+ optional "DEFAULT") to proxy URLs; point
+# each at a cheap regional egress node (a handful cover all users). See docs/PER_USER_PROXY.md.
+# REGION_PROXIES={"US":"http://us-east.proxy:3128","GB":"http://eu-west.proxy:3128","DEFAULT":"http://us-east.proxy:3128"}
+REGION_PROXIES=
 PROXY_URL=
 
 

--- a/.env.example
+++ b/.env.example
@@ -225,6 +225,10 @@ NGROK_JAEGER_PREFIX=your-app-jaeger
 SELENIUM_HUB_HOST=selenium-chrome
 SELENIUM_HUB_PORT=4444
 SELENIUM_KEEP_VIDEOS_X_DAYS=7
+# Optional box-wide egress proxy for the automation browser (scheme://host:port).
+# Per-user proxies (users.proxy_url) take precedence; this is the fallback default.
+# Leave blank to egress straight from the host. See docs/PER_USER_PROXY.md.
+PROXY_URL=
 
 
 # =============================================================================

--- a/compose/local/database/migrations/V32__add_user_proxy.sql
+++ b/compose/local/database/migrations/V32__add_user_proxy.sql
@@ -1,0 +1,7 @@
+-- Per-user egress proxy for Selenium automation.
+-- LinkedIn flags logins whose IP geolocates far from where the user normally signs in.
+-- Routing a user's browser session through a proxy near their location (e.g. a free
+-- home exit node they provide) makes the login look normal. Stored as a full proxy URL
+-- (scheme://[user:pass@]host:port); NULL = no proxy (egress straight from the host).
+ALTER TABLE users
+    ADD COLUMN proxy_url VARCHAR(500) NULL AFTER country;

--- a/docs/PER_USER_PROXY.md
+++ b/docs/PER_USER_PROXY.md
@@ -1,85 +1,95 @@
-# Per-user egress proxy (DRAFT)
+# Per-user egress proxy
 
-**Status:** groundwork / draft. The plumbing (DB field + Selenium wiring) is in place;
-no paid provider is wired by default. This doc records the design and the **free**
-strategies that rely only on services we already have.
+Routes each user's automation browser through an egress IP near where they normally
+sign in — the durable fix for LinkedIn's "new location" device-approval challenges.
+**Zero user-side setup:** routing is derived automatically from the user's stored
+location; the user installs/configures nothing.
 
 ## The problem
 
-LinkedIn flags a login when the request's **IP geolocates somewhere different** from
-where the user normally signs in, and challenges it with "Check your LinkedIn app →
-tap Yes". Our automation egresses from the **VPS's single datacenter IP**, which:
+LinkedIn challenges a login when its **IP geolocates far from the user's usual
+location**, and again when the IP keeps changing. Our automation egresses from the
+VPS's single datacenter IP — wrong location for most users, and unstable across the
+fleet. Browser-fingerprint stealth (shipped: `navigator.webdriver`, UA, timezone,
+locale, geolocation overrides) makes the session look non-automated but **cannot
+change the IP**, which is the dominant signal. So we need per-user egress from a
+**stable IP near that user's location**.
 
-1. is geographically fixed (one city) — wrong for every user not near it, and
-2. is a *datacenter* IP, which LinkedIn weights as higher-risk than a residential ISP.
+## How it resolves (automatic, no user action)
 
-Browser fingerprint stealth (already shipped: `navigator.webdriver`, UA, timezone,
-locale, geolocation overrides) makes the session look non-automated, **but it cannot
-change the IP**. The IP is the dominant "new location" signal. So the durable fix is
-**per-user egress from an IP near that user's normal location.**
+`get_docker_driver(user_id=…)` calls `resolve_proxy(explicit, country)` —
+`utilities/proxy.py` — which picks, first match wins:
 
-## Why not just buy residential proxies
+1. **`users.proxy_url`** — explicit per-user override (power users / paid proxies).
+2. **`REGION_PROXIES[country]`** — a regional proxy matched to the user's **stored
+   country** (we already capture location, incl. IP auto-capture). **This is the
+   zero-setup path:** the user just has a location (often auto-detected) and is routed
+   automatically.
+3. **`PROXY_URL`** — a global default.
+4. **none** — direct egress (today's behavior).
 
-Residential proxy providers (Bright Data, Oxylabs, Smartproxy…) bill ~$3–15 **per GB**.
-At SaaS scale — every user, every automation cycle, loading image-heavy LinkedIn pages
-— that cost grows with usage and erodes margin. So paid residential is **not** the
-default. We want a free path that scales.
+`REGION_PROXIES` is a JSON map of ISO country codes (+ optional `"DEFAULT"`) → proxy
+URL. Chrome gets `--proxy-server=scheme://host:port`.
 
-## The abstraction (shipped in this draft)
+## Options that need NO user setup
 
-Each user has an optional `users.proxy_url` (`scheme://[user:pass@]host:port`, migration
-`V32`). `get_docker_driver(user_id=…)` reads it (falling back to a global `PROXY_URL`
-env) and adds `--proxy-server=scheme://host:port` to Chrome, so that user's browser
-egresses through it. `NULL` → straight from the host (today's behavior). DB helpers:
-`get_user_proxy` / `update_user_proxy`.
+### 1. A few cheap regional egress nodes — recommended ✅
 
-Auth note: Chrome's `--proxy-server` can't carry inline `user:pass`. The free options
-below are all **auth-less from the browser** (they authenticate by *source IP*), so
-they work as-is. Credentialed commercial proxies would additionally need an
-auth-handler extension (a follow-up, deliberately out of this draft).
+Stand up one tiny proxy (Squid/3proxy on a `t4g.nano` / Lightsail / cheap VPS, ~$3–4/mo)
+in each region your users cluster in (e.g. `us-east`, `us-west`, `eu-west`,
+`ap-southeast`). Put their URLs in `REGION_PROXIES`. Each user is auto-routed to the
+node matching their country.
 
-## Free strategies (use only services we already have)
+- **Zero user setup** — derived from location we already have.
+- **Cost scales with *regions* (a handful), not users** — one node serves everyone in
+  its region, so it stays cheap at SaaS scale.
+- **Stable IP per region** — once a user's device is approved from that IP, cookies +
+  "recognize this device" keep subsequent logins clean.
+- Uses infra we already have (**AWS** account / the same VPS provider).
+- Trade-off: these are *datacenter* IPs. The **geography matches** (kills the "new
+  location" flag), but datacenter is a minor residual signal vs. residential. In
+  practice geography-match + stable IP + one-time approval is enough for most users.
+  Provision these as a small Terraform/CDK module or a per-region cloud-init script
+  (follow-up — the app side is done and config-driven).
 
-### 1. BYO home exit node — recommended, free, per-user, scales ✅
+### 2. Cloudflare WARP on the box — free baseline 🟡
 
-Each user runs a **free exit node on their own home connection**; LEM routes *that
-user's* session through *their* home IP. The egress is then a genuine residential IP in
-the user's real city — exactly what LinkedIn expects — at **zero marginal cost to the
-SaaS** (the user supplies the bandwidth). Two zero-cost ways, both services we use:
+Run WARP (`warp-cli`, free) on the VPS / a sidecar and set it as `REGION_PROXIES`'
+`DEFAULT` (or `PROXY_URL`). Free, zero setup, sheds the raw datacenter IP for a
+cleaner Cloudflare egress — but it's **one shared location**, so it doesn't match
+per-user geography. Good as the catch-all default beneath the regional nodes.
 
-- **Cloudflare Tunnel (`cloudflared`)** — we already run Cloudflare. The user installs
-  `cloudflared` at home and exposes a local SOCKS/HTTP forward; we store that as their
-  `proxy_url`. (Cloudflare WARP Connector / private networks can do the same on the
-  free plan.)
-- **Tailscale exit node (free Personal plan)** — the user enables "exit node" on a home
-  device; the LEM box joins their tailnet and routes the session out that node.
+### 3. Commercial residential proxy — opt-in, paid 🟡
 
-Onboarding cost: the user runs one installer once. This is the scalable answer — cost
-stays flat as users grow because each user brings their own egress.
+Point a user's `users.proxy_url` at a residential provider (Bright Data, Oxylabs,
+Smartproxy…). Best stealth (real residential IPs), but **per-GB billing** that grows
+with usage — so keep it opt-in for users who want turnkey and will pay, not the default.
 
-### 2. Cloudflare WARP on the box — free, but shared 🟡
+## Not recommended here
 
-Run WARP (`warp-cli`, free) on the VPS / a sidecar so automation egresses through
-Cloudflare rather than the bare datacenter IP. Cleaner reputation than the raw VPS IP,
-**but** it's one shared egress for everyone — it does **not** match each user's
-location. Useful as a baseline; not a per-user fix.
-
-### 3. BYO proxy — free/cheap, user's choice 🟡
-
-A power user can point `proxy_url` at any IP-allowlisted proxy they trust (a free-tier
-VPS in their region, a friend's connection, etc.). Same wiring, their responsibility.
+- **BYO home exit node (Tailscale / `cloudflared`)** — gives a genuine residential IP
+  at zero marginal cost, but **requires the user to install software at home**. Ruled
+  out: we want no user-side setup. (Left reachable only as a `users.proxy_url` override
+  for a technical user who opts in.)
+- **Tor** — free but LinkedIn blocks exit nodes and you can't pin exit geography.
 
 ## Recommendation
 
-Ship the abstraction (this draft) → make **#1 (BYO home exit node)** the documented
-onboarding path for users who get flagged, with **#2 (WARP)** as a free box-wide
-baseline. Keep paid residential proxies as an opt-in `proxy_url` for users who want
-turnkey and will pay. Combined with the existing one-time device approval + cookie
-persistence, most users should stop seeing challenges without any per-GB spend.
+Ship the resolver (this change) → run **a few regional egress nodes (#1)** keyed by
+country via `REGION_PROXIES`, with **WARP (#2)** as the free `DEFAULT`. Users do
+nothing. Combined with the existing one-time device approval + cookie persistence,
+this removes the "new location" challenge without per-GB spend or user onboarding.
 
-## Open follow-ups (not in this draft)
+## Auth note
 
-- Auth-handler extension so credentialed (`user:pass`) proxies work over the Remote grid.
-- `GET/PUT /user/proxy` API + a Settings UI field (mirrors the location endpoints).
-- Optional WARP sidecar in `docker-compose.prod.yml` + a setup script.
-- Health-check a user's proxy before a run; fall back to direct egress with a warning.
+Chrome's `--proxy-server` can't carry inline `user:pass`. The options above are all
+auth-less from the browser (they authenticate by *source IP* — lock the regional nodes
+to the VPS's IP). Credentialed commercial proxies additionally need an auth-handler
+extension (follow-up).
+
+## Status / follow-ups
+
+- App side (DB field, resolver, Selenium wiring, tests) — **done, config-driven**.
+- Provision the regional nodes (Terraform/CDK or cloud-init) + lock to the box IP.
+- `GET/PUT /user/proxy` + Settings UI (only needed for the opt-in override).
+- Auth-handler extension for credentialed proxies.

--- a/docs/PER_USER_PROXY.md
+++ b/docs/PER_USER_PROXY.md
@@ -1,0 +1,85 @@
+# Per-user egress proxy (DRAFT)
+
+**Status:** groundwork / draft. The plumbing (DB field + Selenium wiring) is in place;
+no paid provider is wired by default. This doc records the design and the **free**
+strategies that rely only on services we already have.
+
+## The problem
+
+LinkedIn flags a login when the request's **IP geolocates somewhere different** from
+where the user normally signs in, and challenges it with "Check your LinkedIn app →
+tap Yes". Our automation egresses from the **VPS's single datacenter IP**, which:
+
+1. is geographically fixed (one city) — wrong for every user not near it, and
+2. is a *datacenter* IP, which LinkedIn weights as higher-risk than a residential ISP.
+
+Browser fingerprint stealth (already shipped: `navigator.webdriver`, UA, timezone,
+locale, geolocation overrides) makes the session look non-automated, **but it cannot
+change the IP**. The IP is the dominant "new location" signal. So the durable fix is
+**per-user egress from an IP near that user's normal location.**
+
+## Why not just buy residential proxies
+
+Residential proxy providers (Bright Data, Oxylabs, Smartproxy…) bill ~$3–15 **per GB**.
+At SaaS scale — every user, every automation cycle, loading image-heavy LinkedIn pages
+— that cost grows with usage and erodes margin. So paid residential is **not** the
+default. We want a free path that scales.
+
+## The abstraction (shipped in this draft)
+
+Each user has an optional `users.proxy_url` (`scheme://[user:pass@]host:port`, migration
+`V32`). `get_docker_driver(user_id=…)` reads it (falling back to a global `PROXY_URL`
+env) and adds `--proxy-server=scheme://host:port` to Chrome, so that user's browser
+egresses through it. `NULL` → straight from the host (today's behavior). DB helpers:
+`get_user_proxy` / `update_user_proxy`.
+
+Auth note: Chrome's `--proxy-server` can't carry inline `user:pass`. The free options
+below are all **auth-less from the browser** (they authenticate by *source IP*), so
+they work as-is. Credentialed commercial proxies would additionally need an
+auth-handler extension (a follow-up, deliberately out of this draft).
+
+## Free strategies (use only services we already have)
+
+### 1. BYO home exit node — recommended, free, per-user, scales ✅
+
+Each user runs a **free exit node on their own home connection**; LEM routes *that
+user's* session through *their* home IP. The egress is then a genuine residential IP in
+the user's real city — exactly what LinkedIn expects — at **zero marginal cost to the
+SaaS** (the user supplies the bandwidth). Two zero-cost ways, both services we use:
+
+- **Cloudflare Tunnel (`cloudflared`)** — we already run Cloudflare. The user installs
+  `cloudflared` at home and exposes a local SOCKS/HTTP forward; we store that as their
+  `proxy_url`. (Cloudflare WARP Connector / private networks can do the same on the
+  free plan.)
+- **Tailscale exit node (free Personal plan)** — the user enables "exit node" on a home
+  device; the LEM box joins their tailnet and routes the session out that node.
+
+Onboarding cost: the user runs one installer once. This is the scalable answer — cost
+stays flat as users grow because each user brings their own egress.
+
+### 2. Cloudflare WARP on the box — free, but shared 🟡
+
+Run WARP (`warp-cli`, free) on the VPS / a sidecar so automation egresses through
+Cloudflare rather than the bare datacenter IP. Cleaner reputation than the raw VPS IP,
+**but** it's one shared egress for everyone — it does **not** match each user's
+location. Useful as a baseline; not a per-user fix.
+
+### 3. BYO proxy — free/cheap, user's choice 🟡
+
+A power user can point `proxy_url` at any IP-allowlisted proxy they trust (a free-tier
+VPS in their region, a friend's connection, etc.). Same wiring, their responsibility.
+
+## Recommendation
+
+Ship the abstraction (this draft) → make **#1 (BYO home exit node)** the documented
+onboarding path for users who get flagged, with **#2 (WARP)** as a free box-wide
+baseline. Keep paid residential proxies as an opt-in `proxy_url` for users who want
+turnkey and will pay. Combined with the existing one-time device approval + cookie
+persistence, most users should stop seeing challenges without any per-GB spend.
+
+## Open follow-ups (not in this draft)
+
+- Auth-handler extension so credentialed (`user:pass`) proxies work over the Remote grid.
+- `GET/PUT /user/proxy` API + a Settings UI field (mirrors the location endpoints).
+- Optional WARP sidecar in `docker-compose.prod.yml` + a setup script.
+- Health-check a user's proxy before a run; fall back to direct egress with a warning.

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1956,6 +1956,48 @@ def update_user_location(user_id: int, latitude: float, longitude: float,
         connection.close()
 
 
+def get_user_proxy(user_id: int) -> Optional[str]:
+    """Return the user's egress proxy URL (scheme://[user:pass@]host:port) or None.
+
+    Used by Selenium to route a user's browser session through an IP near where they
+    normally log in, reducing LinkedIn "new location" challenges. None = egress from
+    the host directly.
+    """
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT proxy_url FROM users WHERE id = %s", (user_id,))
+        row = cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get proxy for user_id {user_id} | Error: {err}")
+        row = None
+    finally:
+        cursor.close()
+        connection.close()
+    if not row or not row[0]:
+        return None
+    return row[0]
+
+
+def update_user_proxy(user_id: int, proxy_url: Optional[str]) -> bool:
+    """Set (or clear, when proxy_url is None/empty) the user's egress proxy URL."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE users SET proxy_url = %s WHERE id = %s",
+            (proxy_url or None, user_id),
+        )
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update proxy for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_user_timezone(user_id: int) -> str:
     """Return the IANA timezone string for the user, defaulting to UTC."""
     connection = get_db_connection()

--- a/src/cqc_lem/utilities/proxy.py
+++ b/src/cqc_lem/utilities/proxy.py
@@ -1,0 +1,60 @@
+"""Egress proxy resolution for the automation browser.
+
+Zero user-side setup: a user's session is routed automatically through an egress
+proxy chosen from their *already-captured* location (country), so their LinkedIn
+login appears to come from near where they normally sign in — without the user
+installing or configuring anything.
+
+Resolution order (first match wins):
+  1. An explicit per-user override (``users.proxy_url``) — for power users / paid proxies.
+  2. A regional proxy matched by the user's country via ``REGION_PROXIES``.
+  3. A global default (``PROXY_URL``).
+  4. None — egress straight from the host (today's behavior).
+
+``REGION_PROXIES`` is a JSON object mapping ISO-3166 alpha-2 country codes (and an
+optional ``"DEFAULT"``) to proxy URLs, e.g.::
+
+    REGION_PROXIES={"US":"http://us-east.proxy.internal:3128",
+                    "GB":"http://eu-west.proxy.internal:3128",
+                    "DEFAULT":"http://us-east.proxy.internal:3128"}
+
+See docs/PER_USER_PROXY.md for how those regional proxies are provisioned (a few
+cheap AWS/VPS egress nodes cover the whole user base — cost scales with regions,
+not users).
+"""
+
+import json
+import os
+from typing import Optional
+
+from cqc_lem.utilities.logger import myprint
+
+
+def _region_proxies() -> dict:
+    raw = (os.getenv("REGION_PROXIES") or "").strip()
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw)
+        return data if isinstance(data, dict) else {}
+    except (ValueError, TypeError) as e:
+        myprint(f"Invalid REGION_PROXIES JSON — ignoring: {e}")
+        return {}
+
+
+def resolve_proxy(explicit_proxy: Optional[str], country: Optional[str]) -> Optional[str]:
+    """Return the egress proxy URL for a session, or None for direct egress."""
+    if explicit_proxy:
+        return explicit_proxy
+
+    regions = _region_proxies()
+    if regions:
+        if country:
+            match = regions.get(country.upper())
+            if match:
+                return match
+        default = regions.get("DEFAULT")
+        if default:
+            return default
+
+    return os.getenv("PROXY_URL") or None

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -2,6 +2,7 @@ import json
 import time
 from datetime import datetime, timedelta
 from functools import wraps
+from urllib.parse import urlparse
 
 import requests
 import selenium
@@ -95,8 +96,9 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
     # where the user normally logs in, to reduce LinkedIn "new location" challenges.
     user_timezone = TZ
     user_locale = "en-US"
+    user_proxy = None
     if user_id is not None:
-        from cqc_lem.utilities.db import get_user_geo
+        from cqc_lem.utilities.db import get_user_geo, get_user_proxy
         geo = get_user_geo(user_id)
         if geo:
             if lat is None and geo.get("latitude") is not None:
@@ -105,11 +107,17 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
                 user_timezone = geo["timezone"]
             if geo.get("locale"):
                 user_locale = geo["locale"]
+        user_proxy = get_user_proxy(user_id)
+    # A global default proxy (PROXY_URL) applies when a user has none configured.
+    if not user_proxy:
+        user_proxy = os.getenv("PROXY_URL") or None
 
     options = getBaseOptions()
     options.add_argument("--ignore-ssl-errors=yes")
     options.add_argument("--ignore-certificate-errors")
     options.add_argument(f"--lang={user_locale}")
+    if user_proxy:
+        apply_proxy(options, user_proxy)
     if headless:
         options = add_headless_options(options)
 
@@ -150,6 +158,34 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
         myprint(f"Could not apply timezone/locale override | Error: {e}")
 
     return driver
+
+
+def apply_proxy(options: Options, proxy_url: str) -> None:
+    """Route the browser's egress through `proxy_url` (scheme://[user:pass@]host:port).
+
+    Chrome's --proxy-server cannot carry inline credentials, so we pass only
+    scheme://host:port. Auth-less proxies — the free, recommended case (a home exit
+    node via Tailscale/cloudflared, Cloudflare WARP, or an IP-allowlisted proxy) —
+    work directly. Credentialed proxies additionally need an auth-handler extension;
+    see docs/PER_USER_PROXY.md. Best-effort: a malformed URL is logged and ignored
+    rather than failing driver creation.
+    """
+    try:
+        parsed = urlparse(proxy_url)
+        scheme = parsed.scheme or "http"
+        host = parsed.hostname or ""
+        if not host:
+            myprint(f"Invalid proxy_url (no host) — ignoring: {proxy_url}")
+            return
+        hostport = f"{host}:{parsed.port}" if parsed.port else host
+        options.add_argument(f"--proxy-server={scheme}://{hostport}")
+        myprint(f"Routing browser egress via proxy {scheme}://{hostport}")
+        if parsed.username:
+            myprint("Proxy URL has inline credentials; --proxy-server cannot carry "
+                    "them. Use an IP-allowlisted proxy or an auth extension "
+                    "(see docs/PER_USER_PROXY.md).")
+    except Exception as e:
+        myprint(f"Could not apply proxy '{proxy_url}': {e}")
 
 
 def add_headless_options(options: Options) -> Options:

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -97,6 +97,7 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
     user_timezone = TZ
     user_locale = "en-US"
     user_proxy = None
+    user_country = None
     if user_id is not None:
         from cqc_lem.utilities.db import get_user_geo, get_user_proxy
         geo = get_user_geo(user_id)
@@ -107,17 +108,20 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
                 user_timezone = geo["timezone"]
             if geo.get("locale"):
                 user_locale = geo["locale"]
+            user_country = geo.get("country")
         user_proxy = get_user_proxy(user_id)
-    # A global default proxy (PROXY_URL) applies when a user has none configured.
-    if not user_proxy:
-        user_proxy = os.getenv("PROXY_URL") or None
+
+    # Resolve egress proxy with zero user setup: explicit override → regional proxy
+    # matched to the user's country → global default → none (direct egress).
+    from cqc_lem.utilities.proxy import resolve_proxy
+    effective_proxy = resolve_proxy(user_proxy, user_country)
 
     options = getBaseOptions()
     options.add_argument("--ignore-ssl-errors=yes")
     options.add_argument("--ignore-certificate-errors")
     options.add_argument(f"--lang={user_locale}")
-    if user_proxy:
-        apply_proxy(options, user_proxy)
+    if effective_proxy:
+        apply_proxy(options, effective_proxy)
     if headless:
         options = add_headless_options(options)
 

--- a/tests/unit/utilities/test_db_proxy.py
+++ b/tests/unit/utilities/test_db_proxy.py
@@ -1,0 +1,56 @@
+"""Unit tests for per-user proxy DB helpers."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _mock_conn(fetch_row=None, rowcount=1):
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = fetch_row
+    cursor.rowcount = rowcount
+    conn.cursor.return_value = cursor
+    return conn, cursor
+
+
+class TestGetUserProxy:
+    def test_returns_url_when_set(self):
+        conn, cursor = _mock_conn(fetch_row=("http://10.0.0.5:8080",))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_proxy
+            assert get_user_proxy(7) == "http://10.0.0.5:8080"
+        args = cursor.execute.call_args[0]
+        assert "proxy_url" in args[0] and args[1] == (7,)
+
+    def test_returns_none_when_null(self):
+        conn, _ = _mock_conn(fetch_row=(None,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_proxy
+            assert get_user_proxy(7) is None
+
+    def test_returns_none_when_no_row(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_proxy
+            assert get_user_proxy(99) is None
+
+
+class TestUpdateUserProxy:
+    def test_sets_url(self):
+        conn, cursor = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_user_proxy
+            assert update_user_proxy(7, "socks5://host:1080") is True
+        conn.commit.assert_called_once()
+        assert cursor.execute.call_args[0][1] == ("socks5://host:1080", 7)
+
+    def test_empty_string_clears_to_none(self):
+        conn, cursor = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_user_proxy
+            update_user_proxy(7, "")
+        assert cursor.execute.call_args[0][1] == (None, 7)

--- a/tests/unit/utilities/test_proxy_resolve.py
+++ b/tests/unit/utilities/test_proxy_resolve.py
@@ -1,0 +1,48 @@
+"""Unit tests for proxy resolution (zero-setup, country-based)."""
+
+import pytest
+
+from cqc_lem.utilities.proxy import resolve_proxy
+
+pytestmark = pytest.mark.unit
+
+
+def test_explicit_override_wins(monkeypatch):
+    monkeypatch.setenv("REGION_PROXIES", '{"US":"http://region:3128"}')
+    monkeypatch.setenv("PROXY_URL", "http://global:3128")
+    assert resolve_proxy("http://explicit:8080", "US") == "http://explicit:8080"
+
+
+def test_region_matched_by_country(monkeypatch):
+    monkeypatch.setenv("REGION_PROXIES", '{"US":"http://us:3128","GB":"http://gb:3128"}')
+    assert resolve_proxy(None, "GB") == "http://gb:3128"
+    assert resolve_proxy(None, "us") == "http://us:3128"  # case-insensitive
+
+
+def test_region_default_when_country_unmapped(monkeypatch):
+    monkeypatch.setenv("REGION_PROXIES", '{"US":"http://us:3128","DEFAULT":"http://def:3128"}')
+    assert resolve_proxy(None, "FR") == "http://def:3128"
+
+
+def test_falls_back_to_global_proxy_url(monkeypatch):
+    monkeypatch.delenv("REGION_PROXIES", raising=False)
+    monkeypatch.setenv("PROXY_URL", "http://global:3128")
+    assert resolve_proxy(None, "FR") == "http://global:3128"
+
+
+def test_none_when_nothing_configured(monkeypatch):
+    monkeypatch.delenv("REGION_PROXIES", raising=False)
+    monkeypatch.delenv("PROXY_URL", raising=False)
+    assert resolve_proxy(None, "US") is None
+
+
+def test_no_country_no_default_falls_through(monkeypatch):
+    monkeypatch.setenv("REGION_PROXIES", '{"US":"http://us:3128"}')
+    monkeypatch.delenv("PROXY_URL", raising=False)
+    assert resolve_proxy(None, None) is None
+
+
+def test_malformed_region_json_is_ignored(monkeypatch):
+    monkeypatch.setenv("REGION_PROXIES", "{not json")
+    monkeypatch.setenv("PROXY_URL", "http://global:3128")
+    assert resolve_proxy(None, "US") == "http://global:3128"

--- a/tests/unit/utilities/test_selenium_geo.py
+++ b/tests/unit/utilities/test_selenium_geo.py
@@ -8,7 +8,7 @@ pytestmark = pytest.mark.unit
 _MOD = "cqc_lem.utilities.selenium_util"
 
 
-def _run(user_id=None, geo=None, headless=False):
+def _run(user_id=None, geo=None, headless=False, proxy=None):
     fake_driver = MagicMock()
     cdp_calls = {}
 
@@ -20,7 +20,8 @@ def _run(user_id=None, geo=None, headless=False):
          patch(f"{_MOD}.DEVICE_FARM_PROJECT_ARN", None), \
          patch(f"{_MOD}.TEST_GRID_PROJECT_ARN", None), \
          patch(f"{_MOD}.webdriver.Remote", return_value=fake_driver), \
-         patch("cqc_lem.utilities.db.get_user_geo", return_value=geo):
+         patch("cqc_lem.utilities.db.get_user_geo", return_value=geo), \
+         patch("cqc_lem.utilities.db.get_user_proxy", return_value=proxy):
         from cqc_lem.utilities.selenium_util import get_docker_driver
         get_docker_driver(headless=headless, user_id=user_id)
     return cdp_calls

--- a/tests/unit/utilities/test_selenium_proxy.py
+++ b/tests/unit/utilities/test_selenium_proxy.py
@@ -1,0 +1,45 @@
+"""Unit tests for apply_proxy (Selenium egress proxy wiring)."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from cqc_lem.utilities.selenium_util import apply_proxy
+
+pytestmark = pytest.mark.unit
+
+
+def _args(options):
+    return [c.args[0] for c in options.add_argument.call_args_list]
+
+
+def test_plain_host_port():
+    opts = MagicMock()
+    apply_proxy(opts, "http://10.0.0.5:8080")
+    assert "--proxy-server=http://10.0.0.5:8080" in _args(opts)
+
+
+def test_socks_scheme_preserved():
+    opts = MagicMock()
+    apply_proxy(opts, "socks5://exit.local:1080")
+    assert "--proxy-server=socks5://exit.local:1080" in _args(opts)
+
+
+def test_inline_credentials_stripped_from_proxy_server():
+    opts = MagicMock()
+    apply_proxy(opts, "http://user:secret@host.example:3128")
+    # creds must NOT appear in the --proxy-server arg
+    proxy_args = [a for a in _args(opts) if a.startswith("--proxy-server")]
+    assert proxy_args == ["--proxy-server=http://host.example:3128"]
+    assert all("secret" not in a for a in _args(opts))
+
+
+def test_invalid_url_no_host_is_ignored():
+    opts = MagicMock()
+    apply_proxy(opts, "not-a-url")
+    assert not any(a.startswith("--proxy-server") for a in _args(opts))
+
+
+def test_default_scheme_when_missing():
+    opts = MagicMock()
+    apply_proxy(opts, "//bare.host:9000")
+    assert "--proxy-server=http://bare.host:9000" in _args(opts)


### PR DESCRIPTION
Per-user egress so a user's automation browser exits from an IP near where they normally log in — the durable fix for LinkedIn "new location" device-approval challenges (stealth can't change the IP). **Zero user-side setup** — routing is derived from the user's already-captured location.

## How it resolves (no user action)
`get_docker_driver(user_id)` → `resolve_proxy(explicit, country)`:
1. `users.proxy_url` (explicit override) → 2. `REGION_PROXIES[country]` (auto, by stored country) → 3. `PROXY_URL` (global) → 4. none.

## Options (elaborated in docs/PER_USER_PROXY.md)
- **Recommended — a few cheap regional egress nodes:** one tiny proxy (~$3–4/mo) per region in `REGION_PROXIES`, auto-matched to each user's country. **Cost scales with regions (a handful), not users**; uses our AWS/VPS; stable IP per region → device stays "recognized". Datacenter IPs but geography matches.
- **Free baseline — Cloudflare WARP** on the box as the `DEFAULT` (sheds the raw datacenter IP; single location).
- **Opt-in/paid — residential proxy** via `users.proxy_url` for users who want turnkey.
- **Ruled out:** BYO home exit node (Tailscale/`cloudflared`) — requires user setup; kept only as an opt-in override. Tor — blocked by LinkedIn.

## What's here
Migration `V32` `users.proxy_url`; `get_user_proxy`/`update_user_proxy`; `utilities/proxy.py`; `apply_proxy()` Selenium wiring; `REGION_PROXIES`/`PROXY_URL` env; docs; tests. **923 unit tests pass.** Inert by default (no `REGION_PROXIES`/`proxy_url` → direct egress, unchanged behavior).

Follow-ups: provision the regional nodes (Terraform/CDK/cloud-init) + lock to the box IP; `GET/PUT /user/proxy` + Settings UI; credentialed-proxy auth extension.

🤖 Generated with [Claude Code](https://claude.com/claude-code)