### PR TITLE
fix(selenium): route every LinkedIn session through the user's proxy + drop the stale UA

### DIFF
--- a/src/cqc_lem/app/aws_test_celery_task.py
+++ b/src/cqc_lem/app/aws_test_celery_task.py
@@ -14,7 +14,7 @@ def test_task(seconds):
 @shared_task.task
 def test_get_my_profile(user_id: int):
     user_email, user_password = get_user_password_pair_by_id(user_id)
-    driver, wait = get_driver_wait_pair(headless=True, session_name="AWS Test Get My Profile")
+    driver, wait = get_driver_wait_pair(headless=True, session_name="AWS Test Get My Profile", user_id=user_id)
 
     try:
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -268,7 +268,7 @@ def comment_on_post(self, user_id: int, post_link: str, comment_text: str):
         myprint("Another task already claimed this post. Skipping...")
         return "Another task already claimed this post. Skipping..."
 
-    driver, wait = get_driver_wait_pair(session_name='Post Comment')
+    driver, wait = get_driver_wait_pair(session_name='Post Comment', user_id=user_id)
 
     try:
 
@@ -1785,7 +1785,7 @@ def accept_connection_request(user_id: int):
 
     user_email, user_password = get_user_password_pair_by_id(user_id)
 
-    driver, wait = get_driver_wait_pair(session_name='Accept Connection Requests')
+    driver, wait = get_driver_wait_pair(session_name='Accept Connection Requests', user_id=user_id)
 
     login_to_linkedin(driver, wait, user_email, user_password)
 
@@ -1979,7 +1979,7 @@ def process_user_followups(self, user_id: int, max_per_run: int = 20):
 def automate_appreciation_dms_for_user(self, user_id: int, loop_for_duration: int = None, future_forward: int = 60):
     user_email, user_password = get_user_password_pair_by_id(user_id)
 
-    driver, wait = get_driver_wait_pair(session_name='Appreciation DMs')
+    driver, wait = get_driver_wait_pair(session_name='Appreciation DMs', user_id=user_id)
 
     try:
         login_to_linkedin(driver, wait, user_email, user_password)
