### PR TITLE
fix(deploy): persist IMAGE_TAG to .env after deploy/rollback

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -12,9 +12,24 @@ cd "$ROOT_DIR"
 TAG="${1:?Usage: deploy.sh <image-tag>}"
 COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.yml"
 LAST_GOOD_FILE="${ROOT_DIR}/.last_good_tag"
+ENV_FILE="${ROOT_DIR}/.env"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
 
 log() { echo "[deploy $(date -u +%H:%M:%S)] $*"; }
+
+# Persist IMAGE_TAG into .env so a reboot or a manual `compose up` (run without
+# this script) stays on the deployed tag. We only `export` IMAGE_TAG for our own
+# compose calls below; without writing it back, .env drifts a release behind and
+# the next unscripted `up` silently reverts every app service to the stale tag.
+persist_image_tag() {
+  local tag="$1"
+  if [[ -f "${ENV_FILE}" ]] && grep -qE '^IMAGE_TAG=' "${ENV_FILE}"; then
+    sed -i -E "s|^IMAGE_TAG=.*|IMAGE_TAG=${tag}|" "${ENV_FILE}"
+  else
+    echo "IMAGE_TAG=${tag}" >> "${ENV_FILE}"
+  fi
+  log "Persisted IMAGE_TAG=${tag} to ${ENV_FILE}"
+}
 
 # 1. Sync compose files + Flyway migrations to the released ref.
 log "Fetching git ref ${TAG}"
@@ -64,6 +79,7 @@ if [[ "${healthy}" != true ]]; then
     log "Rolling back to ${prev}"
     git checkout --quiet "${prev}" 2>/dev/null || git checkout --quiet "tags/${prev}" || true
     export IMAGE_TAG="${prev}"
+    persist_image_tag "${prev}"
     ${COMPOSE} up -d --remove-orphans
   fi
   exit 1
@@ -71,6 +87,7 @@ fi
 
 # 8. Record the new good tag and prune old artifacts.
 echo "${TAG}" > "${LAST_GOOD_FILE}"
+persist_image_tag "${TAG}"
 log "Deploy of ${TAG} OK. Pruning old images/build cache (>168h)."
 docker image prune -af --filter "until=168h" >/dev/null 2>&1 || true
 docker builder prune -af --filter "until=168h" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Why

`scripts/deploy.sh` only `export`s `IMAGE_TAG` for its own `docker compose` invocations — it never writes the tag back to `/opt/lem/.env`. So after every release the persisted `.env` drifts a version behind what's actually running.

**Observed live (2026-07-22):** after `v0.45.5` deployed, all 7 app containers ran `v0.45.5` while `/opt/lem/.env` still said `IMAGE_TAG=v0.45.4`. Any unscripted `docker compose up` — a VPS reboot, or a manual restart — would resolve the image from `.env` and **silently revert every app service to the stale tag**, undoing the just-deployed code. That's especially dangerous for fixes like the egress-identity change (#372), where reverting reintroduces the datacenter-IP-leak / 429 behavior with no obvious signal.

## What

- Add `persist_image_tag()` and call it:
  - on the **success path**, right after recording `.last_good_tag`
  - on the **rollback path**, with the `prev` tag, so `.env` matches the rolled-back reality
- Idempotent: replaces an existing `IMAGE_TAG=` line, appends if absent, creates `.env` if missing.

## Tests

Exercised the helper's three branches (replace / append / create) in isolation — all produce the expected `.env`. `bash -n` clean. No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
