### PR TITLE
chore(ci): reuse GHCR_PAT for Dependabot auto-merge (no new secret)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,11 +5,17 @@ name: Dependabot Auto-Merge
 # change in the group, and our dependabot.yml groups are minor/patch-only, so grouped PRs
 # match the condition below while any major arrives as its own ungrouped PR.
 #
-# Token: uses DEPENDABOT_MERGE_TOKEN (a fine-grained PAT with contents:write +
-# pull-requests:write) when present, falling back to GITHUB_TOKEN. A PAT is recommended
-# because auto-merge enabled via the built-in GITHUB_TOKEN does not reliably enter this
-# repo's merge queue (bot-token actions don't kick the queue) — the PAT behaves like a human
-# enqueue, which is what actually drains the queue.
+# Token: uses GHCR_PAT (a PAT with contents:write + pull-requests:write) when present,
+# falling back to GITHUB_TOKEN. A PAT is needed because auto-merge enabled via the built-in
+# GITHUB_TOKEN does not reliably enter this repo's merge queue (bot-token actions don't kick
+# the queue) — the PAT behaves like a human enqueue, which is what actually drains it.
+#
+# NOTE: this job runs in the DEPENDABOT event context, which can ONLY read secrets from the
+# *Dependabot* secret store — not Actions secrets. GHCR_PAT currently lives only in the
+# Actions store, so here it resolves empty and this job falls back to GITHUB_TOKEN. To make
+# the event-driven auto-merge use the PAT too, also add GHCR_PAT under Settings → Secrets →
+# Dependabot. Not required for correctness: the scheduled reconciler (Actions context, which
+# CAN read GHCR_PAT) sweeps up ready PRs every 6h regardless.
 
 on:
   pull_request:
@@ -48,4 +54,4 @@ jobs:
         run: gh pr merge --auto "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.DEPENDABOT_MERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-merge-reconciler.yml
+++ b/.github/workflows/dependabot-merge-reconciler.yml
@@ -23,8 +23,9 @@ jobs:
     steps:
       - name: Enqueue mergeable Dependabot PRs
         env:
-          # PAT recommended (see dependabot-auto-merge.yml); falls back to GITHUB_TOKEN.
-          GH_TOKEN: ${{ secrets.DEPENDABOT_MERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          # Runs in the Actions context, so it reads GHCR_PAT (contents+PR write) directly —
+          # no Dependabot-store copy needed. Falls back to GITHUB_TOKEN if unset.
+          GH_TOKEN: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
Points the Dependabot auto-merge + reconciler workflows at the existing **`GHCR_PAT`** instead of a new `DEPENDABOT_MERGE_TOKEN`.

- **Reconciler** (scheduled, Actions context) reads `GHCR_PAT` directly — it's already in the Actions store, so this works with **zero new secrets** and drains ready grouped PRs every 6h.
- **Event-driven auto-merge** runs in the Dependabot context, which can only read *Dependabot*-store secrets. `GHCR_PAT` isn't there, so that job falls back to `GITHUB_TOKEN` (harmless — the reconciler covers merging). To make it use the PAT too, add `GHCR_PAT` under **Settings → Secrets → Dependabot**.

⚠️ Requires `GHCR_PAT` to have **contents:write + pull-requests:write** (classic `repo` scope covers it). If it's a packages-only fine-grained token, it can push to GHCR but can't merge PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)