### PR TITLE
feat(spa): Save Draft vs Approve & Schedule for SPA-created posts + newsletters

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -325,6 +325,7 @@ class NewsletterDraftRequest(BaseModel):
     title: Optional[str] = None
     subtitle: Optional[str] = None
     body: Optional[str] = None
+    scheduled_datetime: Optional[datetime] = None
     action: str = "save"
 
 
@@ -686,9 +687,12 @@ def schedule_post(post: PostRequest) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=403, detail="User not found")
 
+    # SPA-created posts carry an explicit status: "Approve & Schedule" → approved,
+    # "Save Draft" → pending. Auto-generated content sets its own status elsewhere.
     if insert_post(post.email, post.content, post.scheduled_datetime, post.post_type,
                    video_url=post.video_url, carousel_slides=post.carousel_slides,
-                   video_quality=post.video_quality or "standard"):
+                   video_quality=post.video_quality or "standard",
+                   status=post.status or PostStatus.PENDING):
         return ResponseModel(status_code=200, detail="Post scheduled successfully")
     else:
         raise HTTPException(status_code=404, detail="Could not schedule post")
@@ -1279,7 +1283,8 @@ def update_newsletter_draft_endpoint(request: NewsletterDraftRequest) -> Respons
         raise HTTPException(status_code=404, detail="Edition not found")
     status = {"approve": "approved", "skip": "skipped"}.get(request.action)  # None for 'save'
     if not update_newsletter_edition(request.edition_id, user_id, title=request.title,
-                                     subtitle=request.subtitle, body=request.body, status=status):
+                                     subtitle=request.subtitle, body=request.body, status=status,
+                                     scheduled_for=request.scheduled_datetime):
         raise HTTPException(status_code=500, detail="Could not update newsletter draft")
     return ResponseModel(status_code=200, detail="Newsletter draft updated")
 

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
@@ -141,7 +141,9 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
     }
   }
 
-  async function handleSubmit(e: React.FormEvent) {
+  // "Approve & Schedule" creates the post approved (ready to publish); "Save Draft" holds it as
+  // pending for later review. Auto-generated content sets its own status server-side.
+  async function handleSubmit(e: React.FormEvent, status: 'pending' | 'approved' = 'approved') {
     e.preventDefault()
     if (!email) { setResult({ ok: false, msg: 'Set your email in Account settings first.' }); return }
     if (!content.trim()) { setResult({ ok: false, msg: 'Post content is required.' }); return }
@@ -162,7 +164,7 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
         post_type: postType.toLowerCase(),
         scheduled_datetime: new Date(scheduledAt).toISOString(),
         email,
-        status: 'pending',
+        status,
         use_avatar: postType !== 'TEXT' && useAvatar && hasActiveAvatar,
       }
       if (postType === 'VIDEO') {
@@ -175,7 +177,7 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
           : slides.filter((s) => s.trim())
       }
       await api.post('/schedule_post/', payload)
-      setResult({ ok: true, msg: 'Post scheduled successfully!' })
+      setResult({ ok: true, msg: status === 'approved' ? 'Post approved & scheduled!' : 'Draft saved.' })
       setContent('')
       setVideoUrl('')
       setSlides([''])
@@ -544,13 +546,23 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
             </p>
           )}
 
-          <button
-            type="submit"
-            disabled={submitting || content.length > MAX_CHARS}
-            className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
-          >
-            {submitting ? 'Scheduling…' : 'Schedule Post'}
-          </button>
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              type="button"
+              onClick={(e) => handleSubmit(e, 'pending')}
+              disabled={submitting || content.length > MAX_CHARS}
+              className="bg-gray-100 text-gray-700 py-2 rounded-lg text-sm font-semibold hover:bg-gray-200 disabled:opacity-50 transition-colors"
+            >
+              {submitting ? 'Saving…' : 'Save Draft'}
+            </button>
+            <button
+              type="submit"
+              disabled={submitting || content.length > MAX_CHARS}
+              className="bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {submitting ? 'Scheduling…' : 'Approve & Schedule'}
+            </button>
+          </div>
         </form>
       </div>
 

