### PR TITLE
feat(engagement): weekly profile synthesis as the voice source for generation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ tests/
 ├── unit/          Fast tests — mock all I/O
 ├── integration/   Require MySQL + Redis service containers
 └── e2e/           Require selenium/standalone-chrome
-compose/local/database/migrations/  Flyway migrations (through V47)
+compose/local/database/migrations/  Flyway migrations (through V48)
 .litellm/
 ├── config.yaml    LiteLLM model aliases and routing config
 └── complexity_router.py  Pre-call hook for lem-router model
@@ -188,7 +188,7 @@ Before merging any PR, all of the following must pass:
 - `linkedin-preview` service (external) was removed — preview is now the native `LinkedInPostPreview.tsx` component.
 - **LinkedIn SDUI:** the old `urn:`, `feed-shared-*`, and `comments-comment-*` DOM anchors are gone. Prefer `data-testid` / `aria-label` selectors via `find_first`/`click_first`. The comment composer has NO `<form>` — "submit" means clicking the Comment/Post button next to the composer (`_composer_submitted`), and the comment overflow "…" menu is hover-hidden.
 - **Emoji in Selenium:** ChromeDriver `send_keys` throws on non-BMP emoji — strip them before typing with `_strip_non_bmp()`.
-- **ENUM columns:** `logs.action_type` (and other status columns) are MySQL ENUMs. Adding a new value requires a migration — e.g. V37 added `'followup'` to `logs.action_type`. Migrations live in `compose/local/database/migrations/` and currently run through **V47** (V46 added the `commented_posts` at-most-once claim ledger, V47 added engagement focus_topics/business_goals/personal_goals).
+- **ENUM columns:** `logs.action_type` (and other status columns) are MySQL ENUMs. Adding a new value requires a migration — e.g. V37 added `'followup'` to `logs.action_type`. Migrations live in `compose/local/database/migrations/` and currently run through **V48** (V46 added the `commented_posts` at-most-once claim ledger, V47 added engagement focus_topics/business_goals/personal_goals, V48 added `profiles.synthesis`/`synthesis_generated_at` — the cached durable voice brief).
 - **Proxy auth:** proxies are authenticated by the runtime MV3 extension (`_build_proxy_auth_extension_b64`), not by URL-embedded credentials — MV2 background pages that used to do this are disabled in Chrome 149+.
 
 ## Git Safety & Multi-Agent Concurrency Rules

--- a/compose/local/database/migrations/V48__add_profile_synthesis.sql
+++ b/compose/local/database/migrations/V48__add_profile_synthesis.sql
@@ -1,0 +1,10 @@
+-- Cached, DURABLE voice/expertise synthesis of each scraped profile. The generation prompts used to
+-- inline the ENTIRE profile JSON (profile.model_dump_json()) as the "voice reference" — bloated, and
+-- the root of "LEM drift": the profile's volatile recent_activities made the model talk about
+-- whatever the user is currently building. Instead we distill a small, stable voice brief on a WEEKLY
+-- schedule (auto-refreshed on a fresh scrape) and drop THAT into every generation prompt. `synthesis`
+-- holds the brief text; `synthesis_generated_at` drives the ~7-day staleness selector for the weekly
+-- refresh task.
+ALTER TABLE profiles
+    ADD COLUMN synthesis TEXT NULL AFTER data,
+    ADD COLUMN synthesis_generated_at TIMESTAMP NULL AFTER synthesis;

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -104,6 +104,12 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_sync_groups',
             'schedule': crontab(hour='7', minute='0', day_of_week='monday')  # Refresh joined groups weekly
         },
