### PR TITLE
feat(observability): margin/unit-economics report + cost block on the daily snapshot (closes #491)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -307,6 +307,22 @@ POSTHOG_HOST=https://us.i.posthog.com
 # Minimum log level forwarded to PostHog (DEBUG/INFO/WARNING/ERROR/CRITICAL). Default: ERROR
 POSTHOG_LOG_LEVEL=ERROR
 
+# --- Unit economics / margin report (docs/cost-performance-margin-plan.md §C.1) ---
+# Monthly price per subscription tier, used to compute MRR for contribution margin. Defaults match
+# the SPA pricing table ($29 / $79 / $199) — change here, not in code, when pricing changes.
+TIER_MRR_STARTER=29
+TIER_MRR_PROFESSIONAL=79
+TIER_MRR_ENTERPRISE=199
+# Total monthly FIXED infra spend (VPS + containers), amortized across active users. 0 = unknown,
+# which reports contribution margin only instead of guessing.
+INFRA_FIXED_MONTHLY=0
+# Customer acquisition cost + expected lifetime, owned by the marketing plan; used only for
+# LTV:CAC and payback in the weekly margin report. 0 CAC = ratios reported as n/a.
+CAC_USD=0
+EXPECTED_LIFETIME_MONTHS=12
+# Where the weekly margin report is emailed. Empty = generated + tracked in PostHog, not emailed.
+MARGIN_REPORT_EMAIL=
+
 # --- Codecov (coverage reporting) ---
 CODECOV_TOKEN=your_codecov_token
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -140,6 +140,21 @@ gunzip -c backups/db-<stamp>.sql.gz | docker exec -i mysql_db \
   mysql -u root -p"$MYSQL_ROOT_PASSWORD" linkedin_manager
 ```
 
+## Performance / margin snapshot
+
+Daily engagement + cost/margin snapshot (issue #491) — runs as `lem`, appends one JSON line per day
+to `/home/lem/perf-tracking/metrics.jsonl`:
+
+```cron
+30 23 * * * /home/lem/<repo-clone>/scripts/perf_snapshot.sh
+```
+
+The script reads MySQL directly and shells into `web_app` for the `margin` block
+(`python -m cqc_lem.utilities.margin --daily-json`), so it needs `sudo -n docker` and a deployed
+image that contains `cqc_lem.utilities.margin`. Overridable: `PERF_DIR`, `LEM_ENV_FILE`,
+`MARGIN_CONTAINER`. `"margin": {"ledger_available": false}` means `cost_ledger` isn't capturing yet.
+The weekly margin report needs no cron — Celery beat runs it (`weekly-margin-report`, Mon 12:00 UTC).
+
 ## Persistent state
 
 Named volumes survive deploys: `db_data` (MySQL), `redis_data`, `flower_db`,

--- a/docs/cost-performance-margin-plan.md
+++ b/docs/cost-performance-margin-plan.md
@@ -30,7 +30,7 @@ Related docs: `docs/CostTracking.md` (superseded by this plan — was a static c
 | Per-user proxy | `src/cqc_lem/utilities/proxy.py` | Regional/per-user egress resolution; per `EGRESS_AT_SCALE.md` cost scales with *regions*, not users (today) — but paid per-user residential is an override path | No recurring proxy cost captured or amortized per active user |
 | Revenue | `src/cqc_lem/utilities/stripe_util.py`, `db.py` → `get_user_subscription_info`, `get_users_with_stripe_subscriptions` | Tiers `starter`/`professional`/`enterprise` → Stripe price IDs; per-user subscription status/tier | MRR not joined to cost → **no margin anywhere today** |
 | Credit ledgers | `avatar_credit_ledger` (V27), `video_credit_ledger` (V30) | Proven `delta`-sum ledger pattern with `user_id`, `reason`, `stripe_session_id`, `post_id` | The template for a generalized `cost_ledger` |
-| Engagement snapshot | `/home/lem/perf-tracking/snapshot.sh` → `metrics.jsonl` (baseline 2026-07-24) | Daily engagement KPIs for user 1 (comments/replies/dms/reactions/posts + cumulative post_stats/engagers/followups) | Engagement-only; **no cost, no revenue, no margin** |
+| Engagement snapshot | `scripts/perf_snapshot.sh` (host cron; supersedes the on-box `/home/lem/perf-tracking/snapshot.sh`) → `metrics.jsonl` (baseline 2026-07-24) | Daily engagement KPIs for user 1 (comments/replies/dms/reactions/posts + cumulative post_stats/engagers/followups) | ~~Engagement-only~~ — now carries the `margin` cost/unit-economics block too (§D.2, issue #491) |
 
 **Design principle:** one instrumentation choke point (`_call_llm` / `track_llm_call`), one durable
 store (a `cost_ledger` table mirroring the credit-ledger pattern), one analytics plane (PostHog),
@@ -289,6 +289,21 @@ could degrade output quality is gated by the quality signals (engagement_rate,
 | **Weekly** | Margin report (per-user CM, system gross margin, cohort engagement lift, LTV:CAC) | posted to owner (email/PostHog dashboard) |
 | **Weekly** | Auto-optimization recommender: scans cost×quality by feature×tier, emits ranked recommendations; for **safe** changes (config toggle, cache extension) the agent pipeline can open an `agent:ready` PR; anything touching routing/quality is filed **`risk:product-decision`** for a human call | recommendations + optional auto-PRs |
 
+**Shipped (issue #491) — the daily block + weekly report.** `src/cqc_lem/utilities/margin.py` holds
+the §C.1 formulas (pure, unit-tested) plus the DB-fed collectors and delivery:
+
+| Piece | How it runs |
+|---|---|
+| Daily cost/margin block | `scripts/perf_snapshot.sh` (host cron; the repo-versioned successor to the on-box `snapshot.sh`) calls `python -m cqc_lem.utilities.margin --daily-json` inside `web_app` and appends it to `metrics.jsonl` as `margin` |
+| Weekly owner report | Celery beat `weekly-margin-report` → `run_scheduler.auto_weekly_margin_report` (Mon 12:00 UTC) → email + PostHog `margin_report` event; also `python -m cqc_lem.utilities.margin --weekly-report [--email]` |
+| Spend source | `cost_ledger` via read-only `db.get_cost_rollup` / `get_user_cost`; `db.cost_ledger_available()` drives the `ledger_available` flag, so a $0 spend reads as "not capturing yet" rather than "nothing spent" |
+| Inputs | `TIER_MRR_*`, `INFRA_FIXED_MONTHLY`, `CAC_USD`, `EXPECTED_LIFETIME_MONTHS`, `MARGIN_REPORT_EMAIL` (env, see `.env.example`) |
+
+Weekly figures are put on a **monthly run-rate** basis (`window spend × 30.4375 / window days`) so
+they are comparable with monthly MRR and the §C.1 formulas apply unchanged; the raw window spend
+rides along as `period_cost_usd`. Trials are included at $0 MRR so their cost still lands in system
+margin, and system-minus-per-user spend is reported as `unattributed_cost_usd` — the §E.2 signal.
+
 ### D.3 Guardrails
 
 - **Quality gate:** no auto-change ships if it moves cohort engagement_rate or median
@@ -357,7 +372,8 @@ Quality guardrail (must hold): cohort engagement_rate · median authenticity_sco
 1. **Attribution first** — add `user_id`/`feature`/`model_tier`/`cached` to `track_llm_call` and
    thread through `_call_llm`. *(No margin is possible without this.)*
 2. **`cost_ledger` table + DB helpers** (TIMESTAMP-versioned migration) + media/proxy/infra capture.
-3. **Cost+margin block** appended to the daily `snapshot.sh` → `metrics.jsonl`; **weekly margin report**.
+3. **Cost+margin block** appended to the daily snapshot → `metrics.jsonl`; **weekly margin report**.
+   *(Shipped, issue #491 — see the table at the end of §D.2. Exact spend needs step 2's ledger.)*
 4. **PostHog dashboards** (Cost Explorer, Margin by Cohort, Engagement Lift, Scorecard).
 5. **Alerts** — per-user ceiling, gross-margin floor, spend anomaly, unattributed-spend.
 6. **Cost-aware optimization loop** extending `complexity_router.py` (`risk:product-decision`).

--- a/scripts/perf_snapshot.sh
+++ b/scripts/perf_snapshot.sh
@@ -23,7 +23,12 @@ mkdir -p "$DIR"
 DBU=$(sudo -n grep -E "^MYSQL_USER=" "$ENVF"|cut -d= -f2)
 DBP=$(sudo -n grep -E "^MYSQL_PASSWORD=" "$ENVF"|cut -d= -f2)
 DBN=$(sudo -n grep -E "^MYSQL_DATABASE=" "$ENVF"|cut -d= -f2)
-q(){ sudo -n docker exec mysql_db mysql -u"$DBU" -p"$DBP" -N -B -e "$1" 2>/dev/null | grep -vi "using a password" | head -1; }
+# The password reaches the mysql client as MYSQL_PWD from a 0600 env-file, never as a `-p` CLI arg:
+# an argv password is readable in the container's process list (and by anything scraping it).
+PWF=$(mktemp)                       # mktemp creates 0600
+trap 'rm -f "$PWF"' EXIT
+printf 'MYSQL_PWD=%s\n' "$DBP" > "$PWF"
+q(){ sudo -n docker exec --env-file "$PWF" mysql_db mysql -u"$DBU" -N -B -e "$1" 2>/dev/null | grep -vi "using a password" | head -1; }
 
 U=1
 DAY="SELECT COUNT(*) FROM $DBN.logs WHERE user_id=$U AND result='success' AND created_at>=NOW()-INTERVAL 1 DAY AND action_type="

--- a/scripts/perf_snapshot.sh
+++ b/scripts/perf_snapshot.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Daily LEM performance snapshot -> appends one JSON line to metrics.jsonl. Started 2026-07-24 to
+# track the impact of the recent engagement features (feed-dedup #474, comment follow-ups #478,
+# connection requests #398, outreach funnel #399) over ~2 weeks. Cron: daily.
+#
+# Two layers per line:
+#   d1/cumulative — ENGAGEMENT KPIs, read straight from MySQL.
+#   margin        — COST + UNIT ECONOMICS (issue #491, docs/cost-performance-margin-plan.md §D.2):
+#                   spend_usd, cost_by_feature, est. mrr, contribution_margin, gross_margin_pct.
+#                   Produced by `python -m cqc_lem.utilities.margin --daily-json` INSIDE the app
+#                   container so it uses the deployed margin math and the container's DB creds.
+#                   `ledger_available: false` means cost_ledger isn't capturing yet, so the $0 spend
+#                   is "not measured", not "nothing spent".
+#
+# This lives in the repo (not only on the box) so the snapshot is reviewable and versioned; point
+# the host cron at this file. Overridable: PERF_DIR, LEM_ENV_FILE, MARGIN_CONTAINER.
+set -uo pipefail
+DIR="${PERF_DIR:-/home/lem/perf-tracking}"
+LOG="$DIR/metrics.jsonl"
+ENVF="${LEM_ENV_FILE:-/opt/lem/.env}"
+MARGIN_CONTAINER="${MARGIN_CONTAINER:-web_app}"
+mkdir -p "$DIR"
+DBU=$(sudo -n grep -E "^MYSQL_USER=" "$ENVF"|cut -d= -f2)
+DBP=$(sudo -n grep -E "^MYSQL_PASSWORD=" "$ENVF"|cut -d= -f2)
+DBN=$(sudo -n grep -E "^MYSQL_DATABASE=" "$ENVF"|cut -d= -f2)
+q(){ sudo -n docker exec mysql_db mysql -u"$DBU" -p"$DBP" -N -B -e "$1" 2>/dev/null | grep -vi "using a password" | head -1; }
+
+U=1
+DAY="SELECT COUNT(*) FROM $DBN.logs WHERE user_id=$U AND result='success' AND created_at>=NOW()-INTERVAL 1 DAY AND action_type="
+c1d=$(q "${DAY}'comment';"); r1d=$(q "${DAY}'reply';"); d1d=$(q "${DAY}'dm';"); e1d=$(q "${DAY}'engaged';"); p1d=$(q "${DAY}'post';")
+ps=$(q "SELECT CONCAT_WS(',',COUNT(DISTINCT post_id),COALESCE(SUM(reactions),0),COALESCE(SUM(comments),0),COALESCE(SUM(impressions),0)) FROM $DBN.post_stats WHERE user_id=$U;")
+eng=$(q "SELECT COUNT(*) FROM $DBN.post_engagers WHERE user_id=$U;")
+fu=$(q "SELECT COUNT(*) FROM $DBN.comment_followups WHERE user_id=$U;")
+cp=$(q "SELECT COUNT(*) FROM $DBN.commented_posts WHERE user_id=$U;")
+IFS=',' read -r pt reac comm impr <<< "${ps:-0,0,0,0}"
+
+# Cost/margin block. Never fatal: an unreachable container or a broken block leaves the engagement
+# line intact (with "margin": null) rather than losing the whole day's snapshot.
+margin=$(sudo -n docker exec "$MARGIN_CONTAINER" python -m cqc_lem.utilities.margin --daily-json 2>/dev/null | tail -1)
+if ! printf '%s' "${margin:-}" | python3 -c "import json,sys; json.loads(sys.stdin.read())" 2>/dev/null; then
+  echo "[$(date -u +%FT%TZ)] margin block unavailable" >> "$DIR/snapshot.log"
+  margin=null
+fi
+
+MARGIN_JSON="$margin" python3 - <<PY >> "$LOG"
+import json, os, datetime
+print(json.dumps({
+  "date": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d"),
+  "ts": datetime.datetime.now(datetime.timezone.utc).isoformat()+"Z",
+  "d1": {"comments": ${c1d:-0}, "replies": ${r1d:-0}, "dms": ${d1d:-0}, "reactions": ${e1d:-0}, "posts": ${p1d:-0}},
+  "cumulative": {"posts_tracked": ${pt:-0}, "own_reactions": ${reac:-0}, "own_comments": ${comm:-0},
+                 "own_impressions": ${impr:-0}, "engagers": ${eng:-0}, "commented_posts": ${cp:-0}, "followups": ${fu:-0}},
+  "margin": json.loads(os.environ["MARGIN_JSON"]),
+}))
+PY
+echo "[$(date -u +%FT%TZ)] snapshot written" >> "$DIR/snapshot.log"

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -200,6 +200,12 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.sync_stripe_subscriptions',
             'schedule': crontab(hour='6', minute='0')  # Daily at 6:00 AM — safety-net for missed webhooks
         },
+        'weekly-margin-report': {
+            'task': 'cqc_lem.app.run_scheduler.auto_weekly_margin_report',
+            # Mondays 12:00 UTC — after the 6:00 Stripe sync, so MRR reflects current tiers, and after
+            # Sunday night's stats scrape, so cohort engagement lift covers the full week.
+            'schedule': crontab(hour='12', minute='0', day_of_week='monday')
+        },
 
     }
 )

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1136,5 +1136,21 @@ def sync_stripe_subscriptions(self):
             log_debug(f"Subscription up-to-date ({db_status}/{tier})", user_id=row["id"])
 
 
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True})
+def auto_weekly_margin_report(self, days: int = 7):
+    """Weekly unit-economics report (issue #491, plan §D.2): joins `cost_ledger` spend to Stripe MRR
+    for per-user contribution margin, system gross margin, cohort engagement lift and LTV:CAC, then
+    delivers it to the owner (email + a PostHog `margin_report` scorecard event)."""
+    from cqc_lem.utilities.margin import collect_margin_report, send_weekly_margin_report
+
+    report = collect_margin_report(days=days)
+    result = send_weekly_margin_report(report)
+    system = report.get("system", {})
+    return (f"Margin report {report.get('period', {}).get('start')}→"
+            f"{report.get('period', {}).get('end')}: {system.get('active_users')} user(s), "
+            f"gross margin {system.get('gross_margin_usd')} USD "
+            f"(emailed={result['emailed']}, tracked={result['tracked']})")
+
+
 if __name__ == "__main__":
     print("Process finished")

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -6211,3 +6211,90 @@ def get_active_avatar(user_id: int) -> Optional[dict]:
     finally:
         cursor.close()
         connection.close()
+
+
+# Cost/margin reporting (docs/cost-performance-margin-plan.md §A.3/§C.1). These are READ-ONLY over
+# the `cost_ledger` table; writes/accruals belong to the ledger capture work. Every one degrades to
+# an empty result when the table isn't present yet, so the margin report ships ahead of it.
+
+# Whitelisted rollup dimensions → the cost_ledger column each groups by. Interpolating anything
+# outside this map into the SQL would be an injection vector.
+COST_ROLLUP_COLUMNS = {
+    "feature": "feature",
+    "category": "category",
+    "provider": "provider",
+    "model_tier": "model_tier",
+    "user": "user_id",
+    "task": "task_name",
+}
+
+
+def cost_ledger_available() -> bool:
+    """True when the durable cost_ledger table exists. The margin report uses this to say whether a
+    $0 spend figure means "nothing spent" or "not capturing yet"."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SHOW TABLES LIKE 'cost_ledger'")
+        return cursor.fetchone() is not None
+    except mysql.connector.Error:
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_cost_rollup(start_date, end_date, group_by: str = "feature",
+                    user_id: Optional[int] = None) -> dict:
+    """Summed `cost_ledger.usd` over [start_date, end_date] grouped by one dimension from
+    COST_ROLLUP_COLUMNS → `{key: usd}`. Omitting `user_id` includes EVERY row, shared/system spend
+    (NULL user_id) included, which is what the system-wide margin totals need. Rows with a NULL
+    group value collapse into the "unknown" key so their spend is never dropped."""
+    column = COST_ROLLUP_COLUMNS.get(group_by)
+    if not column:
+        myprint(f"Unsupported cost rollup dimension '{group_by}'")
+        return {}
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        sql = (f"SELECT COALESCE({column}, 'unknown'), COALESCE(SUM(usd), 0) FROM cost_ledger "
+               "WHERE incurred_on BETWEEN %s AND %s")
+        params = [start_date, end_date]
+        if user_id is not None:
+            sql += " AND user_id = %s"
+            params.append(user_id)
+        cursor.execute(sql + f" GROUP BY {column}", tuple(params))
+        return {str(key): float(usd or 0) for key, usd in cursor.fetchall()}
+    except mysql.connector.Error:
+        return {}  # table not created yet (or unreadable) — caller reports it as unavailable
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_user_cost(user_id: int, start_date, end_date) -> dict:
+    """One user's spend over a window, grouped by cost category (llm/media/proxy/infra/...)."""
+    return get_cost_rollup(start_date, end_date, group_by="category", user_id=user_id)
+
+
+def get_margin_users() -> list:
+    """Users the margin report covers: everyone on an active/past-due subscription or an open trial.
+    Trials are included (tier `free_trial`, $0 MRR) so the cost they incur still lands in system
+    margin instead of vanishing. `cohort` is the signup month — `users` has no created_at, so
+    trial_started_at is the signup timestamp, falling back to updated_at for pre-trial rows."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            """SELECT id, subscription_tier, subscription_status,
+                      DATE_FORMAT(COALESCE(trial_started_at, updated_at), '%Y-%m') AS cohort
+               FROM users
+               WHERE subscription_status IN ('active', 'past_due', 'trial')"""
+        )
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        myprint(f"Could not fetch margin users | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -6249,7 +6249,9 @@ def get_cost_rollup(start_date, end_date, group_by: str = "feature",
     """Summed `cost_ledger.usd` over [start_date, end_date] grouped by one dimension from
     COST_ROLLUP_COLUMNS → `{key: usd}`. Omitting `user_id` includes EVERY row, shared/system spend
     (NULL user_id) included, which is what the system-wide margin totals need. Rows with a NULL
-    group value collapse into the "unknown" key so their spend is never dropped."""
+    group value collapse into the "unknown" key so their spend is never dropped — the column is CAST
+    to CHAR first so a numeric dimension (user_id) can't coerce 'unknown' into 0 and merge NULL
+    rows with a real user 0."""
     column = COST_ROLLUP_COLUMNS.get(group_by)
     if not column:
         myprint(f"Unsupported cost rollup dimension '{group_by}'")
@@ -6257,13 +6259,13 @@ def get_cost_rollup(start_date, end_date, group_by: str = "feature",
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
-        sql = (f"SELECT COALESCE({column}, 'unknown'), COALESCE(SUM(usd), 0) FROM cost_ledger "
-               "WHERE incurred_on BETWEEN %s AND %s")
+        sql = (f"SELECT COALESCE(CAST({column} AS CHAR), 'unknown') AS rollup_key, "
+               "COALESCE(SUM(usd), 0) FROM cost_ledger WHERE incurred_on BETWEEN %s AND %s")
         params = [start_date, end_date]
         if user_id is not None:
             sql += " AND user_id = %s"
             params.append(user_id)
-        cursor.execute(sql + f" GROUP BY {column}", tuple(params))
+        cursor.execute(sql + " GROUP BY rollup_key", tuple(params))
         return {str(key): float(usd or 0) for key, usd in cursor.fetchall()}
     except mysql.connector.Error:
         return {}  # table not created yet (or unreadable) — caller reports it as unavailable

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -179,6 +179,21 @@ STRIPE_PRICE_ID_PROFESSIONAL  = get_constant_from_env('STRIPE_PRICE_ID_PROFESSIO
 STRIPE_PRICE_ID_ENTERPRISE    = get_constant_from_env('STRIPE_PRICE_ID_ENTERPRISE')
 FREE_TRIAL_DAYS           = int(get_constant_from_env('FREE_TRIAL_DAYS', default_value='14'))
 
+# Unit-economics inputs for the margin report (docs/cost-performance-margin-plan.md §C.1). Monthly
+# tier prices mirror the SPA pricing table — override per environment instead of editing code so a
+# price change never needs a deploy.
+TIER_MRR_STARTER          = float(get_constant_from_env('TIER_MRR_STARTER', default_value='29'))
+TIER_MRR_PROFESSIONAL     = float(get_constant_from_env('TIER_MRR_PROFESSIONAL', default_value='79'))
+TIER_MRR_ENTERPRISE       = float(get_constant_from_env('TIER_MRR_ENTERPRISE', default_value='199'))
+# Total monthly fixed infra spend (VPS + containers), amortized across active users. 0 = unknown,
+# which reports contribution margin only rather than guessing a fixed cost.
+INFRA_FIXED_MONTHLY       = float(get_constant_from_env('INFRA_FIXED_MONTHLY', default_value='0'))
+# CAC and expected lifetime are OWNED by the marketing plan; imported here only for LTV:CAC/payback.
+CAC_USD                   = float(get_constant_from_env('CAC_USD', default_value='0'))
+EXPECTED_LIFETIME_MONTHS  = float(get_constant_from_env('EXPECTED_LIFETIME_MONTHS', default_value='12'))
+# Where the weekly margin report is emailed. Empty = generate + track only, no email.
+MARGIN_REPORT_EMAIL       = get_constant_from_env('MARGIN_REPORT_EMAIL', default_value='')
+
 NGROK_LIPREVIEW_PREFIX=get_constant_from_env('NGROK_LIPREVIEW_PREFIX')
 if NGROK_FREE_DOMAIN and NGROK_LIPREVIEW_PREFIX:
     LINKEDIN_PREVIEW_URL = f"https://{NGROK_LIPREVIEW_PREFIX}.{NGROK_FREE_DOMAIN}"

--- a/src/cqc_lem/utilities/margin.py
+++ b/src/cqc_lem/utilities/margin.py
@@ -1,0 +1,506 @@
+"""Unit economics: cost → revenue → contribution margin (docs/cost-performance-margin-plan.md §C, §D.2).
+
+Structured like `scripts/model_health_check.py`: PURE formulas + report builders first (no DB, no
+network — these ARE the §C.1 formulas and are what the unit tests pin), then the DB-fed collectors,
+delivery and CLI.
+
+Two consumers:
+  * the daily engagement snapshot (`scripts/perf_snapshot.sh`) appends the `margin` block to
+    `metrics.jsonl`  →  `python -m cqc_lem.utilities.margin --daily-json`
+  * the weekly owner report (Celery beat `auto_weekly_margin_report`, or `--weekly-report [--email]`)
+
+Spend comes from the durable `cost_ledger` (plan §A.3). Until that table exists the collectors
+report zero spend with `ledger_available: false` instead of failing, so the snapshot block and the
+weekly report ship now and become exact the moment the ledger lands.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from datetime import date, datetime, timedelta, timezone
+from typing import Iterable, Mapping, Optional, Sequence
+
+from cqc_lem.utilities.env_constants import (
+    CAC_USD,
+    EXPECTED_LIFETIME_MONTHS,
+    INFRA_FIXED_MONTHLY,
+    MARGIN_REPORT_EMAIL,
+    TIER_MRR_ENTERPRISE,
+    TIER_MRR_PROFESSIONAL,
+    TIER_MRR_STARTER,
+)
+from cqc_lem.utilities.logger import log_info, log_warning
+from cqc_lem.utilities.post_stats import engagement_rate, engagement_score
+
+# ───────────────────────────── pure math (§C.1) ─────────────────────────────
+
+# Monthly price per subscription tier. `free_trial` earns nothing yet but still costs us money, so
+# it is a real $0-MRR row rather than an exclusion — that keeps trial drag visible in system margin.
+TIER_MRR_USD = {
+    "starter": TIER_MRR_STARTER,
+    "professional": TIER_MRR_PROFESSIONAL,
+    "enterprise": TIER_MRR_ENTERPRISE,
+    "free_trial": 0.0,
+}
+
+# `cost_ledger.category` → the §C.1 cost kind it belongs to. An UNKNOWN category counts as variable
+# so a newly added cost driver can never silently disappear from contribution margin.
+SEMI_VARIABLE_CATEGORIES = frozenset({"proxy"})
+FIXED_CATEGORIES = frozenset({"infra"})
+
+# Average calendar month — used to put a 7-day window's spend on the same monthly basis as MRR.
+DAYS_PER_MONTH = 30.4375
+
+# Engagement-lift metric labels (mirrors post_stats' rate-mode gate).
+METRIC_RATE = "engagement_rate"
+METRIC_COUNT = "engagement"
+
+# Column layout of `db.get_post_engagement_rows` tuples.
+_IDX_SCHEDULED, _IDX_REACTIONS, _IDX_COMMENTS, _IDX_REPOSTS, _IDX_IMPRESSIONS = 0, 1, 2, 3, 9
+
+
+def tier_mrr_usd(tier: Optional[str]) -> float:
+    """Monthly recurring revenue for a subscription tier. Unknown/None → 0.0 (no revenue assumed)."""
+    return float(TIER_MRR_USD.get((tier or "").strip().lower(), 0.0))
+
+
+def split_cost_by_kind(by_category: Optional[Mapping[str, float]]) -> dict:
+    """Bucket a `{category: usd}` rollup into the §C.1 kinds:
+    `{"variable", "semi_variable", "fixed"}`. Proxy is semi-variable (linear-ish in users), infra is
+    fixed/amortized, everything else — including categories added later — is variable."""
+    out = {"variable": 0.0, "semi_variable": 0.0, "fixed": 0.0}
+    for category, usd in (by_category or {}).items():
+        key = ("fixed" if category in FIXED_CATEGORIES else
+               "semi_variable" if category in SEMI_VARIABLE_CATEGORIES else "variable")
+        out[key] += float(usd or 0.0)
+    return out
+
+
+def monthly_run_rate(period_usd: float, period_days: float) -> float:
+    """Scale a window's spend to a monthly run rate so it is comparable with monthly MRR. A
+    non-positive window returns the spend unchanged rather than dividing by zero."""
+    if period_days <= 0:
+        return float(period_usd or 0.0)
+    return float(period_usd or 0.0) * (DAYS_PER_MONTH / float(period_days))
+
+
+def contribution_margin(mrr_usd: float, variable_cost_usd: float,
+                        semi_variable_cost_usd: float = 0.0) -> float:
+    """§C.1 `contribution_margin(user) = MRR − variable_cost − semi_var_cost`."""
+    return float(mrr_usd or 0.0) - float(variable_cost_usd or 0.0) - float(semi_variable_cost_usd or 0.0)
+
+
+def margin_pct(margin_usd: float, mrr_usd: float) -> Optional[float]:
+    """Margin as a fraction of revenue. None when there is no revenue — CM% is undefined then, and
+    reporting 0% would read as "breaking even" for a free trial that is actually pure cost."""
+    if not mrr_usd or float(mrr_usd) <= 0:
+        return None
+    return float(margin_usd or 0.0) / float(mrr_usd)
+
+
+def allocated_fixed_per_user(infra_monthly_usd: float, active_users: int) -> float:
+    """§C.1 `allocated_fixed(user) = INFRA_FIXED_MONTHLY / active_users(month)`. 0 users → 0.0."""
+    if not active_users or active_users <= 0:
+        return 0.0
+    return float(infra_monthly_usd or 0.0) / float(active_users)
+
+
+def fully_loaded_margin(contribution_margin_usd: float, allocated_fixed_usd: float) -> float:
+    """§C.1 `fully_loaded_margin(user) = contribution_margin − allocated_fixed`."""
+    return float(contribution_margin_usd or 0.0) - float(allocated_fixed_usd or 0.0)
+
+
+def system_gross_margin(total_mrr_usd: float, total_variable_usd: float,
+                        total_semi_variable_usd: float, infra_monthly_usd: float) -> dict:
+    """§C.1 system block: `gross_margin$ = ΣMRR − Σvariable − Σsemi_var − INFRA_FIXED_MONTHLY` and
+    `gross_margin% = gross_margin$ / ΣMRR` (None with no revenue)."""
+    gross = (float(total_mrr_usd or 0.0) - float(total_variable_usd or 0.0)
+             - float(total_semi_variable_usd or 0.0) - float(infra_monthly_usd or 0.0))
+    return {"gross_margin_usd": gross, "gross_margin_pct": margin_pct(gross, total_mrr_usd)}
+
+
+def ltv_usd(avg_monthly_cm_usd: float, expected_lifetime_months: float) -> float:
+    """§C.1 `LTV = avg_monthly_contribution_margin × expected_lifetime_months`."""
+    return float(avg_monthly_cm_usd or 0.0) * float(expected_lifetime_months or 0.0)
+
+
+def payback_months(cac_usd: float, avg_monthly_cm_usd: float) -> Optional[float]:
+    """§C.1 `payback = CAC / avg_monthly_contribution_margin`. None when CM ≤ 0 — a negative-margin
+    customer never pays back — and None when CAC is unknown/0, which would otherwise report an
+    instant payback."""
+    if not cac_usd or float(cac_usd) <= 0:
+        return None
+    if not avg_monthly_cm_usd or float(avg_monthly_cm_usd) <= 0:
+        return None
+    return float(cac_usd or 0.0) / float(avg_monthly_cm_usd)
+
+
+def ltv_cac_ratio(ltv: float, cac_usd: float) -> Optional[float]:
+    """§C.1 `LTV:CAC` (target ≥ 3:1). None when CAC is unknown/0 — the ratio is meaningless then."""
+    if not cac_usd or float(cac_usd) <= 0:
+        return None
+    return float(ltv or 0.0) / float(cac_usd)
+
+
+def _cell(row: Sequence, index: int):
+    return row[index] if len(row) > index else None
+
+
+def _window_metric(rows: Sequence) -> dict:
+    """Engagement for one set of post-stat rows: impression-normalized RATE when every row carries
+    impressions, else average weighted engagement per post (the same rate-mode gate `post_stats`
+    uses, so a partial-impression window is never mixed with a complete one)."""
+    if not rows:
+        return {"metric": None, "value": None, "samples": 0}
+    if all(int(_cell(r, _IDX_IMPRESSIONS) or 0) > 0 for r in rows):
+        totals = [sum(int(_cell(r, i) or 0) for r in rows)
+                  for i in (_IDX_REACTIONS, _IDX_COMMENTS, _IDX_REPOSTS, _IDX_IMPRESSIONS)]
+        return {"metric": METRIC_RATE, "value": engagement_rate(*totals), "samples": len(rows)}
+    total = sum(engagement_score(_cell(r, _IDX_REACTIONS), _cell(r, _IDX_COMMENTS),
+                                 _cell(r, _IDX_REPOSTS)) for r in rows)
+    return {"metric": METRIC_COUNT, "value": total / len(rows), "samples": len(rows)}
+
+
+def engagement_lift(rows: Iterable[Sequence], window_start: date) -> dict:
+    """§B.2 engagement lift: the user's engagement in the report window vs. their EARLIER posts.
+    `rows` are `db.get_post_engagement_rows` tuples (latest stats per post + its posted time).
+    Returns `{"current", "baseline", "metric", "lift_pct", "samples", "baseline_samples"}`;
+    `lift_pct` is None unless both windows have data on the SAME metric and a positive baseline."""
+    current, baseline = [], []
+    for row in rows or []:
+        scheduled = _cell(row, _IDX_SCHEDULED) if row else None
+        day = scheduled.date() if hasattr(scheduled, "date") else None
+        if day is None:
+            continue
+        (current if day >= window_start else baseline).append(row)
+    now, before = _window_metric(current), _window_metric(baseline)
+    lift = None
+    if (now["value"] is not None and before["value"] is not None
+            and now["metric"] == before["metric"] and before["value"] > 0):
+        lift = (now["value"] - before["value"]) / before["value"] * 100.0
+    return {"current": now["value"], "baseline": before["value"],
+            "metric": now["metric"] or before["metric"], "lift_pct": lift,
+            "samples": now["samples"], "baseline_samples": before["samples"]}
+
+
+def _round(value: Optional[float], digits: int = 6) -> Optional[float]:
+    return None if value is None else round(float(value), digits)
+
+
+# ──────────────────────── pure builders (daily + weekly) ────────────────────────
+
+def build_daily_margin_block(day: date, spend_by_feature: Optional[Mapping[str, float]],
+                             mtd_cost_by_category: Optional[Mapping[str, float]],
+                             total_mrr_usd: float, infra_monthly_usd: float = 0.0,
+                             ledger_available: bool = True) -> dict:
+    """The cost/margin block appended to the daily snapshot (§D.2 row 1).
+
+    `spend_usd` / `cost_by_feature` are TODAY's spend; the margin figures are MONTH-TO-DATE against
+    the current MRR run rate, because §C.1 margin is a monthly quantity — so the daily line trends
+    toward the true month-end margin as the month fills in."""
+    by_feature = {str(k): round(float(v or 0.0), 6) for k, v in (spend_by_feature or {}).items()}
+    kinds = split_cost_by_kind(mtd_cost_by_category)
+    cm = contribution_margin(total_mrr_usd, kinds["variable"], kinds["semi_variable"])
+    system = system_gross_margin(total_mrr_usd, kinds["variable"], kinds["semi_variable"],
+                                 infra_monthly_usd)
+    return {
+        "date": day.isoformat(),
+        "spend_usd": round(sum(by_feature.values()), 6),
+        "cost_by_feature": by_feature,
+        "mtd_spend_usd": round(kinds["variable"] + kinds["semi_variable"] + kinds["fixed"], 6),
+        "mrr_usd": _round(total_mrr_usd, 2),
+        "contribution_margin_usd": _round(cm, 2),
+        "gross_margin_pct": _round(system["gross_margin_pct"], 4),
+        "ledger_available": bool(ledger_available),
+    }
+
+
+def build_margin_report(period_start: date, period_end: date, users: Sequence[Mapping],
+                        system_cost_by_category: Optional[Mapping[str, float]] = None,
+                        infra_monthly_usd: float = 0.0, cac_usd: float = 0.0,
+                        expected_lifetime_months: float = 0.0,
+                        ledger_available: bool = True) -> dict:
+    """The weekly margin report (§D.2 row 3), pure: per-user CM & CM%, system gross margin, cohort
+    engagement lift, LTV:CAC and payback.
+
+    Every cost figure is put on a MONTHLY RUN-RATE basis (`period spend × 30.4375 / period_days`) so
+    it is comparable with monthly MRR and the §C.1 formulas apply unchanged; the raw window spend
+    rides along as `period_cost_usd`. Each `users` entry is
+    `{"user_id", "tier", "cohort", "cost_by_category", "engagement"}`."""
+    days = max((period_end - period_start).days + 1, 1)
+    rows, margins, total_mrr, total_variable, total_semi = [], [], 0.0, 0.0, 0.0
+    attributed = 0.0
+    for user in users or []:
+        kinds = split_cost_by_kind(user.get("cost_by_category"))
+        variable = monthly_run_rate(kinds["variable"], days)
+        semi = monthly_run_rate(kinds["semi_variable"], days)
+        mrr = tier_mrr_usd(user.get("tier"))
+        cm = contribution_margin(mrr, variable, semi)
+        engagement = dict(user.get("engagement") or {})
+        attributed += kinds["variable"] + kinds["semi_variable"] + kinds["fixed"]
+        total_mrr += mrr
+        total_variable += variable
+        total_semi += semi
+        margins.append(cm)
+        rows.append({
+            "user_id": user.get("user_id"),
+            "tier": user.get("tier"),
+            "cohort": user.get("cohort"),
+            "mrr_usd": _round(mrr, 2),
+            "variable_cost_usd": _round(variable, 4),
+            "semi_variable_cost_usd": _round(semi, 4),
+            "period_cost_usd": _round(kinds["variable"] + kinds["semi_variable"], 4),
+            "contribution_margin_usd": _round(cm, 2),
+            "cm_pct": _round(margin_pct(cm, mrr), 4),
+            "engagement_rate": _round(engagement.get("current"), 6),
+            "engagement_metric": engagement.get("metric"),
+            "engagement_lift_pct": _round(engagement.get("lift_pct"), 2),
+        })
+
+    active_users = len(rows)
+    per_user_fixed = allocated_fixed_per_user(infra_monthly_usd, active_users)
+    for row, cm in zip(rows, margins):
+        row["allocated_fixed_usd"] = _round(per_user_fixed, 4)
+        row["fully_loaded_margin_usd"] = _round(fully_loaded_margin(cm, per_user_fixed), 2)
+    paying = [(row, cm) for row, cm in zip(rows, margins) if (row["mrr_usd"] or 0.0) > 0]
+    rows.sort(key=lambda r: (r["contribution_margin_usd"] is None,
+                             r["contribution_margin_usd"] or 0.0))
+
+    if system_cost_by_category is None:
+        # No system-wide rollup supplied → the per-user sums ARE the system totals.
+        system_variable, system_semi = total_variable, total_semi
+        system_total = attributed
+    else:
+        # Shared/system ledger rows carry a NULL user_id, so the system rollup is a superset of the
+        # per-user ones; the remainder is exactly the plan's §E.2 "unattributed spend" signal.
+        system_kinds = split_cost_by_kind(system_cost_by_category)
+        system_variable = monthly_run_rate(system_kinds["variable"], days)
+        system_semi = monthly_run_rate(system_kinds["semi_variable"], days)
+        system_total = system_kinds["variable"] + system_kinds["semi_variable"] + system_kinds["fixed"]
+    gross = system_gross_margin(total_mrr, system_variable, system_semi, infra_monthly_usd)
+
+    avg_cm = (sum(cm for _, cm in paying) / len(paying)) if paying else 0.0
+    ltv = ltv_usd(avg_cm, expected_lifetime_months)
+
+    return {
+        "period": {"start": period_start.isoformat(), "end": period_end.isoformat(), "days": days,
+                   "basis": "monthly_run_rate"},
+        "ledger_available": bool(ledger_available),
+        "users": rows,
+        "system": {
+            "active_users": active_users,
+            "paying_users": len(paying),
+            "mrr_usd": _round(total_mrr, 2),
+            "variable_cost_usd": _round(system_variable, 4),
+            "semi_variable_cost_usd": _round(system_semi, 4),
+            "infra_fixed_usd": _round(infra_monthly_usd, 2),
+            "allocated_fixed_per_user_usd": _round(per_user_fixed, 4),
+            "period_cost_usd": _round(system_total, 4),
+            "unattributed_cost_usd": _round(max(system_total - attributed, 0.0), 4),
+            "gross_margin_usd": _round(gross["gross_margin_usd"], 2),
+            "gross_margin_pct": _round(gross["gross_margin_pct"], 4),
+            "avg_contribution_margin_usd": _round(avg_cm, 2),
+        },
+        "cohorts": _build_cohorts(rows),
+        "unit_economics": {
+            "cac_usd": _round(cac_usd, 2),
+            "expected_lifetime_months": _round(expected_lifetime_months, 2),
+            "ltv_usd": _round(ltv, 2),
+            "ltv_cac_ratio": _round(ltv_cac_ratio(ltv, cac_usd), 2),
+            "payback_months": _round(payback_months(cac_usd, avg_cm), 2),
+        },
+    }
+
+
+def _build_cohorts(rows: Sequence[Mapping]) -> list:
+    """Per signup-month cohort aggregates (§B.2): CM, CM% and engagement lift, so a newer cohort can
+    be read against an older one. Sorted by cohort so the trend reads top-to-bottom."""
+    groups: dict = {}
+    for row in rows:
+        groups.setdefault(row.get("cohort") or "unknown", []).append(row)
+    out = []
+    for cohort in sorted(groups):
+        members = groups[cohort]
+        cms = [m["contribution_margin_usd"] for m in members if m["contribution_margin_usd"] is not None]
+        pcts = [m["cm_pct"] for m in members if m["cm_pct"] is not None]
+        lifts = [m["engagement_lift_pct"] for m in members if m["engagement_lift_pct"] is not None]
+        rates = [m["engagement_rate"] for m in members if m["engagement_rate"] is not None]
+        out.append({
+            "cohort": cohort,
+            "users": len(members),
+            "avg_cm_usd": _round(statistics.fmean(cms), 2) if cms else None,
+            "avg_cm_pct": _round(statistics.fmean(pcts), 4) if pcts else None,
+            "median_engagement_rate": _round(statistics.median(rates), 6) if rates else None,
+            "avg_engagement_lift_pct": _round(statistics.fmean(lifts), 2) if lifts else None,
+        })
+    return out
+
+
+def _pct(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"{value * 100:.1f}%"
+
+
+def _usd(value: Optional[float]) -> str:
+    return "n/a" if value is None else f"${value:,.2f}"
+
+
+def render_margin_report_text(report: Mapping) -> str:
+    """Plain-text owner report — also the plaintext alternative of the email (a missing text/plain
+    part is a spam signal, see `email._dispatch_email`)."""
+    period, system, unit = report.get("period", {}), report.get("system", {}), report.get("unit_economics", {})
+    lines = [f"LEM margin report — {period.get('start')} → {period.get('end')} "
+             f"({period.get('days')}d, {period.get('basis')} basis)", ""]
+    if not report.get("ledger_available", True):
+        lines += ["NOTE: cost_ledger is not present yet — spend reads as $0 and margin is "
+                  "revenue-only until it lands.", ""]
+    lines += [
+        f"System: {system.get('active_users')} active user(s), {system.get('paying_users')} paying",
+        f"  MRR                 {_usd(system.get('mrr_usd'))}",
+        f"  Variable cost       {_usd(system.get('variable_cost_usd'))}",
+        f"  Semi-variable cost  {_usd(system.get('semi_variable_cost_usd'))}",
+        f"  Fixed infra         {_usd(system.get('infra_fixed_usd'))}",
+        f"  Gross margin        {_usd(system.get('gross_margin_usd'))} ({_pct(system.get('gross_margin_pct'))})",
+        f"  Unattributed spend  {_usd(system.get('unattributed_cost_usd'))}",
+        "",
+        f"Unit economics: LTV {_usd(unit.get('ltv_usd'))} · CAC {_usd(unit.get('cac_usd'))} · "
+        f"LTV:CAC {unit.get('ltv_cac_ratio') if unit.get('ltv_cac_ratio') is not None else 'n/a'} · "
+        f"payback {unit.get('payback_months') if unit.get('payback_months') is not None else 'n/a'} mo",
+        "",
+        "Per user (worst margin first):",
+    ]
+    for row in report.get("users", []):
+        lift = row.get("engagement_lift_pct")
+        lines.append(f"  #{row.get('user_id')} {row.get('tier') or '-'}: "
+                     f"MRR {_usd(row.get('mrr_usd'))}, cost {_usd(row.get('variable_cost_usd'))}"
+                     f"+{_usd(row.get('semi_variable_cost_usd'))}, "
+                     f"CM {_usd(row.get('contribution_margin_usd'))} ({_pct(row.get('cm_pct'))}), "
+                     f"engagement lift {'n/a' if lift is None else f'{lift:+.1f}%'}")
+    lines += ["", "Cohorts:"]
+    for cohort in report.get("cohorts", []):
+        lift = cohort.get("avg_engagement_lift_pct")
+        lines.append(f"  {cohort.get('cohort')}: {cohort.get('users')} user(s), "
+                     f"avg CM {_usd(cohort.get('avg_cm_usd'))} ({_pct(cohort.get('avg_cm_pct'))}), "
+                     f"avg lift {'n/a' if lift is None else f'{lift:+.1f}%'}")
+    return "\n".join(lines)
+
+
+def render_margin_report_html(report: Mapping) -> str:
+    """HTML body of the owner email — the text report in a <pre> block keeps it readable in every
+    client without a template, and the numbers are identical to the plaintext part."""
+    body = (render_margin_report_text(report)
+            .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+    return ("<h2>LEM margin report</h2><pre style=\"font-family:ui-monospace,monospace;"
+            f"font-size:13px;line-height:1.5\">{body}</pre>")
+
+
+# ─────────────────────── DB-fed collectors & delivery ───────────────────────
+
+def _today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def collect_daily_margin_block(day: Optional[date] = None) -> dict:
+    """Read today's spend + current MRR run rate and build the snapshot block."""
+    from cqc_lem.utilities.db import cost_ledger_available, get_cost_rollup, get_margin_users
+
+    day = day or _today()
+    users = get_margin_users()
+    total_mrr = sum(tier_mrr_usd(u.get("subscription_tier")) for u in users)
+    return build_daily_margin_block(
+        day,
+        get_cost_rollup(day, day, group_by="feature"),
+        get_cost_rollup(day.replace(day=1), day, group_by="category"),
+        total_mrr,
+        infra_monthly_usd=INFRA_FIXED_MONTHLY,
+        ledger_available=cost_ledger_available(),
+    )
+
+
+def collect_margin_report(end: Optional[date] = None, days: int = 7) -> dict:
+    """Read the trailing `days` window per user and build the weekly report."""
+    from cqc_lem.utilities.db import (cost_ledger_available, get_cost_rollup, get_margin_users,
+                                      get_post_engagement_rows)
+
+    end = end or _today()
+    start = end - timedelta(days=max(days, 1) - 1)
+    users = []
+    for row in get_margin_users():
+        user_id = row.get("id")
+        users.append({
+            "user_id": user_id,
+            "tier": row.get("subscription_tier"),
+            "cohort": row.get("cohort"),
+            "cost_by_category": get_cost_rollup(start, end, group_by="category", user_id=user_id),
+            "engagement": engagement_lift(get_post_engagement_rows(user_id), start),
+        })
+    return build_margin_report(
+        start, end, users,
+        system_cost_by_category=get_cost_rollup(start, end, group_by="category"),
+        infra_monthly_usd=INFRA_FIXED_MONTHLY,
+        cac_usd=CAC_USD,
+        expected_lifetime_months=EXPECTED_LIFETIME_MONTHS,
+        ledger_available=cost_ledger_available(),
+    )
+
+
+def send_weekly_margin_report(report: Optional[Mapping] = None,
+                              to_email: Optional[str] = None) -> dict:
+    """Deliver the weekly report to the owner: email + a PostHog `margin_report` event for the
+    unit-economics scorecard (§E.1.4). Returns `{"emailed": bool, "tracked": bool, "report": ...}` —
+    delivery failures are logged, never raised, so a beat run is not lost over an email hiccup."""
+    from cqc_lem.utilities.email import _dispatch_email
+    from cqc_lem.utilities.observability import track_margin_report
+
+    report = report if report is not None else collect_margin_report()
+    text = render_margin_report_text(report)
+    recipient = to_email or MARGIN_REPORT_EMAIL
+    emailed = False
+    if recipient:
+        period = report.get("period", {})
+        try:
+            emailed = bool(_dispatch_email(
+                recipient, f"LEM margin report — {period.get('start')} → {period.get('end')}",
+                render_margin_report_html(report), text_content=text))
+        except Exception as e:
+            log_warning("Margin report email failed", exc=e, task_name="auto_weekly_margin_report")
+    else:
+        log_warning("MARGIN_REPORT_EMAIL not set — margin report not emailed",
+                    task_name="auto_weekly_margin_report")
+    tracked = False
+    try:
+        track_margin_report(report)
+        tracked = True
+    except Exception as e:
+        log_warning("Margin report PostHog capture failed", exc=e,
+                    task_name="auto_weekly_margin_report")
+    log_info(f"Margin report generated (emailed={emailed}, tracked={tracked})",
+             task_name="auto_weekly_margin_report")
+    return {"emailed": emailed, "tracked": tracked, "report": report}
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="LEM cost/margin reporting")
+    parser.add_argument("--daily-json", action="store_true",
+                        help="print today's cost/margin block as one JSON object (snapshot.sh)")
+    parser.add_argument("--weekly-report", action="store_true", help="build the weekly margin report")
+    parser.add_argument("--email", action="store_true", help="also email the weekly report to the owner")
+    parser.add_argument("--json", action="store_true", help="print the weekly report as JSON")
+    parser.add_argument("--days", type=int, default=7, help="weekly report window in days (default 7)")
+    args = parser.parse_args(argv)
+
+    if args.daily_json:
+        print(json.dumps(collect_daily_margin_block()))
+        return 0
+    if args.weekly_report:
+        report = collect_margin_report(days=args.days)
+        if args.email:
+            send_weekly_margin_report(report)
+        print(json.dumps(report) if args.json else render_margin_report_text(report))
+        return 0
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/src/cqc_lem/utilities/margin.py
+++ b/src/cqc_lem/utilities/margin.py
@@ -352,7 +352,7 @@ def render_margin_report_text(report: Mapping) -> str:
     lines = [f"LEM margin report — {period.get('start')} → {period.get('end')} "
              f"({period.get('days')}d, {period.get('basis')} basis)", ""]
     if not report.get("ledger_available", True):
-        lines += ["NOTE: cost_ledger is not present yet — spend reads as $0 and margin is "
+        lines += ["NOTE: cost_ledger is not present yet — spend reads as $0 and margin is " +
                   "revenue-only until it lands.", ""]
     lines += [
         f"System: {system.get('active_users')} active user(s), {system.get('paying_users')} paying",

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -284,6 +284,30 @@ def track_post_outcome(
     )
 
 
+def track_margin_report(report: dict) -> None:
+    """Emit the weekly unit-economics scorecard (plan §E.1.4) as one `margin_report` event so the
+    PostHog tiles read system margin, cohort margin and LTV:CAC without re-deriving them. Per-user
+    financials stay out of the event body — internal-only by policy (plan §E.5) — but the cohort
+    aggregates the Margin-by-Cohort dashboard needs ride along."""
+    system = dict((report or {}).get("system") or {})
+    unit = dict((report or {}).get("unit_economics") or {})
+    period = dict((report or {}).get("period") or {})
+    posthog.capture(
+        distinct_id="system",
+        event="margin_report",
+        properties={
+            "period_start": period.get("start"),
+            "period_end": period.get("end"),
+            "period_days": period.get("days"),
+            "basis": period.get("basis"),
+            "ledger_available": (report or {}).get("ledger_available"),
+            "cohorts": (report or {}).get("cohorts") or [],
+            **{f"system_{key}": value for key, value in system.items()},
+            **unit,
+        },
+    )
+
+
 def track_task(
     task_name: str,
     duration_ms: int,

--- a/tests/unit/app/test_weekly_margin_report.py
+++ b/tests/unit/app/test_weekly_margin_report.py
@@ -1,0 +1,54 @@
+"""Unit tests for the weekly margin-report beat task (issue #491)."""
+
+from datetime import date
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_S = "cqc_lem.app.run_scheduler"
+_M = "cqc_lem.utilities.margin"
+
+
+def _report():
+    from cqc_lem.utilities.margin import build_margin_report
+    return build_margin_report(
+        date(2026, 7, 19), date(2026, 7, 25),
+        [{"user_id": 1, "tier": "professional", "cohort": "2026-06",
+          "cost_by_category": {"llm": 7.0}, "engagement": {}}])
+
+
+class TestAutoWeeklyMarginReport:
+    def test_collects_then_delivers_the_report(self):
+        report = _report()
+        with patch(f"{_M}.collect_margin_report", return_value=report) as collect, \
+             patch(f"{_M}.send_weekly_margin_report",
+                   return_value={"emailed": True, "tracked": True, "report": report}) as send:
+            from cqc_lem.app.run_scheduler import auto_weekly_margin_report
+            result = auto_weekly_margin_report()
+
+        collect.assert_called_once_with(days=7)
+        send.assert_called_once_with(report)
+        assert "2026-07-19→2026-07-25" in result
+        assert "emailed=True" in result and "tracked=True" in result
+
+    def test_window_is_configurable(self):
+        report = _report()
+        with patch(f"{_M}.collect_margin_report", return_value=report) as collect, \
+             patch(f"{_M}.send_weekly_margin_report",
+                   return_value={"emailed": False, "tracked": True, "report": report}):
+            from cqc_lem.app.run_scheduler import auto_weekly_margin_report
+            auto_weekly_margin_report(days=30)
+
+        collect.assert_called_once_with(days=30)
+
+
+class TestBeatSchedule:
+    def test_the_weekly_report_is_scheduled_on_mondays(self):
+        from cqc_lem.app.my_celery import app
+        entry = app.conf.beat_schedule["weekly-margin-report"]
+        assert entry["task"] == "cqc_lem.app.run_scheduler.auto_weekly_margin_report"
+        crontab = entry["schedule"]
+        assert crontab.day_of_week == {1}  # Monday
+        assert crontab.hour == {12} and crontab.minute == {0}

--- a/tests/unit/app/test_weekly_margin_report.py
+++ b/tests/unit/app/test_weekly_margin_report.py
@@ -7,7 +7,6 @@ from unittest.mock import patch
 
 pytestmark = pytest.mark.unit
 
-_S = "cqc_lem.app.run_scheduler"
 _M = "cqc_lem.utilities.margin"
 
 

--- a/tests/unit/utilities/test_db_cost_ledger.py
+++ b/tests/unit/utilities/test_db_cost_ledger.py
@@ -1,0 +1,106 @@
+"""Unit tests for the read-only cost_ledger accessors used by the margin report (issue #491)."""
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import mysql.connector
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _mock_conn(fetch_all=None, fetch_one=None, error=None, dictionary=False):
+    conn, cur = MagicMock(), MagicMock()
+    cur.fetchall.return_value = fetch_all if fetch_all is not None else []
+    cur.fetchone.return_value = fetch_one
+    if error:
+        cur.execute.side_effect = mysql.connector.Error(error)
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestCostLedgerAvailable:
+    def test_true_when_table_exists(self):
+        conn, cur = _mock_conn(fetch_one=("cost_ledger",))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import cost_ledger_available
+            assert cost_ledger_available() is True
+        assert "SHOW TABLES LIKE 'cost_ledger'" in cur.execute.call_args[0][0]
+
+    def test_false_when_absent(self):
+        conn, _ = _mock_conn(fetch_one=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import cost_ledger_available
+            assert cost_ledger_available() is False
+
+    def test_false_on_db_error(self):
+        conn, _ = _mock_conn(error="connection lost")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import cost_ledger_available
+            assert cost_ledger_available() is False
+
+
+class TestGetCostRollup:
+    def test_sums_by_feature_across_all_users(self):
+        conn, cur = _mock_conn(fetch_all=[("content", 1.5), ("comment", 0.25)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_cost_rollup
+            assert get_cost_rollup(date(2026, 7, 1), date(2026, 7, 25)) == {"content": 1.5,
+                                                                           "comment": 0.25}
+        sql, params = cur.execute.call_args[0]
+        assert "SUM(usd)" in sql and "GROUP BY feature" in sql
+        assert "user_id = %s" not in sql  # no user filter → shared/system rows included
+        assert params == (date(2026, 7, 1), date(2026, 7, 25))
+
+    def test_filters_by_user_when_given(self):
+        conn, cur = _mock_conn(fetch_all=[("llm", 7.0)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_cost_rollup
+            assert get_cost_rollup(date(2026, 7, 1), date(2026, 7, 25),
+                                   group_by="category", user_id=5) == {"llm": 7.0}
+        sql, params = cur.execute.call_args[0]
+        assert "GROUP BY category" in sql and "user_id = %s" in sql
+        assert params == (date(2026, 7, 1), date(2026, 7, 25), 5)
+
+    def test_rejects_an_unknown_dimension_instead_of_interpolating_it(self):
+        with patch(f"{_DB}.get_db_connection") as gc:
+            from cqc_lem.utilities.db import get_cost_rollup
+            assert get_cost_rollup(date(2026, 7, 1), date(2026, 7, 25),
+                                   group_by="feature; DROP TABLE users") == {}
+        gc.assert_not_called()
+
+    def test_empty_when_table_missing(self):
+        conn, _ = _mock_conn(error="Table 'cost_ledger' doesn't exist")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_cost_rollup
+            assert get_cost_rollup(date(2026, 7, 1), date(2026, 7, 25)) == {}
+
+    def test_get_user_cost_groups_by_category_for_one_user(self):
+        conn, cur = _mock_conn(fetch_all=[("llm", 2.0), ("proxy", 1.0)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_cost
+            assert get_user_cost(9, date(2026, 7, 1), date(2026, 7, 25)) == {"llm": 2.0,
+                                                                            "proxy": 1.0}
+        sql, params = cur.execute.call_args[0]
+        assert "GROUP BY category" in sql and params[-1] == 9
+
+
+class TestGetMarginUsers:
+    def test_returns_tier_status_and_signup_cohort(self):
+        rows = [{"id": 1, "subscription_tier": "professional", "subscription_status": "active",
+                 "cohort": "2026-06"}]
+        conn, cur = _mock_conn(fetch_all=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_margin_users
+            assert get_margin_users() == rows
+        sql = cur.execute.call_args[0][0]
+        assert "'active', 'past_due', 'trial'" in sql  # trials cost money → included at $0 MRR
+        assert "trial_started_at" in sql
+
+    def test_empty_on_db_error(self):
+        conn, _ = _mock_conn(error="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_margin_users
+            assert get_margin_users() == []

--- a/tests/unit/utilities/test_db_cost_ledger.py
+++ b/tests/unit/utilities/test_db_cost_ledger.py
@@ -50,7 +50,7 @@ class TestGetCostRollup:
             assert get_cost_rollup(date(2026, 7, 1), date(2026, 7, 25)) == {"content": 1.5,
                                                                            "comment": 0.25}
         sql, params = cur.execute.call_args[0]
-        assert "SUM(usd)" in sql and "GROUP BY feature" in sql
+        assert "SUM(usd)" in sql and "CAST(feature AS CHAR)" in sql and "GROUP BY rollup_key" in sql
         assert "user_id = %s" not in sql  # no user filter → shared/system rows included
         assert params == (date(2026, 7, 1), date(2026, 7, 25))
 
@@ -61,8 +61,19 @@ class TestGetCostRollup:
             assert get_cost_rollup(date(2026, 7, 1), date(2026, 7, 25),
                                    group_by="category", user_id=5) == {"llm": 7.0}
         sql, params = cur.execute.call_args[0]
-        assert "GROUP BY category" in sql and "user_id = %s" in sql
+        assert "CAST(category AS CHAR)" in sql and "GROUP BY rollup_key" in sql
+        assert "user_id = %s" in sql
         assert params == (date(2026, 7, 1), date(2026, 7, 25), 5)
+
+    def test_numeric_dimension_is_cast_so_null_never_collapses_into_user_zero(self):
+        conn, cur = _mock_conn(fetch_all=[("unknown", 3.0), ("7", 1.0)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_cost_rollup
+            assert get_cost_rollup(date(2026, 7, 1), date(2026, 7, 25),
+                                   group_by="user") == {"unknown": 3.0, "7": 1.0}
+        sql = cur.execute.call_args[0][0]
+        assert "COALESCE(CAST(user_id AS CHAR), 'unknown')" in sql
+        assert "GROUP BY rollup_key" in sql
 
     def test_rejects_an_unknown_dimension_instead_of_interpolating_it(self):
         with patch(f"{_DB}.get_db_connection") as gc:
@@ -84,7 +95,7 @@ class TestGetCostRollup:
             assert get_user_cost(9, date(2026, 7, 1), date(2026, 7, 25)) == {"llm": 2.0,
                                                                             "proxy": 1.0}
         sql, params = cur.execute.call_args[0]
-        assert "GROUP BY category" in sql and params[-1] == 9
+        assert "CAST(category AS CHAR)" in sql and params[-1] == 9
 
 
 class TestGetMarginUsers:

--- a/tests/unit/utilities/test_margin.py
+++ b/tests/unit/utilities/test_margin.py
@@ -1,0 +1,372 @@
+"""Unit tests for the cost/margin unit-economics layer (issue #491).
+
+The §C.1 formulas are pinned numerically here — if the margin math drifts, these fail.
+"""
+
+from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cqc_lem.utilities import margin as m
+
+pytestmark = pytest.mark.unit
+
+_MARGIN = "cqc_lem.utilities.margin"
+
+
+def _row(days_ago: int, reactions=10, comments=2, reposts=1, impressions=1000):
+    """A `db.get_post_engagement_rows` tuple: scheduled_time first, impressions at index 9."""
+    posted = datetime(2026, 7, 20) - timedelta(days=days_ago)
+    return (posted, reactions, comments, reposts, None, None, None, None, None, impressions)
+
+
+class TestTierMrr:
+    def test_maps_tiers_and_treats_trial_as_zero(self):
+        assert m.tier_mrr_usd("professional") == m.TIER_MRR_PROFESSIONAL
+        assert m.tier_mrr_usd("  Starter ") == m.TIER_MRR_STARTER
+        assert m.tier_mrr_usd("enterprise") == m.TIER_MRR_ENTERPRISE
+        assert m.tier_mrr_usd("free_trial") == 0.0
+
+    def test_unknown_and_none_earn_nothing(self):
+        assert m.tier_mrr_usd(None) == 0.0
+        assert m.tier_mrr_usd("legacy_plan") == 0.0
+
+
+class TestSplitCostByKind:
+    def test_buckets_by_category(self):
+        split = m.split_cost_by_kind({"llm": 1.5, "media": 2.0, "proxy": 3.0, "infra": 10.0})
+        assert split == {"variable": 3.5, "semi_variable": 3.0, "fixed": 10.0}
+
+    def test_unknown_category_counts_as_variable_so_spend_never_vanishes(self):
+        assert m.split_cost_by_kind({"quantum_gpu": 4.0})["variable"] == 4.0
+
+    def test_empty_and_none(self):
+        assert m.split_cost_by_kind(None) == {"variable": 0.0, "semi_variable": 0.0, "fixed": 0.0}
+
+
+class TestFormulas:
+    def test_contribution_margin_and_pct(self):
+        cm = m.contribution_margin(79.0, 12.0, 3.0)
+        assert cm == 64.0
+        assert m.margin_pct(cm, 79.0) == pytest.approx(64.0 / 79.0)
+
+    def test_margin_pct_undefined_without_revenue(self):
+        # A $0-MRR trial that costs money is NOT "0% margin" — the ratio has no meaning.
+        assert m.margin_pct(-5.0, 0.0) is None
+
+    def test_allocated_fixed_amortizes_and_survives_zero_users(self):
+        assert m.allocated_fixed_per_user(100.0, 8) == 12.5
+        assert m.allocated_fixed_per_user(100.0, 0) == 0.0
+
+    def test_fully_loaded_margin_subtracts_allocated_fixed(self):
+        assert m.fully_loaded_margin(64.0, 12.5) == 51.5
+
+    def test_system_gross_margin(self):
+        result = m.system_gross_margin(1000.0, 200.0, 50.0, 100.0)
+        assert result["gross_margin_usd"] == 650.0
+        assert result["gross_margin_pct"] == pytest.approx(0.65)
+
+    def test_system_gross_margin_pct_none_without_revenue(self):
+        assert m.system_gross_margin(0.0, 10.0, 0.0, 0.0)["gross_margin_pct"] is None
+
+    def test_ltv_payback_and_ratio(self):
+        ltv = m.ltv_usd(50.0, 12)
+        assert ltv == 600.0
+        assert m.ltv_cac_ratio(ltv, 150.0) == pytest.approx(4.0)
+        assert m.payback_months(150.0, 50.0) == pytest.approx(3.0)
+
+    def test_payback_none_when_margin_not_positive(self):
+        assert m.payback_months(150.0, 0.0) is None
+        assert m.payback_months(150.0, -4.0) is None
+
+    def test_payback_none_without_cac_instead_of_reporting_instant(self):
+        assert m.payback_months(0.0, 50.0) is None
+
+    def test_ltv_cac_ratio_none_without_cac(self):
+        assert m.ltv_cac_ratio(600.0, 0.0) is None
+
+    def test_monthly_run_rate_scales_a_window(self):
+        assert m.monthly_run_rate(7.0, 7) == pytest.approx(7.0 * m.DAYS_PER_MONTH / 7)
+        assert m.monthly_run_rate(5.0, 0) == 5.0  # no division by zero
+
+
+class TestEngagementLift:
+    def test_rate_mode_lift_against_earlier_posts(self):
+        rows = [_row(1, reactions=20, comments=4, reposts=2, impressions=1000),   # in window
+                _row(30, reactions=10, comments=2, reposts=1, impressions=1000)]  # baseline
+        lift = m.engagement_lift(rows, date(2026, 7, 14))
+        assert lift["metric"] == m.METRIC_RATE
+        assert lift["current"] == pytest.approx(0.032)   # (20 + 2*4 + 2*2)/1000
+        assert lift["baseline"] == pytest.approx(0.016)  # (10 + 2*2 + 2*1)/1000
+        assert lift["lift_pct"] == pytest.approx(100.0)
+        assert (lift["samples"], lift["baseline_samples"]) == (1, 1)
+
+    def test_falls_back_to_counts_when_impressions_incomplete(self):
+        rows = [_row(1, impressions=None), _row(30, impressions=1000)]
+        lift = m.engagement_lift(rows, date(2026, 7, 14))
+        assert lift["metric"] == m.METRIC_COUNT
+        assert lift["current"] == pytest.approx(16.0)  # 10 + 2*2 + 2*1
+
+    def test_no_baseline_means_no_lift(self):
+        lift = m.engagement_lift([_row(1)], date(2026, 7, 14))
+        assert lift["current"] is not None and lift["baseline"] is None
+        assert lift["lift_pct"] is None
+
+    def test_rows_without_a_timestamp_are_ignored(self):
+        assert m.engagement_lift([(None, 5, 1, 0, None, None, None, None, None, 100)],
+                                 date(2026, 7, 14))["samples"] == 0
+
+    def test_empty_rows(self):
+        lift = m.engagement_lift([], date(2026, 7, 14))
+        assert lift == {"current": None, "baseline": None, "metric": None, "lift_pct": None,
+                        "samples": 0, "baseline_samples": 0}
+
+
+class TestDailyBlock:
+    def test_block_carries_spend_features_and_margin(self):
+        block = m.build_daily_margin_block(
+            date(2026, 7, 25),
+            {"content": 0.42, "comment": 0.08},
+            {"llm": 6.0, "media": 2.0, "proxy": 2.0, "infra": 30.0},
+            total_mrr_usd=79.0, infra_monthly_usd=30.0)
+        assert block["date"] == "2026-07-25"
+        assert block["spend_usd"] == pytest.approx(0.5)
+        assert block["cost_by_feature"] == {"content": 0.42, "comment": 0.08}
+        assert block["mtd_spend_usd"] == pytest.approx(40.0)
+        assert block["mrr_usd"] == 79.0
+        # 79 − (6+2 variable) − 2 semi-var = 69
+        assert block["contribution_margin_usd"] == 69.0
+        # gross margin also nets the fixed infra: (69 − 30) / 79
+        assert block["gross_margin_pct"] == pytest.approx(0.4937, abs=1e-4)
+        assert block["ledger_available"] is True
+
+    def test_no_ledger_yet_reports_zero_spend_and_flags_it(self):
+        block = m.build_daily_margin_block(date(2026, 7, 25), {}, {}, 79.0,
+                                           ledger_available=False)
+        assert block["spend_usd"] == 0.0
+        assert block["cost_by_feature"] == {}
+        assert block["contribution_margin_usd"] == 79.0
+        assert block["ledger_available"] is False
+
+
+def _users():
+    return [
+        {"user_id": 1, "tier": "professional", "cohort": "2026-06",
+         "cost_by_category": {"llm": 7.0, "proxy": 3.5},
+         "engagement": {"current": 0.03, "baseline": 0.02, "metric": m.METRIC_RATE,
+                        "lift_pct": 50.0}},
+        {"user_id": 2, "tier": "free_trial", "cohort": "2026-07",
+         "cost_by_category": {"llm": 14.0},
+         "engagement": {"current": 0.01, "baseline": None, "metric": m.METRIC_RATE,
+                        "lift_pct": None}},
+    ]
+
+
+class TestWeeklyReport:
+    def test_per_user_margin_on_a_monthly_run_rate_basis(self):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), _users(),
+                                       system_cost_by_category={"llm": 21.0, "proxy": 3.5},
+                                       infra_monthly_usd=60.0, cac_usd=150.0,
+                                       expected_lifetime_months=12)
+        assert report["period"] == {"start": "2026-07-19", "end": "2026-07-25", "days": 7,
+                                    "basis": "monthly_run_rate"}
+        by_id = {row["user_id"]: row for row in report["users"]}
+        scale = m.DAYS_PER_MONTH / 7
+        assert by_id[1]["variable_cost_usd"] == pytest.approx(7.0 * scale, abs=1e-3)
+        assert by_id[1]["semi_variable_cost_usd"] == pytest.approx(3.5 * scale, abs=1e-3)
+        expected_cm = m.TIER_MRR_PROFESSIONAL - 10.5 * scale
+        assert by_id[1]["contribution_margin_usd"] == pytest.approx(round(expected_cm, 2))
+        assert by_id[1]["cm_pct"] == pytest.approx(expected_cm / m.TIER_MRR_PROFESSIONAL, abs=1e-4)
+        assert by_id[1]["engagement_lift_pct"] == 50.0
+        # A trial earns nothing, so CM% is undefined while its cost is still fully counted.
+        assert by_id[2]["mrr_usd"] == 0.0 and by_id[2]["cm_pct"] is None
+        assert by_id[2]["contribution_margin_usd"] == pytest.approx(round(-14.0 * scale, 2))
+
+    def test_worst_margin_first(self):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), _users())
+        assert [row["user_id"] for row in report["users"]] == [2, 1]
+
+    def test_system_block_amortizes_fixed_and_flags_unattributed_spend(self):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), _users(),
+                                       system_cost_by_category={"llm": 25.0, "proxy": 3.5},
+                                       infra_monthly_usd=60.0)
+        system = report["system"]
+        assert (system["active_users"], system["paying_users"]) == (2, 1)
+        assert system["mrr_usd"] == pytest.approx(m.TIER_MRR_PROFESSIONAL)
+        assert system["allocated_fixed_per_user_usd"] == 30.0
+        # System llm spend (25) exceeds what is attributed to users (21 llm + 3.5 proxy = 24.5).
+        assert system["unattributed_cost_usd"] == pytest.approx(4.0)
+        scale = m.DAYS_PER_MONTH / 7
+        expected = m.TIER_MRR_PROFESSIONAL - 25.0 * scale - 3.5 * scale - 60.0
+        assert system["gross_margin_usd"] == pytest.approx(round(expected, 2))
+        assert system["gross_margin_pct"] == pytest.approx(expected / m.TIER_MRR_PROFESSIONAL,
+                                                           abs=1e-4)
+
+    def test_system_totals_fall_back_to_per_user_sums(self):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), _users())
+        scale = m.DAYS_PER_MONTH / 7
+        assert report["system"]["variable_cost_usd"] == pytest.approx(21.0 * scale, abs=1e-3)
+        assert report["system"]["unattributed_cost_usd"] == 0.0
+
+    def test_unit_economics_from_paying_users_only(self):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), _users(),
+                                       cac_usd=150.0, expected_lifetime_months=12)
+        scale = m.DAYS_PER_MONTH / 7
+        avg_cm = m.TIER_MRR_PROFESSIONAL - 10.5 * scale  # the trial is excluded from the average
+        unit = report["unit_economics"]
+        assert report["system"]["avg_contribution_margin_usd"] == pytest.approx(round(avg_cm, 2))
+        assert unit["ltv_usd"] == pytest.approx(round(avg_cm * 12, 2))
+        assert unit["ltv_cac_ratio"] == pytest.approx(round(avg_cm * 12 / 150.0, 2))
+        assert unit["payback_months"] == pytest.approx(round(150.0 / avg_cm, 2))
+
+    def test_cohorts_aggregate_margin_and_lift(self):
+        cohorts = {c["cohort"]: c for c in
+                   m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), _users())["cohorts"]}
+        assert set(cohorts) == {"2026-06", "2026-07"}
+        assert cohorts["2026-06"]["users"] == 1
+        assert cohorts["2026-06"]["avg_engagement_lift_pct"] == 50.0
+        assert cohorts["2026-06"]["median_engagement_rate"] == 0.03
+        # The trial cohort has no CM% and no lift — reported as unknown, not as zero.
+        assert cohorts["2026-07"]["avg_cm_pct"] is None
+        assert cohorts["2026-07"]["avg_engagement_lift_pct"] is None
+
+    def test_empty_user_set_is_safe(self):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), [])
+        assert report["users"] == [] and report["cohorts"] == []
+        assert report["system"]["mrr_usd"] == 0.0
+        assert report["system"]["gross_margin_pct"] is None
+        assert report["unit_economics"]["payback_months"] is None
+
+
+class TestRenderers:
+    def test_text_report_includes_headline_numbers(self):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), _users(),
+                                       infra_monthly_usd=60.0, cac_usd=150.0,
+                                       expected_lifetime_months=12)
+        text = m.render_margin_report_text(report)
+        assert "2026-07-19 → 2026-07-25" in text
+        assert "Gross margin" in text and "Unit economics" in text
+        assert "#1 professional" in text and "#2 free_trial" in text
+        assert "2026-06:" in text
+
+    def test_text_report_warns_when_ledger_missing(self):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), [],
+                                       ledger_available=False)
+        assert "cost_ledger is not present yet" in m.render_margin_report_text(report)
+
+    def test_html_escapes_and_wraps_the_text_report(self):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), _users())
+        report["users"][0]["tier"] = "<b>pro</b>"
+        html = m.render_margin_report_html(report)
+        assert html.startswith("<h2>LEM margin report</h2><pre")
+        # Report content is escaped (so a tier/label can't inject markup) but stays readable.
+        assert "&lt;b&gt;pro&lt;/b&gt;" in html and "→" in html
+
+
+class TestCollectors:
+    def _patch_db(self, rollups=None, users=None, rows=None, ledger=True):
+        """Patch the db layer the collectors import; returns (context, rollup_mock)."""
+        rollups = rollups or {}
+        rollup = MagicMock(side_effect=lambda s, e, group_by="feature", user_id=None:
+                           rollups.get((group_by, user_id), {}))
+        return patch.multiple(
+            "cqc_lem.utilities.db",
+            get_cost_rollup=rollup,
+            get_margin_users=MagicMock(return_value=users if users is not None else []),
+            get_post_engagement_rows=MagicMock(return_value=rows or []),
+            cost_ledger_available=MagicMock(return_value=ledger),
+        ), rollup
+
+    def test_daily_block_sums_mrr_over_active_subscribers(self):
+        rollups = {("feature", None): {"content": 1.0}, ("category", None): {"llm": 4.0}}
+        users = [{"subscription_tier": "professional"}, {"subscription_tier": "starter"},
+                 {"subscription_tier": "free_trial"}]
+        with self._patch_db(rollups=rollups, users=users)[0]:
+            block = m.collect_daily_margin_block(date(2026, 7, 25))
+        assert block["spend_usd"] == 1.0
+        assert block["mrr_usd"] == pytest.approx(m.TIER_MRR_PROFESSIONAL + m.TIER_MRR_STARTER)
+        assert block["ledger_available"] is True
+
+    def test_daily_block_flags_a_missing_ledger(self):
+        with self._patch_db(ledger=False)[0]:
+            assert m.collect_daily_margin_block(date(2026, 7, 25))["ledger_available"] is False
+
+    def test_weekly_report_window_and_per_user_costs(self):
+        rollups = {("category", 5): {"llm": 7.0}, ("category", None): {"llm": 9.0}}
+        users = [{"id": 5, "subscription_tier": "professional", "cohort": "2026-06"}]
+        context, rollup = self._patch_db(rollups=rollups, users=users, rows=[_row(1), _row(30)])
+        with context:
+            report = m.collect_margin_report(end=date(2026, 7, 25), days=7)
+        assert report["period"]["start"] == "2026-07-19"
+        assert rollup.call_args_list[0][0] == (date(2026, 7, 19), date(2026, 7, 25))
+        row = report["users"][0]
+        assert row["user_id"] == 5 and row["cohort"] == "2026-06"
+        assert row["variable_cost_usd"] == pytest.approx(7.0 * m.DAYS_PER_MONTH / 7, abs=1e-3)
+        assert row["engagement_metric"] == m.METRIC_RATE
+        assert report["system"]["unattributed_cost_usd"] == pytest.approx(2.0)
+
+
+class TestDelivery:
+    def _report(self):
+        return m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), _users())
+
+    def test_emails_and_tracks(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as send, \
+             patch("cqc_lem.utilities.observability.track_margin_report") as track:
+            result = m.send_weekly_margin_report(self._report(), to_email="owner@example.com")
+        assert result == {"emailed": True, "tracked": True, "report": result["report"]}
+        args, kwargs = send.call_args
+        assert args[0] == "owner@example.com"
+        assert "2026-07-19 → 2026-07-25" in args[1]
+        assert kwargs["text_content"].startswith("LEM margin report")
+        track.assert_called_once()
+
+    def test_no_recipient_still_tracks(self):
+        with patch(f"{_MARGIN}.MARGIN_REPORT_EMAIL", ""), \
+             patch("cqc_lem.utilities.email._dispatch_email") as send, \
+             patch("cqc_lem.utilities.observability.track_margin_report"):
+            result = m.send_weekly_margin_report(self._report())
+        send.assert_not_called()
+        assert result["emailed"] is False and result["tracked"] is True
+
+    def test_email_failure_does_not_lose_the_report(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", side_effect=RuntimeError("smtp down")), \
+             patch("cqc_lem.utilities.observability.track_margin_report"):
+            result = m.send_weekly_margin_report(self._report(), to_email="owner@example.com")
+        assert result["emailed"] is False and result["tracked"] is True
+
+    def test_tracking_failure_does_not_lose_the_email(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True), \
+             patch("cqc_lem.utilities.observability.track_margin_report",
+                   side_effect=RuntimeError("posthog down")):
+            result = m.send_weekly_margin_report(self._report(), to_email="owner@example.com")
+        assert result["emailed"] is True and result["tracked"] is False
+
+
+class TestCli:
+    def test_daily_json_prints_one_object(self, capsys):
+        with patch(f"{_MARGIN}.collect_daily_margin_block", return_value={"spend_usd": 1.25}):
+            assert m.main(["--daily-json"]) == 0
+        import json as _json
+        assert _json.loads(capsys.readouterr().out.strip()) == {"spend_usd": 1.25}
+
+    def test_weekly_report_renders_text_without_emailing(self, capsys):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), [])
+        with patch(f"{_MARGIN}.collect_margin_report", return_value=report) as collect, \
+             patch(f"{_MARGIN}.send_weekly_margin_report") as send:
+            assert m.main(["--weekly-report", "--days", "14"]) == 0
+        collect.assert_called_once_with(days=14)
+        send.assert_not_called()
+        assert "LEM margin report" in capsys.readouterr().out
+
+    def test_weekly_report_email_flag_delivers(self):
+        report = m.build_margin_report(date(2026, 7, 19), date(2026, 7, 25), [])
+        with patch(f"{_MARGIN}.collect_margin_report", return_value=report), \
+             patch(f"{_MARGIN}.send_weekly_margin_report") as send:
+            assert m.main(["--weekly-report", "--email", "--json"]) == 0
+        send.assert_called_once_with(report)
+
+    def test_no_flags_prints_help_and_fails(self, capsys):
+        assert m.main([]) == 1
+        assert "usage:" in capsys.readouterr().out

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -470,3 +470,42 @@ class TestLlmTrackedAttribution:
             call()
 
         assert mock_ph.capture.call_args[1]["properties"]["feature"] == "system"
+
+
+class TestTrackMarginReport:
+    def _report(self):
+        return {
+            "period": {"start": "2026-07-19", "end": "2026-07-25", "days": 7,
+                       "basis": "monthly_run_rate"},
+            "ledger_available": True,
+            "users": [{"user_id": 1, "mrr_usd": 79.0, "cm_pct": 0.8}],
+            "system": {"mrr_usd": 79.0, "gross_margin_pct": 0.62},
+            "cohorts": [{"cohort": "2026-06", "users": 1, "avg_cm_usd": 63.0}],
+            "unit_economics": {"ltv_usd": 600.0, "ltv_cac_ratio": 4.0, "payback_months": 3.0},
+        }
+
+    def test_captures_scorecard_properties(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_margin_report
+            track_margin_report(self._report())
+
+        assert mock_ph.capture.call_args[1]["event"] == "margin_report"
+        props = mock_ph.capture.call_args[1]["properties"]
+        assert props["period_start"] == "2026-07-19" and props["period_days"] == 7
+        assert props["system_gross_margin_pct"] == 0.62
+        assert props["ltv_cac_ratio"] == 4.0
+        assert props["cohorts"][0]["cohort"] == "2026-06"
+
+    def test_omits_per_user_financials(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_margin_report
+            track_margin_report(self._report())
+
+        # Per-user cost/revenue is internal-only (plan §E.5) — it must not leave in the event.
+        assert "users" not in mock_ph.capture.call_args[1]["properties"]
+
+    def test_empty_report_does_not_raise(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_margin_report
+            track_margin_report({})
+        assert mock_ph.capture.call_args[1]["properties"]["cohorts"] == []


### PR DESCRIPTION
## What & why

Adds the **cost + unit-economics layer** on top of the daily engagement snapshot
(`docs/cost-performance-margin-plan.md` §C, §D.2). Before this, LEM had cost *attribution*
(#489) but no margin anywhere: spend was never joined to Stripe MRR.

### Daily — cost/margin block in `metrics.jsonl`
`scripts/perf_snapshot.sh` is the repo-versioned successor to the on-box
`/home/lem/perf-tracking/snapshot.sh`: same engagement KPIs, plus a `margin` block produced by
`python -m cqc_lem.utilities.margin --daily-json` **inside `web_app`** (so it uses the deployed
margin math and the container's DB creds):

```json
"margin": {"date":"2026-07-25","spend_usd":0.5,"cost_by_feature":{"content":0.42,"comment":0.08},
           "mtd_spend_usd":8.0,"mrr_usd":79.0,"contribution_margin_usd":71.0,
           "gross_margin_pct":0.8987,"ledger_available":true}
```

Never fatal — an unreachable container leaves the engagement line intact with `"margin": null`
rather than losing the day.

### Weekly — owner margin report
Celery beat `weekly-margin-report` (Mon 12:00 UTC, after the 06:00 Stripe sync and Sunday's stats
scrape) → `run_scheduler.auto_weekly_margin_report`: per-user CM & CM%, fully-loaded margin, system
gross margin, cohort engagement lift, LTV / LTV:CAC / payback. Delivered as an email **and** a
PostHog `margin_report` event for the §E.1.4 scorecard (per-user financials deliberately stay out of
the event body — plan §E.5). Also runnable ad hoc:
`python -m cqc_lem.utilities.margin --weekly-report [--email] [--json] [--days N]`.

### Margin math (§C.1, pinned by tests)
`src/cqc_lem/utilities/margin.py` keeps the formulas pure (no DB, no network) with the DB-fed
collectors and delivery below them, mirroring `scripts/model_health_check.py`'s split. Judgement
calls, all tested:

- **Monthly run-rate basis** for the weekly report (`window spend × 30.4375 / window days`) so cost
  is comparable with monthly MRR and §C.1 applies unchanged; the raw window spend rides along as
  `period_cost_usd`.
- **Trials are included at $0 MRR** — they cost money, so excluding them would hide real drag.
- **CM% / gross-margin% / payback / LTV:CAC are `null`, not `0`,** when undefined (no revenue, no
  CAC, non-positive margin) — a `0` there reads as "breaking even"/"instant payback".
- **Unknown cost categories count as variable**, so a newly added cost driver can never silently
  vanish from contribution margin.
- `unattributed_cost_usd` = system spend − attributed spend, which is exactly the plan's §E.2
  unattributed-spend alert signal (ready for #493).

### Data access
Read-only `cost_ledger` accessors in `db.py` — `get_cost_rollup` (group-by dimension whitelisted, so
it can't be interpolated), `get_user_cost`, `get_margin_users`, `cost_ledger_available` — each
degrading to an empty result when the table is absent.

## ⚠️ Dependency note
Issue #491 depends on **#490 (`cost_ledger` table)**, which is held `needs-human` /
`risk:migration`. Rather than pre-empt that migration decision, this PR reads the ledger through
those helpers and reports `ledger_available: false` with $0 spend until it lands — so the block and
report ship now and become **exact** the moment #490 merges, with no further changes here. Revenue,
MRR, cohort engagement lift and all the margin math are live today.

## Testing
- `tests/unit/utilities/test_margin.py` — 44 tests: every §C.1 formula numerically pinned, engagement
  lift (rate-mode + count fallback), daily block, weekly report, cohorts, renderers, collectors
  (db mocked), delivery failure paths, CLI.
- `tests/unit/utilities/test_db_cost_ledger.py` — the new accessors, incl. the rejected group-by
  dimension and missing-table degradation.
- `tests/unit/app/test_weekly_margin_report.py` — the beat task + its schedule entry.
- `tests/unit/utilities/test_observability.py` — `track_margin_report` (incl. that per-user
  financials are omitted).
- Full local suite: **3952 passed**.

## Owner action after release
Point the host cron at the repo script once a release containing `cqc_lem.utilities.margin` is
deployed (see the new "Performance / margin snapshot" section in `docs/DEPLOYMENT.md`):

```cron
30 23 * * * /home/lem/<repo-clone>/scripts/perf_snapshot.sh
```

Optional env (`.env.example`): `TIER_MRR_STARTER/PROFESSIONAL/ENTERPRISE` (default 29/79/199, matching
the SPA pricing table), `INFRA_FIXED_MONTHLY`, `CAC_USD`, `EXPECTED_LIFETIME_MONTHS`,
`MARGIN_REPORT_EMAIL`. Without `MARGIN_REPORT_EMAIL` the report is still generated and tracked, just
not emailed.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)