### PR TITLE
feat(content): weave lead-magnet CTA into ~1-in-N generated posts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,10 @@ POST_RESEARCH_ENABLED=true
 # grounded in the target post — a Perplexity call per comment would multiply API spend for
 # marginal value. Opt in only if you want research-backed comments.
 COMMENT_RESEARCH_ENABLED=false
+# Lead-magnet soft-ask cadence: when a user has the "comment KEYWORD → DM" lead magnet enabled,
+# weave the compliant "comment KEYWORD and I'll DM it to you" CTA into roughly 1 in N generated
+# posts (deterministic, keyed off post id). Never every post (that reads as spam / gets flagged).
+LEAD_MAGNET_CTA_EVERY_N=3
 
 # --- Ollama (local + cloud model hosting) ---
 OLLAMA_API_KEY=your_ollama_api_key

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -23,8 +23,10 @@ from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, upda
     get_user_blog_url, get_user_sitemap_url, get_active_user_ids, get_planned_posts_for_next_week, PostStatus, \
     update_db_post_video_url, update_db_post_status, PostType, get_user_preferences, \
     update_db_post_carousel_slides, get_post_content, get_user_timezone, get_engagement_preferences
-from cqc_lem.utilities.db import get_recent_post_shape_history, update_db_post_shape
+from cqc_lem.utilities.db import get_recent_post_shape_history, update_db_post_shape, get_lead_magnet_settings
 from cqc_lem.utilities.ai.content_framework import select_blueprint
+from cqc_lem.utilities.ai.content_alignment import (
+    should_include_lead_magnet_cta, lead_magnet_cta_directive)
 from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_RATIO, \
     DEFAULT_IMAGE_RATIO, AI_DISCLOSURE_ENABLED, AI_DISCLOSURE_TEXT, \
     STANDARD_VIDEO_MODEL, PREMIUM_VIDEO_MODEL, PREMIUM_TOP_VIDEO_MODEL, \
