### PR TITLE
feat(ci): autonomous milestone pipeline (Claude Max implementer, Copilot reviewer)

### DIFF
--- a/scripts/agent-pipeline/README.md
+++ b/scripts/agent-pipeline/README.md
@@ -1,0 +1,47 @@
+# LEM Autonomous Milestone Pipeline
+
+Drives GitHub issues (Milestones 7–12) to merged & deployed, using **Claude on your Max
+subscription** (no API cost) as the implementer and **GitHub Copilot** as the free reviewer.
+
+## Flow (one issue at a time)
+```
+cron (hourly) → tick.sh advances the pipeline by ONE step:
+  • no PR in flight  → pick next `agent:ready` issue (M7→M12, by priority) → Claude implements
+                       in an isolated git worktree → pushes → opens PR → enables auto-merge
+                       (or holds it, if risky)
+  • PR CI failing    → Claude fixes on the same branch (≤4 attempts, then escalates to you)
+  • Copilot requested changes → Claude addresses every comment
+  • CI green, no change-requests → auto-merge lands it → release-please → build → VPS deploy
+  • risky / stuck / needs live-LinkedIn → label `needs-human`, assign you, stop
+```
+`tick.sh` only spends Max tokens when there's real work (implement / fix / address review).
+CI-pending and merge-waiting ticks are cheap `gh` reads — no Claude call.
+
+## Design choices
+- **Subscription only.** Runs `claude` on the box under `~/.claude` (your Max login). No `ANTHROPIC_API_KEY`.
+- **Copilot = review only** (free); it never writes code here.
+- **Serial (cap=1).** One PR in flight; gentlest on Max limits. Change the concurrency by running
+  tick more often — but keep cap=1 unless you add branch-conflict handling.
+- **Isolated worktrees.** Never switches your dev checkout's branch.
+- **Auto-merge green, hold risky.** Issues labeled `risk:migration` / `risk:security` /
+  `risk:live-linkedin` / `risk:product-decision` are built to green then handed to you to merge.
+
+## Labels
+- `agent:ready` — eligible for pickup · `agent:working` — in flight · `agent:blocked` — parked
+- `needs-human` — escalated & assigned to you
+- `risk:*` — held at merge for your review
+
+## Controls
+| Action | Command |
+|---|---|
+| Go live | `rm /home/lem/agent-pipeline/PAUSED` |
+| Pause | `touch /home/lem/agent-pipeline/PAUSED` |
+| Watch | `tail -f /home/lem/agent-pipeline/logs/tick-*.log` |
+| Dry-run | `DRY_RUN=1 /home/lem/agent-pipeline/tick.sh` |
+| One tick now | `/home/lem/agent-pipeline/tick.sh` |
+| Kill switch | `touch PAUSED` + `crontab -e` (remove the tick line) |
+
+## Safety net
+Every PR must pass **Unit Tests, Integration Tests, GitGuardian** (branch protection) plus Copilot
+review before it can merge. Deploy has auto-rollback to `.last_good_tag` on health-check failure.
+Risky classes never auto-merge. You can pause instantly with the `PAUSED` file.

--- a/scripts/agent-pipeline/RUNBOOK.md
+++ b/scripts/agent-pipeline/RUNBOOK.md
@@ -43,13 +43,14 @@ A fresh worktree on branch `$BRANCH` (from origin/main) is ready. Implement issu
    `gh pr create --base main --head $BRANCH --title "<type>(<scope>): <summary> (closes #$ISSUE)"
     --body "<what & why, testing notes, 'Closes #$ISSUE'>" --label agent:working`
    End the PR body with: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
-7. **Merge policy:**
-   - If `RISK=none`: enable auto-merge → `gh pr merge --auto "<pr-url>"` (NO strategy flag — the repo merge
-     queue fixes it). It will merge itself once required checks pass and no "changes requested" is open.
-   - If `RISK` is non-empty (migration/security/live-linkedin/product-decision): **do NOT enable auto-merge.**
-     Add label `needs-human`, assign `gitchrisqueen`, and comment that this PR is built and green-pending but
-     held for human review before it deploys to prod.
-8. STOP. (CI + Copilot review happen asynchronously; a later tick handles them.)
+7. **Do NOT enable auto-merge.** Merge is controlled by the runner (`tick.sh`), which merges only after
+   CI is green AND Copilot has reviewed the current head AND every Copilot thread is resolved.
+   - If `RISK=none`: leave the PR labeled `agent:working`. The runner takes it from here (fix → review → merge).
+   - If `RISK` is non-empty (migration/security/live-linkedin/product-decision): add label `needs-human`,
+     assign `gitchrisqueen`, comment that it's held for human review before it deploys to prod, then **park it**
+     so the serial pipeline proceeds: `gh pr edit <pr> --add-label agent:blocked --remove-label agent:working`
+     and `gh issue edit <ISSUE> --add-label agent:blocked --remove-label agent:working`. The human owns it.
+8. STOP. (CI + Copilot review happen asynchronously; later ticks handle fix/review/merge.)
 
 ## MODE=fix  (env: PR, ISSUE, WORKTREE, BRANCH, ATTEMPTS)
 Required CI checks are failing on PR #$PR (attempt #$ATTEMPTS). The worktree is on `$BRANCH`.
@@ -60,12 +61,22 @@ Required CI checks are failing on PR #$PR (attempt #$ATTEMPTS). The worktree is 
 - If ATTEMPTS ≥ 4, escalate (see above) instead of another blind fix.
 
 ## MODE=review  (env: PR, ISSUE, WORKTREE, BRANCH)
