### PR TITLE
feat(poster): publish native document/PDF posts (closes #390)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,8 @@ LI_CLIENT_SECRET=your_linkedin_client_secret
 # LI_REDIRECT_URL is auto-overridden by NGROK_CUSTOM_DOMAIN when set (see env_constants.py)
 LI_REDIRECT_URL=https://your.domain.com/auth/linkedin/callback
 LI_STATE_SALT=your_state_salt_string
-LI_API_VERSION=202501
+# LinkedIn retires versioned-API versions ~a year after issue — bump annually or /rest/* calls 426
+LI_API_VERSION=202606
 LI_USERINFO_RESOURCE=/userinfo
 LI_POSTS_RESOURCE=/posts
 

--- a/compose/local/database/migrations/V20260723234736__add_document_post_type.sql
+++ b/compose/local/database/migrations/V20260723234736__add_document_post_type.sql
@@ -2,4 +2,7 @@
 -- Document posts reuse the carousel slide pipeline: slides are rendered to PNGs and
 -- bundled into a single PDF at publish time, so no new asset column is needed —
 -- carousel_slides carries the rendered slides for both types.
+-- MySQL stores ENUM values by ordinal, so the three existing members are repeated in their
+-- original setup.sql order ('carousel','text','video') and 'document' is appended LAST —
+-- existing rows keep their indexes and are not remapped.
 ALTER TABLE posts MODIFY COLUMN post_type ENUM('carousel', 'text', 'video', 'document') NOT NULL;

--- a/compose/local/database/migrations/V20260723234736__add_document_post_type.sql
+++ b/compose/local/database/migrations/V20260723234736__add_document_post_type.sql
@@ -1,0 +1,5 @@
+-- Native document/PDF posts (issue #390 — 2026's highest-reach format, ~6.6–7%).
+-- Document posts reuse the carousel slide pipeline: slides are rendered to PNGs and
+-- bundled into a single PDF at publish time, so no new asset column is needed —
+-- carousel_slides carries the rendered slides for both types.
+ALTER TABLE posts MODIFY COLUMN post_type ENUM('carousel', 'text', 'video', 'document') NOT NULL;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -944,7 +944,7 @@ def get_posts_for_email(
     sort_order: str = Query(default='asc', pattern='^(asc|desc)$'),
     sort_by: str = Query(default='scheduled_time', pattern='^(scheduled_time|status|post_type|id)$'),
     status_filter: Optional[str] = Query(default=None),
-    post_type_filter: Optional[str] = Query(default=None, pattern='^(text|video|carousel)$'),
+    post_type_filter: Optional[str] = Query(default=None, pattern='^(text|video|carousel|document)$'),
     search: Optional[str] = Query(default=None, max_length=500),
 ) -> ResponseModel:
     if not email:
@@ -2563,7 +2563,8 @@ def admin_regenerate_carousel(
     _require_admin(x_admin_secret)
 
     post_type = get_post_type(request.post_id)
-    if post_type != PostType.CAROUSEL:
+    # Document posts are carousels published as a native PDF — same slide regeneration path.
+    if post_type not in (PostType.CAROUSEL, PostType.DOCUMENT):
         raise HTTPException(status_code=404, detail="Post not found or not a carousel post")
 
     stage = get_post_buyer_stage(request.post_id) or "awareness"

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2917,13 +2917,18 @@ def post_to_linkedin(self, user_id: int, post_id: int):
         else:
             urn = share_carousel_on_linkedin(user_id, content, slides)
         if not urn:
+            # Only a missing/empty slide list is definitively an asset problem; a publish that
+            # returned no URN could equally be missing credentials or an API failure, so don't
+            # tell ops to go fix images when the deck may have been fine.
+            reason = ("no real slide images" if not slides
+                      else "publish returned no URN (check slide images, LinkedIn credentials and API logs)")
             update_db_post_status(post_id, PostStatus.ERROR)
-            log_error(f"{label} has no real slide images — flagged 'error' for manual fix",
+            log_error(f"{label} not posted: {reason} — flagged 'error' for manual fix",
                       user_id=user_id, post_id=post_id, action_type="post", api_provider="linkedin")
             insert_new_log(user_id=user_id, action_type=LogActionType.POST, result=LogResultType.FAILURE,
                            post_id=post_id,
-                           message=f"{label} not posted: no real slide images. Status set to 'error'.")
-            return f"Post {post_id} flagged 'error' — {label.lower()} had no usable images"
+                           message=f"{label} not posted: {reason}. Status set to 'error'.")
+            return f"Post {post_id} flagged 'error' — {label.lower()} not posted: {reason}"
     elif post_type == PostType.VIDEO:
         video_url = get_post_video_url(post_id)
         if video_url:

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -37,7 +37,7 @@ from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
     load_profile_for_user
 from cqc_lem.utilities.linkedin.poster import share_on_linkedin, share_carousel_on_linkedin, \
-    comment_on_linkedin_post, object_urn_from_post_url
+    share_document_on_linkedin, comment_on_linkedin_post, object_urn_from_post_url
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited, _redis_client
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text
@@ -2903,20 +2903,27 @@ def post_to_linkedin(self, user_id: int, post_id: int):
     post_type = get_post_type(post_id)
     myprint(f"Post type: {post_type}")
 
-    if post_type == PostType.CAROUSEL:
+    if post_type in (PostType.CAROUSEL, PostType.DOCUMENT):
         slides = get_carousel_slides(post_id)
-        myprint(f"Carousel slides ({len(slides)}): {slides}")
-        # No slides, or no real per-slide images → don't post a placeholder carousel.
+        label = "Document" if post_type == PostType.DOCUMENT else "Carousel"
+        myprint(f"{label} slides ({len(slides)}): {slides}")
+        # No slides, or no real per-slide images → don't post a placeholder deck.
         # Flag the post 'error' so it surfaces for manual/dev fix instead of failing silently.
-        urn = share_carousel_on_linkedin(user_id, content, slides) if slides else None
+        if not slides:
+            urn = None
+        elif post_type == PostType.DOCUMENT:
+            # Native document/PDF: the same slides bundled into one swipeable deck.
+            urn = share_document_on_linkedin(user_id, content, slides, post_id=post_id)
+        else:
+            urn = share_carousel_on_linkedin(user_id, content, slides)
         if not urn:
             update_db_post_status(post_id, PostStatus.ERROR)
-            log_error("Carousel has no real slide images — flagged 'error' for manual fix",
+            log_error(f"{label} has no real slide images — flagged 'error' for manual fix",
                       user_id=user_id, post_id=post_id, action_type="post", api_provider="linkedin")
             insert_new_log(user_id=user_id, action_type=LogActionType.POST, result=LogResultType.FAILURE,
                            post_id=post_id,
-                           message="Carousel not posted: no real slide images. Status set to 'error'.")
-            return f"Post {post_id} flagged 'error' — carousel had no usable images"
+                           message=f"{label} not posted: no real slide images. Status set to 'error'.")
+            return f"Post {post_id} flagged 'error' — {label.lower()} had no usable images"
     elif post_type == PostType.VIDEO:
         video_url = get_post_video_url(post_id)
         if video_url:

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -47,6 +47,11 @@ from cqc_lem.utilities.utils import get_best_posting_time, get_post_time, create
 from requests.adapters import HTTPAdapter
 from urllib3 import Retry
 
+# Post types the 30-day plan balances across. Native documents (PDF decks) are 2026's
+# highest-reach format, so they get an equal share alongside text/carousel/video.
+PLANNED_POST_TYPES = [PostType.CAROUSEL.value, PostType.TEXT.value,
+                      PostType.VIDEO.value, PostType.DOCUMENT.value]
+
 
 @shared_task.task
 def auto_generate_content():
@@ -117,12 +122,12 @@ def plan_content_for_user(self, user_id: int):
 
     # myprint(f"Target Posts: {target_posts}")
 
-    needed_posts = {post_type: target_posts // 3 for post_type in ['carousel', 'text', 'video']}
+    needed_posts = {post_type: target_posts // len(PLANNED_POST_TYPES) for post_type in PLANNED_POST_TYPES}
 
     # myprint(f"Needed Posts: {needed_posts}")
 
     # Ensure all post types are present in current_counts and percentages
-    for post_type in ['carousel', 'text', 'video']:
+    for post_type in PLANNED_POST_TYPES:
         if post_type not in percentages:
             percentages[post_type] = 0.0
 
@@ -228,9 +233,11 @@ def create_content(user_id: int, post_type: str, stage: str, post_id: int = None
     video_url = None
     content = None
 
-    if post_type == "video":
+    if post_type == PostType.VIDEO.value:
         content, video_url = create_video_content(user_id, stage, post_id=post_id)
-    elif post_type == "carousel":
+    elif post_type in (PostType.CAROUSEL.value, PostType.DOCUMENT.value):
+        # A document post IS a carousel deck — same generated slides, published as a
+        # native PDF instead of a multi-image share (see share_document_on_linkedin).
         content = create_carousel_content(user_id, stage, post_id)
     else:
         content = create_text_post(user_id, stage, post_id=post_id)
@@ -337,7 +344,7 @@ def _post_missing_required_asset(post_id: int, post_type, video_url) -> bool:
     pt = str(post_type).lower()
     if pt == PostType.VIDEO.value:
         return not video_url
-    if pt == PostType.CAROUSEL.value:
+    if pt in (PostType.CAROUSEL.value, PostType.DOCUMENT.value):
         from cqc_lem.utilities.db import get_post_carousel_slides
         slides = get_post_carousel_slides(post_id)
         # Missing if empty OR only text titles (no real slide images generated yet).

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -668,7 +668,7 @@ def auto_backfill_missing_assets():
         if pt == 'video':
             regenerate_post_video_task.apply_async(kwargs={'post_id': post_id})
             queued += 1
-        elif pt == 'carousel':
+        elif pt in ('carousel', 'document'):  # documents share the carousel slide pipeline
             regenerate_post_carousel_task.apply_async(kwargs={'post_id': post_id})
             queued += 1
         log_warning("Backfilling missing media asset for unposted post",

--- a/src/cqc_lem/streamlit/pages/3_Review_Schedule.py
+++ b/src/cqc_lem/streamlit/pages/3_Review_Schedule.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytz
 import requests
 import streamlit as st
-from cqc_lem.utilities.db import PostStatus
+from cqc_lem.utilities.db import PostStatus, PostType
 from cqc_lem.utilities.env_constants import LINKEDIN_PREVIEW_URL, CODE_TRACING, TZ, API_URL_FINAL
 from cqc_lem.utilities.jaeger_tracer_helper import get_jaeger_tracer
 from st_aggrid import AgGrid, GridOptionsBuilder, DataReturnMode, GridUpdateMode
@@ -104,7 +104,7 @@ with (tracer.start_as_current_span("review_schedule") if tracer else nullcontext
 
         # Configure post_type column as a dropdown with enum values
         gb.configure_column("post_type", editable=True, cellEditor='agSelectCellEditor',
-                            cellEditorParams={'values': ['text', 'carousel', 'video']})
+                            cellEditorParams={'values': [post_type.value for post_type in PostType]})
         # Configure status column as a dropdown with custom values
         gb.configure_column("status", editable_wheel=True, cellEditor='agSelectCellEditor',
                             cellEditorParams={'values': [status.value for status in PostStatus]})

--- a/src/cqc_lem/ui/src/components/LinkedInPostPreview.tsx
+++ b/src/cqc_lem/ui/src/components/LinkedInPostPreview.tsx
@@ -114,7 +114,9 @@ export default function LinkedInPostPreview({
   const hasMore = lines.length > 3 || content.length > 300
 
   const showVideo = (postType === 'video' || !!videoUrl) && !!videoUrl
-  const showCarousel = !showVideo && postType === 'carousel' && !!slides && slides.length > 0
+  // A native document post is the same slide deck as a carousel, published as one PDF.
+  const showCarousel = !showVideo && (postType === 'carousel' || postType === 'document')
+    && !!slides && slides.length > 0
   const showImage = !showVideo && !showCarousel && !!mediaUrl
 
   return (

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -31,13 +31,18 @@ const STATUSES: { label: string; value: Status }[] = [
   { label: 'REJECTED', value: 'rejected' },
 ]
 
-type PostTypeFilter = 'ALL' | 'text' | 'video' | 'carousel'
+type PostTypeFilter = 'ALL' | 'text' | 'video' | 'carousel' | 'document'
 const POST_TYPE_FILTERS: { label: string; value: PostTypeFilter }[] = [
   { label: 'All types', value: 'ALL' },
   { label: 'Text', value: 'text' },
   { label: 'Video', value: 'video' },
   { label: 'Carousel', value: 'carousel' },
+  { label: 'Document', value: 'document' },
 ]
+
+// Carousels and native documents share the same generated slide deck — a document post
+// is published as a single PDF instead of a multi-image share.
+const isDeckType = (postType: string) => postType === 'carousel' || postType === 'document'
 
 type SortBy = 'scheduled_time' | 'status' | 'post_type' | 'id'
 const SORT_BY_OPTIONS: { label: string; value: SortBy }[] = [
@@ -569,7 +574,7 @@ export default function ContentStudio() {
                     </div>
                   </div>
                   <p className="text-sm text-gray-700 line-clamp-2">{post.content}</p>
-                  {post.post_type === 'carousel' && post.carousel_slides && (
+                  {isDeckType(post.post_type) && post.carousel_slides && (
                     <p className="text-xs text-gray-400 mt-1">{post.carousel_slides.length} slides</p>
                   )}
                 </div>
@@ -670,12 +675,12 @@ export default function ContentStudio() {
                         ...editingPost,
                         post_type: newType,
                         video_url: newType === 'video' ? editingPost.video_url : null,
-                        carousel_slides: newType === 'carousel' ? editingPost.carousel_slides : null,
+                        carousel_slides: isDeckType(newType) ? editingPost.carousel_slides : null,
                       })
                     }}
                     className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                   >
-                    {['text', 'video', 'carousel'].map((t) => (
+                    {['text', 'video', 'carousel', 'document'].map((t) => (
                       <option key={t} value={t}>{t.toUpperCase()}</option>
                     ))}
                   </select>
@@ -694,7 +699,7 @@ export default function ContentStudio() {
                   </div>
                 )}
 
-                {editingPost.post_type === 'carousel' && editingPost.carousel_slides && (
+                {isDeckType(editingPost.post_type) && editingPost.carousel_slides && (
                   <div>
                     <label className="block text-xs font-medium text-gray-600 mb-1">
                       Slides ({editingPost.carousel_slides.length})

--- a/src/cqc_lem/utilities/carousel_creator.py
+++ b/src/cqc_lem/utilities/carousel_creator.py
@@ -2343,6 +2343,44 @@ def create_carousel_slide_images(
     return image_paths
 
 
+def create_carousel_pdf(image_paths: list[str], post_id: int,
+                        output_dir: Optional[str] = None) -> Optional[str]:
+    """Bundle already-rendered slide images into ONE multi-page PDF (a native LinkedIn document).
+
+    LinkedIn's document/PDF format is a different feed object than a multi-image post —
+    it renders as a swipeable, downloadable deck. The slides are the same 1080x1080 PNGs
+    ``create_carousel_slide_images`` produces, so a document post is a carousel published
+    through the document path.
+
+    Returns the absolute PDF path, or None when no slide image could be read (never a
+    partial/placeholder deck — the caller flags the post 'error' instead).
+    """
+    from PIL import Image
+    from cqc_lem.utilities.logger import log_warning
+
+    pages = []
+    for path in image_paths or []:
+        try:
+            with Image.open(path) as img:
+                pages.append(img.convert("RGB"))
+        except Exception as e:
+            log_warning("Could not read carousel slide for PDF", exc=e, post_id=post_id)
+            return None
+
+    if not pages:
+        return None
+
+    if output_dir is None:
+        current_dir = os.path.dirname(__file__)
+        assets_root = os.path.join(current_dir, "..", "assets", "images", "carousel", str(post_id))
+        output_dir = os.path.realpath(assets_root)
+    os.makedirs(output_dir, exist_ok=True)
+
+    pdf_path = os.path.join(output_dir, f"document_{post_id}.pdf")
+    pages[0].save(pdf_path, "PDF", save_all=True, append_images=pages[1:], resolution=150.0)
+    return pdf_path
+
+
 if __name__ == "__main__":
     # Debug
     # debug_master_slide_placeholders_and_text()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -64,6 +64,7 @@ class PostType(StrEnum):
     TEXT = 'text'
     CAROUSEL = 'carousel'
     VIDEO = 'video'
+    DOCUMENT = 'document'  # native PDF/document post — highest-reach 2026 format
 
 
 class PostStatus(StrEnum):
@@ -4302,7 +4303,7 @@ def get_unposted_posts_missing_assets(within_days: int = 14) -> list:
               AND scheduled_time <= NOW() + INTERVAL %s DAY
               AND (
                     (post_type = 'video'    AND (video_url IS NULL OR video_url = ''))
-                 OR (post_type = 'carousel' AND (
+                 OR (post_type IN ('carousel', 'document') AND (
                         carousel_slides IS NULL OR carousel_slides = '' OR carousel_slides = '[]'
                         OR (carousel_slides NOT LIKE '%%http%%'
                             AND carousel_slides NOT LIKE '%%/assets%%'

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -33,7 +33,10 @@ LI_CLIENT_ID = get_constant_from_env('LI_CLIENT_ID')
 LI_CLIENT_SECRET = get_constant_from_env('LI_CLIENT_SECRET')
 LI_REDIRECT_URL = get_constant_from_env('LI_REDIRECT_URL')
 LI_STATE_SALT = get_constant_from_env('LI_STATE_SALT')
-LI_API_VERSION = get_constant_from_env('LI_API_VERSION', default_value='202501')
+# LinkedIn retires versioned-API versions ~a year after issue; a retired value makes every
+# /rest/* call fail 426 NONEXISTENT_VERSION. Bump this — AND LI_API_VERSION in the deployment
+# .env, which overrides it — at least annually. See upload_document() in linkedin/poster.py.
+LI_API_VERSION = get_constant_from_env('LI_API_VERSION', default_value='202606')
 PEXELS_API_KEY = get_constant_from_env('PEXELS_API_KEY')
 PERPLEXITY_API_KEY = get_constant_from_env('PERPLEXITY_API_KEY')
 HF_TOKEN = get_constant_from_env('HF_TOKEN')

--- a/src/cqc_lem/utilities/linkedin/poster.py
+++ b/src/cqc_lem/utilities/linkedin/poster.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shutil
 import tempfile
 import uuid
 from typing import List, Optional, Annotated, Dict
@@ -455,6 +456,9 @@ def share_document_on_linkedin(user_id: int, content: str, slides: list[str],
 
     local_paths: List[str] = []
     tmp_paths: List[str] = []
+    # Without a post_id there is no per-post assets dir to write the PDF into, so it goes to
+    # a temp dir that we own and delete once the upload is done (or has failed).
+    tmp_pdf_dir: Optional[str] = None
     try:
         for slide in slides or []:
             if _is_image_url(slide):
@@ -472,48 +476,54 @@ def share_document_on_linkedin(user_id: int, content: str, slides: list[str],
             log_warning("Document post has no slides — not posting", user_id=user_id, post_id=post_id)
             return None
 
-        # Without a post_id there is no per-post assets dir to write into — use a temp dir.
+        if post_id is None:
+            tmp_pdf_dir = tempfile.mkdtemp()
         pdf_path = create_carousel_pdf(
             local_paths,
             post_id if post_id is not None else user_id,
-            output_dir=None if post_id is not None else tempfile.mkdtemp(),
+            output_dir=tmp_pdf_dir,
         )
+
+        if not pdf_path:
+            log_warning("Could not build document PDF from slides", user_id=user_id, post_id=post_id)
+            return None
+
+        deck_title = title or _document_title(content)
+
+        try:
+            document_urn = upload_document(access_token, linked_sub_id, pdf_path)
+            urn = _create_document_post_versioned(access_token, f"urn:li:person:{linked_sub_id}",
+                                                  content, document_urn, deck_title)
+        except Exception as e:
+            # Nothing is published until /rest/posts succeeds, so retrying on the legacy path
+            # cannot duplicate the post.
+            log_warning("Versioned Documents API failed — falling back to legacy ugcPost document",
+                        exc=e, user_id=user_id, post_id=post_id, api_provider="linkedin")
+            try:
+                urn = _create_document_post_legacy(access_token, linked_sub_id, content, pdf_path, deck_title)
+            except Exception as legacy_error:
+                log_error("Document post failed on both the versioned and legacy paths",
+                          exc=legacy_error, user_id=user_id, post_id=post_id, api_provider="linkedin")
+                return None
+
+        if not urn:
+            log_error("Document post returned no URN", user_id=user_id, post_id=post_id, api_provider="linkedin")
+            return None
+
+        log_info(f"Document shared on LinkedIn: https://www.linkedin.com/feed/update/{urn}",
+                 user_id=user_id, post_id=post_id, api_provider="linkedin")
+        return urn
     finally:
+        # Best-effort scratch cleanup: the post is already published (or already failed) at this
+        # point, so a leftover temp file must never change the outcome — log it and move on.
         for path in tmp_paths:
             try:
                 os.remove(path)
-            except OSError:
-                pass
-
-    if not pdf_path:
-        log_warning("Could not build document PDF from slides", user_id=user_id, post_id=post_id)
-        return None
-
-    deck_title = title or _document_title(content)
-
-    try:
-        document_urn = upload_document(access_token, linked_sub_id, pdf_path)
-        urn = _create_document_post_versioned(access_token, f"urn:li:person:{linked_sub_id}",
-                                              content, document_urn, deck_title)
-    except Exception as e:
-        # Nothing is published until /rest/posts succeeds, so retrying on the legacy path
-        # cannot duplicate the post.
-        log_warning("Versioned Documents API failed — falling back to legacy ugcPost document",
-                    exc=e, user_id=user_id, post_id=post_id, api_provider="linkedin")
-        try:
-            urn = _create_document_post_legacy(access_token, linked_sub_id, content, pdf_path, deck_title)
-        except Exception as legacy_error:
-            log_error("Document post failed on both the versioned and legacy paths",
-                      exc=legacy_error, user_id=user_id, post_id=post_id, api_provider="linkedin")
-            return None
-
-    if not urn:
-        log_error("Document post returned no URN", user_id=user_id, post_id=post_id, api_provider="linkedin")
-        return None
-
-    log_info(f"Document shared on LinkedIn: https://www.linkedin.com/feed/update/{urn}",
-             user_id=user_id, post_id=post_id, api_provider="linkedin")
-    return urn
+            except OSError as e:
+                log_warning("Could not remove temporary document slide", exc=e,
+                            user_id=user_id, post_id=post_id)
+        if tmp_pdf_dir:
+            shutil.rmtree(tmp_pdf_dir, ignore_errors=True)
 
 
 # --- socialActions comments API -------------------------------------------------

--- a/src/cqc_lem/utilities/linkedin/poster.py
+++ b/src/cqc_lem/utilities/linkedin/poster.py
@@ -334,6 +334,13 @@ def upload_document(access_token: str, owner_sub_id: str, document_path: str) ->
         json={"initializeUploadRequest": {"owner": f"urn:li:person:{owner_sub_id}"}},
         timeout=30,
     )
+    # A retired LinkedIn-Version answers 426 NONEXISTENT_VERSION on every versioned call, which
+    # would otherwise look like "app not provisioned" and silently demote every document post to
+    # the legacy path. Name the real cause so it's a config fix, not a debugging session.
+    if init_response.status_code == 426:
+        log_error(f"LinkedIn API version {LI_API_VERSION} is retired — set LI_API_VERSION to a "
+                  f"current version to publish native documents",
+                  api_provider="linkedin", http_status=426)
     init_response.raise_for_status()
 
     value = init_response.json().get("value", {})

--- a/src/cqc_lem/utilities/linkedin/poster.py
+++ b/src/cqc_lem/utilities/linkedin/poster.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import tempfile
 import uuid
 from typing import List, Optional, Annotated, Dict
 
@@ -10,13 +11,14 @@ from pydantic import BaseModel, Field
 from pydantic.types import StringConstraints
 
 from cqc_lem.utilities.db import get_user_linked_sub_id, get_user_access_token
-from cqc_lem.utilities.logger import myprint
+from cqc_lem.utilities.env_constants import LI_API_VERSION
+from cqc_lem.utilities.logger import myprint, log_info, log_warning, log_error
 from cqc_lem.utilities.mime_type_helper import get_file_mime_type
 from cqc_lem.utilities.utils import get_file_extension_from_filepath
 
 # Define annotations for constrained strings
 ReadyStatus = Annotated[str, StringConstraints(pattern=r'^(READY)$')]
-ShareMediaCategory = Annotated[str, StringConstraints(pattern=r'^(NONE|ARTICLE|IMAGE|VIDEO)$')]
+ShareMediaCategory = Annotated[str, StringConstraints(pattern=r'^(NONE|ARTICLE|IMAGE|VIDEO|DOCUMENT)$')]
 NonEmptyString = Annotated[str, StringConstraints(min_length=1)]
 
 
@@ -298,6 +300,213 @@ def share_carousel_on_linkedin(user_id: int, content: str, slide_texts: list[str
     myprint(f"Carousel shared on LinkedIn: https://www.linkedin.com/feed/update/{urn}")
     return urn
 
+
+# --- native document (PDF) posts -----------------------------------------------
+# LinkedIn's document format is a DIFFERENT feed object than a multi-image share: it
+# renders as a swipeable, downloadable deck and is the highest-reach 2026 format. It is
+# published through the VERSIONED Documents API (/rest/documents + /rest/posts), not the
+# legacy multi-image ugcPost path used by share_carousel_on_linkedin. The legacy
+# assets/ugcPost DOCUMENT path is kept as a fallback for tokens whose app is not
+# provisioned for the versioned API.
+
+DOCUMENT_TITLE_MAX = 100
+
+
+def _document_title(content: str, fallback: str = "Document") -> str:
+    """Derive the in-feed deck title from the post body's first non-empty line."""
+    for line in (content or "").splitlines():
+        line = line.strip()
+        if line:
+            return line[:DOCUMENT_TITLE_MAX]
+    return fallback
+
+
+def upload_document(access_token: str, owner_sub_id: str, document_path: str) -> Optional[str]:
+    """Upload a PDF via the versioned Documents API. Returns the urn:li:document:... URN."""
+    init_response = requests.post(
+        "https://api.linkedin.com/rest/documents?action=initializeUpload",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "LinkedIn-Version": LI_API_VERSION,
+            "X-Restli-Protocol-Version": "2.0.0",
+        },
+        json={"initializeUploadRequest": {"owner": f"urn:li:person:{owner_sub_id}"}},
+        timeout=30,
+    )
+    init_response.raise_for_status()
+
+    value = init_response.json().get("value", {})
+    upload_url = value.get("uploadUrl")
+    document_urn = value.get("document")
+    if not upload_url or not document_urn:
+        raise ValueError(f"Documents API returned no upload URL/URN: {value}")
+
+    with open(document_path, "rb") as document_file:
+        document_bytes = document_file.read()
+
+    upload_response = requests.put(
+        upload_url,
+        headers={"Authorization": f"Bearer {access_token}", "Content-Type": "application/octet-stream"},
+        data=document_bytes,
+        timeout=120,
+    )
+    if upload_response.status_code not in (200, 201):
+        raise RuntimeError(f"Document upload failed with status {upload_response.status_code}")
+
+    log_info("Document uploaded to LinkedIn", api_provider="linkedin")
+    return document_urn
+
+
+def _create_document_post_versioned(access_token: str, author: str, content: str,
+                                    document_urn: str, title: str) -> Optional[str]:
+    """Publish the uploaded document through the versioned /rest/posts endpoint."""
+    response = requests.post(
+        "https://api.linkedin.com/rest/posts",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "LinkedIn-Version": LI_API_VERSION,
+            "X-Restli-Protocol-Version": "2.0.0",
+        },
+        json={
+            "author": author,
+            "commentary": content,
+            "visibility": "PUBLIC",
+            "distribution": {
+                "feedDistribution": "MAIN_FEED",
+                "targetEntities": [],
+                "thirdPartyDistributionChannels": [],
+            },
+            "content": {"media": {"title": title, "id": document_urn}},
+            "lifecycleState": "PUBLISHED",
+            "isReshareDisabledByAuthor": False,
+        },
+        timeout=30,
+    )
+    response.raise_for_status()
+
+    # The versioned API returns the new post's URN in the x-restli-id header; some
+    # responses echo it in the body instead.
+    urn = response.headers.get("x-restli-id")
+    if not urn:
+        try:
+            urn = response.json().get("id")
+        except ValueError:
+            urn = None
+    return urn
+
+
+def _create_document_post_legacy(access_token: str, owner_sub_id: str, content: str,
+                                 document_path: str, title: str) -> Optional[str]:
+    """Fallback: legacy assets upload + ugcPost with shareMediaCategory=DOCUMENT."""
+    asset_urn = upload_media(access_token, owner_sub_id, document_path, "document")
+
+    share_content = ShareContent(
+        shareCommentary={"text": content},
+        shareMediaCategory="DOCUMENT",
+        media=[ShareMedia(status="READY", media=asset_urn, title={"text": title}).model_dump()],
+    ).model_dump()
+
+    restli_client = _restli()
+    posts_create_response = restli_client.create(
+        resource_path="/ugcPosts",
+        entity={
+            "author": f"urn:li:person:{owner_sub_id}",
+            "lifecycleState": "PUBLISHED",
+            "specificContent": {
+                "com.linkedin.ugc.ShareContent": {
+                    **share_content
+                }
+            },
+            "visibility": {
+                "com.linkedin.ugc.MemberNetworkVisibility": "PUBLIC"
+            },
+        },
+        access_token=access_token,
+    )
+    return posts_create_response.entity_id
+
+
+def share_document_on_linkedin(user_id: int, content: str, slides: list[str],
+                               post_id: Optional[int] = None,
+                               title: Optional[str] = None) -> Optional[str]:
+    """Publish a NATIVE document post: the rendered carousel slides bundled into one PDF.
+
+    ``slides`` holds the same entries as a carousel post — absolute paths to slide PNGs or
+    asset URLs. Every slide must resolve to a real image; a partial deck is never posted
+    (the caller flags the post 'error' instead), matching share_carousel_on_linkedin.
+    """
+    from cqc_lem.utilities.carousel_creator import create_carousel_pdf
+
+    linked_sub_id = get_user_linked_sub_id(user_id)
+    access_token = get_user_access_token(user_id)
+
+    if not linked_sub_id or not access_token:
+        log_warning("No LinkedIn credentials found — cannot post document", user_id=user_id)
+        return None
+
+    local_paths: List[str] = []
+    tmp_paths: List[str] = []
+    try:
+        for slide in slides or []:
+            if _is_image_url(slide):
+                path = download_media(slide)
+                tmp_paths.append(path)
+            elif _is_local_image_path(slide) and os.path.isfile(slide):
+                path = slide
+            else:
+                log_warning("Document slide is not a real image — not posting",
+                            user_id=user_id, post_id=post_id)
+                return None
+            local_paths.append(path)
+
+        if not local_paths:
+            log_warning("Document post has no slides — not posting", user_id=user_id, post_id=post_id)
+            return None
+
+        # Without a post_id there is no per-post assets dir to write into — use a temp dir.
+        pdf_path = create_carousel_pdf(
+            local_paths,
+            post_id if post_id is not None else user_id,
+            output_dir=None if post_id is not None else tempfile.mkdtemp(),
+        )
+    finally:
+        for path in tmp_paths:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+    if not pdf_path:
+        log_warning("Could not build document PDF from slides", user_id=user_id, post_id=post_id)
+        return None
+
+    deck_title = title or _document_title(content)
+
+    try:
+        document_urn = upload_document(access_token, linked_sub_id, pdf_path)
+        urn = _create_document_post_versioned(access_token, f"urn:li:person:{linked_sub_id}",
+                                              content, document_urn, deck_title)
+    except Exception as e:
+        # Nothing is published until /rest/posts succeeds, so retrying on the legacy path
+        # cannot duplicate the post.
+        log_warning("Versioned Documents API failed — falling back to legacy ugcPost document",
+                    exc=e, user_id=user_id, post_id=post_id, api_provider="linkedin")
+        try:
+            urn = _create_document_post_legacy(access_token, linked_sub_id, content, pdf_path, deck_title)
+        except Exception as legacy_error:
+            log_error("Document post failed on both the versioned and legacy paths",
+                      exc=legacy_error, user_id=user_id, post_id=post_id, api_provider="linkedin")
+            return None
+
+    if not urn:
+        log_error("Document post returned no URN", user_id=user_id, post_id=post_id, api_provider="linkedin")
+        return None
+
+    log_info(f"Document shared on LinkedIn: https://www.linkedin.com/feed/update/{urn}",
+             user_id=user_id, post_id=post_id, api_provider="linkedin")
+    return urn
 
 
 # --- socialActions comments API -------------------------------------------------

--- a/tests/unit/app/test_document_posts.py
+++ b/tests/unit/app/test_document_posts.py
@@ -1,0 +1,111 @@
+"""Unit tests for native document posts in the publish + planning pipelines (issue #390)."""
+
+import pytest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+BASE_PATCHES = [
+    ("cqc_lem.app.run_automation.get_post_status", {"return_value": "approved"}),
+    ("cqc_lem.app.run_automation.get_user_password_pair_by_id", {"return_value": ("u@example.com", "pw")}),
+    ("cqc_lem.app.run_automation.get_post_content", {"return_value": "Post text"}),
+    ("cqc_lem.app.run_automation.insert_new_log", {}),
+    ("cqc_lem.app.run_automation.update_db_post_status", {}),
+    ("cqc_lem.app.run_automation.get_engagement_preferences", {"return_value": {"reply_check_mode": "event"}}),
+    ("cqc_lem.app.run_automation.sweep_reply_comments", {}),
+]
+
+
+@pytest.mark.unit
+class TestPostToLinkedinDocument:
+
+    def test_document_post_calls_share_document_on_linkedin(self):
+        from cqc_lem.utilities.db import PostType
+        from cqc_lem.app.run_automation import post_to_linkedin
+
+        slides = ["/assets/images/carousel/40/slide_01.png", "/assets/images/carousel/40/slide_02.png"]
+        with ExitStack() as stack:
+            for target, kwargs in BASE_PATCHES:
+                stack.enter_context(patch(target, **kwargs))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_post_type", return_value=PostType.DOCUMENT))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_carousel_slides", return_value=slides))
+            mock_document = stack.enter_context(
+                patch("cqc_lem.app.run_automation.share_document_on_linkedin", return_value="urn:li:share:40")
+            )
+            mock_carousel = stack.enter_context(patch("cqc_lem.app.run_automation.share_carousel_on_linkedin"))
+            mock_share = stack.enter_context(patch("cqc_lem.app.run_automation.share_on_linkedin"))
+
+            post_to_linkedin.run(1, 40)
+
+            mock_document.assert_called_once_with(1, "Post text", slides, post_id=40)
+            mock_carousel.assert_not_called()
+            mock_share.assert_not_called()
+
+    def test_document_post_without_slides_is_flagged_error(self):
+        from cqc_lem.utilities.db import PostType, PostStatus
+        from cqc_lem.app.run_automation import post_to_linkedin
+
+        with ExitStack() as stack:
+            for target, kwargs in BASE_PATCHES:
+                if target.endswith("update_db_post_status"):
+                    continue
+                stack.enter_context(patch(target, **kwargs))
+            mock_status = stack.enter_context(patch("cqc_lem.app.run_automation.update_db_post_status"))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_post_type", return_value=PostType.DOCUMENT))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_carousel_slides", return_value=[]))
+            mock_document = stack.enter_context(patch("cqc_lem.app.run_automation.share_document_on_linkedin"))
+
+            result = post_to_linkedin.run(1, 41)
+
+            mock_document.assert_not_called()
+            mock_status.assert_called_once_with(41, PostStatus.ERROR)
+            assert "error" in result
+
+    def test_document_publish_failure_is_flagged_error(self):
+        from cqc_lem.utilities.db import PostType, PostStatus
+        from cqc_lem.app.run_automation import post_to_linkedin
+
+        with ExitStack() as stack:
+            for target, kwargs in BASE_PATCHES:
+                if target.endswith("update_db_post_status"):
+                    continue
+                stack.enter_context(patch(target, **kwargs))
+            mock_status = stack.enter_context(patch("cqc_lem.app.run_automation.update_db_post_status"))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_post_type", return_value=PostType.DOCUMENT))
+            stack.enter_context(patch("cqc_lem.app.run_automation.get_carousel_slides", return_value=["/s1.png"]))
+            stack.enter_context(patch("cqc_lem.app.run_automation.share_document_on_linkedin", return_value=None))
+
+            post_to_linkedin.run(1, 42)
+
+            mock_status.assert_called_once_with(42, PostStatus.ERROR)
+
+
+@pytest.mark.unit
+class TestDocumentContentPlanning:
+
+    def test_document_posts_use_the_carousel_slide_pipeline(self):
+        from cqc_lem.app.run_content_plan import create_content
+
+        with patch("cqc_lem.app.run_content_plan.create_carousel_content",
+                   return_value="Deck caption") as mock_carousel:
+            content, video_url = create_content(user_id=1, post_type="document", stage="awareness", post_id=42)
+
+        assert content == "Deck caption"
+        assert video_url is None
+        mock_carousel.assert_called_once_with(1, "awareness", 42)
+
+    def test_document_is_balanced_alongside_the_other_types(self):
+        from cqc_lem.app.run_content_plan import PLANNED_POST_TYPES
+        from cqc_lem.utilities.db import PostType
+
+        assert PostType.DOCUMENT.value in PLANNED_POST_TYPES
+        assert set(PLANNED_POST_TYPES) == {t.value for t in PostType}
+
+    def test_document_without_real_slides_is_missing_its_asset(self):
+        from cqc_lem.app.run_content_plan import _post_missing_required_asset
+
+        with patch("cqc_lem.utilities.db.get_post_carousel_slides", return_value=["Just a title"]):
+            assert _post_missing_required_asset(42, "document", None) is True
+
+        with patch("cqc_lem.utilities.db.get_post_carousel_slides",
+                   return_value=["https://assets.example/slide_01.png"]):
+            assert _post_missing_required_asset(42, "document", None) is False

--- a/tests/unit/app/test_document_posts.py
+++ b/tests/unit/app/test_document_posts.py
@@ -59,24 +59,30 @@ class TestPostToLinkedinDocument:
             mock_document.assert_not_called()
             mock_status.assert_called_once_with(41, PostStatus.ERROR)
             assert "error" in result
+            assert "no real slide images" in result
 
-    def test_document_publish_failure_is_flagged_error(self):
+    def test_document_publish_failure_does_not_blame_the_slide_images(self):
+        """A None URN from a deck that HAD slides may be creds/API — don't send ops after images."""
         from cqc_lem.utilities.db import PostType, PostStatus
         from cqc_lem.app.run_automation import post_to_linkedin
 
         with ExitStack() as stack:
             for target, kwargs in BASE_PATCHES:
-                if target.endswith("update_db_post_status"):
+                if target.endswith(("update_db_post_status", "insert_new_log")):
                     continue
                 stack.enter_context(patch(target, **kwargs))
             mock_status = stack.enter_context(patch("cqc_lem.app.run_automation.update_db_post_status"))
+            mock_log = stack.enter_context(patch("cqc_lem.app.run_automation.insert_new_log"))
             stack.enter_context(patch("cqc_lem.app.run_automation.get_post_type", return_value=PostType.DOCUMENT))
             stack.enter_context(patch("cqc_lem.app.run_automation.get_carousel_slides", return_value=["/s1.png"]))
             stack.enter_context(patch("cqc_lem.app.run_automation.share_document_on_linkedin", return_value=None))
 
-            post_to_linkedin.run(1, 42)
+            result = post_to_linkedin.run(1, 42)
 
             mock_status.assert_called_once_with(42, PostStatus.ERROR)
+            assert "no real slide images" not in result
+            assert "no URN" in result
+            assert "no real slide images" not in mock_log.call_args[1]["message"]
 
 
 @pytest.mark.unit

--- a/tests/unit/app/test_run_content_plan.py
+++ b/tests/unit/app/test_run_content_plan.py
@@ -410,7 +410,7 @@ class TestPlanContentForUser:
         from cqc_lem.app.run_content_plan import plan_content_for_user
         plan_content_for_user.run(user_id=1)
         plan = mock_save.call_args.args[1]
-        valid_types = {"carousel", "text", "video"}
+        valid_types = {"carousel", "text", "video", "document"}
         for entry in plan:
             assert entry["post_type"] in valid_types
 

--- a/tests/unit/utilities/linkedin/test_poster_document.py
+++ b/tests/unit/utilities/linkedin/test_poster_document.py
@@ -1,0 +1,234 @@
+"""Unit tests for the native document (PDF) publish path — issue #390."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+@pytest.mark.unit
+class TestDocumentTitle:
+    def test_uses_first_non_empty_line(self):
+        from cqc_lem.utilities.linkedin.poster import _document_title
+
+        assert _document_title("\n\n5 lessons from 2026\n\nrest of the post") == "5 lessons from 2026"
+
+    def test_truncates_to_linkedin_max(self):
+        from cqc_lem.utilities.linkedin.poster import _document_title, DOCUMENT_TITLE_MAX
+
+        title = _document_title("x" * 300)
+        assert len(title) == DOCUMENT_TITLE_MAX
+
+    def test_falls_back_when_content_is_blank(self):
+        from cqc_lem.utilities.linkedin.poster import _document_title
+
+        assert _document_title("   \n  ") == "Document"
+        assert _document_title(None) == "Document"
+
+
+@pytest.mark.unit
+class TestUploadDocument:
+    def _init_response(self, value=None):
+        response = MagicMock()
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"value": value if value is not None else {
+            "uploadUrl": "https://upload.linkedin.example/doc",
+            "document": "urn:li:document:abc123",
+        }}
+        return response
+
+    def test_initializes_uploads_and_returns_document_urn(self, tmp_path):
+        from cqc_lem.utilities.linkedin.poster import upload_document
+
+        pdf = tmp_path / "deck.pdf"
+        pdf.write_bytes(b"%PDF-1.4 fake")
+
+        put_response = MagicMock(status_code=201)
+        with patch("requests.post", return_value=self._init_response()) as mock_post, \
+             patch("requests.put", return_value=put_response) as mock_put:
+            urn = upload_document("token", "sub-1", str(pdf))
+
+        assert urn == "urn:li:document:abc123"
+        assert "documents?action=initializeUpload" in mock_post.call_args[0][0]
+        assert mock_post.call_args.kwargs["json"] == {
+            "initializeUploadRequest": {"owner": "urn:li:person:sub-1"}
+        }
+        assert mock_post.call_args.kwargs["headers"]["LinkedIn-Version"]
+        assert mock_put.call_args[0][0] == "https://upload.linkedin.example/doc"
+        assert mock_put.call_args.kwargs["data"] == b"%PDF-1.4 fake"
+
+    def test_raises_when_no_upload_url_returned(self, tmp_path):
+        from cqc_lem.utilities.linkedin.poster import upload_document
+
+        pdf = tmp_path / "deck.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        with patch("requests.post", return_value=self._init_response(value={})):
+            with pytest.raises(ValueError):
+                upload_document("token", "sub-1", str(pdf))
+
+    def test_raises_when_upload_put_fails(self, tmp_path):
+        from cqc_lem.utilities.linkedin.poster import upload_document
+
+        pdf = tmp_path / "deck.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        with patch("requests.post", return_value=self._init_response()), \
+             patch("requests.put", return_value=MagicMock(status_code=500)):
+            with pytest.raises(RuntimeError):
+                upload_document("token", "sub-1", str(pdf))
+
+
+@pytest.mark.unit
+class TestShareDocumentOnLinkedin:
+
+    def _slides(self, tmp_path, count=2):
+        paths = []
+        for i in range(count):
+            p = tmp_path / f"slide_{i}.png"
+            p.write_bytes(b"png")
+            paths.append(str(p))
+        return paths
+
+    def test_returns_none_without_credentials(self):
+        from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
+
+        with patch("cqc_lem.utilities.linkedin.poster.get_user_linked_sub_id", return_value=None), \
+             patch("cqc_lem.utilities.linkedin.poster.get_user_access_token", return_value=None):
+            assert share_document_on_linkedin(1, "content", ["/tmp/slide.png"]) is None
+
+    def test_returns_none_when_a_slide_is_not_a_real_image(self):
+        """Same posture as carousels: never publish a partial/placeholder deck."""
+        from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
+
+        with patch("cqc_lem.utilities.linkedin.poster.get_user_linked_sub_id", return_value="sub-1"), \
+             patch("cqc_lem.utilities.linkedin.poster.get_user_access_token", return_value="token"), \
+             patch("cqc_lem.utilities.linkedin.poster.upload_document") as mock_upload:
+            assert share_document_on_linkedin(1, "content", ["A slide title, not a path"]) is None
+            mock_upload.assert_not_called()
+
+    def test_returns_none_when_pdf_cannot_be_built(self, tmp_path):
+        from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
+
+        with patch("cqc_lem.utilities.linkedin.poster.get_user_linked_sub_id", return_value="sub-1"), \
+             patch("cqc_lem.utilities.linkedin.poster.get_user_access_token", return_value="token"), \
+             patch("cqc_lem.utilities.carousel_creator.create_carousel_pdf", return_value=None), \
+             patch("cqc_lem.utilities.linkedin.poster.upload_document") as mock_upload:
+            assert share_document_on_linkedin(1, "content", self._slides(tmp_path), post_id=9) is None
+            mock_upload.assert_not_called()
+
+    def test_publishes_through_versioned_documents_api(self, tmp_path):
+        from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
+
+        with patch("cqc_lem.utilities.linkedin.poster.get_user_linked_sub_id", return_value="sub-1"), \
+             patch("cqc_lem.utilities.linkedin.poster.get_user_access_token", return_value="token"), \
+             patch("cqc_lem.utilities.carousel_creator.create_carousel_pdf",
+                   return_value=str(tmp_path / "deck.pdf")) as mock_pdf, \
+             patch("cqc_lem.utilities.linkedin.poster.upload_document",
+                   return_value="urn:li:document:abc") as mock_upload, \
+             patch("cqc_lem.utilities.linkedin.poster._create_document_post_versioned",
+                   return_value="urn:li:share:999") as mock_post:
+            urn = share_document_on_linkedin(1, "Deck title\nbody", self._slides(tmp_path), post_id=9)
+
+        assert urn == "urn:li:share:999"
+        assert mock_pdf.call_args[0][1] == 9
+        mock_upload.assert_called_once()
+        assert mock_post.call_args[0][3] == "urn:li:document:abc"
+        assert mock_post.call_args[0][4] == "Deck title"
+
+    def test_downloads_slide_urls_and_cleans_up_temp_files(self, tmp_path):
+        from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
+
+        downloaded = str(tmp_path / "downloaded.png")
+        with open(downloaded, "wb") as f:
+            f.write(b"png")
+
+        with patch("cqc_lem.utilities.linkedin.poster.get_user_linked_sub_id", return_value="sub-1"), \
+             patch("cqc_lem.utilities.linkedin.poster.get_user_access_token", return_value="token"), \
+             patch("cqc_lem.utilities.linkedin.poster.download_media", return_value=downloaded) as mock_dl, \
+             patch("cqc_lem.utilities.carousel_creator.create_carousel_pdf",
+                   return_value=str(tmp_path / "deck.pdf")) as mock_pdf, \
+             patch("cqc_lem.utilities.linkedin.poster.upload_document", return_value="urn:li:document:abc"), \
+             patch("cqc_lem.utilities.linkedin.poster._create_document_post_versioned",
+                   return_value="urn:li:share:999"):
+            urn = share_document_on_linkedin(1, "content", ["https://assets.example/slide_1.png"], post_id=9)
+
+        assert urn == "urn:li:share:999"
+        mock_dl.assert_called_once_with("https://assets.example/slide_1.png")
+        assert mock_pdf.call_args[0][0] == [downloaded]
+        import os
+        assert not os.path.exists(downloaded), "temp download should be cleaned up"
+
+    def test_falls_back_to_legacy_ugcpost_when_versioned_fails(self, tmp_path):
+        from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
+
+        with patch("cqc_lem.utilities.linkedin.poster.get_user_linked_sub_id", return_value="sub-1"), \
+             patch("cqc_lem.utilities.linkedin.poster.get_user_access_token", return_value="token"), \
+             patch("cqc_lem.utilities.carousel_creator.create_carousel_pdf",
+                   return_value=str(tmp_path / "deck.pdf")), \
+             patch("cqc_lem.utilities.linkedin.poster.upload_document",
+                   side_effect=RuntimeError("not provisioned")), \
+             patch("cqc_lem.utilities.linkedin.poster._create_document_post_legacy",
+                   return_value="urn:li:ugcPost:555") as mock_legacy:
+            urn = share_document_on_linkedin(1, "content", self._slides(tmp_path), post_id=9)
+
+        assert urn == "urn:li:ugcPost:555"
+        mock_legacy.assert_called_once()
+
+    def test_returns_none_when_both_paths_fail(self, tmp_path):
+        from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
+
+        with patch("cqc_lem.utilities.linkedin.poster.get_user_linked_sub_id", return_value="sub-1"), \
+             patch("cqc_lem.utilities.linkedin.poster.get_user_access_token", return_value="token"), \
+             patch("cqc_lem.utilities.carousel_creator.create_carousel_pdf",
+                   return_value=str(tmp_path / "deck.pdf")), \
+             patch("cqc_lem.utilities.linkedin.poster.upload_document", side_effect=RuntimeError("boom")), \
+             patch("cqc_lem.utilities.linkedin.poster._create_document_post_legacy",
+                   side_effect=RuntimeError("boom too")):
+            assert share_document_on_linkedin(1, "content", self._slides(tmp_path), post_id=9) is None
+
+
+@pytest.mark.unit
+class TestDocumentPostRequests:
+
+    def test_versioned_post_sends_document_media(self):
+        from cqc_lem.utilities.linkedin.poster import _create_document_post_versioned
+
+        response = MagicMock(headers={"x-restli-id": "urn:li:share:1"})
+        response.raise_for_status = MagicMock()
+        with patch("requests.post", return_value=response) as mock_post:
+            urn = _create_document_post_versioned("token", "urn:li:person:sub-1", "body",
+                                                  "urn:li:document:abc", "Deck")
+
+        assert urn == "urn:li:share:1"
+        body = mock_post.call_args.kwargs["json"]
+        assert body["content"]["media"] == {"title": "Deck", "id": "urn:li:document:abc"}
+        assert body["commentary"] == "body"
+        assert body["lifecycleState"] == "PUBLISHED"
+
+    def test_versioned_post_falls_back_to_body_id(self):
+        from cqc_lem.utilities.linkedin.poster import _create_document_post_versioned
+
+        response = MagicMock(headers={})
+        response.raise_for_status = MagicMock()
+        response.json.return_value = {"id": "urn:li:share:2"}
+        with patch("requests.post", return_value=response):
+            urn = _create_document_post_versioned("token", "urn:li:person:sub-1", "body",
+                                                  "urn:li:document:abc", "Deck")
+
+        assert urn == "urn:li:share:2"
+
+    def test_legacy_post_uses_document_share_media_category(self):
+        from cqc_lem.utilities.linkedin.poster import _create_document_post_legacy
+
+        restli = MagicMock()
+        restli.create.return_value = MagicMock(entity_id="urn:li:ugcPost:2")
+        with patch("cqc_lem.utilities.linkedin.poster.upload_media",
+                   return_value="urn:li:digitalmediaAsset:xyz"), \
+             patch("cqc_lem.utilities.linkedin.poster._restli", return_value=restli):
+            urn = _create_document_post_legacy("token", "sub-1", "body", "/tmp/deck.pdf", "Deck")
+
+        assert urn == "urn:li:ugcPost:2"
+        entity = restli.create.call_args.kwargs["entity"]
+        share_content = entity["specificContent"]["com.linkedin.ugc.ShareContent"]
+        assert share_content["shareMediaCategory"] == "DOCUMENT"
+        assert share_content["media"][0]["media"] == "urn:li:digitalmediaAsset:xyz"
+        assert share_content["media"][0]["title"] == {"text": "Deck"}

--- a/tests/unit/utilities/linkedin/test_poster_document.py
+++ b/tests/unit/utilities/linkedin/test_poster_document.py
@@ -65,6 +65,26 @@ class TestUploadDocument:
             with pytest.raises(ValueError):
                 upload_document("token", "sub-1", str(pdf))
 
+    def test_retired_api_version_is_named_in_the_error(self, tmp_path):
+        """A retired LinkedIn-Version 426s every versioned call — say so instead of
+        letting it look like the app simply isn't provisioned for documents."""
+        import requests
+        from cqc_lem.utilities.linkedin.poster import upload_document
+
+        pdf = tmp_path / "deck.pdf"
+        pdf.write_bytes(b"%PDF-1.4")
+
+        retired = MagicMock(status_code=426)
+        retired.raise_for_status.side_effect = requests.HTTPError("426")
+
+        with patch("requests.post", return_value=retired), \
+             patch("cqc_lem.utilities.linkedin.poster.log_error") as mock_log:
+            with pytest.raises(requests.HTTPError):
+                upload_document("token", "sub-1", str(pdf))
+
+        assert "retired" in mock_log.call_args[0][0]
+        assert mock_log.call_args.kwargs["http_status"] == 426
+
     def test_raises_when_upload_put_fails(self, tmp_path):
         from cqc_lem.utilities.linkedin.poster import upload_document
 

--- a/tests/unit/utilities/linkedin/test_poster_document.py
+++ b/tests/unit/utilities/linkedin/test_poster_document.py
@@ -193,6 +193,64 @@ class TestShareDocumentOnLinkedin:
         assert urn == "urn:li:ugcPost:555"
         mock_legacy.assert_called_once()
 
+    def test_removes_the_scratch_pdf_dir_when_there_is_no_post_id(self, tmp_path):
+        """Without a post_id the PDF goes to a temp dir we own — it must not outlive the call."""
+        import os
+        from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
+
+        scratch = str(tmp_path / "scratch")
+        os.makedirs(scratch)
+
+        with patch("cqc_lem.utilities.linkedin.poster.get_user_linked_sub_id", return_value="sub-1"), \
+             patch("cqc_lem.utilities.linkedin.poster.get_user_access_token", return_value="token"), \
+             patch("cqc_lem.utilities.linkedin.poster.tempfile.mkdtemp", return_value=scratch), \
+             patch("cqc_lem.utilities.carousel_creator.create_carousel_pdf",
+                   return_value=str(tmp_path / "deck.pdf")) as mock_pdf, \
+             patch("cqc_lem.utilities.linkedin.poster.upload_document", return_value="urn:li:document:abc"), \
+             patch("cqc_lem.utilities.linkedin.poster._create_document_post_versioned",
+                   return_value="urn:li:share:999"):
+            urn = share_document_on_linkedin(1, "content", self._slides(tmp_path))
+
+        assert urn == "urn:li:share:999"
+        assert mock_pdf.call_args[1]["output_dir"] == scratch
+        assert not os.path.exists(scratch), "scratch PDF dir should be removed"
+
+    def test_scratch_pdf_dir_is_removed_even_when_publishing_fails(self, tmp_path):
+        import os
+        from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
+
+        scratch = str(tmp_path / "scratch")
+        os.makedirs(scratch)
+
+        with patch("cqc_lem.utilities.linkedin.poster.get_user_linked_sub_id", return_value="sub-1"), \
+             patch("cqc_lem.utilities.linkedin.poster.get_user_access_token", return_value="token"), \
+             patch("cqc_lem.utilities.linkedin.poster.tempfile.mkdtemp", return_value=scratch), \
+             patch("cqc_lem.utilities.carousel_creator.create_carousel_pdf",
+                   return_value=str(tmp_path / "deck.pdf")), \
+             patch("cqc_lem.utilities.linkedin.poster.upload_document", side_effect=RuntimeError("boom")), \
+             patch("cqc_lem.utilities.linkedin.poster._create_document_post_legacy",
+                   side_effect=RuntimeError("boom too")):
+            assert share_document_on_linkedin(1, "content", self._slides(tmp_path)) is None
+
+        assert not os.path.exists(scratch)
+
+    def test_no_scratch_dir_is_created_when_post_id_is_given(self, tmp_path):
+        from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
+
+        with patch("cqc_lem.utilities.linkedin.poster.get_user_linked_sub_id", return_value="sub-1"), \
+             patch("cqc_lem.utilities.linkedin.poster.get_user_access_token", return_value="token"), \
+             patch("cqc_lem.utilities.linkedin.poster.tempfile.mkdtemp") as mock_mkdtemp, \
+             patch("cqc_lem.utilities.carousel_creator.create_carousel_pdf",
+                   return_value=str(tmp_path / "deck.pdf")) as mock_pdf, \
+             patch("cqc_lem.utilities.linkedin.poster.upload_document", return_value="urn:li:document:abc"), \
+             patch("cqc_lem.utilities.linkedin.poster._create_document_post_versioned",
+                   return_value="urn:li:share:999"):
+            assert share_document_on_linkedin(1, "content", self._slides(tmp_path), post_id=9) \
+                == "urn:li:share:999"
+
+        mock_mkdtemp.assert_not_called()
+        assert mock_pdf.call_args[1]["output_dir"] is None
+
     def test_returns_none_when_both_paths_fail(self, tmp_path):
         from cqc_lem.utilities.linkedin.poster import share_document_on_linkedin
 

--- a/tests/unit/utilities/test_carousel_pdf.py
+++ b/tests/unit/utilities/test_carousel_pdf.py
@@ -1,0 +1,64 @@
+"""Unit tests for create_carousel_pdf — slide PNGs bundled into a native document."""
+
+import os
+
+import pytest
+
+
+def _write_png(path: str, color=(10, 20, 30)) -> str:
+    from PIL import Image
+    Image.new("RGB", (64, 64), color=color).save(path)
+    return path
+
+
+@pytest.mark.unit
+class TestCreateCarouselPdf:
+
+    def test_builds_multi_page_pdf_from_slides(self, tmp_path):
+        from cqc_lem.utilities.carousel_creator import create_carousel_pdf
+
+        slides = [_write_png(str(tmp_path / f"slide_{i}.png")) for i in range(3)]
+        out_dir = tmp_path / "out"
+
+        pdf_path = create_carousel_pdf(slides, post_id=42, output_dir=str(out_dir))
+
+        assert pdf_path == os.path.join(str(out_dir), "document_42.pdf")
+        assert os.path.isfile(pdf_path)
+        with open(pdf_path, "rb") as f:
+            assert f.read(5) == b"%PDF-"
+
+    def test_defaults_to_post_assets_dir(self, tmp_path):
+        from cqc_lem.utilities.carousel_creator import create_carousel_pdf
+
+        slides = [_write_png(str(tmp_path / "slide_1.png"))]
+
+        pdf_path = create_carousel_pdf(slides, post_id=7)
+
+        assert pdf_path.endswith(os.path.join("carousel", "7", "document_7.pdf"))
+        assert os.path.isfile(pdf_path)
+        os.remove(pdf_path)
+
+    def test_returns_none_without_slides(self, tmp_path):
+        from cqc_lem.utilities.carousel_creator import create_carousel_pdf
+
+        assert create_carousel_pdf([], post_id=1, output_dir=str(tmp_path)) is None
+        assert create_carousel_pdf(None, post_id=1, output_dir=str(tmp_path)) is None
+
+    def test_returns_none_when_a_slide_is_unreadable(self, tmp_path):
+        """Never publish a partial deck — one bad slide fails the whole document."""
+        from cqc_lem.utilities.carousel_creator import create_carousel_pdf
+
+        good = _write_png(str(tmp_path / "slide_1.png"))
+        bad = str(tmp_path / "slide_2.png")
+        with open(bad, "wb") as f:
+            f.write(b"not really a png")
+
+        assert create_carousel_pdf([good, bad], post_id=1, output_dir=str(tmp_path)) is None
+
+    def test_returns_none_when_a_slide_is_missing(self, tmp_path):
+        from cqc_lem.utilities.carousel_creator import create_carousel_pdf
+
+        good = _write_png(str(tmp_path / "slide_1.png"))
+        missing = str(tmp_path / "nope.png")
+
+        assert create_carousel_pdf([good, missing], post_id=1, output_dir=str(tmp_path)) is None

--- a/tests/unit/utilities/test_carousel_pdf.py
+++ b/tests/unit/utilities/test_carousel_pdf.py
@@ -27,16 +27,23 @@ class TestCreateCarouselPdf:
         with open(pdf_path, "rb") as f:
             assert f.read(5) == b"%PDF-"
 
-    def test_defaults_to_post_assets_dir(self, tmp_path):
+    def test_defaults_to_post_assets_dir(self, tmp_path, monkeypatch):
+        """The default path is derived from the module's __file__ — redirect that so the
+        assets tree is created under tmp_path instead of in the repo working copy."""
+        from cqc_lem.utilities import carousel_creator
         from cqc_lem.utilities.carousel_creator import create_carousel_pdf
+
+        fake_pkg = tmp_path / "pkg" / "utilities"
+        fake_pkg.mkdir(parents=True)
+        monkeypatch.setattr(carousel_creator, "__file__", str(fake_pkg / "carousel_creator.py"))
 
         slides = [_write_png(str(tmp_path / "slide_1.png"))]
 
         pdf_path = create_carousel_pdf(slides, post_id=7)
 
         assert pdf_path.endswith(os.path.join("carousel", "7", "document_7.pdf"))
+        assert pdf_path.startswith(os.path.realpath(str(tmp_path)))
         assert os.path.isfile(pdf_path)
-        os.remove(pdf_path)
 
     def test_returns_none_without_slides(self, tmp_path):
         from cqc_lem.utilities.carousel_creator import create_carousel_pdf


### PR DESCRIPTION
## What & why

Native document/PDF posts are 2026's highest-reach LinkedIn format (~6.6–7%). LEM published every generated deck as a **multi-image ugcPost** (`poster.py`), which is a different, lower-reach feed object. This adds a real native-document publish path on top of the existing slide pipeline.

- **`share_document_on_linkedin()`** (`utilities/linkedin/poster.py`) — resolves the post's rendered carousel slides (local paths or asset URLs), bundles them into ONE PDF via the new `create_carousel_pdf()` (Pillow, `utilities/carousel_creator.py`), then publishes through the **versioned Documents API**: `/rest/documents?action=initializeUpload` → upload → `/rest/posts` with `content.media = {title, id: urn:li:document:…}`.
  - **Fallback:** legacy `assets` upload (`feedshare-document` recipe) + `ugcPost` with `shareMediaCategory=DOCUMENT`, for tokens whose app isn't provisioned for the versioned API. Nothing is published until `/rest/posts` succeeds, so the fallback cannot duplicate a post.
  - Same no-placeholder posture as carousels: if any slide can't resolve to a real image, nothing is posted and `post_to_linkedin` flags the post `error`.
- **`PostType.DOCUMENT`** (`utilities/db.py`) + migration `V20260723234736__add_document_post_type.sql` widening the `posts.post_type` ENUM.
- **Content plan** (`app/run_content_plan.py`) — the distribution balancer now spans 4 types via `PLANNED_POST_TYPES`. A document post *is* a carousel deck, so generation reuses `create_carousel_content`; the asset gate (`_post_missing_required_asset`), the backfill safety net (`run_scheduler` + `get_unposted_posts_missing_assets`) and the admin regenerate endpoint all treat `document` like `carousel`.
- **UI** — Content Studio type filter/editor and `LinkedInPostPreview` (deck preview) plus the legacy Streamlit editor now include `document`.

No new DB column: document posts store their slides in `carousel_slides` exactly like carousels, and the PDF is built at publish time (and purged with the rest of the post's assets).

## Testing

- 26 new unit tests: PDF builder (multi-page output, refuses partial/unreadable decks), `upload_document` + both publish paths, versioned→legacy fallback, temp-file cleanup for downloaded slide URLs, `post_to_linkedin` document branching + `error` flagging, planner/asset-gate coverage.
- Full unit suite green locally (2875 passed); SPA `tsc -b` clean.
- **Not yet live-validated.** The acceptance criterion — publish one document post and confirm it renders as a *document* (not multi-image) in-feed — needs a real LinkedIn session/token, which this agent can't do headless. Held for human review before it deploys (`risk:live-linkedin`).

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)