### PR TITLE
fix(automation): stop duplicate feed comments — URN-stable dedup key + concurrency gate (closes #474)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -44,7 +44,8 @@ from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile,
 from cqc_lem.utilities.linkedin.poster import share_on_linkedin, share_carousel_on_linkedin, \
     share_document_on_linkedin, comment_on_linkedin_post, object_urn_from_post_url
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
-from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited, _redis_client
+from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited, _redis_client, \
+    acquire_run_lock, release_run_lock
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text
 from cqc_lem.utilities.logger import myprint, log_error, log_info, log_warning
 from cqc_lem.utilities.observability import track_post_outcome
@@ -468,10 +469,67 @@ def _author_is_me(author: str, my_profile: LinkedInProfile) -> bool:
     return bool(me) and (author or "").strip().lower() == me
 
 
+# Canonical LinkedIn post identity. The activity/ugcPost/share URN is stable across re-renders;
+# it's the only reliable dedup anchor. A content hash is NOT — a "…see more" toggle or our own
+# just-posted comment mutates the card's text and yields a different hash for the SAME post,
+# which is how feed commenting posted two comments on one post (issue #474).
+_URN_RE = re.compile(r"urn:li:(?:activity|ugcPost|share):\d+", re.I)
+
+
+def _normalize_post_text(content: str) -> str:
+    """Collapse the volatile bits of a card's rendered text so the SAME post hashes the same
+    across re-renders: drop the 'see more'/'…more' expander tokens and ellipses, collapse all
+    whitespace, lowercase. Used only for the no-URN fallback key + the per-run fingerprint."""
+    t = (content or "").lower()
+    t = re.sub(r"\s*(?:…|\.\.\.)?\s*see\s+more\b", " ", t)
+    t = re.sub(r"\s*(?:…|\.\.\.)\s*more\b", " ", t)
+    t = t.replace("…", " ")
+    t = re.sub(r"\s+", " ", t).strip()
+    return t
+
+
 def _feed_post_key(author: str, content: str) -> str:
-    """Stable-ish dedup key for a feed post (no permalink/urn exists in the SDUI DOM anymore)."""
-    digest = hashlib.sha1(f"{author}|{content[:200]}".encode("utf-8", "ignore")).hexdigest()[:20]
+    """Last-resort dedup key when no stable URN/permalink is available. Hashes the NORMALIZED
+    text (see _normalize_post_text) so it's stable across see-more/whitespace re-renders."""
+    norm = _normalize_post_text(content)[:240]
+    digest = hashlib.sha1(f"{(author or '').strip().lower()}|{norm}".encode("utf-8", "ignore")).hexdigest()[:20]
     return f"feedpost://{digest}"
+
+
+def _feed_post_urn_from_card(card) -> "str | None":
+    """The canonical urn:li:(activity|ugcPost|share):<id> for a feed card, read from any data
+    attribute or anywhere in the card's HTML. Returns the lowercased URN or None."""
+    try:
+        html = card.get_attribute("outerHTML")
+    except Exception:
+        return None
+    if not isinstance(html, str):
+        return None
+    m = _URN_RE.search(html)
+    return m.group(0).lower() if m else None
+
+
+def _stable_feed_post_key(card, author: str, content: str) -> str:
+    """Single canonical dedup key for a feed post, stable across re-renders. Prefers the URN
+    (from the permalink anchor OR anywhere in the card HTML) so permalink-present and
+    permalink-absent renders of the same post map to ONE key; only falls back to the normalized
+    content hash when no URN can be found."""
+    urn = None
+    permalink = _post_permalink_from_card(card)
+    if permalink:
+        m = _URN_RE.search(permalink)
+        urn = m.group(0).lower() if m else None
+    if not urn:
+        urn = _feed_post_urn_from_card(card)
+    if urn:
+        return f"feedurn://{urn}"
+    return _feed_post_key(author, content)
+
+
+def _feed_content_fingerprint(author: str, content: str) -> str:
+    """A render-stable per-run fingerprint of the post's text — a second dedup guard so that even
+    on the URN-less fallback path an unstable render can't sneak a second comment through."""
+    return "fp:" + _feed_post_key(author, content)
 
 
 def _post_permalink_from_card(card):
@@ -962,10 +1020,12 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             if card is None:
                 continue
             author = _post_author_from_card(card)
-            # Prefer the real /feed/update/ permalink so the logged post_url links correctly;
-            # fall back to the synthetic hash for cards that expose no anchor.
-            key = _post_permalink_from_card(card) or _feed_post_key(author, content)
-            if key in seen:
+            # Canonical URN-based key (stable across re-renders); normalized content hash only
+            # when no URN exists. `fp` is a second, render-stable fingerprint so even the URN-less
+            # fallback path can't slip a second comment through on a "…see more"/re-render (#474).
+            key = _stable_feed_post_key(card, author, content)
+            fp = _feed_content_fingerprint(author, content)
+            if key in seen or fp in seen:
                 continue
             examined_keys.add(key)
             # Persistent, cross-run/worker dedup: skip anything already claimed or commented
@@ -973,6 +1033,7 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             if (has_commented_post(user_id, key) or has_user_commented_on_post_url(user_id, key)
                     or not _passes_hard_excludes(content, author, prefs)):
                 seen.add(key)
+                seen.add(fp)
                 continue
             # Recency + min-reactions are soft gates: when the whole feed fails them the empty-feed
             # fallback relaxes them (below), so a reject here goes to soft_seen (reconsiderable),
@@ -991,12 +1052,13 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             meta = {"author": author, "age_minutes": age, "comments": counts["comments"],
                     "reactions": counts["reactions"], "relevant": _literal_relevant(content, author, prefs)}
             hard_keys.add(key)
-            candidates.append((_score_feed_post(meta, prefs, engagers), key, card, content, author, age))
+            candidates.append((_score_feed_post(meta, prefs, engagers), key, card, content, author, age, fp))
 
         if candidates:
             candidates.sort(key=lambda c: c[0], reverse=True)
-            score, key, card, content, author, age = candidates[0]
-            seen.add(key)  # decided on this one either way
+            score, key, card, content, author, age, fp = candidates[0]
+            seen.add(key)   # decided on this one either way
+            seen.add(fp)    # and its render-stable fingerprint (URN-less fallback guard)
             # Include gate (may use the LLM topic classifier) on the chosen post. If the feed keeps
             # producing nothing that matches the user's include filters, RELAX to fallback for the rest
             # of the run — comment on the best feed post regardless of include (LinkedIn already curates
@@ -1742,10 +1804,20 @@ def automate_commenting(self, user_id: int, loop_for_duration: int = None, futur
 
     myprint("Starting Automate Commenting Thread...")
 
+    # Single-flight per user: the pre-post trigger, the golden-hour beat, and this task's own
+    # self-requeue can otherwise run concurrently and double-walk the feed. Only one commenting
+    # run per user at a time; a loser skips this cycle (its own re-schedule will pick it up).
+    lock_name = f"automate_commenting:{user_id}"
+    lock_token = acquire_run_lock(lock_name, ttl_seconds=1800)
+    if lock_token is None:
+        myprint(f"Another commenting run is in progress for user {user_id} — skipping this cycle.")
+        return "Skipped: another commenting run already in progress for this user."
+
     try:
         driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Auto Commenting")
     except Exception as e:
         log_error("Error while getting profile for auto commenting", exc=e, user_id=user_id, task_name="automate_commenting")
+        release_run_lock(lock_name, lock_token)
         return f"Failed to start auto commenting: {e}"
 
     result = "Automate Commenting Task Started"
@@ -1791,6 +1863,9 @@ def automate_commenting(self, user_id: int, loop_for_duration: int = None, futur
         result = f"Error while automating commenting: {e}"
     finally:
         quit_gracefully(driver)  # Close the driver
+        # Released here (after this run's feed walk); the self-requeue fires 60s later as a fresh
+        # task and re-acquires. A crash still frees the lock via its TTL.
+        release_run_lock(lock_name, lock_token)
 
     return result
 

--- a/src/cqc_lem/utilities/linkedin/rate_limit.py
+++ b/src/cqc_lem/utilities/linkedin/rate_limit.py
@@ -179,3 +179,45 @@ def automation_pause_remaining() -> int:
 
 def is_automation_paused() -> bool:
     return automation_pause_remaining() > 0
+
+
+# --- single-flight task locks -------------------------------------------------
+# A per-user run lock so overlapping schedules of the SAME Selenium task (e.g. feed commenting
+# fired by the pre-post trigger, the golden-hour beat, and its own self-requeue) can't run
+# concurrently and double-act on the feed. Fails OPEN: if Redis is unavailable the lock no-ops
+# (returns a sentinel token) so behaviour is unchanged rather than blocking the task entirely.
+_LOCK_PREFIX = "linkedin:runlock:"
+_LOCK_FAILOPEN = ("no-redis", "lock-error")
+
+
+def acquire_run_lock(name: str, ttl_seconds: int = 1800) -> "str | None":
+    """Try to take a named single-flight lock. Returns an opaque token to pass to
+    release_run_lock() if acquired (or a fail-open sentinel if Redis is down), else None when
+    another holder is active. TTL auto-expires the lock if the holder crashes without releasing."""
+    client = _redis_client()
+    if client is None:
+        return "no-redis"  # fail open — don't block the task when Redis is unavailable
+    token = f"{os.getpid()}-{name}"
+    try:
+        if client.set(f"{_LOCK_PREFIX}{name}", token, nx=True, ex=max(1, int(ttl_seconds))):
+            return token
+        return None
+    except Exception as e:
+        log_warning("Run-lock acquire failed — proceeding without lock", exc=e, action_type="rate_limit")
+        return "lock-error"  # fail open
+
+
+def release_run_lock(name: str, token: "str | None") -> None:
+    """Release a lock only if we still hold the same token (never free another holder's lock, e.g.
+    one that TTL-expired and was reacquired). No-ops for the fail-open sentinels."""
+    if not token or token in _LOCK_FAILOPEN:
+        return
+    client = _redis_client()
+    if client is None:
+        return
+    try:
+        current = client.get(f"{_LOCK_PREFIX}{name}")
+        if current is not None and current.decode("utf-8", "ignore") == token:
+            client.delete(f"{_LOCK_PREFIX}{name}")
+    except Exception:
+        pass

--- a/tests/unit/app/test_feed_dedup_key.py
+++ b/tests/unit/app/test_feed_dedup_key.py
@@ -1,0 +1,111 @@
+"""Unit tests for the stable feed dedup key + normalization — issue #474.
+
+The bug: the dedup key was a hash of the post's rendered text, so a "…see more" toggle or our
+own just-posted comment mutated the text and produced a NEW key for the SAME post, defeating
+every dedup layer and posting a second comment. These lock in URN-first, render-stable keys.
+"""
+
+import pytest
+from unittest.mock import MagicMock
+
+pytestmark = pytest.mark.unit
+
+
+def _fns():
+    # Lazy import: importing run_automation at module scope instantiates the OpenAI client at
+    # collection time, which fails in CI (no OPENAI_API_KEY).
+    from cqc_lem.app.run_automation import (
+        _normalize_post_text, _feed_post_key, _feed_post_urn_from_card,
+        _stable_feed_post_key, _feed_content_fingerprint,
+    )
+    return (_normalize_post_text, _feed_post_key, _feed_post_urn_from_card,
+            _stable_feed_post_key, _feed_content_fingerprint)
+
+
+def _card(outer_html=None, permalink_href=None):
+    card = MagicMock()
+    card.get_attribute.return_value = outer_html or ""
+    if permalink_href is not None:
+        anchor = MagicMock()
+        anchor.get_attribute.return_value = permalink_href
+        card.find_elements.return_value = [anchor]
+    else:
+        card.find_elements.return_value = []
+    return card
+
+
+class TestNormalizePostText:
+    def test_strips_see_more_and_collapses_whitespace(self):
+        norm = _fns()[0]
+        a = norm("Great insight here.\n\n…see more")
+        b = norm("Great   insight here.")
+        assert a == b == "great insight here."
+
+    def test_strips_trailing_more_toggle(self):
+        norm = _fns()[0]
+        assert norm("The full thought …more") == norm("The full thought")
+
+    def test_handles_none(self):
+        assert _fns()[0](None) == ""
+
+
+class TestFeedPostKeyStability:
+    def test_same_post_hashes_the_same_across_see_more_render(self):
+        _, feed_post_key, *_ = _fns()
+        collapsed = feed_post_key("Jane Doe", "Models can't fix bad data.\n…see more")
+        expanded = feed_post_key("Jane Doe", "Models can't fix bad data.")
+        assert collapsed == expanded  # the exact bug: these used to differ
+
+    def test_author_case_and_padding_do_not_change_key(self):
+        _, feed_post_key, *_ = _fns()
+        assert feed_post_key("  Jane Doe ", "hello world") == feed_post_key("jane doe", "hello world")
+
+    def test_different_posts_differ(self):
+        _, feed_post_key, *_ = _fns()
+        assert feed_post_key("Jane", "post one") != feed_post_key("Jane", "post two")
+
+
+class TestUrnExtraction:
+    def test_reads_urn_from_card_html(self):
+        urn_from_card = _fns()[2]
+        card = _card(outer_html='<div data-id="urn:li:activity:7486221543367397377">x</div>')
+        assert urn_from_card(card) == "urn:li:activity:7486221543367397377"
+
+    def test_returns_none_when_no_urn(self):
+        assert _fns()[2](_card(outer_html="<div>no urn here</div>")) is None
+
+    def test_returns_none_on_exception(self):
+        card = MagicMock()
+        card.get_attribute.side_effect = RuntimeError("stale")
+        assert _fns()[2](card) is None
+
+
+class TestStableFeedPostKey:
+    def test_prefers_urn_and_is_render_independent(self):
+        stable = _fns()[3]
+        html = '<div data-urn="urn:li:activity:123">Bad data post …see more</div>'
+        k1 = stable(_card(outer_html=html), "Jane", "Bad data post …see more")
+        # a later render: text expanded, permalink now present — SAME urn, so SAME key
+        k2 = stable(_card(outer_html=html, permalink_href="https://www.linkedin.com/feed/update/urn:li:activity:123/"),
+                    "Jane", "Bad data post, the whole thing now visible")
+        assert k1 == k2 == "feedurn://urn:li:activity:123"
+
+    def test_permalink_and_html_urn_agree_on_one_key(self):
+        stable = _fns()[3]
+        by_html = stable(_card(outer_html='<a>urn:li:ugcPost:99</a>'), "A", "x")
+        by_link = stable(_card(permalink_href="https://www.linkedin.com/feed/update/urn:li:ugcPost:99/"), "A", "x")
+        assert by_html == by_link == "feedurn://urn:li:ugcpost:99"
+
+    def test_falls_back_to_normalized_hash_without_urn(self):
+        stable = _fns()[3]
+        k1 = stable(_card(outer_html="<div>no urn</div>"), "Jane", "Same post …see more")
+        k2 = stable(_card(outer_html="<div>no urn</div>"), "Jane", "Same post")
+        assert k1 == k2  # render-stable even on the fallback path
+        assert k1.startswith("feedpost://")
+
+
+class TestContentFingerprint:
+    def test_fingerprint_is_render_stable_and_distinct_namespace(self):
+        fp = _fns()[4]
+        assert fp("Jane", "Post …see more") == fp("Jane", "Post")
+        assert fp("Jane", "Post").startswith("fp:")

--- a/tests/unit/utilities/linkedin/test_run_lock.py
+++ b/tests/unit/utilities/linkedin/test_run_lock.py
@@ -1,0 +1,67 @@
+"""Unit tests for the single-flight run lock — issue #474 (feed-commenting concurrency gate)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+MOD = "cqc_lem.utilities.linkedin.rate_limit"
+
+
+class TestAcquireRunLock:
+    def test_acquires_when_free(self):
+        from cqc_lem.utilities.linkedin.rate_limit import acquire_run_lock
+        client = MagicMock()
+        client.set.return_value = True
+        with patch(f"{MOD}._redis_client", return_value=client):
+            token = acquire_run_lock("automate_commenting:1", ttl_seconds=1800)
+        assert token and token not in ("no-redis", "lock-error")
+        # NX + EX so it's atomic and self-expiring
+        _, kwargs = client.set.call_args
+        assert kwargs.get("nx") is True and kwargs.get("ex") == 1800
+
+    def test_returns_none_when_held(self):
+        from cqc_lem.utilities.linkedin.rate_limit import acquire_run_lock
+        client = MagicMock()
+        client.set.return_value = None  # NX failed — someone else holds it
+        with patch(f"{MOD}._redis_client", return_value=client):
+            assert acquire_run_lock("automate_commenting:1") is None
+
+    def test_fails_open_without_redis(self):
+        from cqc_lem.utilities.linkedin.rate_limit import acquire_run_lock
+        with patch(f"{MOD}._redis_client", return_value=None):
+            assert acquire_run_lock("x") == "no-redis"
+
+    def test_fails_open_on_redis_error(self):
+        from cqc_lem.utilities.linkedin.rate_limit import acquire_run_lock
+        client = MagicMock()
+        client.set.side_effect = RuntimeError("boom")
+        with patch(f"{MOD}._redis_client", return_value=client):
+            assert acquire_run_lock("x") == "lock-error"
+
+
+class TestReleaseRunLock:
+    def test_deletes_only_when_token_matches(self):
+        from cqc_lem.utilities.linkedin.rate_limit import release_run_lock
+        client = MagicMock()
+        client.get.return_value = b"tok-123"
+        with patch(f"{MOD}._redis_client", return_value=client):
+            release_run_lock("job", "tok-123")
+        client.delete.assert_called_once()
+
+    def test_does_not_delete_another_holders_lock(self):
+        from cqc_lem.utilities.linkedin.rate_limit import release_run_lock
+        client = MagicMock()
+        client.get.return_value = b"someone-else"
+        with patch(f"{MOD}._redis_client", return_value=client):
+            release_run_lock("job", "tok-123")
+        client.delete.assert_not_called()
+
+    def test_noop_for_failopen_sentinels(self):
+        from cqc_lem.utilities.linkedin.rate_limit import release_run_lock
+        client = MagicMock()
+        with patch(f"{MOD}._redis_client", return_value=client):
+            release_run_lock("job", "no-redis")
+            release_run_lock("job", None)
+        client.get.assert_not_called()
+        client.delete.assert_not_called()


### PR DESCRIPTION
## The bug (production, today)
Feed commenting posted **two comments on the same post**. User 1's 8 feed comments on 2026-07-24 were really **4 posts commented twice each**, ~2–3 min apart — all keyed `feedpost://<hash>`, and the `commented_posts` ledger held 8 distinct keys, so dedup believed they were 8 different posts.

## Root cause
The dedup key was a **hash of the post's rendered text** (`sha1(author|content[:200])`). The stable activity URN was never captured — `_post_permalink_from_card` only checked an `a[href*='/feed/update/']` anchor this SDUI doesn't expose — so every post fell back to the content hash.

When the same card re-rendered mid-scroll (a "…see more" toggle, or our own just-posted comment/reaction mutating the text node), `content[:200]` changed → a **new hash** → a new key that evaded **every** dedup layer at once: the in-memory `seen` set, `has_commented_post()` / the ledger, and the atomic `claim_post_for_comment()` (the `UNIQUE(user_id, post_key)` constraint is fine — it was just protecting an unstable key). The post re-scored, ranked top again, took a fresh claim under the new key, and got a second comment.

## Fix
1. **Canonical URN key** — `_stable_feed_post_key()` derives `feedurn://urn:li:(activity|ugcPost|share):<id>` from the permalink anchor **or anywhere in the card HTML**, so permalink-present and permalink-absent renders of one post map to **one** key. Content hash is last-resort only.
2. **Render-stable fallback** — `_normalize_post_text()` strips "see more"/ellipses and collapses whitespace before hashing, plus a per-run content fingerprint as a second guard on the URN-less path.
3. **Concurrency gate** — a per-user Redis single-flight lock (`rate_limit.acquire_run_lock/release_run_lock`) around `automate_commenting`, so the pre-post trigger, golden-hour beat, and self-requeue can't double-walk the feed. Fails **open** if Redis is unavailable.

## Testing
- 20 new unit tests: text normalization, key stability across see-more re-renders, URN extraction (permalink + card HTML agree on one key), and the lock (acquire/held/fail-open/token-safe release).
- Adjacent dedup/permalink suites still green; **full unit suite: 3231 passed**.

## Notes
- **No schema change** — `commented_posts.UNIQUE(user_id, post_key)` already exists; this makes the *key* it protects stable. Risk: none.
- The 4 already-duplicated posts are being cleaned up operationally (separate from this code fix).

Closes #474

🤖 Generated with [Claude Code](https://claude.com/claude-code)