### PR TITLE
fix(ci): merge-queue-safe releases + resilient deploys

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -68,12 +68,68 @@ jobs:
       CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
       CF_ZONE_ID: ${{ secrets.CF_ZONE_ID }}
     steps:
-      - name: Deploy over SSH
+      # SSH to the VPS can intermittently time out ("dial tcp :22 i/o timeout"), and the
+      # default 10m command_timeout once KILLED `docker compose up` mid-recreation, taking
+      # the stack down. Fix: a larger command_timeout (deploy.sh health-checks + rolls back
+      # within it, so it must not be cut off) plus up to 3 attempts with backoff to ride
+      # out transient SSH failures. deploy.sh is idempotent, so retries are safe.
+      - name: Deploy over SSH (attempt 1)
+        id: deploy1
+        continue-on-error: true
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.VPS_HOST }}
           username: ${{ secrets.VPS_USER }}
           key: ${{ secrets.VPS_SSH_KEY }}
+          timeout: 60s
+          command_timeout: 25m
+          script_stop: true
+          envs: GHCR_USER,GHCR_PAT
+          script: |
+            cd /opt/lem
+            ./scripts/deploy.sh "${{ needs.build-and-push.outputs.tag }}"
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+
+      - name: Backoff before deploy retry 2
+        if: ${{ steps.deploy1.outcome == 'failure' }}
+        run: sleep 45
+
+      - name: Deploy over SSH (attempt 2)
+        id: deploy2
+        if: ${{ steps.deploy1.outcome == 'failure' }}
+        continue-on-error: true
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          timeout: 60s
+          command_timeout: 25m
+          script_stop: true
+          envs: GHCR_USER,GHCR_PAT
+          script: |
+            cd /opt/lem
+            ./scripts/deploy.sh "${{ needs.build-and-push.outputs.tag }}"
+        env:
+          GHCR_USER: ${{ github.actor }}
+          GHCR_PAT: ${{ secrets.GHCR_PAT }}
+
+      - name: Backoff before deploy retry 3
+        if: ${{ steps.deploy1.outcome == 'failure' && steps.deploy2.outcome == 'failure' }}
+        run: sleep 90
+
+      - name: Deploy over SSH (attempt 3, final)
+        id: deploy3
+        if: ${{ steps.deploy1.outcome == 'failure' && steps.deploy2.outcome == 'failure' }}
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          timeout: 60s
+          command_timeout: 25m
           script_stop: true
           envs: GHCR_USER,GHCR_PAT
           script: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,3 +38,32 @@ jobs:
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+
+  # Safety net for the merge queue: it merges the release PR under a rewritten SHA,
+  # so release-please can't find it ("SHA not found in recent commits, skipping") and
+  # never tags/builds. This job is SHA-independent — it just ensures the version that's
+  # now on main has a tag, creating it + dispatching the build if not. No-op on normal
+  # merges (version unchanged → tag already exists).
+  ensure-release-tag:
+    name: Ensure release tag (merge-queue safe)
+    runs-on: ubuntu-latest
+    needs: release-please
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Tag + dispatch build if the current version is untagged
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          version="$(grep -m1 '^version = ' pyproject.toml | sed -E 's/^version = "(.*)"/\1/')"
+          tag="v${version}"
+          if [ -z "${version}" ]; then echo "Could not read version from pyproject.toml"; exit 1; fi
+          if git ls-remote --tags origin "refs/tags/${tag}" | grep -q "${tag}"; then
+            echo "Tag ${tag} already exists — nothing to do."
+            exit 0
+          fi
+          echo "Version ${version} is on main but ${tag} doesn't exist (merge queue rewrote the"
+          echo "release-PR SHA, so release-please skipped tagging). Creating ${tag} + dispatching build."
+          gh release create "${tag}" --target "${GITHUB_SHA}" --title "${tag}" --generate-notes
+          gh workflow run build-and-push.yml --repo "${{ github.repository }}" --ref "${tag}"


### PR DESCRIPTION
Fixes the two pipeline failure modes that caused silent non-deploys and a brief outage this cycle.

**1. Merge-queue-safe tagging.** The merge queue merges the release-please PR under a rewritten SHA → release-please logs *"SHA not found … skipping"* and never tags (so build/deploy never fire). New **`ensure-release-tag`** job (in `release-please.yml`, `needs: release-please`) is SHA-independent: on push to main it checks whether the current `pyproject` version has a tag and, if not, creates it + dispatches `build-and-push`. No-op on normal feature merges (version unchanged → tag exists).

**2. Resilient SSH deploy.** The deploy SSH intermittently `i/o timeout`s, and the default 10m `command_timeout` once **killed `docker compose up` mid-recreation** (web_app + celery went down). Now: `command_timeout: 25m` (deploy.sh health-checks + rolls back *within* it, so it must not be cut off), `timeout: 60s`, and **up to 3 attempts with backoff**. `deploy.sh` is idempotent, so retries are safe.

This very release exercises both fixes end-to-end (a `fix:` bump → the new tag job + retrying deploy should land it with no manual steps). Both workflow files validated as parseable YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)