### PR TITLE
feat(replies): event-driven + reduced reply/comment follow-up to cut LinkedIn 429s

### DIFF
--- a/compose/local/database/migrations/V55__add_reply_check_config.sql
+++ b/compose/local/database/migrations/V55__add_reply_check_config.sql
@@ -1,0 +1,24 @@
+-- Per-user reply/comment follow-up configuration, to cut the LinkedIn HTTP 429 rate-limiting the
+-- old 24h-per-post reply-check loop caused. `reply_check_mode` selects how we follow up on comments
+-- left on the user's posts:
+--   event     (default) — a forwarded LinkedIn comment-notification email hits our webhook and
+--                         triggers a targeted reply sweep; near-zero Selenium/429. One golden-hour
+--                         safety check per post backstops a missed forward.
+--   scheduled           — a beat dispatcher runs a recent-posts reply sweep reply_sweeps_per_day
+--                         times/day (floor 2, cap 12 enforced in update_engagement_preferences).
+--   off                 — no reply automation.
+-- reply_max_post_age_days bounds how far back a sweep looks for the user's own posts (reused by
+-- get_recent_posted_post_ids). These live on the single per-user engagement_preferences row.
+ALTER TABLE engagement_preferences
+    ADD COLUMN reply_check_mode        VARCHAR(16) NULL DEFAULT 'event' AFTER default_video_quality,
+    ADD COLUMN reply_sweeps_per_day    INT         NULL DEFAULT 2       AFTER reply_check_mode,
+    ADD COLUMN reply_max_post_age_days INT         NULL DEFAULT 2       AFTER reply_sweeps_per_day;
+
+-- Persistent per-user token embedded in the comment-notification forwarding address
+-- (reply+<token>@parse.<domain>). Kept on users (identity/routing), NOT on the one-row prefs upsert,
+-- so it can't be clobbered by a prefs save and gets its own unique index for the webhook reverse
+-- lookup (get_user_id_by_reply_token).
+ALTER TABLE users
+    ADD COLUMN reply_inbound_token VARCHAR(32) NULL;
+ALTER TABLE users
+    ADD UNIQUE INDEX ux_users_reply_inbound_token (reply_inbound_token);

