### PR TITLE
feat(feedback): LLM auto-classifier for feedback — category/severity/risk → real repo labels (closes #497)

### DIFF
--- a/src/cqc_lem/utilities/feedback/classifier.py
+++ b/src/cqc_lem/utilities/feedback/classifier.py
@@ -23,7 +23,6 @@ Env:
 
 import json
 import os
-import re
 from dataclasses import dataclass, field
 from enum import StrEnum
 from typing import Optional
@@ -403,22 +402,67 @@ def _normalize(data: dict, candidate_ids: set[int]) -> dict:
     return out
 
 
-def parse_classification(raw_text: str, candidate_ids: Optional[set[int]] = None
+def _balanced_end(text: str, start: int) -> Optional[int]:
+    """Index just past the `}` that closes the `{` at `start`, or None if it never closes. Brace
+    counting is string-aware so braces inside JSON string values don't shift the depth."""
+    depth = 0
+    in_string = False
+    escaped = False
+    for index in range(start, len(text)):
+        char = text[index]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return index + 1
+    return None
+
+
+def _json_object_candidates(text: str):
+    """Yield each top-level balanced `{...}` span in order. A greedy `\\{.*\\}` would swallow prose
+    braces and a second object into one unparseable blob; this hands out real objects one at a time."""
+    index = 0
+    while True:
+        start = text.find("{", index)
+        if start == -1:
+            return
+        end = _balanced_end(text, start)
+        if end is None:
+            index = start + 1
+            continue
+        yield text[start:end]
+        index = end
+
+
+def parse_classification(raw_text: Optional[str], candidate_ids: Optional[set[int]] = None
                          ) -> tuple[Optional[dict], list[str]]:
     """Parse the model's reply into a schema-valid dict. Returns (data, errors) — data is None when
-    the reply is not usable. Tolerates ```json fences and prose around the object."""
-    match = re.search(r"\{.*\}", raw_text or "", re.DOTALL)
-    if not match:
-        return None, ["no JSON object in the response"]
-    try:
-        data = json.loads(match.group(0))
-    except ValueError as e:
-        return None, [f"invalid JSON: {e}"]
-    normalized = _normalize(data, candidate_ids or set())
-    errors = validate_classification(normalized)
-    if errors:
-        return None, errors
-    return normalized, []
+    the reply is not usable. Tolerates ```json fences, prose (even prose with braces) around the
+    object, and a trailing second object; the first span that is valid JSON decides the result."""
+    errors: list[str] = []
+    for candidate in _json_object_candidates(raw_text or ""):
+        try:
+            data = json.loads(candidate)
+        except ValueError as e:
+            errors = [f"invalid JSON: {e}"]
+            continue
+        normalized = _normalize(data, candidate_ids or set())
+        validation_errors = validate_classification(normalized)
+        if validation_errors:
+            return None, validation_errors
+        return normalized, []
+    return None, errors or ["no JSON object in the response"]
 
 
 def _from_dict(data: dict) -> FeedbackClassification:
@@ -434,7 +478,8 @@ def _from_dict(data: dict) -> FeedbackClassification:
     )
 
 
-def _unclassified(body: str, type_hint: Optional[str], errors: list[str]) -> FeedbackClassification:
+def _unclassified(body: Optional[str], type_hint: Optional[str],
+                  errors: list[str]) -> FeedbackClassification:
     """The fail-SAFE result: confidence 0.0, which always routes to NEEDS_HUMAN. The type hint is
     the only thing we trust here, purely so the triage queue is sortable."""
     hint = str(type_hint or "").strip().lower()
@@ -457,7 +502,8 @@ def _unclassified(body: str, type_hint: Optional[str], errors: list[str]) -> Fee
     )
 
 
-def classify_feedback(body: str, type_hint: Optional[str] = None, context: Optional[dict] = None,
+def classify_feedback(body: Optional[str], type_hint: Optional[str] = None,
+                      context: Optional[dict] = None,
                       duplicate_candidates: Optional[list[dict]] = None,
                       user_id: Optional[int] = None) -> FeedbackClassification:
     """Classify ONE feedback item with a single `lem-medium` call.

--- a/src/cqc_lem/utilities/feedback/classifier.py
+++ b/src/cqc_lem/utilities/feedback/classifier.py
@@ -1,0 +1,505 @@
+"""LLM auto-classifier for captured feedback (issue #497) — stage 2 of the feedback->auto-work loop.
+
+Stage 1 (issue #496) captures raw free text into the `feedback` table. This module turns one such
+row into a triaged, label-mapped decision with ZERO human triage, using ONE `lem-medium` call:
+
+    body ──► single LLM call (strict JSON) ──► schema validation ──► deterministic label mapping
+                                                                 └─► route (auto-work/FAQ/drop/human)
+
+Two halves, deliberately separated so the expensive half can be mocked and the cheap half is
+exhaustively testable:
+  * `classify_feedback()` — the one LLM call plus strict parsing. Non-deterministic, fails SAFE.
+  * `labels_for()` / `route_for()` — pure functions. The model NEVER names a GitHub label; it only
+    picks taxonomy values, and this module maps those to labels that actually exist in the repo.
+
+Fails SAFE, not open and not closed: any bad/unparseable/errored answer becomes a low-confidence
+result routed to NEEDS_HUMAN. Feedback is never silently dropped because the classifier hiccuped —
+only an explicit, confident `noise` verdict drops.
+
+Env:
+  FEEDBACK_CLASSIFIER_MODEL           — model alias for the call (default: lem-medium)
+  FEEDBACK_CLASSIFIER_MIN_CONFIDENCE  — below this the item goes to human triage (default: 0.6)
+"""
+
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Optional
+
+from cqc_lem.utilities.logger import log_debug, log_warning
+
+DEFAULT_MODEL = "lem-medium"
+DEFAULT_MIN_CONFIDENCE = 0.6
+
+# Everything sent to / accepted from the model is bounded — feedback bodies are user-supplied and a
+# runaway "summary" would land unbounded in an issue body.
+MAX_BODY_CHARS = 4000
+MAX_TITLE_CHARS = 80
+MAX_SUMMARY_CHARS = 500
+MAX_DUPLICATE_CANDIDATES = 25
+
+
+class FeedbackCategory(StrEnum):
+    """What KIND of work (if any) a piece of feedback implies."""
+    BUG = 'bug'                  # something is broken / behaves wrong
+    FEATURE = 'feature'          # something that does not exist yet
+    ENHANCEMENT = 'enhancement'  # an existing thing should work better ("update")
+    CLEANUP = 'cleanup'          # tech debt, confusing copy/UX, deprecation
+    QUESTION = 'question'        # a support question — answerable, not buildable
+    NOISE = 'noise'              # praise, spam, tests, empty — no work item
+
+
+class FeedbackSeverity(StrEnum):
+    """How badly it hurts. Maps 1:1 onto the repo's priority:* labels."""
+    CRITICAL = 'critical'  # data loss, security, or the product is unusable
+    HIGH = 'high'          # a core flow is broken/blocked with no workaround
+    MEDIUM = 'medium'      # painful but has a workaround
+    LOW = 'low'            # cosmetic / nice-to-have
+
+
+class FeedbackRisk(StrEnum):
+    """Why a human may need to look before this ships. Maps onto the repo's risk:* hold labels."""
+    NONE = 'none'
+    PRODUCT_DECISION = 'product-decision'  # needs a product/policy call
+    LIVE_LINKEDIN = 'live-linkedin'        # needs live LinkedIn/Selenium validation
+    MIGRATION = 'migration'                # implies a DB schema change
+    SECURITY = 'security'                  # security/privacy sensitive
+
+
+class FeedbackRoute(StrEnum):
+    """Where the classified item goes next."""
+    AUTO_WORK = 'auto_work'      # clustered + auto-opened as a GitHub issue
+    FAQ = 'faq'                  # answered by the FAQ service, no issue
+    DROP = 'drop'                # dismissed, no work
+    NEEDS_HUMAN = 'needs_human'  # low confidence / unusable answer — human triage queue
+
+
+# The product areas the classifier is allowed to name. A closed menu keeps `component` groupable
+# (the clustering step buckets on it) instead of a free-text field with 40 spellings of "feed".
+COMPONENTS = (
+    'feed-commenting', 'replies', 'dms', 'connections', 'content-generation', 'scheduling',
+    'newsletter', 'carousels', 'video', 'analytics', 'billing', 'auth', 'onboarding',
+    'ui', 'api', 'infra', 'other',
+)
+
+# --- Taxonomy -> REAL repo labels ---------------------------------------------------------------
+# Every value below must exist in christopherqueenconsulting/linkedin_engagement_manager's label
+# set. NOISE has no label on purpose (it is dropped, never filed).
+CATEGORY_LABELS: dict[FeedbackCategory, str] = {
+    FeedbackCategory.BUG: 'bug',
+    FeedbackCategory.FEATURE: 'feature',
+    FeedbackCategory.ENHANCEMENT: 'enhancement',
+    FeedbackCategory.CLEANUP: 'cleanup',
+    FeedbackCategory.QUESTION: 'question',
+}
+
+SEVERITY_LABELS: dict[FeedbackSeverity, str] = {
+    FeedbackSeverity.CRITICAL: 'priority:critical',
+    FeedbackSeverity.HIGH: 'priority:high',
+    FeedbackSeverity.MEDIUM: 'priority:medium',
+    FeedbackSeverity.LOW: 'priority:low',
+}
+
+RISK_LABELS: dict[FeedbackRisk, str] = {
+    FeedbackRisk.PRODUCT_DECISION: 'risk:product-decision',
+    FeedbackRisk.LIVE_LINKEDIN: 'risk:live-linkedin',
+    FeedbackRisk.MIGRATION: 'risk:migration',
+    FeedbackRisk.SECURITY: 'risk:security',
+}
+
+NEEDS_HUMAN_LABEL = 'needs-human'
+
+# Synonyms models reach for (and the widget's own type_hint values) folded onto the taxonomy.
+_CATEGORY_ALIASES: dict[str, FeedbackCategory] = {
+    'fix': FeedbackCategory.BUG, 'defect': FeedbackCategory.BUG, 'error': FeedbackCategory.BUG,
+    'broken': FeedbackCategory.BUG, 'regression': FeedbackCategory.BUG,
+    'feature_request': FeedbackCategory.FEATURE, 'feature-request': FeedbackCategory.FEATURE,
+    'idea': FeedbackCategory.FEATURE, 'request': FeedbackCategory.FEATURE,
+    'new': FeedbackCategory.FEATURE,
+    'update': FeedbackCategory.ENHANCEMENT, 'improvement': FeedbackCategory.ENHANCEMENT,
+    'improve': FeedbackCategory.ENHANCEMENT, 'ux': FeedbackCategory.ENHANCEMENT,
+    'chore': FeedbackCategory.CLEANUP, 'refactor': FeedbackCategory.CLEANUP,
+    'tech-debt': FeedbackCategory.CLEANUP, 'debt': FeedbackCategory.CLEANUP,
+    'confusing': FeedbackCategory.CLEANUP,
+    'support': FeedbackCategory.QUESTION, 'help': FeedbackCategory.QUESTION,
+    'praise': FeedbackCategory.NOISE, 'spam': FeedbackCategory.NOISE,
+    'test': FeedbackCategory.NOISE, 'none': FeedbackCategory.NOISE,
+}
+
+_SEVERITY_ALIASES: dict[str, FeedbackSeverity] = {
+    'blocker': FeedbackSeverity.CRITICAL, 'urgent': FeedbackSeverity.CRITICAL,
+    'p0': FeedbackSeverity.CRITICAL, 'sev1': FeedbackSeverity.CRITICAL,
+    'major': FeedbackSeverity.HIGH, 'p1': FeedbackSeverity.HIGH,
+    'moderate': FeedbackSeverity.MEDIUM, 'normal': FeedbackSeverity.MEDIUM,
+    'p2': FeedbackSeverity.MEDIUM,
+    'minor': FeedbackSeverity.LOW, 'trivial': FeedbackSeverity.LOW,
+    'cosmetic': FeedbackSeverity.LOW, 'p3': FeedbackSeverity.LOW,
+}
+
+# Keys are hyphenated/lowercased the same way `_normalize` folds the model's answer.
+_RISK_ALIASES: dict[str, FeedbackRisk] = {
+    '': FeedbackRisk.NONE, 'null': FeedbackRisk.NONE, 'no': FeedbackRisk.NONE,
+    'product': FeedbackRisk.PRODUCT_DECISION, 'policy': FeedbackRisk.PRODUCT_DECISION,
+    'linkedin': FeedbackRisk.LIVE_LINKEDIN, 'selenium': FeedbackRisk.LIVE_LINKEDIN,
+    'db': FeedbackRisk.MIGRATION, 'schema': FeedbackRisk.MIGRATION,
+    'privacy': FeedbackRisk.SECURITY, 'auth': FeedbackRisk.SECURITY,
+}
+
+# --- Output contract -----------------------------------------------------------------------------
+# Handed to the model verbatim AND enforced on the way back by `validate_classification()`, so the
+# thing we prompt for and the thing we accept can never drift apart.
+FEEDBACK_CLASSIFICATION_SCHEMA: dict = {
+    "type": "object",
+    "required": ["category", "severity", "component", "title", "summary", "risk",
+                 "duplicate_of", "confidence"],
+    "properties": {
+        "category": {"type": "string", "enum": [c.value for c in FeedbackCategory]},
+        "severity": {"type": "string", "enum": [s.value for s in FeedbackSeverity]},
+        "component": {"type": "string", "enum": list(COMPONENTS)},
+        "title": {"type": "string", "maxLength": MAX_TITLE_CHARS},
+        "summary": {"type": "string", "maxLength": MAX_SUMMARY_CHARS},
+        "risk": {"type": "string", "enum": [r.value for r in FeedbackRisk]},
+        "duplicate_of": {"type": ["integer", "null"]},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+    },
+}
+
+
+def validate_classification(data: object) -> list[str]:
+    """Validate `data` against FEEDBACK_CLASSIFICATION_SCHEMA, returning a list of human-readable
+    errors (empty == valid). Supports the JSON Schema subset the contract above uses — object /
+    required / properties / type (incl. union lists) / enum / maxLength / minimum / maximum — so
+    the schema stays the single source of truth without pulling in a runtime dependency."""
+    errors: list[str] = []
+    if not isinstance(data, dict):
+        return [f"expected an object, got {type(data).__name__}"]
+    for key in FEEDBACK_CLASSIFICATION_SCHEMA["required"]:
+        if key not in data:
+            errors.append(f"missing required field '{key}'")
+    for key, rule in FEEDBACK_CLASSIFICATION_SCHEMA["properties"].items():
+        if key not in data:
+            continue
+        errors.extend(f"{key}: {e}" for e in _validate_value(data[key], rule))
+    return errors
+
+
+_JSON_TYPES: dict[str, tuple] = {
+    "object": (dict,), "array": (list,), "string": (str,),
+    "integer": (int,), "number": (int, float), "boolean": (bool,),
+}
+
+
+def _validate_value(value: object, rule: dict) -> list[str]:
+    errors: list[str] = []
+    types = rule.get("type")
+    types = [types] if isinstance(types, str) else list(types or [])
+    if types:
+        # bool is an int subclass in Python; never let True satisfy an integer/number field.
+        ok = any(value is None if t == "null"
+                 else isinstance(value, _JSON_TYPES.get(t, ()))
+                 and not (isinstance(value, bool) and t in ("integer", "number"))
+                 for t in types)
+        if not ok:
+            errors.append(f"expected type {'|'.join(types)}, got {type(value).__name__}")
+            return errors
+    if "enum" in rule and value not in rule["enum"]:
+        errors.append(f"'{value}' is not one of {rule['enum']}")
+    if "maxLength" in rule and isinstance(value, str) and len(value) > rule["maxLength"]:
+        errors.append(f"longer than {rule['maxLength']} characters")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        if "minimum" in rule and value < rule["minimum"]:
+            errors.append(f"below minimum {rule['minimum']}")
+        if "maximum" in rule and value > rule["maximum"]:
+            errors.append(f"above maximum {rule['maximum']}")
+    return errors
+
+
+@dataclass(frozen=True)
+class FeedbackClassification:
+    """One classified feedback item. `labels` and `route` are derived deterministically from the
+    taxonomy fields — the model does not choose them."""
+    category: FeedbackCategory
+    severity: FeedbackSeverity
+    component: str
+    title: str
+    summary: str
+    risk: FeedbackRisk = FeedbackRisk.NONE
+    duplicate_of: Optional[int] = None
+    confidence: float = 0.0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def route(self) -> FeedbackRoute:
+        return route_for(self.category, self.confidence)
+
+    @property
+    def labels(self) -> list[str]:
+        return labels_for(self.category, self.severity, self.risk, self.route)
+
+    @property
+    def needs_human(self) -> bool:
+        return self.route == FeedbackRoute.NEEDS_HUMAN
+
+    def to_dict(self) -> dict:
+        return {
+            "category": str(self.category),
+            "severity": str(self.severity),
+            "component": self.component,
+            "title": self.title,
+            "summary": self.summary,
+            "risk": str(self.risk),
+            "duplicate_of": self.duplicate_of,
+            "confidence": self.confidence,
+            "route": str(self.route),
+            "labels": self.labels,
+        }
+
+
+def min_confidence() -> float:
+    """Confidence floor for acting without a human, read at call time (the live-env pattern used by
+    POST_SIMILARITY_MAX) so it can be tuned per-deploy without a restart."""
+    raw = (os.environ.get("FEEDBACK_CLASSIFIER_MIN_CONFIDENCE") or "").strip()
+    try:
+        value = float(raw) if raw else DEFAULT_MIN_CONFIDENCE
+    except ValueError:
+        return DEFAULT_MIN_CONFIDENCE
+    return max(0.0, min(1.0, value))
+
+
+def classifier_model() -> str:
+    return (os.environ.get("FEEDBACK_CLASSIFIER_MODEL") or "").strip() or DEFAULT_MODEL
+
+
+def route_for(category: FeedbackCategory, confidence: float) -> FeedbackRoute:
+    """Deterministic routing. An unsure verdict ALWAYS wins over the category — we would rather put
+    a human on a praise message than silently drop a real bug the model misread."""
+    if confidence < min_confidence():
+        return FeedbackRoute.NEEDS_HUMAN
+    if category == FeedbackCategory.NOISE:
+        return FeedbackRoute.DROP
+    if category == FeedbackCategory.QUESTION:
+        return FeedbackRoute.FAQ
+    return FeedbackRoute.AUTO_WORK
+
+
+def labels_for(category: FeedbackCategory, severity: FeedbackSeverity,
+               risk: FeedbackRisk = FeedbackRisk.NONE,
+               route: Optional[FeedbackRoute] = None) -> list[str]:
+    """Map the taxonomy onto labels that exist in the repo. Dropped items get none; questions get
+    only `question` (they never become a prioritized work item); human-triage items carry
+    `needs-human` so the escalation queue is one label filter."""
+    route = route if route is not None else FeedbackRoute.AUTO_WORK
+    if route == FeedbackRoute.DROP:
+        return []
+    labels: list[str] = []
+    category_label = CATEGORY_LABELS.get(category)
+    if category_label:
+        labels.append(category_label)
+    if route == FeedbackRoute.FAQ:
+        return labels
+    labels.append(SEVERITY_LABELS[severity])
+    risk_label = RISK_LABELS.get(risk)
+    if risk_label:
+        labels.append(risk_label)
+    if route == FeedbackRoute.NEEDS_HUMAN:
+        labels.append(NEEDS_HUMAN_LABEL)
+    return labels
+
+
+_SYSTEM_PROMPT = (
+    "You are the triage engineer for LinkedIn Engagement Manager (LEM), a SaaS that automates "
+    "LinkedIn engagement: AI content generation and scheduling, feed commenting, replies, DMs and "
+    "follow-ups, newsletters, carousels/video, analytics, and billing.\n"
+    "You are given ONE piece of user feedback. Classify it so it can be worked with no human triage.\n\n"
+    "Rules:\n"
+    "- category: 'bug' (something behaves wrong), 'feature' (does not exist yet), 'enhancement' "
+    "(exists but should work better), 'cleanup' (tech debt, confusing copy/UX), 'question' (a "
+    "support question that an answer resolves — no code change), 'noise' (praise, spam, test "
+    "submissions, or empty content).\n"
+    "- severity: 'critical' (data loss, security, product unusable), 'high' (core flow blocked, no "
+    "workaround), 'medium' (painful, has a workaround), 'low' (cosmetic or nice-to-have). Use 'low' "
+    "for question/noise.\n"
+    "- risk: 'security' if it touches auth/privacy/secrets; 'migration' if it needs a DB schema "
+    "change; 'live-linkedin' if it can only be validated against a live LinkedIn session; "
+    "'product-decision' if it needs a product or policy call; otherwise 'none'.\n"
+    "- title: an imperative GitHub issue title, at most 80 characters, no trailing period.\n"
+    "- summary: at most 500 characters, factual, only what the user actually said. Never invent "
+    "reproduction steps, versions, or numbers that are not in the feedback.\n"
+    "- duplicate_of: the id of an existing item below that reports the SAME underlying problem, "
+    "else null. Only use ids that were given to you.\n"
+    "- confidence: 0.0-1.0, how sure you are of category and severity. Be honest — vague, "
+    "truncated, or off-topic feedback deserves a LOW confidence so a human reviews it.\n"
+    "- The user's own type hint is a hint only; the text wins if they disagree.\n\n"
+    "Respond with ONLY a compact JSON object, no prose and no code fences, matching this schema:\n"
+)
+
+
+def _as_int(value: object) -> Optional[int]:
+    """int(value) or None — feedback ids arrive from callers/models as ints, digit strings, or junk."""
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _build_user_prompt(body: str, type_hint: Optional[str], context: Optional[dict],
+                       duplicate_candidates: Optional[list[dict]]) -> str:
+    parts = []
+    if type_hint:
+        parts.append(f"User's type hint: {str(type_hint)[:32]}")
+    if context:
+        # Only the fields that help triage — never the screenshot blob or anything unbounded.
+        wanted = {k: context.get(k) for k in ("route", "app_version", "user_agent", "viewport")
+                  if context.get(k)}
+        if wanted:
+            parts.append("Client context: " + json.dumps(wanted)[:500])
+    if duplicate_candidates:
+        listed = []
+        for candidate in duplicate_candidates[:MAX_DUPLICATE_CANDIDATES]:
+            candidate_id = _as_int(candidate.get("id"))
+            text = str(candidate.get("title") or candidate.get("body") or "").strip()
+            if candidate_id is not None and text:
+                listed.append(f"- {candidate_id}: {text[:160]}")
+        if listed:
+            parts.append("Existing feedback items (for duplicate_of):\n" + "\n".join(listed))
+    parts.append(f"Feedback:\n{body}")
+    return "\n\n".join(parts)
+
+
+def _normalize(data: dict, candidate_ids: set[int]) -> dict:
+    """Fold aliases/casing/None into the taxonomy and clamp lengths BEFORE schema validation, so a
+    model that answers 'Fix' / 'P1' / 'DB' is accepted while genuinely unusable output still fails."""
+    out = dict(data)
+
+    raw_category = str(out.get("category") or "").strip().lower()
+    category = _CATEGORY_ALIASES.get(raw_category)
+    out["category"] = str(category) if category else raw_category
+
+    raw_severity = str(out.get("severity") or "").strip().lower()
+    severity = _SEVERITY_ALIASES.get(raw_severity)
+    out["severity"] = str(severity) if severity else raw_severity
+
+    raw_risk = str(out.get("risk") or "").strip().lower().removeprefix("risk:").replace("_", "-")
+    risk = _RISK_ALIASES.get(raw_risk)
+    out["risk"] = str(risk) if risk else raw_risk
+
+    component = str(out.get("component") or "").strip().lower().replace("_", "-")
+    out["component"] = component if component in COMPONENTS else 'other'
+
+    out["title"] = str(out.get("title") or "").strip()[:MAX_TITLE_CHARS]
+    out["summary"] = str(out.get("summary") or "").strip()[:MAX_SUMMARY_CHARS]
+
+    duplicate_of = _as_int(out.get("duplicate_of"))
+    # A duplicate id the model invented is worse than none — it would merge unrelated reports.
+    out["duplicate_of"] = duplicate_of if duplicate_of in candidate_ids else None
+
+    try:
+        confidence = float(out.get("confidence"))
+    except (TypeError, ValueError):
+        confidence = 0.0
+    out["confidence"] = max(0.0, min(1.0, confidence))
+    return out
+
+
+def parse_classification(raw_text: str, candidate_ids: Optional[set[int]] = None
+                         ) -> tuple[Optional[dict], list[str]]:
+    """Parse the model's reply into a schema-valid dict. Returns (data, errors) — data is None when
+    the reply is not usable. Tolerates ```json fences and prose around the object."""
+    match = re.search(r"\{.*\}", raw_text or "", re.DOTALL)
+    if not match:
+        return None, ["no JSON object in the response"]
+    try:
+        data = json.loads(match.group(0))
+    except ValueError as e:
+        return None, [f"invalid JSON: {e}"]
+    normalized = _normalize(data, candidate_ids or set())
+    errors = validate_classification(normalized)
+    if errors:
+        return None, errors
+    return normalized, []
+
+
+def _from_dict(data: dict) -> FeedbackClassification:
+    return FeedbackClassification(
+        category=FeedbackCategory(data["category"]),
+        severity=FeedbackSeverity(data["severity"]),
+        component=data["component"],
+        title=data["title"],
+        summary=data["summary"],
+        risk=FeedbackRisk(data["risk"]),
+        duplicate_of=data["duplicate_of"],
+        confidence=data["confidence"],
+    )
+
+
+def _unclassified(body: str, type_hint: Optional[str], errors: list[str]) -> FeedbackClassification:
+    """The fail-SAFE result: confidence 0.0, which always routes to NEEDS_HUMAN. The type hint is
+    the only thing we trust here, purely so the triage queue is sortable."""
+    hint = str(type_hint or "").strip().lower()
+    category = _CATEGORY_ALIASES.get(hint)
+    if category is None:
+        try:
+            category = FeedbackCategory(hint)
+        except ValueError:
+            category = FeedbackCategory.BUG
+    return FeedbackClassification(
+        category=category,
+        severity=FeedbackSeverity.MEDIUM,
+        component='other',
+        title=(body or "").strip().splitlines()[0][:MAX_TITLE_CHARS] if (body or "").strip() else "",
+        summary=(body or "").strip()[:MAX_SUMMARY_CHARS],
+        risk=FeedbackRisk.NONE,
+        duplicate_of=None,
+        confidence=0.0,
+        errors=errors,
+    )
+
+
+def classify_feedback(body: str, type_hint: Optional[str] = None, context: Optional[dict] = None,
+                      duplicate_candidates: Optional[list[dict]] = None,
+                      user_id: Optional[int] = None) -> FeedbackClassification:
+    """Classify ONE feedback item with a single `lem-medium` call.
+
+    `duplicate_candidates` is an optional list of {'id': int, 'title'|'body': str} the model may
+    point `duplicate_of` at; anything else it names is discarded. NEVER raises — an empty body, a
+    failed call, or an off-contract answer all come back as a confidence-0.0 result whose route is
+    NEEDS_HUMAN."""
+    text = (body or "").strip()[:MAX_BODY_CHARS]
+    if not text:
+        return _unclassified(text, type_hint, ["empty feedback body"])
+
+    candidate_ids = {cid for cid in (_as_int(c.get("id")) for c in (duplicate_candidates or []))
+                     if cid is not None}
+    model = classifier_model()
+    try:
+        # Lazy import keeps this module importable (and unit-testable) without the AI stack loaded.
+        from cqc_lem.utilities.ai.ai_helper import _call_llm
+        response = _call_llm(
+            model=model,
+            messages=[
+                {"role": "system",
+                 "content": _SYSTEM_PROMPT + json.dumps(FEEDBACK_CLASSIFICATION_SCHEMA)},
+                {"role": "user",
+                 "content": _build_user_prompt(text, type_hint, context, duplicate_candidates)},
+            ],
+            temperature=0,
+            _track_user_id=user_id,
+        )
+        raw = response.choices[0].message.content or ""
+    except Exception as e:
+        log_warning("Feedback classification call failed — routing to human triage", exc=e,
+                    ai_model=model, user_id=user_id)
+        return _unclassified(text, type_hint, [f"llm call failed: {e}"])
+
+    data, errors = parse_classification(raw, candidate_ids)
+    if data is None:
+        log_warning("Feedback classification was off-contract — routing to human triage",
+                    ai_model=model, user_id=user_id)
+        return _unclassified(text, type_hint, errors)
+
+    result = _from_dict(data)
+    log_debug(f"Classified feedback as {result.category}/{result.severity} "
+              f"({result.confidence:.2f}) -> {result.route}", ai_model=model, user_id=user_id)
+    return result

--- a/tests/unit/utilities/test_feedback_classifier.py
+++ b/tests/unit/utilities/test_feedback_classifier.py
@@ -1,0 +1,395 @@
+"""Unit tests for the feedback auto-classifier — issue #497. Covers the deterministic halves (schema
+validation, alias normalization, label mapping, routing) exhaustively, and the single LLM call with
+a mocked client (happy path, off-contract answers, and the fail-safe path)."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from cqc_lem.utilities.feedback.classifier import (
+    CATEGORY_LABELS,
+    COMPONENTS,
+    FEEDBACK_CLASSIFICATION_SCHEMA,
+    FeedbackCategory,
+    FeedbackClassification,
+    FeedbackRisk,
+    FeedbackRoute,
+    FeedbackSeverity,
+    RISK_LABELS,
+    SEVERITY_LABELS,
+    classifier_model,
+    classify_feedback,
+    labels_for,
+    min_confidence,
+    parse_classification,
+    route_for,
+    validate_classification,
+)
+
+pytestmark = pytest.mark.unit
+
+_AI = "cqc_lem.utilities.ai.ai_helper._call_llm"
+
+# Every label this module can emit must exist in the repo's label set (gh label list).
+REAL_REPO_LABELS = {
+    'bug', 'feature', 'enhancement', 'cleanup', 'question', 'documentation', 'duplicate',
+    'priority:critical', 'priority:high', 'priority:medium', 'priority:low',
+    'risk:product-decision', 'risk:live-linkedin', 'risk:migration', 'risk:security',
+    'needs-human',
+}
+
+
+def _valid_payload(**overrides) -> dict:
+    payload = {
+        "category": "bug",
+        "severity": "high",
+        "component": "feed-commenting",
+        "title": "Feed commenting stops after the first comment",
+        "summary": "User reports that only one comment is posted per run.",
+        "risk": "none",
+        "duplicate_of": None,
+        "confidence": 0.9,
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _llm_reply(payload) -> MagicMock:
+    response = MagicMock()
+    response.choices = [MagicMock()]
+    response.choices[0].message.content = payload if isinstance(payload, str) else json.dumps(payload)
+    return response
+
+
+class TestSchemaValidation:
+    def test_accepts_a_valid_payload(self):
+        assert validate_classification(_valid_payload()) == []
+
+    def test_rejects_non_objects(self):
+        assert validate_classification(["bug"])
+        assert validate_classification("bug")
+
+    @pytest.mark.parametrize("missing", list(FEEDBACK_CLASSIFICATION_SCHEMA["required"]))
+    def test_rejects_missing_required_field(self, missing):
+        payload = _valid_payload()
+        payload.pop(missing)
+        errors = validate_classification(payload)
+        assert any(missing in e for e in errors)
+
+    @pytest.mark.parametrize("field,value", [
+        ("category", "wontfix"),
+        ("severity", "sev9"),
+        ("component", "telepathy"),
+        ("risk", "risk:unknown"),
+    ])
+    def test_rejects_values_outside_the_enum(self, field, value):
+        errors = validate_classification(_valid_payload(**{field: value}))
+        assert any(e.startswith(field) for e in errors)
+
+    @pytest.mark.parametrize("value", [-0.1, 1.5])
+    def test_rejects_confidence_out_of_range(self, value):
+        assert validate_classification(_valid_payload(confidence=value))
+
+    def test_rejects_wrong_types(self):
+        assert validate_classification(_valid_payload(title=42))
+        assert validate_classification(_valid_payload(duplicate_of="12"))
+        # bool is an int subclass — it must not satisfy integer/number fields.
+        assert validate_classification(_valid_payload(confidence=True))
+        assert validate_classification(_valid_payload(duplicate_of=True))
+
+    def test_accepts_null_duplicate_and_integer_duplicate(self):
+        assert validate_classification(_valid_payload(duplicate_of=None)) == []
+        assert validate_classification(_valid_payload(duplicate_of=7)) == []
+
+    def test_rejects_overlong_title(self):
+        assert validate_classification(_valid_payload(title="x" * 200))
+
+    def test_schema_enums_match_the_enums(self):
+        assert FEEDBACK_CLASSIFICATION_SCHEMA["properties"]["category"]["enum"] == \
+               [c.value for c in FeedbackCategory]
+        assert FEEDBACK_CLASSIFICATION_SCHEMA["properties"]["risk"]["enum"] == \
+               [r.value for r in FeedbackRisk]
+
+
+class TestLabelMapping:
+    def test_every_mapped_label_exists_in_the_repo(self):
+        emitted = set(CATEGORY_LABELS.values()) | set(SEVERITY_LABELS.values()) | set(RISK_LABELS.values())
+        assert emitted <= REAL_REPO_LABELS
+
+    def test_noise_has_no_category_label(self):
+        assert FeedbackCategory.NOISE not in CATEGORY_LABELS
+
+    def test_bug_maps_to_bug_and_priority(self):
+        assert labels_for(FeedbackCategory.BUG, FeedbackSeverity.CRITICAL) == \
+               ['bug', 'priority:critical']
+
+    @pytest.mark.parametrize("category,expected", [
+        (FeedbackCategory.BUG, 'bug'),
+        (FeedbackCategory.FEATURE, 'feature'),
+        (FeedbackCategory.ENHANCEMENT, 'enhancement'),
+        (FeedbackCategory.CLEANUP, 'cleanup'),
+    ])
+    def test_category_label_per_category(self, category, expected):
+        assert labels_for(category, FeedbackSeverity.LOW)[0] == expected
+
+    @pytest.mark.parametrize("severity,expected", [
+        (FeedbackSeverity.CRITICAL, 'priority:critical'),
+        (FeedbackSeverity.HIGH, 'priority:high'),
+        (FeedbackSeverity.MEDIUM, 'priority:medium'),
+        (FeedbackSeverity.LOW, 'priority:low'),
+    ])
+    def test_severity_label_per_severity(self, severity, expected):
+        assert expected in labels_for(FeedbackCategory.BUG, severity)
+
+    @pytest.mark.parametrize("risk,expected", [
+        (FeedbackRisk.PRODUCT_DECISION, 'risk:product-decision'),
+        (FeedbackRisk.LIVE_LINKEDIN, 'risk:live-linkedin'),
+        (FeedbackRisk.MIGRATION, 'risk:migration'),
+        (FeedbackRisk.SECURITY, 'risk:security'),
+    ])
+    def test_risk_label_added(self, risk, expected):
+        assert labels_for(FeedbackCategory.FEATURE, FeedbackSeverity.MEDIUM, risk)[-1] == expected
+
+    def test_no_risk_label_when_risk_is_none(self):
+        assert labels_for(FeedbackCategory.FEATURE, FeedbackSeverity.MEDIUM, FeedbackRisk.NONE) == \
+               ['feature', 'priority:medium']
+
+    def test_dropped_items_get_no_labels(self):
+        assert labels_for(FeedbackCategory.NOISE, FeedbackSeverity.LOW,
+                          FeedbackRisk.NONE, FeedbackRoute.DROP) == []
+
+    def test_questions_get_only_the_question_label(self):
+        assert labels_for(FeedbackCategory.QUESTION, FeedbackSeverity.LOW,
+                          FeedbackRisk.NONE, FeedbackRoute.FAQ) == ['question']
+
+    def test_human_triage_items_carry_needs_human(self):
+        labels = labels_for(FeedbackCategory.BUG, FeedbackSeverity.MEDIUM,
+                            FeedbackRisk.NONE, FeedbackRoute.NEEDS_HUMAN)
+        assert labels == ['bug', 'priority:medium', 'needs-human']
+
+
+class TestRouting:
+    def test_confident_bug_is_auto_worked(self):
+        assert route_for(FeedbackCategory.BUG, 0.9) == FeedbackRoute.AUTO_WORK
+
+    def test_question_goes_to_faq(self):
+        assert route_for(FeedbackCategory.QUESTION, 0.9) == FeedbackRoute.FAQ
+
+    def test_noise_is_dropped(self):
+        assert route_for(FeedbackCategory.NOISE, 0.95) == FeedbackRoute.DROP
+
+    @pytest.mark.parametrize("category", list(FeedbackCategory))
+    def test_low_confidence_always_goes_to_a_human(self, category):
+        assert route_for(category, 0.1) == FeedbackRoute.NEEDS_HUMAN
+
+    def test_threshold_is_env_tunable(self, monkeypatch):
+        monkeypatch.setenv("FEEDBACK_CLASSIFIER_MIN_CONFIDENCE", "0.95")
+        assert route_for(FeedbackCategory.BUG, 0.9) == FeedbackRoute.NEEDS_HUMAN
+        monkeypatch.setenv("FEEDBACK_CLASSIFIER_MIN_CONFIDENCE", "0.1")
+        assert route_for(FeedbackCategory.BUG, 0.9) == FeedbackRoute.AUTO_WORK
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("", 0.6), ("not-a-number", 0.6), ("0.8", 0.8), ("-1", 0.0), ("5", 1.0),
+    ])
+    def test_min_confidence_parsing(self, monkeypatch, raw, expected):
+        monkeypatch.setenv("FEEDBACK_CLASSIFIER_MIN_CONFIDENCE", raw)
+        assert min_confidence() == expected
+
+    def test_model_is_lem_medium_by_default(self, monkeypatch):
+        monkeypatch.delenv("FEEDBACK_CLASSIFIER_MODEL", raising=False)
+        assert classifier_model() == "lem-medium"
+        monkeypatch.setenv("FEEDBACK_CLASSIFIER_MODEL", "lem-simple")
+        assert classifier_model() == "lem-simple"
+
+
+class TestParsing:
+    def test_parses_a_plain_json_object(self):
+        data, errors = parse_classification(json.dumps(_valid_payload()))
+        assert errors == []
+        assert data["category"] == "bug"
+
+    def test_tolerates_fences_and_prose(self):
+        raw = "Sure! Here you go:\n```json\n" + json.dumps(_valid_payload()) + "\n```\nHope that helps."
+        data, errors = parse_classification(raw)
+        assert errors == []
+        assert data["severity"] == "high"
+
+    @pytest.mark.parametrize("raw", ["", None, "no json here", "{not json}", "[1, 2]"])
+    def test_unusable_replies_return_errors(self, raw):
+        data, errors = parse_classification(raw)
+        assert data is None
+        assert errors
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("Fix", "bug"), ("DEFECT", "bug"), ("idea", "feature"), ("Update", "enhancement"),
+        ("refactor", "cleanup"), ("support", "question"), ("praise", "noise"),
+    ])
+    def test_category_aliases_are_folded(self, raw, expected):
+        data, errors = parse_classification(json.dumps(_valid_payload(category=raw)))
+        assert errors == []
+        assert data["category"] == expected
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("P1", "high"), ("blocker", "critical"), ("Normal", "medium"), ("minor", "low"),
+        ("HIGH", "high"),
+    ])
+    def test_severity_aliases_are_folded(self, raw, expected):
+        data, _ = parse_classification(json.dumps(_valid_payload(severity=raw)))
+        assert data["severity"] == expected
+
+    @pytest.mark.parametrize("raw,expected", [
+        ("risk:security", "security"), ("privacy", "security"), ("db", "migration"),
+        ("live_linkedin", "live-linkedin"), ("policy", "product-decision"),
+        ("", "none"), (None, "none"),
+    ])
+    def test_risk_aliases_are_folded(self, raw, expected):
+        data, errors = parse_classification(json.dumps(_valid_payload(risk=raw)))
+        assert errors == []
+        assert data["risk"] == expected
+
+    def test_unknown_component_falls_back_to_other(self):
+        data, _ = parse_classification(json.dumps(_valid_payload(component="Telepathy")))
+        assert data["component"] == 'other'
+
+    def test_known_component_is_normalized(self):
+        data, _ = parse_classification(json.dumps(_valid_payload(component="Feed_Commenting")))
+        assert data["component"] == 'feed-commenting'
+
+    def test_overlong_text_is_clamped_not_rejected(self):
+        data, errors = parse_classification(json.dumps(_valid_payload(title="t" * 300,
+                                                                     summary="s" * 900)))
+        assert errors == []
+        assert len(data["title"]) == 80
+        assert len(data["summary"]) == 500
+
+    def test_confidence_is_clamped(self):
+        assert parse_classification(json.dumps(_valid_payload(confidence=1.7)))[0]["confidence"] == 1.0
+        assert parse_classification(json.dumps(_valid_payload(confidence="nope")))[0]["confidence"] == 0.0
+
+    def test_duplicate_of_must_be_a_known_candidate(self):
+        data, _ = parse_classification(json.dumps(_valid_payload(duplicate_of=99)), {12, 13})
+        assert data["duplicate_of"] is None
+        data, _ = parse_classification(json.dumps(_valid_payload(duplicate_of="13")), {12, 13})
+        assert data["duplicate_of"] == 13
+
+    def test_missing_field_is_still_an_error_after_normalization(self):
+        payload = _valid_payload()
+        payload.pop("category")
+        data, errors = parse_classification(json.dumps(payload))
+        assert data is None
+        assert errors
+
+
+class TestClassifyFeedback:
+    def test_happy_path_returns_labels_and_route(self):
+        with patch(_AI, return_value=_llm_reply(_valid_payload())) as mock_llm:
+            result = classify_feedback("Commenting only posts one comment", type_hint="bug")
+        assert result.category == FeedbackCategory.BUG
+        assert result.severity == FeedbackSeverity.HIGH
+        assert result.component == 'feed-commenting'
+        assert result.route == FeedbackRoute.AUTO_WORK
+        assert result.labels == ['bug', 'priority:high']
+        assert result.needs_human is False
+        assert mock_llm.call_count == 1
+        assert mock_llm.call_args.kwargs["model"] == "lem-medium"
+        assert mock_llm.call_args.kwargs["temperature"] == 0
+
+    def test_prompt_carries_the_schema_hint_and_candidates(self):
+        with patch(_AI, return_value=_llm_reply(_valid_payload())) as mock_llm:
+            classify_feedback("It broke", type_hint="bug",
+                              context={"route": "/dashboard", "app_version": "0.77.0",
+                                       "screenshot": "data:image/png;base64,AAAA"},
+                              duplicate_candidates=[{"id": 12, "title": "Commenting broken"}],
+                              user_id=5)
+        messages = mock_llm.call_args.kwargs["messages"]
+        system, user = messages[0]["content"], messages[1]["content"]
+        assert "duplicate_of" in system and "confidence" in system
+        assert "/dashboard" in user and "0.77.0" in user
+        # The screenshot blob must never be shipped to the classifier.
+        assert "base64" not in user
+        assert "12: Commenting broken" in user
+        assert mock_llm.call_args.kwargs["_track_user_id"] == 5
+
+    def test_question_routes_to_faq(self):
+        payload = _valid_payload(category="question", severity="low",
+                                 title="How do I change my posting time?")
+        with patch(_AI, return_value=_llm_reply(payload)):
+            result = classify_feedback("How do I change my posting time?", type_hint="other")
+        assert result.route == FeedbackRoute.FAQ
+        assert result.labels == ['question']
+
+    def test_noise_is_dropped_with_no_labels(self):
+        payload = _valid_payload(category="noise", severity="low", risk="none")
+        with patch(_AI, return_value=_llm_reply(payload)):
+            result = classify_feedback("love this tool!!", type_hint="praise")
+        assert result.route == FeedbackRoute.DROP
+        assert result.labels == []
+
+    def test_low_confidence_goes_to_human_triage(self):
+        with patch(_AI, return_value=_llm_reply(_valid_payload(confidence=0.2))):
+            result = classify_feedback("something's off", type_hint="bug")
+        assert result.route == FeedbackRoute.NEEDS_HUMAN
+        assert 'needs-human' in result.labels
+
+    def test_duplicate_is_kept_when_it_is_a_real_candidate(self):
+        payload = _valid_payload(duplicate_of=12)
+        with patch(_AI, return_value=_llm_reply(payload)):
+            result = classify_feedback("Commenting broken again",
+                                       duplicate_candidates=[{"id": 12, "body": "Commenting broken"},
+                                                             {"id": "bad", "body": "ignored"}])
+        assert result.duplicate_of == 12
+
+    def test_off_contract_answer_fails_safe_to_human(self):
+        with patch(_AI, return_value=_llm_reply("I think this is a bug, honestly.")):
+            result = classify_feedback("The DM sequence stopped", type_hint="bug")
+        assert result.route == FeedbackRoute.NEEDS_HUMAN
+        assert result.confidence == 0.0
+        assert result.errors
+        assert result.summary == "The DM sequence stopped"
+
+    def test_llm_error_fails_safe_to_human(self):
+        with patch(_AI, side_effect=RuntimeError("proxy down")):
+            result = classify_feedback("Scheduling is off by an hour", type_hint="idea")
+        assert result.route == FeedbackRoute.NEEDS_HUMAN
+        assert result.category == FeedbackCategory.FEATURE  # from the type hint
+        assert any("proxy down" in e for e in result.errors)
+
+    def test_unknown_type_hint_falls_back_to_bug(self):
+        with patch(_AI, side_effect=RuntimeError("boom")):
+            result = classify_feedback("Something happened", type_hint="wat")
+        assert result.category == FeedbackCategory.BUG
+
+    def test_explicit_hint_matching_a_category_is_used(self):
+        with patch(_AI, side_effect=RuntimeError("boom")):
+            result = classify_feedback("Please add dark mode", type_hint="feature")
+        assert result.category == FeedbackCategory.FEATURE
+
+    @pytest.mark.parametrize("body", ["", "   ", None])
+    def test_empty_body_never_calls_the_llm(self, body):
+        with patch(_AI) as mock_llm:
+            result = classify_feedback(body)
+        mock_llm.assert_not_called()
+        assert result.route == FeedbackRoute.NEEDS_HUMAN
+        assert result.errors == ["empty feedback body"]
+
+    def test_body_is_truncated_before_the_call(self):
+        with patch(_AI, return_value=_llm_reply(_valid_payload())) as mock_llm:
+            classify_feedback("x" * 9000)
+        assert mock_llm.call_args.kwargs["messages"][1]["content"].count("x") == 4000
+
+    def test_to_dict_is_serializable(self):
+        with patch(_AI, return_value=_llm_reply(_valid_payload())):
+            result = classify_feedback("Commenting broke")
+        as_dict = result.to_dict()
+        assert json.loads(json.dumps(as_dict))["route"] == 'auto_work'
+        assert as_dict["labels"] == ['bug', 'priority:high']
+        assert as_dict["component"] in COMPONENTS
+
+
+class TestClassificationDataclass:
+    def test_defaults_route_to_human(self):
+        result = FeedbackClassification(category=FeedbackCategory.BUG,
+                                        severity=FeedbackSeverity.MEDIUM,
+                                        component='other', title='t', summary='s')
+        assert result.needs_human is True
+        assert result.duplicate_of is None

