### PR TITLE
feat(newsletter): multi-draft review queue with configurable count + days-ahead

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1127,6 +1127,11 @@ def update_newsletter_settings_endpoint(request: NewsletterSettingsRequest) -> R
         raise HTTPException(status_code=401, detail="Invalid or expired session")
     if not update_newsletter_settings(user_id, request.model_dump(exclude={"session_token"})):
         raise HTTPException(status_code=500, detail="Could not update newsletter settings")
+    # Top up the review queue now so a raised max_queued_drafts adds drafts immediately instead of
+    # waiting for the daily beat. Idempotent: a full queue generates nothing.
+    if request.enabled:
+        from cqc_lem.app.run_scheduler import generate_newsletter_drafts_for_user
+        generate_newsletter_drafts_for_user.apply_async(kwargs={"user_id": user_id})
     return ResponseModel(status_code=200, detail="Newsletter settings updated")
 
 

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -137,58 +137,93 @@ def _max_dt(*dts):
     return max(present) if present else None
 
 
-@shared_task.task
-def auto_generate_newsletter_drafts():
-    """Keep each enabled user's review queue topped up to their max_queued_drafts, so they can plan
-    ahead. The first-ever draft waits for the generate_lead_days window; once the queue is rolling it
-    refills to the cap as editions publish/skip. Each draft covers the next uncovered cadence slot."""
+def _topup_newsletter_drafts_for_user(user_id: int, now: datetime,
+                                      allow_bootstrap: bool = True) -> int:
+    """Top a single user's review queue up to their max_queued_drafts and return how many drafts were
+    generated. Each draft covers the next uncovered cadence slot.
+
+    `allow_bootstrap` gates the first-ever draft (empty queue): the daily beat passes True so the very
+    first draft still waits for the generate_lead_days window; an explicit user action (e.g. raising
+    the count) passes False to fill the queue ahead immediately."""
     import pytz