--- a/docs/REPLY_NOTIFICATIONS.md
+++ b/docs/REPLY_NOTIFICATIONS.md
@@ -1,0 +1,51 @@
+# Event-driven reply notifications
+
+Reply/comment follow-up on a user's own posts can run **event-driven** (recommended) instead of
+polling LinkedIn on a timer. Polling logs into LinkedIn in a real browser through the user's
+residential proxy every few minutes for hours, which is a primary cause of HTTP 429 rate-limiting.
+Event mode replies only when a comment actually happens — no browser polling, no 429.
+
+## How it works
+
+1. LinkedIn emails the user when someone comments on their post.
+2. The user sets a mail filter to **auto-forward** those emails to a personal tokenized address:
+   `reply+<token>@parse.<domain>` (shown in the account settings, "Reply follow-up mode → Event-driven").
+3. **SendGrid Inbound Parse** (already configured for the parse domain, same as the login-PIN flow)
+   delivers the forwarded email to `POST /api/linkedin/comment-notification/inbound`.
+4. The webhook resolves the token → user, confirms it's a *comment* (not a reaction), and triggers a
+   **debounced** recent-posts reply sweep (`sweep_reply_comments`). A burst of notifications collapses
+   into one sweep (120s window).
+
+Event mode also schedules **one** golden-hour safety sweep ~35 min after each post publishes, in case
+a notification isn't forwarded.
+
+## User setup
+
+1. **Enable LinkedIn email notifications** for comments: LinkedIn → Settings & Privacy →
+   Notifications → *Comments on your posts* (and *replies*) → ensure **Email** is on.
+2. **Gmail auto-forward filter**: Settings → Filters and Blocked Addresses → *Create a new filter* →
+   From `notifications-noreply@linkedin.com`, Subject `commented OR replied` → *Forward it to*
+   `reply+<token>@parse.<domain>` (add/verify the forwarding address first under Settings →
+   Forwarding). Copy the exact address from the account page.
+
+## Modes (per user, `engagement_preferences.reply_check_mode`)
+
+| Mode | Behavior |
+|---|---|
+| `event` (default) | Forwarded-email webhook + one golden-hour safety sweep per post. |
+| `scheduled` | A beat dispatcher runs a recent-posts sweep `reply_sweeps_per_day` times/day (2–12). Shows a 429 warning in the UI. |
+| `off` | No reply automation. |
+
+## Config / env
+
+- `LINKEDIN_PARSE_DOMAIN` — inbound parse host (e.g. `parse.christopherqueenconsulting.com`); else
+  derived from `SENDGRID_FROM_EMAIL` / `PUBLIC_BASE_URL` (see `_default_parse_domain`).
+- The per-user token is minted lazily and stored on `users.reply_inbound_token` (unique).
+- The webhook is public (`_PUBLIC_API_PREFIXES`) and always returns 200.
+
+## Related code
+
+- `src/cqc_lem/utilities/linkedin/notification_email.py` — address + comment-vs-reaction classifier.
+- `src/cqc_lem/api/main.py` — `linkedin_comment_notification_inbound` (+ debounce).
+- `src/cqc_lem/app/run_automation.py` — `sweep_reply_comments`, `post_to_linkedin` mode branch.
+- `src/cqc_lem/utilities/linkedin/verification_pin.py` — the PIN inbound flow this mirrors.

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -31,7 +31,7 @@ from cqc_lem.utilities.db import (
     has_linkedin_session, get_user_password_pair_by_id,
     get_company_linked_in_url_for_user, update_company_linked_in_url_for_user,
     get_user_subscription_info, get_user_preferences, update_user_preferences,
-    get_engagement_preferences, update_engagement_preferences,
+    get_engagement_preferences, update_engagement_preferences, get_or_create_reply_inbound_token,
     get_newsletter_settings, update_newsletter_settings,
     get_pending_newsletter_editions,
     get_latest_edition_scheduled_for, update_newsletter_edition, get_newsletter_edition,
@@ -400,11 +400,35 @@ class EngagementPreferencesRequest(BaseModel):
     max_dms_per_day: int = 20
     default_buyer_stage: Optional[str] = Field(default=None, max_length=_LEN_BUYER_STAGE)
     default_video_quality: str = "standard"
+    reply_check_mode: str = "event"
+    reply_sweeps_per_day: int = 2
+    reply_max_post_age_days: int = 2
 
     @field_validator("default_video_quality")
     @classmethod
     def _coerce_video_quality(cls, v: str) -> str:
         return v if v in _VALID_VIDEO_QUALITIES else "standard"
+
+    @field_validator("reply_check_mode")
+    @classmethod
+    def _coerce_reply_mode(cls, v: str) -> str:
+        return v if v in ("event", "scheduled", "off") else "event"
+
+    @field_validator("reply_sweeps_per_day")
+    @classmethod
+    def _clamp_sweeps(cls, v: int) -> int:
+        try:
+            return min(12, max(2, int(v)))
+        except (TypeError, ValueError):
+            return 2
+
+    @field_validator("reply_max_post_age_days")
+    @classmethod
+    def _clamp_age_days(cls, v: int) -> int:
+        try:
+            return min(14, max(1, int(v)))
+        except (TypeError, ValueError):
+            return 2
 
 
 class DmTemplateItem(BaseModel):
@@ -1206,7 +1230,15 @@ def get_engagement_preferences_endpoint(session_token: str) -> ResponseModel:
     user_id = get_session_user_id(session_token)
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
-    return ResponseModel(status_code=200, detail=get_engagement_preferences(user_id))
+    prefs = get_engagement_preferences(user_id)
+    # Read-only: the address the user forwards LinkedIn comment-notification emails to (event mode).
+    try:
+        from cqc_lem.utilities.linkedin.notification_email import reply_inbound_address
+        token = get_or_create_reply_inbound_token(user_id)
+        prefs["reply_inbound_address"] = reply_inbound_address(token) if token else None
+    except Exception:
+        prefs["reply_inbound_address"] = None
+    return ResponseModel(status_code=200, detail=prefs)
 
 
 @router.put("/user/engagement-preferences")

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -14,7 +14,7 @@ from cqc_lem.app.aws_test_celery_task import test_get_my_profile
 from cqc_lem.app.run_automation import (
     automate_invites_to_company_page_for_user, automate_reply_commenting,
     automate_commenting, automate_appreciation_dms_for_user,
-    send_private_dm, consolidate_duplicate_comments_for_user,
+    send_private_dm, consolidate_duplicate_comments_for_user, sweep_reply_comments,
 )
 from celery import chain as celery_chain
 from cqc_lem.app.run_content_plan import auto_create_weekly_content, plan_content_for_user
@@ -125,7 +125,8 @@ _API_ACCESS_TOKEN_SET = {t.strip() for t in API_ACCESS_TOKENS.split(",") if t.st
 # it's invalid — same model as the /api/auth/ endpoints. This exact leaf path only; the rest
 # of /api/user/* stays gated.
 _PUBLIC_API_PREFIXES = ("/api/auth/", "/api/billing/webhook", "/api/assets",
-                        "/api/linkedin/verification-pin", "/api/app-info",
+                        "/api/linkedin/verification-pin", "/api/linkedin/comment-notification",
+                        "/api/app-info",
                         "/api/extension/", "/api/user/linkedin-cookie")
 
 
@@ -663,6 +664,50 @@ async def linkedin_verification_pin_inbound(request: Request) -> ResponseModel:
     if user_id:
         log_info("Received LinkedIn verification PIN via email reply", user_id=user_id)
     return ResponseModel(status_code=200, detail="accepted" if user_id else "ignored")
+
+
+def _reply_sweep_debounced(user_id: int, window_s: int = 120) -> bool:
+    """True the first time we see this user within window_s — collapses a burst of comment
+    notifications into ONE reply sweep. Fails OPEN (returns True) if Redis is unavailable so a
+    notification is never silently dropped."""
+    try:
+        from cqc_lem.utilities.linkedin.rate_limit import _redis_client
+        client = _redis_client()
+        if client is None:
+            return True
+        return bool(client.set(f"linkedin:reply_sweep_debounce:{user_id}", "1", nx=True, ex=window_s))
+    except Exception:
+        return True
+
+
+@router.post("/linkedin/comment-notification/inbound")
+async def linkedin_comment_notification_inbound(request: Request) -> ResponseModel:
+    """SendGrid Inbound Parse webhook: a forwarded LinkedIn 'commented on your post' email. The
+    tokenized address (reply+<token>@parse-domain) attributes it to a user; if it's a comment (not a
+    reaction) we trigger a debounced recent-posts reply sweep — no polling, so it doesn't trip the
+    429 rate limit. Always 200 so SendGrid doesn't retry-storm on unrelated/malformed mail."""
+    from cqc_lem.utilities.linkedin.notification_email import (
+        extract_reply_token_from_address, is_comment_notification)
+    from cqc_lem.utilities.db import get_user_id_by_reply_token
+    try:
+        form = await request.form()
+    except Exception:
+        return ResponseModel(status_code=200, detail="ignored")
+    to_field = str(form.get("to") or "")
+    envelope = str(form.get("envelope") or "")
+    subject = str(form.get("subject") or "")
+    text = str(form.get("text") or form.get("html") or "")
+    token = extract_reply_token_from_address(to_field) or extract_reply_token_from_address(envelope)
+    if not token:
+        return ResponseModel(status_code=200, detail="ignored")
+    user_id = get_user_id_by_reply_token(token)
+    if not user_id or not is_comment_notification(subject, text):
+        return ResponseModel(status_code=200, detail="ignored")
+    if not _reply_sweep_debounced(user_id):
+        return ResponseModel(status_code=200, detail="debounced")
+    sweep_reply_comments.apply_async(kwargs={"user_id": user_id}, countdown=120)
+    log_info("Triggered reply sweep from comment notification", user_id=user_id)
+    return ResponseModel(status_code=200, detail="accepted")
 
 
 @router.put("/user/", responses={

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -105,6 +105,11 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_publish_scheduled_editions',
             'schedule': crontab(minute='5')  # Hourly: publish any edition whose scheduled slot has arrived
         },
+        'dispatch-scheduled-reply-sweeps': {
+            'task': 'cqc_lem.app.run_scheduler.dispatch_scheduled_reply_sweeps',
+            # Every 30 min; a per-user Redis interval key gates it to reply_sweeps_per_day (2–12) sweeps.
+            'schedule': crontab(minute='*/30')
+        },
         'sync-user-groups': {
             'task': 'cqc_lem.app.run_scheduler.auto_sync_groups',
             'schedule': crontab(hour='7', minute='0', day_of_week='monday')  # Refresh joined groups weekly

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -37,6 +37,7 @@ from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile,
     load_profile_for_user
 from cqc_lem.utilities.linkedin.poster import share_on_linkedin, share_carousel_on_linkedin
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
+from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text
 from cqc_lem.utilities.logger import myprint, log_error, log_info, log_warning
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
@@ -1482,14 +1483,150 @@ def automate_commenting(self, user_id: int, loop_for_duration: int = None, futur
     return result
 
 
+def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my_profile,
+                                    profile_synthesis: str) -> str:
+    """Navigate to the user's own post and reply to comments on it (thread-builder replies, plus
+    reciprocity/lead-magnet handling). Shared by the per-post reply task and the recent-posts sweep.
+    Returns a short human result string. Assumes the caller already has a live driver/profile."""
+    post_url = get_post_url_from_log_for_user(user_id, post_id)
+    if not post_url:
+        myprint(f"No successful post URL for post {post_id}; skipping replies.")
+        return "No post URL"
+    # Ground replies in the canonical post body (posts table); fall back to the log message.
+    post_message = get_post_content(post_id) or get_post_message_from_log_for_user(user_id, post_id)
+
+    myprint(f"Replying to Comments of Post ID:{post_id} ...")
+    if driver.current_url != post_url:
+        driver.get(post_url)
+
+    # SDUI: expand more replies where available, then collect comment items from the
+    # new data-testid comment list (comments are no longer article.comments-comment-entity).
+    for _ in range(5):
+        more = click_first(driver, wait,
+                           [(By.XPATH, "//button[contains(@aria-label,'more comment') or "
+                                       "contains(normalize-space(),'Load more') or "
+                                       "contains(normalize-space(),'more repl')]")],
+                           "Load more comments", required=False)
+        if not more:
+            break
+        time.sleep(2)
+
+    comments = _comment_items_from_thread(driver)
+    myprint(f"Comments Found: {len(comments)}")
+
+    # our profile slug — used to detect comments we've already replied to
+    path = urlparse(str(my_profile.profile_url)).path
+    unique_url_name = path.split("/")[2] if len(path.split("/")) > 2 else None
+
+    comments_replied_count = 0
+    lead_magnet = get_lead_magnet_settings(user_id)
+    lead_magnet_blog_url = get_user_blog_url(user_id) if lead_magnet.get("enabled") else ""
+    for comment in comments:
+        try:
+            tb = comment.find_elements(By.CSS_SELECTOR, "[data-testid='expandable-text-box']")
+            comment_text = ((tb[0].text if tb else comment.text) or "").strip()
+        except Exception:
+            continue
+        short_comment_text = comment_text[:75]
+        # Reciprocity + lead-magnet: read the commenter, record them as an engager, and
+        # (if enabled) DM them the resource when their comment contains the trigger keyword.
+        try:
+            _link = comment.find_element(By.CSS_SELECTOR, "a[href*='/in/']")
+            _ename = ((_link.text or "") or (_link.get_attribute("aria-label") or "")).strip().split("\n")[0]
+            _eprofile = (_link.get_attribute("href") or "").split("?")[0]
+            if _ename and _ename.lower() != (my_profile.full_name or "").lower():
+                upsert_engager(user_id, _ename, _eprofile)
+                if (lead_magnet.get("enabled") and lead_magnet.get("keyword") and lead_magnet.get("message")
+                        and lead_magnet["keyword"].lower() in comment_text.lower()
+                        and _eprofile and not has_received_lead_magnet(user_id, _eprofile)):
+                    lm_message = render_dm_placeholders(
+                        lead_magnet["message"],
+                        first_name=(_ename or "").split(" ")[0],
+                        blog_url=lead_magnet_blog_url or "")
+                    send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": _eprofile,
+                                                        "message": lm_message})
+                    record_lead_magnet_sent(user_id, _eprofile, post_id)
+                    myprint(f"Lead magnet DM queued to {_ename} (keyword '{lead_magnet['keyword']}')")
+        except Exception:
+            pass
+        # Already replied if our own profile link already appears in this comment's replies.
+        already_replied = False
+        if unique_url_name:
+            try:
+                already_replied = bool(comment.find_elements(By.CSS_SELECTOR, f"a[href*='{unique_url_name}']"))
+            except Exception:
+                already_replied = False
+        if already_replied:
+            myprint(f"We already replied to this comment: {short_comment_text}...")
+            continue
+        myprint(f"Responding to this comment: {short_comment_text}...")
+        # Thread-builder: reply in a way that ends with a follow-up question so the commenter
+        # replies again — first-hour thread depth is the top 2026 reach signal.
+        response = generate_thread_reply(post_message, comment_text, my_profile,
+                                         prefs=get_engagement_preferences(user_id),
+                                         profile_synthesis=profile_synthesis)
+        myprint(f"AI Generated Response to Comment: {response}")
+        if response and _reply_to_comment_inline(driver, wait, comment, response, user_id=user_id):
+            insert_new_log(user_id=user_id, post_id=post_id, action_type=LogActionType.REPLY,
+                           result=LogResultType.SUCCESS, post_url=post_url, message=response)
+            comments_replied_count += 1
+            time.sleep(random.uniform(5, 12))
+        else:
+            insert_new_log(user_id=user_id, post_id=post_id, action_type=LogActionType.REPLY,
+                           result=LogResultType.FAILURE, post_url=post_url, message=response)
+    return f"Replied to {comments_replied_count} comments"
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='se_engage')
+def sweep_reply_comments(self, user_id: int):
+    """Reply to new comments across the user's RECENT posts in ONE Selenium session. Triggered by a
+    forwarded comment-notification email (event mode) or the scheduled dispatcher — replacing the old
+    24h-per-post polling loop that drove the 429 rate-limiting. 429-safe: a rate-limited session logs
+    a clean skip and returns (a later trigger/sweep retries)."""
+    prefs = get_engagement_preferences(user_id)
+    days = int(prefs.get("reply_max_post_age_days") or 2)
+    post_ids = get_recent_posted_post_ids(user_id, days=days)
+    if not post_ids:
+        return "No recent posts to sweep"
+    try:
+        driver, wait, _user_email, my_profile = get_current_profile(user_id=user_id, session_name="Reply Sweep")
+    except LinkedInRateLimited as e:
+        log_warning("Reply sweep skipped — LinkedIn rate-limited", exc=e, user_id=user_id,
+                    task_name="sweep_reply_comments")
+        return "Skipped — rate limited"
+    except Exception as e:
+        log_error("Error starting reply sweep", exc=e, user_id=user_id, task_name="sweep_reply_comments")
+        return f"Failed to start reply sweep: {e}"
+    try:
+        profile_synthesis = get_or_create_profile_synthesis(user_id, my_profile)
+        swept = 0
+        for post_id in post_ids:
+            try:
+                _reply_to_comments_on_open_post(driver, wait, user_id, post_id, my_profile, profile_synthesis)
+                swept += 1
+            except Exception as e:
+                log_warning("Reply sweep: post failed", exc=e, user_id=user_id, post_id=post_id,
+                            task_name="sweep_reply_comments")
+        return f"Swept replies on {swept}/{len(post_ids)} recent posts"
+    finally:
+        quit_gracefully(driver)
+
+
 @shared_task.task(bind=True, base=QueueOnce,
                   once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id', 'post_id']},
                   queue='se_engage')
 def automate_reply_commenting(self, user_id: int, post_id: int, loop_for_duration: int = 60, future_forward=0):
-    """Reply to recent comments left on the post recently posted"""
+    """Reply to recent comments left on a single post. Retained for the manual/API trigger and
+    back-compat; the default post-publish path now uses sweep_reply_comments (event/scheduled mode).
+    429-safe: a rate-limited session returns cleanly instead of dying before the re-queue."""
 
     try:
         driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Reply to Comments")
+    except LinkedInRateLimited as e:
+        log_warning("Reply commenting skipped — LinkedIn rate-limited", exc=e, user_id=user_id,
+                    task_name="automate_reply_commenting")
+        return "Skipped — rate limited"
     except Exception as e:
         log_error("Error while getting profile for reply commenting", exc=e, user_id=user_id, task_name="automate_reply_commenting")
         return f"Failed to start reply commenting: {e}"
@@ -1500,103 +1637,10 @@ def automate_reply_commenting(self, user_id: int, post_id: int, loop_for_duratio
 
         start_time = datetime.now()
 
-        myprint(f"Replying to Comments of Post ID:{post_id} ...")
-
-        # Use the user id and the post id to get the post_url from the database
-        post_url = get_post_url_from_log_for_user(user_id, post_id)
-
-        # Get the message content of the post
-        post_message = get_post_message_from_log_for_user(user_id, post_id)
-
         # Stable VOICE synthesis reused across every reply in this run (voice source, not the raw JSON).
         profile_synthesis = get_or_create_profile_synthesis(user_id, my_profile)
 
-        if post_url:
-            # Navigate to the Post
-            if driver.current_url != post_url:
-                driver.get(post_url)
-
-            # SDUI: expand more replies where available, then collect comment items from the
-            # new data-testid comment list (comments are no longer article.comments-comment-entity).
-            for _ in range(5):
-                more = click_first(driver, wait,
-                                   [(By.XPATH, "//button[contains(@aria-label,'more comment') or "
-                                               "contains(normalize-space(),'Load more') or "
-                                               "contains(normalize-space(),'more repl')]")],
-                                   "Load more comments", required=False)
-                if not more:
-                    break
-                time.sleep(2)
-
-            comments = _comment_items_from_thread(driver)
-            myprint(f"Comments Found: {len(comments)}")
-            result = f"Comments Found: {len(comments)}"
-
-            # our profile slug — used to detect comments we've already replied to
-            path = urlparse(str(my_profile.profile_url)).path
-            unique_url_name = path.split("/")[2] if len(path.split("/")) > 2 else None
-
-            comments_replied_count = 0
-            lead_magnet = get_lead_magnet_settings(user_id)
-            lead_magnet_blog_url = get_user_blog_url(user_id) if lead_magnet.get("enabled") else ""
-            for comment in comments:
-                try:
-                    tb = comment.find_elements(By.CSS_SELECTOR, "[data-testid='expandable-text-box']")
-                    comment_text = ((tb[0].text if tb else comment.text) or "").strip()
-                except Exception:
-                    continue
-                short_comment_text = comment_text[:75]
-                # Reciprocity + lead-magnet: read the commenter, record them as an engager, and
-                # (if enabled) DM them the resource when their comment contains the trigger keyword.
-                try:
-                    _link = comment.find_element(By.CSS_SELECTOR, "a[href*='/in/']")
-                    _ename = ((_link.text or "") or (_link.get_attribute("aria-label") or "")).strip().split("\n")[0]
-                    _eprofile = (_link.get_attribute("href") or "").split("?")[0]
-                    if _ename and _ename.lower() != (my_profile.full_name or "").lower():
-                        upsert_engager(user_id, _ename, _eprofile)
-                        if (lead_magnet.get("enabled") and lead_magnet.get("keyword") and lead_magnet.get("message")
-                                and lead_magnet["keyword"].lower() in comment_text.lower()
-                                and _eprofile and not has_received_lead_magnet(user_id, _eprofile)):
-                            lm_message = render_dm_placeholders(
-                                lead_magnet["message"],
-                                first_name=(_ename or "").split(" ")[0],
-                                blog_url=lead_magnet_blog_url or "")
-                            send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": _eprofile,
-                                                                "message": lm_message})
-                            record_lead_magnet_sent(user_id, _eprofile, post_id)
-                            myprint(f"Lead magnet DM queued to {_ename} (keyword '{lead_magnet['keyword']}')")
-                except Exception:
-                    pass
-                # Already replied if our own profile link already appears in this comment's replies.
-                already_replied = False
-                if unique_url_name:
-                    try:
-                        already_replied = bool(comment.find_elements(By.CSS_SELECTOR, f"a[href*='{unique_url_name}']"))
-                    except Exception:
-                        already_replied = False
-                if already_replied:
-                    myprint(f"We already replied to this comment: {short_comment_text}...")
-                    continue
-                myprint(f"Responding to this comment: {short_comment_text}...")
-                # Thread-builder: reply in a way that ends with a follow-up question so the commenter
-                # replies again — first-hour thread depth is the top 2026 reach signal.
-                response = generate_thread_reply(post_message, comment_text, my_profile,
-                                                 prefs=get_engagement_preferences(user_id),
-                                                 profile_synthesis=profile_synthesis)
-                myprint(f"AI Generated Response to Comment: {response}")
-                if response and _reply_to_comment_inline(driver, wait, comment, response, user_id=user_id):
-                    insert_new_log(user_id=user_id, post_id=post_id, action_type=LogActionType.REPLY,
-                                   result=LogResultType.SUCCESS, post_url=post_url, message=response)
-                    comments_replied_count += 1
-                    time.sleep(random.uniform(5, 12))
-                else:
-                    insert_new_log(user_id=user_id, post_id=post_id, action_type=LogActionType.REPLY,
-                                   result=LogResultType.FAILURE, post_url=post_url, message=response)
-                result = f"Replied to {comments_replied_count} comments"
-
-        else:
-            myprint("Could not find successful post for this user and post_id. Sleeping...")
-            result = "Could not find successful post for this user and post_id. Sleeping..."
+        result = _reply_to_comments_on_open_post(driver, wait, user_id, post_id, my_profile, profile_synthesis)
 
         # Re-schedule the task in the queue for the future
         if loop_for_duration:
