### PR TITLE
refactor(cleanup): remove dead/stub code surfaced by 2026 audit (closes #402)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ LinkedIn Engagement Manager (LEM) automates LinkedIn engagement end to end: Sele
 Two pillars:
 
 - **Content generation & scheduling** — a 30-day content plan of buyer-journey-staged posts (thought leadership, industry-news commentary, personal story, engagement prompts, carousels, native video, blog summaries) auto-scheduled around peak/golden hours, with sentiment checks and a preview/approval workflow.
-- **Engagement automation** — feed commenting, replies on the user's own posts, seed-and-pin first comments, appreciation/outreach DMs with multi-touch follow-ups, and monthly company-page invitations — all driven by per-user targeting, voice/tone, and per-day cap preferences.
+- **Engagement automation** — feed commenting, replies on the user's own posts, seed first comments, appreciation/outreach DMs with multi-touch follow-ups, and monthly company-page invitations — all driven by per-user targeting, voice/tone, and per-day cap preferences.
 
 See **Feature Areas** below for the code paths behind each capability.
 
@@ -137,7 +137,7 @@ Use `click_element_wait_retry()` for all click interactions — it handles trans
 
 ### Engagement automation (`app/run_automation.py`)
 - **Feed commenting** rebuilt for LinkedIn's SDUI: resilient `find_first`/`click_first`/`find_all_first` selectors (`utilities/linkedin/helper.py`); inline compose + submit; **recency-dominant scoring matrix** (`_score_feed_post` = recency + relevance + reciprocity + activity) with post-age (`_post_age_minutes`) and social-count (`_post_social_counts`) extraction, best-effort "Recent" feed sort (`_switch_feed_to_recent`); targeting filters + per-day caps + voice/tone. Runs pre-post (≈15 min before each scheduled post) and daily at a golden hour.
-- **Replies** to comments on the user's own posts (`automate_reply_commenting`); **seed + pin a first comment** on own posts (`auto_seed_comment_on_post` → `_pin_own_comment`).
+- **Replies** to comments on the user's own posts (`automate_reply_commenting`); **seed a first comment** on own posts (`auto_seed_comment_on_post`).
 - **Reciprocity tracking** via the `post_engagers` table — boosts commenting back on people who engaged with us (`get_recent_engagers`).
 - **DMs**: appreciation (connection / recommendation / collaboration), profile-viewer outreach, and **multi-touch follow-up sequences** — all templated and voice-aligned (`build_dm_from_template`, `dm_templates`, `dm_followups`, `process_user_followups`).
 - Monthly **company-page invitations** (`utilities/linkedin/company_page_inviter.py`).

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1374,28 +1374,6 @@ def track_newsletter_subscribers(self, user_id: int):
         quit_gracefully(driver)
 
 
-def _pin_own_comment(driver) -> bool:
-    """Best-effort: pin our just-posted comment on our own post. The comment's overflow control
-    (aria-label 'View more options for <name>'s comment.') is hover-hidden, so we JS-click it,
-    then click 'Pin comment' in the menu. Non-fatal — the seed comment's value stands without it."""
-    try:
-        opened = driver.execute_script(
-            "const b=[...document.querySelectorAll('button[aria-label]')].find(x=>{"
-            "const a=(x.getAttribute('aria-label')||'').toLowerCase();"
-            "return a.includes('options for') && a.includes('comment');});"
-            "if(b){b.scrollIntoView({block:'center'}); b.click(); return true;} return false;")
-        if not opened:
-            return False
-        time.sleep(random.uniform(1, 2))
-        return bool(driver.execute_script(
-            "const el=[...document.querySelectorAll(\"[role=menuitem],[role=menuitemradio],button,div,span,li,h5\")]"
-            ".find(e=>/^pin\\b/i.test((e.innerText||'').trim()) && (e.innerText||'').trim().length<20);"
-            "if(el){(el.closest('[role=menuitem]')||el).click(); return true;} return false;"))
-    except Exception as e:
-        log_warning("Pin own comment failed", exc=e, action_type="comment")
-        return False
-
-
 # JS: count the overflow ("…") buttons for OUR OWN comments on the current post. LinkedIn labels each
 # comment's overflow control "View more options for <name>'s comment.", so matching our full name
 # restricts this to comments WE authored — we never touch anyone else's comment.
@@ -2717,16 +2695,7 @@ def engage_with_profile_viewer(self, user_id: int, viewer_url, viewer_name):
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True}, reject_on_worker_lost=True,
                   rate_limit='2/m', queue='se_outreach')
 def clean_stale_invites(self, user_id: int):
