### PR TITLE
fix(linkedin): self-heal a 429-after-cookie-load with a fresh login

### DIFF
--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -435,13 +435,29 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
 
     # LinkedIn serves a "HTTP ERROR 429 / This page isn't working" body at the SAME
     # /feed/ URL when the account/IP is rate-limited. A naive URL check would treat
-    # that as "logged in" and downstream profile scraping would crash. Detect it and
-    # raise a transient error so callers back off instead of hammering.
+    # that as "logged in" and downstream profile scraping would crash.
+    #
+    # When we hit this WITH stored cookies, the usual cause is a cookie/egress-IP
+    # mismatch — cookies minted from a different IP (e.g. before switching to the
+    # residential proxy) replayed through the proxy — not a genuine account throttle.
+    # That is the same root cause the redirect-loop path above handles, and a fresh
+    # credential login on the current IP clears it (verified live: a stale li_at from
+    # the datacenter era 429'd on the proxy, but a cookie-less login succeeded). So drop
+    # the cookies and fall through to a fresh login instead of giving up. Only treat it
+    # as a real rate limit when we arrived here WITHOUT cookies (nothing left to drop).
     if _is_logged_in(driver.current_url) and _page_is_rate_limited(driver):
-        mark_rate_limited("429 at feed after cookie load")
-        raise LinkedInRateLimited(
-            "LinkedIn is rate-limiting this session (HTTP 429). Backing off — "
-            "reduce automation frequency and retry later.")
+        if cookies:
+            myprint("429 at feed with stored cookies — likely a stale-cookie/egress-IP "
+                    "mismatch; clearing cookies and re-authenticating fresh")
+            driver.delete_all_cookies()
+            cookies = None
+            driver.get(login_url)
+            time.sleep(1)
+        else:
+            mark_rate_limited("429 at feed (no stored cookies to drop)")
+            raise LinkedInRateLimited(
+                "LinkedIn is rate-limiting this session (HTTP 429). Backing off — "
+                "reduce automation frequency and retry later.")
 
     # A Chrome transport error (proxy blip / DNS / timeout) also sits on the /feed URL, so it would
     # otherwise be mistaken for a live session below — clearing the breaker and storing junk cookies.
@@ -524,6 +540,15 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
     time.sleep(2)
     if _is_challenge_url(driver.current_url):
         _handle_challenge("post-submit")
+
+    # A fresh credential login can still 429 when the IP/account is genuinely throttled
+    # (not just a stale-cookie mismatch). Detect it here so we back off cleanly instead
+    # of timing out on the Feed-title wait below.
+    if _page_is_rate_limited(driver):
+        mark_rate_limited("429 after fresh credential login")
+        raise LinkedInRateLimited(
+            "LinkedIn is rate-limiting this session (HTTP 429) even after a fresh login. "
+            "Backing off — reduce automation frequency and retry later.")
 
     wait.until(EC.title_contains("Feed"), "Waiting for Feed to load after login")
 

--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -504,8 +504,8 @@ class TestRateLimitCircuitBreaker:
         driver.get.assert_not_called()
         mock_cookies.assert_not_called()
 
-    def test_rate_limited_feed_page_opens_breaker(self):
-        """A 429 body served at /feed/ must mark the breaker open and raise."""
+    def test_rate_limited_feed_no_cookies_opens_breaker(self):
+        """A 429 body at /feed/ with NO stored cookies (nothing to drop) opens the breaker."""
         driver = _make_driver("https://www.linkedin.com/feed/")
         wait = _make_wait()
         body_el = MagicMock()
@@ -516,7 +516,7 @@ class TestRateLimitCircuitBreaker:
         with patch(f"{_MODULE}.rate_limit_cooldown_remaining", return_value=0), \
              patch(f"{_MODULE}.mark_rate_limited") as mock_mark, \
              patch(f"{_MODULE}.clear_rate_limit") as mock_clear, \
-             patch(f"{_MODULE}.get_cookies", return_value=[{"name": "x"}]), \
+             patch(f"{_MODULE}.get_cookies", return_value=None), \
              patch(f"{_MODULE}.load_cookies"), patch(f"{_MODULE}.store_cookies"), \
              pytest.raises(LinkedInRateLimited, match="rate-limiting"):
             from cqc_lem.utilities.linkedin.helper import login_to_linkedin
@@ -524,6 +524,51 @@ class TestRateLimitCircuitBreaker:
 
         mock_mark.assert_called_once()
         mock_clear.assert_not_called()
