### PR TITLE
fix(time): user-local 12h times + hide synthetic feed URLs (P0)

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -167,6 +167,30 @@ def _parse_slides(raw) -> Optional[List[str]]:
         return None
 
 
+def _utc_iso(dt) -> Optional[str]:
+    """Serialize a datetime as an explicit-UTC ISO string (trailing 'Z') so clients localize it
+    correctly. Stored datetimes are UTC but historically naive — assume naive means UTC. Without the
+    offset the browser parses the string as local time and every displayed value is off by its
+    UTC offset."""
+    if dt is None:
+        return None
+    if isinstance(dt, str):
+        try:
+            dt = datetime.fromisoformat(dt.replace("Z", "+00:00"))
+        except ValueError:
+            return dt
+    dt = dt.replace(tzinfo=timezone.utc) if getattr(dt, "tzinfo", None) is None else dt.astimezone(timezone.utc)
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _public_post_url(value) -> Optional[str]:
+    """Only surface real http(s) permalinks. Home-feed comments have no LinkedIn permalink and are
+    logged under a synthetic 'feedpost://<hash>' dedup key — never expose that raw string to the UI."""
+    if isinstance(value, str) and value.lower().startswith(("http://", "https://")):
+        return value
+    return None
+
+
 class PostRequest(BaseModel):
     content: str
     video_url: Optional[str] = None
@@ -470,9 +494,9 @@ def get_activity(email: str, limit: int = 20) -> ResponseModel:
             "action_type": row["action_type"],
             "result": row["result"],
             "post_id": row["post_id"],
-            "post_url": row["post_url"],
+            "post_url": _public_post_url(row["post_url"]),
             "message": row["message"],
-            "created_at": row["created_at"].isoformat() if row.get("created_at") else None,
+            "created_at": _utc_iso(row.get("created_at")),
         }
         for row in logs
     ]
