### PR TITLE
feat(newsletter): humanize edition titles with a title-specific de-hype pass (closes #439)

### DIFF
--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -24,6 +24,7 @@ from cqc_lem.utilities.ai.content_alignment import (
     select_focus_topic as _select_focus_topic,
     lead_magnet_preserve_note as _lead_magnet_preserve_note,
     humanize_text as _humanize_text,
+    humanize_title as _humanize_title,
 )
 from cqc_lem.utilities.ai.content_research import research_topic
 from cqc_lem.utilities.ai.tools import search_recent_news, search_with_perplexity
@@ -626,7 +627,11 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
     try:
         data = _json.loads(content)
         if data.get("title") and data.get("body"):
-            title = normalize_public_text(str(data["title"]).strip())[:255]
+            # Titles get the title-specific de-hype pass (issue #439), not the prose rewrite — a
+            # headline must keep its hook while losing the wordbank/clickbait tells.
+            title = normalize_public_text(_humanize_title(
+                str(data["title"]).strip(), content_type="newsletter",
+                profile_synthesis=profile_synthesis, prefs=prefs, max_chars=255))[:255]
             # Humanization pass (issue #416 — A5): de-slop the edition body before it's persisted/reviewed.
             body = _clean_newsletter_body(_humanize_text(
                 str(data["body"]).strip(), content_type="newsletter",
@@ -640,7 +645,9 @@ def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
     except (ValueError, TypeError, AttributeError):
         pass
     parts = content.strip().split("\n", 1)   # fallback: first line = title, remainder = body
-    title = parts[0].strip()[:255]
+    title = normalize_public_text(_humanize_title(
+        parts[0].strip(), content_type="newsletter",
+        profile_synthesis=profile_synthesis, prefs=prefs, max_chars=255))[:255]
     body = _clean_newsletter_body(_humanize_text(
         parts[1].strip() if len(parts) > 1 else content.strip(),
         content_type="newsletter", profile_synthesis=profile_synthesis, prefs=prefs))

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -854,6 +854,121 @@ def humanize_text(content: Optional[str], content_type: str = "post",
     return rewritten
 
 
+# --- Title de-hype pass (issue #439) --------------------------------------------------------------
+# A headline is not prose: the full READER-mode rewrite above flattens it into a sentence and costs the
+# open rate. Titles get their own pass that strips the hype/AI tells while KEEPING one real hook.
+
+# Headline-only hype tells (clickbait superlatives + growth-hack verbs) that aren't in the tier-1 prose
+# wordbank. Used to steer the rewrite prompt and as a deterministic, testable audit.
+TITLE_HYPE_WORDS = frozenset({
+    "explosive", "explode", "exploding", "supercharge", "supercharged", "skyrocket", "skyrocketing",
+    "insane", "jaw-dropping", "mind-blowing", "shocking", "ultimate", "secret", "secrets", "hack",
+    "hacks", "guru", "ninja", "viral", "effortless", "effortlessly", "proven", "foolproof",
+    "must-have", "no-brainer", "revolutionary", "epic", "killer", "supercharging", "10x",
+})
+
+
+def find_title_slop_words(text: Optional[str]) -> list[str]:
+    """Deterministic audit for headlines: tier-1 AI-tell words (AI_TELL_WORDS) plus the headline-only
+    hype lexicon (TITLE_HYPE_WORDS) present in `text`, in order of first appearance, de-duplicated and
+    case-insensitive. NO LLM call."""
+    out, seen = [], set()
+    for tok in _WORD_TOKEN_RE.findall(text or ""):
+        low = tok.lower()
+        if (low in AI_TELL_WORDS or low in TITLE_HYPE_WORDS) and low not in seen:
+            seen.add(low)
+            out.append(low)
+    return out
+
+
+_HUMANIZE_TITLE_SYSTEM = (
+    "You rewrite an AI-drafted HEADLINE so it reads like a human editor wrote it, without changing what "
+    "the piece is about. This headline is published in the author's own name.\n\n"
+    "HARD RULES:\n"
+    "- NEVER invent facts: no numbers, names, dates, claims, or specifics that are not already in the "
+    "draft headline (or the author-background section below, when one is given).\n"
+    "- Keep the same subject. If the draft names a real specific (a tool, a number, a place), keep it.\n"
+    "- It stays a HEADLINE: one short line, no trailing period, no quotes around it, no subtitle, no "
+    "explanation. Aim for under ~90 characters.\n"
+    "- KEEP ONE genuine hook - a tension, a specific promise, a contrarian angle, a concrete outcome. "
+    "Do NOT flatten it into a bland topic label, and do NOT turn it into a sentence of prose or a rant.\n\n"
+    "DE-HYPE (this is the job):\n"
+    "- Cut hype adjectives: game-changing, groundbreaking, revolutionary, explosive, ultimate, "
+    "unparalleled, cutting-edge, transformative, insane, must-have, secret, proven.\n"
+    "- Cut AI verbs: unlock, unleash, elevate, harness, leverage, supercharge, master, delve, "
+    "revolutionize, skyrocket.\n"
+    "- Drop clickbait scaffolds: '7 X That Will...', 'The Ultimate Guide to', 'You Won't Believe', "
+    "'Here's Why/How', 'X Is Killing Y'. A number stays only if it names something real in the draft.\n"
+    "- No emoji, no ALL-CAPS words, no exclamation marks, no em dashes, no curly quotes.\n"
+    "- Use the plain words a person would say out loud.\n\n"
+    "Output ONLY the rewritten headline."
+)
+
+_TITLE_LABEL_RE = re.compile(r"^(?:title|headline)\s*[:\-]\s*", re.IGNORECASE)
+
+
+def _clean_title_line(text: str) -> str:
+    """Coerce a model reply back into a single headline: first non-empty line, no 'Title:' label, no
+    wrapping quotes, whitespace collapsed, em-dash tells removed."""
+    line = next((ln.strip() for ln in (text or "").splitlines() if ln.strip()), "")
+    line = _TITLE_LABEL_RE.sub("", line).strip()
+    if len(line) >= 2 and line[0] == line[-1] and line[0] in "\"'":
+        line = line[1:-1].strip()
+    line = re.sub(r"\s+", " ", cap_em_dashes(line, 0)).strip()
+    if line.endswith(".") and not line.endswith("..."):
+        line = line[:-1].rstrip()
+    return line
+
+
+def humanize_title(title: Optional[str], content_type: str = "newsletter",
+                   profile_synthesis: Optional[str] = None,
+                   prefs: Optional[dict] = None, max_chars: int = 255) -> Optional[str]:
+    """Title-appropriate de-hype pass (issue #439). Strips the AI/hype tells from an AI-drafted headline
+    (wordbank hits, clickbait scaffolds, superlatives) while keeping ONE compelling hook, so titles stop
+    reading like "7 Game-Changing Tactics for Explosive Growth". Shares the HUMANIZE_ENABLED /
+    HUMANIZE_<TYPE>_ENABLED toggles with humanize_text and FAILS OPEN the same way: returns `title`
+    unchanged when the pass is disabled, the input is empty, the model errors, the reply collapses to a
+    fragment, it grows past the draft's own length or the `max_chars` budget (a reply that long is prose,
+    not a headline), or the rewrite carries more hype/AI tells than what came in."""
+    if not title or not str(title).strip():
+        return title
+    if not humanize_enabled(content_type):
+        return title
+    original = title
+    try:
+        extra = ""
+        synth = (profile_synthesis or "").strip()
+        if synth:
+            extra += ("\n\nAuthor background - the ONLY source of real specifics you may draw on (never "
+                      "copy it verbatim, never invent beyond it):\n" + synth[:400])
+        hits = find_title_slop_words(str(title))
+        if hits:
+            extra += ("\n\nRemove these hype / AI-tell words that appear in the draft headline: "
+                      + ", ".join(hits[:20]) + ".")
+        extra += f"\n\nHard limit: the headline MUST be at most {int(max_chars)} characters."
+        # Lazy import avoids a circular import (ai_helper imports this module).
+        from cqc_lem.utilities.ai.ai_helper import _call_llm
+        resp = _call_llm(
+            model="lem-simple",
+            messages=[
+                {"role": "system", "content": _HUMANIZE_TITLE_SYSTEM + extra},
+                {"role": "user", "content": str(title).strip()},
+            ],
+            temperature=0.4,
+        )
+        rewritten = _clean_title_line(resp.choices[0].message.content or "")
+    except Exception:
+        return original
+    # A headline that came back as a couple of words lost its hook (or the model refused). De-hyping
+    # never needs MORE room than the draft, so a reply that grew is prose/an explanation, not a title.
+    budget = min(int(max_chars), max(90, len(str(title).strip())))
+    if len(rewritten) < 12 or len(rewritten) > budget:
+        return original
+    if len(find_title_slop_words(rewritten)) > len(find_title_slop_words(str(title))):
+        return original
+    return rewritten
+
+
 def score_authenticity(content: str, profile=None, profile_synthesis: Optional[str] = None,
                        prefs: dict = None) -> dict:
     """LLM-judge the authenticity / generic-AI risk of a finished post draft.

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -868,12 +868,17 @@ TITLE_HYPE_WORDS = frozenset({
 })
 
 
+# Headline tokens may START with a digit ("10x"), unlike the prose wordbank, so this pass gets its own
+# tokenizer instead of _WORD_TOKEN_RE.
+_TITLE_TOKEN_RE = re.compile(r"[a-zA-Z0-9][a-zA-Z0-9-]*")
+
+
 def find_title_slop_words(text: Optional[str]) -> list[str]:
     """Deterministic audit for headlines: tier-1 AI-tell words (AI_TELL_WORDS) plus the headline-only
     hype lexicon (TITLE_HYPE_WORDS) present in `text`, in order of first appearance, de-duplicated and
     case-insensitive. NO LLM call."""
     out, seen = [], set()
-    for tok in _WORD_TOKEN_RE.findall(text or ""):
+    for tok in _TITLE_TOKEN_RE.findall(text or ""):
         low = tok.lower()
         if (low in AI_TELL_WORDS or low in TITLE_HYPE_WORDS) and low not in seen:
             seen.add(low)
@@ -928,8 +933,13 @@ def humanize_title(title: Optional[str], content_type: str = "newsletter",
     reading like "7 Game-Changing Tactics for Explosive Growth". Shares the HUMANIZE_ENABLED /
     HUMANIZE_<TYPE>_ENABLED toggles with humanize_text and FAILS OPEN the same way: returns `title`
     unchanged when the pass is disabled, the input is empty, the model errors, the reply collapses to a
-    fragment, it grows past the draft's own length or the `max_chars` budget (a reply that long is prose,
-    not a headline), or the rewrite carries more hype/AI tells than what came in."""
+    fragment, it runs past the headline budget (a reply that long is prose, not a headline), or the
+    rewrite carries more hype/AI tells than what came in.
+
+    Headline budget = min(max_chars, max(90, len(title))). The 90-char floor matches the "aim for under
+    ~90 characters" instruction in the prompt: de-hyping a SHORT hype headline ("10x Your Reach") into
+    plain words legitimately needs a little more room, so capping at the draft's own length there would
+    fail open on exactly the titles this pass exists for. Longer drafts never get to grow."""
     if not title or not str(title).strip():
         return title
     if not humanize_enabled(content_type):
@@ -959,8 +969,8 @@ def humanize_title(title: Optional[str], content_type: str = "newsletter",
         rewritten = _clean_title_line(resp.choices[0].message.content or "")
     except Exception:
         return original
-    # A headline that came back as a couple of words lost its hook (or the model refused). De-hyping
-    # never needs MORE room than the draft, so a reply that grew is prose/an explanation, not a title.
+    # A headline that came back as a couple of words lost its hook (or the model refused). Past the
+    # headline budget (see docstring) the reply is prose/an explanation, not a title.
     budget = min(int(max_chars), max(90, len(str(title).strip())))
     if len(rewritten) < 12 or len(rewritten) > budget:
         return original

--- a/tests/unit/utilities/ai/test_humanize.py
+++ b/tests/unit/utilities/ai/test_humanize.py
@@ -198,6 +198,10 @@ class TestFindTitleSlopWords:
     def test_case_insensitive_and_deduped(self):
         assert ca.find_title_slop_words("Explosive. EXPLOSIVE growth") == ["explosive"]
 
+    def test_detects_hype_tokens_that_start_with_a_digit(self):
+        assert ca.find_title_slop_words("10x Your LinkedIn Reach") == ["10x"]
+        assert ca.find_title_slop_words("How to 10X reach") == ["10x"]
+
     def test_clean_headline_has_no_hits(self):
         assert ca.find_title_slop_words("What our best buyers actually read") == []
 
@@ -207,7 +211,7 @@ class TestFindTitleSlopWords:
 
 
 class TestHumanizeTitle:
-    def test_slopy_title_in_dehyped_title_out(self, monkeypatch):
+    def test_sloppy_title_in_dehyped_title_out(self, monkeypatch):
         monkeypatch.setenv("HUMANIZE_ENABLED", "on")
         slop = "7 Game-Changing AI Tactics for Explosive LinkedIn Growth"
         clean = "The AI tactics that actually moved our LinkedIn numbers"
@@ -286,6 +290,21 @@ class TestHumanizeTitle:
         original = "A" * 120
         with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply("B" * 60)):
             assert ca.humanize_title(original, "newsletter", max_chars=40) == original
+
+    def test_short_draft_may_grow_up_to_the_90_char_headline_floor(self, monkeypatch):
+        # De-hyping a short hype headline needs a little room; budget = min(max_chars, max(90, len)).
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        clean = "The reach numbers we actually got after six months of posting"  # 61 chars
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply(clean)):
+            assert ca.humanize_title("10x Your Reach", "newsletter") == clean
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply("B" * 91)):
+            assert ca.humanize_title("10x Your Reach", "newsletter") == "10x Your Reach"
+
+    def test_long_draft_may_not_grow_past_its_own_length(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        original = "A" * 100
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply("B" * 101)):
+            assert ca.humanize_title(original, "newsletter") == original
 
     def test_prompt_forbids_fabrication_and_lists_detected_tells(self, monkeypatch):
         monkeypatch.setenv("HUMANIZE_ENABLED", "on")

--- a/tests/unit/utilities/ai/test_humanize.py
+++ b/tests/unit/utilities/ai/test_humanize.py
@@ -187,6 +187,125 @@ class TestHumanizeText:
         assert "leverage" in system and "tapestry" in system
 
 
+class TestFindTitleSlopWords:
+    def test_detects_hype_and_tier1_words(self):
+        hits = ca.find_title_slop_words(
+            "7 Game-Changing AI Tactics for Explosive LinkedIn Growth")
+        assert set(hits) >= {"game-changing", "explosive"}
+        assert "unlock" in ca.find_title_slop_words("Unlock the Ultimate Secret")
+        assert "ultimate" in ca.find_title_slop_words("Unlock the Ultimate Secret")
+
+    def test_case_insensitive_and_deduped(self):
+        assert ca.find_title_slop_words("Explosive. EXPLOSIVE growth") == ["explosive"]
+
+    def test_clean_headline_has_no_hits(self):
+        assert ca.find_title_slop_words("What our best buyers actually read") == []
+
+    def test_empty_input(self):
+        assert ca.find_title_slop_words("") == []
+        assert ca.find_title_slop_words(None) == []
+
+
+class TestHumanizeTitle:
+    def test_slopy_title_in_dehyped_title_out(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        slop = "7 Game-Changing AI Tactics for Explosive LinkedIn Growth"
+        clean = "The AI tactics that actually moved our LinkedIn numbers"
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply(clean)):
+            out = ca.humanize_title(slop, "newsletter")
+        assert out == clean
+        assert ca.find_title_slop_words(out) == []
+
+    def test_disabled_returns_byte_identical(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "off")
+        slop = "Unlock Explosive Growth With These Game-Changing Tactics"
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm") as m:
+            assert ca.humanize_title(slop, "newsletter") == slop
+            m.assert_not_called()
+
+    def test_per_type_toggle_disables_newsletter_titles(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        monkeypatch.setenv("HUMANIZE_NEWSLETTER_ENABLED", "off")
+        slop = "Unlock Explosive Growth With These Game-Changing Tactics"
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm") as m:
+            assert ca.humanize_title(slop, "newsletter") == slop
+            m.assert_not_called()
+
+    def test_empty_input_is_returned_unchanged(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm") as m:
+            assert ca.humanize_title("", "newsletter") == ""
+            assert ca.humanize_title(None, "newsletter") is None
+            m.assert_not_called()
+
+    def test_reply_is_coerced_back_into_one_headline(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        messy = 'Title: "The AI tactics that actually moved our numbers."\n\n(kept the hook)'
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply(messy)):
+            out = ca.humanize_title("Unlock Explosive Growth Today With AI", "newsletter")
+        assert out == "The AI tactics that actually moved our numbers"
+
+    def test_em_dashes_are_stripped_from_the_headline(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_reply("Buyers ignored our best work — here is what changed")):
+            out = ca.humanize_title("Why Impressive AI Content Repels Your Best Buyers", "newsletter")
+        assert ca.count_em_dashes(out) == 0
+        assert out == "Buyers ignored our best work, here is what changed"
+
+    def test_fails_open_on_llm_error(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        original = "Why Impressive AI Content Repels Your Best Buyers"
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", side_effect=RuntimeError("proxy down")):
+            assert ca.humanize_title(original, "newsletter") == original
+
+    def test_fails_open_on_empty_or_fragment_reply(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        original = "Why Impressive AI Content Repels Your Best Buyers"
+        for reply in ("", "   ", "AI"):
+            with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply(reply)):
+                assert ca.humanize_title(original, "newsletter") == original
+
+    def test_fails_open_when_reply_is_prose_not_a_headline(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        original = "Why Impressive AI Content Repels Your Best Buyers"
+        prose = ("Here is a rewritten headline for you, and I kept the hook while removing the hype "
+                 "words you asked me to remove from the original draft headline.")
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply(prose)):
+            assert ca.humanize_title(original, "newsletter") == original
+
+    def test_fails_open_when_rewrite_is_slopier(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        original = "How we rebuilt our newsletter open rates"
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_reply("Unlock Explosive Open Rates")):
+            assert ca.humanize_title(original, "newsletter") == original
+
+    def test_max_chars_budget_keeps_original_when_exceeded(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        original = "A" * 120
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply("B" * 60)):
+            assert ca.humanize_title(original, "newsletter", max_chars=40) == original
+
+    def test_prompt_forbids_fabrication_and_lists_detected_tells(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        captured = {}
+
+        def _fake(**kwargs):
+            captured["messages"] = kwargs["messages"]
+            return _llm_reply("The AI tactics that actually moved our numbers")
+
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", side_effect=_fake):
+            ca.humanize_title("7 Game-Changing Tactics to Unlock Explosive Growth", "newsletter",
+                              profile_synthesis="Ran a 12-person agency for 8 years.")
+        system = captured["messages"][0]["content"]
+        assert "NEVER invent facts" in system
+        assert "Ran a 12-person agency" in system
+        for tell in ("game-changing", "unlock", "explosive"):
+            assert tell in system
+        assert "at most 255 characters" in system
+
+
 class TestGeneratorsRouteThroughHumanize:
     """Acceptance: all four content types run through the humanization pass before review. Each test
     turns the pass ON, spies on the wired humanize_text, and asserts the generator's output is the
@@ -243,6 +362,52 @@ class TestGeneratorsRouteThroughHumanize:
         assert edition is not None
         assert "HUMANIZED[newsletter]" in edition["body"]
         h.assert_called_once()
+
+    def test_newsletter_title_routes_through_title_dehype(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        from cqc_lem.utilities.ai import ai_helper
+        seen = {}
+
+        def _spy(title, content_type="post", **kw):
+            seen["content_type"] = content_type
+            seen["title"] = title
+            return "The AI tactics that actually moved our numbers"
+
+        edition_json = ('{"title": "7 Game-Changing AI Tactics for Explosive Growth", '
+                        '"subtitle": "S", "body": "raw newsletter body"}')
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply(edition_json)), \
+             patch("cqc_lem.utilities.ai.ai_helper._humanize_text", side_effect=lambda t, **kw: t), \
+             patch("cqc_lem.utilities.ai.ai_helper._humanize_title", side_effect=_spy):
+            edition = ai_helper.generate_newsletter_edition(self._profile(), topic="x")
+        assert edition is not None
+        assert edition["title"] == "The AI tactics that actually moved our numbers"
+        assert seen["content_type"] == "newsletter"
+        assert seen["title"] == "7 Game-Changing AI Tactics for Explosive Growth"
+
+    def test_newsletter_fallback_title_routes_through_title_dehype(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "on")
+        from cqc_lem.utilities.ai import ai_helper
+        # Non-JSON reply -> the fallback path (first line = title, remainder = body).
+        raw = "Unlock Explosive Growth With AI\n\nThe body of the edition goes here."
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply(raw)), \
+             patch("cqc_lem.utilities.ai.ai_helper._humanize_text", side_effect=lambda t, **kw: t), \
+             patch("cqc_lem.utilities.ai.ai_helper._humanize_title",
+                   side_effect=lambda t, content_type="post", **kw: f"TITLE[{content_type}]"):
+            edition = ai_helper.generate_newsletter_edition(self._profile(), topic="x")
+        assert edition is not None
+        assert edition["title"] == "TITLE[newsletter]"
+
+    def test_newsletter_title_unchanged_when_humanize_disabled(self, monkeypatch):
+        monkeypatch.setenv("HUMANIZE_ENABLED", "off")
+        from cqc_lem.utilities.ai import ai_helper
+        raw_title = "7 Game-Changing AI Tactics for Explosive Growth"
+        edition_json = ('{"title": "' + raw_title + '", "subtitle": "S", '
+                        '"body": "raw newsletter body"}')
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_reply(edition_json)):
+            edition = ai_helper.generate_newsletter_edition(self._profile(), topic="x")
+        assert edition is not None
+        assert edition["title"] == raw_title
+        assert edition["body"] == "raw newsletter body"
 
     def test_dm_builder_routes_through(self, monkeypatch):
         monkeypatch.setenv("HUMANIZE_ENABLED", "on")


### PR DESCRIPTION
## What & why

Newsletter **titles** bypassed the humanization pass — `generate_newsletter_edition` humanized only the body, so editions still shipped headlines like *"7 Game-Changing AI Tactics for Explosive LinkedIn Growth"* / *"Why Impressive AI Content Repels Your Best Buyers"*.

A full READER-mode prose rewrite is the wrong tool for a headline (it flattens the hook and costs the open rate), so titles get a **title-appropriate de-hype** instead:

- **`humanize_title()`** (`utilities/ai/content_alignment.py`) — LLM pass on `lem-simple` that strips tier-1 wordbank hits, hype superlatives, and clickbait scaffolds ("7 X That Will…", "The Ultimate Guide to", "Here's Why") while keeping ONE genuine hook, staying a single ≤255-char headline (no trailing period, no quotes, no em dashes, no emoji/ALL-CAPS).
- **`find_title_slop_words()`** — deterministic, testable headline audit: tier-1 `AI_TELL_WORDS` plus a new headline-only `TITLE_HYPE_WORDS` lexicon. Steers the prompt and gates the result.
- **Wired into both title paths** of `generate_newsletter_edition` (primary JSON + non-JSON fallback), before `normalize_public_text(...)[:255]`. The fallback path now also normalizes, matching the primary path.

Reuses the existing toggles and fail-open contract — no parallel helper:

- Gated by `humanize_enabled("newsletter")`, i.e. `HUMANIZE_ENABLED` + `HUMANIZE_NEWSLETTER_ENABLED`. With `HUMANIZE_ENABLED=off` the prior title behavior is byte-identical and no LLM call is made.
- **Fails open** (keeps the original title) on: disabled, empty input, LLM error, a reply that collapsed to a fragment, a reply that grew past the draft's own length / `max_chars` (that's prose or an explanation, not a headline), or a rewrite carrying **more** hype/AI tells than the draft.
- Never fabricates: the prompt forbids inventing numbers/names/claims; real specifics come only from the draft or the author's `profile_synthesis`.

## Testing notes

`tests/unit/utilities/ai/test_humanize.py` — 3 new classes/blocks:

- `TestFindTitleSlopWords` — hype + tier-1 detection, case-insensitive/deduped, clean headline has no hits.
- `TestHumanizeTitle` — slop-y title in → de-hyped title out; master + per-type toggle off returns byte-identical (no LLM call); messy reply coerced back to one headline (`Title:` label, wrapping quotes, trailing period, extra lines); em dashes stripped; fail-open on error / empty / fragment / prose / slopier rewrite / over-budget; prompt asserts the no-fabrication contract, the author background, and the detected tells.
- Generator wiring — primary JSON path, non-JSON fallback path, and `HUMANIZE_ENABLED=off` end-to-end.

Full unit suite: **2846 passed**.

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)