### PR TITLE
fix(content): single clean lead-magnet ask (preserve in rewrites + strip soft paraphrase)

### DIFF
--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -809,10 +809,16 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
 
     if refine_final_post:
         # Both refinement passes get the user's prefs so the LLM rewrites can't re-introduce
-        # emojis/hashtags the user turned off (or flatten a configured tone).
-        final_content = get_ai_linked_post_refinement(final_content, prefs=prefs)
+        # emojis/hashtags the user turned off (or flatten a configured tone). CTA-selected posts
+        # also pass the keyword so the passes' own anti-bait rules don't paraphrase the sanctioned
+        # 'comment KEYWORD' ask into 'reach out for...'.
+        _cta_kw = (str(lead_magnet.get("keyword")).strip()
+                   if include_cta and lead_magnet else None)
+        final_content = get_ai_linked_post_refinement(final_content, prefs=prefs,
+                                                      preserve_cta_keyword=_cta_kw)
         # Hook + save-worthy pass: strong first line before the '…more' fold; save-worthy framing.
-        final_content = optimize_post_hook(final_content, prefs=prefs)
+        final_content = optimize_post_hook(final_content, prefs=prefs,
+                                           preserve_cta_keyword=_cta_kw)
         final_content = sanitize_for_linkedin(final_content)
         # Guardrail: strip classic engagement-bait CTAs (penalized), keeping lead-magnet CTAs —
         # including one whose configured trigger word collides with the bait regex (e.g. 'YES').

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -22,6 +22,7 @@ from cqc_lem.utilities.ai.content_alignment import (
     alignment_directive as _alignment_directive,
     voice_reference as _voice_reference,
     select_focus_topic as _select_focus_topic,
+    lead_magnet_preserve_note as _lead_magnet_preserve_note,
 )
 from cqc_lem.utilities.ai.content_research import research_topic
 from cqc_lem.utilities.ai.tools import search_recent_news, search_with_perplexity
@@ -707,7 +708,8 @@ def generate_thread_reply(post_content: str, comment_text: str, profile: "Linked
     return content.strip() if content is not None else None
 
 
-def optimize_post_hook(post_content: str, prefs: dict = None) -> str:
+def optimize_post_hook(post_content: str, prefs: dict = None,
+                       preserve_cta_keyword: str = None) -> str:
     """Rewrite a generated post so it opens with a scroll-stopping hook within the first ~210
     characters (before LinkedIn's '…more' fold) and, when the topic fits, frames it as save-worthy
     (a framework/checklist) with ONE soft 'save this' invite. Preserves substance + voice. Returns
@@ -724,7 +726,11 @@ def optimize_post_hook(post_content: str, prefs: dict = None) -> str:
         (no 'comment YES'), NO external links, do not add hashtags. Return ONLY the rewritten post."""
         # The rewrite must respect the user's saved voice settings (tone, emoji/hashtag toggles) —
         # without this the hook pass could re-introduce emojis a user has turned off. "" when unset.
-        + _style_directive(prefs, "post"),
+        + _style_directive(prefs, "post")
+        # This pass's own NO-engagement-bait rule is precisely what used to rewrite the sanctioned
+        # 'comment KEYWORD' lead-magnet ask into 'reach out for...' — the preserve note carves the
+        # configured keyword out of that rule. "" when no keyword.
+        + _lead_magnet_preserve_note(preserve_cta_keyword),
     }
     user_prompt = {"role": "user", "content": post_content}
     try:
@@ -891,7 +897,7 @@ def get_industries_of_profile_from_ai(linked_in_profile: LinkedInProfile, indust
     return comment
 
 def get_ai_linked_post_refinement(original_message: str, character_limit: int = 3000,
-                                  prefs: dict = None):
+                                  prefs: dict = None, preserve_cta_keyword: str = None):
     character_limit_string = (f"""\nThe refined LinkedIn Post needs to be less than or equal to {character_limit} characters including white spaces and punctuations. You may use symbols, abbreviations, and other and short-hand.
                                Ideally, Posts between 1,300 and 2,000 characters tend to perform well by providing enough detail while maintaining readability.\n\n""") if character_limit > 0 else ""
 
