### PR TITLE
feat(engagement): daily golden-hour commenting on top of pre-post

### DIFF
--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -88,9 +88,9 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_send_due_followups',
             'schedule': crontab(minute='*/30')  # Send due multi-touch DM follow-ups every 30 min
         },
-        'daily-engagement-no-post-days': {
+        'daily-golden-hour-engagement': {
             'task': 'cqc_lem.app.run_scheduler.auto_daily_engagement',
-            'schedule': crontab(hour='14', minute='0')  # Comment on the feed on days with no scheduled post
+            'schedule': crontab(hour='13', minute='0')  # Daily peak-hour feed commenting (~9am ET), on top of pre-post
         },
         'clen-up-stale-profiles': {
             'task': 'cqc_lem.app.run_scheduler.auto_clean_stale_profiles',

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -110,20 +110,20 @@ def auto_appreciate_dms():
 
 @shared_task.task
 def auto_daily_engagement():
-    """Standalone feed-commenting run for reciprocity on days with NO scheduled post. Days that
-    do have a post are already covered by the pre-post commenting trigger (auto_check_scheduled_posts),
-    so we skip them to avoid double-commenting. The per-day comment cap still applies inside
-    comment_on_feed_inline."""
+    """Daily golden-hour feed-commenting run — fires EVERY day at a peak engagement window, on
+    top of the pre-post commenting that already runs around each scheduled post. This gives a
+    consistent daily reciprocity burst even when a post is (or isn't) scheduled. Volume stays safe
+    because both this run and the pre-post runs share the per-day comment cap (enforced in
+    comment_on_feed_inline), and QueueOnce (keys=['user_id']) prevents overlapping double-runs for
+    the same user."""
     users = get_active_user_ids()
     dispatched = 0
     for user_id in users:
-        if has_scheduled_post_today(user_id):
-            continue  # pre-post commenting already engages the feed today
         if not has_linkedin_session(user_id):
             continue  # no session → the Selenium task would just fail and waste a Chrome slot
         automate_commenting.apply_async(kwargs={'user_id': user_id, 'loop_for_duration': 60 * 15})
         dispatched += 1
-    return f"Daily engagement dispatched for {dispatched}/{len(users)} active user(s)"
+    return f"Golden-hour engagement dispatched for {dispatched}/{len(users)} active user(s)"
 
 
 @shared_task.task

--- a/tests/unit/app/test_daily_engagement.py
+++ b/tests/unit/app/test_daily_engagement.py
@@ -27,14 +27,12 @@ class TestHasScheduledPostToday:
 
 
 class TestAutoDailyEngagement:
-    def test_dispatches_only_for_no_post_connected_users(self):
+    def test_dispatches_daily_for_all_connected_users(self):
         from cqc_lem.app.run_scheduler import auto_daily_engagement
+        # Runs every day now (no post-day skip); only the no-session user is excluded.
         with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2, 3]), \
-             patch(f"{_RS}.has_scheduled_post_today", side_effect=lambda u: u == 1), \
              patch(f"{_RS}.has_linkedin_session", side_effect=lambda u: u != 3), \
              patch(f"{_RS}.automate_commenting") as ac:
             result = auto_daily_engagement()
-        # user 1 has a post today (skip), user 3 has no session (skip) → only user 2 dispatched
-        ac.apply_async.assert_called_once()
-        assert ac.apply_async.call_args.kwargs["kwargs"]["user_id"] == 2
-        assert "1/3" in result
+        assert ac.apply_async.call_count == 2                 # users 1 & 2 (3 has no session)
+        assert "2/3" in result


### PR DESCRIPTION
Per discussion: the standalone commenting run now fires **every day at a golden hour** (13:00 UTC ≈ 9am ET peak), **on top of** the pre-post commenting around each scheduled post — not just on no-post days.

- Both runs share `max_comments_per_day` and `QueueOnce` prevents overlapping runs, so total volume stays safe/human-like.
- `max_post_age_hours` stays lenient (24h) — recency **scoring** prioritizes fresh posts softly instead of a hard golden-hour gate (which would starve the engine when nothing fresh is in view).

Result: consistent daily peak-hour engagement **+** the reciprocity burst around your posts. 3 tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)