### PR TITLE
fix(feed): log real /feed/update/ permalinks so activity feed links work

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -439,6 +439,19 @@ def _feed_post_key(author: str, content: str) -> str:
     return f"feedpost://{digest}"
 
 
+def _post_permalink_from_card(card):
+    """Real LinkedIn permalink for a feed post, read from its /feed/update/ anchor (the SDUI
+    card has no data-urn). Returns a normalized https URL or None."""
+    try:
+        for a in card.find_elements(By.CSS_SELECTOR, "a[href*='/feed/update/']"):
+            href = (a.get_attribute("href") or "").split("?")[0]
+            if "/feed/update/" in href:
+                return href.rstrip("/") + "/"
+        return None
+    except Exception:
+        return None
+
+
 # Relative-age units → minutes. The SDUI card shows a token like "3h •", "5d •", "2w •", "10mo •".
 _AGE_UNIT_MIN = {"s": 0, "m": 1, "h": 60, "d": 1440, "w": 10080, "mo": 43200, "y": 525600}
 _AGE_TOKEN_RE = re.compile(r"^(\d+)\s?(mo|[smhdwy])", re.I)
@@ -715,7 +728,9 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             if card is None:
                 continue
             author = _post_author_from_card(card)
-            key = _feed_post_key(author, content)
+            # Prefer the real /feed/update/ permalink so the logged post_url links correctly;
+            # fall back to the synthetic hash for cards that expose no anchor.
+            key = _post_permalink_from_card(card) or _feed_post_key(author, content)
             if key in seen:
                 continue
             if has_user_commented_on_post_url(user_id, key) or not _passes_hard_excludes(content, author, prefs):

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import api from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
 import { formatInTimezone } from '../utils/datetime'