--- a/tests/unit/utilities/test_feedback_classifier.py
+++ b/tests/unit/utilities/test_feedback_classifier.py
@@ -6,26 +6,6 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch
 
-from cqc_lem.utilities.feedback.classifier import (
-    CATEGORY_LABELS,
-    COMPONENTS,
-    FEEDBACK_CLASSIFICATION_SCHEMA,
-    FeedbackCategory,
-    FeedbackClassification,
-    FeedbackRisk,
-    FeedbackRoute,
-    FeedbackSeverity,
-    RISK_LABELS,
-    SEVERITY_LABELS,
-    classifier_model,
-    classify_feedback,
-    labels_for,
-    min_confidence,
-    parse_classification,
-    route_for,
-    validate_classification,
-)
-
 pytestmark = pytest.mark.unit
 
 _AI = "cqc_lem.utilities.ai.ai_helper._call_llm"
@@ -37,6 +17,18 @@ REAL_REPO_LABELS = {
     'risk:product-decision', 'risk:live-linkedin', 'risk:migration', 'risk:security',
     'needs-human',
 }
+
+# Literals so parametrization never imports cqc_lem at collection time; asserted against the real
+# schema/enums in test_required_fields_match_the_schema / test_categories_match_the_enum.
+REQUIRED_FIELDS = ["category", "severity", "component", "title", "summary", "risk",
+                   "duplicate_of", "confidence"]
+CATEGORIES = ["bug", "feature", "enhancement", "cleanup", "question", "noise"]
+
+
+def _mod():
+    """The module under test, imported inside the test (per tests.instructions.md)."""
+    from cqc_lem.utilities.feedback import classifier
+    return classifier
 
 
 def _valid_payload(**overrides) -> dict:
