### PR TITLE
feat(observability): budget-threshold alerts + spend anomaly detection (closes #493)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -306,8 +306,9 @@ POSTHOG_API_KEY=your_posthog_api_key
 POSTHOG_HOST=https://us.i.posthog.com
 # Minimum log level forwarded to PostHog (DEBUG/INFO/WARNING/ERROR/CRITICAL). Default: ERROR
 POSTHOG_LOG_LEVEL=ERROR
-# Personal API key (insight + dashboard write scope) used ONLY by scripts/posthog_dashboards.py to
-# provision the cost/margin dashboards (§E.1). Not needed by the app — leave unset in the stack.
+# Personal API key (insight + dashboard write scope) used by scripts/posthog_dashboards.py to
+# provision the cost/margin dashboards (§E.1), and — read-only — by the daily budget alerts to read
+# LLM cache-hit rate (§E.2). Optional in the stack: unset just skips the cache-hit check.
 POSTHOG_PERSONAL_API_KEY=
 # PostHog project the dashboards live in, and the app host used to build their links.
 POSTHOG_PROJECT_ID=475262
@@ -328,6 +329,29 @@ CAC_USD=0
 EXPECTED_LIFETIME_MONTHS=12
 # Where the weekly margin report is emailed. Empty = generated + tracked in PostHog, not emailed.
 MARGIN_REPORT_EMAIL=
+
+# --- Budget / anomaly alerts (docs/cost-performance-margin-plan.md §E.2) ---
+# Daily Celery check (`auto_daily_cost_alerts`). All thresholds are tunable per environment.
+# Per-user variable+semi-variable cost as a share of that user's tier MRR (0.25 = 25% of MRR).
+COST_ALERT_USER_COST_PCT=0.25
+# System gross-margin floor — alert when gross_margin% drops below it (0.70 = the 70% target).
+COST_ALERT_MARGIN_FLOOR=0.70
+# Spend anomaly: alert when a day's spend exceeds mean + N×stdev of the trailing window.
+COST_ALERT_SPEND_SIGMA=3
+# Hard daily spend ceiling in USD; 0 disables the absolute-budget check.
+COST_ALERT_DAILY_BUDGET_USD=0
+# Noise floor — a day under this many USD never trips the σ check (cents can't be an anomaly).
+COST_ALERT_MIN_SPEND_USD=1
+# LLM cache-hit collapse: relative drop vs the trailing baseline (0.5 = cache-hit% halved).
+COST_ALERT_CACHE_DROP_PCT=0.5
+# Optional absolute cache-hit floor (0 = disabled) and the minimum llm_call volume to judge either.
+COST_ALERT_CACHE_HIT_FLOOR=0
+COST_ALERT_CACHE_MIN_CALLS=50
+# Share of spend with no user (system rows) or no feature before it reads as an instrumentation
+# regression (0.10 = 10%).
+COST_ALERT_UNATTRIBUTED_PCT=0.10
+# Where budget alerts are emailed. Empty falls back to MARGIN_REPORT_EMAIL.
+COST_ALERT_EMAIL=
 
 # --- Codecov (coverage reporting) ---
 CODECOV_TOKEN=your_codecov_token

--- a/docs/cost-performance-margin-plan.md
+++ b/docs/cost-performance-margin-plan.md
@@ -285,7 +285,7 @@ could degrade output quality is gated by the quality signals (engagement_rate,
 | Cadence | Job | Output |
 |---|---|---|
 | **Daily** | Extend `snapshot.sh` with a cost+margin block (`cost_by_feature`, `spend_usd`, est. `mrr`, `contribution_margin`) appended to `metrics.jsonl` | trend line for cost & margin next to engagement |
-| **Daily** | Spend anomaly detection (spend vs. trailing-7-day mean/σ) | alert if today's spend > μ+3σ or a per-user ceiling is breached |
+| **Daily** | Spend anomaly detection (spend vs. trailing-7-day mean/σ) — *shipped, issue #493: Celery beat `daily-cost-alerts` → `run_scheduler.auto_daily_cost_alerts`, see §E.2* | alert if the last complete day's spend > μ+3σ or a per-user ceiling is breached |
 | **Weekly** | Margin report (per-user CM, system gross margin, cohort engagement lift, LTV:CAC) | posted to owner (email/PostHog dashboard) |
 | **Weekly** | Auto-optimization recommender: scans cost×quality by feature×tier, emits ranked recommendations; for **safe** changes (config toggle, cache extension) the agent pipeline can open an `agent:ready` PR; anything touching routing/quality is filed **`risk:product-decision`** for a human call | recommendations + optional auto-PRs |
 
@@ -350,12 +350,29 @@ exact §C.1 figures from the durable ledger.
 
 ### E.2 Alerts (thresholds)
 
-- **Per-user cost ceiling breached** (variable cost > X% of tier MRR).
-- **Gross-margin floor breached** (system gross_margin% < target).
-- **Spend anomaly** (daily spend > μ+3σ of trailing 7 days, or > absolute daily budget).
-- **Cache-hit-rate collapse** (LLM cache-hit% drops → cost spike warning).
-- **Unattributed spend** (share of `llm_call` events with `user_id="system"` or null `feature`
-  rises above a threshold → instrumentation regression).
+**Shipped (issue #493).** `src/cqc_lem/utilities/cost_alerts.py` holds the pure, unit-tested
+evaluators plus the ledger/PostHog collectors and delivery; Celery beat `daily-cost-alerts` →
+`run_scheduler.auto_daily_cost_alerts` runs them **daily at 13:00 UTC over the last COMPLETE UTC
+day** (a partial today would read as a spend collapse). Also `python -m cqc_lem.utilities.cost_alerts
+[--json] [--email] [--day YYYY-MM-DD]` — exit 2 signals a breach.
+
+| Alert | Source | Fires when | Threshold env var (default) |
+|---|---|---|---|
+| **Per-user cost ceiling** | `cost_ledger` via the §D.2 margin report | a user's variable+semi-variable cost > X% of their tier MRR (critical when it exceeds MRR outright — that user is margin-negative) | `COST_ALERT_USER_COST_PCT` (0.25) |
+| **Gross-margin floor** | same | system `gross_margin%` < target (critical when negative) | `COST_ALERT_MARGIN_FLOOR` (0.70) |
+| **Spend anomaly** | `db.get_daily_cost_totals` | a day's spend > μ+Nσ of the trailing 7 days, and/or > an absolute daily budget (critical) | `COST_ALERT_SPEND_SIGMA` (3), `COST_ALERT_DAILY_BUDGET_USD` (0 = off), `COST_ALERT_MIN_SPEND_USD` (1, noise floor) |
+| **Cache-hit collapse** | PostHog `llm_call` (`cached`), read via `observability.posthog_hogql_query` | cache-hit% falls by X% vs its trailing call-weighted baseline, or under an optional absolute floor | `COST_ALERT_CACHE_DROP_PCT` (0.5), `COST_ALERT_CACHE_HIT_FLOOR` (0 = off), `COST_ALERT_CACHE_MIN_CALLS` (50) |
+| **Unattributed spend** | `cost_ledger` rollups | share of spend with no `user_id` **or** no/`system` `feature` rises above a threshold | `COST_ALERT_UNATTRIBUTED_PCT` (0.10) |
+
+Every check reports `ok`, `alert` or **`skipped` with a reason** — an absent `cost_ledger`, a day
+with no rows, too little trailing data, or an unconfigured PostHog read path is unknown data, never
+a $0 "all clear" and never a false alarm. Days missing from the ledger are NOT counted as $0 spend,
+so a ledger that starts capturing mid-window can't flag its first real day as a spike.
+
+Delivery reuses the margin report's path: an owner email (only when something actually fired — a
+daily "all clear" trains people to ignore it) to `COST_ALERT_EMAIL`, falling back to
+`MARGIN_REPORT_EMAIL`; one PostHog `cost_alert` event per alert; and a structured log line
+(`log_error` for critical, which the logger forwards to PostHog on its own).
 
 ### E.3 KPI tree (north-star: **System Gross Margin $ at target margin %**)
 
@@ -372,7 +389,8 @@ Quality guardrail (must hold): cohort engagement_rate · median authenticity_sco
 
 ### E.4 Cadence summary
 
-- **Daily:** engagement snapshot (exists) **+ new cost/margin block**; spend-anomaly check.
+- **Daily:** engagement snapshot (exists) **+ new cost/margin block**; the §E.2 alert sweep
+  (spend anomaly, per-user ceiling, margin floor, cache-hit collapse, unattributed spend).
 - **Weekly:** margin report + auto-optimization recommendations.
 - **Monthly:** proxy/infra accrual; cohort LTV:CAC review; target-margin recalibration.
 
@@ -399,7 +417,8 @@ Quality guardrail (must hold): cohort engagement_rate · median authenticity_sco
    *(Shipped, issue #491 — see the table at the end of §D.2. Exact spend needs step 2's ledger.)*
 4. **PostHog dashboards** (Cost Explorer, Margin by Cohort, Engagement Lift, Scorecard).
    *(Shipped, issue #492 — links + the `scripts/posthog_dashboards.py` provisioner in §E.1.)*
-5. **Alerts** — per-user ceiling, gross-margin floor, spend anomaly, unattributed-spend.
+5. **Alerts** — per-user ceiling, gross-margin floor, spend anomaly, cache-hit collapse,
+   unattributed-spend. *(Shipped, issue #493 — the table + thresholds in §E.2.)*
 6. **Cost-aware optimization loop** extending `complexity_router.py` (`risk:product-decision`).
 
 Each is filed as an `agent:ready` GitHub issue referencing this doc. Anything that can auto-degrade

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -206,6 +206,12 @@ app.conf.update(
             # Sunday night's stats scrape, so cohort engagement lift covers the full week.
             'schedule': crontab(hour='12', minute='0', day_of_week='monday')
         },
+        'daily-cost-alerts': {
+            'task': 'cqc_lem.app.run_scheduler.auto_daily_cost_alerts',
+            # Daily 13:00 UTC — scores YESTERDAY (the last complete UTC day), after the 6:00 Stripe
+            # sync so tier MRR is current, and after the weekly margin report so they never overlap.
+            'schedule': crontab(hour='13', minute='0')
+        },
 
     }
 )

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1152,5 +1152,21 @@ def auto_weekly_margin_report(self, days: int = 7):
             f"(emailed={result['emailed']}, tracked={result['tracked']})")
 
 
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True})
+def auto_daily_cost_alerts(self, days: int = 7):
+    """Daily budget/anomaly guardrails (issue #493, plan §E.2): per-user cost ceiling, system
+    gross-margin floor, spend anomaly (μ+Nσ / absolute budget), LLM cache-hit collapse and
+    unattributed spend. Evaluates the last COMPLETE UTC day and delivers only actual breaches
+    (owner email + a PostHog `cost_alert` event each)."""
+    from cqc_lem.utilities.cost_alerts import collect_cost_alert_report, send_cost_alerts
+
+    report = collect_cost_alert_report(days=days)
+    result = send_cost_alerts(report)
+    return (f"Cost alerts {report.get('date')}: {result['alerts']} alert(s), "
+            f"{report.get('critical_count')} critical, "
+            f"skipped {report.get('skipped_checks')} "
+            f"(emailed={result['emailed']}, tracked={result['tracked']})")
+
+
 if __name__ == "__main__":
     print("Process finished")

