### PR TITLE
feat(ui): consolidate Schedule + Review into one Content Studio page

### DIFF
--- a/src/cqc_lem/ui/src/App.tsx
+++ b/src/cqc_lem/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, useSearchParams } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import Layout from './components/Layout'
@@ -7,11 +7,20 @@ import LoginModal from './components/LoginModal'
 import Dashboard from './pages/Dashboard'
 import Account from './pages/Account'
 import Avatars from './pages/Avatars'
-import ScheduleContent from './pages/ScheduleContent'
-import ReviewSchedule from './pages/ReviewSchedule'
+import ContentStudio from './pages/ContentStudio'
 import Landing from './pages/Landing'
 
 const queryClient = new QueryClient()
+
+// Backward-compat: the old /review page defaulted to the posts-review list, and /review?tab=X
+// deep-linked newsletters/dms. Map those to the consolidated /content tabs. Bare /review must go
+// to the review tab (NOT the compose default).
+function LegacyReviewRedirect() {
+  const [params] = useSearchParams()
+  const tab = params.get('tab')
+  const target = tab === 'newsletters' || tab === 'dms' ? tab : 'review'
+  return <Navigate to={`/content?tab=${target}`} replace />
+}
 
 function AppRoutes() {
   const { user, isLoginModalOpen } = useAuth()
@@ -31,13 +40,12 @@ function AppRoutes() {
             element={<ProtectedRoute><Avatars /></ProtectedRoute>}
           />
           <Route
-            path="schedule"
-            element={<ProtectedRoute><ScheduleContent /></ProtectedRoute>}
+            path="content"
+            element={<ProtectedRoute><ContentStudio /></ProtectedRoute>}
           />
-          <Route
-            path="review"
-            element={<ProtectedRoute><ReviewSchedule /></ProtectedRoute>}
-          />
+          {/* Legacy routes → consolidated Content Studio */}
+          <Route path="schedule" element={<Navigate to="/content" replace />} />
+          <Route path="review" element={<ProtectedRoute><LegacyReviewRedirect /></ProtectedRoute>} />
         </Route>
       </Routes>
     </>

--- a/src/cqc_lem/ui/src/components/Layout.tsx
+++ b/src/cqc_lem/ui/src/components/Layout.tsx
@@ -4,14 +4,13 @@ import AccountReadinessBanner from './AccountReadinessBanner'
 import Footer from './Footer'
 
 // Pages whose features depend on a fully set-up account — show the readiness banner here.
-const AUTOMATION_PATHS = ['/schedule', '/review', '/avatars']
+const AUTOMATION_PATHS = ['/content', '/schedule', '/review', '/avatars']
 
 const navLinks = [
   { to: '/', label: 'Home', end: true },
   { to: '/account', label: 'Account' },
   { to: '/avatars', label: 'Avatars' },
-  { to: '/schedule', label: 'Schedule Post' },
-  { to: '/review', label: 'Review Posts' },
+  { to: '/content', label: 'Content' },
 ]
 
 export default function Layout() {

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -5,15 +5,19 @@ import api from '../api/client'
 import LinkedInPostPreview from '../components/LinkedInPostPreview'
 import NewsletterQueue from './review/NewsletterQueue'
 import ScheduledDMs from './review/ScheduledDMs'
+import ComposePost from './content/ComposePost'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
 import { formatInTimezone } from '../utils/datetime'
 
-type View = 'posts' | 'newsletters' | 'dms'
+// Consolidated content hub: compose posts, schedule DMs, manage newsletters, and review/edit
+// existing content — one page, four tabs, synced to ?tab= for deep-linking.
+type View = 'posts' | 'dms' | 'newsletters' | 'review'
 const VIEWS: { key: View; label: string }[] = [
   { key: 'posts', label: 'Posts' },
-  { key: 'newsletters', label: 'Newsletters' },
   { key: 'dms', label: 'DMs' },
+  { key: 'newsletters', label: 'Newsletters' },
+  { key: 'review', label: 'Review & Edit' },
 ]
 const VIEW_KEYS = VIEWS.map((v) => v.key) as string[]
 
@@ -55,7 +59,7 @@ const STATUS_COLORS: Record<string, string> = {
   scheduled: 'bg-purple-100 text-purple-700',
 }
 
-export default function ReviewSchedule() {
+export default function ContentStudio() {
   const { user, sessionToken } = useAuth()
   const email = user?.email ?? ''
   const qc = useQueryClient()
@@ -223,8 +227,8 @@ export default function ReviewSchedule() {
     <div className="space-y-4">
       {/* Header */}
       <div className="flex items-center justify-between flex-wrap gap-3">
-        <h1 className="text-2xl font-bold text-gray-800">Review</h1>
-        {view === 'posts' && (
+        <h1 className="text-2xl font-bold text-gray-800">Content Studio</h1>
+        {view === 'review' && (
           <button
             onClick={() => weeklyMutation.mutate()}
             disabled={weeklyMutation.isPending}
@@ -233,9 +237,17 @@ export default function ReviewSchedule() {
             {weeklyMutation.isPending ? 'Generating content…' : 'Generate Weekly Content'}
           </button>
         )}
+        {view === 'review' && (
+          <button
+            onClick={() => setView('posts')}
+            className="border border-blue-600 text-blue-700 px-4 py-2 rounded-lg text-sm font-semibold hover:bg-blue-50 transition-colors"
+          >
+            + Schedule a post
+          </button>
+        )}
       </div>
 
-      {/* Posts / Newsletters tabs */}
+      {/* Content tabs */}
       <div className="flex flex-wrap gap-1 border-b border-gray-200">
         {VIEWS.map((v) => (
           <button
@@ -252,11 +264,17 @@ export default function ReviewSchedule() {
         ))}
       </div>
 
+      {/* Compose stays MOUNTED (hidden when inactive) so in-progress captions and generated AI
+          carousel slides survive a tab switch. */}
+      <div className={view === 'posts' ? '' : 'hidden'}>
+        <ComposePost onNavigateTab={(t) => setView(t as View)} />
+      </div>
+
       {view === 'newsletters' && <NewsletterQueue userTimezone={userTimezone} />}
 
       {view === 'dms' && <ScheduledDMs userTimezone={userTimezone} />}
 
-      {view === 'posts' && (
+      {view === 'review' && (
       <>
       {regenNotice && (
         <div className="bg-indigo-50 border border-indigo-200 text-indigo-800 rounded-lg px-4 py-2 text-sm">

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -127,13 +127,13 @@ export default function Dashboard() {
         <h1 className="text-2xl font-bold text-gray-800">Dashboard</h1>
         <div className="flex gap-2">
           <Link
-            to="/schedule"
+            to="/content"
             className="bg-blue-600 text-white px-4 py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 transition-colors"
           >
             + Schedule Post
           </Link>
           <Link
-            to="/review"
+            to="/content?tab=review"
             className="border border-gray-300 text-gray-600 px-4 py-2 rounded-lg text-sm font-semibold hover:bg-gray-50 transition-colors"
           >
             Review Posts
@@ -153,7 +153,7 @@ export default function Dashboard() {
         <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-5">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-lg font-semibold text-gray-700">Planned Tasks</h2>
-            <Link to="/review" className="text-xs text-blue-600 hover:underline">
+            <Link to="/content?tab=review" className="text-xs text-blue-600 hover:underline">
               Manage all
             </Link>
           </div>
@@ -161,7 +161,7 @@ export default function Dashboard() {
             <div className="text-center py-6">
               <p className="text-sm text-gray-400">No upcoming tasks scheduled.</p>
               <Link
-                to="/review"
+                to="/content?tab=review"
                 className="text-xs text-blue-600 hover:underline mt-1 inline-block"
               >
                 Generate weekly content →

--- a/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
@@ -129,7 +129,7 @@ export default function NewsletterCard() {
           </div>
           <p className="text-xs text-gray-500">
             Review &amp; approve drafts on the{' '}
-            <Link to="/review?tab=newsletters" className="text-blue-600 font-medium hover:underline">Review → Newsletters</Link>{' '}
+            <Link to="/content?tab=newsletters" className="text-blue-600 font-medium hover:underline">Content → Newsletters</Link>{' '}
             tab.
           </p>
         </>

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
@@ -1,10 +1,10 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
-import api from '../api/client'
-import LinkedInPostPreview from '../components/LinkedInPostPreview'
-import { useAuth } from '../contexts/AuthContext'
-import { useUserTimezone } from '../hooks/useUserTimezone'
+import api from '../../api/client'
+import LinkedInPostPreview from '../../components/LinkedInPostPreview'
+import { useAuth } from '../../contexts/AuthContext'
+import { useUserTimezone } from '../../hooks/useUserTimezone'
 
 const POST_TYPES = ['TEXT', 'VIDEO', 'CAROUSEL'] as const
 type PostType = typeof POST_TYPES[number]
@@ -40,7 +40,7 @@ interface CarouselTemplate {
   description: string
 }
 
-export default function ScheduleContent() {
+export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: string) => void }) {
   const { user, sessionToken } = useAuth()
   const email = user?.email ?? ''
 
@@ -196,8 +196,6 @@ export default function ScheduleContent() {
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div className="space-y-4">
-        <h1 className="text-2xl font-bold text-gray-800">Schedule Content</h1>
-
         {!email && (
           <div className="bg-red-50 border border-red-200 rounded-lg px-4 py-3 text-sm text-red-700">
             No account email set. Please{' '}
@@ -537,6 +535,12 @@ export default function ScheduleContent() {
           {result && (
             <p className={`text-sm font-medium ${result.ok ? 'text-green-600' : 'text-red-600'}`}>
               {result.msg}
+              {result.ok && onNavigateTab && (
+                <button type="button" onClick={() => onNavigateTab('review')}
+                  className="ml-2 font-semibold text-blue-600 hover:underline">
+                  View in Review &rarr;
+                </button>
+              )}
             </p>
           )}
 


### PR DESCRIPTION
Consolidates the separate **/schedule** ("Schedule Post") and **/review** ("Review Posts") pages into one **/content "Content Studio"** page (designed via a planning pass for a clean, intuitive IA).

## Tabs
1. **Posts** — compose a new post (the old ScheduleContent form: type, AI carousel, avatar, video tier, best-time helper, live preview).
2. **DMs** — schedule 1:1 DMs (from #306).
3. **Newsletters** — the newsletter draft queue.
4. **Review & Edit** — the existing posts review list (filter, bulk actions, per-post edit, quick-delete, regenerate-with-suggestions, Generate Weekly Content).

## Notable
- **State-preserving compose:** the Posts (compose) panel stays mounted (toggled with `hidden`) so a typed caption and — importantly — **generated AI carousel slides** survive a tab switch.
- **Cross-tab affordances:** "View in Review →" after scheduling; "＋ Schedule a post" from the Review tab.
- **Backward-compatible URLs:** `/schedule → /content`; bare `/review → /content?tab=review`; `/review?tab=newsletters|dms` preserved. Nav collapses to a single **Content** link; Dashboard + NewsletterCard links updated.

## Refactor
- `ScheduleContent.tsx → pages/content/ComposePost.tsx` (git-mv, history preserved; header removed, `onNavigateTab` added).
- `ReviewSchedule.tsx → pages/ContentStudio.tsx` (parent owns `?tab=`; posts-review logic now under the Review & Edit tab). `ScheduledDMs` + `NewsletterQueue` reused unchanged.

Frontend `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)