### PR TITLE
feat(account): LinkedIn-session emails + auto-detect + readiness API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -181,6 +181,11 @@ LINKEDIN_APPROVAL_WAIT_SECONDS=120
 LINKEDIN_APPROVAL_EMAIL_ENABLED=true
 # Link included in that email (and docs) for watching the live browser session.
 LEMVNC_URL=https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret
+# Base app URL used in "connect/reconnect your LinkedIn" emails (links to /account).
+LEM_APP_URL=https://lem.christopherqueenconsulting.com
+# Throttle for the connect/re-validate LinkedIn-session emails — at most one per user
+# per this many days (login auto-detect + the daily missing-session sweep). Default: 7.
+LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS=7
 
 # Observability & CI
 # =============================================================================

--- a/compose/local/database/migrations/V33__add_session_email_sent_at.sql
+++ b/compose/local/database/migrations/V33__add_session_email_sent_at.sql
@@ -1,0 +1,5 @@
+-- Throttle for LinkedIn session notification emails (connect / re-validate). We email a
+-- user when they have no validated session cookie, or when a stored one stops working —
+-- but only at most once per window, tracked here.
+ALTER TABLE users
+    ADD COLUMN linkedin_session_email_sent_at DATETIME NULL AFTER proxy_url;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -23,6 +23,7 @@ from cqc_lem.utilities.db import (
     create_pin_for_email, verify_pin_for_email, delete_pin_for_email,
     create_session, get_session_user_id, delete_session,
     add_user_by_email, get_user_email, get_user_token_info, store_linkedin_li_at,
+    has_linkedin_session, get_user_password_pair_by_id,
     get_user_subscription_info, get_user_preferences, update_user_preferences,
     update_subscription_from_stripe, update_user_linkedin_token,
     get_users_with_stripe_subscriptions,
@@ -1089,6 +1090,46 @@ def store_linkedin_cookie_endpoint(request: LinkedInCookieRequest) -> ResponseMo
         status_code=200,
         detail="LinkedIn session saved. Automation will reuse it and skip the password login.",
     )
