### PR TITLE
fix(automation): make auto-commenting resilient to LinkedIn 429/auth-wall

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -18,7 +18,8 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, PostType, \
     get_dm_history_for_profile, get_post_status, get_user_blog_url, get_post_type, get_carousel_slides
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
-from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url
+from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
+    load_profile_for_user
 from cqc_lem.utilities.linkedin.poster import share_on_linkedin, share_carousel_on_linkedin
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.logger import myprint, log_error, log_info, log_warning
@@ -1435,15 +1436,31 @@ def get_current_profile(user_id: int, session_name: str = "Get Current Profile")
 
     driver, wait = get_driver_wait_pair(session_name=session_name, user_id=user_id)
 
+    # Login first — a failure here (e.g. HTTP 429 rate-limit, expired cookie) is fatal
+    # for this run; abort cleanly so the caller backs off instead of hammering LinkedIn.
     try:
-
         login_to_linkedin(driver, wait, user_email, user_password)
-        my_profile = get_my_profile(driver, wait, user_email, user_password, user_id=user_id)
-
     except Exception as e:
-        log_error("Error while getting updated profile", exc=e, user_id=user_id)
-        quit_gracefully(driver)  # Close the driver
+        log_error("LinkedIn login failed (possibly rate-limited)", exc=e, user_id=user_id)
+        quit_gracefully(driver)
         raise e
+
+    # A live profile refresh can fail independently (auth-wall on the profile view,
+    # transient DOM change) even when the feed is reachable. Don't let that abort the
+    # whole task — fall back to the user's cached profile so commenting can proceed.
+    try:
+        my_profile = get_my_profile(driver, wait, user_email, user_password, user_id=user_id)
+    except Exception as e:
+        log_warning("Live profile refresh failed; falling back to cached profile", exc=e, user_id=user_id)
+        my_profile = None
+
+    if my_profile is None and user_id is not None:
+        my_profile = load_profile_for_user(user_id)
+
+    if my_profile is None:
+        log_error("No profile available (live scrape failed and no cached profile)", user_id=user_id)
+        quit_gracefully(driver)
+        raise RuntimeError("Profile unavailable: live scrape failed and no cached profile to fall back on")
 
     return driver, wait, user_email, my_profile
 

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -145,6 +145,19 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
     def _is_logged_in(url: str) -> bool:
         return any(p in url for p in _LOGGED_IN_PATHS)
 
