### PR TITLE
fix(login): derive PIN Reply-To domain from configured env, not example.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -196,6 +196,8 @@ LINKEDIN_PIN_TTL_SECONDS=900
 # Subdomain configured for SendGrid Inbound Parse (MX → mx.sendgrid.net). The PIN-request
 # email's Reply-To is pin+<token>@this-domain, and the parse webhook must POST to
 # /api/linkedin/verification-pin/inbound. See docs/EMAIL_PIN_VERIFICATION.md for setup.
+# OPTIONAL: if unset, it's derived as parse.<base-domain> from SENDGRID_FROM_EMAIL (or
+# PUBLIC_BASE_URL). Set explicitly only to override that derived value.
 LINKEDIN_PARSE_DOMAIN=parse.christopherqueenconsulting.com
 # Link included in that email (and docs) for watching the live browser session.
 LEMVNC_URL=https://lemvnc.christopherqueenconsulting.com/?autoconnect=1&password=secret

--- a/src/cqc_lem/utilities/linkedin/verification_pin.py
+++ b/src/cqc_lem/utilities/linkedin/verification_pin.py
@@ -31,9 +31,28 @@ _PIN_RE = re.compile(r"(?<!\d)(\d{6})(?!\d)")
 _TOKEN_RE = re.compile(r"pin\+([A-Za-z0-9]+)@")
 
 
+def _default_parse_domain() -> str:
+    """Derive `parse.<base-domain>` from existing domain config so the Reply-To uses the
+    real domain, not a placeholder, when LINKEDIN_PARSE_DOMAIN isn't set explicitly.
+
+    Prefers the SENDGRID_FROM_EMAIL domain (e.g. no-reply@christopherqueenconsulting.com
+    → parse.christopherqueenconsulting.com), falling back to the registrable domain of
+    PUBLIC_BASE_URL's host.
+    """
+    from_email = os.getenv("SENDGRID_FROM_EMAIL", "")
+    base = from_email.rsplit("@", 1)[-1].strip().lower() if "@" in from_email else ""
+    if not base:
+        from urllib.parse import urlparse
+        host = (urlparse(os.getenv("PUBLIC_BASE_URL", "")).hostname or "").lower()
+        labels = [p for p in host.split(".") if p]
+        base = ".".join(labels[-2:]) if len(labels) >= 2 else ""
+    return f"parse.{base}" if base else "parse.example.com"
+
+
 def pin_reply_address(token: str) -> str:
-    """Tokenized Reply-To used in the PIN-request email (host set by LINKEDIN_PARSE_DOMAIN)."""
-    domain = os.getenv("LINKEDIN_PARSE_DOMAIN", "parse.example.com")
+    """Tokenized Reply-To used in the PIN-request email. Host is LINKEDIN_PARSE_DOMAIN if
+    set, else derived from the configured domain (see _default_parse_domain)."""
+    domain = os.getenv("LINKEDIN_PARSE_DOMAIN") or _default_parse_domain()
     return f"pin+{token}@{domain}"
 
 

--- a/tests/unit/utilities/linkedin/test_verification_pin.py
+++ b/tests/unit/utilities/linkedin/test_verification_pin.py
@@ -44,6 +44,33 @@ class TestExtractPin:
         assert extract_pin_from_text("no digits here") is None
 
 
+class TestPinReplyAddress:
+    def test_explicit_env_wins(self, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_PARSE_DOMAIN", "parse.custom.io")
+        from cqc_lem.utilities.linkedin.verification_pin import pin_reply_address
+        assert pin_reply_address("tok9") == "pin+tok9@parse.custom.io"
+
+    def test_derives_from_sendgrid_from_email(self, monkeypatch):
+        monkeypatch.delenv("LINKEDIN_PARSE_DOMAIN", raising=False)
+        monkeypatch.setenv("SENDGRID_FROM_EMAIL", "no-reply@christopherqueenconsulting.com")
+        from cqc_lem.utilities.linkedin.verification_pin import pin_reply_address
+        assert pin_reply_address("t") == "pin+t@parse.christopherqueenconsulting.com"
+
+    def test_derives_from_public_base_url_when_no_from_email(self, monkeypatch):
+        monkeypatch.delenv("LINKEDIN_PARSE_DOMAIN", raising=False)
+        monkeypatch.setenv("SENDGRID_FROM_EMAIL", "")
+        monkeypatch.setenv("PUBLIC_BASE_URL", "https://lem.christopherqueenconsulting.com")
+        from cqc_lem.utilities.linkedin.verification_pin import _default_parse_domain
+        assert _default_parse_domain() == "parse.christopherqueenconsulting.com"
+
+    def test_falls_back_to_example_when_nothing_configured(self, monkeypatch):
+        monkeypatch.delenv("LINKEDIN_PARSE_DOMAIN", raising=False)
+        monkeypatch.setenv("SENDGRID_FROM_EMAIL", "")
+        monkeypatch.setenv("PUBLIC_BASE_URL", "")
+        from cqc_lem.utilities.linkedin.verification_pin import _default_parse_domain
+        assert _default_parse_domain() == "parse.example.com"
+
+
 class TestTokenRoundTrip:
     def test_create_then_submit_by_token(self, fake_redis):
         store = {}


### PR DESCRIPTION
## Problem

The verification-PIN request email's **Reply-To** showed `pin+<token>@parse.example.com` — because `pin_reply_address()` fell back to a literal `parse.example.com` when `LINKEDIN_PARSE_DOMAIN` wasn't set in the deployment.

## Fix

Derive `parse.<base-domain>` from the domain vars already configured:
- Prefer `SENDGRID_FROM_EMAIL`'s domain (`no-reply@christopherqueenconsulting.com` → `parse.christopherqueenconsulting.com`).
- Fall back to `PUBLIC_BASE_URL`'s registrable host.
- `LINKEDIN_PARSE_DOMAIN` still works as an explicit override; the `example.com` literal only appears when nothing is configured.

4 new unit tests (explicit override, derive-from-from-email, derive-from-base-url, fallback). Also set the value in prod `.env` as an immediate stopgap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)