@@ -63,17 +55,21 @@ def _llm_reply(payload) -> MagicMock:
 
 class TestSchemaValidation:
     def test_accepts_a_valid_payload(self):
-        assert validate_classification(_valid_payload()) == []
+        assert _mod().validate_classification(_valid_payload()) == []
 
     def test_rejects_non_objects(self):
+        validate_classification = _mod().validate_classification
         assert validate_classification(["bug"])
         assert validate_classification("bug")
 
-    @pytest.mark.parametrize("missing", list(FEEDBACK_CLASSIFICATION_SCHEMA["required"]))
+    def test_required_fields_match_the_schema(self):
+        assert _mod().FEEDBACK_CLASSIFICATION_SCHEMA["required"] == REQUIRED_FIELDS
+
+    @pytest.mark.parametrize("missing", REQUIRED_FIELDS)
     def test_rejects_missing_required_field(self, missing):
         payload = _valid_payload()
         payload.pop(missing)
-        errors = validate_classification(payload)
+        errors = _mod().validate_classification(payload)
         assert any(missing in e for e in errors)
 
     @pytest.mark.parametrize("field,value", [
@@ -83,14 +79,15 @@ class TestSchemaValidation:
         ("risk", "risk:unknown"),
     ])
     def test_rejects_values_outside_the_enum(self, field, value):
