### PR TITLE
feat(proxy): support credentialed proxies via MV3 auth extension

### DIFF
--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -1,5 +1,8 @@
+import base64
+import io
 import json
 import time
+import zipfile
 from datetime import datetime, timedelta
 from functools import wraps
 from urllib.parse import urlparse
@@ -164,15 +167,51 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
     return driver
 
 
+def _build_proxy_auth_extension_b64(username: str, password: str) -> str:
+    """Build an in-memory MV3 Chrome extension that answers the proxy's auth challenge.
+
+    Chrome's --proxy-server can't carry credentials, so an authenticated proxy (e.g. a
+    residential provider whose sticky-session + geo target live in the username, like
+    DataImpulse) needs an extension that supplies them via webRequest.onAuthRequired.
+    MV2 background pages are disabled in current Chrome (149+), so this uses an MV3
+    service worker with the `webRequestAuthProvider` permission (which is what re-enables
+    a blocking onAuthRequired listener for a normal extension). Returned base64 zip is
+    passed to options.add_encoded_extension so there are no temp files to clean up.
+    """
+    manifest = {
+        "name": "lem-proxy-auth",
+        "version": "1.0",
+        "manifest_version": 3,
+        "permissions": ["proxy", "webRequest", "webRequestAuthProvider"],
+        "host_permissions": ["<all_urls>"],
+        "background": {"service_worker": "background.js"},
+        "minimum_chrome_version": "108",
+    }
+    # json.dumps escapes the ';' and '.' in the sticky-session username safely.
+    background = (
+        f"const U = {json.dumps(username)};\n"
+        f"const P = {json.dumps(password)};\n"
+        "chrome.webRequest.onAuthRequired.addListener(\n"
+        "  function (details) { return { authCredentials: { username: U, password: P } }; },\n"
+        "  { urls: ['<all_urls>'] },\n"
+        "  ['blocking']\n"
+        ");\n"
+    )
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("manifest.json", json.dumps(manifest))
+        z.writestr("background.js", background)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
 def apply_proxy(options: Options, proxy_url: str) -> None:
     """Route the browser's egress through `proxy_url` (scheme://[user:pass@]host:port).
 
-    Chrome's --proxy-server cannot carry inline credentials, so we pass only
-    scheme://host:port. Auth-less proxies — the free, recommended case (a home exit
-    node via Tailscale/cloudflared, Cloudflare WARP, or an IP-allowlisted proxy) —
-    work directly. Credentialed proxies additionally need an auth-handler extension;
-    see docs/PER_USER_PROXY.md. Best-effort: a malformed URL is logged and ignored
-    rather than failing driver creation.
+    Auth-less proxies (IP-allowlisted, Tailscale/cloudflared exit node) work via a bare
+    --proxy-server=scheme://host:port. Credentialed proxies additionally get an MV3
+    auth-handler extension so Chrome can answer the proxy's 407 challenge (see
+    docs/PER_USER_PROXY.md). Best-effort: a malformed URL is logged and ignored rather
+    than failing driver creation.
     """
     try:
         parsed = urlparse(proxy_url)
@@ -184,10 +223,13 @@ def apply_proxy(options: Options, proxy_url: str) -> None:
         hostport = f"{host}:{parsed.port}" if parsed.port else host
         options.add_argument(f"--proxy-server={scheme}://{hostport}")
         myprint(f"Routing browser egress via proxy {scheme}://{hostport}")
-        if parsed.username:
-            myprint("Proxy URL has inline credentials; --proxy-server cannot carry "
-                    "them. Use an IP-allowlisted proxy or an auth extension "
-                    "(see docs/PER_USER_PROXY.md).")
+        if parsed.username and parsed.password:
+            options.add_encoded_extension(
+                _build_proxy_auth_extension_b64(parsed.username, parsed.password))
+            myprint("Loaded proxy auth extension for credentialed proxy")
+        elif parsed.username:
+            myprint("Proxy URL has a username but no password; sending host:port only. "
+                    "Use user:pass or an IP-allowlisted proxy (see docs/PER_USER_PROXY.md).")
     except Exception as e:
         myprint(f"Could not apply proxy '{proxy_url}': {e}")
 

