### PR TITLE
fix(ui,deploy): lowercase post_type on schedule + optional Flower basic auth

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -64,9 +64,12 @@ CELERY_RESULT_BACKEND=redis://redis:6379/1
 CELERY_BROKER_CONNECTION_RETRY_ON_STARTUP=True
 CELERY_RESULT_EXTENDED=True
 CELERY_FLOWER_PORT=8555
-# Flower basic auth (also gated by Cloudflare Access).
-CELERY_FLOWER_USER=admin
-CELERY_FLOWER_PASSWORD=CHANGE_ME_strong_flower_password
+# Flower basic auth — OPTIONAL extra protection on top of Cloudflare Zero Trust
+# Access. Leave both unset to run Flower with no basic auth (the container still
+# boots); set both to require a login. Marked "# optional" so check_env.sh does
+# not fail the deploy when they are absent.
+CELERY_FLOWER_USER=admin  # optional
+CELERY_FLOWER_PASSWORD=CHANGE_ME_strong_flower_password  # optional
 CELERY_FLOWER_STATE_SAVE_INTERVAL=5000
 CELERY_WORKER_HOST=celery-worker-host
 CELERY_WORKER_NAME=worker@%h

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -137,9 +137,10 @@ services:
       - ./logs:/app/logs
       - flower_db:/data
     environment:
-      # Replace the dev unauthenticated mode with basic auth + persistence.
-      # Kept behind Cloudflare Access as well (see cloudflared/config.yml).
-      - FLOWER_BASIC_AUTH=${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}
+      # Optional basic auth + persistence. Flower is gated by Cloudflare Zero Trust
+      # Access regardless; basic auth is extra protection. When CELERY_FLOWER_USER is
+      # unset the whole value collapses to empty (no auth) instead of a broken ":".
+      - FLOWER_BASIC_AUTH=${CELERY_FLOWER_USER:+${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}}
       - FLOWER_PERSISTENT=True
       - CELERY_TIMEZONE=${CELERY_TIMEZONE:-UTC}
     deploy:

--- a/scripts/check_env.sh
+++ b/scripts/check_env.sh
@@ -12,9 +12,12 @@ TEMPLATE="${2:-${ROOT_DIR}/.env.prod.example}"
 [[ -f "$ENV_FILE" ]] || { echo "ERROR: env file not found: $ENV_FILE" >&2; exit 1; }
 [[ -f "$TEMPLATE" ]] || { echo "ERROR: template not found: $TEMPLATE" >&2; exit 1; }
 
-# Extract KEY names (strip comments/blank lines, take text before first '=').
+# Extract REQUIRED key names (strip comments/blank lines, take text before first
+# '='). Lines tagged with a trailing "# optional" are excluded — they may be unset
+# on the server without failing the deploy (e.g. Flower basic auth, which is also
+# gated by Cloudflare Access).
 keys_of() {
-  grep -vE '^[[:space:]]*(#|$)' "$1" | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=.*/\1/' | sort -u
+  grep -vE '^[[:space:]]*(#|$)' "$1" | grep -viE '#[[:space:]]*optional' | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*=.*/\1/' | sort -u
 }
 
 missing=()

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
@@ -159,7 +159,7 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
     try {
       const payload: Record<string, unknown> = {
         content,
-        post_type: postType,
+        post_type: postType.toLowerCase(),
         scheduled_datetime: new Date(scheduledAt).toISOString(),
         email,
         status: 'pending',


### PR DESCRIPTION
Two fixes surfaced while deploying the carousel-image fix.

## 1. Content Studio manual scheduling 422 (bug)
`ComposePost.tsx` kept `postType` as `'TEXT'`/`'VIDEO'`/`'CAROUSEL'` (uppercase) for internal UI state but sent it **verbatim** in the `/schedule_post/` payload. The backend `PostType` enum expects lowercase, so scheduling failed with:
```
Input should be 'text', 'carousel' or 'video'  (input: "TEXT")
```
Fix: `post_type: postType.toLowerCase()` in the payload. Internal comparisons (`postType === 'CAROUSEL'`, etc.) stay uppercase.

## 2. Flower basic auth made optional (deploy unblock)
The release deploy preflight (`scripts/check_env.sh`) hard-requires every key in `.env.prod.example`, including `CELERY_FLOWER_USER`/`CELERY_FLOWER_PASSWORD`. Those were intentionally removed from the server `.env` (Flower is gated by Cloudflare Zero Trust Access), so **every deploy now fails preflight**. 

- `check_env.sh` skips template keys tagged `# optional`.
- The two `CELERY_FLOWER_*` keys are tagged `# optional` in `.env.prod.example`.
- `docker-compose.prod.yml` collapses `FLOWER_BASIC_AUTH` to empty (no auth) instead of a broken `":"` when creds are unset: `${CELERY_FLOWER_USER:+${CELERY_FLOWER_USER}:${CELERY_FLOWER_PASSWORD}}`. Verified via `docker compose config` (empty when unset, `user:pass` when set).

Flower still supports basic auth as extra protection when both keys are set; it just no longer *requires* them and no longer blocks deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)