### PR TITLE
fix(login): recover from stale-cookie redirect loop after egress-IP change

### DIFF
--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -160,6 +160,19 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
             return True
         return "http error 429" in low or "too many requests" in low
 
+    def _page_is_redirect_loop(drv) -> bool:
+        """Stored cookies minted from a different egress IP (e.g. after switching to a
+        residential proxy) can make LinkedIn loop on re-auth, serving a browser error
+        page ("redirected you too many times / ERR_TOO_MANY_REDIRECTS"). The URL still
+        looks logged-in (/feed), so detect it from the body to avoid mistaking it for a
+        live session — the fix is to drop the cookies and do a fresh credential login."""
+        try:
+            body = drv.find_element(By.TAG_NAME, "body").text or ""
+        except Exception:
+            return False
+        low = body.lower()
+        return "err_too_many_redirects" in low or "redirected you too many times" in low
+
     def _wait_for_manual_approval() -> bool:
         """Poll for a device-approval / 2FA checkpoint to clear.
 
@@ -246,6 +259,18 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
 
     if _is_challenge_url(driver.current_url):
         _handle_challenge("post-cookie-load")
+
+    # Stored cookies minted from a different egress IP (e.g. after switching to a
+    # residential proxy) can make LinkedIn loop on re-auth, landing on a redirect-error
+    # page that still sits on /feed. Handle this BEFORE the 429 check — the redirect
+    # page also says "this page isn't working", which the rate-limit heuristic would
+    # otherwise misclassify as a 429. Drop the cookies and do a fresh credential login.
+    if cookies and _is_logged_in(driver.current_url) and _page_is_redirect_loop(driver):
+        myprint("Stored session unusable (redirect loop) — clearing cookies and re-authenticating")
+        driver.delete_all_cookies()
+        cookies = None
+        driver.get(login_url)
+        time.sleep(1)
 
     # LinkedIn serves a "HTTP ERROR 429 / This page isn't working" body at the SAME
     # /feed/ URL when the account/IP is rate-limited. A naive URL check would treat

--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -522,3 +522,70 @@ class TestRateLimitCircuitBreaker:
             login_to_linkedin(driver, wait, "u@e.com", "pw")
 
         mock_clear.assert_called_once()
+
+
+@pytest.mark.unit
+class TestRedirectLoopRecovery:
+    """Stale cookies from a different egress IP produce a redirect-loop page at /feed/;
+    login must recover via a fresh credential login instead of mistaking it for a 429
+    or for a live session."""
+
+    def _run(self):
+        state = {"url": "https://www.linkedin.com"}
+        body = {"text": ""}
+
+        def on_get(u):
+            if "feed" in u:
+                state["url"] = "https://www.linkedin.com/feed/"
+                body["text"] = ("This page isn't working www.linkedin.com redirected "
+                                "you too many times ERR_TOO_MANY_REDIRECTS")
+            elif "login" in u:
+                state["url"] = "https://www.linkedin.com/login"
+                body["text"] = ""
+            else:
+                state["url"] = "https://www.linkedin.com"
+                body["text"] = ""
+
+        driver = MagicMock()
+        driver.get.side_effect = on_get
+        driver.get_cookies.return_value = [{"name": "li_at", "value": "fresh"}]
+        type(driver).current_url = property(lambda self: state["url"])
+        body_el = MagicMock()
+        type(body_el).text = property(lambda self: body["text"])
+        driver.find_element.return_value = body_el
+
+        signin = MagicMock()
+        def do_click():
+            state["url"] = "https://www.linkedin.com/feed/"
+            body["text"] = ""   # feed loads cleanly after credential login
+        signin.click.side_effect = do_click
+        fields = [MagicMock(), MagicMock(), signin]  # username, password, sign-in
+
+        wait = _make_wait()
+        with patch(f"{_MODULE}.rate_limit_cooldown_remaining", return_value=0), \
+             patch(f"{_MODULE}.mark_rate_limited") as mock_mark, \
+             patch(f"{_MODULE}.clear_rate_limit"), \
+             patch(f"{_MODULE}.get_cookies", return_value=[{"name": "li_at", "value": "stale"}]), \
+             patch(f"{_MODULE}.load_cookies"), \
+             patch(f"{_MODULE}.store_cookies") as mock_store, \
+             patch(f"{_MODULE}.get_visible_element_wait_retry", side_effect=fields):
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "user@e.com", "pw")
+        return driver, mock_mark, mock_store
+
+    def test_redirect_loop_clears_cookies_and_reauths(self):
+        driver, mock_mark, mock_store = self._run()
+        # Stale browser cookies dropped, then a fresh credential login navigated to /login
+        driver.delete_all_cookies.assert_called_once()
+        assert any("login" in c.args[0] for c in driver.get.call_args_list), \
+            "expected a fresh credential login navigation to /login"
+
+    def test_redirect_loop_not_treated_as_rate_limit(self):
+        # The redirect page also says "this page isn't working"; it must NOT trip the 429
+        # breaker (checked before the rate-limit heuristic).
+        _, mock_mark, _ = self._run()
+        mock_mark.assert_not_called()
+
+    def test_redirect_loop_recovers_to_successful_login(self):
+        _, _, mock_store = self._run()
+        mock_store.assert_called_once()  # fresh cookies persisted after re-auth


### PR DESCRIPTION
## Problem

Found while validating the per-user residential-proxy path live. When a user's stored `li_at` cookies were minted from a **different egress IP** (e.g. after switching that user to a residential proxy), LinkedIn loops on re-auth and serves a browser error page — `ERR_TOO_MANY_REDIRECTS` / "www.linkedin.com redirected you too many times" — that **still sits on `/feed`**.

Two bugs resulted:
1. `login_to_linkedin`'s URL-only check treated `/feed` as **"already logged in"**, returned success, and every downstream scrape then failed on the error page.
2. The redirect page also contains the string *"this page isn't working"*, which the 429 heuristic (`_page_is_rate_limited`) matches for short bodies — so it would be **misclassified as a rate-limit** and trip the new circuit breaker.

## Fix

Add `_page_is_redirect_loop()` and check it **before** the 429 check. When stored cookies produce a redirect loop, drop the browser cookies (`delete_all_cookies`), null out `cookies`, and fall through to a **fresh credential login** that re-mints cookies bound to the current IP.

## Verification

Reproduced live: user switched to a DataImpulse US residential IP → the 429 disappeared (residential IP defeats the datacenter block) but the old cookies produced exactly this redirect loop. This fix makes login self-heal instead of false-positiving.

3 unit tests added: recovers via credential re-auth, does **not** trip the 429 breaker, persists fresh cookies. Full `test_helper.py` suite green (29 tests).