### PR TITLE
fix(engagement): break the LinkedIn 429 breaker doom loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,29 @@ Before merging any PR, all of the following must pass:
 - `CodeQL Security Analysis`
 - `GitGuardian Security Scan`
 
+## Production Deployment & Environment
+
+LEM runs as a Docker Compose stack on a **Hostinger VPS**, exposed via a Cloudflare Tunnel. There are two checkouts on the box, and they are NOT the same:
+
+| Path | Owner | Purpose |
+|---|---|---|
+| `/home/lem/linkedin_engagement_manager` | `lem` | Dev/agent working checkout (where you edit + commit). Has `./src` on disk. |
+| `/opt/lem` | `deploy` | **Live production stack.** Compose project workdir; `scripts/deploy.sh` checks out release tags here. |
+
+**Standard release flow (the only path that keeps prod on the release train):**
+
+```
+local dev → PR to main → CI gates pass → release-please tags vX.Y.Z
+  → build-and-push.yml builds ghcr.io/christopherqueenconsulting/cqc-lem:vX.Y.Z → GHCR
+  → SSH deploy to VPS runs scripts/deploy.sh vX.Y.Z (git checkout tag, flyway migrate,
+    compose up, /health check, auto-rollback to .last_good_tag on failure)
+```
+
+- The stack is launched with **both** compose files: `docker compose -f docker-compose.yml -f docker-compose.prod.yml`. `docker-compose.yml` alone is the DEV config (it bind-mounts `./src:/app/src`); **`docker-compose.prod.yml` overrides that away**, so in PRODUCTION every app service runs the code baked into the image — editing files on disk does nothing until a new image ships. Code lives at `/app/src/cqc_lem/...` inside the image.
+- Image ref is `${DOCKER_IMAGE_NAME}:${IMAGE_TAG:-latest}`, both set in `/opt/lem/.env` (git-ignored, lives on the box); `scripts/deploy.sh` exports `IMAGE_TAG` per-deploy. App services sharing the image: `web_app`, `celery_worker`, `celery_worker_selenium`, `celery_worker_selenium_outreach`, `celery_worker_selenium_content`, `celery_beat`, `flower`. Infra services (`mysql`, `redis`, `selenium-chrome`, `litellm`, `cloudflared`, `flyway`) use their own upstream images.
+- **Runtime state (429 breaker, manual automation pause, reply-sweep cadence keys) lives in Redis**, not the DB or containers — it survives deploys. Inspect/repair it by calling the real functions in the container, e.g. `docker exec celery_worker_selenium python -c "from cqc_lem.utilities.linkedin.rate_limit import clear_rate_limit, pause_automation; ..."`, so the correct Redis URL is used.
+- **Local hotfix deploy (fallback when CI/release is too slow or blocked):** build a thin overlay image `FROM` the running release tag that only `COPY`s the changed `src` files (guarantees identical deps, seconds not minutes), then on the box set `/opt/lem/.env` `IMAGE_TAG=<hotfix-tag>` and `cd /opt/lem && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --no-deps --pull never <app-services>`. Keep the prior release image locally for instant rollback (`IMAGE_TAG=vX.Y.Z`). **This diverges prod from `main`** — the fix MUST still land via PR→release, or the next release will REVERT it. Requires `sudo` for the Docker socket on this box.
+
 ## Known Gotchas
 
 - `get_docker_driver()` previously connected to Selenium Grid hub+node. It now connects to `selenium/standalone-chrome:latest` at port 4444.

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -42,10 +42,6 @@ def _skip_if_throttled(name: str) -> bool:
     return False
 
 
-# Backward-compatible alias — historically only checked the manual pause.
-_skip_if_paused = _skip_if_throttled
-
-
 
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, }, reject_on_worker_lost=True)
 def auto_check_scheduled_posts(self):
@@ -76,8 +72,15 @@ def auto_check_scheduled_posts(self):
         # connection and subscription. Inactive/disconnected users' sessions fail
         # immediately and waste a Chrome slot that active users need. Also skip them
         # while throttled (pause / 429 breaker) so they don't probe the feed — the API
-        # post above still goes out regardless.
-        if user_id in active_user_ids and not _skip_if_throttled("pre-post Selenium"):
+        # post above still goes out regardless. The two skip reasons are distinct, so
+        # branch them separately to keep the logs honest (the throttle path already
+        # logs its own reason inside _skip_if_throttled).
+        if user_id not in active_user_ids:
+            log_warning(
+                "Skipping pre-post Selenium tasks — user not active/connected",
+                user_id=user_id, post_id=post_id, task_name="auto_check_scheduled_posts",
+            )
+        elif not _skip_if_throttled("pre-post Selenium"):
             base_kwargs = {'user_id': user_id, 'loop_for_duration': 60 * 15}
 
             # Start the pre-post commenting task 15 minutes before scheduled post (loop for 15 minutes)
@@ -91,11 +94,6 @@ def auto_check_scheduled_posts(self):
             # Schedule the pre-post profile viewer dm task 10 minutes before scheduled post (loop for 10 minutes)
             base_kwargs['loop_for_duration'] = 60 * 10
             automate_profile_viewer_engagement.apply_async(kwargs=base_kwargs, eta=scheduled_time - timedelta(minutes=10))
