### PR TITLE
fix: clean up coverage-found bugs + Copilot review findings (21 items)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,7 +99,7 @@ POST_RESEARCH_ENABLED=true
 COMMENT_RESEARCH_ENABLED=false
 # Lead-magnet soft-ask cadence: when a user has the "comment KEYWORD → DM" lead magnet enabled,
 # weave the compliant "comment KEYWORD and I'll DM it to you" CTA into roughly 1 in N generated
-# posts (deterministic, keyed off post id). Never every post (that reads as spam / gets flagged).
+# posts (deterministic, keyed off post id). Never on every post (that reads as spam / gets flagged).
 LEAD_MAGNET_CTA_EVERY_N=3
 # Post uniqueness review gate: a new post whose normalized token-set overlap with any recent post
 # (last ~20 pending/approved/posted) exceeds this ceiling is regenerated ONCE with an explicit

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1195,7 +1195,7 @@ def _compute_next_publish(user_id: int, anchor=None):
     """Next scheduled publish datetime (naive UTC) after `anchor`, or None. When `anchor` is None the
     user's last_published_at is used, giving the soonest upcoming slot."""
     import pytz
-    from datetime import datetime as _dt
+    from datetime import datetime as _dt, timezone as _tz
     from cqc_lem.utilities.newsletter import next_publish_datetime
     settings = get_newsletter_settings(user_id)
     try:
@@ -1206,7 +1206,8 @@ def _compute_next_publish(user_id: int, anchor=None):
         anchor = settings.get("last_published_at")
     return next_publish_datetime(
         settings.get("publish_day", 1), settings.get("publish_hour", 9),
-        settings.get("cadence", "weekly"), anchor, tz, _dt.utcnow())
+        settings.get("cadence", "weekly"), anchor, tz,
+        _dt.now(_tz.utc).replace(tzinfo=None))  # naive UTC — compared to naive DB datetimes
 
 
 @router.get("/user/newsletter-draft")

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -49,7 +49,7 @@ from cqc_lem.utilities.db import (
     get_avatar_trainings, get_active_avatar,
     get_user_timezone, update_user_timezone,
     get_user_geo, update_user_location,
-    replace_video_url_base, get_post_type, get_post_buyer_stage,
+    replace_video_url_base, get_post_type, get_post_buyer_stage, get_post_status,
     update_db_post_carousel_slides,
     get_post_url_from_log_for_user,
 )
@@ -1275,6 +1275,13 @@ def regenerate_post_endpoint(request: PostRegenerateRequest) -> ResponseModel:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
     if get_post_user_id(request.post_id) != user_id:
         raise HTTPException(status_code=404, detail="Post not found")
+    # Regeneration resets the post to PENDING — only sensible from the review states. Regenerating
+    # a scheduled/posted/rejected post would silently yank it out of (or back into) the pipeline.
+    post_status = get_post_status(request.post_id)
+    if post_status not in (PostStatus.PENDING.value, PostStatus.APPROVED.value):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Post is '{post_status}' — only pending or approved posts can be regenerated")
     from cqc_lem.app.run_content_plan import regenerate_post_task
     guidance = (request.guidance or "").strip() or None
     regenerate_post_task.apply_async(kwargs={"post_id": request.post_id, "guidance": guidance})

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1318,7 +1318,14 @@ def update_scheduled_dm_endpoint(request: UpdateDmRequest) -> ResponseModel:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
     if get_scheduled_dm_user_id(request.dm_id) != user_id:
         raise HTTPException(status_code=404, detail="Scheduled DM not found")
-    status = {"approve": ScheduledDmStatus.APPROVED, "cancel": ScheduledDmStatus.CANCELED}.get(request.action)
+    action_map = {"approve": ScheduledDmStatus.APPROVED, "cancel": ScheduledDmStatus.CANCELED}
+    if request.action is not None and request.action not in action_map:
+        raise HTTPException(status_code=422,
+                            detail=f"Unknown action '{request.action}' — expected 'approve' or 'cancel'")
+    status = action_map.get(request.action)
+    if status is None and all(v is None for v in (request.recipient_profile_url, request.recipient_name,
+                                                  request.message, request.scheduled_datetime)):
+        raise HTTPException(status_code=422, detail="Nothing to update — provide at least one field or an action")
     if not update_scheduled_dm(request.dm_id, recipient_profile_url=request.recipient_profile_url,
                                recipient_name=request.recipient_name, message=request.message,
                                scheduled_time=request.scheduled_datetime, status=status):

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -79,7 +79,7 @@ from fastapi.staticfiles import StaticFiles
 from linkedin_api.clients.auth.client import AuthClient
 from linkedin_api.clients.restli.client import RestliClient
 from linkedin_api.common.errors import ResponseFormattingError
-from pydantic import BaseModel, computed_field, field_validator, model_validator, Field
+from pydantic import BaseModel, field_validator, model_validator, Field
 
 app = FastAPI()
 
@@ -228,17 +228,6 @@ class UpgradeVideoRequest(BaseModel):
 
 class AvatarActivateRequest(BaseModel):
     session_token: str
-
-    @property
-    def post_json(self):
-        json = self.model_dump()
-        json['scheduled_datetime'] = self.scheduled_time
-        return json
-
-    @computed_field
-    @property
-    def scheduled_time(self) -> str:
-        return self.scheduled_datetime.isoformat()
 
 
 class BulkUpdateRequest(BaseModel):

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1403,6 +1403,15 @@ def update_lead_magnet_endpoint(request: LeadMagnetRequest) -> ResponseModel:
     user_id = get_session_user_id(request.session_token)
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
+    # A trigger word that itself reads as engagement bait (YES/AGREE/BELOW/AMEN/ME/👇) would be
+    # stripped from generated posts by the bait filter — reject it up front.
+    from cqc_lem.utilities.linkedin_formatter import is_bait_keyword
+    if request.keyword and is_bait_keyword(request.keyword):
+        raise HTTPException(
+            status_code=422,
+            detail=(f"Keyword '{request.keyword.strip()}' collides with the engagement-bait filter "
+                    "(words like YES, AGREE, BELOW, AMEN, ME). Choose a distinctive trigger word "
+                    "such as AUDIT or GUIDE."))
     if not update_lead_magnet_settings(user_id, request.model_dump(exclude={"session_token"})):
         raise HTTPException(status_code=500, detail="Could not update lead magnet")
     return ResponseModel(status_code=200, detail="Lead magnet updated")

--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -68,7 +68,7 @@ def get_aws_sqs(queue_name: str,
                 # region_name: str,
                 session: boto3.session.Session) -> dict:
     sqs = session.client(
-        service_name='elasticcache',
+        service_name='sqs',
         # region_name=region_name
     )
 

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -1,5 +1,5 @@
 import time as _time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from celery import Celery
 from celery import current_app
@@ -284,7 +284,7 @@ def update_queue_length_metric(sender=None, headers=None, **kwargs) -> int:
                         'MetricName': 'QueueLength',
                         'Value': total_tasks,
                         'Unit': 'Count',
