### PR TITLE
feat(ui): copyright footer with configurable release-version text

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,12 @@ ADMIN_SECRET=change_me_to_a_strong_random_secret
 # Comma-separated bearer tokens accepted on /api routes (Authorization: Bearer ...).
 # Leave EMPTY for local/dev to disable the gate. Set on internet-facing deploys.
 API_ACCESS_TOKENS=
+# SPA footer: show the running release version in small text (so you always know
+# which version the site is serving). Set to false to hide the version text.
+SHOW_VERSION_FOOTER=true
+# Optional override for the displayed version. Leave EMPTY to auto-detect from the
+# installed package (matches the release baked into the running image).
+APP_VERSION=
 
 
 # =============================================================================

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -112,7 +112,7 @@ _API_ACCESS_TOKEN_SET = {t.strip() for t in API_ACCESS_TOKENS.split(",") if t.st
 # handler (get_assets) is GET-only and path-traversal safe (_find_asset_file
 # rejects .. / separators and only returns real files under assets_dir).
 _PUBLIC_API_PREFIXES = ("/api/auth/", "/api/billing/webhook", "/api/assets",
-                        "/api/linkedin/verification-pin")
+                        "/api/linkedin/verification-pin", "/api/app-info")
 
 
 def _api_token_required(path: str) -> bool:
@@ -461,6 +461,16 @@ class FutureForwardValues(IntEnum):
 @app.get("/health")
 def health_check():
     return {"status": "healthy"}