@@ -2688,14 +2732,12 @@ def post_to_linkedin(self, user_id: int, post_id: int):
                        post_url=post_url,
                        message=f"Successfully created post using /posts API endpoint.")
 
-        # Schedule Reply to comments for 24 hours now that this has been posted
-        base_kwargs = {
-            'user_id': user_id,
-            'post_id': post_id,
-            'loop_for_duration': 60 * 60 * 24,
-            'future_forward': 0
-        }
-        automate_reply_commenting.apply_async(kwargs=base_kwargs)
+        # Reply/comment follow-up per the user's reply_check_mode (replaces the old 24h polling loop
+        # that drove LinkedIn 429s). event → ONE golden-hour safety sweep as a backstop for a missed
+        # forwarded notification; scheduled → the beat dispatcher handles it; off → nothing.
+        reply_mode = get_engagement_preferences(user_id).get("reply_check_mode", "event")
+        if reply_mode == "event":
+            sweep_reply_comments.apply_async(kwargs={'user_id': user_id}, countdown=35 * 60)
 
         return f"Post successfully created"
 

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -8,13 +8,15 @@ from cqc_lem import assets_dir
 from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.app.run_automation import automate_commenting, automate_profile_viewer_engagement, \
     automate_appreciation_dms_for_user, clean_stale_invites, update_stale_profile, post_to_linkedin, \
