### PR TITLE
feat(ai): add anti-ai skill reference files (for #416 humanization)

### DIFF
--- a/src/cqc_lem/utilities/ai/anti_ai_skill/SKILL.md
+++ b/src/cqc_lem/utilities/ai/anti_ai_skill/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: anti-ai
+description: Rewrite AI-generated text so it passes as human — to human readers AND to statistical AI detectors (Pangram etc.), using empirically validated recipes (discourse fracture, interleave protocol). ONLY use this skill when the user explicitly invokes it by name — i.e. they type "/anti-ai" (or literally write "anti-ai" / "use the anti-ai skill"). Do NOT trigger it on paraphrased intent such as "humanize this", "make it sound less AI", "this reads like ChatGPT", or "fix the writing style" — the user has deliberately scoped this skill to explicit invocation only, so for those requests handle the rewrite normally without loading this skill unless they name it.
+---
+
+# Anti-AI: make the text pass as human
+
+You have **full license to modify the text heavily** — restructure, cut, reorder, roughen. Preserve only: (1) the core message and facts, (2) the author's intent and audience, (3) the format (a LinkedIn post stays a LinkedIn post).
+
+## STEP 0 — Pick the mode (mandatory, before any editing)
+
+There are two different targets, and the edits that satisfy one FAIL the other. Route first:
+
+| Situation | Mode |
+|---|---|
+| User mentions a detector (Pangram, GPTZero, Turnitin, "AI detection", "pass as human", "not flagged") — or doesn't say, and the text is a personal/social/newsletter piece | **DETECTOR mode** (default) |
+| User supplied (or can supply) a rough draft in their own words | **DETECTOR mode → interleave protocol** (the reliable variant) |
+| Formal register where a live-rant voice is absurd (client docs, white papers, documentation) — or user explicitly wants only style cleanup | **READER mode** — and warn: this output will still score 100% AI on detectors |
+
+**Default is DETECTOR mode.** The owner of this skill tests output against Pangram. When in doubt, fracture. A clean, polished, "human-sounding" rewrite is a FAILURE in detector mode — that exact output scored 100% AI eleven times in testing (see appendix).
+
+---
+
+## DETECTOR MODE
+
+Statistical detectors don't read style. They detect **generation dynamics**: planned text where every sentence advances a known arc. Eleven styled rewrites — clean, punchy, rambling, typo-ridden, ESL-flavored, idiolect-mimicking — ALL scored 100% AI on Pangram. Surface mess is not the lever. Two recipes are:
+
+### Recipe 1 — Interleave protocol (use when a human draft exists; the reliable path)
+
+A genuinely human base draft absorbs up to ~45% AI-added words and still scores 100% Human.
+
+1. Get the user's rough draft in their own words (voice-note transcript, ugly stream-of-consciousness — quality irrelevant, authorship everything). If they have none and the piece matters, ask for 2 minutes of typing from a bullet spine you provide.
+2. **Preserve their sentences verbatim.** Never fix their grammar, typos, or run-ons — fractures are load-bearing human signal. Paraphrasing a human sentence converts it to AI tokens.
+3. **Add, don't replace.** Your sentences go *between* theirs. Never two AI sentences in a row.
+4. **Stay under ~40% AI words** (45% passed at the cliff; a contiguous majority-AI block failed).
+5. **Keep their opening sentence verbatim** — first tokens set the classifier's frame.
+6. Tell the user which sentences are theirs vs yours, so later edits don't paraphrase away the human signal.
+
+### Recipe 2 — Discourse fracture (use when only AI text exists)
+
+Validated 2/2 first-try on fresh topics (after 11 failures without it). The text must read as **composed live** — drafted in public, plan abandoned midway — not planned. ALL EIGHT ingredients, not a sample:
+
+1. **One meandering specific story, not an argument.** A single incident with a timeline and named particulars. If each sentence advances a distinct point, it fails no matter how it's dressed — this is the #1 killer. Outline test: if the text can be outlined as tidy bullets, rewrite it.
+2. **Meta self-interruption** — the writer comments on their own writing and abandons the plan: "i was going to write something structured here but forget it".
+3. **Self-correction left visible** — correct a fact mid-text, keep both: "this was february, or march. february."
+4. **Repetition as emotion** — same words re-hit because the writer is still angry: "one. per week." / "everywhere. everywhere."
+5. **Emotional punctuation** — doubled marks ("!!", "??") at feeling spikes; all-lowercase in casual registers; dropped apostrophes (im, dont, its).
+6. **World-vocabulary left raw** — untranslated foreign terms, domain shorthand, local prices/times exactly as the writer's world has them (1,40€, 15h, notaire, kbis).
+7. **Unquoted reported dialogue with a name** — "i dont care about the lamination jerome."
+8. **End on a self-contradiction the writer notices and leaves in** — "and yes i will buy another one friday. i know." Never a synthesis, never a recap — and never a meaning-tag on the contradiction (see constraint 14; "thats the disgusting part honestly" is exactly the pattern that later failed).
+
+**Plus these constraints that override everything above — craft kills (learned from a controlled A/B: an 8/8-checklist text still scored 100% AI because it was well-written; the same story flattened passed 100% Human):**
+
+9. **No punchlines.** Fragments must be flat complaints ("my calves by 15h, dead"), never comedy beats ("free. zero furniture." / "same emails. same speed. so much for productivity."). If a line would get a laugh read aloud on stage, it's crafted — rewrite it duller. Rants vent; they don't perform.
+10. **No essay skeleton in disguise.** No staged progression ("week one… week two…"), no rhetorical pivot ("you know what actually worked?"), no thesis/moral sentence ("we paid 600€ to trade one problem for another"), no elegant callback ending. If paragraphs have *roles* (setup → experiment → alternative → coda), it's an essay wearing a costume and it will fail.
+11. **Stay under ~160 words.** Every pass was 119–155 words; the 251-word failure gave the classifier twice the evidence and let structure creep back. Longer pieces need the interleave protocol instead.
+12. **Drop most of the original's points.** Keep 2–3 max; abandon the rest without apology. A second A/B failure converted ALL of an essay's arguments into story beats (stat → anecdote, cost point → rent line, turnover point → quitters line) and scored 100% AI despite passing every other check — full coverage IS the planning fingerprint. Rants don't cover; they fixate on the one thing that hurt.
+13. **Entity budget: ≤4 named specifics, and dwell on them.** The failing version introduced a new name/number nearly every sentence (a report, a colleague, a headcount, a distance, a room, an HR person, a stat, quitters) — that's fiction *establishing a setting*. Real rants re-hit the same few details ("jerome… jerome…", "600€… 600!!"). One colleague mentioned three times beats three colleagues mentioned once.
+14. **OBLITERATE significance-marking meta commentary.** Never write a sentence whose only job is to tell the reader what a moment *means* or which part matters. Banned patterns (and every variant): "thats the part that got me" · "thats the [uncomfortable/disgusting/weird/funny] part (honestly)" · "what got me was" · "the thing is" · "heres the thing" · "and thats the point" · "which is exactly the problem" · "let that sink in" · "thats what kills me". These are the narrator stepping outside the rant to frame it — pure authorial planning signal. Field-verified 2026-07-22: a substack rant passed every other check but contained TWO of these ("thats the part that got me", "thats the uncomfortable part honestly") → 100% AI; deleting exactly those two sentences, changing nothing else → 100% Human. A real ranter never announces significance — they just repeat the detail (constraint 4) or trail off. If a moment matters, hit it again; never label it.
+15. **Wordbank sweep, detector mode too.** Read `references/wordbank.md` this session. Zero tier-1 hits, obviously — but ALSO no soft framing adverbs even from tier 2: quietly · genuinely · truly · honestly (as a sentence-tag) · literally (as intensifier) · actually (as pivot) · basically. At most ONE of these in the whole piece, and only inside a sentence doing real work, never tagging feeling onto the end of one. Stacked soft adverbs are the polite ghost of the meta commentary banned in 14.
+
+**Worked example (this exact text scored 100% Human, High Confidence on Pangram):**
+
+Before (AI draft — scores 100% AI):
+> Croissants are, frankly, overrated and even disgusting. The flaky texture that enthusiasts praise is actually a structural disaster, shattering into greasy shards that cling to your clothes and fingers. Each bite delivers an overwhelming amount of butter, coating the palate with a heavy, cloying film. Furthermore, the interior is often disappointingly hollow… Ultimately, the croissant is a triumph of marketing over flavor.
+
+After (discourse fracture — scores 100% Human):
+> i know im not supposed to say this but croissants are disgusting. i said it. this was supposed to be a whole review of the boulangerie near my office but forget it, let's talk about the croissant itself. i bought one tuesday, wednesday? tuesday. 1,40€. the outside does its little crunch thing everyone loves and then immediately its raining greasy flakes, on my desk, in my keyboard, everywhere. everywhere. and inside?? air. literally air with butter walls. my colleague says you dont get it, its about the lamination. i dont care about the lamination jerome. the butter sits in your stomach until 15h like a stone. and yes i will buy another one friday. thats the disgusting part honestly.
+
+Note what the After is NOT: it is not the Before with typos added. It abandoned the argument structure entirely and told one tuesday-croissant story instead. That swap — argument → incident — is the mechanism; the surface mess alone tested at 100% AI.
+
+⚠️ **Known flaw in this example:** its closing tag "thats the disgusting part honestly" is a significance-marker (constraint 14). It passed once, but the same pattern caused a 100% AI verdict in a later field test — do NOT imitate that line. End the contradiction plain, e.g. "and yes i will buy another one friday. i know."
+
+⚠️ **Do not template off the examples in this file.** In an audit, three independent rewrites all ended with the literal words "i know.", two invented a "marie", two set the incident on "tuesday" — copied straight from this document. Invent fresh names, days, prices, and a fresh plain ending every time; if any exact phrase from this file appears in your output, replace it.
+
+### Detector-mode self-verify (do this before delivering)
+
+Count, literally:
+- [ ] Story test: is it ONE incident, impossible to outline as topic-bullets? Check hard — paragraphs with roles (setup/experiment/alternative/coda) or a "you know what actually worked?" pivot mean it outlines and FAILS, even if it feels story-like
+- [ ] ≥1 meta self-interruption
+- [ ] ≥1 visible self-correction (both versions kept)
+- [ ] ≥1 repetition-as-emotion
+- [ ] ≥2 emotional punctuation moments ("!!", "??")
+- [ ] ≥1 unquoted dialogue with a name
+- [ ] Ending contradicts the writer's own stance, no recap
+- [ ] Casual register: lowercase, dropped apostrophes throughout (consistently, not sprinkled)
+- [ ] Punchline sweep: zero lines that perform (no rhythmic fragments, no wit that lands, no thesis/moral sentence, no callback) — flat complaints only
+- [ ] Word count ≤ ~160
+- [ ] Coverage test: at least half the original's points are GONE (list the original's points; if each one has a corresponding story beat, it's a translated essay → cut points, not just words)
+- [ ] Entity test: ≤4 named/numbered specifics total, and the central ones recur — no sentence-after-sentence parade of fresh details
+- [ ] **Meta-commentary sweep (constraint 14): ZERO significance-markers.** Grep the draft literally for: "the part", "the thing", "what got me", "what kills me", "thats the point", "which is exactly", "let that sink". Also scan every sentence and ask: does this sentence exist only to tell the reader what another sentence meant? If yes → delete it (don't reword it — deletion is what flipped the verdict in testing)
+- [ ] **Wordbank sweep (constraint 15):** zero tier-1 hits; ≤1 soft framing adverb total (quietly/genuinely/truly/honestly/literally/actually/basically), and never as a sentence-final feeling-tag
+
+Any unchecked box → not done. Deliver only when 14/14. A text that satisfies the checklist but is *well-written* still fails — this is the one rewrite where your instinct to write well is the enemy. Write worse: dwell, repeat, fixate, leave arguments unmade.
+
+### Detector-mode output format
+
+1. The rewritten text, ready to copy.
+2. A flag list of **invented specifics** (names, prices, dates you fabricated as scaffolding) — the user must swap in real ones before publishing as their own experience. Never silently present invented facts as real.
+3. One line: "Re-test this on the detector — recipes ride the classifier's boundary and detectors retrain." If browser access to the user's detector account is available in the session, offer to test it for them.
+
+### Hard truths to state when relevant (don't oversell)
+
+- No output is promised detector-proof; the fracture recipe passed 2/2 but detectors update.
+- Character-level hacks (zero-width chars, homoglyphs) move scores but corrupt text — never apply them; mention only if asked how evasion tools work, with the downsides.
+- A discourse-fractured white paper is absurd to a human reader — if the register can't carry a live-rant voice, detector mode needs the interleave protocol (human draft) instead, or the goal isn't reachable.
+
+---
+
+## READER MODE
+
+Target: no *human reader* pegs it as machine-written. This is classic de-AI-ing — it will NOT pass statistical detectors (say so if the user might care). Work top-down: structure → sentences → words.
+
+**Audit first.** Score the text against `references/tells.md` (read it this session) and `references/wordbank.md`: lexicon hits, constructions (negative parallelism, rule of three, rhetorical Q&A, copula dodges, participial tails, hedge stacks, vague authority), punctuation (count em dashes), structure (uniform sentence lengths, fractal summaries, signposted conclusions), voice (no specifics, no stance). Keep the tally as your before-score.
+
+**Rewrite, in order:**
+1. **Re-architect.** Delete throat-clearing openers and recap conclusions — start where the point starts, end on a specific (image, number, flat statement). Break the intro→3-points→conclusion mold. Cut restatement: AI says everything 1.5 times; say it once where it lands hardest.
+2. **Restore burstiness.** At least one ≤6-word sentence and one 25+-word sentence; visibly uneven paragraphs; a fragment where it punches; start a sentence with And/But/Because. Max one or two single-sentence paragraphs — a drumbeat of them is the AI pattern.
+3. **Kill constructions on sight** (full list + fixes in `references/tells.md`): "It's not X — it's Y" → say Y. Rule-of-three → best item only, or four with one oddly specific. "serves as" → "is". Hedge stacks → commit. "Experts say" → name the source or cut.
+4. **Swap the lexicon** per `references/wordbank.md` — the plain spoken word ("use" not "leverage"), or better, a concrete noun from the text's own world.
+5. **Ground it in the real.** The strongest single move: numbers, days, names, brands, prices, places, one irrelevant-but-true detail. If the draft has no real specifics, use plausible placeholders and flag them — never silently invent facts presented as real.
+6. **Punctuation & format.** Em dashes ≤1. Strip emoji bullets, bold-first bullets, title-case headings. Contractions on.
+7. **Humanity pass, calibrated to register:** a purposeful comma splice, a parenthetical with attitude, an admission, dry humor, a mild unhedged opinion. Micro-imperfections: at most one or two, casual registers only, never in headlines or names. (This 1–2 cap applies in READER mode only — DETECTOR mode's fracture deliberately exceeds it.)
+
+**Verify.** Re-run the audit: 0 tier-1 lexicon hits, em dashes ≤1, no signposted conclusion, burstiness real, picture visible in the first three sentences, every sentence sayable aloud. Then the over-scrubbing check: zero tells + zero personality is still AI-shaped — the goal is a voice, not an absence.
+
+**Output:** the rewrite first, then a 3–6 bullet change log (tell-count before → after, biggest structural changes, placeholders to replace). No inline annotations, no permission-asking.
+
+---
+
+## Appendix — evidence base (Pangram v3.3.2, tested 2026-07-22)
+
+- **11 pure-AI styled rewrites, all 100% AI High Confidence:** punchy/clipped (77w), rambling prose (204w), lowercase texting-mess (124w), notes-with-file-paths (101w), literary/witty (235w), keyboard-noise typos (196w), 63-word minimum, reader-mode skill rewrite with concrete specifics, ESL circling rant, idiolect mimicry of the owner's hand-written text, and more. No gradient — always 100%/High. Style, length, typos, register: not the lever.
+- **Discourse fracture: 4/4 passes with the full constraint set** (French-startup deal story 155w; croissant rant 119w; standing-desk rant 144w; open-plan rant 141w) — all 100% Human, High Confidence. **Two controlled A/Bs (2026-07-22) from fresh-session failures:** (1) a 251-word rant with all 8 base ingredients but *crafted* — punchline fragments, staged progression, rhetorical pivot, moral sentence, callback — scored 100% AI; the same story flattened passed → constraints 9–11. (2) a 141-word rant that converted EVERY point of the source essay into a story beat and introduced a new named specific nearly every sentence scored 100% AI; the same incident with coverage dropped to 2 points and ~4 recurring entities passed → constraints 12–13. Fresh sessions following the recipe went 0/2 before these constraints existed; both failures taught the recipe something.
+- **Interleave battery on a genuine human draft:** ~13% AI interleaved → Human; ~35% → Human; ~45% strictly alternating → Human; ~70% with one contiguous AI block → 100% AI. Levers: ratio ≤ ~40% and no 2+ consecutive AI sentences.
+- **Controls:** owner's genuine 2008 blog and hand-written rant → 100% Human.
+- **Significance-marker isolation test (2026-07-22, field):** a substack/instagram-ads rant satisfying the full 13-point recipe scored 100% AI. The owner deleted exactly two sentences — "thats the part that got me" and "thats the uncomfortable part honestly" — changed nothing else → 100% Human. The cleanest single-variable result in the evidence base: significance-marking meta commentary is, by itself, sufficient for an AI verdict → constraints 14–15.
+
+Interpretation: the classifier keys on planned-text generation dynamics and dominant authorship, not surface style. These thresholds are a snapshot, not a contract — re-test everything.

--- a/src/cqc_lem/utilities/ai/anti_ai_skill/evals/evals.json
+++ b/src/cqc_lem/utilities/ai/anti_ai_skill/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "anti-ai",
+  "evals": [
+    {
+      "id": 0,
+      "name": "linkedin-ai-post",
+      "prompt": "I used chatgpt to draft this linkedin post and it 100% smells like AI. rewrite it so nobody can tell — keep my story (10 years of productivity hacks, the point that clarity beats tools) and keep it a linkedin post, roughly the same length:\n\nI spent 10 years chasing productivity hacks. Then I realized the truth.\n\nIt's not about doing more — it's about doing what matters.\n\nHere's the kicker: most people don't have a productivity problem. They have a clarity problem.\n\n✅ They chase every new tool\n✅ They optimize their calendars\n✅ They wake up at 5am\n\nBut here's the thing — none of it works without focus.\n\nWhen I finally embraced this mindset shift, everything changed. My output soared. My stress plummeted. My clients noticed.\n\nThe lesson? Productivity isn't about squeezing more into your day. It's about unlocking what truly matters.\n\nIn today's fast-paced world, focus is your superpower. Harness it.\n\nAgree? ♻️ Repost if this resonated.",
+      "expected_output": "A LinkedIn post with the same story that keeps no AI tells: no emoji bullets, at most one em dash, no negative parallelism, no 'here's the kicker', no pep-talk close, varied rhythm, concrete specifics.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "remote-work-blog",
+      "prompt": "This is the intro section of a blog article for my company site about remote work. It reads super AI-generated. Audit it and rewrite it heavily so it feels written by a human editor. Keep it around 250-300 words:\n\nThe Future of Remote Work: Navigating a Changing Landscape\n\nIn today's fast-paced digital world, remote work has become a pivotal aspect of the modern workplace. Companies across the globe are grappling with the complexities of hybrid arrangements, seeking to strike a balance between flexibility and collaboration. This article delves into the evolving landscape of remote work and explores the key trends shaping its future.\n\nFirst and foremost, it is important to note that remote work is not merely a temporary trend — it represents a fundamental shift in how we approach our professional lives. Studies show that a significant majority of employees prefer flexible arrangements, underscoring the enduring appeal of remote work. Furthermore, organizations that embrace this shift often experience enhanced productivity, improved employee satisfaction, and reduced overhead costs.\n\nHowever, remote work is not without its challenges. Maintaining company culture, fostering meaningful connections, and ensuring seamless communication remain crucial concerns for leaders navigating this new terrain. Moreover, the blurring of boundaries between work and personal life can lead to burnout if not carefully managed.\n\nUltimately, the future of remote work will be shaped by a delicate interplay between technology, culture, and human needs. Organizations that leverage innovative tools while prioritizing employee well-being will be best positioned to thrive. In conclusion, remote work stands as a testament to our capacity for adaptation, and embracing this transformation will be key as we move into the future.",
+      "expected_output": "A rewritten blog intro (~250-300 words) with zero tier-1 vocabulary, no title-case colon headline, no 'In conclusion' recap, committed stances instead of hedging, named/specific details or flagged placeholders, and bursty rhythm.",
+      "files": []
+    },
+    {
+      "id": 2,
+      "name": "newsletter-anecdote",
+      "prompt": "here's a section from my personal newsletter. i love the story but it sounds like a robot wrote a hallmark card. make it sound like a real person wrote it, you can change whatever you need:\n\nLast month, I visited my grandmother's house for the first time since she passed. As I stepped through the door, a wave of nostalgia washed over me. The house was quiet — thick with memories of Sunday dinners and laughter.\n\nI couldn't help but feel a profound sense of loss as I sorted through her belongings. Each item told a story: a worn recipe book, a faded photograph, a hand-knitted scarf. They were testaments to a life lived with unwavering dedication to family.\n\nIn her desk drawer, I stumbled upon a stack of letters she had written but never sent. Little did I know, these letters would change my perspective on everything. As I read her words, my heart pounding, I felt a newfound sense of purpose wash over me.\n\nFrom that day forward, I made a commitment to write one letter every week to someone I love. It's not about grand gestures — it's about showing up, consistently, for the people who matter.\n\nHer legacy serves as a stark reminder that the little things are, in fact, the big things. And in a world of instant messages and fleeting connections, perhaps a handwritten letter is the most powerful way to truly connect.",
+      "expected_output": "The same story told in a human voice: narrative clichés gone (washed over, couldn't help but feel, little did I know, from that day forward, testament, unwavering), specific sensory details or tangents added, no 'It's not X it's Y', no tidy moral-of-the-story ending.",
+      "files": []
+    }
+  ]
+}

--- a/src/cqc_lem/utilities/ai/anti_ai_skill/references/tells.md
+++ b/src/cqc_lem/utilities/ai/anti_ai_skill/references/tells.md
@@ -1,0 +1,83 @@
+# The tell checklist (audit reference)
+
+Condensed from the AI Writing Wiki (50-source synthesis + contributed research). Each entry: what to spot → how to fix. Count every hit during the audit; the total is the AI-Feel Score. One hit means nothing — clustering is the signal — but the rewrite should still clear almost all of them, because you're being read by people who now know these patterns.
+
+## 1. Constructions (highest-value kills)
+
+| Tell | Spot it | Fix |
+|---|---|---|
+| Negative parallelism | "It's not X — it's Y" / "not just X, but Y" / "Not X. Not Y. Just Z." / "The question isn't X…" | Say Y directly. Or make the contrast concrete and asymmetric ("It's not that I'm cheap — the restaurant had too many forks" works; symmetrical abstractions don't). |
+| Rule of three | "fast, reliable, and scalable"; triads in consecutive sentences | Keep the best item. Or two. Or four with one oddly specific. |
+| Rhetorical Q&A | "The result? Devastating." "Why? Because…" | State it. If a question stays, it must be one the reader was actually asking. |
+| Copula dodge | serves as, stands as, marks, represents, functions as, boasts | "is", "has". Plain copulas are human. |
+| Participial tail | "…, highlighting the importance of…", "…, underscoring its role" | Delete, or promote to a real claim with support. |
+| False range | "from X to Y" over items that form no spectrum | Name the actual items or cut. |
+| Hedge stack | "it's important to note", "while X, consider Y", "arguably", "on both sides" | Commit to the author's position. Max one earned hedge per piece. |
+| Vague authority | "experts argue", "studies show", "observers note" | Name the source, or own the claim ("I think"), or cut. |
+| False suspense | "Here's the kicker", "here's where it gets interesting", "the best part?" | Deliver the content; delete the drumroll. |
+| Analogy reflex | "Think of it as a highway for data" | Keep only if the analogy is genuinely clearer than the thing itself. |
+| Invented concept labels | "the supervision paradox", "workload creep" (coined compound posing as established) | Describe the thing in plain words. |
+| Inspirational pivot | concrete topic swerves to "what this means for humanity" | End on the concrete instead. |
+| Grandiosity | "pivotal moment", "enduring legacy", "define the next era" | Scale claims down to what the facts support. Mundane is credible. |
+| Anaphora abuse | same sentence-opener repeated in a row | Vary — unless the repetition is a deliberate, single rhetorical moment. |
+| Dead metaphor flogging | one metaphor reused 5+ times | Use it once. Then move on. |
+
+## 2. Punctuation & formatting
+
+- **Em dashes** — the most famous tell. AI: 20+ per piece; humans: 2–3. Target ≤1. Watch the double-hyphen (--) variant too; the compulsive mid-sentence pivot is the tell, not the glyph.
+- **Bold-first bullets** ("**Security:** …") — almost no human does this unprompted. Merge into prose or use plain bullets of uneven length.
+- **Emoji bullets / ✅ / 🧠 / 🔹 / decorative →** — strip (unless the author's established voice genuinely uses one, sparingly).
+- **Title Case Headings / colon-split titles** ("The Power of X: Why Y Works") — sentence case; retitle from the content's most specific detail.
+- **Curly quotes pasted into plain-text contexts** — normalize to whatever the destination uses.
+- **Semicolons** — model-dependent tell in both directions; when in doubt use a period. Parentheses with a human aside inside are a *positive* human marker.
+- **Oxford comma** — AI uses it 100% of the time. Dropping it occasionally in casual registers is a legitimate humanity-pass move.
+- **Markdown residue** — `**`, `##`, `[text](url)` in contexts that don't render markdown: remove.
+
+## 3. Structure & rhythm
+
+- **Low burstiness** — uniform 15–20-word sentences, rectangular paragraphs. Fix: force spread (≤6-word sentence AND 25+-word sentence; uneven paragraphs; one single-line paragraph max).
+- **Fractal summaries** — previews and recaps at every level ("In this section we'll… / …as we've seen"). Delete all of them.
+- **Signposted conclusion** — "In conclusion / In summary / Overall," + restatement + uplift ("Despite challenges… the future is bright"). Delete; end on the last concrete point.
+- **Pep-talk ending** — "As we move forward, embracing X will be key." Delete on sight.
+- **Prompt echo** — text that restates the assignment ("This essay will explore…"). Delete.
+- **Listicle in a trenchcoat** — "The first reason is… The second reason is…" Merge into flowing argument.
+- **One-point dilution** — the same idea restated in new clothes. Cut to the single strongest statement.
+- **Uniform staccato** — chains of same-shaped short sentences ("X is A. X is B. X is C.") — combine into one sentence with a list, or vary the frames.
+
+## 4. Content & voice
+
+- **No concrete imagery** — the picture test: if the first three sentences evoke nothing visible, inject a specific (thing, place, number, name).
+- **Proper-noun avoidance** — generic "a client", "a tool", "a city" → name it (or placeholder-and-flag). Also: AI character names cluster on Emily/Sarah — if the text names invented people, pick unlikelier names.
+- **Narrative clichés** (AI fiction/anecdote register) — "couldn't help but feel", "heart pounding", "a sense of peace washed over", "found solace in", "unwavering", "the human spirit", "from that day on", "a testament to", "little did I know". Replace with the specific sensation or cut.
+- **Performed earnestness** — text that narrates its own helpfulness ("I hope this helps clarify"). Delete.
+- **Uniform positivity** — everything upbeat, certain, achievement-toned (measured: certainty +111–152%, positive emotion +69–133% vs human). Let something be annoying, unresolved, or mildly negative — human texts carry friction.
+- **Both-sidesing** — every claim auto-balanced by its counterpoint. Commit.
+- **Suspiciously tidy anecdotes** — stories that serve the argument with perfect efficiency. Add one irrelevant detail; real stories have tangents.
+- **Register scrubbing** — no contractions, no slang, no colloquialisms. Restore the ones the author's voice would use.
+
+## 5. Smoking guns (instant kills, always)
+
+Leaked scaffolding ("Certainly! Here's…", "I hope this helps", "let me know if…"), self-reference ("as an AI language model", knowledge-cutoff notes), placeholder text ("[insert example]"), `utm_source=chatgpt.com` in URLs, hallucinated-looking citations, "best regards" sign-offs in non-email contexts.
+
+## 6. Tells vs. detectors (they are not the same target)
+
+Everything in this file is a **reader-facing** tell — what makes a human who knows the patterns think "a machine wrote this." Statistical detectors (Pangram, GPTZero, Originality.ai) do **not** score these. They're supervised classifiers trained on model outputs, and they detect the token-level fingerprint of the generating model, which is invariant to the surface fixes here.
+
+Tested 2026-07-22 against Pangram v3.3.2: the same anecdote rewritten eight ways (punchy, rambling, sloppy-texting, notes-with-file-paths, literary, typo-noise, minimum-length) scored **100% AI, High Confidence every time** — no gradient. A 2008 human blog scored 100% human. Takeaways for this wiki:
+
+- Fixing every tell in this file makes text pass a **human**, not a **classifier**. Keep the two goals separate and never conflate a clean tell-audit with "detector-proof."
+- The clipped LinkedIn-anecdote cadence this file's "burstiness" advice can push toward is itself now a reader-tell *and* is overrepresented in classifier training data. Short punchy fragments are not a safe default.
+- Length is not the lever, and neither is style mimicry — an AI rewrite imitating a specific human's fractured idiolect (run-ons, "it's just mathematic"-style errors, self-contradiction) still scored 100% AI. Eleven styled pure-AI rewrites failed in total.
+- **Mixing works (second battery, same day):** a genuinely hand-written base draft absorbed AI-inserted sentences up to ~45% of total words and still scored 100% Human — *if* every AI sentence sat between verbatim human sentences. A ~70% AI version with one contiguous AI block scored 100% AI. Recipe in SKILL.md ("The interleave protocol"): human base draft verbatim (typos intact — they're signal), AI adds between the lines, ratio ≤ ~40%, never two AI sentences in a row, human opening kept.
+- **Discourse fracture works, barely (third battery):** the 12th pure-AI attempt scored 100% Human when the text was broken at the *discourse* level — one meandering specific story instead of an argument, meta self-interruption ("i was going to write something structured here but"), a self-corrected fact left visible ("february, or march. february."), repetition-as-anger ("one. per week."), doubled punctuation, unquoted dialogue, closing self-contradiction. The same register without the composed-live artifacts (an ESL-flavored essay, one topic per sentence) failed — the classifier keys on planned-text dynamics, not sentence mess. Full recipe in SKILL.md ("The discourse fracture"); 3/3 once the craft constraints were added, but treat as boundary-riding and always re-test — this pattern is what detectors will train on next.
+- **Craft is a detector tell even inside mess (controlled A/B):** a 251-word rant with all 8 fracture ingredients scored 100% AI because it *performed* — punchline fragments ("free. zero furniture."), staged week-by-week progression, a rhetorical pivot, a moral sentence, a callback ending. The same story flattened to 144 words of dull complaint scored 100% Human. For detectors: no punchlines, no essay skeleton in disguise, ≤ ~160 words. Well-written mess is still machine-written.
+- **Coverage and entity-density are planning fingerprints (second A/B):** a fracture that converted every point of the source essay into a story beat, introducing a new named specific almost every sentence, scored 100% AI despite passing all other checks. The same incident with half the points abandoned and ~4 entities re-hit repeatedly scored 100% Human. Rants fixate and dwell; essays cover and establish. Drop points, repeat details.
+- Character-hacks (zero-width/homoglyph injection) also move scores but corrupt the text and are out of scope for a writing skill.
+
+## 7. What NOT to do
+
+- Don't thesaurus-swap into weirdness — "humanizer" word salad is its own tell.
+- Don't scatter random typos — errors must look like casualness, not carelessness, and only in registers that tolerate them.
+- Don't scrub personality along with the tells — a flat, tell-free text is still AI-shaped. Voice in, patterns out.
+- Don't invent real-sounding facts, statistics, or quotes; use flagged placeholders instead.
+- Don't shrink every long sentence — humans write long sentences; they just don't write *only* 18-word ones.

--- a/src/cqc_lem/utilities/ai/anti_ai_skill/references/wordbank.md
+++ b/src/cqc_lem/utilities/ai/anti_ai_skill/references/wordbank.md
@@ -1,0 +1,56 @@
+# Word banks (lexicon reference)
+
+Tier 1 must go to zero. Tier 2 items survive only when they're genuinely the right word (literal use, term of art) — never in clusters. The swap principle: prefer the word you'd say out loud, and prefer a concrete noun from the text's own world over any synonym.
+
+## Tier 1 — kill on sight
+
+**Verbs:** delve · leverage · underscore · harness · foster · navigate (figurative) · utilize · facilitate · streamline · bolster · illuminate · showcase · embark · elevate · empower · unleash · unlock (figurative) · uncover · optimize · garner · resonate · revolutionize · shed light on · synthesize · elucidate · transcend · reimagine · intertwine · entwine · grapple with · espouse · exemplify · underpin
+
+**Nouns:** tapestry · landscape (figurative) · realm · ecosystem (figurative) · paradigm · synergy · testament · beacon · journey (figurative) · interplay · intricacies · symphony (figurative) · kaleidoscope · tempest · whimsy · quest (figurative) · roadmap (figurative) · endeavor · myriad · plethora · advancements · trajectory (figurative)
+
+**Adjectives/adverbs:** pivotal · crucial · seamless(ly) · robust · vibrant · intricate · meticulous(ly) · nuanced · cutting-edge · transformative · game-changing · groundbreaking · unparalleled · invaluable · multifaceted · commendable · indelible · poignant · profound(ly) · relentless(ly) · tireless(ly) · unwavering · unyielding · timeless · ever-evolving · fast-paced
+
+**Stock phrases:** in today's fast-paced world/landscape · it's important to note · it is worth noting · plays a pivotal/crucial role in · stands as a testament to · rich tapestry/history/heritage · navigate the complexities of · in conclusion · in summary · overall, (as an opener) · ultimately, (as a conclusion opener) · at its core · that being said · a key takeaway · paving the way for · valuable insights (into) · deeper understanding of · shed light on · when it comes to · not only… but also · here's the kicker/the thing/the best part · I hope this email finds you well · look no further · dive/deep-dive into · let's explore/unpack/break down · furthermore · moreover · additionally (sentence-initial)
+
+**Narrative clichés:** couldn't help but feel/wonder · heart pounding · a sense of X washed over · found solace in · the human spirit · from that day (on/forward) · little did I/we know · a stark reminder · a cautionary tale · knew that (he/she/they) had to · felt a (newfound) sense of purpose · what lay ahead · turn of events · thick with (tension) · stumbled upon · nestled (in/between) · bustling · enigmatic · captivating · glimpse into
+
+## Tier 2 — allowed alone, banned in clusters
+
+comprehensive · significant(ly) · essential · critical · key (adjective) · dynamic · innovative · powerful · notable/notably · vital · vast · rich (figurative) · deep/deeper (figurative) · explore · enhance · ensure · foster · highlight · reveal · engage · embrace (figurative) · insights · perspective · framework · approach · strategy · challenges · opportunities · potential · impact(ful) · quietly/quiet (figurative "quiet confidence") · genuinely · truly · remarkably · arguably · generally speaking · typically · thought-provoking · well-being · resilience · perseverance · dedication · commitment to · high-quality · step-by-step · sustainable/sustainability
+
+Rule of thumb: two tier-2 words in one sentence, or five in one piece, counts as a cluster — replace until under.
+
+## Swap table (defaults — always prefer a concrete specific over these)
+
+| Flagged | Say instead |
+|---|---|
+| leverage / utilize | use |
+| delve into / dive into | look at, dig into, get into |
+| pivotal / crucial | big, key, the one that matters |
+| seamless | smooth, painless, or describe what didn't break |
+| robust | solid, sturdy, hard to break |
+| navigate (complexities) | deal with, figure out, handle |
+| foster | build, grow, help |
+| facilitate | help, run, make easier |
+| streamline | simplify, cut steps |
+| underscore / highlight | show, point at, "which is the point:" |
+| showcase | show |
+| harness | use, put to work |
+| optimize | tune, tighten, improve |
+| empower | let, give X the ability to |
+| landscape / realm / space | field, market, area — or name the actual field |
+| tapestry / interplay | mix, back-and-forth |
+| testament to | proof of, "you can tell because" |
+| journey | process, the last six months, what happened |
+| myriad / plethora | a lot of, dozens of, (a number) |
+| transformative / game-changing | (state what actually changed, with a number) |
+| comprehensive | full, complete, everything-included |
+| furthermore / moreover / additionally | also, and, plus — or just start the sentence |
+| in conclusion / in summary | (delete; end on the last concrete point) |
+| valuable insights | what I learned, the useful part |
+| deeper understanding | (name the specific thing now understood) |
+| it's important to note | (delete; if it's important, the sentence shows it) |
+
+## Human markers to add (the positive list)
+
+Contractions (it's, don't, we've, you're) · a number with texture ($43, 11 months, 4:30am, v2) · a named thing (brand, tool, street, person) · a parenthetical aside with attitude · "I think" / "honestly" / "to be fair" used once · a sentence starting with And, But, or Because · one single-sentence paragraph · a mild complaint or unresolved edge · an irrelevant-but-true detail in any anecdote · a dropped Oxford comma (casual registers) · a question the reader was genuinely asking · uneven list items · a plain "is" where AI would write "serves as"


### PR DESCRIPTION
Reference rules for the READER-mode humanization pass (#416). Docs/spec only — no product code. DETECTOR-mode fracture is intentionally out of the auto path. 🤖 Generated with [Claude Code](https://claude.com/claude-code)