### PR TITLE
feat(content): inject mandatory first-person proof slot into blueprints (closes #383)

### DIFF
--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -26,10 +26,10 @@ from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, upda
 from cqc_lem.utilities.db import get_recent_post_shape_history, update_db_post_shape, get_lead_magnet_settings
 from cqc_lem.utilities.db import get_recent_post_texts
 from cqc_lem.utilities.ai.content_framework import select_blueprint, history_avoidance_directive, \
-    find_most_similar, post_similarity_max
+    find_most_similar, post_similarity_max, has_first_person_proof
 from cqc_lem.utilities.ai.content_alignment import (
     should_include_lead_magnet_cta, lead_magnet_cta_directive, ensure_lead_magnet_cta,
-    content_matches_focus)
+    content_matches_focus, personal_proof_directive)
 from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_RATIO, \
     DEFAULT_IMAGE_RATIO, AI_DISCLOSURE_ENABLED, AI_DISCLOSURE_TEXT, \
     STANDARD_VIDEO_MODEL, PREMIUM_VIDEO_MODEL, PREMIUM_TOP_VIDEO_MODEL, \
@@ -613,31 +613,58 @@ def _check_post_alignment(content: str, prefs: dict, user_id: int = None,
     return aligned
 
 
+def _proof_regen_enabled() -> bool:
+    """Whether a draft missing its A2 first-person proof slot is regenerated (vs. only logged). Read
+    at call time (the POST_SIMILARITY_MAX / research-toggle live-env pattern) so ops can dial the
+    extra generation cost back without a restart. Defaults ON — the reject/regenerate is the point of
+    issue #383; the detector still runs and warns even when regeneration is off, so the A1/anti-slop
+    signal is never lost."""
+    return str(os.getenv("POST_PROOF_REGEN_ENABLED", "on")).strip().lower() in (
+        "1", "true", "yes", "on")
+
+
 def _review_generated_post(user_id: int, stage: str, post_type: str, user_profile: LinkedInProfile,
                            blueprint: dict, post_id: int, lead_magnet_cta: str, content: str,
-                           recent_texts: list, prefs: dict = None) -> str:
+                           recent_texts: list, prefs: dict = None,
+                           profile_synthesis: str = None) -> str:
     """The post-generation REVIEW GATE (the newsletter's dedup maturity applied to posts): compare
     the finished post against the user's recent posts with the deterministic token-set overlap in
-    content_framework. Too similar (> POST_SIMILARITY_MAX) → regenerate ONCE with an explicit avoid
-    directive naming the offending post; still similar → log a structured warning and keep the
-    second attempt (never loop, never hard-block). Also runs the cheap focus-alignment check on
-    whatever content ships."""
+    content_framework, AND check the A2 personal-proof slot (a concrete first-person lived detail).
+    Too similar (> POST_SIMILARITY_MAX) or missing proof → regenerate ONCE with an explicit
+    avoid/proof directive; still failing → log a structured warning and keep the second attempt
+    (never loop, never hard-block). Also runs the cheap focus-alignment check on whatever content
+    ships."""
     threshold = post_similarity_max()
     score, match = find_most_similar(content, recent_texts)
-    if score <= threshold:
+    too_similar = score > threshold
+    missing_proof = not has_first_person_proof(content)
+    proof_regen = missing_proof and _proof_regen_enabled()
+
+    if not too_similar and not proof_regen:
+        if missing_proof:
+            log_warning("Generated post lacks a concrete first-person lived detail (A2 proof slot)",
+                        user_id=user_id, post_id=post_id, task_name="create_text_post")
         _check_post_alignment(content, prefs, user_id, post_id)
         return content
 
-    myprint(f"Post too similar to a recent post (score {score:.2f} > max {threshold:.2f}) — "
-            f"retrying once with an explicit avoid directive")
-    retry_directive = history_avoidance_directive(recent_texts, offending_text=match)
+    reasons = []
+    if too_similar:
+        reasons.append(f"too similar to a recent post (score {score:.2f} > max {threshold:.2f})")
+    if proof_regen:
+        reasons.append("missing a concrete first-person lived detail (A2 proof slot)")
+    myprint(f"Post {'; '.join(reasons)} — retrying once with an explicit avoid/proof directive")
+
+    retry_directive = history_avoidance_directive(
+        recent_texts, offending_text=match if too_similar else None)
+    if proof_regen:
+        retry_directive += personal_proof_directive(profile_synthesis)
     try:
         second = create_text_post(user_id, stage, post_type, user_profile, refine_final_post=True,
                                   blueprint=blueprint, post_id=post_id,
                                   lead_magnet_cta=lead_magnet_cta,
                                   history_directive=retry_directive, similarity_check=False)
     except Exception as e:
-        log_warning("Similarity retry generation failed; keeping first draft", exc=e,
+        log_warning("Review-gate retry generation failed; keeping first draft", exc=e,
                     user_id=user_id, post_id=post_id, task_name="create_text_post")
         second = None
     if not second:
@@ -648,6 +675,10 @@ def _review_generated_post(user_id: int, stage: str, post_type: str, user_profil
     if second_score > threshold:
         log_warning(f"Post still similar to a recent post after retry "
                     f"(score {second_score:.2f} > max {threshold:.2f}); keeping second attempt",
+                    user_id=user_id, post_id=post_id, task_name="create_text_post")
+    if not has_first_person_proof(second):
+        log_warning("Post still lacks a concrete first-person lived detail after retry "
+                    "(A2 proof slot); keeping second attempt",
                     user_id=user_id, post_id=post_id, task_name="create_text_post")
     _check_post_alignment(second, prefs, user_id, post_id)
     return second
@@ -856,7 +887,7 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
     if final_content and refine_final_post and similarity_check:
         final_content = _review_generated_post(user_id, stage, post_type, user_profile, blueprint,
                                                post_id, lead_magnet_cta, final_content,
-                                               recent_texts, prefs)
+                                               recent_texts, prefs, profile_synthesis)
 
     # The refinement passes above (and any review-gate retry) are LLM rewrites — verified in prod to
     # reword the "comment KEYWORD" mechanic into a generic ask or drop it entirely, which silently

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -626,7 +626,7 @@ def _proof_regen_enabled() -> bool:
 def _review_generated_post(user_id: int, stage: str, post_type: str, user_profile: LinkedInProfile,
                            blueprint: dict, post_id: int, lead_magnet_cta: str, content: str,
                            recent_texts: list, prefs: dict = None,
-                           profile_synthesis: str = None) -> str:
+                           profile_synthesis: Optional[str] = None) -> str:
     """The post-generation REVIEW GATE (the newsletter's dedup maturity applied to posts): compare
     the finished post against the user's recent posts with the deterministic token-set overlap in
     content_framework, AND check the A2 personal-proof slot (a concrete first-person lived detail).
@@ -1062,7 +1062,7 @@ def process_selected_post(url, content):
 
 
 def generate_website_content_post(sitemap_url, linked_user_profile, stage: str, prefs: dict = None,
-                                  profile_synthesis: str = None, blueprint: dict = None,
+                                  profile_synthesis: Optional[str] = None, blueprint: dict = None,
                                   lead_magnet_cta: str = None, history_directive: str = None):
     """
     Generate a post based on content found on the user's website using their sitemap url catered to readers in the desired buyers journey stage.

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -403,6 +403,31 @@ def ensure_lead_magnet_cta(content: Optional[str], lead_magnet: Optional[dict], 
     return normalize_public_text(deduped.rstrip() + "\n\n" + line)
 
 
+def personal_proof_directive(profile_synthesis: Optional[str] = None) -> str:
+    """The A2 first-person proof requirement, SOURCED from the durable profile synthesis (the
+    author's real credibility/expertise brief from get_or_create_profile_synthesis) plus whatever
+    blog/experience content already rides in the prompt: instruct the writer to mine ONE concrete,
+    lived detail — a real number, a moment in time, a named example, or a concrete outcome — out of
+    that background and land it in the first person. This is the sourcing half of the mandatory proof
+    slot content_framework.blueprint_directive injects; content_framework.has_first_person_proof is
+    the deterministic gate that reject/regenerates a draft that comes back generic. Always returns a
+    non-empty directive so callers can append it unconditionally on a regeneration retry. It asks for
+    lived EXPERTISE, never a plug — so it stays inside the NO_SELF_PROMO_GUARDRAIL."""
+    directive = (
+        "\n\nFIRST-PERSON PROOF (required — 2026 authenticity, feeds the anti-generic gate):\n"
+        "- Include at least ONE specific, first-person lived detail the author has actually earned: "
+        "a real number, a moment in time, a named example, or a concrete outcome from their own work "
+        "or experience — never a generic, could-be-anyone claim, and never invented.\n"
+        "- Own it in the first person (\"I\"/\"we\") so it reads as genuine expertise, not AI filler. "
+        "This is proof of experience, not self-promotion — do not turn it into a plug.\n")
+    synth = (profile_synthesis or "").strip()
+    if synth:
+        directive += ("- Draw that detail from the author's real background below; pick a concrete "
+                      "specific already grounded in it rather than inventing one:\n"
+                      + synth[:800] + "\n")
+    return directive
+
+
 def voice_reference(profile, profile_synthesis: Optional[str] = None) -> str:
     """The VOICE/TONE/credibility reference string dropped into a generation prompt. Prefers the
     compact, stable synthesis; falls back to the guarded full profile JSON only when no synthesis was

--- a/src/cqc_lem/utilities/ai/content_framework.py
+++ b/src/cqc_lem/utilities/ai/content_framework.py
@@ -607,6 +607,8 @@ def blueprint_directive(content_type: str, blueprint: dict) -> str:
     if cta:
         c_meta = menu["ctas"][cta]
         lines.append(f"CTA STYLE: {c_meta['label']}. {c_meta['guidance']}")
+    if content_type in _PROOF_SLOT_TYPES:
+        lines.append(PERSONAL_PROOF_SLOT)
     return "\n".join(lines) + "\n"
 
 
@@ -615,6 +617,85 @@ def compact_blueprint(blueprint: dict) -> Optional[dict]:
     if not isinstance(blueprint, dict):
         return None
     return {k: blueprint.get(k) for k in ("subject", "angle", "format", "hook_style", "cta_style")}
+
+
+# ---------------------------------------------------------------------------
+# Personal-expertise / first-person proof slot (A2). 2026 authenticity guidance: AI content that
+# reads as generic gets demoted, so every long/short-form piece must carry at least ONE concrete,
+# FIRST-PERSON lived detail — a real number, a moment in time, a named example, or an outcome from
+# the author's own experience, not an abstract claim. blueprint_directive() injects the mandatory
+# "proof slot" below into the writer prompt (the specific material is the author's voice/expertise
+# reference already in the prompt — see content_alignment.personal_proof_directive), and the
+# deterministic (no-LLM) detector further down is the gate run_content_plan uses to reject and
+# regenerate a draft whose proof slot came back empty or generic (the signal the A1 anti-slop gate
+# also consumes).
+# ---------------------------------------------------------------------------
+
+# Content types that must fill the proof slot. Comments stay grounded in the TARGET post (that is
+# their proof), so forcing the author's own numbers into every comment would drift them off-topic —
+# comments are exempt.
+_PROOF_SLOT_TYPES = frozenset({"post", "newsletter"})
+
+# The mandatory A2 proof-slot line appended to the writer directive. Kept distinct from self-promo:
+# it asks for the author's lived EXPERTISE (credibility), never a plug for anything they are building.
+PERSONAL_PROOF_SLOT = (
+    "MANDATORY PERSONAL-PROOF SLOT: somewhere in the body, land at least ONE specific, first-person "
+    "lived detail only THIS author could write — a real number, a moment in time, a named example, "
+    "or a concrete outcome from their own experience or work (draw it from the author voice & "
+    "expertise reference above). Own it in the first person (\"I\"/\"we\"). Generic, could-be-anyone "
+    "claims do NOT satisfy this — this is what separates real expertise from generic AI content. This "
+    "is proof of experience, not self-promotion: never turn it into a plug for anything the author "
+    "is building."
+)
+
+# First-person ownership markers — the "this happened to ME" half of a lived detail.
+_FIRST_PERSON_RE = re.compile(
+    r"\b(?:i|i'm|i've|i'd|i'll|me|my|myself|mine|we|we're|we've|we'd|we'll|our|ours|us)\b",
+    re.IGNORECASE)
+
+_PROOF_MONTHS = ("january|february|march|april|may|june|july|august|september|october|november|"
+                 "december")
+_PROOF_WEEKDAYS = "monday|tuesday|wednesday|thursday|friday|saturday|sunday"
+
+# Concrete-specificity signals — the "and here is the CHECKABLE particular" half. A number (digit or
+# spelled), a relative-time anchor, or a named day/month grounds the claim in a real moment instead
+# of an abstraction. The gate flags genuinely generic drafts (no number AND no time anchor tied to a
+# first-person clause), not merely digit-free ones — it only regenerates, never hard-blocks, and the
+# proof slot steers writers toward exactly these anchors. Erring toward "counts as proof" keeps the
+# extra generation cost down: a false pass ships a slightly-less-proven post, a false fail burns a
+# regeneration.
+_SPECIFICITY_RE = re.compile(
+    r"\d"
+    r"|\b(?:one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|"
+    r"dozens?|hundreds?|thousands?|millions?|billions?)\b"
+    r"|\b(?:years?|months?|weeks?|weekends?|days?|hours?|decades?)\s+ago\b"
+    r"|\b(?:last|past|next|first|second|third)\s+"
+    r"(?:year|month|week|weekend|quarter|decade|time|day|night|morning)\b"
+    r"|\bback\s+in\b"
+    rf"|\b(?:{_PROOF_MONTHS})\b"
+    rf"|\b(?:{_PROOF_WEEKDAYS})\b",
+    re.IGNORECASE)
+
+_PROOF_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+")
+
+
+def first_person_proof_sentences(text: str) -> list:
+    """Sentences carrying BOTH a first-person marker AND a concrete-specificity signal — i.e. a
+    lived, first-person detail rather than an abstract claim. Deterministic, no LLM. The same-sentence
+    tie is what keeps an unrelated stat elsewhere in a generic post from counting as the author's own
+    proof."""
+    out = []
+    for sentence in _PROOF_SENTENCE_SPLIT.split(text or ""):
+        s = sentence.strip()
+        if s and _FIRST_PERSON_RE.search(s) and _SPECIFICITY_RE.search(s):
+            out.append(s)
+    return out
+
+
+def has_first_person_proof(text: str) -> bool:
+    """True when the draft fills the A2 proof slot — at least one concrete first-person lived detail.
+    Empty/None or purely-generic content → False, so the caller reject/regenerates it."""
+    return bool(first_person_proof_sentences(text))
 
 
 # ---------------------------------------------------------------------------

--- a/src/cqc_lem/utilities/ai/content_framework.py
+++ b/src/cqc_lem/utilities/ai/content_framework.py
@@ -679,7 +679,7 @@ _SPECIFICITY_RE = re.compile(
 _PROOF_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+")
 
 
-def first_person_proof_sentences(text: str) -> list:
+def first_person_proof_sentences(text: Optional[str]) -> list:
     """Sentences carrying BOTH a first-person marker AND a concrete-specificity signal — i.e. a
     lived, first-person detail rather than an abstract claim. Deterministic, no LLM. The same-sentence
     tie is what keeps an unrelated stat elsewhere in a generic post from counting as the author's own
@@ -692,7 +692,7 @@ def first_person_proof_sentences(text: str) -> list:
     return out
 
 
-def has_first_person_proof(text: str) -> bool:
+def has_first_person_proof(text: Optional[str]) -> bool:
     """True when the draft fills the A2 proof slot — at least one concrete first-person lived detail.
     Empty/None or purely-generic content → False, so the caller reject/regenerates it."""
     return bool(first_person_proof_sentences(text))

--- a/tests/unit/app/test_content_plan_deep_coverage.py
+++ b/tests/unit/app/test_content_plan_deep_coverage.py
@@ -2,6 +2,8 @@
 create_text_post routing/refinement/shape persistence, premium video tiers, and
 regenerate task wrappers."""
 
+import os
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -139,6 +141,9 @@ class _TextPostHarness:
             "bait": patch(f"{_RCP}.strip_engagement_bait", side_effect=lambda c, **kw: c),
             "shape_save": patch(f"{_RCP}.update_db_post_shape",
                                 side_effect=self.overrides.get("shape_exc")),
+            # These tests exercise routing/refinement/shape persistence, not the A2 proof gate —
+            # keep the stub post bodies from triggering a proof regeneration.
+            "proof_env": patch.dict(os.environ, {"POST_PROOF_REGEN_ENABLED": "off"}),
         }
         self.mocks = {k: p.start() for k, p in self.patchers.items()}
         return self.mocks

--- a/tests/unit/app/test_post_review_gate.py
+++ b/tests/unit/app/test_post_review_gate.py
@@ -25,6 +25,15 @@ _FRESH = ("AI reliability starts with observability.\n\nWe traced a silent failu
           "production to one retry loop nobody owned. Dashboards did not catch it; distributed "
           "tracing did. Instrument before you scale.")
 
+# Carries a concrete first-person lived detail (the A2 proof slot): first person + a real number.
+_WITH_PROOF = ("Cutting AI cost is a routing problem, not a model problem.\n\nLast quarter I routed "
+               "our simplest calls to a cheap model and dropped our bill by 38%. The frontier model "
+               "now only sees the genuinely hard prompts.")
+
+# First-person voice but NO concrete lived detail — should trip the A2 proof gate.
+_NO_PROOF = ("Authenticity is what wins on LinkedIn.\n\nI believe leaders build trust by showing up "
+             "and adding value. We should all strive to be genuine and put people first, always.")
+
 
 def _run(outputs, recent=None, prefs=None, post_id=77, log=None):
     """Drive create_text_post with a generator that returns `outputs` in order."""
@@ -116,11 +125,13 @@ class TestSimilarityGate:
 
     def test_threshold_env_override_allows_similar_content(self, monkeypatch):
         monkeypatch.setenv("POST_SIMILARITY_MAX", "0.99")
+        monkeypatch.setenv("POST_PROOF_REGEN_ENABLED", "off")  # isolate the similarity gate
         out, gen = _run([_NEAR_DUP], recent=[_RECENT])
         assert out == _NEAR_DUP
         assert gen.call_count == 1  # ceiling raised → no retry
 
-    def test_no_recent_posts_no_gate(self):
+    def test_no_recent_posts_no_gate(self, monkeypatch):
+        monkeypatch.setenv("POST_PROOF_REGEN_ENABLED", "off")  # isolate the similarity gate
         out, gen = _run([_NEAR_DUP], recent=[])
         assert out == _NEAR_DUP
         assert gen.call_count == 1
@@ -143,7 +154,8 @@ class TestAlignmentCheck:
         assert out == off_focus  # never blocks
         assert any("focus topic" in str(c.args[0]) for c in log.call_args_list)
 
-    def test_empty_focus_topics_is_noop(self):
+    def test_empty_focus_topics_is_noop(self, monkeypatch):
+        monkeypatch.setenv("POST_PROOF_REGEN_ENABLED", "off")  # isolate the focus-alignment check
         log = MagicMock()
         out, _ = _run(["Anything at all about any subject whatsoever."],
                       recent=[], prefs={"focus_topics": []}, log=log)
@@ -163,3 +175,47 @@ class TestAlignmentCheck:
             _run([off_focus], recent=[], prefs=self._PREFS, log=log)
         llm_check.assert_called_once()
         assert not any("focus topic" in str(c.args[0]) for c in log.call_args_list)
+
+
+class TestProofGate:
+    """A2 personal-expertise gate: a finished post lacking a concrete first-person lived detail is
+    regenerated once (never hard-blocked); one that already carries proof ships untouched."""
+
+    def test_post_with_proof_passes_untouched(self):
+        out, gen = _run([_WITH_PROOF], recent=[])
+        assert out == _WITH_PROOF
+        assert gen.call_count == 1
+
+    def test_post_without_proof_triggers_one_retry_with_proof_directive(self):
+        out, gen = _run([_NO_PROOF, _WITH_PROOF], recent=[])
+        assert out == _WITH_PROOF
+        assert gen.call_count == 2
+        retry_directive = gen.call_args_list[1].kwargs["history_directive"]
+        assert "FIRST-PERSON PROOF" in retry_directive
+
+    def test_second_attempt_still_no_proof_keeps_it_and_warns(self):
+        log = MagicMock()
+        out, gen = _run([_NO_PROOF, _NO_PROOF], recent=[], log=log)
+        assert out == _NO_PROOF  # never loops, never blocks
+        assert gen.call_count == 2
+        assert any("lived detail" in str(c.args[0]) for c in log.call_args_list)
+
+    def test_proof_directive_sourced_from_synthesis(self):
+        # get_or_create_profile_synthesis is patched to "voice" in _run; the retry proof directive
+        # sources its concrete detail from that synthesis text.
+        _, gen = _run([_NO_PROOF, _WITH_PROOF], recent=[])
+        retry_directive = gen.call_args_list[1].kwargs["history_directive"]
+        assert "voice" in retry_directive
+
+    def test_proof_regen_disabled_logs_but_keeps_first_draft(self, monkeypatch):
+        monkeypatch.setenv("POST_PROOF_REGEN_ENABLED", "off")
+        log = MagicMock()
+        out, gen = _run([_NO_PROOF], recent=[], log=log)
+        assert out == _NO_PROOF
+        assert gen.call_count == 1  # detector still runs, but regeneration is off
+        assert any("lived detail" in str(c.args[0]) for c in log.call_args_list)
+
+    def test_retry_failure_keeps_first_draft(self):
+        out, gen = _run([_NO_PROOF, RuntimeError("llm down")], recent=[])
+        assert out == _NO_PROOF
+        assert gen.call_count == 2

--- a/tests/unit/utilities/ai/test_content_alignment.py
+++ b/tests/unit/utilities/ai/test_content_alignment.py
@@ -264,3 +264,33 @@ class TestEnsureLeadMagnetCta:
         assert "the resource" in out
         assert "This is a" not in out  # never a garbled 'my This is a checklist...' label
         assert "http" not in out.lower() and "#" not in out
+
+
+class TestPersonalProofDirective:
+    """A2: the proof requirement, sourced from the profile synthesis, appended on a regeneration."""
+
+    def test_directive_always_non_empty(self):
+        assert ca.personal_proof_directive().strip()
+        assert ca.personal_proof_directive(None).strip()
+        assert ca.personal_proof_directive("").strip()
+
+    def test_directive_demands_first_person_specificity(self):
+        text = ca.personal_proof_directive()
+        assert "FIRST-PERSON PROOF" in text
+        assert "first person" in text.lower()
+        assert "generic" in text.lower()
+
+    def test_directive_sources_from_synthesis_when_provided(self):
+        synth = "Founder who scaled a fintech from 0 to 12,000 users; led a 9-person team."
+        text = ca.personal_proof_directive(synth)
+        assert synth in text
+
+    def test_synthesis_is_length_capped(self):
+        synth = "x" * 5000
+        text = ca.personal_proof_directive(synth)
+        assert "x" * 800 in text
+        assert "x" * 900 not in text
+
+    def test_directive_is_not_self_promo(self):
+        # Proof of experience, never a plug — stays inside NO_SELF_PROMO_GUARDRAIL.
+        assert "not self-promotion" in ca.personal_proof_directive()

--- a/tests/unit/utilities/ai/test_content_framework.py
+++ b/tests/unit/utilities/ai/test_content_framework.py
@@ -266,3 +266,73 @@ class TestDirectivesAndCompact:
         # The old one-size-fits-all viral template is gone for good.
         assert "10 relevant hashtags" not in text
         assert "SUCKS" not in text
+
+
+class TestPersonalProofSlot:
+    """A2: every post/newsletter blueprint carries a mandatory first-person proof slot, and comments
+    (grounded in the target post) are exempt."""
+
+    def test_post_directive_carries_proof_slot(self):
+        text = fw.blueprint_directive("post", {"format": "contrarian_take", "hook_style": "bold_claim"})
+        assert fw.PERSONAL_PROOF_SLOT in text
+        assert "MANDATORY PERSONAL-PROOF SLOT" in text
+
+    def test_newsletter_directive_carries_proof_slot(self):
+        text = fw.blueprint_directive("newsletter", {"format": "case_study"})
+        assert fw.PERSONAL_PROOF_SLOT in text
+
+    def test_comment_directive_has_no_proof_slot(self):
+        text = fw.blueprint_directive("comment", {"format": "expander"})
+        assert "MANDATORY PERSONAL-PROOF SLOT" not in text
+
+    def test_proof_slot_is_not_self_promo(self):
+        # The slot asks for lived expertise, never a plug — it must stay inside the guardrail.
+        assert "not self-promotion" in fw.PERSONAL_PROOF_SLOT
+        assert "first person" in fw.PERSONAL_PROOF_SLOT.lower()
+
+
+class TestFirstPersonProofDetector:
+    """The deterministic gate: a draft with a concrete first-person lived detail passes; a generic,
+    could-be-anyone draft (no such detail) is rejected."""
+
+    _WITH_PROOF = ("Three years ago I shipped a feature that tanked our activation rate by 40%.\n\n"
+                   "I learned that shipping fast without a rollback plan is how you lose a quarter.")
+
+    _NAMED_MONTH_PROOF = ("Last March I sat across from a skeptical CFO who cut my budget in half.\n\n"
+                          "We rebuilt the roadmap around what actually moved revenue.")
+
+    _GENERIC = ("Authenticity is what wins on LinkedIn.\n\n"
+                "Great leaders build trust by being consistent, showing up, and adding value to "
+                "their audience every single day. That is how influence compounds over time.")
+
+    _NUMBER_BUT_NO_FIRST_PERSON = ("Studies show that 70% of B2B buyers research on LinkedIn.\n\n"
+                                   "The platform rewards consistency and genuine engagement.")
+
+    _FIRST_PERSON_BUT_ABSTRACT = ("I believe authenticity is everything.\n\n"
+                                  "We should all strive to add value and build real relationships.")
+
+    def test_draft_with_first_person_number_passes(self):
+        assert fw.has_first_person_proof(self._WITH_PROOF)
+        sents = fw.first_person_proof_sentences(self._WITH_PROOF)
+        assert any("40%" in s for s in sents)
+
+    def test_named_month_lived_detail_passes(self):
+        assert fw.has_first_person_proof(self._NAMED_MONTH_PROOF)
+
+    def test_generic_draft_is_rejected(self):
+        assert not fw.has_first_person_proof(self._GENERIC)
+
+    def test_number_without_first_person_is_rejected(self):
+        # A stat elsewhere in the post is not the AUTHOR's own proof.
+        assert not fw.has_first_person_proof(self._NUMBER_BUT_NO_FIRST_PERSON)
+
+    def test_first_person_without_specificity_is_rejected(self):
+        assert not fw.has_first_person_proof(self._FIRST_PERSON_BUT_ABSTRACT)
+
+    def test_empty_or_none_is_rejected(self):
+        assert not fw.has_first_person_proof("")
+        assert not fw.has_first_person_proof(None)
+        assert fw.first_person_proof_sentences(None) == []
+
+    def test_detector_is_deterministic(self):
+        assert fw.has_first_person_proof(self._WITH_PROOF) == fw.has_first_person_proof(self._WITH_PROOF)

--- a/tests/unit/utilities/ai/test_cta_dedup_tighten.py
+++ b/tests/unit/utilities/ai/test_cta_dedup_tighten.py
@@ -1,6 +1,8 @@
 """Unit tests for the tightened lead-magnet CTA flow: strengthened prompt contract, rewrite-pass
 preservation context, and soft-paraphrase dedup at repair time."""
 
+import os
+
 import pytest
 from unittest.mock import MagicMock, patch
 
@@ -120,7 +122,8 @@ class TestCreateTextPostThreadsKeyword:
         def gen(*a, **kw):
             return "generated body"
 
-        with patch(f"{_RCP}.get_engagement_preferences", return_value={}), \
+        with patch.dict(os.environ, {"POST_PROOF_REGEN_ENABLED": "off"}), \
+             patch(f"{_RCP}.get_engagement_preferences", return_value={}), \
              patch(f"{_RCP}.get_or_create_profile_synthesis", return_value="voice"), \
              patch(f"{_RCP}.get_lead_magnet_settings", return_value=_LM), \
              patch(f"{_RCP}.get_recent_post_texts", return_value=[]), \
@@ -142,7 +145,8 @@ class TestCreateTextPostThreadsKeyword:
         def gen(*a, **kw):
             return "generated body"
 
-        with patch(f"{_RCP}.get_engagement_preferences", return_value={}), \
+        with patch.dict(os.environ, {"POST_PROOF_REGEN_ENABLED": "off"}), \
+             patch(f"{_RCP}.get_engagement_preferences", return_value={}), \
              patch(f"{_RCP}.get_or_create_profile_synthesis", return_value="voice"), \
              patch(f"{_RCP}.get_lead_magnet_settings", return_value=_LM), \
              patch(f"{_RCP}.get_recent_post_texts", return_value=[]), \


### PR DESCRIPTION
## What & why

2026 authenticity guidance: AI content must carry **specific, contextual, first-person expertise** to escape the generic-AI demotion. This adds a mandatory *personal-proof slot* to the shared blueprint core and a deterministic gate that rejects/regenerates drafts whose proof slot came back empty or generic (feeding the A1 anti-slop gate).

## Changes

- **`utilities/ai/content_framework.py`**
  - `blueprint_directive` now appends a mandatory **`PERSONAL_PROOF_SLOT`** for `post` and `newsletter` (comments stay grounded in the target post, so they're exempt). Flows into every generation prompt automatically — no per-type helper.
  - New deterministic (no-LLM) gate: `has_first_person_proof` / `first_person_proof_sentences` — a sentence carrying **both** a first-person marker **and** a concrete-specificity signal (number, relative-time anchor, named day/month) counts as lived proof. The same-sentence tie keeps an unrelated stat elsewhere in a generic post from passing.
- **`utilities/ai/content_alignment.py`**
  - New `personal_proof_directive(profile_synthesis)` — sources the proof requirement from the durable profile synthesis (`get_or_create_profile_synthesis`), appended on a regeneration to steer toward a real number / moment / named example / outcome. It asks for lived **expertise**, never a plug, so it stays inside `NO_SELF_PROMO_GUARDRAIL`.
- **`app/run_content_plan.py`**
  - The post review gate (`_review_generated_post`) now also checks the A2 proof slot: too-similar **or** missing-proof → regenerate **once** with a combined avoid/proof directive; still failing → log a structured warning and keep the second attempt. Never loops, never hard-blocks.
  - `POST_PROOF_REGEN_ENABLED` (default **on**, live-env toggle like `POST_SIMILARITY_MAX`) gates the regeneration; the detector still runs and warns when off, so the anti-slop signal is never lost.

## Testing

- `poetry run pytest tests/unit -q` → **2632 passed**.
- New tests: detector accepts profile-sourced specificity and rejects generic / first-person-but-abstract / stat-without-first-person / empty drafts; proof slot present for post/newsletter and absent for comment; `personal_proof_directive` sources + length-caps the synthesis; review-gate proof retry, synthesis-sourced retry directive, warn-and-keep, retry-failure, and env-toggle paths all covered.
- Acceptance criterion met: a draft lacking a concrete first-person detail is rejected (regenerated); one with profile-sourced specificity passes untouched.
- Legacy gate tests that rely on proof-less stub bodies isolate the new gate via `POST_PROOF_REGEN_ENABLED=off`.

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)