### PR TITLE
feat(outreach): automate LinkedIn Catch-up trigger-event congratulations (closes #482)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -120,6 +120,15 @@ FEED_SCORE_W_RECIPROCITY=0.2
 FEED_SCORE_W_ACTIVITY=0.1
 # Recency exp-decay half-life in minutes for the score above (~1.0 under an hour at the default).
 FEED_RECENCY_HALFLIFE_MIN=180
+# LinkedIn Catch-up congratulations (issue #482). Moments scoring below this are tombstoned as
+# 'skipped' instead of drafted — job change / promotion / in-the-news / work anniversary clear 30 on
+# their own, education and birthday only for people matching the user's targeting.
+CATCHUP_MIN_SCORE=30
+# Congratulations text comes from LinkedIn's OWN pre-drafted response. When the card doesn't render a
+# suggestion chip we open LinkedIn's "Say congrats" composer, read the draft it pre-filled and close
+# it WITHOUT sending. Set false to stay strictly read-only on the card (we then use the built-in
+# per-milestone one-liner). Either way no LLM is called unless the user picks the AI message source.
+CATCHUP_HARVEST_LINKEDIN_DRAFT=true
 # Default best posting hour per weekday (Monday..Sunday, 24h user-local hours) used by the content
 # planner until a user has enough post-stats for personalized times. Default = the 2026 peak model.
 DEFAULT_POSTING_HOURS=16,15,16,17,11,10,18

--- a/compose/local/database/migrations/V20260724211808__add_catchup_touches.sql
+++ b/compose/local/database/migrations/V20260724211808__add_catchup_touches.sql
@@ -46,7 +46,9 @@ ALTER TABLE dm_followups
                            'work_anniversary','birthday','education','in_the_news') NOT NULL;
 
 -- Per-day cap for catch-up touches. Deliberately small (5) — these are personal congratulations, not a
--- campaign; they also count against max_dms_per_day at send time.
+-- campaign; they also count against max_dms_per_day at send time. 5/day is the ceiling on every plan;
+-- raising it to 10/day is a premium (professional/enterprise) feature, enforced in db.py at save AND
+-- send time (see max_catchup_touches_allowed).
 ALTER TABLE engagement_preferences
     ADD COLUMN max_catchup_touches_per_day INT NOT NULL DEFAULT 5;
 
@@ -55,7 +57,15 @@ ALTER TABLE engagement_preferences
 ALTER TABLE engagement_preferences
     ADD COLUMN catchup_touch_mode ENUM('pre_review','auto_approve') NOT NULL DEFAULT 'pre_review';
 
--- Which milestone types are eligible. Defaults to the BD-relevant subset (new job + promotion) so the
--- feature does not spray "Congrats!" at birthdays out of the box. JSON list of event_type values.
+-- Which milestone types are eligible. All six are user-configurable; the default is the BD-relevant
+-- subset (new job + promotion) so the feature does not spray "Congrats!" at birthdays out of the box.
+-- JSON list of event_type values.
 ALTER TABLE engagement_preferences
     ADD COLUMN catchup_event_types JSON NULL;
+
+-- Where the congratulations text comes from. 'linkedin' (default) uses LinkedIn's OWN pre-drafted
+-- response for the moment — the text LinkedIn already suggests in the catch-up card — with a
+-- deterministic per-milestone one-liner when the feed doesn't surface one. No LLM call at all.
+-- 'ai' opts into the DM-template + voice-refinement path for users who want more customization.
+ALTER TABLE engagement_preferences
+    ADD COLUMN catchup_message_source ENUM('linkedin','ai') NOT NULL DEFAULT 'linkedin';

--- a/compose/local/database/migrations/V20260724211808__add_catchup_touches.sql
+++ b/compose/local/database/migrations/V20260724211808__add_catchup_touches.sql
@@ -1,0 +1,61 @@
+-- LinkedIn Catch-up automation (issue #482): the /mynetwork/catch-up/ feed is a daily stream of network
+-- "moments" (new job, promotion, work anniversary, birthday, education, in the news). Those are classic
+-- trigger events — the warmest reason to reconnect — but a generic "Congrats!" at volume is worse than
+-- nothing, so this stays APPROVAL-GATED, ICP-SCORED, DAILY-CAPPED and DEDUPED.
+--
+-- One row per drafted touch. `event_period` is the dedup bucket for the milestone: annual events
+-- (birthday / work anniversary) bucket by YEAR, one-off events (job change / promotion / education /
+-- in the news) bucket by MONTH — so the same milestone can never be messaged twice no matter how many
+-- times it re-appears in the feed. Status mirrors connection_requests:
+--   pending  -> drafted, awaiting human approval
+--   approved -> approved, waiting for the capped scanner
+--   sending  -> scanner dispatched the send task
+--   sent     -> DM sent
+--   skipped  -> scored below the bar / event type disabled (kept as a dedup tombstone)
+--   failed   -> send failed
+--   canceled -> operator canceled before send
+CREATE TABLE IF NOT EXISTS catchup_touches (
+    id              INT AUTO_INCREMENT PRIMARY KEY,
+    user_id         INT NOT NULL,
+    profile_url     VARCHAR(512) NOT NULL,
+    person_name     VARCHAR(255) NULL,
+    event_type      ENUM('job_change','promotion','work_anniversary','birthday','education','in_the_news') NOT NULL,
+    event_detail    VARCHAR(512) NULL,   -- the moment text as scraped ("started a new position as ...")
+    event_period    VARCHAR(16) NOT NULL,  -- dedup bucket: 'YYYY' (annual) or 'YYYY-MM' (one-off)
+    score           INT NOT NULL DEFAULT 0,
+    message         TEXT NULL,           -- drafted congratulations DM, awaiting approval
+    status          ENUM('pending','approved','sending','sent','skipped','failed','canceled') NOT NULL DEFAULT 'pending',
+    created_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_catchup_touch (user_id, profile_url, event_type, event_period),
+    KEY idx_catchup_user_status (user_id, status),
+    KEY idx_catchup_status (status),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Route catch-up congratulations through the existing DM template + multi-touch follow-up machinery by
+-- adding one event_type per milestone. Preserves the existing enum values and appends the new ones, so a
+-- replying prospect drops straight into dm_followups (the value-first nurture toward a BD conversation).
+ALTER TABLE dm_templates
+    MODIFY event_type ENUM('connection_accepted','recommendation_received','collaboration',
+                           'profile_viewer','manual','funnel','job_change','promotion',
+                           'work_anniversary','birthday','education','in_the_news') NOT NULL;
+ALTER TABLE dm_followups
+    MODIFY event_type ENUM('connection_accepted','recommendation_received','collaboration',
+                           'profile_viewer','manual','funnel','job_change','promotion',
+                           'work_anniversary','birthday','education','in_the_news') NOT NULL;
+
+-- Per-day cap for catch-up touches. Deliberately small (5) — these are personal congratulations, not a
+-- campaign; they also count against max_dms_per_day at send time.
+ALTER TABLE engagement_preferences
+    ADD COLUMN max_catchup_touches_per_day INT NOT NULL DEFAULT 5;
+
+-- Approval posture. 'pre_review' (default) holds every drafted touch for explicit human approve/edit in
+-- the Catch-up review UI; 'auto_approve' queues drafts straight into the capped send drip.
+ALTER TABLE engagement_preferences
+    ADD COLUMN catchup_touch_mode ENUM('pre_review','auto_approve') NOT NULL DEFAULT 'pre_review';
+
+-- Which milestone types are eligible. Defaults to the BD-relevant subset (new job + promotion) so the
+-- feature does not spray "Congrats!" at birthdays out of the box. JSON list of event_type values.
+ALTER TABLE engagement_preferences
+    ADD COLUMN catchup_event_types JSON NULL;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -34,6 +34,10 @@ from cqc_lem.utilities.db import (
     get_lead_signals, get_lead_signal, update_lead_signal,
     count_new_lead_signals, LeadSignalStatus,
     get_leads, get_lead, update_lead, count_hot_leads, LeadStage,
+    get_catchup_touches, get_catchup_touch_user_id, update_catchup_touch,
+    update_catchup_touch_status, CatchupTouchStatus, CatchupEventType,
+    DEFAULT_CATCHUP_EVENT_TYPES, VALID_CATCHUP_TOUCH_MODES,
+    CATCHUP_TOUCHES_MIN, CATCHUP_TOUCHES_MAX,
     create_pin_for_email, verify_pin_for_email, delete_pin_for_email,
     create_session, get_session_user_id, delete_session,
     add_user_by_email, get_user_email, get_user_token_info, store_linkedin_li_at,
@@ -447,6 +451,24 @@ class OutreachTargetDeleteRequest(BaseModel):
     target_id: int
 
 
+# LinkedIn Catch-up touches (issue #482) — approval-gated milestone congratulations
+_LEN_CATCHUP_NAME = 255     # catchup_touches.person_name VARCHAR(255)
+_LEN_CATCHUP_MESSAGE = 1000  # catchup_touches.message (TEXT; app cap — a DM is refined to ≤300)
+
+
+class UpdateCatchupTouchRequest(BaseModel):
+    session_token: str
+    touch_id: int
+    person_name: Optional[str] = Field(default=None, max_length=_LEN_CATCHUP_NAME)
+    message: Optional[str] = Field(default=None, max_length=_LEN_CATCHUP_MESSAGE)
+    action: Optional[str] = None  # 'approve' | 'cancel' | None (save fields only)
+
+
+class CatchupTouchDeleteRequest(BaseModel):
+    session_token: str
+    touch_id: int
+
+
 class EngagementPreferencesRequest(BaseModel):
     session_token: str
     tone: Optional[str] = Field(default=None, max_length=_LEN_TONE)
@@ -482,6 +504,10 @@ class EngagementPreferencesRequest(BaseModel):
     reply_max_post_age_days: int = 2
     feed_fallback_when_empty: bool = True
     link_in_first_comment: bool = True
+    # Catch-up congratulations (issue #482)
+    max_catchup_touches_per_day: int = 5
+    catchup_touch_mode: str = "pre_review"  # 'pre_review' (default) | 'auto_approve'
+    catchup_event_types: List[str] = list(DEFAULT_CATCHUP_EVENT_TYPES)
 
     @field_validator("comment_length")
     @classmethod
@@ -531,6 +557,25 @@ class EngagementPreferencesRequest(BaseModel):
             return min(14, max(1, int(v)))
         except (TypeError, ValueError):
             return 2
+
+    @field_validator("catchup_touch_mode")
+    @classmethod
+    def _coerce_catchup_mode(cls, v: str) -> str:
+        return v if v in VALID_CATCHUP_TOUCH_MODES else "pre_review"
+
+    @field_validator("max_catchup_touches_per_day")
+    @classmethod
+    def _clamp_catchup_cap(cls, v: int) -> int:
+        try:
+            return min(CATCHUP_TOUCHES_MAX, max(CATCHUP_TOUCHES_MIN, int(v)))
+        except (TypeError, ValueError):
+            return 5
+
+    @field_validator("catchup_event_types")
+    @classmethod
+    def _clean_catchup_event_types(cls, v: List[str]) -> List[str]:
+        # Drop unknown milestone types at the boundary — the ledger column is a MySQL ENUM.
+        return [t for t in (v or []) if t in tuple(CatchupEventType)]
 
 
 class DmTemplateItem(BaseModel):
@@ -1974,6 +2019,55 @@ def refresh_leads_endpoint(request: LeadRefreshRequest) -> ResponseModel:
     from cqc_lem.app.run_scheduler import rebuild_leads_for_user
     rebuild_leads_for_user.apply_async(kwargs={"user_id": user_id})
     return ResponseModel(status_code=200, detail="Re-scoring your leads — refresh in a moment")
+
+
+@router.get("/catchup/touches")
+def list_catchup_touches_endpoint(session_token: str, status_filter: Optional[str] = None,
+                                  event_type_filter: Optional[str] = None, page: int = 1,
+                                  page_size: int = 25, sort_order: str = "desc") -> ResponseModel:
+    """Drafted LinkedIn Catch-up congratulations awaiting review (issue #482), highest-scoring first."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail=get_catchup_touches(
+        user_id, status_filter=status_filter, event_type_filter=event_type_filter,
+        page=page, page_size=page_size, sort_order=sort_order))
+
+
+@router.put("/catchup/touch")
+def update_catchup_touch_endpoint(request: UpdateCatchupTouchRequest) -> ResponseModel:
+    """Edit a drafted congratulations, or approve/cancel it. Approving queues it for the daily-capped
+    send drip; nothing is sent until a human approves (unless the account opted into auto-approve)."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if get_catchup_touch_user_id(request.touch_id) != user_id:
+        raise HTTPException(status_code=404, detail="Catch-up touch not found")
+    action_map = {"approve": CatchupTouchStatus.APPROVED, "cancel": CatchupTouchStatus.CANCELED}
+    if request.action is not None and request.action not in action_map:
+        raise HTTPException(status_code=422,
+                            detail=f"Unknown action '{request.action}' — expected 'approve' or 'cancel'")
+    status = action_map.get(request.action)
+    if status is None and all(v is None for v in (request.message, request.person_name)):
+        raise HTTPException(status_code=422, detail="Nothing to update — provide at least one field or an action")
+    if not update_catchup_touch(request.touch_id, message=request.message,
+                                person_name=request.person_name, status=status):
+        raise HTTPException(status_code=500, detail="Could not update catch-up touch")
+    return ResponseModel(status_code=200, detail="Catch-up touch updated")
+
+
+@router.delete("/catchup/touch")
+def delete_catchup_touch_endpoint(request: CatchupTouchDeleteRequest) -> ResponseModel:
+    """Cancel a drafted catch-up touch (soft — sets status 'canceled' so it won't be sent, and the
+    row stays as the dedup tombstone for that milestone)."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if get_catchup_touch_user_id(request.touch_id) != user_id:
+        raise HTTPException(status_code=404, detail="Catch-up touch not found")
+    if not update_catchup_touch_status(request.touch_id, CatchupTouchStatus.CANCELED):
+        raise HTTPException(status_code=500, detail="Could not cancel catch-up touch")
+    return ResponseModel(status_code=200, detail="Catch-up touch canceled")
 
 
 class GroupTogglesRequest(BaseModel):

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -36,8 +36,9 @@ from cqc_lem.utilities.db import (
     get_leads, get_lead, update_lead, count_hot_leads, LeadStage,
     get_catchup_touches, get_catchup_touch_user_id, update_catchup_touch,
     update_catchup_touch_status, CatchupTouchStatus, CatchupEventType,
-    DEFAULT_CATCHUP_EVENT_TYPES, VALID_CATCHUP_TOUCH_MODES,
-    CATCHUP_TOUCHES_MIN, CATCHUP_TOUCHES_MAX,
+    DEFAULT_CATCHUP_EVENT_TYPES, VALID_CATCHUP_TOUCH_MODES, VALID_CATCHUP_MESSAGE_SOURCES,
+    CATCHUP_TOUCHES_MIN, CATCHUP_TOUCHES_MAX, CATCHUP_TOUCHES_MAX_STANDARD,
+    max_catchup_touches_allowed,
     create_pin_for_email, verify_pin_for_email, delete_pin_for_email,
     create_session, get_session_user_id, delete_session,
     add_user_by_email, get_user_email, get_user_token_info, store_linkedin_li_at,
@@ -505,9 +506,10 @@ class EngagementPreferencesRequest(BaseModel):
     feed_fallback_when_empty: bool = True
     link_in_first_comment: bool = True
     # Catch-up congratulations (issue #482)
-    max_catchup_touches_per_day: int = 5
+    max_catchup_touches_per_day: int = CATCHUP_TOUCHES_MAX_STANDARD
     catchup_touch_mode: str = "pre_review"  # 'pre_review' (default) | 'auto_approve'
     catchup_event_types: List[str] = list(DEFAULT_CATCHUP_EVENT_TYPES)
+    catchup_message_source: str = "linkedin"  # 'linkedin' (LinkedIn's own draft) | 'ai'
 
     @field_validator("comment_length")
     @classmethod
@@ -563,13 +565,20 @@ class EngagementPreferencesRequest(BaseModel):
     def _coerce_catchup_mode(cls, v: str) -> str:
         return v if v in VALID_CATCHUP_TOUCH_MODES else "pre_review"
 
+    @field_validator("catchup_message_source")
+    @classmethod
+    def _coerce_catchup_message_source(cls, v: str) -> str:
+        return v if v in VALID_CATCHUP_MESSAGE_SOURCES else "linkedin"
+
     @field_validator("max_catchup_touches_per_day")
     @classmethod
     def _clamp_catchup_cap(cls, v: int) -> int:
+        # Absolute ceiling only — the per-plan allowance (10/day premium, 5/day otherwise) is applied
+        # in update_engagement_preferences, which knows the user.
         try:
             return min(CATCHUP_TOUCHES_MAX, max(CATCHUP_TOUCHES_MIN, int(v)))
         except (TypeError, ValueError):
-            return 5
+            return CATCHUP_TOUCHES_MAX_STANDARD
 
     @field_validator("catchup_event_types")
     @classmethod
@@ -1525,6 +1534,9 @@ def get_engagement_preferences_endpoint(session_token: str) -> ResponseModel:
         prefs["reply_inbound_address"] = None
     # Gmail forwarding auto-confirmation status (so the UI can surface the code if auto-confirm failed).
     prefs["gmail_forward_confirmation"] = get_gmail_forward_confirmation(user_id)
+    # Read-only: the highest catch-up cap this plan allows, so the UI can bound the input and show
+    # what upgrading unlocks (10/day is premium-only).
+    prefs["max_catchup_touches_allowed"] = max_catchup_touches_allowed(user_id)
     # Read-only: the last feed scan's reach funnel so the user can see when their targeting is too
     # strict (posts examined -> matched their filters -> commented).
     try:

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -34,7 +34,7 @@ from cqc_lem.utilities.db import (
     get_lead_signals, get_lead_signal, update_lead_signal,
     count_new_lead_signals, LeadSignalStatus,
     get_leads, get_lead, update_lead, count_hot_leads, LeadStage,
-    get_catchup_touches, get_catchup_touch_user_id, update_catchup_touch,
+    get_catchup_touches, get_catchup_touch, get_catchup_touch_user_id, update_catchup_touch,
     update_catchup_touch_status, CatchupTouchStatus, CatchupEventType,
     DEFAULT_CATCHUP_EVENT_TYPES, VALID_CATCHUP_TOUCH_MODES, VALID_CATCHUP_MESSAGE_SOURCES,
     CATCHUP_TOUCHES_MIN, CATCHUP_TOUCHES_MAX, CATCHUP_TOUCHES_MAX_STANDARD,
@@ -2053,7 +2053,8 @@ def update_catchup_touch_endpoint(request: UpdateCatchupTouchRequest) -> Respons
     user_id = get_session_user_id(request.session_token)
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
-    if get_catchup_touch_user_id(request.touch_id) != user_id:
+    touch = get_catchup_touch(request.touch_id)
+    if not touch or touch.get("user_id") != user_id:
         raise HTTPException(status_code=404, detail="Catch-up touch not found")
     action_map = {"approve": CatchupTouchStatus.APPROVED, "cancel": CatchupTouchStatus.CANCELED}
     if request.action is not None and request.action not in action_map:
@@ -2062,6 +2063,12 @@ def update_catchup_touch_endpoint(request: UpdateCatchupTouchRequest) -> Respons
     status = action_map.get(request.action)
     if status is None and all(v is None for v in (request.message, request.person_name)):
         raise HTTPException(status_code=422, detail="Nothing to update — provide at least one field or an action")
+    if request.message is not None and not request.message.strip():
+        raise HTTPException(status_code=422, detail="Message cannot be empty")
+    # Approving is what queues the send, and send_catchup_touch turns a blank message into a permanent
+    # SKIPPED — so an approval must always land on a real message, saved now or already stored.
+    if status == CatchupTouchStatus.APPROVED and not (request.message or touch.get("message") or "").strip():
+        raise HTTPException(status_code=422, detail="Add a message before approving this catch-up touch")
     if not update_catchup_touch(request.touch_id, message=request.message,
                                 person_name=request.person_name, status=status):
         raise HTTPException(status_code=500, detail="Could not update catch-up touch")

--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -117,6 +117,8 @@ task_routes = {
     'cqc_lem.app.run_automation.update_stale_profile': {'queue': 'se_outreach'},
     'cqc_lem.app.run_automation.send_lead_response': {'queue': 'se_outreach'},
     'cqc_lem.app.run_automation.scan_connection_candidates': {'queue': 'se_outreach'},
+    'cqc_lem.app.run_automation.automate_catchup_touches': {'queue': 'se_outreach'},
+    'cqc_lem.app.run_automation.send_catchup_touch': {'queue': 'se_outreach'},
     # --- se_content: seeding, stats, group + newsletter publishing --------
     'cqc_lem.app.run_automation.auto_seed_comment_on_post': {'queue': 'se_content'},
     'cqc_lem.app.run_automation.auto_scrape_post_stats': {'queue': 'se_content'},

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -103,6 +103,17 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_process_outreach_funnel',
             'schedule': crontab(minute='*/30')  # Advance approved comment->connect->DM funnel steps
         },
+        'scan-catchup-moments': {
+            'task': 'cqc_lem.app.run_scheduler.auto_scan_catchup_moments',
+            # Daily draft-only pass over the LinkedIn Catch-up feed (issue #482). Nothing sends here —
+            # it queues approval-gated congratulations for the review UI.
+            'schedule': crontab(hour='12', minute='30')
+        },
+        'send-catchup-touches': {
+            'task': 'cqc_lem.app.run_scheduler.auto_check_catchup_touches',
+            # Slow drip of APPROVED catch-up congratulations, per-user daily capped
+            'schedule': crontab(minute='*/20')
+        },
         'daily-golden-hour-engagement': {
             'task': 'cqc_lem.app.run_scheduler.auto_daily_engagement',
             'schedule': crontab(hour='13', minute='0')  # Daily peak-hour feed commenting (~9am ET), on top of pre-post

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -45,13 +45,15 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     get_dm_template, enqueue_followup, get_due_followups, mark_followup, stop_followups_for_profile, \
     set_profile_synthesis, get_duplicate_comment_posts, count_dms_sent_today, \
     get_approved_outreach_targets, update_outreach_target, update_outreach_target_status, \
-    OutreachStage, OutreachStatus, \
+    OutreachStage, OutreachStatus, insert_outreach_target, get_outreach_target_by_url, \
     insert_lead_signal, has_lead_signal, get_lead_signal, update_lead_signal, \
     LeadSignalSource, LeadSignalChannel, LeadSignalStatus, \
     insert_scheduled_dm, has_open_scheduled_dm, count_scheduled_dms_created_today, \
     ScheduledDmStatus, SCHEDULED_DM_SOURCE_NURTURE, \
     insert_connection_request, count_open_connection_requests, get_requested_person_keys, \
-    get_engager_candidates, get_profile_facts, count_invites_sent_today, ConnectionRequestStatus
+    get_engager_candidates, get_profile_facts, count_invites_sent_today, ConnectionRequestStatus, \
+    CatchupTouchStatus, insert_catchup_touch, has_catchup_touch, get_catchup_touch, \
+    update_catchup_touch_status, count_catchup_touches_sent_today
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
     load_profile_for_user
@@ -68,7 +70,7 @@ from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
     get_element_wait_retry, get_elements_as_list_wait_stale, getText, close_tab, get_driver_wait_pair, quit_gracefully, \
     wait_for_ajax, find_first, click_first, find_all_first
 from dotenv import load_dotenv
-from selenium.common import NoSuchElementException, JavascriptException
+from selenium.common import NoSuchElementException, JavascriptException, StaleElementReferenceException
 from selenium.webdriver import ActionChains, Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -2747,37 +2749,42 @@ class _SafePlaceholders(dict):
 
 
 def render_dm_placeholders(text: str, *, first_name: str = "", headline: str = "",
-                           blog_url: str = "") -> str:
+                           blog_url: str = "", event_detail: str = "") -> str:
     """Single source of truth for filling DM / lead-magnet {placeholders}: {first_name},
-    {headline}, {blog_url}. Used by BOTH the DM-template path and the Comment->DM lead magnet
-    so their substitution can never drift. Tolerates unknown/malformed tokens gracefully."""
+    {headline}, {blog_url}, {event_detail}. Used by BOTH the DM-template path and the Comment->DM
+    lead magnet so their substitution can never drift. Tolerates unknown/malformed tokens gracefully."""
     if not text:
         return text or ""
     ctx = _SafePlaceholders(first_name=first_name or "there",
                             headline=headline or "my professional field",
-                            blog_url=blog_url or "")
+                            blog_url=blog_url or "",
+                            # Catch-up templates (issue #482) reference the specific milestone; the
+                            # fallback keeps the sentence grammatical if the detail didn't scrape.
+                            event_detail=event_detail or "the news")
     try:
         return text.format_map(ctx)
     except (IndexError, ValueError):
         # malformed/positional braces (e.g. a stray "{") — replace known tokens only
         out = text
-        for k in ("first_name", "headline", "blog_url"):
+        for k in ("first_name", "headline", "blog_url", "event_detail"):
             out = out.replace("{" + k + "}", str(ctx[k]))
         return out
 
 
 @attribute_llm_cost(FEATURE_DM)
 def build_dm_from_template(user_id: int, event_type: str, first_name: str,
-                           my_profile: LinkedInProfile, step: int = 0, blog_url: str = "") -> "str | None":
-    """Render the user's DM template for an event (filling {first_name}/{headline}/{blog_url})
-    and LLM-refine it to their voice (<=300 chars). Falls back to the code-default template;
-    returns None only when no template exists for that (event, step)."""
+                           my_profile: LinkedInProfile, step: int = 0, blog_url: str = "",
+                           event_detail: str = "") -> "str | None":
+    """Render the user's DM template for an event (filling {first_name}/{headline}/{blog_url}/
+    {event_detail}) and LLM-refine it to their voice (<=300 chars). Falls back to the code-default
+    template; returns None only when no template exists for that (event, step)."""
     tmpl = get_dm_template(user_id, event_type, step)
     if not tmpl:
         return None
     headline = getattr(my_profile, "job_title", None) or "my professional field"
     rendered = render_dm_placeholders(tmpl["template_text"], first_name=first_name,
-                                      headline=headline, blog_url=blog_url)
+                                      headline=headline, blog_url=blog_url,
+                                      event_detail=event_detail)
     try:
         refined = get_ai_message_refinement(rendered, character_limit=300)
         # Humanization pass (issue #416 — A5): de-slop the DM before it's sent. Fails open and keeps