+        'refresh-profile-syntheses': {
+            'task': 'cqc_lem.app.run_scheduler.auto_refresh_profile_syntheses',
+            # Weekly: regenerate each active user's DURABLE voice synthesis (missing/stale >7d) used as
+            # the voice source for every comment/post — Mondays at 4:30 AM, off-peak.
+            'schedule': crontab(hour='4', minute='30', day_of_week='monday')
+        },
         'group-engagement': {
             'task': 'cqc_lem.app.run_scheduler.auto_group_engagement',
             'schedule': crontab(hour='16', minute='0')  # Daily value-add commenting in enabled groups

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -15,7 +15,8 @@ from celery_once import QueueOnce
 from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_refinement, summarize_recent_activity, \
     ai_check_message_history, post_is_relevant, generate_newsletter_edition, generate_group_post, \
-    generate_thread_reply, generate_seed_comment, choose_post_reaction
+    generate_thread_reply, generate_seed_comment, choose_post_reaction, get_or_create_profile_synthesis, \
+    synthesize_profile
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
@@ -27,7 +28,8 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     claim_post_for_comment, mark_post_commented, mark_post_reacted, release_post_claim, has_commented_post, \
     has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, PostType, \
     get_dm_history_for_profile, get_post_status, get_user_blog_url, get_post_type, get_carousel_slides, \
-    get_dm_template, enqueue_followup, get_due_followups, mark_followup, stop_followups_for_profile
+    get_dm_template, enqueue_followup, get_due_followups, mark_followup, stop_followups_for_profile, \
+    set_profile_synthesis
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
     load_profile_for_user
@@ -791,6 +793,9 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
     max_posts = min(max_posts, remaining_today)
     max_age_min = (prefs.get("max_post_age_hours") or 24) * 60
     min_reactions = prefs.get("min_reactions") or 0
+    # Stable VOICE synthesis (cached weekly, lazily created on first use) — the voice source for every
+    # comment this run, in place of the bloated/volatile full profile JSON.
+    profile_synthesis = get_or_create_profile_synthesis(user_id, my_profile)
     _switch_feed_to_recent(driver, wait)  # surface golden-hour posts; scoring still ranks them
 
     posted, seen, scrolls = 0, set(), 0
@@ -845,7 +850,8 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             # comment per post per user, across the pre-post run, the golden-hour run, and retries.
             if not claim_post_for_comment(user_id, key):
                 continue
-            comment_text = generate_ai_response(content, my_profile, None, prefs=prefs)
+            comment_text = generate_ai_response(content, my_profile, None, prefs=prefs,
+                                                profile_synthesis=profile_synthesis)
             if comment_text:
                 driver.execute_script("arguments[0].scrollIntoView({block:'center'});", card)
                 time.sleep(simulate_reading_time(content) / 2 + simulate_thinking_time())
@@ -1094,7 +1100,8 @@ def auto_seed_comment_on_post(self, user_id: int, post_id: int):
     try:
         driver.get(post_url)
         time.sleep(random.uniform(4, 7))
-        seed = generate_seed_comment(post_message, my_profile, get_engagement_preferences(user_id))
+        seed = generate_seed_comment(post_message, my_profile, get_engagement_preferences(user_id),
+                                     profile_synthesis=get_or_create_profile_synthesis(user_id, my_profile))
         if not seed:
             return "No seed comment generated"
         card = find_first(driver, wait, [(By.CSS_SELECTOR, "div.feed-shared-update-v2"), (By.TAG_NAME, "main")],
@@ -1227,7 +1234,9 @@ def auto_post_to_group(self, user_id: int, group_id: str):
     try:
         driver.get(f"https://www.linkedin.com/groups/{group_id}/")
         time.sleep(random.uniform(4, 7))
-        text = _strip_non_bmp(generate_group_post(my_profile, prefs=get_engagement_preferences(user_id)) or "")
+        text = _strip_non_bmp(generate_group_post(
+            my_profile, prefs=get_engagement_preferences(user_id),
+            profile_synthesis=get_or_create_profile_synthesis(user_id, my_profile)) or "")
         if not text.strip():
             return "No group post generated"
         # Open the group share box, type, and post (best-effort SDUI selectors).
@@ -1343,6 +1352,9 @@ def automate_reply_commenting(self, user_id: int, post_id: int, loop_for_duratio
         # Get the message content of the post
         post_message = get_post_message_from_log_for_user(user_id, post_id)
 
+        # Stable VOICE synthesis reused across every reply in this run (voice source, not the raw JSON).
+        profile_synthesis = get_or_create_profile_synthesis(user_id, my_profile)
+
         if post_url:
             # Navigate to the Post
             if driver.current_url != post_url:
@@ -1408,7 +1420,8 @@ def automate_reply_commenting(self, user_id: int, post_id: int, loop_for_duratio
                 # Thread-builder: reply in a way that ends with a follow-up question so the commenter
                 # replies again — first-hour thread depth is the top 2026 reach signal.
                 response = generate_thread_reply(post_message, comment_text, my_profile,
-                                                 prefs=get_engagement_preferences(user_id))
+                                                 prefs=get_engagement_preferences(user_id),
+                                                 profile_synthesis=profile_synthesis)
                 myprint(f"AI Generated Response to Comment: {response}")
                 if response and _reply_to_comment_inline(driver, wait, comment, response, user_id=user_id):
                     insert_new_log(user_id=user_id, post_id=post_id, action_type=LogActionType.REPLY,
@@ -1718,7 +1731,8 @@ def automate_appreciation_dms_for_user(self, user_id: int, loop_for_duration: in
     return result
 
 
-def generate_and_post_comment(driver, wait, post_link, my_profile: LinkedInProfile) -> bool:
+def generate_and_post_comment(driver, wait, post_link, my_profile: LinkedInProfile,
+                              profile_synthesis: str = None) -> bool:
     if post_link != driver.current_url:
         # Switch to post url
         driver.get(post_link)
@@ -1768,7 +1782,7 @@ def generate_and_post_comment(driver, wait, post_link, my_profile: LinkedInProfi
     time.sleep(thinking_time)
 
     # Generate AI response
-    comment_text = generate_ai_response(content, my_profile, img_url)
+    comment_text = generate_ai_response(content, my_profile, img_url, profile_synthesis=profile_synthesis)
 
     myprint(f"AI Generated Comment: {comment_text}")
     # Simulate typing the AI-generated comment
@@ -1998,13 +2012,16 @@ def engage_with_profile_viewer(self, user_id: int, viewer_url, viewer_name):
                     # DONT: Shuffle the activities (they are already in order of latest to oldest)
                     # random.shuffle(recent_activities)
                     able_to_comment = False
+                    # Our own stable voice synthesis (the comment is written in the USER's voice).
+                    profile_synthesis = get_or_create_profile_synthesis(user_id, my_profile)
 
                     # Filter list to activities I haven't commented on
                     for activity in recent_activities:
                         link = str(activity.link)
 
                         # Leave comment on that activity
-                        able_to_comment = generate_and_post_comment(driver, wait, link, my_profile)
+                        able_to_comment = generate_and_post_comment(driver, wait, link, my_profile,
+                                                                    profile_synthesis=profile_synthesis)
                         if able_to_comment:
                             break  # Only comment/interact with one
 
@@ -2310,6 +2327,16 @@ def update_stale_profile(self, user_id: int):
         log_error("Error while updating stale profile", exc=e, user_id=user_id, task_name="update_stale_profile")
         return f"Failed to update profile: {e}"
     quit_gracefully(driver)
+    # A fresh scrape should yield a fresh voice synthesis — regenerate it now so the cached brief never
+    # lags the profile it was distilled from. Best-effort: never fail the refresh over this.
+    if my_profile is not None:
+        try:
+            synthesis = synthesize_profile(my_profile)
+            if synthesis:
+                set_profile_synthesis(user_id, synthesis)
+        except Exception as e:
+            log_warning("Could not refresh profile synthesis after scrape", exc=e, user_id=user_id,
+                        task_name="update_stale_profile")
     return "Profile Updated Successfully"
 
 

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -16,7 +16,8 @@ from cqc_lem.utilities.ai.ai_helper import get_blog_summary_post_from_ai, get_we
     get_flux_image_prompt_from_ai, generate_flux1_image_from_prompt, get_runway_ml_video_prompt_from_ai, \
     create_runway_video, get_ai_linked_post_refinement, optimize_post_hook
 from cqc_lem.utilities.ai.ai_helper import get_thought_leadership_post_from_ai, \
-    get_industry_news_post_from_ai, get_personal_story_post_from_ai, generate_engagement_prompt_post
+    get_industry_news_post_from_ai, get_personal_story_post_from_ai, generate_engagement_prompt_post, \
+    get_or_create_profile_synthesis
 from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, update_db_post_content, \
     get_planned_posts_for_current_week, get_last_planned_post_date_for_user, get_user_password_pair_by_id, \
     get_user_blog_url, get_user_sitemap_url, get_active_user_ids, get_planned_posts_for_next_week, PostStatus, \
@@ -534,10 +535,16 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
     # whatever the user is currently building.
     prefs = get_engagement_preferences(user_id)
 
+    # Stable VOICE synthesis (cached weekly; lazily generated on first use) replaces the bloated full
+    # profile JSON as the voice/credibility source — keeps posts in the user's voice without dragging
+    # in their volatile recent activity / current projects (LEM-drift).
+    profile_synthesis = get_or_create_profile_synthesis(user_id, user_profile)
+
     # Generate the post based on the selected type
     myprint(f"Creating text post of type: {post_type} for stage: {stage}")
     if post_type == "thought_leadership":
-        final_content = get_thought_leadership_post_from_ai(user_profile, stage, prefs=prefs)
+        final_content = get_thought_leadership_post_from_ai(user_profile, stage, prefs=prefs,
+                                                            profile_synthesis=profile_synthesis)
     elif post_type == "blog_summary":
         # Get the users blog url
         user_main_blog_url = get_user_blog_url(user_id)
@@ -545,7 +552,7 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
         if blog_post_url and blog_post_content:
             process_selected_post(blog_post_url, blog_post_content)
             final_content = get_blog_summary_post_from_ai(blog_post_url, blog_post_content, user_profile, stage,
-                                                          prefs=prefs)
+                                                          prefs=prefs, profile_synthesis=profile_synthesis)
         else:
             myprint("No blog post found for this user. Generating another post type")
             # Chose another random post type that is not "blog_summary"
@@ -556,7 +563,8 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
         # Get the users sitemap url
         sitemap_url = get_user_sitemap_url(user_id)
         if sitemap_url:
-            content = generate_website_content_post(sitemap_url, user_profile, stage, prefs=prefs)
+            content = generate_website_content_post(sitemap_url, user_profile, stage, prefs=prefs,
+                                                    profile_synthesis=profile_synthesis)
             if content:
                 final_content = content
             else:
@@ -572,11 +580,14 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
             post_type = random.choice(post_types)
             final_content = create_text_post(user_id, stage, post_type, user_profile, refine_final_post=False)
     elif post_type == "industry_news":
-        final_content = get_industry_news_post_from_ai(user_profile, stage, prefs=prefs)
+        final_content = get_industry_news_post_from_ai(user_profile, stage, prefs=prefs,
+                                                       profile_synthesis=profile_synthesis)
     elif post_type == "personal_story":
-        final_content = get_personal_story_post_from_ai(user_profile, stage, prefs=prefs)
+        final_content = get_personal_story_post_from_ai(user_profile, stage, prefs=prefs,
+                                                        profile_synthesis=profile_synthesis)
     else:
-        final_content = generate_engagement_prompt_post(user_profile, stage, prefs=prefs)
+        final_content = generate_engagement_prompt_post(user_profile, stage, prefs=prefs,
+                                                        profile_synthesis=profile_synthesis)
 
     if refine_final_post:
         final_content = get_ai_linked_post_refinement(final_content)
@@ -738,7 +749,8 @@ def process_selected_post(url, content):
         myprint("Selected Post Content: None")
 
 
-def generate_website_content_post(sitemap_url, linked_user_profile, stage: str, prefs: dict = None):
+def generate_website_content_post(sitemap_url, linked_user_profile, stage: str, prefs: dict = None,
+                                  profile_synthesis: str = None):
     """
     Generate a post based on content found on the user's website using their sitemap url catered to readers in the desired buyers journey stage.
     Scrapes or retrieves key points from the website's sitemap.
@@ -768,7 +780,7 @@ def generate_website_content_post(sitemap_url, linked_user_profile, stage: str, 
         if content is not None:
             # 4. Generate a social media post based on the extracted content
             social_media_post = get_website_content_post_from_ai(content, selected_url, linked_user_profile, stage,
-                                                                 prefs=prefs)
+                                                                 prefs=prefs, profile_synthesis=profile_synthesis)
             return social_media_post
         else:
             myprint("No content extracted from the selected URL.")

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -239,6 +239,35 @@ def auto_publish_scheduled_editions():
 
 
 @shared_task.task
+def auto_refresh_profile_syntheses():
+    """Weekly: (re)generate the cached, DURABLE voice synthesis for each active user whose synthesis is
+    missing or stale (>7 days). The synthesis replaces the bloated full profile JSON as the voice
+    source in every comment/post prompt; refreshing it on a slow cadence keeps the voice stable while
+    still tracking real profile changes. No Selenium — works off each user's cached profile JSON."""
+    from cqc_lem.utilities.ai.ai_helper import synthesize_profile
+    from cqc_lem.utilities.db import get_user_ids_needing_profile_synthesis, set_profile_synthesis
+    from cqc_lem.utilities.linkedin.helper import load_profile_for_user
+    active = set(get_active_user_ids())
+    stale = [uid for uid in get_user_ids_needing_profile_synthesis(stale_days=7) if uid in active]
+    refreshed = 0
+    for uid in stale:
+        profile = load_profile_for_user(uid)
+        if profile is None:
+            continue
+        try:
+            synthesis = synthesize_profile(profile)
+        except Exception as e:
+            log_warning("Weekly profile synthesis failed", exc=e, user_id=uid,
+                        task_name="auto_refresh_profile_syntheses")
+            continue
+        if synthesis and set_profile_synthesis(uid, synthesis):
+            refreshed += 1
+    log_info(f"Refreshed {refreshed}/{len(stale)} stale profile synthesis(es)",
+             task_name="auto_refresh_profile_syntheses")
+    return f"Refreshed {refreshed}/{len(stale)} profile synthesis(es)"
+
+
+@shared_task.task
 def auto_sync_groups():
     """Refresh each active user's joined-groups list (new groups default to enabled)."""
     from cqc_lem.app.run_automation import auto_sync_user_groups

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -1,6 +1,7 @@
 import os
 import random
 import time
+from datetime import datetime
 
 import openai
 import replicate
@@ -198,8 +199,118 @@ def _alignment_directive(prefs: dict = None) -> str:
     return "\n\nContent alignment rules:\n- " + _NO_SELF_PROMO_GUARDRAIL + _focus_directive(prefs)
 
 
+# Volatile profile fields deliberately EXCLUDED from the synthesis INPUT. `recent_activities` is the
+# root of "LEM drift" — it is dominated by whatever the user is building / posting THIS week, which
+# the model otherwise pulls in as subject matter. The synthesis is about who the user IS and how they
+# SOUND (durable voice + expertise), never their current projects. password/email are PII with no
+# voice value.
+_SYNTHESIS_EXCLUDE_FIELDS = {"recent_activities", "password", "email"}
+
+
+def synthesize_profile(profile: "LinkedInProfile") -> str:
+    """Distill a LinkedInProfile into a SHORT, DURABLE voice/expertise brief used as the VOICE, TONE
+    and CREDIBILITY reference for that user's future comments and posts — dropped into every
+    generation prompt in place of the bloated full profile JSON.
+
+    It captures who they are (role, industry/domain), core expertise, the audience they serve, their
+    tone/voice characteristics, and credibility points/values. It DELIBERATELY EXCLUDES the volatile
+    "currently building X / working on Y" noise in `recent_activities` (stripped from the input, and
+    hard-excluded again in the prompt) so nothing here can reintroduce project/self-promo drift."""
+    import json as _json
+    durable = profile.model_dump(mode="json", exclude=_SYNTHESIS_EXCLUDE_FIELDS)
+    durable_json = _json.dumps(durable, default=str)
+
+    # Best-effort durable enrichment (reuses the existing industry helper). Never fatal.
+    industries = ""
+    try:
+        industries = get_industries_of_profile_from_ai(profile) or ""
+    except Exception as exc:
+        log_warning("Profile synthesis: industry enrichment failed", exc=exc)
+
+    system_prompt = {
+        "role": "system",
+        "content": (
+            "You distill a LinkedIn profile into a SHORT, DURABLE voice-and-expertise brief. This brief "
+            "will be used ONLY as a VOICE, TONE, and CREDIBILITY reference when writing the person's "
+            "future LinkedIn comments and posts — capture who they ARE and how they SOUND, never what "
+            "they happen to be doing this week.\n\n"
+            "Produce a few tight bullet lines covering:\n"
+            "- Who they are: role, industry/domain, seniority\n"
+            "- Core expertise: the topics they can speak to with genuine authority\n"
+            "- Audience they serve or want to reach\n"
+            "- Tone & voice characteristics: how they phrase things (e.g. plain-spoken, data-driven, warm)\n"
+            "- Credibility points and values: durable proof, not news\n\n"
+            "HARD EXCLUSIONS: Do NOT name, describe, or allude to any specific project, product, app, "
+            "tool, platform, or 'currently building / working on / launching' activity. Distill only "
+            "DURABLE themes. " + _NO_SELF_PROMO_GUARDRAIL + " Keep it under ~150 words. Output ONLY the "
+            "brief as plain bullet lines — no preamble, no headings, no self-promotion."
+        ),
+    }
+    user_prompt = {
+        "role": "user",
+        "content": ("Durable profile data (volatile recent activity has already been removed):\n"
+                    + durable_json
+                    + (f"\n\nLikely industries: {industries}" if industries else "")),
+    }
+    response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt], temperature=0.3)
+    content = response.choices[0].message.content
+    return content.strip() if content is not None else ""
+
+
+def _voice_reference(profile: "LinkedInProfile", profile_synthesis: str = None) -> str:
+    """The VOICE/TONE/credibility reference string dropped into a generation prompt. Prefers the
+    compact, stable synthesis; falls back to the guarded full profile JSON only when no synthesis was
+    supplied (keeps behavior working before the first weekly refresh has run)."""
+    if profile_synthesis and profile_synthesis.strip():
+        return profile_synthesis.strip()
+    return profile.model_dump_json()
+
+
+def get_or_create_profile_synthesis(user_id: int, profile: "LinkedInProfile" = None,
+                                    max_age_days: int = 7) -> "str | None":
+    """Return the user's cached profile synthesis, lazily generating + persisting it when missing or
+    stale so generation never breaks before the first weekly refresh. Returns the cached value (even
+    if stale) or None when there is nothing to synthesize from — callers pass the result straight to
+    the generators, which fall back to the guarded full JSON when it is None."""
+    from cqc_lem.utilities.db import get_profile_synthesis, set_profile_synthesis
+    cached_text = None
+    try:
+        row = get_profile_synthesis(user_id)
+    except Exception as exc:
+        log_warning("Could not read cached profile synthesis", exc=exc, user_id=user_id)
+        row = None
+    if row:
+        cached_text, generated_at = row
+        if cached_text and generated_at is not None:
+            try:
+                age_days = (datetime.now() - generated_at).days
+            except TypeError:
+                age_days = None
+            if age_days is not None and age_days < max_age_days:
+                return cached_text
+
+    if profile is None:
+        from cqc_lem.utilities.linkedin.helper import load_profile_for_user
+        profile = load_profile_for_user(user_id)
+    if profile is None:
+        return cached_text
+
+    try:
+        text = synthesize_profile(profile)
+    except Exception as exc:
+        log_warning("Profile synthesis generation failed; using cached", exc=exc, user_id=user_id)
+        return cached_text
+    if not text:
+        return cached_text
+    try:
+        set_profile_synthesis(user_id, text)
+    except Exception as exc:
+        log_warning("Could not persist profile synthesis", exc=exc, user_id=user_id)
+    return text
+
+
 def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=None, post_comment: str = None,
-                         prefs: dict = None):
+                         prefs: dict = None, profile_synthesis: str = None):
     image_attached = "(image attached)" if post_img_url else ""
     _no_hashtags = "" if (prefs and prefs.get("use_hashtags")) else " without using any hashtags"
     user_comment = f"\n\nRespond to this Comment Directly: <comment>{post_comment}</comment>\n\nYou are responding as the author of the LinkedIn Content. Keep your response short and sweet{_no_hashtags}.\n\n" if post_comment else ""
@@ -207,7 +318,7 @@ def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=No
     prompt = (f"""Please write a comment in response to the LinkedIn Content below, in the voice of the following LinkedIn User.
 
                 Voice reference — the user's profile, provided for TONE and CREDIBILITY ONLY. Do NOT make the
-                comment about the user, their company, or anything they are building:\n\n{profile.model_dump_json()}\n\n
+                comment about the user, their company, or anything they are building:\n\n{_voice_reference(profile, profile_synthesis)}\n\n
 
                 The SUBJECT of your comment is this LinkedIn Content{image_attached} — engage with what it actually says:
                 <content>'{post_content}'</content>
@@ -421,7 +532,8 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
     return {"title": title, "subtitle": (topic or title).strip()[:150], "body": body}
 
 
-def generate_group_post(profile: "LinkedInProfile", group_name: str = None, prefs: dict = None) -> "str | None":
+def generate_group_post(profile: "LinkedInProfile", group_name: str = None, prefs: dict = None,
+                        profile_synthesis: str = None) -> "str | None":
     """A short, value-add post for a LinkedIn Group — a genuine insight or open question for that
     community, NEVER promotional (groups penalize/moderate self-promo). Ends inviting discussion."""
     ctx = f"for the LinkedIn group \"{group_name}\"" if group_name else "for a professional LinkedIn group"
@@ -433,14 +545,15 @@ def generate_group_post(profile: "LinkedInProfile", group_name: str = None, pref
         voice, and end by inviting members to weigh in. """ + _NO_SELF_PROMO_GUARDRAIL + """ Output ONLY the post text.""",
     }
     user_prompt = {"role": "user",
-                   "content": f"Author profile:\n{profile.model_dump_json()}\n{_focus_directive(prefs)}{_style_directive(prefs)}"}
+                   "content": f"Author profile:\n{_voice_reference(profile, profile_synthesis)}\n{_focus_directive(prefs)}{_style_directive(prefs)}"}
     response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt],
                          temperature=round(random.uniform(0.5, 0.7), 2))
     content = response.choices[0].message.content
     return content.strip() if content is not None else None
 
 
