### PR TITLE
ci(db): timestamp Flyway migration versions (permanent collision fix)

### DIFF
--- a/.github/workflows/migration-check.yml
+++ b/.github/workflows/migration-check.yml
@@ -1,8 +1,11 @@
 name: Migration Versions
 
-# Fails if two Flyway migrations share a version number. Same-version/different-filename migrations
-# don't git-conflict, so they merge clean but break `flyway migrate` at deploy — this catches them
-# at PR time. Make "Migration Versions" a required check to enforce it.
+# Guards Flyway migrations on every PR:
+#   1. No two migrations share a version (a duplicate breaks `flyway migrate` at deploy).
+#   2. Every NEW migration uses a 14-digit TIMESTAMP version V<YYYYMMDDHHMMSS>__ ; legacy V1-V58
+#      are grandfathered. Timestamps are unique per authoring second and sort after all legacy
+#      integers, so parallel PRs can never collide again.
+# Make "Migration Versions" a required check to enforce it.
 
 on:
   pull_request:
@@ -13,13 +16,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: No duplicate migration versions
+      - name: Unique versions + timestamp format for new migrations
         run: |
           cd compose/local/database/migrations
-          dups=$(ls V*.sql 2>/dev/null | sed -E 's/^(V[0-9]+)__.*/\1/' | sort | uniq -d)
-          if [ -n "$dups" ]; then
-            echo "::error::Duplicate Flyway migration version(s): $dups"
-            for v in $dups; do echo "  $v:"; ls ${v}__*.sql; done
-            exit 1
-          fi
-          echo "All migration versions are unique."
+          fail=0
+          dups=$(ls V*.sql 2>/dev/null | sed -E 's/^V([0-9]+)__.*/\1/' | sort | uniq -d || true)
+          if [ -n "$dups" ]; then echo "::error::Duplicate Flyway migration version(s): $dups"; fail=1; fi
+          for f in V*.sql; do
+            v=$(echo "$f" | sed -E 's/^V([0-9]+)__.*/\1/')
+            # grandfather legacy integer migrations (<= 58)
+            if echo "$v" | grep -qE '^[0-9]{1,2}$' && [ "$v" -le 58 ]; then continue; fi
+            # everything else must be a 14-digit timestamp V<YYYYMMDDHHMMSS>__
+            if ! echo "$v" | grep -qE '^[0-9]{14}$'; then
+              echo "::error::$f — new migrations must use a 14-digit timestamp version 'V<YYYYMMDDHHMMSS>__' (run: date -u +%Y%m%d%H%M%S). Legacy V<=58 are grandfathered. Got '$v'."
+              fail=1
+            fi
+          done
+          if [ "$fail" = 0 ]; then echo "Migrations OK: unique versions, new ones are timestamps."; else exit 1; fi

--- a/compose/local/database/migrations/README.md
+++ b/compose/local/database/migrations/README.md
@@ -1,0 +1,28 @@
+# Database migrations (Flyway)
+
+## Naming: NEW migrations use a TIMESTAMP version
+
+```
+V<YYYYMMDDHHMMSS>__short_description.sql
+```
+Get the version at authoring time (UTC):
+```
+date -u +%Y%m%d%H%M%S        # e.g. 20260723211500
+# -> V20260723211500__add_widget_table.sql
+```
+
+### Why
+Sequential integers (V57, V58, …) collide when two branches are open at once — each grabs the
+same "next" number, both merge (different filenames don't git-conflict), and `flyway migrate`
+then fails *"Found more than one migration with version N"*, blocking every deploy. Timestamps are
+unique per authoring second and always sort **after** the legacy integer migrations.
+
+### Rules
+- **Never** use a bare integer version for a new migration.
+- **Never** rename/renumber an already-merged migration — Flyway tracks applied ones by
+  version + checksum, so renaming a shipped migration breaks validation everywhere it ran.
+- Legacy `V1`–`V58` are frozen and grandfathered; everything new is a timestamp.
+- Enforced by the **Migration Versions** CI check.
+
+Flyway runs `outOfOrder=false` with validation on, so a duplicate/out-of-order migration *fails
+the deploy* rather than silently skipping — timestamps prevent it entirely.


### PR DESCRIPTION
New migrations must use `V<YYYYMMDDHHMMSS>__name.sql` timestamps (legacy V1-V58 grandfathered, never renamed — that would break Flyway). Enhances the Migration Versions check to enforce unique versions + timestamp format, and adds a migrations README. Eliminates the duplicate-version collision permanently. 🤖 Generated with [Claude Code](https://claude.com/claude-code)