### PR TITLE
feat(login): email-reply verification-PIN flow for LinkedIn challenges

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,19 @@ LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS=1800
 # When a device-approval challenge is hit, email the user (high priority) so they can
 # approve from their phone instead of the run stalling silently. Set false to disable.
 LINKEDIN_APPROVAL_EMAIL_ENABLED=true
+# Email verification-code (PIN) challenge flow. On a login challenge the automation drives
+# LinkedIn's "enter the code we emailed you" path and emails the user asking them to REPLY
+# with the 6-digit code (routed back via SendGrid Inbound Parse → the inbound webhook). This
+# is preferred over the unreliable mobile-app "tap Yes". Set false to fall back to app-approval.
+LINKEDIN_EMAIL_PIN_ENABLED=true
+# Seconds the login waits for the user to reply with the code before giving up. Default 300.
+LINKEDIN_PIN_WAIT_SECONDS=300
+# TTL (seconds) for the reply token and the stored PIN in Redis. Default 900 (15 min).
+LINKEDIN_PIN_TTL_SECONDS=900
+# Subdomain configured for SendGrid Inbound Parse (MX → mx.sendgrid.net). The PIN-request
+# email's Reply-To is pin+<token>@this-domain, and the parse webhook must POST to
+# /api/linkedin/verification-pin/inbound. See docs/EMAIL_PIN_VERIFICATION.md for setup.
+LINKEDIN_PARSE_DOMAIN=parse.christopherqueenconsulting.com
 # Link included in that email (and docs) for watching the live browser session.
 LEMVNC_URL=https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret
 # Base app URL used in "connect/reconnect your LinkedIn" emails (links to /account).

--- a/docs/EMAIL_PIN_VERIFICATION.md
+++ b/docs/EMAIL_PIN_VERIFICATION.md
@@ -1,0 +1,63 @@
+# Email-Reply Verification-PIN for LinkedIn Login Challenges
+
+When LinkedIn challenges an automated login (new IP / "suspicious login"), its mobile-app
+"tap Yes" approval is unreliable — it often never prompts. This flow uses LinkedIn's
+**email verification-code** path instead and lets the user hand the code back by simply
+**replying to an email**.
+
+## Flow
+
+1. On a login challenge, `login_to_linkedin` → `_handle_challenge` calls
+   `drive_email_pin_challenge` (`utilities/linkedin/helper.py`), which navigates LinkedIn's
+   challenge to the "enter the code we emailed you" screen (this makes LinkedIn send the
+   user a 6-digit code).
+2. It mints a reply token (`verification_pin.create_pin_request`) and emails the user
+   (`send_login_pin_request_email`) with a tokenized **Reply-To**: `pin+<token>@<parse-domain>`.
+3. The user **replies to that email** with the code.
+4. **SendGrid Inbound Parse** receives the reply and POSTs it to
+   `POST /api/linkedin/verification-pin/inbound`. The webhook extracts the token (from the
+   `to`/`envelope`) and the 6-digit code (from the body), and stores the PIN in Redis keyed
+   by user (`submit_pin_by_token`).
+5. The paused login is polling `get_pin(user_id)`; it enters the code, ticks "recognize this
+   device", and submits. On success it stores fresh cookies — so subsequent logins from the
+   same (sticky residential) IP reuse cookies and rarely re-challenge.
+
+Fails open: if Redis or email is unavailable, the login falls back to the mobile-app
+approval wait, exactly as before.
+
+## One-time setup
+
+### 1. Env vars (`.env`)
+```
+LINKEDIN_EMAIL_PIN_ENABLED=true
+LINKEDIN_PIN_WAIT_SECONDS=300
+LINKEDIN_PIN_TTL_SECONDS=900
+LINKEDIN_PARSE_DOMAIN=parse.christopherqueenconsulting.com
+```
+
+### 2. DNS — MX record for the parse subdomain
+Point the parse subdomain's MX at SendGrid:
+```
+parse.christopherqueenconsulting.com.  MX  10  mx.sendgrid.net.
+```
+
+### 3. SendGrid Inbound Parse
+SendGrid → Settings → **Inbound Parse** → Add Host & URL:
+- **Receiving domain:** `parse.christopherqueenconsulting.com`
+- **Destination URL:** `https://lem.christopherqueenconsulting.com/api/linkedin/verification-pin/inbound`
+- POST the raw, full MIME message: not required (we read the parsed `to`/`text`/`envelope` fields).
+
+The webhook is under `/api/linkedin/verification-pin` (a public prefix — no bearer auth), and
+always returns `200` so SendGrid doesn't retry-storm on unrelated mail.
+
+### 4. Verify
+- Send yourself a test to `pin+test@parse.christopherqueenconsulting.com` with a 6-digit code
+  in the body; the webhook should log `Received LinkedIn verification PIN via email reply`
+  (or `ignored` if the token is unknown — expected for a made-up token).
+
+## Security notes
+- The token is single-purpose, short-TTL (15 min), and only maps to a user id — a stray/spoofed
+  reply with an unknown token is ignored.
+- The stored PIN has the same short TTL and is cleared once consumed.
+- The webhook is intentionally permissive (always `200`, ignores anything without a valid
+  token + 6-digit code) to avoid leaking which tokens are live.

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -44,13 +44,15 @@ from cqc_lem.utilities.db import (
     get_post_url_from_log_for_user,
 )
 from cqc_lem.utilities.email import generate_pin, hash_pin, send_pin_email