@@ -559,7 +561,8 @@ def regenerate_post_task(post_id: int, guidance: str = None):
 
 
 def create_text_post(user_id: int, stage: str, post_type: str = None, user_profile: LinkedInProfile=None,
-                     refine_final_post: bool = True, blueprint: dict = None, post_id: int = None):
+                     refine_final_post: bool = True, blueprint: dict = None, post_id: int = None,
+                     lead_magnet_cta: str = None):
     """
     Generate a text post for LinkedIn based on the user's profile, blog, or website content.
 
@@ -619,12 +622,31 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
     myprint(f"Post blueprint: format={blueprint.get('format')} hook={blueprint.get('hook_style')} "
             f"cta={blueprint.get('cta_style')}")
 
+    # Lead-magnet soft-ask: on a deterministic 1-in-N rotation (keyed off post_id so it's stable and
+    # testable), weave the user's configured "comment KEYWORD and I'll DM it to you" CTA into the
+    # post — the compliant way to share a resource and what fires the keyword listener in the
+    # automation. Only SOME posts get it (all = spammy/pattern-flagged). Recursive fallbacks reuse
+    # the already-computed directive so the same post stays consistent. No-op unless the user enabled
+    # the lead magnet with a non-empty keyword.
+    if lead_magnet_cta is None:
+        try:
+            lead_magnet = get_lead_magnet_settings(user_id)
+            include_cta = should_include_lead_magnet_cta(lead_magnet, post_id)
+            lead_magnet_cta = lead_magnet_cta_directive(lead_magnet, include_cta)
+            if lead_magnet_cta:
+                myprint(f"Lead-magnet CTA included on post_id={post_id} "
+                        f"(keyword '{lead_magnet.get('keyword')}')")
+        except Exception as e:
+            myprint(f"Lead-magnet CTA skipped (settings unavailable): {e}")
+            lead_magnet_cta = ""
+
     # Generate the post based on the selected type
     myprint(f"Creating text post of type: {post_type} for stage: {stage}")
     if post_type == "thought_leadership":
         final_content = get_thought_leadership_post_from_ai(user_profile, stage, prefs=prefs,
                                                             profile_synthesis=profile_synthesis,
-                                                            blueprint=blueprint)
+                                                            blueprint=blueprint,
+                                                            lead_magnet_cta=lead_magnet_cta)
     elif post_type == "blog_summary":
         # Get the users blog url
         user_main_blog_url = get_user_blog_url(user_id)
@@ -633,21 +655,21 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
             process_selected_post(blog_post_url, blog_post_content)
             final_content = get_blog_summary_post_from_ai(blog_post_url, blog_post_content, user_profile, stage,
                                                           prefs=prefs, profile_synthesis=profile_synthesis,
-                                                          blueprint=blueprint)
+                                                          blueprint=blueprint, lead_magnet_cta=lead_magnet_cta)
         else:
             myprint("No blog post found for this user. Generating another post type")
             # Chose another random post type that is not "blog_summary"
             post_types.remove("blog_summary")
             post_type = random.choice(post_types)
             final_content = create_text_post(user_id, stage, post_type, user_profile, refine_final_post=False,
-                                             blueprint=blueprint)
+                                             blueprint=blueprint, lead_magnet_cta=lead_magnet_cta)
     elif post_type == "website_content":
         # Get the users sitemap url
         sitemap_url = get_user_sitemap_url(user_id)
         if sitemap_url:
             content = generate_website_content_post(sitemap_url, user_profile, stage, prefs=prefs,
                                                     profile_synthesis=profile_synthesis,
-                                                    blueprint=blueprint)
+                                                    blueprint=blueprint, lead_magnet_cta=lead_magnet_cta)
             if content:
                 final_content = content
             else:
@@ -656,26 +678,26 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
                 post_types.remove("website_content")
                 post_type = random.choice(post_types)
                 final_content = create_text_post(user_id, stage, post_type, user_profile, refine_final_post=False,
-                                             blueprint=blueprint)
+                                             blueprint=blueprint, lead_magnet_cta=lead_magnet_cta)
         else:
             myprint("No sitemap found for this user. Generating another post type")
             # Chose another random post type that is not "website_content"
             post_types.remove("website_content")
             post_type = random.choice(post_types)
             final_content = create_text_post(user_id, stage, post_type, user_profile, refine_final_post=False,
-                                             blueprint=blueprint)
+                                             blueprint=blueprint, lead_magnet_cta=lead_magnet_cta)
     elif post_type == "industry_news":
         final_content = get_industry_news_post_from_ai(user_profile, stage, prefs=prefs,
                                                        profile_synthesis=profile_synthesis,
-                                                       blueprint=blueprint)
+                                                       blueprint=blueprint, lead_magnet_cta=lead_magnet_cta)
     elif post_type == "personal_story":
         final_content = get_personal_story_post_from_ai(user_profile, stage, prefs=prefs,
                                                         profile_synthesis=profile_synthesis,
-                                                        blueprint=blueprint)
+                                                        blueprint=blueprint, lead_magnet_cta=lead_magnet_cta)
     else:
         final_content = generate_engagement_prompt_post(user_profile, stage, prefs=prefs,
                                                         profile_synthesis=profile_synthesis,
-                                                        blueprint=blueprint)
+                                                        blueprint=blueprint, lead_magnet_cta=lead_magnet_cta)
 
     if refine_final_post:
         final_content = get_ai_linked_post_refinement(final_content)
@@ -846,7 +868,8 @@ def process_selected_post(url, content):
 
 
 def generate_website_content_post(sitemap_url, linked_user_profile, stage: str, prefs: dict = None,
-                                  profile_synthesis: str = None, blueprint: dict = None):
+                                  profile_synthesis: str = None, blueprint: dict = None,
+                                  lead_magnet_cta: str = None):
     """
     Generate a post based on content found on the user's website using their sitemap url catered to readers in the desired buyers journey stage.
     Scrapes or retrieves key points from the website's sitemap.