-        else:
-            log_warning(
-                "Skipping pre-post Selenium tasks — user not active/connected",
-                user_id=user_id, post_id=post_id, task_name="auto_check_scheduled_posts",
-            )
 
     # Re-queue any posts that got stuck in 'scheduled' (task was lost, e.g. on container restart)
     # but never transitioned to 'posted'. The 2-hour gap ensures we don't race with a task
@@ -157,7 +155,7 @@ def auto_check_scheduled_dms(self):
 @shared_task.task
 def auto_appreciate_dms():
     if _skip_if_throttled("auto_appreciate_dms"):
-        return "Automation paused"
+        return "Automation throttled"
     # For each user schedule appreciate DMS
     users = get_active_user_ids()
 
@@ -190,7 +188,7 @@ def auto_daily_engagement():
     comment_on_feed_inline), and QueueOnce (keys=['user_id']) prevents overlapping double-runs for
     the same user."""
     if _skip_if_throttled("auto_daily_engagement"):
-        return "Automation paused"
+        return "Automation throttled"
     users = get_active_user_ids()
     dispatched = 0
     for user_id in users:
@@ -527,7 +525,7 @@ def auto_sync_groups():
 def auto_group_engagement():
     """Daily value-add commenting in each active user's ENABLED groups (shares the per-day cap)."""
     if _skip_if_throttled("auto_group_engagement"):
-        return "Automation paused"
+        return "Automation throttled"
     from cqc_lem.app.run_automation import auto_comment_in_groups
     users = get_active_user_ids()
     n = 0
@@ -559,7 +557,7 @@ def auto_group_posts():
 def auto_scrape_stats():
     """Daily: capture engagement stats on each active user's recent posts (powers post-time recs)."""
     if _skip_if_throttled("auto_scrape_stats"):
-        return "Automation paused"
+        return "Automation throttled"
     from cqc_lem.app.run_automation import auto_scrape_post_stats
     users = get_active_user_ids()
     n = 0
@@ -574,7 +572,7 @@ def auto_scrape_stats():
 def auto_send_due_followups():
     """Dispatch a per-user Selenium task to send due DM follow-ups (each gated by reply-detection)."""
     if _skip_if_throttled("auto_send_due_followups"):
-        return "Automation paused"
+        return "Automation throttled"
     from cqc_lem.app.run_automation import process_user_followups
     from cqc_lem.utilities.db import get_due_followups
     # due_at is stored naive-UTC; compare against naive-UTC now (not container-local time).
@@ -679,7 +677,7 @@ def auto_clean_stale_profiles():
 def auto_invite_to_company_pages():
     """Start invite process for each active user who has a linked in company page"""
     if _skip_if_throttled("auto_invite_to_company_pages"):
