### PR TITLE
feat(newsletter): topic-planning phase + synthesis alignment + Re-generate w/ guidance

### DIFF
--- a/compose/local/database/migrations/V49__add_newsletter_edition_subject.sql
+++ b/compose/local/database/migrations/V49__add_newsletter_edition_subject.sql
@@ -1,0 +1,8 @@
+-- Persist the planned SUBJECT/angle of each newsletter edition. The draft queue used to generate
+-- every edition INDEPENDENTLY from the newsletter's single `topic` description, producing near
+-- duplicate editions ("Harness/Harnessing/Mastering AI for LinkedIn Growth ..."). We now PLAN a
+-- sequence of distinct subjects up front; storing the chosen subject per edition lets the planner
+-- read the history of prior editions (published, queued, AND recently skipped) and keep every new
+-- edition unique + coherent. Nullable so existing editions backfill cleanly.
+ALTER TABLE newsletter_editions
+    ADD COLUMN subject VARCHAR(500) NULL AFTER subtitle;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -319,6 +319,12 @@ class NewsletterDraftRequest(BaseModel):
     action: str = "save"
 
 
+class NewsletterRegenerateRequest(BaseModel):
+    session_token: str
+    edition_id: int
+    guidance: Optional[str] = None  # free-text "Added Guidance"; empty => AI decides a fresh take
+
+
 class EngagementPreferencesRequest(BaseModel):
     session_token: str
     tone: Optional[str] = None
@@ -1201,6 +1207,24 @@ def update_newsletter_draft_endpoint(request: NewsletterDraftRequest) -> Respons
                                      subtitle=request.subtitle, body=request.body, status=status):
         raise HTTPException(status_code=500, detail="Could not update newsletter draft")
     return ResponseModel(status_code=200, detail="Newsletter draft updated")