-        errors = validate_classification(_valid_payload(**{field: value}))
+        errors = _mod().validate_classification(_valid_payload(**{field: value}))
         assert any(e.startswith(field) for e in errors)
 
     @pytest.mark.parametrize("value", [-0.1, 1.5])
     def test_rejects_confidence_out_of_range(self, value):
-        assert validate_classification(_valid_payload(confidence=value))
+        assert _mod().validate_classification(_valid_payload(confidence=value))
 
     def test_rejects_wrong_types(self):
+        validate_classification = _mod().validate_classification
         assert validate_classification(_valid_payload(title=42))
         assert validate_classification(_valid_payload(duplicate_of="12"))
         # bool is an int subclass — it must not satisfy integer/number fields.
@@ -98,104 +95,146 @@ class TestSchemaValidation:
         assert validate_classification(_valid_payload(duplicate_of=True))
 
     def test_accepts_null_duplicate_and_integer_duplicate(self):
+        validate_classification = _mod().validate_classification
         assert validate_classification(_valid_payload(duplicate_of=None)) == []
         assert validate_classification(_valid_payload(duplicate_of=7)) == []
 
     def test_rejects_overlong_title(self):
-        assert validate_classification(_valid_payload(title="x" * 200))
+        assert _mod().validate_classification(_valid_payload(title="x" * 200))
 
     def test_schema_enums_match_the_enums(self):
