### PR TITLE
feat(content): performance-aware content selection — close the loop (closes #389)

### DIFF
--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -23,7 +23,8 @@ from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, upda
     get_user_blog_url, get_user_sitemap_url, get_active_user_ids, get_planned_posts_for_next_week, PostStatus, \
     update_db_post_video_url, update_db_post_status, PostType, get_user_preferences, \
     update_db_post_carousel_slides, get_post_content, get_user_timezone, get_engagement_preferences
-from cqc_lem.utilities.db import get_recent_post_shape_history, update_db_post_shape, get_lead_magnet_settings
+from cqc_lem.utilities.db import get_recent_post_shape_history, update_db_post_shape, get_lead_magnet_settings, \
+    get_shape_performance
 from cqc_lem.utilities.db import get_recent_post_texts
 from cqc_lem.utilities.ai.content_framework import select_blueprint, history_avoidance_directive, \
     find_most_similar, post_similarity_max, has_first_person_proof
@@ -770,10 +771,18 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
         except Exception as e:
             myprint(f"Could not load post shape history (rotating without it): {e}")
             shape_history = []
+        # Close the feedback loop (issue #389 / B4): bias shape selection away from the user's
+        # historically under-performing archetypes/hooks while keeping rotation + exploration.
+        try:
+            performance = get_shape_performance(user_id)
+        except Exception as e:
+            myprint(f"Could not load shape performance (selecting without it): {e}")
+            performance = None
         blueprint = select_blueprint(
             "post",
             recent_formats=[h.get("archetype") for h in shape_history if h.get("archetype")],
-            recent_hook_styles=[h.get("hook_style") for h in shape_history if h.get("hook_style")])
+            recent_hook_styles=[h.get("hook_style") for h in shape_history if h.get("hook_style")],
+            performance=performance)
     myprint(f"Post blueprint: format={blueprint.get('format')} hook={blueprint.get('hook_style')} "
             f"cta={blueprint.get('cta_style')}")
 

--- a/src/cqc_lem/utilities/ai/content_framework.py
+++ b/src/cqc_lem/utilities/ai/content_framework.py
@@ -17,6 +17,14 @@ from typing import Optional
 # strict no-consecutive-repeat rule). 3 keeps rotation fresh while the menus stay pickable.
 _AVOID_WINDOW = 3
 
+# Performance-aware selection (issue #389 / B4 — close the feedback loop). Below this many total
+# observed samples for a shape KIND (format or hook) we have too little signal to steer, so
+# selection stays pure rotation (behavior unchanged). The exploration floor is the smallest weight
+# an under-performing shape may be reduced to — never 0, so we keep sampling every shape and never
+# collapse to a single winner. Both read at call time so ops/tests can tune without a restart.
+PERF_MIN_SAMPLES_DEFAULT = 5
+PERF_EXPLORATION_FLOOR_DEFAULT = 0.25
+
 # ---------------------------------------------------------------------------
 # NEWSLETTER menu (long-form editions) — unchanged from the V50 blueprint system.
 # ---------------------------------------------------------------------------
@@ -487,9 +495,93 @@ def options_text(content_type: str) -> str:
     return "\n".join(lines)
 
 