+
+
+@router.post("/user/newsletter-draft/regenerate")
+def regenerate_newsletter_draft_endpoint(request: NewsletterRegenerateRequest) -> ResponseModel:
+    """Regenerate a single queued edition. Generation is a slow lem-complex call, so dispatch it to a
+    Celery task and let the UI refetch the queue once it lands. Optional free-text `guidance` steers
+    the rewrite; empty guidance lets the AI decide a fresh, distinct take."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    existing = get_newsletter_edition(request.edition_id)
+    if not existing or existing.get("user_id") != user_id:
+        raise HTTPException(status_code=404, detail="Edition not found")
+    from cqc_lem.app.run_scheduler import regenerate_newsletter_edition
+    guidance = (request.guidance or "").strip() or None
+    regenerate_newsletter_edition.apply_async(
+        kwargs={"edition_id": request.edition_id, "guidance": guidance})
+    return ResponseModel(status_code=200, detail="Regeneration started")
 
 
 class GroupTogglesRequest(BaseModel):

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -148,9 +148,12 @@ def _topup_newsletter_drafts_for_user(user_id: int, now: datetime,
     import pytz
     from cqc_lem.utilities.db import (get_newsletter_settings, get_user_timezone,
                                       count_pending_newsletter_editions,
-                                      get_latest_edition_scheduled_for, create_newsletter_edition)
+                                      get_latest_edition_scheduled_for, create_newsletter_edition,
+                                      get_pending_newsletter_editions, get_recent_newsletter_subjects,
+                                      get_engagement_preferences)
     from cqc_lem.utilities.linkedin.helper import load_profile_for_user
-    from cqc_lem.utilities.ai.ai_helper import generate_newsletter_edition
+    from cqc_lem.utilities.ai.ai_helper import (generate_newsletter_edition, plan_newsletter_topics,
+                                                get_or_create_profile_synthesis)
     from cqc_lem.utilities.newsletter import upcoming_publish_slots, should_generate_now
     from cqc_lem.utilities.notifications import notify_newsletter_draft_ready
 
@@ -176,15 +179,46 @@ def _topup_newsletter_drafts_for_user(user_id: int, now: datetime,
     if pending == 0 and allow_bootstrap and not should_generate_now(slots[0], now, lead_days=lead):
         return 0
 
-    generated = 0
     profile = load_profile_for_user(user_id)
-    for slot in slots:
-        edition = generate_newsletter_edition(profile, topic=settings.get("topic"))
+    synthesis = get_or_create_profile_synthesis(user_id, profile)
+    prefs = get_engagement_preferences(user_id)
+    description = settings.get("topic")
+
+    # Dedup history: subjects of already-queued editions + recently published/skipped ones. Feeding
+    # this into the planner (and the per-edition generator) is what keeps every edition unique and
+    # fresh instead of near-duplicate rehashes of the newsletter's single description.
+    queued_subjects = [e.get("subject") for e in get_pending_newsletter_editions(user_id)
+                       if e.get("subject")]
+    prior_subjects = list(dict.fromkeys(
+        [s for s in queued_subjects if s] + get_recent_newsletter_subjects(user_id, limit=20)))
+
+    # PLAN a coherent, distinct sequence of subjects up front (one shot), THEN write one edition per
+    # planned subject. Falls back to single-topic generation when planning yields nothing.
+    planned = plan_newsletter_topics(synthesis or "", description or "", prefs, prior_subjects,
+                                     len(slots))
+
+    generated = 0
+    for i, slot in enumerate(slots):
+        plan = planned[i] if i < len(planned) else None
+        subject_ctx = None
+        if plan:
+            subject_ctx = plan["subject"]
+            if plan.get("angle"):
+                subject_ctx = f"{plan['subject']} — angle: {plan['angle']}"
+        # Even the fallback path stays distinct: avoid every other planned subject + all prior ones.
+        avoid = prior_subjects + [p["subject"] for j, p in enumerate(planned)
+                                  if j != i and p.get("subject")]
+        edition = generate_newsletter_edition(profile, topic=description, prefs=prefs,
+                                              subject=subject_ctx, avoid_subjects=avoid,
+                                              profile_synthesis=synthesis)
         if not edition:
             break
+        edition_subject = edition.get("subject") or (plan["subject"] if plan else None)
         if not create_newsletter_edition(user_id, edition["title"], edition.get("subtitle"),
-                                          edition["body"], slot):
+                                          edition["body"], slot, subject=edition_subject):
             break  # duplicate slot / db error → stop this user's run
+        if edition_subject:
+            prior_subjects.append(edition_subject)  # subsequent iterations avoid it too
         notify_newsletter_draft_ready(user_id, edition["title"], slot)
         generated += 1
     return generated
@@ -225,6 +259,57 @@ def generate_newsletter_drafts_for_user(user_id: int):
                     task_name="generate_newsletter_drafts_for_user")
         return "Generated 0 newsletter draft(s)"
     return f"Generated {generated} newsletter draft(s)"
+
+
+@shared_task.task
+def regenerate_newsletter_edition(edition_id: int, guidance: str = None):
+    """Regenerate ONE queued newsletter edition in place. Generation is a slow lem-complex call, so
+    it runs as a task (not inline in the API request). Honors free-text `guidance` when provided
+    (edit the same subject OR take a completely different direction); with no guidance the AI decides
+    a fresh, distinct take. Grounded in the author's voice synthesis + the newsletter description, and
+    steered AWAY from the OTHER queued editions' subjects (and recent history) so regeneration never
+    reintroduces a duplicate. Updates the row (title/subtitle/subject/body) and resets status to
+    'draft'."""
+    from cqc_lem.utilities.db import (get_newsletter_edition, get_newsletter_settings,
+                                      get_pending_newsletter_editions, get_recent_newsletter_subjects,
+                                      get_engagement_preferences, update_newsletter_edition)
+    from cqc_lem.utilities.linkedin.helper import load_profile_for_user
+    from cqc_lem.utilities.ai.ai_helper import (generate_newsletter_edition,
+                                                get_or_create_profile_synthesis)
+
+    edition = get_newsletter_edition(edition_id)
+    if not edition or edition.get("status") not in ("draft", "approved"):
+        return f"Edition {edition_id} not regenerable"
+    user_id = edition["user_id"]
+    settings = get_newsletter_settings(user_id)
+    prefs = get_engagement_preferences(user_id)
+    profile = load_profile_for_user(user_id)
+    synthesis = get_or_create_profile_synthesis(user_id, profile)
+
+    # Avoid the OTHER queued editions' subjects + recent history so the rewrite stays unique.
+    others = [e.get("subject") for e in get_pending_newsletter_editions(user_id)
+              if e.get("id") != edition_id and e.get("subject")]
+    avoid = list(dict.fromkeys([s for s in others if s] + get_recent_newsletter_subjects(user_id, limit=20)))
+
+    # With guidance we keep the current subject as the starting point (the guidance may edit it or
+    # redirect entirely). With NO guidance the AI decides a fresh, distinct subject (subject=None).
+    subject = edition.get("subject") if (guidance and guidance.strip()) else None
+    try:
+        new_ed = generate_newsletter_edition(profile, topic=settings.get("topic"), prefs=prefs,
+                                             subject=subject, avoid_subjects=avoid,
+                                             profile_synthesis=synthesis, guidance=guidance)
+    except Exception as e:
+        log_warning("Newsletter regeneration failed", exc=e, user_id=user_id,
+                    task_name="regenerate_newsletter_edition")
+        return f"Regeneration failed for edition {edition_id}"
+    if not new_ed:
+        return f"Regeneration produced nothing for edition {edition_id}"
+    update_newsletter_edition(edition_id, user_id, title=new_ed["title"],
+                              subtitle=new_ed.get("subtitle"), body=new_ed["body"],
+                              subject=new_ed.get("subject") or subject, status="draft")
+    log_info("Regenerated newsletter edition", user_id=user_id,
+             task_name="regenerate_newsletter_edition")
+    return f"Regenerated newsletter edition {edition_id}"
 
 
 @shared_task.task

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -44,6 +44,7 @@ export type NewsletterEdition = {
   id: number
   title: string | null
   subtitle: string | null
+  subject?: string | null
   body: string | null
   status: string
   scheduled_for: string | null

--- a/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
+++ b/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
@@ -16,6 +16,10 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
   const qc = useQueryClient()
   const [selectedId, setSelectedId] = useState<number | null>(null)
   const [draftEdit, setDraftEdit] = useState<NewsletterEdition | null>(null)
+  const [guidance, setGuidance] = useState('')
+  // After a regenerate lands, force the editor to re-seed from the freshly fetched edition (same id,
+  // new content) — the normal seed effect only fires when the selection is GONE.
+  const [reseedId, setReseedId] = useState<number | null>(null)
   const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null)
 
   const { data, isLoading } = useQuery({
@@ -45,6 +49,16 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
     }
   }, [data, selectedId])
 
+  // Pull in regenerated content once the async task has updated the edition in place.
+  useEffect(() => {
+    if (reseedId == null) return
+    const fresh = editions.find((e) => e.id === reseedId)
+    if (fresh) {
+      setDraftEdit({ ...fresh })
+      setReseedId(null)
+    }
+  }, [data, reseedId])
+
   const setDe = (patch: Partial<NewsletterEdition>) => setDraftEdit((p) => (p ? { ...p, ...patch } : p))
 
   const draftMutation = useMutation({
@@ -69,6 +83,36 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
       setTimeout(() => setMsg(null), 5000)
     },
   })
+
+  const regenerateMutation = useMutation({
+    mutationFn: () =>
+      api.post('/user/newsletter-draft/regenerate', {
+        session_token: sessionToken,
+        edition_id: draftEdit!.id,
+        guidance: guidance.trim() || null,
+      }),
+    onSuccess: () => {
+      const id = draftEdit!.id
+      setGuidance('')
+      setMsg({ ok: true, text: 'Regenerating… this can take a minute.' })
+      // The task is async — refetch a couple of times to pick up the rewritten draft, then re-seed
+      // the editor from the fresh content.
+      setTimeout(() => qc.invalidateQueries({ queryKey: ['newsletter-queue'] }), 6000)
+      setTimeout(() => {
+        qc.invalidateQueries({ queryKey: ['newsletter-queue'] })
+        setReseedId(id)
+        setMsg({ ok: true, text: 'Regenerated draft updated below.' })
+        setTimeout(() => setMsg(null), 3000)
+      }, 15000)
+    },
+    onError: () => {
+      setMsg({ ok: false, text: 'Could not start regeneration — try again.' })
+      setTimeout(() => setMsg(null), 5000)
+    },
+  })
+
+  const regenerating = regenerateMutation.isPending || reseedId != null
+  const busy = draftMutation.isPending || regenerating
 
   function selectEdition(e: NewsletterEdition) {
     setSelectedId(e.id)
@@ -148,21 +192,39 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
               <textarea value={draftEdit.body || ''} onChange={(e) => setDe({ body: e.target.value })} rows={10}
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500" />
             </div>
+
+            {/* Re-generate: the prominent action. Optional guidance steers the rewrite; empty guidance
+                lets the AI pick a fresh, distinct take. */}
+            <div className="border-t border-gray-100 pt-3 space-y-2">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Added Guidance <span className="font-normal text-gray-400">(optional)</span>
+              </label>
+              <textarea value={guidance} onChange={(e) => setGuidance(e.target.value)} rows={2}
+                placeholder="What should change and why? Leave blank to let AI pick a fresh, distinct take."
+                disabled={busy}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50" />
+              <button type="button" onClick={() => regenerateMutation.mutate()} disabled={busy}
+                className="w-full bg-indigo-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-colors">
+                {regenerating ? 'Regenerating…' : 'Re-generate'}
+              </button>
+            </div>
+
             {msg && <p className={`text-sm font-medium ${msg.ok ? 'text-green-600' : 'text-red-600'}`}>{msg.text}</p>}
-            <div className="grid grid-cols-3 gap-2">
-              <button type="button" onClick={() => draftMutation.mutate('save')} disabled={draftMutation.isPending}
+            <div className="grid grid-cols-2 gap-2">
+              <button type="button" onClick={() => draftMutation.mutate('save')} disabled={busy}
                 className="bg-gray-100 text-gray-700 py-2 rounded-lg text-sm font-semibold hover:bg-gray-200 disabled:opacity-50 transition-colors">
                 Save
               </button>
-              <button type="button" onClick={() => draftMutation.mutate('approve')} disabled={draftMutation.isPending}
+              <button type="button" onClick={() => draftMutation.mutate('approve')} disabled={busy}
                 className="bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
                 Approve
               </button>
-              <button type="button" onClick={() => draftMutation.mutate('skip')} disabled={draftMutation.isPending}
-                className="bg-white border border-gray-300 text-gray-700 py-2 rounded-lg text-sm font-semibold hover:bg-gray-50 disabled:opacity-50 transition-colors">
-                Skip
-              </button>
             </div>
+            {/* Skip stays as a smaller secondary action — not publishing an edition is still useful. */}
+            <button type="button" onClick={() => draftMutation.mutate('skip')} disabled={busy}
+              className="w-full text-xs text-gray-400 hover:text-gray-600 disabled:opacity-50 transition-colors">
+              Skip this edition
+            </button>
           </div>
 
           <NewsletterArticlePreview

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -456,16 +456,132 @@ def _clean_newsletter_body(body: str) -> str:
     return sanitize_for_linkedin(body or "")
 
 
+# Unlike comments/posts (which carry the HARD _NO_SELF_PROMO_GUARDRAIL), a newsletter is the author's
+# OWN publication, so a LIGHT, occasional, SECONDARY mention of the tools/approach the author uses is
+# acceptable when it genuinely serves the reader. The edition's SUBJECT and value must still stand on
+# their own — never turn an edition into an ad, and never let a tool become the whole subject.
+_NEWSLETTER_SOFT_PROMO_NOTE = (
+    "This is the author's OWN newsletter. A LIGHT, OCCASIONAL, SECONDARY mention of a tool, product, "
+    "or approach the author uses is allowed when it genuinely helps the reader — but keep it brief and "
+    "secondary. The edition's subject and value must stand on their own; never turn it into an ad and "
+    "never let a product become the whole subject."
+)
+
+
+def plan_newsletter_topics(profile_synthesis: str, newsletter_description: str, prefs: dict = None,
+                           prior_subjects: list = None, count: int = 1) -> list:
+    """Plan a sequence of `count` DISTINCT newsletter subjects that form a natural, coherent
+    progression BEFORE any edition is written — so the queued editions build on each other instead of
+    each independently rehashing the newsletter's single description (the near-duplicate bug).
+
+    Alignment (in priority order): the newsletter's DESCRIPTION/promise, the author's durable voice &
+    expertise SYNTHESIS, then their declared focus topics/goals. `prior_subjects` (already-queued,
+    published, and recently-skipped subjects) are AVOIDED so nothing repeats. Each item is
+    {"subject": str, "angle": str}. Robust JSON parsing; returns [] on any failure so the caller can
+    gracefully fall back to single-topic generation."""
+    import json as _json
+    count = max(1, int(count))
+    prior = [str(s).strip() for s in (prior_subjects or []) if str(s).strip()]
+    avoid_block = ("\n\nAlready-covered subjects to AVOID repeating (cover materially different "
+                   "ground):\n- " + "\n- ".join(prior) + "\n") if prior else ""
+    system_prompt = {
+        "role": "system",
+        "content": (
+            "You are the EDITORIAL PLANNER for a LinkedIn creator's newsletter. Plan a sequence of "
+            f"exactly {count} DISTINCT edition subjects that together form a COHERENT PROGRESSION — "
+            "each edition should advance the reader, never repeat a previous one.\n\n"
+            "Ground every subject in, in priority order:\n"
+            "1. The newsletter's stated purpose/description (its promise to subscribers) — the PRIMARY anchor.\n"
+            "2. The author's durable voice & expertise (their synthesis) — pick subjects THIS author can "
+            "speak to with real authority.\n"
+            "3. The author's declared focus topics and goals, when provided — use to refine the angle.\n\n"
+            "RULES:\n"
+            "- Each subject MUST be materially different from the others AND from any already-covered "
+            "subject: a different problem, angle, and takeaway. No rephrasings of the same idea, no "
+            "regurgitated fluff.\n"
+            "- Prefer a natural arc (e.g. foundational -> tactical -> advanced, or problem -> framework "
+            "-> execution).\n"
+            "- Subjects are about the READER'S growth and the newsletter's topic — NOT about the "
+            "author's own products. " + _NEWSLETTER_SOFT_PROMO_NOTE + " At most ONE of the planned "
+            "subjects may LIGHTLY touch tools/tooling; keep every other subject tool-agnostic.\n\n"
+            f"Return ONLY valid JSON with exactly this shape and exactly {count} items:\n"
+            '{"editions": [{"subject": "short specific subject (<= ~120 chars)", "angle": "the '
+            'distinct angle/takeaway for this edition"}]}'
+        ),
+    }
+    user_prompt = {
+        "role": "user",
+        "content": (f"Newsletter description / promise:\n{(newsletter_description or '').strip() or '(not provided)'}\n\n"
+                    f"Author voice & expertise synthesis:\n{(profile_synthesis or '').strip() or '(not provided)'}\n"
+                    f"{_focus_directive(prefs)}{avoid_block}\n"
+                    f"Plan exactly {count} distinct subjects now."),
+    }
+    try:
+        response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt],
+                             temperature=round(random.uniform(0.6, 0.8), 2))
+        content = response.choices[0].message.content
+    except Exception as exc:
+        log_warning("Newsletter topic planning failed; falling back to single-topic", exc=exc)
+        return []
+    if not content:
+        return []
+    raw = content.strip()
+    # Tolerate ```json fences some models still emit.
+    if raw.startswith("```"):
+        raw = raw.strip("`")
+        raw = raw[raw.find("{"):raw.rfind("}") + 1] if "{" in raw else raw
+    try:
+        data = _json.loads(raw)
+    except (ValueError, TypeError):
+        start, end = raw.find("{"), raw.rfind("}")
+        if start == -1 or end == -1:
+            return []
+        try:
+            data = _json.loads(raw[start:end + 1])
+        except (ValueError, TypeError):
+            return []
+    items = data.get("editions") if isinstance(data, dict) else data
+    if not isinstance(items, list):
+        return []
+    planned = []
+    seen = set()
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        subject = str(it.get("subject") or "").strip()[:500]
+        if not subject or subject.lower() in seen:
+            continue
+        seen.add(subject.lower())
+        planned.append({"subject": subject, "angle": str(it.get("angle") or "").strip()[:500]})
+    return planned[:count]
+
+
 def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
-                                blog_content: str = None, prefs: dict = None) -> "dict | None":
+                                blog_content: str = None, prefs: dict = None,
+                                subject: str = None, avoid_subjects: list = None,
+                                profile_synthesis: str = None,
+                                guidance: str = None) -> "dict | None":
     """Generate one substantial LinkedIn newsletter edition in the author's voice, repurposing the
     author's blog content when provided. Aims for ~800–1200 words with a strong hook, 3–5 developed
     sections, a takeaways block, and a reply-driving CTA — worth an email, not a skeleton. Body is
