### PR TITLE
fix(automation): actually post inline comments/replies (submit was broken)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -430,11 +430,49 @@ def _feed_post_key(author: str, content: str) -> str:
     return f"feedpost://{digest}"
 
 
-def post_comment_inline(driver, wait, card, comment_text: str, user_id: int = None) -> bool:
-    """Open the card's inline comment composer, type the comment, and submit. Returns True if it
-    appears posted. Ctrl+Enter is the reliable submit in the new composer (verified live), with the
-    'Comment'/'Post' button as the primary path."""
+def _strip_non_bmp(text: str) -> str:
+    # ChromeDriver's send_keys raises WebDriverException on non-BMP characters (most emoji), so
+    # drop them — otherwise emoji-flavoured AI comments fail to type at all.
+    return ''.join(c for c in (text or "") if ord(c) <= 0xFFFF)
+
+
+# The SDUI comment/reply composer has NO <form> ancestor, so walk up from the textbox and click
+# the enabled submit button whose text is Comment/Post/Reply — excluding the aria-label
+# Comment/Reply buttons that OPEN a composer. Returns True if a button was clicked.
+_SUBMIT_NEAR_COMPOSER_JS = (
+    "let root=arguments[0]; for(let i=0;i<7 && root.parentElement;i++) root=root.parentElement;"
+    "const b=[...root.querySelectorAll('button')].find(x=>!x.disabled && x.offsetParent!==null &&"
+    "['comment','post','reply'].includes((x.innerText||'').trim().toLowerCase()) &&"
+    "!['comment','reply'].includes((x.getAttribute('aria-label')||'').toLowerCase()));"
+    "if(b){b.click(); return true;} return false;")
+
+
+def _composer_submitted(driver, composer, text: str) -> bool:
+    """True only if the text actually posted: the composer cleared (or detached), or the text now
+    shows in the nearby comment list — NOT merely still sitting in a full composer (the old
+    'text in body' check false-positived on that, so comments silently never posted)."""
     try:
+        if (composer.text or "").strip() == "":
+            return True
+    except Exception:
+        return True  # composer detached/re-rendered after posting
+    try:
+        return bool(driver.execute_script(
+            "let r=arguments[0]; for(let i=0;i<9 && r.parentElement;i++) r=r.parentElement;"
+            "const cl=r.querySelector(\"[data-testid*='-commentList']\");"
+            "return cl ? cl.innerText.includes(arguments[1]) : false;", composer, text[:25]))
+    except Exception:
+        return False
+
+
+def post_comment_inline(driver, wait, card, comment_text: str, user_id: int = None) -> bool:
+    """Open the card's inline comment composer, type the comment, and submit via the composer's
+    own Comment/Post button (the SDUI composer has no <form>). Returns True only if the comment
+    actually lands (composer clears / appears in the list), not just because text was typed."""
+    try:
+        comment_text = _strip_non_bmp(comment_text)
+        if not comment_text.strip():
+            return False
         if click_first(driver, wait, [(By.CSS_SELECTOR, "button[aria-label='Comment']")],
                        "Open comment composer", parent_element=card, required=False, user_id=user_id) is None:
             return False
