### PR TITLE
fix(carousel): send browser User-Agent when downloading Pexels slide images

### DIFF
--- a/src/cqc_lem/utilities/carousel_creator.py
+++ b/src/cqc_lem/utilities/carousel_creator.py
@@ -227,9 +227,11 @@ def get_pexels_image_path(query: str, default_path: Optional[str] = None) -> Opt
         from cqc_lem.utilities.pexels_helper import get_photo
         photo = get_photo(query)
         url = photo.medium  # medium-size JPEG is a good balance for slides
-        suffix = ".jpg"
-        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
-        urllib.request.urlretrieve(url, tmp.name)
+        # Pexels' image CDN 403s the default urllib User-Agent, so send a browser one.
+        req = urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        tmp = tempfile.NamedTemporaryFile(delete=False, suffix=".jpg")
+        with urllib.request.urlopen(req, timeout=20) as resp, open(tmp.name, "wb") as fh:
+            fh.write(resp.read())
         return tmp.name
     except Exception:
         return default_path


### PR DESCRIPTION
## Problem
Carousel content slides were rendering **text-only** in production despite the carousel-imagery feature (PR #323) being merged and deployed (v0.38.0). Root cause: Pexels' image CDN (`images.pexels.com`) returns **HTTP 403 Forbidden** to `urllib.request.urlretrieve`'s default `Python-urllib` User-Agent. `get_pexels_image_path` swallows the exception and returns `None`, so `select_slide_image` yields no image and every inner slide falls back to text-only.

Verified live on the VPS: `get_photos()` (the Pexels *API*) works fine and returns valid URLs, but downloading `photo.medium` via `urlretrieve` 403s. Adding a `User-Agent: Mozilla/5.0` header makes the download succeed (13.8 KB image returned).

## Fix
Download the image with `urllib.request.Request(url, headers={"User-Agent": "Mozilla/5.0"})` instead of bare `urlretrieve`.

## Scope confirmation
Inner-slides-only behavior is already correct — the PNG renderer composites images only on content slides (`idx != 1` and `idx != total`); cover and CTA slides are untouched. No change needed there.

## Tests
`tests/unit/utilities/test_carousel_image_selection.py` — 48 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)