### PR TITLE
feat(review): post-type filter + boolean keyword search + sort on Review & Edit

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -763,7 +763,10 @@ def get_posts_for_email(
     page: int = Query(default=1, ge=1),
     page_size: int = Query(default=10, ge=1, le=200),
     sort_order: str = Query(default='asc', pattern='^(asc|desc)$'),
+    sort_by: str = Query(default='scheduled_time', pattern='^(scheduled_time|status|post_type|id)$'),
     status_filter: Optional[str] = Query(default=None),
+    post_type_filter: Optional[str] = Query(default=None, pattern='^(text|video|carousel)$'),
+    search: Optional[str] = Query(default=None, max_length=500),
 ) -> ResponseModel:
     if not email:
         raise HTTPException(status_code=400, detail="Email is required")
@@ -771,7 +774,8 @@ def get_posts_for_email(
     offset = (page - 1) * page_size
     posts, total = get_post_by_email(
         email, limit=page_size, offset=offset,
-        sort_order=sort_order, status_filter=status_filter
+        sort_order=sort_order, status_filter=status_filter,
+        post_type_filter=post_type_filter, search=search, sort_by=sort_by,
     )
 
     posts_list = [

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../api/client'
@@ -29,6 +29,22 @@ const STATUSES: { label: string; value: Status }[] = [
   { label: 'SCHEDULED', value: 'scheduled' },
   { label: 'POSTED', value: 'posted' },
   { label: 'REJECTED', value: 'rejected' },
+]
+
+type PostTypeFilter = 'ALL' | 'text' | 'video' | 'carousel'
+const POST_TYPE_FILTERS: { label: string; value: PostTypeFilter }[] = [
+  { label: 'All types', value: 'ALL' },
+  { label: 'Text', value: 'text' },
+  { label: 'Video', value: 'video' },
+  { label: 'Carousel', value: 'carousel' },
+]
+
+type SortBy = 'scheduled_time' | 'status' | 'post_type' | 'id'
+const SORT_BY_OPTIONS: { label: string; value: SortBy }[] = [
+  { label: 'Scheduled time', value: 'scheduled_time' },
+  { label: 'Status', value: 'status' },
+  { label: 'Type', value: 'post_type' },
+  { label: 'Created (ID)', value: 'id' },
 ]
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50]
@@ -73,9 +89,24 @@ export default function ContentStudio() {
 
   // Filter / sort / pagination state
   const [filterStatus, setFilterStatus] = useState<Status>('ALL')
+  const [filterPostType, setFilterPostType] = useState<PostTypeFilter>('ALL')
+  const [sortBy, setSortBy] = useState<SortBy>('scheduled_time')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
   const [page, setPage] = useState(1)
   const [pageSize, setPageSize] = useState(10)
+
+  // Keyword search — raw input is debounced into the applied query so we don't
+  // refetch on every keystroke. Supports boolean operators (AND / OR / NOT).
+  const [searchInput, setSearchInput] = useState('')
+  const [searchQuery, setSearchQuery] = useState('')
+  useEffect(() => {
+    const t = setTimeout(() => {
+      setSearchQuery(searchInput.trim())
+      setPage(1)
+      setSelectedIds(new Set())
+    }, 400)
+    return () => clearTimeout(t)
+  }, [searchInput])
 
   // Selection / bulk state
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
@@ -90,7 +121,7 @@ export default function ContentStudio() {
   const [regenGuidance, setRegenGuidance] = useState('')
   const [regenNotice, setRegenNotice] = useState<string | null>(null)
 
-  const queryKey = ['posts', email, page, pageSize, sortOrder, filterStatus]
+  const queryKey = ['posts', email, page, pageSize, sortOrder, sortBy, filterStatus, filterPostType, searchQuery]
 
   const { data, isLoading } = useQuery<{ detail: PostsResponse }>({
     queryKey,
@@ -100,8 +131,11 @@ export default function ContentStudio() {
         page: String(page),
         page_size: String(pageSize),
         sort_order: sortOrder,
+        sort_by: sortBy,
       })
       if (filterStatus !== 'ALL') params.set('status_filter', filterStatus)
+      if (filterPostType !== 'ALL') params.set('post_type_filter', filterPostType)
+      if (searchQuery) params.set('search', searchQuery)
       return api.get(`/posts/?${params.toString()}`).then((r) => r.data)
     },
     enabled: !!email,
@@ -223,6 +257,19 @@ export default function ContentStudio() {
     if (newFilter !== undefined) setFilterStatus(newFilter)
   }
 
+  const hasActiveFilters = filterStatus !== 'ALL' || filterPostType !== 'ALL' || searchQuery !== ''
+
+  function clearFilters() {
+    setFilterStatus('ALL')
+    setFilterPostType('ALL')
+    setSearchInput('')
+    setSearchQuery('')
+    setSortBy('scheduled_time')
+    setPage(1)
+    setSelectedIds(new Set())
+    setEditingPost(null)
+  }
+
   const allOnPageSelected = posts.length > 0 && posts.every((p) => selectedIds.has(p.post_id))
 
   return (
@@ -300,13 +347,69 @@ export default function ContentStudio() {
         ))}
       </div>
 
-      {/* Sort + page-size controls */}
+      {/* Keyword search — boolean operators supported */}
+      <div>
+        <div className="relative">
+          <span className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 text-sm">🔍</span>
+          <input
+            type="search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder='Search posts… e.g.  ai AND "case study" NOT hiring'
+            aria-label="Search posts by keyword"
+            className="w-full border border-gray-300 rounded-lg pl-9 pr-8 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          {searchInput && (
+            <button
+              type="button"
+              onClick={() => setSearchInput('')}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 text-base leading-none px-1"
+            >
+              ×
+            </button>
+          )}
+        </div>
+        <p className="text-xs text-gray-400 mt-1">
+          Combine keywords with <span className="font-mono font-semibold">AND</span>,{' '}
+          <span className="font-mono font-semibold">OR</span>,{' '}
+          <span className="font-mono font-semibold">NOT</span> and parentheses; wrap phrases in "quotes".
+        </p>
+      </div>
+
+      {/* Sort + type filter + page-size controls */}
       <div className="flex items-center gap-3 flex-wrap text-sm">
