### PR TITLE
fix(api): dashboard stats 500s in the first days of a month

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1,7 +1,7 @@
 import json
 import os
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import IntEnum
 from typing import Dict, List, Union
 from typing import Optional, Any
@@ -361,7 +361,9 @@ def get_dashboard_stats(email: str) -> ResponseModel:
     posts, _ = get_posts(user_id)
     now = datetime.now(timezone.utc)
     week_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
-    week_start = week_start.replace(day=week_start.day - week_start.weekday())
+    # Back up to Monday. Use timedelta, not replace(day=...): naive day subtraction
+    # goes out of range in the first days of a month (e.g. Wed the 1st → day=-1).
+    week_start = week_start - timedelta(days=week_start.weekday())
 
     scheduled_this_week = sum(
         1 for p in posts

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -62,6 +62,20 @@ class TestDashboardStats:
         assert detail["pending_review"] == 0
         assert detail["posted_total"] == 0
 
+    def test_start_of_month_does_not_crash(self, client):
+        # Regression: week_start was computed with replace(day=day-weekday()), which
+        # goes out of range in the first days of a month (Wed the 1st → day=-1 → 500).
+        class _FixedDatetime(datetime):
+            @classmethod
+            def now(cls, tz=None):
+                return datetime(2026, 7, 1, tzinfo=tz)  # Wednesday the 1st
+
+        with patch(f"{_MAIN}.get_user_id", return_value=1), \
+             patch(f"{_MAIN}.get_posts", return_value=([], 0)), \
+             patch(f"{_MAIN}.datetime", _FixedDatetime):
+            resp = client.get(self.BASE, params={"email": "user@example.com"})
+        assert resp.status_code == 200
+
     def test_posted_total_counted_correctly(self, client):
         from cqc_lem.utilities.db import PostStatus
         posts = [


### PR DESCRIPTION
## Problem

Found while reviewing CI/prod: `GET /api/dashboard/stats/` returns **500** for every user during the first days of each month.

```python
week_start = week_start.replace(day=week_start.day - week_start.weekday())
```

On Wed **July 1** (`day=1`, `weekday()=2`) this becomes `replace(day=-1)` → `ValueError: day is out of range for month`. It fails roughly the 1st–4th of every month (whenever day-of-month ≤ weekday index). This is a live prod outage of the dashboard stats endpoint today, and it's why `main` unit-test CI is currently red.

## Fix

Back up to Monday with `timedelta(days=weekday())` instead of naive `replace(day=...)`.

Added a regression test pinned to Wed 2026-07-01 so the guard is deterministic year-round — the existing tests only caught it by luck of running on a month boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)