### PR TITLE
fix(newsletter): publish one per run and shift a missed-slot backlog forward

### DIFF
--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -463,9 +463,58 @@ def regenerate_newsletter_edition(edition_id: int, guidance: str = None):
     return f"Regenerated newsletter edition {edition_id}"
 
 
+def _reschedule_pending_editions_forward(user_id: int, editions: list, now: datetime) -> int:
+    """Re-slot the given pending editions (ordered by scheduled_for) onto the next consecutive cadence
+    slots after `now`, preserving their order. Used when slots were missed so a backlog SHIFTS forward
+    as an ordered sequence — the user's planned order is kept and nothing is dropped. Returns how many
+    editions actually moved."""
+    if not editions:
+        return 0
+    import pytz
+    from cqc_lem.utilities.db import (get_newsletter_settings, get_user_timezone,
+                                      update_newsletter_edition)
+    from cqc_lem.utilities.newsletter import upcoming_publish_slots
+    settings = get_newsletter_settings(user_id)
+    tz = pytz.timezone(get_user_timezone(user_id))
+    slots = upcoming_publish_slots(settings.get("publish_day", 1), settings.get("publish_hour", 9),
+                                   settings.get("cadence", "weekly"), now, tz, now, len(editions))
+    moved = 0
+    for e, slot in zip(editions, slots):
+        if e.get("scheduled_for") != slot and update_newsletter_edition(
+                e["id"], user_id, scheduled_for=slot):
+            moved += 1
+    return moved
+
+
+def _publish_next_due_edition_for_user(user_id: int, now: datetime, dispatch) -> int:
+    """Publish at most ONE — the oldest — due edition for a user this run. When more than one is due
+    (slots were missed and a backlog built up), publish the oldest and SHIFT the remaining pending
+    editions forward onto future cadence slots (order preserved) so a subscriber never receives
+    several editions at once. `dispatch(edition_id)` queues the actual Selenium publish. Returns 1 if
+    an edition was dispatched, else 0."""
+    from cqc_lem.utilities.db import get_pending_newsletter_editions
+    pending = get_pending_newsletter_editions(user_id)  # ordered by scheduled_for ASC
+    due = [e for e in pending
+           if e.get("scheduled_for") is not None and e["scheduled_for"] <= now]
+    if not due:
+        return 0
+    oldest = due[0]
+    dispatch(oldest["id"])
+    if len(due) > 1:
+        remaining = [e for e in pending if e["id"] != oldest["id"]]
+        moved = _reschedule_pending_editions_forward(user_id, remaining, now)
+        log_info(f"Newsletter backlog: published oldest due edition {oldest['id']} and shifted "
+                 f"{moved} later edition(s) forward to preserve planned order/cadence",
+                 user_id=user_id, task_name="auto_publish_scheduled_editions")
+    return 1
+
+
 @shared_task.task
 def auto_publish_scheduled_editions():
-    """Publish any newsletter edition whose scheduled slot has arrived (approved or untouched draft)."""
+    """Publish due newsletter editions — at most ONE per user per run. When slots were missed and a
+    backlog built up (e.g. after a throttle/pause), publish the oldest due edition and SHIFT the rest
+    forward onto future cadence slots, so a subscriber never gets several editions at once and the
+    user's planned order is preserved (nothing is dropped)."""
     # Newsletter publishing is Selenium-driven, so gate it on the breaker like the other fan-outs.
     # This hourly task was the primary re-tripper of the 429 doom loop: it probed the feed the moment
     # the cooldown lapsed and re-escalated it back to the 6h cap.
@@ -473,10 +522,14 @@ def auto_publish_scheduled_editions():
         return "Automation throttled"
     from cqc_lem.app.run_automation import auto_publish_edition
     from cqc_lem.utilities.db import get_editions_due_to_publish
-    due = get_editions_due_to_publish(datetime.now(timezone.utc).replace(tzinfo=None))
-    for e in due:
-        auto_publish_edition.apply_async(kwargs={'edition_id': e['id']})
-    return f"Dispatched {len(due)} newsletter edition(s)"
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    due = get_editions_due_to_publish(now)
+    user_ids = sorted({e["user_id"] for e in due})
+    dispatched = 0
+    for uid in user_ids:
+        dispatched += _publish_next_due_edition_for_user(
+            uid, now, lambda eid: auto_publish_edition.apply_async(kwargs={"edition_id": eid}))
+    return f"Dispatched {dispatched} newsletter edition(s) (<=1/user; backlog shifted forward)"
 
 
 @shared_task.task

