### PR TITLE
feat(text): strip rogue AI typography (em dashes, smart quotes) from public output

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -35,6 +35,7 @@ from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile,
     load_profile_for_user
 from cqc_lem.utilities.linkedin.poster import share_on_linkedin, share_carousel_on_linkedin
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
+from cqc_lem.utilities.linkedin_formatter import normalize_public_text
 from cqc_lem.utilities.logger import myprint, log_error, log_info, log_warning
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
     get_element_wait_retry, get_elements_as_list_wait_stale, getText, close_tab, get_driver_wait_pair, quit_gracefully, \
@@ -597,9 +598,11 @@ def _score_feed_post(meta: dict, prefs: dict, engagers: set = None) -> float:
 
 
 def _strip_non_bmp(text: str) -> str:
-    # ChromeDriver's send_keys raises WebDriverException on non-BMP characters (most emoji), so
-    # drop them — otherwise emoji-flavoured AI comments fail to type at all.
-    return ''.join(c for c in (text or "") if ord(c) <= 0xFFFF)
+    # First normalize rogue AI typography (em dashes, smart quotes, ellipsis, exotic spaces) to plain
+    # ASCII so those tell-tale characters never reach a public comment/post. Then drop non-BMP chars:
+    # ChromeDriver's send_keys raises WebDriverException on them (most emoji), so keep the composer typing.
+    text = normalize_public_text(text or "")
+    return ''.join(c for c in text if ord(c) <= 0xFFFF)
 
 
 # The SDUI comment/reply composer has NO <form> ancestor, so walk up from the textbox and click

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -10,6 +10,7 @@ from cqc_lem.utilities.ai.client import client
 from cqc_lem.utilities.ai import newsletter_blueprint as _blueprint
 from cqc_lem.utilities.ai.tools import search_recent_news, search_with_perplexity
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
+from cqc_lem.utilities.linkedin_formatter import normalize_public_text, PLAIN_PUNCTUATION_DIRECTIVE
 from cqc_lem.utilities.logger import myprint, log_debug, log_error, log_warning
 from cqc_lem.utilities.utils import create_folder_if_not_exists, save_video_url_to_dir
 from cqc_lem.utilities.env_constants import DEFAULT_VIDEO_MODEL, DEFAULT_IMAGE_MODEL, DEFAULT_IMAGE_RATIO
@@ -645,6 +646,9 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
         markdown. Output PLAIN TEXT only:
         - NEVER use markdown: no '#'/'##' headers, no '**bold**' or '*italic*', no '- ' bullet
           syntax, no '[text](url)' links, no backticks.
+        - Use ONLY plain ASCII punctuation: NEVER use em dashes or en dashes (use a comma, period, or
+          plain hyphen), no curly/smart quotes (use straight ' and "), no ellipsis character (type
+          three periods). Fancy Unicode punctuation reads as AI-generated.
         - Write section headers in Title Case or UPPERCASE on their OWN line, with a blank line above
           and below.
         - For any list, put each item on its own short line beginning with a literal "-> " or a
@@ -689,9 +693,9 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
     try:
         data = _json.loads(content)
         if data.get("title") and data.get("body"):
-            title = str(data["title"]).strip()[:255]
+            title = normalize_public_text(str(data["title"]).strip())[:255]
             body = _clean_newsletter_body(str(data["body"]).strip())
-            subtitle = str(data.get("subtitle") or "").strip()[:150]
+            subtitle = normalize_public_text(str(data.get("subtitle") or "").strip())[:150]
             if not subtitle:
                 subtitle = (subject or topic or title).strip()[:150]
             out_subject = str(data.get("subject") or "").strip()[:500] or _default_subject or title[:500]
@@ -2633,7 +2637,8 @@ Return ONLY valid JSON. No explanation, no markdown fences."""
         "content": (
             "You are an expert LinkedIn content creator who produces high-engagement carousel posts. "
             "You always return well-structured JSON with no markdown formatting. "
-            "All text in the JSON is concise, professional, and written for a LinkedIn audience."
+            "All text in the JSON is concise, professional, and written for a LinkedIn audience. "
+            + PLAIN_PUNCTUATION_DIRECTIVE
         ),
     }
     user_message = {"role": "user", "content": [{"type": "text", "text": prompt}]}
@@ -2654,6 +2659,18 @@ Return ONLY valid JSON. No explanation, no markdown fences."""
         log_error("generate_carousel_content: LLM returned invalid JSON", exc=exc)
         parsed = {}
 
-    post_text = parsed.get("post_text", f"Explore our latest insights on {industry}.")
-    carousel_dict = parsed.get("carousel", {})
+    post_text = normalize_public_text(parsed.get("post_text", f"Explore our latest insights on {industry}."))
+    carousel_dict = _normalize_carousel_strings(parsed.get("carousel", {}))
     return post_text, carousel_dict