-        return "Automation paused"
+        return "Automation throttled"
 
     # Get all active users and loop through them
     users = get_active_user_ids()

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -20,19 +20,30 @@ from cqc_lem.utilities.db import (
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES
 from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
-from cqc_lem.utilities.linkedin.rate_limit import is_automation_paused, automation_pause_remaining
+from cqc_lem.utilities.linkedin.rate_limit import is_automation_paused, automation_pause_remaining, \
+    rate_limit_cooldown_remaining
 from cqc_lem.utilities.notifications import notify_linkedin_session
 
 
-def _skip_if_paused(name: str) -> bool:
-    """True when a manual automation pause is active — Selenium fan-out beat tasks short-circuit on
-    it so a recovering rate-limited account isn't hammered (login_to_linkedin also gates centrally,
-    but skipping here avoids spinning up Chrome sessions that would only fail). POSTING is API-driven
-    and deliberately NOT gated."""
+def _skip_if_throttled(name: str) -> bool:
+    """True when Selenium engagement should NOT fan out — either a manual automation pause OR an open
+    429 circuit breaker cooldown is active. Beat dispatchers short-circuit on both so a rate-limited
+    account isn't hammered: login_to_linkedin gates centrally too, but skipping at dispatch avoids
+    spinning up Chrome sessions that would only fail AND — critically — stops tasks from probing the
+    feed the instant the cooldown expires, which is what re-tripped the breaker into a doom loop.
+    POSTING is API-driven and deliberately NOT gated."""
     if is_automation_paused():
         log_info(f"{name} skipped — automation paused (~{automation_pause_remaining()}s left)")
         return True
+    cooldown = rate_limit_cooldown_remaining()
+    if cooldown > 0:
+        log_info(f"{name} skipped — LinkedIn 429 breaker open (~{cooldown}s left)")
+        return True
     return False
+
+
+# Backward-compatible alias — historically only checked the manual pause.
+_skip_if_paused = _skip_if_throttled
 
 
 
@@ -63,8 +74,10 @@ def auto_check_scheduled_posts(self):
 
         # Only dispatch Selenium pre-post tasks for users with an active LinkedIn
         # connection and subscription. Inactive/disconnected users' sessions fail
-        # immediately and waste a Chrome slot that active users need.
-        if user_id in active_user_ids:
+        # immediately and waste a Chrome slot that active users need. Also skip them
+        # while throttled (pause / 429 breaker) so they don't probe the feed — the API
+        # post above still goes out regardless.
+        if user_id in active_user_ids and not _skip_if_throttled("pre-post Selenium"):
             base_kwargs = {'user_id': user_id, 'loop_for_duration': 60 * 15}
 
             # Start the pre-post commenting task 15 minutes before scheduled post (loop for 15 minutes)
@@ -143,7 +156,7 @@ def auto_check_scheduled_dms(self):
 
 @shared_task.task
 def auto_appreciate_dms():
-    if _skip_if_paused("auto_appreciate_dms"):
+    if _skip_if_throttled("auto_appreciate_dms"):
         return "Automation paused"
     # For each user schedule appreciate DMS
     users = get_active_user_ids()
@@ -176,7 +189,7 @@ def auto_daily_engagement():
     because both this run and the pre-post runs share the per-day comment cap (enforced in
     comment_on_feed_inline), and QueueOnce (keys=['user_id']) prevents overlapping double-runs for
     the same user."""
-    if _skip_if_paused("auto_daily_engagement"):
+    if _skip_if_throttled("auto_daily_engagement"):
         return "Automation paused"
     users = get_active_user_ids()
     dispatched = 0
@@ -195,6 +208,8 @@ def dispatch_scheduled_reply_sweeps():
     interval gates it: while the key exists we're within the interval and skip, so running this beat
     every ~30 min naturally yields ~reply_sweeps_per_day sweeps. Fails open on Redis outage (dispatch
     anyway) — sweep_reply_comments itself is QueueOnce + 429-safe, so an extra run is harmless."""
+    if _skip_if_throttled("dispatch_scheduled_reply_sweeps"):
+        return "Automation throttled"
     from cqc_lem.utilities.linkedin.rate_limit import _redis_client
     users = get_users_with_reply_mode("scheduled")
     if not users:
@@ -453,6 +468,11 @@ def regenerate_newsletter_edition(edition_id: int, guidance: str = None):
 @shared_task.task
 def auto_publish_scheduled_editions():
     """Publish any newsletter edition whose scheduled slot has arrived (approved or untouched draft)."""
+    # Newsletter publishing is Selenium-driven, so gate it on the breaker like the other fan-outs.
+    # This hourly task was the primary re-tripper of the 429 doom loop: it probed the feed the moment
+    # the cooldown lapsed and re-escalated it back to the 6h cap.
+    if _skip_if_throttled("auto_publish_scheduled_editions"):
+        return "Automation throttled"
     from cqc_lem.app.run_automation import auto_publish_edition
     from cqc_lem.utilities.db import get_editions_due_to_publish
     due = get_editions_due_to_publish(datetime.now(timezone.utc).replace(tzinfo=None))
@@ -506,7 +526,7 @@ def auto_sync_groups():
 @shared_task.task
 def auto_group_engagement():
     """Daily value-add commenting in each active user's ENABLED groups (shares the per-day cap)."""
-    if _skip_if_paused("auto_group_engagement"):
+    if _skip_if_throttled("auto_group_engagement"):
         return "Automation paused"
     from cqc_lem.app.run_automation import auto_comment_in_groups
     users = get_active_user_ids()
@@ -538,7 +558,7 @@ def auto_group_posts():
 @shared_task.task
 def auto_scrape_stats():
     """Daily: capture engagement stats on each active user's recent posts (powers post-time recs)."""
-    if _skip_if_paused("auto_scrape_stats"):
+    if _skip_if_throttled("auto_scrape_stats"):
         return "Automation paused"
     from cqc_lem.app.run_automation import auto_scrape_post_stats
     users = get_active_user_ids()
@@ -553,7 +573,7 @@ def auto_scrape_stats():
 @shared_task.task
 def auto_send_due_followups():
     """Dispatch a per-user Selenium task to send due DM follow-ups (each gated by reply-detection)."""
-    if _skip_if_paused("auto_send_due_followups"):
+    if _skip_if_throttled("auto_send_due_followups"):
         return "Automation paused"
     from cqc_lem.app.run_automation import process_user_followups
     from cqc_lem.utilities.db import get_due_followups
@@ -658,7 +678,7 @@ def auto_clean_stale_profiles():
 @shared_task.task
 def auto_invite_to_company_pages():
     """Start invite process for each active user who has a linked in company page"""
-    if _skip_if_paused("auto_invite_to_company_pages"):
+    if _skip_if_throttled("auto_invite_to_company_pages"):
         return "Automation paused"
 
     # Get all active users and loop through them

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -1,4 +1,5 @@
 import os
+import random
 import time
 from typing import Optional
 
@@ -17,6 +18,39 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
+
+
+def _human_pause(min_seconds: float, max_seconds: float) -> None:
+    """Sleep a random human-like interval to space out automated navigations. Set
+    LINKEDIN_HUMANIZE_DELAYS=false (e.g. in tests) to make this a no-op."""
+    if os.getenv("LINKEDIN_HUMANIZE_DELAYS", "true").lower() == "false":
+        return
+    time.sleep(random.uniform(min_seconds, max_seconds))
+
+
+def _text_is_transport_error(body: str) -> bool:
+    """Chrome network/proxy error interstitial ("This site can't be reached", ERR_* codes) — a
+    transport failure (flaky residential proxy, DNS, timeout), NOT a LinkedIn throttle. Kept separate
+    so a proxy blip doesn't trip the shared 429 breaker and pause all automation."""
+    low = (body or "").lower()
+    return ("this site can’t be reached" in low or "this site can't be reached" in low
+            or "err_" in low)
+
+
+def _text_is_rate_limited(body: str) -> bool:
+    """True when the rendered page text is a LinkedIn rate-limit response (HTTP 429, or LinkedIn's
+    custom 999 anti-bot status). Deliberately does NOT fire on the bare "This page isn't working"
+    shell alone — Chrome renders that identical shell for 500/502/503 and for proxy/network errors,
+    so keying off it indiscriminately trips the breaker on transient failures."""
+    if _text_is_transport_error(body):
+        return False
+    low = (body or "").lower()
+    if "too many requests" in low or "http error 429" in low or "http error 999" in low:
+        return True
+    # Tiny HTTP-error shell: only a rate-limit status code (429 / LinkedIn's 999) counts.
+    if len(body or "") < 200 and ("this page isn’t working" in low or "this page isn't working" in low):
+        return "429" in low or "999" in low
+    return False
 
 
 def solve_arkose_challenge(driver: WebDriver, wait: WebDriverWait) -> bool:
@@ -259,18 +293,17 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
     def _is_logged_in(url: str) -> bool:
         return any(p in url for p in _LOGGED_IN_PATHS)
 
-    def _page_is_rate_limited(drv) -> bool:
-        """LinkedIn returns a 429 error page (or a tiny 'This page isn't working' body)
-        at normal URLs when throttled. Detect it from the rendered body text."""
+    def _page_body(drv) -> str:
         try:
-            body = drv.find_element(By.TAG_NAME, "body").text or ""
+            return drv.find_element(By.TAG_NAME, "body").text or ""
         except Exception:
-            return False
-        low = body.lower()
-        if len(body) < 200 and ("429" in low or "this page isn’t working" in low
-                                or "this page isn't working" in low):
-            return True
-        return "http error 429" in low or "too many requests" in low
+            return ""
+
+    def _page_is_transport_error(drv) -> bool:
+        return _text_is_transport_error(_page_body(drv))
+
+    def _page_is_rate_limited(drv) -> bool:
+        return _text_is_rate_limited(_page_body(drv))
 
     def _page_is_redirect_loop(drv) -> bool:
         """Stored cookies minted from a different egress IP (e.g. after switching to a
@@ -372,6 +405,10 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
     if cookies:
         myprint("Found previous cookies. Loading them now!")
         load_cookies(driver, cookies)
+        # Human-like jitter before hitting the feed. Rapid, perfectly-timed base→feed navigations
+        # from a headless browser are an easy automation tell; a short randomized settle lets the
+        # base page finish and spaces requests out. Tunable/zeroable via env for tests.
+        _human_pause(1.5, 4.0)
         # Navigate directly to the feed — if cookies are valid LinkedIn serves it;
         # if invalid/expired it redirects to a login or challenge page
         driver.get(feed_url)
@@ -405,6 +442,14 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
         raise LinkedInRateLimited(
             "LinkedIn is rate-limiting this session (HTTP 429). Backing off — "
             "reduce automation frequency and retry later.")
+
+    # A Chrome transport error (proxy blip / DNS / timeout) also sits on the /feed URL, so it would
+    # otherwise be mistaken for a live session below — clearing the breaker and storing junk cookies.
+    # Raise a transient error WITHOUT tripping the 429 breaker so the task simply retries later.
+    if _is_logged_in(driver.current_url) and _page_is_transport_error(driver):
+        raise LinkedInRateLimited(
+            "Feed did not load (proxy/network error) — transient, retrying later without "
+            "tripping the rate-limit breaker.")
 
     if _is_logged_in(driver.current_url):
         myprint(f"Already logged in! (current URL: {driver.current_url})")

--- a/src/cqc_lem/utilities/linkedin/rate_limit.py
+++ b/src/cqc_lem/utilities/linkedin/rate_limit.py
@@ -99,6 +99,8 @@ def mark_rate_limited(reason: str = "") -> None:
         try:
             client.expire(_TRIP_COUNT_KEY, seconds + _trip_count_grace_seconds())
         except Exception:
+            # Best-effort TTL refresh — the counter still has its previous TTL, so a failure here
+            # just means slightly less-precise self-reset timing, not a broken breaker. Swallow it.
             pass
         client.set(_COOLDOWN_KEY, reason or "429", ex=seconds)
         log_warning(f"LinkedIn 429 circuit breaker OPEN for {seconds}s (consecutive trip #{trips}) "

--- a/src/cqc_lem/utilities/linkedin/rate_limit.py
+++ b/src/cqc_lem/utilities/linkedin/rate_limit.py
@@ -18,7 +18,13 @@ _TRIP_COUNT_KEY = "linkedin:429_trip_count"   # consecutive trips → escalating
 _PAUSE_KEY = "linkedin:automation_paused"     # manual global Selenium pause
 _DEFAULT_COOLDOWN_SECONDS = 1800  # 30 min
 _DEFAULT_MAX_COOLDOWN_SECONDS = 6 * 60 * 60  # cap the escalation at 6h
-_TRIP_COUNT_TTL = 24 * 60 * 60  # remember consecutive trips for a day
+# Grace window added to the cooldown when setting the consecutive-trip counter's TTL. The counter is
+# what drives escalation; tying its lifetime to (cooldown + grace) instead of a fixed 24h makes the
+# escalation SELF-RESETTING: once a full cooldown elapses without a fresh trip (the throttle lifted,
+# so the post-cooldown probe either succeeded → clear_rate_limit, or simply didn't re-trip), the
+# counter expires and the next 429 starts back at the base cooldown. A fixed 24h TTL let the counter
+# outlive several 6h cooldowns, pinning escalation at the cap long after conditions improved.
+_DEFAULT_TRIP_COUNT_GRACE_SECONDS = 30 * 60  # 30 min
 
 
 class LinkedInRateLimited(RuntimeError):
@@ -41,6 +47,13 @@ def _max_cooldown_seconds() -> int:
         return int(os.getenv("LINKEDIN_RATE_LIMIT_MAX_COOLDOWN_SECONDS", str(_DEFAULT_MAX_COOLDOWN_SECONDS)))
     except ValueError:
         return _DEFAULT_MAX_COOLDOWN_SECONDS
+
+
+def _trip_count_grace_seconds() -> int:
+    try:
+        return int(os.getenv("LINKEDIN_RATE_LIMIT_TRIP_GRACE_SECONDS", str(_DEFAULT_TRIP_COUNT_GRACE_SECONDS)))
+    except ValueError:
+        return _DEFAULT_TRIP_COUNT_GRACE_SECONDS
 
 
 def _redis_client():
@@ -69,17 +82,24 @@ def mark_rate_limited(reason: str = "") -> None:
     if client is None:
         return
     try:
-        # Escalating back-off: each CONSECUTIVE trip (counter cleared only by a successful login)
-        # doubles the cooldown — base, 2x, 4x, … up to a cap. A fixed 30-min cooldown meant that as
-        # soon as it expired some task probed LinkedIn, drew a fresh 429 and re-tripped it every
-        # ~30 min forever (the doom loop). Escalation probes less and less often so the throttled IP
-        # can actually recover.
+        # Escalating back-off: each CONSECUTIVE trip doubles the cooldown — base, 2x, 4x, … up to a
+        # cap. A fixed 30-min cooldown meant that as soon as it expired some task probed LinkedIn,
+        # drew a fresh 429 and re-tripped it every ~30 min forever (the doom loop). Escalation probes
+        # less and less often so the throttled IP can actually recover. The consecutive-trip counter
+        # is cleared by a successful login (clear_rate_limit) OR self-expires once a full cooldown +
+        # grace elapses with no new trip — see the counter-TTL note below.
         try:
             trips = int(client.incr(_TRIP_COUNT_KEY))
-            client.expire(_TRIP_COUNT_KEY, _TRIP_COUNT_TTL)
         except Exception:
             trips = 1
         seconds = min(_max_cooldown_seconds(), _cooldown_seconds() * (2 ** max(0, trips - 1)))
+        # Counter lives exactly as long as this back-off window plus a grace period. If the throttle
+        # lifts, the post-cooldown probe won't re-trip within grace, the counter expires, and the
+        # NEXT 429 (if any) escalates from scratch — instead of staying pinned at the cap for a day.
+        try:
+            client.expire(_TRIP_COUNT_KEY, seconds + _trip_count_grace_seconds())
+        except Exception:
+            pass
         client.set(_COOLDOWN_KEY, reason or "429", ex=seconds)
         log_warning(f"LinkedIn 429 circuit breaker OPEN for {seconds}s (consecutive trip #{trips}) "
                     "— Selenium engagement paused", action_type="rate_limit", http_status=429)

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -31,6 +31,15 @@ _PATCH_AUTOMATE_COMMENTING = f"{_MOD}.automate_commenting"
 _PATCH_AUTOMATE_PROFILE_VIEWER = f"{_MOD}.automate_profile_viewer_engagement"
 
 
+@pytest.fixture(autouse=True)
+def _not_throttled():
+    """Keep the automation throttle (manual pause + 429 breaker) OPEN=off and hermetic by default so
+    dispatcher tests never touch Redis. Tests exercising the throttle gate patch these explicitly."""
+    with patch(f"{_MOD}.is_automation_paused", return_value=False), \
+         patch(f"{_MOD}.rate_limit_cooldown_remaining", return_value=0):
+        yield
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -926,3 +935,88 @@ class TestDispatchScheduledReplySweeps:
              patch(f"{self._M}.sweep_reply_comments"):
             dispatch_scheduled_reply_sweeps()
         assert redis.set.call_args.kwargs["ex"] == 2 * 60 * 60  # 12/day = 2h, the floor
+
+
+# ---------------------------------------------------------------------------
+# _skip_if_throttled + dispatcher gating on the 429 breaker
+# ---------------------------------------------------------------------------
+
+class TestSkipIfThrottled:
+    def test_not_throttled_returns_false(self):
+        from cqc_lem.app.run_scheduler import _skip_if_throttled
+        with patch(f"{_MOD}.is_automation_paused", return_value=False), \
+             patch(f"{_MOD}.rate_limit_cooldown_remaining", return_value=0):
+            assert _skip_if_throttled("x") is False
+
+    def test_manual_pause_returns_true(self):
+        from cqc_lem.app.run_scheduler import _skip_if_throttled
+        with patch(f"{_MOD}.is_automation_paused", return_value=True), \
+             patch(f"{_MOD}.automation_pause_remaining", return_value=123), \
+             patch(f"{_MOD}.rate_limit_cooldown_remaining", return_value=0):
+            assert _skip_if_throttled("x") is True
+
+    def test_open_429_breaker_returns_true(self):
+        # The core fix: dispatchers must short-circuit on the 429 cooldown, not only the manual pause.
+        from cqc_lem.app.run_scheduler import _skip_if_throttled
+        with patch(f"{_MOD}.is_automation_paused", return_value=False), \
+             patch(f"{_MOD}.rate_limit_cooldown_remaining", return_value=900):
+            assert _skip_if_throttled("x") is True
+
+    def test_legacy_alias_points_at_throttled(self):
+        from cqc_lem.app.run_scheduler import _skip_if_paused, _skip_if_throttled
+        assert _skip_if_paused is _skip_if_throttled
+
+
+class TestNewsletterPublishGatedOnBreaker:
+    def test_skips_dispatch_when_breaker_open(self):
+        from cqc_lem.app.run_scheduler import auto_publish_scheduled_editions
+        with patch(f"{_MOD}.rate_limit_cooldown_remaining", return_value=900), \
+             patch(f"{_MOD}.is_automation_paused", return_value=False), \
+             patch("cqc_lem.app.run_automation.auto_publish_edition") as pub, \
+             patch("cqc_lem.utilities.db.get_editions_due_to_publish") as due:
+            result = auto_publish_scheduled_editions()
+        pub.apply_async.assert_not_called()
+        due.assert_not_called()
+        assert "throttled" in result.lower()
+
+    def test_dispatches_when_not_throttled(self):
+        from cqc_lem.app.run_scheduler import auto_publish_scheduled_editions
+        with patch("cqc_lem.app.run_automation.auto_publish_edition") as pub, \
+             patch("cqc_lem.utilities.db.get_editions_due_to_publish", return_value=[{"id": 7}]):
+            result = auto_publish_scheduled_editions()
+        pub.apply_async.assert_called_once()
+        assert "Dispatched 1" in result
+
+
+class TestReplySweepDispatchGatedOnBreaker:
+    def test_skips_dispatch_when_breaker_open(self):
+        from cqc_lem.app.run_scheduler import dispatch_scheduled_reply_sweeps
+        with patch(f"{_MOD}.rate_limit_cooldown_remaining", return_value=900), \
+             patch(f"{_MOD}.is_automation_paused", return_value=False), \
+             patch(f"{_MOD}.get_users_with_reply_mode") as get_users, \
+             patch(f"{_MOD}.sweep_reply_comments") as sweep:
+            result = dispatch_scheduled_reply_sweeps()
+        get_users.assert_not_called()
+        sweep.apply_async.assert_not_called()
+        assert "throttled" in result.lower()
+
+
+class TestPrePostSeleniumGatedOnBreaker:
+    def test_pre_post_selenium_skipped_when_breaker_open_but_post_still_dispatched(self):
+        from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+        sched = datetime(2026, 7, 21, 12, 0, tzinfo=timezone.utc)
+        with patch(f"{_MOD}.rate_limit_cooldown_remaining", return_value=900), \
+             patch(f"{_MOD}.is_automation_paused", return_value=False), \
+             patch(_PATCH_GET_POSTS, return_value=[(101, sched, 1)]), \
+             patch(_PATCH_GET_ACTIVE, return_value=[1]), \
+             patch(_PATCH_UPDATE_POST_STATUS), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
+             patch(_PATCH_POST_TO_LINKEDIN) as post, \
+             patch(_PATCH_AUTOMATE_COMMENTING) as commenting, \
+             patch(f"{_MOD}.auto_seed_comment_on_post") as seed, \
+             patch(_PATCH_AUTOMATE_PROFILE_VIEWER) as viewer:
+            auto_check_scheduled_posts()
+        post.apply_async.assert_called_once()      # API post still goes out
+        commenting.apply_async.assert_not_called()  # Selenium pre-post gated off
+        seed.apply_async.assert_not_called()
+        viewer.apply_async.assert_not_called()

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -863,7 +863,7 @@ class TestAutomationPauseGating:
              patch(f"{self._M}.automation_pause_remaining", return_value=999), \
              patch(f"{self._M}.get_active_user_ids") as users:
             result = auto_daily_engagement()
-        assert "paused" in result.lower()
+        assert "throttled" in result.lower()  # generic — the skip may be pause OR the 429 breaker
         users.assert_not_called()  # short-circuits before fanning out any Selenium work
 
     def test_appreciate_dms_skips_when_paused(self):
@@ -872,7 +872,7 @@ class TestAutomationPauseGating:
              patch(f"{self._M}.automation_pause_remaining", return_value=1), \
              patch(f"{self._M}.get_active_user_ids") as users:
             result = auto_appreciate_dms()
-        assert "paused" in result.lower()
+        assert "throttled" in result.lower()  # generic — the skip may be pause OR the 429 breaker
         users.assert_not_called()
 
     def test_runs_normally_when_not_paused(self):
@@ -961,10 +961,6 @@ class TestSkipIfThrottled:
         with patch(f"{_MOD}.is_automation_paused", return_value=False), \
              patch(f"{_MOD}.rate_limit_cooldown_remaining", return_value=900):
             assert _skip_if_throttled("x") is True
-
-    def test_legacy_alias_points_at_throttled(self):
-        from cqc_lem.app.run_scheduler import _skip_if_paused, _skip_if_throttled
-        assert _skip_if_paused is _skip_if_throttled
 
 
 class TestNewsletterPublishGatedOnBreaker:

--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -665,3 +665,73 @@ class TestRedirectLoopRecovery:
     def test_redirect_loop_recovers_to_successful_login(self):
         _, _, mock_store = self._run()
         mock_store.assert_called_once()  # fresh cookies persisted after re-auth
+
+
+# ---------------------------------------------------------------------------
+# 429 / transport-error page classification (hardened detector)
+# ---------------------------------------------------------------------------
+
+class TestPageClassification:
+    def test_explicit_429_body_is_rate_limited(self):
+        from cqc_lem.utilities.linkedin.helper import _text_is_rate_limited
+        assert _text_is_rate_limited("HTTP ERROR 429") is True
+
+    def test_too_many_requests_is_rate_limited(self):
+        from cqc_lem.utilities.linkedin.helper import _text_is_rate_limited
+        assert _text_is_rate_limited("Too Many Requests") is True
+
+    def test_linkedin_999_is_rate_limited(self):
+        from cqc_lem.utilities.linkedin.helper import _text_is_rate_limited
+        assert _text_is_rate_limited("HTTP ERROR 999") is True
+
+    def test_tiny_shell_with_429_code_is_rate_limited(self):
+        from cqc_lem.utilities.linkedin.helper import _text_is_rate_limited
+        assert _text_is_rate_limited("This page isn't working. HTTP ERROR 429") is True
+
+    def test_tiny_shell_without_code_is_not_rate_limited(self):
+        # Bare "This page isn't working" (no 429/999) must NOT trip the breaker — it's the generic
+        # Chrome HTTP-error shell also used for 500/502/503.
+        from cqc_lem.utilities.linkedin.helper import _text_is_rate_limited
+        assert _text_is_rate_limited("This page isn't working right now.") is False
+
+    def test_server_error_500_is_not_rate_limited(self):
+        from cqc_lem.utilities.linkedin.helper import _text_is_rate_limited
+        assert _text_is_rate_limited("This page isn't working. HTTP ERROR 500") is False
+
+    def test_proxy_error_is_not_rate_limited(self):
+        # A flaky residential proxy must not be mistaken for a LinkedIn throttle.
+        from cqc_lem.utilities.linkedin.helper import _text_is_rate_limited
+        assert _text_is_rate_limited("This site can't be reached. ERR_PROXY_CONNECTION_FAILED") is False
+
+    def test_proxy_error_is_transport_error(self):
+        from cqc_lem.utilities.linkedin.helper import _text_is_transport_error
+        assert _text_is_transport_error("This site can't be reached\nERR_TIMED_OUT") is True
+
+    def test_normal_feed_is_neither(self):
+        from cqc_lem.utilities.linkedin.helper import _text_is_rate_limited, _text_is_transport_error
+        body = "Home  My Network  Jobs  Messaging  Notifications  Start a post"
+        assert _text_is_rate_limited(body) is False
+        assert _text_is_transport_error(body) is False
+
+    def test_empty_body_is_neither(self):
+        from cqc_lem.utilities.linkedin.helper import _text_is_rate_limited, _text_is_transport_error
+        assert _text_is_rate_limited("") is False
+        assert _text_is_transport_error("") is False
+
+
+class TestHumanPause:
+    def test_disabled_is_noop(self, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_HUMANIZE_DELAYS", "false")
+        import cqc_lem.utilities.linkedin.helper as h
+        with patch.object(h.time, "sleep") as slept:
+            h._human_pause(1.0, 2.0)
+        slept.assert_not_called()
+
+    def test_enabled_sleeps_within_range(self, monkeypatch):
+        monkeypatch.delenv("LINKEDIN_HUMANIZE_DELAYS", raising=False)
+        import cqc_lem.utilities.linkedin.helper as h
+        with patch.object(h.time, "sleep") as slept, \
+             patch.object(h.random, "uniform", return_value=1.5) as uni:
+            h._human_pause(1.0, 2.0)
+        uni.assert_called_once_with(1.0, 2.0)
+        slept.assert_called_once_with(1.5)

--- a/tests/unit/utilities/linkedin/test_rate_limit.py
+++ b/tests/unit/utilities/linkedin/test_rate_limit.py
@@ -32,6 +32,23 @@ class TestCooldownSeconds:
         assert _cooldown_seconds() == 1800
 
 
+class TestTripCountGraceSeconds:
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("LINKEDIN_RATE_LIMIT_TRIP_GRACE_SECONDS", raising=False)
+        from cqc_lem.utilities.linkedin.rate_limit import _trip_count_grace_seconds
+        assert _trip_count_grace_seconds() == 1800
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_TRIP_GRACE_SECONDS", "90")
+        from cqc_lem.utilities.linkedin.rate_limit import _trip_count_grace_seconds
+        assert _trip_count_grace_seconds() == 90
+
+    def test_bad_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_TRIP_GRACE_SECONDS", "nope")
+        from cqc_lem.utilities.linkedin.rate_limit import _trip_count_grace_seconds
+        assert _trip_count_grace_seconds() == 1800
+
+
 class TestMarkRateLimited:
     def test_sets_key_with_ttl(self, fake_redis, monkeypatch):
         monkeypatch.setenv("LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS", "120")
@@ -63,6 +80,26 @@ class TestMarkRateLimited:
         mark_rate_limited("x")
         fake_redis.incr.assert_called_once_with("linkedin:429_trip_count")
         fake_redis.expire.assert_called_once()
+
+    def test_trip_counter_ttl_is_cooldown_plus_grace(self, fake_redis, monkeypatch):
+        # The counter must self-expire once a full cooldown + grace elapses without a new trip, so the
+        # escalation resets instead of staying pinned at the cap (the old fixed-24h TTL doom loop).
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS", "100")
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_TRIP_GRACE_SECONDS", "60")
+        monkeypatch.delenv("LINKEDIN_RATE_LIMIT_MAX_COOLDOWN_SECONDS", raising=False)
+        fake_redis.incr.return_value = 3  # cooldown = 100 * 2^2 = 400
+        from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited
+        mark_rate_limited("x")
+        fake_redis.expire.assert_called_once_with("linkedin:429_trip_count", 400 + 60)
+
+    def test_trip_counter_ttl_uses_capped_cooldown_plus_grace(self, fake_redis, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS", "1800")
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_MAX_COOLDOWN_SECONDS", "21600")
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_TRIP_GRACE_SECONDS", "1800")
+        fake_redis.incr.return_value = 20  # far past the cap → cooldown clamps to 21600
+        from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited
+        mark_rate_limited("x")
+        fake_redis.expire.assert_called_once_with("linkedin:429_trip_count", 21600 + 1800)
 
     def test_defaults_reason(self, fake_redis):
         from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited


### PR DESCRIPTION
## Problem

Feed commenting (and all Selenium engagement) had been fully paused for days. `automate_commenting` aborted at login every run with *"429 circuit breaker open."*

LinkedIn serves a real HTTP 429 on the authenticated `/feed/` nav (verified: user 1's proxy IP gets 200 on the guest home but 429 on the authed feed — throttle tied to the bot-like session, not a dead proxy). The shared breaker escalated to its 6h cap (trip #27) and stayed stuck because:

1. **Beat dispatchers only short-circuited on the manual pause, not the 429 cooldown** — so tasks (notably the hourly `auto_publish_edition`) kept probing the feed the instant the cooldown lapsed and re-escalated it.
2. **The consecutive-trip counter had a fixed 24h TTL** that outlived several 6h cooldowns, pinning escalation at the cap long after conditions improved.

## Fix

- `run_scheduler`: `_skip_if_paused` → `_skip_if_throttled`, gating on **both** the manual pause and `rate_limit_cooldown_remaining()>0`; applied to every Selenium fan-out incl. `auto_publish_scheduled_editions`, `dispatch_scheduled_reply_sweeps`, and the pre-post block (the API post stays ungated).
- `rate_limit`: trip-counter TTL now = `cooldown + grace` (`LINKEDIN_RATE_LIMIT_TRIP_GRACE_SECONDS`, default 30m) so escalation **self-resets** once a full back-off window elapses without a fresh trip.
- `helper`: hardened the 429 detector — a bare "This page isn't working" shell or a Chrome `ERR_*` proxy/transport error no longer trips the breaker (require an actual 429/999); transport errors raise transient instead of masquerading as a live session. Pure text classification extracted to module level for testing.
- `helper`: human-like jitter before the feed nav (`LINKEDIN_HUMANIZE_DELAYS`).

## Tests

New coverage for dispatcher gating, trip-counter TTL/grace, the hardened detector, and jitter. Full unit suite green (2572 passed).

## Ops note

Live account was recovered on 2026-07-21 via a 24h `pause_automation` + breaker reset; escalation has since dropped 27 → 1. LinkedIn is still 429'ing the authed feed as of 2026-07-22, so this gating/decay is what prevents the hourly re-escalation going forward. **Already running in production as the `hotfix-429` overlay image** — merging this + cutting a release replaces that overlay with a proper GHCR build so the next release doesn't revert the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)