-    from cqc_lem.utilities.db import (get_enabled_newsletter_user_ids, get_newsletter_settings,
-                                      get_user_timezone, count_pending_newsletter_editions,
+    from cqc_lem.utilities.db import (get_newsletter_settings, get_user_timezone,
+                                      count_pending_newsletter_editions,
                                       get_latest_edition_scheduled_for, create_newsletter_edition)
     from cqc_lem.utilities.linkedin.helper import load_profile_for_user
     from cqc_lem.utilities.ai.ai_helper import generate_newsletter_edition
     from cqc_lem.utilities.newsletter import upcoming_publish_slots, should_generate_now
     from cqc_lem.utilities.notifications import notify_newsletter_draft_ready
 
+    settings = get_newsletter_settings(user_id)
+    cap = settings.get("max_queued_drafts", 1)
+    lead = settings.get("generate_lead_days", 3)
+    pending = count_pending_newsletter_editions(user_id)
+    remaining = cap - pending
+    if remaining <= 0:
+        return 0  # queue already full
+
+    tz = pytz.timezone(get_user_timezone(user_id))
+    # Anchor on the latest slot ANY edition already covers (incl. published/skipped) so a freed cap
+    # slot fills the next future slot, never re-covering a skipped one.
+    anchor = _max_dt(settings.get("last_published_at"),
+                     get_latest_edition_scheduled_for(user_id))
+    slots = upcoming_publish_slots(
+        settings.get("publish_day", 1), settings.get("publish_hour", 9),
+        settings.get("cadence", "weekly"), anchor, tz, now, remaining)
+    # Bootstrap gate: only the first-ever draft waits for the lead window, and only when triggered by
+    # the daily beat. Once the queue is rolling (pending > 0), or when the user explicitly asked for
+    # more queued drafts, keep it topped up regardless of how far out the slots land.
+    if pending == 0 and allow_bootstrap and not should_generate_now(slots[0], now, lead_days=lead):
+        return 0
+
+    generated = 0
+    profile = load_profile_for_user(user_id)
+    for slot in slots:
+        edition = generate_newsletter_edition(profile, topic=settings.get("topic"))
+        if not edition:
+            break
+        if not create_newsletter_edition(user_id, edition["title"], edition.get("subtitle"),
+                                          edition["body"], slot):
+            break  # duplicate slot / db error → stop this user's run
+        notify_newsletter_draft_ready(user_id, edition["title"], slot)
+        generated += 1
+    return generated
+
+
+@shared_task.task
+def auto_generate_newsletter_drafts():
+    """Keep each enabled user's review queue topped up to their max_queued_drafts, so they can plan
+    ahead. The first-ever draft waits for the generate_lead_days window; once the queue is rolling it
+    refills to the cap as editions publish/skip."""
+    from cqc_lem.utilities.db import get_enabled_newsletter_user_ids
+
     now = datetime.utcnow()
     generated = 0
     for user_id in get_enabled_newsletter_user_ids():
         try:
-            settings = get_newsletter_settings(user_id)
-            cap = settings.get("max_queued_drafts", 1)
-            lead = settings.get("generate_lead_days", 3)
-            pending = count_pending_newsletter_editions(user_id)
-            remaining = cap - pending
-            if remaining <= 0:
-                continue  # queue already full
-
-            tz = pytz.timezone(get_user_timezone(user_id))
-            # Anchor on the latest slot ANY edition already covers (incl. published/skipped) so a
-            # freed cap slot fills the next future slot, never re-covering a skipped one.
-            anchor = _max_dt(settings.get("last_published_at"),
-                             get_latest_edition_scheduled_for(user_id))
-            slots = upcoming_publish_slots(
-                settings.get("publish_day", 1), settings.get("publish_hour", 9),
-                settings.get("cadence", "weekly"), anchor, tz, now, remaining)
-            # Bootstrap gate: only the first-ever draft waits for the lead window. Once the queue is
-            # rolling (pending > 0), keep it topped up regardless of how far out the slots land.
-            if pending == 0 and not should_generate_now(slots[0], now, lead_days=lead):
-                continue
-
-            profile = load_profile_for_user(user_id)
-            for slot in slots:
-                edition = generate_newsletter_edition(profile, topic=settings.get("topic"))
-                if not edition:
-                    break
-                if not create_newsletter_edition(user_id, edition["title"], edition.get("subtitle"),
-                                                 edition["body"], slot):
-                    break  # duplicate slot / db error → stop this user's run
-                notify_newsletter_draft_ready(user_id, edition["title"], slot)
-                generated += 1
+            generated += _topup_newsletter_drafts_for_user(user_id, now)
         except Exception as e:
             log_warning("Failed to generate newsletter draft", exc=e, user_id=user_id,
                         task_name="auto_generate_newsletter_drafts")
+    return f"Generated {generated} newsletter draft(s)"
+
+
+@shared_task.task
+def generate_newsletter_drafts_for_user(user_id: int):
+    """Top up a single user's newsletter review queue on demand (e.g. right after they raise their
+    max_queued_drafts in settings), so new slots don't wait for the daily beat. Skips the bootstrap
+    lead-window gate: an explicit settings change should fill the queue ahead immediately."""
+    from cqc_lem.utilities.db import get_newsletter_settings
+
+    if not get_newsletter_settings(user_id).get("enabled"):
+        return "Newsletter disabled"
+    try:
+        generated = _topup_newsletter_drafts_for_user(user_id, datetime.utcnow(),
+                                                       allow_bootstrap=False)
+    except Exception as e:
+        log_warning("Failed to generate newsletter draft", exc=e, user_id=user_id,
+                    task_name="generate_newsletter_drafts_for_user")
+        return "Generated 0 newsletter draft(s)"
     return f"Generated {generated} newsletter draft(s)"
 
 

--- a/tests/unit/api/test_newsletter_api.py
+++ b/tests/unit/api/test_newsletter_api.py
@@ -14,6 +14,7 @@ def client():
         patch("cqc_lem.app.run_automation.automate_reply_commenting"),
         patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
         patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+        patch("cqc_lem.app.run_scheduler.generate_newsletter_drafts_for_user"),
     ]
     for p in patches:
         p.start()
@@ -76,6 +77,24 @@ class TestNewsletterSettings:
         assert resp.status_code == 200
         args = upd.call_args[0][1]
         assert args["max_queued_drafts"] == 1 and args["generate_lead_days"] == 0