-    PLAIN TEXT (no markdown; LinkedIn's article editor renders none). Returns
-    {'title','subtitle','body'} or None."""
+    PLAIN TEXT (no markdown; LinkedIn's article editor renders none).
+
+    `subject` is the SPECIFIC planned subject/angle for THIS edition (from plan_newsletter_topics);
+    `topic` remains the newsletter's overall description/theme (context). `avoid_subjects` lists the
+    other editions' subjects so this one stays distinct. Voice comes from the durable
+    `profile_synthesis` (falls back to the guarded full profile JSON only when none supplied).
+    `guidance` is optional free-text steering for a regeneration (edit the same subject or take a
+    completely different direction). Returns {'title','subtitle','subject','body'} or None."""
     import json as _json
     src = f"\n\nSource material to repurpose (from the author's blog):\n{blog_content[:4000]}" if blog_content else ""
-    topic_line = f"Topic/theme for this edition: {topic}\n" if topic else ""
+    topic_line = f"Newsletter overall theme/description: {topic}\n" if topic else ""
+    subject_line = (f"THIS edition's specific subject/angle to develop (make the edition about THIS): "
+                    f"{subject}\n") if subject else ""
+    avoid = [str(s).strip() for s in (avoid_subjects or []) if str(s).strip()]
+    avoid_line = ("Do NOT overlap with these other editions' subjects — cover DISTINCT ground:\n- "
+                  + "\n- ".join(avoid) + "\n") if avoid else ""
+    guidance_line = ("\nUSER GUIDANCE for this rewrite — apply it. It may ask for edits to the same "
+                     f"subject or a COMPLETELY different take:\n{guidance.strip()}\n") if guidance and guidance.strip() else ""
     system_prompt = {
         "role": "system",
         "content": """You are a LinkedIn newsletter ghostwriter for the profile user. Write ONE
@@ -496,23 +612,28 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
         - Use short paragraphs and blank lines between them for white space and readability.
 
         VOICE: the author's authentic voice and expertise, confident and human. No emojis unless the
-        author clearly uses them.
+        author clearly uses them. """ + _NEWSLETTER_SOFT_PROMO_NOTE + """
 
         Return ONLY valid JSON with exactly these keys:
-        {"title": "...", "subtitle": "...", "body": "..."}
+        {"title": "...", "subtitle": "...", "subject": "...", "body": "..."}
         - title: a specific, benefit-driven, scroll-stopping edition title (<= ~90 chars).
         - subtitle: a <= 150 character description of what THIS edition delivers and why to read it
           (for LinkedIn's edition-description field). Plain text, no markdown.
+        - subject: a short (<= ~120 char) phrase naming THIS edition's specific subject/angle, for
+          internal dedup history (echo the given subject when one is provided).
         - body: the full plain-text article with real line breaks (\\n) as described above.""",
     }
     user_prompt = {"role": "user",
-                   "content": f"Author profile:\n{profile.model_dump_json()}\n\n{topic_line}{src}"
-                              f"{_style_directive(prefs)}"}
+                   "content": f"Author voice reference (TONE + CREDIBILITY only):\n"
+                              f"{_voice_reference(profile, profile_synthesis)}\n\n"
+                              f"{topic_line}{subject_line}{avoid_line}{guidance_line}{src}"
+                              f"{_focus_directive(prefs)}{_style_directive(prefs)}"}
     response = _call_llm(model="lem-complex", messages=[system_prompt, user_prompt],
                          temperature=round(random.uniform(0.5, 0.7), 2))
     content = response.choices[0].message.content
     if not content:
         return None