-        assert FEEDBACK_CLASSIFICATION_SCHEMA["properties"]["category"]["enum"] == \
-               [c.value for c in FeedbackCategory]
-        assert FEEDBACK_CLASSIFICATION_SCHEMA["properties"]["risk"]["enum"] == \
-               [r.value for r in FeedbackRisk]
+        classifier = _mod()
+        assert classifier.FEEDBACK_CLASSIFICATION_SCHEMA["properties"]["category"]["enum"] == \
+               [c.value for c in classifier.FeedbackCategory]
+        assert classifier.FEEDBACK_CLASSIFICATION_SCHEMA["properties"]["risk"]["enum"] == \
+               [r.value for r in classifier.FeedbackRisk]
+
+    def test_categories_match_the_enum(self):
+        assert [c.value for c in _mod().FeedbackCategory] == CATEGORIES
 
 
 class TestLabelMapping:
     def test_every_mapped_label_exists_in_the_repo(self):
-        emitted = set(CATEGORY_LABELS.values()) | set(SEVERITY_LABELS.values()) | set(RISK_LABELS.values())
+        classifier = _mod()
+        emitted = (set(classifier.CATEGORY_LABELS.values()) | set(classifier.SEVERITY_LABELS.values())
+                   | set(classifier.RISK_LABELS.values()))
         assert emitted <= REAL_REPO_LABELS
 
     def test_noise_has_no_category_label(self):
