### PR TITLE
feat(routing): cost-aware model down-routing loop with A/B + auto-rollback (closes #494)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -372,6 +372,32 @@ REGION_PROXY_COST=0
 # Total monthly fixed infra USD (VPS + containers), amortized across active users.
 INFRA_FIXED_MONTHLY=0
 
+# --- Cost-aware model routing (docs/cost-performance-margin-plan.md §D.1(1)) ---
+# TWO switches, both must be true for a call to ever be down-routed: the app side (below) decides
+# whether experiments run at all and is written into the published policy; the proxy side
+# (COST_AWARE_ROUTING_ENABLED) lets the LiteLLM container ignore the policy entirely.
+COST_ROUTING_ENABLED=false
+COST_AWARE_ROUTING_ENABLED=false
+# Where the policy document lives. MUST be the same Redis the app and the LiteLLM container share.
+COST_ROUTING_REDIS_URL=redis://redis:6379/0
+# Seconds the proxy reuses a fetched policy before re-reading Redis (a rollback lands within one).
+COST_ROUTING_POLICY_TTL_SECONDS=60
+# Days of post outcomes each weekly evaluation reads, and posts required PER ARM to judge a bucket.
+COST_ROUTING_WINDOW_DAYS=28
+COST_ROUTING_MIN_SAMPLES=20
+# Equivalence margin — the largest RELATIVE engagement drop still counted as "indistinguishable".
+COST_ROUTING_MAX_QUALITY_DROP=0.05
+# Authenticity gate in score points: a bigger median drop, or a median under the floor, rolls back.
+COST_ROUTING_AUTH_MAX_DROP=5
+COST_ROUTING_AUTH_FLOOR=60
+# z for the non-inferiority confidence interval (1.96 = 95%).
+COST_ROUTING_CONFIDENCE_Z=1.96
+# Days a rolled-back bucket is left alone before it may be re-proposed.
+COST_ROUTING_COOLDOWN_DAYS=28
+# Blast radius: share of users a new experiment starts on, and how many buckets may run at once.
+COST_ROUTING_INITIAL_COHORT_PCT=0.1
+COST_ROUTING_MAX_EXPERIMENTS=1
+
 # --- Codecov (coverage reporting) ---
 CODECOV_TOKEN=your_codecov_token
 

--- a/.env.example
+++ b/.env.example
@@ -379,6 +379,8 @@ INFRA_FIXED_MONTHLY=0
 # Set them TOGETHER. App-on/proxy-off is NOT a dry run: experiments would open and ramp while both
 # arms actually run on the same tier, so the gate passes on a comparison of nothing — and turning the
 # proxy on later would start at whatever cohort the sham ramp had reached.
+# Shipped OFF by owner decision (PR #529): the loop is dormant — while COST_ROUTING_ENABLED is false
+# the weekly task observes nothing and just republishes the parked policy. Flip BOTH to true to start.
 COST_ROUTING_ENABLED=false
 COST_AWARE_ROUTING_ENABLED=false
 # Where the policy document lives. MUST be the same Redis the app and the LiteLLM container share.

--- a/.env.example
+++ b/.env.example
@@ -376,6 +376,9 @@ INFRA_FIXED_MONTHLY=0
 # TWO switches, both must be true for a call to ever be down-routed: the app side (below) decides
 # whether experiments run at all and is written into the published policy; the proxy side
 # (COST_AWARE_ROUTING_ENABLED) lets the LiteLLM container ignore the policy entirely.
+# Set them TOGETHER. App-on/proxy-off is NOT a dry run: experiments would open and ramp while both
+# arms actually run on the same tier, so the gate passes on a comparison of nothing — and turning the
+# proxy on later would start at whatever cohort the sham ramp had reached.
 COST_ROUTING_ENABLED=false
 COST_AWARE_ROUTING_ENABLED=false
 # Where the policy document lives. MUST be the same Redis the app and the LiteLLM container share.

--- a/.litellm/complexity_router.py
+++ b/.litellm/complexity_router.py
@@ -1,32 +1,153 @@
-"""LiteLLM pre-call hook: routes 'lem-router' requests to tier based on prompt complexity."""
+"""LiteLLM pre-call hook: resolves the tier a request runs on.
+
+Two stages, in order:
+1. **Complexity** (always) — `lem-router` requests are mapped to a tier from prompt shape.
+2. **Cost-aware down-routing** (flag-gated, `COST_AWARE_ROUTING_ENABLED`) — the tier from stage 1,
+   or an explicitly requested `lem-*` tier, may be routed one tier DOWN for the treatment cohort of
+   an active experiment (docs/cost-performance-margin-plan.md §D.1(1), issue #494).
+
+The decision itself lives in `routing_policy.py` — the app module mounted into this container by
+docker-compose, and the same code the weekly optimizer uses to evaluate the experiment. The policy
+document is published to Redis by `cqc_lem.utilities.cost_routing`; this hook only reads it, caches
+it briefly in-process, and FAILS OPEN: any missing module, unreachable Redis, or malformed document
+leaves routing exactly as it was before this feature existed.
+"""
+import json
+import logging
+import os
+import sys
+import time
+
 from litellm.integrations.custom_logger import CustomLogger
 
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+try:
+    import routing_policy
+except Exception:  # pragma: no cover - container without the mounted module: complexity only
+    routing_policy = None
+
+log = logging.getLogger("lem.router")
+
+# Signals kept here as the fallback for a container that has no routing_policy mount, so this hook
+# never loses its original behaviour.
 SIMPLE_SIGNALS = ["refine", "shorten", "summarize briefly", "comma separated", "short list"]
 COMPLEX_SIGNALS = [
     "thought leadership", "viral post", "personal story", "industry news",
     "buyer stage", "comprehensive", "step-by-step", "framework",
 ]
 
+ROUTER_MODEL = "lem-router"
+TIERS = ("lem-simple", "lem-medium", "lem-complex")
+
+# Seconds a fetched policy is reused before Redis is consulted again. The policy changes weekly, so
+# this is purely about not paying a Redis round-trip per LLM call; a rollback still takes effect
+# within one TTL.
+POLICY_TTL_SECONDS = int(os.getenv("COST_ROUTING_POLICY_TTL_SECONDS", "60") or 60)
+
+
+def _cost_routing_enabled():
+    return (os.getenv("COST_AWARE_ROUTING_ENABLED", "false") or "").strip().lower() in (
+        "1", "true", "yes", "on")
+
+
+def _redis_url():
+    """Must resolve to the SAME Redis the app publishes to — see COST_ROUTING_REDIS_URL in
+    .env.example. The Celery broker is the fallback because that is where LEM's runtime state
+    already lives."""
+    for env_var in ("COST_ROUTING_REDIS_URL", "CELERY_BROKER_URL"):
+        url = (os.getenv(env_var) or "").strip()
+        if url.startswith("redis"):
+            return url
+    return "redis://{}:{}/0".format(os.getenv("REDIS_HOST", "redis"), os.getenv("REDIS_PORT", "6379"))
+
 
 class LEMComplexityRouter(CustomLogger):
-    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
-        if data.get("model") != "lem-router":
-            return data
+    def __init__(self):
+        super().__init__()
+        self._policy = None
+        self._policy_fetched_at = 0.0
+
+    # ───────────────────────── policy plumbing ─────────────────────────
+
+    def _fetch_policy(self):
+        """Read the published policy from Redis. None on any failure — the caller treats that as
+        "no policy", i.e. complexity-only routing."""
+        try:
+            import redis
+        except Exception:
+            return None
+        try:
+            client = redis.Redis.from_url(_redis_url(), socket_timeout=2, socket_connect_timeout=2)
+            raw = client.get(routing_policy.POLICY_REDIS_KEY)
+        except Exception as exc:
+            log.debug("cost-aware routing: policy read failed (%s)", exc)
+            return None
+        if not raw:
+            return None
+        try:
+            return json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+        except Exception:
+            log.warning("cost-aware routing: policy in Redis is not valid JSON — ignoring")
+            return None
+
+    def _current_policy(self):
+        now = time.time()
+        if self._policy is None or (now - self._policy_fetched_at) >= POLICY_TTL_SECONDS:
+            self._policy = self._fetch_policy() or {}
+            self._policy_fetched_at = now
+        return self._policy
+
+    # ───────────────────────── tier resolution ─────────────────────────
+
+    def _complexity_tier(self, data):
+        if routing_policy is not None:
+            return routing_policy.complexity_tier(routing_policy.prompt_text(data.get("messages")))
         prompt = " ".join(
             m.get("content", "") for m in data.get("messages", [])
             if isinstance(m.get("content"), str)
         ).lower()
-        score = (
-            sum(1 for s in COMPLEX_SIGNALS if s in prompt)
-            - sum(1 for s in SIMPLE_SIGNALS if s in prompt)
-        )
+        score = (sum(1 for s in COMPLEX_SIGNALS if s in prompt)
+                 - sum(1 for s in SIMPLE_SIGNALS if s in prompt))
         token_estimate = len(prompt.split())
         if score >= 2 or token_estimate > 800:
-            data["model"] = "lem-complex"
-        elif score >= 1 or token_estimate > 300:
-            data["model"] = "lem-medium"
+            return "lem-complex"
+        if score >= 1 or token_estimate > 300:
+            return "lem-medium"
+        return "lem-simple"
+
+    @staticmethod
+    def _attribution(data):
+        """(feature, user_id) for this request, from the `metadata` block `_call_llm` attaches. The
+        same two dimensions cost is attributed by, so an experiment bucket and a spend bucket always
+        mean the same thing."""
+        metadata = data.get("metadata")
+        if not isinstance(metadata, dict):
+            return None, None
+        return metadata.get("feature"), metadata.get("user_id")
+
+    async def async_pre_call_hook(self, user_api_key_dict, cache, data, call_type):
+        requested = data.get("model")
+        if requested == ROUTER_MODEL:
+            tier = self._complexity_tier(data)
+        elif requested in TIERS:
+            tier = requested
         else:
-            data["model"] = "lem-simple"
+            return data  # image/research/raw provider models are never re-routed
+
+        if routing_policy is not None and _cost_routing_enabled():
+            feature, user_id = self._attribution(data)
+            try:
+                decision = routing_policy.resolve_tier(tier, feature, user_id, self._current_policy())
+            except Exception as exc:  # never let the optimizer take an LLM call down with it
+                log.warning("cost-aware routing failed, using %s: %s", tier, exc)
+            else:
+                if decision["applied"]:
+                    log.info("cost-aware down-route %s→%s (bucket=%s, feature=%s)",
+                             tier, decision["tier"], decision["bucket"], feature)
+                    tier = decision["tier"]
+
+        data["model"] = tier
         return data
 
 

--- a/.litellm/complexity_router.py
+++ b/.litellm/complexity_router.py
@@ -143,8 +143,11 @@ class LEMComplexityRouter(CustomLogger):
                 log.warning("cost-aware routing failed, using %s: %s", tier, exc)
             else:
                 if decision["applied"]:
-                    log.info("cost-aware down-route %s→%s (bucket=%s, feature=%s)",
-                             tier, decision["tier"], decision["bucket"], feature)
+                    # DEBUG, not INFO: this fires on every down-routed call (10%+ of ALL LLM traffic
+                    # once enabled). INFO here is reserved for state transitions, which the weekly
+                    # optimizer logs on the app side.
+                    log.debug("cost-aware down-route %s→%s (bucket=%s, feature=%s)",
+                              tier, decision["tier"], decision["bucket"], feature)
                     tier = decision["tier"]
 
         data["model"] = tier

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,13 @@ response = client.chat.completions.create(model="lem-simple", messages=[...])
 | `lem-embedding` | Embeddings for feedback dedup/clustering (`client.embeddings.create`) |
 | `lem-router` | Auto-routes by prompt complexity via `LEMComplexityRouter` |
 
+**Cost-aware down-routing** (`utilities/routing_policy.py`, `utilities/cost_routing.py`): the router
+can additionally route a tier ONE step down for the treatment cohort of an active cost/quality
+experiment. `routing_policy.py` is the shared decision core — the app imports it, and docker-compose
+mounts that same file into the LiteLLM container — so it must stay **stdlib-only** (no `cqc_lem.*`
+imports). Off unless BOTH `COST_ROUTING_ENABLED` and `COST_AWARE_ROUTING_ENABLED` are set. See
+`docs/cost-performance-margin-plan.md` §D.1.1.
+
 See `ai_helper.py` for the per-function model assignment.
 
 ## Selenium Pattern

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -300,6 +300,10 @@ services:
       - "4000:4000"
     volumes:
       - ./.litellm:/app/.litellm
+      # The complexity router's decision core, shared with the app so the weekly optimizer and the
+      # router can never disagree about a bucket (issue #494). Mounted, not copied: this image has
+      # no LEM package, and the module is deliberately stdlib-only for exactly that reason.
+      - ./src/cqc_lem/utilities/routing_policy.py:/app/.litellm/routing_policy.py:ro
     command: ["--config", "/app/.litellm/config.yaml", "--port", "4000"]
     environment:
       - OPENAI_API_KEY=${OPENAI_API_KEY}
@@ -310,6 +314,11 @@ services:
       - OLLAMA_CLOUD_API_KEY=${OLLAMA_CLOUD_API_KEY}
       # lem-research (newsletter research grounding) routes to Perplexity Sonar
       - PERPLEXITY_API_KEY=${PERPLEXITY_API_KEY}
+      # Cost-aware down-routing (issue #494). OFF unless BOTH this and COST_ROUTING_ENABLED (app
+      # side) are on. The Redis URL must point at the same instance the app publishes the policy to.
+      - COST_AWARE_ROUTING_ENABLED=${COST_AWARE_ROUTING_ENABLED:-false}
+      - COST_ROUTING_REDIS_URL=${COST_ROUTING_REDIS_URL:-redis://redis:6379/0}
+      - COST_ROUTING_POLICY_TTL_SECONDS=${COST_ROUTING_POLICY_TTL_SECONDS:-60}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')\" 2>/dev/null || exit 1"]

--- a/docs/cost-performance-margin-plan.md
+++ b/docs/cost-performance-margin-plan.md
@@ -325,6 +325,20 @@ reached. At most `COST_ROUTING_MAX_EXPERIMENTS` buckets run at once. Every failu
 unreachable Redis, malformed document, a broken decision core, a call with no user id — fails open to
 the tier the call would have used before this feature existed.
 
+**Shipped state (owner decision on PR #529, 2026-07-25).** Merged **dormant**: both flags stay
+`false` in production, so no experiment opens and no call is down-routed until someone turns them on.
+The weekly beat task still runs, but while `COST_ROUTING_ENABLED` is off it skips the observation
+window entirely and only republishes the parked policy. The gate ships at its documented defaults
+(5% equivalence margin, authenticity floor 60, max median drop 5 points, 95% CI, 20 posts per arm),
+and the first bucket is left to the ranker rather than named by hand — it will take the most
+expensive tier first, i.e. `content:lem-complex → lem-medium`.
+
+**Turning it on later.** Set `COST_ROUTING_ENABLED=true` **and** `COST_AWARE_ROUTING_ENABLED=true`
+together in `/opt/lem/.env`, recreate the app services and `litellm`, then either wait for Monday
+14:00 UTC or run `python -m cqc_lem.utilities.cost_routing --json` in a worker to see what the next
+run would do before it does it. Turning either flag back off parks every bucket without losing the
+experiment state the next run needs.
+
 **What is NOT auto-routed.** Only features with a per-artifact quality signal (`MEASURABLE_FEATURES`,
 today just `content`) can be auto-experimented. Comments, DMs and newsletters have nothing that could
 clear an automated gate, so their spend is surfaced as a ranked human-gated recommendation in the

--- a/docs/cost-performance-margin-plan.md
+++ b/docs/cost-performance-margin-plan.md
@@ -269,6 +269,7 @@ could degrade output quality is gated by the quality signals (engagement_rate,
    not just latency. For feature×context buckets where the cheaper tier's historical
    engagement/authenticity is statistically indistinguishable, route down. Ship behind a flag; auto
    A/B on a cohort; auto-rollback if quality drops. **`risk:product-decision`.**
+   *(Shipped, issue #494 — see §D.1.1 below.)*
 2. **Feature cost toggles** — the proven pattern (`COMMENT_RESEARCH_ENABLED` OFF by default because
    comments are high-volume). Generalize: any feature whose cost/engagement ratio degrades gets an
    auto-recommended toggle.
@@ -280,6 +281,52 @@ could degrade output quality is gated by the quality signals (engagement_rate,
    trust allows (biggest linear-cost lever).
 6. **Media reuse** — reuse/branch existing assets before paying for a new render.
 
+### D.1.1 Cost-aware down-routing — how it actually works (shipped, issue #494)
+
+One decision core, `src/cqc_lem/utilities/routing_policy.py`, is used by BOTH sides: the app imports
+it as `cqc_lem.utilities.routing_policy`, and docker-compose mounts that same file into the LiteLLM
+container next to `.litellm/complexity_router.py`, which imports it as a bare `routing_policy`. It is
+stdlib-only for exactly that reason (the LiteLLM image has no LEM package). Router and optimizer can
+therefore never disagree about which bucket a call belongs to.
+
+| Piece | How it runs |
+|---|---|
+| Routing hook | `.litellm/complexity_router.py` — stage 1 complexity (unchanged), stage 2 cost-aware down-routing of the resulting tier **or** of an explicitly requested `lem-*` tier |
+| Decision core | `utilities/routing_policy.py` — `complexity_tier`, `assign_arm`, `resolve_tier`; down-route only, never up, never off-tier |
+| Optimizer | Celery beat `weekly-cost-routing` → `run_scheduler.auto_weekly_cost_routing` (Mon 14:00 UTC); also `python -m cqc_lem.utilities.cost_routing [--json] [--apply] [--days N]` (exit 2 = a bucket rolled back) |
+| Policy transport | one JSON document at Redis `lem:routing:policy`; the hook caches it for `COST_ROUTING_POLICY_TTL_SECONDS`, so a rollback lands within one TTL |
+| Quality source | `db.get_post_quality_rows` — every posted post's latest `post_stats` row + `posts.authenticity_score` (V57) |
+| Attribution | `_call_llm` sends `metadata={feature, user_id}` to the proxy — the same two dimensions cost is attributed by, so the experiment bucket and the spend bucket mean the same thing |
+
+**The bucket lifecycle.** A bucket is one `feature:tier` pair (`content:lem-complex`). It starts as an
+`experiment` on `COST_ROUTING_INITIAL_COHORT_PCT` of users, climbs the ramp (10% → 50% → **90%,
+`adopted`**) each week it passes, and snaps back to `rolled_back` — cohort 0, with a cooldown — the
+week it fails. The top of the ramp is deliberately NOT 100%: **a bucket with no control arm can never
+be measured again**, so the permanent holdout is what keeps auto-rollback alive after full rollout.
+Re-proposing a rolled-back bucket bumps its generation, which re-salts the cohort hash so the retry
+isn't run on the same users.
+
+**The gate is non-inferiority, not "looks fine" (§D.3).** Each week the window's posts are split into
+the arms their authors were assigned to, and the cheaper tier is promoted only when the 95% CI lower
+bound on (treatment − control) engagement sits inside the equivalence margin
+(`COST_ROUTING_MAX_QUALITY_DROP`). An underpowered, noisy comparison reads `inconclusive` and the
+experiment keeps running — it never passes by default. Authenticity is an absolute veto on top: a
+median below `COST_ROUTING_AUTH_FLOOR`, or a drop of more than `COST_ROUTING_AUTH_MAX_DROP` points,
+rolls the bucket back whatever engagement did. Engagement is impression-normalized when every post in
+the comparison carries impressions, and raw weighted engagement otherwise (never a mix).
+
+**Blast radius.** Two independent flags, and BOTH must be on for any call to move:
+`COST_ROUTING_ENABLED` (app side — also written into the policy document, so flipping it off parks
+every bucket without losing experiment state) and `COST_AWARE_ROUTING_ENABLED` (proxy side). Both
+default OFF. At most `COST_ROUTING_MAX_EXPERIMENTS` buckets run at once. Every failure mode — no
+policy, unreachable Redis, malformed document, a broken decision core, a call with no user id — fails
+open to the tier the call would have used before this feature existed.
+
+**What is NOT auto-routed.** Only features with a per-artifact quality signal (`MEASURABLE_FEATURES`,
+today just `content`) can be auto-experimented. Comments, DMs and newsletters have nothing that could
+clear an automated gate, so their spend is surfaced as a ranked human-gated recommendation in the
+weekly report instead — the §D.3 `risk:product-decision` posture, enforced in code.
+
 ### D.2 Automated cadence
 
 | Cadence | Job | Output |
@@ -287,7 +334,7 @@ could degrade output quality is gated by the quality signals (engagement_rate,
 | **Daily** | Extend `snapshot.sh` with a cost+margin block (`cost_by_feature`, `spend_usd`, est. `mrr`, `contribution_margin`) appended to `metrics.jsonl` | trend line for cost & margin next to engagement |
 | **Daily** | Spend anomaly detection (spend vs. trailing-7-day mean/σ) — *shipped, issue #493: Celery beat `daily-cost-alerts` → `run_scheduler.auto_daily_cost_alerts`, see §E.2* | alert if the last complete day's spend > μ+3σ or a per-user ceiling is breached |
 | **Weekly** | Margin report (per-user CM, system gross margin, cohort engagement lift, LTV:CAC) | posted to owner (email/PostHog dashboard) |
-| **Weekly** | Auto-optimization recommender: scans cost×quality by feature×tier, emits ranked recommendations; for **safe** changes (config toggle, cache extension) the agent pipeline can open an `agent:ready` PR; anything touching routing/quality is filed **`risk:product-decision`** for a human call | recommendations + optional auto-PRs |
+| **Weekly** | Auto-optimization recommender: scans cost×quality by feature×tier, emits ranked recommendations; for **safe** changes (config toggle, cache extension) the agent pipeline can open an `agent:ready` PR; anything touching routing/quality is filed **`risk:product-decision`** for a human call — *routing half shipped, issue #494: Celery beat `weekly-cost-routing` → `run_scheduler.auto_weekly_cost_routing`, see §D.1.1; the auto-PR path for config/cache toggles is not built* | recommendations + optional auto-PRs |
 
 **Shipped (issue #491) — the daily block + weekly report.** `src/cqc_lem/utilities/margin.py` holds
 the §C.1 formulas (pure, unit-tested) plus the DB-fed collectors and delivery:
@@ -420,6 +467,7 @@ Quality guardrail (must hold): cohort engagement_rate · median authenticity_sco
 5. **Alerts** — per-user ceiling, gross-margin floor, spend anomaly, cache-hit collapse,
    unattributed-spend. *(Shipped, issue #493 — the table + thresholds in §E.2.)*
 6. **Cost-aware optimization loop** extending `complexity_router.py` (`risk:product-decision`).
+   *(Shipped, issue #494 — §D.1.1. Flag-gated OFF on both sides; turning it on is the product call.)*
 
 Each is filed as an `agent:ready` GitHub issue referencing this doc. Anything that can auto-degrade
 output quality or auto-modify routing/billing carries `risk:product-decision`.

--- a/docs/cost-performance-margin-plan.md
+++ b/docs/cost-performance-margin-plan.md
@@ -318,9 +318,12 @@ the comparison carries impressions, and raw weighted engagement otherwise (never
 **Blast radius.** Two independent flags, and BOTH must be on for any call to move:
 `COST_ROUTING_ENABLED` (app side — also written into the policy document, so flipping it off parks
 every bucket without losing experiment state) and `COST_AWARE_ROUTING_ENABLED` (proxy side). Both
-default OFF. At most `COST_ROUTING_MAX_EXPERIMENTS` buckets run at once. Every failure mode — no
-policy, unreachable Redis, malformed document, a broken decision core, a call with no user id — fails
-open to the tier the call would have used before this feature existed.
+default OFF, and they must be flipped **together**: app-on/proxy-off is not a dry run — experiments
+would open and ramp while both arms actually ran on the same tier, so the gate would pass on a
+comparison of nothing, and enabling the proxy later would start at whatever cohort that sham ramp had
+reached. At most `COST_ROUTING_MAX_EXPERIMENTS` buckets run at once. Every failure mode — no policy,
+unreachable Redis, malformed document, a broken decision core, a call with no user id — fails open to
+the tier the call would have used before this feature existed.
 
 **What is NOT auto-routed.** Only features with a per-artifact quality signal (`MEASURABLE_FEATURES`,
 today just `content`) can be auto-experimented. Comments, DMs and newsletters have nothing that could

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -253,6 +253,12 @@ app.conf.update(
             # sync so tier MRR is current, and after the weekly margin report so they never overlap.
             'schedule': crontab(hour='13', minute='0')
         },
+        'weekly-cost-routing': {
+            'task': 'cqc_lem.app.run_scheduler.auto_weekly_cost_routing',
+            # Mondays 14:00 UTC — after the margin report (12:00) and the alert sweep (13:00), so a
+            # routing change is judged on the same week's cost/quality picture those just reported.
+            'schedule': crontab(hour='14', minute='0', day_of_week='monday')
+        },
 
     }
 )

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -22,7 +22,8 @@ from cqc_lem.utilities.db import (
     get_approved_catchup_touches, get_orphaned_catchup_touches, update_catchup_touch_status,
     count_catchup_touches_sent_today, CatchupTouchStatus, max_catchup_touches_allowed,
 )
-from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES
+from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES, \
+    COST_ROUTING_WINDOW_DAYS
 from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
 from cqc_lem.utilities.linkedin.rate_limit import is_automation_paused, automation_pause_remaining, \
     rate_limit_cooldown_remaining
@@ -1339,6 +1340,22 @@ def auto_rollup_llm_costs(self):
     written = flush_llm_cost_rollup()
     log_info(f"LLM cost rollup: wrote {written} ledger row(s)", task_name="auto_rollup_llm_costs")
     return written
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True})
+def auto_weekly_cost_routing(self, days: int = COST_ROUTING_WINDOW_DAYS):
+    """Weekly cost-aware routing optimization (issue #494, plan §D.1(1)): scores every running
+    down-route experiment against the §D.3 quality gate (engagement non-inferiority +
+    `posts.authenticity_score`), promotes the ones that hold, **auto-rolls-back** the ones that
+    don't, opens at most `COST_ROUTING_MAX_EXPERIMENTS` new ones, and publishes the policy the
+    LiteLLM complexity router reads. A no-op unless COST_ROUTING_ENABLED is on."""
+    from cqc_lem.utilities.cost_routing import apply_routing_report, collect_routing_report
+
+    report = collect_routing_report(days=days)
+    result = apply_routing_report(report)
+    return (f"Cost routing {report.get('date')}: {result['changes']} change(s), "
+            f"{result['rollbacks']} rollback(s) over {report.get('observations')} post(s) "
+            f"(published={result['published']}, emailed={result['emailed']})")
 
 
 if __name__ == "__main__":

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1348,7 +1348,8 @@ def auto_weekly_cost_routing(self, days: int = COST_ROUTING_WINDOW_DAYS):
     down-route experiment against the §D.3 quality gate (engagement non-inferiority +
     `posts.authenticity_score`), promotes the ones that hold, **auto-rolls-back** the ones that
     don't, opens at most `COST_ROUTING_MAX_EXPERIMENTS` new ones, and publishes the policy the
-    LiteLLM complexity router reads. A no-op unless COST_ROUTING_ENABLED is on."""
+    LiteLLM complexity router reads. While COST_ROUTING_ENABLED is off it observes nothing and only
+    republishes the parked policy, so the loop is dormant until the flag is turned on."""
     from cqc_lem.utilities.cost_routing import apply_routing_report, collect_routing_report
 
     report = collect_routing_report(days=days)

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -44,6 +44,20 @@ from dotenv import load_dotenv
 load_dotenv()
 
 
+def _attach_routing_metadata(kwargs: dict, user_id, feature) -> None:
+    """Send this call's (user, feature) to the LiteLLM proxy as request `metadata`, so the
+    complexity router can look the call's cost-aware routing bucket up (issue #494). Same two
+    dimensions cost is attributed by — the experiment bucket and the spend bucket must mean the
+    same thing. Only tier aliases are routable, so nothing is attached to raw provider models.
+    Best-effort: an existing `extra_body` from the caller wins over ours."""
+    if not str(kwargs.get("model") or "").startswith("lem-"):
+        return
+    extra_body = kwargs.setdefault("extra_body", {})
+    if not isinstance(extra_body, dict) or "metadata" in extra_body:
+        return
+    extra_body["metadata"] = {"feature": feature, "user_id": user_id}
+
+
 def _call_llm(**kwargs):
     """Thin wrapper around client.chat.completions.create that logs model, latency, and token usage.
 
@@ -65,6 +79,10 @@ def _call_llm(**kwargs):
         )
 
     try:
+        try:
+            _attach_routing_metadata(kwargs, *_attribution())
+        except Exception:
+            pass  # attribution is observability, never a reason to lose the generation
         response = client.chat.completions.create(**kwargs)
         duration_ms = int((time.time() - start) * 1000)
         usage = getattr(response, "usage", None)

--- a/src/cqc_lem/utilities/cost_routing.py
+++ b/src/cqc_lem/utilities/cost_routing.py
@@ -97,7 +97,11 @@ COHORT_RAMP_TAIL = (0.5, ADOPTED_COHORT_PCT)
 
 def default_thresholds() -> dict:
     """Thresholds from the environment (`COST_ROUTING_*`). Every caller merges over this, so a test —
-    or a CLI run — can override one threshold without restating the rest."""
+    or a CLI run — can override one threshold without restating the rest.
+
+    The initial cohort is clamped to `ADOPTED_COHORT_PCT`: a configured start above the adopted
+    ceiling would open an experiment with (almost) no control arm, and the permanent holdout is what
+    keeps the §D.3 quality gate measurable — including after a bucket is adopted."""
     return {
         "min_samples": COST_ROUTING_MIN_SAMPLES,
         "max_quality_drop": COST_ROUTING_MAX_QUALITY_DROP,
@@ -105,7 +109,7 @@ def default_thresholds() -> dict:
         "authenticity_floor": COST_ROUTING_AUTH_FLOOR,
         "confidence_z": COST_ROUTING_CONFIDENCE_Z,
         "cooldown_days": COST_ROUTING_COOLDOWN_DAYS,
-        "initial_cohort_pct": COST_ROUTING_INITIAL_COHORT,
+        "initial_cohort_pct": min(max(COST_ROUTING_INITIAL_COHORT, 0.0), ADOPTED_COHORT_PCT),
         "max_experiments": COST_ROUTING_MAX_EXPERIMENTS,
     }
 

--- a/src/cqc_lem/utilities/cost_routing.py
+++ b/src/cqc_lem/utilities/cost_routing.py
@@ -516,16 +516,23 @@ def collect_quality_observations(days: int = COST_ROUTING_WINDOW_DAYS,
 
 
 def collect_routing_report(days: int = COST_ROUTING_WINDOW_DAYS, today: Optional[date] = None,
-                           thresholds: Optional[Mapping] = None) -> dict:
+                           thresholds: Optional[Mapping] = None,
+                           enabled: bool = COST_ROUTING_ENABLED) -> dict:
     """Read the live policy, the window's quality observations and (when the ledger is capturing) the
-    per-feature spend, then build the next policy."""
+    per-feature spend, then build the next policy.
+
+    While `COST_ROUTING_ENABLED` is off nothing is being routed, so the window is not scanned at all —
+    the weekly run costs one Redis read/write instead of a cross-user posts+post_stats scan. It still
+    republishes the parked (`enabled: false`) document so the proxy sees the flag flip, and any bucket
+    left in it is judged on no data, which can only HOLD: turning the flag back on resumes exactly
+    where the loop left off, and no experiment can open while it is off."""
     from cqc_lem.utilities.db import cost_ledger_available, get_cost_rollup
 
     today = today or _today()
-    observations = collect_quality_observations(days, end=today)
-    spend = get_cost_rollup(today - timedelta(days=max(int(days), 1)), today,
-                            group_by="feature") if cost_ledger_available() else {}
-    result = build_routing_policy(load_policy(), observations, today, spend, thresholds)
+    observations = collect_quality_observations(days, end=today) if enabled else []
+    spend = (get_cost_rollup(today - timedelta(days=max(int(days), 1)), today, group_by="feature")
+             if enabled and cost_ledger_available() else {})
+    result = build_routing_policy(load_policy(), observations, today, spend, thresholds, enabled)
     return {
         "date": today.isoformat(),
         "window_days": int(days),

--- a/src/cqc_lem/utilities/cost_routing.py
+++ b/src/cqc_lem/utilities/cost_routing.py
@@ -1,0 +1,604 @@
+"""Cost-aware model-cost optimization loop (docs/cost-performance-margin-plan.md §D.1(1), issue #494).
+
+Structured like `utilities/cost_alerts.py`: PURE evaluators first (no DB, no network — these are what
+the unit tests pin with synthetic cohorts), then the DB-fed collectors, publication and CLI.
+
+The loop, once a week:
+
+1. **Observe** — per-post quality (`engagement_rate` / engagement score + `posts.authenticity_score`)
+   for the window, split into the A/B arms of every ACTIVE routing bucket.
+2. **Judge** — a non-inferiority test per bucket: the cheaper tier is adopted only when the treatment
+   arm's quality is statistically INDISTINGUISHABLE from control (its confidence-interval lower bound
+   sits inside the equivalence margin), never merely "looks fine".
+3. **Act** — promote along the cohort ramp (10% → 50% → 100% = adopted), HOLD when the data is
+   inconclusive, or **auto-rollback** the moment the quality gate is breached (§D.3).
+4. **Publish** — the policy document lands in Redis, where `.litellm/complexity_router.py` reads it.
+   `utilities/routing_policy.py` is the single shared decision core, so router and optimizer can
+   never disagree about which bucket a call belongs to.
+
+Two independent flags gate it: `COST_ROUTING_ENABLED` (this side — writes `enabled` into the policy)
+and `COST_AWARE_ROUTING_ENABLED` (the proxy side). Either one off means the router routes exactly as
+it did before this existed. Only features with a real quality signal (`MEASURABLE_FEATURES`) can be
+auto-experimented; everything else is reported as a human-gated recommendation, per §D.3.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+from datetime import date, datetime, timedelta, timezone
+from typing import Mapping, Optional, Sequence
+
+from cqc_lem.utilities.env_constants import (
+    COST_ALERT_EMAIL,
+    COST_ROUTING_AUTH_FLOOR,
+    COST_ROUTING_AUTH_MAX_DROP,
+    COST_ROUTING_CONFIDENCE_Z,
+    COST_ROUTING_COOLDOWN_DAYS,
+    COST_ROUTING_ENABLED,
+    COST_ROUTING_INITIAL_COHORT,
+    COST_ROUTING_MAX_EXPERIMENTS,
+    COST_ROUTING_MAX_QUALITY_DROP,
+    COST_ROUTING_MIN_SAMPLES,
+    COST_ROUTING_WINDOW_DAYS,
+    MARGIN_REPORT_EMAIL,
+)
+from cqc_lem.utilities.logger import log_error, log_info, log_warning
+from cqc_lem.utilities.routing_policy import (
+    ARM_CONTROL,
+    ARM_TREATMENT,
+    POLICY_REDIS_KEY,
+    POLICY_VERSION,
+    ROUTING_STATES,
+    STATE_ADOPTED,
+    STATE_EXPERIMENT,
+    STATE_ROLLED_BACK,
+    TIER_COMPLEX,
+    TIER_MEDIUM,
+    assign_arm,
+    bucket_key,
+    cheaper_tier,
+    normalize_policy,
+)
+
+# ───────────────────────────── vocabulary ─────────────────────────────
+
+VERDICT_NON_INFERIOR = "non_inferior"
+VERDICT_DEGRADED = "degraded"
+VERDICT_INCONCLUSIVE = "inconclusive"
+VERDICT_INSUFFICIENT = "insufficient_data"
+
+ACTION_PROMOTE = "promote"
+ACTION_ADOPT = "adopt"
+ACTION_ROLLBACK = "rollback"
+ACTION_HOLD = "hold"
+ACTION_START = "start"
+
+METRIC_RATE = "engagement_rate"
+METRIC_COUNT = "engagement"
+
+# Features whose output quality is actually measurable per artifact. Posts carry both signals the
+# §D.3 gate needs (engagement via `post_stats`, `posts.authenticity_score`); a comment or a DM has
+# neither, so down-routing them can never be auto-adopted — it is reported for a human instead.
+MEASURABLE_FEATURES = ("content",)
+
+# Tiers worth experimenting on, expensive-first. `lem-simple` is already the floor.
+CANDIDATE_TIERS = (TIER_COMPLEX, TIER_MEDIUM)
+
+# Cohort ramp: an experiment that keeps passing widens, so a regression that only shows at scale
+# still gets caught while most traffic is on the known-good tier. The top step is deliberately NOT
+# 100%: a bucket with no control arm can never be measured again, and "adopted" has to stay
+# revocable — the permanent holdout is what keeps auto-rollback (§D.3) alive after full rollout.
+ADOPTED_COHORT_PCT = 0.9
+COHORT_RAMP_TAIL = (0.5, ADOPTED_COHORT_PCT)
+
+
+def default_thresholds() -> dict:
+    """Thresholds from the environment (`COST_ROUTING_*`). Every caller merges over this, so a test —
+    or a CLI run — can override one threshold without restating the rest."""
+    return {
+        "min_samples": COST_ROUTING_MIN_SAMPLES,
+        "max_quality_drop": COST_ROUTING_MAX_QUALITY_DROP,
+        "authenticity_max_drop": COST_ROUTING_AUTH_MAX_DROP,
+        "authenticity_floor": COST_ROUTING_AUTH_FLOOR,
+        "confidence_z": COST_ROUTING_CONFIDENCE_Z,
+        "cooldown_days": COST_ROUTING_COOLDOWN_DAYS,
+        "initial_cohort_pct": COST_ROUTING_INITIAL_COHORT,
+        "max_experiments": COST_ROUTING_MAX_EXPERIMENTS,
+    }
+
+
+def cohort_ramp(initial_pct: float) -> tuple:
+    """The ramp an experiment climbs. Steps at or below the initial cohort are dropped so a
+    configured 60% start doesn't "promote" down to 50%."""
+    return (float(initial_pct),) + tuple(step for step in COHORT_RAMP_TAIL if step > initial_pct)
+
+
+def next_cohort_pct(current: float, initial_pct: float) -> Optional[float]:
+    """The next ramp step above `current`, or None when the experiment is already at full traffic."""
+    for step in cohort_ramp(initial_pct):
+        if step > current + 1e-9:
+            return step
+    return None
+
+
+# ───────────────────────────── pure evaluators ─────────────────────────────
+
+def _engagement(row: Mapping) -> float:
+    """Weighted engagement — same weighting `post_stats` and `track_post_outcome` use, restated here
+    only through the shared helper so the loop can never score posts on a different scale."""
+    from cqc_lem.utilities.post_stats import engagement_score
+    return float(engagement_score(row.get("reactions"), row.get("comments"), row.get("reposts")))
+
+
+def pick_metric(rows: Sequence[Mapping]) -> str:
+    """Impression-normalized rate when EVERY row in the comparison carries impressions, else raw
+    engagement. Mixing the two would compare a rate against a count; falling back to counts is safe
+    because both arms cover the same window and the same cohort split."""
+    rows = list(rows or [])
+    if rows and all((row.get("impressions") or 0) > 0 for row in rows):
+        return METRIC_RATE
+    return METRIC_COUNT
+
+
+def summarize_arm(rows: Optional[Sequence[Mapping]], metric: str = METRIC_COUNT) -> dict:
+    """Mean/σ of the quality metric plus the median authenticity score for one arm. Posts with no
+    authenticity score (pre-gate rows) are simply absent from the median rather than counted as 0 —
+    an unscored post is unknown quality, not bad quality."""
+    rows = list(rows or [])
+    values = []
+    for row in rows:
+        engagement = _engagement(row)
+        if metric == METRIC_RATE:
+            impressions = row.get("impressions") or 0
+            if impressions <= 0:
+                continue
+            values.append(engagement / float(impressions))
+        else:
+            values.append(engagement)
+    authenticity = [float(row["authenticity_score"]) for row in rows
+                    if row.get("authenticity_score") is not None]
+    return {
+        "n": len(values),
+        "metric": metric,
+        "mean": statistics.fmean(values) if values else 0.0,
+        "stdev": statistics.stdev(values) if len(values) > 1 else 0.0,
+        "authenticity_n": len(authenticity),
+        "authenticity_median": statistics.median(authenticity) if authenticity else None,
+    }
+
+
+def compare_arms(treatment: Optional[Mapping], control: Optional[Mapping],
+                 thresholds: Optional[Mapping] = None) -> dict:
+    """Non-inferiority test of the cheaper tier (treatment) against the incumbent (control).
+
+    "Statistically indistinguishable" is the plan's bar, so a plain mean comparison won't do: the
+    cheaper tier is accepted only when the 95% CI lower bound on (treatment − control) sits INSIDE
+    the equivalence margin (`max_quality_drop` of the control mean). A wide, underpowered interval
+    therefore reads `inconclusive` — the experiment keeps running — rather than passing by default.
+
+    The authenticity gate is separate and absolute: a median below the floor, or a drop bigger than
+    `authenticity_max_drop` points, is `degraded` no matter what engagement did (§D.3).
+    """
+    limits = {**default_thresholds(), **(thresholds or {})}
+    treatment, control = dict(treatment or {}), dict(control or {})
+    t_n, c_n = int(treatment.get("n") or 0), int(control.get("n") or 0)
+    detail = {"treatment": treatment, "control": control}
+
+    if t_n < limits["min_samples"] or c_n < limits["min_samples"]:
+        return {"verdict": VERDICT_INSUFFICIENT,
+                "reason": f"need {limits['min_samples']} posts per arm, have "
+                          f"{t_n} treatment / {c_n} control",
+                **detail}
+
+    t_auth, c_auth = treatment.get("authenticity_median"), control.get("authenticity_median")
+    if t_auth is not None and t_auth < limits["authenticity_floor"]:
+        return {"verdict": VERDICT_DEGRADED,
+                "reason": f"treatment authenticity median {t_auth:.0f} below floor "
+                          f"{limits['authenticity_floor']:.0f}",
+                "authenticity_delta": (t_auth - c_auth) if c_auth is not None else None, **detail}
+    if t_auth is not None and c_auth is not None and (c_auth - t_auth) > limits["authenticity_max_drop"]:
+        return {"verdict": VERDICT_DEGRADED,
+                "reason": f"authenticity median dropped {c_auth - t_auth:.1f} points "
+                          f"(> {limits['authenticity_max_drop']:.1f})",
+                "authenticity_delta": t_auth - c_auth, **detail}
+
+    delta = float(treatment["mean"]) - float(control["mean"])
+    standard_error = math.sqrt((float(treatment["stdev"]) ** 2) / t_n
+                               + (float(control["stdev"]) ** 2) / c_n)
+    half_width = limits["confidence_z"] * standard_error
+    margin = limits["max_quality_drop"] * abs(float(control["mean"]))
+    lower, upper = delta - half_width, delta + half_width
+    stats = {"delta": delta, "ci_lower": lower, "ci_upper": upper, "margin": margin,
+             "authenticity_delta": (t_auth - c_auth) if (t_auth is not None and c_auth is not None)
+                                   else None, **detail}
+
+    if upper < -margin:
+        return {"verdict": VERDICT_DEGRADED,
+                "reason": f"engagement is significantly worse (CI upper {upper:.4f} < "
+                          f"-{margin:.4f})", **stats}
+    if lower >= -margin:
+        return {"verdict": VERDICT_NON_INFERIOR,
+                "reason": f"quality held (CI lower {lower:.4f} within margin -{margin:.4f})", **stats}
+    return {"verdict": VERDICT_INCONCLUSIVE,
+            "reason": f"CI [{lower:.4f}, {upper:.4f}] too wide to clear margin -{margin:.4f}",
+            **stats}
+
+
+def evaluate_bucket(bucket: Mapping, comparison: Mapping, today: date,
+                    thresholds: Optional[Mapping] = None) -> dict:
+    """Turn one bucket's verdict into its next state: promote along the ramp, adopt at full traffic,
+    HOLD while the data is thin, or roll back the moment the quality gate is breached.
+
+    Rollback is unconditional — it applies to an `adopted` bucket exactly as it does to a running
+    experiment, so a tier that degrades only after full rollout still snaps back to the incumbent.
+    The bucket stays in the document with a cooldown so the loop doesn't immediately re-propose it.
+    """
+    limits = {**default_thresholds(), **(thresholds or {})}
+    updated = dict(bucket)
+    verdict = comparison.get("verdict")
+    reason = comparison.get("reason") or ""
+
+    if verdict == VERDICT_DEGRADED:
+        updated.update(state=STATE_ROLLED_BACK, cohort_pct=0.0,
+                       cooldown_until=(today + timedelta(days=limits["cooldown_days"])).isoformat(),
+                       reason=reason, evaluated_on=today.isoformat())
+        return {"action": ACTION_ROLLBACK, "bucket": updated, "reason": reason,
+                "comparison": comparison}
+
+    if verdict == VERDICT_NON_INFERIOR and updated.get("state") == STATE_EXPERIMENT:
+        current = float(updated.get("cohort_pct") or 0.0)
+        promoted = next_cohort_pct(current, limits["initial_cohort_pct"])
+        adopted = promoted is None or promoted >= ADOPTED_COHORT_PCT
+        updated.update(cohort_pct=promoted if promoted is not None else current, reason=reason,
+                       evaluated_on=today.isoformat())
+        if adopted:
+            updated["state"] = STATE_ADOPTED
+        return {"action": ACTION_ADOPT if adopted else ACTION_PROMOTE, "bucket": updated,
+                "reason": reason, "comparison": comparison}
+
+    updated.update(reason=reason, evaluated_on=today.isoformat())
+    return {"action": ACTION_HOLD, "bucket": updated, "reason": reason, "comparison": comparison}
+
+
+def split_observations(observations: Optional[Sequence[Mapping]], bucket: Mapping) -> dict:
+    """Bucket every observed post into the arm its author was assigned to, ignoring posts published
+    before the experiment started (they predate the routing change and would dilute both arms)."""
+    started_on = bucket.get("started_on")
+    arms = {ARM_TREATMENT: [], ARM_CONTROL: []}
+    for row in observations or []:
+        day = row.get("day")
+        if started_on and day and str(day) < str(started_on):
+            continue
+        arms[assign_arm(row.get("user_id"), bucket)].append(row)
+    return arms
+
+
+def new_bucket(feature: str, from_tier: str, today: date, cohort_pct: float,
+               generation: int = 1) -> dict:
+    to_tier = cheaper_tier(from_tier)
+    return {
+        "id": f"{bucket_key(feature, from_tier)}#{generation}",
+        "feature": feature,
+        "from_tier": from_tier,
+        "to_tier": to_tier,
+        "state": STATE_EXPERIMENT,
+        "cohort_pct": float(cohort_pct),
+        "generation": generation,
+        "started_on": today.isoformat(),
+        "cooldown_until": None,
+        "reason": f"opened cost/quality experiment {from_tier}→{to_tier}",
+        "evaluated_on": None,
+    }
+
+
+def propose_buckets(observations: Optional[Sequence[Mapping]], existing: Mapping, today: date,
+                    spend_by_feature: Optional[Mapping] = None,
+                    thresholds: Optional[Mapping] = None) -> list:
+    """Rank the cost×quality opportunities and open at most `max_experiments` of them.
+
+    A bucket is only proposed when the feature already has enough measured posts to judge it AND its
+    current authenticity median clears the floor — down-routing content that is *already* scraping
+    the quality gate would be optimizing the wrong end of the funnel. Ranking prefers the feature
+    with the most attributed spend (from `cost_ledger`, when it is capturing), falling back to post
+    volume so the loop still ranks something before the ledger lands.
+    """
+    limits = {**default_thresholds(), **(thresholds or {})}
+    spend = dict(spend_by_feature or {})
+    active = sum(1 for b in existing.values() if b.get("state") in ROUTING_STATES)
+    slots = max(0, int(limits["max_experiments"]) - active)
+    if slots <= 0:
+        return []
+
+    candidates = []
+    for feature in MEASURABLE_FEATURES:
+        feature_rows = [row for row in (observations or [])
+                        if row.get("feature", "content") == feature]
+        baseline = summarize_arm(feature_rows, pick_metric(feature_rows))
+        for tier in CANDIDATE_TIERS:
+            key = bucket_key(feature, tier)
+            previous = existing.get(key)
+            if previous:
+                if previous.get("state") in ROUTING_STATES:
+                    continue
+                cooldown = previous.get("cooldown_until")
+                if cooldown and today.isoformat() < str(cooldown):
+                    continue
+            if baseline["n"] < limits["min_samples"]:
+                continue
+            median = baseline.get("authenticity_median")
+            if median is not None and median < limits["authenticity_floor"]:
+                continue
+            generation = int((previous or {}).get("generation") or 0) + 1
+            candidates.append((float(spend.get(feature) or 0.0), baseline["n"],
+                               new_bucket(feature, tier, today, limits["initial_cohort_pct"],
+                                          generation)))
+    candidates.sort(key=lambda item: (item[0], item[1]), reverse=True)
+    return [bucket for _, _, bucket in candidates[:slots]]
+
+
+def build_routing_policy(previous: Optional[Mapping], observations: Optional[Sequence[Mapping]],
+                         today: date, spend_by_feature: Optional[Mapping] = None,
+                         thresholds: Optional[Mapping] = None,
+                         enabled: bool = COST_ROUTING_ENABLED) -> dict:
+    """Evaluate every live bucket, then open new experiments in whatever slots are left, and return
+    `{"policy": ..., "changes": [...], "recommendations": [...]}`.
+
+    `enabled` is written INTO the document, so flipping `COST_ROUTING_ENABLED` off parks every bucket
+    at once without erasing the experiment state the next run needs."""
+    limits = {**default_thresholds(), **(thresholds or {})}
+    policy = normalize_policy(previous)
+    buckets = dict(policy.get("buckets") or {})
+    rows = list(observations or [])
+    changes, holds = [], []
+
+    for key, bucket in list(buckets.items()):
+        if bucket.get("state") not in ROUTING_STATES:
+            continue
+        feature_rows = [row for row in rows if row.get("feature", "content") == bucket.get("feature")]
+        arms = split_observations(feature_rows, bucket)
+        metric = pick_metric(arms[ARM_TREATMENT] + arms[ARM_CONTROL])
+        comparison = compare_arms(summarize_arm(arms[ARM_TREATMENT], metric),
+                                  summarize_arm(arms[ARM_CONTROL], metric), limits)
+        outcome = evaluate_bucket(bucket, comparison, today, limits)
+        buckets[key] = outcome["bucket"]
+        record = {"bucket": key, "action": outcome["action"], "reason": outcome["reason"],
+                  "bucket_state": outcome["bucket"], "comparison": comparison}
+        # A hold moved no traffic — it belongs in the digest, not in the "something changed" list
+        # that decides whether the owner is emailed.
+        (holds if outcome["action"] == ACTION_HOLD else changes).append(record)
+
+    if enabled:
+        for bucket in propose_buckets(rows, buckets, today, spend_by_feature, limits):
+            key = bucket_key(bucket["feature"], bucket["from_tier"])
+            buckets[key] = bucket
+            changes.append({"bucket": key, "action": ACTION_START, "bucket_state": bucket,
+                            "reason": bucket["reason"], "comparison": None})
+
+    return {
+        "policy": {
+            "version": POLICY_VERSION,
+            "enabled": bool(enabled),
+            "generated_at": datetime.now(timezone.utc).isoformat(),
+            "buckets": buckets,
+        },
+        "changes": changes,
+        "holds": holds,
+        "recommendations": recommend_unmeasurable(spend_by_feature),
+    }
+
+
+def recommend_unmeasurable(spend_by_feature: Optional[Mapping]) -> list:
+    """§D.3: features that spend real money but expose no per-artifact quality signal can't clear an
+    automated gate, so they are surfaced as human-gated recommendations rather than auto-routed."""
+    recommendations = []
+    for feature, usd in sorted((spend_by_feature or {}).items(), key=lambda kv: -float(kv[1] or 0)):
+        if feature in MEASURABLE_FEATURES or float(usd or 0) <= 0:
+            continue
+        recommendations.append({
+            "feature": feature,
+            "spend_usd": round(float(usd), 4),
+            "recommendation": f"{feature} spend is ${float(usd):.2f} with no per-artifact quality "
+                              "signal — down-routing it needs a human product call (risk:product-decision)",
+        })
+    return recommendations
+
+
+def render_routing_text(report: Mapping) -> str:
+    """Plain-text digest — the CLI output and the plaintext alternative of the owner email."""
+    policy = report.get("policy") or {}
+    buckets = policy.get("buckets") or {}
+    lines = [f"LEM cost-aware routing — {report.get('date')} "
+             f"(enabled={policy.get('enabled')}, {len(report.get('changes') or [])} change(s))", ""]
+    if not report.get("changes"):
+        lines.append("No routing changes this run.")
+    for change in list(report.get("changes") or []) + list(report.get("holds") or []):
+        bucket = change.get("bucket_state") or {}
+        state = bucket.get("state") if isinstance(bucket, Mapping) else None
+        lines.append(f"[{str(change.get('action', '')).upper()}] {change.get('bucket')}"
+                     f"{f' → {state}' if state else ''}")
+        lines.append(f"    {change.get('reason')}")
+    lines += ["", "Buckets:"]
+    if not buckets:
+        lines.append("  (none)")
+    for key, bucket in buckets.items():
+        lines.append(f"  {key}: {bucket.get('state')} → {bucket.get('to_tier')} "
+                     f"@ {float(bucket.get('cohort_pct') or 0) * 100:.0f}% cohort")
+    for recommendation in report.get("recommendations") or []:
+        lines += ["", f"RECOMMENDATION: {recommendation.get('recommendation')}"]
+    return "\n".join(lines)
+
+
+def render_routing_html(report: Mapping) -> str:
+    body = (render_routing_text(report)
+            .replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+    return ("<h2>LEM cost-aware routing</h2><pre style=\"font-family:ui-monospace,monospace;"
+            f"font-size:13px;line-height:1.5\">{body}</pre>")
+
+
+# ─────────────────────── DB/Redis-fed collectors & publication ───────────────────────
+
+def _today() -> date:
+    return datetime.now(timezone.utc).date()
+
+
+def _redis_client():
+    """Redis handle for the policy document, or None when Redis is unavailable (the loop then still
+    evaluates and reports — it just can't publish). Must resolve to the same instance the LiteLLM
+    container reads, hence the shared `COST_ROUTING_REDIS_URL` override."""
+    try:
+        import redis
+    except Exception:
+        return None
+    url = (os.getenv("COST_ROUTING_REDIS_URL") or "").strip()
+    if not url.startswith("redis"):
+        url = os.getenv("CELERY_BROKER_URL", "")
+    if not url.startswith("redis"):
+        url = f"redis://redis:{os.getenv('REDIS_PORT', '6379')}/0"
+    try:
+        return redis.Redis.from_url(url, socket_timeout=2, socket_connect_timeout=2)
+    except Exception:
+        return None
+
+
+def load_policy() -> dict:
+    """The currently published policy, or `{}` when there is none (or Redis is unreachable). An
+    unreadable policy is treated as "no experiments running" for evaluation purposes — the router
+    fails open the same way, so both sides degrade to complexity-only routing together."""
+    client = _redis_client()
+    if client is None:
+        return {}
+    try:
+        raw = client.get(POLICY_REDIS_KEY)
+    except Exception as e:
+        log_warning("Could not read routing policy from Redis", exc=e,
+                    task_name="auto_weekly_cost_routing")
+        return {}
+    if not raw:
+        return {}
+    try:
+        return normalize_policy(json.loads(raw.decode("utf-8") if isinstance(raw, bytes) else raw))
+    except Exception as e:
+        log_warning("Routing policy in Redis is not valid JSON — ignoring", exc=e,
+                    task_name="auto_weekly_cost_routing")
+        return {}
+
+
+def publish_policy(policy: Mapping) -> bool:
+    """Write the policy where `.litellm/complexity_router.py` reads it. No TTL: an expired key would
+    silently revert routing mid-week, and "no policy" must mean "nothing decided", not "we forgot"."""
+    client = _redis_client()
+    if client is None:
+        log_warning("Redis unavailable — routing policy not published",
+                    task_name="auto_weekly_cost_routing")
+        return False
+    try:
+        client.set(POLICY_REDIS_KEY, json.dumps(policy))
+        return True
+    except Exception as e:
+        log_warning("Could not publish routing policy to Redis", exc=e,
+                    task_name="auto_weekly_cost_routing")
+        return False
+
+
+def collect_quality_observations(days: int = COST_ROUTING_WINDOW_DAYS,
+                                 end: Optional[date] = None) -> list:
+    """Per-post quality rows for the window, tagged with the feature they belong to. Posts are the
+    `content` feature by definition — the other features have no per-artifact outcome to measure."""
+    from cqc_lem.utilities.db import get_post_quality_rows
+
+    end = end or _today()
+    start = end - timedelta(days=max(int(days), 1))
+    rows = get_post_quality_rows(start, end + timedelta(days=1))
+    return [{**row, "feature": "content"} for row in rows]
+
+
+def collect_routing_report(days: int = COST_ROUTING_WINDOW_DAYS, today: Optional[date] = None,
+                           thresholds: Optional[Mapping] = None) -> dict:
+    """Read the live policy, the window's quality observations and (when the ledger is capturing) the
+    per-feature spend, then build the next policy."""
+    from cqc_lem.utilities.db import cost_ledger_available, get_cost_rollup
+
+    today = today or _today()
+    observations = collect_quality_observations(days, end=today)
+    spend = get_cost_rollup(today - timedelta(days=max(int(days), 1)), today,
+                            group_by="feature") if cost_ledger_available() else {}
+    result = build_routing_policy(load_policy(), observations, today, spend, thresholds)
+    return {
+        "date": today.isoformat(),
+        "window_days": int(days),
+        "observations": len(observations),
+        "spend_by_feature": spend,
+        **result,
+    }
+
+
+def apply_routing_report(report: Optional[Mapping] = None, publish: bool = True,
+                         to_email: Optional[str] = None) -> dict:
+    """Publish the new policy and tell the owner what moved. Only ACTUAL changes are delivered — a
+    weekly "nothing changed" email would train the owner to ignore the one that says a bucket rolled
+    back. A rollback logs at ERROR so it reaches PostHog through the logger on its own."""
+    from cqc_lem.utilities.email import _dispatch_email
+    from cqc_lem.utilities.observability import track_routing_policy
+
+    report = report if report is not None else collect_routing_report()
+    changes = list(report.get("changes") or [])
+    rollbacks = [c for c in changes if c.get("action") == ACTION_ROLLBACK]
+
+    for change in rollbacks:
+        log_error(f"Cost-aware routing rolled back {change.get('bucket')}: {change.get('reason')}",
+                  task_name="auto_weekly_cost_routing")
+
+    published = publish_policy(report.get("policy") or {}) if publish else False
+
+    tracked = False
+    try:
+        track_routing_policy(report)
+        tracked = True
+    except Exception as e:
+        log_warning("Routing policy PostHog capture failed", exc=e,
+                    task_name="auto_weekly_cost_routing")
+
+    recipient = to_email or COST_ALERT_EMAIL or MARGIN_REPORT_EMAIL
+    emailed = False
+    if changes and recipient:
+        try:
+            subject = (f"LEM routing {'ROLLBACK' if rollbacks else 'update'} — "
+                       f"{len(changes)} change(s) {report.get('date')}")
+            emailed = bool(_dispatch_email(recipient, subject, render_routing_html(report),
+                                           text_content=render_routing_text(report),
+                                           high_priority=bool(rollbacks)))
+        except Exception as e:
+            log_warning("Routing policy email failed", exc=e, task_name="auto_weekly_cost_routing")
+
+    log_info(f"Cost-aware routing {report.get('date')}: {len(changes)} change(s), "
+             f"{len(rollbacks)} rollback(s), {report.get('observations')} observed post(s) "
+             f"(published={published}, emailed={emailed}, tracked={tracked})",
+             task_name="auto_weekly_cost_routing")
+    return {"published": published, "emailed": emailed, "tracked": tracked,
+            "changes": len(changes), "rollbacks": len(rollbacks), "report": report}
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="LEM cost-aware routing optimizer")
+    parser.add_argument("--json", action="store_true", help="print the full report as JSON")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="evaluate and print without publishing the policy or emailing")
+    parser.add_argument("--apply", action="store_true",
+                        help="publish the new policy to Redis and deliver changes")
+    parser.add_argument("--days", type=int, default=COST_ROUTING_WINDOW_DAYS,
+                        help=f"observation window in days (default {COST_ROUTING_WINDOW_DAYS})")
+    args = parser.parse_args(argv)
+
+    report = collect_routing_report(days=args.days)
+    if args.apply and not args.dry_run:
+        apply_routing_report(report)
+    print(json.dumps(report) if args.json else render_routing_text(report))
+    # Exit 2 when a bucket rolled back, so a cron/CI caller can act on it without parsing output.
+    return 2 if any(c.get("action") == ACTION_ROLLBACK for c in report.get("changes") or []) else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -6455,6 +6455,47 @@ def get_daily_cost_totals(start_date, end_date) -> dict:
         connection.close()
 
 
+def get_post_quality_rows(start_date, end_date) -> list:
+    """Per-post QUALITY observations across all users over [start_date, end_date] — the outcome side
+    of the cost-aware routing experiment (docs/cost-performance-margin-plan.md §D.1(1), issue #494):
+    `{user_id, post_id, day, reactions, comments, reposts, impressions, authenticity_score}` for
+    every POSTED post with captured stats, using the LATEST `post_stats` row per post.
+
+    Read-only and cross-user by design — the A/B arms are cohorts of users, so the comparison has to
+    see every user's posts, unlike the per-user `get_post_engagement_rows`."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT p.user_id, p.id AS post_id, DATE(p.scheduled_time) AS day, "
+            "p.authenticity_score, s.reactions, s.comments, s.reposts, s.impressions "
+            "FROM posts p JOIN post_stats s ON s.post_id=p.id AND s.user_id=p.user_id "
+            "WHERE p.status='posted' AND p.scheduled_time BETWEEN %s AND %s "
+            "AND s.id IN (SELECT MAX(id) FROM post_stats GROUP BY post_id)",
+            (start_date, end_date))
+        rows = cursor.fetchall() or []
+        return [
+            {
+                "user_id": r["user_id"],
+                "post_id": r["post_id"],
+                "day": r["day"].isoformat() if hasattr(r.get("day"), "isoformat") else r.get("day"),
+                "reactions": int(r["reactions"] or 0),
+                "comments": int(r["comments"] or 0),
+                "reposts": int(r["reposts"] or 0),
+                "impressions": int(r["impressions"]) if r.get("impressions") else None,
+                "authenticity_score": (int(r["authenticity_score"])
+                                       if r.get("authenticity_score") is not None else None),
+            }
+            for r in rows
+        ]
+    except mysql.connector.Error as err:
+        myprint(f"Could not get post quality rows | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_margin_users() -> list:
     """Users the margin report covers: everyone on an active/past-due subscription or an open trial.
     Trials are included (tier `free_trial`, $0 MRR) so the cost they incur still lands in system

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -226,6 +226,35 @@ COST_ALERT_UNATTRIBUTED   = float(get_constant_from_env('COST_ALERT_UNATTRIBUTED
 # Where budget alerts are emailed. Empty falls back to MARGIN_REPORT_EMAIL.
 COST_ALERT_EMAIL          = get_constant_from_env('COST_ALERT_EMAIL', default_value='')
 
+# Cost-aware down-routing (docs/cost-performance-margin-plan.md §D.1(1)). OFF by default: this can
+# change which model writes a user's content, so it ships flag-gated and cohort-scoped. The LiteLLM
+# proxy has its own switch (COST_AWARE_ROUTING_ENABLED) — BOTH must be on for a call to down-route.
+COST_ROUTING_ENABLED      = (get_constant_from_env('COST_ROUTING_ENABLED', default_value='false')
+                             or '').strip().lower() in ('1', 'true', 'yes', 'on')
+# Days of post outcomes each weekly evaluation reads.
+COST_ROUTING_WINDOW_DAYS  = int(get_constant_from_env('COST_ROUTING_WINDOW_DAYS', default_value='28'))
+# Posts required PER ARM before a bucket is judged at all — below this the experiment just runs on.
+COST_ROUTING_MIN_SAMPLES  = int(get_constant_from_env('COST_ROUTING_MIN_SAMPLES', default_value='20'))
+# Equivalence margin: the largest RELATIVE engagement drop still counted as "indistinguishable".
+COST_ROUTING_MAX_QUALITY_DROP = float(get_constant_from_env('COST_ROUTING_MAX_QUALITY_DROP',
+                                                            default_value='0.05'))
+# Authenticity gate (§D.3), in score points: a bigger median drop — or a median under the floor —
+# rolls the bucket back regardless of engagement.
+COST_ROUTING_AUTH_MAX_DROP = float(get_constant_from_env('COST_ROUTING_AUTH_MAX_DROP',
+                                                         default_value='5'))
+COST_ROUTING_AUTH_FLOOR   = float(get_constant_from_env('COST_ROUTING_AUTH_FLOOR', default_value='60'))
+# z for the non-inferiority confidence interval (1.96 = 95%).
+COST_ROUTING_CONFIDENCE_Z = float(get_constant_from_env('COST_ROUTING_CONFIDENCE_Z',
+                                                        default_value='1.96'))
+# Days a rolled-back bucket is left alone before it may be re-proposed.
+COST_ROUTING_COOLDOWN_DAYS = int(get_constant_from_env('COST_ROUTING_COOLDOWN_DAYS',
+                                                       default_value='28'))
+# Share of users a new experiment starts on, and how many buckets may run at once (blast radius).
+COST_ROUTING_INITIAL_COHORT = float(get_constant_from_env('COST_ROUTING_INITIAL_COHORT_PCT',
+                                                          default_value='0.1'))
+COST_ROUTING_MAX_EXPERIMENTS = int(get_constant_from_env('COST_ROUTING_MAX_EXPERIMENTS',
+                                                         default_value='1'))
+
 NGROK_LIPREVIEW_PREFIX=get_constant_from_env('NGROK_LIPREVIEW_PREFIX')
 if NGROK_FREE_DOMAIN and NGROK_LIPREVIEW_PREFIX:
     LINKEDIN_PREVIEW_URL = f"https://{NGROK_LIPREVIEW_PREFIX}.{NGROK_FREE_DOMAIN}"

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -491,6 +491,34 @@ def track_margin_report(report: dict) -> None:
     )
 
 
+def track_routing_policy(report: dict) -> None:
+    """Emit the weekly cost-aware routing decision (plan §D.1(1)) as one `routing_policy` event, so
+    a down-route — and especially an auto-rollback — is queryable next to the cost it was meant to
+    save and the engagement it was gated on. The full comparison stats stay out of the event body;
+    the per-bucket verdict and cohort are what a dashboard needs."""
+    report = dict(report or {})
+    policy = dict(report.get("policy") or {})
+    buckets = policy.get("buckets") or {}
+    posthog.capture(
+        distinct_id="system",
+        event="routing_policy",
+        properties={
+            "date": report.get("date"),
+            "enabled": policy.get("enabled"),
+            "window_days": report.get("window_days"),
+            "observations": report.get("observations"),
+            "change_count": len(report.get("changes") or []),
+            "rollback_count": sum(1 for c in report.get("changes") or []
+                                  if c.get("action") == "rollback"),
+            "changes": [{"bucket": c.get("bucket"), "action": c.get("action"),
+                         "reason": c.get("reason")} for c in report.get("changes") or []],
+            "buckets": [{"bucket": key, "state": b.get("state"), "to_tier": b.get("to_tier"),
+                         "cohort_pct": b.get("cohort_pct")} for key, b in buckets.items()],
+            "recommendations": report.get("recommendations") or [],
+        },
+    )
+
+
 def track_cost_alert(alert: dict, day: Optional[str] = None) -> None:
     """Emit one budget/anomaly alert (plan §E.2) as a `cost_alert` event so a breach is queryable
     next to the spend it came from, and a PostHog alert can page off it. Per-user alerts are keyed

--- a/src/cqc_lem/utilities/routing_policy.py
+++ b/src/cqc_lem/utilities/routing_policy.py
@@ -1,0 +1,196 @@
+"""Shared model-routing decision core — complexity scoring + cost-aware down-routing
+(docs/cost-performance-margin-plan.md §D.1(1), issue #494).
+
+STDLIB ONLY, and deliberately dependency-free. This module is imported from BOTH sides of a
+container boundary:
+
+* the app (`cqc_lem.utilities.routing_policy`) — builds/evaluates the policy and publishes it, and
+* the LiteLLM proxy, where docker-compose mounts this exact file next to
+  `.litellm/complexity_router.py` and the hook imports it as a bare `routing_policy`.
+
+The LiteLLM image has no LEM package and no LEM dependencies, so NEVER import `cqc_lem.*`, a
+third-party library, or anything with I/O here. One file, one decision — the router and the weekly
+optimizer can never drift into disagreeing about which tier a call belongs in.
+
+The policy itself is a JSON document in Redis (`lem:routing:policy`), written weekly by
+`utilities/cost_routing.py` and read by the hook. Its shape:
+
+    {
+      "version": 1,
+      "enabled": true,                      # master switch baked into the document
+      "generated_at": "2026-07-25T12:00:00+00:00",
+      "buckets": {
+        "content:lem-complex": {
+          "id": "content:lem-complex#2",     # bucket + generation — the A/B hash salt
+          "feature": "content", "from_tier": "lem-complex", "to_tier": "lem-medium",
+          "state": "experiment",             # experiment | adopted | rolled_back | hold
+          "cohort_pct": 0.1,                 # share of users routed DOWN (the treatment arm)
+          "generation": 2, "started_on": "2026-07-18", "cooldown_until": null
+        }
+      }
+    }
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Any, Mapping, Optional
+
+# ───────────────────────────── vocabulary ─────────────────────────────
+
+TIER_SIMPLE = "lem-simple"
+TIER_MEDIUM = "lem-medium"
+TIER_COMPLEX = "lem-complex"
+
+# Cheapest → most expensive. Index order is what makes "never route UP" a one-line check.
+TIER_ORDER = (TIER_SIMPLE, TIER_MEDIUM, TIER_COMPLEX)
+
+STATE_EXPERIMENT = "experiment"
+STATE_ADOPTED = "adopted"
+STATE_ROLLED_BACK = "rolled_back"
+STATE_HOLD = "hold"
+
+# Only these two states move traffic. `rolled_back` and `hold` stay in the document (they carry the
+# cooldown and the reason the optimizer needs next week) but route nothing.
+ROUTING_STATES = frozenset({STATE_EXPERIMENT, STATE_ADOPTED})
+
+ARM_TREATMENT = "treatment"
+ARM_CONTROL = "control"
+
+POLICY_VERSION = 1
+POLICY_REDIS_KEY = "lem:routing:policy"
+
+# Complexity signals — unchanged from the original latency-era router, just moved here so the
+# decision is testable without a LiteLLM proxy.
+SIMPLE_SIGNALS = ("refine", "shorten", "summarize briefly", "comma separated", "short list")
+COMPLEX_SIGNALS = ("thought leadership", "viral post", "personal story", "industry news",
+                   "buyer stage", "comprehensive", "step-by-step", "framework")
+
+
+def cheaper_tier(tier: Optional[str]) -> Optional[str]:
+    """The next tier down, or None at the bottom (or for a non-tier model)."""
+    if tier not in TIER_ORDER:
+        return None
+    index = TIER_ORDER.index(tier)
+    return TIER_ORDER[index - 1] if index > 0 else None
+
+
+def bucket_key(feature: Optional[str], tier: Optional[str]) -> str:
+    """Feature×tier is the optimization bucket: the same tier can be safe to down-route for comments
+    and unsafe for long-form content, so they are never judged together."""
+    return f"{feature or 'system'}:{tier}"
+
+
+# ───────────────────────────── complexity tier ─────────────────────────────
+
+def prompt_text(messages: Any) -> str:
+    """Flatten a chat payload to lowercase text for signal matching. Non-string content (image
+    parts) is skipped rather than stringified — it would add noise to the token estimate."""
+    parts = []
+    for message in messages or []:
+        if isinstance(message, Mapping):
+            content = message.get("content")
+            if isinstance(content, str):
+                parts.append(content)
+    return " ".join(parts).lower()
+
+
+def complexity_score(prompt: str) -> int:
+    return (sum(1 for signal in COMPLEX_SIGNALS if signal in prompt)
+            - sum(1 for signal in SIMPLE_SIGNALS if signal in prompt))
+
+
+def complexity_tier(prompt: str) -> str:
+    """The tier `lem-router` resolves to from prompt shape alone — the pre-cost baseline. Cost-aware
+    down-routing is applied to this result, never in place of it, so a complex prompt still starts
+    from the complex tier and only moves if the DATA says the cheaper tier holds up."""
+    score = complexity_score(prompt)
+    token_estimate = len(prompt.split())
+    if score >= 2 or token_estimate > 800:
+        return TIER_COMPLEX
+    if score >= 1 or token_estimate > 300:
+        return TIER_MEDIUM
+    return TIER_SIMPLE
+
+
+# ───────────────────────────── policy application ─────────────────────────────
+
+def normalize_policy(policy: Optional[Mapping]) -> dict:
+    """Coerce whatever came out of Redis into a policy dict, or `{}` when it is unusable. A policy
+    written by a NEWER version is treated as unusable rather than best-guessed — routing fails open
+    to complexity-only, which is always the safe direction."""
+    if not isinstance(policy, Mapping):
+        return {}
+    try:
+        version = int(policy.get("version") or 0)
+    except (TypeError, ValueError):
+        return {}
+    if version != POLICY_VERSION:
+        return {}
+    buckets = policy.get("buckets")
+    return {
+        "version": version,
+        "enabled": bool(policy.get("enabled")),
+        "generated_at": policy.get("generated_at"),
+        "buckets": {str(k): dict(v) for k, v in buckets.items()
+                    if isinstance(v, Mapping)} if isinstance(buckets, Mapping) else {},
+    }
+
+
+def assign_arm(user_id: Optional[Any], bucket: Optional[Mapping]) -> str:
+    """Which A/B arm a user falls in for this bucket. Deterministic on (bucket id, user), so a user
+    keeps the same arm for the whole experiment — a user flipping arms mid-week would contaminate
+    both sides of the comparison. The bucket id carries a generation counter, so re-running a
+    previously rolled-back experiment reshuffles the cohort instead of re-testing the same users.
+
+    Traffic with no user id (system/housekeeping calls) always lands in control: it cannot be
+    attributed to a cohort, so it must not silently join the treatment.
+    """
+    if not isinstance(bucket, Mapping):
+        return ARM_CONTROL
+    try:
+        pct = float(bucket.get("cohort_pct") or 0.0)
+    except (TypeError, ValueError):
+        return ARM_CONTROL
+    if pct <= 0:
+        return ARM_CONTROL
+    if user_id is None or str(user_id).strip() == "":
+        return ARM_CONTROL
+    if pct >= 1:
+        return ARM_TREATMENT
+    salt = f"{bucket.get('id') or bucket_key(bucket.get('feature'), bucket.get('from_tier'))}|{user_id}"
+    digest = hashlib.md5(salt.encode("utf-8")).hexdigest()  # noqa: S324 - cohort split, not a secret
+    return ARM_TREATMENT if (int(digest[:8], 16) % 10_000) / 10_000.0 < pct else ARM_CONTROL
+
+
+def resolve_tier(base_tier: Optional[str], feature: Optional[str], user_id: Optional[Any],
+                 policy: Optional[Mapping]) -> dict:
+    """Apply the cost-aware policy to a tier the complexity rules already chose.
+
+    Returns `{"tier", "base_tier", "arm", "applied", "bucket"}`. Every failure mode — no policy, a
+    disabled policy, an unknown bucket, a bucket that isn't routing, a control-arm user, a target
+    that isn't strictly cheaper — resolves to the base tier untouched. Down-routing is the only
+    thing this can do; it can never route a call UP or to a non-tier model.
+    """
+    result = {"tier": base_tier, "base_tier": base_tier, "arm": ARM_CONTROL,
+              "applied": False, "bucket": None}
+    if base_tier not in TIER_ORDER:
+        return result
+    policy = normalize_policy(policy)
+    if not policy or not policy.get("enabled"):
+        return result
+
+    key = bucket_key(feature, base_tier)
+    bucket = policy["buckets"].get(key)
+    if not bucket or bucket.get("state") not in ROUTING_STATES:
+        return result
+
+    target = bucket.get("to_tier") or cheaper_tier(base_tier)
+    if target not in TIER_ORDER or TIER_ORDER.index(target) >= TIER_ORDER.index(base_tier):
+        return result
+
+    result["bucket"] = key
+    result["arm"] = assign_arm(user_id, bucket)
+    if result["arm"] == ARM_TREATMENT:
+        result["tier"] = target
+        result["applied"] = True
+    return result

--- a/src/cqc_lem/utilities/routing_policy.py
+++ b/src/cqc_lem/utilities/routing_policy.py
@@ -144,6 +144,9 @@ def assign_arm(user_id: Optional[Any], bucket: Optional[Mapping]) -> str:
 
     Traffic with no user id (system/housekeeping calls) always lands in control: it cannot be
     attributed to a cohort, so it must not silently join the treatment.
+
+    SHA-256 is used purely as a uniform, stable hash of (bucket, user) — nothing here is a secret —
+    but a weak digest has no upside for that and trips security scanners, so don't "optimize" it back.
     """
     if not isinstance(bucket, Mapping):
         return ARM_CONTROL
@@ -158,7 +161,7 @@ def assign_arm(user_id: Optional[Any], bucket: Optional[Mapping]) -> str:
     if pct >= 1:
         return ARM_TREATMENT
     salt = f"{bucket.get('id') or bucket_key(bucket.get('feature'), bucket.get('from_tier'))}|{user_id}"
-    digest = hashlib.md5(salt.encode("utf-8")).hexdigest()  # noqa: S324 - cohort split, not a secret
+    digest = hashlib.sha256(salt.encode("utf-8")).hexdigest()
     return ARM_TREATMENT if (int(digest[:8], 16) % 10_000) / 10_000.0 < pct else ARM_CONTROL
 
 

--- a/tests/unit/test_complexity_router.py
+++ b/tests/unit/test_complexity_router.py
@@ -1,0 +1,179 @@
+"""Unit tests for the LiteLLM pre-call hook `.litellm/complexity_router.py` (issue #494).
+
+The hook lives outside the package (it is mounted into the LiteLLM container, which has no LEM
+install), so it is loaded here by path with a stubbed `litellm` — that library is a container
+dependency, not one of ours.
+"""
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ROUTER_PATH = Path(__file__).resolve().parents[2] / ".litellm" / "complexity_router.py"
+
+
+@pytest.fixture
+def router_module(monkeypatch):
+    """Import the hook fresh with `litellm` stubbed, and with the shared decision core importable
+    the same way the container sees it (a bare `routing_policy` next to the hook)."""
+    litellm = types.ModuleType("litellm")
+    integrations = types.ModuleType("litellm.integrations")
+    custom_logger = types.ModuleType("litellm.integrations.custom_logger")
+
+    class CustomLogger:
+        pass
+
+    custom_logger.CustomLogger = CustomLogger
+    monkeypatch.setitem(sys.modules, "litellm", litellm)
+    monkeypatch.setitem(sys.modules, "litellm.integrations", integrations)
+    monkeypatch.setitem(sys.modules, "litellm.integrations.custom_logger", custom_logger)
+
+    from cqc_lem.utilities import routing_policy
+    monkeypatch.setitem(sys.modules, "routing_policy", routing_policy)
+
+    spec = importlib.util.spec_from_file_location("lem_complexity_router", ROUTER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _policy(cohort_pct=1.0, state="experiment", enabled=True):
+    return {"version": 1, "enabled": enabled, "buckets": {
+        "content:lem-complex": {"id": "content:lem-complex#1", "feature": "content",
+                                "from_tier": "lem-complex", "to_tier": "lem-medium",
+                                "state": state, "cohort_pct": cohort_pct}}}
+
+
+async def _route(router, model, messages=None, metadata=None):
+    data = {"model": model, "messages": messages or [{"role": "user", "content": "hi"}]}
+    if metadata is not None:
+        data["metadata"] = metadata
+    return (await router.async_pre_call_hook(None, None, data, "completion"))["model"]
+
+
+# ── stage 1: complexity routing is unchanged ──
+
+@pytest.mark.parametrize("content,expected", [
+    ("write a thought leadership post with a framework", "lem-complex"),
+    ("write a personal story", "lem-medium"),
+    ("refine this", "lem-simple"),
+])
+async def test_router_model_resolves_by_complexity(router_module, content, expected):
+    router = router_module.LEMComplexityRouter()
+    assert await _route(router, "lem-router", [{"role": "user", "content": content}]) == expected
+
+
+async def test_non_tier_models_are_never_rewritten(router_module):
+    router = router_module.LEMComplexityRouter()
+    assert await _route(router, "lem-image") == "lem-image"
+    assert await _route(router, "gpt-4o") == "gpt-4o"
+
+
+# ── stage 2: cost-aware down-routing ──
+
+async def test_explicit_tier_is_untouched_while_the_flag_is_off(router_module, monkeypatch):
+    monkeypatch.delenv("COST_AWARE_ROUTING_ENABLED", raising=False)
+    router = router_module.LEMComplexityRouter()
+    router._policy, router._policy_fetched_at = _policy(), float("inf")
+    assert await _route(router, "lem-complex", metadata={"feature": "content", "user_id": 1}) \
+        == "lem-complex"
+
+
+async def test_flag_on_downroutes_the_treatment_cohort(router_module, monkeypatch):
+    monkeypatch.setenv("COST_AWARE_ROUTING_ENABLED", "true")
+    router = router_module.LEMComplexityRouter()
+    router._policy, router._policy_fetched_at = _policy(), float("inf")
+    assert await _route(router, "lem-complex", metadata={"feature": "content", "user_id": 1}) \
+        == "lem-medium"
+
+
+async def test_flag_on_also_downroutes_the_complexity_result(router_module, monkeypatch):
+    monkeypatch.setenv("COST_AWARE_ROUTING_ENABLED", "true")
+    router = router_module.LEMComplexityRouter()
+    router._policy, router._policy_fetched_at = _policy(), float("inf")
+    complex_prompt = [{"role": "user", "content": "thought leadership framework"}]
+    assert await _route(router, "lem-router", complex_prompt,
+                        metadata={"feature": "content", "user_id": 1}) == "lem-medium"
+
+
+@pytest.mark.parametrize("metadata", [None, {}, {"feature": "comment", "user_id": 1},
+                                      {"feature": "content"}])
+async def test_calls_outside_the_bucket_keep_their_tier(router_module, monkeypatch, metadata):
+    """No metadata, another feature, or no user id — none of them may join the experiment."""
+    monkeypatch.setenv("COST_AWARE_ROUTING_ENABLED", "true")
+    router = router_module.LEMComplexityRouter()
+    router._policy, router._policy_fetched_at = _policy(), float("inf")
+    assert await _route(router, "lem-complex", metadata=metadata) == "lem-complex"
+
+
+async def test_a_rolled_back_policy_stops_routing_down(router_module, monkeypatch):
+    monkeypatch.setenv("COST_AWARE_ROUTING_ENABLED", "true")
+    router = router_module.LEMComplexityRouter()
+    router._policy, router._policy_fetched_at = _policy(state="rolled_back"), float("inf")
+    assert await _route(router, "lem-complex", metadata={"feature": "content", "user_id": 1}) \
+        == "lem-complex"
+
+
+async def test_a_broken_decision_core_fails_open(router_module, monkeypatch):
+    monkeypatch.setenv("COST_AWARE_ROUTING_ENABLED", "true")
+    router = router_module.LEMComplexityRouter()
+    router._policy, router._policy_fetched_at = _policy(), float("inf")
+    with patch.object(router_module.routing_policy, "resolve_tier",
+                      side_effect=RuntimeError("boom")):
+        assert await _route(router, "lem-complex", metadata={"feature": "content", "user_id": 1}) \
+            == "lem-complex"
+
+
+# ── policy fetching ──
+
+def test_policy_is_read_from_redis_and_cached(router_module, monkeypatch):
+    monkeypatch.setenv("COST_ROUTING_REDIS_URL", "redis://redis:6379/0")
+    client = MagicMock()
+    client.get.return_value = json.dumps(_policy()).encode()
+    redis_module = types.ModuleType("redis")
+    redis_module.Redis = MagicMock(from_url=MagicMock(return_value=client))
+    monkeypatch.setitem(sys.modules, "redis", redis_module)
+
+    router = router_module.LEMComplexityRouter()
+    assert router._current_policy()["enabled"] is True
+    router._current_policy()
+    client.get.assert_called_once_with(router_module.routing_policy.POLICY_REDIS_KEY)
+
+
+@pytest.mark.parametrize("value", [None, b"", b"{not json"])
+def test_unreadable_policy_degrades_to_no_policy(router_module, monkeypatch, value):
+    client = MagicMock()
+    client.get.return_value = value
+    redis_module = types.ModuleType("redis")
+    redis_module.Redis = MagicMock(from_url=MagicMock(return_value=client))
+    monkeypatch.setitem(sys.modules, "redis", redis_module)
+    assert router_module.LEMComplexityRouter()._current_policy() == {}
+
+
+def test_redis_failure_degrades_to_no_policy(router_module, monkeypatch):
+    redis_module = types.ModuleType("redis")
+    redis_module.Redis = MagicMock(from_url=MagicMock(side_effect=RuntimeError("no redis")))
+    monkeypatch.setitem(sys.modules, "redis", redis_module)
+    assert router_module.LEMComplexityRouter()._current_policy() == {}
+
+
+def test_redis_url_prefers_the_shared_override(router_module, monkeypatch):
+    monkeypatch.setenv("COST_ROUTING_REDIS_URL", "redis://shared:6379/2")
+    monkeypatch.setenv("CELERY_BROKER_URL", "sqs://queue")
+    assert router_module._redis_url() == "redis://shared:6379/2"
+    monkeypatch.delenv("COST_ROUTING_REDIS_URL")
+    monkeypatch.setenv("CELERY_BROKER_URL", "redis://broker:6379/0")
+    assert router_module._redis_url() == "redis://broker:6379/0"
+    monkeypatch.setenv("CELERY_BROKER_URL", "sqs://queue")
+    assert router_module._redis_url() == "redis://redis:6379/0"
+
+
+@pytest.mark.parametrize("value,expected", [("true", True), ("1", True), ("on", True),
+                                            ("false", False), ("", False), ("maybe", False)])
+def test_flag_parsing(router_module, monkeypatch, value, expected):
+    monkeypatch.setenv("COST_AWARE_ROUTING_ENABLED", value)
+    assert router_module._cost_routing_enabled() is expected

--- a/tests/unit/test_complexity_router.py
+++ b/tests/unit/test_complexity_router.py
@@ -13,6 +13,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+pytestmark = pytest.mark.unit
+
 ROUTER_PATH = Path(__file__).resolve().parents[2] / ".litellm" / "complexity_router.py"
 
 

--- a/tests/unit/utilities/ai/test_routing_metadata.py
+++ b/tests/unit/utilities/ai/test_routing_metadata.py
@@ -1,0 +1,55 @@
+"""`_call_llm` tells the LiteLLM proxy which (user, feature) bucket a call belongs to, so the
+complexity router can look up its cost-aware routing policy (issue #494)."""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_AI = "cqc_lem.utilities.ai.ai_helper"
+
+
+def _response():
+    response = MagicMock()
+    response.usage.prompt_tokens = 10
+    response.usage.completion_tokens = 5
+    return response
+
+
+def _call(model, **kwargs):
+    from cqc_lem.utilities.ai.ai_helper import _call_llm
+    create = MagicMock(return_value=_response())
+    with patch(f"{_AI}.client") as client:
+        client.chat.completions.create = create
+        _call_llm(model=model, messages=[{"role": "user", "content": "hi"}], **kwargs)
+    return create.call_args[1]
+
+
+class TestRoutingMetadata:
+    def test_tier_calls_carry_the_attribution_bucket(self):
+        with patch("cqc_lem.utilities.observability.current_llm_attribution",
+                   return_value=(7, "content")):
+            sent = _call("lem-complex")
+        assert sent["extra_body"]["metadata"] == {"feature": "content", "user_id": 7}
+
+    def test_explicit_track_kwargs_win_over_the_ambient_scope(self):
+        with patch("cqc_lem.utilities.observability.current_llm_attribution",
+                   return_value=(1, "system")):
+            sent = _call("lem-medium", _track_user_id=9, _track_feature="newsletter")
+        assert sent["extra_body"]["metadata"] == {"feature": "newsletter", "user_id": 9}
+        # The tracking kwargs are still popped — they must never reach the proxy as request fields.
+        assert "_track_user_id" not in sent and "_track_feature" not in sent
+
+    def test_raw_provider_models_are_not_tagged(self):
+        """Only tier aliases are routable, so nothing is attached to a raw provider model."""
+        assert "extra_body" not in _call("gpt-4o-mini")
+
+    def test_a_callers_own_metadata_is_not_overwritten(self):
+        sent = _call("lem-simple", extra_body={"metadata": {"feature": "custom"}})
+        assert sent["extra_body"]["metadata"] == {"feature": "custom"}
+
+    def test_attribution_failure_never_breaks_the_call(self):
+        with patch("cqc_lem.utilities.observability.current_llm_attribution",
+                   side_effect=RuntimeError("boom")):
+            sent = _call("lem-complex")
+        assert "metadata" not in sent.get("extra_body", {})

--- a/tests/unit/utilities/test_cost_routing.py
+++ b/tests/unit/utilities/test_cost_routing.py
@@ -300,6 +300,43 @@ def test_collect_routing_report_skips_spend_without_a_ledger():
     assert report["date"] == "2026-08-01"
 
 
+def test_collect_routing_report_observes_nothing_while_the_flag_is_off():
+    """Dormant (owner decision on PR #529): no window scan, no ledger read — just the parked policy."""
+    with patch.object(cr, "collect_quality_observations") as observe, \
+         patch("cqc_lem.utilities.db.cost_ledger_available") as ledger, \
+         patch.object(cr, "load_policy", return_value={}):
+        report = cr.collect_routing_report(days=7, today=TODAY, enabled=False)
+    observe.assert_not_called()
+    ledger.assert_not_called()
+    assert report["observations"] == 0
+    assert report["policy"]["enabled"] is False
+    assert report["policy"]["buckets"] == {} and report["changes"] == []
+
+
+def test_dormant_run_holds_an_existing_bucket_instead_of_moving_it():
+    """A bucket left over from an earlier run is judged on no data, so it can only HOLD — flipping the
+    flag back on resumes the experiment where it stopped."""
+    bucket = _bucket(cohort_pct=0.5)
+    policy = {"version": rp.POLICY_VERSION, "enabled": True,
+              "buckets": {rp.bucket_key("content", rp.TIER_COMPLEX): bucket}}
+    with patch.object(cr, "collect_quality_observations") as observe, \
+         patch.object(cr, "load_policy", return_value=policy):
+        report = cr.collect_routing_report(days=7, today=TODAY, enabled=False)
+    observe.assert_not_called()
+    held = report["policy"]["buckets"][rp.bucket_key("content", rp.TIER_COMPLEX)]
+    assert held["state"] == rp.STATE_EXPERIMENT and held["cohort_pct"] == 0.5
+    assert report["changes"] == [] and len(report["holds"]) == 1
+
+
+def test_collect_routing_report_scans_the_window_when_enabled():
+    with patch.object(cr, "collect_quality_observations", return_value=_rows(3, 10)) as observe, \
+         patch("cqc_lem.utilities.db.cost_ledger_available", return_value=False), \
+         patch.object(cr, "load_policy", return_value={}):
+        report = cr.collect_routing_report(days=7, today=TODAY, enabled=True)
+    observe.assert_called_once()
+    assert report["observations"] == 3 and report["policy"]["enabled"] is True
+
+
 def test_apply_routing_report_publishes_and_emails_only_on_change():
     report = {"date": "2026-08-01", "policy": {"version": 1, "enabled": True, "buckets": {}},
               "changes": [], "holds": [], "recommendations": []}

--- a/tests/unit/utilities/test_cost_routing.py
+++ b/tests/unit/utilities/test_cost_routing.py
@@ -1,0 +1,354 @@
+"""Unit tests for the cost-aware routing optimization loop (issue #494)."""
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cqc_lem.utilities import cost_routing as cr
+from cqc_lem.utilities import routing_policy as rp
+
+TODAY = date(2026, 8, 1)
+
+
+def _rows(count, engagement, impressions=1000, authenticity=80, user_offset=0, day="2026-07-20"):
+    """`count` posts with a fixed weighted engagement score (reactions carry weight 1)."""
+    return [{"user_id": user_offset + i, "post_id": user_offset + i, "day": day,
+             "reactions": engagement, "comments": 0, "reposts": 0,
+             "impressions": impressions, "authenticity_score": authenticity,
+             "feature": "content"}
+            for i in range(count)]
+
+
+def _bucket(**overrides):
+    bucket = cr.new_bucket("content", rp.TIER_COMPLEX, date(2026, 7, 1), 0.1)
+    bucket.update(overrides)
+    return bucket
+
+
+# ── metric selection & summaries ──
+
+def test_pick_metric_needs_impressions_on_every_row():
+    assert cr.pick_metric(_rows(3, 10)) == cr.METRIC_RATE
+    assert cr.pick_metric(_rows(3, 10, impressions=None)) == cr.METRIC_COUNT
+    assert cr.pick_metric(_rows(2, 10) + _rows(1, 10, impressions=0)) == cr.METRIC_COUNT
+    assert cr.pick_metric([]) == cr.METRIC_COUNT
+
+
+def test_summarize_arm_uses_post_stats_weighting():
+    summary = cr.summarize_arm([{"reactions": 1, "comments": 2, "reposts": 1, "impressions": None,
+                                 "authenticity_score": 70}])
+    assert summary["mean"] == 7.0  # 1 + 2*2 + 2*1
+    assert summary["authenticity_median"] == 70.0
+
+
+def test_summarize_arm_ignores_unscored_posts_in_the_median():
+    rows = _rows(2, 10, authenticity=90) + _rows(2, 10, authenticity=None, user_offset=50)
+    summary = cr.summarize_arm(rows)
+    assert summary["n"] == 4
+    assert summary["authenticity_n"] == 2
+    assert summary["authenticity_median"] == 90.0
+
+
+# ── the non-inferiority judgement ──
+
+def test_compare_arms_needs_enough_samples_per_arm():
+    verdict = cr.compare_arms(cr.summarize_arm(_rows(5, 10)), cr.summarize_arm(_rows(50, 10)))
+    assert verdict["verdict"] == cr.VERDICT_INSUFFICIENT
+
+
+def test_compare_arms_accepts_indistinguishable_quality():
+    treatment, control = _rows(40, 10), _rows(40, 10, user_offset=100)
+    verdict = cr.compare_arms(cr.summarize_arm(treatment, cr.METRIC_RATE),
+                              cr.summarize_arm(control, cr.METRIC_RATE))
+    assert verdict["verdict"] == cr.VERDICT_NON_INFERIOR
+
+
+def test_compare_arms_flags_a_real_engagement_drop():
+    treatment, control = _rows(40, 4), _rows(40, 10, user_offset=100)
+    verdict = cr.compare_arms(cr.summarize_arm(treatment, cr.METRIC_RATE),
+                              cr.summarize_arm(control, cr.METRIC_RATE))
+    assert verdict["verdict"] == cr.VERDICT_DEGRADED
+
+
+def test_compare_arms_is_inconclusive_when_the_interval_is_too_wide():
+    """Noisy arms whose means match must NOT pass as "indistinguishable" — the CI has to clear the
+    equivalence margin, which is what stops an underpowered experiment auto-adopting."""
+    noisy = [{**row, "reactions": 100 if i % 2 else 1} for i, row in enumerate(_rows(30, 10))]
+    control = [{**row, "reactions": 100 if i % 2 else 1}
+               for i, row in enumerate(_rows(30, 10, user_offset=100))]
+    verdict = cr.compare_arms(cr.summarize_arm(noisy, cr.METRIC_RATE),
+                              cr.summarize_arm(control, cr.METRIC_RATE))
+    assert verdict["verdict"] == cr.VERDICT_INCONCLUSIVE
+
+
+def test_authenticity_floor_overrides_good_engagement():
+    treatment = _rows(40, 20, authenticity=40)
+    control = _rows(40, 10, authenticity=85, user_offset=100)
+    verdict = cr.compare_arms(cr.summarize_arm(treatment, cr.METRIC_RATE),
+                              cr.summarize_arm(control, cr.METRIC_RATE))
+    assert verdict["verdict"] == cr.VERDICT_DEGRADED
+    assert "floor" in verdict["reason"]
+
+
+def test_authenticity_drop_overrides_good_engagement():
+    treatment = _rows(40, 20, authenticity=70)
+    control = _rows(40, 10, authenticity=90, user_offset=100)
+    verdict = cr.compare_arms(cr.summarize_arm(treatment, cr.METRIC_RATE),
+                              cr.summarize_arm(control, cr.METRIC_RATE))
+    assert verdict["verdict"] == cr.VERDICT_DEGRADED
+    assert "authenticity" in verdict["reason"]
+
+
+# ── ramp, promotion and auto-rollback ──
+
+def test_cohort_ramp_skips_steps_below_the_configured_start():
+    assert cr.cohort_ramp(0.1) == (0.1, 0.5, cr.ADOPTED_COHORT_PCT)
+    assert cr.cohort_ramp(0.6) == (0.6, cr.ADOPTED_COHORT_PCT)
+    assert cr.next_cohort_pct(0.1, 0.1) == 0.5
+    assert cr.next_cohort_pct(0.5, 0.1) == cr.ADOPTED_COHORT_PCT
+    assert cr.next_cohort_pct(cr.ADOPTED_COHORT_PCT, 0.1) is None
+
+
+def test_the_ramp_never_reaches_full_traffic():
+    """A bucket at 100% has no control arm left, so nothing could ever detect a regression — the
+    top of the ramp keeps a permanent holdout on the incumbent tier."""
+    assert cr.ADOPTED_COHORT_PCT < 1.0
+    assert max(cr.cohort_ramp(0.1)) < 1.0
+
+
+def test_passing_experiment_climbs_the_ramp():
+    outcome = cr.evaluate_bucket(_bucket(cohort_pct=0.1),
+                                 {"verdict": cr.VERDICT_NON_INFERIOR, "reason": "held"}, TODAY)
+    assert outcome["action"] == cr.ACTION_PROMOTE
+    assert outcome["bucket"]["cohort_pct"] == 0.5
+    assert outcome["bucket"]["state"] == rp.STATE_EXPERIMENT
+
+
+def test_experiment_at_the_top_of_the_ramp_is_adopted():
+    outcome = cr.evaluate_bucket(_bucket(cohort_pct=0.5),
+                                 {"verdict": cr.VERDICT_NON_INFERIOR, "reason": "held"}, TODAY)
+    assert outcome["action"] == cr.ACTION_ADOPT
+    assert outcome["bucket"]["state"] == rp.STATE_ADOPTED
+    assert outcome["bucket"]["cohort_pct"] == cr.ADOPTED_COHORT_PCT
+
+
+def test_an_adopted_bucket_still_has_a_control_arm_to_be_judged_on():
+    """The holdout is what keeps the gate live: at the adopted cohort both arms still get posts."""
+    bucket = _bucket(state=rp.STATE_ADOPTED, cohort_pct=cr.ADOPTED_COHORT_PCT,
+                     started_on="2026-07-01")
+    observations = [row for user in range(400) for row in _rows(1, 10, user_offset=user)]
+    arms = cr.split_observations(observations, bucket)
+    assert len(arms[rp.ARM_TREATMENT]) > 0 and len(arms[rp.ARM_CONTROL]) > 0
+
+
+def test_degraded_quality_rolls_back_with_a_cooldown():
+    outcome = cr.evaluate_bucket(_bucket(cohort_pct=0.5),
+                                 {"verdict": cr.VERDICT_DEGRADED, "reason": "engagement fell"},
+                                 TODAY, {"cooldown_days": 14})
+    assert outcome["action"] == cr.ACTION_ROLLBACK
+    assert outcome["bucket"]["state"] == rp.STATE_ROLLED_BACK
+    assert outcome["bucket"]["cohort_pct"] == 0.0
+    assert outcome["bucket"]["cooldown_until"] == "2026-08-15"
+
+
+def test_an_adopted_bucket_still_rolls_back():
+    """Adoption is not a graduation — a regression that only shows at full cohort must still revert."""
+    outcome = cr.evaluate_bucket(_bucket(state=rp.STATE_ADOPTED, cohort_pct=cr.ADOPTED_COHORT_PCT),
+                                 {"verdict": cr.VERDICT_DEGRADED, "reason": "quality fell"}, TODAY)
+    assert outcome["action"] == cr.ACTION_ROLLBACK
+    assert outcome["bucket"]["state"] == rp.STATE_ROLLED_BACK
+
+
+@pytest.mark.parametrize("verdict", [cr.VERDICT_INCONCLUSIVE, cr.VERDICT_INSUFFICIENT])
+def test_thin_or_noisy_data_holds_the_bucket_where_it_is(verdict):
+    outcome = cr.evaluate_bucket(_bucket(cohort_pct=0.1), {"verdict": verdict, "reason": "wait"},
+                                 TODAY)
+    assert outcome["action"] == cr.ACTION_HOLD
+    assert outcome["bucket"]["cohort_pct"] == 0.1
+    assert outcome["bucket"]["state"] == rp.STATE_EXPERIMENT
+
+
+# ── observation splitting ──
+
+def test_split_observations_ignores_posts_from_before_the_experiment():
+    bucket = _bucket(cohort_pct=1.0, started_on="2026-07-15")
+    arms = cr.split_observations(_rows(3, 10, day="2026-07-01") + _rows(2, 10, day="2026-07-20",
+                                                                       user_offset=50), bucket)
+    assert len(arms[rp.ARM_TREATMENT]) == 2
+    assert arms[rp.ARM_CONTROL] == []
+
+
+# ── policy assembly ──
+
+def test_build_routing_policy_opens_one_experiment_when_enabled():
+    result = cr.build_routing_policy(None, _rows(40, 10), TODAY, {"content": 12.0}, enabled=True)
+    buckets = result["policy"]["buckets"]
+    assert list(buckets) == ["content:lem-complex"]  # most expensive tier first
+    assert buckets["content:lem-complex"]["cohort_pct"] == cr.COST_ROUTING_INITIAL_COHORT
+    assert result["policy"]["enabled"] is True
+    assert result["changes"][0]["action"] == cr.ACTION_START
+
+
+def test_build_routing_policy_opens_nothing_when_disabled():
+    result = cr.build_routing_policy(None, _rows(40, 10), TODAY, enabled=False)
+    assert result["policy"]["buckets"] == {}
+    assert result["policy"]["enabled"] is False
+
+
+def test_build_routing_policy_will_not_experiment_on_thin_data():
+    result = cr.build_routing_policy(None, _rows(3, 10), TODAY, enabled=True)
+    assert result["policy"]["buckets"] == {}
+
+
+def test_build_routing_policy_will_not_downroute_content_already_failing_the_gate():
+    result = cr.build_routing_policy(None, _rows(40, 10, authenticity=45), TODAY, enabled=True)
+    assert result["policy"]["buckets"] == {}
+
+
+def test_build_routing_policy_respects_the_experiment_cap():
+    previous = {"version": 1, "enabled": True,
+                "buckets": {"content:lem-complex": _bucket(cohort_pct=0.1)}}
+    result = cr.build_routing_policy(previous, _rows(40, 10), TODAY, enabled=True)
+    assert list(result["policy"]["buckets"]) == ["content:lem-complex"]
+
+
+def test_build_routing_policy_rolls_a_degraded_bucket_back_end_to_end():
+    """The whole gate, from raw posts to a published policy: the treatment cohort engages half as
+    well, so the bucket must come back to the incumbent tier on its own."""
+    bucket = _bucket(cohort_pct=0.5, started_on="2026-07-01")
+    previous = {"version": 1, "enabled": True, "buckets": {"content:lem-complex": bucket}}
+    observations = []
+    for user in range(400):
+        arm = rp.assign_arm(user, bucket)
+        observations += _rows(1, 3 if arm == rp.ARM_TREATMENT else 10, user_offset=user)
+    result = cr.build_routing_policy(previous, observations, TODAY, enabled=True)
+    updated = result["policy"]["buckets"]["content:lem-complex"]
+    assert updated["state"] == rp.STATE_ROLLED_BACK
+    assert updated["cohort_pct"] == 0.0
+    assert any(c["action"] == cr.ACTION_ROLLBACK for c in result["changes"])
+    # And the rolled-back policy no longer routes anything down.
+    assert rp.resolve_tier(rp.TIER_COMPLEX, "content", 1, result["policy"])["applied"] is False
+
+
+def test_rolled_back_bucket_is_not_reproposed_until_the_cooldown_expires():
+    rolled_back = _bucket(state=rp.STATE_ROLLED_BACK, cohort_pct=0.0,
+                          cooldown_until="2026-09-01", generation=1)
+    previous = {"version": 1, "enabled": True, "buckets": {"content:lem-complex": rolled_back}}
+    result = cr.build_routing_policy(previous, _rows(40, 10), TODAY, enabled=True)
+    assert result["policy"]["buckets"]["content:lem-complex"]["state"] == rp.STATE_ROLLED_BACK
+
+    result = cr.build_routing_policy(previous, _rows(40, 10), date(2026, 9, 2), enabled=True)
+    reopened = result["policy"]["buckets"]["content:lem-complex"]
+    assert reopened["state"] == rp.STATE_EXPERIMENT
+    assert reopened["generation"] == 2  # fresh cohort salt, not a re-test of the same users
+
+
+def test_unmeasurable_features_are_recommended_not_auto_routed():
+    recommendations = cr.recommend_unmeasurable({"content": 20.0, "comment": 9.0, "dm": 0.0})
+    assert [r["feature"] for r in recommendations] == ["comment"]
+    assert "human product call" in recommendations[0]["recommendation"]
+
+
+# ── collectors, publication and delivery ──
+
+def test_load_policy_survives_junk_in_redis():
+    client = MagicMock()
+    client.get.return_value = b"{not json"
+    with patch.object(cr, "_redis_client", return_value=client):
+        assert cr.load_policy() == {}
+    client.get.return_value = None
+    with patch.object(cr, "_redis_client", return_value=client):
+        assert cr.load_policy() == {}
+    with patch.object(cr, "_redis_client", return_value=None):
+        assert cr.load_policy() == {}
+
+
+def test_publish_policy_writes_the_shared_key():
+    client = MagicMock()
+    with patch.object(cr, "_redis_client", return_value=client):
+        assert cr.publish_policy({"version": 1, "enabled": True, "buckets": {}}) is True
+    key, payload = client.set.call_args[0]
+    assert key == rp.POLICY_REDIS_KEY
+    assert '"enabled": true' in payload
+
+
+def test_publish_policy_reports_failure_without_raising():
+    client = MagicMock()
+    client.set.side_effect = RuntimeError("redis down")
+    with patch.object(cr, "_redis_client", return_value=client):
+        assert cr.publish_policy({}) is False
+    with patch.object(cr, "_redis_client", return_value=None):
+        assert cr.publish_policy({}) is False
+
+
+def test_collect_quality_observations_tags_the_content_feature():
+    with patch("cqc_lem.utilities.db.get_post_quality_rows",
+               return_value=[{"user_id": 1, "post_id": 2}]) as rows:
+        observations = cr.collect_quality_observations(days=7, end=TODAY)
+    assert observations == [{"user_id": 1, "post_id": 2, "feature": "content"}]
+    assert rows.call_args[0][0] == date(2026, 7, 25)
+
+
+def test_collect_routing_report_skips_spend_without_a_ledger():
+    with patch("cqc_lem.utilities.db.cost_ledger_available", return_value=False), \
+         patch("cqc_lem.utilities.db.get_cost_rollup") as rollup, \
+         patch.object(cr, "collect_quality_observations", return_value=[]), \
+         patch.object(cr, "load_policy", return_value={}):
+        report = cr.collect_routing_report(days=7, today=TODAY)
+    rollup.assert_not_called()
+    assert report["spend_by_feature"] == {}
+    assert report["date"] == "2026-08-01"
+
+
+def test_apply_routing_report_publishes_and_emails_only_on_change():
+    report = {"date": "2026-08-01", "policy": {"version": 1, "enabled": True, "buckets": {}},
+              "changes": [], "holds": [], "recommendations": []}
+    with patch.object(cr, "publish_policy", return_value=True) as publish, \
+         patch("cqc_lem.utilities.observability.track_routing_policy"), \
+         patch("cqc_lem.utilities.email._dispatch_email") as dispatch:
+        result = cr.apply_routing_report(report)
+    assert result["published"] is True and result["emailed"] is False
+    publish.assert_called_once()
+    dispatch.assert_not_called()
+
+
+def test_apply_routing_report_emails_and_logs_a_rollback():
+    report = {"date": "2026-08-01", "policy": {"version": 1, "enabled": True, "buckets": {}},
+              "changes": [{"bucket": "content:lem-complex", "action": cr.ACTION_ROLLBACK,
+                           "reason": "engagement fell"}], "holds": [], "recommendations": []}
+    with patch.object(cr, "publish_policy", return_value=True), \
+         patch("cqc_lem.utilities.observability.track_routing_policy"), \
+         patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as dispatch, \
+         patch.object(cr, "log_error") as logged, \
+         patch.object(cr, "COST_ALERT_EMAIL", "owner@example.com"):
+        result = cr.apply_routing_report(report)
+    assert result["emailed"] is True and result["rollbacks"] == 1
+    assert "ROLLBACK" in dispatch.call_args[0][1]
+    logged.assert_called_once()
+
+
+def test_render_routing_text_lists_changes_and_buckets():
+    report = {"date": "2026-08-01",
+              "policy": {"enabled": True,
+                         "buckets": {"content:lem-complex": {"state": "experiment",
+                                                             "to_tier": "lem-medium",
+                                                             "cohort_pct": 0.1}}},
+              "changes": [{"bucket": "content:lem-complex", "action": cr.ACTION_START,
+                           "reason": "opened", "bucket_state": {"state": "experiment"}}],
+              "holds": [], "recommendations": [{"recommendation": "comment needs a human call"}]}
+    text = cr.render_routing_text(report)
+    assert "[START] content:lem-complex → experiment" in text
+    assert "content:lem-complex: experiment → lem-medium @ 10% cohort" in text
+    assert "RECOMMENDATION: comment needs a human call" in text
+    assert "&" not in cr.render_routing_html(report).split("<pre")[0][:20]
+
+
+def test_main_exits_2_on_a_rollback():
+    report = {"date": "2026-08-01", "policy": {"buckets": {}},
+              "changes": [{"action": cr.ACTION_ROLLBACK, "bucket": "content:lem-complex",
+                           "reason": "fell"}], "holds": [], "recommendations": []}
+    with patch.object(cr, "collect_routing_report", return_value=report):
+        assert cr.main(["--json"]) == 2
+    report["changes"] = []
+    with patch.object(cr, "collect_routing_report", return_value=report):
+        assert cr.main([]) == 0

--- a/tests/unit/utilities/test_cost_routing.py
+++ b/tests/unit/utilities/test_cost_routing.py
@@ -7,6 +7,8 @@ import pytest
 from cqc_lem.utilities import cost_routing as cr
 from cqc_lem.utilities import routing_policy as rp
 
+pytestmark = pytest.mark.unit
+
 TODAY = date(2026, 8, 1)
 
 
@@ -107,6 +109,14 @@ def test_cohort_ramp_skips_steps_below_the_configured_start():
     assert cr.next_cohort_pct(0.1, 0.1) == 0.5
     assert cr.next_cohort_pct(0.5, 0.1) == cr.ADOPTED_COHORT_PCT
     assert cr.next_cohort_pct(cr.ADOPTED_COHORT_PCT, 0.1) is None
+
+
+def test_configured_initial_cohort_cannot_exceed_the_adopted_ceiling():
+    """An over-configured start would open an experiment with no measurable control arm."""
+    with patch.object(cr, "COST_ROUTING_INITIAL_COHORT", 0.99):
+        assert cr.default_thresholds()["initial_cohort_pct"] == cr.ADOPTED_COHORT_PCT
+    with patch.object(cr, "COST_ROUTING_INITIAL_COHORT", -0.5):
+        assert cr.default_thresholds()["initial_cohort_pct"] == 0.0
 
 
 def test_the_ramp_never_reaches_full_traffic():

--- a/tests/unit/utilities/test_db_post_quality.py
+++ b/tests/unit/utilities/test_db_post_quality.py
@@ -1,0 +1,73 @@
+"""Unit tests for `get_post_quality_rows` — the observation source of the cost-aware routing
+experiment (issue #494)."""
+
+from datetime import date, datetime
+from unittest.mock import MagicMock, patch
+
+import mysql.connector
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _mock_conn(fetch_all=None, error=None):
+    conn, cur = MagicMock(), MagicMock()
+    cur.fetchall.return_value = fetch_all if fetch_all is not None else []
+    if error:
+        cur.execute.side_effect = mysql.connector.Error(error)
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+def _row(**overrides):
+    row = {"user_id": 1, "post_id": 9, "day": date(2026, 7, 20), "authenticity_score": 82,
+           "reactions": 5, "comments": 2, "reposts": 1, "impressions": 900}
+    row.update(overrides)
+    return row
+
+
+class TestGetPostQualityRows:
+    def test_returns_every_users_latest_stat_row(self):
+        conn, cur = _mock_conn(fetch_all=[_row(), _row(user_id=2, post_id=10)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_quality_rows
+            rows = get_post_quality_rows(date(2026, 7, 1), date(2026, 8, 1))
+        assert [r["user_id"] for r in rows] == [1, 2]
+        assert rows[0] == {"user_id": 1, "post_id": 9, "day": "2026-07-20", "reactions": 5,
+                           "comments": 2, "reposts": 1, "impressions": 900,
+                           "authenticity_score": 82}
+        sql, params = cur.execute.call_args[0]
+        assert "status='posted'" in sql
+        assert "MAX(id) FROM post_stats" in sql  # latest stats row per post
+        assert params == (date(2026, 7, 1), date(2026, 8, 1))
+
+    def test_unknown_impressions_and_scores_stay_none(self):
+        """A post with no impressions or no authenticity score is UNKNOWN quality, never zero —
+        scoring it as 0 would drag an arm's mean down for a missing measurement."""
+        conn, _ = _mock_conn(fetch_all=[_row(impressions=None, authenticity_score=None)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_quality_rows
+            rows = get_post_quality_rows(date(2026, 7, 1), date(2026, 8, 1))
+        assert rows[0]["impressions"] is None
+        assert rows[0]["authenticity_score"] is None
+
+    def test_zero_impressions_read_as_unknown(self):
+        conn, _ = _mock_conn(fetch_all=[_row(impressions=0)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_quality_rows
+            assert get_post_quality_rows(date(2026, 7, 1), date(2026, 8, 1))[0]["impressions"] is None
+
+    def test_datetime_day_is_serialized(self):
+        conn, _ = _mock_conn(fetch_all=[_row(day=datetime(2026, 7, 20, 9, 30))])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_quality_rows
+            assert get_post_quality_rows(date(2026, 7, 1), date(2026, 8, 1))[0]["day"] \
+                .startswith("2026-07-20")
+
+    def test_db_error_degrades_to_empty(self):
+        conn, _ = _mock_conn(error="table missing")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_quality_rows
+            assert get_post_quality_rows(date(2026, 7, 1), date(2026, 8, 1)) == []

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -530,6 +530,38 @@ class TestTrackCostAlert:
         assert mock_ph.capture.call_args[1]["distinct_id"] == "system"
 
 
+class TestTrackRoutingPolicy:
+    def _report(self):
+        return {"date": "2026-08-01", "window_days": 28, "observations": 42,
+                "policy": {"enabled": True, "buckets": {
+                    "content:lem-complex": {"state": "experiment", "to_tier": "lem-medium",
+                                            "cohort_pct": 0.1}}},
+                "changes": [{"bucket": "content:lem-complex", "action": "rollback",
+                             "reason": "engagement fell", "comparison": {"treatment": {"n": 40}}}],
+                "recommendations": [{"feature": "comment", "recommendation": "human call"}]}
+
+    def test_captures_the_routing_decision(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_routing_policy
+            track_routing_policy(self._report())
+
+        kwargs = mock_ph.capture.call_args[1]
+        props = kwargs["properties"]
+        assert kwargs["event"] == "routing_policy" and kwargs["distinct_id"] == "system"
+        assert props["enabled"] is True and props["observations"] == 42
+        assert props["change_count"] == 1 and props["rollback_count"] == 1
+        assert props["buckets"][0] == {"bucket": "content:lem-complex", "state": "experiment",
+                                       "to_tier": "lem-medium", "cohort_pct": 0.1}
+        # The full arm statistics stay out of the event body — the verdict is what a tile needs.
+        assert "comparison" not in props["changes"][0]
+
+    def test_empty_report_does_not_raise(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_routing_policy
+            track_routing_policy({})
+        assert mock_ph.capture.call_args[1]["properties"]["change_count"] == 0
+
+
 class TestPostHogHogqlQuery:
     def test_returns_none_when_the_read_path_is_not_configured(self):
         with patch.dict("os.environ", {"POSTHOG_PERSONAL_API_KEY": "", "POSTHOG_PROJECT_ID": ""},

--- a/tests/unit/utilities/test_routing_policy.py
+++ b/tests/unit/utilities/test_routing_policy.py
@@ -1,0 +1,145 @@
+"""Unit tests for the shared routing decision core (issue #494)."""
+import pytest
+
+from cqc_lem.utilities import routing_policy as rp
+
+
+def _bucket(**overrides):
+    bucket = {
+        "id": "content:lem-complex#1",
+        "feature": "content",
+        "from_tier": rp.TIER_COMPLEX,
+        "to_tier": rp.TIER_MEDIUM,
+        "state": rp.STATE_EXPERIMENT,
+        "cohort_pct": 1.0,
+    }
+    bucket.update(overrides)
+    return bucket
+
+
+def _policy(bucket=None, enabled=True):
+    bucket = bucket or _bucket()
+    return {"version": rp.POLICY_VERSION, "enabled": enabled,
+            "buckets": {rp.bucket_key(bucket["feature"], bucket["from_tier"]): bucket}}
+
+
+# ── complexity tier (pre-existing behaviour, now testable) ──
+
+@pytest.mark.parametrize("prompt,expected", [
+    ("write a thought leadership post with a framework", rp.TIER_COMPLEX),
+    ("industry news commentary for the buyer stage", rp.TIER_COMPLEX),
+    ("write a personal story", rp.TIER_MEDIUM),
+    ("refine this", rp.TIER_SIMPLE),
+    ("summarize briefly as a comma separated short list", rp.TIER_SIMPLE),
+])
+def test_complexity_tier_signals(prompt, expected):
+    assert rp.complexity_tier(prompt) == expected
+
+
+def test_complexity_tier_escalates_on_length():
+    assert rp.complexity_tier("word " * 400) == rp.TIER_MEDIUM
+    assert rp.complexity_tier("word " * 900) == rp.TIER_COMPLEX
+
+
+def test_prompt_text_skips_non_string_content():
+    text = rp.prompt_text([{"role": "user", "content": "Hello"},
+                           {"role": "user", "content": [{"type": "image_url"}]},
+                           "not-a-message"])
+    assert text == "hello"
+
+
+def test_cheaper_tier_bottoms_out():
+    assert rp.cheaper_tier(rp.TIER_COMPLEX) == rp.TIER_MEDIUM
+    assert rp.cheaper_tier(rp.TIER_MEDIUM) == rp.TIER_SIMPLE
+    assert rp.cheaper_tier(rp.TIER_SIMPLE) is None
+    assert rp.cheaper_tier("gpt-4o") is None
+
+
+# ── policy normalization ──
+
+@pytest.mark.parametrize("raw", [None, "nope", {}, {"version": 99, "buckets": {}},
+                                {"version": "x"}])
+def test_normalize_policy_rejects_unusable(raw):
+    assert rp.normalize_policy(raw) == {}
+
+
+def test_normalize_policy_drops_non_mapping_buckets():
+    policy = rp.normalize_policy({"version": 1, "enabled": True,
+                                  "buckets": {"a": {"state": "experiment"}, "b": "junk"}})
+    assert list(policy["buckets"]) == ["a"]
+
+
+# ── A/B arm assignment ──
+
+def test_assign_arm_is_deterministic_and_respects_cohort():
+    bucket = _bucket(cohort_pct=0.5)
+    first = rp.assign_arm(7, bucket)
+    assert first == rp.assign_arm(7, bucket)
+    assert rp.assign_arm(7, _bucket(cohort_pct=0)) == rp.ARM_CONTROL
+    assert rp.assign_arm(7, _bucket(cohort_pct=1.0)) == rp.ARM_TREATMENT
+
+
+def test_assign_arm_reshuffles_on_a_new_generation():
+    """A re-run experiment must not silently re-test the same cohort — the generation salts it."""
+    users = range(200)
+    first = {u: rp.assign_arm(u, _bucket(cohort_pct=0.5, id="content:lem-complex#1")) for u in users}
+    second = {u: rp.assign_arm(u, _bucket(cohort_pct=0.5, id="content:lem-complex#2")) for u in users}
+    assert first != second
+
+
+def test_assign_arm_cohort_share_is_roughly_the_configured_pct():
+    bucket = _bucket(cohort_pct=0.25)
+    treated = sum(1 for u in range(2000) if rp.assign_arm(u, bucket) == rp.ARM_TREATMENT)
+    assert 0.20 < treated / 2000 < 0.30
+
+
+def test_assign_arm_without_user_is_control():
+    assert rp.assign_arm(None, _bucket(cohort_pct=0.5)) == rp.ARM_CONTROL
+    assert rp.assign_arm("", _bucket(cohort_pct=0.5)) == rp.ARM_CONTROL
+    assert rp.assign_arm(1, None) == rp.ARM_CONTROL
+    assert rp.assign_arm(1, _bucket(cohort_pct="junk")) == rp.ARM_CONTROL
+
+
+# ── the routing decision itself ──
+
+def test_resolve_tier_downroutes_treatment_cohort():
+    decision = rp.resolve_tier(rp.TIER_COMPLEX, "content", 1, _policy())
+    assert decision == {"tier": rp.TIER_MEDIUM, "base_tier": rp.TIER_COMPLEX,
+                        "arm": rp.ARM_TREATMENT, "applied": True, "bucket": "content:lem-complex"}
+
+
+def test_resolve_tier_leaves_control_cohort_alone():
+    decision = rp.resolve_tier(rp.TIER_COMPLEX, "content", 1, _policy(_bucket(cohort_pct=0.0)))
+    assert decision["tier"] == rp.TIER_COMPLEX
+    assert decision["applied"] is False
+    assert decision["arm"] == rp.ARM_CONTROL
+
+
+@pytest.mark.parametrize("policy", [
+    None,
+    {},
+    _policy(enabled=False),                                    # master switch off
+    _policy(_bucket(state=rp.STATE_ROLLED_BACK)),              # rolled back → incumbent tier
+    _policy(_bucket(state=rp.STATE_HOLD)),
+    _policy(_bucket(feature="comment")),                       # different bucket than the call
+    _policy(_bucket(to_tier=rp.TIER_COMPLEX)),                 # never route UP
+    _policy(_bucket(to_tier="gpt-4o")),                        # never route off-tier
+])
+def test_resolve_tier_fails_open(policy):
+    decision = rp.resolve_tier(rp.TIER_COMPLEX, "content", 1, policy)
+    assert decision["tier"] == rp.TIER_COMPLEX
+    assert decision["applied"] is False
+
+
+def test_resolve_tier_ignores_non_tier_models():
+    decision = rp.resolve_tier("lem-image", "content", 1, _policy())
+    assert decision["tier"] == "lem-image"
+    assert decision["applied"] is False
+
+
+def test_resolve_tier_matches_the_bucket_by_feature_and_tier():
+    policy = _policy(_bucket(feature="comment", from_tier=rp.TIER_MEDIUM,
+                             to_tier=rp.TIER_SIMPLE, id="comment:lem-medium#1"))
+    assert rp.resolve_tier(rp.TIER_MEDIUM, "comment", 3, policy)["tier"] == rp.TIER_SIMPLE
+    assert rp.resolve_tier(rp.TIER_MEDIUM, "content", 3, policy)["tier"] == rp.TIER_MEDIUM
+    assert rp.resolve_tier(rp.TIER_COMPLEX, "comment", 3, policy)["tier"] == rp.TIER_COMPLEX

--- a/tests/unit/utilities/test_routing_policy.py
+++ b/tests/unit/utilities/test_routing_policy.py
@@ -3,6 +3,8 @@ import pytest
 
 from cqc_lem.utilities import routing_policy as rp
 
+pytestmark = pytest.mark.unit
+
 
 def _bucket(**overrides):
     bucket = {


### PR DESCRIPTION
## What

Closes the automated fine-tuning loop from `docs/cost-performance-margin-plan.md` §D.1(1) — the last unshipped item in the §F rollout. The LiteLLM complexity router gains a **second, flag-gated stage**: a tier may be routed **one step down** for the treatment cohort of an active cost/quality experiment, and the experiment is promoted, held, or **auto-rolled-back** weekly against a quality gate.

**Both flags default OFF** (`COST_ROUTING_ENABLED` app-side, `COST_AWARE_ROUTING_ENABLED` proxy-side) — merging this changes no routing until someone turns it on. That is the product call this PR is held for.

### One decision core, two containers

`src/cqc_lem/utilities/routing_policy.py` is imported by the app **and** mounted by docker-compose into the LiteLLM container next to `.litellm/complexity_router.py`, which imports it as a bare `routing_policy`. It is deliberately **stdlib-only** (the LiteLLM image has no LEM package). Router and optimizer therefore cannot drift into disagreeing about which bucket a call belongs to.

| Piece | What it does |
|---|---|
| `.litellm/complexity_router.py` | stage 1 complexity (unchanged behaviour); stage 2 applies the policy to the resulting tier **or** to an explicitly requested `lem-*` tier |
| `utilities/routing_policy.py` | `complexity_tier`, `assign_arm`, `resolve_tier` — down-route only, never up, never off-tier |
| `utilities/cost_routing.py` | the weekly optimizer: observe → judge → act → publish |
| Redis `lem:routing:policy` | the policy document; the hook caches it for `COST_ROUTING_POLICY_TTL_SECONDS` so a rollback lands within one TTL |
| `db.get_post_quality_rows` | read-only: every posted post's latest `post_stats` row + `posts.authenticity_score` (V57) |
| `_call_llm` | sends `metadata={feature, user_id}` to the proxy — the same dimensions cost is attributed by |
| Celery beat `weekly-cost-routing` | `run_scheduler.auto_weekly_cost_routing`, Mon 14:00 UTC (after the margin report + alert sweep) |

### The gate is non-inferiority, not "looks fine"

The cheaper tier is promoted only when the **95% CI lower bound** on (treatment − control) engagement sits inside the equivalence margin (`COST_ROUTING_MAX_QUALITY_DROP`, default 5%). An underpowered/noisy comparison reads `inconclusive` and the experiment keeps running — it never passes by default. `posts.authenticity_score` is an **absolute veto** on top: a median below the floor, or a drop over `COST_ROUTING_AUTH_MAX_DROP` points, rolls the bucket back whatever engagement did. Engagement is impression-normalized when every post in the comparison carries impressions, raw weighted engagement otherwise — never a mix.

### Lifecycle & blast radius

`experiment` @10% → 50% → **90% = `adopted`** → `rolled_back` (cohort 0 + 28-day cooldown) the moment the gate fails. The top of the ramp is deliberately **not 100%**: a bucket with no control arm can never be measured again, so the permanent holdout is what keeps auto-rollback alive after full rollout. Re-proposing a rolled-back bucket bumps its generation, re-salting the cohort hash so the retry isn't run on the same users. At most `COST_ROUTING_MAX_EXPERIMENTS` (1) run at a time.

Only features with a per-artifact quality signal (today just `content`) can be auto-adopted. Comment/DM/newsletter spend is surfaced as a ranked **human-gated recommendation** instead — the §D.3 `risk:product-decision` posture, enforced in code.

Every failure mode fails open to the tier the call would have used before this existed: no policy, unreachable Redis, malformed document, a raised exception in the core, or a call with no user id.

## Testing

96 new unit tests, `poetry run pytest tests/unit -q` → **4149 passed** locally. Coverage on the new modules: `cost_routing.py` 92%, `routing_policy.py` 100%.

- decision core: complexity tiers, policy normalization, deterministic/reshuffling cohort split, and every fail-open path
- gate: insufficient / non-inferior / degraded / **inconclusive** (a noisy match must not auto-adopt), both authenticity vetoes
- lifecycle: ramp, adopt, hold, rollback-with-cooldown, rollback of an *adopted* bucket, no re-proposal during cooldown, end-to-end rollback from raw posts to a policy that no longer routes down
- hook: loaded by path with `litellm` stubbed — flag off/on, cohort membership, rolled-back policy, Redis caching and failure
- `db.get_post_quality_rows` (unknown impressions/scores stay `None`, never 0) and the `_call_llm` metadata plumbing

Closes #494

🤖 Generated with [Claude Code](https://claude.com/claude-code)