--- a/tests/unit/utilities/test_selenium_proxy.py
+++ b/tests/unit/utilities/test_selenium_proxy.py
@@ -1,15 +1,25 @@
 """Unit tests for apply_proxy (Selenium egress proxy wiring)."""
 
+import base64
+import io
+import json
+import zipfile
+
 import pytest
 from unittest.mock import MagicMock
 
-from cqc_lem.utilities.selenium_util import apply_proxy
+from cqc_lem.utilities.selenium_util import apply_proxy, _build_proxy_auth_extension_b64
 
 pytestmark = pytest.mark.unit
 
 
 def _args(options):
     return [c.args[0] for c in options.add_argument.call_args_list]
+
+
+def _extension_files(b64):
+    z = zipfile.ZipFile(io.BytesIO(base64.b64decode(b64)))
+    return {n: z.read(n).decode() for n in z.namelist()}
 
 
 def test_plain_host_port():
@@ -43,3 +53,42 @@ def test_default_scheme_when_missing():
     opts = MagicMock()
     apply_proxy(opts, "//bare.host:9000")
     assert "--proxy-server=http://bare.host:9000" in _args(opts)
+
+
+def test_credentialed_proxy_loads_auth_extension():
+    opts = MagicMock()
+    apply_proxy(opts, "http://user:secret@host.example:3128")
+    # host:port still passed bare (no creds); auth handled by the extension
+    assert "--proxy-server=http://host.example:3128" in _args(opts)
+    opts.add_encoded_extension.assert_called_once()
+    b64 = opts.add_encoded_extension.call_args.args[0]
+    files = _extension_files(b64)
+    assert "manifest.json" in files and "background.js" in files
+    manifest = json.loads(files["manifest.json"])
+    assert manifest["manifest_version"] == 3
+    assert "webRequestAuthProvider" in manifest["permissions"]
+    assert "user" in files["background.js"] and "secret" in files["background.js"]
+
+
+def test_username_only_no_extension():
+    opts = MagicMock()
+    apply_proxy(opts, "http://user@host.example:3128")
+    assert "--proxy-server=http://host.example:3128" in _args(opts)
+    opts.add_encoded_extension.assert_not_called()
+
+
+def test_no_extension_for_authless_proxy():
+    opts = MagicMock()
+    apply_proxy(opts, "http://10.0.0.5:8080")
+    opts.add_encoded_extension.assert_not_called()
+
+
+def test_sticky_username_with_special_chars_embedded_safely():
+    # DataImpulse sticky username carries ';' and '.' targeting params
+    user = "acct__cr.us;state.florida;city.jacksonville;sessid.lem001"
+    opts = MagicMock()
+    apply_proxy(opts, f"http://{user}:pw123@gw.dataimpulse.com:10000")
+    b64 = opts.add_encoded_extension.call_args.args[0]
+    bg = _extension_files(b64)["background.js"]
+    # embedded via json.dumps → the exact username string round-trips inside a JS literal
+    assert json.dumps(user) in bg


### PR DESCRIPTION
## Why

The per-user residential-proxy strategy (see `docs/EGRESS_AT_SCALE.md`) requires **sticky, geo-targeted** residential IPs to defeat LinkedIn's datacenter-IP 429. Providers like DataImpulse encode the sticky-session + country/city in the proxy **username**, which means `username:password` auth — and Chrome's `--proxy-server` can't carry credentials.

## What

`apply_proxy()` now detects a credentialed proxy URL and loads an in-memory **MV3 Chrome extension** that answers the proxy's `407` via `webRequest.onAuthRequired` (`webRequestAuthProvider` permission). MV2 background pages are disabled in current Chrome (**149**), so this uses an MV3 service worker; the extension is delivered via `add_encoded_extension` (no temp files). Auth-less proxies (IP-allowlist / exit node) are unchanged.

## Verified live

Against the running Chrome 149 + a DataImpulse sticky endpoint:
- Browser authenticated to the credentialed proxy (no `407`, no VPS IP).
- Held **one stable US residential IP (`12.75.74.36`) across back-to-back sessions**.
- Confirmed end-to-end that a residential IP clears the LinkedIn 429.

5 new unit tests (extension built + MV3 manifest + creds embedded; username-only and auth-less paths unchanged). Full proxy suite green (21 tests).

Companion to #222 (redirect-loop recovery) and the egress decision doc.