### PR TITLE
feat(automation): auto-follow-up on replies to our automated comments + harden reply sweep (closes #478)

### DIFF
--- a/compose/local/database/migrations/V20260724174124__add_comment_followups.sql
+++ b/compose/local/database/migrations/V20260724174124__add_comment_followups.sql
@@ -1,0 +1,18 @@
+-- Auto-follow-up on replies to OUR automated comments on others' posts (issue #478).
+-- One row per (user, reply we've handled) so we react/reply to each reply AT MOST ONCE — dedup on
+-- a stable reply key, never on text (the #474 lesson). post_key is the feedurn:// of the post we
+-- commented on; reply_key is a stable id of the specific reply we handled.
+CREATE TABLE IF NOT EXISTS comment_followups (
+    id          INT NOT NULL AUTO_INCREMENT,
+    user_id     INT NOT NULL,
+    post_key    VARCHAR(255) NOT NULL,
+    reply_key   VARCHAR(255) NOT NULL,
+    reacted     TINYINT(1) NOT NULL DEFAULT 0,
+    replied     TINYINT(1) NOT NULL DEFAULT 0,
+    created_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_comment_followups_user_reply (user_id, reply_key),
+    KEY idx_comment_followups_user_created (user_id, created_at),
+    CONSTRAINT comment_followups_ibfk_1 FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -107,6 +107,12 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_daily_engagement',
             'schedule': crontab(hour='13', minute='0')  # Daily peak-hour feed commenting (~9am ET), on top of pre-post
         },
+        'dispatch-comment-followups': {
+            'task': 'cqc_lem.app.run_scheduler.dispatch_comment_followups',
+            # Every 6h; a per-user 12h Redis interval gates it to ~twice a day. React + answer
+            # question-replies on our automated comments (issue #478).
+            'schedule': crontab(minute='0', hour='*/6')
+        },
         'generate-newsletter-drafts': {
             'task': 'cqc_lem.app.run_scheduler.auto_generate_newsletter_drafts',
             'schedule': crontab(hour='10', minute='0')  # Daily: top up each user's newsletter draft queue for review

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2248,6 +2248,12 @@ def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str,
         log_warning("Follow-up: no profile slug — skipping to avoid mis-scoping", user_id=user_id,
                     action_type="reply")
         return result
+    # A very long post pushes comments far below the fold; a TALL viewport is what actually makes
+    # them lazy-render (scrolling alone on the default 1080-tall window did not). Validated live.
+    try:
+        driver.set_window_size(1400, 3400)
+    except Exception:
+        pass
     if driver.current_url.split("?")[0].rstrip("/") != post_url.split("?")[0].rstrip("/"):
         driver.get(post_url)
         time.sleep(random.uniform(2.5, 4))

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -17,7 +17,8 @@ from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.utilities.ai.content_framework import select_blueprint
 from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_refinement, summarize_recent_activity, \
     ai_check_message_history, post_is_relevant, generate_newsletter_edition, generate_group_post, \
-    generate_thread_reply, generate_seed_comment, choose_post_reaction, get_or_create_profile_synthesis, \
+    generate_thread_reply, generate_comment_reply_followup, generate_seed_comment, choose_post_reaction, \
+    get_or_create_profile_synthesis, \
     synthesize_profile
 from cqc_lem.utilities.ai.content_alignment import humanize_text, split_link_for_first_comment, \
     append_link_to_comment
@@ -2151,7 +2152,7 @@ def _react_to_comment_inline(driver, wait, comment_el, user_id: int = None) -> b
             ActionChains(driver).move_to_element(comment_el).pause(0.7).perform()  # reveal the bar
             time.sleep(random.uniform(0.5, 1.0))
         except Exception:
-            pass
+            pass  # hover is best-effort; a headless/again-stale element still gets the click below
         btns = comment_el.find_elements(
             By.CSS_SELECTOR,
             "button[aria-label^='React '], button[aria-label='Like'], "
@@ -2198,7 +2199,7 @@ def _reply_under_comment_inline(driver, wait, comment_el, reply_text: str, user_
         try:
             ActionChains(driver).move_to_element(comment_el).pause(0.5).perform()  # reveal action bar
         except Exception:
-            pass
+            pass  # hover is best-effort; the Reply button lookup below still runs
         rbtns = comment_el.find_elements(By.CSS_SELECTOR, "button[aria-label='Reply']")
         if not rbtns:
             log_warning("Reply-under-comment: no Reply button found", action_type="reply", user_id=user_id)
@@ -2253,7 +2254,7 @@ def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str,
     try:
         driver.set_window_size(1400, 3400)
     except Exception:
-        pass
+        pass  # some drivers reject resize; scrolling below is the fallback
     if driver.current_url.split("?")[0].rstrip("/") != post_url.split("?")[0].rstrip("/"):
         driver.get(post_url)
         time.sleep(random.uniform(2.5, 4))
@@ -2321,8 +2322,9 @@ def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str,
                            result=LogResultType.SUCCESS, post_url=post_url,
                            message="Reacted to reply on our comment")
         if not did_reply and replies_remaining > 0 and _reply_is_question(reply_text):
-            response = generate_thread_reply(reply_text, reply_text, my_profile, prefs=prefs,
-                                             profile_synthesis=profile_synthesis)
+            # We are a GUEST replying in someone else's thread — not the post author (issue #478).
+            response = generate_comment_reply_followup(reply_text, my_profile, prefs=prefs,
+                                                       profile_synthesis=profile_synthesis)
             if response and _reply_under_comment_inline(driver, wait, cont, response, user_id=user_id):
                 result["replied"] += 1
                 replies_remaining -= 1
@@ -2339,6 +2341,12 @@ def sweep_comment_followups(self, user_id: int):
     """Revisit posts we automated a comment on in the last few days and follow up on replies to our
     comment: react to each reply, and answer question-replies (issue #478). Only touches OUR
     automated comments (the commented_posts ledger). QueueOnce + single-flight lock + 429-safe."""
+    return _run_comment_followups_sweep(user_id)
+
+
+def _run_comment_followups_sweep(user_id: int) -> str:
+    """Body of sweep_comment_followups, extracted so it is unit-testable without the QueueOnce/Redis
+    task wrapper."""
     posts = get_recent_navigable_commented_posts(user_id, days=_FOLLOWUP_WINDOW_DAYS)
     if not posts:
         return "No recent navigable commented posts to follow up on"
@@ -2386,6 +2394,11 @@ def process_comment_followups_for_url(self, user_id: int, post_url: str):
     """Single-post entrypoint for the follow-up feature — run it against ONE post URL (manual/API/
     verification), independent of the ledger. Reacts to replies on our comment and answers
     questions, same as the sweep (issue #478)."""
+    return _run_single_post_followup(user_id, post_url)
+
+
+def _run_single_post_followup(user_id: int, post_url: str) -> str:
+    """Body of process_comment_followups_for_url, extracted for unit testing (no QueueOnce/Redis)."""
     key = None
     m = re.search(r"urn:li:(?:activity|ugcPost|share):\d+", post_url or "")
     if m:
@@ -2453,6 +2466,11 @@ def reconcile_recent_comment_urns(self, user_id: int, days: int = _FOLLOWUP_WIND
     """Backfill: recover navigable URNs for recent 'feedpost://' ledger rows via the user's own
     recent-activity/comments page, so pre-#474 comments become follow-up-able. Matches each activity
     comment to a ledger row by our comment text, then upgrades the key to feedurn:// (issue #478)."""
+    return _run_reconcile_comment_urns(user_id, days)
+
+
+def _run_reconcile_comment_urns(user_id: int, days: int = _FOLLOWUP_WINDOW_DAYS) -> str:
+    """Body of reconcile_recent_comment_urns, extracted for unit testing (no QueueOnce/Redis)."""
     stale = [r for r in get_recent_commented_rows_with_text(user_id, days=days)
              if str(r.get("post_key", "")).startswith("feedpost://")]
     if not stale:

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2141,12 +2141,15 @@ def _comment_container(driver, textbox):
 
 
 def _react_to_comment_inline(driver, wait, comment_el, user_id: int = None) -> bool:
-    """Like a comment/reply (best-effort, non-fatal). The like button's aria-label starts 'React '
-    (e.g. 'React Like'); skip if already reacted (aria-pressed)."""
+    """Like a comment/reply (best-effort, non-fatal). On this SDUI the react control's aria-label is
+    'Open reactions menu' (a single click applies the default Like); older markup used 'React Like'.
+    Skips if already reacted (aria-pressed). If a click opens the reaction flyout instead of liking,
+    picks the visible 'Like' option."""
     try:
         btns = comment_el.find_elements(
             By.CSS_SELECTOR,
-            "button[aria-label^='React '], button[aria-label='Like'], button[aria-label*='Like']")
+            "button[aria-label='Open reactions menu'], button[aria-label^='React '], "
+            "button[aria-label='Like'], button[aria-label*='Like']")
         for b in btns:
             if (b.get_attribute("aria-pressed") or "").lower() == "true":
                 return False  # already liked
@@ -2154,8 +2157,16 @@ def _react_to_comment_inline(driver, wait, comment_el, user_id: int = None) -> b
             time.sleep(random.uniform(0.6, 1.4))
             b.click()
             time.sleep(random.uniform(1, 2))
+            # If the reaction flyout opened instead of applying Like, click the visible Like option.
+            if (b.get_attribute("aria-pressed") or "").lower() != "true":
+                for lk in driver.find_elements(
+                        By.CSS_SELECTOR, "button[aria-label='Like'], button[aria-label^='React Like']"):
+                    try:
+                        if lk.is_displayed():
+                            lk.click(); time.sleep(random.uniform(0.8, 1.4)); break
+                    except Exception:
+                        continue
             return True
-        # Log what IS present so a live run surfaces the real label if this misses.
         labels = [b.get_attribute("aria-label") for b in comment_el.find_elements(By.CSS_SELECTOR, "button")]
         log_warning(f"No like button matched on reply; buttons={[l for l in labels if l][:8]}",
                     action_type="engaged", user_id=user_id)

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2188,6 +2188,54 @@ def _react_to_comment_inline(driver, wait, comment_el, user_id: int = None) -> b
         return False
 
 
+def _reply_under_comment_inline(driver, wait, comment_el, reply_text: str, user_id: int = None) -> bool:
+    """Reply UNDER a specific comment — NOT as a new top-level comment. The bug: clicking a comment's
+    Reply then taking the first page-wide role=textbox grabbed the post's main 'Add a comment' box, so
+    the reply posted as a standalone comment. Fix: after opening the reply box, type into the composer
+    NEAREST the comment (the inline reply box opens right below it), never the far-away main box."""
+    try:
+        driver.execute_script("arguments[0].scrollIntoView({block:'center'});", comment_el)
+        try:
+            ActionChains(driver).move_to_element(comment_el).pause(0.5).perform()  # reveal action bar
+        except Exception:
+            pass
+        rbtns = comment_el.find_elements(By.CSS_SELECTOR, "button[aria-label='Reply']")
+        if not rbtns:
+            log_warning("Reply-under-comment: no Reply button found", action_type="reply", user_id=user_id)
+            return False
+        try:
+            ActionChains(driver).move_to_element(rbtns[0]).pause(0.2).click(rbtns[0]).perform()
+        except Exception:
+            driver.execute_script("arguments[0].click();", rbtns[0])
+        time.sleep(random.uniform(1.5, 2.8))
+        # Pick the VISIBLE composer nearest the comment (the reply box that just opened below it);
+        # heavily penalise any composer above the comment (that's the main top comment box).
+        composer = driver.execute_script(
+            "const a=arguments[0].getBoundingClientRect();"
+            "const boxes=[...document.querySelectorAll(\"div[role='textbox']\")].filter(e=>{"
+            "  const r=e.getBoundingClientRect(); return r.width>0 && r.height>0;});"
+            "let best=null,bd=1e12;"
+            "for(const e of boxes){const r=e.getBoundingClientRect();"
+            "  let d=Math.abs(r.top-a.bottom)+(r.top<a.top?1e6:0);"
+            "  if(d<bd){bd=d;best=e;}} return best;", comment_el)
+        if composer is None:
+            log_warning("Reply-under-comment: no composer near the comment", action_type="reply", user_id=user_id)
+            return False
+        reply_text = _strip_non_bmp(reply_text)
+        if not reply_text.strip():
+            return False
+        composer.click()
+        composer.send_keys(reply_text)
+        time.sleep(random.uniform(1, 2))
+        if not driver.execute_script(_SUBMIT_NEAR_COMPOSER_JS, composer):
+            composer.send_keys(Keys.CONTROL, Keys.RETURN)  # fallback
+        time.sleep(random.uniform(3, 5))
+        return _composer_submitted(driver, composer, reply_text)
+    except Exception as e:
+        log_warning("Reply-under-comment failed", exc=e, action_type="reply", user_id=user_id)
+        return False
+
+
 def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str, post_key: str,
                                       my_profile, profile_synthesis: str, prefs: dict,
                                       replies_remaining: int) -> dict:
@@ -2269,7 +2317,7 @@ def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str,
         if not did_reply and replies_remaining > 0 and _reply_is_question(reply_text):
             response = generate_thread_reply(reply_text, reply_text, my_profile, prefs=prefs,
                                              profile_synthesis=profile_synthesis)
-            if response and _reply_to_comment_inline(driver, wait, cont, response, user_id=user_id):
+            if response and _reply_under_comment_inline(driver, wait, cont, response, user_id=user_id):
                 result["replied"] += 1
                 replies_remaining -= 1
                 record_comment_followup(user_id, post_key, reply_key, reacted=did_react, replied=True)

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2103,12 +2103,50 @@ def _followup_reply_key(post_key: str, replier_href: str, reply_text: str) -> st
     return f"{post_key}#reply:{slug}:{digest}"
 
 
+# SDUI comment thread (validated live 2026-07-24 on a moderated group post, issue #478):
+#   * comments render as [data-testid='expandable-text-box'] INSIDE [data-testid*='commentList']
+#     — but ONLY once scrolled into view (a long post pushes them far below the fold);
+#   * a comment's author is the header /in/ link that is NOT inside the text box (an @mention in a
+#     reply body is also an /in/ link — that was the false "mine" match);
+#   * replies are nested inside their parent comment's container (DOM containment);
+#   * the like control is a button whose aria-label starts "React " (e.g. "React Like"); the reply
+#     control is aria-label="Reply". "…more" truncates long replies until expanded.
+_COMMENTLIST_TEXTBOX = "[data-testid*='commentList'] [data-testid='expandable-text-box']"
+
+
+def _comment_header_author(driver, container) -> str:
+    """A comment's author profile href from its HEADER link — never an @mention inside the body
+    text box (that false match flagged a reply that mentioned us as 'ours')."""
+    try:
+        return driver.execute_script(
+            "const c=arguments[0];"
+            "for(const a of c.querySelectorAll(\"a[href*='/in/']\")){"
+            "  if(!a.closest(\"[data-testid='expandable-text-box']\")) return (a.href||'').split('?')[0];"
+            "}return '';", container) or ""
+    except Exception:
+        return ""
+
+
+def _comment_container(driver, textbox):
+    """Smallest ancestor of a comment text box that carries a HEADER author link and is not the
+    post wrapper (which uniquely has the GIF/Repost/Emoji composer buttons)."""
+    try:
+        return driver.execute_script(
+            "let el=arguments[0],d=0;while(el&&d<10){"
+            " const hdr=[...el.querySelectorAll(\"a[href*='/in/']\")].some(a=>!a.closest(\"[data-testid='expandable-text-box']\"));"
+            " const post=[...el.querySelectorAll('button')].some(b=>/GIF|Repost|Emoji Picker/.test(b.getAttribute('aria-label')||''));"
+            " if(hdr&&!post) return el; el=el.parentElement;d++;}return null;", textbox)
+    except Exception:
+        return None
+
+
 def _react_to_comment_inline(driver, wait, comment_el, user_id: int = None) -> bool:
-    """Like a specific comment/reply element (best-effort, non-fatal). Skips if already reacted."""
+    """Like a comment/reply (best-effort, non-fatal). The like button's aria-label starts 'React '
+    (e.g. 'React Like'); skip if already reacted (aria-pressed)."""
     try:
         btns = comment_el.find_elements(
             By.CSS_SELECTOR,
-            "button[aria-label^='React Like'], button[aria-label='Like'], button[aria-label*='Like']")
+            "button[aria-label^='React '], button[aria-label='Like'], button[aria-label*='Like']")
         for b in btns:
             if (b.get_attribute("aria-pressed") or "").lower() == "true":
                 return False  # already liked
@@ -2117,59 +2155,21 @@ def _react_to_comment_inline(driver, wait, comment_el, user_id: int = None) -> b
             b.click()
             time.sleep(random.uniform(1, 2))
             return True
+        # Log what IS present so a live run surfaces the real label if this misses.
+        labels = [b.get_attribute("aria-label") for b in comment_el.find_elements(By.CSS_SELECTOR, "button")]
+        log_warning(f"No like button matched on reply; buttons={[l for l in labels if l][:8]}",
+                    action_type="engaged", user_id=user_id)
         return False
     except Exception as e:
         log_warning("Could not react to comment reply", exc=e, action_type="engaged", user_id=user_id)
         return False
 
 
-def _our_comment_elements(driver, comments, our_slug: str) -> list:
-    """From the thread's comment items, the ones WE authored (our profile slug in an author link)."""
-    ours = []
-    for c in comments:
-        try:
-            if c.find_elements(By.CSS_SELECTOR, f"a[href*='/in/{our_slug}']"):
-                ours.append(c)
-        except Exception:
-            continue
-    return ours
-
-
-def _replies_under_comment(driver, our_comment_el, our_slug: str) -> list:
-    """(reply_item, replier_href) for each reply nested under our comment that is NOT ours. Walks up
-    from each non-self /in/ author link inside our comment's subtree to the reply's text container."""
-    out, seen = [], set()
-    try:
-        links = our_comment_el.find_elements(By.CSS_SELECTOR, "a[href*='/in/']")
-    except Exception:
-        return out
-    for a in links:
-        try:
-            href = (a.get_attribute("href") or "").split("?")[0]
-        except Exception:
-            continue
-        if not href or f"/in/{our_slug}" in href:
-            continue  # our own author link (the parent comment)
-        item = driver.execute_script(
-            "let el=arguments[0],d=0;while(el&&d<6){"
-            "if(el.querySelector&&el.querySelector(\"[data-testid='expandable-text-box']\"))return el;"
-            "el=el.parentElement;d++;}return null;", a)
-        if item is None:
-            continue
-        marker = href + "|" + (item.get_attribute("data-id") or item.id or "")
-        if marker in seen:
-            continue
-        seen.add(marker)
-        out.append((item, href))
-    return out
-
-
 def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str, post_key: str,
                                       my_profile, profile_synthesis: str, prefs: dict,
                                       replies_remaining: int) -> dict:
     """Revisit ONE post we commented on: react to replies to our comment, and answer question-replies.
-    Returns {'reacted': n, 'replied': n}. Best-effort/non-fatal; DOM targeting is validated on a
-    supervised first run (issue #478)."""
+    Returns {'reacted': n, 'replied': n}. Best-effort/non-fatal (issue #478)."""
     result = {"reacted": 0, "replied": 0}
     path = urlparse(str(my_profile.profile_url)).path
     our_slug = path.split("/")[2] if len(path.split("/")) > 2 else None
@@ -2180,51 +2180,72 @@ def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str,
     if driver.current_url.split("?")[0].rstrip("/") != post_url.split("?")[0].rstrip("/"):
         driver.get(post_url)
         time.sleep(random.uniform(2.5, 4))
-    # Expand hidden replies so ours (and their replies) are in the DOM.
-    for _ in range(5):
-        if not click_first(driver, wait,
-                           [(By.XPATH, "//button[contains(@aria-label,'more repl') or "
-                                       "contains(normalize-space(),'more repl') or "
-                                       "contains(normalize-space(),'Load more')]")],
-                           "Expand replies", required=False):
+    # A long post pushes comments far below the fold; scroll thoroughly so they lazy-render.
+    for _ in range(10):
+        driver.execute_script("window.scrollBy(0, 1000);")
+        time.sleep(random.uniform(0.9, 1.4))
+        cl = driver.find_elements(By.CSS_SELECTOR, "[data-testid*='commentList']")
+        if cl:
+            driver.execute_script("arguments[0].scrollIntoView({block:'center'});", cl[0])
+    # Expand truncated replies + hidden reply threads.
+    for _ in range(6):
+        exp = [b for b in driver.find_elements(By.CSS_SELECTOR, "[data-testid*='commentList'] button")
+               if re.search(r'\bmore\b|repl', (b.text or ''), re.I)]
+        if not exp:
             break
-        time.sleep(random.uniform(1.5, 2.5))
+        try:
+            driver.execute_script("arguments[0].click();", exp[0]); time.sleep(random.uniform(1.2, 2))
+        except Exception:
+            break
 
-    comments = _comment_items_from_thread(driver)
-    for our_comment in _our_comment_elements(driver, comments, our_slug):
-        for reply_item, replier_href in _replies_under_comment(driver, our_comment, our_slug):
-            if result["reacted"] >= _MAX_FOLLOWUP_REACTS_PER_RUN:
-                return result
-            try:
-                tb = reply_item.find_elements(By.CSS_SELECTOR, "[data-testid='expandable-text-box']")
-                reply_text = ((tb[0].text if tb else reply_item.text) or "").strip()
-            except Exception:
-                continue
-            if not reply_text:
-                continue
-            reply_key = _followup_reply_key(post_key, replier_href, reply_text)
-            state = get_comment_followup(user_id, reply_key) or {}
-            did_react = bool(state.get("reacted"))
-            did_reply = bool(state.get("replied"))
-            if not did_react:
-                if _react_to_comment_inline(driver, wait, reply_item, user_id=user_id):
-                    result["reacted"] += 1
-                    did_react = True
-                    record_comment_followup(user_id, post_key, reply_key, reacted=True)
-                    insert_new_log(user_id=user_id, action_type=LogActionType.ENGAGED,
-                                   result=LogResultType.SUCCESS, post_url=post_url,
-                                   message="Reacted to reply on our comment")
-            # Auto-reply only to questions, and only while under the daily reply cap.
-            if not did_reply and replies_remaining > 0 and _reply_is_question(reply_text):
-                response = generate_thread_reply(reply_text, reply_text, my_profile, prefs=prefs,
-                                                 profile_synthesis=profile_synthesis)
-                if response and _reply_to_comment_inline(driver, wait, reply_item, response, user_id=user_id):
-                    result["replied"] += 1
-                    replies_remaining -= 1
-                    record_comment_followup(user_id, post_key, reply_key, reacted=did_react, replied=True)
-                    insert_new_log(user_id=user_id, action_type=LogActionType.REPLY,
-                                   result=LogResultType.SUCCESS, post_url=post_url, message=response)
-                    time.sleep(random.uniform(5, 12))
+    boxes = driver.find_elements(By.CSS_SELECTOR, _COMMENTLIST_TEXTBOX)
+    # Map each comment text box -> (container, author_href).
+    items = []
+    for tb in boxes:
+        cont = _comment_container(driver, tb)
+        if cont is None:
+            continue
+        items.append((tb, cont, _comment_header_author(driver, cont)))
+    our_conts = [c for (_tb, c, a) in items if f"/in/{our_slug}" in a]
+    log_info(f"Follow-up: {len(boxes)} comment box(es), {len(our_conts)} ours, on {post_url}",
+             user_id=user_id, task_name="sweep_comment_followups")
+
+    for tb, cont, author in items:
+        if result["reacted"] >= _MAX_FOLLOWUP_REACTS_PER_RUN:
+            break
+        if not author or f"/in/{our_slug}" in author:
+            continue  # skip our own comments/replies
+        # Only replies to OUR comment: the reply's container is nested inside one of ours.
+        if not any(driver.execute_script("return arguments[0].contains(arguments[1]);", oc, cont)
+                   for oc in our_conts):
+            continue
+        try:
+            reply_text = (tb.text or "").strip()
+        except Exception:
+            continue
+        if not reply_text:
+            continue
+        reply_key = _followup_reply_key(post_key, author, reply_text)
+        state = get_comment_followup(user_id, reply_key) or {}
+        did_react = bool(state.get("reacted"))
+        did_reply = bool(state.get("replied"))
+        if not did_react and _react_to_comment_inline(driver, wait, cont, user_id=user_id):
+            result["reacted"] += 1
+            did_react = True
+            record_comment_followup(user_id, post_key, reply_key, reacted=True)
+            insert_new_log(user_id=user_id, action_type=LogActionType.ENGAGED,
+                           result=LogResultType.SUCCESS, post_url=post_url,
+                           message="Reacted to reply on our comment")
+        if not did_reply and replies_remaining > 0 and _reply_is_question(reply_text):
+            response = generate_thread_reply(reply_text, reply_text, my_profile, prefs=prefs,
+                                             profile_synthesis=profile_synthesis)
+            if response and _reply_to_comment_inline(driver, wait, cont, response, user_id=user_id):
+                result["replied"] += 1
+                replies_remaining -= 1
+                record_comment_followup(user_id, post_key, reply_key, reacted=did_react, replied=True)
+                insert_new_log(user_id=user_id, action_type=LogActionType.REPLY,
+                               result=LogResultType.SUCCESS, post_url=post_url, message=response)
+                time.sleep(random.uniform(5, 12))
     return result
 
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -31,6 +31,8 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     get_lead_magnet_settings, has_received_lead_magnet, record_lead_magnet_sent, \
     LogResultType, has_user_commented_on_post_url, get_post_url_from_log_for_user, get_post_message_from_log_for_user, \
     claim_post_for_comment, mark_post_commented, mark_post_reacted, release_post_claim, has_commented_post, \
+    get_recent_navigable_commented_posts, get_comment_followup, record_comment_followup, \
+    count_followup_replies_today, update_commented_post_key, get_recent_commented_rows_with_text, \
     has_engaged_url_with_x_days, get_post_content, get_post_video_url, update_db_post_status, PostStatus, PostType, \
     update_db_post_content, update_db_post_first_comment_link, get_post_first_comment_link, \
     get_dm_history_for_profile, get_post_status, get_user_blog_url, get_post_type, get_carousel_slides, \
@@ -2017,14 +2019,25 @@ def sweep_reply_comments(self, user_id: int, sweep_slot: int = 0):
     post_ids = get_recent_posted_post_ids(user_id, days=days)
     if not post_ids:
         return "No recent posts to sweep"
+    # Single-flight: QueueOnce uses unlock_before_run (frees the lock at task START to avoid a
+    # crashed task holding it forever), which leaves a narrow window where the email-event trigger
+    # and the scheduled dispatcher could start two concurrent sweeps and double-reply. This lock
+    # closes that window; it fails OPEN if Redis is down. (Belt-and-suspenders with #474.)
+    lock_name = f"sweep_reply_comments:{user_id}"
+    lock_token = acquire_run_lock(lock_name, ttl_seconds=1800)
+    if lock_token is None:
+        myprint(f"Another reply sweep is already running for user {user_id} — skipping.")
+        return "Skipped — another reply sweep in progress"
     try:
         driver, wait, _user_email, my_profile = get_current_profile(user_id=user_id, session_name="Reply Sweep")
     except LinkedInRateLimited as e:
         log_warning("Reply sweep skipped — LinkedIn rate-limited", exc=e, user_id=user_id,
                     task_name="sweep_reply_comments")
+        release_run_lock(lock_name, lock_token)
         return "Skipped — rate limited"
     except Exception as e:
         log_error("Error starting reply sweep", exc=e, user_id=user_id, task_name="sweep_reply_comments")
+        release_run_lock(lock_name, lock_token)
         return f"Failed to start reply sweep: {e}"
     try:
         profile_synthesis = get_or_create_profile_synthesis(user_id, my_profile)
@@ -2039,6 +2052,333 @@ def sweep_reply_comments(self, user_id: int, sweep_slot: int = 0):
         return f"Swept replies on {swept}/{len(post_ids)} recent posts"
     finally:
         quit_gracefully(driver)
+        release_run_lock(lock_name, lock_token)
+
+
+# --- follow-up on replies to OUR automated comments on OTHERS' posts (issue #478) --------------
+# When someone (usually the author) replies to a comment WE automated, we react to their reply and,
+# if it asks a question, post a voice-aligned answer. Scoped to OUR automated comments ONLY: the
+# posts come from the commented_posts ledger (which only holds comments comment_on_feed_inline made
+# — never anything the user typed by hand), so a manual comment is structurally out of scope.
+_FOLLOWUP_WINDOW_DAYS = 3           # only revisit posts we commented on this recently
+_MAX_FOLLOWUP_REACTS_PER_RUN = 25   # volume backstop per post-sweep
+_MAX_FOLLOWUP_REPLIES_PER_DAY = 10  # cap on auto-replies/day (a real DM-like touch)
+
+
+def _post_url_from_key(key: str) -> "str | None":
+    """A navigable LinkedIn post URL from a ledger key. feedurn://urn:li:activity:<id> ->
+    https://www.linkedin.com/feed/update/urn:li:activity:<id>/. Returns None for the legacy
+    feedpost:// hash keys (not navigable) or anything unrecognized."""
+    if not key:
+        return None
+    key = str(key)
+    if key.startswith("feedurn://"):
+        urn = key[len("feedurn://"):]
+        return f"https://www.linkedin.com/feed/update/{urn}/" if urn.startswith("urn:li:") else None
+    if key.startswith("http"):
+        return key
+    return None
+
+
+def _reply_is_question(text: str) -> bool:
+    """True if a reply is asking us something (worth an auto-reply). A literal '?' is the primary
+    signal; strip URLs first so a link's query string never counts. Reactions are handled
+    separately — this only gates whether we also post a reply."""
+    if not text:
+        return False
+    stripped = re.sub(r"https?://\S+", " ", text)
+    return "?" in stripped
+
+
+def _followup_reply_key(post_key: str, replier_href: str, reply_text: str) -> str:
+    """Stable dedup id for a specific reply so we react/reply to it AT MOST ONCE (the #474 lesson —
+    key on identity, not raw text). Anchored to the post, the replier's profile slug, and a
+    NORMALIZED hash of the reply text."""
+    slug = ""
+    if replier_href:
+        m = re.search(r"/in/([^/?#]+)", replier_href)
+        slug = (m.group(1).lower() if m else "")
+    norm = _normalize_post_text(reply_text)[:200]
+    digest = hashlib.sha1(f"{slug}|{norm}".encode("utf-8", "ignore")).hexdigest()[:16]
+    return f"{post_key}#reply:{slug}:{digest}"
+
+
+def _react_to_comment_inline(driver, wait, comment_el, user_id: int = None) -> bool:
+    """Like a specific comment/reply element (best-effort, non-fatal). Skips if already reacted."""
+    try:
+        btns = comment_el.find_elements(
+            By.CSS_SELECTOR,
+            "button[aria-label^='React Like'], button[aria-label='Like'], button[aria-label*='Like']")
+        for b in btns:
+            if (b.get_attribute("aria-pressed") or "").lower() == "true":
+                return False  # already liked
+            driver.execute_script("arguments[0].scrollIntoView({block:'center'});", b)
+            time.sleep(random.uniform(0.6, 1.4))
+            b.click()
+            time.sleep(random.uniform(1, 2))
+            return True
+        return False
+    except Exception as e:
+        log_warning("Could not react to comment reply", exc=e, action_type="engaged", user_id=user_id)
+        return False
+
+
+def _our_comment_elements(driver, comments, our_slug: str) -> list:
+    """From the thread's comment items, the ones WE authored (our profile slug in an author link)."""
+    ours = []
+    for c in comments:
+        try:
+            if c.find_elements(By.CSS_SELECTOR, f"a[href*='/in/{our_slug}']"):
+                ours.append(c)
+        except Exception:
+            continue
+    return ours
+
+
+def _replies_under_comment(driver, our_comment_el, our_slug: str) -> list:
+    """(reply_item, replier_href) for each reply nested under our comment that is NOT ours. Walks up
+    from each non-self /in/ author link inside our comment's subtree to the reply's text container."""
+    out, seen = [], set()
+    try:
+        links = our_comment_el.find_elements(By.CSS_SELECTOR, "a[href*='/in/']")
+    except Exception:
+        return out
+    for a in links:
+        try:
+            href = (a.get_attribute("href") or "").split("?")[0]
+        except Exception:
+            continue
+        if not href or f"/in/{our_slug}" in href:
+            continue  # our own author link (the parent comment)
+        item = driver.execute_script(
+            "let el=arguments[0],d=0;while(el&&d<6){"
+            "if(el.querySelector&&el.querySelector(\"[data-testid='expandable-text-box']\"))return el;"
+            "el=el.parentElement;d++;}return null;", a)
+        if item is None:
+            continue
+        marker = href + "|" + (item.get_attribute("data-id") or item.id or "")
+        if marker in seen:
+            continue
+        seen.add(marker)
+        out.append((item, href))
+    return out
+
+
+def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str, post_key: str,
+                                      my_profile, profile_synthesis: str, prefs: dict,
+                                      replies_remaining: int) -> dict:
+    """Revisit ONE post we commented on: react to replies to our comment, and answer question-replies.
+    Returns {'reacted': n, 'replied': n}. Best-effort/non-fatal; DOM targeting is validated on a
+    supervised first run (issue #478)."""
+    result = {"reacted": 0, "replied": 0}
+    path = urlparse(str(my_profile.profile_url)).path
+    our_slug = path.split("/")[2] if len(path.split("/")) > 2 else None
+    if not our_slug:
+        log_warning("Follow-up: no profile slug — skipping to avoid mis-scoping", user_id=user_id,
+                    action_type="reply")
+        return result
+    if driver.current_url.split("?")[0].rstrip("/") != post_url.split("?")[0].rstrip("/"):
+        driver.get(post_url)
+        time.sleep(random.uniform(2.5, 4))
+    # Expand hidden replies so ours (and their replies) are in the DOM.
+    for _ in range(5):
+        if not click_first(driver, wait,
+                           [(By.XPATH, "//button[contains(@aria-label,'more repl') or "
+                                       "contains(normalize-space(),'more repl') or "
+                                       "contains(normalize-space(),'Load more')]")],
+                           "Expand replies", required=False):
+            break
+        time.sleep(random.uniform(1.5, 2.5))
+
+    comments = _comment_items_from_thread(driver)
+    for our_comment in _our_comment_elements(driver, comments, our_slug):
+        for reply_item, replier_href in _replies_under_comment(driver, our_comment, our_slug):
+            if result["reacted"] >= _MAX_FOLLOWUP_REACTS_PER_RUN:
+                return result
+            try:
+                tb = reply_item.find_elements(By.CSS_SELECTOR, "[data-testid='expandable-text-box']")
+                reply_text = ((tb[0].text if tb else reply_item.text) or "").strip()
+            except Exception:
+                continue
+            if not reply_text:
+                continue
+            reply_key = _followup_reply_key(post_key, replier_href, reply_text)
+            state = get_comment_followup(user_id, reply_key) or {}
+            did_react = bool(state.get("reacted"))
+            did_reply = bool(state.get("replied"))
+            if not did_react:
+                if _react_to_comment_inline(driver, wait, reply_item, user_id=user_id):
+                    result["reacted"] += 1
+                    did_react = True
+                    record_comment_followup(user_id, post_key, reply_key, reacted=True)
+                    insert_new_log(user_id=user_id, action_type=LogActionType.ENGAGED,
+                                   result=LogResultType.SUCCESS, post_url=post_url,
+                                   message="Reacted to reply on our comment")
+            # Auto-reply only to questions, and only while under the daily reply cap.
+            if not did_reply and replies_remaining > 0 and _reply_is_question(reply_text):
+                response = generate_thread_reply(reply_text, reply_text, my_profile, prefs=prefs,
+                                                 profile_synthesis=profile_synthesis)
+                if response and _reply_to_comment_inline(driver, wait, reply_item, response, user_id=user_id):
+                    result["replied"] += 1
+                    replies_remaining -= 1
+                    record_comment_followup(user_id, post_key, reply_key, reacted=did_react, replied=True)
+                    insert_new_log(user_id=user_id, action_type=LogActionType.REPLY,
+                                   result=LogResultType.SUCCESS, post_url=post_url, message=response)
+                    time.sleep(random.uniform(5, 12))
+    return result
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='se_engage')
+def sweep_comment_followups(self, user_id: int):
+    """Revisit posts we automated a comment on in the last few days and follow up on replies to our
+    comment: react to each reply, and answer question-replies (issue #478). Only touches OUR
+    automated comments (the commented_posts ledger). QueueOnce + single-flight lock + 429-safe."""
+    posts = get_recent_navigable_commented_posts(user_id, days=_FOLLOWUP_WINDOW_DAYS)
+    if not posts:
+        return "No recent navigable commented posts to follow up on"
+    lock_name = f"sweep_comment_followups:{user_id}"
+    lock_token = acquire_run_lock(lock_name, ttl_seconds=1800)
+    if lock_token is None:
+        return "Skipped — another follow-up sweep in progress"
+    prefs = get_engagement_preferences(user_id)
+    replies_remaining = max(0, _MAX_FOLLOWUP_REPLIES_PER_DAY - count_followup_replies_today(user_id))
+    try:
+        driver, wait, _email, my_profile = get_current_profile(user_id=user_id, session_name="Comment Follow-ups")
+    except LinkedInRateLimited as e:
+        log_warning("Follow-up sweep skipped — rate-limited", exc=e, user_id=user_id,
+                    task_name="sweep_comment_followups")
+        release_run_lock(lock_name, lock_token)
+        return "Skipped — rate limited"
+    except Exception as e:
+        log_error("Error starting follow-up sweep", exc=e, user_id=user_id, task_name="sweep_comment_followups")
+        release_run_lock(lock_name, lock_token)
+        return f"Failed to start follow-up sweep: {e}"
+    try:
+        synthesis = get_or_create_profile_synthesis(user_id, my_profile)
+        reacted = replied = 0
+        for row in posts:
+            key = row.get("post_key")
+            url = _post_url_from_key(key)
+            if not url:
+                continue
+            try:
+                r = _followup_on_post_comment_replies(driver, wait, user_id, url, key, my_profile,
+                                                      synthesis, prefs, replies_remaining)
+                reacted += r["reacted"]; replied += r["replied"]; replies_remaining -= r["replied"]
+            except Exception as e:
+                log_warning("Follow-up: post failed", exc=e, user_id=user_id,
+                            task_name="sweep_comment_followups")
+        return f"Follow-ups: reacted {reacted}, replied {replied} across {len(posts)} post(s)"
+    finally:
+        quit_gracefully(driver)
+        release_run_lock(lock_name, lock_token)
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id', 'post_url']},
+                  queue='se_engage')
+def process_comment_followups_for_url(self, user_id: int, post_url: str):
+    """Single-post entrypoint for the follow-up feature — run it against ONE post URL (manual/API/
+    verification), independent of the ledger. Reacts to replies on our comment and answers
+    questions, same as the sweep (issue #478)."""
+    key = None
+    m = re.search(r"urn:li:(?:activity|ugcPost|share):\d+", post_url or "")
+    if m:
+        key = f"feedurn://{m.group(0).lower()}"
+    if not key:
+        return "No activity URN in the given URL"
+    lock_name = f"sweep_comment_followups:{user_id}"
+    lock_token = acquire_run_lock(lock_name, ttl_seconds=1800)
+    if lock_token is None:
+        return "Skipped — another follow-up run in progress"
+    prefs = get_engagement_preferences(user_id)
+    replies_remaining = max(0, _MAX_FOLLOWUP_REPLIES_PER_DAY - count_followup_replies_today(user_id))
+    try:
+        driver, wait, _email, my_profile = get_current_profile(user_id=user_id, session_name="Comment Follow-up (single)")
+    except Exception as e:
+        log_error("Error starting single follow-up", exc=e, user_id=user_id,
+                  task_name="process_comment_followups_for_url")
+        release_run_lock(lock_name, lock_token)
+        return f"Failed: {e}"
+    try:
+        synthesis = get_or_create_profile_synthesis(user_id, my_profile)
+        url = _post_url_from_key(key)
+        r = _followup_on_post_comment_replies(driver, wait, user_id, url, key, my_profile,
+                                              synthesis, prefs, replies_remaining)
+        return f"Follow-up on {url}: reacted {r['reacted']}, replied {r['replied']}"
+    finally:
+        quit_gracefully(driver)
+        release_run_lock(lock_name, lock_token)
+
+
+def _scrape_activity_comment_urns(driver, wait, my_profile) -> dict:
+    """Map {normalized comment text -> post URL} from the user's own recent-activity/comments page.
+    Each activity card holds the post's /feed/update/ permalink plus the comment we left, so we can
+    recover the navigable URN for comments the ledger only has a hash for. Best-effort; validated on
+    a supervised run (issue #478)."""
+    mapping = {}
+    path = urlparse(str(my_profile.profile_url)).path.rstrip("/")
+    if not path:
+        return mapping
+    driver.get(f"https://www.linkedin.com{path}/recent-activity/comments/")
+    time.sleep(random.uniform(3, 5))
+    for _ in range(8):
+        driver.execute_script("window.scrollBy(0, 1400);")
+        time.sleep(random.uniform(1.5, 2.5))
+    for box in driver.find_elements(By.CSS_SELECTOR, _FEED_POST_TEXT_SEL):
+        try:
+            text = (box.text or "").strip()
+            if len(text) < 15:
+                continue
+            card = _card_for_textbox(driver, box) or box
+            url = _post_permalink_from_card(card)
+            if not url:
+                urn = _feed_post_urn_from_card(card)
+                url = f"https://www.linkedin.com/feed/update/{urn}/" if urn else None
+            if url:
+                mapping[_normalize_post_text(text)[:200]] = url
+        except Exception:
+            continue
+    return mapping
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='se_engage')
+def reconcile_recent_comment_urns(self, user_id: int, days: int = _FOLLOWUP_WINDOW_DAYS):
+    """Backfill: recover navigable URNs for recent 'feedpost://' ledger rows via the user's own
+    recent-activity/comments page, so pre-#474 comments become follow-up-able. Matches each activity
+    comment to a ledger row by our comment text, then upgrades the key to feedurn:// (issue #478)."""
+    stale = [r for r in get_recent_commented_rows_with_text(user_id, days=days)
+             if str(r.get("post_key", "")).startswith("feedpost://")]
+    if not stale:
+        return "No stale (feedpost://) commented posts in window"
+    lock_name = f"reconcile_comment_urns:{user_id}"
+    lock_token = acquire_run_lock(lock_name, ttl_seconds=1200)
+    if lock_token is None:
+        return "Skipped — reconcile already running"
+    try:
+        driver, wait, _email, my_profile = get_current_profile(user_id=user_id, session_name="Reconcile Comment URNs")
+    except Exception as e:
+        log_error("Error starting reconcile", exc=e, user_id=user_id, task_name="reconcile_recent_comment_urns")
+        release_run_lock(lock_name, lock_token)
+        return f"Failed: {e}"
+    try:
+        mapping = _scrape_activity_comment_urns(driver, wait, my_profile)  # {our_comment_text_norm: post_url}
+        upgraded = 0
+        for row in stale:
+            old_key = row["post_key"]
+            body = (row.get("comment_text") or "").strip()
+            url = mapping.get(_normalize_post_text(body)[:200]) if body else None
+            m = re.search(r"urn:li:(?:activity|ugcPost|share):\d+", url or "")
+            if not m:
+                continue
+            new_key = f"feedurn://{m.group(0).lower()}"
+            if update_commented_post_key(user_id, old_key, new_key):
+                upgraded += 1
+        return f"Reconciled {upgraded}/{len(stale)} stale commented-post keys"
+    finally:
+        quit_gracefully(driver)
+        release_run_lock(lock_name, lock_token)
 
 
 @shared_task.task(bind=True, base=QueueOnce,

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2141,29 +2141,41 @@ def _comment_container(driver, textbox):
 
 
 def _react_to_comment_inline(driver, wait, comment_el, user_id: int = None) -> bool:
-    """Like a comment/reply (best-effort, non-fatal). On this SDUI the react control's aria-label is
-    'Open reactions menu' (a single click applies the default Like); older markup used 'React Like'.
-    Skips if already reacted (aria-pressed). If a click opens the reaction flyout instead of liking,
-    picks the visible 'Like' option."""
+    """Like a comment/reply (best-effort, non-fatal). The action bar is HOVER-HIDDEN (the react
+    button is zero-size until the comment is hovered), so hover first, then click the react control
+    ('Open reactions menu' on this SDUI; a single click applies the default Like). If the click
+    opens the reaction flyout instead, pick the visible 'Like'. Skips if already reacted."""
     try:
+        driver.execute_script("arguments[0].scrollIntoView({block:'center'});", comment_el)
+        try:
+            ActionChains(driver).move_to_element(comment_el).pause(0.7).perform()  # reveal the bar
+            time.sleep(random.uniform(0.5, 1.0))
+        except Exception:
+            pass
         btns = comment_el.find_elements(
             By.CSS_SELECTOR,
-            "button[aria-label='Open reactions menu'], button[aria-label^='React '], "
-            "button[aria-label='Like'], button[aria-label*='Like']")
+            "button[aria-label^='React '], button[aria-label='Like'], "
+            "button[aria-label='Open reactions menu'], button[aria-label*='Like']")
         for b in btns:
             if (b.get_attribute("aria-pressed") or "").lower() == "true":
                 return False  # already liked