@@ -3008,6 +3015,11 @@ def process_user_followups(self, user_id: int, max_per_run: int = 20):
                 if _nurture_after_reply(user_id, f, their_message, my_profile,
                                         prefs=lead_ctx["prefs"], profile_synthesis=lead_ctx["synthesis"]):
                     nurtured += 1
+                elif not is_stop_intent(classify_reply_intent(their_message, use_llm=False)["intent"]):
+                    # Nurture (#485) owns the drafted next message whenever it produced one, so the
+                    # catch-up funnel hand-off (#482) is the fallback — one approval-gated draft per
+                    # replying prospect, and none at all when their reply was an explicit no.
+                    _route_replied_catchup_to_funnel(user_id, f)
                 continue
             if str(f["event_type"]) == NURTURE_EVENT_TYPE:
                 # A nurture re-check with no new reply. Nothing to send: the drafted message is the
@@ -4142,6 +4154,339 @@ def process_outreach_funnel(self, user_id: int, max_per_run: int = 25):
             update_outreach_target_status(target["id"], OutreachStatus.FAILED)
             results.append(f"target {target['id']}: error")
     return "; ".join(results)
+
+
+# --- LinkedIn Catch-up automation (issue #482) — trigger-event congratulations, approval-gated ---
+# The catch-up feed is a daily stream of network "moments". New job / promotion moments are genuine
+# trigger events (a reason to reconnect that isn't salesy); birthdays are small talk. So every moment
+# is CLASSIFIED, ICP-SCORED against the user's targeting prefs, DEDUPED on the milestone, drafted from
+# the user's own DM template, and held for human approval before a single message goes out.
+CATCHUP_URL = "https://www.linkedin.com/mynetwork/catch-up/all/"
+# Moments scoring below this are recorded as 'skipped' tombstones (dedup) instead of drafted — a
+# generic "Congrats!" is worse than saying nothing.
+CATCHUP_MIN_SCORE = int(os.getenv("CATCHUP_MIN_SCORE", "30"))
+
+# Ordered fallback chain for the catch-up cards. LinkedIn's SDUI ships hashed classes, so we prefer
+# data-view-name, then the semantic list, then any main-content list item that links to a profile.
+# NOTE: needs a supervised live-grounding pass on a real account before broad enablement (see #478).
+_CATCHUP_CARD_LOCATORS = [
+    (By.CSS_SELECTOR, "div[data-view-name='catch-up-card']"),
+    (By.CSS_SELECTOR, "li[data-view-name='catch-up-card']"),
+    (By.CSS_SELECTOR, "section[data-view-name*='catch-up'] li"),
+    (By.CSS_SELECTOR, "main li:has(a[href*='/in/'])"),
+    (By.XPATH, "//main//li[.//a[contains(@href,'/in/')]]"),
+]
+_CATCHUP_PROFILE_LINK_LOCATORS = [
+    (By.CSS_SELECTOR, "a[data-view-name='catch-up-card-profile-link']"),
+    (By.CSS_SELECTOR, "a[href*='/in/']"),
+]
+
+# Base value of each milestone type. New job / promotion are the BD goldmine; a birthday is not.
+# Read together with CATCHUP_MIN_SCORE (30): job change, promotion, in-the-news and work anniversary
+# clear the bar on their own, while education and birthday only clear it for people who also match the
+# user's targeting (+25 literal / +15 LLM topical). So enabling "birthday" means "congratulate the
+# birthdays of people in my ICP", not "congratulate everyone's birthday".
+_CATCHUP_EVENT_BASE = {
+    "job_change": 50,
+    "promotion": 50,
+    "in_the_news": 35,
+    "work_anniversary": 30,
+    "education": 25,
+    "birthday": 10,
+}
+_CATCHUP_ICP_BONUS = 25    # a targeting keyword/topic appears in the moment text
+_CATCHUP_TOPIC_BONUS = 15  # LLM says the moment is topically relevant to the user's include_topics
+
+# Ordered classifiers — first match wins, so more specific phrasings are tested first ("promoted to X
+# at Y" and "celebrating 5 years at Y" both contain the new-position "at" pattern).
+_CATCHUP_CLASSIFIERS = [
+    ("promotion", re.compile(r"\bpromot(?:ed|ion)\b", re.IGNORECASE)),
+    ("work_anniversary", re.compile(r"work anniversary|\b\d+\s*(?:year|yr)s?\b\s*(?:at|with)\b", re.IGNORECASE)),
+    ("job_change", re.compile(r"start\w*\s+a\s+new\s+(?:position|job|role)|new\s+(?:position|role|job)\s+(?:as|at)\b"
+                              r"|\bis\s+now\b.*\bat\b|\bjoined\b.*\bas\b", re.IGNORECASE)),
+    ("birthday", re.compile(r"\bbirthday\b", re.IGNORECASE)),
+    ("education", re.compile(r"\bgraduat\w*|\bearned\b.*\b(?:degree|diploma|certificat\w*)"
+                             r"|\bcomplet\w*\b.*\b(?:degree|program|certificat\w*)", re.IGNORECASE)),
+    ("in_the_news", re.compile(r"in the news|\bwas\s+(?:featured|mentioned|quoted)\b|\bfeatured in\b",
+                               re.IGNORECASE)),
+]
+
+# Annual milestones dedup by YEAR; one-off milestones by MONTH (so a genuinely new job change later in
+# the year can still earn a touch, but the same card re-appearing for days cannot).
+_CATCHUP_ANNUAL_EVENTS = ("work_anniversary", "birthday")
+# The milestone types worth nurturing toward a real BD conversation once they reply.
+_CATCHUP_HIGH_VALUE_EVENTS = ("job_change", "promotion")
+
+
+def _normalize_profile_url(url: str) -> str:
+    """Strip query/fragment/trailing slash so the same person can't enter the dedup ledger twice
+    under two URL spellings (LinkedIn appends tracking params to catch-up links)."""
+    if not url:
+        return ""
+    parsed = urlparse(url.strip())
+    path = (parsed.path or "").rstrip("/")
+    if parsed.scheme and parsed.netloc:
+        return f"{parsed.scheme}://{parsed.netloc}{path}"
+    return path
+
+
+def _classify_catchup_moment(text: str) -> "str | None":
+    """Map a catch-up card's text to a CatchupEventType value, or None when it isn't a moment we
+    know how to congratulate (LinkedIn also renders suggestions/ads in this feed)."""
+    if not text:
+        return None
+    for event_type, pattern in _CATCHUP_CLASSIFIERS:
+        if pattern.search(text):
+            return event_type
+    return None
+
+
+def _catchup_event_period(event_type: str, now: datetime = None) -> str:
+    """Dedup bucket for a milestone — see _CATCHUP_ANNUAL_EVENTS."""
+    moment = now or datetime.now(timezone.utc)
+    return moment.strftime("%Y") if event_type in _CATCHUP_ANNUAL_EVENTS else moment.strftime("%Y-%m")
+
+
+def _catchup_excluded(moment: dict, prefs: dict) -> bool:
+    """Honor the user's exclusion targeting — an excluded author/keyword is never touched at all."""
+    haystack = f"{moment.get('name', '')} {moment.get('text', '')}".lower()
+    for author in (prefs.get("exclude_authors") or []):
+        if str(author).strip() and str(author).strip().lower() in (moment.get("name") or "").lower():
+            return True
+    for term in list(prefs.get("exclude_keywords") or []) + list(prefs.get("exclude_topics") or []):
+        if str(term).strip() and str(term).strip().lower() in haystack:
+            return True
+    return False
+
+
+def _score_catchup_moment(moment: dict, prefs: dict) -> int:
+    """Score = milestone value + ICP fit. The literal keyword check is free; the LLM relevance check
+    only runs when the literal one missed AND the user configured include_topics, so scoring a day's
+    feed costs at most a handful of lem-simple calls."""
+    score = _CATCHUP_EVENT_BASE.get(moment.get("event_type"), 0)
+    haystack = f"{moment.get('name', '')} {moment.get('text', '')}".lower()
+    literal_terms = (list(prefs.get("focus_topics") or []) + list(prefs.get("include_keywords") or [])
+                     + list(prefs.get("include_topics") or []))
+    if any(str(t).strip() and str(t).strip().lower() in haystack for t in literal_terms):
+        return score + _CATCHUP_ICP_BONUS
+    include_topics = prefs.get("include_topics") or []
+    if include_topics and post_is_relevant(moment.get("text", ""), include_topics):
+        score += _CATCHUP_TOPIC_BONUS
+    return score
+
+
+def _card_profile_link(card: WebElement) -> "WebElement | None":
+    """First profile link inside a catch-up card, trying the ordered locator chain. Searched directly
+    (no WebDriverWait) because the card is already in the DOM — a per-card wait would cost the full
+    timeout on every non-person card LinkedIn mixes into the feed."""
+    for find_by, value in _CATCHUP_PROFILE_LINK_LOCATORS:
+        try:
+            els = card.find_elements(find_by, value)
+        except (StaleElementReferenceException, NoSuchElementException):
+            continue
+        if els:
+            return els[0]
+    return None
+
+
+def _scrape_catchup_moments(driver: WebDriver, max_moments: int = 40,
+                            user_id: int = None) -> List[dict]:
+    """Scrape the catch-up feed into [{name, profile_url, text}] — one entry per card, deduped by
+    profile+text. Best-effort by design: a selector miss returns fewer moments (logged) rather than
+    failing the run."""
+    driver.get(CATCHUP_URL)
+    time.sleep(random.uniform(3, 5))
+
+    moments: List[dict] = []
+    seen: set = set()
+    for _ in range(3):  # the feed lazy-loads; a few scrolls cover a normal day's moments
+        cards = find_all_first(driver, _CATCHUP_CARD_LOCATORS)
+        for card in cards:
+            if len(moments) >= max_moments:
+                break
+            link = _card_profile_link(card)
+            if link is None:
+                continue
+            try:
+                profile_url = _normalize_profile_url(link.get_attribute("href") or "")
+                text = normalize_public_text(getText(card) or "").replace("\n", " ").strip()
+            except (StaleElementReferenceException, NoSuchElementException):
+                continue
+            if not profile_url or "/in/" not in profile_url or not text:
+                continue
+            key = (profile_url, text)
+            if key in seen:
+                continue
+            seen.add(key)
+            moments.append({"name": _catchup_name_from_card(text, link), "profile_url": profile_url,
+                            "text": text})
+        if len(moments) >= max_moments:
+            break
+        driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
+        time.sleep(random.uniform(2, 4))
+
+    if not moments:
+        log_warning("Catch-up feed produced no moments", user_id=user_id, action_type="catchup")
+    return moments
+
+
+def _catchup_name_from_card(text: str, link) -> str:
+    """The card's person name: the profile link's own text when LinkedIn renders it, else the first
+    line of the card (which leads with the name)."""
+    try:
+        name = (getText(link) or "").strip().split("\n")[0]
+    except (StaleElementReferenceException, NoSuchElementException):
+        name = ""
+    if not name:
+        name = (text or "").strip().split(" ·")[0]
+    return name[:255]
+
+
+def _draft_catchup_message(user_id: int, moment: dict, my_profile: LinkedInProfile) -> "str | None":
+    """Render the user's DM template for this milestone type, in their voice, referencing the actual
+    event. Returns None when the user has deactivated the template for that event type."""
+    first_name = (moment.get("name") or "").strip().split(" ")[0] or "there"
+    return build_dm_from_template(user_id, moment["event_type"], first_name, my_profile,
+                                  event_detail=moment.get("event_detail") or moment.get("text", ""))
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  reject_on_worker_lost=True, rate_limit='2/m', queue='se_outreach')
+def automate_catchup_touches(self, user_id: int, max_moments: int = 40, max_drafts: int = 10):
+    """Scrape -> score -> draft the user's LinkedIn Catch-up congratulations (issue #482).
+
+    NOTHING is sent here. Qualifying moments become 'pending' rows in catchup_touches for human
+    approval (or 'approved' when the user opted into catchup_touch_mode='auto_approve'), and the
+    capped scanner sends them later. Only milestone types the user enabled are drafted, each
+    milestone is deduped on (person, event_type, period), and moments scoring below CATCHUP_MIN_SCORE
+    are tombstoned as 'skipped' so we neither draft nor re-score them."""
+    prefs = get_engagement_preferences(user_id)
+    enabled = {str(t) for t in (prefs.get("catchup_event_types") or [])}
+    if not enabled:
+        return f"Catch-up touches disabled for user {user_id} (no event types enabled)"
+
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id,
+                                                                   session_name="Catch-up Moments")
+    except LinkedInRateLimited as e:
+        myprint(f"automate_catchup_touches deferred (throttled): {e}")
+        return "Catch-up scan deferred (LinkedIn throttled)"
+    except Exception as e:
+        log_error("Failed to get profile for catch-up scan", exc=e, user_id=user_id,
+                  task_name="automate_catchup_touches")
+        return f"Failed to start catch-up scan: {e}"
+
+    drafted = skipped = 0
+    try:
+        moments = _scrape_catchup_moments(driver, max_moments=max_moments, user_id=user_id)
+    except LinkedInRateLimited as e:
+        myprint(f"automate_catchup_touches deferred mid-scrape (throttled): {e}")
+        return "Catch-up scan deferred (LinkedIn throttled)"
+    except Exception as e:
+        log_error("Catch-up scrape failed", exc=e, user_id=user_id, task_name="automate_catchup_touches")
+        return f"Catch-up scrape failed: {e}"
+    finally:
+        quit_gracefully(driver)
+
+    auto_approve = str(prefs.get("catchup_touch_mode") or "pre_review") == "auto_approve"
+    for moment in moments:
+        if drafted >= max_drafts:
+            break
+        event_type = _classify_catchup_moment(moment.get("text", ""))
+        if event_type is None or event_type not in enabled:
+            continue
+        if _catchup_excluded(moment, prefs):
+            continue
+        moment["event_type"] = event_type
+        period = _catchup_event_period(event_type)
+        if has_catchup_touch(user_id, moment["profile_url"], event_type, period):
+            continue
+        score = _score_catchup_moment(moment, prefs)
+        if score < CATCHUP_MIN_SCORE:
+            insert_catchup_touch(user_id, moment["profile_url"], event_type, period,
+                                 person_name=moment.get("name"), event_detail=moment.get("text"),
+                                 score=score, status=CatchupTouchStatus.SKIPPED)
+            skipped += 1
+            continue
+        try:
+            message = _draft_catchup_message(user_id, moment, my_profile)
+        except Exception as e:
+            log_warning("Could not draft catch-up message", exc=e, user_id=user_id, action_type="catchup")
+            continue
+        if not message:
+            continue
+        status = CatchupTouchStatus.APPROVED if auto_approve else CatchupTouchStatus.PENDING
+        if insert_catchup_touch(user_id, moment["profile_url"], event_type, period,
+                                person_name=moment.get("name"), event_detail=moment.get("text"),
+                                message=message, score=score, status=status):
+            drafted += 1
+
+    log_info(f"Catch-up scan drafted {drafted} touch(es) from {len(moments)} moment(s)",
+             user_id=user_id, task_name="automate_catchup_touches", action_type="catchup")
+    return (f"Catch-up: {len(moments)} moment(s) scanned, {drafted} drafted "
+            f"({'approved' if auto_approve else 'awaiting approval'}), {skipped} below the bar")
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'keys': ['touch_id']},
+                  reject_on_worker_lost=True, rate_limit='1/m', queue='se_outreach')
+def send_catchup_touch(self, touch_id: int):
+    """Send one APPROVED catch-up congratulations (issue #482). Enforces BOTH the catch-up per-day cap
+    and the overall DM cap at send time — either one trips the touch back to 'approved' for the next
+    scan rather than sending — and reuses send_dm_now, so it honors the 429 breaker / kill-switch and
+    the shared DM logging. A high-value milestone also enqueues the user's follow-up sequence, which is
+    what routes a replying prospect into the BD nurture."""
+    touch = get_catchup_touch(touch_id)
+    if not touch or touch["status"] not in (CatchupTouchStatus.APPROVED, CatchupTouchStatus.SENDING):
+        return f"Catch-up touch {touch_id} not sendable (status={touch['status'] if touch else 'missing'})"
+    if not (touch.get("message") or "").strip():
+        update_catchup_touch_status(touch_id, CatchupTouchStatus.SKIPPED)
+        log_warning("Catch-up touch approved with no message; skipping", user_id=touch["user_id"],
+                    action_type="catchup")
+        return f"Catch-up touch {touch_id} skipped (no message)"
+
+    user_id = touch["user_id"]
+    prefs = get_engagement_preferences(user_id)
+    if count_catchup_touches_sent_today(user_id) >= int(prefs.get("max_catchup_touches_per_day") or 0):
+        update_catchup_touch_status(touch_id, CatchupTouchStatus.APPROVED)  # retry on the next scan
+        return f"Catch-up touch {touch_id} deferred (daily catch-up cap reached)"
+    if count_dms_sent_today(user_id) >= int(prefs.get("max_dms_per_day") or 0):
+        update_catchup_touch_status(touch_id, CatchupTouchStatus.APPROVED)
+        return f"Catch-up touch {touch_id} deferred (daily DM cap reached)"
+
+    try:
+        sent = send_dm_now(user_id, touch["profile_url"], touch["message"])
+    except LinkedInRateLimited as e:
+        myprint(f"send_catchup_touch: throttled, deferring {touch_id}: {e}")
+        update_catchup_touch_status(touch_id, CatchupTouchStatus.APPROVED)
+        return f"Catch-up touch {touch_id} deferred (LinkedIn throttled)"
+    update_catchup_touch_status(touch_id, CatchupTouchStatus.SENT if sent else CatchupTouchStatus.FAILED)
+    if sent:
+        first_name = (touch.get("person_name") or "").strip().split(" ")[0] or "there"
+        enqueue_next_followup(user_id, touch["profile_url"], first_name, str(touch["event_type"]), 0)
+    return f"Catch-up touch {touch_id} -> {'sent' if sent else 'failed'}"
+
+
+def _route_replied_catchup_to_funnel(user_id: int, followup: dict) -> None:
+    """A reply to a new-job/promotion congratulations is the opening of a real conversation — drop that
+    prospect into the comment-first outreach funnel at the DM stage as 'pending' so the operator can
+    nurture it toward a BD conversation (issue #482, step 5). Approval-gated like every funnel stage,
+    and never duplicates a target already in the funnel. Best-effort: never breaks the follow-up loop."""
+    event_type = str(followup.get("event_type") or "")
+    if event_type not in _CATCHUP_HIGH_VALUE_EVENTS:
+        return
+    profile_url = followup.get("profile_url")
+    try:
+        if get_outreach_target_by_url(user_id, profile_url):
+            return
+        target = {"target_name": followup.get("first_name"), "target_profile_url": profile_url}
+        insert_outreach_target(user_id, profile_url, target_name=followup.get("first_name"),
+                               draft_text=_draft_funnel_stage(user_id, OutreachStage.DM, target),
+                               stage=OutreachStage.DM, status=OutreachStatus.PENDING)
+        log_info("Routed replying catch-up prospect into the outreach funnel", user_id=user_id,
+                 action_type="catchup")
+    except Exception as e:
+        log_warning("Could not route catch-up reply into the outreach funnel", exc=e,
+                    user_id=user_id, action_type="catchup")
 
 
 def final_method(drivers: List[WebDriver]):

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -4261,6 +4261,9 @@ _CATCHUP_CLASSIFIERS = [
 _CATCHUP_ANNUAL_EVENTS = ("work_anniversary", "birthday")
 # The milestone types worth nurturing toward a real BD conversation once they reply.
 _CATCHUP_HIGH_VALUE_EVENTS = ("job_change", "promotion")
+# How long after a high-value congratulations we check whether they replied, when the user configured
+# no step-1 follow-up template of their own. Long enough that a same-day reply has landed.
+CATCHUP_REPLY_CHECK_HOURS = int(os.getenv("CATCHUP_REPLY_CHECK_HOURS", "48"))
 
 
 def _normalize_profile_url(url: str) -> str:
@@ -4404,8 +4407,10 @@ def _dismiss_catchup_composer(driver: WebDriver) -> None:
                 return
         ActionChains(driver).send_keys(Keys.ESCAPE).perform()
     except (StaleElementReferenceException, NoSuchElementException, ElementNotInteractableException,
-            WebDriverException):
-        pass
+            WebDriverException) as e:
+        # Nothing to recover: the overlay is already gone or unreachable, and the very next action is
+        # a fresh driver.get() of the catch-up feed. Logged only, so a dismiss miss never fails a scan.
+        log_warning("Could not dismiss the catch-up composer", exc=e, action_type="catchup")
 
 
 def _scrape_catchup_moments(driver: WebDriver, max_moments: int = 40, user_id: int = None,
@@ -4606,8 +4611,29 @@ def send_catchup_touch(self, touch_id: int):
     update_catchup_touch_status(touch_id, CatchupTouchStatus.SENT if sent else CatchupTouchStatus.FAILED)
     if sent:
         first_name = (touch.get("person_name") or "").strip().split(" ")[0] or "there"
-        enqueue_next_followup(user_id, touch["profile_url"], first_name, str(touch["event_type"]), 0)
+        _schedule_catchup_followup(user_id, touch["profile_url"], first_name, str(touch["event_type"]))
     return f"Catch-up touch {touch_id} -> {'sent' if sent else 'failed'}"
+
+
+def _schedule_catchup_followup(user_id: int, profile_url: str, first_name: str, event_type: str) -> None:
+    """Queue the dm_followups row that process_user_followups works off after a congratulations goes out.
+
+    When the user configured a step-1 template this is the normal follow-up sequence. When they didn't
+    — the out-of-the-box case, since the catch-up defaults only cover step 0 — a high-value milestone
+    STILL needs the row, because the reply check it drives is what routes a replying prospect into the
+    outreach funnel (#482, step 5). With no template build_dm_from_template returns None, so that row
+    only ever checks for a reply and is then stopped; it can never send an extra DM."""
+    try:
+        if get_dm_template(user_id, event_type, 1):
+            enqueue_next_followup(user_id, profile_url, first_name, event_type, 0)
+            return
+        if event_type not in _CATCHUP_HIGH_VALUE_EVENTS:
+            return
+        due = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=CATCHUP_REPLY_CHECK_HOURS)
+        enqueue_followup(user_id, profile_url, first_name, event_type, 1, due)
+    except Exception as e:
+        log_warning("Could not schedule the catch-up reply check", exc=e, user_id=user_id,
+                    action_type="catchup")
 
 
 def _route_replied_catchup_to_funnel(user_id: int, followup: dict) -> None:

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -53,7 +53,7 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     insert_connection_request, count_open_connection_requests, get_requested_person_keys, \
     get_engager_candidates, get_profile_facts, count_invites_sent_today, ConnectionRequestStatus, \
     CatchupTouchStatus, insert_catchup_touch, has_catchup_touch, get_catchup_touch, \
-    update_catchup_touch_status, count_catchup_touches_sent_today
+    update_catchup_touch_status, count_catchup_touches_sent_today, max_catchup_touches_allowed
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
     load_profile_for_user