+    def _page_is_rate_limited(drv) -> bool:
+        """LinkedIn returns a 429 error page (or a tiny 'This page isn't working' body)
+        at normal URLs when throttled. Detect it from the rendered body text."""
+        try:
+            body = drv.find_element(By.TAG_NAME, "body").text or ""
+        except Exception:
+            return False
+        low = body.lower()
+        if len(body) < 200 and ("429" in low or "this page isn’t working" in low
+                                or "this page isn't working" in low):
+            return True
+        return "http error 429" in low or "too many requests" in low
+
     def _wait_for_manual_approval() -> bool:
         """Poll for a device-approval / 2FA checkpoint to clear.
 
@@ -223,6 +236,15 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
 
     if _is_challenge_url(driver.current_url):
         _handle_challenge("post-cookie-load")
+
+    # LinkedIn serves a "HTTP ERROR 429 / This page isn't working" body at the SAME
+    # /feed/ URL when the account/IP is rate-limited. A naive URL check would treat
+    # that as "logged in" and downstream profile scraping would crash. Detect it and
+    # raise a transient error so callers back off instead of hammering.
+    if _is_logged_in(driver.current_url) and _page_is_rate_limited(driver):
+        raise RuntimeError(
+            "LinkedIn is rate-limiting this session (HTTP 429). Backing off — "
+            "reduce automation frequency and retry later.")
 
     if _is_logged_in(driver.current_url):
         myprint(f"Already logged in! (current URL: {driver.current_url})")

--- a/src/cqc_lem/utilities/linkedin/scrapper.py
+++ b/src/cqc_lem/utilities/linkedin/scrapper.py
@@ -66,6 +66,31 @@ def deep_compare(dict1, dict2):
         return dict1 == dict2
 
 
+class ProfileUnavailableError(Exception):
+    """Raised when a LinkedIn profile page can't be parsed (rate-limited, auth-wall,
+    challenge, or a DOM change) — lets callers handle it gracefully instead of
+    crashing with an opaque AttributeError on a None element."""
+
+
+# Signatures of the non-profile pages LinkedIn serves at the same URL (rate-limit
+# error page, guest auth-wall, login/checkpoint). Matched against visible body text.
+_ERROR_PAGE_MARKERS = (
+    "http error 429",
+    "this page isn’t working",
+    "this page isn't working",
+    "too many requests",
+    "join linkedin",
+    "sign up | linkedin",
+    "let’s sign you in",
+    "security verification",
+)
+
+
+def _is_linkedin_error_page(page_text: str) -> bool:
+    low = (page_text or "").lower()
+    return any(marker in low for marker in _ERROR_PAGE_MARKERS)
+
+
 def get_page_source(driver, url, scroll_times=0):
     if url != driver.current_url:
         # Open the profile URL
@@ -77,22 +102,46 @@ def get_page_source(driver, url, scroll_times=0):
     return BeautifulSoup(driver.page_source, "html.parser")
 
 
+def parse_profile_header(source, profile_url, company_name=None) -> dict:
+    """Extract name/title/connection from a parsed profile page (pure, no Selenium).
+
+    Raises ProfileUnavailableError on rate-limit / auth-wall / error pages or when the
+    name can't be located, so callers handle it instead of crashing on a None element.
+    """
+    page_text = source.get_text(" ", strip=True)[:400] if source else ""
+    if not source or _is_linkedin_error_page(page_text):
+        raise ProfileUnavailableError(
+            f"Profile page unavailable (rate-limited/auth-wall/challenge) for {profile_url}: {page_text[:160]!r}")
+
+    # Header container class changes often; fall back to the whole document so a class
+    # rename doesn't break extraction. Then guard every lookup.
+    info = source.find('div', class_='mt2 relative') or source
+
+    name_el = info.find('h1') or source.find('h1')
+    if name_el is None:
+        raise ProfileUnavailableError(f"Could not locate profile name (DOM changed?) for {profile_url}")
+
+    title_el = info.find('div', class_='text-body-medium') or source.select_one('div.text-body-medium')
+    connection = info.find('span', class_='dist-value') or source.find('span', class_='dist-value')
+
+    profile = {'full_name': name_el.get_text().strip()}
+    if company_name:
+        profile['company_name'] = company_name
+    profile['job_title'] = title_el.get_text().lstrip().strip() if title_el else ""
+    if connection:
+        profile['connection'] = connection.get_text().strip()
+    profile['profile_url'] = profile_url
+    return profile
+
+
 # returns LinkedIn profile information
 def returnProfileInfo(driver: webdriver, profile_url, company_name=None, is_main_user=False):
     url = profile_url
     source = get_page_source(driver, url, 0)
-    profile = {}
-    info = source.find('div', class_='mt2 relative')
-    name = info.find('h1', class_='break-words').get_text().strip()
-    title = info.find('div', class_='text-body-medium break-words').get_text().lstrip().strip()
-    connection = info.find('span', class_='dist-value')
-    profile['full_name'] = name
-    if company_name:
-        profile['company_name'] = company_name
-    profile['job_title'] = title
-    if connection:
-        profile['connection'] = connection.get_text().strip()
-    profile['profile_url'] = profile_url
+
+    # Bail out clearly on rate-limit / auth-wall / error pages — parsing these used to
+    # crash with "'NoneType' object has no attribute 'find'" and take down auto-commenting.
+    profile = parse_profile_header(source, profile_url, company_name)
 
     # profile_li = source.find_all('li', class_='artdeco-list__item')
 

--- a/tests/unit/app/test_get_current_profile.py
+++ b/tests/unit/app/test_get_current_profile.py
@@ -1,0 +1,63 @@
+"""Unit tests for graceful profile fallback in run_automation.get_current_profile."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+
+def _patches():
+    return {
+        "get_user_password_pair_by_id": patch(f"{_RA}.get_user_password_pair_by_id", return_value=("e@x.com", "pw")),
+        "get_driver_wait_pair": patch(f"{_RA}.get_driver_wait_pair", return_value=(MagicMock(), MagicMock())),
+        "login_to_linkedin": patch(f"{_RA}.login_to_linkedin"),
+        "quit_gracefully": patch(f"{_RA}.quit_gracefully"),
+    }
+
+
+class TestGetCurrentProfile:
+    def test_falls_back_to_cached_profile_when_live_scrape_fails(self):
+        cached = MagicMock(name="CachedProfile")
+        p = _patches()
+        with p["get_user_password_pair_by_id"], p["get_driver_wait_pair"], \
+             p["login_to_linkedin"], p["quit_gracefully"], \
+             patch(f"{_RA}.get_my_profile", side_effect=RuntimeError("auth-wall")), \
+             patch(f"{_RA}.load_profile_for_user", return_value=cached) as mock_cache:
+            from cqc_lem.app.run_automation import get_current_profile
+            driver, wait, email, profile = get_current_profile(user_id=1)
+        mock_cache.assert_called_once_with(1)
+        assert profile is cached
+
+    def test_raises_when_login_fails(self):
+        # Login failure (e.g. 429) is fatal — must propagate so the caller backs off.
+        p = _patches()
+        with p["get_user_password_pair_by_id"], p["get_driver_wait_pair"], \
+             p["quit_gracefully"], \
+             patch(f"{_RA}.login_to_linkedin", side_effect=RuntimeError("HTTP 429 rate-limited")):
+            from cqc_lem.app.run_automation import get_current_profile
+            with pytest.raises(RuntimeError, match="429"):
+                get_current_profile(user_id=1)
+
+    def test_raises_when_no_profile_anywhere(self):
+        p = _patches()
+        with p["get_user_password_pair_by_id"], p["get_driver_wait_pair"], \
+             p["login_to_linkedin"], p["quit_gracefully"], \
+             patch(f"{_RA}.get_my_profile", side_effect=RuntimeError("scrape failed")), \
+             patch(f"{_RA}.load_profile_for_user", return_value=None):
+            from cqc_lem.app.run_automation import get_current_profile
+            with pytest.raises(RuntimeError, match="Profile unavailable"):
+                get_current_profile(user_id=1)
+
+    def test_returns_live_profile_on_success(self):
+        live = MagicMock(name="LiveProfile")
+        p = _patches()
+        with p["get_user_password_pair_by_id"], p["get_driver_wait_pair"], \
+             p["login_to_linkedin"], p["quit_gracefully"], \
+             patch(f"{_RA}.get_my_profile", return_value=live), \
+             patch(f"{_RA}.load_profile_for_user") as mock_cache:
+            from cqc_lem.app.run_automation import get_current_profile
+            _, _, _, profile = get_current_profile(user_id=1)
+        assert profile is live
+        mock_cache.assert_not_called()

