### PR TITLE
feat(newsletter): edition blueprint/variety system + Perplexity research grounding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,9 @@ OPENROUTER_API_KEY=your_openrouter_api_key
 
 # --- Perplexity (advanced search / RAG) ---
 PERPLEXITY_API_KEY=your_perplexity_api_key
+# Web research grounding for newsletter editions (lem-research alias -> Perplexity Sonar).
+# Default true; set false to generate editions from expertise only (no research call).
+NEWSLETTER_RESEARCH_ENABLED=true
 
 # --- Ollama (local + cloud model hosting) ---
 OLLAMA_API_KEY=your_ollama_api_key

--- a/.litellm/config.yaml
+++ b/.litellm/config.yaml
@@ -73,6 +73,16 @@ model_list:
       model: anthropic/claude-sonnet-4-6
       api_key: os.environ/ANTHROPIC_API_KEY
 
+  # ── RESEARCH: web-grounded current facts via Perplexity Sonar ────────────────
+  # Used by newsletter_research.research_newsletter_topic (one call per edition) to ground
+  # editions in current stats/examples. Falls back in code to the direct Perplexity helper.
+  - model_name: lem-research
+    litellm_params:
+      model: perplexity/sonar
+      api_key: os.environ/PERPLEXITY_API_KEY
+      request_timeout: 60
+      rpm: 20
+
   # ── IMAGE generation — no Ollama Cloud equivalent; use OpenAI DALL-E ─────────
   - model_name: lem-image
     litellm_params:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ tests/
 ├── unit/          Fast tests — mock all I/O
 ├── integration/   Require MySQL + Redis service containers
 └── e2e/           Require selenium/standalone-chrome
-compose/local/database/migrations/  Flyway migrations (through V48)
+compose/local/database/migrations/  Flyway migrations (through V50)
 .litellm/
 ├── config.yaml    LiteLLM model aliases and routing config
 └── complexity_router.py  Pre-call hook for lem-router model
@@ -188,7 +188,7 @@ Before merging any PR, all of the following must pass:
 - `linkedin-preview` service (external) was removed — preview is now the native `LinkedInPostPreview.tsx` component.
 - **LinkedIn SDUI:** the old `urn:`, `feed-shared-*`, and `comments-comment-*` DOM anchors are gone. Prefer `data-testid` / `aria-label` selectors via `find_first`/`click_first`. The comment composer has NO `<form>` — "submit" means clicking the Comment/Post button next to the composer (`_composer_submitted`), and the comment overflow "…" menu is hover-hidden.
 - **Emoji in Selenium:** ChromeDriver `send_keys` throws on non-BMP emoji — strip them before typing with `_strip_non_bmp()`.
-- **ENUM columns:** `logs.action_type` (and other status columns) are MySQL ENUMs. Adding a new value requires a migration — e.g. V37 added `'followup'` to `logs.action_type`. Migrations live in `compose/local/database/migrations/` and currently run through **V48** (V46 added the `commented_posts` at-most-once claim ledger, V47 added engagement focus_topics/business_goals/personal_goals, V48 added `profiles.synthesis`/`synthesis_generated_at` — the cached durable voice brief).
+- **ENUM columns:** `logs.action_type` (and other status columns) are MySQL ENUMs. Adding a new value requires a migration — e.g. V37 added `'followup'` to `logs.action_type`. Migrations live in `compose/local/database/migrations/` and currently run through **V50** (V48 added `profiles.synthesis`/`synthesis_generated_at` — the cached durable voice brief, V49 added `newsletter_editions.subject` for topic dedup, V50 added `newsletter_editions.format`/`hook_style`/`opening_line`/`blueprint` — the edition SHAPE history for format/hook/opener rotation).
 - **Proxy auth:** proxies are authenticated by the runtime MV3 extension (`_build_proxy_auth_extension_b64`), not by URL-embedded credentials — MV2 background pages that used to do this are disabled in Chrome 149+.
 
 ## Git Safety & Multi-Agent Concurrency Rules

--- a/compose/local/database/migrations/V50__add_newsletter_edition_blueprint.sql
+++ b/compose/local/database/migrations/V50__add_newsletter_edition_blueprint.sql
@@ -1,0 +1,11 @@
+-- Persist each edition's SHAPE, not just its subject. V49's subject history fixed repeated TOPICS,
+-- but regenerated editions still all opened with the same rhetorical template and followed the same
+-- skeleton. Storing the assigned format + hook style + the actual opening line (+ the compact
+-- blueprint JSON for audit/UI) lets the planner and regenerator rotate away from recently used
+-- SHAPES and openers across runs — every edition unique in structure, hook, and rhythm, not just
+-- subject. Nullable so existing editions backfill cleanly.
+ALTER TABLE newsletter_editions
+    ADD COLUMN `format` VARCHAR(50) NULL AFTER subject,
+    ADD COLUMN hook_style VARCHAR(50) NULL AFTER `format`,
+    ADD COLUMN opening_line VARCHAR(500) NULL AFTER hook_style,
+    ADD COLUMN blueprint JSON NULL AFTER opening_line;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -308,6 +308,8 @@ services:
       - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY}
       - OLLAMA_CLOUD_URL=${OLLAMA_CLOUD_URL}
       - OLLAMA_CLOUD_API_KEY=${OLLAMA_CLOUD_API_KEY}
+      # lem-research (newsletter research grounding) routes to Perplexity Sonar
+      - PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')\" 2>/dev/null || exit 1"]

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -150,10 +150,13 @@ def _topup_newsletter_drafts_for_user(user_id: int, now: datetime,
                                       count_pending_newsletter_editions,
                                       get_latest_edition_scheduled_for, create_newsletter_edition,
                                       get_pending_newsletter_editions, get_recent_newsletter_subjects,
+                                      get_recent_newsletter_blueprint_history,
                                       get_engagement_preferences)
     from cqc_lem.utilities.linkedin.helper import load_profile_for_user
     from cqc_lem.utilities.ai.ai_helper import (generate_newsletter_edition, plan_newsletter_topics,
                                                 get_or_create_profile_synthesis)
+    from cqc_lem.utilities.ai.newsletter_blueprint import compact_blueprint
+    from cqc_lem.utilities.ai.newsletter_research import research_newsletter_topic
     from cqc_lem.utilities.newsletter import upcoming_publish_slots, should_generate_now
     from cqc_lem.utilities.notifications import notify_newsletter_draft_ready
 
@@ -192,10 +195,19 @@ def _topup_newsletter_drafts_for_user(user_id: int, now: datetime,
     prior_subjects = list(dict.fromkeys(
         [s for s in queued_subjects if s] + get_recent_newsletter_subjects(user_id, limit=20)))
 
-    # PLAN a coherent, distinct sequence of subjects up front (one shot), THEN write one edition per
-    # planned subject. Falls back to single-topic generation when planning yields nothing.
+    # SHAPE history (formats/hook styles/actual opening lines of recent editions, queued included) —
+    # fed to the planner so new editions rotate away from recently used shapes, and to the writer so
+    # no two editions open with the same line or rhetorical template.
+    shape_history = get_recent_newsletter_blueprint_history(user_id, limit=12)
+    recent_formats = [h.get("format") for h in shape_history if h.get("format")]
+    recent_hooks = [h.get("hook_style") for h in shape_history if h.get("hook_style")]
+    recent_openers = [h.get("opening_line") for h in shape_history if h.get("opening_line")]
+
+    # PLAN a coherent, distinct sequence of edition BLUEPRINTS up front (one shot), THEN write one
+    # edition per blueprint. Falls back to single-topic generation when planning yields nothing.
     planned = plan_newsletter_topics(synthesis or "", description or "", prefs, prior_subjects,
-                                     len(slots))
+                                     len(slots), recent_formats=recent_formats,
+                                     recent_hook_styles=recent_hooks)
 
     generated = 0
     for i, slot in enumerate(slots):
@@ -208,17 +220,29 @@ def _topup_newsletter_drafts_for_user(user_id: int, now: datetime,
         # Even the fallback path stays distinct: avoid every other planned subject + all prior ones.
         avoid = prior_subjects + [p["subject"] for j, p in enumerate(planned)
                                   if j != i and p.get("subject")]
+        # ONE research call per edition: current stats/examples for THIS subject, woven into the
+        # body as source material. Degrades to empty findings (write from expertise) on any failure.
+        research = research_newsletter_topic(
+            (plan.get("subject") if plan else None) or description or "",
+            blueprint=plan, newsletter_description=description, prefs=prefs)
         edition = generate_newsletter_edition(profile, topic=description, prefs=prefs,
                                               subject=subject_ctx, avoid_subjects=avoid,
-                                              profile_synthesis=synthesis)
+                                              profile_synthesis=synthesis, blueprint=plan,
+                                              avoid_openers=recent_openers, research=research)
         if not edition:
             break
         edition_subject = edition.get("subject") or (plan["subject"] if plan else None)
         if not create_newsletter_edition(user_id, edition["title"], edition.get("subtitle"),
-                                          edition["body"], slot, subject=edition_subject):
+                                          edition["body"], slot, subject=edition_subject,
+                                          edition_format=edition.get("format"),
+                                          hook_style=edition.get("hook_style"),
+                                          opening_line=edition.get("opening_line"),
+                                          blueprint=compact_blueprint(plan) if plan else None):
             break  # duplicate slot / db error → stop this user's run
         if edition_subject:
             prior_subjects.append(edition_subject)  # subsequent iterations avoid it too
+        if edition.get("opening_line"):
+            recent_openers.insert(0, edition["opening_line"])  # later slots avoid this opener too
         notify_newsletter_draft_ready(user_id, edition["title"], slot)
         generated += 1
     return generated