+
+
+def _normalize_carousel_strings(value):
+    """Recursively normalize every string in the carousel data (slide titles/content) so rogue
+    typographic characters never get rendered onto the slide images."""
+    if isinstance(value, str):
+        return normalize_public_text(value)
+    if isinstance(value, dict):
+        return {k: _normalize_carousel_strings(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_normalize_carousel_strings(v) for v in value]
+    return value

--- a/src/cqc_lem/utilities/linkedin_formatter.py
+++ b/src/cqc_lem/utilities/linkedin_formatter.py
@@ -1,4 +1,55 @@
 import re
+import unicodedata
+
+# Fancy typographic glyphs that models love to emit — em/en dashes, curly quotes, ellipsis, exotic
+# spaces — are tell-tale AI signs and sometimes render as mojibake on downstream surfaces. Map each
+# to a plain ASCII equivalent. Uses \u escapes (never literal glyphs) so the table stays unambiguous.
+# Deliberately does NOT touch the bullet char (U+2022, used on purpose for LinkedIn bullets), the
+# em dash (handled separately -> spaced hyphen), or emojis/accented letters, which may be intentional.
+_TYPOGRAPHY_MAP = {
+    "–": "-", "―": "-", "‒": "-", "‑": "-", "−": "-",  # en/horiz-bar/figure/nb-hyphen/minus
+    "‘": "'", "’": "'", "‚": "'", "‛": "'",  # single curly quotes
+    "“": '"', "”": '"', "„": '"', "‟": '"',  # double curly quotes
+    "′": "'", "″": '"', "‵": "'", "‶": '"',  # primes
+    "«": '"', "»": '"', "‹": "'", "›": "'",  # guillemets
+    "…": "...",  # horizontal ellipsis
+    # Exotic / non-breaking spaces -> plain space
+    " ": " ", " ": " ", " ": " ", " ": " ", " ": " ", " ": " ",
+    " ": " ", " ": " ", " ": " ", " ": " ", " ": " ", " ": " ", "　": " ",
+    "�": "",  # replacement char (mojibake artifact)
+}
+# Zero-width / invisible chars models sometimes inject — strip entirely.
+_ZERO_WIDTH = {ord(c): None for c in "​‌‍⁠﻿"}
+
+# Em dash (U+2014) -> spaced hyphen, absorbing any padding so "a — b" and "a—b" both become "a - b".
+_EM_DASH_RE = re.compile(r"[ \t]*—[ \t]*")
+
+
+def normalize_public_text(text: str) -> str:
+    """Normalize AI-generated, public-facing text to plain ASCII punctuation so no rogue non-standard
+    characters (em dashes, smart quotes, ellipsis, exotic spaces, zero-width/control chars) leak out.
+    Em dashes become a spaced hyphen; emojis, accented letters and intentional bullets are preserved."""
+    if not text:
+        return text
+    text = _EM_DASH_RE.sub(" - ", text)
+    for bad, good in _TYPOGRAPHY_MAP.items():
+        text = text.replace(bad, good)
+    text = text.translate(_ZERO_WIDTH)
+    # Drop control chars except tab/newline/carriage-return.
+    text = "".join(c for c in text if c in "\n\r\t" or unicodedata.category(c)[0] != "C")
+    # Collapse runs of spaces/tabs left by the substitutions (never touch newlines).
+    text = re.sub(r"[ \t]{2,}", " ", text)
+    return text
+
+
+# Drop-in directive for AI system prompts so models avoid the fancy punctuation in the first place
+# (normalize_public_text is the safety net; this is the prevention).
+PLAIN_PUNCTUATION_DIRECTIVE = (
+    "PUNCTUATION: Use only plain ASCII punctuation. NEVER use em dashes or en dashes - use a comma, "
+    "period, or a plain hyphen instead. Do NOT use curly/smart quotes (use straight ' and \") and do "
+    "NOT use the ellipsis character - type three periods. Avoid any other non-standard Unicode "
+    "punctuation; these read as AI-generated."
+)
 
 
 def sanitize_for_linkedin(text: str) -> str:
@@ -6,9 +57,12 @@ def sanitize_for_linkedin(text: str) -> str:
 
     LinkedIn does not render standard markdown. This function removes formatting
     markers while preserving the underlying text, emojis, hashtags, and line breaks.
+    Also normalizes rogue typographic characters (em dashes, smart quotes, ...) to plain ASCII.
     """
     if not text:
         return text
+
+    text = normalize_public_text(text)
 
     # Remove markdown headers (# through ######) at line start, keep the text
     text = re.sub(r"^#{1,6}\s+", "", text, flags=re.MULTILINE)

--- a/tests/unit/app/test_comment_inline.py
+++ b/tests/unit/app/test_comment_inline.py
@@ -19,9 +19,15 @@ class TestStripNonBmp:
         from cqc_lem.app.run_automation import _strip_non_bmp
         assert _strip_non_bmp("Hooked and not even sorry 😄 nice") == "Hooked and not even sorry  nice"
 
-    def test_plain_text_unchanged(self):
+    def test_plain_ascii_unchanged(self):
         from cqc_lem.app.run_automation import _strip_non_bmp
-        assert _strip_non_bmp("plain ascii — even en-dash") == "plain ascii — even en-dash"
+        assert _strip_non_bmp("plain ascii, nothing fancy here") == "plain ascii, nothing fancy here"
+
+    def test_normalizes_rogue_typography(self):
+        # Em dashes / smart quotes are AI tell-tale signs — normalized to plain ASCII before typing.
+        from cqc_lem.app.run_automation import _strip_non_bmp
+        assert _strip_non_bmp("clean copy—no em dashes and “no” smart quotes") == \
+            "clean copy - no em dashes and \"no\" smart quotes"
 
 
 class TestComposerSubmitted:

--- a/tests/unit/utilities/test_linkedin_formatter.py
+++ b/tests/unit/utilities/test_linkedin_formatter.py
@@ -1,7 +1,53 @@
 """Unit tests for LinkedIn text formatter utility."""
 
 import pytest
-from cqc_lem.utilities.linkedin_formatter import sanitize_for_linkedin
+from cqc_lem.utilities.linkedin_formatter import (
+    sanitize_for_linkedin, normalize_public_text, PLAIN_PUNCTUATION_DIRECTIVE)
+
+
+@pytest.mark.unit
+class TestNormalizePublicText:
+    def test_empty_and_none(self):
+        assert normalize_public_text("") == ""
+        assert normalize_public_text(None) is None
+
+    def test_em_dash_becomes_spaced_hyphen(self):
+        assert normalize_public_text("The result—surprising—was clear") == "The result - surprising - was clear"
+        assert normalize_public_text("A — B") == "A - B"
+
+    def test_en_dash_ranges_become_hyphen(self):
+        assert normalize_public_text("pages 5–10") == "pages 5-10"
+
+    def test_smart_quotes_become_straight(self):
+        assert normalize_public_text("“Hello” it’s ‘here’") == "\"Hello\" it's 'here'"
+
+    def test_ellipsis_becomes_three_dots(self):
+        assert normalize_public_text("Wait… really") == "Wait... really"
+
+    def test_zero_width_chars_stripped(self):
+        assert normalize_public_text("in​vis﻿ible") == "invisible"
+
+    def test_replacement_char_removed(self):
+        assert normalize_public_text("bad�char") == "badchar"
+
+    def test_preserves_emoji_accents_and_bullets(self):
+        # Intentional characters must survive: emoji, accented letters, and the LinkedIn bullet.
+        assert normalize_public_text("Café \U0001F680 • bullet") == "Café \U0001F680 • bullet"
+
+    def test_preserves_newlines(self):
+        assert normalize_public_text("line1\n\nline2") == "line1\n\nline2"
+
+    def test_directive_is_ascii_and_nonempty(self):
+        assert PLAIN_PUNCTUATION_DIRECTIVE
+        assert PLAIN_PUNCTUATION_DIRECTIVE.isascii()
+
+
+@pytest.mark.unit
+class TestSanitizeNormalizesTypography:
+    def test_sanitize_strips_markdown_and_typography(self):
+        out = sanitize_for_linkedin("**Bold** text—with em dash and “quotes”")
+        assert out == "Bold text - with em dash and \"quotes\""
+        assert "—" not in out and "“" not in out
 
 
 @pytest.mark.unit


### PR DESCRIPTION
Em dashes, curly quotes, ellipsis chars, and exotic/zero-width spaces are AI tell-tale signs (and sometimes render as mojibake — spotted on carousel slides). This normalizes them to plain ASCII everywhere public-facing, with a prompt directive so models avoid them in the first place.

## Normalizer (`linkedin_formatter.normalize_public_text`)
- **em dash → " - "** (spaced hyphen); en/figure dashes → `-`; curly quotes → straight `'`/`"`; ellipsis `…` → `...`; non-breaking/exotic spaces → normal space; zero-width + replacement chars stripped; control chars dropped (keeps tabs/newlines).
- **Preserves** emojis, accented letters, and the intentional LinkedIn bullet `•`.
- Uses `\u`-escape tables (no fragile literal glyphs).

## Applied at every public choke point
- `sanitize_for_linkedin` → posts + newsletter body
- newsletter **title/subtitle** at generation
- **carousel slides** (recursive dict normalize) — where the user saw rogue chars
- `_strip_non_bmp` → comments/replies/typed fields via Selenium

## Prevention
`PLAIN_PUNCTUATION_DIRECTIVE` injected into the newsletter + carousel system prompts (belt-and-suspenders with the normalizer safety net).

## Testing
- New `normalize_public_text` tests (em dash, en dash, smart quotes, ellipsis, zero-width, replacement char, preserves emoji/accents/bullets/newlines) + sanitize-integration + `_strip_non_bmp` normalization.
- Full suite: **1483 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)