@@ -877,7 +900,7 @@ def generate_website_content_post(sitemap_url, linked_user_profile, stage: str, 
             # 4. Generate a social media post based on the extracted content
             social_media_post = get_website_content_post_from_ai(content, selected_url, linked_user_profile, stage,
                                                                  prefs=prefs, profile_synthesis=profile_synthesis,
-                                                                 blueprint=blueprint)
+                                                                 blueprint=blueprint, lead_magnet_cta=lead_magnet_cta)
             return social_media_post
         else:
             myprint("No content extracted from the selected URL.")

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -1258,7 +1258,7 @@ def create_video_from_prompt(prompt: str):
 
 def get_thought_leadership_post_from_ai(linked_user_profile: LinkedInProfile, buyer_stage: str,
                                         prefs: dict = None, profile_synthesis: str = None,
-                                        blueprint: dict = None):
+                                        blueprint: dict = None, lead_magnet_cta: str = None):
     """
         Generate a thought leadership post based on user's expertise and industry.
         Uses the user's profile (e.g., job title, industry) and intended buyer_stage to form an insightful post.
@@ -1294,7 +1294,7 @@ def get_thought_leadership_post_from_ai(linked_user_profile: LinkedInProfile, bu
     # Add the industry trend analysis to the prompt
     prompt += f"\n ### Current {industry} Trends: <analysis>{analysis}</analysis>"
 
-    prompt += _alignment_directive(prefs)
+    prompt += _alignment_directive(prefs, lead_magnet_cta)
     # Shared framework core: this post's assigned archetype/hook/CTA blueprint (rotated across
     # the user's recent posts by the caller) + the invariant short-form craft rules + prefs.
     prompt += _framework.blueprint_directive("post", blueprint)
@@ -1434,7 +1434,7 @@ def get_industry_trend_analysis_based_on_user_profile(linked_in_profile: LinkedI
 
 def get_industry_news_post_from_ai(linked_user_profile: LinkedInProfile, buyer_stage: str,
                                    prefs: dict = None, profile_synthesis: str = None,
-                                   blueprint: dict = None):
+                                   blueprint: dict = None, lead_magnet_cta: str = None):
     """
        Generate a post sharing industry news based on the LinkedIn user's profile and the intended buyer stage, along with the user's commentary.
     """
@@ -1470,7 +1470,7 @@ def get_industry_news_post_from_ai(linked_user_profile: LinkedInProfile, buyer_s
     
     """
 
-    prompt += _alignment_directive(prefs)
+    prompt += _alignment_directive(prefs, lead_magnet_cta)
     # Shared framework core: this post's assigned archetype/hook/CTA blueprint (rotated across
     # the user's recent posts by the caller) + the invariant short-form craft rules + prefs.
     prompt += _framework.blueprint_directive("post", blueprint)
@@ -1619,7 +1619,7 @@ def get_industry_trend_from_ai(industry: str, articles: list):
 
 def get_personal_story_post_from_ai(linked_user_profile: LinkedInProfile, stage: str,
                                     prefs: dict = None, profile_synthesis: str = None,
-                                    blueprint: dict = None):
+                                    blueprint: dict = None, lead_magnet_cta: str = None):
     """
     Generate a post sharing a personal or professional story, based on the user's profile.
     """
