### PR TITLE
fix(engagement): ground group + post-stats selectors from live sweep

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -410,7 +410,10 @@ def check_commented(driver, wait, user_id: int = None, post_url: str = None):
 # feed-shared-* / comments-comment-* classes and permalink navigation are gone. Posts are now
 # anchored by stable data-testid / aria-label attributes and commenting happens INLINE on the
 # feed card (no per-post permalink). Verified live 2026-07-03.
-_FEED_POST_TEXT_SEL = "[data-testid='expandable-text-box']"
+# SDUI home feed uses data-testid='expandable-text-box'; classic Group feeds still render posts as
+# feed-shared-update-v2 with .update-components-text — include both so group commenting finds posts.
+# Content-hash dedup (_feed_post_key) covers any overlap between the two selectors on a page.
+_FEED_POST_TEXT_SEL = "[data-testid='expandable-text-box'], .feed-shared-update-v2 .update-components-text"
 
 
 def _card_for_textbox(driver, box):
@@ -441,6 +444,7 @@ _AGE_UNIT_MIN = {"s": 0, "m": 1, "h": 60, "d": 1440, "w": 10080, "mo": 43200, "y
 _AGE_TOKEN_RE = re.compile(r"^(\d+)\s?(mo|[smhdwy])", re.I)
 _COMMENTS_RE = re.compile(r"([\d,]+)\s+comments?", re.I)
 _REACTIONS_RE = re.compile(r"([\d,]+)\s+(?:reactions?|likes?)", re.I)
+_IMPRESSIONS_RE = re.compile(r"([\d,]+)\s+impressions?", re.I)
 
 
 def _post_age_minutes(driver, card) -> "int | None":
@@ -467,18 +471,20 @@ def _post_age_minutes(driver, card) -> "int | None":
 
 
 def _post_social_counts(card) -> dict:
-    """Best-effort reaction/comment counts parsed from the card's social-counts bar text. Returns
-    {reactions, comments} (0 on miss) — used only for the low-weight 'activity' scoring signal."""
+    """Best-effort reaction/comment/impression counts parsed from the card's social-counts bar text.
+    Returns {reactions, comments, impressions} (0 on miss). Impressions show only on the author's own
+    post detail page; reactions/comments feed the low-weight feed 'activity' scoring signal."""
     try:
         text = card.text or ""
     except Exception:
-        return {"reactions": 0, "comments": 0}
+        return {"reactions": 0, "comments": 0, "impressions": 0}
 
     def _num(rx):
         m = rx.search(text)
         return int(m.group(1).replace(",", "")) if m else 0
 
-    return {"reactions": _num(_REACTIONS_RE), "comments": _num(_COMMENTS_RE)}
+    return {"reactions": _num(_REACTIONS_RE), "comments": _num(_COMMENTS_RE),
+            "impressions": _num(_IMPRESSIONS_RE)}
 
 
 # Feed-post prioritization weights (tunable). Recency dominates: golden-hour posts get 4–10× the
@@ -948,8 +954,9 @@ def auto_scrape_post_stats(self, user_id: int):
                 container = driver.find_element(By.TAG_NAME, "main")
             except Exception:
                 container = None
-            counts = _post_social_counts(container) if container is not None else {"reactions": 0, "comments": 0}
-            record_post_stats(user_id, pid, counts["reactions"], counts["comments"])
+            counts = _post_social_counts(container) if container is not None else {"reactions": 0, "comments": 0, "impressions": 0}
+            record_post_stats(user_id, pid, counts["reactions"], counts["comments"],
+                              impressions=counts.get("impressions") or None)
             scraped += 1
         return f"Scraped stats for {scraped} post(s)"
     finally:
@@ -1039,7 +1046,10 @@ def auto_post_to_group(self, user_id: int, group_id: str):
         if not text.strip():
             return "No group post generated"
         # Open the group share box, type, and post (best-effort SDUI selectors).
-        if click_first(driver, wait, [(By.XPATH, "//button[contains(normalize-space(),'Start a post') or contains(@aria-label,'Start a post') or contains(@aria-label,'Create a post')]")],
+        if click_first(driver, wait, [(By.XPATH,
+                "//button[contains(normalize-space(),'Start a post') or contains(normalize-space(),'Start a public post') "
+                "or contains(@aria-label,'Start a post') or contains(@aria-label,'Create a post') "
+                "or (contains(normalize-space(),'Start a') and contains(normalize-space(),'post'))]")],
                        "Group share box", required=False) is None:
             return "Group share box not found"
         time.sleep(random.uniform(2, 3))

--- a/tests/unit/app/test_feed_signals.py
+++ b/tests/unit/app/test_feed_signals.py
@@ -32,8 +32,13 @@ class TestPostSocialCounts:
     def test_parses_comments_and_reactions(self):
         from cqc_lem.app.run_automation import _post_social_counts
         card = self._card("Jane Doe\n3h •\nGreat post body\n1,204 reactions\n8 comments • 2 reposts")
-        assert _post_social_counts(card) == {"reactions": 1204, "comments": 8}
+        assert _post_social_counts(card) == {"reactions": 1204, "comments": 8, "impressions": 0}
 
     def test_zero_when_no_counts(self):
         from cqc_lem.app.run_automation import _post_social_counts
-        assert _post_social_counts(self._card("Just a fresh post with no engagement yet")) == {"reactions": 0, "comments": 0}
+        assert _post_social_counts(self._card("Just a fresh post with no engagement yet")) == {"reactions": 0, "comments": 0, "impressions": 0}
+
+    def test_parses_impressions_on_own_post(self):
+        from cqc_lem.app.run_automation import _post_social_counts
+        card = self._card("Post impressions\n153 impressions\n5 reactions\n2 comments")
+        assert _post_social_counts(card) == {"reactions": 5, "comments": 2, "impressions": 153}

--- a/tests/unit/app/test_sweep_fixes.py
+++ b/tests/unit/app/test_sweep_fixes.py
@@ -1,0 +1,46 @@
+"""Unit tests for the live-sweep selector/parse fixes (groups + post-stats impressions)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+
+class _Card:
+    def __init__(self, text): self.text = text
+
+
+class TestSocialCountsImpressions:
+    def test_captures_impressions_and_counts(self):
+        from cqc_lem.app.run_automation import _post_social_counts
+        c = _post_social_counts(_Card("Post impressions\n153 impressions\n5 reactions\n2 comments"))
+        assert c == {"reactions": 5, "comments": 2, "impressions": 153}
+
+    def test_quiet_post_has_only_impressions(self):
+        from cqc_lem.app.run_automation import _post_social_counts
+        c = _post_social_counts(_Card("Post impressions\n137 impressions"))
+        assert c["impressions"] == 137 and c["reactions"] == 0 and c["comments"] == 0
+
+
+class TestGroupFeedSelector:
+    def test_selector_covers_classic_group_feed(self):
+        from cqc_lem.app.run_automation import _FEED_POST_TEXT_SEL
+        # SDUI home feed AND classic group feed containers both covered
+        assert "expandable-text-box" in _FEED_POST_TEXT_SEL
+        assert "feed-shared-update-v2" in _FEED_POST_TEXT_SEL
+
+
+class TestScrapeRecordsImpressions:
+    def test_impressions_passed_to_record(self):
+        with patch(f"{_RA}.time.sleep"), \
+             patch(f"{_RA}.get_recent_posted_post_ids", return_value=[9]), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://x/urn"), \
+             patch(f"{_RA}._post_social_counts", return_value={"reactions": 5, "comments": 2, "impressions": 153}), \
+             patch(f"{_RA}.record_post_stats") as rec, patch(f"{_RA}.quit_gracefully"):
+            from cqc_lem.app.run_automation import auto_scrape_post_stats
+            auto_scrape_post_stats.run(user_id=1)
+        # record_post_stats(user_id, pid, reactions, comments, impressions=153)
+        assert rec.call_args.kwargs.get("impressions") == 153


### PR DESCRIPTION
Live-validation sweep on the real account (v0.23.0) found 3 selector/parse gaps — all fixed and re-validated live:

- **Group feeds** are classic `feed-shared-update-v2` (not SDUI) → commenting engine found 0 posts. Broadened `_FEED_POST_TEXT_SEL` to also match `.feed-shared-update-v2 .update-components-text` (home feed unaffected; dedup covers overlap). **Live: 0 → 3 posts found.**
- **Group composer** button is 'Start a public post' → `auto_post_to_group` now matches it. **Live: composer/editor opens.**
- **Post-stats** read 0/0 because those posts only have impressions → `_post_social_counts` now also parses impressions and records them. **Live: 153/137 impressions captured.**

Enumeration (55 groups) + newsletter editor were already clean. 14 unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)