### PR TITLE
fix(carousel): self-heal stale/errored carousels into branded slides

### DIFF
--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -315,7 +315,8 @@ def _post_missing_required_asset(post_id: int, post_type, video_url) -> bool:
     if pt == PostType.CAROUSEL.value:
         from cqc_lem.utilities.db import get_post_carousel_slides
         slides = get_post_carousel_slides(post_id)
-        return not slides or str(slides).strip() in ("", "[]")
+        # Missing if empty OR only text titles (no real slide images generated yet).
+        return not _carousel_slides_are_real_images(slides)
     return False
 
 
@@ -456,9 +457,25 @@ def regenerate_post_video_task(post_id: int):
 
 
 @shared_task.task
+def _carousel_slides_are_real_images(slides) -> bool:
+    """True if carousel slides reference real images (URLs/paths), not plain text titles."""
+    if not slides:
+        return False
+    blob = str(slides)
+    return any(marker in blob for marker in ("http", "/assets", ".png", ".jpg"))
+
+
 def regenerate_post_carousel_task(post_id: int):
-    """Regenerate a carousel post's slide images (used by the asset-backfill safety net)."""
-    from cqc_lem.utilities.db import get_post_user_id, get_post_buyer_stage, update_db_post_content
+    """Regenerate a carousel post's slide images (used by the asset-backfill safety net).
+
+    On success (real slide images produced) it clears an 'error'/stale state back to
+    'approved' so the healed carousel can post. create_carousel_content flags 'error' on
+    failure, so a failed regeneration stays flagged for manual/dev attention.
+    """
+    from cqc_lem.utilities.db import (
+        get_post_user_id, get_post_buyer_stage, update_db_post_content,
+        get_post_carousel_slides, update_db_post_status, get_post_status,
+    )
     user_id = get_post_user_id(post_id)
     if not user_id:
         myprint(f"regenerate_post_carousel_task: no user for post_id={post_id}")
@@ -467,6 +484,12 @@ def regenerate_post_carousel_task(post_id: int):
     content = create_carousel_content(user_id, stage, post_id)
     if content:
         update_db_post_content(post_id, content)
+
+    # If real slide images now exist, heal the post back to 'approved' (e.g. from 'error').
+    if _carousel_slides_are_real_images(get_post_carousel_slides(post_id)):
+        if get_post_status(post_id) != PostStatus.POSTED.value:
+            update_db_post_status(post_id, PostStatus.APPROVED)
+            myprint(f"regenerate_post_carousel_task: post {post_id} healed → approved")
     return content
 
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2408,15 +2408,25 @@ def get_unposted_posts_missing_assets(within_days: int = 14) -> list:
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
+        # Include 'error' so failed posts get a regeneration attempt. A carousel needs
+        # regeneration when its slides are empty OR are plain text titles with no real image
+        # reference — real slides are stored as URLs (https .../api/assets/...png), so the
+        # absence of any image marker means generation never produced images.
         cursor.execute("""
             SELECT id, user_id, post_type, buyer_stage, scheduled_time
             FROM posts
-            WHERE status IN ('approved', 'pending', 'scheduled')
+            WHERE status IN ('approved', 'pending', 'scheduled', 'error')
               AND scheduled_time > NOW()
               AND scheduled_time <= NOW() + INTERVAL %s DAY
               AND (
                     (post_type = 'video'    AND (video_url IS NULL OR video_url = ''))
-                 OR (post_type = 'carousel' AND (carousel_slides IS NULL OR carousel_slides = '' OR carousel_slides = '[]'))
+                 OR (post_type = 'carousel' AND (
+                        carousel_slides IS NULL OR carousel_slides = '' OR carousel_slides = '[]'
+                        OR (carousel_slides NOT LIKE '%%http%%'
+                            AND carousel_slides NOT LIKE '%%/assets%%'
+                            AND carousel_slides NOT LIKE '%%.png%%'
+                            AND carousel_slides NOT LIKE '%%.jpg%%')
+                    ))
               )
             ORDER BY scheduled_time
         """, (within_days,))

--- a/tests/unit/app/test_asset_backfill.py
+++ b/tests/unit/app/test_asset_backfill.py
@@ -38,7 +38,15 @@ class TestMissingAssetGuard:
 
     def test_carousel_slides_states(self):
         from cqc_lem.app.run_content_plan import _post_missing_required_asset
-        for val, missing in [(None, True), ('[]', True), ('', True), ('["url"]', False)]:
+        cases = [
+            (None, True),
+            ('[]', True),
+            ('', True),
+            ('["Just A Text Title", "Another Title"]', True),  # text slides count as missing now
+            ('["https://x/assets?file_name=images/carousel/5/slide_01.png"]', False),
+            ('["/app/assets/slide_01.png"]', False),
+        ]
+        for val, missing in cases:
             with patch("cqc_lem.utilities.db.get_post_carousel_slides", return_value=val):
                 assert _post_missing_required_asset(5, "carousel", None) is missing
 

