### PR TITLE
feat(analytics): real LLM token/cost + post-outcome PostHog events (closes #397)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -44,6 +44,7 @@ from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited, _redis_client
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text
 from cqc_lem.utilities.logger import myprint, log_error, log_info, log_warning
+from cqc_lem.utilities.observability import track_post_outcome
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
     get_element_wait_retry, get_elements_as_list_wait_stale, getText, close_tab, get_driver_wait_pair, quit_gracefully, \
     wait_for_ajax, find_first, click_first, find_all_first
@@ -1515,6 +1516,10 @@ def auto_scrape_post_stats(self, user_id: int):
                               reposts=counts.get("reposts") or 0,
                               impressions=counts.get("impressions") or None,
                               saves=counts.get("saves") or 0)
+            track_post_outcome(post_id=pid, reactions=counts.get("reactions", 0),
+                               comments=counts.get("comments", 0), reposts=counts.get("reposts") or 0,
+                               impressions=counts.get("impressions") or None,
+                               saves=counts.get("saves") or 0, user_id=user_id)
             scraped += 1
         return f"Scraped stats for {scraped} post(s)"
     finally:

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -1,7 +1,8 @@
+import json
 import os
 import time
 from functools import wraps
-from typing import Optional
+from typing import Optional, Tuple
 
 import posthog
 
@@ -17,6 +18,61 @@ posthog.on_error = _posthog_on_error
 # Disable PostHog when no key configured (local dev without key)
 if not posthog.api_key:
     posthog.disabled = True
+
+
+# Approximate USD cost per 1K tokens as (input, output), keyed by the model string passed to
+# track_llm_call — the tier alias (lem-*) in normal operation, or a raw model name. These are
+# coarse blended estimates for cost TREND analytics, not billing; override any entry with the
+# LLM_COST_PER_1K env var (JSON: {"lem-complex": [0.003, 0.015], ...}).
+_DEFAULT_COST_PER_1K = {
+    "lem-simple": (0.00015, 0.00060),
+    "lem-medium": (0.00060, 0.00240),
+    "lem-complex": (0.00300, 0.01500),
+    "lem-router": (0.00060, 0.00240),
+    "lem-research": (0.00100, 0.00100),
+    "lem-image": (0.0, 0.0),
+}
+
+
+def _cost_table() -> dict:
+    table = dict(_DEFAULT_COST_PER_1K)
+    raw = os.getenv("LLM_COST_PER_1K")
+    if raw:
+        try:
+            for key, val in json.loads(raw).items():
+                if isinstance(val, (list, tuple)) and len(val) == 2:
+                    table[key] = (float(val[0]), float(val[1]))
+        except (ValueError, TypeError):
+            pass
+    return table
+
+
+def estimate_llm_cost_usd(model: str, prompt_tokens: int, completion_tokens: int) -> float:
+    """Coarse USD cost estimate for a completion from a per-1K-token price table (env-overridable
+    via LLM_COST_PER_1K). Unknown models fall back to a substring match then the lem-medium rate so
+    a real call's cost signal is never silently zero. Returns 0.0 when there are no tokens."""
+    prompt = int(prompt_tokens or 0)
+    completion = int(completion_tokens or 0)
+    if not prompt and not completion:
+        return 0.0
+    table = _cost_table()
+    rates = table.get(model)
+    if rates is None:
+        key = next((k for k in table if k != "lem-image" and k in (model or "")), None)
+        rates = table[key] if key else table["lem-medium"]
+    cost = (prompt / 1000.0) * rates[0] + (completion / 1000.0) * rates[1]
+    return round(cost, 6)
+
+
+def _extract_token_usage(result) -> Tuple[int, int]:
+    """(prompt_tokens, completion_tokens) from an OpenAI-style response's `.usage`, or (0, 0) when
+    the wrapped call returned something without usage."""
+    usage = getattr(result, "usage", None)
+    if usage is None:
+        return 0, 0
+    prompt = int(getattr(usage, "prompt_tokens", 0) or 0)
+    completion = int(getattr(usage, "completion_tokens", 0) or 0)
+    return prompt, completion
 
 
 def track_llm_call(
@@ -35,8 +91,40 @@ def track_llm_call(
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": prompt_tokens + completion_tokens,
+            "cost_usd": estimate_llm_cost_usd(model, prompt_tokens, completion_tokens),
             "latency_ms": latency_ms,
             "success": success,
+        },
+    )
+
+
+def track_post_outcome(
+    post_id: int,
+    reactions: Optional[int],
+    comments: Optional[int],
+    reposts: Optional[int] = 0,
+    impressions: Optional[int] = None,
+    saves: Optional[int] = 0,
+    user_id: Optional[int] = None,
+    **extra,
+) -> None:
+    """Emit a LinkedIn post-outcome event so content performance (impressions / engagement rate) is
+    queryable in PostHog alongside LLM cost. `engagement` / `engagement_rate` are derived with the
+    same weighting `post_stats` uses; `engagement_rate` is None when impressions are unknown."""
+    from cqc_lem.utilities.post_stats import engagement_score, engagement_rate
+    posthog.capture(
+        distinct_id=str(user_id or "system"),
+        event="post_outcome",
+        properties={
+            "post_id": post_id,
+            "reactions": int(reactions or 0),
+            "comments": int(comments or 0),
+            "reposts": int(reposts or 0),
+            "saves": int(saves or 0),
+            "impressions": int(impressions) if impressions else None,
+            "engagement": engagement_score(reactions, comments, reposts),
+            "engagement_rate": engagement_rate(reactions, comments, reposts, impressions),
+            **extra,
         },
     )
 