+import { isHttpUrl } from '../utils/links'
 
 interface PostStats {
   recommendations: { weekday: string; hour: number; avg_engagement: number; sample: number }[]
@@ -220,16 +221,19 @@ export default function Dashboard() {
                     {entry.message && (
                       <p className="text-xs text-gray-500 mt-0.5 line-clamp-1">{entry.message}</p>
                     )}
-                    {entry.post_url && (
-                      <a
-                        href={entry.post_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-xs text-blue-500 hover:underline truncate block"
-                      >
-                        {entry.post_url}
-                      </a>
-                    )}
+                    {entry.post_url &&
+                      (isHttpUrl(entry.post_url) ? (
+                        <a
+                          href={entry.post_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-xs text-blue-500 hover:underline truncate block"
+                        >
+                          {entry.post_url}
+                        </a>
+                      ) : (
+                        <span className="text-xs text-gray-400 truncate block">{entry.post_url}</span>
+                      ))}
                   </div>
                   <span className="text-xs text-gray-400 flex-shrink-0 whitespace-nowrap">
                     {formatInTimezone(entry.created_at, userTimezone)}

--- a/src/cqc_lem/ui/src/utils/links.ts
+++ b/src/cqc_lem/ui/src/utils/links.ts
@@ -1,0 +1,5 @@
+// Only http(s) values are safe to render as a clickable link. Legacy activity rows may carry a
+// synthetic dedup key (e.g. "feedpost://<hash>") as post_url — those must render as plain text.
+export function isHttpUrl(value: string | null | undefined): boolean {
+  return typeof value === 'string' && /^https?:\/\//i.test(value)
+}

--- a/tests/unit/app/test_feed_permalink.py
+++ b/tests/unit/app/test_feed_permalink.py
@@ -3,7 +3,14 @@
 import pytest
 from unittest.mock import MagicMock
 
-from cqc_lem.app.run_automation import _post_permalink_from_card
+pytestmark = pytest.mark.unit
+
+
+def _fn():
+    # Lazy import: importing run_automation at module scope instantiates the OpenAI client at
+    # collection time, which fails in CI (no OPENAI_API_KEY). Match the codebase's in-test pattern.
+    from cqc_lem.app.run_automation import _post_permalink_from_card
+    return _post_permalink_from_card
 
 
 def _anchor(href):
@@ -12,34 +19,27 @@ def _anchor(href):
     return a
 
 
-@pytest.mark.unit
 class TestPostPermalinkFromCard:
     def test_returns_normalized_permalink_stripping_query(self):
         card = MagicMock()
         card.find_elements.return_value = [
             _anchor("https://www.linkedin.com/feed/update/urn:li:ugcPost:123/?utm=1&x=2")
         ]
-        assert (
-            _post_permalink_from_card(card)
-            == "https://www.linkedin.com/feed/update/urn:li:ugcPost:123/"
-        )
+        assert _fn()(card) == "https://www.linkedin.com/feed/update/urn:li:ugcPost:123/"
 
     def test_appends_trailing_slash_when_missing(self):
         card = MagicMock()
         card.find_elements.return_value = [
             _anchor("https://www.linkedin.com/feed/update/urn:li:ugcPost:456")
         ]
-        assert (
-            _post_permalink_from_card(card)
-            == "https://www.linkedin.com/feed/update/urn:li:ugcPost:456/"
-        )
+        assert _fn()(card) == "https://www.linkedin.com/feed/update/urn:li:ugcPost:456/"
 
     def test_returns_none_when_no_anchor(self):
         card = MagicMock()
         card.find_elements.return_value = []
-        assert _post_permalink_from_card(card) is None
+        assert _fn()(card) is None
 
     def test_returns_none_on_exception(self):
         card = MagicMock()
         card.find_elements.side_effect = RuntimeError("stale element")
-        assert _post_permalink_from_card(card) is None
+        assert _fn()(card) is None

--- a/tests/unit/app/test_feed_permalink.py
+++ b/tests/unit/app/test_feed_permalink.py
@@ -1,0 +1,45 @@
+"""Unit tests for _post_permalink_from_card — reading real /feed/update/ permalinks off SDUI cards."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from cqc_lem.app.run_automation import _post_permalink_from_card
+
+
+def _anchor(href):
+    a = MagicMock()
+    a.get_attribute.return_value = href
+    return a
+
+
+@pytest.mark.unit
+class TestPostPermalinkFromCard:
+    def test_returns_normalized_permalink_stripping_query(self):
+        card = MagicMock()
+        card.find_elements.return_value = [
+            _anchor("https://www.linkedin.com/feed/update/urn:li:ugcPost:123/?utm=1&x=2")
+        ]
+        assert (
+            _post_permalink_from_card(card)
+            == "https://www.linkedin.com/feed/update/urn:li:ugcPost:123/"
+        )
+
+    def test_appends_trailing_slash_when_missing(self):
+        card = MagicMock()
+        card.find_elements.return_value = [
+            _anchor("https://www.linkedin.com/feed/update/urn:li:ugcPost:456")
+        ]
+        assert (
+            _post_permalink_from_card(card)
+            == "https://www.linkedin.com/feed/update/urn:li:ugcPost:456/"
+        )
+
+    def test_returns_none_when_no_anchor(self):
+        card = MagicMock()
+        card.find_elements.return_value = []
+        assert _post_permalink_from_card(card) is None
+
+    def test_returns_none_on_exception(self):
+        card = MagicMock()
+        card.find_elements.side_effect = RuntimeError("stale element")
+        assert _post_permalink_from_card(card) is None


### PR DESCRIPTION
## Problem
The Dashboard activity feed rendered broken comment links like `feedpost://ec34d641e56a0132be1a` instead of real LinkedIn URLs.

When LEM comments on a home-feed post, it logged the action with `post_url` set to an internal dedup key `feedpost://<sha1>` from `_feed_post_key(author, content)`. These synthetic keys exist because the SDUI feed card has no `data-urn`. The activity API returns them as `post_url`, and the Dashboard rendered them as clickable `<a href>` → broken links.

## Fix
**Backend (`run_automation.py`)** — the SDUI card *does* contain a real permalink anchor (`a[href*='/feed/update/']`). New helper `_post_permalink_from_card(card)` reads and normalizes it. In `comment_on_feed_inline`, the candidate `key` is now `permalink or _feed_post_key(...)`, so the real URL flows through the `seen` set, the `has_user_commented_on_post_url` dedup check, and the `insert_new_log(..., post_url=...)` call. The `feedpost://` hash remains as a fallback for cards without an anchor. Dedup semantics are otherwise unchanged.

**Frontend (`Dashboard.tsx`)** — guarded the activity-row link via a small `isHttpUrl()` helper: only `http(s)` `post_url` values render as anchors; legacy `feedpost://` rows (already in the DB, which the backend fix can't retroactively correct) render as plain text with no broken href.

## Tests
- `tests/unit/app/test_feed_permalink.py`: `_post_permalink_from_card` normalizes/strips query, appends trailing slash, returns None with no anchor / on exception.
- `poetry run pytest tests/unit -q` → 1214 passed.
- `cd src/cqc_lem/ui && npx tsc --noEmit` → exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EW1XumE9HwvC8WCkkFG3tx