### PR TITLE
fix(engagement): make feed_fallback_when_empty relax the hard gates too

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -867,6 +867,13 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
     # include = also matched the user's include topics/keywords/authors.
     examined_keys, hard_keys, include_keys = set(), set(), set()
     strict_misses, fallback_active, fallback_used = 0, False, False
+    # Posts that cleared excludes + dedup but failed ONLY the recency/min-reactions gates. Tracked
+    # apart from the permanent `seen` set so the empty-feed fallback can RECONSIDER them (relaxing
+    # those two gates) when nothing clears the hard filters at all. Without this, a sparse or
+    # low-reaction feed produces zero comments even with feed_fallback_when_empty on — because the
+    # existing include-miss fallback only triggers on posts that first passed the hard gates.
+    soft_seen: set = set()
+    hard_relaxed = False
     _incl = [f for f in ((prefs.get("include_keywords") or []) + (prefs.get("include_authors") or [])
                          + (prefs.get("include_topics") or [])) if f]
     fallback_enabled = bool(prefs.get("feed_fallback_when_empty", True)) and bool(_incl)
@@ -898,14 +905,20 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
                     or not _passes_hard_excludes(content, author, prefs)):
                 seen.add(key)
                 continue
+            # Recency + min-reactions are soft gates: when the whole feed fails them the empty-feed
+            # fallback relaxes them (below), so a reject here goes to soft_seen (reconsiderable),
+            # not the permanent `seen`. Skip already-soft-rejected posts until we relax.
+            if not hard_relaxed and key in soft_seen:
+                continue
             age = _post_age_minutes(driver, card)
             counts = _post_social_counts(card)
-            if age is not None and age > max_age_min:           # recency hard gate
-                seen.add(key)
-                continue
-            if min_reactions and counts["reactions"] < min_reactions:
-                seen.add(key)
-                continue
+            if not hard_relaxed:
+                if age is not None and age > max_age_min:        # recency gate
+                    soft_seen.add(key)
+                    continue
+                if min_reactions and counts["reactions"] < min_reactions:
+                    soft_seen.add(key)
+                    continue
             meta = {"author": author, "age_minutes": age, "comments": counts["comments"],
                     "reactions": counts["reactions"], "relevant": _literal_relevant(content, author, prefs)}
             hard_keys.add(key)
@@ -966,6 +979,20 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             else:
                 release_post_claim(user_id, key)  # no comment generated — release the claim
             continue  # DOM re-rendered / candidate consumed — re-gather from the top
+        # Nothing cleared the hard filters this pass. If the whole feed keeps coming up empty
+        # (0 posts past excludes + recency + min-reactions) but some only missed the recency/
+        # min-reactions gates, relax THOSE gates once and re-scan from the top — otherwise a
+        # sparse or low-reaction feed yields zero comments even with feed_fallback_when_empty on
+        # (excludes/dedup still apply; we still comment on the best-scored post).
+        if (fallback_enabled and not hard_relaxed and posted == 0 and not hard_keys
+                and soft_seen and scrolls + 1 >= _FEED_FALLBACK_AFTER_MISSES):
+            hard_relaxed = True
+            fallback_active = True
+            myprint("No posts cleared the recency/min-reaction gates — relaxing them "
+                    "(empty-feed fallback) and re-scanning the top of the feed")
+            driver.execute_script("window.scrollTo(0, 0);")
+            time.sleep(random.uniform(2.0, 3.5))
+            continue
         # nothing actionable in view — scroll to load more
         driver.execute_script("window.scrollBy(0, 1200);")
         scrolls += 1

--- a/tests/unit/app/test_comment_dedup.py
+++ b/tests/unit/app/test_comment_dedup.py
@@ -255,3 +255,24 @@ class TestFeedFunnelAndFallback:
                       prefs={"max_comments_per_day": 20})
         assert r["posted"] == 1
         assert r["funnel"]["fallback_used"] is False
+
+    def test_empty_hard_filters_relaxes_when_enabled(self):
+        # Every post fails the min-reactions gate (0 < 5), so NOTHING clears the hard filters —
+        # the include-miss fallback can't help (it only triggers on posts that first passed the
+        # hard gates). With fallback ON, the empty-feed path must relax recency/min-reactions and
+        # comment anyway (this is the case feed_fallback_when_empty is named for).
+        boxes = [_box("Sparse feed post with enough text to qualify for scanning.")]
+        r = _run_feed(boxes, matches=False,
+                      prefs={"max_comments_per_day": 20, "include_topics": ["AI"],
+                             "feed_fallback_when_empty": True, "min_reactions": 5})
+        assert r["posted"] >= 1
+        assert r["funnel"]["fallback_used"] is True
+
+    def test_empty_hard_filters_no_relax_when_disabled(self):
+        # Same sparse/low-reaction feed but fallback OFF -> stays at zero comments.
+        boxes = [_box("Sparse feed post with enough text to qualify for scanning.")]
+        r = _run_feed(boxes, matches=False,
+                      prefs={"max_comments_per_day": 20, "include_topics": ["AI"],
+                             "feed_fallback_when_empty": False, "min_reactions": 5})
+        assert r["posted"] == 0
+        assert r["funnel"]["fallback_used"] is False


### PR DESCRIPTION
## Why

`feed_fallback_when_empty` is meant to guarantee engagement when a user's targeting matches nothing — but it did nothing in the case it's actually named for.

Its trigger, `strict_misses`, only increments when a post **passes the hard gates** (excludes + recency + `min_reactions`) and *then* misses the include-topics. When **nothing clears the hard gates** — a sparse or low-reaction feed — no candidate ever forms, `strict_misses` stays 0, and the fallback never fires even with the pref on.

Observed live for user 1:
```
Feed scan: examined 7, passed filters 0, matched topics 0, commented 0, fallback=False
```
with `feed_fallback_when_empty = 1` → zero comments. (This surfaced only after the login-429 and the `lem-simple` model-retirement blockers were cleared, so the feed loop finally ran to completion.)

## What

- Track posts that cleared excludes+dedup but failed **only** recency/`min_reactions` in a separate `soft_seen` set instead of the permanent `seen`.
- When the feed keeps coming up empty of hard-passing posts (`hard_keys` empty) but has soft-rejected ones, **relax the recency + min-reactions gates once and re-scan from the top**, then comment on the best-scored post.
- Hard **excludes and dedup still apply**; the include-topics fallback path is unchanged.

## Tests (`TestFeedFunnelAndFallback`)

- `test_empty_hard_filters_relaxes_when_enabled` — every post fails `min_reactions` (0 < 5); with fallback ON it relaxes and comments (`fallback_used=True`).
- `test_empty_hard_filters_no_relax_when_disabled` — same feed, fallback OFF → stays at zero.
- Existing include-miss fallback tests still green (6/6 in the class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