-def generate_seed_comment(post_content, profile: "LinkedInProfile", prefs: dict = None):
+def generate_seed_comment(post_content, profile: "LinkedInProfile", prefs: dict = None,
+                          profile_synthesis: str = None):
     """The author's own FIRST comment on their post, to seed a discussion thread (threads drive
     reach). The model picks whatever fits the post — an open question to the audience OR a short
     behind-the-scenes insight/context the post didn't cover — and always invites replies. No
@@ -458,7 +571,7 @@ def generate_seed_comment(post_content, profile: "LinkedInProfile", prefs: dict 
     }
     user_prompt = {
         "role": "user",
-        "content": f"My LinkedIn profile:\n{profile.model_dump_json()}\n\n"
+        "content": f"My LinkedIn profile:\n{_voice_reference(profile, profile_synthesis)}\n\n"
                    f"My post:\n<content>{post_content}</content>\n{_intention_directive(prefs)}{_style_directive(prefs)}",
     }
     response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt],
@@ -468,7 +581,7 @@ def generate_seed_comment(post_content, profile: "LinkedInProfile", prefs: dict 
 
 
 def generate_thread_reply(post_content: str, comment_text: str, profile: "LinkedInProfile",
-                          prefs: dict = None) -> "str | None":
+                          prefs: dict = None, profile_synthesis: str = None) -> "str | None":
     """Reply to a commenter on the AUTHOR's own post so the thread KEEPS GOING: acknowledge their
     specific point, add one useful thought, and END with a genuine, easy follow-up question directed
     back to them. First-hour thread depth is the top 2026 reach signal. Short."""
@@ -481,7 +594,7 @@ def generate_thread_reply(post_content: str, comment_text: str, profile: "Linked
         + _NO_SELF_PROMO_GUARDRAIL,
     }
     user_prompt = {"role": "user", "content":
-        f"Author profile:\n{profile.model_dump_json()}\n\nMy post:\n{post_content}\n\n"
+        f"Author profile:\n{_voice_reference(profile, profile_synthesis)}\n\nMy post:\n{post_content}\n\n"
         f"Their comment:\n{comment_text}\n{_intention_directive(prefs)}{_style_directive(prefs)}"}
     response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt],
                          temperature=round(random.uniform(0.5, 0.7), 2))
@@ -819,11 +932,12 @@ def get_ai_message_refinement(original_message: str, character_limit: int = 300)
     return comment
 
 
-def get_video_content_from_ai(linked_user_profile: LinkedInProfile, buyer_stage: str):
+def get_video_content_from_ai(linked_user_profile: LinkedInProfile, buyer_stage: str,
+                              profile_synthesis: str = None):
     """Generate video content based on the LinkedIn user profile and buyer stage."""
 
-    # Use json to output to string
-    linked_in_profile_json = linked_user_profile.model_dump_json()
+    # Voice/credibility reference — prefer the stable synthesis, else the guarded full JSON.
+    linked_in_profile_json = _voice_reference(linked_user_profile, profile_synthesis)
 
     prompts = [f"""Create a short, high-impact video script tailored for LinkedIn to introduce and build awareness about the expertise or unique value of the profile represented by the following LinkedIn Profile. 
                 This video should appeal to users in the {buyer_stage} buyer stage, aiming to quickly capture attention with a clear, memorable introduction. 