--- a/tests/unit/utilities/linkedin/test_scrapper_profile.py
+++ b/tests/unit/utilities/linkedin/test_scrapper_profile.py
@@ -1,0 +1,77 @@
+"""Unit tests for resilient profile parsing in scrapper.parse_profile_header."""
+
+import pytest
+from bs4 import BeautifulSoup
+
+pytestmark = pytest.mark.unit
+
+
+def _soup(html):
+    return BeautifulSoup(html, "html.parser")
+
+
+class TestIsLinkedinErrorPage:
+    def test_429(self):
+        from cqc_lem.utilities.linkedin.scrapper import _is_linkedin_error_page
+        assert _is_linkedin_error_page("This page isn't working HTTP ERROR 429 Reload") is True
+
+    def test_authwall_join(self):
+        from cqc_lem.utilities.linkedin.scrapper import _is_linkedin_error_page
+        assert _is_linkedin_error_page("Join LinkedIn to continue") is True
+
+    def test_real_profile_text(self):
+        from cqc_lem.utilities.linkedin.scrapper import _is_linkedin_error_page
+        assert _is_linkedin_error_page("Jane Doe Senior Engineer at Acme") is False
+
+
+class TestParseProfileHeader:
+    def test_rate_limited_page_raises(self):
+        from cqc_lem.utilities.linkedin.scrapper import parse_profile_header, ProfileUnavailableError
+        page = _soup("<html><body>This page isn't working. HTTP ERROR 429</body></html>")
+        with pytest.raises(ProfileUnavailableError):
+            parse_profile_header(page, "https://www.linkedin.com/in/x/")
+
+    def test_missing_name_raises(self):
+        from cqc_lem.utilities.linkedin.scrapper import parse_profile_header, ProfileUnavailableError
+        page = _soup("<html><body><div>no header here</div></body></html>")
+        with pytest.raises(ProfileUnavailableError):
+            parse_profile_header(page, "https://www.linkedin.com/in/x/")
+
+    def test_none_source_raises(self):
+        from cqc_lem.utilities.linkedin.scrapper import parse_profile_header, ProfileUnavailableError
+        with pytest.raises(ProfileUnavailableError):
+            parse_profile_header(None, "https://www.linkedin.com/in/x/")
+
+    def test_extracts_name_and_title_with_fallback_selectors(self):
+        # No 'mt2 relative' container — must still find the h1 + title via fallbacks.
+        from cqc_lem.utilities.linkedin.scrapper import parse_profile_header
+        page = _soup(
+            "<html><body><main>"
+            "<h1 class='inline t-24'>Jane Doe</h1>"
+            "<div class='text-body-medium break-words'>Senior Engineer at Acme</div>"
+            "</main></body></html>")
+        prof = parse_profile_header(page, "https://www.linkedin.com/in/jane/", company_name="Acme")
+        assert prof["full_name"] == "Jane Doe"
+        assert prof["job_title"] == "Senior Engineer at Acme"
+        assert prof["company_name"] == "Acme"
+        assert prof["profile_url"] == "https://www.linkedin.com/in/jane/"
+
+    def test_title_missing_is_empty_not_crash(self):
+        from cqc_lem.utilities.linkedin.scrapper import parse_profile_header
+        page = _soup("<html><body><h1>Jane Doe</h1></body></html>")
+        prof = parse_profile_header(page, "https://www.linkedin.com/in/jane/")
+        assert prof["full_name"] == "Jane Doe"
+        assert prof["job_title"] == ""
+
+    def test_old_container_still_works(self):
+        from cqc_lem.utilities.linkedin.scrapper import parse_profile_header
+        page = _soup(
+            "<html><body><div class='mt2 relative'>"
+            "<h1 class='break-words'>Bob Smith</h1>"
+            "<div class='text-body-medium break-words'>CTO at Beta</div>"
+            "<span class='dist-value'>1st</span>"
+            "</div></body></html>")
+        prof = parse_profile_header(page, "https://www.linkedin.com/in/bob/")
+        assert prof["full_name"] == "Bob Smith"
+        assert prof["job_title"] == "CTO at Beta"
+        assert prof["connection"] == "1st"


