### PR TITLE
feat(litellm): weekly model-health check with auto-upgrade + safe deploy reload

### DIFF
--- a/.litellm/model_upgrades.yaml
+++ b/.litellm/model_upgrades.yaml
@@ -1,0 +1,20 @@
+# Ollama Cloud model retirement map, consumed by scripts/model_health_check.py.
+#
+# When the weekly check finds a configured model that the provider has RETIRED (HTTP 410),
+# it looks the bare model name up here and:
+#   - "<replacement>"  -> auto-swaps to it (AFTER verifying the replacement works), opens a PR,
+#                         restarts litellm, smoke-tests all tiers, and rolls back on any failure.
+#   - "REMOVE"         -> alerts a human (block deletion is not auto-applied — a tier could be
+#                         left with no working deployment). ministral/kimi-k2:1t were REMOVEs,
+#                         handled manually, and are recorded here so the check labels them
+#                         "known/handled" instead of "unknown retirement".
+# A 410 with NO entry here is an UNKNOWN retirement -> the check alerts so a mapping is added.
+#
+# Keys/values are the bare Ollama model names (no "openai/" prefix — the check strips it).
+upgrades:
+  # --- confirmed retirements + recommended replacements ---
+  "minimax-m2.5": "minimax-m2.7"
+  "kimi-k2.5": "kimi-k2.6"
+  # --- retired with no drop-in replacement (removed from config manually) ---
+  "ministral-3:8b": "REMOVE"
+  "kimi-k2:1t": "REMOVE"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -32,9 +32,23 @@ persist_image_tag() {
 }
 
 # 1. Sync compose files + Flyway migrations to the released ref.
+PREV_TAG="$(cat "${LAST_GOOD_FILE}" 2>/dev/null || echo "")"
 log "Fetching git ref ${TAG}"
 git fetch --tags --quiet origin
+# Discard any transient on-box .litellm hotfix (e.g. from the weekly model-health check) so the
+# release tag's config is authoritative and the checkout below can't fail on a dirty tracked file.
+# The durable version of any such hotfix arrives through that check's PR, not the box edit.
+git checkout -- .litellm 2>/dev/null || true
 git checkout --quiet "${TAG}" 2>/dev/null || git checkout --quiet "tags/${TAG}"
+
+# litellm reads its bind-mounted .litellm/config.yaml ONLY at startup, and `compose up -d` does
+# not recreate it on a mere file change — so a config edit (e.g. dropping a retired model) would
+# otherwise sit inert until a manual restart. Restart it below when the config changed vs the last
+# good tag (or when there's no baseline to compare against).
+LITELLM_RESTART=0
+if [[ -z "${PREV_TAG}" ]] || ! git diff --quiet "${PREV_TAG}" "${TAG}" -- .litellm/config.yaml 2>/dev/null; then
+  LITELLM_RESTART=1
+fi
 
 # 2. Validate env before touching containers.
 ./scripts/check_env.sh
@@ -59,6 +73,12 @@ ${COMPOSE} run --rm flyway
 # 6. Recreate changed services.
 log "Starting stack"
 ${COMPOSE} up -d --remove-orphans
+
+# 6b. Reload litellm if its config changed (compose won't recreate it on a bind-mount edit alone).
+if [[ "${LITELLM_RESTART}" == "1" ]]; then
+  log "litellm config changed vs ${PREV_TAG:-<none>} — restarting litellm to reload it"
+  ${COMPOSE} restart litellm || log "WARN: litellm restart failed (continuing)"
+fi
 
 # 7. Wait for the web app to report healthy; roll back on failure.
 log "Waiting up to ${HEALTH_TIMEOUT}s for web_app health"

