### PR TITLE
feat(content): default to no hashtags and bait-free CTAs (closes #393)

### DIFF
--- a/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
@@ -113,9 +113,9 @@ export default function EngagementSettingsCard() {
             <Toggle on={engPrefs.use_hashtags} onClick={() => setEng({ use_hashtags: !engPrefs.use_hashtags })} />
           </div>
           <p className="text-xs text-gray-500 mt-1">
-            Off by default. In 2026 hashtags no longer expand reach — hashtag-free posts see roughly
-            5–10% more — so LEM writes without them. Turn this on only if you want a minimal set
-            (at most 3) on the final line.
+            Off by default. In 2026 hashtags no longer expand reach: posts without them reach
+            roughly 5–10% more people, so LEM writes without them. Turn this on only if you want a
+            minimal set (at most 3) on the final line.
           </p>
         </div>
         {saveBtn('Save Voice & Tone')}

--- a/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
@@ -107,9 +107,16 @@ export default function EngagementSettingsCard() {
           <p className="text-sm font-medium text-gray-700">Use emojis</p>
           <Toggle on={engPrefs.use_emojis} onClick={() => setEng({ use_emojis: !engPrefs.use_emojis })} />
         </div>
-        <div className="flex items-center justify-between">
-          <p className="text-sm font-medium text-gray-700">Use hashtags</p>
-          <Toggle on={engPrefs.use_hashtags} onClick={() => setEng({ use_hashtags: !engPrefs.use_hashtags })} />
+        <div>
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-medium text-gray-700">Use hashtags</p>
+            <Toggle on={engPrefs.use_hashtags} onClick={() => setEng({ use_hashtags: !engPrefs.use_hashtags })} />
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            Off by default. In 2026 hashtags no longer expand reach — hashtag-free posts see roughly
+            5–10% more — so LEM writes without them. Turn this on only if you want a minimal set
+            (at most 3) on the final line.
+          </p>
         </div>
         {saveBtn('Save Voice & Tone')}
       </div>

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -932,16 +932,14 @@ def get_ai_linked_post_refinement(original_message: str, character_limit: int = 
 
     # Pref-aware formatting rules. The old hardcoded lines instructed emoji bullets and a trailing
     # hashtag block on EVERY refinement — directly fighting a user's use_emojis / use_hashtags
-    # settings (and the style directive the generator already honored). When no prefs are supplied
-    # the original wording is used verbatim, so unconfigured callers see a byte-identical prompt.
+    # settings (and the style directive the generator already honored). Hashtags now come from the
+    # shared 2026 policy (issue #393), which is hashtag-free unless the user opted in.
     emoji_line = "Use emojis (✅, 👉, 🔑, 💡) for visual emphasis and as bullet replacements."
-    hashtag_line = "Place all hashtags together on the final line of the post."
+    hashtag_line = _framework.hashtag_directive(prefs)
     tone_line = ""
     if prefs:
         if not prefs.get("use_emojis"):
             emoji_line = "Do NOT use any emojis; remove any emojis present in the draft."
-        if not prefs.get("use_hashtags"):
-            hashtag_line = "Do NOT add hashtags; remove any hashtags present in the draft."
         if prefs.get("tone"):
             tone_line = (f"\n        6. **Preserve the author's configured tone**\n"
                          f"           - The author writes in a {prefs['tone']} tone — preserve it; "
@@ -2010,14 +2008,12 @@ def get_blog_summary_post_from_ai(blog_post_url: str, blog_post_content: str, li
 
     # Pref-aware emoji/hashtag instructions — the hardcoded versions told the model to use emojis
     # and add hashtags even when the user's settings (already in the style directive above) said
-    # not to, and a system-prompt instruction usually wins that fight. Unset prefs keep the
-    # original wording so unconfigured behavior is unchanged.
+    # not to, and a system-prompt instruction usually wins that fight. Hashtags follow the shared
+    # 2026 policy (issue #393): none unless the user opted in.
     _emoji_instr = ("You can use emojis (such as 📊, 🌟, or ❓) to add personality, but only if it aligns with the user’s tone and industry norms."
                     if (not prefs or prefs.get("use_emojis"))
                     else "Do NOT use any emojis in the post.")
-    _hashtag_instr = ("Use up to 5 relevant hashtags, based on the article’s subject and the user’s industry. Suggested tags may include broader industry terms (#Innovation, #AI, #Leadership) and niche terms directly related to the content."
-                      if (not prefs or prefs.get("use_hashtags"))
-                      else "Do NOT include any hashtags in the post.")
+    _hashtag_instr = _framework.hashtag_directive(prefs)
 
     # System prompt to be included in every request
     system_prompt = {
@@ -2128,14 +2124,12 @@ def get_website_content_post_from_ai(content: str, url: str, linked_user_profile
     content = [{"type": "text", "text": prompt}]
 
     # Pref-aware emoji/hashtag instructions (same fix as get_blog_summary_post_from_ai): honor the
-    # user's use_emojis/use_hashtags settings instead of hardcoding both ON. Unset prefs keep the
-    # original wording.
+    # user's use_emojis/use_hashtags settings instead of hardcoding both ON. Hashtags follow the
+    # shared 2026 policy (issue #393): none unless the user opted in.
     _emoji_instr = ("You can use emojis (such as 📊, 🌟, or ❓) to add personality, but only if it aligns with the user’s tone and industry norms."
                     if (not prefs or prefs.get("use_emojis"))
                     else "Do NOT use any emojis in the post.")
-    _hashtag_instr = ("Use up to 5 relevant hashtags, based on the website content’s subject and the user’s industry. Suggested tags may include broader industry terms (#Innovation, #AI, #Leadership) and niche terms directly related to the content."
-                      if (not prefs or prefs.get("use_hashtags"))
-                      else "Do NOT include any hashtags in the post.")
+    _hashtag_instr = _framework.hashtag_directive(prefs)
 
     # System prompt to be included in every request
     system_prompt = {
@@ -2749,10 +2743,9 @@ def generate_carousel_content(user_id: int, stage: str, prefs: dict = None,
     job_title = getattr(profile, "job_title", "Professional") or "Professional"
 
     # Honor the user's hashtag setting — the old prompt hardcoded "End with 5-10 hashtags" for
-    # every carousel regardless of use_hashtags. Unset prefs keep the original instruction.
-    _hashtag_rule = ("End with 5-10 relevant hashtags on the final line."
-                     if (not prefs or prefs.get("use_hashtags"))
-                     else "Do NOT include any hashtags.")
+    # every carousel regardless of use_hashtags. Hashtags now follow the shared 2026 policy
+    # (issue #393): none unless the user opted in.
+    _hashtag_rule = _framework.hashtag_directive(prefs)
 
     # Shared LinkedIn formatting/QA best practices + a hard length cap for the caption (carousels
     # previously had NO length or formatting enforcement — one post came back as a 3400-char wall).

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -85,6 +85,7 @@ def style_directive(prefs: dict = None, content_type: str = "comment") -> str:
     the profile-inferred defaults (tone, length, emoji/hashtag rules, freeform style). The
     comment-length cap only applies to comments — posts and newsletters carry their own length
     guidance in their prompts."""
+    from cqc_lem.utilities.ai.content_framework import hashtag_directive
     if not prefs:
         return ""
     parts = []
@@ -96,7 +97,7 @@ def style_directive(prefs: dict = None, content_type: str = "comment") -> str:
         parts.append(f"Keep it {length} — at most ~{COMMENT_LENGTH_CHARS.get(length, 180)} characters "
                      f"(a few sentences); brevity beats length.")
     parts.append("You may use one tasteful emoji." if prefs.get("use_emojis") else "Do not use emojis.")
-    parts.append("Relevant hashtags are okay." if prefs.get("use_hashtags") else "Do not use any hashtags.")
+    parts.append(hashtag_directive(prefs))
     if prefs.get("comment_style"):
         parts.append(f"Style guidance: {prefs['comment_style']}.")
     return "\n\nStyle requirements (follow these):\n- " + "\n- ".join(parts) + "\n"

--- a/src/cqc_lem/utilities/ai/content_framework.py
+++ b/src/cqc_lem/utilities/ai/content_framework.py
@@ -197,27 +197,70 @@ HOOK_STYLES: dict = {
     },
 }
 
+# ---------------------------------------------------------------------------
+# 2026 CTA + hashtag policy (issue #393 / C4). Two things flipped under the 2026 algorithm:
+# engagement-bait closes ("comment YES", "tag 3 people", "follow for more") are demoted instead of
+# rewarded, and hashtags no longer expand reach — hashtag-free posts run roughly +5-10%. Both
+# policies live HERE, once, so newsletters, posts, comments, and carousels can never drift apart
+# on them.
+# ---------------------------------------------------------------------------
+
+# The cap for a user who explicitly opts back INTO hashtags: minimal, never decorative.
+HASHTAG_MAX = 3
+
+# Named in the writer directive so the model knows exactly what is banned. Detection of these in
+# generated text is `linkedin_formatter.contains_engagement_bait` — the ONE bait detector.
+ENGAGEMENT_BAIT_EXAMPLES: tuple = (
+    "comment YES", "type INFO below", "tag 3 people", "like if you agree",
+    "follow for more", "smash the like button", "repost if you agree",
+)
+
+
+def cta_policy_directive() -> str:
+    """The invariant CTA rule injected wherever a CTA style is assigned: earn a real reply, never
+    farm a reflex."""
+    bait = ", ".join(f"'{e}'" for e in ENGAGEMENT_BAIT_EXAMPLES[:4])
+    return ("CTA RULE: the close must invite a genuine, specific response the reader has to think "
+            f"about. NEVER engagement bait — no {bait}, and never ask for likes, follows, reposts, "
+            "tags, or one-word replies. LinkedIn demotes bait in 2026; only a question worth "
+            "answering earns the comment.")
+
+
+def hashtag_directive(prefs: Optional[dict] = None) -> str:
+    """The hashtag instruction for any prompt. The default is NONE — in 2026 hashtags no longer
+    expand reach and hashtag-free posts measurably out-perform tagged ones — so tags appear only
+    when the user explicitly turned `use_hashtags` on, and even then they stay minimal."""
+    if prefs and prefs.get("use_hashtags"):
+        return (f"Use at most {HASHTAG_MAX} highly relevant hashtags, together on the final line — "
+                "hashtags no longer expand reach, so include only ones a human would actually follow.")
+    return ("Do NOT include any hashtags — hashtag-free posts reach more people in 2026; remove any "
+            "present in the draft.")
+
+
 CTA_STYLES: dict = {
     "reply_question": {
         "label": "Reply-Driving Question",
         "guidance": ("Close with ONE open, specific question about the reader's own situation and "
                      "explicitly invite them to answer in the comments — specific questions get "
-                     "replies; 'thoughts?' gets silence."),
+                     "replies; 'thoughts?' gets silence. Never a yes/no or one-word ask."),
     },
     "challenge": {
         "label": "This-Week Challenge",
         "guidance": ("Close by assigning one small, concrete action to take this week, and invite the "
-                     "reader to report back in the comments with what happened."),
+                     "reader to report back in the comments with what actually happened — the result, "
+                     "not a checkmark."),
     },
     "debate": {
         "label": "Invite Disagreement",
         "guidance": ("Close by inviting pushback — name the most likely objection and ask readers to "
-                     "tell you where you're wrong in the comments. Disagreement is engagement."),
+                     "tell you where you're wrong, and why, in the comments. Reasoned disagreement is "
+                     "the highest-value reply there is."),
     },
     "share_forward": {
-        "label": "Share With Someone",
-        "guidance": ("Close by asking the reader to share this edition with ONE specific kind of "
-                     "person who needs it right now, and invite new readers to subscribe."),
+        "label": "Pass It To One Person",
+        "guidance": ("Close by naming the ONE specific kind of person this edition would genuinely "
+                     "help right now and suggesting the reader forward it to them, and invite new "
+                     "readers to subscribe. Never a blanket share-or-repost request."),
     },
     "teaser_next": {
         "label": "Next-Edition Teaser",
@@ -225,9 +268,10 @@ CTA_STYLES: dict = {
                      "subscribing for — and invite readers to subscribe so they don't miss it."),
     },
     "poll_prompt": {
-        "label": "Either/Or Poll",
-        "guidance": ("Close with a crisp either/or question (option A vs option B) readers can answer "
-                     "in one comment — a low-effort on-ramp that starts real conversations."),
+        "label": "Either/Or With Reasons",
+        "guidance": ("Close with a crisp either/or question (option A vs option B) and ask which the "
+                     "reader would pick AND why in one line — the reason is the point; a bare vote "
+                     "is bait and teaches the feed nothing."),
     },
 }
 
@@ -353,7 +397,7 @@ POST_CTA_STYLES: dict = {
         "label": "Worth Saving",
         "guidance": ("Close with ONE short, soft 'worth saving for later' style line (saves are the "
                      "strongest 2026 engagement signal) plus a specific question so commenters still "
-                     "have an easy way in. Never beg — no 'smash that save button'."),
+                     "have a real way in. Never beg for the save."),
     },
 }
 
@@ -710,6 +754,7 @@ def blueprint_directive(content_type: str, blueprint: dict) -> str:
     if cta:
         c_meta = menu["ctas"][cta]
         lines.append(f"CTA STYLE: {c_meta['label']}. {c_meta['guidance']}")
+        lines.append(cta_policy_directive())
     if content_type in _PROOF_SLOT_TYPES:
         lines.append(PERSONAL_PROOF_SLOT)
     return "\n".join(lines) + "\n"
@@ -1150,10 +1195,11 @@ def post_writing_directive() -> str:
         "- Plain, conversational language; no jargon, no hype words, no markdown syntax of any kind.\n"
         "- Every claim needs a specific: a number, a named example, or a concrete step — from the "
         "provided source material or genuinely well-established knowledge; NEVER invent statistics.\n"
-        "- No engagement-bait ('comment YES', 'tag someone', 'smash like') and no external links in "
-        "the body.\n"
-        "- If hashtags are allowed by the style requirements, at most 3-5 relevant ones on the final "
-        "line; otherwise none.\n"
+        "- " + cta_policy_directive() + "\n"
+        "- No external links in the body.\n"
+        "- Hashtags are OFF unless the style requirements above explicitly allow them — posts "
+        f"without hashtags reach more people in 2026. When allowed, at most {HASHTAG_MAX} highly "
+        "relevant ones on the final line.\n"
         "- " + PLAIN_PUNCTUATION_DIRECTIVE + "\n"
         + dwell_directive()
         + "\n- Output ONLY the final post text — no quotes, no labels, no explanation.\n"

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2611,6 +2611,8 @@ def update_user_preferences(
 
 _ENGAGEMENT_DEFAULTS: dict = {
     "tone": None, "comment_length": "short", "comment_style": None,
+    # use_hashtags stays OFF by default (issue #393): hashtags no longer expand reach in 2026 and
+    # hashtag-free posts out-perform tagged ones. See content_framework.hashtag_directive.
     "use_emojis": True, "use_hashtags": False,
     "include_topics": [], "exclude_topics": [], "include_keywords": [], "exclude_keywords": [],
     "include_authors": [], "exclude_authors": [], "post_types": [],

--- a/src/cqc_lem/utilities/linkedin_formatter.py
+++ b/src/cqc_lem/utilities/linkedin_formatter.py
@@ -190,8 +190,22 @@ _BAIT_PATTERNS = [
     r"double[- ]tap",
     r"(repost|share)\s+(this\s+)?if",
     r"comment\s+[\"']?(yes|agree|below|amen|me|👇)\b",
+    # 2026 additions (issue #393): reflex-action asks the algorithm now demotes outright.
+    r"follow\s+(me\s+|us\s+)?for\s+more",
+    r"(hit|smash|tap)\s+(that\s+|the\s+)?(save|follow|subscribe)",
+    r"type\s+[\"'“”]?\w+[\"'“”]?\s+(below|in the comments)",
+    r"drop\s+(a|an)\s+(like|emoji|\d+)\b",
+    r"drop\s+(a|an)\s+[\U0001F300-\U0001FAFF]",
 ]
 _BAIT_RE = re.compile("|".join(_BAIT_PATTERNS), re.IGNORECASE)
+
+
+def contains_engagement_bait(text: Optional[str]) -> bool:
+    """True when `text` asks for a reflex engagement action for its own sake (a one-word reply, a
+    like, a tag, a follow) — the closes LinkedIn demotes in 2026. This is the ONE bait detector:
+    `strip_engagement_bait` removes such lines from drafts, `is_bait_keyword` rejects colliding
+    lead-magnet trigger words, and the content-framework CTA menus are guarded against it."""
+    return bool(text) and bool(_BAIT_RE.search(str(text)))
 
 
 def is_bait_keyword(keyword: Optional[str]) -> bool:

--- a/tests/unit/utilities/ai/test_content_alignment.py
+++ b/tests/unit/utilities/ai/test_content_alignment.py
@@ -56,7 +56,7 @@ class TestStyleDirectivePerType:
     def test_long_form_types_drop_comment_length_cap(self, content_type):
         d = ca.style_directive(self._PREFS, content_type)
         assert "550" not in d and "brevity beats length" not in d
-        assert "warm" in d and "Do not use any hashtags" in d
+        assert "warm" in d and "Do NOT include any hashtags" in d
 
     def test_empty_prefs_yield_empty_directive(self):
         assert ca.style_directive(None) == ""

--- a/tests/unit/utilities/ai/test_content_framework.py
+++ b/tests/unit/utilities/ai/test_content_framework.py
@@ -261,7 +261,7 @@ class TestDirectivesAndCompact:
         text = fw.post_writing_directive()
         assert "210 characters" in text          # hook before the '...more' fold
         assert "1300-2000" in text               # optimal short-form length
-        assert "engagement-bait" in text
+        assert "NEVER engagement bait" in text
         assert "NEVER invent statistics" in text
         # The old one-size-fits-all viral template is gone for good.
         assert "10 relevant hashtags" not in text

--- a/tests/unit/utilities/ai/test_hashtag_cta_policy.py
+++ b/tests/unit/utilities/ai/test_hashtag_cta_policy.py
@@ -1,0 +1,111 @@
+"""Unit tests for the 2026 hashtag + anti-engagement-bait policy (issue #393 / C4): generated
+content is hashtag-free unless the user explicitly opts in, and no CTA the framework can assign
+asks for a reflex action the algorithm demotes."""
+
+import pytest
+
+from cqc_lem.utilities.ai import content_framework as cf
+from cqc_lem.utilities.linkedin_formatter import contains_engagement_bait
+
+pytestmark = pytest.mark.unit
+
+
+class TestCtaMenusAreBaitFree:
+    @pytest.mark.parametrize("menu_name", ["CTA_STYLES", "POST_CTA_STYLES"])
+    def test_no_cta_style_asks_for_a_reflex_action(self, menu_name):
+        for key, meta in getattr(cf, menu_name).items():
+            for field in ("label", "guidance"):
+                assert not contains_engagement_bait(meta[field]), \
+                    f"{menu_name}[{key}].{field} reads as engagement bait: {meta[field]}"
+
+    def test_every_menu_entry_still_drives_a_real_conversation(self):
+        for key, meta in cf.POST_CTA_STYLES.items():
+            text = meta["guidance"].lower()
+            assert any(word in text for word in ("question", "comment", "reply", "why", "report back")), \
+                f"POST_CTA_STYLES[{key}] no longer invites a response"
+
+    def test_format_structures_and_guidance_are_bait_free(self):
+        for menu_name in ("NEWSLETTER_FORMATS", "POST_FORMATS", "COMMENT_FORMATS"):
+            for key, meta in getattr(cf, menu_name).items():
+                assert not contains_engagement_bait(meta["guidance"]), f"{menu_name}[{key}]"
+                for step in meta["structure"]:
+                    assert not contains_engagement_bait(step), f"{menu_name}[{key}]: {step}"
+
+    def test_poll_cta_demands_the_reason_not_a_bare_vote(self):
+        guidance = cf.POST_CTA_STYLES["poll_prompt"]["guidance"].lower()
+        assert "why" in guidance and "bait" in guidance
+
+
+class TestCtaPolicyDirective:
+    def test_names_the_banned_patterns_and_is_injected_with_every_cta(self):
+        directive = cf.cta_policy_directive()
+        assert "NEVER engagement bait" in directive
+        assert cf.ENGAGEMENT_BAIT_EXAMPLES[0] in directive
+        blueprint = cf.select_blueprint("post")
+        assert directive in cf.blueprint_directive("post", blueprint)
+
+    def test_post_craft_rules_carry_the_policy(self):
+        rules = cf.post_writing_directive()
+        assert "NEVER engagement bait" in rules
+        assert "Hashtags are OFF unless" in rules
+
+
+class TestHashtagDirective:
+    @pytest.mark.parametrize("prefs", [None, {}, {"use_hashtags": False}, {"use_hashtags": 0}])
+    def test_default_is_no_hashtags(self, prefs):
+        assert "Do NOT include any hashtags" in cf.hashtag_directive(prefs)
+
+    def test_opt_in_stays_minimal(self):
+        directive = cf.hashtag_directive({"use_hashtags": True})
+        assert "Do NOT" not in directive
+        assert f"at most {cf.HASHTAG_MAX}" in directive
+        assert cf.HASHTAG_MAX <= 3
+
+    def test_style_directive_uses_the_shared_policy(self):
+        from cqc_lem.utilities.ai.content_alignment import style_directive
+        assert cf.hashtag_directive(None) in style_directive({"tone": "warm"})
+        assert cf.hashtag_directive({"use_hashtags": True}) in style_directive(
+            {"tone": "warm", "use_hashtags": True})
+
+
+class TestGeneratorsDefaultToNoHashtags:
+    """Unset prefs used to mean 'hashtags ON' in these prompt builders — the opposite of the 2026
+    default. Each prompt must now come back hashtag-free unless the user opted in."""
+
+    @staticmethod
+    def _prompt_text(mock_llm) -> str:
+        parts = []
+        for message in mock_llm.call_args.kwargs["messages"]:
+            content = message["content"]
+            if isinstance(content, list):
+                parts += [c.get("text", "") for c in content]
+            else:
+                parts.append(str(content))
+        return "\n".join(parts)
+
+    @pytest.fixture
+    def mock_llm(self):
+        from unittest.mock import MagicMock, patch
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content="post text"))]
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=response) as mock:
+            yield mock
+
+    def test_post_refinement_strips_hashtags_when_prefs_unset(self, mock_llm):
+        from cqc_lem.utilities.ai.ai_helper import get_ai_linked_post_refinement
+        get_ai_linked_post_refinement("Some draft post")
+        assert "Do NOT include any hashtags" in self._prompt_text(mock_llm)
+
+    def test_post_refinement_honors_opt_in(self, mock_llm):
+        from cqc_lem.utilities.ai.ai_helper import get_ai_linked_post_refinement
+        get_ai_linked_post_refinement("Some draft post", prefs={"use_hashtags": True})
+        prompt = self._prompt_text(mock_llm)
+        assert f"at most {cf.HASHTAG_MAX} highly relevant hashtags" in prompt
+
+    def test_blog_summary_prompt_has_no_hashtags_when_prefs_unset(self, mock_llm):
+        from cqc_lem.utilities.ai.ai_helper import get_blog_summary_post_from_ai
+        from cqc_lem.utilities.linkedin.profile import LinkedInProfile
+        profile = LinkedInProfile(full_name="Test User", job_title="CTO", company_name="ACME",
+                                  industry="Technology")
+        get_blog_summary_post_from_ai("https://example.com/post", "Blog body", profile, "awareness")
+        assert "Do NOT include any hashtags" in self._prompt_text(mock_llm)

--- a/tests/unit/utilities/ai/test_pref_alignment.py
+++ b/tests/unit/utilities/ai/test_pref_alignment.py
@@ -1,6 +1,6 @@
 """Configurability-audit tests: generation/refinement prompts must be driven by the user's
-engagement preferences (use_emojis / use_hashtags / tone) when set, and keep the pre-audit
-default wording when no prefs are supplied — no behavior change for unconfigured callers."""
+engagement preferences (use_emojis / use_hashtags / tone) when set. Hashtags follow the shared
+2026 policy (issue #393) — OFF unless the user explicitly opted in, in every prompt builder."""
 
 import json
 
@@ -29,22 +29,22 @@ class TestPostRefinementPrefs:
             get_ai_linked_post_refinement("Draft post", prefs=prefs)
         return _messages_text(llm)
 
-    def test_default_keeps_original_emoji_and_hashtag_lines(self):
+    def test_default_keeps_emoji_line_but_drops_hashtags(self):
         text = self._run(prefs=None)
         assert "Use emojis (✅, 👉, 🔑, 💡)" in text
-        assert "Place all hashtags together on the final line" in text
+        assert "Do NOT include any hashtags" in text
         assert "Do NOT use any emojis" not in text
 
     def test_emojis_off_instructs_removal(self):
         text = self._run(prefs={"use_emojis": False, "use_hashtags": True})
         assert "Do NOT use any emojis" in text
         assert "Use emojis (✅, 👉, 🔑, 💡)" not in text
-        assert "Place all hashtags together on the final line" in text
+        assert "at most 3 highly relevant hashtags" in text
 
     def test_hashtags_off_instructs_removal(self):
         text = self._run(prefs={"use_emojis": True, "use_hashtags": False})
-        assert "Do NOT add hashtags" in text
-        assert "Place all hashtags together on the final line" not in text
+        assert "Do NOT include any hashtags" in text
+        assert "at most 3 highly relevant hashtags" not in text
         assert "Use emojis (✅, 👉, 🔑, 💡)" in text
 
     def test_configured_tone_is_preserved(self):
@@ -80,14 +80,13 @@ class TestSummaryPostHashtagPrefs:
         from cqc_lem.utilities.linkedin.profile import LinkedInProfile
         return LinkedInProfile(**sample_linkedin_profile)
 
-    def test_blog_summary_default_keeps_hashtag_instruction(self, sample_linkedin_profile):
+    def test_blog_summary_default_has_no_hashtags(self, sample_linkedin_profile):
         from cqc_lem.utilities.ai.ai_helper import get_blog_summary_post_from_ai
         with patch(f"{_AI}._call_llm", return_value=_resp("post")) as llm:
             get_blog_summary_post_from_ai("https://x.test/a", "blog body",
                                           self._profile(sample_linkedin_profile), "awareness")
         text = _messages_text(llm)
-        assert "Use up to 5 relevant hashtags" in text
-        assert "Do NOT include any hashtags" not in text
+        assert "Do NOT include any hashtags" in text
 
     def test_blog_summary_hashtags_off(self, sample_linkedin_profile):
         from cqc_lem.utilities.ai.ai_helper import get_blog_summary_post_from_ai
@@ -97,7 +96,6 @@ class TestSummaryPostHashtagPrefs:
                                           prefs={"use_hashtags": False, "use_emojis": False})
         text = _messages_text(llm)
         assert "Do NOT include any hashtags" in text
-        assert "Use up to 5 relevant hashtags" not in text
         assert "Do NOT use any emojis" in text
 
     def test_website_post_hashtags_off(self, sample_linkedin_profile):
@@ -110,12 +108,12 @@ class TestSummaryPostHashtagPrefs:
         assert "Do NOT include any hashtags" in text
         assert "You can use emojis" in text
 
-    def test_website_post_default_unchanged(self, sample_linkedin_profile):
+    def test_website_post_default_has_no_hashtags(self, sample_linkedin_profile):
         from cqc_lem.utilities.ai.ai_helper import get_website_content_post_from_ai
         with patch(f"{_AI}._call_llm", return_value=_resp("post")) as llm:
             get_website_content_post_from_ai("site body", "https://x.test",
                                              self._profile(sample_linkedin_profile), "awareness")
-        assert "Use up to 5 relevant hashtags" in _messages_text(llm)
+        assert "Do NOT include any hashtags" in _messages_text(llm)
 
 
 class TestCarouselHashtagPref:
@@ -136,14 +134,19 @@ class TestCarouselHashtagPref:
             generate_carousel_content(user_id=1, stage="awareness", prefs=prefs)
         return _messages_text(llm)
 
-    def test_default_keeps_hashtag_instruction(self):
+    def test_default_has_no_hashtags(self):
         text = self._run(prefs=None)
-        assert "End with 5-10 relevant hashtags on the final line." in text
+        assert "Do NOT include any hashtags" in text
+        assert "End with 5-10 relevant hashtags" not in text
 
     def test_hashtags_off(self):
         text = self._run(prefs={"use_hashtags": False})
-        assert "Do NOT include any hashtags." in text
+        assert "Do NOT include any hashtags" in text
         assert "End with 5-10 relevant hashtags" not in text
+
+    def test_hashtags_opt_in_is_capped(self):
+        text = self._run(prefs={"use_hashtags": True})
+        assert "at most 3 highly relevant hashtags" in text
 
     def test_falls_back_to_cached_profile_before_generic_persona(self):
         from cqc_lem.utilities.ai.ai_helper import generate_carousel_content

--- a/tests/unit/utilities/ai/test_style_directive.py
+++ b/tests/unit/utilities/ai/test_style_directive.py
@@ -11,12 +11,12 @@ class TestStyleDirective:
         d = _style_directive({"tone": "warm", "comment_length": "short",
                               "use_emojis": False, "use_hashtags": False, "comment_style": "punchy"})
         assert "warm" in d and "short" in d
-        assert "Do not use emojis" in d and "Do not use any hashtags" in d and "punchy" in d
+        assert "Do not use emojis" in d and "Do NOT include any hashtags" in d and "punchy" in d
 
     def test_emojis_and_hashtags_allowed(self):
         from cqc_lem.utilities.ai.ai_helper import _style_directive
         d = _style_directive({"comment_length": "long", "use_emojis": True, "use_hashtags": True})
-        assert "tasteful emoji" in d and "hashtags are okay" in d.lower()
+        assert "tasteful emoji" in d and "at most 3 highly relevant hashtags" in d
 
     def test_empty_without_prefs(self):
         from cqc_lem.utilities.ai.ai_helper import _style_directive

--- a/tests/unit/utilities/test_linkedin_formatter.py
+++ b/tests/unit/utilities/test_linkedin_formatter.py
@@ -4,7 +4,41 @@ import pytest
 from cqc_lem.utilities.ai.content_alignment import LEAD_MAGNET_CTA_REPAIR_MENU
 from cqc_lem.utilities.linkedin_formatter import (
     sanitize_for_linkedin, normalize_public_text, PLAIN_PUNCTUATION_DIRECTIVE,
-    strip_engagement_bait, is_bait_keyword)
+    strip_engagement_bait, is_bait_keyword, contains_engagement_bait)
+
+
+@pytest.mark.unit
+class TestContainsEngagementBait:
+    """The ONE bait detector — shared by the stripper, the lead-magnet keyword guard, and the
+    content-framework CTA-menu test (issue #393)."""
+
+    @pytest.mark.parametrize("bait", [
+        "Follow for more tips like this.",
+        "Follow me for more.",
+        "Smash that save button.",
+        "Hit follow if this helped.",
+        "Type INFO below and I'll send it.",
+        "Type 'GUIDE' in the comments.",
+        "Drop a like if you're with me.",
+        "Drop a 🔥 if you relate.",
+    ])
+    def test_detects_2026_bait(self, bait):
+        assert contains_engagement_bait(bait)
+
+    @pytest.mark.parametrize("clean", [
+        "",
+        None,
+        "What would you do differently, and why?",
+        "Comment AUDIT and I'll DM you the checklist.",
+        "Save this for the next time you scope a launch.",
+        "Tell me where I'm wrong in the comments.",
+    ])
+    def test_leaves_genuine_ctas_alone(self, clean):
+        assert not contains_engagement_bait(clean)
+
+    def test_new_patterns_are_stripped_from_drafts(self):
+        text = "A real insight worth reading.\n\nFollow for more tips like this."
+        assert strip_engagement_bait(text) == "A real insight worth reading."
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## What & why

2026 algorithm reality: hashtags no longer expand reach (no-hashtag posts run **+5–10%**), and engagement-bait CTAs ("comment YES", "tag 3 people", "follow for more") are demoted rather than rewarded. This makes both the default.

**One policy, one place** — `utilities/ai/content_framework.py` gains `hashtag_directive(prefs)` and `cta_policy_directive()`, shared by newsletters, posts, comments, and carousels (no parallel per-content-type helpers).

### Hashtags default off
The DB/API defaults were already `use_hashtags = False`, but four prompt builders treated *unset* prefs as hashtags-**on** (`if (not prefs or prefs.get("use_hashtags"))`) — so unconfigured generation still produced 5–10 tags. All of them now route through `hashtag_directive(prefs)`: none by default, and capped at `HASHTAG_MAX = 3` when a user explicitly opts in.
- `get_ai_linked_post_refinement`, `get_blog_summary_post_from_ai`, `get_website_content_post_from_ai`, `generate_carousel_content`, plus `content_alignment.style_directive`.

### CTA menus retuned (no bait)
- `poll_prompt` → **Either/Or With Reasons**: asks which *and why*, instead of a one-comment vote.
- `share_forward` → **Pass It To One Person**: names the one person it helps; no blanket share/repost ask.
- `reply_question` / `challenge` / `debate`: explicitly rule out yes/no and one-word asks; ask for the result or the reasoning.
- `cta_policy_directive()` is now injected with **every** assigned CTA style via `blueprint_directive`, and replaces the old ad-hoc bait line in `post_writing_directive`.

### One bait detector, extended
Rather than adding a parallel matcher, the existing `linkedin_formatter._BAIT_PATTERNS` gained the 2026 patterns (follow-for-more, smash/hit save·follow·subscribe, "type X below", drop a like/emoji) and is exposed as `contains_engagement_bait()`. Lead-magnet `comment <KEYWORD>` CTAs remain exempt (`exempt_keyword` / `is_bait_keyword` unchanged).

### UI
The hashtag toggle in `EngagementSettingsCard.tsx` now says it is off by default, why, and that opting in stays minimal (≤3).

No migration required — `engagement_preferences.use_hashtags` already defaults to `0` (V34).

## Testing

- New `tests/unit/utilities/ai/test_hashtag_cta_policy.py` (16 tests): every CTA style label/guidance and every format guidance/structure step is asserted bait-free via the shared detector (the acceptance criterion), the directive is asserted present in `blueprint_directive` + `post_writing_directive`, and the hashtag-free default is asserted end-to-end through the real prompt builders (opt-in path covered too).
- `tests/unit/utilities/test_linkedin_formatter.py`: new `TestContainsEngagementBait` covering the added patterns and the genuine-CTA negatives.
- Existing tests that encoded the old hashtags-on default were updated to the new policy.
- `poetry run pytest tests/unit -q` → **3037 passed**. `tsc -b` clean on the UI change (local `vite build` needs a newer Node than this box has; CI covers it).

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)