### PR TITLE
test(integration): skip pexels download test on 401/403 (unblock Dependabot CI)

### DIFF
--- a/tests/integration/test_pexels_video.py
+++ b/tests/integration/test_pexels_video.py
@@ -76,10 +76,19 @@ class TestPexelsVideoSearch:
         if not os.environ.get("PEXELS_API_KEY"):
             pytest.skip("PEXELS_API_KEY not set")
 
+        import requests
         from cqc_lem.utilities.pexels_helper import download_pexels_video
 
         dest = str(tmp_path)
-        path = download_pexels_video("technology", dest)
+        try:
+            path = download_pexels_video("technology", dest)
+        except requests.exceptions.HTTPError as e:
+            # A present-but-invalid/expired key (401/403) — e.g. Dependabot runs that cannot read
+            # the Actions-store PEXELS_API_KEY — is functionally "no key" for this live-call test.
+            status = getattr(e.response, "status_code", None)
+            if status in (401, 403):
+                pytest.skip(f"PEXELS_API_KEY unauthorized ({status})")
+            raise
 
         if path is None:
             pytest.skip("Pexels returned no video results for 'technology'")


### PR DESCRIPTION
## Problem
`tests/integration/test_pexels_video.py::TestPexelsVideoSearch::test_download_pexels_video_saves_file` makes a **live Pexels API call** and hard-fails with `401 Client Error` on Dependabot PRs. Dependabot workflow runs can only read the **Dependabot** secret store, not the **Actions** store where `PEXELS_API_KEY` lives, so the key is absent/unauthorized and the test 401s. This blocks the required **Integration Tests** check on **#368** and **#369** (and every Dependabot PR).

## Fix
Mirror the sibling `test_search_videos_returns_results`, which already `pytest.skip`s on a 401/403. Wrap the `download_pexels_video` call in the same guard so a present-but-unauthorized/absent key skips instead of failing. Test-only change; no product code touched.

## After merge
Rebase #368 and #369 (`@dependabot rebase`) so they pick up this test and re-run Integration Tests green, then the existing `dependabot-auto-merge` workflow enqueues them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)