### PR TITLE
feat(feedback): auto-file GitHub issues from classified feedback with dedup/clustering (closes #498)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -453,3 +453,23 @@ STREAMLIT_PORT=8501
 # Optional descriptive User-Agent for OpenStreetMap Nominatim geocoding (Login Location
 # city/state lookup). Nominatim policy requires a UA; a sensible default is used if unset.
 NOMINATIM_USER_AGENT=LinkedInEngagementManager/1.0 (+https://lem.christopherqueenconsulting.com)
+
+# --- Feedback → auto-work loop (issues #497/#498) ---
+# Stage 2 classifier: model alias and the confidence floor below which an item goes to human triage.
+FEEDBACK_CLASSIFIER_MODEL=lem-medium
+FEEDBACK_CLASSIFIER_MIN_CONFIDENCE=0.6
+# Stage 3 auto-filer. With NO token set nothing is ever filed — this is the kill switch. Use a
+# fine-grained PAT with Issues: read/write on the repo below (never a broad token).
+FEEDBACK_GITHUB_TOKEN=
+FEEDBACK_GITHUB_REPO=christopherqueenconsulting/linkedin_engagement_manager
+# Who risky/held auto-filed issues are assigned to.
+FEEDBACK_ISSUE_ASSIGNEE=gitchrisqueen
+# Embedding alias used for dedup. Unavailable -> similarity falls back to token overlap.
+FEEDBACK_EMBEDDING_MODEL=lem-embedding
+# Similarity at/above which a new report is the SAME problem as an open cluster (+1 the existing
+# issue instead of filing). 0.82 catches rewordings without merging two distinct bugs.
+FEEDBACK_DUPLICATE_SIMILARITY=0.82
+# Distinct reporters a FEATURE cluster needs before it may carry agent:ready. Bugs auto-file at 1.
+FEEDBACK_FEATURE_DEMAND_MIN=2
+# Abuse guard: how many of ONE user's reports may reach GitHub per 24h.
+FEEDBACK_MAX_ISSUES_PER_USER_PER_DAY=3

--- a/.litellm/config.yaml
+++ b/.litellm/config.yaml
@@ -86,6 +86,14 @@ model_list:
       model: openai/dall-e-3
       api_key: os.environ/OPENAI_API_KEY
 
+  # ── EMBEDDING: cheap vectors for feedback dedup/clustering (issue #498) ──────
+  # No Ollama Cloud embedding equivalent; text-embedding-3-small is the cheapest useful option.
+  # Callers MUST tolerate this being unavailable — feedback dedup falls back to token overlap.
+  - model_name: lem-embedding
+    litellm_params:
+      model: openai/text-embedding-3-small
+      api_key: os.environ/OPENAI_API_KEY
+
   # ── ROUTER: auto-routes by prompt complexity via LEMComplexityRouter hook ─────
   - model_name: lem-router
     litellm_params:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,7 @@ response = client.chat.completions.create(model="lem-simple", messages=[...])
 | `lem-medium` | Balanced: comments, post refinement, blog summaries |
 | `lem-complex` | Long-form: thought leadership, personal story, industry news |
 | `lem-image` | Image generation (DALL-E 3) |
+| `lem-embedding` | Embeddings for feedback dedup/clustering (`client.embeddings.create`) |
 | `lem-router` | Auto-routes by prompt complexity via `LEMComplexityRouter` |
 
 See `ai_helper.py` for the per-function model assignment.

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -206,6 +206,18 @@ app.conf.update(
             # Sunday night's stats scrape, so cohort engagement lift covers the full week.
             'schedule': crontab(hour='12', minute='0', day_of_week='monday')
         },
+        'file-feedback-issues': {
+            'task': 'cqc_lem.app.run_scheduler.auto_file_feedback_issues',
+            # Every 30 min — captured feedback becomes a pipeline-ready issue the same hour it lands
+            # (issue #498). Deduped against open clusters, so a burst of the same report is one issue.
+            'schedule': crontab(minute='*/30')
+        },
+        'recluster-feedback': {
+            'task': 'cqc_lem.app.run_scheduler.auto_recluster_feedback',
+            # Nightly 2:45 AM — regroups the backlog (embedding backfill + late duplicates) between
+            # the 2:00 stale-invite clean-up and the 3:00 stale-profile pass. Files nothing.
+            'schedule': crontab(hour='2', minute='45')
+        },
         'daily-cost-alerts': {
             'task': 'cqc_lem.app.run_scheduler.auto_daily_cost_alerts',
             # Daily 13:00 UTC — scores YESTERDAY (the last complete UTC day), after the 6:00 Stripe

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1168,5 +1168,29 @@ def auto_daily_cost_alerts(self, days: int = 7):
             f"(emailed={result['emailed']}, tracked={result['tracked']})")
 
 
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True})
+def auto_file_feedback_issues(self, limit: int = 25):
+    """Drain the captured-feedback queue into the work pipeline (issue #498, plan §B.2/B.3): classify
+    each new report, dedup it against the open clusters (+1 the existing issue) and open ONE
+    `MODE=start`-shaped issue per genuinely new problem. QueueOnce so two beat ticks can never file
+    the same report twice."""
+    from cqc_lem.utilities.feedback.issue_service import process_new_feedback
+
+    result = process_new_feedback(limit=limit)
+    return f"Feedback filing: {result['processed']} row(s) — {result['counts'] or 'nothing to do'}"
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True})
+def auto_recluster_feedback(self, limit: int = 200):
+    """Nightly reclustering of the feedback backlog (issue #498, plan §B.3): backfill missing
+    embeddings and attach leftover/untriaged reports to the open cluster they now match, bumping that
+    issue's demand. Files nothing — that stays with `auto_file_feedback_issues`."""
+    from cqc_lem.utilities.feedback.issue_service import recluster_feedback
+
+    result = recluster_feedback(limit=limit)
+    return (f"Feedback recluster: {result['scanned']} scanned, {result['attached']} attached to "
+            f"{result['clusters']} open cluster(s), {result['embedded']} embedding(s) backfilled")
+
+
 if __name__ == "__main__":
     print("Process finished")

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -6370,3 +6370,142 @@ def insert_feedback(body: str, user_id: int = None,
     finally:
         cursor.close()
         connection.close()
+
+
+# Clustering convention (issue #498): a cluster is identified by the `feedback.id` of its SEED row —
+# the first report that got an issue filed. The seed carries `cluster_id = id`; every later duplicate
+# copies that cluster_id and the seed's github_issue_number. No extra table, so "one recurring
+# problem = one issue" is a self-join instead of a schema change.
+_FEEDBACK_COLUMNS = ("id, user_id, source, type_hint, body, context_json, embedding, cluster_id, "
+                     "github_issue_number, status, sentiment, created_at")
+
+
+def get_feedback_by_id(feedback_id: int) -> Optional[dict]:
+    """One feedback row, or None when it does not exist (issue #498)."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(f"SELECT {_FEEDBACK_COLUMNS} FROM feedback WHERE id=%s", (feedback_id,))
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        log_error(f"Could not fetch feedback {feedback_id}", exc=err)
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_unprocessed_feedback(limit: int = 25, statuses: tuple = (FeedbackStatus.NEW,)) -> list:
+    """Captured-but-unclustered feedback, oldest first so the queue drains FIFO (issue #498).
+
+    Defaults to `new` only — the auto-filer must not re-classify (and re-pay for) rows it already
+    parked in `triaged`. The nightly reclustering pass widens `statuses` to reconsider those."""
+    wanted = [str(s) for s in (statuses or ()) if str(s) in tuple(FeedbackStatus)]
+    if not wanted:
+        return []
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            f"SELECT {_FEEDBACK_COLUMNS} FROM feedback "
+            f"WHERE status IN ({','.join(['%s'] * len(wanted))}) AND cluster_id IS NULL "
+            "ORDER BY created_at ASC, id ASC LIMIT %s",
+            (*wanted, int(limit)))
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        log_error("Could not fetch unprocessed feedback", exc=err)
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_open_feedback_clusters(limit: int = 100) -> list:
+    """The open clusters an incoming report can be deduped against (issue #498).
+
+    One row per cluster: the seed's body/embedding (what similarity is measured against), the GitHub
+    issue it was filed as, plus `item_count` and `reporter_count` (DISTINCT non-null user_id) — the
+    demand signal that decides whether a *feature* cluster is allowed to auto-work."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT s.id AS cluster_id, s.body AS body, s.embedding AS embedding, "
+            "       s.github_issue_number AS github_issue_number, s.type_hint AS type_hint, "
+            "       COUNT(m.id) AS item_count, "
+            "       COUNT(DISTINCT m.user_id) AS reporter_count, "
+            "       MAX(m.created_at) AS last_seen_at "
+            "FROM feedback s JOIN feedback m ON m.cluster_id = s.cluster_id "
+            "WHERE s.cluster_id = s.id AND s.status IN ('clustered','issue_created') "
+            "GROUP BY s.id, s.body, s.embedding, s.github_issue_number, s.type_hint "
+            "ORDER BY last_seen_at DESC LIMIT %s",
+            (int(limit),))
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        log_error("Could not fetch open feedback clusters", exc=err)
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def count_feedback_filed_by_user(user_id: int, hours: int = 24) -> int:
+    """How many of this user's reports reached GitHub in the last `hours` — the abuse guard's counter
+    (issue #498). Anonymous feedback (NULL user_id) is not attributable, so it is never counted."""
+    if user_id is None:
+        return 0
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM feedback WHERE user_id=%s AND github_issue_number IS NOT NULL "
+            "AND created_at >= (NOW() - INTERVAL %s HOUR)",
+            (user_id, int(hours)))
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+    except mysql.connector.Error as err:
+        log_error("Could not count filed feedback for user", exc=err, user_id=user_id)
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_feedback_triage(feedback_id: int, status: "FeedbackStatus" = None,
+                           cluster_id: int = None, github_issue_number: int = None,
+                           embedding: list = None, sentiment: str = None) -> bool:
+    """Stamp the auto-triage result back onto a feedback row (issue #498). Only the arguments you
+    pass are written, so the filer can save an embedding on one pass and the cluster/issue on the
+    next without clobbering anything."""
+    updates: list = []
+    params: list = []
+    if status is not None:
+        updates.append("status=%s")
+        params.append(str(status))
+    if cluster_id is not None:
+        updates.append("cluster_id=%s")
+        params.append(int(cluster_id))
+    if github_issue_number is not None:
+        updates.append("github_issue_number=%s")
+        params.append(int(github_issue_number))
+    if embedding is not None:
+        updates.append("embedding=%s")
+        params.append(json.dumps(embedding))
+    if sentiment is not None:
+        updates.append("sentiment=%s")
+        params.append(str(sentiment)[:16])
+    if not updates:
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        params.append(feedback_id)
+        cursor.execute(f"UPDATE feedback SET {', '.join(updates)} WHERE id=%s", tuple(params))
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        log_error(f"Could not update feedback triage for {feedback_id}", exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()

--- a/src/cqc_lem/utilities/feedback/issue_service.py
+++ b/src/cqc_lem/utilities/feedback/issue_service.py
@@ -391,7 +391,7 @@ def build_issue_body(classification: FeedbackClassification, feedback_id: Option
     """The `MODE=start` body: Why / Scope / Files / Acceptance, plus the provenance the pipeline and
     a human both need. Only the classifier's factual summary is included — never the raw report."""
     ready = is_agent_ready(classification, reporter_count)
-    demand = (f"Reported by {max(1, int(reporter_count or 0))} distinct user(s) across "
+    demand = (f"Reported by {max(0, int(reporter_count or 0))} distinct user(s) across "
               f"{max(1, int(item_count or 0))} feedback item(s).")
     provenance = (f"Auto-filed from in-app feedback"
                   f"{f' #{feedback_id}' if feedback_id else ''} by the feedback→auto-work loop "
@@ -475,7 +475,7 @@ def build_duplicate_comment(classification: FeedbackClassification,
         "",
         f"New detail: {classification.summary or '(none)'}",
         "",
-        f"Demand now: {max(1, int(reporter_count or 0))} distinct reporter(s), "
+        f"Demand now: {max(0, int(reporter_count or 0))} distinct reporter(s), "
         f"{max(1, int(item_count or 0))} report(s). "
         f"Latest: feedback{f' #{feedback_id}' if feedback_id else ''} "
         f"({classification.category}/{classification.severity}, confidence "
@@ -600,8 +600,10 @@ def file_feedback_issue(feedback: dict, classification: FeedbackClassification =
     match, score = find_duplicate_cluster(body, vector, open_clusters)
     match = match or cluster_by_id(open_clusters, classification.duplicate_of)
     if match:
-        reporter_count = int(match.get("reporter_count") or 1) + (1 if user_id is not None else 0)
-        item_count = int(match.get("item_count") or 1) + 1
+        # reporter_count counts DISTINCT identified users; an anonymous report adds a report but no
+        # reporter, so it must never be floored up to 1 — that would fake the feature-demand signal.
+        reporter_count = int(match.get("reporter_count") or 0) + (1 if user_id is not None else 0)
+        item_count = int(match.get("item_count") or 0) + 1
         commented = comment_on_issue(match["github_issue_number"], build_duplicate_comment(
             classification, feedback_id, reporter_count, item_count))
         if not commented:
@@ -617,7 +619,7 @@ def file_feedback_issue(feedback: dict, classification: FeedbackClassification =
                        cluster_id=match["cluster_id"],
                        issue_number=match["github_issue_number"], similarity=score)
 
-    reporter_count = 1
+    reporter_count = 1 if user_id is not None else 0
     labels = labels_for_issue(classification, reporter_count)
     ready = AGENT_READY_LABEL in labels
     number = create_github_issue(
@@ -636,7 +638,7 @@ def file_feedback_issue(feedback: dict, classification: FeedbackClassification =
                    agent_ready=ready, similarity=score,
                    cluster={"cluster_id": feedback_id, "body": body, "embedding": vector,
                             "github_issue_number": number, "item_count": 1,
-                            "reporter_count": 1 if user_id is not None else 0})
+                            "reporter_count": reporter_count})
 
 
 def process_new_feedback(limit: int = 25) -> dict:

--- a/src/cqc_lem/utilities/feedback/issue_service.py
+++ b/src/cqc_lem/utilities/feedback/issue_service.py
@@ -1,0 +1,707 @@
+"""Auto-file GitHub issues from classified feedback — issue #498, stage 3 of the feedback->auto-work
+loop (docs/launch-and-marketing-plan.md §B.2/B.3).
+
+Stage 1 (#496) captures raw feedback; stage 2 (#497, `classifier.py`) turns one row into a
+category/severity/risk verdict. This stage decides what the world sees:
+
+    feedback row ──► classify (#497) ──► route
+                                         ├─ drop / FAQ / human-triage  → status only, NO issue
+                                         └─ auto_work
+                                              ├─ over the per-user file cap → held, retried later
+                                              ├─ similar to an OPEN cluster → +1 ITS issue
+                                              └─ new problem → open ONE issue, stamp it back
+
+Dedup is the whole point: one recurring problem must be one issue, so the Nth report bumps demand on
+the existing issue instead of spamming the backlog. Similarity is embedding cosine when an embedding
+is available and falls back to `content_framework.text_similarity` (the deterministic token-overlap
+measure the post-uniqueness gate already uses) when it is not — so dedup NEVER silently degrades to
+"everything is new" just because the embedding endpoint is down.
+
+Every filed body is shaped for the pipeline RUNBOOK's `MODE=start` (Why / Scope / Files /
+Acceptance) and carries `agent:ready` only when it is safe to build unattended: risk `none`,
+confidence ≥ 0.7, and — for *features*, which are higher-risk than bugs — enough distinct reporters
+to prove demand. Anything risky gets the matching `risk:*` + `needs-human` label, the owner assigned, and a
+RUNBOOK-shaped Decision Comment so the hold is letter-pickable instead of prose.
+
+Privacy: only the classifier's factual `summary` reaches GitHub — never the raw feedback text or any
+reporter identity. Issues reference the internal `feedback.id` for correlation.
+
+Env:
+  FEEDBACK_GITHUB_TOKEN / GITHUB_TOKEN   — token used to file/comment; NO token == nothing is filed
+  FEEDBACK_GITHUB_REPO                   — owner/name (default is this repo)
+  FEEDBACK_ISSUE_ASSIGNEE                — who risky issues are assigned to (default gitchrisqueen)
+  FEEDBACK_EMBEDDING_MODEL               — embedding alias (default lem-embedding)
+  FEEDBACK_DUPLICATE_SIMILARITY          — dedup threshold 0-1 (default 0.82)
+  FEEDBACK_FEATURE_DEMAND_MIN            — distinct reporters a FEATURE cluster needs (default 2)
+  FEEDBACK_MAX_ISSUES_PER_USER_PER_DAY   — abuse guard (default 3)
+"""
+
+import json
+import os
+from typing import Optional
+
+from cqc_lem.utilities.ai.content_framework import text_similarity
+from cqc_lem.utilities.db import (
+    FeedbackStatus, count_feedback_filed_by_user, get_open_feedback_clusters,
+    get_unprocessed_feedback, update_feedback_triage,
+)
+from cqc_lem.utilities.feedback.classifier import (
+    MAX_BODY_CHARS, NEEDS_HUMAN_LABEL, RISK_LABELS, FeedbackCategory, FeedbackClassification,
+    FeedbackRisk, FeedbackRoute, classify_feedback, labels_for,
+)
+from cqc_lem.utilities.logger import log_debug, log_error, log_info, log_warning
+
+PLAN_DOC = "docs/launch-and-marketing-plan.md"
+GITHUB_API_BASE = "https://api.github.com"
+DEFAULT_REPO = "christopherqueenconsulting/linkedin_engagement_manager"
+DEFAULT_ASSIGNEE = "gitchrisqueen"
+DEFAULT_EMBEDDING_MODEL = "lem-embedding"
+
+FEEDBACK_LABEL = "feedback-loop"
+AGENT_READY_LABEL = "agent:ready"
+
+# Plan §B.2: `agent:ready` (build it unattended) requires risk none AND confidence >= 0.7. This is
+# deliberately ABOVE the classifier's own min_confidence floor (0.6) — 0.6-0.7 is filed but held.
+AGENT_READY_MIN_CONFIDENCE = 0.7
+
+# Cosine/overlap at-or-above this means "same underlying problem". 0.82 is tight enough that two
+# distinct bugs in the same component stay separate, loose enough to catch rewordings.
+DUPLICATE_SIMILARITY_DEFAULT = 0.82
+FEATURE_DEMAND_MIN_DEFAULT = 2
+MAX_ISSUES_PER_USER_PER_DAY_DEFAULT = 3
+RATE_LIMIT_WINDOW_HOURS = 24
+
+MAX_CLUSTER_CANDIDATES = 100
+MAX_TITLE_CHARS = 120
+GITHUB_TIMEOUT_SECONDS = 20
+
+
+class IssueAction:
+    """What `file_feedback_issue` actually did — the contract callers/tests assert on."""
+    FILED = 'filed'                  # a new issue was opened for a new cluster
+    DEDUPED = 'deduped'              # +1 comment on the existing cluster's issue
+    DROPPED = 'dropped'              # noise — dismissed, nothing filed
+    FAQ = 'faq'                      # a support question — answered elsewhere (#507)
+    NEEDS_HUMAN = 'needs_human'      # low confidence — human triage queue, no issue spam
+    RATE_LIMITED = 'rate_limited'    # over this user's daily cap — held for a later pass
+    ERROR = 'error'                  # GitHub call failed; row left for the next pass to retry
+
+
+# Conventional-commit type per category, so a filed title reads like the commit that will close it.
+_COMMIT_TYPES: dict[FeedbackCategory, str] = {
+    FeedbackCategory.BUG: 'fix',
+    FeedbackCategory.FEATURE: 'feat',
+    FeedbackCategory.ENHANCEMENT: 'feat',
+    FeedbackCategory.CLEANUP: 'chore',
+    FeedbackCategory.QUESTION: 'docs',
+    FeedbackCategory.NOISE: 'chore',
+}
+
+# Component -> the files an implementer starts in. This is the `## Files` hint MODE=start reads; it
+# is a STARTING POINT, not a contract, which is why every entry ends with the generic test dirs.
+_COMPONENT_FILES: dict[str, tuple] = {
+    'feed-commenting': ('src/cqc_lem/app/run_automation.py',
+                        'src/cqc_lem/utilities/linkedin/helper.py'),
+    'replies': ('src/cqc_lem/app/run_automation.py',),
+    'dms': ('src/cqc_lem/app/run_automation.py', 'src/cqc_lem/utilities/ai/dm_nurture.py'),
+    'connections': ('src/cqc_lem/app/run_automation.py',
+                    'src/cqc_lem/utilities/linkedin/company_page_inviter.py'),
+    'content-generation': ('src/cqc_lem/app/run_content_plan.py',
+                           'src/cqc_lem/utilities/ai/ai_helper.py',
+                           'src/cqc_lem/utilities/ai/content_framework.py'),
+    'scheduling': ('src/cqc_lem/app/run_scheduler.py',),
+    'newsletter': ('src/cqc_lem/app/run_scheduler.py',),
+    'carousels': ('src/cqc_lem/utilities/carousel_creator.py',),
+    'video': ('src/cqc_lem/app/generate_variants.py',),
+    'analytics': ('src/cqc_lem/utilities/observability.py',),
+    'billing': ('src/cqc_lem/api/main.py', 'src/cqc_lem/utilities/db.py'),
+    'auth': ('src/cqc_lem/api/main.py', 'src/cqc_lem/utilities/linkedin/token_refresh.py'),
+    'onboarding': ('src/cqc_lem/ui/src/', 'src/cqc_lem/api/main.py'),
+    'ui': ('src/cqc_lem/ui/src/',),
+    'api': ('src/cqc_lem/api/main.py',),
+    'infra': ('docker-compose.yml', 'compose/local/'),
+    'other': (),
+}
+
+# The single genuine decision a held auto-filed item poses, per hold reason (RUNBOOK: never invent
+# decisions — one question when there is one call to make). Each value is
+# (question, *(option, consequence)) with option A always the recommendation.
+_RISK_QUESTIONS: dict[FeedbackRisk, tuple] = {
+    FeedbackRisk.PRODUCT_DECISION: (
+        "This needs a product call before anything is built — how should the agent proceed?",
+        ("Build it as scoped above", "agent implements the scope as written"),
+        ("Build a narrower version", "reply with the reduced scope; agent implements that"),
+        ("Don't build it", "issue is closed as wontfix"),
+    ),
+    FeedbackRisk.LIVE_LINKEDIN: (
+        "This can only be verified against a live LinkedIn session — how should it be validated?",
+        ("Agent ships it behind unit tests; you validate live after deploy",
+         "fastest, live behavior unverified at merge"),
+        ("Hold until you run a live grounding pass", "no code lands until you validate selectors"),
+        ("Don't build it", "issue is closed as wontfix"),
+    ),
+    FeedbackRisk.MIGRATION: (
+        "This implies a schema change — how should the migration be handled?",
+        ("Additive-only migration (new nullable column/table), agent writes it",
+         "no data loss, backward compatible"),
+        ("You author the migration; agent does the code only",
+         "you own the schema, agent wires it up"),
+        ("Don't build it", "issue is closed as wontfix"),
+    ),
+    FeedbackRisk.SECURITY: (
+        "This touches auth/privacy/secrets — how should it be handled?",
+        ("Agent implements it, you review the security diff before merge",
+         "held at merge for your review"),
+        ("You handle it yourself", "agent stays out of it entirely"),
+        ("Don't build it", "issue is closed as wontfix"),
+    ),
+}
+
+# Hold reasons that are NOT about risk: unproven feature demand, and a scope the classifier itself
+# was only ~two-thirds sure of.
+_DEMAND_QUESTION: tuple = (
+    "Only a few people have asked for this feature — should the pipeline build it now?",
+    ("Build it now", "agent implements it this cycle"),
+    ("Wait for more demand", "issue stays open, unbuilt, until more reports land"),
+    ("Don't build it", "issue is closed as wontfix"),
+)
+
+_CONFIDENCE_QUESTION: tuple = (
+    "The classifier was only moderately sure it read this report correctly — is the scope right?",
+    ("Scope is right, build it", "agent implements the scope as written"),
+    ("Scope is wrong", "reply with the correct scope; agent implements that"),
+    ("Don't build it", "issue is closed as wontfix"),
+)
+
+_LETTERS = ('A', 'B', 'C', 'D')
+
+# One sentence of WHY per hold reason — the RUNBOOK requires the recommendation to be justified.
+_RECOMMENDATION_WHY: dict[str, str] = {
+    'unproven-demand': "The report is concrete enough to build; A only costs one cycle if demand "
+                       "never grows, while waiting costs the reporter.",
+    'low-confidence': "The scope reads as filed; A is cheapest to correct if the classifier "
+                      "misread it, since the change is small and scoped.",
+    **{f"risk:{risk}": "The report is concrete enough to build as scoped; the hold exists for the "
+                       "risk, not for the scope." for risk in RISK_LABELS},
+}
+
+
+# --- Env readers (read at call time, the live-env pattern used across the codebase) --------------
+
+def github_repo() -> str:
+    return (os.environ.get("FEEDBACK_GITHUB_REPO") or "").strip() or DEFAULT_REPO
+
+
+def github_token() -> Optional[str]:
+    token = ((os.environ.get("FEEDBACK_GITHUB_TOKEN") or "").strip()
+             or (os.environ.get("GITHUB_TOKEN") or "").strip())
+    return token or None
+
+
+def issue_assignee() -> str:
+    return (os.environ.get("FEEDBACK_ISSUE_ASSIGNEE") or "").strip() or DEFAULT_ASSIGNEE
+
+
+def embedding_model() -> str:
+    return (os.environ.get("FEEDBACK_EMBEDDING_MODEL") or "").strip() or DEFAULT_EMBEDDING_MODEL
+
+
+def _env_float(key: str, default: float, low: float, high: float) -> float:
+    raw = (os.environ.get(key) or "").strip()
+    try:
+        value = float(raw) if raw else default
+    except ValueError:
+        return default
+    return max(low, min(high, value))
+
+
+def _env_int(key: str, default: int, low: int, high: int) -> int:
+    raw = (os.environ.get(key) or "").strip()
+    try:
+        value = int(float(raw)) if raw else default
+    except ValueError:
+        return default
+    return max(low, min(high, value))
+
+
+def duplicate_similarity_min() -> float:
+    return _env_float("FEEDBACK_DUPLICATE_SIMILARITY", DUPLICATE_SIMILARITY_DEFAULT, 0.0, 1.0)
+
+
+def feature_demand_min() -> int:
+    return _env_int("FEEDBACK_FEATURE_DEMAND_MIN", FEATURE_DEMAND_MIN_DEFAULT, 1, 100)
+
+
+def max_issues_per_user_per_day() -> int:
+    return _env_int("FEEDBACK_MAX_ISSUES_PER_USER_PER_DAY",
+                    MAX_ISSUES_PER_USER_PER_DAY_DEFAULT, 1, 100)
+
+
+# --- Similarity ---------------------------------------------------------------------------------
+
+def cosine_similarity(a: Optional[list], b: Optional[list]) -> float:
+    """Cosine of two equal-length vectors, clamped to 0.0-1.0. Mismatched lengths, empties, and
+    zero-norm vectors are 0.0 (not an error) so a half-written embedding can never claim a match.
+    Negative cosines are clamped to 0.0 — "less than unrelated" is still just unrelated here."""
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    try:
+        dot = sum(float(x) * float(y) for x, y in zip(a, b))
+        norm_a = sum(float(x) * float(x) for x in a) ** 0.5
+        norm_b = sum(float(y) * float(y) for y in b) ** 0.5
+    except (TypeError, ValueError):
+        return 0.0
+    if norm_a <= 0 or norm_b <= 0:
+        return 0.0
+    return max(0.0, min(1.0, dot / (norm_a * norm_b)))
+
+
+def as_vector(raw: object) -> Optional[list]:
+    """A stored embedding as a list of floats. `feedback.embedding` is a JSON column, which MySQL
+    hands back as a str on some connector versions and a list on others; junk becomes None."""
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except ValueError:
+            return None
+    if not isinstance(raw, list) or not raw:
+        return None
+    try:
+        return [float(x) for x in raw]
+    except (TypeError, ValueError):
+        return None
+
+
+def similarity(text_a: str, text_b: str, vector_a: object = None,
+               vector_b: object = None) -> float:
+    """How alike two reports are. Prefers embedding cosine (catches "comments never post" vs "my
+    replies don't go through", which share almost no vocabulary); falls back to the deterministic
+    token-overlap measure whenever either embedding is missing or unusable."""
+    va, vb = as_vector(vector_a), as_vector(vector_b)
+    if va and vb and len(va) == len(vb):
+        return cosine_similarity(va, vb)
+    return text_similarity(text_a or "", text_b or "")
+
+
+def embed_text(text: Optional[str]) -> Optional[list]:
+    """Embed one feedback body via the LiteLLM proxy. Returns None on any failure — callers must
+    treat a missing embedding as "compare lexically", never as "no duplicates exist"."""
+    body = (text or "").strip()[:MAX_BODY_CHARS]
+    if not body:
+        return None
+    model = embedding_model()
+    try:
+        # Lazy import keeps this module importable without the AI stack configured.
+        from cqc_lem.utilities.ai.client import client
+        response = client.embeddings.create(model=model, input=body)
+        vector = as_vector(list(response.data[0].embedding))
+    except Exception as e:
+        log_warning("Feedback embedding failed — dedup falls back to token overlap", exc=e,
+                    ai_model=model)
+        return None
+    if not vector:
+        log_warning("Feedback embedding was empty — dedup falls back to token overlap",
+                    ai_model=model)
+    return vector
+
+
+def find_duplicate_cluster(body: str, vector: Optional[list], clusters: Optional[list],
+                           threshold: float = None) -> tuple:
+    """(cluster, score) of the most similar OPEN cluster at-or-above the threshold, else (None, best
+    score seen). Clusters with no filed issue are skipped — there is nothing to +1."""
+    limit = duplicate_similarity_min() if threshold is None else threshold
+    best_cluster, best_score = None, 0.0
+    for cluster in (clusters or [])[:MAX_CLUSTER_CANDIDATES]:
+        if not cluster or not cluster.get("github_issue_number"):
+            continue
+        score = similarity(body, cluster.get("body") or "", vector, cluster.get("embedding"))
+        if score > best_score:
+            best_score = score
+            if score >= limit:
+                best_cluster = cluster
+    return (best_cluster if best_score >= limit else None), best_score
+
+
+def cluster_by_id(clusters: Optional[list], cluster_id: Optional[int]) -> Optional[dict]:
+    """The cluster whose id the classifier named in `duplicate_of` (it sees the same candidates), or
+    None. Its judgement is honored even below the cosine threshold — it read both texts."""
+    if cluster_id is None:
+        return None
+    for cluster in clusters or []:
+        if cluster and cluster.get("cluster_id") == cluster_id and cluster.get(
+                "github_issue_number"):
+            return cluster
+    return None
+
+
+def duplicate_candidates(clusters: Optional[list]) -> list:
+    """Open clusters in the {'id', 'title'} shape `classify_feedback(duplicate_candidates=...)`
+    expects, so the LLM can flag a duplicate the vectors miss."""
+    return [{"id": c.get("cluster_id"), "title": (c.get("body") or "").strip()}
+            for c in (clusters or []) if c and c.get("cluster_id") and c.get("github_issue_number")]
+
+
+# --- Label + body construction (pure) -----------------------------------------------------------
+
+def feature_demand_met(category: FeedbackCategory, reporter_count: int) -> bool:
+    """Plan §B.3 abuse guard: bugs auto-file immediately, but a FEATURE needs demand from enough
+    distinct reporters before the pipeline may build it unattended — so a first-of-its-kind feature
+    request is filed and HELD for the owner rather than built on one person's word."""
+    if category != FeedbackCategory.FEATURE:
+        return True
+    return int(reporter_count or 0) >= feature_demand_min()
+
+
+def is_agent_ready(classification: FeedbackClassification, reporter_count: int = 1) -> bool:
+    """Whether the pipeline may build this with no human in the loop."""
+    return (classification.risk == FeedbackRisk.NONE
+            and classification.route == FeedbackRoute.AUTO_WORK
+            and classification.confidence >= AGENT_READY_MIN_CONFIDENCE
+            and feature_demand_met(classification.category, reporter_count))
+
+
+def labels_for_issue(classification: FeedbackClassification, reporter_count: int = 1) -> list:
+    """The full label set for a filed issue: the classifier's taxonomy labels, the `feedback-loop`
+    provenance label, and EXACTLY ONE of `agent:ready` (safe to build unattended) or `needs-human`
+    (risky or unproven demand — the pipeline holds it)."""
+    labels = list(labels_for(classification.category, classification.severity,
+                             classification.risk, classification.route))
+    labels.append(FEEDBACK_LABEL)
+    if is_agent_ready(classification, reporter_count):
+        labels.append(AGENT_READY_LABEL)
+    elif NEEDS_HUMAN_LABEL not in labels:
+        labels.append(NEEDS_HUMAN_LABEL)
+    # dict.fromkeys: de-dupe (risk/needs-human can arrive from both sources) while keeping order.
+    return list(dict.fromkeys(labels))
+
+
+def build_issue_title(classification: FeedbackClassification) -> str:
+    """Conventional-commit-shaped title: `<type>(<component>): <imperative summary>`."""
+    commit_type = _COMMIT_TYPES.get(classification.category, 'chore')
+    title = (classification.title or classification.summary or "Investigate user feedback").strip()
+    return f"{commit_type}({classification.component}): {title}"[:MAX_TITLE_CHARS]
+
+
+def _files_hint(component: str) -> list:
+    return list(_COMPONENT_FILES.get(component, ())) + ["tests/unit/"]
+
+
+def build_issue_body(classification: FeedbackClassification, feedback_id: Optional[int] = None,
+                     reporter_count: int = 1, item_count: int = 1) -> str:
+    """The `MODE=start` body: Why / Scope / Files / Acceptance, plus the provenance the pipeline and
+    a human both need. Only the classifier's factual summary is included — never the raw report."""
+    ready = is_agent_ready(classification, reporter_count)
+    demand = (f"Reported by {max(1, int(reporter_count or 0))} distinct user(s) across "
+              f"{max(1, int(item_count or 0))} feedback item(s).")
+    provenance = (f"Auto-filed from in-app feedback"
+                  f"{f' #{feedback_id}' if feedback_id else ''} by the feedback→auto-work loop "
+                  f"(`{PLAN_DOC}` §B.2/B.3). Classifier: {classification.category}/"
+                  f"{classification.severity}, risk `{classification.risk}`, confidence "
+                  f"{classification.confidence:.2f}.")
+
+    scope = [f"Address the reported {classification.category} in the `{classification.component}` "
+             f"area of the product.",
+             "Keep the change minimal and scoped to this report — no unrelated refactors."]
+    if classification.risk != FeedbackRisk.NONE:
+        scope.append(f"Risk `{classification.risk}` — see the Decision Comment below before "
+                     f"implementing.")
+
+    acceptance = ["The behavior the reporter described is fixed/implemented.",
+                  "Unit tests cover the new/changed logic (≥80% patch coverage).",
+                  "All required CI gates pass."]
+    if classification.risk == FeedbackRisk.MIGRATION:
+        acceptance.append("Any migration is additive and named "
+                          "`V<YYYYMMDDHHMMSS>__short_name.sql`.")
+    if not ready:
+        acceptance.append("A human has answered the Decision Comment before this is merged.")
+
+    lines = ["## Why", classification.summary or "(no summary — see the classifier verdict below)",
+             "", demand, "", provenance, "",
+             "## Scope"]
+    lines += [f"- {item}" for item in scope]
+    lines += ["", "## Files",
+              "Likely starting points (verify before editing; add/extend the unit tests):"]
+    lines += [f"- `{path}`" for path in _files_hint(classification.component)]
+    lines += ["", "## Acceptance"]
+    lines += [f"- {item}" for item in acceptance]
+    return "\n".join(lines)
+
+
+def hold_reason(classification: FeedbackClassification, reporter_count: int = 1) -> Optional[str]:
+    """Why this item can't ship unattended — `risk:<kind>`, `unproven-demand`, `low-confidence` — or
+    None when it is `agent:ready`. This is the `risk:` line of the Decision Comment."""
+    if is_agent_ready(classification, reporter_count):
+        return None
+    if classification.risk != FeedbackRisk.NONE:
+        return f"risk:{classification.risk}"
+    if not feature_demand_met(classification.category, reporter_count):
+        return "unproven-demand"
+    return "low-confidence"
+
+
+def build_decision_comment(classification: FeedbackClassification,
+                           reporter_count: int = 1) -> str:
+    """The RUNBOOK Decision Comment for a HELD auto-filed item: ONE genuine question (should this be
+    built, and under what constraint), lettered options with consequences, and a recommendation. The
+    question is chosen by why it is actually held — risk, unproven demand, or low confidence."""
+    reason = hold_reason(classification, reporter_count) or "low-confidence"
+    if classification.risk != FeedbackRisk.NONE:
+        question, *options = _RISK_QUESTIONS[classification.risk]
+    elif reason == "unproven-demand":
+        question, *options = _DEMAND_QUESTION
+    else:
+        question, *options = _CONFIDENCE_QUESTION
+
+    lines = ["## 🧑‍⚖️ Human decision needed — reply with option letters",
+             f"Held (`{NEEDS_HUMAN_LABEL}`, {reason}). Auto-filed from user feedback by the "
+             f"feedback→auto-work loop (`{PLAN_DOC}` §B.2), but it cannot ship unattended.",
+             "Reply one letter per question — e.g. `1A` — or `ok` for all recommendations.", "",
+             f"### 1. {question}"]
+    for letter, (option, consequence) in zip(_LETTERS, options):
+        recommended = "  ✅ *recommended*" if letter == 'A' else ""
+        lines.append(f"- **{letter}. {option}** — {consequence}{recommended}")
+    why = _RECOMMENDATION_WHY.get(reason, _RECOMMENDATION_WHY['low-confidence'])
+    lines += ["", f"**My recommendation: `1A`.** {why}"]
+    return "\n".join(lines)
+
+
+def build_duplicate_comment(classification: FeedbackClassification,
+                            feedback_id: Optional[int] = None, reporter_count: int = 1,
+                            item_count: int = 1) -> str:
+    """The +1 that a repeat report leaves on the EXISTING issue instead of opening a new one — the
+    demand signal the pipeline prioritizes by."""
+    return "\n".join([
+        "**+1 — reported again via in-app feedback.**",
+        "",
+        f"New detail: {classification.summary or '(none)'}",
+        "",
+        f"Demand now: {max(1, int(reporter_count or 0))} distinct reporter(s), "
+        f"{max(1, int(item_count or 0))} report(s). "
+        f"Latest: feedback{f' #{feedback_id}' if feedback_id else ''} "
+        f"({classification.category}/{classification.severity}, confidence "
+        f"{classification.confidence:.2f}).",
+        "",
+        f"_Auto-deduplicated by the feedback→auto-work loop (`{PLAN_DOC}` §B.3)._",
+    ])
+
+
+# --- GitHub I/O ---------------------------------------------------------------------------------
+
+def _github_request(method: str, path: str, payload: dict = None) -> Optional[dict]:
+    """One GitHub REST call. Returns the parsed body, or None when unconfigured/failed — filing is
+    best-effort by design: a GitHub outage must never lose the feedback row."""
+    token = github_token()
+    if not token:
+        log_warning("Feedback issue filing skipped — no FEEDBACK_GITHUB_TOKEN/GITHUB_TOKEN set",
+                    api_provider="github")
+        return None
+    import requests
+    url = f"{GITHUB_API_BASE}/repos/{github_repo()}/{path.lstrip('/')}"
+    try:
+        response = requests.request(
+            method, url, json=payload, timeout=GITHUB_TIMEOUT_SECONDS,
+            headers={"Authorization": f"Bearer {token}",
+                     "Accept": "application/vnd.github+json",
+                     "X-GitHub-Api-Version": "2022-11-28"})
+    except Exception as e:
+        log_error(f"GitHub {method} {path} failed", exc=e, api_provider="github")
+        return None
+    if response.status_code >= 300:
+        log_error(f"GitHub {method} {path} returned {response.status_code}: "
+                  f"{response.text[:300]}", api_provider="github",
+                  http_status=response.status_code)
+        return None
+    try:
+        return response.json()
+    except ValueError:
+        return {}
+
+
+def create_github_issue(title: str, body: str, labels: list,
+                        assignees: list = None) -> Optional[int]:
+    """Open an issue; returns its number or None."""
+    payload = {"title": title, "body": body, "labels": list(labels or [])}
+    if assignees:
+        payload["assignees"] = list(assignees)
+    data = _github_request("POST", "issues", payload)
+    number = (data or {}).get("number")
+    if number is None:
+        return None
+    log_info(f"Auto-filed feedback issue #{number}: {title}", api_provider="github")
+    return int(number)
+
+
+def comment_on_issue(issue_number: int, body: str) -> bool:
+    """Comment on an existing issue; True when GitHub accepted it."""
+    if not issue_number:
+        return False
+    return _github_request("POST", f"issues/{int(issue_number)}/comments",
+                           {"body": body}) is not None
+
+
+# --- Orchestration ------------------------------------------------------------------------------
+
+def _result(action: str, feedback_id: Optional[int], **extra) -> dict:
+    return {"action": action, "feedback_id": feedback_id, **extra}
+
+
+def file_feedback_issue(feedback: dict, classification: FeedbackClassification = None,
+                        clusters: list = None) -> dict:
+    """Take ONE captured feedback row all the way to its outcome (see `IssueAction`). Never raises.
+
+    `classification` / `clusters` are injectable so a batch pass classifies once and loads the open
+    clusters once. When a new issue IS filed, the caller should append the returned `cluster` to its
+    in-memory cluster list so two identical reports in the same batch don't both file."""
+    row = feedback or {}
+    feedback_id = row.get("id")
+    body = row.get("body") or ""
+    if not body.strip():
+        return _result(IssueAction.DROPPED, feedback_id, reason="empty body")
+    user_id = row.get("user_id")
+
+    # Abuse guard FIRST: one user cannot turn the backlog into their personal firehose. Checked
+    # before the LLM so a held row costs nothing, and the row's status is left alone so a later pass
+    # (fresh 24h window) picks it up — held, never dropped.
+    if user_id is not None:
+        recent = count_feedback_filed_by_user(user_id, RATE_LIMIT_WINDOW_HOURS)
+        if recent >= max_issues_per_user_per_day():
+            log_info(f"Feedback {feedback_id} held — {recent} of this user's report(s) already "
+                     f"reached GitHub in {RATE_LIMIT_WINDOW_HOURS}h", user_id=user_id)
+            return _result(IssueAction.RATE_LIMITED, feedback_id, recent=recent)
+
+    open_clusters = get_open_feedback_clusters() if clusters is None else clusters
+
+    context = row.get("context_json")
+    if isinstance(context, str):
+        try:
+            context = json.loads(context)
+        except ValueError:
+            context = None
+
+    if classification is None:
+        classification = classify_feedback(
+            body, type_hint=row.get("type_hint"), context=context,
+            duplicate_candidates=duplicate_candidates(open_clusters), user_id=user_id)
+
+    # Routes that must never produce an issue. Statuses still move so the row leaves the queue.
+    if classification.route == FeedbackRoute.DROP:
+        update_feedback_triage(feedback_id, status=FeedbackStatus.DISMISSED)
+        return _result(IssueAction.DROPPED, feedback_id, reason="classified as noise")
+    if classification.route == FeedbackRoute.FAQ:
+        update_feedback_triage(feedback_id, status=FeedbackStatus.TRIAGED)
+        return _result(IssueAction.FAQ, feedback_id)
+    if classification.route == FeedbackRoute.NEEDS_HUMAN:
+        update_feedback_triage(feedback_id, status=FeedbackStatus.TRIAGED)
+        return _result(IssueAction.NEEDS_HUMAN, feedback_id,
+                       confidence=classification.confidence)
+
+    vector = as_vector(row.get("embedding")) or embed_text(body)
+
+    match, score = find_duplicate_cluster(body, vector, open_clusters)
+    match = match or cluster_by_id(open_clusters, classification.duplicate_of)
+    if match:
+        reporter_count = int(match.get("reporter_count") or 1) + (1 if user_id is not None else 0)
+        item_count = int(match.get("item_count") or 1) + 1
+        commented = comment_on_issue(match["github_issue_number"], build_duplicate_comment(
+            classification, feedback_id, reporter_count, item_count))
+        if not commented:
+            return _result(IssueAction.ERROR, feedback_id, reason="duplicate comment failed",
+                           cluster_id=match.get("cluster_id"))
+        update_feedback_triage(feedback_id, status=FeedbackStatus.CLUSTERED,
+                               cluster_id=match["cluster_id"],
+                               github_issue_number=match["github_issue_number"],
+                               embedding=vector)
+        log_debug(f"Feedback {feedback_id} deduped into cluster {match['cluster_id']} "
+                  f"(similarity {score:.2f})", user_id=user_id)
+        return _result(IssueAction.DEDUPED, feedback_id,
+                       cluster_id=match["cluster_id"],
+                       issue_number=match["github_issue_number"], similarity=score)
+
+    reporter_count = 1
+    labels = labels_for_issue(classification, reporter_count)
+    ready = AGENT_READY_LABEL in labels
+    number = create_github_issue(
+        build_issue_title(classification),
+        build_issue_body(classification, feedback_id, reporter_count, item_count=1),
+        labels, assignees=None if ready else [issue_assignee()])
+    if number is None:
+        # Leave the row unclustered/`new` — the next pass retries rather than losing the report.
+        return _result(IssueAction.ERROR, feedback_id, reason="issue creation failed",
+                       labels=labels)
+    if not ready:
+        comment_on_issue(number, build_decision_comment(classification, reporter_count))
+    update_feedback_triage(feedback_id, status=FeedbackStatus.ISSUE_CREATED,
+                           cluster_id=feedback_id, github_issue_number=number, embedding=vector)
+    return _result(IssueAction.FILED, feedback_id, issue_number=number, labels=labels,
+                   agent_ready=ready, similarity=score,
+                   cluster={"cluster_id": feedback_id, "body": body, "embedding": vector,
+                            "github_issue_number": number, "item_count": 1,
+                            "reporter_count": 1 if user_id is not None else 0})
+
+
+def process_new_feedback(limit: int = 25) -> dict:
+    """Drain the capture queue: classify, dedup, and file each unprocessed feedback row. The open
+    clusters are loaded ONCE and grown in memory as issues are filed, so a burst of identical
+    reports in one pass produces one issue and N-1 +1 comments."""
+    rows = get_unprocessed_feedback(limit)
+    clusters = get_open_feedback_clusters()
+    counts: dict = {}
+    for row in rows:
+        try:
+            result = file_feedback_issue(row, clusters=clusters)
+        except Exception as e:
+            log_error(f"Auto-filing feedback {row.get('id')} failed", exc=e)
+            counts[IssueAction.ERROR] = counts.get(IssueAction.ERROR, 0) + 1
+            continue
+        counts[result["action"]] = counts.get(result["action"], 0) + 1
+        if result.get("cluster"):
+            clusters.append(result["cluster"])
+    log_info(f"Feedback auto-filing pass: {len(rows)} row(s) — {counts or 'nothing to do'}")
+    return {"processed": len(rows), "counts": counts}
+
+
+def recluster_feedback(limit: int = 200) -> dict:
+    """Nightly regrouping pass (`auto_recluster_feedback`). Deliberately does NOT file anything: it
+    backfills missing embeddings and attaches leftover rows — including ones the classifier left in
+    human triage — to an open cluster they now match, +1-ing that cluster's issue. Filing stays with
+    `process_new_feedback` so a nightly re-run can never open a second issue for a known problem.
+
+    Auto-closing issues whose cluster is resolved is NOT here — resolution is tracked on the GitHub
+    side by the changelog/notify stage (issue #502)."""
+    clusters = get_open_feedback_clusters()
+    # Unlike the filing pass, this one also reconsiders rows already parked in `triaged` — a report
+    # a human never got to may well be the same problem as an issue filed since.
+    rows = get_unprocessed_feedback(limit, statuses=(FeedbackStatus.NEW, FeedbackStatus.TRIAGED))
+    attached = 0
+    embedded = 0
+    for row in rows:
+        body = row.get("body") or ""
+        if not body.strip():
+            continue
+        vector = as_vector(row.get("embedding"))
+        if vector is None:
+            vector = embed_text(body)
+            if vector:
+                update_feedback_triage(row.get("id"), embedding=vector)
+                embedded += 1
+        match, score = find_duplicate_cluster(body, vector, clusters)
+        if not match:
+            continue
+        commented = comment_on_issue(match["github_issue_number"], "\n".join([
+            "**+1 — a previously untriaged report matches this issue.**",
+            "",
+            f"Nightly reclustering matched feedback #{row.get('id')} to this cluster "
+            f"(similarity {score:.2f}).",
+            "",
+            f"_Auto-reclustered by the feedback→auto-work loop (`{PLAN_DOC}` §B.3)._",
+        ]))
+        if not commented:
+            continue
+        update_feedback_triage(row.get("id"), status=FeedbackStatus.CLUSTERED,
+                               cluster_id=match["cluster_id"],
+                               github_issue_number=match["github_issue_number"])
+        attached += 1
+    log_info(f"Feedback recluster pass: {len(rows)} candidate(s), {attached} attached, "
+             f"{embedded} embedding(s) backfilled")
+    return {"scanned": len(rows), "attached": attached, "embedded": embedded,
+            "clusters": len(clusters)}

--- a/tests/unit/app/test_feedback_issue_tasks.py
+++ b/tests/unit/app/test_feedback_issue_tasks.py
@@ -1,0 +1,61 @@
+"""Unit tests for the feedback auto-filing beat tasks and their schedule entries — issue #498."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_SVC = "cqc_lem.utilities.feedback.issue_service"
+
+
+class TestAutoFileFeedbackIssues:
+    def test_delegates_to_the_service_and_summarizes_the_pass(self):
+        with patch(f"{_SVC}.process_new_feedback",
+                   return_value={"processed": 3, "counts": {"filed": 1, "deduped": 2}}) as service:
+            from cqc_lem.app.run_scheduler import auto_file_feedback_issues
+            result = auto_file_feedback_issues(limit=7)
+        service.assert_called_once_with(limit=7)
+        assert "3 row(s)" in result
+        assert "'filed': 1" in result
+
+    def test_empty_pass_says_nothing_to_do(self):
+        with patch(f"{_SVC}.process_new_feedback", return_value={"processed": 0, "counts": {}}):
+            from cqc_lem.app.run_scheduler import auto_file_feedback_issues
+            assert "nothing to do" in auto_file_feedback_issues()
+
+
+class TestAutoReclusterFeedback:
+    def test_delegates_to_the_service_and_summarizes_the_pass(self):
+        with patch(f"{_SVC}.recluster_feedback",
+                   return_value={"scanned": 9, "attached": 2, "embedded": 4,
+                                 "clusters": 5}) as service:
+            from cqc_lem.app.run_scheduler import auto_recluster_feedback
+            result = auto_recluster_feedback(limit=50)
+        service.assert_called_once_with(limit=50)
+        assert "9 scanned" in result
+        assert "2 attached" in result
+        assert "5 open cluster(s)" in result
+        assert "4 embedding(s) backfilled" in result
+
+
+class TestBeatSchedule:
+    def _schedule(self):
+        from cqc_lem.app.my_celery import app
+        return app.conf.beat_schedule
+
+    def test_both_feedback_entries_point_at_real_tasks(self):
+        import cqc_lem.app.run_scheduler as scheduler
+        schedule = self._schedule()
+        for name, attr in (('file-feedback-issues', 'auto_file_feedback_issues'),
+                           ('recluster-feedback', 'auto_recluster_feedback')):
+            assert schedule[name]['task'] == f"cqc_lem.app.run_scheduler.{attr}"
+            assert hasattr(scheduler, attr)
+
+    def test_filing_runs_every_thirty_minutes(self):
+        entry = self._schedule()['file-feedback-issues']['schedule']
+        assert entry.minute == {0, 30}
+
+    def test_reclustering_runs_nightly_off_peak(self):
+        entry = self._schedule()['recluster-feedback']['schedule']
+        assert entry.hour == {2}
+        assert entry.minute == {45}

--- a/tests/unit/utilities/test_db_feedback.py
+++ b/tests/unit/utilities/test_db_feedback.py
@@ -89,3 +89,177 @@ class TestFeedbackEnums:
         from cqc_lem.utilities.db import FeedbackStatus
         assert {str(s) for s in FeedbackStatus} == {
             "new", "triaged", "clustered", "issue_created", "resolved", "dismissed"}
+
+
+def _dict_conn(rows=None, one=None, rowcount=1):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.fetchall.return_value = rows
+    cur.fetchone.return_value = one
+    cur.rowcount = rowcount
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestGetFeedbackById:
+    def test_returns_the_row(self):
+        conn, cur = _dict_conn(one={"id": 5, "body": "broken"})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_feedback_by_id
+            assert get_feedback_by_id(5) == {"id": 5, "body": "broken"}
+        sql, params = cur.execute.call_args[0]
+        assert "FROM feedback WHERE id=%s" in sql
+        assert params == (5,)
+
+    def test_db_error_returns_none(self):
+        import mysql.connector
+        conn, cur = _dict_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import get_feedback_by_id
+            assert get_feedback_by_id(5) is None
+        conn.close.assert_called_once()
+
+
+class TestGetUnprocessedFeedback:
+    def test_defaults_to_new_only_and_orders_fifo(self):
+        conn, cur = _dict_conn(rows=[{"id": 1}])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_unprocessed_feedback
+            assert get_unprocessed_feedback(limit=5) == [{"id": 1}]
+        sql, params = cur.execute.call_args[0]
+        assert "status IN (%s)" in sql
+        assert "cluster_id IS NULL" in sql
+        assert "ORDER BY created_at ASC, id ASC" in sql
+        assert params == ("new", 5)
+
+    def test_widened_statuses_are_all_bound_as_parameters(self):
+        conn, cur = _dict_conn(rows=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_unprocessed_feedback, FeedbackStatus
+            get_unprocessed_feedback(limit=9, statuses=(FeedbackStatus.NEW,
+                                                        FeedbackStatus.TRIAGED))
+        sql, params = cur.execute.call_args[0]
+        assert "status IN (%s,%s)" in sql
+        assert params == ("new", "triaged", 9)
+
+    def test_unknown_status_values_are_rejected_without_touching_db(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            from cqc_lem.utilities.db import get_unprocessed_feedback
+            assert get_unprocessed_feedback(statuses=("'; DROP TABLE feedback; --",)) == []
+            assert get_unprocessed_feedback(statuses=()) == []
+        get_conn.assert_not_called()
+
+    def test_db_error_returns_empty_list(self):
+        import mysql.connector
+        conn, cur = _dict_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import get_unprocessed_feedback
+            assert get_unprocessed_feedback() == []
+
+
+class TestGetOpenFeedbackClusters:
+    def test_groups_on_the_seed_row_and_counts_distinct_reporters(self):
+        rows = [{"cluster_id": 7, "body": "x", "github_issue_number": 101, "item_count": 3,
+                 "reporter_count": 2}]
+        conn, cur = _dict_conn(rows=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_open_feedback_clusters
+            assert get_open_feedback_clusters(limit=50) == rows
+        sql, params = cur.execute.call_args[0]
+        assert "s.cluster_id = s.id" in sql                   # only seeds
+        assert "COUNT(DISTINCT m.user_id) AS reporter_count" in sql
+        assert "s.status IN ('clustered','issue_created')" in sql
+        assert params == (50,)
+
+    def test_db_error_returns_empty_list(self):
+        import mysql.connector
+        conn, cur = _dict_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import get_open_feedback_clusters
+            assert get_open_feedback_clusters() == []
+
+
+class TestCountFeedbackFiledByUser:
+    def test_counts_only_rows_that_reached_github_in_the_window(self):
+        conn, cur = _dict_conn(one=(4,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_feedback_filed_by_user
+            assert count_feedback_filed_by_user(9, hours=12) == 4
+        sql, params = cur.execute.call_args[0]
+        assert "github_issue_number IS NOT NULL" in sql
+        assert "INTERVAL %s HOUR" in sql
+        assert params == (9, 12)
+
+    def test_anonymous_feedback_is_never_counted(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            from cqc_lem.utilities.db import count_feedback_filed_by_user
+            assert count_feedback_filed_by_user(None) == 0
+        get_conn.assert_not_called()
+
+    def test_null_count_and_db_error_are_zero(self):
+        import mysql.connector
+        conn, cur = _dict_conn(one=(None,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_feedback_filed_by_user
+            assert count_feedback_filed_by_user(9) == 0
+        conn, cur = _dict_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import count_feedback_filed_by_user
+            assert count_feedback_filed_by_user(9) == 0
+
+
+class TestUpdateFeedbackTriage:
+    def test_writes_only_the_fields_passed(self):
+        conn, cur = _dict_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_feedback_triage, FeedbackStatus
+            assert update_feedback_triage(3, status=FeedbackStatus.ISSUE_CREATED,
+                                         cluster_id=3, github_issue_number=88,
+                                         embedding=[0.5, 0.25]) is True
+        sql, params = cur.execute.call_args[0]
+        assert sql == ("UPDATE feedback SET status=%s, cluster_id=%s, github_issue_number=%s, "
+                       "embedding=%s WHERE id=%s")
+        assert params == ("issue_created", 3, 88, json.dumps([0.5, 0.25]), 3)
+        conn.commit.assert_called_once()
+
+    def test_embedding_only_update_leaves_status_alone(self):
+        conn, cur = _dict_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_feedback_triage
+            update_feedback_triage(3, embedding=[1.0])
+        sql, params = cur.execute.call_args[0]
+        assert sql == "UPDATE feedback SET embedding=%s WHERE id=%s"
+        assert params == (json.dumps([1.0]), 3)
+
+    def test_no_fields_is_a_no_op_that_never_opens_a_connection(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            from cqc_lem.utilities.db import update_feedback_triage
+            assert update_feedback_triage(3) is False
+        get_conn.assert_not_called()
+
+    def test_missing_row_returns_false(self):
+        conn, cur = _dict_conn(rowcount=0)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_feedback_triage, FeedbackStatus
+            assert update_feedback_triage(99, status=FeedbackStatus.TRIAGED) is False
+
+    def test_over_long_sentiment_is_truncated(self):
+        conn, cur = _dict_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_feedback_triage
+            update_feedback_triage(3, sentiment="s" * 40)
+        assert len(cur.execute.call_args[0][1][0]) == 16
+
+    def test_db_error_returns_false_and_closes(self):
+        import mysql.connector
+        conn, cur = _dict_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import update_feedback_triage, FeedbackStatus
+            assert update_feedback_triage(3, status=FeedbackStatus.TRIAGED) is False
+        cur.close.assert_called_once()
+        conn.close.assert_called_once()

--- a/tests/unit/utilities/test_feedback_issue_service.py
+++ b/tests/unit/utilities/test_feedback_issue_service.py
@@ -545,6 +545,41 @@ class TestFileFeedbackIssue:
         assert result["cluster_id"] == 7
         mocks["create"].assert_not_called()
 
+    def test_anonymous_report_counts_zero_reporters_not_one(self):
+        # reporter_count is DISTINCT identified users — an anonymous report is a report with no
+        # attributable reporter, so it must not be floored up to 1 (that fakes the demand signal).
+        result, mocks = self._run({"id": 12, "user_id": None, "body": "comments never post"})
+        assert result["action"] == "filed"
+        assert result["cluster"]["reporter_count"] == 0
+        assert "0 distinct user(s) across 1 feedback item(s)" in mocks["create"].call_args[0][1]
+
+    def test_dedup_onto_an_anonymous_cluster_does_not_inflate_the_demand_count(self):
+        clusters = [_cluster(7, "comments never post", 101, embedding=[1.0, 0.0], reporters=0,
+                             items=1)]
+        _, mocks = self._run({"id": 15, "user_id": 4, "body": "replies do not post"},
+                             clusters=clusters)
+        assert "1 distinct reporter(s), 2 report(s)" in mocks["comment"].call_args[0][1]
+
+    def test_two_anonymous_reports_still_add_up_to_zero_reporters(self):
+        clusters = [_cluster(7, "comments never post", 101, embedding=[1.0, 0.0], reporters=0,
+                             items=1)]
+        _, mocks = self._run({"id": 15, "user_id": None, "body": "replies do not post"},
+                             clusters=clusters)
+        assert "0 distinct reporter(s), 2 report(s)" in mocks["comment"].call_args[0][1]
+
+    def test_anonymous_feature_request_does_not_satisfy_the_demand_gate(self, monkeypatch):
+        from cqc_lem.utilities.feedback.classifier import FeedbackCategory
+        monkeypatch.setenv("FEEDBACK_FEATURE_DEMAND_MIN", "1")
+        feature = _classification(category=FeedbackCategory.FEATURE, confidence=0.95)
+        anonymous, _ = self._run({"id": 12, "user_id": None, "body": "add a dark mode"},
+                                 classification=feature)
+        assert anonymous["agent_ready"] is False
+        assert 'needs-human' in anonymous["labels"]
+        # …while one identified reporter does clear a min of 1.
+        identified, _ = self._run({"id": 13, "user_id": 3, "body": "add a dark mode"},
+                                  classification=feature)
+        assert identified["agent_ready"] is True
+
     def test_failed_duplicate_comment_leaves_the_row_for_a_retry(self):
         clusters = [_cluster(7, "comments never post", 101, embedding=[1.0, 0.0])]
         result, mocks = self._run({"id": 15, "user_id": 4, "body": "replies do not post"},

--- a/tests/unit/utilities/test_feedback_issue_service.py
+++ b/tests/unit/utilities/test_feedback_issue_service.py
@@ -1,0 +1,814 @@
+"""Unit tests for the feedback auto-filer — issue #498.
+
+Covers the deterministic halves exhaustively (similarity, dedup selection, label logic, MODE=start
+body shape, Decision Comment shape) and the orchestrator with GitHub + DB + the classifier mocked.
+"""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_SVC = "cqc_lem.utilities.feedback.issue_service"
+
+# The labels this module can emit must all exist in the repo (gh label list) — same guard as #497.
+REAL_REPO_LABELS = {
+    'bug', 'feature', 'enhancement', 'cleanup', 'question', 'documentation', 'duplicate',
+    'feedback-loop', 'priority:critical', 'priority:high', 'priority:medium', 'priority:low',
+    'risk:product-decision', 'risk:live-linkedin', 'risk:migration', 'risk:security',
+    'needs-human', 'agent:ready', 'agent:blocked', 'agent:working',
+}
+
+
+def _mod():
+    from cqc_lem.utilities.feedback import issue_service
+    return issue_service
+
+
+def _classification(**overrides):
+    from cqc_lem.utilities.feedback.classifier import (
+        FeedbackCategory, FeedbackClassification, FeedbackRisk, FeedbackSeverity)
+    kwargs = {
+        "category": FeedbackCategory.BUG,
+        "severity": FeedbackSeverity.HIGH,
+        "component": "feed-commenting",
+        "title": "Stop feed commenting after the first comment",
+        "summary": "Only one comment is posted per automation run.",
+        "risk": FeedbackRisk.NONE,
+        "duplicate_of": None,
+        "confidence": 0.9,
+    }
+    kwargs.update(overrides)
+    return FeedbackClassification(**kwargs)
+
+
+def _cluster(cluster_id=7, body="comments never post to the feed", issue=101,
+             embedding=None, reporters=1, items=1):
+    return {"cluster_id": cluster_id, "body": body, "github_issue_number": issue,
+            "embedding": embedding, "reporter_count": reporters, "item_count": items}
+
+
+class TestCosineSimilarity:
+    def test_identical_vectors_score_one_and_orthogonal_score_zero(self):
+        svc = _mod()
+        assert svc.cosine_similarity([1.0, 0.0, 2.0], [1.0, 0.0, 2.0]) == pytest.approx(1.0)
+        assert svc.cosine_similarity([1.0, 0.0], [0.0, 1.0]) == 0.0
+
+    def test_scaled_vector_is_still_identical(self):
+        assert _mod().cosine_similarity([1.0, 2.0], [3.0, 6.0]) == pytest.approx(1.0)
+
+    def test_opposite_vectors_clamp_to_zero(self):
+        assert _mod().cosine_similarity([1.0, 1.0], [-1.0, -1.0]) == 0.0
+
+    @pytest.mark.parametrize("a,b", [
+        ([1.0, 2.0], [1.0]),      # length mismatch
+        ([], [1.0]),              # empty
+        (None, [1.0]),            # missing
+        ([0.0, 0.0], [1.0, 1.0]),  # zero norm
+    ])
+    def test_unusable_inputs_are_zero_not_an_error(self, a, b):
+        assert _mod().cosine_similarity(a, b) == 0.0
+
+    def test_non_numeric_values_are_zero(self):
+        assert _mod().cosine_similarity([1.0, "x"], [1.0, 2.0]) == 0.0
+
+
+class TestAsVector:
+    def test_parses_json_string_and_list(self):
+        svc = _mod()
+        assert svc.as_vector("[1, 2.5]") == [1.0, 2.5]
+        assert svc.as_vector([1, 2]) == [1.0, 2.0]
+
+    @pytest.mark.parametrize("raw", ["not json", "[]", [], None, {"a": 1}, ["x"], "{}"])
+    def test_junk_becomes_none(self, raw):
+        assert _mod().as_vector(raw) is None
+
+
+class TestSimilarity:
+    def test_uses_cosine_when_both_embeddings_exist(self):
+        # Texts share no vocabulary; only the vectors can say they are the same problem.
+        score = _mod().similarity("comments never post", "replies do not go through",
+                                  [1.0, 0.0], [1.0, 0.0])
+        assert score == pytest.approx(1.0)
+
+    def test_falls_back_to_token_overlap_when_an_embedding_is_missing(self):
+        svc = _mod()
+        from cqc_lem.utilities.ai.content_framework import text_similarity
+        a, b = "feed commenting stops after one comment", "commenting stops after the first comment"
+        assert svc.similarity(a, b, [1.0, 0.0], None) == pytest.approx(text_similarity(a, b))
+        assert svc.similarity(a, b) > 0.5
+
+    def test_mismatched_embedding_lengths_fall_back_instead_of_scoring_zero(self):
+        svc = _mod()
+        same = "feed commenting stops after one comment"
+        assert svc.similarity(same, same, [1.0, 0.0], [1.0, 0.0, 0.0]) == pytest.approx(1.0)
+
+    def test_unrelated_texts_are_not_duplicates(self):
+        assert _mod().similarity("billing charged me twice", "add dark mode to the UI") < 0.3
+
+
+class TestFindDuplicateCluster:
+    def test_returns_the_best_matching_cluster_above_threshold(self):
+        svc = _mod()
+        clusters = [_cluster(1, "billing charged me twice", 11, embedding=[0.0, 1.0]),
+                    _cluster(2, "comments never post", 22, embedding=[1.0, 0.0])]
+        match, score = svc.find_duplicate_cluster("replies do not post", [1.0, 0.0], clusters)
+        assert match["cluster_id"] == 2
+        assert score == pytest.approx(1.0)
+
+    def test_below_threshold_is_not_a_duplicate_but_reports_the_best_score(self):
+        svc = _mod()
+        clusters = [_cluster(1, "billing charged me twice", 11, embedding=[0.0, 1.0])]
+        match, score = svc.find_duplicate_cluster("comments never post", [1.0, 0.0], clusters)
+        assert match is None
+        assert score == 0.0
+
+    def test_cluster_without_a_filed_issue_is_skipped(self):
+        svc = _mod()
+        clusters = [_cluster(1, "comments never post", issue=None, embedding=[1.0, 0.0])]
+        match, _ = svc.find_duplicate_cluster("comments never post", [1.0, 0.0], clusters)
+        assert match is None
+
+    def test_empty_and_none_cluster_lists_are_safe(self):
+        svc = _mod()
+        assert svc.find_duplicate_cluster("x", None, None) == (None, 0.0)
+        assert svc.find_duplicate_cluster("x", None, [None]) == (None, 0.0)
+
+    def test_threshold_override_is_honored(self):
+        svc = _mod()
+        clusters = [_cluster(1, "feed commenting stops after one comment", 11)]
+        text = "comments stop after one comment"
+        assert svc.find_duplicate_cluster(text, None, clusters)[0] is None
+        assert svc.find_duplicate_cluster(text, None, clusters,
+                                          threshold=0.2)[0]["cluster_id"] == 1
+
+    def test_env_threshold_is_read_at_call_time(self, monkeypatch):
+        svc = _mod()
+        clusters = [_cluster(1, "feed commenting stops after one comment", 11)]
+        monkeypatch.setenv("FEEDBACK_DUPLICATE_SIMILARITY", "0.2")
+        assert svc.duplicate_similarity_min() == pytest.approx(0.2)
+        assert svc.find_duplicate_cluster("comments stop after one comment", None,
+                                          clusters)[0] is not None
+
+
+class TestClusterLookupHelpers:
+    def test_cluster_by_id_honors_the_classifier_verdict(self):
+        svc = _mod()
+        clusters = [_cluster(3, issue=33)]
+        assert svc.cluster_by_id(clusters, 3)["github_issue_number"] == 33
+        assert svc.cluster_by_id(clusters, 4) is None
+        assert svc.cluster_by_id(clusters, None) is None
+
+    def test_cluster_by_id_ignores_clusters_with_no_issue(self):
+        assert _mod().cluster_by_id([_cluster(3, issue=None)], 3) is None
+
+    def test_duplicate_candidates_shape_matches_the_classifier_contract(self):
+        svc = _mod()
+        got = svc.duplicate_candidates([_cluster(5, "billing double charge", 55),
+                                        _cluster(6, "no issue yet", None)])
+        assert got == [{"id": 5, "title": "billing double charge"}]
+
+
+class TestEmbedText:
+    def test_returns_the_provider_vector(self):
+        svc = _mod()
+        client = MagicMock()
+        client.embeddings.create.return_value = MagicMock(
+            data=[MagicMock(embedding=[0.1, 0.2])])
+        with patch("cqc_lem.utilities.ai.client.client", client):
+            assert svc.embed_text("comments never post") == [0.1, 0.2]
+        assert client.embeddings.create.call_args.kwargs["model"] == "lem-embedding"
+
+    def test_provider_failure_returns_none_so_dedup_falls_back(self):
+        svc = _mod()
+        client = MagicMock()
+        client.embeddings.create.side_effect = RuntimeError("proxy down")
+        with patch("cqc_lem.utilities.ai.client.client", client):
+            assert svc.embed_text("comments never post") is None
+
+    def test_empty_provider_vector_is_none(self):
+        svc = _mod()
+        client = MagicMock()
+        client.embeddings.create.return_value = MagicMock(data=[MagicMock(embedding=[])])
+        with patch("cqc_lem.utilities.ai.client.client", client):
+            assert svc.embed_text("comments never post") is None
+
+    def test_blank_body_never_calls_the_provider(self):
+        svc = _mod()
+        client = MagicMock()
+        with patch("cqc_lem.utilities.ai.client.client", client):
+            assert svc.embed_text("   ") is None
+            assert svc.embed_text(None) is None
+        client.embeddings.create.assert_not_called()
+
+    def test_model_alias_is_configurable(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_EMBEDDING_MODEL", "other-embed")
+        assert svc.embedding_model() == "other-embed"
+
+
+class TestLabelLogic:
+    def test_confident_riskless_bug_is_agent_ready(self):
+        svc = _mod()
+        labels = svc.labels_for_issue(_classification())
+        assert labels == ['bug', 'priority:high', 'feedback-loop', 'agent:ready']
+        assert svc.hold_reason(_classification()) is None
+
+    def test_risky_item_gets_the_risk_label_needs_human_and_no_agent_ready(self):
+        from cqc_lem.utilities.feedback.classifier import FeedbackRisk
+        svc = _mod()
+        labels = svc.labels_for_issue(_classification(risk=FeedbackRisk.MIGRATION))
+        assert 'risk:migration' in labels
+        assert 'needs-human' in labels
+        assert 'agent:ready' not in labels
+
+    def test_confidence_below_the_agent_ready_floor_is_held(self):
+        svc = _mod()
+        held = _classification(confidence=0.65)
+        assert svc.labels_for_issue(held) == ['bug', 'priority:high', 'feedback-loop',
+                                             'needs-human']
+        assert svc.hold_reason(held) == 'low-confidence'
+
+    def test_feature_needs_demand_before_it_may_auto_work(self):
+        from cqc_lem.utilities.feedback.classifier import FeedbackCategory
+        svc = _mod()
+        feature = _classification(category=FeedbackCategory.FEATURE, confidence=0.95)
+        assert 'agent:ready' not in svc.labels_for_issue(feature, reporter_count=1)
+        assert svc.hold_reason(feature, reporter_count=1) == 'unproven-demand'
+        assert 'agent:ready' in svc.labels_for_issue(feature, reporter_count=2)
+
+    def test_bug_auto_files_on_a_single_report(self):
+        svc = _mod()
+        assert svc.feature_demand_met(_classification().category, 1) is True
+
+    def test_demand_threshold_is_configurable(self, monkeypatch):
+        from cqc_lem.utilities.feedback.classifier import FeedbackCategory
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_FEATURE_DEMAND_MIN", "5")
+        feature = _classification(category=FeedbackCategory.FEATURE, confidence=0.95)
+        assert 'agent:ready' not in svc.labels_for_issue(feature, reporter_count=4)
+        assert 'agent:ready' in svc.labels_for_issue(feature, reporter_count=5)
+
+    @pytest.mark.parametrize("risk", ['none', 'product-decision', 'live-linkedin', 'migration',
+                                      'security'])
+    @pytest.mark.parametrize("confidence", [0.6, 0.7, 1.0])
+    def test_every_emitted_label_exists_in_the_repo(self, risk, confidence):
+        from cqc_lem.utilities.feedback.classifier import FeedbackRisk
+        svc = _mod()
+        labels = svc.labels_for_issue(_classification(risk=FeedbackRisk(risk),
+                                                     confidence=confidence))
+        assert set(labels) <= REAL_REPO_LABELS
+        # Exactly one of the two mutually exclusive pipeline verdicts.
+        assert ('agent:ready' in labels) != ('needs-human' in labels)
+
+    def test_labels_are_deduplicated(self):
+        svc = _mod()
+        labels = svc.labels_for_issue(_classification(confidence=0.1))
+        assert len(labels) == len(set(labels))
+
+
+class TestIssueTitle:
+    @pytest.mark.parametrize("category,expected", [
+        ('bug', 'fix'), ('feature', 'feat'), ('enhancement', 'feat'),
+        ('cleanup', 'chore'), ('question', 'docs'),
+    ])
+    def test_conventional_commit_type_per_category(self, category, expected):
+        from cqc_lem.utilities.feedback.classifier import FeedbackCategory
+        svc = _mod()
+        title = svc.build_issue_title(_classification(category=FeedbackCategory(category)))
+        assert title.startswith(f"{expected}(feed-commenting): ")
+
+    def test_title_is_bounded(self):
+        svc = _mod()
+        got = svc.build_issue_title(_classification(title="x" * 300))
+        assert len(got) <= svc.MAX_TITLE_CHARS
+
+    def test_missing_title_falls_back_to_the_summary(self):
+        svc = _mod()
+        assert "Only one comment" in svc.build_issue_title(_classification(title=""))
+
+
+class TestIssueBody:
+    def test_body_has_the_mode_start_sections_in_order(self):
+        svc = _mod()
+        body = svc.build_issue_body(_classification(), feedback_id=42)
+        for section in ("## Why", "## Scope", "## Files", "## Acceptance"):
+            assert section in body
+        assert (body.index("## Why") < body.index("## Scope")
+                < body.index("## Files") < body.index("## Acceptance"))
+
+    def test_body_carries_provenance_the_plan_doc_and_the_feedback_id(self):
+        svc = _mod()
+        body = svc.build_issue_body(_classification(), feedback_id=42)
+        assert svc.PLAN_DOC in body
+        assert "#42" in body
+        assert "bug/high" in body
+        assert "confidence 0.90" in body
+
+    def test_body_never_leaks_the_raw_report_only_the_summary(self):
+        svc = _mod()
+        body = svc.build_issue_body(_classification(summary="Only one comment posts."),
+                                    feedback_id=1)
+        assert "Only one comment posts." in body
+
+    def test_files_hint_points_at_the_component(self):
+        svc = _mod()
+        body = svc.build_issue_body(_classification(), feedback_id=1)
+        assert "src/cqc_lem/app/run_automation.py" in body
+        assert "tests/unit/" in body
+
+    def test_unknown_component_still_hints_the_tests(self):
+        svc = _mod()
+        body = svc.build_issue_body(_classification(component="other"), feedback_id=1)
+        assert "tests/unit/" in body
+
+    def test_migration_risk_adds_the_timestamp_naming_rule(self):
+        from cqc_lem.utilities.feedback.classifier import FeedbackRisk
+        svc = _mod()
+        body = svc.build_issue_body(_classification(risk=FeedbackRisk.MIGRATION), feedback_id=1)
+        assert "V<YYYYMMDDHHMMSS>__short_name.sql" in body
+        assert "Decision Comment" in body
+
+    def test_agent_ready_body_has_no_decision_gate_in_acceptance(self):
+        svc = _mod()
+        body = svc.build_issue_body(_classification(), feedback_id=1)
+        assert "Decision Comment" not in body
+
+    def test_demand_line_reflects_the_cluster(self):
+        svc = _mod()
+        body = svc.build_issue_body(_classification(), feedback_id=1, reporter_count=4,
+                                    item_count=9)
+        assert "4 distinct user(s) across 9 feedback item(s)" in body
+
+
+class TestDecisionComment:
+    @pytest.mark.parametrize("risk", ['product-decision', 'live-linkedin', 'migration', 'security'])
+    def test_risk_comment_is_letter_pickable_with_a_recommendation(self, risk):
+        from cqc_lem.utilities.feedback.classifier import FeedbackRisk
+        svc = _mod()
+        comment = svc.build_decision_comment(_classification(risk=FeedbackRisk(risk)))
+        assert "Human decision needed" in comment
+        assert f"risk:{risk}" in comment
+        assert "- **A." in comment and "- **B." in comment and "- **C." in comment
+        assert "✅ *recommended*" in comment
+        assert "**My recommendation: `1A`.**" in comment
+        assert "### 1." in comment
+        # Exactly ONE question — the RUNBOOK forbids inventing extra decisions.
+        assert comment.count("### ") == 1
+
+    def test_unproven_demand_asks_the_demand_question_not_a_risk_one(self):
+        from cqc_lem.utilities.feedback.classifier import FeedbackCategory
+        svc = _mod()
+        comment = svc.build_decision_comment(
+            _classification(category=FeedbackCategory.FEATURE, confidence=0.95),
+            reporter_count=1)
+        assert "unproven-demand" in comment
+        assert "should the pipeline build it now?" in comment
+
+    def test_low_confidence_asks_the_scope_question(self):
+        svc = _mod()
+        comment = svc.build_decision_comment(_classification(confidence=0.62))
+        assert "low-confidence" in comment
+        assert "is the scope right?" in comment
+
+
+class TestDuplicateComment:
+    def test_plus_one_carries_the_new_detail_and_the_demand_count(self):
+        svc = _mod()
+        comment = svc.build_duplicate_comment(_classification(), feedback_id=9,
+                                             reporter_count=3, item_count=5)
+        assert comment.startswith("**+1")
+        assert "Only one comment is posted per automation run." in comment
+        assert "3 distinct reporter(s), 5 report(s)" in comment
+        assert "#9" in comment
+        assert svc.PLAN_DOC in comment
+
+
+class TestGithubIO:
+    def _response(self, status=201, payload=None):
+        response = MagicMock(status_code=status, text="")
+        response.json.return_value = payload if payload is not None else {}
+        return response
+
+    def test_create_issue_posts_title_body_labels_and_returns_the_number(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        monkeypatch.setenv("FEEDBACK_GITHUB_REPO", "o/r")
+        requests = MagicMock()
+        requests.request.return_value = self._response(201, {"number": 777})
+        with patch.dict("sys.modules", {"requests": requests}):
+            got = svc.create_github_issue("t", "b", ["bug"], assignees=["gitchrisqueen"])
+        assert got == 777
+        method, url = requests.request.call_args[0]
+        assert method == "POST"
+        assert url == "https://api.github.com/repos/o/r/issues"
+        payload = requests.request.call_args.kwargs["json"]
+        assert payload == {"title": "t", "body": "b", "labels": ["bug"],
+                           "assignees": ["gitchrisqueen"]}
+        headers = requests.request.call_args.kwargs["headers"]
+        assert headers["Authorization"] == "Bearer tok"
+
+    def test_no_token_files_nothing(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.delenv("FEEDBACK_GITHUB_TOKEN", raising=False)
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+        requests = MagicMock()
+        with patch.dict("sys.modules", {"requests": requests}):
+            assert svc.create_github_issue("t", "b", []) is None
+        requests.request.assert_not_called()
+
+    def test_github_token_is_the_fallback_credential(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.delenv("FEEDBACK_GITHUB_TOKEN", raising=False)
+        monkeypatch.setenv("GITHUB_TOKEN", "fallback")
+        assert svc.github_token() == "fallback"
+
+    def test_error_status_returns_none(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        requests = MagicMock()
+        requests.request.return_value = self._response(422, {"message": "nope"})
+        with patch.dict("sys.modules", {"requests": requests}):
+            assert svc.create_github_issue("t", "b", []) is None
+
+    def test_network_failure_returns_none(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        requests = MagicMock()
+        requests.request.side_effect = OSError("connection reset")
+        with patch.dict("sys.modules", {"requests": requests}):
+            assert svc.comment_on_issue(5, "body") is False
+
+    def test_comment_targets_the_issue_number(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        monkeypatch.setenv("FEEDBACK_GITHUB_REPO", "o/r")
+        requests = MagicMock()
+        requests.request.return_value = self._response(201, {"id": 1})
+        with patch.dict("sys.modules", {"requests": requests}):
+            assert svc.comment_on_issue(42, "+1") is True
+        assert requests.request.call_args[0][1] == \
+            "https://api.github.com/repos/o/r/issues/42/comments"
+
+    def test_non_json_success_response_still_counts_as_accepted(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        response = MagicMock(status_code=204, text="")
+        response.json.side_effect = ValueError("no body")
+        requests = MagicMock()
+        requests.request.return_value = response
+        with patch.dict("sys.modules", {"requests": requests}):
+            assert svc.comment_on_issue(42, "+1") is True
+
+    def test_comment_without_an_issue_number_is_a_no_op(self):
+        assert _mod().comment_on_issue(None, "+1") is False
+
+
+class TestFileFeedbackIssue:
+    """The orchestrator, with the classifier + GitHub + DB writes all mocked."""
+
+    def _patches(self, classification=None, issue_number=555, commented=True):
+        classification = classification or _classification()
+        return {
+            "classify": patch(f"{_SVC}.classify_feedback", return_value=classification),
+            "create": patch(f"{_SVC}.create_github_issue", return_value=issue_number),
+            "comment": patch(f"{_SVC}.comment_on_issue", return_value=commented),
+            "embed": patch(f"{_SVC}.embed_text", return_value=[1.0, 0.0]),
+            "triage": patch(f"{_SVC}.update_feedback_triage", return_value=True),
+            "rate": patch(f"{_SVC}.count_feedback_filed_by_user", return_value=0),
+        }
+
+    def _run(self, feedback, clusters=None, **overrides):
+        svc = _mod()
+        patches = self._patches(**overrides)
+        with patches["classify"] as classify, patches["create"] as create, \
+                patches["comment"] as comment, patches["embed"], \
+                patches["triage"] as triage, patches["rate"] as rate:
+            result = svc.file_feedback_issue(feedback, clusters=clusters if clusters is not None
+                                             else [])
+        return result, {"classify": classify, "create": create, "comment": comment,
+                        "triage": triage, "rate": rate}
+
+    def test_new_problem_files_one_issue_and_stamps_it_back(self):
+        from cqc_lem.utilities.db import FeedbackStatus
+        result, mocks = self._run({"id": 12, "user_id": 3, "body": "comments never post"})
+        assert result["action"] == "filed"
+        assert result["issue_number"] == 555
+        assert result["agent_ready"] is True
+        assert 'agent:ready' in result["labels"]
+        mocks["triage"].assert_called_once_with(
+            12, status=FeedbackStatus.ISSUE_CREATED, cluster_id=12,
+            github_issue_number=555, embedding=[1.0, 0.0])
+        # agent:ready issues are NOT assigned to a human and get no Decision Comment.
+        assert mocks["create"].call_args.kwargs["assignees"] is None
+        mocks["comment"].assert_not_called()
+
+    def test_filed_result_returns_a_cluster_for_in_batch_dedup(self):
+        result, _ = self._run({"id": 12, "user_id": 3, "body": "comments never post"})
+        assert result["cluster"] == {"cluster_id": 12, "body": "comments never post",
+                                    "embedding": [1.0, 0.0], "github_issue_number": 555,
+                                    "item_count": 1, "reporter_count": 1}
+
+    def test_risky_item_is_assigned_and_gets_a_decision_comment(self):
+        from cqc_lem.utilities.feedback.classifier import FeedbackRisk
+        result, mocks = self._run({"id": 12, "user_id": 3, "body": "delete my data please"},
+                                  classification=_classification(risk=FeedbackRisk.SECURITY))
+        assert result["agent_ready"] is False
+        assert mocks["create"].call_args.kwargs["assignees"] == ["gitchrisqueen"]
+        body = mocks["comment"].call_args[0][1]
+        assert "Human decision needed" in body
+        assert "risk:security" in body
+
+    def test_duplicate_comments_on_the_existing_issue_instead_of_filing(self):
+        from cqc_lem.utilities.db import FeedbackStatus
+        clusters = [_cluster(7, "comments never post", 101, embedding=[1.0, 0.0], reporters=2,
+                             items=3)]
+        result, mocks = self._run({"id": 15, "user_id": 4, "body": "replies do not post"},
+                                  clusters=clusters)
+        assert result["action"] == "deduped"
+        assert result["issue_number"] == 101
+        assert result["cluster_id"] == 7
+        mocks["create"].assert_not_called()
+        assert mocks["comment"].call_args[0][0] == 101
+        assert "+1" in mocks["comment"].call_args[0][1]
+        mocks["triage"].assert_called_once_with(
+            15, status=FeedbackStatus.CLUSTERED, cluster_id=7, github_issue_number=101,
+            embedding=[1.0, 0.0])
+
+    def test_classifier_named_duplicate_wins_even_below_the_cosine_threshold(self):
+        clusters = [_cluster(7, "billing double charge", 101, embedding=[0.0, 1.0])]
+        result, mocks = self._run({"id": 15, "user_id": 4, "body": "comments never post"},
+                                  clusters=clusters,
+                                  classification=_classification(duplicate_of=7))
+        assert result["action"] == "deduped"
+        assert result["cluster_id"] == 7
+        mocks["create"].assert_not_called()
+
+    def test_failed_duplicate_comment_leaves_the_row_for_a_retry(self):
+        clusters = [_cluster(7, "comments never post", 101, embedding=[1.0, 0.0])]
+        result, mocks = self._run({"id": 15, "user_id": 4, "body": "replies do not post"},
+                                  clusters=clusters, commented=False)
+        assert result["action"] == "error"
+        mocks["triage"].assert_not_called()
+
+    def test_failed_issue_creation_leaves_the_row_for_a_retry(self):
+        result, mocks = self._run({"id": 12, "user_id": 3, "body": "comments never post"},
+                                  issue_number=None)
+        assert result["action"] == "error"
+        assert result["reason"] == "issue creation failed"
+        mocks["triage"].assert_not_called()
+
+    def test_noise_is_dismissed_without_touching_github(self):
+        from cqc_lem.utilities.db import FeedbackStatus
+        from cqc_lem.utilities.feedback.classifier import FeedbackCategory
+        result, mocks = self._run({"id": 1, "user_id": 3, "body": "you guys rock"},
+                                  classification=_classification(
+                                      category=FeedbackCategory.NOISE, confidence=0.99))
+        assert result["action"] == "dropped"
+        mocks["create"].assert_not_called()
+        mocks["comment"].assert_not_called()
+        mocks["triage"].assert_called_once_with(1, status=FeedbackStatus.DISMISSED)
+
+    def test_question_is_routed_to_the_faq_queue_without_an_issue(self):
+        from cqc_lem.utilities.db import FeedbackStatus
+        from cqc_lem.utilities.feedback.classifier import FeedbackCategory
+        result, mocks = self._run({"id": 2, "user_id": 3, "body": "how do I schedule a post?"},
+                                  classification=_classification(
+                                      category=FeedbackCategory.QUESTION, confidence=0.99))
+        assert result["action"] == "faq"
+        mocks["create"].assert_not_called()
+        mocks["triage"].assert_called_once_with(2, status=FeedbackStatus.TRIAGED)
+
+    def test_low_confidence_goes_to_human_triage_not_the_backlog(self):
+        from cqc_lem.utilities.db import FeedbackStatus
+        result, mocks = self._run({"id": 3, "user_id": 3, "body": "idk it's weird"},
+                                  classification=_classification(confidence=0.2))
+        assert result["action"] == "needs_human"
+        mocks["create"].assert_not_called()
+        mocks["triage"].assert_called_once_with(3, status=FeedbackStatus.TRIAGED)
+
+    def test_empty_body_is_dropped_without_classifying(self):
+        result, mocks = self._run({"id": 4, "user_id": 3, "body": "   "})
+        assert result["action"] == "dropped"
+        mocks["classify"].assert_not_called()
+
+    def test_over_the_per_user_cap_is_held_before_any_llm_call(self):
+        svc = _mod()
+        with patch(f"{_SVC}.count_feedback_filed_by_user", return_value=3), \
+                patch(f"{_SVC}.classify_feedback") as classify, \
+                patch(f"{_SVC}.create_github_issue") as create, \
+                patch(f"{_SVC}.update_feedback_triage") as triage:
+            result = svc.file_feedback_issue({"id": 5, "user_id": 9, "body": "another one"},
+                                             clusters=[])
+        assert result["action"] == "rate_limited"
+        assert result["recent"] == 3
+        classify.assert_not_called()
+        create.assert_not_called()
+        # Status untouched, so a later pass (fresh window) still gets to file it.
+        triage.assert_not_called()
+
+    def test_anonymous_feedback_skips_the_per_user_cap(self):
+        svc = _mod()
+        with patch(f"{_SVC}.count_feedback_filed_by_user") as counter, \
+                patch(f"{_SVC}.classify_feedback", return_value=_classification()), \
+                patch(f"{_SVC}.create_github_issue", return_value=1), \
+                patch(f"{_SVC}.embed_text", return_value=None), \
+                patch(f"{_SVC}.update_feedback_triage"):
+            result = svc.file_feedback_issue({"id": 6, "user_id": None, "body": "comments break"},
+                                            clusters=[])
+        assert result["action"] == "filed"
+        counter.assert_not_called()
+
+    def test_stored_embedding_is_reused_instead_of_re_embedding(self):
+        svc = _mod()
+        with patch(f"{_SVC}.classify_feedback", return_value=_classification()), \
+                patch(f"{_SVC}.create_github_issue", return_value=1), \
+                patch(f"{_SVC}.embed_text") as embed, \
+                patch(f"{_SVC}.count_feedback_filed_by_user", return_value=0), \
+                patch(f"{_SVC}.update_feedback_triage"):
+            svc.file_feedback_issue({"id": 7, "user_id": 1, "body": "x y z",
+                                     "embedding": "[0.5, 0.5]"}, clusters=[])
+        embed.assert_not_called()
+
+    def test_context_json_string_is_passed_to_the_classifier_as_a_dict(self):
+        svc = _mod()
+        with patch(f"{_SVC}.classify_feedback", return_value=_classification()) as classify, \
+                patch(f"{_SVC}.create_github_issue", return_value=1), \
+                patch(f"{_SVC}.embed_text", return_value=None), \
+                patch(f"{_SVC}.count_feedback_filed_by_user", return_value=0), \
+                patch(f"{_SVC}.update_feedback_triage"):
+            svc.file_feedback_issue({"id": 8, "user_id": 1, "body": "broken",
+                                     "type_hint": "bug",
+                                     "context_json": json.dumps({"route": "/content"})},
+                                    clusters=[])
+        assert classify.call_args.kwargs["context"] == {"route": "/content"}
+        assert classify.call_args.kwargs["type_hint"] == "bug"
+
+    def test_malformed_context_json_does_not_break_filing(self):
+        svc = _mod()
+        with patch(f"{_SVC}.classify_feedback", return_value=_classification()) as classify, \
+                patch(f"{_SVC}.create_github_issue", return_value=1), \
+                patch(f"{_SVC}.embed_text", return_value=None), \
+                patch(f"{_SVC}.count_feedback_filed_by_user", return_value=0), \
+                patch(f"{_SVC}.update_feedback_triage"):
+            result = svc.file_feedback_issue({"id": 9, "user_id": 1, "body": "broken",
+                                             "context_json": "{not json"}, clusters=[])
+        assert result["action"] == "filed"
+        assert classify.call_args.kwargs["context"] is None
+
+    def test_clusters_are_loaded_from_the_db_when_not_injected(self):
+        svc = _mod()
+        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]) as loader, \
+                patch(f"{_SVC}.classify_feedback", return_value=_classification()), \
+                patch(f"{_SVC}.create_github_issue", return_value=1), \
+                patch(f"{_SVC}.embed_text", return_value=None), \
+                patch(f"{_SVC}.count_feedback_filed_by_user", return_value=0), \
+                patch(f"{_SVC}.update_feedback_triage"):
+            svc.file_feedback_issue({"id": 10, "user_id": 1, "body": "broken"})
+        loader.assert_called_once()
+
+
+class TestProcessNewFeedback:
+    def test_identical_reports_in_one_batch_file_one_issue(self):
+        svc = _mod()
+        rows = [{"id": 1, "user_id": 1, "body": "feed commenting stops after one comment"},
+                {"id": 2, "user_id": 2, "body": "feed commenting stops after one comment"}]
+        with patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.classify_feedback", return_value=_classification()), \
+                patch(f"{_SVC}.create_github_issue", return_value=900) as create, \
+                patch(f"{_SVC}.comment_on_issue", return_value=True) as comment, \
+                patch(f"{_SVC}.embed_text", return_value=None), \
+                patch(f"{_SVC}.count_feedback_filed_by_user", return_value=0), \
+                patch(f"{_SVC}.update_feedback_triage"):
+            result = svc.process_new_feedback(limit=10)
+        assert result == {"processed": 2, "counts": {"filed": 1, "deduped": 1}}
+        create.assert_called_once()
+        assert comment.call_args[0][0] == 900
+
+    def test_a_row_that_explodes_does_not_stop_the_pass(self):
+        svc = _mod()
+        rows = [{"id": 1, "user_id": 1, "body": "a"}, {"id": 2, "user_id": 2, "body": "b"}]
+        with patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.file_feedback_issue",
+                      side_effect=[RuntimeError("boom"), {"action": "filed"}]):
+            result = svc.process_new_feedback()
+        assert result == {"processed": 2, "counts": {"error": 1, "filed": 1}}
+
+    def test_empty_queue_is_a_no_op(self):
+        svc = _mod()
+        with patch(f"{_SVC}.get_unprocessed_feedback", return_value=[]), \
+                patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.create_github_issue") as create:
+            assert svc.process_new_feedback() == {"processed": 0, "counts": {}}
+        create.assert_not_called()
+
+
+class TestReclusterFeedback:
+    def test_late_duplicate_is_attached_and_plus_ones_the_existing_issue(self):
+        from cqc_lem.utilities.db import FeedbackStatus
+        svc = _mod()
+        clusters = [_cluster(7, "comments never post", 101, embedding=[1.0, 0.0])]
+        rows = [{"id": 30, "user_id": 5, "body": "replies do not post", "embedding": [1.0, 0.0]}]
+        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=clusters), \
+                patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.comment_on_issue", return_value=True) as comment, \
+                patch(f"{_SVC}.update_feedback_triage") as triage, \
+                patch(f"{_SVC}.embed_text") as embed:
+            result = svc.recluster_feedback()
+        assert result == {"scanned": 1, "attached": 1, "embedded": 0, "clusters": 1}
+        embed.assert_not_called()
+        assert comment.call_args[0][0] == 101
+        triage.assert_called_once_with(30, status=FeedbackStatus.CLUSTERED, cluster_id=7,
+                                       github_issue_number=101)
+
+    def test_missing_embeddings_are_backfilled(self):
+        svc = _mod()
+        rows = [{"id": 31, "user_id": 5, "body": "billing charged me twice"}]
+        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.embed_text", return_value=[0.0, 1.0]), \
+                patch(f"{_SVC}.update_feedback_triage") as triage:
+            result = svc.recluster_feedback()
+        assert result["embedded"] == 1
+        assert result["attached"] == 0
+        triage.assert_called_once_with(31, embedding=[0.0, 1.0])
+
+    def test_it_never_files_a_new_issue(self):
+        svc = _mod()
+        rows = [{"id": 32, "user_id": 5, "body": "something brand new"}]
+        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.embed_text", return_value=None), \
+                patch(f"{_SVC}.create_github_issue") as create, \
+                patch(f"{_SVC}.update_feedback_triage"):
+            svc.recluster_feedback()
+        create.assert_not_called()
+
+    def test_it_reconsiders_rows_already_parked_in_triage(self):
+        from cqc_lem.utilities.db import FeedbackStatus
+        svc = _mod()
+        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.get_unprocessed_feedback", return_value=[]) as loader:
+            svc.recluster_feedback(limit=50)
+        assert loader.call_args[0][0] == 50
+        assert loader.call_args.kwargs["statuses"] == (FeedbackStatus.NEW, FeedbackStatus.TRIAGED)
+
+    def test_a_failed_comment_does_not_mark_the_row_clustered(self):
+        svc = _mod()
+        clusters = [_cluster(7, "comments never post", 101, embedding=[1.0, 0.0])]
+        rows = [{"id": 33, "user_id": 5, "body": "replies do not post", "embedding": [1.0, 0.0]}]
+        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=clusters), \
+                patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.comment_on_issue", return_value=False), \
+                patch(f"{_SVC}.update_feedback_triage") as triage:
+            result = svc.recluster_feedback()
+        assert result["attached"] == 0
+        triage.assert_not_called()
+
+    def test_blank_bodies_are_skipped(self):
+        svc = _mod()
+        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.get_unprocessed_feedback",
+                      return_value=[{"id": 34, "body": "  "}]), \
+                patch(f"{_SVC}.embed_text") as embed:
+            result = svc.recluster_feedback()
+        assert result == {"scanned": 1, "attached": 0, "embedded": 0, "clusters": 0}
+        embed.assert_not_called()
+
+
+class TestEnvReaders:
+    def test_defaults(self, monkeypatch):
+        svc = _mod()
+        for key in ("FEEDBACK_GITHUB_REPO", "FEEDBACK_ISSUE_ASSIGNEE",
+                    "FEEDBACK_DUPLICATE_SIMILARITY", "FEEDBACK_FEATURE_DEMAND_MIN",
+                    "FEEDBACK_MAX_ISSUES_PER_USER_PER_DAY", "FEEDBACK_EMBEDDING_MODEL"):
+            monkeypatch.delenv(key, raising=False)
+        assert svc.github_repo() == svc.DEFAULT_REPO
+        assert svc.issue_assignee() == "gitchrisqueen"
+        assert svc.duplicate_similarity_min() == svc.DUPLICATE_SIMILARITY_DEFAULT
+        assert svc.feature_demand_min() == svc.FEATURE_DEMAND_MIN_DEFAULT
+        assert svc.max_issues_per_user_per_day() == svc.MAX_ISSUES_PER_USER_PER_DAY_DEFAULT
+        assert svc.embedding_model() == svc.DEFAULT_EMBEDDING_MODEL
+
+    @pytest.mark.parametrize("raw,expected", [("junk", 0.82), ("", 0.82), ("2", 1.0), ("-1", 0.0),
+                                              ("0.5", 0.5)])
+    def test_similarity_env_is_clamped_and_junk_tolerant(self, monkeypatch, raw, expected):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_DUPLICATE_SIMILARITY", raw)
+        assert svc.duplicate_similarity_min() == pytest.approx(expected)
+
+    @pytest.mark.parametrize("raw,expected", [("junk", 3), ("0", 1), ("500", 100), ("7", 7)])
+    def test_cap_env_is_clamped_and_junk_tolerant(self, monkeypatch, raw, expected):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_MAX_ISSUES_PER_USER_PER_DAY", raw)
+        assert svc.max_issues_per_user_per_day() == expected
+
+    def test_repo_and_assignee_are_configurable(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_REPO", "me/mine")
+        monkeypatch.setenv("FEEDBACK_ISSUE_ASSIGNEE", "someone")
+        assert svc.github_repo() == "me/mine"
+        assert svc.issue_assignee() == "someone"


### PR DESCRIPTION
## What & why

Stage 3 of the feedback→auto-work loop (`docs/launch-and-marketing-plan.md` §B.2/B.3). Stage 1 (#496) captures feedback, stage 2 (#497) classifies it; this stage turns an `auto_work` verdict into a **pipeline-ready GitHub issue** — and, crucially, prevents the same recurring problem from becoming N issues.

### New `utilities/feedback/issue_service.py`

- **Issue bodies are shaped for the RUNBOOK's `MODE=start`** — `## Why` / `## Scope` / `## Files` / `## Acceptance`, with a per-component files hint, the classifier verdict, and a reference to the plan doc. Title is conventional-commit shaped (`fix(feed-commenting): …`).
- **Label logic** (plan §B.2): the classifier's taxonomy labels + `feedback-loop`, then **exactly one** of
  - `agent:ready` — risk `none` **and** confidence ≥ 0.7 **and** feature demand proven → the pipeline builds it unattended;
  - `needs-human` (+ the matching `risk:*`), owner assigned, and a **RUNBOOK Decision Comment** with lettered options and a recommendation. The question asked matches *why* it is held: risk kind, unproven demand, or low confidence — one genuine question, never invented ones.
- **Dedup** (plan §B.3): embedding cosine against the open clusters, falling back to `content_framework.text_similarity` (the existing post-uniqueness token-overlap measure) whenever an embedding is missing — so dedup degrades to *lexical*, never to "everything is new". A match leaves a **+1 comment with the new detail and the demand count** on the existing issue instead of filing. The classifier's own `duplicate_of` verdict is honored even below the cosine threshold.
- **Abuse guards**: a per-user 24h cap checked **before** the LLM call (the row is *held*, not dropped, and a later pass with a fresh window picks it up); a *feature* cluster needs ≥ 2 distinct reporters before it may carry `agent:ready` — bugs auto-file on the first report.
- **Privacy**: only the classifier's factual `summary` reaches GitHub — never raw report text or reporter identity. Issues correlate by internal `feedback.id`.
- **Fail-safe**: a GitHub outage returns `error` and leaves the row unclustered for the next pass, so a report is never lost. **With no token configured nothing is ever filed** — that is the kill switch.

### Clustering with no schema change

A cluster id **is** the `feedback.id` of its seed row (the first report that got an issue). New db.py helpers: `get_feedback_by_id`, `get_unprocessed_feedback` (status-filtered), `get_open_feedback_clusters` (self-join giving the seed body/embedding + `item_count`/`reporter_count`), `count_feedback_filed_by_user`, `update_feedback_triage` (writes only the fields passed). No migration.

### Beat entries

| Entry | Cadence | Does |
|---|---|---|
| `file-feedback-issues` | every 30 min | classify → dedup → file; clusters loaded once and grown in memory, so a burst of identical reports = 1 issue + N-1 `+1`s |
| `recluster-feedback` | nightly 2:45 UTC | backfills missing embeddings, attaches leftover/untriaged rows to a cluster they now match. **Files nothing** — so a nightly re-run can never open a second issue for a known problem |

Both are `QueueOnce`. Auto-closing resolved clusters is deliberately left to the changelog/notify stage (#502).

Also adds the `lem-embedding` alias (`text-embedding-3-small`) to `.litellm/config.yaml` — callers tolerate it being absent — plus the new env vars in `.env.example` and the alias row in `CLAUDE.md`.

## Testing notes

- `tests/unit/utilities/test_feedback_issue_service.py` — 123 tests, **100% coverage of the new module**: cosine/fallback similarity edge cases, dedup selection (best match, below-threshold, no-issue clusters, env/arg threshold), label logic (every emitted label asserted against the real `gh label list` set, and `agent:ready` XOR `needs-human`), MODE=start body shape/ordering/provenance, Decision Comment shape per hold reason, GitHub I/O (auth header, payload, 4xx, network error, no-token), and the orchestrator for all seven outcomes.
- `tests/unit/utilities/test_db_feedback.py` — 12 new tests for the db helpers, incl. that unknown status values are rejected without touching the DB.
- `tests/unit/app/test_feedback_issue_tasks.py` — the two tasks + both beat entries resolve to real task attributes.
- Full unit suite: **4320 passed**.

Closes #498

🤖 Generated with [Claude Code](https://claude.com/claude-code)