### PR TITLE
fix(time): pin Celery beat to UTC + follow-ups/tz-default on UTC (P1 backend)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -141,7 +141,7 @@ services:
       # Kept behind Cloudflare Access as well (see cloudflared/config.yml).
       - FLOWER_BASIC_AUTH=${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}
       - FLOWER_PERSISTENT=True
-      - CELERY_TIMEZONE=${TZ:-UTC}
+      - CELERY_TIMEZONE=${CELERY_TIMEZONE:-UTC}
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,7 +88,7 @@ services:
     env_file:
       - .env
     environment:
-      - CELERY_TIMEZONE=${TZ:-UTC}
+      - CELERY_TIMEZONE=${CELERY_TIMEZONE:-UTC}
     depends_on:
       redis:
         condition: service_healthy
@@ -120,7 +120,7 @@ services:
     env_file:
       - .env
     environment:
-      - CELERY_TIMEZONE=${TZ:-UTC}
+      - CELERY_TIMEZONE=${CELERY_TIMEZONE:-UTC}
       - SELENIUM_QUEUES=se_engage
       - SELENIUM_CONCURRENCY=2
     depends_on:
@@ -156,7 +156,7 @@ services:
     env_file:
       - .env
     environment:
-      - CELERY_TIMEZONE=${TZ:-UTC}
+      - CELERY_TIMEZONE=${CELERY_TIMEZONE:-UTC}
       - SELENIUM_QUEUES=se_outreach
       - SELENIUM_CONCURRENCY=1
     depends_on:
@@ -192,7 +192,7 @@ services:
     env_file:
       - .env
     environment:
-      - CELERY_TIMEZONE=${TZ:-UTC}
+      - CELERY_TIMEZONE=${CELERY_TIMEZONE:-UTC}
       - SELENIUM_QUEUES=se_content
       - SELENIUM_CONCURRENCY=1
     depends_on:
@@ -220,7 +220,7 @@ services:
     env_file:
       - .env
     environment:
-      - CELERY_TIMEZONE=${TZ:-UTC}
+      - CELERY_TIMEZONE=${CELERY_TIMEZONE:-UTC}
     depends_on:
       redis:
         condition: service_healthy
@@ -249,7 +249,7 @@ services:
     environment:
       - FLOWER_UNAUTHENTICATED_API=True
       - FLOWER_PERSISTENT=False
-      - CELERY_TIMEZONE=${TZ:-UTC}
+      - CELERY_TIMEZONE=${CELERY_TIMEZONE:-UTC}
     ports:
       - "${CELERY_FLOWER_PORT}:${CELERY_FLOWER_PORT}"
     depends_on:

--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -33,7 +33,10 @@ result_backend_max_retries = 3
 # The Redis backend health checks every 5 minutes (300 seconds)
 redis_backend_health_check_interval = 300
 
-timezone = os.getenv('CELERY_TIMEZONE') or os.getenv('TZ') or 'UTC'
+# Beat schedules (my_celery.py crontabs) are authored in UTC — keep the scheduler on UTC and do
+# NOT inherit the container's TZ (which sets local wall-clock / Python datetime.now()), or hour-based
+# crontabs fire at the wrong instant. Post publishing uses aware-UTC ETAs and is unaffected either way.
+timezone = os.getenv('CELERY_TIMEZONE') or 'UTC'
 enable_utc = True
 
 # Prevent task messages from being lost

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -7,7 +7,7 @@ import random
 import sys
 import threading
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import List, Tuple
 from urllib.parse import urlparse
 
