### PR TITLE
perf(tests): make the unit lane hermetic — 49s → 20s CI unit run, same coverage (closes #480)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,6 +144,10 @@ pytest-playwright = ">=0.4.0,<1.0.0"
 
 
 [tool.coverage.run]
+# sys.monitoring-based tracer (CPython 3.12+, which this project requires). Same line-coverage
+# results as the C tracer at roughly half the measurement overhead — issue #480 measured the
+# unit suite at 33s with the default core vs 19s with sysmon, byte-identical coverage totals.
+core = "sysmon"
 omit = [
     "tests/*",
     "src/cqc_lem/aws/*",

--- a/tests/README.md
+++ b/tests/README.md
@@ -158,6 +158,63 @@ poetry run pytest -x
 poetry run pytest --lf
 ```
 
+## Unit-Suite Performance
+
+The unit lane is the merge-queue feedback loop, so it is kept deliberately fast. Issue #480 profiled
+it and cut the CI-shaped run (`-m "not slow" --cov`) from **~49s to ~20s** with byte-identical
+coverage. Two things keep it there:
+
+### 1. The unit lane is hermetic (`tests/unit/conftest.py`)
+
+Two autouse guards make un-mocked external I/O fail *instantly* instead of dialling out:
+
+| Guard | What it does | Why |
+|---|---|---|
+| `_no_real_llm_calls` | Raises `APIConnectionError` from the shared `ai.client.client` | A few tests never mocked the client. Each one spent ~1.3s in httpx connect + the OpenAI SDK's retry back-off before the production `except` branch ran. Four carousel tests alone cost 12.8s. |
+| `_no_real_redis` | Makes `redis.Redis.from_url` raise, so `_redis_client()` returns `None` | CI has no Redis in the unit lane, so those call sites already took the fails-open branch. On a dev box running the compose stack the same tests would connect to the live broker and read/write real 429-breaker keys. |
+
+Both guards reproduce the behaviour the tests already had in CI — they only remove the waiting and
+the dev-box non-determinism. A test that wants a *working* LLM/Redis handle patches it itself; that
+patch nests inside the guard and wins.
+
+**When adding tests:** mock the collaborator explicitly. If a test only passes because a guard failed
+the call for it, that is accidental coverage — assert the failure path on purpose instead.
+
+### 2. Coverage uses the `sysmon` core
+
+`[tool.coverage.run] core = "sysmon"` in `pyproject.toml` selects coverage.py's `sys.monitoring`
+tracer (CPython 3.12+, which this project requires). Measured on the unit suite: 33s with the default
+C tracer vs 19s with sysmon, identical line-coverage totals.
+
+### Known inherently-slow tests (leave them alone)
+
+These are the slowest survivors. Each is slow because it does real work the test is specifically
+there to verify — do not mock it away:
+
+| Test | ~Cost | Why it stays |
+|---|---|---|
+| `test_date.py::test_purge_removes_unparseable_dates` | 1.0s | First unparseable input makes `dateparser` load its full language/locale set. One-time process cost, not per-test. |
+| `test_admin_engagement_test_runs.py` setup | 0.9s | Builds the whole FastAPI app + OpenAPI schema. Already `scope="module"`, so it is paid once per file. |
+| `test_geocoding.py::TestGeocodeCity` (3 tests) | 1.3s | Real `timezonefinder` lat/long→IANA lookups; the assertions are on real timezone output. |
+| `test_carousel_image_selection.py::TestPillowComposition` | 1.5s | Real Pillow slide composition; the assertions inspect the rendered pixels. |
+
+### Parallelism (`pytest-xdist`) — measured, not adopted
+
+`-n auto --dist loadfile` was benchmarked on this suite: 12.5s on an 8-core box, but only ~19s at
+`-n 4` (the width of a GitHub-hosted runner) versus ~20s serial. At ~3200 fast tests the worker
+startup and coverage-combine overhead eats the gain, so xdist is **not** a dependency here. Re-run
+the benchmark before adding it — it becomes worthwhile if the suite grows well past ~60s.
+
+### Re-profiling
+
+```bash
+# Rank the slowest tests (and slowest setup/teardown)
+poetry run pytest tests/unit -m "not slow" --durations=50
+
+# cProfile a single offender
+poetry run pytest tests/unit/path/to/test_x.py::TestY::test_z --profile
+```
+
 ## Fixtures
 
 Shared fixtures are defined in `conftest.py`:
@@ -347,6 +404,8 @@ poetry install --with test
 - Mark slow tests with `@pytest.mark.slow`
 - Run quick tests: `pytest -m "not slow"`
 - Use mocks instead of real services
+- See [Unit-Suite Performance](#unit-suite-performance) for the profiling workflow and the
+  already-triaged offenders
 
 ## Resources
 

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -473,6 +473,14 @@ class TestGmailForwardConfirmationStorage:
             from cqc_lem.api.main import get_gmail_forward_confirmation
             assert get_gmail_forward_confirmation(7) is None
 
+    def test_get_none_when_redis_read_raises(self):
+        from unittest.mock import MagicMock
+        redis = MagicMock()
+        redis.get.side_effect = ConnectionError("redis down")
+        with patch(self._RL, return_value=redis):
+            from cqc_lem.api.main import get_gmail_forward_confirmation
+            assert get_gmail_forward_confirmation(7) is None
+
     def test_confirmation_stores_status_in_redis(self, client):
         from unittest.mock import MagicMock
         redis = MagicMock()
@@ -488,6 +496,23 @@ class TestGmailForwardConfirmationStorage:
         assert resp.json()["detail"] == "confirmed"
         redis.set.assert_called_once()
         assert redis.set.call_args.args[0] == "linkedin:gmail_forward_confirm:7"
+
+    def test_redis_write_failure_never_breaks_the_webhook(self, client):
+        from unittest.mock import MagicMock
+        redis = MagicMock()
+        redis.set.side_effect = ConnectionError("redis down")
+        got = type("R", (), {"status_code": 200})()
+        body = ("confirm the request: https://mail.google.com/mail/vf-abc\n"
+                "Confirmation code: 999888777")
+        with patch("cqc_lem.utilities.db.get_user_id_by_reply_token", return_value=7), \
+             patch("cqc_lem.api.main.requests.get", return_value=got), \
+             patch(self._RL, return_value=redis):
+            resp = client.post("/api/linkedin/comment-notification/inbound", data={
+                "to": "reply+tok9@parse.example.com",
+                "from": "forwarding-noreply@google.com",
+                "subject": "Gmail Forwarding Confirmation", "text": body})
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == "confirmed"
 
 
 class TestSharedInboundRouting:

--- a/tests/unit/app/test_post_review_gate.py
+++ b/tests/unit/app/test_post_review_gate.py
@@ -93,7 +93,8 @@ class TestSteering:
              patch(f"{_RCP}.get_ai_linked_post_refinement", side_effect=lambda c, **kw: c), \
              patch(f"{_RCP}.optimize_post_hook", side_effect=lambda c, **kw: c), \
              patch(f"{_RCP}.sanitize_for_linkedin", side_effect=lambda c, **kw: c), \
-             patch(f"{_RCP}.strip_engagement_bait", side_effect=lambda c, **kw: c):
+             patch(f"{_RCP}.strip_engagement_bait", side_effect=lambda c, **kw: c), \
+             patch(f"{_RCP}._score_and_persist_authenticity"):
             out = rcp.create_text_post(1, "awareness", post_type="thought_leadership",
                                        user_profile=MagicMock(), post_id=5)
         assert out == _FRESH

--- a/tests/unit/app/test_run_automation_login.py
+++ b/tests/unit/app/test_run_automation_login.py
@@ -162,6 +162,7 @@ class TestUpdateStaleProfileLoginError:
         """update_stale_profile calls quit_gracefully when get_current_profile succeeds."""
         mock_driver = MagicMock()
         with patch(_PATCH_GET_PROFILE, return_value=(mock_driver, MagicMock(), "u@e.com", MagicMock())), \
+             patch(f"{_MOD}.synthesize_profile", return_value=""), \
              patch(f"{_MOD}.quit_gracefully") as mock_quit:
             from cqc_lem.app.run_automation import update_stale_profile
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,54 @@
+"""Unit-lane guards that keep tests/unit/ hermetic and fast.
+
+Issue #480: a handful of unit tests reached the real network because the shared
+`cqc_lem.utilities.ai.client.client` singleton was never mocked. Every such call burned
+~1.3s in httpx connect + the OpenAI SDK's retry back-off sleeps before the production
+except-branch finally ran. Nothing under tests/unit/ is allowed to talk to a real LLM
+endpoint, so the call is failed immediately instead: the code under test takes the exact
+same failure branch it already took in CI, it just gets there without the sleeps.
+
+Tests that need a working LLM/Redis handle still patch it themselves — their patch nests
+inside these fixtures and wins.
+"""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+from openai import APIConnectionError
+
+_BLOCKED_URL = "http://litellm.invalid/v1/chat/completions"
+
+
+def _blocked_llm_call(*args, **kwargs):
+    raise APIConnectionError(request=httpx.Request("POST", _BLOCKED_URL))
+
+
+@pytest.fixture(autouse=True)
+def _no_real_llm_calls():
+    """Fail un-mocked LLM traffic instantly instead of dialing out and retrying."""
+    # Imported lazily: constructing the singleton needs the API key that the
+    # session-scoped setup_test_environment fixture puts in os.environ, which is not
+    # yet set at the time this conftest module is imported.
+    from cqc_lem.utilities.ai.client import client
+
+    with patch.object(client.chat.completions, "create",
+                      side_effect=_blocked_llm_call), \
+         patch.object(client.images, "generate", side_effect=_blocked_llm_call):
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _no_real_redis():
+    """Keep un-mocked `_redis_client()` callers on the fails-open (None) path.
+
+    In CI there is no Redis in the unit lane, so every one of those call sites already
+    took the None branch. On a dev box running the compose stack the same tests would
+    instead connect to the real broker and read/write live breaker keys — slower and,
+    worse, non-deterministic. Failing construction pins both environments to the CI
+    behaviour. Tests that want a working handle keep patching `_redis_client` directly;
+    those patches bypass this entirely.
+    """
+    blocked = ConnectionError("redis blocked in unit tests")
+    with patch("redis.Redis.from_url", side_effect=blocked):
+        yield


### PR DESCRIPTION
## What & why

Issue #480: the unit lane is the merge-queue feedback loop, and it was getting slow. I profiled `tests/unit` with `--durations` and cProfile.

The top offenders were **not slow tests** — they were tests that never mocked an external client and paid for it in connect + retry back-off:

| Offender | Cost | Root cause |
|---|---|---|
| `test_carousel_slide_images.py` (4 tests) | **12.8s** | `derive_image_query` reached the real LiteLLM endpoint; 3.9s of each test was `openai._sleep_for_retry` |
| `test_run_automation_login.py::test_quits_driver_on_success` | 2.5s | `update_stale_profile` → un-mocked `synthesize_profile` LLM call |
| `test_post_review_gate.py::test_history_fetch_failure_never_blocks_generation` | 1.3s | missing the `_score_and_persist_authenticity` patch its sibling helper already applies |

## Changes

1. **`tests/unit/conftest.py` (new)** — two autouse guards that fail un-mocked LLM and Redis traffic *instantly*:
   - `_no_real_llm_calls` — raises `APIConnectionError` from the shared `ai.client.client` singleton.
   - `_no_real_redis` — makes `redis.Redis.from_url` raise so `_redis_client()` returns `None`.

   Both reproduce the branch these tests **already took in CI** (there is no LiteLLM and no Redis in the unit lane). They only remove the waiting — plus a real dev-box hazard: with the compose stack running, unit tests were connecting to the live broker and reading/writing real 429-breaker keys.
2. **The three tests above** now patch their collaborator explicitly.
3. **`pyproject.toml`** — `[tool.coverage.run] core = "sysmon"`, coverage.py's `sys.monitoring` tracer (CPython 3.12+, which this project already requires). Roughly half the measurement overhead, identical results.
4. **Two new tests** in `test_main_general.py`. The guards revealed that two `except` branches in `api/main.py` (the Gmail-forward-confirmation Redis read/write) were covered only *by accident*, via a real `ConnectionError` leaking out of a live client. They now have deliberate tests.

## Results

Median of 3 runs, same box, same test count:

| run | `main` | this branch |
|---|---|---|
| `pytest tests/unit -m "not slow"` | 32.7s | **18.3s** (−44%) |
| `+ --cov=src/cqc_lem` (what CI runs) | 49.3s | **20.0s** (−59%) |

**Coverage is byte-identical to `main`:** `10699 statements / 572 missed / 95%`, and `api/main.py` unchanged at `1851 / 125 / 93%`. No test was weakened, deleted, or had an assertion changed; no production code changed.

Slowest test after the fix is 1.0s (was 4.2s), and the suite now makes **zero** real socket connections and spends **zero** seconds in real `time.sleep` (verified with an instrumented run).

## Deliberately not done

- **`pytest-xdist`** — benchmarked, not adopted: 12.5s at `-n auto --dist loadfile` on an 8-core box, but only ~19s at `-n 4` (a GitHub-hosted runner's width) vs ~20s serial. At ~3200 fast tests the worker startup + coverage-combine overhead eats the gain, so it is not worth a new dependency yet.
- **Four remaining slow tests** are inherently slow and documented as such in `tests/README.md` (first-call `dateparser` locale load, FastAPI app boot in a module-scoped fixture, real `timezonefinder` lookups, real Pillow composition). Each does the real work its assertions are about.

`tests/README.md` gains a **Unit-Suite Performance** section covering the guards, the sysmon core, the triaged offenders, the xdist rationale, and the re-profiling recipe.

## Testing

- `poetry run pytest tests/unit -m "not slow" --cov=src/cqc_lem` → 3233 passed, 95% total (unchanged).
- `poetry run pytest tests/unit` (no marker filter) → 3233 passed.
- `ruff check` on the touched files: no new findings (new `conftest.py` is clean).

Closes #480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
