### PR TITLE
feat(feed): empty-filter fallback + reach estimate for feed commenting

### DIFF
--- a/compose/local/database/migrations/V56__add_feed_fallback_pref.sql
+++ b/compose/local/database/migrations/V56__add_feed_fallback_pref.sql
@@ -1,0 +1,7 @@
+-- Feed-commenting fallback: when a user's targeting INCLUDE filters (topics/keywords/authors) match
+-- nothing in the feed, comment on the best feed posts anyway (hard EXCLUDES, recency, min-reactions,
+-- and the daily cap still apply). LinkedIn already curates the feed to relevant content, so "anything
+-- in feed" is a reasonable floor that keeps engagement flowing instead of a silent zero. Default ON;
+-- users who want strict-only targeting can turn it off. Lives on the single per-user prefs row.
+ALTER TABLE engagement_preferences
+    ADD COLUMN feed_fallback_when_empty TINYINT(1) NULL DEFAULT 1 AFTER reply_max_post_age_days;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -404,6 +404,7 @@ class EngagementPreferencesRequest(BaseModel):
     reply_check_mode: str = "event"
     reply_sweeps_per_day: int = 2
     reply_max_post_age_days: int = 2
+    feed_fallback_when_empty: bool = True
 
     @field_validator("default_video_quality")
     @classmethod
@@ -1283,6 +1284,13 @@ def get_engagement_preferences_endpoint(session_token: str) -> ResponseModel:
         prefs["reply_inbound_address"] = reply_inbound_address(token) if token else None
     except Exception:
         prefs["reply_inbound_address"] = None
+    # Read-only: the last feed scan's reach funnel so the user can see when their targeting is too
+    # strict (posts examined -> matched their filters -> commented).
+    try:
+        from cqc_lem.app.run_automation import get_feed_funnel
+        prefs["feed_reach"] = get_feed_funnel(user_id)
+    except Exception:
+        prefs["feed_reach"] = None
     return ResponseModel(status_code=200, detail=prefs)
 
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -38,7 +38,7 @@ from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile,
 from cqc_lem.utilities.linkedin.poster import share_on_linkedin, share_carousel_on_linkedin, \
     comment_on_linkedin_post, object_urn_from_post_url
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
-from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
+from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited, _redis_client
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text
 from cqc_lem.utilities.logger import myprint, log_error, log_info, log_warning
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
@@ -794,6 +794,42 @@ def _switch_feed_to_recent(driver, wait) -> None:
         log_warning("Feed recent-sort failed", exc=e, action_type="scrape")
 
 
+_FEED_FUNNEL_KEY = "linkedin:feed_funnel:{user_id}"
+_FEED_FUNNEL_TTL = 30 * 24 * 60 * 60  # keep the last scan's reach estimate for 30 days
+# Consecutive top-candidate include-misses before we relax to the fallback (comment on the best feed
+# post regardless of the include filters). Hard excludes / recency / min-reactions still apply.
+_FEED_FALLBACK_AFTER_MISSES = 6
+
+
+def set_feed_funnel(user_id: int, funnel: dict) -> None:
+    """Persist the last feed scan's reach funnel (posts examined -> matched -> commented) so the UI
+    can show the user how strict their targeting is. Best-effort; no-op without Redis."""
+    client = _redis_client()
+    if client is None:
+        return
+    try:
+        client.set(_FEED_FUNNEL_KEY.format(user_id=user_id), json.dumps(funnel), ex=_FEED_FUNNEL_TTL)
+    except Exception as e:
+        log_warning("Could not store feed funnel", exc=e, user_id=user_id, action_type="comment")
+
+
+def get_feed_funnel(user_id: int) -> "dict | None":
+    """Last feed scan's reach funnel for a user, or None if there hasn't been one recently."""
+    client = _redis_client()
+    if client is None:
+        return None
+    try:
+        raw = client.get(_FEED_FUNNEL_KEY.format(user_id=user_id))
+    except Exception:
+        return None
+    if not raw:
+        return None
+    try:
+        return json.loads(raw.decode() if isinstance(raw, (bytes, bytearray)) else raw)
+    except (ValueError, TypeError):
+        return None
+
+
 def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: int,
                            max_posts: int = 10, deadline_ts: float = None, prefs: dict = None,
                            engagers: set = None) -> int:
@@ -826,6 +862,14 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
     used_comment_shapes: list = []
 
     posted, seen, scrolls = 0, set(), 0
+    # Reach funnel (surfaced to the user so they can tell when their targeting is too strict) and the
+    # empty-filter fallback. examined = posts we looked at; hard = passed excludes/recency/min-reactions;
+    # include = also matched the user's include topics/keywords/authors.
+    examined_keys, hard_keys, include_keys = set(), set(), set()
+    strict_misses, fallback_active, fallback_used = 0, False, False
+    _incl = [f for f in ((prefs.get("include_keywords") or []) + (prefs.get("include_authors") or [])
+                         + (prefs.get("include_topics") or [])) if f]
+    fallback_enabled = bool(prefs.get("feed_fallback_when_empty", True)) and bool(_incl)
     while posted < max_posts and scrolls < 15:
         if deadline_ts and time.time() >= deadline_ts:
             break
@@ -847,6 +891,7 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             key = _post_permalink_from_card(card) or _feed_post_key(author, content)
             if key in seen:
                 continue
+            examined_keys.add(key)
             # Persistent, cross-run/worker dedup: skip anything already claimed or commented
             # (commented_posts ledger), plus historical SUCCESS comment logs, plus hard excludes.
             if (has_commented_post(user_id, key) or has_user_commented_on_post_url(user_id, key)
@@ -863,14 +908,26 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
                 continue
             meta = {"author": author, "age_minutes": age, "comments": counts["comments"],
                     "reactions": counts["reactions"], "relevant": _literal_relevant(content, author, prefs)}
+            hard_keys.add(key)
             candidates.append((_score_feed_post(meta, prefs, engagers), key, card, content, author, age))
 
         if candidates:
             candidates.sort(key=lambda c: c[0], reverse=True)
             score, key, card, content, author, age = candidates[0]
             seen.add(key)  # decided on this one either way
-            # Full include check (may use the LLM topic classifier) only on the chosen post.
-            if not post_matches_preferences(content, author, prefs):
+            # Include gate (may use the LLM topic classifier) on the chosen post. If the feed keeps
+            # producing nothing that matches the user's include filters, RELAX to fallback for the rest
+            # of the run — comment on the best feed post regardless of include (LinkedIn already curates
+            # the feed to relevant content). Hard excludes / recency / min-reactions still applied.
+            if not fallback_active and fallback_enabled and strict_misses >= _FEED_FALLBACK_AFTER_MISSES:
+                fallback_active = True
+                myprint("Feed targeting matched nothing — falling back to top feed posts for this run")
+            if fallback_active:
+                fallback_used = True
+            elif post_matches_preferences(content, author, prefs):
+                include_keys.add(key)
+            else:
+                strict_misses += 1
                 continue
             # Atomically claim the post BEFORE spending an LLM call or commenting. If a prior/
             # concurrent run already holds it, we lose the race here and move on — at most one
@@ -913,6 +970,19 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
         driver.execute_script("window.scrollBy(0, 1200);")
         scrolls += 1
         time.sleep(random.uniform(2.5, 4))
+
+    set_feed_funnel(user_id, {
+        "examined": len(examined_keys),
+        "passed_filters": len(hard_keys),      # cleared excludes + recency + min-reactions
+        "matched_topics": len(include_keys),   # also matched include topics/keywords/authors
+        "commented": posted,
+        "fallback_used": fallback_used,
+        "max_post_age_hours": prefs.get("max_post_age_hours") or 24,
+        "min_reactions": min_reactions,
+        "at": datetime.now().isoformat(),
+    })
+    myprint(f"Feed scan: examined {len(examined_keys)}, passed filters {len(hard_keys)}, "
+            f"matched topics {len(include_keys)}, commented {posted}, fallback={fallback_used}")
     return posted
 
 

--- a/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
@@ -209,6 +209,30 @@ export default function EngagementSettingsCard() {
             <p className="text-xs text-gray-400 mt-1">Premium spends video credits per auto-generated video; falls back to standard when you have none.</p>
           </div>
         </div>
+        <div className="border-t border-gray-100 pt-4 space-y-2">
+          <div className="flex items-center justify-between">
+            <div className="pr-4">
+              <p className="text-sm font-medium text-gray-700">Comment anyway if my filters match nothing</p>
+              <p className="text-xs text-gray-400">If none of the posts in your feed match your include topics/keywords, comment on the best feed posts anyway (excludes, recency and min-reactions still apply). LinkedIn already curates your feed to relevant content.</p>
+            </div>
+            <Toggle on={engPrefs.feed_fallback_when_empty} onClick={() => setEng({ feed_fallback_when_empty: !engPrefs.feed_fallback_when_empty })} />
+          </div>
+          {engPrefs.feed_reach && (
+            <div className="rounded-lg bg-gray-50 border border-gray-100 p-3 text-xs text-gray-600">
+              <p className="font-medium text-gray-700 mb-1">Last feed scan reach</p>
+              <p>
+                Examined <span className="font-semibold">{engPrefs.feed_reach.examined}</span> posts →{' '}
+                <span className="font-semibold">{engPrefs.feed_reach.passed_filters}</span> passed your recency / min-reactions filters →{' '}
+                <span className="font-semibold">{engPrefs.feed_reach.matched_topics}</span> matched your topics/keywords → commented on{' '}
+                <span className="font-semibold">{engPrefs.feed_reach.commented}</span>
+                {engPrefs.feed_reach.fallback_used ? ' (used fallback)' : ''}.
+              </p>
+              {engPrefs.feed_reach.examined > 0 && engPrefs.feed_reach.matched_topics === 0 && (
+                <p className="mt-1 text-amber-600">Your include filters matched nothing in the last scan — consider loosening topics/keywords, lowering min-reactions, or widening max post age.</p>
+              )}
+            </div>
+          )}
+        </div>
         <div className="flex items-center justify-between">
           <p className="text-sm font-medium text-gray-700">Reply to comments on my posts</p>
           <Toggle on={engPrefs.reply_to_own_comments} onClick={() => setEng({ reply_to_own_comments: !engPrefs.reply_to_own_comments })} />

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -23,6 +23,19 @@ export type EngPrefs = {
   reply_sweeps_per_day: number
   reply_max_post_age_days: number
   reply_inbound_address?: string | null
+  feed_fallback_when_empty: boolean
+  feed_reach?: FeedReach | null
+}
+
+export type FeedReach = {
+  examined: number
+  passed_filters: number
+  matched_topics: number
+  commented: number
+  fallback_used: boolean
+  max_post_age_hours?: number
+  min_reactions?: number
+  at?: string
 }
 
 export type DmTemplate = {

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2502,18 +2502,21 @@ _ENGAGEMENT_DEFAULTS: dict = {
     "max_comments_per_day": 20, "max_dms_per_day": 20, "default_buyer_stage": None,
     "default_video_quality": "standard",
     "reply_check_mode": "event", "reply_sweeps_per_day": 2, "reply_max_post_age_days": 2,
+    "feed_fallback_when_empty": True,
 }
 _ENGAGEMENT_JSON_FIELDS = ("include_topics", "exclude_topics", "include_keywords",
                            "exclude_keywords", "include_authors", "exclude_authors", "post_types",
                            "focus_topics")
-_ENGAGEMENT_BOOL_FIELDS = ("use_emojis", "use_hashtags", "reply_to_own_comments")
+_ENGAGEMENT_BOOL_FIELDS = ("use_emojis", "use_hashtags", "reply_to_own_comments",
+                           "feed_fallback_when_empty")
 _ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "use_hashtags",
                     "include_topics", "exclude_topics", "include_keywords", "exclude_keywords",
                     "include_authors", "exclude_authors", "post_types", "focus_topics",
                     "business_goals", "personal_goals", "min_reactions",
                     "max_post_age_hours", "reply_to_own_comments", "max_comments_per_day",
                     "max_dms_per_day", "default_buyer_stage", "default_video_quality",
-                    "reply_check_mode", "reply_sweeps_per_day", "reply_max_post_age_days")
+                    "reply_check_mode", "reply_sweeps_per_day", "reply_max_post_age_days",
+                    "feed_fallback_when_empty")
 
 VALID_VIDEO_QUALITIES = ("standard", "premium", "premium_top")
 VALID_REPLY_MODES = ("event", "scheduled", "off")

--- a/tests/unit/api/test_engagement_prefs_api.py
+++ b/tests/unit/api/test_engagement_prefs_api.py
@@ -178,3 +178,24 @@ class TestEngagementPersistenceRegression:
              / "compose/local/database/migrations/V52__widen_engagement_tone.sql")
         sql = p.read_text().lower()
         assert "tone" in sql and "varchar(255)" in sql