@@ -653,7 +677,7 @@ def get_posts_for_email(
             "post_id": post["id"],
             "content": post["content"],
             "video_url": post["video_url"],
-            "scheduled_time": post["scheduled_time"],
+            "scheduled_time": _utc_iso(post["scheduled_time"]),
             "post_type": post["post_type"],
             "status": post["status"],
             "carousel_slides": _parse_slides(post.get("carousel_slides")),

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -235,29 +235,28 @@ export default function Dashboard() {
                     {entry.message && (
                       <p className="text-xs text-gray-500 mt-0.5 line-clamp-1">{entry.message}</p>
                     )}
-                    {entry.post_url &&
-                      (isHttpUrl(entry.post_url) ? (
-                        <a
-                          href={entry.post_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-xs text-blue-500 hover:underline truncate block"
-                        >
-                          {entry.post_url}
-                        </a>
-                      ) : commentsUrl ? (
-                        <a
-                          href={commentsUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          title="View your LinkedIn comments"
-                          className="text-xs text-blue-500 hover:underline truncate block"
-                        >
-                          View your LinkedIn comments
-                        </a>
-                      ) : (
-                        <span className="text-xs text-gray-400 truncate block">{entry.post_url}</span>
-                      ))}
+                    {isHttpUrl(entry.post_url) ? (
+                      <a
+                        href={entry.post_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-xs text-blue-500 hover:underline truncate block"
+                      >
+                        {entry.post_url}
+                      </a>
+                    ) : commentsUrl && (entry.action_type === 'comment' || entry.action_type === 'reply') ? (
+                      // Feed comments/replies have no permalink (post_url is blanked server-side) —
+                      // link to the user's own LinkedIn "recent activity → comments" page instead.
+                      <a
+                        href={commentsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        title="View your LinkedIn comments"
+                        className="text-xs text-blue-500 hover:underline truncate block"
+                      >
+                        View your LinkedIn comments
+                      </a>
+                    ) : null}
                   </div>
                   <span className="text-xs text-gray-400 flex-shrink-0 whitespace-nowrap">
                     {formatInTimezone(entry.created_at, userTimezone)}

--- a/src/cqc_lem/ui/src/utils/datetime.ts
+++ b/src/cqc_lem/ui/src/utils/datetime.ts
@@ -1,3 +1,12 @@
+// Backend datetimes are UTC. They were historically serialized as naive ISO (no 'Z'/offset); the
+// API now emits an explicit 'Z', but we still defensively append one when it's missing so
+// `new Date()` parses them as UTC rather than the viewer's local time — otherwise every rendered
+// time is off by the browser's UTC offset. Times are always shown 12-hour (never 24h).
+function toUtcDate(isoString: string): Date {
+  const hasOffset = /[zZ]$|[+-]\d\d:?\d\d$/.test(isoString)
+  return new Date(hasOffset ? isoString : isoString + 'Z')
+}
+
 export function formatInTimezone(
   isoString: string | null | undefined,
   tz: string,
@@ -9,11 +18,12 @@ export function formatInTimezone(
       timeZone: tz,
       month: 'short',
       day: 'numeric',
-      hour: '2-digit',
+      hour: 'numeric',
       minute: '2-digit',
+      hour12: true,
       ...options,
-    }).format(new Date(isoString))
+    }).format(toUtcDate(isoString))
   } catch {
-    return new Date(isoString).toLocaleString()
+    return toUtcDate(isoString).toLocaleString('en-US', { hour12: true })
   }
 }

--- a/src/cqc_lem/ui/src/utils/links.ts
+++ b/src/cqc_lem/ui/src/utils/links.ts
@@ -1,6 +1,7 @@
-// Only http(s) values are safe to render as a clickable link. Legacy activity rows may carry a
-// synthetic dedup key (e.g. "feedpost://<hash>") as post_url — those must render as plain text.
-export function isHttpUrl(value: string | null | undefined): boolean {
+// Only http(s) values are safe to render as a clickable link. The API blanks non-http post_url
+// values (e.g. the synthetic "feedpost://<hash>" dedup key for permalink-less feed comments), so
+// this narrows post_url to a real URL string for the link branch.
+export function isHttpUrl(value: string | null | undefined): value is string {
   return typeof value === 'string' && /^https?:\/\//i.test(value)
 }
 

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -132,6 +132,31 @@ class TestGetActivity:
         assert resp.status_code == 200
         assert resp.json()["detail"] == []
 
+    def test_created_at_serialized_as_explicit_utc(self, client):
+        log_row = {
+            "id": 1, "action_type": "post", "result": "success", "post_id": 10,
+            "post_url": "https://linkedin.com/p/123", "message": "ok",
+            "created_at": datetime(2024, 1, 15, 12, 0, 0),  # naive == UTC
+        }
+        with patch(f"{_MAIN}.get_user_id", return_value=5), \
+             patch(f"{_MAIN}.get_recent_logs", return_value=[log_row]):
+            resp = client.get(self.BASE, params={"email": "user@example.com"})
+        assert resp.json()["detail"][0]["created_at"] == "2024-01-15T12:00:00Z"
+
+    def test_synthetic_feedpost_url_blanked(self, client):
+        rows = [
+            {"id": 1, "action_type": "comment", "result": "success", "post_id": None,
+             "post_url": "feedpost://abc123", "message": "nice", "created_at": datetime(2024, 1, 1)},
+            {"id": 2, "action_type": "post", "result": "success", "post_id": 3,
+             "post_url": "https://www.linkedin.com/feed/update/x", "message": "up",
+             "created_at": datetime(2024, 1, 2)},
+        ]
+        with patch(f"{_MAIN}.get_user_id", return_value=5), \
+             patch(f"{_MAIN}.get_recent_logs", return_value=rows):
+            detail = client.get(self.BASE, params={"email": "user@example.com"}).json()["detail"]
+        assert detail[0]["post_url"] is None                                      # feedpost:// hidden
+        assert detail[1]["post_url"] == "https://www.linkedin.com/feed/update/x"  # real permalink kept
+
 
 # ---------------------------------------------------------------------------
 # PUT /api/user/


### PR DESCRIPTION
**Phase 1 (P0)** of the time/date alignment audit. Two visible correctness bugs.

## 1. Times displayed wrong (~4–5h off in ET)
UTC datetimes were serialized as **naive ISO with no offset**, and the SPA
formatter parsed them with `new Date()` as **browser-local** — so every rendered
time was shifted by the viewer's UTC offset.

- **API** now emits explicit-UTC ISO (`…Z`) via `_utc_iso()` for activity
  `created_at` and post `scheduled_time` (handles naive/aware datetimes and ISO
  strings).
- **`formatInTimezone()`** defensively appends `Z` when the string carries no
  offset, and now forces `hour12: true` — **12-hour, never 24h** — in the user's
  timezone.

## 2. `feedpost://<hash>` shown raw in the activity feed
Permalink-less home-feed comments are logged under a synthetic
`feedpost://<hash>` dedup key in `logs.post_url`. It leaked to the UI as raw gray
text for users with no stored LinkedIn profile URL.

- **API** `_public_post_url()` blanks any non-`http(s)` `post_url` in the activity
  response, so the synthetic key never reaches the client (DB value is untouched —
  dedup still works).
- **Dashboard** links comment/reply rows to the user's LinkedIn
  *recent-activity → comments* page instead of rendering the raw string.

## Tests
- `test_main_general.py`: `created_at` serialized as explicit UTC; `feedpost://`
  blanked while real permalinks pass through.
- Full `tests/unit/api` green (221 → 224 passed); SPA `tsc --noEmit` clean.

## Follow-ups (later phases, from the audit)
- **P1 backend:** pin Celery beat to UTC (beat currently runs in ET while crontab
  comments assume UTC); standardize `dm_followups` on UTC; reconcile tz defaults.
- **P1 UI:** replace remaining 24h pickers/`datetime-local` inputs with 12h;
  unify scheduling-input conventions to the user's tz; unify FE/BE best-time model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)