### PR TITLE
feat(content): A1/A3 authenticity rubric + golden set (closes #405)

### DIFF
--- a/docs/AUTHENTICITY_RUBRIC.md
+++ b/docs/AUTHENTICITY_RUBRIC.md
@@ -1,0 +1,110 @@
+# Authenticity Rubric — A1 Anti-Slop Gate (360Brew Defense)
+
+> **Spike deliverable for issue #405 (R2 — 360Brew authenticity-rubric deep-dive).**
+> This document is the calibrated rubric that feeds the **A1 authenticity-scoring gate** (issue #382)
+> and the **A3 Topic-DNA governor** (issue #384) acceptance tests. The machine-readable form of
+> everything here lives in `src/cqc_lem/utilities/ai/authenticity_rubric.py` — A1 imports the
+> weights, threshold, and judge-criteria from that module, and the golden set drives the tests.
+
+## Why this exists
+
+LinkedIn's **2026 Authenticity Update** (paired with the **360Brew** ranking model) actively demotes
+generic AI content. Public reporting and Richard van der Blom's *Algorithm Insights* both describe:
+
+- Early classifier tests flagged obviously-generic posts **~94%** of the time.
+- Organic reach for low-authenticity accounts is down **~50% YoY**.
+- 360Brew derives a per-author **"Topic DNA"** from the headline/about/history and **suppresses
+  off-niche posts** — profile↔content consistency is now a ranking input (this is what A3 governs).
+
+LEM is AI-content-heavy with no authenticity safeguard, so a generic-slop draft is the single biggest
+reach risk. **But over-correcting is just as damaging:** demoting good, AI-*assisted*-but-personal
+content would gut the product's value. The whole calibration challenge is to flag *generic* while
+never demoting *personal-with-AI-help*.
+
+## Calibration principle
+
+> **The enemy is _generic_, not _AI-assisted_.**
+> Polish, correct grammar, and the use of AI are **NEUTRAL** — they must never lower the score on
+> their own. Reach is earned by lived first-person proof, checkable specificity, a consistent human
+> voice, on-niche topic authority, and a non-obvious point of view. The rubric rewards those and
+> penalizes only their **absence** (plus the AI-slop tells below).
+
+This is why the two heaviest dimensions are *first-person proof* and *specificity*: they are the
+signals a language model cannot fabricate for content it didn't live, and they are the same signals
+the existing deterministic **A2 personal-proof detector** (`content_framework.py`) already steers
+writers toward.
+
+## Scoring dimensions
+
+Each dimension is scored **0–100** by the A1 LLM-judge (`lem-medium`). The composite is the weighted
+average (`weighted_score` in the module). Weights sum to 1.0.
+
+| Dimension | Weight | Scores HIGH when | Scores LOW when |
+|---|---|---|---|
+| **First-person lived proof** | 0.28 | ≥1 concrete detail only this author could write — a real number, a moment in time, a named person/tool/company, an outcome from their own work — owned in first person. | Only abstract could-be-anyone claims; advice with no evidence the author has done it. |
+| **Checkable specificity** | 0.22 | Claims grounded in figures, dates, before/after deltas, concrete scenarios. | Vague superlatives / buzzwords stand in for substance. |
+| **Consistent human voice** | 0.18 | Author's established tone; natural rhythm; a real point of view. | Flat corporate-neutral register; no discernible person. |
+| **On-niche topic authority (A3)** | 0.17 | Subject sits inside `focus_topics` / profile headline & about — 360Brew "Topic DNA" consistency. | Off-niche drift into a topic the profile gives no reason to trust them on. |
+| **Non-obvious insight** | 0.15 | A specific, non-obvious, or mildly contrarian point. | Restates consensus; obvious-tips listicle; hollow "Thoughts?". |
+
+### AI-slop tells (weigh DOWN)
+
+Any single tell is weak evidence; a **pileup of them alongside no first-person proof** is the signal
+the gate should act on. They mostly hurt *specificity*, *voice consistency*, and *originality*:
+
+- "In today's fast-paced / ever-evolving world…", "In the age of AI…"
+- "It's not just X, it's Y" / "This isn't about X. It's about Y." cadence on repeat.
+- Rule-of-three everything ("faster, smarter, better").
+- Emoji-bulleted listicle, one abstract tip per bullet, no lived example.
+- Hollow engagement-bait CTA ("Thoughts?", "Agree?", "Drop a 🔥 if you relate").
+- Grand hollow abstractions ("unlock/leverage/harness synergies", "game-changer", "paradigm shift").
+- Definitional filler that teaches nothing ("Leadership is about people.").
+
+## Threshold & gate action
+
+| Band | Composite | Gate action |
+|---|---|---|
+| **Demote** | `< 60` | Flip `APPROVED → PENDING` (mirrors the deterministic similarity gate at `run_content_plan.py`). |
+| **Caution** | `60 – 71` | Keep, but prime a personal-proof nudge on any regeneration. |
+| **Pass** | `≥ 72` | Ship as-is. |
+
+- `AUTHENTICITY_GATE_THRESHOLD = 60`
+- `AUTHENTICITY_CAUTION_CEILING = 72`
+
+The threshold was calibrated against the golden set so that **every** generic draft lands below 60
+and **every** authentic / AI-assisted-personal draft lands at or above 60 — i.e. the gate flags
+generic content with **no false demotion** of good AI-assisted posts (the A1 acceptance criterion).
+
+## Golden set
+
+The labeled reference drafts live in `GOLDEN_SET` in the module. Labels and the binary gate
+expectation (`expected_action`):
+
+| Label | Meaning | `expected_action` |
+|---|---|---|
+| `generic` | Known generic AI slop. | `demote` |
+| `authentic` | Human, specific, first-person. | `keep` |
+| `ai_assisted_personal` | Polished / AI-assisted **but** carries real lived proof and stays on-niche — the false-demotion guard. | `keep` |
+
+Each entry also carries `expected_dimension_scores` — the calibration target the A1 judge is tuned
+against. Acceptance tests assert the resulting **gate action** (via `gate_draft` / `classify_score`),
+not the exact per-dimension numbers, so a re-tuned judge stays green as long as it lands in the right
+band.
+
+### How A1 and A3 consume this
+
+- **A1 (#382)** imports `AUTHENTICITY_JUDGE_CRITERIA`, `AUTHENTICITY_DIMENSIONS`, and
+  `AUTHENTICITY_GATE_THRESHOLD` into its `lem-medium` judge, calls `weighted_score` on the judge's
+  per-dimension output, and gates on `gate_draft`. Its acceptance test runs the `GOLDEN_SET`.
+- **A3 (#384)** already governs the `topic_authority` dimension; its tests reuse
+  `golden_by_label("generic")` / `golden_by_label("authentic")` to confirm off-niche drafts score
+  low and on-niche pass.
+
+## Sources
+
+- LinkedIn 2026 **Authenticity Update** + **360Brew** ranking model (generic-AI demotion; per-author
+  "Topic DNA" / off-niche suppression).
+- Richard van der Blom — **LinkedIn Algorithm Insights 2026** (authenticity & topic-consistency as
+  ranking inputs; reach decline for low-authenticity accounts).
+- LEM 2026 Growth Roadmap, Milestone 7 (Authenticity & Anti-Slop Guardrails): A1 #382, A2 #383,
+  A3 #384, A4 #385, R2 #405.

--- a/src/cqc_lem/utilities/ai/authenticity_rubric.py
+++ b/src/cqc_lem/utilities/ai/authenticity_rubric.py
@@ -1,0 +1,296 @@
+"""Calibrated authenticity rubric for the A1 authenticity-scoring gate (issue #382) and the A3
+Topic-DNA governor (issue #384).
+
+Deliverable of the R2 360Brew rubric spike (issue #405). This module is the SINGLE source of truth
+for HOW authentic-vs-generic-AI content is scored, WHERE the gate threshold sits, and WHICH labeled
+drafts the A1/A3 acceptance tests run against. It carries NO LLM calls and NO I/O — A1 imports the
+weights, threshold, and judge-criteria text into its `lem-medium` LLM-judge prompt, and the golden
+set drives the acceptance tests that prove the gate flags generic drafts while NOT demoting good
+AI-assisted-but-personal ones.
+
+The calibration principle (from the 2026 LinkedIn Authenticity Update + Richard van der Blom's
+Algorithm Insights): the enemy is *generic* content that could have been written by anyone, NOT
+content that was written with AI help. Polish, correct grammar, and AI assistance are NEUTRAL. What
+earns reach is lived first-person proof, checkable specificity, a consistent human voice, on-niche
+topic authority, and a non-obvious point of view. The rubric therefore rewards those signals and
+only penalizes their absence — so an AI-assisted post that carries real experience passes.
+
+See docs/AUTHENTICITY_RUBRIC.md for the human-readable rubric, sources, and worked examples.
+"""
+
+# ---------------------------------------------------------------------------
+# Scoring dimensions. Each dimension is scored 0-100 by the A1 LLM-judge; the composite is their
+# weighted average. Weights sum to 1.0. The two heaviest dimensions (first_person_proof,
+# specificity) are the ones that most cleanly separate generic AI from lived expertise, and are the
+# same signals the deterministic A2 proof-slot detector already steers writers toward.
+# ---------------------------------------------------------------------------
+
+AUTHENTICITY_DIMENSIONS: dict = {
+    "first_person_proof": {
+        "weight": 0.28,
+        "label": "First-person lived proof",
+        "scores_high_when": (
+            "Carries at least one concrete detail only THIS author could write — a real number, a "
+            "moment in time, a named person/tool/company, or a specific outcome from their own work "
+            "— owned in the first person (\"I\"/\"we\")."
+        ),
+        "scores_low_when": (
+            "Only abstract, could-be-anyone claims; advice stated in the second/third person with no "
+            "evidence the author has actually done it."
+        ),
+    },
+    "specificity": {
+        "weight": 0.22,
+        "label": "Checkable specificity",
+        "scores_high_when": (
+            "Claims are grounded in checkable particulars — figures, dates, before/after deltas, "
+            "concrete scenarios — instead of platitudes."
+        ),
+        "scores_low_when": (
+            "Vague superlatives and buzzwords (\"game-changing\", \"leverage synergies\", \"in "
+            "today's fast-paced world\") stand in for substance."
+        ),
+    },
+    "voice_consistency": {
+        "weight": 0.18,
+        "label": "Consistent human voice",
+        "scores_high_when": (
+            "Reads in the author's established tone; natural rhythm; a real point of view. Matches "
+            "the voice/expertise reference for this author."
+        ),
+        "scores_low_when": (
+            "Flat corporate-neutral register; tone unlike the author's other writing; no discernible "
+            "person behind the words."
+        ),
+    },
+    "topic_authority": {
+        "weight": 0.17,
+        "label": "On-niche topic authority (A3)",
+        "scores_high_when": (
+            "The subject sits inside the author's focus_topics / profile headline & about — 360Brew "
+            "'Topic DNA' consistency. This is the dimension the A3 governor consumes."
+        ),
+        "scores_low_when": (
+            "Off-niche drift into a topic the author has no established authority in; a subject the "
+            "profile gives no reason to trust them on."
+        ),
+    },
+    "originality": {
+        "weight": 0.15,
+        "label": "Non-obvious insight",
+        "scores_high_when": (
+            "Offers a specific, non-obvious, or mildly contrarian point — teaches something the "
+            "reader could not have guessed from the headline."
+        ),
+        "scores_low_when": (
+            "Restates consensus everyone already agrees with; a listicle of obvious tips; ends on a "
+            "hollow \"Thoughts?\" with nothing earned."
+        ),
+    },
+}
+
+# Common AI-slop tells the A1 judge should weigh DOWN (they mostly hurt `specificity`, `voice_
+# consistency`, and `originality`). Listed so the gate flags the *pattern*, not merely the phrase —
+# any single tell is weak evidence; a pileup of them alongside no first-person proof is the signal.
+AI_SLOP_TELLS: tuple = (
+    "opening with \"In today's fast-paced/ever-evolving world\" or \"In the age of AI\"",
+    "\"It's not just X, it's Y\" / \"This isn't about X. It's about Y.\" cadence on repeat",
+    "rule-of-three everything (\"faster, smarter, better\")",
+    "emoji-bulleted listicle with one abstract tip per bullet and no lived example",
+    "hollow engagement-bait CTA (\"Thoughts?\", \"Agree?\", \"Drop a 🔥 if you relate\")",
+    "grand hollow abstractions (\"unlock/leverage/harness synergies\", \"game-changer\", "
+    "\"paradigm shift\") standing in for a concrete claim",
+    "definitional filler that teaches nothing (\"Leadership is about people.\")",
+)
+
+# ---------------------------------------------------------------------------
+# Gate threshold. Composite score below this flips the draft APPROVED -> PENDING (mirrors the
+# deterministic similarity gate the A1 issue points at). Calibrated on the golden set below:
+# every `authentic` and `ai_assisted_personal` draft sits at/above it; every `generic` draft sits
+# below it — so the gate flags generic content with NO false demotion of good AI-assisted posts.
+# ---------------------------------------------------------------------------
+
+AUTHENTICITY_GATE_THRESHOLD: int = 60
+
+# A soft caution band: at/above the gate but not clearly strong. A1 need not demote these, but they
+# are the drafts most worth a personal-proof nudge on regeneration.
+AUTHENTICITY_CAUTION_CEILING: int = 72
+
+# Text block A1 drops verbatim into the lem-medium judge prompt. Kept here (not in A1) so the
+# scoring criteria and the golden set that validates them can never drift apart.
+AUTHENTICITY_JUDGE_CRITERIA: str = (
+    "You are scoring a LinkedIn draft for AUTHENTICITY under LinkedIn's 2026 Authenticity Update, "
+    "which demotes generic AI content. Score generic-AI RISK, not writing quality: AI assistance, "
+    "polish, and correct grammar are NEUTRAL and must never lower the score on their own. Reward "
+    "lived first-person proof, checkable specificity, a consistent human voice, on-niche topic "
+    "authority, and a non-obvious point of view. Penalize only their ABSENCE and the AI-slop tells. "
+    "Return an integer 0-100 for each dimension and a short reason per dimension; higher = more "
+    "authentic / lower generic-AI risk."
+)
+
+
+def weighted_score(dimension_scores: dict) -> float:
+    """Composite 0-100 authenticity score from per-dimension 0-100 scores.
+
+    Missing dimensions are treated as 0 (a judge that could not evidence a dimension gets no credit
+    for it). Unknown keys are ignored so the caller can pass extra judge metadata safely.
+    """
+    total = 0.0
+    for name, spec in AUTHENTICITY_DIMENSIONS.items():
+        raw = dimension_scores.get(name, 0)
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            value = 0.0
+        value = max(0.0, min(100.0, value))
+        total += value * spec["weight"]
+    return round(total, 2)
+
+
+def classify_score(score: float) -> str:
+    """Map a composite score to a gate action: 'demote' (< threshold), 'caution' (threshold..
+    ceiling), or 'pass' (>= ceiling)."""
+    if score < AUTHENTICITY_GATE_THRESHOLD:
+        return "demote"
+    if score < AUTHENTICITY_CAUTION_CEILING:
+        return "caution"
+    return "pass"
+
+
+def gate_draft(dimension_scores: dict) -> bool:
+    """True when the draft should be demoted (APPROVED -> PENDING) — composite below the gate
+    threshold. The A1 gate calls this so the threshold has exactly one definition."""
+    return weighted_score(dimension_scores) < AUTHENTICITY_GATE_THRESHOLD
+
+
+# ---------------------------------------------------------------------------
+# Golden set. Labeled reference drafts the A1/A3 acceptance tests run against. Labels:
+#   - "generic"               : known generic AI slop — the gate MUST demote (expected 'demote').
+#   - "authentic"             : human, specific, first-person — MUST pass (expected 'pass').
+#   - "ai_assisted_personal"  : polished/AI-assisted BUT carries real lived proof & stays on-niche —
+#                               the false-demotion guard; MUST NOT be demoted (expected 'pass').
+# `expected_dimension_scores` are the calibration target the A1 judge is tuned against (illustrative,
+# not asserted exactly — tests assert the resulting gate ACTION via classify_score). Kept realistic
+# so weighted_score(expected) lands in the labeled band.
+# ---------------------------------------------------------------------------
+
+GOLDEN_SET: tuple = (
+    {
+        "id": "generic_thought_leadership",
+        "label": "generic",
+        "expected_action": "demote",
+        "text": (
+            "In today's fast-paced world, leadership is more important than ever. Great leaders "
+            "inspire their teams to be faster, smarter, and better. It's not just about managing — "
+            "it's about empowering people to unlock their full potential. Success isn't a "
+            "destination, it's a journey. Agree? Thoughts?"
+        ),
+        "expected_dimension_scores": {
+            "first_person_proof": 5,
+            "specificity": 10,
+            "voice_consistency": 30,
+            "topic_authority": 45,
+            "originality": 10,
+        },
+    },
+    {
+        "id": "generic_ai_tips_listicle",
+        "label": "generic",
+        "expected_action": "demote",
+        "text": (
+            "5 ways AI will change your business:\n"
+            "🚀 Boost productivity\n"
+            "🤖 Automate everything\n"
+            "📈 Drive growth\n"
+            "💡 Unlock innovation\n"
+            "🔥 Stay ahead of the curve\n"
+            "The future is here. Are you ready? Drop a 🔥 if you agree!"
+        ),
+        "expected_dimension_scores": {
+            "first_person_proof": 0,
+            "specificity": 15,
+            "voice_consistency": 25,
+            "topic_authority": 55,
+            "originality": 8,
+        },
+    },
+    {
+        "id": "authentic_personal_story",
+        "label": "authentic",
+        "expected_action": "keep",
+        "text": (
+            "Three years ago I shipped a pricing change on a Friday afternoon and took down checkout "
+            "for 40 minutes. We lost about $12k in orders and I spent the weekend writing the "
+            "post-mortem. The fix wasn't technical — we added a rule that no pricing change goes out "
+            "after noon on a Friday. Boring, unglamorous, and we haven't had a weekend outage since. "
+            "The best reliability work rarely looks impressive."
+        ),
+        "expected_dimension_scores": {
+            "first_person_proof": 92,
+            "specificity": 88,
+            "voice_consistency": 82,
+            "topic_authority": 78,
+            "originality": 75,
+        },
+    },
+    {
+        "id": "ai_assisted_personal_polished",
+        "label": "ai_assisted_personal",
+        "expected_action": "keep",
+        "text": (
+            "I used to think onboarding was a checklist. Then I watched our Q1 cohort: the 6 new "
+            "hires who paired with someone on day one shipped their first PR in 4 days; the 5 who "
+            "didn't took 11. Same docs, same tooling. The variable was a human who answered the "
+            "dumb questions in real time. We now assign a day-one buddy to everyone — it's the "
+            "cheapest retention lever we've found."
+        ),
+        "expected_dimension_scores": {
+            "first_person_proof": 85,
+            "specificity": 90,
+            "voice_consistency": 76,
+            "topic_authority": 80,
+            "originality": 70,
+        },
+    },
+    {
+        "id": "borderline_thin_but_personal",
+        "label": "authentic",
+        "expected_action": "keep",
+        "text": (
+            "Spent last Tuesday rewriting our incident template. Cut it from 9 sections to 3: what "
+            "broke, who it hit, what we changed. Adoption went from 'nobody fills it out' to every "
+            "incident this week. Shorter forms get filled."
+        ),
+        "expected_dimension_scores": {
+            "first_person_proof": 78,
+            "specificity": 72,
+            "voice_consistency": 68,
+            "topic_authority": 66,
+            "originality": 58,
+        },
+    },
+    {
+        "id": "generic_offniche_drift",
+        "label": "generic",
+        "expected_action": "demote",
+        "text": (
+            "Everyone talks about crypto, but let's talk about mindset. Winners never quit and "
+            "quitters never win. Hustle harder, dream bigger, and manifest your best life. The only "
+            "limit is you. Who's with me?"
+        ),
+        "expected_dimension_scores": {
+            "first_person_proof": 8,
+            "specificity": 6,
+            "voice_consistency": 22,
+            "topic_authority": 12,
+            "originality": 6,
+        },
+    },
+)
+
+GOLDEN_LABELS: frozenset = frozenset({"generic", "authentic", "ai_assisted_personal"})
+
+
+def golden_by_label(label: str) -> tuple:
+    """All golden-set drafts carrying `label`."""
+    return tuple(d for d in GOLDEN_SET if d["label"] == label)

--- a/src/cqc_lem/utilities/ai/authenticity_rubric.py
+++ b/src/cqc_lem/utilities/ai/authenticity_rubric.py
@@ -129,12 +129,9 @@ AUTHENTICITY_JUDGE_CRITERIA: str = (
 )
 
 
-def weighted_score(dimension_scores: dict) -> float:
-    """Composite 0-100 authenticity score from per-dimension 0-100 scores.
-
-    Missing dimensions are treated as 0 (a judge that could not evidence a dimension gets no credit
-    for it). Unknown keys are ignored so the caller can pass extra judge metadata safely.
-    """
+def _weighted_score_raw(dimension_scores: dict) -> float:
+    """Unrounded composite score. Gate logic uses this so rounding can't flip a borderline draft
+    across the threshold (e.g. 59.996 -> 60.0)."""
     total = 0.0
     for name, spec in AUTHENTICITY_DIMENSIONS.items():
         raw = dimension_scores.get(name, 0)
@@ -144,7 +141,17 @@ def weighted_score(dimension_scores: dict) -> float:
             value = 0.0
         value = max(0.0, min(100.0, value))
         total += value * spec["weight"]
-    return round(total, 2)
+    return total
+
+
+def weighted_score(dimension_scores: dict) -> float:
+    """Composite 0-100 authenticity score from per-dimension 0-100 scores, rounded to 2 decimals
+    for display. Gate logic uses the raw (unrounded) value via ``gate_draft``.
+
+    Missing dimensions are treated as 0 (a judge that could not evidence a dimension gets no credit
+    for it). Unknown keys are ignored so the caller can pass extra judge metadata safely.
+    """
+    return round(_weighted_score_raw(dimension_scores), 2)
 
 
 def classify_score(score: float) -> str:
@@ -160,7 +167,7 @@ def classify_score(score: float) -> str:
 def gate_draft(dimension_scores: dict) -> bool:
     """True when the draft should be demoted (APPROVED -> PENDING) — composite below the gate
     threshold. The A1 gate calls this so the threshold has exactly one definition."""
-    return weighted_score(dimension_scores) < AUTHENTICITY_GATE_THRESHOLD
+    return _weighted_score_raw(dimension_scores) < AUTHENTICITY_GATE_THRESHOLD
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utilities/ai/test_authenticity_rubric.py
+++ b/tests/unit/utilities/ai/test_authenticity_rubric.py
@@ -1,0 +1,153 @@
+"""Unit tests for the A1/A3 authenticity rubric (issue #405 spike deliverable).
+
+These tests ARE the calibration guard: they prove the gate flags every generic golden draft and
+demotes NONE of the authentic / AI-assisted-personal ones, and they lock the rubric's structural
+invariants (weights sum to 1, threshold ordering, golden-set integrity) so a future edit to the
+rubric can't silently break the A1/A3 acceptance contract.
+"""
+
+import pytest
+
+from cqc_lem.utilities.ai.authenticity_rubric import (
+    AI_SLOP_TELLS,
+    AUTHENTICITY_CAUTION_CEILING,
+    AUTHENTICITY_DIMENSIONS,
+    AUTHENTICITY_GATE_THRESHOLD,
+    AUTHENTICITY_JUDGE_CRITERIA,
+    GOLDEN_LABELS,
+    GOLDEN_SET,
+    classify_score,
+    gate_draft,
+    golden_by_label,
+    weighted_score,
+)
+
+
+def test_dimension_weights_sum_to_one():
+    total = sum(d["weight"] for d in AUTHENTICITY_DIMENSIONS.values())
+    assert total == pytest.approx(1.0)
+
+
+def test_dimensions_have_required_fields():
+    for name, spec in AUTHENTICITY_DIMENSIONS.items():
+        assert 0.0 < spec["weight"] < 1.0, name
+        assert spec["label"]
+        assert spec["scores_high_when"]
+        assert spec["scores_low_when"]
+
+
+def test_first_person_proof_and_specificity_are_heaviest():
+    # Calibration principle: the two signals AI can't fake for unlived content dominate.
+    ranked = sorted(AUTHENTICITY_DIMENSIONS.items(), key=lambda kv: kv[1]["weight"], reverse=True)
+    assert {ranked[0][0], ranked[1][0]} == {"first_person_proof", "specificity"}
+
+
+def test_threshold_ordering():
+    assert 0 < AUTHENTICITY_GATE_THRESHOLD < AUTHENTICITY_CAUTION_CEILING < 100
+
+
+def test_judge_criteria_states_ai_is_neutral():
+    text = AUTHENTICITY_JUDGE_CRITERIA.lower()
+    assert "neutral" in text
+    assert "0-100" in AUTHENTICITY_JUDGE_CRITERIA
+
+
+def test_ai_slop_tells_present():
+    assert len(AI_SLOP_TELLS) >= 5
+    assert all(isinstance(t, str) and t for t in AI_SLOP_TELLS)
+
+
+class TestWeightedScore:
+    def test_all_max_is_100(self):
+        assert weighted_score({k: 100 for k in AUTHENTICITY_DIMENSIONS}) == pytest.approx(100.0)
+
+    def test_all_zero_is_0(self):
+        assert weighted_score({k: 0 for k in AUTHENTICITY_DIMENSIONS}) == 0.0
+
+    def test_empty_is_0(self):
+        assert weighted_score({}) == 0.0
+
+    def test_missing_dimension_gets_no_credit(self):
+        full = weighted_score({k: 80 for k in AUTHENTICITY_DIMENSIONS})
+        one_missing = weighted_score(
+            {k: 80 for k in AUTHENTICITY_DIMENSIONS if k != "first_person_proof"}
+        )
+        assert one_missing < full
+
+    def test_unknown_keys_ignored(self):
+        base = weighted_score({k: 50 for k in AUTHENTICITY_DIMENSIONS})
+        with_junk = weighted_score({**{k: 50 for k in AUTHENTICITY_DIMENSIONS}, "reason": "n/a"})
+        assert base == with_junk
+
+    def test_out_of_range_is_clamped(self):
+        assert weighted_score({k: 999 for k in AUTHENTICITY_DIMENSIONS}) == pytest.approx(100.0)
+        assert weighted_score({k: -50 for k in AUTHENTICITY_DIMENSIONS}) == 0.0
+
+    def test_non_numeric_treated_as_zero(self):
+        assert weighted_score({k: "oops" for k in AUTHENTICITY_DIMENSIONS}) == 0.0
+
+
+class TestClassifyAndGate:
+    def test_below_threshold_demotes(self):
+        assert classify_score(AUTHENTICITY_GATE_THRESHOLD - 1) == "demote"
+
+    def test_caution_band(self):
+        assert classify_score(AUTHENTICITY_GATE_THRESHOLD) == "caution"
+        assert classify_score(AUTHENTICITY_CAUTION_CEILING - 1) == "caution"
+
+    def test_pass_band(self):
+        assert classify_score(AUTHENTICITY_CAUTION_CEILING) == "pass"
+        assert classify_score(100) == "pass"
+
+    def test_gate_draft_matches_threshold(self):
+        assert gate_draft({k: 0 for k in AUTHENTICITY_DIMENSIONS}) is True
+        assert gate_draft({k: 100 for k in AUTHENTICITY_DIMENSIONS}) is False
+
+
+class TestGoldenSet:
+    def test_ids_unique(self):
+        ids = [d["id"] for d in GOLDEN_SET]
+        assert len(ids) == len(set(ids))
+
+    def test_labels_valid(self):
+        for d in GOLDEN_SET:
+            assert d["label"] in GOLDEN_LABELS
+
+    def test_every_label_represented(self):
+        present = {d["label"] for d in GOLDEN_SET}
+        assert present == GOLDEN_LABELS
+
+    def test_expected_action_matches_label(self):
+        for d in GOLDEN_SET:
+            expected = "demote" if d["label"] == "generic" else "keep"
+            assert d["expected_action"] == expected, d["id"]
+
+    def test_entries_are_well_formed(self):
+        for d in GOLDEN_SET:
+            assert d["text"].strip()
+            assert set(d["expected_dimension_scores"]) == set(AUTHENTICITY_DIMENSIONS)
+            assert all(0 <= v <= 100 for v in d["expected_dimension_scores"].values())
+
+    def test_golden_by_label(self):
+        generic = golden_by_label("generic")
+        assert generic and all(d["label"] == "generic" for d in generic)
+        assert golden_by_label("nope") == ()
+
+    # --- The A1 acceptance contract: flag generic, demote nothing personal ---
+
+    @pytest.mark.parametrize("draft", GOLDEN_SET, ids=[d["id"] for d in GOLDEN_SET])
+    def test_calibration_gate_action(self, draft):
+        demoted = gate_draft(draft["expected_dimension_scores"])
+        expected_demoted = draft["expected_action"] == "demote"
+        assert demoted is expected_demoted, (
+            f"{draft['id']} scored {weighted_score(draft['expected_dimension_scores'])}"
+        )
+
+    def test_no_false_demotion_of_personal_content(self):
+        for label in ("authentic", "ai_assisted_personal"):
+            for d in golden_by_label(label):
+                assert not gate_draft(d["expected_dimension_scores"]), d["id"]
+
+    def test_all_generic_demoted(self):
+        for d in golden_by_label("generic"):
+            assert gate_draft(d["expected_dimension_scores"]), d["id"]

--- a/tests/unit/utilities/ai/test_authenticity_rubric.py
+++ b/tests/unit/utilities/ai/test_authenticity_rubric.py
@@ -8,6 +8,8 @@ rubric can't silently break the A1/A3 acceptance contract.
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 from cqc_lem.utilities.ai.authenticity_rubric import (
     AI_SLOP_TELLS,
     AUTHENTICITY_CAUTION_CEILING,


### PR DESCRIPTION
## What & why

R2 spike (issue #405): a **calibrated authenticity rubric** that feeds the **A1 anti-slop gate** (#382) and **A3 Topic-DNA governor** (#384) acceptance tests. LinkedIn's 2026 Authenticity Update / 360Brew demotes generic AI content and suppresses off-niche posts; A1 needs a scoring rubric before it can gate. The calibration challenge is to flag *generic* content **without** demoting good *AI-assisted-but-personal* content — so the rubric rewards lived first-person proof, specificity, voice, on-niche topic authority, and non-obvious insight, and treats AI assistance / polish as **neutral**.

## Deliverables

- **`docs/AUTHENTICITY_RUBRIC.md`** — human-readable rubric: 5 weighted dimensions, gate threshold + caution band, AI-slop tells, golden set, and sources (2026 Authenticity Update / 360Brew + Richard van der Blom Algorithm Insights).
- **`src/cqc_lem/utilities/ai/authenticity_rubric.py`** — the machine-readable single source of truth A1 imports (no LLM calls, no I/O): `AUTHENTICITY_DIMENSIONS` (weights sum to 1.0), `AUTHENTICITY_GATE_THRESHOLD=60` / `AUTHENTICITY_CAUTION_CEILING=72`, `AUTHENTICITY_JUDGE_CRITERIA` prompt block, `AI_SLOP_TELLS`, `weighted_score` / `classify_score` / `gate_draft` helpers, and a labeled `GOLDEN_SET` (generic / authentic / ai_assisted_personal).
- **`tests/unit/utilities/ai/test_authenticity_rubric.py`** — 31 tests locking the structural invariants and the A1 acceptance contract: every `generic` draft demotes, **no** `authentic` / `ai_assisted_personal` draft does.

## Testing

- `poetry run pytest tests/unit/utilities/ai/test_authenticity_rubric.py` → **31 passed**.
- Patch coverage on the new module: **100%**.
- No behavior change to existing content generation — this spike only adds the rubric artifact A1/A3 will consume (A1 wires it into the gate in #382).

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)