@@ -272,10 +296,14 @@ def regenerate_newsletter_edition(edition_id: int, guidance: str = None):
     'draft'."""
     from cqc_lem.utilities.db import (get_newsletter_edition, get_newsletter_settings,
                                       get_pending_newsletter_editions, get_recent_newsletter_subjects,
+                                      get_recent_newsletter_blueprint_history,
                                       get_engagement_preferences, update_newsletter_edition)
     from cqc_lem.utilities.linkedin.helper import load_profile_for_user
     from cqc_lem.utilities.ai.ai_helper import (generate_newsletter_edition,
                                                 get_or_create_profile_synthesis)
+    from cqc_lem.utilities.ai.newsletter_blueprint import (build_regeneration_blueprint,
+                                                           compact_blueprint)
+    from cqc_lem.utilities.ai.newsletter_research import research_newsletter_topic
 
     edition = get_newsletter_edition(edition_id)
     if not edition or edition.get("status") not in ("draft", "approved"):
@@ -291,13 +319,29 @@ def regenerate_newsletter_edition(edition_id: int, guidance: str = None):
               if e.get("id") != edition_id and e.get("subject")]
     avoid = list(dict.fromkeys([s for s in others if s] + get_recent_newsletter_subjects(user_id, limit=20)))
 
+    # Rotate the rewrite's SHAPE too: pick a fresh format/hook/CTA away from the recent history —
+    # including this edition's own previous shape — so regeneration changes form, not just words.
+    # Free-text guidance may name a format (e.g. "make it a case study"); the builder honors it.
+    shape_history = get_recent_newsletter_blueprint_history(user_id, limit=12)
+    recent_formats = [h.get("format") for h in shape_history if h.get("format")]
+    recent_hooks = [h.get("hook_style") for h in shape_history if h.get("hook_style")]
+    recent_openers = [h.get("opening_line") for h in shape_history if h.get("opening_line")]
+
     # With guidance we keep the current subject as the starting point (the guidance may edit it or
     # redirect entirely). With NO guidance the AI decides a fresh, distinct subject (subject=None).
     subject = edition.get("subject") if (guidance and guidance.strip()) else None
+    blueprint = build_regeneration_blueprint(subject=subject, recent_formats=recent_formats,
+                                             recent_hook_styles=recent_hooks, guidance=guidance)
+    # ONE research call per regenerate — grounds the rewrite in current facts; empty on failure.
+    research = research_newsletter_topic(subject or settings.get("topic") or "",
+                                         blueprint=blueprint,
+                                         newsletter_description=settings.get("topic"), prefs=prefs)
     try:
         new_ed = generate_newsletter_edition(profile, topic=settings.get("topic"), prefs=prefs,
                                              subject=subject, avoid_subjects=avoid,
-                                             profile_synthesis=synthesis, guidance=guidance)
+                                             profile_synthesis=synthesis, guidance=guidance,
+                                             blueprint=blueprint, avoid_openers=recent_openers,
+                                             research=research)
     except Exception as e:
         log_warning("Newsletter regeneration failed", exc=e, user_id=user_id,
                     task_name="regenerate_newsletter_edition")
@@ -306,7 +350,12 @@ def regenerate_newsletter_edition(edition_id: int, guidance: str = None):
         return f"Regeneration produced nothing for edition {edition_id}"
     update_newsletter_edition(edition_id, user_id, title=new_ed["title"],
                               subtitle=new_ed.get("subtitle"), body=new_ed["body"],
-                              subject=new_ed.get("subject") or subject, status="draft")
+                              subject=new_ed.get("subject") or subject, status="draft",
+                              edition_format=new_ed.get("format"),
+                              hook_style=new_ed.get("hook_style"),
+                              opening_line=new_ed.get("opening_line"),
+                              blueprint=compact_blueprint(
+                                  {**blueprint, "subject": new_ed.get("subject") or subject}))
     log_info("Regenerated newsletter edition", user_id=user_id,
              task_name="regenerate_newsletter_edition")
     return f"Regenerated newsletter edition {edition_id}"

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -45,6 +45,8 @@ export type NewsletterEdition = {
   title: string | null
   subtitle: string | null
   subject?: string | null
+  format?: string | null
+  hook_style?: string | null
   body: string | null
   status: string
   scheduled_for: string | null

--- a/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
+++ b/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
@@ -11,6 +11,9 @@ const STATUS_COLORS: Record<string, string> = {
   approved: 'bg-green-100 text-green-700',
 }
 
+// e.g. "case_study" -> "Case Study" for the format/hook badges.
+const prettyKey = (k: string) => k.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+
 export default function NewsletterQueue({ userTimezone }: { userTimezone: string }) {
   const { user, sessionToken } = useAuth()
   const qc = useQueryClient()
@@ -161,6 +164,20 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
             </div>
             <p className="text-sm font-medium text-gray-800 truncate">{e.title || 'Untitled edition'}</p>
             {e.subtitle && <p className="text-xs text-gray-500 line-clamp-1">{e.subtitle}</p>}
+            {(e.format || e.hook_style) && (
+              <div className="flex flex-wrap gap-1 mt-1.5">
+                {e.format && (
+                  <span className="px-1.5 py-0.5 rounded bg-indigo-50 text-indigo-600 text-[10px] font-medium uppercase tracking-wide">
+                    {prettyKey(e.format)}
+                  </span>
+                )}
+                {e.hook_style && (
+                  <span className="px-1.5 py-0.5 rounded bg-purple-50 text-purple-600 text-[10px] font-medium uppercase tracking-wide">
+                    {prettyKey(e.hook_style)} hook
+                  </span>
+                )}
+              </div>
+            )}
           </div>
         ))}
       </div>
@@ -200,7 +217,7 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
                 Added Guidance <span className="font-normal text-gray-400">(optional)</span>
               </label>
               <textarea value={guidance} onChange={(e) => setGuidance(e.target.value)} rows={2}
-                placeholder="What should change and why? Leave blank to let AI pick a fresh, distinct take."
+                placeholder="What should change and why? You can name a format (e.g. case study, listicle, contrarian). Leave blank for a fresh, distinct take."
                 disabled={busy}
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 disabled:opacity-50" />
               <button type="button" onClick={() => regenerateMutation.mutate()} disabled={busy}

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -7,6 +7,7 @@ import openai
 import replicate
 from cqc_lem import assets_dir
 from cqc_lem.utilities.ai.client import client
+from cqc_lem.utilities.ai import newsletter_blueprint as _blueprint
 from cqc_lem.utilities.ai.tools import search_recent_news, search_with_perplexity
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.logger import myprint, log_debug, log_error, log_warning
@@ -469,27 +470,38 @@ _NEWSLETTER_SOFT_PROMO_NOTE = (
 
 
 def plan_newsletter_topics(profile_synthesis: str, newsletter_description: str, prefs: dict = None,
-                           prior_subjects: list = None, count: int = 1) -> list:
-    """Plan a sequence of `count` DISTINCT newsletter subjects that form a natural, coherent
-    progression BEFORE any edition is written — so the queued editions build on each other instead of
-    each independently rehashing the newsletter's single description (the near-duplicate bug).
+                           prior_subjects: list = None, count: int = 1,
+                           recent_formats: list = None, recent_hook_styles: list = None) -> list:
+    """Plan a sequence of `count` DISTINCT edition BLUEPRINTS — subject + angle + format + hook_style
+    + cta_style (+ structure attached in code) — BEFORE any edition is written, so the queued
+    editions differ in TOPIC and in SHAPE instead of each rehashing the same rhetorical template.
 
     Alignment (in priority order): the newsletter's DESCRIPTION/promise, the author's durable voice &
     expertise SYNTHESIS, then their declared focus topics/goals. `prior_subjects` (already-queued,
-    published, and recently-skipped subjects) are AVOIDED so nothing repeats. Each item is
-    {"subject": str, "angle": str}. Robust JSON parsing; returns [] on any failure so the caller can
-    gracefully fall back to single-topic generation."""
+    published, and recently-skipped subjects) are AVOIDED so no topic repeats; `recent_formats` /
+    `recent_hook_styles` (most-recent first) are AVOIDED so no SHAPE repeats — and
+    enforce_blueprint_variety GUARANTEES that in code regardless of what the model returns. Each item
+    is {"subject", "angle", "format", "hook_style", "cta_style", "structure"}. Robust JSON parsing;
+    returns [] on any failure so the caller can gracefully fall back to single-topic generation."""
     import json as _json
     count = max(1, int(count))
     prior = [str(s).strip() for s in (prior_subjects or []) if str(s).strip()]
     avoid_block = ("\n\nAlready-covered subjects to AVOID repeating (cover materially different "
                    "ground):\n- " + "\n- ".join(prior) + "\n") if prior else ""
+    recent_f = [str(f).strip() for f in (recent_formats or []) if str(f).strip()]
+    recent_h = [str(h).strip() for h in (recent_hook_styles or []) if str(h).strip()]
+    recent_shape_block = ""
+    if recent_f or recent_h:
+        recent_shape_block = ("\nRecently used FORMATS (most recent first) — do NOT assign these to "
+                              "the first new editions: " + ", ".join(recent_f[:5] or ["(none)"]) +
+                              "\nRecently used HOOK STYLES (most recent first) — same rule: "
+                              + ", ".join(recent_h[:5] or ["(none)"]) + "\n")
     system_prompt = {
         "role": "system",
         "content": (
             "You are the EDITORIAL PLANNER for a LinkedIn creator's newsletter. Plan a sequence of "
-            f"exactly {count} DISTINCT edition subjects that together form a COHERENT PROGRESSION — "
-            "each edition should advance the reader, never repeat a previous one.\n\n"
+            f"exactly {count} DISTINCT edition BLUEPRINTS that together form a COHERENT PROGRESSION — "
+            "each edition should advance the reader, never repeat a previous one in topic OR shape.\n\n"
             "Ground every subject in, in priority order:\n"
             "1. The newsletter's stated purpose/description (its promise to subscribers) — the PRIMARY anchor.\n"
             "2. The author's durable voice & expertise (their synthesis) — pick subjects THIS author can "
@@ -501,20 +513,25 @@ def plan_newsletter_topics(profile_synthesis: str, newsletter_description: str, 
             "regurgitated fluff.\n"
             "- Prefer a natural arc (e.g. foundational -> tactical -> advanced, or problem -> framework "
             "-> execution).\n"
+            "- VARIETY OF SHAPE IS MANDATORY: no two consecutive editions may share a format or a "
+            "hook_style, and avoid the recently used formats/hook styles the user lists. Assign the "
+            "format and hook style that BEST FIT each subject while honoring that rotation.\n"
             "- Subjects are about the READER'S growth and the newsletter's topic — NOT about the "
             "author's own products. " + _NEWSLETTER_SOFT_PROMO_NOTE + " At most ONE of the planned "
             "subjects may LIGHTLY touch tools/tooling; keep every other subject tool-agnostic.\n\n"
+            + _blueprint.blueprint_options_text() + "\n\n"
             f"Return ONLY valid JSON with exactly this shape and exactly {count} items:\n"
             '{"editions": [{"subject": "short specific subject (<= ~120 chars)", "angle": "the '
-            'distinct angle/takeaway for this edition"}]}'
+            'distinct angle/takeaway for this edition", "format": "<format key>", '
+            '"hook_style": "<hook style key>", "cta_style": "<cta style key>"}]}'
         ),
     }
     user_prompt = {
         "role": "user",
         "content": (f"Newsletter description / promise:\n{(newsletter_description or '').strip() or '(not provided)'}\n\n"
                     f"Author voice & expertise synthesis:\n{(profile_synthesis or '').strip() or '(not provided)'}\n"
-                    f"{_focus_directive(prefs)}{avoid_block}\n"
-                    f"Plan exactly {count} distinct subjects now."),
+                    f"{_focus_directive(prefs)}{avoid_block}{recent_shape_block}\n"
+                    f"Plan exactly {count} distinct blueprints now."),
     }
     try:
         response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt],
@@ -552,15 +569,20 @@ def plan_newsletter_topics(profile_synthesis: str, newsletter_description: str, 
         if not subject or subject.lower() in seen:
             continue
         seen.add(subject.lower())
-        planned.append({"subject": subject, "angle": str(it.get("angle") or "").strip()[:500]})
-    return planned[:count]
+        planned.append({"subject": subject, "angle": str(it.get("angle") or "").strip()[:500],
+                        "format": it.get("format"), "hook_style": it.get("hook_style"),
+                        "cta_style": it.get("cta_style")})
+    # The prompt REQUESTS shape rotation; this GUARANTEES it — normalizes formats/hooks/CTAs to known
+    # keys, reassigns any consecutive/recent repeats, and attaches each format's structure skeleton.
+    return _blueprint.enforce_blueprint_variety(planned[:count], recent_formats, recent_hook_styles)
 
 
 def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
                                 blog_content: str = None, prefs: dict = None,
                                 subject: str = None, avoid_subjects: list = None,
                                 profile_synthesis: str = None,
-                                guidance: str = None) -> "dict | None":
+                                guidance: str = None, blueprint: dict = None,
+                                avoid_openers: list = None, research: dict = None) -> "dict | None":
     """Generate one substantial LinkedIn newsletter edition in the author's voice, repurposing the
     author's blog content when provided. Aims for ~800–1200 words with a strong hook, 3–5 developed
     sections, a takeaways block, and a reply-driving CTA — worth an email, not a skeleton. Body is
@@ -568,10 +590,15 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
 
     `subject` is the SPECIFIC planned subject/angle for THIS edition (from plan_newsletter_topics);
     `topic` remains the newsletter's overall description/theme (context). `avoid_subjects` lists the
-    other editions' subjects so this one stays distinct. Voice comes from the durable
-    `profile_synthesis` (falls back to the guarded full profile JSON only when none supplied).
-    `guidance` is optional free-text steering for a regeneration (edit the same subject or take a
-    completely different direction). Returns {'title','subtitle','subject','body'} or None."""
+    other editions' subjects so this one stays distinct. `blueprint` assigns THIS edition's shape
+    (format + structure skeleton + hook style + CTA style — see newsletter_blueprint) and
+    `avoid_openers` lists prior editions' actual opening lines, so no two editions share a rhetorical
+    template. `research` ({'findings','sources'} from research_newsletter_topic) is woven in as
+    source material — specific numbers/examples over vague claims, no links in the body. Voice comes
+    from the durable `profile_synthesis` (falls back to the guarded full profile JSON only when none
+    supplied). `guidance` is optional free-text steering for a regeneration (edit the same subject or
+    take a completely different direction). Returns {'title','subtitle','subject','body',
+    'format','hook_style','cta_style','opening_line'} or None."""
     import json as _json
     src = f"\n\nSource material to repurpose (from the author's blog):\n{blog_content[:4000]}" if blog_content else ""
     topic_line = f"Newsletter overall theme/description: {topic}\n" if topic else ""
@@ -580,8 +607,21 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
     avoid = [str(s).strip() for s in (avoid_subjects or []) if str(s).strip()]
     avoid_line = ("Do NOT overlap with these other editions' subjects — cover DISTINCT ground:\n- "
                   + "\n- ".join(avoid) + "\n") if avoid else ""
+    openers = [str(o).strip() for o in (avoid_openers or []) if str(o).strip()]
+    openers_line = ("Previous editions OPENED with these exact lines. Your opening must NOT reuse or "
+                    "resemble ANY of them — different wording, different rhetorical device, different "
+                    "rhythm:\n- " + "\n- ".join(openers[:10]) + "\n") if openers else ""
     guidance_line = ("\nUSER GUIDANCE for this rewrite — apply it. It may ask for edits to the same "
                      f"subject or a COMPLETELY different take:\n{guidance.strip()}\n") if guidance and guidance.strip() else ""