@@ -448,22 +486,10 @@ def post_comment_inline(driver, wait, card, comment_text: str, user_id: int = No
         composer.click()
         composer.send_keys(comment_text)
         time.sleep(random.uniform(1, 2))
-        submitted = False
-        form = driver.execute_script(
-            "let e=arguments[0];while(e){if(e.tagName==='FORM')return e;e=e.parentElement;}return null;", composer)
-        if form is not None:
-            for b in form.find_elements(By.XPATH, ".//button[normalize-space()='Comment' or normalize-space()='Post']"):
-                try:
-                    if b.is_displayed() and not b.get_attribute("disabled"):
-                        driver.execute_script("arguments[0].click();", b)
-                        submitted = True
-                        break
-                except Exception:
-                    continue
-        if not submitted:
-            composer.send_keys(Keys.CONTROL, Keys.RETURN)
+        if not driver.execute_script(_SUBMIT_NEAR_COMPOSER_JS, composer):
+            composer.send_keys(Keys.CONTROL, Keys.RETURN)  # fallback
         time.sleep(random.uniform(3, 5))
-        return comment_text[:22] in driver.find_element(By.TAG_NAME, "body").text
+        return _composer_submitted(driver, composer, comment_text)
     except Exception as e:
         log_warning("Inline comment post failed", exc=e, action_type="comment", user_id=user_id)
         return False
@@ -573,25 +599,16 @@ def _reply_to_comment_inline(driver, wait, comment_el, reply_text: str, user_id:
                               "Reply composer", visible_only=True, required=False, user_id=user_id)
         if composer is None:
             return False
+        reply_text = _strip_non_bmp(reply_text)
+        if not reply_text.strip():
+            return False
         composer.click()
         composer.send_keys(reply_text)
         time.sleep(random.uniform(1, 2))
-        submitted = False
-        form = driver.execute_script(
-            "let e=arguments[0];while(e){if(e.tagName==='FORM')return e;e=e.parentElement;}return null;", composer)
-        if form is not None:
-            for b in form.find_elements(By.XPATH, ".//button[normalize-space()='Reply' or normalize-space()='Comment' or normalize-space()='Post']"):
-                try:
-                    if b.is_displayed() and not b.get_attribute("disabled"):
-                        driver.execute_script("arguments[0].click();", b)
-                        submitted = True
-                        break
-                except Exception:
-                    continue
-        if not submitted:
-            composer.send_keys(Keys.CONTROL, Keys.RETURN)
+        if not driver.execute_script(_SUBMIT_NEAR_COMPOSER_JS, composer):
+            composer.send_keys(Keys.CONTROL, Keys.RETURN)  # fallback
         time.sleep(random.uniform(3, 5))
-        return reply_text[:22] in driver.find_element(By.TAG_NAME, "body").text
+        return _composer_submitted(driver, composer, reply_text)
     except Exception as e:
         log_warning("Inline reply post failed", exc=e, action_type="reply", user_id=user_id)
         return False

--- a/tests/unit/app/test_comment_inline.py
+++ b/tests/unit/app/test_comment_inline.py
@@ -1,0 +1,73 @@
+"""Unit tests for the SDUI inline comment submit + verification fixes."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with patch(f"{_RA}.time.sleep"):
+        yield
+
+
+class TestStripNonBmp:
+    def test_drops_emoji_keeps_text(self):
+        from cqc_lem.app.run_automation import _strip_non_bmp
+        assert _strip_non_bmp("Hooked and not even sorry 😄 nice") == "Hooked and not even sorry  nice"
+
+    def test_plain_text_unchanged(self):
+        from cqc_lem.app.run_automation import _strip_non_bmp
+        assert _strip_non_bmp("plain ascii — even en-dash") == "plain ascii — even en-dash"
+
+
+class TestComposerSubmitted:
+    def test_true_when_composer_cleared(self):
+        from cqc_lem.app.run_automation import _composer_submitted
+        composer = MagicMock(); composer.text = ""
+        assert _composer_submitted(MagicMock(), composer, "some comment") is True
+
+    def test_true_when_composer_detached(self):
+        from cqc_lem.app.run_automation import _composer_submitted
+        composer = MagicMock(); type(composer).text = property(lambda self: (_ for _ in ()).throw(Exception("stale")))
+        assert _composer_submitted(MagicMock(), composer, "x") is True
+
+    def test_false_when_full_and_not_in_list(self):
+        from cqc_lem.app.run_automation import _composer_submitted
+        composer = MagicMock(); composer.text = "still typing this"
+        driver = MagicMock(); driver.execute_script.return_value = False
+        assert _composer_submitted(driver, composer, "still typing this") is False
+
+    def test_true_when_full_but_in_list(self):
+        from cqc_lem.app.run_automation import _composer_submitted
+        composer = MagicMock(); composer.text = "leftover"
+        driver = MagicMock(); driver.execute_script.return_value = True
+        assert _composer_submitted(driver, composer, "leftover") is True
+
+
+class TestPostCommentInline:
+    def test_posts_and_confirms(self):
+        from cqc_lem.app import run_automation as ra
+        composer = MagicMock(); composer.text = ""       # cleared after real submit
+        driver = MagicMock(); driver.execute_script.return_value = True  # submit button clicked
+        with patch(f"{_RA}.click_first", return_value=MagicMock()), \
+             patch(f"{_RA}.find_first", return_value=composer):
+            ok = ra.post_comment_inline(driver, MagicMock(), MagicMock(), "Great post, thanks", user_id=1)
+        assert ok is True
+
+    def test_emoji_only_comment_skipped(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.click_first") as cf:
+            ok = ra.post_comment_inline(MagicMock(), MagicMock(), MagicMock(), "😄😄😄", user_id=1)
+        assert ok is False
+        cf.assert_not_called()  # nothing left to type after stripping
+
+    def test_false_when_no_composer(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.click_first", return_value=MagicMock()), \
+             patch(f"{_RA}.find_first", return_value=None):
+            ok = ra.post_comment_inline(MagicMock(), MagicMock(), MagicMock(), "hello", user_id=1)
+        assert ok is False

--- a/tests/unit/app/test_reply_inline.py
+++ b/tests/unit/app/test_reply_inline.py
@@ -14,25 +14,28 @@ def _no_sleep():
         yield
 
 
-def _driver_body(text):
-    driver = MagicMock()
-    driver.execute_script.return_value = None  # no <form> ancestor → Ctrl+Enter path
-    body = MagicMock(); body.text = text
-    driver.find_element.return_value = body
-    return driver
-
-
 class TestReplyInline:
-    def test_posts_reply_via_ctrl_enter(self):
+    def test_posts_reply_and_confirms_via_cleared_composer(self):
         from cqc_lem.app import run_automation as ra
-        composer = MagicMock()
-        driver = _driver_body("... hello this is my reply text ...")
+        composer = MagicMock(); composer.text = ""          # composer cleared after a real post
+        driver = MagicMock(); driver.execute_script.return_value = True  # submit button clicked
         with patch(f"{_RA}.click_first", return_value=MagicMock()), \
              patch(f"{_RA}.find_first", return_value=composer):
             ok = ra._reply_to_comment_inline(driver, MagicMock(), MagicMock(),
                                              "hello this is my reply text", user_id=1)
         assert ok is True
         composer.send_keys.assert_called()  # typed the reply
+
+    def test_returns_false_when_composer_still_full(self):
+        # Submit failed: composer keeps the text and it's not in the list → NOT a false positive.
+        from cqc_lem.app import run_automation as ra
+        composer = MagicMock(); composer.text = "hello this is my reply text still here"
+        driver = MagicMock(); driver.execute_script.side_effect = [False, False]  # no button; not in list
+        with patch(f"{_RA}.click_first", return_value=MagicMock()), \
+             patch(f"{_RA}.find_first", return_value=composer):
+            ok = ra._reply_to_comment_inline(driver, MagicMock(), MagicMock(),
+                                             "hello this is my reply text", user_id=1)
+        assert ok is False
 
     def test_returns_false_when_no_reply_button(self):
         from cqc_lem.app import run_automation as ra


### PR DESCRIPTION
## Why your comments weren't appearing
Live diagnosis on the feed found comments **almost never posted**, yet the logs said SUCCESS. Two bugs, both masked by a false-positive check:

1. **Submit never fired.** The SDUI composer has **no `<form>` ancestor**, but the code only looked for the Comment/Post button *inside a form* → found none → fell back to Ctrl+Enter, which doesn't post. The real button is a plain `<button>Comment</button>` beside the composer. Verified live: with the new logic the composer clears and the comment shows in the list. ✅
2. **Emoji crash.** ChromeDriver's `send_keys` throws `WebDriverException` on non-BMP chars (most emoji), so emoji-flavoured AI comments failed to type. Now stripped before typing.

**Verification rewritten:** `comment_text[:22] in body` was always true (text sits in the composer regardless of posting) — that's what produced the phantom success logs. Now confirms the composer cleared/detached or the comment appears in the comment list.

Applied to both `post_comment_inline` and `_reply_to_comment_inline`. 14 unit tests. **Validated live** — a real comment posted and appeared in the thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)