@@ -2450,7 +2450,7 @@ def send_dm_now(user_id: int, profile_url: str, message: str) -> bool:
     (issue #306 scheduler) so both use the same send + logging path."""
     user_email, user_password = get_user_password_pair_by_id(user_id)
 
-    driver, wait = get_driver_wait_pair(session_name='Private DM')
+    driver, wait = get_driver_wait_pair(session_name='Private DM', user_id=user_id)
 
     login_to_linkedin(driver, wait, user_email, user_password)
 
@@ -2545,7 +2545,7 @@ def send_scheduled_dm(self, dm_id: int):
 def invite_to_connect(self, user_id: int, profile_url: str, message: str = None):
     user_email, user_password = get_user_password_pair_by_id(user_id)
 
-    driver, wait = get_driver_wait_pair(session_name='Invite to Connect')
+    driver, wait = get_driver_wait_pair(session_name='Invite to Connect', user_id=user_id)
 
     result = "Invitation to Connect Started"
 
@@ -2848,7 +2848,7 @@ def post_to_linkedin(self, user_id: int, post_id: int):
 def automate_invites_to_company_page_for_user(self, user_id: int):
     """Send invites to the company page for the given user."""
 
-    driver, wait = get_driver_wait_pair(session_name='Company Page Invites')
+    driver, wait = get_driver_wait_pair(session_name='Company Page Invites', user_id=user_id)
 
     try:
 

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -680,7 +680,7 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
 
     if user_profile is None:
         user_email, user_password = get_user_password_pair_by_id(user_id)
-        driver, wait = get_driver_wait_pair(session_name='Create Text Post')
+        driver, wait = get_driver_wait_pair(session_name='Create Text Post', user_id=user_id)
         try:
             user_profile = get_my_profile(driver, wait, user_email, user_password, user_id=user_id)
         except Exception as e:

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -2697,7 +2697,7 @@ def generate_carousel_content(user_id: int, stage: str, prefs: dict = None,
     # Attempt to load user profile for personalisation; fall back gracefully
     try:
         user_email, user_password = get_user_password_pair_by_id(user_id)
-        driver, wait = get_driver_wait_pair(session_name="Carousel AI")
+        driver, wait = get_driver_wait_pair(session_name="Carousel AI", user_id=user_id)
         try:
             profile = get_my_profile(driver, wait, user_email, user_password, user_id=user_id)
         finally:

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -5,6 +5,7 @@ import time
 import zipfile
 from datetime import datetime, timedelta
 from functools import wraps
+from typing import Optional
 from urllib.parse import urlparse
 
 import requests
@@ -21,8 +22,12 @@ from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 from cqc_lem.utilities.env_constants import *
-from cqc_lem.utilities.logger import myprint, log_warning
+from cqc_lem.utilities.logger import myprint, log_info, log_warning
 from cqc_lem.utilities.utils import get_aws_device_farm_url
+
+# Last-resort geolocation when a session has no user_id and therefore no stored Login Location.
+_DEFAULT_LATITUDE = 30.3321
+_DEFAULT_LONGITUDE = -81.6556
 
 
 def quit_gracefully(driver: WebDriver):
@@ -101,7 +106,17 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
     user_locale = "en-US"
     user_proxy = None
     user_country = None
-    if user_id is not None:
+    if user_id is None:
+        # Without a user_id there is no proxy, no timezone, no locale and no geo — the session
+        # egresses straight from the host (a datacenter IP on the VPS) with a mismatched location.
+        # That is the configuration that drove the sustained LinkedIn /feed 429s, and it used to
+        # happen silently at nearly every call site. Never let it be silent again.
+        log_warning(
+            f"Selenium session '{session_name}' created WITHOUT user_id — no proxy, timezone, "
+            "locale or geolocation will be applied and egress will be the host IP. Pass user_id "
+            "for any session that touches LinkedIn.",
+            action_type="login")
+    else:
         from cqc_lem.utilities.db import get_user_geo, get_user_proxy
         geo = get_user_geo(user_id)
         if geo:
@@ -118,6 +133,12 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
     # matched to the user's country → global default → none (direct egress).
     from cqc_lem.utilities.proxy import resolve_proxy
     effective_proxy = resolve_proxy(user_proxy, user_country)
+
+    # One line per session answering "was this actually proxied, and as whom?" — previously this
+    # could only be determined by shelling into the container. Host:port only; never the
+    # credentials embedded in the proxy URL.
+    log_info(f"Selenium session '{session_name}' egress={_proxy_label(effective_proxy)} "
+             f"tz={user_timezone} locale={user_locale}", user_id=user_id, action_type="login")
 
     options = getBaseOptions()
     options.add_argument("--ignore-ssl-errors=yes")
@@ -150,11 +171,21 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
         myprint(f"Could not apply stealth init script | Error: {e}")
 
     if coordinates is None:
+        # lat/lng come from the user's stored Login Location (get_user_geo above). The constants are
+        # a last-resort fallback ONLY — reporting a fixed city that contradicts the egress IP's city
+        # is itself a "new location" signal, so a session without a resolved geo is degraded, not
+        # neutral. That's part of what the missing-user_id warning below is about.
         coordinates = {
-            "latitude": lat if lat is not None else 30.3321,
-            "longitude": lng if lng is not None else -81.6556,
+            "latitude": lat if lat is not None else _DEFAULT_LATITUDE,
+            "longitude": lng if lng is not None else _DEFAULT_LONGITUDE,
             "accuracy": 100,
         }
+        if lat is None:
+            log_warning(
+                "Selenium session has no resolved geolocation — falling back to default "
+                f"coordinates ({_DEFAULT_LATITUDE}, {_DEFAULT_LONGITUDE}), which may contradict "
+                "the egress IP's location",
+                user_id=user_id, action_type="login")
     # Apply geo, timezone and locale overrides at the CDP layer so JS fingerprint
     # signals (geolocation API, Intl/Date timezone, navigator.language) are consistent.
     driver.execute_cdp_cmd("Emulation.setGeolocationOverride", coordinates)
@@ -202,6 +233,19 @@ def _build_proxy_auth_extension_b64(username: str, password: str) -> str:
         z.writestr("manifest.json", json.dumps(manifest))
         z.writestr("background.js", background)
     return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _proxy_label(proxy_url: Optional[str]) -> str:
+    """host:port of a proxy URL for logging, or 'DIRECT'. Never leaks the credentials."""
+    if not proxy_url:
+        return "DIRECT"
+    try:
+        parsed = urlparse(proxy_url)
+        if not parsed.hostname:
+            return "invalid"
+        return f"{parsed.hostname}:{parsed.port}" if parsed.port else parsed.hostname
+    except Exception:
+        return "invalid"
 
 
 def apply_proxy(options: Options, proxy_url: str) -> None:
@@ -288,11 +332,15 @@ def getBaseOptions(base_download_directory: str = None):
     options.add_experimental_option("excludeSwitches", ["enable-automation"])
     options.add_experimental_option("useAutomationExtension", False)
     options.add_argument("window-size=1920x1080")
-    options.add_argument(
-        # "user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Safari/537.36"
-        #"user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.6723.91 Safari/537.36"
-        "user-agent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.6723.91 Safari/537.36"
-    )
+    # NO --user-agent override. A pinned UA string is a LIABILITY, not stealth: Chrome derives
+    # User-Agent Client Hints (navigator.userAgentData, Sec-CH-UA, Sec-CH-UA-Platform) from the
+    # real build, and --user-agent does NOT change them. Any string we invent therefore contradicts
+    # the Client Hints the same request sends. This code pinned "Chrome/130 on macOS" while the
+    # selenium/standalone-chrome image silently rolled forward to Chrome 150 on Linux — a 20-version
+    # AND wrong-OS mismatch that is trivial for LinkedIn to check, and a prime suspect in the
+    # sustained /feed 429s. Chrome's own UA is always self-consistent; let it speak for itself.
+    # If a specific UA is ever genuinely required, set it via CDP Network.setUserAgentOverride WITH
+    # a matching userAgentMetadata payload — that updates the Client Hints too.
 
     # options.set_capability("browserVersion", "100.0")  # This is needed for this version
 

--- a/tests/unit/utilities/test_selenium_egress_identity.py
+++ b/tests/unit/utilities/test_selenium_egress_identity.py
@@ -1,0 +1,139 @@
+"""Regression guards for the LinkedIn 429 root causes: unproxied Selenium sessions
+and a pinned User-Agent that contradicts Chrome's User-Agent Client Hints."""
+
+import ast
+import pathlib
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.selenium_util"
+_SRC = pathlib.Path(__file__).resolve().parents[3] / "src" / "cqc_lem"
+
+
+def _proxy_url(user: str, password: str, host: str, port: int) -> str:
+    """Assemble a credentialed proxy URL from parts so no literal user:pass@host
+    string lives in the source — secret scanners flag that as a Basic Auth String."""
+    return f"http://{user}:{password}@{host}:{port}"
+
+
+class TestNoUserAgentOverride:
+    """A hardcoded UA cannot be kept truthful: --user-agent does not update
+    navigator.userAgentData / Sec-CH-UA, so any pinned string eventually contradicts the
+    real Chrome build and OS. Chrome's own UA is the only self-consistent option."""
+
+    def test_base_options_set_no_user_agent(self):
+        from cqc_lem.utilities.selenium_util import getBaseOptions
+        args = getBaseOptions().arguments
+        assert not any("user-agent" in a.lower() for a in args), (
+            f"a --user-agent override was reintroduced: {args}")
+
+    def test_docker_driver_sets_no_user_agent(self):
+        args = _capture_options(user_id=None).arguments
+        assert not any("user-agent" in a.lower() for a in args)
+
+
+class TestProxyLabel:
+    def test_direct_when_no_proxy(self):
+        from cqc_lem.utilities.selenium_util import _proxy_label
+        assert _proxy_label(None) == "DIRECT"
+        assert _proxy_label("") == "DIRECT"
+
+    def test_host_and_port_without_credentials(self):
+        from cqc_lem.utilities.selenium_util import _proxy_label
+        label = _proxy_label(_proxy_url("someuser", "s3cret", "host.example", 12323))
+        assert label == "host.example:12323"
+        assert "s3cret" not in label and "someuser" not in label
+
+    def test_host_only_when_no_port(self):
+        from cqc_lem.utilities.selenium_util import _proxy_label
+        assert _proxy_label("http://proxy.internal") == "proxy.internal"
+
+    def test_invalid_url_does_not_raise(self):
+        from cqc_lem.utilities.selenium_util import _proxy_label
+        assert _proxy_label("not a url") == "invalid"
+
+
+class TestMissingUserIdIsLoud:
+    """A session without user_id gets no proxy, timezone, locale or geo — it egresses from
+    the host's datacenter IP. That must never happen silently again."""
+
+    def test_warns_when_user_id_missing(self):
+        with patch(f"{_MOD}.log_warning") as warn:
+            _capture_options(user_id=None)
+        messages = " ".join(str(c.args[0]) for c in warn.call_args_list)
+        assert "WITHOUT user_id" in messages
+
+    def test_no_missing_user_id_warning_when_provided(self):
+        geo = {"latitude": 28.5, "longitude": -81.4, "timezone": "America/New_York",
+               "locale": "en-US", "country": "US"}
+        with patch(f"{_MOD}.log_warning") as warn:
+            _capture_options(user_id=1, geo=geo, proxy=_proxy_url("u", "p", "host.example", 9000))
+        messages = " ".join(str(c.args[0]) for c in warn.call_args_list)
+        assert "WITHOUT user_id" not in messages
+
+    def test_warns_when_falling_back_to_default_coordinates(self):
+        with patch(f"{_MOD}.log_warning") as warn:
+            _capture_options(user_id=None)
+        messages = " ".join(str(c.args[0]) for c in warn.call_args_list)
+        assert "no resolved geolocation" in messages
+
+
+class TestEgressLogging:
+    def test_logs_proxy_host_without_credentials(self):
+        geo = {"latitude": 28.5, "longitude": -81.4, "timezone": "America/New_York",
+               "locale": "en-US", "country": "US"}
+        with patch(f"{_MOD}.log_info") as info:
+            _capture_options(user_id=1, geo=geo, proxy=_proxy_url("user", "s3cret", "host.example", 9000))
+        messages = " ".join(str(c.args[0]) for c in info.call_args_list)
+        assert "egress=host.example:9000" in messages
+        assert "s3cret" not in messages
+
+    def test_logs_direct_when_unproxied(self):
+        with patch(f"{_MOD}.log_info") as info:
+            _capture_options(user_id=None)
+        messages = " ".join(str(c.args[0]) for c in info.call_args_list)
+        assert "egress=DIRECT" in messages
+
+
+class TestEverySessionPassesUserId:
+    """AST guard: every get_driver_wait_pair() call in the app must pass user_id, or that
+    task silently loses its proxy and geo. This is the bug that caused the 429s."""
+
+    def test_all_call_sites_pass_user_id(self):
+        offenders = []
+        for path in _SRC.rglob("*.py"):
+            tree = ast.parse(path.read_text(), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                fn = node.func
+                name = fn.attr if isinstance(fn, ast.Attribute) else getattr(fn, "id", None)
+                if name != "get_driver_wait_pair":
+                    continue
+                if not any(kw.arg == "user_id" for kw in node.keywords):
+                    offenders.append(f"{path.relative_to(_SRC)}:{node.lineno}")
+        assert not offenders, (
+            "get_driver_wait_pair() called without user_id — these sessions egress from the "
+            f"host IP with no proxy/geo: {offenders}")
+
+
+def _capture_options(user_id=None, geo=None, proxy=None):
+    """Build a driver with all I/O mocked and return the ChromeOptions actually used."""
+    captured = {}
+
+    def _remote(command_executor=None, options=None):
+        captured["options"] = options
+        return MagicMock()
+
+    with patch(f"{_MOD}._wait_for_selenium_ready"), \
+         patch(f"{_MOD}.DEVICE_FARM_PROJECT_ARN", None), \
+         patch(f"{_MOD}.TEST_GRID_PROJECT_ARN", None), \
+         patch(f"{_MOD}.webdriver.Remote", side_effect=_remote), \
+         patch("cqc_lem.utilities.db.get_user_geo", return_value=geo), \
+         patch("cqc_lem.utilities.db.get_user_proxy", return_value=proxy):
+        from cqc_lem.utilities.selenium_util import get_docker_driver
+        get_docker_driver(headless=False, user_id=user_id)
+    return captured["options"]


### PR DESCRIPTION
## Why

Sustained LinkedIn `/feed` **429s** were being treated as a rate-limiter problem, but the real cause was two configuration bugs that made every automation session look like a bot from a datacenter IP:

1. **Unproxied sessions.** `get_docker_driver()` only resolves the per-user residential proxy, timezone, locale and geolocation when `user_id` is passed — and **8 of 9 call sites omitted it** despite having `user_id` in scope, including `comment_on_post` (the core feed-commenting task). Those sessions egressed straight from the Hostinger VPS datacenter IP (AS47583) while reporting hardcoded Jacksonville coordinates, even though a working residential proxy was configured on `users.proxy_url`.

2. **Inconsistent User-Agent.** `getBaseOptions()` pinned a "Chrome/130 on macOS" UA while the `selenium/standalone-chrome` image had rolled to Chrome 150 on Linux. `--user-agent` does **not** override User-Agent Client Hints, so `navigator.userAgentData` reported the real build while the header claimed another — a 20-version, wrong-OS mismatch that is trivial to fingerprint.

## What

- Thread `user_id` through all 9 `get_driver_wait_pair()` / `get_docker_driver()` call sites so every LinkedIn session uses the user's residential proxy.
- Warn loudly whenever a session is created without `user_id` (never silently unproxied again) and whenever it falls back to the default coordinates.
- Drive fallback coordinates from named constants.
- Log each session's **effective egress host:port** (never the credentials) so "was this actually proxied?" is answerable from logs.
- Drop the `--user-agent` override entirely — Chrome's own UA is always self-consistent with its Client Hints.

## Tests

New `tests/unit/utilities/test_selenium_egress_identity.py` (12 tests):
- **AST-based regression guard** asserting every `get_driver_wait_pair()` call in `src/` passes `user_id` — verified to fail when the bug is reintroduced.
- `_proxy_label` credential redaction, missing-`user_id` and default-coordinate warnings, the egress log line, and the absence of any `--user-agent` override.

Full unit suite: **2583 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