@@ -1450,11 +1450,13 @@ def build_dm_from_template(user_id: int, event_type: str, first_name: str,
 
 
 def enqueue_next_followup(user_id: int, profile_url: str, first_name: str, event_type: str, current_step: int) -> None:
-    """If a follow-up template exists for the next step, schedule it at now + its delay_hours."""
+    """If a follow-up template exists for the next step, schedule it at now + its delay_hours.
+    due_at is stored as naive UTC to match the rest of the system (see get_due_followups)."""
     try:
         nxt = get_dm_template(user_id, event_type, current_step + 1)
         if nxt:
-            due = datetime.now() + timedelta(hours=int(nxt.get("delay_hours", 24) or 24))
+            now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
+            due = now_utc + timedelta(hours=int(nxt.get("delay_hours", 24) or 24))
             enqueue_followup(user_id, profile_url, first_name, event_type, current_step + 1, due)
     except Exception as e:
         log_warning("Failed to enqueue next follow-up", exc=e, action_type="followup", user_id=user_id)
@@ -1505,7 +1507,8 @@ def process_user_followups(self, user_id: int, max_per_run: int = 20):
     """Send this user's due DM follow-ups: skip (and stop the sequence) anyone who has replied,
     otherwise render the next-step template in the user's voice, send it, mark it sent, and
     schedule the following step."""
-    due = [f for f in get_due_followups(datetime.now()) if f["user_id"] == user_id]
+    due = [f for f in get_due_followups(datetime.now(timezone.utc).replace(tzinfo=None))
+           if f["user_id"] == user_id]
     if not due:
         return "No due follow-ups"
     try:

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -243,7 +243,8 @@ def auto_send_due_followups():
     """Dispatch a per-user Selenium task to send due DM follow-ups (each gated by reply-detection)."""
     from cqc_lem.app.run_automation import process_user_followups
     from cqc_lem.utilities.db import get_due_followups
-    due = get_due_followups(datetime.now())
+    # due_at is stored naive-UTC; compare against naive-UTC now (not container-local time).
+    due = get_due_followups(datetime.now(timezone.utc).replace(tzinfo=None))
     user_ids = sorted({f["user_id"] for f in due})
     for uid in user_ids:
         process_user_followups.apply_async(kwargs={"user_id": uid})

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2924,16 +2924,17 @@ def update_user_proxy(user_id: int, proxy_url: Optional[str]) -> bool:
 
 
 def get_user_timezone(user_id: int) -> str:
-    """Return the IANA timezone string for the user, defaulting to UTC."""
+    """Return the IANA timezone string for the user. Defaults to America/New_York to match the
+    users.timezone column default and the UI default (not UTC, which would misrender local times)."""
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         cursor.execute("SELECT timezone FROM users WHERE id = %s", (user_id,))
         row = cursor.fetchone()
-        return row[0] if row and row[0] else 'UTC'
+        return row[0] if row and row[0] else 'America/New_York'
     except mysql.connector.Error as err:
         myprint(f"Could not get timezone for user_id {user_id} | Error: {err}")
-        return 'UTC'
+        return 'America/New_York'
     finally:
         cursor.close()
         connection.close()

--- a/tests/unit/utilities/test_db_timezone.py
+++ b/tests/unit/utilities/test_db_timezone.py
@@ -42,26 +42,26 @@ class TestGetUserTimezone:
             result = get_user_timezone(1)
         assert result == "America/New_York"
 
-    def test_returns_utc_when_row_is_none(self, mock_database_connection):
+    def test_returns_default_when_row_is_none(self, mock_database_connection):
         with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
             mock_database_connection["cursor"].fetchone.return_value = None
             from cqc_lem.utilities.db import get_user_timezone
             result = get_user_timezone(99)
-        assert result == "UTC"
+        assert result == "America/New_York"
 
-    def test_returns_utc_when_field_is_empty(self, mock_database_connection):
+    def test_returns_default_when_field_is_empty(self, mock_database_connection):
         with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
             mock_database_connection["cursor"].fetchone.return_value = ("",)
             from cqc_lem.utilities.db import get_user_timezone
             result = get_user_timezone(5)
-        assert result == "UTC"
+        assert result == "America/New_York"
 
-    def test_returns_utc_on_db_error(self, mock_database_connection):
+    def test_returns_default_on_db_error(self, mock_database_connection):
         with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
             mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("fail")
             from cqc_lem.utilities.db import get_user_timezone
             result = get_user_timezone(7)
-        assert result == "UTC"
+        assert result == "America/New_York"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**Phase 2 (P1 backend timing)** of the time/date alignment audit. Follows #279 (P0 display).

## 1. Celery beat fired ~4h off intent
`my_celery.py` beat crontabs are authored in **UTC** (comments like `hour='13'  # ~9am ET`), but `celeryconfig.timezone` inherited the container **TZ** (`America/New_York`), so hour-based schedules (daily golden-hour engagement, group engagement, stats scrape, content-plan, appreciation DMs) ran in ET — ~4h from intent.
- `celeryconfig.py`: `timezone = os.getenv('CELERY_TIMEZONE') or 'UTC'` — no longer falls back to `TZ`.
- `docker-compose*.yml`: `CELERY_TIMEZONE=${CELERY_TIMEZONE:-UTC}` (was `${TZ:-UTC}`).
- `TZ` still controls container-local wall-clock / Python `datetime.now()`. Post publishing uses aware-UTC ETAs and is unaffected.

## 2. `dm_followups` was the only subsystem on local (ET) time
`due_at` was written and compared with naive **ET** `datetime.now()`. Standardized on **naive-UTC** (matching posts/logs/newsletters) on both write (`enqueue_next_followup`) and read (`process_user_followups`, `auto_send_due_followups`).
- *Transitional note:* follow-ups enqueued before deploy carry ET wall-clock and see a one-time ~4–5h skew as they drain; new ones are correct.

## 3. tz default mismatch
`get_user_timezone` defaulted to `'UTC'` while the `users.timezone` column and the UI default to `'America/New_York'` → reconciled to `America/New_York`.

## Tests
- Updated `test_db_timezone.py` for the new default; full `tests/unit` green (**1268 passed**).

## Remaining (Phase 3, P1 UI)
Replace 24h pickers / `datetime-local` inputs with 12h; unify SPA scheduling-input conventions to the user's tz; unify FE/BE best-posting-time model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)