### PR TITLE
feat(content): Topic Authority (Topic DNA) governor (closes #384)

### DIFF
--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -29,7 +29,7 @@ from cqc_lem.utilities.ai.content_framework import select_blueprint, history_avo
     find_most_similar, post_similarity_max, has_first_person_proof
 from cqc_lem.utilities.ai.content_alignment import (
     should_include_lead_magnet_cta, lead_magnet_cta_directive, ensure_lead_magnet_cta,
-    content_matches_focus, personal_proof_directive)
+    personal_proof_directive, topic_authority_score, topic_authority_min, profile_topic_dna)
 from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_RATIO, \
     DEFAULT_IMAGE_RATIO, AI_DISCLOSURE_ENABLED, AI_DISCLOSURE_TEXT, \
     STANDARD_VIDEO_MODEL, PREMIUM_VIDEO_MODEL, PREMIUM_TOP_VIDEO_MODEL, \
@@ -591,24 +591,31 @@ def regenerate_post_task(post_id: int, guidance: str = None):
     return regenerate_post(post_id, guidance)
 
 
-def _check_post_alignment(content: str, prefs: dict, user_id: int = None,
-                          post_id: int = None) -> bool:
-    """Lightweight focus-alignment check on a FINAL post: when the user declared focus_topics,
-    verify the post plausibly relates to at least one of them via the cheap deterministic token
-    heuristic (content_matches_focus — NO LLM call). POST_ALIGNMENT_LLM_CHECK_ENABLED (default OFF,
-    the COMMENT_RESEARCH_ENABLED cost-gating pattern) lets an LLM relevance check rescue keyword
-    misses — it only fires when the heuristic already failed, so the default path costs nothing.
-    Misalignment logs a structured warning and never blocks the pipeline."""
+def _check_post_alignment(content: str, prefs: dict, user_id: int = None, post_id: int = None,
+                          user_profile: LinkedInProfile = None,
+                          profile_synthesis: Optional[str] = None) -> bool:
+    """Topic Authority (Topic DNA) governor on a FINAL post (issue #384): when the user declared
+    focus_topics, score how tightly the post sits inside their niche — their focus topics PLUS the
+    profile headline/about vocabulary — via the cheap deterministic overlap heuristic
+    (topic_authority_score — NO LLM call). Below the off-niche threshold, POST_ALIGNMENT_LLM_CHECK_ENABLED
+    (default OFF, the COMMENT_RESEARCH_ENABLED cost-gating pattern) lets an LLM relevance check rescue
+    keyword misses — it only fires when the heuristic already failed, so the default path costs
+    nothing. An off-niche post logs a structured warning (with its score) and never blocks the
+    pipeline."""
     topics = [str(t).strip() for t in ((prefs or {}).get("focus_topics") or []) if str(t).strip()]
     if not topics or not content:
         return True
-    aligned = content_matches_focus(content, topics)
+    headline, about = profile_topic_dna(user_profile, profile_synthesis)
+    threshold = topic_authority_min()
+    score = topic_authority_score(content, topics, headline, about)
+    aligned = score >= threshold
     if not aligned and str(os.getenv("POST_ALIGNMENT_LLM_CHECK_ENABLED", "")).strip().lower() in (
             "1", "true", "yes", "on"):
         from cqc_lem.utilities.ai.ai_helper import post_is_relevant
         aligned = post_is_relevant(content, topics)
     if not aligned:
-        log_warning("Generated post does not appear to relate to any declared focus topic",
+        log_warning(f"Generated post is off-niche vs the user's Topic DNA — does not relate to any "
+                    f"declared focus topic (topic authority {score:.2f} < min {threshold:.2f})",
                     user_id=user_id, post_id=post_id, task_name="create_text_post")
     return aligned
 
@@ -644,7 +651,7 @@ def _review_generated_post(user_id: int, stage: str, post_type: str, user_profil
         if missing_proof:
             log_warning("Generated post lacks a concrete first-person lived detail (A2 proof slot)",
                         user_id=user_id, post_id=post_id, task_name="create_text_post")
-        _check_post_alignment(content, prefs, user_id, post_id)
+        _check_post_alignment(content, prefs, user_id, post_id, user_profile, profile_synthesis)
         return content
 
     reasons = []
@@ -668,7 +675,7 @@ def _review_generated_post(user_id: int, stage: str, post_type: str, user_profil
                     user_id=user_id, post_id=post_id, task_name="create_text_post")
         second = None
     if not second:
-        _check_post_alignment(content, prefs, user_id, post_id)
+        _check_post_alignment(content, prefs, user_id, post_id, user_profile, profile_synthesis)
         return content
 
     second_score, _ = find_most_similar(second, recent_texts)
@@ -680,7 +687,7 @@ def _review_generated_post(user_id: int, stage: str, post_type: str, user_profil
         log_warning("Post still lacks a concrete first-person lived detail after retry "
                     "(A2 proof slot); keeping second attempt",
                     user_id=user_id, post_id=post_id, task_name="create_text_post")
-    _check_post_alignment(second, prefs, user_id, post_id)
+    _check_post_alignment(second, prefs, user_id, post_id, user_profile, profile_synthesis)
     return second
 
 

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -614,9 +614,10 @@ def _check_post_alignment(content: str, prefs: dict, user_id: int = None, post_i
         from cqc_lem.utilities.ai.ai_helper import post_is_relevant
         aligned = post_is_relevant(content, topics)
     if not aligned:
-        log_warning(f"Generated post is off-niche vs the user's Topic DNA — does not relate to any "
-                    f"declared focus topic (topic authority {score:.2f} < min {threshold:.2f})",
-                    user_id=user_id, post_id=post_id, task_name="create_text_post")
+        log_warning("Generated post is off-niche vs the user's Topic DNA — does not relate to any "
+                    "declared focus topic",
+                    user_id=user_id, post_id=post_id, task_name="create_text_post",
+                    topic_authority_score=round(score, 4), topic_authority_min=round(threshold, 4))
     return aligned
 
 

--- a/src/cqc_lem/ui/src/components/TopicAuthorityMeter.tsx
+++ b/src/cqc_lem/ui/src/components/TopicAuthorityMeter.tsx
@@ -1,0 +1,93 @@
+// Topic Authority (Topic DNA) consistency meter — issue #384. 2026 LinkedIn ranking derives a
+// 'Topic DNA' from the author's headline/about + declared focus topics and SUPPRESSES off-niche
+// posts, so this surfaces — right in the post preview — how tightly a draft sits inside that niche.
+// The score MIRRORS the backend deterministic heuristic in content_alignment.topic_authority_score
+// (token-set overlap coefficient) so the meter roughly agrees with the server-side governor. It is
+// advisory: nothing here blocks publishing.
+
+// Kept in sync with content_framework._STOPWORDS — meaningful-token extraction must match the
+// backend or the meter would disagree with the governor that actually flags off-niche posts.
+const STOPWORDS = new Set(
+  ('a an and are as at be been but by can could did do does for from had has have he her here his ' +
+    'how i if in into is it its just me more most my no nor not of on or our out over she so some ' +
+    'than that the their them then there these they this those to too up us was we were what when ' +
+    'where which who why will with would you your').split(' '),
+)
+
+function tokens(text: string): Set<string> {
+  const out = new Set<string>()
+  for (const w of (text || '').toLowerCase().match(/[a-z0-9']+/g) || []) {
+    if (w.length > 1 && !STOPWORDS.has(w)) out.add(w)
+  }
+  return out
+}
+
+// Overlap coefficient |content∩dna| / min(|content|,|dna|) — same measure as the Python scorer.
+export function topicAuthorityScore(
+  content: string,
+  focusTopics: string[],
+  headline?: string,
+  about?: string,
+): number {
+  const dna = new Set<string>()
+  for (const t of focusTopics || []) for (const w of tokens(t)) dna.add(w)
+  for (const w of tokens(headline || '')) dna.add(w)
+  for (const w of tokens(about || '')) dna.add(w)
+  const ctokens = tokens(content)
+  if (dna.size === 0 || ctokens.size === 0) return 1
+  let hits = 0
+  for (const w of ctokens) if (dna.has(w)) hits += 1
+  return hits / Math.min(ctokens.size, dna.size)
+}
+
+// Matches content_alignment.TOPIC_AUTHORITY_MIN_DEFAULT.
+const OFF_NICHE_THRESHOLD = 0.15
+
+interface TopicAuthorityMeterProps {
+  content: string
+  focusTopics: string[]
+  headline?: string
+  about?: string
+}
+
+export default function TopicAuthorityMeter({
+  content,
+  focusTopics,
+  headline,
+  about,
+}: TopicAuthorityMeterProps) {
+  // No declared niche → nothing to score against; hide the meter rather than show a misleading 100%.
+  if (!focusTopics || focusTopics.length === 0) return null
+  if (!content.trim()) return null
+
+  const score = topicAuthorityScore(content, focusTopics, headline, about)
+  const pct = Math.round(score * 100)
+  const offNiche = score < OFF_NICHE_THRESHOLD
+  const strong = score >= 0.35
+
+  const barColor = offNiche ? 'bg-red-500' : strong ? 'bg-green-500' : 'bg-amber-500'
+  const label = offNiche ? 'Off-niche' : strong ? 'On-niche' : 'Loosely on-niche'
+  const labelColor = offNiche ? 'text-red-600' : strong ? 'text-green-600' : 'text-amber-600'
+
+  return (
+    <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
+      <div className="flex items-center justify-between mb-1">
+        <p className="text-xs font-medium text-gray-700">Topic authority consistency</p>
+        <span className={`text-xs font-semibold ${labelColor}`}>
+          {label} · {pct}%
+        </span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-gray-200" aria-hidden="true">
+        <div
+          className={`h-full rounded-full ${barColor} transition-all`}
+          style={{ width: `${Math.max(pct, 3)}%` }}
+        />
+      </div>
+      <p className="mt-1.5 text-[11px] leading-snug text-gray-500">
+        {offNiche
+          ? 'This draft drifts off your focus topics. 2026 LinkedIn suppresses off-niche posts — steer it back toward your Topic DNA.'
+          : 'How tightly this draft sits inside your focus topics and profile — LinkedIn now rewards profile↔content consistency.'}
+      </p>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/components/TopicAuthorityMeter.tsx
+++ b/src/cqc_lem/ui/src/components/TopicAuthorityMeter.tsx
@@ -69,6 +69,10 @@ export default function TopicAuthorityMeter({
   const label = offNiche ? 'Off-niche' : strong ? 'On-niche' : 'Loosely on-niche'
   const labelColor = offNiche ? 'text-red-600' : strong ? 'text-green-600' : 'text-amber-600'
 
+  // Only claim the profile is part of the score when profile inputs are actually wired in.
+  const scoredAgainst =
+    headline?.trim() || about?.trim() ? 'focus topics and profile' : 'focus topics'
+
   return (
     <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-3">
       <div className="flex items-center justify-between mb-1">
@@ -86,7 +90,7 @@ export default function TopicAuthorityMeter({
       <p className="mt-1.5 text-[11px] leading-snug text-gray-500">
         {offNiche
           ? 'This draft drifts off your focus topics. 2026 LinkedIn suppresses off-niche posts — steer it back toward your Topic DNA.'
-          : 'How tightly this draft sits inside your focus topics and profile — LinkedIn now rewards profile↔content consistency.'}
+          : `How tightly this draft sits inside your ${scoredAgainst} — LinkedIn now rewards profile↔content consistency.`}
       </p>
     </div>
   )

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import api from '../../api/client'
 import LinkedInPostPreview from '../../components/LinkedInPostPreview'
+import TopicAuthorityMeter from '../../components/TopicAuthorityMeter'
 import { useAuth } from '../../contexts/AuthContext'
 import { useUserTimezone } from '../../hooks/useUserTimezone'
 
@@ -90,6 +91,19 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
       return r.data.detail.templates as CarouselTemplate[]
     },
   })
+
+  // Focus topics drive the Topic Authority meter below the preview (issue #384). Reuse the same
+  // engagement-preferences query key/shape as the Account settings so it's served from cache.
+  const { data: engPrefs } = useQuery({
+    queryKey: ['engagement-preferences', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/engagement-preferences?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as { focus_topics?: string[] }),
+    enabled: !!sessionToken,
+    staleTime: 60 * 1000,
+  })
+  const focusTopics = engPrefs?.focus_topics ?? []
 
   const templates = templatesData ?? []
   const activeAvatar = avatarData?.active_avatar
@@ -580,6 +594,9 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
               : null
           }
         />
+        {postType === 'TEXT' && (
+          <TopicAuthorityMeter content={content} focusTopics={focusTopics} />
+        )}
         {postType === 'CAROUSEL' && generatedSlideUrls.length > 0 && (
           <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-4">
             <p className="text-sm font-semibold text-gray-700 mb-3">Slide Previews</p>

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -1453,8 +1453,10 @@ def get_industry_trend_analysis_based_on_user_profile(linked_in_profile: LinkedI
     # user's declared focus. When focus_topics exist, anchor the trend subject to the INTERSECTION
     # of the industry and ONE focus topic (rotated deterministically per post via sequence_index so
     # anchoring never collapses onto a single topic); with no intersection the focus topic itself
-    # wins. No focus topics → the original industry-only behavior, unchanged.
-    focus_topic = _select_focus_topic(prefs, sequence_index)
+    # wins. No focus topics → fall back to on-niche anchors derived from the profile (Topic-DNA
+    # steering, issue #384); with no usable profile anchors either, the original industry-only
+    # behavior is unchanged.
+    focus_topic = _select_focus_topic(prefs, sequence_index, profile=linked_in_profile)
     if focus_topic:
         myprint(f"Anchoring trends to focus topic: {focus_topic}")
         subject = (f"{focus_topic} in the {industry} industry: recent trends, developments, and "

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -125,14 +125,19 @@ def _focus_topics(prefs: dict = None) -> list:
     return [str(t).strip() for t in ((prefs or {}).get("focus_topics") or []) if str(t).strip()]
 
 
-def select_focus_topic(prefs: dict = None, sequence_index: Optional[int] = None) -> Optional[str]:
+def select_focus_topic(prefs: dict = None, sequence_index: Optional[int] = None,
+                       profile=None) -> Optional[str]:
     """The SUBJECT anchor for one trend-based post: rotate deterministically across the user's
     declared focus topics (keyed off a stable per-post integer — the post id — the same way the
     lead-magnet CTA rotation works) so anchoring never collapses every post onto one topic. Without
     a sequence key it deterministically falls back to the FIRST topic — reproducible and testable,
-    no per-call randomness. Returns None when the user declared no focus topics — callers keep
-    their current profile-industry-only behavior."""
+    no per-call randomness. When the user declared NO focus topics, fall back to on-niche anchors
+    derived from `profile` (Topic-DNA steering, issue #384) so subjects still stay on-niche; with no
+    usable profile anchors either, returns None and callers keep their profile-industry-only
+    behavior."""
     topics = _focus_topics(prefs)
+    if not topics and profile is not None:
+        topics = profile_niche_anchors(profile)
     if not topics:
         return None
     if sequence_index is None:
@@ -160,6 +165,117 @@ def content_matches_focus(content: str, focus_topics: list, subject: str = None)
         if hits >= max(1, math.ceil(len(needed) / 2)):
             return True
     return not checked_any
+
+
+# ---------------------------------------------------------------------------
+# Topic Authority (Topic DNA) governor — issue #384. 2026 LinkedIn ranking (per 360Brew) derives a
+# 'Topic DNA' from the author's headline / about / posting history and SUPPRESSES off-niche posts, so
+# profile↔content consistency is now a ranking input. This is the deterministic, NO-LLM measure of
+# how tightly a draft sits inside the user's niche vocabulary (declared focus topics PLUS the profile
+# headline/about), plus the profile-derived subject steering that keeps drafts on-niche in the first
+# place. It reuses content_framework.content_tokens so it stays aligned with the similarity engine.
+# ---------------------------------------------------------------------------
+
+# Minimum topic-authority score below which a draft reads as off-niche and gets flagged/steered.
+# 0.15 is deliberately lenient — the governor is meant to catch clearly off-niche drafts (which score
+# ~0.0) without punishing an on-niche post that spends most of its words on connective prose. Override
+# per-deploy with TOPIC_AUTHORITY_MIN (same live-env pattern as POST_SIMILARITY_MAX).
+TOPIC_AUTHORITY_MIN_DEFAULT = 0.15
+
+
+def topic_authority_min() -> float:
+    """The off-niche threshold, read at call time so ops/tests can tune TOPIC_AUTHORITY_MIN without a
+    restart (the POST_SIMILARITY_MAX / research-toggle live-env pattern)."""
+    raw = (os.environ.get("TOPIC_AUTHORITY_MIN") or "").strip()
+    try:
+        return float(raw) if raw else TOPIC_AUTHORITY_MIN_DEFAULT
+    except ValueError:
+        return TOPIC_AUTHORITY_MIN_DEFAULT
+
+
+def topic_dna_tokens(focus_topics: list = None, headline: str = None, about: str = None) -> set:
+    """The user's 'Topic DNA' as a meaningful-token set: the union of their declared focus topics and
+    the vocabulary of their profile headline + about. Stopwords / 1-char noise are dropped by
+    content_tokens so only niche-bearing words remain."""
+    from cqc_lem.utilities.ai.content_framework import content_tokens
+    dna: set = set()
+    for t in (focus_topics or []):
+        dna |= content_tokens(str(t))
+    dna |= content_tokens(headline or "")
+    dna |= content_tokens(about or "")
+    return dna
+
+
+def topic_authority_score(content: str, focus_topics: list = None, headline: str = None,
+                          about: str = None) -> float:
+    """0.0–1.0 consistency of a draft with the user's Topic DNA (focus topics + profile headline/about
+    vocabulary). Uses the same deterministic token-set OVERLAP COEFFICIENT as
+    content_framework.text_similarity — |content∩dna| / min(|content|,|dna|) — so a short, tightly
+    on-niche post scores high and an off-niche post scores ~0. Returns 1.0 (a no-op, never flagged)
+    when there is no Topic DNA to judge against or the content has no scorable tokens, mirroring
+    content_matches_focus's empty-input behavior. NO LLM call."""
+    from cqc_lem.utilities.ai.content_framework import content_tokens
+    dna = topic_dna_tokens(focus_topics, headline, about)
+    ctokens = content_tokens(content or "")
+    if not dna or not ctokens:
+        return 1.0
+    return len(ctokens & dna) / min(len(ctokens), len(dna))
+
+
+def is_on_niche(content: str, focus_topics: list = None, headline: str = None, about: str = None,
+                threshold: Optional[float] = None) -> bool:
+    """True when the draft's topic-authority score clears the off-niche threshold (defaults to
+    topic_authority_min()). The boolean companion to topic_authority_score for gate/flag callers."""
+    t = topic_authority_min() if threshold is None else threshold
+    return topic_authority_score(content, focus_topics, headline, about) >= t
+
+
+def _typed_terms(values, limit: Optional[int] = None) -> list:
+    """Ordered, de-duplicated, whitespace-trimmed niche terms from a profile field. Only genuine
+    strings (or objects exposing a string `.name`, e.g. LinkedInSkill) are kept, so a MagicMock or a
+    stray non-string never leaks in as a bogus term. A non-sequence input (e.g. a MagicMock profile
+    field) is treated as empty rather than raising."""
+    if not isinstance(values, (list, tuple)):
+        return []
+    out, seen = [], set()
+    for v in values:
+        name = v if isinstance(v, str) else getattr(v, "name", None)
+        if not isinstance(name, str) or not name.strip():
+            continue
+        key = name.strip().lower()
+        if key not in seen:
+            seen.add(key)
+            out.append(name.strip())
+        if limit is not None and len(out) >= limit:
+            break
+    return out
+
+
+def profile_topic_dna(profile=None, profile_synthesis: Optional[str] = None) -> tuple:
+    """Assemble the (headline, about) Topic-DNA strings from a LinkedInProfile for the scorer:
+    HEADLINE ≈ job title + industry (the LinkedIn 'headline' analogue LEM stores), ABOUT ≈ the durable
+    voice/credibility synthesis brief plus the profile's listed skills (the 'about'/expertise
+    analogue). Every field is optional and defensively typed, so a partial or mock profile yields
+    ('', '') rather than raising. NO LLM call."""
+    headline_parts = _typed_terms(
+        [getattr(profile, "job_title", None), getattr(profile, "industry", None)])
+    about_parts = []
+    if isinstance(profile_synthesis, str) and profile_synthesis.strip():
+        about_parts.append(profile_synthesis.strip())
+    about_parts.extend(_typed_terms(getattr(profile, "skills", None)))
+    return " ".join(headline_parts), " ".join(about_parts)
+
+
+def profile_niche_anchors(profile=None) -> list:
+    """Fallback Topic-DNA subject anchors derived from a profile when the user declared NO focus
+    topics — this is the on-niche subject STEERING (issue #384). Prefers explicit niche signals (the
+    listed skills) over the raw job title so the anchor is a TOPIC, not a role, and deliberately omits
+    the industry (which trend subjects already carry) to avoid an '{industry} in the {industry}'
+    tautology. Returns [] for a missing/mock profile, so callers fall back to their prior
+    profile-industry-only behavior unchanged."""
+    if profile is None:
+        return []
+    return _typed_terms(getattr(profile, "skills", None), limit=5)
 
 
 def intention_directive(prefs: dict = None) -> str:

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -9,9 +9,12 @@ out of alignment with each other over time."""
 import math
 import os
 import re
-from typing import Optional
+from typing import TYPE_CHECKING, Optional
 
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text
+
+if TYPE_CHECKING:
+    from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 
 # Tight, engagement-optimized targets. Short is the default: LinkedIn rewards comments that
 # earn a REPLY (threads), and a punchy, specific comment out-performs a long essay. Even
@@ -126,7 +129,7 @@ def _focus_topics(prefs: dict = None) -> list:
 
 
 def select_focus_topic(prefs: dict = None, sequence_index: Optional[int] = None,
-                       profile=None) -> Optional[str]:
+                       profile: "Optional[LinkedInProfile]" = None) -> Optional[str]:
     """The SUBJECT anchor for one trend-based post: rotate deterministically across the user's
     declared focus topics (keyed off a stable per-post integer — the post id — the same way the
     lead-magnet CTA rotation works) so anchoring never collapses every post onto one topic. Without
@@ -187,10 +190,17 @@ def topic_authority_min() -> float:
     """The off-niche threshold, read at call time so ops/tests can tune TOPIC_AUTHORITY_MIN without a
     restart (the POST_SIMILARITY_MAX / research-toggle live-env pattern)."""
     raw = (os.environ.get("TOPIC_AUTHORITY_MIN") or "").strip()
+    if not raw:
+        return TOPIC_AUTHORITY_MIN_DEFAULT
     try:
-        return float(raw) if raw else TOPIC_AUTHORITY_MIN_DEFAULT
+        value = float(raw)
     except ValueError:
         return TOPIC_AUTHORITY_MIN_DEFAULT
+    # Reject nan/inf and out-of-range values — score is always in [0, 1], so a non-finite or
+    # out-of-band threshold would make every comparison misbehave (e.g. score >= nan is always False).
+    if not math.isfinite(value) or not 0.0 <= value <= 1.0:
+        return TOPIC_AUTHORITY_MIN_DEFAULT
+    return value
 
 
 def topic_dna_tokens(focus_topics: list = None, headline: str = None, about: str = None) -> set:
@@ -251,7 +261,8 @@ def _typed_terms(values, limit: Optional[int] = None) -> list:
     return out
 
 
-def profile_topic_dna(profile=None, profile_synthesis: Optional[str] = None) -> tuple:
+def profile_topic_dna(profile: "Optional[LinkedInProfile]" = None,
+                      profile_synthesis: Optional[str] = None) -> tuple:
     """Assemble the (headline, about) Topic-DNA strings from a LinkedInProfile for the scorer:
     HEADLINE ≈ job title + industry (the LinkedIn 'headline' analogue LEM stores), ABOUT ≈ the durable
     voice/credibility synthesis brief plus the profile's listed skills (the 'about'/expertise
@@ -266,7 +277,7 @@ def profile_topic_dna(profile=None, profile_synthesis: Optional[str] = None) -> 
     return " ".join(headline_parts), " ".join(about_parts)
 
 
-def profile_niche_anchors(profile=None) -> list:
+def profile_niche_anchors(profile: "Optional[LinkedInProfile]" = None) -> list:
     """Fallback Topic-DNA subject anchors derived from a profile when the user declared NO focus
     topics — this is the on-niche subject STEERING (issue #384). Prefers explicit niche signals (the
     listed skills) over the raw job title so the anchor is a TOPIC, not a role, and deliberately omits

--- a/tests/unit/utilities/ai/test_topic_authority.py
+++ b/tests/unit/utilities/ai/test_topic_authority.py
@@ -1,0 +1,147 @@
+"""Unit tests for the Topic Authority (Topic DNA) governor (issue #384): the deterministic, NO-LLM
+scoring of how tightly a draft sits inside the user's niche (declared focus topics + profile
+headline/about), plus the profile-derived subject steering that keeps drafts on-niche. Off-niche
+drafts must score low; on-niche drafts must clear the threshold."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from cqc_lem.utilities.ai.content_alignment import (
+    topic_authority_score, topic_authority_min, topic_dna_tokens, is_on_niche,
+    profile_topic_dna, profile_niche_anchors, select_focus_topic)
+
+pytestmark = pytest.mark.unit
+
+_FOCUS = ["LLM cost efficiency", "AI reliability and observability"]
+
+_ON_NICHE = ("AI reliability starts with observability. We traced a silent failure spike to one "
+             "retry loop; distributed tracing caught what dashboards missed.")
+_OFF_NICHE = ("I planted tomatoes with my kids last weekend and the garden taught me patience. "
+              "Seedlings grow slowly; compounding beats intensity.")
+
+
+class _Skill:
+    def __init__(self, name):
+        self.name = name
+
+
+class _Profile:
+    """Minimal stand-in for LinkedInProfile — only the fields the Topic-DNA helpers read."""
+    def __init__(self, job_title=None, industry=None, skills=None):
+        self.job_title = job_title
+        self.industry = industry
+        self.skills = skills if skills is not None else []
+
+
+class TestTopicAuthorityScore:
+    def test_on_niche_draft_scores_high(self):
+        assert topic_authority_score(_ON_NICHE, _FOCUS) >= 0.35
+
+    def test_off_niche_draft_scores_low(self):
+        score = topic_authority_score(_OFF_NICHE, _FOCUS)
+        assert score < topic_authority_min()
+
+    def test_on_niche_passes_off_niche_flagged(self):
+        assert is_on_niche(_ON_NICHE, _FOCUS)
+        assert not is_on_niche(_OFF_NICHE, _FOCUS)
+
+    def test_score_bounded_zero_to_one(self):
+        for content in (_ON_NICHE, _OFF_NICHE, "", "ai ai ai reliability observability"):
+            s = topic_authority_score(content, _FOCUS)
+            assert 0.0 <= s <= 1.0
+
+    def test_empty_dna_is_noop_scores_one(self):
+        # No focus topics and no profile headline/about → nothing to judge, never flag.
+        assert topic_authority_score(_OFF_NICHE, []) == 1.0
+        assert topic_authority_score(_OFF_NICHE, None, None, None) == 1.0
+
+    def test_empty_content_is_noop_scores_one(self):
+        assert topic_authority_score("", _FOCUS) == 1.0
+        assert topic_authority_score(None, _FOCUS) == 1.0
+
+    def test_headline_and_about_broaden_the_dna(self):
+        # A draft off the focus topics but squarely in the profile's headline/about niche still scores.
+        draft = "Our supply-chain logistics network cut delivery times across every regional warehouse."
+        assert topic_authority_score(draft, _FOCUS) < topic_authority_min()
+        rescued = topic_authority_score(
+            draft, _FOCUS, headline="Supply-chain logistics leader",
+            about="warehouse network delivery optimization")
+        assert rescued >= topic_authority_min()
+
+    def test_dna_tokens_union_of_all_sources(self):
+        dna = topic_dna_tokens(["ai routing"], headline="observability", about="tracing")
+        assert {"ai", "routing", "observability", "tracing"} <= dna
+
+    def test_stopwords_and_noise_excluded_from_dna(self):
+        dna = topic_dna_tokens(["the and of a"])  # all stopwords → nothing survives
+        assert dna == set()
+
+
+class TestThresholdConfig:
+    def test_default_threshold(self):
+        assert topic_authority_min() == pytest.approx(0.15)
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("TOPIC_AUTHORITY_MIN", "0.9")
+        assert topic_authority_min() == pytest.approx(0.9)
+        # A moderately on-niche draft now falls below a stricter bar.
+        assert not is_on_niche(_ON_NICHE, _FOCUS)
+
+    def test_invalid_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("TOPIC_AUTHORITY_MIN", "not-a-number")
+        assert topic_authority_min() == pytest.approx(0.15)
+
+    def test_explicit_threshold_arg_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("TOPIC_AUTHORITY_MIN", "0.99")
+        assert is_on_niche(_ON_NICHE, _FOCUS, threshold=0.1)
+
+
+class TestProfileTopicDna:
+    def test_headline_and_about_assembled_from_profile(self):
+        p = _Profile(job_title="AI Reliability Engineer", industry="Software",
+                     skills=[_Skill("Observability"), "Distributed Tracing"])
+        headline, about = profile_topic_dna(p, profile_synthesis="I build resilient AI systems.")
+        assert "AI Reliability Engineer" in headline and "Software" in headline
+        assert "resilient AI systems" in about
+        assert "Observability" in about and "Distributed Tracing" in about
+
+    def test_missing_profile_yields_empty(self):
+        assert profile_topic_dna(None, None) == ("", "")
+
+    def test_partial_profile_and_mock_do_not_raise(self):
+        headline, about = profile_topic_dna(_Profile(job_title="Coach"))
+        assert headline == "Coach" and about == ""
+        # A MagicMock's auto-attrs are not strings → they must be filtered out, not stringified.
+        headline, about = profile_topic_dna(MagicMock(), profile_synthesis="voice")
+        assert headline == "" and about == "voice"
+
+
+class TestProfileNicheAnchors:
+    def test_derives_ordered_deduped_skill_anchors(self):
+        p = _Profile(skills=[_Skill("AI Routing"), "Observability", _Skill("AI Routing")])
+        assert profile_niche_anchors(p) == ["AI Routing", "Observability"]
+
+    def test_none_and_mock_profile_yield_no_anchors(self):
+        assert profile_niche_anchors(None) == []
+        assert profile_niche_anchors(MagicMock()) == []
+
+    def test_capped_at_five(self):
+        p = _Profile(skills=[f"skill{i}" for i in range(9)])
+        assert len(profile_niche_anchors(p)) == 5
+
+
+class TestSelectFocusTopicProfileSteering:
+    def test_falls_back_to_profile_anchors_when_no_focus_topics(self):
+        p = _Profile(skills=["AI Routing", "Observability"])
+        assert select_focus_topic({}, 0, profile=p) == "AI Routing"
+        assert select_focus_topic({}, 1, profile=p) == "Observability"
+        assert select_focus_topic({}, None, profile=p) == "AI Routing"
+
+    def test_declared_focus_topics_win_over_profile(self):
+        p = _Profile(skills=["Gardening"])
+        assert select_focus_topic({"focus_topics": _FOCUS}, 0, profile=p) == _FOCUS[0]
+
+    def test_no_anchors_and_no_focus_returns_none(self):
+        # Mock profile → no usable anchors → None, preserving the industry-only behavior.
+        assert select_focus_topic({}, 1, profile=MagicMock()) is None
+        assert select_focus_topic({}, 1, profile=None) is None

--- a/tests/unit/utilities/ai/test_topic_authority.py
+++ b/tests/unit/utilities/ai/test_topic_authority.py
@@ -91,6 +91,16 @@ class TestThresholdConfig:
         monkeypatch.setenv("TOPIC_AUTHORITY_MIN", "not-a-number")
         assert topic_authority_min() == pytest.approx(0.15)
 
+    @pytest.mark.parametrize("bad", ["nan", "inf", "-inf", "-0.5", "1.5", "2.0"])
+    def test_non_finite_or_out_of_range_falls_back_to_default(self, monkeypatch, bad):
+        monkeypatch.setenv("TOPIC_AUTHORITY_MIN", bad)
+        assert topic_authority_min() == pytest.approx(0.15)
+
+    @pytest.mark.parametrize("good", ["0", "0.0", "1", "1.0", "0.5"])
+    def test_in_range_values_are_honored(self, monkeypatch, good):
+        monkeypatch.setenv("TOPIC_AUTHORITY_MIN", good)
+        assert topic_authority_min() == pytest.approx(float(good))
+
     def test_explicit_threshold_arg_overrides_env(self, monkeypatch):
         monkeypatch.setenv("TOPIC_AUTHORITY_MIN", "0.99")
         assert is_on_niche(_ON_NICHE, _FOCUS, threshold=0.1)


### PR DESCRIPTION
## What & why
2026 LinkedIn ranking (per 360Brew) derives a **Topic DNA** from the author's headline/about/history and **suppresses off-niche posts** — profile↔content consistency is now a ranking input. This adds a deterministic, NO-LLM governor that scores each draft against the user's niche and steers/flags off-niche content.

## Changes
- **`utilities/ai/content_alignment.py`** — the Topic Authority core:
  - `topic_authority_score(content, focus_topics, headline, about)` → 0.0–1.0 token-set **overlap coefficient** (same measure as `content_framework.text_similarity`) of the draft against the user's Topic DNA (declared focus topics **+ profile headline/about** vocabulary). No-op `1.0` when there's no DNA/content to judge.
  - `topic_authority_min()` (env `TOPIC_AUTHORITY_MIN`, default `0.15`, live-read like `POST_SIMILARITY_MAX`), `is_on_niche()`, `topic_dna_tokens()`, `profile_topic_dna()` (assembles headline/about from a `LinkedInProfile`).
  - **Steering:** `select_focus_topic()` now falls back to profile-derived niche anchors (skills) when the user declared no focus topics, so trend subjects stay on-niche. Wired into `get_industry_trend_analysis_based_on_user_profile` (`ai_helper.py`). Backward-compatible — no anchors ⇒ prior industry-only behavior unchanged.
- **`app/run_content_plan.py`** — the post review-gate alignment check now scores with the governor (profile headline/about folded into the DNA) and logs a structured warning **with the score** when off-niche. Never blocks the pipeline; the optional `POST_ALIGNMENT_LLM_CHECK_ENABLED` rescue path is preserved.
- **`ui/.../TopicAuthorityMeter.tsx` + `ComposePost.tsx`** — surfaces a **"topic authority consistency"** meter in the compose preview (On-niche / Loosely / Off-niche + %), mirroring the backend heuristic. Hidden when no focus topics are declared.

## Acceptance
- Off-niche draft scores low and is flagged/steered; on-niche draft passes. ✓ (`tests/unit/utilities/ai/test_topic_authority.py`)
- Unit test on the scoring function. ✓

## Testing
- `poetry run pytest tests/unit/utilities/ai tests/unit/app` → **967 passed** (incl. new `test_topic_authority.py` and unchanged review-gate/focus-anchoring suites).
- UI `tsc -b` compiles clean.

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)