@@ -1000,7 +1114,7 @@ def create_video_from_prompt(prompt: str):
 
 
 def get_thought_leadership_post_from_ai(linked_user_profile: LinkedInProfile, buyer_stage: str,
-                                        prefs: dict = None):
+                                        prefs: dict = None, profile_synthesis: str = None):
     """
         Generate a thought leadership post based on user's expertise and industry.
         Uses the user's profile (e.g., job title, industry) and intended buyer_stage to form an insightful post.
@@ -1014,7 +1128,7 @@ def get_thought_leadership_post_from_ai(linked_user_profile: LinkedInProfile, bu
         f'Generating Thought Leadership AI Response for {buyer_stage} buyer stage about the {industry} industry.\n\nAnalysis: {analysis} ')
 
     # Use json to output to string
-    linked_in_profile_json = linked_user_profile.model_dump_json()
+    linked_in_profile_json = _voice_reference(linked_user_profile, profile_synthesis)
 
     prompt = f"""Please create a thought leadership post for me based on my LinkedIn Profile information and the current trends in the {industry} industry.
 
@@ -1165,7 +1279,7 @@ def get_industry_trend_analysis_based_on_user_profile(linked_in_profile: LinkedI
 
 
 def get_industry_news_post_from_ai(linked_user_profile: LinkedInProfile, buyer_stage: str,
-                                   prefs: dict = None):
+                                   prefs: dict = None, profile_synthesis: str = None):
     """
        Generate a post sharing industry news based on the LinkedIn user's profile and the intended buyer stage, along with the user's commentary.
     """
