### PR TITLE
fix: resolve v0.19.0 runtime errors from celery/PostHog logs

### DIFF
--- a/.litellm/config.yaml
+++ b/.litellm/config.yaml
@@ -49,15 +49,9 @@ model_list:
       api_key: os.environ/OPENAI_API_KEY
 
   # ── COMPLEX tier: long-form, high-quality content ────────────────────────────
-  - model_name: lem-complex
-    litellm_params:
-      model: openai/kimi-k2:1t
-      api_base: os.environ/OLLAMA_CLOUD_URL
-      api_key: os.environ/OLLAMA_CLOUD_API_KEY
-      max_parallel_requests: 4
-      request_timeout: 300
-      rpm: 30
-
+  # NOTE: openai/kimi-k2:1t was RETIRED 2026-06-16 (returns 410) and was removed — it was
+  # the primary here, so content generation fell through to the OpenAI/Anthropic fallbacks,
+  # which fail when those keys aren't set. qwen3.5:397b (OLLAMA) is now primary.
   - model_name: lem-complex
     litellm_params:
       model: openai/qwen3.5:397b

--- a/compose/local/database/migrations/V37__add_followup_to_logs_action_type.sql
+++ b/compose/local/database/migrations/V37__add_followup_to_logs_action_type.sql
@@ -1,0 +1,5 @@
+-- v0.19.0 added LogActionType.FOLLOWUP ('followup') for DM follow-up sequence logging, but the
+-- logs.action_type ENUM was never extended to include it — so process_user_followups' inserts
+-- were rejected (strict mode) or silently truncated. Add 'followup' to the ENUM.
+ALTER TABLE logs
+    MODIFY COLUMN action_type ENUM('comment','dm','reply','post','engaged','followup') NOT NULL;

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -456,7 +456,6 @@ def regenerate_post_video_task(post_id: int):
     return regenerate_video_for_post(post_id)
 
 
-@shared_task.task
 def _carousel_slides_are_real_images(slides) -> bool:
     """True if carousel slides reference real images (URLs/paths), not plain text titles."""
     if not slides:
@@ -465,6 +464,7 @@ def _carousel_slides_are_real_images(slides) -> bool:
     return any(marker in blob for marker in ("http", "/assets", ".png", ".jpg"))
 
 
