### PR TITLE
chore(ci): sync agent runner + release auto-merge + Dependabot->Claude routing

### DIFF
--- a/.github/workflows/dependabot-ci-autofix.yml
+++ b/.github/workflows/dependabot-ci-autofix.yml
@@ -1,4 +1,10 @@
-name: Dependabot CI Auto-Fix Trigger
+name: Dependabot CI Auto-Fix Router
+
+# When a Dependabot PR's CI fails, route the fix to the Claude pipeline (label agent:depfix)
+# instead of spending Copilot coding-agent credits with "@copilot fix". The local Claude runner
+# picks up agent:depfix PRs in a PRIORITY lane, smart-triages the failure (fix the bump on-branch,
+# or open a main-side fix PR + @dependabot rebase when it isn't the bump's fault), then clears the
+# label. Copilot remains the (free) reviewer only.
 
 on:
   workflow_run:
@@ -11,8 +17,8 @@ on:
       - completed
 
 jobs:
-  post-copilot-fix:
-    name: Post @copilot fix on Dependabot CI failure
+  route-to-claude:
+    name: Route Dependabot CI failure to the Claude pipeline
     runs-on: ubuntu-latest
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
@@ -23,10 +29,7 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v7
-
-      - name: Get PR for workflow run
-        id: get-pr
+      - name: Label the failing Dependabot PR for Claude
         uses: actions/github-script@v7
         with:
           script: |
@@ -39,37 +42,14 @@ jobs:
             });
             if (pulls.data.length === 0) return;
             const pr = pulls.data[0];
-            if (pr.user.login !== 'dependabot[bot]') return;
-            core.setOutput('pr_number', pr.number);
-            core.setOutput('head_sha', run.head_sha);
-
-      - name: Check for existing @copilot fix comment
-        if: steps.get-pr.outputs.pr_number != ''
-        id: check-comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const comments = await github.rest.issues.listComments({
+            if (pr.user.login !== 'dependabot[bot]') {
+              console.log(`#${pr.number} is not a Dependabot PR — skipping.`);
+              return;
+            }
+            await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: parseInt('${{ steps.get-pr.outputs.pr_number }}'),
+              issue_number: pr.number,
+              labels: ['agent:depfix'],
             });
-            const sha = '${{ steps.get-pr.outputs.head_sha }}';
-            const alreadyPosted = comments.data.some(c =>
-              c.body.includes('@copilot fix') && c.body.includes(sha)
-            );
-            core.setOutput('already_posted', alreadyPosted ? 'true' : 'false');
-
-      - name: Post @copilot fix comment
-        if: |
-          steps.get-pr.outputs.pr_number != '' &&
-          steps.check-comment.outputs.already_posted == 'false'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: parseInt('${{ steps.get-pr.outputs.pr_number }}'),
-              body: `@copilot fix\n\n<!-- sha:${{ steps.get-pr.outputs.head_sha }} -->`,
-            });
+            console.log(`Labeled #${pr.number} agent:depfix — Claude pipeline will handle it.`);

--- a/.github/workflows/release-auto-merge.yml
+++ b/.github/workflows/release-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Auto-merge Release PRs
+
+# Enables auto-merge on release-please PRs so a green release merges itself -> tag -> build -> VPS deploy,
+# with no manual "Merge when ready" click. Mirrors dependabot-auto-merge.yml: uses GHCR_PAT when present
+# (a PAT behaves like a human enqueue and reliably drains this repo's merge queue; the built-in
+# GITHUB_TOKEN from a bot action does not). No strategy flag — the merge queue fixes the strategy.
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, labeled, ready_for_review]
+
+jobs:
+  auto-merge:
+    name: Auto-merge release-please PRs
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.event.pull_request.head.ref, 'release-please--') ||
+      contains(github.event.pull_request.labels.*.name, 'autorelease: pending')
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Enable auto-merge on the release PR
+        run: gh pr merge --auto "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}