-    automate_invites_to_company_page_for_user, auto_seed_comment_on_post, send_scheduled_dm
+    automate_invites_to_company_page_for_user, auto_seed_comment_on_post, send_scheduled_dm, \
+    sweep_reply_comments
 from cqc_lem.utilities.db import (
     get_ready_to_post_posts, get_orphaned_scheduled_posts, update_db_post_status,
     get_active_user_ids, PostStatus, has_linkedin_session, has_scheduled_post_today,
     get_company_linked_in_url_for_user,
     get_users_with_stripe_subscriptions, update_subscription_from_stripe,
     get_due_scheduled_dms, get_orphaned_scheduled_dms, update_scheduled_dm_status, ScheduledDmStatus,
+    get_users_with_reply_mode, get_engagement_preferences,
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES
 from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
@@ -168,6 +170,37 @@ def auto_daily_engagement():
         automate_commenting.apply_async(kwargs={'user_id': user_id, 'loop_for_duration': 60 * 15})
         dispatched += 1
     return f"Golden-hour engagement dispatched for {dispatched}/{len(users)} active user(s)"
+
+
+@shared_task.task
+def dispatch_scheduled_reply_sweeps():
+    """Beat: for users on reply_check_mode='scheduled', run a recent-posts reply sweep at their
+    configured cadence (reply_sweeps_per_day, 2–12). A per-user Redis key with TTL = the cadence
+    interval gates it: while the key exists we're within the interval and skip, so running this beat
+    every ~30 min naturally yields ~reply_sweeps_per_day sweeps. Fails open on Redis outage (dispatch
+    anyway) — sweep_reply_comments itself is QueueOnce + 429-safe, so an extra run is harmless."""
+    from cqc_lem.utilities.linkedin.rate_limit import _redis_client
+    users = get_users_with_reply_mode("scheduled")
+    if not users:
+        return "No scheduled-mode users"
+    client = _redis_client()
+    dispatched = 0
+    for user_id in users:
+        if not has_linkedin_session(user_id):
+            continue
+        sweeps = int(get_engagement_preferences(user_id).get("reply_sweeps_per_day") or 2)
+        interval_s = max(2 * 60 * 60, (24 * 60 * 60) // max(1, sweeps))  # floor 2h between sweeps
+        due = True
+        if client is not None:
+            try:
+                # nx=True sets the key only if absent (i.e. we're past the interval) → this run is due.
+                due = bool(client.set(f"linkedin:last_reply_sweep:{user_id}", "1", nx=True, ex=interval_s))
+            except Exception:
+                due = True
+        if due:
+            sweep_reply_comments.apply_async(kwargs={'user_id': user_id})
+            dispatched += 1
+    return f"Scheduled reply sweeps dispatched for {dispatched}/{len(users)} user(s)"
 
 
 def _max_dt(*dts):

--- a/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
@@ -213,6 +213,39 @@ export default function EngagementSettingsCard() {
           <p className="text-sm font-medium text-gray-700">Reply to comments on my posts</p>
           <Toggle on={engPrefs.reply_to_own_comments} onClick={() => setEng({ reply_to_own_comments: !engPrefs.reply_to_own_comments })} />
         </div>
+        <div className="border-t border-gray-100 pt-4">
+          <label className="block text-sm font-medium text-gray-700 mb-1">Reply follow-up mode</label>
+          <select value={engPrefs.reply_check_mode ?? 'event'}
+            onChange={(e) => setEng({ reply_check_mode: e.target.value })}
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm">
+            <option value="event">Event-driven — reply when notified (recommended)</option>
+            <option value="scheduled">Scheduled — check on a timer</option>
+            <option value="off">Off — don't auto-reply</option>
+          </select>
+          {engPrefs.reply_check_mode === 'event' && (
+            <div className="mt-2 text-xs text-gray-500 space-y-1">
+              <p>Forward LinkedIn "commented on your post" emails to the address below (Gmail → Settings → Filters → Forward), and enable LinkedIn's comment email notifications. We reply within minutes — no browser polling, so it won't trip LinkedIn's rate limits.</p>
+              {engPrefs.reply_inbound_address && (
+                <div className="flex items-center gap-2">
+                  <code className="bg-gray-100 rounded px-2 py-1 text-gray-700 break-all">{engPrefs.reply_inbound_address}</code>
+                  <button type="button" onClick={() => navigator.clipboard?.writeText(engPrefs.reply_inbound_address || '')}
+                    className="text-blue-600 hover:underline shrink-0">Copy</button>
+                </div>
+              )}
+            </div>
+          )}
+          {engPrefs.reply_check_mode === 'scheduled' && (
+            <div className="mt-2 space-y-2">
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Reply checks per day (2–12)</label>
+                <input type="number" min={2} max={12} value={engPrefs.reply_sweeps_per_day ?? 2}
+                  onChange={(e) => setEng({ reply_sweeps_per_day: Math.min(12, Math.max(2, Number(e.target.value) || 2)) })}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+              </div>
+              <p className="text-xs text-amber-600">⚠ Scheduled checks open a browser session each run, which can get your account temporarily rate-limited (HTTP 429) by LinkedIn. Event-driven is recommended.</p>
+            </div>
+          )}
+        </div>
         {saveBtn('Save Targeting')}
       </div>
     </>

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -19,6 +19,10 @@ export type EngPrefs = {
   max_comments_per_day: number
   max_dms_per_day: number
   default_video_quality: string
+  reply_check_mode: string
+  reply_sweeps_per_day: number
+  reply_max_post_age_days: number
+  reply_inbound_address?: string | null
 }
 
 export type DmTemplate = {

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2568,14 +2568,18 @@ def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
     # numbers → clamped to bounds.
     if merged.get("reply_check_mode") not in VALID_REPLY_MODES:
         merged["reply_check_mode"] = "event"
+    # Clamp numerics WITHOUT `or` fallbacks — 0 is falsy but is a real (out-of-range) value that must
+    # clamp to the floor, not silently become the default (matches the API-layer validators).
+    _sw = merged.get("reply_sweeps_per_day")
     try:
-        merged["reply_sweeps_per_day"] = min(REPLY_SWEEPS_MAX, max(REPLY_SWEEPS_MIN,
-                                                                    int(merged.get("reply_sweeps_per_day") or REPLY_SWEEPS_MIN)))
+        merged["reply_sweeps_per_day"] = (min(REPLY_SWEEPS_MAX, max(REPLY_SWEEPS_MIN, int(_sw)))
+                                          if _sw is not None else REPLY_SWEEPS_MIN)
     except (TypeError, ValueError):
         merged["reply_sweeps_per_day"] = REPLY_SWEEPS_MIN
+    _age = merged.get("reply_max_post_age_days")
     try:
-        merged["reply_max_post_age_days"] = min(REPLY_MAX_AGE_DAYS_MAX, max(REPLY_MAX_AGE_DAYS_MIN,
-                                                                            int(merged.get("reply_max_post_age_days") or 2)))
+        merged["reply_max_post_age_days"] = (min(REPLY_MAX_AGE_DAYS_MAX, max(REPLY_MAX_AGE_DAYS_MIN, int(_age)))
+                                             if _age is not None else 2)
     except (TypeError, ValueError):
         merged["reply_max_post_age_days"] = 2
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1,5 +1,6 @@
 import json
 import os
+import uuid
 from datetime import datetime, timedelta, timezone
 from enum import StrEnum
 from typing import Optional
@@ -2500,6 +2501,7 @@ _ENGAGEMENT_DEFAULTS: dict = {
     "min_reactions": None, "max_post_age_hours": 24, "reply_to_own_comments": True,
     "max_comments_per_day": 20, "max_dms_per_day": 20, "default_buyer_stage": None,
     "default_video_quality": "standard",
+    "reply_check_mode": "event", "reply_sweeps_per_day": 2, "reply_max_post_age_days": 2,
 }
 _ENGAGEMENT_JSON_FIELDS = ("include_topics", "exclude_topics", "include_keywords",
                            "exclude_keywords", "include_authors", "exclude_authors", "post_types",
@@ -2510,9 +2512,14 @@ _ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "us
                     "include_authors", "exclude_authors", "post_types", "focus_topics",
                     "business_goals", "personal_goals", "min_reactions",
                     "max_post_age_hours", "reply_to_own_comments", "max_comments_per_day",
-                    "max_dms_per_day", "default_buyer_stage", "default_video_quality")
+                    "max_dms_per_day", "default_buyer_stage", "default_video_quality",
+                    "reply_check_mode", "reply_sweeps_per_day", "reply_max_post_age_days")
 
 VALID_VIDEO_QUALITIES = ("standard", "premium", "premium_top")
+VALID_REPLY_MODES = ("event", "scheduled", "off")
+# Scheduled reply-sweep cadence bounds: floor 2×/day (as requested), cap 12×/day (every ~2h).
+REPLY_SWEEPS_MIN, REPLY_SWEEPS_MAX = 2, 12
+REPLY_MAX_AGE_DAYS_MIN, REPLY_MAX_AGE_DAYS_MAX = 1, 14
 
 
 def _coerce_json_list(value) -> list:
@@ -2556,6 +2563,22 @@ def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
     """Upsert the user's engagement preferences (INSERT ... ON DUPLICATE KEY UPDATE)."""
     merged = {**_ENGAGEMENT_DEFAULTS, **{k: v for k, v in prefs.items() if k in _ENGAGEMENT_DEFAULTS}}
 
+    # Clamp/validate reply-check config so a bad value can't overflow a column and roll back the
+    # WHOLE single-row upsert (the V52 tone incident). Bad mode → the safe default; out-of-range
+    # numbers → clamped to bounds.
+    if merged.get("reply_check_mode") not in VALID_REPLY_MODES:
+        merged["reply_check_mode"] = "event"
+    try:
+        merged["reply_sweeps_per_day"] = min(REPLY_SWEEPS_MAX, max(REPLY_SWEEPS_MIN,
+                                                                    int(merged.get("reply_sweeps_per_day") or REPLY_SWEEPS_MIN)))
+    except (TypeError, ValueError):
+        merged["reply_sweeps_per_day"] = REPLY_SWEEPS_MIN
+    try:
+        merged["reply_max_post_age_days"] = min(REPLY_MAX_AGE_DAYS_MAX, max(REPLY_MAX_AGE_DAYS_MIN,
+                                                                            int(merged.get("reply_max_post_age_days") or 2)))
+    except (TypeError, ValueError):
+        merged["reply_max_post_age_days"] = 2
+
     def _val(col):
         v = merged[col]
         if col in _ENGAGEMENT_JSON_FIELDS:
@@ -2578,6 +2601,63 @@ def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
     except mysql.connector.Error as err:
         myprint(f"Could not update engagement prefs for user_id {user_id} | Error: {err}")
         return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_or_create_reply_inbound_token(user_id: int) -> Optional[str]:
+    """The user's PERSISTENT inbound token for the comment-notification forwarding address
+    (reply+<token>@parse-domain). Minted once and stored on the users row so the Gmail forward
+    filter the user sets up keeps resolving to them. Returns None only on DB error."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT reply_inbound_token FROM users WHERE id = %s", (user_id,))
+        row = cursor.fetchone()
+        if row and row[0]:
+            return row[0]
+        token = uuid.uuid4().hex[:20]
+        cursor.execute("UPDATE users SET reply_inbound_token = %s WHERE id = %s", (token, user_id))
+        connection.commit()
+        return token
+    except mysql.connector.Error as err:
+        myprint(f"Could not get/create reply inbound token for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_user_id_by_reply_token(token: str) -> Optional[int]:
+    """Reverse lookup for the comment-notification webhook: token → user_id (unique index)."""
+    if not token:
+        return None
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT id FROM users WHERE reply_inbound_token = %s", (token,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not look up user by reply token | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_users_with_reply_mode(mode: str) -> list:
+    """user_ids whose engagement prefs set reply_check_mode = mode (drives the scheduled sweep
+    dispatcher). Users with no prefs row default to 'event', so they never appear for 'scheduled'."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT user_id FROM engagement_preferences WHERE reply_check_mode = %s", (mode,))
+        return [r[0] for r in cursor.fetchall()]
+    except mysql.connector.Error as err:
+        myprint(f"Could not get users with reply mode {mode} | Error: {err}")
+        return []
     finally:
         cursor.close()
         connection.close()

--- a/src/cqc_lem/utilities/linkedin/notification_email.py
+++ b/src/cqc_lem/utilities/linkedin/notification_email.py
@@ -1,0 +1,58 @@
+"""Helpers for the event-driven reply feature: a user forwards LinkedIn "commented on your post"
+notification emails to a tokenized address (reply+<token>@parse.<domain>) that SendGrid Inbound
+Parse pipes to our webhook. Mirrors the PIN-verification email helpers (verification_pin.py) — same
+parse-domain derivation and tokenized-address style — but the token is a PERSISTENT per-user id
+(stored on the users row) since the forward filter is set up once and forwards indefinitely.
+"""
+import os
+import re
+from typing import Optional
+
+# Reuse the exact parse-domain derivation used by the PIN flow (SENDGRID_FROM_EMAIL /
+# PUBLIC_BASE_URL, overridable by LINKEDIN_PARSE_DOMAIN) so both inbound addresses share a domain.
+from cqc_lem.utilities.linkedin.verification_pin import _default_parse_domain
+
+# Tokenized local part reply+<token>@parse.domain — appears in SendGrid's `to`/`envelope` fields.
+_REPLY_TOKEN_RE = re.compile(r"reply\+([A-Za-z0-9]+)@")
+
+# Subject/body phrases LinkedIn uses when someone COMMENTS or REPLIES on the user's content (trigger
+# a reply sweep) vs merely REACTS/likes/mentions (ignore — nothing to reply to).
+_COMMENT_PHRASES = ("commented on", "replied to", "left a comment", "comment on your")
+_REACTION_PHRASES = ("liked", "reacted to", "celebrates", "loves", "supports",
+                     "found your post", "mentioned you", "started following")
+
+
+def reply_inbound_address(token: str) -> str:
+    """The forwarding address the user points a Gmail filter at. Host is LINKEDIN_PARSE_DOMAIN if
+    set, else derived from the configured domain (see _default_parse_domain)."""
+    domain = os.getenv("LINKEDIN_PARSE_DOMAIN") or _default_parse_domain()
+    return f"reply+{token}@{domain}"
+
+
+def extract_reply_token_from_address(value: str) -> Optional[str]:
+    """Pull the persistent per-user token out of a `to`/`envelope` value from the inbound webhook."""
+    if not value:
+        return None
+    m = _REPLY_TOKEN_RE.search(value)
+    return m.group(1) if m else None
+
+
+def is_comment_notification(subject: str, text: str = "") -> bool:
+    """True when the forwarded LinkedIn email is a COMMENT/REPLY notification (something to reply to),
+    False for reactions/likes/mentions/other. Reads the subject plus the top of the body (like
+    extract_pin_from_text) so quoted history can't flip the classification."""
+    subject = (subject or "").lower()
+    # Top of the body only — stop at quoted history so a forwarded chain doesn't add noise.
+    head_lines = []
+    for line in (text or "").splitlines():
+        if line.lstrip().startswith(">") or line.strip().lower().startswith("on "):
+            break
+        head_lines.append(line)
+    head = ("\n".join(head_lines)).lower()
+    hay = f"{subject}\n{head}"
+    if any(p in hay for p in _COMMENT_PHRASES):
+        return True
+    # Subject alone is the most reliable signal; if it's clearly a reaction, reject.
+    if any(p in subject for p in _REACTION_PHRASES):
+        return False
+    return False

--- a/tests/unit/api/test_engagement_prefs_api.py
+++ b/tests/unit/api/test_engagement_prefs_api.py
@@ -116,6 +116,38 @@ class TestUpdateEngagementPreferences:
         assert upd.call_args[0][1]["tone"] == long_tone
 
 
+class TestReplyCheckConfig:
+    def test_get_includes_reply_inbound_address(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_engagement_preferences",
+                   return_value={"reply_check_mode": "event"}), \
+             patch("cqc_lem.api.main.get_or_create_reply_inbound_token", return_value="tok9"), \
+             patch.dict("os.environ", {"LINKEDIN_PARSE_DOMAIN": "parse.example.com"}):
+            resp = client.get(f"/api/user/engagement-preferences?session_token={_SESSION}")
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["reply_inbound_address"] == "reply+tok9@parse.example.com"
+
+    def test_reply_mode_passthrough_and_clamps(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences",
+                              json={"session_token": _SESSION, "reply_check_mode": "scheduled",
+                                    "reply_sweeps_per_day": 99, "reply_max_post_age_days": 0})
+        assert resp.status_code == 200
+        arg = upd.call_args[0][1]
+        assert arg["reply_check_mode"] == "scheduled"
+        assert arg["reply_sweeps_per_day"] == 12   # clamped to max
+        assert arg["reply_max_post_age_days"] == 1  # clamped to min
+
+    def test_bad_reply_mode_coerced_to_event(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences",
+                              json={"session_token": _SESSION, "reply_check_mode": "bogus"})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1]["reply_check_mode"] == "event"
+
+
 class TestEngagementPersistenceRegression:
     """Guards for the class of bug that silently dropped engagement settings."""
 

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -329,6 +329,58 @@ class TestGetUserLinkedInProfile:
         assert resp.json()["detail"]["linkedin_profile_url"] is None
 
 
+class TestCommentNotificationInbound:
+    """SendGrid Inbound Parse webhook for forwarded LinkedIn comment notifications."""
+    BASE = "/api/linkedin/comment-notification/inbound"
+    _DB = "cqc_lem.utilities.db.get_user_id_by_reply_token"
+
+    def test_comment_triggers_debounced_sweep(self, client):
+        with patch(self._DB, return_value=7), \
+             patch(f"{_MAIN}._reply_sweep_debounced", return_value=True), \
+             patch(f"{_MAIN}.sweep_reply_comments") as sweep:
+            resp = client.post(self.BASE, data={
+                "to": "reply+tok9@parse.example.com",
+                "subject": "Chris, Jane commented on your post",
+                "text": "great post!"})
+        assert resp.status_code == 200 and resp.json()["detail"] == "accepted"
+        sweep.apply_async.assert_called_once()
+        assert sweep.apply_async.call_args.kwargs["kwargs"] == {"user_id": 7}
+
+    def test_reaction_email_ignored(self, client):
+        with patch(self._DB, return_value=7), \
+             patch(f"{_MAIN}.sweep_reply_comments") as sweep:
+            resp = client.post(self.BASE, data={
+                "to": "reply+tok9@parse.example.com",
+                "subject": "Jane liked your post", "text": ""})
+        assert resp.json()["detail"] == "ignored"
+        sweep.apply_async.assert_not_called()
+
+    def test_unknown_token_ignored(self, client):
+        with patch(self._DB, return_value=None), \
+             patch(f"{_MAIN}.sweep_reply_comments") as sweep:
+            resp = client.post(self.BASE, data={
+                "to": "reply+stale@parse.example.com",
+                "subject": "someone commented on your post"})
+        assert resp.json()["detail"] == "ignored"
+        sweep.apply_async.assert_not_called()
+
+    def test_no_token_ignored(self, client):
+        with patch(f"{_MAIN}.sweep_reply_comments") as sweep:
+            resp = client.post(self.BASE, data={"to": "x@y.com", "subject": "commented on your post"})
+        assert resp.json()["detail"] == "ignored"
+        sweep.apply_async.assert_not_called()
+
+    def test_debounced_second_notification(self, client):
+        with patch(self._DB, return_value=7), \
+             patch(f"{_MAIN}._reply_sweep_debounced", return_value=False), \
+             patch(f"{_MAIN}.sweep_reply_comments") as sweep:
+            resp = client.post(self.BASE, data={
+                "to": "reply+tok9@parse.example.com",
+                "subject": "Jane commented on your post"})
+        assert resp.json()["detail"] == "debounced"
+        sweep.apply_async.assert_not_called()
+
+
 class TestVerificationPinInbound:
     """SendGrid Inbound Parse webhook that receives the user's PIN reply."""
     BASE = "/api/linkedin/verification-pin/inbound"

--- a/tests/unit/app/test_reply_sweep.py
+++ b/tests/unit/app/test_reply_sweep.py
@@ -60,3 +60,114 @@ class TestSweepReplyComments:
              patch(f"{_RA}.quit_gracefully"):
             result = sweep_reply_comments.run(user_id=1)
         assert "1/2" in result  # first post errored, second succeeded
+
+
+class _FakeComment:
+    def __init__(self, text, author="Jane Doe", href="https://www.linkedin.com/in/jane", already=False):
+        self._text, self._author, self._href, self._already = text, author, href, already
+        self.text = text
+
+    def find_elements(self, by, sel):
+        if "expandable-text-box" in sel:
+            tb = MagicMock(); tb.text = self._text
+            return [tb]
+        return [MagicMock()] if self._already else []   # already-replied probe
+
+    def find_element(self, by, sel):
+        if "/in/" in sel:
+            link = MagicMock(); link.text = self._author
+            link.get_attribute = lambda a: self._href if a == "href" else ""
+            return link
+        raise Exception("not found")
+
+
+class TestReplyToCommentsOnOpenPost:
+    def _profile(self):
+        p = MagicMock(); p.profile_url = "https://www.linkedin.com/in/me"; p.full_name = "Me Myself"
+        return p
+
+    def test_replies_to_new_comment(self):
+        from cqc_lem.app.run_automation import _reply_to_comments_on_open_post
+        driver = MagicMock(); driver.current_url = "other"
+        with patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://li/feed/update/urn:li:share:1/"), \
+             patch(f"{_RA}.get_post_content", return_value="post body"), \
+             patch(f"{_RA}.click_first", return_value=None), \
+             patch(f"{_RA}._comment_items_from_thread", return_value=[_FakeComment("Nice post")]), \
+             patch(f"{_RA}.get_lead_magnet_settings", return_value={"enabled": False}), \
+             patch(f"{_RA}.upsert_engager"), \
+             patch(f"{_RA}.generate_thread_reply", return_value="Thanks! What resonated most?"), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}._reply_to_comment_inline", return_value=True) as rep, \
+             patch(f"{_RA}.insert_new_log") as log:
+            result = _reply_to_comments_on_open_post(driver, MagicMock(), 1, 9, self._profile(), "synth")
+        driver.get.assert_called_once()  # navigated to the post
+        rep.assert_called_once()
+        log.assert_called_once()
+        assert "Replied to 1 comments" in result
+
+    def test_skips_already_replied(self):
+        from cqc_lem.app.run_automation import _reply_to_comments_on_open_post
+        driver = MagicMock(); driver.current_url = "x"
+        with patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://li/feed/update/urn:li:share:1/"), \
+             patch(f"{_RA}.get_post_content", return_value="post body"), \
+             patch(f"{_RA}.click_first", return_value=None), \
+             patch(f"{_RA}._comment_items_from_thread",
+                   return_value=[_FakeComment("hi", author="Me Myself", href="https://www.linkedin.com/in/me", already=True)]), \
+             patch(f"{_RA}.get_lead_magnet_settings", return_value={"enabled": False}), \
+             patch(f"{_RA}.upsert_engager"), \
+             patch(f"{_RA}.generate_thread_reply") as gen, \
+             patch(f"{_RA}._reply_to_comment_inline") as rep, \
+             patch(f"{_RA}.insert_new_log"):
+            _reply_to_comments_on_open_post(driver, MagicMock(), 1, 9, self._profile(), "synth")
+        gen.assert_not_called()   # our own reply already present → skip
+        rep.assert_not_called()
+
+    def test_lead_magnet_dm_on_keyword(self):
+        from cqc_lem.app.run_automation import _reply_to_comments_on_open_post
+        driver = MagicMock(); driver.current_url = "x"
+        with patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://li/feed/update/urn:li:share:1/"), \
+             patch(f"{_RA}.get_post_content", return_value="post body"), \
+             patch(f"{_RA}.click_first", return_value=None), \
+             patch(f"{_RA}._comment_items_from_thread", return_value=[_FakeComment("Send me GUIDE please")]), \
+             patch(f"{_RA}.get_lead_magnet_settings",
+                   return_value={"enabled": True, "keyword": "GUIDE", "message": "Here: {blog_url}"}), \
+             patch(f"{_RA}.get_user_blog_url", return_value="https://blog"), \
+             patch(f"{_RA}.has_received_lead_magnet", return_value=False), \
+             patch(f"{_RA}.render_dm_placeholders", return_value="Here: https://blog"), \
+             patch(f"{_RA}.send_private_dm") as dm, \
+             patch(f"{_RA}.record_lead_magnet_sent") as rec, \
+             patch(f"{_RA}.upsert_engager"), \
+             patch(f"{_RA}.generate_thread_reply", return_value="reply"), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}._reply_to_comment_inline", return_value=True), \
+             patch(f"{_RA}.insert_new_log"):
+            _reply_to_comments_on_open_post(driver, MagicMock(), 1, 9, self._profile(), "synth")
+        dm.apply_async.assert_called_once()
+        rec.assert_called_once()
+
+    def test_no_post_url_returns_early(self):
+        from cqc_lem.app.run_automation import _reply_to_comments_on_open_post
+        with patch(f"{_RA}.get_post_url_from_log_for_user", return_value=None):
+            result = _reply_to_comments_on_open_post(MagicMock(), MagicMock(), 1, 9, self._profile(), "s")
+        assert "No post URL" in result
+
+
+class TestAutomateReplyCommenting:
+    def test_rate_limited_returns_clean_skip(self):
+        from cqc_lem.app.run_automation import automate_reply_commenting
+        from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
+        with patch(f"{_RA}.get_current_profile", side_effect=LinkedInRateLimited("429")), \
+             patch(f"{_RA}.log_warning") as warn:
+            result = automate_reply_commenting.run(user_id=1, post_id=9, loop_for_duration=0)
+        assert "rate limited" in result.lower()
+        warn.assert_called_once()
+
+    def test_single_pass_no_requeue_when_loop_zero(self):
+        from cqc_lem.app.run_automation import automate_reply_commenting
+        with patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"), \
+             patch(f"{_RA}._reply_to_comments_on_open_post", return_value="Replied to 2 comments") as helper, \
+             patch(f"{_RA}.quit_gracefully"):
+            result = automate_reply_commenting.run(user_id=1, post_id=9, loop_for_duration=0)
+        helper.assert_called_once()
+        assert "Replied to 2 comments" in result

