### PR TITLE
feat(onboarding): automated activation checklist + stalled-user nudges (closes #500)

### DIFF
--- a/compose/local/database/migrations/V20260725090900__add_onboarding_state.sql
+++ b/compose/local/database/migrations/V20260725090900__add_onboarding_state.sql
@@ -1,0 +1,28 @@
+-- Automated activation checklist + stalled-user nudges (issue #500). "Aha" = the user's first AI post
+-- is published AND their first automated comment/DM has gone out under their own voice, within 7 days.
+--
+-- Step completion is DERIVED from data we already store (session cookie, engagement prefs, posts,
+-- logs), but the FIRST time each step flips is persisted here so (a) the SPA checklist is stable,
+-- (b) the PostHog step event is emitted exactly once, and (c) the nudge clock has a start.
+CREATE TABLE IF NOT EXISTS onboarding_state (
+    user_id                 INT NOT NULL PRIMARY KEY,
+    started_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,  -- trial start when known
+    linkedin_connected_at   DATETIME NULL,
+    voice_set_at            DATETIME NULL,
+    first_post_approved_at  DATETIME NULL,
+    caps_enabled_at         DATETIME NULL,
+    activated_at            DATETIME NULL,
+    updated_at              DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    KEY idx_onboarding_activated (activated_at),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- One row per nudge actually sent, so each nudge fires AT MOST ONCE per user (a stalled user gets the
+-- next-best nudge tomorrow instead of the same one again) and the daily cooldown reads MAX(sent_at).
+CREATE TABLE IF NOT EXISTS onboarding_nudges (
+    user_id     INT NOT NULL,
+    nudge_key   VARCHAR(32) NOT NULL,
+    sent_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, nudge_key),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -2490,6 +2490,19 @@ def account_readiness_endpoint(session_token: str) -> ResponseModel:
     return ResponseModel(status_code=200, detail={"ready": ready, "items": items})
 
 
+@router.get("/user/onboarding")
+def onboarding_endpoint(session_token: str) -> ResponseModel:
+    """The activation checklist (issue #500): each step, when it completed, and the next-best nudge
+    to show in-app. Reading it also advances the persisted state, so the PostHog activation funnel
+    records a step the moment the user finishes it — not a day later when the beat task runs."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    from cqc_lem.utilities.onboarding import onboarding_snapshot
+    return ResponseModel(status_code=200, detail=onboarding_snapshot(user_id))
+
+
 @router.put("/user/company-page")
 def update_company_page_endpoint(request: LinkedInCompanyPageRequest) -> ResponseModel:
     """Save (or clear) the user's LinkedIn company page URL. The monthly invite

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -192,6 +192,12 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_notify_missing_linkedin_session',
             'schedule': crontab(hour='9', minute='0')  # Daily 9:00 AM — throttled per-user to 1/week
         },
+        'onboarding-nudges': {
+            'task': 'cqc_lem.app.run_scheduler.auto_onboarding_nudges',
+            # Daily 9:30 AM — right after the missing-session email, so a user who just got that one
+            # isn't emailed twice in the same minute. Each nudge is one-shot per user (issue #500).
+            'schedule': crontab(hour='9', minute='30')
+        },
         'send-appreciation-dms': {
             'task': 'cqc_lem.app.run_scheduler.auto_appreciate_dms',
             'schedule': crontab(hour='8', minute='0')  # Run every day at 8:00 AM

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -908,6 +908,32 @@ def auto_notify_missing_linkedin_session():
 
 
 @shared_task.task
+def auto_onboarding_nudges():
+    """Daily: advance every not-yet-activated user's checklist (persisting steps + emitting the
+    activation funnel to PostHog) and email the ONE next-best nudge to those who stalled (issue
+    #500). Each nudge is one-shot per user and capped at one per NUDGE_COOLDOWN_HOURS, so this can
+    run daily without spamming — same posture as auto_notify_missing_linkedin_session."""
+    from cqc_lem.utilities.db import get_onboarding_candidate_user_ids
+    from cqc_lem.utilities.onboarding import (sync_onboarding_state, next_nudge_for_user,
+                                              send_onboarding_nudge)
+
+    users = get_onboarding_candidate_user_ids()
+    nudged = 0
+    for user_id in users:
+        try:
+            state = sync_onboarding_state(user_id)
+            nudge = next_nudge_for_user(user_id, state)
+            if nudge and send_onboarding_nudge(user_id, nudge):
+                nudged += 1
+        except Exception as e:
+            log_warning("Failed to process onboarding nudge", exc=e, user_id=user_id,
+                        task_name="auto_onboarding_nudges")
+    log_info(f"Onboarding: nudged {nudged} of {len(users)} un-activated user(s)",
+             task_name="auto_onboarding_nudges")
+    return f"Nudged {nudged} of {len(users)} un-activated user(s)"
+
+
+@shared_task.task
 def auto_backfill_missing_assets():
     """Safety net: regenerate missing media for unposted video/carousel posts before they
     publish, so a post never reaches its scheduled time without its asset (e.g. when the

--- a/src/cqc_lem/ui/src/components/OnboardingChecklist.tsx
+++ b/src/cqc_lem/ui/src/components/OnboardingChecklist.tsx
@@ -1,0 +1,58 @@
+import { Link } from 'react-router-dom'
+import { useOnboarding } from '../hooks/useOnboarding'
+
+// Activation checklist + in-app nudge (issue #500). Renders nothing once the user has activated
+// (first AI post published AND first automated comment/DM sent), so it disappears on its own.
+export default function OnboardingChecklist() {
+  const { data } = useOnboarding()
+  if (!data || data.activated) return null
+
+  const done = data.steps.filter((s) => s.ok).length
+  const next = data.steps.find((s) => !s.ok)
+
+  return (
+    <div className="bg-white border border-blue-200 rounded-lg p-4 mb-6">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="text-sm font-semibold text-gray-900">Get to your first live post</p>
+        <span className="text-xs text-gray-500">
+          {done} of {data.steps.length} done
+        </span>
+      </div>
+
+      {data.nudge && (
+        <div className="mt-3 bg-blue-50 border border-blue-200 rounded p-3">
+          <p className="text-sm font-semibold text-blue-900">{data.nudge.headline}</p>
+          <p className="text-sm text-blue-800 mt-1">{data.nudge.body}</p>
+          <Link
+            to={data.nudge.cta_path}
+            className="inline-block mt-2 text-sm font-semibold text-blue-700 underline hover:text-blue-900"
+          >
+            {data.nudge.cta_label} →
+          </Link>
+        </div>
+      )}
+
+      <ul className="mt-3 space-y-1">
+        {data.steps.map((s) => (
+          <li key={s.key} className="text-sm flex items-start gap-2">
+            <span className={s.ok ? 'text-green-600 leading-5' : 'text-gray-300 leading-5'}>
+              {s.ok ? '✓' : '○'}
+            </span>
+            <span className={s.ok ? 'text-gray-500 line-through' : 'text-gray-800'}>
+              {s.ok || s.key !== next?.key ? (
+                s.label
+              ) : (
+                <Link to={s.path} className="font-medium text-blue-700 underline hover:text-blue-900">
+                  {s.label}
+                </Link>
+              )}
+              {!s.ok && s.key === next?.key && s.hint ? (
+                <span className="text-gray-500"> — {s.hint}</span>
+              ) : null}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/hooks/useOnboarding.ts
+++ b/src/cqc_lem/ui/src/hooks/useOnboarding.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query'
+import api from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
+
+export interface OnboardingStep {
+  key: string
+  label: string
+  hint: string
+  path: string
+  ok: boolean
+  completed_at: string | null
+}
+
+export interface OnboardingNudge {
+  key: string
+  headline: string
+  body: string
+  cta_label: string
+  cta_path: string
+}
+
+export interface Onboarding {
+  activated: boolean
+  started_at: string | null
+  steps: OnboardingStep[]
+  nudge: OnboardingNudge | null
+}
+
+// The activation checklist (issue #500). Reading it also advances the server-side state,
+// so the PostHog activation funnel records each step as soon as the user finishes it.
+export function useOnboarding() {
+  const { sessionToken } = useAuth()
+  return useQuery({
+    queryKey: ['onboarding', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/onboarding?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as Onboarding),
+    enabled: !!sessionToken,
+    staleTime: 60 * 1000,
+  })
+}

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
 import { formatInTimezone } from '../utils/datetime'
 import { isHttpUrl, commentsActivityUrl } from '../utils/links'
+import OnboardingChecklist from '../components/OnboardingChecklist'
 import LineChart, { type LinePoint } from '../components/charts/LineChart'
 import Leaderboard, { type RankEntry } from '../components/charts/Leaderboard'
 import { compactNumber, formatRate } from '../components/charts/palette'
@@ -226,6 +227,9 @@ export default function Dashboard() {
           </Link>
         </div>
       </div>
+
+      {/* Activation checklist — hides itself once the user is activated */}
+      <OnboardingChecklist />
 
       {/* Stats */}
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -2946,3 +2946,40 @@ def _normalize_carousel_strings(value):
     if isinstance(value, list):
         return [_normalize_carousel_strings(v) for v in value]
     return value
+
+# LEM's OWN brand voice for product emails — plain, direct, useful. Deliberately separate from the
+# user's LinkedIn voice: these emails come from us, not from them.
+_LEM_BRAND_VOICE = (
+    "You write product emails for LinkedIn Engagement Manager (LEM), a tool that runs a busy "
+    "professional's LinkedIn presence for them — posting in their voice and engaging genuinely on "
+    "their behalf. Brand voice: plain, direct, warm, and specific. No hype, no exclamation marks, no "
+    "marketing cliches, no emoji, no greeting or sign-off. Respect the reader's time."
+)
+
+
+def generate_onboarding_nudge_copy(user_id: int, nudge: dict) -> str:
+    """Rewrite a stalled-user activation nudge (issue #500) in LEM's brand voice. Short, one call to
+    `lem-simple`. Returns the default body on any failure — the nudge must never depend on the LLM."""
+    default_body = (nudge or {}).get("body") or ""
+    try:
+        response = _call_llm(
+            model="lem-simple",
+            messages=[
+                {"role": "system", "content": _LEM_BRAND_VOICE + PLAIN_PUNCTUATION_DIRECTIVE},
+                {"role": "user", "content":
+                    f"Rewrite this onboarding reminder as 2 sentences (max 45 words) of email "
+                    f"body copy. Keep the same ask and the same facts — do not invent features, "
+                    f"numbers, or deadlines. Return only the body text.\n\n"
+                    f"Headline: {(nudge or {}).get('headline', '')}\n"
+                    f"Body: {default_body}\n"
+                    f"Button: {(nudge or {}).get('cta_label', '')}"},
+            ],
+            temperature=0.4,
+            max_tokens=120,
+            _track_user_id=user_id,
+        )
+        text = (response.choices[0].message.content or "").strip()
+        return normalize_public_text(text) if text else default_body
+    except Exception as e:
+        log_warning("Could not generate onboarding nudge copy — using default", exc=e)
+        return default_body

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -199,6 +199,21 @@ class FeedbackStatus(StrEnum):
     DISMISSED = 'dismissed'          # not actionable
 
 
+class OnboardingStep(StrEnum):
+    """Steps of the activation checklist (issue #500), in the order a user completes them.
+    ACTIVATED is the "aha" moment: first AI post published AND first automated comment/DM sent."""
+    LINKEDIN_CONNECTED = 'linkedin_connected'
+    VOICE_SET = 'voice_set'
+    FIRST_POST_APPROVED = 'first_post_approved'
+    CAPS_ENABLED = 'caps_enabled'
+    ACTIVATED = 'activated'
+
+
+# Ordered checklist + the onboarding_state column that timestamps each step's first completion.
+ONBOARDING_STEPS: tuple = tuple(OnboardingStep)
+_ONBOARDING_COLS: tuple = tuple(f"{step.value}_at" for step in ONBOARDING_STEPS)
+
+
 # Enum for log actions types
 class LogActionType(StrEnum):
     COMMENT = 'comment'
@@ -6505,6 +6520,181 @@ def update_feedback_triage(feedback_id: int, status: "FeedbackStatus" = None,
         return cursor.rowcount > 0
     except mysql.connector.Error as err:
         log_error(f"Could not update feedback triage for {feedback_id}", exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+# --- Onboarding / activation checklist (issue #500) ---------------------------------
+def ensure_onboarding_state(user_id: int) -> bool:
+    """Create the user's onboarding row if it doesn't exist. `started_at` is the trial start when we
+    know it, so the nudge clock measures time-since-signup rather than time-since-first-scan."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT IGNORE INTO onboarding_state (user_id, started_at) "
+            "SELECT id, COALESCE(trial_started_at, NOW()) FROM users WHERE id = %s", (user_id,))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        log_error(f"Could not ensure onboarding state for user_id {user_id}", exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_onboarding_state(user_id: int) -> dict:
+    """The persisted checklist row (started_at + one completion timestamp per step). Empty dict when
+    the user has no row yet."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            f"SELECT user_id, started_at, {', '.join(_ONBOARDING_COLS)} "
+            f"FROM onboarding_state WHERE user_id = %s", (user_id,))
+        return cursor.fetchone() or {}
+    except mysql.connector.Error as err:
+        log_error(f"Could not get onboarding state for user_id {user_id}", exc=err)
+        return {}
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def mark_onboarding_step(user_id: int, step: "OnboardingStep") -> bool:
+    """Stamp a checklist step as complete. Idempotent: only the FIRST completion writes, and True is
+    returned only then — so the caller emits its PostHog event exactly once."""
+    column = f"{OnboardingStep(step).value}_at"
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            f"UPDATE onboarding_state SET {column} = NOW() "
+            f"WHERE user_id = %s AND {column} IS NULL", (user_id,))
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        log_error(f"Could not mark onboarding step {step} for user_id {user_id}", exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_onboarding_nudges_sent(user_id: int) -> dict:
+    """nudge_key -> sent_at for every nudge already delivered to this user."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT nudge_key, sent_at FROM onboarding_nudges WHERE user_id = %s",
+                       (user_id,))
+        return {row[0]: row[1] for row in cursor.fetchall()}
+    except mysql.connector.Error as err:
+        log_error(f"Could not get onboarding nudges for user_id {user_id}", exc=err)
+        return {}
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_onboarding_nudge(user_id: int, nudge_key: str) -> bool:
+    """Record that a nudge was sent. Returns False when this nudge was already sent (the PK makes
+    each nudge one-shot per user)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("INSERT IGNORE INTO onboarding_nudges (user_id, nudge_key) VALUES (%s, %s)",
+                       (user_id, str(nudge_key)[:32]))
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        log_error(f"Could not record onboarding nudge {nudge_key} for user_id {user_id}", exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_onboarding_candidate_user_ids() -> list:
+    """Users still working toward activation: paying or on an unexpired trial, and not yet activated.
+    Deliberately NOT get_active_user_ids() — that requires a live LinkedIn connection, which is the
+    very step most stalled users are stuck on."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("""
+            SELECT u.id
+            FROM users u
+            LEFT JOIN onboarding_state o ON o.user_id = u.id
+            WHERE (
+                    u.subscription_status = 'active'
+                    OR (u.subscription_status = 'trial'
+                        AND (u.trial_ends_at IS NULL OR u.trial_ends_at > NOW()))
+                  )
+              AND o.activated_at IS NULL
+        """)
+        return [row[0] for row in cursor.fetchall()]
+    except mysql.connector.Error as err:
+        log_error("Could not get onboarding candidate user ids", exc=err)
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def has_engagement_preferences(user_id: int) -> bool:
+    """True when the user has actually SAVED engagement preferences. get_engagement_preferences()
+    returns code defaults for everyone, so only the row's existence proves they configured it."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT 1 FROM engagement_preferences WHERE user_id = %s LIMIT 1", (user_id,))
+        return cursor.fetchone() is not None
+    except mysql.connector.Error as err:
+        log_error(f"Could not check engagement prefs for user_id {user_id}", exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def has_post_with_status(user_id: int, statuses: tuple) -> bool:
+    """True when the user has at least one post in any of the given statuses."""
+    if not statuses:
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        placeholders = ", ".join(["%s"] * len(statuses))
+        cursor.execute(
+            f"SELECT 1 FROM posts WHERE user_id = %s AND status IN ({placeholders}) LIMIT 1",
+            (user_id, *[str(s) for s in statuses]))
+        return cursor.fetchone() is not None
+    except mysql.connector.Error as err:
+        log_error(f"Could not check posts for user_id {user_id}", exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def has_automated_engagement(user_id: int) -> bool:
+    """True once automation has successfully commented, replied, or DM'd on the user's behalf —
+    the engagement half of the activation ("aha") moment."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT 1 FROM logs WHERE user_id = %s AND result = %s "
+            "AND action_type IN (%s, %s, %s, %s) LIMIT 1",
+            (user_id, str(LogResultType.SUCCESS), str(LogActionType.COMMENT),
+             str(LogActionType.REPLY), str(LogActionType.DM), str(LogActionType.FOLLOWUP)))
+        return cursor.fetchone() is not None
+    except mysql.connector.Error as err:
+        log_error(f"Could not check automated engagement for user_id {user_id}", exc=err)
         return False
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -5,6 +5,7 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import formataddr
+from html import escape as html_escape
 from typing import Optional, Tuple
 
 from cqc_lem.utilities.env_constants import (
@@ -370,12 +371,18 @@ def send_onboarding_nudge_email(to_email: str, subject: str, headline: str, body
     import os
     base = (os.getenv("LEM_APP_URL") or "https://lem.christopherqueenconsulting.com").rstrip("/")
     url = f"{base}{cta_path if cta_path.startswith('/') else '/' + cta_path}"
+    # body is LLM-generated and the rest is caller-supplied — escape before templating so copy
+    # can't inject markup or break the layout
+    safe_headline = html_escape(headline or "")
+    safe_body = html_escape(body or "").replace("\n", "<br/>")
+    safe_cta_label = html_escape(cta_label or "")
+    safe_url = html_escape(url)
     html = f"""
     <html><body style="font-family:Arial,Helvetica,sans-serif;color:#222;">
-    <h2>{headline}</h2>
-    <p>{body}</p>
-    <p><a href="{url}" style="background:#0a66c2;color:#fff;padding:10px 16px;border-radius:6px;
-    text-decoration:none;">{cta_label}</a></p>
+    <h2>{safe_headline}</h2>
+    <p>{safe_body}</p>
+    <p><a href="{safe_url}" style="background:#0a66c2;color:#fff;padding:10px 16px;border-radius:6px;
+    text-decoration:none;">{safe_cta_label}</a></p>
     <p style="color:#888;font-size:12px;">If you've already done this, you can ignore this email —
     we only send each setup reminder once.</p>
     </body></html>

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -363,6 +363,26 @@ def send_newsletter_draft_ready_email(to_email: str, edition_title: str,
         to_email, f"📝 Your newsletter draft is ready: {title}", html, high_priority=True)
 
 
+def send_onboarding_nudge_email(to_email: str, subject: str, headline: str, body: str,
+                                cta_label: str, cta_path: str = "/account") -> bool:
+    """Nudge a user who stalled part-way through activation (issue #500). Copy is supplied by the
+    caller (LLM-refreshed, with a static fallback) so this stays a pure send."""
+    import os
+    base = (os.getenv("LEM_APP_URL") or "https://lem.christopherqueenconsulting.com").rstrip("/")
+    url = f"{base}{cta_path if cta_path.startswith('/') else '/' + cta_path}"
+    html = f"""
+    <html><body style="font-family:Arial,Helvetica,sans-serif;color:#222;">
+    <h2>{headline}</h2>
+    <p>{body}</p>
+    <p><a href="{url}" style="background:#0a66c2;color:#fff;padding:10px 16px;border-radius:6px;
+    text-decoration:none;">{cta_label}</a></p>
+    <p style="color:#888;font-size:12px;">If you've already done this, you can ignore this email —
+    we only send each setup reminder once.</p>
+    </body></html>
+    """
+    return _dispatch_email(to_email, subject, html)
+
+
 def send_pin_email(
     to_email: str,
     pin: str,

--- a/src/cqc_lem/utilities/notifications.py
+++ b/src/cqc_lem/utilities/notifications.py
@@ -47,6 +47,33 @@ def notify_linkedin_session(user_id: int, revalidation: bool = False) -> bool:
     return sent
 
 
+def notify_onboarding_nudge(user_id: int, nudge: dict) -> bool:
+    """Email a stalled user their next-best activation nudge (issue #500). Throttling is the caller's
+    job — each nudge is one-shot per user via the onboarding_nudges ledger. Returns True only if an
+    email was actually sent."""
+    try:
+        email = get_user_email(user_id)
+        if not email:
+            return False
+        from cqc_lem.utilities.email import send_onboarding_nudge_email
+        sent = send_onboarding_nudge_email(
+            email,
+            subject=nudge.get("subject") or "Finish setting up LinkedIn Engagement Manager",
+            headline=nudge.get("headline") or "One step left",
+            body=nudge.get("body") or "",
+            cta_label=nudge.get("cta_label") or "Finish setup",
+            cta_path=nudge.get("cta_path") or "/account",
+        )
+        if sent:
+            from cqc_lem.utilities.observability import track_onboarding_nudge
+            track_onboarding_nudge(user_id, str(nudge.get("key")))
+            myprint(f"Sent onboarding nudge '{nudge.get('key')}' to user_id {user_id}")
+        return sent
+    except Exception as e:
+        myprint(f"Could not send onboarding nudge to user_id {user_id} | Error: {e}")
+        return False
+
+
 def notify_newsletter_draft_ready(user_id: int, edition_title: str, scheduled_for) -> bool:
     """Email the user that their newsletter draft is ready to review and when it auto-publishes.
     Non-fatal — returns True only if an email was actually sent."""

--- a/src/cqc_lem/utilities/notifications.py
+++ b/src/cqc_lem/utilities/notifications.py
@@ -18,7 +18,7 @@ from cqc_lem.utilities.email import (
     send_session_revalidation_email,
     send_newsletter_draft_ready_email,
 )
-from cqc_lem.utilities.logger import myprint
+from cqc_lem.utilities.logger import log_info, log_warning, myprint
 
 
 def notify_linkedin_session(user_id: int, revalidation: bool = False) -> bool:
@@ -67,10 +67,12 @@ def notify_onboarding_nudge(user_id: int, nudge: dict) -> bool:
         if sent:
             from cqc_lem.utilities.observability import track_onboarding_nudge
             track_onboarding_nudge(user_id, str(nudge.get("key")))
-            myprint(f"Sent onboarding nudge '{nudge.get('key')}' to user_id {user_id}")
+            log_info(f"Sent onboarding nudge '{nudge.get('key')}'", user_id=user_id,
+                     action_type="onboarding_nudge")
         return sent
     except Exception as e:
-        myprint(f"Could not send onboarding nudge to user_id {user_id} | Error: {e}")
+        log_warning("Could not send onboarding nudge", exc=e, user_id=user_id,
+                    action_type="onboarding_nudge")
         return False
 
 

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -346,6 +346,30 @@ def posthog_hogql_query(sql: str, timeout: int = 30) -> Optional[list]:
         return None
 
 
+def track_onboarding_step(
+    user_id: int,
+    step: str,
+    hours_since_start: Optional[float] = None,
+    **extra,
+) -> None:
+    """Emit one activation-funnel event per checklist step (issue #500), the first time that step
+    completes — so time-to-aha and per-step drop-off are queryable in PostHog."""
+    posthog.capture(
+        distinct_id=str(user_id),
+        event="onboarding_step",
+        properties={"step": step, "hours_since_start": hours_since_start, **extra},
+    )
+
+
+def track_onboarding_nudge(user_id: int, nudge_key: str, **extra) -> None:
+    """Emit the stalled-user nudge we sent, so nudge → step-completion is measurable."""
+    posthog.capture(
+        distinct_id=str(user_id),
+        event="onboarding_nudge",
+        properties={"nudge": nudge_key, **extra},
+    )
+
+
 def track_task(
     task_name: str,
     duration_ms: int,

--- a/src/cqc_lem/utilities/onboarding.py
+++ b/src/cqc_lem/utilities/onboarding.py
@@ -1,0 +1,240 @@
+"""Activation checklist + stalled-user nudges (issue #500).
+
+"Aha" is the first AI post published AND the first automated comment/DM sent under the user's voice,
+within 7 days. Step completion is DERIVED from data we already store (session cookie, engagement
+preferences, posts, logs) and the first flip of each step is persisted in `onboarding_state`, so the
+SPA checklist is stable, the PostHog step event fires exactly once, and the nudge clock has a start.
+
+Nudge selection (`select_nudge`) is deliberately a PURE function of the checklist + timestamps so the
+"who gets nudged, with what, when" policy is unit-testable without touching the DB, email, or an LLM.
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from cqc_lem.utilities.db import (
+    OnboardingStep, ONBOARDING_STEPS, PostStatus,
+    ensure_onboarding_state, get_onboarding_state, mark_onboarding_step,
+    get_onboarding_nudges_sent, record_onboarding_nudge,
+    get_engagement_preferences, has_engagement_preferences, has_linkedin_session,
+    has_post_with_status, has_automated_engagement, get_user_subscription_info,
+)
+from cqc_lem.utilities.logger import log_info, log_warning
+
+# The checklist as the SPA renders it: label + where the user goes to finish the step.
+STEP_LABELS: dict = {
+    OnboardingStep.LINKEDIN_CONNECTED: "Connect LinkedIn",
+    OnboardingStep.VOICE_SET: "Set your voice & targeting",
+    OnboardingStep.FIRST_POST_APPROVED: "Approve your first post",
+    OnboardingStep.CAPS_ENABLED: "Turn on daily engagement",
+    OnboardingStep.ACTIVATED: "Activated — first post live + first auto-engagement",
+}
+STEP_HINTS: dict = {
+    OnboardingStep.LINKEDIN_CONNECTED: "Automation can't post or engage without an authorized session.",
+    OnboardingStep.VOICE_SET: "Tone, topics, and who to engage with — this is what makes it sound like you.",
+    OnboardingStep.FIRST_POST_APPROVED: "Approve a drafted post so your content plan starts publishing.",
+    OnboardingStep.CAPS_ENABLED: "Set how many comments and DMs a day you're comfortable with.",
+    OnboardingStep.ACTIVATED: "Nothing to do — this flips on its own once both have happened.",
+}
+STEP_PATHS: dict = {
+    OnboardingStep.LINKEDIN_CONNECTED: "/account",
+    OnboardingStep.VOICE_SET: "/account",
+    OnboardingStep.FIRST_POST_APPROVED: "/content?tab=review",
+    OnboardingStep.CAPS_ENABLED: "/account",
+    OnboardingStep.ACTIVATED: "/",
+}
+
+# Nudge keys (also the onboarding_nudges PK half — each fires at most once per user).
+NUDGE_CONNECT = "connect_linkedin"
+NUDGE_VOICE = "set_voice"
+NUDGE_FIRST_POST = "approve_post"
+NUDGE_TRIAL_ENDING = "trial_ending"
+
+# Step nudges, in checklist order: the earliest incomplete step whose grace period has elapsed wins.
+_STEP_NUDGES: tuple = (
+    {
+        "key": NUDGE_CONNECT,
+        "step": OnboardingStep.LINKEDIN_CONNECTED,
+        "after_hours": 24,
+        "subject": "Connect LinkedIn to switch your automation on",
+        "headline": "One step left before anything can run",
+        "body": ("Your account is ready, but LinkedIn isn't connected yet — so nothing can post, "
+                 "comment, or send. It takes about a minute from your account page."),
+        "cta_label": "Connect LinkedIn",
+        "cta_path": "/account",
+    },
+    {
+        "key": NUDGE_VOICE,
+        "step": OnboardingStep.VOICE_SET,
+        "after_hours": 48,
+        "subject": "Tell us how you sound before we post for you",
+        "headline": "Set your voice so it sounds like you",
+        "body": ("LinkedIn is connected. Next: pick your tone, the topics you want to be known for, "
+                 "and who's worth engaging — that's what keeps every comment and post yours."),
+        "cta_label": "Set your voice",
+        "cta_path": "/account",
+    },
+    {
+        "key": NUDGE_FIRST_POST,
+        "step": OnboardingStep.FIRST_POST_APPROVED,
+        "after_hours": 72,
+        "subject": "Your drafts are waiting on one approval",
+        "headline": "Approve one post and the plan starts running",
+        "body": ("We've drafted content in your voice, but nothing publishes until you approve the "
+                 "first one. Review it, edit anything you'd say differently, and approve."),
+        "cta_label": "Review your drafts",
+        "cta_path": "/content?tab=review",
+    },
+)
+
+# Sent when the trial is within this many days of ending and the user still hasn't activated.
+TRIAL_ENDING_WITHIN_DAYS = 3
+_TRIAL_NUDGE: dict = {
+    "key": NUDGE_TRIAL_ENDING,
+    "step": OnboardingStep.ACTIVATED,
+    "subject": "Your trial ends soon — let's get your first post live",
+    "headline": "Your trial ends in a few days",
+    "body": ("You haven't seen LEM actually run yet. Finish the last setup step and your first post "
+             "plus your first automated comment can go out before the trial is up."),
+    "cta_label": "Finish setup",
+    "cta_path": "/account",
+}
+
+# At most one onboarding nudge per user per this many hours, whatever the beat cadence.
+NUDGE_COOLDOWN_HOURS = 24
+
+
+def evaluate_steps(user_id: int) -> dict:
+    """Live truth for each checklist step, derived from what the user has actually done."""
+    prefs = get_engagement_preferences(user_id)
+    configured = has_engagement_preferences(user_id)
+    posted = has_post_with_status(user_id, (PostStatus.POSTED,))
+    voice_set = configured and bool(
+        prefs.get("tone") or prefs.get("comment_style") or prefs.get("focus_topics")
+        or prefs.get("include_topics"))
+    caps_enabled = configured and (int(prefs.get("max_comments_per_day") or 0) > 0
+                                   or int(prefs.get("max_dms_per_day") or 0) > 0)
+    return {
+        OnboardingStep.LINKEDIN_CONNECTED: has_linkedin_session(user_id),
+        OnboardingStep.VOICE_SET: voice_set,
+        OnboardingStep.FIRST_POST_APPROVED: has_post_with_status(
+            user_id, (PostStatus.APPROVED, PostStatus.SCHEDULED, PostStatus.POSTED)),
+        OnboardingStep.CAPS_ENABLED: caps_enabled,
+        # The aha moment: a published post AND automation having engaged in the user's voice.
+        OnboardingStep.ACTIVATED: posted and has_automated_engagement(user_id),
+    }
+
+
+def sync_onboarding_state(user_id: int) -> dict:
+    """Persist newly-completed steps and emit one PostHog event per step the FIRST time it completes.
+    Returns the refreshed `onboarding_state` row."""
+    ensure_onboarding_state(user_id)
+    steps = evaluate_steps(user_id)
+    state = get_onboarding_state(user_id)
+    for step in ONBOARDING_STEPS:
+        if not steps.get(step) or state.get(f"{step.value}_at"):
+            continue
+        if mark_onboarding_step(user_id, step):
+            _track_step(user_id, step, state.get("started_at"))
+    return get_onboarding_state(user_id)
+
+
+def _track_step(user_id: int, step: "OnboardingStep", started_at: Optional[datetime]) -> None:
+    """Emit the activation-funnel event. Never fatal — analytics must not break onboarding."""
+    try:
+        from cqc_lem.utilities.observability import track_onboarding_step
+        hours = None
+        if started_at:
+            hours = round(max(0.0, (datetime.now() - started_at).total_seconds() / 3600.0), 2)
+        track_onboarding_step(user_id, str(step), hours_since_start=hours)
+        log_info(f"Onboarding step completed: {step}", user_id=user_id)
+    except Exception as e:
+        log_warning("Could not track onboarding step", exc=e, user_id=user_id)
+
+
+def select_nudge(steps: dict, started_at: Optional[datetime] = None,
+                 trial_ends_at: Optional[datetime] = None, sent_keys=(),
+                 last_sent_at: Optional[datetime] = None,
+                 now: Optional[datetime] = None) -> Optional[dict]:
+    """The next-best nudge for a stalled user, or None when there's nothing worth sending.
+
+    Rules: activated users are never nudged; each nudge sends at most once (`sent_keys`); at most one
+    nudge per NUDGE_COOLDOWN_HOURS (`last_sent_at`); a step nudge only fires once its grace period
+    has elapsed since `started_at`; the earliest incomplete step wins, and the trial-ending nudge is
+    the fallback once the blocking step has already been nudged."""
+    now = now or datetime.now()
+    if steps.get(OnboardingStep.ACTIVATED):
+        return None
+    if last_sent_at and now - last_sent_at < timedelta(hours=NUDGE_COOLDOWN_HOURS):
+        return None
+
+    sent = set(sent_keys or ())
+    age_hours = max(0.0, (now - started_at).total_seconds() / 3600.0) if started_at else 0.0
+
+    for nudge in _STEP_NUDGES:
+        if steps.get(nudge["step"]):
+            continue  # step done — check the next one in the checklist
+        if age_hours >= nudge["after_hours"] and nudge["key"] not in sent:
+            return dict(nudge)
+        # A step that is incomplete but still inside its grace period blocks the later step nudges
+        # (they'd be premature), but not the time-critical trial warning below.
+        break
+
+    if trial_ends_at and NUDGE_TRIAL_ENDING not in sent:
+        remaining = trial_ends_at - now
+        if timedelta(0) < remaining <= timedelta(days=TRIAL_ENDING_WITHIN_DAYS):
+            return dict(_TRIAL_NUDGE)
+    return None
+
+
+def next_nudge_for_user(user_id: int, state: Optional[dict] = None) -> Optional[dict]:
+    """`select_nudge` bound to a real user — used by both the beat task and the in-app banner."""
+    state = state if state is not None else get_onboarding_state(user_id)
+    steps = {step: bool(state.get(f"{step.value}_at")) for step in ONBOARDING_STEPS}
+    sent = get_onboarding_nudges_sent(user_id)
+    sub = get_user_subscription_info(user_id) or {}
+    last_sent = max(sent.values()) if sent else None
+    return select_nudge(steps, started_at=state.get("started_at"),
+                        trial_ends_at=sub.get("trial_ends_at"), sent_keys=set(sent),
+                        last_sent_at=last_sent)
+
+
+def onboarding_snapshot(user_id: int) -> dict:
+    """Everything the SPA needs: the persisted checklist plus the nudge to surface in-app."""
+    state = sync_onboarding_state(user_id)
+    steps = []
+    for step in ONBOARDING_STEPS:
+        completed_at = state.get(f"{step.value}_at")
+        steps.append({
+            "key": str(step),
+            "label": STEP_LABELS[step],
+            "hint": STEP_HINTS[step],
+            "path": STEP_PATHS[step],
+            "ok": bool(completed_at),
+            "completed_at": completed_at.isoformat() if completed_at else None,
+        })
+    nudge = next_nudge_for_user(user_id, state)
+    return {
+        "activated": bool(state.get(f"{OnboardingStep.ACTIVATED.value}_at")),
+        "started_at": state["started_at"].isoformat() if state.get("started_at") else None,
+        "steps": steps,
+        "nudge": {"key": nudge["key"], "headline": nudge["headline"], "body": nudge["body"],
+                  "cta_label": nudge["cta_label"], "cta_path": nudge["cta_path"]} if nudge else None,
+    }
+
+
+def send_onboarding_nudge(user_id: int, nudge: dict) -> bool:
+    """Email the nudge (copy refreshed by `lem-simple`, falling back to the static body) and record
+    it so it never sends twice. Returns True only when an email actually went out."""
+    from cqc_lem.utilities.notifications import notify_onboarding_nudge
+    body = nudge.get("body") or ""
+    try:
+        from cqc_lem.utilities.ai.ai_helper import generate_onboarding_nudge_copy
+        body = generate_onboarding_nudge_copy(user_id, nudge) or body
+    except Exception as e:
+        log_warning("Onboarding nudge copy generation failed — using default copy",
+                    exc=e, user_id=user_id)
+    if not notify_onboarding_nudge(user_id, {**nudge, "body": body}):
+        return False
+    record_onboarding_nudge(user_id, nudge["key"])
+    return True

--- a/tests/integration/test_onboarding_checklist.py
+++ b/tests/integration/test_onboarding_checklist.py
@@ -1,0 +1,147 @@
+"""Integration test for the activation checklist endpoint (issue #500).
+
+Drives the real GET /api/user/onboarding handler through the real onboarding module and the real
+db.py SQL into a stateful fake cursor that models `onboarding_state` — so a step the user just
+finished provably lands as a persisted row (and emits its funnel event exactly once) without needing
+a live MySQL container.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.integration
+
+_DB = "cqc_lem.utilities.db"
+
+_STEP_COLUMNS = ("linkedin_connected_at", "voice_set_at", "first_post_approved_at",
+                 "caps_enabled_at", "activated_at")
+
+
+class _FakeCursor:
+    """Minimal MySQL-ish cursor over an in-memory `onboarding_state` / `onboarding_nudges` store."""
+
+    def __init__(self, store, dictionary=False):
+        self.store = store
+        self.dictionary = dictionary
+        self._result = []
+        self.rowcount = 0
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        self._result = []
+        self.rowcount = 0
+        if s.startswith("INSERT IGNORE INTO onboarding_state"):
+            if self.store["state"] is None:
+                self.store["state"] = {"user_id": params[0], "started_at": self.store["started_at"],
+                                       **{c: None for c in _STEP_COLUMNS}}
+                self.rowcount = 1
+        elif s.startswith("SELECT user_id, started_at"):
+            state = self.store["state"]
+            self._result = [dict(state)] if state else []
+        elif s.startswith("UPDATE onboarding_state SET"):
+            column = s.split("SET ")[1].split(" =")[0]
+            state = self.store["state"]
+            if state and state.get(column) is None:
+                state[column] = datetime.now()
+                self.rowcount = 1
+        elif s.startswith("SELECT nudge_key, sent_at"):
+            self._result = list(self.store["nudges"].items())
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return list(self._result)
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, store):
+        self.store = store
+
+    def cursor(self, *a, **k):
+        return _FakeCursor(self.store, dictionary=k.get("dictionary", False))
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from cqc_lem.api.main import app
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _get(client, store, *, session, voice, approved, posted, engaged, trial_ends_at=None):
+    """Call the endpoint with the checklist EVIDENCE stubbed but state persistence real."""
+    prefs = {"tone": "friendly" if voice else None, "comment_style": None, "focus_topics": [],
+             "include_topics": [], "max_comments_per_day": 20, "max_dms_per_day": 20}
+
+    def _has_post(_user_id, statuses):
+        from cqc_lem.utilities.db import PostStatus
+        return posted if tuple(statuses) == (PostStatus.POSTED,) else approved
+
+    with patch(f"{_DB}.get_db_connection", side_effect=lambda *a, **k: _FakeConn(store)), \
+         patch("cqc_lem.api.main.get_session_user_id", return_value=4), \
+         patch("cqc_lem.utilities.onboarding.has_linkedin_session", return_value=session), \
+         patch("cqc_lem.utilities.onboarding.get_engagement_preferences", return_value=prefs), \
+         patch("cqc_lem.utilities.onboarding.has_engagement_preferences", return_value=True), \
+         patch("cqc_lem.utilities.onboarding.has_post_with_status", side_effect=_has_post), \
+         patch("cqc_lem.utilities.onboarding.has_automated_engagement", return_value=engaged), \
+         patch("cqc_lem.utilities.onboarding.get_user_subscription_info",
+               return_value={"trial_ends_at": trial_ends_at}), \
+         patch("cqc_lem.utilities.observability.track_onboarding_step") as track:
+        response = client.get("/api/user/onboarding?session_token=sess-abc")
+    return response, track
+
+
+class TestOnboardingChecklistEndpoint:
+    def test_steps_persist_once_and_the_next_nudge_surfaces(self, client):
+        store = {"state": None, "nudges": {}, "started_at": datetime.now() - timedelta(days=3)}
+
+        response, track = _get(client, store, session=True, voice=False, approved=False,
+                               posted=False, engaged=False)
+
+        assert response.status_code == 200
+        detail = response.json()["detail"]
+        assert detail["activated"] is False
+        by_key = {s["key"]: s for s in detail["steps"]}
+        assert by_key["linkedin_connected"]["ok"] is True
+        assert by_key["voice_set"]["ok"] is False
+        # Connected 3 days in with no voice yet → the voice nudge is the next best thing to say.
+        assert detail["nudge"]["key"] == "set_voice"
+
+        # Persisted, and one funnel event per completed step (session + saved caps), none for the
+        # steps still outstanding.
+        assert store["state"]["linkedin_connected_at"] is not None
+        assert store["state"]["caps_enabled_at"] is not None
+        assert store["state"]["voice_set_at"] is None
+        assert {c.args[1] for c in track.call_args_list} == {"linkedin_connected", "caps_enabled"}
+
+        # A second read re-derives the same truth but must not re-emit the event.
+        response2, track2 = _get(client, store, session=True, voice=False, approved=False,
+                                 posted=False, engaged=False)
+        assert response2.json()["detail"]["steps"][0]["ok"] is True
+        assert track2.call_count == 0
+
+    def test_activation_clears_the_checklist_and_stops_nudging(self, client):
+        store = {"state": None, "nudges": {}, "started_at": datetime.now() - timedelta(days=6)}
+
+        response, _track = _get(client, store, session=True, voice=True, approved=True,
+                                posted=True, engaged=True,
+                                trial_ends_at=datetime.now() + timedelta(days=1))
+
+        detail = response.json()["detail"]
+        assert detail["activated"] is True
+        assert all(s["ok"] for s in detail["steps"])
+        assert detail["nudge"] is None  # activated users are never nudged, trial ending or not
+        assert store["state"]["activated_at"] is not None

--- a/tests/unit/api/test_onboarding_api.py
+++ b/tests/unit/api/test_onboarding_api.py
@@ -1,0 +1,62 @@
+"""Unit tests for GET /api/user/onboarding (issue #500)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_M = "cqc_lem.api.main"
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_SNAPSHOT = {
+    "activated": False,
+    "started_at": "2026-07-20T09:00:00",
+    "steps": [
+        {"key": "linkedin_connected", "label": "Connect LinkedIn", "hint": "", "path": "/account",
+         "ok": True, "completed_at": "2026-07-21T09:00:00"},
+        {"key": "voice_set", "label": "Set your voice & targeting", "hint": "", "path": "/account",
+         "ok": False, "completed_at": None},
+    ],
+    "nudge": {"key": "set_voice", "headline": "Set your voice", "body": "Pick your tone.",
+              "cta_label": "Set your voice", "cta_path": "/account"},
+}
+
+
+class TestOnboardingEndpoint:
+    def test_returns_the_checklist_and_nudge(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch("cqc_lem.utilities.onboarding.onboarding_snapshot",
+                   return_value=_SNAPSHOT) as snap:
+            resp = client.get("/api/user/onboarding?session_token=tok")
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert detail["activated"] is False
+        assert [s["key"] for s in detail["steps"]] == ["linkedin_connected", "voice_set"]
+        assert detail["nudge"]["key"] == "set_voice"
+        snap.assert_called_once_with(42)
+
+    def test_401_invalid_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.get("/api/user/onboarding?session_token=bad")
+        assert resp.status_code == 401

--- a/tests/unit/app/test_onboarding_nudges.py
+++ b/tests/unit/app/test_onboarding_nudges.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 
 pytestmark = pytest.mark.unit
 
-_RS = "cqc_lem.app.run_scheduler"
 _ON = "cqc_lem.utilities.onboarding"
 _DB = "cqc_lem.utilities.db"
 

--- a/tests/unit/app/test_onboarding_nudges.py
+++ b/tests/unit/app/test_onboarding_nudges.py
@@ -1,0 +1,55 @@
+"""Unit tests for the daily onboarding beat task (issue #500)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_RS = "cqc_lem.app.run_scheduler"
+_ON = "cqc_lem.utilities.onboarding"
+_DB = "cqc_lem.utilities.db"
+
+
+def _run(candidates, nudges, send_result=True):
+    with patch(f"{_DB}.get_onboarding_candidate_user_ids", return_value=candidates), \
+         patch(f"{_ON}.sync_onboarding_state", return_value={}) as sync, \
+         patch(f"{_ON}.next_nudge_for_user", side_effect=nudges), \
+         patch(f"{_ON}.send_onboarding_nudge", return_value=send_result) as send:
+        from cqc_lem.app.run_scheduler import auto_onboarding_nudges
+        result = auto_onboarding_nudges()
+    return result, sync, send
+
+
+class TestAutoOnboardingNudges:
+    def test_syncs_every_candidate_and_sends_only_due_nudges(self):
+        nudge = {"key": "connect_linkedin"}
+        result, sync, send = _run([1, 2, 3], [nudge, None, nudge])
+        assert sync.call_count == 3
+        assert send.call_count == 2
+        assert result == "Nudged 2 of 3 un-activated user(s)"
+
+    def test_counts_only_emails_that_actually_went_out(self):
+        result, _sync, _send = _run([1], [{"key": "connect_linkedin"}], send_result=False)
+        assert result == "Nudged 0 of 1 un-activated user(s)"
+
+    def test_no_candidates(self):
+        result, _sync, send = _run([], [])
+        assert result == "Nudged 0 of 0 un-activated user(s)"
+        send.assert_not_called()
+
+    def test_one_user_failing_does_not_stop_the_rest(self):
+        with patch(f"{_DB}.get_onboarding_candidate_user_ids", return_value=[1, 2]), \
+             patch(f"{_ON}.sync_onboarding_state", side_effect=[RuntimeError("db down"), {}]), \
+             patch(f"{_ON}.next_nudge_for_user", return_value={"key": "connect_linkedin"}), \
+             patch(f"{_ON}.send_onboarding_nudge", return_value=True) as send:
+            from cqc_lem.app.run_scheduler import auto_onboarding_nudges
+            result = auto_onboarding_nudges()
+        assert send.call_count == 1
+        assert result == "Nudged 1 of 2 un-activated user(s)"
+
+
+class TestBeatSchedule:
+    def test_task_is_registered_daily(self):
+        from cqc_lem.app.my_celery import app
+        entry = app.conf.beat_schedule["onboarding-nudges"]
+        assert entry["task"] == "cqc_lem.app.run_scheduler.auto_onboarding_nudges"

--- a/tests/unit/utilities/test_db_onboarding.py
+++ b/tests/unit/utilities/test_db_onboarding.py
@@ -1,0 +1,174 @@
+"""Unit tests for the onboarding/activation DB helpers (issue #500)."""
+
+from datetime import datetime
+
+import mysql.connector
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(rowcount=1, fetchone=None, fetchall=None):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.rowcount = rowcount
+    cur.fetchone.return_value = fetchone
+    cur.fetchall.return_value = fetchall or []
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+def _erroring_conn():
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.execute.side_effect = mysql.connector.Error("boom")
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestOnboardingState:
+    def test_ensure_seeds_from_the_trial_start(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import ensure_onboarding_state
+            assert ensure_onboarding_state(4) is True
+        sql, params = cur.execute.call_args[0]
+        assert "INSERT IGNORE INTO onboarding_state" in sql
+        assert "COALESCE(trial_started_at, NOW())" in sql
+        assert params == (4,)
+        conn.commit.assert_called_once()
+
+    def test_get_state_returns_row_and_empty_dict_when_missing(self):
+        row = {"user_id": 4, "started_at": datetime(2026, 7, 20)}
+        conn, cur = _conn(fetchone=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_onboarding_state
+            assert get_onboarding_state(4) == row
+        assert "activated_at" in cur.execute.call_args[0][0]
+
+        conn, _cur = _conn(fetchone=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_onboarding_state
+            assert get_onboarding_state(4) == {}
+
+    def test_mark_step_only_writes_the_first_completion(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import mark_onboarding_step, OnboardingStep
+            assert mark_onboarding_step(4, OnboardingStep.VOICE_SET) is True
+        sql = cur.execute.call_args[0][0]
+        assert "SET voice_set_at = NOW()" in sql
+        assert "voice_set_at IS NULL" in sql  # idempotent — a second call updates nothing
+
+        conn, _cur = _conn(rowcount=0)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import mark_onboarding_step, OnboardingStep
+            assert mark_onboarding_step(4, OnboardingStep.VOICE_SET) is False
+
+    def test_state_errors_are_swallowed(self):
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import (ensure_onboarding_state, get_onboarding_state,
+                                              mark_onboarding_step, OnboardingStep)
+            assert ensure_onboarding_state(4) is False
+            assert get_onboarding_state(4) == {}
+            assert mark_onboarding_step(4, OnboardingStep.ACTIVATED) is False
+
+
+class TestOnboardingNudges:
+    def test_sent_ledger_maps_key_to_timestamp(self):
+        sent_at = datetime(2026, 7, 24, 9, 0)
+        conn, _cur = _conn(fetchall=[("connect_linkedin", sent_at)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_onboarding_nudges_sent
+            assert get_onboarding_nudges_sent(4) == {"connect_linkedin": sent_at}
+
+    def test_record_is_one_shot_and_truncates_the_key(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_onboarding_nudge
+            assert record_onboarding_nudge(4, "k" * 40) is True
+        sql, params = cur.execute.call_args[0]
+        assert "INSERT IGNORE INTO onboarding_nudges" in sql
+        assert len(params[1]) == 32  # onboarding_nudges.nudge_key VARCHAR(32)
+
+        conn, _cur = _conn(rowcount=0)  # already sent → PK swallows it
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_onboarding_nudge
+            assert record_onboarding_nudge(4, "connect_linkedin") is False
+
+    def test_nudge_errors_are_swallowed(self):
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_onboarding_nudges_sent, record_onboarding_nudge
+            assert get_onboarding_nudges_sent(4) == {}
+            assert record_onboarding_nudge(4, "connect_linkedin") is False
+
+
+class TestOnboardingCandidates:
+    def test_selects_paying_or_trialing_users_who_have_not_activated(self):
+        conn, cur = _conn(fetchall=[(1,), (5,)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_onboarding_candidate_user_ids
+            assert get_onboarding_candidate_user_ids() == [1, 5]
+        sql = " ".join(cur.execute.call_args[0][0].split())
+        assert "o.activated_at IS NULL" in sql
+        assert "subscription_status = 'trial'" in sql
+        # Must NOT require a live LinkedIn connection — that's the step most stalled users lack.
+        assert "linkedin_connection_status" not in sql
+
+    def test_error_returns_empty_list(self):
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_onboarding_candidate_user_ids
+            assert get_onboarding_candidate_user_ids() == []
+
+
+class TestStepEvidenceQueries:
+    def test_has_engagement_preferences(self):
+        conn, _cur = _conn(fetchone=(1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_engagement_preferences
+            assert has_engagement_preferences(4) is True
+
+        conn, _cur = _conn(fetchone=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_engagement_preferences
+            assert has_engagement_preferences(4) is False
+
+    def test_has_post_with_status_expands_placeholders(self):
+        conn, cur = _conn(fetchone=(1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_post_with_status, PostStatus
+            assert has_post_with_status(4, (PostStatus.APPROVED, PostStatus.POSTED)) is True
+        sql, params = cur.execute.call_args[0]
+        assert "status IN (%s, %s)" in sql
+        assert params == (4, "approved", "posted")
+
+    def test_has_post_with_status_short_circuits_on_no_statuses(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            from cqc_lem.utilities.db import has_post_with_status
+            assert has_post_with_status(4, ()) is False
+        get_conn.assert_not_called()
+
+    def test_has_automated_engagement_counts_only_successful_actions(self):
+        conn, cur = _conn(fetchone=(1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_automated_engagement
+            assert has_automated_engagement(4) is True
+        sql, params = cur.execute.call_args[0]
+        assert "result = %s" in sql
+        assert params[1] == "success"
+        assert set(params[2:]) == {"comment", "reply", "dm", "followup"}
+
+    def test_evidence_errors_are_swallowed(self):
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import (has_engagement_preferences, has_post_with_status,
+                                              has_automated_engagement, PostStatus)
+            assert has_engagement_preferences(4) is False
+            assert has_post_with_status(4, (PostStatus.POSTED,)) is False
+            assert has_automated_engagement(4) is False

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -558,3 +558,24 @@ class TestPostHogHogqlQuery:
              patch("requests.post", side_effect=RuntimeError("posthog down")):
             from cqc_lem.utilities.observability import posthog_hogql_query
             assert posthog_hogql_query("SELECT 1") is None
+
+
+class TestTrackOnboarding:
+    def test_step_event_carries_the_step_and_time_to_here(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_onboarding_step
+            track_onboarding_step(42, "voice_set", hours_since_start=26.5)
+
+        _, kwargs = mock_ph.capture.call_args
+        assert kwargs["distinct_id"] == "42"
+        assert kwargs["event"] == "onboarding_step"
+        assert kwargs["properties"] == {"step": "voice_set", "hours_since_start": 26.5}
+
+    def test_nudge_event_names_the_nudge(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_onboarding_nudge
+            track_onboarding_nudge(7, "connect_linkedin")
+
+        _, kwargs = mock_ph.capture.call_args
+        assert kwargs["event"] == "onboarding_nudge"
+        assert kwargs["properties"]["nudge"] == "connect_linkedin"

--- a/tests/unit/utilities/test_onboarding.py
+++ b/tests/unit/utilities/test_onboarding.py
@@ -1,0 +1,249 @@
+"""Unit tests for the activation checklist + stalled-user nudges (issue #500):
+step derivation, one-shot state persistence + PostHog emission, and the pure nudge selector."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_ON = "cqc_lem.utilities.onboarding"
+
+NOW = datetime(2026, 7, 25, 12, 0, 0)
+
+
+def _steps(**done):
+    """Checklist dict keyed like the module does, defaulting every step to incomplete."""
+    from cqc_lem.utilities.db import ONBOARDING_STEPS
+    steps = {step: False for step in ONBOARDING_STEPS}
+    for key, value in done.items():
+        steps[key] = value
+    return steps
+
+
+class TestSelectNudge:
+    def test_no_nudge_before_the_grace_period(self):
+        from cqc_lem.utilities.onboarding import select_nudge
+        assert select_nudge(_steps(), started_at=NOW - timedelta(hours=23), now=NOW) is None
+
+    def test_connect_nudge_after_24h_without_a_session(self):
+        from cqc_lem.utilities.onboarding import select_nudge, NUDGE_CONNECT
+        nudge = select_nudge(_steps(), started_at=NOW - timedelta(hours=25), now=NOW)
+        assert nudge["key"] == NUDGE_CONNECT
+        assert nudge["cta_path"] == "/account"
+
+    def test_voice_nudge_after_48h_once_connected(self):
+        from cqc_lem.utilities.onboarding import select_nudge, NUDGE_VOICE
+        steps = _steps(linkedin_connected=True)
+        assert select_nudge(steps, started_at=NOW - timedelta(hours=47), now=NOW) is None
+        nudge = select_nudge(steps, started_at=NOW - timedelta(hours=49), now=NOW)
+        assert nudge["key"] == NUDGE_VOICE
+
+    def test_first_post_nudge_after_72h(self):
+        from cqc_lem.utilities.onboarding import select_nudge, NUDGE_FIRST_POST
+        steps = _steps(linkedin_connected=True, voice_set=True)
+        assert select_nudge(steps, started_at=NOW - timedelta(hours=71), now=NOW) is None
+        nudge = select_nudge(steps, started_at=NOW - timedelta(hours=73), now=NOW)
+        assert nudge["key"] == NUDGE_FIRST_POST
+
+    def test_earliest_incomplete_step_wins(self):
+        """A user who set their voice but never connected still gets the connect nudge."""
+        from cqc_lem.utilities.onboarding import select_nudge, NUDGE_CONNECT
+        steps = _steps(voice_set=True, first_post_approved=True)
+        nudge = select_nudge(steps, started_at=NOW - timedelta(days=5), now=NOW)
+        assert nudge["key"] == NUDGE_CONNECT
+
+    def test_activated_user_is_never_nudged(self):
+        from cqc_lem.utilities.onboarding import select_nudge
+        steps = _steps(activated=True)
+        assert select_nudge(steps, started_at=NOW - timedelta(days=10),
+                            trial_ends_at=NOW + timedelta(days=1), now=NOW) is None
+
+    def test_each_nudge_sends_only_once(self):
+        from cqc_lem.utilities.onboarding import select_nudge, NUDGE_CONNECT
+        assert select_nudge(_steps(), started_at=NOW - timedelta(days=3),
+                            sent_keys={NUDGE_CONNECT}, now=NOW) is None
+
+    def test_cooldown_blocks_a_second_nudge_the_same_day(self):
+        from cqc_lem.utilities.onboarding import select_nudge
+        assert select_nudge(_steps(), started_at=NOW - timedelta(days=3),
+                            last_sent_at=NOW - timedelta(hours=2), now=NOW) is None
+
+    def test_trial_ending_nudge_once_the_step_nudge_was_sent(self):
+        from cqc_lem.utilities.onboarding import select_nudge, NUDGE_CONNECT, NUDGE_TRIAL_ENDING
+        nudge = select_nudge(_steps(), started_at=NOW - timedelta(days=11),
+                             trial_ends_at=NOW + timedelta(days=2),
+                             sent_keys={NUDGE_CONNECT}, now=NOW)
+        assert nudge["key"] == NUDGE_TRIAL_ENDING
+
+    def test_no_trial_nudge_when_the_trial_is_far_out_or_over(self):
+        from cqc_lem.utilities.onboarding import select_nudge, NUDGE_CONNECT
+        sent = {NUDGE_CONNECT}
+        started = NOW - timedelta(days=11)
+        assert select_nudge(_steps(), started_at=started, trial_ends_at=NOW + timedelta(days=5),
+                            sent_keys=sent, now=NOW) is None
+        assert select_nudge(_steps(), started_at=started, trial_ends_at=NOW - timedelta(hours=1),
+                            sent_keys=sent, now=NOW) is None
+
+    def test_missing_started_at_never_nudges_a_step(self):
+        from cqc_lem.utilities.onboarding import select_nudge
+        assert select_nudge(_steps(), started_at=None, now=NOW) is None
+
+
+def _eval_patches(*, session=True, prefs=None, configured=True, approved=True, posted=True,
+                  engaged=True):
+    base_prefs = {"tone": "friendly", "comment_style": None, "focus_topics": [],
+                  "include_topics": [], "max_comments_per_day": 20, "max_dms_per_day": 20}
+    base_prefs.update(prefs or {})
+
+    def _has_post(_user_id, statuses):
+        from cqc_lem.utilities.db import PostStatus
+        return posted if tuple(statuses) == (PostStatus.POSTED,) else approved
+
+    return [
+        patch(f"{_ON}.has_linkedin_session", return_value=session),
+        patch(f"{_ON}.get_engagement_preferences", return_value=base_prefs),
+        patch(f"{_ON}.has_engagement_preferences", return_value=configured),
+        patch(f"{_ON}.has_post_with_status", side_effect=_has_post),
+        patch(f"{_ON}.has_automated_engagement", return_value=engaged),
+    ]
+
+
+def _evaluate(**kw):
+    ctxs = _eval_patches(**kw)
+    for c in ctxs:
+        c.start()
+    try:
+        from cqc_lem.utilities.onboarding import evaluate_steps
+        return evaluate_steps(1)
+    finally:
+        for c in ctxs:
+            c.stop()
+
+
+class TestEvaluateSteps:
+    def test_all_steps_complete(self):
+        from cqc_lem.utilities.db import OnboardingStep
+        steps = _evaluate()
+        assert all(steps[s] for s in OnboardingStep)
+
+    def test_voice_and_caps_need_a_saved_preferences_row(self):
+        """Code-level defaults apply to everyone, so an unsaved row must not count as configured."""
+        from cqc_lem.utilities.db import OnboardingStep
+        steps = _evaluate(configured=False)
+        assert steps[OnboardingStep.VOICE_SET] is False
+        assert steps[OnboardingStep.CAPS_ENABLED] is False
+
+    def test_voice_counts_when_only_topics_are_set(self):
+        from cqc_lem.utilities.db import OnboardingStep
+        steps = _evaluate(prefs={"tone": None, "focus_topics": ["ai"]})
+        assert steps[OnboardingStep.VOICE_SET] is True
+
+    def test_caps_off_when_both_are_zero(self):
+        from cqc_lem.utilities.db import OnboardingStep
+        steps = _evaluate(prefs={"max_comments_per_day": 0, "max_dms_per_day": 0})
+        assert steps[OnboardingStep.CAPS_ENABLED] is False
+
+    def test_activation_needs_both_a_published_post_and_engagement(self):
+        from cqc_lem.utilities.db import OnboardingStep
+        assert _evaluate(engaged=False)[OnboardingStep.ACTIVATED] is False
+        assert _evaluate(posted=False)[OnboardingStep.ACTIVATED] is False
+
+
+class TestSyncOnboardingState:
+    def test_marks_new_steps_once_and_tracks_them(self):
+        from cqc_lem.utilities.db import OnboardingStep
+        state = {"started_at": NOW - timedelta(hours=5),
+                 "linkedin_connected_at": NOW - timedelta(hours=4)}
+        with patch(f"{_ON}.ensure_onboarding_state", return_value=True), \
+             patch(f"{_ON}.get_onboarding_state", return_value=state), \
+             patch(f"{_ON}.evaluate_steps", return_value={
+                 OnboardingStep.LINKEDIN_CONNECTED: True, OnboardingStep.VOICE_SET: True,
+                 OnboardingStep.FIRST_POST_APPROVED: False, OnboardingStep.CAPS_ENABLED: True,
+                 OnboardingStep.ACTIVATED: False}), \
+             patch(f"{_ON}.mark_onboarding_step", return_value=True) as mark, \
+             patch("cqc_lem.utilities.observability.track_onboarding_step") as track:
+            from cqc_lem.utilities.onboarding import sync_onboarding_state
+            sync_onboarding_state(7)
+
+        marked = [c.args[1] for c in mark.call_args_list]
+        # Already-stamped and incomplete steps are skipped.
+        assert marked == [OnboardingStep.VOICE_SET, OnboardingStep.CAPS_ENABLED]
+        assert track.call_count == 2
+
+    def test_tracking_failure_does_not_break_the_sync(self):
+        from cqc_lem.utilities.db import OnboardingStep
+        with patch(f"{_ON}.ensure_onboarding_state", return_value=True), \
+             patch(f"{_ON}.get_onboarding_state", return_value={"started_at": NOW}), \
+             patch(f"{_ON}.evaluate_steps",
+                   return_value={OnboardingStep.LINKEDIN_CONNECTED: True}), \
+             patch(f"{_ON}.mark_onboarding_step", return_value=True), \
+             patch("cqc_lem.utilities.observability.track_onboarding_step",
+                   side_effect=RuntimeError("posthog down")):
+            from cqc_lem.utilities.onboarding import sync_onboarding_state
+            assert sync_onboarding_state(7) == {"started_at": NOW}
+
+
+class TestNextNudgeForUser:
+    def test_reads_persisted_steps_sent_ledger_and_trial(self):
+        from cqc_lem.utilities.onboarding import next_nudge_for_user, NUDGE_CONNECT
+        state = {"started_at": datetime.now() - timedelta(days=2)}
+        with patch(f"{_ON}.get_onboarding_nudges_sent", return_value={}), \
+             patch(f"{_ON}.get_user_subscription_info", return_value={"trial_ends_at": None}):
+            nudge = next_nudge_for_user(3, state)
+        assert nudge["key"] == NUDGE_CONNECT
+
+    def test_respects_the_cooldown_from_the_last_sent_nudge(self):
+        from cqc_lem.utilities.onboarding import next_nudge_for_user
+        state = {"started_at": datetime.now() - timedelta(days=4)}
+        with patch(f"{_ON}.get_onboarding_nudges_sent",
+                   return_value={"set_voice": datetime.now() - timedelta(hours=1)}), \
+             patch(f"{_ON}.get_user_subscription_info", return_value={}):
+            assert next_nudge_for_user(3, state) is None
+
+
+class TestSnapshotAndSend:
+    def test_snapshot_shape(self):
+        from cqc_lem.utilities.db import OnboardingStep
+        state = {"started_at": NOW, f"{OnboardingStep.LINKEDIN_CONNECTED.value}_at": NOW}
+        with patch(f"{_ON}.sync_onboarding_state", return_value=state), \
+             patch(f"{_ON}.next_nudge_for_user", return_value=None):
+            from cqc_lem.utilities.onboarding import onboarding_snapshot
+            snap = onboarding_snapshot(5)
+        assert snap["activated"] is False
+        assert snap["nudge"] is None
+        assert [s["key"] for s in snap["steps"]] == [str(s) for s in OnboardingStep]
+        assert snap["steps"][0]["ok"] is True and snap["steps"][1]["ok"] is False
+
+    def test_send_uses_llm_copy_and_records_the_nudge(self):
+        from cqc_lem.utilities.onboarding import send_onboarding_nudge, _STEP_NUDGES
+        nudge = dict(_STEP_NUDGES[0])
+        with patch("cqc_lem.utilities.ai.ai_helper.generate_onboarding_nudge_copy",
+                   return_value="Fresh copy."), \
+             patch("cqc_lem.utilities.notifications.notify_onboarding_nudge",
+                   return_value=True) as notify, \
+             patch(f"{_ON}.record_onboarding_nudge", return_value=True) as record:
+            assert send_onboarding_nudge(9, nudge) is True
+        assert notify.call_args.args[1]["body"] == "Fresh copy."
+        record.assert_called_once_with(9, nudge["key"])
+
+    def test_send_falls_back_to_default_copy_when_the_llm_fails(self):
+        from cqc_lem.utilities.onboarding import send_onboarding_nudge, _STEP_NUDGES
+        nudge = dict(_STEP_NUDGES[0])
+        with patch("cqc_lem.utilities.ai.ai_helper.generate_onboarding_nudge_copy",
+                   side_effect=RuntimeError("llm down")), \
+             patch("cqc_lem.utilities.notifications.notify_onboarding_nudge",
+                   return_value=True) as notify, \
+             patch(f"{_ON}.record_onboarding_nudge", return_value=True):
+            assert send_onboarding_nudge(9, nudge) is True
+        assert notify.call_args.args[1]["body"] == nudge["body"]
+
+    def test_nothing_is_recorded_when_the_email_fails(self):
+        from cqc_lem.utilities.onboarding import send_onboarding_nudge, _STEP_NUDGES
+        with patch("cqc_lem.utilities.ai.ai_helper.generate_onboarding_nudge_copy",
+                   return_value="Fresh copy."), \
+             patch("cqc_lem.utilities.notifications.notify_onboarding_nudge", return_value=False), \
+             patch(f"{_ON}.record_onboarding_nudge") as record:
+            assert send_onboarding_nudge(9, dict(_STEP_NUDGES[0])) is False
+        record.assert_not_called()

--- a/tests/unit/utilities/test_onboarding_notify.py
+++ b/tests/unit/utilities/test_onboarding_notify.py
@@ -33,6 +33,17 @@ class TestSendOnboardingNudgeEmail:
         html = dispatch.call_args[0][2]
         assert "https://app.example.com/account" in html
 
+    def test_escapes_caller_supplied_copy(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as dispatch:
+            from cqc_lem.utilities.email import send_onboarding_nudge_email
+            send_onboarding_nudge_email(
+                "u@example.com", "s", "<script>x</script>", "Line one\nAT&T & <b>bold</b>",
+                "Go </a><script>", "/account")
+        html = dispatch.call_args[0][2]
+        assert "<script>" not in html
+        assert "&lt;script&gt;x&lt;/script&gt;" in html
+        assert "Line one<br/>AT&amp;T &amp; &lt;b&gt;bold&lt;/b&gt;" in html
+
 
 class TestNotifyOnboardingNudge:
     def test_sends_and_tracks(self):

--- a/tests/unit/utilities/test_onboarding_notify.py
+++ b/tests/unit/utilities/test_onboarding_notify.py
@@ -1,0 +1,93 @@
+"""Unit tests for onboarding nudge delivery (issue #500): the email builder, the notification
+wrapper, and the brand-voice copy generator."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_NUDGE = {"key": "approve_post", "subject": "Your drafts are waiting",
+          "headline": "Approve one post", "body": "Nothing publishes until you approve one.",
+          "cta_label": "Review your drafts", "cta_path": "/content?tab=review"}
+
+
+class TestSendOnboardingNudgeEmail:
+    def test_builds_an_absolute_cta_url_and_dispatches(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as dispatch, \
+             patch.dict("os.environ", {"LEM_APP_URL": "https://app.example.com/"}):
+            from cqc_lem.utilities.email import send_onboarding_nudge_email
+            assert send_onboarding_nudge_email(
+                "u@example.com", _NUDGE["subject"], _NUDGE["headline"], _NUDGE["body"],
+                _NUDGE["cta_label"], _NUDGE["cta_path"]) is True
+        to_email, subject, html = dispatch.call_args[0]
+        assert to_email == "u@example.com"
+        assert subject == "Your drafts are waiting"
+        assert "https://app.example.com/content?tab=review" in html
+        assert _NUDGE["body"] in html
+
+    def test_relative_path_without_a_leading_slash_still_works(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as dispatch, \
+             patch.dict("os.environ", {"LEM_APP_URL": "https://app.example.com"}):
+            from cqc_lem.utilities.email import send_onboarding_nudge_email
+            send_onboarding_nudge_email("u@example.com", "s", "h", "b", "Go", "account")
+        html = dispatch.call_args[0][2]
+        assert "https://app.example.com/account" in html
+
+
+class TestNotifyOnboardingNudge:
+    def test_sends_and_tracks(self):
+        with patch("cqc_lem.utilities.notifications.get_user_email", return_value="u@example.com"), \
+             patch("cqc_lem.utilities.email.send_onboarding_nudge_email",
+                   return_value=True) as send, \
+             patch("cqc_lem.utilities.observability.track_onboarding_nudge") as track:
+            from cqc_lem.utilities.notifications import notify_onboarding_nudge
+            assert notify_onboarding_nudge(3, _NUDGE) is True
+        assert send.call_args.kwargs["subject"] == _NUDGE["subject"]
+        track.assert_called_once_with(3, "approve_post")
+
+    def test_no_email_address_means_no_send(self):
+        with patch("cqc_lem.utilities.notifications.get_user_email", return_value=None), \
+             patch("cqc_lem.utilities.email.send_onboarding_nudge_email") as send:
+            from cqc_lem.utilities.notifications import notify_onboarding_nudge
+            assert notify_onboarding_nudge(3, _NUDGE) is False
+        send.assert_not_called()
+
+    def test_missing_copy_falls_back_to_defaults(self):
+        with patch("cqc_lem.utilities.notifications.get_user_email", return_value="u@example.com"), \
+             patch("cqc_lem.utilities.email.send_onboarding_nudge_email",
+                   return_value=True) as send, \
+             patch("cqc_lem.utilities.observability.track_onboarding_nudge"):
+            from cqc_lem.utilities.notifications import notify_onboarding_nudge
+            assert notify_onboarding_nudge(3, {"key": "x"}) is True
+        assert send.call_args.kwargs["cta_path"] == "/account"
+        assert send.call_args.kwargs["cta_label"] == "Finish setup"
+
+    def test_send_failure_is_reported_not_raised(self):
+        with patch("cqc_lem.utilities.notifications.get_user_email", return_value="u@example.com"), \
+             patch("cqc_lem.utilities.email.send_onboarding_nudge_email",
+                   side_effect=RuntimeError("smtp down")):
+            from cqc_lem.utilities.notifications import notify_onboarding_nudge
+            assert notify_onboarding_nudge(3, _NUDGE) is False
+
+
+class TestGenerateOnboardingNudgeCopy:
+    def test_returns_the_model_copy(self):
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content="  Two tight sentences.  "))]
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=response) as call:
+            from cqc_lem.utilities.ai.ai_helper import generate_onboarding_nudge_copy
+            assert generate_onboarding_nudge_copy(3, _NUDGE) == "Two tight sentences."
+        assert call.call_args.kwargs["model"] == "lem-simple"
+        assert call.call_args.kwargs["_track_user_id"] == 3
+
+    def test_empty_completion_falls_back_to_the_default_body(self):
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content="  "))]
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=response):
+            from cqc_lem.utilities.ai.ai_helper import generate_onboarding_nudge_copy
+            assert generate_onboarding_nudge_copy(3, _NUDGE) == _NUDGE["body"]
+
+    def test_llm_failure_falls_back_to_the_default_body(self):
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", side_effect=RuntimeError("boom")):
+            from cqc_lem.utilities.ai.ai_helper import generate_onboarding_nudge_copy
+            assert generate_onboarding_nudge_copy(3, _NUDGE) == _NUDGE["body"]


### PR DESCRIPTION
## What & why

Fully-automated onboarding/activation (launch plan §A.3). **Aha** = first AI post published **and** first automated comment/DM under the user's voice, within 7 days. Until now nothing measured that, and a user who stalled at "LinkedIn not connected" was silently stuck.

### Server-persisted checklist
New `onboarding_state` + `onboarding_nudges` tables (timestamp migration `V20260725090900`). Step completion is **derived** from data we already store — session cookie, a *saved* `engagement_preferences` row, posts, logs — but the first flip of each step is persisted so the SPA checklist is stable, the PostHog event fires exactly once, and the nudge clock has a start (`trial_started_at` when known).

Steps: `linkedin_connected` → `voice_set` → `first_post_approved` → `caps_enabled` → `activated`.

Note on `voice_set` / `caps_enabled`: `get_engagement_preferences()` returns code-level defaults (caps 20/20) for **everyone**, so only the existence of a saved row counts as configured — hence the new `has_engagement_preferences()`.

### Nudges
New daily beat task `auto_onboarding_nudges` (09:30 UTC, right after `notify-missing-linkedin-session` so nobody gets two emails in the same minute).

`select_nudge` is a **pure** function of checklist + timestamps (unit-tested without DB/email/LLM):

| Nudge | Fires when |
|---|---|
| `connect_linkedin` | no LinkedIn session, 24h after start |
| `set_voice` | connected, no voice/targeting saved, 48h |
| `approve_post` | voice set, no approved post, 72h |
| `trial_ending` | trial ends within 3 days and still not activated |

The earliest incomplete step wins; each nudge sends **at most once per user** (the `onboarding_nudges` PK), at most **one nudge per 24h**, and activated users are never nudged. Candidates come from a new paying/trialing-and-not-activated query — deliberately **not** `get_active_user_ids()`, which requires a live LinkedIn connection (the very step most stalled users lack).

Copy is refreshed by `lem-simple` in LEM's own brand voice and falls back to the static body on any LLM failure, then goes out via `utilities/email.py` → `notifications.notify_onboarding_nudge`.

### SPA + analytics
`GET /api/user/onboarding` returns the checklist plus the next-best nudge; `OnboardingChecklist` renders it on the dashboard (in-app banner + progress list) and hides itself once activated. Reading the endpoint advances the persisted state, so the funnel records a step the moment the user finishes it rather than a day later. PostHog gets `onboarding_step` (with `hours_since_start`, i.e. time-to-aha) and `onboarding_nudge`.

## Testing notes

- `tests/unit/utilities/test_onboarding.py` — nudge selector (thresholds, ordering, one-shot, cooldown, trial window), step derivation, one-shot state sync + funnel emission, snapshot shape, send path incl. LLM-failure fallback.
- `tests/unit/utilities/test_db_onboarding.py` — the new DB helpers, including that the candidate query never filters on `linkedin_connection_status`.
- `tests/unit/utilities/test_onboarding_notify.py` — email builder, notify wrapper, brand-voice copy generator.
- `tests/unit/app/test_onboarding_nudges.py` — the beat task + its schedule entry.
- `tests/unit/api/test_onboarding_api.py` and `tests/integration/test_onboarding_checklist.py` — the endpoint, the latter driving real onboarding + real SQL into a stateful fake cursor to prove steps persist once and an activated user gets no nudge.
- Full local unit suite: **4380 passed**. SPA `tsc -b` clean.

Closes #500

🤖 Generated with [Claude Code](https://claude.com/claude-code)