### PR TITLE
feat(ui): account-readiness gating + LinkedIn session card + required marks

### DIFF
--- a/src/cqc_lem/ui/src/components/AccountReadinessBanner.tsx
+++ b/src/cqc_lem/ui/src/components/AccountReadinessBanner.tsx
@@ -1,0 +1,37 @@
+import { Link } from 'react-router-dom'
+import { useAccountReadiness } from '../hooks/useAccountReadiness'
+
+// Shown on automation pages when required account data is missing, so users can't
+// expect automation to run until they finish setup. Renders nothing when ready.
+export default function AccountReadinessBanner() {
+  const { data } = useAccountReadiness()
+  if (!data || data.ready) return null
+
+  const missing = data.items.filter((i) => i.required && !i.ok)
+  if (missing.length === 0) return null
+
+  return (
+    <div className="bg-amber-50 border border-amber-300 rounded-lg p-4 mb-6">
+      <p className="text-sm font-semibold text-amber-900">
+        ⚠️ Finish setting up your account before automation can run
+      </p>
+      <ul className="mt-2 space-y-1">
+        {missing.map((i) => (
+          <li key={i.key} className="text-sm text-amber-800 flex items-start gap-2">
+            <span className="text-amber-500 leading-5">●</span>
+            <span>
+              <span className="font-medium">{i.label}</span>
+              {i.hint ? ` — ${i.hint}` : ''}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <Link
+        to="/account"
+        className="inline-block mt-3 text-sm font-semibold text-amber-900 underline hover:text-amber-950"
+      >
+        Go to Account to finish setup →
+      </Link>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/components/Layout.tsx
+++ b/src/cqc_lem/ui/src/components/Layout.tsx
@@ -1,5 +1,9 @@
-import { NavLink, Outlet, useNavigate } from 'react-router-dom'
+import { NavLink, Outlet, useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
+import AccountReadinessBanner from './AccountReadinessBanner'
+
+// Pages whose features depend on a fully set-up account — show the readiness banner here.
+const AUTOMATION_PATHS = ['/schedule', '/review', '/avatars']
 
 const navLinks = [
   { to: '/', label: 'Home', end: true },
@@ -12,6 +16,8 @@ const navLinks = [
 export default function Layout() {
   const { user, logout, openLoginModal } = useAuth()
   const navigate = useNavigate()
+  const location = useLocation()
+  const showReadiness = !!user && AUTOMATION_PATHS.some((p) => location.pathname.startsWith(p))
 
   async function handleLogout() {
     await logout()
@@ -64,6 +70,7 @@ export default function Layout() {
         </div>
       </nav>
       <main className="max-w-5xl mx-auto px-4 py-6">
+        {showReadiness && <AccountReadinessBanner />}
         <Outlet />
       </main>
     </div>

--- a/src/cqc_lem/ui/src/components/LinkedInSessionCard.tsx
+++ b/src/cqc_lem/ui/src/components/LinkedInSessionCard.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import api from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
+
+// Connect LinkedIn by reusing the user's existing session cookie (li_at) so automation
+// resumes a trusted session instead of a password login (which trips LinkedIn's
+// new-device challenge). Easiest path is the one-click browser extension.
+export default function LinkedInSessionCard({ connected }: { connected?: boolean }) {
+  const { sessionToken } = useAuth()
+  const queryClient = useQueryClient()
+  const [liAt, setLiAt] = useState('')
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null)
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      api.post('/user/linkedin-cookie', { session_token: sessionToken, li_at: liAt.trim() }),
+    onSuccess: () => {
+      setLiAt('')
+      setMsg({ ok: true, text: 'LinkedIn session saved. Automation will reuse it.' })
+      queryClient.invalidateQueries({ queryKey: ['account-readiness'] })
+      setTimeout(() => setMsg(null), 5000)
+    },
+    onError: () => {
+      setMsg({ ok: false, text: 'Could not save — paste the full li_at cookie value.' })
+      setTimeout(() => setMsg(null), 6000)
+    },
+  })
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+      <div>
+        <h2 className="text-base font-semibold text-gray-700">
+          LinkedIn Session <span className="text-red-500">*</span>
+          <span className="ml-2 text-[11px] font-semibold text-red-600 bg-red-50 px-2 py-0.5 rounded">
+            Required
+          </span>
+        </h2>
+        <p className="text-xs text-gray-500 mt-1">
+          Lets LEM resume your existing LinkedIn session instead of logging in with a
+          password — which avoids LinkedIn's "Check your app" security challenge. The
+          easiest way is the one-click browser extension; or paste your <code>li_at</code>{' '}
+          cookie value below.
+        </p>
+      </div>
+
+      {connected && (
+        <div className="flex items-center gap-2 text-sm text-green-700">
+          <span className="w-2.5 h-2.5 rounded-full bg-green-500" /> A session is saved.
+          Re-paste only if automation reports it disconnected.
+        </div>
+      )}
+
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">li_at cookie value</label>
+        <input
+          type="password"
+          value={liAt}
+          onChange={(e) => setLiAt(e.target.value)}
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          placeholder="paste your LinkedIn li_at cookie value"
+          autoComplete="off"
+        />
+        <p className="text-xs text-gray-400 mt-1">
+          DevTools (F12) → Application → Cookies → https://www.linkedin.com → copy the value of{' '}
+          <code>li_at</code>. This is sensitive — treat it like a password.
+        </p>
+      </div>
+
+      {msg && (
+        <p className={`text-sm font-medium ${msg.ok ? 'text-green-600' : 'text-red-600'}`}>
+          {msg.text}
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={() => mutation.mutate()}
+        disabled={mutation.isPending || liAt.trim().length < 20}
+        className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+      >
+        {mutation.isPending ? 'Saving…' : 'Save LinkedIn Session'}
+      </button>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/hooks/useAccountReadiness.ts
+++ b/src/cqc_lem/ui/src/hooks/useAccountReadiness.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query'
+import api from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
+
+export interface ReadinessItem {
+  key: string
+  label: string
+  ok: boolean
+  required: boolean
+  hint: string | null
+}
+
+export interface AccountReadiness {
+  ready: boolean
+  items: ReadinessItem[]
+}
+
+// Reports whether the account has everything the automation needs (LinkedIn OAuth,
+// a session cookie or password, an active plan; location optional).
+export function useAccountReadiness() {
+  const { sessionToken } = useAuth()
+  return useQuery({
+    queryKey: ['account-readiness', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/account-readiness?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as AccountReadiness),
+    enabled: !!sessionToken,
+    staleTime: 60 * 1000,
+  })
+}

--- a/src/cqc_lem/ui/src/pages/Account.tsx
+++ b/src/cqc_lem/ui/src/pages/Account.tsx
@@ -3,6 +3,8 @@ import { useSearchParams } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import api from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
+import { useAccountReadiness } from '../hooks/useAccountReadiness'
+import LinkedInSessionCard from '../components/LinkedInSessionCard'
 
 const LI_AUTH_URL = '/api/auth/linkedin/'
 
@@ -91,6 +93,8 @@ export default function Account() {
   const { user, sessionToken } = useAuth()
   const email = user?.email ?? ''
   const queryClient = useQueryClient()
+  const { data: readiness } = useAccountReadiness()
+  const sessionOk = readiness?.items.find((i) => i.key === 'linkedin_session')?.ok ?? false
 
   const [searchParams, setSearchParams] = useSearchParams()
   const [blogUrl, setBlogUrl] = useState(localStorage.getItem('lem_blog_url') || '')
@@ -444,7 +448,9 @@ export default function Account() {
       {/* Subscription card */}
       <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
         <div className="flex items-center justify-between">
-          <h2 className="text-base font-semibold text-gray-700">Subscription</h2>
+          <h2 className="text-base font-semibold text-gray-700">
+            Subscription <span className="text-red-500">*</span>
+          </h2>
           <span className={`text-xs font-semibold px-2.5 py-1 rounded-full ${TIER_COLORS[tier] ?? TIER_COLORS.free_trial}`}>
             {TIER_LABELS[tier] ?? tier}
           </span>
@@ -547,7 +553,12 @@ export default function Account() {
       {/* LinkedIn connection — hidden when connected and token healthy */}
       {showLinkedInSection && (
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
-          <h2 className="text-base font-semibold text-gray-700">LinkedIn Connection</h2>
+          <h2 className="text-base font-semibold text-gray-700">
+            LinkedIn Connection <span className="text-red-500">*</span>
+            <span className="ml-2 text-[11px] font-semibold text-red-600 bg-red-50 px-2 py-0.5 rounded">
+              Required
+            </span>
+          </h2>
 
           {isLinkedInConnected && tokenExpiringSoon && !tokenExpired && (
             <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-3 text-sm text-yellow-800">
@@ -587,6 +598,9 @@ export default function Account() {
           </a>
         </div>
       )}
+
+      {/* LinkedIn Session (cookie) — preferred login method; avoids the device challenge */}
+      <LinkedInSessionCard connected={sessionOk} />
 
       {/* LinkedIn Automation Password — always shown when LinkedIn is connected */}
       {isLinkedInConnected && !tokenExpired && (


### PR DESCRIPTION
Frontend (PR 2 of 2) consuming the readiness API from #199. **Verified locally: `tsc -b && vite build` passes** (run in a node:20 container, since there's no host Node).

## What's here
- **`useAccountReadiness`** hook → `GET /api/user/account-readiness`.
- **`AccountReadinessBanner`** rendered by `Layout` on automation pages (`/schedule`, `/review`, `/avatars`): when required account data is missing it lists exactly what's needed and links to Account. (Soft gate — prominent warning, doesn't hard-lock the page.)
- **`LinkedInSessionCard`** on the Account page: connect by pasting the `li_at` cookie (one-click browser extension is the easy path), invalidates readiness on save.
- **Required markers** on LinkedIn Connection / LinkedIn Session / Subscription.

## Notes
- Changes are additive (every import is used → satisfies `noUnusedLocals`).
- A deeper visual reorganization of the Account page can follow; this focuses on the functional asks (gating, required marks, the cookie-connect UI, readiness) without a risky full reshuffle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)