### PR TITLE
fix(replies): route reply+ mail from the single SendGrid inbound URL (PIN endpoint)

### DIFF
--- a/docs/REPLY_NOTIFICATIONS.md
+++ b/docs/REPLY_NOTIFICATIONS.md
@@ -11,7 +11,12 @@ Event mode replies only when a comment actually happens — no browser polling, 
 2. The user sets a mail filter to **auto-forward** those emails to a personal tokenized address:
    `reply+<token>@parse.<domain>` (shown in the account settings, "Reply follow-up mode → Event-driven").
 3. **SendGrid Inbound Parse** (already configured for the parse domain, same as the login-PIN flow)
-   delivers the forwarded email to `POST /api/linkedin/comment-notification/inbound`.
+   delivers the forwarded email to the app. NOTE: SendGrid Inbound Parse posts ALL mail for the
+   parse host to a SINGLE URL — the login-PIN endpoint `POST /api/linkedin/verification-pin/inbound`.
+   That endpoint dispatches on the address prefix: `pin+<token>` → PIN flow, `reply+<token>` →
+   `_process_reply_inbound` (Gmail forwarding confirmation + comment notifications). The dedicated
+   `POST /api/linkedin/comment-notification/inbound` path also exists and runs the same handler, but
+   SendGrid does not need to be reconfigured — no second Inbound Parse URL is required.
 4. The webhook resolves the token → user, confirms it's a *comment* (not a reaction), and triggers a
    **debounced** recent-posts reply sweep (`sweep_reply_comments`). A burst of notifications collapses
    into one sweep (120s window).

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -655,6 +655,12 @@ async def linkedin_verification_pin_inbound(request: Request) -> ResponseModel:
         return ResponseModel(status_code=200, detail="ignored")
     to_field = str(form.get("to") or "")
     envelope = str(form.get("envelope") or "")
+    # SendGrid Inbound Parse routes ALL mail for the parse host to this ONE URL, so this endpoint
+    # must also handle the reply+<token> traffic (Gmail forwarding confirmations + comment
+    # notifications), not only pin+<token> PIN replies. Dispatch by the address prefix.
+    from cqc_lem.utilities.linkedin.notification_email import extract_reply_token_from_address
+    if extract_reply_token_from_address(to_field) or extract_reply_token_from_address(envelope):
+        return _process_reply_inbound(form)
     text = str(form.get("text") or form.get("html") or "")
     subject = str(form.get("subject") or "")
     token = extract_token_from_address(to_field) or extract_token_from_address(envelope)
@@ -729,19 +735,14 @@ def _reply_sweep_debounced(user_id: int, window_s: int = 120) -> bool:
         return True
 
 
-@router.post("/linkedin/comment-notification/inbound")
-async def linkedin_comment_notification_inbound(request: Request) -> ResponseModel:
-    """SendGrid Inbound Parse webhook: a forwarded LinkedIn 'commented on your post' email. The
-    tokenized address (reply+<token>@parse-domain) attributes it to a user; if it's a comment (not a
-    reaction) we trigger a debounced recent-posts reply sweep — no polling, so it doesn't trip the
-    429 rate limit. Always 200 so SendGrid doesn't retry-storm on unrelated/malformed mail."""
+def _process_reply_inbound(form) -> ResponseModel:
+    """Handle inbound mail sent to a reply+<token>@parse-domain address: a Gmail forwarding
+    confirmation (auto-click the verify link) or a forwarded LinkedIn comment notification (trigger a
+    debounced recent-posts reply sweep). Reactions/unknown tokens are ignored. Always 200. Called
+    from BOTH inbound endpoints because SendGrid Inbound Parse posts all parse-host mail to one URL."""
     from cqc_lem.utilities.linkedin.notification_email import (
         extract_reply_token_from_address, is_comment_notification, is_gmail_forwarding_confirmation)
     from cqc_lem.utilities.db import get_user_id_by_reply_token
-    try:
-        form = await request.form()
-    except Exception:
-        return ResponseModel(status_code=200, detail="ignored")
     to_field = str(form.get("to") or "")
     envelope = str(form.get("envelope") or "")
     from_field = str(form.get("from") or "")
@@ -764,6 +765,17 @@ async def linkedin_comment_notification_inbound(request: Request) -> ResponseMod
     sweep_reply_comments.apply_async(kwargs={"user_id": user_id}, countdown=120)
     log_info("Triggered reply sweep from comment notification", user_id=user_id)
     return ResponseModel(status_code=200, detail="accepted")
