### PR TITLE
feat(newsletter): draft-review workflow + day/time scheduling

### DIFF
--- a/compose/local/database/migrations/V44__add_newsletter_scheduling.sql
+++ b/compose/local/database/migrations/V44__add_newsletter_scheduling.sql
@@ -1,0 +1,23 @@
+-- Newsletter scheduling controls + a draft-review workflow. Editions are generated a few days
+-- ahead as drafts (status='draft'), the user may edit/approve them, and they auto-publish at the
+-- chosen weekday/hour (user-local) — auto-publishing untouched drafts so cadence never breaks.
+ALTER TABLE newsletter_settings
+    ADD COLUMN publish_day  TINYINT NOT NULL DEFAULT 1,   -- 0=Mon .. 6=Sun; default Tuesday
+    ADD COLUMN publish_hour TINYINT NOT NULL DEFAULT 9;   -- user-local hour of day; default 9am
+
+CREATE TABLE IF NOT EXISTS newsletter_editions (
+    id             INT AUTO_INCREMENT PRIMARY KEY,
+    user_id        INT NOT NULL,
+    title          VARCHAR(255) NULL,
+    subtitle       VARCHAR(255) NULL,
+    body           MEDIUMTEXT NULL,
+    status         ENUM('draft','approved','published','failed','skipped') NOT NULL DEFAULT 'draft',
+    scheduled_for  DATETIME NOT NULL,           -- UTC; when the edition should publish
+    published_url  VARCHAR(512) NULL,
+    generated_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    published_at   DATETIME NULL,
+    updated_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_user_status (user_id, status),
+    KEY idx_scheduled (scheduled_for, status),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -28,6 +28,8 @@ from cqc_lem.utilities.db import (
     get_user_subscription_info, get_user_preferences, update_user_preferences,
     get_engagement_preferences, update_engagement_preferences,
     get_newsletter_settings, update_newsletter_settings,
+    get_pending_newsletter_edition, update_newsletter_edition, get_newsletter_edition,
+    get_user_timezone,
     get_user_groups, set_groups_enabled, get_post_engagement_rows,
     get_lead_magnet_settings, update_lead_magnet_settings,
     get_dm_templates, upsert_dm_templates,
@@ -267,6 +269,17 @@ class NewsletterSettingsRequest(BaseModel):
     topic: Optional[str] = None
     cadence: str = "weekly"
     align_with_blog: bool = True
+    publish_day: int = 1
+    publish_hour: int = 9
+
+
+class NewsletterDraftRequest(BaseModel):
+    session_token: str
+    edition_id: int
+    title: Optional[str] = None
+    subtitle: Optional[str] = None
+    body: Optional[str] = None
+    action: str = "save"
 
 
 class EngagementPreferencesRequest(BaseModel):
@@ -1078,6 +1091,52 @@ def update_newsletter_settings_endpoint(request: NewsletterSettingsRequest) -> R
     if not update_newsletter_settings(user_id, request.model_dump(exclude={"session_token"})):
         raise HTTPException(status_code=500, detail="Could not update newsletter settings")
     return ResponseModel(status_code=200, detail="Newsletter settings updated")
+
+
+def _compute_next_publish(user_id: int):
+    """Next scheduled publish datetime (naive UTC) for the user's newsletter, or None."""
+    import pytz
+    from datetime import datetime as _dt
+    from cqc_lem.utilities.newsletter import next_publish_datetime
+    settings = get_newsletter_settings(user_id)
+    try:
+        tz = pytz.timezone(get_user_timezone(user_id))
+    except Exception:
+        tz = pytz.utc
+    return next_publish_datetime(
+        settings.get("publish_day", 1), settings.get("publish_hour", 9),
+        settings.get("cadence", "weekly"), settings.get("last_published_at"), tz, _dt.utcnow())
+
+
+@router.get("/user/newsletter-draft")
+def get_newsletter_draft_endpoint(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    edition = get_pending_newsletter_edition(user_id)
+    if edition and edition.get("scheduled_for") is not None:
+        edition["scheduled_for"] = edition["scheduled_for"].isoformat() if hasattr(
+            edition["scheduled_for"], "isoformat") else str(edition["scheduled_for"])
+    next_pub = _compute_next_publish(user_id)
+    return ResponseModel(status_code=200, detail={
+        "edition": edition,
+        "next_publish": next_pub.isoformat() if next_pub is not None else None,
+    })
+
+
+@router.put("/user/newsletter-draft")
+def update_newsletter_draft_endpoint(request: NewsletterDraftRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    existing = get_newsletter_edition(request.edition_id)
+    if not existing or existing.get("user_id") != user_id:
+        raise HTTPException(status_code=404, detail="Edition not found")
+    status = {"approve": "approved", "skip": "skipped"}.get(request.action)  # None for 'save'
+    if not update_newsletter_edition(request.edition_id, user_id, title=request.title,
+                                     subtitle=request.subtitle, body=request.body, status=status):
+        raise HTTPException(status_code=500, detail="Could not update newsletter draft")
+    return ResponseModel(status_code=200, detail="Newsletter draft updated")
 
 
 class GroupTogglesRequest(BaseModel):

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -92,9 +92,13 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_daily_engagement',
             'schedule': crontab(hour='13', minute='0')  # Daily peak-hour feed commenting (~9am ET), on top of pre-post
         },
-        'publish-due-newsletters': {
-            'task': 'cqc_lem.app.run_scheduler.auto_publish_due_newsletters',
-            'schedule': crontab(hour='12', minute='30')  # Daily check; publishes editions whose cadence is due
+        'generate-newsletter-drafts': {
+            'task': 'cqc_lem.app.run_scheduler.auto_generate_newsletter_drafts',
+            'schedule': crontab(hour='10', minute='0')  # Daily: draft editions ~3 days before their slot for review
+        },
+        'publish-scheduled-newsletters': {
+            'task': 'cqc_lem.app.run_scheduler.auto_publish_scheduled_editions',
+            'schedule': crontab(minute='5')  # Hourly: publish any edition whose scheduled slot has arrived
         },
         'sync-user-groups': {
             'task': 'cqc_lem.app.run_scheduler.auto_sync_groups',

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -20,6 +20,7 @@ from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
     get_newsletter_settings, mark_newsletter_published, \
+    get_newsletter_edition, mark_edition_published, mark_edition_failed, \
     upsert_user_group, get_enabled_group_ids, record_post_stats, get_recent_posted_post_ids, \
     get_lead_magnet_settings, has_received_lead_magnet, record_lead_magnet_sent, \
     LogResultType, has_user_commented_on_post_url, get_post_url_from_log_for_user, get_post_message_from_log_for_user, \
@@ -911,6 +912,40 @@ def auto_publish_newsletter_edition(self, user_id: int):
     except Exception as e:
         log_error("Newsletter publish error", exc=e, user_id=user_id, task_name="auto_publish_newsletter_edition")
         return f"Newsletter error: {e}"
+    finally:
+        quit_gracefully(driver)
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['edition_id']},
+                  queue='selenium')
+def auto_publish_edition(self, edition_id: int):
+    """Publish a reviewed/untouched newsletter edition at its scheduled slot. Loads the pre-generated
+    edition (draft or approved), fills LinkedIn's article editor, and records the outcome. Best-effort
+    — the multi-step publish flow varies; first real publish should be supervised."""
+    edition = get_newsletter_edition(edition_id)
+    if not edition or edition.get("status") not in ("draft", "approved"):
+        return f"Edition {edition_id} not publishable"
+    user_id = edition["user_id"]
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Newsletter")
+    except Exception as e:
+        log_error("Error getting profile for newsletter edition", exc=e, user_id=user_id, task_name="auto_publish_edition")
+        return f"Failed to start newsletter edition: {e}"
+    try:
+        driver.get("https://www.linkedin.com/article/new/")
+        time.sleep(random.uniform(6, 9))
+        url = _fill_and_publish_article(driver, wait, edition["title"], edition["body"],
+                                        subtitle=edition.get("subtitle"))
+        if url:
+            mark_edition_published(edition_id, url)
+            myprint(f"Published newsletter edition {edition_id} for user {user_id}: {edition['title']}")
+            return f"Published newsletter edition: {edition['title']}"
+        mark_edition_failed(edition_id)
+        return "Newsletter edition publish flow did not complete"
+    except Exception as e:
+        log_error("Newsletter edition publish error", exc=e, user_id=user_id, task_name="auto_publish_edition")
+        mark_edition_failed(edition_id)
+        return f"Newsletter edition error: {e}"
     finally:
         quit_gracefully(driver)
 

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -132,14 +132,54 @@ def auto_daily_engagement():
 
 
 @shared_task.task
-def auto_publish_due_newsletters():
-    """Publish a newsletter edition for each user whose enabled newsletter is due per its cadence."""
-    from cqc_lem.app.run_automation import auto_publish_newsletter_edition
-    from cqc_lem.utilities.db import get_newsletter_due_user_ids
-    due = get_newsletter_due_user_ids(datetime.utcnow())
-    for uid in due:
-        auto_publish_newsletter_edition.apply_async(kwargs={'user_id': uid})
-    return f"Dispatched newsletter edition for {len(due)} user(s)"
+def auto_generate_newsletter_drafts():
+    """Generate a draft edition ~GENERATE_LEAD_DAYS before each enabled user's next slot, so they
+    have time to review before it auto-publishes. Skips users who already have a pending edition."""
+    import pytz
+    from cqc_lem.utilities.db import (get_enabled_newsletter_user_ids, get_newsletter_settings,
+                                      get_user_timezone, get_pending_newsletter_edition,
+                                      create_newsletter_edition)
+    from cqc_lem.utilities.linkedin.helper import load_profile_for_user
+    from cqc_lem.utilities.ai.ai_helper import generate_newsletter_edition
+    from cqc_lem.utilities.newsletter import next_publish_datetime, should_generate_now
+    from cqc_lem.utilities.notifications import notify_newsletter_draft_ready
+
+    now = datetime.utcnow()
+    generated = 0
+    for user_id in get_enabled_newsletter_user_ids():
+        try:
+            settings = get_newsletter_settings(user_id)
+            tz = pytz.timezone(get_user_timezone(user_id))
+            next_pub = next_publish_datetime(
+                settings.get("publish_day", 1), settings.get("publish_hour", 9),
+                settings.get("cadence", "weekly"), settings.get("last_published_at"), tz, now)
+            if not should_generate_now(next_pub, now):
+                continue
+            if get_pending_newsletter_edition(user_id) is not None:
+                continue
+            profile = load_profile_for_user(user_id)
+            edition = generate_newsletter_edition(profile, topic=settings.get("topic"))
+            if not edition:
+                continue
+            create_newsletter_edition(user_id, edition["title"], edition.get("subtitle"),
+                                      edition["body"], next_pub)
+            notify_newsletter_draft_ready(user_id, edition["title"], next_pub)
+            generated += 1
+        except Exception as e:
+            log_warning("Failed to generate newsletter draft", exc=e, user_id=user_id,
+                        task_name="auto_generate_newsletter_drafts")
+    return f"Generated newsletter draft for {generated} user(s)"
+
+
+@shared_task.task
+def auto_publish_scheduled_editions():
+    """Publish any newsletter edition whose scheduled slot has arrived (approved or untouched draft)."""
+    from cqc_lem.app.run_automation import auto_publish_edition
+    from cqc_lem.utilities.db import get_editions_due_to_publish
+    due = get_editions_due_to_publish(datetime.utcnow())
+    for e in due:
+        auto_publish_edition.apply_async(kwargs={'edition_id': e['id']})
+    return f"Dispatched {len(due)} newsletter edition(s)"
 
 
 @shared_task.task

--- a/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
@@ -3,13 +3,24 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import Toggle from '../../components/Toggle'
-import type { NewsletterSettings } from './types'
+import type { NewsletterSettings, NewsletterDraft, NewsletterEdition } from './types'
+import { WEEKDAYS } from './types'
+
+const fmt = (iso: string | null) => {
+  if (!iso) return null
+  const d = new Date(iso.endsWith('Z') || iso.includes('+') ? iso : iso + 'Z')
+  if (isNaN(d.getTime())) return null
+  return d.toLocaleString(undefined, {
+    weekday: 'long', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
+  })
+}
 
 export default function NewsletterCard() {
   const { sessionToken } = useAuth()
   const queryClient = useQueryClient()
   const [newsletter, setNewsletter] = useState<NewsletterSettings | null>(null)
   const [nlMsg, setNlMsg] = useState<{ ok: boolean; text: string } | null>(null)
+  const [draftEdit, setDraftEdit] = useState<NewsletterEdition | null>(null)
 
   const { data: nlData } = useQuery({
     queryKey: ['newsletter-settings', sessionToken],
@@ -24,7 +35,21 @@ export default function NewsletterCard() {
     if (nlData && !newsletter) setNewsletter(nlData)
   }, [nlData])
 
+  const { data: draftData } = useQuery({
+    queryKey: ['newsletter-draft', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/newsletter-draft?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as NewsletterDraft),
+    enabled: !!sessionToken && !!newsletter?.enabled,
+    staleTime: 30 * 1000,
+  })
+  useEffect(() => {
+    setDraftEdit(draftData?.edition ? { ...draftData.edition } : null)
+  }, [draftData])
+
   const setNl = (patch: Partial<NewsletterSettings>) => setNewsletter((p) => (p ? { ...p, ...patch } : p))
+  const setDe = (patch: Partial<NewsletterEdition>) => setDraftEdit((p) => (p ? { ...p, ...patch } : p))
 
   const nlMutation = useMutation({
     mutationFn: () => api.put('/user/newsletter-settings', { session_token: sessionToken, ...newsletter }),
@@ -39,7 +64,31 @@ export default function NewsletterCard() {
     },
   })
 
+  const draftMutation = useMutation({
+    mutationFn: (action: 'save' | 'approve' | 'skip') =>
+      api.put('/user/newsletter-draft', {
+        session_token: sessionToken,
+        edition_id: draftEdit!.id,
+        title: draftEdit!.title,
+        subtitle: draftEdit!.subtitle,
+        body: draftEdit!.body,
+        action,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['newsletter-draft'] })
+      setNlMsg({ ok: true, text: 'Saved.' })
+      setTimeout(() => setNlMsg(null), 3000)
+    },
+    onError: () => {
+      setNlMsg({ ok: false, text: 'Could not save — try again.' })
+      setTimeout(() => setNlMsg(null), 5000)
+    },
+  })
+
   if (!newsletter) return null
+
+  const nextPublish = fmt(draftData?.next_publish ?? null)
+  const autoDate = fmt(draftEdit?.scheduled_for ?? null)
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
@@ -68,6 +117,26 @@ export default function NewsletterCard() {
               </select>
             </div>
           </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Publish day</label>
+              <select value={newsletter.publish_day} onChange={(e) => setNl({ publish_day: Number(e.target.value) })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm">
+                {WEEKDAYS.map((d, i) => (
+                  <option key={i} value={i}>{d}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Publish hour (your time)</label>
+              <select value={newsletter.publish_hour} onChange={(e) => setNl({ publish_hour: Number(e.target.value) })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm">
+                {Array.from({ length: 24 }, (_, h) => (
+                  <option key={h} value={h}>{`${h.toString().padStart(2, '0')}:00`}</option>
+                ))}
+              </select>
+            </div>
+          </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Topic / theme</label>
             <input type="text" value={newsletter.topic || ''} onChange={(e) => setNl({ topic: e.target.value })}
@@ -77,6 +146,9 @@ export default function NewsletterCard() {
             <p className="text-sm font-medium text-gray-700">Align with my blog</p>
             <Toggle on={newsletter.align_with_blog} onClick={() => setNl({ align_with_blog: !newsletter.align_with_blog })} />
           </div>
+          {nextPublish && (
+            <p className="text-xs text-gray-500">Next edition: <span className="font-medium text-gray-700">{nextPublish}</span></p>
+          )}
         </>
       )}
       {nlMsg && <p className={`text-sm font-medium ${nlMsg.ok ? 'text-green-600' : 'text-red-600'}`}>{nlMsg.text}</p>}
@@ -84,6 +156,46 @@ export default function NewsletterCard() {
         className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
         {nlMutation.isPending ? 'Saving…' : 'Save Newsletter Settings'}
       </button>
+
+      {newsletter.enabled && draftEdit && (
+        <div className="border-t border-gray-200 pt-4 space-y-3">
+          <div>
+            <h3 className="text-sm font-semibold text-gray-700">Draft ready to review</h3>
+            {autoDate && (
+              <p className="text-xs text-gray-500">Auto-publishes {autoDate} unless you skip it.</p>
+            )}
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+            <input type="text" value={draftEdit.title || ''} onChange={(e) => setDe({ title: e.target.value })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Subtitle</label>
+            <input type="text" value={draftEdit.subtitle || ''} onChange={(e) => setDe({ subtitle: e.target.value })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Body</label>
+            <textarea value={draftEdit.body || ''} onChange={(e) => setDe({ body: e.target.value })} rows={10}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono" />
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            <button type="button" onClick={() => draftMutation.mutate('save')} disabled={draftMutation.isPending}
+              className="bg-gray-100 text-gray-700 py-2 rounded-lg text-sm font-semibold hover:bg-gray-200 disabled:opacity-50 transition-colors">
+              Save
+            </button>
+            <button type="button" onClick={() => draftMutation.mutate('approve')} disabled={draftMutation.isPending}
+              className="bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
+              Approve
+            </button>
+            <button type="button" onClick={() => draftMutation.mutate('skip')} disabled={draftMutation.isPending}
+              className="bg-white border border-gray-300 text-gray-700 py-2 rounded-lg text-sm font-semibold hover:bg-gray-50 disabled:opacity-50 transition-colors">
+              Skip
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -31,7 +31,25 @@ export type NewsletterSettings = {
   topic: string | null
   cadence: string
   align_with_blog: boolean
+  publish_day: number
+  publish_hour: number
 }
+
+export type NewsletterEdition = {
+  id: number
+  title: string | null
+  subtitle: string | null
+  body: string | null
+  status: string
+  scheduled_for: string | null
+}
+
+export type NewsletterDraft = {
+  edition: NewsletterEdition | null
+  next_publish: string | null
+}
+
+export const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
 
 export type UserGroup = {
   group_id: string

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2424,8 +2424,10 @@ def record_lead_magnet_sent(user_id: int, recipient_profile: str, post_id: int =
 _NEWSLETTER_DEFAULTS: dict = {
     "enabled": False, "title": None, "topic": None, "cadence": "weekly",
     "align_with_blog": True, "newsletter_url": None, "last_published_at": None,
+    "publish_day": 1, "publish_hour": 9,
 }
-_NEWSLETTER_COLS = ("enabled", "title", "topic", "cadence", "align_with_blog", "newsletter_url")
+_NEWSLETTER_COLS = ("enabled", "title", "topic", "cadence", "align_with_blog", "newsletter_url",
+                    "publish_day", "publish_hour")
 
 
 def get_newsletter_settings(user_id: int) -> dict:
@@ -2434,13 +2436,16 @@ def get_newsletter_settings(user_id: int) -> dict:
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            "SELECT enabled, title, topic, cadence, align_with_blog, newsletter_url, last_published_at "
+            "SELECT enabled, title, topic, cadence, align_with_blog, newsletter_url, last_published_at, "
+            "publish_day, publish_hour "
             "FROM newsletter_settings WHERE user_id = %s", (user_id,))
         row = cursor.fetchone()
         if row is None:
             return dict(_NEWSLETTER_DEFAULTS)
         row["enabled"] = bool(row.get("enabled"))
         row["align_with_blog"] = bool(row.get("align_with_blog"))
+        row["publish_day"] = int(row.get("publish_day") if row.get("publish_day") is not None else 1)
+        row["publish_hour"] = int(row.get("publish_hour") if row.get("publish_hour") is not None else 9)
         return row
     except mysql.connector.Error as err:
         myprint(f"Could not get newsletter settings for user {user_id} | Error: {err}")
@@ -2509,6 +2514,153 @@ def get_newsletter_due_user_ids(now) -> list:
     except mysql.connector.Error as err:
         myprint(f"Could not get newsletter-due users | Error: {err}")
         return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_enabled_newsletter_user_ids() -> list:
+    """User IDs whose newsletter is enabled (regardless of cadence timing)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT user_id FROM newsletter_settings WHERE enabled=1")
+        return [r[0] for r in cursor.fetchall()]
+    except mysql.connector.Error as err:
+        myprint(f"Could not get enabled newsletter users | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def create_newsletter_edition(user_id: int, title: str, subtitle: str, body: str,
+                              scheduled_for) -> int:
+    """Insert a draft newsletter edition (status defaults to 'draft'). Returns its id."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO newsletter_editions (user_id, title, subtitle, body, scheduled_for) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            (user_id, title, subtitle, body, scheduled_for))
+        connection.commit()
+        return cursor.lastrowid
+    except mysql.connector.Error as err:
+        myprint(f"Could not create newsletter edition for user {user_id} | Error: {err}")
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_pending_newsletter_edition(user_id: int) -> "dict | None":
+    """The most recent edition still under review (status draft/approved) for this user."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT id, title, subtitle, body, status, scheduled_for FROM newsletter_editions "
+            "WHERE user_id = %s AND status IN ('draft', 'approved') "
+            "ORDER BY id DESC LIMIT 1", (user_id,))
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get pending newsletter edition for user {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_newsletter_edition(edition_id: int, user_id: int, title: str = None,
+                              subtitle: str = None, body: str = None,
+                              status: str = None) -> bool:
+    """Update only the provided fields on an edition, scoped to its owner (COALESCE-style)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE newsletter_editions SET "
+            "title = COALESCE(%s, title), subtitle = COALESCE(%s, subtitle), "
+            "body = COALESCE(%s, body), status = COALESCE(%s, status) "
+            "WHERE id = %s AND user_id = %s",
+            (title, subtitle, body, status, edition_id, user_id))
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update newsletter edition {edition_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_editions_due_to_publish(now) -> list:
+    """Editions whose scheduled slot has arrived and are still awaiting publish (draft/approved)."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT id, user_id, title, subtitle, body FROM newsletter_editions "
+            "WHERE scheduled_for <= %s AND status IN ('draft', 'approved')", (now,))
+        return cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get editions due to publish | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_newsletter_edition(edition_id: int) -> "dict | None":
+    """Fetch a single newsletter edition by id."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT id, user_id, title, subtitle, body, status, scheduled_for, published_url "
+            "FROM newsletter_editions WHERE id = %s", (edition_id,))
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get newsletter edition {edition_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def mark_edition_published(edition_id: int, url: str) -> bool:
+    """Mark an edition published and roll the user's newsletter cadence forward."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE newsletter_editions SET status='published', published_at=NOW(), published_url=%s "
+            "WHERE id=%s", (url, edition_id))
+        cursor.execute(
+            "UPDATE newsletter_settings SET last_published_at=NOW() "
+            "WHERE user_id = (SELECT user_id FROM newsletter_editions WHERE id=%s)", (edition_id,))
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not mark edition {edition_id} published | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def mark_edition_failed(edition_id: int) -> bool:
+    """Mark an edition as failed to publish."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("UPDATE newsletter_editions SET status='failed' WHERE id=%s", (edition_id,))
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not mark edition {edition_id} failed | Error: {err}")
+        return False
     finally:
         cursor.close()
         connection.close()

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -282,6 +282,28 @@ def send_session_revalidation_email(to_email: str, account_url: Optional[str] = 
         to_email, "⚠️ Action needed: reconnect your LinkedIn session", html)
 
 
+def send_newsletter_draft_ready_email(to_email: str, edition_title: str,
+                                      scheduled_for: str, account_url: Optional[str] = None) -> bool:
+    """Email a user that their newsletter draft is ready to review before it auto-publishes."""
+    url = account_url or _account_url()
+    title = edition_title or "Your next edition"
+    html = f"""
+    <html><body>
+    <h2>Your newsletter draft is ready to review</h2>
+    <p>We drafted your next LinkedIn newsletter edition, <strong>{title}</strong>.
+    Review, edit, approve, or skip it before it goes out.</p>
+    <p>If you do nothing, it will <strong>auto-publish as-is on {scheduled_for}</strong> so your
+    cadence never breaks.</p>
+    <p><a href="{url}" style="background:#0a66c2;color:#fff;padding:10px 16px;border-radius:6px;
+    text-decoration:none;">Review your draft</a></p>
+    <p style="color:#888;font-size:12px;">You can edit the title, subtitle, and body, or skip this
+    edition entirely from your account page.</p>
+    </body></html>
+    """
+    return _send_high_priority_email(
+        to_email, f"📝 Your newsletter draft is ready: {title}", html)
+
+
 def send_pin_email(
     to_email: str,
     pin: str,

--- a/src/cqc_lem/utilities/newsletter.py
+++ b/src/cqc_lem/utilities/newsletter.py
@@ -1,0 +1,52 @@
+"""Newsletter scheduling math (pure, testable) — computes when the next edition should publish."""
+
+from datetime import datetime, timedelta
+
+import pytz
+
+_CADENCE_DAYS = {"weekly": 7, "biweekly": 14, "monthly": 30}
+
+# How many days before the scheduled slot a draft is generated for review.
+GENERATE_LEAD_DAYS = 3
+
+
+def _as_utc(dt: datetime):
+    if dt is None:
+        return None
+    return pytz.utc.localize(dt) if dt.tzinfo is None else dt.astimezone(pytz.utc)
+
+
+def next_publish_datetime(publish_day: int, publish_hour: int, cadence: str,
+                          last_published_at: datetime, tz, now_utc: datetime) -> datetime:
+    """Next UTC datetime (naive) the newsletter should publish.
+
+    - publish_day: 0=Mon .. 6=Sun; publish_hour: 0-23, interpreted in the user's local `tz`.
+    - Respects cadence: the slot must be >= last_published_at + interval (7/14/30 days), and >= now.
+    - `tz` is a pytz timezone; DST-safe via localize() on a naive local wall-clock time.
+    """
+    utc = pytz.utc
+    now_utc = _as_utc(now_utc)
+    interval = _CADENCE_DAYS.get(cadence, 7)
+    if last_published_at is not None:
+        earliest = max(now_utc, _as_utc(last_published_at) + timedelta(days=interval))
+    else:
+        earliest = now_utc
+
+    local_earliest = earliest.astimezone(tz)
+    d = local_earliest.date()
+    days_ahead = (int(publish_day) - d.weekday()) % 7
+    cand_date = d + timedelta(days=days_ahead)
+    local_dt = tz.localize(datetime(cand_date.year, cand_date.month, cand_date.day, int(publish_hour), 0, 0))
+    if local_dt < local_earliest:
+        # the slot already passed today/this week → next weekly occurrence
+        local_dt = tz.localize(datetime(cand_date.year, cand_date.month, cand_date.day,
+                                        int(publish_hour), 0, 0) + timedelta(days=7))
+    return local_dt.astimezone(utc).replace(tzinfo=None)
+
+
+def should_generate_now(next_publish: datetime, now_utc: datetime,
+                        lead_days: int = GENERATE_LEAD_DAYS) -> bool:
+    """True when we're within the lead window of the next slot (time to generate the draft)."""
+    if next_publish is None:
+        return False
+    return _as_utc(now_utc) >= _as_utc(next_publish) - timedelta(days=lead_days)

--- a/src/cqc_lem/utilities/notifications.py
+++ b/src/cqc_lem/utilities/notifications.py
@@ -16,6 +16,7 @@ from cqc_lem.utilities.db import (
 from cqc_lem.utilities.email import (
     send_connect_linkedin_email,
     send_session_revalidation_email,
+    send_newsletter_draft_ready_email,
 )
 from cqc_lem.utilities.logger import myprint
 
@@ -44,3 +45,21 @@ def notify_linkedin_session(user_id: int, revalidation: bool = False) -> bool:
         myprint(f"Sent LinkedIn session {'re-validation' if revalidation else 'connect'} "
                 f"email to user_id {user_id}")
     return sent
+
+
+def notify_newsletter_draft_ready(user_id: int, edition_title: str, scheduled_for) -> bool:
+    """Email the user that their newsletter draft is ready to review and when it auto-publishes.
+    Non-fatal — returns True only if an email was actually sent."""
+    try:
+        email = get_user_email(user_id)
+        if not email:
+            return False
+        when = scheduled_for.strftime("%A, %B %d at %I:%M %p UTC") if hasattr(
+            scheduled_for, "strftime") else str(scheduled_for)
+        sent = send_newsletter_draft_ready_email(email, edition_title, when)
+        if sent:
+            myprint(f"Sent newsletter draft-ready email to user_id {user_id}")
+        return sent
+    except Exception as e:
+        myprint(f"Could not send newsletter draft-ready email to user_id {user_id} | Error: {e}")
+        return False

--- a/tests/unit/api/test_newsletter_api.py
+++ b/tests/unit/api/test_newsletter_api.py
@@ -48,7 +48,89 @@ class TestNewsletterSettings:
         args = upd.call_args[0][1]
         assert "session_token" not in args and args["title"] == "Weekly Wins"
 
+    def test_put_passes_publish_day_hour(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_newsletter_settings", return_value=True) as upd:
+            resp = client.put("/api/user/newsletter-settings", json={
+                "session_token": _SESSION, "enabled": True, "publish_day": 3, "publish_hour": 14})
+        assert resp.status_code == 200
+        args = upd.call_args[0][1]
+        assert args["publish_day"] == 3 and args["publish_hour"] == 14
+
     def test_401(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
             resp = client.get("/api/user/newsletter-settings?session_token=bad")
+        assert resp.status_code == 401
+
+
+class TestNewsletterDraft:
+    def test_get_returns_edition_and_next_publish(self, client):
+        from datetime import datetime
+        edition = {"id": 4, "title": "T", "subtitle": "S", "body": "B", "status": "draft",
+                   "scheduled_for": datetime(2026, 7, 7, 13, 0, 0)}
+        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None}
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_pending_newsletter_edition", return_value=edition), \
+             patch("cqc_lem.api.main.get_newsletter_settings", return_value=settings), \
+             patch("cqc_lem.api.main.get_user_timezone", return_value="UTC"):
+            resp = client.get(f"/api/user/newsletter-draft?session_token={_SESSION}")
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert detail["edition"]["id"] == 4
+        assert detail["edition"]["scheduled_for"].startswith("2026-07-07")
+        assert detail["next_publish"] is not None
+
+    def test_get_null_when_no_edition(self, client):
+        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None}
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_pending_newsletter_edition", return_value=None), \
+             patch("cqc_lem.api.main.get_newsletter_settings", return_value=settings), \
+             patch("cqc_lem.api.main.get_user_timezone", return_value="UTC"):
+            resp = client.get(f"/api/user/newsletter-draft?session_token={_SESSION}")
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["edition"] is None
+
+    def test_get_401(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.get("/api/user/newsletter-draft?session_token=bad")
+        assert resp.status_code == 401
+
+    def test_put_approve(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_newsletter_edition", return_value={"id": 4, "user_id": _USER}), \
+             patch("cqc_lem.api.main.update_newsletter_edition", return_value=True) as upd:
+            resp = client.put("/api/user/newsletter-draft", json={
+                "session_token": _SESSION, "edition_id": 4, "action": "approve"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["status"] == "approved"
+
+    def test_put_skip(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_newsletter_edition", return_value={"id": 4, "user_id": _USER}), \
+             patch("cqc_lem.api.main.update_newsletter_edition", return_value=True) as upd:
+            resp = client.put("/api/user/newsletter-draft", json={
+                "session_token": _SESSION, "edition_id": 4, "action": "skip"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["status"] == "skipped"
+
+    def test_put_save_leaves_status_none(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_newsletter_edition", return_value={"id": 4, "user_id": _USER}), \
+             patch("cqc_lem.api.main.update_newsletter_edition", return_value=True) as upd:
+            resp = client.put("/api/user/newsletter-draft", json={
+                "session_token": _SESSION, "edition_id": 4, "title": "New", "action": "save"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["status"] is None
+
+    def test_put_404_when_not_owner(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_newsletter_edition", return_value={"id": 4, "user_id": 999}):
+            resp = client.put("/api/user/newsletter-draft", json={
+                "session_token": _SESSION, "edition_id": 4, "action": "save"})
+        assert resp.status_code == 404
+
+    def test_put_401(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.put("/api/user/newsletter-draft", json={
+                "session_token": "bad", "edition_id": 4, "action": "save"})
         assert resp.status_code == 401

--- a/tests/unit/app/test_newsletter_publish.py
+++ b/tests/unit/app/test_newsletter_publish.py
@@ -59,11 +59,123 @@ class TestFillEditionDescription:
         el.send_keys.assert_called_once()
 
 
-class TestAutoPublishDueNewsletters:
-    def test_dispatches_due_users(self):
-        from cqc_lem.app.run_scheduler import auto_publish_due_newsletters
-        with patch("cqc_lem.utilities.db.get_newsletter_due_user_ids", return_value=[1, 7]), \
-             patch("cqc_lem.app.run_automation.auto_publish_newsletter_edition") as task:
-            result = auto_publish_due_newsletters()
+class TestAutoPublishEdition:
+    def test_skips_when_not_publishable(self):
+        from cqc_lem.app.run_automation import auto_publish_edition
+        with patch(f"{_RA}.get_newsletter_edition", return_value={"user_id": 1, "status": "published"}), \
+             patch(f"{_RA}.get_current_profile") as gp:
+            result = auto_publish_edition.run(edition_id=9)
+        assert "not publishable" in result
+        gp.assert_not_called()
+
+    def test_skips_when_missing(self):
+        from cqc_lem.app.run_automation import auto_publish_edition
+        with patch(f"{_RA}.get_newsletter_edition", return_value=None), \
+             patch(f"{_RA}.get_current_profile") as gp:
+            result = auto_publish_edition.run(edition_id=9)
+        assert "not publishable" in result
+        gp.assert_not_called()
+
+    def test_publishes_and_marks(self):
+        from cqc_lem.app.run_automation import auto_publish_edition
+        edition = {"id": 9, "user_id": 1, "status": "approved", "title": "5 Levers",
+                   "subtitle": "The reach levers.", "body": "Hook\n\nSECTION\n\nBody."}
+        with patch(f"{_RA}.get_newsletter_edition", return_value=edition), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}._fill_and_publish_article", return_value="https://x/pulse/5-levers") as fill, \
+             patch(f"{_RA}.mark_edition_published") as mark, \
+             patch(f"{_RA}.mark_edition_failed") as fail, \
+             patch(f"{_RA}.quit_gracefully"):
+            result = auto_publish_edition.run(edition_id=9)
+        mark.assert_called_once_with(9, "https://x/pulse/5-levers")
+        fail.assert_not_called()
+        assert "Published newsletter edition: 5 Levers" in result
+        assert fill.call_args.kwargs.get("subtitle") == "The reach levers."
+
+    def test_marks_failed_when_flow_incomplete(self):
+        from cqc_lem.app.run_automation import auto_publish_edition
+        edition = {"id": 9, "user_id": 1, "status": "draft", "title": "T", "subtitle": None, "body": "B"}
+        with patch(f"{_RA}.get_newsletter_edition", return_value=edition), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}._fill_and_publish_article", return_value=None), \
+             patch(f"{_RA}.mark_edition_published") as mark, \
+             patch(f"{_RA}.mark_edition_failed") as fail, \
+             patch(f"{_RA}.quit_gracefully"):
+            result = auto_publish_edition.run(edition_id=9)
+        mark.assert_not_called()
+        fail.assert_called_once_with(9)
+        assert "did not complete" in result
+
+
+class TestGenerateNewsletterDrafts:
+    def test_generates_and_notifies(self):
+        from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
+        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly",
+                    "last_published_at": None, "topic": "reach"}
+        edition = {"title": "T", "subtitle": "S", "body": "B"}
+        with patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=[1]), \
+             patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=settings), \
+             patch("cqc_lem.utilities.db.get_user_timezone", return_value="UTC"), \
+             patch("cqc_lem.utilities.db.get_pending_newsletter_edition", return_value=None), \
+             patch("cqc_lem.utilities.db.create_newsletter_edition", return_value=42) as create, \
+             patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()), \
+             patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", return_value=edition), \
+             patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=True), \
+             patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready") as notify:
+            result = auto_generate_newsletter_drafts()
+        create.assert_called_once()
+        notify.assert_called_once()
+        assert "1 user" in result
+
+    def test_skips_when_pending_exists(self):
+        from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
+        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None}
+        with patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=[1]), \
+             patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=settings), \
+             patch("cqc_lem.utilities.db.get_user_timezone", return_value="UTC"), \
+             patch("cqc_lem.utilities.db.get_pending_newsletter_edition", return_value={"id": 5}), \
+             patch("cqc_lem.utilities.db.create_newsletter_edition") as create, \
+             patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=True):
+            result = auto_generate_newsletter_drafts()
+        create.assert_not_called()
+        assert "0 user" in result
+
+    def test_skips_when_not_time_yet(self):
+        from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
+        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None}
+        with patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=[1]), \
+             patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=settings), \
+             patch("cqc_lem.utilities.db.get_user_timezone", return_value="UTC"), \
+             patch("cqc_lem.utilities.db.get_pending_newsletter_edition", return_value=None) as pend, \
+             patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=False):
+            result = auto_generate_newsletter_drafts()
+        pend.assert_not_called()
+        assert "0 user" in result
+
+    def test_one_user_failure_does_not_stop_loop(self):
+        from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
+        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly",
+                    "last_published_at": None, "topic": None}
+        with patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=[1, 2]), \
+             patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=settings), \
+             patch("cqc_lem.utilities.db.get_user_timezone", side_effect=[Exception("boom"), "UTC"]), \
+             patch("cqc_lem.utilities.db.get_pending_newsletter_edition", return_value=None), \
+             patch("cqc_lem.utilities.db.create_newsletter_edition", return_value=1), \
+             patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()), \
+             patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition",
+                   return_value={"title": "T", "subtitle": "S", "body": "B"}), \
+             patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=True), \
+             patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready"):
+            result = auto_generate_newsletter_drafts()
+        assert "1 user" in result
+
+
+class TestPublishScheduledEditions:
+    def test_dispatches_due_editions(self):
+        from cqc_lem.app.run_scheduler import auto_publish_scheduled_editions
+        with patch("cqc_lem.utilities.db.get_editions_due_to_publish",
+                   return_value=[{"id": 3}, {"id": 8}]), \
+             patch("cqc_lem.app.run_automation.auto_publish_edition") as task:
+            result = auto_publish_scheduled_editions()
         assert task.apply_async.call_count == 2
-        assert "2 user" in result
+        assert "2 newsletter edition" in result

--- a/tests/unit/utilities/test_db_newsletter.py
+++ b/tests/unit/utilities/test_db_newsletter.py
@@ -52,3 +52,94 @@ class TestNewsletterDue:
             import datetime
             assert get_newsletter_due_user_ids(datetime.datetime(2026, 7, 4)) == [1, 5]
         assert "enabled=1" in cur.execute.call_args[0][0]
+
+
+class TestNewsletterSchedulingFields:
+    def test_settings_include_publish_day_hour(self):
+        row = {"enabled": 1, "title": "T", "topic": None, "cadence": "weekly",
+               "align_with_blog": 1, "newsletter_url": None, "last_published_at": None,
+               "publish_day": "3", "publish_hour": "14"}
+        conn, _ = _mock_conn(fetch_row=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_settings
+            s = get_newsletter_settings(1)
+        assert s["publish_day"] == 3 and s["publish_hour"] == 14
+
+    def test_defaults_publish_day_hour(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_settings
+            s = get_newsletter_settings(1)
+        assert s["publish_day"] == 1 and s["publish_hour"] == 9
+
+
+class TestEnabledNewsletterUsers:
+    def test_returns_ids(self):
+        conn, cur = _mock_conn(fetch_all=[(2,), (9,)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_enabled_newsletter_user_ids
+            assert get_enabled_newsletter_user_ids() == [2, 9]
+        assert "enabled=1" in cur.execute.call_args[0][0]
+
+
+class TestEditions:
+    def test_create_returns_lastrowid(self):
+        conn, cur = _mock_conn()
+        cur.lastrowid = 77
+        import datetime
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import create_newsletter_edition
+            assert create_newsletter_edition(1, "T", "S", "B", datetime.datetime(2026, 7, 7, 13)) == 77
+        assert "INSERT INTO newsletter_editions" in cur.execute.call_args[0][0]
+
+    def test_get_pending(self):
+        row = {"id": 4, "title": "T", "subtitle": "S", "body": "B", "status": "draft",
+               "scheduled_for": None}
+        conn, cur = _mock_conn(fetch_row=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_pending_newsletter_edition
+            assert get_pending_newsletter_edition(1)["id"] == 4
+        sql = cur.execute.call_args[0][0]
+        assert "draft" in sql and "approved" in sql
+
+    def test_update_only_provided_fields(self):
+        conn, cur = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_newsletter_edition
+            assert update_newsletter_edition(4, 1, status="approved") is True
+        sql, params = cur.execute.call_args[0]
+        assert "COALESCE" in sql
+        assert params == (None, None, None, "approved", 4, 1)
+
+    def test_editions_due(self):
+        rows = [{"id": 3, "user_id": 1, "title": "T", "subtitle": "S", "body": "B"}]
+        conn, cur = _mock_conn(fetch_all=rows)
+        import datetime
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_editions_due_to_publish
+            due = get_editions_due_to_publish(datetime.datetime(2026, 7, 7, 13))
+        assert due[0]["id"] == 3
+        assert "scheduled_for <= %s" in cur.execute.call_args[0][0]
+
+    def test_get_edition(self):
+        row = {"id": 3, "user_id": 1, "title": "T", "subtitle": "S", "body": "B",
+               "status": "draft", "scheduled_for": None, "published_url": None}
+        conn, _ = _mock_conn(fetch_row=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_edition
+            assert get_newsletter_edition(3)["user_id"] == 1
+
+    def test_mark_published_rolls_cadence(self):
+        conn, cur = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import mark_edition_published
+            assert mark_edition_published(3, "https://x/pulse/y") is True
+        sqls = " ".join(c.args[0] for c in cur.execute.call_args_list)
+        assert "status='published'" in sqls and "last_published_at=NOW()" in sqls
+
+    def test_mark_failed(self):
+        conn, cur = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import mark_edition_failed
+            assert mark_edition_failed(3) is True
+        assert "status='failed'" in cur.execute.call_args[0][0]

--- a/tests/unit/utilities/test_newsletter_scheduling.py
+++ b/tests/unit/utilities/test_newsletter_scheduling.py
@@ -1,0 +1,46 @@
+"""Unit tests for newsletter scheduling math."""
+
+from datetime import datetime
+
+import pytest
+import pytz
+
+pytestmark = pytest.mark.unit
+
+_ET = pytz.timezone("America/New_York")  # July = EDT (UTC-4), so 9am local = 13:00 UTC
+
+
+class TestNextPublishDatetime:
+    def test_never_published_finds_next_tuesday_9am_local(self):
+        from cqc_lem.utilities.newsletter import next_publish_datetime
+        now = datetime(2026, 7, 5, 12, 0)  # Sunday, UTC
+        nxt = next_publish_datetime(1, 9, "weekly", None, _ET, now)  # Tue 9am
+        assert nxt == datetime(2026, 7, 7, 13, 0)  # Tue 2026-07-07 09:00 EDT == 13:00 UTC
+
+    def test_respects_weekly_interval_after_last_edition(self):
+        from cqc_lem.utilities.newsletter import next_publish_datetime
+        last = datetime(2026, 7, 7, 13, 0)  # published Tue
+        now = datetime(2026, 7, 8, 12, 0)
+        nxt = next_publish_datetime(1, 9, "weekly", last, _ET, now)
+        assert nxt == datetime(2026, 7, 14, 13, 0)  # the FOLLOWING Tuesday, not tomorrow
+
+    def test_slot_already_passed_today_rolls_to_next_week(self):
+        from cqc_lem.utilities.newsletter import next_publish_datetime
+        now = datetime(2026, 7, 7, 15, 0)  # Tuesday 15:00 UTC — past the 13:00 slot
+        nxt = next_publish_datetime(1, 9, "weekly", None, _ET, now)
+        assert nxt == datetime(2026, 7, 14, 13, 0)
+
+    def test_biweekly_interval(self):
+        from cqc_lem.utilities.newsletter import next_publish_datetime
+        last = datetime(2026, 7, 7, 13, 0)
+        now = datetime(2026, 7, 8, 12, 0)
+        nxt = next_publish_datetime(1, 9, "biweekly", last, _ET, now)
+        assert nxt == datetime(2026, 7, 21, 13, 0)  # +14 days → Tue 2026-07-21
+
+
+class TestShouldGenerateNow:
+    def test_within_lead_window(self):
+        from cqc_lem.utilities.newsletter import should_generate_now
+        nxt = datetime(2026, 7, 14, 13, 0)
+        assert should_generate_now(nxt, datetime(2026, 7, 12, 12, 0)) is True   # 2 days out
+        assert should_generate_now(nxt, datetime(2026, 7, 10, 12, 0)) is False  # 4 days out

--- a/tests/unit/utilities/test_notifications.py
+++ b/tests/unit/utilities/test_notifications.py
@@ -71,6 +71,24 @@ def test_throttle_zero_always_sends(monkeypatch):
         sc.assert_called_once()
 
 
+def test_newsletter_draft_ready_sends():
+    from datetime import datetime
+    from cqc_lem.utilities.notifications import notify_newsletter_draft_ready
+    with patch(f"{_MOD}.get_user_email", return_value="u@e.com"), \
+         patch(f"{_MOD}.send_newsletter_draft_ready_email", return_value=True) as snd:
+        assert notify_newsletter_draft_ready(3, "My Edition", datetime(2026, 7, 7, 13, 0)) is True
+        snd.assert_called_once()
+        assert snd.call_args[0][1] == "My Edition"
+
+
+def test_newsletter_draft_ready_no_email():
+    from cqc_lem.utilities.notifications import notify_newsletter_draft_ready
+    with patch(f"{_MOD}.get_user_email", return_value=None), \
+         patch(f"{_MOD}.send_newsletter_draft_ready_email") as snd:
+        assert notify_newsletter_draft_ready(3, "My Edition", "2026-07-07") is False
+        snd.assert_not_called()
+
+
 def test_not_stamped_when_send_fails(monkeypatch):
     monkeypatch.setenv("LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS", "7")
     with patch(f"{_MOD}.get_linkedin_session_email_sent_at", return_value=None), \


### PR DESCRIPTION
Closes the gaps you flagged: no review step, no day/time control, no next-post visibility.

**How it works now:** ~3 days before your slot, the edition is generated as a **draft**, you're **emailed**, and you can edit/approve/skip it in the SPA. At your chosen **weekday + hour** (default Tue 9am, your timezone) it auto-publishes the (possibly-edited) draft — untouched drafts still go out, so cadence never breaks.

- **V44**: `publish_day`/`publish_hour` on newsletter_settings + `newsletter_editions` table (draft→approved→published / skipped / failed).
- **Scheduling math** (`utilities/newsletter.py`, hand-written + unit-tested): next Tue-9am-local slot, respects weekly/biweekly interval, DST-safe.
- **Beats**: `generate-newsletter-drafts` (daily, generates ahead + emails) replaces the old one-shot publish; `publish-scheduled-newsletters` (hourly, publishes due editions via `auto_publish_edition`).
- **API**: settings gain day/hour; `GET/PUT /user/newsletter-draft` (save/approve/skip).
- **UI**: NewsletterCard gets weekday+hour pickers, next-edition date, and an editable draft with Approve/Skip.

1254 unit tests pass; tsc clean. Reviewed: workflow states, dedup (skips users with a pending edition), `last_published_at` rolls forward on publish to prevent re-generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)