-            driver.execute_script("arguments[0].scrollIntoView({block:'center'});", b)
-            time.sleep(random.uniform(0.6, 1.4))
-            b.click()
+            try:
+                sz = b.size or {}
+                if sz.get("width", 0) > 0 and sz.get("height", 0) > 0:
+                    ActionChains(driver).move_to_element(b).pause(0.3).click(b).perform()
+                else:  # still zero-size after hover — bypass interactability
+                    driver.execute_script("arguments[0].click();", b)
+            except Exception:
+                driver.execute_script("arguments[0].click();", b)
             time.sleep(random.uniform(1, 2))
-            # If the reaction flyout opened instead of applying Like, click the visible Like option.
+            # If a reaction flyout opened rather than applying Like, click the visible Like option.
             if (b.get_attribute("aria-pressed") or "").lower() != "true":
                 for lk in driver.find_elements(
                         By.CSS_SELECTOR, "button[aria-label='Like'], button[aria-label^='React Like']"):
                     try:
-                        if lk.is_displayed():
-                            lk.click(); time.sleep(random.uniform(0.8, 1.4)); break
+                        if lk.is_displayed() and (lk.size or {}).get("width", 0) > 0:
+                            ActionChains(driver).move_to_element(lk).pause(0.2).click(lk).perform()
+                            time.sleep(random.uniform(0.8, 1.4)); break
                     except Exception:
                         continue
             return True

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2226,9 +2226,16 @@ def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str,
             break
         if not author or f"/in/{our_slug}" in author:
             continue  # skip our own comments/replies
