### PR TITLE
fix(scraper): rebuild feed commenting for LinkedIn's SDUI redesign

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1,3 +1,4 @@
+import hashlib
 import inspect
 import json
 import random
@@ -25,7 +26,7 @@ from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.logger import myprint, log_error, log_info, log_warning
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
     get_element_wait_retry, get_elements_as_list_wait_stale, getText, close_tab, get_driver_wait_pair, quit_gracefully, \
-    wait_for_ajax
+    wait_for_ajax, find_first, click_first
 from dotenv import load_dotenv
 from selenium.common import NoSuchElementException, JavascriptException
 from selenium.webdriver import ActionChains, Keys
@@ -396,6 +397,125 @@ def check_commented(driver, wait, user_id: int = None, post_url: str = None):
     return already_commented
 
 
+# --- SDUI feed engine (LinkedIn's 2026 redesign) -----------------------------------------
+# LinkedIn moved the feed to a server-driven-UI framework: the old urn:li:activity data-ids,
+# feed-shared-* / comments-comment-* classes and permalink navigation are gone. Posts are now
+# anchored by stable data-testid / aria-label attributes and commenting happens INLINE on the
+# feed card (no per-post permalink). Verified live 2026-07-03.
+_FEED_POST_TEXT_SEL = "[data-testid='expandable-text-box']"
+
+
+def _card_for_textbox(driver, box):
+    """Nearest ancestor of a post's text box that contains its Comment button — i.e. the post card."""
+    return driver.execute_script(
+        "let el=arguments[0],d=0;while(el&&d<15){"
+        "if(el.querySelector&&el.querySelector(\"button[aria-label='Comment']\"))return el;"
+        "el=el.parentElement;d++;}return null;", box)
+
+
+def _post_author_from_card(card) -> str:
+    """Author name is embedded in the card's 'Hide post by <Name>' control's aria-label."""
+    try:
+        label = card.find_element(By.CSS_SELECTOR, "button[aria-label^='Hide post by']").get_attribute("aria-label") or ""
+        return label.replace("Hide post by ", "").strip()
+    except Exception:
+        return ""
+
+
+def _feed_post_key(author: str, content: str) -> str:
+    """Stable-ish dedup key for a feed post (no permalink/urn exists in the SDUI DOM anymore)."""
+    digest = hashlib.sha1(f"{author}|{content[:200]}".encode("utf-8", "ignore")).hexdigest()[:20]
+    return f"feedpost://{digest}"
+
+
+def post_comment_inline(driver, wait, card, comment_text: str, user_id: int = None) -> bool:
+    """Open the card's inline comment composer, type the comment, and submit. Returns True if it
+    appears posted. Ctrl+Enter is the reliable submit in the new composer (verified live), with the
+    'Comment'/'Post' button as the primary path."""
+    try:
+        if click_first(driver, wait, [(By.CSS_SELECTOR, "button[aria-label='Comment']")],
+                       "Open comment composer", parent_element=card, required=False, user_id=user_id) is None:
+            return False
+        time.sleep(random.uniform(1.5, 3))
+        composer = find_first(driver, wait,
+                              [(By.CSS_SELECTOR, "div[role='textbox'][aria-label*='creating comment']"),
+                               (By.CSS_SELECTOR, "div[role='textbox']")],
+                              "Comment composer", visible_only=True, required=False, user_id=user_id)
+        if composer is None:
+            return False
+        composer.click()
+        composer.send_keys(comment_text)
+        time.sleep(random.uniform(1, 2))
+        submitted = False
+        form = driver.execute_script(
+            "let e=arguments[0];while(e){if(e.tagName==='FORM')return e;e=e.parentElement;}return null;", composer)
+        if form is not None:
+            for b in form.find_elements(By.XPATH, ".//button[normalize-space()='Comment' or normalize-space()='Post']"):
+                try:
+                    if b.is_displayed() and not b.get_attribute("disabled"):
+                        driver.execute_script("arguments[0].click();", b)
+                        submitted = True
+                        break
+                except Exception:
+                    continue
+        if not submitted:
+            composer.send_keys(Keys.CONTROL, Keys.RETURN)
+        time.sleep(random.uniform(3, 5))
+        return comment_text[:22] in driver.find_element(By.TAG_NAME, "body").text
+    except Exception as e:
+        log_warning("Inline comment post failed", exc=e, action_type="comment", user_id=user_id)
+        return False
+
+
+def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: int,
+                           max_posts: int = 10, deadline_ts: float = None) -> int:
+    """Walk the SDUI feed, generate an AI comment per fresh/relevant post, and comment inline.
+    Returns the number of comments posted. Re-queries the feed after each action (the DOM
+    re-renders) and scrolls to load more when the current batch is exhausted."""
+    from selenium.common.exceptions import StaleElementReferenceException
+    posted, seen, scrolls = 0, set(), 0
+    while posted < max_posts and scrolls < 15:
+        if deadline_ts and time.time() >= deadline_ts:
+            break
+        boxes = driver.find_elements(By.CSS_SELECTOR, _FEED_POST_TEXT_SEL)
+        acted = False
+        for box in boxes:
+            try:
+                content = (box.text or "").strip()
+            except StaleElementReferenceException:
+                continue
+            if len(content) < 20:
+                continue
+            card = _card_for_textbox(driver, box)
+            if card is None:
+                continue
+            author = _post_author_from_card(card)
+            key = _feed_post_key(author, content)
+            if key in seen:
+                continue
+            seen.add(key)
+            if has_user_commented_on_post_url(user_id, key):
+                continue
+            comment_text = generate_ai_response(content, my_profile, None)
+            if not comment_text:
+                continue
+            driver.execute_script("arguments[0].scrollIntoView({block:'center'});", card)
+            time.sleep(simulate_reading_time(content) / 2 + simulate_thinking_time())
+            if post_comment_inline(driver, wait, card, comment_text, user_id=user_id):
+                insert_new_log(user_id=user_id, action_type=LogActionType.COMMENT,
+                               result=LogResultType.SUCCESS, post_url=key, message=comment_text)
+                posted += 1
+                myprint(f"Commented on {author or 'a'}'s post ({posted}/{max_posts})")
+                time.sleep(random.uniform(6, 14))  # human pacing between comments
+            acted = True
+            break  # DOM re-rendered after commenting — re-query from the top
+        if not acted:
+            driver.execute_script("window.scrollBy(0, 1200);")
+            scrolls += 1
+            time.sleep(random.uniform(2.5, 4))
+    return posted
+
+
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
                   queue='selenium')
 def automate_commenting(self, user_id: int, loop_for_duration: int = None, future_forward: int = 60):