@@ -914,6 +920,9 @@ def get_ai_linked_post_refinement(original_message: str, character_limit: int = 
 
     prompt = f"""Please review and refine the following LinkedIn Post Draft. {character_limit_string} LinkedIn Post Draft: {original_message}
                 """
+    # Selected lead-magnet posts carry a REQUIRED comment-keyword CTA that this rewrite must not
+    # paraphrase away (the DM automation watches comments for the exact word).
+    prompt += _lead_magnet_preserve_note(preserve_cta_keyword)
 
     # myprint(f"Prompt: {prompt}")
 

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -245,12 +245,33 @@ def lead_magnet_cta_directive(lead_magnet: Optional[dict], include: bool) -> str
     return (
         "\n\nSANCTIONED lead-magnet call-to-action (this post ONLY — the user has explicitly "
         "configured this offer, so it OVERRIDES the no-self-promo guardrail for THIS CTA):\n"
-        f"- End the post with a short, soft invitation for readers to comment the exact word "
-        f"\"{keyword}\" to receive the resource; it will be delivered by DM after they comment.\n"
+        f"- REQUIRED: end the post with ONE short line that literally asks readers to comment the "
+        f"exact word \"{keyword}\" to receive the resource by DM. The words 'comment' and "
+        f"\"{keyword}\" must BOTH appear in that line — e.g. 'Comment {keyword} and I'll DM it to "
+        "you.'\n"
+        "- Do NOT paraphrase the mechanic: 'reach out', 'DM me', 'message me', 'send me a note', or "
+        "a link are NOT acceptable substitutes — an automation watches the comments for that exact "
+        "word, so a paraphrase breaks delivery.\n"
         "- Write it in the user's own voice — plainspoken, no hype, no hard sell, and NO link in the "
         "post body (the DM delivers it). Honor the user's emoji/hashtag settings.\n"
-        "- Keep it to one clean ask; do NOT stack multiple asks or use engagement-bait phrasing "
-        "(no 'tag a friend', no 'like if')." + context_line + "\n")
+        "- Keep it to exactly ONE ask; do NOT also add softer offers of the same resource, and no "
+        "engagement-bait phrasing (no 'tag a friend', no 'like if')." + context_line + "\n")
+
+
+def lead_magnet_preserve_note(keyword: Optional[str]) -> str:
+    """Preservation instruction for the downstream REWRITE passes (refinement / hook optimization).
+    Those prompts carry their own anti-engagement-bait rules, which is exactly what rewrites
+    'comment KEYWORD' into 'reach out for...' — this note carves out the sanctioned CTA so the
+    mechanic survives. Empty string when no keyword, so callers can append unconditionally."""
+    keyword = str(keyword or "").strip()
+    if not keyword:
+        return ""
+    return (
+        f"\n\nREQUIRED CTA — PRESERVE: the draft ends with a line asking readers to comment the "
+        f"exact word \"{keyword}\" to receive a resource by DM. That line is a sanctioned, "
+        "user-configured call-to-action, NOT engagement-bait: keep it (verbatim or lightly "
+        "polished), never paraphrase it into 'reach out'/'DM me'/'message me', never remove the "
+        f"word \"{keyword}\" or the word 'comment' from it, and keep exactly ONE such ask.")
 
 
 # The prompt directive above is only a REQUEST — the downstream refinement passes (LLM rewrites +
@@ -322,6 +343,39 @@ def has_lead_magnet_cta_mechanic(content: Optional[str], keyword: Optional[str])
     return bool(_cta_mechanic_re(keyword).search(content))
 
 
