### PR TITLE
feat(linkedin): weekly API-version check with gated auto-bump and rollback

### DIFF
--- a/scripts/linkedin_version_check.py
+++ b/scripts/linkedin_version_check.py
@@ -22,6 +22,7 @@ import argparse
 import json
 import re
 import sys
+import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -31,11 +32,20 @@ PROBE_URL = "https://api.linkedin.com/rest/me"
 DEFAULT_MIN_HEADROOM = 2
 DEFAULT_LOOKBACK = 24
 DEFAULT_LOOKAHEAD = 2
+DEFAULT_ATTEMPTS = 3
 ENV_KEY = "LI_API_VERSION"
+
+# Only these prove a version is live: 200 with a read scope, 403 ACCESS_DENIED without one
+# (LEM's token). 426 NONEXISTENT_VERSION is the only "not live" answer. EVERYTHING else —
+# throttling, outages, an unexpected 4xx — is undecidable and must not be guessed at, or a
+# transient blip would forge a live-window and drive a bad keep/bump decision.
+ACTIVE_STATUSES = frozenset({200, 403})
+INACTIVE_STATUSES = frozenset({426})
+RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
 
 
 class ProbeError(RuntimeError):
-    """The probe could not decide whether a version is active (bad/absent token)."""
+    """The probe could not decide whether a version is active."""
 
 
 def candidate_versions(today: datetime, lookback: int = DEFAULT_LOOKBACK,
@@ -47,27 +57,45 @@ def candidate_versions(today: datetime, lookback: int = DEFAULT_LOOKBACK,
 
 
 def is_active_response(status_code: int, body: str) -> bool:
-    """True if the probe response proves the version is active.
+    """True if the probe response PROVES the version is active, False if it proves it is not.
 
-    426 NONEXISTENT_VERSION is the only "not active" signal. A 401 means the token itself is
-    unusable, so nothing can be concluded — that is an error, not a "retired" verdict.
+    Anything that proves neither raises ProbeError, so the planner reports action=error and
+    alerts instead of inferring a window from a throttle or an outage.
     """
+    if status_code in INACTIVE_STATUSES:
+        return False
+    if status_code in ACTIVE_STATUSES:
+        return True
     if status_code == 401:
         raise ProbeError(f"LinkedIn rejected the probe token (401): {body[:200]}")
-    return status_code != 426
+    raise ProbeError(f"undecidable probe response {status_code}: {body[:200]}")
 
 
-def probe_version(token: str, version: str, timeout: int = 20) -> bool:
+def probe_version(token: str, version: str, timeout: int = 20,
+                  attempts: int = DEFAULT_ATTEMPTS, sleep=time.sleep) -> bool:
+    """Probe one version, retrying transient throttles/outages before giving up."""
     request = urllib.request.Request(PROBE_URL, headers={
         "Authorization": f"Bearer {token}",
         "LinkedIn-Version": version,
         "X-Restli-Protocol-Version": "2.0.0",
     })
-    try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            return is_active_response(response.status, "")
-    except urllib.error.HTTPError as e:
-        return is_active_response(e.code, e.read().decode("utf-8", "replace"))
+    for attempt in range(1, attempts + 1):
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                status, body = response.status, ""
+        except urllib.error.HTTPError as e:
+            status, body = e.code, e.read().decode("utf-8", "replace")
+        except urllib.error.URLError as e:
+            if attempt < attempts:
+                sleep(2 * attempt)
+                continue
+            raise ProbeError(f"probe of {version} failed to connect: {e}") from e
+
+        if status in RETRYABLE_STATUSES and attempt < attempts:
+            sleep(2 * attempt)
+            continue
+        return is_active_response(status, body)
+    raise ProbeError(f"probe of {version} exhausted {attempts} attempts")
 
 
 def find_active_versions(token: str, candidates: list[str], probe=probe_version) -> list[str]:

--- a/scripts/linkedin_version_check.py
+++ b/scripts/linkedin_version_check.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""LinkedIn versioned-API version checker.
+
+LinkedIn retires versioned-API versions on a rolling window (as of 2026-07 only ~7 months
+are live at once). A retired ``LI_API_VERSION`` makes every ``/rest/*`` call answer
+``426 NONEXISTENT_VERSION`` — which silently demotes native document posts to the legacy
+ugcPost path and would break any future versioned call outright.
+
+There is no discovery endpoint, so liveness is probed. ``GET /rest/me`` is a side-effect-free
+read that answers 426 NONEXISTENT_VERSION when a version is not active, and something else
+(403 without the read scope, 200 with it) when it is. An unissued FUTURE version answers 426
+too, so the newest active version is simply the newest candidate that is not 426.
+
+Policy: do NOT chase the newest version every month — a version bump can change API behaviour,
+and a pin that works is worth keeping. Bump only when the pinned version is retired, or has
+drifted to within ``--min-headroom`` of the oldest still-live version.
+
+Pure planning logic is unit-tested; the probe is mocked.
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Optional
+
+PROBE_URL = "https://api.linkedin.com/rest/me"
+DEFAULT_MIN_HEADROOM = 2
+DEFAULT_LOOKBACK = 24
+DEFAULT_LOOKAHEAD = 2
+ENV_KEY = "LI_API_VERSION"
+
+
+class ProbeError(RuntimeError):
+    """The probe could not decide whether a version is active (bad/absent token)."""
+
+
+def candidate_versions(today: datetime, lookback: int = DEFAULT_LOOKBACK,
+                       lookahead: int = DEFAULT_LOOKAHEAD) -> list[str]:
+    """Candidate YYYYMM versions, NEWEST first, spanning lookahead ahead .. lookback back."""
+    start = today.year * 12 + (today.month - 1) + lookahead
+    return [f"{(start - i) // 12:04d}{(start - i) % 12 + 1:02d}"
+            for i in range(lookahead + lookback + 1)]
+
+
+def is_active_response(status_code: int, body: str) -> bool:
+    """True if the probe response proves the version is active.
+
+    426 NONEXISTENT_VERSION is the only "not active" signal. A 401 means the token itself is
+    unusable, so nothing can be concluded — that is an error, not a "retired" verdict.
+    """
+    if status_code == 401:
+        raise ProbeError(f"LinkedIn rejected the probe token (401): {body[:200]}")
+    return status_code != 426
+
+
+def probe_version(token: str, version: str, timeout: int = 20) -> bool:
+    request = urllib.request.Request(PROBE_URL, headers={
+        "Authorization": f"Bearer {token}",
+        "LinkedIn-Version": version,
+        "X-Restli-Protocol-Version": "2.0.0",
+    })
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return is_active_response(response.status, "")
+    except urllib.error.HTTPError as e:
+        return is_active_response(e.code, e.read().decode("utf-8", "replace"))
+
+
+def find_active_versions(token: str, candidates: list[str], probe=probe_version) -> list[str]:
+    """Probe newest→oldest and stop at the first gap below the live window.
+
+    The live window is contiguous, so once an active version has been seen, the first
+    inactive one below it ends the window — no need to probe the whole lookback.
+    """
+    active: list[str] = []
+    for version in candidates:
+        if probe(token, version):
+            active.append(version)
+        elif active:
+            break
+    return sorted(active)
+
+
+def decide(current: Optional[str], active: list[str],
+           min_headroom: int = DEFAULT_MIN_HEADROOM) -> dict:
+    """Plan an action from the pinned version and the live window."""
+    if not active:
+        return {"action": "error", "target": current,
+                "reason": "no active LinkedIn API version found — probe or token is broken"}
+
+    active = sorted(active)
+    newest = active[-1]
+
+    if not current:
+        return {"action": "urgent-bump", "target": newest,
+                "reason": f"no {ENV_KEY} configured; pinning to newest active {newest}"}
+
+    if current not in active:
+        return {"action": "urgent-bump", "target": newest,
+                "reason": f"{current} is retired (426 NONEXISTENT_VERSION); newest active is {newest}"}
+
+    headroom = active.index(current)  # how many still-live versions are older than the pin
+    if headroom < min_headroom:
+        return {"action": "bump", "target": newest, "headroom": headroom,
+                "reason": (f"{current} is {headroom} version(s) from the oldest live version "
+                           f"({active[0]}) — bumping to {newest} before it retires")}
+
+    return {"action": "none", "target": current, "headroom": headroom,
+            "reason": f"{current} is active with {headroom} version(s) of headroom"}
+
+
+def rewrite_env_text(text: str, version: str, key: str = ENV_KEY) -> tuple[str, bool]:
+    """Replace a KEY=value line in a .env-style file. Returns (text, changed)."""
+    pattern = re.compile(rf"^{re.escape(key)}=.*$", re.MULTILINE)
+    if not pattern.search(text):
+        return text, False
+    new_text = pattern.sub(f"{key}={version}", text)
+    return new_text, new_text != text
+
+
+def rewrite_default_text(text: str, version: str, key: str = ENV_KEY) -> tuple[str, bool]:
+    """Replace the default_value in the env_constants.py get_constant_from_env(KEY, ...) call."""
+    pattern = re.compile(
+        rf"(get_constant_from_env\(\s*'{re.escape(key)}'\s*,\s*default_value\s*=\s*')(\d+)(')")
+    if not pattern.search(text):
+        return text, False
+    new_text = pattern.sub(rf"\g<1>{version}\g<3>", text)
+    return new_text, new_text != text
+
+
+def _access_token(user_id: int) -> Optional[str]:
+    from cqc_lem.utilities.db import get_user_access_token
+    return get_user_access_token(user_id)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--plan-json", action="store_true", help="probe and emit a JSON plan")
+    parser.add_argument("--current", help=f"currently configured {ENV_KEY}")
+    parser.add_argument("--token", help="LinkedIn access token (default: read user's from the DB)")
+    parser.add_argument("--user-id", type=int, default=1, help="user whose token probes with")
+    parser.add_argument("--min-headroom", type=int, default=DEFAULT_MIN_HEADROOM)
+    parser.add_argument("--lookback", type=int, default=DEFAULT_LOOKBACK)
+    parser.add_argument("--rewrite-repo-defaults", metavar="ROOT",
+                        help="update .env.example + env_constants.py in a repo checkout")
+    parser.add_argument("--version", help="version to write with --rewrite-repo-defaults")
+    args = parser.parse_args(argv)
+
+    if args.rewrite_repo_defaults:
+        if not args.version:
+            parser.error("--rewrite-repo-defaults requires --version")
+        changed = []
+        targets = [(f"{args.rewrite_repo_defaults}/.env.example", rewrite_env_text),
+                   (f"{args.rewrite_repo_defaults}/src/cqc_lem/utilities/env_constants.py",
+                    rewrite_default_text)]
+        for path, rewrite in targets:
+            try:
+                with open(path, encoding="utf-8") as handle:
+                    original = handle.read()
+            except OSError as e:
+                print(f"skip {path}: {e}", file=sys.stderr)
+                continue
+            updated, did_change = rewrite(original, args.version)
+            if did_change:
+                with open(path, "w", encoding="utf-8") as handle:
+                    handle.write(updated)
+                changed.append(path)
+        print(json.dumps({"changed": changed}))
+        return 0
+
+    if not args.plan_json:
+        parser.error("nothing to do — pass --plan-json or --rewrite-repo-defaults")
+
+    token = args.token or _access_token(args.user_id)
+    if not token:
+        print(json.dumps({"action": "error",
+                          "reason": f"no LinkedIn access token for user {args.user_id}"}))
+        return 1
+
+    candidates = candidate_versions(datetime.now(timezone.utc), lookback=args.lookback)
+    try:
+        active = find_active_versions(token, candidates)
+    except ProbeError as e:
+        print(json.dumps({"action": "error", "reason": str(e)}))
+        return 1
+
+    plan = decide(args.current, active, min_headroom=args.min_headroom)
+    plan["current"] = args.current
+    plan["active"] = active
+    plan["newest_active"] = active[-1] if active else None
+    print(json.dumps(plan))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/weekly_linkedin_version_check.sh
+++ b/scripts/weekly_linkedin_version_check.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# Weekly LinkedIn API-version orchestrator (host cron, runs as `lem`).
+#
+# LinkedIn retires versioned-API versions on a rolling window (~7 months live as of 2026-07).
+# A retired LI_API_VERSION makes every /rest/* call answer 426 NONEXISTENT_VERSION, which
+# silently demotes native document posts to the legacy path. This keeps the pin alive.
+#
+# Flow: plan (scripts/linkedin_version_check.py, probing LinkedIn from inside web_app) -> if the
+# pin is retired or near the retirement edge, GATE on the unit suite, back up + bump
+# /opt/lem/.env, recreate the app services, smoke-test the deployed version against the live API,
+# and ROLL BACK on any failure; on success open a PR so the repo defaults follow, and alert.
+#
+# Safe by construction: the target version is probe-verified before use, the unit suite must pass
+# before prod is touched, the change is smoke-tested against LinkedIn after the restart, and a
+# timestamped .env backup is restored automatically if anything fails.
+set -uo pipefail
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/lem/.local/bin"
+
+# Self-locate the repo root so this can run from a dedicated cron clone, isolated from any
+# interactive dev checkout (overridable via REPO=... for tests).
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+ENV_FILE="/opt/lem/.env"
+DIR="/home/lem/li-version-check"
+LOG="$DIR/li_version_check.log"
+COMPOSE="sudo -n docker compose -f /opt/lem/docker-compose.yml -f /opt/lem/docker-compose.prod.yml"
+APP_SERVICES="web_app celery_worker celery_worker_selenium celery_worker_selenium_outreach celery_worker_selenium_content celery_beat flower"
+MIN_HEADROOM="${MIN_HEADROOM:-2}"
+# DRY_RUN=1 plans and runs the unit gate, but never writes .env, recreates containers, opens a
+# PR or emails — so the bump path can be rehearsed against prod safely.
+DRY_RUN="${DRY_RUN:-0}"
+mkdir -p "$DIR"
+
+# Python with pytest (unit gate). Prefer the stable dev-checkout venv; fall back to poetry.
+_DEV_VENV_PY="/home/lem/linkedin_engagement_manager/.venv/bin/python"
+if [ -x "$_DEV_VENV_PY" ]; then PY=("$_DEV_VENV_PY"); else PY=(poetry run python); fi
+
+log(){ echo "[$(date -u +%FT%TZ)] $*" | tee -a "$LOG" >&2; }
+
+alert(){  # log + best-effort email to the admin; never fails the run
+  log "ALERT: $1"
+  [ "$DRY_RUN" = "1" ] && { log "DRY_RUN: skipping alert email"; return 0; }
+  sudo -n docker exec -i web_app python - "$1" <<'PY' >>"$LOG" 2>&1 || true
+import os, sys
+msg = sys.argv[1]
+try:
+    from cqc_lem.utilities.email import _dispatch_email
+    to = os.environ.get("ADMIN_EMAIL") or os.environ.get("LINKEDIN_EMAIL") or "christopher.queen@gmail.com"
+    html = "<pre>" + msg.replace("&", "&amp;").replace("<", "&lt;") + "</pre>"
+    _dispatch_email(to, "LEM weekly LinkedIn API-version check", html, text_content=msg, high_priority=True)
+    print("alert emailed to", to)
+except Exception as e:
+    print("alert email failed (logged only):", e)
+PY
+}
+
+plan_json(){  # probe LinkedIn from inside web_app (it has the DB token); $1=current version
+  sudo -n docker exec -i web_app python - --plan-json --current "$1" --min-headroom "$MIN_HEADROOM" \
+    < "$REPO/scripts/linkedin_version_check.py" 2>>"$LOG"
+}
+
+jget(){ printf '%s' "$1" | python3 -c "import sys,json;print(json.load(sys.stdin).get('$2',''))" 2>/dev/null; }
+
+recreate_apps(){  # `restart` reuses the old env — the containers must be RECREATED to pick up .env
+  log "recreating app services"
+  # shellcheck disable=SC2086
+  $COMPOSE up -d --no-deps --pull never $APP_SERVICES >>"$LOG" 2>&1
+}
+
+wait_healthy(){  # 0 once no app container is still starting (bounded wait)
+  local i
+  for i in $(seq 1 60); do
+    if ! sudo -n docker ps --format '{{.Status}}' | grep -q 'health: starting'; then return 0; fi
+    sleep 5
+  done
+  return 1
+}
+
+smoke(){  # $1=expected version — the DEPLOYED containers must carry it AND LinkedIn must accept it
+  local want="$1" got
+  got="$(sudo -n docker exec web_app printenv LI_API_VERSION 2>/dev/null)"
+  if [ "$got" != "$want" ]; then log "smoke: web_app has LI_API_VERSION=$got, expected $want"; return 1; fi
+  got="$(sudo -n docker exec celery_worker printenv LI_API_VERSION 2>/dev/null)"
+  if [ "$got" != "$want" ]; then log "smoke: celery_worker has LI_API_VERSION=$got, expected $want"; return 1; fi
+  # A live versioned call with the deployed pin — this is the failure the whole job exists to catch.
+  if ! sudo -n docker exec -i web_app python - <<'PY' >>"$LOG" 2>&1
+import sys, requests
+from cqc_lem.utilities.db import get_user_access_token
+from cqc_lem.utilities.env_constants import LI_API_VERSION
+r = requests.get("https://api.linkedin.com/rest/me", timeout=20, headers={
+    "Authorization": f"Bearer {get_user_access_token(1)}", "LinkedIn-Version": LI_API_VERSION})
+print(f"probe {LI_API_VERSION} -> {r.status_code}")
+sys.exit(1 if r.status_code == 426 else 0)
+PY
+  then log "smoke: LinkedIn rejected the deployed version"; return 1; fi
+  log "smoke: OK ($want live in web_app + celery_worker)"
+  return 0
+}
+
+open_pr(){  # mirror the bump into the repo via an EPHEMERAL worktree — never touches the shared
+            # dev checkout's branch/working tree (a human may be working there). $1=version
+  local version="$1" wt; wt="$(mktemp -d /tmp/li-version-wt.XXXXXX)"
+  ( cd "$REPO" && git fetch -q origin main \
+      && git worktree add -q -B auto/li-api-version "$wt" origin/main ) || { log "worktree add failed"; return 1; }
+  (
+    cd "$wt" || exit 1
+    "${PY[@]}" "$REPO/scripts/linkedin_version_check.py" --rewrite-repo-defaults "$wt" \
+        --version "$version" >>"$LOG" 2>&1
+    git add .env.example src/cqc_lem/utilities/env_constants.py
+    git commit -q -m "fix(linkedin): bump LI_API_VERSION to $version [weekly version check]" \
+        -m "Opened by scripts/weekly_linkedin_version_check.sh after probing LinkedIn for the live version window, passing the unit suite, and smoke-testing the bump on the box." >>"$LOG" 2>&1 \
+        || { log "no repo diff to PR"; exit 0; }
+    git push -q -u origin auto/li-api-version >>"$LOG" 2>&1
+    gh pr create --base main --head auto/li-api-version \
+       --title "fix(linkedin): bump LI_API_VERSION to $version" \
+       --body "Automated by the weekly LinkedIn API-version check. \`$version\` was probe-verified against the live API, the unit suite passed, and the bump was smoke-tested on the box before this PR. Production is already on it — this keeps the repo defaults in step." >>"$LOG" 2>&1 \
+       && log "PR opened" || log "PR create skipped (maybe one already open)"
+  )
+  ( cd "$REPO" && git worktree remove --force "$wt" 2>/dev/null ) || true
+}
+
+log "=== weekly LinkedIn API-version check start ==="
+CURRENT="$(sudo -n grep -E "^LI_API_VERSION=" "$ENV_FILE" | head -1 | cut -d= -f2)"
+log "configured LI_API_VERSION=${CURRENT:-<unset>}"
+
+PLAN="$(plan_json "$CURRENT")"
+[ -z "$PLAN" ] && { log "planner produced no output — aborting"; alert "LinkedIn version check could not run (no planner output)."; exit 1; }
+ACTION="$(jget "$PLAN" action)"
+TARGET="$(jget "$PLAN" target)"
+REASON="$(jget "$PLAN" reason)"
+log "plan: action=$ACTION target=$TARGET ($REASON)"
+
+case "$ACTION" in
+  none)
+    log "nothing to do"; log "=== done ==="; exit 0 ;;
+  error)
+    alert "LinkedIn API-version check FAILED: $REASON"; exit 1 ;;
+  bump|urgent-bump) ;;
+  *)
+    alert "LinkedIn API-version check: unknown action '$ACTION'"; exit 1 ;;
+esac
+
+# --- gate on the unit suite BEFORE prod is touched ------------------------------------------
+log "running unit suite as the gate"
+if ! ( cd "$REPO" && PYTHONPATH="$REPO/src" "${PY[@]}" -m pytest tests/unit -q -p no:cacheprovider \
+        --no-header >>"$LOG" 2>&1 ); then
+  alert "LinkedIn API-version bump to $TARGET ABORTED — unit suite failed. Prod untouched (still $CURRENT)."
+  exit 1
+fi
+log "unit suite passed"
+
+# --- apply to prod, verify, roll back on failure ---------------------------------------------
+if [ "$DRY_RUN" = "1" ]; then
+  log "DRY_RUN: would back up $ENV_FILE, set LI_API_VERSION=$TARGET, recreate [$APP_SERVICES],"
+  log "DRY_RUN: smoke-test $TARGET against LinkedIn, open a PR, and alert. Nothing changed."
+  log "=== dry run done ==="; exit 0
+fi
+
+BK="$ENV_FILE.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+sudo -n cp -a "$ENV_FILE" "$BK"; log "backed up env -> $BK"
+if sudo -n grep -qE "^LI_API_VERSION=" "$ENV_FILE"; then
+  sudo -n sed -i "s/^LI_API_VERSION=.*$/LI_API_VERSION=$TARGET/" "$ENV_FILE"
+else  # key absent entirely — append it, or the bump would be a silent no-op
+  echo "LI_API_VERSION=$TARGET" | sudo -n tee -a "$ENV_FILE" >/dev/null
+fi
+log "set LI_API_VERSION=$TARGET in $ENV_FILE"
+
+recreate_apps
+wait_healthy || log "warning: containers still reporting 'health: starting' after the wait"
+
+if smoke "$TARGET"; then
+  log "bump verified — keeping"
+  open_pr "$TARGET"
+  alert "LinkedIn API version bumped ${CURRENT:-<unset>} -> $TARGET and verified live. Reason: $REASON. PR opened to sync the repo defaults."
+else
+  log "smoke FAILED — rolling back to $BK"
+  sudo -n cp -a "$BK" "$ENV_FILE"
+  recreate_apps
+  wait_healthy || true
+  alert "LinkedIn API-version bump to $TARGET FAILED smoke-test — rolled back to ${CURRENT:-<unset>}. Manual review needed."
+  exit 1
+fi
+log "=== weekly LinkedIn API-version check done ==="

--- a/scripts/weekly_linkedin_version_check.sh
+++ b/scripts/weekly_linkedin_version_check.sh
@@ -67,20 +67,35 @@ recreate_apps(){  # `restart` reuses the old env — the containers must be RECR
 }
 
 wait_healthy(){  # 0 once no app container is still starting (bounded wait)
-  local i
+  # A failing `docker ps` must NOT read as healthy: capture it and check its exit status
+  # separately, instead of letting a broken pipeline look identical to "grep found nothing".
+  local i out
   for i in $(seq 1 60); do
-    if ! sudo -n docker ps --format '{{.Status}}' | grep -q 'health: starting'; then return 0; fi
-    sleep 5
+    if ! out="$(sudo -n docker ps --format '{{.Status}}' 2>/dev/null)"; then
+      log "wait_healthy: docker ps failed (attempt $i) — retrying"
+      sleep 5; continue
+    fi
+    case "$out" in
+      *"health: starting"*) sleep 5 ;;
+      *) return 0 ;;
+    esac
   done
+  log "wait_healthy: gave up waiting for containers to settle"
   return 1
 }
 
 smoke(){  # $1=expected version — the DEPLOYED containers must carry it AND LinkedIn must accept it
-  local want="$1" got
-  got="$(sudo -n docker exec web_app printenv LI_API_VERSION 2>/dev/null)"
-  if [ "$got" != "$want" ]; then log "smoke: web_app has LI_API_VERSION=$got, expected $want"; return 1; fi
-  got="$(sudo -n docker exec celery_worker printenv LI_API_VERSION 2>/dev/null)"
-  if [ "$got" != "$want" ]; then log "smoke: celery_worker has LI_API_VERSION=$got, expected $want"; return 1; fi
+  local want="$1" got service
+  # An exec failure is reported as such, but still fails the smoke test — the safe direction,
+  # since the caller rolls back rather than trusting an unverifiable container.
+  for service in web_app celery_worker; do
+    if ! got="$(sudo -n docker exec "$service" printenv LI_API_VERSION 2>/dev/null)"; then
+      log "smoke: could not read LI_API_VERSION from $service (exec failed)"; return 1
+    fi
+    if [ "$got" != "$want" ]; then
+      log "smoke: $service has LI_API_VERSION=$got, expected $want"; return 1
+    fi
+  done
   # A live versioned call with the deployed pin — this is the failure the whole job exists to catch.
   if ! sudo -n docker exec -i web_app python - <<'PY' >>"$LOG" 2>&1
 import sys, requests
@@ -103,7 +118,11 @@ open_pr(){  # mirror the bump into the repo via an EPHEMERAL worktree — never 
       && git worktree add -q -B auto/li-api-version "$wt" origin/main ) || { log "worktree add failed"; return 1; }
   (
     cd "$wt" || exit 1
-    "${PY[@]}" "$REPO/scripts/linkedin_version_check.py" --rewrite-repo-defaults "$wt" \
+    # Rewrite with the worktree's OWN copy of the script so the rewriter always matches the
+    # files it edits; fall back to this checkout only if main doesn't carry it yet.
+    local rewriter="$wt/scripts/linkedin_version_check.py"
+    [ -f "$rewriter" ] || rewriter="$REPO/scripts/linkedin_version_check.py"
+    "${PY[@]}" "$rewriter" --rewrite-repo-defaults "$wt" \
         --version "$version" >>"$LOG" 2>&1
     git add .env.example src/cqc_lem/utilities/env_constants.py
     git commit -q -m "fix(linkedin): bump LI_API_VERSION to $version [weekly version check]" \

--- a/tests/unit/test_linkedin_version_check.py
+++ b/tests/unit/test_linkedin_version_check.py
@@ -41,6 +41,61 @@ class TestIsActiveResponse:
         with pytest.raises(lvc.ProbeError):
             lvc.is_active_response(401, '{"code":"EMPTY_ACCESS_TOKEN"}')
 
+    @pytest.mark.parametrize("status", [429, 500, 502, 503, 504, 404, 418])
+    def test_anything_that_proves_neither_raises(self, status):
+        """A throttle or an outage must never read as 'this version is live' — guessing
+        there would forge a live window and drive a bad keep/bump decision."""
+        with pytest.raises(lvc.ProbeError):
+            lvc.is_active_response(status, "boom")
+
+
+@pytest.mark.unit
+class TestProbeVersionRetries:
+    @staticmethod
+    def _http_error(status):
+        import io
+        import urllib.error
+        return urllib.error.HTTPError(lvc.PROBE_URL, status, "err", {}, io.BytesIO(b"{}"))
+
+    def _raiser(self, errors):
+        def urlopen(*_a, **_k):
+            raise errors.pop(0)
+        return urlopen
+
+    def test_retries_a_throttle_then_succeeds(self, monkeypatch):
+        errors = [self._http_error(429), self._http_error(403)]
+        monkeypatch.setattr(lvc.urllib.request, "urlopen", self._raiser(errors))
+        assert lvc.probe_version("tok", "202607", sleep=lambda _s: None) is True
+        assert errors == []
+
+    def test_raises_after_exhausting_retries_on_a_throttle(self, monkeypatch):
+        monkeypatch.setattr(lvc.urllib.request, "urlopen",
+                            lambda *a, **k: self._raise(self._http_error(429)))
+        with pytest.raises(lvc.ProbeError):
+            lvc.probe_version("tok", "202607", attempts=2, sleep=lambda _s: None)
+
+    def test_426_is_not_retried(self, monkeypatch):
+        calls = []
+
+        def urlopen(*_a, **_k):
+            calls.append(1)
+            raise self._http_error(426)
+
+        monkeypatch.setattr(lvc.urllib.request, "urlopen", urlopen)
+        assert lvc.probe_version("tok", "202501", sleep=lambda _s: None) is False
+        assert len(calls) == 1
+
+    def test_connection_failure_raises_probe_error(self, monkeypatch):
+        import urllib.error
+        monkeypatch.setattr(lvc.urllib.request, "urlopen",
+                            lambda *a, **k: self._raise(urllib.error.URLError("down")))
+        with pytest.raises(lvc.ProbeError):
+            lvc.probe_version("tok", "202607", attempts=2, sleep=lambda _s: None)
+
+    @staticmethod
+    def _raise(exc):
+        raise exc
+
 
 @pytest.mark.unit
 class TestFindActiveVersions:

--- a/tests/unit/test_linkedin_version_check.py
+++ b/tests/unit/test_linkedin_version_check.py
@@ -1,0 +1,147 @@
+"""Unit tests for the LinkedIn API version checker (scripts/linkedin_version_check.py)."""
+
+import importlib.util
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "linkedin_version_check.py"
+_spec = importlib.util.spec_from_file_location("linkedin_version_check", SCRIPT)
+lvc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(lvc)
+
+
+@pytest.mark.unit
+class TestCandidateVersions:
+    def test_newest_first_and_spans_the_window(self):
+        versions = lvc.candidate_versions(datetime(2026, 7, 24, tzinfo=timezone.utc),
+                                          lookback=3, lookahead=1)
+        assert versions == ["202608", "202607", "202606", "202605", "202604"]
+
+    def test_rolls_over_the_year_boundary(self):
+        versions = lvc.candidate_versions(datetime(2026, 1, 15, tzinfo=timezone.utc),
+                                          lookback=2, lookahead=1)
+        assert versions == ["202602", "202601", "202512", "202511"]
+
+
+@pytest.mark.unit
+class TestIsActiveResponse:
+    def test_426_means_not_active(self):
+        assert lvc.is_active_response(426, '{"code":"NONEXISTENT_VERSION"}') is False
+
+    def test_403_still_proves_the_version_exists(self):
+        # LEM's token has no read scope, so an active version answers ACCESS_DENIED.
+        assert lvc.is_active_response(403, '{"code":"ACCESS_DENIED"}') is True
+
+    def test_200_is_active(self):
+        assert lvc.is_active_response(200, "{}") is True
+
+    def test_401_is_undecidable_and_raises(self):
+        with pytest.raises(lvc.ProbeError):
+            lvc.is_active_response(401, '{"code":"EMPTY_ACCESS_TOKEN"}')
+
+
+@pytest.mark.unit
+class TestFindActiveVersions:
+    def test_collects_the_contiguous_live_window_below_unissued_versions(self):
+        live = {"202607", "202606", "202605"}
+        calls = []
+
+        def probe(_token, version):
+            calls.append(version)
+            return version in live
+
+        active = lvc.find_active_versions("tok", ["202609", "202608", "202607", "202606",
+                                                  "202605", "202604", "202603"], probe=probe)
+        assert active == ["202605", "202606", "202607"]
+        # stops at the first gap below the window instead of probing the whole lookback
+        assert calls[-1] == "202604"
+
+    def test_returns_empty_when_nothing_is_active(self):
+        assert lvc.find_active_versions("tok", ["202607", "202606"],
+                                        probe=lambda *_: False) == []
+
+
+@pytest.mark.unit
+class TestDecide:
+    ACTIVE = ["202601", "202602", "202603", "202604", "202605", "202606", "202607"]
+
+    def test_retired_pin_is_an_urgent_bump(self):
+        plan = lvc.decide("202501", self.ACTIVE)
+        assert plan["action"] == "urgent-bump"
+        assert plan["target"] == "202607"
+        assert "retired" in plan["reason"]
+
+    def test_healthy_pin_is_left_alone(self):
+        plan = lvc.decide("202606", self.ACTIVE)
+        assert plan["action"] == "none"
+        assert plan["target"] == "202606"
+        assert plan["headroom"] == 5
+
+    def test_pin_at_the_retirement_edge_is_bumped(self):
+        plan = lvc.decide("202602", self.ACTIVE, min_headroom=2)
+        assert plan["action"] == "bump"
+        assert plan["target"] == "202607"
+        assert plan["headroom"] == 1
+
+    def test_oldest_live_version_is_bumped(self):
+        plan = lvc.decide("202601", self.ACTIVE)
+        assert plan["action"] == "bump"
+        assert plan["headroom"] == 0
+
+    def test_newest_pin_never_bumps(self):
+        assert lvc.decide("202607", self.ACTIVE)["action"] == "none"
+
+    def test_missing_pin_is_an_urgent_bump(self):
+        assert lvc.decide(None, self.ACTIVE)["action"] == "urgent-bump"
+
+    def test_no_active_versions_is_an_error_not_a_bump(self):
+        plan = lvc.decide("202606", [])
+        assert plan["action"] == "error"
+
+    def test_min_headroom_zero_only_bumps_the_oldest(self):
+        assert lvc.decide("202601", self.ACTIVE, min_headroom=0)["action"] == "none"
+
+
+@pytest.mark.unit
+class TestRewrites:
+    def test_rewrites_the_env_line_only(self):
+        text = "FOO=1\nLI_API_VERSION=202501\nLI_USERINFO_RESOURCE=/userinfo\n"
+        updated, changed = lvc.rewrite_env_text(text, "202607")
+        assert changed is True
+        assert "LI_API_VERSION=202607" in updated
+        assert "LI_USERINFO_RESOURCE=/userinfo" in updated
+        assert "FOO=1" in updated
+
+    def test_env_rewrite_is_a_noop_when_the_key_is_absent(self):
+        assert lvc.rewrite_env_text("FOO=1\n", "202607") == ("FOO=1\n", False)
+
+    def test_rewrites_the_env_constants_default(self):
+        text = ("LI_API_VERSION = get_constant_from_env('LI_API_VERSION', "
+                "default_value='202501')\n")
+        updated, changed = lvc.rewrite_default_text(text, "202607")
+        assert changed is True
+        assert "default_value='202607'" in updated
+
+    def test_default_rewrite_leaves_other_constants_alone(self):
+        text = ("OTHER = get_constant_from_env('OTHER', default_value='202501')\n"
+                "LI_API_VERSION = get_constant_from_env('LI_API_VERSION', default_value='202501')\n")
+        updated, _ = lvc.rewrite_default_text(text, "202607")
+        assert "OTHER', default_value='202501'" in updated
+        assert "LI_API_VERSION', default_value='202607'" in updated
+
+
+@pytest.mark.unit
+class TestMainRewriteRepoDefaults:
+    def test_writes_both_files(self, tmp_path):
+        (tmp_path / ".env.example").write_text("LI_API_VERSION=202501\n")
+        constants = tmp_path / "src" / "cqc_lem" / "utilities"
+        constants.mkdir(parents=True)
+        (constants / "env_constants.py").write_text(
+            "LI_API_VERSION = get_constant_from_env('LI_API_VERSION', default_value='202501')\n")
+
+        assert lvc.main(["--rewrite-repo-defaults", str(tmp_path), "--version", "202607"]) == 0
+
+        assert "LI_API_VERSION=202607" in (tmp_path / ".env.example").read_text()
+        assert "default_value='202607'" in (constants / "env_constants.py").read_text()


### PR DESCRIPTION
## What & why

Prod was pinned to `LI_API_VERSION=202501`, which LinkedIn had **retired**. Nothing noticed until the native-document path (#390 / #442) was live-tested and every `/rest/*` call came back `426 NONEXISTENT_VERSION`. Because the document publisher catches that and falls back to the legacy `ugcPost` path, the failure mode is *silent degradation*, not an error — the high-reach format simply never gets used.

LinkedIn has no version-discovery endpoint and retires versions on a rolling window (probed 2026-07-24: **202601–202607 live, 202512 and older dead** — about 7 months). So this is a recurring hazard, not a one-off.

## How

**`scripts/linkedin_version_check.py`** — probes `GET /rest/me` (a side-effect-free read) with each candidate `YYYYMM`. `426 NONEXISTENT_VERSION` is the only "not active" signal; `403 ACCESS_DENIED` still proves the version exists, which is what LEM's token returns since it has no read scope. Unissued future versions also answer 426, so the newest active version is simply the newest non-426 candidate.

Policy is deliberately **not latest-always**: a version bump can change API behaviour, so a working pin is kept until it is retired or has drifted within `--min-headroom` (default 2) of the oldest live version. Today that means 202606 stays put with 5 versions of headroom.

**`scripts/weekly_linkedin_version_check.sh`** — host orchestrator, mirroring `weekly_model_check.sh`:

1. Plan (probe from inside `web_app`, which holds the DB token)
2. `none` → exit. `error` → alert, touch nothing
3. **Gate on the full unit suite before prod is touched** — a failure aborts with prod unchanged
4. Back up `/opt/lem/.env` (timestamped), bump the pin
5. **Recreate** the app services — `restart` reuses the old env and would silently keep the stale pin
6. Smoke-test: the deployed containers must carry the new pin **and** a live versioned call must not 426
7. Roll back to the backup and re-recreate on any failure, then alert
8. On success, open a PR syncing the repo defaults, and email

`DRY_RUN=1` rehearses the entire path without writing anything.

## Testing

- 21 new unit tests: window construction incl. year rollover, response classification (426/403/200, and 401 raising rather than being misread as "retired"), contiguous-window discovery with early stop, every branch of the bump policy, and both file rewrites.
- Full unit suite: **2898 passed**.
- Live-validated the planner against the real API: healthy pin → `action=none, headroom=5`; simulated retired pin (202501) → `action=urgent-bump, target=202607`.
- Dry-ran the orchestrator end to end, including a forced-bump run that exercised the unit gate.

## Not covered

The apply/rollback branch has not been executed for real — it needs an actual retirement (or a forced `MIN_HEADROOM`) to fire, and I did not want to bounce prod to manufacture one. Its individual steps are the same ones used by hand for the 202501→202606 bump earlier today, which worked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)