### PR TITLE
feat(leads): inbound-intent detection & hot-lead routing from comments/replies/DMs (closes #483)

### DIFF
--- a/compose/local/database/migrations/V20260724214753__add_lead_signals.sql
+++ b/compose/local/database/migrations/V20260724214753__add_lead_signals.sql
@@ -1,0 +1,36 @@
+-- Inbound-intent detection & hot-lead routing (issue #483): someone asking "how much?", "do you
+-- help with X?", or "DM me" in a comment/reply/DM is the warmest lead we get, and today those
+-- signals are read and dropped. This table is the surfaced queue: one row per detected signal,
+-- deduped per (user_id, thread_key) so one conversation is never re-flagged.
+--
+-- source: which read path caught it — a comment on OUR post, a reply to OUR automated comment, or
+--         an inbound DM (all rides on reads that already happen; no new scraping).
+-- channel: how the approved response goes out — 'reply' posts under their comment at context_url,
+--          'dm' sends the drafted message via the existing send_private_dm primitive.
+-- status: new -> draft awaiting human approval
+--         approved -> human approved; the responder task will deliver it
+--         sent -> the response was delivered
+--         dismissed -> operator dismissed the signal (no response)
+--         failed -> delivery errored
+CREATE TABLE IF NOT EXISTS lead_signals (
+    id                  INT AUTO_INCREMENT PRIMARY KEY,
+    user_id             INT NOT NULL,
+    source              ENUM('post_comment','comment_reply','dm') NOT NULL,
+    channel             ENUM('reply','dm') NOT NULL DEFAULT 'reply',
+    person_name         VARCHAR(255) NULL,
+    person_profile_url  VARCHAR(512) NULL,
+    thread_key          VARCHAR(255) NOT NULL,   -- dedup anchor: person + thread, never raw text
+    snippet             TEXT NULL,               -- what they actually said (evidence for the operator)
+    score               TINYINT UNSIGNED NOT NULL DEFAULT 0,
+    matched_signals     VARCHAR(512) NULL,       -- comma-separated intent labels that fired
+    post_id             INT NULL,                -- our post, when the signal came from one
+    context_url         VARCHAR(512) NULL,       -- post/thread URL to reply in
+    draft_response      TEXT NULL,               -- approval-gated draft, editable before sending
+    status              ENUM('new','approved','sent','dismissed','failed') NOT NULL DEFAULT 'new',
+    created_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_lead_signal_thread (user_id, thread_key),
+    KEY idx_lead_signal_user_status (user_id, status),
+    KEY idx_lead_signal_created (user_id, created_at),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -31,7 +31,7 @@ from cqc_lem.utilities.db import (
     insert_outreach_target, get_outreach_targets, get_outreach_target_user_id,
     get_outreach_target_by_url, update_outreach_target, update_outreach_target_status,
     OutreachStatus,
-    get_lead_signals, get_lead_signal, get_lead_signal_user_id, update_lead_signal,
+    get_lead_signals, get_lead_signal, update_lead_signal,
     count_new_lead_signals, LeadSignalStatus,
     create_pin_for_email, verify_pin_for_email, delete_pin_for_email,
     create_session, get_session_user_id, delete_session,

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -15,6 +15,7 @@ from cqc_lem.app.run_automation import (
     automate_invites_to_company_page_for_user, automate_reply_commenting,
     automate_commenting, automate_appreciation_dms_for_user,
     send_private_dm, consolidate_duplicate_comments_for_user, sweep_reply_comments,
+    send_lead_response,
 )
 from celery import chain as celery_chain
 from cqc_lem.app.run_content_plan import auto_create_weekly_content, plan_content_for_user
@@ -30,6 +31,8 @@ from cqc_lem.utilities.db import (
     insert_outreach_target, get_outreach_targets, get_outreach_target_user_id,
     get_outreach_target_by_url, update_outreach_target, update_outreach_target_status,
     OutreachStatus,
+    get_lead_signals, get_lead_signal, get_lead_signal_user_id, update_lead_signal,
+    count_new_lead_signals, LeadSignalStatus,
     create_pin_for_email, verify_pin_for_email, delete_pin_for_email,
     create_session, get_session_user_id, delete_session,
     add_user_by_email, get_user_email, get_user_token_info, store_linkedin_li_at,
@@ -1830,6 +1833,59 @@ def delete_outreach_target_endpoint(request: OutreachTargetDeleteRequest) -> Res
     if not update_outreach_target_status(request.target_id, OutreachStatus.CANCELED):
         raise HTTPException(status_code=500, detail="Could not cancel outreach target")
     return ResponseModel(status_code=200, detail="Outreach target canceled")
+
+
+# Inbound hot leads (issue #483) — the leads inbox. Signals are detected on read paths that already
+# run; the operator approves (or edits then approves) the drafted response before anything is sent.
+_LEN_LEAD_DRAFT = 3000  # lead_signals.draft_response (TEXT; app cap)
+
+
+class LeadSignalUpdate(BaseModel):
+    session_token: str
+    signal_id: int
+    draft_response: Optional[str] = Field(default=None, max_length=_LEN_LEAD_DRAFT)
+    action: Optional[str] = None  # 'approve' | 'dismiss' | None (save the draft only)
+
+
+@router.get("/lead_signals")
+def list_lead_signals_endpoint(session_token: str, status_filter: Optional[str] = None,
+                               page: int = 1, page_size: int = 25,
+                               sort_order: str = "desc") -> ResponseModel:
+    """The leads inbox: detected buying signals with their approval-gated draft responses."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    result = get_lead_signals(user_id, status_filter=status_filter, page=page,
+                              page_size=page_size, sort_order=sort_order)
+    result["new_count"] = count_new_lead_signals(user_id)
+    return ResponseModel(status_code=200, detail=result)
+
+
+@router.put("/lead_signal")
+def update_lead_signal_endpoint(request: LeadSignalUpdate) -> ResponseModel:
+    """Edit a lead's draft, dismiss the signal, or APPROVE it — approval is the only thing that
+    dispatches a response, and it sends exactly the text the operator sees."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    signal = get_lead_signal(request.signal_id)
+    if not signal or signal.get("user_id") != user_id:
+        raise HTTPException(status_code=404, detail="Lead signal not found")
+    action_map = {"approve": LeadSignalStatus.APPROVED, "dismiss": LeadSignalStatus.DISMISSED}
+    if request.action is not None and request.action not in action_map:
+        raise HTTPException(status_code=422,
+                            detail=f"Unknown action '{request.action}' — expected 'approve' or 'dismiss'")
+    status = action_map.get(request.action)
+    if status is None and request.draft_response is None:
+        raise HTTPException(status_code=422, detail="Nothing to update — provide a draft or an action")
+    draft = request.draft_response if request.draft_response is not None else signal.get("draft_response")
+    if status == LeadSignalStatus.APPROVED and not (draft or "").strip():
+        raise HTTPException(status_code=422, detail="Cannot approve a lead with an empty response")
+    if not update_lead_signal(request.signal_id, draft_response=request.draft_response, status=status):
+        raise HTTPException(status_code=500, detail="Could not update lead signal")
+    if status == LeadSignalStatus.APPROVED:
+        send_lead_response.apply_async(kwargs={"signal_id": request.signal_id})
+    return ResponseModel(status_code=200, detail="Lead signal updated")
 
 
 class GroupTogglesRequest(BaseModel):

--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -115,6 +115,7 @@ task_routes = {
     'cqc_lem.app.run_automation.automate_invites_to_company_page_for_user': {'queue': 'se_outreach'},
     'cqc_lem.app.run_automation.clean_stale_invites': {'queue': 'se_outreach'},
     'cqc_lem.app.run_automation.update_stale_profile': {'queue': 'se_outreach'},
+    'cqc_lem.app.run_automation.send_lead_response': {'queue': 'se_outreach'},
     # --- se_content: seeding, stats, group + newsletter publishing --------
     'cqc_lem.app.run_automation.auto_seed_comment_on_post': {'queue': 'se_content'},
     'cqc_lem.app.run_automation.auto_scrape_post_stats': {'queue': 'se_content'},

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -18,8 +18,9 @@ from cqc_lem.utilities.ai.content_framework import select_blueprint
 from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_refinement, summarize_recent_activity, \
     ai_check_message_history, post_is_relevant, generate_newsletter_edition, generate_group_post, \
     generate_thread_reply, generate_comment_reply_followup, generate_seed_comment, choose_post_reaction, \
-    get_or_create_profile_synthesis, \
+    get_or_create_profile_synthesis, generate_lead_response, \
     synthesize_profile
+from cqc_lem.utilities.ai.lead_intent import detect_lead_signals
 from cqc_lem.utilities.ai.content_alignment import humanize_text, split_link_for_first_comment, \
     append_link_to_comment
 from cqc_lem.utilities.date import convert_viewed_on_to_date
@@ -40,7 +41,9 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     get_dm_template, enqueue_followup, get_due_followups, mark_followup, stop_followups_for_profile, \
     set_profile_synthesis, get_duplicate_comment_posts, count_dms_sent_today, \
     get_approved_outreach_targets, update_outreach_target, update_outreach_target_status, \
-    OutreachStage, OutreachStatus
+    OutreachStage, OutreachStatus, \
+    insert_lead_signal, has_lead_signal, get_lead_signal, update_lead_signal, \
+    LeadSignalSource, LeadSignalChannel, LeadSignalStatus
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
     load_profile_for_user
@@ -1901,6 +1904,68 @@ def _golden_hour_sweep_countdowns(sweeps: int = _GOLDEN_HOUR_REPLY_SWEEPS,
     return [int(round(step * i)) for i in range(1, n + 1)]
 
 
+# --- inbound hot-lead detection (issue #483) ---------------------------------------------------
+# Every read path below already HAS the text — someone asking "how much?" or "can you help with X?"
+# is the warmest lead we get, and we were dropping it. Detection rides those existing reads: no new
+# scraping, no extra navigation. A hit records a lead_signals row with an APPROVAL-GATED draft.
+_MAX_LEAD_FLAGS_PER_SWEEP = 10  # volume backstop: a draft costs an LLM call, so bound them per run
+
+
+def _profile_slug(profile_url: str) -> str:
+    """The /in/<slug> identity from a profile URL — the stable half of a lead's dedup key."""
+    m = re.search(r"/in/([^/?#]+)", profile_url or "")
+    return (m.group(1).lower() if m else "")
+
+
+def _lead_thread_key(source: str, thread_ref: str, person_profile_url: str, person_name: str = "") -> str:
+    """Stable dedup id for ONE conversation with ONE person, so a re-scan (or a second buying-intent
+    line in the same thread) never re-flags a lead the operator has already seen. Keyed on identity
+    + thread — never on the message text (the #474 lesson)."""
+    who = _profile_slug(person_profile_url)
+    if not who:
+        who = hashlib.sha1((person_name or "").strip().lower().encode("utf-8", "ignore")).hexdigest()[:12]
+    return f"lead:{source}:{thread_ref}:{who}"
+
+
+def _flag_lead_signal(user_id: int, text: str, source: "LeadSignalSource", thread_ref: str,
+                      person_name: str = None, person_profile_url: str = None,
+                      channel: "LeadSignalChannel" = LeadSignalChannel.REPLY,
+                      post_id: int = None, context_url: str = None, context_text: str = None,
+                      my_profile=None, prefs: dict = None, profile_synthesis: str = None) -> "int | None":
+    """Classify one piece of inbound text and, on a buying-intent hit, queue it as a hot lead with a
+    drafted response awaiting approval. Returns the new signal id, or None (no intent, already
+    flagged, or an error). Best-effort and NON-FATAL — lead detection must never break a reply sweep."""
+    try:
+        if not text or not str(text).strip():
+            return None
+        key = _lead_thread_key(str(source), thread_ref, person_profile_url or "", person_name or "")
+        if has_lead_signal(user_id, key):
+            return None
+        verdict = detect_lead_signals(text)
+        if not verdict.get("is_lead"):
+            return None
+        draft = None
+        try:
+            draft = generate_lead_response(text, my_profile, channel=str(channel), context=context_text,
+                                           prefs=prefs, profile_synthesis=profile_synthesis)
+        except Exception as e:
+            log_warning("Lead response draft failed; queueing the signal without one", exc=e,
+                        user_id=user_id, action_type="engaged")
+        signal_id = insert_lead_signal(
+            user_id, source, key, person_name=person_name, person_profile_url=person_profile_url,
+            snippet=str(text)[:2000], score=int(verdict.get("score") or 0),
+            matched_signals=",".join(verdict.get("matched") or [])[:512], post_id=post_id,
+            context_url=context_url, draft_response=draft, channel=channel)
+        if signal_id:
+            log_info(f"Hot lead detected ({verdict.get('method')}, score {verdict.get('score')}) "
+                     f"from {person_name or person_profile_url or 'unknown'}",
+                     user_id=user_id, post_id=post_id, action_type="engaged")
+        return signal_id
+    except Exception as e:
+        log_warning("Lead-signal detection failed", exc=e, user_id=user_id, action_type="engaged")
+        return None
+
+
 def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my_profile,
                                     profile_synthesis: str) -> str:
     """Navigate to the user's own post and reply to comments on it (thread-builder replies, plus
@@ -1943,6 +2008,8 @@ def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my
         return "Skipped — no profile slug for dedup"
 
     comments_replied_count = 0
+    leads_flagged = 0
+    prefs = get_engagement_preferences(user_id)
     lead_magnet = get_lead_magnet_settings(user_id)
     lead_magnet_blog_url = get_user_blog_url(user_id) if lead_magnet.get("enabled") else ""
     for comment in comments:
@@ -1964,6 +2031,14 @@ def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my
             _eprofile = (_link.get_attribute("href") or "").split("?")[0]
             if _ename and _ename.lower() != (my_profile.full_name or "").lower():
                 upsert_engager(user_id, _ename, _eprofile)
+                # Inbound intent (#483): this commenter may be raising their hand — flag + draft.
+                if leads_flagged < _MAX_LEAD_FLAGS_PER_SWEEP and _flag_lead_signal(
+                        user_id, comment_text, LeadSignalSource.POST_COMMENT, f"post:{post_id}",
+                        person_name=_ename, person_profile_url=_eprofile,
+                        channel=LeadSignalChannel.REPLY, post_id=post_id, context_url=post_url,
+                        context_text=post_message, my_profile=my_profile, prefs=prefs,
+                        profile_synthesis=profile_synthesis):
+                    leads_flagged += 1
                 if (lead_magnet.get("enabled") and lead_magnet.get("keyword") and lead_magnet.get("message")
                         and lead_magnet["keyword"].lower() in comment_text.lower()
                         and _eprofile and not has_received_lead_magnet(user_id, _eprofile)):
@@ -1991,7 +2066,7 @@ def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my
         # Thread-builder: reply in a way that ends with a follow-up question so the commenter
         # replies again — first-hour thread depth is the top 2026 reach signal.
         response = generate_thread_reply(post_message, comment_text, my_profile,
-                                         prefs=get_engagement_preferences(user_id),
+                                         prefs=prefs,
                                          profile_synthesis=profile_synthesis)
         myprint(f"AI Generated Response to Comment: {response}")
         if response and _reply_to_comment_inline(driver, wait, comment, response, user_id=user_id):
@@ -2240,9 +2315,10 @@ def _reply_under_comment_inline(driver, wait, comment_el, reply_text: str, user_
 def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str, post_key: str,
                                       my_profile, profile_synthesis: str, prefs: dict,
                                       replies_remaining: int) -> dict:
-    """Revisit ONE post we commented on: react to replies to our comment, and answer question-replies.
-    Returns {'reacted': n, 'replied': n}. Best-effort/non-fatal (issue #478)."""
-    result = {"reacted": 0, "replied": 0}
+    """Revisit ONE post we commented on: react to replies to our comment, answer question-replies,
+    and flag buying intent. Returns {'reacted': n, 'replied': n, 'leads': n}. Best-effort/non-fatal
+    (issues #478, #483)."""
+    result = {"reacted": 0, "replied": 0, "leads": 0}
     path = urlparse(str(my_profile.profile_url)).path
     our_slug = path.split("/")[2] if len(path.split("/")) > 2 else None
     if not our_slug:
@@ -2310,6 +2386,12 @@ def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str,
             continue
         if not reply_text:
             continue
+        # Inbound intent (#483): a reply to our comment is a prime place for "can you help with X?".
+        if result["leads"] < _MAX_LEAD_FLAGS_PER_SWEEP and _flag_lead_signal(
+                user_id, reply_text, LeadSignalSource.COMMENT_REPLY, post_key,
+                person_profile_url=author, channel=LeadSignalChannel.REPLY, context_url=post_url,
+                my_profile=my_profile, prefs=prefs, profile_synthesis=profile_synthesis):
+            result["leads"] += 1
         reply_key = _followup_reply_key(post_key, author, reply_text)
         state = get_comment_followup(user_id, reply_key) or {}
         did_react = bool(state.get("reacted"))
@@ -2369,7 +2451,7 @@ def _run_comment_followups_sweep(user_id: int) -> str:
         return f"Failed to start follow-up sweep: {e}"
     try:
         synthesis = get_or_create_profile_synthesis(user_id, my_profile)
-        reacted = replied = 0
+        reacted = replied = leads = 0
         for row in posts:
             key = row.get("post_key")
             url = _post_url_from_key(key)
@@ -2379,10 +2461,12 @@ def _run_comment_followups_sweep(user_id: int) -> str:
                 r = _followup_on_post_comment_replies(driver, wait, user_id, url, key, my_profile,
                                                       synthesis, prefs, replies_remaining)
                 reacted += r["reacted"]; replied += r["replied"]; replies_remaining -= r["replied"]
+                leads += r.get("leads", 0)
             except Exception as e:
                 log_warning("Follow-up: post failed", exc=e, user_id=user_id,
                             task_name="sweep_comment_followups")
-        return f"Follow-ups: reacted {reacted}, replied {replied} across {len(posts)} post(s)"
+        return (f"Follow-ups: reacted {reacted}, replied {replied}, leads {leads} "
+                f"across {len(posts)} post(s)")
     finally:
         quit_gracefully(driver)
         release_run_lock(lock_name, lock_token)
@@ -2423,7 +2507,8 @@ def _run_single_post_followup(user_id: int, post_url: str) -> str:
         url = _post_url_from_key(key)
         r = _followup_on_post_comment_replies(driver, wait, user_id, url, key, my_profile,
                                               synthesis, prefs, replies_remaining)
-        return f"Follow-up on {url}: reacted {r['reacted']}, replied {r['replied']}"
+        return (f"Follow-up on {url}: reacted {r['reacted']}, replied {r['replied']}, "
+                f"leads {r.get('leads', 0)}")
     finally:
         quit_gracefully(driver)
         release_run_lock(lock_name, lock_token)
@@ -2709,6 +2794,23 @@ _LAST_SENDER_JS = (
     "for(let i=ev.length-1;i>=0;i--){const n=ev[i].querySelector('.msg-s-message-group__name');"
     "if(n&&n.innerText.trim())return n.innerText.trim();}return null;")
 
+# The BODY of the most recent message bubble in the open thread — same DOM the reply-detector above
+# already reads. Inbound-intent detection (#483) rides that read; it never opens a thread of its own.
+_LAST_MESSAGE_JS = (
+    "const ev=[...document.querySelectorAll('li.msg-s-message-list__event, .msg-s-event-listitem')];"
+    "for(let i=ev.length-1;i>=0;i--){const b=ev[i].querySelector('.msg-s-event-listitem__body, "
+    ".msg-s-event__content');if(b&&b.innerText.trim())return b.innerText.trim();}return null;")
+
+
+def _last_inbound_message(driver) -> str:
+    """Text of the newest message in the ALREADY-OPEN thread. Best-effort — returns '' when the DOM
+    doesn't match (detection simply finds nothing rather than breaking the follow-up run)."""
+    try:
+        return (driver.execute_script(_LAST_MESSAGE_JS) or "").strip()
+    except Exception as e:
+        log_warning("Could not read the last DM body", exc=e, action_type="dm")
+        return ""
+
 
 def check_dm_replied(driver, wait, profile_url: str, my_name: str = None) -> bool:
     """Best-effort: has this person replied since our last message? Opens their message thread
@@ -2755,9 +2857,20 @@ def process_user_followups(self, user_id: int, max_per_run: int = 20):
         log_error("Error getting profile for follow-ups", exc=e, user_id=user_id, task_name="process_user_followups")
         return f"Failed to start follow-ups: {e}"
     sent = 0
+    lead_ctx: dict = {}  # voice context for lead drafts — fetched lazily, only if someone replies
     try:
         for f in due[:max_per_run]:
             if check_dm_replied(driver, wait, f["profile_url"], my_name=getattr(my_profile, "full_name", None)):
+                # Their reply is on screen already — read it once and check for buying intent (#483)
+                # before we walk away from this thread for good.
+                if not lead_ctx:
+                    lead_ctx = {"prefs": get_engagement_preferences(user_id),
+                                "synthesis": get_or_create_profile_synthesis(user_id, my_profile)}
+                _flag_lead_signal(user_id, _last_inbound_message(driver), LeadSignalSource.DM,
+                                  "thread", person_name=f.get("first_name"),
+                                  person_profile_url=f["profile_url"], channel=LeadSignalChannel.DM,
+                                  context_url=f["profile_url"], my_profile=my_profile,
+                                  prefs=lead_ctx["prefs"], profile_synthesis=lead_ctx["synthesis"])
                 stop_followups_for_profile(user_id, f["profile_url"])
                 mark_followup(f["id"], "stopped")
                 continue
@@ -3338,6 +3451,89 @@ def send_scheduled_dm(self, dm_id: int):
     dm_sent = send_dm_now(user_id, dm["recipient_profile_url"], dm["message"])
     update_scheduled_dm_status(dm_id, ScheduledDmStatus.SENT if dm_sent else ScheduledDmStatus.FAILED)
     return f"Scheduled DM {dm_id} -> {'sent' if dm_sent else 'failed'}"
+
+
+def _reply_to_person_on_post(driver, wait, post_url: str, person_profile_url: str, text: str,
+                             user_id: int = None) -> bool:
+    """Post `text` as a reply UNDER a specific person's comment on `post_url` — the delivery half of
+    an approved hot-lead response (issue #483). Reuses the #478 comment-thread helpers: a tall
+    viewport + scrolling is what actually makes comments lazy-render on a long post."""
+    slug = _profile_slug(person_profile_url)
+    if not slug:
+        log_warning("Lead response: no profile slug to target", user_id=user_id, action_type="reply")
+        return False
+    try:
+        driver.set_window_size(1400, 3400)
+    except Exception:
+        pass  # some drivers reject resize; the scrolling below is the fallback
+    driver.get(post_url)
+    time.sleep(random.uniform(2.5, 4))
+    for _ in range(10):
+        driver.execute_script("window.scrollBy(0, 1000);")
+        time.sleep(random.uniform(0.9, 1.4))
+        cl = driver.find_elements(By.CSS_SELECTOR, "[data-testid*='commentList']")
+        if cl:
+            driver.execute_script("arguments[0].scrollIntoView({block:'center'});", cl[0])
+    for tb in driver.find_elements(By.CSS_SELECTOR, _COMMENTLIST_TEXTBOX):
+        cont = _comment_container(driver, tb)
+        if cont is None:
+            continue
+        if f"/in/{slug}" not in _comment_header_author(driver, cont):
+            continue
+        return _reply_under_comment_inline(driver, wait, cont, text, user_id=user_id)
+    log_warning(f"Lead response: no comment by /in/{slug} found on {post_url}", user_id=user_id,
+                action_type="reply")
+    return False
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'keys': ['signal_id']},
+                  reject_on_worker_lost=True, rate_limit='2/m', queue='se_outreach')
+def send_lead_response(self, signal_id: int):
+    """Deliver an APPROVED hot-lead response (issue #483) — a reply under their comment, or a DM."""
+    return _send_lead_response(signal_id)
+
+
+def _send_lead_response(signal_id: int) -> str:
+    """Body of send_lead_response, extracted for unit testing (no QueueOnce/Redis). Only ever acts
+    on a signal a human APPROVED — nothing here can auto-respond to a lead on its own."""
+    signal = get_lead_signal(signal_id)
+    if not signal:
+        return f"Lead signal {signal_id} not found"
+    if str(signal.get("status")) != str(LeadSignalStatus.APPROVED):
+        return f"Lead signal {signal_id} not sendable (status={signal.get('status')})"
+    message = (signal.get("draft_response") or "").strip()
+    if not message:
+        update_lead_signal(signal_id, status=LeadSignalStatus.FAILED)
+        return f"Lead signal {signal_id} has no draft to send"
+
+    user_id = signal["user_id"]
+    if str(signal.get("channel")) == str(LeadSignalChannel.DM):
+        sent = send_dm_now(user_id, signal["person_profile_url"], message)
+        update_lead_signal(signal_id, status=LeadSignalStatus.SENT if sent else LeadSignalStatus.FAILED)
+        return f"Lead signal {signal_id} DM -> {'sent' if sent else 'failed'}"
+
+    if not signal.get("context_url"):
+        update_lead_signal(signal_id, status=LeadSignalStatus.FAILED)
+        return f"Lead signal {signal_id} has no post to reply on"
+    try:
+        driver, wait, _email, _my_profile = get_current_profile(user_id=user_id, session_name="Lead Response")
+    except LinkedInRateLimited as e:
+        log_warning("Lead response skipped — LinkedIn rate-limited", exc=e, user_id=user_id,
+                    task_name="send_lead_response")
+        return "Skipped — rate limited"  # left APPROVED so a later run retries it
+    except Exception as e:
+        log_error("Error starting lead response", exc=e, user_id=user_id, task_name="send_lead_response")
+        return f"Failed to start lead response: {e}"
+    try:
+        sent = _reply_to_person_on_post(driver, wait, signal["context_url"],
+                                        signal.get("person_profile_url") or "", message, user_id=user_id)
+        update_lead_signal(signal_id, status=LeadSignalStatus.SENT if sent else LeadSignalStatus.FAILED)
+        insert_new_log(user_id=user_id, post_id=signal.get("post_id"), action_type=LogActionType.REPLY,
+                       result=LogResultType.SUCCESS if sent else LogResultType.FAILURE,
+                       post_url=signal["context_url"], message=message)
+        return f"Lead signal {signal_id} reply -> {'sent' if sent else 'failed'}"
+    finally:
+        quit_gracefully(driver)
 
 
 def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -> bool:

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -7,6 +7,7 @@ import NewsletterQueue from './review/NewsletterQueue'
 import ScheduledDMs from './review/ScheduledDMs'
 import ConnectionRequests from './review/ConnectionRequests'
 import OutreachFunnel from './review/OutreachFunnel'
+import LeadsInbox from './review/LeadsInbox'
 import ComposePost from './content/ComposePost'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
@@ -14,12 +15,13 @@ import { formatInTimezone } from '../utils/datetime'
 
 // Consolidated content hub: compose posts, schedule DMs, manage newsletters, and review/edit
 // existing content — one page, four tabs, synced to ?tab= for deep-linking.
-type View = 'posts' | 'dms' | 'connections' | 'outreach' | 'newsletters' | 'review'
+type View = 'posts' | 'dms' | 'connections' | 'outreach' | 'leads' | 'newsletters' | 'review'
 const VIEWS: { key: View; label: string }[] = [
   { key: 'posts', label: 'Posts' },
   { key: 'dms', label: 'DMs' },
   { key: 'connections', label: 'Connections' },
   { key: 'outreach', label: 'Outreach' },
+  { key: 'leads', label: 'Leads' },
   { key: 'newsletters', label: 'Newsletters' },
   { key: 'review', label: 'Review & Edit' },
 ]
@@ -335,6 +337,8 @@ export default function ContentStudio() {
       {view === 'connections' && <ConnectionRequests userTimezone={userTimezone} />}
 
       {view === 'outreach' && <OutreachFunnel />}
+
+      {view === 'leads' && <LeadsInbox userTimezone={userTimezone} />}
 
       {view === 'review' && (
       <>

--- a/src/cqc_lem/ui/src/pages/review/LeadsInbox.tsx
+++ b/src/cqc_lem/ui/src/pages/review/LeadsInbox.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import api from '../../api/client'
+import { useAuth } from '../../contexts/AuthContext'
+import { formatInTimezone } from '../../utils/datetime'
+
+// Inbound hot leads (issue #483): buying signals ("how much?", "can you help with X?", "DM me")
+// caught in comments, replies, and DMs the automation already reads. Nothing is ever sent
+// automatically — the drafted response is editable and only goes out when you approve it.
+const DRAFT_MAX = 3000
+
+interface LeadSignal {
+  id: number
+  source: string
+  channel: string
+  person_name: string | null
+  person_profile_url: string | null
+  snippet: string | null
+  score: number
+  matched_signals: string | null
+  context_url: string | null
+  draft_response: string | null
+  status: string
+  created_at: string
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  new: 'bg-orange-100 text-orange-700',
+  approved: 'bg-green-100 text-green-700',
+  sent: 'bg-blue-100 text-blue-700',
+  dismissed: 'bg-gray-100 text-gray-500',
+  failed: 'bg-red-100 text-red-700',
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  post_comment: 'Comment on your post',
+  comment_reply: 'Reply to your comment',
+  dm: 'Direct message',
+}
+
+const STATUSES = ['ALL', 'new', 'approved', 'sent', 'dismissed', 'failed']
+
+export default function LeadsInbox({ userTimezone }: { userTimezone: string }) {
+  const { sessionToken } = useAuth()
+  const qc = useQueryClient()
+  const [filter, setFilter] = useState('new')
+  const [drafts, setDrafts] = useState<Record<number, string>>({})
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null)
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['lead-signals', sessionToken, filter],
+    queryFn: () => {
+      const p = new URLSearchParams({ session_token: sessionToken!, page: '1', page_size: '50' })
+      if (filter !== 'ALL') p.set('status_filter', filter)
+      return api
+        .get(`/lead_signals?${p.toString()}`)
+        .then((r) => r.data.detail as { signals: LeadSignal[]; total: number; new_count: number })
+    },
+    enabled: !!sessionToken,
+  })
+  const signals = data?.signals ?? []
+
+  const flash = (ok: boolean, text: string) => { setMsg({ ok, text }); setTimeout(() => setMsg(null), 4000) }
+
+  const actionMutation = useMutation({
+    mutationFn: (v: { id: number; action?: 'approve' | 'dismiss'; draft_response?: string }) =>
+      api.put('/lead_signal', {
+        session_token: sessionToken,
+        signal_id: v.id,
+        action: v.action ?? null,
+        draft_response: v.draft_response ?? null,
+      }),
+    onSuccess: (_r, v) => {
+      qc.invalidateQueries({ queryKey: ['lead-signals'] })
+      flash(true, v.action === 'approve' ? 'Approved — sending your response.'
+        : v.action === 'dismiss' ? 'Dismissed.' : 'Draft saved.')
+    },
+    onError: () => flash(false, 'Could not update this lead — try again.'),
+  })
+
+  const draftFor = (s: LeadSignal) => drafts[s.id] ?? s.draft_response ?? ''
+
+  return (
+    <div className="space-y-4">
+      {msg && <p className={`text-sm font-medium ${msg.ok ? 'text-green-600' : 'text-red-600'}`}>{msg.text}</p>}
+
+      <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-5">
+        <h3 className="font-semibold text-gray-700">
+          Leads inbox{data?.new_count ? ` — ${data.new_count} waiting` : ''}
+        </h3>
+        <p className="text-xs text-gray-500 mt-1">
+          People who asked about pricing, availability, or whether you can help — spotted in comments,
+          replies, and DMs. Edit the draft if you want, then approve to send it. Nothing goes out
+          until you approve.
+        </p>
+      </div>
+
+      <div className="flex gap-2 flex-wrap">
+        {STATUSES.map((s) => (
+          <button key={s} onClick={() => setFilter(s)}
+            className={`px-3 py-1.5 rounded-full text-xs font-semibold transition-colors ${
+              filter === s ? 'bg-blue-600 text-white' : 'bg-white text-gray-600 border border-gray-300 hover:border-blue-400'
+            }`}>
+            {s.toUpperCase()}
+          </button>
+        ))}
+      </div>
+
+      {isLoading && <p className="text-gray-400 text-sm">Loading leads…</p>}
+      {!isLoading && signals.length === 0 && (
+        <div className="text-center py-10 bg-white rounded-lg border border-gray-200 text-sm text-gray-500">
+          No leads here yet — they show up when someone asks about your work.
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {signals.map((s) => (
+          <div key={s.id} className="bg-white rounded-lg border border-gray-200 p-4 space-y-2">
+            <div className="flex items-center justify-between gap-2">
+              {s.person_profile_url ? (
+                <a href={s.person_profile_url} target="_blank" rel="noopener noreferrer"
+                  className="text-sm font-medium text-blue-700 truncate hover:underline">
+                  {s.person_name || s.person_profile_url}
+                </a>
+              ) : (
+                <span className="text-sm font-medium text-gray-700 truncate">{s.person_name || 'Unknown'}</span>
+              )}
+              <div className="flex items-center gap-2 shrink-0">
+                <span className="text-xs text-gray-400">{formatInTimezone(s.created_at, userTimezone)}</span>
+                <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-amber-100 text-amber-700">
+                  {s.score}
+                </span>
+                <span className={`px-2 py-0.5 rounded-full text-xs font-medium ${STATUS_COLORS[s.status] ?? 'bg-gray-100 text-gray-600'}`}>
+                  {s.status.toUpperCase()}
+                </span>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap items-center gap-2 text-xs text-gray-500">
+              <span>{SOURCE_LABELS[s.source] ?? s.source}</span>
+              <span>·</span>
+              <span>responds by {s.channel === 'dm' ? 'DM' : 'public reply'}</span>
+              {s.matched_signals && (<><span>·</span><span className="italic">{s.matched_signals}</span></>)}
+              {s.context_url && (
+                <a href={s.context_url} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline">
+                  view thread
+                </a>
+              )}
+            </div>
+
+            {s.snippet && (
+              <blockquote className="border-l-2 border-gray-200 pl-3 text-sm text-gray-700 whitespace-pre-wrap">
+                {s.snippet}
+              </blockquote>
+            )}
+
+            {s.status === 'new' ? (
+              <>
+                <textarea value={draftFor(s)} rows={3} maxLength={DRAFT_MAX}
+                  onChange={(e) => setDrafts({ ...drafts, [s.id]: e.target.value })}
+                  placeholder="Your response…"
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => actionMutation.mutate({ id: s.id, action: 'approve', draft_response: draftFor(s) })}
+                    disabled={actionMutation.isPending || !draftFor(s).trim()}
+                    className="px-3 py-1 bg-green-600 text-white rounded text-xs font-semibold hover:bg-green-700 disabled:opacity-50">
+                    Approve &amp; send
+                  </button>
+                  <button
+                    onClick={() => actionMutation.mutate({ id: s.id, draft_response: draftFor(s) })}
+                    disabled={actionMutation.isPending || !draftFor(s).trim()}
+                    className="px-3 py-1 border border-gray-300 text-gray-700 rounded text-xs font-semibold hover:bg-gray-50 disabled:opacity-50">
+                    Save draft
+                  </button>
+                  <button onClick={() => actionMutation.mutate({ id: s.id, action: 'dismiss' })}
+                    disabled={actionMutation.isPending}
+                    className="px-3 py-1 border border-gray-300 text-gray-600 rounded text-xs font-semibold hover:bg-gray-50 disabled:opacity-50">
+                    Dismiss
+                  </button>
+                </div>
+              </>
+            ) : (
+              s.draft_response && (
+                <p className="text-sm text-gray-700 whitespace-pre-wrap line-clamp-3">{s.draft_response}</p>
+              )
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -766,6 +766,42 @@ def generate_comment_reply_followup(their_reply: str, profile: "LinkedInProfile"
                           profile_synthesis=profile_synthesis, prefs=prefs)
 
 
+def generate_lead_response(their_message: str, profile: "LinkedInProfile", channel: str = "reply",
+                           context: str = None, prefs: dict = None,
+                           profile_synthesis: str = None) -> "str | None":
+    """Draft a response to someone showing INBOUND BUYING INTENT (issue #483) — they asked about
+    pricing, availability, or whether we can help. This is the one place the no-self-promo guardrail
+    does NOT apply: they raised their hand, so answering directly is what they want. Never invent
+    prices, timelines, or capabilities — acknowledge the ask, give one genuinely useful line, and
+    move it to a real conversation. The draft is APPROVAL-GATED; a human sends it."""
+    is_dm = str(channel).lower() == "dm"
+    limit = 300 if is_dm else 500
+    system_prompt = {
+        "role": "system",
+        "content": f"""You are responding to someone who just showed BUYING INTENT toward your work —
+        they asked about your services, pricing, availability, or whether you can help them. Answer
+        like a helpful professional, not a salesperson: acknowledge their SPECIFIC ask, give ONE
+        concrete, genuinely useful line, and end with a low-friction next step (a question about
+        their situation, or an offer to take it to messages/a short call).
+        NEVER invent prices, timelines, package names, client names, or capabilities — if the answer
+        depends on details you do not have, say what it depends on and ask for it. No hard sell, no
+        hype, no links, no hashtags, no emoji spam. Warm, human, in the author's voice.
+        {'Write it as a direct message.' if is_dm else 'Write it as a public reply under their comment.'}
+        2-4 sentences, under {limit} characters. Output ONLY the message text.""",
+    }
+    ctx = f"Context (the post/thread this came from):\n{context}\n\n" if context else ""
+    user_prompt = {"role": "user", "content":
+        f"My voice:\n{_voice_reference(profile, profile_synthesis)}\n\n{ctx}"
+        f"What they said:\n{their_message}\n{_style_directive(prefs)}"}
+    response = _call_llm(model="lem-medium", messages=[system_prompt, user_prompt],
+                         temperature=round(random.uniform(0.4, 0.6), 2))
+    content = response.choices[0].message.content
+    if content is None:
+        return None
+    return _humanize_text(content.strip(), content_type="dm" if is_dm else "comment",
+                          profile_synthesis=profile_synthesis, prefs=prefs, max_chars=limit)
+
+
 def optimize_post_hook(post_content: str, prefs: dict = None,
                        preserve_cta_keyword: str = None) -> str:
     """Rewrite a generated post so it opens with a scroll-stopping hook within the first ~210

--- a/src/cqc_lem/utilities/ai/lead_intent.py
+++ b/src/cqc_lem/utilities/ai/lead_intent.py
@@ -33,6 +33,8 @@ _LLM_SCORE = 55
 _MIN_TEXT_CHARS = 8
 # Cap what we send to the classifier / store as evidence.
 _MAX_TEXT_CHARS = 1200
+# The tier-2 answer is one word ('yes'/'no') — no reason to pay for more.
+_LLM_MAX_TOKENS = 3
 
 _STRONG_PATTERNS: "list[tuple[str, str]]" = [
     ("pricing", r"\b(how much|pricing|price list|prices?|what (does|would) (it|this|that) cost|"
@@ -88,10 +90,13 @@ def _min_score() -> int:
 
 def _llm_says_lead(text: str) -> bool:
     """Tier-2 check for the ambiguous band. Fails CLOSED (False) — a classifier hiccup must not
-    flood the operator's leads inbox with noise; a genuine lead usually carries a strong keyword."""
-    from cqc_lem.utilities.ai.client import client
+    flood the operator's leads inbox with noise; a genuine lead usually carries a strong keyword.
+
+    Routed through `_call_llm` so this high-volume classifier's tokens/latency land in PostHog with
+    every other LLM call."""
+    from cqc_lem.utilities.ai.ai_helper import _call_llm
     try:
-        response = client.chat.completions.create(
+        response = _call_llm(
             model="lem-simple",
             messages=[
                 {"role": "system", "content": _LLM_SYSTEM},
@@ -99,6 +104,7 @@ def _llm_says_lead(text: str) -> bool:
                                             f"Answer yes or no."},
             ],
             temperature=0,
+            max_tokens=_LLM_MAX_TOKENS,
         )
         answer = (response.choices[0].message.content or "").strip().lower()
         return answer.startswith("y")

--- a/src/cqc_lem/utilities/ai/lead_intent.py
+++ b/src/cqc_lem/utilities/ai/lead_intent.py
@@ -1,0 +1,135 @@
+"""Inbound buying-intent detection (issue #483).
+
+Someone asking "how much?", "do you help with X?", or "DM me" in a comment/reply/DM is the warmest
+lead we get. This module is the classifier the existing read paths call on text they ALREADY have —
+it never scrapes anything itself.
+
+Two tiers, in cost order:
+1. A heuristic keyword/regex pass. STRONG families (pricing, hiring us, contact-me, stated need,
+   referral ask, demo/trial) are decisive on their own; WEAK families are merely suggestive.
+2. For the ambiguous band only — weak signal but no strong one — ONE cheap `lem-simple` call.
+   Text with no signal at all never reaches the LLM, which matters because comments and replies run
+   at high volume (same cost logic as COMMENT_RESEARCH_ENABLED in content_research.py).
+
+Env:
+  LEAD_INTENT_LLM_ENABLED  — allow the tier-2 LLM check for ambiguous text (default: true)
+  LEAD_INTENT_MIN_SCORE    — score at/above which text is flagged a lead (default: 40)
+"""
+
+import os
+import re
+
+from cqc_lem.utilities.logger import log_debug, log_warning
+
+# Weight per matched family. One STRONG family alone clears the default threshold; WEAK families
+# only accumulate toward the ambiguous band that earns an LLM check.
+_STRONG_WEIGHT = 40
+_WEAK_WEIGHT = 15
+_MAX_SCORE = 100
+# What the LLM's "yes" is worth — above the default threshold, but below a strong keyword hit so the
+# operator's queue still ranks explicit asks first.
+_LLM_SCORE = 55
+# Text shorter than this ("nice!", "🔥") can't carry intent; skip it before any matching.
+_MIN_TEXT_CHARS = 8
+# Cap what we send to the classifier / store as evidence.
+_MAX_TEXT_CHARS = 1200
+
+_STRONG_PATTERNS: "list[tuple[str, str]]" = [
+    ("pricing", r"\b(how much|pricing|price list|prices?|what (does|would) (it|this|that) cost|"
+                r"cost(s)? (per|to|for)|rates?|quote|retainer|budget for)\b"),
+    ("engage_us", r"\b(do you (offer|sell|provide|have|do|build|handle|work with|help)|"
+                  r"can you (help|do|build|make|handle|take)|could you (help|do|build)|"
+                  r"are you (taking|accepting)\b[^.?!]{0,20}\b(clients|customers|work|projects))\b"),
+    ("contact_me", r"\b(dm me|dm'?d you|send me a dm|message me|pm me|email me|reach out|"
+                   r"get in touch|contact me|let'?s (talk|chat|connect|set (up|something)|schedule)|"
+                   r"book a (call|demo|time)|hop on a call|calendly)\b"),
+    ("stated_need", r"\b(i need|we need|i'?m looking for|we'?re looking for|looking for someone|"
+                    r"need help with|need this|in the market for|shopping for|trying to find)\b"),
+    ("referral", r"\b(who do you recommend|any recommendations|recommend (someone|anyone|a\b)|"
+                 r"referral|know anyone who)\b"),
+    ("demo_trial", r"\b(free trial|start a trial|book a demo|see a demo|sign up for|how do i "
+                   r"(start|sign up|get started)|get started with)\b"),
+]
+
+_WEAK_PATTERNS: "list[tuple[str, str]]" = [
+    ("curiosity", r"\b(interested in|tell me more|more info(rmation)?|learn more|send (me )?"
+                  r"(the )?(link|details|info)|curious (about|how|what))\b"),
+    ("buying_context", r"\b(my (team|company|agency|clients)|our (team|company|agency|clients)|"
+                       r"we'?re (currently|about to|planning to|evaluating))\b"),
+    ("direct_question", r"\byou(r)?\b[^?]{0,120}\?"),
+]
+
+_COMPILED_STRONG = [(label, re.compile(pattern, re.I)) for label, pattern in _STRONG_PATTERNS]
+_COMPILED_WEAK = [(label, re.compile(pattern, re.I)) for label, pattern in _WEAK_PATTERNS]
+
+_NO_SIGNAL: dict = {"is_lead": False, "score": 0, "matched": [], "method": "none"}
+
+_LLM_SYSTEM = (
+    "You classify whether a LinkedIn comment or message is INBOUND BUYING INTENT — the person is "
+    "asking about the author's services, pricing, availability, or otherwise raising their hand to "
+    "start a business conversation. Praise, agreement, general discussion, job seeking, and "
+    "someone pitching THEIR OWN services are NOT buying intent. Answer with only 'yes' or 'no'."
+)
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _min_score() -> int:
+    try:
+        return int(os.environ.get("LEAD_INTENT_MIN_SCORE") or _STRONG_WEIGHT)
+    except ValueError:
+        return _STRONG_WEIGHT
+
+
+def _llm_says_lead(text: str) -> bool:
+    """Tier-2 check for the ambiguous band. Fails CLOSED (False) — a classifier hiccup must not
+    flood the operator's leads inbox with noise; a genuine lead usually carries a strong keyword."""
+    from cqc_lem.utilities.ai.client import client
+    try:
+        response = client.chat.completions.create(
+            model="lem-simple",
+            messages=[
+                {"role": "system", "content": _LLM_SYSTEM},
+                {"role": "user", "content": f"Message:\n{text}\n\nIs this inbound buying intent? "
+                                            f"Answer yes or no."},
+            ],
+            temperature=0,
+        )
+        answer = (response.choices[0].message.content or "").strip().lower()
+        return answer.startswith("y")
+    except Exception as e:
+        log_warning("Lead-intent LLM check failed (treating as not a lead)", exc=e, ai_model="lem-simple")
+        return False
+
+
+def detect_lead_signals(text: str, use_llm: bool = True) -> dict:
+    """Classify one piece of inbound text (a comment, reply, or DM body) for buying intent.
+
+    Returns {'is_lead': bool, 'score': 0-100, 'matched': [family labels], 'method': 'none'|
+    'heuristic'|'llm'}. Never raises — an unusable input or a failed LLM call is simply "not a lead".
+    """
+    cleaned = (text or "").strip()[:_MAX_TEXT_CHARS]
+    if len(cleaned) < _MIN_TEXT_CHARS:
+        return dict(_NO_SIGNAL)
+
+    matched = [label for label, rx in _COMPILED_STRONG if rx.search(cleaned)]
+    weak = [label for label, rx in _COMPILED_WEAK if rx.search(cleaned)]
+    score = min(_MAX_SCORE, len(matched) * _STRONG_WEIGHT + len(weak) * _WEAK_WEIGHT)
+    matched += weak
+    threshold = _min_score()
+
+    if score >= threshold:
+        log_debug(f"Lead intent (heuristic, score {score}): {matched}", action_type="engaged")
+        return {"is_lead": True, "score": score, "matched": matched, "method": "heuristic"}
+
+    # Ambiguous band: something suggestive fired but nothing decisive. Only these pay for an LLM call.
+    if score > 0 and use_llm and _bool_env("LEAD_INTENT_LLM_ENABLED", True) and _llm_says_lead(cleaned):
+        log_debug(f"Lead intent (LLM) on weak signals {matched}", action_type="engaged")
+        return {"is_lead": True, "score": max(score, _LLM_SCORE), "matched": matched, "method": "llm"}
+
+    return {"is_lead": False, "score": score, "matched": matched, "method": "heuristic"}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -115,6 +115,28 @@ class OutreachStatus(StrEnum):
     CANCELED = 'canceled'    # operator canceled the whole funnel for this target
 
 
+class LeadSignalSource(StrEnum):
+    """Which existing read path caught an inbound buying signal (issue #483)."""
+    POST_COMMENT = 'post_comment'    # a comment on the user's OWN post
+    COMMENT_REPLY = 'comment_reply'  # a reply to a comment WE left on someone else's post
+    DM = 'dm'                        # an inbound DM reply in a thread we already open
+
+
+class LeadSignalChannel(StrEnum):
+    """How an approved hot-lead response is delivered (issue #483)."""
+    REPLY = 'reply'  # post the draft under their comment at context_url
+    DM = 'dm'        # send the draft as a private message
+
+
+class LeadSignalStatus(StrEnum):
+    """Lifecycle of a detected hot lead (issue #483), mirroring the approval-gated DM lifecycle."""
+    NEW = 'new'              # draft awaiting human approval
+    APPROVED = 'approved'    # human approved; the responder will deliver it
+    SENT = 'sent'            # response delivered
+    DISMISSED = 'dismissed'  # operator dismissed the signal
+    FAILED = 'failed'        # delivery errored
+
+
 # Enum for log actions types
 class LogActionType(StrEnum):
     COMMENT = 'comment'
@@ -4074,6 +4096,157 @@ def record_lead_magnet_sent(user_id: int, recipient_profile: str, post_id: int =
     except mysql.connector.Error as err:
         myprint(f"Could not record lead magnet sent for user {user_id} | Error: {err}")
         return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+# --- inbound hot-lead signals (issue #483) ----------------------------------------------------
+_LEAD_SIGNAL_COLS = ("id", "user_id", "source", "channel", "person_name", "person_profile_url",
+                     "thread_key", "snippet", "score", "matched_signals", "post_id", "context_url",
+                     "draft_response", "status", "created_at", "updated_at")
+
+
+def insert_lead_signal(user_id: int, source: "LeadSignalSource", thread_key: str,
+                       person_name: str = None, person_profile_url: str = None,
+                       snippet: str = None, score: int = 0, matched_signals: str = None,
+                       post_id: int = None, context_url: str = None, draft_response: str = None,
+                       channel: "LeadSignalChannel" = LeadSignalChannel.REPLY) -> Optional[int]:
+    """Record a detected buying signal. Deduped by UNIQUE(user_id, thread_key) — a second detection
+    on the same conversation returns None instead of re-flagging it (and never overwrites an
+    operator's edited draft or their dismissal)."""
+    if not thread_key:
+        return None
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT IGNORE INTO lead_signals (user_id, source, channel, person_name, "
+            "person_profile_url, thread_key, snippet, score, matched_signals, post_id, context_url, "
+            "draft_response) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)",
+            (user_id, str(source), str(channel), person_name, person_profile_url,
+             str(thread_key)[:255], snippet, max(0, min(255, int(score or 0))), matched_signals,
+             post_id, context_url, draft_response))
+        connection.commit()
+        return cursor.lastrowid or None
+    except mysql.connector.Error as err:
+        myprint(f"Could not insert lead signal for user {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def has_lead_signal(user_id: int, thread_key: str) -> bool:
+    """True if this conversation was already flagged. Checked BEFORE the expensive draft generation
+    so a re-scan of the same thread costs nothing. Fails safe to True (skip) on error."""
+    if not thread_key:
+        return True
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT 1 FROM lead_signals WHERE user_id=%s AND thread_key=%s LIMIT 1",
+                       (user_id, str(thread_key)[:255]))
+        return cursor.fetchone() is not None
+    except mysql.connector.Error:
+        return True
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_lead_signal(signal_id: int) -> Optional[dict]:
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(f"SELECT {', '.join(_LEAD_SIGNAL_COLS)} FROM lead_signals WHERE id=%s", (signal_id,))
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get lead signal {signal_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_lead_signal_user_id(signal_id: int) -> Optional[int]:
+    row = get_lead_signal(signal_id)
+    return row["user_id"] if row else None
+
+
+def get_lead_signals(user_id: int, status_filter: str = None, page: int = 1, page_size: int = 25,
+                     sort_order: str = "desc") -> dict:
+    """Paginated leads inbox for a user (mirrors the scheduled-DM/outreach list response). Hottest
+    first within a timestamp: newest signals matter most — a slow response kills an inbound lead."""
+    order = "ASC" if str(sort_order).lower() == "asc" else "DESC"
+    where = "WHERE user_id = %s"
+    params: list = [user_id]
+    if status_filter:
+        where += " AND status = %s"
+        params.append(status_filter)
+    offset = max(0, (max(1, page) - 1) * page_size)
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(f"SELECT COUNT(*) AS c FROM lead_signals {where}", tuple(params))
+        total = int(cursor.fetchone()["c"])
+        cursor.execute(
+            f"SELECT {', '.join(_LEAD_SIGNAL_COLS)} FROM lead_signals {where} "
+            f"ORDER BY created_at {order}, score DESC LIMIT %s OFFSET %s",
+            tuple(params + [page_size, offset]))
+        rows = cursor.fetchall()
+        for r in rows:
+            for k in ("created_at", "updated_at"):
+                if isinstance(r.get(k), datetime):
+                    r[k] = r[k].isoformat()
+        return {"signals": rows, "total": total, "page": page, "page_size": page_size}
+    except mysql.connector.Error as err:
+        myprint(f"Could not list lead signals for user {user_id} | Error: {err}")
+        return {"signals": [], "total": 0, "page": page, "page_size": page_size}
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_lead_signal(signal_id: int, draft_response: str = None,
+                       status: "LeadSignalStatus" = None,
+                       channel: "LeadSignalChannel" = None) -> bool:
+    """Edit a lead's draft and/or move its status. Only the supplied fields change."""
+    fields, params = [], []
+    if draft_response is not None:
+        fields.append("draft_response = %s")
+        params.append(draft_response)
+    for col, val in (("status", status), ("channel", channel)):
+        if val is not None:
+            fields.append(f"{col} = %s")
+            params.append(str(val))
+    if not fields:
+        return False
+    params.append(signal_id)
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(f"UPDATE lead_signals SET {', '.join(fields)} WHERE id = %s", tuple(params))
+        connection.commit()
+        return cursor.rowcount >= 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update lead signal {signal_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def count_new_lead_signals(user_id: int) -> int:
+    """Unactioned hot leads — the inbox badge count."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT COUNT(*) FROM lead_signals WHERE user_id=%s AND status='new'", (user_id,))
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] else 0
+    except mysql.connector.Error:
+        return 0
     finally:
         cursor.close()
         connection.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -4169,11 +4169,6 @@ def get_lead_signal(signal_id: int) -> Optional[dict]:
         connection.close()
 
 
-def get_lead_signal_user_id(signal_id: int) -> Optional[int]:
-    row = get_lead_signal(signal_id)
-    return row["user_id"] if row else None
-
-
 def get_lead_signals(user_id: int, status_filter: str = None, page: int = 1, page_size: int = 25,
                      sort_order: str = "desc") -> dict:
     """Paginated leads inbox for a user (mirrors the scheduled-DM/outreach list response). Hottest

--- a/tests/unit/api/test_lead_signals_api.py
+++ b/tests/unit/api/test_lead_signals_api.py
@@ -1,0 +1,169 @@
+"""Unit tests for the leads-inbox API endpoints (issue #483) — listing, editing a draft, dismissing,
+and the approval gate that is the ONLY thing that dispatches a response."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_M = "cqc_lem.api.main"
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_S = "tok"
+_U = 5
+_SIGNAL = {"id": 3, "user_id": _U, "status": "new", "channel": "reply",
+           "draft_response": "Happy to help — what's your timeline?"}
+
+
+class TestListLeadSignals:
+    def test_lists_with_the_unactioned_count(self, client):
+        listing = {"signals": [_SIGNAL], "total": 1, "page": 1, "page_size": 25}
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signals", return_value=listing) as get, \
+             patch(f"{_M}.count_new_lead_signals", return_value=4):
+            resp = client.get(f"/api/lead_signals?session_token={_S}&status_filter=new")
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert detail["total"] == 1 and detail["new_count"] == 4
+        assert get.call_args.kwargs["status_filter"] == "new"
+
+    def test_requires_a_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.get(f"/api/lead_signals?session_token=bad")
+        assert resp.status_code == 401
+
+
+class TestUpdateLeadSignal:
+    def test_approve_dispatches_the_response(self, client):
+        from cqc_lem.utilities.db import LeadSignalStatus
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signal", return_value=dict(_SIGNAL)), \
+             patch(f"{_M}.update_lead_signal", return_value=True) as upd, \
+             patch(f"{_M}.send_lead_response.apply_async") as task:
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3,
+                                                        "action": "approve"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["status"] == LeadSignalStatus.APPROVED
+        task.assert_called_once_with(kwargs={"signal_id": 3})
+
+    def test_approve_sends_the_edited_text(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signal", return_value=dict(_SIGNAL)), \
+             patch(f"{_M}.update_lead_signal", return_value=True) as upd, \
+             patch(f"{_M}.send_lead_response.apply_async"):
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3,
+                                                        "action": "approve",
+                                                        "draft_response": "My own words."})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["draft_response"] == "My own words."
+
+    def test_saving_a_draft_does_not_send_anything(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signal", return_value=dict(_SIGNAL)), \
+             patch(f"{_M}.update_lead_signal", return_value=True) as upd, \
+             patch(f"{_M}.send_lead_response.apply_async") as task:
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3,
+                                                        "draft_response": "later"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["status"] is None
+        task.assert_not_called()
+
+    def test_dismiss(self, client):
+        from cqc_lem.utilities.db import LeadSignalStatus
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signal", return_value=dict(_SIGNAL)), \
+             patch(f"{_M}.update_lead_signal", return_value=True) as upd, \
+             patch(f"{_M}.send_lead_response.apply_async") as task:
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3,
+                                                        "action": "dismiss"})
+        assert resp.status_code == 200
+        assert upd.call_args.kwargs["status"] == LeadSignalStatus.DISMISSED
+        task.assert_not_called()
+
+    def test_cannot_approve_an_empty_response(self, client):
+        signal = dict(_SIGNAL, draft_response=None)
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signal", return_value=signal), \
+             patch(f"{_M}.update_lead_signal") as upd, \
+             patch(f"{_M}.send_lead_response.apply_async") as task:
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3,
+                                                        "action": "approve"})
+        assert resp.status_code == 422
+        upd.assert_not_called()
+        task.assert_not_called()
+
+    def test_unknown_action_is_rejected(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signal", return_value=dict(_SIGNAL)), \
+             patch(f"{_M}.update_lead_signal") as upd:
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3,
+                                                        "action": "send-now"})
+        assert resp.status_code == 422
+        upd.assert_not_called()
+
+    def test_nothing_to_update_is_rejected(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signal", return_value=dict(_SIGNAL)), \
+             patch(f"{_M}.update_lead_signal") as upd:
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3})
+        assert resp.status_code == 422
+        upd.assert_not_called()
+
+    def test_another_users_signal_is_not_found(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signal", return_value=dict(_SIGNAL, user_id=99)), \
+             patch(f"{_M}.update_lead_signal") as upd:
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3,
+                                                        "action": "approve"})
+        assert resp.status_code == 404
+        upd.assert_not_called()
+
+    def test_missing_signal_is_404(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signal", return_value=None):
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3,
+                                                        "action": "approve"})
+        assert resp.status_code == 404
+
+    def test_requires_a_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.put("/api/lead_signal", json={"session_token": "bad", "signal_id": 3,
+                                                        "action": "approve"})
+        assert resp.status_code == 401
+
+    def test_db_failure_is_a_500(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U), \
+             patch(f"{_M}.get_lead_signal", return_value=dict(_SIGNAL)), \
+             patch(f"{_M}.update_lead_signal", return_value=False), \
+             patch(f"{_M}.send_lead_response.apply_async") as task:
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3,
+                                                        "action": "approve"})
+        assert resp.status_code == 500
+        task.assert_not_called()
+
+    def test_oversized_draft_is_rejected(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_U):
+            resp = client.put("/api/lead_signal", json={"session_token": _S, "signal_id": 3,
+                                                        "draft_response": "x" * 3001})
+        assert resp.status_code == 422

--- a/tests/unit/app/test_comment_followups.py
+++ b/tests/unit/app/test_comment_followups.py
@@ -180,6 +180,7 @@ def _worker_env(es, reply_text="Thanks! How do you test drift?", followup_state=
     _p(es, "_react_to_comment_inline", return_value=react)
     _p(es, "_reply_under_comment_inline", return_value=reply)
     _p(es, "generate_comment_reply_followup", return_value="a thoughtful answer")
+    _p(es, "_flag_lead_signal", return_value=None)   # inbound-intent detection rides this path (#483)
     my_profile = MagicMock(); my_profile.profile_url = "https://www.linkedin.com/in/me/"
     return driver, my_profile, rec
 
@@ -192,7 +193,7 @@ class TestFollowupWorker:
             r = _followup_on_post_comment_replies(driver, MagicMock(), 1,
                     "https://www.linkedin.com/feed/update/urn:li:activity:1/",
                     "feedurn://urn:li:activity:1", prof, "voice", {}, replies_remaining=5)
-        assert r == {"reacted": 1, "replied": 1}
+        assert r == {"reacted": 1, "replied": 1, "leads": 0}
 
     def test_reacts_only_when_reply_is_not_a_question(self):
         from cqc_lem.app.run_automation import _followup_on_post_comment_replies
@@ -208,7 +209,7 @@ class TestFollowupWorker:
             driver, prof, rec = _worker_env(es, followup_state={"reacted": 1, "replied": 1})
             r = _followup_on_post_comment_replies(driver, MagicMock(), 1, "u", "feedurn://urn:li:activity:1",
                                                   prof, "voice", {}, replies_remaining=5)
-        assert r == {"reacted": 0, "replied": 0}
+        assert r == {"reacted": 0, "replied": 0, "leads": 0}
 
     def test_reply_cap_blocks_reply_but_not_react(self):
         from cqc_lem.app.run_automation import _followup_on_post_comment_replies
@@ -223,7 +224,7 @@ class TestFollowupWorker:
         prof = MagicMock(); prof.profile_url = "https://www.linkedin.com/"
         with patch(f"{RA}.log_warning"):
             r = _followup_on_post_comment_replies(MagicMock(), MagicMock(), 1, "u", "k", prof, "v", {}, 5)
-        assert r == {"reacted": 0, "replied": 0}
+        assert r == {"reacted": 0, "replied": 0, "leads": 0}
 
 
 class TestOrchestration:

--- a/tests/unit/app/test_dm_followups.py
+++ b/tests/unit/app/test_dm_followups.py
@@ -65,6 +65,10 @@ class TestProcessUserFollowups:
              patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
              patch(f"{_RA}.quit_gracefully"), patch(f"{_RA}.time.sleep"), patch(f"{_RA}.insert_new_log"), \
              patch(f"{_RA}.check_dm_replied", return_value=True), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"), \
+             patch(f"{_RA}._last_inbound_message", return_value="thanks!"), \
+             patch(f"{_RA}._flag_lead_signal", return_value=None), \
              patch(f"{_RA}.stop_followups_for_profile") as stop, \
              patch(f"{_RA}.send_private_dm") as dm, \
              patch(f"{_RA}.mark_followup") as mark:

--- a/tests/unit/app/test_lead_signals.py
+++ b/tests/unit/app/test_lead_signals.py
@@ -1,0 +1,336 @@
+"""Unit tests for inbound hot-lead routing — issue #483. Covers the dedup key, the flag/draft
+helper, the DM-body read that rides the existing follow-up thread open, and the approval-gated
+responder (DM + reply channels). Selenium DOM targeting itself is validated on a supervised run."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with patch(f"{_RA}.time.sleep"):
+        yield
+
+
+def _fn(name):
+    import importlib
+    return getattr(importlib.import_module(_RA), name)
+
+
+class TestProfileSlug:
+    def test_extracts_and_lowercases(self):
+        assert _fn("_profile_slug")("https://www.linkedin.com/in/Jane-Doe/") == "jane-doe"
+
+    def test_strips_query_string(self):
+        assert _fn("_profile_slug")("https://x/in/jane?trk=abc") == "jane"
+
+    def test_missing_returns_empty(self):
+        assert _fn("_profile_slug")("https://www.linkedin.com/company/acme") == ""
+        assert _fn("_profile_slug")(None) == ""
+
+
+class TestLeadThreadKey:
+    def test_same_person_same_thread_is_one_key(self):
+        f = _fn("_lead_thread_key")
+        a = f("post_comment", "post:7", "https://www.linkedin.com/in/jane/")
+        b = f("post_comment", "post:7", "https://x/in/JANE?trk=1")
+        assert a == b
+
+    def test_different_threads_differ(self):
+        f = _fn("_lead_thread_key")
+        assert f("post_comment", "post:7", "https://x/in/jane") != \
+               f("post_comment", "post:8", "https://x/in/jane")
+
+    def test_falls_back_to_name_when_no_profile_url(self):
+        f = _fn("_lead_thread_key")
+        key = f("dm", "thread", "", "Jane Doe")
+        assert key.startswith("lead:dm:thread:") and len(key) > len("lead:dm:thread:")
+        assert key == f("dm", "thread", "", " jane doe ")
+
+    def test_key_ignores_message_text_entirely(self):
+        f = _fn("_lead_thread_key")
+        assert f("comment_reply", "feedurn://urn:li:activity:1", "https://x/in/jane") == \
+               f("comment_reply", "feedurn://urn:li:activity:1", "https://x/in/jane")
+
+
+class TestFlagLeadSignal:
+    def _patches(self, **over):
+        base = {
+            "has_lead_signal": False,
+            "detect": {"is_lead": True, "score": 55, "matched": ["pricing"], "method": "heuristic"},
+            "draft": "Happy to help — what's the timeline?",
+            "insert": 42,
+        }
+        base.update(over)
+        return base
+
+    def _run(self, text="How much do you charge?", **over):
+        p = self._patches(**over)
+        with patch(f"{_RA}.has_lead_signal", return_value=p["has_lead_signal"]) as has, \
+             patch(f"{_RA}.detect_lead_signals", return_value=p["detect"]) as det, \
+             patch(f"{_RA}.generate_lead_response", return_value=p["draft"]) as gen, \
+             patch(f"{_RA}.insert_lead_signal", return_value=p["insert"]) as ins, \
+             patch(f"{_RA}.log_info"), patch(f"{_RA}.log_warning") as warn:
+            from cqc_lem.utilities.db import LeadSignalSource
+            result = _fn("_flag_lead_signal")(1, text, LeadSignalSource.POST_COMMENT, "post:7",
+                                              person_name="Jane", person_profile_url="https://x/in/jane",
+                                              post_id=7, context_url="https://x/post/7",
+                                              my_profile=MagicMock())
+        return result, {"has": has, "detect": det, "gen": gen, "insert": ins, "warn": warn}
+
+    def test_flags_and_stores_the_draft(self):
+        result, m = self._run()
+        assert result == 42
+        kwargs = m["insert"].call_args.kwargs
+        assert kwargs["draft_response"] == "Happy to help — what's the timeline?"
+        assert kwargs["score"] == 55
+        assert kwargs["matched_signals"] == "pricing"
+        assert kwargs["post_id"] == 7
+
+    def test_no_intent_means_no_row_and_no_draft(self):
+        result, m = self._run(detect={"is_lead": False, "score": 0, "matched": [], "method": "heuristic"})
+        assert result is None
+        m["gen"].assert_not_called()
+        m["insert"].assert_not_called()
+
+    def test_already_flagged_thread_short_circuits_before_classifying(self):
+        result, m = self._run(has_lead_signal=True)
+        assert result is None
+        m["detect"].assert_not_called()
+        m["gen"].assert_not_called()
+
+    def test_blank_text_is_ignored(self):
+        result, m = self._run(text="   ")
+        assert result is None
+        m["has"].assert_not_called()
+
+    def test_draft_failure_still_queues_the_signal(self):
+        p = self._patches()
+        with patch(f"{_RA}.has_lead_signal", return_value=False), \
+             patch(f"{_RA}.detect_lead_signals", return_value=p["detect"]), \
+             patch(f"{_RA}.generate_lead_response", side_effect=RuntimeError("llm down")), \
+             patch(f"{_RA}.insert_lead_signal", return_value=9) as ins, \
+             patch(f"{_RA}.log_info"), patch(f"{_RA}.log_warning") as warn:
+            from cqc_lem.utilities.db import LeadSignalSource
+            result = _fn("_flag_lead_signal")(1, "how much?", LeadSignalSource.DM, "thread",
+                                              my_profile=MagicMock())
+        assert result == 9
+        assert ins.call_args.kwargs["draft_response"] is None
+        warn.assert_called_once()
+
+    def test_detection_errors_are_non_fatal(self):
+        with patch(f"{_RA}.has_lead_signal", side_effect=RuntimeError("db down")), \
+             patch(f"{_RA}.log_warning") as warn:
+            from cqc_lem.utilities.db import LeadSignalSource
+            assert _fn("_flag_lead_signal")(1, "how much?", LeadSignalSource.DM, "t") is None
+        warn.assert_called_once()
+
+
+class TestLastInboundMessage:
+    def test_reads_the_newest_bubble(self):
+        driver = MagicMock()
+        driver.execute_script.return_value = "  Do you offer this?  "
+        assert _fn("_last_inbound_message")(driver) == "Do you offer this?"
+
+    def test_no_match_returns_empty(self):
+        driver = MagicMock()
+        driver.execute_script.return_value = None
+        assert _fn("_last_inbound_message")(driver) == ""
+
+    def test_script_error_is_non_fatal(self):
+        driver = MagicMock()
+        driver.execute_script.side_effect = RuntimeError("stale")
+        with patch(f"{_RA}.log_warning") as warn:
+            assert _fn("_last_inbound_message")(driver) == ""
+        warn.assert_called_once()
+
+
+class TestReplyToPersonOnPost:
+    def _driver_with(self, authors):
+        driver, wait = MagicMock(), MagicMock()
+        boxes = [MagicMock(name=f"tb{i}") for i in range(len(authors))]
+        driver.find_elements.side_effect = lambda by, sel: (boxes if "expandable-text-box" in sel else [])
+        return driver, wait, boxes
+
+    def test_replies_under_the_right_persons_comment(self):
+        driver, wait, boxes = self._driver_with(["https://x/in/bob", "https://x/in/jane"])
+        conts = [MagicMock(name="c0"), MagicMock(name="c1")]
+        with patch(f"{_RA}._comment_container", side_effect=conts), \
+             patch(f"{_RA}._comment_header_author", side_effect=["https://x/in/bob", "https://x/in/jane"]), \
+             patch(f"{_RA}._reply_under_comment_inline", return_value=True) as rep:
+            ok = _fn("_reply_to_person_on_post")(driver, wait, "https://x/post/1",
+                                                 "https://x/in/jane", "hi", user_id=1)
+        assert ok is True
+        assert rep.call_args.args[2] is conts[1]
+
+    def test_person_not_found_returns_false(self):
+        driver, wait, _ = self._driver_with(["https://x/in/bob"])
+        with patch(f"{_RA}._comment_container", return_value=MagicMock()), \
+             patch(f"{_RA}._comment_header_author", return_value="https://x/in/bob"), \
+             patch(f"{_RA}._reply_under_comment_inline") as rep, \
+             patch(f"{_RA}.log_warning") as warn:
+            ok = _fn("_reply_to_person_on_post")(driver, wait, "https://x/post/1",
+                                                 "https://x/in/jane", "hi")
+        assert ok is False
+        rep.assert_not_called()
+        warn.assert_called_once()
+
+    def test_no_slug_never_navigates(self):
+        driver, wait = MagicMock(), MagicMock()
+        with patch(f"{_RA}.log_warning") as warn:
+            assert _fn("_reply_to_person_on_post")(driver, wait, "https://x/post/1", "", "hi") is False
+        driver.get.assert_not_called()
+        warn.assert_called_once()
+
+
+class TestSendLeadResponse:
+    _BASE = {"id": 3, "user_id": 1, "status": "approved", "channel": "dm",
+             "draft_response": "Happy to help!", "person_profile_url": "https://x/in/jane",
+             "context_url": "https://x/post/1", "post_id": None}
+
+    def _signal(self, **over):
+        s = dict(self._BASE)
+        s.update(over)
+        return s
+
+    def test_dm_channel_sends_and_marks_sent(self):
+        from cqc_lem.utilities.db import LeadSignalStatus
+        with patch(f"{_RA}.get_lead_signal", return_value=self._signal()), \
+             patch(f"{_RA}.send_dm_now", return_value=True) as send, \
+             patch(f"{_RA}.update_lead_signal") as upd:
+            result = _fn("_send_lead_response")(3)
+        send.assert_called_once_with(1, "https://x/in/jane", "Happy to help!")
+        assert upd.call_args.kwargs["status"] == LeadSignalStatus.SENT
+        assert "sent" in result
+
+    def test_failed_dm_marks_failed(self):
+        from cqc_lem.utilities.db import LeadSignalStatus
+        with patch(f"{_RA}.get_lead_signal", return_value=self._signal()), \
+             patch(f"{_RA}.send_dm_now", return_value=False), \
+             patch(f"{_RA}.update_lead_signal") as upd:
+            _fn("_send_lead_response")(3)
+        assert upd.call_args.kwargs["status"] == LeadSignalStatus.FAILED
+
+    def test_reply_channel_posts_under_their_comment(self):
+        from cqc_lem.utilities.db import LeadSignalStatus
+        with patch(f"{_RA}.get_lead_signal", return_value=self._signal(channel="reply")), \
+             patch(f"{_RA}.get_current_profile",
+                   return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}._reply_to_person_on_post", return_value=True) as rep, \
+             patch(f"{_RA}.insert_new_log") as log, \
+             patch(f"{_RA}.update_lead_signal") as upd, \
+             patch(f"{_RA}.quit_gracefully") as quit_:
+            result = _fn("_send_lead_response")(3)
+        rep.assert_called_once()
+        assert upd.call_args.kwargs["status"] == LeadSignalStatus.SENT
+        log.assert_called_once()
+        quit_.assert_called_once()
+        assert "sent" in result
+
+    def test_unapproved_signal_is_never_sent(self):
+        with patch(f"{_RA}.get_lead_signal", return_value=self._signal(status="new")), \
+             patch(f"{_RA}.send_dm_now") as send, \
+             patch(f"{_RA}.update_lead_signal") as upd:
+            result = _fn("_send_lead_response")(3)
+        send.assert_not_called()
+        upd.assert_not_called()
+        assert "not sendable" in result
+
+    def test_missing_signal(self):
+        with patch(f"{_RA}.get_lead_signal", return_value=None):
+            assert "not found" in _fn("_send_lead_response")(3)
+
+    def test_empty_draft_fails_instead_of_sending_nothing(self):
+        from cqc_lem.utilities.db import LeadSignalStatus
+        with patch(f"{_RA}.get_lead_signal", return_value=self._signal(draft_response="  ")), \
+             patch(f"{_RA}.send_dm_now") as send, \
+             patch(f"{_RA}.update_lead_signal") as upd:
+            _fn("_send_lead_response")(3)
+        send.assert_not_called()
+        assert upd.call_args.kwargs["status"] == LeadSignalStatus.FAILED
+
+    def test_reply_without_a_post_url_fails(self):
+        from cqc_lem.utilities.db import LeadSignalStatus
+        with patch(f"{_RA}.get_lead_signal", return_value=self._signal(channel="reply", context_url=None)), \
+             patch(f"{_RA}.get_current_profile") as gcp, \
+             patch(f"{_RA}.update_lead_signal") as upd:
+            _fn("_send_lead_response")(3)
+        gcp.assert_not_called()
+        assert upd.call_args.kwargs["status"] == LeadSignalStatus.FAILED
+
+    def test_rate_limited_session_leaves_it_approved_for_a_retry(self):
+        from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
+        with patch(f"{_RA}.get_lead_signal", return_value=self._signal(channel="reply")), \
+             patch(f"{_RA}.get_current_profile", side_effect=LinkedInRateLimited("429")), \
+             patch(f"{_RA}.update_lead_signal") as upd, \
+             patch(f"{_RA}.log_warning") as warn:
+            result = _fn("_send_lead_response")(3)
+        upd.assert_not_called()  # still APPROVED, so a later run retries it
+        warn.assert_called_once()
+        assert "rate limited" in result.lower()
+
+    def test_session_failure_reports_without_marking_sent(self):
+        with patch(f"{_RA}.get_lead_signal", return_value=self._signal(channel="reply")), \
+             patch(f"{_RA}.get_current_profile", side_effect=RuntimeError("no driver")), \
+             patch(f"{_RA}.update_lead_signal") as upd, \
+             patch(f"{_RA}.log_error"):
+            result = _fn("_send_lead_response")(3)
+        upd.assert_not_called()
+        assert "Failed to start" in result
+
+
+class TestReadPathWiring:
+    def test_dm_followup_flags_their_reply(self):
+        """A follow-up that detects a reply reads that reply once and checks it for intent (#483)."""
+        from cqc_lem.app.run_automation import process_user_followups
+        from cqc_lem.utilities.db import LeadSignalSource
+        due = [{"id": 1, "user_id": 1, "profile_url": "https://x/in/jane", "first_name": "Jane",
+                "event_type": "manual", "next_step": 1}]
+        with patch(f"{_RA}.get_due_followups", return_value=due), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"), \
+             patch(f"{_RA}.check_dm_replied", return_value=True), \
+             patch(f"{_RA}._last_inbound_message", return_value="How much for the full program?"), \
+             patch(f"{_RA}._flag_lead_signal", return_value=5) as flag, \
+             patch(f"{_RA}.stop_followups_for_profile"), \
+             patch(f"{_RA}.mark_followup"), \
+             patch(f"{_RA}.quit_gracefully"):
+            process_user_followups.run(user_id=1)
+        flag.assert_called_once()
+        assert flag.call_args.args[1] == "How much for the full program?"
+        assert flag.call_args.args[2] == LeadSignalSource.DM
+
+    def test_own_post_comment_flags_a_lead(self):
+        """A comment on our own post is classified before we decide whether to reply to it."""
+        comment = MagicMock()
+        comment.find_elements.return_value = []          # no text box -> falls back to .text
+        comment.text = "Do you offer this for agencies?"
+        link = MagicMock()
+        link.text = "Jane Doe"
+        link.get_attribute.return_value = "https://www.linkedin.com/in/jane?trk=x"
+        comment.find_element.return_value = link
+        profile = MagicMock()
+        profile.profile_url = "https://www.linkedin.com/in/me/"
+        profile.full_name = "Me Myself"
+        with patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://x/post/7"), \
+             patch(f"{_RA}.get_post_content", return_value="my post"), \
+             patch(f"{_RA}.click_first", return_value=None), \
+             patch(f"{_RA}._comment_items_from_thread", return_value=[comment]), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_lead_magnet_settings", return_value={"enabled": False}), \
+             patch(f"{_RA}.upsert_engager"), \
+             patch(f"{_RA}._flag_lead_signal", return_value=1) as flag, \
+             patch(f"{_RA}.generate_thread_reply", return_value=None), \
+             patch(f"{_RA}.insert_new_log"):
+            driver = MagicMock()
+            driver.current_url = "https://x/post/7"
+            _fn("_reply_to_comments_on_open_post")(driver, MagicMock(), 1, 7, profile, "synth")
+        flag.assert_called_once()
+        assert flag.call_args.args[1] == "Do you offer this for agencies?"
+        assert flag.call_args.kwargs["person_name"] == "Jane Doe"
+        assert flag.call_args.kwargs["post_id"] == 7

--- a/tests/unit/app/test_reply_sweep.py
+++ b/tests/unit/app/test_reply_sweep.py
@@ -124,6 +124,7 @@ class TestReplyToCommentsOnOpenPost:
              patch(f"{_RA}.upsert_engager"), \
              patch(f"{_RA}.generate_thread_reply", return_value="Thanks! What resonated most?"), \
              patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}._flag_lead_signal", return_value=None), \
              patch(f"{_RA}._reply_to_comment_inline", return_value=True) as rep, \
              patch(f"{_RA}.insert_new_log") as log:
             result = _reply_to_comments_on_open_post(driver, MagicMock(), 1, 9, self._profile(), "synth")
@@ -143,6 +144,8 @@ class TestReplyToCommentsOnOpenPost:
              patch(f"{_RA}.get_lead_magnet_settings", return_value={"enabled": False}), \
              patch(f"{_RA}.upsert_engager"), \
              patch(f"{_RA}.generate_thread_reply") as gen, \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}._flag_lead_signal", return_value=None), \
              patch(f"{_RA}._reply_to_comment_inline") as rep, \
              patch(f"{_RA}.insert_new_log"):
             _reply_to_comments_on_open_post(driver, MagicMock(), 1, 9, self._profile(), "synth")
@@ -166,6 +169,7 @@ class TestReplyToCommentsOnOpenPost:
              patch(f"{_RA}.upsert_engager"), \
              patch(f"{_RA}.generate_thread_reply", return_value="reply"), \
              patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}._flag_lead_signal", return_value=None), \
              patch(f"{_RA}._reply_to_comment_inline", return_value=True), \
              patch(f"{_RA}.insert_new_log"):
             _reply_to_comments_on_open_post(driver, MagicMock(), 1, 9, self._profile(), "synth")
@@ -203,6 +207,7 @@ class TestReplyToCommentsOnOpenPost:
              patch(f"{_RA}.upsert_engager"), \
              patch(f"{_RA}.generate_thread_reply", return_value="reply"), \
              patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}._flag_lead_signal", return_value=None), \
              patch(f"{_RA}._reply_to_comment_inline", return_value=True) as rep, \
              patch(f"{_RA}.insert_new_log"):
             _reply_to_comments_on_open_post(MagicMock(), MagicMock(), 1, 9, self._profile(), "s")

--- a/tests/unit/utilities/ai/test_lead_response.py
+++ b/tests/unit/utilities/ai/test_lead_response.py
@@ -1,0 +1,59 @@
+"""Unit tests for the hot-lead response generator (issue #483) — the approval-gated draft sent to
+someone showing inbound buying intent."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_AI = "cqc_lem.utilities.ai.ai_helper"
+
+
+def _resp(text):
+    r = MagicMock(); r.choices = [MagicMock(message=MagicMock(content=text))]
+    return r
+
+
+def _profile():
+    p = MagicMock(); p.model_dump_json.return_value = "{}"
+    return p
+
+
+class TestGenerateLeadResponse:
+    def test_returns_the_draft(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("  Depends on scope — what's your timeline?  ")):
+            out = ai_helper.generate_lead_response("How much?", _profile())
+        assert out == "Depends on scope — what's your timeline?"
+
+    def test_none_when_the_model_returns_nothing(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp(None)):
+            assert ai_helper.generate_lead_response("How much?", _profile()) is None
+
+    def test_dm_channel_uses_the_dm_budget(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("hi")), \
+             patch(f"{_AI}._humanize_text", side_effect=lambda c, **kw: c) as hum:
+            ai_helper.generate_lead_response("How much?", _profile(), channel="dm")
+        assert hum.call_args.kwargs["max_chars"] == 300
+        assert hum.call_args.kwargs["content_type"] == "dm"
+
+    def test_reply_channel_uses_the_comment_budget(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("hi")), \
+             patch(f"{_AI}._humanize_text", side_effect=lambda c, **kw: c) as hum:
+            ai_helper.generate_lead_response("How much?", _profile(), channel="reply")
+        assert hum.call_args.kwargs["max_chars"] == 500
+        assert hum.call_args.kwargs["content_type"] == "comment"
+
+    def test_prompt_forbids_inventing_prices_and_includes_their_message(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("hi")) as call, \
+             patch(f"{_AI}._humanize_text", side_effect=lambda c, **kw: c):
+            ai_helper.generate_lead_response("What does this cost?", _profile(),
+                                             context="the post they commented on")
+        messages = call.call_args.kwargs["messages"]
+        assert "NEVER invent prices" in messages[0]["content"]
+        assert "What does this cost?" in messages[1]["content"]
+        assert "the post they commented on" in messages[1]["content"]

--- a/tests/unit/utilities/test_db_lead_signals.py
+++ b/tests/unit/utilities/test_db_lead_signals.py
@@ -1,0 +1,184 @@
+"""Unit tests for the lead_signals DB helpers (issue #483) — dedup insert, fail-safe existence
+check, paginated inbox, partial updates, and the unactioned count."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import mysql.connector
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _mock_conn(fetch_row=None, fetch_all=None, lastrowid=7, side_effect=None):
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchone.return_value = fetch_row
+    cursor.fetchall.return_value = fetch_all or []
+    cursor.lastrowid = lastrowid
+    cursor.rowcount = 1
+    if side_effect is not None:
+        cursor.execute.side_effect = side_effect
+    conn.cursor.return_value = cursor
+    return conn, cursor
+
+
+class TestInsertLeadSignal:
+    def test_inserts_and_returns_the_id(self):
+        conn, cursor = _mock_conn(lastrowid=7)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_lead_signal, LeadSignalSource, LeadSignalChannel
+            sid = insert_lead_signal(1, LeadSignalSource.POST_COMMENT, "lead:post:1:jane",
+                                     person_name="Jane", score=55, matched_signals="pricing",
+                                     channel=LeadSignalChannel.DM)
+        assert sid == 7
+        sql, params = cursor.execute.call_args[0]
+        assert "INSERT IGNORE INTO lead_signals" in sql   # dedup is the UNIQUE(user_id, thread_key)
+        assert params[1] == "post_comment" and params[2] == "dm"
+
+    def test_duplicate_thread_returns_none(self):
+        conn, _ = _mock_conn(lastrowid=0)   # INSERT IGNORE swallowed it
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_lead_signal, LeadSignalSource
+            assert insert_lead_signal(1, LeadSignalSource.DM, "lead:dm:thread:jane") is None
+
+    def test_blank_key_is_refused(self):
+        with patch(f"{_DB}.get_db_connection") as get:
+            from cqc_lem.utilities.db import insert_lead_signal, LeadSignalSource
+            assert insert_lead_signal(1, LeadSignalSource.DM, "") is None
+        get.assert_not_called()
+
+    def test_score_is_clamped_into_the_tinyint_column(self):
+        conn, cursor = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_lead_signal, LeadSignalSource
+            insert_lead_signal(1, LeadSignalSource.DM, "k", score=9999)
+        assert cursor.execute.call_args[0][1][7] == 255
+
+    def test_db_error_returns_none(self):
+        conn, _ = _mock_conn(side_effect=mysql.connector.Error("boom"))
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.myprint"):
+            from cqc_lem.utilities.db import insert_lead_signal, LeadSignalSource
+            assert insert_lead_signal(1, LeadSignalSource.DM, "k") is None
+
+
+class TestHasLeadSignal:
+    def test_true_when_present(self):
+        conn, _ = _mock_conn(fetch_row=(1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_lead_signal
+            assert has_lead_signal(1, "k") is True
+
+    def test_false_when_absent(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_lead_signal
+            assert has_lead_signal(1, "k") is False
+
+    def test_blank_key_and_db_errors_fail_safe_to_skipping(self):
+        from cqc_lem.utilities.db import has_lead_signal
+        assert has_lead_signal(1, "") is True
+        conn, _ = _mock_conn(side_effect=mysql.connector.Error("boom"))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert has_lead_signal(1, "k") is True
+
+
+class TestGetLeadSignals:
+    def test_paginates_and_serializes_datetimes(self):
+        from datetime import datetime
+        rows = [{"id": 1, "created_at": datetime(2026, 7, 24, 12, 0), "updated_at": None}]
+        conn, cursor = _mock_conn(fetch_row={"c": 1}, fetch_all=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_lead_signals
+            out = get_lead_signals(1, status_filter="new", page=2, page_size=10)
+        assert out["total"] == 1 and out["page"] == 2
+        assert out["signals"][0]["created_at"] == "2026-07-24T12:00:00"
+        sql, params = cursor.execute.call_args[0]
+        assert tuple(params[-2:]) == (10, 10)   # page_size, offset
+        assert "status = %s" in sql
+
+    def test_sort_order_asc(self):
+        conn, cursor = _mock_conn(fetch_row={"c": 0}, fetch_all=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_lead_signals
+            get_lead_signals(1, sort_order="asc")
+        assert "ORDER BY created_at ASC" in cursor.execute.call_args[0][0]
+
+    def test_db_error_returns_an_empty_page(self):
+        conn, _ = _mock_conn(side_effect=mysql.connector.Error("boom"))
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.myprint"):
+            from cqc_lem.utilities.db import get_lead_signals
+            out = get_lead_signals(1)
+        assert out == {"signals": [], "total": 0, "page": 1, "page_size": 25}
+
+
+class TestGetLeadSignal:
+    def test_returns_the_row_and_its_owner(self):
+        conn, _ = _mock_conn(fetch_row={"id": 3, "user_id": 5})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_lead_signal, get_lead_signal_user_id
+            assert get_lead_signal(3)["id"] == 3
+            assert get_lead_signal_user_id(3) == 5
+
+    def test_missing_row_has_no_owner(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_lead_signal_user_id
+            assert get_lead_signal_user_id(3) is None
+
+    def test_db_error_returns_none(self):
+        conn, _ = _mock_conn(side_effect=mysql.connector.Error("boom"))
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.myprint"):
+            from cqc_lem.utilities.db import get_lead_signal
+            assert get_lead_signal(3) is None
+
+
+class TestUpdateLeadSignal:
+    def test_updates_only_the_supplied_fields(self):
+        conn, cursor = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_lead_signal, LeadSignalStatus
+            assert update_lead_signal(3, status=LeadSignalStatus.SENT) is True
+        sql, params = cursor.execute.call_args[0]
+        assert "status = %s" in sql and "draft_response" not in sql
+        assert params == ("sent", 3)
+
+    def test_draft_and_status_together(self):
+        conn, cursor = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_lead_signal, LeadSignalStatus
+            update_lead_signal(3, draft_response="hi", status=LeadSignalStatus.APPROVED)
+        assert cursor.execute.call_args[0][1] == ("hi", "approved", 3)
+
+    def test_nothing_to_update_is_a_no_op(self):
+        with patch(f"{_DB}.get_db_connection") as get:
+            from cqc_lem.utilities.db import update_lead_signal
+            assert update_lead_signal(3) is False
+        get.assert_not_called()
+
+    def test_db_error_returns_false(self):
+        conn, _ = _mock_conn(side_effect=mysql.connector.Error("boom"))
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.myprint"):
+            from cqc_lem.utilities.db import update_lead_signal, LeadSignalStatus
+            assert update_lead_signal(3, status=LeadSignalStatus.SENT) is False
+
+
+class TestCountNewLeadSignals:
+    def test_counts(self):
+        conn, _ = _mock_conn(fetch_row=(4,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_new_lead_signals
+            assert count_new_lead_signals(1) == 4
+
+    def test_no_rows_is_zero(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_new_lead_signals
+            assert count_new_lead_signals(1) == 0
+
+    def test_db_error_is_zero(self):
+        conn, _ = _mock_conn(side_effect=mysql.connector.Error("boom"))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_new_lead_signals
+            assert count_new_lead_signals(1) == 0

--- a/tests/unit/utilities/test_db_lead_signals.py
+++ b/tests/unit/utilities/test_db_lead_signals.py
@@ -117,15 +117,16 @@ class TestGetLeadSignal:
     def test_returns_the_row_and_its_owner(self):
         conn, _ = _mock_conn(fetch_row={"id": 3, "user_id": 5})
         with patch(f"{_DB}.get_db_connection", return_value=conn):
-            from cqc_lem.utilities.db import get_lead_signal, get_lead_signal_user_id
-            assert get_lead_signal(3)["id"] == 3
-            assert get_lead_signal_user_id(3) == 5
+            from cqc_lem.utilities.db import get_lead_signal
+            row = get_lead_signal(3)
+        assert row["id"] == 3
+        assert row["user_id"] == 5
 
-    def test_missing_row_has_no_owner(self):
+    def test_missing_row_is_none(self):
         conn, _ = _mock_conn(fetch_row=None)
         with patch(f"{_DB}.get_db_connection", return_value=conn):
-            from cqc_lem.utilities.db import get_lead_signal_user_id
-            assert get_lead_signal_user_id(3) is None
+            from cqc_lem.utilities.db import get_lead_signal
+            assert get_lead_signal(3) is None
 
     def test_db_error_returns_none(self):
         conn, _ = _mock_conn(side_effect=mysql.connector.Error("boom"))

--- a/tests/unit/utilities/test_lead_intent.py
+++ b/tests/unit/utilities/test_lead_intent.py
@@ -1,0 +1,149 @@
+"""Unit tests for the inbound buying-intent classifier — issue #483. Covers the heuristic families,
+the cost gate (only ambiguous text reaches the LLM), the LLM tier's fail-closed behaviour, and the
+env-tunable threshold."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_LI = "cqc_lem.utilities.ai.lead_intent"
+
+
+def _detect(*args, **kwargs):
+    from cqc_lem.utilities.ai.lead_intent import detect_lead_signals
+    return detect_lead_signals(*args, **kwargs)
+
+
+class TestStrongSignals:
+    @pytest.mark.parametrize("text,family", [
+        ("How much do you charge for this?", "pricing"),
+        ("What would this cost for a team of 20?", "pricing"),
+        ("Do you offer this as a done-for-you service?", "engage_us"),
+        ("Can you help with our LinkedIn strategy?", "engage_us"),
+        ("Just sent you a note — DM me when you have a minute", "contact_me"),
+        ("Let's talk, I'd like to hear more about how you work", "contact_me"),
+        ("We need help with our content pipeline", "stated_need"),
+        ("I'm looking for someone who does exactly this", "stated_need"),
+        ("Who do you recommend for this kind of work?", "referral"),
+        ("How do I get started with this?", "demo_trial"),
+    ])
+    def test_flags_as_lead(self, text, family):
+        result = _detect(text, use_llm=False)
+        assert result["is_lead"] is True
+        assert family in result["matched"]
+        assert result["method"] == "heuristic"
+
+    def test_score_accumulates_but_is_capped(self):
+        text = ("How much does it cost? Do you offer this? DM me — we need help with this, "
+                "and who do you recommend? I'm curious about your team.")
+        assert _detect(text, use_llm=False)["score"] == 100
+
+
+class TestNonLeads:
+    @pytest.mark.parametrize("text", [
+        "Great post, thanks for sharing!",
+        "Congrats on the launch — this is amazing work.",
+        "Totally agree. We saw the same thing last quarter.",
+        "",
+        None,
+        "nice",          # below the minimum length
+        "🔥🔥🔥",
+    ])
+    def test_not_a_lead(self, text):
+        result = _detect(text, use_llm=False)
+        assert result["is_lead"] is False
+        assert result["score"] == 0
+
+    def test_short_text_never_reaches_the_matcher(self):
+        assert _detect("hi", use_llm=False)["method"] == "none"
+
+
+class TestAmbiguousBand:
+    _AMBIGUOUS = "Interested in how your team approaches this."
+
+    def test_weak_only_is_below_threshold_without_llm(self):
+        result = _detect(self._AMBIGUOUS, use_llm=False)
+        assert result["is_lead"] is False
+        assert 0 < result["score"] < 40
+
+    def test_llm_promotes_an_ambiguous_hit(self):
+        with patch(f"{_LI}._llm_says_lead", return_value=True) as llm:
+            result = _detect(self._AMBIGUOUS)
+        llm.assert_called_once()
+        assert result["is_lead"] is True
+        assert result["method"] == "llm"
+        assert result["score"] >= 40
+
+    def test_llm_no_keeps_it_out_of_the_inbox(self):
+        with patch(f"{_LI}._llm_says_lead", return_value=False):
+            result = _detect(self._AMBIGUOUS)
+        assert result["is_lead"] is False
+
+    def test_no_signal_at_all_never_pays_for_an_llm_call(self):
+        with patch(f"{_LI}._llm_says_lead") as llm:
+            _detect("Great post, thanks for sharing!")
+        llm.assert_not_called()
+
+    def test_strong_signal_never_pays_for_an_llm_call(self):
+        with patch(f"{_LI}._llm_says_lead") as llm:
+            assert _detect("How much do you charge?")["is_lead"] is True
+        llm.assert_not_called()
+
+    def test_llm_tier_can_be_disabled_by_env(self, monkeypatch):
+        monkeypatch.setenv("LEAD_INTENT_LLM_ENABLED", "false")
+        with patch(f"{_LI}._llm_says_lead") as llm:
+            assert _detect(self._AMBIGUOUS)["is_lead"] is False
+        llm.assert_not_called()
+
+
+class TestLlmTier:
+    def _response(self, content):
+        resp = MagicMock()
+        resp.choices = [MagicMock(message=MagicMock(content=content))]
+        return resp
+
+    def test_yes_is_a_lead(self):
+        from cqc_lem.utilities.ai.lead_intent import _llm_says_lead
+        client = MagicMock()
+        client.chat.completions.create.return_value = self._response("Yes")
+        with patch("cqc_lem.utilities.ai.client.client", client):
+            assert _llm_says_lead("do you do this?") is True
+        assert client.chat.completions.create.call_args.kwargs["model"] == "lem-simple"
+
+    def test_no_is_not_a_lead(self):
+        from cqc_lem.utilities.ai.lead_intent import _llm_says_lead
+        client = MagicMock()
+        client.chat.completions.create.return_value = self._response("no")
+        with patch("cqc_lem.utilities.ai.client.client", client):
+            assert _llm_says_lead("nice work") is False
+
+    def test_failure_fails_closed(self):
+        from cqc_lem.utilities.ai.lead_intent import _llm_says_lead
+        client = MagicMock()
+        client.chat.completions.create.side_effect = RuntimeError("proxy down")
+        with patch("cqc_lem.utilities.ai.client.client", client), patch(f"{_LI}.log_warning") as warn:
+            assert _llm_says_lead("maybe?") is False
+        warn.assert_called_once()
+
+    def test_empty_content_is_not_a_lead(self):
+        from cqc_lem.utilities.ai.lead_intent import _llm_says_lead
+        client = MagicMock()
+        client.chat.completions.create.return_value = self._response(None)
+        with patch("cqc_lem.utilities.ai.client.client", client):
+            assert _llm_says_lead("hmm") is False
+
+
+class TestThresholdEnv:
+    def test_threshold_can_be_raised(self, monkeypatch):
+        monkeypatch.setenv("LEAD_INTENT_MIN_SCORE", "90")
+        assert _detect("How much do you charge?", use_llm=False)["is_lead"] is False
+
+    def test_garbage_threshold_falls_back_to_the_default(self, monkeypatch):
+        monkeypatch.setenv("LEAD_INTENT_MIN_SCORE", "not-a-number")
+        assert _detect("How much do you charge?", use_llm=False)["is_lead"] is True
+
+    def test_long_text_is_truncated_before_matching(self):
+        from cqc_lem.utilities.ai.lead_intent import _MAX_TEXT_CHARS
+        text = ("x" * (_MAX_TEXT_CHARS + 50)) + " how much do you charge?"
+        assert _detect(text, use_llm=False)["is_lead"] is False

--- a/tests/unit/utilities/test_lead_intent.py
+++ b/tests/unit/utilities/test_lead_intent.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 pytestmark = pytest.mark.unit
 
 _LI = "cqc_lem.utilities.ai.lead_intent"
+_AI = "cqc_lem.utilities.ai.ai_helper"
 
 
 def _detect(*args, **kwargs):
@@ -104,33 +105,29 @@ class TestLlmTier:
         return resp
 
     def test_yes_is_a_lead(self):
-        from cqc_lem.utilities.ai.lead_intent import _llm_says_lead
-        client = MagicMock()
-        client.chat.completions.create.return_value = self._response("Yes")
-        with patch("cqc_lem.utilities.ai.client.client", client):
+        from cqc_lem.utilities.ai.lead_intent import _llm_says_lead, _LLM_MAX_TOKENS
+        with patch(f"{_AI}._call_llm", return_value=self._response("Yes")) as call:
             assert _llm_says_lead("do you do this?") is True
-        assert client.chat.completions.create.call_args.kwargs["model"] == "lem-simple"
+        # _call_llm is what emits the PostHog llm_call event, so routing through it keeps this
+        # high-volume classifier in the usage metrics — and the answer is one word.
+        assert call.call_args.kwargs["model"] == "lem-simple"
+        assert call.call_args.kwargs["max_tokens"] == _LLM_MAX_TOKENS
 
     def test_no_is_not_a_lead(self):
         from cqc_lem.utilities.ai.lead_intent import _llm_says_lead
-        client = MagicMock()
-        client.chat.completions.create.return_value = self._response("no")
-        with patch("cqc_lem.utilities.ai.client.client", client):
+        with patch(f"{_AI}._call_llm", return_value=self._response("no")):
             assert _llm_says_lead("nice work") is False
 
     def test_failure_fails_closed(self):
         from cqc_lem.utilities.ai.lead_intent import _llm_says_lead
-        client = MagicMock()
-        client.chat.completions.create.side_effect = RuntimeError("proxy down")
-        with patch("cqc_lem.utilities.ai.client.client", client), patch(f"{_LI}.log_warning") as warn:
+        with patch(f"{_AI}._call_llm", side_effect=RuntimeError("proxy down")), \
+                patch(f"{_LI}.log_warning") as warn:
             assert _llm_says_lead("maybe?") is False
         warn.assert_called_once()
 
     def test_empty_content_is_not_a_lead(self):
         from cqc_lem.utilities.ai.lead_intent import _llm_says_lead
-        client = MagicMock()
-        client.chat.completions.create.return_value = self._response(None)
-        with patch("cqc_lem.utilities.ai.client.client", client):
+        with patch(f"{_AI}._call_llm", return_value=self._response(None)):
             assert _llm_says_lead("hmm") is False
 
 


### PR DESCRIPTION
## What

Someone asking *"how much?"*, *"do you help with X?"*, or *"DM me"* in a comment or message is the warmest lead we get — and today we read that text and throw it away. This turns those signals into a surfaced, actioned queue.

**Detection rides the reads that already happen** — no new scraping, no extra navigation:
| Source | Where it hooks in |
|---|---|
| `post_comment` | `_reply_to_comments_on_open_post` — comments on the user's own posts |
| `comment_reply` | `_followup_on_post_comment_replies` — replies to comments we automated (#478) |
| `dm` | `process_user_followups` — the thread `check_dm_replied` already opens |

## How

- **`utilities/ai/lead_intent.py` — `detect_lead_signals(text)`**: two tiers in cost order. Heuristic families (pricing / engage-us / contact-me / stated-need / referral / demo-trial) are decisive on their own; weak families only accumulate. **Only the ambiguous band** (weak signal, nothing decisive) pays for one cheap `lem-simple` call — text with no signal never reaches the LLM, which matters at comment volume (same logic as `COMMENT_RESEARCH_ENABLED`). The LLM tier **fails closed** so a classifier hiccup can't flood the inbox. Env: `LEAD_INTENT_LLM_ENABLED` (default on), `LEAD_INTENT_MIN_SCORE` (default 40).
- **`lead_signals` table** (`V20260724214753__add_lead_signals.sql`) with `UNIQUE(user_id, thread_key)` — dedup is keyed on **person + thread, never on message text** (the #474 lesson), so one conversation is flagged once and an operator's edit/dismissal is never clobbered. The existence check runs *before* draft generation, so a re-scan costs nothing.
- **`generate_lead_response`** drafts the reply/DM in the user's voice via the existing alignment + humanization machinery. It's the one generator where `NO_SELF_PROMO_GUARDRAIL` deliberately does **not** apply (they asked) — and it is explicitly forbidden from inventing prices, timelines, or capabilities.
- **Leads inbox** — new "Leads" tab in Content Studio, with the evidence snippet, the matched intent families, the score, and an editable draft. `GET /api/lead_signals`, `PUT /api/lead_signal`.
- **Approval gate**: nothing is ever sent automatically. `send_lead_response` only acts on a signal whose status is `approved`, and sends exactly the text the operator sees — as a reply under their comment (reusing the #478 comment-thread helpers) or as a DM via `send_dm_now`. A 429 leaves it `approved` for a later retry rather than marking it failed.
- Volume backstops: max 10 new flags per sweep (a draft costs an LLM call).

## Testing

- 71 new unit tests: classifier tiers + cost gate + fail-closed, `lead_signals` DB helpers (dedup, fail-safe paths, pagination, partial updates), dedup key + flag helper + read-path wiring, the responder (both channels, unapproved/empty-draft/rate-limited paths), and the API (approval gate, ownership 404, validation).
- Full unit suite green: **3393 passed**. UI typechecks (`tsc -b`).
- Existing tests on the three touched read paths were updated to patch the new detection call (kept hermetic per #480).

## Notes

- The issue's *optional* owner notification is not included — the inbox surfaces a `new_count` badge instead; an email/push hook can be added later without touching this schema.
- Selenium DOM targeting for the reply delivery reuses the selectors validated live in #478; it still deserves a supervised live pass.

Closes #483

🤖 Generated with [Claude Code](https://claude.com/claude-code)