### PR TITLE
fix(replies): loop-safety guards on the reply sweep (event-driven replies on own posts)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1557,6 +1557,12 @@ def automate_commenting(self, user_id: int, loop_for_duration: int = None, futur
     return result
 
 
+# Max replies posted per post in a single sweep — a volume backstop so a huge comment thread (or an
+# unexpected re-trigger) can never fire an unbounded burst. Already-replied comments are skipped
+# regardless, so this only ever caps NEW replies.
+_MAX_REPLIES_PER_SWEEP = 15
+
+
 def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my_profile,
                                     profile_synthesis: str) -> str:
     """Navigate to the user's own post and reply to comments on it (thread-builder replies, plus
@@ -1588,14 +1594,24 @@ def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my
     comments = _comment_items_from_thread(driver)
     myprint(f"Comments Found: {len(comments)}")
 
-    # our profile slug — used to detect comments we've already replied to
+    # our profile slug — used to detect comments we AUTHORED or already replied to (the loop-breaker).
     path = urlparse(str(my_profile.profile_url)).path
     unique_url_name = path.split("/")[2] if len(path.split("/")) > 2 else None
+    # LOOP SAFETY: without our slug we can't tell our own comments / already-replied ones apart, so a
+    # sweep could reply to our own comments and re-reply every run. Fail SAFE — skip replying entirely.
+    if not unique_url_name:
+        log_warning("Reply sweep: could not resolve own profile slug — skipping replies to avoid "
+                    "duplicate/self replies", user_id=user_id, post_id=post_id, action_type="reply")
+        return "Skipped — no profile slug for dedup"
 
     comments_replied_count = 0
     lead_magnet = get_lead_magnet_settings(user_id)
     lead_magnet_blog_url = get_user_blog_url(user_id) if lead_magnet.get("enabled") else ""
     for comment in comments:
+        # Per-post volume backstop: never fire an unbounded burst of replies from one sweep.
+        if comments_replied_count >= _MAX_REPLIES_PER_SWEEP:
+            myprint(f"Reply cap reached ({_MAX_REPLIES_PER_SWEEP}) for post {post_id}")
+            break
         try:
             tb = comment.find_elements(By.CSS_SELECTOR, "[data-testid='expandable-text-box']")
             comment_text = ((tb[0].text if tb else comment.text) or "").strip()

--- a/tests/unit/app/test_reply_sweep.py
+++ b/tests/unit/app/test_reply_sweep.py
@@ -145,6 +145,42 @@ class TestReplyToCommentsOnOpenPost:
         dm.apply_async.assert_called_once()
         rec.assert_called_once()
 
+    def test_bails_when_profile_slug_unresolvable(self):
+        """LOOP SAFETY: with no profile slug we can't dedup our own / already-replied comments, so
+        the sweep must skip replying entirely rather than risk duplicate/self replies."""
+        from cqc_lem.app.run_automation import _reply_to_comments_on_open_post
+        from unittest.mock import MagicMock
+        prof = MagicMock(); prof.profile_url = None; prof.full_name = "Me"
+        with patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://li/feed/update/urn:li:share:1/"), \
+             patch(f"{_RA}.get_post_content", return_value="body"), \
+             patch(f"{_RA}.click_first", return_value=None), \
+             patch(f"{_RA}._comment_items_from_thread", return_value=[_FakeComment("hi")]), \
+             patch(f"{_RA}.get_lead_magnet_settings", return_value={"enabled": False}), \
+             patch(f"{_RA}.log_warning"), \
+             patch(f"{_RA}.generate_thread_reply") as gen, \
+             patch(f"{_RA}._reply_to_comment_inline") as rep:
+            result = _reply_to_comments_on_open_post(MagicMock(), MagicMock(), 1, 9, prof, "s")
+        assert "no profile slug" in result.lower()
+        gen.assert_not_called()
+        rep.assert_not_called()
+
+    def test_reply_cap_limits_burst(self):
+        from cqc_lem.app.run_automation import _reply_to_comments_on_open_post, _MAX_REPLIES_PER_SWEEP
+        from unittest.mock import MagicMock
+        boxes = [_FakeComment(f"comment number {i}") for i in range(_MAX_REPLIES_PER_SWEEP + 5)]
+        with patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://li/feed/update/urn:li:share:1/"), \
+             patch(f"{_RA}.get_post_content", return_value="body"), \
+             patch(f"{_RA}.click_first", return_value=None), \
+             patch(f"{_RA}._comment_items_from_thread", return_value=boxes), \
+             patch(f"{_RA}.get_lead_magnet_settings", return_value={"enabled": False}), \
+             patch(f"{_RA}.upsert_engager"), \
+             patch(f"{_RA}.generate_thread_reply", return_value="reply"), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}._reply_to_comment_inline", return_value=True) as rep, \
+             patch(f"{_RA}.insert_new_log"):
+            _reply_to_comments_on_open_post(MagicMock(), MagicMock(), 1, 9, self._profile(), "s")
+        assert rep.call_count == _MAX_REPLIES_PER_SWEEP
+
     def test_no_post_url_returns_early(self):
         from cqc_lem.app.run_automation import _reply_to_comments_on_open_post
         with patch(f"{_RA}.get_post_url_from_log_for_user", return_value=None):


### PR DESCRIPTION
## Why

Event-driven reply now runs on the user's OWN posts, so we hardened against any re-reply / self-reply loop.

## Loop-safety (already present, documented here)
- The sweep **skips any comment where the user's own profile link already appears** — which covers **their own comments** (seed comment / their own replies) **and** comments **already replied to**. So it never replies to itself and never double-replies.
- **LinkedIn doesn't notify you of your own comments/replies** → our replies don't generate new notification emails → no self-triggering.
- **120s debounce + `QueueOnce(keys=['user_id'])`** → collapse bursts, no concurrent sweeps.
- Only **comment/reply** notifications trigger (not reactions).

## New hardening in this PR
- **Fail SAFE when the profile slug can't be resolved** (e.g. a cached profile missing its URL): the dedup can't work without it, so the sweep **skips replying entirely** rather than risk duplicate/self replies.
- **Per-post reply cap** (`_MAX_REPLIES_PER_SWEEP = 15`) as a volume backstop — already-replied comments are skipped regardless, so this only ever caps NEW replies.

## Tests

2547 pass. New: bails when profile slug unresolvable (no replies), and the per-post reply cap limits a burst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)