### PR TITLE
ci: UI build gate + ignore typescript major (prevent build-break merges)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -83,3 +83,7 @@ updates:
         update-types:
           - "minor"
           - "patch"
+    ignore:
+      # typescript major (7.x) breaks typescript-eslint's peer (<6.1.0) and the Docker npm ci.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -1,0 +1,28 @@
+name: UI Build
+
+# Runs the strict `npm ci` + production build the Docker image does, on every PR — so a
+# dependency change that breaks the image (e.g. an ERESOLVE peer conflict) fails CI here
+# instead of silently breaking release/deploy. Make "UI Build" a required check to enforce it.
+
+on:
+  pull_request:
+
+jobs:
+  ui-build:
+    name: UI Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: src/cqc_lem/ui/package-lock.json
+      - name: npm ci (strict — matches the Docker build)
+        working-directory: src/cqc_lem/ui
+        run: npm ci
+      - name: Production build
+        working-directory: src/cqc_lem/ui
+        run: npm run build
+        env:
+          VITE_API_TOKEN: ${{ secrets.UI_API_TOKEN }}


### PR DESCRIPTION
Prevents a repeat of the prod freeze: a strict `npm ci`+build **UI Build** check on every PR (catches ERESOLVE/build breaks the Python-only required checks miss), plus a dependabot ignore for typescript major. After merge, add **UI Build** to required checks to enforce it. 🤖 Generated with [Claude Code](https://claude.com/claude-code)