--- a/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
+++ b/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
@@ -14,6 +14,14 @@ const STATUS_COLORS: Record<string, string> = {
 // e.g. "case_study" -> "Case Study" for the format/hook badges.
 const prettyKey = (k: string) => k.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 
+// UTC ISO string -> value for a <input type="datetime-local"> (local wall-clock, minute precision).
+const toLocalInput = (iso?: string | null): string => {
+  if (!iso) return ''
+  const d = new Date(iso)
+  if (isNaN(d.getTime())) return ''
+  return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16)
+}
+
 export default function NewsletterQueue({ userTimezone }: { userTimezone: string }) {
   const { user, sessionToken } = useAuth()
   const qc = useQueryClient()
@@ -72,6 +80,7 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
         title: draftEdit!.title,
         subtitle: draftEdit!.subtitle,
         body: draftEdit!.body,
+        scheduled_datetime: draftEdit!.scheduled_for || null,
         action,
       }),
     onSuccess: (_res, action) => {
@@ -209,6 +218,15 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
               <textarea value={draftEdit.body || ''} onChange={(e) => setDe({ body: e.target.value })} rows={10}
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500" />
             </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Publish date &amp; time</label>
+              <input
+                type="datetime-local"
+                value={toLocalInput(draftEdit.scheduled_for)}
+                onChange={(e) => setDe({ scheduled_for: e.target.value ? new Date(e.target.value).toISOString() : draftEdit.scheduled_for })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            </div>
 
             {/* Re-generate: the prominent action. Optional guidance steers the rewrite; empty guidance
                 lets the AI pick a fresh, distinct take. */}
@@ -230,11 +248,11 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
             <div className="grid grid-cols-2 gap-2">
               <button type="button" onClick={() => draftMutation.mutate('save')} disabled={busy}
                 className="bg-gray-100 text-gray-700 py-2 rounded-lg text-sm font-semibold hover:bg-gray-200 disabled:opacity-50 transition-colors">
-                Save
+                Save Draft
               </button>
               <button type="button" onClick={() => draftMutation.mutate('approve')} disabled={busy}
                 className="bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
-                Approve
+                Approve &amp; Schedule
               </button>
             </div>
             {/* Skip stays as a smaller secondary action — not publishing an edition is still useful. */}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -373,7 +373,7 @@ def get_user_id(email: str):
 
 def insert_post(email: str, content: str, scheduled_time: datetime, post_type: PostType,
                 video_url: Optional[str] = None, carousel_slides: Optional[list[str]] = None,
-                video_quality: str = "standard") -> bool:
+                video_quality: str = "standard", status: PostStatus = PostStatus.PENDING) -> bool:
     user_id = get_user_id(email)
 
     success = False
@@ -394,10 +394,10 @@ def insert_post(email: str, content: str, scheduled_time: datetime, post_type: P
         slides_json = json.dumps(carousel_slides) if carousel_slides else None
 
         cursor.execute("""
-            INSERT INTO posts (content, scheduled_time, post_type, user_id, video_url, carousel_slides, video_quality)
-            VALUES (%s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO posts (content, scheduled_time, post_type, user_id, video_url, carousel_slides, video_quality, status)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
         """, (content, scheduled_time, post_type.value, user_id, video_url, slides_json,
-              video_quality or "standard"))
+              video_quality or "standard", status.value))
 
         connection.commit()
         success = cursor.rowcount == 1
@@ -3355,21 +3355,26 @@ def update_newsletter_edition(edition_id: int, user_id: int, title: str = None,
                               subtitle: str = None, body: str = None,
                               status: str = None, subject: str = None,
                               edition_format: str = None, hook_style: str = None,
-                              opening_line: str = None, blueprint: dict = None) -> bool:
+                              opening_line: str = None, blueprint: dict = None,
+                              scheduled_for=None) -> bool:
     """Update only the provided fields on an edition, scoped to its owner (COALESCE-style)."""
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
+        if scheduled_for is not None and getattr(scheduled_for, "tzinfo", None) is not None:
+            scheduled_for = scheduled_for.astimezone(timezone.utc).replace(tzinfo=None)
         cursor.execute(
             "UPDATE newsletter_editions SET "
             "title = COALESCE(%s, title), subtitle = COALESCE(%s, subtitle), "
             "subject = COALESCE(%s, subject), "
             "`format` = COALESCE(%s, `format`), hook_style = COALESCE(%s, hook_style), "
             "opening_line = COALESCE(%s, opening_line), blueprint = COALESCE(%s, blueprint), "
-            "body = COALESCE(%s, body), status = COALESCE(%s, status) "
+            "body = COALESCE(%s, body), status = COALESCE(%s, status), "
+            "scheduled_for = COALESCE(%s, scheduled_for) "
             "WHERE id = %s AND user_id = %s",
             (title, subtitle, subject, edition_format, hook_style, opening_line,
-             json.dumps(blueprint) if blueprint else None, body, status, edition_id, user_id))
+             json.dumps(blueprint) if blueprint else None, body, status, scheduled_for,
+             edition_id, user_id))
         connection.commit()
         return cursor.rowcount >= 0
     except mysql.connector.Error as err:

--- a/tests/unit/api/test_api_coverage_misc.py
+++ b/tests/unit/api/test_api_coverage_misc.py
@@ -82,6 +82,26 @@ class TestAutomationTriggerEndpoints:
                 "email": "a@x.com"})
         assert resp.status_code == 404
 
+    def test_schedule_post_forwards_approved_status(self, client):
+        from cqc_lem.utilities.db import PostStatus
+        with patch(f"{_M}.get_user_id", return_value=_UID), \
+             patch(f"{_M}.insert_post", return_value=True) as ins:
+            resp = client.post("/api/schedule_post/", json={
+                "content": "hello", "scheduled_datetime": "2026-07-10T15:00:00",
+                "email": "a@x.com", "post_type": "text", "status": "approved"})
+        assert resp.status_code == 200
+        assert ins.call_args[1].get("status") == PostStatus.APPROVED
+
+    def test_schedule_post_defaults_to_pending_status(self, client):
+        from cqc_lem.utilities.db import PostStatus
+        with patch(f"{_M}.get_user_id", return_value=_UID), \
+             patch(f"{_M}.insert_post", return_value=True) as ins:
+            resp = client.post("/api/schedule_post/", json={
+                "content": "hello", "scheduled_datetime": "2026-07-10T15:00:00",
+                "email": "a@x.com", "post_type": "text"})
+        assert resp.status_code == 200
+        assert ins.call_args[1].get("status") == PostStatus.PENDING
+
     def test_create_weekly_content_chains_plan_then_create(self, client):
         chain_obj = MagicMock()
         with patch(f"{_M}.celery_chain", return_value=chain_obj) as chain, \

--- a/tests/unit/api/test_newsletter_api.py
+++ b/tests/unit/api/test_newsletter_api.py
@@ -166,6 +166,17 @@ class TestNewsletterDraft:
         assert resp.status_code == 200
         assert upd.call_args.kwargs["status"] is None
 
