### PR TITLE
feat(newsletter): multi-draft review queue on Review page + plan-ahead config

### DIFF
--- a/compose/local/database/migrations/V45__add_newsletter_draft_config.sql
+++ b/compose/local/database/migrations/V45__add_newsletter_draft_config.sql
@@ -1,0 +1,16 @@
+-- Per-user controls for planning newsletter editions ahead. Instead of a single draft generated a
+-- fixed few days out, users choose how far ahead drafts appear and how many to keep queued so they
+-- can review/edit without feeling rushed.
+--   generate_lead_days: days before its slot the first draft is generated (was hardcoded 3).
+--   max_queued_drafts:  how many unpublished draft/approved editions to keep queued (1-10).
+-- Defaults (3, 1) backfill existing rows, preserving today's single-draft behavior until a user opts in.
+ALTER TABLE newsletter_settings
+    ADD COLUMN generate_lead_days TINYINT NOT NULL DEFAULT 3,
+    ADD COLUMN max_queued_drafts  TINYINT NOT NULL DEFAULT 1,
+    ADD CONSTRAINT chk_nl_lead_days  CHECK (generate_lead_days BETWEEN 0 AND 60),
+    ADD CONSTRAINT chk_nl_max_queued CHECK (max_queued_drafts  BETWEEN 1 AND 10);
+
+-- Idempotency backstop: never two editions for the same user+slot, so a repeated generation run
+-- (or a rare double beat) can't create duplicate drafts for the same scheduled time.
+ALTER TABLE newsletter_editions
+    ADD UNIQUE KEY uq_user_slot (user_id, scheduled_for);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -28,7 +28,8 @@ from cqc_lem.utilities.db import (
     get_user_subscription_info, get_user_preferences, update_user_preferences,
     get_engagement_preferences, update_engagement_preferences,
     get_newsletter_settings, update_newsletter_settings,
-    get_pending_newsletter_edition, update_newsletter_edition, get_newsletter_edition,
+    get_pending_newsletter_editions,
+    get_latest_edition_scheduled_for, update_newsletter_edition, get_newsletter_edition,
     get_user_timezone,
     get_user_groups, set_groups_enabled, get_post_engagement_rows,
     get_lead_magnet_settings, update_lead_magnet_settings,
@@ -76,7 +77,7 @@ from fastapi.staticfiles import StaticFiles
 from linkedin_api.clients.auth.client import AuthClient
 from linkedin_api.clients.restli.client import RestliClient
 from linkedin_api.common.errors import ResponseFormattingError
-from pydantic import BaseModel, computed_field, model_validator
+from pydantic import BaseModel, computed_field, field_validator, model_validator
 
 app = FastAPI()
 
@@ -295,6 +296,18 @@ class NewsletterSettingsRequest(BaseModel):
     align_with_blog: bool = True
     publish_day: int = 1
     publish_hour: int = 9
+    generate_lead_days: int = 3
+    max_queued_drafts: int = 1
+
+    @field_validator("max_queued_drafts")
+    @classmethod
+    def _clamp_max_queued(cls, v: int) -> int:
+        return max(1, min(10, v))
+
+    @field_validator("generate_lead_days")
+    @classmethod
+    def _clamp_lead_days(cls, v: int) -> int:
+        return max(0, min(60, v))
 
 
 class NewsletterDraftRequest(BaseModel):
@@ -1117,8 +1130,9 @@ def update_newsletter_settings_endpoint(request: NewsletterSettingsRequest) -> R
     return ResponseModel(status_code=200, detail="Newsletter settings updated")
 
 
-def _compute_next_publish(user_id: int):
-    """Next scheduled publish datetime (naive UTC) for the user's newsletter, or None."""
+def _compute_next_publish(user_id: int, anchor=None):
+    """Next scheduled publish datetime (naive UTC) after `anchor`, or None. When `anchor` is None the
+    user's last_published_at is used, giving the soonest upcoming slot."""
     import pytz
     from datetime import datetime as _dt
     from cqc_lem.utilities.newsletter import next_publish_datetime
@@ -1127,9 +1141,11 @@ def _compute_next_publish(user_id: int):
         tz = pytz.timezone(get_user_timezone(user_id))
     except Exception:
         tz = pytz.utc
+    if anchor is None:
+        anchor = settings.get("last_published_at")
     return next_publish_datetime(
         settings.get("publish_day", 1), settings.get("publish_hour", 9),
-        settings.get("cadence", "weekly"), settings.get("last_published_at"), tz, _dt.utcnow())
+        settings.get("cadence", "weekly"), anchor, tz, _dt.utcnow())
 
 
 @router.get("/user/newsletter-draft")
@@ -1137,14 +1153,20 @@ def get_newsletter_draft_endpoint(session_token: str) -> ResponseModel:
     user_id = get_session_user_id(session_token)
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
-    edition = get_pending_newsletter_edition(user_id)
-    if edition and edition.get("scheduled_for") is not None:
-        edition["scheduled_for"] = edition["scheduled_for"].isoformat() if hasattr(
-            edition["scheduled_for"], "isoformat") else str(edition["scheduled_for"])
-    next_pub = _compute_next_publish(user_id)
+    editions = get_pending_newsletter_editions(user_id)
+    for e in editions:
+        sched = e.get("scheduled_for")
+        if sched is not None:
+            e["scheduled_for"] = sched.isoformat() if hasattr(sched, "isoformat") else str(sched)
+    # next_publish is the slot AFTER the last edition already queued, so the UI can show what's next.
+    anchor = get_latest_edition_scheduled_for(user_id)
+    next_pub = _compute_next_publish(user_id, anchor=anchor)
+    settings = get_newsletter_settings(user_id)
     return ResponseModel(status_code=200, detail={
-        "edition": edition,
+        "editions": editions,
         "next_publish": next_pub.isoformat() if next_pub is not None else None,
+        "max_queued_drafts": settings.get("max_queued_drafts", 1),
+        "generate_lead_days": settings.get("generate_lead_days", 3),
     })
 
 

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -94,7 +94,7 @@ app.conf.update(
         },
         'generate-newsletter-drafts': {
             'task': 'cqc_lem.app.run_scheduler.auto_generate_newsletter_drafts',
-            'schedule': crontab(hour='10', minute='0')  # Daily: draft editions ~3 days before their slot for review
+            'schedule': crontab(hour='10', minute='0')  # Daily: top up each user's newsletter draft queue for review
         },
         'publish-scheduled-newsletters': {
             'task': 'cqc_lem.app.run_scheduler.auto_publish_scheduled_editions',

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -131,17 +131,24 @@ def auto_daily_engagement():
     return f"Golden-hour engagement dispatched for {dispatched}/{len(users)} active user(s)"
 
 
+def _max_dt(*dts):
+    """Max of the given datetimes, ignoring None (returns None if all are None)."""
+    present = [d for d in dts if d is not None]
+    return max(present) if present else None
+
+
 @shared_task.task
 def auto_generate_newsletter_drafts():
-    """Generate a draft edition ~GENERATE_LEAD_DAYS before each enabled user's next slot, so they
-    have time to review before it auto-publishes. Skips users who already have a pending edition."""
+    """Keep each enabled user's review queue topped up to their max_queued_drafts, so they can plan
+    ahead. The first-ever draft waits for the generate_lead_days window; once the queue is rolling it
+    refills to the cap as editions publish/skip. Each draft covers the next uncovered cadence slot."""
     import pytz
     from cqc_lem.utilities.db import (get_enabled_newsletter_user_ids, get_newsletter_settings,
-                                      get_user_timezone, get_pending_newsletter_edition,
-                                      create_newsletter_edition)
+                                      get_user_timezone, count_pending_newsletter_editions,
+                                      get_latest_edition_scheduled_for, create_newsletter_edition)
     from cqc_lem.utilities.linkedin.helper import load_profile_for_user
     from cqc_lem.utilities.ai.ai_helper import generate_newsletter_edition
