### PR TITLE
feat(carousel): composite relevant images into content slides (fill white space)

### DIFF
--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -296,7 +296,7 @@ def create_carousel_content(user_id: int, stage: str, post_id: int = None,
         try:
             # Render slide images using Pillow; explicit override wins over auto-pick
             image_paths = create_carousel_slide_images(
-                carousel_obj, post_id, template=template or carousel_template
+                carousel_obj, post_id, template=template or carousel_template, user_id=user_id
             )
             slide_urls = [
                 f"{API_URL_FINAL}/api/assets?file_name=images/carousel/{post_id}/{os.path.basename(p)}"

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -308,7 +308,7 @@ def create_carousel_content(user_id: int, stage: str, post_id: int = None,
             # Also generate PPTX for user download
             try:
                 ppt_name = f"carousel_{post_id}"
-                create_ppt(ppt_name, carousel_obj)
+                create_ppt(ppt_name, carousel_obj, post_id=post_id, user_id=user_id)
             except Exception as ppt_err:
                 myprint(f"PPTX generation failed (non-fatal): {ppt_err}")
         except Exception as img_err:

--- a/src/cqc_lem/utilities/carousel_creator.py
+++ b/src/cqc_lem/utilities/carousel_creator.py
@@ -1,9 +1,32 @@
+"""Carousel rendering + a structured, deterministic image-selection strategy for
+content slides.
+
+LinkedIn carousel imagery — research-backed principles encoded below (from Buffer /
+PostNitro / Hootsuite analyses of high-engagement document posts):
+
+- CONTENT (middle) slides should carry a relevant image so they don't read as
+  text-on-blank. The image must REINFORCE the slide's single idea — a concept,
+  metaphor, or data-viz cue — never be random stock filler unrelated to the point.
+- Keep a CONSISTENT visual style across slides (calm, professional, uncluttered) so
+  the deck reads as one system, not a scrapbook.
+- AVOID busy / text-heavy images that fight the slide's own overlaid text for
+  attention. Prefer clean subjects with breathing room.
+- The COVER and CTA slides are their own thing (bold title / clear ask); we leave
+  those layouts as-is and only enrich the middle slides.
+
+Sourcing is deterministic and cheap-first: Pexels stock (a free API call) is the
+default; Replicate generation is opt-in, low-rate, and only used with the user's
+active avatar when a person likeness actually adds value (e.g. personal stories).
+Every whether/source decision is seeded by (post_id, slide_index) so regeneration
+is stable and unit-testable, and every step degrades gracefully to a text-only
+layout rather than crashing carousel generation.
+"""
 import os
 import random
 import tempfile
 import urllib.request
 from datetime import datetime
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 from lxml.etree import tostring
 from pptx import Presentation
@@ -150,7 +173,9 @@ def create_ppt(ppt_name, carousel_data: Union[
     TestimonialCarousel,
     ProductDemoCarousel],
                my_theme: PowerPointThemeColors = PowerPointThemeColors(**{"lt1": "e9d437", "dk2": "a89816"}),
-               design_number: int = 1):
+               design_number: int = 1,
+               post_id: Optional[int] = None,
+               user_id: Optional[int] = None):
     current_dir = os.path.dirname(__file__)
     generated_dir = os.path.join(current_dir, "generated_designs")
     os.makedirs(generated_dir, exist_ok=True)
@@ -159,22 +184,22 @@ def create_ppt(ppt_name, carousel_data: Union[
 
     if isinstance(carousel_data, EducationalContentCarousel):
         # Handle EducationalContentCarousel
-        prs = create_ppt_educational_content_carousel(prs, carousel_data)
+        prs = create_ppt_educational_content_carousel(prs, carousel_data, post_id=post_id, user_id=user_id)
         pass
     elif isinstance(carousel_data, CaseStudyCarousel):
         # Handle CaseStudyCarousel
-        prs = create_ppt_case_study_carousel(prs, carousel_data)
+        prs = create_ppt_case_study_carousel(prs, carousel_data, post_id=post_id, user_id=user_id)
         pass
     elif isinstance(carousel_data, PersonalStoryCarousel):
-        prs = create_ppt_personal_story_carousel(prs, carousel_data)
+        prs = create_ppt_personal_story_carousel(prs, carousel_data, post_id=post_id, user_id=user_id)
     elif isinstance(carousel_data, IndustryInsightsCarousel):
-        prs = create_ppt_industry_insights_carousel(prs, carousel_data)
+        prs = create_ppt_industry_insights_carousel(prs, carousel_data, post_id=post_id, user_id=user_id)
     elif isinstance(carousel_data, EventRecapCarousel):
-        prs = create_ppt_event_recap_carousel(prs, carousel_data)
+        prs = create_ppt_event_recap_carousel(prs, carousel_data, post_id=post_id, user_id=user_id)
     elif isinstance(carousel_data, TestimonialCarousel):
         prs = create_ppt_testimonial_carousel(prs, carousel_data)
     elif isinstance(carousel_data, ProductDemoCarousel):
-        prs = create_ppt_product_demo_carousel(prs, carousel_data)
+        prs = create_ppt_product_demo_carousel(prs, carousel_data, post_id=post_id, user_id=user_id)
 
     file_path = os.path.join(generated_dir, f"{ppt_name}.pptx")
     prs.save(file_path)
@@ -210,7 +235,189 @@ def get_pexels_image_path(query: str, default_path: Optional[str] = None) -> Opt
         return default_path
 
 
-def create_ppt_educational_content_carousel(prs: Presentation, carousel: EducationalContentCarousel) -> Presentation:
+# ── Structured, deterministic content-slide image selection ───────────────────
+# Avatar (person likeness) only helps where the slide is about the author's own
+# narrative — using it elsewhere is off-brand. Keep this narrow on purpose.
+CAROUSEL_AVATAR_RELEVANT_TYPES: set[str] = {"personal_story"}
+
+_QUERY_STOPWORDS: set[str] = {
+    "the", "a", "an", "and", "or", "but", "to", "of", "for", "in", "on", "at",
+    "with", "your", "you", "our", "we", "how", "why", "what", "when", "is", "are",
+    "be", "this", "that", "it", "as", "from", "by", "will", "can", "do", "not",
+    "more", "less", "than", "then", "so", "if", "up", "out", "into", "about",
+    "tip", "tips", "step", "steps", "way", "ways",
+}
+
+
+def _seeded_unit(post_id: Optional[int], slide_index: int, purpose: str) -> float:
+    """Deterministic float in [0, 1) keyed by (post_id, slide_index, purpose)."""
+    return random.Random(f"{post_id}:{slide_index}:{purpose}").random()
+
+
+def _heuristic_image_query(title: Optional[str], content: Optional[str],
+                           content_type: Optional[str]) -> str:
+    """Local (no-API) keyword extraction — concrete visual terms from slide text."""
+    text = " ".join([t for t in (title, content) if t]).lower()
+    words = [w.strip(".,:;!?\"'()[]") for w in text.split()]
+    keywords = [w for w in words if len(w) > 3 and w not in _QUERY_STOPWORDS]
+    if not keywords:
+        return (content_type or "professional business").replace("_", " ")
+    return " ".join(keywords[:3])
+
+
+def derive_image_query(title: Optional[str], content: Optional[str],
+                       content_type: Optional[str]) -> str:
+    """Derive visual search keywords that capture the slide's MEANING (not its raw
+    title). Uses an ``lem-simple`` LLM call when enabled; falls back to a local
+    keyword heuristic on failure or when disabled.
+    """
+    from cqc_lem.utilities.env_constants import CAROUSEL_IMAGE_QUERY_LLM
+    from cqc_lem.utilities.logger import log_debug, log_warning
+
+    if not CAROUSEL_IMAGE_QUERY_LLM:
+        return _heuristic_image_query(title, content, content_type)
+    try:
+        from cqc_lem.utilities.ai.client import client
+        prompt = (
+            "Give 2-4 concrete visual search keywords for a clean, professional stock "
+            "photo that visually reinforces this LinkedIn carousel slide's single idea. "
+            "Return ONLY the space-separated keywords, no punctuation, no quotes.\n\n"
+            f"Title: {title or ''}\nBody: {content or ''}"
+        )
+        resp = client.chat.completions.create(
+            model="lem-simple",
+            messages=[{"role": "user", "content": prompt}],
+        )
+        raw = (resp.choices[0].message.content or "").strip()
+        cleaned = " ".join(
+            w.strip(".,:;!?\"'()[]") for w in raw.replace("\n", " ").split()
+        ).strip()
+        if cleaned:
+            log_debug("Derived carousel image query", ai_model="lem-simple")
+            return cleaned[:80]
+        return _heuristic_image_query(title, content, content_type)
+    except Exception as e:
+        log_warning("Carousel image-query LLM failed, using heuristic", exc=e,
+                    ai_model="lem-simple")
+        return _heuristic_image_query(title, content, content_type)
+
+
+def _should_include_slide_image(post_id: Optional[int], slide_index: int) -> bool:
+    from cqc_lem.utilities.env_constants import CAROUSEL_IMAGES_ENABLED, CAROUSEL_IMAGE_RATE
+    if not CAROUSEL_IMAGES_ENABLED:
+        return False
+    if CAROUSEL_IMAGE_RATE >= 1.0:
+        return True
+    if CAROUSEL_IMAGE_RATE <= 0.0:
+        return False
+    return _seeded_unit(post_id, slide_index, "include") < CAROUSEL_IMAGE_RATE
+
+
+def _user_has_active_avatar(user_id: Optional[int]) -> bool:
+    if user_id is None:
+        return False
+    try:
+        from cqc_lem.utilities.db import get_active_avatar
+        avatar = get_active_avatar(user_id)
+        return bool(avatar and avatar.get("status") == "succeeded" and avatar.get("model_ref"))
+    except Exception:
+        return False
+
+
+def _should_generate_with_replicate(post_id: Optional[int], slide_index: int,
+                                    user_id: Optional[int], content_type: Optional[str]) -> bool:
+    """Replicate generation is gated: globally enabled, avatar-relevant content type,
+    a deterministic low-rate sample, AND the user actually has an active avatar."""
+    from cqc_lem.utilities.env_constants import CAROUSEL_REPLICATE_ENABLED, CAROUSEL_REPLICATE_RATE
+    if not CAROUSEL_REPLICATE_ENABLED or user_id is None:
+        return False
+    if (content_type or "") not in CAROUSEL_AVATAR_RELEVANT_TYPES:
+        return False
+    if _seeded_unit(post_id, slide_index, "source") >= CAROUSEL_REPLICATE_RATE:
+        return False
+    return _user_has_active_avatar(user_id)
+
+
+def _generate_avatar_slide_image(query: str, user_id: int) -> Optional[str]:
+    from cqc_lem.utilities.logger import log_warning
+    try:
+        from cqc_lem.utilities.ai.ai_helper import generate_post_image
+        prompt = f"{query}, professional, clean minimal background, high quality, editorial"
+        path = generate_post_image(prompt, user_id)
+        return path or None
+    except Exception as e:
+        log_warning("Carousel avatar image generation failed, falling back to Pexels",
+                    exc=e, user_id=user_id, api_provider="replicate")
+        return None
+
+
+def select_slide_image(
+    *,
+    title: Optional[str],
+    content: Optional[str],
+    content_type: str,
+    post_id: Optional[int],
+    slide_index: int,
+    user_id: Optional[int] = None,
+    default_path: Optional[str] = None,
+) -> Optional[str]:
+    """Deterministically decide whether a content slide gets an image, derive its
+    search query, and resolve a source (Pexels-first, then optional avatar-based
+    Replicate generation). Returns a local image path or ``default_path``/None.
+
+    Never raises — every failure degrades to ``default_path`` so carousel generation
+    (and the caller's text-only layout fallback) is never blocked.
+    """
+    from cqc_lem.utilities.env_constants import CAROUSEL_PEXELS_ENABLED
+
+    if not _should_include_slide_image(post_id, slide_index):
+        return default_path
+
+    query = derive_image_query(title, content, content_type)
+
+    if _should_generate_with_replicate(post_id, slide_index, user_id, content_type):
+        generated = _generate_avatar_slide_image(query, user_id)
+        if generated:
+            return generated
+        # fall through to Pexels on generation failure
+
+    if CAROUSEL_PEXELS_ENABLED:
+        pexels_path = get_pexels_image_path(query, default_path)
+        if pexels_path:
+            return pexels_path
+
+    return default_path
+
+
+def _content_layout_pools() -> tuple[list[Callable], list[Callable]]:
+    """(image-capable, text-only) content layout pools. Image-capable layouts have a
+    picture placeholder; text-only layouts render title+body with no image slot."""
+    image_layouts = [create_one_column_text_layout_slide, create_one_column_text_1_layout_slide]
+    text_layouts = [create_title_and_body_layout_slide, create_title_and_body_1_layout_slide]
+    return image_layouts, text_layouts
+
+
+def choose_content_layout(
+    image_path: Optional[str],
+    post_id: Optional[int],
+    slide_index: int,
+    image_layouts: Optional[list[Callable]] = None,
+    text_layouts: Optional[list[Callable]] = None,
+) -> Callable:
+    """Route a content slide to a layout. When ``image_path`` is set the slide is
+    guaranteed an IMAGE-CAPABLE layout (with a picture placeholder) so the fetched
+    image never lands on a layout that silently discards it; otherwise a text-only
+    layout is used. The choice is deterministic per (post_id, slide_index)."""
+    default_img, default_txt = _content_layout_pools()
+    image_layouts = image_layouts or default_img
+    text_layouts = text_layouts or default_txt
+    rng = random.Random(f"{post_id}:{slide_index}:layout")
+    return rng.choice(image_layouts if image_path else text_layouts)
+
+
+def create_ppt_educational_content_carousel(prs: Presentation, carousel: EducationalContentCarousel,
+                                            post_id: Optional[int] = None,
+                                            user_id: Optional[int] = None) -> Presentation:
     """
     Create a PowerPoint presentation for Educational Content Carousel.
 
@@ -236,24 +443,16 @@ def create_ppt_educational_content_carousel(prs: Presentation, carousel: Educati
         **cover_slide_args
     )
 
-    # Slide 2-5: Content/Tips
-    content_layouts = [create_title_and_body_layout_slide, create_one_column_text_layout_slide,
-                       # create_ppt_for_title_and_two_columns_layout # TODO: Figure out if and how to implement this one
-                       ]
-
-    content_slide_args = {
-        "prs": prs
-    }
-    for content in carousel.contents:
-        content_slide_args["title"] = content.title
-        content_slide_args["body_text"] = content.content
-        image_path = getattr(content, "image_path", None)
-        content_slide_args["image_path"] = image_path or get_pexels_image_path(
-            content.title or "professional", default_image_path
+    # Slide 2-5: Content/Tips — structured, deterministic image selection + layout
+    # routing so image-bearing slides land on an image-capable layout.
+    for slide_index, content in enumerate(carousel.contents, start=2):
+        image_path = getattr(content, "image_path", None) or select_slide_image(
+            title=content.title, content=content.content, content_type="educational",
+            post_id=post_id, slide_index=slide_index, user_id=user_id,
+            default_path=default_image_path,
         )
-        content_slide = random.choice(content_layouts)(
-            **content_slide_args
-        )
+        layout_fn = choose_content_layout(image_path, post_id, slide_index)
+        layout_fn(prs=prs, title=content.title, body_text=content.content, image_path=image_path)
 
     # Slide 6: Conclusion
     conclusion_layouts = [create_section_title_and_description_layout_slide, create_custom_3_1_layout_slide,
@@ -275,7 +474,9 @@ def create_ppt_educational_content_carousel(prs: Presentation, carousel: Educati
     return prs  # Return the presentation for further modifications or saving
 
 
-def create_ppt_case_study_carousel(prs: Presentation, case_study_carousel: CaseStudyCarousel) -> Presentation:
+def create_ppt_case_study_carousel(prs: Presentation, case_study_carousel: CaseStudyCarousel,
+                                   post_id: Optional[int] = None,
+                                   user_id: Optional[int] = None) -> Presentation:
     """
     Create a PowerPoint presentation for Case Study Carousel.
 
@@ -294,43 +495,45 @@ def create_ppt_case_study_carousel(prs: Presentation, case_study_carousel: CaseS
     }
     cover_slide = random.choice(cover_layouts)(**cover_kwargs)
 
+    default_image_path = get_default_image_path()
+
     # Slide 2: Challenge
-    challenge_layouts = [create_title_and_body_layout_slide, create_one_column_text_layout_slide]
-    challenge_kwargs = {
-        'prs': prs,
-        'title': case_study_carousel.challenge.title,
-        'body_text': case_study_carousel.challenge.content,
-        'image_path': getattr(case_study_carousel.challenge, 'image_path', None) or get_pexels_image_path(
-            case_study_carousel.challenge.title or "challenge", get_default_image_path()
-        ),
-    }
-    challenge_slide = random.choice(challenge_layouts)(**challenge_kwargs)
+    challenge_image = getattr(case_study_carousel.challenge, 'image_path', None) or select_slide_image(
+        title=case_study_carousel.challenge.title, content=case_study_carousel.challenge.content,
+        content_type="case_study", post_id=post_id, slide_index=2, user_id=user_id,
+        default_path=default_image_path,
+    )
+    choose_content_layout(challenge_image, post_id, 2)(
+        prs=prs, title=case_study_carousel.challenge.title,
+        body_text=case_study_carousel.challenge.content, image_path=challenge_image,
+    )
 
     # Slide 3: Solution
-    solution_layouts = [create_title_and_body_layout_slide, create_title_and_body_1_layout_slide,
-                        # create_title_and_two_columns_layout_slide # TODO: Figure how to implement this one
-                        ]
-    solution_kwargs = {
-        'prs': prs,
-        'title': case_study_carousel.solution.title,
-        'body_text': case_study_carousel.solution.content
-    }
-    solution_slide = random.choice(solution_layouts)(**solution_kwargs)
+    solution_image = getattr(case_study_carousel.solution, 'image_path', None) or select_slide_image(
+        title=case_study_carousel.solution.title, content=case_study_carousel.solution.content,
+        content_type="case_study", post_id=post_id, slide_index=3, user_id=user_id,
+        default_path=default_image_path,
+    )
+    choose_content_layout(solution_image, post_id, 3)(
+        prs=prs, title=case_study_carousel.solution.title,
+        body_text=case_study_carousel.solution.content, image_path=solution_image,
+    )
 
-    # Slide 4: Results
-    results_layouts = [create_big_number_layout_slide, create_title_and_body_layout_slide,
-                       create_one_column_text_layout_slide]
-    results_kwargs = {
-        'prs': prs,
-        'title': case_study_carousel.results.title,
-        'body_text': case_study_carousel.results.content,
-        'image_path': getattr(case_study_carousel.results, 'image_path', None) or get_pexels_image_path(
-            case_study_carousel.results.title or "results", get_default_image_path()
-        ),
-        'big_number': getattr(case_study_carousel.results, 'big_number', ''),
-        'subtitle': getattr(case_study_carousel.results, 'subtitle', case_study_carousel.results.content),
-    }
-    results_slide = random.choice(results_layouts)(**results_kwargs)
+    # Slide 4: Results — no image keeps the big-number data-viz layout available.
+    results_image = getattr(case_study_carousel.results, 'image_path', None) or select_slide_image(
+        title=case_study_carousel.results.title, content=case_study_carousel.results.content,
+        content_type="case_study", post_id=post_id, slide_index=4, user_id=user_id,
+        default_path=default_image_path,
+    )
+    choose_content_layout(
+        results_image, post_id, 4,
+        text_layouts=[create_big_number_layout_slide, create_title_and_body_1_layout_slide],
+    )(
+        prs=prs, title=case_study_carousel.results.title,
+        body_text=case_study_carousel.results.content, image_path=results_image,
+        big_number=getattr(case_study_carousel.results, 'big_number', ''),
+        subtitle=getattr(case_study_carousel.results, 'subtitle', case_study_carousel.results.content),
+    )
 
     # Slide 5: Testimonial
     testimonial_layouts = [create_caption_only_layout_slide, create_blank_1_1_layout_slide]
@@ -357,7 +560,9 @@ def create_ppt_case_study_carousel(prs: Presentation, case_study_carousel: CaseS
     return prs  # Return the presentation for further modifications or saving
 
 
-def create_ppt_personal_story_carousel(prs: Presentation, carousel: PersonalStoryCarousel) -> Presentation:
+def create_ppt_personal_story_carousel(prs: Presentation, carousel: PersonalStoryCarousel,
+                                       post_id: Optional[int] = None,
+                                       user_id: Optional[int] = None) -> Presentation:
     default_image = get_default_image_path()
 
     cover_layouts = [create_title_layout_slide, create_section_header_layout_slide, create_title_only_layout_slide]
@@ -366,13 +571,13 @@ def create_ppt_personal_story_carousel(prs: Presentation, carousel: PersonalStor
         percentage="", body_text=carousel.cover.content
     )
 
-    story_layouts = [create_title_and_body_layout_slide, create_one_column_text_layout_slide]
-    for slide_data in carousel.story_slides:
-        random.choice(story_layouts)(
-            prs=prs, title=slide_data.title, body_text=slide_data.content,
-            image_path=getattr(slide_data, "image_path", None) or get_pexels_image_path(
-                slide_data.title or "story", default_image
-            ),
+    for slide_index, slide_data in enumerate(carousel.story_slides, start=2):
+        image_path = getattr(slide_data, "image_path", None) or select_slide_image(
+            title=slide_data.title, content=slide_data.content, content_type="personal_story",
+            post_id=post_id, slide_index=slide_index, user_id=user_id, default_path=default_image,
+        )
+        choose_content_layout(image_path, post_id, slide_index)(
+            prs=prs, title=slide_data.title, body_text=slide_data.content, image_path=image_path,
         )
 
     create_title_and_body_1_layout_slide(
@@ -387,7 +592,9 @@ def create_ppt_personal_story_carousel(prs: Presentation, carousel: PersonalStor
     return prs
 
 
-def create_ppt_industry_insights_carousel(prs: Presentation, carousel: IndustryInsightsCarousel) -> Presentation:
+def create_ppt_industry_insights_carousel(prs: Presentation, carousel: IndustryInsightsCarousel,
+                                          post_id: Optional[int] = None,
+                                          user_id: Optional[int] = None) -> Presentation:
     default_image = get_default_image_path()
 
     cover_layouts = [create_title_layout_slide, create_title_only_layout_slide]
@@ -395,13 +602,13 @@ def create_ppt_industry_insights_carousel(prs: Presentation, carousel: IndustryI
         prs=prs, title=carousel.cover.title, subtitle=carousel.cover.content
     )
 
-    insight_layouts = [create_title_and_body_layout_slide, create_one_column_text_layout_slide]
-    for insight in carousel.insights:
-        random.choice(insight_layouts)(
-            prs=prs, title=insight.title, body_text=insight.content,
-            image_path=getattr(insight, "image_path", None) or get_pexels_image_path(
-                insight.title or "industry", default_image
-            ),
+    for slide_index, insight in enumerate(carousel.insights, start=2):
+        image_path = getattr(insight, "image_path", None) or select_slide_image(
+            title=insight.title, content=insight.content, content_type="industry_insights",
+            post_id=post_id, slide_index=slide_index, user_id=user_id, default_path=default_image,
+        )
+        choose_content_layout(image_path, post_id, slide_index)(
+            prs=prs, title=insight.title, body_text=insight.content, image_path=image_path,
         )
 
     cta_layouts = [create_section_title_and_description_layout_slide, create_custom_3_1_layout_slide]
@@ -412,7 +619,9 @@ def create_ppt_industry_insights_carousel(prs: Presentation, carousel: IndustryI
     return prs
 
 
-def create_ppt_event_recap_carousel(prs: Presentation, carousel: EventRecapCarousel) -> Presentation:
+def create_ppt_event_recap_carousel(prs: Presentation, carousel: EventRecapCarousel,
+                                    post_id: Optional[int] = None,
+                                    user_id: Optional[int] = None) -> Presentation:
     default_image = get_default_image_path()
 
     cover_layouts = [create_title_layout_slide, create_section_header_layout_slide]
@@ -421,13 +630,13 @@ def create_ppt_event_recap_carousel(prs: Presentation, carousel: EventRecapCarou
         percentage=""
     )
 
-    moment_layouts = [create_title_and_body_layout_slide, create_one_column_text_layout_slide]
-    for moment in carousel.key_moments:
-        random.choice(moment_layouts)(
-            prs=prs, title=moment.title, body_text=moment.content,
-            image_path=getattr(moment, "image_path", None) or get_pexels_image_path(
-                moment.title or "event", default_image
-            ),
+    for slide_index, moment in enumerate(carousel.key_moments, start=2):
+        image_path = getattr(moment, "image_path", None) or select_slide_image(
+            title=moment.title, content=moment.content, content_type="event_recap",
+            post_id=post_id, slide_index=slide_index, user_id=user_id, default_path=default_image,
+        )
+        choose_content_layout(image_path, post_id, slide_index)(
+            prs=prs, title=moment.title, body_text=moment.content, image_path=image_path,
         )
 
     cta_layouts = [create_section_title_and_description_layout_slide, create_custom_3_1_layout_slide]
@@ -459,7 +668,9 @@ def create_ppt_testimonial_carousel(prs: Presentation, carousel: TestimonialCaro
     return prs
 
 
-def create_ppt_product_demo_carousel(prs: Presentation, carousel: ProductDemoCarousel) -> Presentation:
+def create_ppt_product_demo_carousel(prs: Presentation, carousel: ProductDemoCarousel,
+                                     post_id: Optional[int] = None,
+                                     user_id: Optional[int] = None) -> Presentation:
     default_image = get_default_image_path()
 
     cover_layouts = [create_title_layout_slide, create_title_only_layout_slide]
@@ -467,20 +678,24 @@ def create_ppt_product_demo_carousel(prs: Presentation, carousel: ProductDemoCar
         prs=prs, title=carousel.cover.title, subtitle=carousel.cover.content
     )
 
-    feature_layouts = [create_title_and_body_layout_slide, create_one_column_text_layout_slide]
-    random.choice(feature_layouts)(
+    main_image = getattr(carousel.main_feature, "image_path", None) or select_slide_image(
+        title=carousel.main_feature.title, content=carousel.main_feature.content,
+        content_type="product_demo", post_id=post_id, slide_index=2, user_id=user_id,
+        default_path=default_image,
+    )
+    choose_content_layout(main_image, post_id, 2)(
         prs=prs, title=carousel.main_feature.title, body_text=carousel.main_feature.content,
-        image_path=getattr(carousel.main_feature, "image_path", None) or get_pexels_image_path(
-            carousel.main_feature.title or "product", default_image
-        ),
+        image_path=main_image,
     )
 
-    for feature in carousel.additional_features:
-        random.choice(feature_layouts)(
-            prs=prs, title=feature.title, body_text=feature.content,
-            image_path=getattr(feature, "image_path", None) or get_pexels_image_path(
-                feature.title or "feature", default_image
-            ),
+    for offset, feature in enumerate(carousel.additional_features):
+        slide_index = 3 + offset
+        image_path = getattr(feature, "image_path", None) or select_slide_image(
+            title=feature.title, content=feature.content, content_type="product_demo",
+            post_id=post_id, slide_index=slide_index, user_id=user_id, default_path=default_image,
+        )
+        choose_content_layout(image_path, post_id, slide_index)(
+            prs=prs, title=feature.title, body_text=feature.content, image_path=image_path,
         )
 
     cta_layouts = [create_section_title_and_description_layout_slide, create_custom_3_1_layout_slide]

--- a/src/cqc_lem/utilities/carousel_creator.py
+++ b/src/cqc_lem/utilities/carousel_creator.py
@@ -1509,6 +1509,41 @@ CAROUSEL_TEMPLATES: dict[str, dict] = {
 DEFAULT_TEMPLATE = "bold_listicle"
 
 
+def _fit_and_crop_image(image_path: str, target_w: int, target_h: int):
+    """Cover-fit + center-crop an image to exactly (target_w, target_h) as RGB.
+
+    Scales so the image fully covers the target box (no letterboxing), then crops
+    the overflow from the center. Raises on any decode failure so callers can fall
+    back to a text-only render.
+    """
+    from PIL import Image
+    with Image.open(image_path) as src:
+        rgb = src.convert("RGB")  # flattens transparency / palette onto RGB
+    sw, sh = rgb.size
+    if sw <= 0 or sh <= 0:
+        raise ValueError("empty source image")
+    scale = max(target_w / sw, target_h / sh)
+    nw, nh = max(1, round(sw * scale)), max(1, round(sh * scale))
+    resized = rgb.resize((nw, nh), Image.LANCZOS)
+    left = (nw - target_w) // 2
+    top = (nh - target_h) // 2
+    return resized.crop((left, top, left + target_w, top + target_h))
+
+
+def _carousel_content_type(carousel_data) -> str:
+    """Map a carousel model instance to the content_type string used by the shared
+    image-selection engine (query derivation + avatar relevance)."""
+    return {
+        EducationalContentCarousel: "educational",
+        CaseStudyCarousel: "case_study",
+        PersonalStoryCarousel: "personal_story",
+        IndustryInsightsCarousel: "industry_insights",
+        EventRecapCarousel: "event_recap",
+        TestimonialCarousel: "testimonial",
+        ProductDemoCarousel: "product_demo",
+    }.get(type(carousel_data), "professional")
+
+
 def create_carousel_slide_images(
     carousel_data: Union[
         EducationalContentCarousel,
@@ -1522,6 +1557,7 @@ def create_carousel_slide_images(
     post_id: int,
     output_dir: Optional[str] = None,
     template: str = DEFAULT_TEMPLATE,
+    user_id: Optional[int] = None,
     # Legacy params retained for backward compat but ignored
     bg_color: tuple = (26, 86, 219),
     accent_color: tuple = (255, 255, 255),
@@ -1534,8 +1570,16 @@ def create_carousel_slide_images(
 
     ``template`` selects a visual style from CAROUSEL_TEMPLATES. Defaults to
     DEFAULT_TEMPLATE ("bold_listicle").
+
+    CONTENT (middle) slides composite a relevant image into a bottom photo band via
+    the shared, deterministic ``select_slide_image`` engine (Pexels-first, optional
+    avatar-gated generation), seeded by (post_id, slide_index). Text reflows into the
+    area above the band so nothing overlaps or clips. When no image is selected or the
+    decode fails, the slide renders exactly as before (text-only). Cover + CTA slides
+    are left as-is.
     """
     from PIL import Image, ImageDraw, ImageFont
+    from cqc_lem.utilities.logger import log_warning
 
     W, H = 1080, 1080
     WHITE = (255, 255, 255)
@@ -1637,6 +1681,28 @@ def create_carousel_slide_images(
         img.convert("RGB").save(out, "PNG", optimize=True)
         return out
 
+    # ── Content-slide photo band ──────────────────────────────────────────────
+    # A full-width band pinned above the slide footer. Preparing the panel up front
+    # means a decode failure returns (None, None) and the slide renders text-only —
+    # identical to today — instead of clipping text for an image that never lands.
+    BAND_H = 360
+
+    def _prep_band(image_path, footer_h, band_h=BAND_H):
+        if not image_path:
+            return None, None
+        band_top = H - footer_h - band_h
+        try:
+            panel = _fit_and_crop_image(image_path, W, band_h)
+        except Exception as e:
+            log_warning("Carousel content image composite failed; rendering text-only",
+                        exc=e, post_id=post_id)
+            return None, None
+        return panel, band_top
+
+    def _place_band(img, draw, panel, band_top, accent):
+        img.paste(panel, (0, band_top))
+        draw.rectangle([(0, band_top), (W, band_top + 6)], fill=accent)
+
     # ══════════════════════════════════════════════════════════════════════════
     # LAYOUT: listicle  (Bold Listicle)
     # White content slides, colored numbered badge circle top-left, navy footer
@@ -1667,7 +1733,7 @@ def create_carousel_slide_images(
         draw.text(((W - hw) // 2, H - 80), hint, font=f_l, fill=(*cover_accent, 160))
         return _save(img, idx)
 
-    def _listicle_content(idx, total, title, body, badge_color) -> str:
+    def _listicle_content(idx, total, title, body, badge_color, image_path=None) -> str:
         f_t = _load_font(64, bold=True)
         f_b = _load_font(38, bold=False)
         f_n = _load_font(50, bold=True)
@@ -1675,6 +1741,8 @@ def create_carousel_slide_images(
         title, body = _norm(title), _norm(body)
         img = Image.new("RGB", (W, H), color=content_bg)
         draw = ImageDraw.Draw(img, "RGBA")
+        BAR = 80
+        panel, band_top = _prep_band(image_path, BAR)
         draw.rectangle([(0, 0), (W, 10)], fill=badge_color)
         cx, cy, cr = 118, 155, 68
         draw.ellipse([(cx - cr, cy - cr), (cx + cr, cy + cr)], fill=badge_color)
@@ -1685,12 +1753,15 @@ def create_carousel_slide_images(
         draw.text((cx - nw // 2, cy - nh // 2 - 3), num_str, font=f_n, fill=WHITE)
         PAD = 62
         t_lines = _wrap(title, f_t, W - PAD * 2, draw)
-        y = _draw_block(draw, t_lines, f_t, PAD, cy + cr + 32, fill=title_color, spacing=12, max_lines=3)
+        y = _draw_block(draw, t_lines, f_t, PAD, cy + cr + 32, fill=title_color, spacing=12,
+                        max_lines=2 if band_top else 3)
         draw.rectangle([(PAD, y + 14), (PAD + 90, y + 20)], fill=badge_color)
         y += 48
         b_lines = _wrap(body, f_b, W - PAD * 2, draw)
-        _draw_block(draw, b_lines, f_b, PAD, y, fill=body_color, spacing=18, max_lines=7)
-        BAR = 80
+        _draw_block(draw, b_lines, f_b, PAD, y, fill=body_color, spacing=18,
+                    max_lines=3 if band_top else 7)
+        if panel is not None:
+            _place_band(img, draw, panel, band_top, badge_color)
         draw.rectangle([(0, H - BAR), (W, H)], fill=bottom_bar)
         draw.rectangle([(0, H - BAR), (int(W * idx / total), H - BAR + 5)], fill=badge_color)
         cnt = f"{idx} / {total}"
@@ -1759,13 +1830,14 @@ def create_carousel_slide_images(
         draw.text((PAD, H - 80), hint, font=f_l, fill=(*cover_accent, 120))
         return _save(img, idx)
 
-    def _dark_content(idx, total, title, body, badge_color) -> str:
+    def _dark_content(idx, total, title, body, badge_color, image_path=None) -> str:
         f_t = _load_font(70, bold=True)
         f_b = _load_font(36, bold=False)
         f_l = _load_font(24, bold=False)
         title, body = _norm(title), _norm(body)
         img = Image.new("RGB", (W, H), color=content_bg)
         draw = ImageDraw.Draw(img, "RGBA")
+        panel, band_top = _prep_band(image_path, 60)
         # Left accent bar (thicker than cover)
         draw.rectangle([(0, 0), (16, H)], fill=badge_color)
         # Slide number — top right, muted
@@ -1775,13 +1847,17 @@ def create_carousel_slide_images(
         # LARGE title left-aligned, starts high
         PAD = 70
         t_lines = _wrap(title, f_t, W - PAD - 60, draw)
-        y = _draw_block(draw, t_lines, f_t, PAD, 180, title_color, spacing=14, max_lines=4)
+        y = _draw_block(draw, t_lines, f_t, PAD, 180, title_color, spacing=14,
+                        max_lines=3 if band_top else 4)
         # Thin colored rule
         draw.rectangle([(PAD, y + 24), (PAD + 100, y + 27)], fill=badge_color)
         y += 52
         # Body text — smaller, muted
         b_lines = _wrap(body, f_b, W - PAD - 60, draw)
-        _draw_block(draw, b_lines, f_b, PAD, y, fill=body_color, spacing=20, max_lines=8)
+        _draw_block(draw, b_lines, f_b, PAD, y, fill=body_color, spacing=20,
+                    max_lines=3 if band_top else 8)
+        if panel is not None:
+            _place_band(img, draw, panel, band_top, badge_color)
         # Bottom: thin line only
         draw.rectangle([(0, H - 60), (W, H - 58)], fill=(*badge_color, 80))
         return _save(img, idx)
@@ -1842,7 +1918,7 @@ def create_carousel_slide_images(
         _draw_block(draw, s_lines, f_s, PAD, y, fill=(*cover_text, 200), spacing=14, centered=True, max_lines=3)
         return _save(img, idx)
 
-    def _stat_content(idx, total, title, body, badge_color) -> str:
+    def _stat_content(idx, total, title, body, badge_color, image_path=None) -> str:
         f_huge = _load_font(100, bold=True)  # title as massive centered text
         f_body = _load_font(36, bold=False)
         f_l    = _load_font(24, bold=False)
@@ -1850,6 +1926,7 @@ def create_carousel_slide_images(
         title, body = _norm(title), _norm(body)
         img = Image.new("RGB", (W, H), color=content_bg)
         draw = ImageDraw.Draw(img, "RGBA")
+        panel, band_top = _prep_band(image_path, 60)
         # Top color band
         draw.rectangle([(0, 0), (W, 90)], fill=badge_color)
         # Step number in top band
@@ -1857,17 +1934,23 @@ def create_carousel_slide_images(
         draw.text((W // 2 - int(draw.textlength(step_label, font=f_num)) // 2, 30),
                   step_label, font=f_num, fill=(*content_bg, 220))
         PAD = 60
-        # HUGE title — centered vertically in upper 65%
+        # HUGE title — centered vertically in upper 65%; lifted to the top band when
+        # an image occupies the lower third.
+        title_max = 2 if band_top else 3
         t_lines = _wrap(title, f_huge, W - PAD * 2, draw)
-        t_h = _block_h(t_lines[:3], f_huge, 18, draw)
-        t_y = max(130, (H * 65 // 100) // 2 - t_h // 2)
-        y = _draw_block(draw, t_lines, f_huge, PAD, t_y, title_color, spacing=18, centered=True, max_lines=3)
+        t_h = _block_h(t_lines[:title_max], f_huge, 18, draw)
+        t_y = 140 if band_top else max(130, (H * 65 // 100) // 2 - t_h // 2)
+        y = _draw_block(draw, t_lines, f_huge, PAD, t_y, title_color, spacing=18, centered=True,
+                        max_lines=title_max)
         # Horizontal rule
         draw.rectangle([(PAD, y + 22), (W - PAD, y + 25)], fill=(*badge_color, 120))
         y += 50
         # Body small, centered
         b_lines = _wrap(body, f_body, W - PAD * 2, draw)
-        _draw_block(draw, b_lines, f_body, PAD, y, fill=body_color, spacing=18, centered=True, max_lines=5)
+        _draw_block(draw, b_lines, f_body, PAD, y, fill=body_color, spacing=18, centered=True,
+                    max_lines=2 if band_top else 5)
+        if panel is not None:
+            _place_band(img, draw, panel, band_top, badge_color)
         # Bottom strip
         draw.rectangle([(0, H - 60), (W, H)], fill=bottom_bar)
         progress_w = int(W * (idx - 1) / max(total - 2, 1))
@@ -1931,7 +2014,7 @@ def create_carousel_slide_images(
         _draw_block(draw, s_lines, f_s, PAD, y, fill=(*cover_text, 200), spacing=14, centered=True, max_lines=3)
         return _save(img, idx)
 
-    def _step_content(idx, total, title, body, badge_color) -> str:
+    def _step_content(idx, total, title, body, badge_color, image_path=None) -> str:
         f_t = _load_font(62, bold=True)
         f_b = _load_font(36, bold=False)
         f_n = _load_font(30, bold=True)
@@ -1941,6 +2024,7 @@ def create_carousel_slide_images(
 
         img = Image.new("RGB", (W, H), color=content_bg)
         draw = ImageDraw.Draw(img, "RGBA")
+        panel, band_top = _prep_band(image_path, 60)
 
         # ── Step progress strip at top ────────────────────────────────────────
         STRIP = 100
@@ -1985,12 +2069,16 @@ def create_carousel_slide_images(
         draw.rectangle([(PAD, y + 12), (PAD + 80, y + 17)], fill=badge_color)
         y += 42
 
-        # ── Body with arrow bullets ───────────────────────────────────────────
-        for line_text in _wrap(body, f_b, W - PAD - 30, draw)[:7]:
+        # ── Body with arrow bullets (fewer lines when a photo band is present) ──
+        body_cap = 4 if band_top else 7
+        for line_text in _wrap(body, f_b, W - PAD - 30, draw)[:body_cap]:
             draw.text((PAD, y), "->", font=f_b, fill=badge_color)
             draw.text((PAD + 52, y), line_text, font=f_b, fill=body_color)
             bb = draw.textbbox((0, 0), line_text, font=f_b)
             y += (bb[3] - bb[1]) + 20
+
+        if panel is not None:
+            _place_band(img, draw, panel, band_top, badge_color)
 
         # ── Bottom bar ────────────────────────────────────────────────────────
         BAR = 60
@@ -2054,7 +2142,7 @@ def create_carousel_slide_images(
         _draw_block(draw, s_lines, f_s, PAD, y, fill=(*cover_text, 190), spacing=16, max_lines=3)
         return _save(img, idx)
 
-    def _story_content(idx, total, title, body, badge_color) -> str:
+    def _story_content(idx, total, title, body, badge_color, image_path=None) -> str:
         f_quote = _load_font(180, bold=True)
         f_t     = _load_font(58, bold=True)
         f_b     = _load_font(36, bold=False)
@@ -2062,6 +2150,7 @@ def create_carousel_slide_images(
         title, body = _norm(title), _norm(body)
         img = Image.new("RGB", (W, H), color=content_bg)
         draw = ImageDraw.Draw(img, "RGBA")
+        panel, band_top = _prep_band(image_path, 60)
         # Right accent border
         draw.rectangle([(W - 14, 0), (W, H)], fill=badge_color)
         # Slide number — top-left badge (square, not circle)
@@ -2077,13 +2166,19 @@ def create_carousel_slide_images(
         # Title — larger, treated as pull-quote
         PAD = 70
         t_lines = _wrap(title, f_t, W - PAD - 80, draw)
-        y = _draw_block(draw, t_lines, f_t, PAD, 220, title_color, spacing=14, max_lines=4)
+        y = _draw_block(draw, t_lines, f_t, PAD, 220, title_color, spacing=14,
+                        max_lines=3 if band_top else 4)
         # Amber rule
         draw.rectangle([(PAD, y + 16), (PAD + 100, y + 20)], fill=badge_color)
         y += 46
         # Body text — softer
         b_lines = _wrap(body, f_b, W - PAD - 80, draw)
-        _draw_block(draw, b_lines, f_b, PAD, y, fill=body_color, spacing=20, max_lines=6)
+        _draw_block(draw, b_lines, f_b, PAD, y, fill=body_color, spacing=20,
+                    max_lines=3 if band_top else 6)
+        if panel is not None:
+            _place_band(img, draw, panel, band_top, badge_color)
+            # keep the signature right border visible over the photo band
+            draw.rectangle([(W - 14, band_top), (W, H)], fill=badge_color)
         # Bottom: issue label
         draw.rectangle([(0, H - 60), (W - 14, H)], fill=bottom_bar)
         cnt = f"Part {idx - 1} of {total - 2}"
@@ -2193,6 +2288,7 @@ def create_carousel_slide_images(
         _add(carousel_data.call_to_action.title, carousel_data.call_to_action.content)
 
     # ── Render ────────────────────────────────────────────────────────────────
+    content_type = _carousel_content_type(carousel_data)
     total = len(slides_data)
     image_paths = []
     for idx, (title, body) in enumerate(slides_data, start=1):
@@ -2202,7 +2298,13 @@ def create_carousel_slide_images(
             path = render_cta(idx, total, title, body)
         else:
             bc = badge_colors[(idx - 2) % len(badge_colors)]
-            path = render_content(idx, total, title, body, bc)
+            # Shared deterministic engine; default_path=None so a miss => text-only
+            # (never a placeholder image).
+            slide_image = select_slide_image(
+                title=title, content=body, content_type=content_type,
+                post_id=post_id, slide_index=idx, user_id=user_id, default_path=None,
+            )
+            path = render_content(idx, total, title, body, bc, slide_image)
         image_paths.append(path)
 
     return image_paths

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -60,6 +60,24 @@ PREMIUM_TOP_VIDEO_MODEL = get_constant_from_env('PREMIUM_TOP_VIDEO_MODEL', defau
 PREMIUM_VIDEO_CREDITS = int(get_constant_from_env('PREMIUM_VIDEO_CREDITS', default_value='1'))
 PREMIUM_TOP_VIDEO_CREDITS = int(get_constant_from_env('PREMIUM_TOP_VIDEO_CREDITS', default_value='3'))
 
+# --- Carousel content-slide imagery ---
+# Content (middle) carousel slides carry a relevant image so they don't render as
+# text-on-blank. Sourcing is deterministic and cheap-first: Pexels stock (just an
+# API call) is the default source; Replicate generation is OFF by default (costs
+# money + only adds value with the user's active avatar). Rates are 0..1 fractions
+# applied against a per-(post_id, slide) deterministic seed so regeneration is stable.
+CAROUSEL_IMAGES_ENABLED = isTrue(get_constant_from_env('CAROUSEL_IMAGES_ENABLED', default_value='True'))
+CAROUSEL_PEXELS_ENABLED = isTrue(get_constant_from_env('CAROUSEL_PEXELS_ENABLED', default_value='True'))
+CAROUSEL_REPLICATE_ENABLED = isTrue(get_constant_from_env('CAROUSEL_REPLICATE_ENABLED', default_value='False'))
+# Fraction of eligible content slides that MAY use Replicate generation (only when
+# CAROUSEL_REPLICATE_ENABLED and the user has an active, relevant avatar). Low by default.
+CAROUSEL_REPLICATE_RATE = float(get_constant_from_env('CAROUSEL_REPLICATE_RATE', default_value='0.34'))
+# Fraction of content slides that get an image at all (1.0 = every content slide).
+CAROUSEL_IMAGE_RATE = float(get_constant_from_env('CAROUSEL_IMAGE_RATE', default_value='1.0'))
+# Use an LLM (lem-simple) to derive visual keywords from slide meaning. When off,
+# a local keyword-extraction heuristic is used (no API call).
+CAROUSEL_IMAGE_QUERY_LLM = isTrue(get_constant_from_env('CAROUSEL_IMAGE_QUERY_LLM', default_value='True'))
+
 # AI disclosure: append a short caption line to AI-visual posts. Guaranteed-visible
 # fallback for C2PA (which self-signed certs can't make LinkedIn trust yet).
 AI_DISCLOSURE_ENABLED = isTrue(get_constant_from_env('AI_DISCLOSURE_ENABLED', default_value='True'))

--- a/tests/unit/utilities/test_carousel_image_selection.py
+++ b/tests/unit/utilities/test_carousel_image_selection.py
@@ -1,18 +1,25 @@
 """Unit tests for the structured, deterministic carousel content-slide image
 selection + layout routing (cqc_lem.utilities.carousel_creator)."""
 
+import os
+import tempfile
+
 import pytest
 from unittest.mock import MagicMock, patch
 
 from cqc_lem.utilities import carousel_creator as cc
 from cqc_lem.utilities.carousel_creator import (
+    EducationalContentCarousel,
     choose_content_layout,
+    create_carousel_slide_images,
     create_one_column_text_layout_slide,
     create_one_column_text_1_layout_slide,
     create_title_and_body_layout_slide,
     create_title_and_body_1_layout_slide,
     derive_image_query,
     select_slide_image,
+    _carousel_content_type,
+    _fit_and_crop_image,
     _heuristic_image_query,
     _seeded_unit,
     _should_include_slide_image,
@@ -299,3 +306,122 @@ class TestCarouselIntegrationRouting:
 
         # Both content slides (index 2 and 3) got an image.
         assert used == [(2, "image"), (3, "image")]
+
+
+# ── Pillow renderer: the actually-posted PNG carousel ─────────────────────────
+
+def _write_solid_image(color, size=(800, 600), suffix=".jpg"):
+    from PIL import Image
+    path = tempfile.NamedTemporaryFile(delete=False, suffix=suffix).name
+    Image.new("RGB", size, color).save(path)
+    return path
+
+
+def _edu_carousel():
+    return EducationalContentCarousel(**{
+        "cover": {"title": "5 Productivity Tips", "content": "Get more done"},
+        "contents": [
+            {"title": "Time Blocking", "content": "Reserve focused blocks for deep work."},
+            {"title": "Batch Tasks", "content": "Group similar tasks to cut context switching."},
+        ],
+        "call_to_action": {"title": "Your turn", "content": "Which tip will you try?"},
+    })
+
+
+@pytest.mark.unit
+class TestFitAndCropImage:
+    def test_exact_size_and_rgb(self):
+        src = _write_solid_image((10, 20, 30), size=(400, 200), suffix=".png")
+        panel = _fit_and_crop_image(src, 1080, 360)
+        assert panel.size == (1080, 360)
+        assert panel.mode == "RGB"
+
+    def test_flattens_transparency(self):
+        from PIL import Image
+        src = tempfile.NamedTemporaryFile(delete=False, suffix=".png").name
+        Image.new("RGBA", (300, 300), (0, 128, 255, 128)).save(src)
+        panel = _fit_and_crop_image(src, 200, 200)
+        assert panel.mode == "RGB"
+        assert panel.size == (200, 200)
+
+    def test_bad_image_raises(self):
+        bad = tempfile.NamedTemporaryFile(delete=False, suffix=".jpg").name
+        with open(bad, "w") as fh:
+            fh.write("not an image")
+        with pytest.raises(Exception):
+            _fit_and_crop_image(bad, 100, 100)
+
+
+@pytest.mark.unit
+class TestContentTypeMapping:
+    def test_maps_known_type(self):
+        assert _carousel_content_type(_edu_carousel()) == "educational"
+
+    def test_unknown_defaults_professional(self):
+        assert _carousel_content_type(object()) == "professional"
+
+
+@pytest.mark.unit
+class TestPillowComposition:
+    """The posted PNGs: content slides composite a photo band; cover/CTA never do;
+    a miss or decode failure falls back to text-only. RED marks the image region."""
+
+    RED = (220, 30, 30)
+    BAND_SAMPLE = (540, 860)  # deep inside the bottom photo band on content slides
+
+    def _render(self, template, image_return, post_id=1):
+        from PIL import Image
+        outdir = tempfile.mkdtemp()
+        with patch.object(cc, "select_slide_image", return_value=image_return):
+            paths = create_carousel_slide_images(
+                _edu_carousel(), post_id=post_id,
+                output_dir=outdir, template=template,
+            )
+        return [Image.open(p).convert("RGB") for p in paths]
+
+    @pytest.mark.parametrize("template", ["bold_listicle", "minimal_dark", "stat_reveal",
+                                          "step_framework", "story_arc"])
+    def test_content_slide_has_image_band(self, template):
+        img_path = _write_solid_image(self.RED)
+        slides = self._render(template, img_path)
+        content = slides[1]  # slide_02 = first content slide
+        assert content.size == (1080, 1080)
+        px = content.getpixel(self.BAND_SAMPLE)
+        assert px[0] > 150 and px[1] < 100 and px[2] < 100, f"{template} band not composited: {px}"
+
+    def test_cover_and_cta_have_no_band(self):
+        img_path = _write_solid_image(self.RED)
+        slides = self._render("bold_listicle", img_path)
+        cover_px = slides[0].getpixel(self.BAND_SAMPLE)
+        cta_px = slides[-1].getpixel(self.BAND_SAMPLE)
+        # Neither cover nor CTA should carry the red photo band.
+        assert not (cover_px[0] > 150 and cover_px[1] < 100 and cover_px[2] < 100)
+        assert not (cta_px[0] > 150 and cta_px[1] < 100 and cta_px[2] < 100)
+
+    def test_no_image_falls_back_to_text_only(self):
+        slides = self._render("bold_listicle", None, post_id=2)
+        content = slides[1]
+        assert content.size == (1080, 1080)
+        px = content.getpixel(self.BAND_SAMPLE)
+        assert not (px[0] > 150 and px[1] < 100 and px[2] < 100)  # no red band
+
+    def test_decode_failure_falls_back_without_crashing(self):
+        bad = tempfile.NamedTemporaryFile(delete=False, suffix=".jpg").name
+        with open(bad, "w") as fh:
+            fh.write("not an image")
+        slides = self._render("minimal_dark", bad, post_id=3)
+        content = slides[1]
+        assert content.size == (1080, 1080)
+        px = content.getpixel(self.BAND_SAMPLE)
+        assert not (px[0] > 150 and px[1] < 100 and px[2] < 100)
+
+    def test_selection_engine_called_per_content_slide_with_seed(self):
+        outdir = tempfile.mkdtemp()
+        with patch.object(cc, "select_slide_image", return_value=None) as mock_sel:
+            create_carousel_slide_images(_edu_carousel(), post_id=77, output_dir=outdir,
+                                         template="bold_listicle", user_id=5)
+        # 2 content slides (cover + CTA excluded); seeded by post_id + slide_index.
+        assert mock_sel.call_count == 2
+        seen = {(c.kwargs["post_id"], c.kwargs["slide_index"], c.kwargs["user_id"])
+                for c in mock_sel.call_args_list}
+        assert seen == {(77, 2, 5), (77, 3, 5)}

--- a/tests/unit/utilities/test_carousel_image_selection.py
+++ b/tests/unit/utilities/test_carousel_image_selection.py
@@ -1,0 +1,301 @@
+"""Unit tests for the structured, deterministic carousel content-slide image
+selection + layout routing (cqc_lem.utilities.carousel_creator)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from cqc_lem.utilities import carousel_creator as cc
+from cqc_lem.utilities.carousel_creator import (
+    choose_content_layout,
+    create_one_column_text_layout_slide,
+    create_one_column_text_1_layout_slide,
+    create_title_and_body_layout_slide,
+    create_title_and_body_1_layout_slide,
+    derive_image_query,
+    select_slide_image,
+    _heuristic_image_query,
+    _seeded_unit,
+    _should_include_slide_image,
+    _should_generate_with_replicate,
+    _user_has_active_avatar,
+    _generate_avatar_slide_image,
+)
+
+ENV = "cqc_lem.utilities.env_constants"
+
+IMAGE_LAYOUTS = {create_one_column_text_layout_slide, create_one_column_text_1_layout_slide}
+TEXT_LAYOUTS = {create_title_and_body_layout_slide, create_title_and_body_1_layout_slide}
+
+
+@pytest.mark.unit
+class TestLayoutRouting:
+    def test_image_slide_routes_to_image_capable_layout(self):
+        # Every content slide that has an image must land on a picture-placeholder layout.
+        for slide_index in range(2, 12):
+            fn = choose_content_layout("/tmp/pic.jpg", post_id=42, slide_index=slide_index)
+            assert fn in IMAGE_LAYOUTS
+
+    def test_textonly_slide_routes_to_text_layout(self):
+        for slide_index in range(2, 12):
+            fn = choose_content_layout(None, post_id=42, slide_index=slide_index)
+            assert fn in TEXT_LAYOUTS
+
+    def test_layout_choice_is_deterministic(self):
+        a = choose_content_layout("/tmp/pic.jpg", post_id=7, slide_index=3)
+        b = choose_content_layout("/tmp/pic.jpg", post_id=7, slide_index=3)
+        assert a is b
+
+    def test_custom_text_pool_used_when_no_image(self):
+        sentinel = MagicMock(name="big_number")
+        fn = choose_content_layout(None, post_id=1, slide_index=2, text_layouts=[sentinel])
+        assert fn is sentinel
+
+
+@pytest.mark.unit
+class TestSeedDeterminism:
+    def test_seeded_unit_is_stable_and_in_range(self):
+        v1 = _seeded_unit(101, 3, "include")
+        v2 = _seeded_unit(101, 3, "include")
+        assert v1 == v2
+        assert 0.0 <= v1 < 1.0
+
+    def test_different_purpose_differs(self):
+        assert _seeded_unit(101, 3, "include") != _seeded_unit(101, 3, "source")
+
+    def test_none_post_id_is_stable(self):
+        assert _seeded_unit(None, 5, "include") == _seeded_unit(None, 5, "include")
+
+
+@pytest.mark.unit
+class TestShouldIncludeImage:
+    def test_disabled_returns_false(self):
+        with patch(f"{ENV}.CAROUSEL_IMAGES_ENABLED", False), \
+             patch(f"{ENV}.CAROUSEL_IMAGE_RATE", 1.0):
+            assert _should_include_slide_image(1, 2) is False
+
+    def test_rate_one_always_true(self):
+        with patch(f"{ENV}.CAROUSEL_IMAGES_ENABLED", True), \
+             patch(f"{ENV}.CAROUSEL_IMAGE_RATE", 1.0):
+            assert _should_include_slide_image(1, 2) is True
+
+    def test_rate_zero_always_false(self):
+        with patch(f"{ENV}.CAROUSEL_IMAGES_ENABLED", True), \
+             patch(f"{ENV}.CAROUSEL_IMAGE_RATE", 0.0):
+            assert _should_include_slide_image(1, 2) is False
+
+    def test_partial_rate_is_deterministic(self):
+        with patch(f"{ENV}.CAROUSEL_IMAGES_ENABLED", True), \
+             patch(f"{ENV}.CAROUSEL_IMAGE_RATE", 0.5):
+            first = _should_include_slide_image(9, 4)
+            assert first == _should_include_slide_image(9, 4)
+
+
+@pytest.mark.unit
+class TestQueryDerivation:
+    def test_heuristic_strips_stopwords_and_limits(self):
+        q = _heuristic_image_query("How to Boost Your Productivity", "the daily focus habit", "educational")
+        assert "the" not in q.split()
+        assert "your" not in q.split()
+        assert len(q.split()) <= 3
+
+    def test_heuristic_falls_back_to_content_type(self):
+        q = _heuristic_image_query("a to of", "", "product_demo")
+        assert q == "product demo"
+
+    def test_llm_disabled_uses_heuristic(self):
+        with patch(f"{ENV}.CAROUSEL_IMAGE_QUERY_LLM", False):
+            q = derive_image_query("Remote Team Collaboration", "async standups", "educational")
+        assert "remote" in q.lower()
+
+    def test_llm_path_returns_cleaned_keywords(self):
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock(message=MagicMock(content=" team collaboration, laptop \n"))]
+        with patch(f"{ENV}.CAROUSEL_IMAGE_QUERY_LLM", True), \
+             patch("cqc_lem.utilities.ai.client.client") as mock_client:
+            mock_client.chat.completions.create.return_value = mock_resp
+            q = derive_image_query("Collaboration", "work together", "educational")
+        assert q == "team collaboration laptop"
+
+    def test_llm_failure_falls_back_to_heuristic(self):
+        with patch(f"{ENV}.CAROUSEL_IMAGE_QUERY_LLM", True), \
+             patch("cqc_lem.utilities.ai.client.client") as mock_client:
+            mock_client.chat.completions.create.side_effect = RuntimeError("boom")
+            q = derive_image_query("Data Pipelines", "streaming events", "industry_insights")
+        assert "data" in q.lower() or "pipelines" in q.lower() or "streaming" in q.lower()
+
+    def test_llm_empty_response_falls_back(self):
+        mock_resp = MagicMock()
+        mock_resp.choices = [MagicMock(message=MagicMock(content="   "))]
+        with patch(f"{ENV}.CAROUSEL_IMAGE_QUERY_LLM", True), \
+             patch("cqc_lem.utilities.ai.client.client") as mock_client:
+            mock_client.chat.completions.create.return_value = mock_resp
+            q = derive_image_query("Cloud Security", "zero trust", "industry_insights")
+        assert q  # non-empty heuristic
+
+
+@pytest.mark.unit
+class TestAvatarGating:
+    def test_no_user_id_no_avatar(self):
+        assert _user_has_active_avatar(None) is False
+
+    def test_active_avatar_true(self):
+        avatar = {"status": "succeeded", "model_ref": "user/model:v1"}
+        with patch("cqc_lem.utilities.db.get_active_avatar", return_value=avatar):
+            assert _user_has_active_avatar(5) is True
+
+    def test_incomplete_avatar_false(self):
+        with patch("cqc_lem.utilities.db.get_active_avatar", return_value={"status": "training"}):
+            assert _user_has_active_avatar(5) is False
+
+    def test_avatar_lookup_error_false(self):
+        with patch("cqc_lem.utilities.db.get_active_avatar", side_effect=Exception("db down")):
+            assert _user_has_active_avatar(5) is False
+
+    def test_replicate_disabled_false(self):
+        with patch(f"{ENV}.CAROUSEL_REPLICATE_ENABLED", False):
+            assert _should_generate_with_replicate(1, 2, 5, "personal_story") is False
+
+    def test_replicate_irrelevant_content_type_false(self):
+        with patch(f"{ENV}.CAROUSEL_REPLICATE_ENABLED", True), \
+             patch(f"{ENV}.CAROUSEL_REPLICATE_RATE", 1.0):
+            assert _should_generate_with_replicate(1, 2, 5, "educational") is False
+
+    def test_replicate_all_gates_pass_true(self):
+        avatar = {"status": "succeeded", "model_ref": "user/model:v1"}
+        with patch(f"{ENV}.CAROUSEL_REPLICATE_ENABLED", True), \
+             patch(f"{ENV}.CAROUSEL_REPLICATE_RATE", 1.0), \
+             patch("cqc_lem.utilities.db.get_active_avatar", return_value=avatar):
+            assert _should_generate_with_replicate(1, 2, 5, "personal_story") is True
+
+    def test_replicate_rate_zero_false(self):
+        with patch(f"{ENV}.CAROUSEL_REPLICATE_ENABLED", True), \
+             patch(f"{ENV}.CAROUSEL_REPLICATE_RATE", 0.0):
+            assert _should_generate_with_replicate(1, 2, 5, "personal_story") is False
+
+
+@pytest.mark.unit
+class TestGenerateAvatarSlideImage:
+    def test_returns_path(self):
+        with patch("cqc_lem.utilities.ai.ai_helper.generate_post_image", return_value="/tmp/gen.png"):
+            assert _generate_avatar_slide_image("team", 5) == "/tmp/gen.png"
+
+    def test_failure_returns_none(self):
+        with patch("cqc_lem.utilities.ai.ai_helper.generate_post_image", side_effect=Exception("api")):
+            assert _generate_avatar_slide_image("team", 5) is None
+
+
+@pytest.mark.unit
+class TestSelectSlideImage:
+    def test_disabled_returns_default(self):
+        with patch.object(cc, "_should_include_slide_image", return_value=False):
+            assert select_slide_image(
+                title="T", content="C", content_type="educational",
+                post_id=1, slide_index=2, default_path="/def.png",
+            ) == "/def.png"
+
+    def test_pexels_first_path(self):
+        with patch.object(cc, "_should_include_slide_image", return_value=True), \
+             patch.object(cc, "derive_image_query", return_value="team laptop"), \
+             patch.object(cc, "_should_generate_with_replicate", return_value=False), \
+             patch(f"{ENV}.CAROUSEL_PEXELS_ENABLED", True), \
+             patch.object(cc, "get_pexels_image_path", return_value="/tmp/pexels.jpg") as mock_pex:
+            result = select_slide_image(
+                title="T", content="C", content_type="educational",
+                post_id=1, slide_index=2, default_path="/def.png",
+            )
+        assert result == "/tmp/pexels.jpg"
+        mock_pex.assert_called_once()
+
+    def test_replicate_used_when_gated_in(self):
+        with patch.object(cc, "_should_include_slide_image", return_value=True), \
+             patch.object(cc, "derive_image_query", return_value="founder story"), \
+             patch.object(cc, "_should_generate_with_replicate", return_value=True), \
+             patch.object(cc, "_generate_avatar_slide_image", return_value="/tmp/avatar.png") as mock_gen, \
+             patch.object(cc, "get_pexels_image_path") as mock_pex:
+            result = select_slide_image(
+                title="T", content="C", content_type="personal_story",
+                post_id=1, slide_index=2, user_id=5, default_path="/def.png",
+            )
+        assert result == "/tmp/avatar.png"
+        mock_gen.assert_called_once()
+        mock_pex.assert_not_called()
+
+    def test_replicate_failure_falls_back_to_pexels(self):
+        with patch.object(cc, "_should_include_slide_image", return_value=True), \
+             patch.object(cc, "derive_image_query", return_value="founder story"), \
+             patch.object(cc, "_should_generate_with_replicate", return_value=True), \
+             patch.object(cc, "_generate_avatar_slide_image", return_value=None), \
+             patch(f"{ENV}.CAROUSEL_PEXELS_ENABLED", True), \
+             patch.object(cc, "get_pexels_image_path", return_value="/tmp/pexels.jpg"):
+            result = select_slide_image(
+                title="T", content="C", content_type="personal_story",
+                post_id=1, slide_index=2, user_id=5, default_path="/def.png",
+            )
+        assert result == "/tmp/pexels.jpg"
+
+    def test_all_sources_fail_returns_default(self):
+        with patch.object(cc, "_should_include_slide_image", return_value=True), \
+             patch.object(cc, "derive_image_query", return_value="x"), \
+             patch.object(cc, "_should_generate_with_replicate", return_value=False), \
+             patch(f"{ENV}.CAROUSEL_PEXELS_ENABLED", True), \
+             patch.object(cc, "get_pexels_image_path", return_value=None):
+            result = select_slide_image(
+                title="T", content="C", content_type="educational",
+                post_id=1, slide_index=2, default_path="/def.png",
+            )
+        assert result == "/def.png"
+
+    def test_pexels_disabled_returns_default(self):
+        with patch.object(cc, "_should_include_slide_image", return_value=True), \
+             patch.object(cc, "derive_image_query", return_value="x"), \
+             patch.object(cc, "_should_generate_with_replicate", return_value=False), \
+             patch(f"{ENV}.CAROUSEL_PEXELS_ENABLED", False):
+            result = select_slide_image(
+                title="T", content="C", content_type="educational",
+                post_id=1, slide_index=2, default_path=None,
+            )
+        assert result is None
+
+
+@pytest.mark.unit
+class TestCarouselIntegrationRouting:
+    """End-to-end: an image-bearing content slide never lands on a no-picture layout."""
+
+    def _make_prs(self):
+        # Minimal fake presentation capturing which layouts were used.
+        from cqc_lem.utilities.carousel_creator import EducationalContentCarousel
+        carousel = EducationalContentCarousel(**{
+            "cover": {"title": "Cover", "content": "Sub"},
+            "contents": [
+                {"title": "Tip One", "content": "Body one"},
+                {"title": "Tip Two", "content": "Body two"},
+            ],
+            "call_to_action": {"title": "CTA", "content": "Act now"},
+        })
+        return carousel
+
+    def test_image_slides_use_picture_layouts(self):
+        carousel = self._make_prs()
+        prs = MagicMock()
+        used = []
+
+        def fake_choose(image_path, post_id, slide_index, *a, **k):
+            def _layout(**kwargs):
+                used.append((slide_index, "image" if kwargs.get("image_path") else "text"))
+                return MagicMock()
+            return _layout
+
+        with patch.object(cc, "select_slide_image", return_value="/tmp/pic.jpg"), \
+             patch.object(cc, "choose_content_layout", side_effect=fake_choose), \
+             patch.object(cc, "get_default_image_path", return_value="/def.png"), \
+             patch.object(cc, "get_pexels_image_path", return_value="/tmp/cta.jpg"), \
+             patch.object(cc, "create_title_layout_slide", return_value=MagicMock()), \
+             patch.object(cc, "create_title_only_layout_slide", return_value=MagicMock()), \
+             patch.object(cc, "create_title_and_body_layout_slide", return_value=MagicMock()), \
+             patch.object(cc, "create_section_title_and_description_layout_slide", return_value=MagicMock()), \
+             patch.object(cc, "create_custom_3_1_layout_slide", return_value=MagicMock()), \
+             patch.object(cc, "create_caption_only_layout_slide", return_value=MagicMock()):
+            cc.create_ppt_educational_content_carousel(prs, carousel, post_id=99, user_id=None)
+
+        # Both content slides (index 2 and 3) got an image.
+        assert used == [(2, "image"), (3, "image")]


### PR DESCRIPTION
## Summary
Carousel content slides (every slide between cover and CTA) rendered as mostly empty white space. This adds a relevant image to each content slide via a **deterministic, Pexels-first** selection engine, fixing both the **posted** PNG renderer (the user-visible complaint) and the download PPTX path.

### Root cause
The posted carousel images come from the Pillow renderer `create_carousel_slide_images`, which had **no image support** — it drew text on colored/white backgrounds, leaving the lower portion of short-body slides empty. (The PPTX path also had a bug where `create_title_and_body_layout_slide`, which has no picture placeholder, could be randomly picked for an image-bearing slide and silently drop the image via `**kwargs`.)

### Image-selection engine (`select_slide_image`, deterministic — seeded by `(post_id, slide_index)`)
- **Whether:** `CAROUSEL_IMAGES_ENABLED` (default on) × `CAROUSEL_IMAGE_RATE` (default 1.0).
- **Query:** `derive_image_query` derives visual keywords from the slide's *meaning* via an `lem-simple` call (`CAROUSEL_IMAGE_QUERY_LLM`, default on), falling back to a local stopword-stripping heuristic — not the raw title.
- **Source:** Pexels-first (`CAROUSEL_PEXELS_ENABLED`, default on). Replicate generation is opt-in (`CAROUSEL_REPLICATE_ENABLED`, default **OFF**), low-rate (`CAROUSEL_REPLICATE_RATE` 0.34), and only when the content type is avatar-relevant (`personal_story`) **and** the user has an active avatar (`get_active_avatar`), reusing the existing `generate_post_image` LoRA helper.

### Posted PNG renderer (`create_carousel_slide_images`)
- Full-width **bottom photo band** (`BAND_H=360`) pinned above each layout's footer; title/body reflow into the space above (reduced `max_lines`) so text never overlaps/clips. 6px template-colored accent divider.
- Applied across all 5 content layouts (`listicle`, `dark_minimal`, `stat_big`, `step_progress`, `quote_pull`); **cover + CTA untouched**.
- `_fit_and_crop_image`: cover-fit → center-crop to band, `convert("RGB")`, output stays 1080×1080 PNG. Any decode/fetch failure → `(None, None)` → slide renders **text-only identically to before**. Existing `PostStatus.ERROR` flag on genuine render failure preserved.

### PPTX path
Image-bearing content slides now route only to layouts with a picture placeholder (`choose_content_layout`).

## Testing
- **45 new tests** (18 for the PNG band + fit/crop, 27 for selection/query/routing/toggles/fallbacks).
- Full unit suite: **2344 passed**. Every fallback branch covered.

## Note for reviewer
`carousel_creator.py` is in the pre-existing Codecov `omit` list (Pillow visual output), so these tests validate behavior but won't count toward patch %. New logic in `env_constants.py` / `run_content_plan.py` is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)