-        assert FeedbackCategory.NOISE not in CATEGORY_LABELS
+        classifier = _mod()
+        assert classifier.FeedbackCategory.NOISE not in classifier.CATEGORY_LABELS
 
     def test_bug_maps_to_bug_and_priority(self):
-        assert labels_for(FeedbackCategory.BUG, FeedbackSeverity.CRITICAL) == \
+        classifier = _mod()
+        assert classifier.labels_for(classifier.FeedbackCategory.BUG,
+                                     classifier.FeedbackSeverity.CRITICAL) == \
                ['bug', 'priority:critical']
 
     @pytest.mark.parametrize("category,expected", [
-        (FeedbackCategory.BUG, 'bug'),
-        (FeedbackCategory.FEATURE, 'feature'),
-        (FeedbackCategory.ENHANCEMENT, 'enhancement'),
-        (FeedbackCategory.CLEANUP, 'cleanup'),
+        ("bug", 'bug'),
+        ("feature", 'feature'),
+        ("enhancement", 'enhancement'),
+        ("cleanup", 'cleanup'),
     ])
     def test_category_label_per_category(self, category, expected):
-        assert labels_for(category, FeedbackSeverity.LOW)[0] == expected
+        classifier = _mod()
+        labels = classifier.labels_for(classifier.FeedbackCategory(category),
+                                       classifier.FeedbackSeverity.LOW)
+        assert labels[0] == expected
 
     @pytest.mark.parametrize("severity,expected", [
-        (FeedbackSeverity.CRITICAL, 'priority:critical'),
-        (FeedbackSeverity.HIGH, 'priority:high'),
-        (FeedbackSeverity.MEDIUM, 'priority:medium'),
-        (FeedbackSeverity.LOW, 'priority:low'),
+        ("critical", 'priority:critical'),
+        ("high", 'priority:high'),
+        ("medium", 'priority:medium'),
+        ("low", 'priority:low'),
     ])
     def test_severity_label_per_severity(self, severity, expected):
-        assert expected in labels_for(FeedbackCategory.BUG, severity)
+        classifier = _mod()
+        assert expected in classifier.labels_for(classifier.FeedbackCategory.BUG,
+                                                 classifier.FeedbackSeverity(severity))
 
     @pytest.mark.parametrize("risk,expected", [
-        (FeedbackRisk.PRODUCT_DECISION, 'risk:product-decision'),
-        (FeedbackRisk.LIVE_LINKEDIN, 'risk:live-linkedin'),
-        (FeedbackRisk.MIGRATION, 'risk:migration'),
-        (FeedbackRisk.SECURITY, 'risk:security'),
+        ("product-decision", 'risk:product-decision'),
+        ("live-linkedin", 'risk:live-linkedin'),
+        ("migration", 'risk:migration'),
+        ("security", 'risk:security'),
     ])
     def test_risk_label_added(self, risk, expected):
-        assert labels_for(FeedbackCategory.FEATURE, FeedbackSeverity.MEDIUM, risk)[-1] == expected
+        classifier = _mod()
+        labels = classifier.labels_for(classifier.FeedbackCategory.FEATURE,
+                                       classifier.FeedbackSeverity.MEDIUM,
+                                       classifier.FeedbackRisk(risk))
+        assert labels[-1] == expected
 
     def test_no_risk_label_when_risk_is_none(self):
-        assert labels_for(FeedbackCategory.FEATURE, FeedbackSeverity.MEDIUM, FeedbackRisk.NONE) == \
-               ['feature', 'priority:medium']
+        classifier = _mod()
+        assert classifier.labels_for(classifier.FeedbackCategory.FEATURE,
+                                     classifier.FeedbackSeverity.MEDIUM,
+                                     classifier.FeedbackRisk.NONE) == ['feature', 'priority:medium']
 
     def test_dropped_items_get_no_labels(self):
-        assert labels_for(FeedbackCategory.NOISE, FeedbackSeverity.LOW,
-                          FeedbackRisk.NONE, FeedbackRoute.DROP) == []
+        classifier = _mod()
+        assert classifier.labels_for(classifier.FeedbackCategory.NOISE,
+                                     classifier.FeedbackSeverity.LOW,
+                                     classifier.FeedbackRisk.NONE,
+                                     classifier.FeedbackRoute.DROP) == []
 
     def test_questions_get_only_the_question_label(self):
-        assert labels_for(FeedbackCategory.QUESTION, FeedbackSeverity.LOW,
-                          FeedbackRisk.NONE, FeedbackRoute.FAQ) == ['question']
+        classifier = _mod()
+        assert classifier.labels_for(classifier.FeedbackCategory.QUESTION,
+                                     classifier.FeedbackSeverity.LOW,
+                                     classifier.FeedbackRisk.NONE,
+                                     classifier.FeedbackRoute.FAQ) == ['question']
 
     def test_human_triage_items_carry_needs_human(self):
