### PR TITLE
fix(scheduler): post at user's local time + close enqueue blind-window

### DIFF
--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -62,9 +62,11 @@ app.conf.update(
         # },
         'check-scheduled-posts': {
             'task': 'cqc_lem.app.run_scheduler.auto_check_scheduled_posts',
-            # 'schedule': timedelta(minutes=CQC_LEM_POST_TIME_DELTA_MINUTES)  # Run every x minutes
-            'schedule': crontab(minute='0,30')  # Run every hour and half hour
-            # 'schedule': crontab(minute='0')  # Run every hour
+            # Run every 10 min so the 20-min lookahead always covers the next run — no
+            # blind window where a post is picked up only after its time (was '0,30':
+            # a 30-min cadence vs 20-min lookahead left a 10-min gap → posts up to ~10
+            # min late, and any non-:00/:30 scheduled time could slip).
+            'schedule': crontab(minute='*/10')
         },
         'generate-content-plan': {
             'task': 'cqc_lem.app.run_content_plan.auto_generate_content',

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 from urllib.parse import urlparse
 from xml.etree import ElementTree
 
+import pytz
 import requests
 from bs4 import BeautifulSoup
 from cqc_lem import assets_dir
@@ -20,7 +21,7 @@ from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, upda
     get_planned_posts_for_current_week, get_last_planned_post_date_for_user, get_user_password_pair_by_id, \
     get_user_blog_url, get_user_sitemap_url, get_active_user_ids, get_planned_posts_for_next_week, PostStatus, \
     update_db_post_video_url, update_db_post_status, PostType, get_user_preferences, \
-    update_db_post_carousel_slides, get_post_content
+    update_db_post_carousel_slides, get_post_content, get_user_timezone
 from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_RATIO, \
     DEFAULT_IMAGE_RATIO, AI_DISCLOSURE_ENABLED, AI_DISCLOSURE_TEXT, \
     STANDARD_VIDEO_MODEL, PREMIUM_VIDEO_MODEL, PREMIUM_TOP_VIDEO_MODEL, \
@@ -168,8 +169,18 @@ def plan_content_for_user(self, user_id: int):
         # Get the best time for the selected date
         post_time = get_best_posting_time(post_date.date())
 
-        # Combine the selected date and time into a single datetime object
+        # get_best_posting_time returns the user's LOCAL audience time (e.g. 2pm). Convert
+        # it from the user's timezone to UTC for storage, because the scheduler treats
+        # stored scheduled_time as UTC. Without this, a 14:00 local post was stored as
+        # 14:00 UTC and fired hours off the intended local time.
         scheduled_datetime = datetime.combine(post_date, post_time)
+        try:
+            user_tz = pytz.timezone(get_user_timezone(user_id))
+            scheduled_datetime = (
+                user_tz.localize(scheduled_datetime).astimezone(pytz.utc).replace(tzinfo=None)
+            )
+        except Exception as e:
+            myprint(f"Timezone conversion failed for user {user_id} — storing as UTC: {e}")
 
         daily_plan.append({
             "scheduled_datetime": scheduled_datetime,

--- a/tests/integration/test_content_plan.py
+++ b/tests/integration/test_content_plan.py
@@ -44,6 +44,42 @@ class TestPlanContentForUser:
             unique_types = set(inserted_types)
             assert len(unique_types) > 1, f"Expected multiple post types, got only: {unique_types}"
 
+    def test_scheduled_times_converted_from_user_local_to_utc(self, mock_database_connection):
+        """Regression: best-times are the user's LOCAL audience times and must be stored
+        as UTC, so posts fire at the intended local time (not hours off)."""
+        import pytz
+        from cqc_lem.app.run_content_plan import plan_content_for_user
+        from cqc_lem.utilities.utils import get_best_posting_times
+
+        captured = []
+        def cap(user_id, scheduled_time, post_type, buyer_stage):
+            captured.append(scheduled_time)
+            return True
+
+        fixed_now = datetime(2026, 6, 1, 0, 0, 0)
+        with patch('cqc_lem.app.run_content_plan.datetime') as mock_dt, \
+             patch('cqc_lem.app.run_content_plan.get_last_planned_post_date_for_user', return_value=None), \
+             patch('cqc_lem.app.run_content_plan.get_user_timezone', return_value='America/New_York'), \
+             patch('cqc_lem.app.run_content_plan.insert_planned_post', side_effect=cap):
+            mock_dt.now.return_value = fixed_now
+            mock_dt.combine = datetime.combine
+            plan_content_for_user(user_id=1)
+
+        assert captured, "no posts were planned"
+        tz = pytz.timezone('America/New_York')
+        local_best = {t.strftime('%H:%M') for t in get_best_posting_times().values()}
+        for st in captured:
+            # Stored value is naive UTC; converting back to the user's tz must land on a best-time.
+            local = pytz.utc.localize(st).astimezone(tz)
+            assert local.strftime('%H:%M') in local_best, (
+                f"stored {st} (UTC) -> {local} ET, not a configured local best-time"
+            )
+        # ET is offset from UTC, so the stored UTC hour must differ from the naive local hour
+        # for at least one post — proving conversion actually happened (not stored as-is).
+        assert any(
+            st.strftime('%H:%M') not in local_best for st in captured
+        ), "scheduled times were stored unconverted (still local-as-UTC)"
+
 
 @pytest.mark.integration
 class TestAutoGenerateContent:


### PR DESCRIPTION
Posts weren't going out at the right time. Two issues:

**1. Timezone (the big one).** `get_best_posting_time` returns the user's **local** audience time (e.g. 2pm), but `run_content_plan` stored `datetime.combine(date, time)` unconverted, and the scheduler treats stored `scheduled_time` as **UTC**. So a 2pm post for an `America/New_York` user was stored as `14:00 UTC` and fired at **10am ET (~4h early)**. Fix: localize the best-time in the user's timezone and convert to UTC before storing.

**2. Enqueue blind-window.** The beat ran every 30 min but the lookahead is 20 min, leaving a 10-min gap where a post is only picked up *after* its time → fired late. Now runs every 10 min so the 20-min lookahead always covers the next run (also snappier orphan recovery). Posts are dispatched with `eta=scheduled_time`, so Celery fires them at the exact time.

Regression test: planned times round-trip back to the user's configured local best-times.

Note: existing approved posts (planned before this fix) still have the old UTC-as-local times — I can run a one-time correction on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)