+    _default_subject = (subject or topic or "").strip()[:500]
     try:
         data = _json.loads(content)
         if data.get("title") and data.get("body"):
@@ -520,14 +641,16 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
             body = _clean_newsletter_body(str(data["body"]).strip())
             subtitle = str(data.get("subtitle") or "").strip()[:150]
             if not subtitle:
-                subtitle = (topic or title).strip()[:150]
-            return {"title": title, "subtitle": subtitle, "body": body}
+                subtitle = (subject or topic or title).strip()[:150]
+            out_subject = str(data.get("subject") or "").strip()[:500] or _default_subject or title[:500]
+            return {"title": title, "subtitle": subtitle, "subject": out_subject, "body": body}
     except (ValueError, TypeError, AttributeError):
         pass
     parts = content.strip().split("\n", 1)   # fallback: first line = title, remainder = body
     title = parts[0].strip()[:255]
     body = _clean_newsletter_body(parts[1].strip() if len(parts) > 1 else content.strip())
-    return {"title": title, "subtitle": (topic or title).strip()[:150], "body": body}
+    return {"title": title, "subtitle": (subject or topic or title).strip()[:150],
+            "subject": _default_subject or title[:500], "body": body}
 
 
 def generate_group_post(profile: "LinkedInProfile", group_name: str = None, prefs: dict = None,

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2762,15 +2762,16 @@ def get_enabled_newsletter_user_ids() -> list:
 
 
 def create_newsletter_edition(user_id: int, title: str, subtitle: str, body: str,
-                              scheduled_for) -> int:
-    """Insert a draft newsletter edition (status defaults to 'draft'). Returns its id."""
+                              scheduled_for, subject: str = None) -> int:
+    """Insert a draft newsletter edition (status defaults to 'draft'). Returns its id. `subject` is
+    the planned topic/angle for this edition, stored so the planner can dedup against prior ones."""
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         cursor.execute(
-            "INSERT INTO newsletter_editions (user_id, title, subtitle, body, scheduled_for) "
-            "VALUES (%s, %s, %s, %s, %s)",
-            (user_id, title, subtitle, body, scheduled_for))
+            "INSERT INTO newsletter_editions (user_id, title, subtitle, subject, body, scheduled_for) "
+            "VALUES (%s, %s, %s, %s, %s, %s)",
+            (user_id, title, subtitle, subject, body, scheduled_for))
         connection.commit()
         return cursor.lastrowid
     except mysql.connector.IntegrityError as err:
@@ -2793,7 +2794,7 @@ def get_pending_newsletter_edition(user_id: int) -> "dict | None":
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            "SELECT id, title, subtitle, body, status, scheduled_for FROM newsletter_editions "
+            "SELECT id, title, subtitle, subject, body, status, scheduled_for FROM newsletter_editions "
             "WHERE user_id = %s AND status IN ('draft', 'approved') "
             "ORDER BY id DESC LIMIT 1", (user_id,))
         return cursor.fetchone()
@@ -2829,7 +2830,7 @@ def get_pending_newsletter_editions(user_id: int) -> list:
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            "SELECT id, title, subtitle, body, status, scheduled_for FROM newsletter_editions "
+            "SELECT id, title, subtitle, subject, body, status, scheduled_for FROM newsletter_editions "
             "WHERE user_id = %s AND status IN ('draft', 'approved') "
             "ORDER BY scheduled_for ASC", (user_id,))
         return cursor.fetchall()
@@ -2860,7 +2861,7 @@ def get_latest_edition_scheduled_for(user_id: int) -> "datetime | None":
 
 def update_newsletter_edition(edition_id: int, user_id: int, title: str = None,
                               subtitle: str = None, body: str = None,
-                              status: str = None) -> bool:
+                              status: str = None, subject: str = None) -> bool:
     """Update only the provided fields on an edition, scoped to its owner (COALESCE-style)."""
     connection = get_db_connection()
     cursor = connection.cursor()
@@ -2868,14 +2869,36 @@ def update_newsletter_edition(edition_id: int, user_id: int, title: str = None,
         cursor.execute(
             "UPDATE newsletter_editions SET "
             "title = COALESCE(%s, title), subtitle = COALESCE(%s, subtitle), "
+            "subject = COALESCE(%s, subject), "
             "body = COALESCE(%s, body), status = COALESCE(%s, status) "
             "WHERE id = %s AND user_id = %s",
-            (title, subtitle, body, status, edition_id, user_id))
+            (title, subtitle, subject, body, status, edition_id, user_id))
         connection.commit()
         return cursor.rowcount >= 0
     except mysql.connector.Error as err:
         myprint(f"Could not update newsletter edition {edition_id} | Error: {err}")
         return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_recent_newsletter_subjects(user_id: int, limit: int = 20) -> list:
+    """Recent edition SUBJECTS (published, queued draft/approved, AND skipped) for a user — the dedup
+    history fed to the topic planner so a new edition never repeats a subject already covered or
+    recently rejected. Most-recent first; NULL/blank subjects excluded."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT subject FROM newsletter_editions "
+            "WHERE user_id = %s AND subject IS NOT NULL AND subject <> '' "
+            "AND status IN ('draft', 'approved', 'published', 'skipped') "
+            "ORDER BY id DESC LIMIT %s", (user_id, int(limit)))
+        return [r[0] for r in cursor.fetchall()]
+    except mysql.connector.Error as err:
+        myprint(f"Could not get recent newsletter subjects for user {user_id} | Error: {err}")
+        return []
     finally:
         cursor.close()
         connection.close()
@@ -2904,7 +2927,7 @@ def get_newsletter_edition(edition_id: int) -> "dict | None":
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            "SELECT id, user_id, title, subtitle, body, status, scheduled_for, published_url "
+            "SELECT id, user_id, title, subtitle, subject, body, status, scheduled_for, published_url "
             "FROM newsletter_editions WHERE id = %s", (edition_id,))
         return cursor.fetchone()
     except mysql.connector.Error as err:

--- a/tests/unit/api/test_newsletter_api.py
+++ b/tests/unit/api/test_newsletter_api.py
@@ -178,3 +178,39 @@ class TestNewsletterDraft:
             resp = client.put("/api/user/newsletter-draft", json={
                 "session_token": "bad", "edition_id": 4, "action": "save"})
         assert resp.status_code == 401
+
+
+class TestNewsletterRegenerate:
+    def test_dispatches_task_with_guidance(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_newsletter_edition", return_value={"id": 4, "user_id": _USER}), \
+             patch("cqc_lem.app.run_scheduler.regenerate_newsletter_edition") as task:
+            resp = client.post("/api/user/newsletter-draft/regenerate", json={
+                "session_token": _SESSION, "edition_id": 4, "guidance": "Make it about pricing"})
+        assert resp.status_code == 200
+        task.apply_async.assert_called_once_with(
+            kwargs={"edition_id": 4, "guidance": "Make it about pricing"})
+
+    def test_blank_guidance_becomes_none(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_newsletter_edition", return_value={"id": 4, "user_id": _USER}), \
+             patch("cqc_lem.app.run_scheduler.regenerate_newsletter_edition") as task:
+            resp = client.post("/api/user/newsletter-draft/regenerate", json={
+                "session_token": _SESSION, "edition_id": 4, "guidance": "   "})
+        assert resp.status_code == 200
+        task.apply_async.assert_called_once_with(kwargs={"edition_id": 4, "guidance": None})
+
+    def test_404_when_not_owner(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_newsletter_edition", return_value={"id": 4, "user_id": 999}), \
+             patch("cqc_lem.app.run_scheduler.regenerate_newsletter_edition") as task:
+            resp = client.post("/api/user/newsletter-draft/regenerate", json={
+                "session_token": _SESSION, "edition_id": 4})
+        assert resp.status_code == 404
+        task.apply_async.assert_not_called()
+
+    def test_401(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.post("/api/user/newsletter-draft/regenerate", json={
+                "session_token": "bad", "edition_id": 4})
+        assert resp.status_code == 401

--- a/tests/unit/app/test_newsletter_publish.py
+++ b/tests/unit/app/test_newsletter_publish.py
@@ -128,7 +128,12 @@ def _run_generate(*, settings, pending, latest=None, gen_now=True,
         p(patch("cqc_lem.utilities.db.count_pending_newsletter_editions", return_value=pending))
         p(patch("cqc_lem.utilities.db.get_latest_edition_scheduled_for", return_value=latest))
         create = p(patch("cqc_lem.utilities.db.create_newsletter_edition", **create_kw))
+        p(patch("cqc_lem.utilities.db.get_pending_newsletter_editions", return_value=[]))
+        p(patch("cqc_lem.utilities.db.get_recent_newsletter_subjects", return_value=[]))
+        p(patch("cqc_lem.utilities.db.get_engagement_preferences", return_value={}))
         p(patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()))
+        p(patch("cqc_lem.utilities.ai.ai_helper.get_or_create_profile_synthesis", return_value="voice brief"))
+        p(patch("cqc_lem.utilities.ai.ai_helper.plan_newsletter_topics", return_value=[]))
         p(patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", **gen_kw))
         p(patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=gen_now))
         notify = p(patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready"))
@@ -213,7 +218,12 @@ def _run_generate_for_user(*, settings, pending, latest=None, gen_now=True, edit
         p(patch("cqc_lem.utilities.db.count_pending_newsletter_editions", return_value=pending))
         p(patch("cqc_lem.utilities.db.get_latest_edition_scheduled_for", return_value=latest))
         create = p(patch("cqc_lem.utilities.db.create_newsletter_edition", return_value=create_ret))
+        p(patch("cqc_lem.utilities.db.get_pending_newsletter_editions", return_value=[]))
+        p(patch("cqc_lem.utilities.db.get_recent_newsletter_subjects", return_value=[]))
+        p(patch("cqc_lem.utilities.db.get_engagement_preferences", return_value={}))
         p(patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()))
+        p(patch("cqc_lem.utilities.ai.ai_helper.get_or_create_profile_synthesis", return_value="voice brief"))
+        p(patch("cqc_lem.utilities.ai.ai_helper.plan_newsletter_topics", return_value=[]))
         p(patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", return_value=edition))
         p(patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=gen_now))
         p(patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready"))
@@ -247,6 +257,123 @@ class TestGenerateNewsletterDraftsForUser:
             settings=_settings(enabled=True, max_queued_drafts=2), pending=2)
         create.assert_not_called()
         assert "Generated 0 newsletter draft" in result
+
+
+class TestTopupPlansDistinctSubjects:
+    def _drive(self, planned, pending=0, existing_subjects=None, recent=None):
+        from contextlib import ExitStack
+        from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
+
+        def _gen(profile, topic=None, prefs=None, subject=None, avoid_subjects=None,
+                 profile_synthesis=None, guidance=None):
+            # Echo the planned subject as the generated edition's canonical subject.
+            base = subject.split(" — angle:")[0] if subject else "Auto"
+            return {"title": f"Title for {base}", "subtitle": "S", "subject": base, "body": "B"}
+
+        with ExitStack() as es:
+            p = es.enter_context
+            p(patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=[1]))
+            p(patch("cqc_lem.utilities.db.get_newsletter_settings",
+                    return_value=_settings(max_queued_drafts=max(1, len(planned)))))
+            p(patch("cqc_lem.utilities.db.get_user_timezone", return_value="UTC"))
+            p(patch("cqc_lem.utilities.db.count_pending_newsletter_editions", return_value=pending))
+            p(patch("cqc_lem.utilities.db.get_latest_edition_scheduled_for", return_value=None))
+            pending_eds = [{"id": i, "subject": s} for i, s in enumerate(existing_subjects or [])]
+            p(patch("cqc_lem.utilities.db.get_pending_newsletter_editions", return_value=pending_eds))
+            p(patch("cqc_lem.utilities.db.get_recent_newsletter_subjects", return_value=recent or []))
+            p(patch("cqc_lem.utilities.db.get_engagement_preferences", return_value={}))
+            create = p(patch("cqc_lem.utilities.db.create_newsletter_edition", return_value=1))
+            p(patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()))
+            p(patch("cqc_lem.utilities.ai.ai_helper.get_or_create_profile_synthesis", return_value="brief"))
+            plan = p(patch("cqc_lem.utilities.ai.ai_helper.plan_newsletter_topics", return_value=planned))
+            p(patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", side_effect=_gen))
+            p(patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=True))
+            p(patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready"))
+            result = auto_generate_newsletter_drafts()
+        return result, create, plan
+
+    def test_plans_then_persists_distinct_subjects(self):
+        planned = [{"subject": "Alpha", "angle": "a"}, {"subject": "Beta", "angle": "b"}]
+        result, create, plan = self._drive(planned)
+        plan.assert_called_once()
+        assert create.call_count == 2
+        subjects = [c.kwargs["subject"] for c in create.call_args_list]
+        assert subjects == ["Alpha", "Beta"]  # distinct, planned, and persisted
+        assert "Generated 2 newsletter draft" in result
+
+    def test_history_fed_into_planning(self):
+        planned = [{"subject": "New1", "angle": "a"}]
+        result, create, plan = self._drive(
+            planned, pending=0, existing_subjects=["Queued Subj"], recent=["Published Subj"])
+        prior = plan.call_args[0][3]  # (synthesis, description, prefs, prior_subjects, count)
+        assert "Queued Subj" in prior and "Published Subj" in prior
+
+    def test_falls_back_to_single_topic_when_planning_empty(self):
+        # Planner returns [] (e.g. LLM failure) → still generate one edition per slot, subject=None ok.
+        result, create, plan = self._drive([], pending=0)
+        # _settings default max_queued_drafts=1 via max(1, 0)
+        assert create.call_count == 1
+        assert "Generated 1 newsletter draft" in result
+
+
+def _run_regenerate(*, edition, guidance=None, others=None, recent=None, new_ed=None):
+    from contextlib import ExitStack
+    from cqc_lem.app.run_scheduler import regenerate_newsletter_edition
+    if new_ed is None:
+        new_ed = {"title": "New T", "subtitle": "New S", "subject": "New Subject", "body": "New B"}
+    captured = {}
+
+    def _gen(profile, topic=None, prefs=None, subject=None, avoid_subjects=None,
+             profile_synthesis=None, guidance=None):
+        captured["subject"] = subject
+        captured["avoid"] = avoid_subjects
+        captured["guidance"] = guidance
+        return new_ed
+
+    with ExitStack() as es:
+        p = es.enter_context
+        p(patch("cqc_lem.utilities.db.get_newsletter_edition", return_value=edition))
+        p(patch("cqc_lem.utilities.db.get_newsletter_settings", return_value=_settings()))
+        p(patch("cqc_lem.utilities.db.get_engagement_preferences", return_value={}))
+        pending_eds = [{"id": o_id, "subject": s} for o_id, s in (others or [])]
+        p(patch("cqc_lem.utilities.db.get_pending_newsletter_editions", return_value=pending_eds))
+        p(patch("cqc_lem.utilities.db.get_recent_newsletter_subjects", return_value=recent or []))
+        p(patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()))
+        p(patch("cqc_lem.utilities.ai.ai_helper.get_or_create_profile_synthesis", return_value="brief"))
+        p(patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", side_effect=_gen))
+        upd = p(patch("cqc_lem.utilities.db.update_newsletter_edition", return_value=True))
+        result = regenerate_newsletter_edition.run(edition_id=edition["id"], guidance=guidance)
+    return result, upd, captured
+
+
+class TestRegenerateNewsletterEdition:
+    def test_not_regenerable_when_published(self):
+        result, upd, _ = _run_regenerate(
+            edition={"id": 9, "user_id": 1, "status": "published", "subject": "X"})
+        assert "not regenerable" in result
+        upd.assert_not_called()
+
+    def test_with_guidance_keeps_subject_and_applies_it(self):
+        ed = {"id": 9, "user_id": 1, "status": "draft", "subject": "Original Subject"}
+        result, upd, cap = _run_regenerate(edition=ed, guidance="Focus on hiring")
+        assert cap["subject"] == "Original Subject"  # guidance -> current subject is the starting point
+        assert cap["guidance"] == "Focus on hiring"
+        assert upd.call_args.kwargs["status"] == "draft"  # resets to draft
+        assert "Regenerated" in result
+
+    def test_without_guidance_ai_decides_fresh(self):
+        ed = {"id": 9, "user_id": 1, "status": "approved", "subject": "Original Subject"}
+        result, upd, cap = _run_regenerate(edition=ed, guidance=None)
+        assert cap["subject"] is None  # no guidance -> AI picks a fresh, distinct subject
+        assert upd.call_args.kwargs["status"] == "draft"
+        assert upd.call_args.kwargs["subject"] == "New Subject"  # persisted from the regenerated edition
+
+    def test_avoids_other_editions_subjects(self):
+        ed = {"id": 9, "user_id": 1, "status": "draft", "subject": "Mine"}
+        result, upd, cap = _run_regenerate(
+            edition=ed, others=[(9, "Mine"), (10, "Other Queued")], recent=["Past One"])
+        assert "Other Queued" in cap["avoid"] and "Past One" in cap["avoid"]
+        assert "Mine" not in cap["avoid"]  # this edition's own subject excluded
 
 
 class TestPublishScheduledEditions:

--- a/tests/unit/utilities/ai/test_newsletter_generation.py
+++ b/tests/unit/utilities/ai/test_newsletter_generation.py
@@ -72,3 +72,116 @@ class TestGenerateNewsletterEdition:
         prof = MagicMock(); prof.model_dump_json.return_value = "{}"
         with patch(f"{_AI}._call_llm", return_value=_resp(None)):
             assert ai_helper.generate_newsletter_edition(prof) is None
+
+
+class TestGenerationUsesSynthesisAndSubject:
+    def test_synthesis_replaces_raw_json_and_subject_in_prompt(self):
+        from cqc_lem.utilities.ai import ai_helper
+        prof = MagicMock(); prof.model_dump_json.return_value = "RAW_PROFILE_JSON_SHOULD_NOT_APPEAR"
+        payload = json.dumps({"title": "T", "subtitle": "S", "subject": "Planned Subject X", "body": "Body."})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)) as call:
+            out = ai_helper.generate_newsletter_edition(
+                prof, topic="desc", subject="Planned Subject X", avoid_subjects=["Avoid Me"],
+                profile_synthesis="THE VOICE BRIEF")
+        prompt = call.call_args.kwargs["messages"][1]["content"]
+        assert "THE VOICE BRIEF" in prompt
+        assert "RAW_PROFILE_JSON_SHOULD_NOT_APPEAR" not in prompt  # raw dump NOT used when synthesis given
+        assert "Planned Subject X" in prompt
+        assert "Avoid Me" in prompt
+        assert out["subject"] == "Planned Subject X"
+
+    def test_falls_back_to_raw_json_without_synthesis(self):
+        from cqc_lem.utilities.ai import ai_helper
+        prof = MagicMock(); prof.model_dump_json.return_value = "RAW_JSON_HERE"
+        payload = json.dumps({"title": "T", "subtitle": "S", "body": "Body."})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)) as call:
+            ai_helper.generate_newsletter_edition(prof, topic="desc")
+        prompt = call.call_args.kwargs["messages"][1]["content"]
+        assert "RAW_JSON_HERE" in prompt
+
+    def test_guidance_included_in_prompt(self):
+        from cqc_lem.utilities.ai import ai_helper
+        prof = MagicMock(); prof.model_dump_json.return_value = "{}"
+        payload = json.dumps({"title": "T", "subtitle": "S", "subject": "S", "body": "B."})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)) as call:
+            ai_helper.generate_newsletter_edition(prof, profile_synthesis="v", guidance="Make it about hiring")
+        prompt = call.call_args.kwargs["messages"][1]["content"]
+        assert "Make it about hiring" in prompt
+
+    def test_subject_defaults_from_passed_subject_when_model_omits(self):
+        from cqc_lem.utilities.ai import ai_helper
+        prof = MagicMock(); prof.model_dump_json.return_value = "{}"
+        payload = json.dumps({"title": "T", "subtitle": "S", "body": "B."})  # no subject key
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)):
+            out = ai_helper.generate_newsletter_edition(prof, subject="Fallback Subject", profile_synthesis="v")
+        assert out["subject"] == "Fallback Subject"
+
+
+class TestPlanNewsletterTopics:
+    def test_returns_distinct_subjects(self):
+        from cqc_lem.utilities.ai import ai_helper
+        payload = json.dumps({"editions": [
+            {"subject": "Content frameworks that scale", "angle": "foundational"},
+            {"subject": "Engagement tactics that compound", "angle": "tactical"},
+            {"subject": "Personal-brand positioning", "angle": "advanced"},
+        ]})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)):
+            out = ai_helper.plan_newsletter_topics("voice", "desc", {}, [], 3)
+        assert len(out) == 3
+        assert {o["subject"] for o in out} == {
+            "Content frameworks that scale", "Engagement tactics that compound",
+            "Personal-brand positioning"}
+        assert out[0]["angle"] == "foundational"
+
+    def test_dedups_within_response(self):
+        from cqc_lem.utilities.ai import ai_helper
+        payload = json.dumps({"editions": [
+            {"subject": "Same Topic", "angle": "a"},
+            {"subject": "same topic", "angle": "b"},  # case-insensitive duplicate dropped
+            {"subject": "Different", "angle": "c"},
+        ]})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)):
+            out = ai_helper.plan_newsletter_topics("v", "d", None, [], 3)
+        assert [o["subject"] for o in out] == ["Same Topic", "Different"]
+
+    def test_passes_prior_subjects_into_prompt(self):
+        from cqc_lem.utilities.ai import ai_helper
+        payload = json.dumps({"editions": [{"subject": "Fresh", "angle": "x"}]})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)) as call:
+            ai_helper.plan_newsletter_topics("v", "d", None, ["Old Subject A", "Old Subject B"], 1)
+        prompt = call.call_args.kwargs["messages"][1]["content"]
+        assert "Old Subject A" in prompt and "Old Subject B" in prompt
+        assert "AVOID" in prompt
+
+    def test_respects_count_cap(self):
+        from cqc_lem.utilities.ai import ai_helper
+        payload = json.dumps({"editions": [
+            {"subject": "A", "angle": "1"}, {"subject": "B", "angle": "2"},
+            {"subject": "C", "angle": "3"}]})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)):
+            out = ai_helper.plan_newsletter_topics("v", "d", None, [], 2)
+        assert len(out) == 2
+
+    def test_tolerates_json_fences(self):
+        from cqc_lem.utilities.ai import ai_helper
+        payload = "```json\n" + json.dumps({"editions": [{"subject": "S", "angle": "a"}]}) + "\n```"
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)):
+            out = ai_helper.plan_newsletter_topics("v", "d", None, [], 1)
+        assert out and out[0]["subject"] == "S"
+
+    def test_extracts_json_from_surrounding_prose(self):
+        from cqc_lem.utilities.ai import ai_helper
+        payload = "Here is the plan:\n" + json.dumps({"editions": [{"subject": "S", "angle": "a"}]})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)):
+            out = ai_helper.plan_newsletter_topics("v", "d", None, [], 1)
+        assert out and out[0]["subject"] == "S"
+
+    def test_bad_json_falls_back_empty(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("not json at all")):
+            assert ai_helper.plan_newsletter_topics("v", "d", None, [], 3) == []
+
+    def test_llm_exception_falls_back_empty(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", side_effect=Exception("boom")):
+            assert ai_helper.plan_newsletter_topics("v", "d", None, [], 3) == []

--- a/tests/unit/utilities/test_db_newsletter.py
+++ b/tests/unit/utilities/test_db_newsletter.py
@@ -181,7 +181,40 @@ class TestEditions:
             assert update_newsletter_edition(4, 1, status="approved") is True
         sql, params = cur.execute.call_args[0]
         assert "COALESCE" in sql
-        assert params == (None, None, None, "approved", 4, 1)
+        # params now include the subject slot (5th position): (title, subtitle, subject, body, status, id, user_id)
+        assert params == (None, None, None, None, "approved", 4, 1)
+
+    def test_update_persists_subject(self):
+        conn, cur = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_newsletter_edition
+            assert update_newsletter_edition(4, 1, subject="New Subject", status="draft") is True
+        sql, params = cur.execute.call_args[0]
+        assert "subject = COALESCE" in sql
+        assert params == (None, None, "New Subject", None, "draft", 4, 1)
+
+    def test_create_persists_subject(self):
+        conn, cur = _mock_conn()
+        cur.lastrowid = 88
+        import datetime
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import create_newsletter_edition
+            assert create_newsletter_edition(1, "T", "S", "B", datetime.datetime(2026, 7, 7, 13),
+                                             subject="Coherent Subject") == 88
+        sql, params = cur.execute.call_args[0]
+        assert "subject" in sql
+        assert "Coherent Subject" in params
+
+    def test_recent_subjects_dedup_history(self):
+        conn, cur = _mock_conn(fetch_all=[("Subject A",), ("Subject B",)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_recent_newsletter_subjects
+            assert get_recent_newsletter_subjects(1, limit=5) == ["Subject A", "Subject B"]
+        sql, params = cur.execute.call_args[0]
+        # Pulls published + queued + skipped history and excludes blanks.
+        assert "published" in sql and "skipped" in sql and "draft" in sql
+        assert "subject IS NOT NULL" in sql
+        assert params == (1, 5)
 
     def test_editions_due(self):
         rows = [{"id": 3, "user_id": 1, "title": "T", "subtitle": "S", "body": "B"}]


### PR DESCRIPTION
Fixes the near-duplicate, under-aligned newsletter drafts. Confirmed on production: a user's 5 queued editions were all variations of "Harness/Mastering AI for LinkedIn Growth."

## Root cause
`_topup_newsletter_drafts_for_user` (run_scheduler.py) looped `generate_newsletter_edition(profile, topic=settings.topic)` with the **same topic** every time, each edition generated independently with **no plan and no history** → duplicates. It also fed raw `profile.model_dump_json()` instead of the V48 profile synthesis → under-aligned voice.

## What changed (plan-then-write)
- **Topic-planning phase** — new `plan_newsletter_topics(...)` (lem-medium) plans N **distinct** subjects up front, aligned in priority order to: the newsletter description (primary anchor) → the author's profile synthesis (voice/expertise) → focus_topics/goals. Each subject must be materially different from the others and from history.
- **Synthesis-grounded editions** — `generate_newsletter_edition` now takes a specific `subject` + `avoid_subjects` + `profile_synthesis` (via `_voice_reference`) instead of raw JSON.
- **History/dedup** — new `subject` column (**V49**) persisted per edition; `get_recent_newsletter_subjects` (published+queued+skipped) feeds the planner + each generate call's avoid-set, and freshly chosen subjects are appended mid-loop so later ones avoid them too.
- **Light LEM soft-promo, bounded** — a `_NEWSLETTER_SOFT_PROMO_NOTE` allows an occasional, secondary tool mention (per request), and the planner caps it to at most one subject. Deliberately does NOT apply the hard anti-self-promo guardrail used for comments/posts.
- **Re-generate + Added Guidance** — Celery task `regenerate_newsletter_edition(edition_id, guidance?)` + `POST /user/newsletter-draft/regenerate`. With guidance → applies it (edits or a different take, keeping the subject as a starting point); without → AI coins a fresh distinct subject; always avoids the other editions' subjects; resets status to draft.
- **UI** — prominent **Re-generate** button + optional **Added Guidance** textarea in the review queue; "Regenerating…" state + refetch. Save/Approve kept; **Skip kept as a smaller secondary link** (decision — flag if you'd rather remove it).

## Testing
- `pytest tests/unit` → **1412 passed** (92 in the newsletter set). Covers planner distinctness/dedup/JSON-fence/prose/bad-JSON fallback, synthesis+subject in prompt (raw JSON absent), top-up plans→persists distinct subjects + feeds history, regenerate with/without guidance, endpoint auth/404, V49 get/set + recent-subjects.
- SPA `tsc --noEmit` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)