-    from cqc_lem.utilities.newsletter import next_publish_datetime, should_generate_now
+    from cqc_lem.utilities.newsletter import upcoming_publish_slots, should_generate_now
     from cqc_lem.utilities.notifications import notify_newsletter_draft_ready
 
     now = datetime.utcnow()
@@ -149,26 +156,40 @@ def auto_generate_newsletter_drafts():
     for user_id in get_enabled_newsletter_user_ids():
         try:
             settings = get_newsletter_settings(user_id)
+            cap = settings.get("max_queued_drafts", 1)
+            lead = settings.get("generate_lead_days", 3)
+            pending = count_pending_newsletter_editions(user_id)
+            remaining = cap - pending
+            if remaining <= 0:
+                continue  # queue already full
+
             tz = pytz.timezone(get_user_timezone(user_id))
-            next_pub = next_publish_datetime(
+            # Anchor on the latest slot ANY edition already covers (incl. published/skipped) so a
+            # freed cap slot fills the next future slot, never re-covering a skipped one.
+            anchor = _max_dt(settings.get("last_published_at"),
+                             get_latest_edition_scheduled_for(user_id))
+            slots = upcoming_publish_slots(
                 settings.get("publish_day", 1), settings.get("publish_hour", 9),
-                settings.get("cadence", "weekly"), settings.get("last_published_at"), tz, now)
-            if not should_generate_now(next_pub, now):
+                settings.get("cadence", "weekly"), anchor, tz, now, remaining)
+            # Bootstrap gate: only the first-ever draft waits for the lead window. Once the queue is
+            # rolling (pending > 0), keep it topped up regardless of how far out the slots land.
+            if pending == 0 and not should_generate_now(slots[0], now, lead_days=lead):
                 continue
-            if get_pending_newsletter_edition(user_id) is not None:
-                continue
+
             profile = load_profile_for_user(user_id)
-            edition = generate_newsletter_edition(profile, topic=settings.get("topic"))
-            if not edition:
-                continue
-            create_newsletter_edition(user_id, edition["title"], edition.get("subtitle"),
-                                      edition["body"], next_pub)
-            notify_newsletter_draft_ready(user_id, edition["title"], next_pub)
-            generated += 1
+            for slot in slots:
+                edition = generate_newsletter_edition(profile, topic=settings.get("topic"))
+                if not edition:
+                    break
+                if not create_newsletter_edition(user_id, edition["title"], edition.get("subtitle"),
+                                                 edition["body"], slot):
+                    break  # duplicate slot / db error → stop this user's run
+                notify_newsletter_draft_ready(user_id, edition["title"], slot)
+                generated += 1
         except Exception as e:
             log_warning("Failed to generate newsletter draft", exc=e, user_id=user_id,
                         task_name="auto_generate_newsletter_drafts")
-    return f"Generated newsletter draft for {generated} user(s)"
+    return f"Generated {generated} newsletter draft(s)"
 
 
 @shared_task.task