@@ -70,7 +70,8 @@ from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
     get_element_wait_retry, get_elements_as_list_wait_stale, getText, close_tab, get_driver_wait_pair, quit_gracefully, \
     wait_for_ajax, find_first, click_first, find_all_first
 from dotenv import load_dotenv
-from selenium.common import NoSuchElementException, JavascriptException, StaleElementReferenceException
+from selenium.common import NoSuchElementException, JavascriptException, StaleElementReferenceException, \
+    ElementNotInteractableException, WebDriverException
 from selenium.webdriver import ActionChains, Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
@@ -4181,6 +4182,50 @@ _CATCHUP_PROFILE_LINK_LOCATORS = [
     (By.CSS_SELECTOR, "a[href*='/in/']"),
 ]
 
+# LinkedIn writes the congratulations for us — the catch-up card ships a pre-drafted response (a
+# suggestion chip on the card, or the pre-filled compose box behind "Say congrats"). That draft is the
+# BASELINE we send (owner review on PR #509): it is what the recipient expects from this surface, and
+# it costs no LLM call. Our own AI is opt-in (catchup_message_source='ai').
+_CATCHUP_SUGGESTED_TEXT_LOCATORS = [
+    (By.CSS_SELECTOR, "button[data-view-name*='suggested-reply']"),
+    (By.CSS_SELECTOR, "button[data-view-name*='message-suggestion']"),
+    (By.CSS_SELECTOR, "[data-view-name*='catch-up-card-suggestion']"),
+    (By.CSS_SELECTOR, "button[aria-label*='Congrats'], button[aria-label*='congrats']"),
+]
+# The card affordance that opens LinkedIn's pre-filled compose overlay. We only ever OPEN it to read
+# the draft — never type, never submit (see _harvest_linkedin_draft).
+_CATCHUP_MESSAGE_TRIGGER_LOCATORS = [
+    (By.CSS_SELECTOR, "button[data-view-name*='catch-up-card-message']"),
+    (By.CSS_SELECTOR, "button[aria-label*='Say congrats'], button[aria-label*='Send message']"),
+    (By.CSS_SELECTOR, "button[aria-label*='Message']"),
+]
+# Only these read as "open the congratulations composer" — anything else on the card is left alone so
+# a selector drift can't make us click Follow/Connect/Send.
+_CATCHUP_TRIGGER_TEXT_RE = re.compile(r"say congrats|congrat|message", re.IGNORECASE)
+_CATCHUP_COMPOSE_LOCATORS = [
+    (By.CSS_SELECTOR, "div[role='dialog'] div[contenteditable='true']"),
+    (By.CSS_SELECTOR, "div[role='dialog'] textarea"),
+    (By.CSS_SELECTOR, "div[contenteditable='true'][aria-label*='message']"),
+]
+_CATCHUP_DISMISS_LOCATORS = [
+    (By.CSS_SELECTOR, "div[role='dialog'] button[aria-label*='Dismiss']"),
+    (By.CSS_SELECTOR, "div[role='dialog'] button[aria-label*='Close']"),
+]
+# Opening LinkedIn's composer to read its draft is one extra interaction per QUALIFYING moment (never
+# per card). Set to false to stay read-only on the card and use the per-milestone fallbacks below.
+CATCHUP_HARVEST_LINKEDIN_DRAFT = os.getenv("CATCHUP_HARVEST_LINKEDIN_DRAFT", "true").lower() == "true"
+# What LinkedIn's own suggestion sounds like, for when the feed doesn't surface one. Deliberately the
+# same short, plain congratulations — NOT an AI rewrite, and never a pitch.
+_CATCHUP_DEFAULT_CONGRATS = {
+    "job_change": "Congrats on the new role, {first_name}!",
+    "promotion": "Congrats on the promotion, {first_name}!",
+    "work_anniversary": "Happy work anniversary, {first_name}!",
+    "birthday": "Happy birthday, {first_name}!",
+    "education": "Congrats on the milestone, {first_name}!",
+    "in_the_news": "Great to see you in the news, {first_name}!",
+}
+CATCHUP_MESSAGE_MAX_CHARS = 300  # same budget as every other DM we send
+
 # Base value of each milestone type. New job / promotion are the BD goldmine; a birthday is not.
 # Read together with CATCHUP_MIN_SCORE (30): job change, promotion, in-the-news and work anniversary
 # clear the bar on their own, while education and birthday only clear it for people who also match the
@@ -4275,11 +4320,11 @@ def _score_catchup_moment(moment: dict, prefs: dict) -> int:
     return score
 
 
-def _card_profile_link(card: WebElement) -> "WebElement | None":
-    """First profile link inside a catch-up card, trying the ordered locator chain. Searched directly
+def _first_in_card(card: WebElement, locators: list) -> "WebElement | None":
+    """First element inside a catch-up card matching the ordered locator chain. Searched directly
     (no WebDriverWait) because the card is already in the DOM — a per-card wait would cost the full
     timeout on every non-person card LinkedIn mixes into the feed."""
-    for find_by, value in _CATCHUP_PROFILE_LINK_LOCATORS:
+    for find_by, value in locators:
         try:
             els = card.find_elements(find_by, value)
         except (StaleElementReferenceException, NoSuchElementException):
@@ -4289,11 +4334,87 @@ def _card_profile_link(card: WebElement) -> "WebElement | None":
     return None
 
 
-def _scrape_catchup_moments(driver: WebDriver, max_moments: int = 40,
-                            user_id: int = None) -> List[dict]:
-    """Scrape the catch-up feed into [{name, profile_url, text}] — one entry per card, deduped by
-    profile+text. Best-effort by design: a selector miss returns fewer moments (logged) rather than
-    failing the run."""
+def _card_profile_link(card: WebElement) -> "WebElement | None":
+    return _first_in_card(card, _CATCHUP_PROFILE_LINK_LOCATORS)
+
+
+def _clean_suggested_message(text: str) -> str:
+    """Normalize a draft LinkedIn handed us: collapse whitespace, drop the button chrome, cap at the
+    DM budget. Anything that doesn't look like a message (empty / a bare label) becomes ''."""
+    cleaned = " ".join((text or "").replace("\n", " ").split()).strip()
+    if len(cleaned) < 4:
+        return ""
+    return cleaned[:CATCHUP_MESSAGE_MAX_CHARS]
+
+
+def _card_suggested_message(card: WebElement) -> str:
+    """LinkedIn's suggested congratulations as rendered ON the card (a quick-reply chip), if any.
+    Read-only — no clicking."""
+    el = _first_in_card(card, _CATCHUP_SUGGESTED_TEXT_LOCATORS)
+    if el is None:
+        return ""
+    try:
+        return _clean_suggested_message(getText(el) or el.get_attribute("aria-label") or "")
+    except (StaleElementReferenceException, NoSuchElementException):
+        return ""
+
+
+def _harvest_linkedin_draft(driver: WebDriver, card: WebElement, user_id: int = None) -> str:
+    """Open LinkedIn's "Say congrats" composer for this card, read the message it pre-drafted, and
+    close it WITHOUT sending. We never type into the box and never click a send/submit control, so the
+    worst case is an opened-and-dismissed overlay. Best-effort: any miss returns '' and the caller
+    falls back to the per-milestone default."""
+    if not CATCHUP_HARVEST_LINKEDIN_DRAFT:
+        return ""
+    trigger = _first_in_card(card, _CATCHUP_MESSAGE_TRIGGER_LOCATORS)
+    if trigger is None:
+        return ""
+    try:
+        label = f"{getText(trigger) or ''} {trigger.get_attribute('aria-label') or ''}"
+        if not _CATCHUP_TRIGGER_TEXT_RE.search(label):
+            return ""  # a drifted selector matched something that isn't the congrats composer
+        trigger.click()
+        time.sleep(random.uniform(1, 2))
+        compose = None
+        for find_by, value in _CATCHUP_COMPOSE_LOCATORS:
+            els = driver.find_elements(find_by, value)
+            if els:
+                compose = els[0]
+                break
+        draft = ""
+        if compose is not None:
+            draft = _clean_suggested_message(getText(compose) or compose.get_attribute("value") or "")
+        return draft
+    except (StaleElementReferenceException, NoSuchElementException, ElementNotInteractableException,
+            WebDriverException) as e:
+        log_warning("Could not read LinkedIn's pre-drafted catch-up message", exc=e, user_id=user_id,
+                    action_type="catchup")
+        return ""
+    finally:
+        _dismiss_catchup_composer(driver)
+
+
+def _dismiss_catchup_composer(driver: WebDriver) -> None:
+    """Close the composer overlay without sending — the dismiss control, else Escape."""
+    try:
+        for find_by, value in _CATCHUP_DISMISS_LOCATORS:
+            els = driver.find_elements(find_by, value)
+            if els:
+                els[0].click()
+                return
+        ActionChains(driver).send_keys(Keys.ESCAPE).perform()
+    except (StaleElementReferenceException, NoSuchElementException, ElementNotInteractableException,
+            WebDriverException):
+        pass
+
+
+def _scrape_catchup_moments(driver: WebDriver, max_moments: int = 40, user_id: int = None,
+                            enabled_event_types: "set | None" = None) -> List[dict]:
+    """Scrape the catch-up feed into [{name, profile_url, text, event_type, suggested_message}] — one
+    entry per card, deduped by profile+text. Classification happens here so LinkedIn's pre-drafted
+    message is only harvested for moments the user actually congratulates (`enabled_event_types`);
+    pass None to skip harvesting entirely. Best-effort by design: a selector miss returns fewer moments
+    (logged) rather than failing the run."""
     driver.get(CATCHUP_URL)
     time.sleep(random.uniform(3, 5))
 
@@ -4318,8 +4439,13 @@ def _scrape_catchup_moments(driver: WebDriver, max_moments: int = 40,
             if key in seen:
                 continue
             seen.add(key)
+            event_type = _classify_catchup_moment(text)
+            suggested = ""
+            if event_type and enabled_event_types and event_type in enabled_event_types:
+                suggested = _card_suggested_message(card) or _harvest_linkedin_draft(
+                    driver, card, user_id=user_id)
             moments.append({"name": _catchup_name_from_card(text, link), "profile_url": profile_url,
-                            "text": text})
+                            "text": text, "event_type": event_type, "suggested_message": suggested})
         if len(moments) >= max_moments:
             break
         driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
@@ -4342,10 +4468,21 @@ def _catchup_name_from_card(text: str, link) -> str:
     return name[:255]
 
 
-def _draft_catchup_message(user_id: int, moment: dict, my_profile: LinkedInProfile) -> "str | None":
-    """Render the user's DM template for this milestone type, in their voice, referencing the actual
-    event. Returns None when the user has deactivated the template for that event type."""
+def _draft_catchup_message(user_id: int, moment: dict, my_profile: LinkedInProfile,
+                           source: str = "linkedin") -> "str | None":
+    """The congratulations to send for this moment.
+
+    'linkedin' (default): LinkedIn's OWN pre-drafted response — the suggestion it renders on the card
+    or pre-fills in its composer — falling back to the matching plain one-liner when the feed gave us
+    none. No LLM call. 'ai': the user's DM template refined to their voice (returns None when they
+    deactivated the template for that event type)."""
     first_name = (moment.get("name") or "").strip().split(" ")[0] or "there"
+    if source != "ai":
+        suggested = _clean_suggested_message(moment.get("suggested_message") or "")
+        if suggested:
+            return suggested
+        default = _CATCHUP_DEFAULT_CONGRATS.get(moment["event_type"])
+        return default.format(first_name=first_name) if default else None
     return build_dm_from_template(user_id, moment["event_type"], first_name, my_profile,
                                   event_detail=moment.get("event_detail") or moment.get("text", ""))
 