--- a/src/cqc_lem/utilities/cost_alerts.py
+++ b/src/cqc_lem/utilities/cost_alerts.py
@@ -1,0 +1,508 @@
+"""Budget-threshold alerts + spend anomaly detection (docs/cost-performance-margin-plan.md §E.2).
+
+Structured like `utilities/margin.py`: PURE evaluators first (no DB, no network — these are what the
+unit tests pin with synthetic breaches), then the DB/PostHog-fed collectors, delivery and CLI.
+
+Five checks, each with an env-configurable threshold (`COST_ALERT_*`, see `.env.example`):
+
+| Check | Source | Fires when |
+|---|---|---|
+| `user_cost_ceiling`   | `cost_ledger` via the margin report | a user's variable+semi-variable cost > X% of their tier MRR |
+| `gross_margin_floor`  | `cost_ledger` via the margin report | system gross_margin% < the target floor |
+| `spend_anomaly`       | `cost_ledger` daily totals          | a day's spend > μ+Nσ of the trailing window, or > an absolute daily budget |
+| `cache_hit_collapse`  | PostHog `llm_call` events           | LLM cache-hit% drops vs its trailing baseline (or under an absolute floor) |
+| `unattributed_spend`  | `cost_ledger` rollups               | share of spend with no user or no feature rises above a threshold |
+
+Every check reports `ok`, `alert` or **`skipped` with a reason** — an unreadable ledger or an
+unconfigured PostHog read path is unknown data, never a $0 "all clear" and never a false alarm.
+Runs daily via Celery beat (`run_scheduler.auto_daily_cost_alerts`) over the last COMPLETE UTC day.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from datetime import date, datetime, timedelta, timezone
+from typing import Mapping, Optional, Sequence
+
+from cqc_lem.utilities.env_constants import (
+    COST_ALERT_CACHE_DROP,
+    COST_ALERT_CACHE_FLOOR,
+    COST_ALERT_CACHE_MIN_CALLS,
+    COST_ALERT_DAILY_BUDGET,
+    COST_ALERT_EMAIL,
+    COST_ALERT_MARGIN_FLOOR,
+    COST_ALERT_MIN_SPEND,
+    COST_ALERT_SPEND_SIGMA,
+    COST_ALERT_UNATTRIBUTED,
+    COST_ALERT_USER_COST_PCT,
+    MARGIN_REPORT_EMAIL,
+)
+from cqc_lem.utilities.logger import log_error, log_info, log_warning
+
+# ───────────────────────────── vocabulary ─────────────────────────────
+
+CHECK_USER_COST = "user_cost_ceiling"
+CHECK_MARGIN_FLOOR = "gross_margin_floor"
+CHECK_SPEND_ANOMALY = "spend_anomaly"
+CHECK_CACHE_COLLAPSE = "cache_hit_collapse"
+CHECK_UNATTRIBUTED = "unattributed_spend"
+
+STATUS_OK = "ok"
+STATUS_ALERT = "alert"
+STATUS_SKIPPED = "skipped"
+
+SEVERITY_WARNING = "warning"
+SEVERITY_CRITICAL = "critical"
+
+# Trailing days the anomaly baseline is drawn from, and the minimum number of them that must carry
+# ledger rows before μ/σ mean anything.
+ANOMALY_WINDOW_DAYS = 7
+ANOMALY_MIN_DAYS = 3
+
+# Rollup keys that mean "we could not attribute this" on either dimension.
+UNATTRIBUTED_KEYS = frozenset({"unknown", "system", "", "none"})
+
+
+def default_thresholds() -> dict:
+    """Thresholds from the environment (`COST_ALERT_*`). Every caller merges over this, so a test —
+    or a CLI run — can override one threshold without restating the rest."""
+    return {
+        "user_cost_pct_of_mrr": COST_ALERT_USER_COST_PCT,
+        "gross_margin_floor": COST_ALERT_MARGIN_FLOOR,
+        "spend_sigma": COST_ALERT_SPEND_SIGMA,
+        "daily_budget_usd": COST_ALERT_DAILY_BUDGET,
+        "min_spend_usd": COST_ALERT_MIN_SPEND,
+        "cache_drop_pct": COST_ALERT_CACHE_DROP,
+        "cache_hit_floor": COST_ALERT_CACHE_FLOOR,
+        "cache_min_calls": COST_ALERT_CACHE_MIN_CALLS,
+        "unattributed_pct": COST_ALERT_UNATTRIBUTED,
+    }
+
+
+def _check(check_id: str, status: str, alerts: Optional[Sequence[Mapping]] = None,
+           reason: Optional[str] = None, **detail) -> dict:
+    return {"check": check_id, "status": status, "alerts": [dict(a) for a in (alerts or [])],
+            "reason": reason, **detail}
+
+
+def _alert(check_id: str, severity: str, title: str, detail: str, value: Optional[float],
+           threshold: Optional[float], **extra) -> dict:
+    return {"check": check_id, "severity": severity, "title": title, "detail": detail,
+            "value": value, "threshold": threshold, **extra}
+
+
+def _round(value: Optional[float], digits: int = 6) -> Optional[float]:
+    return None if value is None else round(float(value), digits)
+
+
+# ───────────────────────────── pure evaluators ─────────────────────────────
+
+def evaluate_user_cost_ceiling(users: Optional[Sequence[Mapping]],
+                               pct_of_mrr: float = COST_ALERT_USER_COST_PCT) -> dict:
+    """§E.2 per-user cost ceiling over the margin report's `users` rows (costs already on a monthly
+    run-rate basis, so they are comparable with monthly MRR). Users with $0 MRR — free trials — are
+    skipped: "% of MRR" is undefined against no revenue, and their drag is caught by the system
+    gross-margin floor instead. A user whose cost exceeds their whole MRR is critical: that user is
+    margin-negative, not merely expensive."""
+    alerts, judged = [], 0
+    for row in users or []:
+        mrr = float(row.get("mrr_usd") or 0.0)
+        if mrr <= 0:
+            continue
+        judged += 1
+        cost = float(row.get("variable_cost_usd") or 0.0) + float(row.get("semi_variable_cost_usd") or 0.0)
+        ratio = cost / mrr
+        if ratio <= pct_of_mrr:
+            continue
+        alerts.append(_alert(
+            CHECK_USER_COST,
+            SEVERITY_CRITICAL if ratio >= 1.0 else SEVERITY_WARNING,
+            f"User #{row.get('user_id')} variable cost is {ratio * 100:.1f}% of tier MRR",
+            f"${cost:,.2f}/mo variable+semi-variable against ${mrr:,.2f}/mo MRR "
+            f"({row.get('tier') or 'unknown tier'}); ceiling is {pct_of_mrr * 100:.0f}%.",
+            _round(ratio, 4), pct_of_mrr,
+            user_id=row.get("user_id"), tier=row.get("tier"),
+            cost_usd=_round(cost, 4), mrr_usd=_round(mrr, 2),
+        ))
+    if not judged:
+        return _check(CHECK_USER_COST, STATUS_SKIPPED, reason="no paying users to judge",
+                      users_judged=0)
+    return _check(CHECK_USER_COST, STATUS_ALERT if alerts else STATUS_OK, alerts,
+                  users_judged=judged)
+
+
+def evaluate_gross_margin_floor(system: Optional[Mapping],
+                                floor: float = COST_ALERT_MARGIN_FLOOR) -> dict:
+    """§E.2 system gross-margin floor. `gross_margin_pct` is None with no revenue (see
+    `margin.margin_pct`) — that is undefined, not a breach, so the check skips."""
+    pct = (system or {}).get("gross_margin_pct")
+    if pct is None:
+        return _check(CHECK_MARGIN_FLOOR, STATUS_SKIPPED, reason="no revenue — margin % undefined")
+    pct = float(pct)
+    if pct >= floor:
+        return _check(CHECK_MARGIN_FLOOR, STATUS_OK, value=_round(pct, 4), threshold=floor)
+    return _check(CHECK_MARGIN_FLOOR, STATUS_ALERT, [_alert(
+        CHECK_MARGIN_FLOOR,
+        SEVERITY_CRITICAL if pct < 0 else SEVERITY_WARNING,
+        f"System gross margin {pct * 100:.1f}% is below the {floor * 100:.0f}% floor",
+        f"Gross margin ${float((system or {}).get('gross_margin_usd') or 0.0):,.2f} on "
+        f"${float((system or {}).get('mrr_usd') or 0.0):,.2f} MRR across "
+        f"{(system or {}).get('active_users')} active user(s).",
+        _round(pct, 4), floor,
+        gross_margin_usd=(system or {}).get("gross_margin_usd"),
+        mrr_usd=(system or {}).get("mrr_usd"),
+    )], value=_round(pct, 4), threshold=floor)
+
+
+def _day_key(day) -> str:
+    return day.isoformat() if hasattr(day, "isoformat") else str(day)
+
+
+def evaluate_spend_anomaly(daily_spend: Optional[Mapping], day: date,
+                           sigma: float = COST_ALERT_SPEND_SIGMA,
+                           daily_budget_usd: float = COST_ALERT_DAILY_BUDGET,
+                           min_spend_usd: float = COST_ALERT_MIN_SPEND,
+                           min_days: int = ANOMALY_MIN_DAYS) -> dict:
+    """§E.2 spend anomaly: `day`'s spend against μ+Nσ of the trailing days in `daily_spend`, plus an
+    optional hard daily budget.
+
+    Days ABSENT from `daily_spend` are not counted as $0 — a ledger that started capturing mid-window
+    would otherwise show a zero baseline and flag its first real day as a spike. `min_spend_usd` is
+    the noise floor: on a near-idle ledger σ collapses to ~0 and any movement clears μ+Nσ, so a day
+    under the floor never alerts. The absolute budget is judged independently of the baseline, since
+    it is meaningful on day one."""
+    series = {str(k): float(v or 0.0) for k, v in (daily_spend or {}).items()}
+    key = _day_key(day)
+    today = series.get(key)
+    if today is None:
+        return _check(CHECK_SPEND_ANOMALY, STATUS_SKIPPED, reason=f"no ledger rows for {key}")
+
+    alerts = []
+    if daily_budget_usd and daily_budget_usd > 0 and today > daily_budget_usd:
+        alerts.append(_alert(
+            CHECK_SPEND_ANOMALY, SEVERITY_CRITICAL,
+            f"Daily spend ${today:,.2f} exceeded the ${daily_budget_usd:,.2f} budget",
+            f"{key} spend is {today / daily_budget_usd:.1f}× the absolute daily budget.",
+            _round(today, 4), daily_budget_usd, day=key, kind="budget",
+        ))
+
+    baseline = [usd for other, usd in series.items() if other < key]
+    if len(baseline) < min_days:
+        status = STATUS_ALERT if alerts else STATUS_SKIPPED
+        return _check(CHECK_SPEND_ANOMALY, status, alerts,
+                      reason=None if alerts else f"only {len(baseline)} trailing day(s) of ledger data",
+                      spend_usd=_round(today, 4), baseline_days=len(baseline))
+
+    mean = statistics.fmean(baseline)
+    stdev = statistics.pstdev(baseline)
+    threshold = mean + (sigma * stdev)
+    if today > threshold and today >= min_spend_usd:
+        alerts.append(_alert(
+            CHECK_SPEND_ANOMALY, SEVERITY_WARNING,
+            f"Daily spend ${today:,.2f} is above μ+{sigma:g}σ (${threshold:,.2f})",
+            f"{key} spend vs a {len(baseline)}-day trailing mean of ${mean:,.2f} "
+            f"(σ ${stdev:,.2f}).",
+            _round(today, 4), _round(threshold, 4), day=key, kind="sigma",
+            mean_usd=_round(mean, 4), stdev_usd=_round(stdev, 4),
+        ))
+    return _check(CHECK_SPEND_ANOMALY, STATUS_ALERT if alerts else STATUS_OK, alerts,
+                  spend_usd=_round(today, 4), mean_usd=_round(mean, 4), stdev_usd=_round(stdev, 4),
+                  threshold=_round(threshold, 4), baseline_days=len(baseline))
+
+
+def evaluate_cache_hit_collapse(cache: Optional[Mapping],
+                                drop_pct: float = COST_ALERT_CACHE_DROP,
+                                floor: float = COST_ALERT_CACHE_FLOOR,
+                                min_calls: int = COST_ALERT_CACHE_MIN_CALLS) -> dict:
+    """§E.2 cache-hit-rate collapse. `cache` is `{"rate", "calls", "baseline_rate", "baseline_calls"}`
+    from `collect_cache_hit_stats` (None when PostHog isn't readable → skipped).
+
+    Alerts on a RELATIVE drop against the trailing baseline — the absolute rate is workload-dependent,
+    the drop is what predicts a cost spike — and optionally on an absolute floor (0 disables it).
+    Both are gated on `min_calls` so a quiet day of a handful of calls can't read as a collapse."""
+    if not cache:
+        return _check(CHECK_CACHE_COLLAPSE, STATUS_SKIPPED,
+                      reason="PostHog llm_call data unavailable")
+    calls = int(cache.get("calls") or 0)
+    rate = cache.get("rate")
+    if rate is None or calls < min_calls:
+        return _check(CHECK_CACHE_COLLAPSE, STATUS_SKIPPED,
+                      reason=f"only {calls} llm_call event(s) — under the {min_calls}-call minimum",
+                      calls=calls, rate=_round(rate, 4))
+    rate = float(rate)
+    baseline = cache.get("baseline_rate")
+    baseline_calls = int(cache.get("baseline_calls") or 0)
+    alerts = []
+    if floor and floor > 0 and rate < floor:
+        alerts.append(_alert(
+            CHECK_CACHE_COLLAPSE, SEVERITY_WARNING,
+            f"LLM cache-hit rate {rate * 100:.1f}% is under the {floor * 100:.0f}% floor",
+            f"{calls} llm_call event(s) on the day — every miss is billed spend.",
+            _round(rate, 4), floor, kind="floor", calls=calls,
+        ))
+    if baseline is not None and baseline_calls >= min_calls and float(baseline) > 0:
+        baseline = float(baseline)
+        drop = (baseline - rate) / baseline
+        if drop >= drop_pct:
+            alerts.append(_alert(
+                CHECK_CACHE_COLLAPSE, SEVERITY_WARNING,
+                f"LLM cache-hit rate fell {drop * 100:.1f}% vs the trailing baseline",
+                f"{rate * 100:.1f}% today vs {baseline * 100:.1f}% baseline over "
+                f"{baseline_calls} call(s) — expect a proportional cost spike.",
+                _round(drop, 4), drop_pct, kind="drop",
+                rate=_round(rate, 4), baseline_rate=_round(baseline, 4), calls=calls,
+            ))
+    return _check(CHECK_CACHE_COLLAPSE, STATUS_ALERT if alerts else STATUS_OK, alerts,
+                  rate=_round(rate, 4), baseline_rate=_round(baseline, 4), calls=calls)
+
+
+def evaluate_unattributed_spend(system: Optional[Mapping], cost_by_feature: Optional[Mapping],
+                                max_share: float = COST_ALERT_UNATTRIBUTED) -> dict:
+    """§E.2 unattributed spend — an instrumentation regression detector, on BOTH dimensions:
+    spend carrying no `user_id` (the margin report's `unattributed_cost_usd`, i.e. system/shared
+    ledger rows) and spend whose `feature` is missing or `system`. The larger share drives the alert
+    so a regression on either dimension surfaces."""
+    total = float((system or {}).get("period_cost_usd") or 0.0)
+    if total <= 0:
+        return _check(CHECK_UNATTRIBUTED, STATUS_SKIPPED, reason="no spend in the window")
+    by_user = float((system or {}).get("unattributed_cost_usd") or 0.0) / total
+    featureless = sum(float(usd or 0.0) for key, usd in (cost_by_feature or {}).items()
+                      if str(key).strip().lower() in UNATTRIBUTED_KEYS)
+    by_feature = featureless / total
+    worst = max(by_user, by_feature)
+    if worst <= max_share:
+        return _check(CHECK_UNATTRIBUTED, STATUS_OK, user_share=_round(by_user, 4),
+                      feature_share=_round(by_feature, 4), threshold=max_share)
+    dimension = "user_id" if by_user >= by_feature else "feature"
+    return _check(CHECK_UNATTRIBUTED, STATUS_ALERT, [_alert(
+        CHECK_UNATTRIBUTED, SEVERITY_WARNING,
+        f"{worst * 100:.1f}% of spend has no {dimension}",
+        f"${total * worst:,.2f} of ${total:,.2f} window spend is unattributed by {dimension} "
+        f"(threshold {max_share * 100:.0f}%) — cost cannot be sliced, check the instrumentation.",
+        _round(worst, 4), max_share, dimension=dimension,
+        user_share=_round(by_user, 4), feature_share=_round(by_feature, 4),
+        unattributed_usd=_round(total * worst, 4), total_usd=_round(total, 4),
+    )], user_share=_round(by_user, 4), feature_share=_round(by_feature, 4), threshold=max_share)
+
+
+# ───────────────────────────── pure report builder ─────────────────────────────
+
+def build_cost_alert_report(day: date, margin_report: Optional[Mapping],
+                            cost_by_feature: Optional[Mapping] = None,
+                            daily_spend: Optional[Mapping] = None,
+                            cache: Optional[Mapping] = None,
+                            thresholds: Optional[Mapping] = None) -> dict:
+    """Run all five §E.2 checks and collect them into one report. `margin_report` is a
+    `margin.build_margin_report` result (the ledger-backed spend/MRR join); the rest are the raw
+    per-day and per-feature rollups and the PostHog cache stats."""
+    limits = {**default_thresholds(), **(thresholds or {})}
+    report = margin_report or {}
+    system = report.get("system") or {}
+    checks = [
+        evaluate_user_cost_ceiling(report.get("users"), limits["user_cost_pct_of_mrr"]),
+        evaluate_gross_margin_floor(system, limits["gross_margin_floor"]),
+        evaluate_spend_anomaly(daily_spend, day, limits["spend_sigma"],
+                               limits["daily_budget_usd"], limits["min_spend_usd"]),
+        evaluate_cache_hit_collapse(cache, limits["cache_drop_pct"], limits["cache_hit_floor"],
+                                    limits["cache_min_calls"]),
+        evaluate_unattributed_spend(system, cost_by_feature, limits["unattributed_pct"]),
+    ]
+    alerts = [alert for check in checks for alert in check["alerts"]]
+    return {
+        "date": day.isoformat(),
+        "period": report.get("period") or {},
+        "ledger_available": bool(report.get("ledger_available", False)),
+        "thresholds": limits,
+        "checks": checks,
+        "alerts": alerts,
+        "alert_count": len(alerts),
+        "critical_count": sum(1 for a in alerts if a.get("severity") == SEVERITY_CRITICAL),
+        "skipped_checks": [c["check"] for c in checks if c["status"] == STATUS_SKIPPED],
+    }
+
+
+def render_cost_alerts_text(report: Mapping) -> str:
+    """Plain-text alert digest — also the plaintext alternative of the email (a missing text/plain
+    part is a spam signal, see `email._dispatch_email`)."""
+    lines = [f"LEM cost alerts — {report.get('date')} "
+             f"({report.get('alert_count', 0)} alert(s), "
+             f"{report.get('critical_count', 0)} critical)", ""]
+    if not report.get("ledger_available", True):
+        lines += ["NOTE: cost_ledger is not present yet — spend reads as $0, so cost-based checks "
+                  "are informational until it lands.", ""]
+    for alert in report.get("alerts") or []:
+        lines.append(f"[{str(alert.get('severity', '')).upper()}] {alert.get('title')}")
+        lines.append(f"    {alert.get('detail')}")
+    if not report.get("alerts"):
+        lines.append("No thresholds breached.")
+    lines += ["", "Checks:"]
+    for check in report.get("checks") or []:
+        reason = f" — {check.get('reason')}" if check.get("reason") else ""
+        lines.append(f"  {check.get('check')}: {check.get('status')}{reason}")
+    return "\n".join(lines)
+
+
+def render_cost_alerts_html(report: Mapping) -> str:
+    """HTML body of the owner email — the text digest in a <pre> block reads correctly in every
+    client without a template, and the numbers are identical to the plaintext part."""
+    body = (render_cost_alerts_text(report)
+            .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+    return ("<h2>LEM cost alerts</h2><pre style=\"font-family:ui-monospace,monospace;"
+            f"font-size:13px;line-height:1.5\">{body}</pre>")
+
+
+# ─────────────────────── DB/PostHog-fed collectors & delivery ───────────────────────
+
+def _today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def _last_complete_day() -> date:
+    """Yesterday (UTC). The checks score a WHOLE day — today is still filling up, and a partial day
+    would read as a spend collapse rather than a real signal."""
+    return _today() - timedelta(days=1)
+
+
+CACHE_HIT_SQL = """
+SELECT toDate(timestamp) AS day,
+       countIf(properties.cached = true) AS hits,
+       count() AS calls
+FROM events
+WHERE event = 'llm_call' AND timestamp >= toDateTime('{start}') AND timestamp < toDateTime('{end}')
+GROUP BY day
+ORDER BY day
+""".strip()
+
+
+def collect_cache_hit_stats(day: Optional[date] = None,
+                            window_days: int = ANOMALY_WINDOW_DAYS) -> Optional[dict]:
+    """LLM cache-hit rate for `day` and the trailing `window_days` baseline, read from PostHog
+    `llm_call` events (the only place the `cached` flag lives — `cost_ledger` stores net spend).
+    None when the PostHog read path isn't configured or the query fails, which the check reports as
+    skipped. The baseline is call-weighted, not a mean of daily rates, so one low-volume day can't
+    swing it."""
+    from cqc_lem.utilities.observability import posthog_hogql_query
+
+    day = day or _last_complete_day()
+    start = day - timedelta(days=max(window_days, 1))
+    rows = posthog_hogql_query(CACHE_HIT_SQL.format(start=start.isoformat(),
+                                                    end=(day + timedelta(days=1)).isoformat()))
+    if rows is None:
+        return None
+    key = day.isoformat()
+    hits = calls = baseline_hits = baseline_calls = 0
+    for row in rows:
+        if not row or len(row) < 3:
+            continue
+        row_day = _day_key(row[0])[:10]
+        row_hits, row_calls = int(row[1] or 0), int(row[2] or 0)
+        if row_day == key:
+            hits, calls = row_hits, row_calls
+        elif row_day < key:
+            baseline_hits += row_hits
+            baseline_calls += row_calls
+    return {
+        "date": key,
+        "rate": (hits / calls) if calls else None,
+        "calls": calls,
+        "baseline_rate": (baseline_hits / baseline_calls) if baseline_calls else None,
+        "baseline_calls": baseline_calls,
+    }
+
+
+def collect_cost_alert_report(day: Optional[date] = None, days: int = ANOMALY_WINDOW_DAYS,
+                              thresholds: Optional[Mapping] = None) -> dict:
+    """Read the ledger + PostHog for the last complete day and run every §E.2 check.
+
+    The margin report is reused wholesale rather than re-deriving spend-vs-MRR here — it already
+    computes the §C.1 per-user and system figures the ceiling, margin-floor and unattributed checks
+    need, from the same `cost_ledger`."""
+    from cqc_lem.utilities.db import get_cost_rollup, get_daily_cost_totals
+    from cqc_lem.utilities.margin import collect_margin_report
+
+    day = day or _last_complete_day()
+    window = max(days, 1)
+    start = day - timedelta(days=window - 1)
+    return build_cost_alert_report(
+        day,
+        collect_margin_report(end=day, days=window),
+        cost_by_feature=get_cost_rollup(start, day, group_by="feature"),
+        daily_spend=get_daily_cost_totals(day - timedelta(days=ANOMALY_WINDOW_DAYS), day),
+        cache=collect_cache_hit_stats(day, window_days=ANOMALY_WINDOW_DAYS),
+        thresholds=thresholds,
+    )
+
+
+def send_cost_alerts(report: Optional[Mapping] = None,
+                     to_email: Optional[str] = None) -> dict:
+    """Deliver breaches over the existing notification path: an owner email (only when something
+    actually fired — a daily "all clear" would train the owner to ignore it), one PostHog
+    `cost_alert` event per alert, and a structured log line per alert (`log_error` for critical,
+    which the logger forwards to PostHog on its own). Delivery failures are logged, never raised, so
+    a beat run isn't lost over an email hiccup."""
+    from cqc_lem.utilities.email import _dispatch_email
+    from cqc_lem.utilities.observability import track_cost_alert
+
+    report = report if report is not None else collect_cost_alert_report()
+    alerts = list(report.get("alerts") or [])
+    day = report.get("date")
+
+    for alert in alerts:
+        message = f"Cost alert [{alert.get('check')}]: {alert.get('title')}"
+        context = {"user_id": alert.get("user_id"), "task_name": "auto_daily_cost_alerts"}
+        if alert.get("severity") == SEVERITY_CRITICAL:
+            log_error(message, **context)
+        else:
+            log_warning(message, **context)
+
+    tracked = False
+    try:
+        for alert in alerts:
+            track_cost_alert(alert, day=day)
+        tracked = True
+    except Exception as e:
+        log_warning("Cost alert PostHog capture failed", exc=e, task_name="auto_daily_cost_alerts")
+
+    recipient = to_email or COST_ALERT_EMAIL or MARGIN_REPORT_EMAIL
+    emailed = False
+    if alerts and recipient:
+        try:
+            severity = "CRITICAL" if report.get("critical_count") else "WARNING"
+            emailed = bool(_dispatch_email(
+                recipient, f"LEM cost alert ({severity}) — {len(alerts)} threshold(s) breached {day}",
+                render_cost_alerts_html(report), text_content=render_cost_alerts_text(report),
+                high_priority=bool(report.get("critical_count"))))
+        except Exception as e:
+            log_warning("Cost alert email failed", exc=e, task_name="auto_daily_cost_alerts")
+    elif alerts and not recipient:
+        log_warning("COST_ALERT_EMAIL/MARGIN_REPORT_EMAIL not set — cost alerts not emailed",
+                    task_name="auto_daily_cost_alerts")
+
+    log_info(f"Cost alerts for {day}: {len(alerts)} alert(s), "
+             f"{report.get('critical_count', 0)} critical, "
+             f"skipped {report.get('skipped_checks') or []} (emailed={emailed}, tracked={tracked})",
+             task_name="auto_daily_cost_alerts")
+    return {"emailed": emailed, "tracked": tracked, "alerts": len(alerts), "report": report}
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="LEM cost budget alerts / anomaly detection")
+    parser.add_argument("--json", action="store_true", help="print the full report as JSON")
+    parser.add_argument("--email", action="store_true", help="deliver breaches (email + PostHog)")
+    parser.add_argument("--day", help="day to evaluate (YYYY-MM-DD, default: yesterday UTC)")
+    parser.add_argument("--days", type=int, default=ANOMALY_WINDOW_DAYS,
+                        help=f"margin/rollup window in days (default {ANOMALY_WINDOW_DAYS})")
+    args = parser.parse_args(argv)
+
+    day = date.fromisoformat(args.day) if args.day else None
+    report = collect_cost_alert_report(day=day, days=args.days)
+    if args.email:
+        send_cost_alerts(report)
+    print(json.dumps(report) if args.json else render_cost_alerts_text(report))
+    # Exit 2 on a breach so a cron/CI caller can act on it without parsing the output.
+    return 2 if report.get("alert_count") else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/src/cqc_lem/utilities/cost_alerts.py
+++ b/src/cqc_lem/utilities/cost_alerts.py
@@ -63,6 +63,13 @@ ANOMALY_MIN_DAYS = 3
 # Rollup keys that mean "we could not attribute this" on either dimension.
 UNATTRIBUTED_KEYS = frozenset({"unknown", "system", "", "none"})
 
+# Checks fed by `cost_ledger` (through the margin report or the daily rollups). Without the table the
+# margin report derives its cost fields from empty rollups, so these would read a confident $0 "ok" —
+# indistinguishable from a genuinely cheap day. They are reported skipped instead: unknown ≠ zero.
+LEDGER_BACKED_CHECKS = frozenset({CHECK_USER_COST, CHECK_MARGIN_FLOOR, CHECK_SPEND_ANOMALY,
+                                  CHECK_UNATTRIBUTED})
+LEDGER_MISSING_REASON = "cost_ledger not present — spend is unknown, not $0"
+
 
 def default_thresholds() -> dict:
     """Thresholds from the environment (`COST_ALERT_*`). Every caller merges over this, so a test —
@@ -288,6 +295,10 @@ def evaluate_unattributed_spend(system: Optional[Mapping], cost_by_feature: Opti
 
 # ───────────────────────────── pure report builder ─────────────────────────────
 
+def _ledger_missing(check_id: str) -> dict:
+    return _check(check_id, STATUS_SKIPPED, reason=LEDGER_MISSING_REASON)
+
+
 def build_cost_alert_report(day: date, margin_report: Optional[Mapping],
                             cost_by_feature: Optional[Mapping] = None,
                             daily_spend: Optional[Mapping] = None,
@@ -295,24 +306,33 @@ def build_cost_alert_report(day: date, margin_report: Optional[Mapping],
                             thresholds: Optional[Mapping] = None) -> dict:
     """Run all five §E.2 checks and collect them into one report. `margin_report` is a
     `margin.build_margin_report` result (the ledger-backed spend/MRR join); the rest are the raw
-    per-day and per-feature rollups and the PostHog cache stats."""
+    per-day and per-feature rollups and the PostHog cache stats.
+
+    When the margin report says `ledger_available: false` the `LEDGER_BACKED_CHECKS` are not run at
+    all — their inputs would be zeros from empty rollups, not measurements. Only the PostHog-fed
+    cache check still has real data to judge."""
     limits = {**default_thresholds(), **(thresholds or {})}
     report = margin_report or {}
     system = report.get("system") or {}
+    ledger = bool(report.get("ledger_available", False))
     checks = [
-        evaluate_user_cost_ceiling(report.get("users"), limits["user_cost_pct_of_mrr"]),
-        evaluate_gross_margin_floor(system, limits["gross_margin_floor"]),
+        evaluate_user_cost_ceiling(report.get("users"), limits["user_cost_pct_of_mrr"])
+        if ledger else _ledger_missing(CHECK_USER_COST),
+        evaluate_gross_margin_floor(system, limits["gross_margin_floor"])
+        if ledger else _ledger_missing(CHECK_MARGIN_FLOOR),
         evaluate_spend_anomaly(daily_spend, day, limits["spend_sigma"],
-                               limits["daily_budget_usd"], limits["min_spend_usd"]),
+                               limits["daily_budget_usd"], limits["min_spend_usd"])
+        if ledger else _ledger_missing(CHECK_SPEND_ANOMALY),
         evaluate_cache_hit_collapse(cache, limits["cache_drop_pct"], limits["cache_hit_floor"],
                                     limits["cache_min_calls"]),
-        evaluate_unattributed_spend(system, cost_by_feature, limits["unattributed_pct"]),
+        evaluate_unattributed_spend(system, cost_by_feature, limits["unattributed_pct"])
+        if ledger else _ledger_missing(CHECK_UNATTRIBUTED),
     ]
     alerts = [alert for check in checks for alert in check["alerts"]]
     return {
         "date": day.isoformat(),
         "period": report.get("period") or {},
-        "ledger_available": bool(report.get("ledger_available", False)),
+        "ledger_available": ledger,
         "thresholds": limits,
         "checks": checks,
         "alerts": alerts,
@@ -329,8 +349,8 @@ def render_cost_alerts_text(report: Mapping) -> str:
              f"({report.get('alert_count', 0)} alert(s), "
              f"{report.get('critical_count', 0)} critical)", ""]
     if not report.get("ledger_available", True):
