### PR TITLE
fix(content): enforce LinkedIn readability + length on carousel captions

### DIFF
--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -27,7 +27,8 @@ from cqc_lem.utilities.ai.content_alignment import (
 from cqc_lem.utilities.ai.content_research import research_topic
 from cqc_lem.utilities.ai.tools import search_recent_news, search_with_perplexity
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
-from cqc_lem.utilities.linkedin_formatter import normalize_public_text, PLAIN_PUNCTUATION_DIRECTIVE
+from cqc_lem.utilities.linkedin_formatter import normalize_public_text, PLAIN_PUNCTUATION_DIRECTIVE, \
+    linkedin_post_format_directive, enforce_post_readability
 from cqc_lem.utilities.logger import myprint, log_debug, log_error, log_warning
 from cqc_lem.utilities.utils import create_folder_if_not_exists, save_video_url_to_dir
 from cqc_lem.utilities.env_constants import DEFAULT_VIDEO_MODEL, DEFAULT_IMAGE_MODEL, DEFAULT_IMAGE_RATIO
@@ -2641,6 +2642,11 @@ def ai_check_message_history(message_history_json: str, main_focus: str, message
     return content
 
 
+# Carousel captions are an INTRO to the slides, so keep them well under LinkedIn's 3000-char hard
+# limit; this is both the prompt target and the deterministic post-generation cap.
+_CAROUSEL_CAPTION_MAX_CHARS = 2200
+
+
 def generate_carousel_content(user_id: int, stage: str, prefs: dict = None,
                               profile_synthesis: str = None) -> tuple[str, dict]:
     """Generate structured carousel content using AI and return (post_text, carousel_dict).
@@ -2718,10 +2724,15 @@ def generate_carousel_content(user_id: int, stage: str, prefs: dict = None,
                      if (not prefs or prefs.get("use_hashtags"))
                      else "Do NOT include any hashtags.")
 
+    # Shared LinkedIn formatting/QA best practices + a hard length cap for the caption (carousels
+    # previously had NO length or formatting enforcement — one post came back as a 3400-char wall).
+    _CAROUSEL_FORMAT_DIRECTIVE = linkedin_post_format_directive(_CAROUSEL_CAPTION_MAX_CHARS)
+
     prompt = f"""You are a LinkedIn content strategist creating a visual carousel post for a {job_title} in the {industry} industry at the {stage} stage of the buyer journey.
 
 Create two things and return them as a single JSON object with these top-level keys:
-1. "post_text": A compelling 1300-2000 character LinkedIn post that introduces the carousel. Use line breaks for readability. {_hashtag_rule} Do NOT use markdown syntax — no **bold**, no *italic*, no # headers.
+1. "post_text": A compelling LinkedIn post (about 1300-2000 characters) that introduces the carousel. {_hashtag_rule}
+   In the JSON string, separate paragraphs with a real "\\n\\n" so it is scannable, not one block. {_CAROUSEL_FORMAT_DIRECTIVE}
 2. "carousel": A JSON object matching the {schema_hint}. Each slide's "title" should be 3-8 words. Each slide's "content" should be 1-3 engaging sentences (max 200 chars).
 
 Return ONLY valid JSON. No explanation, no markdown fences."""
@@ -2761,7 +2772,11 @@ Return ONLY valid JSON. No explanation, no markdown fences."""
         log_error("generate_carousel_content: LLM returned invalid JSON", exc=exc)
         parsed = {}
 
-    post_text = normalize_public_text(parsed.get("post_text", f"Explore our latest insights on {industry}."))
+    # QA guard: reflow a wall-of-text caption into scannable paragraphs and hard-cap the length,
+    # even when the model ignored the format directive (JSON mode often drops line breaks).
+    post_text = enforce_post_readability(
+        normalize_public_text(parsed.get("post_text", f"Explore our latest insights on {industry}.")),
+        max_chars=_CAROUSEL_CAPTION_MAX_CHARS)
     carousel_dict = _normalize_carousel_strings(parsed.get("carousel", {}))
     return post_text, carousel_dict
 

--- a/src/cqc_lem/utilities/linkedin_formatter.py
+++ b/src/cqc_lem/utilities/linkedin_formatter.py
@@ -53,6 +53,58 @@ PLAIN_PUNCTUATION_DIRECTIVE = (
 )
 
 
+def linkedin_post_format_directive(max_chars: int = 2200) -> str:
+    """Shared LinkedIn post-formatting best practices for AI system prompts (the QA rules we
+    researched): hook first line, short scannable paragraphs separated by BLANK LINES, a hard length
+    cap, and no markdown. This is the PREVENTION side; enforce_post_readability() is the safety net
+    for when the model ignores it (e.g. JSON-mode carousel captions that come back as one long block)."""
+    return (
+        "FORMAT FOR LINKEDIN: Open with a scroll-stopping first line (the hook) - it is the only line "
+        "shown before the '...more' fold. Then write SHORT, scannable paragraphs of 1-2 sentences each, "
+        "each separated by a BLANK LINE (real line breaks - never one long block of text). Keep the "
+        f"entire post under {max_chars} characters. Do NOT use markdown (no **bold**, no # headers, no "
+        "bullet characters unless intentional) - LinkedIn renders it literally."
+    )
+
+
+_SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+
+
+def enforce_post_readability(text: str, max_chars: int = 2200, target_paragraph_chars: int = 220) -> str:
+    """Deterministic QA guard for AI-generated post captions - the safety net when the model ignores
+    the format directive (e.g. a carousel caption that came back as one 3400-char paragraph):
+
+      - reflow a long 'wall of text' (a body with no blank-line paragraphs) into short, scannable
+        paragraphs, keeping any trailing hashtag/link line on its own;
+      - hard-cap length at a sentence boundary (LinkedIn's limit is 3000; the default stays well under).
+
+    Already-formatted (has blank-line paragraphs) or short posts are returned unchanged."""
+    if not text:
+        return text
+    text = text.strip()
+    if "\n\n" not in text and len(text) > 600:
+        lines = text.split("\n")
+        body, trailer = lines[0], "\n".join(lines[1:]).strip()
+        sentences = [s.strip() for s in _SENTENCE_SPLIT_RE.split(body) if s.strip()]
+        paras, cur = [], ""
+        for s in sentences:
+            if cur and len(cur) + 1 + len(s) > target_paragraph_chars:
+                paras.append(cur)
+                cur = s
+            else:
+                cur = f"{cur} {s}".strip()
+        if cur:
+            paras.append(cur)
+        text = "\n\n".join(paras)
+        if trailer:
+            text += "\n\n" + trailer
+    if len(text) > max_chars:
+        cut = text[:max_chars]
+        ends = list(re.finditer(r"[.!?](?:\s|$)", cut))
+        text = (cut[:ends[-1].end()] if ends else cut).rstrip()
+    return text
+
+
 def sanitize_for_linkedin(text: str) -> str:
     """Strip markdown syntax from AI-generated text so it renders cleanly on LinkedIn.
 

--- a/tests/unit/utilities/ai/test_ai_helper_carousel.py
+++ b/tests/unit/utilities/ai/test_ai_helper_carousel.py
@@ -103,3 +103,34 @@ class TestGenerateCarouselContent:
             from cqc_lem.utilities.ai.ai_helper import generate_carousel_content
             post_text, carousel_dict = generate_carousel_content(user_id=1, stage="awareness")
         assert isinstance(post_text, str)
+
+
+@pytest.mark.unit
+def test_wall_of_text_caption_is_reflowed_and_capped():
+    """Regression (post 72): a caption that comes back as a long single paragraph must be reflowed
+    into scannable paragraphs and hard-capped under the LinkedIn limit."""
+    from contextlib import contextmanager
+    from cqc_lem.utilities.linkedin.profile import LinkedInProfile
+
+    wall = " ".join(f"Intro sentence number {i} is here." for i in range(150))  # long, no line breaks
+    assert "\n\n" not in wall and len(wall) > 3000
+    payload = _educational_carousel_json()
+    payload["post_text"] = wall
+
+    profile = LinkedInProfile(full_name="Test User", job_title="CTO", company_name="ACME", industry="Technology")
+
+    @contextmanager
+    def _env():
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_make_llm_mock(payload)), \
+             patch("cqc_lem.utilities.db.get_user_password_pair_by_id", return_value=("t@e.com", "p")), \
+             patch("cqc_lem.utilities.selenium_util.get_driver_wait_pair", return_value=(MagicMock(), MagicMock())), \
+             patch("cqc_lem.utilities.linkedin.helper.get_my_profile", return_value=profile), \
+             patch("cqc_lem.utilities.selenium_util.quit_gracefully"):
+            yield
+
+    with _env():
+        from cqc_lem.utilities.ai.ai_helper import generate_carousel_content, _CAROUSEL_CAPTION_MAX_CHARS
+        post_text, _ = generate_carousel_content(user_id=1, stage="awareness")
+
+    assert len(post_text) <= _CAROUSEL_CAPTION_MAX_CHARS   # hard-capped
+    assert "\n\n" in post_text                             # reflowed into paragraphs

--- a/tests/unit/utilities/test_linkedin_formatter.py
+++ b/tests/unit/utilities/test_linkedin_formatter.py
@@ -227,3 +227,53 @@ class TestSanitizeForLinkedIn:
         assert "• Bullet one" in result
         assert "this link (https://example.com)" in result
         assert "#ai" in result
+
+
+@pytest.mark.unit
+class TestEnforcePostReadability:
+    def test_reflows_wall_of_text_into_paragraphs(self):
+        from cqc_lem.utilities.linkedin_formatter import enforce_post_readability
+        wall = " ".join(f"Sentence number {i} is here." for i in range(60))  # long, no blank lines
+        assert "\n\n" not in wall and len(wall) > 600
+        out = enforce_post_readability(wall, max_chars=5000)
+        assert out.count("\n\n") >= 3  # broke into multiple paragraphs
+
+    def test_hard_caps_length_at_sentence_boundary(self):
+        from cqc_lem.utilities.linkedin_formatter import enforce_post_readability
+        text = " ".join(f"Sentence {i}." for i in range(300))
+        out = enforce_post_readability(text, max_chars=200)
+        assert len(out) <= 200
+        assert out.rstrip().endswith(".")  # trimmed at a sentence end, not mid-word
+
+    def test_short_post_unchanged(self):
+        from cqc_lem.utilities.linkedin_formatter import enforce_post_readability
+        s = "A short and sweet post."
+        assert enforce_post_readability(s) == s
+
+    def test_already_paragraphed_post_unchanged(self):
+        from cqc_lem.utilities.linkedin_formatter import enforce_post_readability
+        s = "Hook line here.\n\n" + ("Body sentence. " * 40).strip()
+        assert enforce_post_readability(s, max_chars=5000) == s  # has blank lines → not reflowed
+
+    def test_keeps_trailing_hashtag_line_separate(self):
+        from cqc_lem.utilities.linkedin_formatter import enforce_post_readability
+        body = " ".join(f"Point {i} made here." for i in range(50))
+        text = body + "\n#ai #linkedin #ml"
+        out = enforce_post_readability(text, max_chars=5000)
+        assert out.rstrip().endswith("#ai #linkedin #ml")
+
+    def test_empty_and_none(self):
+        from cqc_lem.utilities.linkedin_formatter import enforce_post_readability
+        assert enforce_post_readability("") == ""
+        assert enforce_post_readability(None) is None
+
+
+@pytest.mark.unit
+class TestLinkedinPostFormatDirective:
+    def test_states_hook_paragraphs_and_char_cap(self):
+        from cqc_lem.utilities.linkedin_formatter import linkedin_post_format_directive
+        d = linkedin_post_format_directive(2200)
+        assert "hook" in d.lower()
+        assert "2200" in d
+        assert "blank line" in d.lower()
+        assert "markdown" in d.lower()


### PR DESCRIPTION
## Problem

A carousel post's caption came out as a **3412-char single paragraph** — a wall of run-on sentences, over LinkedIn's 3000-char limit (reported post: activity 7481708902112329729 / post id 72).

## Root cause

`generate_carousel_content` is a one-shot inline prompt that **bypasses the text-post pipeline** (no blueprint, no hook pass, no similarity gate) and had **no length or formatting enforcement and no QA step**. Its prompt only *asked* for "1300–2000 chars / line breaks"; the model (in JSON mode) ignored both and returned one long block, which was stored/posted verbatim. `normalize_public_text` preserves newlines, so it wasn't the culprit.

## Fix

Adds a shared LinkedIn best-practices/QA layer in `linkedin_formatter.py`:
- **`linkedin_post_format_directive(max_chars)`** — reusable pre-prompt: hook first line, short blank-line-separated paragraphs, hard char cap, no markdown (prevention).
- **`enforce_post_readability(text, max_chars)`** — deterministic safety net: reflows a wall of text into scannable paragraphs and hard-caps length at a sentence boundary; leaves already-formatted/short posts untouched.

Applied in `generate_carousel_content` (both the prompt and a post-generation guard, cap 2200). These helpers are reusable by other generators too.

## Note on the shared QA gap

There's currently **no single consolidated LinkedIn context/QA pre-prompt** across generators — best practices live in `content_framework.py` (blueprints), `content_alignment.py` (guardrails/purpose), `PLAIN_PUNCTUATION_DIRECTIVE`, and `optimize_post_hook`, applied mostly to **text** posts. Carousels bypassed all of it. This PR is the first shared readability/QA primitive; extending it to all generators is a good follow-up.

## The live post

Post 72's text was separately reformatted (faithful condense to 1973 chars / 10 paragraphs) and the DB record updated; the live LinkedIn post is edited manually (API can't edit published commentary; Selenium is rate-limited).

## Tests

2511 unit tests pass. New coverage for `enforce_post_readability` (reflow, cap-at-sentence-boundary, short/formatted untouched, trailing hashtag line), the directive, and a `generate_carousel_content` regression (wall-of-text caption → reflowed + capped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)