### PR TITLE
fix(dashboard): correct stale top stats via SQL aggregates

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -18,7 +18,7 @@ from celery import chain as celery_chain
 from cqc_lem.app.run_content_plan import auto_create_weekly_content, plan_content_for_user
 from cqc_lem.utilities.db import (
     insert_post, get_post_by_email, get_user_id, update_db_post, get_post_user_id,
-    add_user_with_access_token, update_user, PostType, PostStatus, get_posts,
+    add_user_with_access_token, update_user, PostType, PostStatus, get_posts, get_dashboard_counts,
     get_recent_logs, bulk_update_posts, soft_delete_posts,
     create_pin_for_email, verify_pin_for_email, delete_pin_for_email,
     create_session, get_session_user_id, delete_session,
@@ -425,26 +425,16 @@ def get_dashboard_stats(email: str) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=403, detail="User not found")
 
-    posts, _ = get_posts(user_id)
     now = datetime.now(timezone.utc)
     week_start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     # Back up to Monday. Use timedelta, not replace(day=...): naive day subtraction
     # goes out of range in the first days of a month (e.g. Wed the 1st → day=-1).
     week_start = week_start - timedelta(days=week_start.weekday())
 
-    scheduled_this_week = sum(
-        1 for p in posts
-        if p.get("status") in (PostStatus.APPROVED, PostStatus.PENDING)
-        and p.get("scheduled_time") and p["scheduled_time"] >= week_start
-    )
-    pending_review = sum(1 for p in posts if p.get("status") == PostStatus.PENDING)
-    posted_total = sum(1 for p in posts if p.get("status") == PostStatus.POSTED)
-
-    stats: Dict[str, int] = {
-        "scheduled_this_week": scheduled_this_week,
-        "pending_review": pending_review,
-        "posted_total": posted_total,
-    }
+    # SQL aggregates over ALL posts — the old code counted in Python over get_posts()'s 10-oldest
+    # slice, so 'posted' capped near 10 and 'scheduled this week' read ~0 (and a naive/aware
+    # datetime compare could 500 the endpoint → all-zeros fallback in the UI).
+    stats: Dict[str, int] = get_dashboard_counts(user_id, week_start)
     return ResponseModel(status_code=200, detail=stats)
 
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -567,6 +567,36 @@ def get_posts(user_id: int, limit: int = 10, offset: int = 0,
     return posts, total
 
 
+def get_dashboard_counts(user_id: int, week_start) -> dict:
+    """Dashboard top-line counts via SQL aggregates over ALL of the user's posts. Replaces the old
+    approach of counting in Python over get_posts()'s 10-oldest-posts slice (which made 'posted'
+    cap near 10 and 'scheduled this week' read ~0). week_start is coerced to a naive UTC datetime so
+    it compares cleanly against the naive UTC scheduled_time column (no tz TypeError)."""
+    if week_start is not None and getattr(week_start, "tzinfo", None) is not None:
+        week_start = week_start.astimezone(timezone.utc).replace(tzinfo=None)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT "
+            "  COALESCE(SUM(status IN (%s,%s) AND scheduled_time >= %s), 0) AS scheduled_this_week, "
+            "  COALESCE(SUM(status = %s), 0) AS pending_review, "
+            "  COALESCE(SUM(status = %s), 0) AS posted_total "
+            "FROM posts WHERE user_id = %s",
+            (PostStatus.APPROVED.value, PostStatus.PENDING.value, week_start,
+             PostStatus.PENDING.value, PostStatus.POSTED.value, user_id))
+        row = cursor.fetchone()
+        return {"scheduled_this_week": int(row[0] or 0),
+                "pending_review": int(row[1] or 0),
+                "posted_total": int(row[2] or 0)}
+    except mysql.connector.Error as err:
+        myprint(f"Could not get dashboard counts for user {user_id} | Error: {err}")
+        return {"scheduled_this_week": 0, "pending_review": 0, "posted_total": 0}
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_posted_posts(user_id: int):
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -52,15 +52,14 @@ class TestDashboardStats:
             resp = client.get(self.BASE, params={"email": "ghost@example.com"})
         assert resp.status_code == 403
 
+    _ZEROS = {"scheduled_this_week": 0, "pending_review": 0, "posted_total": 0}
+
     def test_known_user_with_no_posts_returns_zeros(self, client):
         with patch(f"{_MAIN}.get_user_id", return_value=1), \
-             patch(f"{_MAIN}.get_posts", return_value=([], 0)):
+             patch(f"{_MAIN}.get_dashboard_counts", return_value=dict(self._ZEROS)):
             resp = client.get(self.BASE, params={"email": "user@example.com"})
         assert resp.status_code == 200
