### PR TITLE
feat(db): content-attribution schema for post_stats (closes #386)

### DIFF
--- a/compose/local/database/migrations/V57__add_post_attribution.sql
+++ b/compose/local/database/migrations/V57__add_post_attribution.sql
@@ -1,0 +1,27 @@
+-- Content attribution for the performance→content feedback loop (#386). Today post_stats can't
+-- be tied to any content attribute, so we can never learn which hooks/formats/topics win.
+--
+-- 1) posts gains `topic` — the subject the post was built around (the post-side twin of
+--    newsletter_editions.subject); the blueprint already carries archetype/hook via V51, this
+--    adds the theme. Nullable so existing/manual posts backfill cleanly.
+ALTER TABLE posts
+    ADD COLUMN topic VARCHAR(255) NULL AFTER hook_style;
+
+-- 2) post_stats SNAPSHOTS the post's content attributes at capture time, so the feedback loop
+--    learns which shape/topic earned engagement even if the post is later edited or its shape
+--    columns change. `format` mirrors posts.post_type (text/carousel/video).
+ALTER TABLE post_stats
+    ADD COLUMN archetype   VARCHAR(50)  NULL AFTER impressions,
+    ADD COLUMN hook_style  VARCHAR(50)  NULL AFTER archetype,
+    ADD COLUMN `format`    VARCHAR(50)  NULL AFTER hook_style,
+    ADD COLUMN topic       VARCHAR(255) NULL AFTER `format`,
+    ADD COLUMN buyer_stage VARCHAR(32)  NULL AFTER topic;
+
+-- 3) Backfill already-captured stat rows from their post so historical stats gain attribution.
+UPDATE post_stats s
+    JOIN posts p ON p.id = s.post_id
+SET s.archetype   = p.archetype,
+    s.hook_style  = p.hook_style,
+    s.`format`    = p.post_type,
+    s.topic       = p.topic,
+    s.buyer_stage = p.buyer_stage;

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -914,7 +914,8 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
     # history, applied to posts via V51). Only the outermost call (which knows the post row) writes.
     if post_id is not None and final_content and blueprint:
         try:
-            update_db_post_shape(post_id, blueprint.get("format"), blueprint.get("hook_style"))
+            update_db_post_shape(post_id, blueprint.get("format"), blueprint.get("hook_style"),
+                                 topic=blueprint.get("subject"))
         except Exception as e:
             myprint(f"Could not persist post shape for post {post_id}: {e}")
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1117,15 +1117,17 @@ def update_db_post_carousel_slides(post_id: int, slides: list[str]) -> bool:
     return success
 
 
-def update_db_post_shape(post_id: int, archetype: Optional[str], hook_style: Optional[str]) -> bool:
-    """Persist the SHAPE (short-form archetype + hook style) assigned to a generated post — the
-    rotation history that keeps a user's next post from reusing a recently used shape (V51)."""
+def update_db_post_shape(post_id: int, archetype: Optional[str], hook_style: Optional[str],
+                         topic: Optional[str] = None) -> bool:
+    """Persist the SHAPE (short-form archetype + hook style + topic) assigned to a generated post —
+    the rotation history that keeps a user's next post from reusing a recently used shape (V51), and
+    the topic attribution the feedback loop reads back off each captured stat row (#386)."""
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         cursor.execute(
-            "UPDATE posts SET archetype = %s, hook_style = %s WHERE id = %s",
-            (archetype, hook_style, post_id)
+            "UPDATE posts SET archetype = %s, hook_style = %s, topic = %s WHERE id = %s",
+            (archetype, hook_style, topic, post_id)
         )
         connection.commit()
         success = cursor.rowcount == 1