+# A "soft offer" is the model's PARAPHRASED version of the lead-magnet CTA — an offer to send the
+# resource without the comment-keyword mechanic ("Feel free to reach out if you'd like a
+# checklist..."). Left in place next to the appended repair line, it reads as a doubled ask. Both
+# halves are required for a strip (offer verb + resource noun) so ordinary sentences like "Reach
+# out to your vendor" or "Here's a checklist" are never touched — precision over recall: a missed
+# soft line is cosmetic, an over-strip loses real content.
+_SOFT_OFFER_VERBS = (r"(?:feel free to )?reach out|dm me|message me|send me a (?:dm|message|note)|"
+                     r"i(?:'|’)ll (?:send|share|dm)|happy to (?:send|share|dm|walk)")
+_SOFT_OFFER_NOUNS = (r"checklist|guide|template|playbook|worksheet|resource|framework|cheat ?sheet|"
+                     r"ebook|e-book|toolkit|audit|scorecard|assessment|list|copy")
+_SOFT_OFFER_RE = re.compile(
+    rf"(?=.*\b(?:{_SOFT_OFFER_VERBS})\b)(?=.*\b(?:{_SOFT_OFFER_NOUNS})\b)", re.IGNORECASE)
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def _strip_soft_resource_offers(content: str, keyword: str) -> str:
+    """Remove sentences that soft-paraphrase the lead-magnet offer (offer verb + resource noun)
+    WITHOUT the comment-keyword mechanic — so the deterministic repair line never ships alongside
+    the model's mangled version of the same ask. Sentences carrying the real mechanic are kept."""
+    mech = _cta_mechanic_re(keyword)
+    out_lines = []
+    for raw_line in content.split("\n"):
+        sentences = _SENTENCE_SPLIT_RE.split(raw_line)
+        kept = [s for s in sentences
+                if not s.strip() or mech.search(s) or not _SOFT_OFFER_RE.search(s)]
+        line = " ".join(s for s in kept if s).rstrip()
+        # Drop a line the strip emptied entirely (was purely the soft offer).
+        if line or not raw_line.strip():
+            out_lines.append(line if raw_line.strip() else raw_line)
+    stripped = "\n".join(out_lines)
+    return re.sub(r"\n{3,}", "\n\n", stripped)
+
+
 def ensure_lead_magnet_cta(content: Optional[str], lead_magnet: Optional[dict], post_id: Optional[int],
                            use_emojis: bool = False, every_n: Optional[int] = None) -> Optional[str]:
     """Deterministic verify-and-repair run AFTER the refinement pipeline: if this post was selected
@@ -331,8 +385,12 @@ def ensure_lead_magnet_cta(content: Optional[str], lead_magnet: Optional[dict], 
     if not content or not should_include_lead_magnet_cta(lead_magnet, post_id, every_n):
         return content
     keyword = str(lead_magnet.get("keyword")).strip()
-    if has_lead_magnet_cta_mechanic(content, keyword):
-        return content
+    # Strip the model's soft PARAPHRASE of the same offer first ("reach out if you'd like the
+    # checklist...") — whether the real mechanic survived or not, a second softer ask next to it
+    # reads as a doubled CTA.
+    deduped = _strip_soft_resource_offers(content, keyword)
+    if has_lead_magnet_cta_mechanic(deduped, keyword):
+        return content if deduped == content else normalize_public_text(deduped)
     # Index by the SELECTION ORDINAL (post_id // n), not raw post_id: selected posts are all
     # multiples of n, so raw post_id % len(menu) would only ever hit gcd(n, len) of the variants —
     # the ordinal makes consecutive selected posts cycle through the whole menu.
@@ -342,7 +400,7 @@ def ensure_lead_magnet_cta(content: Optional[str], lead_magnet: Optional[dict], 
         keyword=keyword, resource=_resource_label(lead_magnet))
     if use_emojis:
         line += " " + _CTA_REPAIR_EMOJI
-    return normalize_public_text(content.rstrip() + "\n\n" + line)
+    return normalize_public_text(deduped.rstrip() + "\n\n" + line)
 
 
 def voice_reference(profile, profile_synthesis: Optional[str] = None) -> str:

--- a/tests/unit/utilities/ai/test_cta_dedup_tighten.py
+++ b/tests/unit/utilities/ai/test_cta_dedup_tighten.py
@@ -1,0 +1,158 @@
+"""Unit tests for the tightened lead-magnet CTA flow: strengthened prompt contract, rewrite-pass
+preservation context, and soft-paraphrase dedup at repair time."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_LM = {"enabled": True, "keyword": "AUDIT",
+       "message": "Here you go, {first_name} - the AI Ops Readiness Checklist."}
+
+
+class TestStrengthenedDirective:
+    def test_directive_demands_verbatim_mechanic(self):
+        from cqc_lem.utilities.ai.content_alignment import lead_magnet_cta_directive
+        d = lead_magnet_cta_directive(_LM, True)
+        assert "REQUIRED" in d
+        assert "Do NOT paraphrase" in d
+        assert "'reach out'" in d
+        assert "exactly ONE ask" in d
+        assert "AUDIT" in d
+
+    def test_preserve_note_carries_keyword(self):
+        from cqc_lem.utilities.ai.content_alignment import lead_magnet_preserve_note
+        note = lead_magnet_preserve_note("AUDIT")
+        assert "PRESERVE" in note and "AUDIT" in note and "comment" in note.lower()
+
+    def test_preserve_note_empty_without_keyword(self):
+        from cqc_lem.utilities.ai.content_alignment import lead_magnet_preserve_note
+        assert lead_magnet_preserve_note(None) == ""
+        assert lead_magnet_preserve_note("  ") == ""
+
+
+class TestSoftOfferDedup:
+    """post_id=30 is on the default 1-in-3 rotation."""
+
+    def test_soft_paraphrase_stripped_when_repair_fires(self):
+        # The live post-27 failure mode: model wove a soft offer, mechanic missing.
+        from cqc_lem.utilities.ai.content_alignment import (ensure_lead_magnet_cta,
+                                                            has_lead_magnet_cta_mechanic)
+        content = ("Strong insight about AI costs.\n\n"
+                   "Feel free to reach out if you'd like a checklist to help you balance both. "
+                   "It only takes 5 minutes to run.")
+        out = ensure_lead_magnet_cta(content, _LM, post_id=30)
+        assert has_lead_magnet_cta_mechanic(out, "AUDIT")
+        assert "reach out" not in out.lower()
+        assert "Strong insight about AI costs." in out  # real content untouched
+
+    def test_soft_duplicate_stripped_even_when_mechanic_survived(self):
+        from cqc_lem.utilities.ai.content_alignment import ensure_lead_magnet_cta
+        content = ("Real point here.\n\n"
+                   "Happy to share my checklist if that helps.\n\n"
+                   "Comment AUDIT and I'll DM it to you.")
+        out = ensure_lead_magnet_cta(content, _LM, post_id=30)
+        assert "Happy to share" not in out
+        assert out.count("AUDIT") == 1  # exactly one ask, no second append
+
+    def test_benign_reach_out_sentence_survives(self):
+        # Offer verb WITHOUT a resource noun must never be stripped.
+        from cqc_lem.utilities.ai.content_alignment import ensure_lead_magnet_cta
+        content = "Reach out to your vendor and ask for pricing.\n\nComment AUDIT and I'll DM it to you."
+        out = ensure_lead_magnet_cta(content, _LM, post_id=30)
+        assert "Reach out to your vendor" in out
+
+    def test_clean_selected_content_is_byte_identical(self):
+        from cqc_lem.utilities.ai.content_alignment import ensure_lead_magnet_cta
+        content = "Point.\n\nComment AUDIT and I'll DM you the checklist."
+        assert ensure_lead_magnet_cta(content, _LM, post_id=30) == content
+
+    def test_unselected_post_untouched_even_with_soft_offer(self):
+        from cqc_lem.utilities.ai.content_alignment import ensure_lead_magnet_cta
+        content = "Post.\n\nFeel free to reach out if you'd like the checklist."
+        assert ensure_lead_magnet_cta(content, _LM, post_id=31) == content  # 31 % 3 != 0
+
+    def test_mechanic_sentence_never_stripped_by_dedup(self):
+        # A mechanic line that ALSO contains offer-ish words must be kept.
+        from cqc_lem.utilities.ai.content_alignment import ensure_lead_magnet_cta
+        content = "Point.\n\nComment AUDIT and I'll send you the checklist by DM."
+        out = ensure_lead_magnet_cta(content, _LM, post_id=30)
+        assert "Comment AUDIT" in out
+
+
+class TestRewritePassPreservation:
+    def _resp(self, text="rewritten"):
+        r = MagicMock(); r.choices = [MagicMock()]; r.choices[0].message.content = text
+        return r
+
+    def test_refinement_prompt_includes_preserve_note_when_keyword(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch.object(ai_helper, "_call_llm", return_value=self._resp()) as call:
+            ai_helper.get_ai_linked_post_refinement("draft", preserve_cta_keyword="AUDIT")
+        sent = str(call.call_args.kwargs["messages"])
+        assert "PRESERVE" in sent and "AUDIT" in sent
+
+    def test_refinement_prompt_unchanged_without_keyword(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch.object(ai_helper, "_call_llm", return_value=self._resp()) as call:
+            ai_helper.get_ai_linked_post_refinement("draft")
+        assert "PRESERVE" not in str(call.call_args.kwargs["messages"])
+
+    def test_hook_pass_carves_keyword_out_of_its_antibait_rule(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch.object(ai_helper, "_call_llm", return_value=self._resp()) as call:
+            ai_helper.optimize_post_hook("draft", preserve_cta_keyword="AUDIT")
+        system = call.call_args.kwargs["messages"][0]["content"]
+        assert "PRESERVE" in system and "AUDIT" in system
+
+    def test_hook_pass_unchanged_without_keyword(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch.object(ai_helper, "_call_llm", return_value=self._resp()) as call:
+            ai_helper.optimize_post_hook("draft")
+        assert "PRESERVE" not in call.call_args.kwargs["messages"][0]["content"]
+
+
+class TestCreateTextPostThreadsKeyword:
+    def test_rewrite_passes_receive_keyword_on_selected_post(self):
+        from cqc_lem.app import run_content_plan as rcp
+        _RCP = "cqc_lem.app.run_content_plan"
+
+        def gen(*a, **kw):
+            return "generated body"
+
+        with patch(f"{_RCP}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RCP}.get_or_create_profile_synthesis", return_value="voice"), \
+             patch(f"{_RCP}.get_lead_magnet_settings", return_value=_LM), \
+             patch(f"{_RCP}.get_recent_post_texts", return_value=[]), \
+             patch(f"{_RCP}.get_recent_post_shape_history", return_value=[]), \
+             patch(f"{_RCP}.update_db_post_shape"), \
+             patch(f"{_RCP}.get_thought_leadership_post_from_ai", side_effect=gen), \
+             patch(f"{_RCP}.get_ai_linked_post_refinement",
+                   side_effect=lambda c, **kw: c) as refine, \
+             patch(f"{_RCP}.optimize_post_hook", side_effect=lambda c, **kw: c) as hook:
+            rcp.create_text_post(1, "awareness", post_type="thought_leadership",
+                                 user_profile=MagicMock(), refine_final_post=True, post_id=30)
+        assert refine.call_args.kwargs["preserve_cta_keyword"] == "AUDIT"
+        assert hook.call_args.kwargs["preserve_cta_keyword"] == "AUDIT"
+
+    def test_rewrite_passes_get_none_on_unselected_post(self):
+        from cqc_lem.app import run_content_plan as rcp
+        _RCP = "cqc_lem.app.run_content_plan"
+
+        def gen(*a, **kw):
+            return "generated body"
+
+        with patch(f"{_RCP}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RCP}.get_or_create_profile_synthesis", return_value="voice"), \
+             patch(f"{_RCP}.get_lead_magnet_settings", return_value=_LM), \
+             patch(f"{_RCP}.get_recent_post_texts", return_value=[]), \
+             patch(f"{_RCP}.get_recent_post_shape_history", return_value=[]), \
+             patch(f"{_RCP}.update_db_post_shape"), \
+             patch(f"{_RCP}.get_thought_leadership_post_from_ai", side_effect=gen), \
+             patch(f"{_RCP}.get_ai_linked_post_refinement",
+                   side_effect=lambda c, **kw: c) as refine, \
+             patch(f"{_RCP}.optimize_post_hook", side_effect=lambda c, **kw: c) as hook:
+            rcp.create_text_post(1, "awareness", post_type="thought_leadership",
+                                 user_profile=MagicMock(), refine_final_post=True, post_id=31)
+        assert refine.call_args.kwargs["preserve_cta_keyword"] is None
+        assert hook.call_args.kwargs["preserve_cta_keyword"] is None


### PR DESCRIPTION
Follow-up to #313 from live v0.37.0 output: on CTA-selected posts the deterministic repair line could ship **next to the model's softer paraphrase** of the same offer ("Feel free to reach out if you'd like a checklist…"), reading as a doubled ask.

## Three-part fix
1. **Stronger generation contract** — `lead_magnet_cta_directive` now marks the comment-KEYWORD line **REQUIRED**, forbids paraphrase explicitly ("'reach out', 'DM me'… are NOT acceptable — an automation watches the comments for that exact word"), and demands exactly ONE ask.
2. **Preservation context in the rewrite passes** — new `lead_magnet_preserve_note(keyword)` threaded into `get_ai_linked_post_refinement` and `optimize_post_hook` on selected posts. Root cause found: the hook pass's own *"NO engagement-bait (no 'comment YES')"* rule is precisely what rewrote the sanctioned "comment AUDIT" into "reach out for…" — the note carves the configured keyword out of that rule.
3. **Soft-paraphrase dedup at repair time** — `ensure_lead_magnet_cta` strips sentences matching offer-verb + resource-noun (both required; sentences carrying the real mechanic are always kept) before verifying/appending. Precision-biased: "Reach out to your vendor for pricing" is never touched; byte-identical no-op on clean content.

## Tests
15 new (directive contract, preserve-note wiring incl. both rewrite passes, dedup true/negative cases incl. the live post-27 failure, keyword threading through `create_text_post` for selected vs unselected posts). **Full suite: 2311 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)