-    """Cleans up stale invites that the user has sent"""
-
-    # TODO": Implement this method and
-    # user_email, user_password = get_user_password_pair_by_id(user_id)
-
-    # driver, wait = get_driver_wait_pair(session_name='Private DM')
-
-    # login_to_linkedin(driver, wait, user_email, user_password)
-
-    # quit_gracefully(driver)  # Close the driver
+    """Cleans up stale invites that the user has sent. Not yet implemented — no-op stub."""
 
     pass
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2695,9 +2695,15 @@ def engage_with_profile_viewer(self, user_id: int, viewer_url, viewer_name):
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True}, reject_on_worker_lost=True,
                   rate_limit='2/m', queue='se_outreach')
 def clean_stale_invites(self, user_id: int):
-    """Cleans up stale invites that the user has sent. Not yet implemented — no-op stub."""
+    """Cleans up stale invites that the user has sent. Not yet implemented — no-op stub.
 
-    pass
+    Emits an explicit log line and returns a descriptive marker so operators can tell an
+    intentional stub run apart from a real cleanup run in logs/metrics."""
+
+    log_info("clean_stale_invites is a no-op stub (not yet implemented) — skipping",
+             user_id=user_id, task_name="clean_stale_invites", action_type="invite")
+
+    return {"status": "not_implemented", "cleaned": 0, "user_id": user_id}
 
 
 def send_dm_now(user_id: int, profile_url: str, message: str) -> bool:

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -178,9 +178,6 @@ def plan_content_for_user(self, user_id: int):
         # Choose a buyer journey stage in a round-robin fashion
         stage = journey_stages[day % len(journey_stages)]
 