-Copilot (the reviewer) requested changes on PR #$PR. The worktree is on `$BRANCH`.
-1. `gh pr view $PR --json reviews,comments` and read Copilot's review + inline comments
-   (`gh api repos/{owner}/{repo}/pulls/$PR/comments`).
-2. Address every actionable comment. If a comment is wrong/not applicable, reply explaining why
-   (`gh pr comment` / reply to the thread) rather than silently ignoring it.
-3. Commit + `git push` (re-triggers CI and a fresh Copilot pass). STOP.
+Copilot (the reviewer) has one or more **unresolved review threads** on PR #$PR. The worktree is on `$BRANCH`.
+The runner will NOT merge while any Copilot thread is unresolved, so you must both address AND resolve them.
+1. List the unresolved Copilot threads (id + body + file/line) via GraphQL:
+   ```
+   gh api graphql -f query='query($o:String!,$n:String!,$p:Int!){repository(owner:$o,name:$n){
+     pullRequest(number:$p){reviewThreads(first:100){nodes{id isResolved path line
+       comments(first:5){nodes{author{login} body}}}}}}}' \
+     -f o=christopherqueenconsulting -f n=linkedin_engagement_manager -F p=$PR
+   ```
+2. For each unresolved thread whose comment author is Copilot:
+   - If actionable → make the code change.
+   - If wrong/not applicable → reply explaining why: `gh api repos/christopherqueenconsulting/linkedin_engagement_manager/pulls/$PR/comments/<comment_id>/replies -f body="..."` (or `gh pr comment`).
+   - Then **resolve the thread** so the merge gate can clear:
+     `gh api graphql -f query='mutation($t:ID!){resolveReviewThread(input:{threadId:$t}){thread{isResolved}}}' -f t="<thread_id>"`
+3. Commit + `git push` (re-triggers CI; Copilot re-reviews the new head and may open fresh threads —
+   a later tick will loop back here until Copilot has nothing left). STOP.
 
 ---
 Keep each tick focused and finite. Prefer correctness and convention-compliance over speed — a clean PR that

