### PR TITLE
feat(rate-limit): adaptive 429 back-off + manual automation pause (break the doom loop)

### DIFF
--- a/docs/AUTOMATION_COOLDOWN.md
+++ b/docs/AUTOMATION_COOLDOWN.md
@@ -1,0 +1,40 @@
+# Automation cooldown & pause (LinkedIn 429 recovery)
+
+LinkedIn rate-limits by egress IP. When the account's residential proxy gets 429'd, every Selenium
+task that navigates LinkedIn re-confirms the throttle. Two mechanisms keep this from becoming a
+self-sustaining doom loop and let a throttled account recover.
+
+## 1. Adaptive circuit-breaker escalation (automatic)
+
+`utilities/linkedin/rate_limit.py` tracks **consecutive** 429 trips (a Redis counter cleared only by a
+successful login). Each trip doubles the breaker cooldown — base → 2× → 4× … up to a cap — so we probe
+LinkedIn less and less often instead of re-tripping every 30 min.
+
+- `LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS` — base cooldown (default 1800 = 30 min).
+- `LINKEDIN_RATE_LIMIT_MAX_COOLDOWN_SECONDS` — escalation cap (default 21600 = 6 h).
+- A successful login calls `clear_rate_limit()` which resets both the breaker and the trip counter.
+
+## 2. Manual global pause (operator kill-switch)
+
+Halts ALL Selenium automation (feed commenting, replies, DMs, stats, invites) for a window so the IP
+can recover. **Posting is API-driven and NOT paused.** Enforced centrally in `login_to_linkedin`
+(every Selenium task logs in through it) and short-circuited early by the high-volume beat dispatchers
+(`_skip_if_paused` in `run_scheduler.py`). Redis-backed with a TTL; fails open (no Redis → not paused).
+
+Admin API (requires the `X-Admin-Secret` header = `ADMIN_SECRET`):
+
+```
+POST /api/admin/automation-pause?hours=24   # pause for N hours (default 24)
+POST /api/admin/automation-resume           # lift immediately
+GET  /api/admin/automation-status           # { paused, pause_remaining_s, breaker_remaining_s }
+```
+
+Helpers: `pause_automation(seconds, reason)`, `resume_automation()`, `is_automation_paused()`,
+`automation_pause_remaining()` in `utilities/linkedin/rate_limit.py`.
+
+## When to use
+
+If the account is 429'd for an extended period (login fails even when the breaker briefly clears),
+`POST /api/admin/automation-pause?hours=24` to stop probing entirely, let LinkedIn's throttle relax,
+then `automation-resume`. Pair with reducing overall automation cadence (e.g. reply-check
+`event` mode, fewer scheduled sweeps).

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -2287,6 +2287,43 @@ def _require_api_and_admin(
         raise HTTPException(status_code=403, detail="Forbidden — missing or invalid X-Admin-Secret")
 
 
+@router.post("/admin/automation-pause", responses={200: {"description": "Automation paused"},
+                                                    403: {"description": "Forbidden"}})
+def admin_pause_automation(hours: float = 24,
+                           x_admin_secret: Optional[str] = Header(default=None)) -> ResponseModel:
+    """Kill-switch: pause ALL Selenium automation (comments/replies/DMs/stats/invites) for `hours` so
+    a 429-rate-limited account/IP can recover. Posting (API) is unaffected. Default 24h."""
+    _require_admin(x_admin_secret)
+    from cqc_lem.utilities.linkedin.rate_limit import pause_automation
+    seconds = int(max(0.0, hours) * 3600) or 3600
+    ok = pause_automation(seconds, reason="admin")
+    return ResponseModel(status_code=200, detail={"paused": ok, "seconds": seconds})
+
+
+@router.post("/admin/automation-resume", responses={200: {"description": "Automation resumed"},
+                                                     403: {"description": "Forbidden"}})
+def admin_resume_automation(x_admin_secret: Optional[str] = Header(default=None)) -> ResponseModel:
+    """Lift a manual automation pause immediately."""
+    _require_admin(x_admin_secret)
+    from cqc_lem.utilities.linkedin.rate_limit import resume_automation
+    return ResponseModel(status_code=200, detail={"resumed": resume_automation()})
+
+
+@router.get("/admin/automation-status", responses={200: {"description": "Automation status"},
+                                                   403: {"description": "Forbidden"}})
+def admin_automation_status(x_admin_secret: Optional[str] = Header(default=None)) -> ResponseModel:
+    """Current pause + 429-breaker state (seconds remaining on each)."""
+    _require_admin(x_admin_secret)
+    from cqc_lem.utilities.linkedin.rate_limit import (
+        automation_pause_remaining, rate_limit_cooldown_remaining)
+    pause_s = automation_pause_remaining()
+    return ResponseModel(status_code=200, detail={
+        "paused": pause_s > 0,
+        "pause_remaining_s": pause_s,
+        "breaker_remaining_s": rate_limit_cooldown_remaining(),
+    })
+
+
 @router.post("/admin/fix-video-urls", responses={
     200: {"description": "Video URLs updated"},
     403: {"description": "Forbidden"},

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -18,7 +18,19 @@ from cqc_lem.utilities.db import (
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES
 from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
+from cqc_lem.utilities.linkedin.rate_limit import is_automation_paused, automation_pause_remaining
 from cqc_lem.utilities.notifications import notify_linkedin_session
+
+
+def _skip_if_paused(name: str) -> bool:
+    """True when a manual automation pause is active — Selenium fan-out beat tasks short-circuit on
+    it so a recovering rate-limited account isn't hammered (login_to_linkedin also gates centrally,
+    but skipping here avoids spinning up Chrome sessions that would only fail). POSTING is API-driven
+    and deliberately NOT gated."""
+    if is_automation_paused():
+        log_info(f"{name} skipped — automation paused (~{automation_pause_remaining()}s left)")
+        return True
+    return False
 
 
 
@@ -129,6 +141,8 @@ def auto_check_scheduled_dms(self):
 
 @shared_task.task
 def auto_appreciate_dms():
+    if _skip_if_paused("auto_appreciate_dms"):
+        return "Automation paused"
     # For each user schedule appreciate DMS
     users = get_active_user_ids()
 
@@ -160,6 +174,8 @@ def auto_daily_engagement():
     because both this run and the pre-post runs share the per-day comment cap (enforced in
     comment_on_feed_inline), and QueueOnce (keys=['user_id']) prevents overlapping double-runs for
     the same user."""
+    if _skip_if_paused("auto_daily_engagement"):
+        return "Automation paused"
     users = get_active_user_ids()
     dispatched = 0
     for user_id in users:
@@ -457,6 +473,8 @@ def auto_sync_groups():
 @shared_task.task
 def auto_group_engagement():
     """Daily value-add commenting in each active user's ENABLED groups (shares the per-day cap)."""
+    if _skip_if_paused("auto_group_engagement"):
+        return "Automation paused"
     from cqc_lem.app.run_automation import auto_comment_in_groups
     users = get_active_user_ids()
     n = 0
@@ -487,6 +505,8 @@ def auto_group_posts():
 @shared_task.task
 def auto_scrape_stats():
     """Daily: capture engagement stats on each active user's recent posts (powers post-time recs)."""
+    if _skip_if_paused("auto_scrape_stats"):
+        return "Automation paused"
     from cqc_lem.app.run_automation import auto_scrape_post_stats
     users = get_active_user_ids()
     n = 0
@@ -500,6 +520,8 @@ def auto_scrape_stats():
 @shared_task.task
 def auto_send_due_followups():
     """Dispatch a per-user Selenium task to send due DM follow-ups (each gated by reply-detection)."""
+    if _skip_if_paused("auto_send_due_followups"):
+        return "Automation paused"
     from cqc_lem.app.run_automation import process_user_followups
     from cqc_lem.utilities.db import get_due_followups
     # due_at is stored naive-UTC; compare against naive-UTC now (not container-local time).
@@ -603,6 +625,8 @@ def auto_clean_stale_profiles():
 @shared_task.task
 def auto_invite_to_company_pages():
     """Start invite process for each active user who has a linked in company page"""
+    if _skip_if_paused("auto_invite_to_company_pages"):
+        return "Automation paused"
 
     # Get all active users and loop through them
     users = get_active_user_ids()

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -7,7 +7,7 @@ from cqc_lem.utilities.db import get_cookies, store_cookies, get_linked_in_profi
     get_linked_in_profile_by_url, get_linked_in_profile_by_user_id
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited, clear_rate_limit, \
-    mark_rate_limited, rate_limit_cooldown_remaining
+    mark_rate_limited, rate_limit_cooldown_remaining, is_automation_paused, automation_pause_remaining
 from cqc_lem.utilities.linkedin.scrapper import returnProfileInfo
 from cqc_lem.utilities.logger import myprint, log_warning, log_error
 from cqc_lem.utilities.selenium_util import load_cookies, get_element_wait_retry, \
@@ -349,6 +349,12 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
         if _wait_for_manual_approval():
             return
         raise RuntimeError(f"Unsolvable LinkedIn challenge at {label}: {driver.current_url}")
+
+    # Manual global pause: a kill-switch to let a rate-limited account recover. Central gate —
+    # every Selenium task logs in through here, so a pause halts all of them without navigating.
+    if is_automation_paused():
+        raise LinkedInRateLimited(
+            f"Automation is paused for ~{automation_pause_remaining()}s — skipping login.")
 
     # Shared 429 circuit breaker: if a recent task already hit LinkedIn's rate limit,
     # don't navigate at all — re-hitting the feed while throttled prolongs the block.

--- a/src/cqc_lem/utilities/linkedin/rate_limit.py
+++ b/src/cqc_lem/utilities/linkedin/rate_limit.py
@@ -14,14 +14,18 @@ import os
 from cqc_lem.utilities.logger import log_warning
 
 _COOLDOWN_KEY = "linkedin:429_cooldown"
+_TRIP_COUNT_KEY = "linkedin:429_trip_count"   # consecutive trips → escalating cooldown
+_PAUSE_KEY = "linkedin:automation_paused"     # manual global Selenium pause
 _DEFAULT_COOLDOWN_SECONDS = 1800  # 30 min
+_DEFAULT_MAX_COOLDOWN_SECONDS = 6 * 60 * 60  # cap the escalation at 6h
+_TRIP_COUNT_TTL = 24 * 60 * 60  # remember consecutive trips for a day
 
 
 class LinkedInRateLimited(RuntimeError):
     """LinkedIn is rate-limiting this session (HTTP 429) — back off before retrying.
 
     Subclasses RuntimeError so existing broad handlers keep treating it as a fatal,
-    back-off-worthy login failure.
+    back-off-worthy login failure. Also raised when automation is manually paused.
     """
 
 
@@ -30,6 +34,13 @@ def _cooldown_seconds() -> int:
         return int(os.getenv("LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS", str(_DEFAULT_COOLDOWN_SECONDS)))
     except ValueError:
         return _DEFAULT_COOLDOWN_SECONDS
+
+
+def _max_cooldown_seconds() -> int:
+    try:
+        return int(os.getenv("LINKEDIN_RATE_LIMIT_MAX_COOLDOWN_SECONDS", str(_DEFAULT_MAX_COOLDOWN_SECONDS)))
+    except ValueError:
+        return _DEFAULT_MAX_COOLDOWN_SECONDS
 
 
 def _redis_client():
@@ -54,14 +65,24 @@ def _redis_client():
 
 
 def mark_rate_limited(reason: str = "") -> None:
-    seconds = _cooldown_seconds()
     client = _redis_client()
     if client is None:
         return
     try:
+        # Escalating back-off: each CONSECUTIVE trip (counter cleared only by a successful login)
+        # doubles the cooldown — base, 2x, 4x, … up to a cap. A fixed 30-min cooldown meant that as
+        # soon as it expired some task probed LinkedIn, drew a fresh 429 and re-tripped it every
+        # ~30 min forever (the doom loop). Escalation probes less and less often so the throttled IP
+        # can actually recover.
+        try:
+            trips = int(client.incr(_TRIP_COUNT_KEY))
+            client.expire(_TRIP_COUNT_KEY, _TRIP_COUNT_TTL)
+        except Exception:
+            trips = 1
+        seconds = min(_max_cooldown_seconds(), _cooldown_seconds() * (2 ** max(0, trips - 1)))
         client.set(_COOLDOWN_KEY, reason or "429", ex=seconds)
-        log_warning(f"LinkedIn 429 circuit breaker OPEN for {seconds}s — Selenium engagement paused",
-                    action_type="rate_limit", http_status=429)
+        log_warning(f"LinkedIn 429 circuit breaker OPEN for {seconds}s (consecutive trip #{trips}) "
+                    "— Selenium engagement paused", action_type="rate_limit", http_status=429)
     except Exception as e:
         log_warning("Failed to set LinkedIn 429 circuit breaker", exc=e, action_type="rate_limit")
 
@@ -79,10 +100,60 @@ def rate_limit_cooldown_remaining() -> int:
 
 
 def clear_rate_limit() -> None:
+    """Close the breaker AND reset the consecutive-trip counter — called on a successful login, so
+    the next 429 (if any) starts the escalation from the base cooldown again."""
     client = _redis_client()
     if client is None:
         return
     try:
-        client.delete(_COOLDOWN_KEY)
+        client.delete(_COOLDOWN_KEY, _TRIP_COUNT_KEY)
     except Exception:
         pass
+
+
+# --- Manual global automation pause -------------------------------------------------
+# A kill-switch to halt ALL Selenium automation (feed commenting, replies, DMs, stats, invites) for
+# a set window so a rate-limited account/IP can recover. Enforced centrally in login_to_linkedin
+# (every Selenium task logs in) and short-circuited by the high-volume beat dispatchers. Redis-backed
+# with a TTL so it auto-expires; fails open (no Redis → not paused) like the breaker.
+
+def pause_automation(seconds: int, reason: str = "manual") -> bool:
+    """Pause all Selenium automation for `seconds`. Returns True if the pause was stored."""
+    client = _redis_client()
+    if client is None:
+        return False
+    try:
+        client.set(_PAUSE_KEY, reason or "manual", ex=max(1, int(seconds)))
+        log_warning(f"Automation PAUSED for {int(seconds)}s (reason: {reason})", action_type="rate_limit")
+        return True
+    except Exception as e:
+        log_warning("Failed to set automation pause", exc=e, action_type="rate_limit")
+        return False
+
+
+def resume_automation() -> bool:
+    """Lift a manual pause immediately. Returns True on success (or no-op when nothing was paused)."""
+    client = _redis_client()
+    if client is None:
+        return False
+    try:
+        client.delete(_PAUSE_KEY)
+        return True
+    except Exception:
+        return False
+
+
+def automation_pause_remaining() -> int:
+    """Seconds left on a manual pause, or 0 if not paused / Redis unavailable."""
+    client = _redis_client()
+    if client is None:
+        return 0
+    try:
+        ttl = client.ttl(_PAUSE_KEY)
+    except Exception:
+        return 0
+    return ttl if ttl and ttl > 0 else 0
+
+
+def is_automation_paused() -> bool:
+    return automation_pause_remaining() > 0

--- a/tests/unit/api/test_api_coverage_misc.py
+++ b/tests/unit/api/test_api_coverage_misc.py
@@ -500,6 +500,35 @@ class TestAdminEndpoints:
                 "old_base": "http://a", "new_base": "http://b"})
         assert resp.status_code == 403
 
+    def test_automation_pause(self, client):
+        with patch(f"{_M}.ADMIN_SECRET", "sekret"), \
+             patch("cqc_lem.utilities.linkedin.rate_limit.pause_automation", return_value=True) as pause:
+            resp = client.post("/api/admin/automation-pause?hours=6", headers=self._HDR)
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == {"paused": True, "seconds": 6 * 3600}
+        assert pause.call_args[0][0] == 6 * 3600
+
+    def test_automation_pause_forbidden_without_secret(self, client):
+        with patch(f"{_M}.ADMIN_SECRET", "sekret"):
+            resp = client.post("/api/admin/automation-pause", headers={})
+        assert resp.status_code == 403
+
+    def test_automation_resume(self, client):
+        with patch(f"{_M}.ADMIN_SECRET", "sekret"), \
+             patch("cqc_lem.utilities.linkedin.rate_limit.resume_automation", return_value=True):
+            resp = client.post("/api/admin/automation-resume", headers=self._HDR)
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == {"resumed": True}
+
+    def test_automation_status(self, client):
+        with patch(f"{_M}.ADMIN_SECRET", "sekret"), \
+             patch("cqc_lem.utilities.linkedin.rate_limit.automation_pause_remaining", return_value=120), \
+             patch("cqc_lem.utilities.linkedin.rate_limit.rate_limit_cooldown_remaining", return_value=900):
+            resp = client.get("/api/admin/automation-status", headers=self._HDR)
+        assert resp.status_code == 200
+        d = resp.json()["detail"]
+        assert d == {"paused": True, "pause_remaining_s": 120, "breaker_remaining_s": 900}
+
     def test_fix_video_urls(self, client):
         with patch(f"{_M}.ADMIN_SECRET", "sekret"), \
              patch(f"{_M}.replace_video_url_base", return_value=3) as rep:

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -843,3 +843,32 @@ class TestAutoRefreshProfileSyntheses:
         syn.assert_not_called()
         setter.assert_not_called()
         assert "0/1" in result
+
+
+class TestAutomationPauseGating:
+    _M = "cqc_lem.app.run_scheduler"
+
+    def test_daily_engagement_skips_when_paused(self):
+        from cqc_lem.app.run_scheduler import auto_daily_engagement
+        with patch(f"{self._M}.is_automation_paused", return_value=True), \
+             patch(f"{self._M}.automation_pause_remaining", return_value=999), \
+             patch(f"{self._M}.get_active_user_ids") as users:
+            result = auto_daily_engagement()
+        assert "paused" in result.lower()
+        users.assert_not_called()  # short-circuits before fanning out any Selenium work
+
+    def test_appreciate_dms_skips_when_paused(self):
+        from cqc_lem.app.run_scheduler import auto_appreciate_dms
+        with patch(f"{self._M}.is_automation_paused", return_value=True), \
+             patch(f"{self._M}.automation_pause_remaining", return_value=1), \
+             patch(f"{self._M}.get_active_user_ids") as users:
+            result = auto_appreciate_dms()
+        assert "paused" in result.lower()
+        users.assert_not_called()
+
+    def test_runs_normally_when_not_paused(self):
+        from cqc_lem.app.run_scheduler import auto_daily_engagement
+        with patch(f"{self._M}.is_automation_paused", return_value=False), \
+             patch(f"{self._M}.get_active_user_ids", return_value=[]):
+            result = auto_daily_engagement()
+        assert "paused" not in result.lower()

--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -29,6 +29,7 @@ def _breaker_closed():
     never touch Redis. Tests exercising the breaker patch these explicitly."""
     with patch(f"{_MODULE}.rate_limit_cooldown_remaining", return_value=0), \
          patch(f"{_MODULE}.mark_rate_limited"), \
+         patch(f"{_MODULE}.is_automation_paused", return_value=False), \
          patch(f"{_MODULE}.clear_rate_limit"):
         yield
 
@@ -481,6 +482,22 @@ class TestRateLimitCircuitBreaker:
              patch(f"{_MODULE}.mark_rate_limited"), patch(f"{_MODULE}.clear_rate_limit"), \
              patch(f"{_MODULE}.get_cookies") as mock_cookies, \
              pytest.raises(LinkedInRateLimited, match="circuit breaker open"):
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "u@e.com", "pw")
+
+        driver.get.assert_not_called()
+        mock_cookies.assert_not_called()
+
+    def test_paused_automation_skips_navigation(self):
+        """A manual automation pause must halt login before touching LinkedIn."""
+        driver = _make_driver("https://www.linkedin.com/feed/")
+        wait = _make_wait()
+        from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
+
+        with patch(f"{_MODULE}.is_automation_paused", return_value=True), \
+             patch(f"{_MODULE}.automation_pause_remaining", return_value=3600), \
+             patch(f"{_MODULE}.get_cookies") as mock_cookies, \
+             pytest.raises(LinkedInRateLimited, match="paused"):
             from cqc_lem.utilities.linkedin.helper import login_to_linkedin
             login_to_linkedin(driver, wait, "u@e.com", "pw")
 

--- a/tests/unit/utilities/linkedin/test_rate_limit.py
+++ b/tests/unit/utilities/linkedin/test_rate_limit.py
@@ -35,9 +35,34 @@ class TestCooldownSeconds:
 class TestMarkRateLimited:
     def test_sets_key_with_ttl(self, fake_redis, monkeypatch):
         monkeypatch.setenv("LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS", "120")
+        fake_redis.incr.return_value = 1  # first trip → base cooldown
         from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited
         mark_rate_limited("boom")
         fake_redis.set.assert_called_once_with("linkedin:429_cooldown", "boom", ex=120)
+
+    def test_consecutive_trips_escalate_cooldown(self, fake_redis, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS", "100")
+        monkeypatch.delenv("LINKEDIN_RATE_LIMIT_MAX_COOLDOWN_SECONDS", raising=False)
+        from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited
+        for trip, expected in [(1, 100), (2, 200), (3, 400), (4, 800)]:
+            fake_redis.incr.return_value = trip
+            mark_rate_limited("x")
+            assert fake_redis.set.call_args.kwargs["ex"] == expected
+
+    def test_escalation_capped(self, fake_redis, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS", "1800")
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_MAX_COOLDOWN_SECONDS", "21600")  # 6h
+        fake_redis.incr.return_value = 20  # 1800 * 2^19 >> cap
+        from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited
+        mark_rate_limited("x")
+        assert fake_redis.set.call_args.kwargs["ex"] == 21600
+
+    def test_trip_counter_incremented_and_expired(self, fake_redis):
+        fake_redis.incr.return_value = 1
+        from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited
+        mark_rate_limited("x")
+        fake_redis.incr.assert_called_once_with("linkedin:429_trip_count")
+        fake_redis.expire.assert_called_once()
 
     def test_defaults_reason(self, fake_redis):
         from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited
@@ -80,10 +105,10 @@ class TestCooldownRemaining:
 
 
 class TestClearRateLimit:
-    def test_deletes_key(self, fake_redis):
+    def test_deletes_cooldown_and_trip_counter(self, fake_redis):
         from cqc_lem.utilities.linkedin.rate_limit import clear_rate_limit
         clear_rate_limit()
-        fake_redis.delete.assert_called_once_with("linkedin:429_cooldown")
+        fake_redis.delete.assert_called_once_with("linkedin:429_cooldown", "linkedin:429_trip_count")
 
     def test_no_redis_is_noop(self):
         with patch(f"{_MOD}._redis_client", return_value=None):
@@ -126,3 +151,41 @@ class TestRedisClientSelection:
             import importlib
             mod = importlib.import_module(_MOD)
             assert mod._redis_client() is None
+
+
+class TestAutomationPause:
+    def test_pause_sets_key_with_ttl(self, fake_redis):
+        from cqc_lem.utilities.linkedin.rate_limit import pause_automation
+        assert pause_automation(3600, reason="admin") is True
+        fake_redis.set.assert_called_once_with("linkedin:automation_paused", "admin", ex=3600)
+
+    def test_pause_floors_seconds_at_one(self, fake_redis):
+        from cqc_lem.utilities.linkedin.rate_limit import pause_automation
+        pause_automation(0)
+        assert fake_redis.set.call_args.kwargs["ex"] == 1
+
+    def test_pause_no_redis_returns_false(self):
+        with patch(f"{_MOD}._redis_client", return_value=None):
+            from cqc_lem.utilities.linkedin.rate_limit import pause_automation
+            assert pause_automation(60) is False
+
+    def test_resume_deletes_key(self, fake_redis):
+        from cqc_lem.utilities.linkedin.rate_limit import resume_automation
+        assert resume_automation() is True
+        fake_redis.delete.assert_called_once_with("linkedin:automation_paused")
+
+    def test_remaining_and_is_paused(self, fake_redis):
+        fake_redis.ttl.return_value = 500
+        from cqc_lem.utilities.linkedin.rate_limit import automation_pause_remaining, is_automation_paused
+        assert automation_pause_remaining() == 500
+        assert is_automation_paused() is True
+
+    def test_not_paused_when_key_absent(self, fake_redis):
+        fake_redis.ttl.return_value = -2
+        from cqc_lem.utilities.linkedin.rate_limit import is_automation_paused
+        assert is_automation_paused() is False
+
+    def test_not_paused_when_no_redis(self):
+        with patch(f"{_MOD}._redis_client", return_value=None):
+            from cqc_lem.utilities.linkedin.rate_limit import is_automation_paused
+            assert is_automation_paused() is False


### PR DESCRIPTION
## Problem

LinkedIn rate-limits by egress IP. The account's residential proxy has been HTTP-429'd **continuously for ~20h** — a self-sustaining doom loop: the fixed 30-min breaker cooldown meant that as soon as it expired, some scheduled Selenium task probed LinkedIn, drew a fresh 429, and re-tripped it. The throttle never got a chance to relax.

## What this does

Two mechanisms to break the loop and let a throttled account recover:

### 1. Adaptive circuit-breaker escalation (automatic)
`rate_limit.py` now tracks **consecutive** 429 trips (Redis counter, reset only by a successful login). Each trip **doubles** the breaker cooldown — base → 2× → 4× … — up to a cap. So we probe LinkedIn less and less often instead of every 30 min.
- `LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS` (base, default 1800) · `LINKEDIN_RATE_LIMIT_MAX_COOLDOWN_SECONDS` (cap, default 21600 = 6h).
- `clear_rate_limit()` (on successful login) resets both breaker + trip counter.

### 2. Manual global pause (operator kill-switch)
Halts ALL Selenium automation (comments/replies/DMs/stats/invites) for a window so the IP recovers. **Posting is API-driven and NOT paused.** Enforced centrally in `login_to_linkedin` (every Selenium task logs in through it) and short-circuited early by the high-volume beat dispatchers (`_skip_if_paused`). Redis-backed with TTL, fails open.

Admin API (needs `X-Admin-Secret`):
```
POST /api/admin/automation-pause?hours=24
POST /api/admin/automation-resume
GET  /api/admin/automation-status   # { paused, pause_remaining_s, breaker_remaining_s }
```

## Changes

- `utilities/linkedin/rate_limit.py`: escalation in `mark_rate_limited`; `clear_rate_limit` resets the counter; `pause_automation`/`resume_automation`/`is_automation_paused`/`automation_pause_remaining`.
- `utilities/linkedin/helper.py`: `login_to_linkedin` raises when paused (before any navigation).
- `app/run_scheduler.py`: `_skip_if_paused` guard on the daily Selenium fan-out beat tasks.
- `api/main.py`: pause/resume/status admin endpoints.
- `docs/AUTOMATION_COOLDOWN.md`.

## Tests

2442 unit tests pass. New coverage for escalation (doubling + cap + counter), pause/resume/status helpers, the login pause-gate (no navigation when paused), the scheduler guards, and the admin endpoints.

## Usage for the current incident

Once deployed: `POST /api/admin/automation-pause?hours=24` to stop probing entirely, let LinkedIn's throttle relax, then `automation-resume`. Complements PR #345 (event-driven replies) — together they sharply cut the Selenium volume driving the 429s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)