-        # TODO: Delete below |  Call the helper function to create content for this post type and buyer journey stage
-        # create_content(user_id, post_type, stage)
-
         # Add this post to the daily plan
         post_date = start_date + timedelta(days=day)
 

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -1309,13 +1309,6 @@ def summarize_recent_activity(recent_activity_profile: LinkedInProfile, main_pro
     return result
 
 
-def create_video_from_prompt(prompt: str):
-    raise NotImplementedError(
-        "openai.Video.create() was removed in OpenAI SDK v1.x. "
-        "Use create_runway_video() or create_replicate_video() instead."
-    )
-
-
 def _subject_anchor_line(trends: dict) -> str:
     """SUBJECT anchor injected into trend-based post prompts when the trend analysis was anchored to
     one of the user's focus topics — states the assigned subject explicitly so the writer model
@@ -2478,8 +2471,6 @@ def generate_flux1_image_from_prompt(prompt: str, *, ratio: str = DEFAULT_IMAGE_
     print(f"Video File Dest: {video_file_dest}")
     # Move the video file to the gradio dir
     shutil.move(video_file_path, video_file_dest)
-
-    # TODO: Verify this final path and move
 
     return video_file_dest
     """

--- a/tests/unit/app/test_clean_stale_invites.py
+++ b/tests/unit/app/test_clean_stale_invites.py
@@ -1,0 +1,25 @@
+"""Unit tests for the clean_stale_invites no-op stub task."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+
+class TestCleanStaleInvites:
+    def test_returns_not_implemented_marker(self):
+        from cqc_lem.app.run_automation import clean_stale_invites
+        with patch(f"{_RA}.log_info") as mock_log:
+            result = clean_stale_invites.run(user_id=42)
+        assert result == {"status": "not_implemented", "cleaned": 0, "user_id": 42}
+
+    def test_logs_explicit_stub_message(self):
+        from cqc_lem.app.run_automation import clean_stale_invites
+        with patch(f"{_RA}.log_info") as mock_log:
+            clean_stale_invites.run(user_id=7)
+        assert mock_log.call_count == 1
+        _, kwargs = mock_log.call_args
+        assert kwargs.get("user_id") == 7
+        assert kwargs.get("task_name") == "clean_stale_invites"

--- a/tests/unit/app/test_seed_comment.py
+++ b/tests/unit/app/test_seed_comment.py
@@ -35,18 +35,6 @@ class TestGenerateSeedComment:
         assert out == "What surprised you most here?"
 
 
-class TestPinOwnComment:
-    def test_true_when_pin_clicked(self):
-        from cqc_lem.app.run_automation import _pin_own_comment
-        d = MagicMock(); d.execute_script.side_effect = [True, True]   # opened menu, clicked Pin
-        assert _pin_own_comment(d) is True
-
-    def test_false_when_no_overflow(self):
-        from cqc_lem.app.run_automation import _pin_own_comment
-        d = MagicMock(); d.execute_script.side_effect = [False]        # overflow not found
-        assert _pin_own_comment(d) is False
-
-
 _URL = "https://www.linkedin.com/feed/update/urn:li:ugcPost:7479519458164695040/"
 
 

--- a/tests/unit/utilities/ai/test_ai_helper.py
+++ b/tests/unit/utilities/ai/test_ai_helper.py
@@ -166,15 +166,6 @@ class TestGetThoughtLeadershipPostFromAi:
 
 
 @pytest.mark.unit
-class TestCreateVideoFromPrompt:
-    def test_raises_not_implemented(self):
-        from cqc_lem.utilities.ai.ai_helper import create_video_from_prompt
-
-        with pytest.raises(NotImplementedError, match="create_runway_video"):
-            create_video_from_prompt("A video about AI")
-
-
-@pytest.mark.unit
 class TestModelTierAssignments:
     """Verify all functions use the expected LiteLLM tier aliases."""
 


### PR DESCRIPTION
## What & why

Removes dead/stub code surfaced by the 2026 audit (F1 cleanup, #402).

- **`_pin_own_comment`** (`run_automation.py`) — defined but never called; LinkedIn exposes no pin API. Removed the function and its two obsolete unit tests.
- **`create_video_from_prompt`** (`ai_helper.py`) — a `NotImplementedError` stub superseded by the Runway/Replicate video path. Removed the function and its obsolete unit test.
- **Leftover TODOs** cleared at the three audited sites:
  - `run_content_plan.py` — dead `# TODO: Delete below` + commented `create_content(...)` call.
  - `ai_helper.py` — stale `# TODO: Verify this final path and move` inside the commented-out flux/gradio block.
  - `run_automation.py` — the `clean_stale_invites` TODO + commented-out login scaffold. **The task itself is kept** (it's a live beat-scheduled `@shared_task` referenced by `auto_clean_stale_invites`, celeryconfig, and tests) and left as a documented no-op stub.
- Updated the `CLAUDE.md` engagement-automation notes to describe seed-only first comments (no pin), matching the removed function.

## Testing notes

- `poetry run pytest tests/unit/app/test_seed_comment.py tests/unit/utilities/ai/test_ai_helper.py` → 56 passed.
- `poetry run pytest tests/unit/app/test_run_scheduler.py tests/unit/app/test_selenium_queue_routing.py` → 76 passed (confirms `clean_stale_invites` wiring intact).
- `py_compile` clean on all three touched modules; no remaining references to the removed symbols in `src/` or `tests/`.

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)