@@ -82,10 +170,11 @@ def llm_tracked(model_alias: str):
             start = time.time()
             try:
                 result = fn(*args, **kwargs)
+                prompt_tokens, completion_tokens = _extract_token_usage(result)
                 track_llm_call(
                     model=model_alias,
-                    prompt_tokens=0,
-                    completion_tokens=0,
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
                     latency_ms=int((time.time() - start) * 1000),
                     success=True,
                 )

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -34,16 +34,30 @@ _DEFAULT_COST_PER_1K = {
 }
 
 
+# Cache the parsed cost table keyed by the raw LLM_COST_PER_1K value so track_llm_call() — which
+# runs on every LLM invocation — doesn't reparse the JSON each call. Rebuilt only when the env var
+# changes (sentinel distinguishes "unset" from "" so both are cached).
+_UNSET = object()
+_cost_table_cache: Optional[dict] = None
+_cost_table_raw = _UNSET
+
+
 def _cost_table() -> dict:
-    table = dict(_DEFAULT_COST_PER_1K)
+    global _cost_table_cache, _cost_table_raw
     raw = os.getenv("LLM_COST_PER_1K")
+    if _cost_table_cache is not None and raw == _cost_table_raw:
+        return _cost_table_cache
+    table = dict(_DEFAULT_COST_PER_1K)
     if raw:
         try:
             for key, val in json.loads(raw).items():
                 if isinstance(val, (list, tuple)) and len(val) == 2:
                     table[key] = (float(val[0]), float(val[1]))
         except (ValueError, TypeError):
+            # Malformed override JSON: keep the built-in defaults rather than crash the tracked call.
             pass
+    _cost_table_cache = table
+    _cost_table_raw = raw
     return table
 
 