+    def test_put_forwards_scheduled_datetime(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_newsletter_edition", return_value={"id": 4, "user_id": _USER}), \
+             patch("cqc_lem.api.main.update_newsletter_edition", return_value=True) as upd:
+            resp = client.put("/api/user/newsletter-draft", json={
+                "session_token": _SESSION, "edition_id": 4, "action": "approve",
+                "scheduled_datetime": "2026-07-10T19:00:00"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["status"] == "approved"
+        assert upd.call_args.kwargs["scheduled_for"] is not None
+
     def test_put_404_when_not_owner(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
              patch("cqc_lem.api.main.get_newsletter_edition", return_value={"id": 4, "user_id": 999}):

--- a/tests/unit/utilities/test_db.py
+++ b/tests/unit/utilities/test_db.py
@@ -371,6 +371,36 @@ class TestInsertPost:
 
             assert result is False
 
+    def test_inserts_with_explicit_status(self, mock_database_connection):
+        from cqc_lem.utilities.db import insert_post, PostType, PostStatus
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
+             patch("cqc_lem.utilities.db.get_user_id", return_value=60):
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].rowcount = 1
+
+            insert_post("test@example.com", "content",
+                        datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc),
+                        PostType.TEXT, status=PostStatus.APPROVED)
+
+            sql, params = mock_database_connection["cursor"].execute.call_args[0]
+            assert "status" in sql
+            assert PostStatus.APPROVED.value in params
+
+    def test_status_defaults_to_pending(self, mock_database_connection):
+        from cqc_lem.utilities.db import insert_post, PostType, PostStatus
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
+             patch("cqc_lem.utilities.db.get_user_id", return_value=60):
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].rowcount = 1
+
+            insert_post("test@example.com", "content",
+                        datetime(2025, 1, 1, 12, 0, 0, tzinfo=timezone.utc), PostType.TEXT)
+
+            _, params = mock_database_connection["cursor"].execute.call_args[0]
+            assert PostStatus.PENDING.value in params
+
 
 @pytest.mark.unit
 class TestGetUserId:

--- a/tests/unit/utilities/test_db_newsletter.py
+++ b/tests/unit/utilities/test_db_newsletter.py
@@ -181,8 +181,8 @@ class TestEditions:
             assert update_newsletter_edition(4, 1, status="approved") is True
         sql, params = cur.execute.call_args[0]
         assert "COALESCE" in sql
-        # (title, subtitle, subject, format, hook_style, opening_line, blueprint, body, status, id, user_id)
-        assert params == (None, None, None, None, None, None, None, None, "approved", 4, 1)
+        # (title, subtitle, subject, format, hook_style, opening_line, blueprint, body, status, scheduled_for, id, user_id)
+        assert params == (None, None, None, None, None, None, None, None, "approved", None, 4, 1)
 
     def test_update_persists_subject(self):
         conn, cur = _mock_conn(rowcount=1)
@@ -191,7 +191,7 @@ class TestEditions:
             assert update_newsletter_edition(4, 1, subject="New Subject", status="draft") is True
         sql, params = cur.execute.call_args[0]
         assert "subject = COALESCE" in sql
-        assert params == (None, None, "New Subject", None, None, None, None, None, "draft", 4, 1)
+        assert params == (None, None, "New Subject", None, None, None, None, None, "draft", None, 4, 1)
 
     def test_update_persists_shape_fields(self):
         import json
@@ -206,6 +206,19 @@ class TestEditions:
         assert "opening_line = COALESCE" in sql and "blueprint = COALESCE" in sql
         assert "case_study" in params and "micro_story" in params and "It was a Tuesday." in params
         assert json.dumps({"format": "case_study"}) in params
+
+    def test_update_persists_scheduled_for(self):
+        from datetime import datetime, timezone
+        conn, cur = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_newsletter_edition
+            # tz-aware input is normalized to naive UTC before storage.
+            assert update_newsletter_edition(
+                4, 1, status="approved",
+                scheduled_for=datetime(2026, 7, 10, 19, 0, 0, tzinfo=timezone.utc)) is True
+        sql, params = cur.execute.call_args[0]
+        assert "scheduled_for = COALESCE" in sql
+        assert datetime(2026, 7, 10, 19, 0, 0) in params
 
     def test_create_persists_subject(self):
         conn, cur = _mock_conn()


### PR DESCRIPTION
Content authored by the user in the SPA should be able to go live on creation (approved), while **auto-generated** content keeps starting in the status configured by the user's profile settings.

## Behavior
- **Posts** (`ComposePost`): the single "Schedule Post" button becomes two — **Save Draft** (status `pending`) and **Approve & Schedule** (status `approved`). The scheduled date/time selector already existed.
- **Newsletters** (`NewsletterQueue`): added an **editable publish date/time** field; the actions are now **Save Draft** and **Approve & Schedule**. Skip stays as the secondary action.
- **DMs**: already had "Save draft" / "Approve & schedule" + a datetime picker — **unchanged** (kept "Save draft" as an explicit opt-out per product decision).
- **Auto-generated content**: untouched. Posts still use `auto_schedule_posts` (`run_content_plan`); newsletter editions still auto-generate as `draft`.

## Backend
- `insert_post` gains `status: PostStatus = PENDING` and writes it; `/schedule_post/` forwards `post.status` (SPA-only path).
- `update_newsletter_edition` gains `scheduled_for` (tz-normalized to naive UTC, COALESCE update); `/user/newsletter-draft` + `NewsletterDraftRequest` forward `scheduled_datetime`.

## Tests
- `insert_post` explicit status + pending default; `/schedule_post` forwards approved and defaults to pending; `update_newsletter_edition` persists `scheduled_for`; newsletter-draft endpoint forwards `scheduled_datetime`.
- Updated the two exact-tuple `update_newsletter_edition` assertions for the new param.
- Full unit suite: **2415 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)