+    findings = str((research or {}).get("findings") or "").strip()
+    research_block = (
+        "\n\nSOURCE MATERIAL — current research findings for this subject. Ground the edition in "
+        "these: weave the specific numbers, dates, and named examples into the prose naturally "
+        "(specific beats vague). Do NOT invent statistics beyond this material. Do NOT paste URLs or "
+        "external links into the body — LinkedIn suppresses off-platform links; you may name a "
+        "source (publication, company, researcher) in prose when natural. Strip any citation markers "
+        "like [1].\n" + findings[:3500] + "\n") if findings else ""
+    blueprint_block = _blueprint.blueprint_directive(blueprint)
     system_prompt = {
         "role": "system",
         "content": """You are a LinkedIn newsletter ghostwriter for the profile user. Write ONE
@@ -612,7 +652,9 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
         - Use short paragraphs and blank lines between them for white space and readability.
 
         VOICE: the author's authentic voice and expertise, confident and human. No emojis unless the
-        author clearly uses them. """ + _NEWSLETTER_SOFT_PROMO_NOTE + """
+        author clearly uses them. NEVER fabricate statistics, studies, or fake specifics — any number
+        you state must come from provided source material or be genuinely well-established; with no
+        source material, write from expertise and lived reasoning instead of invented data. """ + _NEWSLETTER_SOFT_PROMO_NOTE + """
 
         Return ONLY valid JSON with exactly these keys:
         {"title": "...", "subtitle": "...", "subject": "...", "body": "..."}
@@ -621,12 +663,13 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
           (for LinkedIn's edition-description field). Plain text, no markdown.
         - subject: a short (<= ~120 char) phrase naming THIS edition's specific subject/angle, for
           internal dedup history (echo the given subject when one is provided).
-        - body: the full plain-text article with real line breaks (\\n) as described above.""",
+        - body: the full plain-text article with real line breaks (\\n) as described above.""" + blueprint_block,
     }
     user_prompt = {"role": "user",
                    "content": f"Author voice reference (TONE + CREDIBILITY only):\n"
                               f"{_voice_reference(profile, profile_synthesis)}\n\n"
-                              f"{topic_line}{subject_line}{avoid_line}{guidance_line}{src}"
+                              f"{topic_line}{subject_line}{avoid_line}{openers_line}{guidance_line}{src}"
+                              f"{research_block}"
                               f"{_focus_directive(prefs)}{_style_directive(prefs)}"}
     response = _call_llm(model="lem-complex", messages=[system_prompt, user_prompt],
                          temperature=round(random.uniform(0.5, 0.7), 2))
@@ -634,6 +677,15 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
     if not content:
         return None
     _default_subject = (subject or topic or "").strip()[:500]
+    # The edition's shape is persisted alongside it so the planner/regenerator can rotate away from
+    # recently used formats, hook styles, AND actual opening lines — not just subjects.
+    shape = {"format": _blueprint.normalize_format((blueprint or {}).get("format")),
+             "hook_style": _blueprint.normalize_hook_style((blueprint or {}).get("hook_style")),
+             "cta_style": _blueprint.normalize_cta_style((blueprint or {}).get("cta_style"))}
+
+    def _opening_line(text: str) -> str:
+        return next((ln.strip() for ln in text.splitlines() if ln.strip()), "")[:500]
+
     try:
         data = _json.loads(content)
         if data.get("title") and data.get("body"):
@@ -643,14 +695,16 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
             if not subtitle:
                 subtitle = (subject or topic or title).strip()[:150]
             out_subject = str(data.get("subject") or "").strip()[:500] or _default_subject or title[:500]
-            return {"title": title, "subtitle": subtitle, "subject": out_subject, "body": body}
+            return {"title": title, "subtitle": subtitle, "subject": out_subject, "body": body,
+                    "opening_line": _opening_line(body), **shape}
     except (ValueError, TypeError, AttributeError):
         pass
     parts = content.strip().split("\n", 1)   # fallback: first line = title, remainder = body
     title = parts[0].strip()[:255]
     body = _clean_newsletter_body(parts[1].strip() if len(parts) > 1 else content.strip())
     return {"title": title, "subtitle": (subject or topic or title).strip()[:150],
-            "subject": _default_subject or title[:500], "body": body}
+            "subject": _default_subject or title[:500], "body": body,
+            "opening_line": _opening_line(body), **shape}
 
 
 def generate_group_post(profile: "LinkedInProfile", group_name: str = None, prefs: dict = None,

--- a/src/cqc_lem/utilities/ai/newsletter_blueprint.py
+++ b/src/cqc_lem/utilities/ai/newsletter_blueprint.py
@@ -1,0 +1,368 @@
+"""Edition BLUEPRINT system: named, testable sets of content FORMATS (archetypes), opening HOOK
+styles, per-format STRUCTURE skeletons, and CTA styles — plus the variety rules that GUARANTEE
+consecutive editions never share a format or hook style. The subject dedup (V49) fixed repeated
+topics; this fixes repeated SHAPE — every planned edition gets an explicit
+{subject, angle, format, hook_style, structure, cta_style} blueprint the writer must follow, so no
+two neighboring editions open the same way or read from the same skeleton."""
+
+from typing import Optional
+
+# How many most-recent historical formats/hook styles a new edition must also avoid (beyond the
+# strict no-consecutive-repeat rule). 3 keeps rotation fresh while 8 options stay pickable.
+_AVOID_WINDOW = 3
+
+FORMATS: dict = {
+    "deep_dive": {
+        "label": "Deep Dive / How-To",
+        "guidance": ("Teach ONE topic exhaustively enough that the reader can act without further "
+                     "reading. Action-oriented section headers; every claim backed by an example, "
+                     "number, or step — depth is the whole value."),
+        "structure": [
+            "Hook/lede in the assigned hook style",
+            "Why this matters right now — the stakes and the cost of getting it wrong",
+            "The core idea, explained through one concrete, worked example",
+            "Going deeper: the nuances, second-order effects, or common failure modes most people miss",
+            "How to apply it — specific, sequential steps the reader can run this week",
+            "Key takeaways — 3-5 crisp lines the reader could screenshot",
+            "CTA in the assigned CTA style",
+        ],
+    },
+    "framework": {
+        "label": "Framework / Playbook",
+        "guidance": ("Package the author's expertise into a NAMED, memorable framework (give it a "
+                     "sticky name). Walk each part with an example, and be honest about where the "
+                     "framework breaks — limits build trust."),
+        "structure": [
+            "Hook/lede in the assigned hook style",
+            "The recurring problem this framework solves and why ad-hoc approaches fail",
+            "Name the framework and give a one-line overview of its parts",
+            "Part-by-part walkthrough — each part gets its own subhead, explanation, and example",
+            "When it breaks: the situations where the framework does NOT apply",
+            "Key takeaways — the framework recapped in screenshot form",
+            "CTA in the assigned CTA style",
+        ],
+    },
+    "case_study": {
+        "label": "Case Study / Story Breakdown",
+        "guidance": ("A real problem→solution→outcome narrative with SPECIFIC numbers. The subject of "
+                     "the story is the hero; the author is the guide. Concrete beats abstract advice "
+                     "every time."),
+        "structure": [
+            "Hook/lede in the assigned hook style — drop the reader into the moment",
+            "The setup: who was involved, what they were trying to do, what was at stake",
+            "The turning point: what went wrong, or what forced a change",
+            "What was actually done, step by step — decisions, trade-offs, dead ends included",
+            "The outcome, with specific numbers or observable results",
+            "The transferable lessons — what the reader can apply without living the story",
+            "CTA in the assigned CTA style",
+        ],
+    },
+    "contrarian": {
+        "label": "Contrarian / Myth-Bust",
+        "guidance": ("Challenge a piece of conventional wisdom the audience genuinely believes. State "
+                     "the common view FAIRLY before dismantling it with evidence — a straw man kills "
+                     "credibility; a steel man builds it."),
+        "structure": [
+            "Hook/lede in the assigned hook style — surface the belief being challenged",
+            "The conventional wisdom, stated fairly and at its strongest",
+            "Why it is wrong or incomplete — evidence, data, or lived counterexamples",
+            "The better mental model to replace it",
+            "What to do differently starting Monday morning",
+            "Key takeaways — the old belief vs. the new model, side by side",
+            "CTA in the assigned CTA style",
+        ],
+    },
+    "listicle": {
+        "label": "Tactical Listicle",
+        "guidance": ("A numbered list of 5-7 parallel, equally-developed items — tips, mistakes, or "
+                     "tools. Each item: a clear header line, why it matters, how to do it, and a "
+                     "quick example. Highly scannable; the number in the title must match."),
+        "structure": [
+            "Hook/lede in the assigned hook style, ending with the promise of the list",
+            "The numbered items (5-7), each with its own header line, the why, the how, and a quick example",
+            "Which single item to start with if the reader only does one thing",
+            "CTA in the assigned CTA style",
+        ],
+    },
+    "teardown": {
+        "label": "Teardown / Analysis",
+        "guidance": ("Pick one real artifact — a launch, a post, a strategy, a trend — and dissect it "
+                     "publicly: what works, what fails, and why. The reader learns judgment by "
+                     "watching the author exercise it."),
+        "structure": [
+            "Hook/lede in the assigned hook style — introduce the artifact under the knife",
+            "What we are analyzing and why it is instructive for this audience",
+            "Section-by-section breakdown: what works, what does not, and the reasoning behind each call",
+            "The transferable principles the reader can steal for their own work",
+            "Key takeaways — the principles in screenshot form",
+            "CTA in the assigned CTA style",
+        ],
+    },
+    "roundup": {
+        "label": "Curated Roundup + Commentary",
+        "guidance": ("3-5 recent developments or ideas, curated for THIS audience. The value is the "
+                     "author's TAKE on each — never just summarize; say what it means and what to do "
+                     "about it. Close by naming the bigger pattern connecting them."),
+        "structure": [
+            "Hook/lede in the assigned hook style — the theme connecting the items",
+            "3-5 developments or ideas, each with: what happened, why it matters to this reader, and the author's take",
+            "The bigger pattern across all of them — the thesis the items add up to",
+            "Key takeaways — what to watch and what to do",
+            "CTA in the assigned CTA style",
+        ],
+    },
+    "personal_lesson": {
+        "label": "Personal Story → Lesson",
+        "guidance": ("One true story from the author's own experience, told with sensory-specific "
+                     "detail, that lands on a transferable principle. Vulnerability first, lesson "
+                     "second — never a humble-brag."),
+        "structure": [
+            "Hook/lede in the assigned hook style — open inside the story",
+            "The full story, with specific details (when, where, who, what it cost)",
+            "The moment of realization — where the author's thinking changed",
+            "The principle extracted from the story, stated plainly",
+            "How the reader applies the principle without living the story",
+            "CTA in the assigned CTA style",
+        ],
+    },
+}
+
+HOOK_STYLES: dict = {
+    "question": {
+        "label": "Pointed Question",
+        "guidance": ("Open with ONE pointed question the reader has genuinely asked themselves — "
+                     "specific to their situation, not a rhetorical 'Have you ever...?' cliché. Then "
+                     "one line acknowledging why it is hard to answer."),
+    },
+    "surprising_stat": {
+        "label": "Surprising Statistic",
+        "guidance": ("Open with a specific, current NUMBER that upends an assumption, then one line "
+                     "on what it means for the reader. Use a real figure from the source material — "
+                     "never invent one."),
+    },
+    "bold_claim": {
+        "label": "Bold / Contrarian Claim",
+        "guidance": ("Open with a confident, defensible claim most of the audience currently "
+                     "disagrees with — then spend the edition earning it. The unresolved tension is "
+                     "what pulls the reader through."),
+    },
+    "micro_story": {
+        "label": "Micro-Story",
+        "guidance": ("Open mid-scene in a real moment — a time, a place, a tension — in 2-3 short "
+                     "lines before zooming out to the point. Specific detail ('a Tuesday in March', "
+                     "'the third slide') is what makes it land."),
+    },
+    "pattern_interrupt": {
+        "label": "Pattern Interrupt",
+        "guidance": ("Open with a line the reader does NOT expect from this newsletter — a blunt "
+                     "confession, an unusual image, a one-word sentence — that breaks the scroll "
+                     "rhythm, then bridge to the topic within two lines."),
+    },
+    "direct_promise": {
+        "label": "Direct Promise",
+        "guidance": ("Open by naming EXACTLY what the reader will be able to do by the end of this "
+                     "edition — a specific outcome with a specific scope, zero hype words."),
+    },
+    "common_frustration": {
+        "label": "Voiced Frustration",
+        "guidance": ("Open by voicing the exact frustration the reader feels but has not articulated "
+                     "— in their words, not the author's jargon — so they feel seen before being "
+                     "taught."),
+    },
+    "mistake_confession": {
+        "label": "Mistake Confession",
+        "guidance": ("Open by owning a specific mistake and what it cost — a real number, a real "
+                     "consequence. Vulnerability first; the lesson comes after the reader trusts the "
+                     "scar is real."),
+    },
+}
+
+CTA_STYLES: dict = {
+    "reply_question": {
+        "label": "Reply-Driving Question",
+        "guidance": ("Close with ONE open, specific question about the reader's own situation and "
+                     "explicitly invite them to answer in the comments — specific questions get "
+                     "replies; 'thoughts?' gets silence."),
+    },
+    "challenge": {
+        "label": "This-Week Challenge",
+        "guidance": ("Close by assigning one small, concrete action to take this week, and invite the "
+                     "reader to report back in the comments with what happened."),
+    },
+    "debate": {
+        "label": "Invite Disagreement",
+        "guidance": ("Close by inviting pushback — name the most likely objection and ask readers to "
+                     "tell you where you're wrong in the comments. Disagreement is engagement."),
+    },
+    "share_forward": {
+        "label": "Share With Someone",
+        "guidance": ("Close by asking the reader to share this edition with ONE specific kind of "
+                     "person who needs it right now, and invite new readers to subscribe."),
+    },
+    "teaser_next": {
+        "label": "Next-Edition Teaser",
+        "guidance": ("Close by teasing what the NEXT edition covers — a specific open loop worth "
+                     "subscribing for — and invite readers to subscribe so they don't miss it."),
+    },
+    "poll_prompt": {
+        "label": "Either/Or Poll",
+        "guidance": ("Close with a crisp either/or question (option A vs option B) readers can answer "
+                     "in one comment — a low-effort on-ramp that starts real conversations."),
+    },
+}
+
+
+def _normalize(value, options: dict) -> Optional[str]:
+    if not value:
+        return None
+    key = str(value).strip().lower().replace("-", "_").replace(" ", "_").replace("/", "_")
+    if key in options:
+        return key
+    # Tolerate labels or partial names ("Case Study", "deep dive how-to") from the LLM.
+    for k, meta in options.items():
+        if k in key or key in k or key == meta["label"].strip().lower().replace("-", "_").replace(" ", "_").replace("/", "_"):
+            return k
+    plain = str(value).strip().lower()
+    for k, meta in options.items():
+        if plain and (plain in meta["label"].lower() or meta["label"].lower() in plain):
+            return k
+    return None
+
+
+def normalize_format(value) -> Optional[str]:
+    return _normalize(value, FORMATS)
+
+
+def normalize_hook_style(value) -> Optional[str]:
+    return _normalize(value, HOOK_STYLES)
+
+
+def normalize_cta_style(value) -> Optional[str]:
+    return _normalize(value, CTA_STYLES)
+
+
+def format_structure(format_key: str) -> list:
+    meta = FORMATS.get(normalize_format(format_key) or "")
+    return list(meta["structure"]) if meta else []
+
+
+def blueprint_options_text() -> str:
+    """The menu of formats/hooks/CTAs given to the PLANNER so it assigns real, known values."""
+    lines = ["Available FORMATS (use the key on the left):"]
+    lines += [f"- {k}: {m['label']} — {m['guidance']}" for k, m in FORMATS.items()]
+    lines.append("\nAvailable HOOK STYLES (use the key on the left):")
+    lines += [f"- {k}: {m['label']} — {m['guidance']}" for k, m in HOOK_STYLES.items()]
+    lines.append("\nAvailable CTA STYLES (use the key on the left):")
+    lines += [f"- {k}: {m['label']} — {m['guidance']}" for k, m in CTA_STYLES.items()]
+    return "\n".join(lines)
+
+
+def _pick(options: dict, recency: list, forbidden: set) -> str:
+    """Pick the least-recently-used option outside `forbidden`. `recency` is most-recent-first;
+    options never used rank best. Relaxes `forbidden` rather than ever failing."""
+    keys = list(options.keys())
+    candidates = [k for k in keys if k not in forbidden]
+    if not candidates:  # everything forbidden → only hard rule left is "not the immediate previous"
+        head = recency[0] if recency else None
+        candidates = [k for k in keys if k != head] or keys
+
+    def rank(k: str) -> int:
+        return recency.index(k) if k in recency else len(recency) + 1
+
+    return max(candidates, key=rank)
+
+
+def enforce_blueprint_variety(blueprints: list, recent_formats: list = None,
+                              recent_hook_styles: list = None) -> list:
+    """Guarantee IN CODE what the planner prompt merely requests: normalize each blueprint's
+    format/hook/cta to known keys and reassign any that repeat — no two consecutive editions (nor an
+    edition and the most recent history) share a format or hook style, no format/hook repeats within
+    the batch or the recent-history window, and every blueprint carries its format's structure."""
+    rf = [f for f in (normalize_format(x) for x in (recent_formats or [])) if f]
+    rh = [h for h in (normalize_hook_style(x) for x in (recent_hook_styles or [])) if h]
+    f_recency, h_recency = list(rf), list(rh)
+    window_f, window_h = set(rf[:_AVOID_WINDOW]), set(rh[:_AVOID_WINDOW])
+    prev_f = rf[0] if rf else None
+    prev_h = rh[0] if rh else None
+    batch_f: set = set()
+    batch_h: set = set()
+    prev_c = None
+    out = []
+    for bp in blueprints or []:
+        if not isinstance(bp, dict):
+            continue
+        fmt = normalize_format(bp.get("format"))
+        if fmt is None or fmt == prev_f or fmt in batch_f or fmt in window_f:
+            fmt = _pick(FORMATS, f_recency, {prev_f} | batch_f | window_f)
+        hook = normalize_hook_style(bp.get("hook_style"))
+        if hook is None or hook == prev_h or hook in batch_h or hook in window_h:
+            hook = _pick(HOOK_STYLES, h_recency, {prev_h} | batch_h | window_h)
+        cta = normalize_cta_style(bp.get("cta_style"))
+        if cta is None or cta == prev_c:
+            cta = _pick(CTA_STYLES, [prev_c] if prev_c else [], {prev_c} if prev_c else set())
+        item = dict(bp)
+        item.update({"format": fmt, "hook_style": hook, "cta_style": cta,
+                     "structure": list(FORMATS[fmt]["structure"])})
+        out.append(item)
+        prev_f, prev_h, prev_c = fmt, hook, cta
+        batch_f.add(fmt)
+        batch_h.add(hook)
+        f_recency.insert(0, fmt)
+        h_recency.insert(0, hook)
+    return out
+
+
+def build_regeneration_blueprint(subject: str = None, angle: str = None,
+                                 recent_formats: list = None, recent_hook_styles: list = None,
+                                 guidance: str = None) -> dict:
+    """A fresh blueprint for a single REGENERATED edition, chosen in code (no LLM call): rotate away
+    from the recent formats/hooks — including the edition's own previous shape — so a rewrite changes
+    form, not just words. Free-text `guidance` may name a format (e.g. 'make it a case study');
+    honor it when it does."""
+    hinted = normalize_format(guidance) if guidance else None
+    if not hinted and guidance:
+        low = guidance.lower()
+        for k, meta in FORMATS.items():
+            if k.replace("_", " ") in low or meta["label"].lower() in low:
+                hinted = k
+                break
+    rf = [f for f in (normalize_format(x) for x in (recent_formats or [])) if f]
+    rh = [h for h in (normalize_hook_style(x) for x in (recent_hook_styles or [])) if h]
+    fmt = hinted or _pick(FORMATS, rf, {rf[0] if rf else None} | set(rf[:_AVOID_WINDOW]))
+    hook = _pick(HOOK_STYLES, rh, {rh[0] if rh else None} | set(rh[:_AVOID_WINDOW]))
+    cta = _pick(CTA_STYLES, [], set())
+    return {"subject": subject, "angle": angle or "", "format": fmt, "hook_style": hook,
+            "cta_style": cta, "structure": list(FORMATS[fmt]["structure"])}
+
+
+def blueprint_directive(blueprint: dict) -> str:
+    """The WRITER-side injection: the assigned format's guidance + ordered structure skeleton, the
+    hook style, and the CTA style. Returns '' when the blueprint carries no known format."""
+    if not isinstance(blueprint, dict):
+        return ""
+    fmt = normalize_format(blueprint.get("format"))
+    if not fmt:
+        return ""
+    hook = normalize_hook_style(blueprint.get("hook_style"))
+    cta = normalize_cta_style(blueprint.get("cta_style"))
+    f_meta = FORMATS[fmt]
+    lines = [
+        "\nTHIS EDITION'S ASSIGNED BLUEPRINT — it OVERRIDES the default structure above. Follow it exactly:",
+        f"FORMAT: {f_meta['label']}. {f_meta['guidance']}",
+        "STRUCTURE — write these sections IN THIS ORDER (plain-text subheads, no markdown):",
+    ]
+    lines += [f"{i}. {s}" for i, s in enumerate(f_meta["structure"], 1)]
+    if hook:
+        h_meta = HOOK_STYLES[hook]
+        lines.append(f"OPENING HOOK STYLE: {h_meta['label']}. {h_meta['guidance']}")
+    if cta:
+        c_meta = CTA_STYLES[cta]
+        lines.append(f"CTA STYLE: {c_meta['label']}. {c_meta['guidance']}")
+    return "\n".join(lines) + "\n"
+
+
+def compact_blueprint(blueprint: dict) -> Optional[dict]:
+    """The persistable core of a blueprint (structure skeletons live in code, not the DB)."""
+    if not isinstance(blueprint, dict):
+        return None
+    return {k: blueprint.get(k) for k in ("subject", "angle", "format", "hook_style", "cta_style")}

--- a/src/cqc_lem/utilities/ai/newsletter_research.py
+++ b/src/cqc_lem/utilities/ai/newsletter_research.py
@@ -1,0 +1,96 @@
+"""Research layer for newsletter editions: ONE web-grounded call per edition that gathers current,
+factual findings (recent stats with rough dates, real examples, trends, credible contrarian data)
+for the edition's subject + blueprint, so the writer weaves specifics instead of vague claims.
+
+Routing: prefer the LiteLLM proxy alias `lem-research` (Perplexity Sonar, see .litellm/config.yaml)
+via the shared client; fall back to the direct `search_with_perplexity` helper when the proxy route
+is unavailable. Every failure path degrades to empty findings — generation NEVER breaks because
+research did. Toggle with NEWSLETTER_RESEARCH_ENABLED (default on)."""
+
+import os
+
+from cqc_lem.utilities.logger import log_debug, log_warning
+
+_EMPTY: dict = {"findings": "", "sources": []}
+
+_RESEARCH_SYSTEM = (
+    "You are a research assistant for a professional newsletter author. Gather CURRENT, FACTUAL, "
+    "citable information on the given subject. Return concise findings the author can weave into "
+    "prose: specific statistics WITH their approximate date and source name, real named examples "
+    "with outcomes, notable recent developments, and any credible data that challenges common "
+    "assumptions. Never invent facts or numbers. If little credible material exists, say so briefly."
+)
+
+
+def _research_enabled() -> bool:
+    return os.environ.get("NEWSLETTER_RESEARCH_ENABLED", "true").strip().lower() not in (
+        "0", "false", "no", "off")
+
+
+def _build_research_query(subject: str, blueprint: dict = None,
+                          newsletter_description: str = None, prefs: dict = None) -> str:
+    from cqc_lem.utilities.ai.newsletter_blueprint import normalize_format
+    parts = [f"Current facts, statistics, and real examples for a newsletter edition about: {subject.strip()}."]
+    angle = (blueprint or {}).get("angle")
+    if angle:
+        parts.append(f"The edition's angle: {str(angle).strip()}.")
+    fmt = normalize_format((blueprint or {}).get("format"))
+    if fmt == "roundup":
+        parts.append("Focus on notable developments from the last few weeks.")
+    elif fmt in ("case_study", "teardown"):
+        parts.append("Prioritize real named examples with concrete outcomes and numbers.")
+    elif fmt == "contrarian":
+        parts.append("Include credible data that challenges the conventional wisdom on this subject.")
+    desc = (newsletter_description or "").strip()
+    if desc:
+        parts.append(f"The newsletter's audience and promise: {desc[:300]}.")
+    focus = (prefs or {}).get("focus_topics")
+    if focus:
+        focus_str = ", ".join(str(t) for t in focus) if isinstance(focus, (list, tuple)) else str(focus)
+        if focus_str.strip():
+            parts.append(f"Audience focus areas: {focus_str[:200]}.")
+    parts.append("Return: 3-6 specific recent statistics (each with its approximate date and source "
+                 "name), 2-3 real examples, and 1-2 notable trends or contrarian data points.")
+    return " ".join(parts)
+
+
+def _research_via_litellm(query: str, max_sources: int) -> dict:
+    from cqc_lem.utilities.ai.client import client
+    response = client.chat.completions.create(
+        model="lem-research",
+        messages=[{"role": "system", "content": _RESEARCH_SYSTEM},
+                  {"role": "user", "content": query}],
+        temperature=0.2, max_tokens=900)
+    findings = (response.choices[0].message.content or "").strip()
+    if not findings:
+        raise RuntimeError("Empty research response from lem-research")
+    # Perplexity via LiteLLM surfaces citations as an extra response field when available.
+    citations = getattr(response, "citations", None) or []
+    sources = [{"url": u} for u in list(citations)[:max_sources] if isinstance(u, str)]
+    return {"findings": findings, "sources": sources}
+
+
+def research_newsletter_topic(subject: str, blueprint: dict = None,
+                              newsletter_description: str = None, prefs: dict = None,
+                              max_sources: int = 5) -> dict:
+    """One research call for one edition. Returns {'findings': str, 'sources': [{'url': ...}]};
+    empty findings on toggle-off, missing key, or any failure — callers always generate regardless."""
+    subject = (subject or "").strip()
+    if not subject or not _research_enabled():
+        return dict(_EMPTY)
+    query = _build_research_query(subject, blueprint, newsletter_description, prefs)
+    try:
+        result = _research_via_litellm(query, max_sources)
+        log_debug("Newsletter research via lem-research succeeded", ai_model="lem-research")
+        return result
+    except Exception as exc:
+        log_warning("Newsletter research via LiteLLM failed; trying direct Perplexity", exc=exc,
+                    api_provider="litellm")
+    try:
+        from cqc_lem.utilities.ai.tools import search_with_perplexity
+        raw = search_with_perplexity(query, max_sources=max_sources)
+        return {"findings": (raw.get("answer") or "").strip(), "sources": raw.get("sources") or []}
+    except Exception as exc:
+        log_warning("Newsletter research unavailable; generating without research", exc=exc,
+                    api_provider="perplexity")
+        return dict(_EMPTY)

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2762,16 +2762,22 @@ def get_enabled_newsletter_user_ids() -> list:
 
 
 def create_newsletter_edition(user_id: int, title: str, subtitle: str, body: str,
-                              scheduled_for, subject: str = None) -> int:
+                              scheduled_for, subject: str = None, edition_format: str = None,
+                              hook_style: str = None, opening_line: str = None,
+                              blueprint: dict = None) -> int:
     """Insert a draft newsletter edition (status defaults to 'draft'). Returns its id. `subject` is
-    the planned topic/angle for this edition, stored so the planner can dedup against prior ones."""
+    the planned topic/angle; `edition_format`/`hook_style`/`opening_line`/`blueprint` record the
+    edition's assigned SHAPE, so the planner can rotate formats/hooks/openers (not just subjects)
+    against prior editions across runs."""
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         cursor.execute(
-            "INSERT INTO newsletter_editions (user_id, title, subtitle, subject, body, scheduled_for) "
-            "VALUES (%s, %s, %s, %s, %s, %s)",
-            (user_id, title, subtitle, subject, body, scheduled_for))
+            "INSERT INTO newsletter_editions (user_id, title, subtitle, subject, `format`, "
+            "hook_style, opening_line, blueprint, body, scheduled_for) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            (user_id, title, subtitle, subject, edition_format, hook_style, opening_line,
+             json.dumps(blueprint) if blueprint else None, body, scheduled_for))
         connection.commit()
         return cursor.lastrowid
     except mysql.connector.IntegrityError as err:
@@ -2794,7 +2800,8 @@ def get_pending_newsletter_edition(user_id: int) -> "dict | None":
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            "SELECT id, title, subtitle, subject, body, status, scheduled_for FROM newsletter_editions "
+            "SELECT id, title, subtitle, subject, `format`, hook_style, body, status, scheduled_for "
+            "FROM newsletter_editions "
             "WHERE user_id = %s AND status IN ('draft', 'approved') "
             "ORDER BY id DESC LIMIT 1", (user_id,))
         return cursor.fetchone()
@@ -2830,7 +2837,8 @@ def get_pending_newsletter_editions(user_id: int) -> list:
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            "SELECT id, title, subtitle, subject, body, status, scheduled_for FROM newsletter_editions "
+            "SELECT id, title, subtitle, subject, `format`, hook_style, body, status, scheduled_for "
+            "FROM newsletter_editions "
             "WHERE user_id = %s AND status IN ('draft', 'approved') "
             "ORDER BY scheduled_for ASC", (user_id,))
         return cursor.fetchall()
@@ -2861,7 +2869,9 @@ def get_latest_edition_scheduled_for(user_id: int) -> "datetime | None":
 
 def update_newsletter_edition(edition_id: int, user_id: int, title: str = None,
                               subtitle: str = None, body: str = None,
-                              status: str = None, subject: str = None) -> bool:
+                              status: str = None, subject: str = None,
+                              edition_format: str = None, hook_style: str = None,
+                              opening_line: str = None, blueprint: dict = None) -> bool:
     """Update only the provided fields on an edition, scoped to its owner (COALESCE-style)."""
     connection = get_db_connection()
     cursor = connection.cursor()
@@ -2870,9 +2880,12 @@ def update_newsletter_edition(edition_id: int, user_id: int, title: str = None,
             "UPDATE newsletter_editions SET "
             "title = COALESCE(%s, title), subtitle = COALESCE(%s, subtitle), "
             "subject = COALESCE(%s, subject), "
+            "`format` = COALESCE(%s, `format`), hook_style = COALESCE(%s, hook_style), "
+            "opening_line = COALESCE(%s, opening_line), blueprint = COALESCE(%s, blueprint), "
             "body = COALESCE(%s, body), status = COALESCE(%s, status) "
             "WHERE id = %s AND user_id = %s",
-            (title, subtitle, subject, body, status, edition_id, user_id))
+            (title, subtitle, subject, edition_format, hook_style, opening_line,
+             json.dumps(blueprint) if blueprint else None, body, status, edition_id, user_id))
         connection.commit()
         return cursor.rowcount >= 0
     except mysql.connector.Error as err:
@@ -2904,6 +2917,27 @@ def get_recent_newsletter_subjects(user_id: int, limit: int = 20) -> list:
         connection.close()
 
 
+def get_recent_newsletter_blueprint_history(user_id: int, limit: int = 12) -> list:
+    """Recent editions' SHAPE history — {subject, format, hook_style, opening_line} dicts, most-recent
+    first, across queued/published/skipped editions. Fed to the planner and regenerator so new
+    editions rotate away from recently used formats, hook styles, AND actual opening lines (the
+    'every edition opens the same way' bug), not just subjects."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT subject, `format`, hook_style, opening_line FROM newsletter_editions "
+            "WHERE user_id = %s AND status IN ('draft', 'approved', 'published', 'skipped') "
+            "ORDER BY id DESC LIMIT %s", (user_id, int(limit)))
+        return cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get newsletter blueprint history for user {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_editions_due_to_publish(now) -> list:
     """Editions whose scheduled slot has arrived and are still awaiting publish (draft/approved)."""
     connection = get_db_connection()
@@ -2927,7 +2961,8 @@ def get_newsletter_edition(edition_id: int) -> "dict | None":
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            "SELECT id, user_id, title, subtitle, subject, body, status, scheduled_for, published_url "
+            "SELECT id, user_id, title, subtitle, subject, `format`, hook_style, opening_line, "
+            "body, status, scheduled_for, published_url "
             "FROM newsletter_editions WHERE id = %s", (edition_id,))
         return cursor.fetchone()
     except mysql.connector.Error as err:

--- a/tests/unit/app/test_newsletter_publish.py
+++ b/tests/unit/app/test_newsletter_publish.py
@@ -130,11 +130,14 @@ def _run_generate(*, settings, pending, latest=None, gen_now=True,
         create = p(patch("cqc_lem.utilities.db.create_newsletter_edition", **create_kw))
         p(patch("cqc_lem.utilities.db.get_pending_newsletter_editions", return_value=[]))
         p(patch("cqc_lem.utilities.db.get_recent_newsletter_subjects", return_value=[]))
+        p(patch("cqc_lem.utilities.db.get_recent_newsletter_blueprint_history", return_value=[]))
         p(patch("cqc_lem.utilities.db.get_engagement_preferences", return_value={}))
         p(patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()))
         p(patch("cqc_lem.utilities.ai.ai_helper.get_or_create_profile_synthesis", return_value="voice brief"))
         p(patch("cqc_lem.utilities.ai.ai_helper.plan_newsletter_topics", return_value=[]))
         p(patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", **gen_kw))
+        p(patch("cqc_lem.utilities.ai.newsletter_research.research_newsletter_topic",
+                return_value={"findings": "", "sources": []}))
         p(patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=gen_now))
         notify = p(patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready"))
         result = auto_generate_newsletter_drafts()
@@ -220,11 +223,14 @@ def _run_generate_for_user(*, settings, pending, latest=None, gen_now=True, edit
         create = p(patch("cqc_lem.utilities.db.create_newsletter_edition", return_value=create_ret))
         p(patch("cqc_lem.utilities.db.get_pending_newsletter_editions", return_value=[]))
         p(patch("cqc_lem.utilities.db.get_recent_newsletter_subjects", return_value=[]))
+        p(patch("cqc_lem.utilities.db.get_recent_newsletter_blueprint_history", return_value=[]))
         p(patch("cqc_lem.utilities.db.get_engagement_preferences", return_value={}))
         p(patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()))
         p(patch("cqc_lem.utilities.ai.ai_helper.get_or_create_profile_synthesis", return_value="voice brief"))
         p(patch("cqc_lem.utilities.ai.ai_helper.plan_newsletter_topics", return_value=[]))
         p(patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", return_value=edition))
+        p(patch("cqc_lem.utilities.ai.newsletter_research.research_newsletter_topic",
+                return_value={"findings": "", "sources": []}))
         p(patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=gen_now))
         p(patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready"))
         result = generate_newsletter_drafts_for_user.run(user_id=1)
@@ -260,15 +266,23 @@ class TestGenerateNewsletterDraftsForUser:
 
 
 class TestTopupPlansDistinctSubjects:
-    def _drive(self, planned, pending=0, existing_subjects=None, recent=None):
+    def _drive(self, planned, pending=0, existing_subjects=None, recent=None,
+               shape_history=None, research=None, gen_captures=None):
         from contextlib import ExitStack
         from cqc_lem.app.run_scheduler import auto_generate_newsletter_drafts
 
         def _gen(profile, topic=None, prefs=None, subject=None, avoid_subjects=None,
-                 profile_synthesis=None, guidance=None):
+                 profile_synthesis=None, guidance=None, blueprint=None, avoid_openers=None,
+                 research=None):
+            if gen_captures is not None:
+                gen_captures.append({"subject": subject, "blueprint": blueprint,
+                                     "avoid_openers": avoid_openers, "research": research})
             # Echo the planned subject as the generated edition's canonical subject.
             base = subject.split(" — angle:")[0] if subject else "Auto"
-            return {"title": f"Title for {base}", "subtitle": "S", "subject": base, "body": "B"}
+            return {"title": f"Title for {base}", "subtitle": "S", "subject": base, "body": "B",
+                    "format": (blueprint or {}).get("format"),
+                    "hook_style": (blueprint or {}).get("hook_style"),
+                    "opening_line": f"Opening for {base}"}
 
         with ExitStack() as es:
             p = es.enter_context
@@ -281,15 +295,20 @@ class TestTopupPlansDistinctSubjects:
             pending_eds = [{"id": i, "subject": s} for i, s in enumerate(existing_subjects or [])]
             p(patch("cqc_lem.utilities.db.get_pending_newsletter_editions", return_value=pending_eds))
             p(patch("cqc_lem.utilities.db.get_recent_newsletter_subjects", return_value=recent or []))
+            p(patch("cqc_lem.utilities.db.get_recent_newsletter_blueprint_history",
+                    return_value=shape_history or []))
             p(patch("cqc_lem.utilities.db.get_engagement_preferences", return_value={}))
             create = p(patch("cqc_lem.utilities.db.create_newsletter_edition", return_value=1))
             p(patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()))
             p(patch("cqc_lem.utilities.ai.ai_helper.get_or_create_profile_synthesis", return_value="brief"))
             plan = p(patch("cqc_lem.utilities.ai.ai_helper.plan_newsletter_topics", return_value=planned))
             p(patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", side_effect=_gen))
+            research_mock = p(patch("cqc_lem.utilities.ai.newsletter_research.research_newsletter_topic",
+                                    return_value=research or {"findings": "", "sources": []}))
             p(patch("cqc_lem.utilities.newsletter.should_generate_now", return_value=True))
             p(patch("cqc_lem.utilities.notifications.notify_newsletter_draft_ready"))
             result = auto_generate_newsletter_drafts()
+        self.research_mock = research_mock
         return result, create, plan
 
     def test_plans_then_persists_distinct_subjects(self):
@@ -315,8 +334,64 @@ class TestTopupPlansDistinctSubjects:
         assert create.call_count == 1
         assert "Generated 1 newsletter draft" in result
 
+    def test_blueprint_and_research_threaded_and_persisted(self):
+        planned = [
+            {"subject": "Alpha", "angle": "a", "format": "case_study", "hook_style": "micro_story",
+             "cta_style": "reply_question"},
+            {"subject": "Beta", "angle": "b", "format": "listicle", "hook_style": "bold_claim",
+             "cta_style": "challenge"},
+        ]
+        captures = []
+        result, create, _ = self._drive(
+            planned, research={"findings": "Fresh stat: 42% (2026, Acme).", "sources": [{"url": "https://x"}]},
+            gen_captures=captures)
+        # Blueprint + research reach the writer for every edition.
+        assert [c["blueprint"]["format"] for c in captures] == ["case_study", "listicle"]
+        assert all(c["research"]["findings"].startswith("Fresh stat") for c in captures)
+        # Exactly ONE research call per edition (cost guard).
+        assert self.research_mock.call_count == 2
+        # Shape persisted alongside the edition.
+        kw = create.call_args_list[0].kwargs
+        assert kw["edition_format"] == "case_study" and kw["hook_style"] == "micro_story"
+        assert kw["opening_line"] == "Opening for Alpha"
+        assert kw["blueprint"]["format"] == "case_study"
+        assert "structure" not in kw["blueprint"]  # compact form persisted, skeleton lives in code
+        assert "Generated 2 newsletter draft" in result
 
-def _run_regenerate(*, edition, guidance=None, others=None, recent=None, new_ed=None):
+    def test_shape_history_fed_into_planning(self):
+        history = [{"subject": "S1", "format": "deep_dive", "hook_style": "question",
+                    "opening_line": "Old opener one."},
+                   {"subject": "S2", "format": "framework", "hook_style": "surprising_stat",
+                    "opening_line": "Old opener two."}]
+        planned = [{"subject": "New", "angle": "x", "format": "case_study",
+                    "hook_style": "micro_story", "cta_style": "debate"}]
+        captures = []
+        self._drive(planned, shape_history=history, gen_captures=captures)
+        plan_kwargs = None
+        # plan mock reference lives inside _drive's return; re-drive to inspect via captured kwargs
+        _, _, plan = self._drive(planned, shape_history=history, gen_captures=[])
+        plan_kwargs = plan.call_args.kwargs
+        assert plan_kwargs["recent_formats"] == ["deep_dive", "framework"]
+        assert plan_kwargs["recent_hook_styles"] == ["question", "surprising_stat"]
+        # Prior openers are fed to the writer as an avoid list.
+        assert "Old opener one." in captures[0]["avoid_openers"]
+        assert "Old opener two." in captures[0]["avoid_openers"]
+
+    def test_new_openers_accumulate_within_run(self):
+        planned = [
+            {"subject": "Alpha", "angle": "a", "format": "case_study", "hook_style": "micro_story",
+             "cta_style": "reply_question"},
+            {"subject": "Beta", "angle": "b", "format": "listicle", "hook_style": "bold_claim",
+             "cta_style": "challenge"},
+        ]
+        captures = []
+        self._drive(planned, gen_captures=captures)
+        # The second edition must avoid the FIRST edition's just-written opening line too.
+        assert "Opening for Alpha" in captures[1]["avoid_openers"]
+
+
+def _run_regenerate(*, edition, guidance=None, others=None, recent=None, new_ed=None,
+                    shape_history=None, research=None):
     from contextlib import ExitStack
     from cqc_lem.app.run_scheduler import regenerate_newsletter_edition
     if new_ed is None:
@@ -324,10 +399,14 @@ def _run_regenerate(*, edition, guidance=None, others=None, recent=None, new_ed=
     captured = {}
 
     def _gen(profile, topic=None, prefs=None, subject=None, avoid_subjects=None,
-             profile_synthesis=None, guidance=None):
+             profile_synthesis=None, guidance=None, blueprint=None, avoid_openers=None,
+             research=None):
         captured["subject"] = subject
         captured["avoid"] = avoid_subjects
         captured["guidance"] = guidance
+        captured["blueprint"] = blueprint
+        captured["avoid_openers"] = avoid_openers
+        captured["research"] = research
         return new_ed
 
     with ExitStack() as es:
@@ -338,11 +417,16 @@ def _run_regenerate(*, edition, guidance=None, others=None, recent=None, new_ed=
         pending_eds = [{"id": o_id, "subject": s} for o_id, s in (others or [])]
         p(patch("cqc_lem.utilities.db.get_pending_newsletter_editions", return_value=pending_eds))
         p(patch("cqc_lem.utilities.db.get_recent_newsletter_subjects", return_value=recent or []))
+        p(patch("cqc_lem.utilities.db.get_recent_newsletter_blueprint_history",
+                return_value=shape_history or []))
         p(patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=MagicMock()))
         p(patch("cqc_lem.utilities.ai.ai_helper.get_or_create_profile_synthesis", return_value="brief"))
         p(patch("cqc_lem.utilities.ai.ai_helper.generate_newsletter_edition", side_effect=_gen))
+        research_mock = p(patch("cqc_lem.utilities.ai.newsletter_research.research_newsletter_topic",
+                                return_value=research or {"findings": "", "sources": []}))
         upd = p(patch("cqc_lem.utilities.db.update_newsletter_edition", return_value=True))
         result = regenerate_newsletter_edition.run(edition_id=edition["id"], guidance=guidance)
+    captured["research_calls"] = research_mock.call_count
     return result, upd, captured
 
 
@@ -374,6 +458,34 @@ class TestRegenerateNewsletterEdition:
             edition=ed, others=[(9, "Mine"), (10, "Other Queued")], recent=["Past One"])
         assert "Other Queued" in cap["avoid"] and "Past One" in cap["avoid"]
         assert "Mine" not in cap["avoid"]  # this edition's own subject excluded