+
+
+class TestFeedFallbackAndReach:
+    def test_feed_fallback_passthrough(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences",
+                              json={"session_token": _SESSION, "feed_fallback_when_empty": False})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1]["feed_fallback_when_empty"] is False
+
+    def test_get_includes_feed_reach(self, client):
+        funnel = {"examined": 40, "passed_filters": 12, "matched_topics": 0,
+                  "commented": 3, "fallback_used": True}
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_engagement_preferences", return_value={}), \
+             patch("cqc_lem.api.main.get_or_create_reply_inbound_token", return_value=None), \
+             patch("cqc_lem.app.run_automation.get_feed_funnel", return_value=funnel):
+            resp = client.get(f"/api/user/engagement-preferences?session_token={_SESSION}")
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["feed_reach"] == funnel

--- a/tests/unit/app/test_comment_dedup.py
+++ b/tests/unit/app/test_comment_dedup.py
@@ -23,7 +23,8 @@ def _box(text):
 
 
 def _run_feed(boxes, *, claim_side_effect=None, has_commented=False, max_posts=10,
-              author="Jane Author", is_me=False, react_returns=True, post_returns=True):
+              author="Jane Author", is_me=False, react_returns=True, post_returns=True,
+              prefs=None, matches=True):
     """Drive comment_on_feed_inline with all the SDUI/DB collaborators mocked. Returns a dict of
     the key mocks so assertions can inspect calls."""
     from cqc_lem.app import run_automation as ra
