### PR TITLE
fix(deploy): run Flyway with outOfOrder=true so timestamp migrations self-heal

### DIFF
--- a/compose/local/database/flyway-entrypoint.sh
+++ b/compose/local/database/flyway-entrypoint.sh
@@ -5,5 +5,14 @@ if [ -f .env ]; then
     export $(grep -v '^#' .env | xargs)
 fi
 
-flyway -baselineOnMigrate=True -validateMigrationNaming=True -url=jdbc:mysql://${MYSQL_HOST}/${MYSQL_DATABASE}?allowPublicKeyRetrieval=true  -schemas=${MYSQL_DATABASE} -user=${MYSQL_USER} -password=${MYSQL_PASSWORD} -connectRetries=3 repair
-flyway -baselineOnMigrate=True -validateMigrationNaming=True -url=jdbc:mysql://${MYSQL_HOST}/${MYSQL_DATABASE}?allowPublicKeyRetrieval=true  -schemas=${MYSQL_DATABASE} -user=${MYSQL_USER} -password=${MYSQL_PASSWORD} -connectRetries=3 migrate
+# outOfOrder=true is REQUIRED, not optional, for our timestamp-versioned migrations
+# (V<YYYYMMDDHHMMSS>__...). Timestamps guarantee unique versions, but PRs merge in an
+# arbitrary order — a PR held open for review lands its OLDER-timestamped migration AFTER
+# newer ones are already applied to prod. With the Flyway default (outOfOrder=false) that
+# older migration is "resolved but not applied below the high-water mark", so `validate`
+# fails and every deploy dies at this step. The migrations are independent additive DDL,
+# so applying them out of order is safe; this makes deploys self-heal that situation.
+FLYWAY_ARGS="-baselineOnMigrate=True -validateMigrationNaming=True -outOfOrder=True -url=jdbc:mysql://${MYSQL_HOST}/${MYSQL_DATABASE}?allowPublicKeyRetrieval=true -schemas=${MYSQL_DATABASE} -user=${MYSQL_USER} -password=${MYSQL_PASSWORD} -connectRetries=3"
+
+flyway ${FLYWAY_ARGS} repair
+flyway ${FLYWAY_ARGS} migrate

--- a/compose/local/database/flyway-entrypoint.sh
+++ b/compose/local/database/flyway-entrypoint.sh
@@ -12,7 +12,18 @@ fi
 # older migration is "resolved but not applied below the high-water mark", so `validate`
 # fails and every deploy dies at this step. The migrations are independent additive DDL,
 # so applying them out of order is safe; this makes deploys self-heal that situation.
-FLYWAY_ARGS="-baselineOnMigrate=True -validateMigrationNaming=True -outOfOrder=True -url=jdbc:mysql://${MYSQL_HOST}/${MYSQL_DATABASE}?allowPublicKeyRetrieval=true -schemas=${MYSQL_DATABASE} -user=${MYSQL_USER} -password=${MYSQL_PASSWORD} -connectRetries=3"
+# An array (expanded as "${FLYWAY_ARGS[@]}") keeps each flag a single word — a password with a
+# space or a glob char like * / ? would otherwise be split or expanded by an unquoted string.
+FLYWAY_ARGS=(
+  -baselineOnMigrate=true
+  -validateMigrationNaming=true
+  -outOfOrder=true
+  -url="jdbc:mysql://${MYSQL_HOST}/${MYSQL_DATABASE}?allowPublicKeyRetrieval=true"
+  -schemas="${MYSQL_DATABASE}"
+  -user="${MYSQL_USER}"
+  -password="${MYSQL_PASSWORD}"
+  -connectRetries=3
+)
 
-flyway ${FLYWAY_ARGS} repair
-flyway ${FLYWAY_ARGS} migrate
+flyway "${FLYWAY_ARGS[@]}" repair
+flyway "${FLYWAY_ARGS[@]}" migrate

--- a/compose/local/database/migrations/README.md
+++ b/compose/local/database/migrations/README.md
@@ -24,5 +24,11 @@ unique per authoring second and always sort **after** the legacy integer migrati
 - Legacy `V1`–`V58` are frozen and grandfathered; everything new is a timestamp.
 - Enforced by the **Migration Versions** CI check.
 
-Flyway runs `outOfOrder=false` with validation on, so a duplicate/out-of-order migration *fails
-the deploy* rather than silently skipping — timestamps prevent it entirely.
+Flyway runs with `outOfOrder=true` (see `../flyway-entrypoint.sh`). Timestamps make versions
+unique, but PRs merge in an arbitrary order — a PR held open for review lands its *older*
+timestamp after newer migrations are already applied to prod. With `outOfOrder=false` that older
+migration is "resolved but not applied below the high-water mark", which makes `validate` fail and
+kills every deploy at the migration step. `outOfOrder=true` applies it in place instead. This is
+safe because migrations are independent additive DDL — do **not** author a migration that depends
+on a later-timestamped one having already run. Duplicate *versions* are still rejected (and caught
+pre-merge by the **Migration Versions** check); only out-of-order *application* is allowed.


### PR DESCRIPTION
## The outage

Production deploys have failed at the **Flyway step** since v0.55.0. Prod froze at **v0.54.0** while releases climbed to v0.58.0. Builds succeeded — only the deploy's migration step failed:

```
ERROR: Validate failed: Migrations have failed validation
Detected resolved migration not applied to database: 20260723234736.
```

## Root cause

PR #442 (document posts) sat open for review for a day while newer-timestamped migrations merged and deployed ahead of it:

| version | migration | applied to prod? |
|---|---|---|
| `20260723211520` | add post stats saves | ✅ rank 59 |
| **`20260723234736`** | **add document post type (#442)** | ❌ pending |
| `20260724000418` | add post dwell score | ✅ rank 60 |
| `20260724011915` | add link in first comment | ❌ pending |

Once `20260724000418` was applied, `20260723234736` became "resolved but not applied **below the high-water mark**". Flyway's default `outOfOrder=false` rejects that on `validate`, so `deploy.sh` dies at `flyway migrate` under `set -e` — *before* the health-check/rollback stage, which is why prod just sat on the old tag with no rollback churn.

**Timestamp versions guarantee uniqueness but not that merge order matches timestamp order.** Any PR held open long enough reintroduces this. It is not a one-off.

## Fix

Run Flyway with `-outOfOrder=True`. Out-of-order *application* is exactly what timestamp versions require, and our migrations are independent additive DDL, so it's safe. Deploys now self-heal a straggler instead of dying.

- Duplicate *versions* are still rejected by Flyway, and still caught pre-merge by the **Migration Versions** CI check — only out-of-order application is now permitted.
- Shared flags refactored into `FLYWAY_ARGS` so `repair` and `migrate` can't drift.
- Updates the migrations README, which asserted the opposite behaviour.

## Note

Prod is being unblocked immediately by applying the two pending migrations out-of-order by hand (equivalent to what this makes automatic). This PR ensures the *next* long-lived PR doesn't refreeze the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)