+        <label className="flex items-center gap-1.5 text-xs text-gray-600">
+          <span>Type</span>
+          <select
+            value={filterPostType}
+            onChange={(e) => { setFilterPostType(e.target.value as PostTypeFilter); setPage(1); setSelectedIds(new Set()) }}
+            className="border border-gray-300 rounded-lg px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500"
+          >
+            {POST_TYPE_FILTERS.map((t) => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </select>
+        </label>
+        <label className="flex items-center gap-1.5 text-xs text-gray-600">
+          <span>Sort by</span>
+          <select
+            value={sortBy}
+            onChange={(e) => { setSortBy(e.target.value as SortBy); resetPage() }}
+            className="border border-gray-300 rounded-lg px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500"
+          >
+            {SORT_BY_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </label>
         <button
           onClick={() => { setSortOrder((o) => (o === 'asc' ? 'desc' : 'asc')); resetPage() }}
           className="flex items-center gap-1 text-gray-600 border border-gray-300 rounded-lg px-3 py-1.5 hover:border-blue-400 transition-colors text-xs font-medium"
         >
-          {sortOrder === 'asc' ? '↑ Oldest first' : '↓ Newest first'}
+          {sortBy === 'scheduled_time'
+            ? (sortOrder === 'asc' ? '↑ Oldest first' : '↓ Newest first')
+            : (sortOrder === 'asc' ? '↑ Ascending' : '↓ Descending')}
         </button>
         <div className="flex items-center gap-1.5 text-xs text-gray-600">
           <span>Show</span>
@@ -403,11 +506,18 @@ export default function ContentStudio() {
             <div className="flex flex-col items-center text-center py-12 px-4 bg-white rounded-lg border border-gray-200">
               <div className="text-4xl mb-4">📅</div>
               <p className="text-gray-600 text-sm mb-6 max-w-xs">
-                {filterStatus === 'ALL'
-                  ? 'Your scheduled posts will appear here. Generate your first week of content to get started.'
-                  : 'No posts match this filter.'}
+                {hasActiveFilters
+                  ? 'No posts match these filters.'
+                  : 'Your scheduled posts will appear here. Generate your first week of content to get started.'}
               </p>
-              {filterStatus === 'ALL' && (
+              {hasActiveFilters ? (
+                <button
+                  onClick={clearFilters}
+                  className="border border-gray-300 text-gray-600 px-5 py-2 rounded-lg text-sm font-semibold hover:bg-gray-50 transition-colors"
+                >
+                  Clear filters
+                </button>
+              ) : (
                 <button
                   onClick={() => weeklyMutation.mutate()}
                   disabled={weeklyMutation.isPending}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -545,12 +545,148 @@ def update_db_post_status(post_id: int, post_status: PostStatus) -> bool:
     return success
 
 
+# Columns the Review & Edit list may be ordered by. Whitelisted to keep the
+# ORDER BY clause injection-safe (the value is interpolated, not parameterized).
+_POST_SORT_COLUMNS = {
+    'scheduled_time': 'scheduled_time',
+    'status': 'status',
+    'post_type': 'post_type',
+    'id': 'id',
+}
+
+_SEARCH_MAX_TERMS = 20
+
+
+def _escape_like(term: str) -> str:
+    """Escape LIKE wildcards so a search term matches literally (default '\\' escape)."""
+    return term.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_')
+
+
+def build_content_search_clause(search: Optional[str], column: str = 'content') -> tuple[Optional[str], list]:
+    """Parse a boolean keyword query into a parameterized SQL condition over *column*.
+
+    Supports AND / OR / NOT (case-insensitive), implicit AND between adjacent terms,
+    parentheses for grouping, and "quoted phrases". Each bare term matches the column
+    case-insensitively via LIKE %term% (wildcards in the term are escaped). Returns
+    ``(sql_fragment, params)`` — the fragment is already fully parenthesized and safe
+    to drop into a WHERE — or ``(None, [])`` when the query is empty. Unparseable input
+    falls back to a single LIKE over the raw string so search never hard-errors.
+    """
+    if not search or not search.strip():
+        return None, []
+
+    # ── Tokenize: parens, "quoted phrases", and bare words (AND/OR/NOT are keywords).
+    tokens: list[tuple[str, str]] = []
+    i, n = 0, len(search)
+    while i < n:
+        ch = search[i]
+        if ch.isspace():
+            i += 1
+        elif ch == '(':
+            tokens.append(('LPAREN', ch)); i += 1
+        elif ch == ')':
+            tokens.append(('RPAREN', ch)); i += 1
+        elif ch == '"':
+            j = i + 1
+            while j < n and search[j] != '"':
+                j += 1
+            phrase = search[i + 1:j]
+            if phrase.strip():
+                tokens.append(('TERM', phrase.strip()))
+            i = j + 1
+        else:
+            j = i
+            while j < n and not search[j].isspace() and search[j] not in '()"':
+                j += 1
+            word = search[i:j]
+            upper = word.upper()
+            if upper in ('AND', 'OR', 'NOT'):
+                tokens.append((upper, word))
+            else:
+                tokens.append(('TERM', word))
+            i = j
+
+    if not tokens:
+        return None, []
+
+    params: list = []
+    term_count = 0
+
+    class _ParseError(Exception):
+        pass
+
+    pos = 0
+
+    def _peek() -> Optional[str]:
+        return tokens[pos][0] if pos < len(tokens) else None
+
+    def _term_sql(value: str) -> str:
+        nonlocal term_count
+        term_count += 1
+        if term_count > _SEARCH_MAX_TERMS:
+            raise _ParseError('too many terms')
+        params.append(f"%{_escape_like(value)}%")
+        return f"{column} LIKE %s"
+
+    def _parse_or() -> str:
+        node = _parse_and()
+        while _peek() == 'OR':
+            nonlocal_advance()
+            node = f"({node} OR {_parse_and()})"
+        return node
+
+    def _parse_and() -> str:
+        node = _parse_not()
+        while _peek() in ('AND', 'NOT', 'TERM', 'LPAREN'):
+            if _peek() == 'AND':
+                nonlocal_advance()
+            node = f"({node} AND {_parse_not()})"
+        return node
+
+    def _parse_not() -> str:
+        if _peek() == 'NOT':
+            nonlocal_advance()
+            return f"(NOT {_parse_not()})"
+        return _parse_atom()
+
+    def _parse_atom() -> str:
+        tok = _peek()
+        if tok == 'LPAREN':
+            nonlocal_advance()
+            inner = _parse_or()
+            if _peek() != 'RPAREN':
+                raise _ParseError('unbalanced parens')
+            nonlocal_advance()
+            return f"({inner})"
+        if tok == 'TERM':
+            value = tokens[pos][1]
+            nonlocal_advance()
+            return _term_sql(value)
+        raise _ParseError(f'unexpected token {tok}')
+
+    def nonlocal_advance() -> None:
+        nonlocal pos
+        pos += 1
+
+    try:
+        sql = _parse_or()
+        if pos != len(tokens):
+            raise _ParseError('trailing tokens')
+        return sql, params
+    except _ParseError:
+        # Fallback: treat the whole raw query as one literal term.
+        return f"{column} LIKE %s", [f"%{_escape_like(search.strip())}%"]
+
+
 def get_posts(user_id: int, limit: int = 10, offset: int = 0,
-              sort_order: str = 'asc', status_filter: Optional[str] = None) -> tuple[list, int]:
+              sort_order: str = 'asc', status_filter: Optional[str] = None,
+              post_type_filter: Optional[str] = None, search: Optional[str] = None,
+              sort_by: str = 'scheduled_time') -> tuple[list, int]:
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
 
     order = 'ASC' if sort_order.lower() != 'desc' else 'DESC'
+    sort_col = _POST_SORT_COLUMNS.get((sort_by or '').lower(), 'scheduled_time')
 
     try:
         where = "WHERE user_id = %s"
@@ -558,6 +694,13 @@ def get_posts(user_id: int, limit: int = 10, offset: int = 0,
         if status_filter:
             where += " AND status = %s"
             params.append(status_filter.lower())
+        if post_type_filter:
+            where += " AND post_type = %s"
+            params.append(post_type_filter.lower())
+        search_sql, search_params = build_content_search_clause(search)
+        if search_sql:
+            where += f" AND ({search_sql})"
+            params.extend(search_params)
 
         cursor.execute(
             f"SELECT COUNT(*) AS total FROM posts {where}",
@@ -567,7 +710,7 @@ def get_posts(user_id: int, limit: int = 10, offset: int = 0,
 
         cursor.execute(
             f"SELECT id, content, video_url, scheduled_time, post_type, status, carousel_slides "
-            f"FROM posts {where} ORDER BY scheduled_time {order} LIMIT %s OFFSET %s",
+            f"FROM posts {where} ORDER BY {sort_col} {order}, id {order} LIMIT %s OFFSET %s",
             params + [limit, offset]
         )
         posts = cursor.fetchall()
@@ -728,14 +871,18 @@ def get_posted_posts(user_id: int):
 
 
 def get_post_by_email(email: str, limit: int = 10, offset: int = 0,
-                      sort_order: str = 'asc', status_filter: Optional[str] = None) -> tuple[list, int]:
+                      sort_order: str = 'asc', status_filter: Optional[str] = None,
+                      post_type_filter: Optional[str] = None, search: Optional[str] = None,
+                      sort_by: str = 'scheduled_time') -> tuple[list, int]:
     user_id = get_user_id(email)
 
     if not user_id:
         myprint(f"User with email {email} not found.")
         return [], 0
 
-    return get_posts(user_id, limit=limit, offset=offset, sort_order=sort_order, status_filter=status_filter)
+    return get_posts(user_id, limit=limit, offset=offset, sort_order=sort_order,
+                     status_filter=status_filter, post_type_filter=post_type_filter,
+                     search=search, sort_by=sort_by)
 
 
 def get_post_content(post_id: int):

--- a/tests/unit/api/test_main_posts.py
+++ b/tests/unit/api/test_main_posts.py
@@ -95,6 +95,9 @@ class TestGetPostsForEmail:
             offset=5,
             sort_order="asc",
             status_filter=None,
+            post_type_filter=None,
+            search=None,
+            sort_by="scheduled_time",
         )
 
     def test_sort_order_desc(self, client):
@@ -110,6 +113,9 @@ class TestGetPostsForEmail:
             offset=0,
             sort_order="desc",
             status_filter=None,
+            post_type_filter=None,
+            search=None,
+            sort_by="scheduled_time",
         )
 
     def test_status_filter_forwarded(self, client):
@@ -125,7 +131,47 @@ class TestGetPostsForEmail:
             offset=0,
             sort_order="asc",
             status_filter="pending",
+            post_type_filter=None,
+            search=None,
+            sort_by="scheduled_time",
         )
+
+    def test_post_type_and_search_and_sort_by_forwarded(self, client):
+        with patch(f"{_DB}.get_post_by_email", return_value=([], 0)) as mock_get:
+            resp = client.get(
+                "/api/posts/",
+                params={
+                    "email": "test@example.com",
+                    "post_type_filter": "carousel",
+                    "search": "ai AND marketing",
+                    "sort_by": "status",
+                },
+            )
+        assert resp.status_code == 200
+        mock_get.assert_called_once_with(
+            "test@example.com",
+            limit=10,
+            offset=0,
+            sort_order="asc",
+            status_filter=None,
+            post_type_filter="carousel",
+            search="ai AND marketing",
+            sort_by="status",
+        )
+
+    def test_invalid_post_type_filter_422(self, client):
+        resp = client.get(
+            "/api/posts/",
+            params={"email": "test@example.com", "post_type_filter": "gif"},
+        )
+        assert resp.status_code == 422
+
+    def test_invalid_sort_by_422(self, client):
+        resp = client.get(
+            "/api/posts/",
+            params={"email": "test@example.com", "sort_by": "content"},
+        )
+        assert resp.status_code == 422
 
     def test_carousel_slides_json_string_parsed(self, client):
         """carousel_slides stored as a JSON string should be decoded to a list."""

--- a/tests/unit/utilities/test_db.py
+++ b/tests/unit/utilities/test_db.py
@@ -164,6 +164,113 @@ class TestGetPosts:
             count_call_params = calls[0][0][1]
             assert 'approved' in count_call_params
 
+    def test_post_type_filter_applied(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_posts
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"total": 0}
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            get_posts(42, post_type_filter='Video')
+
+            calls = mock_database_connection["cursor"].execute.call_args_list
+            count_sql, count_params = calls[0][0]
+            assert "post_type = %s" in count_sql
+            assert 'video' in count_params  # lowercased
+
+    def test_search_adds_like_condition(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_posts
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"total": 0}
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            get_posts(42, search='ai AND marketing')
+
+            count_sql, count_params = mock_database_connection["cursor"].execute.call_args_list[0][0]
+            assert "content LIKE %s" in count_sql
+            assert '%ai%' in count_params and '%marketing%' in count_params
+
+    def test_sort_by_whitelisted_column(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_posts
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"total": 0}
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            get_posts(42, sort_by='status')
+
+            data_sql = mock_database_connection["cursor"].execute.call_args_list[1][0][0]
+            assert "ORDER BY status" in data_sql
+
+    def test_sort_by_rejects_injection(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_posts
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"total": 0}
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            get_posts(42, sort_by='content; DROP TABLE posts')
+
+            data_sql = mock_database_connection["cursor"].execute.call_args_list[1][0][0]
+            assert "DROP TABLE" not in data_sql
+            assert "ORDER BY scheduled_time" in data_sql  # safe default
+
+
+@pytest.mark.unit
+class TestBuildContentSearchClause:
+    def test_empty_returns_none(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        assert build_content_search_clause('') == (None, [])
+        assert build_content_search_clause('   ') == (None, [])
+        assert build_content_search_clause(None) == (None, [])
+
+    def test_single_term(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        sql, params = build_content_search_clause('ai')
+        assert sql == 'content LIKE %s'
+        assert params == ['%ai%']
+
+    def test_and_or_not(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        sql, params = build_content_search_clause('ai AND marketing')
+        assert ' AND ' in sql and params == ['%ai%', '%marketing%']
+        sql, _ = build_content_search_clause('ai OR marketing')
+        assert ' OR ' in sql
+        sql, _ = build_content_search_clause('NOT ai')
+        assert 'NOT' in sql
+
+    def test_implicit_and(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        sql, params = build_content_search_clause('ai marketing')
+        assert ' AND ' in sql and params == ['%ai%', '%marketing%']
+
+    def test_grouping_and_phrase(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        sql, params = build_content_search_clause('(ai OR ml) AND NOT "growth hacking"')
+        assert params == ['%ai%', '%ml%', '%growth hacking%']
+        assert ' OR ' in sql and ' AND ' in sql and 'NOT' in sql
+
+    def test_wildcards_escaped(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        _, params = build_content_search_clause('50%_off')
+        assert params == ['%50\\%\\_off%']
+
+    def test_unbalanced_falls_back_to_literal(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        sql, params = build_content_search_clause('(unbalanced OR')
+        assert sql == 'content LIKE %s'
+        assert params == ['%(unbalanced OR%']
+
+    def test_custom_column(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        sql, _ = build_content_search_clause('hi', column='message')
+        assert sql == 'message LIKE %s'
+
 
 @pytest.mark.unit
 class TestInsertPost:

--- a/tests/unit/utilities/test_db.py
+++ b/tests/unit/utilities/test_db.py
@@ -220,6 +220,18 @@ class TestGetPosts:
             assert "DROP TABLE" not in data_sql
             assert "ORDER BY scheduled_time" in data_sql  # safe default
 
+    def test_db_error_returns_empty(self, mock_database_connection):
+        import mysql.connector
+        from cqc_lem.utilities.db import get_posts
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("boom")
+
+            posts, total = get_posts(42, search='ai')
+
+            assert posts == [] and total == 0
+
 
 @pytest.mark.unit
 class TestBuildContentSearchClause:
@@ -270,6 +282,56 @@ class TestBuildContentSearchClause:
         from cqc_lem.utilities.db import build_content_search_clause
         sql, _ = build_content_search_clause('hi', column='message')
         assert sql == 'message LIKE %s'
+
+    def test_empty_quotes_tokenize_to_nothing(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        # Non-blank input that yields no tokens (empty quoted phrase) → treated as no search.
+        assert build_content_search_clause('""') == (None, [])
+
+    def test_too_many_terms_falls_back_to_literal(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        query = " ".join(f"t{i}" for i in range(25))  # exceeds the term cap
+        sql, params = build_content_search_clause(query)
+        assert sql == 'content LIKE %s'
+        assert params == [f"%{query}%"]
+
+    def test_open_paren_without_close_falls_back(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        sql, params = build_content_search_clause('(ai')
+        assert sql == 'content LIKE %s'
+        assert params == ['%(ai%']
+
+    def test_trailing_tokens_fall_back(self):
+        from cqc_lem.utilities.db import build_content_search_clause
+        sql, params = build_content_search_clause('ai )')
+        assert sql == 'content LIKE %s'
+        assert params == ['%ai )%']
+
+
+@pytest.mark.unit
+class TestGetPostByEmail:
+    def test_unknown_email_returns_empty(self):
+        from cqc_lem.utilities.db import get_post_by_email
+
+        with patch("cqc_lem.utilities.db.get_user_id", return_value=None):
+            assert get_post_by_email("nobody@example.com") == ([], 0)
+
+    def test_forwards_all_filters_to_get_posts(self):
+        from cqc_lem.utilities.db import get_post_by_email
+
+        with patch("cqc_lem.utilities.db.get_user_id", return_value=7), \
+             patch("cqc_lem.utilities.db.get_posts", return_value=(["p"], 1)) as mock_gp:
+            result = get_post_by_email(
+                "u@example.com", limit=5, offset=10, sort_order='desc',
+                status_filter='approved', post_type_filter='video',
+                search='ai OR ml', sort_by='status',
+            )
+
+        assert result == (["p"], 1)
+        mock_gp.assert_called_once_with(
+            7, limit=5, offset=10, sort_order='desc', status_filter='approved',
+            post_type_filter='video', search='ai OR ml', sort_by='status',
+        )
 
 
 @pytest.mark.unit

--- a/tests/unit/utilities/test_db_extended.py
+++ b/tests/unit/utilities/test_db_extended.py
@@ -486,7 +486,8 @@ class TestGetPostByEmail:
             assert posts == ["post1"]
             assert total == 1
             mock_get_posts.assert_called_once_with(
-                42, limit=5, offset=10, sort_order="desc", status_filter="pending"
+                42, limit=5, offset=10, sort_order="desc", status_filter="pending",
+                post_type_filter=None, search=None, sort_by="scheduled_time"
             )
 
 


### PR DESCRIPTION
Adds filtering, boolean keyword search, and sort controls to the **Review & Edit** tab (Content Studio). All applied **server-side** so they compose correctly with pagination (client-side would only filter the current page).

## Features
- **Filter by post type** — text / video / carousel.
- **Filter by status** — existing, unchanged.
- **Keyword search** over post content with boolean operators: `AND`, `OR`, `NOT`, implicit AND between terms, parentheses for grouping, and `"quoted phrases"`.
  - e.g. `ai AND "case study" NOT hiring` or `(ml OR ai) AND growth`
- **Sort** by scheduled time / status / type / created-id, with the existing asc/desc toggle.

## Backend
- `db.build_content_search_clause()` — a small recursive-descent parser that compiles a boolean query into a **parameterized** `content LIKE %s` expression. Wildcards (`%`, `_`) in terms are escaped; unbalanced/invalid input falls back to a single literal match so search never 500s; term count capped.
- `get_posts` / `get_post_by_email` gain `post_type_filter`, `search`, `sort_by`. Sort column is **whitelisted** (`_POST_SORT_COLUMNS`) — the value is interpolated, so this keeps `ORDER BY` injection-safe.
- `/posts/` endpoint validates `post_type_filter` (`text|video|carousel`) and `sort_by` (`scheduled_time|status|post_type|id`) via `pattern`, and caps `search` length.

## Frontend (`ContentStudio.tsx`)
- Debounced search box (400ms) with an operator hint + clear button, a Type selector, a Sort-by selector, and a "Clear filters" empty state.

## Tests
- Parser: operators, implicit AND, grouping, quoted phrases, wildcard escaping, empty + unbalanced fallback, custom column.
- `get_posts`: post_type filter, search LIKE conditions, whitelisted sort column, and an injection attempt rejected to the safe default.
- Endpoint: new params forwarded; invalid `post_type_filter`/`sort_by` → 422.
- Full suite for touched files: **87 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)