### PR TITLE
feat(content): authenticity scoring gate (360Brew defense) (closes #382)

### DIFF
--- a/compose/local/database/migrations/V57__add_post_authenticity_score.sql
+++ b/compose/local/database/migrations/V57__add_post_authenticity_score.sql
@@ -1,0 +1,7 @@
+-- Authenticity gate (issue #382 — 360Brew / LinkedIn 2026 Authenticity Update defense).
+-- An LLM judge scores each generated post for generic-AI risk + profile-topic consistency
+-- (0 = obviously generic AI slop, 100 = authentic, specific, on-voice). The content-plan
+-- status-setter demotes an auto-approve to PENDING (human review) when the score falls below
+-- AUTHENTICITY_SCORE_MIN — the same demote-not-block posture as the deterministic similarity gate.
+-- NULL = not yet scored (e.g. pre-existing rows, or the gate disabled).
+ALTER TABLE posts ADD COLUMN authenticity_score INT NULL;

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -25,12 +25,14 @@ from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, upda
     update_db_post_carousel_slides, get_post_content, get_user_timezone, get_engagement_preferences
 from cqc_lem.utilities.db import get_recent_post_shape_history, update_db_post_shape, get_lead_magnet_settings, \
     get_shape_performance
-from cqc_lem.utilities.db import get_recent_post_texts
+from cqc_lem.utilities.db import get_recent_post_texts, update_db_post_authenticity_score, \
+    get_post_authenticity_score
 from cqc_lem.utilities.ai.content_framework import select_blueprint, history_avoidance_directive, \
     find_most_similar, post_similarity_max, has_first_person_proof
 from cqc_lem.utilities.ai.content_alignment import (
     should_include_lead_magnet_cta, lead_magnet_cta_directive, ensure_lead_magnet_cta,
-    personal_proof_directive, topic_authority_score, topic_authority_min, profile_topic_dna)
+    personal_proof_directive, topic_authority_score, topic_authority_min, profile_topic_dna,
+    content_matches_focus, score_authenticity, authenticity_gate_enabled, authenticity_score_min)
 from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_RATIO, \
     DEFAULT_IMAGE_RATIO, AI_DISCLOSURE_ENABLED, AI_DISCLOSURE_TEXT, \
     STANDARD_VIDEO_MODEL, PREMIUM_VIDEO_MODEL, PREMIUM_TOP_VIDEO_MODEL, \
@@ -632,6 +634,32 @@ def _proof_regen_enabled() -> bool:
         "1", "true", "yes", "on")
 
 
+def _score_and_persist_authenticity(user_id: int, post_id: int, content: str,
+                                    user_profile: LinkedInProfile, profile_synthesis: str = None,
+                                    prefs: dict = None) -> None:
+    """Run the authenticity gate's LLM judge on a finished draft and persist the 0-100 score (issue
+    #382). This only SCORES + records; the demotion to PENDING happens in the content-plan
+    status-setter, which reads the score back. No-op when the gate is disabled. Best-effort — a scorer
+    or DB hiccup never blocks generation (score_authenticity itself fails open)."""
+    if not authenticity_gate_enabled():
+        return
+    try:
+        result = score_authenticity(content, profile=user_profile,
+                                    profile_synthesis=profile_synthesis, prefs=prefs)
+        update_db_post_authenticity_score(post_id, result.get("score"))
+        if result.get("flagged"):
+            log_warning(
+                f"Post flagged as low-authenticity (score {result.get('score')} < "
+                f"{authenticity_score_min()}) — will hold for review: "
+                f"{'; '.join(result.get('reasons') or []) or 'no reasons given'}",
+                user_id=user_id, post_id=post_id, task_name="create_text_post")
+        else:
+            log_info(f"Post authenticity score {result.get('score')}",
+                     user_id=user_id, post_id=post_id, task_name="create_text_post")
+    except Exception as e:
+        myprint(f"Authenticity scoring skipped for post {post_id}: {e}")
+
+
 def _review_generated_post(user_id: int, stage: str, post_type: str, user_profile: LinkedInProfile,
                            blueprint: dict, post_id: int, lead_magnet_cta: str, content: str,
                            recent_texts: list, prefs: dict = None,
@@ -897,6 +925,14 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
             final_content,
             exempt_keyword=(lead_magnet or {}).get("keyword") if include_cta else None)
         final_content = final_content.strip()