+
+    def test_rotates_shape_away_from_history_and_persists(self):
+        ed = {"id": 9, "user_id": 1, "status": "draft", "subject": "Mine"}
+        history = [{"subject": "Mine", "format": "deep_dive", "hook_style": "question",
+                    "opening_line": "Most founders treat X like Y."}]
+        result, upd, cap = _run_regenerate(edition=ed, shape_history=history)
+        # A fresh blueprint is built in code: not the edition's own previous shape.
+        assert cap["blueprint"]["format"] != "deep_dive"
+        assert cap["blueprint"]["hook_style"] != "question"
+        assert "Most founders treat X like Y." in cap["avoid_openers"]
+        # Exactly ONE research call per regenerate.
+        assert cap["research_calls"] == 1
+        # New shape persisted on the row (blueprint in compact form).
+        kw = upd.call_args.kwargs
+        assert kw["edition_format"] == cap["blueprint"]["format"] or kw["edition_format"] is None
+        assert kw["blueprint"]["format"] == cap["blueprint"]["format"]
+        assert "structure" not in kw["blueprint"]
+
+    def test_guidance_format_hint_honored(self):
+        ed = {"id": 9, "user_id": 1, "status": "draft", "subject": "Mine"}
+        result, upd, cap = _run_regenerate(edition=ed, guidance="Rewrite this as a case study please")
+        assert cap["blueprint"]["format"] == "case_study"
+
+    def test_research_findings_reach_the_writer(self):
+        ed = {"id": 9, "user_id": 1, "status": "draft", "subject": "Mine"}
+        result, upd, cap = _run_regenerate(
+            edition=ed, research={"findings": "In March 2026, 61% of B2B teams...", "sources": []})
+        assert cap["research"]["findings"].startswith("In March 2026")
 
 
 class TestPublishScheduledEditions:

--- a/tests/unit/utilities/ai/test_newsletter_blueprint.py
+++ b/tests/unit/utilities/ai/test_newsletter_blueprint.py
@@ -1,0 +1,154 @@
+"""Unit tests for the newsletter edition blueprint / variety system."""
+
+import pytest
+
+from cqc_lem.utilities.ai import newsletter_blueprint as bp
+
+pytestmark = pytest.mark.unit
+
+
+class TestSetsAreConsistent:
+    def test_formats_non_empty_and_complete(self):
+        assert len(bp.FORMATS) >= 6
+        for key, meta in bp.FORMATS.items():
+            assert key == key.lower().replace(" ", "_")
+            assert meta["label"] and meta["guidance"]
+            assert isinstance(meta["structure"], list) and len(meta["structure"]) >= 3
+            # Every skeleton opens with the hook and closes with the CTA.
+            assert "hook" in meta["structure"][0].lower()
+            assert "cta" in meta["structure"][-1].lower()
+
+    def test_hooks_non_empty_and_complete(self):
+        assert len(bp.HOOK_STYLES) >= 6
+        for key, meta in bp.HOOK_STYLES.items():
+            assert meta["label"] and meta["guidance"]
+
+    def test_ctas_non_empty_and_complete(self):
+        assert len(bp.CTA_STYLES) >= 4
+        for key, meta in bp.CTA_STYLES.items():
+            assert meta["label"] and meta["guidance"]
+
+    def test_expected_archetypes_present(self):
+        for expected in ("deep_dive", "framework", "case_study", "contrarian", "listicle",
+                         "teardown", "roundup", "personal_lesson"):
+            assert expected in bp.FORMATS
+
+
+class TestNormalize:
+    def test_exact_keys(self):
+        assert bp.normalize_format("case_study") == "case_study"
+        assert bp.normalize_hook_style("bold_claim") == "bold_claim"
+        assert bp.normalize_cta_style("reply_question") == "reply_question"
+
+    def test_tolerates_labels_spaces_and_case(self):
+        assert bp.normalize_format("Case Study") == "case_study"
+        assert bp.normalize_format("Deep Dive / How-To") == "deep_dive"
+        assert bp.normalize_hook_style("Surprising Statistic") == "surprising_stat"
+        assert bp.normalize_cta_style("reply question") == "reply_question"
+
+    def test_unknown_returns_none(self):
+        assert bp.normalize_format("interpretive dance") is None
+        assert bp.normalize_hook_style(None) is None
+        assert bp.normalize_cta_style("") is None
+
+
+class TestEnforceVariety:
+    def test_consecutive_formats_and_hooks_never_repeat(self):
+        raw = [{"subject": f"S{i}", "format": "deep_dive", "hook_style": "question",
+                "cta_style": "reply_question"} for i in range(5)]
+        out = bp.enforce_blueprint_variety(raw)
+        for a, b in zip(out, out[1:]):
+            assert a["format"] != b["format"]
+            assert a["hook_style"] != b["hook_style"]
+            assert a["cta_style"] != b["cta_style"]
+
+    def test_avoids_recent_history(self):
+        raw = [{"subject": "S1"}, {"subject": "S2"}]
+        out = bp.enforce_blueprint_variety(raw, recent_formats=["case_study", "listicle"],
+                                           recent_hook_styles=["micro_story", "bold_claim"])
+        for item in out:
+            assert item["format"] not in ("case_study", "listicle")
+            assert item["hook_style"] not in ("micro_story", "bold_claim")
+
+    def test_valid_non_repeating_choices_kept(self):
+        raw = [{"subject": "A", "format": "case_study", "hook_style": "micro_story", "cta_style": "debate"},
+               {"subject": "B", "format": "listicle", "hook_style": "bold_claim", "cta_style": "challenge"}]
+        out = bp.enforce_blueprint_variety(raw)
+        assert [o["format"] for o in out] == ["case_study", "listicle"]
+        assert [o["hook_style"] for o in out] == ["micro_story", "bold_claim"]
+
+    def test_invalid_values_replaced_with_known_keys(self):
+        out = bp.enforce_blueprint_variety([{"subject": "A", "format": "sonnet", "hook_style": "smoke signal"}])
+        assert out[0]["format"] in bp.FORMATS
+        assert out[0]["hook_style"] in bp.HOOK_STYLES
+        assert out[0]["cta_style"] in bp.CTA_STYLES
+
+    def test_attaches_structure_and_keeps_subject_angle(self):
+        out = bp.enforce_blueprint_variety([{"subject": "A", "angle": "the angle", "format": "framework",
+                                             "hook_style": "direct_promise", "cta_style": "teaser_next"}])
+        assert out[0]["subject"] == "A" and out[0]["angle"] == "the angle"
+        assert out[0]["structure"] == bp.FORMATS["framework"]["structure"]
+
+    def test_no_repeat_within_batch_even_when_pool_pressured(self):
+        # 8 formats, batch of 6 + 3 recent: still no within-batch repeats.
+        raw = [{"subject": f"S{i}"} for i in range(6)]
+        out = bp.enforce_blueprint_variety(raw, recent_formats=["deep_dive", "framework", "case_study"])
+        formats = [o["format"] for o in out]
+        assert len(set(formats)) == len(formats)
+
+    def test_empty_and_garbage_input(self):
+        assert bp.enforce_blueprint_variety([]) == []
+        assert bp.enforce_blueprint_variety(None) == []
+        assert bp.enforce_blueprint_variety(["not a dict", 42]) == []
+
+
+class TestRegenerationBlueprint:
+    def test_rotates_away_from_recent_shape(self):
+        out = bp.build_regeneration_blueprint(subject="S", recent_formats=["deep_dive", "framework"],
+                                              recent_hook_styles=["question", "surprising_stat"])
+        assert out["format"] in bp.FORMATS and out["format"] not in ("deep_dive", "framework")
+        assert out["hook_style"] in bp.HOOK_STYLES
+        assert out["hook_style"] not in ("question", "surprising_stat")
+        assert out["cta_style"] in bp.CTA_STYLES
+        assert out["structure"] == bp.FORMATS[out["format"]]["structure"]
+        assert out["subject"] == "S"
+
+    def test_guidance_format_hint_wins(self):
+        out = bp.build_regeneration_blueprint(subject="S", recent_formats=["listicle"],
+                                              guidance="make this one a Case Study of a real client")
+        assert out["format"] == "case_study"
+
+    def test_no_history_still_valid(self):
+        out = bp.build_regeneration_blueprint()
+        assert out["format"] in bp.FORMATS and out["hook_style"] in bp.HOOK_STYLES
+
+
+class TestDirectivesAndCompact:
+    def test_blueprint_directive_includes_structure_hook_cta(self):
+        blueprint = {"subject": "S", "format": "contrarian", "hook_style": "bold_claim",
+                     "cta_style": "debate"}
+        text = bp.blueprint_directive(blueprint)
+        assert "ASSIGNED BLUEPRINT" in text
+        assert bp.FORMATS["contrarian"]["label"] in text
+        for i, section in enumerate(bp.FORMATS["contrarian"]["structure"], 1):
+            assert f"{i}. {section}" in text
+        assert bp.HOOK_STYLES["bold_claim"]["guidance"] in text
+        assert bp.CTA_STYLES["debate"]["guidance"] in text
+
+    def test_blueprint_directive_empty_without_format(self):
+        assert bp.blueprint_directive(None) == ""
+        assert bp.blueprint_directive({}) == ""
+        assert bp.blueprint_directive({"format": "not real"}) == ""
+
+    def test_compact_drops_structure(self):
+        blueprint = {"subject": "S", "angle": "a", "format": "listicle", "hook_style": "question",
+                     "cta_style": "poll_prompt", "structure": ["x", "y"]}
+        compact = bp.compact_blueprint(blueprint)
+        assert compact == {"subject": "S", "angle": "a", "format": "listicle",
+                           "hook_style": "question", "cta_style": "poll_prompt"}
+        assert bp.compact_blueprint(None) is None
+
+    def test_options_text_lists_all_keys(self):
+        text = bp.blueprint_options_text()
+        for key in list(bp.FORMATS) + list(bp.HOOK_STYLES) + list(bp.CTA_STYLES):
+            assert key in text