+@shared_task.task
 def regenerate_post_carousel_task(post_id: int):
     """Regenerate a carousel post's slide images (used by the asset-backfill safety net).
 

--- a/src/cqc_lem/utilities/linkedin/scrapper.py
+++ b/src/cqc_lem/utilities/linkedin/scrapper.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup, PageElement
 from cqc_lem.utilities.date import convert_datetime_to_start_of_day
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.date import get_linkedin_datetime_from_text
+from cqc_lem.utilities.logger import myprint
 from cqc_lem.utilities.selenium_util import window_scroll, click_element_wait_retry, get_driver_wait, \
     get_elements_as_list_wait_stale, \
     getText, wait_for_ajax

--- a/src/cqc_lem/utilities/logger.py
+++ b/src/cqc_lem/utilities/logger.py
@@ -82,8 +82,19 @@ if _posthog_handler is not None:
 
 # ── Internal helpers ─────────────────────────────────────────────────────────
 
+_PRIMITIVE_TYPES = (bool, str, bytes, int, float)
+
+
 def _extra(**kwargs) -> dict:
-    return {k: v for k, v in kwargs.items() if v is not None}
+    # Structured-log backends (PostHog/OTel) only accept primitive attribute values, so coerce
+    # anything else (e.g. an exception or WebElement passed as context) to str rather than
+    # emitting an "Invalid type ... for attribute" warning and dropping the field.
+    out = {}
+    for k, v in kwargs.items():
+        if v is None:
+            continue
+        out[k] = v if isinstance(v, _PRIMITIVE_TYPES) else str(v)
+    return out
 
 
 # ── Public API ────────────────────────────────────────────────────────────────
@@ -106,9 +117,17 @@ def log_info(message: str, **context) -> None:
     logger.info(message, extra=_extra(**context))
 
 
-def log_warning(message: str, **context) -> None:
-    """Log at WARNING level with optional structured context."""
-    logger.warning(message, extra=_extra(**context))
+def log_warning(
+    message: str,
+    exc: Optional[BaseException] = None,
+    **context,
+) -> None:
+    """Log at WARNING level with optional structured context. Pass exc= to capture the
+    exception's stack trace (via exc_info) instead of passing it as a raw attribute."""
+    if exc is not None:
+        logger.warning(message, exc_info=exc, extra=_extra(**context))
+    else:
+        logger.warning(message, extra=_extra(**context))
 
 
 def log_error(

--- a/tests/unit/utilities/test_logger_extra.py
+++ b/tests/unit/utilities/test_logger_extra.py
@@ -1,0 +1,37 @@
+"""Unit tests for logger structured-context coercion + log_warning exc handling."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+def test_extra_coerces_non_primitives_and_drops_none():
+    from cqc_lem.utilities.logger import _extra
+
+    class Boom(Exception):
+        pass
+
+    out = _extra(user_id=5, exc=Boom("bad selector"), flag=True, note=None, name="x")
+    assert out["user_id"] == 5 and out["flag"] is True and out["name"] == "x"
+    assert "note" not in out                       # None is dropped
+    assert isinstance(out["exc"], str) and "bad selector" in out["exc"]  # object coerced to str
+
+
+def test_log_warning_routes_exc_to_exc_info_not_property():
+    from cqc_lem.utilities import logger as L
+    with patch.object(L.logger, "warning") as w:
+        L.log_warning("boom", exc=ValueError("x"), user_id=1, action_type="comment")
+    _, kwargs = w.call_args
+    assert kwargs.get("exc_info") is not None       # stack trace captured
+    assert "exc" not in kwargs["extra"]             # not shipped as a raw attribute
+    assert kwargs["extra"]["user_id"] == 1 and kwargs["extra"]["action_type"] == "comment"
+
+
+def test_log_warning_without_exc_still_works():
+    from cqc_lem.utilities import logger as L
+    with patch.object(L.logger, "warning") as w:
+        L.log_warning("plain", user_id=2)
+    _, kwargs = w.call_args
+    assert kwargs.get("exc_info") is None
+    assert kwargs["extra"]["user_id"] == 2


### PR DESCRIPTION
Reviewed `celery_worker` / `celery_worker_selenium` logs after the 0.19.0 deploy and fixed the errors (incl. soft/warning-level ones):

| Symptom in logs | Root cause | Fix |
|---|---|---|
| follow-up log inserts fail | `logs.action_type` ENUM never got `'followup'` (v0.19.0 added the Python enum only) | **V37** migration extends the ENUM |
| `Invalid type WebDriverException for attribute 'exc'` (constant) | `log_warning` had no `exc=` param → exception shipped to PostHog as a raw attribute | add `exc=` (→ `exc_info`) + `_extra()` coerces non-primitives to `str` |
| `auto_backfill_missing_assets` crashes every 3h: `'function' object has no attribute 'apply_async'` | `@shared_task.task` decorator landed on the `_carousel_slides_are_real_images` helper instead of `regenerate_post_carousel_task` | move the decorator |
| `Error getting: awards/interests \| name 'myprint' is not defined` | `scrapper.py` used `myprint` without importing it | add the import |
| `Skipping post_id …: content generation raised 410 … kimi-k2:1t was retired` | `lem-complex` primary model retired 2026-06-16 → fell through to OpenAI/Anthropic fallbacks with no keys | remove it; `qwen3.5:397b` (OLLAMA) is now primary |

3 logger regression tests; carousel task + config validated.

**Heads-up (not code):** `OPENAI_API_KEY=CHANGE_ME` and `ANTHROPIC_API_KEY` is unset on the VPS. The OLLAMA tier covers every `lem-*` alias, so automations work without them — but set real keys if you want the OpenAI/Anthropic fallbacks active.

The commenting automation itself is working (logs show "Commented on … (1/10)", "(2/10)"); the per-post "Inline comment post failed" entries are individual posts skipped gracefully, now without the PostHog attribute spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)