+
+    # Authenticity gate (issue #382 — 360Brew defense): score the finished draft for generic-AI risk
+    # + profile-topic consistency and persist the score BEFORE the similarity gate. The gate itself is
+    # a status demotion (APPROVED -> PENDING) applied by the content-plan status-setter, which reads
+    # the persisted score back — mirroring the deterministic similarity gate's demote-not-block posture.
+    if final_content and refine_final_post and similarity_check and post_id is not None:
+        _score_and_persist_authenticity(user_id, post_id, final_content, user_profile,
+                                        profile_synthesis, prefs)
 
     # Review gate (runs once, in the outermost call): deterministic near-duplicate check against the
     # user's recent posts with ONE avoid-directive retry, plus a cheap focus-alignment check. Never
@@ -1371,6 +1407,18 @@ def auto_create_weekly_content(user_id: int = None):
         if _post_missing_required_asset(post_id, post_type, video_url):
             new_status = PostStatus.PENDING
             myprint(f"post_id {post_id}: required media asset missing — holding PENDING")
+
+        # Authenticity gate (issue #382): demote an auto-approve to PENDING when the persisted
+        # LLM-judged authenticity score (set by create_text_post's scoring step) is below threshold,
+        # so a generic-AI-flagged draft gets human review before it can post. Only downgrades an
+        # APPROVED — never upgrades a PENDING, and never blocks when unscored (score None).
+        if new_status == PostStatus.APPROVED and authenticity_gate_enabled():
+            score = get_post_authenticity_score(post_id)
+            if score is not None and score < authenticity_score_min():
+                new_status = PostStatus.PENDING
+                log_warning(f"post_id {post_id}: authenticity score {score} < "
+                            f"{authenticity_score_min()} — holding PENDING for review",
+                            user_id=user_id, post_id=post_id, task_name="create_content")
 
         myprint(f"Updating post_id: {post_id} Status={new_status}")
         update_db_post_status(post_id, new_status)

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -6,6 +6,7 @@ a HARD no-self-promo guardrail for comments/posts, a LIGHT soft-promo allowance 
 own newsletter. Keeping all of this in one module is what stops the content types from drifting
 out of alignment with each other over time."""
 
+import json
 import math
 import os
 import re
@@ -562,3 +563,114 @@ def voice_reference(profile, profile_synthesis: Optional[str] = None) -> str:
     if profile_synthesis and profile_synthesis.strip():
         return profile_synthesis.strip()
     return profile.model_dump_json()
+
+
+# --- Authenticity gate (issue #382 — 360Brew / LinkedIn 2026 Authenticity Update defense) ---------
+# LinkedIn's 2026 ranking (360Brew + the Authenticity Update) demotes generic AI content — the single
+# biggest threat to an AI-content-heavy product. Before the deterministic similarity gate, an LLM judge
+# (reusing lem-medium) scores a FINISHED draft on how generically-AI it reads AND how consistent it is
+# with the author's own profile/topics: 0 = obviously generic AI slop, 100 = authentic, specific, and
+# on-voice. Drafts below AUTHENTICITY_SCORE_MIN are held for human review instead of auto-approved —
+# the same demote-not-block posture as the similarity gate. Fails OPEN (a scorer hiccup never blocks
+# publishing). Rubric anchored to the 360Brew failure modes: no specifics, hollow buzzwords, listicle
+# scaffolding, and drift away from the author's stated expertise.
+AUTHENTICITY_SCORE_MIN_DEFAULT = 60
+
+
+def authenticity_score_min() -> int:
+    """Score below which a draft is demoted APPROVED -> PENDING. Read live (like post_similarity_max)
+    so ops/tests can tune AUTHENTICITY_SCORE_MIN without a restart. Clamped to 0-100."""
+    raw = (os.environ.get("AUTHENTICITY_SCORE_MIN") or "").strip()
+    try:
+        value = int(raw) if raw else AUTHENTICITY_SCORE_MIN_DEFAULT
+    except ValueError:
+        value = AUTHENTICITY_SCORE_MIN_DEFAULT
+    return max(0, min(100, value))
+
+
+def authenticity_gate_enabled() -> bool:
+    """The authenticity gate defaults ON — it is the core 360Brew defense. Set AUTHENTICITY_GATE_ENABLED
+    to a falsey value (0/false/no/off) to disable it per-deploy."""
+    raw = (os.environ.get("AUTHENTICITY_GATE_ENABLED") or "").strip().lower()
+    if not raw:
+        return True
+    return raw in ("1", "true", "yes", "on")
+
+
+_AUTHENTICITY_JUDGE_SYSTEM = (
+    "You are a strict LinkedIn content authenticity judge modeling LinkedIn's 2026 ranking (360Brew + "
+    "the Authenticity Update), which DEMOTES generic AI-written content. Score how AUTHENTIC and "
+    "human/specific a post reads, and how CONSISTENT it is with the author's stated expertise and voice.\n"
+    "Penalize (lower score): generic buzzword filler with no concrete specifics; interchangeable "
+    "'thought-leader' phrasing that could be posted by anyone; hollow listicle scaffolding; obvious "
+    "AI tells; and topic drift away from the author's actual expertise.\n"
+    "Reward (higher score): a specific point of view, concrete detail/example/number, a genuine "
+    "personal or first-hand angle, and clear consistency with the author's profile topics.\n"
+    "0 = obviously generic AI slop; 100 = authentic, specific, and unmistakably on-voice.\n"
+    "Respond ONLY with a compact JSON object: {\"score\": <int 0-100>, \"reasons\": [\"...\", \"...\"]}."
+)
+
+
+def _coerce_authenticity_result(raw_text: str) -> Optional[dict]:
+    """Parse the judge's JSON reply into {score:int 0-100, reasons:list[str]} or None if unusable."""
+    if not raw_text:
+        return None
+    text = raw_text.strip()
+    # Tolerate ```json fences and any prose around the object.
+    match = re.search(r"\{.*\}", text, re.DOTALL)
+    if not match:
+        return None
+    try:
+        data = json.loads(match.group(0))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict) or "score" not in data:
+        return None
+    try:
+        score = int(round(float(data["score"])))
+    except (ValueError, TypeError):
+        return None
+    reasons = data.get("reasons") or []
+    if isinstance(reasons, str):
+        reasons = [reasons]
+    reasons = [str(r).strip() for r in reasons if str(r).strip()]
+    return {"score": max(0, min(100, score)), "reasons": reasons}
+
+
+def score_authenticity(content: str, profile=None, profile_synthesis: Optional[str] = None,
+                       prefs: dict = None) -> dict:
+    """LLM-judge the authenticity / generic-AI risk of a finished post draft.
+
+    Returns {"score": int 0-100, "reasons": list[str], "flagged": bool} where flagged means the score
+    fell below authenticity_score_min(). Reuses lem-medium. FAILS OPEN — on any error (or empty input)
+    it returns a passing, unflagged result so a judge hiccup never blocks publishing."""
+    passing = {"score": 100, "reasons": [], "flagged": False}
+    if not content or not content.strip():
+        return passing
+    try:
+        voice = voice_reference(profile, profile_synthesis) if profile is not None else ""
+        topics = ", ".join(_focus_topics(prefs)) if prefs else ""
+        context_lines = []
+        if voice:
+            context_lines.append(f"Author voice/profile reference:\n{voice[:1500]}")
+        if topics:
+            context_lines.append(f"Author's declared focus topics: {topics}")
+        context = ("\n\n".join(context_lines) + "\n\n") if context_lines else ""
+
+        # Lazy import avoids a circular import (ai_helper imports this module).
+        from cqc_lem.utilities.ai.ai_helper import _call_llm
+        resp = _call_llm(
+            model="lem-medium",
+            messages=[
+                {"role": "system", "content": _AUTHENTICITY_JUDGE_SYSTEM},
+                {"role": "user", "content": f"{context}Post to score:\n{content[:3000]}"},
+            ],
+            temperature=0,
+        )
+        parsed = _coerce_authenticity_result(resp.choices[0].message.content or "")
+        if parsed is None:
+            return passing
+        parsed["flagged"] = parsed["score"] < authenticity_score_min()
+        return parsed
+    except Exception:
+        return passing

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1138,6 +1138,44 @@ def update_db_post_shape(post_id: int, archetype: Optional[str], hook_style: Opt
     return success
 
 
+def update_db_post_authenticity_score(post_id: int, score: Optional[int]) -> bool:
+    """Persist the authenticity gate's LLM-judged score (0-100, or NULL) for a post — the reader that
+    gives the previously dead post-quality column a purpose (issue #382, V57 authenticity_score). The
+    content-plan status-setter reads this back to demote a low-scoring auto-approve to PENDING."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE posts SET authenticity_score = %s WHERE id = %s",
+            (score, post_id)
+        )
+        connection.commit()
+        success = cursor.rowcount == 1
+    except mysql.connector.Error as e:
+        success = False
+        myprint(f"Could not update authenticity score for post {post_id}. Error: {e}")
+    finally:
+        cursor.close()
+        connection.close()
+    return success
+
+
+def get_post_authenticity_score(post_id: int) -> Optional[int]:
+    """The authenticity gate's persisted score for a post (0-100), or None when unscored (issue #382)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT authenticity_score FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not get authenticity score for post {post_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_recent_post_shape_history(user_id: int, limit: int = 10) -> list:
     """Recent posts' SHAPE history — {archetype, hook_style} dicts, most-recent first — fed to the
     shared content framework so a new post rotates away from recently used archetypes/hooks (the

--- a/tests/unit/app/test_content_plan_coverage.py
+++ b/tests/unit/app/test_content_plan_coverage.py
@@ -160,6 +160,7 @@ class TestAutoCreateWeeklyContentVideoPath:
              patch(f"{_RCP}.update_db_post_status") as upd_status, \
              patch(f"{_RCP}.get_user_preferences", return_value={"auto_schedule_posts": True}), \
              patch(f"{_RCP}._post_missing_required_asset", return_value=False), \
+             patch(f"{_RCP}.get_post_authenticity_score", return_value=None), \
              patch.object(rcp, "AI_DISCLOSURE_ENABLED", True), \
              patch.object(rcp, "AI_DISCLOSURE_TEXT", "\n\nAI visuals."):
             rcp.auto_create_weekly_content(user_id=1)
@@ -187,6 +188,7 @@ class TestAutoCreateWeeklyContentVideoPath:
              patch(f"{_RCP}.update_db_post_status"), \
              patch(f"{_RCP}.get_user_preferences", return_value={"auto_schedule_posts": True}), \
              patch(f"{_RCP}._post_missing_required_asset", return_value=False), \
+             patch(f"{_RCP}.get_post_authenticity_score", return_value=None), \
              patch.object(rcp, "AI_DISCLOSURE_ENABLED", True), \
              patch.object(rcp, "AI_DISCLOSURE_TEXT", "\n\nAI visuals."):
             rcp.auto_create_weekly_content(user_id=1)

--- a/tests/unit/app/test_content_plan_deep_coverage.py
+++ b/tests/unit/app/test_content_plan_deep_coverage.py
@@ -144,6 +144,7 @@ class _TextPostHarness:
             # These tests exercise routing/refinement/shape persistence, not the A2 proof gate —
             # keep the stub post bodies from triggering a proof regeneration.
             "proof_env": patch.dict(os.environ, {"POST_PROOF_REGEN_ENABLED": "off"}),
+            "authenticity": patch(f"{_RCP}._score_and_persist_authenticity"),
         }
         self.mocks = {k: p.start() for k, p in self.patchers.items()}
         return self.mocks

--- a/tests/unit/app/test_lead_magnet_cta_survival.py
+++ b/tests/unit/app/test_lead_magnet_cta_survival.py
@@ -46,6 +46,7 @@ def _run_pipeline(post_id, refined_output, lead_magnet=_LM_ON, prefs=None):
          patch(f"{_RCP}.update_db_post_shape"), \
          patch(f"{_RCP}.get_thought_leadership_post_from_ai", side_effect=gen), \
          patch(f"{_RCP}.get_ai_linked_post_refinement", return_value=refined_output), \
+         patch(f"{_RCP}._score_and_persist_authenticity"), \
          patch(f"{_RCP}.optimize_post_hook", side_effect=lambda t, **kw: t):
         return rcp.create_text_post(1, "awareness", post_type="thought_leadership",
                                     user_profile=MagicMock(), refine_final_post=True,

--- a/tests/unit/app/test_post_review_gate.py
+++ b/tests/unit/app/test_post_review_gate.py
@@ -52,6 +52,9 @@ def _run(outputs, recent=None, prefs=None, post_id=77, log=None):
         patch(f"{_RCP}.optimize_post_hook", side_effect=lambda c, **kw: c),
         patch(f"{_RCP}.sanitize_for_linkedin", side_effect=lambda c, **kw: c),
         patch(f"{_RCP}.strip_engagement_bait", side_effect=lambda c, **kw: c),
+        # Authenticity gate is exercised in test_authenticity_gate.py — no-op it here so the
+        # similarity-gate tests stay focused (and don't attempt a real LLM/DB call).
+        patch(f"{_RCP}._score_and_persist_authenticity"),
     ]
     if log is not None:
         patches.append(patch(f"{_RCP}.log_warning", log))

--- a/tests/unit/app/test_run_content_plan.py
+++ b/tests/unit/app/test_run_content_plan.py
@@ -83,13 +83,15 @@ class TestAutoCreateWeeklyContent:
         auto_create_weekly_content(user_id=1)
         mock_update_status.assert_called_once_with(55, PostStatus.PENDING)
 
+    @patch('cqc_lem.app.run_content_plan.get_post_authenticity_score', return_value=None)
     @patch('cqc_lem.app.run_content_plan.get_user_preferences', return_value={'auto_schedule_posts': 1})
     @patch('cqc_lem.app.run_content_plan.update_db_post_status')
     @patch('cqc_lem.app.run_content_plan.update_db_post_content')
     @patch('cqc_lem.app.run_content_plan.create_content', return_value=('Auto-on content', None))
     @patch('cqc_lem.app.run_content_plan.get_planned_posts_for_current_week')
     def test_status_is_approved_when_auto_schedule_on(
-        self, mock_current, mock_create, mock_update_content, mock_update_status, mock_prefs
+        self, mock_current, mock_create, mock_update_content, mock_update_status, mock_prefs,
+        mock_auth_score
     ):
         from cqc_lem.app.run_content_plan import auto_create_weekly_content
         from cqc_lem.utilities.db import PostStatus

--- a/tests/unit/utilities/ai/test_authenticity_gate.py
+++ b/tests/unit/utilities/ai/test_authenticity_gate.py
@@ -1,0 +1,226 @@
+"""Unit tests for the authenticity gate (issue #382 — 360Brew defense): the LLM-judge scorer in
+content_alignment (threshold config, JSON coercion, fail-open behavior) and its integration into
+the content pipeline (persist the score, demote a low-scoring auto-approve APPROVED -> PENDING)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cqc_lem.utilities.ai import content_alignment as ca
+
+pytestmark = pytest.mark.unit
+
+
+def _llm_reply(text: str) -> MagicMock:
+    resp = MagicMock()
+    resp.choices = [MagicMock(message=MagicMock(content=text))]
+    return resp
+
+
+class TestThresholdConfig:
+    def test_default_min(self, monkeypatch):
+        monkeypatch.delenv("AUTHENTICITY_SCORE_MIN", raising=False)
+        assert ca.authenticity_score_min() == ca.AUTHENTICITY_SCORE_MIN_DEFAULT
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("AUTHENTICITY_SCORE_MIN", "75")
+        assert ca.authenticity_score_min() == 75
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("AUTHENTICITY_SCORE_MIN", "not-a-number")
+        assert ca.authenticity_score_min() == ca.AUTHENTICITY_SCORE_MIN_DEFAULT
+
+    def test_env_clamped_to_range(self, monkeypatch):
+        monkeypatch.setenv("AUTHENTICITY_SCORE_MIN", "500")
+        assert ca.authenticity_score_min() == 100
+        monkeypatch.setenv("AUTHENTICITY_SCORE_MIN", "-10")
+        assert ca.authenticity_score_min() == 0
+
+    def test_gate_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("AUTHENTICITY_GATE_ENABLED", raising=False)
+        assert ca.authenticity_gate_enabled() is True
+
+    @pytest.mark.parametrize("val,expected", [
+        ("0", False), ("false", False), ("no", False), ("off", False),
+        ("1", True), ("true", True), ("yes", True), ("on", True),
+    ])
+    def test_gate_toggle(self, monkeypatch, val, expected):
+        monkeypatch.setenv("AUTHENTICITY_GATE_ENABLED", val)
+        assert ca.authenticity_gate_enabled() is expected
+
+
+class TestCoerceResult:
+    def test_plain_json(self):
+        out = ca._coerce_authenticity_result('{"score": 82, "reasons": ["specific", "on-voice"]}')
+        assert out == {"score": 82, "reasons": ["specific", "on-voice"]}
+
+    def test_fenced_and_prose_wrapped(self):
+        text = 'Here is my judgment:\n```json\n{"score": 40, "reasons": ["generic"]}\n```\nDone.'
+        out = ca._coerce_authenticity_result(text)
+        assert out["score"] == 40
+        assert out["reasons"] == ["generic"]
+
+    def test_float_score_rounded(self):
+        assert ca._coerce_authenticity_result('{"score": 66.7}')["score"] == 67
+
+    def test_score_clamped(self):
+        assert ca._coerce_authenticity_result('{"score": 140}')["score"] == 100
+        assert ca._coerce_authenticity_result('{"score": -5}')["score"] == 0
+
+    def test_string_reasons_normalized_to_list(self):
+        assert ca._coerce_authenticity_result('{"score": 50, "reasons": "too generic"}')["reasons"] == [
+            "too generic"]
+
+    def test_missing_reasons_ok(self):
+        assert ca._coerce_authenticity_result('{"score": 90}')["reasons"] == []
+
+    @pytest.mark.parametrize("bad", [
+        "", "no json here", "{not valid json}", '{"reasons": ["x"]}',
+        '{"score": "high"}',
+    ])
+    def test_unusable_returns_none(self, bad):
+        assert ca._coerce_authenticity_result(bad) is None
+
+
+class TestScoreAuthenticity:
+    def test_empty_content_passes_without_llm(self):
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm") as m:
+            out = ca.score_authenticity("   ")
+        m.assert_not_called()
+        assert out == {"score": 100, "reasons": [], "flagged": False}
+
+    def test_high_score_not_flagged(self, monkeypatch):
+        monkeypatch.setenv("AUTHENTICITY_SCORE_MIN", "60")
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_reply('{"score": 85, "reasons": ["specific"]}')):
+            out = ca.score_authenticity("A concrete, specific post about our migration.")
+        assert out["score"] == 85
+        assert out["flagged"] is False
+
+    def test_low_score_flagged(self, monkeypatch):
+        monkeypatch.setenv("AUTHENTICITY_SCORE_MIN", "60")
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_reply('{"score": 30, "reasons": ["generic buzzwords"]}')):
+            out = ca.score_authenticity("In today's fast-paced world, synergy unlocks success.")
+        assert out["score"] == 30
+        assert out["flagged"] is True
+        assert out["reasons"] == ["generic buzzwords"]
+
+    def test_fails_open_on_llm_error(self):
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", side_effect=RuntimeError("proxy down")):
+            out = ca.score_authenticity("anything")
+        assert out == {"score": 100, "reasons": [], "flagged": False}
+
+    def test_fails_open_on_unparseable_reply(self):
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_reply("the model rambled with no json")):
+            out = ca.score_authenticity("anything")
+        assert out == {"score": 100, "reasons": [], "flagged": False}
+
+    def test_profile_and_topics_ride_into_prompt(self):
+        prof = MagicMock()
+        prof.model_dump_json.return_value = '{"full_name": "Ada"}'
+        captured = {}
+
+        def _fake(**kwargs):
+            captured.update(kwargs)
+            return _llm_reply('{"score": 70}')
+
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", side_effect=_fake):
+            ca.score_authenticity("post body", profile=prof,
+                                  prefs={"focus_topics": ["MLOps", "observability"]})
+        user_msg = captured["messages"][-1]["content"]
+        assert "MLOps" in user_msg and "observability" in user_msg
+        assert "Ada" in user_msg
+        assert captured["model"] == "lem-medium"
+
+
+_RCP = "cqc_lem.app.run_content_plan"
+
+
+class TestScoreAndPersistHelper:
+    def test_persists_score_and_warns_when_flagged(self):
+        from cqc_lem.app import run_content_plan as rcp
+        log = MagicMock()
+        with patch(f"{_RCP}.authenticity_gate_enabled", return_value=True), \
+             patch(f"{_RCP}.score_authenticity",
+                   return_value={"score": 25, "reasons": ["generic"], "flagged": True}), \
+             patch(f"{_RCP}.update_db_post_authenticity_score") as upd, \
+             patch(f"{_RCP}.log_warning", log):
+            rcp._score_and_persist_authenticity(1, 42, "content", MagicMock())
+        upd.assert_called_once_with(42, 25)
+        assert log.called
+
+    def test_persists_score_when_passing(self):
+        from cqc_lem.app import run_content_plan as rcp
+        with patch(f"{_RCP}.authenticity_gate_enabled", return_value=True), \
+             patch(f"{_RCP}.score_authenticity",
+                   return_value={"score": 88, "reasons": [], "flagged": False}), \
+             patch(f"{_RCP}.update_db_post_authenticity_score") as upd:
+            rcp._score_and_persist_authenticity(1, 42, "content", MagicMock())
+        upd.assert_called_once_with(42, 88)
+
+    def test_noop_when_gate_disabled(self):
+        from cqc_lem.app import run_content_plan as rcp
+        with patch(f"{_RCP}.authenticity_gate_enabled", return_value=False), \
+             patch(f"{_RCP}.score_authenticity") as sc, \
+             patch(f"{_RCP}.update_db_post_authenticity_score") as upd:
+            rcp._score_and_persist_authenticity(1, 42, "content", MagicMock())
+        sc.assert_not_called()
+        upd.assert_not_called()
+
+    def test_exception_never_propagates(self):
+        from cqc_lem.app import run_content_plan as rcp
+        with patch(f"{_RCP}.authenticity_gate_enabled", return_value=True), \
+             patch(f"{_RCP}.score_authenticity", side_effect=RuntimeError("boom")):
+            # Must not raise.
+            rcp._score_and_persist_authenticity(1, 42, "content", MagicMock())
+
+
+class TestStatusDemotion:
+    """The gate at the content-plan status-setter: a low authenticity score demotes an auto-approve
+    to PENDING; it never upgrades, never blocks an unscored post, and honors the disable toggle."""
+
+    def _run(self, score, auto_schedule=True, gate_enabled=True, score_min=60):
+        from cqc_lem.app import run_content_plan as rcp
+        planned = [{"user_id": 1, "id": 42, "post_type": "text", "buyer_stage": "awareness"}]
+        captured = {}
+
+        def _capture_status(post_id, status):
+            captured["status"] = status
+            return True
+
+        with patch(f"{_RCP}.get_planned_posts_for_current_week", return_value=planned), \
+             patch(f"{_RCP}.get_planned_posts_for_next_week", return_value=planned), \
+             patch(f"{_RCP}.create_content", return_value=("some content", None)), \
+             patch(f"{_RCP}.get_user_preferences",
+                   return_value={"auto_schedule_posts": auto_schedule}), \
+             patch(f"{_RCP}._post_missing_required_asset", return_value=False), \
+             patch(f"{_RCP}.update_db_post_content"), \
+             patch(f"{_RCP}.authenticity_gate_enabled", return_value=gate_enabled), \
+             patch(f"{_RCP}.authenticity_score_min", return_value=score_min), \
+             patch(f"{_RCP}.get_post_authenticity_score", return_value=score), \
+             patch(f"{_RCP}.update_db_post_status", side_effect=_capture_status):
+            rcp.auto_create_weekly_content(user_id=1)
+        return captured.get("status")
+
+    def test_low_score_demotes_approved_to_pending(self):
+        from cqc_lem.utilities.db import PostStatus
+        assert self._run(score=30) == PostStatus.PENDING
+
+    def test_high_score_stays_approved(self):
+        from cqc_lem.utilities.db import PostStatus
+        assert self._run(score=90) == PostStatus.APPROVED
+
+    def test_unscored_post_stays_approved(self):
+        from cqc_lem.utilities.db import PostStatus
+        assert self._run(score=None) == PostStatus.APPROVED
+
+    def test_gate_disabled_stays_approved(self):
+        from cqc_lem.utilities.db import PostStatus
+        assert self._run(score=10, gate_enabled=False) == PostStatus.APPROVED
+
+    def test_never_upgrades_a_pending_post(self):
+        # auto_schedule False => PENDING regardless; a high score must not flip it to APPROVED.
+        from cqc_lem.utilities.db import PostStatus
+        assert self._run(score=95, auto_schedule=False) == PostStatus.PENDING

