### PR TITLE
feat(replies): auto-confirm Gmail forwarding to the reply address

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -667,6 +667,54 @@ async def linkedin_verification_pin_inbound(request: Request) -> ResponseModel:
     return ResponseModel(status_code=200, detail="accepted" if user_id else "ignored")
 
 
+_GMAIL_CONFIRM_KEY = "linkedin:gmail_forward_confirm:{user_id}"
+
+
+def _handle_gmail_forwarding_confirmation(user_id: int, body: str) -> ResponseModel:
+    """Auto-confirm the user's Gmail forwarding to our address: click the verify link server-side
+    (Gmail confirms on GET), and stash the numeric code + status so the UI can show it as a fallback
+    if the auto-click didn't take. Always 200."""
+    from cqc_lem.utilities.linkedin.notification_email import (
+        extract_gmail_confirmation_url, extract_gmail_confirmation_code)
+    url = extract_gmail_confirmation_url(body)
+    code = extract_gmail_confirmation_code(body)
+    confirmed = False
+    if url:
+        try:
+            resp = requests.get(url, timeout=15)
+            confirmed = resp.status_code < 400
+        except Exception as e:
+            log_warning("Gmail forwarding auto-confirm click failed", exc=e, user_id=user_id)
+    try:
+        from cqc_lem.utilities.linkedin.rate_limit import _redis_client
+        client = _redis_client()
+        if client is not None:
+            client.set(_GMAIL_CONFIRM_KEY.format(user_id=user_id),
+                       json.dumps({"code": code, "confirmed": confirmed, "url_found": bool(url)}),
+                       ex=7 * 24 * 60 * 60)
+    except Exception:
+        pass
+    log_info(f"Gmail forwarding confirmation: url_found={bool(url)} confirmed={confirmed} "
+             f"code={'yes' if code else 'no'}", user_id=user_id)
+    return ResponseModel(status_code=200,
+                         detail="confirmed" if confirmed else ("code_stored" if code else "ignored"))
+
+
+def get_gmail_forward_confirmation(user_id: int) -> "dict | None":
+    """Last Gmail-forwarding confirmation result for a user (auto-confirmed? code fallback?)."""
+    try:
+        from cqc_lem.utilities.linkedin.rate_limit import _redis_client
+        client = _redis_client()
+        if client is None:
+            return None
+        raw = client.get(_GMAIL_CONFIRM_KEY.format(user_id=user_id))
+        if not raw:
+            return None
+        return json.loads(raw.decode() if isinstance(raw, (bytes, bytearray)) else raw)
+    except Exception:
+        return None
+
+
 def _reply_sweep_debounced(user_id: int, window_s: int = 120) -> bool:
     """True the first time we see this user within window_s — collapses a burst of comment
     notifications into ONE reply sweep. Fails OPEN (returns True) if Redis is unavailable so a
@@ -688,7 +736,7 @@ async def linkedin_comment_notification_inbound(request: Request) -> ResponseMod
     reaction) we trigger a debounced recent-posts reply sweep — no polling, so it doesn't trip the
     429 rate limit. Always 200 so SendGrid doesn't retry-storm on unrelated/malformed mail."""
     from cqc_lem.utilities.linkedin.notification_email import (
-        extract_reply_token_from_address, is_comment_notification)
+        extract_reply_token_from_address, is_comment_notification, is_gmail_forwarding_confirmation)
     from cqc_lem.utilities.db import get_user_id_by_reply_token
     try:
         form = await request.form()
@@ -696,13 +744,20 @@ async def linkedin_comment_notification_inbound(request: Request) -> ResponseMod
         return ResponseModel(status_code=200, detail="ignored")
     to_field = str(form.get("to") or "")
     envelope = str(form.get("envelope") or "")
+    from_field = str(form.get("from") or "")
     subject = str(form.get("subject") or "")
-    text = str(form.get("text") or form.get("html") or "")
+    text = str(form.get("text") or "")
+    html = str(form.get("html") or "")
     token = extract_reply_token_from_address(to_field) or extract_reply_token_from_address(envelope)
     if not token:
         return ResponseModel(status_code=200, detail="ignored")
     user_id = get_user_id_by_reply_token(token)