--- a/tests/unit/utilities/ai/test_newsletter_generation.py
+++ b/tests/unit/utilities/ai/test_newsletter_generation.py
@@ -117,6 +117,82 @@ class TestGenerationUsesSynthesisAndSubject:
         assert out["subject"] == "Fallback Subject"
 
 
+class TestGenerationWritesToBlueprint:
+    _BLUEPRINT = {"subject": "S", "angle": "a", "format": "contrarian",
+                  "hook_style": "bold_claim", "cta_style": "debate"}
+
+    def _gen(self, **kwargs):
+        from cqc_lem.utilities.ai import ai_helper
+        prof = MagicMock(); prof.model_dump_json.return_value = "{}"
+        payload = json.dumps({"title": "T", "subtitle": "S", "subject": "S",
+                              "body": "The opener line.\n\nSECTION\n\nBody text."})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)) as call:
+            out = ai_helper.generate_newsletter_edition(prof, profile_synthesis="THE VOICE BRIEF",
+                                                        **kwargs)
+        system = call.call_args.kwargs["messages"][0]["content"]
+        user = call.call_args.kwargs["messages"][1]["content"]
+        return out, system, user
+
+    def test_blueprint_structure_hook_cta_injected(self):
+        from cqc_lem.utilities.ai.newsletter_blueprint import FORMATS, HOOK_STYLES, CTA_STYLES
+        out, system, user = self._gen(blueprint=self._BLUEPRINT)
+        assert "ASSIGNED BLUEPRINT" in system
+        assert FORMATS["contrarian"]["structure"][1] in system  # skeleton sections present
+        assert HOOK_STYLES["bold_claim"]["guidance"] in system
+        assert CTA_STYLES["debate"]["guidance"] in system
+        # Blueprint shape echoed back for persistence.
+        assert out["format"] == "contrarian" and out["hook_style"] == "bold_claim"
+        assert out["cta_style"] == "debate"
+        assert out["opening_line"] == "The opener line."
+
+    def test_avoid_openers_injected(self):
+        _, _, user = self._gen(avoid_openers=["Most founders treat X like Y.", "It was a Tuesday."])
+        assert "Most founders treat X like Y." in user
+        assert "It was a Tuesday." in user
+        assert "must NOT reuse or resemble" in user
+
+    def test_research_findings_injected_as_source_material(self):
+        _, _, user = self._gen(research={"findings": "In Q1 2026, 57% of SMBs adopted...",
+                                         "sources": [{"url": "https://src"}]})
+        assert "SOURCE MATERIAL" in user
+        assert "In Q1 2026, 57% of SMBs adopted..." in user
+        assert "Do NOT invent statistics" in user
+        assert "Do NOT paste URLs" in user
+        assert "https://src" not in user  # source URLs never enter the writing prompt/body
+
+    def test_no_research_block_when_findings_empty(self):
+        _, _, user = self._gen(research={"findings": "", "sources": []})
+        assert "SOURCE MATERIAL" not in user
+
+    def test_blueprint_plus_synthesis_coexist(self):
+        prof_marker = "RAW_PROFILE_JSON_SHOULD_NOT_APPEAR"
+        from cqc_lem.utilities.ai import ai_helper
+        prof = MagicMock(); prof.model_dump_json.return_value = prof_marker
+        payload = json.dumps({"title": "T", "subtitle": "S", "subject": "S", "body": "B."})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)) as call:
+            ai_helper.generate_newsletter_edition(prof, profile_synthesis="THE VOICE BRIEF",
+                                                  blueprint=self._BLUEPRINT,
+                                                  research={"findings": "A fact.", "sources": []})
+        user = call.call_args.kwargs["messages"][1]["content"]
+        assert "THE VOICE BRIEF" in user
+        assert prof_marker not in user
+
+    def test_no_blueprint_keeps_default_behavior(self):
+        out, system, _ = self._gen()
+        assert "ASSIGNED BLUEPRINT" not in system
+        assert out["format"] is None and out["hook_style"] is None
+        assert out["opening_line"] == "The opener line."
+
+    def test_fallback_plain_text_still_carries_shape(self):
+        from cqc_lem.utilities.ai import ai_helper
+        prof = MagicMock(); prof.model_dump_json.return_value = "{}"
+        with patch(f"{_AI}._call_llm", return_value=_resp("My Title\nFirst body line\nMore")):
+            out = ai_helper.generate_newsletter_edition(prof, topic="growth",
+                                                        blueprint=self._BLUEPRINT)
+        assert out["format"] == "contrarian" and out["hook_style"] == "bold_claim"
+        assert out["opening_line"] == "First body line"
+
+
 class TestPlanNewsletterTopics:
     def test_returns_distinct_subjects(self):
         from cqc_lem.utilities.ai import ai_helper
@@ -185,3 +261,60 @@ class TestPlanNewsletterTopics:
         from cqc_lem.utilities.ai import ai_helper
         with patch(f"{_AI}._call_llm", side_effect=Exception("boom")):
             assert ai_helper.plan_newsletter_topics("v", "d", None, [], 3) == []
+
+
+class TestPlannerEmitsBlueprints:
+    def test_full_blueprints_with_valid_keys_and_structure(self):
+        from cqc_lem.utilities.ai import ai_helper
+        from cqc_lem.utilities.ai.newsletter_blueprint import FORMATS, HOOK_STYLES, CTA_STYLES
+        payload = json.dumps({"editions": [
+            {"subject": "A", "angle": "1", "format": "case_study", "hook_style": "micro_story",
+             "cta_style": "reply_question"},
+            {"subject": "B", "angle": "2", "format": "listicle", "hook_style": "bold_claim",
+             "cta_style": "challenge"},
+        ]})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)):
+            out = ai_helper.plan_newsletter_topics("v", "d", None, [], 2)
+        assert [o["format"] for o in out] == ["case_study", "listicle"]
+        assert [o["hook_style"] for o in out] == ["micro_story", "bold_claim"]
+        for o in out:
+            assert o["format"] in FORMATS and o["hook_style"] in HOOK_STYLES
+            assert o["cta_style"] in CTA_STYLES
+            assert o["structure"] == FORMATS[o["format"]]["structure"]
+
+    def test_consecutive_repeats_from_model_are_fixed_in_code(self):
+        from cqc_lem.utilities.ai import ai_helper
+        payload = json.dumps({"editions": [
+            {"subject": "A", "angle": "1", "format": "deep_dive", "hook_style": "question"},
+            {"subject": "B", "angle": "2", "format": "deep_dive", "hook_style": "question"},
+            {"subject": "C", "angle": "3", "format": "deep_dive", "hook_style": "question"},
+        ]})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)):
+            out = ai_helper.plan_newsletter_topics("v", "d", None, [], 3)
+        for a, b in zip(out, out[1:]):
+            assert a["format"] != b["format"]
+            assert a["hook_style"] != b["hook_style"]
+
+    def test_recent_shapes_in_prompt_and_avoided(self):
+        from cqc_lem.utilities.ai import ai_helper
+        payload = json.dumps({"editions": [{"subject": "A", "angle": "1", "format": "deep_dive",
+                                            "hook_style": "question"}]})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)) as call:
+            out = ai_helper.plan_newsletter_topics(
+                "v", "d", None, [], 1, recent_formats=["deep_dive", "framework"],
+                recent_hook_styles=["question"])
+        prompt = call.call_args.kwargs["messages"][1]["content"]
+        assert "deep_dive" in prompt and "framework" in prompt and "question" in prompt
+        # Model repeated a recent shape; code rotated it away.
+        assert out[0]["format"] not in ("deep_dive", "framework")
+        assert out[0]["hook_style"] != "question"
+
+    def test_format_menu_present_in_system_prompt(self):
+        from cqc_lem.utilities.ai import ai_helper
+        from cqc_lem.utilities.ai.newsletter_blueprint import FORMATS
+        payload = json.dumps({"editions": [{"subject": "A", "angle": "1"}]})
+        with patch(f"{_AI}._call_llm", return_value=_resp(payload)) as call:
+            ai_helper.plan_newsletter_topics("v", "d", None, [], 1)
+        system = call.call_args.kwargs["messages"][0]["content"]
+        for key in FORMATS:
+            assert key in system

--- a/tests/unit/utilities/ai/test_newsletter_research.py
+++ b/tests/unit/utilities/ai/test_newsletter_research.py
@@ -43,6 +43,23 @@ class TestLiteLLMRoutePreferred:
         assert "conventional wisdom" in query  # contrarian → challenge-the-consensus focus
         assert "SaaS founders" in query
 
+    def test_query_focus_for_roundup_and_focus_topics(self):
+        with patch(_CLIENT) as client:
+            client.chat.completions.create.return_value = _resp("findings")
+            nr.research_newsletter_topic(
+                "AI tooling this month", blueprint={"format": "roundup"},
+                prefs={"focus_topics": ["ai agents", "automation"]})
+        query = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+        assert "last few weeks" in query
+        assert "ai agents, automation" in query
+
+    def test_query_focus_for_case_study(self):
+        with patch(_CLIENT) as client:
+            client.chat.completions.create.return_value = _resp("findings")
+            nr.research_newsletter_topic("churn turnarounds", blueprint={"format": "case_study"})
+        query = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+        assert "real named examples" in query
+
     def test_exactly_one_call_per_invocation(self):
         with patch(_CLIENT) as client:
             client.chat.completions.create.return_value = _resp("findings")

