### PR TITLE
feat(billing): early-adopter extended-trial (60d) auto-grant, gated on review submission (closes #499)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -199,6 +199,15 @@ C2PA_KEY_PATH=
 # =============================================================================
 FREE_TRIAL_DAYS=14
 
+# Early-adopter extended trial (issue #499): a longer trial in exchange for a public review.
+# Disabled until you explicitly turn it on — it changes billing terms.
+EARLY_ADOPTER_TRIAL_ENABLED=False
+EARLY_ADOPTER_TRIAL_DAYS=60
+EARLY_ADOPTER_P0_SLOTS=25
+EARLY_ADOPTER_P1_SLOTS=100
+# Optional Stripe coupon ID applied when a grant holder converts. Empty = extended trial only.
+EARLY_ADOPTER_COUPON_ID=
+
 # --- Stripe Test (use sk_test_* keys for test mode) ---
 STRIPE_API_KEY=sk_test_your_stripe_secret_key
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_signing_secret

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -113,6 +113,12 @@ RUNWAYML_API_SECRET=CHANGE_ME
 # Billing (Stripe — LIVE)
 # =============================================================================
 FREE_TRIAL_DAYS=14
+# Early-adopter extended trial (issue #499) — off until the launch cohort opens.
+EARLY_ADOPTER_TRIAL_ENABLED=False
+EARLY_ADOPTER_TRIAL_DAYS=60
+EARLY_ADOPTER_P0_SLOTS=25
+EARLY_ADOPTER_P1_SLOTS=100
+EARLY_ADOPTER_COUPON_ID=
 STRIPE_API_KEY=sk_live_CHANGE_ME
 STRIPE_WEBHOOK_SECRET=whsec_CHANGE_ME
 STRIPE_PRICE_ID_STARTER=price_CHANGE_ME

--- a/compose/local/database/migrations/V20260725085226__add_early_adopter_trial.sql
+++ b/compose/local/database/migrations/V20260725085226__add_early_adopter_trial.sql
@@ -1,0 +1,30 @@
+-- Early-adopter extended trial (issue #499). Early adopters trade a public review for a longer
+-- trial (EARLY_ADOPTER_TRIAL_DAYS, default 60) instead of the standard FREE_TRIAL_DAYS (14).
+--
+-- Two tables, because the two things they hold have different lifetimes:
+--   early_adopter_slots  -> the ATOMIC cohort counter. One row per cohort; a slot is claimed with a
+--                           single `UPDATE ... SET used = used + 1 WHERE cohort=? AND used < ?`,
+--                           whose rowcount is the claim result. The cap lives in env (not here) so
+--                           the owner can retune P0/P1 without a migration.
+--   early_adopter_grants -> the audit trail of who got what, UNIQUE on user_id so one user can
+--                           never consume two slots even under concurrent requests.
+CREATE TABLE IF NOT EXISTS early_adopter_slots (
+    cohort     VARCHAR(16) NOT NULL PRIMARY KEY,
+    used       INT NOT NULL DEFAULT 0,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+INSERT INTO early_adopter_slots (cohort, used) VALUES ('P0', 0), ('P1', 0)
+    ON DUPLICATE KEY UPDATE cohort = cohort;
+
+CREATE TABLE IF NOT EXISTS early_adopter_grants (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    user_id       INT NOT NULL,
+    cohort        VARCHAR(16) NOT NULL,
+    trial_days    INT NOT NULL,
+    feedback_id   INT NULL,
+    trial_ends_at DATETIME NOT NULL,
+    granted_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_early_adopter_user (user_id),
+    INDEX idx_early_adopter_cohort (cohort, granted_at)
+);

--- a/docs/stripe-setup-guide.md
+++ b/docs/stripe-setup-guide.md
@@ -94,6 +94,25 @@ FREE_TRIAL_DAYS=14
 
 New users created via the email PIN flow are automatically assigned a trial subscription when their account is created.
 
+### Early-adopter extended trial (issue #499)
+
+Early adopters can trade a public review for a longer trial. `POST /api/trial/extend` grants it only
+when the user has a `feedback` row with `source='review'`, and only while a cohort slot is free —
+slots are claimed atomically, so the caps are hard caps. When both cohorts are full the user simply
+keeps the standard `FREE_TRIAL_DAYS` trial.
+
+```env
+EARLY_ADOPTER_TRIAL_ENABLED=False   # off until you open the program
+EARLY_ADOPTER_TRIAL_DAYS=60
+EARLY_ADOPTER_P0_SLOTS=25           # first cohort; 0 closes it
+EARLY_ADOPTER_P1_SLOTS=100          # fills after P0
+EARLY_ADOPTER_COUPON_ID=            # optional Stripe coupon ID applied on conversion
+```
+
+When a grant holder converts, the days still left on the extension are carried into Checkout as
+`trial_period_days` (plus the coupon, if set), so upgrading early doesn't forfeit the remaining
+trial. Users without a grant convert exactly as before.
+
 ---
 
 ## Complete `.env` Stripe block
@@ -105,6 +124,11 @@ STRIPE_PRICE_ID_STARTER=price_1Abc...
 STRIPE_PRICE_ID_PROFESSIONAL=price_1Def...
 STRIPE_PRICE_ID_ENTERPRISE=price_1Ghi...
 FREE_TRIAL_DAYS=14
+EARLY_ADOPTER_TRIAL_ENABLED=False
+EARLY_ADOPTER_TRIAL_DAYS=60
+EARLY_ADOPTER_P0_SLOTS=25
+EARLY_ADOPTER_P1_SLOTS=100
+EARLY_ADOPTER_COUPON_ID=
 ```
 
 ---

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1,5 +1,6 @@
 import io
 import json
+import math
 import os
 import time
 import zipfile
@@ -70,6 +71,7 @@ from cqc_lem.utilities.db import (
     update_db_post_carousel_slides,
     get_post_url_from_log_for_user,
     insert_feedback, FeedbackSource,
+    get_latest_review_feedback_id, get_early_adopter_grant, extend_trial_for_user,
 )
 from cqc_lem.utilities.email import generate_pin, hash_pin, send_pin_email
 from cqc_lem.utilities.linkedin.verification_pin import (
@@ -298,6 +300,11 @@ class CheckoutSessionRequest(BaseModel):
 class PortalSessionRequest(BaseModel):
     session_token: str
     return_url: str
+
+
+class TrialExtendRequest(BaseModel):
+    """Claim the early-adopter extended trial (issue #499)."""
+    session_token: str
 
 
 class UserPreferencesRequest(BaseModel):
@@ -2692,6 +2699,75 @@ def update_company_page_endpoint(request: LinkedInCompanyPageRequest) -> Respons
     return ResponseModel(status_code=200, detail="Company page saved" if url else "Company page cleared")
 
 
+@router.post("/trial/extend", responses={
+    200: {"description": "Extension result (granted or the reason it wasn't)"},
+    **{k: v for k, v in error_responses.items() if k in [401, 404]},
+})
+def trial_extend_endpoint(request: TrialExtendRequest) -> ResponseModel:
+    """Claim the early-adopter extended trial (issue #499): EARLY_ADOPTER_TRIAL_DAYS instead of the
+    standard FREE_TRIAL_DAYS, in exchange for a public review.
+
+    Not-granted outcomes are 200s with a `reason`, not errors — the SPA renders them as a prompt
+    ("submit a quick review to unlock N days"), and an exhausted cohort is a normal state, not a
+    failure: the user simply keeps their standard trial.
+    """
+    from cqc_lem.utilities.env_constants import (
+        EARLY_ADOPTER_TRIAL_ENABLED, EARLY_ADOPTER_TRIAL_DAYS, FREE_TRIAL_DAYS,
+    )
+    if not EARLY_ADOPTER_TRIAL_ENABLED:
+        raise HTTPException(status_code=404, detail="Early-adopter extended trial is not available")
+
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    review_id = get_latest_review_feedback_id(user_id)
+    if not review_id:
+        return ResponseModel(status_code=200, detail={
+            "granted": False,
+            "reason": "review_required",
+            "trial_days": FREE_TRIAL_DAYS,
+            "message": f"Submit a quick review to unlock {EARLY_ADOPTER_TRIAL_DAYS} days.",
+        })
+
+    result = extend_trial_for_user(user_id, feedback_id=review_id)
+    trial_ends_at = result.get("trial_ends_at")
+    return ResponseModel(status_code=200, detail={
+        "granted": result.get("granted", False),
+        "reason": result.get("reason"),
+        "cohort": result.get("cohort"),
+        "trial_days": result.get("trial_days", FREE_TRIAL_DAYS),
+        "trial_ends_at": trial_ends_at.isoformat() if trial_ends_at else None,
+    })
+
+
+def _early_adopter_checkout_extras(user_id: int) -> tuple[Optional[int], Optional[List[dict]]]:
+    """Mirror an unfinished early-adopter trial into Stripe on conversion (issue #499): the days
+    still left on the grant become the Checkout trial, and the optional launch coupon rides along.
+    Only grant holders are affected — a standard trial converts exactly as it does today.
+
+    Best-effort by design: this is a perk lookup, so any failure degrades to a normal checkout
+    rather than blocking the user from paying us."""
+    from cqc_lem.utilities.env_constants import EARLY_ADOPTER_COUPON_ID
+    try:
+        grant = get_early_adopter_grant(user_id)
+    except Exception as e:
+        log_warning("Could not read early-adopter grant for checkout", exc=e, user_id=user_id)
+        return None, None
+    if not grant:
+        return None, None
+    ends_at = grant.get("trial_ends_at")
+    trial_period_days = None
+    if ends_at:
+        if ends_at.tzinfo is None:
+            ends_at = ends_at.replace(tzinfo=timezone.utc)
+        remaining = math.ceil((ends_at - datetime.now(timezone.utc)).total_seconds() / 86400)
+        if remaining >= 1:
+            trial_period_days = int(remaining)
+    discounts = [{"coupon": EARLY_ADOPTER_COUPON_ID}] if EARLY_ADOPTER_COUPON_ID else None
+    return trial_period_days, discounts
+
+
 @router.post("/billing/create-checkout-session")
 def billing_create_checkout_session(request: CheckoutSessionRequest) -> ResponseModel:
     user_id = get_session_user_id(request.session_token)
@@ -2718,11 +2794,14 @@ def billing_create_checkout_session(request: CheckoutSessionRequest) -> Response
             f"In-place upgrade failed for sub={existing_sub_id}; falling back to checkout session"
         )
 
+    trial_period_days, discounts = _early_adopter_checkout_extras(user_id)
     url = create_checkout_session(
         stripe_customer_id,
         request.tier,
         request.success_url,
         request.cancel_url,
+        trial_period_days=trial_period_days,
+        discounts=discounts,
     )
     if not url:
         raise HTTPException(status_code=500, detail="Could not create Stripe checkout session")

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -2764,6 +2764,10 @@ def _early_adopter_checkout_extras(user_id: int) -> tuple[Optional[int], Optiona
         remaining = math.ceil((ends_at - datetime.now(timezone.utc)).total_seconds() / 86400)
         if remaining >= 1:
             trial_period_days = int(remaining)
+    # The coupon rides with the unfinished trial, so an expired/exhausted grant carries neither —
+    # otherwise a long-lapsed grant would keep discounting every future checkout.
+    if trial_period_days is None:
+        return None, None
     discounts = [{"coupon": EARLY_ADOPTER_COUPON_ID}] if EARLY_ADOPTER_COUPON_ID else None
     return trial_period_days, discounts
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -13,7 +13,7 @@ from cqc_lem.utilities.env_constants import (
     SESSION_IDLE_HOURS,
 )
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
-from cqc_lem.utilities.logger import myprint, log_error
+from cqc_lem.utilities.logger import myprint, log_error, log_info
 from cqc_lem.utilities.utils import get_top_level_domain, get_aws_ssm_secret
 from dotenv import load_dotenv
 from mysql.connector import errorcode
@@ -7000,6 +7000,185 @@ def has_automated_engagement(user_id: int) -> bool:
     except mysql.connector.Error as err:
         log_error(f"Could not check automated engagement for user_id {user_id}", exc=err)
         return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+# ---------------------------------------------------------------------------
+# Early-adopter extended trial (issue #499)
+# ---------------------------------------------------------------------------
+
+# Cohorts are tried in order: P0 (the hand-picked launch group) fills first, then P1. Capacities
+# come from env at call time so the caps can be retuned without a migration or a code change.
+EARLY_ADOPTER_COHORTS = ("P0", "P1")
+
+# Statuses an extension may act on. A paying ('active'/'past_due') or churned ('cancelled') user is
+# not on a trial, so extending one would either be a no-op or silently reopen a closed account.
+_EXTENDABLE_STATUSES = ("trial", "inactive")
+
+
+def _as_naive_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    """MySQL DATETIME columns come back naive; our own timestamps are UTC-aware. Normalize both to
+    naive-UTC so they can be compared without a TypeError."""
+    if dt is None or dt.tzinfo is None:
+        return dt
+    return dt.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def get_latest_review_feedback_id(user_id: int) -> Optional[int]:
+    """The most recent `feedback` row this user filed with source='review' — the gate the
+    early-adopter extension is traded for. None when they haven't left a review yet."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT id FROM feedback WHERE user_id=%s AND source=%s ORDER BY created_at DESC, id DESC LIMIT 1",
+            (user_id, str(FeedbackSource.REVIEW)),
+        )
+        row = cursor.fetchone()
+        return int(row[0]) if row else None
+    except mysql.connector.Error as err:
+        log_error("Could not look up review feedback", exc=err, user_id=user_id)
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_early_adopter_grant(user_id: int) -> Optional[dict]:
+    """The user's early-adopter grant, or None. Read by the checkout flow so the extension mirrors
+    into Stripe on conversion."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT id, user_id, cohort, trial_days, feedback_id, trial_ends_at, granted_at "
+            "FROM early_adopter_grants WHERE user_id=%s",
+            (user_id,),
+        )
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        log_error("Could not fetch early-adopter grant", exc=err, user_id=user_id)
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_early_adopter_slot_usage() -> dict:
+    """`{cohort: used}` for every cohort row — what the caps are measured against."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT cohort, used FROM early_adopter_slots")
+        return {str(cohort): int(used or 0) for cohort, used in cursor.fetchall()}
+    except mysql.connector.Error as err:
+        log_error("Could not read early-adopter slot usage", exc=err)
+        return {}
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def extend_trial_for_user(user_id: int, feedback_id: Optional[int] = None) -> dict:
+    """Claim an early-adopter cohort slot and extend the user's trial to
+    `trial_started_at + EARLY_ADOPTER_TRIAL_DAYS` (issue #499).
+
+    The caller owns the review gate; this owns atomicity. Everything below runs in ONE transaction:
+    the slot claim is a single conditional UPDATE (its rowcount IS the claim result, so two
+    concurrent requests can never both take the last slot), and the unique `user_id` on
+    early_adopter_grants means a duplicate request rolls the whole thing back — including the
+    counter — rather than burning a second slot.
+
+    Returns a dict the API can hand straight to the SPA:
+      granted, reason, cohort, trial_days, trial_ends_at
+    where reason is one of granted | already_granted | slots_exhausted | not_on_trial |
+    user_not_found | error.
+    """
+    from cqc_lem.utilities.env_constants import (
+        EARLY_ADOPTER_P0_SLOTS, EARLY_ADOPTER_P1_SLOTS, EARLY_ADOPTER_TRIAL_DAYS, FREE_TRIAL_DAYS,
+    )
+    capacities = {"P0": EARLY_ADOPTER_P0_SLOTS, "P1": EARLY_ADOPTER_P1_SLOTS}
+
+    def _result(granted: bool, reason: str, cohort: Optional[str] = None,
+                trial_days: int = FREE_TRIAL_DAYS, trial_ends_at: Optional[datetime] = None) -> dict:
+        return {"granted": granted, "reason": reason, "cohort": cohort,
+                "trial_days": trial_days, "trial_ends_at": trial_ends_at}
+
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        connection.start_transaction()
+
+        cursor.execute(
+            "SELECT cohort, trial_days, trial_ends_at FROM early_adopter_grants WHERE user_id=%s FOR UPDATE",
+            (user_id,),
+        )
+        existing = cursor.fetchone()
+        if existing:
+            connection.rollback()
+            return _result(True, "already_granted", existing["cohort"],
+                           int(existing["trial_days"]), existing["trial_ends_at"])
+
+        cursor.execute(
+            "SELECT subscription_status, trial_started_at, trial_ends_at FROM users WHERE id=%s FOR UPDATE",
+            (user_id,),
+        )
+        user = cursor.fetchone()
+        if not user:
+            connection.rollback()
+            return _result(False, "user_not_found")
+        if user["subscription_status"] not in _EXTENDABLE_STATUSES:
+            connection.rollback()
+            return _result(False, "not_on_trial")
+
+        claimed: Optional[str] = None
+        for cohort in EARLY_ADOPTER_COHORTS:
+            capacity = int(capacities.get(cohort, 0))
+            if capacity <= 0:
+                continue
+            cursor.execute(
+                "UPDATE early_adopter_slots SET used = used + 1 WHERE cohort=%s AND used < %s",
+                (cohort, capacity),
+            )
+            if cursor.rowcount == 1:
+                claimed = cohort
+                break
+        if not claimed:
+            connection.rollback()
+            return _result(False, "slots_exhausted")
+
+        started = _as_naive_utc(user["trial_started_at"]) or datetime.now(timezone.utc).replace(tzinfo=None)
+        new_end = started + timedelta(days=EARLY_ADOPTER_TRIAL_DAYS)
+        current_end = _as_naive_utc(user["trial_ends_at"])
+        # An extension must never shorten a trial the user already has.
+        if current_end and current_end > new_end:
+            new_end = current_end
+
+        cursor.execute(
+            "INSERT INTO early_adopter_grants (user_id, cohort, trial_days, feedback_id, trial_ends_at) "
+            "VALUES (%s,%s,%s,%s,%s)",
+            (user_id, claimed, EARLY_ADOPTER_TRIAL_DAYS, feedback_id, new_end),
+        )
+        cursor.execute(
+            "UPDATE users SET trial_started_at=%s, trial_ends_at=%s, subscription_status='trial', "
+            "subscription_tier=COALESCE(subscription_tier,'free_trial') WHERE id=%s",
+            (started, new_end, user_id),
+        )
+        connection.commit()
+        log_info("Early-adopter trial granted", user_id=user_id)
+        return _result(True, "granted", claimed, EARLY_ADOPTER_TRIAL_DAYS, new_end)
+    except mysql.connector.Error as err:
+        connection.rollback()
+        if err.errno == errorcode.ER_DUP_ENTRY:
+            # Two concurrent requests for the same user; the rollback released the slot this one took.
+            existing = get_early_adopter_grant(user_id)
+            if existing:
+                return _result(True, "already_granted", existing["cohort"],
+                               int(existing["trial_days"]), existing["trial_ends_at"])
+        log_error("Could not extend trial", exc=err, user_id=user_id)
+        return _result(False, "error")
     finally:
         cursor.close()
         connection.close()

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -179,6 +179,17 @@ STRIPE_PRICE_ID_PROFESSIONAL  = get_constant_from_env('STRIPE_PRICE_ID_PROFESSIO
 STRIPE_PRICE_ID_ENTERPRISE    = get_constant_from_env('STRIPE_PRICE_ID_ENTERPRISE')
 FREE_TRIAL_DAYS           = int(get_constant_from_env('FREE_TRIAL_DAYS', default_value='14'))
 
+# Early-adopter extended trial (issue #499). OFF by default: it changes billing terms, so every
+# environment has to opt in explicitly rather than inheriting a longer trial from a deploy.
+# Cohort caps live here (not in the DB) so P0/P1 can be retuned without a migration; setting a cap
+# to 0 closes that cohort. When both are exhausted the user simply keeps the standard trial.
+EARLY_ADOPTER_TRIAL_ENABLED = isTrue(get_constant_from_env('EARLY_ADOPTER_TRIAL_ENABLED', default_value='False'))
+EARLY_ADOPTER_TRIAL_DAYS  = int(get_constant_from_env('EARLY_ADOPTER_TRIAL_DAYS', default_value='60'))
+EARLY_ADOPTER_P0_SLOTS    = int(get_constant_from_env('EARLY_ADOPTER_P0_SLOTS', default_value='25'))
+EARLY_ADOPTER_P1_SLOTS    = int(get_constant_from_env('EARLY_ADOPTER_P1_SLOTS', default_value='100'))
+# Optional Stripe coupon applied at conversion for grant holders. Empty = no discount, trial only.
+EARLY_ADOPTER_COUPON_ID   = get_constant_from_env('EARLY_ADOPTER_COUPON_ID', default_value='')
+
 # Unit-economics inputs for the margin report (docs/cost-performance-margin-plan.md §C.1). Monthly
 # tier prices mirror the SPA pricing table — override per environment instead of editing code so a
 # price change never needs a deploy.

--- a/src/cqc_lem/utilities/stripe_util.py
+++ b/src/cqc_lem/utilities/stripe_util.py
@@ -59,14 +59,24 @@ def create_stripe_customer(email: str, user_id: int) -> Optional[str]:
         return None
 
 
+# Stripe rejects a subscription trial longer than 2 years.
+STRIPE_MAX_TRIAL_DAYS = 730
+
+
 def create_checkout_session(
     stripe_customer_id: str,
     tier: str,
     success_url: str,
     cancel_url: str,
+    trial_period_days: Optional[int] = None,
+    discounts: Optional[list[dict]] = None,
 ) -> Optional[str]:
     """Create a Stripe Checkout session for a subscription upgrade.
     Returns the checkout session URL, or None on failure.
+
+    `trial_period_days` carries an unfinished trial (e.g. an early-adopter extension, issue #499)
+    into Stripe so converting early doesn't forfeit the remaining days; `discounts` is passed
+    straight through as Stripe's discounts list (e.g. `[{"coupon": "EARLYBIRD"}]`).
     """
     price_id = TIER_PRICE_MAP.get(tier)
     if not price_id:
@@ -75,6 +85,14 @@ def create_checkout_session(
     if not STRIPE_API_KEY:
         myprint("STRIPE_API_KEY not set — cannot create checkout session")
         return None
+
+    extra: dict = {}
+    if trial_period_days and int(trial_period_days) > 0:
+        extra["subscription_data"] = {
+            "trial_period_days": min(int(trial_period_days), STRIPE_MAX_TRIAL_DAYS)
+        }
+    if discounts:
+        extra["discounts"] = discounts
 
     stripe = _get_stripe()
     try:
@@ -85,6 +103,7 @@ def create_checkout_session(
             mode="subscription",
             success_url=success_url,
             cancel_url=cancel_url,
+            **extra,
         )
         return session.url
     except Exception as e:

--- a/tests/integration/test_early_adopter_trial.py
+++ b/tests/integration/test_early_adopter_trial.py
@@ -1,0 +1,234 @@
+"""Integration test for the early-adopter extended trial (#499).
+
+Drives the real POST /api/trial/extend handler through the real db.extend_trial_for_user into a
+stateful fake that models `users`, `feedback`, `early_adopter_slots` and `early_adopter_grants` —
+including the row lock behind the conditional slot UPDATE — so the acceptance criteria (grant only
+with a review, atomic slot counter, extension mirrored into Stripe on conversion) are proven
+end-to-end without a live MySQL container.
+"""
+import threading
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from unittest.mock import patch
+
+import mysql.connector
+from mysql.connector import errorcode
+
+pytestmark = pytest.mark.integration
+
+_DB = "cqc_lem.utilities.db"
+_MAIN = "cqc_lem.api.main"
+_ENV = "cqc_lem.utilities.env_constants"
+
+STARTED = datetime(2026, 7, 1, 12, 0, 0)
+
+
+class _Store:
+    """In-memory stand-in for the four tables the extension touches."""
+
+    def __init__(self, user_ids, reviewers):
+        self.users = {uid: {"subscription_status": "trial", "trial_started_at": STARTED,
+                            "trial_ends_at": STARTED + timedelta(days=14)} for uid in user_ids}
+        self.reviews = {uid: 100 + uid for uid in reviewers}
+        self.slots = {"P0": 0, "P1": 0}
+        self.grants: dict = {}
+        # MySQL serializes the conditional slot UPDATE on the cohort row; this is that row lock.
+        self.lock = threading.Lock()
+
+
+class _Cursor:
+    def __init__(self, store, conn):
+        self.store = store
+        self.conn = conn
+        self._result = None
+        self.rowcount = 0
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        self.rowcount = 0
+        if s.startswith("SELECT id FROM feedback"):
+            user_id, source = params
+            assert source == "review"
+            fid = self.store.reviews.get(user_id)
+            self._result = (fid,) if fid else None
+        elif s.startswith("SELECT cohort, trial_days, trial_ends_at FROM early_adopter_grants"):
+            self._result = self.store.grants.get(params[0])
+        elif s.startswith("SELECT id, user_id, cohort"):
+            self._result = self.store.grants.get(params[0])
+        elif s.startswith("SELECT subscription_status, trial_started_at, trial_ends_at FROM users"):
+            self._result = self.store.users.get(params[0])
+        elif s.startswith("UPDATE early_adopter_slots"):
+            cohort, capacity = params
+            with self.store.lock:
+                if self.store.slots.get(cohort, 0) < capacity:
+                    self.store.slots[cohort] += 1
+                    self.conn.claimed.append(cohort)
+                    self.rowcount = 1
+        elif s.startswith("INSERT INTO early_adopter_grants"):
+            user_id, cohort, trial_days, feedback_id, ends = params
+            if user_id in self.store.grants:
+                err = mysql.connector.Error("duplicate")
+                err.errno = errorcode.ER_DUP_ENTRY
+                raise err
+            self.conn.pending_grant = (user_id, {"id": len(self.store.grants) + 1,
+                                                 "user_id": user_id, "cohort": cohort,
+                                                 "trial_days": trial_days,
+                                                 "feedback_id": feedback_id,
+                                                 "trial_ends_at": ends})
+            self.rowcount = 1
+        elif s.startswith("UPDATE users SET trial_started_at"):
+            started, ends, user_id = params
+            self.conn.pending_user = (user_id, started, ends)
+            self.rowcount = 1
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    def fetchone(self):
+        return self._result
+
+    def fetchall(self):
+        return []
+
+    def close(self):
+        pass
+
+
+class _Conn:
+    def __init__(self, store):
+        self.store = store
+        self.claimed: list = []
+        self.pending_grant = None
+        self.pending_user = None
+
+    def cursor(self, *a, **k):
+        return _Cursor(self.store, self)
+
+    def start_transaction(self):
+        pass
+
+    def commit(self):
+        if self.pending_grant:
+            user_id, row = self.pending_grant
+            self.store.grants[user_id] = row
+        if self.pending_user:
+            user_id, started, ends = self.pending_user
+            self.store.users[user_id].update({"trial_started_at": started, "trial_ends_at": ends,
+                                              "subscription_status": "trial"})
+        self._reset()
+
+    def rollback(self):
+        # A rolled-back transaction gives its claimed slot back — otherwise a losing racer would
+        # permanently burn a seat in the cohort.
+        with self.store.lock:
+            for cohort in self.claimed:
+                self.store.slots[cohort] -= 1
+        self._reset()
+
+    def _reset(self):
+        self.claimed = []
+        self.pending_grant = None
+        self.pending_user = None
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from cqc_lem.api.main import app
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _extend(client, store, user_id, p0=25, p1=100):
+    with patch(f"{_DB}.get_db_connection", side_effect=lambda: _Conn(store)), \
+            patch(f"{_MAIN}.get_session_user_id", return_value=user_id), \
+            patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_ENABLED", True), \
+            patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_DAYS", 60), \
+            patch(f"{_ENV}.EARLY_ADOPTER_P0_SLOTS", p0), \
+            patch(f"{_ENV}.EARLY_ADOPTER_P1_SLOTS", p1):
+        return client.post("/api/trial/extend", json={"session_token": f"tok{user_id}"})
+
+
+def test_review_gate_blocks_the_extension(client):
+    store = _Store(user_ids=[1], reviewers=[])
+    resp = _extend(client, store, 1)
+
+    assert resp.status_code == 200
+    detail = resp.json()["detail"]
+    assert detail["granted"] is False and detail["reason"] == "review_required"
+    assert store.grants == {} and store.slots == {"P0": 0, "P1": 0}
+    # trial untouched: still the standard 14 days
+    assert store.users[1]["trial_ends_at"] == STARTED + timedelta(days=14)
+
+
+def test_review_unlocks_60_days_and_is_idempotent(client):
+    store = _Store(user_ids=[1], reviewers=[1])
+
+    detail = _extend(client, store, 1).json()["detail"]
+    assert detail["granted"] is True
+    assert detail["cohort"] == "P0" and detail["trial_days"] == 60
+    assert store.users[1]["trial_ends_at"] == STARTED + timedelta(days=60)
+    assert store.grants[1]["feedback_id"] == 101  # the review row that unlocked it
+    assert store.slots["P0"] == 1
+
+    again = _extend(client, store, 1).json()["detail"]
+    assert again["granted"] is True and again["reason"] == "already_granted"
+    assert store.slots["P0"] == 1  # no second slot consumed
+
+
+def test_cohort_counter_is_atomic_under_concurrency(client):
+    """8 simultaneous claims against a 2-seat cohort must produce exactly 2 grants."""
+    user_ids = list(range(1, 9))
+    store = _Store(user_ids=user_ids, reviewers=user_ids)
+    results: list = []
+    barrier = threading.Barrier(len(user_ids))
+
+    from cqc_lem.api.main import trial_extend_endpoint, TrialExtendRequest
+
+    def _claim(user_id: int):
+        barrier.wait()
+        with patch(f"{_MAIN}.get_session_user_id", return_value=user_id):
+            results.append(trial_extend_endpoint(TrialExtendRequest(session_token=f"tok{user_id}")))
+
+    with patch(f"{_DB}.get_db_connection", side_effect=lambda: _Conn(store)), \
+            patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_ENABLED", True), \
+            patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_DAYS", 60), \
+            patch(f"{_ENV}.EARLY_ADOPTER_P0_SLOTS", 2), \
+            patch(f"{_ENV}.EARLY_ADOPTER_P1_SLOTS", 0):
+        threads = [threading.Thread(target=_claim, args=(uid,)) for uid in user_ids]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+    granted = [r for r in results if r.detail["granted"]]
+    assert len(granted) == 2
+    assert store.slots["P0"] == 2
+    assert len(store.grants) == 2
+    assert all(r.detail["reason"] == "slots_exhausted" for r in results if not r.detail["granted"])
+
+
+def test_conversion_mirrors_the_remaining_trial_into_stripe(client):
+    store = _Store(user_ids=[1], reviewers=[1])
+    # Trial started today so the grant still has ~60 days left to carry into Stripe.
+    store.users[1]["trial_started_at"] = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(days=10)
+    store.users[1]["trial_ends_at"] = None
+    assert _extend(client, store, 1).json()["detail"]["granted"] is True
+
+    with patch(f"{_DB}.get_db_connection", side_effect=lambda: _Conn(store)), \
+            patch(f"{_MAIN}.get_session_user_id", return_value=1), \
+            patch(f"{_ENV}.EARLY_ADOPTER_COUPON_ID", "EARLYBIRD"), \
+            patch(f"{_MAIN}.get_user_subscription_info",
+                  return_value={"stripe_customer_id": "cus_1", "stripe_subscription_id": None,
+                                "subscription_status": "trial"}), \
+            patch("cqc_lem.utilities.stripe_util.create_checkout_session",
+                  return_value="https://checkout.stripe.com/x") as create:
+        resp = client.post("/api/billing/create-checkout-session",
+                           json={"session_token": "tok1", "tier": "starter",
+                                 "success_url": "https://e.com/s", "cancel_url": "https://e.com/c"})
+
+    assert resp.status_code == 200
+    assert create.call_args.kwargs["trial_period_days"] == 50  # 60-day grant, 10 days used
+    assert create.call_args.kwargs["discounts"] == [{"coupon": "EARLYBIRD"}]

--- a/tests/unit/api/test_main_billing.py
+++ b/tests/unit/api/test_main_billing.py
@@ -278,6 +278,8 @@ class TestBillingCreateCheckoutSession:
             "cus_new", "starter",
             "https://example.com/success",
             "https://example.com/cancel",
+            trial_period_days=None,   # no early-adopter grant (issue #499)
+            discounts=None,
         )
 
     def test_create_checkout_session_returns_none_raises_500(self, client):

--- a/tests/unit/api/test_trial_extend_api.py
+++ b/tests/unit/api/test_trial_extend_api.py
@@ -1,0 +1,144 @@
+"""Unit tests for POST /api/trial/extend and the Stripe conversion mirror (issue #499)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+_MAIN = "cqc_lem.api.main"
+_ENV = "cqc_lem.utilities.env_constants"
+
+
+@pytest.fixture(scope="module")
+def client():
+    from cqc_lem.api.main import app
+    with TestClient(app, raise_server_exceptions=False) as tc:
+        yield tc
+
+
+class TestTrialExtendEndpoint:
+    BASE = "/api/trial/extend"
+
+    def test_disabled_flag_returns_404_without_touching_db(self, client):
+        with patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_ENABLED", False), \
+             patch(f"{_MAIN}.extend_trial_for_user") as extend:
+            resp = client.post(self.BASE, json={"session_token": "tok"})
+        assert resp.status_code == 404
+        extend.assert_not_called()
+
+    def test_invalid_session_returns_401(self, client):
+        with patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_ENABLED", True), \
+             patch(f"{_MAIN}.get_session_user_id", return_value=None), \
+             patch(f"{_MAIN}.extend_trial_for_user") as extend:
+            resp = client.post(self.BASE, json={"session_token": "bad"})
+        assert resp.status_code == 401
+        extend.assert_not_called()
+
+    def test_no_review_returns_prompt_and_grants_nothing(self, client):
+        with patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_ENABLED", True), \
+             patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_DAYS", 60), \
+             patch(f"{_MAIN}.get_session_user_id", return_value=7), \
+             patch(f"{_MAIN}.get_latest_review_feedback_id", return_value=None), \
+             patch(f"{_MAIN}.extend_trial_for_user") as extend:
+            resp = client.post(self.BASE, json={"session_token": "tok"})
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert detail["granted"] is False
+        assert detail["reason"] == "review_required"
+        assert "60 days" in detail["message"]
+        extend.assert_not_called()
+
+    def test_review_present_grants_and_passes_feedback_id(self, client):
+        ends = datetime(2026, 9, 1, 12, 0, 0)
+        with patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_ENABLED", True), \
+             patch(f"{_MAIN}.get_session_user_id", return_value=7), \
+             patch(f"{_MAIN}.get_latest_review_feedback_id", return_value=31), \
+             patch(f"{_MAIN}.extend_trial_for_user",
+                   return_value={"granted": True, "reason": "granted", "cohort": "P0",
+                                 "trial_days": 60, "trial_ends_at": ends}) as extend:
+            resp = client.post(self.BASE, json={"session_token": "tok"})
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert detail == {"granted": True, "reason": "granted", "cohort": "P0",
+                          "trial_days": 60, "trial_ends_at": ends.isoformat()}
+        extend.assert_called_once_with(7, feedback_id=31)
+
+    def test_exhausted_cohorts_are_a_200_not_an_error(self, client):
+        with patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_ENABLED", True), \
+             patch(f"{_MAIN}.get_session_user_id", return_value=7), \
+             patch(f"{_MAIN}.get_latest_review_feedback_id", return_value=31), \
+             patch(f"{_MAIN}.extend_trial_for_user",
+                   return_value={"granted": False, "reason": "slots_exhausted", "cohort": None,
+                                 "trial_days": 14, "trial_ends_at": None}):
+            resp = client.post(self.BASE, json={"session_token": "tok"})
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert (detail["granted"], detail["reason"], detail["trial_days"]) == (False, "slots_exhausted", 14)
+        assert detail["trial_ends_at"] is None
+
+
+class TestEarlyAdopterCheckoutExtras:
+    def test_no_grant_means_no_trial_and_no_discount(self):
+        from cqc_lem.api.main import _early_adopter_checkout_extras
+        with patch(f"{_MAIN}.get_early_adopter_grant", return_value=None):
+            assert _early_adopter_checkout_extras(7) == (None, None)
+
+    def test_remaining_days_are_rounded_up_and_coupon_applied(self):
+        from cqc_lem.api.main import _early_adopter_checkout_extras
+        grant = {"trial_ends_at": datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(days=40, hours=6)}
+        with patch(f"{_MAIN}.get_early_adopter_grant", return_value=grant), \
+             patch(f"{_ENV}.EARLY_ADOPTER_COUPON_ID", "EARLYBIRD"):
+            days, discounts = _early_adopter_checkout_extras(7)
+        assert days == 41  # 40d6h rounds up so a partial day isn't forfeited
+        assert discounts == [{"coupon": "EARLYBIRD"}]
+
+    def test_lookup_failure_degrades_to_a_normal_checkout(self):
+        """A perk lookup must never stop a user from paying us."""
+        from cqc_lem.api.main import _early_adopter_checkout_extras
+        with patch(f"{_MAIN}.get_early_adopter_grant", side_effect=RuntimeError("db down")), \
+             patch(f"{_MAIN}.log_warning") as warned:
+            assert _early_adopter_checkout_extras(7) == (None, None)
+        assert warned.called
+
+    def test_expired_grant_sends_no_trial_days(self):
+        from cqc_lem.api.main import _early_adopter_checkout_extras
+        grant = {"trial_ends_at": datetime.now(timezone.utc) - timedelta(days=3)}
+        with patch(f"{_MAIN}.get_early_adopter_grant", return_value=grant), \
+             patch(f"{_ENV}.EARLY_ADOPTER_COUPON_ID", ""):
+            assert _early_adopter_checkout_extras(7) == (None, None)
+
+
+class TestCheckoutSessionMirrorsGrant:
+    BASE = "/api/billing/create-checkout-session"
+    PAYLOAD = {"session_token": "tok", "tier": "starter",
+               "success_url": "https://e.com/s", "cancel_url": "https://e.com/c"}
+
+    def test_grant_holder_conversion_forwards_trial_and_coupon(self, client):
+        with patch(f"{_MAIN}.get_session_user_id", return_value=7), \
+             patch(f"{_MAIN}.get_user_subscription_info",
+                   return_value={"stripe_customer_id": "cus_1", "stripe_subscription_id": None,
+                                 "subscription_status": "trial"}), \
+             patch(f"{_MAIN}._early_adopter_checkout_extras",
+                   return_value=(41, [{"coupon": "EARLYBIRD"}])), \
+             patch("cqc_lem.utilities.stripe_util.create_checkout_session",
+                   return_value="https://checkout.stripe.com/x") as create:
+            resp = client.post(self.BASE, json=self.PAYLOAD)
+        assert resp.status_code == 200
+        assert create.call_args.kwargs["trial_period_days"] == 41
+        assert create.call_args.kwargs["discounts"] == [{"coupon": "EARLYBIRD"}]
+
+    def test_standard_user_conversion_is_unchanged(self, client):
+        with patch(f"{_MAIN}.get_session_user_id", return_value=7), \
+             patch(f"{_MAIN}.get_user_subscription_info",
+                   return_value={"stripe_customer_id": "cus_1", "stripe_subscription_id": None,
+                                 "subscription_status": "trial"}), \
+             patch(f"{_MAIN}.get_early_adopter_grant", return_value=None), \
+             patch("cqc_lem.utilities.stripe_util.create_checkout_session",
+                   return_value="https://checkout.stripe.com/x") as create:
+            resp = client.post(self.BASE, json=self.PAYLOAD)
+        assert resp.status_code == 200
+        assert create.call_args.kwargs["trial_period_days"] is None
+        assert create.call_args.kwargs["discounts"] is None

--- a/tests/unit/api/test_trial_extend_api.py
+++ b/tests/unit/api/test_trial_extend_api.py
@@ -110,6 +110,20 @@ class TestEarlyAdopterCheckoutExtras:
              patch(f"{_ENV}.EARLY_ADOPTER_COUPON_ID", ""):
             assert _early_adopter_checkout_extras(7) == (None, None)
 
+    def test_expired_grant_does_not_apply_the_coupon_either(self):
+        """The coupon is part of the unfinished trial — a lapsed grant must not discount forever."""
+        from cqc_lem.api.main import _early_adopter_checkout_extras
+        grant = {"trial_ends_at": datetime.now(timezone.utc) - timedelta(days=90)}
+        with patch(f"{_MAIN}.get_early_adopter_grant", return_value=grant), \
+             patch(f"{_ENV}.EARLY_ADOPTER_COUPON_ID", "EARLYBIRD"):
+            assert _early_adopter_checkout_extras(7) == (None, None)
+
+    def test_grant_with_no_end_date_carries_nothing(self):
+        from cqc_lem.api.main import _early_adopter_checkout_extras
+        with patch(f"{_MAIN}.get_early_adopter_grant", return_value={"trial_ends_at": None}), \
+             patch(f"{_ENV}.EARLY_ADOPTER_COUPON_ID", "EARLYBIRD"):
+            assert _early_adopter_checkout_extras(7) == (None, None)
+
 
 class TestCheckoutSessionMirrorsGrant:
     BASE = "/api/billing/create-checkout-session"

--- a/tests/unit/utilities/test_db_early_adopter_trial.py
+++ b/tests/unit/utilities/test_db_early_adopter_trial.py
@@ -1,0 +1,295 @@
+"""Unit tests for the early-adopter extended-trial DB layer (issue #499)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+_ENV = "cqc_lem.utilities.env_constants"
+
+STARTED = datetime(2026, 7, 1, 12, 0, 0)
+
+
+class _Cursor:
+    """Stateful stand-in for the `early_adopter_*` + `users` rows the extension touches.
+
+    The slot counter is modeled faithfully — `used < capacity` is evaluated inside the UPDATE and
+    surfaced as rowcount — so the exhaustion tests exercise the same conditional the DB does.
+    """
+
+    def __init__(self, *, grant=None, user=None, used=None):
+        self.grant = grant
+        self.user = user
+        self.used = dict(used or {"P0": 0, "P1": 0})
+        self.inserted_grants: list = []
+        self.user_updates: list = []
+        self.rowcount = 0
+        self._result = None
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        self.rowcount = 0
+        if s.startswith("SELECT cohort, trial_days, trial_ends_at FROM early_adopter_grants"):
+            self._result = self.grant
+        elif s.startswith("SELECT subscription_status, trial_started_at, trial_ends_at FROM users"):
+            self._result = self.user
+        elif s.startswith("UPDATE early_adopter_slots"):
+            cohort, capacity = params
+            if self.used.get(cohort, 0) < capacity:
+                self.used[cohort] = self.used.get(cohort, 0) + 1
+                self.rowcount = 1
+        elif s.startswith("INSERT INTO early_adopter_grants"):
+            self.inserted_grants.append(params)
+            self.rowcount = 1
+        elif s.startswith("UPDATE users SET trial_started_at"):
+            self.user_updates.append((s, params))
+            self.rowcount = 1
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    def fetchone(self):
+        return self._result
+
+    def close(self):
+        pass
+
+
+class _Conn:
+    def __init__(self, cursor):
+        self._cur = cursor
+        self.committed = False
+        self.rolled_back = False
+
+    def cursor(self, *a, **k):
+        return self._cur
+
+    def start_transaction(self):
+        pass
+
+    def commit(self):
+        self.committed = True
+
+    def rollback(self):
+        self.rolled_back = True
+
+    def close(self):
+        pass
+
+
+def _user(status="trial", started=STARTED, ends=None):
+    if ends is None and started is not None:
+        ends = started + timedelta(days=14)
+    return {"subscription_status": status, "trial_started_at": started, "trial_ends_at": ends}
+
+
+def _extend(cursor, user_id=5, feedback_id=99, p0=25, p1=100, days=60):
+    conn = _Conn(cursor)
+    with patch(f"{_DB}.get_db_connection", return_value=conn), \
+            patch(f"{_ENV}.EARLY_ADOPTER_P0_SLOTS", p0), \
+            patch(f"{_ENV}.EARLY_ADOPTER_P1_SLOTS", p1), \
+            patch(f"{_ENV}.EARLY_ADOPTER_TRIAL_DAYS", days):
+        from cqc_lem.utilities.db import extend_trial_for_user
+        return extend_trial_for_user(user_id, feedback_id=feedback_id), conn
+
+
+class TestGetLatestReviewFeedbackId:
+    def test_returns_most_recent_review_id(self):
+        cur = MagicMock()
+        cur.fetchone.return_value = (17,)
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_latest_review_feedback_id
+            assert get_latest_review_feedback_id(5) == 17
+        sql, params = cur.execute.call_args[0]
+        assert "source=%s" in sql and params == (5, "review")
+
+    def test_no_review_returns_none(self):
+        cur = MagicMock()
+        cur.fetchone.return_value = None
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_latest_review_feedback_id
+            assert get_latest_review_feedback_id(5) is None
+
+    def test_db_error_returns_none_and_closes(self):
+        import mysql.connector
+        cur = MagicMock()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import get_latest_review_feedback_id
+            assert get_latest_review_feedback_id(5) is None
+        cur.close.assert_called_once()
+        conn.close.assert_called_once()
+
+
+class TestExtendTrialForUser:
+    def test_grants_p0_slot_and_extends_to_started_plus_days(self):
+        cur = _Cursor(user=_user())
+        result, conn = _extend(cur)
+
+        assert result["granted"] is True
+        assert result["reason"] == "granted"
+        assert result["cohort"] == "P0"
+        assert result["trial_days"] == 60
+        assert result["trial_ends_at"] == STARTED + timedelta(days=60)
+        assert cur.used["P0"] == 1 and cur.used["P1"] == 0
+        # grant row records who unlocked it and with which review
+        user_id, cohort, trial_days, feedback_id, ends = cur.inserted_grants[0]
+        assert (user_id, cohort, trial_days, feedback_id) == (5, "P0", 60, 99)
+        assert ends == STARTED + timedelta(days=60)
+        assert conn.committed is True
+
+    def test_user_row_is_put_back_on_trial(self):
+        cur = _Cursor(user=_user(status="inactive"))
+        result, _ = _extend(cur)
+        assert result["granted"] is True
+        sql, params = cur.user_updates[0]
+        assert "subscription_status='trial'" in sql
+        assert params == (STARTED, STARTED + timedelta(days=60), 5)
+
+    def test_p0_full_falls_through_to_p1(self):
+        cur = _Cursor(user=_user(), used={"P0": 25, "P1": 0})
+        result, _ = _extend(cur)
+        assert result["cohort"] == "P1"
+        assert cur.used["P1"] == 1
+
+    def test_all_slots_exhausted_falls_back_to_standard_trial(self):
+        cur = _Cursor(user=_user(), used={"P0": 25, "P1": 100})
+        result, conn = _extend(cur)
+        assert result["granted"] is False
+        assert result["reason"] == "slots_exhausted"
+        assert result["trial_days"] == 14  # FREE_TRIAL_DAYS default
+        assert cur.inserted_grants == [] and cur.user_updates == []
+        assert conn.rolled_back is True and conn.committed is False
+
+    def test_zero_capacity_cohort_is_skipped(self):
+        cur = _Cursor(user=_user())
+        result, _ = _extend(cur, p0=0)
+        assert result["cohort"] == "P1"
+        assert cur.used["P0"] == 0
+
+    def test_existing_grant_is_idempotent_and_consumes_no_slot(self):
+        cur = _Cursor(grant={"cohort": "P0", "trial_days": 60,
+                             "trial_ends_at": STARTED + timedelta(days=60)},
+                      user=_user())
+        result, conn = _extend(cur)
+        assert result == {"granted": True, "reason": "already_granted", "cohort": "P0",
+                          "trial_days": 60, "trial_ends_at": STARTED + timedelta(days=60)}
+        assert cur.used == {"P0": 0, "P1": 0}
+        assert conn.committed is False
+
+    def test_unknown_user_is_rejected(self):
+        cur = _Cursor(user=None)
+        result, conn = _extend(cur)
+        assert (result["granted"], result["reason"]) == (False, "user_not_found")
+        assert cur.used["P0"] == 0 and conn.rolled_back is True
+
+    @pytest.mark.parametrize("status", ["active", "past_due", "cancelled"])
+    def test_non_trial_subscription_is_rejected(self, status):
+        cur = _Cursor(user=_user(status=status))
+        result, _ = _extend(cur)
+        assert (result["granted"], result["reason"]) == (False, "not_on_trial")
+        assert cur.used["P0"] == 0
+
+    def test_never_shortens_an_already_longer_trial(self):
+        longer = STARTED + timedelta(days=90)
+        cur = _Cursor(user=_user(ends=longer))
+        result, _ = _extend(cur)
+        assert result["trial_ends_at"] == longer
+
+    def test_missing_trial_start_uses_now(self):
+        cur = _Cursor(user=_user(started=None, ends=None))
+        before = datetime.now(timezone.utc).replace(tzinfo=None)
+        result, _ = _extend(cur)
+        assert result["granted"] is True
+        assert result["trial_ends_at"] >= before + timedelta(days=59)
+
+    def test_aware_timestamps_are_compared_without_error(self):
+        from datetime import timezone as _tz
+        cur = _Cursor(user={"subscription_status": "trial",
+                            "trial_started_at": STARTED.replace(tzinfo=_tz.utc),
+                            "trial_ends_at": (STARTED + timedelta(days=120)).replace(tzinfo=_tz.utc)})
+        result, _ = _extend(cur)
+        assert result["trial_ends_at"] == STARTED + timedelta(days=120)
+
+    def test_duplicate_grant_race_returns_the_winning_grant(self):
+        import mysql.connector
+        from mysql.connector import errorcode
+
+        err = mysql.connector.Error("dup")
+        err.errno = errorcode.ER_DUP_ENTRY
+        cur = _Cursor(user=_user())
+        original_execute = cur.execute
+
+        def _boom(sql, params=None):
+            if " ".join(sql.split()).startswith("INSERT INTO early_adopter_grants"):
+                raise err
+            original_execute(sql, params)
+
+        cur.execute = _boom
+        winner = {"cohort": "P0", "trial_days": 60, "trial_ends_at": STARTED + timedelta(days=60)}
+        conn = _Conn(cur)
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+                patch(f"{_DB}.get_early_adopter_grant", return_value=winner):
+            from cqc_lem.utilities.db import extend_trial_for_user
+            result = extend_trial_for_user(5, feedback_id=1)
+        assert (result["granted"], result["reason"]) == (True, "already_granted")
+        assert conn.rolled_back is True
+
+    def test_db_error_rolls_back_and_reports_error(self):
+        import mysql.connector
+        cur = _Cursor(user=_user())
+        cur.execute = MagicMock(side_effect=mysql.connector.Error("boom"))
+        conn = _Conn(cur)
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import extend_trial_for_user
+            result = extend_trial_for_user(5)
+        assert (result["granted"], result["reason"]) == (False, "error")
+        assert conn.rolled_back is True and conn.committed is False
+
+
+class TestGrantAndSlotReads:
+    def test_get_grant_returns_row(self):
+        cur = MagicMock()
+        cur.fetchone.return_value = {"user_id": 5, "cohort": "P0"}
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_early_adopter_grant
+            assert get_early_adopter_grant(5)["cohort"] == "P0"
+
+    def test_get_grant_db_error_returns_none(self):
+        import mysql.connector
+        cur = MagicMock()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import get_early_adopter_grant
+            assert get_early_adopter_grant(5) is None
+
+    def test_slot_usage_maps_cohort_to_used(self):
+        cur = MagicMock()
+        cur.fetchall.return_value = [("P0", 3), ("P1", 0)]
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_early_adopter_slot_usage
+            assert get_early_adopter_slot_usage() == {"P0": 3, "P1": 0}
+
+    def test_slot_usage_db_error_returns_empty(self):
+        import mysql.connector
+        cur = MagicMock()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        conn = MagicMock()
+        conn.cursor.return_value = cur
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import get_early_adopter_slot_usage
+            assert get_early_adopter_slot_usage() == {}

--- a/tests/unit/utilities/test_stripe_util.py
+++ b/tests/unit/utilities/test_stripe_util.py
@@ -132,6 +132,60 @@ class TestCreateCheckoutSession:
 
         assert result == "https://checkout.stripe.com/pay/cs_abc"
 
+    def test_no_trial_or_discount_keeps_payload_unchanged(self):
+        """Standard conversion must not gain subscription_data/discounts (issue #499)."""
+        mock_stripe = _make_stripe_mock()
+
+        with patch("cqc_lem.utilities.stripe_util.STRIPE_API_KEY", "sk_test_key"), \
+             patch("cqc_lem.utilities.stripe_util.TIER_PRICE_MAP", {"starter": "price_starter_id"}), \
+             patch("cqc_lem.utilities.stripe_util._get_stripe", return_value=mock_stripe):
+            from cqc_lem.utilities.stripe_util import create_checkout_session
+            create_checkout_session("cus_abc", "starter", "https://e.com/s", "https://e.com/c")
+
+        kwargs = mock_stripe.checkout.Session.create.call_args.kwargs
+        assert "subscription_data" not in kwargs
+        assert "discounts" not in kwargs
+
+    def test_trial_days_and_coupon_are_forwarded(self):
+        """An early-adopter extension mirrors into Stripe as a trial + coupon (issue #499)."""
+        mock_stripe = _make_stripe_mock()
+
+        with patch("cqc_lem.utilities.stripe_util.STRIPE_API_KEY", "sk_test_key"), \
+             patch("cqc_lem.utilities.stripe_util.TIER_PRICE_MAP", {"starter": "price_starter_id"}), \
+             patch("cqc_lem.utilities.stripe_util._get_stripe", return_value=mock_stripe):
+            from cqc_lem.utilities.stripe_util import create_checkout_session
+            create_checkout_session("cus_abc", "starter", "https://e.com/s", "https://e.com/c",
+                                    trial_period_days=47, discounts=[{"coupon": "EARLYBIRD"}])
+
+        kwargs = mock_stripe.checkout.Session.create.call_args.kwargs
+        assert kwargs["subscription_data"] == {"trial_period_days": 47}
+        assert kwargs["discounts"] == [{"coupon": "EARLYBIRD"}]
+
+    def test_trial_days_capped_at_stripe_maximum(self):
+        mock_stripe = _make_stripe_mock()
+
+        with patch("cqc_lem.utilities.stripe_util.STRIPE_API_KEY", "sk_test_key"), \
+             patch("cqc_lem.utilities.stripe_util.TIER_PRICE_MAP", {"starter": "price_starter_id"}), \
+             patch("cqc_lem.utilities.stripe_util._get_stripe", return_value=mock_stripe):
+            from cqc_lem.utilities.stripe_util import create_checkout_session, STRIPE_MAX_TRIAL_DAYS
+            create_checkout_session("cus_abc", "starter", "https://e.com/s", "https://e.com/c",
+                                    trial_period_days=5000)
+
+        kwargs = mock_stripe.checkout.Session.create.call_args.kwargs
+        assert kwargs["subscription_data"]["trial_period_days"] == STRIPE_MAX_TRIAL_DAYS
+
+    def test_non_positive_trial_days_is_ignored(self):
+        mock_stripe = _make_stripe_mock()
+
+        with patch("cqc_lem.utilities.stripe_util.STRIPE_API_KEY", "sk_test_key"), \
+             patch("cqc_lem.utilities.stripe_util.TIER_PRICE_MAP", {"starter": "price_starter_id"}), \
+             patch("cqc_lem.utilities.stripe_util._get_stripe", return_value=mock_stripe):
+            from cqc_lem.utilities.stripe_util import create_checkout_session
+            create_checkout_session("cus_abc", "starter", "https://e.com/s", "https://e.com/c",
+                                    trial_period_days=0)
+
+        assert "subscription_data" not in mock_stripe.checkout.Session.create.call_args.kwargs
+
     def test_missing_price_id_for_tier_returns_none(self):
         with patch("cqc_lem.utilities.stripe_util.STRIPE_API_KEY", "sk_test_key"), \
              patch("cqc_lem.utilities.stripe_util.TIER_PRICE_MAP", {"starter": None}):


### PR DESCRIPTION
## What & why

Launch plan §A.2: early adopters trade a public review for a longer trial — `EARLY_ADOPTER_TRIAL_DAYS` (default **60**) instead of the standard `FREE_TRIAL_DAYS` (14).

**`POST /api/trial/extend`** (feature-flagged, cohort-gated):
- **Review gate** — granted only when the caller has a `feedback` row with `source='review'`. Otherwise a 200 with `reason: review_required` + a "Submit a quick review to unlock 60 days." message, so the SPA can render the prompt instead of an error.
- **Atomic cohort slots** — a seat is claimed with a single conditional `UPDATE early_adopter_slots SET used = used + 1 WHERE cohort=? AND used < ?`; its rowcount *is* the claim result, so two concurrent requests can never take the same last seat. The whole grant runs in one transaction, and the `UNIQUE(user_id)` on `early_adopter_grants` makes a duplicate request roll back — releasing the slot instead of burning it. Cohorts fill in order (P0 → P1); when both are exhausted the user simply keeps the standard trial (`reason: slots_exhausted`).
- **Caps live in env**, not the DB (`EARLY_ADOPTER_P0_SLOTS=25`, `EARLY_ADOPTER_P1_SLOTS=100`), so they can be retuned without a migration; `0` closes a cohort.
- Only extends users on `trial`/`inactive` — a paying or cancelled account is rejected (`not_on_trial`) — and it never *shortens* a trial the user already has.

**Stripe mirror on conversion** — `create_checkout_session` now takes `trial_period_days` / `discounts`. A grant holder converting mid-extension carries their remaining days into Checkout (plus `EARLY_ADOPTER_COUPON_ID`, if set), so upgrading early doesn't forfeit the perk. Users without a grant convert exactly as before, and the grant lookup is best-effort: if it fails, checkout proceeds normally rather than blocking the payment.

**Flag defaults OFF** (`EARLY_ADOPTER_TRIAL_ENABLED=False`) — this changes billing terms, so every environment opts in explicitly; the endpoint 404s until then.

## Files
- `compose/local/database/migrations/V20260725085226__add_early_adopter_trial.sql` — additive only: `early_adopter_slots` (the counter) + `early_adopter_grants` (the audit trail, UNIQUE on `user_id`).
- `utilities/db.py` — `extend_trial_for_user`, `get_latest_review_feedback_id`, `get_early_adopter_grant`, `get_early_adopter_slot_usage`.
- `utilities/stripe_util.py`, `utilities/env_constants.py`, `api/main.py`, `.env*.example`, `docs/stripe-setup-guide.md`.

## Testing
- `tests/unit/utilities/test_db_early_adopter_trial.py` — review lookup, grant/exhaustion/fallthrough, idempotency, non-trial + unknown user rejection, never-shorten, naive/aware timestamp mix, dup-entry race, DB-error rollback.
- `tests/unit/api/test_trial_extend_api.py` — flag off → 404, bad session → 401, review gate, grant pass-through, exhausted-is-a-200, and the Stripe extras (rounding, expired grant, lookup failure).
- `tests/integration/test_early_adopter_trial.py` — the real endpoint through the real DB helper against a stateful fake of all four tables, including **8 threads racing a 2-seat cohort → exactly 2 grants**, and the conversion mirror.
- `4365 passed` locally (full unit suite + the new integration test).

Closes #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)