### PR TITLE
fix(email): brand transactional mail as LEM + disable SendGrid click-tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -202,7 +202,7 @@ SENDGRID_API_KEY=your_sendgrid_api_key
 # DNS records to add. Recommended: no-reply@lem.christopherqueenconsulting.com
 SENDGRID_FROM_EMAIL=no-reply@lem.christopherqueenconsulting.com
 # Friendly From display name (shown in inboxes) — should match your brand/domain.
-EMAIL_FROM_NAME=Christopher Queen Consulting
+EMAIL_FROM_NAME=LinkedIn Engagement Manager
 # Real, monitored Reply-To for transactional mail (helps deliverability & trust). Leave blank
 # to omit the Reply-To header.
 EMAIL_REPLY_TO=support@christopherqueenconsulting.com

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -148,7 +148,9 @@ def _build_approval_html(vnc_url: str | None) -> str:
 def _sendgrid_send(to_email: str, subject: str, html_content: str, text_content: str,
                    reply_to: Optional[str], high_priority: bool) -> None:
     from sendgrid import SendGridAPIClient
-    from sendgrid.helpers.mail import Email, Header, Mail, ReplyTo
+    from sendgrid.helpers.mail import (
+        ClickTracking, Email, Header, Mail, ReplyTo, TrackingSettings,
+    )
 
     message = Mail(
         from_email=Email(SENDGRID_FROM_EMAIL, EMAIL_FROM_NAME),
@@ -157,6 +159,12 @@ def _sendgrid_send(to_email: str, subject: str, html_content: str, text_content:
         plain_text_content=text_content,
         html_content=html_content,
     )
+    # These are all security/transactional emails (sign-in codes, session reconnect). Rewriting
+    # the button href through SendGrid's click-tracking redirect makes them look like phishing and
+    # hurts trust/deliverability — keep the real account URL the user can verify.
+    tracking = TrackingSettings()
+    tracking.click_tracking = ClickTracking(False, False)
+    message.tracking_settings = tracking
     if reply_to:
         message.reply_to = ReplyTo(reply_to)
     if high_priority:

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -155,7 +155,7 @@ SENDGRID_API_KEY     = get_constant_from_env('SENDGRID_API_KEY')
 SENDGRID_FROM_EMAIL  = get_constant_from_env('SENDGRID_FROM_EMAIL', default_value='noreply@example.com')
 # Friendly From display name and Reply-To for outbound transactional mail. A recognizable
 # From name that matches the sending domain and a real Reply-To reduce spam/phishing scores.
-EMAIL_FROM_NAME      = get_constant_from_env('EMAIL_FROM_NAME', default_value='Christopher Queen Consulting')
+EMAIL_FROM_NAME      = get_constant_from_env('EMAIL_FROM_NAME', default_value='LinkedIn Engagement Manager')
 EMAIL_REPLY_TO       = get_constant_from_env('EMAIL_REPLY_TO', default_value='')
 
 # SMTP fallback (Gmail or any STARTTLS-capable server)

--- a/tests/unit/utilities/test_email.py
+++ b/tests/unit/utilities/test_email.py
@@ -226,23 +226,23 @@ class TestSendLoginApprovalEmail:
 
 class TestPinEmailContent:
     def test_html_contains_code_and_no_links(self):
-        from cqc_lem.utilities.email import _build_pin_html
+        from cqc_lem.utilities.email import EMAIL_FROM_NAME, _build_pin_html
         html = _build_pin_html("123456", "sign in")
         assert "123456" in html
         assert "expires" in html.lower()
         # No links at all in a login-code email (removes link-mismatch phishing signal)
         assert "href" not in html.lower()
         assert "http://" not in html and "https://" not in html
-        # Anti-phishing reassurance + company footer
+        # Anti-phishing reassurance + brand footer
         assert "never" in html.lower()
-        assert "Christopher Queen Consulting" in html
+        assert EMAIL_FROM_NAME in html
 
     def test_text_part_contains_code_and_company(self):
-        from cqc_lem.utilities.email import _build_pin_text
+        from cqc_lem.utilities.email import EMAIL_FROM_NAME, _build_pin_text
         text = _build_pin_text("654321", "create your account")
         assert "654321" in text
         assert "create your account" in text
-        assert "Christopher Queen Consulting" in text
+        assert EMAIL_FROM_NAME in text
         # plain text must not carry HTML tags
         assert "<" not in text and ">" not in text
 

--- a/tests/unit/utilities/test_email.py
+++ b/tests/unit/utilities/test_email.py
@@ -81,6 +81,19 @@ class TestSendPinEmailSendGrid:
 
         mock_sg.send.assert_called_once()
 
+    @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", "sg_test_key")
+    @patch("cqc_lem.utilities.email.SMTP_USER", None)
+    @patch("cqc_lem.utilities.email.SMTP_PASSWORD", None)
+    @patch("sendgrid.SendGridAPIClient")
+    def test_click_tracking_disabled_on_transactional_mail(self, mock_sg_class):
+        mock_sg = MagicMock()
+        mock_sg_class.return_value = mock_sg
+
+        send_pin_email("test@example.com", "123456")
+
+        sent = mock_sg.send.call_args[0][0]
+        assert sent.get()["tracking_settings"]["click_tracking"]["enable"] is False
+
 
 class TestSendPinEmailSmtpFallback:
     @patch("cqc_lem.utilities.email.SENDGRID_API_KEY", None)


### PR DESCRIPTION
## Why

A user flagged two things about LEM's transactional emails:

1. **"Weird link"** — the *Reconnect LinkedIn* / sign-in buttons pointed at a `url###.christopherqueenconsulting.com/ls/click?upn=…` redirect (SendGrid click-tracking rewriting the href). On a security/session email that reads exactly like phishing and hurts trust + deliverability.
2. **Brand mismatch** — From-name/subject said "Christopher Queen Consulting" while the reconnect email *body* hardcodes "LinkedIn Engagement Manager", so the two disagreed.

Both emails are legitimately generated by our own code (`send_pin_email`, `send_session_revalidation_email`) — not a spoof. This just makes them look trustworthy and consistent.

## Changes

- **Disable SendGrid click-tracking** on the transactional send path (`_sendgrid_send`) via `TrackingSettings(click_tracking=ClickTracking(False, False))`. Every email through this path is transactional (sign-in codes, session reconnect, approval), so buttons now link to the real, verifiable account URL.
- **Default `EMAIL_FROM_NAME` → "LinkedIn Engagement Manager"** in `env_constants.py` + `.env.example`, so From, subject, and body all agree.
- Test asserting click-tracking is disabled on the sent `Mail`.

## Follow-up (not in this PR)
Prod `/opt/lem/.env` currently sets `EMAIL_FROM_NAME=Christopher Queen Consulting`, which overrides the code default. That env value must be updated to `LinkedIn Engagement Manager` and the api + celery-worker services restarted for the branding change to take effect live. The click-tracking fix ships with the release automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)