-        detail = resp.json()["detail"]
-        assert detail["scheduled_this_week"] == 0
-        assert detail["pending_review"] == 0
-        assert detail["posted_total"] == 0
+        assert resp.json()["detail"] == self._ZEROS
 
     def test_start_of_month_does_not_crash(self, client):
         # Regression: week_start was computed with replace(day=day-weekday()), which
@@ -71,25 +70,23 @@ class TestDashboardStats:
                 return datetime(2026, 7, 1, tzinfo=tz)  # Wednesday the 1st
 
         with patch(f"{_MAIN}.get_user_id", return_value=1), \
-             patch(f"{_MAIN}.get_posts", return_value=([], 0)), \
+             patch(f"{_MAIN}.get_dashboard_counts", return_value=dict(self._ZEROS)), \
              patch(f"{_MAIN}.datetime", _FixedDatetime):
             resp = client.get(self.BASE, params={"email": "user@example.com"})
         assert resp.status_code == 200
 
-    def test_posted_total_counted_correctly(self, client):
-        from cqc_lem.utilities.db import PostStatus
-        posts = [
-            {"status": PostStatus.POSTED, "scheduled_time": None},
-            {"status": PostStatus.POSTED, "scheduled_time": None},
-            {"status": PostStatus.PENDING, "scheduled_time": None},
-        ]
+    def test_returns_counts_from_db_helper_over_all_posts(self, client):
+        # The endpoint now delegates to the SQL-aggregate helper (counts over ALL posts, not the
+        # 10-oldest get_posts() slice that made these stale). It passes a tz-aware Monday week_start.
+        counts = {"scheduled_this_week": 4, "pending_review": 1, "posted_total": 37}
         with patch(f"{_MAIN}.get_user_id", return_value=1), \
-             patch(f"{_MAIN}.get_posts", return_value=(posts, 3)):
+             patch(f"{_MAIN}.get_dashboard_counts", return_value=counts) as gdc:
             resp = client.get(self.BASE, params={"email": "user@example.com"})
         assert resp.status_code == 200
-        detail = resp.json()["detail"]
-        assert detail["posted_total"] == 2
-        assert detail["pending_review"] == 1
+        assert resp.json()["detail"] == counts
+        user_id_arg, week_start_arg = gdc.call_args[0][0], gdc.call_args[0][1]
+        assert user_id_arg == 1
+        assert week_start_arg.weekday() == 0 and week_start_arg.hour == 0  # Monday 00:00
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utilities/test_db_dashboard.py
+++ b/tests/unit/utilities/test_db_dashboard.py
@@ -1,0 +1,45 @@
+"""Unit tests for get_dashboard_counts (SQL-aggregate dashboard stats)."""
+
+import datetime
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(row):
+    conn = MagicMock(); cur = MagicMock()
+    cur.fetchone.return_value = row
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestGetDashboardCounts:
+    def test_aggregates_returned(self):
+        conn, cur = _conn((4, 1, 37))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_dashboard_counts
+            out = get_dashboard_counts(1, datetime.datetime(2026, 7, 6))
+        assert out == {"scheduled_this_week": 4, "pending_review": 1, "posted_total": 37}
+        # single aggregate query, not a paginated fetch
+        assert "SUM(" in cur.execute.call_args[0][0] and "LIMIT" not in cur.execute.call_args[0][0]
+
+    def test_tz_aware_week_start_coerced_to_naive(self):
+        conn, cur = _conn((0, 0, 0))
+        aware = datetime.datetime(2026, 7, 6, tzinfo=datetime.timezone.utc)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_dashboard_counts
+            get_dashboard_counts(1, aware)
+        # the week_start param passed to SQL must be tz-naive (avoids naive/aware compare error)
+        params = cur.execute.call_args[0][1]
+        passed_week_start = params[2]
+        assert passed_week_start.tzinfo is None
+
+    def test_null_sums_become_zero(self):
+        conn, _ = _conn((None, None, None))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_dashboard_counts
+            assert get_dashboard_counts(1, datetime.datetime(2026, 7, 6)) == {
+                "scheduled_this_week": 0, "pending_review": 0, "posted_total": 0}


### PR DESCRIPTION
**Bug:** the dashboard's top stat cards (scheduled-this-week / pending-review / total-posted) were counted in Python over `get_posts(user_id)`, which defaults to the **10 oldest posts** (`ORDER BY scheduled_time ASC LIMIT 10`). So 'total posted' capped near 10 and 'scheduled this week' (newest posts, past the window) read ~0 — the stale/incorrect values reported. A naive-vs-aware datetime compare could also 500 the endpoint → all-zeros fallback.

**Fix:** new `get_dashboard_counts()` — a single SQL aggregate over **all** posts, with `week_start` coerced to naive UTC (no tz TypeError). Endpoint delegates to it.

32 unit tests (endpoint delegation asserts Monday-00:00 week_start; SQL-aggregate helper asserts no LIMIT, tz-naive param, NULL→0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)