### PR TITLE
docs: refresh capabilities in CLAUDE.md, README, and copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -4,6 +4,8 @@
 
 LinkedIn Engagement Manager (LEM) automates LinkedIn engagement: Selenium-based scraping, AI-generated content (via LiteLLM proxy routing to OpenAI / Claude / Ollama / OpenRouter), Celery task queue, React SPA frontend, MySQL persistence, and FastAPI backend.
 
+Two pillars: (1) **content generation & scheduling** — a 30-day buyer-journey content plan (thought leadership, industry-news commentary, personal story, engagement prompts, carousels, native video, blog summaries) auto-scheduled around peak hours with sentiment checks and a preview/approval workflow; (2) **engagement automation** — SDUI-resilient feed commenting with a recency-dominant scoring matrix, replies + seed/pin on own posts, reciprocity tracking, appreciation/outreach DMs with multi-touch follow-ups, and monthly company-page invites. All shaped by per-user targeting, voice/tone, and per-day caps (`engagement_preferences`). Code paths: `app/run_content_plan.py`, `app/run_scheduler.py`, `app/run_automation.py`, `utilities/ai/ai_helper.py`.
+
 ## Tech Stack
 
 | Layer | Technology |
@@ -24,7 +26,7 @@ LinkedIn Engagement Manager (LEM) automates LinkedIn engagement: Selenium-based 
 ```
 src/cqc_lem/
 ├── api/           FastAPI app (main.py, routers)
-├── app/           Celery tasks (run_scheduler.py, run_automation.py, my_celery.py)
+├── app/           Celery tasks (run_scheduler.py, run_automation.py, run_content_plan.py, my_celery.py)
 ├── utilities/
 │   ├── ai/        LiteLLM-backed AI helpers (ai_helper.py, client.py)
 │   ├── linkedin/  Selenium automation (scrapper.py, poster.py, commenter.py)
@@ -105,6 +107,12 @@ response = client.chat.completions.create(model="lem-simple", messages=[...])
 ## Selenium Pattern
 
 Always use `get_docker_driver()` from `selenium_util.py`. Connect to `selenium-chrome:4444`. Never instantiate `webdriver.Chrome()` directly. Use `click_element_wait_retry()` for all clicks.
+
+**LinkedIn SDUI gotchas:**
+- Old `urn:` / `feed-shared-*` / `comments-comment-*` DOM anchors are gone — prefer `data-testid` / `aria-label` via `find_first`/`click_first`. The comment composer has NO `<form>`; submit = the Comment/Post button next to it.
+- ChromeDriver `send_keys` throws on non-BMP emoji — strip with `_strip_non_bmp()` before typing.
+- Proxies authenticate via a runtime MV3 extension (`_build_proxy_auth_extension_b64`), not URL credentials.
+- `logs.action_type` and other status columns are MySQL ENUMs — add values via a Flyway migration (`compose/local/database/migrations/`, currently through V39; V37 added `'followup'`).
 
 ## Testing Standards
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,14 @@
 
 ## Project Overview
 
-LinkedIn Engagement Manager (LEM) automates LinkedIn engagement: Selenium-based scraping, AI-generated content (via LiteLLM proxy routing to OpenAI / Claude / Ollama / OpenRouter), Celery task queue, React SPA frontend, MySQL persistence, and FastAPI backend.
+LinkedIn Engagement Manager (LEM) automates LinkedIn engagement end to end: Selenium-based scraping and feed interaction, AI-generated content (via LiteLLM proxy routing to OpenAI / Claude / Ollama / OpenRouter), Celery task queue, React SPA frontend, MySQL persistence, and FastAPI backend.
+
+Two pillars:
+
+- **Content generation & scheduling** — a 30-day content plan of buyer-journey-staged posts (thought leadership, industry-news commentary, personal story, engagement prompts, carousels, native video, blog summaries) auto-scheduled around peak/golden hours, with sentiment checks and a preview/approval workflow.
+- **Engagement automation** — feed commenting, replies on the user's own posts, seed-and-pin first comments, appreciation/outreach DMs with multi-touch follow-ups, and monthly company-page invitations — all driven by per-user targeting, voice/tone, and per-day cap preferences.
+
+See **Feature Areas** below for the code paths behind each capability.
 
 ## Tech Stack
 
@@ -23,20 +30,34 @@ LinkedIn Engagement Manager (LEM) automates LinkedIn engagement: Selenium-based 
 
 ```
 src/cqc_lem/
