### PR TITLE
feat(analytics): outcome-tracked A/B variant harness (closes #396)

### DIFF
--- a/compose/local/database/migrations/V20260724073055__add_post_variant_shipped.sql
+++ b/compose/local/database/migrations/V20260724073055__add_post_variant_shipped.sql
@@ -1,0 +1,19 @@
+-- Lightweight outcome-tracked A/B harness (issue #396 / D2). `generate_variants.py` produces
+-- media/content variants for human preview only — nothing records which one actually SHIPPED for a
+-- post, so realized `post_stats` can never be attributed back to the variant that earned them.
+--
+-- This table pins the shipped variant per post (one row per post — re-recording overwrites). Joined
+-- to the post's latest `post_stats` row it lets `select_variant_winners` pick winners over time.
+CREATE TABLE IF NOT EXISTS post_variants (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    user_id       INT NOT NULL,
+    post_id       INT NOT NULL,
+    batch_id      VARCHAR(64)  NULL,   -- generate_variants batch the shipped variant came from
+    variant_index INT          NULL,   -- its index within that batch
+    variant_key   VARCHAR(255) NOT NULL,  -- stable A/B identity (e.g. image|video|ratio|seed)
+    combo         JSON         NULL,   -- full combo for provenance
+    shipped_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_post (post_id),
+    KEY idx_user (user_id),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/compose/local/database/migrations/V20260724073055__add_post_variant_shipped.sql
+++ b/compose/local/database/migrations/V20260724073055__add_post_variant_shipped.sql
@@ -15,5 +15,6 @@ CREATE TABLE IF NOT EXISTS post_variants (
     shipped_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE KEY uq_post (post_id),
     KEY idx_user (user_id),
-    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+    FOREIGN KEY (post_id) REFERENCES posts(id) ON DELETE CASCADE
 );

--- a/src/cqc_lem/app/generate_variants.py
+++ b/src/cqc_lem/app/generate_variants.py
@@ -66,7 +66,10 @@ def combo_key(combo: dict) -> str:
     image = combo.get("image_model", DEFAULT_IMAGE_MODEL)
     include_video = combo.get("include_video", True)
     video = combo.get("video_model", DEFAULT_VIDEO_MODEL) if include_video else "none"
+    # Collapse a Runway resolution alias (e.g. "960:960") to its friendly aspect ("1:1")
+    # so equivalent ratios don't fragment outcome attribution into separate keys.
     ratio = combo.get("ratio", DEFAULT_VIDEO_RATIO)
+    ratio = _RES_TO_ASPECT.get(ratio, ratio)
     key = f"{image}|{video}|{ratio}"
     seed = combo.get("seed")
     if seed is not None:

--- a/src/cqc_lem/app/generate_variants.py
+++ b/src/cqc_lem/app/generate_variants.py
@@ -20,7 +20,7 @@ from cqc_lem.utilities.ai.ai_helper import (
     get_runway_ml_video_prompt_from_ai, create_runway_video,
 )
 from cqc_lem.utilities.ai.video_models import estimate_video_cost, RATIO_ALIASES
-from cqc_lem.utilities.db import get_post_content
+from cqc_lem.utilities.db import get_post_content, record_shipped_variant as _db_record_shipped_variant
 from cqc_lem.utilities.env_constants import (
     API_URL_FINAL, DEFAULT_VIDEO_MODEL, DEFAULT_VIDEO_RATIO, DEFAULT_IMAGE_MODEL,
 )
@@ -59,6 +59,31 @@ def _image_cost(image_model: str) -> float:
     return _IMAGE_COST.get(image_model, 0.03)
 
 
+def combo_key(combo: dict) -> str:
+    """Stable A/B identity for a variant combo — the key realized `post_stats` are attributed to
+    (issue #396). Combos that render the same look collapse to the same key; ``seed`` and the
+    video-off case are only encoded when they actually differ the output."""
+    image = combo.get("image_model", DEFAULT_IMAGE_MODEL)
+    include_video = combo.get("include_video", True)
+    video = combo.get("video_model", DEFAULT_VIDEO_MODEL) if include_video else "none"
+    ratio = combo.get("ratio", DEFAULT_VIDEO_RATIO)
+    key = f"{image}|{video}|{ratio}"
+    seed = combo.get("seed")
+    if seed is not None:
+        key += f"|seed={seed}"
+    return key
+
+
+def record_shipped_variant(user_id: int, post_id: int, combo: dict, *,
+                           batch_id: Optional[str] = None, variant_index: Optional[int] = None) -> bool:
+    """Record which variant `combo` actually shipped for `post_id` so its outcome can be attributed
+    later (issue #396 / D2). Derives the stable `combo_key` and persists via db; returns False on
+    any DB error rather than raising, so a shipping path is never broken by tracking."""
+    return _db_record_shipped_variant(
+        user_id, post_id, combo_key(combo), combo=combo,
+        batch_id=batch_id, variant_index=variant_index)
+
+
 def _public_url(batch_id: str, file_name: str) -> str:
     return f"{API_URL_FINAL}/api/assets?file_name=variants/{batch_id}/{file_name}"
 
@@ -86,7 +111,8 @@ def _generate_one_variant(idx: int, combo: dict, source_text: str, profile, user
         "duration": duration, "seed": seed, "include_video": include_video,
     }
     result = {
-        "combo": normalized_combo, "image_url": None, "video_url": None,
+        "combo": normalized_combo, "variant_key": combo_key(normalized_combo),
+        "image_url": None, "video_url": None,
         "image_prompt": "", "video_prompt": None,
         "estimated_cost_usd": 0.0, "error": None,
     }
@@ -156,7 +182,8 @@ def generate_media_variants(*, post_id: Optional[int] = None, text: Optional[str
         except Exception as e:
             log_warning(f"Variant {idx} failed", exc=e)
             variants.append({
-                "combo": combo, "image_url": None, "video_url": None,
+                "combo": combo, "variant_key": combo_key(combo),
+                "image_url": None, "video_url": None,
                 "image_prompt": "", "video_prompt": None,
                 "estimated_cost_usd": 0.0, "error": f"{type(e).__name__}: {e}",
             })

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3404,6 +3404,62 @@ def get_post_performance_rows(user_id: int, days: Optional[int] = None) -> list:
         connection.close()
 
 
+def record_shipped_variant(user_id: int, post_id: int, variant_key: str,
+                           combo: Optional[dict] = None, batch_id: Optional[str] = None,
+                           variant_index: Optional[int] = None) -> bool:
+    """Persist which A/B variant actually SHIPPED for a post (issue #396 / D2) so its realized
+    `post_stats` can be attributed back to that variant when picking winners. One row per post —
+    re-recording overwrites. `combo` is stored as JSON for provenance."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO post_variants (user_id, post_id, batch_id, variant_index, variant_key, combo) "
+            "VALUES (%s,%s,%s,%s,%s,%s) "
+            "ON DUPLICATE KEY UPDATE batch_id=VALUES(batch_id), variant_index=VALUES(variant_index), "
+            "variant_key=VALUES(variant_key), combo=VALUES(combo), shipped_at=CURRENT_TIMESTAMP",
+            (user_id, post_id, batch_id, variant_index, variant_key,
+             json.dumps(combo, default=str) if combo is not None else None))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not record shipped variant for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_variant_outcome_rows(user_id: int) -> list:
+    """Realized outcomes for shipped A/B variants (issue #396 / D2). Joins each recorded shipped
+    variant (`post_variants`) with its post's LATEST captured `post_stats` row → dicts of
+    ``{variant_key, scheduled_time, reactions, comments, reposts, impressions}`` that feed
+    ``post_stats.select_variant_winners``. `impressions` may be NULL (only the author's own view
+    exposes it), so winner selection falls back to raw counts until coverage is complete."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT v.variant_key, p.scheduled_time, s.reactions, s.comments, s.reposts, s.impressions "
+            "FROM post_variants v "
+            "JOIN posts p ON p.id=v.post_id AND p.user_id=v.user_id "
+            "JOIN post_stats s ON s.post_id=v.post_id AND s.user_id=v.user_id "
+            "WHERE v.user_id=%s AND s.id IN "
+            "(SELECT MAX(id) FROM post_stats WHERE user_id=%s GROUP BY post_id)",
+            (user_id, user_id))
+        return [
+            {"variant_key": r[0], "scheduled_time": r[1], "reactions": r[2],
+             "comments": r[3], "reposts": r[4], "impressions": r[5]}
+            for r in (cursor.fetchall() or [])
+        ]
+    except mysql.connector.Error as err:
+        myprint(f"Could not get variant outcome rows for user {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
 _LEAD_MAGNET_DEFAULTS: dict = {"enabled": False, "keyword": None, "message": None}
 
 

--- a/src/cqc_lem/utilities/post_stats.py
+++ b/src/cqc_lem/utilities/post_stats.py
@@ -172,6 +172,47 @@ def rank_content_attributes(rows: Iterable[Sequence], attributes: Optional[Itera
     return result
 
 
+def select_variant_winners(rows: Iterable[Mapping], top_n: Optional[int] = None,
+                           min_samples: int = 1, now: Optional[datetime] = None,
+                           half_life_days: float = RECENCY_HALF_LIFE_DAYS) -> dict:
+    """Outcome-tracked A/B winner selection (issue #396 / D2). `rows` are the dicts from
+    `db.get_variant_outcome_rows` — each a post that SHIPPED a given `variant_key`, carrying its
+    latest captured signals. Groups by variant_key and ranks by the SAME recency-weighted,
+    impression-normalized metric as `rank_content_attributes`, so a variant only wins on enough
+    RECENT evidence (a single stale fluke can't top the ranking). Returns
+    ``{"winner": <key or None>, "ranking": [{"key","score","avg_engagement","support","samples",
+    "metric"}, ...]}`` best-first; keys seen fewer than `min_samples` times are dropped. Pure — no
+    DB. The ranking entries share `rank_content_attributes`' shape so B3/B4 consumers can read
+    them the same way."""
+    groups: dict = defaultdict(list)
+    for r in rows:
+        if not r:
+            continue
+        key = r.get("variant_key")
+        if key is None or key == "":
+            continue
+        # Rebuild the canonical positional layout so the shared scoring machinery applies.
+        row = [None] * (_IDX_IMPRESSIONS + 1)
+        row[_IDX_SCHEDULED] = r.get("scheduled_time")
+        row[_IDX_REACTIONS] = r.get("reactions")
+        row[_IDX_COMMENTS] = r.get("comments")
+        row[_IDX_REPOSTS] = r.get("reposts")
+        row[_IDX_IMPRESSIONS] = r.get("impressions")
+        groups[key].append(row)
+    groups = {key: group for key, group in groups.items() if len(group) >= min_samples}
+    # Scale is decided across every variant so their keys stay comparable to each other.
+    rate_mode = _rate_mode([row for group in groups.values() for row in group])
+    scored = []
+    for key, group in groups.items():
+        raw_score, metrics = _group_metrics(group, rate_mode, now, half_life_days)
+        scored.append((raw_score, {"key": key, **metrics}))
+    scored.sort(key=lambda entry: (-entry[0], -entry[1]["samples"], str(entry[1]["key"])))
+    ranking = [entry for _, entry in scored]
+    if top_n:
+        ranking = ranking[:top_n]
+    return {"winner": ranking[0]["key"] if ranking else None, "ranking": ranking}
+
+
 def _int(value: Any) -> int:
     try:
         return int(value or 0)

--- a/tests/integration/test_variant_ab_harness.py
+++ b/tests/integration/test_variant_ab_harness.py
@@ -1,0 +1,161 @@
+"""Integration test for the outcome-tracked A/B harness (#396 / D2).
+
+Exercises the harness end to end through a stateful fake cursor that models the `posts`,
+`post_stats` and `post_variants` tables: a shipped variant is recorded (`record_shipped_variant`),
+its post's engagement is captured (`record_post_stats`), the two are joined back
+(`get_variant_outcome_rows`), and winner selection (`select_variant_winners`) provably reflects the
+seeded results — the acceptance criterion — without a live MySQL container.
+"""
+import json
+import re
+import pytest
+from datetime import datetime
+
+from unittest.mock import patch
+
+pytestmark = pytest.mark.integration
+
+_DB = "cqc_lem.utilities.db"
+
+
+class _FakeCursor:
+    """Minimal MySQL-ish cursor over in-memory `posts`, `post_stats`, `post_variants` stores."""
+
+    def __init__(self, posts, stats, variants):
+        self.posts = posts
+        self.stats = stats
+        self.variants = variants
+        self._result = []
+        self.rowcount = 0
+        self.lastrowid = 0
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        if s.startswith("INSERT INTO post_variants"):
+            user_id, post_id, batch_id, variant_index, variant_key, combo = params
+            self.variants[post_id] = {  # UNIQUE(post_id) → re-record overwrites
+                "user_id": user_id, "post_id": post_id, "batch_id": batch_id,
+                "variant_index": variant_index, "variant_key": variant_key, "combo": combo,
+            }
+            self.rowcount = 1
+        elif s.startswith("SELECT archetype, hook_style, post_type, topic, buyer_stage FROM posts"):
+            p = self.posts.get(params[0])
+            self._result = [(p["archetype"], p["hook_style"], p["post_type"],
+                             p["topic"], p["buyer_stage"])] if p else []
+        elif s.startswith("INSERT INTO post_stats"):
+            (user_id, post_id, reactions, comments, reposts, impressions, saves,
+             archetype, hook_style, fmt, topic, buyer_stage) = params
+            self.lastrowid = len(self.stats) + 1
+            self.stats.append({
+                "id": self.lastrowid, "user_id": user_id, "post_id": post_id,
+                "reactions": reactions, "comments": comments, "reposts": reposts,
+                "impressions": impressions, "saves": saves,
+            })
+            self.rowcount = 1
+        elif s.startswith("SELECT v.variant_key, p.scheduled_time, s.reactions"):
+            user_id = params[0]
+            latest = {}
+            for row in self.stats:  # append order → last wins = MAX(id)
+                if row["user_id"] == user_id:
+                    latest[row["post_id"]] = row
+            self._result = []
+            for v in self.variants.values():
+                if v["user_id"] != user_id:
+                    continue
+                r = latest.get(v["post_id"])
+                if r is None or v["post_id"] not in self.posts:
+                    continue
+                self._result.append((v["variant_key"], self.posts[v["post_id"]]["scheduled_time"],
+                                     r["reactions"], r["comments"], r["reposts"], r["impressions"]))
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return list(self._result)
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, posts, stats, variants):
+        self._cur = _FakeCursor(posts, stats, variants)
+
+    def cursor(self, *a, **k):
+        return self._cur
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class TestVariantABHarness:
+    def test_shipped_variant_recorded_and_winner_reflects_seeded_results(self):
+        from cqc_lem.utilities.db import (record_shipped_variant, record_post_stats,
+                                          get_variant_outcome_rows)
+        from cqc_lem.utilities.post_stats import select_variant_winners
+
+        now = datetime(2026, 7, 24, 12, 0)
+        # Two posts shipped variant A, two shipped variant B — B seeded as the strong performer.
+        posts = {
+            1: _post(datetime(2026, 7, 23, 9, 0)),
+            2: _post(datetime(2026, 7, 22, 9, 0)),
+            3: _post(datetime(2026, 7, 23, 9, 0)),
+            4: _post(datetime(2026, 7, 22, 9, 0)),
+        }
+        stats, variants = [], {}
+
+        def _conn(*a, **k):
+            return _FakeConn(posts, stats, variants)
+
+        combo_a = {"image_model": "flux-dev", "video_model": "gen4_turbo", "ratio": "1:1"}
+        combo_b = {"image_model": "flux-1.1-pro", "video_model": "gen4_turbo", "ratio": "1:1"}
+        with patch(f"{_DB}.get_db_connection", side_effect=_conn):
+            # 1) Persist which variant actually shipped for each post.
+            assert record_shipped_variant(1, 1, "A", combo=combo_a, batch_id="b", variant_index=0)
+            assert record_shipped_variant(1, 2, "A", combo=combo_a, batch_id="b", variant_index=0)
+            assert record_shipped_variant(1, 3, "B", combo=combo_b, batch_id="b", variant_index=1)
+            assert record_shipped_variant(1, 4, "B", combo=combo_b, batch_id="b", variant_index=1)
+            # 2) Capture engagement outcomes — B far outperforms A.
+            record_post_stats(1, 1, reactions=3, comments=0, impressions=500)
+            record_post_stats(1, 2, reactions=4, comments=1, impressions=500)
+            record_post_stats(1, 3, reactions=60, comments=15, impressions=500)
+            record_post_stats(1, 4, reactions=55, comments=12, impressions=500)
+            # 3) Read the shipped variants back joined to their outcomes, then pick a winner.
+            rows = get_variant_outcome_rows(1)
+            result = select_variant_winners(rows, now=now)
+
+        assert len(rows) == 4
+        # combo JSON round-trips as provenance on the recorded row.
+        assert json.loads(variants[1]["combo"])["image_model"] == "flux-dev"
+        assert result["winner"] == "B"
+        assert [r["key"] for r in result["ranking"]] == ["B", "A"]
+        assert result["ranking"][0]["samples"] == 2
+        assert result["ranking"][0]["metric"] == "engagement_rate"  # every row has impressions
+
+    def test_re_recording_overwrites_shipped_variant(self):
+        from cqc_lem.utilities.db import record_shipped_variant, get_variant_outcome_rows
+        posts = {1: _post(datetime(2026, 7, 23, 9, 0))}
+        stats = [{"id": 1, "user_id": 1, "post_id": 1, "reactions": 10, "comments": 0,
+                  "reposts": 0, "impressions": None}]
+        variants = {}
+
+        def _conn(*a, **k):
+            return _FakeConn(posts, stats, variants)
+
+        with patch(f"{_DB}.get_db_connection", side_effect=_conn):
+            record_shipped_variant(1, 1, "A")
+            record_shipped_variant(1, 1, "B")  # same post → overwrite
+            rows = get_variant_outcome_rows(1)
+
+        assert len(rows) == 1 and rows[0]["variant_key"] == "B"
+
+
+def _post(scheduled_time):
+    return {"user_id": 1, "post_type": "text", "buyer_stage": "awareness",
+            "scheduled_time": scheduled_time, "archetype": "a", "hook_style": "h", "topic": "t"}

--- a/tests/integration/test_variant_ab_harness.py
+++ b/tests/integration/test_variant_ab_harness.py
@@ -7,7 +7,6 @@ its post's engagement is captured (`record_post_stats`), the two are joined back
 seeded results — the acceptance criterion — without a live MySQL container.
 """
 import json
-import re
 import pytest
 from datetime import datetime
 

--- a/tests/unit/app/test_generate_variants.py
+++ b/tests/unit/app/test_generate_variants.py
@@ -101,6 +101,14 @@ class TestComboKey:
                          "ratio": "1:1", "include_video": False})
         assert key == "m|none|1:1"
 
+    def test_resolution_alias_collapses_to_friendly_ratio(self):
+        from cqc_lem.app.generate_variants import combo_key
+        base = {"image_model": "m", "video_model": "gen4_turbo"}
+        # A Runway resolution alias and its friendly aspect must yield the same key
+        # so equivalent ratios don't fragment outcome attribution.
+        assert combo_key({**base, "ratio": "960:960"}) == combo_key({**base, "ratio": "1:1"})
+        assert combo_key({**base, "ratio": "960:960"}) == "m|gen4_turbo|1:1"
+
 
 class TestVariantKeyInPayload:
     def test_each_variant_carries_its_key(self, tmp_path):

--- a/tests/unit/app/test_generate_variants.py
+++ b/tests/unit/app/test_generate_variants.py
@@ -80,3 +80,65 @@ class TestGenerateMediaVariants:
         assert payload["variants"][0]["error"] is not None
         assert payload["variants"][1]["error"] is None
         assert payload["variants"][1]["image_url"] is not None
+
+
+class TestComboKey:
+    def test_stable_key_encodes_models_and_ratio(self):
+        from cqc_lem.app.generate_variants import combo_key
+        key = combo_key({"image_model": "black-forest-labs/flux-1.1-pro",
+                         "video_model": "gen4_turbo", "ratio": "1:1"})
+        assert key == "black-forest-labs/flux-1.1-pro|gen4_turbo|1:1"
+
+    def test_seed_only_encoded_when_present(self):
+        from cqc_lem.app.generate_variants import combo_key
+        base = {"image_model": "m", "video_model": "gen4_turbo", "ratio": "1:1"}
+        assert combo_key(base) == "m|gen4_turbo|1:1"
+        assert combo_key({**base, "seed": 42}) == "m|gen4_turbo|1:1|seed=42"
+
+    def test_video_off_collapses_to_none(self):
+        from cqc_lem.app.generate_variants import combo_key
+        key = combo_key({"image_model": "m", "video_model": "gen4_turbo",
+                         "ratio": "1:1", "include_video": False})
+        assert key == "m|none|1:1"
+
+
+class TestVariantKeyInPayload:
+    def test_each_variant_carries_its_key(self, tmp_path):
+        img = _make_image(tmp_path)
+        with patch("cqc_lem.app.generate_variants.assets_dir", str(tmp_path)), \
+             patch("cqc_lem.app.generate_variants.get_flux_image_prompt_from_ai", return_value="p"), \
+             patch("cqc_lem.app.generate_variants.generate_flux1_image_from_prompt", return_value=img), \
+             patch("cqc_lem.app.generate_variants.create_runway_video", return_value=None):
+            from cqc_lem.app.generate_variants import generate_media_variants
+            payload = generate_media_variants(
+                text="topic",
+                combos=[{"image_model": "black-forest-labs/flux-dev", "video_model": "gen4_turbo",
+                         "ratio": "1:1", "include_video": False}],
+                timestamp=1,
+            )
+        assert payload["variants"][0]["variant_key"] == "black-forest-labs/flux-dev|none|1:1"
+
+    def test_failed_variant_still_carries_key(self, tmp_path):
+        with patch("cqc_lem.app.generate_variants.assets_dir", str(tmp_path)), \
+             patch("cqc_lem.app.generate_variants.get_flux_image_prompt_from_ai",
+                   side_effect=RuntimeError("boom")):
+            from cqc_lem.app.generate_variants import generate_media_variants
+            payload = generate_media_variants(
+                text="topic",
+                combos=[{"image_model": "m", "video_model": "gen4_turbo", "ratio": "1:1"}],
+                timestamp=1,
+            )
+        v = payload["variants"][0]
+        assert v["error"] is not None and v["variant_key"] == "m|gen4_turbo|1:1"
+
+
+class TestRecordShippedVariant:
+    def test_derives_key_and_delegates_to_db(self):
+        with patch("cqc_lem.app.generate_variants._db_record_shipped_variant",
+                   return_value=True) as rec:
+            from cqc_lem.app.generate_variants import record_shipped_variant
+            combo = {"image_model": "m", "video_model": "gen4_turbo", "ratio": "1:1", "seed": 7}
+            ok = record_shipped_variant(1, 99, combo, batch_id="b1", variant_index=2)
+        assert ok is True
+        rec.assert_called_once_with(1, 99, "m|gen4_turbo|1:1|seed=7", combo=combo,
+                                    batch_id="b1", variant_index=2)

--- a/tests/unit/utilities/test_db_coverage_errors.py
+++ b/tests/unit/utilities/test_db_coverage_errors.py
@@ -93,6 +93,8 @@ _ERROR_CASES = [
     ("record_post_stats", (1, 2, 3, 4), False),
     ("get_recent_posted_post_ids", (1,), []),
     ("get_post_engagement_rows", (1,), []),
+    ("record_shipped_variant", (1, 2, "flux|gen4|1:1"), False),
+    ("get_variant_outcome_rows", (1,), []),
     ("has_received_lead_magnet", (1, "u"), True),  # fail-safe: never double-DM
     ("record_lead_magnet_sent", (1, "u"), False),
     ("update_newsletter_settings", (1, {"enabled": True}), False),

--- a/tests/unit/utilities/test_post_stats.py
+++ b/tests/unit/utilities/test_post_stats.py
@@ -356,3 +356,67 @@ class TestScrapeStatsTask:
             from cqc_lem.app.run_automation import auto_scrape_post_stats
             result = auto_scrape_post_stats.run(user_id=1)
         assert rec.call_count == 2 and "Scraped stats for 2" in result
+
+
+def _variant_row(variant_key, scheduled_time, reactions=0, comments=0, reposts=0, impressions=None):
+    """A `db.get_variant_outcome_rows` dict."""
+    return {"variant_key": variant_key, "scheduled_time": scheduled_time, "reactions": reactions,
+            "comments": comments, "reposts": reposts, "impressions": impressions}
+
+
+class TestSelectVariantWinners:
+    def test_winner_reflects_seeded_results(self):
+        from cqc_lem.utilities.post_stats import select_variant_winners
+        rows = [
+            _variant_row("A", _NOW - dt.timedelta(days=2), reactions=5, comments=1),
+            _variant_row("B", _NOW - dt.timedelta(days=2), reactions=40, comments=10),
+        ]
+        out = select_variant_winners(rows, now=_NOW)
+        assert out["winner"] == "B"
+        assert [r["key"] for r in out["ranking"]] == ["B", "A"]
+        assert out["ranking"][0]["metric"] == "engagement"
+
+    def test_rate_mode_when_all_have_impressions(self):
+        """Small-reach variant with a far higher RATE wins over a big-reach loser."""
+        from cqc_lem.utilities.post_stats import select_variant_winners
+        rows = [
+            _variant_row("small", _NOW - dt.timedelta(days=1), reactions=30, impressions=300),
+            _variant_row("big", _NOW - dt.timedelta(days=1), reactions=100, impressions=100_000),
+        ]
+        out = select_variant_winners(rows, now=_NOW)
+        assert out["winner"] == "small"
+        assert out["ranking"][0]["metric"] == "engagement_rate"
+
+    def test_recent_evidence_beats_stale_fluke(self):
+        from cqc_lem.utilities.post_stats import select_variant_winners
+        rows = [
+            _variant_row("stale", _NOW - dt.timedelta(days=400), reactions=200),
+            _variant_row("fresh", _NOW - dt.timedelta(days=1), reactions=30),
+            _variant_row("fresh", _NOW - dt.timedelta(days=2), reactions=28),
+        ]
+        out = select_variant_winners(rows, now=_NOW)
+        assert out["winner"] == "fresh"
+
+    def test_min_samples_drops_thin_variants(self):
+        from cqc_lem.utilities.post_stats import select_variant_winners
+        rows = [
+            _variant_row("A", _NOW - dt.timedelta(days=1), reactions=5),
+            _variant_row("B", _NOW - dt.timedelta(days=1), reactions=99),
+            _variant_row("B", _NOW - dt.timedelta(days=2), reactions=90),
+        ]
+        out = select_variant_winners(rows, min_samples=2, now=_NOW)
+        assert [r["key"] for r in out["ranking"]] == ["B"]
+
+    def test_top_n_truncates(self):
+        from cqc_lem.utilities.post_stats import select_variant_winners
+        rows = [_variant_row(k, _NOW - dt.timedelta(days=1), reactions=n)
+                for k, n in (("A", 30), ("B", 20), ("C", 10))]
+        out = select_variant_winners(rows, top_n=2, now=_NOW)
+        assert [r["key"] for r in out["ranking"]] == ["A", "B"]
+
+    def test_empty_and_keyless_rows(self):
+        from cqc_lem.utilities.post_stats import select_variant_winners
+        assert select_variant_winners([]) == {"winner": None, "ranking": []}
+        out = select_variant_winners([None, {"variant_key": None, "reactions": 5},
+                                      {"variant_key": "", "reactions": 5}])
+        assert out == {"winner": None, "ranking": []}


### PR DESCRIPTION
## What & why
`generate_variants.py` produced media/content variants for **human preview only** — nothing recorded which one actually shipped for a post, so realized `post_stats` could never be attributed back to the variant that earned them, and no winner could be selected. This adds a lightweight, outcome-tracked A/B harness (D2 / Milestone 10).

## Changes
- **Migration** `V20260724073055__add_post_variant_shipped.sql` — new `post_variants` table (one row per post via `UNIQUE(post_id)`; re-recording overwrites), storing `variant_key`, `combo` (JSON provenance), `batch_id`, `variant_index`.
- **`utilities/db.py`**
  - `record_shipped_variant(user_id, post_id, variant_key, combo=…, batch_id=…, variant_index=…)` — upserts the shipped variant.
  - `get_variant_outcome_rows(user_id)` — joins each shipped variant to its post's **latest** captured `post_stats` row (`MAX(id)`), returning `{variant_key, scheduled_time, reactions, comments, reposts, impressions}`.
- **`utilities/post_stats.py`** — pure `select_variant_winners(rows, …)`: groups by `variant_key` and ranks by the **same** recency-weighted, impression-normalized metric as `rank_content_attributes` (so a variant only wins on enough recent evidence; a stale fluke can't top it). Returns `{"winner", "ranking": [...]}`, ranking entries sharing `rank_content_attributes`' shape so B3/B4 consumers read them identically.
- **`app/generate_variants.py`** — stable `combo_key()`, a `variant_key` on every variant payload (success **and** error paths), and a `record_shipped_variant()` wrapper that derives the key and never raises into a shipping path.

## Testing notes
- Unit: `combo_key` / `variant_key` payload / wrapper delegation; `select_variant_winners` (winner reflects seeded results, rate-mode vs count-mode, recency-vs-stale, `min_samples`, `top_n`, empty/keyless); db error-fallback contract for the two new helpers.
- Integration (`test_variant_ab_harness.py`): full loop over a stateful fake cursor — shipped variant recorded → outcomes captured → joined back → **winner selection reflects the seeded strong performer**; plus re-record overwrite.
- `poetry run pytest tests/unit` → 3074 passed; new integration test green.

Closes #396

🤖 Generated with [Claude Code](https://claude.com/claude-code)