-        # Only replies to OUR comment: the reply's container is nested inside one of ours.
-        if not any(driver.execute_script("return arguments[0].contains(arguments[1]);", oc, cont)
-                   for oc in our_conts):
+        # A reply is "to our comment" if its block is nested in our comment's thread OR its body
+        # @mentions us — LinkedIn auto-prepends the @mention of the person being replied to, so a
+        # reply to us reliably carries our /in/ link inside its text box.
+        nested = any(driver.execute_script("return arguments[0].contains(arguments[1]);", oc, cont)
+                     for oc in our_conts)
+        try:
+            mentions_us = bool(tb.find_elements(By.CSS_SELECTOR, f"a[href*='/in/{our_slug}']"))
+        except Exception:
+            mentions_us = False
+        if not (nested or mentions_us):
             continue
         try:
             reply_text = (tb.text or "").strip()

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -9,7 +9,7 @@ from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.app.run_automation import automate_commenting, automate_profile_viewer_engagement, \
     automate_appreciation_dms_for_user, clean_stale_invites, update_stale_profile, post_to_linkedin, \
     automate_invites_to_company_page_for_user, send_scheduled_dm, send_connection_request, \
-    sweep_reply_comments
+    sweep_reply_comments, sweep_comment_followups
 from cqc_lem.utilities.db import (
     get_ready_to_post_posts, get_orphaned_scheduled_posts, update_db_post_status,
     get_active_user_ids, PostStatus, has_linkedin_session, has_scheduled_post_today,
@@ -279,6 +279,36 @@ def dispatch_scheduled_reply_sweeps():
             sweep_reply_comments.apply_async(kwargs={'user_id': user_id})
             dispatched += 1
     return f"Scheduled reply sweeps dispatched for {dispatched}/{len(users)} user(s)"
+
+
+@shared_task.task
+def dispatch_comment_followups():
+    """Beat: revisit posts each user automated a comment on recently and follow up on replies to our
+    comment — react, and answer question-replies (issue #478). One sweep per active user with a
+    LinkedIn session, per-user interval-gated to ~twice a day; sweep_comment_followups is QueueOnce +
+    429-safe so an extra dispatch is harmless."""
+    if _skip_if_throttled("dispatch_comment_followups"):
+        return "Automation throttled"
+    from cqc_lem.utilities.linkedin.rate_limit import _redis_client
+    users = get_active_user_ids()
+    if not users:
+        return "No active users"
+    client = _redis_client()
+    dispatched = 0
+    for user_id in users:
+        if not has_linkedin_session(user_id):
+            continue
+        due = True
+        if client is not None:
+            try:
+                due = bool(client.set(f"linkedin:last_comment_followup:{user_id}", "1",
+                                      nx=True, ex=12 * 60 * 60))  # ~twice a day
+            except Exception:
+                due = True
+        if due:
+            sweep_comment_followups.apply_async(kwargs={'user_id': user_id})
+            dispatched += 1
+    return f"Comment follow-up sweeps dispatched for {dispatched}/{len(users)} user(s)"
 
 
 def _max_dt(*dts):

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -734,6 +734,38 @@ def generate_thread_reply(post_content: str, comment_text: str, profile: "Linked
                           profile_synthesis=profile_synthesis, prefs=prefs)
 
 
+def generate_comment_reply_followup(their_reply: str, profile: "LinkedInProfile",
+                                    our_comment: str = None, post_content: str = None,
+                                    prefs: dict = None, profile_synthesis: str = None) -> "str | None":
+    """Reply to someone who replied to OUR comment on SOMEONE ELSE'S post (issue #478). Unlike
+    generate_thread_reply, we are NOT the post author here — we're a guest in their thread, so the
+    prompt must not speak as if we own the post. Acknowledge their specific point, add one useful
+    thought, optionally a light question. Short, in our own voice."""
+    system_prompt = {
+        "role": "system",
+        "content": """You are replying to someone who responded to YOUR comment on SOMEONE ELSE'S
+        post. You are a helpful guest in their thread — do NOT speak as if you own the post or thank
+        them for posting. Briefly acknowledge their SPECIFIC point, add ONE useful thought, and
+        optionally end with a light, genuine question. Warm, human, in your own voice, 1–3 sentences.
+        No links, no hashtags, no generic 'thanks for sharing'. """ + _NO_SELF_PROMO_GUARDRAIL,
+    }
+    ctx = ""
+    if post_content:
+        ctx += f"The post (NOT mine):\n{post_content}\n\n"
+    if our_comment:
+        ctx += f"My earlier comment:\n{our_comment}\n\n"
+    user_prompt = {"role": "user", "content":
+        f"My voice:\n{_voice_reference(profile, profile_synthesis)}\n\n{ctx}"
+        f"Their reply to me:\n{their_reply}\n{_intention_directive(prefs)}{_style_directive(prefs)}"}
+    response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt],
+                         temperature=round(random.uniform(0.5, 0.7), 2))
+    content = response.choices[0].message.content
+    if content is None:
+        return None
+    return _humanize_text(content.strip(), content_type="comment",
+                          profile_synthesis=profile_synthesis, prefs=prefs)
+
+
 def optimize_post_hook(post_content: str, prefs: dict = None,
                        preserve_cta_keyword: str = None) -> str:
     """Rewrite a generated post so it opens with a scroll-stopping hook within the first ~210

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3564,6 +3564,144 @@ def has_commented_post(user_id: int, post_key: str) -> bool:
         connection.close()
 
 
+def get_recent_navigable_commented_posts(user_id: int, days: int = 3) -> list:
+    """Posts we automated a comment on in the last `days` whose ledger key is a NAVIGABLE URN
+    (feedurn://urn:li:...), newest first. These are the posts the follow-up sweep can revisit to
+    handle replies to our comment (issue #478). Pre-#474 'feedpost://' hash keys aren't navigable
+    and are excluded."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT post_key, created_at FROM commented_posts "
+            "WHERE user_id=%s AND status='commented' AND post_key LIKE 'feedurn://%%' "
+            "AND created_at >= (NOW() - INTERVAL %s DAY) ORDER BY created_at DESC",
+            (user_id, int(days)))
+        return list(cursor.fetchall() or [])
+    except mysql.connector.Error:
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_recent_commented_rows_with_text(user_id: int, days: int = 3) -> list:
+    """Recent commented_posts rows plus the comment text we left (from the most recent matching
+    SUCCESS comment log), for the URN reconcile backfill. Includes legacy 'feedpost://' rows so
+    they can be matched by text and upgraded (issue #478)."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT cp.post_key, cp.created_at, "
+            "  (SELECT l.message FROM logs l WHERE l.user_id=cp.user_id AND l.post_url=cp.post_key "
+            "   AND l.action_type='comment' AND l.result='success' "
+            "   ORDER BY l.created_at DESC LIMIT 1) AS comment_text "
+            "FROM commented_posts cp "
+            "WHERE cp.user_id=%s AND cp.status='commented' "
+            "  AND cp.created_at >= (NOW() - INTERVAL %s DAY) "
+            "ORDER BY cp.created_at DESC",
+            (user_id, int(days)))
+        return list(cursor.fetchall() or [])
+    except mysql.connector.Error:
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_comment_followup(user_id: int, reply_key: str) -> "dict | None":
+    """The follow-up ledger row for a specific reply (reacted/replied flags), or None if we have
+    never handled this reply. Dedup anchor for the follow-up sweep."""
+    if not reply_key:
+        return None
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT reacted, replied FROM comment_followups WHERE user_id=%s AND reply_key=%s",
+            (user_id, str(reply_key)[:255]))
+        return cursor.fetchone()
+    except mysql.connector.Error:
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_comment_followup(user_id: int, post_key: str, reply_key: str,
+                            reacted: bool = False, replied: bool = False) -> bool:
+    """Upsert a follow-up record for a reply. Flags are latched ON (never cleared) so a later
+    partial pass can't undo an earlier action, and the UNIQUE(user_id, reply_key) constraint makes
+    this the single source of truth for 'already reacted/replied to this reply'."""
+    if not reply_key:
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO comment_followups (user_id, post_key, reply_key, reacted, replied) "
+            "VALUES (%s,%s,%s,%s,%s) ON DUPLICATE KEY UPDATE "
+            "reacted=GREATEST(reacted, VALUES(reacted)), replied=GREATEST(replied, VALUES(replied))",
+            (user_id, str(post_key)[:255], str(reply_key)[:255], int(bool(reacted)), int(bool(replied))))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not record comment followup for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def count_followup_replies_today(user_id: int) -> int:
+    """Auto-replies posted to comment-replies today — the daily cap for the follow-up feature."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM comment_followups "
+            "WHERE user_id=%s AND replied=1 AND updated_at >= CURDATE()",
+            (user_id,))
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] else 0
+    except mysql.connector.Error:
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_commented_post_key(user_id: int, old_key: str, new_key: str) -> bool:
+    """Backfill: upgrade a commented_posts row's key from the old 'feedpost://' content hash to the
+    navigable 'feedurn://' URN once we recover it (issue #478 reconcile). If the new key already
+    exists for this user (already commented under the URN), drop the stale hash row instead so the
+    UNIQUE(user_id, post_key) constraint isn't violated."""
+    if not old_key or not new_key or old_key == new_key:
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM commented_posts WHERE user_id=%s AND post_key=%s",
+            (user_id, str(new_key)[:255]))
+        exists = bool((cursor.fetchone() or [0])[0])
+        if exists:
+            cursor.execute("DELETE FROM commented_posts WHERE user_id=%s AND post_key=%s",
+                           (user_id, str(old_key)[:255]))
+        else:
+            cursor.execute("UPDATE commented_posts SET post_key=%s WHERE user_id=%s AND post_key=%s",
+                           (str(new_key)[:255], user_id, str(old_key)[:255]))
+        connection.commit()
+        return cursor.rowcount >= 1
+    except mysql.connector.Error as err:
+        myprint(f"Could not update commented post key for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_duplicate_comment_posts(user_id: int, hours: int = 24):
     """Read-only report: posts the user commented on MORE THAN ONCE in the last `hours`, from the
     SUCCESS comment logs. Returns list of (post_url, comment_count, first_at, last_at) ordered by

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3565,7 +3565,7 @@ def has_commented_post(user_id: int, post_key: str) -> bool:
 
 
 def get_recent_navigable_commented_posts(user_id: int, days: int = 3) -> list:
-    """Posts we automated a comment on in the last `days` whose ledger key is a NAVIGABLE URN
+    """Posts we automated a comment on in the last `days` whose ledger key is a navigable URN
     (feedurn://urn:li:...), newest first. These are the posts the follow-up sweep can revisit to
     handle replies to our comment (issue #478). Pre-#474 'feedpost://' hash keys aren't navigable
     and are excluded."""

--- a/tests/unit/app/test_comment_followups.py
+++ b/tests/unit/app/test_comment_followups.py
@@ -1,0 +1,65 @@
+"""Unit tests for the auto-follow-up feature — issue #478 (pure logic; Selenium DOM is validated
+on a supervised run). Covers URL derivation, question detection, stable reply keys, and the
+sweep_reply_comments concurrency lock."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+RA = "cqc_lem.app.run_automation"
+
+
+def _fn(name):
+    import importlib
+    return getattr(importlib.import_module(RA), name)
+
+
+class TestPostUrlFromKey:
+    def test_feedurn_becomes_navigable_url(self):
+        f = _fn("_post_url_from_key")
+        assert f("feedurn://urn:li:activity:7486451907129958400") == \
+            "https://www.linkedin.com/feed/update/urn:li:activity:7486451907129958400/"
+
+    def test_legacy_hash_key_is_not_navigable(self):
+        assert _fn("_post_url_from_key")("feedpost://abc123") is None
+
+    def test_passthrough_http(self):
+        assert _fn("_post_url_from_key")("https://x/y").startswith("https://")
+
+    def test_none_and_garbage(self):
+        f = _fn("_post_url_from_key")
+        assert f(None) is None
+        assert f("feedurn://not-a-urn") is None
+
+
+class TestReplyIsQuestion:
+    def test_question_mark_is_a_question(self):
+        assert _fn("_reply_is_question")("Interesting — how do you handle scale?") is True
+
+    def test_statement_is_not(self):
+        assert _fn("_reply_is_question")("Great point, totally agree.") is False
+
+    def test_url_query_string_does_not_count(self):
+        assert _fn("_reply_is_question")("see https://x.com/a?b=1 for more") is False
+
+    def test_empty(self):
+        assert _fn("_reply_is_question")("") is False
+
+
+class TestFollowupReplyKey:
+    def test_stable_across_whitespace_and_case(self):
+        f = _fn("_followup_reply_key")
+        a = f("feedurn://urn:li:activity:1", "https://www.linkedin.com/in/jane-doe/", "Nice!  …see more")
+        b = f("feedurn://urn:li:activity:1", "https://www.linkedin.com/in/jane-doe/?x=1", "nice!")
+        assert a == b  # same replier + same normalized text -> one key
+
+    def test_namespaced_to_post_and_replier(self):
+        f = _fn("_followup_reply_key")
+        k = f("feedurn://urn:li:activity:1", "https://www.linkedin.com/in/jane-doe/", "hi")
+        assert k.startswith("feedurn://urn:li:activity:1#reply:jane-doe:")
+
+    def test_different_repliers_differ(self):
+        f = _fn("_followup_reply_key")
+        assert f("p", "https://www.linkedin.com/in/a/", "hi") != \
+               f("p", "https://www.linkedin.com/in/b/", "hi")

--- a/tests/unit/app/test_comment_followups.py
+++ b/tests/unit/app/test_comment_followups.py
@@ -1,6 +1,7 @@
-"""Unit tests for the auto-follow-up feature — issue #478 (pure logic; Selenium DOM is validated
-on a supervised run). Covers URL derivation, question detection, stable reply keys, and the
-sweep_reply_comments concurrency lock."""
+"""Unit tests for the auto-follow-up feature — issue #478. Covers URL/URN derivation, question
+detection, stable reply keys, the DOM helpers + worker (mocked driver), the sweep/single/reconcile
+orchestration, and the guest-voice reply generator. Selenium DOM targeting itself is validated on a
+supervised live run."""
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -8,6 +9,13 @@ from unittest.mock import MagicMock, patch
 pytestmark = pytest.mark.unit
 
 RA = "cqc_lem.app.run_automation"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    # The worker's scroll/pacing loops call time.sleep; skip the real waits in unit tests.
+    with patch(f"{RA}.time.sleep", lambda *a, **k: None):
+        yield
 
 
 def _fn(name):
@@ -63,3 +71,334 @@ class TestFollowupReplyKey:
         f = _fn("_followup_reply_key")
         assert f("p", "https://www.linkedin.com/in/a/", "hi") != \
                f("p", "https://www.linkedin.com/in/b/", "hi")
+
+
+from contextlib import ExitStack
+
+
+def _p(es, name, **kw):
+    return es.enter_context(patch(f"{RA}.{name}", **kw))
+
+
+class TestReactToCommentInline:
+    def test_likes_when_button_present(self):
+        from cqc_lem.app.run_automation import _react_to_comment_inline
+        btn = MagicMock(); btn.get_attribute.return_value = None; btn.size = {"width": 20, "height": 20}
+        comment = MagicMock(); comment.find_elements.return_value = [btn]
+        driver = MagicMock()
+        with patch(f"{RA}.ActionChains") as AC:
+            AC.return_value.move_to_element.return_value.pause.return_value.click.return_value.perform.return_value = None
+            AC.return_value.move_to_element.return_value.pause.return_value.perform.return_value = None
+            assert _react_to_comment_inline(driver, MagicMock(), comment, user_id=1) is True
+
+    def test_skips_when_already_reacted(self):
+        from cqc_lem.app.run_automation import _react_to_comment_inline
+        btn = MagicMock(); btn.get_attribute.return_value = "true"  # aria-pressed
+        comment = MagicMock(); comment.find_elements.return_value = [btn]
+        with patch(f"{RA}.ActionChains"):
+            assert _react_to_comment_inline(MagicMock(), MagicMock(), comment, user_id=1) is False
+
+    def test_returns_false_and_logs_when_no_button(self):
+        from cqc_lem.app.run_automation import _react_to_comment_inline
+        comment = MagicMock(); comment.find_elements.return_value = []
+        with patch(f"{RA}.ActionChains"), patch(f"{RA}.log_warning") as lw:
+            assert _react_to_comment_inline(MagicMock(), MagicMock(), comment, user_id=1) is False
+        assert lw.called
+
+
+class TestReplyUnderComment:
+    def test_types_into_nearest_composer_and_submits(self):
+        from cqc_lem.app.run_automation import _reply_under_comment_inline
+        rbtn = MagicMock()
+        comment = MagicMock(); comment.find_elements.return_value = [rbtn]
+        composer = MagicMock()
+        driver = MagicMock()
+        # scrollIntoView -> None; composer proximity JS -> composer; submit JS -> True
+        driver.execute_script.side_effect = [None, composer, True]
+        with patch(f"{RA}.ActionChains"), patch(f"{RA}._strip_non_bmp", side_effect=lambda s: s), \
+             patch(f"{RA}._composer_submitted", return_value=True):
+            assert _reply_under_comment_inline(driver, MagicMock(), comment, "Great point!", user_id=1) is True
+        composer.send_keys.assert_called()
+
+    def test_returns_false_when_no_reply_button(self):
+        from cqc_lem.app.run_automation import _reply_under_comment_inline
+        comment = MagicMock(); comment.find_elements.return_value = []
+        driver = MagicMock()
+        with patch(f"{RA}.ActionChains"), patch(f"{RA}.log_warning"):
+            assert _reply_under_comment_inline(driver, MagicMock(), comment, "hi", user_id=1) is False
+
+
+class TestCommentContainerHelpers:
+    def test_header_author_passthrough(self):
+        from cqc_lem.app.run_automation import _comment_header_author
+        driver = MagicMock(); driver.execute_script.return_value = "https://www.linkedin.com/in/jane/"
+        assert _comment_header_author(driver, MagicMock()) == "https://www.linkedin.com/in/jane/"
+
+    def test_header_author_empty_on_error(self):
+        from cqc_lem.app.run_automation import _comment_header_author
+        driver = MagicMock(); driver.execute_script.side_effect = RuntimeError("x")
+        assert _comment_header_author(driver, MagicMock()) == ""
+
+    def test_container_passthrough(self):
+        from cqc_lem.app.run_automation import _comment_container
+        node = MagicMock()
+        driver = MagicMock(); driver.execute_script.return_value = node
+        assert _comment_container(driver, MagicMock()) is node
+
+
+def _worker_env(es, reply_text="Thanks! How do you test drift?", followup_state=None,
+                react=True, reply=True, replies_remaining=5):
+    """Patch the follow-up worker's collaborators; returns (driver, my_profile, records)."""
+    our_tb, reply_tb = MagicMock(), MagicMock()
+    our_tb.text = "our original comment"
+    reply_tb.text = reply_text
+    # reply's text box @mentions us -> mentions_us True
+    reply_tb.find_elements.return_value = [MagicMock()]
+    our_tb.find_elements.return_value = [MagicMock()]
+    our_cont, reply_cont = MagicMock(name="our_cont"), MagicMock(name="reply_cont")
+
+    driver = MagicMock()
+    driver.current_url = "https://www.linkedin.com/feed/update/urn:li:activity:1/"
+    def find_elements(by, sel):
+        from cqc_lem.app.run_automation import _COMMENTLIST_TEXTBOX
+        if sel == _COMMENTLIST_TEXTBOX:
+            return [our_tb, reply_tb]
+        return []  # scroll sentinel + expand buttons
+    driver.find_elements.side_effect = find_elements
+    driver.execute_script.return_value = None  # scrollBy + contains() -> falsy (use mentions path)
+
+    def container(_drv, tb):
+        return our_cont if tb is our_tb else reply_cont
+    def author(_drv, cont):
+        return "https://www.linkedin.com/in/me/" if cont is our_cont else "https://www.linkedin.com/in/glenda/"
+
+    _p(es, "_comment_container", side_effect=container)
+    _p(es, "_comment_header_author", side_effect=author)
+    _p(es, "get_comment_followup", return_value=followup_state)
+    rec = _p(es, "record_comment_followup", return_value=True)
+    _p(es, "insert_new_log")
+    _p(es, "_react_to_comment_inline", return_value=react)
+    _p(es, "_reply_under_comment_inline", return_value=reply)
+    _p(es, "generate_comment_reply_followup", return_value="a thoughtful answer")
+    my_profile = MagicMock(); my_profile.profile_url = "https://www.linkedin.com/in/me/"
+    return driver, my_profile, rec
+
+
+class TestFollowupWorker:
+    def test_reacts_and_replies_to_a_question_reply(self):
+        from cqc_lem.app.run_automation import _followup_on_post_comment_replies
+        with ExitStack() as es:
+            driver, prof, rec = _worker_env(es)
+            r = _followup_on_post_comment_replies(driver, MagicMock(), 1,
+                    "https://www.linkedin.com/feed/update/urn:li:activity:1/",
+                    "feedurn://urn:li:activity:1", prof, "voice", {}, replies_remaining=5)
+        assert r == {"reacted": 1, "replied": 1}
+
+    def test_reacts_only_when_reply_is_not_a_question(self):
+        from cqc_lem.app.run_automation import _followup_on_post_comment_replies
+        with ExitStack() as es:
+            driver, prof, rec = _worker_env(es, reply_text="Nice, totally agree.")
+            r = _followup_on_post_comment_replies(driver, MagicMock(), 1, "u", "feedurn://urn:li:activity:1",
+                                                  prof, "voice", {}, replies_remaining=5)
+        assert r["replied"] == 0 and r["reacted"] == 1
+
+    def test_dedup_skips_already_handled(self):
+        from cqc_lem.app.run_automation import _followup_on_post_comment_replies
+        with ExitStack() as es:
+            driver, prof, rec = _worker_env(es, followup_state={"reacted": 1, "replied": 1})
+            r = _followup_on_post_comment_replies(driver, MagicMock(), 1, "u", "feedurn://urn:li:activity:1",
+                                                  prof, "voice", {}, replies_remaining=5)
+        assert r == {"reacted": 0, "replied": 0}
+
+    def test_reply_cap_blocks_reply_but_not_react(self):
+        from cqc_lem.app.run_automation import _followup_on_post_comment_replies
+        with ExitStack() as es:
+            driver, prof, rec = _worker_env(es)
+            r = _followup_on_post_comment_replies(driver, MagicMock(), 1, "u", "feedurn://urn:li:activity:1",
+                                                  prof, "voice", {}, replies_remaining=0)
+        assert r["reacted"] == 1 and r["replied"] == 0
+
+    def test_no_slug_returns_early(self):
+        from cqc_lem.app.run_automation import _followup_on_post_comment_replies
+        prof = MagicMock(); prof.profile_url = "https://www.linkedin.com/"
+        with patch(f"{RA}.log_warning"):
+            r = _followup_on_post_comment_replies(MagicMock(), MagicMock(), 1, "u", "k", prof, "v", {}, 5)
+        assert r == {"reacted": 0, "replied": 0}
+
+
+class TestOrchestration:
+    def _profile_patches(self, es):
+        _p(es, "get_engagement_preferences", return_value={})
+        _p(es, "count_followup_replies_today", return_value=0)
+        _p(es, "get_or_create_profile_synthesis", return_value="voice")
+        _p(es, "get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock()))
+        _p(es, "quit_gracefully")
+
+    def test_single_post_no_urn(self):
+        from cqc_lem.app.run_automation import _run_single_post_followup
+        assert "No activity URN" in _run_single_post_followup(1, "https://linkedin.com/feed/x")
+
+    def test_single_post_lock_held(self):
+        from cqc_lem.app.run_automation import _run_single_post_followup
+        with ExitStack() as es:
+            _p(es, "acquire_run_lock", return_value=None)
+            out = _run_single_post_followup(1, "https://www.linkedin.com/feed/update/urn:li:activity:9/")
+        assert "another follow-up run" in out.lower()
+
+    def test_single_post_runs_worker(self):
+        from cqc_lem.app.run_automation import _run_single_post_followup
+        with ExitStack() as es:
+            _p(es, "acquire_run_lock", return_value="tok")
+            rel = _p(es, "release_run_lock")
+            self._profile_patches(es)
+            _p(es, "_followup_on_post_comment_replies", return_value={"reacted": 1, "replied": 1})
+            out = _run_single_post_followup(1, "https://www.linkedin.com/feed/update/urn:li:activity:9/")
+        assert "reacted 1, replied 1" in out
+        rel.assert_called()
+
+    def test_sweep_no_posts(self):
+        from cqc_lem.app.run_automation import _run_comment_followups_sweep
+        with ExitStack() as es:
+            _p(es, "get_recent_navigable_commented_posts", return_value=[])
+            assert "No recent navigable" in _run_comment_followups_sweep(1)
+
+    def test_sweep_runs_worker_over_posts(self):
+        from cqc_lem.app.run_automation import _run_comment_followups_sweep
+        with ExitStack() as es:
+            _p(es, "get_recent_navigable_commented_posts",
+               return_value=[{"post_key": "feedurn://urn:li:activity:1"},
+                             {"post_key": "feedpost://hash"}])  # 2nd not navigable -> skipped
+            _p(es, "acquire_run_lock", return_value="tok")
+            rel = _p(es, "release_run_lock")
+            self._profile_patches(es)
+            w = _p(es, "_followup_on_post_comment_replies", return_value={"reacted": 2, "replied": 1})
+            out = _run_comment_followups_sweep(1)
+        assert "reacted 2, replied 1" in out
+        assert w.call_count == 1  # only the feedurn post
+        rel.assert_called()
+
+    def test_sweep_lock_held(self):
+        from cqc_lem.app.run_automation import _run_comment_followups_sweep
+        with ExitStack() as es:
+            _p(es, "get_recent_navigable_commented_posts", return_value=[{"post_key": "feedurn://urn:li:activity:1"}])
+            _p(es, "acquire_run_lock", return_value=None)
+            assert "in progress" in _run_comment_followups_sweep(1).lower()
+
+    def test_reconcile_no_stale(self):
+        from cqc_lem.app.run_automation import _run_reconcile_comment_urns
+        with ExitStack() as es:
+            _p(es, "get_recent_commented_rows_with_text",
+               return_value=[{"post_key": "feedurn://urn:li:activity:1", "comment_text": "x"}])
+            assert "No stale" in _run_reconcile_comment_urns(1)
+
+    def test_reconcile_upgrades_stale_key(self):
+        from cqc_lem.app.run_automation import _run_reconcile_comment_urns
+        with ExitStack() as es:
+            _p(es, "get_recent_commented_rows_with_text",
+               return_value=[{"post_key": "feedpost://h", "comment_text": "my comment"}])
+            _p(es, "acquire_run_lock", return_value="tok")
+            _p(es, "release_run_lock")
+            _p(es, "get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock()))
+            _p(es, "quit_gracefully")
+            _p(es, "_scrape_activity_comment_urns",
+               return_value={"my comment": "https://www.linkedin.com/feed/update/urn:li:activity:5/"})
+            upd = _p(es, "update_commented_post_key", return_value=True)
+            out = _run_reconcile_comment_urns(1)
+        assert "Reconciled 1/1" in out
+        assert "feedurn://urn:li:activity:5" in upd.call_args[0][2]
+
+
+class TestGuestReplyGenerator:
+    def test_frames_as_guest_and_humanizes(self):
+        from cqc_lem.utilities.ai import ai_helper
+        resp = MagicMock(); resp.choices = [MagicMock()]
+        resp.choices[0].message.content = "  raw reply  "
+        with patch.object(ai_helper, "_call_llm", return_value=resp) as call, \
+             patch.object(ai_helper, "_humanize_text", side_effect=lambda t, **k: "clean reply"), \
+             patch.object(ai_helper, "_voice_reference", return_value="voice"):
+            out = ai_helper.generate_comment_reply_followup("How do you test?", MagicMock(),
+                                                            prefs={}, profile_synthesis="v")
+        assert out == "clean reply"
+        system = call.call_args.kwargs["messages"][0]["content"].lower()
+        assert "someone else" in system and "do not speak as if you own" in system
+
+    def test_returns_none_when_llm_empty(self):
+        from cqc_lem.utilities.ai import ai_helper
+        resp = MagicMock(); resp.choices = [MagicMock()]; resp.choices[0].message.content = None
+        with patch.object(ai_helper, "_call_llm", return_value=resp), \
+             patch.object(ai_helper, "_voice_reference", return_value="voice"):
+            assert ai_helper.generate_comment_reply_followup("hi?", MagicMock()) is None
+
+
+class TestScrapeActivityUrns:
+    def test_maps_normalized_text_to_post_url(self):
+        from cqc_lem.app.run_automation import _scrape_activity_comment_urns
+        box = MagicMock(); box.text = "My earlier comment here"
+        driver = MagicMock(); driver.find_elements.return_value = [box]
+        prof = MagicMock(); prof.profile_url = "https://www.linkedin.com/in/me/"
+        with patch(f"{RA}._card_for_textbox", return_value=MagicMock()), \
+             patch(f"{RA}._post_permalink_from_card",
+                   return_value="https://www.linkedin.com/feed/update/urn:li:activity:7/"):
+            m = _scrape_activity_comment_urns(driver, MagicMock(), prof)
+        assert "https://www.linkedin.com/feed/update/urn:li:activity:7/" in m.values()
+
+    def test_empty_when_no_profile_path(self):
+        from cqc_lem.app.run_automation import _scrape_activity_comment_urns
+        prof = MagicMock(); prof.profile_url = "https://www.linkedin.com/"
+        assert _scrape_activity_comment_urns(MagicMock(), MagicMock(), prof) == {}
+
+
+class TestDispatchCommentFollowups:
+    SCH = "cqc_lem.app.run_scheduler"
+
+    def test_dispatches_for_users_with_session(self):
+        from cqc_lem.app.run_scheduler import dispatch_comment_followups
+        with ExitStack() as es:
+            es.enter_context(patch(f"{self.SCH}._skip_if_throttled", return_value=False))
+            es.enter_context(patch(f"{self.SCH}.get_active_user_ids", return_value=[1, 2]))
+            es.enter_context(patch(f"{self.SCH}.has_linkedin_session", side_effect=lambda u: u == 1))
+            es.enter_context(patch("cqc_lem.utilities.linkedin.rate_limit._redis_client", return_value=None))
+            sweep = es.enter_context(patch(f"{self.SCH}.sweep_comment_followups"))
+            out = dispatch_comment_followups()
+        assert sweep.apply_async.call_count == 1  # only the user with a session
+        assert "1/2" in out
+
+    def test_throttled_returns_early(self):
+        from cqc_lem.app.run_scheduler import dispatch_comment_followups
+        with patch(f"{self.SCH}._skip_if_throttled", return_value=True):
+            assert "throttled" in dispatch_comment_followups().lower()
+
+
+class TestGuestReplyContext:
+    def test_includes_post_and_prior_comment_context(self):
+        from cqc_lem.utilities.ai import ai_helper
+        resp = MagicMock(); resp.choices = [MagicMock()]; resp.choices[0].message.content = "x"
+        with patch.object(ai_helper, "_call_llm", return_value=resp) as call, \
+             patch.object(ai_helper, "_humanize_text", side_effect=lambda t, **k: t), \
+             patch.object(ai_helper, "_voice_reference", return_value="v"):
+            ai_helper.generate_comment_reply_followup("their reply?", MagicMock(),
+                                                      our_comment="my comment", post_content="the post")
+        user_msg = call.call_args.kwargs["messages"][1]["content"]
+        assert "the post" in user_msg and "my comment" in user_msg
+
+
+class TestDispatchBranches:
+    SCH = "cqc_lem.app.run_scheduler"
+
+    def test_no_active_users(self):
+        from cqc_lem.app.run_scheduler import dispatch_comment_followups
+        with patch(f"{self.SCH}._skip_if_throttled", return_value=False), \
+             patch(f"{self.SCH}.get_active_user_ids", return_value=[]):
+            assert "No active users" in dispatch_comment_followups()
+
+    def test_redis_interval_gate(self):
+        from cqc_lem.app.run_scheduler import dispatch_comment_followups
+        client = MagicMock(); client.set.return_value = True  # due
+        with patch(f"{self.SCH}._skip_if_throttled", return_value=False), \
+             patch(f"{self.SCH}.get_active_user_ids", return_value=[1]), \
+             patch(f"{self.SCH}.has_linkedin_session", return_value=True), \
+             patch("cqc_lem.utilities.linkedin.rate_limit._redis_client", return_value=client), \
+             patch(f"{self.SCH}.sweep_comment_followups") as sweep:
+            out = dispatch_comment_followups()
+        assert sweep.apply_async.called and "1/1" in out
+        assert client.set.call_args.kwargs.get("nx") is True

--- a/tests/unit/utilities/test_db_comment_followups.py
+++ b/tests/unit/utilities/test_db_comment_followups.py
@@ -1,0 +1,81 @@
+"""Unit tests for comment_followups DB helpers — issue #478."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+DB = "cqc_lem.utilities.db"
+
+
+def _conn():
+    conn = MagicMock()
+    cur = MagicMock()
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestRecordAndRead:
+    def test_record_upserts_and_latches_flags(self):
+        from cqc_lem.utilities.db import record_comment_followup
+        conn, cur = _conn()
+        with patch(f"{DB}.get_db_connection", return_value=conn):
+            assert record_comment_followup(1, "feedurn://urn:li:activity:1", "rk", reacted=True) is True
+        sql = cur.execute.call_args[0][0]
+        assert "ON DUPLICATE KEY UPDATE" in sql
+        assert "GREATEST(reacted" in sql and "GREATEST(replied" in sql
+
+    def test_get_followup_returns_flags(self):
+        from cqc_lem.utilities.db import get_comment_followup
+        conn, cur = _conn()
+        cur.fetchone.return_value = {"reacted": 1, "replied": 0}
+        with patch(f"{DB}.get_db_connection", return_value=conn):
+            assert get_comment_followup(1, "rk") == {"reacted": 1, "replied": 0}
+
+    def test_get_followup_none_for_empty_key(self):
+        from cqc_lem.utilities.db import get_comment_followup
+        assert get_comment_followup(1, "") is None
+
+
+class TestNavigableAndCap:
+    def test_recent_navigable_filters_to_feedurn(self):
+        from cqc_lem.utilities.db import get_recent_navigable_commented_posts
+        conn, cur = _conn()
+        cur.fetchall.return_value = [{"post_key": "feedurn://urn:li:activity:1"}]
+        with patch(f"{DB}.get_db_connection", return_value=conn):
+            rows = get_recent_navigable_commented_posts(1, days=3)
+        assert rows and rows[0]["post_key"].startswith("feedurn://")
+        assert "feedurn://%" in cur.execute.call_args[0][0]
+
+    def test_count_followup_replies_today(self):
+        from cqc_lem.utilities.db import count_followup_replies_today
+        conn, cur = _conn()
+        cur.fetchone.return_value = [4]
+        with patch(f"{DB}.get_db_connection", return_value=conn):
+            assert count_followup_replies_today(1) == 4
+        assert "replied=1" in cur.execute.call_args[0][0]
+
+
+class TestUpdateKey:
+    def test_upgrade_when_new_key_absent(self):
+        from cqc_lem.utilities.db import update_commented_post_key
+        conn, cur = _conn()
+        cur.fetchone.return_value = [0]   # new key not present
+        cur.rowcount = 1
+        with patch(f"{DB}.get_db_connection", return_value=conn):
+            assert update_commented_post_key(1, "feedpost://h", "feedurn://urn:li:activity:1") is True
+        assert any("UPDATE commented_posts SET post_key" in c.args[0] for c in cur.execute.call_args_list)
+
+    def test_deletes_stale_when_new_key_already_exists(self):
+        from cqc_lem.utilities.db import update_commented_post_key
+        conn, cur = _conn()
+        cur.fetchone.return_value = [1]   # new key already there
+        cur.rowcount = 1
+        with patch(f"{DB}.get_db_connection", return_value=conn):
+            assert update_commented_post_key(1, "feedpost://h", "feedurn://urn:li:activity:1") is True
+        assert any("DELETE FROM commented_posts" in c.args[0] for c in cur.execute.call_args_list)
+
+    def test_noop_for_identical_or_empty(self):
+        from cqc_lem.utilities.db import update_commented_post_key
+        assert update_commented_post_key(1, "x", "x") is False
+        assert update_commented_post_key(1, "", "y") is False

--- a/tests/unit/utilities/test_db_comment_followups.py
+++ b/tests/unit/utilities/test_db_comment_followups.py
@@ -79,3 +79,42 @@ class TestUpdateKey:
         from cqc_lem.utilities.db import update_commented_post_key
         assert update_commented_post_key(1, "x", "x") is False
         assert update_commented_post_key(1, "", "y") is False
+
+
+import mysql.connector
+
+
+class TestRowsWithTextAndErrorBranches:
+    def test_recent_rows_with_text_happy(self):
+        from cqc_lem.utilities.db import get_recent_commented_rows_with_text
+        conn, cur = _conn()
+        cur.fetchall.return_value = [{"post_key": "feedpost://h", "comment_text": "hi"}]
+        with patch(f"{DB}.get_db_connection", return_value=conn):
+            rows = get_recent_commented_rows_with_text(1, days=3)
+        assert rows and rows[0]["comment_text"] == "hi"
+        assert "flyway" not in cur.execute.call_args[0][0].lower()
+
+    @pytest.mark.parametrize("fn,args,default", [
+        ("get_recent_navigable_commented_posts", (1,), []),
+        ("get_recent_commented_rows_with_text", (1,), []),
+        ("get_comment_followup", (1, "rk"), None),
+        ("record_comment_followup", (1, "pk", "rk"), False),
+        ("count_followup_replies_today", (1,), 0),
+        ("update_commented_post_key", (1, "a", "b"), False),
+    ])
+    def test_db_error_returns_safe_default(self, fn, args, default):
+        import cqc_lem.utilities.db as db
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{DB}.get_db_connection", return_value=conn):
+            assert getattr(db, fn)(*args) == default
+
+
+class TestGuards:
+    def test_record_followup_empty_key(self):
+        from cqc_lem.utilities.db import record_comment_followup
+        assert record_comment_followup(1, "pk", "") is False
+
+    def test_get_followup_empty_key(self):
+        from cqc_lem.utilities.db import get_comment_followup
+        assert get_comment_followup(1, "") is None


### PR DESCRIPTION
## What
When someone (usually the author) replies to a comment **we automated** on their post, **react** to the reply and, if it **asks a question**, post a voice-aligned **answer**. Scoped to our automated comments only — driven by the `commented_posts` ledger, which never holds a manually-typed comment.

Requested after #474: the author replied with a question to our comment on `urn:li:activity:7486451907129958400` and nothing handled it.

## How
- **`sweep_comment_followups(user_id)`** — revisits posts we commented on in the last 3 days whose ledger key is a **navigable `feedurn://` URN** (from #474), reacts to replies on our comment, answers question-replies. `QueueOnce` + the #475 single-flight lock + 429-safe. Daily reply cap (10) + per-run react cap (25).
- **`process_comment_followups_for_url(user_id, url)`** — single-post entrypoint (manual/API/**verification**), independent of the ledger.
- **`reconcile_recent_comment_urns(user_id, days)`** — backfill that recovers navigable URNs for recent legacy `feedpost://` rows via the user's `recent-activity/comments` page, so pre-#474 comments become follow-up-able.
- **Dedup:** new `comment_followups` table (migration `V20260724174124`) keyed on a **stable reply id** (`post + replier-slug + normalized-text hash`), never raw text — the #474 lesson. Flags `reacted`/`replied` latch on.
- **Beat:** `dispatch-comment-followups` every 6h, per-user 12h interval-gated (~twice/day).

## Also: hardened `sweep_reply_comments` (the item you asked for)
`QueueOnce(unlock_before_run=True)` releases its lock at task **start**, leaving a narrow window where the email-event trigger and the scheduled dispatcher could start two concurrent sweeps and double-reply. Added the same single-flight lock (fail-open) to close it. Not the #474 cause — belt-and-suspenders.

## Trigger note
LinkedIn "X replied to your comment" emails already classify as comment notifications (`_COMMENT_PHRASES` has `"replied to"`), but today they fire the **own-posts** reply sweep — a no-op for third-party replies. This adds the missing handler.

## Testing
- 19 new unit tests: URL/URN derivation, question detection (incl. URL-query false-positive guard), reply-key stability, the `comment_followups` DB helpers, and `update_commented_post_key` conflict handling. Full suite **3250 passed**.
- **Selenium DOM targeting** (locating our comment + its replies, reacting to a reply, the activity-page scrape) is best-effort and **validated on a supervised first run** — I'm running that against the post above.

## Product/ToS note
This auto-replies on **other people's** posts (only to question-replies on our own comments, capped). Flagging for your sign-off on defaults (react-always + reply-to-questions; 10 replies/day; 3-day window) before it deploys broadly.

Closes #478

🤖 Generated with [Claude Code](https://claude.com/claude-code)