@@ -60,8 +74,9 @@ def estimate_llm_cost_usd(model: str, prompt_tokens: int, completion_tokens: int
     if rates is None:
         key = next((k for k in table if k != "lem-image" and k in (model or "")), None)
         rates = table[key] if key else table["lem-medium"]
-    cost = (prompt / 1000.0) * rates[0] + (completion / 1000.0) * rates[1]
-    return round(cost, 6)
+    # No rounding: a few prompt tokens on a cheap tier round to 0.0 at 6dp, which would erase the
+    # non-zero cost signal for real calls. PostHog handles display rounding.
+    return (prompt / 1000.0) * rates[0] + (completion / 1000.0) * rates[1]
 
 
 def _extract_token_usage(result) -> Tuple[int, int]:

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -1,11 +1,16 @@
 """Unit tests for cqc_lem.utilities.observability."""
 
 import pytest
+from types import SimpleNamespace
 from unittest.mock import patch
 
 pytestmark = pytest.mark.unit
 
 _MOD = "cqc_lem.utilities.observability"
+
+
+def _usage(prompt, completion):
+    return SimpleNamespace(usage=SimpleNamespace(prompt_tokens=prompt, completion_tokens=completion))
 
 
 class TestTrackLlmCall:
@@ -24,6 +29,15 @@ class TestTrackLlmCall:
         assert props["total_tokens"] == 30
         assert props["latency_ms"] == 150
         assert props["success"] is True
+        assert props["cost_usd"] > 0
+
+    def test_cost_is_zero_when_no_tokens(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="lem-simple", prompt_tokens=0, completion_tokens=0, latency_ms=10)
+
+        _, kwargs = mock_ph.capture.call_args
+        assert kwargs["properties"]["cost_usd"] == 0.0
 
     def test_uses_system_distinct_id_when_no_user(self):
         with patch(f"{_MOD}.posthog") as mock_ph:
@@ -181,3 +195,105 @@ class TestLlmTrackedDecorator:
         latency = kwargs["properties"]["latency_ms"]
         assert isinstance(latency, int)
         assert latency >= 0
+
+    def test_real_tokens_extracted_from_response_usage(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import llm_tracked
+
+            @llm_tracked("lem-complex")
+            def call():
+                return _usage(120, 340)
+
+            call()
+
+        _, kwargs = mock_ph.capture.call_args
+        props = kwargs["properties"]
+        assert props["prompt_tokens"] == 120
+        assert props["completion_tokens"] == 340
+        assert props["total_tokens"] == 460
+        assert props["cost_usd"] > 0
+
+    def test_zero_tokens_when_result_has_no_usage(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import llm_tracked
+
+            @llm_tracked("lem-simple")
+            def call():
+                return "plain string"
+
+            call()
+
+        _, kwargs = mock_ph.capture.call_args
+        props = kwargs["properties"]
+        assert props["prompt_tokens"] == 0
+        assert props["completion_tokens"] == 0
+        assert props["cost_usd"] == 0.0
+
+
+class TestEstimateLlmCost:
+    def test_zero_tokens_zero_cost(self):
+        from cqc_lem.utilities.observability import estimate_llm_cost_usd
+        assert estimate_llm_cost_usd("lem-complex", 0, 0) == 0.0
+
+    def test_known_alias_nonzero_cost(self):
+        from cqc_lem.utilities.observability import estimate_llm_cost_usd
+        # lem-complex: (0.003 input, 0.015 output) per 1K → 1000*0.003 + 1000*0.015
+        assert estimate_llm_cost_usd("lem-complex", 1000, 1000) == pytest.approx(0.018)
+
+    def test_unknown_model_falls_back_to_medium(self):
+        from cqc_lem.utilities.observability import estimate_llm_cost_usd
+        # lem-medium: (0.0006, 0.0024) per 1K
+        assert estimate_llm_cost_usd("totally-unknown", 1000, 1000) == pytest.approx(0.003)
+
+    def test_substring_match_before_default(self):
+        from cqc_lem.utilities.observability import estimate_llm_cost_usd
+        # "openai/lem-simple-v2" contains "lem-simple" → simple rates, not the medium fallback
+        assert estimate_llm_cost_usd("openai/lem-simple-v2", 1000, 0) == pytest.approx(0.00015)
+
+    def test_env_override(self):
+        with patch.dict("os.environ", {"LLM_COST_PER_1K": '{"lem-simple": [1.0, 2.0]}'}):
+            from cqc_lem.utilities.observability import estimate_llm_cost_usd
+            assert estimate_llm_cost_usd("lem-simple", 1000, 1000) == pytest.approx(3.0)
+
+    def test_malformed_env_override_ignored(self):
+        with patch.dict("os.environ", {"LLM_COST_PER_1K": "not json"}):
+            from cqc_lem.utilities.observability import estimate_llm_cost_usd
+            assert estimate_llm_cost_usd("lem-simple", 1000, 0) == pytest.approx(0.00015)
+
+
+class TestTrackPostOutcome:
+    def test_captures_post_outcome_event(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_post_outcome
+            track_post_outcome(post_id=9, reactions=10, comments=4, reposts=2,
+                               impressions=500, saves=3, user_id=1)
+
+        mock_ph.capture.assert_called_once()
+        _, kwargs = mock_ph.capture.call_args
+        assert kwargs["event"] == "post_outcome"
+        assert kwargs["distinct_id"] == "1"
+        props = kwargs["properties"]
+        assert props["post_id"] == 9
+        assert props["impressions"] == 500
+        # engagement = 10 + 2*4 + 2*2 = 22 ; rate = 22/500
+        assert props["engagement"] == 22
+        assert props["engagement_rate"] == pytest.approx(22 / 500)
+
+    def test_engagement_rate_none_without_impressions(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_post_outcome
+            track_post_outcome(post_id=1, reactions=3, comments=1)
+
+        _, kwargs = mock_ph.capture.call_args
+        props = kwargs["properties"]
+        assert props["impressions"] is None
+        assert props["engagement_rate"] is None
+        assert kwargs["distinct_id"] == "system"
+
+    def test_extra_attribution_passed_through(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_post_outcome
+            track_post_outcome(post_id=1, reactions=1, comments=0, archetype="how-to")
+
+        _, kwargs = mock_ph.capture.call_args
+        assert kwargs["properties"]["archetype"] == "how-to"

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -260,6 +260,13 @@ class TestEstimateLlmCost:
             from cqc_lem.utilities.observability import estimate_llm_cost_usd
             assert estimate_llm_cost_usd("lem-simple", 1000, 0) == pytest.approx(0.00015)
 
+    def test_tiny_cost_not_collapsed_to_zero(self):
+        # A few prompt tokens on the cheapest tier costs < 1e-6 USD; must stay non-zero (no rounding).
+        from cqc_lem.utilities.observability import estimate_llm_cost_usd
+        cost = estimate_llm_cost_usd("lem-simple", 3, 0)
+        assert cost > 0.0
+        assert cost == pytest.approx(3 / 1000.0 * 0.00015)
+
 
 class TestTrackPostOutcome:
     def test_captures_post_outcome_event(self):


### PR DESCRIPTION
## What & why
`track_llm_call` token fields were hardcoded to `0` by the `llm_tracked` decorator, so PostHog cost analytics were a stub, and no PostHog events tied back to LinkedIn post outcomes (issue #397).

### Real token/cost (`llm_call`)
- `llm_tracked` now extracts real `prompt_tokens` / `completion_tokens` from the wrapped call's OpenAI-style response (`.usage`), falling back to `(0, 0)` when a wrapped call returns something without usage.
- Every `llm_call` event now carries an estimated `cost_usd`, computed from a coarse per-1K-token price table keyed by model/tier alias. Unknown models fall back to a substring match then the `lem-medium` rate; the whole table is overridable via the `LLM_COST_PER_1K` env var (JSON). Cost is `0.0` when there are no tokens.
- `_call_llm` in `ai_helper.py` already passed real tokens; this closes the gap on the decorator path.

### Post-outcome events (`post_outcome`)
- New `track_post_outcome()` emits impressions, reactions/comments/reposts/saves, and the derived `engagement` + `engagement_rate` (reusing `post_stats` weighting; rate is `None` when impressions are unknown).
- Wired into `auto_scrape_post_stats` alongside `record_post_stats`, so content performance is queryable in PostHog next to LLM cost.

## Testing
- Extended `tests/unit/utilities/test_observability.py`: decorator token extraction (with/without usage), `cost_usd` non-zero/zero paths, `estimate_llm_cost_usd` (known alias, unknown fallback, substring match, env override + malformed override), and `track_post_outcome` (event shape, rate-None-without-impressions, extra attribution passthrough).
- `poetry run pytest tests/unit/utilities/test_observability.py tests/unit/app/test_sweep_fixes.py tests/unit/utilities/test_post_stats.py` — all green (85 tests).

## Acceptance
PostHog receives non-zero token/cost `llm_call` events and new `post_outcome` events (verify via PostHog MCP).

Closes #397

🤖 Generated with [Claude Code](https://claude.com/claude-code)