### PR TITLE
feat(linkedin): session-cookie (li_at) reuse

### DIFF
--- a/docs/LINKEDIN_COOKIE.md
+++ b/docs/LINKEDIN_COOKIE.md
@@ -1,0 +1,63 @@
+# Connect LinkedIn by session cookie (recommended)
+
+The most reliable, lowest-friction way to keep a user's automation logged in **without
+triggering LinkedIn's "Check your app" new-device challenge** is to reuse their existing
+LinkedIn session instead of doing a fresh password login.
+
+## Why this works
+
+LinkedIn challenges a login when it sees a **fresh password sign-in from a new
+device/IP** — exactly what our Selenium login does. But if we present the user's already
+established session cookie (`li_at`), LinkedIn sees a continued, trusted session and does
+**not** challenge it. `login_to_linkedin` already tries stored cookies first, so once a
+valid `li_at` is saved, the password step (and its 2FA challenge) is skipped entirely.
+
+`li_at` is an **httpOnly** cookie — page JavaScript can't read it, which is why the
+one-click capture uses a browser extension (the `chrome.cookies` API can).
+
+## Option A — one-click browser extension (least steps)
+
+`tools/linkedin-cookie-extension/` is a minimal Chrome/Edge MV3 extension.
+
+1. `chrome://extensions` → enable **Developer mode** → **Load unpacked** →
+   select `tools/linkedin-cookie-extension/`.
+2. Be signed in to `linkedin.com` in that browser.
+3. Click the extension → set **LEM URL** (default prod) → paste your **LEM session
+   token** once (saved locally) → **Connect**.
+
+It reads `li_at` (+ `JSESSIONID`) and POSTs them to `POST /api/user/linkedin-cookie`.
+After that, automation reuses the session; re-click **Connect** if the session ever
+disconnects.
+
+## Option B — manual paste (no extension)
+
+1. On `linkedin.com`: DevTools (F12) → **Application** → **Cookies** →
+   `https://www.linkedin.com` → copy the **Value** of `li_at`.
+2. Send it to the endpoint:
+
+```bash
+curl -X POST "$LEM_URL/api/user/linkedin-cookie" \
+  -H "Content-Type: application/json" \
+  -d '{"session_token":"<your LEM session token>","li_at":"<li_at value>"}'
+```
+
+## The endpoint
+
+`POST /api/user/linkedin-cookie` — body `{ session_token, li_at, jsessionid? }`.
+Authenticated by the user's LEM `session_token`. Validates `li_at` and stores it via the
+standard cookie store (`store_linkedin_li_at` → `store_cookies`), so the existing
+cookie-first `login_to_linkedin` path picks it up. Returns 422 on a malformed `li_at`,
+401 on a bad session.
+
+## Security
+
+`li_at` is **as sensitive as a password** — anyone holding it can act as that LinkedIn
+user. It is the user's own session, sent only to their own LEM instance over HTTPS and
+stored in the same `cookies` table the automation already uses. Treat it accordingly;
+rotate by signing out of LinkedIn (which invalidates it) and reconnecting.
+
+## Combine with the proxy (optional)
+
+Cookie reuse removes the *login* challenge. Pairing it with a stable per-user egress
+(`REGION_PROXIES`, see [`PER_USER_PROXY.md`](PER_USER_PROXY.md)) keeps the session's IP
+consistent too — but it's no longer required just to log in.

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -22,7 +22,7 @@ from cqc_lem.utilities.db import (
     get_recent_logs, bulk_update_posts, soft_delete_posts,
     create_pin_for_email, verify_pin_for_email, delete_pin_for_email,
     create_session, get_session_user_id, delete_session,
-    add_user_by_email, get_user_email, get_user_token_info,
+    add_user_by_email, get_user_email, get_user_token_info, store_linkedin_li_at,
     get_user_subscription_info, get_user_preferences, update_user_preferences,
     update_subscription_from_stripe, update_user_linkedin_token,
     get_users_with_stripe_subscriptions,
@@ -271,6 +271,12 @@ class LocationRequest(BaseModel):
 
 class LocationAutocaptureRequest(BaseModel):
     session_token: str
+
+
+class LinkedInCookieRequest(BaseModel):
+    session_token: str
+    li_at: str
+    jsessionid: Optional[str] = None
 
 
 class AdminFixVideoUrlsRequest(BaseModel):
@@ -1056,6 +1062,33 @@ def autocapture_user_location_endpoint(request: LocationAutocaptureRequest, http
         "city": data.get("city"), "country": data.get("country_code") or data.get("country"),
         "timezone": data.get("timezone"), "locale": locale,
     })