--- a/tests/unit/utilities/ai/test_cta_dedup_tighten.py
+++ b/tests/unit/utilities/ai/test_cta_dedup_tighten.py
@@ -129,6 +129,7 @@ class TestCreateTextPostThreadsKeyword:
              patch(f"{_RCP}.get_recent_post_texts", return_value=[]), \
              patch(f"{_RCP}.get_recent_post_shape_history", return_value=[]), \
              patch(f"{_RCP}.update_db_post_shape"), \
+             patch(f"{_RCP}._score_and_persist_authenticity"), \
              patch(f"{_RCP}.get_thought_leadership_post_from_ai", side_effect=gen), \
              patch(f"{_RCP}.get_ai_linked_post_refinement",
                    side_effect=lambda c, **kw: c) as refine, \
@@ -152,6 +153,7 @@ class TestCreateTextPostThreadsKeyword:
              patch(f"{_RCP}.get_recent_post_texts", return_value=[]), \
              patch(f"{_RCP}.get_recent_post_shape_history", return_value=[]), \
              patch(f"{_RCP}.update_db_post_shape"), \
+             patch(f"{_RCP}._score_and_persist_authenticity"), \
              patch(f"{_RCP}.get_thought_leadership_post_from_ai", side_effect=gen), \
              patch(f"{_RCP}.get_ai_linked_post_refinement",
                    side_effect=lambda c, **kw: c) as refine, \