--- a/src/cqc_lem/ui/src/components/NewsletterArticlePreview.tsx
+++ b/src/cqc_lem/ui/src/components/NewsletterArticlePreview.tsx
@@ -1,0 +1,53 @@
+interface NewsletterArticlePreviewProps {
+  title?: string | null
+  subtitle?: string | null
+  body?: string | null
+  author?: string
+}
+
+// A lightweight LinkedIn-newsletter-article mock: byline, title, subtitle, article body, and a
+// subscribe footer. Distinct from LinkedInPostPreview (a feed post) — newsletters lead with a title.
+export default function NewsletterArticlePreview({
+  title,
+  subtitle,
+  body,
+  author = 'Your Name',
+}: NewsletterArticlePreviewProps) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 shadow-sm max-w-lg font-sans overflow-hidden">
+      {/* Byline */}
+      <div className="flex items-center gap-3 px-5 pt-5">
+        <div className="w-10 h-10 rounded-full bg-blue-600 flex items-center justify-center text-white font-bold flex-shrink-0">
+          {author.charAt(0).toUpperCase()}
+        </div>
+        <div className="min-w-0">
+          <p className="font-semibold text-gray-900 text-sm truncate">{author}</p>
+          <p className="text-xs text-gray-500">Newsletter · Just now</p>
+        </div>
+      </div>
+
+      {/* Title + subtitle */}
+      <div className="px-5 pt-4">
+        <h1 className="text-xl font-bold text-gray-900 leading-snug">
+          {title || <span className="text-gray-400">Untitled edition</span>}
+        </h1>
+        {subtitle && <p className="text-sm text-gray-500 mt-1">{subtitle}</p>}
+      </div>
+
+      {/* Body */}
+      <div className="px-5 py-4">
+        <p className="text-sm text-gray-800 whitespace-pre-wrap leading-relaxed">
+          {body || <span className="text-gray-400">No content yet.</span>}
+        </p>
+      </div>
+
+      {/* Subscribe footer, evoking LinkedIn's newsletter card */}
+      <div className="px-5 py-3 border-t border-gray-100 flex items-center justify-between">
+        <span className="text-xs text-gray-500">Subscribers get this by notification + email</span>
+        <button className="text-blue-600 border border-blue-600 rounded-full px-3 py-1 text-xs font-semibold hover:bg-blue-50">
+          Subscribe
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/components/NewsletterArticlePreview.tsx
+++ b/src/cqc_lem/ui/src/components/NewsletterArticlePreview.tsx
@@ -44,7 +44,7 @@ export default function NewsletterArticlePreview({
       {/* Subscribe footer, evoking LinkedIn's newsletter card */}
       <div className="px-5 py-3 border-t border-gray-100 flex items-center justify-between">
         <span className="text-xs text-gray-500">Subscribers get this by notification + email</span>
-        <button className="text-blue-600 border border-blue-600 rounded-full px-3 py-1 text-xs font-semibold hover:bg-blue-50">
+        <button type="button" className="text-blue-600 border border-blue-600 rounded-full px-3 py-1 text-xs font-semibold hover:bg-blue-50">
           Subscribe
         </button>
       </div>

--- a/src/cqc_lem/ui/src/pages/ReviewSchedule.tsx
+++ b/src/cqc_lem/ui/src/pages/ReviewSchedule.tsx
@@ -1,10 +1,18 @@
 import { useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../api/client'
 import LinkedInPostPreview from '../components/LinkedInPostPreview'
+import NewsletterQueue from './review/NewsletterQueue'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
 import { formatInTimezone } from '../utils/datetime'
+
+type View = 'posts' | 'newsletters'
+const VIEWS: { key: View; label: string }[] = [
+  { key: 'posts', label: 'Posts' },
+  { key: 'newsletters', label: 'Newsletters' },
+]
 
 type Status = 'ALL' | 'pending' | 'approved' | 'scheduled' | 'posted' | 'rejected'
 const STATUSES: { label: string; value: Status }[] = [
@@ -49,6 +57,11 @@ export default function ReviewSchedule() {
   const email = user?.email ?? ''
   const qc = useQueryClient()
   const userTimezone = useUserTimezone()
+
+  // Top-level view (Posts / Newsletters), synced to the ?tab= query param for deep-linking.
+  const [searchParams, setSearchParams] = useSearchParams()
+  const view: View = searchParams.get('tab') === 'newsletters' ? 'newsletters' : 'posts'
+  const setView = (v: View) => setSearchParams(v === 'posts' ? {} : { tab: v }, { replace: true })
 
   // Filter / sort / pagination state
   const [filterStatus, setFilterStatus] = useState<Status>('ALL')
@@ -171,16 +184,39 @@ export default function ReviewSchedule() {
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between flex-wrap gap-3">
-        <h1 className="text-2xl font-bold text-gray-800">Review Posts</h1>
-        <button
-          onClick={() => weeklyMutation.mutate()}
-          disabled={weeklyMutation.isPending}
-          className="bg-green-600 text-white px-4 py-2 rounded-lg text-sm font-semibold hover:bg-green-700 disabled:opacity-50 transition-colors"
-        >
-          {weeklyMutation.isPending ? 'Generating content…' : 'Generate Weekly Content'}
-        </button>
+        <h1 className="text-2xl font-bold text-gray-800">Review</h1>
+        {view === 'posts' && (
+          <button
+            onClick={() => weeklyMutation.mutate()}
+            disabled={weeklyMutation.isPending}
+            className="bg-green-600 text-white px-4 py-2 rounded-lg text-sm font-semibold hover:bg-green-700 disabled:opacity-50 transition-colors"
+          >
+            {weeklyMutation.isPending ? 'Generating content…' : 'Generate Weekly Content'}
+          </button>
+        )}
       </div>
 
+      {/* Posts / Newsletters tabs */}
+      <div className="flex flex-wrap gap-1 border-b border-gray-200">
+        {VIEWS.map((v) => (
+          <button
+            key={v.key}
+            onClick={() => setView(v.key)}
+            className={`px-3 py-2 text-sm font-semibold border-b-2 -mb-px transition-colors ${
+              view === v.key
+                ? 'border-blue-600 text-blue-700'
+                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+            }`}
+          >
+            {v.label}
+          </button>
+        ))}
+      </div>
+
+      {view === 'newsletters' && <NewsletterQueue userTimezone={userTimezone} />}
+
+      {view === 'posts' && (
+      <>
       {/* Status tabs */}
       <div className="flex gap-2 flex-wrap">
         {STATUSES.map((s) => (
@@ -539,6 +575,8 @@ export default function ReviewSchedule() {
           </div>
         )}
       </div>
+      </>
+      )}
     </div>
   )
 }

--- a/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
@@ -1,19 +1,11 @@
 import { useEffect, useState } from 'react'
+import { Link } from 'react-router-dom'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import Toggle from '../../components/Toggle'
-import type { NewsletterSettings, NewsletterDraft, NewsletterEdition } from './types'
+import type { NewsletterSettings } from './types'
 import { WEEKDAYS } from './types'
-
-const fmt = (iso: string | null) => {
-  if (!iso) return null
-  const d = new Date(iso.endsWith('Z') || iso.includes('+') ? iso : iso + 'Z')
-  if (isNaN(d.getTime())) return null
-  return d.toLocaleString(undefined, {
-    weekday: 'long', month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit',
-  })
-}
 
 // 12-hour label for an hour-of-day 0–23 (never 24h): 0 -> "12:00 AM", 13 -> "1:00 PM".
 const hour12Label = (h: number) => `${h % 12 === 0 ? 12 : h % 12}:00 ${h < 12 ? 'AM' : 'PM'}`
@@ -23,7 +15,6 @@ export default function NewsletterCard() {
   const queryClient = useQueryClient()
   const [newsletter, setNewsletter] = useState<NewsletterSettings | null>(null)
   const [nlMsg, setNlMsg] = useState<{ ok: boolean; text: string } | null>(null)
-  const [draftEdit, setDraftEdit] = useState<NewsletterEdition | null>(null)
 
   const { data: nlData } = useQuery({
     queryKey: ['newsletter-settings', sessionToken],
@@ -38,21 +29,7 @@ export default function NewsletterCard() {
     if (nlData && !newsletter) setNewsletter(nlData)
   }, [nlData])
 
-  const { data: draftData } = useQuery({
-    queryKey: ['newsletter-draft', sessionToken],
-    queryFn: () =>
-      api
-        .get(`/user/newsletter-draft?session_token=${encodeURIComponent(sessionToken!)}`)
-        .then((r) => r.data.detail as NewsletterDraft),
-    enabled: !!sessionToken && !!newsletter?.enabled,
-    staleTime: 30 * 1000,
-  })
-  useEffect(() => {
-    setDraftEdit(draftData?.edition ? { ...draftData.edition } : null)
-  }, [draftData])
-
   const setNl = (patch: Partial<NewsletterSettings>) => setNewsletter((p) => (p ? { ...p, ...patch } : p))
-  const setDe = (patch: Partial<NewsletterEdition>) => setDraftEdit((p) => (p ? { ...p, ...patch } : p))
 
   const nlMutation = useMutation({
     mutationFn: () => api.put('/user/newsletter-settings', { session_token: sessionToken, ...newsletter }),
@@ -67,31 +44,7 @@ export default function NewsletterCard() {
     },
   })
 
-  const draftMutation = useMutation({
-    mutationFn: (action: 'save' | 'approve' | 'skip') =>
-      api.put('/user/newsletter-draft', {
-        session_token: sessionToken,
-        edition_id: draftEdit!.id,
-        title: draftEdit!.title,
-        subtitle: draftEdit!.subtitle,
-        body: draftEdit!.body,
-        action,
-      }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['newsletter-draft'] })
-      setNlMsg({ ok: true, text: 'Saved.' })
-      setTimeout(() => setNlMsg(null), 3000)
-    },
-    onError: () => {
-      setNlMsg({ ok: false, text: 'Could not save — try again.' })
-      setTimeout(() => setNlMsg(null), 5000)
-    },
-  })
-
   if (!newsletter) return null
-
-  const nextPublish = fmt(draftData?.next_publish ?? null)
-  const autoDate = fmt(draftEdit?.scheduled_for ?? null)
 
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
@@ -145,13 +98,37 @@ export default function NewsletterCard() {
             <input type="text" value={newsletter.topic || ''} onChange={(e) => setNl({ topic: e.target.value })}
               placeholder="What each edition should focus on" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
           </div>
+
+          {/* Plan-ahead controls: keep several drafts queued, generated early, so reviews never feel rushed. */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Draft newsletters to keep ready</label>
+              <select value={newsletter.max_queued_drafts} onChange={(e) => setNl({ max_queued_drafts: Number(e.target.value) })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm">
+                {Array.from({ length: 10 }, (_, i) => i + 1).map((n) => (
+                  <option key={n} value={n}>{n}</option>
+                ))}
+              </select>
+              <p className="text-xs text-gray-400 mt-1">We'll keep this many drafts queued so you can plan ahead.</p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Generate drafts this many days ahead</label>
+              <input type="number" min={0} max={60} value={newsletter.generate_lead_days}
+                onChange={(e) => setNl({ generate_lead_days: Number(e.target.value) })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+              <p className="text-xs text-gray-400 mt-1">How early each new draft appears for review.</p>
+            </div>
+          </div>
+
           <div className="flex items-center justify-between">
             <p className="text-sm font-medium text-gray-700">Align with my blog</p>
             <Toggle on={newsletter.align_with_blog} onClick={() => setNl({ align_with_blog: !newsletter.align_with_blog })} />
           </div>
-          {nextPublish && (
-            <p className="text-xs text-gray-500">Next edition: <span className="font-medium text-gray-700">{nextPublish}</span></p>
-          )}
+          <p className="text-xs text-gray-500">
+            Review &amp; approve drafts on the{' '}
+            <Link to="/review?tab=newsletters" className="text-blue-600 font-medium hover:underline">Review → Newsletters</Link>{' '}
+            tab.
+          </p>
         </>
       )}
       {nlMsg && <p className={`text-sm font-medium ${nlMsg.ok ? 'text-green-600' : 'text-red-600'}`}>{nlMsg.text}</p>}
@@ -159,46 +136,6 @@ export default function NewsletterCard() {
         className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
         {nlMutation.isPending ? 'Saving…' : 'Save Newsletter Settings'}
       </button>
-
-      {newsletter.enabled && draftEdit && (
-        <div className="border-t border-gray-200 pt-4 space-y-3">
-          <div>
-            <h3 className="text-sm font-semibold text-gray-700">Draft ready to review</h3>
-            {autoDate && (
-              <p className="text-xs text-gray-500">Auto-publishes {autoDate} unless you skip it.</p>
-            )}
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
-            <input type="text" value={draftEdit.title || ''} onChange={(e) => setDe({ title: e.target.value })}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Subtitle</label>
-            <input type="text" value={draftEdit.subtitle || ''} onChange={(e) => setDe({ subtitle: e.target.value })}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Body</label>
-            <textarea value={draftEdit.body || ''} onChange={(e) => setDe({ body: e.target.value })} rows={10}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono" />
-          </div>
-          <div className="grid grid-cols-3 gap-2">
-            <button type="button" onClick={() => draftMutation.mutate('save')} disabled={draftMutation.isPending}
-              className="bg-gray-100 text-gray-700 py-2 rounded-lg text-sm font-semibold hover:bg-gray-200 disabled:opacity-50 transition-colors">
-              Save
-            </button>
-            <button type="button" onClick={() => draftMutation.mutate('approve')} disabled={draftMutation.isPending}
-              className="bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
-              Approve
-            </button>
-            <button type="button" onClick={() => draftMutation.mutate('skip')} disabled={draftMutation.isPending}
-              className="bg-white border border-gray-300 text-gray-700 py-2 rounded-lg text-sm font-semibold hover:bg-gray-50 disabled:opacity-50 transition-colors">
-              Skip
-            </button>
-          </div>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -33,6 +33,8 @@ export type NewsletterSettings = {
   align_with_blog: boolean
   publish_day: number
   publish_hour: number
+  generate_lead_days: number
+  max_queued_drafts: number
 }
 
 export type NewsletterEdition = {
@@ -45,8 +47,10 @@ export type NewsletterEdition = {
 }
 
 export type NewsletterDraft = {
-  edition: NewsletterEdition | null
+  editions: NewsletterEdition[]
   next_publish: string | null
+  max_queued_drafts?: number
+  generate_lead_days?: number
 }
 
 export const WEEKDAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']

--- a/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
+++ b/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
@@ -30,17 +30,20 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
 
   const editions = data?.editions ?? []
 
-  // Keep a selection; default to the soonest draft. Sync the editable copy when selection changes.
+  // Seed the editor only when the current selection is GONE (initial load, or the selected draft was
+  // approved/skipped away) — default to the soonest draft. When the selection is still present we
+  // leave draftEdit alone so a background refetch can't wipe in-progress edits.
   useEffect(() => {
     if (editions.length === 0) {
       setSelectedId(null)
       setDraftEdit(null)
       return
     }
-    const current = editions.find((e) => e.id === selectedId) ?? editions[0]
-    setSelectedId(current.id)
-    setDraftEdit({ ...current })
-  }, [data])
+    if (!editions.some((e) => e.id === selectedId)) {
+      setSelectedId(editions[0].id)
+      setDraftEdit({ ...editions[0] })
+    }
+  }, [data, selectedId])
 
   const setDe = (patch: Partial<NewsletterEdition>) => setDraftEdit((p) => (p ? { ...p, ...patch } : p))
 

--- a/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
+++ b/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
@@ -1,0 +1,175 @@
+import { useEffect, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import api from '../../api/client'
+import { useAuth } from '../../contexts/AuthContext'
+import NewsletterArticlePreview from '../../components/NewsletterArticlePreview'
+import { formatInTimezone } from '../../utils/datetime'
+import type { NewsletterDraft, NewsletterEdition } from '../account/types'
+
+const STATUS_COLORS: Record<string, string> = {
+  draft: 'bg-yellow-100 text-yellow-700',
+  approved: 'bg-green-100 text-green-700',
+}
+
+export default function NewsletterQueue({ userTimezone }: { userTimezone: string }) {
+  const { user, sessionToken } = useAuth()
+  const qc = useQueryClient()
+  const [selectedId, setSelectedId] = useState<number | null>(null)
+  const [draftEdit, setDraftEdit] = useState<NewsletterEdition | null>(null)
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['newsletter-queue', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/newsletter-draft?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as NewsletterDraft),
+    enabled: !!sessionToken,
+    staleTime: 30 * 1000,
+  })
+
+  const editions = data?.editions ?? []
+
+  // Keep a selection; default to the soonest draft. Sync the editable copy when selection changes.
+  useEffect(() => {
+    if (editions.length === 0) {
+      setSelectedId(null)
+      setDraftEdit(null)
+      return
+    }
+    const current = editions.find((e) => e.id === selectedId) ?? editions[0]
+    setSelectedId(current.id)
+    setDraftEdit({ ...current })
+  }, [data])
+
+  const setDe = (patch: Partial<NewsletterEdition>) => setDraftEdit((p) => (p ? { ...p, ...patch } : p))
+
+  const draftMutation = useMutation({
+    mutationFn: (action: 'save' | 'approve' | 'skip') =>
+      api.put('/user/newsletter-draft', {
+        session_token: sessionToken,
+        edition_id: draftEdit!.id,
+        title: draftEdit!.title,
+        subtitle: draftEdit!.subtitle,
+        body: draftEdit!.body,
+        action,
+      }),
+    onSuccess: (_res, action) => {
+      qc.invalidateQueries({ queryKey: ['newsletter-queue'] })
+      // Approving/skipping removes the edition from the queue — move selection off it.
+      if (action !== 'save') setSelectedId(null)
+      setMsg({ ok: true, text: action === 'skip' ? 'Skipped.' : action === 'approve' ? 'Approved.' : 'Saved.' })
+      setTimeout(() => setMsg(null), 3000)
+    },
+    onError: () => {
+      setMsg({ ok: false, text: 'Could not save — try again.' })
+      setTimeout(() => setMsg(null), 5000)
+    },
+  })
+
+  function selectEdition(e: NewsletterEdition) {
+    setSelectedId(e.id)
+    setDraftEdit({ ...e })
+  }
+
+  if (isLoading) return <p className="text-gray-400 text-sm">Loading drafts…</p>
+
+  if (editions.length === 0) {
+    return (
+      <div className="flex flex-col items-center text-center py-12 px-4 bg-white rounded-lg border border-gray-200">
+        <div className="text-4xl mb-4">📰</div>
+        <p className="text-gray-600 text-sm mb-2 max-w-sm">No newsletter drafts queued yet.</p>
+        <p className="text-gray-400 text-xs max-w-sm">
+          Enable your newsletter and set how many drafts to keep ready on the Account page — drafts will
+          appear here for review before they auto-publish.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {/* Queue list */}
+      <div className="space-y-3">
+        {data?.next_publish && (
+          <p className="text-xs text-gray-400">
+            Next auto-generated slot: {formatInTimezone(data.next_publish, userTimezone)}
+          </p>
+        )}
+        {editions.map((e) => (
+          <div
+            key={e.id}
+            onClick={() => selectEdition(e)}
+            className={`bg-white rounded-lg border p-4 cursor-pointer hover:border-blue-400 transition-colors ${
+              selectedId === e.id ? 'border-blue-500 ring-1 ring-blue-500' : 'border-gray-200'
+            }`}
+          >
+            <div className="flex items-center justify-between mb-1 gap-2">
+              <span className="text-xs text-gray-400 truncate">
+                {e.scheduled_for ? formatInTimezone(e.scheduled_for, userTimezone) : 'Unscheduled'}
+              </span>
+              <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[e.status] ?? 'bg-gray-100 text-gray-600'}`}>
+                {e.status.toUpperCase()}
+              </span>
+            </div>
+            <p className="text-sm font-medium text-gray-800 truncate">{e.title || 'Untitled edition'}</p>
+            {e.subtitle && <p className="text-xs text-gray-500 line-clamp-1">{e.subtitle}</p>}
+          </div>
+        ))}
+      </div>
+
+      {/* Editor + preview */}
+      {draftEdit && (
+        <div className="sticky top-4 self-start space-y-4 max-h-[calc(100vh-2rem)] overflow-y-auto">
+          <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-5 space-y-3">
+            <div>
+              <h3 className="text-sm font-semibold text-gray-700">Review draft</h3>
+              {draftEdit.scheduled_for && (
+                <p className="text-xs text-gray-500">
+                  Auto-publishes {formatInTimezone(draftEdit.scheduled_for, userTimezone)} unless you skip it.
+                </p>
+              )}
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Title</label>
+              <input type="text" value={draftEdit.title || ''} onChange={(e) => setDe({ title: e.target.value })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Subtitle</label>
+              <input type="text" value={draftEdit.subtitle || ''} onChange={(e) => setDe({ subtitle: e.target.value })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Body</label>
+              <textarea value={draftEdit.body || ''} onChange={(e) => setDe({ body: e.target.value })} rows={10}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500" />
+            </div>
+            {msg && <p className={`text-sm font-medium ${msg.ok ? 'text-green-600' : 'text-red-600'}`}>{msg.text}</p>}
+            <div className="grid grid-cols-3 gap-2">
+              <button type="button" onClick={() => draftMutation.mutate('save')} disabled={draftMutation.isPending}
+                className="bg-gray-100 text-gray-700 py-2 rounded-lg text-sm font-semibold hover:bg-gray-200 disabled:opacity-50 transition-colors">
+                Save
+              </button>
+              <button type="button" onClick={() => draftMutation.mutate('approve')} disabled={draftMutation.isPending}
+                className="bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
+                Approve
+              </button>
+              <button type="button" onClick={() => draftMutation.mutate('skip')} disabled={draftMutation.isPending}
+                className="bg-white border border-gray-300 text-gray-700 py-2 rounded-lg text-sm font-semibold hover:bg-gray-50 disabled:opacity-50 transition-colors">
+                Skip
+              </button>
+            </div>
+          </div>
+
+          <NewsletterArticlePreview
+            title={draftEdit.title}
+            subtitle={draftEdit.subtitle}
+            body={draftEdit.body}
+            author={(user?.email ?? 'You').split('@')[0]}
+          />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2550,8 +2550,11 @@ def create_newsletter_edition(user_id: int, title: str, subtitle: str, body: str
             (user_id, title, subtitle, body, scheduled_for))
         connection.commit()
         return cursor.lastrowid
-    except mysql.connector.IntegrityError:
-        # uq_user_slot: an edition for this user+slot already exists — expected, not an error.
+    except mysql.connector.IntegrityError as err:
+        # errno 1062 = ER_DUP_ENTRY: uq_user_slot already covers this user+slot — expected, not an
+        # error. Other integrity failures (e.g. FK on user_id) are real problems worth surfacing.
+        if getattr(err, "errno", None) != 1062:
+            myprint(f"Could not create newsletter edition for user {user_id} | Error: {err}")
         return 0
     except mysql.connector.Error as err:
         myprint(f"Could not create newsletter edition for user {user_id} | Error: {err}")

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2424,10 +2424,10 @@ def record_lead_magnet_sent(user_id: int, recipient_profile: str, post_id: int =
 _NEWSLETTER_DEFAULTS: dict = {
     "enabled": False, "title": None, "topic": None, "cadence": "weekly",
     "align_with_blog": True, "newsletter_url": None, "last_published_at": None,
-    "publish_day": 1, "publish_hour": 9,
+    "publish_day": 1, "publish_hour": 9, "generate_lead_days": 3, "max_queued_drafts": 1,
 }
 _NEWSLETTER_COLS = ("enabled", "title", "topic", "cadence", "align_with_blog", "newsletter_url",
-                    "publish_day", "publish_hour")
+                    "publish_day", "publish_hour", "generate_lead_days", "max_queued_drafts")
 
 
 def get_newsletter_settings(user_id: int) -> dict:
@@ -2437,7 +2437,7 @@ def get_newsletter_settings(user_id: int) -> dict:
     try:
         cursor.execute(
             "SELECT enabled, title, topic, cadence, align_with_blog, newsletter_url, last_published_at, "
-            "publish_day, publish_hour "
+            "publish_day, publish_hour, generate_lead_days, max_queued_drafts "
             "FROM newsletter_settings WHERE user_id = %s", (user_id,))
         row = cursor.fetchone()
         if row is None:
@@ -2446,6 +2446,10 @@ def get_newsletter_settings(user_id: int) -> dict:
         row["align_with_blog"] = bool(row.get("align_with_blog"))
         row["publish_day"] = int(row.get("publish_day") if row.get("publish_day") is not None else 1)
         row["publish_hour"] = int(row.get("publish_hour") if row.get("publish_hour") is not None else 9)
+        row["generate_lead_days"] = int(
+            row.get("generate_lead_days") if row.get("generate_lead_days") is not None else 3)
+        row["max_queued_drafts"] = int(
+            row.get("max_queued_drafts") if row.get("max_queued_drafts") is not None else 1)
         return row
     except mysql.connector.Error as err:
         myprint(f"Could not get newsletter settings for user {user_id} | Error: {err}")
@@ -2546,6 +2550,9 @@ def create_newsletter_edition(user_id: int, title: str, subtitle: str, body: str
             (user_id, title, subtitle, body, scheduled_for))
         connection.commit()
         return cursor.lastrowid
+    except mysql.connector.IntegrityError:
+        # uq_user_slot: an edition for this user+slot already exists — expected, not an error.
+        return 0
     except mysql.connector.Error as err:
         myprint(f"Could not create newsletter edition for user {user_id} | Error: {err}")
         return 0
@@ -2566,6 +2573,59 @@ def get_pending_newsletter_edition(user_id: int) -> "dict | None":
         return cursor.fetchone()
     except mysql.connector.Error as err:
         myprint(f"Could not get pending newsletter edition for user {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def count_pending_newsletter_editions(user_id: int) -> int:
+    """How many editions are still queued (status draft/approved) for this user."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM newsletter_editions "
+            "WHERE user_id = %s AND status IN ('draft', 'approved')", (user_id,))
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not count pending newsletter editions for user {user_id} | Error: {err}")
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_pending_newsletter_editions(user_id: int) -> list:
+    """All editions still under review (status draft/approved), soonest slot first — the review queue."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT id, title, subtitle, body, status, scheduled_for FROM newsletter_editions "
+            "WHERE user_id = %s AND status IN ('draft', 'approved') "
+            "ORDER BY scheduled_for ASC", (user_id,))
+        return cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get pending newsletter editions for user {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_latest_edition_scheduled_for(user_id: int) -> "datetime | None":
+    """The latest slot already covered by ANY edition (any status), so the next slot never re-covers it."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT MAX(scheduled_for) FROM newsletter_editions WHERE user_id = %s", (user_id,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not get latest edition slot for user {user_id} | Error: {err}")
         return None
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/newsletter.py
+++ b/src/cqc_lem/utilities/newsletter.py
@@ -50,3 +50,20 @@ def should_generate_now(next_publish: datetime, now_utc: datetime,
     if next_publish is None:
         return False
     return _as_utc(now_utc) >= _as_utc(next_publish) - timedelta(days=lead_days)
+
+
+def upcoming_publish_slots(publish_day: int, publish_hour: int, cadence: str,
+                           last_published_at: datetime, tz, now_utc: datetime,
+                           count: int) -> list:
+    """The next `count` cadence-spaced UTC publish slots, soonest first.
+
+    Chains next_publish_datetime by feeding each computed slot back in as the anchor, so slot N+1 is
+    exactly one cadence interval past slot N (weekday/hour/DST handling reused, never duplicated).
+    """
+    slots = []
+    anchor = last_published_at
+    for _ in range(max(0, count)):
+        slot = next_publish_datetime(publish_day, publish_hour, cadence, anchor, tz, now_utc)
+        slots.append(slot)
+        anchor = slot
+    return slots

--- a/tests/unit/api/test_newsletter_api.py
+++ b/tests/unit/api/test_newsletter_api.py
@@ -57,6 +57,26 @@ class TestNewsletterSettings:
         args = upd.call_args[0][1]
         assert args["publish_day"] == 3 and args["publish_hour"] == 14
 
+    def test_put_clamps_draft_config(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_newsletter_settings", return_value=True) as upd:
+            resp = client.put("/api/user/newsletter-settings", json={
+                "session_token": _SESSION, "enabled": True,
+                "max_queued_drafts": 15, "generate_lead_days": 100})
+        assert resp.status_code == 200
+        args = upd.call_args[0][1]
+        assert args["max_queued_drafts"] == 10 and args["generate_lead_days"] == 60
+
+    def test_put_clamps_draft_config_low(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_newsletter_settings", return_value=True) as upd:
+            resp = client.put("/api/user/newsletter-settings", json={
+                "session_token": _SESSION, "enabled": True,
+                "max_queued_drafts": 0, "generate_lead_days": -5})
+        assert resp.status_code == 200
+        args = upd.call_args[0][1]
+        assert args["max_queued_drafts"] == 1 and args["generate_lead_days"] == 0
+
     def test_401(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
             resp = client.get("/api/user/newsletter-settings?session_token=bad")
@@ -64,31 +84,36 @@ class TestNewsletterSettings:
 
 
 class TestNewsletterDraft:
-    def test_get_returns_edition_and_next_publish(self, client):
+    def test_get_returns_editions_and_next_publish(self, client):
         from datetime import datetime
-        edition = {"id": 4, "title": "T", "subtitle": "S", "body": "B", "status": "draft",
-                   "scheduled_for": datetime(2026, 7, 7, 13, 0, 0)}
-        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None}
+        editions = [{"id": 4, "title": "T", "subtitle": "S", "body": "B", "status": "draft",
+                     "scheduled_for": datetime(2026, 7, 7, 13, 0, 0)}]
+        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None,
+                    "max_queued_drafts": 3, "generate_lead_days": 14}
         with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
-             patch("cqc_lem.api.main.get_pending_newsletter_edition", return_value=edition), \
+             patch("cqc_lem.api.main.get_pending_newsletter_editions", return_value=editions), \
+             patch("cqc_lem.api.main.get_latest_edition_scheduled_for", return_value=None), \
              patch("cqc_lem.api.main.get_newsletter_settings", return_value=settings), \
              patch("cqc_lem.api.main.get_user_timezone", return_value="UTC"):
             resp = client.get(f"/api/user/newsletter-draft?session_token={_SESSION}")
         assert resp.status_code == 200
         detail = resp.json()["detail"]
-        assert detail["edition"]["id"] == 4
-        assert detail["edition"]["scheduled_for"].startswith("2026-07-07")
+        assert detail["editions"][0]["id"] == 4
+        assert detail["editions"][0]["scheduled_for"].startswith("2026-07-07")
         assert detail["next_publish"] is not None
+        assert detail["max_queued_drafts"] == 3 and detail["generate_lead_days"] == 14
 
-    def test_get_null_when_no_edition(self, client):
-        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None}
+    def test_get_empty_when_no_editions(self, client):
+        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None,
+                    "max_queued_drafts": 1, "generate_lead_days": 3}
         with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
-             patch("cqc_lem.api.main.get_pending_newsletter_edition", return_value=None), \
+             patch("cqc_lem.api.main.get_pending_newsletter_editions", return_value=[]), \
+             patch("cqc_lem.api.main.get_latest_edition_scheduled_for", return_value=None), \
              patch("cqc_lem.api.main.get_newsletter_settings", return_value=settings), \
              patch("cqc_lem.api.main.get_user_timezone", return_value="UTC"):
             resp = client.get(f"/api/user/newsletter-draft?session_token={_SESSION}")
         assert resp.status_code == 200
-        assert resp.json()["detail"]["edition"] is None
+        assert resp.json()["detail"]["editions"] == []
 
     def test_get_401(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=None):

--- a/tests/unit/app/test_newsletter_publish.py
+++ b/tests/unit/app/test_newsletter_publish.py
@@ -108,12 +108,15 @@ class TestAutoPublishEdition:
 
 
 def _run_generate(*, settings, pending, latest=None, gen_now=True,
-                  edition={"title": "T", "subtitle": "S", "body": "B"},
-                  edition_side_effect=None, create_ret=1, create_side_effect=None,
-                  user_ids=[1], tz_side_effect=None):
+                  edition=None, edition_side_effect=None, create_ret=1, create_side_effect=None,
+                  user_ids=None, tz_side_effect=None):
     """Drive auto_generate_newsletter_drafts with the new pure-count collaborators mocked out."""
     from contextlib import ExitStack
     from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
+    if edition is None:
+        edition = {"title": "T", "subtitle": "S", "body": "B"}
+    if user_ids is None:
+        user_ids = [1]
     gen_kw = {"side_effect": edition_side_effect} if edition_side_effect else {"return_value": edition}
     create_kw = {"side_effect": create_side_effect} if create_side_effect else {"return_value": create_ret}
     tz_kw = {"side_effect": tz_side_effect} if tz_side_effect else {"return_value": "UTC"}

--- a/tests/unit/app/test_newsletter_publish.py
+++ b/tests/unit/app/test_newsletter_publish.py
@@ -107,67 +107,92 @@ class TestAutoPublishEdition:
         assert "did not complete" in result
 
 
+def _run_generate(*, settings, pending, latest=None, gen_now=True,
+                  edition={"title": "T", "subtitle": "S", "body": "B"},
+                  edition_side_effect=None, create_ret=1, create_side_effect=None,
+                  user_ids=[1], tz_side_effect=None):
+    """Drive auto_generate_newsletter_drafts with the new pure-count collaborators mocked out."""
+    from contextlib import ExitStack
+    from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
+    gen_kw = {"side_effect": edition_side_effect} if edition_side_effect else {"return_value": edition}
+    create_kw = {"side_effect": create_side_effect} if create_side_effect else {"return_value": create_ret}
+    tz_kw = {"side_effect": tz_side_effect} if tz_side_effect else {"return_value": "UTC"}
+    with ExitStack() as es:
+        p = es.enter_context
+        p(patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=user_ids))
+        p(patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=settings))
+        p(patch("cqc_lem.utilities.db.get_user_timezone", **tz_kw))
+        p(patch("cqc_lem.utilities.db.count_pending_newsletter_editions", return_value=pending))
+        p(patch("cqc_lem.utilities.db.get_latest_edition_scheduled_for", return_value=latest))
+        create = p(patch("cqc_lem.utilities.db.create_newsletter_edition", **create_kw))
+        p(patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()))
+        p(patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", **gen_kw))
+        p(patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=gen_now))
+        notify = p(patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready"))
+        result = auto_generate_newsletter_drafts()
+    return result, create, notify
+
+
+_SETTINGS = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None,
+             "topic": "reach", "max_queued_drafts": 1, "generate_lead_days": 3}
+
+
+def _settings(**overrides):
+    return {**_SETTINGS, **overrides}
+
+
 class TestGenerateNewsletterDrafts:
-    def test_generates_and_notifies(self):
-        from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
-        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly",
-                    "last_published_at": None, "topic": "reach"}
-        edition = {"title": "T", "subtitle": "S", "body": "B"}
-        with patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=[1]), \
-             patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=settings), \
-             patch("cqc_lem.utilities.db.get_user_timezone", return_value="UTC"), \
-             patch("cqc_lem.utilities.db.get_pending_newsletter_edition", return_value=None), \
-             patch("cqc_lem.utilities.db.create_newsletter_edition", return_value=42) as create, \
-             patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()), \
-             patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", return_value=edition), \
-             patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=True), \
-             patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready") as notify:
-            result = auto_generate_newsletter_drafts()
+    def test_bootstrap_generates_one(self):
+        result, create, notify = _run_generate(settings=_settings(max_queued_drafts=1), pending=0)
         create.assert_called_once()
         notify.assert_called_once()
-        assert "1 user" in result
+        assert "Generated 1 newsletter draft" in result
 
-    def test_skips_when_pending_exists(self):
-        from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
-        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None}
-        with patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=[1]), \
-             patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=settings), \
-             patch("cqc_lem.utilities.db.get_user_timezone", return_value="UTC"), \
-             patch("cqc_lem.utilities.db.get_pending_newsletter_edition", return_value={"id": 5}), \
-             patch("cqc_lem.utilities.db.create_newsletter_edition") as create, \
-             patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=True):
-            result = auto_generate_newsletter_drafts()
+    def test_fills_queue_to_cap(self):
+        # cap 5, empty queue → generate all 5 upcoming slots in one run.
+        result, create, notify = _run_generate(settings=_settings(max_queued_drafts=5), pending=0)
+        assert create.call_count == 5
+        assert notify.call_count == 5
+        assert "Generated 5 newsletter draft" in result
+
+    def test_skips_when_queue_full(self):
+        # pending == cap → nothing to add.
+        result, create, _ = _run_generate(settings=_settings(max_queued_drafts=3), pending=3)
         create.assert_not_called()
-        assert "0 user" in result
+        assert "Generated 0 newsletter draft" in result
 
-    def test_skips_when_not_time_yet(self):
-        from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
-        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly", "last_published_at": None}
-        with patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=[1]), \
-             patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=settings), \
-             patch("cqc_lem.utilities.db.get_user_timezone", return_value="UTC"), \
-             patch("cqc_lem.utilities.db.get_pending_newsletter_edition", return_value=None) as pend, \
-             patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=False):
-            result = auto_generate_newsletter_drafts()
-        pend.assert_not_called()
-        assert "0 user" in result
+    def test_bootstrap_gate_blocks_when_not_time_yet(self):
+        # First-ever draft (pending 0) waits for the lead window.
+        result, create, _ = _run_generate(settings=_settings(max_queued_drafts=2), pending=0, gen_now=False)
+        create.assert_not_called()
+        assert "Generated 0 newsletter draft" in result
+
+    def test_rolling_refill_ignores_lead_gate(self):
+        # Queue already rolling (pending > 0) → top up to cap even though the lead gate would say "not yet".
+        result, create, _ = _run_generate(settings=_settings(max_queued_drafts=3), pending=2, gen_now=False)
+        create.assert_called_once()
+        assert "Generated 1 newsletter draft" in result
+
+    def test_stops_when_generation_fails_midway(self):
+        result, create, notify = _run_generate(
+            settings=_settings(max_queued_drafts=3), pending=0,
+            edition_side_effect=[{"title": "T", "subtitle": "S", "body": "B"}, None])
+        create.assert_called_once()
+        assert "Generated 1 newsletter draft" in result
+
+    def test_stops_on_duplicate_slot(self):
+        # create returning 0 (uq_user_slot collision) halts this user's run.
+        result, create, _ = _run_generate(
+            settings=_settings(max_queued_drafts=3), pending=0, create_side_effect=[10, 0])
+        assert create.call_count == 2
+        assert "Generated 1 newsletter draft" in result
 
     def test_one_user_failure_does_not_stop_loop(self):
-        from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
-        settings = {"publish_day": 1, "publish_hour": 9, "cadence": "weekly",
-                    "last_published_at": None, "topic": None}
-        with patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=[1, 2]), \
-             patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=settings), \
-             patch("cqc_lem.utilities.db.get_user_timezone", side_effect=[Exception("boom"), "UTC"]), \
-             patch("cqc_lem.utilities.db.get_pending_newsletter_edition", return_value=None), \
-             patch("cqc_lem.utilities.db.create_newsletter_edition", return_value=1), \
-             patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()), \
-             patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition",
-                   return_value={"title": "T", "subtitle": "S", "body": "B"}), \
-             patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=True), \
-             patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready"):
-            result = auto_generate_newsletter_drafts()
-        assert "1 user" in result
+        result, create, _ = _run_generate(
+            settings=_settings(max_queued_drafts=1), pending=0, user_ids=[1, 2],
+            tz_side_effect=[Exception("boom"), "UTC"])
+        create.assert_called_once()
+        assert "Generated 1 newsletter draft" in result
 
 
 class TestPublishScheduledEditions:

--- a/tests/unit/utilities/test_db_newsletter.py
+++ b/tests/unit/utilities/test_db_newsletter.py
@@ -43,6 +43,14 @@ class TestUpdateNewsletterSettings:
             assert update_newsletter_settings(1, {"enabled": True, "title": "Weekly Wins", "cadence": "weekly"}) is True
         assert "ON DUPLICATE KEY UPDATE" in cur.execute.call_args[0][0]
 
+    def test_upsert_includes_draft_config_columns(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_newsletter_settings
+            update_newsletter_settings(1, {"generate_lead_days": 14, "max_queued_drafts": 5})
+        sql = cur.execute.call_args[0][0]
+        assert "generate_lead_days" in sql and "max_queued_drafts" in sql
+
 
 class TestNewsletterDue:
     def test_returns_due_user_ids(self):
@@ -73,6 +81,34 @@ class TestNewsletterSchedulingFields:
         assert s["publish_day"] == 1 and s["publish_hour"] == 9
 
 
+class TestNewsletterDraftConfigFields:
+    def test_settings_coerce_draft_config(self):
+        row = {"enabled": 1, "title": "T", "topic": None, "cadence": "weekly",
+               "align_with_blog": 1, "newsletter_url": None, "last_published_at": None,
+               "publish_day": "1", "publish_hour": "9",
+               "generate_lead_days": "14", "max_queued_drafts": "5"}
+        conn, _ = _mock_conn(fetch_row=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_settings
+            s = get_newsletter_settings(1)
+        assert s["generate_lead_days"] == 14 and s["max_queued_drafts"] == 5
+
+    def test_defaults_draft_config(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_settings
+            s = get_newsletter_settings(1)
+        assert s["generate_lead_days"] == 3 and s["max_queued_drafts"] == 1
+
+    def test_selects_draft_config_columns(self):
+        conn, cur = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_settings
+            get_newsletter_settings(1)
+        sql = cur.execute.call_args[0][0]
+        assert "generate_lead_days" in sql and "max_queued_drafts" in sql
+
+
 class TestEnabledNewsletterUsers:
     def test_returns_ids(self):
         conn, cur = _mock_conn(fetch_all=[(2,), (9,)])
@@ -101,6 +137,42 @@ class TestEditions:
             assert get_pending_newsletter_edition(1)["id"] == 4
         sql = cur.execute.call_args[0][0]
         assert "draft" in sql and "approved" in sql
+
+    def test_create_returns_zero_on_duplicate_slot(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.IntegrityError("dup uq_user_slot")
+        import datetime
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import create_newsletter_edition
+            assert create_newsletter_edition(1, "T", "S", "B", datetime.datetime(2026, 7, 7, 13)) == 0
+
+    def test_count_pending(self):
+        conn, cur = _mock_conn(fetch_row=(3,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_pending_newsletter_editions
+            assert count_pending_newsletter_editions(1) == 3
+        sql = cur.execute.call_args[0][0]
+        assert "COUNT(*)" in sql and "draft" in sql and "approved" in sql
+
+    def test_get_pending_editions_plural_ordered(self):
+        rows = [{"id": 1, "title": "A", "subtitle": None, "body": "B", "status": "draft", "scheduled_for": None},
+                {"id": 2, "title": "C", "subtitle": None, "body": "D", "status": "approved", "scheduled_for": None}]
+        conn, cur = _mock_conn(fetch_all=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_pending_newsletter_editions
+            out = get_pending_newsletter_editions(1)
+        assert [e["id"] for e in out] == [1, 2]
+        assert "ORDER BY scheduled_for ASC" in cur.execute.call_args[0][0]
+
+    def test_get_latest_scheduled_for(self):
+        import datetime
+        dt = datetime.datetime(2026, 7, 21, 13)
+        conn, cur = _mock_conn(fetch_row=(dt,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_latest_edition_scheduled_for
+            assert get_latest_edition_scheduled_for(1) == dt
+        assert "MAX(scheduled_for)" in cur.execute.call_args[0][0]
 
     def test_update_only_provided_fields(self):
         conn, cur = _mock_conn(rowcount=1)

--- a/tests/unit/utilities/test_newsletter_scheduling.py
+++ b/tests/unit/utilities/test_newsletter_scheduling.py
@@ -44,3 +44,34 @@ class TestShouldGenerateNow:
         nxt = datetime(2026, 7, 14, 13, 0)
         assert should_generate_now(nxt, datetime(2026, 7, 12, 12, 0)) is True   # 2 days out
         assert should_generate_now(nxt, datetime(2026, 7, 10, 12, 0)) is False  # 4 days out
+
+    def test_custom_lead_days(self):
+        from cqc_lem.utilities.newsletter import should_generate_now
+        nxt = datetime(2026, 7, 14, 13, 0)
+        # A 10-day lead window generates a full week+ ahead...
+        assert should_generate_now(nxt, datetime(2026, 7, 6, 12, 0), lead_days=10) is True
+        # ...while a 1-day window holds off until the day before.
+        assert should_generate_now(nxt, datetime(2026, 7, 12, 12, 0), lead_days=1) is False
+        assert should_generate_now(nxt, datetime(2026, 7, 13, 13, 0), lead_days=1) is True
+
+
+class TestUpcomingPublishSlots:
+    def test_chains_weekly_slots_spaced_seven_days(self):
+        from cqc_lem.utilities.newsletter import upcoming_publish_slots
+        now = datetime(2026, 7, 5, 12, 0)  # Sunday
+        slots = upcoming_publish_slots(1, 9, "weekly", None, _ET, now, 3)
+        assert slots == [
+            datetime(2026, 7, 7, 13, 0),
+            datetime(2026, 7, 14, 13, 0),
+            datetime(2026, 7, 21, 13, 0),
+        ]
+
+    def test_biweekly_spacing(self):
+        from cqc_lem.utilities.newsletter import upcoming_publish_slots
+        now = datetime(2026, 7, 5, 12, 0)
+        slots = upcoming_publish_slots(1, 9, "biweekly", None, _ET, now, 2)
+        assert slots == [datetime(2026, 7, 7, 13, 0), datetime(2026, 7, 21, 13, 0)]
+
+    def test_zero_count_returns_empty(self):
+        from cqc_lem.utilities.newsletter import upcoming_publish_slots
+        assert upcoming_publish_slots(1, 9, "weekly", None, _ET, datetime(2026, 7, 5, 12, 0), 0) == []


### PR DESCRIPTION
## What & why

Newsletter draft review was cramped onto the Account page and only ever held **one** draft generated a fixed 3 days out — users felt rushed. This lets them plan editions ahead.

### Two changes
1. **Draft editing moves to the Review page** under a new **Newsletters** tab (`/review?tab=newsletters`), beside post review, with a LinkedIn-article-style preview.
2. **Account page gains plan-ahead config**: how many **days in advance** drafts are generated, and how many **draft newsletters** to keep queued (**1–10**).

### Queue semantics — "pure count"
Always keep exactly `max_queued_drafts` unpublished (draft/approved) editions queued. `generate_lead_days` only gates the **first-ever** draft; once rolling, the queue refills to the cap as editions publish/skip. Each draft covers the next uncovered cadence slot (anchored on the latest slot any edition already covers, so skipped slots are never re-covered).

## Changes
**Backend**
- `V45` migration: `generate_lead_days` + `max_queued_drafts` columns; `uq_user_slot` unique key
- `db.py`: settings plumbing; `count_/get_pending_newsletter_editions` (plural), `get_latest_edition_scheduled_for`; dup-tolerant `create_newsletter_edition`
- `newsletter.py`: `upcoming_publish_slots` (chains `next_publish_datetime`)
- `run_scheduler.py`: `auto_generate_newsletter_drafts` rewritten for pure-count
- `api/main.py`: clamped settings fields; `GET /user/newsletter-draft` returns an `editions` list (was a single `edition`)

**Frontend**
- Review page Posts/Newsletters tab bar (URL-synced)
- `review/NewsletterQueue.tsx`, `components/NewsletterArticlePreview.tsx`
- `NewsletterCard.tsx`: editor removed, config added
- `types.ts`: draft-config fields; `NewsletterDraft` carries an editions list

## Testing
- **1299 unit tests pass** (63 newsletter-specific: cap-binds, bootstrap gate, rolling refill, dup-slot stop, settings clamps, queue shape)
- SPA `tsc --noEmit` typecheck clean

> **Breaking:** `GET /user/newsletter-draft` response key `edition` → `editions` (list). The only consumer (the Account draft editor) is moved in this same PR, so no shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)