### PR DESCRIPTION
## Symptom

`cqc_lem.app.run_automation.automate_commenting` was failing for user 1:

```
ERROR Error while getting profile for auto commenting
AttributeError: 'NoneType' object has no attribute 'find'
  File ".../run_automation.py", line 406, in automate_commenting
```

## Root cause (found via live Selenium debugging)

Driving the same `selenium-chrome` session the automation uses, the feed body was:

```
This page isn't working … HTTP ERROR 429
```

LinkedIn was **rate-limiting** the account/IP and serving a 429 error page (and an auth-wall on profile views) at normal URLs. The code:
1. `login_to_linkedin` saw `/feed/` in the URL and reported "Already logged in" — but the page was the 429 error.
2. `returnProfileInfo` then parsed that error page: `source.find('div', class_='mt2 relative')` → `None` → `.find()` → `AttributeError`.

## Fix (defensive — never crash, back off cleanly)

- **scrapper.py**: new `ProfileUnavailableError` + `_is_linkedin_error_page`; extracted a pure, unit-testable `parse_profile_header` that detects rate-limit/auth-wall/error pages and guards every lookup (falls back from the fragile `mt2 relative` container to the whole document, uses a single-class title selector). A DOM change or error page now raises a clear, catchable error instead of `AttributeError`.
- **helper.login_to_linkedin**: detect the HTTP 429 body served at `/feed/` and raise a transient rate-limit error instead of falsely reporting "Already logged in".
- **run_automation.get_current_profile**: separate a fatal login failure (abort so the caller backs off) from a failed live profile refresh (fall back to the user's cached profile so commenting can still proceed); raise cleanly only when no profile is available anywhere.

## Tests

- `test_scrapper_profile.py` — error-page detection, fallback selectors, legacy container, missing/empty fields.
- `test_get_current_profile.py` — cached-profile fallback, fatal-login abort, no-profile raise, live-success path.
- Full unit suite: **985 passed**.

## Operational note

The underlying 429 is a LinkedIn rate-limit (aggravated by frequent Selenium engagement + debugging). This PR makes the system fail safe and back off rather than crash; if throttling persists, automation cadence should be reduced. Carousel/post publishing is unaffected — it uses the LinkedIn REST API, not Selenium.

🤖 Generated with [Claude Code](https://claude.com/claude-code)