### PR TITLE
feat(newsletter): subscriber-growth tracking + opt-in invite flow (closes #400)

### DIFF
--- a/compose/local/database/migrations/V20260724113220__add_newsletter_subscriber_growth.sql
+++ b/compose/local/database/migrations/V20260724113220__add_newsletter_subscriber_growth.sql
@@ -1,0 +1,22 @@
+-- Newsletter subscriber-growth tracking (issue #400). Two parts:
+--   1. A time-series of subscriber counts so growth can be charted over time. Each tracking run
+--      records one row: the scraped subscriber_count (NULL when the page couldn't be read) plus
+--      how many connections were invited that run (invites_sent) — so the same row documents both
+--      the snapshot and the growth action taken.
+--   2. Opt-in "invite my connections to subscribe" controls on newsletter_settings. Inviting is a
+--      subscriber-facing outbound action, so it is OFF by default (invite_connections_enabled=0)
+--      and hard-capped per run (max_invites_per_run) on top of LinkedIn's own weekly invite limit.
+CREATE TABLE IF NOT EXISTS newsletter_subscriber_stats (
+    id               INT AUTO_INCREMENT PRIMARY KEY,
+    user_id          INT NOT NULL,
+    subscriber_count INT NULL,                 -- scraped subscriber count; NULL when unreadable
+    invites_sent     INT NOT NULL DEFAULT 0,   -- connections invited on this run (0 when invites off/none)
+    captured_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_user_captured (user_id, captured_at),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+ALTER TABLE newsletter_settings
+    ADD COLUMN invite_connections_enabled TINYINT(1) NOT NULL DEFAULT 0,
+    ADD COLUMN max_invites_per_run        SMALLINT   NOT NULL DEFAULT 50,
+    ADD CONSTRAINT chk_nl_max_invites CHECK (max_invites_per_run BETWEEN 0 AND 500);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -319,6 +319,8 @@ class NewsletterSettingsRequest(BaseModel):
     publish_hour: int = 9
     generate_lead_days: int = 3
     max_queued_drafts: int = 1
+    invite_connections_enabled: bool = False
+    max_invites_per_run: int = 50
 
     @field_validator("max_queued_drafts")
     @classmethod
@@ -329,6 +331,11 @@ class NewsletterSettingsRequest(BaseModel):
     @classmethod
     def _clamp_lead_days(cls, v: int) -> int:
         return max(0, min(60, v))
+
+    @field_validator("max_invites_per_run")
+    @classmethod
+    def _clamp_max_invites(cls, v: int) -> int:
+        return max(0, min(500, v))
 
 
 class NewsletterDraftRequest(BaseModel):
@@ -1413,6 +1420,20 @@ def get_newsletter_settings_endpoint(session_token: str) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
     return ResponseModel(status_code=200, detail=get_newsletter_settings(user_id))
+
+
+@router.get("/user/newsletter-subscribers")
+def get_newsletter_subscribers_endpoint(session_token: str) -> ResponseModel:
+    """Subscriber-growth time-series for the current user (issue #400): the recorded snapshots plus
+    the latest known subscriber count, for charting growth over time."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    from cqc_lem.utilities.db import get_newsletter_subscriber_stats, get_latest_newsletter_subscriber_count
+    return ResponseModel(status_code=200, detail={
+        "latest": get_latest_newsletter_subscriber_count(user_id),
+        "history": get_newsletter_subscriber_stats(user_id),
+    })
 
 
 @router.put("/user/newsletter-settings")

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -105,6 +105,11 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_publish_scheduled_editions',
             'schedule': crontab(minute='5')  # Hourly: publish any edition whose scheduled slot has arrived
         },
+        'track-newsletter-subscribers': {
+            'task': 'cqc_lem.app.run_scheduler.auto_track_newsletter_subscribers',
+            # Weekly (Mon 11:00 UTC): snapshot subscriber counts + run opted-in invites within caps
+            'schedule': crontab(hour='11', minute='0', day_of_week='1')
+        },
         'dispatch-scheduled-reply-sweeps': {
             'task': 'cqc_lem.app.run_scheduler.dispatch_scheduled_reply_sweeps',
             # Every 30 min; a per-user Redis interval key gates it to reply_sweeps_per_day (2–12) sweeps.

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -24,7 +24,7 @@ from cqc_lem.utilities.ai.content_alignment import humanize_text, split_link_for
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
-    get_newsletter_settings, mark_newsletter_published, \
+    get_newsletter_settings, mark_newsletter_published, record_newsletter_subscriber_stat, \
     get_newsletter_edition, mark_edition_published, mark_edition_failed, \
     upsert_user_group, get_enabled_group_ids, record_post_stats, get_recent_posted_post_ids, \
     get_lead_magnet_settings, has_received_lead_magnet, record_lead_magnet_sent, \
@@ -1250,6 +1250,123 @@ def auto_publish_edition(self, edition_id: int):
         log_error("Newsletter edition publish error", exc=e, user_id=user_id, task_name="auto_publish_edition")
         mark_edition_failed(edition_id)
         return f"Newsletter edition error: {e}"
+    finally:
+        quit_gracefully(driver)
+
+
+def _parse_subscriber_count(text: str) -> "int | None":
+    """Pull a subscriber count out of LinkedIn's label text, e.g. '1,234 subscribers' -> 1234,
+    '3.2K subscribers' -> 3200. Returns None when no count is present."""
+    if not text:
+        return None
+    m = re.search(r"([\d.,]+)\s*([KkMm]?)\s*subscriber", text)
+    if not m:
+        return None
+    num, suffix = m.group(1), m.group(2).upper()
+    try:
+        value = float(num.replace(",", ""))
+    except ValueError:
+        return None
+    if suffix == "K":
+        value *= 1_000
+    elif suffix == "M":
+        value *= 1_000_000
+    return int(value)
+
+
+def _read_newsletter_subscriber_count(driver, wait, newsletter_url: str) -> "int | None":
+    """Best-effort: open the user's newsletter page and read its 'N subscribers' label. LinkedIn
+    renders the count in a header near the newsletter title; selectors vary, so we scan a few
+    candidates and fall back to a page-text regex. Returns None when the count can't be read —
+    never raises (validated on a supervised first real run)."""
+    if not newsletter_url:
+        return None
+    driver.get(newsletter_url)
+    time.sleep(random.uniform(4, 7))
+    el = find_first(driver, wait,
+                    [(By.XPATH, "//*[contains(translate(text(),'SUBSCRIBER','subscriber'),'subscriber')]")],
+                    "Subscriber count", visible_only=True, required=False, max_try=1)
+    if el is not None:
+        count = _parse_subscriber_count(getText(el) or "")
+        if count is not None:
+            return count
+    try:
+        return _parse_subscriber_count(driver.find_element(By.TAG_NAME, "body").text)
+    except Exception:
+        return None
+
+
+def _invite_connections_to_newsletter(driver, wait, cap: int) -> int:
+    """Best-effort: from the open newsletter page, invite up to `cap` connections to subscribe.
+    Opens the 'Invite' dialog (LinkedIn labels it 'Invite connections'/'Manage'), selects up to
+    `cap` connection checkboxes, and sends. Returns the number invited (0 when the flow isn't
+    available or cap<=0). Never raises — caps are enforced here, opt-in is enforced by the caller
+    (validated on a supervised first real run)."""
+    if cap <= 0:
+        return 0
+    if click_first(driver, wait,
+                   [(By.XPATH, "//button[contains(translate(@aria-label,'INVITE','invite'),'invite')]"),
+                    (By.XPATH, "//button[contains(translate(normalize-space(),'INVITE','invite'),'invite')]")],
+                   "Invite connections", required=False, max_try=1) is None:
+        return 0
+    time.sleep(random.uniform(2, 4))
+    checkboxes = get_elements_as_list_wait_stale(
+        wait, "//input[@type='checkbox' and contains(@id,'invitee')]",
+        "Newsletter invitee checkboxes", max_retry=0) or []
+    selected = 0
+    for cb in checkboxes:
+        if selected >= cap:
+            break
+        try:
+            driver.execute_script("arguments[0].click();", cb)
+            selected += 1
+            time.sleep(random.uniform(0.2, 0.6))
+        except Exception:
+            continue
+    if selected == 0:
+        return 0
+    if click_first(driver, wait,
+                   [(By.XPATH, "//button[contains(translate(normalize-space(),'INVITE','invite'),'invite') "
+                               "and not(@disabled)]")],
+                   "Send newsletter invites", required=False, max_try=1) is None:
+        return 0
+    time.sleep(random.uniform(2, 4))
+    return selected
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='se_content')
+def track_newsletter_subscribers(self, user_id: int):
+    """Capture the user's newsletter subscriber count over time and, when opted in, invite
+    connections to subscribe within the per-run cap (issue #400). Reads the count from the
+    newsletter page and records a growth snapshot; inviting only runs when
+    invite_connections_enabled is set and stops at max_invites_per_run. Best-effort Selenium —
+    the first real run should be supervised."""
+    settings = get_newsletter_settings(user_id)
+    if not settings.get("enabled"):
+        return "Newsletter not enabled"
+    newsletter_url = settings.get("newsletter_url")
+    if not newsletter_url:
+        return "No newsletter URL yet"
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Newsletter")
+    except Exception as e:
+        log_error("Error getting profile for newsletter tracking", exc=e, user_id=user_id,
+                  task_name="track_newsletter_subscribers")
+        return f"Failed to start newsletter tracking: {e}"
+    try:
+        count = _read_newsletter_subscriber_count(driver, wait, newsletter_url)
+        invited = 0
+        if settings.get("invite_connections_enabled"):
+            invited = _invite_connections_to_newsletter(driver, wait, int(settings.get("max_invites_per_run") or 0))
+        record_newsletter_subscriber_stat(user_id, subscriber_count=count, invites_sent=invited)
+        log_info("Newsletter subscriber snapshot", user_id=user_id,
+                 task_name="track_newsletter_subscribers")
+        return f"Subscribers: {count if count is not None else 'unknown'}; invited {invited}"
+    except Exception as e:
+        log_error("Newsletter subscriber tracking error", exc=e, user_id=user_id,
+                  task_name="track_newsletter_subscribers")
+        return f"Newsletter tracking error: {e}"
     finally:
         quit_gracefully(driver)
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1254,7 +1254,7 @@ def auto_publish_edition(self, edition_id: int):
         quit_gracefully(driver)
 
 
-def _parse_subscriber_count(text: str) -> "int | None":
+def _parse_subscriber_count(text: "str | None") -> "int | None":
     """Pull a subscriber count out of LinkedIn's label text, e.g. '1,234 subscribers' -> 1234,
     '3.2K subscribers' -> 3200. Returns None when no count is present."""
     if not text:

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -368,6 +368,24 @@ def auto_generate_newsletter_drafts():
 
 
 @shared_task.task
+def auto_track_newsletter_subscribers():
+    """Fan out per-user newsletter subscriber-growth tracking for every enabled newsletter user
+    (issue #400). Each per-user task reads the subscriber count into the growth time-series and,
+    when opted in, invites connections within the per-run cap. Selenium-backed, so it respects the
+    global throttle breaker."""
+    if _skip_if_throttled("auto_track_newsletter_subscribers"):
+        return "Skipped (throttled)"
+    from cqc_lem.app.run_automation import track_newsletter_subscribers
+    from cqc_lem.utilities.db import get_enabled_newsletter_user_ids
+
+    dispatched = 0
+    for user_id in get_enabled_newsletter_user_ids():
+        track_newsletter_subscribers.apply_async(kwargs={"user_id": user_id})
+        dispatched += 1
+    return f"Dispatched newsletter subscriber tracking for {dispatched} user(s)"
+
+
+@shared_task.task
 def generate_newsletter_drafts_for_user(user_id: int):
     """Top up a single user's newsletter review queue on demand (e.g. right after they raise their
     max_queued_drafts in settings), so new slots don't wait for the daily beat. Skips the bootstrap

--- a/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import Toggle from '../../components/Toggle'
-import type { NewsletterSettings } from './types'
+import type { NewsletterSettings, NewsletterSubscribers } from './types'
 import { WEEKDAYS } from './types'
 import { FIELD_LIMITS } from './fieldLimits'
 
@@ -29,6 +29,16 @@ export default function NewsletterCard() {
   useEffect(() => {
     if (nlData && !newsletter) setNewsletter(nlData)
   }, [nlData])
+
+  const { data: subs } = useQuery({
+    queryKey: ['newsletter-subscribers', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/newsletter-subscribers?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as NewsletterSubscribers),
+    enabled: !!sessionToken && !!newsletter?.enabled,
+    staleTime: 60 * 1000,
+  })
 
   const setNl = (patch: Partial<NewsletterSettings>) => setNewsletter((p) => (p ? { ...p, ...patch } : p))
 
@@ -121,6 +131,39 @@ export default function NewsletterCard() {
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
               <p className="text-xs text-gray-400 mt-1">How early each new draft appears for review.</p>
             </div>
+          </div>
+
+          {/* Subscriber growth: count over time + opt-in invite flow (capped). */}
+          <div className="border-t border-gray-100 pt-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-gray-700">Subscribers</p>
+              <p className="text-sm font-semibold text-gray-900">
+                {subs?.latest != null ? subs.latest.toLocaleString() : '—'}
+              </p>
+            </div>
+            {subs && subs.history.length > 0 && (
+              <p className="text-xs text-gray-400">
+                Tracked {subs.history.length} time{subs.history.length === 1 ? '' : 's'}; last invited{' '}
+                {subs.history[0].invites_sent} connection{subs.history[0].invites_sent === 1 ? '' : 's'}.
+              </p>
+            )}
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-medium text-gray-700">Invite my connections to subscribe</p>
+                <p className="text-xs text-gray-500">Opt-in. We only invite when this is on, up to your cap per run (plus LinkedIn's own weekly limit).</p>
+              </div>
+              <Toggle on={newsletter.invite_connections_enabled}
+                onClick={() => setNl({ invite_connections_enabled: !newsletter.invite_connections_enabled })} />
+            </div>
+            {newsletter.invite_connections_enabled && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">Max invites per run</label>
+                <input type="number" min={0} max={500} value={newsletter.max_invites_per_run}
+                  onChange={(e) => setNl({ max_invites_per_run: Number(e.target.value) })}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+                <p className="text-xs text-gray-400 mt-1">Hard cap on connections invited each run (0–500).</p>
+              </div>
+            )}
           </div>
 
           <div className="flex items-center justify-between">

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -64,6 +64,19 @@ export type NewsletterSettings = {
   publish_hour: number
   generate_lead_days: number
   max_queued_drafts: number
+  invite_connections_enabled: boolean
+  max_invites_per_run: number
+}
+
+export type NewsletterSubscriberStat = {
+  subscriber_count: number | null
+  invites_sent: number
+  captured_at: string
+}
+
+export type NewsletterSubscribers = {
+  latest: number | null
+  history: NewsletterSubscriberStat[]
 }
 
 export type NewsletterEdition = {

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3536,9 +3536,11 @@ _NEWSLETTER_DEFAULTS: dict = {
     "enabled": False, "title": None, "topic": None, "cadence": "weekly",
     "align_with_blog": True, "newsletter_url": None, "last_published_at": None,
     "publish_day": 1, "publish_hour": 9, "generate_lead_days": 3, "max_queued_drafts": 1,
+    "invite_connections_enabled": False, "max_invites_per_run": 50,
 }
 _NEWSLETTER_COLS = ("enabled", "title", "topic", "cadence", "align_with_blog", "newsletter_url",
-                    "publish_day", "publish_hour", "generate_lead_days", "max_queued_drafts")
+                    "publish_day", "publish_hour", "generate_lead_days", "max_queued_drafts",
+                    "invite_connections_enabled", "max_invites_per_run")
 
 
 def get_newsletter_settings(user_id: int) -> dict:
@@ -3548,19 +3550,23 @@ def get_newsletter_settings(user_id: int) -> dict:
     try:
         cursor.execute(
             "SELECT enabled, title, topic, cadence, align_with_blog, newsletter_url, last_published_at, "
-            "publish_day, publish_hour, generate_lead_days, max_queued_drafts "
+            "publish_day, publish_hour, generate_lead_days, max_queued_drafts, "
+            "invite_connections_enabled, max_invites_per_run "
             "FROM newsletter_settings WHERE user_id = %s", (user_id,))
         row = cursor.fetchone()
         if row is None:
             return dict(_NEWSLETTER_DEFAULTS)
         row["enabled"] = bool(row.get("enabled"))
         row["align_with_blog"] = bool(row.get("align_with_blog"))
+        row["invite_connections_enabled"] = bool(row.get("invite_connections_enabled"))
         row["publish_day"] = int(row.get("publish_day") if row.get("publish_day") is not None else 1)
         row["publish_hour"] = int(row.get("publish_hour") if row.get("publish_hour") is not None else 9)
         row["generate_lead_days"] = int(
             row.get("generate_lead_days") if row.get("generate_lead_days") is not None else 3)
         row["max_queued_drafts"] = int(
             row.get("max_queued_drafts") if row.get("max_queued_drafts") is not None else 1)
+        row["max_invites_per_run"] = int(
+            row.get("max_invites_per_run") if row.get("max_invites_per_run") is not None else 50)
         return row
     except mysql.connector.Error as err:
         myprint(f"Could not get newsletter settings for user {user_id} | Error: {err}")
@@ -3574,7 +3580,8 @@ def update_newsletter_settings(user_id: int, settings: dict) -> bool:
     """Upsert the user's newsletter config (title/topic/cadence/enabled/align_with_blog)."""
     merged = {**_NEWSLETTER_DEFAULTS, **{k: v for k, v in settings.items() if k in _NEWSLETTER_COLS}}
     values = [user_id] + [
-        (1 if merged[c] else 0) if c in ("enabled", "align_with_blog") else merged[c]
+        (1 if merged[c] else 0) if c in ("enabled", "align_with_blog", "invite_connections_enabled")
+        else merged[c]
         for c in _NEWSLETTER_COLS]
     placeholders = ", ".join(["%s"] * (len(_NEWSLETTER_COLS) + 1))
     updates = ", ".join(f"{c}=VALUES({c})" for c in _NEWSLETTER_COLS)
@@ -3608,6 +3615,65 @@ def mark_newsletter_published(user_id: int, newsletter_url: str = None) -> bool:
     except mysql.connector.Error as err:
         myprint(f"Could not mark newsletter published for user {user_id} | Error: {err}")
         return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_newsletter_subscriber_stat(user_id: int, subscriber_count: "int | None" = None,
+                                      invites_sent: int = 0) -> bool:
+    """Append one subscriber-growth snapshot for the user: the scraped subscriber_count (NULL when
+    the page couldn't be read) and how many connections were invited on this run. One row per
+    tracking run so growth can be charted over time (issue #400)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO newsletter_subscriber_stats (user_id, subscriber_count, invites_sent) "
+            "VALUES (%s, %s, %s)",
+            (user_id, subscriber_count, int(invites_sent or 0)))
+        connection.commit()
+        return cursor.rowcount == 1
+    except mysql.connector.Error as err:
+        myprint(f"Could not record newsletter subscriber stat for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_newsletter_subscriber_stats(user_id: int, limit: int = 52) -> list:
+    """Return the user's subscriber-growth snapshots, most recent first (default last 52 runs — a
+    year of weekly tracking). Each item: subscriber_count, invites_sent, captured_at."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT subscriber_count, invites_sent, captured_at FROM newsletter_subscriber_stats "
+            "WHERE user_id = %s ORDER BY captured_at DESC, id DESC LIMIT %s", (user_id, limit))
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        myprint(f"Could not get newsletter subscriber stats for user {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_latest_newsletter_subscriber_count(user_id: int) -> "int | None":
+    """Most recent non-NULL subscriber_count for the user, or None if never captured."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT subscriber_count FROM newsletter_subscriber_stats "
+            "WHERE user_id = %s AND subscriber_count IS NOT NULL "
+            "ORDER BY captured_at DESC, id DESC LIMIT 1", (user_id,))
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not get latest newsletter subscriber count for user {user_id} | Error: {err}")
+        return None
     finally:
         cursor.close()
         connection.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3577,7 +3577,8 @@ def get_newsletter_settings(user_id: int) -> dict:
 
 
 def update_newsletter_settings(user_id: int, settings: dict) -> bool:
-    """Upsert the user's newsletter config (title/topic/cadence/enabled/align_with_blog)."""
+    """Upsert the user's newsletter config (title/topic/cadence/enabled/align_with_blog,
+    plus the opt-in invite flow: invite_connections_enabled/max_invites_per_run)."""
     merged = {**_NEWSLETTER_DEFAULTS, **{k: v for k, v in settings.items() if k in _NEWSLETTER_COLS}}
     values = [user_id] + [
         (1 if merged[c] else 0) if c in ("enabled", "align_with_blog", "invite_connections_enabled")

--- a/tests/unit/api/test_newsletter_api.py
+++ b/tests/unit/api/test_newsletter_api.py
@@ -96,9 +96,44 @@ class TestNewsletterSettings:
         assert resp.status_code == 200
         task.apply_async.assert_not_called()
 
+    def test_put_clamps_max_invites_high(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_newsletter_settings", return_value=True) as upd:
+            resp = client.put("/api/user/newsletter-settings", json={
+                "session_token": _SESSION, "enabled": True,
+                "invite_connections_enabled": True, "max_invites_per_run": 9999})
+        assert resp.status_code == 200
+        args = upd.call_args[0][1]
+        assert args["invite_connections_enabled"] is True and args["max_invites_per_run"] == 500
+
+    def test_put_clamps_max_invites_low(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_newsletter_settings", return_value=True) as upd:
+            resp = client.put("/api/user/newsletter-settings", json={
+                "session_token": _SESSION, "enabled": True, "max_invites_per_run": -10})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1]["max_invites_per_run"] == 0
+
     def test_401(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
             resp = client.get("/api/user/newsletter-settings?session_token=bad")
+        assert resp.status_code == 401
+
+
+class TestNewsletterSubscribers:
+    def test_get_returns_history_and_latest(self, client):
+        history = [{"subscriber_count": 130, "invites_sent": 0, "captured_at": "2026-07-20T00:00:00"}]
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.utilities.db.get_latest_newsletter_subscriber_count", return_value=130), \
+             patch("cqc_lem.utilities.db.get_newsletter_subscriber_stats", return_value=history):
+            resp = client.get(f"/api/user/newsletter-subscribers?session_token={_SESSION}")
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert detail["latest"] == 130 and detail["history"][0]["subscriber_count"] == 130
+
+    def test_401(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.get("/api/user/newsletter-subscribers?session_token=bad")
         assert resp.status_code == 401
 
 

--- a/tests/unit/app/test_newsletter_subscribers.py
+++ b/tests/unit/app/test_newsletter_subscribers.py
@@ -11,7 +11,7 @@ _RS = "cqc_lem.app.run_scheduler"
 
 @pytest.fixture(autouse=True)
 def _no_sleep():
-    with patch(f"{_RA}.time.sleep"), patch(f"{_RA}.random.uniform", return_value=0):
+    with patch("time.sleep"), patch("random.uniform", return_value=0):
         yield
 
 

--- a/tests/unit/app/test_newsletter_subscribers.py
+++ b/tests/unit/app/test_newsletter_subscribers.py
@@ -1,0 +1,177 @@
+"""Unit tests for newsletter subscriber-growth tracking + opt-in invite flow (issue #400)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+_RS = "cqc_lem.app.run_scheduler"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with patch(f"{_RA}.time.sleep"), patch(f"{_RA}.random.uniform", return_value=0):
+        yield
+
+
+class TestParseSubscriberCount:
+    @pytest.mark.parametrize("text,expected", [
+        ("1,234 subscribers", 1234),
+        ("1 subscriber", 1),
+        ("3.2K subscribers", 3200),
+        ("2M subscribers", 2_000_000),
+        ("987 subscribers • Weekly", 987),
+        ("", None),
+        ("No count here", None),
+        (None, None),
+    ])
+    def test_parse(self, text, expected):
+        from cqc_lem.app.run_automation import _parse_subscriber_count
+        assert _parse_subscriber_count(text) == expected
+
+
+class TestReadSubscriberCount:
+    def test_none_when_no_url(self):
+        from cqc_lem.app.run_automation import _read_newsletter_subscriber_count
+        assert _read_newsletter_subscriber_count(MagicMock(), MagicMock(), None) is None
+
+    def test_reads_from_element(self):
+        from cqc_lem.app.run_automation import _read_newsletter_subscriber_count
+        el = MagicMock()
+        with patch(f"{_RA}.find_first", return_value=el), \
+             patch(f"{_RA}.getText", return_value="4,560 subscribers"):
+            out = _read_newsletter_subscriber_count(MagicMock(), MagicMock(), "https://x/newsletter")
+        assert out == 4560
+
+    def test_falls_back_to_body_text(self):
+        from cqc_lem.app.run_automation import _read_newsletter_subscriber_count
+        driver = MagicMock()
+        driver.find_element.return_value.text = "Header 88 subscribers footer"
+        with patch(f"{_RA}.find_first", return_value=None):
+            out = _read_newsletter_subscriber_count(driver, MagicMock(), "https://x/newsletter")
+        assert out == 88
+
+    def test_none_when_unreadable(self):
+        from cqc_lem.app.run_automation import _read_newsletter_subscriber_count
+        driver = MagicMock()
+        driver.find_element.side_effect = Exception("no body")
+        with patch(f"{_RA}.find_first", return_value=None):
+            assert _read_newsletter_subscriber_count(driver, MagicMock(), "https://x") is None
+
+
+class TestInviteConnections:
+    def test_zero_cap_no_op(self):
+        from cqc_lem.app.run_automation import _invite_connections_to_newsletter
+        with patch(f"{_RA}.click_first") as cf:
+            assert _invite_connections_to_newsletter(MagicMock(), MagicMock(), 0) == 0
+        cf.assert_not_called()
+
+    def test_zero_when_no_invite_button(self):
+        from cqc_lem.app.run_automation import _invite_connections_to_newsletter
+        with patch(f"{_RA}.click_first", return_value=None):
+            assert _invite_connections_to_newsletter(MagicMock(), MagicMock(), 10) == 0
+
+    def test_selects_up_to_cap_and_sends(self):
+        from cqc_lem.app.run_automation import _invite_connections_to_newsletter
+        boxes = [MagicMock() for _ in range(10)]
+        with patch(f"{_RA}.click_first", return_value=MagicMock()), \
+             patch(f"{_RA}.get_elements_as_list_wait_stale", return_value=boxes):
+            invited = _invite_connections_to_newsletter(MagicMock(), MagicMock(), 3)
+        assert invited == 3
+
+    def test_zero_when_no_checkboxes(self):
+        from cqc_lem.app.run_automation import _invite_connections_to_newsletter
+        with patch(f"{_RA}.click_first", return_value=MagicMock()), \
+             patch(f"{_RA}.get_elements_as_list_wait_stale", return_value=[]):
+            assert _invite_connections_to_newsletter(MagicMock(), MagicMock(), 5) == 0
+
+    def test_zero_when_send_button_missing(self):
+        from cqc_lem.app.run_automation import _invite_connections_to_newsletter
+        boxes = [MagicMock() for _ in range(3)]
+        # First click (open dialog) succeeds; send-button click returns None.
+        with patch(f"{_RA}.click_first", side_effect=[MagicMock(), None]), \
+             patch(f"{_RA}.get_elements_as_list_wait_stale", return_value=boxes):
+            assert _invite_connections_to_newsletter(MagicMock(), MagicMock(), 3) == 0
+
+
+class TestTrackNewsletterSubscribers:
+    def test_skips_when_disabled(self):
+        from cqc_lem.app.run_automation import track_newsletter_subscribers
+        with patch(f"{_RA}.get_newsletter_settings", return_value={"enabled": False}), \
+             patch(f"{_RA}.get_current_profile") as gp:
+            result = track_newsletter_subscribers.run(user_id=1)
+        assert "not enabled" in result
+        gp.assert_not_called()
+
+    def test_skips_when_no_url(self):
+        from cqc_lem.app.run_automation import track_newsletter_subscribers
+        with patch(f"{_RA}.get_newsletter_settings",
+                   return_value={"enabled": True, "newsletter_url": None}), \
+             patch(f"{_RA}.get_current_profile") as gp:
+            result = track_newsletter_subscribers.run(user_id=1)
+        assert "No newsletter URL" in result
+        gp.assert_not_called()
+
+    def test_captures_count_without_inviting_when_opted_out(self):
+        from cqc_lem.app.run_automation import track_newsletter_subscribers
+        settings = {"enabled": True, "newsletter_url": "https://x/nl",
+                    "invite_connections_enabled": False, "max_invites_per_run": 50}
+        with patch(f"{_RA}.get_newsletter_settings", return_value=settings), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}._read_newsletter_subscriber_count", return_value=210), \
+             patch(f"{_RA}._invite_connections_to_newsletter") as invite, \
+             patch(f"{_RA}.record_newsletter_subscriber_stat") as rec, \
+             patch(f"{_RA}.quit_gracefully"):
+            result = track_newsletter_subscribers.run(user_id=1)
+        invite.assert_not_called()
+        rec.assert_called_once_with(1, subscriber_count=210, invites_sent=0)
+        assert "Subscribers: 210" in result and "invited 0" in result
+
+    def test_invites_within_cap_when_opted_in(self):
+        from cqc_lem.app.run_automation import track_newsletter_subscribers
+        settings = {"enabled": True, "newsletter_url": "https://x/nl",
+                    "invite_connections_enabled": True, "max_invites_per_run": 25}
+        with patch(f"{_RA}.get_newsletter_settings", return_value=settings), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}._read_newsletter_subscriber_count", return_value=210), \
+             patch(f"{_RA}._invite_connections_to_newsletter", return_value=25) as invite, \
+             patch(f"{_RA}.record_newsletter_subscriber_stat") as rec, \
+             patch(f"{_RA}.quit_gracefully"):
+            result = track_newsletter_subscribers.run(user_id=1)
+        invite.assert_called_once()
+        assert invite.call_args[0][2] == 25  # cap threaded through
+        rec.assert_called_once_with(1, subscriber_count=210, invites_sent=25)
+        assert "invited 25" in result
+
+    def test_records_unknown_when_count_unreadable(self):
+        from cqc_lem.app.run_automation import track_newsletter_subscribers
+        settings = {"enabled": True, "newsletter_url": "https://x/nl",
+                    "invite_connections_enabled": False, "max_invites_per_run": 50}
+        with patch(f"{_RA}.get_newsletter_settings", return_value=settings), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}._read_newsletter_subscriber_count", return_value=None), \
+             patch(f"{_RA}.record_newsletter_subscriber_stat") as rec, \
+             patch(f"{_RA}.quit_gracefully"):
+            result = track_newsletter_subscribers.run(user_id=1)
+        rec.assert_called_once_with(1, subscriber_count=None, invites_sent=0)
+        assert "unknown" in result
+
+
+class TestAutoTrackFanout:
+    def test_dispatches_per_enabled_user(self):
+        from cqc_lem.app.run_scheduler import auto_track_newsletter_subscribers
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch("cqc_lem.utilities.db.get_enabled_newsletter_user_ids", return_value=[1, 4, 7]), \
+             patch("cqc_lem.app.run_automation.track_newsletter_subscribers") as task:
+            result = auto_track_newsletter_subscribers()
+        assert task.apply_async.call_count == 3
+        assert "3 user" in result
+
+    def test_skips_when_throttled(self):
+        from cqc_lem.app.run_scheduler import auto_track_newsletter_subscribers
+        with patch(f"{_RS}._skip_if_throttled", return_value=True), \
+             patch("cqc_lem.app.run_automation.track_newsletter_subscribers") as task:
+            result = auto_track_newsletter_subscribers()
+        task.apply_async.assert_not_called()
+        assert "throttled" in result.lower()

--- a/tests/unit/utilities/test_db_newsletter.py
+++ b/tests/unit/utilities/test_db_newsletter.py
@@ -109,6 +109,104 @@ class TestNewsletterDraftConfigFields:
         assert "generate_lead_days" in sql and "max_queued_drafts" in sql
 
 
+class TestNewsletterInviteFields:
+    def test_settings_coerce_invite_fields(self):
+        row = {"enabled": 1, "title": "T", "topic": None, "cadence": "weekly",
+               "align_with_blog": 1, "newsletter_url": None, "last_published_at": None,
+               "publish_day": "1", "publish_hour": "9", "generate_lead_days": "3",
+               "max_queued_drafts": "1", "invite_connections_enabled": 1, "max_invites_per_run": "80"}
+        conn, _ = _mock_conn(fetch_row=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_settings
+            s = get_newsletter_settings(1)
+        assert s["invite_connections_enabled"] is True and s["max_invites_per_run"] == 80
+
+    def test_defaults_invite_fields(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_settings
+            s = get_newsletter_settings(1)
+        assert s["invite_connections_enabled"] is False and s["max_invites_per_run"] == 50
+
+    def test_selects_invite_columns(self):
+        conn, cur = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_settings
+            get_newsletter_settings(1)
+        sql = cur.execute.call_args[0][0]
+        assert "invite_connections_enabled" in sql and "max_invites_per_run" in sql
+
+    def test_upsert_includes_invite_columns(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_newsletter_settings
+            update_newsletter_settings(1, {"invite_connections_enabled": True, "max_invites_per_run": 30})
+        sql, params = cur.execute.call_args[0]
+        assert "invite_connections_enabled" in sql and "max_invites_per_run" in sql
+        assert 1 in params and 30 in params  # bool coerced to 1
+
+
+class TestSubscriberStats:
+    def test_record_stat_inserts(self):
+        conn, cur = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_newsletter_subscriber_stat
+            assert record_newsletter_subscriber_stat(1, subscriber_count=123, invites_sent=5) is True
+        sql, params = cur.execute.call_args[0]
+        assert "INSERT INTO newsletter_subscriber_stats" in sql
+        assert params == (1, 123, 5)
+
+    def test_record_stat_defaults(self):
+        conn, cur = _mock_conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_newsletter_subscriber_stat
+            assert record_newsletter_subscriber_stat(1) is True
+        _, params = cur.execute.call_args[0]
+        assert params == (1, None, 0)
+
+    def test_record_stat_false_on_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_newsletter_subscriber_stat
+            assert record_newsletter_subscriber_stat(1, 5) is False
+
+    def test_get_stats_orders_desc(self):
+        import datetime
+        rows = [{"subscriber_count": 130, "invites_sent": 0, "captured_at": datetime.datetime(2026, 7, 20)},
+                {"subscriber_count": 120, "invites_sent": 5, "captured_at": datetime.datetime(2026, 7, 13)}]
+        conn, cur = _mock_conn(fetch_all=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_subscriber_stats
+            out = get_newsletter_subscriber_stats(1, limit=10)
+        assert [r["subscriber_count"] for r in out] == [130, 120]
+        sql, params = cur.execute.call_args[0]
+        assert "ORDER BY captured_at DESC" in sql and params == (1, 10)
+
+    def test_get_stats_empty_on_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_newsletter_subscriber_stats
+            assert get_newsletter_subscriber_stats(1) == []
+
+    def test_latest_count_returns_int(self):
+        conn, cur = _mock_conn(fetch_row=(142,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_latest_newsletter_subscriber_count
+            assert get_latest_newsletter_subscriber_count(1) == 142
+        sql = cur.execute.call_args[0][0]
+        assert "subscriber_count IS NOT NULL" in sql
+
+    def test_latest_count_none_when_absent(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_latest_newsletter_subscriber_count
+            assert get_latest_newsletter_subscriber_count(1) is None
+
+
 class TestEnabledNewsletterUsers:
     def test_returns_ids(self):
         conn, cur = _mock_conn(fetch_all=[(2,), (9,)])


### PR DESCRIPTION
## What & why
Issue #400: the newsletter engine only *published* editions — no subscriber-count tracking and no growth flow. This adds both:

1. **Subscriber count over time** — each tracking run records one `newsletter_subscriber_stats` row (`subscriber_count`, `invites_sent`, `captured_at`) so growth can be charted. Count is scraped best-effort from the newsletter page; `NULL` when unreadable.
2. **Opt-in "invite my connections to subscribe" flow** — OFF by default (`invite_connections_enabled`), hard-capped per run (`max_invites_per_run`, 0–500, default 50) on top of LinkedIn's own weekly invite limit.

## Changes
- **Migration** `V20260724113220__add_newsletter_subscriber_growth.sql`: new `newsletter_subscriber_stats` table + two opt-in columns on `newsletter_settings` (CHECK 0..500).
- **db.py**: `record_newsletter_subscriber_stat`, `get_newsletter_subscriber_stats`, `get_latest_newsletter_subscriber_count`; settings read/upsert extended for the two new fields.
- **run_automation.py**: `track_newsletter_subscribers` per-user task (Selenium, `se_content` queue) + helpers `_read_newsletter_subscriber_count` / `_invite_connections_to_newsletter` / `_parse_subscriber_count`. Inviting runs only when opted in and stops at the cap.
- **run_scheduler.py**: `auto_track_newsletter_subscribers` fan-out (throttle-aware). **my_celery** beat: weekly Mon 11:00 UTC.
- **API**: `GET /user/newsletter-subscribers` (latest + history); `NewsletterSettingsRequest` gains the two clamped fields.
- **UI**: `NewsletterCard` shows subscriber count + tracking history and the invite opt-in toggle + cap input.

## Testing
- `tests/unit/utilities/test_db_newsletter.py` — subscriber-stat helpers + new settings coercion/upsert.
- `tests/unit/api/test_newsletter_api.py` — clamp of `max_invites_per_run` + subscribers endpoint.
- `tests/unit/app/test_newsletter_subscribers.py` — count parsing, read/invite helpers, task opt-in/cap gating, fan-out.
- All newsletter unit suites green locally; UI `tsc -b` clean.

## Notes for review (held for human — RISK=migration + product-decision)
- The Selenium scrape/invite selectors are **best-effort** (mirroring the existing article-publish flow) and should be validated on a **supervised first real run** against live LinkedIn.
- Inviting connections is a **subscriber-facing outbound action** and a **product/ToS decision** — hence opt-in + cap, held for owner review before it reaches prod.

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)