--- a/scripts/agent-pipeline/RUNBOOK.md
+++ b/scripts/agent-pipeline/RUNBOOK.md
@@ -1,0 +1,72 @@
+# Agent Pipeline Runbook
+
+You are an autonomous engineering agent working the **LinkedIn Engagement Manager (LEM)** 2026
+Growth Roadmap (GitHub Milestones 7–12, issues #382–406). You run headless, one invocation per
+pipeline "tick", authenticated with the owner's Claude Max subscription. `tick.sh` has already
+determined the MODE and prepared a git worktree for you. Do exactly the one step for your MODE,
+then stop. Another tick will continue later.
+
+Repo: `christopherqueenconsulting/linkedin_engagement_manager`. Owner/escalation assignee: `gitchrisqueen`.
+
+## Ground rules (always)
+- **Obey `CLAUDE.md`** in the repo root — it overrides your defaults (logging via `cqc_lem.utilities.logger`,
+  type hints, enums for status, no raw SQL outside `utilities/db.py`, LLM calls via the client aliases,
+  Selenium via `get_docker_driver()`, no hardcoded secrets, migrations advance from the highest existing V##).
+- **Stay scoped to the single issue.** Do not refactor unrelated code or touch other issues' files.
+- **Tests are mandatory:** new logic → `tests/unit/`; new API endpoints → `tests/integration/`. Target ≥80% patch coverage.
+- Run `poetry run pytest tests/unit -q` locally before pushing when the environment allows; **CI is the source of truth**.
+- **Never** edit files under `/opt/lem` (that is live prod), never run `docker`, never deploy, never touch secrets/`.env`.
+- Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- You are in a dedicated worktree already on the correct branch. Do not `git checkout main` or switch branches.
+
+## Escalate to a human instead of proceeding when:
+- The issue needs **live LinkedIn interaction / real credentials / a running Selenium session** you can't do headless.
+- It requires a **product or policy decision**, an external secret, or account/ToS judgment.
+- A **DB migration is destructive** or ambiguous, or you'd have to weaken a security control.
+- You've made **4+ fix attempts** on CI and it still fails, or you're otherwise stuck.
+
+To escalate: `gh issue edit <ISSUE> --add-label needs-human --add-assignee gitchrisqueen`, remove `agent:ready`
+(`--remove-label agent:ready`), post a comment explaining precisely what you need from the human, and if a
+PR exists convert it to draft (`gh pr ready --undo <PR>`) and label it `agent:blocked`. Then STOP.
+
+---
+
+## MODE=start  (env: ISSUE, WORKTREE, RISK, BRANCH)
+A fresh worktree on branch `$BRANCH` (from origin/main) is ready. Implement issue #$ISSUE.
+1. `gh issue view $ISSUE` — read the full issue (Why/Scope/Files/Acceptance).
+2. Implement the smallest correct change that satisfies the acceptance criteria, following `CLAUDE.md`.
+   Reuse existing utilities named in the issue; don't invent parallel helpers.
+3. Add/extend tests. Run unit tests locally if you can.
+4. Commit atomically with a clear conventional-commit message.
+5. `git push -u origin $BRANCH`.
+6. Open the PR:
+   `gh pr create --base main --head $BRANCH --title "<type>(<scope>): <summary> (closes #$ISSUE)"
+    --body "<what & why, testing notes, 'Closes #$ISSUE'>" --label agent:working`
+   End the PR body with: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
+7. **Merge policy:**
+   - If `RISK=none`: enable auto-merge → `gh pr merge --auto "<pr-url>"` (NO strategy flag — the repo merge
+     queue fixes it). It will merge itself once required checks pass and no "changes requested" is open.
+   - If `RISK` is non-empty (migration/security/live-linkedin/product-decision): **do NOT enable auto-merge.**
+     Add label `needs-human`, assign `gitchrisqueen`, and comment that this PR is built and green-pending but
+     held for human review before it deploys to prod.
+8. STOP. (CI + Copilot review happen asynchronously; a later tick handles them.)
+
+## MODE=fix  (env: PR, ISSUE, WORKTREE, BRANCH, ATTEMPTS)
+Required CI checks are failing on PR #$PR (attempt #$ATTEMPTS). The worktree is on `$BRANCH`.
+1. `gh pr checks $PR` and inspect the failing run logs (`gh run view <run-id> --log-failed`).
+2. Diagnose and fix the real cause (code or test). Keep it scoped to this PR.
+3. Re-run relevant unit tests locally if possible.
+4. Commit + `git push`. The push re-triggers CI. STOP.
+- If ATTEMPTS ≥ 4, escalate (see above) instead of another blind fix.
+
+## MODE=review  (env: PR, ISSUE, WORKTREE, BRANCH)
+Copilot (the reviewer) requested changes on PR #$PR. The worktree is on `$BRANCH`.
+1. `gh pr view $PR --json reviews,comments` and read Copilot's review + inline comments
+   (`gh api repos/{owner}/{repo}/pulls/$PR/comments`).
+2. Address every actionable comment. If a comment is wrong/not applicable, reply explaining why
+   (`gh pr comment` / reply to the thread) rather than silently ignoring it.
+3. Commit + `git push` (re-triggers CI and a fresh Copilot pass). STOP.
+
+---
+Keep each tick focused and finite. Prefer correctness and convention-compliance over speed — a clean PR that
+passes CI and Copilot review the first time is the goal.

--- a/scripts/agent-pipeline/apply-parking-fix.sh
+++ b/scripts/agent-pipeline/apply-parking-fix.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Apply the "park held PRs" fix without pausing the live pipeline:
+#  - copy the patched RUNBOOK to the box (no full re-install, so PAUSED is untouched)
+#  - park the already-held PR #408 + issue #382 so the pipeline proceeds to the next issue
+#  - tidy #402's redundant priority label
+set -uo pipefail
+SRC="$(cd "$(dirname "$0")" && pwd)"
+SLUG="christopherqueenconsulting/linkedin_engagement_manager"
+
+cp "$SRC/RUNBOOK.md" /home/lem/agent-pipeline/RUNBOOK.md
+echo "runbook updated on box."
+
+gh pr edit 408 --repo "$SLUG" --add-label agent:blocked --remove-label agent:working >/dev/null 2>&1 && echo "PR #408 parked (agent:blocked)."
+gh issue edit 382 --repo "$SLUG" --add-label agent:blocked --remove-label agent:working >/dev/null 2>&1 && echo "issue #382 parked."
+gh issue edit 402 --repo "$SLUG" --remove-label priority:critical >/dev/null 2>&1 && echo "#402 priority tidied."
+
+echo "done. Next tick will pick the next ready issue (#383)."

--- a/scripts/agent-pipeline/apply-review-gate-fix.sh
+++ b/scripts/agent-pipeline/apply-review-gate-fix.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Apply the runner-controlled-merge / Copilot-review-gate fix to the live box install.
+# Grabs the pipeline lock first so it can't overwrite files mid-tick.
+set -uo pipefail
+SRC="$(cd "$(dirname "$0")" && pwd)"
+DEST="/home/lem/agent-pipeline"
+
+exec 9>"$DEST/lock"
+if ! flock -n 9; then
+  echo "A tick is currently running. Re-run this in a minute." >&2
+  exit 1
+fi
+
+cp "$SRC/tick.sh"     "$DEST/tick.sh"     && chmod +x "$DEST/tick.sh"
+cp "$SRC/RUNBOOK.md"  "$DEST/RUNBOOK.md"
+echo "Updated tick.sh + RUNBOOK.md on the box."
+echo "Merge is now runner-controlled: a PR merges only after CI green + Copilot reviewed head + all Copilot threads resolved."

--- a/scripts/agent-pipeline/classify-issues.sh
+++ b/scripts/agent-pipeline/classify-issues.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# One-time: label the roadmap issues so the pipeline knows what to work, what to auto-merge,
+# and what to hand to you. Idempotent. Run as `lem`.
+set -uo pipefail
+SLUG="christopherqueenconsulting/linkedin_engagement_manager"
+add(){ gh issue edit "$1" --repo "$SLUG" --add-label "$2" >/dev/null 2>&1 && echo "  #$1 += $2"; }
+
+echo "agent:ready (workable by the pipeline)"
+for n in 382 383 384 385 405 386 387 388 389 390 391 392 393 394 406 395 396 397 398 399 400 401 402; do add "$n" "agent:ready"; done
+
+echo "needs-human + assign (live-LinkedIn spikes that can't run headless)"
+for n in 403 404; do
+  gh issue edit "$n" --repo "$SLUG" --add-label needs-human --add-label risk:live-linkedin --add-assignee gitchrisqueen >/dev/null 2>&1 && echo "  #$n needs-human+assigned"
+done
+
+echo "risk:migration (built to green, held for your merge)"
+for n in 382 385 386 400; do add "$n" "risk:migration"; done
+echo "risk:product-decision"
+for n in 385 398 399 400; do add "$n" "risk:product-decision"; done
+echo "risk:live-linkedin (agent-workable, held for your merge)"
+for n in 387 390; do add "$n" "risk:live-linkedin"; done
+echo "done"

--- a/scripts/agent-pipeline/install.sh
+++ b/scripts/agent-pipeline/install.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# One-time installer for the LEM agent pipeline. Run as user `lem` on the VPS.
+# Copies the runner to /home/lem/agent-pipeline, starts it PAUSED, and adds an hourly cron.
+set -euo pipefail
+SRC="$(cd "$(dirname "$0")" && pwd)"
+DEST="/home/lem/agent-pipeline"
+
+mkdir -p "$DEST/logs" "$DEST/work"
+cp "$SRC/tick.sh" "$DEST/tick.sh"
+cp "$SRC/RUNBOOK.md" "$DEST/RUNBOOK.md"
+chmod +x "$DEST/tick.sh"
+touch "$DEST/PAUSED"   # start paused — nothing runs until you remove this file
+echo "Installed to $DEST (PAUSED)."
+
+# Add hourly cron for lem if not already present
+LINE="0 * * * * /home/lem/agent-pipeline/tick.sh >/dev/null 2>&1"
+if crontab -l 2>/dev/null | grep -qF "/home/lem/agent-pipeline/tick.sh"; then
+  echo "cron entry already present."
+else
+  ( crontab -l 2>/dev/null; echo "$LINE" ) | crontab -
+  echo "cron entry added (hourly)."
+fi
+
+cat <<'EOF'
+
+Next steps:
+  1. Dry-run once to validate selection/state logic (no code changes, no Claude call):
+       DRY_RUN=1 /home/lem/agent-pipeline/tick.sh ; tail -n 40 /home/lem/agent-pipeline/logs/tick-*.log
+  2. Go LIVE:      rm /home/lem/agent-pipeline/PAUSED
+  3. Pause again:  touch /home/lem/agent-pipeline/PAUSED
+  4. Watch:        tail -f /home/lem/agent-pipeline/logs/tick-*.log
+  5. Run one tick manually now (instead of waiting for cron):
+       /home/lem/agent-pipeline/tick.sh
+EOF

--- a/scripts/agent-pipeline/stage-pr.sh
+++ b/scripts/agent-pipeline/stage-pr.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Stage the agent pipeline as a reviewable repo PR (additive only).
+# Uses an isolated worktree so your dev checkout / current branch is untouched.
+set -euo pipefail
+
+SRC="$(cd "$(dirname "$0")" && pwd)"
+REPO="/home/lem/linkedin_engagement_manager"
+WT="/home/lem/agent-pipeline-pr"
+BR="feature/claude-agent-pipeline"
+
+cd "$REPO"
+git fetch origin --prune
+git worktree prune
+rm -rf "$WT"
+git worktree add "$WT" -b "$BR" origin/main
+
+mkdir -p "$WT/scripts/agent-pipeline"
+for f in tick.sh RUNBOOK.md install.sh classify-issues.sh README.md stage-pr.sh; do
+  cp "$SRC/$f" "$WT/scripts/agent-pipeline/$f"
+done
+chmod +x "$WT/scripts/agent-pipeline/"*.sh
+
+cd "$WT"
+git add scripts/agent-pipeline
+git commit -m "feat(ci): autonomous milestone pipeline (Claude Max implementer, Copilot reviewer)
+
+Local runner that drives roadmap issues (Milestones 7-12, #382-406) to merged+deployed:
+Claude on the Max subscription implements each issue in an isolated git worktree, opens a
+PR, fixes CI and addresses Copilot review comments, and auto-merges green low-risk PRs
+(risky classes are held for human merge). Copilot stays review-only. Serial, cap=1, paced
+to Max limits. Deploy rides the existing merge->release-please->build->deploy-vps pipeline.
+
+Additive only; the runner is installed on the box at /home/lem/agent-pipeline. This commit
+version-controls the source for review/transparency. Starts paused.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+
+git push -u origin "$BR"
+
+gh pr create --base main --head "$BR" \
+  --title "feat(ci): autonomous milestone pipeline (Claude Max implementer, Copilot reviewer)" \
+  --body "$(cat <<'BODY'
+## What
+Version-controls the **autonomous milestone pipeline** that drives roadmap issues (Milestones 7–12, #382–406) to merged & deployed. Additive only — no existing files changed.
+
+## How it works
+- **Implementer = Claude on the Max subscription** (runs on the VPS under `~/.claude`, **no API cost**). Works one issue at a time in an isolated git worktree → opens a PR → fixes failing CI → addresses **Copilot** review comments → auto-merges when green.
+- **Reviewer = GitHub Copilot only** (free). Copilot never writes code here.
+- **Serial (cap=1)**, priority order M7→M12, paced to Max limits (waits/resumes on usage caps).
+- **Auto-merge green, hold risky.** `risk:migration` / `risk:security` / `risk:live-linkedin` / `risk:product-decision` are built to green then handed to a human to merge. Merge → existing release-please → build → `deploy-vps` (auto-rollback on health fail).
+- **Escalation:** `needs-human` + assignee when stuck (≤4 CI-fix attempts), needs live-LinkedIn, or needs a decision.
+
+## Files (`scripts/agent-pipeline/`)
+- `tick.sh` — driver: advances the pipeline one step per cron tick
+- `RUNBOOK.md` — the start/fix/review/escalate instructions Claude follows
+- `install.sh` — installs the runner to `/home/lem/agent-pipeline` (paused) + hourly cron
+- `classify-issues.sh` — labels the roadmap issues (already applied)
+- `README.md` — operator docs & controls
+
+## Safety
+Every PR must pass **Unit Tests, Integration Tests, GitGuardian** + Copilot review before merge. Risky classes never auto-merge. Instant pause via `touch /home/lem/agent-pipeline/PAUSED`.
+
+## Note
+`.github/workflows/claude-code-review.yml` (the old API-key-based Claude reviewer) is **dormant** — no `ANTHROPIC_API_KEY` secret — since reviews are handled by Copilot. Consider removing it in a follow-up to avoid accidental future API spend.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+BODY
+)"
+
+echo
+echo "PR opened. Review it, then merge when ready. To clean up the worktree later:"
+echo "  git -C $REPO worktree remove $WT"

--- a/scripts/agent-pipeline/sync-pr.sh
+++ b/scripts/agent-pipeline/sync-pr.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Sync PR #407 (feature/claude-agent-pipeline) so the repo copy matches the corrected box runner.
+set -euo pipefail
+SRC="$(cd "$(dirname "$0")" && pwd)"
+REPO="/home/lem/linkedin_engagement_manager"
+WT="/home/lem/agent-pipeline-pr"
+BR="feature/claude-agent-pipeline"
+
+# Ensure the worktree exists and is on the PR branch, up to date with the remote.
+if [ ! -d "$WT/.git" ] && ! git -C "$REPO" worktree list | grep -q "$WT"; then
+  git -C "$REPO" fetch origin --prune
+  git -C "$REPO" worktree prune
+  rm -rf "$WT"
+  git -C "$REPO" worktree add "$WT" -b "$BR" "origin/$BR"
+fi
+git -C "$WT" fetch origin "$BR"
+git -C "$WT" checkout "$BR"
+git -C "$WT" reset --hard "origin/$BR"
+
+mkdir -p "$WT/scripts/agent-pipeline"
+for f in tick.sh RUNBOOK.md install.sh classify-issues.sh README.md \
+         stage-pr.sh apply-parking-fix.sh apply-review-gate-fix.sh sync-pr.sh; do
+  cp "$SRC/$f" "$WT/scripts/agent-pipeline/$f"
+done
+chmod +x "$WT/scripts/agent-pipeline/"*.sh
+
+cd "$WT"
+if git diff --quiet && git diff --cached --quiet; then
+  echo "Nothing to sync — PR #407 already matches the box."
+  exit 0
+fi
+git add scripts/agent-pipeline
+git commit -m "chore(ci): sync agent pipeline runner — runner-controlled merge + Copilot review gate
+
+- Merge is now controlled by tick.sh (not GitHub eager auto-merge): a no-risk PR merges only
+  after CI green AND Copilot reviewed the current head AND all Copilot review threads resolved.
+- MODE=review addresses and resolves each Copilot thread (catches COMMENTED suggestions, not
+  just CHANGES_REQUESTED).
+- Risk-labeled PRs are parked (agent:blocked + needs-human) so the serial pipeline proceeds.
+- Adds the operational helper scripts used on the box.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+git push origin "$BR"
+echo "Synced. PR #407 now matches the box runner."

--- a/scripts/agent-pipeline/tick.sh
+++ b/scripts/agent-pipeline/tick.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# Agent pipeline driver — one "advance the pipeline by one step" tick.
+# Serial (cap=1): finishes the in-flight agent PR before starting a new issue.
+# Uses the owner's Claude Max login (no API cost). Never touches the dev checkout's branch —
+# all issue work happens in isolated git worktrees. Deploy happens via the existing
+# merge->release-please->build->deploy pipeline once a PR lands on main.
+set -uo pipefail
+
+# --- config ---
+BASE="/home/lem/agent-pipeline"
+REPO="/home/lem/linkedin_engagement_manager"
+SLUG="christopherqueenconsulting/linkedin_engagement_manager"
+ASSIGNEE="gitchrisqueen"
+WORKROOT="$BASE/work"
+LOGDIR="$BASE/logs"
+RUNBOOK="$BASE/RUNBOOK.md"
+PAUSED="$BASE/PAUSED"
+LOCK="$BASE/lock"
+MAX_FIX_ATTEMPTS=4
+CLAUDE_TIMEOUT="45m"
+DRY_RUN="${DRY_RUN:-0}"
+
+export PATH="/home/lem/.local/bin:/usr/local/bin:/usr/bin:/bin"
+export HOME="/home/lem"
+export GH_PROMPT_DISABLED=1
+
+mkdir -p "$WORKROOT" "$LOGDIR"
+LOG="$LOGDIR/tick-$(date +%Y%m%d).log"
+log() { echo "[$(date '+%F %T')] $*" | tee -a "$LOG" ; }
+
+# --- guards ---
+# DRY_RUN is inert (no pushes, no Claude, no merges) so it may validate even while paused.
+if [ -f "$PAUSED" ] && [ "$DRY_RUN" != "1" ]; then log "PAUSED file present — skipping."; exit 0; fi
+exec 9>"$LOCK"
+flock -n 9 || { log "another tick holds the lock — skipping."; exit 0; }
+
+# --- helpers ---
+select_next_issue() {
+  # Next ready issue: has agent:ready, not needs-human/agent:blocked, ordered by
+  # milestone number (7->12) then priority (critical>high>medium>low) then issue number.
+  gh issue list --repo "$SLUG" --state open --limit 100 --label "agent:ready" \
+    --json number,labels,milestone | jq -r '
+    def prio: (.labels|map(.name)|map(select(startswith("priority:")))|.[0] // "priority:zzz")
+      | {"priority:critical":0,"priority:high":1,"priority:medium":2,"priority:low":3}[.] // 4;
+    def msnum: (.milestone.title // "Milestone 999" | capture("Milestone (?<n>[0-9]+)").n | tonumber);
+    map(select((.labels|map(.name)) as $l
+        | ($l|index("needs-human")|not) and ($l|index("agent:blocked")|not)))
+    | sort_by(msnum, prio, .number)
+    | .[0].number // empty'
+}
+
+open_agent_pr() {
+  gh pr list --repo "$SLUG" --state open --label "agent:working" \
+    --json number,headRefName,labels | jq -r '.[0] // empty | @json'
+}
+
+risk_of_issue() {
+  gh issue view "$1" --repo "$SLUG" --json labels \
+    | jq -r '[.labels[].name | select(startswith("risk:")) | sub("risk:";"")] | join(" ")'
+}
+
+add_worktree() {  # $1=branch  $2=base(ref)  -> path on stdout
+  local branch="$1" base="$2" wt="$WORKROOT/$1"
+  git -C "$REPO" worktree prune >/dev/null 2>&1
+  rm -rf "$wt"
+  if git -C "$REPO" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
+    git -C "$REPO" worktree add "$wt" "origin/$branch" >/dev/null 2>&1
+    git -C "$wt" checkout -B "$branch" "origin/$branch" >/dev/null 2>&1
+  else
+    git -C "$REPO" worktree add -b "$branch" "$wt" "$base" >/dev/null 2>&1
+  fi
+  echo "$wt"
+}
+
+run_claude() {  # $1=worktree  $2=prompt
+  local wt="$1" prompt="$2"
+  if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would run claude in $wt"; return 0; fi
+  ( cd "$wt" && timeout "$CLAUDE_TIMEOUT" claude -p "$prompt" \
+      --dangerously-skip-permissions --add-dir "$BASE" ) >>"$LOG" 2>&1
+  local rc=$?
+  [ $rc -ne 0 ] && log "claude exited rc=$rc (timeout/interrupt/limit) — will retry next tick."
+  return $rc
+}
+
+# --- state machine ---
+git -C "$REPO" fetch origin --prune >/dev/null 2>&1
+
+PR_JSON="$(open_agent_pr)"
+
+if [ -n "$PR_JSON" ]; then
+  PR="$(echo "$PR_JSON" | jq -r .number)"
+  BRANCH="$(echo "$PR_JSON" | jq -r .headRefName)"
+  ISSUE="$(gh pr view "$PR" --repo "$SLUG" --json body,title \
+           | jq -r '(.body,.title)|scan("#([0-9]{3,})")|.[0]' | head -1)"
+  log "In-flight PR #$PR (branch $BRANCH, issue #${ISSUE:-?})."
+
+  ROLLUP="$(gh pr view "$PR" --repo "$SLUG" --json statusCheckRollup \
+    | jq -r '[.statusCheckRollup[]? | {s:(.conclusion//.state//"PENDING")}]')"
+  FAILED="$(echo "$ROLLUP" | jq '[.[]|select(.s=="FAILURE" or .s=="ERROR" or .s=="TIMED_OUT" or .s=="CANCELLED")]|length')"
+  PENDING="$(echo "$ROLLUP" | jq '[.[]|select(.s=="PENDING" or .s=="QUEUED" or .s=="IN_PROGRESS" or .s=="EXPECTED")]|length')"
+
+  COPILOT_CR="$(gh pr view "$PR" --repo "$SLUG" --json reviews \
+    | jq '[.reviews[]?|select(.author.login=="copilot-pull-request-reviewer")]|last|.state=="CHANGES_REQUESTED"' 2>/dev/null)"
+
+  ATTEMPTS="$(git -C "$REPO" rev-list --count "origin/main..origin/$BRANCH" 2>/dev/null || echo 1)"
+
+  if [ "${FAILED:-0}" -gt 0 ]; then
+    if [ "${ATTEMPTS:-1}" -ge "$MAX_FIX_ATTEMPTS" ]; then
+      log "PR #$PR failing after $ATTEMPTS attempts — escalating to human."
+      if [ "$DRY_RUN" != "1" ]; then
+        gh pr edit "$PR" --repo "$SLUG" --add-label needs-human --add-label agent:blocked --remove-label agent:working >/dev/null 2>&1
+        gh pr ready --undo "$PR" --repo "$SLUG" >/dev/null 2>&1
+        [ -n "$ISSUE" ] && gh issue edit "$ISSUE" --repo "$SLUG" --add-label needs-human --add-assignee "$ASSIGNEE" --remove-label agent:ready >/dev/null 2>&1
+        gh pr comment "$PR" --repo "$SLUG" --body "🚧 Auto-fix gave up after $ATTEMPTS attempts. Assigning @$ASSIGNEE — CI is still red; needs a human look." >/dev/null 2>&1
+      fi
+      exit 0
+    fi
+    log "PR #$PR CI failing (attempt $ATTEMPTS) — invoking fix."
+    WT="$(add_worktree "$BRANCH" origin/main)"
+    export MODE=fix PR ISSUE WORKTREE="$WT" BRANCH ATTEMPTS
+    run_claude "$WT" "Read $RUNBOOK and follow MODE=fix. PR=$PR ISSUE=$ISSUE BRANCH=$BRANCH ATTEMPTS=$ATTEMPTS."
+    exit 0
+  fi
+
+  if [ "${COPILOT_CR:-false}" = "true" ]; then
+    log "PR #$PR — Copilot requested changes — invoking review-address."
+    WT="$(add_worktree "$BRANCH" origin/main)"
+    export MODE=review PR ISSUE WORKTREE="$WT" BRANCH
+    run_claude "$WT" "Read $RUNBOOK and follow MODE=review. PR=$PR ISSUE=$ISSUE BRANCH=$BRANCH."
+    exit 0
+  fi
+
+  if [ "${PENDING:-0}" -gt 0 ]; then
+    log "PR #$PR — CI still running ($PENDING pending). Waiting; no Claude call."
+    exit 0
+  fi
+
+  log "PR #$PR — checks green, no change requests. Auto-merge lands it (or it's held for human). Nothing to do."
+  exit 0
+fi
+
+# No in-flight PR — start the next ready issue.
+ISSUE="$(select_next_issue)"
+if [ -z "$ISSUE" ]; then
+  log "No agent:ready issues remaining. Pipeline idle."
+  exit 0
+fi
+RISK="$(risk_of_issue "$ISSUE")"; [ -z "$RISK" ] && RISK="none"
+BRANCH="feature/claude-issue-$ISSUE"
+log "Starting issue #$ISSUE (risk=$RISK) on $BRANCH."
+if [ "$DRY_RUN" = "1" ]; then
+  log "DRY_RUN: would create worktree $BRANCH and run MODE=start for #$ISSUE."
+  exit 0
+fi
+gh issue edit "$ISSUE" --repo "$SLUG" --add-label agent:working --remove-label agent:ready >/dev/null 2>&1
+WT="$(add_worktree "$BRANCH" origin/main)"
+export MODE=start ISSUE WORKTREE="$WT" BRANCH RISK
+run_claude "$WT" "Read $RUNBOOK and follow MODE=start. ISSUE=$ISSUE BRANCH=$BRANCH RISK=$RISK WORKTREE=$WT."
+exit 0

--- a/scripts/agent-pipeline/tick.sh
+++ b/scripts/agent-pipeline/tick.sh
@@ -4,13 +4,20 @@
 # Uses the owner's Claude Max login (no API cost). Never touches the dev checkout's branch —
 # all issue work happens in isolated git worktrees. Deploy happens via the existing
 # merge->release-please->build->deploy pipeline once a PR lands on main.
+#
+# MERGE IS RUNNER-CONTROLLED (not GitHub eager auto-merge): a PR is merged ONLY after
+#   (1) all CI checks are green, (2) Copilot has reviewed the current head commit, and
+#   (3) there are zero unresolved Copilot review threads.
+# This guarantees Copilot's comments are read + addressed BEFORE merge.
 set -uo pipefail
 
 # --- config ---
 BASE="/home/lem/agent-pipeline"
 REPO="/home/lem/linkedin_engagement_manager"
 SLUG="christopherqueenconsulting/linkedin_engagement_manager"
+OWNER="${SLUG%%/*}"; NAME="${SLUG##*/}"
 ASSIGNEE="gitchrisqueen"
+COPILOT="copilot-pull-request-reviewer"
 WORKROOT="$BASE/work"
 LOGDIR="$BASE/logs"
 RUNBOOK="$BASE/RUNBOOK.md"
@@ -35,16 +42,18 @@ exec 9>"$LOCK"
 flock -n 9 || { log "another tick holds the lock — skipping."; exit 0; }
 
 # --- helpers ---
+epoch() { date -d "$1" +%s 2>/dev/null || echo 0; }
+
 select_next_issue() {
-  # Next ready issue: has agent:ready, not needs-human/agent:blocked, ordered by
-  # milestone number (7->12) then priority (critical>high>medium>low) then issue number.
+  # Next ready issue: has agent:ready, not needs-human/agent:working/agent:blocked,
+  # ordered by milestone number (7->12) then priority then issue number.
   gh issue list --repo "$SLUG" --state open --limit 100 --label "agent:ready" \
     --json number,labels,milestone | jq -r '
     def prio: (.labels|map(.name)|map(select(startswith("priority:")))|.[0] // "priority:zzz")
       | {"priority:critical":0,"priority:high":1,"priority:medium":2,"priority:low":3}[.] // 4;
     def msnum: (.milestone.title // "Milestone 999" | capture("Milestone (?<n>[0-9]+)").n | tonumber);
     map(select((.labels|map(.name)) as $l
-        | ($l|index("needs-human")|not) and ($l|index("agent:blocked")|not)))
+        | ($l|index("needs-human")|not) and ($l|index("agent:blocked")|not) and ($l|index("agent:working")|not)))
     | sort_by(msnum, prio, .number)
     | .[0].number // empty'
 }
@@ -54,9 +63,22 @@ open_agent_pr() {
     --json number,headRefName,labels | jq -r '.[0] // empty | @json'
 }
 
-risk_of_issue() {
-  gh issue view "$1" --repo "$SLUG" --json labels \
-    | jq -r '[.labels[].name | select(startswith("risk:")) | sub("risk:";"")] | join(" ")'
+# Count of UNRESOLVED review threads whose first comment is authored by Copilot.
+copilot_unresolved_threads() {  # $1=pr
+  gh api graphql -f query='
+    query($owner:String!,$name:String!,$pr:Int!){
+      repository(owner:$owner,name:$name){ pullRequest(number:$pr){
+        reviewThreads(first:100){ nodes{ isResolved comments(first:1){ nodes{ author{ login } } } } } } } }' \
+    -f owner="$OWNER" -f name="$NAME" -F pr="$1" 2>/dev/null \
+  | jq --arg c "$COPILOT" '[.data.repository.pullRequest.reviewThreads.nodes[]?
+       | select(.isResolved==false)
+       | select((.comments.nodes[0].author.login // "")|test($c;"i"))] | length' 2>/dev/null || echo 0
+}
+
+# ISO timestamp of Copilot's most recent submitted review (empty if none).
+copilot_last_review_at() {  # $1=pr
+  gh pr view "$1" --repo "$SLUG" --json reviews \
+    | jq -r --arg c "$COPILOT" '[.reviews[]?|select(.author.login==$c)]|last|.submittedAt // empty' 2>/dev/null
 }
 
 add_worktree() {  # $1=branch  $2=base(ref)  -> path on stdout
@@ -92,26 +114,26 @@ if [ -n "$PR_JSON" ]; then
   BRANCH="$(echo "$PR_JSON" | jq -r .headRefName)"
   ISSUE="$(gh pr view "$PR" --repo "$SLUG" --json body,title \
            | jq -r '(.body,.title)|scan("#([0-9]{3,})")|.[0]' | head -1)"
+  HEAD_DATE="$(git -C "$REPO" log -1 --format=%cI "origin/$BRANCH" 2>/dev/null)"
   log "In-flight PR #$PR (branch $BRANCH, issue #${ISSUE:-?})."
 
   ROLLUP="$(gh pr view "$PR" --repo "$SLUG" --json statusCheckRollup \
     | jq -r '[.statusCheckRollup[]? | {s:(.conclusion//.state//"PENDING")}]')"
   FAILED="$(echo "$ROLLUP" | jq '[.[]|select(.s=="FAILURE" or .s=="ERROR" or .s=="TIMED_OUT" or .s=="CANCELLED")]|length')"
   PENDING="$(echo "$ROLLUP" | jq '[.[]|select(.s=="PENDING" or .s=="QUEUED" or .s=="IN_PROGRESS" or .s=="EXPECTED")]|length')"
-
-  COPILOT_CR="$(gh pr view "$PR" --repo "$SLUG" --json reviews \
-    | jq '[.reviews[]?|select(.author.login=="copilot-pull-request-reviewer")]|last|.state=="CHANGES_REQUESTED"' 2>/dev/null)"
-
   ATTEMPTS="$(git -C "$REPO" rev-list --count "origin/main..origin/$BRANCH" 2>/dev/null || echo 1)"
+  UNRESOLVED="$(copilot_unresolved_threads "$PR")"
+  CP_AT="$(copilot_last_review_at "$PR")"
 
+  # 1) CI failing -> fix (or escalate after too many tries)
   if [ "${FAILED:-0}" -gt 0 ]; then
     if [ "${ATTEMPTS:-1}" -ge "$MAX_FIX_ATTEMPTS" ]; then
       log "PR #$PR failing after $ATTEMPTS attempts — escalating to human."
       if [ "$DRY_RUN" != "1" ]; then
         gh pr edit "$PR" --repo "$SLUG" --add-label needs-human --add-label agent:blocked --remove-label agent:working >/dev/null 2>&1
         gh pr ready --undo "$PR" --repo "$SLUG" >/dev/null 2>&1
-        [ -n "$ISSUE" ] && gh issue edit "$ISSUE" --repo "$SLUG" --add-label needs-human --add-assignee "$ASSIGNEE" --remove-label agent:ready >/dev/null 2>&1
-        gh pr comment "$PR" --repo "$SLUG" --body "🚧 Auto-fix gave up after $ATTEMPTS attempts. Assigning @$ASSIGNEE — CI is still red; needs a human look." >/dev/null 2>&1
+        [ -n "$ISSUE" ] && gh issue edit "$ISSUE" --repo "$SLUG" --add-label needs-human --add-label agent:blocked --add-assignee "$ASSIGNEE" --remove-label agent:working >/dev/null 2>&1
+        gh pr comment "$PR" --repo "$SLUG" --body "🚧 Auto-fix gave up after $ATTEMPTS attempts. Assigning @$ASSIGNEE — CI is still red." >/dev/null 2>&1
       fi
       exit 0
     fi
@@ -122,20 +144,33 @@ if [ -n "$PR_JSON" ]; then
     exit 0
   fi
 
-  if [ "${COPILOT_CR:-false}" = "true" ]; then
-    log "PR #$PR — Copilot requested changes — invoking review-address."
+  # 2) Copilot has unresolved review threads -> address + resolve them BEFORE any merge
+  if [ "${UNRESOLVED:-0}" -gt 0 ]; then
+    log "PR #$PR — $UNRESOLVED unresolved Copilot thread(s) — invoking review-address."
     WT="$(add_worktree "$BRANCH" origin/main)"
     export MODE=review PR ISSUE WORKTREE="$WT" BRANCH
     run_claude "$WT" "Read $RUNBOOK and follow MODE=review. PR=$PR ISSUE=$ISSUE BRANCH=$BRANCH."
     exit 0
   fi
 
+  # 3) CI still running -> wait
   if [ "${PENDING:-0}" -gt 0 ]; then
-    log "PR #$PR — CI still running ($PENDING pending). Waiting; no Claude call."
+    log "PR #$PR — CI still running ($PENDING pending). Waiting."
     exit 0
   fi
 
-  log "PR #$PR — checks green, no change requests. Auto-merge lands it (or it's held for human). Nothing to do."
+  # 4) CI green + no unresolved Copilot threads. Require Copilot to have reviewed the CURRENT head.
+  if [ -z "$CP_AT" ] || [ "$(epoch "$CP_AT")" -lt "$(epoch "$HEAD_DATE")" ]; then
+    log "PR #$PR — green, but waiting for Copilot to review the current head commit before merge."
+    exit 0
+  fi
+
+  # 5) Green + Copilot reviewed head + all threads resolved -> merge (runner-controlled).
+  log "PR #$PR — green, Copilot reviewed & all threads resolved. Merging."
+  if [ "$DRY_RUN" != "1" ]; then
+    gh pr merge --auto "$(gh pr view "$PR" --repo "$SLUG" --json url --jq .url)" >/dev/null 2>&1 \
+      && gh pr comment "$PR" --repo "$SLUG" --body "✅ CI green, Copilot review addressed & resolved — merging." >/dev/null 2>&1
+  fi
   exit 0
 fi
 
@@ -145,7 +180,9 @@ if [ -z "$ISSUE" ]; then
   log "No agent:ready issues remaining. Pipeline idle."
   exit 0
 fi
-RISK="$(risk_of_issue "$ISSUE")"; [ -z "$RISK" ] && RISK="none"
+RISK="$(gh issue view "$ISSUE" --repo "$SLUG" --json labels \
+        | jq -r '[.labels[].name|select(startswith("risk:"))|sub("risk:";"")]|join(" ")')"
+[ -z "$RISK" ] && RISK="none"
 BRANCH="feature/claude-issue-$ISSUE"
 log "Starting issue #$ISSUE (risk=$RISK) on $BRANCH."
 if [ "$DRY_RUN" = "1" ]; then


### PR DESCRIPTION
## What
Version-controls the **autonomous milestone pipeline** that drives roadmap issues (Milestones 7–12, #382–406) to merged & deployed. Additive only — no existing files changed.

## How it works
- **Implementer = Claude on the Max subscription** (runs on the VPS under `~/.claude`, **no API cost**). Works one issue at a time in an isolated git worktree → opens a PR → fixes failing CI → addresses **Copilot** review comments → auto-merges when green.
- **Reviewer = GitHub Copilot only** (free). Copilot never writes code here.
- **Serial (cap=1)**, priority order M7→M12, paced to Max limits (waits/resumes on usage caps).
- **Auto-merge green, hold risky.** `risk:migration` / `risk:security` / `risk:live-linkedin` / `risk:product-decision` are built to green then handed to a human to merge. Merge → existing release-please → build → `deploy-vps` (auto-rollback on health fail).
- **Escalation:** `needs-human` + assignee when stuck (≤4 CI-fix attempts), needs live-LinkedIn, or needs a decision.

## Files (`scripts/agent-pipeline/`)
- `tick.sh` — driver: advances the pipeline one step per cron tick
- `RUNBOOK.md` — the start/fix/review/escalate instructions Claude follows
- `install.sh` — installs the runner to `/home/lem/agent-pipeline` (paused) + hourly cron
- `classify-issues.sh` — labels the roadmap issues (already applied)
- `README.md` — operator docs & controls

## Safety
Every PR must pass **Unit Tests, Integration Tests, GitGuardian** + Copilot review before merge. Risky classes never auto-merge. Instant pause via `touch /home/lem/agent-pipeline/PAUSED`.

## Note
`.github/workflows/claude-code-review.yml` (the old API-key-based Claude reviewer) is **dormant** — no `ANTHROPIC_API_KEY` secret — since reviews are handled by Copilot. Consider removing it in a follow-up to avoid accidental future API spend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)