--- a/tests/unit/utilities/ai/test_newsletter_research.py
+++ b/tests/unit/utilities/ai/test_newsletter_research.py
@@ -1,0 +1,106 @@
+"""Unit tests for the newsletter research layer (all I/O mocked)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from cqc_lem.utilities.ai import newsletter_research as nr
+
+pytestmark = pytest.mark.unit
+
+_CLIENT = "cqc_lem.utilities.ai.client.client"
+_DIRECT = "cqc_lem.utilities.ai.tools.search_with_perplexity"
+
+
+def _resp(text, citations=None):
+    r = MagicMock()
+    r.choices = [MagicMock(message=MagicMock(content=text))]
+    r.citations = citations if citations is not None else []
+    return r
+
+
+class TestLiteLLMRoutePreferred:
+    def test_uses_lem_research_alias(self, monkeypatch):
+        monkeypatch.delenv("NEWSLETTER_RESEARCH_ENABLED", raising=False)
+        with patch(_CLIENT) as client, patch(_DIRECT) as direct:
+            client.chat.completions.create.return_value = _resp(
+                "42% of teams (2026, Acme survey) now...", ["https://acme.example/report"])
+            out = nr.research_newsletter_topic("delegation for founders")
+        client.chat.completions.create.assert_called_once()
+        assert client.chat.completions.create.call_args.kwargs["model"] == "lem-research"
+        direct.assert_not_called()  # LiteLLM route preferred; direct helper untouched
+        assert out["findings"].startswith("42% of teams")
+        assert out["sources"] == [{"url": "https://acme.example/report"}]
+
+    def test_query_includes_subject_angle_and_format_focus(self):
+        with patch(_CLIENT) as client:
+            client.chat.completions.create.return_value = _resp("findings")
+            nr.research_newsletter_topic(
+                "pricing strategy", blueprint={"angle": "the psychology angle", "format": "contrarian"},
+                newsletter_description="a newsletter for SaaS founders")
+        query = client.chat.completions.create.call_args.kwargs["messages"][1]["content"]
+        assert "pricing strategy" in query
+        assert "the psychology angle" in query
+        assert "conventional wisdom" in query  # contrarian → challenge-the-consensus focus
+        assert "SaaS founders" in query
+
+    def test_exactly_one_call_per_invocation(self):
+        with patch(_CLIENT) as client:
+            client.chat.completions.create.return_value = _resp("findings")
+            nr.research_newsletter_topic("subject one")
+        assert client.chat.completions.create.call_count == 1
+
+
+class TestFallbacks:
+    def test_falls_back_to_direct_helper_when_litellm_fails(self):
+        with patch(_CLIENT) as client, patch(_DIRECT) as direct:
+            client.chat.completions.create.side_effect = Exception("proxy down")
+            direct.return_value = {"query": "q", "answer": "Direct answer with stats.",
+                                   "sources": [{"url": "https://s"}]}
+            out = nr.research_newsletter_topic("some subject")
+        direct.assert_called_once()
+        assert out == {"findings": "Direct answer with stats.", "sources": [{"url": "https://s"}]}
+
+    def test_empty_litellm_response_falls_back(self):
+        with patch(_CLIENT) as client, patch(_DIRECT) as direct:
+            client.chat.completions.create.return_value = _resp("")
+            direct.return_value = {"query": "q", "answer": "fallback", "sources": []}
+            out = nr.research_newsletter_topic("some subject")
+        assert out["findings"] == "fallback"
+
+    def test_both_routes_fail_returns_empty_never_raises(self):
+        with patch(_CLIENT) as client, patch(_DIRECT) as direct:
+            client.chat.completions.create.side_effect = Exception("proxy down")
+            direct.side_effect = RuntimeError("PERPLEXITY_API_KEY is not set")
+            out = nr.research_newsletter_topic("some subject")
+        assert out == {"findings": "", "sources": []}
+
+    def test_blank_subject_skips_all_calls(self):
+        with patch(_CLIENT) as client, patch(_DIRECT) as direct:
+            out = nr.research_newsletter_topic("   ")
+        client.chat.completions.create.assert_not_called()
+        direct.assert_not_called()
+        assert out == {"findings": "", "sources": []}
+
+
+class TestToggle:
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off", "FALSE"])
+    def test_disabled_values_skip_research(self, monkeypatch, value):
+        monkeypatch.setenv("NEWSLETTER_RESEARCH_ENABLED", value)
+        with patch(_CLIENT) as client:
+            out = nr.research_newsletter_topic("a subject")
+        client.chat.completions.create.assert_not_called()
+        assert out == {"findings": "", "sources": []}
+
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("NEWSLETTER_RESEARCH_ENABLED", raising=False)
+        with patch(_CLIENT) as client:
+            client.chat.completions.create.return_value = _resp("findings")
+            out = nr.research_newsletter_topic("a subject")
+        client.chat.completions.create.assert_called_once()
+        assert out["findings"] == "findings"
+
+    def test_explicit_true_enables(self, monkeypatch):
+        monkeypatch.setenv("NEWSLETTER_RESEARCH_ENABLED", "true")
+        with patch(_CLIENT) as client:
+            client.chat.completions.create.return_value = _resp("findings")
+            assert nr.research_newsletter_topic("a subject")["findings"] == "findings"

--- a/tests/unit/utilities/test_db_newsletter.py
+++ b/tests/unit/utilities/test_db_newsletter.py
@@ -181,8 +181,8 @@ class TestEditions:
             assert update_newsletter_edition(4, 1, status="approved") is True
         sql, params = cur.execute.call_args[0]
         assert "COALESCE" in sql
-        # params now include the subject slot (5th position): (title, subtitle, subject, body, status, id, user_id)
-        assert params == (None, None, None, None, "approved", 4, 1)
+        # (title, subtitle, subject, format, hook_style, opening_line, blueprint, body, status, id, user_id)
+        assert params == (None, None, None, None, None, None, None, None, "approved", 4, 1)
 
     def test_update_persists_subject(self):
         conn, cur = _mock_conn(rowcount=1)
@@ -191,7 +191,21 @@ class TestEditions:
             assert update_newsletter_edition(4, 1, subject="New Subject", status="draft") is True
         sql, params = cur.execute.call_args[0]
         assert "subject = COALESCE" in sql
-        assert params == (None, None, "New Subject", None, "draft", 4, 1)
+        assert params == (None, None, "New Subject", None, None, None, None, None, "draft", 4, 1)
+
+    def test_update_persists_shape_fields(self):
+        import json
+        conn, cur = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_newsletter_edition
+            assert update_newsletter_edition(
+                4, 1, edition_format="case_study", hook_style="micro_story",
+                opening_line="It was a Tuesday.", blueprint={"format": "case_study"}) is True
+        sql, params = cur.execute.call_args[0]
+        assert "`format` = COALESCE" in sql and "hook_style = COALESCE" in sql
+        assert "opening_line = COALESCE" in sql and "blueprint = COALESCE" in sql
+        assert "case_study" in params and "micro_story" in params and "It was a Tuesday." in params
+        assert json.dumps({"format": "case_study"}) in params
 
     def test_create_persists_subject(self):
         conn, cur = _mock_conn()
@@ -204,6 +218,59 @@ class TestEditions:
         sql, params = cur.execute.call_args[0]
         assert "subject" in sql
         assert "Coherent Subject" in params
+
+    def test_create_persists_shape_fields(self):
+        import json
+        conn, cur = _mock_conn()
+        cur.lastrowid = 89
+        import datetime
+        bp = {"subject": "S", "format": "contrarian", "hook_style": "bold_claim", "cta_style": "debate"}
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import create_newsletter_edition
+            assert create_newsletter_edition(
+                1, "T", "S", "B", datetime.datetime(2026, 7, 7, 13), subject="S",
+                edition_format="contrarian", hook_style="bold_claim",
+                opening_line="Everyone is wrong about this.", blueprint=bp) == 89
+        sql, params = cur.execute.call_args[0]
+        assert "`format`" in sql and "hook_style" in sql and "opening_line" in sql and "blueprint" in sql
+        assert "contrarian" in params and "bold_claim" in params
+        assert "Everyone is wrong about this." in params
+        assert json.dumps(bp) in params
+
+    def test_create_shape_fields_default_null(self):
+        conn, cur = _mock_conn()
+        cur.lastrowid = 90
+        import datetime
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import create_newsletter_edition
+            assert create_newsletter_edition(1, "T", "S", "B", datetime.datetime(2026, 7, 7, 13)) == 90
+        _, params = cur.execute.call_args[0]
+        # blueprint None → stored NULL, not the string 'null'
+        assert "null" not in [p for p in params if isinstance(p, str)]
+
+    def test_blueprint_history(self):
+        rows = [{"subject": "S1", "format": "case_study", "hook_style": "micro_story",
+                 "opening_line": "It was a Tuesday."},
+                {"subject": "S2", "format": "listicle", "hook_style": "question",
+                 "opening_line": "What would you do?"}]
+        conn, cur = _mock_conn(fetch_all=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_recent_newsletter_blueprint_history
+            out = get_recent_newsletter_blueprint_history(1, limit=5)
+        assert [h["format"] for h in out] == ["case_study", "listicle"]
+        sql, params = cur.execute.call_args[0]
+        assert "`format`" in sql and "hook_style" in sql and "opening_line" in sql
+        assert "published" in sql and "skipped" in sql and "draft" in sql
+        assert "ORDER BY id DESC" in sql
+        assert params == (1, 5)
+
+    def test_blueprint_history_empty_on_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_recent_newsletter_blueprint_history
+            assert get_recent_newsletter_blueprint_history(1) == []
 
     def test_recent_subjects_dedup_history(self):
         conn, cur = _mock_conn(fetch_all=[("Subject A",), ("Subject B",)])


### PR DESCRIPTION
Makes the newsletter tool polished and authoritative: every edition unique in **every** aspect (subject, structure, hook, CTA) AND grounded in current facts. Follows v0.30.0's subject-planning (subjects were distinct but openers/structure all repeated — "Most founders treat X like Y…").

## Structured blueprint + variety (`newsletter_blueprint.py`)
- **8 formats** (deep_dive, framework, case_study, contrarian, listicle, teardown, roundup, personal_lesson) — each with authoring guidance + an ordered structure skeleton — **8 hook styles**, **6 CTA styles**.
- Planner emits a full blueprint per edition; `enforce_blueprint_variety()` guarantees **in code** (regardless of model output) that no two consecutive editions (incl. vs. recent history) share a format or hook style, with LRU replacement over a 3-edition window.
- Writer receives the assigned skeleton + hook/CTA guidance + an explicit **avoid-openers list of prior editions' actual first lines**, and returns its format/hook/opening_line so shape history persists.
- Regenerate rotates away from recent shapes (honors a format named in Added Guidance).

## Research layer (`newsletter_research.py`)
- `research_newsletter_topic()` pulls current stats/examples/trends per edition, **routed through LiteLLM** via a new `lem-research` alias → `perplexity/sonar` (falls back to the existing direct `search_with_perplexity`). Findings injected as source material; **specific numbers over vague claims, no statistics beyond the material (anti-fabrication rule), no URLs in the body** (a source may be named).
- Env toggle `NEWSLETTER_RESEARCH_ENABLED` (default true) + graceful fallback (missing key / failure / empty → generate without research, never break). **Exactly one Sonar call per edition/regenerate.**

## Persistence + UI
- **V50** stores `format`/`hook_style`/`opening_line`/`blueprint` on `newsletter_editions`; `get_recent_newsletter_blueprint_history` dedupes shape across runs. Format/hook **badges** on each review-queue card.
- Prod-ready: base compose passes `PERPLEXITY_API_KEY` to litellm (inherited by the prod overlay); `deploy.sh` git-checks-out the tag so the `.litellm` alias lands; `PERPLEXITY_API_KEY` already set in prod.

## Research basis (cited)
Content archetypes/skeletons (Animalz), newsletter formats (Newsletter Operator, HubSpot), hook taxonomies (Neal O'Grady, Winning Presentations), LinkedIn newsletter growth (ContentIn, InfluenceFlow, Postiz), RAG grounding / anti-hallucination (arXiv, MDPI), credible-stat provenance (chiefmartec).

## Testing
- `pytest tests/unit` → **1471 passed** (+30). New-module coverage: blueprint 96%, research 91%+. SPA `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)