-def _pick(options: dict, recency: list, forbidden: set) -> str:
-    """Pick the least-recently-used option outside `forbidden`, choosing RANDOMLY among ties (so a
-    user with no history still gets variety instead of always the first menu key). `recency` is
+def _perf_min_samples() -> int:
+    raw = (os.environ.get("PERF_MIN_SAMPLES") or "").strip()
+    try:
+        return max(1, int(raw)) if raw else PERF_MIN_SAMPLES_DEFAULT
+    except ValueError:
+        return PERF_MIN_SAMPLES_DEFAULT
+
+
+def _perf_exploration_floor() -> float:
+    raw = (os.environ.get("PERF_EXPLORATION_FLOOR") or "").strip()
+    try:
+        val = float(raw) if raw else PERF_EXPLORATION_FLOOR_DEFAULT
+    except ValueError:
+        return PERF_EXPLORATION_FLOOR_DEFAULT
+    return min(1.0, max(0.0, val))
+
+
+def _shape_engagement(agg: dict) -> float:
+    """Per-post engagement metric for one shape's aggregated stats. Weights comments (2×) and
+    reposts (3×) above reactions since they signal stronger reach on the 2026 feed. Impression-
+    normalized (engagement rate) ONLY when every sample for this shape carries impressions
+    (B2/B3 populated); otherwise average engagement per post. The caller keeps all shapes of a
+    kind on the same scale (see `performance_weights`)."""
+    samples = agg.get("samples", 0) or 0
+    if samples <= 0:
+        return 0.0
+    engagement = (agg.get("reactions", 0) or 0) + 2 * (agg.get("comments", 0) or 0) \
+        + 3 * (agg.get("reposts", 0) or 0)
+    impressions = agg.get("impressions", 0) or 0
+    if agg.get("impression_samples", 0) == samples and impressions > 0:
+        return engagement / impressions
+    return engagement / samples
+
+
+def _all_impression_covered(perf: dict) -> bool:
+    """True only when every sampled shape has full impression coverage — the gate for using
+    engagement-RATE scoring uniformly instead of average-per-post (mixing the two scales across
+    shapes would make the comparison meaningless)."""
+    sampled = [a for a in perf.values() if (a.get("samples", 0) or 0) > 0]
+    return bool(sampled) and all(
+        a.get("impression_samples", 0) == a.get("samples", 0) and (a.get("impressions", 0) or 0) > 0
+        for a in sampled)
+
+
+def performance_weights(perf: Optional[dict], keys, min_samples: int = None,
+                        floor: float = None) -> dict:
+    """Turn per-shape outcome aggregates into multiplicative SELECTION weights for `_pick` (issue
+    #389 / B4). `perf` maps shape key → aggregate (from `db.get_shape_performance`); `keys` is the
+    menu's full key set for this kind. Returns {} (⇒ pure rotation, behavior unchanged) until at
+    least `min_samples` total observations exist. Otherwise: shapes performing below the sampled
+    mean are down-weighted proportionally, floored at the exploration floor so they're never
+    dropped; at-or-above-mean and unsampled shapes stay at weight 1.0 (unsampled = keep exploring).
+    """
+    if not perf:
+        return {}
+    min_samples = _perf_min_samples() if min_samples is None else min_samples
+    floor = _perf_exploration_floor() if floor is None else floor
+    total = sum((a.get("samples", 0) or 0) for a in perf.values())
+    if total < min_samples:
+        return {}
+    rate_mode = _all_impression_covered(perf)
+    metrics = {}
+    for key, agg in perf.items():
+        if (agg.get("samples", 0) or 0) <= 0:
+            continue
+        m = _shape_engagement(agg)
+        # In rate_mode every metric is already a rate; otherwise all are avg-per-post. Same scale.
+        metrics[key] = m
+    if not metrics:
+        return {}
+    mean = sum(metrics.values()) / len(metrics)
+    weights = {}
+    for key in keys:
+        if key not in metrics:
+            weights[key] = 1.0  # unsampled shape — neutral, so exploration keeps sampling it
+        elif mean <= 0:
+            weights[key] = 1.0
+        else:
+            weights[key] = max(floor, min(1.0, metrics[key] / mean))
+    return weights
+
+
+def _pick(options: dict, recency: list, forbidden: set, weights: dict = None) -> str:
+    """Pick the least-recently-used option outside `forbidden`, choosing among ties by `weights`
+    (a shape→multiplier map; missing/None ⇒ uniform, preserving prior behavior). Recency stays the
+    PRIMARY axis so variety is never sacrificed; performance only biases the random tie-break so
+    under-performing shapes surface less often while every shape can still be picked. `recency` is
     most-recent-first; options never used rank best. Relaxes `forbidden` rather than ever failing."""
     keys = list(options.keys())
     candidates = [k for k in keys if k not in forbidden]
@@ -501,7 +593,12 @@ def _pick(options: dict, recency: list, forbidden: set) -> str:
         return recency.index(k) if k in recency else len(recency) + 1
 
     best = max(rank(k) for k in candidates)
-    return random.choice([k for k in candidates if rank(k) == best])
+    tied = [k for k in candidates if rank(k) == best]
+    if weights:
+        w = [max(0.0, weights.get(k, 1.0)) for k in tied]
+        if sum(w) > 0:
+            return random.choices(tied, weights=w, k=1)[0]
+    return random.choice(tied)
 
 
 def enforce_variety(content_type: str, blueprints: list, recent_formats: list = None,
@@ -554,11 +651,13 @@ def enforce_variety(content_type: str, blueprints: list, recent_formats: list = 
 
 def select_blueprint(content_type: str, subject: str = None, angle: str = None,
                      recent_formats: list = None, recent_hook_styles: list = None,
-                     guidance: str = None) -> dict:
+                     guidance: str = None, performance: Optional[dict] = None) -> dict:
     """A fresh blueprint for ONE piece of any content type, chosen in code (no LLM call): rotate
     away from the recent formats/hooks — including the piece's own previous shape — so consecutive
     pieces change form, not just words. Free-text `guidance` may name a format (e.g. 'make it a
-    case study'); honor it when it does."""
+    case study'); honor it when it does. `performance` (from `db.get_shape_performance`, keys
+    'format'/'hook') closes the feedback loop — under-performing shapes are surfaced less often
+    while rotation and exploration are preserved (issue #389 / B4)."""
     menu = _menu(content_type)
     formats, hooks, ctas = menu["formats"], menu["hooks"], menu["ctas"]
     hinted = _normalize(guidance, formats) if guidance else None
@@ -570,10 +669,13 @@ def select_blueprint(content_type: str, subject: str = None, angle: str = None,
                 break
     rf = [f for f in (_normalize(x, formats) for x in (recent_formats or [])) if f]
     rh = [h for h in (_normalize(x, hooks) for x in (recent_hook_styles or [])) if h]
-    fmt = hinted or _pick(formats, rf, {rf[0] if rf else None} | set(rf[:_AVOID_WINDOW]))
+    fmt_weights = performance_weights((performance or {}).get("format"), formats.keys())
+    hook_weights = performance_weights((performance or {}).get("hook"), hooks.keys())
+    fmt = hinted or _pick(formats, rf, {rf[0] if rf else None} | set(rf[:_AVOID_WINDOW]), fmt_weights)
     out = {"subject": subject, "angle": angle or "", "format": fmt,
            "structure": list(formats[fmt]["structure"])}
-    out["hook_style"] = _pick(hooks, rh, {rh[0] if rh else None} | set(rh[:_AVOID_WINDOW])) if hooks else None
+    out["hook_style"] = _pick(hooks, rh, {rh[0] if rh else None} | set(rh[:_AVOID_WINDOW]),
+                              hook_weights) if hooks else None
     out["cta_style"] = _pick(ctas, [], set()) if ctas else None
     return out
 

--- a/src/cqc_lem/utilities/ai/content_framework.py
+++ b/src/cqc_lem/utilities/ai/content_framework.py
@@ -512,19 +512,20 @@ def _perf_exploration_floor() -> float:
     return min(1.0, max(0.0, val))
 
 
-def _shape_engagement(agg: dict) -> float:
+def _shape_engagement(agg: dict, rate_mode: bool = False) -> float:
     """Per-post engagement metric for one shape's aggregated stats. Weights comments (2×) and
     reposts (3×) above reactions since they signal stronger reach on the 2026 feed. Impression-
-    normalized (engagement rate) ONLY when every sample for this shape carries impressions
-    (B2/B3 populated); otherwise average engagement per post. The caller keeps all shapes of a
-    kind on the same scale (see `performance_weights`)."""
+    normalized (engagement rate) ONLY when the caller passes `rate_mode` — i.e. EVERY sampled
+    shape of this kind has full impression coverage (see `_all_impression_covered`); otherwise
+    average engagement per post. The rate/per-post decision is made once by the caller so all
+    shapes of a kind stay on the same scale (see `performance_weights`)."""
     samples = agg.get("samples", 0) or 0
     if samples <= 0:
         return 0.0
     engagement = (agg.get("reactions", 0) or 0) + 2 * (agg.get("comments", 0) or 0) \
         + 3 * (agg.get("reposts", 0) or 0)
     impressions = agg.get("impressions", 0) or 0
-    if agg.get("impression_samples", 0) == samples and impressions > 0:
+    if rate_mode and impressions > 0:
         return engagement / impressions
     return engagement / samples
 
@@ -560,9 +561,9 @@ def performance_weights(perf: Optional[dict], keys, min_samples: int = None,
     for key, agg in perf.items():
         if (agg.get("samples", 0) or 0) <= 0:
             continue
-        m = _shape_engagement(agg)
-        # In rate_mode every metric is already a rate; otherwise all are avg-per-post. Same scale.
-        metrics[key] = m
+        # rate_mode gates the scale for ALL shapes at once: engagement-rate when every sampled
+        # shape has full impression coverage, else avg-per-post everywhere. Same scale either way.
+        metrics[key] = _shape_engagement(agg, rate_mode)
     if not metrics:
         return {}
     mean = sum(metrics.values()) / len(metrics)

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3207,7 +3207,7 @@ def get_shape_performance(user_id: int, days: int = 90) -> dict:
                 "SUM(CASE WHEN s.impressions IS NOT NULL THEN 1 ELSE 0 END) "
                 "FROM posts p JOIN post_stats s "
                 "ON s.post_id=p.id AND s.user_id=p.user_id "
-                f"WHERE p.user_id=%s AND p.{column} IS NOT NULL "
+                f"WHERE p.user_id=%s AND p.status='posted' AND p.{column} IS NOT NULL "
                 "AND p.scheduled_time >= (NOW() - INTERVAL %s DAY) "
                 "AND s.id IN (SELECT MAX(id) FROM post_stats WHERE user_id=%s GROUP BY post_id) "
                 f"GROUP BY p.{column}",

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3184,6 +3184,52 @@ def get_post_engagement_rows(user_id: int) -> list:
         connection.close()
 
 
+def get_shape_performance(user_id: int, days: int = 90) -> dict:
+    """Per-SHAPE engagement totals for a user's recently posted content — the outcomes side of the
+    performance→content feedback loop (issue #389 / B4). Joins each posted post's assigned shape
+    (`posts.archetype` = short-form FORMAT key, `posts.hook_style`) with its LATEST captured
+    `post_stats` row and aggregates raw signal counts per shape key.
+
+    Returns ``{"format": {archetype: agg}, "hook": {hook_style: agg}}`` where each ``agg`` is
+    ``{"samples", "reactions", "comments", "reposts", "impressions", "impression_samples"}``.
+    ``impressions`` sums only rows where impressions is non-NULL (``impression_samples`` counts
+    them) so the caller can tell whether impression-normalized scoring is available yet (B2/B3).
+    The engagement-metric/weighting policy lives in ``content_framework``; this stays pure access."""
+    result = {"format": {}, "hook": {}}
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        for column, bucket in (("archetype", "format"), ("hook_style", "hook")):
+            cursor.execute(
+                f"SELECT p.{column}, COUNT(*), "
+                "COALESCE(SUM(s.reactions),0), COALESCE(SUM(s.comments),0), "
+                "COALESCE(SUM(s.reposts),0), COALESCE(SUM(s.impressions),0), "
+                "SUM(CASE WHEN s.impressions IS NOT NULL THEN 1 ELSE 0 END) "
+                "FROM posts p JOIN post_stats s "
+                "ON s.post_id=p.id AND s.user_id=p.user_id "
+                f"WHERE p.user_id=%s AND p.{column} IS NOT NULL "
+                "AND p.scheduled_time >= (NOW() - INTERVAL %s DAY) "
+                "AND s.id IN (SELECT MAX(id) FROM post_stats WHERE user_id=%s GROUP BY post_id) "
+                f"GROUP BY p.{column}",
+                (user_id, days, user_id))
+            for key, samples, reactions, comments, reposts, impressions, imp_samples in cursor.fetchall():
+                result[bucket][key] = {
+                    "samples": int(samples or 0),
+                    "reactions": int(reactions or 0),
+                    "comments": int(comments or 0),
+                    "reposts": int(reposts or 0),
+                    "impressions": int(impressions or 0),
+                    "impression_samples": int(imp_samples or 0),
+                }
+        return result
+    except mysql.connector.Error as err:
+        myprint(f"Could not get shape performance for user {user_id} | Error: {err}")
+        return {"format": {}, "hook": {}}
+    finally:
+        cursor.close()
+        connection.close()
+
+
 _LEAD_MAGNET_DEFAULTS: dict = {"enabled": False, "keyword": None, "message": None}
 
 

--- a/tests/unit/utilities/ai/test_content_framework.py
+++ b/tests/unit/utilities/ai/test_content_framework.py
@@ -395,6 +395,19 @@ class TestPerformanceWeights:
         w = fw.performance_weights(perf, fw.HOOK_STYLES.keys(), min_samples=5)
         assert w["question"] < w["bold_claim"] == 1.0
 
+    def test_one_shape_fully_covered_does_not_rate_scale_when_another_lacks_it(self):
+        # Regression for the scale-mixing bug: 'question' has full per-shape impression coverage
+        # but 'bold_claim' has none, so rate_mode must be OFF and BOTH scored avg-per-post. If
+        # 'question' were rate-scored (0.01/post) while 'bold_claim' stayed per-post (10/post) the
+        # scales would be incomparable and 'question' would be spuriously crushed to the floor.
+        perf = {
+            "question": self._agg(5, reactions=50, impressions=5000, impression_samples=5),
+            "bold_claim": self._agg(5, reactions=50, impressions=0, impression_samples=0),
+        }
+        w = fw.performance_weights(perf, fw.HOOK_STYLES.keys(), min_samples=5, floor=0.25)
+        # Equal avg-per-post (10 each) ⇒ equal weights, both at the mean (1.0), none floored.
+        assert w["question"] == w["bold_claim"] == 1.0
+
 
 class TestPerformanceAwareSelection:
     """The end-to-end acceptance: a seeded under-performing hook is selected less often once
@@ -402,6 +415,8 @@ class TestPerformanceAwareSelection:
 
     def _count_hook(self, hook, performance, n=600, min_samples=5):
         import os
+        import random
+        random.seed(1337)  # deterministic RNG so the statistical assertions never flake
         os.environ["PERF_MIN_SAMPLES"] = str(min_samples)
         try:
             hits = 0

--- a/tests/unit/utilities/ai/test_content_framework.py
+++ b/tests/unit/utilities/ai/test_content_framework.py
@@ -336,3 +336,100 @@ class TestFirstPersonProofDetector:
 
     def test_detector_is_deterministic(self):
         assert fw.has_first_person_proof(self._WITH_PROOF) == fw.has_first_person_proof(self._WITH_PROOF)
+
+
+class TestPerformanceWeights:
+    """Issue #389 / B4 — outcome aggregates become selection weights that down-weight
+    under-performing shapes while keeping rotation and exploration intact."""
+
+    def _agg(self, samples, reactions=0, comments=0, reposts=0,
+             impressions=0, impression_samples=0):
+        return {"samples": samples, "reactions": reactions, "comments": comments,
+                "reposts": reposts, "impressions": impressions,
+                "impression_samples": impression_samples}
+
+    def test_below_min_samples_returns_empty(self):
+        # Too little data → no steering (empty ⇒ pure rotation, behavior unchanged).
+        perf = {"question": self._agg(2, reactions=1)}
+        assert fw.performance_weights(perf, fw.HOOK_STYLES.keys(), min_samples=5) == {}
+
+    def test_none_perf_returns_empty(self):
+        assert fw.performance_weights(None, fw.HOOK_STYLES.keys()) == {}
+        assert fw.performance_weights({}, fw.HOOK_STYLES.keys()) == {}
+
+    def test_under_performer_down_weighted_others_neutral(self):
+        perf = {
+            "question": self._agg(4, reactions=2),          # weak: metric 0.5/post
+            "bold_claim": self._agg(4, reactions=40),       # strong: metric 10/post
+        }
+        w = fw.performance_weights(perf, fw.HOOK_STYLES.keys(), min_samples=5, floor=0.25)
+        assert w["question"] < w["bold_claim"]
+        assert w["bold_claim"] == 1.0                        # at/above mean stays full
+        assert w["question"] >= 0.25                         # never below the exploration floor
+        # Unsampled shapes stay neutral so exploration keeps sampling them.
+        assert w["micro_story"] == 1.0
+
+    def test_floor_is_respected(self):
+        perf = {
+            "question": self._agg(5, reactions=0),           # metric 0 → would be 0 without floor
+            "bold_claim": self._agg(5, reactions=100),
+        }
+        w = fw.performance_weights(perf, fw.HOOK_STYLES.keys(), min_samples=5, floor=0.3)
+        assert w["question"] == 0.3
+
+    def test_rate_mode_when_all_impressions_present(self):
+        # Same raw engagement, very different impressions → the low-CTR shape is down-weighted.
+        perf = {
+            "question": self._agg(5, reactions=50, impressions=10000, impression_samples=5),
+            "bold_claim": self._agg(5, reactions=50, impressions=500, impression_samples=5),
+        }
+        w = fw.performance_weights(perf, fw.HOOK_STYLES.keys(), min_samples=5)
+        assert w["question"] < w["bold_claim"]
+
+    def test_partial_impressions_falls_back_to_per_post(self):
+        # Mixed coverage must NOT use rate mode (would mix incomparable scales).
+        perf = {
+            "question": self._agg(5, reactions=10, impressions=1000, impression_samples=3),
+            "bold_claim": self._agg(5, reactions=20),
+        }
+        w = fw.performance_weights(perf, fw.HOOK_STYLES.keys(), min_samples=5)
+        assert w["question"] < w["bold_claim"] == 1.0
+
+
+class TestPerformanceAwareSelection:
+    """The end-to-end acceptance: a seeded under-performing hook is selected less often once
+    enough data exists, and selection is unchanged below the min-sample threshold."""
+
+    def _count_hook(self, hook, performance, n=600, min_samples=5):
+        import os
+        os.environ["PERF_MIN_SAMPLES"] = str(min_samples)
+        try:
+            hits = 0
+            for _ in range(n):
+                bp = fw.select_blueprint("post", performance=performance)
+                if bp["hook_style"] == hook:
+                    hits += 1
+            return hits
+        finally:
+            os.environ.pop("PERF_MIN_SAMPLES", None)
+
+    def _perf(self, weak_hook, strong_hook, samples):
+        agg = lambda s, r: {"samples": s, "reactions": r, "comments": 0, "reposts": 0,
+                            "impressions": 0, "impression_samples": 0}
+        return {"format": {}, "hook": {weak_hook: agg(samples, 1), strong_hook: agg(samples, 200)}}
+
+    def test_underperformer_selected_less_after_enough_data(self):
+        weak, strong = "question", "bold_claim"
+        perf = self._perf(weak, strong, samples=10)          # well above min_samples
+        weak_hits = self._count_hook(weak, perf)
+        strong_hits = self._count_hook(strong, perf)
+        assert weak_hits < strong_hits
+
+    def test_behavior_unchanged_below_min_sample_threshold(self):
+        weak, strong = "question", "bold_claim"
+        # Only 2 samples each (4 total) < min_samples(5) → no steering, roughly equal.
+        perf = self._perf(weak, strong, samples=2)
+        weak_hits = self._count_hook(weak, perf)
+        strong_hits = self._count_hook(strong, perf)
+        # Without steering both are equally likely among the same tie group.
+        assert abs(weak_hits - strong_hits) < weak_hits * 0.4

--- a/tests/unit/utilities/test_shape_performance.py
+++ b/tests/unit/utilities/test_shape_performance.py
@@ -1,0 +1,47 @@
+"""Unit tests for db.get_shape_performance — the outcomes side of the performance→content
+feedback loop (issue #389 / B4)."""
+
+import mysql.connector
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestGetShapePerformance:
+    def test_aggregates_format_and_hook_buckets(self, mock_database_connection):
+        cursor = mock_database_connection["cursor"]
+        # First execute → archetype (format) rows, second → hook_style rows.
+        cursor.fetchall.side_effect = [
+            [("how_to", 3, 30, 4, 1, 0, 0), ("contrarian_take", 2, 5, 0, 0, 0, 0)],
+            [("bold_claim", 4, 40, 2, 0, 1200, 4)],
+        ]
+        from cqc_lem.utilities.db import get_shape_performance
+        perf = get_shape_performance(7)
+        assert perf["format"]["how_to"] == {
+            "samples": 3, "reactions": 30, "comments": 4, "reposts": 1,
+            "impressions": 0, "impression_samples": 0}
+        assert perf["format"]["contrarian_take"]["samples"] == 2
+        assert perf["hook"]["bold_claim"]["impression_samples"] == 4
+        assert perf["hook"]["bold_claim"]["impressions"] == 1200
+        assert cursor.execute.call_count == 2
+
+    def test_empty_when_no_rows(self, mock_database_connection):
+        cursor = mock_database_connection["cursor"]
+        cursor.fetchall.side_effect = [[], []]
+        from cqc_lem.utilities.db import get_shape_performance
+        assert get_shape_performance(7) == {"format": {}, "hook": {}}
+
+    def test_db_error_returns_empty_shape(self, mock_database_connection):
+        cursor = mock_database_connection["cursor"]
+        cursor.execute.side_effect = mysql.connector.Error("boom")
+        from cqc_lem.utilities.db import get_shape_performance
+        assert get_shape_performance(7) == {"format": {}, "hook": {}}
+
+    def test_query_filters_user_and_window(self, mock_database_connection):
+        cursor = mock_database_connection["cursor"]
+        cursor.fetchall.side_effect = [[], []]
+        from cqc_lem.utilities.db import get_shape_performance
+        get_shape_performance(42, days=30)
+        sql, params = cursor.execute.call_args_list[0][0]
+        assert "JOIN post_stats" in sql and "GROUP BY p.archetype" in sql
+        assert params == (42, 30, 42)


### PR DESCRIPTION
## What & why
Content generation previously read **zero** performance data — the loop from post outcomes into *what* to post never existed (only *when*, via best-times). This wires B3-style rankings into shape selection so under-performing archetypes/hook-styles surface less often, while keeping exploration so we never collapse to one format.

## Changes
- **`db.get_shape_performance(user_id, days=90)`** — aggregates each user's *latest* `post_stats` row per posted post, grouped by the assigned shape (`posts.archetype` = format key, `posts.hook_style`). Returns raw signal totals + impression coverage per shape; pure data access, no scoring logic.
- **`content_framework.performance_weights(perf, keys, ...)`** — turns those aggregates into multiplicative selection weights: shapes below the sampled mean are down-weighted proportionally, floored at an exploration floor (never dropped); at/above-mean and unsampled shapes stay neutral (1.0). Returns `{}` (⇒ pure rotation, behavior unchanged) below a min-sample threshold. Uses engagement-**rate** only when every shape has full impression coverage (B2/B3), else average engagement per post — so scales are never mixed.
- **`_pick` / `select_blueprint`** — accept the weights and apply them as a weighted random **tie-break**. Recency-based rotation stays the primary axis (variety preserved); performance only biases which of the equally-fresh shapes wins.
- **`plan_content_for_user`** — fetches performance and passes it into `select_blueprint` (best-effort; falls back to plain rotation on error).

Thresholds are runtime-tunable via `PERF_MIN_SAMPLES` / `PERF_EXPLORATION_FLOOR` (same live-env pattern as `POST_SIMILARITY_MAX`).

## Acceptance
> Unit test: a seeded under-performing hook is selected less often after enough data; behavior unchanged below min-sample threshold.

Both covered in `TestPerformanceAwareSelection` (end-to-end over `select_blueprint`), plus unit coverage of the weighting math, rate-mode gating, floor, and the DB aggregation.

## Testing notes
- `poetry run pytest tests/unit/utilities/test_shape_performance.py tests/unit/utilities/ai/test_content_framework.py` → 60 passed
- Broader affected suites (`tests/unit/utilities/ai`, content-plan deep coverage, post_stats) → 515 passed

No migration (reuses existing `post_stats` V42 + `posts.archetype`/`hook_style` V51).

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)