### PR TITLE
test(feed): cover feed funnel storage helpers

### DIFF
--- a/tests/unit/app/test_reply_sweep.py
+++ b/tests/unit/app/test_reply_sweep.py
@@ -171,3 +171,42 @@ class TestAutomateReplyCommenting:
             result = automate_reply_commenting.run(user_id=1, post_id=9, loop_for_duration=0)
         helper.assert_called_once()
         assert "Replied to 2 comments" in result
+
+
+class TestFeedFunnelStorage:
+    def test_set_and_get_round_trip(self):
+        import json
+        redis = MagicMock()
+        with patch(f"{_RA}._redis_client", return_value=redis):
+            from cqc_lem.app.run_automation import set_feed_funnel, get_feed_funnel
+            set_feed_funnel(1, {"examined": 5, "commented": 2})
+            stored = redis.set.call_args
+            assert stored.args[0] == "linkedin:feed_funnel:1"
+            assert json.loads(stored.args[1]) == {"examined": 5, "commented": 2}
+            assert stored.kwargs["ex"] == 30 * 24 * 60 * 60
+            redis.get.return_value = stored.args[1]
+            assert get_feed_funnel(1) == {"examined": 5, "commented": 2}
+
+    def test_get_returns_none_when_absent(self):
+        redis = MagicMock(); redis.get.return_value = None
+        with patch(f"{_RA}._redis_client", return_value=redis):
+            from cqc_lem.app.run_automation import get_feed_funnel
+            assert get_feed_funnel(1) is None
+
+    def test_no_redis_is_safe(self):
+        with patch(f"{_RA}._redis_client", return_value=None):
+            from cqc_lem.app.run_automation import set_feed_funnel, get_feed_funnel
+            set_feed_funnel(1, {"x": 1})     # must not raise
+            assert get_feed_funnel(1) is None
+
+    def test_set_swallows_redis_error(self):
+        redis = MagicMock(); redis.set.side_effect = RuntimeError("down")
+        with patch(f"{_RA}._redis_client", return_value=redis), patch(f"{_RA}.log_warning"):
+            from cqc_lem.app.run_automation import set_feed_funnel
+            set_feed_funnel(1, {"x": 1})     # must not raise
+
+    def test_get_handles_bad_json(self):
+        redis = MagicMock(); redis.get.return_value = b"not json"
+        with patch(f"{_RA}._redis_client", return_value=redis):
+            from cqc_lem.app.run_automation import get_feed_funnel
+            assert get_feed_funnel(1) is None


### PR DESCRIPTION
Follow-up to #353 — adds direct unit tests for set_feed_funnel/get_feed_funnel (round-trip, no-redis, redis error, bad JSON) that codecov/patch flagged as uncovered (they were exercised only via mocks in the feed harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)