@@ -3134,10 +3136,19 @@ def record_post_stats(user_id: int, post_id: int, reactions: int, comments: int,
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
+        # Snapshot the post's content attributes at capture time so the feedback loop (#386) can
+        # learn which shape/topic earned engagement even if the post is later edited.
         cursor.execute(
-            "INSERT INTO post_stats (user_id, post_id, reactions, comments, reposts, impressions) "
-            "VALUES (%s,%s,%s,%s,%s,%s)",
-            (user_id, post_id, int(reactions or 0), int(comments or 0), int(reposts or 0), impressions))
+            "SELECT archetype, hook_style, post_type, topic, buyer_stage FROM posts WHERE id=%s",
+            (post_id,))
+        row = cursor.fetchone()
+        archetype, hook_style, fmt, topic, buyer_stage = row if row else (None, None, None, None, None)
+        cursor.execute(
+            "INSERT INTO post_stats (user_id, post_id, reactions, comments, reposts, impressions, "
+            "archetype, hook_style, `format`, topic, buyer_stage) "
+            "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+            (user_id, post_id, int(reactions or 0), int(comments or 0), int(reposts or 0),
+             impressions, archetype, hook_style, fmt, topic, buyer_stage))
         connection.commit()
         return True
     except mysql.connector.Error as err:
@@ -3165,12 +3176,15 @@ def get_recent_posted_post_ids(user_id: int, days: int = 21) -> list:
 
 def get_post_engagement_rows(user_id: int) -> list:
     """Latest stats per post joined with when it was posted → rows of
-    (scheduled_time, reactions, comments, reposts) for post-time analysis."""
+    (scheduled_time, reactions, comments, reposts, archetype, hook_style, format, topic,
+    buyer_stage) for post-time and content-attribution analysis (#386). The attribution columns
+    are the snapshot captured on the stat row, so they reflect the post as it was when scraped."""
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         cursor.execute(
-            "SELECT p.scheduled_time, s.reactions, s.comments, s.reposts "
+            "SELECT p.scheduled_time, s.reactions, s.comments, s.reposts, "
+            "s.archetype, s.hook_style, s.`format`, s.topic, s.buyer_stage "
             "FROM posts p JOIN post_stats s ON s.post_id=p.id AND s.user_id=p.user_id "
             "WHERE p.user_id=%s AND s.id IN "
             "(SELECT MAX(id) FROM post_stats WHERE user_id=%s GROUP BY post_id)",

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3139,8 +3139,9 @@ def record_post_stats(user_id: int, post_id: int, reactions: int, comments: int,
         # Snapshot the post's content attributes at capture time so the feedback loop (#386) can
         # learn which shape/topic earned engagement even if the post is later edited.
         cursor.execute(
-            "SELECT archetype, hook_style, post_type, topic, buyer_stage FROM posts WHERE id=%s",
-            (post_id,))
+            "SELECT archetype, hook_style, post_type, topic, buyer_stage "
+            "FROM posts WHERE id=%s AND user_id=%s",
+            (post_id, user_id))
         row = cursor.fetchone()
         archetype, hook_style, fmt, topic, buyer_stage = row if row else (None, None, None, None, None)
         cursor.execute(

--- a/tests/integration/test_post_attribution.py
+++ b/tests/integration/test_post_attribution.py
@@ -25,7 +25,7 @@ class _FakeCursor:
         self.rowcount = 0
         self.lastrowid = 0
 
-    def execute(self, sql, params=()):
+    def execute(self, sql, params=None):
         s = " ".join(sql.split())
         if s.startswith("UPDATE posts SET archetype"):
             archetype, hook_style, topic, post_id = params

--- a/tests/integration/test_post_attribution.py
+++ b/tests/integration/test_post_attribution.py
@@ -1,0 +1,138 @@
+"""Integration test for the content-attribution feedback loop (#386).
+
+Exercises the db.py helpers together (update_db_post_shape → record_post_stats →
+get_post_engagement_rows) through a stateful fake cursor that models the `posts` and `post_stats`
+tables, so a captured stat row provably resolves back to its post's hook/format/topic — the
+acceptance criterion — without needing a live MySQL container.
+"""
+import re
+import pytest
+from datetime import datetime
+from unittest.mock import patch
+
+pytestmark = pytest.mark.integration
+
+_DB = "cqc_lem.utilities.db"
+
+
+class _FakeCursor:
+    """Minimal MySQL-ish cursor over in-memory `posts` and `post_stats` stores."""
+
+    def __init__(self, posts, stats):
+        self.posts = posts
+        self.stats = stats
+        self._result = []
+        self.rowcount = 0
+        self.lastrowid = 0
+
+    def execute(self, sql, params=()):
+        s = " ".join(sql.split())
+        if s.startswith("UPDATE posts SET archetype"):
+            archetype, hook_style, topic, post_id = params
+            self.posts[post_id].update(archetype=archetype, hook_style=hook_style, topic=topic)
+            self.rowcount = 1
+        elif s.startswith("SELECT archetype, hook_style, post_type, topic, buyer_stage FROM posts"):
+            p = self.posts.get(params[0])
+            self._result = [(p["archetype"], p["hook_style"], p["post_type"],
+                             p["topic"], p["buyer_stage"])] if p else []
+        elif s.startswith("INSERT INTO post_stats"):
+            (user_id, post_id, reactions, comments, reposts, impressions,
+             archetype, hook_style, fmt, topic, buyer_stage) = params
+            self.lastrowid = len(self.stats) + 1
+            self.stats.append({
+                "id": self.lastrowid, "user_id": user_id, "post_id": post_id,
+                "reactions": reactions, "comments": comments, "reposts": reposts,
+                "impressions": impressions, "archetype": archetype, "hook_style": hook_style,
+                "format": fmt, "topic": topic, "buyer_stage": buyer_stage,
+            })
+            self.rowcount = 1
+        elif re.search(r"SELECT p\.scheduled_time, s\.reactions", s):
+            user_id = params[0]
+            latest = {}
+            for row in self.stats:
+                if row["user_id"] == user_id:
+                    latest[row["post_id"]] = row  # append order → last wins = MAX(id)
+            self._result = [
+                (self.posts[r["post_id"]]["scheduled_time"], r["reactions"], r["comments"],
+                 r["reposts"], r["archetype"], r["hook_style"], r["format"], r["topic"],
+                 r["buyer_stage"])
+                for r in latest.values() if r["post_id"] in self.posts
+            ]
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return list(self._result)
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, posts, stats):
+        self._cur = _FakeCursor(posts, stats)
+
+    def cursor(self, *a, **k):
+        return self._cur
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class TestPostAttributionFeedbackLoop:
+    def test_captured_stat_resolves_to_post_hook_format_topic(self):
+        from cqc_lem.utilities.db import (update_db_post_shape, record_post_stats,
+                                          get_post_engagement_rows)
+
+        posts = {9: {"user_id": 1, "post_type": "carousel", "buyer_stage": "consideration",
+                     "scheduled_time": datetime(2026, 7, 20, 14, 0),
+                     "archetype": None, "hook_style": None, "topic": None}}
+        stats = []
+
+        def _conn(*a, **k):
+            return _FakeConn(posts, stats)
+
+        with patch(f"{_DB}.get_db_connection", side_effect=_conn):
+            # 1) Generation assigns the post's shape + topic.
+            assert update_db_post_shape(9, "case_study", "bold_claim", topic="AI onboarding") is True
+            # 2) The stat scraper captures engagement and snapshots attribution off the post.
+            assert record_post_stats(1, 9, reactions=42, comments=7, reposts=3, impressions=900) is True
+            # 3) The feedback loop reads stats back WITH attribution resolved.
+            rows = get_post_engagement_rows(1)
+
+        assert len(rows) == 1
+        scheduled_time, reactions, comments, reposts, archetype, hook_style, fmt, topic, stage = rows[0]
+        assert (reactions, comments, reposts) == (42, 7, 3)
+        assert archetype == "case_study"
+        assert hook_style == "bold_claim"
+        assert fmt == "carousel"          # from posts.post_type
+        assert topic == "AI onboarding"
+        assert stage == "consideration"
+
+    def test_stat_snapshot_survives_later_post_edit(self):
+        """The snapshot is taken at capture time, so re-shaping the post afterward does NOT
+        rewrite the historical stat's attribution."""
+        from cqc_lem.utilities.db import (update_db_post_shape, record_post_stats,
+                                          get_post_engagement_rows)
+
+        posts = {5: {"user_id": 1, "post_type": "text", "buyer_stage": "awareness",
+                     "scheduled_time": datetime(2026, 7, 21, 9, 0),
+                     "archetype": "myth_bust", "hook_style": "question", "topic": "hiring"}}
+        stats = []
+
+        def _conn(*a, **k):
+            return _FakeConn(posts, stats)
+
+        with patch(f"{_DB}.get_db_connection", side_effect=_conn):
+            record_post_stats(1, 5, reactions=10, comments=1)
+            update_db_post_shape(5, "tactical_list", "story", topic="retention")
+            rows = get_post_engagement_rows(1)
+
+        _, _, _, _, archetype, hook_style, _, topic, _ = rows[0]
+        assert (archetype, hook_style, topic) == ("myth_bust", "question", "hiring")

--- a/tests/unit/app/test_content_plan_deep_coverage.py
+++ b/tests/unit/app/test_content_plan_deep_coverage.py
@@ -162,7 +162,7 @@ class TestCreateTextPost:
                                       user_profile=_profile(), post_id=42)
         assert result == "refined:TL post"
         assert m["tl"].call_args[1]["blueprint"] == _BLUEPRINT
-        m["shape_save"].assert_called_once_with(42, "listicle", "question")
+        m["shape_save"].assert_called_once_with(42, "listicle", "question", topic=None)
 
     def test_industry_news_and_personal_story_and_prompt(self):
         from cqc_lem.app.run_content_plan import create_text_post

--- a/tests/unit/app/test_post_shape_rotation.py
+++ b/tests/unit/app/test_post_shape_rotation.py
@@ -48,7 +48,7 @@ class TestPostShapeRotation:
         assert bp["format"] not in ("personal_lesson", "contrarian_take")
         assert bp["hook_style"] not in ("question", "surprising_stat")
         hist.assert_called_once()
-        save.assert_called_once_with(77, bp["format"], bp["hook_style"])
+        save.assert_called_once_with(77, bp["format"], bp["hook_style"], topic=bp.get("subject"))
 
     def test_no_persistence_without_post_id(self):
         out, captured, _, save = _run(post_id=None)
@@ -61,7 +61,7 @@ class TestPostShapeRotation:
         out, captured, hist, save = _run(blueprint=bp_in)
         assert captured["blueprint"] is bp_in
         hist.assert_not_called()
-        save.assert_called_once_with(77, "tactical_list", "bold_claim")
+        save.assert_called_once_with(77, "tactical_list", "bold_claim", topic=None)
 
     def test_lead_magnet_cta_woven_when_enabled_and_selected(self):
         lm = {"enabled": True, "keyword": "AUDIT", "message": "Free profile audit checklist."}

--- a/tests/unit/utilities/test_db_coverage_avatar_groups.py
+++ b/tests/unit/utilities/test_db_coverage_avatar_groups.py
@@ -134,12 +134,26 @@ class TestUserGroups:
 
 class TestPostStats:
     def test_record_post_stats_coerces_none_counts(self):
+        # No matching post row → attribution snapshot is all-NULL but the stat is still recorded.
         conn, cur = _conn()
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import record_post_stats
             assert record_post_stats(1, 9, None, None, reposts=None, impressions=120) is True
-        params = cur.execute.call_args[0][1]
-        assert params == (1, 9, 0, 0, 0, 120)
+        params = cur.execute.call_args[0][1]  # last execute = the INSERT
+        assert params == (1, 9, 0, 0, 0, 120, None, None, None, None, None)
+
+    def test_record_post_stats_snapshots_post_attribution(self):
+        # The post's shape/topic is snapshotted onto the stat row at capture time (#386).
+        conn, cur = _conn(fetch_one=("tactical_list", "bold_claim", "text", "AI hiring", "awareness"))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_post_stats
+            assert record_post_stats(1, 9, 10, 3, reposts=1, impressions=200) is True
+        select_sql, select_params = cur.execute.call_args_list[0][0]
+        assert "FROM posts WHERE id=%s" in select_sql and select_params == (9,)
+        insert_sql, insert_params = cur.execute.call_args_list[1][0]
+        assert "INSERT INTO post_stats" in insert_sql and "`format`" in insert_sql
+        assert insert_params == (1, 9, 10, 3, 1, 200,
+                                 "tactical_list", "bold_claim", "text", "AI hiring", "awareness")
 
     def test_get_recent_posted_post_ids(self):
         conn, cur = _conn(fetch_all=[(4,), (7,)])

--- a/tests/unit/utilities/test_db_coverage_avatar_groups.py
+++ b/tests/unit/utilities/test_db_coverage_avatar_groups.py
@@ -149,7 +149,7 @@ class TestPostStats:
             from cqc_lem.utilities.db import record_post_stats
             assert record_post_stats(1, 9, 10, 3, reposts=1, impressions=200) is True
         select_sql, select_params = cur.execute.call_args_list[0][0]
-        assert "FROM posts WHERE id=%s" in select_sql and select_params == (9,)
+        assert "FROM posts WHERE id=%s AND user_id=%s" in select_sql and select_params == (9, 1)
         insert_sql, insert_params = cur.execute.call_args_list[1][0]
         assert "INSERT INTO post_stats" in insert_sql and "`format`" in insert_sql
         assert insert_params == (1, 9, 10, 3, 1, 200,

--- a/tests/unit/utilities/test_db_post_shape.py
+++ b/tests/unit/utilities/test_db_post_shape.py
@@ -23,8 +23,16 @@ class TestUpdateDbPostShape:
             from cqc_lem.utilities.db import update_db_post_shape
             assert update_db_post_shape(7, "tactical_list", "bold_claim") is True
         sql, params = cur.execute.call_args[0]
-        assert "UPDATE posts SET archetype" in sql and "hook_style" in sql
-        assert params == ("tactical_list", "bold_claim", 7)
+        assert "UPDATE posts SET archetype" in sql and "hook_style" in sql and "topic" in sql
+        assert params == ("tactical_list", "bold_claim", None, 7)
+
+    def test_persists_topic(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_db_post_shape
+            assert update_db_post_shape(7, "tactical_list", "bold_claim", topic="AI hiring") is True
+        _, params = cur.execute.call_args[0]
+        assert params == ("tactical_list", "bold_claim", "AI hiring", 7)
 
     def test_false_on_db_error(self):
         import mysql.connector


### PR DESCRIPTION
## What & why
Today `post_stats` rows can't be tied to any content attribute, so the 2026 feedback loop (Milestone 8) can never learn which hooks/formats/topics actually win. `posts.archetype`/`hook_style` already exist (V51) but weren't wired into stats, and there was no per-post topic at all.

This adds the attribution schema and populates it on stat capture.

## Changes
- **V57 migration (`V57__add_post_attribution.sql`)**
  - Adds `posts.topic VARCHAR(255)` — the subject a post was built around (post-side twin of `newsletter_editions.subject`).
  - Adds snapshot columns to `post_stats`: `archetype`, `hook_style`, `format` (mirrors `posts.post_type`), `topic`, `buyer_stage`.
  - Backfills existing `post_stats` rows from their post.
- **`record_post_stats`** snapshots the post's content attributes at capture time, so historical stats keep their attribution even if the post is later edited/re-shaped.
- **`get_post_engagement_rows`** returns the resolved attribution alongside the existing engagement columns (appended, so `recommend_post_times` is unaffected).
- **`update_db_post_shape`** now also persists the post's `topic` (from the blueprint `subject`); its one caller in `run_content_plan.py` passes it through.

### Design note
The issue offered "columns on `post_stats` **or** a join view". I chose a **snapshot at capture time** because a stat is a point-in-time measurement — pinning the attributes as they were when scraped is what a feedback loop needs (a later shape edit must not rewrite history), which a live join view can't give. `blueprint` is decomposed into its queryable parts (`archetype`/`hook_style`/`format`) rather than stored as an opaque JSON blob so the loop can `GROUP BY` attribute.

## Testing
- Integration test (`tests/integration/test_post_attribution.py`): a captured stat row resolves to its post's hook/format/topic end-to-end, plus a regression that the snapshot survives a later post edit.
- Unit tests updated/added for `record_post_stats` snapshot params and `update_db_post_shape` topic persistence.
- Full unit suite green (2698 passed).

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)