@@ -1175,7 +1289,7 @@ def get_industry_news_post_from_ai(linked_user_profile: LinkedInProfile, buyer_s
     analysis = trends.get("analysis", "")
 
     # Use json to output to string
-    linked_in_profile_json = linked_user_profile.model_dump_json()
+    linked_in_profile_json = _voice_reference(linked_user_profile, profile_synthesis)
 
     prompt = f"""Please create a post sharing recent {industry} industry news based on my LinkedIn Profile information provided below. 
     Tailor the post to readers in the {buyer_stage} buyer stage of their journey and include my own commentary to add perspective.
@@ -1345,7 +1459,7 @@ def get_industry_trend_from_ai(industry: str, articles: list):
 
 
 def get_personal_story_post_from_ai(linked_user_profile: LinkedInProfile, stage: str,
-                                    prefs: dict = None):
+                                    prefs: dict = None, profile_synthesis: str = None):
     """
     Generate a post sharing a personal or professional story, based on the user's profile.
     """
@@ -1353,7 +1467,7 @@ def get_personal_story_post_from_ai(linked_user_profile: LinkedInProfile, stage:
     # Example content: "Reflecting on my journey as a [job title], I’ve learned that..."
 
     # Use json to output to string
-    linked_in_profile_json = linked_user_profile.model_dump_json()
+    linked_in_profile_json = _voice_reference(linked_user_profile, profile_synthesis)
 
     prompt = f"""Please create a story-based post for me, reflecting on a personal or professional milestone, achievement, or challenge, using the information from my LinkedIn Profile provided below. 
     Tailor the story to connect with readers in the {stage} buyer stage of their journey. 
@@ -1454,7 +1568,7 @@ def get_personal_story_post_from_ai(linked_user_profile: LinkedInProfile, stage:
 
 
 def generate_engagement_prompt_post(linked_user_profile: LinkedInProfile, stage: str,
-                                    prefs: dict = None):
+                                    prefs: dict = None, profile_synthesis: str = None):
     """
     Generate a question or prompt that encourages engagement from followers.
     """
@@ -1462,7 +1576,7 @@ def generate_engagement_prompt_post(linked_user_profile: LinkedInProfile, stage:
     # Example content: "As a [job title], I’m curious to hear how others are handling [challenge]..."
 
     # Use json to output to string
-    linked_in_profile_json = linked_user_profile.model_dump_json()
+    linked_in_profile_json = _voice_reference(linked_user_profile, profile_synthesis)
 
     prompt = f"""Please generate a question or prompt to encourage engagement from my followers based on the information in my LinkedIn Profile below and related it to current industry trends. 
     Tailor the question to resonate with readers in the {stage} buyer stage of their journey.
@@ -1559,14 +1673,14 @@ def generate_engagement_prompt_post(linked_user_profile: LinkedInProfile, stage:
 
 
 def get_blog_summary_post_from_ai(blog_post_url: str, blog_post_content: str, linked_user_profile: LinkedInProfile,
-                                  stage: str, prefs: dict = None):
+                                  stage: str, prefs: dict = None, profile_synthesis: str = None):
     """
     Generate a summary post for a blog article using the provide post url and post content from user to create interest using relevance to the provided LinkedIn Profile.
     """
     # create a LinkedIn-friendly summary
 
     # Use json to output to string
-    linked_in_profile_json = linked_user_profile.model_dump_json()
+    linked_in_profile_json = _voice_reference(linked_user_profile, profile_synthesis)
 
     prompt = f"""Please generate a LinkedIn-friendly summary post for the blog article provided below. 
     Tailor the post to appeal to readers in the {stage} buyer stage of their journey, using my LinkedIn profile details to make the summary relevant to my role and industry.
@@ -1661,14 +1775,14 @@ def get_blog_summary_post_from_ai(blog_post_url: str, blog_post_content: str, li
 
 
 def get_website_content_post_from_ai(content: str, url: str, linked_user_profile: LinkedInProfile, stage: str,
-                                     prefs: dict = None):
+                                     prefs: dict = None, profile_synthesis: str = None):
     """
         Generate a summary post for a blog article using the provide post url and post content from user to create interest using relevance to the provided LinkedIn Profile.
         """
     # create a LinkedIn-friendly summary
 
     # Use json to output to string
-    linked_in_profile_json = linked_user_profile.model_dump_json()
+    linked_in_profile_json = _voice_reference(linked_user_profile, profile_synthesis)
 
     prompt = f"""Please generate a LinkedIn-friendly summary post for the website content provided below. 
         Tailor the post to appeal to readers in the {stage} buyer stage of their journey, using my LinkedIn profile details to make the summary relevant to my role and industry.

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -281,12 +281,10 @@ def get_or_create_profile_synthesis(user_id: int, profile: "LinkedInProfile" = N
         row = None
     if row:
         cached_text, generated_at = row
-        if cached_text and generated_at is not None:
-            try:
-                age_days = (datetime.now() - generated_at).days
-            except TypeError:
-                age_days = None
-            if age_days is not None and age_days < max_age_days:
+        # Only trust a real datetime for the staleness check — a non-datetime (bad/legacy data, or a
+        # mocked row) must fall through to regeneration rather than crash on the comparison.
+        if cached_text and isinstance(generated_at, datetime):
+            if (datetime.now() - generated_at).days < max_age_days:
                 return cached_text
 
     if profile is None:

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1046,6 +1046,69 @@ def get_linked_in_profile_by_user_id(user_id: int, updated_less_than_days_ago: i
     return profile_data
 
 
+def get_profile_synthesis(user_id: int) -> Optional[tuple]:
+    """Return the user's cached (synthesis_text, synthesis_generated_at) or None when there is no
+    profile row / no synthesis yet. Kept separate from the profile-JSON getters so the small, stable
+    voice brief can be read cheaply on every generation call without pulling the full profile blob."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT synthesis, synthesis_generated_at FROM profiles WHERE user_id = %s", (user_id,))
+        row = cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get profile synthesis for user_id={user_id} | Error: {err}")
+        row = None
+    finally:
+        cursor.close()
+        connection.close()
+
+    if not row or row[0] is None:
+        return None
+    return row[0], row[1]
+
+
+def set_profile_synthesis(user_id: int, synthesis: str) -> bool:
+    """Persist a freshly generated voice synthesis and stamp synthesis_generated_at = NOW() (drives
+    the weekly staleness selector). No-op-safe: returns False if the profile row doesn't exist yet."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE profiles SET synthesis = %s, synthesis_generated_at = NOW() WHERE user_id = %s",
+            (synthesis, user_id))
+        connection.commit()
+        success = cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not set profile synthesis for user_id={user_id} | Error: {err}")
+        success = False
+    finally:
+        cursor.close()
+        connection.close()
+    return success
+
+
+def get_user_ids_needing_profile_synthesis(stale_days: int = 7) -> list:
+    """User IDs whose cached profile synthesis is MISSING or older than `stale_days` — the work list
+    for the weekly refresh task. Only rows that actually have a profile (user_id NOT NULL) qualify."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT user_id FROM profiles WHERE user_id IS NOT NULL AND ("
+            "synthesis IS NULL OR synthesis_generated_at IS NULL "
+            "OR synthesis_generated_at < NOW() - INTERVAL %s DAY)",
+            (stale_days,))
+        rows = cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get user_ids needing profile synthesis | Error: {err}")
+        rows = []
+    finally:
+        cursor.close()
+        connection.close()
+    return [row[0] for row in rows]
+
+
 def remove_linked_in_profile_by_user_id(user_id: int):
     connection = get_db_connection()
     cursor = connection.cursor()

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -816,3 +816,30 @@ class TestAutoInviteToCompanyPages:
             result = auto_invite_to_company_pages()
         mock_task.apply_async.assert_not_called()
         assert "No active users with a company page" in result
