### PR TITLE
fix(litellm): drop retired ministral-3:8b from lem-simple

### DIFF
--- a/.litellm/config.yaml
+++ b/.litellm/config.yaml
@@ -9,14 +9,11 @@ model_list:
       request_timeout: 90
       rpm: 100
 
-  - model_name: lem-simple
-    litellm_params:
-      model: openai/ministral-3:8b
-      api_base: os.environ/OLLAMA_CLOUD_URL
-      api_key: os.environ/OLLAMA_CLOUD_API_KEY
-      max_parallel_requests: 8
-      request_timeout: 60
-      rpm: 120
+  # NOTE: openai/ministral-3:8b was RETIRED 2026-07-15 (returns 410) and was removed — same
+  # class of breakage as kimi-k2:1t below. Under latency-based routing it kept getting picked
+  # (a 410 is "fast"), so a share of lem-simple calls failed; the profile scrape (lem-simple)
+  # then aborted auto-commenting with "Profile unavailable". gpt-oss:20b stays primary, with
+  # gpt-4o-mini as the in-group OpenAI fallback.
 
   # OpenAI fallback (when Ollama Cloud is unavailable)
   - model_name: lem-simple


### PR DESCRIPTION
## Why

While validating the egress-identity fix (#372) with a live feed-comment run for user 1, a **fresh proxy-native login succeeded** (the 429 was a stale-cookie/IP-mismatch, now resolved) — but auto-commenting still aborted, this time with:

```
Profile unavailable: live scrape failed and no cached profile to fall back on
```

Root cause: the profile scrape's `lem-simple` LLM call hit **`openai/ministral-3:8b`, which Ollama Cloud retired on 2026-07-15 (HTTP 410)**. It was still one of three `lem-simple` deployments. Under `latency-based-routing` a 410 returns "fast", so the dead endpoint kept getting selected; `num_retries: 2` masked it on most calls, but a share still hard-failed — and `lem-simple` has no cross-group fallback, so the scrape returned no profile and commenting bailed.

This is the same class of breakage already documented for `kimi-k2:1t` (retired 2026-06-16) in `lem-complex`.

## What

- Remove the retired `openai/ministral-3:8b` deployment from the `lem-simple` group.
- `gpt-oss:20b` stays primary; `gpt-4o-mini` remains the in-group OpenAI fallback.
- Add a NOTE documenting the retirement (mirrors the existing `kimi-k2:1t` note).

## Verification

- `yaml.safe_load` valid; `lem-simple` now has 2 deployments, zero `ministral` references.
- Functional probe through the app client (`web_app`): `lem-simple` / `lem-medium` / `lem-complex` / `lem-router` all return OK.

## Deploy note

`.litellm/config.yaml` is bind-mounted (`/opt/lem/.litellm → /app/.litellm`), and LiteLLM reads it only at startup — so applying this needs a `litellm` container restart, which a plain image deploy does not trigger. (Handled out of band for the live box.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
