### PR TITLE
fix(carousel): keep content-slide body text inside the margins

### DIFF
--- a/src/cqc_lem/utilities/carousel_creator.py
+++ b/src/cqc_lem/utilities/carousel_creator.py
@@ -1511,6 +1511,47 @@ CAROUSEL_TEMPLATES: dict[str, dict] = {
 DEFAULT_TEMPLATE = "bold_listicle"
 
 
+def _wrap_text(text: str, font, max_px: int, draw) -> list[str]:
+    """Greedy word-wrap `text` to lines no wider than `max_px` (measured via `draw`).
+
+    A single token wider than `max_px` (long URL/word) is hard-broken into
+    margin-fitting chunks so no line ever bleeds past the slide edge. `draw` is a
+    Pillow ImageDraw whose ``textlength`` is used to measure — passed in so this is a
+    pure function (unit-testable without the renderer closure).
+    """
+    if not text:
+        return []
+
+    def _fits(s: str) -> bool:
+        return draw.textlength(s, font=font) <= max_px
+
+    def _break_long(word: str) -> list[str]:
+        chunks, cur = [], ""
+        for ch in word:
+            if cur and not _fits(cur + ch):
+                chunks.append(cur)
+                cur = ch
+            else:
+                cur += ch
+        if cur:
+            chunks.append(cur)
+        return chunks
+
+    words, lines, cur = text.split(), [], ""
+    for word in words:
+        for piece in ([word] if _fits(word) else _break_long(word)):
+            test = (cur + " " + piece).strip()
+            if _fits(test):
+                cur = test
+            else:
+                if cur:
+                    lines.append(cur)
+                cur = piece
+    if cur:
+        lines.append(cur)
+    return lines
+
+
 def _fit_and_crop_image(image_path: str, target_w: int, target_h: int):
     """Cover-fit + center-crop an image to exactly (target_w, target_h) as RGB.
 
@@ -1643,20 +1684,7 @@ def create_carousel_slide_images(
         return text
 
     def _wrap(text: str, font, max_px: int, draw) -> list[str]:
-        if not text:
-            return []
-        words, lines, cur = text.split(), [], ""
-        for word in words:
-            test = (cur + " " + word).strip()
-            if draw.textlength(test, font=font) <= max_px:
-                cur = test
-            else:
-                if cur:
-                    lines.append(cur)
-                cur = word
-        if cur:
-            lines.append(cur)
-        return lines
+        return _wrap_text(text, font, max_px, draw)
 
     def _block_h(lines, font, spacing, draw) -> int:
         total_h = 0
@@ -2072,10 +2100,13 @@ def create_carousel_slide_images(
         y += 42
 
         # ── Body with arrow bullets (fewer lines when a photo band is present) ──
+        # Wrap to the width AFTER the arrow indent, keeping a right margin (PAD), so
+        # bulleted lines never run past the slide edge.
+        BULLET_INDENT = 52
         body_cap = 4 if band_top else 7
-        for line_text in _wrap(body, f_b, W - PAD - 30, draw)[:body_cap]:
+        for line_text in _wrap(body, f_b, W - (PAD + BULLET_INDENT) - PAD, draw)[:body_cap]:
             draw.text((PAD, y), "->", font=f_b, fill=badge_color)
-            draw.text((PAD + 52, y), line_text, font=f_b, fill=body_color)
+            draw.text((PAD + BULLET_INDENT, y), line_text, font=f_b, fill=body_color)
             bb = draw.textbbox((0, 0), line_text, font=f_b)
             y += (bb[3] - bb[1]) + 20
 

--- a/tests/unit/utilities/test_carousel_image_selection.py
+++ b/tests/unit/utilities/test_carousel_image_selection.py
@@ -425,3 +425,38 @@ class TestPillowComposition:
         seen = {(c.kwargs["post_id"], c.kwargs["slide_index"], c.kwargs["user_id"])
                 for c in mock_sel.call_args_list}
         assert seen == {(77, 2, 5), (77, 3, 5)}
+
+
+@pytest.mark.unit
+class TestWrapText:
+    """Word-wrap must never produce a line wider than the budget — including long
+    tokens (URLs) which are hard-broken — so slide text never bleeds past the margin."""
+
+    def _draw_font(self):
+        from PIL import Image, ImageDraw, ImageFont
+        draw = ImageDraw.Draw(Image.new("RGB", (10, 10)))
+        return draw, ImageFont.load_default()
+
+    def test_empty_returns_empty(self):
+        draw, font = self._draw_font()
+        assert cc._wrap_text("", font, 100, draw) == []
+
+    def test_wraps_within_max(self):
+        draw, font = self._draw_font()
+        text = "the quick brown fox jumps over the lazy dog " * 4
+        max_px = 120
+        lines = cc._wrap_text(text, font, max_px, draw)
+        assert len(lines) > 1
+        for ln in lines:
+            assert draw.textlength(ln, font=font) <= max_px
+
+    def test_long_token_is_hard_broken_within_max(self):
+        draw, font = self._draw_font()
+        long_word = "https://example.com/" + "a" * 400
+        max_px = 90
+        lines = cc._wrap_text(long_word, font, max_px, draw)
+        assert len(lines) > 1
+        for ln in lines:
+            assert draw.textlength(ln, font=font) <= max_px
+        # No context lost — every character survives the break.
+        assert "".join(lines) == long_word


### PR DESCRIPTION
## Problem
On regenerated carousels, the body text on **step-framework** content slides ran past the right edge (e.g. "…ensuring A" clipped). The arrow-bulleted body was wrapped to `W - PAD - 30` (988px) but each line is drawn at `PAD + 52` (the bullet indent, x=114) — so a full line reached ~1102px, 22px past the 1080px slide edge, with no right margin.

## Fix
- Wrap the bulleted body to the width **after** the indent, keeping a right margin: `W - (PAD + BULLET_INDENT) - PAD` → lines end at ≤1018px.
- Harden word-wrap generally: extracted the wrapper to a testable module-level `_wrap_text` that **hard-breaks** any single token wider than the line (long URLs/words) into margin-fitting chunks — so no layout bleeds past the edge and no characters are dropped (polished look without losing context).

## Tests
- New `TestWrapText`: empty input, normal wrap stays within budget, and a long token is hard-broken with every line within budget and all characters preserved.
- Existing carousel render tests still pass (photo-band composition across all 5 templates incl. step_framework). **51 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)