+
+
+@router.get("/user/account-readiness")
+def account_readiness_endpoint(session_token: str) -> ResponseModel:
+    """Report whether the account has everything the automation needs (LinkedIn OAuth for
+    posting, a session cookie or password for engagement, an active plan; location is
+    recommended). The UI uses this to mark required fields and gate automation pages."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    token_info = get_user_token_info(user_id)
+    has_oauth = bool(token_info and token_info.get("access_token"))
+
+    has_session_cookie = has_linkedin_session(user_id)
+    _, li_password = get_user_password_pair_by_id(user_id)
+    has_engagement_login = has_session_cookie or bool(li_password)
+
+    sub = get_user_subscription_info(user_id)
+    sub_status = (sub or {}).get("subscription_status")
+    sub_active = sub_status in ("active", "trial")
+
+    geo = get_user_geo(user_id)
+    has_location = bool(geo and geo.get("latitude") is not None)
+
+    items = [
+        {"key": "email", "label": "Verified email", "ok": True, "required": True,
+         "hint": None},
+        {"key": "linkedin_oauth", "label": "LinkedIn connected (posting)", "ok": has_oauth,
+         "required": True, "hint": "Connect LinkedIn in your account."},
+        {"key": "linkedin_session", "label": "LinkedIn session (engagement)",
+         "ok": has_engagement_login, "required": True,
+         "hint": "Connect your LinkedIn session (cookie) or save your LinkedIn password."},
+        {"key": "subscription", "label": "Active plan", "ok": sub_active, "required": True,
+         "hint": "Start a plan or trial under Subscription."},
+        {"key": "location", "label": "Login location set", "ok": has_location,
+         "required": False, "hint": "Set your login location to reduce LinkedIn challenges."},
+    ]
+    ready = all(i["ok"] for i in items if i["required"])
+    return ResponseModel(status_code=200, detail={"ready": ready, "items": items})
 
 
 @router.post("/billing/create-checkout-session")

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -94,6 +94,10 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_invite_to_company_pages',
             'schedule': crontab(hour='5', minute='0', day_of_month='1')  # Run on the 1st of the month at 5:00 AM
         },
+        'notify-missing-linkedin-session': {
+            'task': 'cqc_lem.app.run_scheduler.auto_notify_missing_linkedin_session',
+            'schedule': crontab(hour='9', minute='0')  # Daily 9:00 AM — throttled per-user to 1/week
+        },
         'send-appreciation-dms': {
             'task': 'cqc_lem.app.run_scheduler.auto_appreciate_dms',
             'schedule': crontab(hour='8', minute='0')  # Run every day at 8:00 AM

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -11,11 +11,12 @@ from cqc_lem.app.run_automation import automate_commenting, automate_profile_vie
     automate_invites_to_company_page_for_user
 from cqc_lem.utilities.db import (
     get_ready_to_post_posts, get_orphaned_scheduled_posts, update_db_post_status,
-    get_active_user_ids, PostStatus,
+    get_active_user_ids, PostStatus, has_linkedin_session,
     get_users_with_stripe_subscriptions, update_subscription_from_stripe,
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES
 from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
+from cqc_lem.utilities.notifications import notify_linkedin_session
 
 
 
@@ -104,6 +105,23 @@ def auto_appreciate_dms():
         return f"No Active Users"
     else:
         return f"Started Appreciate DM Process for {len(users)} user(s)"
+
+
+@shared_task.task
+def auto_notify_missing_linkedin_session():
+    """Email active users who have no validated LinkedIn session cookie, prompting them
+    to connect — automation can't run without one. Throttled per-user inside
+    notify_linkedin_session, so this can run daily without spamming."""
+    users = get_active_user_ids()
+    notified = 0
+    for user_id in users:
+        try:
+            if not has_linkedin_session(user_id):
+                if notify_linkedin_session(user_id, revalidation=False):
+                    notified += 1
+        except Exception as e:
+            log_warning("Failed to notify missing LinkedIn session", exc=e, user_id=user_id)
+    return f"Notified {notified} of {len(users)} active user(s) missing a LinkedIn session"
 
 
 @shared_task.task

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -178,6 +178,60 @@ def store_linkedin_li_at(user_id: int, li_at: str, jsessionid: Optional[str] = N
         return False
 
 
+def has_linkedin_session(user_id: int) -> bool:
+    """True if the user has a stored LinkedIn session cookie (li_at) to log in with."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT 1 FROM cookies WHERE user_id = %s AND name = 'li_at' LIMIT 1",
+            (user_id,),
+        )
+        return cursor.fetchone() is not None
+    except mysql.connector.Error as err:
+        myprint(f"Could not check linkedin session for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_linkedin_session_email_sent_at(user_id: int):
+    """Return the datetime the last session notification email was sent, or None."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT linkedin_session_email_sent_at FROM users WHERE id = %s", (user_id,)
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not read session email timestamp for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def set_linkedin_session_email_sent_at(user_id: int) -> bool:
+    """Stamp now() as the last session notification email time (throttle)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE users SET linkedin_session_email_sent_at = NOW() WHERE id = %s", (user_id,)
+        )
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not set session email timestamp for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def add_user(email: str, password: str):
     connection = get_db_connection()
     cursor = connection.cursor()

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -3,7 +3,7 @@ import secrets
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
-from typing import Tuple
+from typing import Optional, Tuple
 
 from cqc_lem.utilities.env_constants import (
     SENDGRID_API_KEY,
@@ -158,6 +158,99 @@ def send_login_approval_email(to_email: str, vnc_url: str | None = None) -> bool
             return False
 
     return False
+
+
+def _send_high_priority_email(to_email: str, subject: str, html_content: str) -> bool:
+    """Send a high-priority email via SendGrid (falling back to SMTP). Returns True if dispatched."""
+    has_sendgrid = bool(SENDGRID_API_KEY)
+    has_smtp = bool(SMTP_USER) and bool(SMTP_PASSWORD)
+    if not has_sendgrid and not has_smtp:
+        myprint(f"No email provider configured — cannot send: {subject}")
+        return False
+
+    if has_sendgrid:
+        try:
+            from sendgrid import SendGridAPIClient
+            from sendgrid.helpers.mail import Header, Mail
+
+            message = Mail(from_email=SENDGRID_FROM_EMAIL, to_emails=to_email,
+                           subject=subject, html_content=html_content)
+            message.header = Header("X-Priority", "1")
+            message.header = Header("X-MSMail-Priority", "High")
+            message.header = Header("Importance", "High")
+            SendGridAPIClient(SENDGRID_API_KEY).send(message)
+            myprint(f"Email sent via SendGrid to {to_email}: {subject}")
+            return True
+        except Exception as e:
+            myprint(f"SendGrid send failed for {to_email}: {e}")
+
+    if has_smtp:
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = subject
+        msg["From"] = SMTP_USER
+        msg["To"] = to_email
+        msg["X-Priority"] = "1"
+        msg["X-MSMail-Priority"] = "High"
+        msg["Importance"] = "High"
+        msg.attach(MIMEText(html_content, "html"))
+        try:
+            with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=15) as server:
+                server.ehlo()
+                server.starttls()
+                server.login(SMTP_USER, SMTP_PASSWORD)
+                server.sendmail(SMTP_USER, to_email, msg.as_string())
+            myprint(f"Email sent via SMTP to {to_email}: {subject}")
+            return True
+        except Exception as e:
+            myprint(f"SMTP send failed for {to_email}: {e}")
+            return False
+
+    return False
+
+
+def _account_url() -> str:
+    import os
+    base = (os.getenv("LEM_APP_URL") or "https://lem.christopherqueenconsulting.com").rstrip("/")
+    return f"{base}/account"
+
+
+def send_connect_linkedin_email(to_email: str, account_url: Optional[str] = None) -> bool:
+    """Email a user who has no validated LinkedIn session, prompting them to connect."""
+    url = account_url or _account_url()
+    html = f"""
+    <html><body>
+    <h2>Connect your LinkedIn to keep automation running</h2>
+    <p>LinkedIn Engagement Manager needs an authorized LinkedIn session to post,
+    comment, and engage on your behalf. Your account doesn't have one yet, so automation
+    can't run.</p>
+    <p>It takes about a minute — open your account and click <strong>Connect LinkedIn</strong>:</p>
+    <p><a href="{url}" style="background:#0a66c2;color:#fff;padding:10px 16px;border-radius:6px;
+    text-decoration:none;">Connect LinkedIn</a></p>
+    <p style="color:#888;font-size:12px;">If you've already connected, you can ignore this email.</p>
+    </body></html>
+    """
+    return _send_high_priority_email(
+        to_email, "⚠️ Action needed: connect your LinkedIn to keep automation running", html)
+
+
+def send_session_revalidation_email(to_email: str, account_url: Optional[str] = None) -> bool:
+    """Email a user whose stored LinkedIn session stopped working, prompting a reconnect."""
+    url = account_url or _account_url()
+    html = f"""
+    <html><body>
+    <h2>Reconnect your LinkedIn session</h2>
+    <p>Your saved LinkedIn session expired or was signed out, so LinkedIn Engagement
+    Manager can no longer act on your behalf — automation is paused until you reconnect.</p>
+    <p>Open your account and reconnect (one click with the browser extension, or paste a
+    fresh session):</p>
+    <p><a href="{url}" style="background:#0a66c2;color:#fff;padding:10px 16px;border-radius:6px;
+    text-decoration:none;">Reconnect LinkedIn</a></p>
+    <p style="color:#888;font-size:12px;">This happens periodically — LinkedIn sessions don't
+    last forever.</p>
+    </body></html>
+    """
+    return _send_high_priority_email(
+        to_email, "⚠️ Action needed: reconnect your LinkedIn session", html)
 
 
 def send_pin_email(

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -230,6 +230,18 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
         myprint("Cookies stored to DB!")
         return
 
+    # We had a stored session cookie but it didn't authenticate — it's stale/expired.
+    # Auto-detect this and email the user to reconnect (preferred over password login).
+    if cookies:
+        try:
+            from cqc_lem.utilities.db import get_user_id
+            from cqc_lem.utilities.notifications import notify_linkedin_session
+            uid = get_user_id(user_email)
+            if uid:
+                notify_linkedin_session(uid, revalidation=True)
+        except Exception as e:
+            log_warning("Failed to send session re-validation email", exc=e, action_type="login")
+
     # Cookies missing or expired — do a full credential login
     myprint(f"Logging in to LinkedIn as: {user_email}")
 

--- a/src/cqc_lem/utilities/notifications.py
+++ b/src/cqc_lem/utilities/notifications.py
@@ -1,0 +1,46 @@
+"""Throttled LinkedIn-session notifications (connect / re-validate).
+
+Used by the login flow (auto-detects a stale session) and by a scheduled task
+(emails users with no validated session). Throttled to at most once per
+LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS so users aren't spammed every automation cycle.
+"""
+
+import os
+from datetime import datetime, timedelta
+
+from cqc_lem.utilities.db import (
+    get_user_email,
+    get_linkedin_session_email_sent_at,
+    set_linkedin_session_email_sent_at,
+)
+from cqc_lem.utilities.email import (
+    send_connect_linkedin_email,
+    send_session_revalidation_email,
+)
+from cqc_lem.utilities.logger import myprint
+
+
+def notify_linkedin_session(user_id: int, revalidation: bool = False) -> bool:
+    """Email the user to connect (revalidation=False) or reconnect (True) their LinkedIn
+    session. Throttled per LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS (default 7). Returns True
+    only if an email was actually sent."""
+    throttle_days = int(os.getenv("LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS", "7"))
+    last = get_linkedin_session_email_sent_at(user_id)
+    if last and throttle_days > 0:
+        try:
+            if datetime.now() - last < timedelta(days=throttle_days):
+                return False
+        except TypeError:
+            pass  # unexpected type — fall through and send
+
+    email = get_user_email(user_id)
+    if not email:
+        return False
+
+    sent = (send_session_revalidation_email(email) if revalidation
+            else send_connect_linkedin_email(email))
+    if sent:
+        set_linkedin_session_email_sent_at(user_id)
+        myprint(f"Sent LinkedIn session {'re-validation' if revalidation else 'connect'} "
+                f"email to user_id {user_id}")
+    return sent

--- a/tests/unit/api/test_api_account_readiness.py
+++ b/tests/unit/api/test_api_account_readiness.py
@@ -1,0 +1,97 @@
+"""Unit tests for GET /api/user/account-readiness."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_M = "cqc_lem.api.main"
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+def _patches(*, oauth, session, password, sub_status, lat):
+    return [
+        patch(f"{_M}.get_session_user_id", return_value=42),
+        patch(f"{_M}.get_user_token_info",
+              return_value={"access_token": "tok"} if oauth else None),
+        patch(f"{_M}.has_linkedin_session", return_value=session),
+        patch(f"{_M}.get_user_password_pair_by_id",
+              return_value=("e", "pw" if password else None)),
+        patch(f"{_M}.get_user_subscription_info",
+              return_value={"subscription_status": sub_status}),
+        patch(f"{_M}.get_user_geo", return_value={"latitude": lat} if lat is not None else None),
+    ]
+
+
+def _run(client, **kw):
+    ctxs = _patches(**kw)
+    for c in ctxs:
+        c.start()
+    try:
+        return client.get("/api/user/account-readiness?session_token=tok")
+    finally:
+        for c in ctxs:
+            c.stop()
+
+
+class TestAccountReadiness:
+    def test_ready_when_all_required_ok(self, client):
+        resp = _run(client, oauth=True, session=True, password=False, sub_status="active", lat=1.0)
+        assert resp.status_code == 200
+        d = resp.json()["detail"]
+        assert d["ready"] is True
+
+    def test_session_satisfied_by_password_alone(self, client):
+        resp = _run(client, oauth=True, session=False, password=True, sub_status="trial", lat=None)
+        d = resp.json()["detail"]
+        # location is not required → still ready
+        assert d["ready"] is True
+        item = next(i for i in d["items"] if i["key"] == "linkedin_session")
+        assert item["ok"] is True
+
+    def test_not_ready_when_no_engagement_login(self, client):
+        resp = _run(client, oauth=True, session=False, password=False, sub_status="active", lat=1.0)
+        d = resp.json()["detail"]
+        assert d["ready"] is False
+        item = next(i for i in d["items"] if i["key"] == "linkedin_session")
+        assert item["ok"] is False and item["required"] is True
+
+    def test_not_ready_when_no_oauth(self, client):
+        resp = _run(client, oauth=False, session=True, password=False, sub_status="active", lat=1.0)
+        assert resp.json()["detail"]["ready"] is False
+
+    def test_not_ready_when_subscription_inactive(self, client):
+        resp = _run(client, oauth=True, session=True, password=False, sub_status="canceled", lat=1.0)
+        assert resp.json()["detail"]["ready"] is False
+
+    def test_location_is_optional(self, client):
+        resp = _run(client, oauth=True, session=True, password=False, sub_status="active", lat=None)
+        d = resp.json()["detail"]
+        assert d["ready"] is True
+        loc = next(i for i in d["items"] if i["key"] == "location")
+        assert loc["required"] is False and loc["ok"] is False
+
+    def test_401_invalid_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.get("/api/user/account-readiness?session_token=bad")
+        assert resp.status_code == 401

--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -152,6 +152,38 @@ class TestLoginToLinkedinCookiePath:
         # Cookies stored after successful login
         mock_store.assert_called_once()
 
+    def test_stale_cookie_triggers_revalidation_email(self):
+        """Cookies present but they don't authenticate → auto-detect stale session and
+        email the user to reconnect (revalidation=True)."""
+        state = {"url": "https://www.linkedin.com"}
+        driver = MagicMock()
+        driver.get_cookies.return_value = [{"name": "li_at"}]
+        driver.find_elements.return_value = []
+        type(driver).current_url = property(lambda self: state["url"])
+
+        def on_get(u):
+            if "feed" in u:
+                state["url"] = "https://www.linkedin.com/login"   # stale cookie → bounced
+            elif "login" in u:
+                state["url"] = "https://www.linkedin.com/feed/"   # credential login succeeds
+            else:
+                state["url"] = "https://www.linkedin.com"
+        driver.get.side_effect = on_get
+
+        wait = _make_wait()
+        with patch(f"{_MODULE}.get_cookies", return_value=[{"name": "li_at"}]), \
+             patch(f"{_MODULE}.load_cookies"), \
+             patch(f"{_MODULE}.store_cookies"), \
+             patch(f"{_MODULE}.get_visible_element_wait_retry", return_value=MagicMock()), \
+             patch("cqc_lem.utilities.db.get_user_id", return_value=7), \
+             patch("cqc_lem.utilities.notifications.notify_linkedin_session") as notify:
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "user@e.com", "pw")
+
+        notify.assert_called_once()
+        assert notify.call_args.args[0] == 7
+        assert notify.call_args.kwargs.get("revalidation") is True
+
 
 @pytest.mark.unit
 class TestSolveArkoseChallenge:

--- a/tests/unit/utilities/test_db_session_helpers.py
+++ b/tests/unit/utilities/test_db_session_helpers.py
@@ -1,0 +1,55 @@
+"""Unit tests for LinkedIn-session DB helpers."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(fetch_row):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.fetchone.return_value = fetch_row
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestHasLinkedInSession:
+    def test_true_when_li_at_present(self):
+        conn, cur = _conn((1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_linkedin_session
+            assert has_linkedin_session(7) is True
+        assert "li_at" in cur.execute.call_args[0][0]
+
+    def test_false_when_absent(self):
+        conn, _ = _conn(None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_linkedin_session
+            assert has_linkedin_session(7) is False
+
+
+class TestSessionEmailTimestamp:
+    def test_get_returns_value(self):
+        import datetime as dt
+        when = dt.datetime(2026, 6, 30, 9, 0, 0)
+        conn, _ = _conn((when,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_linkedin_session_email_sent_at
+            assert get_linkedin_session_email_sent_at(7) == when
+
+    def test_get_returns_none_when_no_row(self):
+        conn, _ = _conn(None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_linkedin_session_email_sent_at
+            assert get_linkedin_session_email_sent_at(7) is None
+
+    def test_set_commits(self):
+        conn, cur = _conn(None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_linkedin_session_email_sent_at
+            assert set_linkedin_session_email_sent_at(7) is True
+        conn.commit.assert_called_once()
+        assert cur.execute.call_args[0][1] == (7,)

--- a/tests/unit/utilities/test_notifications.py
+++ b/tests/unit/utilities/test_notifications.py
@@ -1,0 +1,81 @@
+"""Unit tests for throttled LinkedIn-session notifications."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from unittest.mock import patch
+
+from cqc_lem.utilities.notifications import notify_linkedin_session
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.notifications"
+
+
+def test_skips_when_recently_sent(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS", "7")
+    with patch(f"{_MOD}.get_linkedin_session_email_sent_at",
+               return_value=datetime.now() - timedelta(days=1)), \
+         patch(f"{_MOD}.get_user_email") as ge, \
+         patch(f"{_MOD}.send_connect_linkedin_email") as sc:
+        assert notify_linkedin_session(7) is False
+        ge.assert_not_called()
+        sc.assert_not_called()
+
+
+def test_sends_connect_when_due(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS", "7")
+    with patch(f"{_MOD}.get_linkedin_session_email_sent_at", return_value=None), \
+         patch(f"{_MOD}.get_user_email", return_value="u@e.com"), \
+         patch(f"{_MOD}.send_connect_linkedin_email", return_value=True) as sc, \
+         patch(f"{_MOD}.send_session_revalidation_email") as sr, \
+         patch(f"{_MOD}.set_linkedin_session_email_sent_at") as stamp:
+        assert notify_linkedin_session(7, revalidation=False) is True
+        sc.assert_called_once_with("u@e.com")
+        sr.assert_not_called()
+        stamp.assert_called_once_with(7)
+
+
+def test_sends_revalidation_when_flagged(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS", "7")
+    with patch(f"{_MOD}.get_linkedin_session_email_sent_at",
+               return_value=datetime.now() - timedelta(days=30)), \
+         patch(f"{_MOD}.get_user_email", return_value="u@e.com"), \
+         patch(f"{_MOD}.send_session_revalidation_email", return_value=True) as sr, \
+         patch(f"{_MOD}.send_connect_linkedin_email") as sc, \
+         patch(f"{_MOD}.set_linkedin_session_email_sent_at"):
+        assert notify_linkedin_session(7, revalidation=True) is True
+        sr.assert_called_once_with("u@e.com")
+        sc.assert_not_called()
+
+
+def test_no_email_returns_false_and_does_not_stamp(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS", "7")
+    with patch(f"{_MOD}.get_linkedin_session_email_sent_at", return_value=None), \
+         patch(f"{_MOD}.get_user_email", return_value=None), \
+         patch(f"{_MOD}.send_connect_linkedin_email") as sc, \
+         patch(f"{_MOD}.set_linkedin_session_email_sent_at") as stamp:
+        assert notify_linkedin_session(7) is False
+        sc.assert_not_called()
+        stamp.assert_not_called()
+
+
+def test_throttle_zero_always_sends(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS", "0")
+    with patch(f"{_MOD}.get_linkedin_session_email_sent_at",
+               return_value=datetime.now()), \
+         patch(f"{_MOD}.get_user_email", return_value="u@e.com"), \
+         patch(f"{_MOD}.send_connect_linkedin_email", return_value=True) as sc, \
+         patch(f"{_MOD}.set_linkedin_session_email_sent_at"):
+        assert notify_linkedin_session(7) is True
+        sc.assert_called_once()
+
+
+def test_not_stamped_when_send_fails(monkeypatch):
+    monkeypatch.setenv("LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS", "7")
+    with patch(f"{_MOD}.get_linkedin_session_email_sent_at", return_value=None), \
+         patch(f"{_MOD}.get_user_email", return_value="u@e.com"), \
+         patch(f"{_MOD}.send_connect_linkedin_email", return_value=False), \
+         patch(f"{_MOD}.set_linkedin_session_email_sent_at") as stamp:
+        assert notify_linkedin_session(7) is False
+        stamp.assert_not_called()


### PR DESCRIPTION
Backend (PR 1 of 2) for the account-health work. Frontend (Account reorg + required-field marks + cookie-connect UI + page gating) follows in a second PR that consumes the readiness API here.

## What's here
- **Auto-detect stale session:** when `login_to_linkedin` loads stored cookies but they don't authenticate, it emails the user to **reconnect** (throttled) — the "is there a way to auto-detect this?" ask.
- **Missing-session sweep:** daily `auto_notify_missing_linkedin_session` (beat 09:00) emails active users with **no** validated session cookie to connect. Throttled per user.
- **`notifications.notify_linkedin_session`** — throttle (`LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS`, default 7) + high-priority connect/re-validate emails linking to `/account` (`LEM_APP_URL`).
- **`GET /api/user/account-readiness`** — reports what automation needs: LinkedIn OAuth (posting), session cookie **or** password (engagement), active plan; location optional. `{ ready, items[] }`.
- **DB:** `has_linkedin_session`, session-email timestamp get/set; migration **V33**.
- Tests for throttle logic, readiness, db helpers, login auto-detect, emails. **955 unit tests pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)