+
+
+class TestAutoRefreshProfileSyntheses:
+    def test_synthesizes_only_stale_active_users(self):
+        # user 3 is stale but NOT active -> must be skipped; user 1 stale+active -> processed.
+        with patch(f"{_MOD}.get_active_user_ids", return_value=[1, 2]), \
+             patch("cqc_lem.utilities.db.get_user_ids_needing_profile_synthesis", return_value=[1, 3]), \
+             patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()), \
+             patch("cqc_lem.utilities.ai.ai_helper.synthesize_profile", return_value="brief") as syn, \
+             patch("cqc_lem.utilities.db.set_profile_synthesis", return_value=True) as setter:
+            from cqc_lem.app.run_scheduler import auto_refresh_profile_syntheses
+            result = auto_refresh_profile_syntheses()
+        syn.assert_called_once()
+        setter.assert_called_once_with(1, "brief")
+        assert "1/1" in result
+
+    def test_skips_users_without_cached_profile(self):
+        with patch(f"{_MOD}.get_active_user_ids", return_value=[1]), \
+             patch("cqc_lem.utilities.db.get_user_ids_needing_profile_synthesis", return_value=[1]), \
+             patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=None), \
+             patch("cqc_lem.utilities.ai.ai_helper.synthesize_profile") as syn, \
+             patch("cqc_lem.utilities.db.set_profile_synthesis") as setter:
+            from cqc_lem.app.run_scheduler import auto_refresh_profile_syntheses
+            result = auto_refresh_profile_syntheses()
+        syn.assert_not_called()
+        setter.assert_not_called()
+        assert "0/1" in result