-├── api/           FastAPI app (main.py, routers)
-├── app/           Celery tasks (run_scheduler.py, run_automation.py, my_celery.py)
+├── api/           FastAPI app (main.py, routers) — engagement_preferences, DM template, PIN endpoints
+├── app/           Celery tasks
+│   ├── run_scheduler.py     post scheduling around golden/peak hours
+│   ├── run_automation.py    feed commenting, replies, seed/pin, DMs + follow-ups
+│   ├── run_content_plan.py  30-day buyer-journey content plan
+│   ├── generate_variants.py media variant generation
+│   └── my_celery.py         Celery app + beat schedule
 ├── utilities/
 │   ├── ai/        LiteLLM-backed AI helpers (ai_helper.py, client.py)
-│   ├── linkedin/  Selenium automation (scrapper.py, poster.py, commenter.py)
+│   ├── linkedin/  Selenium automation
+│   │   ├── scrapper.py            profile/feed scraping
+│   │   ├── poster.py              publishing posts/carousels/video
+│   │   ├── company_page_inviter.py  monthly company-page invites
+│   │   ├── verification_pin.py    email-PIN LinkedIn verification flow
+│   │   ├── rate_limit.py          429/auth-wall backoff
+│   │   └── helper.py, profile.py, token_refresh.py
 │   ├── db.py      All database access (no raw SQL outside this file)
+│   ├── proxy.py   Per-user static residential proxy resolution
+│   ├── geocoding.py  Login Location city/state geocoding
 │   ├── logger.py  Structured logger — log_info/log_error/etc. preferred over myprint()
-│   └── selenium_util.py  get_docker_driver() — always use this for WebDriver
-├── ui/            React SPA (src/, dist/ is built output)
+│   └── selenium_util.py  get_docker_driver() + MV3 proxy-auth extension builder
+├── ui/            React SPA (src/, dist/ is built output) — Account.tsx holds engagement prefs
 └── aws/           AWS CDK stacks
 tests/
 ├── unit/          Fast tests — mock all I/O
 ├── integration/   Require MySQL + Redis service containers
 └── e2e/           Require selenium/standalone-chrome
+compose/local/database/migrations/  Flyway migrations (through V39)
 .litellm/
 ├── config.yaml    LiteLLM model aliases and routing config
 └── complexity_router.py  Pre-call hook for lem-router model