--- a/tests/unit/app/test_newsletter_catchup.py
+++ b/tests/unit/app/test_newsletter_catchup.py
@@ -1,0 +1,107 @@
+"""Newsletter catch-up publishing: at most one edition per user per run, and a missed-slot backlog
+shifts forward (order preserved) instead of all publishing at once."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RS = "cqc_lem.app.run_scheduler"
+_DB = "cqc_lem.utilities.db"
+_NL = "cqc_lem.utilities.newsletter"
+
+
+class TestPublishNextDueEditionForUser:
+    def test_no_due_editions_is_noop(self):
+        from cqc_lem.app import run_scheduler as rs
+        pending = [{"id": 6, "scheduled_for": datetime(2026, 8, 1, 13, 0)}]  # future
+        dispatch = MagicMock()
+        with patch(f"{_DB}.get_pending_newsletter_editions", return_value=pending):
+            n = rs._publish_next_due_edition_for_user(1, datetime(2026, 7, 23, 3, 0), dispatch)
+        assert n == 0
+        dispatch.assert_not_called()
+
+    def test_single_due_publishes_without_reschedule(self):
+        from cqc_lem.app import run_scheduler as rs
+        pending = [{"id": 5, "scheduled_for": datetime(2026, 7, 21, 13, 0)},   # due
+                   {"id": 6, "scheduled_for": datetime(2026, 7, 28, 13, 0)}]   # future
+        dispatch = MagicMock()
+        with patch(f"{_DB}.get_pending_newsletter_editions", return_value=pending), \
+             patch(f"{_RS}._reschedule_pending_editions_forward") as resched:
+            n = rs._publish_next_due_edition_for_user(1, datetime(2026, 7, 22, 3, 0), dispatch)
+        assert n == 1
+        dispatch.assert_called_once_with(5)
+        resched.assert_not_called()  # only one due -> nothing to shift
+
+    def test_backlog_publishes_oldest_only_and_shifts_rest_in_order(self):
+        from cqc_lem.app import run_scheduler as rs
+        pending = [{"id": 2, "scheduled_for": datetime(2026, 7, 14, 13, 0)},   # due (oldest)
+                   {"id": 3, "scheduled_for": datetime(2026, 7, 21, 13, 0)},   # due (backlog)
+                   {"id": 4, "scheduled_for": datetime(2026, 7, 28, 13, 0)}]   # future
+        dispatch = MagicMock()
+        with patch(f"{_DB}.get_pending_newsletter_editions", return_value=pending), \
+             patch(f"{_RS}._reschedule_pending_editions_forward", return_value=2) as resched:
+            n = rs._publish_next_due_edition_for_user(1, datetime(2026, 7, 23, 3, 0), dispatch)
+        assert n == 1
+        dispatch.assert_called_once_with(2)                 # ONLY the oldest publishes now
+        resched.assert_called_once()
+        shifted_ids = [e["id"] for e in resched.call_args.args[1]]
+        assert shifted_ids == [3, 4]                        # everything after the oldest, in order
+
+
+class TestRescheduleForward:
+    def test_reslots_in_order_onto_upcoming_slots(self):
+        from cqc_lem.app import run_scheduler as rs
+        editions = [{"id": 3, "scheduled_for": datetime(2026, 7, 21, 13, 0)},
+                    {"id": 4, "scheduled_for": datetime(2026, 7, 28, 13, 0)}]
+        slots = [datetime(2026, 7, 30, 13, 0), datetime(2026, 8, 6, 13, 0)]
+        with patch(f"{_DB}.get_newsletter_settings",
+                   return_value={"publish_day": 1, "publish_hour": 9, "cadence": "weekly"}), \
+             patch(f"{_DB}.get_user_timezone", return_value="America/New_York"), \
+             patch(f"{_NL}.upcoming_publish_slots", return_value=slots), \
+             patch(f"{_DB}.update_newsletter_edition", return_value=True) as upd:
+            moved = rs._reschedule_pending_editions_forward(1, editions, datetime(2026, 7, 23, 3, 0))
+        assert moved == 2
+        moves = {c.args[0]: c.kwargs["scheduled_for"] for c in upd.call_args_list}
+        assert moves == {3: slots[0], 4: slots[1]}          # order preserved
+
+    def test_skips_editions_already_on_their_slot(self):
+        from cqc_lem.app import run_scheduler as rs
+        editions = [{"id": 3, "scheduled_for": datetime(2026, 7, 30, 13, 0)}]  # already == slot
+        slots = [datetime(2026, 7, 30, 13, 0)]
+        with patch(f"{_DB}.get_newsletter_settings",
+                   return_value={"publish_day": 1, "publish_hour": 9, "cadence": "weekly"}), \
+             patch(f"{_DB}.get_user_timezone", return_value="America/New_York"), \
+             patch(f"{_NL}.upcoming_publish_slots", return_value=slots), \
+             patch(f"{_DB}.update_newsletter_edition", return_value=True) as upd:
+            moved = rs._reschedule_pending_editions_forward(1, editions, datetime(2026, 7, 23, 3, 0))
+        assert moved == 0
+        upd.assert_not_called()
+
+    def test_empty_is_noop(self):
+        from cqc_lem.app import run_scheduler as rs
+        assert rs._reschedule_pending_editions_forward(1, [], datetime(2026, 7, 23, 3, 0)) == 0
+
+
+class TestAutoPublishScheduledEditions:
+    def test_dispatches_at_most_one_per_user(self):
+        from cqc_lem.app.run_scheduler import auto_publish_scheduled_editions
+        due = [{"id": 2, "user_id": 1}, {"id": 3, "user_id": 1}, {"id": 9, "user_id": 2}]
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch("cqc_lem.app.run_automation.auto_publish_edition", MagicMock()), \
+             patch(f"{_DB}.get_editions_due_to_publish", return_value=due), \
+             patch(f"{_RS}._publish_next_due_edition_for_user", return_value=1) as pnext:
+            res = auto_publish_scheduled_editions.run()
+        assert pnext.call_count == 2                          # once per distinct user
+        assert sorted(c.args[0] for c in pnext.call_args_list) == [1, 2]
+        assert "2 newsletter edition(s)" in res
+
+    def test_throttled_publishes_nothing(self):
+        from cqc_lem.app.run_scheduler import auto_publish_scheduled_editions
+        with patch(f"{_RS}._skip_if_throttled", return_value=True), \
+             patch(f"{_RS}._publish_next_due_edition_for_user") as pnext:
+            res = auto_publish_scheduled_editions.run()
+        assert res == "Automation throttled"
+        pnext.assert_not_called()

--- a/tests/unit/app/test_newsletter_publish.py
+++ b/tests/unit/app/test_newsletter_publish.py
@@ -490,9 +490,14 @@ class TestRegenerateNewsletterEdition:
 
 class TestPublishScheduledEditions:
     def test_dispatches_due_editions(self):
+        # Two DIFFERENT users each with one due edition -> one dispatch each (<=1 per user per run).
+        from datetime import datetime
         from cqc_lem.app.run_scheduler import auto_publish_scheduled_editions
         with patch("cqc_lem.utilities.db.get_editions_due_to_publish",
-                   return_value=[{"id": 3}, {"id": 8}]), \
+                   return_value=[{"id": 3, "user_id": 1}, {"id": 8, "user_id": 2}]), \
+             patch("cqc_lem.utilities.db.get_pending_newsletter_editions",
+                   side_effect=lambda uid: [{"id": 3 if uid == 1 else 8,
+                                             "scheduled_for": datetime(2026, 1, 1)}]), \
              patch("cqc_lem.app.run_automation.auto_publish_edition") as task:
             result = auto_publish_scheduled_editions()
         assert task.apply_async.call_count == 2

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -978,7 +978,10 @@ class TestNewsletterPublishGatedOnBreaker:
     def test_dispatches_when_not_throttled(self):
         from cqc_lem.app.run_scheduler import auto_publish_scheduled_editions
         with patch("cqc_lem.app.run_automation.auto_publish_edition") as pub, \
-             patch("cqc_lem.utilities.db.get_editions_due_to_publish", return_value=[{"id": 7}]):
+             patch("cqc_lem.utilities.db.get_editions_due_to_publish",
+                   return_value=[{"id": 7, "user_id": 1}]), \
+             patch("cqc_lem.utilities.db.get_pending_newsletter_editions",
+                   return_value=[{"id": 7, "scheduled_for": datetime(2026, 1, 1)}]):
             result = auto_publish_scheduled_editions()
         pub.apply_async.assert_called_once()
         assert "Dispatched 1" in result


### PR DESCRIPTION
## Why

Two newsletters went out for user 1 within one minute of each other (editions scheduled **07-14** and **07-21**, both published **07-23 02:06/02:07**). Root cause: `auto_publish_scheduled_editions` dispatched **every** due edition in a single run:

```python
due = get_editions_due_to_publish(now)   # ALL editions with scheduled_for <= now
for e in due:
    auto_publish_edition.apply_async(...) # no cap, no ordering, no staleness handling
```

Newsletter publishing is Selenium-gated by the 429 breaker (`_skip_if_throttled`), so during the ~1.5-week 429 throttle the editions piled up. The moment the breaker cleared (right after the login/cookie fix that morning), the whole backlog flushed at once.

## What

Per the intent that missed editions should **shift forward, in order, not drop or cluster**:

- **Publish at most ONE (the oldest) due edition per user per run.**
- When more than one is due (slots were missed), publish the oldest and **shift the remaining pending editions forward** onto the next consecutive cadence slots — order preserved, nothing dropped. The backlog then drains one-per-cadence.
- `auto_publish_scheduled_editions` now iterates the distinct users with due editions.

New helpers:
- `_publish_next_due_edition_for_user` — oldest-due dispatch + backlog shift.
- `_reschedule_pending_editions_forward` — re-slots pending editions onto upcoming cadence slots (reuses `upcoming_publish_slots`), preserving order; no-op when an edition is already on its slot.

## Tests (`test_newsletter_catchup.py`, +2 updated)
- one dispatch per user per run; on a backlog, only the oldest publishes and the rest shift in order; single-due does not reschedule; reschedule preserves order and skips on-slot editions; throttled run is a no-op.
- Full scheduler + newsletter suites green (107 passed locally).

## Note
User 1's already-sent editions can't be un-sent; their remaining queue (08-04/08-11/etc.) is already correctly spaced, so no remediation is needed — this prevents recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
