### PR TITLE
feat(content): link-in-first-comment mechanic (closes #392)

### DIFF
--- a/compose/local/database/migrations/V20260724011915__add_link_in_first_comment.sql
+++ b/compose/local/database/migrations/V20260724011915__add_link_in_first_comment.sql
@@ -1,0 +1,11 @@
+-- Link-in-first-comment mechanic (issue #392 - C3). An external link in the post BODY costs
+-- ~60-68% reach on LinkedIn; the same link in the author's FIRST COMMENT costs nothing. At publish
+-- time the body is split: carried links are stripped from what publishes and stashed here, then the
+-- seed-comment task (auto_seed_comment_on_post) appends them to the first comment it leaves.
+-- Newline-separated when a post carries more than one link. NULL = nothing to carry.
+ALTER TABLE posts ADD COLUMN first_comment_link VARCHAR(1024) NULL;
+
+-- Opt-out for the mechanic. Default ON (it is the 2026 best practice); users who want their links
+-- inline can turn it off. Lives on the single per-user prefs row like every other engagement pref.
+ALTER TABLE engagement_preferences
+    ADD COLUMN link_in_first_comment TINYINT(1) NULL DEFAULT 1 AFTER feed_fallback_when_empty;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -405,6 +405,7 @@ class EngagementPreferencesRequest(BaseModel):
     reply_sweeps_per_day: int = 2
     reply_max_post_age_days: int = 2
     feed_fallback_when_empty: bool = True
+    link_in_first_comment: bool = True
 
     @field_validator("default_video_quality")
     @classmethod

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2918,16 +2918,11 @@ def post_to_linkedin(self, user_id: int, post_id: int):
     # Link-in-first-comment (issue #392 - C3): an external link in the BODY costs ~60-68% reach, so
     # hold the link back here - the single choke point every post (generated OR hand-written) passes
     # through - and stash it for the seed comment dispatched below. Only links that will actually be
-    # carried are removed, so nothing is ever silently lost.
+    # carried are removed, so nothing is ever silently lost. The split is in-memory only; the DB is
+    # not touched until the publish succeeds, so a failed share leaves the original body+link intact
+    # for a retry.
     content, first_comment_links = split_link_for_first_comment(
         content, enabled=bool(prefs.get("link_in_first_comment", True)))
-    if first_comment_links:
-        # Keep the stored post in sync with what actually publishes (the preview, the seed comment's
-        # grounding, and the post history all read this back).
-        update_db_post_content(post_id, content)
-        update_db_post_first_comment_link(post_id, "\n".join(first_comment_links))
-        log_info(f"Held {len(first_comment_links)} link(s) back for the first comment",
-                 user_id=user_id, post_id=post_id, action_type="post", task_name="post_to_linkedin")
 
     myprint(f"Posting to LinkedIn: {content}")
 
@@ -2962,6 +2957,15 @@ def post_to_linkedin(self, user_id: int, post_id: int):
 
         # Update DB with status=posted
         update_db_post_status(post_id, PostStatus.POSTED)
+
+        # Only now — with the post actually live — persist the link split. Keeps the stored post in
+        # sync with what published (the preview, the seed comment's grounding, and the post history
+        # all read this back) without stranding the post in a link-held-back state if sharing failed.
+        if first_comment_links:
+            update_db_post_content(post_id, content)
+            update_db_post_first_comment_link(post_id, "\n".join(first_comment_links))
+            log_info(f"Held {len(first_comment_links)} link(s) back for the first comment",
+                     user_id=user_id, post_id=post_id, action_type="post", task_name="post_to_linkedin")
 
         # Purge local media now that LinkedIn has re-hosted it — keeps the assets
         # volume bounded. Best-effort: never let cleanup failure break posting.

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -19,7 +19,8 @@ from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_
     ai_check_message_history, post_is_relevant, generate_newsletter_edition, generate_group_post, \
     generate_thread_reply, generate_seed_comment, choose_post_reaction, get_or_create_profile_synthesis, \
     synthesize_profile
-from cqc_lem.utilities.ai.content_alignment import humanize_text
+from cqc_lem.utilities.ai.content_alignment import humanize_text, split_link_for_first_comment, \
+    append_link_to_comment
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
@@ -30,6 +31,7 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     LogResultType, has_user_commented_on_post_url, get_post_url_from_log_for_user, get_post_message_from_log_for_user, \
     claim_post_for_comment, mark_post_commented, mark_post_reacted, release_post_claim, has_commented_post, \
     has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, PostType, \
+    update_db_post_content, update_db_post_first_comment_link, get_post_first_comment_link, \
     get_dm_history_for_profile, get_post_status, get_user_blog_url, get_post_type, get_carousel_slides, \
     get_dm_template, enqueue_followup, get_due_followups, mark_followup, stop_followups_for_profile, \
     set_profile_synthesis, get_duplicate_comment_posts
@@ -1411,13 +1413,20 @@ def auto_seed_comment_on_post(self, user_id: int, post_id: int):
     NOT Selenium: commenting on the user's OWN post needs no browser and no login, so it is immune
     to the feed-navigation 429 rate limit. Everything it needs (post body, voice synthesis, profile,
     prefs) is read from the DB. Pinning is skipped here — LinkedIn exposes no pin API and the seed
-    comment's thread-starting value stands without it."""
+    comment's thread-starting value stands without it.
+
+    When the publish step held an external link back (issue #392 — C3), that link is appended to the
+    comment: this is the delivery half of the link-in-first-comment mechanic."""
     post_url = get_post_url_from_log_for_user(user_id, post_id)
     if not post_url:
         return "No post URL yet for seed comment"
     object_urn = object_urn_from_post_url(post_url)
     if not object_urn:
         return f"Could not derive object URN from {post_url}"
+    # Idempotency: a retried/re-dispatched task must not leave a SECOND comment on the same post
+    # (duplicate own-comments are what consolidate_duplicate_comments_for_user exists to clean up).
+    if has_user_commented_on_post_url(user_id, post_url):
+        return "Seed comment already exists for this post"
     # Ground the AI in the canonical post body (posts table). Fall back to the log message only if
     # the post row is gone. Historical POST logs stored a status string, so grounding on the log
     # made seed comments read like they were about the /posts API instead of the post's subject.
@@ -1428,6 +1437,11 @@ def auto_seed_comment_on_post(self, user_id: int, post_id: int):
         my_profile = load_profile_for_user(user_id)  # cached DB read — no scrape/login
         seed = generate_seed_comment(post_message, my_profile, get_engagement_preferences(user_id),
                                      profile_synthesis=get_or_create_profile_synthesis(user_id, my_profile))
+        # The generated comment never contains links (the prompt forbids them); the link held back at
+        # publish time is appended deterministically here. A link on its own still ships when the
+        # generator came back empty — losing the link entirely would be the worse failure.
+        held_links = [l for l in (get_post_first_comment_link(post_id) or "").split("\n") if l.strip()]
+        seed = append_link_to_comment(seed, held_links, post_id=post_id)
         if not seed:
             return "No seed comment generated"
         comment_urn = comment_on_linkedin_post(user_id, object_urn, seed)
@@ -2898,6 +2912,23 @@ def post_to_linkedin(self, user_id: int, post_id: int):
 
     # Get the post content
     content = get_post_content(post_id)
+
+    prefs = get_engagement_preferences(user_id)
+
+    # Link-in-first-comment (issue #392 - C3): an external link in the BODY costs ~60-68% reach, so
+    # hold the link back here - the single choke point every post (generated OR hand-written) passes
+    # through - and stash it for the seed comment dispatched below. Only links that will actually be
+    # carried are removed, so nothing is ever silently lost.
+    content, first_comment_links = split_link_for_first_comment(
+        content, enabled=bool(prefs.get("link_in_first_comment", True)))
+    if first_comment_links:
+        # Keep the stored post in sync with what actually publishes (the preview, the seed comment's
+        # grounding, and the post history all read this back).
+        update_db_post_content(post_id, content)
+        update_db_post_first_comment_link(post_id, "\n".join(first_comment_links))
+        log_info(f"Held {len(first_comment_links)} link(s) back for the first comment",
+                 user_id=user_id, post_id=post_id, action_type="post", task_name="post_to_linkedin")
+
     myprint(f"Posting to LinkedIn: {content}")
 
     post_type = get_post_type(post_id)
@@ -2948,10 +2979,18 @@ def post_to_linkedin(self, user_id: int, post_id: int):
                        post_url=post_url,
                        message=content)
 
+        # Seed the author's own FIRST comment ~3 min in (the post's golden hour). Dispatched HERE,
+        # not from the scheduler: the seed needs the published post's URL, which only exists once
+        # this task succeeds, and it is API-driven like posting itself (no Selenium, so the
+        # active-user/throttle gates the scheduler applies to browser work don't belong on it).
+        # This is also what guarantees a link held back above is actually delivered.
+        auto_seed_comment_on_post.apply_async(kwargs={'user_id': user_id, 'post_id': post_id},
+                                              countdown=3 * 60)
+
         # Reply/comment follow-up per the user's reply_check_mode (replaces the old 24h polling loop
         # that drove LinkedIn 429s). event → ONE golden-hour safety sweep as a backstop for a missed
         # forwarded notification; scheduled → the beat dispatcher handles it; off → nothing.
-        reply_mode = get_engagement_preferences(user_id).get("reply_check_mode", "event")
+        reply_mode = prefs.get("reply_check_mode", "event")
         if reply_mode == "event":
             sweep_reply_comments.apply_async(kwargs={'user_id': user_id}, countdown=35 * 60)
 

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -8,7 +8,7 @@ from cqc_lem import assets_dir
 from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.app.run_automation import automate_commenting, automate_profile_viewer_engagement, \
     automate_appreciation_dms_for_user, clean_stale_invites, update_stale_profile, post_to_linkedin, \
-    automate_invites_to_company_page_for_user, auto_seed_comment_on_post, send_scheduled_dm, \
+    automate_invites_to_company_page_for_user, send_scheduled_dm, \
     sweep_reply_comments
 from cqc_lem.utilities.db import (
     get_ready_to_post_posts, get_orphaned_scheduled_posts, update_db_post_status,
@@ -86,10 +86,9 @@ def auto_check_scheduled_posts(self):
             # Start the pre-post commenting task 15 minutes before scheduled post (loop for 15 minutes)
             automate_commenting.apply_async(kwargs=base_kwargs, eta=scheduled_time - timedelta(minutes=15))
 
-            # Seed a pinned first comment ~3 min after the post publishes (its golden hour) so the
-            # post has a value-adding comment thread started from the author.
-            auto_seed_comment_on_post.apply_async(kwargs={'user_id': user_id, 'post_id': post_id},
-                                                  eta=scheduled_time + timedelta(minutes=3))
+            # The seed first comment is dispatched by post_to_linkedin itself once the post is live —
+            # it needs the published post's URL, and (being API-driven) it must not be gated on the
+            # Selenium throttle/active checks that guard the browser tasks here.
 
             # Schedule the pre-post profile viewer dm task 10 minutes before scheduled post (loop for 10 minutes)
             base_kwargs['loop_for_duration'] = 60 * 10

--- a/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
@@ -234,6 +234,13 @@ export default function EngagementSettingsCard() {
           )}
         </div>
         <div className="flex items-center justify-between">
+          <div className="pr-4">
+            <p className="text-sm font-medium text-gray-700">Put links in the first comment</p>
+            <p className="text-xs text-gray-400">When a post contains an external link, publish the post without it and drop the link into the first comment instead. Links in the body cost roughly 60-68% of a post's reach.</p>
+          </div>
+          <Toggle on={engPrefs.link_in_first_comment} onClick={() => setEng({ link_in_first_comment: !engPrefs.link_in_first_comment })} />
+        </div>
+        <div className="flex items-center justify-between">
           <p className="text-sm font-medium text-gray-700">Reply to comments on my posts</p>
           <Toggle on={engPrefs.reply_to_own_comments} onClick={() => setEng({ reply_to_own_comments: !engPrefs.reply_to_own_comments })} />
         </div>

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -25,6 +25,7 @@ export type EngPrefs = {
   reply_inbound_address?: string | null
   gmail_forward_confirmation?: GmailForwardConfirmation | null
   feed_fallback_when_empty: boolean
+  link_in_first_comment: boolean
   feed_reach?: FeedReach | null
 }
 

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -531,6 +531,133 @@ def ensure_lead_magnet_cta(content: Optional[str], lead_magnet: Optional[dict], 
     return normalize_public_text(deduped.rstrip() + "\n\n" + line)
 
 
+# --- Link-in-first-comment (issue #392 - C3) ------------------------------------------------------
+# An external link in the post BODY carries a ~60-68% reach penalty; the SAME link in the author's
+# first comment costs nothing. These helpers are the deterministic (no-LLM) half of the mechanic:
+# split the carried links out of a finished body at publish time, and rebuild the comment line that
+# delivers them. LinkedIn's own URLs are left alone - they are not the off-platform penalty.
+_LINK_RE = re.compile(r"(?:https?://|www\.)[^\s<>\[\]{}|\\^\"']+", re.IGNORECASE)
+_INTERNAL_LINK_HOSTS = ("linkedin.com", "lnkd.in")
+# Sentence punctuation that commonly abuts a URL and does not belong to it.
+_LINK_TRAILING_PUNCT = ".,;:!?\"'"
+
+# Carry at most a few links, and never more than the posts.first_comment_link column holds - links
+# beyond the budget stay in the body rather than being silently dropped.
+FIRST_COMMENT_LINK_MAX = 3
+FIRST_COMMENT_LINK_MAX_CHARS = 1000
+
+# Rotated by post_id (the LEAD_MAGNET_CTA_REPAIR_MENU idiom) so a user's first comments are not
+# word-for-word identical post after post.
+FIRST_COMMENT_LINK_MENU = (
+    "Link to the full piece: {link}",
+    "Full write-up here: {link}",
+    "Here's the link if you want the details: {link}",
+    "The whole thing lives here: {link}",
+    "Details are here: {link}",
+)
+
+
+def _clean_link(raw: str) -> str:
+    """Trim sentence punctuation the URL regex swallowed, and drop a trailing ')' that closes a
+    parenthetical rather than being part of the URL."""
+    link = (raw or "").strip()
+    while link and link[-1] in _LINK_TRAILING_PUNCT:
+        link = link[:-1]
+    while link.endswith(")") and link.count(")") > link.count("("):
+        link = link[:-1]
+    return link
+
+
+def is_external_link(url: Optional[str]) -> bool:
+    """True for an off-platform link (the one LinkedIn's reach penalty applies to)."""
+    link = (url or "").strip().lower()
+    if not link:
+        return False
+    host = re.sub(r"^(?:https?://)?(?:www\.)?", "", link).split("/")[0].split("?")[0]
+    return not any(host == h or host.endswith("." + h) for h in _INTERNAL_LINK_HOSTS)
+
+
+def extract_external_links(content: Optional[str]) -> list:
+    """Ordered, de-duplicated external links found in the content."""
+    links = []
+    for match in _LINK_RE.findall(content or ""):
+        link = _clean_link(match)
+        if link and is_external_link(link) and link not in links:
+            links.append(link)
+    return links
+
+
+def _tidy_after_link_removal(line: str) -> str:
+    """Repair the seam a removed URL leaves behind: empty brackets, a dangling 'here:' colon or
+    arrow, doubled spaces, and a space before sentence punctuation."""
+    line = re.sub(r"\(\s*\)|\[\s*\]|<\s*>", "", line)
+    # A connector that pointed AT the link ("Read more:", "Full piece ->") now points at nothing.
+    line = re.sub(r"[ \t]*[:>\-][ \t]*(?=[.,;!?]|$)", "", line)
+    line = re.sub(r"[ \t]+([.,;:!?])", r"\1", line)
+    line = re.sub(r"[ \t]{2,}", " ", line)
+    return line.rstrip()
+
+
+def split_link_for_first_comment(content: Optional[str], enabled: bool = True,
+                                 max_links: int = FIRST_COMMENT_LINK_MAX,
+                                 max_chars: int = FIRST_COMMENT_LINK_MAX_CHARS) -> tuple:
+    """Split a finished post body into (body_without_carried_links, carried_links).
+
+    Only links that will actually be carried into the first comment are removed, so a link can never
+    be lost: over-budget links stay in the body. Returns the content unchanged with an empty list
+    when disabled or when there is nothing external to move."""
+    if not content or not enabled:
+        return content, []
+    links = extract_external_links(content)
+    if not links:
+        return content, []
+
+    carried, budget = [], 0
+    for link in links[:max_links]:
+        cost = len(link) + (1 if carried else 0)  # newline-joined when persisted
+        if budget + cost > max_chars:
+            break
+        carried.append(link)
+        budget += cost
+    if not carried:
+        return content, []
+
+    body = content
+    # Longest first: removing "https://x.io/a" before "https://x.io/a/b" would corrupt the longer one.
+    for link in sorted(carried, key=len, reverse=True):
+        # The body may hold the link with trailing punctuation attached; only the URL itself goes.
+        body = body.replace(link, "")
+    cleaned_lines = []
+    for raw_line in body.split("\n"):
+        line = _tidy_after_link_removal(raw_line)
+        # A line that existed only to hold the link disappears entirely.
+        if line or not raw_line.strip():
+            cleaned_lines.append(line)
+    body = re.sub(r"\n{3,}", "\n\n", "\n".join(cleaned_lines)).strip()
+    return body, carried
+
+
+def first_comment_link_text(links, post_id: Optional[int] = None) -> str:
+    """The link-delivery line(s) for the author's first comment. Empty string when no links."""
+    links = [str(l).strip() for l in (links or []) if str(l or "").strip()]
+    if not links:
+        return ""
+    idx = (int(post_id) % len(FIRST_COMMENT_LINK_MENU)) if post_id is not None else 0
+    lines = [FIRST_COMMENT_LINK_MENU[idx].format(link=links[0])] + links[1:]
+    return "\n".join(lines)
+
+
+def append_link_to_comment(comment: Optional[str], links, post_id: Optional[int] = None) -> str:
+    """Attach the carried link(s) to the generated seed comment. The AI half never writes links (the
+    prompt forbids them), so this deterministic append is what actually delivers the mechanic - and
+    it still returns a link-only comment when seed generation came back empty."""
+    link_text = first_comment_link_text(links, post_id)
+    base = (comment or "").strip()
+    if not link_text:
+        return base
+    return normalize_public_text(f"{base}\n\n{link_text}" if base else link_text)
+
+
 def personal_proof_directive(profile_synthesis: Optional[str] = None) -> str:
     """The A2 first-person proof requirement, SOURCED from the durable profile synthesis (the
     author's real credibility/expertise brief from get_or_create_profile_synthesis) plus whatever

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1216,6 +1216,44 @@ def get_post_dwell_score(post_id: int) -> Optional[int]:
         connection.close()
 
 
+def update_db_post_first_comment_link(post_id: int, link: Optional[str]) -> bool:
+    """Stash the external link(s) stripped from a post body at publish time (issue #392, C3) so the
+    seed-comment task can deliver them in the author's first comment. Newline-separated for multiple
+    links; None clears it."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE posts SET first_comment_link = %s WHERE id = %s",
+            (link, post_id)
+        )
+        connection.commit()
+        success = cursor.rowcount == 1
+    except mysql.connector.Error as e:
+        success = False
+        myprint(f"Could not update first comment link for post {post_id}. Error: {e}")
+    finally:
+        cursor.close()
+        connection.close()
+    return success
+
+
+def get_post_first_comment_link(post_id: int) -> Optional[str]:
+    """The link(s) held back from a post's body for its first comment, or None (issue #392)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT first_comment_link FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+        return row[0] if row and row[0] else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not get first comment link for post {post_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_recent_post_shape_history(user_id: int, limit: int = 10) -> list:
     """Recent posts' SHAPE history — {archetype, hook_style} dicts, most-recent first — fed to the
     shared content framework so a new post rotates away from recently used archetypes/hooks (the
@@ -2580,13 +2618,13 @@ _ENGAGEMENT_DEFAULTS: dict = {
     "max_comments_per_day": 20, "max_dms_per_day": 20, "default_buyer_stage": None,
     "default_video_quality": "standard",
     "reply_check_mode": "event", "reply_sweeps_per_day": 2, "reply_max_post_age_days": 2,
-    "feed_fallback_when_empty": True,
+    "feed_fallback_when_empty": True, "link_in_first_comment": True,
 }
 _ENGAGEMENT_JSON_FIELDS = ("include_topics", "exclude_topics", "include_keywords",
                            "exclude_keywords", "include_authors", "exclude_authors", "post_types",
                            "focus_topics")
 _ENGAGEMENT_BOOL_FIELDS = ("use_emojis", "use_hashtags", "reply_to_own_comments",
-                           "feed_fallback_when_empty")
+                           "feed_fallback_when_empty", "link_in_first_comment")
 _ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "use_hashtags",
                     "include_topics", "exclude_topics", "include_keywords", "exclude_keywords",
                     "include_authors", "exclude_authors", "post_types", "focus_topics",
@@ -2594,7 +2632,7 @@ _ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "us
                     "max_post_age_hours", "reply_to_own_comments", "max_comments_per_day",
                     "max_dms_per_day", "default_buyer_stage", "default_video_quality",
                     "reply_check_mode", "reply_sweeps_per_day", "reply_max_post_age_days",
-                    "feed_fallback_when_empty")
+                    "feed_fallback_when_empty", "link_in_first_comment")
 
 VALID_VIDEO_QUALITIES = ("standard", "premium", "premium_top")
 VALID_REPLY_MODES = ("event", "scheduled", "off")

--- a/tests/e2e/test_carousel_video_post_e2e.py
+++ b/tests/e2e/test_carousel_video_post_e2e.py
@@ -26,6 +26,7 @@ class TestCarouselPostE2E:
              patch("cqc_lem.app.run_automation.insert_new_log", return_value=None), \
              patch("cqc_lem.app.run_automation.share_carousel_on_linkedin",
                    return_value=expected_urn) as mock_share, \
+             patch("cqc_lem.app.run_automation.auto_seed_comment_on_post"), \
              patch("cqc_lem.app.run_automation.automate_reply_commenting"):
             from cqc_lem.utilities.db import PostType
             mock_get_type.return_value = PostType.CAROUSEL
@@ -99,6 +100,7 @@ class TestVideoPostE2E:
              patch("cqc_lem.app.run_automation.insert_new_log", return_value=None), \
              patch("cqc_lem.app.run_automation.share_on_linkedin",
                    return_value=expected_urn) as mock_share, \
+             patch("cqc_lem.app.run_automation.auto_seed_comment_on_post"), \
              patch("cqc_lem.app.run_automation.automate_reply_commenting"):
             from cqc_lem.utilities.db import PostType
             mock_get_type.return_value = PostType.VIDEO

--- a/tests/integration/test_link_first_comment.py
+++ b/tests/integration/test_link_first_comment.py
@@ -1,0 +1,178 @@
+"""Integration test for the link-in-first-comment mechanic (issue #392 — C3).
+
+Acceptance: a post carrying an external link publishes a LINK-FREE body and the author's seeded
+first comment carries the link. Exercises the real chain — post_to_linkedin → db.py (posts, logs,
+engagement_preferences) → auto_seed_comment_on_post — over a stateful fake cursor, so the handoff
+between publish and seed goes through the actual persisted columns without needing a live MySQL.
+"""
+import pytest
+from contextlib import ExitStack
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.integration
+
+_DB = "cqc_lem.utilities.db"
+_RA = "cqc_lem.app.run_automation"
+
+_BODY = ("Three lessons from the rebuild.\n\n"
+         "We cut deploy time by 40%.\n\n"
+         "Full breakdown: https://example.com/rebuild")
+
+
+class _FakeCursor:
+    """Minimal MySQL-ish cursor over in-memory posts / users / logs / prefs stores."""
+
+    def __init__(self, store, dictionary=False):
+        self.store = store
+        self.dictionary = dictionary
+        self._result = []
+        self.rowcount = 0
+
+    def _rows(self, dict_rows, order):
+        self._result = [r if self.dictionary else tuple(r[c] for c in order) for r in dict_rows]
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        posts, logs = self.store["posts"], self.store["logs"]
+        if s.startswith("SELECT status FROM posts"):
+            self._rows([posts[params[0]]], ["status"])
+        elif s.startswith("SELECT content FROM posts"):
+            self._rows([posts[params[0]]], ["content"])
+        elif s.startswith("SELECT post_type FROM posts"):
+            self._rows([posts[params[0]]], ["post_type"])
+        elif s.startswith("SELECT first_comment_link FROM posts"):
+            self._rows([posts[params[0]]], ["first_comment_link"])
+        elif s.startswith("UPDATE posts SET content"):
+            posts[params[1]]["content"] = params[0]
+            self.rowcount = 1
+        elif s.startswith("UPDATE posts SET first_comment_link"):
+            posts[params[1]]["first_comment_link"] = params[0]
+            self.rowcount = 1
+        elif s.startswith("UPDATE posts SET status"):
+            posts[params[1]]["status"] = params[0]
+            self.rowcount = 1
+        elif s.startswith("SELECT email, password FROM users"):
+            self._rows([self.store["users"][params[0]]], ["email", "password"])
+        elif "FROM engagement_preferences" in s:
+            row = self.store["prefs"].get(params[0])
+            self._result = [row] if row else []
+        elif s.startswith("INSERT INTO logs"):
+            user_id, action_type, post_id, post_url, message, result = params
+            logs.append({"user_id": user_id, "action_type": action_type, "post_id": post_id,
+                         "post_url": post_url, "message": message, "result": result})
+            self.rowcount = 1
+        elif s.startswith("SELECT post_url FROM logs"):
+            user_id, post_id, action_type, result = params
+            match = [r for r in logs if (r["user_id"], r["post_id"], r["action_type"], r["result"])
+                     == (user_id, post_id, action_type, result)]
+            self._result = [(match[-1]["post_url"],)] if match else []
+        elif s.startswith("SELECT COUNT(*) FROM logs"):
+            user_id, post_url, action_type, result = params
+            self._result = [(len([r for r in logs if (r["user_id"], r["post_url"], r["action_type"],
+                                                      r["result"]) == (user_id, post_url, action_type,
+                                                                       result)]),)]
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return list(self._result)
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, store):
+        self.store = store
+
+    def cursor(self, *a, **k):
+        return _FakeCursor(self.store, dictionary=bool(k.get("dictionary")))
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def _store(link_pref_row=None):
+    return {
+        "posts": {10: {"id": 10, "status": "approved", "content": _BODY, "post_type": "text",
+                       "first_comment_link": None}},
+        "users": {1: {"email": "u@example.com", "password": "pw"}},
+        "prefs": ({1: link_pref_row} if link_pref_row else {}),
+        "logs": [],
+    }
+
+
+def _run_publish_and_seed(store):
+    """Publish the post, then run the seed-comment task the publish dispatched — inline, so the
+    handoff happens through the persisted columns exactly as it does in the worker."""
+    from cqc_lem.app.run_automation import post_to_linkedin, auto_seed_comment_on_post
+
+    seed_task = MagicMock()
+    seed_task.apply_async.side_effect = lambda kwargs=None, **kw: auto_seed_comment_on_post.run(**kwargs)
+    published, commented = {}, {}
+
+    def _share(user_id, content, *a, **k):
+        published["body"] = content
+        return "urn:li:ugcPost:7479519458164695040"
+
+    def _comment(user_id, object_urn, text, *a, **k):
+        commented["text"] = text
+        return "urn:li:comment:(x,1)"
+
+    with ExitStack() as stack:
+        stack.enter_context(patch(f"{_DB}.get_db_connection", side_effect=lambda *a, **k: _FakeConn(store)))
+        stack.enter_context(patch(f"{_RA}.share_on_linkedin", side_effect=_share))
+        stack.enter_context(patch(f"{_RA}.comment_on_linkedin_post", side_effect=_comment))
+        stack.enter_context(patch(f"{_RA}.auto_seed_comment_on_post", seed_task))
+        stack.enter_context(patch(f"{_RA}.sweep_reply_comments"))
+        stack.enter_context(patch("cqc_lem.utilities.utils.purge_post_assets"))
+        stack.enter_context(patch(f"{_RA}.load_profile_for_user", return_value=MagicMock()))
+        stack.enter_context(patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"))
+        stack.enter_context(patch(f"{_RA}.generate_seed_comment",
+                                  return_value="What would you have cut first?"))
+        post_to_linkedin.run(1, 10)
+
+    return published, commented
+
+
+class TestLinkInFirstComment:
+    def test_link_free_body_publishes_and_first_comment_carries_the_link(self):
+        store = _store()
+        published, commented = _run_publish_and_seed(store)
+
+        # 1) What LinkedIn received as the POST has no external link left in it.
+        assert "https://example.com/rebuild" not in published["body"]
+        assert "Three lessons from the rebuild." in published["body"]
+        assert "We cut deploy time by 40%." in published["body"]
+
+        # 2) The link round-tripped through the posts row to the seeded FIRST comment.
+        assert store["posts"][10]["first_comment_link"] == "https://example.com/rebuild"
+        assert "https://example.com/rebuild" in commented["text"]
+        assert "What would you have cut first?" in commented["text"]
+
+        # 3) The stored post + the POST log match what actually published (no phantom link).
+        assert store["posts"][10]["content"] == published["body"]
+        post_log = [r for r in store["logs"] if r["action_type"] == "post"][0]
+        assert post_log["message"] == published["body"]
+
+        # 4) The seeded comment is logged against the live post URL.
+        comment_log = [r for r in store["logs"] if r["action_type"] == "comment"][0]
+        assert comment_log["post_url"].endswith("urn:li:ugcPost:7479519458164695040/")
+        assert "https://example.com/rebuild" in comment_log["message"]
+
+    def test_opted_out_user_keeps_the_link_in_the_body(self):
+        from cqc_lem.utilities.db import _ENGAGEMENT_DEFAULTS
+        row = dict(_ENGAGEMENT_DEFAULTS, link_in_first_comment=0, reply_check_mode="off")
+        store = _store(link_pref_row=row)
+        published, commented = _run_publish_and_seed(store)
+
+        assert "https://example.com/rebuild" in published["body"]
+        assert store["posts"][10]["first_comment_link"] is None
+        # The seed comment still runs — it just has no link to deliver.
+        assert commented["text"] == "What would you have cut first?"

--- a/tests/unit/api/test_engagement_prefs_api.py
+++ b/tests/unit/api/test_engagement_prefs_api.py
@@ -189,6 +189,18 @@ class TestFeedFallbackAndReach:
         assert resp.status_code == 200
         assert upd.call_args[0][1]["feed_fallback_when_empty"] is False
 
+    def test_link_in_first_comment_passthrough(self, client):
+        """The #392 opt-out reaches the DB layer, and defaults ON when the client omits it."""
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_engagement_preferences", return_value=True) as upd:
+            off = client.put("/api/user/engagement-preferences",
+                             json={"session_token": _SESSION, "link_in_first_comment": False})
+            default = client.put("/api/user/engagement-preferences",
+                                 json={"session_token": _SESSION})
+        assert off.status_code == 200 and default.status_code == 200
+        assert upd.call_args_list[0][0][1]["link_in_first_comment"] is False
+        assert upd.call_args_list[1][0][1]["link_in_first_comment"] is True
+
     def test_get_includes_feed_reach(self, client):
         funnel = {"examined": 40, "passed_filters": 12, "matched_topics": 0,
                   "commented": 3, "fallback_used": True}

--- a/tests/unit/app/test_document_posts.py
+++ b/tests/unit/app/test_document_posts.py
@@ -12,6 +12,8 @@ BASE_PATCHES = [
     ("cqc_lem.app.run_automation.update_db_post_status", {}),
     ("cqc_lem.app.run_automation.get_engagement_preferences", {"return_value": {"reply_check_mode": "event"}}),
     ("cqc_lem.app.run_automation.sweep_reply_comments", {}),
+    # post_to_linkedin dispatches the seed first comment itself once the post is live (#392).
+    ("cqc_lem.app.run_automation.auto_seed_comment_on_post", {}),
 ]
 
 

--- a/tests/unit/app/test_link_first_comment_task.py
+++ b/tests/unit/app/test_link_first_comment_task.py
@@ -1,0 +1,141 @@
+"""Unit tests for the link-in-first-comment mechanic at the task layer (issue #392 — C3):
+post_to_linkedin holds the link back, auto_seed_comment_on_post delivers it."""
+
+import pytest
+from contextlib import ExitStack
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+_URL = "https://www.linkedin.com/feed/update/urn:li:ugcPost:7479519458164695040/"
+_BODY_WITH_LINK = "Three lessons from the rebuild.\n\nFull breakdown: https://example.com/rebuild"
+
+
+def _post_patches(stack, content, prefs=None, share_urn="urn:li:ugcPost:1"):
+    from cqc_lem.utilities.db import PostType
+    targets = {
+        "get_post_status": {"return_value": "approved"},
+        "get_user_password_pair_by_id": {"return_value": ("u@example.com", "pw")},
+        "get_post_content": {"return_value": content},
+        "get_engagement_preferences": {"return_value": prefs if prefs is not None else {}},
+        "get_post_type": {"return_value": PostType.TEXT},
+        "share_on_linkedin": {"return_value": share_urn},
+        "insert_new_log": {},
+        "update_db_post_status": {},
+        "sweep_reply_comments": {},
+        "auto_seed_comment_on_post": {},
+    }
+    return {name: stack.enter_context(patch(f"{_RA}.{name}", **kw)) for name, kw in targets.items()}
+
+
+class TestPostToLinkedinHoldsLinkBack:
+    def test_publishes_link_free_body_and_stashes_the_link(self):
+        from cqc_lem.app.run_automation import post_to_linkedin
+        with ExitStack() as stack:
+            m = _post_patches(stack, _BODY_WITH_LINK)
+            content_upd = stack.enter_context(patch(f"{_RA}.update_db_post_content"))
+            link_upd = stack.enter_context(patch(f"{_RA}.update_db_post_first_comment_link"))
+            post_to_linkedin.run(1, 10)
+
+        published = m["share_on_linkedin"].call_args[0][1]
+        assert "https://example.com/rebuild" not in published
+        assert "Three lessons from the rebuild." in published
+        link_upd.assert_called_once_with(10, "https://example.com/rebuild")
+        # The stored post is kept in sync with what actually published.
+        content_upd.assert_called_once_with(10, published)
+        # The success log records the published (link-free) body.
+        assert m["insert_new_log"].call_args.kwargs["message"] == published
+
+    def test_pref_off_publishes_the_link_inline(self):
+        from cqc_lem.app.run_automation import post_to_linkedin
+        with ExitStack() as stack:
+            m = _post_patches(stack, _BODY_WITH_LINK, prefs={"link_in_first_comment": False})
+            link_upd = stack.enter_context(patch(f"{_RA}.update_db_post_first_comment_link"))
+            post_to_linkedin.run(1, 10)
+
+        assert "https://example.com/rebuild" in m["share_on_linkedin"].call_args[0][1]
+        link_upd.assert_not_called()
+
+    def test_link_free_post_touches_nothing(self):
+        from cqc_lem.app.run_automation import post_to_linkedin
+        with ExitStack() as stack:
+            m = _post_patches(stack, "No links in this one.")
+            content_upd = stack.enter_context(patch(f"{_RA}.update_db_post_content"))
+            link_upd = stack.enter_context(patch(f"{_RA}.update_db_post_first_comment_link"))
+            post_to_linkedin.run(1, 10)
+
+        assert m["share_on_linkedin"].call_args[0][1] == "No links in this one."
+        content_upd.assert_not_called()
+        link_upd.assert_not_called()
+
+    def test_seed_comment_is_dispatched_after_publish(self):
+        """The seed task is dispatched HERE (not by the scheduler) because it needs the published
+        post's URL — and it is what delivers the held-back link."""
+        from cqc_lem.app.run_automation import post_to_linkedin
+        with ExitStack() as stack:
+            m = _post_patches(stack, _BODY_WITH_LINK)
+            stack.enter_context(patch(f"{_RA}.update_db_post_content"))
+            stack.enter_context(patch(f"{_RA}.update_db_post_first_comment_link"))
+            post_to_linkedin.run(1, 10)
+
+        m["auto_seed_comment_on_post"].apply_async.assert_called_once()
+        kwargs = m["auto_seed_comment_on_post"].apply_async.call_args.kwargs
+        assert kwargs["kwargs"] == {"user_id": 1, "post_id": 10}
+        assert kwargs["countdown"] > 0
+
+    def test_no_seed_dispatch_when_publishing_failed(self):
+        from cqc_lem.app.run_automation import post_to_linkedin
+        with ExitStack() as stack:
+            m = _post_patches(stack, "No links in this one.", share_urn=None)
+            post_to_linkedin.run(1, 10)
+        m["auto_seed_comment_on_post"].apply_async.assert_not_called()
+
+
+class TestSeedCommentDeliversTheLink:
+    def _seed(self, stack, held_link, seed_text="What surprised you most?", already_commented=False):
+        from cqc_lem.app.run_automation import auto_seed_comment_on_post
+        from unittest.mock import MagicMock
+        stack.enter_context(patch(f"{_RA}.get_post_url_from_log_for_user", return_value=_URL))
+        stack.enter_context(patch(f"{_RA}.has_user_commented_on_post_url", return_value=already_commented))
+        stack.enter_context(patch(f"{_RA}.get_post_content", return_value="Three lessons."))
+        stack.enter_context(patch(f"{_RA}.load_profile_for_user", return_value=MagicMock()))
+        stack.enter_context(patch(f"{_RA}.get_engagement_preferences", return_value={}))
+        stack.enter_context(patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"))
+        stack.enter_context(patch(f"{_RA}.generate_seed_comment", return_value=seed_text))
+        stack.enter_context(patch(f"{_RA}.get_post_first_comment_link", return_value=held_link))
+        stack.enter_context(patch(f"{_RA}.insert_new_log"))
+        api = stack.enter_context(patch(f"{_RA}.comment_on_linkedin_post",
+                                        return_value="urn:li:comment:(x,1)"))
+        result = auto_seed_comment_on_post.run(user_id=1, post_id=9)
+        return api, result
+
+    def test_held_link_is_appended_to_the_seed_comment(self):
+        with ExitStack() as stack:
+            api, _ = self._seed(stack, "https://example.com/rebuild")
+        comment = api.call_args.args[2]
+        assert "What surprised you most?" in comment
+        assert "https://example.com/rebuild" in comment
+
+    def test_multiple_links_all_ship(self):
+        with ExitStack() as stack:
+            api, _ = self._seed(stack, "https://example.com/a\nhttps://example.com/b")
+        comment = api.call_args.args[2]
+        assert "https://example.com/a" in comment and "https://example.com/b" in comment
+
+    def test_link_still_ships_when_generation_returns_nothing(self):
+        with ExitStack() as stack:
+            api, _ = self._seed(stack, "https://example.com/rebuild", seed_text=None)
+        assert "https://example.com/rebuild" in api.call_args.args[2]
+
+    def test_no_held_link_leaves_the_comment_unchanged(self):
+        with ExitStack() as stack:
+            api, _ = self._seed(stack, None)
+        assert api.call_args.args[2] == "What surprised you most?"
+
+    def test_bails_when_a_comment_already_exists(self):
+        """Idempotency: a re-dispatched seed must not leave a second comment on the same post."""
+        with ExitStack() as stack:
+            api, result = self._seed(stack, "https://example.com/a", already_commented=True)
+        api.assert_not_called()
+        assert "already exists" in result

--- a/tests/unit/app/test_link_first_comment_task.py
+++ b/tests/unit/app/test_link_first_comment_task.py
@@ -91,6 +91,35 @@ class TestPostToLinkedinHoldsLinkBack:
             post_to_linkedin.run(1, 10)
         m["auto_seed_comment_on_post"].apply_async.assert_not_called()
 
+    def test_failed_publish_leaves_the_stored_post_intact(self):
+        """The split is in-memory until the share succeeds — a failed publish must not strand the
+        post in the link-held-back state, or a retry would publish a body whose link is gone."""
+        from cqc_lem.app.run_automation import post_to_linkedin
+        with ExitStack() as stack:
+            _post_patches(stack, _BODY_WITH_LINK, share_urn=None)
+            content_upd = stack.enter_context(patch(f"{_RA}.update_db_post_content"))
+            link_upd = stack.enter_context(patch(f"{_RA}.update_db_post_first_comment_link"))
+            post_to_linkedin.run(1, 10)
+
+        content_upd.assert_not_called()
+        link_upd.assert_not_called()
+
+    def test_failed_carousel_leaves_the_stored_post_intact(self):
+        """Same for the carousel early-return path (no usable slide images)."""
+        from cqc_lem.utilities.db import PostType
+        from cqc_lem.app.run_automation import post_to_linkedin
+        with ExitStack() as stack:
+            m = _post_patches(stack, _BODY_WITH_LINK)
+            m["get_post_type"].return_value = PostType.CAROUSEL
+            stack.enter_context(patch(f"{_RA}.get_carousel_slides", return_value=[]))
+            stack.enter_context(patch(f"{_RA}.log_error"))
+            content_upd = stack.enter_context(patch(f"{_RA}.update_db_post_content"))
+            link_upd = stack.enter_context(patch(f"{_RA}.update_db_post_first_comment_link"))
+            post_to_linkedin.run(1, 10)
+
+        content_upd.assert_not_called()
+        link_upd.assert_not_called()
+
 
 class TestSeedCommentDeliversTheLink:
     def _seed(self, stack, held_link, seed_text="What surprised you most?", already_commented=False):

--- a/tests/unit/app/test_run_automation_posting.py
+++ b/tests/unit/app/test_run_automation_posting.py
@@ -13,6 +13,8 @@ BASE_PATCHES = [
     ("cqc_lem.app.run_automation.update_db_post_status", {}),
     ("cqc_lem.app.run_automation.get_engagement_preferences", {"return_value": {"reply_check_mode": "event"}}),
     ("cqc_lem.app.run_automation.sweep_reply_comments", {}),
+    # post_to_linkedin dispatches the seed first comment itself once the post is live (#392).
+    ("cqc_lem.app.run_automation.auto_seed_comment_on_post", {}),
 ]
 
 

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -225,13 +225,6 @@ class TestSyncStripeSubscriptions:
 # ---------------------------------------------------------------------------
 
 class TestAutoCheckScheduledPosts:
-    @pytest.fixture(autouse=True)
-    def _mock_seed_task(self):
-        # auto_check_scheduled_posts now also schedules a seed comment; mock that Celery task so
-        # tests don't touch Redis. It doesn't affect the post/commenting/profile-viewer assertions.
-        with patch(f"{_MOD}.auto_seed_comment_on_post", _async_task_mock()):
-            yield
-
     def test_no_posts_returns_no_post_to_schedule(self):
         with patch(_PATCH_GET_POSTS, return_value=[]), \
              patch(_PATCH_GET_ORPHANED, return_value=[]):
@@ -1012,10 +1005,8 @@ class TestPrePostSeleniumGatedOnBreaker:
              patch(_PATCH_GET_ORPHANED, return_value=[]), \
              patch(_PATCH_POST_TO_LINKEDIN) as post, \
              patch(_PATCH_AUTOMATE_COMMENTING) as commenting, \
-             patch(f"{_MOD}.auto_seed_comment_on_post") as seed, \
              patch(_PATCH_AUTOMATE_PROFILE_VIEWER) as viewer:
             auto_check_scheduled_posts()
         post.apply_async.assert_called_once()      # API post still goes out
         commenting.apply_async.assert_not_called()  # Selenium pre-post gated off
-        seed.apply_async.assert_not_called()
         viewer.apply_async.assert_not_called()

--- a/tests/unit/app/test_seed_comment.py
+++ b/tests/unit/app/test_seed_comment.py
@@ -15,6 +15,15 @@ def _no_sleep():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _no_db_reads():
+    """Neutral defaults for the seed task's DB lookups (dupe guard + held-back link) so tests that
+    aren't about them don't need a live MySQL. Individual tests patch over these."""
+    with patch(f"{_RA}.has_user_commented_on_post_url", return_value=False), \
+         patch(f"{_RA}.get_post_first_comment_link", return_value=None):
+        yield
+
+
 class TestGenerateSeedComment:
     def test_returns_stripped_comment(self):
         from cqc_lem.utilities.ai import ai_helper

--- a/tests/unit/utilities/ai/test_link_first_comment.py
+++ b/tests/unit/utilities/ai/test_link_first_comment.py
@@ -1,0 +1,121 @@
+"""Unit tests for the link-in-first-comment split/deliver core (issue #392 — C3)."""
+
+import pytest
+
+from cqc_lem.utilities.ai.content_alignment import (
+    FIRST_COMMENT_LINK_MENU, append_link_to_comment, extract_external_links,
+    first_comment_link_text, is_external_link, split_link_for_first_comment,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestExternalLinkDetection:
+    @pytest.mark.parametrize("url", [
+        "https://example.com/post", "http://blog.example.io/a?b=1", "www.example.com/x",
+    ])
+    def test_external(self, url):
+        assert is_external_link(url) is True
+
+    @pytest.mark.parametrize("url", [
+        "https://www.linkedin.com/feed/update/urn:li:ugcPost:1/",
+        "https://linkedin.com/in/someone", "https://lnkd.in/abc123", "",
+    ])
+    def test_not_external(self, url):
+        assert is_external_link(url) is False
+
+    def test_lookalike_host_is_still_external(self):
+        # notlinkedin.com must not be treated as LinkedIn's own domain.
+        assert is_external_link("https://notlinkedin.com/x") is True
+
+    def test_extracts_in_order_without_duplicates(self):
+        content = ("Read https://example.com/a and then https://example.com/b. "
+                   "Again: https://example.com/a")
+        assert extract_external_links(content) == ["https://example.com/a", "https://example.com/b"]
+
+    def test_trailing_sentence_punctuation_is_not_part_of_the_link(self):
+        assert extract_external_links("See https://example.com/a.") == ["https://example.com/a"]
+        assert extract_external_links("(https://example.com/a)") == ["https://example.com/a"]
+
+
+class TestSplitLinkForFirstComment:
+    def test_link_moves_out_of_the_body(self):
+        body, links = split_link_for_first_comment(
+            "Three lessons from the rebuild.\n\nFull breakdown: https://example.com/rebuild\n\n#growth")
+        assert links == ["https://example.com/rebuild"]
+        assert "https://" not in body
+        assert "Full breakdown" in body and "#growth" in body
+
+    def test_dangling_connector_is_tidied(self):
+        body, _ = split_link_for_first_comment("I wrote it up here: https://example.com/a")
+        assert body == "I wrote it up here"
+
+    def test_mid_sentence_link_leaves_clean_punctuation(self):
+        body, _ = split_link_for_first_comment(
+            "I wrote about it (https://example.com/a). It changed how we hire.")
+        assert body == "I wrote about it. It changed how we hire."
+
+    def test_line_that_only_held_the_link_disappears(self):
+        body, links = split_link_for_first_comment("Body line.\n\nhttps://example.com/a\n\nClosing line.")
+        assert links == ["https://example.com/a"]
+        assert body == "Body line.\n\nClosing line."
+
+    def test_disabled_returns_content_untouched(self):
+        content = "Read https://example.com/a"
+        assert split_link_for_first_comment(content, enabled=False) == (content, [])
+
+    def test_linkedin_links_stay_in_the_body(self):
+        content = "My last post: https://www.linkedin.com/feed/update/urn:li:ugcPost:1/"
+        assert split_link_for_first_comment(content) == (content, [])
+
+    def test_no_links_returns_content_unchanged(self):
+        content = "No links here at all."
+        assert split_link_for_first_comment(content) == (content, [])
+
+    def test_empty_content_is_safe(self):
+        assert split_link_for_first_comment(None) == (None, [])
+
+    def test_over_budget_links_stay_in_the_body(self):
+        """A link that will not be carried must NOT be stripped — losing it entirely is worse
+        than paying the body-link penalty for it."""
+        content = "a https://example.com/1 b https://example.com/2 c https://example.com/3 d https://example.com/4"
+        body, links = split_link_for_first_comment(content, max_links=2)
+        assert links == ["https://example.com/1", "https://example.com/2"]
+        assert "https://example.com/3" in body and "https://example.com/4" in body
+
+    def test_char_budget_caps_what_is_carried(self):
+        content = "x https://example.com/aaaaaaaaaa y https://example.com/bbbbbbbbbb"
+        body, links = split_link_for_first_comment(content, max_chars=30)
+        assert links == ["https://example.com/aaaaaaaaaa"]
+        assert "https://example.com/bbbbbbbbbb" in body
+
+    def test_prefix_link_is_not_corrupted_by_a_longer_sibling(self):
+        content = "one https://example.com/a two https://example.com/a/deeper"
+        body, links = split_link_for_first_comment(content)
+        assert set(links) == {"https://example.com/a", "https://example.com/a/deeper"}
+        assert "example.com" not in body
+
+
+class TestFirstCommentDelivery:
+    def test_link_text_rotates_by_post_id(self):
+        variants = {first_comment_link_text(["https://example.com/a"], post_id=i)
+                    for i in range(len(FIRST_COMMENT_LINK_MENU))}
+        assert len(variants) == len(FIRST_COMMENT_LINK_MENU)
+
+    def test_extra_links_are_listed_after_the_lead_line(self):
+        text = first_comment_link_text(["https://example.com/a", "https://example.com/b"], post_id=0)
+        assert text.endswith("https://example.com/b")
+        assert "https://example.com/a" in text.split("\n")[0]
+
+    def test_appends_to_the_generated_seed_comment(self):
+        out = append_link_to_comment("What surprised you most?", ["https://example.com/a"], post_id=1)
+        assert out.startswith("What surprised you most?")
+        assert "https://example.com/a" in out
+
+    def test_link_only_comment_when_generation_returned_nothing(self):
+        out = append_link_to_comment(None, ["https://example.com/a"], post_id=1)
+        assert "https://example.com/a" in out
+
+    def test_no_links_leaves_the_comment_alone(self):
+        assert append_link_to_comment("Just a question?", []) == "Just a question?"
+        assert append_link_to_comment(None, []) == ""

--- a/tests/unit/utilities/test_db_first_comment_link.py
+++ b/tests/unit/utilities/test_db_first_comment_link.py
@@ -1,0 +1,92 @@
+"""Unit tests for the link-in-first-comment DB layer (issue #392 — C3)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _mock_conn(fetch_one=None, rowcount=1):
+    conn = MagicMock(); cur = MagicMock()
+    cur.fetchone.return_value = fetch_one
+    cur.rowcount = rowcount
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestUpdateDbPostFirstCommentLink:
+    def test_stores_link(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_db_post_first_comment_link
+            assert update_db_post_first_comment_link(7, "https://example.com/a") is True
+        sql, params = cur.execute.call_args[0]
+        assert "UPDATE posts SET first_comment_link" in sql
+        assert params == ("https://example.com/a", 7)
+
+    def test_clears_with_none(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_db_post_first_comment_link
+            assert update_db_post_first_comment_link(7, None) is True
+        assert cur.execute.call_args[0][1] == (None, 7)
+
+    def test_false_on_db_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_db_post_first_comment_link
+            assert update_db_post_first_comment_link(7, "https://example.com/a") is False
+
+
+class TestGetPostFirstCommentLink:
+    def test_returns_stored_links(self):
+        conn, cur = _mock_conn(fetch_one=("https://example.com/a\nhttps://example.com/b",))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_first_comment_link
+            assert get_post_first_comment_link(7) == "https://example.com/a\nhttps://example.com/b"
+        sql, params = cur.execute.call_args[0]
+        assert "SELECT first_comment_link FROM posts" in sql
+        assert params == (7,)
+
+    def test_none_when_empty_or_missing(self):
+        for row in [(None,), ("",), None]:
+            conn, _ = _mock_conn(fetch_one=row)
+            with patch(f"{_DB}.get_db_connection", return_value=conn):
+                from cqc_lem.utilities.db import get_post_first_comment_link
+                assert get_post_first_comment_link(7) is None
+
+    def test_none_on_db_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_first_comment_link
+            assert get_post_first_comment_link(7) is None
+
+
+class TestLinkInFirstCommentPref:
+    def test_default_true(self):
+        conn, _ = _mock_conn()
+        conn.cursor.return_value.fetchone.return_value = None
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            assert get_engagement_preferences(1)["link_in_first_comment"] is True
+
+    def test_decodes_as_bool(self):
+        conn, _ = _mock_conn(fetch_one={"link_in_first_comment": 0})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            assert get_engagement_preferences(1)["link_in_first_comment"] is False
+
+    def test_persists_as_int(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_engagement_preferences
+            update_engagement_preferences(3, {"link_in_first_comment": False})
+        cols = list(__import__("cqc_lem.utilities.db", fromlist=["_ENGAGEMENT_COLS"])._ENGAGEMENT_COLS)
+        by_col = dict(zip(cols, cur.execute.call_args[0][1][1:]))
+        assert by_col["link_in_first_comment"] == 0


### PR DESCRIPTION
## What & why

External links in a LinkedIn post body carry a ~60-68% reach penalty. Best practice is to keep the body link-free and put the link in the author's first comment. This wires that end to end.

**Where the split happens:** `post_to_linkedin` — the single choke point every post passes through, generated *or* hand-written in Content Studio. Doing it at publish (rather than at generation in `run_content_plan`) means manually authored posts get the same treatment, and the body that publishes is exactly the body that gets stored and logged.

- **`content_alignment.py`** (the shared alignment/CTA-and-link core, per repo convention): `extract_external_links` / `split_link_for_first_comment` / `append_link_to_comment`. LinkedIn's own URLs (`linkedin.com`, `lnkd.in`) are not "external" and stay put. The split tidies the seam a removed URL leaves behind (`"I wrote it up here: <url>"` → `"I wrote it up here"`, empty parens, doubled spaces). **A link is never lost:** only links that will actually be carried are stripped — anything over the count/character budget stays in the body.
- **`post_to_linkedin`**: splits the body, publishes the link-free version, syncs `posts.content`, and stashes the link on `posts.first_comment_link`.
- **`auto_seed_comment_on_post`**: appends the held-back link to the seed comment (post_id-rotated phrasing, the `LEAD_MAGNET_CTA_REPAIR_MENU` idiom). If seed generation returns nothing, a link-only comment still ships — losing the link entirely is the worse failure. The task is now idempotent via the existing COMMENT log, so a re-dispatch can't leave a second comment on the same post.
- **Seed dispatch moved** from `auto_check_scheduled_posts` to `post_to_linkedin`. The seed needs the *published* post's URL, which only exists once the post task succeeds (the old `scheduled_time + 3min` eta could fire before the post was live), and being API-driven it shouldn't be gated behind the Selenium throttle / active-user checks that guard browser work. This is also what guarantees a held-back link is actually delivered.
- **Opt-out**: `engagement_preferences.link_in_first_comment`, default ON, wired through `db.py`, the API model, and the Account → Engagement settings card.

Migration `V20260724011915__add_link_in_first_comment.sql` (timestamp version) adds `posts.first_comment_link VARCHAR(1024) NULL` and the new pref column. Both additive and nullable.

## Testing

- `tests/integration/test_link_first_comment.py` — the acceptance criterion: a post with a link publishes a link-free body and the seeded first comment carries the link, with the handoff going through the real `posts`/`logs` columns (stateful fake cursor, same pattern as `test_post_attribution.py`). Second case covers an opted-out user.
- `tests/unit/utilities/ai/test_link_first_comment.py` — 26 cases over detection, splitting, seam tidying, budgets, and delivery.
- `tests/unit/app/test_link_first_comment_task.py` — task layer: hold-back, pref off, no-link posts, seed dispatch, link delivery, idempotency guard.
- `tests/unit/utilities/test_db_first_comment_link.py` — new DB helpers + the pref's default/decode/persist.
- API pref passthrough case added; `test_run_scheduler` / `test_run_automation_posting` / `test_seed_comment` updated for the moved dispatch and the new lookups.

Full unit suite: 2940 passed locally. UI `tsc --noEmit` clean.

Closes #392

🤖 Generated with [Claude Code](https://claude.com/claude-code)