### PR TITLE
feat(outreach): comment→connect→DM outreach funnel, approval-gated (closes #399)

### DIFF
--- a/compose/local/database/migrations/V20260724110833__add_outreach_funnel.sql
+++ b/compose/local/database/migrations/V20260724110833__add_outreach_funnel.sql
@@ -1,0 +1,43 @@
+-- Comment-first outreach funnel (issue #399): a sequenced, APPROVAL-GATED
+-- value-comment -> connect -> DM funnel keyed to a per-user target list. The comment/connect/DM
+-- send primitives (comment_on_post, invite_to_connect, send_private_dm) and the DM
+-- template/follow-up machinery already exist; this table is the missing per-prospect state store.
+--
+-- One row per (user_id, target_profile_url). `stage` is where the prospect is in the funnel and
+-- `status` is the state of that stage. A stage only fires when a human has approved it
+-- (status='approved'); firing it advances the target to the NEXT stage as 'pending', which requires
+-- a fresh approval — so no step ever auto-fires at volume. Status/stage mirror the scheduled_dms
+-- pending->approved->acted lifecycle:
+--   stage:  comment -> connect -> dm -> completed
+--   status: pending  -> draft awaiting human approval
+--           approved -> human approved; the funnel processor will fire this stage on its next run
+--           acted    -> terminal: the final (dm) stage fired
+--           skipped  -> current stage skipped without firing (no draft to act on)
+--           failed   -> firing the stage errored (e.g. comment stage with no post URL)
+--           canceled -> operator canceled the whole funnel for this target
+CREATE TABLE IF NOT EXISTS outreach_funnel_targets (
+    id                  INT AUTO_INCREMENT PRIMARY KEY,
+    user_id             INT NOT NULL,
+    target_profile_url  VARCHAR(512) NOT NULL,
+    target_name         VARCHAR(255) NULL,
+    stage               ENUM('comment','connect','dm','completed') NOT NULL DEFAULT 'comment',
+    status              ENUM('pending','approved','acted','skipped','failed','canceled') NOT NULL DEFAULT 'pending',
+    context_url         VARCHAR(512) NULL,   -- post to comment on (comment stage)
+    draft_text          TEXT NULL,           -- drafted action text for the current stage, awaiting approval
+    notes               VARCHAR(512) NULL,
+    created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_funnel_user_target (user_id, target_profile_url),
+    KEY idx_funnel_user_status (user_id, status),
+    KEY idx_funnel_stage_status (stage, status),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Route funnel DMs through the existing DM template + follow-up machinery by adding a 'funnel'
+-- event_type. Preserves the existing enum values and appends the new one.
+ALTER TABLE dm_templates
+    MODIFY event_type ENUM('connection_accepted','recommendation_received','collaboration',
+                           'profile_viewer','manual','funnel') NOT NULL;
+ALTER TABLE dm_followups
+    MODIFY event_type ENUM('connection_accepted','recommendation_received','collaboration',
+                           'profile_viewer','manual','funnel') NOT NULL;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1744,11 +1744,18 @@ def create_outreach_target_endpoint(request: OutreachTargetRequest) -> ResponseM
     user_id = get_session_user_id(request.session_token)
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
-    if get_outreach_target_by_url(user_id, request.target_profile_url):
+    # Normalize at the boundary so whitespace variants ("…/in/jane" vs "…/in/jane ") can't slip past
+    # the duplicate check and the unique constraint as distinct rows.
+    target_profile_url = request.target_profile_url.strip()
+    target_name = request.target_name.strip() if request.target_name else None
+    context_url = request.context_url.strip() if request.context_url else None
+    if not target_profile_url:
+        raise HTTPException(status_code=422, detail="target_profile_url is required")
+    if get_outreach_target_by_url(user_id, target_profile_url):
         raise HTTPException(status_code=409, detail="Target is already in the outreach funnel")
     status = OutreachStatus.APPROVED if request.status == "approved" else OutreachStatus.PENDING
-    target_id = insert_outreach_target(user_id, request.target_profile_url,
-                                       target_name=request.target_name, context_url=request.context_url,
+    target_id = insert_outreach_target(user_id, target_profile_url,
+                                       target_name=target_name, context_url=context_url,
                                        draft_text=request.draft_text, status=status)
     if not target_id:
         raise HTTPException(status_code=500, detail="Could not create outreach target")

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -27,6 +27,9 @@ from cqc_lem.utilities.db import (
     update_scheduled_dm, update_scheduled_dm_status, ScheduledDmStatus,
     insert_connection_request, get_connection_requests, get_connection_request_user_id,
     update_connection_request, update_connection_request_status, ConnectionRequestStatus,
+    insert_outreach_target, get_outreach_targets, get_outreach_target_user_id,
+    get_outreach_target_by_url, update_outreach_target, update_outreach_target_status,
+    OutreachStatus,
     create_pin_for_email, verify_pin_for_email, delete_pin_for_email,
     create_session, get_session_user_id, delete_session,
     add_user_by_email, get_user_email, get_user_token_info, store_linkedin_li_at,
@@ -402,6 +405,35 @@ class ConnectionRequestUpdate(BaseModel):
 class ConnectionRequestDelete(BaseModel):
     session_token: str
     request_id: int
+
+
+# Comment-first outreach funnel (issue #399) — approval-gated comment->connect->DM
+_LEN_OUTREACH_URL = 512    # outreach_funnel_targets.target_profile_url / context_url VARCHAR(512)
+_LEN_OUTREACH_NAME = 255   # outreach_funnel_targets.target_name VARCHAR(255)
+_LEN_OUTREACH_DRAFT = 3000  # outreach_funnel_targets.draft_text (TEXT; app cap)
+
+
+class OutreachTargetRequest(BaseModel):
+    session_token: str
+    target_profile_url: str = Field(max_length=_LEN_OUTREACH_URL)
+    target_name: Optional[str] = Field(default=None, max_length=_LEN_OUTREACH_NAME)
+    context_url: Optional[str] = Field(default=None, max_length=_LEN_OUTREACH_URL)
+    draft_text: Optional[str] = Field(default=None, max_length=_LEN_OUTREACH_DRAFT)
+    status: str = "pending"  # 'pending' (draft) or 'approved' (let the processor fire this stage)
+
+
+class UpdateOutreachTargetRequest(BaseModel):
+    session_token: str
+    target_id: int
+    target_name: Optional[str] = Field(default=None, max_length=_LEN_OUTREACH_NAME)
+    context_url: Optional[str] = Field(default=None, max_length=_LEN_OUTREACH_URL)
+    draft_text: Optional[str] = Field(default=None, max_length=_LEN_OUTREACH_DRAFT)
+    action: Optional[str] = None  # 'approve' | 'cancel' | None (save fields only)
+
+
+class OutreachTargetDeleteRequest(BaseModel):
+    session_token: str
+    target_id: int
 
 
 class EngagementPreferencesRequest(BaseModel):
@@ -1702,6 +1734,74 @@ def delete_connection_request_endpoint(request: ConnectionRequestDelete) -> Resp
     if not update_connection_request_status(request.request_id, ConnectionRequestStatus.CANCELED):
         raise HTTPException(status_code=500, detail="Could not cancel connection request")
     return ResponseModel(status_code=200, detail="Connection request canceled")
+
+
+@router.post("/outreach/target")
+def create_outreach_target_endpoint(request: OutreachTargetRequest) -> ResponseModel:
+    """Add a prospect to the comment-first outreach funnel (issue #399). The target starts at the
+    'comment' stage; every stage is approval-gated — the funnel processor only acts on APPROVED
+    stages and re-drops each fired stage to 'pending', so no step auto-fires at volume."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if get_outreach_target_by_url(user_id, request.target_profile_url):
+        raise HTTPException(status_code=409, detail="Target is already in the outreach funnel")
+    status = OutreachStatus.APPROVED if request.status == "approved" else OutreachStatus.PENDING
+    target_id = insert_outreach_target(user_id, request.target_profile_url,
+                                       target_name=request.target_name, context_url=request.context_url,
+                                       draft_text=request.draft_text, status=status)
+    if not target_id:
+        raise HTTPException(status_code=500, detail="Could not create outreach target")
+    return ResponseModel(status_code=200, detail={"target_id": target_id})
+
+
+@router.get("/outreach/targets")
+def list_outreach_targets_endpoint(session_token: str, status_filter: Optional[str] = None,
+                                   stage_filter: Optional[str] = None, page: int = 1,
+                                   page_size: int = 25, sort_order: str = "asc") -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail=get_outreach_targets(
+        user_id, status_filter=status_filter, stage_filter=stage_filter, page=page,
+        page_size=page_size, sort_order=sort_order))
+
+
+@router.put("/outreach/target")
+def update_outreach_target_endpoint(request: UpdateOutreachTargetRequest) -> ResponseModel:
+    """Edit a funnel target's current-stage draft, or approve/cancel it. 'approve' gates the current
+    stage for the processor; 'cancel' aborts the whole funnel for this target."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if get_outreach_target_user_id(request.target_id) != user_id:
+        raise HTTPException(status_code=404, detail="Outreach target not found")
+    action_map = {"approve": OutreachStatus.APPROVED, "cancel": OutreachStatus.CANCELED}
+    if request.action is not None and request.action not in action_map:
+        raise HTTPException(status_code=422,
+                            detail=f"Unknown action '{request.action}' — expected 'approve' or 'cancel'")
+    status = action_map.get(request.action)
+    if status is None and all(v is None for v in (request.target_name, request.context_url,
+                                                  request.draft_text)):
+        raise HTTPException(status_code=422, detail="Nothing to update — provide at least one field or an action")
+    if not update_outreach_target(request.target_id, target_name=request.target_name,
+                                  context_url=request.context_url, draft_text=request.draft_text,
+                                  status=status):
+        raise HTTPException(status_code=500, detail="Could not update outreach target")
+    return ResponseModel(status_code=200, detail="Outreach target updated")
+
+
+@router.delete("/outreach/target")
+def delete_outreach_target_endpoint(request: OutreachTargetDeleteRequest) -> ResponseModel:
+    """Cancel a funnel target (soft — sets status 'canceled' so no further stage fires)."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if get_outreach_target_user_id(request.target_id) != user_id:
+        raise HTTPException(status_code=404, detail="Outreach target not found")
+    if not update_outreach_target_status(request.target_id, OutreachStatus.CANCELED):
+        raise HTTPException(status_code=500, detail="Could not cancel outreach target")
+    return ResponseModel(status_code=200, detail="Outreach target canceled")
 
 
 class GroupTogglesRequest(BaseModel):

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -99,6 +99,10 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_send_due_followups',
             'schedule': crontab(minute='*/30')  # Send due multi-touch DM follow-ups every 30 min
         },
+        'process-outreach-funnel': {
+            'task': 'cqc_lem.app.run_scheduler.auto_process_outreach_funnel',
+            'schedule': crontab(minute='*/30')  # Advance approved comment->connect->DM funnel steps
+        },
         'daily-golden-hour-engagement': {
             'task': 'cqc_lem.app.run_scheduler.auto_daily_engagement',
             'schedule': crontab(hour='13', minute='0')  # Daily peak-hour feed commenting (~9am ET), on top of pre-post

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -35,7 +35,9 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     update_db_post_content, update_db_post_first_comment_link, get_post_first_comment_link, \
     get_dm_history_for_profile, get_post_status, get_user_blog_url, get_post_type, get_carousel_slides, \
     get_dm_template, enqueue_followup, get_due_followups, mark_followup, stop_followups_for_profile, \
-    set_profile_synthesis, get_duplicate_comment_posts
+    set_profile_synthesis, get_duplicate_comment_posts, count_dms_sent_today, \
+    get_approved_outreach_targets, update_outreach_target, update_outreach_target_status, \
+    OutreachStage, OutreachStatus
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
     load_profile_for_user
@@ -2882,6 +2884,108 @@ def send_connection_request(self, request_id: int):
     update_connection_request_status(
         request_id, ConnectionRequestStatus.SENT if sent else ConnectionRequestStatus.FAILED)
     return f"Connection request {request_id} -> {'sent' if sent else 'failed'}"
+
+
+# --- Comment-first outreach funnel (issue #399) — approval-gated comment->connect->DM ---
+_FUNNEL_CONNECT_NOTE = ("Hi {first_name}, I've been enjoying your posts and the perspective you "
+                        "share — would love to connect and keep in touch.")
+
+
+def _funnel_first_name(target: dict) -> str:
+    name = (target.get("target_name") or "").strip()
+    return name.split()[0] if name else "there"
+
+
+def _draft_funnel_stage(user_id: int, stage: str, target: dict) -> str:
+    """Draft the voice-aligned action text for the NEXT funnel stage. Connect notes are refined to
+    the user's voice; the DM is rendered from the user's 'funnel' DM template (existing machinery).
+    Returns '' when there's nothing to pre-draft — the operator can still edit before approving."""
+    first_name = _funnel_first_name(target)
+    if stage == OutreachStage.CONNECT:
+        base = _FUNNEL_CONNECT_NOTE.format(first_name=first_name)
+        try:
+            return (get_ai_message_refinement(base, character_limit=300) or base).strip()
+        except Exception as e:
+            log_warning("Funnel connect-note refinement failed", exc=e, user_id=user_id,
+                        action_type="outreach_funnel")
+            return base
+    if stage == OutreachStage.DM:
+        # my_profile is only used for the {headline} fallback; None is safe (see build_dm_from_template).
+        return (build_dm_from_template(user_id, "funnel", first_name, None) or "").strip()
+    return ""
+
+
+def _fire_funnel_stage(user_id: int, target: dict) -> str:
+    """Fire one APPROVED funnel stage by enqueuing the existing primitive, then advance the target to
+    the next stage as 'pending' (needs a fresh approval). Daily caps DEFER a stage (leave it approved
+    for the next run) rather than auto-firing it."""
+    target_id = target["id"]
+    stage = str(target.get("stage"))
+    profile_url = target.get("target_profile_url")
+    draft = (target.get("draft_text") or "").strip()
+    first_name = _funnel_first_name(target)
+    prefs = get_engagement_preferences(user_id)
+
+    if not draft:
+        update_outreach_target_status(target_id, OutreachStatus.SKIPPED)
+        log_warning("Funnel target approved with no draft text; skipping stage",
+                    user_id=user_id, action_type="outreach_funnel")
+        return f"target {target_id}: skipped {stage} (no draft)"
+
+    if stage == OutreachStage.COMMENT:
+        if count_comments_today(user_id) >= int(prefs.get("max_comments_per_day") or 0):
+            return f"target {target_id}: comment deferred (daily comment cap)"
+        context_url = target.get("context_url")
+        if not context_url:
+            update_outreach_target_status(target_id, OutreachStatus.FAILED)
+            log_warning("Funnel comment stage has no post URL to comment on",
+                        user_id=user_id, action_type="outreach_funnel")
+            return f"target {target_id}: comment failed (no post url)"
+        comment_on_post.apply_async(kwargs={"user_id": user_id, "post_link": context_url,
+                                            "comment_text": draft})
+        next_stage = OutreachStage.CONNECT
+    elif stage == OutreachStage.CONNECT:
+        invite_to_connect.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url,
+                                              "message": draft})
+        next_stage = OutreachStage.DM
+    elif stage == OutreachStage.DM:
+        if count_dms_sent_today(user_id) >= int(prefs.get("max_dms_per_day") or 0):
+            return f"target {target_id}: DM deferred (daily DM cap)"
+        send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url,
+                                            "message": draft})
+        enqueue_next_followup(user_id, profile_url, first_name, "funnel", 0)
+        update_outreach_target(target_id, stage=OutreachStage.COMPLETED, status=OutreachStatus.ACTED)
+        return f"target {target_id}: DM sent -> funnel completed"
+    else:
+        return f"target {target_id}: nothing to do (stage={stage})"
+
+    next_draft = _draft_funnel_stage(user_id, next_stage, target)
+    update_outreach_target(target_id, stage=next_stage, status=OutreachStatus.PENDING,
+                           draft_text=next_draft)
+    return f"target {target_id}: {stage} fired -> {next_stage} pending approval"
+
+
+@shared_task.task(bind=True, base=QueueOnce,
+                  once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']})
+def process_outreach_funnel(self, user_id: int, max_per_run: int = 25):
+    """Advance a user's APPROVED comment->connect->DM funnel targets one stage each (issue #399).
+    Every stage is approval-gated: only status='approved' rows are acted on, and each fired stage
+    drops the target to the NEXT stage as 'pending' — requiring a fresh human approval — so no step
+    ever auto-fires at volume. Reuses comment_on_post / invite_to_connect / send_private_dm and the
+    DM follow-up machinery; daily comment/DM caps defer a stage rather than fire it."""
+    targets = get_approved_outreach_targets(user_id)
+    if not targets:
+        return f"No approved outreach targets for user {user_id}"
+    results = []
+    for target in targets[:max_per_run]:
+        try:
+            results.append(_fire_funnel_stage(user_id, target))
+        except Exception as e:
+            log_error("Outreach funnel stage failed", exc=e, user_id=user_id,
+                      action_type="outreach_funnel")
+            update_outreach_target_status(target["id"], OutreachStatus.FAILED)
+            results.append(f"target {target['id']}: error")
+    return "; ".join(results)
 
 
 def final_method(drivers: List[WebDriver]):

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -686,6 +686,21 @@ def auto_send_due_followups():
 
 
 @shared_task.task
+def auto_process_outreach_funnel():
+    """Dispatch per-user processing of APPROVED comment->connect->DM funnel targets (issue #399).
+    Approval-gated: only targets a human has approved advance, and each advance drops the target
+    back to 'pending' for re-approval — nothing auto-fires at volume."""
+    if _skip_if_throttled("auto_process_outreach_funnel"):
+        return "Automation throttled"
+    from cqc_lem.app.run_automation import process_outreach_funnel
+    from cqc_lem.utilities.db import get_users_with_approved_outreach
+    user_ids = get_users_with_approved_outreach()
+    for uid in user_ids:
+        process_outreach_funnel.apply_async(kwargs={"user_id": uid})
+    return f"Dispatched outreach funnel for {len(user_ids)} user(s)"
+
+
+@shared_task.task
 def auto_notify_missing_linkedin_session():
     """Email active users who have no validated LinkedIn session cookie, prompting them
     to connect — automation can't run without one. Throttled per-user inside

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -6,6 +6,7 @@ import LinkedInPostPreview from '../components/LinkedInPostPreview'
 import NewsletterQueue from './review/NewsletterQueue'
 import ScheduledDMs from './review/ScheduledDMs'
 import ConnectionRequests from './review/ConnectionRequests'
+import OutreachFunnel from './review/OutreachFunnel'
 import ComposePost from './content/ComposePost'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
@@ -13,11 +14,12 @@ import { formatInTimezone } from '../utils/datetime'
 
 // Consolidated content hub: compose posts, schedule DMs, manage newsletters, and review/edit
 // existing content — one page, four tabs, synced to ?tab= for deep-linking.
-type View = 'posts' | 'dms' | 'connections' | 'newsletters' | 'review'
+type View = 'posts' | 'dms' | 'connections' | 'outreach' | 'newsletters' | 'review'
 const VIEWS: { key: View; label: string }[] = [
   { key: 'posts', label: 'Posts' },
   { key: 'dms', label: 'DMs' },
   { key: 'connections', label: 'Connections' },
+  { key: 'outreach', label: 'Outreach' },
   { key: 'newsletters', label: 'Newsletters' },
   { key: 'review', label: 'Review & Edit' },
 ]
@@ -331,6 +333,8 @@ export default function ContentStudio() {
       {view === 'dms' && <ScheduledDMs userTimezone={userTimezone} />}
 
       {view === 'connections' && <ConnectionRequests userTimezone={userTimezone} />}
+
+      {view === 'outreach' && <OutreachFunnel />}
 
       {view === 'review' && (
       <>

--- a/src/cqc_lem/ui/src/pages/review/OutreachFunnel.tsx
+++ b/src/cqc_lem/ui/src/pages/review/OutreachFunnel.tsx
@@ -1,0 +1,231 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import api from '../../api/client'
+import { useAuth } from '../../contexts/AuthContext'
+
+// Comment-first outreach funnel (issue #399): a sequenced, APPROVAL-GATED value-comment -> connect
+// -> DM funnel keyed to a target list. Every stage is drafted as 'pending' and only fires once a
+// human approves it; approving one stage advances the target to the next stage as 'pending' again —
+// so no step ever auto-fires at volume.
+const DRAFT_MAX = 3000
+
+interface OutreachTarget {
+  id: number
+  target_profile_url: string
+  target_name: string | null
+  stage: string
+  status: string
+  context_url: string | null
+  draft_text: string | null
+  updated_at: string | null
+}
+
+const STAGE_LABELS: Record<string, string> = {
+  comment: '1 · Comment',
+  connect: '2 · Connect',
+  dm: '3 · DM',
+  completed: '✓ Completed',
+}
+
+const STAGE_HELP: Record<string, string> = {
+  comment: 'Leave a value-adding comment on their post (needs a post URL).',
+  connect: 'Send a connection request with this note.',
+  dm: 'Send this voice-aligned DM (must be a 1st-degree connection).',
+  completed: 'The DM has been sent — this target has finished the funnel.',
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: 'bg-yellow-100 text-yellow-700',
+  approved: 'bg-green-100 text-green-700',
+  acted: 'bg-blue-100 text-blue-700',
+  skipped: 'bg-gray-100 text-gray-500',
+  failed: 'bg-red-100 text-red-700',
+  canceled: 'bg-gray-100 text-gray-500',
+}
+
+const STATUSES = ['ALL', 'pending', 'approved', 'acted', 'skipped', 'failed', 'canceled']
+
+export default function OutreachFunnel() {
+  const { sessionToken } = useAuth()
+  const qc = useQueryClient()
+  const [filter, setFilter] = useState('ALL')
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null)
+
+  // New-target draft form
+  const [url, setUrl] = useState('')
+  const [name, setName] = useState('')
+  const [contextUrl, setContextUrl] = useState('')
+  const [draft, setDraft] = useState('')
+
+  // Per-target draft edits (keyed by id) so each card edits independently.
+  const [edits, setEdits] = useState<Record<number, string>>({})
+
+  const queryKey = ['outreach-targets', sessionToken, filter]
+  const { data, isLoading } = useQuery({
+    queryKey,
+    queryFn: () => {
+      const p = new URLSearchParams({ session_token: sessionToken!, page: '1', page_size: '50' })
+      if (filter !== 'ALL') p.set('status_filter', filter)
+      return api.get(`/outreach/targets?${p.toString()}`).then((r) => r.data.detail as { targets: OutreachTarget[]; total: number })
+    },
+    enabled: !!sessionToken,
+  })
+  const targets = data?.targets ?? []
+
+  const flash = (ok: boolean, text: string) => { setMsg({ ok, text }); setTimeout(() => setMsg(null), 4000) }
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['outreach-targets'] })
+
+  const createMutation = useMutation({
+    mutationFn: (status: 'pending' | 'approved') =>
+      api.post('/outreach/target', {
+        session_token: sessionToken,
+        target_profile_url: url.trim(),
+        target_name: name.trim() || null,
+        context_url: contextUrl.trim() || null,
+        draft_text: draft.trim() || null,
+        status,
+      }),
+    onSuccess: () => {
+      invalidate(); setUrl(''); setName(''); setContextUrl(''); setDraft('')
+      flash(true, 'Target added to the funnel.')
+    },
+    onError: (e: unknown) => {
+      const status = (e as { response?: { status?: number } })?.response?.status
+      flash(false, status === 409 ? 'That profile is already in your funnel.' : 'Could not add — check the fields and try again.')
+    },
+  })
+
+  const saveMutation = useMutation({
+    mutationFn: (v: { id: number; draft_text: string }) =>
+      api.put('/outreach/target', { session_token: sessionToken, target_id: v.id, draft_text: v.draft_text }),
+    onSuccess: (_r, v) => { invalidate(); setEdits((e) => { const n = { ...e }; delete n[v.id]; return n }); flash(true, 'Draft saved.') },
+    onError: () => flash(false, 'Could not save the draft.'),
+  })
+
+  const actionMutation = useMutation({
+    mutationFn: (v: { id: number; action: 'approve' | 'cancel' }) =>
+      api.put('/outreach/target', { session_token: sessionToken, target_id: v.id, action: v.action }),
+    onSuccess: () => invalidate(),
+  })
+
+  const canSubmit = url.trim().length > 0
+
+  return (
+    <div className="space-y-4">
+      {msg && <p className={`text-sm font-medium ${msg.ok ? 'text-green-600' : 'text-red-600'}`}>{msg.text}</p>}
+
+      {/* New target */}
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-5 space-y-3">
+        <h3 className="font-semibold text-gray-700">Add a target to the funnel</h3>
+        <p className="text-xs text-gray-500">
+          Each target moves comment → connect → DM, and <span className="font-semibold">every step needs your
+          approval</span> before it fires. Approving a step advances the target to the next step for review — nothing
+          sends automatically.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <input type="url" value={url} onChange={(e) => setUrl(e.target.value)} maxLength={512}
+            placeholder="Target profile URL (https://www.linkedin.com/in/…)"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+          <input type="text" value={name} onChange={(e) => setName(e.target.value)} maxLength={255}
+            placeholder="Target name (optional)"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+        </div>
+        <input type="url" value={contextUrl} onChange={(e) => setContextUrl(e.target.value)} maxLength={512}
+          placeholder="Post URL to comment on (the first step)"
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+        <textarea value={draft} onChange={(e) => setDraft(e.target.value)} rows={3} maxLength={DRAFT_MAX}
+          placeholder="Your value-adding comment…"
+          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+        <div className="flex flex-wrap items-center gap-3">
+          <button onClick={() => createMutation.mutate('pending')} disabled={!canSubmit || createMutation.isPending}
+            className="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50">
+            Save draft
+          </button>
+          <button onClick={() => createMutation.mutate('approved')} disabled={!canSubmit || createMutation.isPending}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50">
+            {createMutation.isPending ? 'Adding…' : 'Add & approve comment'}
+          </button>
+        </div>
+      </div>
+
+      {/* Status filter */}
+      <div className="flex gap-2 flex-wrap">
+        {STATUSES.map((s) => (
+          <button key={s} onClick={() => setFilter(s)}
+            className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
+              filter === s ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 border border-gray-300 hover:border-blue-400'
+            }`}>
+            {s.toUpperCase()}
+          </button>
+        ))}
+      </div>
+
+      {isLoading && <p className="text-gray-400 text-sm">Loading funnel…</p>}
+      {!isLoading && targets.length === 0 && (
+        <div className="text-center py-10 bg-white rounded-lg border border-gray-200 text-sm text-gray-500">
+          No targets in the funnel yet.
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {targets.map((t) => {
+          const editing = edits[t.id] !== undefined
+          const draftValue = editing ? edits[t.id] : (t.draft_text ?? '')
+          const terminal = ['completed'].includes(t.stage) || ['canceled', 'acted'].includes(t.status)
+          return (
+            <div key={t.id} className="bg-white rounded-lg border border-gray-200 p-4 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <a href={t.target_profile_url} target="_blank" rel="noopener noreferrer"
+                  className="text-sm font-medium text-blue-700 truncate hover:underline">
+                  {t.target_name || t.target_profile_url}
+                </a>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-700">
+                    {STAGE_LABELS[t.stage] ?? t.stage}
+                  </span>
+                  <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[t.status] ?? 'bg-gray-100 text-gray-600'}`}>
+                    {t.status.toUpperCase()}
+                  </span>
+                </div>
+              </div>
+              <p className="text-xs text-gray-400">{STAGE_HELP[t.stage] ?? ''}</p>
+
+              {!terminal && (
+                <>
+                  <textarea
+                    value={draftValue}
+                    onChange={(e) => setEdits((prev) => ({ ...prev, [t.id]: e.target.value }))}
+                    rows={3} maxLength={DRAFT_MAX}
+                    placeholder={t.stage === 'comment' ? 'Comment text…' : t.stage === 'connect' ? 'Connection note…' : 'DM message…'}
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+                  <div className="flex gap-2 flex-wrap">
+                    <button onClick={() => saveMutation.mutate({ id: t.id, draft_text: draftValue })}
+                      disabled={!editing || saveMutation.isPending}
+                      className="px-3 py-1 border border-gray-300 text-gray-600 rounded text-xs font-semibold hover:bg-gray-50 disabled:opacity-50">
+                      Save draft
+                    </button>
+                    {t.status === 'pending' && (
+                      <button onClick={() => actionMutation.mutate({ id: t.id, action: 'approve' })}
+                        disabled={actionMutation.isPending}
+                        className="px-3 py-1 bg-green-600 text-white rounded text-xs font-semibold hover:bg-green-700 disabled:opacity-50">
+                        Approve {t.stage}
+                      </button>
+                    )}
+                    <button onClick={() => actionMutation.mutate({ id: t.id, action: 'cancel' })}
+                      disabled={actionMutation.isPending}
+                      className="px-3 py-1 border border-gray-300 text-gray-600 rounded text-xs font-semibold hover:bg-gray-50 disabled:opacity-50">
+                      Cancel
+                    </button>
+                  </div>
+                </>
+              )}
+              {terminal && t.draft_text && (
+                <p className="text-sm text-gray-700 whitespace-pre-wrap line-clamp-3">{t.draft_text}</p>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/pages/review/OutreachFunnel.tsx
+++ b/src/cqc_lem/ui/src/pages/review/OutreachFunnel.tsx
@@ -204,11 +204,11 @@ export default function OutreachFunnel() {
                       className="px-3 py-1 border border-gray-300 text-gray-600 rounded text-xs font-semibold hover:bg-gray-50 disabled:opacity-50">
                       Save draft
                     </button>
-                    {t.status === 'pending' && (
+                    {['pending', 'failed', 'skipped'].includes(t.status) && (
                       <button onClick={() => actionMutation.mutate({ id: t.id, action: 'approve' })}
                         disabled={actionMutation.isPending}
                         className="px-3 py-1 bg-green-600 text-white rounded text-xs font-semibold hover:bg-green-700 disabled:opacity-50">
-                        Approve {t.stage}
+                        {t.status === 'pending' ? 'Approve' : 'Retry'} {t.stage}
                       </button>
                     )}
                     <button onClick={() => actionMutation.mutate({ id: t.id, action: 'cancel' })}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -97,6 +97,24 @@ class ConnectionRequestStatus(StrEnum):
     CANCELED = 'canceled'    # canceled before send
 
 
+class OutreachStage(StrEnum):
+    """Stage of a comment-first outreach funnel target (issue #399)."""
+    COMMENT = 'comment'      # leave a value-adding comment on the prospect's post
+    CONNECT = 'connect'      # send a connection request (with a note)
+    DM = 'dm'                # send the voice-aligned DM (must be a 1st-degree connection)
+    COMPLETED = 'completed'  # terminal: the DM fired
+
+
+class OutreachStatus(StrEnum):
+    """Status of the current funnel stage (issue #399), mirroring the approval-gated DM lifecycle."""
+    PENDING = 'pending'      # draft awaiting human approval
+    APPROVED = 'approved'    # human approved; the processor will fire this stage
+    ACTED = 'acted'          # terminal: the final (dm) stage fired
+    SKIPPED = 'skipped'      # current stage skipped without firing
+    FAILED = 'failed'        # firing the stage errored
+    CANCELED = 'canceled'    # operator canceled the whole funnel for this target
+
+
 # Enum for log actions types
 class LogActionType(StrEnum):
     COMMENT = 'comment'
@@ -3196,6 +3214,187 @@ def update_connection_request(request_id: int, recipient_profile_url: str = None
         connection.close()
 
 
+# --- Comment-first outreach funnel (issue #399) — approval-gated comment->connect->DM ---
+_OUTREACH_COLS = ("id", "user_id", "target_profile_url", "target_name", "stage", "status",
+                  "context_url", "draft_text", "notes", "created_at", "updated_at")
+
+
+def insert_outreach_target(user_id: int, target_profile_url: str, target_name: str = None,
+                           context_url: str = None, draft_text: str = None,
+                           stage: "OutreachStage" = OutreachStage.COMMENT,
+                           status: "OutreachStatus" = OutreachStatus.PENDING) -> Optional[int]:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO outreach_funnel_targets (user_id, target_profile_url, target_name, stage, "
+            "status, context_url, draft_text) VALUES (%s,%s,%s,%s,%s,%s,%s)",
+            (user_id, target_profile_url, target_name, str(stage), str(status), context_url, draft_text))
+        connection.commit()
+        return cursor.lastrowid
+    except mysql.connector.Error as err:
+        myprint(f"Could not insert outreach target for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_outreach_target(target_id: int) -> Optional[dict]:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            f"SELECT {', '.join(_OUTREACH_COLS)} FROM outreach_funnel_targets WHERE id = %s", (target_id,))
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get outreach target {target_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_outreach_target_user_id(target_id: int) -> Optional[int]:
+    row = get_outreach_target(target_id)
+    return row["user_id"] if row else None
+
+
+def get_outreach_target_by_url(user_id: int, target_profile_url: str) -> Optional[dict]:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            f"SELECT {', '.join(_OUTREACH_COLS)} FROM outreach_funnel_targets "
+            "WHERE user_id = %s AND target_profile_url = %s", (user_id, target_profile_url))
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not look up outreach target for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_outreach_targets(user_id: int, status_filter: str = None, stage_filter: str = None,
+                         page: int = 1, page_size: int = 25, sort_order: str = "asc") -> dict:
+    """Paginated list of a user's outreach-funnel targets (mirrors the scheduled-DM list response)."""
+    order = "DESC" if str(sort_order).lower() == "desc" else "ASC"
+    where = "WHERE user_id = %s"
+    params: list = [user_id]
+    if status_filter:
+        where += " AND status = %s"
+        params.append(status_filter)
+    if stage_filter:
+        where += " AND stage = %s"
+        params.append(stage_filter)
+    offset = max(0, (max(1, page) - 1) * page_size)
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(f"SELECT COUNT(*) AS c FROM outreach_funnel_targets {where}", tuple(params))
+        total = int(cursor.fetchone()["c"])
+        cursor.execute(
+            f"SELECT {', '.join(_OUTREACH_COLS)} FROM outreach_funnel_targets {where} "
+            f"ORDER BY updated_at {order} LIMIT %s OFFSET %s",
+            tuple(params + [page_size, offset]))
+        rows = cursor.fetchall()
+        for r in rows:
+            for k in ("created_at", "updated_at"):
+                if isinstance(r.get(k), datetime):
+                    r[k] = r[k].isoformat()
+        return {"targets": rows, "total": total, "page": page, "page_size": page_size}
+    except mysql.connector.Error as err:
+        myprint(f"Could not list outreach targets for user_id {user_id} | Error: {err}")
+        return {"targets": [], "total": 0, "page": page, "page_size": page_size}
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_approved_outreach_targets(user_id: int) -> list:
+    """Approved, not-yet-completed funnel targets for a user — the rows the processor may fire.
+    Oldest-updated first so a backlog drains in order. Returns dict rows."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            f"SELECT {', '.join(_OUTREACH_COLS)} FROM outreach_funnel_targets "
+            "WHERE user_id = %s AND status = 'approved' AND stage <> 'completed' "
+            "ORDER BY updated_at ASC", (user_id,))
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        myprint(f"Could not get approved outreach targets for user_id {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_users_with_approved_outreach() -> list:
+    """Distinct user_ids that have at least one approved, non-completed funnel target (dispatcher)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT DISTINCT user_id FROM outreach_funnel_targets "
+            "WHERE status = 'approved' AND stage <> 'completed'")
+        return [r[0] for r in cursor.fetchall()]
+    except mysql.connector.Error as err:
+        myprint(f"Could not get users with approved outreach | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_outreach_target_status(target_id: int, status: "OutreachStatus") -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("UPDATE outreach_funnel_targets SET status = %s WHERE id = %s",
+                       (str(status), target_id))
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update outreach target {target_id} status | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_outreach_target(target_id: int, target_profile_url: str = None, target_name: str = None,
+                           context_url: str = None, draft_text: str = None, notes: str = None,
+                           stage: "OutreachStage" = None, status: "OutreachStatus" = None) -> bool:
+    fields, params = [], []
+    for col, val in (("target_profile_url", target_profile_url), ("target_name", target_name),
+                     ("context_url", context_url), ("draft_text", draft_text), ("notes", notes)):
+        if val is not None:
+            fields.append(f"{col} = %s")
+            params.append(val)
+    for col, val in (("stage", stage), ("status", status)):
+        if val is not None:
+            fields.append(f"{col} = %s")
+            params.append(str(val))
+    if not fields:
+        return False
+    params.append(target_id)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(f"UPDATE outreach_funnel_targets SET {', '.join(fields)} WHERE id = %s",
+                       tuple(params))
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update outreach target {target_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def has_scheduled_post_today(user_id: int) -> bool:
     """True if the user has a post going out today (UTC) — those days are already covered by the
     pre-post commenting trigger, so the standalone daily engagement run should skip them. Fails
@@ -4128,6 +4327,8 @@ _DM_DEFAULT_TEMPLATES = {
                       "I share insights on {headline} and thought there might be synergy between our work. "
                       "Would love to connect more directly — feel free to share what you're working on!",
     "manual": "Hi {first_name}, thanks for connecting!",
+    "funnel": "Hi {first_name}, really glad we connected. I've enjoyed following the work you're "
+              "sharing and would love to swap notes sometime. What are you focused on this quarter?",
 }
 
 

--- a/tests/unit/api/test_outreach_funnel_api.py
+++ b/tests/unit/api/test_outreach_funnel_api.py
@@ -56,6 +56,27 @@ class TestCreateTarget:
         from cqc_lem.utilities.db import OutreachStatus
         assert ins.call_args.kwargs["status"] == OutreachStatus.APPROVED
 
+    def test_strips_whitespace_before_dedup_and_insert(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_by_url", return_value=None) as dup, \
+             patch(f"{_M}.insert_outreach_target", return_value=13) as ins:
+            resp = client.post("/api/outreach/target", json={
+                "session_token": _S, "target_profile_url": "  https://x/in/jane  ",
+                "target_name": "  Jane  ", "context_url": "  https://x/post/1  "})
+        assert resp.status_code == 200
+        assert dup.call_args.args[1] == "https://x/in/jane"
+        assert ins.call_args.args[1] == "https://x/in/jane"
+        assert ins.call_args.kwargs["target_name"] == "Jane"
+        assert ins.call_args.kwargs["context_url"] == "https://x/post/1"
+
+    def test_blank_url_422(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.insert_outreach_target") as ins:
+            resp = client.post("/api/outreach/target", json={
+                "session_token": _S, "target_profile_url": "   "})
+        assert resp.status_code == 422
+        ins.assert_not_called()
+
     def test_duplicate_409(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_U), \
              patch(f"{_M}.get_outreach_target_by_url", return_value={"id": 1}), \

--- a/tests/unit/api/test_outreach_funnel_api.py
+++ b/tests/unit/api/test_outreach_funnel_api.py
@@ -1,0 +1,155 @@
+"""Unit tests for the outreach-funnel API endpoints (issue #399)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_M = "cqc_lem.api.main"
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_S = "tok"
+_U = 5
+
+
+class TestCreateTarget:
+    def test_creates_pending(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_by_url", return_value=None), \
+             patch(f"{_M}.insert_outreach_target", return_value=11) as ins:
+            resp = client.post("/api/outreach/target", json={
+                "session_token": _S, "target_profile_url": "https://x/in/jane",
+                "target_name": "Jane", "context_url": "https://x/post/1", "draft_text": "nice"})
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["target_id"] == 11
+        from cqc_lem.utilities.db import OutreachStatus
+        assert ins.call_args.kwargs["status"] == OutreachStatus.PENDING
+
+    def test_approved_status_maps(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_by_url", return_value=None), \
+             patch(f"{_M}.insert_outreach_target", return_value=12) as ins:
+            resp = client.post("/api/outreach/target", json={
+                "session_token": _S, "target_profile_url": "https://x/in/jane", "status": "approved"})
+        assert resp.status_code == 200
+        from cqc_lem.utilities.db import OutreachStatus
+        assert ins.call_args.kwargs["status"] == OutreachStatus.APPROVED
+
+    def test_duplicate_409(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_by_url", return_value={"id": 1}), \
+             patch(f"{_M}.insert_outreach_target") as ins:
+            resp = client.post("/api/outreach/target", json={
+                "session_token": _S, "target_profile_url": "https://x/in/jane"})
+        assert resp.status_code == 409
+        ins.assert_not_called()
+
+    def test_401(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.post("/api/outreach/target", json={
+                "session_token": "bad", "target_profile_url": "u"})
+        assert resp.status_code == 401
+
+    def test_insert_failure_500(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_by_url", return_value=None), \
+             patch(f"{_M}.insert_outreach_target", return_value=None):
+            resp = client.post("/api/outreach/target", json={
+                "session_token": _S, "target_profile_url": "https://x/in/jane"})
+        assert resp.status_code == 500
+
+
+class TestListTargets:
+    def test_lists(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_targets",
+                   return_value={"targets": [], "total": 0, "page": 1, "page_size": 25}) as lst:
+            resp = client.get(f"/api/outreach/targets?session_token={_S}&status_filter=pending&stage_filter=comment")
+        assert resp.status_code == 200
+        assert lst.call_args.kwargs["status_filter"] == "pending"
+        assert lst.call_args.kwargs["stage_filter"] == "comment"
+
+    def test_401(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.get("/api/outreach/targets?session_token=bad")
+        assert resp.status_code == 401
+
+
+class TestUpdateAndCancel:
+    def test_approve(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_user_id", return_value=_U), \
+             patch(f"{_M}.update_outreach_target", return_value=True) as upd:
+            resp = client.put("/api/outreach/target", json={"session_token": _S, "target_id": 3, "action": "approve"})
+        assert resp.status_code == 200
+        from cqc_lem.utilities.db import OutreachStatus
+        assert upd.call_args.kwargs["status"] == OutreachStatus.APPROVED
+
+    def test_save_draft_only(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_user_id", return_value=_U), \
+             patch(f"{_M}.update_outreach_target", return_value=True) as upd:
+            resp = client.put("/api/outreach/target", json={"session_token": _S, "target_id": 3, "draft_text": "hi"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["draft_text"] == "hi"
+        assert upd.call_args.kwargs["status"] is None
+
+    def test_update_404_when_not_owner(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_user_id", return_value=999):
+            resp = client.put("/api/outreach/target", json={"session_token": _S, "target_id": 3, "draft_text": "x"})
+        assert resp.status_code == 404
+
+    def test_unknown_action_422(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_user_id", return_value=_U), \
+             patch(f"{_M}.update_outreach_target") as upd:
+            resp = client.put("/api/outreach/target", json={"session_token": _S, "target_id": 3, "action": "nope"})
+        assert resp.status_code == 422
+        assert "Unknown action" in resp.json()["detail"]
+        upd.assert_not_called()
+
+    def test_no_fields_and_no_action_422(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_user_id", return_value=_U), \
+             patch(f"{_M}.update_outreach_target") as upd:
+            resp = client.put("/api/outreach/target", json={"session_token": _S, "target_id": 3})
+        assert resp.status_code == 422
+        assert "Nothing to update" in resp.json()["detail"]
+        upd.assert_not_called()
+
+    def test_cancel_sets_canceled(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_user_id", return_value=_U), \
+             patch(f"{_M}.update_outreach_target_status", return_value=True) as upd:
+            resp = client.request("DELETE", "/api/outreach/target", json={"session_token": _S, "target_id": 3})
+        assert resp.status_code == 200
+        from cqc_lem.utilities.db import OutreachStatus
+        upd.assert_called_once_with(3, OutreachStatus.CANCELED)
+
+    def test_delete_404_when_not_owner(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_outreach_target_user_id", return_value=999):
+            resp = client.request("DELETE", "/api/outreach/target", json={"session_token": _S, "target_id": 3})
+        assert resp.status_code == 404

--- a/tests/unit/app/test_outreach_funnel.py
+++ b/tests/unit/app/test_outreach_funnel.py
@@ -1,7 +1,7 @@
 """Unit tests for the comment-first outreach funnel (issue #399): stage firing, processor, dispatch."""
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 pytestmark = pytest.mark.unit
 

--- a/tests/unit/app/test_outreach_funnel.py
+++ b/tests/unit/app/test_outreach_funnel.py
@@ -1,0 +1,192 @@
+"""Unit tests for the comment-first outreach funnel (issue #399): stage firing, processor, dispatch."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+_RS = "cqc_lem.app.run_scheduler"
+_DB = "cqc_lem.utilities.db"
+
+
+def _target(**kw):
+    base = {"id": 1, "user_id": 1, "target_profile_url": "https://x/in/jane", "target_name": "Jane Doe",
+            "stage": "comment", "status": "approved", "context_url": "https://x/post/1",
+            "draft_text": "great post"}
+    base.update(kw)
+    return base
+
+
+def _prefs():
+    return {"max_comments_per_day": 50, "max_dms_per_day": 25}
+
+
+class TestFireFunnelStage:
+    def _common(self):
+        return {
+            "prefs": patch(f"{_RA}.get_engagement_preferences", return_value=_prefs()),
+            "cc": patch(f"{_RA}.count_comments_today", return_value=0),
+            "cd": patch(f"{_RA}.count_dms_sent_today", return_value=0),
+            "refine": patch(f"{_RA}.get_ai_message_refinement", return_value="refined note"),
+            "dm": patch(f"{_RA}.build_dm_from_template", return_value="dm text"),
+            "enq": patch(f"{_RA}.enqueue_next_followup"),
+            "upd": patch(f"{_RA}.update_outreach_target"),
+            "ust": patch(f"{_RA}.update_outreach_target_status"),
+        }
+
+    def test_comment_fires_and_advances_to_connect(self):
+        from cqc_lem.app.run_automation import _fire_funnel_stage
+        from cqc_lem.utilities.db import OutreachStage, OutreachStatus
+        c = self._common()
+        with c["prefs"], c["cc"], c["cd"], c["refine"], c["dm"], c["enq"], \
+             c["upd"] as upd, c["ust"], patch(f"{_RA}.comment_on_post") as cop:
+            out = _fire_funnel_stage(1, _target())
+        cop.apply_async.assert_called_once()
+        assert cop.apply_async.call_args.kwargs["kwargs"]["post_link"] == "https://x/post/1"
+        assert cop.apply_async.call_args.kwargs["kwargs"]["comment_text"] == "great post"
+        assert upd.call_args.kwargs["stage"] == OutreachStage.CONNECT
+        assert upd.call_args.kwargs["status"] == OutreachStatus.PENDING
+        assert upd.call_args.kwargs["draft_text"] == "refined note"
+        assert "connect" in out
+
+    def test_comment_deferred_when_cap_reached(self):
+        from cqc_lem.app.run_automation import _fire_funnel_stage
+        c = self._common()
+        with c["prefs"], patch(f"{_RA}.count_comments_today", return_value=99), c["cd"], \
+             c["refine"], c["dm"], c["enq"], c["upd"], c["ust"], patch(f"{_RA}.comment_on_post") as cop:
+            out = _fire_funnel_stage(1, _target())
+        cop.apply_async.assert_not_called()
+        assert "deferred" in out
+
+    def test_comment_fails_without_context_url(self):
+        from cqc_lem.app.run_automation import _fire_funnel_stage
+        from cqc_lem.utilities.db import OutreachStatus
+        c = self._common()
+        with c["prefs"], c["cc"], c["cd"], c["refine"], c["dm"], c["enq"], c["upd"], \
+             c["ust"] as ust, patch(f"{_RA}.comment_on_post") as cop:
+            out = _fire_funnel_stage(1, _target(context_url=None))
+        cop.apply_async.assert_not_called()
+        ust.assert_called_once_with(1, OutreachStatus.FAILED)
+        assert "failed" in out
+
+    def test_connect_fires_and_advances_to_dm(self):
+        from cqc_lem.app.run_automation import _fire_funnel_stage
+        from cqc_lem.utilities.db import OutreachStage
+        c = self._common()
+        with c["prefs"], c["cc"], c["cd"], c["refine"], c["dm"], c["enq"], \
+             c["upd"] as upd, c["ust"], patch(f"{_RA}.invite_to_connect") as inv:
+            out = _fire_funnel_stage(1, _target(stage="connect", draft_text="my note"))
+        inv.apply_async.assert_called_once()
+        assert inv.apply_async.call_args.kwargs["kwargs"]["message"] == "my note"
+        assert upd.call_args.kwargs["stage"] == OutreachStage.DM
+        assert upd.call_args.kwargs["draft_text"] == "dm text"
+        assert "dm" in out
+
+    def test_dm_fires_and_completes(self):
+        from cqc_lem.app.run_automation import _fire_funnel_stage
+        from cqc_lem.utilities.db import OutreachStage, OutreachStatus
+        c = self._common()
+        with c["prefs"], c["cc"], c["cd"], c["refine"], c["dm"], \
+             c["enq"] as enq, c["upd"] as upd, c["ust"], patch(f"{_RA}.send_private_dm") as spd:
+            out = _fire_funnel_stage(1, _target(stage="dm", draft_text="hi jane"))
+        spd.apply_async.assert_called_once()
+        assert spd.apply_async.call_args.kwargs["kwargs"]["message"] == "hi jane"
+        enq.assert_called_once()
+        assert enq.call_args[0][3] == "funnel"  # event_type
+        assert upd.call_args.kwargs["stage"] == OutreachStage.COMPLETED
+        assert upd.call_args.kwargs["status"] == OutreachStatus.ACTED
+        assert "completed" in out
+
+    def test_dm_deferred_when_cap_reached(self):
+        from cqc_lem.app.run_automation import _fire_funnel_stage
+        c = self._common()
+        with c["prefs"], c["cc"], patch(f"{_RA}.count_dms_sent_today", return_value=99), \
+             c["refine"], c["dm"], c["enq"], c["upd"], c["ust"], patch(f"{_RA}.send_private_dm") as spd:
+            out = _fire_funnel_stage(1, _target(stage="dm", draft_text="hi"))
+        spd.apply_async.assert_not_called()
+        assert "deferred" in out
+
+    def test_no_draft_skips(self):
+        from cqc_lem.app.run_automation import _fire_funnel_stage
+        from cqc_lem.utilities.db import OutreachStatus
+        c = self._common()
+        with c["prefs"], c["cc"], c["cd"], c["refine"], c["dm"], c["enq"], c["upd"], \
+             c["ust"] as ust, patch(f"{_RA}.comment_on_post") as cop:
+            out = _fire_funnel_stage(1, _target(draft_text=""))
+        cop.apply_async.assert_not_called()
+        ust.assert_called_once_with(1, OutreachStatus.SKIPPED)
+        assert "skipped" in out
+
+
+class TestDraftFunnelStage:
+    def test_connect_note_refined(self):
+        from cqc_lem.app.run_automation import _draft_funnel_stage
+        from cqc_lem.utilities.db import OutreachStage
+        with patch(f"{_RA}.get_ai_message_refinement", return_value="voiced note"):
+            got = _draft_funnel_stage(1, OutreachStage.CONNECT, _target(target_name="Jane Doe"))
+        assert got == "voiced note"
+
+    def test_connect_note_falls_back_on_error(self):
+        from cqc_lem.app.run_automation import _draft_funnel_stage
+        from cqc_lem.utilities.db import OutreachStage
+        with patch(f"{_RA}.get_ai_message_refinement", side_effect=RuntimeError("boom")):
+            got = _draft_funnel_stage(1, OutreachStage.CONNECT, _target())
+        assert "connect" in got.lower() or got  # non-empty fallback
+
+    def test_dm_uses_template(self):
+        from cqc_lem.app.run_automation import _draft_funnel_stage
+        from cqc_lem.utilities.db import OutreachStage
+        with patch(f"{_RA}.build_dm_from_template", return_value="hi from template") as b:
+            got = _draft_funnel_stage(1, OutreachStage.DM, _target())
+        assert got == "hi from template"
+        assert b.call_args[0][1] == "funnel"  # event_type
+
+    def test_dm_empty_when_no_template(self):
+        from cqc_lem.app.run_automation import _draft_funnel_stage
+        from cqc_lem.utilities.db import OutreachStage
+        with patch(f"{_RA}.build_dm_from_template", return_value=None):
+            assert _draft_funnel_stage(1, OutreachStage.DM, _target()) == ""
+
+
+class TestProcessOutreachFunnel:
+    def test_no_targets(self):
+        from cqc_lem.app.run_automation import process_outreach_funnel
+        with patch(f"{_RA}.get_approved_outreach_targets", return_value=[]):
+            out = process_outreach_funnel.run(user_id=1)
+        assert "No approved" in out
+
+    def test_fires_each_target(self):
+        from cqc_lem.app.run_automation import process_outreach_funnel
+        with patch(f"{_RA}.get_approved_outreach_targets", return_value=[_target(id=1), _target(id=2)]), \
+             patch(f"{_RA}._fire_funnel_stage", side_effect=["a", "b"]) as fire:
+            out = process_outreach_funnel.run(user_id=1)
+        assert fire.call_count == 2
+        assert out == "a; b"
+
+    def test_marks_failed_on_error(self):
+        from cqc_lem.app.run_automation import process_outreach_funnel
+        from cqc_lem.utilities.db import OutreachStatus
+        with patch(f"{_RA}.get_approved_outreach_targets", return_value=[_target(id=7)]), \
+             patch(f"{_RA}._fire_funnel_stage", side_effect=RuntimeError("x")), \
+             patch(f"{_RA}.update_outreach_target_status") as ust:
+            out = process_outreach_funnel.run(user_id=1)
+        ust.assert_called_once_with(7, OutreachStatus.FAILED)
+        assert "error" in out
+
+
+class TestDispatcher:
+    def test_dispatches_per_user(self):
+        from cqc_lem.app.run_scheduler import auto_process_outreach_funnel
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_DB}.get_users_with_approved_outreach", return_value=[1, 2]), \
+             patch(f"{_RA}.process_outreach_funnel") as proc:
+            out = auto_process_outreach_funnel()
+        assert proc.apply_async.call_count == 2
+        assert "2 user" in out
+
+    def test_throttled(self):
+        from cqc_lem.app.run_scheduler import auto_process_outreach_funnel
+        with patch(f"{_RS}._skip_if_throttled", return_value=True):
+            out = auto_process_outreach_funnel()
+        assert "throttled" in out.lower()

--- a/tests/unit/utilities/test_db_outreach_funnel.py
+++ b/tests/unit/utilities/test_db_outreach_funnel.py
@@ -1,0 +1,124 @@
+"""Unit tests for outreach-funnel DB helpers (issue #399)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(fetch_row=None, fetchall=None, lastrowid=7):
+    conn = MagicMock(); cur = MagicMock()
+    cur.fetchone.return_value = fetch_row
+    cur.fetchall.return_value = fetchall or []
+    cur.rowcount = 1
+    cur.lastrowid = lastrowid
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestOutreachFunnelDb:
+    def test_insert_returns_id(self):
+        conn, cur = _conn(lastrowid=42)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_outreach_target
+            got = insert_outreach_target(1, "https://x/in/jane", target_name="Jane",
+                                         context_url="https://x/post/1", draft_text="great post")
+        assert got == 42
+        assert "INSERT INTO outreach_funnel_targets" in cur.execute.call_args[0][0]
+
+    def test_insert_error_returns_none(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="dupe")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_outreach_target
+            assert insert_outreach_target(1, "u") is None
+
+    def test_get_target_and_user_id(self):
+        conn, cur = _conn(fetch_row={"id": 3, "user_id": 9})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_outreach_target, get_outreach_target_user_id
+            assert get_outreach_target(3)["user_id"] == 9
+            assert get_outreach_target_user_id(3) == 9
+
+    def test_get_target_user_id_none_when_missing(self):
+        conn, cur = _conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_outreach_target_user_id
+            assert get_outreach_target_user_id(3) is None
+
+    def test_get_by_url(self):
+        conn, cur = _conn(fetch_row={"id": 3})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_outreach_target_by_url
+            assert get_outreach_target_by_url(1, "https://x/in/jane")["id"] == 3
+        sql = cur.execute.call_args[0][0]
+        assert "target_profile_url = %s" in sql
+
+    def test_list_returns_pagination_shape(self):
+        conn, cur = _conn()
+        cur.fetchone.return_value = {"c": 2}
+        cur.fetchall.return_value = [{"id": 1, "stage": "comment", "status": "pending",
+                                      "created_at": None, "updated_at": None}]
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_outreach_targets
+            out = get_outreach_targets(1, status_filter="pending", stage_filter="comment", page=1, page_size=25)
+        assert out["total"] == 2 and out["page"] == 1 and len(out["targets"]) == 1
+        # both filters applied
+        list_sql = cur.execute.call_args_list[-1][0][0]
+        assert "status = %s" in list_sql and "stage = %s" in list_sql
+
+    def test_list_error_returns_empty(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="down")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_outreach_targets
+            out = get_outreach_targets(1)
+        assert out == {"targets": [], "total": 0, "page": 1, "page_size": 25}
+
+    def test_get_approved_filters(self):
+        conn, cur = _conn(fetchall=[{"id": 1}])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_approved_outreach_targets
+            rows = get_approved_outreach_targets(5)
+        assert len(rows) == 1
+        sql = cur.execute.call_args[0][0]
+        assert "status = 'approved'" in sql and "stage <> 'completed'" in sql
+
+    def test_users_with_approved(self):
+        conn, cur = _conn(fetchall=[(1,), (4,)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_users_with_approved_outreach
+            assert get_users_with_approved_outreach() == [1, 4]
+
+    def test_update_status(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_outreach_target_status, OutreachStatus
+            assert update_outreach_target_status(7, OutreachStatus.CANCELED) is True
+        assert "UPDATE outreach_funnel_targets SET status" in cur.execute.call_args[0][0]
+
+    def test_partial_update_builds_only_provided_fields(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_outreach_target, OutreachStage, OutreachStatus
+            assert update_outreach_target(7, draft_text="new", stage=OutreachStage.DM,
+                                          status=OutreachStatus.PENDING) is True
+        sql = cur.execute.call_args[0][0]
+        assert "draft_text = %s" in sql and "stage = %s" in sql and "status = %s" in sql
+        assert "target_profile_url" not in sql
+
+    def test_update_empty_draft_still_updates(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_outreach_target
+            # empty string is a real value (clears a stale draft) — must NOT be treated as "skip".
+            assert update_outreach_target(7, draft_text="") is True
+        assert "draft_text = %s" in cur.execute.call_args[0][0]
+
+    def test_update_noop_when_nothing_provided(self):
+        from cqc_lem.utilities.db import update_outreach_target
+        assert update_outreach_target(7) is False


### PR DESCRIPTION
## What & why
Issue #399 (E2 — Comment-first outreach funnel). The pieces existed (comment engine, connect/invite, DM sender, follow-ups) but there was no sequenced **value comment → wait → connect → DM** funnel keyed to a target list. This composes one from the existing primitives, with **every outbound step approval-gated** so nothing auto-fires at volume.

## How it works
A target is one row in the new `outreach_funnel_targets` table with a `stage` (comment → connect → dm → completed) and a per-stage `status` (pending → approved → acted, plus skipped/failed/canceled), mirroring the scheduled-DM lifecycle.

- The operator adds a target (drafts the comment, optionally a post URL to comment on). It starts `pending`.
- The beat dispatcher `auto_process_outreach_funnel` (every 30 min, throttle-aware) fans out to a per-user `process_outreach_funnel` task that acts **only on `approved` rows**.
- Firing a stage enqueues the existing primitive — `comment_on_post`, `invite_to_connect`, or `send_private_dm` — then advances the target to the **next** stage as `pending` again, requiring a fresh human approval. So a target moves comment→connect→DM **only with an approval at each step**.
- The DM is voice-aligned via the existing `build_dm_from_template` machinery (new `funnel` event_type + default template) and drops the prospect into the existing `dm_followups` sequence via `enqueue_next_followup`.
- Daily comment/DM caps (`max_comments_per_day` / `max_dms_per_day`) **defer** a stage (leave it approved for the next run) rather than firing it.

## Files
- `compose/local/database/migrations/V20260724110833__add_outreach_funnel.sql` — new table + `funnel` event_type on `dm_templates`/`dm_followups`.
- `utilities/db.py` — `OutreachStage`/`OutreachStatus` enums, CRUD helpers, `funnel` default template.
- `app/run_automation.py` — `process_outreach_funnel` + stage-firing helpers.
- `app/run_scheduler.py` + `app/my_celery.py` — dispatcher + 30-min beat entry.
- `api/main.py` — session-token-authed `POST/GET/PUT/DELETE /outreach/target[s]`.
- `ui/.../review/OutreachFunnel.tsx` + Content Studio "Outreach" tab — review/edit/approve/cancel each stage.

## Testing
- 43 new unit tests (db CRUD, API endpoints, stage firing + caps + advance, processor, dispatcher) — all green.
- Adjacent DM/scheduler suites still green (49 passed). UI `tsc -b` clean.

## ⚠️ Held for human review (risk: product-decision)
This ships an outbound-automation funnel. Although every step is approval-gated and nothing auto-fires at volume, the product/policy shape (default templates, cadence, ToS posture) warrants owner sign-off before it deploys to prod. Parked accordingly.

Closes #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)