-                        'Timestamp': datetime.utcnow(),
+                        'Timestamp': datetime.now(timezone.utc),
                         'Dimensions': [
                             {
                                 'Name': 'QueueName',

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -528,7 +528,8 @@ def regenerate_post(post_id: int, guidance: str = None) -> Optional[str]:
         return None
     post_type = get_post_type(post_id)
     pt_value = post_type.value if isinstance(post_type, PostType) else post_type
-    if pt_value and pt_value != PostType.TEXT.value:
+    # Unknown/None type counts as non-text: regenerating blind could clobber a carousel/video post.
+    if pt_value != PostType.TEXT.value:
         myprint(f"regenerate_post: post {post_id} is '{pt_value}', not text — skipping text regenerate")
         return None
 

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -813,8 +813,11 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
         # Hook + save-worthy pass: strong first line before the '…more' fold; save-worthy framing.
         final_content = optimize_post_hook(final_content, prefs=prefs)
         final_content = sanitize_for_linkedin(final_content)
-        # Guardrail: strip classic engagement-bait CTAs (penalized), keeping lead-magnet CTAs.
-        final_content = strip_engagement_bait(final_content)
+        # Guardrail: strip classic engagement-bait CTAs (penalized), keeping lead-magnet CTAs —
+        # including one whose configured trigger word collides with the bait regex (e.g. 'YES').
+        final_content = strip_engagement_bait(
+            final_content,
+            exempt_keyword=(lead_magnet or {}).get("keyword") if include_cta else None)
         final_content = final_content.strip()
 
     # Review gate (runs once, in the outermost call): deterministic near-duplicate check against the

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -14,7 +14,7 @@ from cqc_lem.utilities.db import (
     get_active_user_ids, PostStatus, has_linkedin_session, has_scheduled_post_today,
     get_company_linked_in_url_for_user,
     get_users_with_stripe_subscriptions, update_subscription_from_stripe,
-    get_due_scheduled_dms, update_scheduled_dm_status, ScheduledDmStatus,
+    get_due_scheduled_dms, get_orphaned_scheduled_dms, update_scheduled_dm_status, ScheduledDmStatus,
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES
 from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
@@ -112,7 +112,19 @@ def auto_check_scheduled_dms(self):
                  user_id=user_id, task_name="auto_check_scheduled_dms")
         dispatched += 1
 
-    return f"Scheduled {dispatched} DM(s)" if dispatched else "No DMs to Schedule"
+    # Re-queue DMs stuck in 'scheduled' whose send task was lost (e.g. on container restart) —
+    # mirrors the orphaned-post recovery above. The 2-hour gap avoids racing an in-flight task.
+    orphaned = get_orphaned_scheduled_dms(lookback_hours=2)
+    for dm_id, scheduled_time, user_id in orphaned:
+        log_warning(
+            f"Re-queueing orphaned scheduled DM {dm_id}",
+            user_id=user_id, task_name="auto_check_scheduled_dms",
+        )
+        send_scheduled_dm.apply_async(kwargs={'dm_id': dm_id})
+
+    if dispatched == 0 and len(orphaned) == 0:
+        return "No DMs to Schedule"
+    return f"Scheduled {dispatched} DM(s); re-queued {len(orphaned)} orphaned DM(s)"
 
 
 @shared_task.task

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -282,7 +282,8 @@ def auto_generate_newsletter_drafts():
     refills to the cap as editions publish/skip."""
     from cqc_lem.utilities.db import get_enabled_newsletter_user_ids
 
-    now = datetime.utcnow()
+    # Naive UTC on purpose — compared against naive DB datetimes downstream.
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
     generated = 0
     for user_id in get_enabled_newsletter_user_ids():
         try:
@@ -303,7 +304,8 @@ def generate_newsletter_drafts_for_user(user_id: int):
     if not get_newsletter_settings(user_id).get("enabled"):
         return "Newsletter disabled"
     try:
-        generated = _topup_newsletter_drafts_for_user(user_id, datetime.utcnow(),
+        generated = _topup_newsletter_drafts_for_user(user_id,
+                                                       datetime.now(timezone.utc).replace(tzinfo=None),
                                                        allow_bootstrap=False)
     except Exception as e:
         log_warning("Failed to generate newsletter draft", exc=e, user_id=user_id,
@@ -392,7 +394,7 @@ def auto_publish_scheduled_editions():
     """Publish any newsletter edition whose scheduled slot has arrived (approved or untouched draft)."""
     from cqc_lem.app.run_automation import auto_publish_edition
     from cqc_lem.utilities.db import get_editions_due_to_publish
-    due = get_editions_due_to_publish(datetime.utcnow())
+    due = get_editions_due_to_publish(datetime.now(timezone.utc).replace(tzinfo=None))
     for e in due:
         auto_publish_edition.apply_async(kwargs={'edition_id': e['id']})
     return f"Dispatched {len(due)} newsletter edition(s)"

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -159,12 +159,14 @@ export default function ContentStudio() {
   // Regenerate a single post with optional freeform guidance — runs the async generation task
   // server-side (honors saved settings + guidance), then resets the post to PENDING for re-review.
   const regenerateMutation = useMutation({
-    mutationFn: (vars: { post_id: number; guidance: string }) =>
-      api.post('/user/post/regenerate', {
+    mutationFn: (vars: { post_id: number; guidance: string }) => {
+      if (!sessionToken) return Promise.reject(new Error('No active session'))
+      return api.post('/user/post/regenerate', {
         session_token: sessionToken,
         post_id: vars.post_id,
         guidance: vars.guidance.trim() || null,
-      }),
+      })
+    },
     onSuccess: () => {
       setRegenGuidance('')
       setRegenNotice('Regenerating… this post will return to PENDING with fresh content shortly.')
@@ -681,16 +683,17 @@ export default function ContentStudio() {
       </>
       )}
 
-      {/* Quick-delete confirmation — permanent, all history lost. */}
+      {/* Quick-delete confirmation — backend is a soft delete (status=rejected), so the copy
+          promises only what actually happens: gone from the queue/views, not purged. */}
       {confirmDeletePost && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
              onClick={() => !deleteMutation.isPending && setConfirmDeletePost(null)}>
           <div className="bg-white rounded-lg shadow-xl max-w-sm w-full p-6 space-y-4"
                onClick={(e) => e.stopPropagation()}>
-            <h3 className="text-base font-semibold text-gray-800">Delete this post?</h3>
+            <h3 className="text-base font-semibold text-gray-800">Remove this post?</h3>
             <p className="text-sm text-gray-600">
-              This will permanently delete post #{confirmDeletePost.post_id} and <span className="font-semibold">ALL of its
-              history</span> (stats, logs, generated media). This cannot be undone.
+              This will remove post #{confirmDeletePost.post_id} from your queue — it won't be published
+              and will disappear from all views. You can't undo this from the UI.
             </p>
             <p className="text-xs text-gray-500 line-clamp-3 bg-gray-50 rounded p-2">{confirmDeletePost.content}</p>
             <div className="flex gap-2 justify-end">
@@ -706,7 +709,7 @@ export default function ContentStudio() {
                 disabled={deleteMutation.isPending}
                 className="px-4 py-2 bg-red-600 text-white rounded-lg text-sm font-semibold hover:bg-red-700 disabled:opacity-50"
               >
-                {deleteMutation.isPending ? 'Deleting…' : 'Delete permanently'}
+                {deleteMutation.isPending ? 'Removing…' : 'Remove post'}
               </button>
             </div>
           </div>

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -1016,6 +1016,8 @@ Return ONLY the revised post text — no preamble, no explanation.
 ### Author's revision request:
 {guidance.strip()}
 """
+    if profile_synthesis and profile_synthesis.strip():
+        prompt += f"\n### Author voice reference (match this voice):\n{profile_synthesis.strip()}\n"
     prompt += _alignment_directive(prefs)
     prompt += _style_directive(prefs, "post")
     prompt += "\n\n" + PLAIN_PUNCTUATION_DIRECTIVE

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -8,7 +8,6 @@ out of alignment with each other over time."""
 
 import math
 import os
-import random
 import re
 from typing import Optional
 
@@ -130,14 +129,14 @@ def select_focus_topic(prefs: dict = None, sequence_index: Optional[int] = None)
     """The SUBJECT anchor for one trend-based post: rotate deterministically across the user's
     declared focus topics (keyed off a stable per-post integer — the post id — the same way the
     lead-magnet CTA rotation works) so anchoring never collapses every post onto one topic. Without
-    a sequence key it falls back to a random pick among the topics (variety over determinism, and
-    consistent with how the industry itself is randomly chosen). Returns None when the user declared
-    no focus topics — callers keep their current profile-industry-only behavior."""
+    a sequence key it deterministically falls back to the FIRST topic — reproducible and testable,
+    no per-call randomness. Returns None when the user declared no focus topics — callers keep
+    their current profile-industry-only behavior."""
     topics = _focus_topics(prefs)
     if not topics:
         return None
     if sequence_index is None:
-        return random.choice(topics)
+        return topics[0]
     return topics[int(sequence_index) % len(topics)]
 
 

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -193,13 +193,27 @@ def alignment_directive(prefs: dict = None, lead_magnet_cta: str = "") -> str:
 # listener in run_automation. But it must NOT appear on every post: a repeated CTA reads as spam and
 # gets pattern-flagged. So it rides a deterministic 1-in-N rotation (default N=3, env-overridable).
 LEAD_MAGNET_CTA_EVERY_N = int(os.getenv("LEAD_MAGNET_CTA_EVERY_N", "3") or "3")
+_DEFAULT_CTA_EVERY_N = 3
+
+
+def _effective_cta_every_n(every_n: Optional[int]) -> int:
+    """The 1-in-N cadence actually used. A misconfigured n < 1 (e.g. LEAD_MAGNET_CTA_EVERY_N=0)
+    must NEVER mean 'every post' — fall back to the default cadence. n == 1 stays a valid explicit
+    operator choice meaning every post."""
+    try:
+        n = int(every_n) if every_n is not None else int(LEAD_MAGNET_CTA_EVERY_N)
+    except (TypeError, ValueError):
+        return _DEFAULT_CTA_EVERY_N
+    return n if n >= 1 else _DEFAULT_CTA_EVERY_N
 
 
 def lead_magnet_enabled(lead_magnet: Optional[dict]) -> bool:
-    """The lead magnet is usable only when the user turned it ON and gave a non-empty trigger keyword
-    (matches the gate the automation keyword-listener uses)."""
+    """The lead magnet is usable only when the user turned it ON and gave BOTH a non-empty trigger
+    keyword AND a non-empty message — the automation DM dispatch gate requires all three, so a
+    keyword-only config would invite comments that never get a DM."""
     return bool(lead_magnet and lead_magnet.get("enabled")
-                and str(lead_magnet.get("keyword") or "").strip())
+                and str(lead_magnet.get("keyword") or "").strip()
+                and str(lead_magnet.get("message") or "").strip())
 
 
 def should_include_lead_magnet_cta(lead_magnet: Optional[dict], sequence_index: Optional[int],
@@ -210,8 +224,8 @@ def should_include_lead_magnet_cta(lead_magnet: Optional[dict], sequence_index: 
     available."""
     if not lead_magnet_enabled(lead_magnet) or sequence_index is None:
         return False
-    n = every_n if (every_n and every_n > 0) else LEAD_MAGNET_CTA_EVERY_N
-    if n <= 1:
+    n = _effective_cta_every_n(every_n)
+    if n == 1:
         return True
     return int(sequence_index) % n == 0
 
@@ -276,7 +290,10 @@ def _resource_label(lead_magnet: Optional[dict]) -> str:
     # Drop emoji/symbols so the appended line keeps its own one-emoji budget.
     first = "".join(c for c in first if ord(c) <= 0xFFFF and not (0x2190 <= ord(c) <= 0x2BFF))
     words = first.split()
-    if not words or words[0].lower() in _LABEL_SENTENCE_STARTS or len(words) > 10:
+    # Check both one- and two-word sentence starts ("this is ...") — a single-word check can never
+    # match the multi-word entries in _LABEL_SENTENCE_STARTS.
+    leading = {words[0].lower(), " ".join(w.lower() for w in words[:2])} if words else set()
+    if not words or (leading & _LABEL_SENTENCE_STARTS) or len(words) > 10:
         return "the resource"
     label = " ".join(words)
     if words[0].lower() in _LABEL_DETERMINERS:
@@ -320,8 +337,8 @@ def ensure_lead_magnet_cta(content: Optional[str], lead_magnet: Optional[dict], 
     # Index by the SELECTION ORDINAL (post_id // n), not raw post_id: selected posts are all
     # multiples of n, so raw post_id % len(menu) would only ever hit gcd(n, len) of the variants —
     # the ordinal makes consecutive selected posts cycle through the whole menu.
-    n = every_n if (every_n and every_n > 0) else LEAD_MAGNET_CTA_EVERY_N
-    idx = (int(post_id) // max(n, 1)) % len(LEAD_MAGNET_CTA_REPAIR_MENU)
+    n = _effective_cta_every_n(every_n)
+    idx = (int(post_id) // n) % len(LEAD_MAGNET_CTA_REPAIR_MENU)
     line = LEAD_MAGNET_CTA_REPAIR_MENU[idx].format(
         keyword=keyword, resource=_resource_label(lead_magnet))
     if use_emojis:

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2405,22 +2405,45 @@ def get_scheduled_dms(user_id: int, status_filter: str = None, page: int = 1,
 
 
 def get_due_scheduled_dms(post_time_delta_minutes: int = 20) -> list:
-    """Approved DMs whose scheduled_time falls between 24h ago and now+delta (mirrors
-    get_ready_to_post_posts). Returns (id, scheduled_time, user_id) tuples."""
+    """Approved DMs whose scheduled_time is at or before now+delta. Deliberately NO lower bound:
+    an approved DM can drift arbitrarily far past its slot (e.g. deferred repeatedly by the daily
+    DM cap) and must stay eligible until sent/canceled. Oldest first so overdue DMs drain in order.
+    Returns (id, scheduled_time, user_id) tuples."""
     now = datetime.now(timezone.utc)
     window_end = now + timedelta(minutes=post_time_delta_minutes)
-    yesterday = now - timedelta(days=1)
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         cursor.execute(
             "SELECT id, scheduled_time, user_id FROM scheduled_dms "
-            "WHERE status = 'approved' AND scheduled_time BETWEEN %s AND %s "
+            "WHERE status = 'approved' AND scheduled_time <= %s "
             "ORDER BY scheduled_time ASC",
-            (yesterday, window_end))
+            (window_end,))
         return cursor.fetchall()
     except mysql.connector.Error as err:
         myprint(f"Could not get due scheduled DMs | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_orphaned_scheduled_dms(lookback_hours: int = 2) -> list:
+    """DMs stuck in 'scheduled' whose send task was lost (e.g. Celery queue purged on container
+    restart) before reaching sent/failed. Mirrors get_orphaned_scheduled_posts — the lookback gap
+    avoids racing a task that is still in flight. Returns (id, scheduled_time, user_id) tuples."""
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=lookback_hours)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT id, scheduled_time, user_id FROM scheduled_dms "
+            "WHERE status = 'scheduled' AND scheduled_time <= %s "
+            "ORDER BY scheduled_time ASC",
+            (cutoff,))
+        return cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get orphaned scheduled DMs | Error: {err}")
         return []
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1020,9 +1020,6 @@ def get_user_password_pair_by_id(user_id: int):
 
 
 def get_active_user_password_pairs():
-    connection = get_db_connection()
-    cursor = connection.cursor()
-
     user_password_pairs = []
 
     active_users = get_active_user_ids()
@@ -1225,7 +1222,7 @@ def remove_linked_in_profile_by_email(profile_email: str):
         connection.commit()
         success = True
     except mysql.connector.Error as err:
-        myprint(f"Could not remove linkedin profile by url | Error: {err}")
+        myprint(f"Could not remove linkedin profile by email | Error: {err}")
         success = False
     finally:
         cursor.close()
@@ -1244,7 +1241,7 @@ def get_post_type_counts(user_id: int):
         post_counts = {row['post_type']: row['count'] for row in cursor.fetchall()}
     except mysql.connector.Error as err:
         myprint(f"Could not get post type counts | Error: {err}")
-        post_counts = 0
+        post_counts = {}
     finally:
         cursor.close()
         connection.close()
@@ -3890,6 +3887,15 @@ def set_active_avatar(user_id: int, avatar_id: int) -> bool:
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
     try:
+        # Validate the target avatar BEFORE deactivating anything — a bad id must leave the
+        # user's current active avatar untouched (never strand them with no active avatar).
+        cursor.execute(
+            "SELECT id FROM avatar_trainings WHERE id = %s AND user_id = %s",
+            (avatar_id, user_id),
+        )
+        if cursor.fetchone() is None:
+            myprint(f"set_active_avatar: avatar {avatar_id} not found for user_id {user_id}")
+            return False
         cursor.execute(
             "UPDATE avatar_trainings SET is_active = 0 WHERE user_id = %s",
             (user_id,),
@@ -3899,7 +3905,7 @@ def set_active_avatar(user_id: int, avatar_id: int) -> bool:
             (avatar_id, user_id),
         )
         connection.commit()
-        return cursor.rowcount > 0
+        return True
     except mysql.connector.Error as err:
         myprint(f"Could not set active avatar for user_id {user_id} | Error: {err}")
         return False

--- a/src/cqc_lem/utilities/linkedin_formatter.py
+++ b/src/cqc_lem/utilities/linkedin_formatter.py
@@ -1,5 +1,6 @@
 import re
 import unicodedata
+from typing import Optional
 
 # Fancy typographic glyphs that models love to emit — em/en dashes, curly quotes, ellipsis, exotic
 # spaces — are tell-tale AI signs and sometimes render as mojibake on downstream surfaces. Map each
@@ -113,10 +114,23 @@ _BAIT_PATTERNS = [
 _BAIT_RE = re.compile("|".join(_BAIT_PATTERNS), re.IGNORECASE)
 
 
-def strip_engagement_bait(text: str) -> str:
+def is_bait_keyword(keyword: Optional[str]) -> bool:
+    """True when 'comment <keyword>' would itself trip the bait filter (YES/AGREE/BELOW/AMEN/ME/👇).
+    Such a lead-magnet trigger word can never reliably survive strip_engagement_bait, so it must be
+    rejected at configuration time."""
+    kw = str(keyword or "").strip()
+    return bool(kw) and bool(_BAIT_RE.search(f"comment {kw}"))
+
+
+def strip_engagement_bait(text: str, exempt_keyword: Optional[str] = None) -> str:
     """Drop lines containing classic engagement-bait CTAs (penalized). Conservative and line-level:
-    bait is almost always its own CTA line, and we avoid touching 'comment <keyword>' lead magnets."""
+    bait is almost always its own CTA line, and we avoid touching 'comment <keyword>' lead magnets.
+    `exempt_keyword` protects lines carrying the user's configured lead-magnet trigger word
+    (whole-word, case-insensitive) when that keyword happens to collide with the bait regex."""
     if not text:
         return text
-    kept = [line for line in text.split("\n") if not _BAIT_RE.search(line)]
+    kw = str(exempt_keyword or "").strip()
+    kw_re = re.compile(rf"(?<!\w){re.escape(kw)}(?!\w)", re.IGNORECASE) if kw else None
+    kept = [line for line in text.split("\n")
+            if not _BAIT_RE.search(line) or (kw_re is not None and kw_re.search(line))]
     return re.sub(r"\n{3,}", "\n\n", "\n".join(kept)).strip()

--- a/tests/unit/api/test_api_coverage_misc.py
+++ b/tests/unit/api/test_api_coverage_misc.py
@@ -338,6 +338,18 @@ class TestLeadMagnetAndPassword:
         assert "session_token" not in upd.call_args[0][1]
         assert upd.call_args[0][1]["keyword"] == "GUIDE"
 
+    @pytest.mark.parametrize("bad_kw", ["YES", "agree", "BELOW", "AMEN", "ME"])
+    def test_put_lead_magnet_rejects_bait_colliding_keyword(self, client, bad_kw):
+        # Keywords that trip the engagement-bait filter would be stripped from generated posts —
+        # reject at config time with a clear message.
+        with patch(f"{_M}.get_session_user_id", return_value=_UID), \
+             patch(f"{_M}.update_lead_magnet_settings", return_value=True) as upd:
+            resp = client.put("/api/user/lead-magnet", json={
+                "session_token": _TOK, "enabled": True, "keyword": bad_kw})
+        assert resp.status_code == 422
+        assert "engagement-bait" in resp.json()["detail"]
+        upd.assert_not_called()
+
     def test_put_lead_magnet_500(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_UID), \
              patch(f"{_M}.update_lead_magnet_settings", return_value=False):

--- a/tests/unit/api/test_dm_scheduler_api.py
+++ b/tests/unit/api/test_dm_scheduler_api.py
@@ -97,6 +97,24 @@ class TestUpdateAndCancel:
             resp = client.put("/api/dm", json={"session_token": _S, "dm_id": 3, "message": "x"})
         assert resp.status_code == 404
 
+    def test_unknown_action_422(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_U), \
+             patch("cqc_lem.api.main.get_scheduled_dm_user_id", return_value=_U), \
+             patch("cqc_lem.api.main.update_scheduled_dm") as upd:
+            resp = client.put("/api/dm", json={"session_token": _S, "dm_id": 3, "action": "sned"})
+        assert resp.status_code == 422
+        assert "Unknown action" in resp.json()["detail"]
+        upd.assert_not_called()
+
+    def test_no_fields_and_no_action_422(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_U), \
+             patch("cqc_lem.api.main.get_scheduled_dm_user_id", return_value=_U), \
+             patch("cqc_lem.api.main.update_scheduled_dm") as upd:
+            resp = client.put("/api/dm", json={"session_token": _S, "dm_id": 3})
+        assert resp.status_code == 422
+        assert "Nothing to update" in resp.json()["detail"]
+        upd.assert_not_called()
+
     def test_cancel_sets_canceled(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=_U), \
              patch("cqc_lem.api.main.get_scheduled_dm_user_id", return_value=_U), \

--- a/tests/unit/api/test_post_regenerate_api.py
+++ b/tests/unit/api/test_post_regenerate_api.py
@@ -35,6 +35,7 @@ class TestRegeneratePostEndpoint:
     def test_dispatches_task_with_guidance(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
              patch("cqc_lem.api.main.get_post_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_status", return_value="pending"), \
              patch("cqc_lem.app.run_content_plan.regenerate_post_task") as task:
             resp = client.post("/api/user/post/regenerate",
                                json={"session_token": _SESSION, "post_id": 7, "guidance": "punchier"})
@@ -46,11 +47,25 @@ class TestRegeneratePostEndpoint:
     def test_blank_guidance_becomes_none(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
              patch("cqc_lem.api.main.get_post_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_status", return_value="approved"), \
              patch("cqc_lem.app.run_content_plan.regenerate_post_task") as task:
             resp = client.post("/api/user/post/regenerate",
                                json={"session_token": _SESSION, "post_id": 7, "guidance": "   "})
         assert resp.status_code == 200
         assert task.apply_async.call_args.kwargs["kwargs"]["guidance"] is None
+
+    @pytest.mark.parametrize("status", ["scheduled", "posted", "rejected", "error", "planning", None])
+    def test_409_when_post_not_in_review_state(self, client, status):
+        # Regeneration resets a post to PENDING — allowed only from pending/approved.
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_status", return_value=status), \
+             patch("cqc_lem.app.run_content_plan.regenerate_post_task") as task:
+            resp = client.post("/api/user/post/regenerate",
+                               json={"session_token": _SESSION, "post_id": 7})
+        assert resp.status_code == 409
+        assert "only pending or approved" in resp.json()["detail"]
+        task.apply_async.assert_not_called()
 
     def test_404_when_not_owner(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \

--- a/tests/unit/app/test_celery_infra_coverage.py
+++ b/tests/unit/app/test_celery_infra_coverage.py
@@ -94,11 +94,16 @@ class TestCelerySignalHandlers:
         import cqc_lem.app.my_celery as mc
         tracer = MagicMock()
         with patch.object(mc, "CODE_TRACING", True), \
-             patch.object(mc, "get_jaeger_tracer", return_value=tracer):
+             patch.object(mc, "get_jaeger_tracer", return_value=tracer) as get_tracer:
             mc.init_celery_tracing()
-        # Either the instrumentor import succeeded (span started) or the ImportError
-        # branch logged and skipped — both are valid; assert the tracer was requested.
-        assert mc.get_jaeger_tracer is not None
+        # The tracer must actually be requested for the celery worker; if the optional
+        # instrumentor import succeeded a span was opened on it as well.
+        get_tracer.assert_called_once_with("celery_worker", mc.__name__)
+        try:
+            import opentelemetry.instrumentation.celery  # noqa: F401
+            tracer.start_as_current_span.assert_called_once_with("init_celery_tracing")
+        except ImportError:
+            tracer.start_as_current_span.assert_not_called()
 
     def test_task_pre_and_postrun_track_duration(self):
         import cqc_lem.app.my_celery as mc

--- a/tests/unit/app/test_celery_infra_coverage.py
+++ b/tests/unit/app/test_celery_infra_coverage.py
@@ -15,7 +15,7 @@ class TestGetAwsSqs:
         session.client.return_value.get_queue_url.return_value = {"QueueUrl": "https://sqs/q"}
         result = get_aws_sqs("celery", session)
         assert result == {"QueueUrl": "https://sqs/q"}
-        session.client.assert_called_once_with(service_name="elasticcache")
+        session.client.assert_called_once_with(service_name="sqs")
         session.client.return_value.get_queue_url.assert_called_once_with(QueueName="celery")
 
 

--- a/tests/unit/app/test_content_plan_coverage.py
+++ b/tests/unit/app/test_content_plan_coverage.py
@@ -431,11 +431,21 @@ class TestScrapeRecentPosts:
 
 
 class TestProcessSelectedPost:
-    def test_handles_list_content_and_missing_values(self, capsys):
+    def test_handles_list_content_and_missing_values(self):
         from cqc_lem.app.run_content_plan import process_selected_post
-        # Must not raise on list content or falsy url/content
-        process_selected_post(None, ["part one", "part two"])
-        process_selected_post("https://x.com/p", None)
+        with patch(f"{_RCP}.myprint") as log:
+            # List content is joined; a falsy url gets the placeholder.
+            process_selected_post(None, ["part one", "part two"])
+            logged = " | ".join(str(c.args[0]) for c in log.call_args_list)
+            assert "Could not retrieve URL" in logged
+            assert "part one part two" in logged
+
+            log.reset_mock()
+            # Falsy content gets the placeholder and never raises.
+            process_selected_post("https://x.com/p", None)
+            logged = " | ".join(str(c.args[0]) for c in log.call_args_list)
+            assert "https://x.com/p" in logged
+            assert "Could not retrieve content" in logged
 
 
 class TestGenerateWebsiteContentPost:

--- a/tests/unit/app/test_content_plan_deep_coverage.py
+++ b/tests/unit/app/test_content_plan_deep_coverage.py
@@ -136,7 +136,7 @@ class _TextPostHarness:
                             side_effect=lambda c, **kw: f"refined:{c}"),
             "hook": patch(f"{_RCP}.optimize_post_hook", side_effect=lambda c, **kw: c),
             "sanitize": patch(f"{_RCP}.sanitize_for_linkedin", side_effect=lambda c: c),
-            "bait": patch(f"{_RCP}.strip_engagement_bait", side_effect=lambda c: c),
+            "bait": patch(f"{_RCP}.strip_engagement_bait", side_effect=lambda c, **kw: c),
             "shape_save": patch(f"{_RCP}.update_db_post_shape",
                                 side_effect=self.overrides.get("shape_exc")),
         }
@@ -345,17 +345,28 @@ class TestRegenerateTaskWrappers:
     def test_regenerate_post_returns_none_when_generation_empty(self):
         from cqc_lem.app.run_content_plan import regenerate_post
         with patch("cqc_lem.utilities.db.get_post_user_id", return_value=1), \
-             patch("cqc_lem.utilities.db.get_post_type", return_value=None), \
+             patch("cqc_lem.utilities.db.get_post_type", return_value="text"), \
              patch("cqc_lem.utilities.db.get_post_buyer_stage", return_value="awareness"), \
              patch(f"{_RCP}.load_profile_for_user", return_value=_profile()), \
              patch(f"{_RCP}.create_text_post", return_value=None):
             assert regenerate_post(9) is None
 
+    def test_regenerate_post_unknown_type_skipped(self):
+        # 'text posts only' treats an unknown/None post type as non-text — never regenerate blind.
+        from cqc_lem.app.run_content_plan import regenerate_post
+        with patch("cqc_lem.utilities.db.get_post_user_id", return_value=1), \
+             patch("cqc_lem.utilities.db.get_post_type", return_value=None), \
+             patch(f"{_RCP}.create_text_post") as ctp, \
+             patch(f"{_RCP}.update_db_post_status") as us:
+            assert regenerate_post(9) is None
+        ctp.assert_not_called()
+        us.assert_not_called()
+
     def test_regenerate_post_guidance_failure_keeps_base_regen(self):
         from cqc_lem.app.run_content_plan import regenerate_post
         from cqc_lem.utilities.db import PostStatus
         with patch("cqc_lem.utilities.db.get_post_user_id", return_value=1), \
-             patch("cqc_lem.utilities.db.get_post_type", return_value=None), \
+             patch("cqc_lem.utilities.db.get_post_type", return_value="text"), \
              patch("cqc_lem.utilities.db.get_post_buyer_stage", return_value="awareness"), \
              patch(f"{_RCP}.load_profile_for_user", return_value=_profile()), \
              patch(f"{_RCP}.create_text_post", return_value="base content"), \

--- a/tests/unit/app/test_dm_scheduler.py
+++ b/tests/unit/app/test_dm_scheduler.py
@@ -66,6 +66,7 @@ class TestAutoCheckScheduledDms:
         from cqc_lem.app import run_scheduler as rs
         due = [(3, datetime(2026, 8, 1, 9, tzinfo=timezone.utc), 1)]
         with patch(f"{_RS}.get_due_scheduled_dms", return_value=due), \
+             patch(f"{_RS}.get_orphaned_scheduled_dms", return_value=[]), \
              patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
              patch(f"{_RS}.update_scheduled_dm_status") as upd, \
              patch(f"{_RS}.send_scheduled_dm") as task:
@@ -80,6 +81,7 @@ class TestAutoCheckScheduledDms:
         from cqc_lem.app import run_scheduler as rs
         due = [(3, datetime(2026, 8, 1, 9, tzinfo=timezone.utc), 99)]
         with patch(f"{_RS}.get_due_scheduled_dms", return_value=due), \
+             patch(f"{_RS}.get_orphaned_scheduled_dms", return_value=[]), \
              patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
              patch(f"{_RS}.update_scheduled_dm_status") as upd, \
              patch(f"{_RS}.send_scheduled_dm") as task:
@@ -87,3 +89,19 @@ class TestAutoCheckScheduledDms:
         task.apply_async.assert_not_called()
         upd.assert_not_called()
         assert "No DMs" in out
+
+    def test_requeues_orphaned_scheduled_dms(self):
+        # A DM stuck in 'scheduled' (send task lost, e.g. container restart) gets re-queued
+        # immediately — no eta, no second status flip. Mirrors the orphaned-post recovery.
+        from cqc_lem.app import run_scheduler as rs
+        orphan = [(7, datetime(2026, 7, 1, 9, tzinfo=timezone.utc), 1)]
+        with patch(f"{_RS}.get_due_scheduled_dms", return_value=[]), \
+             patch(f"{_RS}.get_orphaned_scheduled_dms", return_value=orphan) as orph, \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
+             patch(f"{_RS}.update_scheduled_dm_status") as upd, \
+             patch(f"{_RS}.send_scheduled_dm") as task:
+            out = rs.auto_check_scheduled_dms()
+        orph.assert_called_once_with(lookback_hours=2)
+        task.apply_async.assert_called_once_with(kwargs={"dm_id": 7})
+        upd.assert_not_called()
+        assert "re-queued 1 orphaned" in out

--- a/tests/unit/app/test_lead_magnet_cta_survival.py
+++ b/tests/unit/app/test_lead_magnet_cta_survival.py
@@ -91,6 +91,15 @@ class TestCreateTextPostCtaSurvival:
         assert (_run_pipeline(post_id=30, refined_output=_DROPPED)
                 == _run_pipeline(post_id=30, refined_output=_DROPPED))
 
+    def test_colliding_keyword_cta_survives_bait_filter(self):
+        # A trigger word colliding with the bait regex ('YES') is exempted via the threaded
+        # keyword — the surviving CTA line stays byte-identical instead of strip-then-repair.
+        lm = {"enabled": True, "keyword": "YES", "message": "A checklist."}
+        kept = ("Six months of testing taught us where acquisition cost hides.\n\n"
+                "Comment YES and I'll DM you the checklist we used.")
+        out = _run_pipeline(post_id=30, refined_output=kept, lead_magnet=lm)
+        assert out == kept
+
     def test_different_posts_get_different_repair_phrasings(self):
         outs = {_run_pipeline(post_id=pid, refined_output=_DROPPED)[len(_DROPPED):]
                 for pid in (27, 30, 33, 36, 39, 42)}

--- a/tests/unit/app/test_placeholder_substitution.py
+++ b/tests/unit/app/test_placeholder_substitution.py
@@ -69,6 +69,27 @@ class TestApplyPostGuidance:
         assert out == "revised post per guidance"
         assert call.called
 
+    def test_profile_synthesis_included_as_voice_reference(self):
+        from cqc_lem.utilities.ai import ai_helper
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "revised"
+        with patch.object(ai_helper, "_call_llm", return_value=resp) as call:
+            ai_helper.apply_post_guidance("original", "tweak", profile_synthesis="Warm, direct, ops-heavy voice.")
+        prompt = call.call_args.kwargs["messages"][1]["content"][0]["text"]
+        assert "Warm, direct, ops-heavy voice." in prompt
+        assert "voice reference" in prompt
+
+    def test_blank_profile_synthesis_omitted(self):
+        from cqc_lem.utilities.ai import ai_helper
+        resp = MagicMock()
+        resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "revised"
+        with patch.object(ai_helper, "_call_llm", return_value=resp) as call:
+            ai_helper.apply_post_guidance("original", "tweak", profile_synthesis="   ")
+        prompt = call.call_args.kwargs["messages"][1]["content"][0]["text"]
+        assert "voice reference" not in prompt
+
     def test_blank_llm_output_falls_back_to_input(self):
         from cqc_lem.utilities.ai import ai_helper
         resp = MagicMock()

--- a/tests/unit/utilities/ai/test_content_alignment.py
+++ b/tests/unit/utilities/ai/test_content_alignment.py
@@ -67,11 +67,14 @@ class TestLeadMagnetCTA:
     _ON = {"enabled": True, "keyword": "AUDIT", "message": "A free 12-point LinkedIn profile audit PDF."}
     _OFF = {"enabled": False, "keyword": "AUDIT", "message": "audit"}
     _NO_KEYWORD = {"enabled": True, "keyword": "  ", "message": "audit"}
+    _NO_MESSAGE = {"enabled": True, "keyword": "AUDIT", "message": "  "}
 
-    def test_enabled_requires_on_and_keyword(self):
+    def test_enabled_requires_on_keyword_and_message(self):
         assert ca.lead_magnet_enabled(self._ON) is True
         assert ca.lead_magnet_enabled(self._OFF) is False
         assert ca.lead_magnet_enabled(self._NO_KEYWORD) is False
+        # No message → the automation DM dispatch gate can never fire; the CTA must not run either.
+        assert ca.lead_magnet_enabled(self._NO_MESSAGE) is False
         assert ca.lead_magnet_enabled(None) is False
 
     def test_directive_included_only_when_enabled_and_selected(self):
@@ -106,7 +109,20 @@ class TestLeadMagnetCTA:
                        for i in range(300) if i % n != 0)
 
     def test_every_n_of_one_selects_all(self):
+        # n == 1 is an explicit operator choice meaning every post.
         assert all(ca.should_include_lead_magnet_cta(self._ON, i, every_n=1) for i in range(10))
+
+    @pytest.mark.parametrize("bad_n", [0, -1, -5])
+    def test_invalid_every_n_falls_back_to_default_cadence(self, bad_n):
+        # A misconfigured cadence (0/negative) must never mean 'every post' — default 1-in-3.
+        selected = [i for i in range(30)
+                    if ca.should_include_lead_magnet_cta(self._ON, i, every_n=bad_n)]
+        assert selected == list(range(0, 30, 3))
+
+    def test_invalid_env_cadence_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setattr(ca, "LEAD_MAGNET_CTA_EVERY_N", 0)
+        selected = [i for i in range(30) if ca.should_include_lead_magnet_cta(self._ON, i)]
+        assert selected == list(range(0, 30, 3))
 
     def test_alignment_directive_appends_cta_when_given(self):
         cta = ca.lead_magnet_cta_directive(self._ON, include=True)
@@ -213,8 +229,10 @@ class TestEnsureLeadMagnetCta:
     def test_noop_when_disabled_or_unkeyworded_or_no_post_id(self):
         off = {"enabled": False, "keyword": "AUDIT", "message": "x"}
         no_kw = {"enabled": True, "keyword": "  ", "message": "x"}
+        no_msg = {"enabled": True, "keyword": "AUDIT", "message": ""}
         assert ca.ensure_lead_magnet_cta(self._BODY, off, post_id=3) == self._BODY
         assert ca.ensure_lead_magnet_cta(self._BODY, no_kw, post_id=3) == self._BODY
+        assert ca.ensure_lead_magnet_cta(self._BODY, no_msg, post_id=3) == self._BODY
         assert ca.ensure_lead_magnet_cta(self._BODY, None, post_id=3) == self._BODY
         assert ca.ensure_lead_magnet_cta(self._BODY, self._LM, post_id=None) == self._BODY
         assert ca.ensure_lead_magnet_cta("", self._LM, post_id=3) == ""
@@ -235,12 +253,14 @@ class TestEnsureLeadMagnetCta:
         assert "a free 12-point LinkedIn profile audit PDF" in out
 
     @pytest.mark.parametrize("message", [
-        "",  # nothing configured
         "https://example.com/get-it #freebie",  # link/hashtag-only message must not leak in
         "I made a checklist that helps founders audit their ops end to end and more words",  # sentence-shaped
+        "This is a checklist for auditing your LinkedIn profile",  # multi-word sentence start
+        "We built an audit template you can copy",  # sentence start, plural
     ])
     def test_resource_label_falls_back_to_generic(self, message):
         lm = dict(self._LM, message=message)
         out = ca.ensure_lead_magnet_cta(self._BODY, lm, post_id=0, every_n=1)
         assert "the resource" in out
+        assert "This is a" not in out  # never a garbled 'my This is a checklist...' label
         assert "http" not in out.lower() and "#" not in out

--- a/tests/unit/utilities/ai/test_focus_anchoring.py
+++ b/tests/unit/utilities/ai/test_focus_anchoring.py
@@ -42,9 +42,11 @@ class TestSelectFocusTopic:
         assert select_focus_topic(None, 1) is None
         assert select_focus_topic({"focus_topics": ["  ", ""]}, 1) is None
 
-    def test_no_sequence_index_still_picks_a_declared_topic(self):
+    def test_no_sequence_index_falls_back_to_first_topic_deterministically(self):
         from cqc_lem.utilities.ai.content_alignment import select_focus_topic
-        assert select_focus_topic(_PREFS, None) in _FOCUS
+        # No stable per-post key → deterministic FIRST topic, never a random pick.
+        assert select_focus_topic(_PREFS, None) == _FOCUS[0]
+        assert select_focus_topic(_PREFS, None) == select_focus_topic(_PREFS, None)
 
 
 class TestTrendAnalysisAnchoring:

--- a/tests/unit/utilities/test_db_coverage_avatar_groups.py
+++ b/tests/unit/utilities/test_db_coverage_avatar_groups.py
@@ -57,15 +57,27 @@ class TestAvatarLedger:
 
 
 class TestAvatarTrainings:
-    def test_set_active_avatar_deactivates_then_activates(self):
-        conn, cur = _conn(rowcount=1)
+    def test_set_active_avatar_validates_then_deactivates_then_activates(self):
+        conn, cur = _conn(rowcount=1, fetch_one={"id": 11})
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import set_active_avatar
             assert set_active_avatar(3, 11) is True
-        first_sql, first_params = cur.execute.call_args_list[0][0]
-        second_sql, second_params = cur.execute.call_args_list[1][0]
+        select_sql, select_params = cur.execute.call_args_list[0][0]
+        first_sql, first_params = cur.execute.call_args_list[1][0]
+        second_sql, second_params = cur.execute.call_args_list[2][0]
+        assert "SELECT id" in select_sql and select_params == (11, 3)
         assert "is_active = 0" in first_sql and first_params == (3,)
         assert "is_active = 1" in second_sql and second_params == (11, 3)
+
+    def test_set_active_avatar_invalid_id_preserves_current_active(self):
+        # Unknown avatar id → False, and NO deactivating UPDATE ever runs.
+        conn, cur = _conn(fetch_one=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_active_avatar
+            assert set_active_avatar(3, 999) is False
+        executed = [c[0][0] for c in cur.execute.call_args_list]
+        assert len(executed) == 1 and "SELECT id" in executed[0]
+        conn.commit.assert_not_called()
 
     def test_set_active_avatar_error(self):
         conn, cur = _conn()

--- a/tests/unit/utilities/test_db_coverage_errors.py
+++ b/tests/unit/utilities/test_db_coverage_errors.py
@@ -47,7 +47,7 @@ _ERROR_CASES = [
     ("get_post_buyer_stage", (1,), None),
     ("get_post_type", (1,), None),
     ("get_carousel_slides", (1,), []),
-    ("get_post_type_counts", (1,), 0),  # documented quirk: 0, not {}
+    ("get_post_type_counts", (1,), {}),  # empty dict so callers can safely .values()
     ("get_last_planned_post_date_for_user", (1,), None),
     ("get_user_blog_url", (1,), None),
     ("get_user_sitemap_url", (1,), None),

--- a/tests/unit/utilities/test_db_coverage_profiles.py
+++ b/tests/unit/utilities/test_db_coverage_profiles.py
@@ -253,21 +253,21 @@ class TestGetUserLocation:
 
 class TestActiveUserPasswordPairs:
     def test_collects_only_complete_pairs(self):
-        conn, _ = _conn()
-        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+        with patch(f"{_DB}.get_db_connection") as get_conn, \
              patch(f"{_DB}.get_active_user_ids", return_value=[1, 2, 3]), \
              patch(f"{_DB}.get_user_password_pair_by_id",
                    side_effect=[("a@x.com", "pw1"), ("b@x.com", None), (None, None)]):
             from cqc_lem.utilities.db import get_active_user_password_pairs
             pairs = get_active_user_password_pairs()
         assert pairs == [["a@x.com", "pw1"]]
+        get_conn.assert_not_called()  # no dangling direct connection — the helpers own their own
 
     def test_empty_when_no_active_users(self):
-        conn, _ = _conn()
-        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+        with patch(f"{_DB}.get_db_connection") as get_conn, \
              patch(f"{_DB}.get_active_user_ids", return_value=[]):
             from cqc_lem.utilities.db import get_active_user_password_pairs
             assert get_active_user_password_pairs() == []
+        get_conn.assert_not_called()
 
 
 class TestProfileSynthesisErrorPaths:

--- a/tests/unit/utilities/test_db_scheduled_dms.py
+++ b/tests/unit/utilities/test_db_scheduled_dms.py
@@ -34,7 +34,34 @@ class TestScheduledDmDb:
             from cqc_lem.utilities.db import get_due_scheduled_dms
             rows = get_due_scheduled_dms(post_time_delta_minutes=20)
         assert len(rows) == 1
-        assert "status = 'approved'" in cur.execute.call_args[0][0]
+        sql = cur.execute.call_args[0][0]
+        assert "status = 'approved'" in sql
+        # No lower time bound: an approved DM deferred >24h past its slot (e.g. by the daily DM
+        # cap) must stay eligible until sent/canceled — oldest first.
+        assert "BETWEEN" not in sql
+        assert "scheduled_time <= %s" in sql
+        assert "ORDER BY scheduled_time ASC" in sql
+        assert len(cur.execute.call_args[0][1]) == 1
+
+    def test_get_orphaned_scheduled_dms(self):
+        from datetime import datetime, timezone, timedelta
+        conn, cur = _conn(fetchall=[(9, MagicMock(), 5)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_orphaned_scheduled_dms
+            rows = get_orphaned_scheduled_dms(lookback_hours=2)
+        assert rows == [(9, cur.fetchall.return_value[0][1], 5)]
+        sql, params = cur.execute.call_args[0]
+        assert "status = 'scheduled'" in sql and "scheduled_time <= %s" in sql
+        # cutoff is ~2h in the past
+        assert params[0] <= datetime.now(timezone.utc) - timedelta(hours=2) + timedelta(seconds=5)
+
+    def test_get_orphaned_scheduled_dms_error_returns_empty(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="db down")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_orphaned_scheduled_dms
+            assert get_orphaned_scheduled_dms() == []
 
     def test_list_returns_pagination_shape(self):
         conn, cur = _conn()

--- a/tests/unit/utilities/test_linkedin_formatter.py
+++ b/tests/unit/utilities/test_linkedin_formatter.py
@@ -4,7 +4,7 @@ import pytest
 from cqc_lem.utilities.ai.content_alignment import LEAD_MAGNET_CTA_REPAIR_MENU
 from cqc_lem.utilities.linkedin_formatter import (
     sanitize_for_linkedin, normalize_public_text, PLAIN_PUNCTUATION_DIRECTIVE,
-    strip_engagement_bait)
+    strip_engagement_bait, is_bait_keyword)
 
 
 @pytest.mark.unit
@@ -33,6 +33,32 @@ class TestStripEngagementBait:
         text = "Real value here.\n\ncomment SCALE and I'll send over the playbook."
         out = strip_engagement_bait(text)
         assert "comment SCALE" in out
+
+    def test_exempt_keyword_protects_colliding_cta_line(self):
+        # A configured trigger word that collides with the bait regex (e.g. 'YES') must survive
+        # when threaded through as exempt_keyword.
+        text = "Real value here.\n\nComment YES and I'll DM you the checklist."
+        assert "Comment YES" not in strip_engagement_bait(text)  # collides by default
+        out = strip_engagement_bait(text, exempt_keyword="YES")
+        assert "Comment YES and I'll DM you the checklist." in out
+
+    def test_exempt_keyword_is_whole_word(self):
+        # 'ME' as the exempt keyword must not shield unrelated bait lines containing 'me' inside
+        # other words.
+        text = "Insight.\n\nTag a friend who needs this moment."
+        out = strip_engagement_bait(text, exempt_keyword="ME")
+        assert "Tag a friend" not in out
+
+    def test_exempt_keyword_none_keeps_default_behavior(self):
+        text = "Insight.\n\nComment YES below if you want more."
+        assert strip_engagement_bait(text, exempt_keyword=None) == "Insight."
+
+    @pytest.mark.parametrize("kw,expected", [
+        ("YES", True), ("agree", True), ("BELOW", True), ("AMEN", True), ("ME", True),
+        ("AUDIT", False), ("GUIDE", False), ("SCALE", False), ("", False), (None, False),
+    ])
+    def test_is_bait_keyword(self, kw, expected):
+        assert is_bait_keyword(kw) is expected
 
     @pytest.mark.parametrize("resource", ["a free 12-point LinkedIn profile audit PDF", "the resource"])
     @pytest.mark.parametrize("template", LEAD_MAGNET_CTA_REPAIR_MENU)


### PR DESCRIPTION
Systematic cleanup of every verified defect surfaced during this release cycle: the **7 bugs documented by the coverage program (#316)** plus **14 triaged Copilot review findings** from #305/#308/#311/#313/#315. Each item was re-verified against the code before fixing; pinning tests updated to assert corrected behavior.

## Highlights (real behavior fixes)
- **Scheduled DMs could strand forever**: the due-DM query's `now-24h` lower bound dropped approved DMs deferred past a day (e.g. by the daily cap) — bound removed. Plus **orphaned-DM recovery** (`get_orphaned_scheduled_dms` + re-queue in the scanner, mirroring posts) so a worker restart can't leave DMs stuck in `scheduled`.
- **Lead magnet**: gate now also requires a configured `message` (posts no longer invite comments that would never get a DM); `LEAD_MAGNET_CTA_EVERY_N=0/negative` no longer means "CTA on every post" (falls back to default 3); `strip_engagement_bait` exempts the active keyword so CTAs like "Comment YES/BELOW" aren't eaten — and the settings API rejects bait-colliding keywords with a 422.
- **Regenerate hardening**: unknown post type treated as non-text (skip); endpoint only allows pending/approved (409 otherwise — no more silently unscheduling a scheduled post).
- **`set_active_avatar`** validates the id before deactivating — a bad id no longer leaves the user with no active avatar.
- **DB/API cleanups**: `get_post_type_counts` error fallback returns `{}` not `0`; `get_active_user_password_pairs` connection leak removed; dead `AvatarActivateRequest` properties deleted; `get_aws_sqs` service name `'elasticcache'`→`'sqs'`; copy-paste error message; all `datetime.utcnow()` deprecations resolved (naive-UTC semantics preserved).
- **PUT /dm** validates action / empty updates (422 instead of a misleading 500).
- **Honest UX copy**: the post delete modal no longer claims it "permanently deletes all history" (backend is a recoverable soft-delete) — copy + button label now match reality; regenerate mutation guards a null session token.
- `apply_post_guidance` now actually uses `profile_synthesis` as a voice reference (was accepted-and-ignored).
- Strengthened 2 weak assertions from the coverage suite; `.env.example` grammar.

## Tests
~25 new tests + 12 pin updates. **Full suite: 2296 passed, 0 failed**; zero deprecation warnings; SPA `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)