### PR TITLE
feat(engagement): react on posts we comment on (SDUI, AI-chosen reaction)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -15,7 +15,7 @@ from celery_once import QueueOnce
 from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_refinement, summarize_recent_activity, \
     ai_check_message_history, post_is_relevant, generate_newsletter_edition, generate_group_post, \
-    generate_thread_reply, generate_seed_comment
+    generate_thread_reply, generate_seed_comment, choose_post_reaction
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
@@ -639,6 +639,50 @@ def post_comment_inline(driver, wait, card, comment_text: str, user_id: int = No
         return False
 
 
+def react_to_post_inline(driver, wait, card, post_content: str = None, comment_text: str = None,
+                         user_id: int = None) -> bool:
+    """Leave a single reaction on the card's post via the SDUI reaction fly-out.
+
+    The 2026 SDUI reaction controls carry obfuscated hashed classes, so the stable anchors are
+    aria-labels (verified live): the per-card 'Open reactions menu' trigger, the 'Reaction button
+    state: ...' toggle, and the fly-out buttons whose aria-label is exactly the reaction name
+    (Like / Celebrate / Support / Love / Insightful). The reaction itself is picked by a fast AI
+    call scoped to the post + our comment, which self-falls-back to random. Returns True only if a
+    reaction registered (the toggle no longer reads 'no reaction')."""
+    try:
+        state = find_first(driver, wait, [(By.CSS_SELECTOR, "button[aria-label^='Reaction button state']")],
+                           "Reaction state", parent_element=card, required=False, visible_only=True, user_id=user_id)
+        if state is not None and "no reaction" not in (state.get_attribute("aria-label") or "").lower():
+            return False  # already reacted on this post
+
+        reaction = choose_post_reaction(post_content, comment_text)
+        if click_first(driver, wait, [(By.CSS_SELECTOR, "button[aria-label='Open reactions menu']")],
+                       "Open reactions menu", parent_element=card, required=False, user_id=user_id) is None:
+            return False
+        time.sleep(random.uniform(0.8, 1.6))
+        # The fly-out can render just outside the card subtree, so match the reaction button globally
+        # (only one menu is open at a time and click_first filters to visible elements).
+        if click_first(driver, wait,
+                       [(By.CSS_SELECTOR, f"button[aria-label='{reaction}']"),
+                        (By.CSS_SELECTOR, "button[aria-label='Like']")],
+                       f"React {reaction}", user_id=user_id) is None:
+            return False
+        time.sleep(random.uniform(0.8, 1.5))
+        wait_for_ajax(driver)
+        after = find_first(driver, wait, [(By.CSS_SELECTOR, "button[aria-label^='Reaction button state']")],
+                           "Reaction state (post-click)", parent_element=card, required=False,
+                           visible_only=True, user_id=user_id)
+        # Best-effort confirm: label flips away from 'no reaction'. If the toggle can't be re-read,
+        # trust the click rather than false-negative.
+        if after is not None and "no reaction" in (after.get_attribute("aria-label") or "").lower():
+            return False
+        myprint(f"Reacted '{reaction}' on post")
+        return True
+    except Exception as e:
+        log_warning("Inline post reaction failed", exc=e, action_type="comment", user_id=user_id)
+        return False
+
+
 def post_matches_preferences(content: str, author: str, prefs: dict) -> bool:
     """Decide whether a post should be engaged given the user's targeting preferences.
 
@@ -764,6 +808,9 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
                     insert_new_log(user_id=user_id, action_type=LogActionType.COMMENT,
                                    result=LogResultType.SUCCESS, post_url=key, message=comment_text)
                     posted += 1
+                    # React on the same post to reinforce the comment (non-fatal if it misses).
+                    react_to_post_inline(driver, wait, card, post_content=content,
+                                         comment_text=comment_text, user_id=user_id)
                     myprint(f"Commented on {author or 'a'}'s post "
                             f"(score {score:.2f}, age {'?' if age is None else str(age) + 'm'}) ({posted}/{max_posts})")
                     time.sleep(random.uniform(6, 14))  # human pacing between comments

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -205,6 +205,64 @@ def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=No
     return content.strip() if content is not None else None
 
 
+# LinkedIn's reaction set, safest-first (also the random-fallback preference order). 'Funny' is
+# omitted by default — it reads poorly on most professional posts; callers can pass it via `allowed`.
+POST_REACTIONS = ["Like", "Celebrate", "Support", "Love", "Insightful"]
+
+
+def _match_reaction(text: str, options: list[str]) -> "str | None":
+    """Normalize a model's one-word answer to one of `options` (case-insensitive), else None."""
+    words = (text or "").strip().strip(".!?\"'").split()
+    if not words:
+        return None
+    pick = words[0]
+    for opt in options:
+        if opt.lower() == pick.lower():
+            return opt
+    return None
+
+
+def choose_post_reaction(post_content: str, comment_text: str = None,
+                         allowed: list[str] = None) -> str:
+    """Pick the single most fitting LinkedIn reaction for a post we just commented on.
+
+    Light + fast: one short `lem-simple` call with minimal context (a post snippet + our comment).
+    If the LiteLLM proxy fails it retries once directly against OpenAI; if that also fails it returns
+    a random choice — so a valid reaction is always returned."""
+    options = allowed or POST_REACTIONS
+    messages = [
+        {"role": "system",
+         "content": ("You pick the single best LinkedIn reaction for a post. Reply with EXACTLY one "
+                     f"word from this list and nothing else: {', '.join(options)}. Choose what a "
+                     "thoughtful professional would leave, matching the post's tone — celebratory news "
+                     "-> Celebrate, hardship or something vulnerable -> Support, a strong data point or "
+                     "lesson -> Insightful, heartfelt or personal -> Love, otherwise -> Like.")},
+        {"role": "user",
+         "content": (f"Post: {(post_content or '').strip()[:600]}\n\n"
+                     f"My comment: {(comment_text or '').strip()[:300]}\n\nReaction:")},
+    ]
+
+    try:
+        resp = _call_llm(model="lem-simple", messages=messages, temperature=0, max_tokens=3)
+        pick = _match_reaction(resp.choices[0].message.content, options)
+        if pick:
+            return pick
+    except Exception as exc:
+        log_warning("Reaction pick via LiteLLM failed; trying OpenAI fallback", exc=exc, api_provider="litellm")
+        try:
+            fallback = openai.OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
+            resp = fallback.chat.completions.create(
+                model=os.getenv("OPENAI_FALLBACK_MODEL", "gpt-4o-mini"),
+                messages=messages, temperature=0, max_tokens=3)
+            pick = _match_reaction(resp.choices[0].message.content, options)
+            if pick:
+                return pick
+        except Exception as exc2:
+            log_warning("Reaction pick via OpenAI fallback failed; using random", exc=exc2, api_provider="openai")
+
+    return random.choice(options)
+
+
 def _clean_newsletter_body(body: str) -> str:
     """Safety net: strip stray markdown the model may slip in (headers, bold, bullet markers) so the
     body typed via Selenium send_keys is clean — LinkedIn's article editor does NOT render markdown.

--- a/tests/unit/app/test_comment_inline.py
+++ b/tests/unit/app/test_comment_inline.py
@@ -71,3 +71,69 @@ class TestPostCommentInline:
              patch(f"{_RA}.find_first", return_value=None):
             ok = ra.post_comment_inline(MagicMock(), MagicMock(), MagicMock(), "hello", user_id=1)
         assert ok is False
+
+
+def _state(label):
+    el = MagicMock()
+    el.get_attribute.return_value = label
+    return el
+
+
+class TestReactToPostInline:
+    def test_reacts_when_not_yet_reacted(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
+             patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.find_first", side_effect=[_state("Reaction button state: no reaction"),
+                                                     _state("Reaction button state: Like reaction")]), \
+             patch(f"{_RA}.click_first", return_value=MagicMock()):
+            ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(),
+                                         post_content="p", comment_text="c", user_id=1)
+        assert ok is True
+
+    def test_skips_when_already_reacted(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction") as cpr, \
+             patch(f"{_RA}.find_first", return_value=_state("Reaction button state: Celebrate reaction")), \
+             patch(f"{_RA}.click_first") as cf:
+            ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
+        assert ok is False
+        cpr.assert_not_called()      # no AI spend when we've already reacted
+        cf.assert_not_called()       # and we never open the menu
+
+    def test_false_when_menu_wont_open(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
+             patch(f"{_RA}.find_first", return_value=_state("Reaction button state: no reaction")), \
+             patch(f"{_RA}.click_first", return_value=None):
+            ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
+        assert ok is False
+
+    def test_clicks_the_ai_chosen_reaction(self):
+        from cqc_lem.app import run_automation as ra
+        seen = []
+
+        def _capture(driver, wait, locators, label, **kw):
+            seen.append(locators)
+            return MagicMock()
+
+        with patch(f"{_RA}.choose_post_reaction", return_value="Support"), \
+             patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.find_first", side_effect=[_state("Reaction button state: no reaction"),
+                                                     _state("Reaction button state: Support reaction")]), \
+             patch(f"{_RA}.click_first", side_effect=_capture):
+            ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(),
+                                         post_content="p", comment_text="c", user_id=1)
+        assert ok is True
+        # 2nd click_first is the reaction click; its primary locator targets aria-label='Support'
+        assert any("aria-label='Support'" in loc[1] for loc in seen[1])
+
+    def test_false_when_reaction_did_not_register(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
+             patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.find_first", side_effect=[_state("Reaction button state: no reaction"),
+                                                     _state("Reaction button state: no reaction")]), \
+             patch(f"{_RA}.click_first", return_value=MagicMock()):
+            ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
+        assert ok is False  # toggle never flipped away from 'no reaction'

--- a/tests/unit/utilities/ai/test_choose_reaction.py
+++ b/tests/unit/utilities/ai/test_choose_reaction.py
@@ -1,0 +1,55 @@
+"""Unit tests for choose_post_reaction — the fast reaction picker with OpenAI + random fallbacks."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_AH = "cqc_lem.utilities.ai.ai_helper"
+
+
+def _resp(content):
+    return MagicMock(choices=[MagicMock(message=MagicMock(content=content))])
+
+
+class TestChoosePostReaction:
+    def test_returns_valid_reaction_from_llm(self):
+        from cqc_lem.utilities.ai.ai_helper import choose_post_reaction
+        with patch(f"{_AH}.client") as client:
+            client.chat.completions.create.return_value = _resp("Celebrate")
+            assert choose_post_reaction("We just closed our seed round!", "Congrats!") == "Celebrate"
+        assert client.chat.completions.create.call_args[1].get("model") == "lem-simple"
+
+    def test_normalizes_case_and_punctuation(self):
+        from cqc_lem.utilities.ai.ai_helper import choose_post_reaction
+        with patch(f"{_AH}.client") as client:
+            client.chat.completions.create.return_value = _resp("insightful.")
+            assert choose_post_reaction("Here's the data", "Good breakdown") == "Insightful"
+
+    def test_invalid_llm_word_falls_back_to_random(self):
+        from cqc_lem.utilities.ai.ai_helper import choose_post_reaction, POST_REACTIONS
+        with patch(f"{_AH}.client") as client:
+            client.chat.completions.create.return_value = _resp("Banana")
+            assert choose_post_reaction("p", "c") in POST_REACTIONS
+
+    def test_litellm_failure_uses_openai_fallback(self):
+        from cqc_lem.utilities.ai.ai_helper import choose_post_reaction
+        with patch(f"{_AH}.client") as client, patch(f"{_AH}.openai") as oa:
+            client.chat.completions.create.side_effect = Exception("proxy down")
+            oa.OpenAI.return_value.chat.completions.create.return_value = _resp("Support")
+            assert choose_post_reaction("Going through a tough layoff", "Hang in there") == "Support"
+            assert oa.OpenAI.called
+
+    def test_all_providers_fail_returns_random(self):
+        from cqc_lem.utilities.ai.ai_helper import choose_post_reaction, POST_REACTIONS
+        with patch(f"{_AH}.client") as client, patch(f"{_AH}.openai") as oa:
+            client.chat.completions.create.side_effect = Exception("proxy down")
+            oa.OpenAI.return_value.chat.completions.create.side_effect = Exception("openai down")
+            assert choose_post_reaction("p", "c") in POST_REACTIONS
+
+    def test_respects_allowed_list(self):
+        from cqc_lem.utilities.ai.ai_helper import choose_post_reaction
+        with patch(f"{_AH}.client") as client:
+            client.chat.completions.create.return_value = _resp("Funny")
+            # 'Funny' is excluded by default; explicitly allowing it lets it through
+            assert choose_post_reaction("lol", "haha", allowed=["Like", "Funny"]) == "Funny"


### PR DESCRIPTION
## Problem
Auto-commenting worked but **never left a reaction** on the post. The reaction
code only existed in the retired per-permalink `comment_on_post` path (built on
dead pre-SDUI `comments-comment-*` selectors). The live SDUI feed flow —
`automate_commenting → comment_on_feed_inline` (also used by
`auto_comment_in_groups`) — commented without reacting.

## Fix
- **`react_to_post_inline()`** (`run_automation.py`): opens the card's reaction
  fly-out and clicks a reaction, wired in right after each successful inline
  comment. Group commenting inherits it (same function).
- **MCP-verified 2026 SDUI selectors.** The reaction controls now carry
  obfuscated hashed classes, so the helper anchors on aria-labels verified live
  against the logged-in feed:
  - trigger: `button[aria-label='Open reactions menu']`
  - reaction: `button[aria-label='Like'|'Celebrate'|'Support'|'Love'|'Insightful']` (exact)
  - skip/verify via the `button[aria-label^='Reaction button state']` toggle
    (`no reaction` → flips once reacted). Skips posts already reacted to; returns
    False if the toggle never flips.
- **AI-chosen reaction, not random.** `choose_post_reaction()`
  (`ai_helper.py`) makes one fast/light `lem-simple` call with minimal context
  (post snippet + our comment) to pick the fitting reaction. Fallback chain:
  **LiteLLM proxy → direct OpenAI (`OPENAI_FALLBACK_MODEL`, default gpt-4o-mini)
  → random choice**, so a valid reaction always lands. `Funny` is excluded by
  default (reads poorly on professional posts); callers can opt in via `allowed`.

## Tests
- `test_comment_inline.py::TestReactToPostInline` — reacts / skips-already-reacted /
  menu-won't-open / uses the AI-chosen aria-label / false-when-not-registered.
- `test_choose_reaction.py` — valid pick, normalization, invalid→random,
  LiteLLM-fail→OpenAI fallback, all-fail→random, `allowed` list respected.
- Full `tests/unit/app` + `tests/unit/utilities/ai` suites green (389 passed).

## Verification
Reaction fly-out selectors confirmed live via the selenium-lem MCP against the
logged-in feed (menu opened, all six reaction buttons enumerated, no reaction
left on the account). End-to-end "actually leave a reaction" run not performed to
avoid mutating the live account — can do on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)