+
+
+@router.post("/user/linkedin-cookie")
+def store_linkedin_cookie_endpoint(request: LinkedInCookieRequest) -> ResponseModel:
+    """Store the user's existing LinkedIn session cookie (li_at) so automation resumes
+    an already-trusted session instead of doing a fresh password login — which is what
+    triggers LinkedIn's "Check your app" new-device challenge. The user captures li_at
+    once (one-click extension or paste); see docs/LINKEDIN_COOKIE.md."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    # A cookie value cannot contain whitespace or ';'. Strip optional surrounding quotes.
+    li_at = (request.li_at or "").strip().strip('"')
+    if len(li_at) < 20 or any(c.isspace() for c in li_at) or ";" in li_at:
+        raise HTTPException(
+            status_code=422,
+            detail="Invalid li_at value — paste the full LinkedIn 'li_at' cookie value.",
+        )
+    jsessionid = (request.jsessionid or "").strip() or None
+
+    if not store_linkedin_li_at(user_id, li_at, jsessionid=jsessionid):
+        raise HTTPException(status_code=500, detail="Could not store LinkedIn session")
+    return ResponseModel(
+        status_code=200,
+        detail="LinkedIn session saved. Automation will reuse it and skip the password login.",
+    )
 
 
 @router.post("/billing/create-checkout-session")

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -147,6 +147,37 @@ def get_cookies(url: str, user_email: str):
     return cookies
 
 
+def store_linkedin_li_at(user_id: int, li_at: str, jsessionid: Optional[str] = None) -> bool:
+    """Persist a user-supplied LinkedIn session cookie (li_at, optionally JSESSIONID).
+
+    Lets login_to_linkedin resume an already-trusted session instead of doing a fresh
+    password login — which is what triggers LinkedIn's new-device challenge. Reuses the
+    standard cookie store so the existing cookie-first login path picks it up.
+    """
+    email = get_user_email(user_id)
+    if not email:
+        myprint(f"store_linkedin_li_at: no email for user_id {user_id}")
+        return False
+
+    import time
+    expiry = int(time.time()) + 365 * 24 * 60 * 60  # ~1 year; load_cookies re-stamps anyway
+    cookies = [{
+        "name": "li_at", "value": li_at, "domain": ".linkedin.com", "path": "/",
+        "expiry": expiry, "secure": True, "httpOnly": True,
+    }]
+    if jsessionid:
+        cookies.append({
+            "name": "JSESSIONID", "value": jsessionid, "domain": ".linkedin.com",
+            "path": "/", "expiry": expiry, "secure": True, "httpOnly": False,
+        })
+    try:
+        store_cookies(email, cookies)
+        return True
+    except Exception as e:
+        myprint(f"Could not store LinkedIn session cookie for user_id {user_id}: {e}")
+        return False
+
+
 def add_user(email: str, password: str):
     connection = get_db_connection()
     cursor = connection.cursor()

--- a/tests/unit/api/test_api_linkedin_cookie.py
+++ b/tests/unit/api/test_api_linkedin_cookie.py
@@ -1,0 +1,88 @@
+"""Unit tests for POST /api/user/linkedin-cookie."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_SESSION = "tok_test"
+_USER_ID = 42
+_VALID = "AQEDAReallyLongLinkedInSessionTokenValue1234567890"
+
+
+class TestStoreLinkedInCookie:
+    def test_stores_valid_li_at(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.store_linkedin_li_at", return_value=True) as store:
+            resp = client.post("/api/user/linkedin-cookie", json={
+                "session_token": _SESSION, "li_at": _VALID,
+            })
+        assert resp.status_code == 200
+        store.assert_called_once()
+        assert store.call_args.args[0] == _USER_ID
+        assert store.call_args.args[1] == _VALID
+
+    def test_strips_surrounding_quotes(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.store_linkedin_li_at", return_value=True) as store:
+            resp = client.post("/api/user/linkedin-cookie", json={
+                "session_token": _SESSION, "li_at": f'  "{_VALID}"  ',
+            })
+        assert resp.status_code == 200
+        assert store.call_args.args[1] == _VALID
+
+    def test_passes_jsessionid_through(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.store_linkedin_li_at", return_value=True) as store:
+            resp = client.post("/api/user/linkedin-cookie", json={
+                "session_token": _SESSION, "li_at": _VALID, "jsessionid": "ajax:123",
+            })
+        assert resp.status_code == 200
+        assert store.call_args.kwargs.get("jsessionid") == "ajax:123"
+
+    def test_401_invalid_session(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.post("/api/user/linkedin-cookie", json={
+                "session_token": "bad", "li_at": _VALID,
+            })
+        assert resp.status_code == 401
+
+    @pytest.mark.parametrize("bad", ["short", "has space inside", "semi;colon", ""])
+    def test_422_invalid_li_at(self, client, bad):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.store_linkedin_li_at", return_value=True) as store:
+            resp = client.post("/api/user/linkedin-cookie", json={
+                "session_token": _SESSION, "li_at": bad,
+            })
+        assert resp.status_code == 422
+        store.assert_not_called()
+
+    def test_500_when_store_fails(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER_ID), \
+             patch("cqc_lem.api.main.store_linkedin_li_at", return_value=False):
+            resp = client.post("/api/user/linkedin-cookie", json={
+                "session_token": _SESSION, "li_at": _VALID,
+            })
+        assert resp.status_code == 500

--- a/tests/unit/utilities/test_db_li_at.py
+++ b/tests/unit/utilities/test_db_li_at.py
@@ -1,0 +1,46 @@
+"""Unit tests for store_linkedin_li_at (cookie-session ingest helper)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+class TestStoreLinkedInLiAt:
+    def test_stores_li_at_cookie(self):
+        with patch(f"{_DB}.get_user_email", return_value="u@e.com"), \
+             patch(f"{_DB}.store_cookies") as store:
+            from cqc_lem.utilities.db import store_linkedin_li_at
+            assert store_linkedin_li_at(7, "TOKENvalue1234567890abc") is True
+        email, cookies = store.call_args.args
+        assert email == "u@e.com"
+        li = cookies[0]
+        assert li["name"] == "li_at" and li["value"] == "TOKENvalue1234567890abc"
+        assert li["domain"] == ".linkedin.com" and li["secure"] and li["httpOnly"]
+        assert len(cookies) == 1
+
+    def test_includes_jsessionid_when_provided(self):
+        with patch(f"{_DB}.get_user_email", return_value="u@e.com"), \
+             patch(f"{_DB}.store_cookies") as store:
+            from cqc_lem.utilities.db import store_linkedin_li_at
+            store_linkedin_li_at(7, "TOKENvalue1234567890abc", jsessionid="ajax:9")
+        cookies = store.call_args.args[1]
+        names = {c["name"] for c in cookies}
+        assert names == {"li_at", "JSESSIONID"}
+        js = next(c for c in cookies if c["name"] == "JSESSIONID")
+        assert js["value"] == "ajax:9" and js["httpOnly"] is False
+
+    def test_returns_false_when_no_email(self):
+        with patch(f"{_DB}.get_user_email", return_value=None), \
+             patch(f"{_DB}.store_cookies") as store:
+            from cqc_lem.utilities.db import store_linkedin_li_at
+            assert store_linkedin_li_at(99, "TOKENvalue1234567890abc") is False
+        store.assert_not_called()
+
+    def test_returns_false_when_store_raises(self):
+        with patch(f"{_DB}.get_user_email", return_value="u@e.com"), \
+             patch(f"{_DB}.store_cookies", side_effect=Exception("db down")):
+            from cqc_lem.utilities.db import store_linkedin_li_at
+            assert store_linkedin_li_at(7, "TOKENvalue1234567890abc") is False

--- a/tools/linkedin-cookie-extension/manifest.json
+++ b/tools/linkedin-cookie-extension/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "LEM LinkedIn Connect",
+  "version": "1.0.0",
+  "description": "One click sends your existing LinkedIn session to LinkedIn Engagement Manager so automation resumes a trusted session (no password login, no new-device challenge).",
+  "permissions": ["cookies", "storage"],
+  "host_permissions": [
+    "https://*.linkedin.com/*",
+    "https://lem.christopherqueenconsulting.com/*",
+    "http://localhost/*"
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "LEM LinkedIn Connect"
+  }
+}

--- a/tools/linkedin-cookie-extension/popup.html
+++ b/tools/linkedin-cookie-extension/popup.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    body { font-family: -apple-system, system-ui, sans-serif; width: 320px; padding: 14px; }
+    h1 { font-size: 15px; margin: 0 0 10px; }
+    label { display: block; font-size: 12px; color: #444; margin: 8px 0 2px; }
+    input { width: 100%; box-sizing: border-box; padding: 6px; font-size: 12px; }
+    button { margin-top: 12px; width: 100%; padding: 8px; font-size: 13px; font-weight: 600;
+             background: #0a66c2; color: #fff; border: 0; border-radius: 4px; cursor: pointer; }
+    button:disabled { background: #9bbfe0; cursor: default; }
+    #status { margin-top: 10px; font-size: 12px; white-space: pre-wrap; }
+    .ok { color: #0a7d2c; } .err { color: #b00020; }
+    .hint { font-size: 11px; color: #777; margin-top: 8px; }
+  </style>
+</head>
+<body>
+  <h1>Connect LinkedIn to LEM</h1>
+  <label for="base">LEM URL</label>
+  <input id="base" type="text" placeholder="https://lem.christopherqueenconsulting.com" />
+  <label for="token">Your LEM session token</label>
+  <input id="token" type="password" placeholder="paste once — it's saved locally" />
+  <button id="connect">Connect (send my LinkedIn session)</button>
+  <div id="status"></div>
+  <div class="hint">Open linkedin.com and stay signed in, then click Connect. Your session
+    stays on your machine and only your LinkedIn cookie is sent to your LEM.</div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/tools/linkedin-cookie-extension/popup.js
+++ b/tools/linkedin-cookie-extension/popup.js
@@ -1,0 +1,64 @@
+// Reads the user's LinkedIn session cookies (li_at is httpOnly, so only the
+// chrome.cookies API can see it — not page JS) and POSTs them to the LEM endpoint,
+// so automation resumes a trusted session instead of doing a password login.
+
+const baseEl = document.getElementById('base');
+const tokenEl = document.getElementById('token');
+const btn = document.getElementById('connect');
+const statusEl = document.getElementById('status');
+
+const DEFAULT_BASE = 'https://lem.christopherqueenconsulting.com';
+
+// Restore saved settings.
+chrome.storage.local.get(['base', 'token'], (s) => {
+  baseEl.value = s.base || DEFAULT_BASE;
+  if (s.token) tokenEl.value = s.token;
+});
+
+function setStatus(msg, cls) {
+  statusEl.textContent = msg;
+  statusEl.className = cls || '';
+}
+
+function getCookie(name) {
+  return new Promise((resolve) => {
+    chrome.cookies.get({ url: 'https://www.linkedin.com', name }, (c) => resolve(c && c.value));
+  });
+}
+
+btn.addEventListener('click', async () => {
+  const base = (baseEl.value || DEFAULT_BASE).trim().replace(/\/+$/, '');
+  const token = (tokenEl.value || '').trim();
+  if (!token) return setStatus('Enter your LEM session token first.', 'err');
+
+  chrome.storage.local.set({ base, token });
+  btn.disabled = true;
+  setStatus('Reading LinkedIn session…');
+
+  try {
+    const li_at = await getCookie('li_at');
+    if (!li_at) {
+      setStatus('No LinkedIn session found. Open linkedin.com, sign in, then retry.', 'err');
+      btn.disabled = false;
+      return;
+    }
+    const jsessionid = await getCookie('JSESSIONID');
+
+    setStatus('Sending to LEM…');
+    const resp = await fetch(`${base}/api/user/linkedin-cookie`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ session_token: token, li_at, jsessionid: jsessionid || null }),
+    });
+    const data = await resp.json().catch(() => ({}));
+    if (resp.ok) {
+      setStatus('✓ Connected. ' + (data.detail || 'LinkedIn session saved.'), 'ok');
+    } else {
+      setStatus(`Failed (${resp.status}): ${data.detail || 'see LEM logs'}`, 'err');
+    }
+  } catch (e) {
+    setStatus('Error: ' + e.message, 'err');
+  } finally {
+    btn.disabled = false;
+  }
+});


### PR DESCRIPTION
Implements option #1 from the research: reuse the user's **existing LinkedIn session** instead of a fresh password login — which is what triggers the "Check your app" new-device challenge every time. `login_to_linkedin` already tries stored cookies first; this adds the ingest path.

## What's here
- **`db.store_linkedin_li_at(user_id, li_at, jsessionid?)`** — builds the cookie dicts, stores via the existing `store_cookies` path.
- **`POST /api/user/linkedin-cookie`** (session_token auth) — validates `li_at` (strips quotes, rejects whitespace/`;`/too-short → 422), stores it. 401 on bad session.
- **`tools/linkedin-cookie-extension/`** — minimal MV3 Chrome/Edge extension. `li_at` is **httpOnly** (page JS can't read it), so the `chrome.cookies` API is the clean one-click capture. Reads `li_at`+`JSESSIONID`, POSTs to the endpoint.
- **`docs/LINKEDIN_COOKIE.md`** — extension + manual (DevTools/curl) flows, endpoint spec, security note (`li_at` ≈ password).
- Tests: db helper + endpoint (auth/validation/quote-strip/jsessionid passthrough). **936 unit tests pass.**

## Why it's the right call
Attacks the root cause (fresh logins), not the IP symptom; mostly free (no proxy infra); one-time per-user capture (one click via the extension). Pairs with the `REGION_PROXIES` resolver for IP consistency but no longer needs it just to log in.

Follow-up: a Settings UI field for the manual paste (extension covers the no-step path today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)