-        labels = labels_for(FeedbackCategory.BUG, FeedbackSeverity.MEDIUM,
-                            FeedbackRisk.NONE, FeedbackRoute.NEEDS_HUMAN)
+        classifier = _mod()
+        labels = classifier.labels_for(classifier.FeedbackCategory.BUG,
+                                       classifier.FeedbackSeverity.MEDIUM,
+                                       classifier.FeedbackRisk.NONE,
+                                       classifier.FeedbackRoute.NEEDS_HUMAN)
         assert labels == ['bug', 'priority:medium', 'needs-human']
 
 
 class TestRouting:
     def test_confident_bug_is_auto_worked(self):
-        assert route_for(FeedbackCategory.BUG, 0.9) == FeedbackRoute.AUTO_WORK
+        classifier = _mod()
+        assert classifier.route_for(classifier.FeedbackCategory.BUG, 0.9) == \
+               classifier.FeedbackRoute.AUTO_WORK
 
     def test_question_goes_to_faq(self):
-        assert route_for(FeedbackCategory.QUESTION, 0.9) == FeedbackRoute.FAQ
+        classifier = _mod()
+        assert classifier.route_for(classifier.FeedbackCategory.QUESTION, 0.9) == \
+               classifier.FeedbackRoute.FAQ
 
     def test_noise_is_dropped(self):
-        assert route_for(FeedbackCategory.NOISE, 0.95) == FeedbackRoute.DROP
+        classifier = _mod()
+        assert classifier.route_for(classifier.FeedbackCategory.NOISE, 0.95) == \
+               classifier.FeedbackRoute.DROP
 
-    @pytest.mark.parametrize("category", list(FeedbackCategory))
+    @pytest.mark.parametrize("category", CATEGORIES)
     def test_low_confidence_always_goes_to_a_human(self, category):
-        assert route_for(category, 0.1) == FeedbackRoute.NEEDS_HUMAN
+        classifier = _mod()
+        assert classifier.route_for(classifier.FeedbackCategory(category), 0.1) == \
+               classifier.FeedbackRoute.NEEDS_HUMAN
 
     def test_threshold_is_env_tunable(self, monkeypatch):
+        classifier = _mod()
         monkeypatch.setenv("FEEDBACK_CLASSIFIER_MIN_CONFIDENCE", "0.95")
-        assert route_for(FeedbackCategory.BUG, 0.9) == FeedbackRoute.NEEDS_HUMAN
+        assert classifier.route_for(classifier.FeedbackCategory.BUG, 0.9) == \
+               classifier.FeedbackRoute.NEEDS_HUMAN
         monkeypatch.setenv("FEEDBACK_CLASSIFIER_MIN_CONFIDENCE", "0.1")
-        assert route_for(FeedbackCategory.BUG, 0.9) == FeedbackRoute.AUTO_WORK
+        assert classifier.route_for(classifier.FeedbackCategory.BUG, 0.9) == \
+               classifier.FeedbackRoute.AUTO_WORK
 
     @pytest.mark.parametrize("raw,expected", [
         ("", 0.6), ("not-a-number", 0.6), ("0.8", 0.8), ("-1", 0.0), ("5", 1.0),
     ])
     def test_min_confidence_parsing(self, monkeypatch, raw, expected):
         monkeypatch.setenv("FEEDBACK_CLASSIFIER_MIN_CONFIDENCE", raw)
-        assert min_confidence() == expected
+        assert _mod().min_confidence() == expected
 
     def test_model_is_lem_medium_by_default(self, monkeypatch):
+        classifier_model = _mod().classifier_model
         monkeypatch.delenv("FEEDBACK_CLASSIFIER_MODEL", raising=False)
         assert classifier_model() == "lem-medium"
         monkeypatch.setenv("FEEDBACK_CLASSIFIER_MODEL", "lem-simple")
@@ -204,19 +243,49 @@ class TestRouting:
 
 class TestParsing:
     def test_parses_a_plain_json_object(self):
-        data, errors = parse_classification(json.dumps(_valid_payload()))
+        data, errors = _mod().parse_classification(json.dumps(_valid_payload()))
         assert errors == []
         assert data["category"] == "bug"
 
     def test_tolerates_fences_and_prose(self):
         raw = "Sure! Here you go:\n```json\n" + json.dumps(_valid_payload()) + "\n```\nHope that helps."
-        data, errors = parse_classification(raw)
+        data, errors = _mod().parse_classification(raw)
         assert errors == []
         assert data["severity"] == "high"
 
+    def test_trailing_prose_with_braces_does_not_break_extraction(self):
+        raw = json.dumps(_valid_payload()) + "\n(note: the {component} field is a guess}"
+        data, errors = _mod().parse_classification(raw)
+        assert errors == []
+        assert data["component"] == 'feed-commenting'
+
+    def test_first_of_two_objects_wins(self):
+        raw = json.dumps(_valid_payload()) + "\n" + json.dumps(_valid_payload(severity="low"))
+        data, errors = _mod().parse_classification(raw)
+        assert errors == []
+        assert data["severity"] == "high"
+
+    def test_skips_a_leading_non_json_brace_block(self):
+        raw = "Reasoning: {the user says commenting is broken}\n" + json.dumps(_valid_payload())
+        data, errors = _mod().parse_classification(raw)
+        assert errors == []
+        assert data["category"] == "bug"
+
+    def test_braces_inside_string_values_are_not_counted(self):
+        payload = _valid_payload(summary="The UI shows a literal {placeholder} instead of my name")
+        data, errors = _mod().parse_classification(json.dumps(payload))
+        assert errors == []
+        assert data["summary"].endswith("instead of my name")
+
+    def test_unterminated_object_is_an_error(self):
+        raw = '{"category": "bug", "severity": "high"'
+        data, errors = _mod().parse_classification(raw)
+        assert data is None
+        assert errors == ["no JSON object in the response"]
+
     @pytest.mark.parametrize("raw", ["", None, "no json here", "{not json}", "[1, 2]"])
     def test_unusable_replies_return_errors(self, raw):
-        data, errors = parse_classification(raw)
+        data, errors = _mod().parse_classification(raw)
         assert data is None
         assert errors
 
@@ -225,7 +294,7 @@ class TestParsing:
         ("refactor", "cleanup"), ("support", "question"), ("praise", "noise"),
     ])
     def test_category_aliases_are_folded(self, raw, expected):
-        data, errors = parse_classification(json.dumps(_valid_payload(category=raw)))
+        data, errors = _mod().parse_classification(json.dumps(_valid_payload(category=raw)))
         assert errors == []
         assert data["category"] == expected
 
@@ -234,7 +303,7 @@ class TestParsing:
         ("HIGH", "high"),
     ])
     def test_severity_aliases_are_folded(self, raw, expected):
-        data, _ = parse_classification(json.dumps(_valid_payload(severity=raw)))
+        data, _ = _mod().parse_classification(json.dumps(_valid_payload(severity=raw)))
         assert data["severity"] == expected
 
     @pytest.mark.parametrize("raw,expected", [
@@ -243,30 +312,32 @@ class TestParsing:
         ("", "none"), (None, "none"),
     ])
     def test_risk_aliases_are_folded(self, raw, expected):
-        data, errors = parse_classification(json.dumps(_valid_payload(risk=raw)))
+        data, errors = _mod().parse_classification(json.dumps(_valid_payload(risk=raw)))
         assert errors == []
         assert data["risk"] == expected
 
     def test_unknown_component_falls_back_to_other(self):
-        data, _ = parse_classification(json.dumps(_valid_payload(component="Telepathy")))
+        data, _ = _mod().parse_classification(json.dumps(_valid_payload(component="Telepathy")))
         assert data["component"] == 'other'
 
     def test_known_component_is_normalized(self):
-        data, _ = parse_classification(json.dumps(_valid_payload(component="Feed_Commenting")))
+        data, _ = _mod().parse_classification(json.dumps(_valid_payload(component="Feed_Commenting")))
         assert data["component"] == 'feed-commenting'
 
     def test_overlong_text_is_clamped_not_rejected(self):
-        data, errors = parse_classification(json.dumps(_valid_payload(title="t" * 300,
-                                                                     summary="s" * 900)))
+        data, errors = _mod().parse_classification(json.dumps(_valid_payload(title="t" * 300,
+                                                                            summary="s" * 900)))
         assert errors == []
         assert len(data["title"]) == 80
         assert len(data["summary"]) == 500
 
     def test_confidence_is_clamped(self):
+        parse_classification = _mod().parse_classification
         assert parse_classification(json.dumps(_valid_payload(confidence=1.7)))[0]["confidence"] == 1.0
         assert parse_classification(json.dumps(_valid_payload(confidence="nope")))[0]["confidence"] == 0.0
 
     def test_duplicate_of_must_be_a_known_candidate(self):
+        parse_classification = _mod().parse_classification
         data, _ = parse_classification(json.dumps(_valid_payload(duplicate_of=99)), {12, 13})
         assert data["duplicate_of"] is None
         data, _ = parse_classification(json.dumps(_valid_payload(duplicate_of="13")), {12, 13})
@@ -275,19 +346,21 @@ class TestParsing:
     def test_missing_field_is_still_an_error_after_normalization(self):
         payload = _valid_payload()
         payload.pop("category")
-        data, errors = parse_classification(json.dumps(payload))
+        data, errors = _mod().parse_classification(json.dumps(payload))
         assert data is None
         assert errors
 
 
 class TestClassifyFeedback:
     def test_happy_path_returns_labels_and_route(self):
+        classifier = _mod()
         with patch(_AI, return_value=_llm_reply(_valid_payload())) as mock_llm:
-            result = classify_feedback("Commenting only posts one comment", type_hint="bug")
-        assert result.category == FeedbackCategory.BUG
-        assert result.severity == FeedbackSeverity.HIGH
+            result = classifier.classify_feedback("Commenting only posts one comment",
+                                                  type_hint="bug")
+        assert result.category == classifier.FeedbackCategory.BUG
+        assert result.severity == classifier.FeedbackSeverity.HIGH
         assert result.component == 'feed-commenting'