--- a/tests/unit/utilities/test_db_authenticity_score.py
+++ b/tests/unit/utilities/test_db_authenticity_score.py
@@ -1,0 +1,74 @@
+"""Unit tests for the V57 authenticity-score DB helpers (issue #382)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _mock_conn(fetch_one=None, rowcount=1):
+    conn = MagicMock(); cur = MagicMock()
+    cur.fetchone.return_value = fetch_one
+    cur.rowcount = rowcount
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestUpdateDbPostAuthenticityScore:
+    def test_updates_score_column(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_db_post_authenticity_score
+            assert update_db_post_authenticity_score(7, 82) is True
+        sql, params = cur.execute.call_args[0]
+        assert "UPDATE posts SET authenticity_score" in sql
+        assert params == (82, 7)
+
+    def test_accepts_null_score(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_db_post_authenticity_score
+            assert update_db_post_authenticity_score(7, None) is True
+        _, params = cur.execute.call_args[0]
+        assert params == (None, 7)
+
+    def test_false_on_db_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_db_post_authenticity_score
+            assert update_db_post_authenticity_score(7, 50) is False
+
+
+class TestGetPostAuthenticityScore:
+    def test_returns_int_score(self):
+        conn, cur = _mock_conn(fetch_one=(73,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_authenticity_score
+            assert get_post_authenticity_score(7) == 73
+        sql, params = cur.execute.call_args[0]
+        assert "SELECT authenticity_score FROM posts" in sql
+        assert params == (7,)
+
+    def test_none_when_unscored(self):
+        conn, cur = _mock_conn(fetch_one=(None,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_authenticity_score
+            assert get_post_authenticity_score(7) is None
+
+    def test_none_when_no_row(self):
+        conn, cur = _mock_conn(fetch_one=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_authenticity_score
+            assert get_post_authenticity_score(999) is None
+
+    def test_none_on_db_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_authenticity_score
+            assert get_post_authenticity_score(7) is None


### PR DESCRIPTION
## What & why
LinkedIn's 2026 ranking (360Brew + the Authenticity Update) demotes generic AI content — early tests flagged generic posts ~94% of the time. LEM is AI-content-heavy with no authenticity safeguard, so this is the single biggest threat to the product. This adds an authenticity-scoring gate that runs **before** the existing deterministic similarity gate.

## How it works
- **`content_alignment.score_authenticity()`** — an LLM judge (reuses `lem-medium`) scores a finished draft **0–100** on generic-AI risk + author profile/topic consistency and returns reasons. Rubric anchored to the 360Brew failure modes (no specifics, hollow buzzwords, listicle scaffolding, topic drift). **Fails OPEN** — any judge/parse error returns a passing, unflagged result so a hiccup never blocks publishing.
- **Config** (live-read, mirrors `post_similarity_max`): `AUTHENTICITY_SCORE_MIN` (default 60), `AUTHENTICITY_GATE_ENABLED` (default ON — this is the core defense).
- **`create_text_post`** scores + persists the score right before `_review_generated_post` (the similarity gate).
- **Gate** at the content-plan status-setter: demotes an auto-approve **APPROVED → PENDING** when the persisted score is below threshold — the same demote-not-block posture as the similarity gate. Never upgrades a PENDING; never blocks an unscored post.
- **Persistence:** `V57` adds `posts.authenticity_score` (INT NULL) with a `db.py` reader/writer. (The `post_quality` column the issue referenced never existed in schema — V30 added `video_quality` — so `authenticity_score` is the reader, per the issue's alternative.)

## Testing notes
- New: `test_authenticity_gate.py` (threshold config, JSON coercion, fail-open, `_score_and_persist` helper, and the APPROVED→PENDING status demotion) and `test_db_authenticity_score.py` (V57 helpers).
- Existing `create_text_post` / `auto_create_weekly_content` tests shielded from the new LLM/DB call.
- Full unit suite green (2649 passed). Patch coverage: `run_content_plan.py` 97%, `content_alignment.py` 99%.

## Migration
`V57__add_post_authenticity_score.sql` — additive `ALTER TABLE posts ADD COLUMN authenticity_score INT NULL` (non-destructive).

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)