@@ -1659,7 +1659,7 @@ def get_personal_story_post_from_ai(linked_user_profile: LinkedInProfile, stage:
         
         """
 
-    prompt += _alignment_directive(prefs)
+    prompt += _alignment_directive(prefs, lead_magnet_cta)
     # Shared framework core: this post's assigned archetype/hook/CTA blueprint (rotated across
     # the user's recent posts by the caller) + the invariant short-form craft rules + prefs.
     prompt += _framework.blueprint_directive("post", blueprint)
@@ -1733,7 +1733,7 @@ def get_personal_story_post_from_ai(linked_user_profile: LinkedInProfile, stage:
 
 def generate_engagement_prompt_post(linked_user_profile: LinkedInProfile, stage: str,
                                     prefs: dict = None, profile_synthesis: str = None,
-                                    blueprint: dict = None):
+                                    blueprint: dict = None, lead_magnet_cta: str = None):
     """
     Generate a question or prompt that encourages engagement from followers.
     """
@@ -1771,7 +1771,7 @@ def generate_engagement_prompt_post(linked_user_profile: LinkedInProfile, stage:
             
             """
 
-    prompt += _alignment_directive(prefs)
+    prompt += _alignment_directive(prefs, lead_magnet_cta)
     # Shared framework core: this post's assigned archetype/hook/CTA blueprint (rotated across
     # the user's recent posts by the caller) + the invariant short-form craft rules + prefs.
     prompt += _framework.blueprint_directive("post", blueprint)
@@ -1843,7 +1843,7 @@ def generate_engagement_prompt_post(linked_user_profile: LinkedInProfile, stage:
 
 def get_blog_summary_post_from_ai(blog_post_url: str, blog_post_content: str, linked_user_profile: LinkedInProfile,
                                   stage: str, prefs: dict = None, profile_synthesis: str = None,
-                                  blueprint: dict = None):
+                                  blueprint: dict = None, lead_magnet_cta: str = None):
     """
     Generate a summary post for a blog article using the provide post url and post content from user to create interest using relevance to the provided LinkedIn Profile.
     """
@@ -1878,7 +1878,7 @@ def get_blog_summary_post_from_ai(blog_post_url: str, blog_post_content: str, li
     
     """
 
-    prompt += _alignment_directive(prefs)
+    prompt += _alignment_directive(prefs, lead_magnet_cta)
     # Shared framework core: this post's assigned archetype/hook/CTA blueprint (rotated across
     # the user's recent posts by the caller) + the invariant short-form craft rules + prefs.
     prompt += _framework.blueprint_directive("post", blueprint)
@@ -1950,7 +1950,7 @@ def get_blog_summary_post_from_ai(blog_post_url: str, blog_post_content: str, li
 
 def get_website_content_post_from_ai(content: str, url: str, linked_user_profile: LinkedInProfile, stage: str,
                                      prefs: dict = None, profile_synthesis: str = None,
-                                     blueprint: dict = None):
+                                     blueprint: dict = None, lead_magnet_cta: str = None):
     """
         Generate a summary post for a blog article using the provide post url and post content from user to create interest using relevance to the provided LinkedIn Profile.
         """
@@ -1984,7 +1984,7 @@ def get_website_content_post_from_ai(content: str, url: str, linked_user_profile
 
                 """
 
-    prompt += _alignment_directive(prefs)
+    prompt += _alignment_directive(prefs, lead_magnet_cta)
     # Shared framework core: this post's assigned archetype/hook/CTA blueprint (rotated across
     # the user's recent posts by the caller) + the invariant short-form craft rules + prefs.
     prompt += _framework.blueprint_directive("post", blueprint)

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -6,6 +6,7 @@ a HARD no-self-promo guardrail for comments/posts, a LIGHT soft-promo allowance 
 own newsletter. Keeping all of this in one module is what stops the content types from drifting
 out of alignment with each other over time."""
 
+import os
 from typing import Optional
 
 # Tight, engagement-optimized targets. Short is the default: LinkedIn rewards comments that
@@ -130,12 +131,67 @@ def intention_directive(prefs: dict = None) -> str:
     return directive
 
 
-def alignment_directive(prefs: dict = None) -> str:
+def alignment_directive(prefs: dict = None, lead_magnet_cta: str = "") -> str:
     """Anti-self-promo guardrail + focus/goal steering, appended to POST prompts so generated posts
     stay aligned to the user's real business/personal goals instead of drifting into promoting
-    whatever the user happens to be building right now."""
+    whatever the user happens to be building right now. `lead_magnet_cta` (built by
+    lead_magnet_cta_directive) is the ONE sanctioned exception to the guardrail and is appended
+    only for the posts the rotation selects — see should_include_lead_magnet_cta."""
     return ("\n\nContent alignment rules:\n- " + NO_SELF_PROMO_GUARDRAIL
-            + "\n- " + engagement_purpose("post") + focus_directive(prefs))
+            + "\n- " + engagement_purpose("post") + focus_directive(prefs)
+            + (lead_magnet_cta or ""))
+
+
+# The lead-magnet soft-ask ("comment KEYWORD and I'll DM it to you") is the compliant way to share a
+# resource on LinkedIn — links in the post body get down-ranked, and it's what fires the keyword
+# listener in run_automation. But it must NOT appear on every post: a repeated CTA reads as spam and
+# gets pattern-flagged. So it rides a deterministic 1-in-N rotation (default N=3, env-overridable).
+LEAD_MAGNET_CTA_EVERY_N = int(os.getenv("LEAD_MAGNET_CTA_EVERY_N", "3") or "3")
+
+
+def lead_magnet_enabled(lead_magnet: Optional[dict]) -> bool:
+    """The lead magnet is usable only when the user turned it ON and gave a non-empty trigger keyword
+    (matches the gate the automation keyword-listener uses)."""
+    return bool(lead_magnet and lead_magnet.get("enabled")
+                and str(lead_magnet.get("keyword") or "").strip())
+
+
+def should_include_lead_magnet_cta(lead_magnet: Optional[dict], sequence_index: Optional[int],
+                                   every_n: Optional[int] = None) -> bool:
+    """Deterministic 1-in-N selection: the soft-ask goes on SOME posts, never all. `sequence_index`
+    is any stable per-post integer (the post id works) so the choice is reproducible and testable —
+    no per-call randomness. Returns False when the lead magnet is off/unkeyworded or no index is
+    available."""
+    if not lead_magnet_enabled(lead_magnet) or sequence_index is None:
+        return False
+    n = every_n if (every_n and every_n > 0) else LEAD_MAGNET_CTA_EVERY_N
+    if n <= 1:
+        return True
+    return int(sequence_index) % n == 0
+
+
+def lead_magnet_cta_directive(lead_magnet: Optional[dict], include: bool) -> str:
+    """The SANCTIONED lead-magnet CTA line appended to a post prompt. This is the ONE allowed
+    exception to NO_SELF_PROMO_GUARDRAIL because it is the user's OWN explicitly-configured offer.
+    Woven in the user's voice by the model, references the ACTUAL trigger keyword, and describes the
+    resource's value. Returns "" when not selected or when the lead magnet is off — so callers can
+    always append it unconditionally."""
+    if not include or not lead_magnet_enabled(lead_magnet):
+        return ""
+    keyword = str(lead_magnet.get("keyword")).strip()
+    resource_context = str(lead_magnet.get("message") or "").strip()[:240]
+    context_line = (f"\n- For context, the resource being offered is described as: "
+                    f"\"{resource_context}\". Convey its value in one plainspoken sentence."
+                    if resource_context else "")
+    return (
+        "\n\nSANCTIONED lead-magnet call-to-action (this post ONLY — the user has explicitly "
+        "configured this offer, so it OVERRIDES the no-self-promo guardrail for THIS CTA):\n"
+        f"- End the post with a short, soft invitation for readers to comment the exact word "
+        f"\"{keyword}\" to receive the resource; it will be delivered by DM after they comment.\n"
+        "- Write it in the user's own voice — plainspoken, no hype, no hard sell, and NO link in the "
+        "post body (the DM delivers it). Honor the user's emoji/hashtag settings.\n"
+        "- Keep it to one clean ask; do NOT stack multiple asks or use engagement-bait phrasing "
+        "(no 'tag a friend', no 'like if')." + context_line + "\n")
 
 
 def voice_reference(profile, profile_synthesis: Optional[str] = None) -> str:

--- a/tests/unit/app/test_post_shape_rotation.py
+++ b/tests/unit/app/test_post_shape_rotation.py
@@ -10,16 +10,22 @@ pytestmark = pytest.mark.unit
 _RCP = "cqc_lem.app.run_content_plan"
 
 
-def _run(post_id=77, blueprint=None, history=None):
+_DISABLED_LM = {"enabled": False, "keyword": None, "message": None}
+
+
+def _run(post_id=77, blueprint=None, history=None, lead_magnet=None):
     from cqc_lem.app import run_content_plan as rcp
     captured = {}
 
-    def gen(user_profile, stage, prefs=None, profile_synthesis=None, blueprint=None):
+    def gen(user_profile, stage, prefs=None, profile_synthesis=None, blueprint=None,
+            lead_magnet_cta=None):
         captured["blueprint"] = blueprint
+        captured["lead_magnet_cta"] = lead_magnet_cta
         return "generated post"
 
     with patch(f"{_RCP}.get_engagement_preferences", return_value={}), \
          patch(f"{_RCP}.get_or_create_profile_synthesis", return_value="voice"), \
+         patch(f"{_RCP}.get_lead_magnet_settings", return_value=lead_magnet or _DISABLED_LM), \
          patch(f"{_RCP}.get_recent_post_shape_history", return_value=history or []) as hist, \
          patch(f"{_RCP}.update_db_post_shape") as save, \
          patch(f"{_RCP}.get_thought_leadership_post_from_ai", side_effect=gen):
@@ -54,10 +60,29 @@ class TestPostShapeRotation:
         hist.assert_not_called()
         save.assert_called_once_with(77, "tactical_list", "bold_claim")
 
+    def test_lead_magnet_cta_woven_when_enabled_and_selected(self):
+        lm = {"enabled": True, "keyword": "AUDIT", "message": "Free profile audit checklist."}
+        # post_id=3 is a multiple of the default 1-in-3 cadence → selected.
+        _, captured, _, _ = _run(post_id=3, lead_magnet=lm)
+        cta = captured["lead_magnet_cta"]
+        assert cta and "AUDIT" in cta and "SANCTIONED" in cta
+
+    def test_lead_magnet_cta_absent_when_not_selected(self):
+        lm = {"enabled": True, "keyword": "AUDIT", "message": "Free profile audit checklist."}
+        # post_id=77 (77 % 3 != 0) is NOT selected → no CTA on this post.
+        _, captured, _, _ = _run(post_id=77, lead_magnet=lm)
+        assert captured["lead_magnet_cta"] == ""
+
+    def test_lead_magnet_cta_absent_when_disabled(self):
+        lm = {"enabled": False, "keyword": "AUDIT", "message": "Free profile audit checklist."}
+        _, captured, _, _ = _run(post_id=3, lead_magnet=lm)
+        assert captured["lead_magnet_cta"] == ""
+
     def test_shape_history_failure_never_blocks_generation(self):
         from cqc_lem.app import run_content_plan as rcp
         with patch(f"{_RCP}.get_engagement_preferences", return_value={}), \
              patch(f"{_RCP}.get_or_create_profile_synthesis", return_value="voice"), \
+             patch(f"{_RCP}.get_lead_magnet_settings", return_value={"enabled": False, "keyword": None, "message": None}), \
              patch(f"{_RCP}.get_recent_post_shape_history", side_effect=RuntimeError("db down")), \
              patch(f"{_RCP}.update_db_post_shape"), \
              patch(f"{_RCP}.get_thought_leadership_post_from_ai", return_value="post"):

--- a/tests/unit/utilities/ai/test_content_alignment.py
+++ b/tests/unit/utilities/ai/test_content_alignment.py
@@ -61,3 +61,57 @@ class TestStyleDirectivePerType:
     def test_empty_prefs_yield_empty_directive(self):
         assert ca.style_directive(None) == ""
         assert ca.style_directive({}) == ""
+
+
+class TestLeadMagnetCTA:
+    _ON = {"enabled": True, "keyword": "AUDIT", "message": "A free 12-point LinkedIn profile audit PDF."}
+    _OFF = {"enabled": False, "keyword": "AUDIT", "message": "audit"}
+    _NO_KEYWORD = {"enabled": True, "keyword": "  ", "message": "audit"}
+
+    def test_enabled_requires_on_and_keyword(self):
+        assert ca.lead_magnet_enabled(self._ON) is True
+        assert ca.lead_magnet_enabled(self._OFF) is False
+        assert ca.lead_magnet_enabled(self._NO_KEYWORD) is False
+        assert ca.lead_magnet_enabled(None) is False
+
+    def test_directive_included_only_when_enabled_and_selected(self):
+        d = ca.lead_magnet_cta_directive(self._ON, include=True)
+        assert "AUDIT" in d
+        assert "SANCTIONED" in d
+        assert "OVERRIDES the no-self-promo guardrail" in d
+        # resource value is threaded in for the model to paraphrase in voice
+        assert "12-point LinkedIn profile audit" in d
+
+    def test_directive_absent_when_not_selected(self):
+        assert ca.lead_magnet_cta_directive(self._ON, include=False) == ""
+
+    def test_directive_absent_when_disabled(self):
+        assert ca.lead_magnet_cta_directive(self._OFF, include=True) == ""
+        assert ca.lead_magnet_cta_directive(self._NO_KEYWORD, include=True) == ""
+
+    def test_selection_off_when_lead_magnet_off_or_no_index(self):
+        assert ca.should_include_lead_magnet_cta(self._OFF, 3) is False
+        assert ca.should_include_lead_magnet_cta(self._ON, None) is False
+
+    def test_selection_is_deterministic_and_roughly_one_in_n(self):
+        n = 3
+        selected = [i for i in range(300)
+                    if ca.should_include_lead_magnet_cta(self._ON, i, every_n=n)]
+        # exactly the multiples of N → deterministic 1-in-N
+        assert selected == list(range(0, 300, n))
+        assert len(selected) == 100
+        # stable across repeated calls (no per-call randomness)
+        assert all(ca.should_include_lead_magnet_cta(self._ON, i, every_n=n) for i in selected)
+        assert not any(ca.should_include_lead_magnet_cta(self._ON, i, every_n=n)
+                       for i in range(300) if i % n != 0)
+
+    def test_every_n_of_one_selects_all(self):
+        assert all(ca.should_include_lead_magnet_cta(self._ON, i, every_n=1) for i in range(10))
+
+    def test_alignment_directive_appends_cta_when_given(self):
+        cta = ca.lead_magnet_cta_directive(self._ON, include=True)
+        d = ca.alignment_directive(None, lead_magnet_cta=cta)
+        assert ca.NO_SELF_PROMO_GUARDRAIL in d
+        assert "AUDIT" in d and "SANCTIONED" in d
+        # default (no CTA) leaves the directive unchanged
+        assert "SANCTIONED" not in ca.alignment_directive(None)

--- a/tests/unit/utilities/test_linkedin_formatter.py
+++ b/tests/unit/utilities/test_linkedin_formatter.py
@@ -2,7 +2,36 @@
 
 import pytest
 from cqc_lem.utilities.linkedin_formatter import (
-    sanitize_for_linkedin, normalize_public_text, PLAIN_PUNCTUATION_DIRECTIVE)
+    sanitize_for_linkedin, normalize_public_text, PLAIN_PUNCTUATION_DIRECTIVE,
+    strip_engagement_bait)
+
+
+@pytest.mark.unit
+class TestStripEngagementBait:
+    @pytest.mark.parametrize("bait", [
+        "Tag a friend who needs this.",
+        "Like if you agree!",
+        "Comment YES below if you want more.",
+        "Repost this if it helped.",
+    ])
+    def test_strips_classic_bait_lines(self, bait):
+        text = f"Here is a real insight.\n\n{bait}"
+        out = strip_engagement_bait(text)
+        assert "real insight" in out
+        assert bait not in out
+
+    def test_preserves_lead_magnet_cta(self):
+        # A sanctioned lead-magnet CTA ("comment KEYWORD") must survive the bait filter.
+        text = ("Cutting acquisition cost took us six months of testing.\n\n"
+                "Comment AUDIT and I'll DM you the 12-point checklist we used.")
+        out = strip_engagement_bait(text)
+        assert "Comment AUDIT" in out
+        assert "12-point checklist" in out
+
+    def test_preserves_lead_magnet_cta_lowercase(self):
+        text = "Real value here.\n\ncomment SCALE and I'll send over the playbook."
+        out = strip_engagement_bait(text)
+        assert "comment SCALE" in out
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem
When the **Comment → DM Lead Magnet** is configured (keyword + resource DM), the automation listens for the trigger keyword in comments and auto-DMs the resource. But **generated posts never told readers to comment the keyword**, so the listener rarely fired — and the no-self-promo guardrail actively suppressed that kind of ask. This is the compliant way to share a resource on LinkedIn (body links get down-ranked).

