### PR TITLE
feat(cost): cost_ledger table + DB helpers + media/proxy/infra cost capture (closes #490)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -353,6 +353,16 @@ COST_ALERT_UNATTRIBUTED_PCT=0.10
 # Where budget alerts are emailed. Empty falls back to MARGIN_REPORT_EMAIL.
 COST_ALERT_EMAIL=
 
+# --- Cost ledger (issue #490 — durable spend behind the margin report) ---
+# USD per generated DALL-E image (default 0.08 = 1024x1024 "hd").
+IMAGE_COST_PER_IMAGE=0.08
+# Monthly USD for a user on the paid per-user residential proxy path (users.proxy_url set).
+PROXY_COST_PER_USER_MONTH=0
+# Monthly USD per shared REGION_PROXIES egress node, split across the users routed through it.
+REGION_PROXY_COST=0
+# Total monthly fixed infra USD (VPS + containers), amortized across active users.
+INFRA_FIXED_MONTHLY=0
+
 # --- Codecov (coverage reporting) ---
 CODECOV_TOKEN=your_codecov_token
 

--- a/compose/local/database/migrations/V20260725032800__add_cost_ledger.sql
+++ b/compose/local/database/migrations/V20260725032800__add_cost_ledger.sql
@@ -1,0 +1,23 @@
+-- Durable, Stripe-joinable cost store behind the margin report (issue #490,
+-- docs/cost-performance-margin-plan.md §A.3(3)). Mirrors the video_credit_ledger pattern:
+-- append-only rows, summed per user/feature/provider. PostHog stays the fast analytics plane;
+-- this table is the exact source of truth (PostHog data can be sampled/retention-limited).
+-- user_id NULL = system/shared cost that is not attributable to one user.
+CREATE TABLE IF NOT EXISTS cost_ledger (
+    id           BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id      INT           NULL,
+    feature      VARCHAR(32)   NOT NULL,  -- content|comment|dm|newsletter|research|image|video|system
+    category     VARCHAR(32)   NOT NULL,  -- llm|media|proxy|email|geocoding|infra|posthog
+    provider     VARCHAR(64)   NULL,      -- openai|anthropic|ollama|runway|perplexity|sendgrid|...
+    model_tier   VARCHAR(64)   NULL,      -- lem-* alias (LLM) or the concrete media model
+    usd          DECIMAL(12,6) NOT NULL,  -- fine precision: cheap tiers round to 0 at fewer decimals
+    qty          DECIMAL(12,4) NULL,      -- tokens / seconds / images / sends / lookups
+    post_id      INT           NULL,
+    task_name    VARCHAR(128)  NULL,
+    incurred_on  DATE          NOT NULL,  -- for daily/monthly rollups
+    created_at   DATETIME      NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_cost_user_day (user_id, incurred_on),
+    KEY idx_cost_feature_day (feature, incurred_on),
+    KEY idx_cost_category_day (category, incurred_on),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/src/cqc_lem/app/generate_variants.py
+++ b/src/cqc_lem/app/generate_variants.py
@@ -100,7 +100,7 @@ def _sign_best_effort(file_path: str) -> None:
 
 
 def _generate_one_variant(idx: int, combo: dict, source_text: str, profile, user_id: Optional[int],
-                          batch_dir: str, batch_id: str) -> dict:
+                          batch_dir: str, batch_id: str, post_id: Optional[int] = None) -> dict:
     image_model = combo.get("image_model", DEFAULT_IMAGE_MODEL)
     video_model = combo.get("video_model", DEFAULT_VIDEO_MODEL)
     ratio = combo.get("ratio", DEFAULT_VIDEO_RATIO)
@@ -142,7 +142,7 @@ def _generate_one_variant(idx: int, combo: dict, source_text: str, profile, user
         result["video_prompt"] = video_prompt
         video_src_url = create_runway_video(
             dest_img, video_prompt, model=video_model, ratio=ratio, duration=duration, seed=seed,
-            user_id=user_id)
+            user_id=user_id, post_id=post_id)
         if video_src_url:
             saved = save_video_url_to_dir(video_src_url, batch_dir)
             vid_name = f"variant_{idx}_video.mp4"
@@ -182,7 +182,8 @@ def generate_media_variants(*, post_id: Optional[int] = None, text: Optional[str
     variants = []
     for idx, combo in enumerate(use_combos):
         try:
-            variants.append(_generate_one_variant(idx, combo, source_text, profile, user_id, batch_dir, batch_id))
+            variants.append(_generate_one_variant(idx, combo, source_text, profile, user_id, batch_dir,
+                                                  batch_id, post_id=post_id))
         except Exception as e:
             log_warning(f"Variant {idx} failed", exc=e)
             variants.append({

--- a/src/cqc_lem/app/generate_variants.py
+++ b/src/cqc_lem/app/generate_variants.py
@@ -141,7 +141,8 @@ def _generate_one_variant(idx: int, combo: dict, source_text: str, profile, user
         video_prompt = get_runway_ml_video_prompt_from_ai(source_text, image_prompt, model=video_model)[:512]
         result["video_prompt"] = video_prompt
         video_src_url = create_runway_video(
-            dest_img, video_prompt, model=video_model, ratio=ratio, duration=duration, seed=seed)
+            dest_img, video_prompt, model=video_model, ratio=ratio, duration=duration, seed=seed,
+            user_id=user_id)
         if video_src_url:
             saved = save_video_url_to_dir(video_src_url, batch_dir)
             vid_name = f"variant_{idx}_video.mp4"

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -208,6 +208,16 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_appreciate_dms',
             'schedule': crontab(hour='8', minute='0')  # Run every day at 8:00 AM
         },
+        'rollup-llm-costs': {
+            'task': 'cqc_lem.app.run_scheduler.auto_rollup_llm_costs',
+            # Daily at 00:20 UTC — collapses the finished day's Redis cost buckets into cost_ledger.
+            'schedule': crontab(hour='0', minute='20')
+        },
+        'accrue-monthly-costs': {
+            'task': 'cqc_lem.app.run_scheduler.auto_accrue_monthly_costs',
+            # 1st of the month at 5:15 AM — proxy + infra accruals for the month just started.
+            'schedule': crontab(hour='5', minute='15', day_of_month='1')
+        },
         'sync-stripe-subscriptions': {
             'task': 'cqc_lem.app.run_scheduler.sync_stripe_subscriptions',
             'schedule': crontab(hour='6', minute='0')  # Daily at 6:00 AM — safety-net for missed webhooks

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -415,10 +415,12 @@ def _generate_video_src(user_id: int, text_content: str, profile, post_id: int =
         if is_premium(model):
             if has_avatar:
                 image_path = generate_post_image(image_prompt, user_id, ratio="9:16")
-                src = create_runway_video(image_path, motion, model=model, ratio="9:16", audio=audio)
+                src = create_runway_video(image_path, motion, model=model, ratio="9:16", audio=audio,
+                                          user_id=user_id, post_id=post_id)
             else:
                 combined = (image_prompt[:700] + " Motion: " + motion)[:980]
-                src = create_runway_video(None, combined, model=model, ratio="9:16", audio=audio)
+                src = create_runway_video(None, combined, model=model, ratio="9:16", audio=audio,
+                                          user_id=user_id, post_id=post_id)
         else:
             # Standard tier still uses the account avatar for the source frame when the user has one
             # (avatar likeness regardless of tier; premium only adds the higher-quality Veo motion +
@@ -427,7 +429,8 @@ def _generate_video_src(user_id: int, text_content: str, profile, post_id: int =
                 image_path = generate_post_image(image_prompt, user_id, ratio=DEFAULT_IMAGE_RATIO)
             else:
                 image_path = generate_flux1_image_from_prompt(image_prompt, ratio=DEFAULT_IMAGE_RATIO)
-            src = create_runway_video(image_path, motion, model=model, ratio=DEFAULT_VIDEO_RATIO)
+            src = create_runway_video(image_path, motion, model=model, ratio=DEFAULT_VIDEO_RATIO,
+                                      user_id=user_id, post_id=post_id)
         if not src:
             raise RuntimeError("no video output")
         myprint(f"_generate_video_src: model={model} audio={audio} -> {str(src)[:60]}")

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1256,5 +1256,90 @@ def auto_changelog_notify(self, hours: int = None):
             f"{result['counts'] or 'nothing to do'}")
 
 
+def _env_rate(name: str) -> float:
+    """A monthly cost rate from the environment. Prices are deployment-specific, so they are never
+    hardcoded — an unset (or malformed) rate is 0 and simply accrues nothing."""
+    try:
+        return float(os.getenv(name, "0") or 0)
+    except ValueError:
+        log_warning(f"Invalid {name} — treating as 0", task_name="auto_accrue_monthly_costs")
+        return 0.0
+
+
+def _monthly_cost_accruals(user_rows: list, proxy_rate: float, region_rate: float,
+                           infra_monthly: float) -> list:
+    """Per-user proxy + infra accruals for one month (issue #490, plan §A.2).
+
+    A user with their own `users.proxy_url` is on the paid per-user path and carries the full
+    PROXY_COST_PER_USER_MONTH; users sharing a regional proxy split REGION_PROXY_COST across
+    everyone routed through that same proxy. Infra is total fixed / active users.
+    """
+    from cqc_lem.utilities.db import CostCategory
+    from cqc_lem.utilities.proxy import resolve_proxy
+
+    accruals = []
+    shared: dict = {}
+    for row in user_rows:
+        if row.get("proxy_url"):
+            if proxy_rate:
+                accruals.append({"user_id": row["user_id"], "category": CostCategory.PROXY,
+                                 "usd": proxy_rate, "provider": "per_user_proxy", "qty": 1})
+            continue
+        resolved = resolve_proxy(None, row.get("country"))
+        if resolved:
+            shared.setdefault(resolved, []).append(row["user_id"])
+
+    if region_rate:
+        for user_ids in shared.values():
+            share = region_rate / len(user_ids)
+            accruals.extend({"user_id": uid, "category": CostCategory.PROXY, "usd": share,
+                             "provider": "region_proxy", "qty": 1} for uid in user_ids)
+
+    if infra_monthly and user_rows:
+        share = infra_monthly / len(user_rows)
+        accruals.extend({"user_id": row["user_id"], "category": CostCategory.INFRA, "usd": share,
+                         "provider": "hosting", "qty": 1} for row in user_rows)
+
+    return [a for a in accruals if a["usd"] > 0]
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True})
+def auto_accrue_monthly_costs(self):
+    """Monthly: accrue the fixed costs no per-call event can capture — each active user's egress
+    proxy and their share of the amortized infra bill — into cost_ledger (issue #490).
+
+    Idempotent per (user, category, month), so a re-run (or a manual catch-up) never double-charges.
+    """
+    from cqc_lem.utilities.db import accrue_monthly_fixed_costs, get_users_proxy_config
+
+    user_ids = get_active_user_ids()
+    if not user_ids:
+        log_info("Monthly cost accrual: no active users", task_name="auto_accrue_monthly_costs")
+        return 0
+
+    period = datetime.now(timezone.utc).date().replace(day=1)
+    accruals = _monthly_cost_accruals(
+        get_users_proxy_config(user_ids),
+        _env_rate("PROXY_COST_PER_USER_MONTH"),
+        _env_rate("REGION_PROXY_COST"),
+        _env_rate("INFRA_FIXED_MONTHLY"),
+    )
+    written = accrue_monthly_fixed_costs(period, accruals)
+    log_info(f"Monthly cost accrual {period}: {written} row(s) for {len(user_ids)} active user(s)",
+             task_name="auto_accrue_monthly_costs")
+    return written
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True})
+def auto_rollup_llm_costs(self):
+    """Daily: collapse yesterday's per-call LLM spend (accumulated in Redis) into cost_ledger —
+    one row per user x feature x tier x day, so the durable table stays small (issue #490)."""
+    from cqc_lem.utilities.observability import flush_llm_cost_rollup
+
+    written = flush_llm_cost_rollup()
+    log_info(f"LLM cost rollup: wrote {written} ledger row(s)", task_name="auto_rollup_llm_costs")
+    return written
+
+
 if __name__ == "__main__":
     print("Process finished")

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -2429,7 +2429,13 @@ def generate_dall_e_image_from_prompt(prompt: str, size: str = "1024x1024"):
         response_format='url'
     )
 
-    if len(response.data) > 0:
+    generated = len(response.data or [])
+    if generated:
+        from cqc_lem.utilities.observability import track_media_cost, image_cost_usd
+        track_media_cost("image", "openai", image_cost_usd(generated), qty=generated,
+                         model="dall-e-3", meta={"size": size})
+
+    if generated > 0:
         return response.data
     else:
         return response.data[0].url

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -2414,7 +2414,7 @@ def get_dall_e_image_prompt_from_ai(post_content: str):
     return content
 
 
-def generate_dall_e_image_from_prompt(prompt: str, size: str = "1024x1024"):
+def generate_dall_e_image_from_prompt(prompt: str, size: str = "1024x1024") -> list:
     """
     Generate an image from the provided prompt using the DALL-E-3 model.
     """
@@ -2435,10 +2435,9 @@ def generate_dall_e_image_from_prompt(prompt: str, size: str = "1024x1024"):
         track_media_cost("image", "openai", image_cost_usd(generated), qty=generated,
                          model="dall-e-3", meta={"size": size})
 
-    if generated > 0:
-        return response.data
-    else:
-        return response.data[0].url
+    # Always the image list: the old empty-data branch indexed data[0] and raised IndexError,
+    # and returning a URL string there made the return type depend on the failure mode.
+    return response.data or []
 
 
 def _profile_visual_context(profile: "LinkedInProfile | None") -> str:

--- a/src/cqc_lem/utilities/ai/video_models.py
+++ b/src/cqc_lem/utilities/ai/video_models.py
@@ -18,6 +18,7 @@ from runwayml import RunwayML
 
 from cqc_lem.utilities.env_constants import DEFAULT_VIDEO_MODEL, DEFAULT_VIDEO_RATIO
 from cqc_lem.utilities.logger import log_debug, log_warning
+from cqc_lem.utilities.observability import track_media_cost
 
 
 @dataclass(frozen=True)
@@ -111,11 +112,15 @@ def create_runway_video(
     duration: Optional[int] = None,
     seed: Optional[int] = None,
     audio: bool = False,
+    user_id: Optional[int] = None,
+    post_id: Optional[int] = None,
 ) -> Optional[str]:
     """Create a video via the RunwayML API and return its URL.
 
     If ``image_path_or_url`` is provided -> image->video; if it's None -> text->video
     (the model must support it). ``audio`` is honored only for audio-capable models.
+    ``user_id``/``post_id`` only attribute the render's cost (issue #490); when omitted the
+    active llm_attribution scope supplies the user.
     Backwards compatible with the old positional ``(image_path, prompt)`` call.
     Raises on creation failure (so callers' fallback can trigger); returns None only
     when the task itself reports FAILED / produces no output.
@@ -163,6 +168,10 @@ def create_runway_video(
         task = runway_client.tasks.retrieve(task_id)
 
     if task.status == "SUCCEEDED" and getattr(task, "output", None):
+        # Only a SUCCEEDED render is billed, so the ledger row goes here and not at creation time.
+        track_media_cost("video", "runway", estimate_video_cost(model, dur), user_id=user_id,
+                         post_id=post_id, qty=dur, model=spec.sdk_model,
+                         meta={"ratio": resolved_ratio, "audio": bool(audio and spec.supports_audio)})
         return task.output[0]
     log_warning(f"Runway task {task_id} ended status={task.status}", ai_model=spec.sdk_model)
     return None

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1,7 +1,7 @@
 import json
 import os
 import uuid
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 from enum import StrEnum
 from typing import Optional
 
@@ -157,6 +157,17 @@ class LeadSignalStatus(StrEnum):
     SENT = 'sent'            # response delivered
     DISMISSED = 'dismissed'  # operator dismissed the signal
     FAILED = 'failed'        # delivery errored
+
+
+class CostCategory(StrEnum):
+    """Kind of spend a `cost_ledger` row records (issue #490, docs/cost-performance-margin-plan.md §A.1)."""
+    LLM = 'llm'              # inference through LiteLLM (rolled up daily per user x feature x tier)
+    MEDIA = 'media'          # video renders (Runway) and generated images (DALL-E)
+    PROXY = 'proxy'          # per-user residential / amortized regional egress proxy
+    INFRA = 'infra'          # VPS + containers, amortized across active users
+    EMAIL = 'email'          # transactional sends
+    GEOCODING = 'geocoding'  # location lookups
+    POSTHOG = 'posthog'      # our own analytics ingestion
 
 
 class LeadStage(StrEnum):
@@ -6249,9 +6260,116 @@ def get_active_avatar(user_id: int) -> Optional[dict]:
         connection.close()
 
 
+# --- Cost ledger writers (issue #490) ------------------------------------------------------
+# Durable, Stripe-joinable spend. PostHog is the fast analytics plane; these rows are the exact
+# source of truth the margin report joins against MRR. High-volume LLM spend arrives here already
+# rolled up (one row per user x feature x tier x day) — see observability.flush_llm_cost_rollup.
+
+
+def insert_cost_ledger_entry(feature: str, category: str, usd: float,
+                             user_id: Optional[int] = None,
+                             provider: Optional[str] = None,
+                             model_tier: Optional[str] = None,
+                             qty: Optional[float] = None,
+                             post_id: Optional[int] = None,
+                             task_name: Optional[str] = None,
+                             incurred_on: Optional[date] = None) -> bool:
+    """Append one spend row. `user_id` None means system/shared cost; `incurred_on` defaults to today (UTC)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            """INSERT INTO cost_ledger
+                   (user_id, feature, category, provider, model_tier, usd, qty, post_id, task_name, incurred_on)
+               VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+            (user_id, str(feature), str(category), provider, model_tier, round(float(usd), 6),
+             round(float(qty), 4) if qty is not None else None,
+             post_id, task_name, incurred_on or datetime.now(timezone.utc).date()),
+        )
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not insert cost_ledger entry ({category}/{feature}) | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def accrue_monthly_fixed_costs(period: date, accruals: list) -> int:
+    """Write this month's fixed-cost accruals (proxy per user, infra amortization) idempotently.
+
+    `period` is the first day of the accrued month and is stored as `incurred_on`; an accrual is a
+    dict of {user_id, category, usd, provider?, feature?, qty?}. A (user_id, category, period)
+    already present is skipped, so re-running the monthly task never double-charges. Returns the
+    number of rows written.
+    """
+    if not accruals:
+        return 0
+
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    written = 0
+    try:
+        for accrual in accruals:
+            user_id = accrual.get("user_id")
+            category = str(accrual.get("category"))
+            # NULL-safe compare: system rows (user_id NULL) must still dedupe against each other.
+            cursor.execute(
+                "SELECT id FROM cost_ledger WHERE user_id <=> %s AND category = %s AND incurred_on = %s LIMIT 1",
+                (user_id, category, period),
+            )
+            if cursor.fetchone():
+                continue
+            cursor.execute(
+                """INSERT INTO cost_ledger
+                       (user_id, feature, category, provider, usd, qty, incurred_on)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s)""",
+                (user_id, str(accrual.get("feature", "system")), category, accrual.get("provider"),
+                 round(float(accrual.get("usd", 0)), 6),
+                 round(float(accrual["qty"]), 4) if accrual.get("qty") is not None else None,
+                 period),
+            )
+            written += 1
+        connection.commit()
+        return written
+    except mysql.connector.Error as err:
+        myprint(f"Could not accrue monthly fixed costs for {period} | Error: {err}")
+        return written
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_users_proxy_config(user_ids: list) -> list:
+    """(user_id, proxy_url, country) for the given users — the inputs proxy.resolve_proxy() needs
+    to decide which egress proxy (and therefore which monthly cost) applies to each user."""
+    if not user_ids:
+        return []
+
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        placeholders = ", ".join(["%s"] * len(user_ids))
+        cursor.execute(
+            f"SELECT id, proxy_url, country FROM users WHERE id IN ({placeholders})",
+            tuple(int(uid) for uid in user_ids),
+        )
+        return [
+            {"user_id": row["id"], "proxy_url": row.get("proxy_url"), "country": row.get("country")}
+            for row in (cursor.fetchall() or [])
+        ]
+    except mysql.connector.Error as err:
+        myprint(f"Could not fetch proxy config for users | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
 # Cost/margin reporting (docs/cost-performance-margin-plan.md §A.3/§C.1). These are READ-ONLY over
-# the `cost_ledger` table; writes/accruals belong to the ledger capture work. Every one degrades to
-# an empty result when the table isn't present yet, so the margin report ships ahead of it.
+# the `cost_ledger` table the writers above fill. Every one degrades to an empty result when the
+# table isn't present yet, so the margin report ships ahead of it.
 
 # Whitelisted rollup dimensions → the cost_ledger column each groups by. Interpolating anything
 # outside this map into the SQL would be an injection vector.

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -4,10 +4,13 @@ import json
 import os
 import time
 from contextlib import contextmanager
+from datetime import date, datetime, timezone
 from functools import wraps
 from typing import Iterator, Optional, Tuple
 
 import posthog
+
+from cqc_lem.utilities.logger import log_warning
 
 posthog.api_key = os.getenv("POSTHOG_API_KEY", "")
 posthog.host = os.getenv("POSTHOG_HOST", "https://us.i.posthog.com")
@@ -230,6 +233,8 @@ def track_llm_call(
     model_tier: Optional[str] = None,
     cached: bool = False,
 ) -> None:
+    cost_usd = 0.0 if cached else estimate_llm_cost_usd(model, prompt_tokens, completion_tokens)
+    tier = model_tier or _model_tier(model)
     posthog.capture(
         distinct_id=str(user_id or "system"),
         event="llm_call",
@@ -240,17 +245,188 @@ def track_llm_call(
             "total_tokens": prompt_tokens + completion_tokens,
             # A cache hit never reached the provider, so it cost nothing — keeping it at the
             # estimated rate would inflate summed spend on every repeated prompt.
-            "cost_usd": 0.0 if cached else estimate_llm_cost_usd(model, prompt_tokens, completion_tokens),
+            "cost_usd": cost_usd,
             "latency_ms": latency_ms,
             "success": success,
             "user_id": user_id,
             # Floor the bucket here, not just in the callers: a PostHog breakdown on `feature`
             # needs every llm_call to carry one, including direct calls that omit it.
             "feature": feature or FEATURE_SYSTEM,
-            "model_tier": model_tier or _model_tier(model),
+            "model_tier": tier,
             "cached": bool(cached),
         },
     )
+    # One ledger row per call would grow unbounded at LEM's call volume, so spend accumulates in a
+    # per-day Redis bucket that the daily rollup task collapses into cost_ledger rows.
+    _accrue_llm_cost(cost_usd, (prompt_tokens or 0) + (completion_tokens or 0),
+                     user_id, feature, tier or model)
+
+
+# --- Durable cost ledger (issue #490) ------------------------------------------------------
+# PostHog answers "what is spend doing?" fast; the cost_ledger table is the exact, Stripe-joinable
+# record the margin report needs. Media lands there per render (spiky, needs per-post accounting);
+# LLM spend is accumulated in Redis and flushed once a day (one row per user x feature x tier x day)
+# so a high-volume table stays small.
+
+# Public list price for one DALL-E 3 1024x1024 "hd" image; override with IMAGE_COST_PER_IMAGE.
+_DEFAULT_IMAGE_COST_USD = 0.08
+
+_LLM_ROLLUP_PREFIX = "lem:cost:llm:"
+_LLM_ROLLUP_QTY_SUFFIX = ":qty"
+# Long enough that a few failed flushes can still be recovered by a later run.
+_LLM_ROLLUP_TTL_SECONDS = 14 * 24 * 60 * 60
+
+
+def image_cost_usd(count: int = 1) -> float:
+    """USD for `count` generated images at the configured per-image rate (IMAGE_COST_PER_IMAGE)."""
+    try:
+        rate = float(os.getenv("IMAGE_COST_PER_IMAGE") or _DEFAULT_IMAGE_COST_USD)
+    except (TypeError, ValueError):
+        rate = _DEFAULT_IMAGE_COST_USD
+    return rate * max(0, int(count or 0))
+
+
+def _write_cost_ledger(**kwargs) -> None:
+    """Best-effort durable write — cost tracking must never break the work that incurred the cost."""
+    try:
+        from cqc_lem.utilities.db import insert_cost_ledger_entry
+        insert_cost_ledger_entry(**kwargs)
+    except Exception as e:
+        log_warning("Could not write cost_ledger entry", exc=e)
+
+
+def track_media_cost(kind: str, provider: str, usd: float, user_id: Optional[int] = None,
+                     post_id: Optional[int] = None, feature: str = FEATURE_CONTENT,
+                     qty: Optional[float] = None, model: Optional[str] = None,
+                     meta: Optional[dict] = None) -> None:
+    """Record one media render's cost: a PostHog `media_cost` event AND a durable cost_ledger row.
+
+    `kind` is video|image, `qty` the billed units (seconds rendered, images generated). When the
+    caller can't supply `user_id`/`feature`, the active llm_attribution scope fills them in.
+    """
+    scope_user_id, scope_feature = current_llm_attribution()
+    user_id = user_id if user_id is not None else scope_user_id
+    feature = feature or scope_feature or FEATURE_CONTENT
+    usd = float(usd or 0.0)
+
+    posthog.capture(
+        distinct_id=str(user_id or "system"),
+        event="media_cost",
+        properties={
+            "kind": kind,
+            "provider": provider,
+            "model": model,
+            "cost_usd": usd,
+            "qty": qty,
+            "user_id": user_id,
+            "post_id": post_id,
+            "feature": feature,
+            **(meta or {}),
+        },
+    )
+    _write_cost_ledger(feature=feature, category="media", usd=usd, user_id=user_id,
+                       provider=provider, model_tier=model, qty=qty, post_id=post_id,
+                       task_name=_current_task_context()[0])
+
+
+def _rollup_field(user_id: Optional[int], feature: Optional[str], model_tier: Optional[str]) -> str:
+    return f"{user_id if user_id is not None else ''}|{feature or FEATURE_SYSTEM}|{model_tier or ''}"
+
+
+def _accrue_llm_cost(usd: float, tokens: int, user_id: Optional[int], feature: Optional[str],
+                     model_tier: Optional[str]) -> None:
+    """Add one call's spend to today's Redis rollup bucket (flushed to cost_ledger daily).
+
+    Silent no-op without Redis — PostHog still has the per-call event, and the ledger keeps only
+    the durable daily aggregate, so a missing bucket costs precision, never correctness elsewhere.
+    """
+    if usd <= 0:
+        return
+    # Same handle the 429 breaker and reply-sweep cadence keys use (Redis is where LEM's runtime
+    # state lives, so a rollup bucket survives deploys).
+    from cqc_lem.utilities.linkedin.rate_limit import _redis_client
+    client = _redis_client()
+    if client is None:
+        return
+    day = datetime.now(timezone.utc).date().isoformat()
+    key = f"{_LLM_ROLLUP_PREFIX}{day}"
+    field = _rollup_field(user_id, feature, model_tier)
+    try:
+        client.hincrbyfloat(key, field, usd)
+        client.expire(key, _LLM_ROLLUP_TTL_SECONDS)
+        if tokens:
+            client.hincrbyfloat(f"{key}{_LLM_ROLLUP_QTY_SUFFIX}", field, tokens)
+            client.expire(f"{key}{_LLM_ROLLUP_QTY_SUFFIX}", _LLM_ROLLUP_TTL_SECONDS)
+    except Exception as e:
+        log_warning("Could not accrue LLM cost rollup", exc=e)
+
+
+def _as_text(value) -> str:
+    return value.decode() if isinstance(value, bytes) else str(value)
+
+
+def flush_llm_cost_rollup(today: Optional[str] = None) -> int:
+    """Write every FINISHED day's accumulated LLM spend into cost_ledger, one row per
+    user x feature x tier x day, then drop that day's Redis bucket. Returns rows written.
+
+    `today` is an ISO date string (default: today UTC); its bucket — and any later one — is left
+    alone because it is still filling. Every OLDER bucket is flushed, so a day missed by a failed
+    run is picked up by the next one rather than lost.
+    """
+    from cqc_lem.utilities.linkedin.rate_limit import _redis_client
+    client = _redis_client()
+    if client is None:
+        return 0
+
+    today = today or datetime.now(timezone.utc).date().isoformat()
+    written = 0
+    try:
+        keys = [_as_text(k) for k in client.scan_iter(match=f"{_LLM_ROLLUP_PREFIX}*")]
+    except Exception as e:
+        log_warning("Could not scan LLM cost rollup buckets", exc=e)
+        return 0
+
+    for key in sorted(k for k in keys if not k.endswith(_LLM_ROLLUP_QTY_SUFFIX)):
+        day = key[len(_LLM_ROLLUP_PREFIX):]
+        try:
+            incurred_on = date.fromisoformat(day)
+        except ValueError:
+            continue
+        if day >= today:
+            continue
+        try:
+            costs = client.hgetall(key) or {}
+            quantities = client.hgetall(f"{key}{_LLM_ROLLUP_QTY_SUFFIX}") or {}
+        except Exception as e:
+            log_warning(f"Could not read LLM cost rollup bucket {key}", exc=e)
+            continue
+
+        for raw_field, raw_usd in costs.items():
+            field = _as_text(raw_field)
+            try:
+                usd = float(_as_text(raw_usd))
+            except ValueError:
+                continue
+            user_part, _, rest = field.partition("|")
+            feature, _, model_tier = rest.partition("|")
+            tokens = quantities.get(raw_field)
+            _write_cost_ledger(
+                feature=feature or FEATURE_SYSTEM,
+                category="llm",
+                usd=usd,
+                user_id=int(user_part) if user_part else None,
+                provider="litellm",
+                model_tier=model_tier or None,
+                qty=float(_as_text(tokens)) if tokens is not None else None,
+                incurred_on=incurred_on,
+            )
+            written += 1
+        try:
+            client.delete(key, f"{key}{_LLM_ROLLUP_QTY_SUFFIX}")
+        except Exception as e:
+            log_warning(f"Could not clear LLM cost rollup bucket {key}", exc=e)
+
+    return written
 
 
 def track_post_outcome(

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -303,11 +303,18 @@ def track_media_cost(kind: str, provider: str, usd: float, user_id: Optional[int
 
     `kind` is video|image, `qty` the billed units (seconds rendered, images generated). When the
     caller can't supply `user_id`/`feature`, the active llm_attribution scope fills them in.
+
+    A non-positive cost writes nothing — an unpriced model or a rate deliberately zeroed out
+    (IMAGE_COST_PER_IMAGE=0) should stay silent rather than fill the ledger with $0 rows, matching
+    the LLM accrual and the monthly fixed-cost accrual.
     """
+    usd = float(usd or 0.0)
+    if usd <= 0:
+        return
+
     scope_user_id, scope_feature = current_llm_attribution()
     user_id = user_id if user_id is not None else scope_user_id
     feature = feature or scope_feature or FEATURE_CONTENT
-    usd = float(usd or 0.0)
 
     posthog.capture(
         distinct_id=str(user_id or "system"),

--- a/tests/integration/test_cost_ledger.py
+++ b/tests/integration/test_cost_ledger.py
@@ -1,0 +1,161 @@
+"""Integration test for the cost ledger (#490).
+
+Drives every writer that feeds `cost_ledger` — a media render, the daily LLM rollup, and the
+monthly proxy/infra accrual — into one stateful fake `cost_ledger` table, then reads it back
+through the read-only accessors the margin report uses (`get_cost_rollup` / `get_user_cost` /
+`get_daily_cost_totals`, #491). That is the acceptance criterion ("media/proxy/infra costs land in
+the ledger") proven end to end, without needing a live MySQL container.
+"""
+from datetime import date
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.integration
+
+_DB = "cqc_lem.utilities.db"
+_OBS = "cqc_lem.utilities.observability"
+_REDIS = "cqc_lem.utilities.linkedin.rate_limit._redis_client"
+
+_INSERT_COLUMNS = ("user_id", "feature", "category", "provider", "model_tier", "usd", "qty",
+                   "post_id", "task_name", "incurred_on")
+_ACCRUAL_COLUMNS = ("user_id", "feature", "category", "provider", "usd", "qty", "incurred_on")
+
+# The reporting window every read below uses. Media rows are stamped with the real UTC "today", so
+# an open-ended window keeps the test independent of the day it runs on.
+_FROM, _TO = date(2000, 1, 1), date(2100, 1, 1)
+
+# `rollup_key` is aliased in SQL — map it back to the row field each dimension groups by.
+_ROLLUP_KEYS = {"feature": "feature", "category": "category", "provider": "provider",
+                "model_tier": "model_tier", "user_id": "user_id", "task_name": "task_name"}
+
+
+class _FakeCursor:
+    """Minimal MySQL-ish cursor over an in-memory `cost_ledger` store."""
+
+    def __init__(self, rows):
+        self.rows = rows
+        self._result = []
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        params = list(params or ())
+        if s.startswith("INSERT INTO cost_ledger"):
+            columns = _INSERT_COLUMNS if "model_tier" in s else _ACCRUAL_COLUMNS
+            self.rows.append(dict(zip(columns, params)))
+        elif s.startswith("SELECT id FROM cost_ledger"):
+            user_id, category, period = params
+            self._result = [(1,) for r in self.rows
+                            if r["user_id"] == user_id and r["category"] == category
+                            and r["incurred_on"] == period]
+        elif "GROUP BY rollup_key" in s:
+            matched = self._between(self.rows, params[0], params[1])
+            if "user_id = %s" in s:
+                only_user = params[2]
+                matched = [r for r in matched if r["user_id"] == only_user]
+            column = next(c for c in _ROLLUP_KEYS if f"CAST({c} AS CHAR)" in s)
+            totals = {}
+            for row in matched:
+                key = row.get(_ROLLUP_KEYS[column])
+                totals[str(key) if key is not None else "unknown"] = (
+                    totals.get(str(key) if key is not None else "unknown", 0.0) + row["usd"])
+            self._result = list(totals.items())
+        elif "GROUP BY incurred_on" in s:
+            matched = self._between(self.rows, params[0], params[1])
+            totals = {}
+            for row in matched:
+                totals[row["incurred_on"]] = totals.get(row["incurred_on"], 0.0) + row["usd"]
+            self._result = sorted(totals.items())
+        else:
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    @staticmethod
+    def _between(rows, start, end):
+        return [r for r in rows if start <= r["incurred_on"] <= end]
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return self._result
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def ledger():
+    rows = []
+    connection = MagicMock()
+    connection.cursor.return_value = _FakeCursor(rows)
+    with patch(f"{_DB}.get_db_connection", return_value=connection):
+        yield rows
+
+
+def _redis_with_bucket():
+    client = MagicMock()
+    client.scan_iter.return_value = iter([b"lem:cost:llm:2026-07-24", b"lem:cost:llm:2026-07-24:qty"])
+    client.hgetall.side_effect = lambda key: (
+        {b"1|content|lem-complex": b"0.0105", b"2|comment|lem-simple": b"0.0004"}
+        if not key.endswith(":qty") else {b"1|content|lem-complex": b"1500"}
+    )
+    return client
+
+
+class TestCostLedgerPipeline:
+    def test_media_llm_and_fixed_costs_all_land_and_roll_up(self, ledger):
+        from cqc_lem.app.run_scheduler import _monthly_cost_accruals
+        from cqc_lem.utilities.db import (accrue_monthly_fixed_costs, get_cost_rollup,
+                                          get_user_cost)
+        from cqc_lem.utilities.observability import flush_llm_cost_rollup, track_media_cost
+
+        # 1. A video render for user 1 (variable, per-post).
+        with patch(f"{_OBS}.posthog"):
+            track_media_cost("video", "runway", 0.25, user_id=1, post_id=42, qty=5,
+                             model="gen4_turbo")
+
+        # 2. Yesterday's accumulated LLM spend, collapsed to one row per user x feature x tier.
+        with patch(_REDIS, return_value=_redis_with_bucket()):
+            assert flush_llm_cost_rollup(today="2026-07-25") == 2
+
+        # 3. This month's fixed costs: user 1 on a paid proxy, infra split across both users.
+        period = date(2026, 7, 1)
+        users = [{"user_id": 1, "proxy_url": "http://paid:3128", "country": "US"},
+                 {"user_id": 2, "proxy_url": None, "country": None}]
+        with patch("cqc_lem.utilities.proxy.resolve_proxy", return_value=None):
+            accruals = _monthly_cost_accruals(users, proxy_rate=12.0, region_rate=0.0,
+                                              infra_monthly=40.0)
+        assert accrue_monthly_fixed_costs(period, accruals) == 3
+        # Re-running the monthly task must not double-charge.
+        assert accrue_monthly_fixed_costs(period, accruals) == 0
+
+        assert len(ledger) == 6
+        media_row = next(r for r in ledger if r["category"] == "media")
+        assert media_row["qty"] == 5 and media_row["post_id"] == 42  # seconds rendered
+
+        by_category = get_cost_rollup(_FROM, _TO, group_by="category")
+        assert set(by_category) == {"media", "llm", "proxy", "infra"}
+        assert by_category["proxy"] == 12.0
+        assert by_category["infra"] == 40.0          # 20 + 20, fully amortized
+        assert by_category["llm"] == pytest.approx(0.0109)
+
+        # user 1: 0.25 media + 0.0105 llm + 12 proxy + 20 infra
+        assert sum(get_user_cost(1, _FROM, _TO).values()) == pytest.approx(32.2605)
+        assert sum(get_user_cost(2, _FROM, _TO).values()) == pytest.approx(20.0004)
+
+        by_feature = get_cost_rollup(_FROM, _TO, group_by="feature")
+        assert by_feature["content"] == pytest.approx(0.2605)
+        assert by_feature["system"] == pytest.approx(52.0)   # proxy + infra accruals
+
+    def test_reads_respect_the_reporting_window(self, ledger):
+        from cqc_lem.utilities.db import (get_daily_cost_totals, get_user_cost,
+                                          insert_cost_ledger_entry)
+
+        insert_cost_ledger_entry("content", "media", 1.0, user_id=1, incurred_on=date(2026, 6, 30))
+        insert_cost_ledger_entry("content", "media", 2.0, user_id=1, incurred_on=date(2026, 7, 15))
+        insert_cost_ledger_entry("content", "media", 4.0, user_id=1, incurred_on=date(2026, 8, 1))
+
+        assert get_user_cost(1, date(2026, 7, 1), date(2026, 7, 31)) == {"media": 2.0}
+        assert get_user_cost(1, _FROM, _TO) == {"media": 7.0}
+        # Days with no rows stay absent rather than reading as a fabricated $0 baseline.
+        assert get_daily_cost_totals(date(2026, 7, 1), date(2026, 7, 31)) == {"2026-07-15": 2.0}

--- a/tests/unit/app/test_generate_variants.py
+++ b/tests/unit/app/test_generate_variants.py
@@ -82,6 +82,23 @@ class TestGenerateMediaVariants:
         assert payload["variants"][1]["image_url"] is not None
 
 
+    def test_render_cost_is_attributed_to_user_and_post(self, tmp_path):
+        """Issue #490: the ledger row must join back to the post the render was for."""
+        img = _make_image(tmp_path)
+        with patch("cqc_lem.app.generate_variants.assets_dir", str(tmp_path)), \
+             patch("cqc_lem.app.generate_variants.get_post_content", return_value="source text"), \
+             patch("cqc_lem.app.generate_variants.load_profile_for_user", return_value=None), \
+             patch("cqc_lem.app.generate_variants.get_flux_image_prompt_from_ai", return_value="p"), \
+             patch("cqc_lem.app.generate_variants.generate_post_image", return_value=img), \
+             patch("cqc_lem.app.generate_variants.get_runway_ml_video_prompt_from_ai", return_value="m"), \
+             patch("cqc_lem.app.generate_variants.create_runway_video", return_value=None) as runway:
+            from cqc_lem.app.generate_variants import generate_media_variants
+            generate_media_variants(post_id=77, user_id=5, combos=[{}], timestamp=1)
+
+        assert runway.call_args[1]["user_id"] == 5
+        assert runway.call_args[1]["post_id"] == 77
+
+
 class TestComboKey:
     def test_stable_key_encodes_models_and_ratio(self):
         from cqc_lem.app.generate_variants import combo_key

--- a/tests/unit/app/test_monthly_cost_accrual.py
+++ b/tests/unit/app/test_monthly_cost_accrual.py
@@ -1,0 +1,101 @@
+"""Unit tests for the monthly proxy/infra accrual + daily LLM rollup tasks (issue #490)."""
+
+from datetime import datetime, timezone
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_SCHED = "cqc_lem.app.run_scheduler"
+
+
+def _users(*rows):
+    return [{"user_id": uid, "proxy_url": proxy, "country": country} for uid, proxy, country in rows]
+
+
+class TestMonthlyCostAccruals:
+    def test_per_user_proxy_charges_full_rate(self):
+        from cqc_lem.app.run_scheduler import _monthly_cost_accruals
+        got = _monthly_cost_accruals(_users((1, "http://paid:3128", "US")), 12.0, 30.0, 0)
+        assert got == [{"user_id": 1, "category": "proxy", "usd": 12.0,
+                        "provider": "per_user_proxy", "qty": 1}]
+
+    def test_regional_proxy_cost_is_split_across_its_users(self):
+        from cqc_lem.app.run_scheduler import _monthly_cost_accruals
+        with patch("cqc_lem.utilities.proxy.resolve_proxy",
+                   side_effect=["http://us:3128", "http://us:3128", "http://gb:3128"]):
+            got = _monthly_cost_accruals(_users((1, None, "US"), (2, None, "US"), (3, None, "GB")), 0, 30.0, 0)
+
+        by_user = {a["user_id"]: a["usd"] for a in got}
+        assert by_user == {1: 15.0, 2: 15.0, 3: 30.0}
+        assert {a["provider"] for a in got} == {"region_proxy"}
+
+    def test_users_without_any_proxy_accrue_nothing(self):
+        from cqc_lem.app.run_scheduler import _monthly_cost_accruals
+        with patch("cqc_lem.utilities.proxy.resolve_proxy", return_value=None):
+            assert _monthly_cost_accruals(_users((1, None, None)), 12.0, 30.0, 0) == []
+
+    def test_infra_is_amortized_across_active_users(self):
+        from cqc_lem.app.run_scheduler import _monthly_cost_accruals
+        with patch("cqc_lem.utilities.proxy.resolve_proxy", return_value=None):
+            got = _monthly_cost_accruals(_users((1, None, None), (2, None, None), (3, None, None)), 0, 0, 60.0)
+
+        assert [a["usd"] for a in got] == [20.0, 20.0, 20.0]
+        assert {a["category"] for a in got} == {"infra"}
+
+    def test_unset_rates_write_nothing(self):
+        """No prices configured (the default) must not litter the ledger with $0 rows."""
+        from cqc_lem.app.run_scheduler import _monthly_cost_accruals
+        assert _monthly_cost_accruals(_users((1, "http://paid:3128", "US")), 0, 0, 0) == []
+
+
+class TestEnvRate:
+    def test_missing_and_malformed_are_zero(self, monkeypatch):
+        from cqc_lem.app.run_scheduler import _env_rate
+        monkeypatch.delenv("PROXY_COST_PER_USER_MONTH", raising=False)
+        assert _env_rate("PROXY_COST_PER_USER_MONTH") == 0.0
+        monkeypatch.setenv("PROXY_COST_PER_USER_MONTH", "cheap")
+        assert _env_rate("PROXY_COST_PER_USER_MONTH") == 0.0
+        monkeypatch.setenv("PROXY_COST_PER_USER_MONTH", "7.5")
+        assert _env_rate("PROXY_COST_PER_USER_MONTH") == 7.5
+
+
+class TestAutoAccrueMonthlyCosts:
+    def test_accrues_for_the_current_month(self, monkeypatch):
+        monkeypatch.setenv("INFRA_FIXED_MONTHLY", "40")
+        monkeypatch.setenv("PROXY_COST_PER_USER_MONTH", "0")
+        monkeypatch.setenv("REGION_PROXY_COST", "0")
+        with patch(f"{_SCHED}.get_active_user_ids", return_value=[1, 2]), \
+             patch("cqc_lem.utilities.db.get_users_proxy_config",
+                   return_value=_users((1, None, None), (2, None, None))), \
+             patch("cqc_lem.utilities.db.accrue_monthly_fixed_costs", return_value=2) as accrue:
+            from cqc_lem.app.run_scheduler import auto_accrue_monthly_costs
+            assert auto_accrue_monthly_costs.run() == 2
+
+        period, accruals = accrue.call_args[0]
+        assert period == datetime.now(timezone.utc).date().replace(day=1)
+        assert [a["usd"] for a in accruals] == [20.0, 20.0]
+
+    def test_no_active_users_writes_nothing(self):
+        with patch(f"{_SCHED}.get_active_user_ids", return_value=[]), \
+             patch("cqc_lem.utilities.db.accrue_monthly_fixed_costs") as accrue:
+            from cqc_lem.app.run_scheduler import auto_accrue_monthly_costs
+            assert auto_accrue_monthly_costs.run() == 0
+        accrue.assert_not_called()
+
+
+class TestAutoRollupLlmCosts:
+    def test_delegates_to_the_flush(self):
+        with patch("cqc_lem.utilities.observability.flush_llm_cost_rollup", return_value=7) as flush:
+            from cqc_lem.app.run_scheduler import auto_rollup_llm_costs
+            assert auto_rollup_llm_costs.run() == 7
+        flush.assert_called_once_with()
+
+
+class TestBeatSchedule:
+    def test_cost_tasks_are_scheduled(self):
+        from cqc_lem.app.my_celery import app
+        schedule = app.conf.beat_schedule
+        assert schedule["rollup-llm-costs"]["task"] == f"{_SCHED}.auto_rollup_llm_costs"
+        assert schedule["accrue-monthly-costs"]["task"] == f"{_SCHED}.auto_accrue_monthly_costs"

--- a/tests/unit/utilities/ai/test_video_models.py
+++ b/tests/unit/utilities/ai/test_video_models.py
@@ -1,8 +1,11 @@
 """Unit tests for the RunwayML video-model abstraction."""
 
 import pytest
+from unittest.mock import patch
 
 pytestmark = pytest.mark.unit
+
+_VM = "cqc_lem.utilities.ai.video_models"
 
 
 class TestEstimateAndResolve:
@@ -57,6 +60,25 @@ class TestCreateRunwayVideo:
         from cqc_lem.utilities.ai.video_models import create_runway_video
         with pytest.raises(ValueError):
             create_runway_video("https://img/base.png", "x", model="does-not-exist")
+
+    def test_successful_render_records_its_cost(self, mock_runwayml):
+        """Issue #490: a render is the spikiest variable cost — it must land in the ledger."""
+        from cqc_lem.utilities.ai.video_models import create_runway_video
+        with patch(f"{_VM}.track_media_cost") as track:
+            create_runway_video("https://img/base.png", "pan", model="gen4.5", duration=10,
+                                user_id=3, post_id=17)
+
+        args, kwargs = track.call_args
+        assert args == ("video", "runway", 1.2)  # 10s x $0.12/s
+        assert kwargs["user_id"] == 3 and kwargs["post_id"] == 17
+        assert kwargs["qty"] == 10 and kwargs["model"] == "gen4.5"
+
+    def test_failed_render_records_no_cost(self, mock_runwayml):
+        from cqc_lem.utilities.ai.video_models import create_runway_video
+        mock_runwayml["task"].status = "FAILED"
+        with patch(f"{_VM}.track_media_cost") as track:
+            create_runway_video("https://img/base.png", "x", model="gen4_turbo")
+        track.assert_not_called()
 
     def test_typeerror_retry_drops_optional_kwargs(self, mock_runwayml):
         from cqc_lem.utilities.ai.video_models import create_runway_video

--- a/tests/unit/utilities/test_cost_tracking.py
+++ b/tests/unit/utilities/test_cost_tracking.py
@@ -1,0 +1,169 @@
+"""Unit tests for media-cost tracking and the daily LLM cost rollup (issue #490)."""
+
+from datetime import date
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.observability"
+_REDIS = "cqc_lem.utilities.linkedin.rate_limit._redis_client"
+
+
+class TestImageCostUsd:
+    def test_defaults_to_list_price(self, monkeypatch):
+        monkeypatch.delenv("IMAGE_COST_PER_IMAGE", raising=False)
+        from cqc_lem.utilities.observability import image_cost_usd
+        assert image_cost_usd(1) == 0.08
+        assert image_cost_usd(3) == pytest.approx(0.24)
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_COST_PER_IMAGE", "0.12")
+        from cqc_lem.utilities.observability import image_cost_usd
+        assert image_cost_usd(2) == pytest.approx(0.24)
+
+    def test_malformed_rate_falls_back(self, monkeypatch):
+        monkeypatch.setenv("IMAGE_COST_PER_IMAGE", "free")
+        from cqc_lem.utilities.observability import image_cost_usd
+        assert image_cost_usd(1) == 0.08
+
+
+class TestTrackMediaCost:
+    def test_emits_event_and_ledger_row(self):
+        with patch(f"{_MOD}.posthog") as mock_ph, patch(f"{_MOD}._write_cost_ledger") as ledger:
+            from cqc_lem.utilities.observability import track_media_cost
+            track_media_cost("video", "runway", 0.25, user_id=3, post_id=9, qty=5,
+                             model="gen4_turbo", meta={"ratio": "960:960"})
+
+        props = mock_ph.capture.call_args[1]["properties"]
+        assert mock_ph.capture.call_args[1]["event"] == "media_cost"
+        assert props["kind"] == "video" and props["cost_usd"] == 0.25 and props["qty"] == 5
+        assert props["ratio"] == "960:960"
+
+        row = ledger.call_args[1]
+        assert row["category"] == "media" and row["provider"] == "runway"
+        assert row["user_id"] == 3 and row["post_id"] == 9 and row["model_tier"] == "gen4_turbo"
+        assert row["feature"] == "content"
+
+    def test_falls_back_to_attribution_scope(self):
+        from cqc_lem.utilities.observability import llm_attribution, track_media_cost, FEATURE_NEWSLETTER
+        with patch(f"{_MOD}.posthog"), patch(f"{_MOD}._write_cost_ledger") as ledger:
+            with llm_attribution(user_id=12, feature=FEATURE_NEWSLETTER):
+                track_media_cost("image", "openai", 0.08, qty=1, model="dall-e-3", feature=None)
+
+        row = ledger.call_args[1]
+        assert row["user_id"] == 12 and row["feature"] == "newsletter"
+
+    def test_ledger_failure_never_propagates(self):
+        with patch(f"{_MOD}.posthog"), \
+             patch("cqc_lem.utilities.db.insert_cost_ledger_entry", side_effect=RuntimeError("db down")):
+            from cqc_lem.utilities.observability import track_media_cost
+            track_media_cost("image", "openai", 0.08)  # must not raise
+
+
+class TestDallEImageCost:
+    def test_generated_image_is_billed_per_image(self):
+        from types import SimpleNamespace
+        response = SimpleNamespace(data=[SimpleNamespace(url="https://img/1.png")])
+        with patch("cqc_lem.utilities.ai.client.client.images.generate", return_value=response), \
+             patch(f"{_MOD}.track_media_cost") as track:
+            from cqc_lem.utilities.ai.ai_helper import generate_dall_e_image_from_prompt
+            assert generate_dall_e_image_from_prompt("a robot") == response.data
+
+        args, kwargs = track.call_args
+        assert args[0] == "image" and args[1] == "openai" and args[2] == pytest.approx(0.08)
+        assert kwargs["qty"] == 1 and kwargs["model"] == "dall-e-3"
+
+
+class TestLlmRollupAccrual:
+    def test_track_llm_call_accrues_to_todays_bucket(self):
+        client = MagicMock()
+        with patch(f"{_MOD}.posthog"), patch(_REDIS, return_value=client):
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="lem-complex", prompt_tokens=1000, completion_tokens=500,
+                           latency_ms=10, user_id=4, feature="content")
+
+        key, field, usd = client.hincrbyfloat.call_args_list[0][0]
+        assert key.startswith("lem:cost:llm:")
+        assert field == "4|content|lem-complex"
+        assert usd == pytest.approx(0.003 + 0.0075)
+        # tokens accrue to the parallel qty bucket
+        qty_call = client.hincrbyfloat.call_args_list[1][0]
+        assert qty_call[0].endswith(":qty") and qty_call[2] == 1500
+
+    def test_cache_hit_costs_nothing_and_is_not_accrued(self):
+        client = MagicMock()
+        with patch(f"{_MOD}.posthog"), patch(_REDIS, return_value=client):
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="lem-complex", prompt_tokens=1000, completion_tokens=500,
+                           latency_ms=10, cached=True)
+        client.hincrbyfloat.assert_not_called()
+
+    def test_no_redis_is_a_noop(self):
+        with patch(f"{_MOD}.posthog"), patch(_REDIS, return_value=None):
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="lem-simple", prompt_tokens=10, completion_tokens=10, latency_ms=5)
+
+    def test_redis_error_does_not_break_the_call(self):
+        client = MagicMock()
+        client.hincrbyfloat.side_effect = RuntimeError("redis gone")
+        with patch(f"{_MOD}.posthog"), patch(_REDIS, return_value=client):
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="lem-simple", prompt_tokens=10, completion_tokens=10, latency_ms=5)
+
+
+class TestFlushLlmCostRollup:
+    def _client(self, keys, costs, quantities):
+        client = MagicMock()
+        client.scan_iter.return_value = iter(keys)
+        client.hgetall.side_effect = lambda k: costs if not k.endswith(":qty") else quantities
+        return client
+
+    def test_writes_one_row_per_bucket_field_and_clears_the_key(self):
+        client = self._client(
+            [b"lem:cost:llm:2026-07-24", b"lem:cost:llm:2026-07-24:qty"],
+            {b"4|content|lem-complex": b"0.0105", b"|system|lem-simple": b"0.0002"},
+            {b"4|content|lem-complex": b"1500"},
+        )
+        with patch(_REDIS, return_value=client), patch(f"{_MOD}._write_cost_ledger") as ledger:
+            from cqc_lem.utilities.observability import flush_llm_cost_rollup
+            assert flush_llm_cost_rollup(today="2026-07-25") == 2
+
+        rows = {c[1]["model_tier"]: c[1] for c in ledger.call_args_list}
+        assert rows["lem-complex"]["user_id"] == 4
+        assert rows["lem-complex"]["feature"] == "content"
+        assert rows["lem-complex"]["qty"] == 1500
+        assert rows["lem-complex"]["incurred_on"] == date(2026, 7, 24)
+        assert rows["lem-complex"]["category"] == "llm"
+        # a system-wide call has no user and no token bucket entry
+        assert rows["lem-simple"]["user_id"] is None and rows["lem-simple"]["qty"] is None
+        client.delete.assert_called_once_with("lem:cost:llm:2026-07-24", "lem:cost:llm:2026-07-24:qty")
+
+    def test_todays_bucket_is_left_alone(self):
+        client = self._client([b"lem:cost:llm:2026-07-25"], {b"1|dm|lem-medium": b"0.01"}, {})
+        with patch(_REDIS, return_value=client), patch(f"{_MOD}._write_cost_ledger") as ledger:
+            from cqc_lem.utilities.observability import flush_llm_cost_rollup
+            assert flush_llm_cost_rollup(today="2026-07-25") == 0
+        ledger.assert_not_called()
+        client.delete.assert_not_called()
+
+    def test_ignores_malformed_keys_and_values(self):
+        client = self._client([b"lem:cost:llm:not-a-date", b"lem:cost:llm:2026-07-01"],
+                              {b"1|dm|lem-medium": b"NaN-ish"}, {})
+        with patch(_REDIS, return_value=client), patch(f"{_MOD}._write_cost_ledger") as ledger:
+            from cqc_lem.utilities.observability import flush_llm_cost_rollup
+            assert flush_llm_cost_rollup(today="2026-07-25") == 0
+        ledger.assert_not_called()
+
+    def test_no_redis_returns_zero(self):
+        with patch(_REDIS, return_value=None):
+            from cqc_lem.utilities.observability import flush_llm_cost_rollup
+            assert flush_llm_cost_rollup() == 0
+
+    def test_scan_error_returns_zero(self):
+        client = MagicMock()
+        client.scan_iter.side_effect = RuntimeError("redis gone")
+        with patch(_REDIS, return_value=client):
+            from cqc_lem.utilities.observability import flush_llm_cost_rollup
+            assert flush_llm_cost_rollup() == 0

--- a/tests/unit/utilities/test_cost_tracking.py
+++ b/tests/unit/utilities/test_cost_tracking.py
@@ -55,6 +55,15 @@ class TestTrackMediaCost:
         row = ledger.call_args[1]
         assert row["user_id"] == 12 and row["feature"] == "newsletter"
 
+    def test_zero_cost_writes_nothing(self):
+        """An unpriced model / a zeroed rate must not produce $0 ledger rows or events."""
+        with patch(f"{_MOD}.posthog") as mock_ph, patch(f"{_MOD}._write_cost_ledger") as ledger:
+            from cqc_lem.utilities.observability import track_media_cost
+            track_media_cost("video", "runway", 0.0, user_id=3, qty=5, model="unpriced-model")
+
+        mock_ph.capture.assert_not_called()
+        ledger.assert_not_called()
+
     def test_ledger_failure_never_propagates(self):
         with patch(f"{_MOD}.posthog"), \
              patch("cqc_lem.utilities.db.insert_cost_ledger_entry", side_effect=RuntimeError("db down")):
@@ -74,6 +83,17 @@ class TestDallEImageCost:
         args, kwargs = track.call_args
         assert args[0] == "image" and args[1] == "openai" and args[2] == pytest.approx(0.08)
         assert kwargs["qty"] == 1 and kwargs["model"] == "dall-e-3"
+
+    @pytest.mark.parametrize("data", [[], None])
+    def test_no_image_returns_empty_list_and_bills_nothing(self, data):
+        from types import SimpleNamespace
+        response = SimpleNamespace(data=data)
+        with patch("cqc_lem.utilities.ai.client.client.images.generate", return_value=response), \
+             patch(f"{_MOD}.track_media_cost") as track:
+            from cqc_lem.utilities.ai.ai_helper import generate_dall_e_image_from_prompt
+            assert generate_dall_e_image_from_prompt("a robot") == []
+
+        track.assert_not_called()
 
 
 class TestLlmRollupAccrual:

--- a/tests/unit/utilities/test_db_cost_ledger_writes.py
+++ b/tests/unit/utilities/test_db_cost_ledger_writes.py
@@ -1,0 +1,128 @@
+"""Unit tests for the cost_ledger WRITE helpers (issue #490).
+
+The read-only accessors the margin report uses live in test_db_cost_ledger.py.
+"""
+
+from datetime import date
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(fetch_row=None, fetchall=None):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.fetchone.return_value = fetch_row
+    cur.fetchall.return_value = fetchall or []
+    cur.rowcount = 1
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestInsertCostLedgerEntry:
+    def test_inserts_row_with_defaults(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_cost_ledger_entry, CostCategory
+            assert insert_cost_ledger_entry("content", CostCategory.MEDIA, 0.25) is True
+
+        sql, params = cur.execute.call_args[0]
+        assert "INSERT INTO cost_ledger" in sql
+        assert params[1:6] == ("content", "media", None, None, 0.25)
+        assert isinstance(params[-1], date)  # incurred_on defaults to today
+        conn.commit.assert_called_once()
+
+    def test_keeps_sub_cent_precision(self):
+        """A cheap LLM tier rounds to zero at 2dp — the ledger must keep the signal."""
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_cost_ledger_entry
+            insert_cost_ledger_entry("comment", "llm", 0.0000123, user_id=4, qty=1234.5678)
+
+        params = cur.execute.call_args[0][1]
+        assert params[0] == 4
+        assert params[5] == 0.000012
+        assert params[6] == 1234.5678
+
+    def test_error_returns_false(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_cost_ledger_entry
+            assert insert_cost_ledger_entry("content", "media", 1.0) is False
+
+
+class TestAccrueMonthlyFixedCosts:
+    def test_no_accruals_is_noop(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            from cqc_lem.utilities.db import accrue_monthly_fixed_costs
+            assert accrue_monthly_fixed_costs(date(2026, 7, 1), []) == 0
+        get_conn.assert_not_called()
+
+    def test_writes_missing_and_skips_existing(self):
+        conn, cur = _conn()
+        # First accrual already present for this period, second is new.
+        cur.fetchone.side_effect = [(1,), None]
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import accrue_monthly_fixed_costs, CostCategory
+            written = accrue_monthly_fixed_costs(date(2026, 7, 1), [
+                {"user_id": 1, "category": CostCategory.PROXY, "usd": 3.0, "provider": "per_user_proxy"},
+                {"user_id": 2, "category": CostCategory.INFRA, "usd": 1.5, "provider": "hosting", "qty": 1},
+            ])
+
+        assert written == 1
+        inserts = [c for c in cur.execute.call_args_list if "INSERT INTO cost_ledger" in c[0][0]]
+        assert len(inserts) == 1
+        params = inserts[0][0][1]
+        assert params[0] == 2 and params[2] == "infra" and params[4] == 1.5
+        assert params[-1] == date(2026, 7, 1)
+
+    def test_dedupe_check_is_null_safe(self):
+        """System rows carry user_id NULL, which `=` never matches — `<=>` does."""
+        conn, cur = _conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import accrue_monthly_fixed_costs
+            accrue_monthly_fixed_costs(date(2026, 7, 1), [{"user_id": None, "category": "infra", "usd": 9.0}])
+        assert "user_id <=> %s" in cur.execute.call_args_list[0][0][0]
+
+    def test_error_returns_rows_written_so_far(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import accrue_monthly_fixed_costs
+            assert accrue_monthly_fixed_costs(date(2026, 7, 1), [{"user_id": 1, "category": "proxy", "usd": 1}]) == 0
+
+
+class TestGetUsersProxyConfig:
+    def test_empty_input_skips_query(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            from cqc_lem.utilities.db import get_users_proxy_config
+            assert get_users_proxy_config([]) == []
+        get_conn.assert_not_called()
+
+    def test_returns_proxy_and_country(self):
+        rows = [{"id": 1, "proxy_url": "http://p:3128", "country": "US"},
+                {"id": 2, "proxy_url": None, "country": None}]
+        conn, cur = _conn(fetchall=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_users_proxy_config
+            got = get_users_proxy_config([1, 2])
+
+        assert got == [{"user_id": 1, "proxy_url": "http://p:3128", "country": "US"},
+                       {"user_id": 2, "proxy_url": None, "country": None}]
+        sql, params = cur.execute.call_args[0]
+        assert "IN (%s, %s)" in sql and params == (1, 2)
+
+    def test_error_returns_empty(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_users_proxy_config
+            assert get_users_proxy_config([1]) == []


### PR DESCRIPTION
## What & why

Adds the durable, Stripe-joinable cost store the margin report needs (plan §A.3(3)/(4), gaps #2–#4). PostHog stays the fast analytics plane; `cost_ledger` is the exact source of truth.

**Migration** — `V20260725032800__add_cost_ledger.sql` (TIMESTAMP-versioned) creates `cost_ledger` exactly as specced: `user_id` (NULL = system, FK `ON DELETE SET NULL`), `feature`, `category`, `provider`, `model_tier`, `usd DECIMAL(12,6)`, `qty`, `post_id`, `task_name`, `incurred_on`, plus the user/feature/category × day indexes.

**DB helpers** (all SQL stays in `db.py`):
- `insert_cost_ledger_entry(...)` — one spend row; `incurred_on` defaults to today (UTC).
- `get_user_cost(user_id, start, end)` — total USD in a window.
- `get_cost_rollup(group_by=user|feature|provider|category, start, end)` — the grouping key is whitelisted before it reaches the `GROUP BY`.
- `accrue_monthly_fixed_costs(period, accruals)` — idempotent per `(user_id, category, month)` using a NULL-safe `<=>` check, so a re-run never double-charges.
- `get_users_proxy_config(user_ids)` — the `proxy_url`/`country` inputs `proxy.resolve_proxy()` needs.
- New `CostCategory` StrEnum (`llm|media|proxy|infra|email|geocoding|posthog`).

**Media cost** — `observability.track_media_cost(kind, provider, usd, ...)` emits a `media_cost` PostHog event **and** writes a ledger row. Wired into `create_runway_video` using the existing `estimate_video_cost(model, duration)` — only on a `SUCCEEDED` render, since that is what Runway bills — with `user_id`/`post_id` threaded from `run_content_plan`/`generate_variants` (falling back to the ambient `llm_attribution` scope), and into the DALL-E path at `IMAGE_COST_PER_IMAGE` (default $0.08 = 1024×1024 hd).

**LLM rollup** — one ledger row per call would not scale, so `track_llm_call` accrues spend into a per-day Redis bucket keyed `user|feature|tier` (cache hits cost nothing and are skipped). The new daily beat task `auto_rollup_llm_costs` (00:20 UTC) flushes every *finished* day into one row per `user × feature × tier × day`; a day missed by a failed run is picked up by the next one. No Redis → silent no-op.

**Proxy & infra accrual** — new monthly beat task `auto_accrue_monthly_costs` (1st, 05:15 UTC): a user with their own `users.proxy_url` carries the full `PROXY_COST_PER_USER_MONTH`; users sharing a regional proxy split `REGION_PROXY_COST` across everyone routed through it; `INFRA_FIXED_MONTHLY` is amortized across active users. Every rate comes from env (documented in `.env.example`) and defaults to 0 — unset prices write nothing rather than $0 noise.

All cost writes are best-effort: a ledger or Redis failure logs a warning and never breaks the work that incurred the cost.

## Testing

- `tests/unit/utilities/test_db_cost_ledger.py` — every helper incl. the SQL-injection guard on `group_by`, NULL-safe dedupe, and error paths.
- `tests/unit/utilities/test_cost_tracking.py` — `track_media_cost`, per-image pricing, the DALL-E wiring, Redis accrual (incl. cache-hit and Redis-down paths) and `flush_llm_cost_rollup`.
- `tests/unit/app/test_monthly_cost_accrual.py` — accrual math (per-user vs. split regional vs. infra), env-rate parsing, both beat tasks and their schedule entries.
- `tests/unit/utilities/ai/test_video_models.py` — a successful render records its cost; a failed one records nothing.
- `tests/integration/test_cost_ledger.py` — drives media + LLM rollup + monthly accrual into one stateful fake `cost_ledger` and reads it back through `get_user_cost`/`get_cost_rollup`, including the re-run-is-a-no-op check.

Full unit suite green locally: 3937 passed.

Closes #490

🤖 Generated with [Claude Code](https://claude.com/claude-code)