-        assert result.route == FeedbackRoute.AUTO_WORK
+        assert result.route == classifier.FeedbackRoute.AUTO_WORK
         assert result.labels == ['bug', 'priority:high']
         assert result.needs_human is False
         assert mock_llm.call_count == 1
@@ -295,6 +368,7 @@ class TestClassifyFeedback:
         assert mock_llm.call_args.kwargs["temperature"] == 0
 
     def test_prompt_carries_the_schema_hint_and_candidates(self):
+        classify_feedback = _mod().classify_feedback
         with patch(_AI, return_value=_llm_reply(_valid_payload())) as mock_llm:
             classify_feedback("It broke", type_hint="bug",
                               context={"route": "/dashboard", "app_version": "0.77.0",
@@ -311,27 +385,32 @@ class TestClassifyFeedback:
         assert mock_llm.call_args.kwargs["_track_user_id"] == 5
 
     def test_question_routes_to_faq(self):
+        classifier = _mod()
         payload = _valid_payload(category="question", severity="low",
                                  title="How do I change my posting time?")
         with patch(_AI, return_value=_llm_reply(payload)):
-            result = classify_feedback("How do I change my posting time?", type_hint="other")
-        assert result.route == FeedbackRoute.FAQ
+            result = classifier.classify_feedback("How do I change my posting time?",
+                                                  type_hint="other")
+        assert result.route == classifier.FeedbackRoute.FAQ
         assert result.labels == ['question']
 
     def test_noise_is_dropped_with_no_labels(self):
+        classifier = _mod()
         payload = _valid_payload(category="noise", severity="low", risk="none")
         with patch(_AI, return_value=_llm_reply(payload)):
-            result = classify_feedback("love this tool!!", type_hint="praise")
-        assert result.route == FeedbackRoute.DROP
+            result = classifier.classify_feedback("love this tool!!", type_hint="praise")
+        assert result.route == classifier.FeedbackRoute.DROP
         assert result.labels == []
 
     def test_low_confidence_goes_to_human_triage(self):
+        classifier = _mod()
         with patch(_AI, return_value=_llm_reply(_valid_payload(confidence=0.2))):
-            result = classify_feedback("something's off", type_hint="bug")
-        assert result.route == FeedbackRoute.NEEDS_HUMAN
+            result = classifier.classify_feedback("something's off", type_hint="bug")
+        assert result.route == classifier.FeedbackRoute.NEEDS_HUMAN
         assert 'needs-human' in result.labels
 
     def test_duplicate_is_kept_when_it_is_a_real_candidate(self):
+        classify_feedback = _mod().classify_feedback
         payload = _valid_payload(duplicate_of=12)
         with patch(_AI, return_value=_llm_reply(payload)):
             result = classify_feedback("Commenting broken again",
@@ -340,56 +419,64 @@ class TestClassifyFeedback:
         assert result.duplicate_of == 12
 
     def test_off_contract_answer_fails_safe_to_human(self):
+        classifier = _mod()
         with patch(_AI, return_value=_llm_reply("I think this is a bug, honestly.")):
-            result = classify_feedback("The DM sequence stopped", type_hint="bug")
-        assert result.route == FeedbackRoute.NEEDS_HUMAN
+            result = classifier.classify_feedback("The DM sequence stopped", type_hint="bug")
+        assert result.route == classifier.FeedbackRoute.NEEDS_HUMAN
         assert result.confidence == 0.0
         assert result.errors
         assert result.summary == "The DM sequence stopped"
 
     def test_llm_error_fails_safe_to_human(self):
+        classifier = _mod()
         with patch(_AI, side_effect=RuntimeError("proxy down")):
-            result = classify_feedback("Scheduling is off by an hour", type_hint="idea")
-        assert result.route == FeedbackRoute.NEEDS_HUMAN
-        assert result.category == FeedbackCategory.FEATURE  # from the type hint
+            result = classifier.classify_feedback("Scheduling is off by an hour", type_hint="idea")
+        assert result.route == classifier.FeedbackRoute.NEEDS_HUMAN
+        assert result.category == classifier.FeedbackCategory.FEATURE  # from the type hint
         assert any("proxy down" in e for e in result.errors)
 
     def test_unknown_type_hint_falls_back_to_bug(self):
+        classifier = _mod()
         with patch(_AI, side_effect=RuntimeError("boom")):
-            result = classify_feedback("Something happened", type_hint="wat")
-        assert result.category == FeedbackCategory.BUG
+            result = classifier.classify_feedback("Something happened", type_hint="wat")
+        assert result.category == classifier.FeedbackCategory.BUG
 
     def test_explicit_hint_matching_a_category_is_used(self):
+        classifier = _mod()
         with patch(_AI, side_effect=RuntimeError("boom")):
-            result = classify_feedback("Please add dark mode", type_hint="feature")
-        assert result.category == FeedbackCategory.FEATURE
+            result = classifier.classify_feedback("Please add dark mode", type_hint="feature")
+        assert result.category == classifier.FeedbackCategory.FEATURE
 
     @pytest.mark.parametrize("body", ["", "   ", None])
     def test_empty_body_never_calls_the_llm(self, body):
+        classifier = _mod()
         with patch(_AI) as mock_llm:
-            result = classify_feedback(body)
+            result = classifier.classify_feedback(body)
         mock_llm.assert_not_called()
-        assert result.route == FeedbackRoute.NEEDS_HUMAN
+        assert result.route == classifier.FeedbackRoute.NEEDS_HUMAN
         assert result.errors == ["empty feedback body"]
 
     def test_body_is_truncated_before_the_call(self):
+        classify_feedback = _mod().classify_feedback
         with patch(_AI, return_value=_llm_reply(_valid_payload())) as mock_llm:
             classify_feedback("x" * 9000)
         assert mock_llm.call_args.kwargs["messages"][1]["content"].count("x") == 4000
 
     def test_to_dict_is_serializable(self):
+        classifier = _mod()
         with patch(_AI, return_value=_llm_reply(_valid_payload())):
-            result = classify_feedback("Commenting broke")
+            result = classifier.classify_feedback("Commenting broke")
         as_dict = result.to_dict()
         assert json.loads(json.dumps(as_dict))["route"] == 'auto_work'
         assert as_dict["labels"] == ['bug', 'priority:high']
-        assert as_dict["component"] in COMPONENTS
+        assert as_dict["component"] in classifier.COMPONENTS
 
 
 class TestClassificationDataclass:
     def test_defaults_route_to_human(self):
-        result = FeedbackClassification(category=FeedbackCategory.BUG,
-                                        severity=FeedbackSeverity.MEDIUM,
-                                        component='other', title='t', summary='s')
+        classifier = _mod()
+        result = classifier.FeedbackClassification(category=classifier.FeedbackCategory.BUG,
+                                                   severity=classifier.FeedbackSeverity.MEDIUM,
+                                                   component='other', title='t', summary='s')
         assert result.needs_human is True
         assert result.duplicate_of is None


### PR DESCRIPTION
## What & why
Stage 2 of the feedback→auto-work loop (after #496 captures raw feedback): classify each item with **zero human triage**.

`src/cqc_lem/utilities/feedback/classifier.py` makes **one `lem-medium` call** (via `ai_helper._call_llm`, so tokens/latency/cost land in PostHog with every other LLM call) and returns strict JSON:
`{category, severity, component, title, summary, risk, duplicate_of, confidence}`.

Deliberate split — the expensive half is mockable, the decision half is pure:
- `classify_feedback()` — the LLM call + strict parsing.
- `labels_for()` / `route_for()` — pure, deterministic. **The model never names a GitHub label**; it only picks taxonomy values, which map onto labels that actually exist in this repo.

**Label mapping** (all verified against `gh label list`):
| taxonomy | label |
|---|---|
| `bug` / `feature` / `enhancement` / `cleanup` / `question` | `bug` / `feature` / `enhancement` / `cleanup` / `question` |
| severity `critical`/`high`/`medium`/`low` | `priority:critical` … `priority:low` |
| risk `product-decision`/`live-linkedin`/`migration`/`security` | `risk:*` (none → no label) |

**Routing:** `question` → FAQ service (only the `question` label, never a prioritized work item) · `noise` → drop (no labels) · low confidence → human triage queue (`needs-human`) · everything else → auto-work.

**Fails SAFE — not open, not closed.** An empty body, a failed call, or an off-contract answer all become a confidence-0.0 result routed to `NEEDS_HUMAN`. Real feedback is never silently dropped by a classifier hiccup; only an explicit, confident `noise` verdict drops.

Other hardening:
- `FEEDBACK_CLASSIFICATION_SCHEMA` is handed to the model verbatim **and** enforced on the way back by `validate_classification()` (a ~20-line validator for the JSON Schema subset used — no new runtime dependency), so prompt and acceptance can't drift.
- Normalization folds the aliases models actually emit (`Fix`, `P1`, `DB`, `risk:security`, `Feed_Commenting`) and clamps `title`/`summary` **before** validation; `component` is a closed menu so the later clustering step can bucket on it.
- A `duplicate_of` id that wasn't in the supplied candidate list is discarded — an invented id would merge unrelated reports.
- The screenshot blob in the captured context is never shipped to the classifier (asserted in tests).

Env: `FEEDBACK_CLASSIFIER_MODEL` (default `lem-medium`), `FEEDBACK_CLASSIFIER_MIN_CONFIDENCE` (default `0.6`), both read at call time.

## Testing
- `tests/unit/utilities/test_feedback_classifier.py` — 103 tests, **100% coverage** of the new module: schema validation (incl. `bool` not satisfying integer/number), alias folding, the full label matrix asserted against the real repo label set, routing thresholds + env tuning, and the mocked-client paths (happy, off-contract, exception, empty body, truncation).
- `poetry run pytest tests/unit -q` → **4167 passed** locally.
- No DB, API, or migration changes.

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)