### PR TITLE
fix(compose): correct selenium-lane healthcheck node name (false unhealthy)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,9 @@ services:
       selenium-chrome:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "celery --app cqc_lem.app.my_celery inspect ping -d selenium-${SELENIUM_QUEUES}-worker@$(hostname) -t 10 || exit 1"]
+      # $$ escapes compose interpolation so the CONTAINER shell expands SELENIUM_QUEUES at runtime
+      # (a bare $ is blanked by compose at parse time → selenium--worker → matches no node → false unhealthy).
+      test: ["CMD-SHELL", "celery --app cqc_lem.app.my_celery inspect ping -d selenium-$${SELENIUM_QUEUES}-worker@$(hostname) -t 10 || exit 1"]
       interval: 30s
       timeout: 30s
       retries: 3
@@ -165,7 +167,9 @@ services:
       selenium-chrome:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "celery --app cqc_lem.app.my_celery inspect ping -d selenium-${SELENIUM_QUEUES}-worker@$(hostname) -t 10 || exit 1"]
+      # $$ escapes compose interpolation so the CONTAINER shell expands SELENIUM_QUEUES at runtime
+      # (a bare $ is blanked by compose at parse time → selenium--worker → matches no node → false unhealthy).
+      test: ["CMD-SHELL", "celery --app cqc_lem.app.my_celery inspect ping -d selenium-$${SELENIUM_QUEUES}-worker@$(hostname) -t 10 || exit 1"]
       interval: 30s
       timeout: 30s
       retries: 3
@@ -199,7 +203,9 @@ services:
       selenium-chrome:
         condition: service_healthy
     healthcheck:
-      test: ["CMD-SHELL", "celery --app cqc_lem.app.my_celery inspect ping -d selenium-${SELENIUM_QUEUES}-worker@$(hostname) -t 10 || exit 1"]
+      # $$ escapes compose interpolation so the CONTAINER shell expands SELENIUM_QUEUES at runtime
+      # (a bare $ is blanked by compose at parse time → selenium--worker → matches no node → false unhealthy).
+      test: ["CMD-SHELL", "celery --app cqc_lem.app.my_celery inspect ping -d selenium-$${SELENIUM_QUEUES}-worker@$(hostname) -t 10 || exit 1"]
       interval: 30s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
## Problem
After the Selenium lane split (#274, v0.25.x), all three lane workers —
`celery_worker_selenium` (se_engage), `_outreach` (se_outreach), `_content` (se_content) —
show **`unhealthy`** on the VPS even though they run fine and answer `celery inspect ping`.

## Root cause
The healthcheck targets a specific node:
```
inspect ping -d selenium-${SELENIUM_QUEUES}-worker@$(hostname)
```
docker-compose **interpolates `${SELENIUM_QUEUES}` at parse time** from the host env (where it is
unset), collapsing the destination to `selenium--worker@<host>` — a node name that never exists.
So the ping always returns *"No nodes replied within time constraint"* → container flagged unhealthy.

The worker's actual node name is built with the lane embedded: `selenium-se_engage-worker@<host>`.

## Fix
Escape as `$${SELENIUM_QUEUES}` so the value is expanded by the **container** shell at runtime
(each worker sets `SELENIUM_QUEUES` in its env), producing the real node name.

## Verification (live on VPS)
Simulated the fixed command inside each running worker:
```
celery_worker_selenium          -> selenium-se_engage-worker@b26110463e62: OK
celery_worker_selenium_outreach -> selenium-se_outreach-worker@8bab348236da: OK
celery_worker_selenium_content  -> selenium-se_content-worker@6bc9ef523dcc: OK
```

## Impact
No autoheal is configured, so the false status was cosmetic — but several services declare
`depends_on: condition: service_healthy` on these workers, so a future `compose up` recreating a
dependent could hang waiting on a worker that never reports healthy. Compose-only change; YAML
validated via `docker compose config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)