--- a/tests/unit/app/test_reply_sweep.py
+++ b/tests/unit/app/test_reply_sweep.py
@@ -1,0 +1,62 @@
+"""Unit tests for sweep_reply_comments — the recent-posts reply sweep that replaces the 24h loop."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with patch(f"{_RA}.time.sleep"):
+        yield
+
+
+class TestSweepReplyComments:
+    def test_sweeps_each_recent_post(self):
+        from cqc_lem.app.run_automation import sweep_reply_comments
+        with patch(f"{_RA}.get_engagement_preferences", return_value={"reply_max_post_age_days": 3}), \
+             patch(f"{_RA}.get_recent_posted_post_ids", return_value=[10, 11, 12]) as grp, \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"), \
+             patch(f"{_RA}._reply_to_comments_on_open_post", return_value="Replied to 1 comments") as rep, \
+             patch(f"{_RA}.quit_gracefully") as quit_:
+            result = sweep_reply_comments.run(user_id=1)
+        grp.assert_called_once_with(1, days=3)
+        assert rep.call_count == 3
+        assert "3/3" in result
+        quit_.assert_called_once()
+
+    def test_no_recent_posts_short_circuits_without_session(self):
+        from cqc_lem.app.run_automation import sweep_reply_comments
+        with patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_recent_posted_post_ids", return_value=[]), \
+             patch(f"{_RA}.get_current_profile") as gcp:
+            result = sweep_reply_comments.run(user_id=1)
+        assert "No recent posts" in result
+        gcp.assert_not_called()
+
+    def test_rate_limited_session_returns_clean_skip(self):
+        from cqc_lem.app.run_automation import sweep_reply_comments
+        from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
+        with patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_recent_posted_post_ids", return_value=[10]), \
+             patch(f"{_RA}.get_current_profile", side_effect=LinkedInRateLimited("429")), \
+             patch(f"{_RA}.log_warning") as warn:
+            result = sweep_reply_comments.run(user_id=1)
+        assert "rate limited" in result.lower()
+        warn.assert_called_once()
+
+    def test_one_post_failure_does_not_abort_sweep(self):
+        from cqc_lem.app.run_automation import sweep_reply_comments
+        with patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_recent_posted_post_ids", return_value=[10, 11]), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"), \
+             patch(f"{_RA}._reply_to_comments_on_open_post", side_effect=[Exception("boom"), "ok"]), \
+             patch(f"{_RA}.log_warning"), \
+             patch(f"{_RA}.quit_gracefully"):
+            result = sweep_reply_comments.run(user_id=1)
+        assert "1/2" in result  # first post errored, second succeeded

--- a/tests/unit/app/test_run_automation_posting.py
+++ b/tests/unit/app/test_run_automation_posting.py
@@ -11,7 +11,8 @@ BASE_PATCHES = [
     ("cqc_lem.app.run_automation.get_post_content", {"return_value": "Post text"}),
     ("cqc_lem.app.run_automation.insert_new_log", {}),
     ("cqc_lem.app.run_automation.update_db_post_status", {}),
-    ("cqc_lem.app.run_automation.automate_reply_commenting", {}),
+    ("cqc_lem.app.run_automation.get_engagement_preferences", {"return_value": {"reply_check_mode": "event"}}),
+    ("cqc_lem.app.run_automation.sweep_reply_comments", {}),
 ]
 
 
@@ -82,6 +83,45 @@ class TestPostToLinkedinTypeBranching:
 
             mock_carousel.assert_called_once_with(1, "Post text", slides)
             mock_share.assert_not_called()
+
+    def test_event_mode_schedules_one_golden_hour_sweep(self):
+        from cqc_lem.utilities.db import PostType
+        from cqc_lem.app.run_automation import post_to_linkedin
+
+        with ExitStack() as stack:
+            for target, kwargs in BASE_PATCHES:
+                if target.endswith("sweep_reply_comments"):
+                    continue
+                stack.enter_context(patch(target, **kwargs))
+            mock_sweep = stack.enter_context(patch("cqc_lem.app.run_automation.sweep_reply_comments"))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_post_type", return_value=PostType.TEXT))
+            stack.enter_context(patch("cqc_lem.app.run_automation.share_on_linkedin", return_value="urn:li:ugcPost:1"))
+
+            post_to_linkedin.run(1, 10)
+
+            mock_sweep.apply_async.assert_called_once()
+            assert mock_sweep.apply_async.call_args.kwargs["kwargs"] == {"user_id": 1}
+            assert mock_sweep.apply_async.call_args.kwargs["countdown"] == 35 * 60
+
+    def test_scheduled_and_off_modes_schedule_no_per_post_sweep(self):
+        from cqc_lem.utilities.db import PostType
+        from cqc_lem.app.run_automation import post_to_linkedin
+
+        for mode in ("scheduled", "off"):
+            with ExitStack() as stack:
+                for target, kwargs in BASE_PATCHES:
+                    if target.endswith("get_engagement_preferences") or target.endswith("sweep_reply_comments"):
+                        continue
+                    stack.enter_context(patch(target, **kwargs))
+                stack.enter_context(patch("cqc_lem.app.run_automation.get_engagement_preferences",
+                                          return_value={"reply_check_mode": mode}))
+                mock_sweep = stack.enter_context(patch("cqc_lem.app.run_automation.sweep_reply_comments"))
+                stack.enter_context(patch("cqc_lem.app.run_automation.get_post_type", return_value=PostType.TEXT))
+                stack.enter_context(patch("cqc_lem.app.run_automation.share_on_linkedin", return_value="urn:li:ugcPost:1"))
+
+                post_to_linkedin.run(1, 10)
+
+                mock_sweep.apply_async.assert_not_called()
 
     def test_skips_already_posted(self):
         from cqc_lem.app.run_automation import post_to_linkedin

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -843,3 +843,57 @@ class TestAutoRefreshProfileSyntheses:
         syn.assert_not_called()
         setter.assert_not_called()
         assert "0/1" in result
+
+
+class TestDispatchScheduledReplySweeps:
+    _M = "cqc_lem.app.run_scheduler"
+
+    def test_dispatches_when_due_and_has_session(self):
+        from cqc_lem.app.run_scheduler import dispatch_scheduled_reply_sweeps
+        redis = MagicMock(); redis.set.return_value = True  # nx=True → key absent → due
+        with patch(f"{self._M}.get_users_with_reply_mode", return_value=[1, 2]), \
+             patch(f"{self._M}.has_linkedin_session", return_value=True), \
+             patch(f"{self._M}.get_engagement_preferences", return_value={"reply_sweeps_per_day": 4}), \
+             patch("cqc_lem.utilities.linkedin.rate_limit._redis_client", return_value=redis), \
+             patch(f"{self._M}.sweep_reply_comments") as sweep:
+            result = dispatch_scheduled_reply_sweeps()
+        assert sweep.apply_async.call_count == 2
+        assert "2/2" in result
+        # interval TTL for 4/day = 6h
+        assert redis.set.call_args.kwargs["ex"] == 6 * 60 * 60
+
+    def test_skips_when_interval_not_elapsed(self):
+        from cqc_lem.app.run_scheduler import dispatch_scheduled_reply_sweeps
+        redis = MagicMock(); redis.set.return_value = False  # key present → too soon
+        with patch(f"{self._M}.get_users_with_reply_mode", return_value=[1]), \
+             patch(f"{self._M}.has_linkedin_session", return_value=True), \
+             patch(f"{self._M}.get_engagement_preferences", return_value={"reply_sweeps_per_day": 2}), \
+             patch("cqc_lem.utilities.linkedin.rate_limit._redis_client", return_value=redis), \
+             patch(f"{self._M}.sweep_reply_comments") as sweep:
+            dispatch_scheduled_reply_sweeps()
+        sweep.apply_async.assert_not_called()
+
+    def test_skips_users_without_session(self):
+        from cqc_lem.app.run_scheduler import dispatch_scheduled_reply_sweeps
+        with patch(f"{self._M}.get_users_with_reply_mode", return_value=[1]), \
+             patch(f"{self._M}.has_linkedin_session", return_value=False), \
+             patch("cqc_lem.utilities.linkedin.rate_limit._redis_client", return_value=None), \
+             patch(f"{self._M}.sweep_reply_comments") as sweep:
+            dispatch_scheduled_reply_sweeps()
+        sweep.apply_async.assert_not_called()
+
+    def test_no_scheduled_users(self):
+        from cqc_lem.app.run_scheduler import dispatch_scheduled_reply_sweeps
+        with patch(f"{self._M}.get_users_with_reply_mode", return_value=[]):
+            assert "No scheduled-mode users" in dispatch_scheduled_reply_sweeps()
+
+    def test_caps_interval_floor_at_2h(self):
+        from cqc_lem.app.run_scheduler import dispatch_scheduled_reply_sweeps
+        redis = MagicMock(); redis.set.return_value = True
+        with patch(f"{self._M}.get_users_with_reply_mode", return_value=[1]), \
+             patch(f"{self._M}.has_linkedin_session", return_value=True), \
+             patch(f"{self._M}.get_engagement_preferences", return_value={"reply_sweeps_per_day": 12}), \
+             patch("cqc_lem.utilities.linkedin.rate_limit._redis_client", return_value=redis), \
+             patch(f"{self._M}.sweep_reply_comments"):
+            dispatch_scheduled_reply_sweeps()
+        assert redis.set.call_args.kwargs["ex"] == 2 * 60 * 60  # 12/day = 2h, the floor

--- a/tests/unit/utilities/linkedin/test_notification_email.py
+++ b/tests/unit/utilities/linkedin/test_notification_email.py
@@ -1,0 +1,61 @@
+"""Unit tests for the comment-notification email helpers (event-driven reply feature)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_M = "cqc_lem.utilities.linkedin.notification_email"
+
+
+class TestAddress:
+    def test_address_uses_env_parse_domain(self):
+        from cqc_lem.utilities.linkedin.notification_email import reply_inbound_address
+        with patch.dict("os.environ", {"LINKEDIN_PARSE_DOMAIN": "parse.example.com"}):
+            assert reply_inbound_address("tok123") == "reply+tok123@parse.example.com"
+
+    def test_token_round_trip(self):
+        from cqc_lem.utilities.linkedin.notification_email import (
+            reply_inbound_address, extract_reply_token_from_address)
+        with patch.dict("os.environ", {"LINKEDIN_PARSE_DOMAIN": "parse.example.com"}):
+            addr = reply_inbound_address("abc987")
+        assert extract_reply_token_from_address(addr) == "abc987"
+
+    def test_extract_from_envelope_json(self):
+        from cqc_lem.utilities.linkedin.notification_email import extract_reply_token_from_address
+        assert extract_reply_token_from_address('{"to":["reply+XY9@parse.example.com"]}') == "XY9"
+
+    def test_extract_none_when_absent(self):
+        from cqc_lem.utilities.linkedin.notification_email import extract_reply_token_from_address
+        assert extract_reply_token_from_address("noreply@linkedin.com") is None
+        assert extract_reply_token_from_address("") is None
+
+
+class TestIsCommentNotification:
+    @pytest.mark.parametrize("subject", [
+        "Chris, someone commented on your post",
+        "Jane Doe replied to your comment",
+        "New comment on your post",
+    ])
+    def test_comment_subjects_true(self, subject):
+        from cqc_lem.utilities.linkedin.notification_email import is_comment_notification
+        assert is_comment_notification(subject) is True
+
+    @pytest.mark.parametrize("subject", [
+        "Jane Doe liked your post",
+        "Your post reached 100 reactions",
+        "Chris, John reacted to your post",
+        "Jane mentioned you in a comment",  # mention, not a comment on our post
+    ])
+    def test_reaction_subjects_false(self, subject):
+        from cqc_lem.utilities.linkedin.notification_email import is_comment_notification
+        assert is_comment_notification(subject) is False
+
+    def test_body_signal_when_subject_neutral(self):
+        from cqc_lem.utilities.linkedin.notification_email import is_comment_notification
+        assert is_comment_notification("LinkedIn", "Jane Doe commented on your post: great work!") is True
+
+    def test_quoted_history_ignored(self):
+        from cqc_lem.utilities.linkedin.notification_email import is_comment_notification
+        body = "FYI\n> On Mon, someone commented on your post"
+        assert is_comment_notification("Weekly digest", body) is False

