### PR TITLE
fix(api): let the browser extension reach /api/user/linkedin-cookie

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -119,9 +119,14 @@ _API_ACCESS_TOKEN_SET = {t.strip() for t in API_ACCESS_TOKENS.split(",") if t.st
 # /api/extension is public: it serves the browser-extension zip as a plain <a href>
 # download from the account page, which carries no bearer token. The bundle is
 # non-sensitive public code (destined for the Chrome Web Store); the route is GET-only.
+# /api/user/linkedin-cookie is public because the browser extension POSTs to it WITHOUT the
+# SPA's bearer token (the extension can't hold the rotating API token). It is
+# self-authenticating: the handler validates the user's own LEM session_token and 401s if
+# it's invalid — same model as the /api/auth/ endpoints. This exact leaf path only; the rest
+# of /api/user/* stays gated.
 _PUBLIC_API_PREFIXES = ("/api/auth/", "/api/billing/webhook", "/api/assets",
                         "/api/linkedin/verification-pin", "/api/app-info",
-                        "/api/extension/")
+                        "/api/extension/", "/api/user/linkedin-cookie")
 
 
 def _api_token_required(path: str) -> bool:

--- a/tests/unit/api/test_extension_download.py
+++ b/tests/unit/api/test_extension_download.py
@@ -60,3 +60,13 @@ class TestDownloadExtension:
         with patch.object(main, "_API_ACCESS_TOKEN_SET", {"secret-token"}):
             assert main._api_token_required("/api/extension/linkedin-connect.zip") is False
             assert main._api_token_required("/api/user/account-readiness") is True
+
+    def test_cookie_post_is_public_but_rest_of_user_is_gated(self):
+        # The extension POSTs the LinkedIn session to /api/user/linkedin-cookie without the
+        # SPA bearer token; it's self-authenticated by the body's session_token. Only that
+        # exact leaf is public — sibling /api/user/* routes stay gated. Regression guard.
+        from cqc_lem.api import main
+        with patch.object(main, "_API_ACCESS_TOKEN_SET", {"secret-token"}):
+            assert main._api_token_required("/api/user/linkedin-cookie") is False
+            assert main._api_token_required("/api/user/linkedin-password") is True
+            assert main._api_token_required("/api/user/profile") is True


### PR DESCRIPTION
## Why

The Chrome extension's **Connect** button always failed with **401: Unauthorized**. The extension POSTs the LinkedIn session to `/api/user/linkedin-cookie` sending only the user's LEM `session_token` in the body — it has no way to attach the SPA's bearer token that the global `/api/*` gate requires. So the request was rejected by the gate before ever reaching the handler. (The SPA's paste form works because its axios client attaches the bearer token automatically.)

Reproduced live: `curl -X POST …/api/user/linkedin-cookie -d '{"session_token":"dummy","li_at":"x"}'` → `401 {"detail":"Unauthorized"}` (the middleware, not the handler).

## Fix (user-approved)

Add the exact leaf path `/api/user/linkedin-cookie` to `_PUBLIC_API_PREFIXES`. It is **self-authenticating** — the handler validates the user's LEM `session_token` and 401s if invalid, the same model as the public `/api/auth/*` endpoints. The rest of `/api/user/*` stays gated.

Security note: this drops only the coarse client gate for one path; real per-user auth (the session_token) is unchanged, and the API token was never a true secret (it's compiled into the public SPA JS bundle). Discussed and explicitly approved.

## Test

Regression test asserts `/api/user/linkedin-cookie` is public under an enabled bearer gate, while `/api/user/linkedin-password` and other `/api/user/*` stay gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)