@@ -47,7 +48,7 @@ def _run_feed(boxes, *, claim_side_effect=None, has_commented=False, max_posts=1
 
     with ExitStack() as es:
         p = lambda name, **kw: es.enter_context(patch(f"{_RA}.{name}", **kw))
-        p("get_engagement_preferences", return_value={"max_comments_per_day": 20})
+        p("get_engagement_preferences", return_value=prefs or {"max_comments_per_day": 20})
         p("get_recent_engagers", return_value=set())
         p("count_comments_today", return_value=0)
         p("_switch_feed_to_recent")
@@ -63,7 +64,9 @@ def _run_feed(boxes, *, claim_side_effect=None, has_commented=False, max_posts=1
         p("_post_social_counts", return_value={"comments": 0, "reactions": 0})
         p("_literal_relevant", return_value=True)
         p("_score_feed_post", return_value=1.0)
-        p("post_matches_preferences", return_value=True)
+        p("post_matches_preferences", return_value=matches)
+        funnel_holder = {}
+        p("set_feed_funnel", side_effect=lambda uid, f: funnel_holder.update(f))
         p("claim_post_for_comment", new=claim)
         p("generate_ai_response", new=gen)
         p("post_comment_inline", new=post_inline)
@@ -78,7 +81,8 @@ def _run_feed(boxes, *, claim_side_effect=None, has_commented=False, max_posts=1
         posted = ra.comment_on_feed_inline(driver, wait, MagicMock(), user_id=1, max_posts=max_posts)
 
     return {"posted": posted, "claim": claim, "post_inline": post_inline, "react": react,
-            "mark": mark, "mark_reacted": mark_reacted, "release": release, "gen": gen}
+            "mark": mark, "mark_reacted": mark_reacted, "release": release, "gen": gen,
+            "funnel": funnel_holder}
 
 
 class TestFeedDedup:
@@ -213,3 +217,41 @@ class TestCommentOnPostTaskIdempotency:
         assert "already commented" in result
         claim.assert_not_called()
         gdw.assert_not_called()
+
+
+class TestFeedFunnelAndFallback:
+    def test_funnel_recorded(self):
+        r = _run_feed([_box("First post content that is long enough."),
+                       _box("Second different post content long enough.")])
+        f = r["funnel"]
+        assert f["examined"] == 2 and f["passed_filters"] == 2
+        assert f["matched_topics"] == 2 and f["commented"] == 2
+        assert f["fallback_used"] is False
+
+    def test_strict_filters_zero_matches_no_fallback_when_disabled(self):
+        # Include filters set, nothing matches, fallback OFF -> comment on nothing.
+        boxes = [_box(f"Post number {i} with enough text to qualify here.") for i in range(9)]
+        r = _run_feed(boxes, matches=False,
+                      prefs={"max_comments_per_day": 20, "include_topics": ["AI"],
+                             "feed_fallback_when_empty": False})
+        assert r["posted"] == 0
+        assert r["funnel"]["matched_topics"] == 0
+        assert r["funnel"]["fallback_used"] is False
+
+    def test_fallback_comments_when_filters_match_nothing(self):
+        # Include filters set, nothing matches, fallback ON -> after enough misses it relaxes and
+        # comments on the best feed posts anyway.
+        boxes = [_box(f"Post number {i} with enough text to qualify here.") for i in range(9)]
+        r = _run_feed(boxes, matches=False,
+                      prefs={"max_comments_per_day": 20, "include_topics": ["AI"],
+                             "feed_fallback_when_empty": True})
+        assert r["posted"] >= 1               # fallback engaged
+        assert r["funnel"]["fallback_used"] is True
+        assert r["funnel"]["matched_topics"] == 0
+
+    def test_no_include_filters_means_no_fallback_flag(self):
+        # With no include filters, everything matches; fallback is irrelevant and stays False.
+        r = _run_feed([_box("Just a normal post with sufficient length to pass.")],
+                      prefs={"max_comments_per_day": 20})
+        assert r["posted"] == 1
+        assert r["funnel"]["fallback_used"] is False

--- a/tests/unit/utilities/test_db_engagement_prefs.py
+++ b/tests/unit/utilities/test_db_engagement_prefs.py
@@ -126,6 +126,29 @@ class TestReplyCheckConfig:
         assert by_col["reply_sweeps_per_day"] == 2          # floor
 
 
+class TestFeedFallbackPref:
+    def test_default_true(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            assert get_engagement_preferences(1)["feed_fallback_when_empty"] is True
+
+    def test_decodes_as_bool(self):
+        conn, _ = _mock_conn(fetch_row={"feed_fallback_when_empty": 0})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            assert get_engagement_preferences(1)["feed_fallback_when_empty"] is False
+
+    def test_persists_as_int(self):
+        conn, cursor = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_engagement_preferences
+            update_engagement_preferences(3, {"feed_fallback_when_empty": False})
+        cols = list(__import__("cqc_lem.utilities.db", fromlist=["_ENGAGEMENT_COLS"])._ENGAGEMENT_COLS)
+        by_col = dict(zip(cols, cursor.execute.call_args[0][1][1:]))
+        assert by_col["feed_fallback_when_empty"] == 0
+
+
 class TestReplyInboundToken:
     def test_returns_existing_token(self):
         conn, cursor = _mock_conn(fetch_row=("existingtoken",))


### PR DESCRIPTION
## Why

User asked: *why isn't feed commenting happening, are the filters too strict, can we estimate results, and fall back to anything in the feed when filters match nothing?*

**Diagnosis:** the immediate blocker is the LinkedIn **429 rate limit** (Selenium can't log in), but the targeting filters are also strict (9 include-topics, 11 include-keywords, min_reactions=5, max_post_age=24h), which can yield 0 matches even when Selenium works.

## Changes

**1. Empty-filter fallback (default on, toggle in Account).** When the user's INCLUDE filters (topics/keywords/authors) match nothing across the feed scan, relax and comment on the best feed posts anyway — hard *excludes*, recency, min-reactions, and the daily cap still apply. LinkedIn already curates the feed to relevant content, so "anything in feed" is a reasonable floor. Sticky per-run once triggered.

**2. Reach estimate.** Instrument the feed scan with a funnel — `examined → passed_filters → matched_topics → commented` (+ `fallback_used`) — stored per user in Redis (30-day TTL) and surfaced in the Account page ("Last feed scan: examined 40 → 12 passed filters → 0 matched your topics → commented 3"), with a nudge to loosen filters when nothing matches.

- `V56` migration + `engagement_preferences.feed_fallback_when_empty`.
- `set_feed_funnel`/`get_feed_funnel` (Redis); funnel counters + sticky fallback in `comment_on_feed_inline`.
- Prefs API field + `feed_reach` in the GET response; Account UI toggle + reach display.

## Tests

New: fallback engages when filters match nothing (and stays off when disabled / no include filters), funnel counts recorded, db bool round-trip, API passthrough + `feed_reach` in GET. Full suite green (one pre-existing flaky email-PIN test passes in isolation).

## Caveat

None of this produces comments until the **429 clears** — the account needs reduced Selenium load to recover (event-mode replies already help; the manual automation-pause would be fastest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)