### PR TITLE
fix(time): 12-hour newsletter publish-hour picker (P1 UI)

### DIFF
--- a/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
@@ -15,6 +15,9 @@ const fmt = (iso: string | null) => {
   })
 }
 
+// 12-hour label for an hour-of-day 0–23 (never 24h): 0 -> "12:00 AM", 13 -> "1:00 PM".
+const hour12Label = (h: number) => `${h % 12 === 0 ? 12 : h % 12}:00 ${h < 12 ? 'AM' : 'PM'}`
+
 export default function NewsletterCard() {
   const { sessionToken } = useAuth()
   const queryClient = useQueryClient()
@@ -132,7 +135,7 @@ export default function NewsletterCard() {
               <select value={newsletter.publish_hour} onChange={(e) => setNl({ publish_hour: Number(e.target.value) })}
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm">
                 {Array.from({ length: 24 }, (_, h) => (
-                  <option key={h} value={h}>{`${h.toString().padStart(2, '0')}:00`}</option>
+                  <option key={h} value={h}>{hour12Label(h)}</option>
                 ))}
               </select>
             </div>


### PR DESCRIPTION
**Phase 3 (P1 UI consistency)** of the time/date alignment audit. Follows #279 (P0) and #280 (P1 backend).

## Change
The newsletter **Publish hour** `<select>` rendered a 24-hour list (`00:00`…`23:00`), violating the app-wide *"never 24h"* rule. It now renders **12-hour AM/PM** labels (`12:00 AM` … `11:00 PM`). The stored value is still the hour-of-day `0–23`, so there's **no API/behavior change** — display only.

## Deferred — need a product decision (not changed here)
These were in the audit's P1 UI bucket but are design-sensitive, so I'm flagging rather than changing blind:

1. **`datetime-local` scheduling inputs** (`ReviewSchedule.tsx`, `ScheduleContent.tsx`) render in the **browser's locale** — HTML `datetime-local` can't be forced to 12-hour without replacing it with a **custom date/time picker**. That's a real UI effort; worth doing if "never 24h" must hold on inputs too.
2. **Scheduling-input timezone convention** is inconsistent across three paths (per-post edit passes the value through as naive; bulk + new-post do `new Date(x).toISOString()` = browser-local→UTC; none reference the user's *profile* timezone despite the "Times are in your profile timezone" label). Unifying requires deciding: **profile tz vs browser tz** as the input basis.
3. **"Best time to post" has three divergent sources** — the frontend heuristic (`ScheduleContent.getBestPostingTime`), the backend fixed heuristic (`utils.get_best_posting_times`), and the data-driven post-stats recommendation (`/user/post-stats`, shown on the Dashboard). They should collapse to **one source of truth** (recommend: post-stats when enough samples, else the backend heuristic, fetched by the frontend).

Happy to take any/all of these once you pick a direction.

## Tests
SPA `tsc --noEmit` clean. (No behavior change; value semantics unchanged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)