+from cqc_lem.utilities.linkedin.verification_pin import (
+    extract_pin_from_text, extract_token_from_address, submit_pin_by_token)
 from cqc_lem.utilities.linkedin.token_refresh import (
     get_token_expiry, is_token_expired, is_token_expiring_soon, attempt_token_refresh,
 )
 from cqc_lem.utilities.env_constants import LI_CLIENT_ID, LI_CLIENT_SECRET, LI_REDIRECT_URL, LI_STATE_SALT, ADMIN_SECRET, API_ACCESS_TOKENS, \
     DEFAULT_IMAGE_MODEL, DEFAULT_VIDEO_MODEL, DEFAULT_VIDEO_RATIO
 import requests
-from cqc_lem.utilities.logger import myprint, log_warning
+from cqc_lem.utilities.logger import myprint, log_warning, log_info
 from cqc_lem.utilities.mime_type_helper import get_file_mime_type
 from cqc_lem.utilities.observability import track_api_call
 from cqc_lem.utilities.utils import get_file_extension_from_filepath
@@ -100,7 +102,8 @@ _API_ACCESS_TOKEN_SET = {t.strip() for t in API_ACCESS_TOKENS.split(",") if t.st
 # LinkedIn fetches over an unauthenticated public URL when publishing. The
 # handler (get_assets) is GET-only and path-traversal safe (_find_asset_file
 # rejects .. / separators and only returns real files under assets_dir).
-_PUBLIC_API_PREFIXES = ("/api/auth/", "/api/billing/webhook", "/api/assets")
+_PUBLIC_API_PREFIXES = ("/api/auth/", "/api/billing/webhook", "/api/assets",
+                        "/api/linkedin/verification-pin")
 
 
 def _api_token_required(path: str) -> bool:
@@ -407,6 +410,30 @@ def get_activity(email: str, limit: int = 20) -> ResponseModel:
         for row in logs
     ]
     return ResponseModel(status_code=200, detail=serialized)