--- a/scripts/agent-pipeline/README.md
+++ b/scripts/agent-pipeline/README.md
@@ -5,13 +5,15 @@ subscription** (no API cost) as the implementer and **GitHub Copilot** as the fr
 
 ## Flow (one issue at a time)
 ```
-cron (hourly) → tick.sh advances the pipeline by ONE step:
+cron (every 15 min) → tick.sh advances the pipeline by ONE step:
+  • Dependabot PR failing (agent:depfix) → PRIORITY lane: Claude smart-triages the fix
+                       (bump-caused → fix on branch; not-the-bump's-fault → main-side fix PR + rebase)
+  • in-flight PR is CONFLICTING → Claude rebases it onto main (resolves conflicts, bumps migration #s)
   • no PR in flight  → pick next `agent:ready` issue (M7→M12, by priority) → Claude implements
-                       in an isolated git worktree → pushes → opens PR → enables auto-merge
-                       (or holds it, if risky)
+                       in an isolated git worktree → pushes → opens PR (holds it if risky)
   • PR CI failing    → Claude fixes on the same branch (≤4 attempts, then escalates to you)
-  • Copilot requested changes → Claude addresses every comment
-  • CI green, no change-requests → auto-merge lands it → release-please → build → VPS deploy
+  • Copilot unresolved threads → Claude addresses + resolves each one
+  • CI green + Copilot reviewed + threads resolved → runner enqueues the merge → release → deploy
   • risky / stuck / needs live-LinkedIn → label `needs-human`, assign you, stop
 ```
 `tick.sh` only spends Max tokens when there's real work (implement / fix / address review).

--- a/scripts/agent-pipeline/RUNBOOK.md
+++ b/scripts/agent-pipeline/RUNBOOK.md
@@ -78,6 +78,40 @@ The runner will NOT merge while any Copilot thread is unresolved, so you must bo
 3. Commit + `git push` (re-triggers CI; Copilot re-reviews the new head and may open fresh threads —
    a later tick will loop back here until Copilot has nothing left). STOP.
 
+## MODE=depfix  (env: PR, BRANCH, WORKTREE)
+A **Dependabot** PR #$PR (branch `$BRANCH`) has failing CI and was routed to you (label `agent:depfix`)
+instead of Copilot. The worktree is checked out on the Dependabot branch. **Smart-triage** the failure —
+do NOT blindly patch the branch:
+1. Read the failing CI logs: `gh pr checks $PR` then `gh run view <run-id> --log-failed`. Identify the exact failure.
+2. Decide the root cause and act accordingly:
+   - **(a) The dependency bump broke it** (compat break, changed API, lockfile/type mismatch introduced by the
+     bumped versions) → fix it **on this Dependabot branch**: make the minimal compat change, commit
+     (with the Claude co-author trailer), `git push`. Note: pushing makes Dependabot stop managing the branch —
+     acceptable to land the fix.
+   - **(b) NOT the bump's fault** (a flaky test, a live-API/secret issue like a 401 in a keyless CI context, or a
+     pre-existing failure also present on `main`) → do NOT hack the Dependabot branch. Instead open a small fix PR
+     to `main` (branch `fix/<slug>`, mirror the pexels 401-skip fix), then `gh pr comment $PR --body "@dependabot rebase"`
+     so this PR re-runs on the fixed `main`.
+   - **(c) Unclear / you can't safely fix it** → escalate: `gh pr edit $PR --add-label needs-human --add-assignee gitchrisqueen --remove-label agent:depfix`, comment what's needed, STOP.
+3. **Clear the flag** so this failure isn't reprocessed: `gh pr edit $PR --remove-label agent:depfix`.
+   (If CI fails again later, the router workflow re-labels it and you'll get another pass; the runner caps at
+   ~3 Claude attempts per branch, then escalates automatically.) STOP.
+   Once the Dependabot PR is green, the existing `dependabot-auto-merge` workflow enqueues it — you do NOT merge it.
+
+## MODE=rebase  (env: PR, ISSUE, BRANCH, WORKTREE)
+PR #$PR is **CONFLICTING** with `main` — it went stale while other PRs merged. The worktree is on `$BRANCH`.
+Rebase it cleanly onto current `main`:
+1. `git fetch origin main` then `git rebase origin/main`.
+2. Resolve **every** conflict, preserving BOTH this PR's intent AND what landed on `main`. If `main` added
+   overlapping code (e.g. another PR already added authenticity/attribution logic to the same file),
+   **integrate** with it — do not clobber what's on main, and don't duplicate it.
+3. **Migration numbers:** if this PR adds `compose/local/database/migrations/V##__*.sql` and that number now
+   exists on `main`, rename yours to the next free `V##` and update any code/tests that reference it.
+4. Run `poetry run pytest tests/unit -q` on the touched areas if feasible.
+5. `git push --force-with-lease` (re-triggers CI + a fresh Copilot review). STOP.
+6. If the conflicts are too complex to resolve safely, escalate:
+   `gh pr edit $PR --add-label needs-human --add-assignee gitchrisqueen`, comment exactly what conflicts, STOP.
+
 ---
 Keep each tick focused and finite. Prefer correctness and convention-compliance over speed — a clean PR that
 passes CI and Copilot review the first time is the goal.