-        lines += ["NOTE: cost_ledger is not present yet — spend reads as $0, so cost-based checks "
-                  "are informational until it lands.", ""]
+        lines += ["NOTE: cost_ledger is not present yet — spend is UNKNOWN (not $0), so the " +
+                  "ledger-backed checks below are skipped, not passing.", ""]
     for alert in report.get("alerts") or []:
         lines.append(f"[{str(alert.get('severity', '')).upper()}] {alert.get('title')}")
         lines.append(f"    {alert.get('detail')}")

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -6279,6 +6279,28 @@ def get_user_cost(user_id: int, start_date, end_date) -> dict:
     return get_cost_rollup(start_date, end_date, group_by="category", user_id=user_id)
 
 
+def get_daily_cost_totals(start_date, end_date) -> dict:
+    """Total spend per DAY over [start_date, end_date] → `{'YYYY-MM-DD': usd}` — the trailing series
+    the §E.2 spend-anomaly check scores today against. A day with no ledger rows is ABSENT rather
+    than 0.0 so a ledger that only started capturing mid-window can't manufacture a zero baseline
+    (and then flag the first real day of spend as an anomaly)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT incurred_on, COALESCE(SUM(usd), 0) FROM cost_ledger "
+            "WHERE incurred_on BETWEEN %s AND %s GROUP BY incurred_on ORDER BY incurred_on",
+            (start_date, end_date),
+        )
+        return {day.isoformat() if hasattr(day, "isoformat") else str(day): float(usd or 0)
+                for day, usd in cursor.fetchall()}
+    except mysql.connector.Error:
+        return {}  # table not created yet (or unreadable) — caller reports the check as skipped
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_margin_users() -> list:
     """Users the margin report covers: everyone on an active/past-due subscription or an open trial.
     Trials are included (tier `free_trial`, $0 MRR) so the cost they incur still lands in system

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -194,6 +194,27 @@ EXPECTED_LIFETIME_MONTHS  = float(get_constant_from_env('EXPECTED_LIFETIME_MONTH
 # Where the weekly margin report is emailed. Empty = generate + track only, no email.
 MARGIN_REPORT_EMAIL       = get_constant_from_env('MARGIN_REPORT_EMAIL', default_value='')
 
+# Budget/anomaly alert thresholds (docs/cost-performance-margin-plan.md §E.2). Every one is a
+# threshold, never a hardcoded price — tune per environment without a deploy.
+# Per-user variable+semi-variable cost as a share of that user's tier MRR (0.25 = the §C.3 ceiling).
+COST_ALERT_USER_COST_PCT  = float(get_constant_from_env('COST_ALERT_USER_COST_PCT', default_value='0.25'))
+# System gross-margin floor (§C.3 target 70%).
+COST_ALERT_MARGIN_FLOOR   = float(get_constant_from_env('COST_ALERT_MARGIN_FLOOR', default_value='0.70'))
+# Spend anomaly: daily spend above μ + N×σ of the trailing window, and/or above a hard daily budget
+# (0 = no absolute budget). The noise floor keeps a few cents from tripping σ on a quiet ledger.
+COST_ALERT_SPEND_SIGMA    = float(get_constant_from_env('COST_ALERT_SPEND_SIGMA', default_value='3'))
+COST_ALERT_DAILY_BUDGET   = float(get_constant_from_env('COST_ALERT_DAILY_BUDGET_USD', default_value='0'))
+COST_ALERT_MIN_SPEND      = float(get_constant_from_env('COST_ALERT_MIN_SPEND_USD', default_value='1'))
+# Cache-hit collapse: relative drop vs the trailing baseline, plus an optional absolute floor
+# (0 = floor disabled). `MIN_CALLS` gates both so a handful of calls can't fake a collapse.
+COST_ALERT_CACHE_DROP     = float(get_constant_from_env('COST_ALERT_CACHE_DROP_PCT', default_value='0.5'))
+COST_ALERT_CACHE_FLOOR    = float(get_constant_from_env('COST_ALERT_CACHE_HIT_FLOOR', default_value='0'))
+COST_ALERT_CACHE_MIN_CALLS = int(get_constant_from_env('COST_ALERT_CACHE_MIN_CALLS', default_value='50'))
+# Share of spend that carries no user (system rows) or no feature — an instrumentation regression.
+COST_ALERT_UNATTRIBUTED   = float(get_constant_from_env('COST_ALERT_UNATTRIBUTED_PCT', default_value='0.10'))
+# Where budget alerts are emailed. Empty falls back to MARGIN_REPORT_EMAIL.
+COST_ALERT_EMAIL          = get_constant_from_env('COST_ALERT_EMAIL', default_value='')
+
 NGROK_LIPREVIEW_PREFIX=get_constant_from_env('NGROK_LIPREVIEW_PREFIX')
 if NGROK_FREE_DOMAIN and NGROK_LIPREVIEW_PREFIX:
     LINKEDIN_PREVIEW_URL = f"https://{NGROK_LIPREVIEW_PREFIX}.{NGROK_FREE_DOMAIN}"

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -308,6 +308,44 @@ def track_margin_report(report: dict) -> None:
     )
 
 
+def track_cost_alert(alert: dict, day: Optional[str] = None) -> None:
+    """Emit one budget/anomaly alert (plan §E.2) as a `cost_alert` event so a breach is queryable
+    next to the spend it came from, and a PostHog alert can page off it. Per-user alerts are keyed
+    to that user's distinct_id; system-wide ones to "system"."""
+    alert = dict(alert or {})
+    posthog.capture(
+        distinct_id=str(alert.get("user_id") or "system"),
+        event="cost_alert",
+        properties={"date": day, **alert},
+    )
+
+
+def posthog_hogql_query(sql: str, timeout: int = 30) -> Optional[list]:
+    """Run a HogQL query against the PostHog query API and return its result ROWS, or None when the
+    read path isn't configured (no personal API key / project) or the call fails. None means
+    "unknown" — never zero — so a check reading it reports itself skipped instead of alerting on a
+    missing analytics plane. Reads only; the write/provision path lives in scripts/posthog_dashboards.py."""
+    api_key = os.getenv("POSTHOG_PERSONAL_API_KEY", "")
+    project_id = os.getenv("POSTHOG_PROJECT_ID", "")
+    if not api_key or not project_id:
+        return None
+    host = os.getenv("POSTHOG_APP_HOST", "https://us.posthog.com").rstrip("/")
+    try:
+        import requests
+        response = requests.post(
+            f"{host}/api/projects/{project_id}/query/",
+            headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
+            json={"query": {"kind": "HogQLQuery", "query": sql}},
+            timeout=timeout,
+        )
+        response.raise_for_status()
+        return response.json().get("results") or []
+    except Exception as e:
+        from cqc_lem.utilities.logger import log_warning
+        log_warning("PostHog HogQL query failed", exc=e, api_provider="posthog")
+        return None
+
+
 def track_task(
     task_name: str,
     duration_ms: int,

--- a/tests/unit/utilities/test_cost_alerts.py
+++ b/tests/unit/utilities/test_cost_alerts.py
@@ -1,0 +1,480 @@
+"""Unit tests for the budget-threshold / spend-anomaly alerts (issue #493, plan §E.2).
+
+Every check is fired on a SYNTHETIC breach here (the acceptance criterion) and pinned on the
+no-breach and not-enough-data paths, so a check can neither go quiet nor cry wolf unnoticed.
+"""
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cqc_lem.utilities import cost_alerts as ca
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.cost_alerts"
+
+DAY = date(2026, 7, 24)
+
+
+def _user(user_id=1, mrr=100.0, variable=10.0, semi=0.0, tier="professional"):
+    return {"user_id": user_id, "tier": tier, "mrr_usd": mrr,
+            "variable_cost_usd": variable, "semi_variable_cost_usd": semi}
+
+
+def _system(**overrides):
+    system = {"active_users": 2, "paying_users": 1, "mrr_usd": 100.0, "gross_margin_pct": 0.8,
+              "gross_margin_usd": 80.0, "period_cost_usd": 20.0, "unattributed_cost_usd": 0.0}
+    system.update(overrides)
+    return system
+
+
+def _series(values, end=DAY):
+    """`{iso_day: usd}` ending on `end`, oldest first."""
+    return {(end - timedelta(days=len(values) - 1 - i)).isoformat(): v
+            for i, v in enumerate(values)}
+
+
+class TestUserCostCeiling:
+    def test_fires_when_variable_cost_exceeds_the_share_of_tier_mrr(self):
+        check = ca.evaluate_user_cost_ceiling([_user(variable=30.0)], pct_of_mrr=0.25)
+        assert check["status"] == ca.STATUS_ALERT
+        alert = check["alerts"][0]
+        assert alert["severity"] == ca.SEVERITY_WARNING
+        assert alert["user_id"] == 1 and alert["value"] == pytest.approx(0.30)
+        assert alert["threshold"] == 0.25 and "30.0% of tier MRR" in alert["title"]
+
+    def test_counts_semi_variable_cost_toward_the_ceiling(self):
+        check = ca.evaluate_user_cost_ceiling([_user(variable=15.0, semi=15.0)], pct_of_mrr=0.25)
+        assert check["alerts"][0]["value"] == pytest.approx(0.30)
+
+    def test_margin_negative_user_is_critical(self):
+        check = ca.evaluate_user_cost_ceiling([_user(variable=120.0)], pct_of_mrr=0.25)
+        assert check["alerts"][0]["severity"] == ca.SEVERITY_CRITICAL
+
+    def test_quiet_under_the_threshold(self):
+        check = ca.evaluate_user_cost_ceiling([_user(variable=10.0)], pct_of_mrr=0.25)
+        assert check["status"] == ca.STATUS_OK and check["alerts"] == []
+
+    def test_threshold_is_configurable(self):
+        users = [_user(variable=15.0)]
+        assert ca.evaluate_user_cost_ceiling(users, pct_of_mrr=0.25)["status"] == ca.STATUS_OK
+        assert ca.evaluate_user_cost_ceiling(users, pct_of_mrr=0.10)["status"] == ca.STATUS_ALERT
+
+    def test_trials_are_skipped_because_percent_of_zero_mrr_is_undefined(self):
+        check = ca.evaluate_user_cost_ceiling(
+            [_user(user_id=2, mrr=0.0, variable=40.0, tier="free_trial")], pct_of_mrr=0.25)
+        assert check["status"] == ca.STATUS_SKIPPED and check["users_judged"] == 0
+
+    def test_no_users_at_all_is_skipped_not_ok(self):
+        assert ca.evaluate_user_cost_ceiling([], pct_of_mrr=0.25)["status"] == ca.STATUS_SKIPPED
+
+
+class TestGrossMarginFloor:
+    def test_fires_below_the_floor(self):
+        check = ca.evaluate_gross_margin_floor(_system(gross_margin_pct=0.55), floor=0.70)
+        assert check["status"] == ca.STATUS_ALERT
+        alert = check["alerts"][0]
+        assert alert["severity"] == ca.SEVERITY_WARNING and alert["value"] == 0.55
+        assert "below the 70% floor" in alert["title"]
+
+    def test_negative_margin_is_critical(self):
+        check = ca.evaluate_gross_margin_floor(
+            _system(gross_margin_pct=-0.2, gross_margin_usd=-20.0), floor=0.70)
+        assert check["alerts"][0]["severity"] == ca.SEVERITY_CRITICAL
+
+    def test_quiet_at_or_above_the_floor(self):
+        assert ca.evaluate_gross_margin_floor(_system(gross_margin_pct=0.70),
+                                              floor=0.70)["status"] == ca.STATUS_OK
+
+    def test_no_revenue_is_skipped_not_a_breach(self):
+        check = ca.evaluate_gross_margin_floor(_system(gross_margin_pct=None), floor=0.70)
+        assert check["status"] == ca.STATUS_SKIPPED and "undefined" in check["reason"]
+
+
+class TestSpendAnomaly:
+    def test_fires_on_a_spike_above_mu_plus_3_sigma(self):
+        series = _series([10.0, 10.5, 9.5, 10.0, 10.2, 9.8, 90.0])
+        check = ca.evaluate_spend_anomaly(series, DAY, sigma=3.0, daily_budget_usd=0,
+                                          min_spend_usd=1.0)
+        assert check["status"] == ca.STATUS_ALERT
+        alert = check["alerts"][0]
+        assert alert["kind"] == "sigma" and alert["value"] == 90.0
+        assert alert["severity"] == ca.SEVERITY_WARNING and alert["day"] == DAY.isoformat()
+
+    def test_quiet_on_steady_spend(self):
+        check = ca.evaluate_spend_anomaly(_series([10.0, 10.5, 9.5, 10.0, 10.2, 9.8, 10.4]), DAY,
+                                          sigma=3.0, daily_budget_usd=0, min_spend_usd=1.0)
+        assert check["status"] == ca.STATUS_OK and check["baseline_days"] == 6
+
+    def test_sigma_multiple_is_configurable(self):
+        # μ=10, σ≈0.82 → 12.0 clears μ+1σ but not μ+3σ.
+        series = _series([10.0, 11.0, 9.0, 10.0, 11.0, 9.0, 12.0])
+        assert ca.evaluate_spend_anomaly(series, DAY, sigma=3.0,
+                                         min_spend_usd=1.0)["status"] == ca.STATUS_OK
+        assert ca.evaluate_spend_anomaly(series, DAY, sigma=1.0,
+                                         min_spend_usd=1.0)["status"] == ca.STATUS_ALERT
+
+    def test_absolute_daily_budget_breach_is_critical(self):
+        check = ca.evaluate_spend_anomaly(_series([10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 42.0]), DAY,
+                                          sigma=3.0, daily_budget_usd=25.0, min_spend_usd=1.0)
+        kinds = {a["kind"]: a for a in check["alerts"]}
+        assert kinds["budget"]["severity"] == ca.SEVERITY_CRITICAL
+        assert kinds["budget"]["threshold"] == 25.0
+
+    def test_budget_breach_fires_before_a_baseline_exists(self):
+        check = ca.evaluate_spend_anomaly({DAY.isoformat(): 99.0}, DAY, daily_budget_usd=25.0)
+        assert check["status"] == ca.STATUS_ALERT
+        assert [a["kind"] for a in check["alerts"]] == ["budget"]
+
+    def test_noise_floor_keeps_cents_from_tripping_sigma(self):
+        # Baseline σ≈0, so any movement clears μ+3σ — the floor is what stops the false alarm.
+        series = _series([0.01, 0.01, 0.01, 0.01, 0.01, 0.01, 0.40])
+        assert ca.evaluate_spend_anomaly(series, DAY, sigma=3.0,
+                                         min_spend_usd=1.0)["status"] == ca.STATUS_OK
+        assert ca.evaluate_spend_anomaly(series, DAY, sigma=3.0,
+                                         min_spend_usd=0.10)["status"] == ca.STATUS_ALERT
+
+    def test_too_few_trailing_days_is_skipped(self):
+        check = ca.evaluate_spend_anomaly(_series([5.0, 90.0]), DAY, sigma=3.0)
+        assert check["status"] == ca.STATUS_SKIPPED and "trailing day" in check["reason"]
+
+    def test_absent_days_are_not_counted_as_zero_spend(self):
+        # Only 2 days of ledger data in an 8-day window → not enough baseline, NOT a 90 USD spike
+        # against six fabricated zeros.
+        series = {"2026-07-23": 5.0, DAY.isoformat(): 90.0}
+        assert ca.evaluate_spend_anomaly(series, DAY, sigma=3.0)["status"] == ca.STATUS_SKIPPED
+
+    def test_no_row_for_the_day_is_skipped(self):
+        check = ca.evaluate_spend_anomaly(_series([10.0, 10.0, 10.0], end=DAY - timedelta(days=1)),
+                                          DAY)
+        assert check["status"] == ca.STATUS_SKIPPED and "no ledger rows" in check["reason"]
+
+
+class TestCacheHitCollapse:
+    def _cache(self, rate=0.2, calls=500, baseline=0.6, baseline_calls=3000):
+        return {"date": DAY.isoformat(), "rate": rate, "calls": calls,
+                "baseline_rate": baseline, "baseline_calls": baseline_calls}
+
+    def test_fires_on_a_relative_drop_against_the_baseline(self):
+        check = ca.evaluate_cache_hit_collapse(self._cache(), drop_pct=0.5, floor=0, min_calls=50)
+        assert check["status"] == ca.STATUS_ALERT
+        alert = check["alerts"][0]
+        assert alert["kind"] == "drop" and alert["value"] == pytest.approx(0.6667, abs=1e-3)
+        assert "cost spike" in alert["detail"]
+
+    def test_absolute_floor_is_opt_in(self):
+        cache = self._cache(rate=0.05, baseline=0.05)
+        assert ca.evaluate_cache_hit_collapse(cache, drop_pct=0.5, floor=0,
+                                              min_calls=50)["status"] == ca.STATUS_OK
+        check = ca.evaluate_cache_hit_collapse(cache, drop_pct=0.5, floor=0.10, min_calls=50)
+        assert check["alerts"][0]["kind"] == "floor"
+
+    def test_quiet_when_the_rate_holds(self):
+        check = ca.evaluate_cache_hit_collapse(self._cache(rate=0.55), drop_pct=0.5, floor=0,
+                                               min_calls=50)
+        assert check["status"] == ca.STATUS_OK
+
+    def test_low_volume_day_cannot_read_as_a_collapse(self):
+        check = ca.evaluate_cache_hit_collapse(self._cache(rate=0.0, calls=3), min_calls=50)
+        assert check["status"] == ca.STATUS_SKIPPED and "under the 50-call minimum" in check["reason"]
+
+    def test_low_volume_baseline_does_not_drive_a_drop(self):
+        check = ca.evaluate_cache_hit_collapse(self._cache(baseline_calls=5), drop_pct=0.5,
+                                               floor=0, min_calls=50)
+        assert check["status"] == ca.STATUS_OK
+
+    def test_unavailable_posthog_is_skipped_not_a_collapse(self):
+        check = ca.evaluate_cache_hit_collapse(None)
+        assert check["status"] == ca.STATUS_SKIPPED and "PostHog" in check["reason"]
+
+
+class TestUnattributedSpend:
+    def test_fires_on_spend_with_no_user(self):
+        check = ca.evaluate_unattributed_spend(
+            _system(period_cost_usd=100.0, unattributed_cost_usd=30.0), {"content": 100.0},
+            max_share=0.10)
+        assert check["status"] == ca.STATUS_ALERT
+        alert = check["alerts"][0]
+        assert alert["dimension"] == "user_id" and alert["value"] == pytest.approx(0.30)
+
+    def test_fires_on_spend_with_no_feature(self):
+        check = ca.evaluate_unattributed_spend(
+            _system(period_cost_usd=100.0, unattributed_cost_usd=0.0),
+            {"content": 60.0, "unknown": 25.0, "system": 15.0}, max_share=0.10)
+        alert = check["alerts"][0]
+        assert alert["dimension"] == "feature" and alert["value"] == pytest.approx(0.40)
+
+    def test_quiet_under_the_threshold(self):
+        check = ca.evaluate_unattributed_spend(
+            _system(period_cost_usd=100.0, unattributed_cost_usd=5.0),
+            {"content": 95.0, "system": 5.0}, max_share=0.10)
+        assert check["status"] == ca.STATUS_OK and check["user_share"] == 0.05
+
+    def test_no_spend_is_skipped(self):
+        check = ca.evaluate_unattributed_spend(_system(period_cost_usd=0.0), {}, max_share=0.10)
+        assert check["status"] == ca.STATUS_SKIPPED
+
+
+class TestThresholds:
+    def test_defaults_come_from_the_environment_constants(self):
+        with patch(f"{_MOD}.COST_ALERT_MARGIN_FLOOR", 0.42), \
+             patch(f"{_MOD}.COST_ALERT_DAILY_BUDGET", 12.5):
+            limits = ca.default_thresholds()
+        assert limits["gross_margin_floor"] == 0.42 and limits["daily_budget_usd"] == 12.5
+
+    def test_report_overrides_merge_over_the_defaults(self):
+        report = ca.build_cost_alert_report(DAY, _margin_report(), thresholds={"spend_sigma": 1.5})
+        assert report["thresholds"]["spend_sigma"] == 1.5
+        assert report["thresholds"]["gross_margin_floor"] == ca.COST_ALERT_MARGIN_FLOOR
+
+
+def _margin_report(**system_overrides):
+    return {"period": {"start": "2026-07-18", "end": "2026-07-24", "days": 7},
+            "ledger_available": True, "users": [_user()], "system": _system(**system_overrides)}
+
+
+class TestBuildReport:
+    def test_runs_every_check_and_flattens_the_breaches(self):
+        report = ca.build_cost_alert_report(
+            DAY,
+            _margin_report(gross_margin_pct=0.1, gross_margin_usd=10.0,
+                           period_cost_usd=100.0, unattributed_cost_usd=50.0),
+            cost_by_feature={"content": 100.0},
+            daily_spend=_series([10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 95.0]),
+            cache={"rate": 0.1, "calls": 500, "baseline_rate": 0.8, "baseline_calls": 900},
+            thresholds={"user_cost_pct_of_mrr": 0.05},
+        )
+        assert [c["check"] for c in report["checks"]] == [
+            ca.CHECK_USER_COST, ca.CHECK_MARGIN_FLOOR, ca.CHECK_SPEND_ANOMALY,
+            ca.CHECK_CACHE_COLLAPSE, ca.CHECK_UNATTRIBUTED]
+        assert {a["check"] for a in report["alerts"]} == {
+            ca.CHECK_USER_COST, ca.CHECK_MARGIN_FLOOR, ca.CHECK_SPEND_ANOMALY,
+            ca.CHECK_CACHE_COLLAPSE, ca.CHECK_UNATTRIBUTED}
+        assert report["alert_count"] == len(report["alerts"]) and report["date"] == "2026-07-24"
+        assert report["skipped_checks"] == []
+
+    def test_all_clear_report_has_no_alerts(self):
+        report = ca.build_cost_alert_report(
+            DAY, _margin_report(), cost_by_feature={"content": 20.0},
+            daily_spend=_series([10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0]),
+            cache={"rate": 0.6, "calls": 500, "baseline_rate": 0.6, "baseline_calls": 900})
+        assert report["alert_count"] == 0 and report["critical_count"] == 0
+
+    def test_counts_criticals_separately(self):
+        report = ca.build_cost_alert_report(
+            DAY, _margin_report(gross_margin_pct=-0.5, gross_margin_usd=-50.0))
+        assert report["critical_count"] == 1
+
+    def test_missing_data_reports_skipped_checks_not_alerts(self):
+        report = ca.build_cost_alert_report(DAY, {"ledger_available": False, "users": [],
+                                                  "system": {}})
+        assert report["alert_count"] == 0
+        assert set(report["skipped_checks"]) == {ca.CHECK_USER_COST, ca.CHECK_MARGIN_FLOOR,
+                                                 ca.CHECK_SPEND_ANOMALY, ca.CHECK_CACHE_COLLAPSE,
+                                                 ca.CHECK_UNATTRIBUTED}
+        assert report["ledger_available"] is False
+
+
+class TestRenderers:
+    def _report(self):
+        return ca.build_cost_alert_report(DAY, _margin_report(gross_margin_pct=0.1,
+                                                              gross_margin_usd=10.0))
+
+    def test_text_lists_alerts_and_every_check_status(self):
+        text = ca.render_cost_alerts_text(self._report())
+        assert text.startswith("LEM cost alerts — 2026-07-24")
+        assert "[WARNING] System gross margin 10.0% is below" in text
+        assert f"{ca.CHECK_SPEND_ANOMALY}: {ca.STATUS_SKIPPED}" in text
+
+    def test_text_says_so_when_nothing_breached(self):
+        report = ca.build_cost_alert_report(DAY, _margin_report())
+        assert "No thresholds breached." in ca.render_cost_alerts_text(report)
+
+    def test_text_warns_when_the_ledger_is_missing(self):
+        report = ca.build_cost_alert_report(DAY, {"ledger_available": False, "system": {}})
+        assert "cost_ledger is not present yet" in ca.render_cost_alerts_text(report)
+
+    def test_html_escapes_and_wraps_the_text_digest(self):
+        report = self._report()
+        report["alerts"][0]["title"] = "<b>margin</b>"
+        html = ca.render_cost_alerts_html(report)
+        assert html.startswith("<h2>LEM cost alerts</h2><pre")
+        assert "&lt;b&gt;margin&lt;/b&gt;" in html
+
+
+class TestCacheHitCollector:
+    def _rows(self):
+        return [["2026-07-22", 60, 100], ["2026-07-23", 60, 100], [DAY.isoformat(), 5, 200]]
+
+    def test_splits_the_day_from_a_call_weighted_baseline(self):
+        with patch("cqc_lem.utilities.observability.posthog_hogql_query",
+                   return_value=self._rows()) as query:
+            stats = ca.collect_cache_hit_stats(DAY)
+        assert stats["rate"] == pytest.approx(0.025) and stats["calls"] == 200
+        assert stats["baseline_rate"] == pytest.approx(0.6) and stats["baseline_calls"] == 200
+        sql = query.call_args[0][0]
+        assert "event = 'llm_call'" in sql and "properties.cached = true" in sql
+
+    def test_unreadable_posthog_returns_none(self):
+        with patch("cqc_lem.utilities.observability.posthog_hogql_query", return_value=None):
+            assert ca.collect_cache_hit_stats(DAY) is None
+
+    def test_malformed_rows_are_ignored(self):
+        rows = [None, ["2026-07-23"], ["2026-07-23", 60, 100], [DAY.isoformat(), 5, 200]]
+        with patch("cqc_lem.utilities.observability.posthog_hogql_query", return_value=rows):
+            stats = ca.collect_cache_hit_stats(DAY)
+        assert stats["calls"] == 200 and stats["baseline_calls"] == 100
+
+    def test_no_events_for_the_day_leaves_the_rate_unknown(self):
+        with patch("cqc_lem.utilities.observability.posthog_hogql_query", return_value=[]):
+            stats = ca.collect_cache_hit_stats(DAY)
+        assert stats["rate"] is None and stats["baseline_rate"] is None
+
+
+class TestCollectReport:
+    def test_reads_the_ledger_and_margin_report_for_the_window(self):
+        with patch(f"{_MOD}.collect_cache_hit_stats", return_value=None), \
+             patch("cqc_lem.utilities.margin.collect_margin_report",
+                   return_value=_margin_report()) as margin, \
+             patch("cqc_lem.utilities.db.get_cost_rollup", return_value={"content": 20.0}) as rollup, \
+             patch("cqc_lem.utilities.db.get_daily_cost_totals",
+                   return_value=_series([10.0] * 7)) as daily:
+            report = ca.collect_cost_alert_report(day=DAY, days=7)
+
+        margin.assert_called_once_with(end=DAY, days=7)
+        assert rollup.call_args[0] == (date(2026, 7, 18), DAY)
+        assert rollup.call_args[1]["group_by"] == "feature"
+        # The anomaly baseline reaches a full window further back than the rollup window.
+        assert daily.call_args[0] == (DAY - timedelta(days=ca.ANOMALY_WINDOW_DAYS), DAY)
+        assert report["date"] == DAY.isoformat() and report["alert_count"] == 0
+
+    def test_defaults_to_the_last_complete_utc_day(self):
+        with patch(f"{_MOD}._today", return_value=date(2026, 7, 25)), \
+             patch(f"{_MOD}.collect_cache_hit_stats", return_value=None), \
+             patch("cqc_lem.utilities.margin.collect_margin_report", return_value=_margin_report()), \
+             patch("cqc_lem.utilities.db.get_cost_rollup", return_value={}), \
+             patch("cqc_lem.utilities.db.get_daily_cost_totals", return_value={}):
+            assert ca.collect_cost_alert_report()["date"] == "2026-07-24"
+
+
+def _breach_report():
+    return ca.build_cost_alert_report(DAY, _margin_report(gross_margin_pct=-0.5,
+                                                          gross_margin_usd=-50.0))
+
+
+class TestDelivery:
+    def test_emails_and_tracks_every_breach(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as send, \
+             patch("cqc_lem.utilities.observability.track_cost_alert") as track:
+            result = ca.send_cost_alerts(_breach_report(), to_email="owner@example.com")
+
+        assert result["emailed"] is True and result["tracked"] is True and result["alerts"] == 1
+        args, kwargs = send.call_args
+        assert args[0] == "owner@example.com" and "CRITICAL" in args[1]
+        assert kwargs["text_content"].startswith("LEM cost alerts")
+        assert kwargs["high_priority"] is True
+        assert track.call_args[1]["day"] == "2026-07-24"
+
+    def test_all_clear_is_not_emailed(self):
+        with patch("cqc_lem.utilities.email._dispatch_email") as send, \
+             patch("cqc_lem.utilities.observability.track_cost_alert"):
+            result = ca.send_cost_alerts(ca.build_cost_alert_report(DAY, _margin_report()),
+                                         to_email="owner@example.com")
+        send.assert_not_called()
+        assert result["emailed"] is False and result["alerts"] == 0
+
+    def test_critical_alerts_are_logged_as_errors(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True), \
+             patch("cqc_lem.utilities.observability.track_cost_alert"), \
+             patch(f"{_MOD}.log_error") as log_error:
+            ca.send_cost_alerts(_breach_report(), to_email="owner@example.com")
+        assert "gross_margin_floor" in log_error.call_args[0][0]
+
+    def test_warning_alerts_are_logged_as_warnings(self):
+        report = ca.build_cost_alert_report(DAY, _margin_report(gross_margin_pct=0.1,
+                                                                gross_margin_usd=10.0))
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True), \
+             patch("cqc_lem.utilities.observability.track_cost_alert"), \
+             patch(f"{_MOD}.log_error") as log_error, patch(f"{_MOD}.log_warning") as log_warning:
+            ca.send_cost_alerts(report, to_email="owner@example.com")
+        log_error.assert_not_called()
+        assert "gross_margin_floor" in log_warning.call_args[0][0]
+
+    def test_falls_back_to_the_margin_report_recipient(self):
+        with patch(f"{_MOD}.COST_ALERT_EMAIL", ""), \
+             patch(f"{_MOD}.MARGIN_REPORT_EMAIL", "margin@example.com"), \
+             patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as send, \
+             patch("cqc_lem.utilities.observability.track_cost_alert"):
+            ca.send_cost_alerts(_breach_report())
+        assert send.call_args[0][0] == "margin@example.com"
+
+    def test_no_recipient_still_tracks(self):
+        with patch(f"{_MOD}.COST_ALERT_EMAIL", ""), patch(f"{_MOD}.MARGIN_REPORT_EMAIL", ""), \
+             patch("cqc_lem.utilities.email._dispatch_email") as send, \
+             patch("cqc_lem.utilities.observability.track_cost_alert"):
+            result = ca.send_cost_alerts(_breach_report())
+        send.assert_not_called()
+        assert result["tracked"] is True
+
+    def test_email_failure_does_not_lose_the_alerts(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", side_effect=RuntimeError("smtp down")), \
+             patch("cqc_lem.utilities.observability.track_cost_alert"):
+            result = ca.send_cost_alerts(_breach_report(), to_email="owner@example.com")
+        assert result["emailed"] is False and result["tracked"] is True
+
+    def test_tracking_failure_does_not_lose_the_email(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True), \
+             patch("cqc_lem.utilities.observability.track_cost_alert",
+                   side_effect=RuntimeError("posthog down")):
+            result = ca.send_cost_alerts(_breach_report(), to_email="owner@example.com")
+        assert result["emailed"] is True and result["tracked"] is False
+
+
+class TestCli:
+    def test_exit_2_on_a_breach_so_a_caller_can_act_on_it(self, capsys):
+        with patch(f"{_MOD}.collect_cost_alert_report", return_value=_breach_report()):
+            assert ca.main([]) == 2
+        assert "LEM cost alerts" in capsys.readouterr().out
+
+    def test_exit_0_when_nothing_breached(self, capsys):
+        clear = ca.build_cost_alert_report(DAY, _margin_report())
+        with patch(f"{_MOD}.collect_cost_alert_report", return_value=clear):
+            assert ca.main(["--json"]) == 0
+        import json as _json
+        assert _json.loads(capsys.readouterr().out.strip())["alert_count"] == 0
+
+    def test_day_and_days_flags_reach_the_collector(self):
+        clear = ca.build_cost_alert_report(DAY, _margin_report())
+        with patch(f"{_MOD}.collect_cost_alert_report", return_value=clear) as collect:
+            ca.main(["--day", "2026-07-20", "--days", "14"])
+        assert collect.call_args[1] == {"day": date(2026, 7, 20), "days": 14}
+
+    def test_email_flag_delivers(self):
+        report = _breach_report()
+        with patch(f"{_MOD}.collect_cost_alert_report", return_value=report), \
+             patch(f"{_MOD}.send_cost_alerts") as send:
+            assert ca.main(["--email"]) == 2
+        send.assert_called_once_with(report)
+
+
+class TestCeleryTask:
+    def test_task_collects_sends_and_summarizes(self):
+        from cqc_lem.app.run_scheduler import auto_daily_cost_alerts
+
+        report = _breach_report()
+        with patch(f"{_MOD}.collect_cost_alert_report", return_value=report), \
+             patch(f"{_MOD}.send_cost_alerts",
+                   return_value={"emailed": True, "tracked": True, "alerts": 1,
+                                 "report": report}) as send:
+            summary = auto_daily_cost_alerts(days=7)
+        send.assert_called_once_with(report)
+        assert "2026-07-24" in summary and "1 alert(s)" in summary
+
+    def test_beat_schedules_it_daily(self):
+        from cqc_lem.app.my_celery import app as celery_app
+
+        entry = celery_app.conf.beat_schedule["daily-cost-alerts"]
+        assert entry["task"] == "cqc_lem.app.run_scheduler.auto_daily_cost_alerts"
+        assert entry["schedule"].hour == {13} and entry["schedule"].minute == {0}

--- a/tests/unit/utilities/test_cost_alerts.py
+++ b/tests/unit/utilities/test_cost_alerts.py
@@ -5,7 +5,7 @@ no-breach and not-enough-data paths, so a check can neither go quiet nor cry wol
 """
 
 from datetime import date, timedelta
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -276,6 +276,22 @@ class TestBuildReport:
                                                  ca.CHECK_UNATTRIBUTED}
         assert report["ledger_available"] is False
 
+    def test_missing_ledger_skips_the_ledger_backed_checks_instead_of_passing_them(self):
+        """A $0 margin report derived from empty rollups must not read as an all-clear."""
+        report = ca.build_cost_alert_report(
+            DAY,
+            {"ledger_available": False, "users": [_user(variable=0.0)],
+             "system": _system(period_cost_usd=0.0, gross_margin_pct=1.0)},
+            cost_by_feature={}, daily_spend=_series([0.0] * 7),
+            cache={"rate": 0.6, "calls": 500, "baseline_rate": 0.6, "baseline_calls": 900})
+        by_id = {c["check"]: c for c in report["checks"]}
+        for check_id in ca.LEDGER_BACKED_CHECKS:
+            assert by_id[check_id]["status"] == ca.STATUS_SKIPPED
+            assert by_id[check_id]["reason"] == ca.LEDGER_MISSING_REASON
+        # The cache check is PostHog-fed, so it still has real data to judge.
+        assert by_id[ca.CHECK_CACHE_COLLAPSE]["status"] == ca.STATUS_OK
+        assert report["alert_count"] == 0
+
 
 class TestRenderers:
     def _report(self):
@@ -294,7 +310,10 @@ class TestRenderers:
 
     def test_text_warns_when_the_ledger_is_missing(self):
         report = ca.build_cost_alert_report(DAY, {"ledger_available": False, "system": {}})
-        assert "cost_ledger is not present yet" in ca.render_cost_alerts_text(report)
+        text = ca.render_cost_alerts_text(report)
+        assert "cost_ledger is not present yet" in text
+        assert "skipped, not passing" in text
+        assert f"{ca.CHECK_MARGIN_FLOOR}: {ca.STATUS_SKIPPED}" in text
 
     def test_html_escapes_and_wraps_the_text_digest(self):
         report = self._report()

--- a/tests/unit/utilities/test_db_cost_ledger.py
+++ b/tests/unit/utilities/test_db_cost_ledger.py
@@ -98,6 +98,31 @@ class TestGetCostRollup:
         assert "CAST(category AS CHAR)" in sql and params[-1] == 9
 
 
+class TestGetDailyCostTotals:
+    def test_returns_one_total_per_day_keyed_by_iso_date(self):
+        conn, cur = _mock_conn(fetch_all=[(date(2026, 7, 24), 4.0), (date(2026, 7, 25), 9.5)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_daily_cost_totals
+            assert get_daily_cost_totals(date(2026, 7, 18), date(2026, 7, 25)) == {
+                "2026-07-24": 4.0, "2026-07-25": 9.5}
+        sql, params = cur.execute.call_args[0]
+        assert "GROUP BY incurred_on" in sql and "SUM(usd)" in sql
+        assert params == (date(2026, 7, 18), date(2026, 7, 25))
+
+    def test_days_without_rows_are_absent_not_zero(self):
+        # A ledger that started capturing mid-window must not report a fabricated $0 baseline.
+        conn, _ = _mock_conn(fetch_all=[(date(2026, 7, 25), 9.5)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_daily_cost_totals
+            assert get_daily_cost_totals(date(2026, 7, 18), date(2026, 7, 25)) == {"2026-07-25": 9.5}
+
+    def test_empty_when_table_missing(self):
+        conn, _ = _mock_conn(error="Table 'cost_ledger' doesn't exist")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_daily_cost_totals
+            assert get_daily_cost_totals(date(2026, 7, 18), date(2026, 7, 25)) == {}
+
+
 class TestGetMarginUsers:
     def test_returns_tier_status_and_signup_cohort(self):
         rows = [{"id": 1, "subscription_tier": "professional", "subscription_status": "active",

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -2,7 +2,7 @@
 
 import pytest
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 pytestmark = pytest.mark.unit
 
@@ -509,3 +509,52 @@ class TestTrackMarginReport:
             from cqc_lem.utilities.observability import track_margin_report
             track_margin_report({})
         assert mock_ph.capture.call_args[1]["properties"]["cohorts"] == []
+
+
+class TestTrackCostAlert:
+    def test_per_user_alert_is_keyed_to_that_user(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_cost_alert
+            track_cost_alert({"check": "user_cost_ceiling", "severity": "warning", "user_id": 7,
+                              "value": 0.42}, day="2026-07-24")
+
+        kwargs = mock_ph.capture.call_args[1]
+        assert kwargs["event"] == "cost_alert" and kwargs["distinct_id"] == "7"
+        assert kwargs["properties"]["date"] == "2026-07-24"
+        assert kwargs["properties"]["check"] == "user_cost_ceiling"
+
+    def test_system_alert_falls_back_to_the_system_distinct_id(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_cost_alert
+            track_cost_alert({"check": "gross_margin_floor", "severity": "critical"})
+        assert mock_ph.capture.call_args[1]["distinct_id"] == "system"
+
+
+class TestPostHogHogqlQuery:
+    def test_returns_none_when_the_read_path_is_not_configured(self):
+        with patch.dict("os.environ", {"POSTHOG_PERSONAL_API_KEY": "", "POSTHOG_PROJECT_ID": ""},
+                        clear=False):
+            from cqc_lem.utilities.observability import posthog_hogql_query
+            assert posthog_hogql_query("SELECT 1") is None
+
+    def test_posts_the_query_and_returns_result_rows(self):
+        response = MagicMock()
+        response.json.return_value = {"results": [["2026-07-24", 3, 10]]}
+        with patch.dict("os.environ", {"POSTHOG_PERSONAL_API_KEY": "phx_key",
+                                       "POSTHOG_PROJECT_ID": "475262",
+                                       "POSTHOG_APP_HOST": "https://us.posthog.com/"}), \
+             patch("requests.post", return_value=response) as post:
+            from cqc_lem.utilities.observability import posthog_hogql_query
+            assert posthog_hogql_query("SELECT 1") == [["2026-07-24", 3, 10]]
+
+        url, kwargs = post.call_args[0][0], post.call_args[1]
+        assert url == "https://us.posthog.com/api/projects/475262/query/"
+        assert kwargs["headers"]["Authorization"] == "Bearer phx_key"
+        assert kwargs["json"]["query"] == {"kind": "HogQLQuery", "query": "SELECT 1"}
+
+    def test_none_on_failure_so_a_caller_never_reads_it_as_zero(self):
+        with patch.dict("os.environ", {"POSTHOG_PERSONAL_API_KEY": "phx_key",
+                                       "POSTHOG_PROJECT_ID": "475262"}), \
+             patch("requests.post", side_effect=RuntimeError("posthog down")):
+            from cqc_lem.utilities.observability import posthog_hogql_query
+            assert posthog_hogql_query("SELECT 1") is None


### PR DESCRIPTION
## What & why

Automated cost guardrails (plan §E.2) so spend can't run away unattended — step 5 of the
`docs/cost-performance-margin-plan.md` rollout, after the ledger-backed margin report (#491) and the
PostHog dashboards (#492).

Five checks, each with an env-configurable threshold, run **daily at 13:00 UTC** via Celery beat
(`daily-cost-alerts` → `run_scheduler.auto_daily_cost_alerts`) over the **last complete UTC day** — a
partial "today" would read as a spend collapse rather than a real signal.

| Alert | Source | Fires when | Threshold (default) |
|---|---|---|---|
| Per-user cost ceiling | `cost_ledger` via the margin report | variable+semi-variable cost > X% of tier MRR (**critical** when it exceeds MRR outright — that user is margin-negative) | `COST_ALERT_USER_COST_PCT` (0.25) |
| Gross-margin floor | same | system `gross_margin%` < target (**critical** when negative) | `COST_ALERT_MARGIN_FLOOR` (0.70) |
| Spend anomaly | `db.get_daily_cost_totals` | day > μ+Nσ of the trailing 7 days, and/or > an absolute daily budget (**critical**) | `COST_ALERT_SPEND_SIGMA` (3), `COST_ALERT_DAILY_BUDGET_USD` (0 = off), `COST_ALERT_MIN_SPEND_USD` (1) |
| Cache-hit collapse | PostHog `llm_call` (`cached`) | cache-hit% falls X% vs a call-weighted trailing baseline, or under an optional absolute floor | `COST_ALERT_CACHE_DROP_PCT` (0.5), `COST_ALERT_CACHE_HIT_FLOOR` (0 = off), `COST_ALERT_CACHE_MIN_CALLS` (50) |
| Unattributed spend | `cost_ledger` rollups | share of spend with no `user_id` **or** no/`system` `feature` above threshold | `COST_ALERT_UNATTRIBUTED_PCT` (0.10) |

## Design notes

- **One §C.1 implementation.** Spend↔MRR is read through the existing `utilities/margin.py` report
  rather than re-derived — the ceiling, margin-floor and unattributed checks all read its per-user
  and system blocks. `utilities/cost_alerts.py` mirrors margin.py's shape: pure evaluators first
  (what the tests pin), then collectors, delivery, CLI.
- **Unknown ≠ zero.** Every check reports `ok`, `alert`, or **`skipped` with a reason**. A missing
  `cost_ledger`, a day with no rows, too little trailing data, or an unconfigured PostHog read path
  is unknown data — never a $0 "all clear" and never a false alarm. Days absent from the ledger are
  *not* counted as $0 spend, so a ledger that starts capturing mid-window can't flag its first real
  day as a spike; `COST_ALERT_MIN_SPEND_USD` is the noise floor that stops σ≈0 on a quiet ledger
  from turning cents into an anomaly.
- **Delivery reuses the existing notification path**: owner email (only when something actually
  fired — a daily "all clear" trains people to ignore it) to `COST_ALERT_EMAIL`, falling back to
  `MARGIN_REPORT_EMAIL`; one PostHog `cost_alert` event per alert; a structured log line
  (`log_error` for critical, which the logger forwards to PostHog on its own).
- New read-only helpers: `db.get_daily_cost_totals` (degrades to `{}` without the table, per the
  existing cost accessors) and `observability.posthog_hogql_query` (HogQL read; `None` when
  `POSTHOG_PERSONAL_API_KEY`/`POSTHOG_PROJECT_ID` are unset, which just skips the cache-hit check).
- CLI for manual/cron use: `python -m cqc_lem.utilities.cost_alerts [--json] [--email] [--day YYYY-MM-DD]`
  — exit 2 signals a breach.
- No migration, no schema change, no writes.

## Testing

- `tests/unit/utilities/test_cost_alerts.py` — 60 tests: **every alert fires on a synthetic breach**
  (the issue's acceptance criterion) and every quiet / not-enough-data path is pinned; thresholds
  proven configurable; renderers, collectors, delivery, CLI exit codes, and the beat entry covered.
  99% coverage on the new module.
- Extended `test_db_cost_ledger.py` (new daily-totals accessor, incl. absent-days-are-not-zero) and
  `test_observability.py` (`track_cost_alert`, `posthog_hogql_query`).
- Full unit suite green locally: 4045 passed.

Closes #493

🤖 Generated with [Claude Code](https://claude.com/claude-code)