-    if not user_id or not is_comment_notification(subject, text):
+    if not user_id:
+        return ResponseModel(status_code=200, detail="ignored")
+    # Gmail forwarding confirmation: the address is ours + token-gated, so auto-click the verify link.
+    if is_gmail_forwarding_confirmation(from_field, subject, text or html):
+        return _handle_gmail_forwarding_confirmation(user_id, f"{text}\n{html}")
+    if not is_comment_notification(subject, text or html):
         return ResponseModel(status_code=200, detail="ignored")
     if not _reply_sweep_debounced(user_id):
         return ResponseModel(status_code=200, detail="debounced")
@@ -1284,6 +1339,8 @@ def get_engagement_preferences_endpoint(session_token: str) -> ResponseModel:
         prefs["reply_inbound_address"] = reply_inbound_address(token) if token else None
     except Exception:
         prefs["reply_inbound_address"] = None
+    # Gmail forwarding auto-confirmation status (so the UI can surface the code if auto-confirm failed).
+    prefs["gmail_forward_confirmation"] = get_gmail_forward_confirmation(user_id)
     # Read-only: the last feed scan's reach funnel so the user can see when their targeting is too
     # strict (posts examined -> matched their filters -> commented).
     try:

--- a/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
@@ -288,6 +288,23 @@ export default function EngagementSettingsCard() {
                   <span className="italic"> “Forward it to”</span> and pick your address. Using another provider?
                   Any rule that forwards LinkedIn comment emails to the address works.
                 </p>
+                <p className="mt-1 text-green-700">
+                  Good news: when Gmail sends the "verify permission" confirmation to your address, we
+                  confirm it for you automatically — no need to fish out the code.
+                </p>
+                {engPrefs.gmail_forward_confirmation && (
+                  <div className="mt-1">
+                    {engPrefs.gmail_forward_confirmation.confirmed ? (
+                      <p className="text-green-700">✅ Gmail forwarding was auto-confirmed.</p>
+                    ) : engPrefs.gmail_forward_confirmation.code ? (
+                      <p className="text-amber-600">
+                        We received Gmail's confirmation but couldn't auto-click it. If forwarding still shows
+                        "pending" in Gmail, enter this code there:{' '}
+                        <code className="bg-gray-100 rounded px-1">{engPrefs.gmail_forward_confirmation.code}</code>
+                      </p>
+                    ) : null}
+                  </div>
+                )}
               </div>
 
               <p className="text-gray-400">

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -23,8 +23,15 @@ export type EngPrefs = {
   reply_sweeps_per_day: number
   reply_max_post_age_days: number
   reply_inbound_address?: string | null
+  gmail_forward_confirmation?: GmailForwardConfirmation | null
   feed_fallback_when_empty: boolean
   feed_reach?: FeedReach | null
+}
+
+export type GmailForwardConfirmation = {
+  code?: string | null
+  confirmed?: boolean
+  url_found?: boolean
 }
 
 export type FeedReach = {

--- a/src/cqc_lem/utilities/linkedin/notification_email.py
+++ b/src/cqc_lem/utilities/linkedin/notification_email.py
@@ -56,3 +56,45 @@ def is_comment_notification(subject: str, text: str = "") -> bool:
     if any(p in subject for p in _REACTION_PHRASES):
         return False
     return False
+
+
+# --- Gmail forwarding auto-confirmation -------------------------------------------
+# When the user adds our reply+<token>@parse-domain address as a Gmail forwarding address, Gmail
+# emails a CONFIRMATION to it ("verify permission"). Since that address is ours and token-gated, we
+# can auto-confirm by clicking the verify link server-side so the user doesn't have to fish the code
+# out. The email also contains a numeric code as a manual fallback.
+_GMAIL_CONFIRM_URL_RE = re.compile(r"https://mail(?:-settings)?\.google\.com/mail/[^\s\"'<>\]\)]+")
+_GMAIL_CONFIRM_CODE_RE = re.compile(r"confirmation code[^0-9]{0,40}(\d{6,12})", re.I)
+
+
+def is_gmail_forwarding_confirmation(sender: str, subject: str, text: str = "") -> bool:
+    """True when the inbound email is a Gmail 'Forwarding Confirmation' asking us to verify the
+    forwarding address (from forwarding-noreply@google.com)."""
+    if "forwarding-noreply@google.com" in (sender or "").lower():
+        return True
+    subj = (subject or "").lower()
+    body = (text or "").lower()
+    return ("forwarding confirmation" in subj
+            or ("verify permission" in body and "mail.google.com/mail" in body)
+            or ("confirm forwarding" in body and "mail.google.com/mail" in body))
+
+
+def extract_gmail_confirmation_url(text: str) -> Optional[str]:
+    """The Gmail verify link to click (prefers the vf-/uf- confirmation link)."""
+    if not text:
+        return None
+    urls = _GMAIL_CONFIRM_URL_RE.findall(text)
+    if not urls:
+        return None
+    for u in urls:
+        if "vf-" in u or "uf-" in u:
+            return u.rstrip(").,;")
+    return urls[0].rstrip(").,;")
+
+
+def extract_gmail_confirmation_code(text: str) -> Optional[str]:
+    """The numeric confirmation code Gmail also provides, for manual entry if auto-confirm fails."""
+    if not text:
+        return None
+    m = _GMAIL_CONFIRM_CODE_RE.search(text)
+    return m.group(1) if m else None

--- a/tests/unit/api/test_engagement_prefs_api.py
+++ b/tests/unit/api/test_engagement_prefs_api.py
@@ -199,3 +199,15 @@ class TestFeedFallbackAndReach:
             resp = client.get(f"/api/user/engagement-preferences?session_token={_SESSION}")
         assert resp.status_code == 200
         assert resp.json()["detail"]["feed_reach"] == funnel
+
+
+class TestGmailForwardConfirmationInPrefs:
+    def test_get_includes_gmail_forward_confirmation(self, client):
+        conf = {"code": "12345678", "confirmed": False, "url_found": True}
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_engagement_preferences", return_value={}), \
+             patch("cqc_lem.api.main.get_or_create_reply_inbound_token", return_value=None), \
+             patch("cqc_lem.api.main.get_gmail_forward_confirmation", return_value=conf):
+            resp = client.get(f"/api/user/engagement-preferences?session_token={_SESSION}")
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["gmail_forward_confirmation"] == conf

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -380,6 +380,33 @@ class TestCommentNotificationInbound:
         assert resp.json()["detail"] == "debounced"
         sweep.apply_async.assert_not_called()
 
+    def test_gmail_forwarding_confirmation_auto_clicks(self, client):
+        body = ("please click the link below to confirm the request:\n"
+                "https://mail.google.com/mail/vf-%5Babc%5D-xyz\nConfirmation code: 123456789")
+        got = type("R", (), {"status_code": 200})()
+        with patch(self._DB, return_value=7), \
+             patch(f"{_MAIN}.sweep_reply_comments") as sweep, \
+             patch(f"{_MAIN}.requests.get", return_value=got) as rget:
+            resp = client.post(self.BASE, data={
+                "to": "reply+tok9@parse.example.com",
+                "from": "forwarding-noreply@google.com",
+                "subject": "Gmail Forwarding Confirmation", "text": body})
+        assert resp.json()["detail"] == "confirmed"
+        rget.assert_called_once()
+        assert rget.call_args.args[0] == "https://mail.google.com/mail/vf-%5Babc%5D-xyz"
+        sweep.apply_async.assert_not_called()   # not a comment → no sweep
+
+    def test_gmail_confirmation_click_fails_stores_code(self, client):
+        body = "verify permission ... https://mail.google.com/mail/vf-x\nConfirmation code: 55667788"
+        with patch(self._DB, return_value=7), \
+             patch(f"{_MAIN}.requests.get", side_effect=RuntimeError("net")), \
+             patch(f"{_MAIN}.log_warning"):
+            resp = client.post(self.BASE, data={
+                "to": "reply+tok9@parse.example.com",
+                "from": "forwarding-noreply@google.com",
+                "subject": "Gmail Forwarding Confirmation", "text": body})
+        assert resp.json()["detail"] == "code_stored"
+
 
 class TestVerificationPinInbound:
     """SendGrid Inbound Parse webhook that receives the user's PIN reply."""

--- a/tests/unit/utilities/linkedin/test_notification_email.py
+++ b/tests/unit/utilities/linkedin/test_notification_email.py
@@ -59,3 +59,43 @@ class TestIsCommentNotification:
         from cqc_lem.utilities.linkedin.notification_email import is_comment_notification
         body = "FYI\n> On Mon, someone commented on your post"
         assert is_comment_notification("Weekly digest", body) is False
+
+
+_GMAIL_BODY = (
+    "forwarding-noreply@google.com has requested to automatically forward mail to your address.\n"
+    "Confirmation code: 987654321\n\n"
+    "To allow christopher.queen@gmail.com to automatically forward mail, please click the link "
+    "below to confirm the request:\n"
+    "https://mail.google.com/mail/vf-%5BANGjdJ8xyz%5D-abc123def456\n\n"
+    "If the link is broken, copy and paste it into a new browser window."
+)
+
+
+class TestGmailForwardingConfirmation:
+    def test_detects_from_sender(self):
+        from cqc_lem.utilities.linkedin.notification_email import is_gmail_forwarding_confirmation
+        assert is_gmail_forwarding_confirmation("Gmail Team <forwarding-noreply@google.com>",
+                                                "(#123) Gmail Forwarding Confirmation", "") is True
+
+    def test_detects_from_subject(self):
+        from cqc_lem.utilities.linkedin.notification_email import is_gmail_forwarding_confirmation
+        assert is_gmail_forwarding_confirmation("x@y.com", "Gmail Forwarding Confirmation - Receive Mail", "") is True
+
+    def test_not_confirmation_for_comment(self):
+        from cqc_lem.utilities.linkedin.notification_email import is_gmail_forwarding_confirmation
+        assert is_gmail_forwarding_confirmation("notify@linkedin.com", "Jane commented on your post", "hi") is False
+
+    def test_extracts_verify_url(self):
+        from cqc_lem.utilities.linkedin.notification_email import extract_gmail_confirmation_url
+        url = extract_gmail_confirmation_url(_GMAIL_BODY)
+        assert url == "https://mail.google.com/mail/vf-%5BANGjdJ8xyz%5D-abc123def456"
+
+    def test_extracts_code(self):
+        from cqc_lem.utilities.linkedin.notification_email import extract_gmail_confirmation_code
+        assert extract_gmail_confirmation_code(_GMAIL_BODY) == "987654321"
+
+    def test_no_url_or_code(self):
+        from cqc_lem.utilities.linkedin.notification_email import (
+            extract_gmail_confirmation_url, extract_gmail_confirmation_code)
+        assert extract_gmail_confirmation_url("nothing here") is None
+        assert extract_gmail_confirmation_code("nothing here") is None


### PR DESCRIPTION
## Problem

When the user adds `reply+<token>@parse.christopherqueenconsulting.com` as a Gmail forwarding address, Gmail sends a **"verify permission" confirmation** email to it. That email lands on our inbound webhook — but the webhook only handled *comment* notifications, so it was **silently ignored** and the forwarding never got confirmed. The user was stuck.

## Fix

The tokenized address is ours and token-gated, so a Gmail forwarding confirmation to it is trusted. The inbound webhook now:
1. Detects Gmail's forwarding-confirmation email (`from forwarding-noreply@google.com` / "Forwarding Confirmation" / "verify permission" + a `mail.google.com/mail` link).
2. **Clicks the verify link server-side** (`requests.get` — Gmail confirms on GET).
3. Stashes the numeric confirmation **code** as a manual fallback (surfaced in the Account page if the auto-click didn't take).

New helpers in `notification_email.py`; `_handle_gmail_forwarding_confirmation` + `get_gmail_forward_confirmation` in `main.py`; `gmail_forward_confirmation` added to the prefs GET; Account UI status line.

## Tests

2535 pass. New: confirmation detection (sender/subject vs comment), URL + code extraction, webhook auto-clicks the link (returns `confirmed`), click-failure stores the code (`code_stored`), and prefs GET surfaces the status.

## Note

No migration. After deploy, the user should re-trigger Gmail's confirmation (re-add / resend from Gmail's Forwarding settings) since the first one was lost before this handler existed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)