+
+    def test_put_enabled_triggers_queue_topup(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_newsletter_settings", return_value=True), \
+             patch("cqc_lem.app.run_scheduler.generate_newsletter_drafts_for_user") as task:
+            resp = client.put("/api/user/newsletter-settings", json={
+                "session_token": _SESSION, "enabled": True, "max_queued_drafts": 3})
+        assert resp.status_code == 200
+        task.apply_async.assert_called_once_with(kwargs={"user_id": _USER})
+
+    def test_put_disabled_does_not_trigger_topup(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_newsletter_settings", return_value=True), \
+             patch("cqc_lem.app.run_scheduler.generate_newsletter_drafts_for_user") as task:
+            resp = client.put("/api/user/newsletter-settings", json={
+                "session_token": _SESSION, "enabled": False, "max_queued_drafts": 3})
+        assert resp.status_code == 200
+        task.apply_async.assert_not_called()
 
     def test_401(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=None):

--- a/tests/unit/app/test_newsletter_publish.py
+++ b/tests/unit/app/test_newsletter_publish.py
@@ -198,6 +198,57 @@ class TestGenerateNewsletterDrafts:
         assert "Generated 1 newsletter draft" in result
 
 
+def _run_generate_for_user(*, settings, pending, latest=None, gen_now=True, edition=None,
+                           create_ret=1):
+    """Drive generate_newsletter_drafts_for_user (the on-demand per-user top-up) with collaborators
+    mocked out."""
+    from contextlib import ExitStack
+    from cqc_lem.app.run_scheduler import generate_newsletter_drafts_for_user
+    if edition is None:
+        edition = {"title": "T", "subtitle": "S", "body": "B"}
+    with ExitStack() as es:
+        p = es.enter_context
+        p(patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=settings))
+        p(patch("cqc_lem.utilities.db.get_user_timezone", return_value="UTC"))
+        p(patch("cqc_lem.utilities.db.count_pending_newsletter_editions", return_value=pending))
+        p(patch("cqc_lem.utilities.db.get_latest_edition_scheduled_for", return_value=latest))
+        create = p(patch("cqc_lem.utilities.db.create_newsletter_edition", return_value=create_ret))
+        p(patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()))
+        p(patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", return_value=edition))
+        p(patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=gen_now))
+        p(patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready"))
+        result = generate_newsletter_drafts_for_user.run(user_id=1)
+    return result, create
+
+
+class TestGenerateNewsletterDraftsForUser:
+    def test_disabled_user_generates_nothing(self):
+        result, create = _run_generate_for_user(
+            settings=_settings(enabled=False, max_queued_drafts=3), pending=1)
+        create.assert_not_called()
+        assert "disabled" in result
+
+    def test_raising_count_adds_delta_when_one_exists(self):
+        # User already has one draft; count raised to 3 → fill the two freed slots.
+        result, create = _run_generate_for_user(
+            settings=_settings(enabled=True, max_queued_drafts=3), pending=1)
+        assert create.call_count == 2
+        assert "Generated 2 newsletter draft" in result
+
+    def test_bypasses_bootstrap_lead_gate(self):
+        # Empty queue, outside the lead window: an explicit settings change still fills ahead.
+        result, create = _run_generate_for_user(
+            settings=_settings(enabled=True, max_queued_drafts=2), pending=0, gen_now=False)
+        assert create.call_count == 2
+        assert "Generated 2 newsletter draft" in result
+
+    def test_skips_when_queue_full(self):
+        result, create = _run_generate_for_user(
+            settings=_settings(enabled=True, max_queued_drafts=2), pending=2)
+        create.assert_not_called()
+        assert "Generated 0 newsletter draft" in result
+
+
 class TestPublishScheduledEditions:
     def test_dispatches_due_editions(self):
         from cqc_lem.app.run_scheduler import auto_publish_scheduled_editions


### PR DESCRIPTION
## Summary
Adds a configurable newsletter draft review queue and fixes queue top-up responsiveness.

- Multi-draft queue with `max_queued_drafts` (count) + `generate_lead_days` (days-ahead) config
- Newsletter draft review moved to the Review page with settings UI
- **Fix:** raising the draft count now tops up the queue immediately instead of waiting for the daily beat

## The fix (latest commit)
Previously `max_queued_drafts` only refilled the queue on the daily 10 AM Celery beat, so a user who already had a draft saw no new drafts appear until the next run — and an empty queue stayed blocked by the bootstrap lead-window gate.

- Extracted per-user top-up into `_topup_newsletter_drafts_for_user(user_id, now, allow_bootstrap)`
- Added on-demand `generate_newsletter_drafts_for_user` task, dispatched from `PUT /user/newsletter-settings` when enabled, bypassing the bootstrap gate so an explicit count increase fills ahead immediately

## Testing
- 38 newsletter unit tests pass (18 pre-existing + new coverage for count-raise delta, bootstrap bypass, disabled/full no-ops, and endpoint dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)