@@ -416,44 +536,11 @@ def automate_commenting(self, user_id: int, loop_for_duration: int = None, futur
         navigate_to_feed(driver, wait)
 
         start_time = datetime.now()
+        deadline_ts = (start_time.timestamp() + loop_for_duration) if loop_for_duration else None
 
-        # Get 10 posts from the feed
-        posts = get_feed_posts(driver, wait, num_posts=10)
-
-        current_tab = driver.current_window_handle
-        handles = driver.window_handles
-
-        post_commented_count = 0
-
-        for post in posts:
-            # break if it has been loop_for_duration seconds since the start time
-            if loop_for_duration:
-                elapsed_time = datetime.now() - start_time
-                if elapsed_time.total_seconds() >= loop_for_duration:
-                    myprint("Loop duration reached. Stopping Automate Commenting thread...")
-                    break
-
-            # Switch back to tab
-            driver.switch_to.window(current_tab)
-
-            post_link = post['link']
-            myprint(f"Post Link: {post_link}")
-
-            # Wait for the new window or tab
-            driver.switch_to.new_window('tab')
-            wait.until(EC.new_window_is_opened(handles))
-
-            # Generate and post comment
-            successful = generate_and_post_comment(driver, wait, post_link, my_profile)
-
-            if successful:
-                post_commented_count += 1
-
-            # Close tab when done
-            close_tab(driver)
-
-        # Switch back to tab
-        driver.switch_to.window(current_tab)
+        # Comment inline on the SDUI feed (no per-post permalink navigation anymore).
+        post_commented_count = comment_on_feed_inline(driver, wait, my_profile, user_id,
+                                                      max_posts=10, deadline_ts=deadline_ts)
 
         result = f"Automate Commenting Task Completed. Commented on {post_commented_count} posts."
 

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -21,7 +21,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 from cqc_lem.utilities.env_constants import *
-from cqc_lem.utilities.logger import myprint
+from cqc_lem.utilities.logger import myprint, log_warning
 from cqc_lem.utilities.utils import get_aws_device_farm_url
 
 
@@ -428,6 +428,97 @@ def get_visible_element_wait_retry(driver: WebDriver, wait: WebDriverWait,
             raise se
         myprint(f"Failed to find visible element: {wait_text}")
         return None
+
+
+def find_first(driver: WebDriver, wait: WebDriverWait, locators: list[tuple[str, str]], label: str,
+               *, required: bool = True, parent_element: WebElement = None,
+               max_try: int = MAX_WAIT_RETRY, visible_only: bool = False,
+               user_id: int = None, post_id: int = None) -> WebElement | None:
+    """Return the first element matching any locator in `locators` (ordered, most-stable first).
+
+    LinkedIn ships hashed CSS classes that churn, so callers pass an ordered fallback chain
+    (aria-label/role → data-* → visible text → semantic → legacy class). On a total miss:
+    if `required`, raise (like the other helpers); else emit a STRUCTURED warning naming the
+    tried selectors + current URL and return None — turning today's silent skips into greppable
+    signal. `visible_only` restricts to displayed elements (duplicate hidden+visible copies).
+    """
+    root = parent_element if parent_element is not None else driver
+
+    def _find(_d):
+        for find_by, value in locators:
+            try:
+                if visible_only:
+                    for el in root.find_elements(find_by, value):
+                        try:
+                            if el.is_displayed():
+                                return el
+                        except StaleElementReferenceException:
+                            continue
+                else:
+                    els = root.find_elements(find_by, value)
+                    if els:
+                        return els[0]
+            except (StaleElementReferenceException, NoSuchElementException):
+                continue
+        return False
+
+    try:
+        return wait.until(_find, label)
+    except (StaleElementReferenceException, TimeoutException) as se:
+        if max_try > 1:
+            myprint(label + " | not found | .....retrying")
+            time.sleep(5)
+            return find_first(driver, wait, locators, label, required=required,
+                              parent_element=parent_element, max_try=max_try - 1,
+                              visible_only=visible_only, user_id=user_id, post_id=post_id)
+        if required:
+            raise se
+        try:
+            current_url = driver.current_url
+        except Exception:
+            current_url = "?"
+        log_warning(f"Selector miss: {label}", action_type="scrape", user_id=user_id, post_id=post_id,
+                    selectors=[f"{by}={val}" for by, val in locators], url=current_url)
+        return None
+
+
+def click_first(driver: WebDriver, wait: WebDriverWait, locators: list[tuple[str, str]], label: str,
+                *, required: bool = True, parent_element: WebElement = None,
+                use_action_chain: bool = False, max_try: int = MAX_WAIT_RETRY,
+                user_id: int = None, post_id: int = None) -> WebElement | None:
+    """Find (via `find_first`) then click the first matching element, with the same resilient
+    fallback + structured-miss-logging behavior. Returns the clicked element or None."""
+    element = find_first(driver, wait, locators, label, required=required,
+                         parent_element=parent_element, max_try=max_try, visible_only=True,
+                         user_id=user_id, post_id=post_id)
+    if element is None:
+        return None
+    try:
+        element = wait.until(EC.element_to_be_clickable(element))
+        if use_action_chain:
+            ActionChains(driver).move_to_element(element).click().perform()
+            wait_for_ajax(driver)
+        else:
+            element.click()
+    except (ElementNotInteractableException, StaleElementReferenceException, TimeoutException) as se:
+        if required:
+            raise se
+        log_warning(f"Click miss: {label}", action_type="scrape", user_id=user_id, post_id=post_id)
+        return None
+    return element
+
+
+def find_all_first(driver: WebDriver, locators: list[tuple[str, str]]) -> list[WebElement]:
+    """Return the element list from the FIRST locator that yields any matches (ordered fallback
+    for collections, e.g. a comment list). Empty list if none match — caller logs if needed."""
+    for find_by, value in locators:
+        try:
+            els = driver.find_elements(find_by, value)
+            if els:
+                return els
+        except (StaleElementReferenceException, NoSuchElementException):
+            continue
+    return []
 
 
 def get_elements_as_list_wait_stale(wait: WebDriverWait, find_by_value: str, wait_text: str,

--- a/tests/unit/utilities/test_selenium_find_first.py
+++ b/tests/unit/utilities/test_selenium_find_first.py
@@ -1,0 +1,102 @@
+"""Unit tests for the resilient find_first / click_first / find_all_first helpers."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from selenium.common.exceptions import TimeoutException
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.selenium_util"
+
+
+class _FakeWait:
+    """Minimal WebDriverWait stand-in: evaluate the predicate once; truthy → return, else Timeout."""
+    def __init__(self, driver):
+        self.driver = driver
+
+    def until(self, fn, msg=None):
+        result = fn(self.driver)
+        if result:
+            return result
+        raise TimeoutException(msg)
+
+
+def _driver_with(find_elements_map):
+    """driver.find_elements(by, value) returns find_elements_map.get(value, [])."""
+    driver = MagicMock()
+    driver.current_url = "https://www.linkedin.com/feed/"
+    driver.find_elements.side_effect = lambda by, value: find_elements_map.get(value, [])
+    return driver
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with patch(f"{_MOD}.time.sleep"):
+        yield
+
+
+class TestFindFirst:
+    def test_returns_first_matching_in_order(self):
+        from cqc_lem.utilities.selenium_util import find_first
+        el = MagicMock()
+        driver = _driver_with({"miss": [], "hit": [el]})
+        wait = _FakeWait(driver)
+        got = find_first(driver, wait, [("css", "miss"), ("css", "hit")], "thing")
+        assert got is el
+
+    def test_miss_required_raises(self):
+        from cqc_lem.utilities.selenium_util import find_first
+        driver = _driver_with({})
+        wait = _FakeWait(driver)
+        with pytest.raises(TimeoutException):
+            find_first(driver, wait, [("css", "a"), ("css", "b")], "thing", max_try=1)
+
+    def test_miss_not_required_logs_and_returns_none(self):
+        from cqc_lem.utilities.selenium_util import find_first
+        driver = _driver_with({})
+        wait = _FakeWait(driver)
+        with patch(f"{_MOD}.log_warning") as warn:
+            got = find_first(driver, wait, [("css", "a"), ("css", "b")], "postbox",
+                             required=False, max_try=1, user_id=7, post_id=3)
+        assert got is None
+        warn.assert_called_once()
+        # structured context includes the tried selectors + url
+        kwargs = warn.call_args.kwargs
+        assert kwargs["user_id"] == 7 and kwargs["post_id"] == 3
+        assert any("a" in s for s in kwargs["selectors"])
+
+    def test_visible_only_skips_hidden(self):
+        from cqc_lem.utilities.selenium_util import find_first
+        hidden = MagicMock(); hidden.is_displayed.return_value = False
+        shown = MagicMock(); shown.is_displayed.return_value = True
+        driver = _driver_with({"box": [hidden, shown]})
+        wait = _FakeWait(driver)
+        got = find_first(driver, wait, [("css", "box")], "composer", visible_only=True)
+        assert got is shown
+
+
+class TestFindAllFirst:
+    def test_returns_first_nonempty_list(self):
+        from cqc_lem.utilities.selenium_util import find_all_first
+        a, b = MagicMock(), MagicMock()
+        driver = _driver_with({"empty": [], "full": [a, b]})
+        got = find_all_first(driver, [("css", "empty"), ("css", "full")])
+        assert got == [a, b]
+
+    def test_returns_empty_when_none_match(self):
+        from cqc_lem.utilities.selenium_util import find_all_first
+        driver = _driver_with({})
+        assert find_all_first(driver, [("css", "x")]) == []
+
+
+class TestClickFirst:
+    def test_clicks_the_found_element(self):
+        from cqc_lem.utilities import selenium_util as su
+        el = MagicMock(); el.is_displayed.return_value = True
+        driver = _driver_with({"btn": [el]})
+        wait = _FakeWait(driver)
+        with patch.object(su.EC, "element_to_be_clickable", return_value=lambda d: el):
+            # _FakeWait.until will call the clickable predicate and return el
+            out = su.click_first(driver, wait, [("css", "btn")], "button")
+        el.click.assert_called_once()
+        assert out is el


### PR DESCRIPTION
## Why

Re-firing engagement surfaced that LinkedIn **migrated the feed to a server-driven-UI framework**. Every old scraper anchor is gone: `urn:li:activity` data-ids, `feed-shared-*` / `comments-comment-*` / `fie-impression-container` classes, and per-post permalinks. Result: `get_feed_posts` found **0 posts**, and content-extraction + comment-box selectors were dead — auto-commenting silently did nothing.

## What (verified live against the current DOM)

Rebuilt around the new **stable** anchors and **inline** commenting (no permalink navigation):

**`selenium_util.py`** — resilient `find_first` / `click_first` / `find_all_first`: ordered fallback selector chains (aria-label/role → data-* → text → semantic → legacy) with **structured miss-logging** (tried selectors + URL), so future breakage is greppable instead of a silent skip. Generalizes the proven `get_visible_element_wait_retry` chain.

**`run_automation.py`** — SDUI feed engine:
- Posts: `[data-testid='expandable-text-box']`; card = nearest ancestor containing `button[aria-label='Comment']`; author from `button[aria-label^='Hide post by']`; content from the text box.
- Comment: click the card's `button[aria-label='Comment']` → type into `div[role='textbox']` → submit via the Comment/Post button, **Ctrl+Enter fallback** (the reliable submit).
- Dedup: content-hash key (no urn/permalink exists anymore) via the existing `has_user_commented_on_post_url`; logs `COMMENT`/`SUCCESS`.
- `automate_commenting` calls the inline engine instead of the tab-per-permalink loop.

## Verified
Live: generated a real on-brand AI comment and it **posted** (Ctrl+Enter) on the current feed. 7 new `find_first` unit tests (chains + miss-logging); existing selenium/login suites green (33).

Part of Workstream 1 (get commenting posting end-to-end). Follow-ups (reply flow, profile parsing) are W3 against these same anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)