## Fix (in the shared alignment core — no parallel path)
`content_alignment.py`:
- `lead_magnet_enabled()` — gate: enabled **and** non-empty keyword (matches the automation's gate).
- `should_include_lead_magnet_cta(lead_magnet, sequence_index, every_n)` — **deterministic 1-in-N** selection keyed off `post_id` (`id % N == 0`); no per-call randomness, fully testable. Default `N=3`, override via `LEAD_MAGNET_CTA_EVERY_N`.
- `lead_magnet_cta_directive()` — the **sanctioned** CTA directive (the ONE explicit exception to `NO_SELF_PROMO_GUARDRAIL`): asks readers to comment the exact keyword, conveys the resource's value, **in the user's voice**, no link in the body (delivered by DM), honors emoji/hashtag prefs, one clean ask, no engagement-bait.
- `alignment_directive(prefs, lead_magnet_cta="")` — backward-compatible extension.

`ai_helper.py` — all 6 post generators accept `lead_magnet_cta` and pass it through `_alignment_directive`. `run_content_plan.py::create_text_post` computes the directive once from the user's lead-magnet settings + the 1-in-N rule and threads it through every generator + fallbacks so a post is consistent.

## Why it's optimized / aligned
- **Some posts, not all:** ~1 in 3 (configurable). A CTA on every post reads as spam and gets pattern-flagged.
- **No-op** unless the lead magnet is enabled with a keyword; only applies to the user's own content-plan posts (not comments).
- `strip_engagement_bait` already preserves "comment KEYWORD" (verified with a new test).

## Tests
New coverage for the gate, 1-in-N determinism (exact over 300 ids), N=1 selects-all, disabled/not-selected → absent, directive wiring, and bait-strip preservation. **`poetry run pytest tests/unit` → 1596 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)