### PR TITLE
feat(observability): per-user/per-feature LLM cost attribution (closes #489)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -54,7 +54,8 @@ from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited, _redis_cl
     acquire_run_lock, release_run_lock
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text
 from cqc_lem.utilities.logger import myprint, log_error, log_info, log_warning
-from cqc_lem.utilities.observability import track_post_outcome
+from cqc_lem.utilities.observability import track_post_outcome, attribute_llm_cost, llm_attribution, \
+    FEATURE_COMMENT, FEATURE_CONTENT, FEATURE_DM
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
     get_element_wait_retry, get_elements_as_list_wait_stale, getText, close_tab, get_driver_wait_pair, quit_gracefully, \
     wait_for_ajax, find_first, click_first, find_all_first
@@ -1085,9 +1086,10 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             if not claim_post_for_comment(user_id, key):
                 continue
             comment_blueprint = select_blueprint("comment", recent_formats=used_comment_shapes)
-            comment_text = generate_ai_response(content, my_profile, None, prefs=prefs,
-                                                profile_synthesis=profile_synthesis,
-                                                blueprint=comment_blueprint)
+            with llm_attribution(user_id=user_id, feature=FEATURE_COMMENT):
+                comment_text = generate_ai_response(content, my_profile, None, prefs=prefs,
+                                                    profile_synthesis=profile_synthesis,
+                                                    blueprint=comment_blueprint)
             if comment_text and comment_blueprint.get("format"):
                 used_comment_shapes.insert(0, comment_blueprint["format"])
             if comment_text:
@@ -1602,8 +1604,9 @@ def auto_seed_comment_on_post(self, user_id: int, post_id: int):
         return "No post content to seed a comment from"
     try:
         my_profile = load_profile_for_user(user_id)  # cached DB read — no scrape/login
-        seed = generate_seed_comment(post_message, my_profile, get_engagement_preferences(user_id),
-                                     profile_synthesis=get_or_create_profile_synthesis(user_id, my_profile))
+        with llm_attribution(user_id=user_id, feature=FEATURE_COMMENT):
+            seed = generate_seed_comment(post_message, my_profile, get_engagement_preferences(user_id),
+                                         profile_synthesis=get_or_create_profile_synthesis(user_id, my_profile))
         # The generated comment never contains links (the prompt forbids them); the link held back at
         # publish time is appended deterministically here. A link on its own still ships when the
         # generator came back empty — losing the link entirely would be the worse failure.
@@ -1771,9 +1774,10 @@ def auto_post_to_group(self, user_id: int, group_id: str):
     try:
         driver.get(f"https://www.linkedin.com/groups/{group_id}/")
         time.sleep(random.uniform(4, 7))
-        text = _strip_non_bmp(generate_group_post(
-            my_profile, prefs=get_engagement_preferences(user_id),
-            profile_synthesis=get_or_create_profile_synthesis(user_id, my_profile)) or "")
+        with llm_attribution(user_id=user_id, feature=FEATURE_CONTENT):
+            text = _strip_non_bmp(generate_group_post(
+                my_profile, prefs=get_engagement_preferences(user_id),
+                profile_synthesis=get_or_create_profile_synthesis(user_id, my_profile)) or "")
         if not text.strip():
             return "No group post generated"
         # Open the group share box, type, and post (best-effort SDUI selectors).
@@ -1946,8 +1950,9 @@ def _flag_lead_signal(user_id: int, text: str, source: "LeadSignalSource", threa
             return None
         draft = None
         try:
-            draft = generate_lead_response(text, my_profile, channel=str(channel), context=context_text,
-                                           prefs=prefs, profile_synthesis=profile_synthesis)
+            with llm_attribution(user_id=user_id, feature=FEATURE_DM):
+                draft = generate_lead_response(text, my_profile, channel=str(channel), context=context_text,
+                                               prefs=prefs, profile_synthesis=profile_synthesis)
         except Exception as e:
             log_warning("Lead response draft failed; queueing the signal without one", exc=e,
                         user_id=user_id, action_type="engaged")
@@ -2065,9 +2070,10 @@ def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my
         myprint(f"Responding to this comment: {short_comment_text}...")
         # Thread-builder: reply in a way that ends with a follow-up question so the commenter
         # replies again — first-hour thread depth is the top 2026 reach signal.
-        response = generate_thread_reply(post_message, comment_text, my_profile,
-                                         prefs=prefs,
-                                         profile_synthesis=profile_synthesis)
+        with llm_attribution(user_id=user_id, feature=FEATURE_COMMENT):
+            response = generate_thread_reply(post_message, comment_text, my_profile,
+                                             prefs=prefs,
+                                             profile_synthesis=profile_synthesis)
         myprint(f"AI Generated Response to Comment: {response}")
         if response and _reply_to_comment_inline(driver, wait, comment, response, user_id=user_id):
             insert_new_log(user_id=user_id, post_id=post_id, action_type=LogActionType.REPLY,
@@ -2405,8 +2411,9 @@ def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str,
                            message="Reacted to reply on our comment")
         if not did_reply and replies_remaining > 0 and _reply_is_question(reply_text):
             # We are a GUEST replying in someone else's thread — not the post author (issue #478).
-            response = generate_comment_reply_followup(reply_text, my_profile, prefs=prefs,
-                                                       profile_synthesis=profile_synthesis)
+            with llm_attribution(user_id=user_id, feature=FEATURE_COMMENT):
+                response = generate_comment_reply_followup(reply_text, my_profile, prefs=prefs,
+                                                           profile_synthesis=profile_synthesis)
             if response and _reply_under_comment_inline(driver, wait, cont, response, user_id=user_id):
                 result["replied"] += 1
                 replies_remaining -= 1
@@ -2751,6 +2758,7 @@ def render_dm_placeholders(text: str, *, first_name: str = "", headline: str = "
         return out
 
 
+@attribute_llm_cost(FEATURE_DM)
 def build_dm_from_template(user_id: int, event_type: str, first_name: str,
                            my_profile: LinkedInProfile, step: int = 0, blog_url: str = "") -> "str | None":
     """Render the user's DM template for an event (filling {first_name}/{headline}/{blog_url})
@@ -3024,8 +3032,9 @@ def generate_and_post_comment(driver, wait, post_link, my_profile: LinkedInProfi
         log_warning("Could not load engagement preferences for comment; generating with defaults",
                     exc=e, user_id=user_id, action_type="comment")
         prefs = None
-    comment_text = generate_ai_response(content, my_profile, img_url, prefs=prefs,
-                                        profile_synthesis=profile_synthesis)
+    with llm_attribution(user_id=user_id, feature=FEATURE_COMMENT):
+        comment_text = generate_ai_response(content, my_profile, img_url, prefs=prefs,
+                                            profile_synthesis=profile_synthesis)
 
     myprint(f"AI Generated Comment: {comment_text}")
     # Simulate typing the AI-generated comment

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -43,6 +43,7 @@ from cqc_lem.utilities.linkedin.helper import get_my_profile, load_profile_for_u
 from cqc_lem.utilities.linkedin_formatter import sanitize_for_linkedin, strip_engagement_bait
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.logger import myprint, log_info, log_warning
+from cqc_lem.utilities.observability import attribute_llm_cost, llm_attribution, FEATURE_CONTENT
 from cqc_lem.utilities.selenium_util import get_driver_wait_pair, quit_gracefully
 from cqc_lem.utilities.utils import get_best_posting_time, get_post_time, create_folder_if_not_exists, save_video_url_to_dir
 from requests.adapters import HTTPAdapter
@@ -245,6 +246,7 @@ def create_content(user_id: int, post_type: str, stage: str, post_id: int = None
     return content, video_url
 
 
+@attribute_llm_cost(FEATURE_CONTENT)
 def create_carousel_content(user_id: int, stage: str, post_id: int = None,
                             template: Optional[str] = None) -> str:
     """Generate AI carousel content, render slide images, update DB, and return the post text."""
@@ -369,6 +371,7 @@ def _premium_tier_for_quality(quality: str):
     return None
 
 
+@attribute_llm_cost(FEATURE_CONTENT)
 def _generate_video_src(user_id: int, text_content: str, profile, post_id: int = None):
     """Generate a video source URL honoring the post's quality tier + video credits.
 
@@ -443,6 +446,7 @@ def _generate_video_src(user_id: int, text_content: str, profile, post_id: int =
             return None
 
 
+@attribute_llm_cost(FEATURE_CONTENT)
 def create_video_content(user_id: int, stage: str, post_id: int = None) -> tuple[str, str | None]:
     # Get Text Content
     text_content = create_text_post(user_id, stage, post_id=post_id)
@@ -579,7 +583,8 @@ def regenerate_post(post_id: int, guidance: str = None) -> Optional[str]:
         try:
             prefs = get_engagement_preferences(user_id)
             synthesis = get_or_create_profile_synthesis(user_id, user_profile)
-            revised = apply_post_guidance(content, guidance, prefs=prefs, profile_synthesis=synthesis)
+            with llm_attribution(user_id=user_id, feature=FEATURE_CONTENT):
+                revised = apply_post_guidance(content, guidance, prefs=prefs, profile_synthesis=synthesis)
             if revised:
                 content = sanitize_for_linkedin(revised).strip()
                 # The guidance rewrite is another LLM pass that can drop the comment-keyword
@@ -758,6 +763,7 @@ def _review_generated_post(user_id: int, stage: str, post_type: str, user_profil
     return second
 
 
+@attribute_llm_cost(FEATURE_CONTENT)
 def create_text_post(user_id: int, stage: str, post_type: str = None, user_profile: LinkedInProfile=None,
                      refine_final_post: bool = True, blueprint: dict = None, post_id: int = None,
                      lead_magnet_cta: str = None, history_directive: str = None,

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -25,6 +25,7 @@ from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
 from cqc_lem.utilities.linkedin.rate_limit import is_automation_paused, automation_pause_remaining, \
     rate_limit_cooldown_remaining
 from cqc_lem.utilities.notifications import notify_linkedin_session
+from cqc_lem.utilities.observability import attribute_llm_cost, llm_attribution, FEATURE_NEWSLETTER
 
 
 def _skip_if_throttled(name: str) -> bool:
@@ -317,6 +318,7 @@ def _max_dt(*dts):
     return max(present) if present else None
 
 
+@attribute_llm_cost(FEATURE_NEWSLETTER)
 def _topup_newsletter_drafts_for_user(user_id: int, now: datetime,
                                       allow_bootstrap: bool = True) -> int:
     """Top a single user's review queue up to their max_queued_drafts and return how many drafts were
@@ -536,11 +538,12 @@ def regenerate_newsletter_edition(edition_id: int, guidance: str = None):
                               blueprint=blueprint,
                               context_description=settings.get("topic"), prefs=prefs)
     try:
-        new_ed = generate_newsletter_edition(profile, topic=settings.get("topic"), prefs=prefs,
-                                             subject=subject, avoid_subjects=avoid,
-                                             profile_synthesis=synthesis, guidance=guidance,
-                                             blueprint=blueprint, avoid_openers=recent_openers,
-                                             research=research)
+        with llm_attribution(user_id=user_id, feature=FEATURE_NEWSLETTER):
+            new_ed = generate_newsletter_edition(profile, topic=settings.get("topic"), prefs=prefs,
+                                                 subject=subject, avoid_subjects=avoid,
+                                                 profile_synthesis=synthesis, guidance=guidance,
+                                                 blueprint=blueprint, avoid_openers=recent_openers,
+                                                 research=research)
     except Exception as e:
         log_warning("Newsletter regeneration failed", exc=e, user_id=user_id,
                     task_name="regenerate_newsletter_edition")

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -45,10 +45,25 @@ load_dotenv()
 
 
 def _call_llm(**kwargs):
-    """Thin wrapper around client.chat.completions.create that logs model, latency, and token usage."""
+    """Thin wrapper around client.chat.completions.create that logs model, latency, and token usage.
+
+    Cost attribution: pass `_track_user_id` / `_track_feature` to say who and what this call is for —
+    both are popped before the LiteLLM call. Omitted values fall back to the ambient
+    `llm_attribution()` scope, then to the running Celery task's name."""
+    track_user_id = kwargs.pop("_track_user_id", None)
+    track_feature = kwargs.pop("_track_feature", None)
     model = kwargs.get("model", "unknown")
     start = time.time()
     log_debug(f"LLM call starting", ai_model=model)
+
+    def _attribution():
+        from cqc_lem.utilities.observability import current_llm_attribution, FEATURE_SYSTEM
+        ambient_user_id, ambient_feature = current_llm_attribution()
+        return (
+            track_user_id if track_user_id is not None else ambient_user_id,
+            track_feature or ambient_feature or FEATURE_SYSTEM,
+        )
+
     try:
         response = client.chat.completions.create(**kwargs)
         duration_ms = int((time.time() - start) * 1000)
@@ -61,13 +76,17 @@ def _call_llm(**kwargs):
             duration_ms=duration_ms,
         )
         try:
-            from cqc_lem.utilities.observability import track_llm_call
+            from cqc_lem.utilities.observability import track_llm_call, llm_cache_hit
+            user_id, feature = _attribution()
             track_llm_call(
                 model=model,
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 latency_ms=duration_ms,
                 success=True,
+                user_id=user_id,
+                feature=feature,
+                cached=llm_cache_hit(response),
             )
         except Exception:
             pass
@@ -77,7 +96,9 @@ def _call_llm(**kwargs):
         log_error(f"LLM call failed after {duration_ms}ms", exc=exc, ai_model=model, duration_ms=duration_ms)
         try:
             from cqc_lem.utilities.observability import track_llm_call
-            track_llm_call(model=model, prompt_tokens=0, completion_tokens=0, latency_ms=duration_ms, success=False)
+            user_id, feature = _attribution()
+            track_llm_call(model=model, prompt_tokens=0, completion_tokens=0, latency_ms=duration_ms,
+                           success=False, user_id=user_id, feature=feature)
         except Exception:
             pass
         raise

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -244,7 +244,9 @@ def track_llm_call(
             "latency_ms": latency_ms,
             "success": success,
             "user_id": user_id,
-            "feature": feature,
+            # Floor the bucket here, not just in the callers: a PostHog breakdown on `feature`
+            # needs every llm_call to carry one, including direct calls that omit it.
+            "feature": feature or FEATURE_SYSTEM,
             "model_tier": model_tier or _model_tier(model),
             "cached": bool(cached),
         },

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -1,8 +1,11 @@
+import contextvars
+import inspect
 import json
 import os
 import time
+from contextlib import contextmanager
 from functools import wraps
-from typing import Optional, Tuple
+from typing import Iterator, Optional, Tuple
 
 import posthog
 
@@ -90,6 +93,132 @@ def _extract_token_usage(result) -> Tuple[int, int]:
     return prompt, completion
 
 
+def llm_cache_hit(result) -> bool:
+    """True when LiteLLM served this completion from its cache — the provider was never called, so
+    the tokens carry no spend. Only a real cache hit counts; prompt-cache discounts are still billed."""
+    hidden = getattr(result, "_hidden_params", None)
+    return bool(hidden.get("cache_hit")) if isinstance(hidden, dict) else False
+
+
+# Feature buckets used for per-feature cost/margin attribution. Keep this vocabulary stable —
+# PostHog breakdowns and the cost plan (docs/cost-performance-margin-plan.md) key off these values.
+FEATURE_CONTENT = "content"
+FEATURE_COMMENT = "comment"
+FEATURE_DM = "dm"
+FEATURE_NEWSLETTER = "newsletter"
+FEATURE_SYSTEM = "system"
+
+# First match wins, so the order encodes precedence: `dispatch_comment_followups` is comment work,
+# and `automate_profile_viewer_engagement` is outreach DM work despite ending in "engagement".
+_TASK_FEATURE_RULES = (
+    ("newsletter", FEATURE_NEWSLETTER),
+    ("edition", FEATURE_NEWSLETTER),
+    ("profile_viewer", FEATURE_DM),
+    ("comment", FEATURE_COMMENT),
+    ("reply", FEATURE_COMMENT),
+    ("seed", FEATURE_COMMENT),
+    ("engagement", FEATURE_COMMENT),
+    ("dm", FEATURE_DM),
+    ("appreciat", FEATURE_DM),
+    ("followup", FEATURE_DM),
+    ("outreach", FEATURE_DM),
+    ("connection_request", FEATURE_DM),
+    ("lead", FEATURE_DM),
+    ("content", FEATURE_CONTENT),
+    ("post", FEATURE_CONTENT),
+    ("carousel", FEATURE_CONTENT),
+    ("video", FEATURE_CONTENT),
+)
+
+
+def feature_from_task_name(task_name: Optional[str]) -> Optional[str]:
+    """Map a Celery task name (fully qualified or bare) onto a feature bucket, for LLM calls whose
+    caller can't supply one. Returns None when nothing matches, so the caller can decide the default."""
+    if not task_name:
+        return None
+    name = task_name.rsplit(".", 1)[-1].lower()
+    for needle, feature in _TASK_FEATURE_RULES:
+        if needle in name:
+            return feature
+    return None
+
+
+def _current_task_context() -> Tuple[Optional[str], Optional[int]]:
+    """(task_name, user_id) of the Celery task executing on this worker, or (None, None) off-worker
+    (API/CLI path). Every per-user task in LEM is dispatched with `kwargs={'user_id': ...}`, so the
+    request kwargs are a reliable last-resort attribution source for calls no scope covered."""
+    try:
+        from celery import current_task
+        name = getattr(current_task, "name", None)
+        if not name:
+            return None, None
+        kwargs = getattr(getattr(current_task, "request", None), "kwargs", None)
+        user_id = kwargs.get("user_id") if isinstance(kwargs, dict) else None
+        return name, user_id
+    except Exception:
+        return None, None
+
+
+_llm_attribution: contextvars.ContextVar[dict] = contextvars.ContextVar("llm_attribution", default={})
+
+
+@contextmanager
+def llm_attribution(user_id: Optional[int] = None, feature: Optional[str] = None) -> Iterator[None]:
+    """Attribute every LLM call made inside this block to a user and/or feature. Task entry points
+    wrap their body in it so cost lands on the right user without threading kwargs through the ~40
+    ai_helper signatures. Nested scopes inherit the outer values; None never clears an outer value."""
+    scope = dict(_llm_attribution.get())
+    if user_id is not None:
+        scope["user_id"] = user_id
+    if feature is not None:
+        scope["feature"] = feature
+    token = _llm_attribution.set(scope)
+    try:
+        yield
+    finally:
+        _llm_attribution.reset(token)
+
+
+def attribute_llm_cost(feature: str, user_id_arg: str = "user_id"):
+    """Decorator form of llm_attribution() for a function that OWNS a feature's LLM work (a Celery
+    task, a generator entry point). It reads the user id from the call's own `user_id_arg` argument,
+    so cost is attributed the same way no matter which caller — beat, API, or healer — invoked it."""
+    def decorator(fn):
+        try:
+            params = list(inspect.signature(fn).parameters)
+        except (TypeError, ValueError):
+            params = []
+        position = params.index(user_id_arg) if user_id_arg in params else None
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            user_id = kwargs.get(user_id_arg)
+            if user_id is None and position is not None and len(args) > position:
+                user_id = args[position]
+            with llm_attribution(user_id=user_id, feature=feature):
+                return fn(*args, **kwargs)
+        return wrapper
+    return decorator
+
+
+def current_llm_attribution() -> Tuple[Optional[int], Optional[str]]:
+    """(user_id, feature) for an LLM call happening right now: the innermost llm_attribution() scope
+    first, then the running Celery task (its name for the feature, its kwargs for the user)."""
+    scope = _llm_attribution.get()
+    user_id, feature = scope.get("user_id"), scope.get("feature")
+    if user_id is None or feature is None:
+        task_name, task_user_id = _current_task_context()
+        user_id = user_id if user_id is not None else task_user_id
+        feature = feature or feature_from_task_name(task_name)
+    return user_id, feature
+
+
+def _model_tier(model: Optional[str]) -> Optional[str]:
+    """The tier alias a call was routed through (lem-simple/medium/complex/...), or None for a call
+    that named a raw provider model instead of a tier."""
+    return model if model and model.startswith("lem-") else None
+
+
 def track_llm_call(
     model: str,
     prompt_tokens: int,
@@ -97,6 +226,9 @@ def track_llm_call(
     latency_ms: int,
     success: bool = True,
     user_id: Optional[int] = None,
+    feature: Optional[str] = None,
+    model_tier: Optional[str] = None,
+    cached: bool = False,
 ) -> None:
     posthog.capture(
         distinct_id=str(user_id or "system"),
@@ -106,9 +238,15 @@ def track_llm_call(
             "prompt_tokens": prompt_tokens,
             "completion_tokens": completion_tokens,
             "total_tokens": prompt_tokens + completion_tokens,
-            "cost_usd": estimate_llm_cost_usd(model, prompt_tokens, completion_tokens),
+            # A cache hit never reached the provider, so it cost nothing — keeping it at the
+            # estimated rate would inflate summed spend on every repeated prompt.
+            "cost_usd": 0.0 if cached else estimate_llm_cost_usd(model, prompt_tokens, completion_tokens),
             "latency_ms": latency_ms,
             "success": success,
+            "user_id": user_id,
+            "feature": feature,
+            "model_tier": model_tier or _model_tier(model),
+            "cached": bool(cached),
         },
     )
 
@@ -183,6 +321,7 @@ def llm_tracked(model_alias: str):
         @wraps(fn)
         def wrapper(*args, **kwargs):
             start = time.time()
+            user_id, feature = current_llm_attribution()
             try:
                 result = fn(*args, **kwargs)
                 prompt_tokens, completion_tokens = _extract_token_usage(result)
@@ -192,6 +331,9 @@ def llm_tracked(model_alias: str):
                     completion_tokens=completion_tokens,
                     latency_ms=int((time.time() - start) * 1000),
                     success=True,
+                    user_id=user_id,
+                    feature=feature or FEATURE_SYSTEM,
+                    cached=llm_cache_hit(result),
                 )
                 return result
             except Exception:
@@ -201,6 +343,8 @@ def llm_tracked(model_alias: str):
                     completion_tokens=0,
                     latency_ms=int((time.time() - start) * 1000),
                     success=False,
+                    user_id=user_id,
+                    feature=feature or FEATURE_SYSTEM,
                 )
                 raise
         return wrapper

--- a/tests/unit/app/test_llm_cost_attribution_callers.py
+++ b/tests/unit/app/test_llm_cost_attribution_callers.py
@@ -8,7 +8,6 @@ pytestmark = pytest.mark.unit
 
 _AUTO = "cqc_lem.app.run_automation"
 _PLAN = "cqc_lem.app.run_content_plan"
-_SCHED = "cqc_lem.app.run_scheduler"
 
 
 @pytest.fixture

--- a/tests/unit/app/test_llm_cost_attribution_callers.py
+++ b/tests/unit/app/test_llm_cost_attribution_callers.py
@@ -1,0 +1,74 @@
+"""The task/generator entry points must scope their LLM calls to the right user + feature, so
+PostHog cost lands on a real user instead of 'system'."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_AUTO = "cqc_lem.app.run_automation"
+_PLAN = "cqc_lem.app.run_content_plan"
+_SCHED = "cqc_lem.app.run_scheduler"
+
+
+@pytest.fixture
+def seen_attribution():
+    """Captures the attribution active at the moment the LLM helper is invoked."""
+    from cqc_lem.utilities.observability import current_llm_attribution
+    captured = {}
+
+    def capture(*args, **kwargs):
+        captured["value"] = current_llm_attribution()
+        return "refined text"
+
+    return captured, capture
+
+
+class TestDmAttribution:
+    def test_build_dm_from_template_attributes_the_dm_feature(self, seen_attribution):
+        from cqc_lem.app.run_automation import build_dm_from_template
+        captured, capture = seen_attribution
+        with patch(f"{_AUTO}.get_dm_template", return_value={"template_text": "Hi {first_name}"}), \
+             patch(f"{_AUTO}.get_ai_message_refinement", side_effect=capture), \
+             patch(f"{_AUTO}.humanize_text", side_effect=lambda text, **k: text):
+            out = build_dm_from_template(42, "connection_accepted", "Ada", None)
+
+        assert out == "refined text"
+        assert captured["value"] == (42, "dm")
+
+
+class TestContentAttribution:
+    def test_create_carousel_content_attributes_the_content_feature(self, seen_attribution):
+        from cqc_lem.app.run_content_plan import create_carousel_content
+        captured, capture = seen_attribution
+
+        def generate(user_id, stage, **kwargs):
+            capture()
+            return "post text", {}
+
+        with patch(f"{_PLAN}.get_engagement_preferences", return_value={}), \
+             patch(f"{_PLAN}.get_or_create_profile_synthesis", return_value="voice"), \
+             patch("cqc_lem.utilities.ai.ai_helper.generate_carousel_content", side_effect=generate):
+            out = create_carousel_content(7, "awareness")
+
+        assert out == "post text"
+        assert captured["value"] == (7, "content")
+
+
+class TestNewsletterAttribution:
+    def test_newsletter_topup_attributes_the_newsletter_feature(self, seen_attribution):
+        from cqc_lem.app.run_scheduler import _topup_newsletter_drafts_for_user
+        from datetime import datetime
+        captured, capture = seen_attribution
+
+        # Bail out right after the attribution scope opens: the settings read is the first thing the
+        # top-up does, so raising there proves the scope wraps the whole generation body.
+        def settings(user_id):
+            capture()
+            raise RuntimeError("stop here")
+
+        with patch("cqc_lem.utilities.db.get_newsletter_settings", side_effect=settings):
+            with pytest.raises(RuntimeError, match="stop here"):
+                _topup_newsletter_drafts_for_user(3, datetime(2026, 7, 25))
+
+        assert captured["value"] == (3, "newsletter")

--- a/tests/unit/utilities/ai/test_llm_cost_attribution.py
+++ b/tests/unit/utilities/ai/test_llm_cost_attribution.py
@@ -1,0 +1,97 @@
+"""Unit tests for the cost-attribution dimensions threaded through ai_helper._call_llm."""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_AI = "cqc_lem.utilities.ai.ai_helper"
+_OBS = "cqc_lem.utilities.observability"
+
+
+def _response(cache_hit: bool = False):
+    resp = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=30, completion_tokens=70))
+    if cache_hit:
+        resp._hidden_params = {"cache_hit": True}
+    return resp
+
+
+def _call(**kwargs):
+    """Call _call_llm with a mocked LiteLLM client; returns (create_mock, track_mock)."""
+    from cqc_lem.utilities.ai.ai_helper import _call_llm
+    client = MagicMock()
+    client.chat.completions.create.return_value = kwargs.pop("_response", _response())
+    with patch(f"{_AI}.client", client), patch(f"{_OBS}.track_llm_call") as track:
+        _call_llm(**kwargs)
+    return client.chat.completions.create, track
+
+
+class TestCallLlmAttribution:
+    def test_explicit_track_kwargs_are_emitted_and_not_forwarded(self):
+        create, track = _call(model="lem-medium", messages=[{"role": "user", "content": "hi"}],
+                              _track_user_id=5, _track_feature="dm")
+
+        forwarded = create.call_args[1]
+        assert "_track_user_id" not in forwarded and "_track_feature" not in forwarded
+        assert forwarded["model"] == "lem-medium"
+        kwargs = track.call_args[1]
+        assert kwargs["user_id"] == 5
+        assert kwargs["feature"] == "dm"
+        assert kwargs["prompt_tokens"] == 30
+        assert kwargs["completion_tokens"] == 70
+        assert kwargs["success"] is True
+
+    def test_falls_back_to_the_ambient_attribution_scope(self):
+        from cqc_lem.utilities.observability import llm_attribution
+        with llm_attribution(user_id=12, feature="comment"):
+            _, track = _call(model="lem-simple", messages=[])
+
+        kwargs = track.call_args[1]
+        assert kwargs["user_id"] == 12
+        assert kwargs["feature"] == "comment"
+
+    def test_explicit_kwargs_win_over_the_ambient_scope(self):
+        from cqc_lem.utilities.observability import llm_attribution
+        with llm_attribution(user_id=12, feature="comment"):
+            _, track = _call(model="lem-simple", messages=[], _track_user_id=99,
+                             _track_feature="newsletter")
+
+        kwargs = track.call_args[1]
+        assert kwargs["user_id"] == 99
+        assert kwargs["feature"] == "newsletter"
+
+    def test_unattributed_call_reports_the_system_feature(self):
+        _, track = _call(model="lem-simple", messages=[])
+        assert track.call_args[1]["feature"] == "system"
+        assert track.call_args[1]["user_id"] is None
+
+    def test_cache_hit_is_reported(self):
+        _, track = _call(model="lem-medium", messages=[], _response=_response(cache_hit=True))
+        assert track.call_args[1]["cached"] is True
+
+    def test_uncached_call_reports_cached_false(self):
+        _, track = _call(model="lem-medium", messages=[])
+        assert track.call_args[1]["cached"] is False
+
+    def test_failed_call_still_carries_attribution(self):
+        from cqc_lem.utilities.ai.ai_helper import _call_llm
+        client = MagicMock()
+        client.chat.completions.create.side_effect = RuntimeError("provider down")
+        with patch(f"{_AI}.client", client), patch(f"{_OBS}.track_llm_call") as track:
+            with pytest.raises(RuntimeError):
+                _call_llm(model="lem-complex", messages=[], _track_user_id=8,
+                          _track_feature="content")
+
+        kwargs = track.call_args[1]
+        assert kwargs["success"] is False
+        assert kwargs["user_id"] == 8
+        assert kwargs["feature"] == "content"
+
+    def test_tracking_failure_never_breaks_the_llm_call(self):
+        from cqc_lem.utilities.ai.ai_helper import _call_llm
+        client = MagicMock()
+        client.chat.completions.create.return_value = _response()
+        with patch(f"{_AI}.client", client), \
+             patch(f"{_OBS}.track_llm_call", side_effect=RuntimeError("posthog down")):
+            assert _call_llm(model="lem-simple", messages=[]) is not None

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -304,3 +304,162 @@ class TestTrackPostOutcome:
 
         _, kwargs = mock_ph.capture.call_args
         assert kwargs["properties"]["archetype"] == "how-to"
+
+
+class TestCostAttributionDimensions:
+    def test_llm_call_carries_attribution_dims(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="lem-complex", prompt_tokens=100, completion_tokens=50, latency_ms=900,
+                           user_id=7, feature="newsletter")
+
+        _, kwargs = mock_ph.capture.call_args
+        props = kwargs["properties"]
+        assert props["user_id"] == 7
+        assert props["feature"] == "newsletter"
+        assert props["model_tier"] == "lem-complex"
+        assert props["cached"] is False
+        assert kwargs["distinct_id"] == "7"
+
+    def test_model_tier_none_for_raw_provider_model(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="gpt-4o-mini", prompt_tokens=10, completion_tokens=10, latency_ms=20)
+
+        assert mock_ph.capture.call_args[1]["properties"]["model_tier"] is None
+
+    def test_explicit_model_tier_wins(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="gpt-4o-mini", prompt_tokens=10, completion_tokens=10, latency_ms=20,
+                           model_tier="lem-router")
+
+        assert mock_ph.capture.call_args[1]["properties"]["model_tier"] == "lem-router"
+
+    def test_cache_hit_costs_nothing(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="lem-complex", prompt_tokens=5000, completion_tokens=800,
+                           latency_ms=12, cached=True)
+
+        props = mock_ph.capture.call_args[1]["properties"]
+        assert props["cached"] is True
+        assert props["cost_usd"] == 0.0
+        # Tokens are still reported — only the spend is zero.
+        assert props["total_tokens"] == 5800
+
+    def test_llm_cache_hit_reads_litellm_hidden_params(self):
+        from cqc_lem.utilities.observability import llm_cache_hit
+        assert llm_cache_hit(SimpleNamespace(_hidden_params={"cache_hit": True})) is True
+        assert llm_cache_hit(SimpleNamespace(_hidden_params={"cache_hit": False})) is False
+        assert llm_cache_hit(SimpleNamespace()) is False
+
+
+class TestFeatureFromTaskName:
+    @pytest.mark.parametrize("task_name,expected", [
+        ("cqc_lem.app.run_scheduler.auto_generate_newsletter_drafts", "newsletter"),
+        ("cqc_lem.app.run_automation.auto_publish_edition", "newsletter"),
+        ("cqc_lem.app.run_automation.automate_commenting", "comment"),
+        ("cqc_lem.app.run_scheduler.dispatch_comment_followups", "comment"),
+        ("cqc_lem.app.run_automation.auto_seed_comment_on_post", "comment"),
+        ("cqc_lem.app.run_automation.automate_profile_viewer_engagement", "dm"),
+        ("cqc_lem.app.run_automation.automate_appreciation_dms_for_user", "dm"),
+        ("cqc_lem.app.run_automation.send_lead_response", "dm"),
+        ("cqc_lem.app.run_content_plan.plan_content_for_user", "content"),
+        ("cqc_lem.app.run_content_plan.regenerate_post_carousel_task", "content"),
+        ("cqc_lem.app.run_scheduler.sync_stripe_subscriptions", None),
+        (None, None),
+    ])
+    def test_maps_task_name_to_feature(self, task_name, expected):
+        from cqc_lem.utilities.observability import feature_from_task_name
+        assert feature_from_task_name(task_name) == expected
+
+
+class TestLlmAttributionScope:
+    def test_scope_is_visible_to_current_attribution(self):
+        from cqc_lem.utilities.observability import llm_attribution, current_llm_attribution
+        with llm_attribution(user_id=3, feature="content"):
+            assert current_llm_attribution() == (3, "content")
+        assert current_llm_attribution() == (None, None)
+
+    def test_nested_scope_inherits_and_overrides(self):
+        from cqc_lem.utilities.observability import llm_attribution, current_llm_attribution
+        with llm_attribution(user_id=3, feature="content"):
+            with llm_attribution(feature="comment"):
+                # user_id inherited from the outer scope, feature narrowed by the inner one
+                assert current_llm_attribution() == (3, "comment")
+            assert current_llm_attribution() == (3, "content")
+
+    def test_falls_back_to_celery_task_name_and_kwargs(self):
+        from cqc_lem.utilities.observability import current_llm_attribution
+        with patch(f"{_MOD}._current_task_context",
+                   return_value=("cqc_lem.app.run_automation.automate_commenting", 11)):
+            assert current_llm_attribution() == (11, "comment")
+
+    def test_explicit_scope_beats_celery_fallback(self):
+        from cqc_lem.utilities.observability import llm_attribution, current_llm_attribution
+        with patch(f"{_MOD}._current_task_context",
+                   return_value=("cqc_lem.app.run_automation.automate_commenting", 11)):
+            with llm_attribution(user_id=4, feature="dm"):
+                assert current_llm_attribution() == (4, "dm")
+
+    def test_decorator_reads_user_id_positionally_and_by_keyword(self):
+        from cqc_lem.utilities.observability import attribute_llm_cost, current_llm_attribution
+
+        @attribute_llm_cost("content")
+        def generate(user_id: int, stage: str):
+            return current_llm_attribution()
+
+        assert generate(8, "awareness") == (8, "content")
+        assert generate(user_id=9, stage="decision") == (9, "content")
+        assert generate.__name__ == "generate"
+
+    def test_decorator_still_sets_feature_without_a_user(self):
+        from cqc_lem.utilities.observability import attribute_llm_cost, current_llm_attribution
+
+        @attribute_llm_cost("newsletter")
+        def generate(edition_id: int):
+            return current_llm_attribution()
+
+        assert generate(5) == (None, "newsletter")
+
+    def test_scope_is_restored_when_the_wrapped_call_raises(self):
+        from cqc_lem.utilities.observability import attribute_llm_cost, current_llm_attribution
+
+        @attribute_llm_cost("content")
+        def boom(user_id: int):
+            raise ValueError("nope")
+
+        with pytest.raises(ValueError):
+            boom(1)
+        assert current_llm_attribution() == (None, None)
+
+
+class TestLlmTrackedAttribution:
+    def test_decorator_emits_ambient_attribution(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import llm_tracked, llm_attribution
+
+            @llm_tracked("lem-medium")
+            def call():
+                return _usage(10, 10)
+
+            with llm_attribution(user_id=6, feature="comment"):
+                call()
+
+        props = mock_ph.capture.call_args[1]["properties"]
+        assert props["user_id"] == 6
+        assert props["feature"] == "comment"
+        assert props["model_tier"] == "lem-medium"
+
+    def test_unattributed_call_falls_back_to_system_feature(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import llm_tracked
+
+            @llm_tracked("lem-simple")
+            def call():
+                return _usage(1, 1)
+
+            call()
+
+        assert mock_ph.capture.call_args[1]["properties"]["feature"] == "system"

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -321,6 +321,13 @@ class TestCostAttributionDimensions:
         assert props["cached"] is False
         assert kwargs["distinct_id"] == "7"
 
+    def test_feature_floors_to_system_when_caller_omits_it(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="lem-simple", prompt_tokens=1, completion_tokens=1, latency_ms=5)
+
+        assert mock_ph.capture.call_args[1]["properties"]["feature"] == "system"
+
     def test_model_tier_none_for_raw_provider_model(self):
         with patch(f"{_MOD}.posthog") as mock_ph:
             from cqc_lem.utilities.observability import track_llm_call


### PR DESCRIPTION
## What & why

`llm_call` events carried only `model` + tokens, so every LLM dollar landed on `distinct_id="system"` — no per-user, per-feature cost or margin was computable (Plan §A.3(1), §0 gap #1).

**`track_llm_call`** (`utilities/observability.py`) now takes and emits `feature`, `model_tier` and `cached` alongside `user_id`:
- `model_tier` defaults to the `lem-*` alias the call routed through (`None` when a raw provider model was named).
- `cached` marks a LiteLLM cache hit; because that call never reached the provider, its `cost_usd` is `0.0` while its tokens are still reported — otherwise summed spend inflates on every repeated prompt.

**`ai_helper._call_llm`** accepts optional `_track_user_id` / `_track_feature`, both popped before the LiteLLM call. When a caller can't supply them, attribution resolves from:
1. the ambient `llm_attribution(user_id=…, feature=…)` scope (contextvar-backed — avoids threading kwargs through ~40 `ai_helper` signatures),
2. the running Celery task — its name → feature (`feature_from_task_name`), its request kwargs → `user_id`,
3. `feature="system"` as the floor.

`attribute_llm_cost(feature)` is the decorator form, used on generator entry points so cost is attributed identically whether the beat, the API, or an asset healer invoked them.

**Callers attributed**
- `run_content_plan.py` → `content`: `create_text_post`, `create_carousel_content`, `create_video_content`, `_generate_video_src`, and the post-guidance rewrite in `regenerate_post`.
- `run_automation.py` → `comment`: feed comments, thread replies, seed comments, comment follow-ups; `content`: group posts; `dm`: lead-response drafts and `build_dm_from_template`.
- Newsletter path (`run_scheduler.py`) → `newsletter`: `_topup_newsletter_drafts_for_user` and `regenerate_newsletter_edition`.

No behavior change to the LLM calls themselves — only what is reported to PostHog. Tracking stays best-effort (a PostHog failure can't break a generation).

## Testing

- `tests/unit/utilities/test_observability.py` — new dims on the `llm_call` event, `model_tier` derivation + explicit override, cache-hit costing, `feature_from_task_name` table (incl. the `dispatch_comment_followups` → comment and `automate_profile_viewer_engagement` → dm precedence cases), scope nesting/restore, Celery fallback, decorator arg resolution.
- `tests/unit/utilities/ai/test_llm_cost_attribution.py` — `_track_*` kwargs emitted but not forwarded to LiteLLM, ambient-scope fallback, `system` default, cached flag, failed-call attribution, tracking failure can't break the call.
- `tests/unit/app/test_llm_cost_attribution_callers.py` — the DM, content and newsletter entry points really open the right scope.
- `poetry run pytest tests/unit -q` → **3537 passed**.

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)