--- a/scripts/agent-pipeline/tick.sh
+++ b/scripts/agent-pipeline/tick.sh
@@ -59,8 +59,10 @@ select_next_issue() {
 }
 
 open_agent_pr() {
+  # Prefer a CONFLICTING (DIRTY) PR — it needs a rebase and blocks its own merge — then by PR number.
   gh pr list --repo "$SLUG" --state open --label "agent:working" \
-    --json number,headRefName,labels | jq -r '.[0] // empty | @json'
+    --json number,headRefName,labels,mergeStateStatus \
+    | jq -r 'sort_by((if .mergeStateStatus=="DIRTY" then 0 else 1 end), .number) | .[0] // empty | @json'
 }
 
 # Count of UNRESOLVED review threads whose first comment is authored by Copilot.
@@ -83,8 +85,9 @@ copilot_last_review_at() {  # $1=pr
 
 add_worktree() {  # $1=branch  $2=base(ref)  -> path on stdout
   local branch="$1" base="$2" wt="$WORKROOT/$1"
-  git -C "$REPO" worktree prune >/dev/null 2>&1
+  git -C "$REPO" worktree remove --force "$wt" >/dev/null 2>&1 || true
   rm -rf "$wt"
+  git -C "$REPO" worktree prune >/dev/null 2>&1
   if git -C "$REPO" show-ref --verify --quiet "refs/remotes/origin/$branch"; then
     git -C "$REPO" worktree add "$wt" "origin/$branch" >/dev/null 2>&1
     git -C "$wt" checkout -B "$branch" "origin/$branch" >/dev/null 2>&1
@@ -107,6 +110,32 @@ run_claude() {  # $1=worktree  $2=prompt
 # --- state machine ---
 git -C "$REPO" fetch origin --prune >/dev/null 2>&1
 
+# ---- PRIORITY LANE: Dependabot CI failures (labeled agent:depfix by the router workflow) ----
+# Handled before roadmap work so dependency PRs get unblocked fast. One Claude call per tick.
+DEPFIX="$(gh pr list --repo "$SLUG" --state open --label "agent:depfix" \
+  --json number,headRefName,labels \
+  | jq -r 'map(select((.labels|map(.name))|index("needs-human")|not))|.[0]//empty|@json')"
+if [ -n "$DEPFIX" ]; then
+  DPR="$(echo "$DEPFIX" | jq -r .number)"
+  DBR="$(echo "$DEPFIX" | jq -r .headRefName)"
+  CLAUDE_TRIES="$(git -C "$REPO" log "origin/$DBR" --grep='Co-Authored-By: Claude' --format=%h 2>/dev/null | wc -l | tr -d ' ')"
+  if [ "${CLAUDE_TRIES:-0}" -ge 3 ]; then
+    log "Dependabot PR #$DPR still failing after $CLAUDE_TRIES Claude attempts — escalating."
+    if [ "$DRY_RUN" != "1" ]; then
+      gh pr edit "$DPR" --repo "$SLUG" --add-label needs-human --remove-label agent:depfix >/dev/null 2>&1
+      gh issue comment "$DPR" --repo "$SLUG" --body "🚧 Claude couldn't fix CI after $CLAUDE_TRIES attempts on this Dependabot PR. Assigning @$ASSIGNEE." >/dev/null 2>&1
+      gh pr edit "$DPR" --repo "$SLUG" --add-assignee "$ASSIGNEE" >/dev/null 2>&1
+    fi
+    exit 0
+  fi
+  log "Dependabot PR #$DPR failing — invoking depfix (priority lane, try $((CLAUDE_TRIES+1)))."
+  if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would run MODE=depfix for #$DPR ($DBR)."; exit 0; fi
+  WT="$(add_worktree "$DBR" origin/main)"
+  export MODE=depfix PR="$DPR" BRANCH="$DBR" WORKTREE="$WT"
+  run_claude "$WT" "Read $RUNBOOK and follow MODE=depfix. PR=$DPR BRANCH=$DBR."
+  exit 0
+fi
+
 PR_JSON="$(open_agent_pr)"
 
 if [ -n "$PR_JSON" ]; then
@@ -116,6 +145,17 @@ if [ -n "$PR_JSON" ]; then
            | jq -r '(.body,.title)|scan("#([0-9]{3,})")|.[0]' | head -1)"
   HEAD_DATE="$(git -C "$REPO" log -1 --format=%cI "origin/$BRANCH" 2>/dev/null)"
   log "In-flight PR #$PR (branch $BRANCH, issue #${ISSUE:-?})."
+
+  # 0) Stale/conflicting with main (went dirty while other PRs merged) -> rebase before anything else.
+  MSTATE="$(gh pr view "$PR" --repo "$SLUG" --json mergeStateStatus --jq .mergeStateStatus 2>/dev/null)"
+  if [ "$MSTATE" = "DIRTY" ]; then
+    log "PR #$PR is CONFLICTING with main — invoking rebase."
+    if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would run MODE=rebase for #$PR."; exit 0; fi
+    WT="$(add_worktree "$BRANCH" origin/main)"
+    export MODE=rebase PR ISSUE WORKTREE="$WT" BRANCH
+    run_claude "$WT" "Read $RUNBOOK and follow MODE=rebase. PR=$PR ISSUE=$ISSUE BRANCH=$BRANCH."
+    exit 0
+  fi
 
   ROLLUP="$(gh pr view "$PR" --repo "$SLUG" --json statusCheckRollup \
     | jq -r '[.statusCheckRollup[]? | {s:(.conclusion//.state//"PENDING")}]')"
@@ -159,14 +199,23 @@ if [ -n "$PR_JSON" ]; then
     exit 0
   fi
 
-  # 4) CI green + no unresolved Copilot threads. Require Copilot to have reviewed the CURRENT head.
-  if [ -z "$CP_AT" ] || [ "$(epoch "$CP_AT")" -lt "$(epoch "$HEAD_DATE")" ]; then
-    log "PR #$PR — green, but waiting for Copilot to review the current head commit before merge."
+  # 4) CI green + no unresolved Copilot threads. Copilot must have reviewed at least once, and
+  #    either it reviewed the current head OR the head has been stable past a grace window
+  #    (Copilot does not re-review every push — don't deadlock waiting for a re-review that
+  #    may never come; unresolved threads on new code would be caught by step 2 anyway).
+  REVIEW_GRACE_SECONDS="${REVIEW_GRACE_SECONDS:-1200}"   # 20 min
+  if [ -z "$CP_AT" ]; then
+    log "PR #$PR — green; waiting for Copilot's first review before merge."
+    exit 0
+  fi
+  if [ "$(epoch "$CP_AT")" -lt "$(epoch "$HEAD_DATE")" ] \
+     && [ "$(( $(date +%s) - $(epoch "$HEAD_DATE") ))" -lt "$REVIEW_GRACE_SECONDS" ]; then
+    log "PR #$PR — green; Copilot hasn't re-reviewed the latest push yet (within ${REVIEW_GRACE_SECONDS}s grace). Waiting."
     exit 0
   fi
 
-  # 5) Green + Copilot reviewed head + all threads resolved -> merge (runner-controlled).
-  log "PR #$PR — green, Copilot reviewed & all threads resolved. Merging."
+  # 5) Green + Copilot reviewed (head or past grace) + all threads resolved -> merge.
+  log "PR #$PR — green, Copilot review satisfied & all threads resolved. Merging."
   if [ "$DRY_RUN" != "1" ]; then
     gh pr merge --auto "$(gh pr view "$PR" --repo "$SLUG" --json url --jq .url)" >/dev/null 2>&1 \
       && gh pr comment "$PR" --repo "$SLUG" --body "✅ CI green, Copilot review addressed & resolved — merging." >/dev/null 2>&1


### PR DESCRIPTION
Consolidated pipeline maintenance:

1. **Runner sync** (`scripts/agent-pipeline/`) — brings the repo copy up to the live box runner: grace-window merge gate (fixes the Copilot-re-review deadlock), worktree self-heal, Dependabot **depfix priority lane** + `MODE=depfix`, **`MODE=rebase`** for stale/conflicting PRs, and conflict-first ordering.
2. **`release-auto-merge.yml`** (new) — enables auto-merge on release-please PRs so a green release merges itself → tag → build → VPS deploy, no manual click. Uses `GHCR_PAT` to drain the merge queue (same pattern as `dependabot-auto-merge.yml`).
3. **`dependabot-ci-autofix.yml`** (changed) — Dependabot CI failures now label `agent:depfix` for the Claude runner (smart triage) instead of `@copilot fix`, saving Copilot coding-agent credits. Copilot stays the free reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)