@@ -4359,7 +4496,8 @@ def automate_catchup_touches(self, user_id: int, max_moments: int = 40, max_draf
     approval (or 'approved' when the user opted into catchup_touch_mode='auto_approve'), and the
     capped scanner sends them later. Only milestone types the user enabled are drafted, each
     milestone is deduped on (person, event_type, period), and moments scoring below CATCHUP_MIN_SCORE
-    are tombstoned as 'skipped' so we neither draft nor re-score them."""
+    are tombstoned as 'skipped' so we neither draft nor re-score them. The message itself is
+    LinkedIn's own pre-drafted response unless the user opted into catchup_message_source='ai'."""
     prefs = get_engagement_preferences(user_id)
     enabled = {str(t) for t in (prefs.get("catchup_event_types") or [])}
     if not enabled:
@@ -4378,7 +4516,8 @@ def automate_catchup_touches(self, user_id: int, max_moments: int = 40, max_draf
 
     drafted = skipped = 0
     try:
-        moments = _scrape_catchup_moments(driver, max_moments=max_moments, user_id=user_id)
+        moments = _scrape_catchup_moments(driver, max_moments=max_moments, user_id=user_id,
+                                          enabled_event_types=enabled)
     except LinkedInRateLimited as e:
         myprint(f"automate_catchup_touches deferred mid-scrape (throttled): {e}")
         return "Catch-up scan deferred (LinkedIn throttled)"
@@ -4389,10 +4528,11 @@ def automate_catchup_touches(self, user_id: int, max_moments: int = 40, max_draf
         quit_gracefully(driver)
 
     auto_approve = str(prefs.get("catchup_touch_mode") or "pre_review") == "auto_approve"
+    source = str(prefs.get("catchup_message_source") or "linkedin")
     for moment in moments:
         if drafted >= max_drafts:
             break
-        event_type = _classify_catchup_moment(moment.get("text", ""))
+        event_type = moment.get("event_type") or _classify_catchup_moment(moment.get("text", ""))
         if event_type is None or event_type not in enabled:
             continue
         if _catchup_excluded(moment, prefs):
@@ -4409,7 +4549,7 @@ def automate_catchup_touches(self, user_id: int, max_moments: int = 40, max_draf
             skipped += 1
             continue
         try:
-            message = _draft_catchup_message(user_id, moment, my_profile)
+            message = _draft_catchup_message(user_id, moment, my_profile, source=source)
         except Exception as e:
             log_warning("Could not draft catch-up message", exc=e, user_id=user_id, action_type="catchup")
             continue
@@ -4446,7 +4586,11 @@ def send_catchup_touch(self, touch_id: int):
 
     user_id = touch["user_id"]
     prefs = get_engagement_preferences(user_id)
-    if count_catchup_touches_sent_today(user_id) >= int(prefs.get("max_catchup_touches_per_day") or 0):
+    # The saved cap can only go as high as the user's plan allows (10/day premium, 5/day otherwise) —
+    # re-checked here so a downgrade takes effect immediately, not at the next settings save.
+    daily_cap = min(int(prefs.get("max_catchup_touches_per_day") or 0),
+                    max_catchup_touches_allowed(user_id))
+    if count_catchup_touches_sent_today(user_id) >= daily_cap:
         update_catchup_touch_status(touch_id, CatchupTouchStatus.APPROVED)  # retry on the next scan
         return f"Catch-up touch {touch_id} deferred (daily catch-up cap reached)"
     if count_dms_sent_today(user_id) >= int(prefs.get("max_dms_per_day") or 0):

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -20,7 +20,7 @@ from cqc_lem.utilities.db import (
     update_connection_request_status, ConnectionRequestStatus, count_invites_sent_today,
     get_users_with_reply_mode, get_engagement_preferences,
     get_approved_catchup_touches, get_orphaned_catchup_touches, update_catchup_touch_status,
-    count_catchup_touches_sent_today, CatchupTouchStatus,
+    count_catchup_touches_sent_today, CatchupTouchStatus, max_catchup_touches_allowed,
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES
 from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
@@ -865,7 +865,9 @@ def auto_check_catchup_touches():
                         user_id=user_id, task_name="auto_check_catchup_touches")
             continue
         if user_id not in budgets:
-            cap = int(get_engagement_preferences(user_id).get("max_catchup_touches_per_day") or 0)
+            # 10/day is a premium-plan allowance; every other plan tops out at 5 (see db.py).
+            cap = min(int(get_engagement_preferences(user_id).get("max_catchup_touches_per_day") or 0),
+                      max_catchup_touches_allowed(user_id))
             budgets[user_id] = max(0, cap - count_catchup_touches_sent_today(user_id))
         if budgets[user_id] <= 0:
             continue  # cap met for today — the rest stay 'approved' for tomorrow

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -9,7 +9,7 @@ from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.app.run_automation import automate_commenting, automate_profile_viewer_engagement, \
     automate_appreciation_dms_for_user, clean_stale_invites, update_stale_profile, post_to_linkedin, \
     automate_invites_to_company_page_for_user, send_scheduled_dm, send_connection_request, \
-    sweep_reply_comments, sweep_comment_followups
+    sweep_reply_comments, sweep_comment_followups, send_catchup_touch
 from cqc_lem.utilities.db import (
     get_ready_to_post_posts, get_orphaned_scheduled_posts, update_db_post_status,
     get_active_user_ids, PostStatus, has_linkedin_session, has_scheduled_post_today,
@@ -19,6 +19,8 @@ from cqc_lem.utilities.db import (
     get_approved_connection_requests, get_orphaned_connection_requests,
     update_connection_request_status, ConnectionRequestStatus, count_invites_sent_today,
     get_users_with_reply_mode, get_engagement_preferences,
+    get_approved_catchup_touches, get_orphaned_catchup_touches, update_catchup_touch_status,
+    count_catchup_touches_sent_today, CatchupTouchStatus,
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES
 from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
@@ -824,6 +826,66 @@ def rebuild_lead_scores():
     for uid in users:
         rebuild_leads_for_user.apply_async(kwargs={"user_id": uid})
     return f"Lead re-scoring dispatched for {len(users)} user(s)"
+
+
+@shared_task.task
+def auto_scan_catchup_moments():
+    """Dispatch the daily per-user LinkedIn Catch-up scan (issue #482). Drafting only — the scan writes
+    approval-gated rows to catchup_touches and sends nothing. Users who disabled every milestone type
+    are skipped so we never open a Chrome session for them."""
+    if _skip_if_throttled("auto_scan_catchup_moments"):
+        return "Automation throttled"
+    from cqc_lem.app.run_automation import automate_catchup_touches
+    dispatched = 0
+    for user_id in get_active_user_ids():
+        if not (get_engagement_preferences(user_id).get("catchup_event_types") or []):
+            continue
+        automate_catchup_touches.apply_async(kwargs={'user_id': user_id})
+        dispatched += 1
+    return f"Dispatched catch-up scan for {dispatched} user(s)"
+
+
+@shared_task.task
+def auto_check_catchup_touches():
+    """Send APPROVED catch-up congratulations on a slow, per-user-capped drip (issue #482). Mirrors
+    auto_check_connection_requests: approval happens upstream (rows only reach 'approved' via the API
+    or the user's auto_approve mode), the whole scan short-circuits while the kill-switch / 429 breaker
+    is open, and the send task re-checks both caps and the throttle."""
+    if _skip_if_throttled("auto_check_catchup_touches"):
+        return "Automation throttled"
+
+    approved = get_approved_catchup_touches()
+    active_user_ids = set(get_active_user_ids()) if approved else set()
+
+    dispatched = 0
+    budgets: dict = {}  # user_id -> remaining catch-up touches allowed today
+    for touch_id, user_id in approved:
+        if user_id not in active_user_ids:
+            log_warning("Skipping catch-up touch — user not active/connected",
+                        user_id=user_id, task_name="auto_check_catchup_touches")
+            continue
+        if user_id not in budgets:
+            cap = int(get_engagement_preferences(user_id).get("max_catchup_touches_per_day") or 0)
+            budgets[user_id] = max(0, cap - count_catchup_touches_sent_today(user_id))
+        if budgets[user_id] <= 0:
+            continue  # cap met for today — the rest stay 'approved' for tomorrow
+        budgets[user_id] -= 1
+        update_catchup_touch_status(touch_id, CatchupTouchStatus.SENDING)
+        send_catchup_touch.apply_async(kwargs={'touch_id': touch_id})
+        dispatched += 1
+
+    # Re-queue touches stuck in 'sending' whose send task was lost (container restart) — mirrors the
+    # orphaned connection-request recovery. The 2-hour gap avoids racing an in-flight task.
+    orphaned = get_orphaned_catchup_touches(lookback_hours=2)
+    for touch_id, user_id in orphaned:
+        log_warning(f"Re-queueing orphaned catch-up touch {touch_id}",
+                    user_id=user_id, task_name="auto_check_catchup_touches")
+        update_catchup_touch_status(touch_id, CatchupTouchStatus.SENDING)
+        send_catchup_touch.apply_async(kwargs={'touch_id': touch_id})
+
+    if dispatched == 0 and len(orphaned) == 0:
+        return "No Catch-up Touches to Send"
+    return f"Dispatched {dispatched} catch-up touch(es); re-queued {len(orphaned)} orphaned"
 
 
 @shared_task.task

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -9,6 +9,7 @@ import ConnectionRequests from './review/ConnectionRequests'
 import OutreachFunnel from './review/OutreachFunnel'
 import LeadsInbox from './review/LeadsInbox'
 import LeadsPipeline from './review/LeadsPipeline'
+import CatchupTouches from './review/CatchupTouches'
 import ComposePost from './content/ComposePost'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
@@ -16,11 +17,12 @@ import { formatInTimezone } from '../utils/datetime'
 
 // Consolidated content hub: compose posts, schedule DMs, manage newsletters, and review/edit
 // existing content — one page, four tabs, synced to ?tab= for deep-linking.
-type View = 'posts' | 'dms' | 'connections' | 'outreach' | 'leads' | 'pipeline' | 'newsletters' | 'review'
+type View = 'posts' | 'dms' | 'connections' | 'catchup' | 'outreach' | 'leads' | 'pipeline' | 'newsletters' | 'review'
 const VIEWS: { key: View; label: string }[] = [
   { key: 'posts', label: 'Posts' },
   { key: 'dms', label: 'DMs' },
   { key: 'connections', label: 'Connections' },
+  { key: 'catchup', label: 'Catch-up' },
   { key: 'outreach', label: 'Outreach' },
   { key: 'leads', label: 'Leads' },
   { key: 'pipeline', label: 'Pipeline' },
@@ -337,6 +339,8 @@ export default function ContentStudio() {
       {view === 'dms' && <ScheduledDMs userTimezone={userTimezone} />}
 
       {view === 'connections' && <ConnectionRequests userTimezone={userTimezone} />}
+
+      {view === 'catchup' && <CatchupTouches userTimezone={userTimezone} />}
 
       {view === 'outreach' && <OutreachFunnel />}
 

--- a/src/cqc_lem/ui/src/pages/account/DmTemplatesCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/DmTemplatesCard.tsx
@@ -84,6 +84,7 @@ export default function DmTemplatesCard() {
         { token: '{first_name}', desc: "The recipient's first name" },
         { token: '{headline}', desc: "The recipient's headline / role" },
         { token: '{blog_url}', desc: 'Your configured blog URL' },
+        { token: '{event_detail}', desc: 'The Catch-up milestone (e.g. "started a new position at Acme")' },
       ]} />
       {DM_EVENTS.map((ev) => {
         const steps = dmTemplates.filter((t) => t.event_type === ev.key).sort((a, b) => a.step - b.step)

--- a/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
@@ -54,6 +54,9 @@ export default function EngagementSettingsCard() {
 
   if (!engPrefs) return null
 
+  // Server-provided ceiling for the catch-up cap — 10/day on Professional/Enterprise, 5/day otherwise.
+  const catchupCapMax = engPrefs.max_catchup_touches_allowed ?? 5
+
   // Every engagement section edits ONE shared object saved by ONE mutation, so a failure in any
   // field (e.g. an over-long value) fails the whole save. Show the result under whichever button
   // the user clicked — previously the message only rendered in the Targeting card, hiding errors
@@ -252,20 +255,35 @@ export default function EngagementSettingsCard() {
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Max catch-up touches/day</label>
-            <input type="number" min={0} max={25} value={engPrefs.max_catchup_touches_per_day ?? 5}
-              onChange={(e) => setEng({ max_catchup_touches_per_day: Number(e.target.value) })}
+            <input type="number" min={0} max={catchupCapMax} value={engPrefs.max_catchup_touches_per_day ?? 5}
+              onChange={(e) => setEng({ max_catchup_touches_per_day: Math.min(catchupCapMax, Number(e.target.value)) })}
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
-            <p className="text-xs text-gray-400 mt-1">Congratulations DMs sent per day from your LinkedIn Catch-up feed. They also count against Max DMs/day.</p>
+            <p className="text-xs text-gray-400 mt-1">
+              Congratulations DMs sent per day from your LinkedIn Catch-up feed. They also count against Max DMs/day.
+              {catchupCapMax > 5
+                ? ' Your plan allows up to 10/day.'
+                : ' Up to 5/day on your plan — 10/day is included with Professional and Enterprise.'}
+            </p>
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Catch-up approval</label>
             <select value={engPrefs.catchup_touch_mode ?? 'pre_review'}
               onChange={(e) => setEng({ catchup_touch_mode: e.target.value })}
               className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm">
-              <option value="pre_review">Pre-review (approve each message first)</option>
-              <option value="auto_approve">Auto-approve (queue drafts immediately)</option>
+              <option value="pre_review">Pre-review (edit + approve each message first)</option>
+              <option value="auto_approve">Auto-use (send LinkedIn's draft as-is)</option>
             </select>
-            <p className="text-xs text-gray-400 mt-1">Pre-review holds each drafted congratulations in the Catch-up tab until you approve it.</p>
+            <p className="text-xs text-gray-400 mt-1">Pre-review holds each congratulations in the Catch-up tab so you can edit it before it goes out; auto-use queues it straight into the capped drip.</p>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Catch-up message</label>
+            <select value={engPrefs.catchup_message_source ?? 'linkedin'}
+              onChange={(e) => setEng({ catchup_message_source: e.target.value })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm">
+              <option value="linkedin">LinkedIn's suggested response (default)</option>
+              <option value="ai">Customize with AI (your DM template + voice)</option>
+            </select>
+            <p className="text-xs text-gray-400 mt-1">LinkedIn already drafts a congratulations for each moment — we use that as the baseline, no AI required. Switch to AI only if you want the message rewritten in your voice from your DM template.</p>
           </div>
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Auto-generated video quality</label>
@@ -313,8 +331,9 @@ export default function EngagementSettingsCard() {
         <div className="border-t border-gray-100 pt-4">
           <p className="text-sm font-medium text-gray-700">Catch-up milestones to congratulate</p>
           <p className="text-xs text-gray-400 mb-2">
-            Which network moments LEM drafts a congratulations for. New job and promotion are real
-            reasons to reconnect; the rest are optional. Unchecking every type turns Catch-up off.
+            Which network moments LEM drafts a congratulations for — all six are yours to turn on.
+            New job and promotion are on by default because they're real reasons to reconnect; the
+            rest are opt-in. Unchecking every type turns Catch-up off.
           </p>
           <div className="flex flex-wrap gap-3">
             {CATCHUP_EVENTS.map((ev) => {

--- a/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import Toggle from '../../components/Toggle'
-import { csv, parseCsv } from './types'
+import { csv, parseCsv, CATCHUP_EVENTS } from './types'
 import type { EngPrefs } from './types'
 import { useRegisterSaveSection } from './SettingsSaveContext'
 import { FIELD_LIMITS } from './fieldLimits'
@@ -251,6 +251,23 @@ export default function EngagementSettingsCard() {
             <p className="text-xs text-gray-400 mt-1">Profile URLs of thought leaders or competitors in your space. LEM harvests the people commenting on their recent posts as warm 2nd-degree candidates. Leave blank to only target people who engage with your own posts.</p>
           </div>
           <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Max catch-up touches/day</label>
+            <input type="number" min={0} max={25} value={engPrefs.max_catchup_touches_per_day ?? 5}
+              onChange={(e) => setEng({ max_catchup_touches_per_day: Number(e.target.value) })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+            <p className="text-xs text-gray-400 mt-1">Congratulations DMs sent per day from your LinkedIn Catch-up feed. They also count against Max DMs/day.</p>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Catch-up approval</label>
+            <select value={engPrefs.catchup_touch_mode ?? 'pre_review'}
+              onChange={(e) => setEng({ catchup_touch_mode: e.target.value })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm">
+              <option value="pre_review">Pre-review (approve each message first)</option>
+              <option value="auto_approve">Auto-approve (queue drafts immediately)</option>
+            </select>
+            <p className="text-xs text-gray-400 mt-1">Pre-review holds each drafted congratulations in the Catch-up tab until you approve it.</p>
+          </div>
+          <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Auto-generated video quality</label>
             <select value={engPrefs.default_video_quality ?? 'standard'}
               onChange={(e) => setEng({ default_video_quality: e.target.value })}
@@ -292,6 +309,29 @@ export default function EngagementSettingsCard() {
             <p className="text-xs text-gray-400">When a post contains an external link, publish the post without it and drop the link into the first comment instead. Links in the body cost roughly 60-68% of a post's reach.</p>
           </div>
           <Toggle on={engPrefs.link_in_first_comment} onClick={() => setEng({ link_in_first_comment: !engPrefs.link_in_first_comment })} />
+        </div>
+        <div className="border-t border-gray-100 pt-4">
+          <p className="text-sm font-medium text-gray-700">Catch-up milestones to congratulate</p>
+          <p className="text-xs text-gray-400 mb-2">
+            Which network moments LEM drafts a congratulations for. New job and promotion are real
+            reasons to reconnect; the rest are optional. Unchecking every type turns Catch-up off.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            {CATCHUP_EVENTS.map((ev) => {
+              const selected = (engPrefs.catchup_event_types ?? []).includes(ev.key)
+              return (
+                <label key={ev.key} className="flex items-center gap-1.5 text-sm text-gray-600">
+                  <input type="checkbox" checked={selected}
+                    onChange={() => setEng({
+                      catchup_event_types: selected
+                        ? (engPrefs.catchup_event_types ?? []).filter((k) => k !== ev.key)
+                        : [...(engPrefs.catchup_event_types ?? []), ev.key],
+                    })} />
+                  {ev.label}
+                </label>
+              )
+            })}
+          </div>
         </div>
         <div className="flex items-center justify-between">
           <p className="text-sm font-medium text-gray-700">Reply to comments on my posts</p>

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -31,6 +31,9 @@ export type EngPrefs = {
   gmail_forward_confirmation?: GmailForwardConfirmation | null
   feed_fallback_when_empty: boolean
   link_in_first_comment: boolean
+  max_catchup_touches_per_day: number
+  catchup_touch_mode: string
+  catchup_event_types: string[]
   feed_reach?: FeedReach | null
 }
 
@@ -125,6 +128,23 @@ export const DM_EVENTS: { key: string; label: string }[] = [
   // The direction for the next message after a lead REPLIES (issue #485). The draft is written
   // against what they actually said; this template sets its intent, not its wording.
   { key: 'nurture', label: 'After they reply (nurture)' },
+  // Catch-up milestone congratulations (issue #482) — these templates also accept {event_detail}.
+  { key: 'job_change', label: 'Catch-up · New job' },
+  { key: 'promotion', label: 'Catch-up · Promotion' },
+  { key: 'work_anniversary', label: 'Catch-up · Work anniversary' },
+  { key: 'education', label: 'Catch-up · Education milestone' },
+  { key: 'in_the_news', label: 'Catch-up · In the news' },
+  { key: 'birthday', label: 'Catch-up · Birthday' },
+]
+
+// Milestone types the Catch-up scan can congratulate, ordered by BD value (issue #482).
+export const CATCHUP_EVENTS: { key: string; label: string }[] = [
+  { key: 'job_change', label: 'New job' },
+  { key: 'promotion', label: 'Promotion' },
+  { key: 'work_anniversary', label: 'Work anniversary' },
+  { key: 'education', label: 'Education milestone' },
+  { key: 'in_the_news', label: 'In the news' },
+  { key: 'birthday', label: 'Birthday' },
 ]
 
 export const csv = (arr: string[] | undefined | null) => (arr && arr.length ? arr.join(', ') : '')

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -34,6 +34,9 @@ export type EngPrefs = {
   max_catchup_touches_per_day: number
   catchup_touch_mode: string
   catchup_event_types: string[]
+  catchup_message_source: string
+  // Read-only: the highest catch-up cap this plan allows (10/day is premium-only).
+  max_catchup_touches_allowed?: number
   feed_reach?: FeedReach | null
 }
 

--- a/src/cqc_lem/ui/src/pages/review/CatchupTouches.tsx
+++ b/src/cqc_lem/ui/src/pages/review/CatchupTouches.tsx
@@ -73,10 +73,17 @@ export default function CatchupTouches({ userTimezone }: { userTimezone: string 
     onError: () => flash(false, 'Could not save the message.'),
   })
 
+  // Approving sends, so it carries the textarea's current value — otherwise an edit the user never
+  // clicked "Save message" on would be silently dropped and the OLD draft would go out.
   const actionMutation = useMutation({
-    mutationFn: (v: { id: number; action: 'approve' | 'cancel' }) =>
-      api.put('/catchup/touch', { session_token: sessionToken, touch_id: v.id, action: v.action }),
-    onSuccess: () => invalidate(),
+    mutationFn: (v: { id: number; action: 'approve' | 'cancel'; message?: string }) =>
+      api.put('/catchup/touch', {
+        session_token: sessionToken, touch_id: v.id, action: v.action,
+        ...(v.message !== undefined ? { message: v.message } : {}),
+      }),
+    onSuccess: (_r, v) => {
+      invalidate(); setEdits((e) => { const n = { ...e }; delete n[v.id]; return n })
+    },
     onError: () => flash(false, 'Could not update this touch.'),
   })
 
@@ -153,8 +160,10 @@ export default function CatchupTouches({ userTimezone }: { userTimezone: string 
                       Save message
                     </button>
                     {['pending', 'failed'].includes(t.status) && (
-                      <button onClick={() => actionMutation.mutate({ id: t.id, action: 'approve' })}
-                        disabled={actionMutation.isPending}
+                      <button
+                        onClick={() => actionMutation.mutate({ id: t.id, action: 'approve', message: messageValue.trim() })}
+                        disabled={actionMutation.isPending || !messageValue.trim()}
+                        title={!messageValue.trim() ? 'Write a message before approving' : undefined}
                         className="px-3 py-1 bg-green-600 text-white rounded text-xs font-semibold hover:bg-green-700 disabled:opacity-50">
                         {t.status === 'pending' ? 'Approve & send' : 'Retry'}
                       </button>

--- a/src/cqc_lem/ui/src/pages/review/CatchupTouches.tsx
+++ b/src/cqc_lem/ui/src/pages/review/CatchupTouches.tsx
@@ -6,9 +6,9 @@ import { formatInTimezone } from '../../utils/datetime'
 import { CATCHUP_EVENTS } from '../account/types'
 
 // LinkedIn Catch-up congratulations (issue #482). LEM scans your Catch-up feed daily, scores each
-// milestone against your targeting, and drafts a personal congratulations in your voice. NOTHING is
-// sent until you approve it (unless you switched Account → Catch-up approval to auto-approve), and
-// sends drip out under your daily catch-up + DM caps.
+// milestone against your targeting, and queues LinkedIn's own suggested congratulations (or an
+// AI-written one when catchup_message_source='ai'). NOTHING is sent until you approve it (unless you
+// switched Account → Catch-up approval to auto-use), and sends drip out under your catch-up + DM caps.
 const MESSAGE_MAX = 1000
 
 interface CatchupTouch {
@@ -88,10 +88,11 @@ export default function CatchupTouches({ userTimezone }: { userTimezone: string 
         <h3 className="font-semibold text-gray-700">Catch-up congratulations</h3>
         <p className="text-xs text-gray-500">
           LEM scans your LinkedIn Catch-up feed daily for network milestones — new jobs, promotions,
-          work anniversaries — scores them against your targeting, and drafts a personal
-          congratulations in your voice. <span className="font-semibold">Nothing sends until you
-          approve it</span>, each milestone is messaged at most once, and approved messages drip out
-          under your daily catch-up and DM caps (Account → Engagement).
+          work anniversaries — scores them against your targeting, and queues LinkedIn's own suggested
+          congratulations for each one (switch to an AI-written version in Account → Catch-up message).
+          <span className="font-semibold"> Nothing sends until you approve it</span>, each milestone is
+          messaged at most once, and approved messages drip out under your daily catch-up and DM caps
+          (Account → Engagement).
         </p>
       </div>
 

--- a/src/cqc_lem/ui/src/pages/review/CatchupTouches.tsx
+++ b/src/cqc_lem/ui/src/pages/review/CatchupTouches.tsx
@@ -1,0 +1,177 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import api from '../../api/client'
+import { useAuth } from '../../contexts/AuthContext'
+import { formatInTimezone } from '../../utils/datetime'
+import { CATCHUP_EVENTS } from '../account/types'
+
+// LinkedIn Catch-up congratulations (issue #482). LEM scans your Catch-up feed daily, scores each
+// milestone against your targeting, and drafts a personal congratulations in your voice. NOTHING is
+// sent until you approve it (unless you switched Account → Catch-up approval to auto-approve), and
+// sends drip out under your daily catch-up + DM caps.
+const MESSAGE_MAX = 1000
+
+interface CatchupTouch {
+  id: number
+  profile_url: string
+  person_name: string | null
+  event_type: string
+  event_detail: string | null
+  event_period: string
+  score: number
+  message: string | null
+  status: string
+  created_at: string
+}
+
+const EVENT_LABELS: Record<string, string> = Object.fromEntries(
+  CATCHUP_EVENTS.map((e) => [e.key, e.label]),
+)
+
+const STATUS_COLORS: Record<string, string> = {
+  pending: 'bg-yellow-100 text-yellow-700',
+  approved: 'bg-green-100 text-green-700',
+  sending: 'bg-purple-100 text-purple-700',
+  sent: 'bg-blue-100 text-blue-700',
+  skipped: 'bg-gray-100 text-gray-500',
+  failed: 'bg-red-100 text-red-700',
+  canceled: 'bg-gray-100 text-gray-500',
+}
+
+const STATUSES = ['pending', 'approved', 'sending', 'sent', 'skipped', 'failed', 'canceled', 'ALL']
+
+export default function CatchupTouches({ userTimezone }: { userTimezone: string }) {
+  const { sessionToken } = useAuth()
+  const qc = useQueryClient()
+  const [filter, setFilter] = useState('pending')
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null)
+  // Per-touch message edits (keyed by id) so each card edits independently.
+  const [edits, setEdits] = useState<Record<number, string>>({})
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['catchup-touches', sessionToken, filter],
+    queryFn: () => {
+      const p = new URLSearchParams({ session_token: sessionToken!, page: '1', page_size: '50' })
+      if (filter !== 'ALL') p.set('status_filter', filter)
+      return api
+        .get(`/catchup/touches?${p.toString()}`)
+        .then((r) => r.data.detail as { touches: CatchupTouch[]; total: number })
+    },
+    enabled: !!sessionToken,
+  })
+  const touches = data?.touches ?? []
+
+  const flash = (ok: boolean, text: string) => { setMsg({ ok, text }); setTimeout(() => setMsg(null), 4000) }
+  const invalidate = () => qc.invalidateQueries({ queryKey: ['catchup-touches'] })
+
+  const saveMutation = useMutation({
+    mutationFn: (v: { id: number; message: string }) =>
+      api.put('/catchup/touch', { session_token: sessionToken, touch_id: v.id, message: v.message }),
+    onSuccess: (_r, v) => {
+      invalidate(); setEdits((e) => { const n = { ...e }; delete n[v.id]; return n }); flash(true, 'Message saved.')
+    },
+    onError: () => flash(false, 'Could not save the message.'),
+  })
+
+  const actionMutation = useMutation({
+    mutationFn: (v: { id: number; action: 'approve' | 'cancel' }) =>
+      api.put('/catchup/touch', { session_token: sessionToken, touch_id: v.id, action: v.action }),
+    onSuccess: () => invalidate(),
+    onError: () => flash(false, 'Could not update this touch.'),
+  })
+
+  return (
+    <div className="space-y-4">
+      {msg && <p className={`text-sm font-medium ${msg.ok ? 'text-green-600' : 'text-red-600'}`}>{msg.text}</p>}
+
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-5 space-y-1">
+        <h3 className="font-semibold text-gray-700">Catch-up congratulations</h3>
+        <p className="text-xs text-gray-500">
+          LEM scans your LinkedIn Catch-up feed daily for network milestones — new jobs, promotions,
+          work anniversaries — scores them against your targeting, and drafts a personal
+          congratulations in your voice. <span className="font-semibold">Nothing sends until you
+          approve it</span>, each milestone is messaged at most once, and approved messages drip out
+          under your daily catch-up and DM caps (Account → Engagement).
+        </p>
+      </div>
+
+      {/* Status filter */}
+      <div className="flex gap-2 flex-wrap">
+        {STATUSES.map((s) => (
+          <button key={s} onClick={() => setFilter(s)}
+            className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
+              filter === s ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 border border-gray-300 hover:border-blue-400'
+            }`}>
+            {s.toUpperCase()}
+          </button>
+        ))}
+      </div>
+
+      {isLoading && <p className="text-gray-400 text-sm">Loading catch-up touches…</p>}
+      {!isLoading && touches.length === 0 && (
+        <div className="text-center py-10 bg-white rounded-lg border border-gray-200 text-sm text-gray-500">
+          No catch-up touches {filter === 'ALL' ? 'yet' : `with status ${filter}`}.
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {touches.map((t) => {
+          const editing = edits[t.id] !== undefined
+          const messageValue = editing ? edits[t.id] : (t.message ?? '')
+          const editable = ['pending', 'approved', 'failed'].includes(t.status)
+          return (
+            <div key={t.id} className="bg-white rounded-lg border border-gray-200 p-4 space-y-2">
+              <div className="flex items-center justify-between gap-2">
+                <a href={t.profile_url} target="_blank" rel="noopener noreferrer"
+                  className="text-sm font-medium text-blue-700 truncate hover:underline">
+                  {t.person_name || t.profile_url}
+                </a>
+                <div className="flex items-center gap-2 shrink-0">
+                  <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-700">
+                    {EVENT_LABELS[t.event_type] ?? t.event_type}
+                  </span>
+                  <span className="text-xs text-gray-400" title="Fit score">{t.score}</span>
+                  <span className="text-xs text-gray-400">{formatInTimezone(t.created_at, userTimezone)}</span>
+                  <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[t.status] ?? 'bg-gray-100 text-gray-600'}`}>
+                    {t.status.toUpperCase()}
+                  </span>
+                </div>
+              </div>
+              {t.event_detail && <p className="text-xs text-gray-400 line-clamp-2">{t.event_detail}</p>}
+
+              {editable ? (
+                <>
+                  <textarea value={messageValue} rows={3} maxLength={MESSAGE_MAX}
+                    onChange={(e) => setEdits((prev) => ({ ...prev, [t.id]: e.target.value }))}
+                    placeholder="Your congratulations message…"
+                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+                  <div className="flex gap-2 flex-wrap">
+                    <button onClick={() => saveMutation.mutate({ id: t.id, message: messageValue })}
+                      disabled={!editing || saveMutation.isPending}
+                      className="px-3 py-1 border border-gray-300 text-gray-600 rounded text-xs font-semibold hover:bg-gray-50 disabled:opacity-50">
+                      Save message
+                    </button>
+                    {['pending', 'failed'].includes(t.status) && (
+                      <button onClick={() => actionMutation.mutate({ id: t.id, action: 'approve' })}
+                        disabled={actionMutation.isPending}
+                        className="px-3 py-1 bg-green-600 text-white rounded text-xs font-semibold hover:bg-green-700 disabled:opacity-50">
+                        {t.status === 'pending' ? 'Approve & send' : 'Retry'}
+                      </button>
+                    )}
+                    <button onClick={() => actionMutation.mutate({ id: t.id, action: 'cancel' })}
+                      disabled={actionMutation.isPending}
+                      className="px-3 py-1 border border-gray-300 text-gray-600 rounded text-xs font-semibold hover:bg-gray-50 disabled:opacity-50">
+                      Cancel
+                    </button>
+                  </div>
+                </>
+              ) : (
+                t.message && <p className="text-sm text-gray-700 whitespace-pre-wrap line-clamp-3">{t.message}</p>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2708,10 +2708,42 @@ def update_user_preferences(
 
 
 # Catch-up milestone types eligible for a congratulations touch out of the box (issue #482): the two
-# real trigger events. Birthdays/anniversaries are opt-in — congratulating those at volume reads as spam.
+# real trigger events. All six types are user-configurable; birthdays/anniversaries are opt-in because
+# congratulating those at volume reads as spam.
 DEFAULT_CATCHUP_EVENT_TYPES = ("job_change", "promotion")
 VALID_CATCHUP_TOUCH_MODES = ("pre_review", "auto_approve")
-CATCHUP_TOUCHES_MIN, CATCHUP_TOUCHES_MAX = 0, 25
+# Where the congratulations text comes from. 'linkedin' = LinkedIn's own pre-drafted response for the
+# moment (no LLM); 'ai' = the DM-template + voice-refinement path, for users who want more customization.
+VALID_CATCHUP_MESSAGE_SOURCES = ("linkedin", "ai")
+# Per-day cap bounds. 5/day is the ceiling on every plan; raising it to 10/day is a premium feature
+# (owner review on PR #509: "3A, but use 3B as a premium subscribed user feature").
+CATCHUP_TOUCHES_MIN = 0
+CATCHUP_TOUCHES_MAX_STANDARD = 5
+CATCHUP_TOUCHES_MAX_PREMIUM = 10
+# Absolute ceiling accepted at the API boundary — the per-user allowance is applied on top of it.
+CATCHUP_TOUCHES_MAX = CATCHUP_TOUCHES_MAX_PREMIUM
+# Paid plans that unlock the premium catch-up allowance (see stripe_util.TIER_PRICE_MAP).
+PREMIUM_SUBSCRIPTION_TIERS = ("professional", "enterprise")
+ACTIVE_SUBSCRIPTION_STATUSES = ("active", "trial")
+
+
+def is_premium_subscriber(user_id: int) -> bool:
+    """True when the user is on a currently-active professional/enterprise plan. Anything else —
+    free trial, starter, lapsed, unknown, or a DB error — is treated as NOT premium, so a premium-only
+    allowance can never be granted by accident."""
+    try:
+        info = get_user_subscription_info(user_id)
+    except Exception:
+        return False
+    if not info:
+        return False
+    return (str(info.get("subscription_tier") or "") in PREMIUM_SUBSCRIPTION_TIERS
+            and str(info.get("subscription_status") or "") in ACTIVE_SUBSCRIPTION_STATUSES)
+
+
+def max_catchup_touches_allowed(user_id: int) -> int:
+    """The highest catch-up cap this user may set — 10/day on premium plans, 5/day otherwise."""
+    return CATCHUP_TOUCHES_MAX_PREMIUM if is_premium_subscriber(user_id) else CATCHUP_TOUCHES_MAX_STANDARD
 
 _ENGAGEMENT_DEFAULTS: dict = {
     # Default to MEDIUM (issue #394): 2026 LinkedIn weights substantive ≥15-word comments ~2.5× short
@@ -2736,8 +2768,10 @@ _ENGAGEMENT_DEFAULTS: dict = {
     "feed_fallback_when_empty": True, "link_in_first_comment": True,
     # Catch-up congratulations (issue #482): small cap, human approval, and only the BD-relevant
     # milestone types out of the box — a generic "Congrats!" at volume is worse than nothing.
-    "max_catchup_touches_per_day": 5, "catchup_touch_mode": "pre_review",
+    # The message itself defaults to LinkedIn's own pre-drafted response (no LLM).
+    "max_catchup_touches_per_day": CATCHUP_TOUCHES_MAX_STANDARD, "catchup_touch_mode": "pre_review",
     "catchup_event_types": list(DEFAULT_CATCHUP_EVENT_TYPES),
+    "catchup_message_source": "linkedin",
 }
 _ENGAGEMENT_JSON_FIELDS = ("include_topics", "exclude_topics", "include_keywords",
                            "exclude_keywords", "include_authors", "exclude_authors", "post_types",
@@ -2755,7 +2789,8 @@ _ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "us
                     "default_buyer_stage", "default_video_quality",
                     "reply_check_mode", "reply_sweeps_per_day", "reply_max_post_age_days",
                     "feed_fallback_when_empty", "link_in_first_comment",
-                    "max_catchup_touches_per_day", "catchup_touch_mode", "catchup_event_types")
+                    "max_catchup_touches_per_day", "catchup_touch_mode", "catchup_event_types",
+                    "catchup_message_source")
 
 VALID_VIDEO_QUALITIES = ("standard", "premium", "premium_top")
 VALID_REPLY_MODES = ("event", "scheduled", "off")
@@ -2799,6 +2834,8 @@ def get_engagement_preferences(user_id: int) -> dict:
         # catch-up touches off, so only coerce the NULL case.
         if row.get("catchup_event_types") is None:
             row["catchup_event_types"] = list(DEFAULT_CATCHUP_EVENT_TYPES)
+        if row.get("catchup_message_source") not in VALID_CATCHUP_MESSAGE_SOURCES:
+            row["catchup_message_source"] = _ENGAGEMENT_DEFAULTS["catchup_message_source"]
         for f in _ENGAGEMENT_JSON_FIELDS:
             row[f] = _coerce_json_list(row.get(f))
         for f in _ENGAGEMENT_BOOL_FIELDS:
@@ -2847,13 +2884,19 @@ def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
         merged["reply_max_post_age_days"] = 2
     if merged.get("catchup_touch_mode") not in VALID_CATCHUP_TOUCH_MODES:
         merged["catchup_touch_mode"] = "pre_review"
+    if merged.get("catchup_message_source") not in VALID_CATCHUP_MESSAGE_SOURCES:
+        merged["catchup_message_source"] = "linkedin"
+    # The cap ceiling is per-plan: 10/day only on an active premium plan, 5/day otherwise. Clamped
+    # here (not just at the API boundary) so a downgrade silently pulls the saved cap back down.
+    _cap_max = max_catchup_touches_allowed(user_id)
     _ct = merged.get("max_catchup_touches_per_day")
     try:
         merged["max_catchup_touches_per_day"] = (
-            min(CATCHUP_TOUCHES_MAX, max(CATCHUP_TOUCHES_MIN, int(_ct))) if _ct is not None
-            else _ENGAGEMENT_DEFAULTS["max_catchup_touches_per_day"])
+            min(_cap_max, max(CATCHUP_TOUCHES_MIN, int(_ct))) if _ct is not None
+            else min(_cap_max, _ENGAGEMENT_DEFAULTS["max_catchup_touches_per_day"]))
     except (TypeError, ValueError):
-        merged["max_catchup_touches_per_day"] = _ENGAGEMENT_DEFAULTS["max_catchup_touches_per_day"]
+        merged["max_catchup_touches_per_day"] = min(
+            _cap_max, _ENGAGEMENT_DEFAULTS["max_catchup_touches_per_day"])
     # Drop unknown milestone types before they hit the ENUM-validated ledger.
     merged["catchup_event_types"] = [t for t in (merged.get("catchup_event_types") or [])
                                      if t in tuple(CatchupEventType)]

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -97,6 +97,28 @@ class ConnectionRequestStatus(StrEnum):
     CANCELED = 'canceled'    # canceled before send
 
 
+class CatchupEventType(StrEnum):
+    """A LinkedIn Catch-up "moment" we can congratulate on (issue #482). Ordered most→least
+    BD-relevant: a new job or promotion is a real trigger event, a birthday is small talk."""
+    JOB_CHANGE = 'job_change'
+    PROMOTION = 'promotion'
+    WORK_ANNIVERSARY = 'work_anniversary'
+    EDUCATION = 'education'
+    IN_THE_NEWS = 'in_the_news'
+    BIRTHDAY = 'birthday'
+
+
+class CatchupTouchStatus(StrEnum):
+    """Status of a drafted catch-up congratulations DM (issue #482), mirroring ConnectionRequestStatus."""
+    PENDING = 'pending'      # drafted, awaiting human approval
+    APPROVED = 'approved'    # approved, waiting for the capped scanner
+    SENDING = 'sending'      # scanner dispatched the send task
+    SENT = 'sent'            # DM sent
+    SKIPPED = 'skipped'      # scored below the bar / event type disabled — kept as a dedup tombstone
+    FAILED = 'failed'        # send failed
+    CANCELED = 'canceled'    # operator canceled before send
+
+
 class OutreachStage(StrEnum):
     """Stage of a comment-first outreach funnel target (issue #399)."""
     COMMENT = 'comment'      # leave a value-adding comment on the prospect's post
@@ -2685,6 +2707,12 @@ def update_user_preferences(
         connection.close()
 
 
+# Catch-up milestone types eligible for a congratulations touch out of the box (issue #482): the two
+# real trigger events. Birthdays/anniversaries are opt-in — congratulating those at volume reads as spam.
+DEFAULT_CATCHUP_EVENT_TYPES = ("job_change", "promotion")
+VALID_CATCHUP_TOUCH_MODES = ("pre_review", "auto_approve")
+CATCHUP_TOUCHES_MIN, CATCHUP_TOUCHES_MAX = 0, 25
+
 _ENGAGEMENT_DEFAULTS: dict = {
     # Default to MEDIUM (issue #394): 2026 LinkedIn weights substantive ≥15-word comments ~2.5× short
     # one-liners, so the out-of-the-box length produces a real, specific reply rather than a throwaway.
@@ -2706,10 +2734,14 @@ _ENGAGEMENT_DEFAULTS: dict = {
     "default_video_quality": "standard",
     "reply_check_mode": "event", "reply_sweeps_per_day": 2, "reply_max_post_age_days": 2,
     "feed_fallback_when_empty": True, "link_in_first_comment": True,
+    # Catch-up congratulations (issue #482): small cap, human approval, and only the BD-relevant
+    # milestone types out of the box — a generic "Congrats!" at volume is worse than nothing.
+    "max_catchup_touches_per_day": 5, "catchup_touch_mode": "pre_review",
+    "catchup_event_types": list(DEFAULT_CATCHUP_EVENT_TYPES),
 }
 _ENGAGEMENT_JSON_FIELDS = ("include_topics", "exclude_topics", "include_keywords",
                            "exclude_keywords", "include_authors", "exclude_authors", "post_types",
-                           "focus_topics", "connection_target_authors")
+                           "focus_topics", "connection_target_authors", "catchup_event_types")
 _ENGAGEMENT_BOOL_FIELDS = ("use_emojis", "use_hashtags", "reply_to_own_comments",
                            "feed_fallback_when_empty", "link_in_first_comment")
 _ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "use_hashtags",
@@ -2722,7 +2754,8 @@ _ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "us
                     "min_connection_icp_score",
                     "default_buyer_stage", "default_video_quality",
                     "reply_check_mode", "reply_sweeps_per_day", "reply_max_post_age_days",
-                    "feed_fallback_when_empty", "link_in_first_comment")
+                    "feed_fallback_when_empty", "link_in_first_comment",
+                    "max_catchup_touches_per_day", "catchup_touch_mode", "catchup_event_types")
 
 VALID_VIDEO_QUALITIES = ("standard", "premium", "premium_top")
 VALID_REPLY_MODES = ("event", "scheduled", "off")
@@ -2761,6 +2794,11 @@ def get_engagement_preferences(user_id: int) -> dict:
         row = cursor.fetchone()
         if row is None:
             return dict(_ENGAGEMENT_DEFAULTS)
+        # A NULL catchup_event_types (every row predating the V20260724211808 migration) means
+        # "never configured" -> the default BD subset. An explicit empty list means the user turned
+        # catch-up touches off, so only coerce the NULL case.
+        if row.get("catchup_event_types") is None:
+            row["catchup_event_types"] = list(DEFAULT_CATCHUP_EVENT_TYPES)
         for f in _ENGAGEMENT_JSON_FIELDS:
             row[f] = _coerce_json_list(row.get(f))
         for f in _ENGAGEMENT_BOOL_FIELDS:
@@ -2807,6 +2845,18 @@ def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
                                              if _age is not None else 2)
     except (TypeError, ValueError):
         merged["reply_max_post_age_days"] = 2
+    if merged.get("catchup_touch_mode") not in VALID_CATCHUP_TOUCH_MODES:
+        merged["catchup_touch_mode"] = "pre_review"
+    _ct = merged.get("max_catchup_touches_per_day")
+    try:
+        merged["max_catchup_touches_per_day"] = (
+            min(CATCHUP_TOUCHES_MAX, max(CATCHUP_TOUCHES_MIN, int(_ct))) if _ct is not None
+            else _ENGAGEMENT_DEFAULTS["max_catchup_touches_per_day"])
+    except (TypeError, ValueError):
+        merged["max_catchup_touches_per_day"] = _ENGAGEMENT_DEFAULTS["max_catchup_touches_per_day"]
+    # Drop unknown milestone types before they hit the ENUM-validated ledger.
+    merged["catchup_event_types"] = [t for t in (merged.get("catchup_event_types") or [])
+                                     if t in tuple(CatchupEventType)]
 
     def _val(col):
         v = merged[col]
@@ -3582,6 +3632,210 @@ def update_outreach_target(target_id: int, target_profile_url: str = None, targe
         return cursor.rowcount >= 0
     except mysql.connector.Error as err:
         myprint(f"Could not update outreach target {target_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+# --- LinkedIn Catch-up touches (issue #482) — approval-gated, deduped milestone congratulations ---
+_CATCHUP_COLS = ("id", "user_id", "profile_url", "person_name", "event_type", "event_detail",
+                 "event_period", "score", "message", "status", "created_at", "updated_at")
+
+
+def insert_catchup_touch(user_id: int, profile_url: str, event_type: "CatchupEventType",
+                         event_period: str, person_name: str = None, event_detail: str = None,
+                         message: str = None, score: int = 0,
+                         status: "CatchupTouchStatus" = CatchupTouchStatus.PENDING) -> Optional[int]:
+    """Record a drafted catch-up touch. Returns None when the milestone is already in the ledger —
+    the (user, profile, event_type, event_period) unique key is the dedup guarantee, so a moment that
+    stays in the feed for days can never be messaged twice."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO catchup_touches (user_id, profile_url, person_name, event_type, "
+            "event_detail, event_period, score, message, status) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+            (user_id, profile_url, person_name, str(event_type), event_detail, event_period,
+             int(score), message, str(status)))
+        connection.commit()
+        return cursor.lastrowid
+    except mysql.connector.Error as err:
+        myprint(f"Could not insert catchup touch for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_catchup_touch(touch_id: int) -> Optional[dict]:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(f"SELECT {', '.join(_CATCHUP_COLS)} FROM catchup_touches WHERE id = %s",
+                       (touch_id,))
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get catchup touch {touch_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_catchup_touch_user_id(touch_id: int) -> Optional[int]:
+    row = get_catchup_touch(touch_id)
+    return row["user_id"] if row else None
+
+
+def has_catchup_touch(user_id: int, profile_url: str, event_type: "CatchupEventType",
+                      event_period: str) -> bool:
+    """True if this exact milestone has already been drafted/sent — checked before drafting so we
+    don't spend an LLM call on a moment the unique key would reject anyway."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT 1 FROM catchup_touches WHERE user_id = %s AND profile_url = %s "
+            "AND event_type = %s AND event_period = %s LIMIT 1",
+            (user_id, profile_url, str(event_type), event_period))
+        return cursor.fetchone() is not None
+    except mysql.connector.Error as err:
+        myprint(f"Could not check catchup touch for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_catchup_touches(user_id: int, status_filter: str = None, event_type_filter: str = None,
+                        page: int = 1, page_size: int = 25, sort_order: str = "desc") -> dict:
+    """Paginated list of a user's catch-up touches (mirrors get_connection_requests)."""
+    order = "ASC" if str(sort_order).lower() == "asc" else "DESC"
+    where = "WHERE user_id = %s"
+    params: list = [user_id]
+    if status_filter:
+        where += " AND status = %s"
+        params.append(status_filter)
+    if event_type_filter:
+        where += " AND event_type = %s"
+        params.append(event_type_filter)
+    offset = max(0, (max(1, page) - 1) * page_size)
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(f"SELECT COUNT(*) AS c FROM catchup_touches {where}", tuple(params))
+        total = int(cursor.fetchone()["c"])
+        cursor.execute(
+            f"SELECT {', '.join(_CATCHUP_COLS)} FROM catchup_touches {where} "
+            f"ORDER BY score DESC, created_at {order} LIMIT %s OFFSET %s",
+            tuple(params + [page_size, offset]))
+        rows = cursor.fetchall()
+        for r in rows:
+            for k in ("created_at", "updated_at"):
+                if isinstance(r.get(k), datetime):
+                    r[k] = r[k].isoformat()
+        return {"touches": rows, "total": total, "page": page, "page_size": page_size}
+    except mysql.connector.Error as err:
+        myprint(f"Could not list catchup touches for user_id {user_id} | Error: {err}")
+        return {"touches": [], "total": 0, "page": page, "page_size": page_size}
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_approved_catchup_touches() -> list:
+    """Approved touches waiting to be sent, highest-scoring first so the best moments go out within
+    the daily cap. Returns (id, user_id) tuples; the cap is enforced by the scanner/send task."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT id, user_id FROM catchup_touches WHERE status = 'approved' "
+            "ORDER BY score DESC, created_at ASC")
+        return cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get approved catchup touches | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_orphaned_catchup_touches(lookback_hours: int = 2) -> list:
+    """Touches stuck in 'sending' whose send task was lost (e.g. Celery queue purged on restart).
+    Mirrors get_orphaned_connection_requests. Returns (id, user_id) tuples."""
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=lookback_hours)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT id, user_id FROM catchup_touches WHERE status = 'sending' "
+            "AND updated_at <= %s ORDER BY updated_at ASC", (cutoff,))
+        return cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get orphaned catchup touches | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def count_catchup_touches_sent_today(user_id: int) -> int:
+    """Catch-up DMs sent today (UTC) — the per-day cap is on top of the overall DM cap."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM catchup_touches WHERE user_id = %s AND status = 'sent' "
+            "AND updated_at >= CURDATE()", (user_id,))
+        r = cursor.fetchone()
+        return int(r[0]) if r else 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not count catchup touches for user_id {user_id} | Error: {err}")
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_catchup_touch_status(touch_id: int, status: "CatchupTouchStatus") -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("UPDATE catchup_touches SET status = %s WHERE id = %s",
+                       (str(status), touch_id))
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update catchup touch {touch_id} status | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_catchup_touch(touch_id: int, message: str = None, person_name: str = None,
+                         status: "CatchupTouchStatus" = None) -> bool:
+    fields, params = [], []
+    for col, val in (("message", message), ("person_name", person_name)):
+        if val is not None:
+            fields.append(f"{col} = %s")
+            params.append(val)
+    if status is not None:
+        fields.append("status = %s")
+        params.append(str(status))
+    if not fields:
+        return False
+    params.append(touch_id)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(f"UPDATE catchup_touches SET {', '.join(fields)} WHERE id = %s", tuple(params))
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update catchup touch {touch_id} | Error: {err}")
         return False
     finally:
         cursor.close()
@@ -5166,6 +5420,20 @@ _DM_DEFAULT_TEMPLATES = {
     "nurture": "Thanks for coming back to me, {first_name} — that's helpful context. Happy to share "
                "what I've seen work on {headline}; would a short call be useful, or shall I just "
                "send over the one thing that would help most?",
+    # Catch-up milestone congratulations (issue #482). The congrats IS the message — no pitch. Each
+    # references the specific moment ({event_detail}) so it can never read as a generic "Congrats!".
+    "job_change": "Hi {first_name}, congratulations on the new role — {event_detail}. That's a great "
+                  "step. What drew you to it?",
+    "promotion": "Hi {first_name}, congratulations on the promotion — {event_detail}. Well earned. "
+                 "What are you most looking forward to in the new scope?",
+    "work_anniversary": "Hi {first_name}, congratulations on the work anniversary — {event_detail}. "
+                        "That's a real milestone. What's changed most for you over that stretch?",
+    "birthday": "Hi {first_name}, happy birthday! Hope you get to step away from the inbox for a bit "
+                "today.",
+    "education": "Hi {first_name}, congratulations — {event_detail}. That's a big commitment to see "
+                 "through. What's next now that it's done?",
+    "in_the_news": "Hi {first_name}, saw you in the news — {event_detail}. Congratulations, that's "
+                   "great visibility. How did it come about?",
 }
 
 

--- a/tests/unit/api/test_catchup_touches_api.py
+++ b/tests/unit/api/test_catchup_touches_api.py
@@ -1,0 +1,186 @@
+"""Unit tests for the catch-up touch API endpoints and preferences (issue #482)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_M = "cqc_lem.api.main"
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_S = "tok"
+_U = 5
+
+
+class TestListTouches:
+    def test_lists_with_filters(self, client):
+        payload = {"touches": [], "total": 0, "page": 1, "page_size": 25}
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touches", return_value=payload) as lister:
+            resp = client.get("/api/catchup/touches",
+                              params={"session_token": _S, "status_filter": "pending",
+                                      "event_type_filter": "job_change"})
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == payload
+        assert lister.call_args.kwargs["status_filter"] == "pending"
+        assert lister.call_args.kwargs["event_type_filter"] == "job_change"
+
+    def test_requires_a_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.get("/api/catchup/touches", params={"session_token": _S})
+        assert resp.status_code == 401
+
+
+class TestUpdateTouch:
+    def test_approve_maps_to_approved_status(self, client):
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U), \
+             patch(f"{_M}.update_catchup_touch", return_value=True) as upd:
+            resp = client.put("/api/catchup/touch",
+                              json={"session_token": _S, "touch_id": 3, "action": "approve"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["status"] == CatchupTouchStatus.APPROVED
+
+    def test_edit_message_without_action(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U), \
+             patch(f"{_M}.update_catchup_touch", return_value=True) as upd:
+            resp = client.put("/api/catchup/touch",
+                              json={"session_token": _S, "touch_id": 3, "message": "Congrats!"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["message"] == "Congrats!"
+        assert upd.call_args.kwargs["status"] is None
+
+    def test_unknown_action_is_rejected(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U):
+            resp = client.put("/api/catchup/touch",
+                              json={"session_token": _S, "touch_id": 3, "action": "send_now"})
+        assert resp.status_code == 422
+
+    def test_empty_update_is_rejected(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U):
+            resp = client.put("/api/catchup/touch", json={"session_token": _S, "touch_id": 3})
+        assert resp.status_code == 422
+
+    def test_another_users_touch_is_not_found(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch_user_id", return_value=99):
+            resp = client.put("/api/catchup/touch",
+                              json={"session_token": _S, "touch_id": 3, "action": "approve"})
+        assert resp.status_code == 404
+
+    def test_requires_a_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.put("/api/catchup/touch",
+                              json={"session_token": _S, "touch_id": 3, "action": "approve"})
+        assert resp.status_code == 401
+
+    def test_db_failure_is_a_500(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U), \
+             patch(f"{_M}.update_catchup_touch", return_value=False):
+            resp = client.put("/api/catchup/touch",
+                              json={"session_token": _S, "touch_id": 3, "action": "approve"})
+        assert resp.status_code == 500
+
+
+class TestDeleteTouch:
+    def test_cancels(self, client):
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U), \
+             patch(f"{_M}.update_catchup_touch_status", return_value=True) as upd:
+            resp = client.request("DELETE", "/api/catchup/touch",
+                                  json={"session_token": _S, "touch_id": 3})
+        assert resp.status_code == 200
+        upd.assert_called_once_with(3, CatchupTouchStatus.CANCELED)
+
+    def test_another_users_touch_is_not_found(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch_user_id", return_value=99):
+            resp = client.request("DELETE", "/api/catchup/touch",
+                                  json={"session_token": _S, "touch_id": 3})
+        assert resp.status_code == 404
+
+    def test_requires_a_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.request("DELETE", "/api/catchup/touch",
+                                  json={"session_token": _S, "touch_id": 3})
+        assert resp.status_code == 401
+
+    def test_db_failure_is_a_500(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U), \
+             patch(f"{_M}.update_catchup_touch_status", return_value=False):
+            resp = client.request("DELETE", "/api/catchup/touch",
+                                  json={"session_token": _S, "touch_id": 3})
+        assert resp.status_code == 500
+
+
+class TestCatchupPreferenceValidation:
+    def test_defaults_are_the_bd_subset_and_pre_review(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences", json={"session_token": _S})
+        assert resp.status_code == 200
+        prefs = upd.call_args[0][1]
+        assert prefs["catchup_event_types"] == ["job_change", "promotion"]
+        assert prefs["catchup_touch_mode"] == "pre_review"
+        assert prefs["max_catchup_touches_per_day"] == 5
+
+    def test_unknown_event_types_are_dropped(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences", json={
+                "session_token": _S, "catchup_event_types": ["promotion", "wedding"]})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1]["catchup_event_types"] == ["promotion"]
+
+    @pytest.mark.parametrize("given,expected", [(999, 25), (-1, 0), (3, 3)])
+    def test_cap_is_clamped(self, client, given, expected):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences", json={
+                "session_token": _S, "max_catchup_touches_per_day": given})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1]["max_catchup_touches_per_day"] == expected
+
+    def test_bad_mode_falls_back_to_pre_review(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences", json={
+                "session_token": _S, "catchup_touch_mode": "yolo"})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1]["catchup_touch_mode"] == "pre_review"
+
+    def test_auto_approve_is_accepted(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences", json={
+                "session_token": _S, "catchup_touch_mode": "auto_approve"})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1]["catchup_touch_mode"] == "auto_approve"

--- a/tests/unit/api/test_catchup_touches_api.py
+++ b/tests/unit/api/test_catchup_touches_api.py
@@ -151,6 +151,7 @@ class TestCatchupPreferenceValidation:
         assert prefs["catchup_event_types"] == ["job_change", "promotion"]
         assert prefs["catchup_touch_mode"] == "pre_review"
         assert prefs["max_catchup_touches_per_day"] == 5
+        assert prefs["catchup_message_source"] == "linkedin"
 
     def test_unknown_event_types_are_dropped(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_U), \
@@ -160,14 +161,35 @@ class TestCatchupPreferenceValidation:
         assert resp.status_code == 200
         assert upd.call_args[0][1]["catchup_event_types"] == ["promotion"]
 
-    @pytest.mark.parametrize("given,expected", [(999, 25), (-1, 0), (3, 3)])
-    def test_cap_is_clamped(self, client, given, expected):
+    @pytest.mark.parametrize("given,expected", [(999, 10), (-1, 0), (3, 3)])
+    def test_cap_is_clamped_to_the_absolute_ceiling(self, client, given, expected):
+        """The boundary caps at the premium ceiling; the per-plan allowance is applied in db.py."""
         with patch(f"{_M}.get_session_user_id", return_value=_U), \
              patch(f"{_M}.update_engagement_preferences", return_value=True) as upd:
             resp = client.put("/api/user/engagement-preferences", json={
                 "session_token": _S, "max_catchup_touches_per_day": given})
         assert resp.status_code == 200
         assert upd.call_args[0][1]["max_catchup_touches_per_day"] == expected
+
+    @pytest.mark.parametrize("given,expected", [("ai", "ai"), ("gpt", "linkedin")])
+    def test_message_source_is_validated(self, client, given, expected):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences", json={
+                "session_token": _S, "catchup_message_source": given})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1]["catchup_message_source"] == expected
+
+    @pytest.mark.parametrize("allowance", [5, 10])
+    def test_get_exposes_the_plan_allowance(self, client, allowance):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_engagement_preferences", return_value={"tone": None}), \
+             patch(f"{_M}.get_or_create_reply_inbound_token", return_value=None), \
+             patch(f"{_M}.get_gmail_forward_confirmation", return_value=None), \
+             patch(f"{_M}.max_catchup_touches_allowed", return_value=allowance):
+            resp = client.get("/api/user/engagement-preferences", params={"session_token": _S})
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["max_catchup_touches_allowed"] == allowance
 
     def test_bad_mode_falls_back_to_pre_review(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_U), \

--- a/tests/unit/api/test_catchup_touches_api.py
+++ b/tests/unit/api/test_catchup_touches_api.py
@@ -52,11 +52,17 @@ class TestListTouches:
         assert resp.status_code == 401
 
 
+def _touch(**kw):
+    base = {"id": 3, "user_id": _U, "message": "Congrats Jane!", "status": "pending"}
+    base.update(kw)
+    return base
+
+
 class TestUpdateTouch:
     def test_approve_maps_to_approved_status(self, client):
         from cqc_lem.utilities.db import CatchupTouchStatus
         with patch(f"{_M}.get_session_user_id", return_value=_U), \
-             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch", return_value=_touch()), \
              patch(f"{_M}.update_catchup_touch", return_value=True) as upd:
             resp = client.put("/api/catchup/touch",
                               json={"session_token": _S, "touch_id": 3, "action": "approve"})
@@ -65,7 +71,7 @@ class TestUpdateTouch:
 
     def test_edit_message_without_action(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_U), \
-             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch", return_value=_touch()), \
              patch(f"{_M}.update_catchup_touch", return_value=True) as upd:
             resp = client.put("/api/catchup/touch",
                               json={"session_token": _S, "touch_id": 3, "message": "Congrats!"})
@@ -73,22 +79,70 @@ class TestUpdateTouch:
         assert upd.call_args.kwargs["message"] == "Congrats!"
         assert upd.call_args.kwargs["status"] is None
 
+    def test_approve_saves_the_edited_message_in_the_same_call(self, client):
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch", return_value=_touch()), \
+             patch(f"{_M}.update_catchup_touch", return_value=True) as upd:
+            resp = client.put("/api/catchup/touch", json={
+                "session_token": _S, "touch_id": 3, "action": "approve", "message": "Edited congrats!"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["message"] == "Edited congrats!"
+        assert upd.call_args.kwargs["status"] == CatchupTouchStatus.APPROVED
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\n\t "])
+    def test_blank_message_is_rejected(self, client, blank):
+        """A blank message would become a permanent SKIPPED at send time — reject it at the boundary."""
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch", return_value=_touch()), \
+             patch(f"{_M}.update_catchup_touch", return_value=True) as upd:
+            resp = client.put("/api/catchup/touch",
+                              json={"session_token": _S, "touch_id": 3, "message": blank})
+        assert resp.status_code == 422
+        upd.assert_not_called()
+
+    def test_approving_a_touch_with_no_stored_message_is_rejected(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch", return_value=_touch(message=None)), \
+             patch(f"{_M}.update_catchup_touch", return_value=True) as upd:
+            resp = client.put("/api/catchup/touch",
+                              json={"session_token": _S, "touch_id": 3, "action": "approve"})
+        assert resp.status_code == 422
+        upd.assert_not_called()
+
+    def test_canceling_a_touch_with_no_message_is_still_allowed(self, client):
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch", return_value=_touch(message=None)), \
+             patch(f"{_M}.update_catchup_touch", return_value=True) as upd:
+            resp = client.put("/api/catchup/touch",
+                              json={"session_token": _S, "touch_id": 3, "action": "cancel"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["status"] == CatchupTouchStatus.CANCELED
+
     def test_unknown_action_is_rejected(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_U), \
-             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U):
+             patch(f"{_M}.get_catchup_touch", return_value=_touch()):
             resp = client.put("/api/catchup/touch",
                               json={"session_token": _S, "touch_id": 3, "action": "send_now"})
         assert resp.status_code == 422
 
     def test_empty_update_is_rejected(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_U), \
-             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U):
+             patch(f"{_M}.get_catchup_touch", return_value=_touch()):
             resp = client.put("/api/catchup/touch", json={"session_token": _S, "touch_id": 3})
         assert resp.status_code == 422
 
     def test_another_users_touch_is_not_found(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_U), \
-             patch(f"{_M}.get_catchup_touch_user_id", return_value=99):
+             patch(f"{_M}.get_catchup_touch", return_value=_touch(user_id=99)):
+            resp = client.put("/api/catchup/touch",
+                              json={"session_token": _S, "touch_id": 3, "action": "approve"})
+        assert resp.status_code == 404
+
+    def test_missing_touch_is_not_found(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch", return_value=None):
             resp = client.put("/api/catchup/touch",
                               json={"session_token": _S, "touch_id": 3, "action": "approve"})
         assert resp.status_code == 404
@@ -101,7 +155,7 @@ class TestUpdateTouch:
 
     def test_db_failure_is_a_500(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_U), \
-             patch(f"{_M}.get_catchup_touch_user_id", return_value=_U), \
+             patch(f"{_M}.get_catchup_touch", return_value=_touch()), \
              patch(f"{_M}.update_catchup_touch", return_value=False):
             resp = client.put("/api/catchup/touch",
                               json={"session_token": _S, "touch_id": 3, "action": "approve"})

--- a/tests/unit/app/test_catchup_touches.py
+++ b/tests/unit/app/test_catchup_touches.py
@@ -516,7 +516,7 @@ class TestSendCatchupTouch:
             "dms": patch(f"{_RA}.count_dms_sent_today", return_value=dms_today),
             "send": patch(f"{_RA}.send_dm_now", return_value=sent),
             "upd": patch(f"{_RA}.update_catchup_touch_status"),
-            "enq": patch(f"{_RA}.enqueue_next_followup"),
+            "enq": patch(f"{_RA}._schedule_catchup_followup"),
         }
 
     def test_sends_and_marks_sent(self):
@@ -618,6 +618,49 @@ class TestSendCatchupTouch:
         send.assert_not_called()
         upd.assert_called_once_with(3, CatchupTouchStatus.SKIPPED)
         assert "no message" in out
+
+
+class TestScheduleCatchupFollowup:
+    """The row this schedules is what process_user_followups reads — and the reply check it drives is
+    the ONLY thing that routes a replying prospect into the funnel, so it has to exist even for a user
+    who never configured a step-1 template (the defaults only cover step 0)."""
+
+    def test_configured_step_one_template_runs_the_normal_sequence(self):
+        from cqc_lem.app.run_automation import _schedule_catchup_followup
+        with patch(f"{_RA}.get_dm_template", return_value={"template_text": "…", "delay_hours": 72}), \
+             patch(f"{_RA}.enqueue_next_followup") as nxt, patch(f"{_RA}.enqueue_followup") as enq:
+            _schedule_catchup_followup(1, "https://www.linkedin.com/in/jane", "Jane", "job_change")
+        nxt.assert_called_once_with(1, "https://www.linkedin.com/in/jane", "Jane", "job_change", 0)
+        enq.assert_not_called()
+
+    @pytest.mark.parametrize("event_type", ["job_change", "promotion"])
+    def test_high_value_milestone_gets_a_reply_check_without_a_template(self, event_type):
+        from datetime import datetime, timezone
+        from cqc_lem.app.run_automation import _schedule_catchup_followup, CATCHUP_REPLY_CHECK_HOURS
+        with patch(f"{_RA}.get_dm_template", return_value=None), \
+             patch(f"{_RA}.enqueue_next_followup") as nxt, patch(f"{_RA}.enqueue_followup") as enq:
+            _schedule_catchup_followup(1, "https://www.linkedin.com/in/jane", "Jane", event_type)
+        nxt.assert_not_called()
+        args = enq.call_args[0]
+        assert args[:5] == (1, "https://www.linkedin.com/in/jane", "Jane", event_type, 1)
+        hours = (args[5] - datetime.now(timezone.utc).replace(tzinfo=None)).total_seconds() / 3600
+        assert CATCHUP_REPLY_CHECK_HOURS - 1 < hours <= CATCHUP_REPLY_CHECK_HOURS
+
+    @pytest.mark.parametrize("event_type", ["work_anniversary", "birthday"])
+    def test_low_value_milestone_without_a_template_schedules_nothing(self, event_type):
+        from cqc_lem.app.run_automation import _schedule_catchup_followup
+        with patch(f"{_RA}.get_dm_template", return_value=None), \
+             patch(f"{_RA}.enqueue_next_followup") as nxt, patch(f"{_RA}.enqueue_followup") as enq:
+            _schedule_catchup_followup(1, "https://www.linkedin.com/in/jane", "Jane", event_type)
+        nxt.assert_not_called()
+        enq.assert_not_called()
+
+    def test_failure_never_propagates(self):
+        from cqc_lem.app.run_automation import _schedule_catchup_followup
+        with patch(f"{_RA}.get_dm_template", side_effect=RuntimeError("db down")), \
+             patch(f"{_RA}.log_warning") as warn:
+            _schedule_catchup_followup(1, "https://www.linkedin.com/in/jane", "Jane", "job_change")
+        warn.assert_called_once()
 
 
 class TestRouteRepliedCatchupToFunnel:

--- a/tests/unit/app/test_catchup_touches.py
+++ b/tests/unit/app/test_catchup_touches.py
@@ -12,7 +12,7 @@ _RS = "cqc_lem.app.run_scheduler"
 
 def _prefs(**kw):
     base = {"max_comments_per_day": 50, "max_dms_per_day": 20, "max_catchup_touches_per_day": 5,
-            "catchup_touch_mode": "pre_review",
+            "catchup_touch_mode": "pre_review", "catchup_message_source": "linkedin",
             "catchup_event_types": ["job_change", "promotion"],
             "focus_topics": [], "include_topics": [], "include_keywords": [],
             "exclude_topics": [], "exclude_keywords": [], "exclude_authors": []}
@@ -184,6 +184,176 @@ class TestScrapeCatchupMoments:
             moments = _scrape_catchup_moments(driver, max_moments=2, user_id=1)
         assert len(moments) == 2
 
+    def test_classifies_each_card_and_skips_harvesting_when_no_types_are_enabled(self):
+        from cqc_lem.app.run_automation import _scrape_catchup_moments
+        card = self._card("Jane Doe started a new position at Acme")
+        driver = MagicMock()
+        with patch(f"{_RA}.find_all_first", return_value=[card]), \
+             patch(f"{_RA}._harvest_linkedin_draft") as harvest:
+            moments = _scrape_catchup_moments(driver, max_moments=10, user_id=1)
+        assert moments[0]["event_type"] == "job_change"
+        assert moments[0]["suggested_message"] == ""
+        harvest.assert_not_called()
+
+    def test_harvests_linkedins_draft_only_for_enabled_milestone_types(self):
+        from cqc_lem.app.run_automation import _scrape_catchup_moments
+        job = self._card("Jane Doe started a new position at Acme")
+        birthday = self._card("Wish Pat a happy birthday", href="https://www.linkedin.com/in/pat",
+                              link_text="Pat Roe")
+        driver = MagicMock()
+        with patch(f"{_RA}.find_all_first", return_value=[job, birthday]), \
+             patch(f"{_RA}._card_suggested_message", return_value=""), \
+             patch(f"{_RA}._harvest_linkedin_draft", return_value="Congrats on the new role!") as harvest:
+            moments = _scrape_catchup_moments(driver, max_moments=10, user_id=1,
+                                              enabled_event_types={"job_change"})
+        assert harvest.call_count == 1
+        assert moments[0]["suggested_message"] == "Congrats on the new role!"
+        assert moments[1]["suggested_message"] == ""
+
+    def test_card_chip_wins_over_opening_the_composer(self):
+        from cqc_lem.app.run_automation import _scrape_catchup_moments
+        card = self._card("Jane Doe started a new position at Acme")
+        driver = MagicMock()
+        with patch(f"{_RA}.find_all_first", return_value=[card]), \
+             patch(f"{_RA}._card_suggested_message", return_value="Congrats Jane!"), \
+             patch(f"{_RA}._harvest_linkedin_draft") as harvest:
+            moments = _scrape_catchup_moments(driver, max_moments=10, user_id=1,
+                                              enabled_event_types={"job_change"})
+        assert moments[0]["suggested_message"] == "Congrats Jane!"
+        harvest.assert_not_called()
+
+
+class TestLinkedInDraftHarvest:
+    """LinkedIn writes the congratulations; we only read it (PR #509 owner review)."""
+
+    @pytest.fixture(autouse=True)
+    def _no_sleeps(self):
+        with patch("time.sleep"):
+            yield
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("  Congrats on the\n new role, Jane! ", "Congrats on the new role, Jane!"),
+        ("", ""),
+        ("Hi", ""),          # a bare label is not a message
+        ("x" * 400, "x" * 300),
+    ])
+    def test_clean_suggested_message(self, raw, expected):
+        from cqc_lem.app.run_automation import _clean_suggested_message
+        assert _clean_suggested_message(raw) == expected
+
+    def test_card_suggestion_is_read_without_clicking(self):
+        from cqc_lem.app.run_automation import _card_suggested_message
+        chip = MagicMock()
+        chip.text = "Congrats on the promotion!"
+        card = MagicMock()
+        card.find_elements.return_value = [chip]
+        assert _card_suggested_message(card) == "Congrats on the promotion!"
+        chip.click.assert_not_called()
+
+    def test_card_without_a_suggestion_returns_empty(self):
+        from cqc_lem.app.run_automation import _card_suggested_message
+        card = MagicMock()
+        card.find_elements.return_value = []
+        assert _card_suggested_message(card) == ""
+
+    def _trigger(self, label="Say congrats"):
+        trigger = MagicMock()
+        trigger.text = label
+        trigger.get_attribute.return_value = label
+        return trigger
+
+    def test_opens_the_composer_reads_the_draft_and_dismisses_without_sending(self):
+        from cqc_lem.app.run_automation import _harvest_linkedin_draft
+        trigger = self._trigger()
+        card = MagicMock()
+        card.find_elements.return_value = [trigger]
+        compose = MagicMock()
+        compose.text = "Congrats on the new role, Jane!"
+        dismiss = MagicMock()
+        driver = MagicMock()
+        driver.find_elements.side_effect = [[compose], [dismiss]]
+        assert _harvest_linkedin_draft(driver, card, user_id=1) == "Congrats on the new role, Jane!"
+        trigger.click.assert_called_once()
+        dismiss.click.assert_called_once()
+
+    def test_never_clicks_a_control_that_isnt_the_congrats_composer(self):
+        """A drifted selector must not let us click Connect/Follow/Send."""
+        from cqc_lem.app.run_automation import _harvest_linkedin_draft
+        trigger = self._trigger(label="Follow")
+        card = MagicMock()
+        card.find_elements.return_value = [trigger]
+        driver = MagicMock()
+        assert _harvest_linkedin_draft(driver, card, user_id=1) == ""
+        trigger.click.assert_not_called()
+
+    def test_no_trigger_on_the_card_returns_empty(self):
+        from cqc_lem.app.run_automation import _harvest_linkedin_draft
+        card = MagicMock()
+        card.find_elements.return_value = []
+        assert _harvest_linkedin_draft(MagicMock(), card, user_id=1) == ""
+
+    def test_missing_composer_still_dismisses_and_returns_empty(self):
+        from cqc_lem.app.run_automation import _harvest_linkedin_draft
+        trigger = self._trigger()
+        card = MagicMock()
+        card.find_elements.return_value = [trigger]
+        driver = MagicMock()
+        driver.find_elements.return_value = []
+        with patch(f"{_RA}.ActionChains") as chains:
+            assert _harvest_linkedin_draft(driver, card, user_id=1) == ""
+        chains.assert_called_once()  # fell back to Escape
+
+    def test_a_selenium_error_is_swallowed(self):
+        from cqc_lem.app.run_automation import _harvest_linkedin_draft
+        from selenium.common import ElementNotInteractableException
+        trigger = self._trigger()
+        trigger.click.side_effect = ElementNotInteractableException("nope")
+        card = MagicMock()
+        card.find_elements.return_value = [trigger]
+        with patch(f"{_RA}.log_warning") as warn:
+            assert _harvest_linkedin_draft(MagicMock(), card, user_id=1) == ""
+        warn.assert_called_once()
+
+    def test_harvesting_can_be_switched_off(self):
+        from cqc_lem.app import run_automation
+        card = MagicMock()
+        with patch.object(run_automation, "CATCHUP_HARVEST_LINKEDIN_DRAFT", False):
+            assert run_automation._harvest_linkedin_draft(MagicMock(), card, user_id=1) == ""
+        card.find_elements.assert_not_called()
+
+
+class TestDraftCatchupMessage:
+    @pytest.mark.parametrize("event_type,expected", [
+        ("job_change", "Congrats on the new role, Jane!"),
+        ("promotion", "Congrats on the promotion, Jane!"),
+        ("work_anniversary", "Happy work anniversary, Jane!"),
+        ("birthday", "Happy birthday, Jane!"),
+        ("education", "Congrats on the milestone, Jane!"),
+        ("in_the_news", "Great to see you in the news, Jane!"),
+    ])
+    def test_every_milestone_has_a_linkedin_style_fallback(self, event_type, expected):
+        from cqc_lem.app.run_automation import _draft_catchup_message
+        moment = _moment(event_type=event_type)
+        with patch(f"{_RA}.build_dm_from_template") as ai:
+            assert _draft_catchup_message(1, moment, MagicMock()) == expected
+        ai.assert_not_called()
+
+    def test_linkedins_own_draft_wins_over_the_fallback(self):
+        from cqc_lem.app.run_automation import _draft_catchup_message
+        moment = _moment(event_type="job_change", suggested_message="Congrats Jane — huge news!")
+        assert _draft_catchup_message(1, moment, MagicMock()) == "Congrats Jane — huge news!"
+
+    def test_unknown_event_type_without_a_suggestion_drafts_nothing(self):
+        from cqc_lem.app.run_automation import _draft_catchup_message
+        assert _draft_catchup_message(1, _moment(event_type="mystery"), MagicMock()) is None
+
+    def test_ai_source_delegates_to_the_dm_template(self):
+        from cqc_lem.app.run_automation import _draft_catchup_message
+        moment = _moment(event_type="job_change", suggested_message="ignored")
+        with patch(f"{_RA}.build_dm_from_template", return_value="In my voice") as ai:
+            assert _draft_catchup_message(1, moment, MagicMock(), source="ai") == "In my voice"
+        assert ai.call_args.kwargs["event_detail"] == moment["text"]
+
 
 class TestAutomateCatchupTouches:
     def _patches(self, moments, prefs=None):
@@ -199,18 +369,29 @@ class TestAutomateCatchupTouches:
             "insert": patch(f"{_RA}.insert_catchup_touch", return_value=7),
         }
 
-    def test_drafts_pending_touch_for_enabled_event_type(self):
+    def test_drafts_pending_touch_from_linkedins_own_suggestion(self):
         from cqc_lem.app.run_automation import automate_catchup_touches
         from cqc_lem.utilities.db import CatchupTouchStatus
-        p = self._patches([_moment()])
-        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], p["draft"], \
-             p["insert"] as ins:
+        p = self._patches([_moment(suggested_message="Congrats on the new role, Jane!")])
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], \
+             p["draft"] as ai_draft, p["insert"] as ins:
             out = automate_catchup_touches.run(user_id=1)
         assert "1 drafted" in out
         kwargs = ins.call_args.kwargs
         assert kwargs["status"] == CatchupTouchStatus.PENDING
-        assert kwargs["message"] == "Congrats Jane!"
+        assert kwargs["message"] == "Congrats on the new role, Jane!"
         assert ins.call_args.args[2] == "job_change"
+        ai_draft.assert_not_called()  # the default path costs no LLM call
+
+    def test_ai_source_uses_the_dm_template_path(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        p = self._patches([_moment(suggested_message="Congrats on the new role, Jane!")],
+                          prefs=_prefs(catchup_message_source="ai"))
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], \
+             p["draft"] as ai_draft, p["insert"] as ins:
+            automate_catchup_touches.run(user_id=1)
+        ai_draft.assert_called_once()
+        assert ins.call_args.kwargs["message"] == "Congrats Jane!"
 
     def test_auto_approve_mode_queues_the_draft(self):
         from cqc_lem.app.run_automation import automate_catchup_touches
@@ -283,13 +464,30 @@ class TestAutomateCatchupTouches:
         scrape.assert_not_called()
         assert "deferred" in out
 
-    def test_missing_template_skips_the_moment(self):
+    def test_missing_template_skips_the_moment_in_ai_mode(self):
         from cqc_lem.app.run_automation import automate_catchup_touches
-        p = self._patches([_moment()])
+        p = self._patches([_moment()], prefs=_prefs(catchup_message_source="ai"))
         with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], \
              patch(f"{_RA}.build_dm_from_template", return_value=None), p["insert"] as ins:
             automate_catchup_touches.run(user_id=1)
         ins.assert_not_called()
+
+    def test_no_linkedin_suggestion_falls_back_to_the_plain_congratulations(self):
+        """LinkedIn didn't surface a draft — we still send its kind of one-liner, not an AI rewrite."""
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        p = self._patches([_moment()])
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], \
+             p["draft"] as ai_draft, p["insert"] as ins:
+            automate_catchup_touches.run(user_id=1)
+        assert ins.call_args.kwargs["message"] == "Congrats on the new role, Jane!"
+        ai_draft.assert_not_called()
+
+    def test_enabled_types_are_passed_to_the_scrape_so_only_those_are_harvested(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        p = self._patches([_moment()])
+        with p["prefs"], p["profile"], p["scrape"] as scrape, p["quit"], p["has"], p["draft"], p["insert"]:
+            automate_catchup_touches.run(user_id=1)
+        assert scrape.call_args.kwargs["enabled_event_types"] == {"job_change", "promotion"}
 
     def test_scrape_failure_still_quits_the_driver(self):
         from cqc_lem.app.run_automation import automate_catchup_touches
@@ -309,10 +507,11 @@ class TestSendCatchupTouch:
         base.update(kw)
         return base
 
-    def _patches(self, touch, sent=True, catchup_today=0, dms_today=0):
+    def _patches(self, touch, sent=True, catchup_today=0, dms_today=0, prefs=None, allowance=5):
         return {
             "get": patch(f"{_RA}.get_catchup_touch", return_value=touch),
-            "prefs": patch(f"{_RA}.get_engagement_preferences", return_value=_prefs()),
+            "prefs": patch(f"{_RA}.get_engagement_preferences", return_value=prefs or _prefs()),
+            "allow": patch(f"{_RA}.max_catchup_touches_allowed", return_value=allowance),
             "cnt": patch(f"{_RA}.count_catchup_touches_sent_today", return_value=catchup_today),
             "dms": patch(f"{_RA}.count_dms_sent_today", return_value=dms_today),
             "send": patch(f"{_RA}.send_dm_now", return_value=sent),
@@ -324,7 +523,7 @@ class TestSendCatchupTouch:
         from cqc_lem.app.run_automation import send_catchup_touch
         from cqc_lem.utilities.db import CatchupTouchStatus
         p = self._patches(self._touch())
-        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"] as enq:
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"] as enq:
             out = send_catchup_touch.run(touch_id=3)
         send.assert_called_once_with(1, "https://www.linkedin.com/in/jane", "Congrats Jane!")
         upd.assert_called_once_with(3, CatchupTouchStatus.SENT)
@@ -335,7 +534,7 @@ class TestSendCatchupTouch:
         from cqc_lem.app.run_automation import send_catchup_touch
         from cqc_lem.utilities.db import CatchupTouchStatus
         p = self._patches(self._touch(), sent=False)
-        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"], p["upd"] as upd, p["enq"] as enq:
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], p["send"], p["upd"] as upd, p["enq"] as enq:
             out = send_catchup_touch.run(touch_id=3)
         upd.assert_called_once_with(3, CatchupTouchStatus.FAILED)
         enq.assert_not_called()
@@ -345,7 +544,7 @@ class TestSendCatchupTouch:
         from cqc_lem.app.run_automation import send_catchup_touch
         from cqc_lem.utilities.db import CatchupTouchStatus
         p = self._patches(self._touch(), catchup_today=5)
-        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"]:
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"]:
             out = send_catchup_touch.run(touch_id=3)
         send.assert_not_called()
         upd.assert_called_once_with(3, CatchupTouchStatus.APPROVED)
@@ -355,7 +554,7 @@ class TestSendCatchupTouch:
         from cqc_lem.app.run_automation import send_catchup_touch
         from cqc_lem.utilities.db import CatchupTouchStatus
         p = self._patches(self._touch(), dms_today=20)
-        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"]:
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"]:
             out = send_catchup_touch.run(touch_id=3)
         send.assert_not_called()
         upd.assert_called_once_with(3, CatchupTouchStatus.APPROVED)
@@ -366,7 +565,7 @@ class TestSendCatchupTouch:
         from cqc_lem.utilities.db import CatchupTouchStatus
         from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
         p = self._patches(self._touch())
-        with p["get"], p["prefs"], p["cnt"], p["dms"], \
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], \
              patch(f"{_RA}.send_dm_now", side_effect=LinkedInRateLimited("429")), \
              p["upd"] as upd, p["enq"]:
             out = send_catchup_touch.run(touch_id=3)
@@ -376,7 +575,7 @@ class TestSendCatchupTouch:
     def test_unapproved_touch_is_never_sent(self):
         from cqc_lem.app.run_automation import send_catchup_touch
         p = self._patches(self._touch(status="pending"))
-        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"], p["enq"]:
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], p["send"] as send, p["upd"], p["enq"]:
             out = send_catchup_touch.run(touch_id=3)
         send.assert_not_called()
         assert "not sendable" in out
@@ -384,16 +583,37 @@ class TestSendCatchupTouch:
     def test_missing_touch_is_handled(self):
         from cqc_lem.app.run_automation import send_catchup_touch
         p = self._patches(None)
-        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"], p["enq"]:
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], p["send"] as send, p["upd"], p["enq"]:
             out = send_catchup_touch.run(touch_id=3)
         send.assert_not_called()
         assert "missing" in out
+
+    def test_saved_cap_above_the_plan_allowance_is_pulled_back_down(self):
+        """A downgrade must bite immediately: a saved 10/day on a standard plan still stops at 5."""
+        from cqc_lem.app.run_automation import send_catchup_touch
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        p = self._patches(self._touch(), catchup_today=5, allowance=5,
+                          prefs=_prefs(max_catchup_touches_per_day=10))
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"]:
+            out = send_catchup_touch.run(touch_id=3)
+        send.assert_not_called()
+        upd.assert_called_once_with(3, CatchupTouchStatus.APPROVED)
+        assert "catch-up cap" in out
+
+    def test_premium_allowance_lets_the_higher_cap_through(self):
+        from cqc_lem.app.run_automation import send_catchup_touch
+        p = self._patches(self._touch(), catchup_today=5, allowance=10,
+                          prefs=_prefs(max_catchup_touches_per_day=10))
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], p["send"] as send, p["upd"], p["enq"]:
+            out = send_catchup_touch.run(touch_id=3)
+        send.assert_called_once()
+        assert "sent" in out
 
     def test_empty_message_is_skipped(self):
         from cqc_lem.app.run_automation import send_catchup_touch
         from cqc_lem.utilities.db import CatchupTouchStatus
         p = self._patches(self._touch(message="   "))
-        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"]:
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"]:
             out = send_catchup_touch.run(touch_id=3)
         send.assert_not_called()
         upd.assert_called_once_with(3, CatchupTouchStatus.SKIPPED)
@@ -463,6 +683,7 @@ class TestCatchupDispatchers:
              patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
              patch(f"{_RS}.get_engagement_preferences",
                    return_value=_prefs(max_catchup_touches_per_day=2)), \
+             patch(f"{_RS}.max_catchup_touches_allowed", return_value=5), \
              patch(f"{_RS}.count_catchup_touches_sent_today", return_value=0), \
              patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[]), \
              patch(f"{_RS}.update_catchup_touch_status"), \
@@ -470,6 +691,23 @@ class TestCatchupDispatchers:
             out = auto_check_catchup_touches()
         assert task.apply_async.call_count == 2
         assert "Dispatched 2" in out
+
+    def test_send_scanner_budget_is_bounded_by_the_plan_allowance(self):
+        """Saved cap 10 but a standard plan — the drip still dispatches at most 5 that day."""
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        approved = [(i, 7) for i in range(1, 9)]
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_catchup_touches", return_value=approved), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
+             patch(f"{_RS}.get_engagement_preferences",
+                   return_value=_prefs(max_catchup_touches_per_day=10)), \
+             patch(f"{_RS}.max_catchup_touches_allowed", return_value=5), \
+             patch(f"{_RS}.count_catchup_touches_sent_today", return_value=0), \
+             patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.update_catchup_touch_status"), \
+             patch(f"{_RS}.send_catchup_touch") as task:
+            auto_check_catchup_touches()
+        assert task.apply_async.call_count == 5
 
     def test_send_scanner_skips_inactive_users(self):
         from cqc_lem.app.run_scheduler import auto_check_catchup_touches

--- a/tests/unit/app/test_catchup_touches.py
+++ b/tests/unit/app/test_catchup_touches.py
@@ -1,0 +1,515 @@
+"""Unit tests for LinkedIn Catch-up automation (issue #482): classification, scoring, dedup,
+approval gating, the capped send drip and the reply->funnel routing."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+_RS = "cqc_lem.app.run_scheduler"
+
+
+def _prefs(**kw):
+    base = {"max_comments_per_day": 50, "max_dms_per_day": 20, "max_catchup_touches_per_day": 5,
+            "catchup_touch_mode": "pre_review",
+            "catchup_event_types": ["job_change", "promotion"],
+            "focus_topics": [], "include_topics": [], "include_keywords": [],
+            "exclude_topics": [], "exclude_keywords": [], "exclude_authors": []}
+    base.update(kw)
+    return base
+
+
+def _moment(**kw):
+    base = {"name": "Jane Doe", "profile_url": "https://www.linkedin.com/in/jane",
+            "text": "Jane Doe started a new position as VP of Sales at Acme"}
+    base.update(kw)
+    return base
+
+
+class TestClassifyCatchupMoment:
+    @pytest.mark.parametrize("text,expected", [
+        ("Jane Doe started a new position as VP of Sales at Acme", "job_change"),
+        ("John Smith is now a Principal Engineer at Globex", "job_change"),
+        ("Amy joined Initech as Head of Product", "job_change"),
+        ("Dana was promoted to Director of Marketing at Acme", "promotion"),
+        ("Sam is celebrating 5 years at Acme", "work_anniversary"),
+        ("Kim celebrates their work anniversary", "work_anniversary"),
+        ("Wish Pat a happy birthday", "birthday"),
+        ("Lee graduated from MIT", "education"),
+        ("Robin earned a Project Management certificate", "education"),
+        ("Alex was featured in Forbes", "in_the_news"),
+        ("Chris is in the news", "in_the_news"),
+    ])
+    def test_classifies_known_moments(self, text, expected):
+        from cqc_lem.app.run_automation import _classify_catchup_moment
+        assert _classify_catchup_moment(text) == expected
+
+    @pytest.mark.parametrize("text", ["", None, "People you may know", "Suggested for you"])
+    def test_returns_none_for_non_moments(self, text):
+        from cqc_lem.app.run_automation import _classify_catchup_moment
+        assert _classify_catchup_moment(text) is None
+
+    def test_promotion_wins_over_new_position_phrasing(self):
+        """'promoted to X at Y' also matches the new-position 'at' pattern — order must favour promotion."""
+        from cqc_lem.app.run_automation import _classify_catchup_moment
+        assert _classify_catchup_moment("Dana was promoted to VP and is now a VP at Acme") == "promotion"
+
+    def test_anniversary_wins_over_new_position_phrasing(self):
+        from cqc_lem.app.run_automation import _classify_catchup_moment
+        assert _classify_catchup_moment("Sam is now celebrating 10 years at Acme") == "work_anniversary"
+
+
+class TestCatchupEventPeriod:
+    def test_annual_events_bucket_by_year(self):
+        from cqc_lem.app.run_automation import _catchup_event_period
+        from datetime import datetime, timezone
+        now = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        assert _catchup_event_period("birthday", now) == "2026"
+        assert _catchup_event_period("work_anniversary", now) == "2026"
+
+    def test_one_off_events_bucket_by_month(self):
+        from cqc_lem.app.run_automation import _catchup_event_period
+        from datetime import datetime, timezone
+        now = datetime(2026, 7, 24, tzinfo=timezone.utc)
+        assert _catchup_event_period("job_change", now) == "2026-07"
+        assert _catchup_event_period("promotion", now) == "2026-07"
+
+    def test_defaults_to_now_when_no_timestamp_given(self):
+        from cqc_lem.app.run_automation import _catchup_event_period
+        assert len(_catchup_event_period("job_change")) == len("2026-07")
+
+
+class TestNormalizeProfileUrl:
+    @pytest.mark.parametrize("raw,expected", [
+        ("https://www.linkedin.com/in/jane/?trk=abc", "https://www.linkedin.com/in/jane"),
+        ("https://www.linkedin.com/in/jane#top", "https://www.linkedin.com/in/jane"),
+        (" https://www.linkedin.com/in/jane/ ", "https://www.linkedin.com/in/jane"),
+        ("", ""),
+        (None, ""),
+    ])
+    def test_strips_tracking_and_trailing_slash(self, raw, expected):
+        from cqc_lem.app.run_automation import _normalize_profile_url
+        assert _normalize_profile_url(raw) == expected
+
+
+class TestScoreCatchupMoment:
+    def test_event_type_sets_the_base_score(self):
+        from cqc_lem.app.run_automation import _score_catchup_moment
+        job = _score_catchup_moment(_moment(event_type="job_change"), _prefs())
+        birthday = _score_catchup_moment(_moment(event_type="birthday"), _prefs())
+        assert job > birthday
+
+    def test_literal_targeting_match_adds_icp_bonus_without_an_llm_call(self):
+        from cqc_lem.app.run_automation import _score_catchup_moment
+        with patch(f"{_RA}.post_is_relevant") as rel:
+            plain = _score_catchup_moment(_moment(event_type="job_change"), _prefs())
+            boosted = _score_catchup_moment(_moment(event_type="job_change"),
+                                            _prefs(focus_topics=["sales"]))
+        assert boosted == plain + 25
+        rel.assert_not_called()
+
+    def test_llm_relevance_only_runs_when_literal_match_missed(self):
+        from cqc_lem.app.run_automation import _score_catchup_moment
+        with patch(f"{_RA}.post_is_relevant", return_value=True) as rel:
+            score = _score_catchup_moment(_moment(event_type="job_change"),
+                                          _prefs(include_topics=["fintech"]))
+        rel.assert_called_once()
+        assert score == 50 + 15
+
+    def test_no_llm_call_when_no_include_topics(self):
+        from cqc_lem.app.run_automation import _score_catchup_moment
+        with patch(f"{_RA}.post_is_relevant") as rel:
+            assert _score_catchup_moment(_moment(event_type="promotion"), _prefs()) == 50
+        rel.assert_not_called()
+
+
+class TestCatchupExcluded:
+    def test_excluded_author_is_skipped(self):
+        from cqc_lem.app.run_automation import _catchup_excluded
+        assert _catchup_excluded(_moment(), _prefs(exclude_authors=["Jane Doe"])) is True
+
+    def test_excluded_keyword_is_skipped(self):
+        from cqc_lem.app.run_automation import _catchup_excluded
+        assert _catchup_excluded(_moment(), _prefs(exclude_keywords=["acme"])) is True
+
+    def test_clean_moment_is_not_excluded(self):
+        from cqc_lem.app.run_automation import _catchup_excluded
+        assert _catchup_excluded(_moment(), _prefs(exclude_keywords=["  "])) is False
+
+
+class TestScrapeCatchupMoments:
+    @pytest.fixture(autouse=True)
+    def _no_sleeps(self):
+        """The scrape paces itself for LinkedIn; the unit lane must stay hermetic AND fast (#480)."""
+        with patch("time.sleep"):
+            yield
+
+    def _card(self, text, href="https://www.linkedin.com/in/jane?trk=x", link_text="Jane Doe"):
+        link = MagicMock()
+        link.get_attribute.return_value = href
+        link.text = link_text
+        card = MagicMock()
+        card.find_elements.return_value = [link]
+        card.text = text
+        return card
+
+    def test_collects_and_dedupes_cards(self):
+        from cqc_lem.app.run_automation import _scrape_catchup_moments
+        card = self._card("Jane Doe started a new position at Acme")
+        driver = MagicMock()
+        with patch(f"{_RA}.find_all_first", return_value=[card, card]):
+            moments = _scrape_catchup_moments(driver, max_moments=10, user_id=1)
+        assert len(moments) == 1
+        assert moments[0]["profile_url"] == "https://www.linkedin.com/in/jane"
+        assert moments[0]["name"] == "Jane Doe"
+
+    def test_skips_cards_without_a_profile_link(self):
+        from cqc_lem.app.run_automation import _scrape_catchup_moments
+        card = MagicMock()
+        card.find_elements.return_value = []
+        driver = MagicMock()
+        with patch(f"{_RA}.find_all_first", return_value=[card]), \
+             patch(f"{_RA}.log_warning") as warn:
+            assert _scrape_catchup_moments(driver, max_moments=10, user_id=1) == []
+        warn.assert_called_once()
+
+    def test_stops_at_max_moments(self):
+        from cqc_lem.app.run_automation import _scrape_catchup_moments
+        cards = [self._card(f"Person {i} started a new position at Acme",
+                            href=f"https://www.linkedin.com/in/p{i}", link_text=f"Person {i}")
+                 for i in range(5)]
+        driver = MagicMock()
+        with patch(f"{_RA}.find_all_first", return_value=cards):
+            moments = _scrape_catchup_moments(driver, max_moments=2, user_id=1)
+        assert len(moments) == 2
+
+
+class TestAutomateCatchupTouches:
+    def _patches(self, moments, prefs=None):
+        prefs = prefs or _prefs()
+        return {
+            "prefs": patch(f"{_RA}.get_engagement_preferences", return_value=prefs),
+            "profile": patch(f"{_RA}.get_current_profile",
+                             return_value=(MagicMock(), MagicMock(), "a@b.c", MagicMock())),
+            "scrape": patch(f"{_RA}._scrape_catchup_moments", return_value=moments),
+            "quit": patch(f"{_RA}.quit_gracefully"),
+            "has": patch(f"{_RA}.has_catchup_touch", return_value=False),
+            "draft": patch(f"{_RA}.build_dm_from_template", return_value="Congrats Jane!"),
+            "insert": patch(f"{_RA}.insert_catchup_touch", return_value=7),
+        }
+
+    def test_drafts_pending_touch_for_enabled_event_type(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        p = self._patches([_moment()])
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], p["draft"], \
+             p["insert"] as ins:
+            out = automate_catchup_touches.run(user_id=1)
+        assert "1 drafted" in out
+        kwargs = ins.call_args.kwargs
+        assert kwargs["status"] == CatchupTouchStatus.PENDING
+        assert kwargs["message"] == "Congrats Jane!"
+        assert ins.call_args.args[2] == "job_change"
+
+    def test_auto_approve_mode_queues_the_draft(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        p = self._patches([_moment()], prefs=_prefs(catchup_touch_mode="auto_approve"))
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], p["draft"], \
+             p["insert"] as ins:
+            automate_catchup_touches.run(user_id=1)
+        assert ins.call_args.kwargs["status"] == CatchupTouchStatus.APPROVED
+
+    def test_disabled_event_type_is_never_drafted(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        p = self._patches([_moment(text="Wish Jane a happy birthday")])
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], p["draft"], \
+             p["insert"] as ins:
+            automate_catchup_touches.run(user_id=1)
+        ins.assert_not_called()
+
+    def test_low_score_moment_is_tombstoned_not_drafted(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        prefs = _prefs(catchup_event_types=["birthday"])
+        p = self._patches([_moment(text="Wish Jane a happy birthday")], prefs=prefs)
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], \
+             p["draft"] as draft, p["insert"] as ins:
+            out = automate_catchup_touches.run(user_id=1)
+        draft.assert_not_called()
+        assert ins.call_args.kwargs["status"] == CatchupTouchStatus.SKIPPED
+        assert "1 below the bar" in out
+
+    def test_already_touched_milestone_is_skipped(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        p = self._patches([_moment()])
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], \
+             patch(f"{_RA}.has_catchup_touch", return_value=True), p["draft"], p["insert"] as ins:
+            automate_catchup_touches.run(user_id=1)
+        ins.assert_not_called()
+
+    def test_excluded_author_is_skipped(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        p = self._patches([_moment()], prefs=_prefs(exclude_authors=["Jane"]))
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], p["draft"], \
+             p["insert"] as ins:
+            automate_catchup_touches.run(user_id=1)
+        ins.assert_not_called()
+
+    def test_no_enabled_event_types_short_circuits_before_selenium(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        p = self._patches([_moment()], prefs=_prefs(catchup_event_types=[]))
+        with p["prefs"], p["profile"] as prof, p["scrape"], p["quit"], p["has"], p["draft"], p["insert"]:
+            out = automate_catchup_touches.run(user_id=1)
+        prof.assert_not_called()
+        assert "disabled" in out
+
+    def test_max_drafts_caps_a_run(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        moments = [_moment(profile_url=f"https://www.linkedin.com/in/p{i}") for i in range(5)]
+        p = self._patches(moments)
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], p["draft"], p["insert"] as ins:
+            automate_catchup_touches.run(user_id=1, max_drafts=2)
+        assert ins.call_count == 2
+
+    def test_throttled_session_defers_without_scraping(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
+        p = self._patches([_moment()])
+        with p["prefs"], patch(f"{_RA}.get_current_profile", side_effect=LinkedInRateLimited("429")), \
+             p["scrape"] as scrape, p["quit"], p["has"], p["draft"], p["insert"]:
+            out = automate_catchup_touches.run(user_id=1)
+        scrape.assert_not_called()
+        assert "deferred" in out
+
+    def test_missing_template_skips_the_moment(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        p = self._patches([_moment()])
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], \
+             patch(f"{_RA}.build_dm_from_template", return_value=None), p["insert"] as ins:
+            automate_catchup_touches.run(user_id=1)
+        ins.assert_not_called()
+
+    def test_scrape_failure_still_quits_the_driver(self):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        p = self._patches([_moment()])
+        with p["prefs"], p["profile"], patch(f"{_RA}._scrape_catchup_moments", side_effect=RuntimeError("boom")), \
+             p["quit"] as quit_driver, p["has"], p["draft"], p["insert"], patch(f"{_RA}.log_error"):
+            out = automate_catchup_touches.run(user_id=1)
+        quit_driver.assert_called_once()
+        assert "failed" in out
+
+
+class TestSendCatchupTouch:
+    def _touch(self, **kw):
+        base = {"id": 3, "user_id": 1, "profile_url": "https://www.linkedin.com/in/jane",
+                "person_name": "Jane Doe", "event_type": "job_change", "message": "Congrats Jane!",
+                "status": "approved"}
+        base.update(kw)
+        return base
+
+    def _patches(self, touch, sent=True, catchup_today=0, dms_today=0):
+        return {
+            "get": patch(f"{_RA}.get_catchup_touch", return_value=touch),
+            "prefs": patch(f"{_RA}.get_engagement_preferences", return_value=_prefs()),
+            "cnt": patch(f"{_RA}.count_catchup_touches_sent_today", return_value=catchup_today),
+            "dms": patch(f"{_RA}.count_dms_sent_today", return_value=dms_today),
+            "send": patch(f"{_RA}.send_dm_now", return_value=sent),
+            "upd": patch(f"{_RA}.update_catchup_touch_status"),
+            "enq": patch(f"{_RA}.enqueue_next_followup"),
+        }
+
+    def test_sends_and_marks_sent(self):
+        from cqc_lem.app.run_automation import send_catchup_touch
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        p = self._patches(self._touch())
+        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"] as enq:
+            out = send_catchup_touch.run(touch_id=3)
+        send.assert_called_once_with(1, "https://www.linkedin.com/in/jane", "Congrats Jane!")
+        upd.assert_called_once_with(3, CatchupTouchStatus.SENT)
+        enq.assert_called_once()
+        assert "sent" in out
+
+    def test_failed_send_marks_failed_and_skips_followup(self):
+        from cqc_lem.app.run_automation import send_catchup_touch
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        p = self._patches(self._touch(), sent=False)
+        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"], p["upd"] as upd, p["enq"] as enq:
+            out = send_catchup_touch.run(touch_id=3)
+        upd.assert_called_once_with(3, CatchupTouchStatus.FAILED)
+        enq.assert_not_called()
+        assert "failed" in out
+
+    def test_catchup_cap_defers_back_to_approved(self):
+        from cqc_lem.app.run_automation import send_catchup_touch
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        p = self._patches(self._touch(), catchup_today=5)
+        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"]:
+            out = send_catchup_touch.run(touch_id=3)
+        send.assert_not_called()
+        upd.assert_called_once_with(3, CatchupTouchStatus.APPROVED)
+        assert "deferred" in out
+
+    def test_dm_cap_defers_back_to_approved(self):
+        from cqc_lem.app.run_automation import send_catchup_touch
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        p = self._patches(self._touch(), dms_today=20)
+        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"]:
+            out = send_catchup_touch.run(touch_id=3)
+        send.assert_not_called()
+        upd.assert_called_once_with(3, CatchupTouchStatus.APPROVED)
+        assert "DM cap" in out
+
+    def test_throttle_defers_back_to_approved(self):
+        from cqc_lem.app.run_automation import send_catchup_touch
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
+        p = self._patches(self._touch())
+        with p["get"], p["prefs"], p["cnt"], p["dms"], \
+             patch(f"{_RA}.send_dm_now", side_effect=LinkedInRateLimited("429")), \
+             p["upd"] as upd, p["enq"]:
+            out = send_catchup_touch.run(touch_id=3)
+        upd.assert_called_once_with(3, CatchupTouchStatus.APPROVED)
+        assert "throttled" in out
+
+    def test_unapproved_touch_is_never_sent(self):
+        from cqc_lem.app.run_automation import send_catchup_touch
+        p = self._patches(self._touch(status="pending"))
+        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"], p["enq"]:
+            out = send_catchup_touch.run(touch_id=3)
+        send.assert_not_called()
+        assert "not sendable" in out
+
+    def test_missing_touch_is_handled(self):
+        from cqc_lem.app.run_automation import send_catchup_touch
+        p = self._patches(None)
+        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"], p["enq"]:
+            out = send_catchup_touch.run(touch_id=3)
+        send.assert_not_called()
+        assert "missing" in out
+
+    def test_empty_message_is_skipped(self):
+        from cqc_lem.app.run_automation import send_catchup_touch
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        p = self._patches(self._touch(message="   "))
+        with p["get"], p["prefs"], p["cnt"], p["dms"], p["send"] as send, p["upd"] as upd, p["enq"]:
+            out = send_catchup_touch.run(touch_id=3)
+        send.assert_not_called()
+        upd.assert_called_once_with(3, CatchupTouchStatus.SKIPPED)
+        assert "no message" in out
+
+
+class TestRouteRepliedCatchupToFunnel:
+    def _followup(self, event_type="job_change"):
+        return {"user_id": 1, "profile_url": "https://www.linkedin.com/in/jane",
+                "first_name": "Jane", "event_type": event_type}
+
+    def test_high_value_reply_enters_the_funnel_at_the_dm_stage(self):
+        from cqc_lem.app.run_automation import _route_replied_catchup_to_funnel
+        from cqc_lem.utilities.db import OutreachStage, OutreachStatus
+        with patch(f"{_RA}.get_outreach_target_by_url", return_value=None), \
+             patch(f"{_RA}._draft_funnel_stage", return_value="draft dm"), \
+             patch(f"{_RA}.insert_outreach_target") as ins:
+            _route_replied_catchup_to_funnel(1, self._followup())
+        assert ins.call_args.kwargs["stage"] == OutreachStage.DM
+        assert ins.call_args.kwargs["status"] == OutreachStatus.PENDING
+        assert ins.call_args.kwargs["draft_text"] == "draft dm"
+
+    def test_low_value_event_is_not_routed(self):
+        from cqc_lem.app.run_automation import _route_replied_catchup_to_funnel
+        with patch(f"{_RA}.insert_outreach_target") as ins:
+            _route_replied_catchup_to_funnel(1, self._followup(event_type="birthday"))
+        ins.assert_not_called()
+
+    def test_existing_funnel_target_is_not_duplicated(self):
+        from cqc_lem.app.run_automation import _route_replied_catchup_to_funnel
+        with patch(f"{_RA}.get_outreach_target_by_url", return_value={"id": 9}), \
+             patch(f"{_RA}.insert_outreach_target") as ins:
+            _route_replied_catchup_to_funnel(1, self._followup())
+        ins.assert_not_called()
+
+    def test_failure_never_propagates(self):
+        from cqc_lem.app.run_automation import _route_replied_catchup_to_funnel
+        with patch(f"{_RA}.get_outreach_target_by_url", side_effect=RuntimeError("db down")), \
+             patch(f"{_RA}.log_warning") as warn:
+            _route_replied_catchup_to_funnel(1, self._followup())
+        warn.assert_called_once()
+
+
+class TestCatchupDispatchers:
+    def test_scan_dispatcher_skips_users_with_no_enabled_types(self):
+        from cqc_lem.app.run_scheduler import auto_scan_catchup_moments
+        prefs = {1: _prefs(), 2: _prefs(catchup_event_types=[])}
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \
+             patch(f"{_RS}.get_engagement_preferences", side_effect=lambda uid: prefs[uid]), \
+             patch(f"{_RA}.automate_catchup_touches") as task:
+            out = auto_scan_catchup_moments()
+        assert task.apply_async.call_count == 1
+        assert "1 user" in out
+
+    def test_scan_dispatcher_short_circuits_when_throttled(self):
+        from cqc_lem.app.run_scheduler import auto_scan_catchup_moments
+        with patch(f"{_RS}._skip_if_throttled", return_value=True), \
+             patch(f"{_RA}.automate_catchup_touches") as task:
+            assert auto_scan_catchup_moments() == "Automation throttled"
+        task.apply_async.assert_not_called()
+
+    def test_send_scanner_respects_the_daily_cap(self):
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_catchup_touches", return_value=[(1, 7), (2, 7), (3, 7)]), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
+             patch(f"{_RS}.get_engagement_preferences",
+                   return_value=_prefs(max_catchup_touches_per_day=2)), \
+             patch(f"{_RS}.count_catchup_touches_sent_today", return_value=0), \
+             patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.update_catchup_touch_status"), \
+             patch(f"{_RS}.send_catchup_touch") as task:
+            out = auto_check_catchup_touches()
+        assert task.apply_async.call_count == 2
+        assert "Dispatched 2" in out
+
+    def test_send_scanner_skips_inactive_users(self):
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_catchup_touches", return_value=[(1, 7)]), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[]), \
+             patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.update_catchup_touch_status"), \
+             patch(f"{_RS}.log_warning"), \
+             patch(f"{_RS}.send_catchup_touch") as task:
+            out = auto_check_catchup_touches()
+        task.apply_async.assert_not_called()
+        assert out == "No Catch-up Touches to Send"
+
+    def test_send_scanner_requeues_orphans(self):
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        from cqc_lem.utilities.db import CatchupTouchStatus
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
+             patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[(9, 7)]), \
+             patch(f"{_RS}.update_catchup_touch_status") as upd, \
+             patch(f"{_RS}.log_warning"), \
+             patch(f"{_RS}.send_catchup_touch") as task:
+            out = auto_check_catchup_touches()
+        upd.assert_called_once_with(9, CatchupTouchStatus.SENDING)
+        task.apply_async.assert_called_once()
+        assert "1 orphaned" in out
+
+    def test_send_scanner_short_circuits_when_throttled(self):
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        with patch(f"{_RS}._skip_if_throttled", return_value=True), \
+             patch(f"{_RS}.send_catchup_touch") as task:
+            assert auto_check_catchup_touches() == "Automation throttled"
+        task.apply_async.assert_not_called()
+
+
+class TestCatchupBeatSchedule:
+    def test_beat_schedule_registers_both_catchup_jobs(self):
+        from cqc_lem.app.my_celery import app
+        schedule = app.conf.beat_schedule
+        assert schedule["scan-catchup-moments"]["task"] == "cqc_lem.app.run_scheduler.auto_scan_catchup_moments"
+        assert schedule["send-catchup-touches"]["task"] == "cqc_lem.app.run_scheduler.auto_check_catchup_touches"

--- a/tests/unit/app/test_catchup_touches.py
+++ b/tests/unit/app/test_catchup_touches.py
@@ -700,6 +700,52 @@ class TestRouteRepliedCatchupToFunnel:
         warn.assert_called_once()
 
 
+class TestCatchupHandoffToNurture:
+    """The reply path is shared with DM auto-nurture (issue #485): the nurture draft wins when there
+    is one, the funnel hand-off is the fallback, and an explicit 'no' gets neither."""
+
+    def _followup(self):
+        return {"id": 3, "user_id": 1, "profile_url": "https://www.linkedin.com/in/jane",
+                "first_name": "Jane", "event_type": "job_change", "next_step": 1}
+
+    def _run(self, reply: str, nurture_id):
+        from cqc_lem.app.run_automation import process_user_followups
+        patches = {
+            "get_due_followups": patch(f"{_RA}.get_due_followups", return_value=[self._followup()]),
+            "get_current_profile": patch(f"{_RA}.get_current_profile",
+                                         return_value=(MagicMock(), MagicMock(), "e", MagicMock())),
+            "quit_gracefully": patch(f"{_RA}.quit_gracefully"),
+            "check_dm_replied": patch(f"{_RA}.check_dm_replied", return_value=True),
+            "_last_inbound_message": patch(f"{_RA}._last_inbound_message", return_value=reply),
+            "get_engagement_preferences": patch(f"{_RA}.get_engagement_preferences", return_value={}),
+            "get_or_create_profile_synthesis": patch(f"{_RA}.get_or_create_profile_synthesis",
+                                                     return_value="voice"),
+            "_flag_lead_signal": patch(f"{_RA}._flag_lead_signal"),
+            "stop_followups_for_profile": patch(f"{_RA}.stop_followups_for_profile"),
+            "mark_followup": patch(f"{_RA}.mark_followup"),
+            "_nurture_after_reply": patch(f"{_RA}._nurture_after_reply", return_value=nurture_id),
+            "_route_replied_catchup_to_funnel": patch(f"{_RA}._route_replied_catchup_to_funnel"),
+        }
+        mocks = {name: p.start() for name, p in patches.items()}
+        try:
+            process_user_followups.run(user_id=1)
+            return mocks
+        finally:
+            patch.stopall()
+
+    def test_a_nurture_draft_wins_over_the_funnel_handoff(self):
+        mocks = self._run("Sounds good, let's talk", nurture_id=7)
+        mocks["_route_replied_catchup_to_funnel"].assert_not_called()
+
+    def test_no_nurture_draft_falls_back_to_the_funnel_handoff(self):
+        mocks = self._run("Sounds good, let's talk", nurture_id=None)
+        mocks["_route_replied_catchup_to_funnel"].assert_called_once_with(1, self._followup())
+
+    def test_an_explicit_no_gets_neither_a_draft_nor_the_funnel(self):
+        mocks = self._run("Not interested, please stop contacting me", nurture_id=None)
+        mocks["_route_replied_catchup_to_funnel"].assert_not_called()
+
+
 class TestCatchupDispatchers:
     def test_scan_dispatcher_skips_users_with_no_enabled_types(self):
         from cqc_lem.app.run_scheduler import auto_scan_catchup_moments

--- a/tests/unit/app/test_selenium_queue_routing.py
+++ b/tests/unit/app/test_selenium_queue_routing.py
@@ -33,6 +33,8 @@ SELENIUM_TASK_LANES = {
     "process_user_followups": "se_outreach",
     "automate_invites_to_company_page_for_user": "se_outreach",
     "clean_stale_invites": "se_outreach",
+    "automate_catchup_touches": "se_outreach",
+    "send_catchup_touch": "se_outreach",
     "update_stale_profile": "se_outreach",
     # se_content
     "auto_seed_comment_on_post": "se_content",

--- a/tests/unit/utilities/test_db_catchup_touches.py
+++ b/tests/unit/utilities/test_db_catchup_touches.py
@@ -1,0 +1,272 @@
+"""Unit tests for catch-up touch DB helpers and the catch-up engagement preferences (issue #482)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(fetch_row=None, fetchall=None, lastrowid=7):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.fetchone.return_value = fetch_row
+    cur.fetchall.return_value = fetchall or []
+    cur.rowcount = 1
+    cur.lastrowid = lastrowid
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestCatchupTouchDb:
+    def test_insert_returns_id(self):
+        conn, cur = _conn(lastrowid=42)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_catchup_touch, CatchupEventType
+            got = insert_catchup_touch(1, "https://x/in/jane", CatchupEventType.JOB_CHANGE, "2026-07",
+                                       person_name="Jane", event_detail="started a new position",
+                                       message="Congrats!", score=50)
+        assert got == 42
+        assert "INSERT INTO catchup_touches" in cur.execute.call_args[0][0]
+
+    def test_insert_duplicate_returns_none(self):
+        """The unique key is the dedup guarantee — a duplicate milestone must not raise."""
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="duplicate entry")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_catchup_touch, CatchupEventType
+            assert insert_catchup_touch(1, "u", CatchupEventType.PROMOTION, "2026-07") is None
+
+    def test_get_touch_and_user_id(self):
+        conn, _ = _conn(fetch_row={"id": 3, "user_id": 9})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_catchup_touch, get_catchup_touch_user_id
+            assert get_catchup_touch(3)["user_id"] == 9
+            assert get_catchup_touch_user_id(3) == 9
+
+    def test_get_touch_user_id_none_when_missing(self):
+        conn, _ = _conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_catchup_touch_user_id
+            assert get_catchup_touch_user_id(3) is None
+
+    def test_get_touch_error_returns_none(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_catchup_touch
+            assert get_catchup_touch(3) is None
+
+    def test_has_catchup_touch_true_and_false(self):
+        conn, cur = _conn(fetch_row=(1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_catchup_touch, CatchupEventType
+            assert has_catchup_touch(1, "https://x/in/jane", CatchupEventType.JOB_CHANGE, "2026-07") is True
+        sql = cur.execute.call_args[0][0]
+        assert "event_period = %s" in sql
+        conn, _ = _conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_catchup_touch, CatchupEventType
+            assert has_catchup_touch(1, "u", CatchupEventType.JOB_CHANGE, "2026-07") is False
+
+    def test_has_catchup_touch_error_fails_open(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_catchup_touch, CatchupEventType
+            assert has_catchup_touch(1, "u", CatchupEventType.BIRTHDAY, "2026") is False
+
+    def test_list_returns_pagination_shape_and_filters(self):
+        conn, cur = _conn()
+        cur.fetchone.return_value = {"c": 2}
+        cur.fetchall.return_value = [{"id": 1, "status": "pending", "created_at": None, "updated_at": None}]
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_catchup_touches
+            out = get_catchup_touches(1, status_filter="pending", event_type_filter="job_change")
+        assert out["total"] == 2 and out["page"] == 1 and len(out["touches"]) == 1
+        list_sql = cur.execute.call_args_list[-1][0][0]
+        assert "status = %s" in list_sql and "event_type = %s" in list_sql
+        assert "ORDER BY score DESC" in list_sql
+
+    def test_list_serializes_datetimes(self):
+        from datetime import datetime
+        conn, cur = _conn()
+        cur.fetchone.return_value = {"c": 1}
+        cur.fetchall.return_value = [{"id": 1, "created_at": datetime(2026, 7, 24),
+                                      "updated_at": datetime(2026, 7, 24)}]
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_catchup_touches
+            out = get_catchup_touches(1)
+        assert out["touches"][0]["created_at"] == "2026-07-24T00:00:00"
+
+    def test_list_error_returns_empty_shape(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_catchup_touches
+            out = get_catchup_touches(1)
+        assert out == {"touches": [], "total": 0, "page": 1, "page_size": 25}
+
+    def test_approved_touches_ordered_by_score(self):
+        conn, cur = _conn(fetchall=[(1, 5), (2, 5)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_approved_catchup_touches
+            assert get_approved_catchup_touches() == [(1, 5), (2, 5)]
+        sql = cur.execute.call_args[0][0]
+        assert "status = 'approved'" in sql and "ORDER BY score DESC" in sql
+
+    def test_approved_touches_error_returns_empty(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_approved_catchup_touches
+            assert get_approved_catchup_touches() == []
+
+    def test_orphaned_touches_use_lookback(self):
+        conn, cur = _conn(fetchall=[(9, 1)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_orphaned_catchup_touches
+            assert get_orphaned_catchup_touches(lookback_hours=3) == [(9, 1)]
+        assert "status = 'sending'" in cur.execute.call_args[0][0]
+
+    def test_orphaned_touches_error_returns_empty(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_orphaned_catchup_touches
+            assert get_orphaned_catchup_touches() == []
+
+    def test_count_sent_today(self):
+        conn, cur = _conn(fetch_row=(4,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_catchup_touches_sent_today
+            assert count_catchup_touches_sent_today(1) == 4
+        assert "status = 'sent'" in cur.execute.call_args[0][0]
+
+    def test_count_sent_today_error_returns_zero(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_catchup_touches_sent_today
+            assert count_catchup_touches_sent_today(1) == 0
+
+    def test_update_status(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_catchup_touch_status, CatchupTouchStatus
+            assert update_catchup_touch_status(3, CatchupTouchStatus.SENT) is True
+        assert cur.execute.call_args[0][1] == ("sent", 3)
+
+    def test_update_status_error_returns_false(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_catchup_touch_status, CatchupTouchStatus
+            assert update_catchup_touch_status(3, CatchupTouchStatus.SENT) is False
+
+    def test_update_fields(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_catchup_touch, CatchupTouchStatus
+            assert update_catchup_touch(3, message="edited", person_name="Jane",
+                                        status=CatchupTouchStatus.APPROVED) is True
+        sql = cur.execute.call_args[0][0]
+        assert "message = %s" in sql and "person_name = %s" in sql and "status = %s" in sql
+
+    def test_update_with_nothing_to_change_is_a_noop(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_catchup_touch
+            assert update_catchup_touch(3) is False
+        cur.execute.assert_not_called()
+
+    def test_update_error_returns_false(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_catchup_touch
+            assert update_catchup_touch(3, message="x") is False
+
+
+class TestCatchupEngagementPrefs:
+    def test_defaults_include_the_bd_subset_only(self):
+        from cqc_lem.utilities.db import _ENGAGEMENT_DEFAULTS
+        assert _ENGAGEMENT_DEFAULTS["catchup_event_types"] == ["job_change", "promotion"]
+        assert _ENGAGEMENT_DEFAULTS["catchup_touch_mode"] == "pre_review"
+        assert _ENGAGEMENT_DEFAULTS["max_catchup_touches_per_day"] == 5
+
+    def test_null_event_types_column_falls_back_to_the_default(self):
+        """Rows predating the migration have NULL — that means 'never configured', not 'all off'."""
+        conn, _ = _conn(fetch_row={"catchup_event_types": None, "include_topics": None,
+                                   "exclude_topics": None, "include_keywords": None,
+                                   "exclude_keywords": None, "include_authors": None,
+                                   "exclude_authors": None, "post_types": None, "focus_topics": None,
+                                   "use_emojis": 1, "use_hashtags": 0, "reply_to_own_comments": 1,
+                                   "feed_fallback_when_empty": 1, "link_in_first_comment": 1})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            prefs = get_engagement_preferences(1)
+        assert prefs["catchup_event_types"] == ["job_change", "promotion"]
+
+    def test_explicit_empty_event_types_stays_empty(self):
+        """An explicit [] means the user turned catch-up off — it must NOT be re-defaulted on."""
+        conn, _ = _conn(fetch_row={"catchup_event_types": "[]", "include_topics": None,
+                                   "exclude_topics": None, "include_keywords": None,
+                                   "exclude_keywords": None, "include_authors": None,
+                                   "exclude_authors": None, "post_types": None, "focus_topics": None,
+                                   "use_emojis": 1, "use_hashtags": 0, "reply_to_own_comments": 1,
+                                   "feed_fallback_when_empty": 1, "link_in_first_comment": 1})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            prefs = get_engagement_preferences(1)
+        assert prefs["catchup_event_types"] == []
+
+    @pytest.mark.parametrize("given,expected", [
+        (100, 25), (-3, 0), ("nope", 5), (None, 5), (4, 4),
+    ])
+    def test_cap_is_clamped_on_upsert(self, given, expected):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_engagement_preferences, _ENGAGEMENT_COLS
+            update_engagement_preferences(1, {"max_catchup_touches_per_day": given})
+        values = cur.execute.call_args[0][1]
+        assert values[1 + _ENGAGEMENT_COLS.index("max_catchup_touches_per_day")] == expected
+
+    def test_bad_mode_falls_back_to_pre_review(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_engagement_preferences, _ENGAGEMENT_COLS
+            update_engagement_preferences(1, {"catchup_touch_mode": "yolo"})
+        values = cur.execute.call_args[0][1]
+        assert values[1 + _ENGAGEMENT_COLS.index("catchup_touch_mode")] == "pre_review"
+
+    def test_unknown_event_types_are_dropped_before_the_enum_column(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_engagement_preferences, _ENGAGEMENT_COLS
+            update_engagement_preferences(1, {"catchup_event_types": ["job_change", "nonsense"]})
+        values = cur.execute.call_args[0][1]
+        assert values[1 + _ENGAGEMENT_COLS.index("catchup_event_types")] == '["job_change"]'
+
+
+class TestCatchupDmTemplates:
+    @pytest.mark.parametrize("event_type", ["job_change", "promotion", "work_anniversary",
+                                            "birthday", "education", "in_the_news"])
+    def test_every_milestone_type_has_a_default_template(self, event_type):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="no row")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_dm_template
+            tmpl = get_dm_template(1, event_type)
+        assert tmpl and tmpl["template_text"]

--- a/tests/unit/utilities/test_db_catchup_touches.py
+++ b/tests/unit/utilities/test_db_catchup_touches.py
@@ -204,6 +204,8 @@ class TestCatchupEngagementPrefs:
         assert _ENGAGEMENT_DEFAULTS["catchup_event_types"] == ["job_change", "promotion"]
         assert _ENGAGEMENT_DEFAULTS["catchup_touch_mode"] == "pre_review"
         assert _ENGAGEMENT_DEFAULTS["max_catchup_touches_per_day"] == 5
+        # LinkedIn's own pre-drafted response is the baseline — our AI is opt-in (PR #509 owner review).
+        assert _ENGAGEMENT_DEFAULTS["catchup_message_source"] == "linkedin"
 
     def test_null_event_types_column_falls_back_to_the_default(self):
         """Rows predating the migration have NULL — that means 'never configured', not 'all off'."""
@@ -232,15 +234,51 @@ class TestCatchupEngagementPrefs:
         assert prefs["catchup_event_types"] == []
 
     @pytest.mark.parametrize("given,expected", [
-        (100, 25), (-3, 0), ("nope", 5), (None, 5), (4, 4),
+        (100, 5), (10, 5), (-3, 0), ("nope", 5), (None, 5), (4, 4),
     ])
-    def test_cap_is_clamped_on_upsert(self, given, expected):
+    def test_cap_is_clamped_to_the_standard_allowance_on_upsert(self, given, expected):
+        """Without a premium plan the cap tops out at 5/day, whatever the client sent."""
         conn, cur = _conn()
-        with patch(f"{_DB}.get_db_connection", return_value=conn):
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.get_user_subscription_info", return_value=None):
             from cqc_lem.utilities.db import update_engagement_preferences, _ENGAGEMENT_COLS
             update_engagement_preferences(1, {"max_catchup_touches_per_day": given})
         values = cur.execute.call_args[0][1]
         assert values[1 + _ENGAGEMENT_COLS.index("max_catchup_touches_per_day")] == expected
+
+    @pytest.mark.parametrize("given,expected", [(100, 10), (10, 10), (7, 7)])
+    def test_premium_plan_unlocks_the_higher_cap_on_upsert(self, given, expected):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.get_user_subscription_info",
+                   return_value={"subscription_tier": "professional", "subscription_status": "active"}):
+            from cqc_lem.utilities.db import update_engagement_preferences, _ENGAGEMENT_COLS
+            update_engagement_preferences(1, {"max_catchup_touches_per_day": given})
+        values = cur.execute.call_args[0][1]
+        assert values[1 + _ENGAGEMENT_COLS.index("max_catchup_touches_per_day")] == expected
+
+    @pytest.mark.parametrize("given,expected", [("ai", "ai"), ("linkedin", "linkedin"),
+                                                ("yolo", "linkedin"), (None, "linkedin")])
+    def test_message_source_is_validated_on_upsert(self, given, expected):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.get_user_subscription_info", return_value=None):
+            from cqc_lem.utilities.db import update_engagement_preferences, _ENGAGEMENT_COLS
+            update_engagement_preferences(1, {"catchup_message_source": given})
+        values = cur.execute.call_args[0][1]
+        assert values[1 + _ENGAGEMENT_COLS.index("catchup_message_source")] == expected
+
+    def test_bad_stored_message_source_reads_back_as_linkedin(self):
+        conn, _ = _conn(fetch_row={"catchup_message_source": "gpt", "catchup_event_types": None,
+                                   "include_topics": None, "exclude_topics": None,
+                                   "include_keywords": None, "exclude_keywords": None,
+                                   "include_authors": None, "exclude_authors": None,
+                                   "post_types": None, "focus_topics": None,
+                                   "use_emojis": 1, "use_hashtags": 0, "reply_to_own_comments": 1,
+                                   "feed_fallback_when_empty": 1, "link_in_first_comment": 1})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            assert get_engagement_preferences(1)["catchup_message_source"] == "linkedin"
 
     def test_bad_mode_falls_back_to_pre_review(self):
         conn, cur = _conn()
@@ -257,6 +295,30 @@ class TestCatchupEngagementPrefs:
             update_engagement_preferences(1, {"catchup_event_types": ["job_change", "nonsense"]})
         values = cur.execute.call_args[0][1]
         assert values[1 + _ENGAGEMENT_COLS.index("catchup_event_types")] == '["job_change"]'
+
+
+class TestPremiumCatchupAllowance:
+    """10 catch-up touches/day is a premium-plan feature; everyone else tops out at 5 (PR #509)."""
+
+    @pytest.mark.parametrize("info,premium", [
+        ({"subscription_tier": "professional", "subscription_status": "active"}, True),
+        ({"subscription_tier": "enterprise", "subscription_status": "trial"}, True),
+        ({"subscription_tier": "starter", "subscription_status": "active"}, False),
+        ({"subscription_tier": "professional", "subscription_status": "cancelled"}, False),
+        ({"subscription_tier": None, "subscription_status": None}, False),
+        (None, False),
+    ])
+    def test_premium_detection(self, info, premium):
+        with patch(f"{_DB}.get_user_subscription_info", return_value=info):
+            from cqc_lem.utilities.db import is_premium_subscriber, max_catchup_touches_allowed
+            assert is_premium_subscriber(1) is premium
+            assert max_catchup_touches_allowed(1) == (10 if premium else 5)
+
+    def test_lookup_failure_is_never_premium(self):
+        with patch(f"{_DB}.get_user_subscription_info", side_effect=RuntimeError("db down")):
+            from cqc_lem.utilities.db import is_premium_subscriber, max_catchup_touches_allowed
+            assert is_premium_subscriber(1) is False
+            assert max_catchup_touches_allowed(1) == 5
 
 
 class TestCatchupDmTemplates:


### PR DESCRIPTION
## What

Automates LinkedIn's **Catch-up** feed (`/mynetwork/catch-up/all/`) — the daily stream of network "moments" — into **personalized, approval-gated congratulations DMs**, and routes the high-value ones into the existing outreach/nurture machinery.

Pipeline: **scrape → classify → exclude → dedup → ICP-score → draft → approve → capped send → route forward**. Nothing sends without a human approval (unless the account explicitly opts into auto-approve).

## Why

Catch-up moments are classic trigger events — a new job or promotion is the warmest, least salesy reason to reconnect, and congratulations get high reply rates. Our baseline shows ~0 DMs in the last 14 days; this is the consistent warm outbound that's missing. It reuses what already exists (DM templates, follow-ups, the outreach funnel, the 429 breaker) rather than adding a parallel stack.

## How it works

**Migration `V20260724211808__add_catchup_touches.sql`**
- `catchup_touches` ledger — one row per drafted touch. `UNIQUE (user_id, profile_url, event_type, event_period)` is the dedup guarantee: annual milestones (birthday, work anniversary) bucket by **year**, one-off milestones (job change, promotion, education, in the news) by **month**. A card that sits in the feed for a week can never be messaged twice.
- Six new `dm_templates` / `dm_followups` event types (`job_change`, `promotion`, `work_anniversary`, `birthday`, `education`, `in_the_news`) — so congratulations flow through the existing template + multi-touch follow-up machinery.
- `engagement_preferences`: `max_catchup_touches_per_day` (default **5**), `catchup_touch_mode` (default **`pre_review`**), `catchup_event_types` (default **`["job_change","promotion"]`**).

**Tasks** (`run_automation.py`, `se_outreach` lane, `QueueOnce` single-flight per user)
- `automate_catchup_touches` — daily, **drafting only**. Scrapes cards via an ordered SDUI fallback chain, classifies with ordered regexes (promotion and anniversary tested before the new-position pattern so "promoted to X at Y" isn't misread), honors exclude authors/keywords/topics, checks the ledger, scores, then drafts via `build_dm_from_template` (voice refinement + `humanize_text`, ≤300 chars, referencing the actual milestone through a new `{event_detail}` placeholder). Rows land as `pending` (or `approved` under auto-approve). Below-threshold moments are recorded as `skipped` **tombstones** so they're never re-scored or drafted.
- `send_catchup_touch` — sends one approved touch through `send_dm_now`, enforcing **both** the catch-up cap and the overall DM cap; either cap or a 429 defers the row back to `approved` instead of sending.

**Scoring** — `base(event_type) + ICP fit`. Base: job change / promotion 50, in the news 35, work anniversary 30, education 25, birthday 10. ICP: **+25** when a `focus_topics` / `include_keywords` / `include_topics` term appears literally in the moment (free), else **+15** when the LLM relevance check passes (only called when the literal check missed *and* `include_topics` is configured — at most a handful of `lem-simple` calls a day). Threshold `CATCHUP_MIN_SCORE=30` (env-overridable): job change, promotion, in-the-news and work anniversary clear it alone; education and birthday only clear it for people who match the user's targeting.

**Scheduler** (`run_scheduler.py` + beat)
- `auto_scan_catchup_moments` — daily 12:30 UTC; skips users with no enabled milestone types (no Chrome session opened for them).
- `auto_check_catchup_touches` — every 20 min; per-user daily budget at dispatch, orphaned-`sending` re-queue, and the whole scan short-circuits while the kill-switch / 429 breaker is open.

**Routing forward** — when a follow-up sweep detects a reply to a `job_change` / `promotion` congratulations, the prospect is inserted into the comment-first outreach funnel at the **DM stage as `pending`** (pre-drafted, needs approval) for a value-first nurture. No duplicates, never breaks the follow-up loop.

**API + UI** — `GET /catchup/touches`, `PUT /catchup/touch` (edit / approve / cancel), `DELETE /catchup/touch`; a **Catch-up** tab in Content Studio mirroring the outreach funnel surface (score, milestone, editable draft, approve/cancel), Account controls for the cap, approval mode and enabled milestone types, and `{event_detail}` added to the DM-template placeholder chips.

## Testing

- 122 new unit tests across `tests/unit/app/test_catchup_touches.py`, `tests/unit/utilities/test_db_catchup_touches.py`, `tests/unit/api/test_catchup_touches_api.py` — classification (incl. the ordering collisions), dedup periods, URL normalization, scoring/LLM-cost gating, exclusions, scrape dedup + caps, approval gating, both daily caps, throttle deferral, dispatchers, orphan recovery, DB helpers + error paths, prefs clamping, and every endpoint's auth/422/404/500 branches.
- Full unit suite green locally: **3415 passed**.
- UI type-check (`tsc -b --force`) clean.

## Known limitation

The catch-up SDUI selector chain (`_CATCHUP_CARD_LOCATORS` / `_CATCHUP_PROFILE_LINK_LOCATORS`) is written defensively but still needs a **supervised live-grounding pass** on a real account (same as #478) before broad enablement — a total selector miss logs a structured warning and yields zero moments rather than failing.

Closes #482

🤖 Generated with [Claude Code](https://claude.com/claude-code)