### PR TITLE
feat(outreach): smart connection targeting from content engagers (closes #486)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,10 @@ DM_NURTURE_AUTO_APPROVE=false
 # Allow one cheap lem-simple call to classify replies no keyword settled (interested / objection /
 # not-now / disinterest). DM replies are low volume, so this defaults ON.
 DM_NURTURE_INTENT_LLM_ENABLED=true
+# Smart connection targeting (issue #486): hard ceiling on how many NEW connection targets one
+# sourcing scan may file per user, independent of their max_invites_per_day. Keeps sourcing a
+# trickle of high-fit people rather than a queue that looks like list-blasting.
+MAX_NEW_CONNECT_TARGETS_PER_SCAN=5
 
 # --- Ollama (local + cloud model hosting) ---
 OLLAMA_API_KEY=your_ollama_api_key

--- a/compose/local/database/migrations/V20260725004908__add_connection_targeting.sql
+++ b/compose/local/database/migrations/V20260725004908__add_connection_targeting.sql
@@ -1,0 +1,31 @@
+-- Smart connection targeting from content engagers (issue #486, extends #398). #398 gave us the
+-- approval-gated, daily-capped SEND path (connection_requests + invite_to_connect); this adds the
+-- SOURCING half: people who engaged with the user's own posts, and people who engaged with a
+-- configurable set of adjacent authors' recent posts, ICP-scored and deduped before they ever
+-- become a request. Nothing here bypasses #398's gates — every target still lands in
+-- connection_requests and still costs one slot of max_invites_per_day.
+
+-- Provenance on the request itself, so the operator approving in the Connections review UI can see
+-- WHERE this person came from and WHY they scored well. Nullable: rows added by hand (or by #398's
+-- API) carry no source and must keep working unchanged.
+ALTER TABLE connection_requests
+    ADD COLUMN source    VARCHAR(32)  NULL AFTER message,
+    ADD COLUMN icp_score TINYINT UNSIGNED NULL AFTER source,
+    ADD COLUMN reasons   VARCHAR(512) NULL AFTER icp_score;
+
+-- Targeting configuration.
+--   connection_targeting_mode — 'off' disables sourcing entirely; 'suggest' (default) ALWAYS files
+--     candidates as 'pending' drafts needing a human approve, regardless of connection_request_mode;
+--     'auto_queue' defers to connection_request_mode (so auto_approve users get the capped drip).
+--     Default 'suggest' means turning this on can never send outbound on its own.
+--   connection_target_authors — adjacent thought-leaders'/competitors' profile URLs whose recent
+--     posts we harvest engagers from (warm 2nd-degree prospects). Empty = own posts only.
+--   min_connection_icp_score — ICP floor for people we HAVE profile facts on. People we've never
+--     scraped score neutral (lead_scoring.ICP_UNKNOWN) and are judged on engagement instead, since
+--     most engagers are never scraped and a floor would otherwise reject everyone.
+-- VARCHAR (not ENUM) for the mode: adding an ENUM value needs a migration (see CLAUDE.md), and this
+-- list will grow.
+ALTER TABLE engagement_preferences
+    ADD COLUMN connection_targeting_mode VARCHAR(16)      NOT NULL DEFAULT 'suggest',
+    ADD COLUMN connection_target_authors JSON             NULL,
+    ADD COLUMN min_connection_icp_score  TINYINT UNSIGNED NOT NULL DEFAULT 55;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -471,6 +471,10 @@ class EngagementPreferencesRequest(BaseModel):
     max_dms_per_day: int = 20
     max_invites_per_day: int = 10
     connection_request_mode: str = "auto_approve"  # 'auto_approve' (default) | 'pre_review'
+    # Smart connection targeting (issue #486): 'off' | 'suggest' (default) | 'auto_queue'
+    connection_targeting_mode: str = "suggest"
+    connection_target_authors: List[str] = []
+    min_connection_icp_score: int = 55
     default_buyer_stage: Optional[str] = Field(default=None, max_length=_LEN_BUYER_STAGE)
     default_video_quality: str = "standard"
     reply_check_mode: str = "event"
@@ -498,6 +502,19 @@ class EngagementPreferencesRequest(BaseModel):
     @classmethod
     def _coerce_connection_mode(cls, v: str) -> str:
         return v if v in ("auto_approve", "pre_review") else "auto_approve"
+
+    @field_validator("connection_targeting_mode")
+    @classmethod
+    def _coerce_targeting_mode(cls, v: str) -> str:
+        return v if v in ("off", "suggest", "auto_queue") else "suggest"
+
+    @field_validator("min_connection_icp_score")
+    @classmethod
+    def _clamp_min_icp(cls, v: int) -> int:
+        try:
+            return min(100, max(0, int(v)))
+        except (TypeError, ValueError):
+            return 55
 
     @field_validator("reply_sweeps_per_day")
     @classmethod

--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -116,6 +116,7 @@ task_routes = {
     'cqc_lem.app.run_automation.clean_stale_invites': {'queue': 'se_outreach'},
     'cqc_lem.app.run_automation.update_stale_profile': {'queue': 'se_outreach'},
     'cqc_lem.app.run_automation.send_lead_response': {'queue': 'se_outreach'},
+    'cqc_lem.app.run_automation.scan_connection_candidates': {'queue': 'se_outreach'},
     # --- se_content: seeding, stats, group + newsletter publishing --------
     'cqc_lem.app.run_automation.auto_seed_comment_on_post': {'queue': 'se_content'},
     'cqc_lem.app.run_automation.auto_scrape_post_stats': {'queue': 'se_content'},

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -159,6 +159,12 @@ app.conf.update(
             # reflects everything that happened yesterday.
             'schedule': crontab(hour='3', minute='30')
         },
+        'scan-connection-candidates': {
+            'task': 'cqc_lem.app.run_scheduler.auto_scan_connection_candidates',
+            # Daily at 4:00 AM — after the 3:30 lead re-score, so targeting reads a fresh view of who
+            # is actually engaging. Files a few targets a day; sending stays daily-capped + approved.
+            'schedule': crontab(hour='4', minute='0')
+        },
         'clen-up-stale-profiles': {
             'task': 'cqc_lem.app.run_scheduler.auto_clean_stale_profiles',
             'schedule': crontab(hour='3', minute='0', )  # Run every day at 3:00 AM

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -22,6 +22,9 @@ from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_
     synthesize_profile
 from cqc_lem.utilities.ai.lead_intent import detect_lead_signals
 from cqc_lem.utilities.ai.dm_nurture import classify_reply_intent, is_stop_intent, nurture_delay_hours
+from cqc_lem.utilities.connection_targeting import CandidateSignal, ScoredCandidate, \
+    CONNECT_NOTE_LIMIT, SOURCE_ADJACENT_POST, SOURCE_OWN_POST, default_connect_note, \
+    rank_candidates, target_terms_from_prefs
 from cqc_lem.utilities.ai.content_alignment import humanize_text, split_link_for_first_comment, \
     append_link_to_comment
 from cqc_lem.utilities.date import convert_viewed_on_to_date
@@ -46,7 +49,9 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     insert_lead_signal, has_lead_signal, get_lead_signal, update_lead_signal, \
     LeadSignalSource, LeadSignalChannel, LeadSignalStatus, \
     insert_scheduled_dm, has_open_scheduled_dm, count_scheduled_dms_created_today, \
-    ScheduledDmStatus, SCHEDULED_DM_SOURCE_NURTURE
+    ScheduledDmStatus, SCHEDULED_DM_SOURCE_NURTURE, \
+    insert_connection_request, count_open_connection_requests, get_requested_person_keys, \
+    get_engager_candidates, get_profile_facts, count_invites_sent_today, ConnectionRequestStatus
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
     load_profile_for_user
@@ -3846,6 +3851,185 @@ def send_connection_request(self, request_id: int):
     update_connection_request_status(
         request_id, ConnectionRequestStatus.SENT if sent else ConnectionRequestStatus.FAILED)
     return f"Connection request {request_id} -> {'sent' if sent else 'failed'}"
+
+
+# --- Smart connection targeting (issue #486) — source warm engagers into #398's send path ---
+# Hard per-scan ceiling, independent of the user's daily invite cap: sourcing should trickle in a
+# handful of high-fit people a day, never file a queue that looks like list-blasting.
+_MAX_NEW_CONNECT_TARGETS_PER_SCAN = int(os.getenv("MAX_NEW_CONNECT_TARGETS_PER_SCAN", "5"))
+_MAX_ADJACENT_AUTHORS_PER_SCAN = 3
+_MAX_ADJACENT_POSTS_PER_AUTHOR = 2
+_MAX_ENGAGERS_PER_ADJACENT_POST = 15
+_CONNECT_ENGAGER_LOOKBACK_DAYS = 30
+
+
+def _author_display_name(profile_url: str) -> str:
+    """Readable name for an adjacent author from their /in/ slug (we don't scrape their profile just
+    to write a note). 'jane-doe-1a2b3c' -> 'Jane Doe'."""
+    slug = _profile_slug(profile_url)
+    if not slug:
+        return ""
+    words = [w for w in slug.split("-") if w and not any(ch.isdigit() for ch in w)]
+    return " ".join(w.capitalize() for w in words[:3])
+
+
+def _harvest_post_commenters(driver, post_url: str, author_name: str, now: datetime,
+                             limit: int = _MAX_ENGAGERS_PER_ADJACENT_POST) -> list:
+    """Commenters on ONE post as connection-targeting signals. Reuses the SDUI comment-thread walker
+    the reply sweep uses, so it survives the same DOM churn."""
+    driver.get(post_url)
+    time.sleep(random.uniform(3, 5))
+    signals = []
+    for comment in _comment_items_from_thread(driver)[:limit]:
+        try:
+            link = comment.find_element(By.CSS_SELECTOR, "a[href*='/in/']")
+            name = ((link.text or "") or (link.get_attribute("aria-label") or "")).strip().split("\n")[0]
+            url = (link.get_attribute("href") or "").split("?")[0]
+        except Exception:
+            continue
+        if not name or not url:
+            continue
+        signals.append(CandidateSignal(person_name=name, person_profile_url=url,
+                                       source=SOURCE_ADJACENT_POST, context_url=post_url,
+                                       context_author=author_name, occurred_at=now))
+    return signals
+
+
+def _adjacent_author_signals(driver, user_id: int, authors: list, my_name: str,
+                             now: datetime) -> list:
+    """Harvest engagers from the recent posts of the user's configured adjacent authors (thought
+    leaders / competitors). Each author is best-effort: one unreachable profile must not lose the
+    others' candidates."""
+    from cqc_lem.utilities.linkedin.scrapper import get_profile_recent_activity
+
+    signals: list = []
+    for author_url in authors[:_MAX_ADJACENT_AUTHORS_PER_SCAN]:
+        author_name = _author_display_name(author_url)
+        try:
+            activity = get_profile_recent_activity(driver, author_url) or []
+        except Exception as e:
+            log_warning("Could not read adjacent author's recent activity", exc=e, user_id=user_id,
+                        action_type="connection_targeting")
+            continue
+        for post in activity[:_MAX_ADJACENT_POSTS_PER_AUTHOR]:
+            link = (post or {}).get("link")
+            if not link:
+                continue
+            try:
+                signals.extend(_harvest_post_commenters(driver, link, author_name, now))
+            except Exception as e:
+                log_warning("Could not harvest engagers from adjacent post", exc=e, user_id=user_id,
+                            action_type="connection_targeting")
+    me = (my_name or "").strip().lower()
+    return [s for s in signals if (s.person_name or "").strip().lower() != me]
+
+
+def _connect_target_budget(user_id: int, prefs: dict, max_new: int = None) -> int:
+    """How many NEW targets this scan may file. The daily invite cap is shared with the reactive
+    profile-viewer flow AND with targets already waiting, so sourcing can never build a backlog that
+    spends tomorrow's cap the moment it opens."""
+    cap = int(prefs.get("max_invites_per_day") or 0)
+    remaining = cap - count_invites_sent_today(user_id) - count_open_connection_requests(user_id)
+    ceiling = _MAX_NEW_CONNECT_TARGETS_PER_SCAN if max_new is None else int(max_new)
+    return max(0, min(remaining, ceiling))
+
+
+def _draft_connect_note(user_id: int, candidate: ScoredCandidate, topic: str = None) -> str:
+    """Personalized connect note for one candidate: a grounded template (it names the actual shared
+    context) refined into the user's voice. Falls back to the template if the LLM is unavailable —
+    a missing note must never block the target."""
+    base = default_connect_note(candidate, topic=topic)
+    try:
+        refined = (get_ai_message_refinement(base, character_limit=CONNECT_NOTE_LIMIT) or "").strip()
+    except Exception as e:
+        log_warning("Connect-note refinement failed", exc=e, user_id=user_id,
+                    action_type="connection_targeting")
+        return base
+    return (refined or base)[:CONNECT_NOTE_LIMIT]
+
+
+def _target_status_for_mode(mode: str, prefs: dict) -> "ConnectionRequestStatus":
+    """'suggest' (default) ALWAYS files a draft needing human approval; 'auto_queue' defers to the
+    user's #398 connection_request_mode. So enabling targeting alone can never send anything."""
+    if mode != "auto_queue":
+        return ConnectionRequestStatus.PENDING
+    return (ConnectionRequestStatus.APPROVED
+            if prefs.get("connection_request_mode") == "auto_approve"
+            else ConnectionRequestStatus.PENDING)
+
+
+@shared_task.task(bind=True, base=QueueOnce,
+                  once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  reject_on_worker_lost=True, rate_limit='1/m', queue='se_outreach')
+def scan_connection_candidates(self, user_id: int, max_new: int = None):
+    """Source ICP-fit connection targets from people who engage with content (issue #486).
+
+    Candidates come from the engagers on the user's OWN posts (read from post_engagers — no
+    scraping) plus the commenters on the recent posts of the adjacent authors they configured
+    (scraped). They're ICP-scored against the user's focus topics, deduped against every
+    connection_requests row they've ever had, and filed as #398 requests with a personalized note —
+    so the existing approval gate, combined daily invite cap and 429 / kill-switch backoff all still
+    apply. Nothing is sent from here."""
+    prefs = get_engagement_preferences(user_id)
+    mode = str(prefs.get("connection_targeting_mode") or "suggest")
+    if mode == "off":
+        return f"Connection targeting off for user {user_id}"
+
+    budget = _connect_target_budget(user_id, prefs, max_new)
+    if budget <= 0:
+        return f"No invite budget left for user {user_id}"
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    signals = [CandidateSignal(person_name=row.get("person_name"),
+                               person_profile_url=row.get("person_profile_url"),
+                               source=SOURCE_OWN_POST, occurred_at=row.get("occurred_at"))
+               for row in get_engager_candidates(user_id, days=_CONNECT_ENGAGER_LOOKBACK_DAYS)]
+
+    authors = [str(a).strip() for a in (prefs.get("connection_target_authors") or []) if str(a or "").strip()]
+    if authors:
+        driver = None
+        try:
+            driver, _wait, _user_email, my_profile = get_current_profile(
+                user_id=user_id, session_name="Connection Targeting")
+            signals.extend(_adjacent_author_signals(driver, user_id, authors,
+                                                    my_profile.full_name, now))
+        except Exception as e:
+            # Own-post engagers still stand on their own — degrade, don't abort the whole scan.
+            log_warning("Adjacent-author sourcing failed; using own-post engagers only", exc=e,
+                        user_id=user_id, task_name="scan_connection_candidates")
+        finally:
+            if driver is not None:
+                quit_gracefully(driver)
+
+    if not signals:
+        return f"No connection candidates found for user {user_id}"
+
+    terms = target_terms_from_prefs(prefs)
+    urls = sorted({s.person_profile_url for s in signals if s.person_profile_url})
+    candidates = rank_candidates(signals, now, facts_by_url=get_profile_facts(urls),
+                                 target_terms=terms,
+                                 min_icp=int(prefs.get("min_connection_icp_score") or 0),
+                                 exclude_keys=get_requested_person_keys(user_id),
+                                 limit=budget)
+    if not candidates:
+        return f"No new connection candidates for user {user_id} (all deduped or below ICP floor)"
+
+    status = _target_status_for_mode(mode, prefs)
+    topic = terms[0] if terms else None
+    filed = 0
+    for candidate in candidates:
+        note = _draft_connect_note(user_id, candidate, topic=topic)
+        request_id = insert_connection_request(
+            user_id, candidate.person_profile_url, message=note,
+            recipient_name=candidate.person_name, status=status,
+            source=candidate.source, icp_score=candidate.icp_score, reasons=candidate.reasons)
+        if not request_id:
+            continue
+        filed += 1
+        log_info(f"Connection target filed ({candidate.source}, score {candidate.score})",
+                 user_id=user_id, task_name="scan_connection_candidates",
+                 action_type="connection_targeting")
+    return f"Filed {filed} connection target(s) as '{status}' for user {user_id}"
 
 
 # --- Comment-first outreach funnel (issue #399) — approval-gated comment->connect->DM ---

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -3856,7 +3856,17 @@ def send_connection_request(self, request_id: int):
 # --- Smart connection targeting (issue #486) — source warm engagers into #398's send path ---
 # Hard per-scan ceiling, independent of the user's daily invite cap: sourcing should trickle in a
 # handful of high-fit people a day, never file a queue that looks like list-blasting.
-_MAX_NEW_CONNECT_TARGETS_PER_SCAN = int(os.getenv("MAX_NEW_CONNECT_TARGETS_PER_SCAN", "5"))
+def _connect_env_int(name: str, default: int) -> int:
+    """A typo'd env var must not take the worker down at import time — fail safe to the default."""
+    try:
+        return int(os.getenv(name) or default)
+    except ValueError:
+        log_warning(f"Invalid {name} env value; falling back to {default}",
+                    action_type="connection_targeting")
+        return default
+
+
+_MAX_NEW_CONNECT_TARGETS_PER_SCAN = _connect_env_int("MAX_NEW_CONNECT_TARGETS_PER_SCAN", 5)
 _MAX_ADJACENT_AUTHORS_PER_SCAN = 3
 _MAX_ADJACENT_POSTS_PER_AUTHOR = 2
 _MAX_ENGAGERS_PER_ADJACENT_POST = 15

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -751,6 +751,21 @@ def auto_process_outreach_funnel():
     return f"Dispatched outreach funnel for {len(user_ids)} user(s)"
 
 
+@shared_task.task
+def auto_scan_connection_candidates():
+    """Dispatch per-user sourcing of ICP-fit connection targets from content engagers (issue #486).
+    Sourcing may scrape adjacent authors' posts, so it IS gated on the 429 breaker / manual pause.
+    The scan only FILES targets into the #398 connection_requests queue — the approval gate and the
+    combined daily invite cap still decide what actually gets sent."""
+    if _skip_if_throttled("auto_scan_connection_candidates"):
+        return "Automation throttled"
+    from cqc_lem.app.run_automation import scan_connection_candidates
+    user_ids = get_active_user_ids()
+    for uid in user_ids:
+        scan_connection_candidates.apply_async(kwargs={"user_id": uid})
+    return f"Dispatched connection targeting for {len(user_ids)} user(s)"
+
+
 # Lead scoring & CRM-lite pipeline (issue #484). Nothing here touches LinkedIn — it re-reads
 # engagement we already stored — so it is deliberately NOT gated on the 429 breaker / pause: a
 # rate-limited account still deserves an accurate hot-leads list.

--- a/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
@@ -225,6 +225,32 @@ export default function EngagementSettingsCard() {
             <p className="text-xs text-gray-400 mt-1">Pre-review holds new connection targets in the Connections tab for your approval before LEM sends them.</p>
           </div>
           <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Connection targeting</label>
+            <select value={engPrefs.connection_targeting_mode ?? 'suggest'}
+              onChange={(e) => setEng({ connection_targeting_mode: e.target.value })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm">
+              <option value="off">Off (no targets sourced)</option>
+              <option value="suggest">Suggest (drafts for your approval)</option>
+              <option value="auto_queue">Auto-queue (use the approval setting above)</option>
+            </select>
+            <p className="text-xs text-gray-400 mt-1">Finds ICP-fit people who engage with your content (and with the adjacent authors below) and drafts a personalized connect note. Suggest never sends without your approval.</p>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Min. ICP fit score</label>
+            <input type="number" min={0} max={100} value={engPrefs.min_connection_icp_score ?? 55}
+              onChange={(e) => setEng({ min_connection_icp_score: Number(e.target.value) })}
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+            <p className="text-xs text-gray-400 mt-1">0-100 fit of their title/company/industry against your focus topics. Only applied to people whose profile LEM has scraped.</p>
+          </div>
+          <div className="sm:col-span-3">
+            <label className="block text-sm font-medium text-gray-700 mb-1">Adjacent authors to source engagers from</label>
+            <input type="text" value={csv(engPrefs.connection_target_authors)}
+              onChange={(e) => setEng({ connection_target_authors: parseCsv(e.target.value) })}
+              placeholder="https://www.linkedin.com/in/their-slug, https://www.linkedin.com/in/another"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+            <p className="text-xs text-gray-400 mt-1">Profile URLs of thought leaders or competitors in your space. LEM harvests the people commenting on their recent posts as warm 2nd-degree candidates. Leave blank to only target people who engage with your own posts.</p>
+          </div>
+          <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">Auto-generated video quality</label>
             <select value={engPrefs.default_video_quality ?? 'standard'}
               onChange={(e) => setEng({ default_video_quality: e.target.value })}

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -20,6 +20,9 @@ export type EngPrefs = {
   max_dms_per_day: number
   max_invites_per_day: number
   connection_request_mode: string
+  connection_targeting_mode: string
+  connection_target_authors: string[]
+  min_connection_icp_score: number
   default_video_quality: string
   reply_check_mode: string
   reply_sweeps_per_day: number

--- a/src/cqc_lem/ui/src/pages/review/ConnectionRequests.tsx
+++ b/src/cqc_lem/ui/src/pages/review/ConnectionRequests.tsx
@@ -17,6 +17,15 @@ interface ConnectionRequest {
   message: string | null
   status: string
   created_at: string
+  // Targeting provenance (issue #486) — null for hand-added targets.
+  source: string | null
+  icp_score: number | null
+  reasons: string | null
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  own_post: 'Engaged with your content',
+  adjacent_post: 'Engaged with an adjacent author',
 }
 
 const STATUS_COLORS: Record<string, string> = {
@@ -150,6 +159,19 @@ export default function ConnectionRequests({ userTimezone }: { userTimezone: str
                 </span>
               </div>
             </div>
+            {(req.source || req.reasons) && (
+              <div className="flex flex-wrap items-center gap-2 mb-1">
+                {req.source && (
+                  <span className="px-2 py-0.5 rounded-full bg-indigo-50 text-indigo-700 text-xs font-medium">
+                    {SOURCE_LABELS[req.source] ?? req.source}
+                  </span>
+                )}
+                {req.icp_score != null && (
+                  <span className="text-xs text-gray-500">ICP fit {req.icp_score}/100</span>
+                )}
+                {req.reasons && <span className="text-xs text-gray-500 truncate">· {req.reasons}</span>}
+              </div>
+            )}
             {req.message && <p className="text-sm text-gray-700 whitespace-pre-wrap line-clamp-3">{req.message}</p>}
             {['pending', 'approved', 'sending'].includes(req.status) && (
               <div className="flex gap-2 mt-2">

--- a/src/cqc_lem/utilities/connection_targeting.py
+++ b/src/cqc_lem/utilities/connection_targeting.py
@@ -209,7 +209,7 @@ def rank_candidates(signals: Iterable[CandidateSignal], now: datetime, facts_by_
             continue
         out.append(candidate)
     out.sort(key=lambda c: (c.score, c.warmth_score, c.signal_count), reverse=True)
-    return out[:limit] if limit else out
+    return out if limit is None else out[:max(0, int(limit))]
 
 
 def first_name(name: str = None) -> str:

--- a/src/cqc_lem/utilities/connection_targeting.py
+++ b/src/cqc_lem/utilities/connection_targeting.py
@@ -1,0 +1,236 @@
+"""Smart connection targeting from content engagers (issue #486, extends #398).
+
+Pure ranking logic — no DB, no Selenium, no LLM — so WHO we ask to connect with is deterministic and
+cheap to test. The sourcing task (`run_automation.scan_connection_candidates`) supplies the raw
+signals it read/scraped and files what comes back as #398 connection requests.
+
+The premise: someone who just commented on our post (or on an adjacent thought-leader's post about
+our topic) is a warm, on-topic 2nd-degree prospect. ICP fit decides whether they're worth a request
+at all; warmth (how recently/often they engaged, and whose content they engaged with) decides the
+order we work through them.
+"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable, Optional
+
+from cqc_lem.utilities.lead_scoring import ICP_UNKNOWN, icp_fit, person_key, profile_slug, \
+    recency_weight
+
+# How they showed up on our radar. Engaging with OUR content is a stronger statement of interest in
+# US than engaging with someone else's post about the same topic.
+SOURCE_OWN_POST = "own_post"
+SOURCE_ADJACENT_POST = "adjacent_post"
+SOURCE_WEIGHTS: dict = {SOURCE_OWN_POST: 1.0, SOURCE_ADJACENT_POST: 0.65}
+
+# Points one engagement is worth before recency/source weighting. Warmth saturates at 100, so a
+# single fresh engagement on our own post already lands mid-range and repeats push it up.
+SIGNAL_POINTS = 45
+
+# Blend. Fit is the gate (see rank_candidates' floor), warmth is the ranking — but fit still carries
+# the larger share so a high-volume engager with no fit can't outrank a real prospect.
+ICP_WEIGHT = 0.6
+WARMTH_WEIGHT = 0.4
+
+# Default ICP floor for people we have facts on. Mirrors the DB default (min_connection_icp_score).
+MIN_ICP_DEFAULT = 55
+
+# LinkedIn caps a connection-request note at 300 characters.
+CONNECT_NOTE_LIMIT = 300
+
+
+@dataclass
+class CandidateSignal:
+    """One observed engagement by one person, from one source."""
+    person_name: Optional[str] = None
+    person_profile_url: Optional[str] = None
+    source: str = SOURCE_OWN_POST
+    context_url: str = ""       # the post they engaged with
+    context_author: str = ""    # whose post it was ('' for our own)
+    occurred_at: Optional[datetime] = None
+
+
+@dataclass
+class ScoredCandidate:
+    """A ranked connection target plus the provenance stored on the request row."""
+    person_key: str
+    person_name: Optional[str] = None
+    person_profile_url: Optional[str] = None
+    source: str = SOURCE_OWN_POST
+    score: int = 0
+    icp_score: int = ICP_UNKNOWN
+    warmth_score: int = 0
+    signal_count: int = 0
+    known_fit: bool = False     # True when we had profile facts to score fit against
+    context_url: str = ""
+    context_author: str = ""
+    reasons: str = ""
+    last_seen_at: Optional[datetime] = None
+    signals: list = field(default_factory=list)
+
+
+def target_terms_from_prefs(prefs: dict) -> list:
+    """What "good fit" means for this user, straight from their engagement preferences."""
+    terms: list = []
+    for key in ("focus_topics", "include_topics", "include_keywords"):
+        terms.extend((prefs or {}).get(key) or [])
+    return [str(t).strip() for t in terms if str(t or "").strip()]
+
+
+def warmth_strength(signals: Iterable[CandidateSignal], now: datetime) -> int:
+    """0-100 from recency, frequency and source. Repeats add with diminishing returns (1, 1/2, 1/3 …)
+    so ten drive-by reactions never outrank someone who keeps showing up on our own posts."""
+    items = sorted((signals or []),
+                   key=lambda s: (s.occurred_at is not None, s.occurred_at), reverse=True)
+    total = 0.0
+    for i, s in enumerate(items):
+        weight = SOURCE_WEIGHTS.get(s.source, SOURCE_WEIGHTS[SOURCE_ADJACENT_POST])
+        total += SIGNAL_POINTS * weight * recency_weight(s.occurred_at, now) / (i + 1)
+    return max(0, min(100, round(total)))
+
+
+def _primary_source(signals: Iterable[CandidateSignal]) -> str:
+    """Own-post engagement is the headline whenever it happened — it's the stronger signal."""
+    return (SOURCE_OWN_POST if any(s.source == SOURCE_OWN_POST for s in signals or [])
+            else SOURCE_ADJACENT_POST)
+
+
+def _describe(candidate_signals: list, icp: int, known_fit: bool, now: datetime) -> str:
+    """Plain-language WHY, for the operator approving the request."""
+    own = sum(1 for s in candidate_signals if s.source == SOURCE_OWN_POST)
+    adjacent = [s for s in candidate_signals if s.source == SOURCE_ADJACENT_POST]
+    parts: list = []
+    if own:
+        parts.append(f"engaged with your content ({own}×)" if own > 1 else "engaged with your content")
+    if adjacent:
+        authors = sorted({s.context_author for s in adjacent if s.context_author})
+        who = f" ({', '.join(authors[:2])})" if authors else ""
+        parts.append(f"engaged with adjacent authors' posts{who}")
+
+    stamps = [s.occurred_at for s in candidate_signals if s.occurred_at]
+    if stamps:
+        days = max(0, int((now - _align(max(stamps), now)).total_seconds() // 86400))
+        parts.append("engaged today" if days == 0 else f"last engaged {days}d ago")
+
+    if not known_fit:
+        parts.append("ICP fit unknown (profile not scraped)")
+    elif icp >= 70:
+        parts.append("strong ICP fit")
+    elif icp < 40:
+        parts.append("weak ICP fit")
+    return " · ".join(parts)[:512]
+
+
+def _align(occurred_at: datetime, now: datetime) -> datetime:
+    """Match tz-awareness so subtraction can't raise — MySQL hands back naive-UTC datetimes."""
+    if (occurred_at.tzinfo is None) != (now.tzinfo is None):
+        return occurred_at.replace(tzinfo=now.tzinfo)
+    return occurred_at
+
+
+def group_signals(signals: Iterable[CandidateSignal]) -> dict:
+    """Collapse raw signals into {person_key: [signals]}, so the same human found on our post and on
+    an adjacent author's post becomes ONE candidate. Keyed by lead_scoring.person_key, so a
+    name-only sighting stays separate from a URL one (display names collide — merging them would
+    silently blend two people)."""
+    people: dict = {}
+    for s in signals or []:
+        key = person_key(s.person_name, s.person_profile_url)
+        if not key:
+            continue
+        people.setdefault(key, []).append(s)
+    return people
+
+
+def score_candidate(signals: list, now: datetime, facts: dict = None,
+                    target_terms: Iterable[str] = None) -> ScoredCandidate:
+    """Score ONE person from every signal we have about them."""
+    facts = facts or {}
+    known_fit = any(str(facts.get(k) or "").strip() for k in ("job_title", "company_name", "industry"))
+    icp = icp_fit(facts, target_terms or [])
+    warmth = warmth_strength(signals, now)
+    primary = _primary_source(signals)
+    # The headline context is the most recent engagement on the strongest source — that's the post
+    # the connect note should reference.
+    ranked = sorted([s for s in signals if s.source == primary] or list(signals),
+                    key=lambda s: (s.occurred_at is not None, s.occurred_at), reverse=True)
+    lead_signal = ranked[0]
+    stamps = [s.occurred_at for s in signals if s.occurred_at]
+    name = next((s.person_name for s in signals if s.person_name), None)
+    url = next((s.person_profile_url for s in signals if s.person_profile_url), None)
+    return ScoredCandidate(
+        person_key=person_key(name, url),
+        person_name=name,
+        person_profile_url=url,
+        source=primary,
+        score=max(0, min(100, round(ICP_WEIGHT * icp + WARMTH_WEIGHT * warmth))),
+        icp_score=icp,
+        warmth_score=warmth,
+        signal_count=len(signals),
+        known_fit=known_fit,
+        context_url=lead_signal.context_url or "",
+        context_author=lead_signal.context_author or "",
+        reasons=_describe(list(signals), icp, known_fit, now),
+        last_seen_at=max(stamps) if stamps else None,
+        signals=list(signals),
+    )
+
+
+def rank_candidates(signals: Iterable[CandidateSignal], now: datetime, facts_by_url: dict = None,
+                    target_terms: Iterable[str] = None, min_icp: int = MIN_ICP_DEFAULT,
+                    exclude_keys: Iterable[str] = None, require_profile_url: bool = True,
+                    limit: int = None) -> list:
+    """Rank connection candidates, best first.
+
+    `exclude_keys` are person_keys we already asked (any connection_requests row, any status) — the
+    dedup that keeps a nightly re-scan from re-inviting the same person.
+
+    The `min_icp` floor applies ONLY to people we have profile facts for. Most engagers have never
+    been scraped, so they score ICP_UNKNOWN; rejecting them would reject nearly everyone and throw
+    away the warm-engager signal this whole feature exists to use. They're kept, ranked on warmth,
+    and their `reasons` says the fit is unverified so the approver can see it.
+
+    `require_profile_url` drops name-only sightings: without a /in/ URL there is nobody to invite.
+    """
+    facts_by_slug = {profile_slug(k): v for k, v in (facts_by_url or {}).items() if profile_slug(k)}
+    excluded = {str(k) for k in (exclude_keys or []) if k}
+    out: list = []
+    for key, person_signals in group_signals(signals).items():
+        if key in excluded:
+            continue
+        candidate = score_candidate(person_signals, now,
+                                    facts=facts_by_slug.get(profile_slug(
+                                        next((s.person_profile_url for s in person_signals
+                                              if s.person_profile_url), "")), {}),
+                                    target_terms=target_terms)
+        if require_profile_url and not candidate.person_profile_url:
+            continue
+        if candidate.known_fit and candidate.icp_score < int(min_icp or 0):
+            continue
+        out.append(candidate)
+    out.sort(key=lambda c: (c.score, c.warmth_score, c.signal_count), reverse=True)
+    return out[:limit] if limit else out
+
+
+def first_name(name: str = None) -> str:
+    cleaned = " ".join(str(name or "").split()).strip()
+    return cleaned.split(" ")[0] if cleaned else "there"
+
+
+def default_connect_note(candidate: ScoredCandidate, topic: str = None) -> str:
+    """The pre-AI connect note. Grounded in the actual reason we found them — a note that names the
+    shared context reads like a human wrote it, which is the whole point of warm targeting.
+    Kept under LinkedIn's 300-char note limit even before refinement."""
+    name = first_name(candidate.person_name)
+    about = f" about {topic}" if topic else ""
+    if candidate.source == SOURCE_ADJACENT_POST and candidate.context_author:
+        note = (f"Hi {name}, I saw your take on {candidate.context_author}'s post{about} — we're "
+                f"clearly following the same conversation. Would love to connect and keep "
+                f"trading notes.")
+    elif candidate.source == SOURCE_ADJACENT_POST:
+        note = (f"Hi {name}, we keep showing up in the same conversations{about} — would love to "
+                f"connect and keep trading notes.")
+    else:
+        note = (f"Hi {name}, thanks for engaging with my posts{about} — really appreciate it. "
+                f"Would love to connect so we can keep the conversation going.")
+    return note[:CONNECT_NOTE_LIMIT]

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2698,6 +2698,10 @@ _ENGAGEMENT_DEFAULTS: dict = {
     "min_reactions": None, "max_post_age_hours": 24, "reply_to_own_comments": True,
     "max_comments_per_day": 20, "max_dms_per_day": 20, "max_invites_per_day": 10,
     "connection_request_mode": "auto_approve",
+    # Smart connection targeting (issue #486). 'suggest' sources candidates but always files them as
+    # drafts, so enabling targeting can never send outbound on its own.
+    "connection_targeting_mode": "suggest", "connection_target_authors": [],
+    "min_connection_icp_score": 55,
     "default_buyer_stage": None,
     "default_video_quality": "standard",
     "reply_check_mode": "event", "reply_sweeps_per_day": 2, "reply_max_post_age_days": 2,
@@ -2705,7 +2709,7 @@ _ENGAGEMENT_DEFAULTS: dict = {
 }
 _ENGAGEMENT_JSON_FIELDS = ("include_topics", "exclude_topics", "include_keywords",
                            "exclude_keywords", "include_authors", "exclude_authors", "post_types",
-                           "focus_topics")
+                           "focus_topics", "connection_target_authors")
 _ENGAGEMENT_BOOL_FIELDS = ("use_emojis", "use_hashtags", "reply_to_own_comments",
                            "feed_fallback_when_empty", "link_in_first_comment")
 _ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "use_hashtags",
@@ -2714,6 +2718,8 @@ _ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "us
                     "business_goals", "personal_goals", "min_reactions",
                     "max_post_age_hours", "reply_to_own_comments", "max_comments_per_day",
                     "max_dms_per_day", "max_invites_per_day", "connection_request_mode",
+                    "connection_targeting_mode", "connection_target_authors",
+                    "min_connection_icp_score",
                     "default_buyer_stage", "default_video_quality",
                     "reply_check_mode", "reply_sweeps_per_day", "reply_max_post_age_days",
                     "feed_fallback_when_empty", "link_in_first_comment")
@@ -2722,6 +2728,10 @@ VALID_VIDEO_QUALITIES = ("standard", "premium", "premium_top")
 VALID_REPLY_MODES = ("event", "scheduled", "off")
 # Approval posture for the proactive connect flow (issue #398 owner review).
 VALID_CONNECTION_REQUEST_MODES = ("auto_approve", "pre_review")
+# Sourcing posture for smart connection targeting (issue #486): 'off' = no sourcing, 'suggest' =
+# source but always file as drafts, 'auto_queue' = defer to connection_request_mode.
+VALID_CONNECTION_TARGETING_MODES = ("off", "suggest", "auto_queue")
+ICP_SCORE_MIN, ICP_SCORE_MAX = 0, 100
 # Scheduled reply-sweep cadence bounds: floor 2×/day (as requested), cap 12×/day (every ~2h).
 REPLY_SWEEPS_MIN, REPLY_SWEEPS_MAX = 2, 12
 REPLY_MAX_AGE_DAYS_MIN, REPLY_MAX_AGE_DAYS_MAX = 1, 14
@@ -2775,6 +2785,14 @@ def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
         merged["reply_check_mode"] = "event"
     if merged.get("connection_request_mode") not in VALID_CONNECTION_REQUEST_MODES:
         merged["connection_request_mode"] = "auto_approve"
+    if merged.get("connection_targeting_mode") not in VALID_CONNECTION_TARGETING_MODES:
+        merged["connection_targeting_mode"] = "suggest"
+    _icp = merged.get("min_connection_icp_score")
+    try:
+        merged["min_connection_icp_score"] = (min(ICP_SCORE_MAX, max(ICP_SCORE_MIN, int(_icp)))
+                                              if _icp is not None else 55)
+    except (TypeError, ValueError):
+        merged["min_connection_icp_score"] = 55
     # Clamp numerics WITHOUT `or` fallbacks — 0 is falsy but is a real (out-of-range) value that must
     # clamp to the floor, not silently become the default (matches the API-layer validators).
     _sw = merged.get("reply_sweeps_per_day")
@@ -3154,21 +3172,25 @@ def count_invites_sent_today(user_id: int) -> int:
 
 
 # --- Proactive connection requests (issue #398) — approval-gated, daily-capped; reuses invite_to_connect ---
+# source/icp_score/reasons carry issue #486's targeting provenance (which engagement surfaced this
+# person, how well they fit) so the operator approving a request can see why it exists.
 _CONN_REQ_COLS = ("id", "user_id", "recipient_profile_url", "recipient_name", "message",
-                  "status", "created_at", "updated_at")
+                  "source", "icp_score", "reasons", "status", "created_at", "updated_at")
 
 
 def insert_connection_request(user_id: int, recipient_profile_url: str, message: str = None,
                               recipient_name: str = None,
-                              status: "ConnectionRequestStatus" = ConnectionRequestStatus.PENDING
+                              status: "ConnectionRequestStatus" = ConnectionRequestStatus.PENDING,
+                              source: str = None, icp_score: int = None, reasons: str = None
                               ) -> Optional[int]:
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         cursor.execute(
             "INSERT INTO connection_requests (user_id, recipient_profile_url, recipient_name, "
-            "message, status) VALUES (%s,%s,%s,%s,%s)",
-            (user_id, recipient_profile_url, recipient_name, message, str(status)))
+            "message, status, source, icp_score, reasons) VALUES (%s,%s,%s,%s,%s,%s,%s,%s)",
+            (user_id, recipient_profile_url, recipient_name, message, str(status),
+             source, icp_score, (reasons or None)))
         connection.commit()
         return cursor.lastrowid
     except mysql.connector.Error as err:
@@ -3311,6 +3333,75 @@ def update_connection_request(request_id: int, recipient_profile_url: str = None
     except mysql.connector.Error as err:
         myprint(f"Could not update connection request {request_id} | Error: {err}")
         return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+# --- Smart connection targeting (issue #486) — sourcing + dedup for the #398 send path ---
+
+def count_open_connection_requests(user_id: int) -> int:
+    """Targets already queued but not yet sent (pending / approved / sending). The sourcing scan
+    subtracts these from the daily invite budget so it can't pile up a backlog that would spend
+    tomorrow's cap the moment it opens."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM connection_requests WHERE user_id=%s "
+            "AND status IN ('pending','approved','sending')", (user_id,))
+        r = cursor.fetchone()
+        return int(r[0]) if r else 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not count open connection requests for user {user_id} | Error: {err}")
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_requested_person_keys(user_id: int) -> set:
+    """person_key()s for everyone this user has EVER had a connection request row for, any status.
+    The dedup set for the nightly sourcing scan: a canceled/failed target must not come back every
+    night, and someone already invited must never be invited twice."""
+    from cqc_lem.utilities.lead_scoring import person_key
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT recipient_name, recipient_profile_url FROM connection_requests WHERE user_id=%s",
+            (user_id,))
+        keys = set()
+        for name, url in cursor.fetchall():
+            key = person_key(name, url)
+            if key:
+                keys.add(key)
+        return keys
+    except mysql.connector.Error as err:
+        myprint(f"Could not read requested person keys for user {user_id} | Error: {err}")
+        return set()
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_engager_candidates(user_id: int, days: int = 30) -> list:
+    """People who recently engaged with the user's OWN posts, as connection-targeting candidates:
+    [{'person_name', 'person_profile_url', 'occurred_at'}]. Only rows with a profile URL — without
+    one there is nobody to invite. Read from post_engagers, so this costs no scraping."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT engager_name AS person_name, engager_profile_url AS person_profile_url, "
+            "last_engaged_at AS occurred_at FROM post_engagers "
+            "WHERE user_id=%s AND engager_profile_url IS NOT NULL "
+            "AND last_engaged_at >= (NOW() - INTERVAL %s DAY) ORDER BY last_engaged_at DESC",
+            (user_id, days))
+        return cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not read engager candidates for user {user_id} | Error: {err}")
+        return []
     finally:
         cursor.close()
         connection.close()

--- a/tests/unit/api/test_engagement_prefs_api.py
+++ b/tests/unit/api/test_engagement_prefs_api.py
@@ -246,3 +246,42 @@ class TestGmailForwardConfirmationInPrefs:
             resp = client.get(f"/api/user/engagement-preferences?session_token={_SESSION}")
         assert resp.status_code == 200
         assert resp.json()["detail"]["gmail_forward_confirmation"] == conf
+
+
+class TestConnectionTargetingPrefs:
+    """Smart connection targeting configuration (issue #486)."""
+
+    def test_targeting_fields_passthrough(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences",
+                              json={"session_token": _SESSION,
+                                    "connection_targeting_mode": "auto_queue",
+                                    "connection_target_authors": ["https://x/in/guru"],
+                                    "min_connection_icp_score": 70})
+        assert resp.status_code == 200
+        prefs_arg = upd.call_args[0][1]
+        assert prefs_arg["connection_targeting_mode"] == "auto_queue"
+        assert prefs_arg["connection_target_authors"] == ["https://x/in/guru"]
+        assert prefs_arg["min_connection_icp_score"] == 70
+
+    def test_defaults_to_suggest_when_omitted(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences",
+                              json={"session_token": _SESSION})
+        assert resp.status_code == 200
+        # Default posture never sends on its own: candidates are filed as drafts.
+        assert upd.call_args[0][1]["connection_targeting_mode"] == "suggest"
+        assert upd.call_args[0][1]["min_connection_icp_score"] == 55
+
+    def test_bad_mode_coerced_and_icp_clamped(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.update_engagement_preferences", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-preferences",
+                              json={"session_token": _SESSION,
+                                    "connection_targeting_mode": "blast_everyone",
+                                    "min_connection_icp_score": 500})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1]["connection_targeting_mode"] == "suggest"
+        assert upd.call_args[0][1]["min_connection_icp_score"] == 100

--- a/tests/unit/app/test_connection_targeting_scan.py
+++ b/tests/unit/app/test_connection_targeting_scan.py
@@ -1,0 +1,278 @@
+"""Unit tests for the connection-candidate sourcing scan (issue #486)."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+_RS = "cqc_lem.app.run_scheduler"
+
+_ENGAGERS = [{"person_name": "Jane Doe",
+              "person_profile_url": "https://www.linkedin.com/in/jane-doe",
+              "occurred_at": datetime(2026, 7, 25, 9, 0, 0)}]
+
+
+def _prefs(**over):
+    prefs = {"connection_targeting_mode": "suggest", "connection_request_mode": "auto_approve",
+             "max_invites_per_day": 10, "min_connection_icp_score": 55,
+             "connection_target_authors": [], "focus_topics": ["revenue operations"]}
+    prefs.update(over)
+    return prefs
+
+
+def _scan(prefs=None, engagers=None, requested=None, open_reqs=0, sent_today=0, facts=None,
+          insert_id=7, max_new=None, adjacent=None):
+    """Run the scan with every I/O boundary mocked; returns (result, insert_mock)."""
+    from cqc_lem.app import run_automation as ra
+    patches = {
+        "get_engagement_preferences": prefs if prefs is not None else _prefs(),
+        "count_invites_sent_today": sent_today,
+        "count_open_connection_requests": open_reqs,
+        "get_engager_candidates": _ENGAGERS if engagers is None else engagers,
+        "get_requested_person_keys": requested or set(),
+        "get_profile_facts": facts or {},
+    }
+    with patch.multiple(_RA, **{k: MagicMock(return_value=v) for k, v in patches.items()}), \
+         patch(f"{_RA}.get_ai_message_refinement", return_value="Refined note"), \
+         patch(f"{_RA}.insert_connection_request", return_value=insert_id) as insert, \
+         patch(f"{_RA}._adjacent_author_signals", return_value=adjacent or []), \
+         patch(f"{_RA}.get_current_profile") as profile, \
+         patch(f"{_RA}.quit_gracefully"):
+        profile.return_value = (MagicMock(), MagicMock(), "me@x.com",
+                               MagicMock(full_name="Me Myself"))
+        return ra.scan_connection_candidates.run(user_id=1, max_new=max_new), insert
+
+
+class TestScanGating:
+    def test_mode_off_does_nothing(self):
+        out, insert = _scan(prefs=_prefs(connection_targeting_mode="off"))
+        insert.assert_not_called()
+        assert "off" in out
+
+    def test_no_budget_left_does_nothing(self):
+        out, insert = _scan(sent_today=10)
+        insert.assert_not_called()
+        assert "budget" in out
+
+    def test_open_targets_consume_the_budget(self):
+        # 10 cap - 2 sent - 8 already queued = 0 left: never build a backlog.
+        out, insert = _scan(sent_today=2, open_reqs=8)
+        insert.assert_not_called()
+        assert "budget" in out
+
+    def test_no_candidates_found(self):
+        out, insert = _scan(engagers=[])
+        insert.assert_not_called()
+        assert "No connection candidates" in out
+
+    def test_all_candidates_already_requested(self):
+        out, insert = _scan(requested={"in:jane-doe"})
+        insert.assert_not_called()
+        assert "deduped" in out
+
+
+class TestScanFiling:
+    def test_files_a_pending_draft_in_suggest_mode(self):
+        from cqc_lem.utilities.db import ConnectionRequestStatus
+        out, insert = _scan()
+        assert insert.call_count == 1
+        kwargs = insert.call_args.kwargs
+        assert insert.call_args.args == (1, "https://www.linkedin.com/in/jane-doe")
+        assert kwargs["status"] == ConnectionRequestStatus.PENDING
+        assert kwargs["recipient_name"] == "Jane Doe"
+        assert kwargs["source"] == "own_post"
+        assert kwargs["message"] == "Refined note"
+        assert "engaged with your content" in kwargs["reasons"]
+        assert "Filed 1" in out
+
+    def test_auto_queue_mode_follows_connection_request_mode(self):
+        from cqc_lem.utilities.db import ConnectionRequestStatus
+        _out, insert = _scan(prefs=_prefs(connection_targeting_mode="auto_queue"))
+        assert insert.call_args.kwargs["status"] == ConnectionRequestStatus.APPROVED
+
+    def test_auto_queue_with_pre_review_still_needs_approval(self):
+        from cqc_lem.utilities.db import ConnectionRequestStatus
+        _out, insert = _scan(prefs=_prefs(connection_targeting_mode="auto_queue",
+                                          connection_request_mode="pre_review"))
+        assert insert.call_args.kwargs["status"] == ConnectionRequestStatus.PENDING
+
+    def test_budget_caps_how_many_targets_are_filed(self):
+        engagers = [{"person_name": f"P{i}",
+                     "person_profile_url": f"https://www.linkedin.com/in/p{i}",
+                     "occurred_at": datetime(2026, 7, 25, 9, 0, 0)} for i in range(8)]
+        _out, insert = _scan(engagers=engagers, sent_today=8)  # 10 cap - 8 sent = 2
+        assert insert.call_count == 2
+
+    def test_explicit_max_new_overrides_the_per_scan_ceiling(self):
+        engagers = [{"person_name": f"P{i}",
+                     "person_profile_url": f"https://www.linkedin.com/in/p{i}",
+                     "occurred_at": datetime(2026, 7, 25, 9, 0, 0)} for i in range(8)]
+        _out, insert = _scan(engagers=engagers, max_new=1)
+        assert insert.call_count == 1
+
+    def test_failed_insert_is_not_counted(self):
+        out, insert = _scan(insert_id=None)
+        assert insert.call_count == 1 and "Filed 0" in out
+
+    def test_below_icp_floor_is_skipped(self):
+        facts = {"https://www.linkedin.com/in/jane-doe": {"job_title": "intern",
+                                                         "industry": "retail"}}
+        out, insert = _scan(facts=facts, prefs=_prefs(min_connection_icp_score=90))
+        insert.assert_not_called()
+        assert "ICP floor" in out
+
+    def test_adjacent_signals_are_included(self):
+        from cqc_lem.utilities.connection_targeting import CandidateSignal, SOURCE_ADJACENT_POST
+        adjacent = [CandidateSignal(person_name="Guru Fan",
+                                    person_profile_url="https://www.linkedin.com/in/guru-fan",
+                                    source=SOURCE_ADJACENT_POST, context_author="Guru Gary",
+                                    context_url="https://x/feed/update/1",
+                                    occurred_at=datetime(2026, 7, 25, 8, 0, 0))]
+        _out, insert = _scan(prefs=_prefs(connection_target_authors=["https://x/in/guru-gary"]),
+                             engagers=[], adjacent=adjacent)
+        assert insert.call_args.kwargs["source"] == "adjacent_post"
+        assert "adjacent authors" in insert.call_args.kwargs["reasons"]
+
+    def test_adjacent_sourcing_failure_still_files_own_post_engagers(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.get_engagement_preferences",
+                   return_value=_prefs(connection_target_authors=["https://x/in/guru"])), \
+             patch(f"{_RA}.count_invites_sent_today", return_value=0), \
+             patch(f"{_RA}.count_open_connection_requests", return_value=0), \
+             patch(f"{_RA}.get_engager_candidates", return_value=_ENGAGERS), \
+             patch(f"{_RA}.get_requested_person_keys", return_value=set()), \
+             patch(f"{_RA}.get_profile_facts", return_value={}), \
+             patch(f"{_RA}.get_ai_message_refinement", return_value="Refined note"), \
+             patch(f"{_RA}.get_current_profile", side_effect=RuntimeError("no session")), \
+             patch(f"{_RA}.insert_connection_request", return_value=7) as insert:
+            out = ra.scan_connection_candidates.run(user_id=1)
+        assert insert.call_count == 1 and "Filed 1" in out
+
+
+class TestConnectNoteDrafting:
+    def test_falls_back_to_the_template_when_the_llm_fails(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.connection_targeting import CandidateSignal, score_candidate
+        candidate = score_candidate([CandidateSignal(person_name="Jane Doe",
+                                                     person_profile_url="https://x/in/jane-doe")],
+                                    datetime(2026, 7, 25))
+        with patch(f"{_RA}.get_ai_message_refinement", side_effect=RuntimeError("llm down")):
+            note = ra._draft_connect_note(1, candidate, topic="ops")
+        assert "Jane" in note and "ops" in note
+
+    def test_blank_refinement_falls_back_to_the_template(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.connection_targeting import CandidateSignal, score_candidate
+        candidate = score_candidate([CandidateSignal(person_name="Jane Doe",
+                                                     person_profile_url="https://x/in/jane-doe")],
+                                    datetime(2026, 7, 25))
+        with patch(f"{_RA}.get_ai_message_refinement", return_value="  "):
+            assert "Jane" in ra._draft_connect_note(1, candidate)
+
+    def test_refined_note_is_truncated_to_linkedins_limit(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.connection_targeting import CONNECT_NOTE_LIMIT, CandidateSignal, \
+            score_candidate
+        candidate = score_candidate([CandidateSignal(person_name="Jane",
+                                                     person_profile_url="https://x/in/jane")],
+                                    datetime(2026, 7, 25))
+        with patch(f"{_RA}.get_ai_message_refinement", return_value="x" * 500):
+            assert len(ra._draft_connect_note(1, candidate)) == CONNECT_NOTE_LIMIT
+
+
+class TestAdjacentAuthorHarvest:
+    def _commenter(self, name="Guru Fan", href="https://www.linkedin.com/in/guru-fan?x=1"):
+        link = MagicMock()
+        link.text = name
+        link.get_attribute.side_effect = lambda attr: href if attr == "href" else ""
+        comment = MagicMock()
+        comment.find_element.return_value = link
+        return comment
+
+    def test_harvests_commenters_with_post_context(self):
+        from cqc_lem.app import run_automation as ra
+        driver = MagicMock()
+        with patch(f"{_RA}._comment_items_from_thread", return_value=[self._commenter()]), \
+             patch(f"{_RA}.time.sleep"):
+            signals = ra._harvest_post_commenters(driver, "https://x/feed/update/1", "Guru Gary",
+                                                  datetime(2026, 7, 25))
+        assert len(signals) == 1
+        assert signals[0].person_profile_url == "https://www.linkedin.com/in/guru-fan"
+        assert signals[0].context_author == "Guru Gary"
+        assert signals[0].source == "adjacent_post"
+
+    def test_skips_comments_with_no_author_link(self):
+        from cqc_lem.app import run_automation as ra
+        broken = MagicMock()
+        broken.find_element.side_effect = Exception("no link")
+        nameless = self._commenter(name="")
+        with patch(f"{_RA}._comment_items_from_thread", return_value=[broken, nameless]), \
+             patch(f"{_RA}.time.sleep"):
+            signals = ra._harvest_post_commenters(MagicMock(), "https://x/p", "G",
+                                                  datetime(2026, 7, 25))
+        assert signals == []
+
+    def test_walks_each_authors_recent_posts_and_drops_ourselves(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.connection_targeting import CandidateSignal, SOURCE_ADJACENT_POST
+        harvested = [CandidateSignal(person_name="Me Myself", person_profile_url="https://x/in/me",
+                                     source=SOURCE_ADJACENT_POST),
+                     CandidateSignal(person_name="Guru Fan", person_profile_url="https://x/in/fan",
+                                     source=SOURCE_ADJACENT_POST)]
+        with patch("cqc_lem.utilities.linkedin.scrapper.get_profile_recent_activity",
+                   return_value=[{"link": "https://x/feed/update/1"},
+                                 {"link": "https://x/feed/update/2"},
+                                 {"link": "https://x/feed/update/3"}]), \
+             patch(f"{_RA}._harvest_post_commenters", return_value=harvested) as harvest:
+            signals = ra._adjacent_author_signals(MagicMock(), 1, ["https://x/in/guru-gary"],
+                                                  "Me Myself", datetime(2026, 7, 25))
+        assert harvest.call_count == 2  # capped at _MAX_ADJACENT_POSTS_PER_AUTHOR
+        assert [s.person_name for s in signals] == ["Guru Fan", "Guru Fan"]
+
+    def test_unreadable_author_and_post_are_skipped(self):
+        from cqc_lem.app import run_automation as ra
+        with patch("cqc_lem.utilities.linkedin.scrapper.get_profile_recent_activity",
+                   side_effect=Exception("profile gone")):
+            assert ra._adjacent_author_signals(MagicMock(), 1, ["https://x/in/a"], "Me",
+                                               datetime(2026, 7, 25)) == []
+        with patch("cqc_lem.utilities.linkedin.scrapper.get_profile_recent_activity",
+                   return_value=[{"link": None}, {"link": "https://x/p"}]), \
+             patch(f"{_RA}._harvest_post_commenters", side_effect=Exception("post gone")):
+            assert ra._adjacent_author_signals(MagicMock(), 1, ["https://x/in/a"], "Me",
+                                               datetime(2026, 7, 25)) == []
+
+    def test_author_display_name_from_slug(self):
+        from cqc_lem.app import run_automation as ra
+        assert ra._author_display_name("https://www.linkedin.com/in/jane-doe-1a2b3c") == "Jane Doe"
+        assert ra._author_display_name("not-a-profile") == ""
+
+
+class TestSchedulerDispatch:
+    def test_dispatches_per_active_user(self):
+        from cqc_lem.app import run_scheduler as rs
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \
+             patch(f"{_RA}.scan_connection_candidates.apply_async") as dispatch:
+            out = rs.auto_scan_connection_candidates()
+        assert dispatch.call_count == 2
+        assert "2 user(s)" in out
+
+    def test_skips_when_throttled(self):
+        from cqc_lem.app import run_scheduler as rs
+        with patch(f"{_RS}._skip_if_throttled", return_value=True), \
+             patch(f"{_RA}.scan_connection_candidates.apply_async") as dispatch:
+            out = rs.auto_scan_connection_candidates()
+        dispatch.assert_not_called()
+        assert out == "Automation throttled"
+
+    def test_beat_schedule_includes_the_scan(self):
+        from cqc_lem.app.my_celery import app
+        entry = app.conf.beat_schedule["scan-connection-candidates"]
+        assert entry["task"] == "cqc_lem.app.run_scheduler.auto_scan_connection_candidates"
+
+    def test_scan_runs_on_the_outreach_lane(self):
+        from cqc_lem.app import run_automation as ra
+        assert ra.scan_connection_candidates.queue == "se_outreach"

--- a/tests/unit/app/test_connection_targeting_scan.py
+++ b/tests/unit/app/test_connection_targeting_scan.py
@@ -113,6 +113,15 @@ class TestScanFiling:
         _out, insert = _scan(engagers=engagers, max_new=1)
         assert insert.call_count == 1
 
+    def test_per_scan_ceiling_env_falls_back_when_unparseable(self, monkeypatch):
+        from cqc_lem.app import run_automation as ra
+        monkeypatch.setenv("MAX_NEW_CONNECT_TARGETS_PER_SCAN", "five")
+        assert ra._connect_env_int("MAX_NEW_CONNECT_TARGETS_PER_SCAN", 5) == 5
+        monkeypatch.setenv("MAX_NEW_CONNECT_TARGETS_PER_SCAN", "3")
+        assert ra._connect_env_int("MAX_NEW_CONNECT_TARGETS_PER_SCAN", 5) == 3
+        monkeypatch.delenv("MAX_NEW_CONNECT_TARGETS_PER_SCAN")
+        assert ra._connect_env_int("MAX_NEW_CONNECT_TARGETS_PER_SCAN", 5) == 5
+
     def test_failed_insert_is_not_counted(self):
         out, insert = _scan(insert_id=None)
         assert insert.call_count == 1 and "Filed 0" in out

--- a/tests/unit/utilities/test_connection_targeting.py
+++ b/tests/unit/utilities/test_connection_targeting.py
@@ -1,0 +1,186 @@
+"""Unit tests for smart connection targeting's pure ranking logic (issue #486)."""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from cqc_lem.utilities.connection_targeting import (CONNECT_NOTE_LIMIT, SOURCE_ADJACENT_POST,
+                                                    SOURCE_OWN_POST, CandidateSignal,
+                                                    default_connect_note, first_name,
+                                                    group_signals, rank_candidates,
+                                                    score_candidate, target_terms_from_prefs,
+                                                    warmth_strength)
+
+pytestmark = pytest.mark.unit
+
+NOW = datetime(2026, 7, 25, 12, 0, 0)
+
+
+def _sig(name="Jane Doe", slug="jane-doe", source=SOURCE_OWN_POST, days_ago=0, author="",
+         url=None, context_url="https://x/feed/update/1"):
+    return CandidateSignal(person_name=name,
+                           person_profile_url=(url if url is not None
+                                               else f"https://www.linkedin.com/in/{slug}"),
+                           source=source, context_url=context_url, context_author=author,
+                           occurred_at=NOW - timedelta(days=days_ago))
+
+
+class TestTargetTerms:
+    def test_merges_focus_include_topics_and_keywords(self):
+        prefs = {"focus_topics": ["AI adoption"], "include_topics": [" leadership "],
+                 "include_keywords": ["ops", ""], "exclude_topics": ["crypto"]}
+        assert target_terms_from_prefs(prefs) == ["AI adoption", "leadership", "ops"]
+
+    def test_empty_prefs(self):
+        assert target_terms_from_prefs({}) == []
+        assert target_terms_from_prefs(None) == []
+
+
+class TestWarmth:
+    def test_own_post_beats_adjacent_post(self):
+        own = warmth_strength([_sig()], NOW)
+        adjacent = warmth_strength([_sig(source=SOURCE_ADJACENT_POST)], NOW)
+        assert own > adjacent
+
+    def test_recent_beats_stale(self):
+        assert warmth_strength([_sig(days_ago=0)], NOW) > warmth_strength([_sig(days_ago=60)], NOW)
+
+    def test_repeats_add_with_diminishing_returns(self):
+        one = warmth_strength([_sig()], NOW)
+        three = warmth_strength([_sig(), _sig(days_ago=1), _sig(days_ago=2)], NOW)
+        assert one < three < one * 3
+
+    def test_bounded_and_empty_safe(self):
+        assert warmth_strength([], NOW) == 0
+        assert warmth_strength([_sig() for _ in range(50)], NOW) == 100
+
+    def test_unknown_timestamp_does_not_zero_the_signal(self):
+        signal = CandidateSignal(person_name="Jane", person_profile_url="https://x/in/jane")
+        assert warmth_strength([signal], NOW) > 0
+
+    def test_tolerates_tz_aware_now(self):
+        from datetime import timezone
+        aware = NOW.replace(tzinfo=timezone.utc)
+        assert warmth_strength([_sig(days_ago=1)], aware) > 0
+
+
+class TestGroupSignals:
+    def test_same_person_across_sources_collapses(self):
+        grouped = group_signals([_sig(), _sig(source=SOURCE_ADJACENT_POST, author="Guru")])
+        assert list(grouped) == ["in:jane-doe"]
+        assert len(grouped["in:jane-doe"]) == 2
+
+    def test_name_only_signal_stays_separate(self):
+        grouped = group_signals([_sig(), _sig(url="")])
+        assert set(grouped) == {"in:jane-doe", "name:jane doe"}
+
+    def test_unidentifiable_signal_dropped(self):
+        assert group_signals([CandidateSignal(person_name="", person_profile_url="")]) == {}
+
+
+class TestScoreCandidate:
+    def test_own_post_is_the_headline_source_even_when_older(self):
+        candidate = score_candidate([_sig(source=SOURCE_ADJACENT_POST, days_ago=0, author="Guru"),
+                                     _sig(source=SOURCE_OWN_POST, days_ago=5)], NOW)
+        assert candidate.source == SOURCE_OWN_POST
+        assert candidate.signal_count == 2
+
+    def test_adjacent_context_is_kept_for_the_note(self):
+        candidate = score_candidate([_sig(source=SOURCE_ADJACENT_POST, author="Guru",
+                                          context_url="https://x/feed/update/9")], NOW)
+        assert candidate.context_author == "Guru"
+        assert candidate.context_url == "https://x/feed/update/9"
+        assert "Guru" in candidate.reasons
+
+    def test_facts_drive_icp_and_known_fit(self):
+        facts = {"job_title": "VP of Revenue Operations", "industry": "SaaS"}
+        candidate = score_candidate([_sig()], NOW, facts=facts, target_terms=["revenue operations"])
+        assert candidate.known_fit is True
+        assert candidate.icp_score > 50
+        assert "strong ICP fit" in candidate.reasons
+
+    def test_no_facts_is_neutral_and_flagged(self):
+        candidate = score_candidate([_sig()], NOW, target_terms=["ops"])
+        assert candidate.known_fit is False
+        assert candidate.icp_score == 50
+        assert "not scraped" in candidate.reasons
+
+    def test_reasons_report_recency_and_repeat_count(self):
+        candidate = score_candidate([_sig(days_ago=0), _sig(days_ago=3)], NOW)
+        assert "engaged with your content (2×)" in candidate.reasons
+        assert "engaged today" in candidate.reasons
+
+    def test_reasons_report_days_since_last_engagement(self):
+        assert "last engaged 4d ago" in score_candidate([_sig(days_ago=4)], NOW).reasons
+
+    def test_reasons_tolerate_a_tz_aware_now(self):
+        # MySQL hands back naive-UTC timestamps; a caller passing an aware `now` must not raise.
+        from datetime import timezone
+        candidate = score_candidate([_sig(days_ago=2)], NOW.replace(tzinfo=timezone.utc))
+        assert "last engaged 2d ago" in candidate.reasons
+
+    def test_weak_fit_is_called_out(self):
+        candidate = score_candidate([_sig()], NOW, facts={"job_title": "intern"},
+                                    target_terms=["revenue operations"])
+        assert "weak ICP fit" in candidate.reasons
+
+
+class TestRankCandidates:
+    def test_ranks_best_first(self):
+        signals = [_sig(name="Warm Wanda", slug="wanda"),
+                   _sig(name="Cold Carl", slug="carl", source=SOURCE_ADJACENT_POST, days_ago=45)]
+        ranked = rank_candidates(signals, NOW)
+        assert [c.person_name for c in ranked] == ["Warm Wanda", "Cold Carl"]
+
+    def test_excludes_already_requested_people(self):
+        ranked = rank_candidates([_sig()], NOW, exclude_keys={"in:jane-doe"})
+        assert ranked == []
+
+    def test_drops_name_only_candidates(self):
+        ranked = rank_candidates([_sig(url="")], NOW)
+        assert ranked == []
+
+    def test_icp_floor_applies_only_to_known_fit(self):
+        facts = {"https://www.linkedin.com/in/carl": {"job_title": "intern", "industry": "retail"}}
+        signals = [_sig(name="Carl", slug="carl"), _sig(name="Unknown Uma", slug="uma")]
+        ranked = rank_candidates(signals, NOW, facts_by_url=facts, target_terms=["revenue ops"],
+                                 min_icp=60)
+        # Carl has facts and misses the floor; Uma has none and is judged on engagement instead.
+        assert [c.person_name for c in ranked] == ["Unknown Uma"]
+
+    def test_facts_match_on_slug_not_raw_url(self):
+        facts = {"https://www.linkedin.com/in/jane-doe/": {"job_title": "Chief Revenue Officer"}}
+        ranked = rank_candidates([_sig()], NOW, facts_by_url=facts, target_terms=["revenue"])
+        assert ranked[0].known_fit is True and ranked[0].icp_score >= 70
+
+    def test_limit_caps_the_result(self):
+        signals = [_sig(name=f"P{i}", slug=f"p{i}") for i in range(5)]
+        assert len(rank_candidates(signals, NOW, limit=2)) == 2
+
+    def test_no_signals(self):
+        assert rank_candidates([], NOW) == []
+
+
+class TestConnectNote:
+    def test_first_name(self):
+        assert first_name("  Jane   Doe ") == "Jane"
+        assert first_name(None) == "there"
+
+    def test_own_post_note_thanks_them_for_engaging(self):
+        candidate = score_candidate([_sig()], NOW)
+        note = default_connect_note(candidate, topic="AI adoption")
+        assert "Jane" in note and "engaging with my posts" in note and "AI adoption" in note
+
+    def test_adjacent_note_names_the_author(self):
+        candidate = score_candidate([_sig(source=SOURCE_ADJACENT_POST, author="Guru Gary")], NOW)
+        assert "Guru Gary's post" in default_connect_note(candidate)
+
+    def test_adjacent_note_without_a_known_author(self):
+        candidate = score_candidate([_sig(source=SOURCE_ADJACENT_POST)], NOW)
+        note = default_connect_note(candidate, topic="ops")
+        assert "same conversations" in note and "ops" in note
+
+    def test_note_respects_linkedin_note_limit(self):
+        candidate = score_candidate([_sig(name="Jane Doe")], NOW)
+        note = default_connect_note(candidate, topic="x" * 400)
+        assert len(note) <= CONNECT_NOTE_LIMIT

--- a/tests/unit/utilities/test_connection_targeting.py
+++ b/tests/unit/utilities/test_connection_targeting.py
@@ -157,6 +157,14 @@ class TestRankCandidates:
         signals = [_sig(name=f"P{i}", slug=f"p{i}") for i in range(5)]
         assert len(rank_candidates(signals, NOW, limit=2)) == 2
 
+    def test_zero_limit_returns_nothing(self):
+        signals = [_sig(name=f"P{i}", slug=f"p{i}") for i in range(5)]
+        assert rank_candidates(signals, NOW, limit=0) == []
+
+    def test_no_limit_returns_everything(self):
+        signals = [_sig(name=f"P{i}", slug=f"p{i}") for i in range(5)]
+        assert len(rank_candidates(signals, NOW, limit=None)) == 5
+
     def test_no_signals(self):
         assert rank_candidates([], NOW) == []
 

--- a/tests/unit/utilities/test_db_connection_targeting.py
+++ b/tests/unit/utilities/test_db_connection_targeting.py
@@ -1,0 +1,151 @@
+"""Unit tests for the connection-targeting DB helpers (issue #486)."""
+
+import mysql.connector
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(fetch_row=None, fetchall=None, lastrowid=7, error=None):
+    conn = MagicMock(); cur = MagicMock()
+    if error:
+        cur.execute.side_effect = mysql.connector.Error(error)
+    cur.fetchone.return_value = fetch_row
+    cur.fetchall.return_value = fetchall or []
+    cur.rowcount = 1
+    cur.lastrowid = lastrowid
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestInsertWithProvenance:
+    def test_stores_source_icp_and_reasons(self):
+        conn, cur = _conn(lastrowid=11)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_connection_request
+            got = insert_connection_request(1, "https://x/in/jane", message="hi",
+                                            recipient_name="Jane", source="own_post",
+                                            icp_score=72, reasons="engaged with your content")
+        assert got == 11
+        sql, params = cur.execute.call_args[0]
+        assert "source, icp_score, reasons" in sql
+        assert params[-3:] == ("own_post", 72, "engaged with your content")
+
+    def test_blank_reasons_stored_as_null(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_connection_request
+            insert_connection_request(1, "https://x/in/jane", reasons="")
+        assert cur.execute.call_args[0][1][-1] is None
+
+    def test_select_columns_include_provenance(self):
+        from cqc_lem.utilities.db import _CONN_REQ_COLS
+        assert {"source", "icp_score", "reasons"}.issubset(set(_CONN_REQ_COLS))
+
+
+class TestCountOpenConnectionRequests:
+    def test_counts_unsent_statuses_only(self):
+        conn, cur = _conn(fetch_row=(3,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_open_connection_requests
+            assert count_open_connection_requests(1) == 3
+        sql, params = cur.execute.call_args[0]
+        assert "status IN ('pending','approved','sending')" in sql
+        assert params == (1,)
+
+    def test_no_rows_is_zero(self):
+        conn, _cur = _conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_open_connection_requests
+            assert count_open_connection_requests(1) == 0
+
+    def test_db_error_is_zero(self):
+        conn, _cur = _conn(error="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_open_connection_requests
+            assert count_open_connection_requests(1) == 0
+
+
+class TestRequestedPersonKeys:
+    def test_keys_every_status_and_prefers_the_slug(self):
+        conn, cur = _conn(fetchall=[("Jane Doe", "https://www.linkedin.com/in/jane-doe?x=1"),
+                                    ("Nameless", None), (None, None)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_requested_person_keys
+            keys = get_requested_person_keys(1)
+        # No status filter: a canceled/failed target must not be re-sourced tomorrow.
+        assert "status" not in cur.execute.call_args[0][0]
+        assert keys == {"in:jane-doe", "name:nameless"}
+
+    def test_db_error_is_empty(self):
+        conn, _cur = _conn(error="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_requested_person_keys
+            assert get_requested_person_keys(1) == set()
+
+
+class TestEngagerCandidates:
+    def test_reads_recent_engagers_with_a_profile_url(self):
+        rows = [{"person_name": "Jane", "person_profile_url": "https://x/in/jane",
+                 "occurred_at": None}]
+        conn, cur = _conn(fetchall=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engager_candidates
+            assert get_engager_candidates(1, days=30) == rows
+        sql, params = cur.execute.call_args[0]
+        assert "FROM post_engagers" in sql
+        assert "engager_profile_url IS NOT NULL" in sql  # nobody to invite without a URL
+        assert params == (1, 30)
+
+    def test_db_error_is_empty(self):
+        conn, _cur = _conn(error="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engager_candidates
+            assert get_engager_candidates(1) == []
+
+
+class TestTargetingPreferences:
+    def test_defaults_are_suggest_mode(self):
+        from cqc_lem.utilities.db import _ENGAGEMENT_DEFAULTS
+        assert _ENGAGEMENT_DEFAULTS["connection_targeting_mode"] == "suggest"
+        assert _ENGAGEMENT_DEFAULTS["connection_target_authors"] == []
+        assert _ENGAGEMENT_DEFAULTS["min_connection_icp_score"] == 55
+
+    def test_authors_list_is_json_coerced_on_read(self):
+        conn, cur = _conn()
+        cur.fetchone.return_value = {"connection_target_authors": '["https://x/in/guru"]',
+                                     "connection_targeting_mode": "auto_queue"}
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_preferences
+            prefs = get_engagement_preferences(1)
+        assert prefs["connection_target_authors"] == ["https://x/in/guru"]
+
+    @pytest.mark.parametrize("bad", ["", "on", None, "AUTO_QUEUE"])
+    def test_invalid_mode_falls_back_to_suggest(self, bad):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_engagement_preferences
+            update_engagement_preferences(1, {"connection_targeting_mode": bad})
+        params = cur.execute.call_args[0][1]
+        assert "suggest" in params
+
+    @pytest.mark.parametrize("raw,expected", [(-5, 0), (140, 100), ("x", 55), (None, 55), (70, 70)])
+    def test_min_icp_is_clamped(self, raw, expected):
+        # An out-of-range value must clamp, not roll back the whole single-row prefs upsert.
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import _ENGAGEMENT_COLS, update_engagement_preferences
+            update_engagement_preferences(1, {"min_connection_icp_score": raw})
+        params = cur.execute.call_args[0][1]
+        assert params[_ENGAGEMENT_COLS.index("min_connection_icp_score") + 1] == expected
+
+    def test_authors_persist_as_json(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import _ENGAGEMENT_COLS, update_engagement_preferences
+            update_engagement_preferences(1, {"connection_target_authors": ["https://x/in/guru"]})
+        params = cur.execute.call_args[0][1]
+        assert params[_ENGAGEMENT_COLS.index("connection_target_authors") + 1] == '["https://x/in/guru"]'


### PR DESCRIPTION
## What & why

Extends #398 with the **sourcing** half of proactive connecting: instead of an operator hand-typing prospects, LEM now finds **warm, ICP-fit people who engage with content** and files them into #398's existing approval-gated, daily-capped connect path. Nothing about the send path changes — approval, the combined `max_invites_per_day` cap, and the 429 / kill-switch backoff all still decide what actually goes out.

## Candidate sourcing
- **Own-post engagers** — read from `post_engagers` (already populated by the reply sweep), so this source costs **no scraping**.
- **Adjacent authors' engagers** — commenters on the recent posts of a configurable set of thought-leaders/competitors (`connection_target_authors`), harvested with the same SDUI comment-thread walker (`_comment_items_from_thread`) the reply sweep uses. Per-scan caps: **3 authors × 2 recent posts × 15 engagers**, each author/post best-effort so one dead profile can't lose the rest.

## ICP scoring & dedup (`utilities/connection_targeting.py` — pure, no DB/Selenium/LLM)
- ICP fit reuses `lead_scoring.icp_fit` against the user's `focus_topics` / include topics+keywords; warmth blends **recency + frequency + source weight** (own post `1.0` > adjacent post `0.65`), with diminishing returns per repeat. Score = `0.6·ICP + 0.4·warmth`.
- **The ICP floor applies only to people we have profile facts on.** Most engagers are never scraped and score `ICP_UNKNOWN` (50) — a blanket floor would reject nearly everyone and throw away the warm-engager signal this feature exists to use. They're kept, ranked on warmth, and their `reasons` says *"ICP fit unknown (profile not scraped)"* so the approver sees it.
- Deduped against **every `connection_requests` row the user has ever had, any status** — so a canceled/failed target doesn't come back tomorrow night. Name-only sightings are dropped (nobody to invite without a `/in/` URL).

## Approval-gated personalized note
- The note is grounded in the actual shared context (*"I saw your take on <author>'s post about <topic>"* / *"thanks for engaging with my posts"*), refined into the user's voice via `get_ai_message_refinement`, with a template fallback when the LLM is down, hard-capped at LinkedIn's 300 chars.
- `connection_targeting_mode`: **`off`** | **`suggest`** (default) | **`auto_queue`**. `suggest` always files `pending` drafts — **enabling targeting can never send anything on its own**; `auto_queue` defers to the existing `connection_request_mode`.
- Per-scan budget = `max_invites_per_day` − invites sent today − targets already queued, further capped by `MAX_NEW_CONNECT_TARGETS_PER_SCAN` (default **5**), so sourcing can never build a backlog that spends tomorrow's cap the instant it opens.
- Daily **4:00 AM** beat scan (after the 3:30 lead re-score), dispatched per active user and gated on the 429 breaker / manual pause; runs on the `se_outreach` lane.

## Also
- `connection_requests.source` / `icp_score` / `reasons` provenance, surfaced on each card in the Connections review UI so the approver can see *where this person came from and why*.
- Account → Engagement Targeting: targeting mode, min ICP fit, adjacent-author list.
- Migration `V20260725004908__add_connection_targeting.sql` (timestamp version, additive only).

## Scope note
Candidate sourcing uses **commenters**, not reactors: `post_engagers` only records commenters, and enumerating a post's reaction list means driving the reactions modal — new Selenium surface that can't be grounded headless. Commenting is also the higher-intent signal. Reactor sourcing is a follow-up if wanted. Already-connected people aren't pre-filtered either (we have no connections table) — those simply come back as `failed` from `invite_to_connect_now`, exactly as a hand-added target does today.

## Testing
- `tests/unit/utilities/test_connection_targeting.py` — 31 tests, **100%** of the new module (warmth/source/recency weighting, grouping, ICP floor semantics, note templates + 300-char limit, tz-aware `now`).
- `tests/unit/app/test_connection_targeting_scan.py` — 26 tests (mode gating, budget math, suggest vs auto_queue status, dedup, adjacent harvest + degradation when the session fails, LLM fallback, beat + queue lane).
- `tests/unit/utilities/test_db_connection_targeting.py` — 22 tests (provenance insert, open-request count, dedup keys across all statuses, engager sourcing, prefs defaults/clamps — the V52 "one bad value rolls back the whole prefs row" lesson).
- 3 added to `tests/unit/api/test_engagement_prefs_api.py`. Full unit suite: **3582 passed**. UI `tsc -b` clean.

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)