### PR TITLE
feat(feedback): NPS/CSAT + review capture, review unlocks the extended trial (closes #501)

### DIFF
--- a/compose/local/database/migrations/V20260725095737__add_survey_prompts.sql
+++ b/compose/local/database/migrations/V20260725095737__add_survey_prompts.sql
@@ -1,0 +1,11 @@
+-- NPS/CSAT + review prompts (issue #501). The RESPONSES live in `feedback` (source='nps'/'review')
+-- so they flow through the same classifier/clustering loop as every other piece of feedback; this
+-- table only records that we ASKED, so each survey is one-shot per user (no daily re-ask) and the
+-- in-app modal and the email prompt share one ledger.
+CREATE TABLE IF NOT EXISTS survey_prompts (
+    user_id     INT NOT NULL,
+    survey_key  VARCHAR(32) NOT NULL,
+    sent_at     DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (user_id, survey_key),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -728,6 +728,34 @@ class FeedbackRequest(BaseModel):
         return v
 
 
+class NpsSurveyRequest(BaseModel):
+    """An NPS answer (issue #501): the 0-10 score plus the free-text 'why'. Bounds mirror
+    `utilities.surveys.NPS_MIN/NPS_MAX`."""
+    session_token: str
+    score: int = Field(ge=0, le=10)
+    why: Optional[str] = Field(default=None, max_length=_LEN_FEEDBACK_BODY)
+    survey_key: Optional[str] = Field(default=None, max_length=_LEN_FEEDBACK_TYPE_HINT)
+    context: Optional[Dict[str, Any]] = None
+
+
+class ReviewSurveyRequest(BaseModel):
+    """A review (issue #501): a 1-5 rating, 'what would make this a 10?', an optional public
+    testimonial and the consent flag that says we may quote it. Submitting one satisfies the
+    extended-trial gate (issue #499)."""
+    session_token: str
+    rating: int = Field(ge=1, le=5)
+    improvement: Optional[str] = Field(default=None, max_length=_LEN_FEEDBACK_BODY)
+    testimonial: Optional[str] = Field(default=None, max_length=_LEN_FEEDBACK_BODY)
+    consent_testimonial: bool = False
+    survey_key: Optional[str] = Field(default=None, max_length=_LEN_FEEDBACK_TYPE_HINT)
+    context: Optional[Dict[str, Any]] = None
+
+
+class SurveyDismissRequest(BaseModel):
+    session_token: str
+    survey_key: str = Field(min_length=1, max_length=_LEN_FEEDBACK_TYPE_HINT)
+
+
 class FutureForwardValues(IntEnum):
     Zero = 0
     ONE = 1
@@ -752,16 +780,22 @@ def get_app_info() -> ResponseModel:
     })
 
 
+def _bounded_context(context: Optional[Dict[str, Any]]) -> Optional[dict]:
+    """Client-supplied context for a feedback/survey row, dropped when a caller tries to write an
+    unbounded JSON blob — the widget and the survey modal only send a handful of fields."""
+    payload: Dict[str, Any] = dict(context or {})
+    if len(json.dumps(payload, default=str)) > _LEN_FEEDBACK_CONTEXT:
+        payload = {"truncated": True}
+    return payload or None
+
+
 @router.post("/feedback")
 def submit_feedback_endpoint(request: FeedbackRequest) -> ResponseModel:
     """Capture in-app feedback / a bug report (issue #496) — the first capture point of the
     feedback->auto-work loop. A valid session_token attributes the row to that user; without one
     (logged-out visitor) the row is kept anonymously with a NULL user_id."""
     user_id = get_session_user_id(request.session_token) if request.session_token else None
-    context: Dict[str, Any] = dict(request.context or {})
-    # Don't let a caller write an unbounded JSON blob — the widget only sends a handful of fields.
-    if len(json.dumps(context, default=str)) > _LEN_FEEDBACK_CONTEXT:
-        context = {"truncated": True}
+    context: Dict[str, Any] = _bounded_context(request.context) or {}
     if request.screenshot:
         context["screenshot"] = request.screenshot
     feedback_id = insert_feedback(request.body, user_id=user_id,
@@ -771,6 +805,76 @@ def submit_feedback_endpoint(request: FeedbackRequest) -> ResponseModel:
         raise HTTPException(status_code=500, detail="Could not save feedback")
     log_info("Feedback captured", user_id=user_id)
     return ResponseModel(status_code=200, detail={"feedback_id": feedback_id})
+
+
+@router.post("/survey/nps")
+def submit_nps_endpoint(request: NpsSurveyRequest) -> ResponseModel:
+    """Capture an NPS response (issue #501) as a `feedback` row with source='nps'. Promoters get
+    invited to turn that score into a review, which is what unlocks the extended trial (#499)."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    from cqc_lem.utilities.db import has_review_feedback
+    from cqc_lem.utilities.surveys import PROMOTER_SCORE, nps_bucket, record_nps_response
+    feedback_id = record_nps_response(user_id, request.score, why=request.why,
+                                      context=_bounded_context(request.context),
+                                      survey_key=request.survey_key)
+    if not feedback_id:
+        raise HTTPException(status_code=500, detail="Could not save your score")
+    log_info("NPS response captured", user_id=user_id)
+    return ResponseModel(status_code=200, detail={
+        "feedback_id": feedback_id,
+        "bucket": nps_bucket(request.score),
+        "review_invite": request.score >= PROMOTER_SCORE and not has_review_feedback(user_id),
+    })
+
+
+@router.post("/survey/review")
+def submit_review_endpoint(request: ReviewSurveyRequest) -> ResponseModel:
+    """Capture a review (issue #501) as a `feedback` row with source='review'. That row IS the gate
+    the extended trial checks (issue #499), so the response reports the unlock."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    from cqc_lem.utilities.surveys import record_review_response
+    feedback_id = record_review_response(
+        user_id, request.rating, improvement=request.improvement,
+        testimonial=request.testimonial, consent_testimonial=request.consent_testimonial,
+        context=_bounded_context(request.context), survey_key=request.survey_key)
+    if not feedback_id:
+        raise HTTPException(status_code=500, detail="Could not save your review")
+    log_info("Review captured", user_id=user_id)
+    return ResponseModel(status_code=200, detail={
+        "feedback_id": feedback_id,
+        "trial_extension_unlocked": True,
+    })
+
+
+@router.post("/survey/dismiss")
+def dismiss_survey_endpoint(request: SurveyDismissRequest) -> ResponseModel:
+    """User closed the survey modal without answering — record the ask so neither the modal nor the
+    email brings it back (issue #501)."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    from cqc_lem.utilities.surveys import dismiss_survey
+    return ResponseModel(status_code=200,
+                         detail={"dismissed": dismiss_survey(user_id, request.survey_key)})
+
+
+@router.get("/user/survey")
+def survey_endpoint(session_token: str) -> ResponseModel:
+    """The survey to show in-app right now (day-3 NPS, trial T-3d NPS, or the review that unlocks
+    the extended trial), or none (issue #501)."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    from cqc_lem.utilities.surveys import survey_snapshot
+    return ResponseModel(status_code=200, detail=survey_snapshot(user_id))
 
 
 @router.get("/dashboard/stats/", responses={

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -198,6 +198,12 @@ app.conf.update(
             # isn't emailed twice in the same minute. Each nudge is one-shot per user (issue #500).
             'schedule': crontab(hour='9', minute='30')
         },
+        'survey-prompts': {
+            'task': 'cqc_lem.app.run_scheduler.auto_survey_prompts',
+            # Daily 9:45 AM — after the onboarding nudge, so a stalled user gets the setup reminder
+            # rather than a survey in the same pass. Each survey is one-shot per user (issue #501).
+            'schedule': crontab(hour='9', minute='45')
+        },
         'send-appreciation-dms': {
             'task': 'cqc_lem.app.run_scheduler.auto_appreciate_dms',
             'schedule': crontab(hour='8', minute='0')  # Run every day at 8:00 AM

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -934,6 +934,30 @@ def auto_onboarding_nudges():
 
 
 @shared_task.task
+def auto_survey_prompts():
+    """Daily: email the ONE survey worth asking each subscriber — the day-3 NPS after activation, the
+    trial T-3d NPS, or the review that unlocks the extended trial (issue #501). Each survey is
+    one-shot per user and capped at one ask per SURVEY_COOLDOWN_HOURS, so this is safe to run daily;
+    a user who already answered (or dismissed the in-app modal) is never emailed about it."""
+    from cqc_lem.utilities.db import get_survey_candidate_user_ids
+    from cqc_lem.utilities.surveys import next_survey_for_user, send_survey_prompt
+
+    users = get_survey_candidate_user_ids()
+    asked = 0
+    for user_id in users:
+        try:
+            survey = next_survey_for_user(user_id)
+            if survey and send_survey_prompt(user_id, survey):
+                asked += 1
+        except Exception as e:
+            log_warning("Failed to process survey prompt", exc=e, user_id=user_id,
+                        task_name="auto_survey_prompts")
+    log_info(f"Surveys: asked {asked} of {len(users)} subscriber(s)",
+             task_name="auto_survey_prompts")
+    return f"Asked {asked} of {len(users)} subscriber(s)"
+
+
+@shared_task.task
 def auto_backfill_missing_assets():
     """Safety net: regenerate missing media for unposted video/carousel posts before they
     publish, so a post never reaches its scheduled time without its asset (e.g. when the

--- a/src/cqc_lem/ui/src/components/Layout.tsx
+++ b/src/cqc_lem/ui/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../contexts/AuthContext'
 import AccountReadinessBanner from './AccountReadinessBanner'
 import FeedbackWidget from './FeedbackWidget'
 import Footer from './Footer'
+import SurveyModal from './SurveyModal'
 
 // Pages whose features depend on a fully set-up account — show the readiness banner here.
 const AUTOMATION_PATHS = ['/content', '/schedule', '/review', '/avatars']
@@ -76,6 +77,8 @@ export default function Layout() {
       </main>
       <Footer />
       <FeedbackWidget />
+      {/* Survey modal — renders only when the server says a survey is due (issue #501) */}
+      {user && <SurveyModal />}
     </div>
   )
 }

--- a/src/cqc_lem/ui/src/components/SurveyModal.tsx
+++ b/src/cqc_lem/ui/src/components/SurveyModal.tsx
@@ -34,6 +34,9 @@ export default function SurveyModal() {
     setError(typeof msg === 'string' ? msg : fallback)
   }
 
+  // Always the key of the survey the SERVER asked for — never the promoter chain-on review, which
+  // has no ledger key of its own. Closing that opportunistic upsell must not burn the scheduled
+  // review_trial_end ask, or the user loses their shot at the extended trial (#499).
   async function dismiss() {
     setClosed(true)
     try {
@@ -79,6 +82,8 @@ export default function SurveyModal() {
         improvement: improvement.trim() || null,
         testimonial: testimonial.trim() || null,
         consent_testimonial: consent,
+        // Only the standalone review survey closes a ledger ask; the promoter chain-on already
+        // closed its NPS key when the score was submitted.
         survey_key: survey!.source === 'review' ? survey!.key : null,
       })
       setDone('Thanks — your review is in, and it unlocks the extended trial.')

--- a/src/cqc_lem/ui/src/components/SurveyModal.tsx
+++ b/src/cqc_lem/ui/src/components/SurveyModal.tsx
@@ -1,0 +1,235 @@
+import { useState } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+import { useSurvey } from '../hooks/useSurvey'
+import api from '../api/client'
+
+// NPS/CSAT + review capture (issue #501). The server decides WHICH survey is due (day-3 NPS,
+// trial T-3d NPS, or the review that unlocks the extended trial) and asks each one only once;
+// this component just renders it. Promoters (9-10) are handed the review form straight after.
+export default function SurveyModal() {
+  const { sessionToken } = useAuth()
+  const { data, refetch } = useSurvey()
+
+  const [closed, setClosed] = useState(false)
+  const [showReview, setShowReview] = useState(false)
+  const [score, setScore] = useState<number | null>(null)
+  const [why, setWhy] = useState('')
+  const [rating, setRating] = useState<number | null>(null)
+  const [improvement, setImprovement] = useState('')
+  const [testimonial, setTestimonial] = useState('')
+  const [consent, setConsent] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [done, setDone] = useState<string | null>(null)
+
+  const survey = data?.survey
+  if (!survey || closed) return null
+
+  const isReview = survey.source === 'review' || showReview
+  const maxScore = data?.nps_max ?? 10
+  const maxRating = data?.review_max_rating ?? 5
+
+  function failed(err: unknown, fallback: string) {
+    const msg = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+    setError(typeof msg === 'string' ? msg : fallback)
+  }
+
+  async function dismiss() {
+    setClosed(true)
+    try {
+      await api.post('/survey/dismiss', { session_token: sessionToken, survey_key: survey!.key })
+    } catch {
+      // Dismissal is best-effort — the modal is already gone for this session either way.
+    }
+    refetch()
+  }
+
+  async function submitNps() {
+    if (score === null) return
+    setLoading(true)
+    setError(null)
+    try {
+      const resp = await api.post('/survey/nps', {
+        session_token: sessionToken,
+        score,
+        why: why.trim() || null,
+        survey_key: survey!.key,
+      })
+      if (resp.data.detail?.review_invite) {
+        setShowReview(true)
+      } else {
+        setDone('Thanks — that goes straight to the team.')
+      }
+      refetch()
+    } catch (err: unknown) {
+      failed(err, 'Could not save your score. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function submitReview() {
+    if (rating === null) return
+    setLoading(true)
+    setError(null)
+    try {
+      await api.post('/survey/review', {
+        session_token: sessionToken,
+        rating,
+        improvement: improvement.trim() || null,
+        testimonial: testimonial.trim() || null,
+        consent_testimonial: consent,
+        survey_key: survey!.source === 'review' ? survey!.key : null,
+      })
+      setDone('Thanks — your review is in, and it unlocks the extended trial.')
+      refetch()
+    } catch (err: unknown) {
+      failed(err, 'Could not save your review. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-4">
+      <div className="relative w-full max-w-md bg-white border border-gray-200 rounded-xl shadow-xl p-5">
+        <button
+          onClick={dismiss}
+          className="absolute top-2 right-3 text-gray-400 hover:text-gray-600 text-xl leading-none"
+          aria-label="Close survey"
+        >
+          ×
+        </button>
+
+        {done ? (
+          <div className="pt-2">
+            <h2 className="text-sm font-bold text-gray-800 mb-1">Thanks 🙏</h2>
+            <p className="text-xs text-gray-500 mb-4">{done}</p>
+            <button
+              onClick={() => setClosed(true)}
+              className="w-full bg-blue-600 text-white py-2 rounded-lg text-xs font-semibold hover:bg-blue-700 transition-colors"
+            >
+              Done
+            </button>
+          </div>
+        ) : isReview ? (
+          <div className="space-y-3 pt-1">
+            <h2 className="text-sm font-bold text-gray-800">
+              {showReview ? 'Turn that into a review?' : survey.headline}
+            </h2>
+            <p className="text-xs text-gray-500">
+              {showReview
+                ? 'A short review unlocks the early-adopter extended trial.'
+                : survey.body}
+            </p>
+
+            <div className="flex gap-1" role="group" aria-label="Rating">
+              {Array.from({ length: maxRating }, (_, i) => i + 1).map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  onClick={() => setRating(n)}
+                  aria-label={`${n} star${n > 1 ? 's' : ''}`}
+                  aria-pressed={rating === n}
+                  className={`w-9 h-9 rounded-lg border text-sm ${
+                    rating !== null && n <= rating
+                      ? 'bg-yellow-400 border-yellow-400 text-white'
+                      : 'bg-white border-gray-300 text-gray-400 hover:border-blue-400'
+                  }`}
+                >
+                  ★
+                </button>
+              ))}
+            </div>
+
+            <textarea
+              rows={3}
+              maxLength={5000}
+              value={improvement}
+              onChange={(e) => setImprovement(e.target.value)}
+              aria-label="What would make this a 10?"
+              placeholder="What would make this a 10?"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <textarea
+              rows={3}
+              maxLength={5000}
+              value={testimonial}
+              onChange={(e) => setTestimonial(e.target.value)}
+              aria-label="Your review"
+              placeholder="Your review, in your words (optional)"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+            <label className="flex items-start gap-2 text-[11px] text-gray-600">
+              <input
+                type="checkbox"
+                checked={consent}
+                onChange={(e) => setConsent(e.target.checked)}
+                className="mt-0.5"
+              />
+              You may quote this (with my name) as a testimonial.
+            </label>
+
+            {error && <p className="text-xs text-red-600">{error}</p>}
+            <button
+              type="button"
+              onClick={submitReview}
+              disabled={loading || rating === null}
+              className="w-full bg-blue-600 text-white py-2 rounded-lg text-xs font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {loading ? 'Sending…' : 'Submit review'}
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3 pt-1">
+            <h2 className="text-sm font-bold text-gray-800">{survey.headline}</h2>
+            <p className="text-xs text-gray-500">{survey.body}</p>
+
+            <div className="flex flex-wrap gap-1" role="group" aria-label="Score 0 to 10">
+              {Array.from({ length: maxScore + 1 }, (_, n) => n).map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  onClick={() => setScore(n)}
+                  aria-label={`Score ${n}`}
+                  aria-pressed={score === n}
+                  className={`w-8 h-8 rounded-lg border text-xs font-semibold ${
+                    score === n
+                      ? 'bg-blue-600 border-blue-600 text-white'
+                      : 'bg-white border-gray-300 text-gray-600 hover:border-blue-400'
+                  }`}
+                >
+                  {n}
+                </button>
+              ))}
+            </div>
+            <div className="flex justify-between text-[11px] text-gray-400">
+              <span>Not likely</span>
+              <span>Very likely</span>
+            </div>
+
+            <textarea
+              rows={3}
+              maxLength={5000}
+              value={why}
+              onChange={(e) => setWhy(e.target.value)}
+              aria-label="Why that score?"
+              placeholder="What's the main reason for your score?"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+
+            {error && <p className="text-xs text-red-600">{error}</p>}
+            <button
+              type="button"
+              onClick={submitNps}
+              disabled={loading || score === null}
+              className="w-full bg-blue-600 text-white py-2 rounded-lg text-xs font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {loading ? 'Sending…' : survey.cta_label}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/hooks/useSurvey.ts
+++ b/src/cqc_lem/ui/src/hooks/useSurvey.ts
@@ -1,0 +1,35 @@
+import { useQuery } from '@tanstack/react-query'
+import api from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
+
+export interface SurveyPrompt {
+  key: string
+  source: 'nps' | 'review'
+  headline: string
+  body: string
+  cta_label: string
+}
+
+export interface SurveySnapshot {
+  survey: SurveyPrompt | null
+  review_submitted: boolean
+  nps_min: number
+  nps_max: number
+  review_min_rating: number
+  review_max_rating: number
+}
+
+// The survey to ask right now — day-3 NPS, trial T-3d NPS, or the review that unlocks the
+// extended trial (issue #501). Null `survey` means there is nothing to ask.
+export function useSurvey() {
+  const { sessionToken } = useAuth()
+  return useQuery({
+    queryKey: ['survey', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/survey?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as SurveySnapshot),
+    enabled: !!sessionToken,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -6526,6 +6526,99 @@ def update_feedback_triage(feedback_id: int, status: "FeedbackStatus" = None,
         connection.close()
 
 
+# --- NPS/CSAT + review surveys (issue #501) -----------------------------------------
+def get_latest_feedback_at(user_id: int, source: "FeedbackSource") -> Optional[datetime]:
+    """When this user last answered a survey of the given source, or None if they never have.
+    Drives both "don't ask again" suppression and the review gate on the extended trial."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT MAX(created_at) FROM feedback WHERE user_id = %s AND source = %s",
+            (user_id, str(source)))
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except mysql.connector.Error as err:
+        log_error(f"Could not get latest {source} feedback for user_id {user_id}", exc=err)
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def has_review_feedback(user_id: int) -> bool:
+    """The extended-trial gate (issue #499 consumes this): True once the user has submitted a
+    review. Fails CLOSED — a DB error never hands out a trial extension."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT 1 FROM feedback WHERE user_id = %s AND source = %s LIMIT 1",
+                       (user_id, str(FeedbackSource.REVIEW)))
+        return cursor.fetchone() is not None
+    except mysql.connector.Error as err:
+        log_error(f"Could not check review feedback for user_id {user_id}", exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_survey_prompts_sent(user_id: int) -> dict:
+    """survey_key -> sent_at for every survey prompt already shown/emailed to this user."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT survey_key, sent_at FROM survey_prompts WHERE user_id = %s",
+                       (user_id,))
+        return {row[0]: row[1] for row in cursor.fetchall()}
+    except mysql.connector.Error as err:
+        log_error(f"Could not get survey prompts for user_id {user_id}", exc=err)
+        return {}
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_survey_prompt(user_id: int, survey_key: str) -> bool:
+    """Record that a survey was asked. Returns False when it was already asked (the PK makes each
+    survey one-shot per user, whether it went out in-app or by email)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("INSERT IGNORE INTO survey_prompts (user_id, survey_key) VALUES (%s, %s)",
+                       (user_id, str(survey_key)[:32]))
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        log_error(f"Could not record survey prompt {survey_key} for user_id {user_id}", exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_survey_candidate_user_ids() -> list:
+    """Users worth surveying: on an active plan or an unexpired trial. Unlike the onboarding
+    candidates this does NOT exclude activated users — activation is exactly what makes someone
+    worth asking (the day-3 NPS fires off their activation timestamp)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("""
+            SELECT id FROM users
+            WHERE subscription_status = 'active'
+               OR (subscription_status = 'trial'
+                   AND (trial_ends_at IS NULL OR trial_ends_at > NOW()))
+        """)
+        return [row[0] for row in cursor.fetchall()]
+    except mysql.connector.Error as err:
+        log_error("Could not get survey candidate user ids", exc=err)
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
 # --- Onboarding / activation checklist (issue #500) ---------------------------------
 def ensure_onboarding_state(user_id: int) -> bool:
     """Create the user's onboarding row if it doesn't exist. `started_at` is the trial start when we

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -390,6 +390,30 @@ def send_onboarding_nudge_email(to_email: str, subject: str, headline: str, body
     return _dispatch_email(to_email, subject, html)
 
 
+def send_survey_prompt_email(to_email: str, subject: str, headline: str, body: str,
+                             cta_label: str, cta_path: str = "/") -> bool:
+    """Invite a user to answer an NPS survey or leave a review (issue #501). The CTA deep-links to
+    the in-app modal, so both channels write the same `feedback` row."""
+    import os
+    base = (os.getenv("LEM_APP_URL") or "https://lem.christopherqueenconsulting.com").rstrip("/")
+    url = f"{base}{cta_path if cta_path.startswith('/') else '/' + cta_path}"
+    safe_headline = html_escape(headline or "")
+    safe_body = html_escape(body or "").replace("\n", "<br/>")
+    safe_cta_label = html_escape(cta_label or "")
+    safe_url = html_escape(url)
+    html = f"""
+    <html><body style="font-family:Arial,Helvetica,sans-serif;color:#222;">
+    <h2>{safe_headline}</h2>
+    <p>{safe_body}</p>
+    <p><a href="{safe_url}" style="background:#0a66c2;color:#fff;padding:10px 16px;border-radius:6px;
+    text-decoration:none;">{safe_cta_label}</a></p>
+    <p style="color:#888;font-size:12px;">We ask each of these once — answer it or ignore it and you
+    won't hear about it again.</p>
+    </body></html>
+    """
+    return _dispatch_email(to_email, subject, html)
+
+
 def send_pin_email(
     to_email: str,
     pin: str,

--- a/src/cqc_lem/utilities/notifications.py
+++ b/src/cqc_lem/utilities/notifications.py
@@ -76,6 +76,34 @@ def notify_onboarding_nudge(user_id: int, nudge: dict) -> bool:
         return False
 
 
+def notify_survey_prompt(user_id: int, survey: dict) -> bool:
+    """Email an NPS/review invite (issue #501). One-shot per survey is the caller's job (the
+    survey_prompts ledger). Returns True only if an email was actually sent."""
+    try:
+        email = get_user_email(user_id)
+        if not email:
+            return False
+        from cqc_lem.utilities.email import send_survey_prompt_email
+        sent = send_survey_prompt_email(
+            email,
+            subject=survey.get("subject") or "How are we doing?",
+            headline=survey.get("headline") or "How are we doing?",
+            body=survey.get("body") or "",
+            cta_label=survey.get("cta_label") or "Answer",
+            cta_path=survey.get("cta_path") or "/",
+        )
+        if sent:
+            from cqc_lem.utilities.observability import track_survey_prompt
+            track_survey_prompt(user_id, str(survey.get("key")))
+            log_info(f"Sent survey prompt '{survey.get('key')}'", user_id=user_id,
+                     action_type="survey_prompt")
+        return sent
+    except Exception as e:
+        log_warning("Could not send survey prompt", exc=e, user_id=user_id,
+                    action_type="survey_prompt")
+        return False
+
+
 def notify_newsletter_draft_ready(user_id: int, edition_title: str, scheduled_for) -> bool:
     """Email the user that their newsletter draft is ready to review and when it auto-publishes.
     Non-fatal — returns True only if an email was actually sent."""

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -370,6 +370,25 @@ def track_onboarding_nudge(user_id: int, nudge_key: str, **extra) -> None:
     )
 
 
+def track_survey_prompt(user_id: int, survey_key: str, **extra) -> None:
+    """Emit the survey we asked for (issue #501), so ask → response rate is measurable."""
+    posthog.capture(
+        distinct_id=str(user_id),
+        event="survey_prompt",
+        properties={"survey": survey_key, **extra},
+    )
+
+
+def track_survey_response(user_id: int, source: str, **extra) -> None:
+    """Emit an NPS/review answer (issue #501) with its score/rating, so NPS and CSAT can be trended
+    in PostHog next to the activation funnel."""
+    posthog.capture(
+        distinct_id=str(user_id),
+        event="survey_response",
+        properties={"source": source, **extra},
+    )
+
+
 def track_task(
     task_name: str,
     duration_ms: int,

--- a/src/cqc_lem/utilities/surveys.py
+++ b/src/cqc_lem/utilities/surveys.py
@@ -1,0 +1,226 @@
+"""NPS/CSAT + review capture (issue #501) — the survey channels of the feedback->auto-work loop.
+
+Responses are stored as ordinary `feedback` rows (source='nps' / source='review') so they flow
+straight into the existing classifier + clustering + auto-FAQ pipeline; the score/rating and the
+consent flag ride along in `context_json`. Only the ASK is tracked separately (`survey_prompts`),
+which is what keeps each survey one-shot per user across the in-app modal and the email.
+
+`select_survey` is deliberately a PURE function of timestamps + what has already been asked/answered,
+so the "who gets asked what, when" policy is unit-testable without a DB, an email, or an LLM — same
+posture as `onboarding.select_nudge`.
+
+A review row is also the gate on the extended trial (issue #499): `db.has_review_feedback`.
+"""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from cqc_lem.utilities.db import (
+    FeedbackSource, get_latest_feedback_at, get_onboarding_state, get_survey_prompts_sent,
+    get_user_subscription_info, has_review_feedback, insert_feedback, record_survey_prompt,
+)
+from cqc_lem.utilities.logger import log_warning
+
+# Survey keys (also the survey_prompts PK half — each is asked at most once per user).
+SURVEY_NPS_DAY3 = "nps_day3"
+SURVEY_NPS_TRIAL_END = "nps_trial_end"
+SURVEY_REVIEW_TRIAL_END = "review_trial_end"
+
+# Ask for NPS this long after the user activated — early enough that the "aha" is fresh, late enough
+# that they've seen automation run for a few days.
+NPS_AFTER_ACTIVATION_DAYS = 3
+# Trial T-3d: the last useful moment to ask, and where the review-for-extended-trial offer lands.
+TRIAL_ENDING_WITHIN_DAYS = 3
+# At most one survey ask per user per this many hours, whatever the beat cadence.
+SURVEY_COOLDOWN_HOURS = 24
+# Promoters get invited to turn that score into a review right after they answer.
+PROMOTER_SCORE = 9
+
+NPS_MIN, NPS_MAX = 0, 10
+# Public review sites LEM syndicates to (marketplace/G2) are 5-star, so the review form is too.
+REVIEW_MIN_RATING, REVIEW_MAX_RATING = 1, 5
+
+_SURVEYS: dict = {
+    SURVEY_NPS_DAY3: {
+        "key": SURVEY_NPS_DAY3,
+        "source": str(FeedbackSource.NPS),
+        "subject": "Quick one: how likely are you to recommend LEM?",
+        "headline": "How likely are you to recommend LEM?",
+        "body": ("You've had your first posts and automated engagement go out. One number, 0–10 — "
+                 "and if you have 10 seconds more, tell us why."),
+        "cta_label": "Give a score",
+    },
+    SURVEY_NPS_TRIAL_END: {
+        "key": SURVEY_NPS_TRIAL_END,
+        "source": str(FeedbackSource.NPS),
+        "subject": "Before your trial ends — how did we do?",
+        "headline": "How likely are you to recommend LEM?",
+        "body": ("Your trial wraps up in a few days. One number, 0–10, tells us whether LEM earned "
+                 "its keep — and what to fix if it didn't."),
+        "cta_label": "Give a score",
+    },
+    SURVEY_REVIEW_TRIAL_END: {
+        "key": SURVEY_REVIEW_TRIAL_END,
+        "source": str(FeedbackSource.REVIEW),
+        "subject": "Leave a review, unlock the extended trial",
+        "headline": "Write a review, keep LEM running longer",
+        "body": ("Your trial ends in a few days. Leave an honest review — a rating and what would "
+                 "make LEM a 10 — and you unlock the early-adopter extended trial."),
+        "cta_label": "Write a review",
+    },
+}
+
+# Every survey opens the same in-app modal; the key tells the SPA which form to render.
+_CTA_PATH = "/?survey="
+
+
+def nps_bucket(score: int) -> str:
+    """Standard NPS banding, stored as the feedback row's sentiment."""
+    if score >= PROMOTER_SCORE:
+        return "promoter"
+    if score >= 7:
+        return "passive"
+    return "detractor"
+
+
+def review_sentiment(rating: int) -> str:
+    """CSAT banding for a 1-5 review rating."""
+    if rating >= 4:
+        return "positive"
+    return "neutral" if rating == 3 else "negative"
+
+
+def _survey(key: str) -> dict:
+    survey = dict(_SURVEYS[key])
+    survey["cta_path"] = f"{_CTA_PATH}{key}"
+    return survey
+
+
+def select_survey(activated_at: Optional[datetime] = None,
+                  trial_ends_at: Optional[datetime] = None,
+                  nps_answered_at: Optional[datetime] = None,
+                  review_answered_at: Optional[datetime] = None,
+                  sent_keys=(), last_sent_at: Optional[datetime] = None,
+                  now: Optional[datetime] = None) -> Optional[dict]:
+    """The one survey worth asking this user right now, or None.
+
+    Rules: each survey is asked at most once (`sent_keys`); at most one ask per
+    SURVEY_COOLDOWN_HOURS (`last_sent_at`); an already-answered survey is never re-asked. At trial
+    T-3d the review offer outranks NPS — it is the ask that gives the user something back."""
+    now = now or datetime.now()
+    if last_sent_at and now - last_sent_at < timedelta(hours=SURVEY_COOLDOWN_HOURS):
+        return None
+
+    sent = set(sent_keys or ())
+    trial_ending = bool(trial_ends_at) and (
+        timedelta(0) < trial_ends_at - now <= timedelta(days=TRIAL_ENDING_WITHIN_DAYS))
+
+    if trial_ending and not review_answered_at and SURVEY_REVIEW_TRIAL_END not in sent:
+        return _survey(SURVEY_REVIEW_TRIAL_END)
+
+    if not nps_answered_at:
+        if (activated_at and SURVEY_NPS_DAY3 not in sent
+                and now - activated_at >= timedelta(days=NPS_AFTER_ACTIVATION_DAYS)):
+            return _survey(SURVEY_NPS_DAY3)
+        if trial_ending and SURVEY_NPS_TRIAL_END not in sent:
+            return _survey(SURVEY_NPS_TRIAL_END)
+    return None
+
+
+def next_survey_for_user(user_id: int) -> Optional[dict]:
+    """`select_survey` bound to a real user — used by both the beat task and the in-app modal."""
+    state = get_onboarding_state(user_id) or {}
+    sub = get_user_subscription_info(user_id) or {}
+    sent = get_survey_prompts_sent(user_id)
+    return select_survey(
+        activated_at=state.get("activated_at"),
+        trial_ends_at=sub.get("trial_ends_at"),
+        nps_answered_at=get_latest_feedback_at(user_id, FeedbackSource.NPS),
+        review_answered_at=get_latest_feedback_at(user_id, FeedbackSource.REVIEW),
+        sent_keys=set(sent),
+        last_sent_at=max(sent.values()) if sent else None,
+    )
+
+
+def survey_snapshot(user_id: int) -> dict:
+    """Everything the SPA modal needs: the survey to ask (if any) and whether the review that
+    unlocks the extended trial (issue #499) is already on file."""
+    survey = next_survey_for_user(user_id)
+    return {
+        "survey": {k: survey[k] for k in ("key", "source", "headline", "body", "cta_label")}
+        if survey else None,
+        "review_submitted": has_review_feedback(user_id),
+        "nps_min": NPS_MIN, "nps_max": NPS_MAX,
+        "review_min_rating": REVIEW_MIN_RATING, "review_max_rating": REVIEW_MAX_RATING,
+    }
+
+
+def record_nps_response(user_id: Optional[int], score: int, why: Optional[str] = None,
+                        context: Optional[dict] = None,
+                        survey_key: Optional[str] = None) -> Optional[int]:
+    """Persist an NPS answer as a `feedback` row (source='nps'). The free-text 'why' is the body so
+    the classifier can act on it; the score rides in context_json and as the NPS band."""
+    text = (why or "").strip()
+    body = text or f"NPS {score}/{NPS_MAX} — no comment"
+    payload = {**(context or {}), "score": int(score), "survey_key": survey_key}
+    feedback_id = insert_feedback(body, user_id=user_id, source=FeedbackSource.NPS,
+                                 type_hint="nps", context=payload,
+                                 sentiment=nps_bucket(int(score)))
+    if feedback_id and user_id:
+        _record_answer(user_id, survey_key)
+        _track_response(user_id, str(FeedbackSource.NPS), score=int(score))
+    return feedback_id
+
+
+def record_review_response(user_id: Optional[int], rating: int, improvement: Optional[str] = None,
+                           testimonial: Optional[str] = None, consent_testimonial: bool = False,
+                           context: Optional[dict] = None,
+                           survey_key: Optional[str] = None) -> Optional[int]:
+    """Persist a review as a `feedback` row (source='review'). This row IS the extended-trial gate
+    (issue #499), and its body feeds the classifier + auto-FAQ like any other feedback."""
+    parts = [p.strip() for p in (testimonial, improvement) if p and p.strip()]
+    body = "\n\n".join(parts) or f"Review {rating}/{REVIEW_MAX_RATING} — no comment"
+    payload = {**(context or {}), "rating": int(rating),
+               "improvement": (improvement or "").strip() or None,
+               "testimonial": (testimonial or "").strip() or None,
+               "consent_testimonial": bool(consent_testimonial), "survey_key": survey_key}
+    feedback_id = insert_feedback(body, user_id=user_id, source=FeedbackSource.REVIEW,
+                                 type_hint="review", context=payload,
+                                 sentiment=review_sentiment(int(rating)))
+    if feedback_id and user_id:
+        _record_answer(user_id, survey_key)
+        _track_response(user_id, str(FeedbackSource.REVIEW), rating=int(rating),
+                        consent_testimonial=bool(consent_testimonial))
+    return feedback_id
+
+
+def _record_answer(user_id: int, survey_key: Optional[str]) -> None:
+    """Close the loop on the ask that produced this answer so nothing re-asks it."""
+    if survey_key in _SURVEYS:
+        record_survey_prompt(user_id, survey_key)
+
+
+def _track_response(user_id: int, source: str, **properties) -> None:
+    """Analytics must never break a survey submission."""
+    try:
+        from cqc_lem.utilities.observability import track_survey_response
+        track_survey_response(user_id, source, **properties)
+    except Exception as e:
+        log_warning("Could not track survey response", exc=e, user_id=user_id)
+
+
+def dismiss_survey(user_id: int, survey_key: str) -> bool:
+    """User closed the modal without answering — record the ask so it isn't shown or emailed again."""
+    if survey_key not in _SURVEYS:
+        return False
+    return record_survey_prompt(user_id, survey_key)
+
+
+def send_survey_prompt(user_id: int, survey: dict) -> bool:
+    """Email the survey invite and record the ask so it never goes out twice. Returns True only when
+    an email actually went out."""
+    from cqc_lem.utilities.notifications import notify_survey_prompt
+    if not notify_survey_prompt(user_id, survey):
+        return False
+    record_survey_prompt(user_id, survey["key"])
+    return True

--- a/tests/integration/test_survey_capture.py
+++ b/tests/integration/test_survey_capture.py
@@ -1,0 +1,190 @@
+"""Integration test for NPS + review capture (issue #501).
+
+Drives the real POST /api/survey/nps, POST /api/survey/review and GET /api/user/survey handlers
+through the real `utilities/surveys.py` policy and the real db.py SQL into a stateful fake cursor
+that models `feedback` + `survey_prompts` + `onboarding_state` — so the rows provably land with the
+right source, the ask is recorded once, and a review provably flips the extended-trial gate
+(`has_review_feedback`, issue #499) without needing a live MySQL container.
+"""
+import json
+from datetime import datetime, timedelta
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.integration
+
+_DB = "cqc_lem.utilities.db"
+
+
+class _FakeCursor:
+    """Minimal MySQL-ish cursor over an in-memory feedback / survey_prompts / onboarding store."""
+
+    def __init__(self, store, dictionary=False):
+        self.store = store
+        self.dictionary = dictionary
+        self._result = []
+        self.rowcount = 0
+        self.lastrowid = None
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        self._result = []
+        self.rowcount = 0
+        if s.startswith("INSERT INTO feedback"):
+            row = {"id": len(self.store["feedback"]) + 1, "user_id": params[0], "source": params[1],
+                   "type_hint": params[2], "body": params[3],
+                   "context_json": json.loads(params[4]) if params[4] else None,
+                   "sentiment": params[5], "created_at": datetime.now()}
+            self.store["feedback"].append(row)
+            self.lastrowid = row["id"]
+            self.rowcount = 1
+        elif s.startswith("SELECT MAX(created_at) FROM feedback"):
+            answers = [r["created_at"] for r in self.store["feedback"]
+                       if r["user_id"] == params[0] and r["source"] == params[1]]
+            self._result = [(max(answers) if answers else None,)]
+        elif s.startswith("SELECT 1 FROM feedback"):
+            self._result = [(1,)] if any(r["user_id"] == params[0] and r["source"] == params[1]
+                                         for r in self.store["feedback"]) else []
+        elif s.startswith("INSERT IGNORE INTO survey_prompts"):
+            if params[1] not in self.store["prompts"]:
+                self.store["prompts"][params[1]] = datetime.now()
+                self.rowcount = 1
+        elif s.startswith("SELECT survey_key, sent_at"):
+            self._result = list(self.store["prompts"].items())
+        elif s.startswith("SELECT user_id, started_at"):
+            self._result = [dict(self.store["onboarding"])] if self.store["onboarding"] else []
+        elif s.startswith("SELECT subscription_status"):
+            self._result = [dict(self.store["subscription"])]
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return list(self._result)
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, store):
+        self.store = store
+
+    def cursor(self, *a, **k):
+        return _FakeCursor(self.store, dictionary=k.get("dictionary", False))
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from cqc_lem.api.main import app
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def store():
+    return {
+        "feedback": [],
+        "prompts": {},
+        "onboarding": {"user_id": 4, "started_at": datetime.now() - timedelta(days=10),
+                       "linkedin_connected_at": None, "voice_set_at": None,
+                       "first_post_approved_at": None, "caps_enabled_at": None,
+                       "activated_at": datetime.now() - timedelta(days=5)},
+        "subscription": {"subscription_status": "trial",
+                         "trial_ends_at": datetime.now() + timedelta(days=2)},
+    }
+
+
+def _call(client, store, method, path, **kwargs):
+    with patch(f"{_DB}.get_db_connection", side_effect=lambda *a, **k: _FakeConn(store)), \
+         patch("cqc_lem.api.main.get_session_user_id", return_value=4), \
+         patch("cqc_lem.utilities.observability.posthog"):
+        return getattr(client, method)(path, **kwargs)
+
+
+class TestSurveyCapture:
+    def test_nps_lands_as_a_feedback_row_and_invites_a_promoter_to_review(self, client, store):
+        response = _call(client, store, "post", "/api/survey/nps", json={
+            "session_token": "sess-abc", "score": 10, "why": "It sounds exactly like me",
+            "survey_key": "nps_day3", "context": {"route": "/"}})
+
+        assert response.status_code == 200
+        detail = response.json()["detail"]
+        assert detail["bucket"] == "promoter"
+        assert detail["review_invite"] is True  # promoter with no review on file yet
+
+        row = store["feedback"][0]
+        assert row["source"] == "nps"
+        assert row["body"] == "It sounds exactly like me"
+        assert row["sentiment"] == "promoter"
+        assert row["context_json"] == {"route": "/", "score": 10, "survey_key": "nps_day3"}
+        assert row["id"] == detail["feedback_id"]
+        # The ask that produced the answer is closed out, so nothing re-asks it.
+        assert "nps_day3" in store["prompts"]
+
+    def test_review_lands_with_source_review_and_unlocks_the_trial_extension(self, client, store):
+        from cqc_lem.utilities.db import has_review_feedback
+
+        with patch(f"{_DB}.get_db_connection", side_effect=lambda *a, **k: _FakeConn(store)):
+            assert has_review_feedback(4) is False  # gate closed before the review
+
+        response = _call(client, store, "post", "/api/survey/review", json={
+            "session_token": "sess-abc", "rating": 5, "improvement": "Fewer clicks to approve",
+            "testimonial": "Saves me an hour a day", "consent_testimonial": True,
+            "survey_key": "review_trial_end"})
+
+        assert response.status_code == 200
+        assert response.json()["detail"]["trial_extension_unlocked"] is True
+
+        row = store["feedback"][0]
+        assert row["source"] == "review"
+        assert row["sentiment"] == "positive"
+        assert row["context_json"]["rating"] == 5
+        assert row["context_json"]["consent_testimonial"] is True
+        assert "Saves me an hour a day" in row["body"]
+        assert "Fewer clicks to approve" in row["body"]
+
+        with patch(f"{_DB}.get_db_connection", side_effect=lambda *a, **k: _FakeConn(store)):
+            assert has_review_feedback(4) is True  # gate now open for POST /trial/extend (#499)
+
+    def test_the_due_survey_is_the_review_offer_and_it_clears_once_answered(self, client, store):
+        # Trial ends in 2 days with no review on file → the review offer outranks the NPS ask.
+        response = _call(client, store, "get", "/api/user/survey?session_token=sess-abc")
+        detail = response.json()["detail"]
+        assert detail["survey"]["key"] == "review_trial_end"
+        assert detail["survey"]["source"] == "review"
+        assert detail["review_submitted"] is False
+
+        _call(client, store, "post", "/api/survey/review",
+              json={"session_token": "sess-abc", "rating": 4, "survey_key": "review_trial_end"})
+
+        detail = _call(client, store, "get",
+                       "/api/user/survey?session_token=sess-abc").json()["detail"]
+        assert detail["review_submitted"] is True
+        assert detail["survey"] is None  # just answered — the daily cooldown holds the next ask
+
+        # A day later the cooldown has lapsed: the NPS this user (activated 5 days ago) still owes
+        # is next — never a review re-ask.
+        store["prompts"]["review_trial_end"] = datetime.now() - timedelta(days=1, hours=1)
+        detail = _call(client, store, "get",
+                       "/api/user/survey?session_token=sess-abc").json()["detail"]
+        assert detail["survey"]["key"] == "nps_day3"
+
+    def test_a_dismissed_survey_is_never_shown_again(self, client, store):
+        dismissed = _call(client, store, "post", "/api/survey/dismiss",
+                          json={"session_token": "sess-abc", "survey_key": "review_trial_end"})
+        assert dismissed.json()["detail"]["dismissed"] is True
+
+        detail = _call(client, store, "get",
+                       "/api/user/survey?session_token=sess-abc").json()["detail"]
+        # The review ask is spent; the cooldown holds the next ask back for a day.
+        assert detail["survey"] is None

--- a/tests/unit/api/test_survey_api.py
+++ b/tests/unit/api/test_survey_api.py
@@ -1,0 +1,154 @@
+"""Unit tests for the NPS / review survey endpoints (issue #501)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_M = "cqc_lem.api.main"
+_S = "cqc_lem.utilities.surveys"
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+class TestNpsEndpoint:
+    def test_persists_the_score_and_the_why(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_nps_response", return_value=101) as record, \
+             patch("cqc_lem.utilities.db.has_review_feedback", return_value=False):
+            resp = client.post("/api/survey/nps", json={
+                "session_token": "tok", "score": 9, "why": "It sounds like me",
+                "survey_key": "nps_day3", "context": {"route": "/"}})
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert detail == {"feedback_id": 101, "bucket": "promoter", "review_invite": True}
+        assert record.call_args.args == (42, 9)
+        assert record.call_args.kwargs["survey_key"] == "nps_day3"
+        assert record.call_args.kwargs["context"] == {"route": "/"}
+
+    def test_promoter_who_already_reviewed_is_not_re_invited(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_nps_response", return_value=102), \
+             patch("cqc_lem.utilities.db.has_review_feedback", return_value=True):
+            resp = client.post("/api/survey/nps",
+                               json={"session_token": "tok", "score": 10})
+        assert resp.json()["detail"]["review_invite"] is False
+
+    def test_detractor_is_not_invited_to_review(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_nps_response", return_value=103), \
+             patch("cqc_lem.utilities.db.has_review_feedback", return_value=False):
+            resp = client.post("/api/survey/nps", json={"session_token": "tok", "score": 4})
+        detail = resp.json()["detail"]
+        assert detail["bucket"] == "detractor"
+        assert detail["review_invite"] is False
+
+    def test_oversized_context_is_dropped(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_nps_response", return_value=104) as record, \
+             patch("cqc_lem.utilities.db.has_review_feedback", return_value=False):
+            client.post("/api/survey/nps", json={"session_token": "tok", "score": 7,
+                                                 "context": {"blob": "x" * 9000}})
+        assert record.call_args.kwargs["context"] == {"truncated": True}
+
+    @pytest.mark.parametrize("score", [-1, 11])
+    def test_out_of_range_scores_are_rejected(self, client, score):
+        with patch(f"{_M}.get_session_user_id", return_value=42):
+            resp = client.post("/api/survey/nps", json={"session_token": "tok", "score": score})
+        assert resp.status_code == 422
+
+    def test_401_without_a_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.post("/api/survey/nps", json={"session_token": "bad", "score": 9})
+        assert resp.status_code == 401
+
+    def test_500_when_the_row_cannot_be_saved(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_nps_response", return_value=None):
+            resp = client.post("/api/survey/nps", json={"session_token": "tok", "score": 9})
+        assert resp.status_code == 500
+
+
+class TestReviewEndpoint:
+    def test_persists_the_review_and_reports_the_unlock(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_review_response", return_value=201) as record:
+            resp = client.post("/api/survey/review", json={
+                "session_token": "tok", "rating": 5, "improvement": "Faster carousels",
+                "testimonial": "Saves me an hour a day", "consent_testimonial": True,
+                "survey_key": "review_trial_end"})
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == {"feedback_id": 201, "trial_extension_unlocked": True}
+        assert record.call_args.args == (42, 5)
+        assert record.call_args.kwargs["consent_testimonial"] is True
+        assert record.call_args.kwargs["testimonial"] == "Saves me an hour a day"
+
+    @pytest.mark.parametrize("rating", [0, 6])
+    def test_out_of_range_ratings_are_rejected(self, client, rating):
+        with patch(f"{_M}.get_session_user_id", return_value=42):
+            resp = client.post("/api/survey/review",
+                               json={"session_token": "tok", "rating": rating})
+        assert resp.status_code == 422
+
+    def test_401_without_a_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.post("/api/survey/review", json={"session_token": "bad", "rating": 5})
+        assert resp.status_code == 401
+
+    def test_500_when_the_row_cannot_be_saved(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_review_response", return_value=None):
+            resp = client.post("/api/survey/review", json={"session_token": "tok", "rating": 5})
+        assert resp.status_code == 500
+
+
+class TestDismissAndSnapshot:
+    def test_dismiss_records_the_ask(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.dismiss_survey", return_value=True) as dismiss:
+            resp = client.post("/api/survey/dismiss",
+                               json={"session_token": "tok", "survey_key": "nps_day3"})
+        assert resp.json()["detail"] == {"dismissed": True}
+        dismiss.assert_called_once_with(42, "nps_day3")
+
+    def test_dismiss_401_without_a_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.post("/api/survey/dismiss",
+                               json={"session_token": "bad", "survey_key": "nps_day3"})
+        assert resp.status_code == 401
+
+    def test_snapshot_returns_the_due_survey(self, client):
+        snapshot = {"survey": {"key": "nps_day3", "source": "nps", "headline": "h", "body": "b",
+                               "cta_label": "Give a score"},
+                    "review_submitted": False, "nps_min": 0, "nps_max": 10,
+                    "review_min_rating": 1, "review_max_rating": 5}
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.survey_snapshot", return_value=snapshot) as snap:
+            resp = client.get("/api/user/survey?session_token=tok")
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["survey"]["key"] == "nps_day3"
+        snap.assert_called_once_with(42)
+
+    def test_snapshot_401_without_a_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.get("/api/user/survey?session_token=bad")
+        assert resp.status_code == 401

--- a/tests/unit/app/test_survey_prompts.py
+++ b/tests/unit/app/test_survey_prompts.py
@@ -1,0 +1,54 @@
+"""Unit tests for the daily survey beat task (issue #501)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_S = "cqc_lem.utilities.surveys"
+_DB = "cqc_lem.utilities.db"
+
+
+def _run(candidates, surveys, send_result=True):
+    with patch(f"{_DB}.get_survey_candidate_user_ids", return_value=candidates), \
+         patch(f"{_S}.next_survey_for_user", side_effect=surveys), \
+         patch(f"{_S}.send_survey_prompt", return_value=send_result) as send:
+        from cqc_lem.app.run_scheduler import auto_survey_prompts
+        result = auto_survey_prompts()
+    return result, send
+
+
+class TestAutoSurveyPrompts:
+    def test_emails_only_the_users_with_a_due_survey(self):
+        survey = {"key": "nps_day3"}
+        result, send = _run([1, 2, 3], [survey, None, survey])
+        assert send.call_count == 2
+        assert result == "Asked 2 of 3 subscriber(s)"
+
+    def test_counts_only_emails_that_actually_went_out(self):
+        result, _send = _run([1], [{"key": "nps_day3"}], send_result=False)
+        assert result == "Asked 0 of 1 subscriber(s)"
+
+    def test_no_candidates(self):
+        result, send = _run([], [])
+        assert result == "Asked 0 of 0 subscriber(s)"
+        send.assert_not_called()
+
+    def test_one_user_failing_does_not_stop_the_rest(self):
+        with patch(f"{_DB}.get_survey_candidate_user_ids", return_value=[1, 2]), \
+             patch(f"{_S}.next_survey_for_user",
+                   side_effect=[RuntimeError("db down"), {"key": "nps_day3"}]), \
+             patch(f"{_S}.send_survey_prompt", return_value=True) as send:
+            from cqc_lem.app.run_scheduler import auto_survey_prompts
+            result = auto_survey_prompts()
+        assert send.call_count == 1
+        assert result == "Asked 1 of 2 subscriber(s)"
+
+
+class TestBeatSchedule:
+    def test_task_is_registered_daily_after_the_onboarding_nudge(self):
+        from cqc_lem.app.my_celery import app
+        entry = app.conf.beat_schedule["survey-prompts"]
+        assert entry["task"] == "cqc_lem.app.run_scheduler.auto_survey_prompts"
+        assert entry["schedule"].hour == {9}
+        assert entry["schedule"].minute == {45}

--- a/tests/unit/utilities/test_db_surveys.py
+++ b/tests/unit/utilities/test_db_surveys.py
@@ -1,0 +1,126 @@
+"""Unit tests for the survey DB helpers (issue #501)."""
+
+from datetime import datetime
+
+import mysql.connector
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(rowcount=1, fetchone=None, fetchall=None):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.rowcount = rowcount
+    cur.fetchone.return_value = fetchone
+    cur.fetchall.return_value = fetchall or []
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+def _erroring_conn():
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.execute.side_effect = mysql.connector.Error("boom")
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestLatestFeedbackAt:
+    def test_returns_the_most_recent_answer_for_that_source(self):
+        when = datetime(2026, 7, 20, 9, 0)
+        conn, cur = _conn(fetchone=(when,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import FeedbackSource, get_latest_feedback_at
+            assert get_latest_feedback_at(4, FeedbackSource.NPS) == when
+        sql, params = cur.execute.call_args[0]
+        assert "MAX(created_at)" in sql
+        assert params == (4, "nps")
+
+    def test_none_when_never_answered_or_on_error(self):
+        conn, _cur = _conn(fetchone=(None,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import FeedbackSource, get_latest_feedback_at
+            assert get_latest_feedback_at(4, FeedbackSource.REVIEW) is None
+
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import FeedbackSource, get_latest_feedback_at
+            assert get_latest_feedback_at(4, FeedbackSource.REVIEW) is None
+
+
+class TestReviewGate:
+    def test_true_only_when_a_review_row_exists(self):
+        conn, cur = _conn(fetchone=(1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_review_feedback
+            assert has_review_feedback(4) is True
+        assert cur.execute.call_args[0][1] == (4, "review")
+
+        conn, _cur = _conn(fetchone=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_review_feedback
+            assert has_review_feedback(4) is False
+
+    def test_fails_closed_on_a_db_error(self):
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_review_feedback
+            assert has_review_feedback(4) is False
+
+
+class TestSurveyPromptLedger:
+    def test_reads_key_to_sent_at(self):
+        sent = datetime(2026, 7, 24, 9, 45)
+        conn, _cur = _conn(fetchall=[("nps_day3", sent)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_survey_prompts_sent
+            assert get_survey_prompts_sent(4) == {"nps_day3": sent}
+
+    def test_empty_dict_on_error(self):
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_survey_prompts_sent
+            assert get_survey_prompts_sent(4) == {}
+
+    def test_record_is_one_shot_and_truncates_the_key(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_survey_prompt
+            assert record_survey_prompt(4, "x" * 40) is True
+        sql, params = cur.execute.call_args[0]
+        assert "INSERT IGNORE INTO survey_prompts" in sql
+        assert params == (4, "x" * 32)
+        conn.commit.assert_called_once()
+
+        conn, _cur = _conn(rowcount=0)  # already asked
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_survey_prompt
+            assert record_survey_prompt(4, "nps_day3") is False
+
+    def test_record_survives_a_db_error(self):
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_survey_prompt
+            assert record_survey_prompt(4, "nps_day3") is False
+
+
+class TestSurveyCandidates:
+    def test_covers_paying_and_trialing_users_including_activated_ones(self):
+        conn, cur = _conn(fetchall=[(1,), (2,)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_survey_candidate_user_ids
+            assert get_survey_candidate_user_ids() == [1, 2]
+        sql = " ".join(cur.execute.call_args[0][0].split())
+        assert "subscription_status = 'active'" in sql
+        assert "trial_ends_at > NOW()" in sql
+        assert "activated_at" not in sql
+
+    def test_empty_on_error(self):
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_survey_candidate_user_ids
+            assert get_survey_candidate_user_ids() == []

--- a/tests/unit/utilities/test_surveys.py
+++ b/tests/unit/utilities/test_surveys.py
@@ -1,0 +1,245 @@
+"""Unit tests for the NPS/review survey policy and capture (issue #501)."""
+
+from datetime import datetime, timedelta
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_S = "cqc_lem.utilities.surveys"
+
+NOW = datetime(2026, 7, 25, 12, 0, 0)
+
+
+class TestBands:
+    @pytest.mark.parametrize("score,band", [(0, "detractor"), (6, "detractor"), (7, "passive"),
+                                            (8, "passive"), (9, "promoter"), (10, "promoter")])
+    def test_nps_bucket(self, score, band):
+        from cqc_lem.utilities.surveys import nps_bucket
+        assert nps_bucket(score) == band
+
+    @pytest.mark.parametrize("rating,sentiment", [(1, "negative"), (2, "negative"), (3, "neutral"),
+                                                  (4, "positive"), (5, "positive")])
+    def test_review_sentiment(self, rating, sentiment):
+        from cqc_lem.utilities.surveys import review_sentiment
+        assert review_sentiment(rating) == sentiment
+
+
+class TestSelectSurvey:
+    def test_day3_nps_after_activation(self):
+        from cqc_lem.utilities.surveys import SURVEY_NPS_DAY3, select_survey
+        survey = select_survey(activated_at=NOW - timedelta(days=3), now=NOW)
+        assert survey["key"] == SURVEY_NPS_DAY3
+        assert survey["source"] == "nps"
+        assert survey["cta_path"] == f"/?survey={SURVEY_NPS_DAY3}"
+
+    def test_nothing_before_day3(self):
+        from cqc_lem.utilities.surveys import select_survey
+        assert select_survey(activated_at=NOW - timedelta(days=2, hours=23), now=NOW) is None
+
+    def test_never_activated_and_no_trial_ending_is_not_asked(self):
+        from cqc_lem.utilities.surveys import select_survey
+        assert select_survey(trial_ends_at=NOW + timedelta(days=9), now=NOW) is None
+
+    def test_review_offer_outranks_nps_at_trial_end(self):
+        from cqc_lem.utilities.surveys import SURVEY_REVIEW_TRIAL_END, select_survey
+        survey = select_survey(activated_at=NOW - timedelta(days=10),
+                               trial_ends_at=NOW + timedelta(days=2), now=NOW)
+        assert survey["key"] == SURVEY_REVIEW_TRIAL_END
+        assert survey["source"] == "review"
+
+    def test_trial_end_nps_once_the_review_is_in(self):
+        from cqc_lem.utilities.surveys import SURVEY_NPS_TRIAL_END, select_survey
+        survey = select_survey(trial_ends_at=NOW + timedelta(days=1),
+                               review_answered_at=NOW - timedelta(days=1), now=NOW)
+        assert survey["key"] == SURVEY_NPS_TRIAL_END
+
+    def test_expired_trial_is_not_a_trial_ending(self):
+        from cqc_lem.utilities.surveys import select_survey
+        assert select_survey(trial_ends_at=NOW - timedelta(hours=1), now=NOW) is None
+
+    def test_answered_surveys_are_never_re_asked(self):
+        from cqc_lem.utilities.surveys import select_survey
+        assert select_survey(activated_at=NOW - timedelta(days=30),
+                             trial_ends_at=NOW + timedelta(days=1),
+                             nps_answered_at=NOW - timedelta(days=20),
+                             review_answered_at=NOW - timedelta(days=20), now=NOW) is None
+
+    def test_already_asked_surveys_are_skipped(self):
+        from cqc_lem.utilities.surveys import (SURVEY_NPS_DAY3, SURVEY_NPS_TRIAL_END,
+                                               SURVEY_REVIEW_TRIAL_END, select_survey)
+        survey = select_survey(activated_at=NOW - timedelta(days=5),
+                               trial_ends_at=NOW + timedelta(days=1),
+                               sent_keys={SURVEY_REVIEW_TRIAL_END}, now=NOW)
+        assert survey["key"] == SURVEY_NPS_DAY3
+        assert select_survey(activated_at=NOW - timedelta(days=5),
+                             trial_ends_at=NOW + timedelta(days=1),
+                             sent_keys={SURVEY_REVIEW_TRIAL_END, SURVEY_NPS_DAY3},
+                             now=NOW)["key"] == SURVEY_NPS_TRIAL_END
+        assert select_survey(activated_at=NOW - timedelta(days=5),
+                             trial_ends_at=NOW + timedelta(days=1),
+                             sent_keys={SURVEY_REVIEW_TRIAL_END, SURVEY_NPS_DAY3,
+                                        SURVEY_NPS_TRIAL_END}, now=NOW) is None
+
+    def test_cooldown_blocks_a_second_ask_the_same_day(self):
+        from cqc_lem.utilities.surveys import select_survey
+        assert select_survey(activated_at=NOW - timedelta(days=5),
+                             last_sent_at=NOW - timedelta(hours=3), now=NOW) is None
+        assert select_survey(activated_at=NOW - timedelta(days=5),
+                             last_sent_at=NOW - timedelta(hours=25), now=NOW) is not None
+
+    def test_defaults_to_wall_clock_now(self):
+        from cqc_lem.utilities.surveys import SURVEY_NPS_DAY3, select_survey
+        assert select_survey(activated_at=datetime.now() - timedelta(days=4))["key"] == \
+            SURVEY_NPS_DAY3
+
+
+class TestNextSurveyForUser:
+    def test_binds_state_answers_and_ledger(self):
+        from cqc_lem.utilities.surveys import SURVEY_NPS_DAY3
+        with patch(f"{_S}.get_onboarding_state",
+                   return_value={"activated_at": datetime.now() - timedelta(days=4)}), \
+             patch(f"{_S}.get_user_subscription_info", return_value={"trial_ends_at": None}), \
+             patch(f"{_S}.get_survey_prompts_sent", return_value={}), \
+             patch(f"{_S}.get_latest_feedback_at", return_value=None):
+            from cqc_lem.utilities.surveys import next_survey_for_user
+            assert next_survey_for_user(7)["key"] == SURVEY_NPS_DAY3
+
+    def test_missing_state_and_subscription_are_survivable(self):
+        with patch(f"{_S}.get_onboarding_state", return_value={}), \
+             patch(f"{_S}.get_user_subscription_info", return_value=None), \
+             patch(f"{_S}.get_survey_prompts_sent", return_value={}), \
+             patch(f"{_S}.get_latest_feedback_at", return_value=None):
+            from cqc_lem.utilities.surveys import next_survey_for_user
+            assert next_survey_for_user(7) is None
+
+    def test_snapshot_exposes_the_survey_and_the_review_gate(self):
+        from cqc_lem.utilities.surveys import SURVEY_REVIEW_TRIAL_END
+        survey = {"key": SURVEY_REVIEW_TRIAL_END, "source": "review", "headline": "h", "body": "b",
+                  "cta_label": "Write a review", "cta_path": "/?survey=review_trial_end"}
+        with patch(f"{_S}.next_survey_for_user", return_value=survey), \
+             patch(f"{_S}.has_review_feedback", return_value=False):
+            from cqc_lem.utilities.surveys import survey_snapshot
+            snap = survey_snapshot(7)
+        assert snap["survey"]["key"] == SURVEY_REVIEW_TRIAL_END
+        assert "cta_path" not in snap["survey"]  # the SPA opens the modal itself
+        assert snap["review_submitted"] is False
+        assert (snap["nps_min"], snap["nps_max"]) == (0, 10)
+
+    def test_snapshot_without_a_due_survey(self):
+        with patch(f"{_S}.next_survey_for_user", return_value=None), \
+             patch(f"{_S}.has_review_feedback", return_value=True):
+            from cqc_lem.utilities.surveys import survey_snapshot
+            snap = survey_snapshot(7)
+        assert snap["survey"] is None
+        assert snap["review_submitted"] is True
+
+
+class TestRecordNps:
+    def test_stores_the_why_as_the_body_with_the_score_in_context(self):
+        with patch(f"{_S}.insert_feedback", return_value=11) as insert, \
+             patch(f"{_S}.record_survey_prompt") as record, \
+             patch("cqc_lem.utilities.observability.track_survey_response") as track:
+            from cqc_lem.utilities.surveys import SURVEY_NPS_DAY3, record_nps_response
+            from cqc_lem.utilities.db import FeedbackSource
+            assert record_nps_response(7, 9, why="  It writes like me  ",
+                                       context={"route": "/"},
+                                       survey_key=SURVEY_NPS_DAY3) == 11
+        kwargs = insert.call_args.kwargs
+        assert insert.call_args.args[0] == "It writes like me"
+        assert kwargs["source"] == FeedbackSource.NPS
+        assert kwargs["sentiment"] == "promoter"
+        assert kwargs["context"] == {"route": "/", "score": 9, "survey_key": SURVEY_NPS_DAY3}
+        record.assert_called_once_with(7, SURVEY_NPS_DAY3)
+        assert track.call_args.kwargs["score"] == 9
+
+    def test_score_only_answer_still_persists(self):
+        with patch(f"{_S}.insert_feedback", return_value=12) as insert, \
+             patch(f"{_S}.record_survey_prompt"), \
+             patch("cqc_lem.utilities.observability.track_survey_response"):
+            from cqc_lem.utilities.surveys import record_nps_response
+            assert record_nps_response(7, 3) == 12
+        assert insert.call_args.args[0] == "NPS 3/10 — no comment"
+        assert insert.call_args.kwargs["sentiment"] == "detractor"
+
+    def test_unknown_survey_key_is_not_recorded_as_asked(self):
+        with patch(f"{_S}.insert_feedback", return_value=13), \
+             patch(f"{_S}.record_survey_prompt") as record, \
+             patch("cqc_lem.utilities.observability.track_survey_response"):
+            from cqc_lem.utilities.surveys import record_nps_response
+            record_nps_response(7, 10, survey_key="made-up")
+        record.assert_not_called()
+
+    def test_failed_insert_skips_the_ledger_and_analytics(self):
+        with patch(f"{_S}.insert_feedback", return_value=None), \
+             patch(f"{_S}.record_survey_prompt") as record, \
+             patch("cqc_lem.utilities.observability.track_survey_response") as track:
+            from cqc_lem.utilities.surveys import record_nps_response
+            assert record_nps_response(7, 10) is None
+        record.assert_not_called()
+        track.assert_not_called()
+
+    def test_tracking_failure_never_loses_the_response(self):
+        with patch(f"{_S}.insert_feedback", return_value=14), \
+             patch(f"{_S}.record_survey_prompt"), \
+             patch("cqc_lem.utilities.observability.track_survey_response",
+                   side_effect=RuntimeError("posthog down")):
+            from cqc_lem.utilities.surveys import record_nps_response
+            assert record_nps_response(7, 10) == 14
+
+
+class TestRecordReview:
+    def test_body_joins_the_testimonial_and_the_improvement(self):
+        with patch(f"{_S}.insert_feedback", return_value=21) as insert, \
+             patch(f"{_S}.record_survey_prompt") as record, \
+             patch("cqc_lem.utilities.observability.track_survey_response") as track:
+            from cqc_lem.utilities.surveys import SURVEY_REVIEW_TRIAL_END, record_review_response
+            from cqc_lem.utilities.db import FeedbackSource
+            assert record_review_response(7, 5, improvement="Faster carousels",
+                                          testimonial="Saves me an hour a day",
+                                          consent_testimonial=True,
+                                          survey_key=SURVEY_REVIEW_TRIAL_END) == 21
+        kwargs = insert.call_args.kwargs
+        assert insert.call_args.args[0] == "Saves me an hour a day\n\nFaster carousels"
+        assert kwargs["source"] == FeedbackSource.REVIEW
+        assert kwargs["sentiment"] == "positive"
+        assert kwargs["context"]["rating"] == 5
+        assert kwargs["context"]["consent_testimonial"] is True
+        assert kwargs["context"]["improvement"] == "Faster carousels"
+        record.assert_called_once_with(7, SURVEY_REVIEW_TRIAL_END)
+        assert track.call_args.kwargs["rating"] == 5
+
+    def test_rating_only_review_still_persists_and_defaults_consent_off(self):
+        with patch(f"{_S}.insert_feedback", return_value=22) as insert, \
+             patch(f"{_S}.record_survey_prompt"), \
+             patch("cqc_lem.utilities.observability.track_survey_response"):
+            from cqc_lem.utilities.surveys import record_review_response
+            assert record_review_response(7, 2) == 22
+        assert insert.call_args.args[0] == "Review 2/5 — no comment"
+        assert insert.call_args.kwargs["sentiment"] == "negative"
+        assert insert.call_args.kwargs["context"]["consent_testimonial"] is False
+        assert insert.call_args.kwargs["context"]["testimonial"] is None
+
+
+class TestDismissAndSend:
+    def test_dismiss_records_a_known_survey_only(self):
+        with patch(f"{_S}.record_survey_prompt", return_value=True) as record:
+            from cqc_lem.utilities.surveys import SURVEY_NPS_DAY3, dismiss_survey
+            assert dismiss_survey(7, SURVEY_NPS_DAY3) is True
+            assert dismiss_survey(7, "nope") is False
+        record.assert_called_once_with(7, SURVEY_NPS_DAY3)
+
+    def test_send_records_the_ask_only_when_the_email_went_out(self):
+        survey = {"key": "nps_day3"}
+        with patch("cqc_lem.utilities.notifications.notify_survey_prompt", return_value=True), \
+             patch(f"{_S}.record_survey_prompt") as record:
+            from cqc_lem.utilities.surveys import send_survey_prompt
+            assert send_survey_prompt(7, survey) is True
+        record.assert_called_once_with(7, "nps_day3")
+
+        with patch("cqc_lem.utilities.notifications.notify_survey_prompt", return_value=False), \
+             patch(f"{_S}.record_survey_prompt") as record:
+            from cqc_lem.utilities.surveys import send_survey_prompt
+            assert send_survey_prompt(7, survey) is False
+        record.assert_not_called()

--- a/tests/unit/utilities/test_surveys_notify.py
+++ b/tests/unit/utilities/test_surveys_notify.py
@@ -1,0 +1,101 @@
+"""Unit tests for survey invite delivery (issue #501): the email builder and the notify wrapper."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_SURVEY = {"key": "review_trial_end", "source": "review",
+           "subject": "Leave a review, unlock the extended trial",
+           "headline": "Write a review, keep LEM running longer",
+           "body": "Your trial ends in a few days.",
+           "cta_label": "Write a review", "cta_path": "/?survey=review_trial_end"}
+
+
+class TestSendSurveyPromptEmail:
+    def test_builds_an_absolute_cta_url_and_dispatches(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as dispatch, \
+             patch.dict("os.environ", {"LEM_APP_URL": "https://app.example.com/"}):
+            from cqc_lem.utilities.email import send_survey_prompt_email
+            assert send_survey_prompt_email(
+                "u@example.com", _SURVEY["subject"], _SURVEY["headline"], _SURVEY["body"],
+                _SURVEY["cta_label"], _SURVEY["cta_path"]) is True
+        to_email, subject, html = dispatch.call_args[0]
+        assert to_email == "u@example.com"
+        assert subject == _SURVEY["subject"]
+        assert "https://app.example.com/?survey=review_trial_end" in html
+        assert _SURVEY["body"] in html
+
+    def test_relative_path_without_a_leading_slash_still_works(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as dispatch, \
+             patch.dict("os.environ", {"LEM_APP_URL": "https://app.example.com"}):
+            from cqc_lem.utilities.email import send_survey_prompt_email
+            send_survey_prompt_email("u@example.com", "s", "h", "b", "Go", "account")
+        assert "https://app.example.com/account" in dispatch.call_args[0][2]
+
+    def test_escapes_caller_supplied_copy(self):
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as dispatch:
+            from cqc_lem.utilities.email import send_survey_prompt_email
+            send_survey_prompt_email("u@example.com", "s", "<script>x</script>",
+                                     "Line one\nAT&T & <b>bold</b>", "Go </a><script>", "/")
+        html = dispatch.call_args[0][2]
+        assert "<script>" not in html
+        assert "&lt;script&gt;x&lt;/script&gt;" in html
+        assert "Line one<br/>AT&amp;T &amp; &lt;b&gt;bold&lt;/b&gt;" in html
+
+
+class TestNotifySurveyPrompt:
+    def test_sends_and_tracks(self):
+        with patch("cqc_lem.utilities.notifications.get_user_email", return_value="u@example.com"), \
+             patch("cqc_lem.utilities.email.send_survey_prompt_email", return_value=True) as send, \
+             patch("cqc_lem.utilities.observability.track_survey_prompt") as track:
+            from cqc_lem.utilities.notifications import notify_survey_prompt
+            assert notify_survey_prompt(9, _SURVEY) is True
+        assert send.call_args.kwargs["subject"] == _SURVEY["subject"]
+        assert send.call_args.kwargs["cta_path"] == _SURVEY["cta_path"]
+        track.assert_called_once_with(9, "review_trial_end")
+
+    def test_no_email_address_means_no_send(self):
+        with patch("cqc_lem.utilities.notifications.get_user_email", return_value=None), \
+             patch("cqc_lem.utilities.email.send_survey_prompt_email") as send:
+            from cqc_lem.utilities.notifications import notify_survey_prompt
+            assert notify_survey_prompt(9, _SURVEY) is False
+        send.assert_not_called()
+
+    def test_unsent_email_is_not_tracked(self):
+        with patch("cqc_lem.utilities.notifications.get_user_email", return_value="u@example.com"), \
+             patch("cqc_lem.utilities.email.send_survey_prompt_email", return_value=False), \
+             patch("cqc_lem.utilities.observability.track_survey_prompt") as track:
+            from cqc_lem.utilities.notifications import notify_survey_prompt
+            assert notify_survey_prompt(9, _SURVEY) is False
+        track.assert_not_called()
+
+    def test_a_send_failure_is_never_fatal(self):
+        with patch("cqc_lem.utilities.notifications.get_user_email", return_value="u@example.com"), \
+             patch("cqc_lem.utilities.email.send_survey_prompt_email",
+                   side_effect=RuntimeError("smtp down")):
+            from cqc_lem.utilities.notifications import notify_survey_prompt
+            assert notify_survey_prompt(9, _SURVEY) is False
+
+    def test_falls_back_to_default_copy(self):
+        with patch("cqc_lem.utilities.notifications.get_user_email", return_value="u@example.com"), \
+             patch("cqc_lem.utilities.email.send_survey_prompt_email", return_value=True) as send, \
+             patch("cqc_lem.utilities.observability.track_survey_prompt"):
+            from cqc_lem.utilities.notifications import notify_survey_prompt
+            assert notify_survey_prompt(9, {"key": "nps_day3"}) is True
+        assert send.call_args.kwargs["subject"] == "How are we doing?"
+        assert send.call_args.kwargs["cta_path"] == "/"
+
+
+class TestTrackers:
+    def test_survey_events_carry_their_properties(self):
+        with patch("cqc_lem.utilities.observability.posthog") as ph:
+            from cqc_lem.utilities.observability import track_survey_prompt, track_survey_response
+            track_survey_prompt(9, "nps_day3")
+            track_survey_response(9, "nps", score=10)
+        prompt_kwargs = ph.capture.call_args_list[0].kwargs
+        assert prompt_kwargs["event"] == "survey_prompt"
+        assert prompt_kwargs["properties"]["survey"] == "nps_day3"
+        response_kwargs = ph.capture.call_args_list[1].kwargs
+        assert response_kwargs["event"] == "survey_response"
+        assert response_kwargs["properties"] == {"source": "nps", "score": 10}


### PR DESCRIPTION
## What & why

Adds the survey capture channels of the feedback→auto-work loop (launch plan A.2/B.1): an NPS/CSAT survey and a review form whose submission is the gate on the early-adopter extended trial.

Responses are stored as ordinary `feedback` rows — `source='nps'` / `source='review'` — so they feed the existing classifier + clustering + auto-FAQ pipeline with no parallel plumbing. The score/rating, the "what would make this a 10?" text and the testimonial-consent flag ride in `context_json`; the NPS band (promoter/passive/detractor) and CSAT sentiment land in `feedback.sentiment`.

### API
| Endpoint | Purpose |
|---|---|
| `POST /api/survey/nps` | 0–10 score + free-text why → `feedback` (source `nps`). Returns the band and, for promoters with no review on file, `review_invite: true`. |
| `POST /api/survey/review` | 1–5 rating + improvement + optional testimonial + consent → `feedback` (source `review`). Returns `trial_extension_unlocked: true`. |
| `POST /api/survey/dismiss` | Modal closed without answering — records the ask so it never returns. |
| `GET /api/user/survey` | The survey due right now (or none) + whether the review is already on file. |

### Triggering
`utilities/surveys.py` holds a PURE `select_survey` policy (unit-testable without DB/email/LLM, same posture as `onboarding.select_nudge`):
- **day-3 NPS** — 3 days after activation (`onboarding_state.activated_at`),
- **trial T-3d** — the review offer outranks the NPS ask there, because it's the ask that gives the user something back; NPS follows once the review is in.

A new `survey_prompts` ledger (timestamp migration `V20260725095737`) records only the **ask**, so each survey is one-shot per user across both channels — the in-app modal and the email — with one ask per `SURVEY_COOLDOWN_HOURS` (24h). New daily beat task `auto_survey_prompts` (09:45, right after the onboarding nudge) emails the due survey; the CTA deep-links to the in-app modal so both channels write the same row.

### Trial-extension gate (#499)
`db.has_review_feedback(user_id)` is the gate helper `POST /trial/extend` will call — it fails **closed**, so a DB error never hands out an extension. This PR deliberately does **not** add `/trial/extend` itself: that endpoint plus the 60-day length, cohort caps and Stripe coupon are issue #499, which is held for an owner product decision.

### SPA
`SurveyModal` (mounted in `Layout`, logged-in only, renders nothing unless the server says a survey is due): 0–10 scale + why, or 1–5 stars + "What would make this a 10?" + optional testimonial + a testimonial-consent checkbox. Promoters are handed the review form immediately after scoring.

PostHog gets `survey_prompt` and `survey_response` events next to the activation funnel.

## Testing
- `tests/unit/utilities/test_surveys.py` — policy (ordering, one-shot, cooldown, expired trial, already-answered), bands, capture/dismiss/send. `surveys.py` at **100%** statement coverage.
- `tests/unit/utilities/test_db_surveys.py` — the four DB helpers incl. the gate failing closed.
- `tests/unit/api/test_survey_api.py` — all four endpoints: happy paths, 401s, 422 range validation, 500s, oversized-context truncation.
- `tests/unit/app/test_survey_prompts.py` — beat task + beat-schedule registration.
- `tests/unit/utilities/test_surveys_notify.py` — email builder (absolute CTA URL, HTML escaping), notify wrapper, PostHog trackers.
- `tests/integration/test_survey_capture.py` — drives the real endpoints through the real `db.py` SQL into a stateful fake cursor: rows land with the right source/sentiment/context, the ask is recorded once, a dismissed survey never returns, and a review provably flips `has_review_feedback` from False to True.
- Full local unit suite: 4460 passed. `tsc -b` clean on the UI.

Closes #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)