--- a/scripts/model_health_check.py
+++ b/scripts/model_health_check.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Weekly LiteLLM model-health check.
+
+Probes every Ollama Cloud model the LiteLLM proxy is configured to use, detects any the
+provider has RETIRED (HTTP 410), and — for retirements with a verified-working replacement in
+.litellm/model_upgrades.yaml — rewrites the config to swap them. Comment-preserving: swaps are a
+single `model:` line replacement, so the rest of the YAML (comments, ordering) is untouched.
+
+This module is intentionally split into PURE logic (parsing, action planning, line rewriting —
+unit-tested) and I/O (provider/proxy probes — mocked in tests). The orchestration that applies to
+the live box, restarts litellm, smoke-tests and rolls back lives in scripts/weekly_model_check.sh.
+
+CLI:
+  --report [--json]      Probe + report model health and planned actions. No writes.
+  --plan-json            Emit ONLY the machine-readable plan (for the shell orchestrator).
+  --apply OUT            Write the swapped config to OUT (reads --config). Prints applied swaps.
+  --smoke-test           Call every tier via the proxy; exit non-zero if any tier fails.
+Options:
+  --config PATH          LiteLLM config to read (default .litellm/config.yaml).
+  --map PATH             Upgrade map (default .litellm/model_upgrades.yaml).
+Exit: 0 healthy/no-op, 2 swaps planned/applied, 3 manual alert needed, 1 error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from typing import Callable, Optional
+
+_OLLAMA_MARKER = "OLLAMA_CLOUD_URL"  # api_base env ref that marks an Ollama Cloud deployment
+
+
+# ─────────────────────────── pure logic (unit-tested) ────────────────────────────
+
+def parse_deployments(config: dict) -> list[dict]:
+    """Flatten a LiteLLM config into [{group, model, bare, is_ollama}] rows. `bare` strips the
+    "openai/" (or other provider) prefix; `is_ollama` is True when the deployment routes to
+    Ollama Cloud (api_base references OLLAMA_CLOUD_URL)."""
+    rows: list[dict] = []
+    for entry in config.get("model_list", []) or []:
+        group = entry.get("model_name")
+        params = entry.get("litellm_params", {}) or {}
+        model = params.get("model", "")
+        api_base = str(params.get("api_base", "") or "")
+        bare = model.split("/", 1)[1] if "/" in model else model
+        rows.append({"group": group, "model": model, "bare": bare,
+                     "is_ollama": _OLLAMA_MARKER in api_base})
+    return rows
+
+
+def load_map(map_doc: dict) -> dict:
+    """Normalize the upgrade-map document into {bare_model: replacement_or_REMOVE}."""
+    return dict((map_doc or {}).get("upgrades", {}) or {})
+
+
+def _unquote(s: str) -> str:
+    s = s.strip()
+    if len(s) >= 2 and s[0] in "'\"" and s[-1] == s[0]:
+        return s[1:-1]
+    return s
+
+
+def load_config_text(text: str) -> dict:
+    """Minimal, dependency-free reader for the bits of a LiteLLM config this tool needs:
+    each `- model_name:` entry with its first `model:` and `api_base:`. Avoids a PyYAML runtime
+    dependency (this runs as a host ops cron). Sections without `- model_name` (router/litellm
+    settings, fallbacks) carry no `model:` lines, so they're naturally ignored."""
+    entries: list[dict] = []
+    cur: Optional[dict] = None
+    for raw in text.splitlines():
+        m = re.match(r"\s*-\s*model_name:\s*(.+?)\s*$", raw)
+        if m:
+            cur = {"model_name": _unquote(m.group(1)), "litellm_params": {}}
+            entries.append(cur)
+            continue
+        if cur is None:
+            continue
+        mm = re.match(r"\s+model:\s*(.+?)\s*$", raw)
+        if mm and "model" not in cur["litellm_params"]:
+            cur["litellm_params"]["model"] = _unquote(mm.group(1))
+            continue
+        mb = re.match(r"\s+api_base:\s*(.+?)\s*$", raw)
+        if mb:
+            cur["litellm_params"]["api_base"] = _unquote(mb.group(1))
+    return {"model_list": entries}
+
+
+def load_map_text(text: str) -> dict:
+    """Parse the quoted `"key": "value"` pairs under `upgrades:` in model_upgrades.yaml without a
+    YAML lib. Keys can contain colons (e.g. "kimi-k2:1t"), so both sides must be quoted."""
+    upgrades: dict[str, str] = {}
+    in_block = False
+    for raw in text.splitlines():
+        if re.match(r"\s*upgrades:\s*$", raw):
+            in_block = True
+            continue
+        if not in_block:
+            continue
+        if raw.strip() == "" or raw.lstrip().startswith("#"):
+            continue
+        m = re.match(r'\s+"([^"]+)"\s*:\s*"([^"]+)"', raw)
+        if m:
+            upgrades[m.group(1)] = m.group(2)
+        elif not raw.startswith((" ", "\t")):
+            break  # dedented past the upgrades block
+    return {"upgrades": upgrades}
+
+
+def plan_actions(deployments: list[dict], retired: set[str], upgrades: dict,
+                 replacement_ok: Callable[[str], bool]) -> list[dict]:
+    """Decide what to do for each Ollama deployment. Pure — `retired` is the set of bare model
+    names the provider rejected, and `replacement_ok(bare)` reports whether a candidate works.
+
+    Returns action dicts, each with `kind`:
+      SWAP   - retired (or map-scheduled) model has a verified replacement -> rewrite the line
+      ALERT  - retired with REMOVE, no mapping, or the mapped replacement also fails -> human
+    Non-retired models with a map entry are swapped PROACTIVELY (e.g. a model flagged for
+    retirement before it starts 410-ing), as long as the replacement verifies.
+    """
+    actions: list[dict] = []
+    # dedup: a model name can appear in several groups; act on each (group, model) occurrence.
+    for d in deployments:
+        if not d["is_ollama"]:
+            continue
+        bare = d["bare"]
+        scheduled = bare in upgrades
+        is_retired = bare in retired
+        if not (is_retired or scheduled):
+            continue
+        repl = upgrades.get(bare)
+        if repl and repl != "REMOVE":
+            if replacement_ok(repl):
+                actions.append({"kind": "SWAP", "group": d["group"], "old": d["model"],
+                                "new": _swap_prefix(d["model"], repl),
+                                "old_bare": bare, "new_bare": repl,
+                                "reason": "retired" if is_retired else "scheduled"})
+            else:
+                actions.append({"kind": "ALERT", "group": d["group"], "model": d["model"],
+                                "reason": f"mapped replacement {repl!r} also failed to verify"})
+        elif repl == "REMOVE":
+            if is_retired:
+                actions.append({"kind": "ALERT", "group": d["group"], "model": d["model"],
+                                "reason": "retired with no replacement (map=REMOVE) — remove the "
+                                          "deployment block manually and confirm the tier still "
+                                          "has a working model"})
+        elif is_retired:
+            actions.append({"kind": "ALERT", "group": d["group"], "model": d["model"],
+                            "reason": "RETIRED with no mapping — add one to model_upgrades.yaml"})
+    return actions
+
+
+def _swap_prefix(old_model: str, new_bare: str) -> str:
+    """Preserve the provider prefix when swapping the bare name (openai/foo -> openai/bar)."""
+    prefix = old_model.split("/", 1)[0] + "/" if "/" in old_model else ""
+    return f"{prefix}{new_bare}"
+
+
+def apply_swaps(config_text: str, swaps: list[dict]) -> tuple[str, int]:
+    """Rewrite `model: <old>` lines to `model: <new>` in the raw YAML text (comment-preserving).
+    Returns (new_text, count). Each swap replaces every exact `model: <old>` occurrence."""
+    text = config_text
+    count = 0
+    for s in swaps:
+        old, new = s["old"], s["new"]
+        # Match the value on a `model:` line, tolerant of surrounding quotes/whitespace.
+        pat = re.compile(r"(^\s*model:\s*['\"]?)" + re.escape(old) + r"(['\"]?\s*$)", re.MULTILINE)
+        text, n = pat.subn(lambda m: m.group(1) + new + m.group(2), text)
+        count += n
+    return text, count
+
+
+# ─────────────────────────────── I/O (mocked in tests) ───────────────────────────
+
+def probe_provider(bare_model: str, *, base_url: str, api_key: str, timeout: float = 30.0) -> str:
+    """Return 'OK', 'RETIRED', or 'ERROR:<detail>' for a single Ollama Cloud model."""
+    try:
+        import openai
+        client = openai.OpenAI(base_url=base_url, api_key=api_key, timeout=timeout)
+        client.chat.completions.create(model=bare_model,
+                                       messages=[{"role": "user", "content": "ping"}],
+                                       max_tokens=1)
+        return "OK"
+    except Exception as e:  # noqa: BLE001 - classify any provider failure
+        s = str(e)
+        if "410" in s or "retired" in s.lower():
+            return "RETIRED"
+        return "ERROR:" + s[:120]
+
+
+def smoke_test_tiers(tiers: list[str], call_tier: Callable[[str], bool]) -> dict:
+    """Call each tier once via the proxy; return {tier: ok_bool}."""
+    return {t: bool(call_tier(t)) for t in tiers}
+
+
+# ─────────────────────────────────── CLI ─────────────────────────────────────────
+
+def _read_text(path: str) -> str:
+    with open(path) as f:
+        return f.read()
+
+
+def _detect(config_path: str, map_path: str) -> dict:
+    base_url = os.environ.get("OLLAMA_CLOUD_URL", "")
+    api_key = os.environ.get("OLLAMA_CLOUD_API_KEY", "")
+    if not base_url or not api_key:
+        raise SystemExit("OLLAMA_CLOUD_URL / OLLAMA_CLOUD_API_KEY must be set to probe the provider")
+    deployments = parse_deployments(load_config_text(_read_text(config_path)))
+    upgrades = load_map(load_map_text(_read_text(map_path)))
+    ollama = {d["bare"] for d in deployments if d["is_ollama"]}
+    # Probe the current models and (lazily) any candidate replacements.
+    status = {m: probe_provider(m, base_url=base_url, api_key=api_key) for m in sorted(ollama)}
+    retired = {m for m, s in status.items() if s == "RETIRED"}
+    repl_cache: dict[str, bool] = {}
+
+    def replacement_ok(bare: str) -> bool:
+        if bare not in repl_cache:
+            repl_cache[bare] = probe_provider(bare, base_url=base_url, api_key=api_key) == "OK"
+        return repl_cache[bare]
+
+    actions = plan_actions(deployments, retired, upgrades, replacement_ok)
+    return {"status": status, "retired": sorted(retired), "actions": actions,
+            "swaps": [a for a in actions if a["kind"] == "SWAP"],
+            "alerts": [a for a in actions if a["kind"] == "ALERT"]}
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config", default=".litellm/config.yaml")
+    ap.add_argument("--map", default=".litellm/model_upgrades.yaml")
+    ap.add_argument("--report", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--plan-json", action="store_true")
+    ap.add_argument("--apply", metavar="OUT")
+    args = ap.parse_args(argv)
+
+    result = _detect(args.config, args.map)
+
+    if args.plan_json:
+        print(json.dumps(result))
+    elif args.apply:
+        with open(args.config) as f:
+            text = f.read()
+        new_text, n = apply_swaps(text, result["swaps"])
+        with open(args.apply, "w") as f:
+            f.write(new_text)
+        for s in result["swaps"]:
+            print(f"SWAP [{s['group']}] {s['old']} -> {s['new']} ({s['reason']})")
+        print(f"applied {n} line-swap(s) -> {args.apply}")
+    else:  # --report (default)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            print("Model health:")
+            for m, s in result["status"].items():
+                print(f"  {m:<22} {s}")
+            for a in result["actions"]:
+                if a["kind"] == "SWAP":
+                    print(f"  PLAN swap [{a['group']}] {a['old']} -> {a['new']} ({a['reason']})")
+                else:
+                    print(f"  ALERT [{a['group']}] {a.get('model','')}: {a['reason']}")
+
+    if result["alerts"]:
+        return 3
+    if result["swaps"]:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/weekly_model_check.sh
+++ b/scripts/weekly_model_check.sh
@@ -24,6 +24,11 @@ COMPOSE="sudo -n docker compose -f /opt/lem/docker-compose.yml -f /opt/lem/docke
 TIERS="lem-simple lem-medium lem-complex lem-router"
 mkdir -p "$DIR"
 
+# Python with the `openai` client (for provider probes / config rewrite). Prefer the stable
+# dev-checkout venv; fall back to `poetry run` inside REPO if that venv is absent.
+_DEV_VENV_PY="/home/lem/linkedin_engagement_manager/.venv/bin/python"
+if [ -x "$_DEV_VENV_PY" ]; then PY=("$_DEV_VENV_PY"); else PY=(poetry run python); fi
+
 log(){ echo "[$(date -u +%FT%TZ)] $*" | tee -a "$LOG" >&2; }
 
 alert(){  # log + best-effort email to the admin; never fails the run
@@ -71,7 +76,7 @@ open_pr(){  # mirror the same swap into the repo via an EPHEMERAL worktree — n
       && git worktree add -q -B auto/model-upgrade "$wt" origin/main ) || { log "worktree add failed"; return 1; }
   (
     cd "$wt" || exit 1
-    poetry run python "$REPO/scripts/model_health_check.py" --apply "$wt/.litellm/config.yaml" \
+    "${PY[@]}" "$REPO/scripts/model_health_check.py" --apply "$wt/.litellm/config.yaml" \
         --config "$wt/.litellm/config.yaml" --map "$wt/.litellm/model_upgrades.yaml" >>"$LOG" 2>&1
     git add .litellm/config.yaml
     git commit -q -m "fix(litellm): auto-swap retired Ollama model(s) [weekly model-health check]" \
@@ -90,7 +95,7 @@ log "=== weekly model-health check start ==="
 set -a; source <(sudo -n grep -E "^(OLLAMA_CLOUD_URL|OLLAMA_CLOUD_API_KEY)=" /opt/lem/.env); set +a
 
 cd "$REPO"
-PLAN="$(poetry run python scripts/model_health_check.py --plan-json --config "$BOX_CFG" --map "$MAP" 2>>"$LOG")"
+PLAN="$("${PY[@]}" scripts/model_health_check.py --plan-json --config "$BOX_CFG" --map "$MAP" 2>>"$LOG")"
 [ -z "$PLAN" ] && { log "planner produced no output — aborting"; exit 1; }
 NSWAP=$(printf '%s' "$PLAN" | python3 -c "import sys,json;print(len(json.load(sys.stdin)['swaps']))" 2>/dev/null || echo 0)
 NALERT=$(printf '%s' "$PLAN" | python3 -c "import sys,json;print(len(json.load(sys.stdin)['alerts']))" 2>/dev/null || echo 0)
@@ -105,7 +110,7 @@ if [ "$NSWAP" -gt 0 ]; then
   BK="$BOX_CFG.bak.$(date -u +%Y%m%dT%H%M%SZ)"
   sudo -n cp -a "$BOX_CFG" "$BK"; log "backed up box config -> $BK"
   TMP=$(mktemp)
-  poetry run python scripts/model_health_check.py --apply "$TMP" --config "$BOX_CFG" --map "$MAP" >>"$LOG" 2>&1
+  "${PY[@]}" scripts/model_health_check.py --apply "$TMP" --config "$BOX_CFG" --map "$MAP" >>"$LOG" 2>&1
   sudo -n cp "$TMP" "$BOX_CFG"; rm -f "$TMP"
   restart_litellm
   if smoke; then

--- a/scripts/weekly_model_check.sh
+++ b/scripts/weekly_model_check.sh
@@ -62,20 +62,25 @@ smoke(){  # 0 iff every tier answers
   return $bad
 }
 
-open_pr(){  # mirror the same swap into the repo config and open a PR
-  cd "$REPO" || return 1
-  git fetch -q origin main
-  git checkout -q -B auto/model-upgrade origin/main
-  poetry run python scripts/model_health_check.py --apply "$REPO/.litellm/config.yaml" \
-      --config "$REPO/.litellm/config.yaml" --map "$MAP" >>"$LOG" 2>&1
-  git add .litellm/config.yaml
-  git commit -q -m "fix(litellm): auto-swap retired Ollama model(s) [weekly model-health check]" \
-      -m "Opened by scripts/weekly_model_check.sh after verifying the replacement against the provider and smoke-testing every tier on the live box." >>"$LOG" 2>&1 || { log "no repo diff to PR"; return 0; }
-  git push -q -u origin auto/model-upgrade >>"$LOG" 2>&1
-  gh pr create --base main --head auto/model-upgrade \
-     --title "fix(litellm): auto-swap retired Ollama model(s)" \
-     --body "Automated by the weekly model-health check. The replacement was verified against Ollama Cloud and every tier smoke-tested on the box before this PR." >>"$LOG" 2>&1 \
-     && log "PR opened" || log "PR create skipped (maybe one already open)"
+open_pr(){  # mirror the same swap into the repo via an EPHEMERAL worktree — never touches the
+            # shared dev checkout's branch/working tree (a human may be working there).
+  local wt; wt="$(mktemp -d /tmp/model-upgrade-wt.XXXXXX)"
+  ( cd "$REPO" && git fetch -q origin main \
+      && git worktree add -q -B auto/model-upgrade "$wt" origin/main ) || { log "worktree add failed"; return 1; }
+  (
+    cd "$wt" || exit 1
+    poetry run python "$REPO/scripts/model_health_check.py" --apply "$wt/.litellm/config.yaml" \
+        --config "$wt/.litellm/config.yaml" --map "$wt/.litellm/model_upgrades.yaml" >>"$LOG" 2>&1
+    git add .litellm/config.yaml
+    git commit -q -m "fix(litellm): auto-swap retired Ollama model(s) [weekly model-health check]" \
+        -m "Opened by scripts/weekly_model_check.sh after verifying the replacement against the provider and smoke-testing every tier on the live box." >>"$LOG" 2>&1 || { log "no repo diff to PR"; exit 0; }
+    git push -q -u origin auto/model-upgrade >>"$LOG" 2>&1
+    gh pr create --base main --head auto/model-upgrade \
+       --title "fix(litellm): auto-swap retired Ollama model(s)" \
+       --body "Automated by the weekly model-health check. The replacement was verified against Ollama Cloud and every tier smoke-tested on the box before this PR." >>"$LOG" 2>&1 \
+       && log "PR opened" || log "PR create skipped (maybe one already open)"
+  )
+  ( cd "$REPO" && git worktree remove --force "$wt" 2>/dev/null ) || true
 }
 
 log "=== weekly model-health check start ==="

--- a/scripts/weekly_model_check.sh
+++ b/scripts/weekly_model_check.sh
@@ -13,7 +13,9 @@
 set -uo pipefail
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/lem/.local/bin"
 
-REPO="/home/lem/linkedin_engagement_manager"
+# Self-locate the repo root so this can run from a dedicated cron clone, isolated from any
+# interactive dev checkout (overridable via REPO=... for tests).
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 BOX_CFG="/opt/lem/.litellm/config.yaml"
 MAP="$REPO/.litellm/model_upgrades.yaml"
 DIR="/home/lem/model-check"

--- a/scripts/weekly_model_check.sh
+++ b/scripts/weekly_model_check.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Weekly LiteLLM model-health orchestrator (host cron, runs as `lem`).
+#
+# Flow: plan (scripts/model_health_check.py against the LIVE box config) -> for retirements with a
+# verified replacement, back up + apply the swap on the box, restart litellm, smoke-test every tier,
+# and ROLL BACK on any failure; on success open a PR so the change lands in git and alert. When no
+# swap is needed but a tier is 410-ing (a stale litellm that wasn't restarted after a deploy), just
+# restart + re-verify. Manual-only retirements (REMOVE / unknown / no working replacement) alert.
+#
+# Safe by construction: a replacement is provider-verified before use, changes are smoke-tested
+# before they're kept, and deploy.sh resets .litellm before its checkout so an on-box hotfix can
+# never block a release.
+set -uo pipefail
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/lem/.local/bin"
+
+REPO="/home/lem/linkedin_engagement_manager"
+BOX_CFG="/opt/lem/.litellm/config.yaml"
+MAP="$REPO/.litellm/model_upgrades.yaml"
+DIR="/home/lem/model-check"
+LOG="$DIR/model_check.log"
+COMPOSE="sudo -n docker compose -f /opt/lem/docker-compose.yml -f /opt/lem/docker-compose.prod.yml"
+TIERS="lem-simple lem-medium lem-complex lem-router"
+mkdir -p "$DIR"
+
+log(){ echo "[$(date -u +%FT%TZ)] $*" | tee -a "$LOG" >&2; }
+
+alert(){  # log + best-effort email to the admin; never fails the run
+  log "ALERT: $1"
+  sudo -n docker exec -i web_app python - "$1" <<'PY' >>"$LOG" 2>&1 || true
+import os, sys
+msg = sys.argv[1]
+try:
+    from cqc_lem.utilities.email import _dispatch_email
+    to = os.environ.get("ADMIN_EMAIL") or os.environ.get("LINKEDIN_EMAIL") or "christopher.queen@gmail.com"
+    html = "<pre>" + msg.replace("&", "&amp;").replace("<", "&lt;") + "</pre>"
+    _dispatch_email(to, "LEM weekly model-health check", html, text_content=msg, high_priority=True)
+    print("alert emailed to", to)
+except Exception as e:
+    print("alert email failed (logged only):", e)
+PY
+}
+
+restart_litellm(){ log "restarting litellm"; $COMPOSE restart litellm >>"$LOG" 2>&1; sleep 8; }
+
+tier_ok(){  # $1=tier -> 0 if a completion succeeds within 3 tries
+  local t="$1" i
+  for i in 1 2 3; do
+    if sudo -n docker exec web_app python -c "
+from cqc_lem.utilities.ai.client import client
+client.chat.completions.create(model='$t', messages=[{'role':'user','content':'ok'}], max_tokens=3)
+" >/dev/null 2>&1; then return 0; fi
+    sleep 4
+  done
+  return 1
+}
+
+smoke(){  # 0 iff every tier answers
+  local bad=0 t
+  for t in $TIERS; do
+    if tier_ok "$t"; then log "smoke $t: OK"; else log "smoke $t: FAIL"; bad=1; fi
+  done
+  return $bad
+}
+
+open_pr(){  # mirror the same swap into the repo config and open a PR
+  cd "$REPO" || return 1
+  git fetch -q origin main
+  git checkout -q -B auto/model-upgrade origin/main
+  poetry run python scripts/model_health_check.py --apply "$REPO/.litellm/config.yaml" \
+      --config "$REPO/.litellm/config.yaml" --map "$MAP" >>"$LOG" 2>&1
+  git add .litellm/config.yaml
+  git commit -q -m "fix(litellm): auto-swap retired Ollama model(s) [weekly model-health check]" \
+      -m "Opened by scripts/weekly_model_check.sh after verifying the replacement against the provider and smoke-testing every tier on the live box." >>"$LOG" 2>&1 || { log "no repo diff to PR"; return 0; }
+  git push -q -u origin auto/model-upgrade >>"$LOG" 2>&1
+  gh pr create --base main --head auto/model-upgrade \
+     --title "fix(litellm): auto-swap retired Ollama model(s)" \
+     --body "Automated by the weekly model-health check. The replacement was verified against Ollama Cloud and every tier smoke-tested on the box before this PR." >>"$LOG" 2>&1 \
+     && log "PR opened" || log "PR create skipped (maybe one already open)"
+}
+
+log "=== weekly model-health check start ==="
+# Provider creds for the planner's direct probes.
+set -a; source <(sudo -n grep -E "^(OLLAMA_CLOUD_URL|OLLAMA_CLOUD_API_KEY)=" /opt/lem/.env); set +a
+
+cd "$REPO"
+PLAN="$(poetry run python scripts/model_health_check.py --plan-json --config "$BOX_CFG" --map "$MAP" 2>>"$LOG")"
+[ -z "$PLAN" ] && { log "planner produced no output — aborting"; exit 1; }
+NSWAP=$(printf '%s' "$PLAN" | python3 -c "import sys,json;print(len(json.load(sys.stdin)['swaps']))" 2>/dev/null || echo 0)
+NALERT=$(printf '%s' "$PLAN" | python3 -c "import sys,json;print(len(json.load(sys.stdin)['alerts']))" 2>/dev/null || echo 0)
+log "plan: swaps=$NSWAP alerts=$NALERT"
+
+if [ "$NALERT" -gt 0 ]; then
+  MSG=$(printf '%s' "$PLAN" | python3 -c "import sys,json;print(chr(10).join(f\"{a['group']}: {a.get('model','')} - {a['reason']}\" for a in json.load(sys.stdin)['alerts']))")
+  alert "Model retirements needing manual action:"$'\n'"$MSG"
+fi
+
+if [ "$NSWAP" -gt 0 ]; then
+  BK="$BOX_CFG.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+  sudo -n cp -a "$BOX_CFG" "$BK"; log "backed up box config -> $BK"
+  TMP=$(mktemp)
+  poetry run python scripts/model_health_check.py --apply "$TMP" --config "$BOX_CFG" --map "$MAP" >>"$LOG" 2>&1
+  sudo -n cp "$TMP" "$BOX_CFG"; rm -f "$TMP"
+  restart_litellm
+  if smoke; then
+    log "swaps verified — keeping"
+    open_pr
+    alert "Applied + verified $NSWAP model swap(s); PR opened to make it durable."
+  else
+    log "smoke FAILED after swaps — rolling back to $BK"
+    sudo -n cp "$BK" "$BOX_CFG"; restart_litellm
+    alert "Model swap smoke-test FAILED — rolled back. Manual review needed."
+    exit 1
+  fi
+else
+  if smoke; then
+    log "all tiers healthy; nothing to do"
+  else
+    log "no swaps but a tier failed — restarting litellm (likely stale config after a deploy)"
+    restart_litellm
+    if smoke; then log "recovered after restart"; else alert "Tiers still failing after litellm restart — manual review."; fi
+  fi
+fi
+log "=== weekly model-health check done ==="

--- a/tests/unit/test_model_health_check.py
+++ b/tests/unit/test_model_health_check.py
@@ -1,0 +1,167 @@
+"""Unit tests for scripts/model_health_check.py — the pure planning/rewriting logic."""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# The tool lives under scripts/ (not an importable package) — load it by path.
+_PATH = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "model_health_check.py"
+_spec = importlib.util.spec_from_file_location("model_health_check", _PATH)
+mhc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mhc)
+
+
+def _cfg():
+    return {"model_list": [
+        {"model_name": "lem-simple", "litellm_params": {
+            "model": "openai/gpt-oss:20b", "api_base": "os.environ/OLLAMA_CLOUD_URL"}},
+        {"model_name": "lem-simple", "litellm_params": {
+            "model": "openai/gpt-4o-mini", "api_key": "os.environ/OPENAI_API_KEY"}},  # not ollama
+        {"model_name": "lem-medium", "litellm_params": {
+            "model": "openai/minimax-m2.5", "api_base": "os.environ/OLLAMA_CLOUD_URL"}},
+    ]}
+
+
+class TestParse:
+    def test_flags_ollama_vs_direct_and_strips_prefix(self):
+        rows = mhc.parse_deployments(_cfg())
+        by_model = {r["model"]: r for r in rows}
+        assert by_model["openai/gpt-oss:20b"]["is_ollama"] is True
+        assert by_model["openai/gpt-oss:20b"]["bare"] == "gpt-oss:20b"
+        assert by_model["openai/gpt-4o-mini"]["is_ollama"] is False  # OpenAI, not Ollama Cloud
+
+    def test_load_map(self):
+        assert mhc.load_map({"upgrades": {"a": "b"}}) == {"a": "b"}
+        assert mhc.load_map({}) == {}
+
+
+class TestTextLoaders:
+    def test_load_config_text_extracts_models_and_ollama_flag(self):
+        text = (
+            "model_list:\n"
+            "  - model_name: lem-simple\n"
+            "    litellm_params:\n"
+            "      model: openai/gpt-oss:20b\n"
+            "      api_base: os.environ/OLLAMA_CLOUD_URL\n"
+            "  - model_name: lem-simple\n"
+            "    litellm_params:\n"
+            "      model: openai/gpt-4o-mini\n"
+            "      api_key: os.environ/OPENAI_API_KEY\n"
+            "router_settings:\n"
+            "  routing_strategy: latency-based-routing\n"
+        )
+        rows = mhc.parse_deployments(mhc.load_config_text(text))
+        assert len(rows) == 2
+        assert rows[0]["bare"] == "gpt-oss:20b" and rows[0]["is_ollama"] is True
+        assert rows[1]["bare"] == "gpt-4o-mini" and rows[1]["is_ollama"] is False
+
+    def test_load_map_text_handles_colon_in_key(self):
+        text = (
+            "upgrades:\n"
+            '  "minimax-m2.5": "minimax-m2.7"\n'
+            '  "kimi-k2:1t": "REMOVE"   # comment\n'
+            "other_section:\n"
+            '  "ignored": "value"\n'
+        )
+        up = mhc.load_map(mhc.load_map_text(text))
+        assert up == {"minimax-m2.5": "minimax-m2.7", "kimi-k2:1t": "REMOVE"}
+
+    def test_real_repo_files_parse(self):
+        root = pathlib.Path(__file__).resolve().parents[2]
+        cfg = mhc.load_config_text((root / ".litellm" / "config.yaml").read_text())
+        rows = mhc.parse_deployments(cfg)
+        assert any(r["group"] == "lem-simple" for r in rows)
+        # No live ministral deployment remains (only the explanatory comment).
+        assert not any(r["bare"] == "ministral-3:8b" for r in rows)
+        up = mhc.load_map(mhc.load_map_text((root / ".litellm" / "model_upgrades.yaml").read_text()))
+        assert up.get("minimax-m2.5") == "minimax-m2.7"
+        assert up.get("kimi-k2.5") == "kimi-k2.6"
+
+
+class TestSwapPrefix:
+    def test_preserves_provider_prefix(self):
+        assert mhc._swap_prefix("openai/minimax-m2.5", "minimax-m2.7") == "openai/minimax-m2.7"
+        assert mhc._swap_prefix("bare-model", "other") == "other"
+
+
+class TestPlanActions:
+    def _rows(self):
+        return mhc.parse_deployments(_cfg())
+
+    def test_scheduled_swap_when_replacement_ok(self):
+        # minimax-m2.5 is in the map (->m2.7); not 410 yet, but swapped proactively.
+        actions = mhc.plan_actions(self._rows(), retired=set(),
+                                   upgrades={"minimax-m2.5": "minimax-m2.7"},
+                                   replacement_ok=lambda b: True)
+        swaps = [a for a in actions if a["kind"] == "SWAP"]
+        assert len(swaps) == 1
+        assert swaps[0]["old"] == "openai/minimax-m2.5"
+        assert swaps[0]["new"] == "openai/minimax-m2.7"
+        assert swaps[0]["reason"] == "scheduled"
+
+    def test_retired_swap_reason(self):
+        actions = mhc.plan_actions(self._rows(), retired={"minimax-m2.5"},
+                                   upgrades={"minimax-m2.5": "minimax-m2.7"},
+                                   replacement_ok=lambda b: True)
+        assert [a for a in actions if a["kind"] == "SWAP"][0]["reason"] == "retired"
+
+    def test_alert_when_replacement_also_fails(self):
+        actions = mhc.plan_actions(self._rows(), retired={"minimax-m2.5"},
+                                   upgrades={"minimax-m2.5": "minimax-m2.7"},
+                                   replacement_ok=lambda b: False)
+        assert actions and actions[0]["kind"] == "ALERT"
+        assert "failed to verify" in actions[0]["reason"]
+
+    def test_retired_no_mapping_alerts(self):
+        actions = mhc.plan_actions(self._rows(), retired={"gpt-oss:20b"},
+                                   upgrades={}, replacement_ok=lambda b: True)
+        assert any(a["kind"] == "ALERT" and "no mapping" in a["reason"] for a in actions)
+
+    def test_retired_remove_alerts_not_autodeletes(self):
+        actions = mhc.plan_actions(self._rows(), retired={"gpt-oss:20b"},
+                                   upgrades={"gpt-oss:20b": "REMOVE"}, replacement_ok=lambda b: True)
+        assert actions and actions[0]["kind"] == "ALERT" and "REMOVE" in actions[0]["reason"]
+
+    def test_non_ollama_never_swapped(self):
+        # gpt-4o-mini is OpenAI-direct; even if it were mapped, it must not be touched.
+        actions = mhc.plan_actions(self._rows(), retired={"gpt-4o-mini"},
+                                   upgrades={"gpt-4o-mini": "x"}, replacement_ok=lambda b: True)
+        assert actions == []
+
+    def test_healthy_model_no_action(self):
+        actions = mhc.plan_actions(self._rows(), retired=set(), upgrades={},
+                                   replacement_ok=lambda b: True)
+        assert actions == []
+
+
+class TestApplySwaps:
+    def test_line_swap_preserves_comments(self):
+        text = (
+            "model_list:\n"
+            "  # keep this comment\n"
+            "  - model_name: lem-medium\n"
+            "    litellm_params:\n"
+            "      model: openai/minimax-m2.5\n"
+            "      api_base: os.environ/OLLAMA_CLOUD_URL\n"
+        )
+        swaps = [{"old": "openai/minimax-m2.5", "new": "openai/minimax-m2.7"}]
+        new, n = mhc.apply_swaps(text, swaps)
+        assert n == 1
+        assert "model: openai/minimax-m2.7" in new
+        assert "openai/minimax-m2.5" not in new
+        assert "# keep this comment" in new  # untouched
+
+    def test_no_partial_or_substring_match(self):
+        # A model whose name is a prefix of another must not be swapped by the shorter key.
+        text = "      model: openai/minimax-m2.75\n"
+        new, n = mhc.apply_swaps(text, [{"old": "openai/minimax-m2.7", "new": "openai/x"}])
+        assert n == 0 and new == text
+
+    def test_swaps_all_occurrences(self):
+        text = ("      model: openai/gpt-oss:20b\n"
+                "      model: openai/gpt-oss:20b\n")
+        new, n = mhc.apply_swaps(text, [{"old": "openai/gpt-oss:20b", "new": "openai/gpt-oss:21b"}])
+        assert n == 2 and "20b" not in new


### PR DESCRIPTION
## Why

Ollama Cloud retires models on a rolling basis, and each retirement has silently broken LEM: `kimi-k2:1t` (2026-06-16) and `ministral-3:8b` (2026-07-15) both started returning HTTP 410, and because they sat in a LiteLLM routing group with `latency-based-routing` (a 410 is "fast"), the proxy kept selecting them. The `ministral` case aborted the profile scrape with *"Profile unavailable"* and blocked auto-commenting. There was no mechanism to detect or heal this — and two deploy gaps meant a config fix wouldn't even take effect (litellm reads its bind-mounted config only at **startup**).

## What

**Self-maintaining model policy**
- **`.litellm/model_upgrades.yaml`** — curated retired→replacement map. Seeded per the current retirement notice: `minimax-m2.5 → minimax-m2.7`, `kimi-k2.5 → kimi-k2.6`, and `ministral-3:8b` / `kimi-k2:1t → REMOVE`.
- **`scripts/model_health_check.py`** — dependency-free (stdlib + `openai`) tool: probes every Ollama Cloud model the proxy uses, plans `SWAP`/`ALERT` actions from the map **and** live 410 probes, **verifies a replacement against the provider before proposing it**, and rewrites the config with comment-preserving single-line swaps. Pure logic is unit-tested (16 tests); provider I/O is mocked.
- **`scripts/weekly_model_check.sh`** — host orchestrator (installed as a weekly cron on the VPS): apply verified swaps on the box → restart litellm → **smoke-test every tier** → **roll back on any failure** → open a PR to make the change durable → email an alert. Manual-only retirements (`REMOVE` / unknown / no working replacement) alert instead of auto-editing.

**Two deploy fixes that made the config fix actually land**
- `deploy.sh` now resets `.litellm` before the tag checkout, so a transient on-box hotfix can never block a release (`git checkout` on a dirty tracked file fails).
- `deploy.sh` now restarts `litellm` when its config changed vs the last good tag — previously a config-only change (like dropping a retired model) was inert until a manual restart, which is exactly why `ministral` kept 410-ing after v0.45.6.

## Verification
- 16 unit tests (parse, plan, swap-rewrite, text loaders, real-repo-file parse). `bash -n` clean on both scripts.
- Live report against the box config: current Ollama models (`gpt-oss:20b/120b`, `minimax-m2.7`, `qwen3.5:397b`) probed; `minimax-m2.7` confirmed current, no `minimax-m2.5`/`ministral` present → exit 0 (compliant with the retirement notice today). `kimi-k2.6` verified available against the provider.

## Note on today's compliance
The config **already** complies with the two mappings — it uses `minimax-m2.7` (not `m2.5`) and has no `kimi-k2.5`. So this PR adds no model change today; its value is the automation that keeps it that way and heals future retirements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