--- a/tests/unit/app/test_carousel_regenerate.py
+++ b/tests/unit/app/test_carousel_regenerate.py
@@ -1,0 +1,74 @@
+"""Unit tests for carousel regeneration / stale-slide healing."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_RCP = "cqc_lem.app.run_content_plan"
+_DB = "cqc_lem.utilities.db"
+
+
+class TestCarouselSlidesAreRealImages:
+    def test_real_image_urls(self):
+        from cqc_lem.app.run_content_plan import _carousel_slides_are_real_images
+        assert _carousel_slides_are_real_images(
+            ["https://x/api/assets?file_name=images/carousel/9/slide_01.png"]) is True
+
+    def test_local_png_paths(self):
+        from cqc_lem.app.run_content_plan import _carousel_slides_are_real_images
+        assert _carousel_slides_are_real_images(["/app/assets/slide_01.png"]) is True
+
+    def test_text_titles_are_not_images(self):
+        from cqc_lem.app.run_content_plan import _carousel_slides_are_real_images
+        assert _carousel_slides_are_real_images(["How We Scaled Operations", "Revenue Grew"]) is False
+
+    def test_empty(self):
+        from cqc_lem.app.run_content_plan import _carousel_slides_are_real_images
+        assert _carousel_slides_are_real_images([]) is False
+        assert _carousel_slides_are_real_images(None) is False
+
+
+class TestPostMissingRequiredAssetCarousel:
+    def test_text_slides_count_as_missing(self):
+        from cqc_lem.app.run_content_plan import _post_missing_required_asset
+        from cqc_lem.utilities.db import PostType
+        with patch(f"{_DB}.get_post_carousel_slides", return_value=["Title A", "Title B"]):
+            assert _post_missing_required_asset(5, PostType.CAROUSEL.value, None) is True
+
+    def test_real_image_slides_not_missing(self):
+        from cqc_lem.app.run_content_plan import _post_missing_required_asset
+        from cqc_lem.utilities.db import PostType
+        with patch(f"{_DB}.get_post_carousel_slides",
+                   return_value=["https://x/api/assets?file_name=images/carousel/5/slide_01.png"]):
+            assert _post_missing_required_asset(5, PostType.CAROUSEL.value, None) is False
+
+
+class TestRegeneratePostCarouselTask:
+    def test_heals_error_to_approved_on_real_images(self):
+        from cqc_lem.app.run_content_plan import regenerate_post_carousel_task
+        from cqc_lem.utilities.db import PostStatus
+        with patch(f"{_DB}.get_post_user_id", return_value=1), \
+             patch(f"{_DB}.get_post_buyer_stage", return_value="awareness"), \
+             patch(f"{_DB}.update_db_post_content"), \
+             patch(f"{_DB}.get_post_carousel_slides",
+                   return_value=["https://x/api/assets?file_name=images/carousel/5/slide_01.png"]), \
+             patch(f"{_DB}.get_post_status", return_value="error"), \
+             patch(f"{_DB}.update_db_post_status") as mock_status, \
+             patch(f"{_RCP}.create_carousel_content", return_value="post text"):
+            regenerate_post_carousel_task(5)
+        statuses = [c.args[1] for c in mock_status.call_args_list]
+        assert PostStatus.APPROVED in statuses
+
+    def test_does_not_approve_when_still_text(self):
+        from cqc_lem.app.run_content_plan import regenerate_post_carousel_task
+        from cqc_lem.utilities.db import PostStatus
+        with patch(f"{_DB}.get_post_user_id", return_value=1), \
+             patch(f"{_DB}.get_post_buyer_stage", return_value="awareness"), \
+             patch(f"{_DB}.update_db_post_content"), \
+             patch(f"{_DB}.get_post_carousel_slides", return_value=["Still A Text Title"]), \
+             patch(f"{_DB}.get_post_status", return_value="error"), \
+             patch(f"{_DB}.update_db_post_status") as mock_status, \
+             patch(f"{_RCP}.create_carousel_content", return_value="post text"):
+            regenerate_post_carousel_task(5)
+        assert PostStatus.APPROVED not in [c.args[1] for c in mock_status.call_args_list]


### PR DESCRIPTION
## Why

Carousels that previously failed image generation were left with plain **text slide titles** (or `error` status). The asset-backfill safety net only treated *empty* slides as missing, so these posts never regenerated and could not post — and historically the poster fell back to a single default image (the Call-of-Duty bug, fixed in #212). This closes the remaining gap so stale carousels self-heal into proper branded slides.

## What

- **`get_unposted_posts_missing_assets`**: include `error` status and detect text-only carousel slides (no `http`/`/assets`/`.png`/`.jpg` markers) as missing assets to backfill.
- **`_post_missing_required_asset`**: treat text-only slides as missing, via a shared `_carousel_slides_are_real_images` helper.
- **`regenerate_post_carousel_task`**: on a successful regeneration that produces real slide images, heal the post back to `approved` (clearing `error`). A failed regeneration stays flagged `error` for manual/dev attention (set by `create_carousel_content`).

## Tests

- `test_carousel_regenerate.py`: helper image-vs-text detection, missing-asset guard for text slides, heal/no-heal paths.
- Updated `test_asset_backfill.py` to cover the new text-slide-is-missing behavior.
- Full unit suite: 972 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)