### PR TITLE
feat(groups): LinkedIn Groups engagement (roadmap P2)

### DIFF
--- a/compose/local/database/migrations/V41__add_user_groups.sql
+++ b/compose/local/database/migrations/V41__add_user_groups.sql
@@ -1,0 +1,15 @@
+-- LinkedIn Groups the user has joined + per-group on/off for LEM engagement (comment/post).
+-- All groups are ENABLED by default (enabled=1). Populated by a periodic sync that scrapes the
+-- user's joined groups; the user toggles which ones LEM touches in the SPA.
+CREATE TABLE IF NOT EXISTS user_groups (
+    id              INT AUTO_INCREMENT PRIMARY KEY,
+    user_id         INT NOT NULL,
+    group_id        VARCHAR(64) NOT NULL,   -- LinkedIn group id from /groups/<id>/
+    group_name      VARCHAR(255) NULL,
+    enabled         TINYINT(1) NOT NULL DEFAULT 1,
+    last_synced_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_user_group (user_id, group_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -27,6 +27,7 @@ from cqc_lem.utilities.db import (
     get_company_linked_in_url_for_user, update_company_linked_in_url_for_user,
     get_user_subscription_info, get_user_preferences, update_user_preferences,
     get_engagement_preferences, update_engagement_preferences,
+    get_user_groups, set_groups_enabled,
     get_dm_templates, upsert_dm_templates,
     update_subscription_from_stripe, update_user_linkedin_token,
     get_users_with_stripe_subscriptions,
@@ -1058,6 +1059,29 @@ def update_engagement_preferences_endpoint(request: EngagementPreferencesRequest
     if not update_engagement_preferences(user_id, prefs):
         raise HTTPException(status_code=500, detail="Could not update engagement preferences")
     return ResponseModel(status_code=200, detail="Engagement preferences updated")
+
+
+class GroupTogglesRequest(BaseModel):
+    session_token: str
+    groups: dict = {}  # {group_id: enabled}
+
+
+@router.get("/user/groups")
+def get_user_groups_endpoint(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail=get_user_groups(user_id))
+
+
+@router.put("/user/groups")
+def update_user_groups_endpoint(request: GroupTogglesRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if not set_groups_enabled(user_id, request.groups):
+        raise HTTPException(status_code=500, detail="Could not update group settings")
+    return ResponseModel(status_code=200, detail="Group settings updated")
 
 
 @router.get("/user/dm-templates")

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -92,6 +92,18 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_daily_engagement',
             'schedule': crontab(hour='13', minute='0')  # Daily peak-hour feed commenting (~9am ET), on top of pre-post
         },
+        'sync-user-groups': {
+            'task': 'cqc_lem.app.run_scheduler.auto_sync_groups',
+            'schedule': crontab(hour='7', minute='0', day_of_week='monday')  # Refresh joined groups weekly
+        },
+        'group-engagement': {
+            'task': 'cqc_lem.app.run_scheduler.auto_group_engagement',
+            'schedule': crontab(hour='16', minute='0')  # Daily value-add commenting in enabled groups
+        },
+        'group-posts': {
+            'task': 'cqc_lem.app.run_scheduler.auto_group_posts',
+            'schedule': crontab(hour='15', minute='0', day_of_week='tuesday')  # Weekly value-add group post
+        },
         'clen-up-stale-profiles': {
             'task': 'cqc_lem.app.run_scheduler.auto_clean_stale_profiles',
             'schedule': crontab(hour='3', minute='0', )  # Run every day at 3:00 AM

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -14,10 +14,11 @@ from urllib.parse import urlparse
 from celery_once import QueueOnce
 from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_refinement, summarize_recent_activity, \
-    ai_check_message_history, post_is_relevant
+    ai_check_message_history, post_is_relevant, generate_group_post
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
+    upsert_user_group, get_enabled_group_ids, \
     LogResultType, has_user_commented_on_post_url, get_post_url_from_log_for_user, get_post_message_from_log_for_user, \
     has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, PostType, \
     get_dm_history_for_profile, get_post_status, get_user_blog_url, get_post_type, get_carousel_slides, \
@@ -794,6 +795,112 @@ def _comment_items_from_thread(driver):
         if item is not None:
             items.append(item)
     return items
+
+
+_GROUP_ID_RE = re.compile(r"/groups/(\d+)")
+
+
+def _enumerate_joined_groups(driver) -> list:
+    """Scrape the user's joined groups from /groups/ → list of (group_id, name). Best-effort."""
+    driver.get("https://www.linkedin.com/groups/")
+    time.sleep(random.uniform(5, 8))
+    for y in (600, 1200, 1800):
+        driver.execute_script(f"window.scrollTo(0,{y});")
+        time.sleep(1.5)
+    items = driver.execute_script(
+        "const out=[]; const seen=new Set();"
+        "for(const a of document.querySelectorAll(\"a[href*='/groups/']\")){"
+        "  const m=(a.getAttribute('href')||'').match(/\\/groups\\/(\\d+)/); if(!m) continue;"
+        "  const id=m[1]; if(seen.has(id)) continue;"
+        "  const name=(a.innerText||'').trim().split('\\n')[0];"
+        "  if(name && name.length>1){ seen.add(id); out.push([id, name.slice(0,255)]); }"
+        "} return out.slice(0,60);")
+    return [(str(i[0]), i[1]) for i in (items or []) if i and i[0]]
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='selenium')
+def auto_sync_user_groups(self, user_id: int):
+    """Refresh the user's joined-groups list (new groups default to enabled)."""
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Sync Groups")
+    except Exception as e:
+        log_error("Error getting profile for group sync", exc=e, user_id=user_id, task_name="auto_sync_user_groups")
+        return f"Failed: {e}"
+    try:
+        groups = _enumerate_joined_groups(driver)
+        for gid, name in groups:
+            upsert_user_group(user_id, gid, name)
+        return f"Synced {len(groups)} group(s)"
+    finally:
+        quit_gracefully(driver)
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='selenium')
+def auto_comment_in_groups(self, user_id: int, max_per_group: int = 2):
+    """Comment (value-add, scored) on posts in each of the user's ENABLED groups. Reuses the feed
+    commenting engine pointed at each group's feed. Shares the per-day comment cap."""
+    enabled = get_enabled_group_ids(user_id)
+    if not enabled:
+        return "No enabled groups"
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Group Commenting")
+    except Exception as e:
+        log_error("Error getting profile for group commenting", exc=e, user_id=user_id, task_name="auto_comment_in_groups")
+        return f"Failed: {e}"
+    prefs = get_engagement_preferences(user_id)
+    engagers = get_recent_engagers(user_id)
+    total = 0
+    try:
+        for gid in enabled:
+            driver.get(f"https://www.linkedin.com/groups/{gid}/")
+            time.sleep(random.uniform(4, 7))
+            total += comment_on_feed_inline(driver, wait, my_profile, user_id,
+                                            max_posts=max_per_group, prefs=prefs, engagers=engagers)
+        return f"Commented {total} time(s) across {len(enabled)} group(s)"
+    finally:
+        quit_gracefully(driver)
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id', 'group_id']},
+                  queue='selenium')
+def auto_post_to_group(self, user_id: int, group_id: str):
+    """Publish one short, value-add (non-promotional) post into a group via its share box.
+    Best-effort — the group composer selectors are validated in the live pass."""
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Group Post")
+    except Exception as e:
+        log_error("Error getting profile for group post", exc=e, user_id=user_id, task_name="auto_post_to_group")
+        return f"Failed: {e}"
+    try:
+        driver.get(f"https://www.linkedin.com/groups/{group_id}/")
+        time.sleep(random.uniform(4, 7))
+        text = _strip_non_bmp(generate_group_post(my_profile, prefs=get_engagement_preferences(user_id)) or "")
+        if not text.strip():
+            return "No group post generated"
+        # Open the group share box, type, and post (best-effort SDUI selectors).
+        if click_first(driver, wait, [(By.XPATH, "//button[contains(normalize-space(),'Start a post') or contains(@aria-label,'Start a post') or contains(@aria-label,'Create a post')]")],
+                       "Group share box", required=False) is None:
+            return "Group share box not found"
+        time.sleep(random.uniform(2, 3))
+        box = find_first(driver, wait, [(By.CSS_SELECTOR, "div[role='textbox']")], "Group post editor",
+                         visible_only=True, required=False)
+        if box is None:
+            return "Group post editor not found"
+        box.click()
+        box.send_keys(text)
+        time.sleep(random.uniform(1, 2))
+        if click_first(driver, wait, [(By.XPATH, "//button[normalize-space()='Post']")], "Group Post button",
+                       required=False) is None:
+            return "Group Post button not found"
+        time.sleep(random.uniform(3, 5))
+        return "Posted to group"
+    except Exception as e:
+        log_error("Group post error", exc=e, user_id=user_id, task_name="auto_post_to_group")
+        return f"Error: {e}"
+    finally:
+        quit_gracefully(driver)
 
 
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -127,6 +127,49 @@ def auto_daily_engagement():
 
 
 @shared_task.task
+def auto_sync_groups():
+    """Refresh each active user's joined-groups list (new groups default to enabled)."""
+    from cqc_lem.app.run_automation import auto_sync_user_groups
+    users = get_active_user_ids()
+    n = 0
+    for uid in users:
+        if has_linkedin_session(uid):
+            auto_sync_user_groups.apply_async(kwargs={'user_id': uid})
+            n += 1
+    return f"Group sync dispatched for {n}/{len(users)} user(s)"
+
+
+@shared_task.task
+def auto_group_engagement():
+    """Daily value-add commenting in each active user's ENABLED groups (shares the per-day cap)."""
+    from cqc_lem.app.run_automation import auto_comment_in_groups
+    users = get_active_user_ids()
+    n = 0
+    for uid in users:
+        if has_linkedin_session(uid):
+            auto_comment_in_groups.apply_async(kwargs={'user_id': uid})
+            n += 1
+    return f"Group commenting dispatched for {n}/{len(users)} user(s)"
+
+
+@shared_task.task
+def auto_group_posts():
+    """Weekly: publish one value-add post into an enabled group per active user."""
+    from cqc_lem.app.run_automation import auto_post_to_group
+    from cqc_lem.utilities.db import get_enabled_group_ids
+    users = get_active_user_ids()
+    n = 0
+    for uid in users:
+        if not has_linkedin_session(uid):
+            continue
+        groups = get_enabled_group_ids(uid)
+        if groups:
+            auto_post_to_group.apply_async(kwargs={'user_id': uid, 'group_id': groups[0]})
+            n += 1
+    return f"Group posts dispatched for {n}/{len(users)} user(s)"
+
+
+@shared_task.task
 def auto_send_due_followups():
     """Dispatch a per-user Selenium task to send due DM follow-ups (each gated by reply-detection)."""
     from cqc_lem.app.run_automation import process_user_followups

--- a/src/cqc_lem/ui/src/pages/Account.tsx
+++ b/src/cqc_lem/ui/src/pages/Account.tsx
@@ -116,6 +116,12 @@ type DmTemplate = {
   is_active: boolean
 }
 
+type UserGroup = {
+  group_id: string
+  group_name: string | null
+  enabled: boolean
+}
+
 function Toggle({ on, onClick }: { on: boolean; onClick: () => void }) {
   return (
     <button
@@ -173,6 +179,9 @@ export default function Account() {
   const [dmTemplates, setDmTemplates] = useState<DmTemplate[]>([])
   const [dmInit, setDmInit] = useState(false)
   const [dmMsg, setDmMsg] = useState<{ ok: boolean; text: string } | null>(null)
+  const [groups, setGroups] = useState<UserGroup[]>([])
+  const [groupsInit, setGroupsInit] = useState(false)
+  const [groupsMsg, setGroupsMsg] = useState<{ ok: boolean; text: string } | null>(null)
 
   // Handle LinkedIn OAuth callback: ?li_connected=1 or ?li_error=... in URL
   useEffect(() => {
@@ -500,6 +509,43 @@ export default function Account() {
     onError: () => {
       setDmMsg({ ok: false, text: 'Could not save — try again.' })
       setTimeout(() => setDmMsg(null), 5000)
+    },
+  })
+
+  // LinkedIn Groups — per-group on/off for LEM engagement
+  const { data: groupsData } = useQuery({
+    queryKey: ['user-groups', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/groups?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as UserGroup[]),
+    enabled: !!sessionToken,
+    staleTime: 60 * 1000,
+  })
+  useEffect(() => {
+    if (groupsData && !groupsInit) {
+      setGroups(groupsData)
+      setGroupsInit(true)
+    }
+  }, [groupsData, groupsInit])
+
+  const toggleGroup = (gid: string) =>
+    setGroups((gs) => gs.map((g) => (g.group_id === gid ? { ...g, enabled: !g.enabled } : g)))
+
+  const groupsMutation = useMutation({
+    mutationFn: () =>
+      api.put('/user/groups', {
+        session_token: sessionToken,
+        groups: Object.fromEntries(groups.map((g) => [g.group_id, g.enabled])),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-groups'] })
+      setGroupsMsg({ ok: true, text: 'Saved.' })
+      setTimeout(() => setGroupsMsg(null), 3000)
+    },
+    onError: () => {
+      setGroupsMsg({ ok: false, text: 'Could not save — try again.' })
+      setTimeout(() => setGroupsMsg(null), 5000)
     },
   })
 
@@ -1096,6 +1142,27 @@ export default function Account() {
           <button type="button" onClick={() => engMutation.mutate()} disabled={engMutation.isPending}
             className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
             {engMutation.isPending ? 'Saving…' : 'Save Targeting'}
+          </button>
+        </div>
+      )}
+
+      {/* Groups card */}
+      {groupsInit && groups.length > 0 && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+          <h2 className="text-base font-semibold text-gray-700">LinkedIn Groups</h2>
+          <p className="text-xs text-gray-500">Choose which of your joined groups LEM engages in (value-add comments + occasional posts). All on by default.</p>
+          <div className="divide-y divide-gray-100">
+            {groups.map((g) => (
+              <div key={g.group_id} className="flex items-center justify-between py-2">
+                <span className="text-sm text-gray-700 truncate pr-3">{g.group_name || `Group ${g.group_id}`}</span>
+                <Toggle on={g.enabled} onClick={() => toggleGroup(g.group_id)} />
+              </div>
+            ))}
+          </div>
+          {groupsMsg && <p className={`text-sm font-medium ${groupsMsg.ok ? 'text-green-600' : 'text-red-600'}`}>{groupsMsg.text}</p>}
+          <button type="button" onClick={() => groupsMutation.mutate()} disabled={groupsMutation.isPending}
+            className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
+            {groupsMutation.isPending ? 'Saving…' : 'Save Group Settings'}
           </button>
         </div>
       )}

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -205,6 +205,24 @@ def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=No
     return content.strip() if content is not None else None
 
 
+def generate_group_post(profile: "LinkedInProfile", group_name: str = None, prefs: dict = None) -> "str | None":
+    """A short, value-add post for a LinkedIn Group — a genuine insight or open question for that
+    community, NEVER promotional (groups penalize/moderate self-promo). Ends inviting discussion."""
+    ctx = f"for the LinkedIn group \"{group_name}\"" if group_name else "for a professional LinkedIn group"
+    system_prompt = {
+        "role": "system",
+        "content": f"""You are the profile user posting {ctx}. Write ONE short, genuinely useful
+        post that helps the community: a specific insight, lesson, or an open question that sparks
+        discussion. Absolutely NO self-promotion, NO links, NO hashtags. Sound human, in the user's
+        voice, and end by inviting members to weigh in. Output ONLY the post text.""",
+    }
+    user_prompt = {"role": "user", "content": f"Author profile:\n{profile.model_dump_json()}\n{_style_directive(prefs)}"}
+    response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt],
+                         temperature=round(random.uniform(0.5, 0.7), 2))
+    content = response.choices[0].message.content
+    return content.strip() if content is not None else None
+
+
 def post_is_relevant(post_content: str, include_topics: list) -> bool:
     """LLM relevance gate: is this post about any of the user's include_topics? Used on top of
     literal keyword matching so targeting catches topical fit beyond exact words. Fails OPEN

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2174,6 +2174,79 @@ def get_recent_engagers(user_id: int, days: int = 14) -> set:
         connection.close()
 
 
+def upsert_user_group(user_id: int, group_id: str, group_name: str = None) -> bool:
+    """Record a joined group (new groups default to enabled=1). Refreshes name + last_synced_at
+    without clobbering the user's enabled choice on an existing row."""
+    if not group_id:
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO user_groups (user_id, group_id, group_name, enabled, last_synced_at) "
+            "VALUES (%s,%s,%s,1,NOW()) ON DUPLICATE KEY UPDATE "
+            "group_name=COALESCE(VALUES(group_name), group_name), last_synced_at=NOW()",
+            (user_id, str(group_id), group_name))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not upsert group for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_user_groups(user_id: int) -> list:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT group_id, group_name, enabled FROM user_groups WHERE user_id=%s ORDER BY group_name",
+            (user_id,))
+        rows = cursor.fetchall() or []
+        for r in rows:
+            r["enabled"] = bool(r.get("enabled"))
+        return rows
+    except mysql.connector.Error as err:
+        myprint(f"Could not list groups for user {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_enabled_group_ids(user_id: int) -> list:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT group_id FROM user_groups WHERE user_id=%s AND enabled=1", (user_id,))
+        return [r[0] for r in cursor.fetchall()]
+    except mysql.connector.Error:
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def set_groups_enabled(user_id: int, group_states: dict) -> bool:
+    """Bulk-update per-group enabled flags: {group_id: bool}."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        for gid, enabled in group_states.items():
+            cursor.execute("UPDATE user_groups SET enabled=%s WHERE user_id=%s AND group_id=%s",
+                           (1 if enabled else 0, user_id, str(gid)))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not update group states for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
 # Default DM templates = today's hard-coded strings, so behaviour is unchanged until a user
 # customizes. {first_name},{headline},{blog_url} are filled at send time.
 _DM_DEFAULT_TEMPLATES = {

--- a/tests/unit/app/test_groups.py
+++ b/tests/unit/app/test_groups.py
@@ -1,0 +1,74 @@
+"""Unit tests for Groups engagement (enumeration, commenting, posting, dispatchers)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+_RS = "cqc_lem.app.run_scheduler"
+_DB = "cqc_lem.utilities.db"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with patch(f"{_RA}.time.sleep"):
+        yield
+
+
+class TestUserGroupsDB:
+    def _conn(self, fetch_all=None, rowcount=1):
+        conn = MagicMock(); cur = MagicMock()
+        cur.fetchall.return_value = fetch_all or []
+        cur.rowcount = rowcount
+        conn.cursor.return_value = cur
+        return conn, cur
+
+    def test_upsert_and_enabled_and_bulk(self):
+        conn, cur = self._conn(fetch_all=[("123",), ("456",)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import upsert_user_group, get_enabled_group_ids, set_groups_enabled
+            assert upsert_user_group(1, "123", "Growth Group") is True
+            assert get_enabled_group_ids(1) == ["123", "456"]
+            assert set_groups_enabled(1, {"123": False, "456": True}) is True
+
+
+class TestSyncUserGroups:
+    def test_upserts_enumerated(self):
+        from cqc_lem.app.run_automation import auto_sync_user_groups
+        with patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}._enumerate_joined_groups", return_value=[("1", "A"), ("2", "B")]), \
+             patch(f"{_RA}.upsert_user_group") as up, patch(f"{_RA}.quit_gracefully"):
+            result = auto_sync_user_groups.run(user_id=1)
+        assert up.call_count == 2 and "Synced 2" in result
+
+
+class TestCommentInGroups:
+    def test_comments_each_enabled_group(self):
+        from cqc_lem.app.run_automation import auto_comment_in_groups
+        with patch(f"{_RA}.get_enabled_group_ids", return_value=["1", "2"]), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_recent_engagers", return_value=set()), \
+             patch(f"{_RA}.comment_on_feed_inline", return_value=1) as cfi, patch(f"{_RA}.quit_gracefully"):
+            result = auto_comment_in_groups.run(user_id=1)
+        assert cfi.call_count == 2 and "across 2 group" in result
+
+    def test_no_enabled_groups(self):
+        from cqc_lem.app.run_automation import auto_comment_in_groups
+        with patch(f"{_RA}.get_enabled_group_ids", return_value=[]), \
+             patch(f"{_RA}.get_current_profile") as gp:
+            result = auto_comment_in_groups.run(user_id=1)
+        assert "No enabled groups" in result
+        gp.assert_not_called()
+
+
+class TestGroupDispatchers:
+    def test_group_engagement_dispatches_connected(self):
+        from cqc_lem.app.run_scheduler import auto_group_engagement
+        with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \
+             patch(f"{_RS}.has_linkedin_session", side_effect=lambda u: u == 1), \
+             patch("cqc_lem.app.run_automation.auto_comment_in_groups") as t:
+            result = auto_group_engagement()
+        t.apply_async.assert_called_once()
+        assert "1/2" in result


### PR DESCRIPTION
P2 of the growth roadmap. Groups are in a 2026 revival (niche targeted reach) — LEM engages the user's joined groups **authentically** (value-add only).

- **V41 `user_groups`** — per-group on/off, **all on by default**. `GET/PUT /user/groups` + a Groups card (toggles) in Account.
- **`auto_sync_user_groups`** — scrapes joined groups from `/groups/`.
- **`auto_comment_in_groups`** — reuses the scored `comment_on_feed_inline` engine on each enabled group's feed (shares the per-day cap).
- **`auto_post_to_group` + `generate_group_post`** — one short, **non-promotional** value-add post per week via the group share box.
- Beats: weekly sync, daily group commenting, weekly group post.

Group feeds reuse the SDUI feed selectors (validated). The group share-box/composer selectors are best-effort and get grounded in the end-of-roadmap live pass. 5 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)