### PR TITLE
feat(automation): consolidate duplicate comments to one-per-post (dry-run default)

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -12,7 +12,7 @@ from cqc_lem.app.aws_test_celery_task import test_get_my_profile
 from cqc_lem.app.run_automation import (
     automate_invites_to_company_page_for_user, automate_reply_commenting,
     automate_commenting, automate_appreciation_dms_for_user,
-    send_private_dm,
+    send_private_dm, consolidate_duplicate_comments_for_user,
 )
 from celery import chain as celery_chain
 from cqc_lem.app.run_content_plan import auto_create_weekly_content, plan_content_for_user
@@ -2246,6 +2246,30 @@ def admin_test_reply(
     return ResponseModel(status_code=200, detail={
         "task_id": result.id, "task": "automate_reply_commenting",
         "post_id": post_id, "user_id": user_id,
+    })
+
+
+@router.post("/admin/consolidate-duplicate-comments", responses={
+    200: {"description": "Consolidation run queued"},
+    401: {"description": "Missing/invalid bearer token"},
+    403: {"description": "Missing/invalid admin secret"},
+})
+def admin_consolidate_duplicate_comments(
+    user_id: int = Query(..., description="LinkedIn account user id", examples=[1]),
+    dry_run: bool = Query(True, description="Report-only when true; set false to actually delete extras"),
+    hours: int = Query(168, ge=1, le=2160,
+                       description="Look back this many hours for duplicate-commented posts (default 7 days)"),
+    _: None = Depends(_require_api_and_admin),
+) -> ResponseModel:
+    """Keep one comment per post and delete the extras for posts this user commented on more than once.
+    Defaults to a DRY RUN (report only) — pass dry_run=false to actually delete."""
+    result = consolidate_duplicate_comments_for_user.apply_async(kwargs={
+        "user_id": user_id, "dry_run": dry_run, "hours": hours,
+    }, queue="se_engage")
+    myprint(f"admin/consolidate-duplicate-comments: queued task={result.id} user_id={user_id} dry_run={dry_run}")
+    return ResponseModel(status_code=200, detail={
+        "task_id": result.id, "task": "consolidate_duplicate_comments_for_user",
+        "user_id": user_id, "dry_run": dry_run, "hours": hours,
     })
 
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -27,7 +27,8 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     claim_post_for_comment, mark_post_commented, mark_post_reacted, release_post_claim, has_commented_post, \
     has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, PostType, \
     get_dm_history_for_profile, get_post_status, get_user_blog_url, get_post_type, get_carousel_slides, \
-    get_dm_template, enqueue_followup, get_due_followups, mark_followup, stop_followups_for_profile
+    get_dm_template, enqueue_followup, get_due_followups, mark_followup, stop_followups_for_profile, \
+    get_duplicate_comment_posts
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
     load_profile_for_user
@@ -1074,6 +1075,133 @@ def _pin_own_comment(driver) -> bool:
     except Exception as e:
         log_warning("Pin own comment failed", exc=e, action_type="comment")
         return False
+
+
+# JS: count the overflow ("…") buttons for OUR OWN comments on the current post. LinkedIn labels each
+# comment's overflow control "View more options for <name>'s comment.", so matching our full name
+# restricts this to comments WE authored — we never touch anyone else's comment.
+_COUNT_OWN_COMMENT_MENUS_JS = (
+    "const name=(arguments[0]||'').toLowerCase();"
+    "return [...document.querySelectorAll('button[aria-label]')].filter(x=>{"
+    "const a=(x.getAttribute('aria-label')||'').toLowerCase();"
+    "return a.includes('options for') && a.includes('comment') && name && a.includes(name);"
+    "}).length;")
+
+# JS: open the overflow menu of the LAST of our own comments (we keep the first/earliest and delete
+# the rest). The control is hover-hidden, so we JS-click it directly.
+_OPEN_LAST_OWN_COMMENT_MENU_JS = (
+    "const name=(arguments[0]||'').toLowerCase();"
+    "const b=[...document.querySelectorAll('button[aria-label]')].filter(x=>{"
+    "const a=(x.getAttribute('aria-label')||'').toLowerCase();"
+    "return a.includes('options for') && a.includes('comment') && name && a.includes(name);"
+    "});"
+    "if(!b.length) return false;"
+    "const t=b[b.length-1]; t.scrollIntoView({block:'center'}); t.click(); return true;")
+
+# JS: click the "Delete" item in the open overflow menu.
+_CLICK_DELETE_MENUITEM_JS = (
+    "const el=[...document.querySelectorAll('[role=menuitem],[role=menuitemradio],button,div,span,li,h5')]"
+    ".find(e=>/^delete\\b/i.test((e.innerText||'').trim()) && (e.innerText||'').trim().length<20);"
+    "if(el){(el.closest('[role=menuitem]')||el).click(); return true;} return false;")
+
+# JS: confirm deletion in the modal that follows (its confirm button reads exactly "Delete").
+_CONFIRM_DELETE_MODAL_JS = (
+    "const d=[...document.querySelectorAll('[role=dialog],.artdeco-modal')];"
+    "for(const m of d){const btn=[...m.querySelectorAll('button')]"
+    ".find(b=>((b.innerText||'').trim().toLowerCase()==='delete'));"
+    "if(btn){btn.click(); return true;}} return false;")
+
+
+def _delete_extra_own_comments_on_post(driver, my_full_name: str, dry_run: bool = True) -> Tuple[int, int]:
+    """On the CURRENTLY-OPEN post page, keep our earliest comment and delete the rest so the post ends
+    with exactly ONE comment from us. Returns (own_comments_found, deleted). In dry_run mode it only
+    counts what WOULD be deleted (deleted stays 0). Only comments authored by `my_full_name` are ever
+    touched — replies/comments by others are never affected."""
+    try:
+        found = int(driver.execute_script(_COUNT_OWN_COMMENT_MENUS_JS, my_full_name) or 0)
+    except Exception as e:
+        log_warning("Could not count own comments on post", exc=e, action_type="comment")
+        return 0, 0
+    if found <= 1:
+        return found, 0
+    if dry_run:
+        return found, 0
+
+    deleted = 0
+    # Delete the last-of-ours repeatedly, re-counting each pass (the DOM re-renders after a delete).
+    # Cap the loop at the initial surplus so a stuck menu can't spin forever.
+    for _ in range(found - 1):
+        try:
+            if not driver.execute_script(_OPEN_LAST_OWN_COMMENT_MENU_JS, my_full_name):
+                break
+            time.sleep(random.uniform(1, 2))
+            if not driver.execute_script(_CLICK_DELETE_MENUITEM_JS):
+                log_warning("Delete menu item not found; stopping this post", action_type="comment")
+                break
+            time.sleep(random.uniform(1, 2))
+            if not driver.execute_script(_CONFIRM_DELETE_MODAL_JS):
+                log_warning("Delete confirm button not found; stopping this post", action_type="comment")
+                break
+            wait_for_ajax(driver)
+            time.sleep(random.uniform(2, 3))
+            deleted += 1
+            remaining = int(driver.execute_script(_COUNT_OWN_COMMENT_MENUS_JS, my_full_name) or 0)
+            if remaining <= 1:
+                break
+        except Exception as e:
+            log_warning("Error deleting a duplicate comment", exc=e, action_type="comment")
+            break
+    return found, deleted
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='se_engage')
+def consolidate_duplicate_comments_for_user(self, user_id: int, dry_run: bool = True, hours: int = 168):
+    """One-off cleanup: for each post this user commented on MORE THAN ONCE in the last `hours`,
+    delete the extra comments so exactly ONE remains. dry_run=True (default) only REPORTS what it
+    would delete — pass dry_run=False to actually delete. Only real post URLs are actionable; feed
+    comments logged under a synthetic key (no navigable URL) are reported as skipped."""
+    dupes = get_duplicate_comment_posts(user_id, hours)
+    if not dupes:
+        return "No duplicate-commented posts found"
+
+    actionable = [row for row in dupes if str(row[0]).startswith("http")]
+    skipped = len(dupes) - len(actionable)
+    if not actionable:
+        return (f"Found {len(dupes)} duplicate-commented post(s) but none have a navigable URL "
+                f"(synthetic feed keys) — cannot auto-delete; inspect manually.")
+
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(
+            user_id=user_id, session_name="Consolidate Comments")
+    except Exception as e:
+        log_error("Login failed for comment consolidation", exc=e, user_id=user_id,
+                  task_name="consolidate_duplicate_comments_for_user")
+        return f"Failed to start: {e}"
+
+    posts_processed, total_found, total_deleted = 0, 0, 0
+    try:
+        for post_url, logged_count, first_at, last_at in actionable:
+            try:
+                driver.get(post_url)
+                time.sleep(random.uniform(4, 7))
+                found, deleted = _delete_extra_own_comments_on_post(driver, my_profile.full_name, dry_run)
+                posts_processed += 1
+                total_found += found
+                total_deleted += deleted
+                log_info(f"Consolidated comments on post (found={found}, deleted={deleted}, "
+                         f"dry_run={dry_run})", user_id=user_id, post_id=post_url,
+                         action_type="comment", task_name="consolidate_duplicate_comments_for_user")
+            except Exception as e:
+                log_warning("Failed to consolidate a post's comments", exc=e, user_id=user_id,
+                            post_id=post_url, action_type="comment")
+    finally:
+        quit_gracefully(driver)
+
+    verb = "would delete" if dry_run else "deleted"
+    return (f"Processed {posts_processed} post(s); {verb} {total_deleted} extra comment(s) "
+            f"(own comments found across posts={total_found}; skipped {skipped} non-URL post(s); "
+            f"dry_run={dry_run})")
 
 
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id', 'post_id']},