@@ -103,6 +124,31 @@ Always use `get_docker_driver()` from `selenium_util.py`. It connects to `seleni
 
 Use `click_element_wait_retry()` for all click interactions — it handles transient DOM timing issues.
 
+## Feature Areas
+
+### Content generation & scheduling (`app/run_content_plan.py`, `app/run_scheduler.py`, `utilities/ai/ai_helper.py`)
+- AI content by buyer-journey stage (awareness / consideration / decision): thought-leadership, industry-news commentary, personal-story, engagement-prompt posts, carousels (educational / case-study / product-demo / insights), native video, and blog summaries.
+- 30-day content plan with balanced post-type distribution; auto-scheduling around golden/peak hours.
+- Self-healing carousels (stale/errored carousels re-generated into branded slides) and asset backfill.
+- `PostType` is `text` / `carousel` / `video`; `PostStatus` includes `error` for generation/posting failures needing manual fix.
+
+### Engagement automation (`app/run_automation.py`)
+- **Feed commenting** rebuilt for LinkedIn's SDUI: resilient `find_first`/`click_first`/`find_all_first` selectors (`utilities/linkedin/helper.py`); inline compose + submit; **recency-dominant scoring matrix** (`_score_feed_post` = recency + relevance + reciprocity + activity) with post-age (`_post_age_minutes`) and social-count (`_post_social_counts`) extraction, best-effort "Recent" feed sort (`_switch_feed_to_recent`); targeting filters + per-day caps + voice/tone. Runs pre-post (≈15 min before each scheduled post) and daily at a golden hour.
+- **Replies** to comments on the user's own posts (`automate_reply_commenting`); **seed + pin a first comment** on own posts (`auto_seed_comment_on_post` → `_pin_own_comment`).
+- **Reciprocity tracking** via the `post_engagers` table — boosts commenting back on people who engaged with us (`get_recent_engagers`).
+- **DMs**: appreciation (connection / recommendation / collaboration), profile-viewer outreach, and **multi-touch follow-up sequences** — all templated and voice-aligned (`build_dm_from_template`, `dm_templates`, `dm_followups`, `process_user_followups`).
+- Monthly **company-page invitations** (`utilities/linkedin/company_page_inviter.py`).
+
+### Engagement configuration (`engagement_preferences` table, API in `api/main.py`, SPA in `ui/.../Account.tsx`)
+- Targeting: include/exclude topics/keywords/authors, `min_reactions`, `max_post_age_hours`, plus LLM topic-relevance scoring.
+- Voice: tone, `comment_length` (short/medium/long; default short), style, emoji/hashtag toggles.
+- Caps: `max_comments_per_day`, `max_dms_per_day`; DM template editor with follow-up steps; Login Location (city/state geocoding via `utilities/geocoding.py`, with admin override).
+
+### Anti-bot / session infra
+- Per-user static residential proxy (`utilities/proxy.py`) + an in-memory **MV3 proxy-auth extension** (`selenium_util.py`, MV2 background pages are disabled in current Chrome).
+- Cookie persistence and an email-PIN LinkedIn verification flow (`utilities/linkedin/verification_pin.py`).
+- 429 / auth-wall backoff and resilience (`utilities/linkedin/rate_limit.py`).
+
 ## Testing Standards
 
 - All new/modified code: ≥80% patch coverage enforced by Codecov.
@@ -140,3 +186,7 @@ Before merging any PR, all of the following must pass:
 - `run_scheduler.py:22` previously had a `raise ValueError("This is a test error")` — this was removed in M3.
 - PostHog replaces Prometheus + Jaeger (both removed from docker-compose).
 - `linkedin-preview` service (external) was removed — preview is now the native `LinkedInPostPreview.tsx` component.
+- **LinkedIn SDUI:** the old `urn:`, `feed-shared-*`, and `comments-comment-*` DOM anchors are gone. Prefer `data-testid` / `aria-label` selectors via `find_first`/`click_first`. The comment composer has NO `<form>` — "submit" means clicking the Comment/Post button next to the composer (`_composer_submitted`), and the comment overflow "…" menu is hover-hidden.
+- **Emoji in Selenium:** ChromeDriver `send_keys` throws on non-BMP emoji — strip them before typing with `_strip_non_bmp()`.
+- **ENUM columns:** `logs.action_type` (and other status columns) are MySQL ENUMs. Adding a new value requires a migration — e.g. V37 added `'followup'` to `logs.action_type`. Migrations live in `compose/local/database/migrations/` and currently run through **V39** (V38 added recency prefs, V39 added the `post_engagers` table).
+- **Proxy auth:** proxies are authenticated by the runtime MV3 extension (`_build_proxy_auth_extension_b64`), not by URL-embedded credentials — MV2 background pages that used to do this are disabled in Chrome 149+.

--- a/README.md
+++ b/README.md
@@ -2,19 +2,33 @@
 
 ## Overview
 
-LinkedIn Engagement Manager (LEM) is an automated solution for managing engagement and post interactions on LinkedIn. This tool automates commenting, sending direct messages (DMs), responding to comments, and scheduling posts. All content (text, carousels, videos) is AI-generated via a LiteLLM proxy and passes through sentiment analysis for appropriateness. LEM includes a preview and approval system enabling manual or automated content approval before publishing.
+LinkedIn Engagement Manager (LEM) is an automated solution for managing engagement and post interactions on LinkedIn. It builds a 30-day content plan, publishes AI-generated posts (text, carousels, native video) around peak hours, and runs the day-to-day engagement — feed commenting, replies, direct messages, and follow-ups — on your behalf. All content is AI-generated via a LiteLLM proxy, passes through sentiment analysis, and can flow through a preview/approval workflow before publishing. Engagement is shaped by per-user targeting, voice/tone, and daily-cap preferences.
 
 ## Key Features
-- **Automated Engagement**: Commenting, messaging profile viewers, and replying to post comments with scheduled engagement tasks.
-- **AI-Generated Content**: LiteLLM-proxied AI services generate carousel, text, and video content with tiered model routing (`lem-simple`, `lem-medium`, `lem-complex`).
-- **Sentiment Analysis**: Ensures content is appropriate and aligned with user preferences.
-- **Approval Workflow**: Preview and approve content before publishing or allow automatic approval.
-- **Video Creation**: Generate videos from prompts using AI.
-- **Summarizing Recent Activity**: Summarize recent LinkedIn activities and craft personalized responses.
-- **Date-Time Picker for Scheduled Posts**: Edit scheduled posts with a date-time picker for easy scheduling.
-- **Dockerized Environment**: Easily deployable locally or to the cloud using Docker Compose.
-- **Modular Design**: Content generation modules can be swapped out for any SaaS services via LiteLLM aliases.
-- **React SPA Dashboard**: Mobile and web-friendly React dashboard for monitoring and controlling the engagement process.
+
+### Content generation & scheduling
+- **Buyer-journey content plan**: A balanced 30-day plan across awareness / consideration / decision stages — thought-leadership, industry-news commentary, personal-story, and engagement-prompt posts, carousels (educational / case-study / product-demo / insights), native video, and blog summaries.
+- **AI-Generated Content**: LiteLLM-proxied models generate text, carousel, and video content with tiered routing (`lem-simple`, `lem-medium`, `lem-complex`, `lem-image`).
+- **Peak-hour scheduling**: Auto-schedules posts around golden/peak hours, with self-healing carousels and media asset backfill.
+- **Sentiment Analysis & Approval Workflow**: Checks content appropriateness; preview and approve manually or let it auto-approve. Native `LinkedInPostPreview` component and a date-time picker for editing scheduled posts.
+
+### Engagement automation
+- **Feed commenting**: SDUI-resilient feed interaction with a recency-dominant scoring matrix (recency + relevance + reciprocity + activity), inline compose/submit, and best-effort "Recent" feed sort. Runs shortly before each scheduled post and daily at a golden hour.
+- **Replies, seed & pin**: Replies to comments on your own posts and auto-seeds + pins a first comment on your posts.
+- **Reciprocity**: Tracks who engaged with you and prioritizes commenting back.
+- **Direct messages**: Appreciation DMs (connections / recommendations / collaborations), profile-viewer outreach, and multi-touch follow-up sequences — all templated and voice-aligned.
+- **Company-page invitations**: Monthly automated invites.
+
+### Configuration & controls
+- **Targeting**: Include/exclude topics, keywords, and authors; minimum reactions and maximum post age; LLM topic-relevance scoring.
+- **Voice**: Tone, comment length (short/medium/long), style, and emoji/hashtag toggles.
+- **Caps**: Per-day comment and DM limits; DM template editor with follow-up steps; Login Location (city/state geocoding).
+
+### Platform
+- **Anti-bot infra**: Per-user static residential proxy with an MV3 proxy-auth extension, cookie persistence, and an email-PIN LinkedIn verification flow; 429/auth-wall backoff.
+- **Dockerized Environment**: Deployable locally or to the cloud via Docker Compose (AWS CDK for cloud).
+- **Modular Design**: Content generation providers are swappable via LiteLLM aliases.
+- **React SPA Dashboard**: Mobile- and web-friendly dashboard for monitoring and controlling engagement.
 - **Observability**: PostHog-based LLM usage tracking, Celery task metrics, and API latency monitoring.
 
 ## Tech Stack


### PR DESCRIPTION
## Summary
Refreshes the three authoritative doc files so they match the project's current capabilities and goals. Documentation only — no code or tests were touched. Claims were verified against the code paths before writing.

### `CLAUDE.md`
- **Project Overview**: reframed around the two pillars (content generation & scheduling; engagement automation) with a pointer to the new Feature Areas section.
- **Directory Map**: expanded `app/` (run_content_plan.py, generate_variants.py) and `utilities/linkedin/` (company_page_inviter, verification_pin, rate_limit); added `proxy.py`, `geocoding.py`, the MV3 proxy-auth note on `selenium_util.py`, and the Flyway migrations dir (through V39).
- **Feature Areas** (new): content plan/scheduling, engagement automation (`_score_feed_post`, `auto_seed_comment_on_post`, `post_engagers`, DM templates/follow-ups, company invites), engagement configuration (`engagement_preferences`, targeting/voice/caps/Login Location), and anti-bot/session infra.
- **Known Gotchas**: added LinkedIn SDUI selectors (no `<form>` on composer, hover-hidden overflow), non-BMP emoji `send_keys` (`_strip_non_bmp`), MySQL ENUM columns needing migrations (V37 followup, V39 post_engagers), and MV3 proxy-auth.

### `README.md`
- Rewrote Overview and restructured **Key Features** into Content generation & scheduling, Engagement automation, Configuration & controls, and Platform groupings.

### `.github/copilot-instructions.md`
- Added the two-pillar capability summary and a concise LinkedIn SDUI / emoji / ENUM / proxy-auth gotchas block; added `run_content_plan.py` to the directory map.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EW1XumE9HwvC8WCkkFG3tx