--- a/tests/unit/utilities/ai/test_profile_synthesis.py
+++ b/tests/unit/utilities/ai/test_profile_synthesis.py
@@ -1,0 +1,158 @@
+"""Unit tests for the DURABLE profile synthesis: the generator that distills a profile into a stable
+voice brief (excluding volatile recent-activity/project noise), the lazy get-or-create cache helper,
+and the generation functions using the synthesis in place of the full profile JSON."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_AI = "cqc_lem.utilities.ai.ai_helper"
+_DB = "cqc_lem.utilities.db"
+
+
+def _resp(text):
+    r = MagicMock()
+    r.choices = [MagicMock(message=MagicMock(content=text))]
+    return r
+
+
+def _mock_profile():
+    """MagicMock profile whose full-JSON dump is a distinctive sentinel so tests can assert the raw
+    JSON is NOT smuggled into a prompt when a synthesis is supplied."""
+    p = MagicMock()
+    p.model_dump_json.return_value = '{"RAW_PROFILE_JSON_SENTINEL": true}'
+    return p
+
+
+class TestSynthesizeProfile:
+    def test_excludes_recent_activity_project_noise(self):
+        from cqc_lem.utilities.ai import ai_helper
+        from cqc_lem.utilities.linkedin.profile import LinkedInProfile, LinkedInActivity
+        profile = LinkedInProfile(
+            full_name="Jane Doe", job_title="COO", company_name="Acme Logistics",
+            recent_activities=[LinkedInActivity(text="Currently building SECRETPROJECTX right now")])
+        with patch(f"{_AI}.get_industries_of_profile_from_ai", return_value="Logistics"), \
+             patch(f"{_AI}._call_llm", return_value=_resp("- COO in logistics\n- plain-spoken")) as m:
+            out = ai_helper.synthesize_profile(profile)
+        assert "COO in logistics" in out
+        kwargs = m.call_args.kwargs
+        assert kwargs["model"] == "lem-medium"          # balanced tier
+        system = kwargs["messages"][0]["content"]
+        user = kwargs["messages"][1]["content"]
+        # Volatile "currently building" project noise is stripped from the synthesis INPUT entirely.
+        assert "SECRETPROJECTX" not in user and "SECRETPROJECTX" not in system
+        # And the prompt hard-excludes such content + carries the anti-self-promo guardrail.
+        assert "currently building" in system.lower()
+        assert ai_helper._NO_SELF_PROMO_GUARDRAIL in system
+        # Durable industry enrichment is present.
+        assert "Logistics" in user
+
+    def test_returns_empty_on_none_content(self):
+        from cqc_lem.utilities.ai import ai_helper
+        from cqc_lem.utilities.linkedin.profile import LinkedInProfile
+        profile = LinkedInProfile(full_name="Jane Doe")
+        with patch(f"{_AI}.get_industries_of_profile_from_ai", return_value=""), \
+             patch(f"{_AI}._call_llm", return_value=_resp(None)):
+            assert ai_helper.synthesize_profile(profile) == ""
+
+
+class TestGetOrCreateProfileSynthesis:
+    def test_returns_fresh_cache_without_regenerating(self):
+        from datetime import datetime
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_DB}.get_profile_synthesis", return_value=("cached brief", datetime.now())), \
+             patch(f"{_AI}.synthesize_profile") as syn:
+            out = ai_helper.get_or_create_profile_synthesis(1, _mock_profile())
+        assert out == "cached brief"
+        syn.assert_not_called()
+
+    def test_regenerates_when_stale(self):
+        from datetime import datetime, timedelta
+        from cqc_lem.utilities.ai import ai_helper
+        old = datetime.now() - timedelta(days=30)
+        with patch(f"{_DB}.get_profile_synthesis", return_value=("old brief", old)), \
+             patch(f"{_AI}.synthesize_profile", return_value="new brief") as syn, \
+             patch(f"{_DB}.set_profile_synthesis", return_value=True) as setter:
+            out = ai_helper.get_or_create_profile_synthesis(1, _mock_profile())
+        assert out == "new brief"
+        syn.assert_called_once()
+        setter.assert_called_once_with(1, "new brief")
+
+    def test_regenerates_when_missing(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_DB}.get_profile_synthesis", return_value=None), \
+             patch(f"{_AI}.synthesize_profile", return_value="fresh brief") as syn, \
+             patch(f"{_DB}.set_profile_synthesis", return_value=True):
+            out = ai_helper.get_or_create_profile_synthesis(2, _mock_profile())
+        assert out == "fresh brief"
+        syn.assert_called_once()
+
+    def test_falls_back_to_cached_when_synthesis_fails(self):
+        from datetime import datetime, timedelta
+        from cqc_lem.utilities.ai import ai_helper
+        old = datetime.now() - timedelta(days=30)
+        with patch(f"{_DB}.get_profile_synthesis", return_value=("old brief", old)), \
+             patch(f"{_AI}.synthesize_profile", side_effect=RuntimeError("boom")), \
+             patch(f"{_DB}.set_profile_synthesis") as setter:
+            out = ai_helper.get_or_create_profile_synthesis(1, _mock_profile())
+        assert out == "old brief"
+        setter.assert_not_called()
+
+    def test_none_when_no_profile_and_no_cache(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_DB}.get_profile_synthesis", return_value=None), \
+             patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=None), \
+             patch(f"{_AI}.synthesize_profile") as syn:
+            out = ai_helper.get_or_create_profile_synthesis(9, None)
+        assert out is None
+        syn.assert_not_called()
+
+
+class TestGenerationUsesSynthesisNotRawJson:
+    def test_comment_uses_synthesis_and_keeps_guardrail(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("What changed your mind?")) as m:
+            ai_helper.generate_ai_response("A POST ABOUT ROBOTS", _mock_profile(),
+                                           profile_synthesis="STABLE VOICE BRIEF")
+        system = m.call_args.kwargs["messages"][0]["content"]
+        user_text = m.call_args.kwargs["messages"][1]["content"][0]["text"]
+        assert "STABLE VOICE BRIEF" in user_text
+        assert "RAW_PROFILE_JSON_SENTINEL" not in user_text     # raw JSON no longer inlined
+        assert ai_helper._NO_SELF_PROMO_GUARDRAIL in system      # guardrail intact
+
+    def test_comment_falls_back_to_full_json_without_synthesis(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("Hmm?")) as m:
+            ai_helper.generate_ai_response("A POST", _mock_profile())  # no synthesis supplied
+        user_text = m.call_args.kwargs["messages"][1]["content"][0]["text"]
+        # Lazy fallback keeps working before the first weekly refresh: full JSON still used.
+        assert "RAW_PROFILE_JSON_SENTINEL" in user_text
+
+    def test_seed_comment_uses_synthesis(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("Backstory — thoughts?")) as m:
+            ai_helper.generate_seed_comment("my post", _mock_profile(),
+                                            profile_synthesis="STABLE VOICE BRIEF")
+        user_text = m.call_args.kwargs["messages"][1]["content"]
+        assert "STABLE VOICE BRIEF" in user_text and "RAW_PROFILE_JSON_SENTINEL" not in user_text
+
+    def test_thread_reply_uses_synthesis(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("How so?")) as m:
+            ai_helper.generate_thread_reply("my post", "their comment", _mock_profile(),
+                                            profile_synthesis="STABLE VOICE BRIEF")
+        user_text = m.call_args.kwargs["messages"][1]["content"]
+        assert "STABLE VOICE BRIEF" in user_text and "RAW_PROFILE_JSON_SENTINEL" not in user_text
+
+    def test_thought_leadership_post_uses_synthesis(self):
+        from cqc_lem.utilities.ai import ai_helper
+        trends = {"industry": "Logistics", "analysis": "robots everywhere"}
+        with patch(f"{_AI}.get_industry_trend_analysis_based_on_user_profile", return_value=trends), \
+             patch(f"{_AI}._call_llm", return_value=_resp("A viral post")) as m:
+            ai_helper.get_thought_leadership_post_from_ai(_mock_profile(), "awareness",
+                                                          profile_synthesis="STABLE VOICE BRIEF")
+        user_text = m.call_args.kwargs["messages"][1]["content"][0]["text"]
+        assert "STABLE VOICE BRIEF" in user_text
+        assert "RAW_PROFILE_JSON_SENTINEL" not in user_text
+        assert "Content alignment rules" in user_text           # anti-self-promo alignment intact

--- a/tests/unit/utilities/test_db_profile_synthesis.py
+++ b/tests/unit/utilities/test_db_profile_synthesis.py
@@ -1,0 +1,84 @@
+"""Unit tests for the cached profile-synthesis DB helpers (get/set + stale selector)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _mock_conn(fetch_row=None, fetch_all=None, rowcount=1):
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = fetch_row
+    cursor.fetchall.return_value = fetch_all if fetch_all is not None else []
+    cursor.rowcount = rowcount
+    conn.cursor.return_value = cursor
+    return conn, cursor
+
+
+class TestGetProfileSynthesis:
+    def test_returns_none_when_no_row(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_profile_synthesis
+            assert get_profile_synthesis(1) is None
+
+    def test_returns_none_when_synthesis_null(self):
+        conn, _ = _mock_conn(fetch_row=(None, None))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_profile_synthesis
+            assert get_profile_synthesis(1) is None
+
+    def test_returns_text_and_timestamp(self):
+        from datetime import datetime
+        ts = datetime(2026, 7, 1)
+        conn, cursor = _mock_conn(fetch_row=("Durable voice brief", ts))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_profile_synthesis
+            text, generated_at = get_profile_synthesis(42)
+        assert text == "Durable voice brief" and generated_at == ts
+        sql = cursor.execute.call_args[0][0]
+        assert "synthesis" in sql and "synthesis_generated_at" in sql
+        assert cursor.execute.call_args[0][1] == (42,)
+
+
+class TestSetProfileSynthesis:
+    def test_updates_and_stamps_now(self):
+        conn, cursor = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_profile_synthesis
+            assert set_profile_synthesis(7, "brief text") is True
+        sql = cursor.execute.call_args[0][0]
+        params = cursor.execute.call_args[0][1]
+        assert "UPDATE profiles" in sql and "synthesis_generated_at = NOW()" in sql
+        assert params == ("brief text", 7)
+        conn.commit.assert_called_once()
+
+    def test_returns_false_when_no_profile_row(self):
+        conn, _ = _mock_conn(rowcount=0)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_profile_synthesis
+            assert set_profile_synthesis(7, "brief") is False
+
+
+class TestStaleSelector:
+    def test_selects_missing_and_stale_user_ids(self):
+        conn, cursor = _mock_conn(fetch_all=[(1,), (5,), (9,)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_ids_needing_profile_synthesis
+            ids = get_user_ids_needing_profile_synthesis(stale_days=7)
+        assert ids == [1, 5, 9]
+        sql = cursor.execute.call_args[0][0]
+        # Missing OR stale, only rows that actually have a profile.
+        assert "synthesis IS NULL" in sql
+        assert "INTERVAL" in sql and "DAY" in sql
+        assert "user_id IS NOT NULL" in sql
+        assert cursor.execute.call_args[0][1] == (7,)
+
+    def test_empty_when_none_stale(self):
+        conn, _ = _mock_conn(fetch_all=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_ids_needing_profile_synthesis
+            assert get_user_ids_needing_profile_synthesis() == []


### PR DESCRIPTION
The durable version of the LEM-drift fix. Instead of dumping the full profile JSON (whose volatile `recent_activities` drag generated content toward "what I'm currently building"), synthesize a compact, STABLE voice/expertise brief once a week and use that as the voice source for comment and post generation.

**Stacked on #293** (`feature/claude-comment-quality`) — retarget to `main` after #293 merges. Builds strictly on top of the alignment guardrails from #293 (nothing weakened).

## What it does
- **`synthesize_profile(profile)`** (lem-medium) — produces a &lt;150-word durable brief: role/industry, expertise, audience, tone/voice, credibility. The input is pre-stripped (`exclude={recent_activities, password, email}`) so current-project noise never enters the prompt, and it reuses the shared anti-self-promo guardrail plus a hard "no specific project/product/'currently building'" exclusion.
- **Persistence (V48):** `synthesis` + `synthesis_generated_at` columns on `profiles`; `get_/set_profile_synthesis` + `get_user_ids_needing_profile_synthesis(stale_days=7)`.
- **Weekly refresh:** `auto_refresh_profile_syntheses` task (Mon 04:30, off-peak) synthesizes for active users with a missing/stale (&gt;7d) synthesis, reading the cached profile (no Selenium). Also re-synthesizes after a live profile re-scrape (`update_stale_profile`).
- **Wiring:** all user-voice generators (comments, seed, thread reply, group post, and the 6 post generators + video) now take an optional `profile_synthesis` and use it via `_voice_reference()` instead of the raw JSON. Callers fetch it lazily (`get_or_create_profile_synthesis`) so nothing breaks before the first weekly run — falls back to the guarded full JSON if none exists yet.
- `summarize_recent_activity` (other people's activity, for outreach) intentionally left as-is.

## Testing
- New: `test_profile_synthesis.py` (excludes project noise, asserts lem-medium + guardrail, cache fresh/stale/missing/failure paths, generation uses synthesis with raw-JSON absent + guardrail present, and the no-synthesis fallback still inlines JSON), `test_db_profile_synthesis.py`, and a weekly-task test (only stale AND active users; skips users with no cached profile).
- Full `tests/unit`: **1374 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)