### PR TITLE
feat(feedback): in-app feedback/bug widget + POST /feedback + feedback table (closes #496)

### DIFF
--- a/compose/local/database/migrations/V20260725063146__add_feedback.sql
+++ b/compose/local/database/migrations/V20260725063146__add_feedback.sql
@@ -1,0 +1,26 @@
+-- In-app feedback capture (issue #496): the first capture point of the feedback->auto-work loop.
+-- The SPA widget POSTs free text + a type hint + auto-attached context (route, app version, PostHog
+-- session id, optional screenshot) here. Later steps of the loop fill the enrichment columns:
+--   embedding           -> vector for clustering similar reports (stored as a JSON array)
+--   cluster_id          -> the cluster this item was grouped into
+--   github_issue_number -> the issue auto-opened for its cluster
+--   sentiment           -> classified tone of the body
+-- user_id is NULLABLE on purpose: the widget is shown to logged-out visitors too.
+CREATE TABLE IF NOT EXISTS feedback (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NULL,
+    source ENUM('widget','bug','nps','review','passive') NOT NULL DEFAULT 'widget',
+    type_hint VARCHAR(32) NULL,
+    body TEXT NOT NULL,
+    context_json JSON NULL,
+    embedding JSON NULL,
+    cluster_id INT NULL,
+    github_issue_number INT NULL,
+    status ENUM('new','triaged','clustered','issue_created','resolved','dismissed') NOT NULL DEFAULT 'new',
+    sentiment VARCHAR(16) NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_feedback_user (user_id, created_at),
+    INDEX idx_feedback_status (status, created_at),
+    INDEX idx_feedback_cluster (cluster_id)
+);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -69,6 +69,7 @@ from cqc_lem.utilities.db import (
     replace_video_url_base, get_post_type, get_post_buyer_stage, get_post_status,
     update_db_post_carousel_slides,
     get_post_url_from_log_for_user,
+    insert_feedback, FeedbackSource,
 )
 from cqc_lem.utilities.email import generate_pin, hash_pin, send_pin_email
 from cqc_lem.utilities.linkedin.verification_pin import (
@@ -321,6 +322,12 @@ _LEN_NL_TOPIC = 512       # newsletter_settings.topic VARCHAR(512)
 _LEN_DM_RECIPIENT_URL = 512   # scheduled_dms.recipient_profile_url VARCHAR(512)
 _LEN_DM_RECIPIENT_NAME = 255  # scheduled_dms.recipient_name VARCHAR(255)
 _LEN_CONNECT_NOTE = 300       # LinkedIn caps a connection-request note at 300 chars
+_LEN_FEEDBACK_BODY = 5000     # feedback.body (TEXT; app cap)
+_LEN_FEEDBACK_TYPE_HINT = 32  # feedback.type_hint VARCHAR(32)
+# Screenshots ride along inside feedback.context_json as a data URL. Capped so one report can't
+# blow past max_allowed_packet; the widget downsizes/rejects before it gets here.
+_LEN_FEEDBACK_SCREENSHOT = 2_000_000
+_LEN_FEEDBACK_CONTEXT = 8000  # serialized auto-attached context, screenshot excluded
 
 
 class NewsletterSettingsRequest(BaseModel):
@@ -695,6 +702,32 @@ class GenerateCarouselPreviewRequest(BaseModel):
     template: Optional[str] = None  # None = auto-pick by stage
 
 
+class FeedbackRequest(BaseModel):
+    """In-app feedback / bug report (issue #496). session_token is optional: the widget is offered
+    to logged-out visitors too, and those land with a NULL user_id."""
+    body: str = Field(min_length=1, max_length=_LEN_FEEDBACK_BODY)
+    session_token: Optional[str] = None
+    source: str = str(FeedbackSource.WIDGET)
+    type_hint: Optional[str] = Field(default=None, max_length=_LEN_FEEDBACK_TYPE_HINT)
+    context: Optional[Dict[str, Any]] = None
+    screenshot: Optional[str] = Field(default=None, max_length=_LEN_FEEDBACK_SCREENSHOT)
+
+    @field_validator("body")
+    @classmethod
+    def body_not_blank(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("Feedback body cannot be empty")
+        return v.strip()
+
+    @field_validator("source")
+    @classmethod
+    def known_source(cls, v: str) -> str:
+        valid = {str(s) for s in FeedbackSource}
+        if v not in valid:
+            raise ValueError(f"Unknown source '{v}' — expected one of {sorted(valid)}")
+        return v
+
+
 class FutureForwardValues(IntEnum):
     Zero = 0
     ONE = 1
@@ -717,6 +750,27 @@ def get_app_info() -> ResponseModel:
         "version": get_app_version(),
         "show_version": SHOW_VERSION_FOOTER,
     })
+
+
+@router.post("/feedback")
+def submit_feedback_endpoint(request: FeedbackRequest) -> ResponseModel:
+    """Capture in-app feedback / a bug report (issue #496) — the first capture point of the
+    feedback->auto-work loop. A valid session_token attributes the row to that user; without one
+    (logged-out visitor) the row is kept anonymously with a NULL user_id."""
+    user_id = get_session_user_id(request.session_token) if request.session_token else None
+    context: Dict[str, Any] = dict(request.context or {})
+    # Don't let a caller write an unbounded JSON blob — the widget only sends a handful of fields.
+    if len(json.dumps(context, default=str)) > _LEN_FEEDBACK_CONTEXT:
+        context = {"truncated": True}
+    if request.screenshot:
+        context["screenshot"] = request.screenshot
+    feedback_id = insert_feedback(request.body, user_id=user_id,
+                                  source=FeedbackSource(request.source),
+                                  type_hint=request.type_hint, context=context or None)
+    if not feedback_id:
+        raise HTTPException(status_code=500, detail="Could not save feedback")
+    log_info("Feedback captured", user_id=user_id)
+    return ResponseModel(status_code=200, detail={"feedback_id": feedback_id})
 
 
 @router.get("/dashboard/stats/", responses={

--- a/src/cqc_lem/ui/src/components/FeedbackWidget.tsx
+++ b/src/cqc_lem/ui/src/components/FeedbackWidget.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react'
+import { useLocation } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+import { useAppInfo } from '../hooks/useAppInfo'
+import api from '../api/client'
+
+const TYPE_HINTS = [
+  { value: 'bug', label: '🐞 Something is broken' },
+  { value: 'idea', label: '💡 Idea / feature request' },
+  { value: 'confusing', label: '🤔 Confusing or unclear' },
+  { value: 'praise', label: '🎉 This worked well' },
+  { value: 'other', label: '💬 Something else' },
+]
+
+// Base64 inflates a file by ~4/3, and the API caps the encoded data URL at 2,000,000 chars.
+const MAX_SCREENSHOT_BYTES = 1_400_000
+
+// PostHog is loaded (when configured) as a global script, not an npm dep — read the session id
+// defensively so the widget works with or without it.
+function posthogSessionId(): string | undefined {
+  const ph = (window as unknown as { posthog?: { get_session_id?: () => string } }).posthog
+  try {
+    return ph?.get_session_id?.()
+  } catch {
+    return undefined
+  }
+}
+
+function readAsDataUrl(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(new Error('Could not read the image'))
+    reader.readAsDataURL(file)
+  })
+}
+
+export default function FeedbackWidget() {
+  const { user, sessionToken } = useAuth()
+  const { data: appInfo } = useAppInfo()
+  const location = useLocation()
+
+  const [isOpen, setIsOpen] = useState(false)
+  const [typeHint, setTypeHint] = useState('bug')
+  const [body, setBody] = useState('')
+  const [screenshot, setScreenshot] = useState<string | null>(null)
+  const [screenshotName, setScreenshotName] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [sent, setSent] = useState(false)
+
+  function close() {
+    setIsOpen(false)
+    setError(null)
+    if (sent) {
+      // Reset only after a successful send so a failed attempt keeps what was typed.
+      setSent(false)
+      setBody('')
+      setScreenshot(null)
+      setScreenshotName(null)
+      setTypeHint('bug')
+    }
+  }
+
+  async function handleScreenshot(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    if (file.size > MAX_SCREENSHOT_BYTES) {
+      setError('That image is too large — please attach one under 1.4 MB.')
+      e.target.value = ''
+      return
+    }
+    try {
+      setScreenshot(await readAsDataUrl(file))
+      setScreenshotName(file.name)
+      setError(null)
+    } catch {
+      setError('Could not read that image.')
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+    try {
+      await api.post('/feedback', {
+        body: body.trim(),
+        session_token: sessionToken,
+        source: 'widget',
+        type_hint: typeHint,
+        screenshot,
+        context: {
+          route: `${location.pathname}${location.search}`,
+          user_id: user?.userId ?? null,
+          app_version: appInfo?.version ?? null,
+          posthog_session_id: posthogSessionId() ?? null,
+          user_agent: navigator.userAgent,
+          viewport: `${window.innerWidth}x${window.innerHeight}`,
+        },
+      })
+      setSent(true)
+    } catch (err: unknown) {
+      const msg = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+      setError(typeof msg === 'string' ? msg : 'Could not send your feedback. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!isOpen) {
+    return (
+      <button
+        onClick={() => setIsOpen(true)}
+        className="fixed bottom-4 right-4 z-40 bg-blue-600 text-white text-xs font-semibold px-3.5 py-2 rounded-full shadow-lg hover:bg-blue-700 transition-colors"
+        aria-label="Feedback / Report a bug"
+      >
+        Feedback / Report a bug
+      </button>
+    )
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-40 w-[22rem] max-w-[calc(100vw-2rem)] bg-white border border-gray-200 rounded-xl shadow-xl p-4">
+      <button
+        onClick={close}
+        className="absolute top-2 right-3 text-gray-400 hover:text-gray-600 text-xl leading-none"
+        aria-label="Close feedback"
+      >
+        ×
+      </button>
+
+      {sent ? (
+        <div className="pt-2">
+          <h2 className="text-sm font-bold text-gray-800 mb-1">Thanks — got it 🙏</h2>
+          <p className="text-xs text-gray-500 mb-4">
+            Your notes go straight to the team along with the page you were on.
+          </p>
+          <button
+            onClick={close}
+            className="w-full bg-blue-600 text-white py-2 rounded-lg text-xs font-semibold hover:bg-blue-700 transition-colors"
+          >
+            Done
+          </button>
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-3 pt-1">
+          <h2 className="text-sm font-bold text-gray-800">Feedback / Report a bug</h2>
+          <select
+            value={typeHint}
+            onChange={(e) => setTypeHint(e.target.value)}
+            aria-label="Feedback type"
+            className="w-full border border-gray-300 rounded-lg px-2 py-1.5 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+          >
+            {TYPE_HINTS.map((t) => (
+              <option key={t.value} value={t.value}>{t.label}</option>
+            ))}
+          </select>
+          <textarea
+            required
+            autoFocus
+            rows={4}
+            maxLength={5000}
+            value={body}
+            onChange={(e) => setBody(e.target.value)}
+            aria-label="What happened?"
+            placeholder="What happened, or what would you change?"
+            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+          <label className="block text-[11px] text-gray-500">
+            Screenshot (optional)
+            <input
+              type="file"
+              accept="image/*"
+              onChange={handleScreenshot}
+              className="mt-1 block w-full text-[11px] text-gray-500 file:mr-2 file:py-1 file:px-2 file:rounded file:border-0 file:bg-gray-100 file:text-gray-600"
+            />
+          </label>
+          {screenshotName && (
+            <p className="text-[11px] text-gray-500">Attached: {screenshotName}</p>
+          )}
+          <p className="text-[11px] text-gray-400">
+            We attach the page you're on{appInfo?.version ? ` and app v${appInfo.version}` : ''} automatically.
+          </p>
+          {error && <p className="text-xs text-red-600">{error}</p>}
+          <button
+            type="submit"
+            disabled={loading || !body.trim()}
+            className="w-full bg-blue-600 text-white py-2 rounded-lg text-xs font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+          >
+            {loading ? 'Sending…' : 'Send feedback'}
+          </button>
+        </form>
+      )}
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/components/Layout.tsx
+++ b/src/cqc_lem/ui/src/components/Layout.tsx
@@ -1,6 +1,7 @@
 import { NavLink, Outlet, useNavigate, useLocation } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import AccountReadinessBanner from './AccountReadinessBanner'
+import FeedbackWidget from './FeedbackWidget'
 import Footer from './Footer'
 
 // Pages whose features depend on a fully set-up account — show the readiness banner here.
@@ -74,6 +75,7 @@ export default function Layout() {
         <Outlet />
       </main>
       <Footer />
+      <FeedbackWidget />
     </div>
   )
 }

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -179,6 +179,26 @@ class LeadSignalKind(StrEnum):
     FUNNEL = 'funnel'              # they are in the comment->connect->DM funnel (issue #399)
 
 
+class FeedbackSource(StrEnum):
+    """Where a piece of user feedback came in from (issue #496). Only WIDGET is captured today —
+    the rest are the channels the feedback->auto-work loop will add later."""
+    WIDGET = 'widget'    # the in-app feedback/bug widget
+    BUG = 'bug'          # a bug report raised outside the widget (e.g. support email)
+    NPS = 'nps'          # an NPS survey response
+    REVIEW = 'review'    # a public review (marketplace/G2/etc.)
+    PASSIVE = 'passive'  # inferred from behavior, not typed by the user
+
+
+class FeedbackStatus(StrEnum):
+    """Lifecycle of a feedback item as it moves through the auto-work loop (issue #496)."""
+    NEW = 'new'                      # just captured, not looked at
+    TRIAGED = 'triaged'              # reviewed/classified
+    CLUSTERED = 'clustered'          # grouped with similar reports
+    ISSUE_CREATED = 'issue_created'  # a GitHub issue was opened for its cluster
+    RESOLVED = 'resolved'            # shipped/answered
+    DISMISSED = 'dismissed'          # not actionable
+
+
 # Enum for log actions types
 class LogActionType(StrEnum):
     COMMENT = 'comment'
@@ -6319,6 +6339,34 @@ def get_margin_users() -> list:
     except mysql.connector.Error as err:
         myprint(f"Could not fetch margin users | Error: {err}")
         return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def insert_feedback(body: str, user_id: int = None,
+                    source: "FeedbackSource" = FeedbackSource.WIDGET,
+                    type_hint: str = None, context: dict = None,
+                    sentiment: str = None) -> Optional[int]:
+    """Persist one piece of user feedback (issue #496). user_id is optional — the widget is offered
+    to logged-out visitors too. `context` is the auto-attached client context (route, app version,
+    PostHog session id, optional screenshot) and is stored as JSON."""
+    if not body or not str(body).strip():
+        return None
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO feedback (user_id, source, type_hint, body, context_json, sentiment) "
+            "VALUES (%s,%s,%s,%s,%s,%s)",
+            (user_id, str(source), str(type_hint)[:32] if type_hint else None, str(body),
+             json.dumps(context) if context else None,
+             str(sentiment)[:16] if sentiment else None))
+        connection.commit()
+        return cursor.lastrowid
+    except mysql.connector.Error as err:
+        myprint(f"Could not insert feedback for user_id {user_id} | Error: {err}")
+        return None
     finally:
         cursor.close()
         connection.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -13,7 +13,7 @@ from cqc_lem.utilities.env_constants import (
     SESSION_IDLE_HOURS,
 )
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
-from cqc_lem.utilities.logger import myprint
+from cqc_lem.utilities.logger import myprint, log_error
 from cqc_lem.utilities.utils import get_top_level_domain, get_aws_ssm_secret
 from dotenv import load_dotenv
 from mysql.connector import errorcode
@@ -6365,7 +6365,7 @@ def insert_feedback(body: str, user_id: int = None,
         connection.commit()
         return cursor.lastrowid
     except mysql.connector.Error as err:
-        myprint(f"Could not insert feedback for user_id {user_id} | Error: {err}")
+        log_error("Could not insert feedback", exc=err, user_id=user_id)
         return None
     finally:
         cursor.close()

--- a/tests/integration/test_feedback_capture.py
+++ b/tests/integration/test_feedback_capture.py
@@ -1,0 +1,112 @@
+"""Integration test for the in-app feedback capture loop (#496).
+
+Drives the real POST /api/feedback handler through the real db.insert_feedback into a stateful fake
+cursor that models the `feedback` table, so a widget submission provably lands as a persisted row —
+the acceptance criterion — without needing a live MySQL container.
+"""
+import json
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.integration
+
+_DB = "cqc_lem.utilities.db"
+
+
+class _FakeCursor:
+    """Minimal MySQL-ish cursor over an in-memory `feedback` store."""
+
+    def __init__(self, rows):
+        self.rows = rows
+        self._result = []
+        self.rowcount = 0
+        self.lastrowid = 0
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        if s.startswith("INSERT INTO feedback"):
+            user_id, source, type_hint, body, context_json, sentiment = params
+            self.lastrowid = len(self.rows) + 1
+            self.rows.append({
+                "id": self.lastrowid, "user_id": user_id, "source": source,
+                "type_hint": type_hint, "body": body, "context_json": context_json,
+                "sentiment": sentiment, "status": "new",
+            })
+            self.rowcount = 1
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return list(self._result)
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, rows):
+        self._cur = _FakeCursor(rows)
+
+    def cursor(self, *a, **k):
+        return self._cur
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from cqc_lem.api.main import app
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestFeedbackCapture:
+    def test_widget_submission_is_persisted_with_its_context(self, client):
+        rows: list = []
+
+        with patch(f"{_DB}.get_db_connection", side_effect=lambda *a, **k: _FakeConn(rows)), \
+             patch("cqc_lem.api.main.get_session_user_id", return_value=4):
+            response = client.post("/api/feedback", json={
+                "session_token": "sess-abc",
+                "body": "The Content tab throws a 500 when I approve a carousel",
+                "type_hint": "bug",
+                "screenshot": "data:image/png;base64,AAAA",
+                "context": {"route": "/content?tab=review", "app_version": "0.77.0",
+                            "posthog_session_id": "ph-session-1"},
+            })
+
+        assert response.status_code == 200
+        feedback_id = response.json()["detail"]["feedback_id"]
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["id"] == feedback_id
+        assert row["user_id"] == 4
+        assert row["source"] == "widget"
+        assert row["type_hint"] == "bug"
+        assert row["body"].startswith("The Content tab throws a 500")
+        context = json.loads(row["context_json"])
+        assert context["route"] == "/content?tab=review"
+        assert context["app_version"] == "0.77.0"
+        assert context["posthog_session_id"] == "ph-session-1"
+        assert context["screenshot"] == "data:image/png;base64,AAAA"
+
+    def test_anonymous_submission_persists_with_null_user(self, client):
+        rows: list = []
+
+        with patch(f"{_DB}.get_db_connection", side_effect=lambda *a, **k: _FakeConn(rows)):
+            response = client.post("/api/feedback", json={"body": "Love the new dashboard",
+                                                          "type_hint": "praise"})
+
+        assert response.status_code == 200
+        assert len(rows) == 1
+        assert rows[0]["user_id"] is None
+        assert rows[0]["context_json"] is None

--- a/tests/unit/api/test_feedback_api.py
+++ b/tests/unit/api/test_feedback_api.py
@@ -122,7 +122,8 @@ class TestFeedbackMigration:
         assert len(files) == 1, "expected exactly one add_feedback migration"
         version = os.path.basename(files[0]).split("__")[0][1:]
         assert len(version) == 14 and version.isdigit(), "new migrations must use a timestamp version"
-        sql = open(files[0]).read()
+        with open(files[0]) as f:
+            sql = f.read()
         for col in ("user_id", "source", "type_hint", "body", "context_json", "embedding",
                     "cluster_id", "github_issue_number", "status", "sentiment", "created_at"):
             assert col in sql, f"missing column {col}"

--- a/tests/unit/api/test_feedback_api.py
+++ b/tests/unit/api/test_feedback_api.py
@@ -1,0 +1,128 @@
+"""Unit tests for the in-app feedback endpoint (issue #496)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+class TestSubmitFeedback:
+    def test_persists_with_session_user_and_context(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=9), \
+             patch("cqc_lem.api.main.insert_feedback", return_value=101) as ins:
+            resp = client.post("/api/feedback", json={
+                "session_token": "tok", "body": "  Scheduling a post 500s  ",
+                "type_hint": "bug",
+                "context": {"route": "/content", "app_version": "0.77.0",
+                            "posthog_session_id": "ph-1"}})
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["feedback_id"] == 101
+        from cqc_lem.utilities.db import FeedbackSource
+        assert ins.call_args[0][0] == "Scheduling a post 500s"  # trimmed
+        assert ins.call_args.kwargs["user_id"] == 9
+        assert ins.call_args.kwargs["source"] == FeedbackSource.WIDGET
+        assert ins.call_args.kwargs["type_hint"] == "bug"
+        assert ins.call_args.kwargs["context"]["route"] == "/content"
+        assert ins.call_args.kwargs["context"]["posthog_session_id"] == "ph-1"
+
+    def test_anonymous_submission_has_no_user_id(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id") as sess, \
+             patch("cqc_lem.api.main.insert_feedback", return_value=102) as ins:
+            resp = client.post("/api/feedback", json={"body": "love the new tabs"})
+        assert resp.status_code == 200
+        sess.assert_not_called()  # no token -> never hit the session table
+        assert ins.call_args.kwargs["user_id"] is None
+
+    def test_invalid_session_token_falls_back_to_anonymous(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None), \
+             patch("cqc_lem.api.main.insert_feedback", return_value=103) as ins:
+            resp = client.post("/api/feedback", json={"session_token": "stale", "body": "hi"})
+        assert resp.status_code == 200
+        assert ins.call_args.kwargs["user_id"] is None
+
+    def test_screenshot_rides_along_in_context(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.insert_feedback", return_value=104) as ins:
+            resp = client.post("/api/feedback", json={
+                "session_token": "tok", "body": "see attached",
+                "screenshot": "data:image/png;base64,AAAA"})
+        assert resp.status_code == 200
+        assert ins.call_args.kwargs["context"]["screenshot"] == "data:image/png;base64,AAAA"
+
+    def test_oversized_context_is_dropped_but_screenshot_kept(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.insert_feedback", return_value=105) as ins:
+            resp = client.post("/api/feedback", json={
+                "session_token": "tok", "body": "big", "screenshot": "data:image/png;base64,BBBB",
+                "context": {"junk": "x" * 9000}})
+        assert resp.status_code == 200
+        ctx = ins.call_args.kwargs["context"]
+        assert ctx == {"truncated": True, "screenshot": "data:image/png;base64,BBBB"}
+
+    def test_blank_body_rejected_422(self, client):
+        with patch("cqc_lem.api.main.insert_feedback") as ins:
+            resp = client.post("/api/feedback", json={"body": "   "})
+        assert resp.status_code == 422
+        ins.assert_not_called()
+
+    def test_over_long_body_rejected_422(self, client):
+        with patch("cqc_lem.api.main.insert_feedback") as ins:
+            resp = client.post("/api/feedback", json={"body": "x" * 5001})
+        assert resp.status_code == 422
+        ins.assert_not_called()
+
+    def test_unknown_source_rejected_422(self, client):
+        with patch("cqc_lem.api.main.insert_feedback") as ins:
+            resp = client.post("/api/feedback", json={"body": "hi", "source": "carrier-pigeon"})
+        assert resp.status_code == 422
+        ins.assert_not_called()
+
+    def test_alternate_source_accepted(self, client):
+        with patch("cqc_lem.api.main.insert_feedback", return_value=106) as ins:
+            resp = client.post("/api/feedback", json={"body": "9/10", "source": "nps"})
+        assert resp.status_code == 200
+        from cqc_lem.utilities.db import FeedbackSource
+        assert ins.call_args.kwargs["source"] == FeedbackSource.NPS
+
+    def test_db_failure_returns_500(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=1), \
+             patch("cqc_lem.api.main.insert_feedback", return_value=None):
+            resp = client.post("/api/feedback", json={"session_token": "tok", "body": "hi"})
+        assert resp.status_code == 500
+
+
+class TestFeedbackMigration:
+    def test_migration_columns_cover_the_issue_spec(self):
+        import glob
+        import os
+        root = os.path.join(os.path.dirname(__file__), "..", "..", "..",
+                            "compose", "local", "database", "migrations")
+        files = glob.glob(os.path.join(root, "V*__add_feedback.sql"))
+        assert len(files) == 1, "expected exactly one add_feedback migration"
+        version = os.path.basename(files[0]).split("__")[0][1:]
+        assert len(version) == 14 and version.isdigit(), "new migrations must use a timestamp version"
+        sql = open(files[0]).read()
+        for col in ("user_id", "source", "type_hint", "body", "context_json", "embedding",
+                    "cluster_id", "github_issue_number", "status", "sentiment", "created_at"):
+            assert col in sql, f"missing column {col}"

--- a/tests/unit/utilities/test_db_feedback.py
+++ b/tests/unit/utilities/test_db_feedback.py
@@ -1,0 +1,88 @@
+"""Unit tests for the feedback DB helper (issue #496)."""
+
+import json
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(lastrowid=7):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.lastrowid = lastrowid
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestInsertFeedback:
+    def test_insert_returns_id_and_serializes_context(self):
+        conn, cur = _conn(lastrowid=42)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_feedback, FeedbackSource
+            got = insert_feedback("The schedule tab 500s", user_id=3,
+                                  source=FeedbackSource.WIDGET, type_hint="bug",
+                                  context={"route": "/content"}, sentiment="negative")
+        assert got == 42
+        sql, params = cur.execute.call_args[0]
+        assert "INSERT INTO feedback" in sql
+        assert params[0] == 3
+        assert params[1] == "widget"
+        assert params[2] == "bug"
+        assert params[3] == "The schedule tab 500s"
+        assert json.loads(params[4]) == {"route": "/content"}
+        assert params[5] == "negative"
+        conn.commit.assert_called_once()
+
+    def test_anonymous_and_empty_context_store_null(self):
+        conn, cur = _conn(lastrowid=8)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_feedback
+            got = insert_feedback("nice work")
+        assert got == 8
+        params = cur.execute.call_args[0][1]
+        assert params[0] is None       # anonymous — NULL user_id
+        assert params[1] == "widget"   # default source
+        assert params[2] is None
+        assert params[4] is None       # no context -> NULL
+        assert params[5] is None
+
+    def test_blank_body_is_rejected_without_touching_db(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            from cqc_lem.utilities.db import insert_feedback
+            assert insert_feedback("   ") is None
+            assert insert_feedback(None) is None
+        get_conn.assert_not_called()
+
+    def test_over_long_type_hint_and_sentiment_are_truncated(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_feedback
+            insert_feedback("body", type_hint="b" * 80, sentiment="s" * 40)
+        params = cur.execute.call_args[0][1]
+        assert len(params[2]) == 32  # feedback.type_hint VARCHAR(32)
+        assert len(params[5]) == 16  # feedback.sentiment VARCHAR(16)
+
+    def test_db_error_returns_none_and_closes(self):
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_feedback
+            assert insert_feedback("body", user_id=1) is None
+        cur.close.assert_called_once()
+        conn.close.assert_called_once()
+
+
+class TestFeedbackEnums:
+    def test_source_values_match_the_migration_enum(self):
+        from cqc_lem.utilities.db import FeedbackSource
+        assert {str(s) for s in FeedbackSource} == {"widget", "bug", "nps", "review", "passive"}
+
+    def test_status_values_match_the_migration_enum(self):
+        from cqc_lem.utilities.db import FeedbackStatus
+        assert {str(s) for s in FeedbackStatus} == {
+            "new", "triaged", "clustered", "issue_created", "resolved", "dismissed"}

--- a/tests/unit/utilities/test_db_feedback.py
+++ b/tests/unit/utilities/test_db_feedback.py
@@ -70,11 +70,14 @@ class TestInsertFeedback:
         import mysql.connector
         conn, cur = _conn()
         cur.execute.side_effect = mysql.connector.Error("boom")
-        with patch(f"{_DB}.get_db_connection", return_value=conn):
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+                patch(f"{_DB}.log_error") as logged:
             from cqc_lem.utilities.db import insert_feedback
             assert insert_feedback("body", user_id=1) is None
         cur.close.assert_called_once()
         conn.close.assert_called_once()
+        assert logged.call_args.kwargs["user_id"] == 1
+        assert isinstance(logged.call_args.kwargs["exc"], mysql.connector.Error)
 
 
 class TestFeedbackEnums:


### PR DESCRIPTION
## What & why
First capture point of the feedback→auto-work loop (issue #496, Section B.1 of the launch plan). There was no in-app way for a user to report a bug or an idea; this adds one end to end.

**DB** — `V20260725063146__add_feedback.sql` creates `feedback`: `id, user_id, source, type_hint, body, context_json, embedding, cluster_id, github_issue_number, status, sentiment, created_at/updated_at`, indexed by user, status and cluster. `source` is the forward-looking ENUM `widget|bug|nps|review|passive`. `user_id` is NULLable on purpose — the widget is offered to logged-out visitors too. `embedding` / `cluster_id` / `github_issue_number` / `sentiment` are the enrichment columns later loop steps fill in.

**db.py** — `FeedbackSource` / `FeedbackStatus` StrEnums + `insert_feedback()` (all DB access stays in `utilities/db.py`; blank bodies never reach MySQL, `type_hint`/`sentiment` are truncated to their column widths).

**API** — `POST /api/feedback`. An optional `session_token` attributes the row to that user (invalid/missing → anonymous). `source` is validated against `FeedbackSource` (422 otherwise), `body` is capped at 5000 chars and trimmed, the screenshot data URL at 2 MB, and an over-large free-form `context` is replaced with `{"truncated": true}` so a caller can't write an unbounded JSON blob.

**SPA** — `FeedbackWidget.tsx`, a persistent bottom-right "Feedback / Report a bug" button mounted in `Layout` (so it's on every page). Type hint (bug / idea / confusing / praise / other), free text, optional screenshot (client-capped at 1.4 MB pre-base64), and auto-attached context: route, `user_id`, app version from `/api/app-info`, PostHog session id (read defensively off `window.posthog`), user agent and viewport.

## Testing
- `tests/unit/utilities/test_db_feedback.py` — insert path, anonymous/NULL context, blank-body guard, truncation, DB-error handling, and enum values matching the migration.
- `tests/unit/api/test_feedback_api.py` — session vs anonymous attribution, screenshot passthrough, oversized-context drop, 422s (blank/over-long body, unknown source), 500 on persist failure, plus a check that the migration is timestamp-versioned and has every spec'd column.
- `tests/integration/test_feedback_capture.py` — drives the real handler through the real `insert_feedback` into a stateful fake cursor: a widget submission provably lands as a persisted row with its context.
- `pytest tests/unit` → 4064 passed locally; `tsc -b --force` on the SPA is clean.

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)