--- a/tests/unit/utilities/test_db_engagement_prefs.py
+++ b/tests/unit/utilities/test_db_engagement_prefs.py
@@ -91,6 +91,78 @@ class TestUpdateEngagementPreferences:
         assert "5 calls/mo" in params and "thought leader" in params
 
 
+class TestReplyCheckConfig:
+    def test_defaults_include_reply_config(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            prefs = get_engagement_preferences(1)
+        assert prefs["reply_check_mode"] == "event"
+        assert prefs["reply_sweeps_per_day"] == 2
+        assert prefs["reply_max_post_age_days"] == 2
+
+    def test_clamps_bad_mode_and_out_of_range_numbers(self):
+        conn, cursor = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_engagement_preferences
+            update_engagement_preferences(3, {
+                "reply_check_mode": "bogus", "reply_sweeps_per_day": 99, "reply_max_post_age_days": 0})
+        cols = list(__import__("cqc_lem.utilities.db", fromlist=["_ENGAGEMENT_COLS"])._ENGAGEMENT_COLS)
+        params = cursor.execute.call_args[0][1]
+        # params = [user_id] + one per col, in _ENGAGEMENT_COLS order
+        by_col = dict(zip(cols, params[1:]))
+        assert by_col["reply_check_mode"] == "event"      # bad → safe default
+        assert by_col["reply_sweeps_per_day"] == 12        # clamped to max
+        assert by_col["reply_max_post_age_days"] == 1      # clamped to min
+
+    def test_valid_mode_and_floor_preserved(self):
+        conn, cursor = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_engagement_preferences
+            update_engagement_preferences(3, {"reply_check_mode": "scheduled", "reply_sweeps_per_day": 1})
+        cols = list(__import__("cqc_lem.utilities.db", fromlist=["_ENGAGEMENT_COLS"])._ENGAGEMENT_COLS)
+        by_col = dict(zip(cols, cursor.execute.call_args[0][1][1:]))
+        assert by_col["reply_check_mode"] == "scheduled"
+        assert by_col["reply_sweeps_per_day"] == 2          # floor
+
+
+class TestReplyInboundToken:
+    def test_returns_existing_token(self):
+        conn, cursor = _mock_conn(fetch_row=("existingtoken",))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_or_create_reply_inbound_token
+            assert get_or_create_reply_inbound_token(1) == "existingtoken"
+        # no UPDATE issued when a token already exists
+        assert all("UPDATE" not in (c.args[0] if c.args else "") for c in cursor.execute.call_args_list)
+
+    def test_mints_when_missing(self):
+        conn, cursor = _mock_conn(fetch_row=(None,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_or_create_reply_inbound_token
+            token = get_or_create_reply_inbound_token(1)
+        assert token and len(token) == 20
+        assert any("UPDATE users SET reply_inbound_token" in (c.args[0] if c.args else "")
+                   for c in cursor.execute.call_args_list)
+
+    def test_reverse_lookup(self):
+        conn, _ = _mock_conn(fetch_row=(42,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_id_by_reply_token
+            assert get_user_id_by_reply_token("abc") == 42
+
+    def test_reverse_lookup_empty_token(self):
+        from cqc_lem.utilities.db import get_user_id_by_reply_token
+        assert get_user_id_by_reply_token("") is None
+
+    def test_users_with_reply_mode(self):
+        conn, cursor = _mock_conn()
+        cursor.fetchall.return_value = [(1,), (5,), (9,)]
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_users_with_reply_mode
+            assert get_users_with_reply_mode("scheduled") == [1, 5, 9]
+        assert "reply_check_mode = %s" in cursor.execute.call_args[0][0]
+
+
 class TestCountActions:
     def test_count_comments_today(self):
         conn, cursor = _mock_conn(fetch_row=(3,))


### PR DESCRIPTION
## Problem

The reply/comment follow-up loop (`automate_reply_commenting`, started by `post_to_linkedin` with `loop_for_duration=24h`) logged into LinkedIn in a real browser every 5→10→15→30→60 min **for 24h per post** through one residential proxy IP — a primary driver of the HTTP 429 rate-limiting currently blocking the account. It also served the golden hour poorly and **died permanently on the first 429** (returned before the re-queue block).

## What this does

Makes reply/comment follow-up **configurable per user** (`engagement_preferences.reply_check_mode`) and far less chatty:

- **event** (new default): the user forwards LinkedIn "commented on your post" emails (Gmail filter) to a tokenized address `reply+<token>@parse.<domain>` that **SendGrid Inbound Parse** (already used by the login-PIN flow) pipes to `POST /api/linkedin/comment-notification/inbound`. A comment (not a reaction) triggers a **debounced** recent-posts reply sweep — no polling, no 429. Plus **one** golden-hour safety sweep per post.
- **scheduled**: a beat dispatcher runs a recent-posts sweep `reply_sweeps_per_day` times/day (floor 2, cap 12), gated by a per-user Redis interval key. UI shows a 429 warning.
- **off**: nothing.

All modes share one reusable `sweep_reply_comments` task (one Selenium session over `get_recent_posted_post_ids`), which sidesteps the fragile `urn:li:activity`→`urn:li:share` email-to-post mapping (the email only needs to identify the *user* + that it's a comment).

Also **fixes the 429-kills-the-loop bug**: both reply tasks now catch `LinkedInRateLimited` and skip cleanly.

## Reused (not rebuilt)

SendGrid inbound-parse + tokenized-address pattern (`verification_pin.py`), `get_recent_posted_post_ids`, the reply mechanics (`_comment_items_from_thread`/`_reply_to_comment_inline`/`generate_thread_reply`), the Redis helper, and the engagement-prefs config/UI plumbing.

## Changes

- **V55 migration**: `engagement_preferences` (reply_check_mode/reply_sweeps_per_day/reply_max_post_age_days) + `users.reply_inbound_token` (unique).
- **db**: config fields + clamps; `get_or_create_reply_inbound_token`, `get_user_id_by_reply_token`, `get_users_with_reply_mode`.
- **run_automation**: `sweep_reply_comments`, `_reply_to_comments_on_open_post` (extracted), 429-safe reply tasks, mode-branched `post_to_linkedin` dispatch (retires the 24h loop).
- **notification_email.py**: address + comment-vs-reaction classifier.
- **api/main.py**: comment-notification webhook (+ debounce) + prefs fields/validators + `reply_inbound_address` on GET.
- **run_scheduler.py + my_celery.py**: `dispatch_scheduled_reply_sweeps` (beat every 30m).
- **UI**: reply-mode selector (event address+copy / scheduled frequency + 429 warning).
- **docs/REPLY_NOTIFICATIONS.md**: Gmail forward + LinkedIn email-notification setup.

## Tests

2470 unit tests pass. New coverage for the reply helper, sweep (429-safe), dispatcher cadence, webhook (comment/reaction/unknown-token/debounce), and db/API config clamps + token getters.

## Verification notes

- V55 applies via Flyway at deploy (not run against prod DB manually).
- Webhook can be exercised with a `curl -F to='reply+<token>@parse.<domain>' -F subject='... commented on your post' ...` once deployed.
- Parser subject/body heuristics should be grounded against one real forwarded LinkedIn comment-notification email and tightened if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)