### PR TITLE
fix(api): make the LinkedIn extension download route public

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -116,8 +116,12 @@ _API_ACCESS_TOKEN_SET = {t.strip() for t in API_ACCESS_TOKENS.split(",") if t.st
 # LinkedIn fetches over an unauthenticated public URL when publishing. The
 # handler (get_assets) is GET-only and path-traversal safe (_find_asset_file
 # rejects .. / separators and only returns real files under assets_dir).
+# /api/extension is public: it serves the browser-extension zip as a plain <a href>
+# download from the account page, which carries no bearer token. The bundle is
+# non-sensitive public code (destined for the Chrome Web Store); the route is GET-only.
 _PUBLIC_API_PREFIXES = ("/api/auth/", "/api/billing/webhook", "/api/assets",
-                        "/api/linkedin/verification-pin", "/api/app-info")
+                        "/api/linkedin/verification-pin", "/api/app-info",
+                        "/api/extension/")
 
 
 def _api_token_required(path: str) -> bool:

--- a/tests/unit/api/test_extension_download.py
+++ b/tests/unit/api/test_extension_download.py
@@ -51,3 +51,12 @@ class TestDownloadExtension:
         manifest = json.loads(zf.read("manifest.json"))
         assert manifest["manifest_version"] == 3
         assert "cookies" in manifest["permissions"]
+
+    def test_route_is_public_when_bearer_gate_enabled(self):
+        # The download is a plain <a href> browser GET with no Authorization header, so it
+        # must bypass the /api/* bearer-token gate (which is off in tests unless a token is
+        # configured). Regression guard for the prod 401.
+        from cqc_lem.api import main
+        with patch.object(main, "_API_ACCESS_TOKEN_SET", {"secret-token"}):
+            assert main._api_token_required("/api/extension/linkedin-connect.zip") is False
+            assert main._api_token_required("/api/user/account-readiness") is True


### PR DESCRIPTION
## Why

After #335 shipped, the account page's **Download extension** button returned **401** in production. The route is fine, but `/api/*` is behind a global bearer-token gate and the download is a plain `<a href>` browser GET that carries no `Authorization` header. The gate is disabled in unit tests (no token configured), which is why #335's tests passed but prod 401'd.

## Fix

- Add `/api/extension/` to `_PUBLIC_API_PREFIXES`. The bundle is non-sensitive public code (headed for the Chrome Web Store) and the route is GET-only.
- Regression test: asserts `_api_token_required("/api/extension/...")` is `False` even when the bearer gate is enabled (and still `True` for a normal user route).

Verified reproduction: `curl https://lem.christopherqueenconsulting.com/api/extension/linkedin-connect.zip` → `401 {"detail":"Unauthorized"}` (from the app, confirmed by hitting the container directly, not Cloudflare).

🤖 Generated with [Claude Code](https://claude.com/claude-code)