### PR TITLE
feat(engagement): configurable targeting + voice/tone (4a)

### DIFF
--- a/compose/local/database/migrations/V34__add_engagement_preferences.sql
+++ b/compose/local/database/migrations/V34__add_engagement_preferences.sql
@@ -1,0 +1,37 @@
+-- Per-user engagement preferences: voice/tone/length for AI comments, topic/keyword/author
+-- targeting (so commenting/replies aren't just whatever the feed serves), per-day caps, and a
+-- default buyer stage. One row per user; list-type fields are JSON arrays of strings. Missing
+-- row → code-level defaults (behaviour unchanged until a user customizes).
+CREATE TABLE IF NOT EXISTS engagement_preferences (
+    id                     INT AUTO_INCREMENT PRIMARY KEY,
+    user_id                INT NOT NULL UNIQUE,
+
+    -- Voice / style (feeds generate_ai_response + DM refinement)
+    tone                   VARCHAR(64)  NULL,
+    comment_length         ENUM('short','medium','long') NOT NULL DEFAULT 'medium',
+    comment_style          VARCHAR(255) NULL,
+    use_emojis             TINYINT(1)   NOT NULL DEFAULT 1,
+    use_hashtags           TINYINT(1)   NOT NULL DEFAULT 0,
+
+    -- Targeting (include/exclude). JSON arrays of strings.
+    include_topics         JSON NULL,
+    exclude_topics         JSON NULL,
+    include_keywords       JSON NULL,
+    exclude_keywords       JSON NULL,
+    include_authors        JSON NULL,
+    exclude_authors        JSON NULL,
+    post_types             JSON NULL,
+    min_reactions          INT  NULL,
+    reply_to_own_comments  TINYINT(1) NOT NULL DEFAULT 1,
+
+    -- Volume caps (per day)
+    max_comments_per_day   INT NOT NULL DEFAULT 20,
+    max_dms_per_day        INT NOT NULL DEFAULT 20,
+
+    -- Default buyer stage for generation when a post/context has none
+    default_buyer_stage    VARCHAR(32) NULL,
+
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -26,6 +26,7 @@ from cqc_lem.utilities.db import (
     has_linkedin_session, get_user_password_pair_by_id,
     get_company_linked_in_url_for_user, update_company_linked_in_url_for_user,
     get_user_subscription_info, get_user_preferences, update_user_preferences,
+    get_engagement_preferences, update_engagement_preferences,
     update_subscription_from_stripe, update_user_linkedin_token,
     get_users_with_stripe_subscriptions,
     update_user_linkedin_password,
@@ -252,6 +253,27 @@ class UserPreferencesRequest(BaseModel):
     session_token: str
     last_login_inactivate_delay: Optional[int] = 90
     auto_schedule_posts: bool = False
+
+
+class EngagementPreferencesRequest(BaseModel):
+    session_token: str
+    tone: Optional[str] = None
+    comment_length: str = "medium"
+    comment_style: Optional[str] = None
+    use_emojis: bool = True
+    use_hashtags: bool = False
+    include_topics: List[str] = []
+    exclude_topics: List[str] = []
+    include_keywords: List[str] = []
+    exclude_keywords: List[str] = []
+    include_authors: List[str] = []
+    exclude_authors: List[str] = []
+    post_types: List[str] = []
+    min_reactions: Optional[int] = None
+    reply_to_own_comments: bool = True
+    max_comments_per_day: int = 20
+    max_dms_per_day: int = 20
+    default_buyer_stage: Optional[str] = None
 
 
 class LinkedInPasswordRequest(BaseModel):
@@ -987,6 +1009,25 @@ def update_user_settings_endpoint(request: UserPreferencesRequest) -> ResponseMo
     if not updated:
         raise HTTPException(status_code=500, detail="Could not update preferences")
     return ResponseModel(status_code=200, detail="Preferences updated")
+
+
+@router.get("/user/engagement-preferences")
+def get_engagement_preferences_endpoint(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail=get_engagement_preferences(user_id))
+
+
+@router.put("/user/engagement-preferences")
+def update_engagement_preferences_endpoint(request: EngagementPreferencesRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    prefs = request.model_dump(exclude={"session_token"})
+    if not update_engagement_preferences(user_id, prefs):
+        raise HTTPException(status_code=500, detail="Could not update engagement preferences")
+    return ResponseModel(status_code=200, detail="Engagement preferences updated")
 
 
 @router.put("/user/linkedin-password")

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -12,9 +12,10 @@ from urllib.parse import urlparse
 from celery_once import QueueOnce
 from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_refinement, summarize_recent_activity, \
-    ai_check_message_history
+    ai_check_message_history, post_is_relevant
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
+    get_engagement_preferences, count_comments_today, \
     LogResultType, has_user_commented_on_post_url, get_post_url_from_log_for_user, get_post_message_from_log_for_user, \
     has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, PostType, \
     get_dm_history_for_profile, get_post_status, get_user_blog_url, get_post_type, get_carousel_slides
@@ -467,12 +468,50 @@ def post_comment_inline(driver, wait, card, comment_text: str, user_id: int = No
         return False
 
 
+def post_matches_preferences(content: str, author: str, prefs: dict) -> bool:
+    """Decide whether a post should be engaged given the user's targeting preferences.
+
+    Exclude keywords/topics/authors always kill it (case-insensitive substring). If any
+    include constraint is set, the post must match at least one: a literal include keyword
+    or author, OR (only if literal misses) LLM topic relevance to include_topics. With no
+    include constraints, engage everything not excluded.
+    """
+    if not prefs:
+        return True
+    text = (content or "").lower()
+    auth = (author or "").lower()
+    if any(str(k).lower() in text for k in (prefs.get("exclude_keywords") or []) + (prefs.get("exclude_topics") or []) if k):
+        return False
+    if any(str(a).lower() in auth for a in (prefs.get("exclude_authors") or []) if a):
+        return False
+    incl_kw = [k for k in (prefs.get("include_keywords") or []) if k]
+    incl_auth = [a for a in (prefs.get("include_authors") or []) if a]
+    incl_topics = [t for t in (prefs.get("include_topics") or []) if t]
+    if not (incl_kw or incl_auth or incl_topics):
+        return True
+    if any(str(k).lower() in text for k in incl_kw):
+        return True
+    if any(str(a).lower() in auth for a in incl_auth):
+        return True
+    if incl_topics and post_is_relevant(content, incl_topics):
+        return True
+    return False
+
+
 def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: int,
-                           max_posts: int = 10, deadline_ts: float = None) -> int:
+                           max_posts: int = 10, deadline_ts: float = None, prefs: dict = None) -> int:
     """Walk the SDUI feed, generate an AI comment per fresh/relevant post, and comment inline.
-    Returns the number of comments posted. Re-queries the feed after each action (the DOM
-    re-renders) and scrolls to load more when the current batch is exhausted."""
+    Applies the user's targeting preferences (topic/keyword/author filters + per-day cap) and
+    voice/tone. Returns the number of comments posted. Re-queries the feed after each action."""
     from selenium.common.exceptions import StaleElementReferenceException
+    if prefs is None:
+        prefs = get_engagement_preferences(user_id)
+    daily_cap = prefs.get("max_comments_per_day") or 20
+    remaining_today = max(0, daily_cap - count_comments_today(user_id))
+    if remaining_today <= 0:
+        myprint(f"Daily comment cap reached ({daily_cap}) — skipping")
+        return 0
+    max_posts = min(max_posts, remaining_today)
     posted, seen, scrolls = 0, set(), 0
     while posted < max_posts and scrolls < 15:
         if deadline_ts and time.time() >= deadline_ts:
@@ -496,7 +535,9 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             seen.add(key)
             if has_user_commented_on_post_url(user_id, key):
                 continue
-            comment_text = generate_ai_response(content, my_profile, None)
+            if not post_matches_preferences(content, author, prefs):
+                continue  # doesn't match targeting; DOM unchanged, try the next post
+            comment_text = generate_ai_response(content, my_profile, None, prefs=prefs)
             if not comment_text:
                 continue
             driver.execute_script("arguments[0].scrollIntoView({block:'center'});", card)

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -104,17 +104,41 @@ def generate_ai_response_test():
     return comment
 
 
-def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=None, post_comment: str = None):
+_COMMENT_LENGTH_CHARS = {"short": 300, "medium": 600, "long": 1100}
+
+
+def _style_directive(prefs: dict = None) -> str:
+    """Turn the user's engagement preferences into an explicit style directive that overrides
+    the profile-inferred defaults (tone, length, emoji/hashtag rules, freeform style)."""
+    if not prefs:
+        return ""
+    parts = []
+    tone = prefs.get("tone")
+    if tone:
+        parts.append(f"Write in a {tone} tone.")
+    length = prefs.get("comment_length") or "medium"
+    parts.append(f"Keep it {length} — around {_COMMENT_LENGTH_CHARS.get(length, 600)} characters.")
+    parts.append("You may use tasteful emojis." if prefs.get("use_emojis") else "Do not use emojis.")
+    parts.append("Relevant hashtags are okay." if prefs.get("use_hashtags") else "Do not use any hashtags.")
+    if prefs.get("comment_style"):
+        parts.append(f"Style guidance: {prefs['comment_style']}.")
+    return "\n\nStyle requirements (follow these):\n- " + "\n- ".join(parts) + "\n"
+
+
+def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=None, post_comment: str = None,
+                         prefs: dict = None):
     image_attached = "(image attached)" if post_img_url else ""
-    user_comment = f"\n\nRespond to this Comment Directly: <comment>{post_comment}</comment>\n\nYou are responding as the author of the LinkedIn Content. Keep your response short and sweet without using any hashtags.\n\n" if post_comment else ""
+    _no_hashtags = "" if (prefs and prefs.get("use_hashtags")) else " without using any hashtags"
+    user_comment = f"\n\nRespond to this Comment Directly: <comment>{post_comment}</comment>\n\nYou are responding as the author of the LinkedIn Content. Keep your response short and sweet{_no_hashtags}.\n\n" if post_comment else ""
 
     prompt = (f"""Please give me a comment in response to the following LinkedIn Content as the following LinkedIn User,"
-              
+
                 LinkedIn User Profile:\n\n{profile.model_dump_json()}\n\n"
-              
+
                 LinkedIn Content{image_attached}: <content>'{post_content}'</content>
-                
+
                 {user_comment}
+                {_style_directive(prefs)}
 
                 Only provide the final comment once it perfectly reflects the LinkedIn user’s style
                 
@@ -183,6 +207,31 @@ def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=No
 
     content = response.choices[0].message.content
     return content.strip() if content is not None else None
+
+
+def post_is_relevant(post_content: str, include_topics: list) -> bool:
+    """LLM relevance gate: is this post about any of the user's include_topics? Used on top of
+    literal keyword matching so targeting catches topical fit beyond exact words. Fails OPEN
+    (returns True) on any error so a classifier hiccup never silently blocks all engagement."""
+    if not include_topics:
+        return True
+    try:
+        topics = ", ".join(str(t) for t in include_topics if t)
+        resp = _call_llm(
+            model="lem-simple",
+            messages=[
+                {"role": "system", "content": "You classify whether a LinkedIn post is topically "
+                                              "relevant to a set of topics. Answer with only 'yes' or 'no'."},
+                {"role": "user", "content": f"Topics: {topics}\n\nPost:\n{post_content[:1200]}\n\n"
+                                            f"Is this post relevant to ANY of the topics? Answer yes or no."},
+            ],
+            temperature=0,
+        )
+        ans = (resp.choices[0].message.content or "").strip().lower()
+        return ans.startswith("y")
+    except Exception as e:
+        myprint(f"post_is_relevant classifier failed (allowing): {e}")
+        return True
 
 
 def get_ai_description_of_profile(linked_in_profile: LinkedInProfile):

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1999,6 +1999,118 @@ def update_user_preferences(
         connection.close()
 
 
+_ENGAGEMENT_DEFAULTS: dict = {
+    "tone": None, "comment_length": "medium", "comment_style": None,
+    "use_emojis": True, "use_hashtags": False,
+    "include_topics": [], "exclude_topics": [], "include_keywords": [], "exclude_keywords": [],
+    "include_authors": [], "exclude_authors": [], "post_types": [],
+    "min_reactions": None, "reply_to_own_comments": True,
+    "max_comments_per_day": 20, "max_dms_per_day": 20, "default_buyer_stage": None,
+}
+_ENGAGEMENT_JSON_FIELDS = ("include_topics", "exclude_topics", "include_keywords",
+                           "exclude_keywords", "include_authors", "exclude_authors", "post_types")
+_ENGAGEMENT_BOOL_FIELDS = ("use_emojis", "use_hashtags", "reply_to_own_comments")
+_ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "use_hashtags",
+                    "include_topics", "exclude_topics", "include_keywords", "exclude_keywords",
+                    "include_authors", "exclude_authors", "post_types", "min_reactions",
+                    "reply_to_own_comments", "max_comments_per_day", "max_dms_per_day",
+                    "default_buyer_stage")
+
+
+def _coerce_json_list(value) -> list:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    try:
+        parsed = json.loads(value)
+        return parsed if isinstance(parsed, list) else []
+    except (ValueError, TypeError):
+        return []
+
+
+def get_engagement_preferences(user_id: int) -> dict:
+    """Return the user's engagement preferences (voice/targeting/caps) with code-level
+    defaults when no row exists — so behaviour is unchanged until the user customizes."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            f"SELECT {', '.join(_ENGAGEMENT_COLS)} FROM engagement_preferences WHERE user_id = %s",
+            (user_id,))
+        row = cursor.fetchone()
+        if row is None:
+            return dict(_ENGAGEMENT_DEFAULTS)
+        for f in _ENGAGEMENT_JSON_FIELDS:
+            row[f] = _coerce_json_list(row.get(f))
+        for f in _ENGAGEMENT_BOOL_FIELDS:
+            row[f] = bool(row.get(f))
+        return row
+    except mysql.connector.Error as err:
+        myprint(f"Could not get engagement prefs for user_id {user_id} | Error: {err}")
+        return dict(_ENGAGEMENT_DEFAULTS)
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
+    """Upsert the user's engagement preferences (INSERT ... ON DUPLICATE KEY UPDATE)."""
+    merged = {**_ENGAGEMENT_DEFAULTS, **{k: v for k, v in prefs.items() if k in _ENGAGEMENT_DEFAULTS}}
+
+    def _val(col):
+        v = merged[col]
+        if col in _ENGAGEMENT_JSON_FIELDS:
+            return json.dumps(v or [])
+        if col in _ENGAGEMENT_BOOL_FIELDS:
+            return 1 if v else 0
+        return v
+
+    values = [user_id] + [_val(c) for c in _ENGAGEMENT_COLS]
+    placeholders = ", ".join(["%s"] * (len(_ENGAGEMENT_COLS) + 1))
+    updates = ", ".join(f"{c}=VALUES({c})" for c in _ENGAGEMENT_COLS)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            f"INSERT INTO engagement_preferences (user_id, {', '.join(_ENGAGEMENT_COLS)}) "
+            f"VALUES ({placeholders}) ON DUPLICATE KEY UPDATE {updates}", values)
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update engagement prefs for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def _count_actions_today(user_id: int, action_type: "LogActionType") -> int:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM logs WHERE user_id=%s AND action_type=%s AND result=%s "
+            "AND created_at >= CURDATE()",
+            (user_id, str(action_type), str(LogResultType.SUCCESS)))
+        r = cursor.fetchone()
+        return int(r[0]) if r else 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not count actions for user_id {user_id} | Error: {err}")
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def count_comments_today(user_id: int) -> int:
+    return _count_actions_today(user_id, LogActionType.COMMENT)
+
+
+def count_dms_sent_today(user_id: int) -> int:
+    return _count_actions_today(user_id, LogActionType.DM)
+
+
 def get_user_geo(user_id: int) -> Optional[dict]:
     """Return the user's full geo profile for Selenium spoofing.
 

--- a/tests/unit/api/test_engagement_prefs_api.py
+++ b/tests/unit/api/test_engagement_prefs_api.py
@@ -1,0 +1,69 @@
+"""Unit tests for the /api/user/engagement-preferences endpoints."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_SESSION = "tok"
+_USER = 5
+
+
+class TestGetEngagementPreferences:
+    def test_returns_prefs(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_engagement_preferences",
+                   return_value={"tone": "warm", "comment_length": "short"}):
+            resp = client.get(f"/api/user/engagement-preferences?session_token={_SESSION}")
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["tone"] == "warm"
+
+    def test_401(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.get("/api/user/engagement-preferences?session_token=bad")
+        assert resp.status_code == 401
+
+
+class TestUpdateEngagementPreferences:
+    def test_updates_and_excludes_session_token(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences",
+                              json={"session_token": _SESSION, "tone": "bold", "include_topics": ["AI"]})
+        assert resp.status_code == 200
+        prefs_arg = upd.call_args[0][1]
+        assert "session_token" not in prefs_arg
+        assert prefs_arg["tone"] == "bold" and prefs_arg["include_topics"] == ["AI"]
+
+    def test_500_on_failure(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_engagement_preferences", return_value=False):
+            resp = client.put("/api/user/engagement-preferences", json={"session_token": _SESSION})
+        assert resp.status_code == 500
+
+    def test_401(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.put("/api/user/engagement-preferences", json={"session_token": "bad"})
+        assert resp.status_code == 401

--- a/tests/unit/app/test_engagement_targeting.py
+++ b/tests/unit/app/test_engagement_targeting.py
@@ -1,0 +1,60 @@
+"""Unit tests for post_matches_preferences (engagement targeting)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+
+def _prefs(**kw):
+    base = {"exclude_keywords": [], "exclude_topics": [], "exclude_authors": [],
+            "include_keywords": [], "include_authors": [], "include_topics": []}
+    base.update(kw)
+    return base
+
+
+class TestPostMatchesPreferences:
+    def test_no_constraints_matches(self):
+        from cqc_lem.app.run_automation import post_matches_preferences
+        assert post_matches_preferences("anything at all", "Jane", _prefs()) is True
+
+    def test_exclude_keyword_blocks(self):
+        from cqc_lem.app.run_automation import post_matches_preferences
+        assert post_matches_preferences("a Crypto scam post", "Jane", _prefs(exclude_keywords=["crypto"])) is False
+
+    def test_exclude_author_blocks(self):
+        from cqc_lem.app.run_automation import post_matches_preferences
+        assert post_matches_preferences("great post", "Spammy Bob", _prefs(exclude_authors=["spammy"])) is False
+
+    def test_include_keyword_required_and_matches(self):
+        from cqc_lem.app.run_automation import post_matches_preferences
+        assert post_matches_preferences("all about AI agents", "Jane", _prefs(include_keywords=["ai"])) is True
+
+    def test_include_keyword_required_no_match(self):
+        from cqc_lem.app.run_automation import post_matches_preferences
+        assert post_matches_preferences("gardening tips", "Jane", _prefs(include_keywords=["ai"])) is False
+
+    def test_include_topics_uses_llm_when_literal_misses(self):
+        from cqc_lem.app.run_automation import post_matches_preferences
+        with patch(f"{_RA}.post_is_relevant", return_value=True) as rel:
+            assert post_matches_preferences("a post about ML", "Jane", _prefs(include_topics=["AI"])) is True
+        rel.assert_called_once()
+
+    def test_include_topics_llm_says_no(self):
+        from cqc_lem.app.run_automation import post_matches_preferences
+        with patch(f"{_RA}.post_is_relevant", return_value=False):
+            assert post_matches_preferences("gardening", "Jane", _prefs(include_topics=["AI"])) is False
+
+    def test_literal_include_short_circuits_llm(self):
+        from cqc_lem.app.run_automation import post_matches_preferences
+        with patch(f"{_RA}.post_is_relevant") as rel:
+            assert post_matches_preferences("about ai stuff", "Jane",
+                                            _prefs(include_keywords=["ai"], include_topics=["X"])) is True
+        rel.assert_not_called()
+
+    def test_exclude_wins_over_include(self):
+        from cqc_lem.app.run_automation import post_matches_preferences
+        assert post_matches_preferences("ai and crypto", "Jane",
+                                        _prefs(include_keywords=["ai"], exclude_keywords=["crypto"])) is False

--- a/tests/unit/utilities/ai/test_style_directive.py
+++ b/tests/unit/utilities/ai/test_style_directive.py
@@ -1,0 +1,24 @@
+"""Unit tests for the engagement-prefs style directive injected into AI comments."""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestStyleDirective:
+    def test_includes_tone_length_and_no_emoji_no_hashtag(self):
+        from cqc_lem.utilities.ai.ai_helper import _style_directive
+        d = _style_directive({"tone": "warm", "comment_length": "short",
+                              "use_emojis": False, "use_hashtags": False, "comment_style": "punchy"})
+        assert "warm" in d and "short" in d
+        assert "Do not use emojis" in d and "Do not use any hashtags" in d and "punchy" in d
+
+    def test_emojis_and_hashtags_allowed(self):
+        from cqc_lem.utilities.ai.ai_helper import _style_directive
+        d = _style_directive({"comment_length": "long", "use_emojis": True, "use_hashtags": True})
+        assert "tasteful emojis" in d and "hashtags are okay" in d.lower()
+
+    def test_empty_without_prefs(self):
+        from cqc_lem.utilities.ai.ai_helper import _style_directive
+        assert _style_directive(None) == ""
+        assert _style_directive({}) == ""

--- a/tests/unit/utilities/test_db_engagement_prefs.py
+++ b/tests/unit/utilities/test_db_engagement_prefs.py
@@ -1,0 +1,72 @@
+"""Unit tests for engagement-preferences DB helpers."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _mock_conn(fetch_row=None, rowcount=1):
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = fetch_row
+    cursor.rowcount = rowcount
+    conn.cursor.return_value = cursor
+    return conn, cursor
+
+
+class TestGetEngagementPreferences:
+    def test_defaults_when_no_row(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            prefs = get_engagement_preferences(1)
+        assert prefs["comment_length"] == "medium"
+        assert prefs["include_topics"] == [] and prefs["max_comments_per_day"] == 20
+        assert prefs["reply_to_own_comments"] is True
+
+    def test_decodes_json_and_bools(self):
+        row = {
+            "tone": "warm", "comment_length": "long", "comment_style": None,
+            "use_emojis": 1, "use_hashtags": 0,
+            "include_topics": json.dumps(["AI", "SaaS"]), "exclude_topics": None,
+            "include_keywords": "[]", "exclude_keywords": None,
+            "include_authors": None, "exclude_authors": None, "post_types": None,
+            "min_reactions": 5, "reply_to_own_comments": 0,
+            "max_comments_per_day": 15, "max_dms_per_day": 10, "default_buyer_stage": "awareness",
+        }
+        conn, _ = _mock_conn(fetch_row=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            prefs = get_engagement_preferences(1)
+        assert prefs["include_topics"] == ["AI", "SaaS"]
+        assert prefs["use_emojis"] is True and prefs["use_hashtags"] is False
+        assert prefs["reply_to_own_comments"] is False and prefs["min_reactions"] == 5
+
+
+class TestUpdateEngagementPreferences:
+    def test_upserts_with_json_encoded_arrays(self):
+        conn, cursor = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_engagement_preferences
+            ok = update_engagement_preferences(7, {
+                "tone": "bold", "include_topics": ["AI"], "use_hashtags": True, "max_comments_per_day": 5})
+        assert ok is True
+        sql = cursor.execute.call_args[0][0]
+        params = cursor.execute.call_args[0][1]
+        assert "ON DUPLICATE KEY UPDATE" in sql and params[0] == 7
+        # JSON array field is json-encoded somewhere in the params
+        assert any(p == json.dumps(["AI"]) for p in params)
+
+
+class TestCountActions:
+    def test_count_comments_today(self):
+        conn, cursor = _mock_conn(fetch_row=(3,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_comments_today
+            assert count_comments_today(1) == 3
+        sql = cursor.execute.call_args[0][0]
+        assert "CURDATE()" in sql


### PR DESCRIPTION
First phase of Workstream 4. Replaces fully-randomized commenting + profile-only voice with **user-configurable targeting and voice/tone**.

- **V34 `engagement_preferences`** table (defaults = unchanged behaviour): tone/length/style, emoji+hashtag toggles, include/exclude topics+keywords+authors (JSON), per-day caps, default buyer stage.
- **db**: get/update (upsert) + count_comments_today/count_dms_sent_today.
- **API**: GET/PUT `/user/engagement-preferences`.
- **Targeting** (`post_matches_preferences`): exclude kills; includes require a literal keyword/author match OR — only when literal misses — **LLM topic relevance** (`post_is_relevant`, fails open). Wired into the feed engine with a per-day cap.
- **Voice**: `generate_ai_response(prefs=...)` injects an explicit style directive (tone, length→char target, emoji/hashtag rules).

21 unit tests. Next: SPA config cards, DM templates (4b), follow-up sequences (4c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)