+
+    def test_rate_limited_with_cookies_self_heals_via_fresh_login(self):
+        """A 429 at /feed/ WITH stored cookies is a stale-cookie/egress-IP mismatch: drop the
+        cookies and do a fresh credential login instead of opening the breaker."""
+        driver = _make_driver("https://www.linkedin.com/feed/")
+        wait = _make_wait()
+        # stage drives both the page body and the "logged-in" URL:
+        #   feed_429 (cookie'd feed 429) -> login (after cookie drop) -> feed_ok (after re-login)
+        state = {"stage": "feed_429"}
+        bodies = {"feed_429": "HTTP ERROR 429 Too Many Requests",
+                  "login": "Sign in to LinkedIn", "feed_ok": "Welcome to your feed"}
+
+        def _body(*_a, **_k):
+            el = MagicMock(); el.text = bodies[state["stage"]]; return el
+        driver.find_element.side_effect = _body
+
+        def _get(url):
+            if "login" in url:
+                state["stage"] = "login"
+                driver.current_url = "https://www.linkedin.com/login"
+            else:
+                driver.current_url = "https://www.linkedin.com/feed/"
+        driver.get.side_effect = _get
+
+        field = MagicMock()
+
+        def _click():  # submitting the fresh login lands back on a clean feed
+            state["stage"] = "feed_ok"
+            driver.current_url = "https://www.linkedin.com/feed/"
+        field.click.side_effect = _click
+
+        with patch(f"{_MODULE}.rate_limit_cooldown_remaining", return_value=0), \
+             patch(f"{_MODULE}.mark_rate_limited") as mock_mark, \
+             patch(f"{_MODULE}.clear_rate_limit") as mock_clear, \
+             patch(f"{_MODULE}.get_cookies", return_value=[{"name": "li_at"}]), \
+             patch(f"{_MODULE}.load_cookies"), \
+             patch(f"{_MODULE}.store_cookies") as mock_store, \
+             patch(f"{_MODULE}.get_visible_element_wait_retry", return_value=field):
+            from cqc_lem.utilities.linkedin.helper import login_to_linkedin
+            login_to_linkedin(driver, wait, "u@e.com", "pw")
+
+        driver.delete_all_cookies.assert_called_once()   # stale cookies dropped
+        mock_mark.assert_not_called()                     # self-healed — breaker NOT opened
+        mock_clear.assert_called()                        # fresh login cleared stale breaker state
+        mock_store.assert_called()                        # fresh proxy-native cookies stored
 
     def test_successful_login_clears_breaker(self):
         """A clean cookie login must clear any stale breaker state."""


### PR DESCRIPTION
## Why

Diagnosed live for user 1: the sustained feed-comment 429 was **not** an IP/account throttle — it was a **stale-cookie / egress-IP mismatch**. User 1's stored `li_at` was minted 2026-07-08 (before the switch to the residential proxy); replaying those datacenter-era cookies through the proxy IP made LinkedIn 429 the `/feed/` nav. Clearing the cookies and doing **one fresh credential login on the same proxy IP succeeded** and re-stored IP-consistent cookies (confirmed end-to-end).

`login_to_linkedin` already handles the sibling case — the redirect-loop path drops cookies and re-authenticates — but the 429-after-cookie-load path just called `mark_rate_limited()` and raised, giving up instead of self-healing.

## What

In `helper.py`, the `429 at /feed after cookie load` branch now:
- **With stored cookies** → `delete_all_cookies()`, set `cookies = None`, go to the login page, and fall through to a fresh credential login (mirrors the redirect-loop handling).
- **Without cookies** (nothing to drop) → treat as a genuine rate limit: `mark_rate_limited()` + raise, as before.
- Adds a rate-limit check **after** the fresh credential submit, so a genuinely throttled IP/account still backs off cleanly (`LinkedInRateLimited`) instead of timing out on the Feed-title wait.

Net effect: stale-cookie 429s recover automatically on the next run — no manual cookie wipe needed — while real throttles still open the breaker.

## Tests

`TestRateLimitCircuitBreaker`:
- `test_rate_limited_feed_no_cookies_opens_breaker` — no cookies → breaker opens + raises (unchanged contract).
- `test_rate_limited_with_cookies_self_heals_via_fresh_login` (new) — cookie'd 429 drops cookies, re-logs in, stores fresh cookies, and does **not** open the breaker.

Full `TestRateLimitCircuitBreaker` green (5/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