+
+
+@router.post("/linkedin/comment-notification/inbound")
+async def linkedin_comment_notification_inbound(request: Request) -> ResponseModel:
+    """SendGrid Inbound Parse webhook for reply+<token> mail (kept as an explicit path; SendGrid
+    actually delivers to the shared parse URL, which also routes here via _process_reply_inbound)."""
+    try:
+        form = await request.form()
+    except Exception:
+        return ResponseModel(status_code=200, detail="ignored")
+    return _process_reply_inbound(form)
 
 
 @router.put("/user/", responses={

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -488,3 +488,37 @@ class TestGmailForwardConfirmationStorage:
         assert resp.json()["detail"] == "confirmed"
         redis.set.assert_called_once()
         assert redis.set.call_args.args[0] == "linkedin:gmail_forward_confirm:7"
+
+
+class TestSharedInboundRouting:
+    """SendGrid posts ALL parse-host mail to the PIN URL, so that endpoint must also route
+    reply+<token> mail (Gmail confirmations + comment notifications)."""
+    PIN = "/api/linkedin/verification-pin/inbound"
+
+    def test_pin_url_routes_reply_comment_to_sweep(self, client):
+        with patch("cqc_lem.utilities.db.get_user_id_by_reply_token", return_value=7), \
+             patch(f"{_MAIN}._reply_sweep_debounced", return_value=True), \
+             patch(f"{_MAIN}.sweep_reply_comments") as sweep:
+            resp = client.post(self.PIN, data={
+                "to": "reply+tok9@parse.example.com",
+                "subject": "Jane commented on your post"})
+        assert resp.json()["detail"] == "accepted"
+        sweep.apply_async.assert_called_once()
+
+    def test_pin_url_routes_gmail_confirmation(self, client):
+        got = type("R", (), {"status_code": 200})()
+        body = "confirm: https://mail.google.com/mail/vf-abc\nConfirmation code: 12345678"
+        with patch("cqc_lem.utilities.db.get_user_id_by_reply_token", return_value=7), \
+             patch(f"{_MAIN}.requests.get", return_value=got):
+            resp = client.post(self.PIN, data={
+                "to": "reply+tok9@parse.example.com",
+                "from": "forwarding-noreply@google.com",
+                "subject": "Gmail Forwarding Confirmation", "text": body})
+        assert resp.json()["detail"] == "confirmed"
+
+    def test_pin_url_still_handles_pin(self, client):
+        with patch(f"{_MAIN}.submit_pin_by_token", return_value=1) as m:
+            resp = client.post(self.PIN, data={
+                "to": "pin+abc123@parse.example.com", "text": "483920"})
+        assert resp.json()["detail"] == "accepted"
+        m.assert_called_once_with("abc123", "483920")


### PR DESCRIPTION
## Root cause (blocking the user)

SendGrid Inbound Parse posts **all** mail for `parse.<domain>` to a **single** URL. Per `docs/EMAIL_PIN_VERIFICATION.md`, that URL is the login-PIN endpoint `POST /api/linkedin/verification-pin/inbound`. So the user's Gmail forwarding **confirmation** (and any LinkedIn comment notifications) — sent to `reply+<token>@parse.<domain>` — hit the **PIN** webhook, which only understands `pin+<token>`, and was **silently ignored**. The forwarding never got confirmed, so the user can't finish the Gmail setup. My earlier `comment-notification/inbound` endpoint was never called by SendGrid.

## Fix

Extract the reply-inbound logic into `_process_reply_inbound(form)` and dispatch to it from the PIN endpoint whenever the address carries a `reply+` token (`pin+` still runs the PIN flow). The dedicated `/comment-notification/inbound` path stays and runs the same handler. **No SendGrid reconfiguration needed.** Doc corrected.

Verified earlier that once `_process_reply_inbound` runs, the full path works end-to-end (a synthetic comment notification queued `sweep_reply_comments(user_id=1)` in Celery). This PR makes SendGrid actually reach that handler.

## Tests

2542 pass. New: PIN URL routes a `reply+` comment → queued sweep (`accepted`), routes a `reply+` Gmail confirmation → auto-click (`confirmed`), and still handles `pin+` PIN replies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)