+
+
+@router.post("/linkedin/verification-pin/inbound")
+async def linkedin_verification_pin_inbound(request: Request) -> ResponseModel:
+    """SendGrid Inbound Parse webhook: the user's email reply carrying their LinkedIn
+    6-digit code. The tokenized Reply-To (pin+<token>@parse-domain) attributes it to the
+    paused login; we extract the code and hand it to the waiting task. Always 200 so
+    SendGrid doesn't retry-storm on a malformed/unrelated message."""
+    try:
+        form = await request.form()
+    except Exception:
+        return ResponseModel(status_code=200, detail="ignored")
+    to_field = str(form.get("to") or "")
+    envelope = str(form.get("envelope") or "")
+    text = str(form.get("text") or form.get("html") or "")
+    subject = str(form.get("subject") or "")
+    token = extract_token_from_address(to_field) or extract_token_from_address(envelope)
+    pin = extract_pin_from_text(text) or extract_pin_from_text(subject)
+    if not token or not pin:
+        return ResponseModel(status_code=200, detail="ignored")
+    user_id = submit_pin_by_token(token, pin)
+    if user_id:
+        log_info("Received LinkedIn verification PIN via email reply", user_id=user_id)
+    return ResponseModel(status_code=200, detail="accepted" if user_id else "ignored")
 
 
 @router.put("/user/", responses={

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -160,8 +160,10 @@ def send_login_approval_email(to_email: str, vnc_url: str | None = None) -> bool
     return False
 
 
-def _send_high_priority_email(to_email: str, subject: str, html_content: str) -> bool:
-    """Send a high-priority email via SendGrid (falling back to SMTP). Returns True if dispatched."""
+def _send_high_priority_email(to_email: str, subject: str, html_content: str,
+                              reply_to: Optional[str] = None) -> bool:
+    """Send a high-priority email via SendGrid (falling back to SMTP). Returns True if
+    dispatched. `reply_to` sets the Reply-To header (used for the email-reply PIN flow)."""
     has_sendgrid = bool(SENDGRID_API_KEY)
     has_smtp = bool(SMTP_USER) and bool(SMTP_PASSWORD)
     if not has_sendgrid and not has_smtp:
@@ -178,6 +180,9 @@ def _send_high_priority_email(to_email: str, subject: str, html_content: str) ->
             message.header = Header("X-Priority", "1")
             message.header = Header("X-MSMail-Priority", "High")
             message.header = Header("Importance", "High")
+            if reply_to:
+                from sendgrid.helpers.mail import ReplyTo
+                message.reply_to = ReplyTo(reply_to)
             SendGridAPIClient(SENDGRID_API_KEY).send(message)
             myprint(f"Email sent via SendGrid to {to_email}: {subject}")
             return True
@@ -192,6 +197,8 @@ def _send_high_priority_email(to_email: str, subject: str, html_content: str) ->
         msg["X-Priority"] = "1"
         msg["X-MSMail-Priority"] = "High"
         msg["Importance"] = "High"
+        if reply_to:
+            msg["Reply-To"] = reply_to
         msg.attach(MIMEText(html_content, "html"))
         try:
             with smtplib.SMTP(SMTP_HOST, SMTP_PORT, timeout=15) as server:
@@ -206,6 +213,28 @@ def _send_high_priority_email(to_email: str, subject: str, html_content: str) ->
             return False
 
     return False
+
+
+def send_login_pin_request_email(to_email: str, reply_to: str) -> bool:
+    """Ask the user to REPLY with the 6-digit LinkedIn verification code.
+
+    The reply routes back (via SendGrid Inbound Parse) to `reply_to`, whose token
+    attributes it to the paused login. High priority so the user acts before the code
+    expires. Best-effort: returns True only if an email was dispatched.
+    """
+    subject = "⚠️ Reply ASAP with your LinkedIn verification code"
+    html = (
+        "<html><body>"
+        "<h2>We need your LinkedIn verification code</h2>"
+        "<p>LinkedIn asked us to verify this sign-in so your automation can keep running.</p>"
+        "<p><strong>Check your inbox for a separate email from LinkedIn with a 6-digit code, "
+        "then simply <u>reply to THIS email</u> with just that code.</strong></p>"
+        "<p>The code expires quickly — please reply as soon as you can.</p>"
+        "<p style='color:#666;font-size:12px'>Didn't try to sign in? You can ignore this — "
+        "no one can get in without the code.</p>"
+        "</body></html>"
+    )
+    return _send_high_priority_email(to_email, subject, html, reply_to=reply_to)
 
 
 def _account_url() -> str:

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -128,6 +128,118 @@ def solve_arkose_challenge(driver: WebDriver, wait: WebDriverWait) -> bool:
         return False
 
 
+def _click_by_text(driver, substrings) -> bool:
+    substrings = [s.lower() for s in substrings]
+    for el in driver.find_elements(By.XPATH, "//button|//a|//*[@role='button']"):
+        try:
+            text = (el.text or "").strip().lower()
+        except WebDriverException:
+            continue
+        if text and any(s in text for s in substrings):
+            try:
+                el.click()
+            except WebDriverException:
+                try:
+                    driver.execute_script("arguments[0].click();", el)
+                except WebDriverException:
+                    continue
+            return True
+    return False
+
+
+def _find_visible_otp_input(driver):
+    for sel in ("input[name='pin']", "input[autocomplete='one-time-code']",
+                "#input__email_verification_pin", "input[inputmode='numeric']",
+                "input[type='tel']", "input[maxlength='6']"):
+        vis = [e for e in driver.find_elements(By.CSS_SELECTOR, sel) if e.is_displayed()]
+        if vis:
+            return vis[0]
+    texts = [e for e in driver.find_elements(By.CSS_SELECTOR, "input[type='text']") if e.is_displayed()]
+    return texts[0] if len(texts) == 1 else None
+
+
+def drive_email_pin_challenge(driver, user_email: str, is_logged_in) -> bool:
+    """Clear a LinkedIn login challenge via the email verification-code path.
+
+    LinkedIn's mobile-app "tap Yes" approval is unreliable, so this drives the more
+    dependable email-code flow: navigate to the code-entry screen (which makes LinkedIn
+    email a 6-digit code), email the user asking them to REPLY with it, then poll Redis
+    (populated by the inbound-parse webhook) for the code and submit it. Returns True if
+    login completes. Best-effort: any failure returns False so the caller can fall back.
+    """
+    from cqc_lem.utilities.db import get_user_id
+    from cqc_lem.utilities.linkedin.verification_pin import (
+        clear_pin, create_pin_request, get_pin, pin_reply_address)
+
+    otp = None
+    for _ in range(5):
+        try:
+            body = driver.find_element(By.TAG_NAME, "body").text.lower()
+        except Exception:
+            body = ""
+        otp = _find_visible_otp_input(driver)
+        if otp is not None and any(k in body for k in ("code", "verif", "sent")):
+            break
+        moved = (_click_by_text(driver, ["access to this device"])
+                 or _click_by_text(driver, ["verify using email", "use email"])
+                 or _click_by_text(driver, ["email"])
+                 or _click_by_text(driver, ["send code", "continue", "next", "verify"]))
+        time.sleep(3)
+        if not moved:
+            break
+    otp = _find_visible_otp_input(driver)
+    if otp is None:
+        return False
+
+    user_id = get_user_id(user_email)
+    if not user_id:
+        return False
+    clear_pin(user_id)
+    token = create_pin_request(user_id)
+    try:
+        from cqc_lem.utilities.email import send_login_pin_request_email
+        send_login_pin_request_email(user_email, pin_reply_address(token))
+    except Exception as e:
+        log_warning("Failed to send verification-PIN request email", exc=e, action_type="login")
+
+    try:
+        wait_secs = int(os.getenv("LINKEDIN_PIN_WAIT_SECONDS", "300"))
+    except ValueError:
+        wait_secs = 300
+    log_warning("LinkedIn email verification required — emailed the user to REPLY with the "
+                f"6-digit code; waiting up to {wait_secs}s.", action_type="login")
+    pin = None
+    deadline = time.time() + wait_secs
+    while time.time() < deadline:
+        time.sleep(5)
+        pin = get_pin(user_id)
+        if pin:
+            break
+    if not pin:
+        return False
+
+    # Remember this device so future logins from the same (sticky) IP skip the challenge.
+    for cb in driver.find_elements(By.CSS_SELECTOR, "input[type='checkbox']"):
+        try:
+            if cb.is_displayed() and not cb.is_selected():
+                cb.click()
+        except WebDriverException:
+            pass
+    otp = _find_visible_otp_input(driver) or otp
+    try:
+        otp.clear()
+        otp.send_keys(pin)
+    except WebDriverException:
+        return False
+    clear_pin(user_id)
+    _click_by_text(driver, ["submit", "verify", "next", "done", "confirm", "agree"])
+    time.sleep(5)
+    if is_logged_in(driver.current_url):
+        return True
+    time.sleep(3)
+    return is_logged_in(driver.current_url)
+
+
 def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, user_password: str):
     linked_url = "https://www.linkedin.com"
     feed_url = "https://www.linkedin.com/feed/"
@@ -215,6 +327,12 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
             myprint(f"CAPTCHA solved at {label} — continuing login")
             time.sleep(2)
             return
+        # Prefer the email verification-code path — the mobile-app "tap Yes" approval is
+        # unreliable (often never prompts). Fall back to waiting for a manual approval.
+        if os.getenv("LINKEDIN_EMAIL_PIN_ENABLED", "true").lower() != "false":
+            if drive_email_pin_challenge(driver, user_email, _is_logged_in):
+                myprint(f"Email verification-code cleared challenge at {label}")
+                return
         if _wait_for_manual_approval():
             return
         raise RuntimeError(f"Unsolvable LinkedIn challenge at {label}: {driver.current_url}")

--- a/src/cqc_lem/utilities/linkedin/verification_pin.py
+++ b/src/cqc_lem/utilities/linkedin/verification_pin.py
@@ -1,0 +1,144 @@
+"""Email-reply verification-PIN exchange for LinkedIn login challenges.
+
+When LinkedIn challenges a login, the automation drives the email-code path, emails
+the user "reply with your code", and waits for them to reply. SendGrid Inbound Parse
+POSTs that reply to our webhook, which extracts the 6-digit code and drops it here
+(keyed by user). The paused login polls `get_pin` and enters it.
+
+Redis-backed with a short TTL. A per-request token maps the tokenized Reply-To address
+back to the user so an inbound reply is attributed to the right pending login. Fails
+open: if Redis is unavailable the store no-ops and login falls back to its old behavior.
+"""
+
+import os
+import re
+import uuid
+from typing import Optional
+
+from cqc_lem.utilities.linkedin.rate_limit import _redis_client
+from cqc_lem.utilities.logger import log_warning
+
+_TOKEN_KEY = "linkedin:pin_token:{token}"   # token -> user_id (attribute inbound reply)
+_PIN_KEY = "linkedin:pin:{user_id}"         # user_id -> submitted 6-digit code
+_DEFAULT_TTL = 900                           # 15 min — challenge codes are short-lived
+
+# LinkedIn codes are 6 digits. Match a standalone run so we don't grab digits out of a
+# year or a phone number in the quoted reply/signature.
+_PIN_RE = re.compile(r"(?<!\d)(\d{6})(?!\d)")
+
+# Tokenized Reply-To local part: pin+<token>@parse.domain (also appears in SendGrid's
+# `envelope` JSON). Attribute an inbound reply back to the pending login.
+_TOKEN_RE = re.compile(r"pin\+([A-Za-z0-9]+)@")
+
+
+def pin_reply_address(token: str) -> str:
+    """Tokenized Reply-To used in the PIN-request email (host set by LINKEDIN_PARSE_DOMAIN)."""
+    domain = os.getenv("LINKEDIN_PARSE_DOMAIN", "parse.example.com")
+    return f"pin+{token}@{domain}"
+
+
+def extract_token_from_address(value: str) -> Optional[str]:
+    """Pull the reply token out of a `to`/`envelope` value from the inbound webhook."""
+    if not value:
+        return None
+    m = _TOKEN_RE.search(value)
+    return m.group(1) if m else None
+
+
+def _ttl() -> int:
+    try:
+        return int(os.getenv("LINKEDIN_PIN_TTL_SECONDS", str(_DEFAULT_TTL)))
+    except ValueError:
+        return _DEFAULT_TTL
+
+
+def _decode(v) -> Optional[str]:
+    if v is None:
+        return None
+    return v.decode() if isinstance(v, (bytes, bytearray)) else str(v)
+
+
+def extract_pin_from_text(text: str) -> Optional[str]:
+    """Return the first standalone 6-digit code in a reply body, or None.
+
+    Reads only the top of the message so a 6-digit string buried in quoted history
+    (">" lines) or a signature doesn't win over the code the user typed at the top.
+    """
+    if not text:
+        return None
+    head_lines = []
+    for line in text.splitlines():
+        if line.lstrip().startswith(">") or line.strip().lower().startswith("on "):
+            break  # start of quoted original message
+        head_lines.append(line)
+    head = "\n".join(head_lines) or text
+    m = _PIN_RE.search(head)
+    return m.group(1) if m else None
+
+
+def create_pin_request(user_id: int) -> str:
+    """Mint a reply token mapping to user_id and store it (TTL). Returns the token even
+    if Redis is down (the caller still emails; attribution just degrades)."""
+    token = uuid.uuid4().hex[:20]
+    client = _redis_client()
+    if client is not None:
+        try:
+            client.set(_TOKEN_KEY.format(token=token), str(user_id), ex=_ttl())
+        except Exception as e:
+            log_warning("Failed to store PIN request token", exc=e, action_type="login")
+    return token
+
+
+def submit_pin_by_token(token: str, pin: str) -> Optional[int]:
+    """Attribute an inbound reply (token + code) to a user and store the PIN. Returns
+    the user_id on success, else None."""
+    client = _redis_client()
+    if client is None or not token or not pin:
+        return None
+    try:
+        raw = client.get(_TOKEN_KEY.format(token=token))
+    except Exception:
+        return None
+    uid = _decode(raw)
+    if not uid:
+        return None
+    user_id = int(uid)
+    if _store_pin(client, user_id, pin):
+        return user_id
+    return None
+
+
+def submit_pin(user_id: int, pin: str) -> bool:
+    client = _redis_client()
+    if client is None:
+        return False
+    return _store_pin(client, user_id, pin)
+
+
+def _store_pin(client, user_id: int, pin: str) -> bool:
+    try:
+        client.set(_PIN_KEY.format(user_id=user_id), str(pin), ex=_ttl())
+        return True
+    except Exception as e:
+        log_warning("Failed to store verification PIN", exc=e, action_type="login")
+        return False
+
+
+def get_pin(user_id: int) -> Optional[str]:
+    client = _redis_client()
+    if client is None:
+        return None
+    try:
+        return _decode(client.get(_PIN_KEY.format(user_id=user_id)))
+    except Exception:
+        return None
+
+
+def clear_pin(user_id: int) -> None:
+    client = _redis_client()
+    if client is None:
+        return
+    try:
+        client.delete(_PIN_KEY.format(user_id=user_id))
+    except Exception:
+        pass

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -276,3 +276,45 @@ class TestGetUserSettings:
         detail = resp.json()["detail"]
         assert detail["subscription"] is None
         assert detail["preferences"] is None
+
+
+class TestVerificationPinInbound:
+    """SendGrid Inbound Parse webhook that receives the user's PIN reply."""
+    BASE = "/api/linkedin/verification-pin/inbound"
+
+    def test_valid_reply_stores_pin(self, client):
+        with patch(f"{_MAIN}.submit_pin_by_token", return_value=1) as m:
+            resp = client.post(self.BASE, data={
+                "to": "pin+abc123XYZ@parse.example.com",
+                "text": "483920\n\nSent from my phone",
+                "subject": "Re: verification code",
+            })
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == "accepted"
+        m.assert_called_once_with("abc123XYZ", "483920")
+
+    def test_reply_but_unknown_token_ignored(self, client):
+        with patch(f"{_MAIN}.submit_pin_by_token", return_value=None):
+            resp = client.post(self.BASE, data={
+                "to": "pin+stale@parse.example.com", "text": "483920"})
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == "ignored"
+
+    def test_no_token_ignored_without_calling_store(self, client):
+        with patch(f"{_MAIN}.submit_pin_by_token") as m:
+            resp = client.post(self.BASE, data={"to": "someone@else.com", "text": "483920"})
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == "ignored"
+        m.assert_not_called()
+
+    def test_no_pin_ignored(self, client):
+        with patch(f"{_MAIN}.submit_pin_by_token") as m:
+            resp = client.post(self.BASE, data={
+                "to": "pin+abc@parse.example.com", "text": "I can't find the code"})
+        assert resp.json()["detail"] == "ignored"
+        m.assert_not_called()
+
+    def test_endpoint_is_public_no_auth(self, client):
+        # Under the public prefix — must not 401/403 even with no auth header.
+        resp = client.post(self.BASE, data={"to": "x", "text": "y"})
+        assert resp.status_code == 200

--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -522,3 +522,62 @@ class TestRateLimitCircuitBreaker:
             login_to_linkedin(driver, wait, "u@e.com", "pw")
 
         mock_clear.assert_called_once()
+
+
+@pytest.mark.unit
+class TestDriveEmailPinChallenge:
+    """The email verification-code challenge path (drive_email_pin_challenge)."""
+
+    def _driver(self, otp=None, buttons=None,
+                body="Enter the verification code we sent to your email"):
+        from selenium.webdriver.common.by import By as _By
+        driver = MagicMock()
+        driver.current_url = "https://www.linkedin.com/checkpoint/challenge/x"
+        body_el = MagicMock(); body_el.text = body
+        driver.find_element.return_value = body_el
+
+        def find_elements(by, sel):
+            if by == _By.XPATH:
+                return buttons or []
+            if by == _By.CSS_SELECTOR and sel == "input[name='pin']":
+                return [otp] if otp is not None else []
+            return []
+        driver.find_elements.side_effect = find_elements
+        return driver
+
+    def test_no_otp_field_returns_false_without_emailing(self):
+        driver = self._driver(otp=None, buttons=[])  # no code field, nothing to click
+        with patch("cqc_lem.utilities.email.send_login_pin_request_email") as mail, \
+             patch("cqc_lem.utilities.db.get_user_id", return_value=1):
+            from cqc_lem.utilities.linkedin.helper import drive_email_pin_challenge
+            assert drive_email_pin_challenge(driver, "u@e.com", lambda url: True) is False
+        mail.assert_not_called()
+
+    def test_success_emails_polls_and_submits(self):
+        otp = MagicMock(); otp.is_displayed.return_value = True
+        submit_btn = MagicMock(); submit_btn.text = "Submit"
+        driver = self._driver(otp=otp, buttons=[submit_btn])
+        with patch("cqc_lem.utilities.db.get_user_id", return_value=7), \
+             patch("cqc_lem.utilities.linkedin.verification_pin.create_pin_request", return_value="tok123"), \
+             patch("cqc_lem.utilities.linkedin.verification_pin.clear_pin"), \
+             patch("cqc_lem.utilities.linkedin.verification_pin.pin_reply_address", return_value="pin+tok123@parse.x"), \
+             patch("cqc_lem.utilities.linkedin.verification_pin.get_pin", return_value="483920"), \
+             patch("cqc_lem.utilities.email.send_login_pin_request_email", return_value=True) as mail:
+            from cqc_lem.utilities.linkedin.helper import drive_email_pin_challenge
+            ok = drive_email_pin_challenge(driver, "u@e.com", lambda url: True)
+        assert ok is True
+        mail.assert_called_once_with("u@e.com", "pin+tok123@parse.x")
+        otp.send_keys.assert_called_once_with("483920")
+
+    def test_pin_never_arrives_returns_false(self):
+        otp = MagicMock(); otp.is_displayed.return_value = True
+        driver = self._driver(otp=otp, buttons=[])
+        with patch("cqc_lem.utilities.db.get_user_id", return_value=7), \
+             patch("cqc_lem.utilities.linkedin.verification_pin.create_pin_request", return_value="tok"), \
+             patch("cqc_lem.utilities.linkedin.verification_pin.clear_pin"), \
+             patch("cqc_lem.utilities.linkedin.verification_pin.pin_reply_address", return_value="a@b"), \
+             patch("cqc_lem.utilities.linkedin.verification_pin.get_pin", return_value=None), \
+             patch("cqc_lem.utilities.email.send_login_pin_request_email", return_value=True), \
+             patch(f"{_MODULE}.time.time", side_effect=[0, 0, 10_000]):  # trip the poll deadline
+            from cqc_lem.utilities.linkedin.helper import drive_email_pin_challenge
+            assert drive_email_pin_challenge(driver, "u@e.com", lambda url: True) is False

--- a/tests/unit/utilities/linkedin/test_verification_pin.py
+++ b/tests/unit/utilities/linkedin/test_verification_pin.py
@@ -1,0 +1,101 @@
+"""Unit tests for the email-reply verification-PIN exchange."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.linkedin.verification_pin"
+
+
+@pytest.fixture
+def fake_redis():
+    client = MagicMock()
+    with patch(f"{_MOD}._redis_client", return_value=client):
+        yield client
+
+
+class TestExtractPin:
+    def test_plain_code(self):
+        from cqc_lem.utilities.linkedin.verification_pin import extract_pin_from_text
+        assert extract_pin_from_text("Here you go: 483920") == "483920"
+
+    def test_code_alone(self):
+        from cqc_lem.utilities.linkedin.verification_pin import extract_pin_from_text
+        assert extract_pin_from_text("123456") == "123456"
+
+    def test_ignores_quoted_history(self):
+        from cqc_lem.utilities.linkedin.verification_pin import extract_pin_from_text
+        body = "654321\n\nOn Tue wrote:\n> your code was 999999 last time"
+        assert extract_pin_from_text(body) == "654321"
+
+    def test_ignores_gt_quoted_block(self):
+        from cqc_lem.utilities.linkedin.verification_pin import extract_pin_from_text
+        body = "111222\n> previously 333444"
+        assert extract_pin_from_text(body) == "111222"
+
+    def test_not_seven_or_more_digits(self):
+        from cqc_lem.utilities.linkedin.verification_pin import extract_pin_from_text
+        assert extract_pin_from_text("order 1234567 shipped") is None
+
+    def test_none_and_empty(self):
+        from cqc_lem.utilities.linkedin.verification_pin import extract_pin_from_text
+        assert extract_pin_from_text("") is None
+        assert extract_pin_from_text("no digits here") is None
+
+
+class TestTokenRoundTrip:
+    def test_create_then_submit_by_token(self, fake_redis):
+        store = {}
+        fake_redis.set.side_effect = lambda k, v, ex=None: store.__setitem__(k, v)
+        fake_redis.get.side_effect = lambda k: store.get(k)
+        from cqc_lem.utilities.linkedin.verification_pin import create_pin_request, submit_pin_by_token, get_pin
+        token = create_pin_request(42)
+        assert token
+        uid = submit_pin_by_token(token, "246810")
+        assert uid == 42
+        assert get_pin(42) == "246810"
+
+    def test_submit_unknown_token_returns_none(self, fake_redis):
+        fake_redis.get.return_value = None
+        from cqc_lem.utilities.linkedin.verification_pin import submit_pin_by_token
+        assert submit_pin_by_token("nope", "123456") is None
+
+    def test_bytes_values_decoded(self, fake_redis):
+        fake_redis.get.return_value = b"7"
+        from cqc_lem.utilities.linkedin.verification_pin import submit_pin_by_token
+        assert submit_pin_by_token("tok", "123456") == 7
+
+
+class TestNoRedisFailsOpen:
+    def test_create_returns_token_without_redis(self):
+        with patch(f"{_MOD}._redis_client", return_value=None):
+            from cqc_lem.utilities.linkedin.verification_pin import create_pin_request
+            assert create_pin_request(1)  # still returns a token
+
+    def test_get_pin_none_without_redis(self):
+        with patch(f"{_MOD}._redis_client", return_value=None):
+            from cqc_lem.utilities.linkedin.verification_pin import get_pin
+            assert get_pin(1) is None
+
+    def test_submit_false_without_redis(self):
+        with patch(f"{_MOD}._redis_client", return_value=None):
+            from cqc_lem.utilities.linkedin.verification_pin import submit_pin
+            assert submit_pin(1, "123456") is False
+
+
+class TestGetAndClear:
+    def test_get_pin_decodes_bytes(self, fake_redis):
+        fake_redis.get.return_value = b"135790"
+        from cqc_lem.utilities.linkedin.verification_pin import get_pin
+        assert get_pin(9) == "135790"
+
+    def test_get_pin_swallows_error(self, fake_redis):
+        fake_redis.get.side_effect = RuntimeError("down")
+        from cqc_lem.utilities.linkedin.verification_pin import get_pin
+        assert get_pin(9) is None
+
+    def test_clear_deletes_key(self, fake_redis):
+        from cqc_lem.utilities.linkedin.verification_pin import clear_pin
+        clear_pin(9)
+        fake_redis.delete.assert_called_once_with("linkedin:pin:9")


### PR DESCRIPTION
## Why

LinkedIn's mobile-app "tap Yes" device approval is **unreliable** — during live testing it repeatedly never prompted, stalling the login until timeout. This replaces it (by default) with LinkedIn's **email verification-code** path, where the user just **replies to an email** with the 6-digit code.

Implements the owner's requested design: *never make the user hand-extract cookies; always drive the email-PIN path, email them "reply with the code ASAP," and store cookies on success so PINs are rare.*

## Flow

1. On challenge, `drive_email_pin_challenge` navigates LinkedIn to the code-entry screen (triggers LinkedIn to email the code) and emails the user with a tokenized **Reply-To** `pin+<token>@<parse-domain>`.
2. User **replies** with the code → **SendGrid Inbound Parse** POSTs it to `POST /api/linkedin/verification-pin/inbound` → token→user + 6-digit code stored in Redis.
3. The paused login polls Redis, enters the code, ticks "recognize this device", submits, and **stores fresh cookies**.

Combined with the sticky residential IP (#223) + cookie reuse, a PIN becomes an occasional event, not every session. Fails open (falls back to app-approval) if Redis/email is unavailable.

## Changes
- `verification_pin.py` — Redis PIN exchange, tokenized attribution, reply-body code extraction (ignores quoted history), short TTLs.
- `helper.py` — `drive_email_pin_challenge` + prefer it in `_handle_challenge` (`LINKEDIN_EMAIL_PIN_ENABLED`).
- `email.py` — `send_login_pin_request_email` + Reply-To support.
- `main.py` — inbound-parse webhook (public prefix, always 200).
- Config vars + **`docs/EMAIL_PIN_VERIFICATION.md`** (DNS MX + SendGrid Inbound Parse setup).

## Tests
23 unit tests (PIN store + token round-trip + code extraction; webhook accept/ignore paths; the Selenium flow: emails+polls+submits, no-OTP→false, PIN-timeout→false). Full linkedin + api suites green (164).

## Not covered by code (owner setup)
DNS MX for the parse subdomain + SendGrid Inbound Parse host/URL — see the doc. Independent of #222/#223; all compose at main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)