--- a/tests/unit/api/test_admin_engagement_test_runs.py
+++ b/tests/unit/api/test_admin_engagement_test_runs.py
@@ -130,6 +130,33 @@ class TestTaskStatus:
         assert r.status_code == 403
 
 
+class TestConsolidateDuplicateComments:
+    def test_forbidden_without_secret(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET):
+            r = client.post("/api/admin/consolidate-duplicate-comments", params={"user_id": 1})
+        assert r.status_code == 403
+
+    def test_defaults_to_dry_run(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
+             patch("cqc_lem.api.main.consolidate_duplicate_comments_for_user.apply_async",
+                   return_value=_async_result()) as t:
+            r = client.post("/api/admin/consolidate-duplicate-comments",
+                            params={"user_id": 3}, headers=_ADMIN_HEADER)
+        assert r.status_code == 200
+        assert r.json()["detail"]["dry_run"] is True
+        assert t.call_args.kwargs["kwargs"] == {"user_id": 3, "dry_run": True, "hours": 168}
+        assert t.call_args.kwargs["queue"] == "se_engage"
+
+    def test_can_request_real_delete(self, client):
+        with patch("cqc_lem.api.main.ADMIN_SECRET", _SECRET), \
+             patch("cqc_lem.api.main.consolidate_duplicate_comments_for_user.apply_async",
+                   return_value=_async_result()) as t:
+            r = client.post("/api/admin/consolidate-duplicate-comments",
+                            params={"user_id": 3, "dry_run": False, "hours": 48}, headers=_ADMIN_HEADER)
+        assert r.status_code == 200
+        assert t.call_args.kwargs["kwargs"] == {"user_id": 3, "dry_run": False, "hours": 48}
+
+
 class TestAuthSchemeInOpenAPI:
     """Both security schemes must be advertised so /docs shows both credentials."""
     def test_both_schemes_present(self, client):

--- a/tests/unit/app/test_consolidate_comments.py
+++ b/tests/unit/app/test_consolidate_comments.py
@@ -1,0 +1,112 @@
+"""Unit tests for the duplicate-comment consolidation task + helper."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+
+class TestDeleteExtraOwnComments:
+    def _driver(self, counts, open_ok=True, delete_ok=True, confirm_ok=True):
+        """A driver whose execute_script returns the queued values for the count JS in order, and
+        fixed truthy/falsy for the open/delete/confirm JS steps."""
+        driver = MagicMock()
+        count_iter = iter(counts)
+
+        def exec_script(js, *args):
+            from cqc_lem.app import run_automation as ra
+            if js == ra._COUNT_OWN_COMMENT_MENUS_JS:
+                return next(count_iter)
+            if js == ra._OPEN_LAST_OWN_COMMENT_MENU_JS:
+                return open_ok
+            if js == ra._CLICK_DELETE_MENUITEM_JS:
+                return delete_ok
+            if js == ra._CONFIRM_DELETE_MODAL_JS:
+                return confirm_ok
+            return None
+
+        driver.execute_script.side_effect = exec_script
+        return driver
+
+    def test_single_comment_is_noop(self):
+        from cqc_lem.app.run_automation import _delete_extra_own_comments_on_post
+        driver = self._driver([1])
+        found, deleted = _delete_extra_own_comments_on_post(driver, "Chris Q", dry_run=False)
+        assert (found, deleted) == (1, 0)
+
+    def test_dry_run_counts_but_does_not_delete(self):
+        from cqc_lem.app.run_automation import _delete_extra_own_comments_on_post
+        driver = self._driver([3])
+        found, deleted = _delete_extra_own_comments_on_post(driver, "Chris Q", dry_run=True)
+        assert (found, deleted) == (3, 0)
+
+    @patch(f"{_RA}.time.sleep")
+    @patch(f"{_RA}.wait_for_ajax")
+    def test_deletes_down_to_one(self, _ajax, _sleep):
+        from cqc_lem.app.run_automation import _delete_extra_own_comments_on_post
+        # initial count 3, then 2 after first delete, then 1 → stop. Keeps exactly one.
+        driver = self._driver([3, 2, 1])
+        found, deleted = _delete_extra_own_comments_on_post(driver, "Chris Q", dry_run=False)
+        assert found == 3
+        assert deleted == 2
+
+    @patch(f"{_RA}.time.sleep")
+    def test_stops_when_delete_item_missing(self, _sleep):
+        from cqc_lem.app.run_automation import _delete_extra_own_comments_on_post
+        driver = self._driver([2, 2], delete_ok=False)
+        found, deleted = _delete_extra_own_comments_on_post(driver, "Chris Q", dry_run=False)
+        assert found == 2 and deleted == 0
+
+
+def _run_task(*, dupes, dry_run=True, full_name="Chris Q", profile_raises=False):
+    from cqc_lem.app.run_automation import consolidate_duplicate_comments_for_user
+    driver = MagicMock()
+    wait = MagicMock()
+    profile = MagicMock()
+    profile.full_name = full_name
+    gcp = (MagicMock(side_effect=Exception("login")) if profile_raises
+           else MagicMock(return_value=(driver, wait, "e@x.com", profile)))
+    with patch(f"{_RA}.get_duplicate_comment_posts", return_value=dupes), \
+         patch(f"{_RA}.get_current_profile", gcp), \
+         patch(f"{_RA}._delete_extra_own_comments_on_post", return_value=(2, 0 if dry_run else 1)) as dele, \
+         patch(f"{_RA}.quit_gracefully"), \
+         patch(f"{_RA}.time.sleep"):
+        result = consolidate_duplicate_comments_for_user.run(user_id=1, dry_run=dry_run, hours=168)
+    return result, dele, driver
+
+
+class TestConsolidateTask:
+    def test_no_duplicates(self):
+        result, dele, _ = _run_task(dupes=[])
+        assert "No duplicate" in result
+        dele.assert_not_called()
+
+    def test_skips_non_url_synthetic_keys(self):
+        # Only a synthetic feed key → nothing navigable to delete.
+        result, dele, _ = _run_task(dupes=[("feedpost://abc123", 2, None, None)])
+        assert "none have a navigable URL" in result
+        dele.assert_not_called()
+
+    def test_dry_run_reports_without_deleting(self):
+        dupes = [("https://www.linkedin.com/feed/update/urn:li:activity:1/", 3, None, None)]
+        result, dele, driver = _run_task(dupes=dupes, dry_run=True)
+        dele.assert_called_once()
+        assert dele.call_args[0][2] is True  # dry_run passed through
+        assert "would delete" in result
+        driver.get.assert_called_once()
+
+    def test_actually_deletes_when_not_dry_run(self):
+        dupes = [("https://www.linkedin.com/feed/update/urn:li:activity:2/", 2, None, None)]
+        result, dele, _ = _run_task(dupes=dupes, dry_run=False)
+        dele.assert_called_once()
+        assert dele.call_args[0][2] is False
+        assert "deleted 1 extra comment" in result
+
+    def test_login_failure_returns_cleanly(self):
+        dupes = [("https://www.linkedin.com/feed/update/urn:li:activity:3/", 2, None, None)]
+        result, dele, _ = _run_task(dupes=dupes, profile_raises=True)
+        assert "Failed to start" in result
+        dele.assert_not_called()


### PR DESCRIPTION
One-off cleanup for the duplicate-comments issue: for each post the user commented on more than once, keep the earliest comment and delete the extras.

**⚠️ This deletes live LinkedIn comments. It defaults to a DRY RUN. Review before merge; needs an authenticated LinkedIn session on the runner (the VPS), which is separate from CI.** Based on `feature/claude-comment-quality` (#293) because it reuses `get_duplicate_comment_posts`.

## What it does
- **`consolidate_duplicate_comments_for_user`** Celery task (queue `se_engage`), `dry_run=True` by default → **reports** how many it would delete without touching anything. Pass `dry_run=false` to actually delete.
- **`_delete_extra_own_comments_on_post`** — on each post page, counts our own comments (matched by our name in the comment's overflow `aria-label`), keeps the first, deletes the rest via the hover-hidden "…" menu → Delete → confirm modal. Re-counts after each delete, caps the loop, stops safely if a menu/confirm control isn't found.
- **Safety:** only comments **we authored** are ever targeted (name match) — others' comments and replies are never touched. Posts logged under a synthetic feed key (no navigable URL) are reported as skipped, not guessed at.
- **`POST /admin/consolidate-duplicate-comments`** (X-Admin-Secret) with `user_id`, `dry_run` (default true), `hours` (default 168 = 7 days).

## How to run on the VPS
1. Dry run first (report only):
   `POST /api/admin/consolidate-duplicate-comments?user_id=1&dry_run=true` with header `X-Admin-Secret: <ADMIN_SECRET>`
2. Check the task result / logs for "would delete N extra comment(s)".
3. Real delete: same call with `dry_run=false`.

## Notes
- This is a durable safeguard companion to #293 (which prevents *new* duplicates). This PR cleans up the *existing* ones.
- Depends on there being a working authenticated LinkedIn session for the user (tied to the open login blocker). If login is blocked, the task returns the failure cleanly without deleting.
- Tests: helper (dry-run, delete-to-one, missing-menu stop), task (no-dupes, skip-non-url, dry-run vs real, login failure), admin endpoint (auth, dry-run default, real-delete params). 36 pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)