+
+
+@router.get("/app-info")
+def get_app_info() -> ResponseModel:
+    """Public: the SPA footer reads the running release version + whether to display it."""
+    from cqc_lem.utilities.env_constants import get_app_version, SHOW_VERSION_FOOTER
+    return ResponseModel(status_code=200, detail={
+        "version": get_app_version(),
+        "show_version": SHOW_VERSION_FOOTER,
+    })
 
 
 @router.get("/dashboard/stats/", responses={

--- a/src/cqc_lem/ui/src/components/Footer.tsx
+++ b/src/cqc_lem/ui/src/components/Footer.tsx
@@ -1,0 +1,17 @@
+import { useAppInfo } from '../hooks/useAppInfo'
+
+export default function Footer() {
+  const { data } = useAppInfo()
+  const year = new Date().getFullYear()
+
+  return (
+    <footer className="border-t border-gray-200 bg-white">
+      <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-center gap-2 text-gray-400">
+        <span className="text-xs">© {year} Christopher Queen Consulting. All rights reserved.</span>
+        {data?.show_version && data.version && (
+          <span className="text-[10px] leading-none text-gray-300">v{data.version}</span>
+        )}
+      </div>
+    </footer>
+  )
+}

--- a/src/cqc_lem/ui/src/components/Layout.tsx
+++ b/src/cqc_lem/ui/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { NavLink, Outlet, useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import AccountReadinessBanner from './AccountReadinessBanner'
+import Footer from './Footer'
 
 // Pages whose features depend on a fully set-up account — show the readiness banner here.
 const AUTOMATION_PATHS = ['/schedule', '/review', '/avatars']
@@ -25,7 +26,7 @@ export default function Layout() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-100">
+    <div className="min-h-screen flex flex-col bg-gray-100">
       <nav className="bg-white border-b border-gray-200 sticky top-0 z-10">
         <div className="max-w-5xl mx-auto px-4 flex items-center gap-6 h-14">
           <span className="font-bold text-blue-600 text-lg">LEM</span>
@@ -69,10 +70,11 @@ export default function Layout() {
           </div>
         </div>
       </nav>
-      <main className="max-w-5xl mx-auto px-4 py-6">
+      <main className="flex-1 w-full max-w-5xl mx-auto px-4 py-6">
         {showReadiness && <AccountReadinessBanner />}
         <Outlet />
       </main>
+      <Footer />
     </div>
   )
 }

--- a/src/cqc_lem/ui/src/hooks/useAppInfo.ts
+++ b/src/cqc_lem/ui/src/hooks/useAppInfo.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query'
+import api from '../api/client'
+
+export interface AppInfo {
+  version: string
+  show_version: boolean
+}
+
+// Public app metadata for the footer: the running release version and whether to
+// display it. Toggled server-side via the SHOW_VERSION_FOOTER env var.
+export function useAppInfo() {
+  return useQuery({
+    queryKey: ['app-info'],
+    queryFn: () => api.get('/app-info').then((r) => r.data.detail as AppInfo),
+    staleTime: 60 * 60 * 1000,
+  })
+}

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -172,3 +172,20 @@ API_ACCESS_TOKENS = get_constant_from_env('API_ACCESS_TOKENS', default_value='')
 
 # Set other constants here
 USE_DOCKER_BROWSER = isTrue(get_constant_from_env('USE_DOCKER_BROWSER', default_value='True'))
+
+# SPA footer version display. SHOW_VERSION_FOOTER toggles the small release-version
+# text in the copyright footer (default on; set to false to hide it). APP_VERSION
+# overrides the auto-detected version; when empty it falls back to the installed
+# package metadata, which reflects the exact release baked into the running image.
+SHOW_VERSION_FOOTER = isTrue(get_constant_from_env('SHOW_VERSION_FOOTER', default_value='True'))
+APP_VERSION = get_constant_from_env('APP_VERSION', default_value='')
+
+
+def get_app_version() -> str:
+    if APP_VERSION:
+        return APP_VERSION
+    try:
+        from importlib.metadata import version
+        return version('linkedin-engagement-manager')
+    except Exception:
+        return 'unknown'

--- a/tests/unit/api/test_api_token_gate.py
+++ b/tests/unit/api/test_api_token_gate.py
@@ -67,6 +67,7 @@ class TestApiTokenRequired:
         "/api/auth/session",
         "/api/billing/webhook",   # Stripe (signature-verified)
         "/api/assets",            # public: LinkedIn fetches media over unauth URL
+        "/api/app-info",          # public: SPA footer version/toggle
         "/health",                # non-/api
         "/auth/linkedin/callback",
         "/assets/index.js",       # SPA static
@@ -107,3 +108,18 @@ class TestGateMiddleware:
         with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", set()):
             resp = client.get("/api/assets", params={"file_name": "x.png"})
         assert resp.status_code != 401
+
+
+class TestAppInfo:
+    def test_returns_version_and_toggle(self, main_mod, client):
+        with patch("cqc_lem.utilities.env_constants.get_app_version", return_value="1.2.3"), \
+             patch("cqc_lem.utilities.env_constants.SHOW_VERSION_FOOTER", True):
+            resp = client.get("/api/app-info")
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == {"version": "1.2.3", "show_version": True}
+
+    def test_reachable_when_gate_enabled(self, main_mod, client):
+        # The footer loads pre-login, so /api/app-info must clear the bearer gate.
+        with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", {"tok"}):
+            resp = client.get("/api/app-info")
+        assert resp.status_code == 200


### PR DESCRIPTION
## Summary
Adds a copyright footer to the bottom of every SPA page, showing the running release version in very small text so you always know which version the site is actually serving.

## Details
- **Footer** (`Footer.tsx`) wired into `Layout` with a sticky-bottom flex layout — appears on all pages (including landing/login).
- **Version source:** read at runtime from installed package metadata (`linkedin-engagement-manager`), which matches the release baked into the running image — no manual bumping.
- **Public endpoint** `GET /api/app-info` returns `{version, show_version}`; added to the bearer-gate allowlist so the footer loads pre-login.
- **Configurable via `.env` (no rebuild):**
  - `SHOW_VERSION_FOOTER` (default `true`) — toggle the version text off/on
  - `APP_VERSION` (optional) — override the auto-detected version

## Testing
- `test_api_token_gate.py`: added coverage for `/api/app-info` output + that it clears the bearer gate (25 pass)
- SPA TypeScript type-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)