### PR TITLE
fix(dashboard): link home-feed comment rows to LinkedIn comments activity

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -34,7 +34,7 @@ from cqc_lem.utilities.db import (
     update_subscription_from_stripe, update_user_linkedin_token,
     get_users_with_stripe_subscriptions,
     update_user_linkedin_password,
-    get_user_blog_url, get_user_sitemap_url,
+    get_user_blog_url, get_user_sitemap_url, get_linkedin_profile_url_by_user_id,
     get_user_by_stripe_customer_id, get_avatar_credit_ledger_entry_by_session,
     get_avatar_credit_balance, add_avatar_credits,
     get_video_credit_balance, add_video_credits,
@@ -1183,6 +1183,16 @@ def get_user_timezone_endpoint(session_token: str) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
     return ResponseModel(status_code=200, detail={"timezone": get_user_timezone(user_id)})
+
+
+@router.get("/user/linkedin-profile")
+def get_user_linkedin_profile_endpoint(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail={
+        "linkedin_profile_url": get_linkedin_profile_url_by_user_id(user_id),
+    })
 
 
 @router.put("/user/timezone")

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import api from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
 import { formatInTimezone } from '../utils/datetime'
-import { isHttpUrl } from '../utils/links'
+import { isHttpUrl, commentsActivityUrl } from '../utils/links'
 
 interface PostStats {
   recommendations: { weekday: string; hour: number; avg_engagement: number; sample: number }[]
@@ -96,6 +96,20 @@ export default function Dashboard() {
     enabled: !!email,
     refetchInterval: 30_000,
   })
+
+  // Home-feed comment rows carry a synthetic post_url (no real permalink); fall back to the
+  // user's own "recent activity → comments" page derived from their stored LinkedIn profile URL.
+  const { data: linkedinProfileUrl } = useQuery({
+    queryKey: ['linkedin-profile', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/linkedin-profile?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => (r.data.detail?.linkedin_profile_url as string | null) ?? null),
+    enabled: !!sessionToken,
+    staleTime: 10 * 60 * 1000,
+  })
+
+  const commentsUrl = commentsActivityUrl(linkedinProfileUrl)
 
   const stats = statsData?.detail ?? { scheduled_this_week: 0, pending_review: 0, posted_total: 0 }
 
@@ -230,6 +244,16 @@ export default function Dashboard() {
                           className="text-xs text-blue-500 hover:underline truncate block"
                         >
                           {entry.post_url}
+                        </a>
+                      ) : commentsUrl ? (
+                        <a
+                          href={commentsUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          title="View your LinkedIn comments"
+                          className="text-xs text-blue-500 hover:underline truncate block"
+                        >
+                          View your LinkedIn comments
                         </a>
                       ) : (
                         <span className="text-xs text-gray-400 truncate block">{entry.post_url}</span>

--- a/src/cqc_lem/ui/src/utils/links.ts
+++ b/src/cqc_lem/ui/src/utils/links.ts
@@ -3,3 +3,17 @@
 export function isHttpUrl(value: string | null | undefined): boolean {
   return typeof value === 'string' && /^https?:\/\//i.test(value)
 }
+
+// Home-feed comments have no per-post permalink. Fall back to the user's own LinkedIn
+// "recent activity → comments" page, where all their comments live. Given a stored profile
+// URL like "https://www.linkedin.com/in/christopherqueen/" this returns
+// "https://www.linkedin.com/in/christopherqueen/recent-activity/comments/". Returns null if the
+// input isn't a parseable /in/<vanity> LinkedIn URL.
+export function commentsActivityUrl(linkedinProfileUrl: string | null | undefined): string | null {
+  if (typeof linkedinProfileUrl !== 'string') return null
+  const match = linkedinProfileUrl.match(/^https?:\/\/([\w.-]*\.)?linkedin\.com\/in\/([^/?#]+)/i)
+  if (!match) return null
+  const vanity = match[2]
+  if (!vanity) return null
+  return `https://www.linkedin.com/in/${vanity}/recent-activity/comments/`
+}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1232,6 +1232,25 @@ def get_user_sitemap_url(user_id: int):
     return sitemap_url[0] if sitemap_url else None
 
 
+def get_linkedin_profile_url_by_user_id(user_id: int) -> Optional[str]:
+    """Return the user's own LinkedIn profile URL (e.g. https://www.linkedin.com/in/<vanity>/).
+    Only the user's own scraped profile carries a non-null user_id in the profiles table."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+
+    try:
+        cursor.execute("SELECT profile_url FROM profiles WHERE user_id = %s LIMIT 1", (user_id,))
+        row = cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get user linkedin profile url | Error: {err}")
+        row = None
+    finally:
+        cursor.close()
+        connection.close()
+
+    return row[0] if row else None
+
+
 _ALLOWED_USER_CLAUSES = frozenset({"email = %s", "blog_url = %s", "sitemap_url = %s"})
 
 

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -275,6 +275,35 @@ class TestGetUserSettings:
         assert detail["preferences"] is None
 
 
+# ---------------------------------------------------------------------------
+# GET /api/user/linkedin-profile
+# ---------------------------------------------------------------------------
+
+class TestGetUserLinkedInProfile:
+    BASE = "/api/user/linkedin-profile"
+
+    def test_invalid_session_returns_401(self, client):
+        with patch(f"{_MAIN}.get_session_user_id", return_value=None):
+            resp = client.get(self.BASE, params={"session_token": "bad-token"})
+        assert resp.status_code == 401
+
+    def test_valid_session_returns_profile_url(self, client):
+        with patch(f"{_MAIN}.get_session_user_id", return_value=5), \
+             patch(f"{_MAIN}.get_linkedin_profile_url_by_user_id",
+                   return_value="https://www.linkedin.com/in/christopherqueen/"):
+            resp = client.get(self.BASE, params={"session_token": "valid-tok"})
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["linkedin_profile_url"] == \
+            "https://www.linkedin.com/in/christopherqueen/"
+
+    def test_missing_profile_returns_null(self, client):
+        with patch(f"{_MAIN}.get_session_user_id", return_value=5), \
+             patch(f"{_MAIN}.get_linkedin_profile_url_by_user_id", return_value=None):
+            resp = client.get(self.BASE, params={"session_token": "valid-tok"})
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["linkedin_profile_url"] is None
+
+
 class TestVerificationPinInbound:
     """SendGrid Inbound Parse webhook that receives the user's PIN reply."""
     BASE = "/api/linkedin/verification-pin/inbound"

--- a/tests/unit/utilities/test_db_timezone.py
+++ b/tests/unit/utilities/test_db_timezone.py
@@ -65,6 +65,35 @@ class TestGetUserTimezone:
 
 
 # ---------------------------------------------------------------------------
+# get_linkedin_profile_url_by_user_id
+# ---------------------------------------------------------------------------
+
+class TestGetLinkedInProfileUrlByUserId:
+    def test_returns_stored_profile_url(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = (
+                "https://www.linkedin.com/in/christopherqueen/",
+            )
+            from cqc_lem.utilities.db import get_linkedin_profile_url_by_user_id
+            result = get_linkedin_profile_url_by_user_id(1)
+        assert result == "https://www.linkedin.com/in/christopherqueen/"
+
+    def test_returns_none_when_no_profile(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = None
+            from cqc_lem.utilities.db import get_linkedin_profile_url_by_user_id
+            result = get_linkedin_profile_url_by_user_id(99)
+        assert result is None
+
+    def test_returns_none_on_db_error(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("fail")
+            from cqc_lem.utilities.db import get_linkedin_profile_url_by_user_id
+            result = get_linkedin_profile_url_by_user_id(7)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
 # update_user_timezone
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem
Dashboard activity-feed rows for **home-feed comments** carry a synthetic `post_url` like `feedpost://<hash>` (LinkedIn SDUI home-feed posts expose no per-post permalink). The v0.24.0 `isHttpUrl` guard renders those as **plain text**, so the user can't get to their comment.

## Fix
Fall back to the user's own LinkedIn **"recent activity → comments"** page (`https://www.linkedin.com/in/{vanity}/recent-activity/comments/`), where all their comments live.

## How the vanity reaches the frontend
The user's own profile URL is already stored in `profiles.profile_url` (only the user's *own* scraped profile has a non-null `user_id`; other scraped profiles are null). Exposed via a tiny new session-token endpoint the Dashboard fetches.

- `src/cqc_lem/utilities/db.py` — `get_linkedin_profile_url_by_user_id(user_id)`
- `src/cqc_lem/api/main.py` — `GET /user/linkedin-profile` → `{ "linkedin_profile_url": ... }`
- `src/cqc_lem/ui/src/pages/Dashboard.tsx` — new query + render fallback link
- `src/cqc_lem/ui/src/utils/links.ts` — `commentsActivityUrl()`

## Behavior
- `http(s)` rows → link to `post_url` (**unchanged**)
- non-http comment rows **with** a resolvable vanity → link to comments-activity page (new tab, `rel="noopener noreferrer"`, title "View your LinkedIn comments")
- otherwise → plain text (**current behavior**)

## Tests / gates
- `npx tsc --noEmit` → exit 0
- `poetry run pytest tests/unit -q` → 1226 passed (added endpoint + db-getter tests)
- No Selenium/docker touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EW1XumE9HwvC8WCkkFG3tx