### PR TITLE
fix(content): reflow over-long paragraphs (under-formatted posts), not just walls

### DIFF
--- a/src/cqc_lem/utilities/linkedin_formatter.py
+++ b/src/cqc_lem/utilities/linkedin_formatter.py
@@ -68,36 +68,64 @@ def linkedin_post_format_directive(max_chars: int = 2200) -> str:
 
 
 _SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+")
+# A "meta" line that should stay on its own, not be reflowed into prose (hashtag line, bare URL,
+# or a near-empty line).
+_META_LINE_RE = re.compile(r"^(#\S|https?://|\W{0,3}$)")
 
 
-def enforce_post_readability(text: str, max_chars: int = 2200, target_paragraph_chars: int = 220) -> str:
+def _reflow_into_paragraphs(prose: str, target_paragraph_chars: int) -> list:
+    """Group a single long prose string into short paragraphs of ~target_paragraph_chars, breaking
+    only on sentence boundaries."""
+    sentences = [s.strip() for s in _SENTENCE_SPLIT_RE.split(prose) if s.strip()]
+    if len(sentences) <= 1:
+        return [prose]
+    paras, cur = [], ""
+    for s in sentences:
+        if cur and len(cur) + 1 + len(s) > target_paragraph_chars:
+            paras.append(cur)
+            cur = s
+        else:
+            cur = f"{cur} {s}".strip()
+    if cur:
+        paras.append(cur)
+    return paras
+
+
+def enforce_post_readability(text: str, max_chars: int = 2200, target_paragraph_chars: int = 220,
+                             long_paragraph_chars: int = 350) -> str:
     """Deterministic QA guard for AI-generated post captions - the safety net when the model ignores
-    the format directive (e.g. a carousel caption that came back as one 3400-char paragraph):
+    the format directive (e.g. a carousel caption that came back as a wall of text):
 
-      - reflow a long 'wall of text' (a body with no blank-line paragraphs) into short, scannable
-        paragraphs, keeping any trailing hashtag/link line on its own;
+      - break any OVER-LONG paragraph (a single-line prose block longer than long_paragraph_chars)
+        into short, scannable paragraphs. This catches both a total wall (one giant paragraph) AND an
+        under-formatted post (a few very long paragraphs), while leaving already-short paragraphs and
+        multi-line blocks (lists) untouched. Trailing hashtag/link lines stay on their own.
       - hard-cap length at a sentence boundary (LinkedIn's limit is 3000; the default stays well under).
 
-    Already-formatted (has blank-line paragraphs) or short posts are returned unchanged."""
+    Well-formatted (short paragraphs) or short posts are returned unchanged."""
     if not text:
         return text
     text = text.strip()
-    if "\n\n" not in text and len(text) > 600:
-        lines = text.split("\n")
-        body, trailer = lines[0], "\n".join(lines[1:]).strip()
-        sentences = [s.strip() for s in _SENTENCE_SPLIT_RE.split(body) if s.strip()]
-        paras, cur = [], ""
-        for s in sentences:
-            if cur and len(cur) + 1 + len(s) > target_paragraph_chars:
-                paras.append(cur)
-                cur = s
-            else:
-                cur = f"{cur} {s}".strip()
-        if cur:
-            paras.append(cur)
-        text = "\n\n".join(paras)
+    out_paras = []
+    for block in re.split(r"\n\s*\n", text):
+        block = block.strip()
+        if not block:
+            continue
+        # Peel trailing meta lines (hashtags / links) so they aren't reflowed into the prose.
+        lines = block.split("\n")
+        trailer = []
+        while len(lines) > 1 and _META_LINE_RE.match(lines[-1].strip()):
+            trailer.insert(0, lines.pop().strip())
+        prose = "\n".join(lines).strip()
+        # Only reflow a SINGLE-LINE prose block that is too long; leave short blocks and multi-line
+        # blocks (lists, deliberately line-broken content) as they are.
+        if "\n" not in prose and len(prose) > long_paragraph_chars:
+            out_paras.extend(_reflow_into_paragraphs(prose, target_paragraph_chars))
+        elif prose:
+            out_paras.append(prose)
         if trailer:
-            text += "\n\n" + trailer
+            out_paras.append("\n".join(trailer))
+    text = "\n\n".join(out_paras)
     if len(text) > max_chars:
         cut = text[:max_chars]
         ends = list(re.finditer(r"[.!?](?:\s|$)", cut))

--- a/tests/unit/utilities/test_linkedin_formatter.py
+++ b/tests/unit/utilities/test_linkedin_formatter.py
@@ -250,10 +250,24 @@ class TestEnforcePostReadability:
         s = "A short and sweet post."
         assert enforce_post_readability(s) == s
 
-    def test_already_paragraphed_post_unchanged(self):
+    def test_well_formatted_short_paragraphs_unchanged(self):
         from cqc_lem.utilities.linkedin_formatter import enforce_post_readability
-        s = "Hook line here.\n\n" + ("Body sentence. " * 40).strip()
-        assert enforce_post_readability(s, max_chars=5000) == s  # has blank lines → not reflowed
+        s = ("Hook line here.\n\n"
+             "A short first paragraph with one idea.\n\n"
+             "A short second paragraph with another idea.\n\n"
+             "#ai #linkedin")
+        assert enforce_post_readability(s, max_chars=5000) == s  # short paras → untouched
+
+    def test_breaks_up_over_long_paragraphs(self):
+        from cqc_lem.utilities.linkedin_formatter import enforce_post_readability
+        # Two giant single-line paragraphs (the under-formatted case, e.g. post 75) — each must be
+        # broken into shorter scannable paragraphs even though the post already has a blank line.
+        big = " ".join(f"Sentence {i} here." for i in range(40))  # ~600 chars, single line
+        s = big + "\n\n" + big
+        out = enforce_post_readability(s, max_chars=9000)
+        assert out.count("\n\n") > 2  # more than the original single blank line
+        # every resulting paragraph is reasonably short
+        assert all(len(p) <= 300 for p in out.split("\n\n"))
 
     def test_keeps_trailing_hashtag_line_separate(self):
         from cqc_lem.utilities.linkedin_formatter import enforce_post_readability


### PR DESCRIPTION
## Why

Following the carousel wall-of-text fix (#350), a pass over the not-yet-posted carousels found the guard only reflowed **total** walls (zero blank lines). It missed **under-formatted** posts — e.g. an approved carousel caption that was 2596 chars in just **2 giant paragraphs**. Those escaped reflow because they technically had a blank line.

## Change

`enforce_post_readability` now reflows **any single-line prose paragraph longer than `long_paragraph_chars` (default 350)** into short scannable paragraphs — catching both total walls and under-formatted posts. Preserved untouched: already-short paragraphs, multi-line blocks (lists/deliberate breaks), and trailing hashtag/link lines.

## Applied to existing unposted carousels

Ran the improved guard (generous 2900-char cap so approved content isn't truncated) over the not-yet-posted approved carousels and updated the DB:
- **post 75**: 2 giant paragraphs → 14 scannable paragraphs (content preserved).
- **post 73**: one long paragraph split (8 → 9).
- **post 77**: already well-formatted → unchanged (guard correctly leaves good posts alone).

They'll publish with the fixed text since the scheduler reads content at post time. (Rejected carousels were skipped — they won't post.)

## Tests

2512 unit tests pass. Updated the "already formatted" test to genuinely short paragraphs and added a test that two giant paragraphs get broken up while short ones are left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)