### PR TITLE
feat(db): auto-prune superseded cookies to keep sessions fresh

### DIFF
--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -137,6 +137,45 @@ def store_cookies(user_email: str, cookies: list[dict]):
     cursor.close()
     connection.close()
 
+    if user_id is not None:
+        prune_superseded_cookies(user_id)
+
+
+def prune_superseded_cookies(user_id: int) -> int:
+    """Keep only the most-recently-updated row per (user_id, name), deleting older duplicates
+    left behind when the same cookie is re-stored under a different domain scope — e.g. the
+    extension writes li_at on '.linkedin.com' while a prior Selenium login stored it on
+    '.www.linkedin.com'. get_cookies matches on `domain LIKE %tld%`, so a stale variant would
+    otherwise be returned alongside the fresh one and could shadow it at login.
+
+    Conservative by design: it only deletes a row when a STRICTLY newer sibling of the same
+    name exists for the same user, so it never removes the newest copy and never touches a
+    uniquely-named cookie. Best-effort — a failure here never breaks the cookie write."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    deleted = 0
+    try:
+        cursor.execute("""
+            DELETE older
+            FROM cookies older
+            JOIN cookies newer
+              ON older.user_id = newer.user_id
+             AND older.name = newer.name
+             AND (newer.updated_at > older.updated_at
+                  OR (newer.updated_at = older.updated_at AND newer.id > older.id))
+            WHERE older.user_id = %s
+        """, (user_id,))
+        deleted = cursor.rowcount
+        connection.commit()
+        if deleted:
+            myprint(f"Pruned {deleted} superseded cookie(s) for user_id {user_id}")
+    except mysql.connector.Error as err:
+        myprint(f"Could not prune superseded cookies for user_id {user_id} | Error: {err}")
+    finally:
+        cursor.close()
+        connection.close()
+    return deleted
+
 
 def get_cookies(url: str, user_email: str):
     connection = get_db_connection()

--- a/tests/unit/utilities/test_db_cookie_prune.py
+++ b/tests/unit/utilities/test_db_cookie_prune.py
@@ -1,0 +1,44 @@
+"""Unit tests for cookie auto-pruning (keep newest per user_id+name)."""
+
+import mysql.connector
+import pytest
+from unittest.mock import patch
+
+from cqc_lem.utilities.db import prune_superseded_cookies, store_cookies
+
+pytestmark = pytest.mark.unit
+
+_COOKIE = {
+    "name": "li_at", "value": "x" * 40, "domain": ".linkedin.com",
+    "path": "/", "secure": True, "httpOnly": True, "expiry": 123,
+}
+
+
+class TestPruneSupersededCookies:
+    def test_deletes_older_duplicates_and_returns_count(self, mock_database_connection):
+        cur = mock_database_connection["cursor"]
+        cur.rowcount = 3
+        deleted = prune_superseded_cookies(7)
+        assert deleted == 3
+        sql, params = cur.execute.call_args[0][0], cur.execute.call_args[0][1]
+        assert "DELETE" in sql.upper() and "cookies" in sql
+        # Only removes rows that have a strictly newer same-name sibling for the same user.
+        assert "newer.updated_at > older.updated_at" in sql
+        assert params == (7,)
+        mock_database_connection["connection"].commit.assert_called()
+
+    def test_swallows_db_error(self, mock_database_connection):
+        mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("boom")
+        assert prune_superseded_cookies(7) == 0  # never raises into the caller
+
+    def test_store_cookies_triggers_prune(self, mock_database_connection):
+        with patch("cqc_lem.utilities.db.get_user_id", return_value=9), \
+             patch("cqc_lem.utilities.db.prune_superseded_cookies") as prune:
+            store_cookies("a@b.com", [_COOKIE])
+            prune.assert_called_once_with(9)
+
+    def test_store_cookies_skips_prune_when_user_unknown(self, mock_database_connection):
+        with patch("cqc_lem.utilities.db.get_user_id", return_value=None), \
+             patch("cqc_lem.utilities.db.prune_superseded_cookies") as prune:
+            store_cookies("nobody@example.com", [_COOKIE])
+            prune.assert_not_called()

--- a/tests/unit/utilities/test_db_extended.py
+++ b/tests/unit/utilities/test_db_extended.py
@@ -30,7 +30,8 @@ class TestStoreCookies:
         }
 
         with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
-             patch("cqc_lem.utilities.db.get_user_id", return_value=42):
+             patch("cqc_lem.utilities.db.get_user_id", return_value=42), \
+             patch("cqc_lem.utilities.db.prune_superseded_cookies"):
             mock_conn.return_value = mock_database_connection["connection"]
 
             store_cookies("user@example.com", [cookie])
@@ -54,7 +55,8 @@ class TestStoreCookies:
         ]
 
         with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
-             patch("cqc_lem.utilities.db.get_user_id", return_value=42):
+             patch("cqc_lem.utilities.db.get_user_id", return_value=42), \
+             patch("cqc_lem.utilities.db.prune_superseded_cookies"):
             mock_conn.return_value = mock_database_connection["connection"]
 
             store_cookies("user@example.com", cookies)
@@ -77,7 +79,8 @@ class TestStoreCookies:
         }
 
         with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
-             patch("cqc_lem.utilities.db.get_user_id", return_value=10):
+             patch("cqc_lem.utilities.db.get_user_id", return_value=10), \
+             patch("cqc_lem.utilities.db.prune_superseded_cookies"):
             mock_conn.return_value = mock_database_connection["connection"]
 
             store_cookies("user@example.com", [cookie])
@@ -93,7 +96,8 @@ class TestStoreCookies:
                   "expiry": 100, "secure": True, "httpOnly": True}
 
         with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
-             patch("cqc_lem.utilities.db.get_user_id", return_value=42):
+             patch("cqc_lem.utilities.db.get_user_id", return_value=42), \
+             patch("cqc_lem.utilities.db.prune_superseded_cookies"):
             mock_conn.return_value = mock_database_connection["connection"]
             mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("DB error")
 
@@ -763,7 +767,8 @@ class TestInsertPostDbError:
         from cqc_lem.utilities.db import insert_post, PostType
 
         with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
-             patch("cqc_lem.utilities.db.get_user_id", return_value=42):
+             patch("cqc_lem.utilities.db.get_user_id", return_value=42), \
+             patch("cqc_lem.utilities.db.prune_superseded_cookies"):
             mock_conn.return_value = mock_database_connection["connection"]
             mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
 
@@ -781,7 +786,8 @@ class TestInsertPostDbError:
 
         slides = ["First slide", "Second slide"]
         with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
-             patch("cqc_lem.utilities.db.get_user_id", return_value=42):
+             patch("cqc_lem.utilities.db.get_user_id", return_value=42), \
+             patch("cqc_lem.utilities.db.prune_superseded_cookies"):
             mock_conn.return_value = mock_database_connection["connection"]
             mock_database_connection["cursor"].rowcount = 1
 
@@ -801,7 +807,8 @@ class TestInsertPostDbError:
         from cqc_lem.utilities.db import insert_post, PostType
 
         with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn, \
-             patch("cqc_lem.utilities.db.get_user_id", return_value=42):
+             patch("cqc_lem.utilities.db.get_user_id", return_value=42), \
+             patch("cqc_lem.utilities.db.prune_superseded_cookies"):
             mock_conn.return_value = mock_database_connection["connection"]
             mock_database_connection["cursor"].rowcount = 1
 


### PR DESCRIPTION
## Why

Confirming the extension write for user 1, the DB showed **stale duplicate** session cookies: a fresh `li_at`/`JSESSIONID` on `.linkedin.com` (just written by the extension) alongside older copies on `.www.linkedin.com` from prior Selenium logins. Because the unique index is `(domain, name)` (no user_id) and `get_cookies` matches `domain LIKE %tld%`, both variants are returned at login — the stale one can shadow the fresh session.

## What this does

`store_cookies()` now calls `prune_superseded_cookies(user_id)` after every write. It keeps only the **most-recently-updated row per `(user_id, name)`** and deletes older same-name siblings (across domain scopes).

### Guardrails against over-pruning
- Deletes a row **only when a strictly newer sibling of the same name exists** for that user (`newer.updated_at > older.updated_at`, tie-break on `id`). It never removes the newest copy.
- Never touches a uniquely-named cookie (no sibling → nothing deleted).
- Scoped per `user_id`.
- Best-effort: wrapped in try/except so a prune failure never breaks the cookie write.

## Test
`tests/unit/utilities/test_db_cookie_prune.py` — asserts the DELETE keeps-newest semantics + params, swallows DB errors, is triggered by `store_cookies`, and is skipped when the user is unknown.

> Note for follow-up (not in this PR): the `cookies` unique index is `(domain, name)` without `user_id`, so two users sharing a cookie name+domain would collide on upsert. Harmless today (single active user) but worth a migration later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)