### PR TITLE
docs(claude): add Git Safety & Multi-Agent Concurrency Rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -190,3 +190,9 @@ Before merging any PR, all of the following must pass:
 - **Emoji in Selenium:** ChromeDriver `send_keys` throws on non-BMP emoji — strip them before typing with `_strip_non_bmp()`.
 - **ENUM columns:** `logs.action_type` (and other status columns) are MySQL ENUMs. Adding a new value requires a migration — e.g. V37 added `'followup'` to `logs.action_type`. Migrations live in `compose/local/database/migrations/` and currently run through **V39** (V38 added recency prefs, V39 added the `post_engagers` table).
 - **Proxy auth:** proxies are authenticated by the runtime MV3 extension (`_build_proxy_auth_extension_b64`), not by URL-embedded credentials — MV2 background pages that used to do this are disabled in Chrome 149+.
+
+## Git Safety & Multi-Agent Concurrency Rules
+- **Fresh State Enforcement**: Before executing or generating any code edit, you MUST explicitly run `git status` and a file read command (e.g., `cat <filename>`) to verify no hidden or uncommitted upstream modifications exist. Never rely on your internal conversation memory for file contents.
+- **Micro-Branching Workflow**: Do not make edits directly on shared branches while working asynchronously. When starting a distinct task, automatically spin up a task-specific feature branch (`git checkout -b feature/claude-<task-name>`).
+- **Atomic Commits**: For every completed sub-task or successful implementation block, automatically stage and commit your files with a clean, concise descriptive message (e.g., `git add . && git commit -m "feat(api): implement active sub-agent locking mechanism"`). 
+- **Conflict Avoidance**: If you detect changes in the working directory that clash with your active target files, immediately halt, stash your progress (`git stash`), pull down the current state, and safely resolve the differences before re-applying your changes.


### PR DESCRIPTION
Appends a **Git Safety & Multi-Agent Concurrency Rules** section to the project `CLAUDE.md`:

- **Fresh State Enforcement** — verify `git status` + read the file before editing; don't trust conversation memory for file contents.
- **Micro-Branching Workflow** — spin up a task-specific `feature/claude-<task-name>` branch; never edit shared branches directly while working async.
- **Atomic Commits** — stage + commit each completed sub-task with a clean message.
- **Conflict Avoidance** — on a working-tree clash, halt, stash, pull, resolve, then re-apply.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)