### PR TITLE
feat(growth): roadmap P2–P7 (groups, stats, lead-magnet, hook/save, guardrails, thread-builder)

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,3 @@
+{
+  "enabledMcpjsonServers": ["selenium-lem", "playwright"]
+}

--- a/compose/local/database/migrations/V41__add_user_groups.sql
+++ b/compose/local/database/migrations/V41__add_user_groups.sql
@@ -1,0 +1,15 @@
+-- LinkedIn Groups the user has joined + per-group on/off for LEM engagement (comment/post).
+-- All groups are ENABLED by default (enabled=1). Populated by a periodic sync that scrapes the
+-- user's joined groups; the user toggles which ones LEM touches in the SPA.
+CREATE TABLE IF NOT EXISTS user_groups (
+    id              INT AUTO_INCREMENT PRIMARY KEY,
+    user_id         INT NOT NULL,
+    group_id        VARCHAR(64) NOT NULL,   -- LinkedIn group id from /groups/<id>/
+    group_name      VARCHAR(255) NULL,
+    enabled         TINYINT(1) NOT NULL DEFAULT 1,
+    last_synced_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_user_group (user_id, group_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/compose/local/database/migrations/V42__add_post_stats.sql
+++ b/compose/local/database/migrations/V42__add_post_stats.sql
@@ -1,0 +1,14 @@
+-- Engagement stats per published post, captured over time by a Selenium scraper. Powers
+-- personalized post-time recommendations (which weekday×hour actually earns the user engagement).
+CREATE TABLE IF NOT EXISTS post_stats (
+    id           INT AUTO_INCREMENT PRIMARY KEY,
+    user_id      INT NOT NULL,
+    post_id      INT NOT NULL,
+    reactions    INT NOT NULL DEFAULT 0,
+    comments     INT NOT NULL DEFAULT 0,
+    reposts      INT NOT NULL DEFAULT 0,
+    impressions  INT NULL,
+    captured_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_user_post (user_id, post_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/compose/local/database/migrations/V43__add_lead_magnet.sql
+++ b/compose/local/database/migrations/V43__add_lead_magnet.sql
@@ -1,0 +1,23 @@
+-- Comment→DM lead magnet: when someone comments a trigger keyword on the user's post, auto-DM
+-- them a resource. The compliant way to distribute links (links in the post body / first comment
+-- are penalized). Opt-in. lead_magnet_sent dedupes so a person is DM'd at most once per post.
+CREATE TABLE IF NOT EXISTS lead_magnet_settings (
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    user_id     INT NOT NULL UNIQUE,
+    enabled     TINYINT(1) NOT NULL DEFAULT 0,
+    keyword     VARCHAR(128) NULL,
+    message     TEXT NULL,
+    created_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS lead_magnet_sent (
+    id                 INT AUTO_INCREMENT PRIMARY KEY,
+    user_id            INT NOT NULL,
+    recipient_profile  VARCHAR(512) NOT NULL,
+    post_id            INT NULL,
+    sent_at            DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_user_recipient (user_id, recipient_profile),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -28,6 +28,8 @@ from cqc_lem.utilities.db import (
     get_user_subscription_info, get_user_preferences, update_user_preferences,
     get_engagement_preferences, update_engagement_preferences,
     get_newsletter_settings, update_newsletter_settings,
+    get_user_groups, set_groups_enabled, get_post_engagement_rows,
+    get_lead_magnet_settings, update_lead_magnet_settings,
     get_dm_templates, upsert_dm_templates,
     update_subscription_from_stripe, update_user_linkedin_token,
     get_users_with_stripe_subscriptions,
@@ -1086,6 +1088,68 @@ def update_newsletter_settings_endpoint(request: NewsletterSettingsRequest) -> R
     if not update_newsletter_settings(user_id, request.model_dump(exclude={"session_token"})):
         raise HTTPException(status_code=500, detail="Could not update newsletter settings")
     return ResponseModel(status_code=200, detail="Newsletter settings updated")
+
+
+class GroupTogglesRequest(BaseModel):
+    session_token: str
+    groups: dict = {}  # {group_id: enabled}
+
+
+@router.get("/user/groups")
+def get_user_groups_endpoint(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail=get_user_groups(user_id))
+
+
+@router.put("/user/groups")
+def update_user_groups_endpoint(request: GroupTogglesRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if not set_groups_enabled(user_id, request.groups):
+        raise HTTPException(status_code=500, detail="Could not update group settings")
+    return ResponseModel(status_code=200, detail="Group settings updated")
+
+
+@router.get("/user/post-stats")
+def get_post_stats_endpoint(session_token: str) -> ResponseModel:
+    """Personalized best-times-to-post recommendations derived from the user's own post stats."""
+    from cqc_lem.utilities.post_stats import recommend_post_times
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    rows = get_post_engagement_rows(user_id)
+    return ResponseModel(status_code=200, detail={
+        "recommendations": recommend_post_times(rows),
+        "sample_size": len(rows),
+    })
+
+
+class LeadMagnetRequest(BaseModel):
+    session_token: str
+    enabled: bool = False
+    keyword: Optional[str] = None
+    message: Optional[str] = None
+
+
+@router.get("/user/lead-magnet")
+def get_lead_magnet_endpoint(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail=get_lead_magnet_settings(user_id))
+
+
+@router.put("/user/lead-magnet")
+def update_lead_magnet_endpoint(request: LeadMagnetRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if not update_lead_magnet_settings(user_id, request.model_dump(exclude={"session_token"})):
+        raise HTTPException(status_code=500, detail="Could not update lead magnet")
+    return ResponseModel(status_code=200, detail="Lead magnet updated")
 
 
 @router.get("/user/dm-templates")

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -96,6 +96,22 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_publish_due_newsletters',
             'schedule': crontab(hour='12', minute='30')  # Daily check; publishes editions whose cadence is due
         },
+        'sync-user-groups': {
+            'task': 'cqc_lem.app.run_scheduler.auto_sync_groups',
+            'schedule': crontab(hour='7', minute='0', day_of_week='monday')  # Refresh joined groups weekly
+        },
+        'group-engagement': {
+            'task': 'cqc_lem.app.run_scheduler.auto_group_engagement',
+            'schedule': crontab(hour='16', minute='0')  # Daily value-add commenting in enabled groups
+        },
+        'group-posts': {
+            'task': 'cqc_lem.app.run_scheduler.auto_group_posts',
+            'schedule': crontab(hour='15', minute='0', day_of_week='tuesday')  # Weekly value-add group post
+        },
+        'scrape-post-stats': {
+            'task': 'cqc_lem.app.run_scheduler.auto_scrape_stats',
+            'schedule': crontab(hour='23', minute='0')  # Nightly: capture post engagement for time recs
+        },
         'clen-up-stale-profiles': {
             'task': 'cqc_lem.app.run_scheduler.auto_clean_stale_profiles',
             'schedule': crontab(hour='3', minute='0', )  # Run every day at 3:00 AM

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -14,11 +14,13 @@ from urllib.parse import urlparse
 from celery_once import QueueOnce
 from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_refinement, summarize_recent_activity, \
-    ai_check_message_history, post_is_relevant, generate_newsletter_edition
+    ai_check_message_history, post_is_relevant, generate_newsletter_edition, generate_group_post, generate_thread_reply
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
     get_newsletter_settings, mark_newsletter_published, \
+    upsert_user_group, get_enabled_group_ids, record_post_stats, get_recent_posted_post_ids, \
+    get_lead_magnet_settings, has_received_lead_magnet, record_lead_magnet_sent, \
     LogResultType, has_user_commented_on_post_url, get_post_url_from_log_for_user, get_post_message_from_log_for_user, \
     has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, PostType, \
     get_dm_history_for_profile, get_post_status, get_user_blog_url, get_post_type, get_carousel_slides, \
@@ -862,6 +864,145 @@ def auto_publish_newsletter_edition(self, user_id: int):
 
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
                   queue='selenium')
+def auto_scrape_post_stats(self, user_id: int):
+    """Capture reactions/comments for each of the user's recent posts (feeds personalized
+    post-time recommendations). Reuses the social-count extraction on each post's detail page."""
+    post_ids = get_recent_posted_post_ids(user_id)
+    if not post_ids:
+        return "No recent posts to scrape"
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Post Stats")
+    except Exception as e:
+        log_error("Error getting profile for post stats", exc=e, user_id=user_id, task_name="auto_scrape_post_stats")
+        return f"Failed: {e}"
+    scraped = 0
+    try:
+        for pid in post_ids:
+            url = get_post_url_from_log_for_user(user_id, pid)
+            if not url:
+                continue
+            driver.get(url)
+            time.sleep(random.uniform(4, 6))
+            try:
+                container = driver.find_element(By.TAG_NAME, "main")
+            except Exception:
+                container = None
+            counts = _post_social_counts(container) if container is not None else {"reactions": 0, "comments": 0}
+            record_post_stats(user_id, pid, counts["reactions"], counts["comments"])
+            scraped += 1
+        return f"Scraped stats for {scraped} post(s)"
+    finally:
+        quit_gracefully(driver)
+
+
+_GROUP_ID_RE = re.compile(r"/groups/(\d+)")
+
+
+def _enumerate_joined_groups(driver) -> list:
+    """Scrape the user's joined groups from /groups/ → list of (group_id, name). Best-effort."""
+    driver.get("https://www.linkedin.com/groups/")
+    time.sleep(random.uniform(5, 8))
+    for y in (600, 1200, 1800):
+        driver.execute_script(f"window.scrollTo(0,{y});")
+        time.sleep(1.5)
+    items = driver.execute_script(
+        "const out=[]; const seen=new Set();"
+        "for(const a of document.querySelectorAll(\"a[href*='/groups/']\")){"
+        "  const m=(a.getAttribute('href')||'').match(/\\/groups\\/(\\d+)/); if(!m) continue;"
+        "  const id=m[1]; if(seen.has(id)) continue;"
+        "  const name=(a.innerText||'').trim().split('\\n')[0];"
+        "  if(name && name.length>1){ seen.add(id); out.push([id, name.slice(0,255)]); }"
+        "} return out.slice(0,60);")
+    return [(str(i[0]), i[1]) for i in (items or []) if i and i[0]]
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='selenium')
+def auto_sync_user_groups(self, user_id: int):
+    """Refresh the user's joined-groups list (new groups default to enabled)."""
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Sync Groups")
+    except Exception as e:
+        log_error("Error getting profile for group sync", exc=e, user_id=user_id, task_name="auto_sync_user_groups")
+        return f"Failed: {e}"
+    try:
+        groups = _enumerate_joined_groups(driver)
+        for gid, name in groups:
+            upsert_user_group(user_id, gid, name)
+        return f"Synced {len(groups)} group(s)"
+    finally:
+        quit_gracefully(driver)
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='selenium')
+def auto_comment_in_groups(self, user_id: int, max_per_group: int = 2):
+    """Comment (value-add, scored) on posts in each of the user's ENABLED groups. Reuses the feed
+    commenting engine pointed at each group's feed. Shares the per-day comment cap."""
+    enabled = get_enabled_group_ids(user_id)
+    if not enabled:
+        return "No enabled groups"
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Group Commenting")
+    except Exception as e:
+        log_error("Error getting profile for group commenting", exc=e, user_id=user_id, task_name="auto_comment_in_groups")
+        return f"Failed: {e}"
+    prefs = get_engagement_preferences(user_id)
+    engagers = get_recent_engagers(user_id)
+    total = 0
+    try:
+        for gid in enabled:
+            driver.get(f"https://www.linkedin.com/groups/{gid}/")
+            time.sleep(random.uniform(4, 7))
+            total += comment_on_feed_inline(driver, wait, my_profile, user_id,
+                                            max_posts=max_per_group, prefs=prefs, engagers=engagers)
+        return f"Commented {total} time(s) across {len(enabled)} group(s)"
+    finally:
+        quit_gracefully(driver)
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id', 'group_id']},
+                  queue='selenium')
+def auto_post_to_group(self, user_id: int, group_id: str):
+    """Publish one short, value-add (non-promotional) post into a group via its share box.
+    Best-effort — the group composer selectors are validated in the live pass."""
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Group Post")
+    except Exception as e:
+        log_error("Error getting profile for group post", exc=e, user_id=user_id, task_name="auto_post_to_group")
+        return f"Failed: {e}"
+    try:
+        driver.get(f"https://www.linkedin.com/groups/{group_id}/")
+        time.sleep(random.uniform(4, 7))
+        text = _strip_non_bmp(generate_group_post(my_profile, prefs=get_engagement_preferences(user_id)) or "")
+        if not text.strip():
+            return "No group post generated"
+        # Open the group share box, type, and post (best-effort SDUI selectors).
+        if click_first(driver, wait, [(By.XPATH, "//button[contains(normalize-space(),'Start a post') or contains(@aria-label,'Start a post') or contains(@aria-label,'Create a post')]")],
+                       "Group share box", required=False) is None:
+            return "Group share box not found"
+        time.sleep(random.uniform(2, 3))
+        box = find_first(driver, wait, [(By.CSS_SELECTOR, "div[role='textbox']")], "Group post editor",
+                         visible_only=True, required=False)
+        if box is None:
+            return "Group post editor not found"
+        box.click()
+        box.send_keys(text)
+        time.sleep(random.uniform(1, 2))
+        if click_first(driver, wait, [(By.XPATH, "//button[normalize-space()='Post']")], "Group Post button",
+                       required=False) is None:
+            return "Group Post button not found"
+        time.sleep(random.uniform(3, 5))
+        return "Posted to group"
+    except Exception as e:
+        log_error("Group post error", exc=e, user_id=user_id, task_name="auto_post_to_group")
+        return f"Error: {e}"
+    finally:
+        quit_gracefully(driver)
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='selenium')
 def automate_commenting(self, user_id: int, loop_for_duration: int = None, future_forward: int = 60):
     global stop_all_thread
 
@@ -972,6 +1113,7 @@ def automate_reply_commenting(self, user_id: int, post_id: int, loop_for_duratio
             unique_url_name = path.split("/")[2] if len(path.split("/")) > 2 else None
 
             comments_replied_count = 0
+            lead_magnet = get_lead_magnet_settings(user_id)
             for comment in comments:
                 try:
                     tb = comment.find_elements(By.CSS_SELECTOR, "[data-testid='expandable-text-box']")
@@ -979,13 +1121,21 @@ def automate_reply_commenting(self, user_id: int, post_id: int, loop_for_duratio
                 except Exception:
                     continue
                 short_comment_text = comment_text[:75]
-                # Reciprocity: record whoever engaged on our post so the feed scorer can prioritize
-                # commenting back on their recent posts. Skip our own name.
+                # Reciprocity + lead-magnet: read the commenter, record them as an engager, and
+                # (if enabled) DM them the resource when their comment contains the trigger keyword.
                 try:
                     _link = comment.find_element(By.CSS_SELECTOR, "a[href*='/in/']")
                     _ename = ((_link.text or "") or (_link.get_attribute("aria-label") or "")).strip().split("\n")[0]
+                    _eprofile = (_link.get_attribute("href") or "").split("?")[0]
                     if _ename and _ename.lower() != (my_profile.full_name or "").lower():
-                        upsert_engager(user_id, _ename, (_link.get_attribute("href") or "").split("?")[0])
+                        upsert_engager(user_id, _ename, _eprofile)
+                        if (lead_magnet.get("enabled") and lead_magnet.get("keyword") and lead_magnet.get("message")
+                                and lead_magnet["keyword"].lower() in comment_text.lower()
+                                and _eprofile and not has_received_lead_magnet(user_id, _eprofile)):
+                            send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": _eprofile,
+                                                                "message": lead_magnet["message"]})
+                            record_lead_magnet_sent(user_id, _eprofile, post_id)
+                            myprint(f"Lead magnet DM queued to {_ename} (keyword '{lead_magnet['keyword']}')")
                 except Exception:
                     pass
                 # Already replied if our own profile link already appears in this comment's replies.
@@ -999,7 +1149,10 @@ def automate_reply_commenting(self, user_id: int, post_id: int, loop_for_duratio
                     myprint(f"We already replied to this comment: {short_comment_text}...")
                     continue
                 myprint(f"Responding to this comment: {short_comment_text}...")
-                response = generate_ai_response(post_message, my_profile, post_comment=comment_text)
+                # Thread-builder: reply in a way that ends with a follow-up question so the commenter
+                # replies again — first-hour thread depth is the top 2026 reach signal.
+                response = generate_thread_reply(post_message, comment_text, my_profile,
+                                                 prefs=get_engagement_preferences(user_id))
                 myprint(f"AI Generated Response to Comment: {response}")
                 if response and _reply_to_comment_inline(driver, wait, comment, response, user_id=user_id):
                     insert_new_log(user_id=user_id, post_id=post_id, action_type=LogActionType.REPLY,

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -14,7 +14,7 @@ from cqc_lem import assets_dir
 from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.utilities.ai.ai_helper import get_blog_summary_post_from_ai, get_website_content_post_from_ai, \
     get_flux_image_prompt_from_ai, generate_flux1_image_from_prompt, get_runway_ml_video_prompt_from_ai, \
-    create_runway_video, get_ai_linked_post_refinement
+    create_runway_video, get_ai_linked_post_refinement, optimize_post_hook
 from cqc_lem.utilities.ai.ai_helper import get_thought_leadership_post_from_ai, \
     get_industry_news_post_from_ai, get_personal_story_post_from_ai, generate_engagement_prompt_post
 from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, update_db_post_content, \
@@ -27,11 +27,11 @@ from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_RATIO, 
     STANDARD_VIDEO_MODEL, PREMIUM_VIDEO_MODEL, PREMIUM_TOP_VIDEO_MODEL, \
     PREMIUM_VIDEO_CREDITS, PREMIUM_TOP_VIDEO_CREDITS
 from cqc_lem.utilities.linkedin.helper import get_my_profile, load_profile_for_user
-from cqc_lem.utilities.linkedin_formatter import sanitize_for_linkedin
+from cqc_lem.utilities.linkedin_formatter import sanitize_for_linkedin, strip_engagement_bait
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.logger import myprint
 from cqc_lem.utilities.selenium_util import get_driver_wait_pair, quit_gracefully
-from cqc_lem.utilities.utils import get_best_posting_time, create_folder_if_not_exists, save_video_url_to_dir
+from cqc_lem.utilities.utils import get_best_posting_time, get_post_time, create_folder_if_not_exists, save_video_url_to_dir
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
@@ -166,8 +166,9 @@ def plan_content_for_user(self, user_id: int):
         # Add this post to the daily plan
         post_date = start_date + timedelta(days=day)
 
-        # Get the best time for the selected date
-        post_time = get_best_posting_time(post_date.date())
+        # Get the best time for the selected date — the user's data-driven best hour when we have
+        # enough post-stats, else the 2026 default peak model.
+        post_time = get_post_time(post_date.date(), user_id)
 
         # get_best_posting_time returns the user's LOCAL audience time (e.g. 2pm). Convert
         # it from the user's timezone to UTC for storage, because the scheduler treats
@@ -573,7 +574,11 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
 
     if refine_final_post:
         final_content = get_ai_linked_post_refinement(final_content)
+        # Hook + save-worthy pass: strong first line before the '…more' fold; save-worthy framing.
+        final_content = optimize_post_hook(final_content)
         final_content = sanitize_for_linkedin(final_content)
+        # Guardrail: strip classic engagement-bait CTAs (penalized), keeping lead-magnet CTAs.
+        final_content = strip_engagement_bait(final_content)
         final_content = final_content.strip()
 
     return final_content

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -138,6 +138,62 @@ def auto_publish_due_newsletters():
 
 
 @shared_task.task
+def auto_sync_groups():
+    """Refresh each active user's joined-groups list (new groups default to enabled)."""
+    from cqc_lem.app.run_automation import auto_sync_user_groups
+    users = get_active_user_ids()
+    n = 0
+    for uid in users:
+        if has_linkedin_session(uid):
+            auto_sync_user_groups.apply_async(kwargs={'user_id': uid})
+            n += 1
+    return f"Group sync dispatched for {n}/{len(users)} user(s)"
+
+
+@shared_task.task
+def auto_group_engagement():
+    """Daily value-add commenting in each active user's ENABLED groups (shares the per-day cap)."""
+    from cqc_lem.app.run_automation import auto_comment_in_groups
+    users = get_active_user_ids()
+    n = 0
+    for uid in users:
+        if has_linkedin_session(uid):
+            auto_comment_in_groups.apply_async(kwargs={'user_id': uid})
+            n += 1
+    return f"Group commenting dispatched for {n}/{len(users)} user(s)"
+
+
+@shared_task.task
+def auto_group_posts():
+    """Weekly: publish one value-add post into an enabled group per active user."""
+    from cqc_lem.app.run_automation import auto_post_to_group
+    from cqc_lem.utilities.db import get_enabled_group_ids
+    users = get_active_user_ids()
+    n = 0
+    for uid in users:
+        if not has_linkedin_session(uid):
+            continue
+        groups = get_enabled_group_ids(uid)
+        if groups:
+            auto_post_to_group.apply_async(kwargs={'user_id': uid, 'group_id': groups[0]})
+            n += 1
+    return f"Group posts dispatched for {n}/{len(users)} user(s)"
+
+
+@shared_task.task
+def auto_scrape_stats():
+    """Daily: capture engagement stats on each active user's recent posts (powers post-time recs)."""
+    from cqc_lem.app.run_automation import auto_scrape_post_stats
+    users = get_active_user_ids()
+    n = 0
+    for uid in users:
+        if has_linkedin_session(uid):
+            auto_scrape_post_stats.apply_async(kwargs={'user_id': uid})
+            n += 1
+    return f"Stats scrape dispatched for {n}/{len(users)} user(s)"
+
+
+@shared_task.task
 def auto_send_due_followups():
     """Dispatch a per-user Selenium task to send due DM follow-ups (each gated by reply-detection)."""
     from cqc_lem.app.run_automation import process_user_followups

--- a/src/cqc_lem/ui/src/pages/Account.tsx
+++ b/src/cqc_lem/ui/src/pages/Account.tsx
@@ -124,6 +124,18 @@ type NewsletterSettings = {
   align_with_blog: boolean
 }
 
+type UserGroup = {
+  group_id: string
+  group_name: string | null
+  enabled: boolean
+}
+
+type LeadMagnet = {
+  enabled: boolean
+  keyword: string | null
+  message: string | null
+}
+
 function Toggle({ on, onClick }: { on: boolean; onClick: () => void }) {
   return (
     <button
@@ -183,6 +195,11 @@ export default function Account() {
   const [dmMsg, setDmMsg] = useState<{ ok: boolean; text: string } | null>(null)
   const [newsletter, setNewsletter] = useState<NewsletterSettings | null>(null)
   const [nlMsg, setNlMsg] = useState<{ ok: boolean; text: string } | null>(null)
+  const [groups, setGroups] = useState<UserGroup[]>([])
+  const [groupsInit, setGroupsInit] = useState(false)
+  const [groupsMsg, setGroupsMsg] = useState<{ ok: boolean; text: string } | null>(null)
+  const [leadMagnet, setLeadMagnet] = useState<LeadMagnet | null>(null)
+  const [lmMsg, setLmMsg] = useState<{ ok: boolean; text: string } | null>(null)
 
   // Handle LinkedIn OAuth callback: ?li_connected=1 or ?li_error=... in URL
   useEffect(() => {
@@ -523,6 +540,17 @@ export default function Account() {
     enabled: !!sessionToken,
     staleTime: 60 * 1000,
   })
+
+  // LinkedIn Groups — per-group on/off for LEM engagement
+  const { data: groupsData } = useQuery({
+    queryKey: ['user-groups', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/groups?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as UserGroup[]),
+    enabled: !!sessionToken,
+    staleTime: 60 * 1000,
+  })
   useEffect(() => {
     if (nlData && !newsletter) setNewsletter(nlData)
   }, [nlData])
@@ -540,6 +568,68 @@ export default function Account() {
       setNlMsg({ ok: false, text: 'Could not save — try again.' })
       setTimeout(() => setNlMsg(null), 5000)
     },
+  })
+
+  useEffect(() => {
+    if (groupsData && !groupsInit) {
+      setGroups(groupsData)
+      setGroupsInit(true)
+    }
+  }, [groupsData, groupsInit])
+
+  const toggleGroup = (gid: string) =>
+    setGroups((gs) => gs.map((g) => (g.group_id === gid ? { ...g, enabled: !g.enabled } : g)))
+
+  const groupsMutation = useMutation({
+    mutationFn: () =>
+      api.put('/user/groups', {
+        session_token: sessionToken,
+        groups: Object.fromEntries(groups.map((g) => [g.group_id, g.enabled])),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['user-groups'] })
+      setGroupsMsg({ ok: true, text: 'Saved.' })
+      setTimeout(() => setGroupsMsg(null), 3000)
+    },
+    onError: () => {
+      setGroupsMsg({ ok: false, text: 'Could not save — try again.' })
+      setTimeout(() => setGroupsMsg(null), 5000)
+    },
+  })
+
+  // Lead magnet (comment→DM)
+  const { data: lmData } = useQuery({
+    queryKey: ['lead-magnet', sessionToken],
+    queryFn: () =>
+      api.get(`/user/lead-magnet?session_token=${encodeURIComponent(sessionToken!)}`).then((r) => r.data.detail as LeadMagnet),
+    enabled: !!sessionToken,
+    staleTime: 60 * 1000,
+  })
+  useEffect(() => {
+    if (lmData && !leadMagnet) setLeadMagnet(lmData)
+  }, [lmData])
+  const setLm = (patch: Partial<LeadMagnet>) => setLeadMagnet((p) => (p ? { ...p, ...patch } : p))
+  const lmMutation = useMutation({
+    mutationFn: () => api.put('/user/lead-magnet', { session_token: sessionToken, ...leadMagnet }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['lead-magnet'] })
+      setLmMsg({ ok: true, text: 'Saved.' }); setTimeout(() => setLmMsg(null), 3000)
+    },
+    onError: () => { setLmMsg({ ok: false, text: 'Could not save — try again.' }); setTimeout(() => setLmMsg(null), 5000) },
+  })
+
+  // Personalized best-times-to-post recommendations (read-only)
+  const { data: postStats } = useQuery({
+    queryKey: ['post-stats', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/post-stats?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as {
+          recommendations: { weekday: string; hour: number; avg_engagement: number; sample: number }[]
+          sample_size: number
+        }),
+    enabled: !!sessionToken,
+    staleTime: 5 * 60 * 1000,
   })
 
   // Stripe checkout redirect
@@ -1182,6 +1272,81 @@ export default function Account() {
           <button type="button" onClick={() => nlMutation.mutate()} disabled={nlMutation.isPending}
             className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
             {nlMutation.isPending ? 'Saving…' : 'Save Newsletter Settings'}
+          </button>
+        </div>
+      )}
+
+      {/* Lead magnet card */}
+      {leadMagnet && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <h2 className="text-base font-semibold text-gray-700">Comment → DM Lead Magnet</h2>
+              <p className="text-xs text-gray-500">When someone comments your keyword on your post, auto-DM them a resource. The compliant way to share links (links in posts are penalized).</p>
+            </div>
+            <Toggle on={leadMagnet.enabled} onClick={() => setLm({ enabled: !leadMagnet.enabled })} />
+          </div>
+          {leadMagnet.enabled && (
+            <>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Trigger keyword</label>
+                <input type="text" value={leadMagnet.keyword || ''} onChange={(e) => setLm({ keyword: e.target.value })}
+                  placeholder="e.g. GUIDE" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">DM message (may include your link)</label>
+                <textarea value={leadMagnet.message || ''} onChange={(e) => setLm({ message: e.target.value })} rows={3}
+                  placeholder="Thanks for the interest! Here's the resource: …" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+              </div>
+            </>
+          )}
+          {lmMsg && <p className={`text-sm font-medium ${lmMsg.ok ? 'text-green-600' : 'text-red-600'}`}>{lmMsg.text}</p>}
+          <button type="button" onClick={() => lmMutation.mutate()} disabled={lmMutation.isPending}
+            className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
+            {lmMutation.isPending ? 'Saving…' : 'Save Lead Magnet'}
+          </button>
+        </div>
+      )}
+
+      {/* Best times to post (data-driven) */}
+      {postStats && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-3">
+          <h2 className="text-base font-semibold text-gray-700">Your Best Times to Post</h2>
+          {postStats.recommendations.length > 0 ? (
+            <>
+              <p className="text-xs text-gray-500">Learned from your own post engagement — scheduling leans toward these.</p>
+              <ul className="text-sm text-gray-700 space-y-1">
+                {postStats.recommendations.map((r, i) => (
+                  <li key={i} className="flex justify-between">
+                    <span>{r.weekday} @ {String(r.hour).padStart(2, '0')}:00</span>
+                    <span className="text-gray-400">avg engagement {r.avg_engagement} · {r.sample} post(s)</span>
+                  </li>
+                ))}
+              </ul>
+            </>
+          ) : (
+            <p className="text-xs text-gray-500">Gathering data — recommendations appear after a few posts have engagement stats (currently {postStats.sample_size}).</p>
+          )}
+        </div>
+      )}
+
+      {/* Groups card */}
+      {groupsInit && groups.length > 0 && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
+          <h2 className="text-base font-semibold text-gray-700">LinkedIn Groups</h2>
+          <p className="text-xs text-gray-500">Choose which of your joined groups LEM engages in (value-add comments + occasional posts). All on by default.</p>
+          <div className="divide-y divide-gray-100">
+            {groups.map((g) => (
+              <div key={g.group_id} className="flex items-center justify-between py-2">
+                <span className="text-sm text-gray-700 truncate pr-3">{g.group_name || `Group ${g.group_id}`}</span>
+                <Toggle on={g.enabled} onClick={() => toggleGroup(g.group_id)} />
+              </div>
+            ))}
+          </div>
+          {groupsMsg && <p className={`text-sm font-medium ${groupsMsg.ok ? 'text-green-600' : 'text-red-600'}`}>{groupsMsg.text}</p>}
+          <button type="button" onClick={() => groupsMutation.mutate()} disabled={groupsMutation.isPending}
+            className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
+            {groupsMutation.isPending ? 'Saving…' : 'Save Group Settings'}
           </button>
         </div>
       )}

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -239,6 +239,70 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
     return {"title": parts[0].strip()[:255], "body": (parts[1].strip() if len(parts) > 1 else content.strip())}
 
 
+def generate_group_post(profile: "LinkedInProfile", group_name: str = None, prefs: dict = None) -> "str | None":
+    """A short, value-add post for a LinkedIn Group — a genuine insight or open question for that
+    community, NEVER promotional (groups penalize/moderate self-promo). Ends inviting discussion."""
+    ctx = f"for the LinkedIn group \"{group_name}\"" if group_name else "for a professional LinkedIn group"
+    system_prompt = {
+        "role": "system",
+        "content": f"""You are the profile user posting {ctx}. Write ONE short, genuinely useful
+        post that helps the community: a specific insight, lesson, or an open question that sparks
+        discussion. Absolutely NO self-promotion, NO links, NO hashtags. Sound human, in the user's
+        voice, and end by inviting members to weigh in. Output ONLY the post text.""",
+    }
+    user_prompt = {"role": "user", "content": f"Author profile:\n{profile.model_dump_json()}\n{_style_directive(prefs)}"}
+    response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt],
+                         temperature=round(random.uniform(0.5, 0.7), 2))
+    content = response.choices[0].message.content
+    return content.strip() if content is not None else None
+
+
+def generate_thread_reply(post_content: str, comment_text: str, profile: "LinkedInProfile",
+                          prefs: dict = None) -> "str | None":
+    """Reply to a commenter on the AUTHOR's own post so the thread KEEPS GOING: acknowledge their
+    specific point, add one useful thought, and END with a genuine, easy follow-up question directed
+    back to them. First-hour thread depth is the top 2026 reach signal. Short."""
+    system_prompt = {
+        "role": "system",
+        "content": """You are the post AUTHOR replying to a comment on YOUR OWN post. Keep the
+        conversation going: briefly acknowledge their SPECIFIC point, add ONE useful thought, and END
+        with a genuine, easy-to-answer follow-up question directed back to THEM. Warm, human, in the
+        author's voice, 1–3 sentences. No links, no hashtags, no generic 'thanks for sharing'.""",
+    }
+    user_prompt = {"role": "user", "content":
+        f"Author profile:\n{profile.model_dump_json()}\n\nMy post:\n{post_content}\n\n"
+        f"Their comment:\n{comment_text}\n{_style_directive(prefs)}"}
+    response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt],
+                         temperature=round(random.uniform(0.5, 0.7), 2))
+    content = response.choices[0].message.content
+    return content.strip() if content is not None else None
+
+
+def optimize_post_hook(post_content: str, prefs: dict = None) -> str:
+    """Rewrite a generated post so it opens with a scroll-stopping hook within the first ~210
+    characters (before LinkedIn's '…more' fold) and, when the topic fits, frames it as save-worthy
+    (a framework/checklist) with ONE soft 'save this' invite. Preserves substance + voice. Returns
+    the original text on any failure."""
+    if not post_content:
+        return post_content
+    system_prompt = {
+        "role": "system",
+        "content": """You are a LinkedIn post editor. Rewrite the post so its FIRST LINE is a
+        scroll-stopping hook that lands within the first 210 characters (before the '…more' fold) —
+        a bold claim, a surprising stat, or a sharp question. Keep the author's substance and voice.
+        If the content lends itself to it, shape the body as a save-worthy framework or checklist and
+        add ONE short, soft 'worth saving for later' style invite near the end. NO engagement-bait
+        (no 'comment YES'), NO external links, do not add hashtags. Return ONLY the rewritten post.""",
+    }
+    user_prompt = {"role": "user", "content": post_content}
+    try:
+        response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt], temperature=0.5)
+        out = response.choices[0].message.content
+        return out.strip() if out else post_content
+    except Exception:
+        return post_content
+
+
 def post_is_relevant(post_content: str, include_topics: list) -> bool:
     """LLM relevance gate: is this post about any of the user's include_topics? Used on top of
     literal keyword matching so targeting catches topical fit beyond exact words. Fails OPEN

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2174,6 +2174,204 @@ def get_recent_engagers(user_id: int, days: int = 14) -> set:
         connection.close()
 
 
+def upsert_user_group(user_id: int, group_id: str, group_name: str = None) -> bool:
+    """Record a joined group (new groups default to enabled=1). Refreshes name + last_synced_at
+    without clobbering the user's enabled choice on an existing row."""
+    if not group_id:
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO user_groups (user_id, group_id, group_name, enabled, last_synced_at) "
+            "VALUES (%s,%s,%s,1,NOW()) ON DUPLICATE KEY UPDATE "
+            "group_name=COALESCE(VALUES(group_name), group_name), last_synced_at=NOW()",
+            (user_id, str(group_id), group_name))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not upsert group for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_user_groups(user_id: int) -> list:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT group_id, group_name, enabled FROM user_groups WHERE user_id=%s ORDER BY group_name",
+            (user_id,))
+        rows = cursor.fetchall() or []
+        for r in rows:
+            r["enabled"] = bool(r.get("enabled"))
+        return rows
+    except mysql.connector.Error as err:
+        myprint(f"Could not list groups for user {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_enabled_group_ids(user_id: int) -> list:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT group_id FROM user_groups WHERE user_id=%s AND enabled=1", (user_id,))
+        return [r[0] for r in cursor.fetchall()]
+    except mysql.connector.Error:
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def set_groups_enabled(user_id: int, group_states: dict) -> bool:
+    """Bulk-update per-group enabled flags: {group_id: bool}."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        for gid, enabled in group_states.items():
+            cursor.execute("UPDATE user_groups SET enabled=%s WHERE user_id=%s AND group_id=%s",
+                           (1 if enabled else 0, user_id, str(gid)))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not update group states for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_post_stats(user_id: int, post_id: int, reactions: int, comments: int,
+                      reposts: int = 0, impressions: int = None) -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO post_stats (user_id, post_id, reactions, comments, reposts, impressions) "
+            "VALUES (%s,%s,%s,%s,%s,%s)",
+            (user_id, post_id, int(reactions or 0), int(comments or 0), int(reposts or 0), impressions))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not record post stats for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_recent_posted_post_ids(user_id: int, days: int = 21) -> list:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT id FROM posts WHERE user_id=%s AND status='posted' "
+            "AND scheduled_time >= (NOW() - INTERVAL %s DAY)", (user_id, days))
+        return [r[0] for r in cursor.fetchall()]
+    except mysql.connector.Error:
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_post_engagement_rows(user_id: int) -> list:
+    """Latest stats per post joined with when it was posted → rows of
+    (scheduled_time, reactions, comments, reposts) for post-time analysis."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT p.scheduled_time, s.reactions, s.comments, s.reposts "
+            "FROM posts p JOIN post_stats s ON s.post_id=p.id AND s.user_id=p.user_id "
+            "WHERE p.user_id=%s AND s.id IN "
+            "(SELECT MAX(id) FROM post_stats WHERE user_id=%s GROUP BY post_id)",
+            (user_id, user_id))
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        myprint(f"Could not get post engagement rows for user {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+_LEAD_MAGNET_DEFAULTS: dict = {"enabled": False, "keyword": None, "message": None}
+
+
+def get_lead_magnet_settings(user_id: int) -> dict:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute("SELECT enabled, keyword, message FROM lead_magnet_settings WHERE user_id=%s", (user_id,))
+        row = cursor.fetchone()
+        if row is None:
+            return dict(_LEAD_MAGNET_DEFAULTS)
+        row["enabled"] = bool(row.get("enabled"))
+        return row
+    except mysql.connector.Error as err:
+        myprint(f"Could not get lead magnet for user {user_id} | Error: {err}")
+        return dict(_LEAD_MAGNET_DEFAULTS)
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_lead_magnet_settings(user_id: int, settings: dict) -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO lead_magnet_settings (user_id, enabled, keyword, message) VALUES (%s,%s,%s,%s) "
+            "ON DUPLICATE KEY UPDATE enabled=VALUES(enabled), keyword=VALUES(keyword), message=VALUES(message)",
+            (user_id, 1 if settings.get("enabled") else 0, settings.get("keyword"), settings.get("message")))
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update lead magnet for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def has_received_lead_magnet(user_id: int, recipient_profile: str) -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT 1 FROM lead_magnet_sent WHERE user_id=%s AND recipient_profile=%s LIMIT 1",
+                       (user_id, recipient_profile))
+        return cursor.fetchone() is not None
+    except mysql.connector.Error:
+        return True   # fail safe: assume sent (don't double-DM on error)
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_lead_magnet_sent(user_id: int, recipient_profile: str, post_id: int = None) -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT IGNORE INTO lead_magnet_sent (user_id, recipient_profile, post_id) VALUES (%s,%s,%s)",
+            (user_id, recipient_profile, post_id))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not record lead magnet sent for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
 _NEWSLETTER_DEFAULTS: dict = {
     "enabled": False, "title": None, "topic": None, "cadence": "weekly",
     "align_with_blog": True, "newsletter_url": None, "last_published_at": None,

--- a/src/cqc_lem/utilities/linkedin_formatter.py
+++ b/src/cqc_lem/utilities/linkedin_formatter.py
@@ -44,3 +44,25 @@ def sanitize_for_linkedin(text: str) -> str:
     text = re.sub(r"\n{3,}", "\n\n", text)
 
     return text.strip()
+
+
+# Classic engagement-bait patterns LinkedIn's 2026 algorithm penalizes. Deliberately does NOT match
+# generic "comment <keyword>" so it never strips a legitimate lead-magnet CTA (Phase 4).
+_BAIT_PATTERNS = [
+    r"tag (a friend|someone|three|3|your)",
+    r"like if you",
+    r"(hit|smash)\s+(the\s+)?like",
+    r"double[- ]tap",
+    r"(repost|share)\s+(this\s+)?if",
+    r"comment\s+[\"']?(yes|agree|below|amen|me|👇)\b",
+]
+_BAIT_RE = re.compile("|".join(_BAIT_PATTERNS), re.IGNORECASE)
+
+
+def strip_engagement_bait(text: str) -> str:
+    """Drop lines containing classic engagement-bait CTAs (penalized). Conservative and line-level:
+    bait is almost always its own CTA line, and we avoid touching 'comment <keyword>' lead magnets."""
+    if not text:
+        return text
+    kept = [line for line in text.split("\n") if not _BAIT_RE.search(line)]
+    return re.sub(r"\n{3,}", "\n\n", "\n".join(kept)).strip()

--- a/src/cqc_lem/utilities/post_stats.py
+++ b/src/cqc_lem/utilities/post_stats.py
@@ -1,0 +1,33 @@
+"""Personalized post-time recommendations from captured engagement stats (pure functions)."""
+
+from collections import defaultdict
+
+_WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+
+
+def engagement_score(reactions, comments, reposts=0) -> int:
+    """Weight deeper signals higher (2026: comments/reposts >> likes)."""
+    return int(reactions or 0) + 2 * int(comments or 0) + 2 * int(reposts or 0)
+
+
+def recommend_post_times(rows, top_n: int = 3, min_posts: int = 3) -> list:
+    """rows: iterable of (scheduled_time[datetime], reactions, comments, reposts). Returns the top
+    (weekday, hour) buckets by average engagement per post. Empty until >= min_posts of data so we
+    don't recommend off noise."""
+    buckets = defaultdict(list)
+    n = 0
+    for row in rows:
+        st = row[0]
+        if st is None:
+            continue
+        n += 1
+        reposts = row[3] if len(row) > 3 else 0
+        buckets[(st.weekday(), st.hour)].append(engagement_score(row[1], row[2], reposts))
+    if n < min_posts:
+        return []
+    ranked = sorted(
+        ({"weekday": _WEEKDAYS[wd], "weekday_num": wd, "hour": hr,
+          "avg_engagement": round(sum(v) / len(v), 1), "sample": len(v)}
+         for (wd, hr), v in buckets.items()),
+        key=lambda b: b["avg_engagement"], reverse=True)
+    return ranked[:top_n]

--- a/src/cqc_lem/utilities/utils.py
+++ b/src/cqc_lem/utilities/utils.py
@@ -72,15 +72,17 @@ def get_top_level_domain(url: str) -> str:
 
 
 def get_best_posting_times():
-    # Determine the best time for posting based on the selected date
+    # 2026 peak-engagement windows shifted to afternoons, strongest Tue–Thu (Wed ~4pm is the peak);
+    # weekends taper. Times are user-local (the scheduler converts to UTC). Superseded per-user by
+    # the data-driven recommend_post_times once enough post-stats data exists (see get_post_time).
     best_times = {
-        0: time(14, 0),  # Monday
-        1: time(9, 0),  # Tuesday
-        2: time(12, 0),  # Wednesday
-        3: time(17, 0),  # Thursday
-        4: time(23, 0),  # Friday
-        5: time(7, 0),  # Saturday
-        6: time(9, 0)  # Sunday
+        0: time(16, 0),  # Monday — 4pm
+        1: time(15, 0),  # Tuesday — 3pm
+        2: time(16, 0),  # Wednesday — 4pm (peak)
+        3: time(17, 0),  # Thursday — 5pm
+        4: time(11, 0),  # Friday — late morning (afternoon drop-off into the weekend)
+        5: time(10, 0),  # Saturday — mid-morning
+        6: time(18, 0),  # Sunday — early evening
     }
 
     return best_times
@@ -93,6 +95,25 @@ def get_best_posting_time(selected_date: date):
     best_time = best_times[selected_date.weekday()]
 
     return best_time
+
+
+def get_post_time(selected_date: date, user_id: int = None):
+    """Best posting time for a date. Prefers the user's own data-driven best hour for that weekday
+    (learned by recommend_post_times, Phase 3) and falls back to the 2026 default model until enough
+    data exists. Keeps the default's minutes so times aren't all on the hour."""
+    default = get_best_posting_time(selected_date)
+    if user_id is None:
+        return default
+    try:
+        from cqc_lem.utilities.db import get_post_engagement_rows
+        from cqc_lem.utilities.post_stats import recommend_post_times
+        recs = recommend_post_times(get_post_engagement_rows(user_id), top_n=7)
+        for r in recs:
+            if r["weekday_num"] == selected_date.weekday():
+                return time(r["hour"], default.minute)
+    except Exception:
+        pass
+    return default
 
 
 def get_12h_format_best_time(best_time: time):

--- a/tests/unit/app/test_groups.py
+++ b/tests/unit/app/test_groups.py
@@ -1,0 +1,74 @@
+"""Unit tests for Groups engagement (enumeration, commenting, posting, dispatchers)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+_RS = "cqc_lem.app.run_scheduler"
+_DB = "cqc_lem.utilities.db"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with patch(f"{_RA}.time.sleep"):
+        yield
+
+
+class TestUserGroupsDB:
+    def _conn(self, fetch_all=None, rowcount=1):
+        conn = MagicMock(); cur = MagicMock()
+        cur.fetchall.return_value = fetch_all or []
+        cur.rowcount = rowcount
+        conn.cursor.return_value = cur
+        return conn, cur
+
+    def test_upsert_and_enabled_and_bulk(self):
+        conn, cur = self._conn(fetch_all=[("123",), ("456",)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import upsert_user_group, get_enabled_group_ids, set_groups_enabled
+            assert upsert_user_group(1, "123", "Growth Group") is True
+            assert get_enabled_group_ids(1) == ["123", "456"]
+            assert set_groups_enabled(1, {"123": False, "456": True}) is True
+
+
+class TestSyncUserGroups:
+    def test_upserts_enumerated(self):
+        from cqc_lem.app.run_automation import auto_sync_user_groups
+        with patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}._enumerate_joined_groups", return_value=[("1", "A"), ("2", "B")]), \
+             patch(f"{_RA}.upsert_user_group") as up, patch(f"{_RA}.quit_gracefully"):
+            result = auto_sync_user_groups.run(user_id=1)
+        assert up.call_count == 2 and "Synced 2" in result
+
+
+class TestCommentInGroups:
+    def test_comments_each_enabled_group(self):
+        from cqc_lem.app.run_automation import auto_comment_in_groups
+        with patch(f"{_RA}.get_enabled_group_ids", return_value=["1", "2"]), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_recent_engagers", return_value=set()), \
+             patch(f"{_RA}.comment_on_feed_inline", return_value=1) as cfi, patch(f"{_RA}.quit_gracefully"):
+            result = auto_comment_in_groups.run(user_id=1)
+        assert cfi.call_count == 2 and "across 2 group" in result
+
+    def test_no_enabled_groups(self):
+        from cqc_lem.app.run_automation import auto_comment_in_groups
+        with patch(f"{_RA}.get_enabled_group_ids", return_value=[]), \
+             patch(f"{_RA}.get_current_profile") as gp:
+            result = auto_comment_in_groups.run(user_id=1)
+        assert "No enabled groups" in result
+        gp.assert_not_called()
+
+
+class TestGroupDispatchers:
+    def test_group_engagement_dispatches_connected(self):
+        from cqc_lem.app.run_scheduler import auto_group_engagement
+        with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \
+             patch(f"{_RS}.has_linkedin_session", side_effect=lambda u: u == 1), \
+             patch("cqc_lem.app.run_automation.auto_comment_in_groups") as t:
+            result = auto_group_engagement()
+        t.apply_async.assert_called_once()
+        assert "1/2" in result

--- a/tests/unit/utilities/ai/test_optimize_post_hook.py
+++ b/tests/unit/utilities/ai/test_optimize_post_hook.py
@@ -1,0 +1,35 @@
+"""Unit tests for the hook + save-worthy post pass."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_AI = "cqc_lem.utilities.ai.ai_helper"
+
+
+def _resp(text):
+    r = MagicMock(); r.choices = [MagicMock(message=MagicMock(content=text))]
+    return r
+
+
+class TestOptimizePostHook:
+    def test_returns_rewritten(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("Bold hook.\n\nBody... Save this.")):
+            out = ai_helper.optimize_post_hook("original boring post")
+        assert out.startswith("Bold hook.")
+
+    def test_empty_passthrough(self):
+        from cqc_lem.utilities.ai import ai_helper
+        assert ai_helper.optimize_post_hook("") == ""
+
+    def test_falls_back_to_original_on_error(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", side_effect=RuntimeError("boom")):
+            assert ai_helper.optimize_post_hook("keep me") == "keep me"
+
+    def test_none_llm_content_keeps_original(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp(None)):
+            assert ai_helper.optimize_post_hook("keep me") == "keep me"

--- a/tests/unit/utilities/ai/test_thread_reply.py
+++ b/tests/unit/utilities/ai/test_thread_reply.py
@@ -1,0 +1,28 @@
+"""Unit tests for the thread-building reply generator (P7)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_AI = "cqc_lem.utilities.ai.ai_helper"
+
+
+def _resp(text):
+    r = MagicMock(); r.choices = [MagicMock(message=MagicMock(content=text))]
+    return r
+
+
+class TestGenerateThreadReply:
+    def test_returns_reply(self):
+        from cqc_lem.utilities.ai import ai_helper
+        prof = MagicMock(); prof.model_dump_json.return_value = "{}"
+        with patch(f"{_AI}._call_llm", return_value=_resp("Great point — what led you there?")):
+            out = ai_helper.generate_thread_reply("my post", "their comment", prof)
+        assert out.endswith("?")
+
+    def test_none_when_empty(self):
+        from cqc_lem.utilities.ai import ai_helper
+        prof = MagicMock(); prof.model_dump_json.return_value = "{}"
+        with patch(f"{_AI}._call_llm", return_value=_resp(None)):
+            assert ai_helper.generate_thread_reply("p", "c", prof) is None

--- a/tests/unit/utilities/test_db_lead_magnet.py
+++ b/tests/unit/utilities/test_db_lead_magnet.py
@@ -1,0 +1,51 @@
+"""Unit tests for lead-magnet DB helpers."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(fetch_row=None, fetch_one=None):
+    conn = MagicMock(); cur = MagicMock()
+    cur.fetchone.return_value = fetch_row if fetch_row is not None else fetch_one
+    cur.rowcount = 1
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestLeadMagnet:
+    def test_defaults_when_no_row(self):
+        conn, _ = _conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_lead_magnet_settings
+            s = get_lead_magnet_settings(1)
+        assert s["enabled"] is False and s["keyword"] is None
+
+    def test_update_upserts(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_lead_magnet_settings
+            assert update_lead_magnet_settings(1, {"enabled": True, "keyword": "GUIDE", "message": "here"}) is True
+        assert "ON DUPLICATE KEY UPDATE" in cur.execute.call_args[0][0]
+
+    def test_has_received_true_when_row(self):
+        conn, _ = _conn(fetch_one=(1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_received_lead_magnet
+            assert has_received_lead_magnet(1, "https://x/in/jane") is True
+
+    def test_has_received_false_when_none(self):
+        conn, _ = _conn(fetch_one=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_received_lead_magnet
+            assert has_received_lead_magnet(1, "https://x/in/new") is False
+
+    def test_record_sent(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_lead_magnet_sent
+            assert record_lead_magnet_sent(1, "https://x/in/jane", 9) is True
+        assert "INSERT IGNORE INTO lead_magnet_sent" in cur.execute.call_args[0][0]

--- a/tests/unit/utilities/test_guardrails_and_peaktime.py
+++ b/tests/unit/utilities/test_guardrails_and_peaktime.py
@@ -1,0 +1,49 @@
+"""Unit tests for P6 — engagement-bait guardrail + peak-time model + data-driven override."""
+
+import datetime as dt
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+class TestStripEngagementBait:
+    def test_removes_bait_lines(self):
+        from cqc_lem.utilities.linkedin_formatter import strip_engagement_bait
+        text = "Great insight here.\nComment YES if you agree!\nTag a friend who needs this.\nReal value line."
+        out = strip_engagement_bait(text)
+        assert "Great insight here." in out and "Real value line." in out
+        assert "YES" not in out and "Tag a friend" not in out
+
+    def test_keeps_lead_magnet_cta(self):
+        from cqc_lem.utilities.linkedin_formatter import strip_engagement_bait
+        text = "Here's my framework.\nComment GUIDE and I'll send you the full checklist."
+        out = strip_engagement_bait(text)
+        assert "Comment GUIDE" in out  # lead-magnet CTA preserved
+
+    def test_empty_passthrough(self):
+        from cqc_lem.utilities.linkedin_formatter import strip_engagement_bait
+        assert strip_engagement_bait("") == ""
+
+
+class TestPeakTimeModel:
+    def test_afternoon_shift(self):
+        from cqc_lem.utilities.utils import get_best_posting_times
+        bt = get_best_posting_times()
+        assert bt[2].hour == 16          # Wednesday peak = 4pm
+        assert all(9 <= bt[d].hour <= 20 for d in (0, 1, 2, 3))  # weekday afternoons
+
+
+class TestGetPostTime:
+    def test_falls_back_to_default_without_user(self):
+        from cqc_lem.utilities.utils import get_post_time, get_best_posting_time
+        d = dt.date(2026, 7, 8)  # Wednesday
+        assert get_post_time(d) == get_best_posting_time(d)
+
+    def test_uses_data_driven_hour(self):
+        from cqc_lem.utilities import utils
+        d = dt.date(2026, 7, 8)  # Wednesday (weekday 2)
+        recs = [{"weekday_num": 2, "hour": 19, "avg_engagement": 50, "sample": 4}]
+        with patch("cqc_lem.utilities.db.get_post_engagement_rows", return_value=[("x",)] * 4), \
+             patch("cqc_lem.utilities.post_stats.recommend_post_times", return_value=recs):
+            assert utils.get_post_time(d, user_id=1).hour == 19

--- a/tests/unit/utilities/test_post_stats.py
+++ b/tests/unit/utilities/test_post_stats.py
@@ -1,0 +1,58 @@
+"""Unit tests for post-time recommendation logic."""
+
+import datetime as dt
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestEngagementScore:
+    def test_weights_comments_and_reposts(self):
+        from cqc_lem.utilities.post_stats import engagement_score
+        assert engagement_score(10, 0, 0) == 10
+        assert engagement_score(0, 5, 0) == 10          # comments ×2
+        assert engagement_score(0, 0, 3) == 6           # reposts ×2
+
+
+class TestRecommendPostTimes:
+    def _row(self, weekday, hour, reactions, comments):
+        # 2026-07-06 is a Monday; add days to hit the desired weekday
+        base = dt.datetime(2026, 7, 6, hour, 0)  # Monday
+        return (base + dt.timedelta(days=weekday), reactions, comments, 0)
+
+    def test_empty_below_min_posts(self):
+        from cqc_lem.utilities.post_stats import recommend_post_times
+        assert recommend_post_times([self._row(0, 9, 5, 1)], min_posts=3) == []
+
+    def test_ranks_best_bucket_first(self):
+        from cqc_lem.utilities.post_stats import recommend_post_times
+        rows = [
+            self._row(2, 16, 50, 10),   # Wed 16:00 — high
+            self._row(2, 16, 40, 8),
+            self._row(0, 9, 5, 0),      # Mon 09:00 — low
+            self._row(0, 9, 6, 1),
+        ]
+        recs = recommend_post_times(rows, top_n=2, min_posts=3)
+        assert recs[0]["weekday"] == "Wednesday" and recs[0]["hour"] == 16
+        assert recs[0]["avg_engagement"] > recs[1]["avg_engagement"]
+
+    def test_none_scheduled_time_skipped(self):
+        from cqc_lem.utilities.post_stats import recommend_post_times
+        rows = [(None, 100, 100, 0)] + [self._row(3, 17, 20, 5) for _ in range(3)]
+        recs = recommend_post_times(rows, min_posts=3)
+        assert recs and recs[0]["weekday"] == "Thursday"
+
+
+class TestScrapeStatsTask:
+    def test_records_each_post(self):
+        from unittest.mock import MagicMock, patch
+        _RA = "cqc_lem.app.run_automation"
+        with patch(f"{_RA}.time.sleep"), \
+             patch(f"{_RA}.get_recent_posted_post_ids", return_value=[9, 10]), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://x/urn"), \
+             patch(f"{_RA}._post_social_counts", return_value={"reactions": 12, "comments": 3}), \
+             patch(f"{_RA}.record_post_stats") as rec, patch(f"{_RA}.quit_gracefully"):
+            from cqc_lem.app.run_automation import auto_scrape_post_stats
+            result = auto_scrape_post_stats.run(user_id=1)
+        assert rec.call_count == 2 and "Scraped stats for 2" in result

--- a/tests/unit/utilities/test_utils.py
+++ b/tests/unit/utilities/test_utils.py
@@ -37,21 +37,21 @@ class TestGetBestPostingTimes:
         for t in get_best_posting_times().values():
             assert isinstance(t, datetime.time)
 
-    def test_monday_is_14_00(self):
+    def test_monday_is_16_00(self):
         from cqc_lem.utilities.utils import get_best_posting_times
-        assert get_best_posting_times()[0] == datetime.time(14, 0)
+        assert get_best_posting_times()[0] == datetime.time(16, 0)  # 2026 afternoon-peak model
 
 
 class TestGetBestPostingTime:
-    def test_monday_returns_14_00(self):
+    def test_monday_returns_16_00(self):
         from cqc_lem.utilities.utils import get_best_posting_time
         monday = datetime.date(2024, 1, 1)  # weekday() == 0
-        assert get_best_posting_time(monday) == datetime.time(14, 0)
+        assert get_best_posting_time(monday) == datetime.time(16, 0)
 
-    def test_tuesday_returns_09_00(self):
+    def test_wednesday_returns_16_00(self):
         from cqc_lem.utilities.utils import get_best_posting_time
-        tuesday = datetime.date(2024, 1, 2)  # weekday() == 1
-        assert get_best_posting_time(tuesday) == datetime.time(9, 0)
+        wednesday = datetime.date(2024, 1, 3)  # weekday() == 2 (peak day)
+        assert get_best_posting_time(wednesday) == datetime.time(16, 0)
 
     def test_all_weekdays_return_time(self):
         from cqc_lem.utilities.utils import get_best_posting_time


### PR DESCRIPTION
Consolidated, conflict-resolved delivery of growth-roadmap phases **2–7** (rebased clean onto main after Newsletter #254 merged). Supersedes the stacked #256/#257.

| Phase | What |
|---|---|
| **P2 Groups** (V41) | per-group on/off (all-on default) · scored group commenting · value-add group posts · weekly sync · Groups card |
| **P3 Stats** (V42) | `post_stats` scraper · `recommend_post_times` (data-driven best hours) · `/user/post-stats` · Best-Times panel |
| **P4 Lead magnet** (V43) | keyword-in-comment → auto-DM resource (dedupe), hooked into own-post reply pass · config card |
| **P5 Hook/save** | `optimize_post_hook` in content generation |
| **P6 Guardrails** | `strip_engagement_bait` · 2026 afternoon peak-time model · data-driven `get_post_time` in the content plan |
| **P7 Thread-builder** | `generate_thread_reply` — own-post replies end with a follow-up question |

**1197 unit tests green; tsc clean.** Migrations V41–V43. Selenium selectors (group composer, post-stats scrape, group enumeration) get grounded in the end-of-roadmap live pass, per plan (live testing after all phases).

Depends on: #252 (seed) + #254 (newsletter, merged). Merge #252 first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)