### PR TITLE
feat(feedback): auto-changelog + notify reporters on shipped fixes (closes #502)

### DIFF
--- a/compose/local/database/migrations/V20260725104900__add_shipped_notices.sql
+++ b/compose/local/database/migrations/V20260725104900__add_shipped_notices.sql
@@ -1,0 +1,39 @@
+-- "You asked, we shipped" changelog + reporter notification (issue #502), the last stage of the
+-- feedback->auto-work loop: capture (#496) -> classify (#497) -> file (#498) -> SHIP + tell the
+-- people who asked, then re-measure satisfaction.
+--
+-- shipped_notices           one row per GitHub issue that a merged PR closed, carrying the
+--                           human-readable changelog line (the user-facing "what's new" feed).
+-- shipped_notice_recipients who was told, when, whether they've seen it in-app. The PK is what
+--                           makes "notified once" true across the email and the in-app channel.
+--
+-- The micro-CSAT that follows a notice ("did this fix it?") is asked through the existing
+-- `survey_prompts` ledger (key `fix_csat_<issue>`) and ANSWERED as an ordinary `feedback` row, so
+-- the answer re-enters the same classifier/clustering loop as any other report — hence the new
+-- 'csat' source value.
+CREATE TABLE IF NOT EXISTS shipped_notices (
+    id                  INT AUTO_INCREMENT PRIMARY KEY,
+    github_issue_number INT NOT NULL,
+    pr_number           INT NULL,
+    title               VARCHAR(255) NULL,
+    changelog_line      VARCHAR(512) NOT NULL,
+    shipped_at          DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_shipped_notice_issue (github_issue_number),
+    INDEX idx_shipped_notice_shipped_at (shipped_at)
+);
+
+CREATE TABLE IF NOT EXISTS shipped_notice_recipients (
+    notice_id   INT NOT NULL,
+    user_id     INT NOT NULL,
+    notified_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    seen_at     DATETIME NULL,
+    PRIMARY KEY (notice_id, user_id),
+    INDEX idx_shipped_recipient_user (user_id, seen_at),
+    FOREIGN KEY (notice_id) REFERENCES shipped_notices(id) ON DELETE CASCADE,
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Additive ENUM value only — existing rows keep their source.
+ALTER TABLE feedback
+    MODIFY COLUMN source ENUM('widget','bug','nps','review','passive','csat')
+    NOT NULL DEFAULT 'widget';

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -756,6 +756,15 @@ class SurveyDismissRequest(BaseModel):
     survey_key: str = Field(min_length=1, max_length=_LEN_FEEDBACK_TYPE_HINT)
 
 
+class ShippedNoticeAckRequest(BaseModel):
+    """Acknowledging a "you asked, we shipped" notice (issue #502). `resolved` is the micro-CSAT:
+    True/False answers "did this fix it?", None means the user just dismissed the notice."""
+    session_token: str
+    notice_id: int = Field(gt=0)
+    resolved: Optional[bool] = None
+    comment: Optional[str] = Field(default=None, max_length=_LEN_FEEDBACK_BODY)
+
+
 class FutureForwardValues(IntEnum):
     Zero = 0
     ONE = 1
@@ -875,6 +884,56 @@ def survey_endpoint(session_token: str) -> ResponseModel:
 
     from cqc_lem.utilities.surveys import survey_snapshot
     return ResponseModel(status_code=200, detail=survey_snapshot(user_id))
+
+
+@router.get("/user/shipped")
+def shipped_notices_endpoint(session_token: str) -> ResponseModel:
+    """The "you asked, we shipped" notices waiting for this user, plus the recent changelog (issue
+    #502). A notice only appears once the reporter has had the fix for FEEDBACK_FIX_CSAT_DELAY_HOURS
+    — that delay is what schedules the micro-CSAT it carries."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    from cqc_lem.utilities.db import get_recent_shipped_notices, get_unseen_shipped_notices
+    from cqc_lem.utilities.feedback.shipped import fix_csat_delay_hours
+    notices = get_unseen_shipped_notices(user_id, delay_hours=fix_csat_delay_hours())
+    return ResponseModel(status_code=200, detail={
+        "notices": [{"id": n.get("id"), "issue_number": n.get("github_issue_number"),
+                     "changelog_line": n.get("changelog_line"),
+                     "shipped_at": n.get("shipped_at")} for n in notices],
+        "changelog": [{"issue_number": n.get("github_issue_number"),
+                       "changelog_line": n.get("changelog_line"),
+                       "shipped_at": n.get("shipped_at")} for n in get_recent_shipped_notices()],
+    })
+
+
+@router.post("/shipped/ack")
+def ack_shipped_notice_endpoint(request: ShippedNoticeAckRequest) -> ResponseModel:
+    """Acknowledge a shipped-fix notice and, when the user answered "did this fix it?", record the
+    micro-CSAT (issue #502). A "not fixed" answer lands as a `feedback` row at status `new`, so it
+    re-enters the auto-work loop instead of stopping at a metric."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    from cqc_lem.utilities.db import get_unseen_shipped_notices, mark_shipped_notice_seen
+    from cqc_lem.utilities.surveys import record_fix_csat_response
+    # Ownership check: a notice is only ackable by a reporter it was actually addressed to.
+    notice = next((n for n in get_unseen_shipped_notices(user_id, limit=50)
+                   if n.get("id") == request.notice_id), None)
+    if not notice:
+        raise HTTPException(status_code=404, detail="Notice not found or already acknowledged")
+
+    mark_shipped_notice_seen(request.notice_id, user_id)
+    feedback_id = None
+    if request.resolved is not None:
+        feedback_id = record_fix_csat_response(
+            user_id, notice.get("github_issue_number"), bool(request.resolved),
+            comment=request.comment)
+        log_info("Fix CSAT captured", user_id=user_id)
+    return ResponseModel(status_code=200, detail={"acknowledged": True,
+                                                  "feedback_id": feedback_id})
 
 
 @router.get("/dashboard/stats/", responses={

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -918,9 +918,13 @@ def ack_shipped_notice_endpoint(request: ShippedNoticeAckRequest) -> ResponseMod
         raise HTTPException(status_code=401, detail="Invalid or expired session")
 
     from cqc_lem.utilities.db import get_unseen_shipped_notices, mark_shipped_notice_seen
+    from cqc_lem.utilities.feedback.shipped import fix_csat_delay_hours
     from cqc_lem.utilities.surveys import record_fix_csat_response
-    # Ownership check: a notice is only ackable by a reporter it was actually addressed to.
-    notice = next((n for n in get_unseen_shipped_notices(user_id, limit=50)
+    # Ownership check: a notice is only ackable by a reporter it was actually addressed to, and only
+    # once it is actually surfacable — same delay gate as GET /api/user/shipped, so an early ack
+    # can't burn a notice (and its micro-CSAT) before the user has been shown it.
+    notice = next((n for n in get_unseen_shipped_notices(
+                       user_id, delay_hours=fix_csat_delay_hours(), limit=50)
                    if n.get("id") == request.notice_id), None)
     if not notice:
         raise HTTPException(status_code=404, detail="Notice not found or already acknowledged")

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -230,6 +230,13 @@ app.conf.update(
             # the 2:00 stale-invite clean-up and the 3:00 stale-profile pass. Files nothing.
             'schedule': crontab(hour='2', minute='45')
         },
+        'changelog-notify': {
+            'task': 'cqc_lem.app.run_scheduler.auto_changelog_notify',
+            # Daily 10:00 AM — after the 9:45 survey pass, so a reporter never gets a survey invite
+            # and a "we shipped it" email in the same minute. The 48h lookback overlaps deliberately;
+            # each reporter is notified once via shipped_notice_recipients (issue #502).
+            'schedule': crontab(hour='10', minute='0')
+        },
         'daily-cost-alerts': {
             'task': 'cqc_lem.app.run_scheduler.auto_daily_cost_alerts',
             # Daily 13:00 UTC — scores YESTERDAY (the last complete UTC day), after the 6:00 Stripe

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1242,5 +1242,19 @@ def auto_recluster_feedback(self, limit: int = 200):
             f"{result['clusters']} open cluster(s), {result['embedded']} embedding(s) backfilled")
 
 
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True})
+def auto_changelog_notify(self, hours: int = None):
+    """Close the feedback loop on shipped work (issue #502, plan §B.4): scan recently merged PRs for
+    `Closes #<issue>`, generate the changelog line for each issue that came from user feedback, and
+    tell every reporter behind that cluster — once — by email + an in-app "you asked, we shipped"
+    notice carrying the micro-CSAT ("did this fix it?"). QueueOnce + the recipient ledger mean an
+    overlapping window can never notify the same reporter twice."""
+    from cqc_lem.utilities.feedback.shipped import process_shipped_fixes
+
+    result = process_shipped_fixes(hours=hours)
+    return (f"Shipped-fix notify: {result['pull_requests']} merged PR(s) — "
+            f"{result['counts'] or 'nothing to do'}")
+
+
 if __name__ == "__main__":
     print("Process finished")

--- a/src/cqc_lem/ui/src/components/Layout.tsx
+++ b/src/cqc_lem/ui/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../contexts/AuthContext'
 import AccountReadinessBanner from './AccountReadinessBanner'
 import FeedbackWidget from './FeedbackWidget'
 import Footer from './Footer'
+import ShippedNotice from './ShippedNotice'
 import SurveyModal from './SurveyModal'
 
 // Pages whose features depend on a fully set-up account — show the readiness banner here.
@@ -73,6 +74,9 @@ export default function Layout() {
       </nav>
       <main className="flex-1 w-full max-w-5xl mx-auto px-4 py-6">
         {showReadiness && <AccountReadinessBanner />}
+        {/* "You asked, we shipped" + its micro-CSAT — renders only when a fix this user
+            reported has shipped and they haven't acknowledged it yet (issue #502) */}
+        {user && <ShippedNotice />}
         <Outlet />
       </main>
       <Footer />

--- a/src/cqc_lem/ui/src/components/ShippedNotice.tsx
+++ b/src/cqc_lem/ui/src/components/ShippedNotice.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+import { useShippedNotices } from '../hooks/useShippedNotices'
+import api from '../api/client'
+
+// "You asked, we shipped" (issue #502) — the last stage of the feedback loop. Shows the oldest
+// un-acknowledged notice for a fix THIS user reported, and asks the micro-CSAT: did it fix it?
+// A "not yet" answer becomes a new feedback row, so it re-enters the same loop that built the fix.
+export default function ShippedNotice() {
+  const { sessionToken } = useAuth()
+  const { data, refetch } = useShippedNotices()
+
+  const [dismissed, setDismissed] = useState<number[]>([])
+  const [showComment, setShowComment] = useState(false)
+  const [comment, setComment] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [done, setDone] = useState<string | null>(null)
+
+  const notice = data?.notices?.find((n) => !dismissed.includes(n.id))
+  if (!notice) return null
+
+  async function ack(resolved: boolean | null, text?: string) {
+    setLoading(true)
+    try {
+      await api.post('/shipped/ack', {
+        session_token: sessionToken,
+        notice_id: notice!.id,
+        resolved,
+        comment: text?.trim() || null,
+      })
+      setDone(
+        resolved === false
+          ? "Thanks — that goes back to the team as a fresh report."
+          : resolved === true
+            ? 'Great — thanks for closing the loop.'
+            : null,
+      )
+      if (resolved === null) setDismissed((d) => [...d, notice!.id])
+      refetch()
+    } catch {
+      // Best-effort: the notice simply comes back on the next load.
+      setDismissed((d) => [...d, notice!.id])
+    } finally {
+      setLoading(false)
+      setShowComment(false)
+    }
+  }
+
+  // `**bold**` from the changelog line — rendered as plain text, no markdown parser needed.
+  const line = notice.changelog_line.replace(/\*\*/g, '')
+
+  return (
+    <div className="mb-4 border border-green-200 bg-green-50 rounded-lg p-3">
+      <div className="flex items-start gap-2">
+        <span aria-hidden="true">🎉</span>
+        <div className="flex-1">
+          <h2 className="text-sm font-bold text-gray-800">You asked, we shipped</h2>
+          <p className="text-xs text-gray-600 mt-0.5">{line}</p>
+
+          {done ? (
+            <p className="text-xs text-green-700 mt-2">{done}</p>
+          ) : showComment ? (
+            <div className="mt-2 space-y-2">
+              <textarea
+                rows={2}
+                maxLength={5000}
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                aria-label="What's still wrong?"
+                placeholder="What's still wrong?"
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              <button
+                type="button"
+                disabled={loading}
+                onClick={() => ack(false, comment)}
+                className="bg-blue-600 text-white px-3 py-1.5 rounded-lg text-xs font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+              >
+                {loading ? 'Sending…' : 'Send'}
+              </button>
+            </div>
+          ) : (
+            <div className="mt-2 flex items-center gap-2">
+              <span className="text-xs text-gray-500">Did this fix it?</span>
+              <button
+                type="button"
+                disabled={loading}
+                onClick={() => ack(true)}
+                className="border border-green-300 bg-white text-green-700 px-2.5 py-1 rounded-lg text-xs font-semibold hover:border-green-500 disabled:opacity-50 transition-colors"
+              >
+                Yes
+              </button>
+              <button
+                type="button"
+                disabled={loading}
+                onClick={() => setShowComment(true)}
+                className="border border-gray-300 bg-white text-gray-600 px-2.5 py-1 rounded-lg text-xs font-semibold hover:border-blue-400 disabled:opacity-50 transition-colors"
+              >
+                Not yet
+              </button>
+            </div>
+          )}
+        </div>
+        <button
+          onClick={() => ack(null)}
+          className="text-gray-400 hover:text-gray-600 text-lg leading-none"
+          aria-label="Dismiss shipped notice"
+        >
+          ×
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/hooks/useShippedNotices.ts
+++ b/src/cqc_lem/ui/src/hooks/useShippedNotices.ts
@@ -1,0 +1,31 @@
+import { useQuery } from '@tanstack/react-query'
+import api from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
+
+export interface ShippedNotice {
+  id: number
+  issue_number: number
+  changelog_line: string
+  shipped_at: string | null
+}
+
+export interface ShippedSnapshot {
+  notices: ShippedNotice[]
+  changelog: Omit<ShippedNotice, 'id'>[]
+}
+
+// "You asked, we shipped" notices for fixes this user reported (issue #502). The server only
+// returns a notice once the reporter has had the fix long enough to judge it, which is what
+// schedules the micro-CSAT the notice carries.
+export function useShippedNotices() {
+  const { sessionToken } = useAuth()
+  return useQuery({
+    queryKey: ['shipped-notices', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/shipped?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as ShippedSnapshot),
+    enabled: !!sessionToken,
+    staleTime: 5 * 60 * 1000,
+  })
+}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -6651,16 +6651,23 @@ def get_feedback_reporters_for_issue(github_issue_number: int) -> list:
 def mark_feedback_resolved_for_issue(github_issue_number: int) -> int:
     """Close the loop on a shipped cluster: every still-open report behind this issue becomes
     `resolved`. Dismissed rows are left alone (they were never part of the fix). Returns how many
-    rows moved."""
+    rows moved.
+
+    Uses the SAME self-join as `get_feedback_reporters_for_issue`, so a report attached to the seed
+    by `cluster_id` before the issue number propagated is resolved too — otherwise the users we
+    notify and the rows we close would drift apart."""
     if not github_issue_number:
         return 0
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         cursor.execute(
-            "UPDATE feedback SET status = %s "
-            "WHERE github_issue_number = %s AND status NOT IN (%s, %s)",
-            (str(FeedbackStatus.RESOLVED), int(github_issue_number),
+            "UPDATE feedback f "
+            "LEFT JOIN feedback s ON s.id = f.cluster_id "
+            "SET f.status = %s "
+            "WHERE (f.github_issue_number = %s OR s.github_issue_number = %s) "
+            "  AND f.status NOT IN (%s, %s)",
+            (str(FeedbackStatus.RESOLVED), int(github_issue_number), int(github_issue_number),
              str(FeedbackStatus.RESOLVED), str(FeedbackStatus.DISMISSED)))
         connection.commit()
         return cursor.rowcount or 0

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -187,6 +187,7 @@ class FeedbackSource(StrEnum):
     NPS = 'nps'          # an NPS survey response
     REVIEW = 'review'    # a public review (marketplace/G2/etc.)
     PASSIVE = 'passive'  # inferred from behavior, not typed by the user
+    CSAT = 'csat'        # a "did this fix it?" answer after a shipped fix (issue #502)
 
 
 class FeedbackStatus(StrEnum):
@@ -6613,6 +6614,209 @@ def get_survey_candidate_user_ids() -> list:
         return [row[0] for row in cursor.fetchall()]
     except mysql.connector.Error as err:
         log_error("Could not get survey candidate user ids", exc=err)
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+# --- Shipped-fix changelog + reporter notification (issue #502) ---------------------
+def get_feedback_reporters_for_issue(github_issue_number: int) -> list:
+    """Every identified user who reported the problem a GitHub issue was filed for — the
+    feedback→issue→cluster mapping the "you asked, we shipped" notice is addressed to.
+
+    Matches BOTH the rows stamped with the issue directly (the seed and every deduped report) and
+    any row that only carries the seed's `cluster_id`, so a report attached by the nightly recluster
+    pass before the issue number propagated is still counted. Anonymous rows have no one to tell."""
+    if not github_issue_number:
+        return []
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT DISTINCT f.user_id FROM feedback f "
+            "LEFT JOIN feedback s ON s.id = f.cluster_id "
+            "WHERE f.user_id IS NOT NULL "
+            "  AND (f.github_issue_number = %s OR s.github_issue_number = %s)",
+            (int(github_issue_number), int(github_issue_number)))
+        return [row[0] for row in cursor.fetchall()]
+    except mysql.connector.Error as err:
+        log_error(f"Could not get feedback reporters for issue {github_issue_number}", exc=err)
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def mark_feedback_resolved_for_issue(github_issue_number: int) -> int:
+    """Close the loop on a shipped cluster: every still-open report behind this issue becomes
+    `resolved`. Dismissed rows are left alone (they were never part of the fix). Returns how many
+    rows moved."""
+    if not github_issue_number:
+        return 0
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE feedback SET status = %s "
+            "WHERE github_issue_number = %s AND status NOT IN (%s, %s)",
+            (str(FeedbackStatus.RESOLVED), int(github_issue_number),
+             str(FeedbackStatus.RESOLVED), str(FeedbackStatus.DISMISSED)))
+        connection.commit()
+        return cursor.rowcount or 0
+    except mysql.connector.Error as err:
+        log_error(f"Could not resolve feedback for issue {github_issue_number}", exc=err)
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_shipped_notice_by_issue(github_issue_number: int) -> Optional[dict]:
+    """The changelog notice already recorded for this issue, or None."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT id, github_issue_number, pr_number, title, changelog_line, shipped_at "
+            "FROM shipped_notices WHERE github_issue_number = %s", (int(github_issue_number),))
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        log_error(f"Could not get shipped notice for issue {github_issue_number}", exc=err)
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_shipped_notice(github_issue_number: int, changelog_line: str, pr_number: int = None,
+                          title: str = None) -> Optional[int]:
+    """Record the changelog line for a shipped issue and return its notice id. One notice per issue
+    (the UNIQUE key), so a re-run of the notify pass re-uses the existing row instead of writing a
+    second changelog entry for the same fix."""
+    if not github_issue_number or not (changelog_line or "").strip():
+        return None
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT IGNORE INTO shipped_notices "
+            "(github_issue_number, pr_number, title, changelog_line) VALUES (%s,%s,%s,%s)",
+            (int(github_issue_number), int(pr_number) if pr_number else None,
+             str(title)[:255] if title else None, str(changelog_line)[:512]))
+        connection.commit()
+        if cursor.lastrowid:
+            return int(cursor.lastrowid)
+        cursor.execute("SELECT id FROM shipped_notices WHERE github_issue_number = %s",
+                       (int(github_issue_number),))
+        row = cursor.fetchone()
+        return int(row[0]) if row else None
+    except mysql.connector.Error as err:
+        log_error(f"Could not record shipped notice for issue {github_issue_number}", exc=err)
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_shipped_notice_recipient(notice_id: int, user_id: int) -> bool:
+    """Attach a reporter to a shipped notice. Returns True ONLY the first time — that is what makes
+    "notified once" true no matter how often the notify pass runs."""
+    if not notice_id or not user_id:
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT IGNORE INTO shipped_notice_recipients (notice_id, user_id) VALUES (%s,%s)",
+            (int(notice_id), int(user_id)))
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        log_error(f"Could not record shipped notice recipient for notice {notice_id}", exc=err,
+                  user_id=user_id)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_shipped_notice_recipient_ids(notice_id: int) -> list:
+    """Who has already been told about this shipped fix. Read BEFORE sending, so a re-run of the
+    notify pass never re-emails a reporter — the recipient PK only stops the duplicate ROW."""
+    if not notice_id:
+        return []
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT user_id FROM shipped_notice_recipients WHERE notice_id = %s",
+                       (int(notice_id),))
+        return [row[0] for row in cursor.fetchall()]
+    except mysql.connector.Error as err:
+        log_error(f"Could not get shipped notice recipients for notice {notice_id}", exc=err)
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_unseen_shipped_notices(user_id: int, delay_hours: int = 0, limit: int = 5) -> list:
+    """Shipped fixes this user asked for and hasn't acknowledged in-app yet, oldest first.
+
+    `delay_hours` is what SCHEDULES the micro-CSAT: a notice is only surfaced once the user has had
+    that long with the fix, so "did this fix it?" is asked after they could have used it rather than
+    in the same minute the email went out."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT n.id, n.github_issue_number, n.pr_number, n.title, n.changelog_line, "
+            "       n.shipped_at, r.notified_at "
+            "FROM shipped_notice_recipients r JOIN shipped_notices n ON n.id = r.notice_id "
+            "WHERE r.user_id = %s AND r.seen_at IS NULL "
+            "  AND r.notified_at <= (NOW() - INTERVAL %s HOUR) "
+            "ORDER BY r.notified_at ASC LIMIT %s",
+            (int(user_id), max(0, int(delay_hours)), int(limit)))
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        log_error("Could not get unseen shipped notices", exc=err, user_id=user_id)
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def mark_shipped_notice_seen(notice_id: int, user_id: int) -> bool:
+    """The user answered or dismissed the notice — stop surfacing it. Idempotent: only the first
+    acknowledgement writes a timestamp."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE shipped_notice_recipients SET seen_at = NOW() "
+            "WHERE notice_id = %s AND user_id = %s AND seen_at IS NULL",
+            (int(notice_id), int(user_id)))
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        log_error(f"Could not mark shipped notice {notice_id} seen", exc=err, user_id=user_id)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_recent_shipped_notices(limit: int = 10) -> list:
+    """The user-facing changelog: what shipped, newest first."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT id, github_issue_number, pr_number, title, changelog_line, shipped_at "
+            "FROM shipped_notices ORDER BY shipped_at DESC, id DESC LIMIT %s", (int(limit),))
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        log_error("Could not get recent shipped notices", exc=err)
         return []
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -414,6 +414,32 @@ def send_survey_prompt_email(to_email: str, subject: str, headline: str, body: s
     return _dispatch_email(to_email, subject, html)
 
 
+def send_shipped_fix_email(to_email: str, changelog_line: str, issue_number: int,
+                           cta_path: str = "/") -> bool:
+    """Tell a reporter the thing they asked for shipped (issue #502). The CTA opens the app, where
+    the in-app notice asks the micro-CSAT ("did this fix it?") that re-enters the feedback loop."""
+    import os
+    base = (os.getenv("LEM_APP_URL") or "https://lem.christopherqueenconsulting.com").rstrip("/")
+    url = f"{base}{cta_path if cta_path.startswith('/') else '/' + cta_path}"
+    # changelog_line is derived from a PR title — escape before templating so it can't inject markup.
+    safe_line = html_escape(changelog_line or "").replace("**", "")
+    safe_url = html_escape(url)
+    html = f"""
+    <html><body style="font-family:Arial,Helvetica,sans-serif;color:#222;">
+    <h2>You asked, we shipped 🎉</h2>
+    <p>You reported this, and it's now live in LinkedIn Engagement Manager:</p>
+    <p style="border-left:3px solid #0a66c2;padding-left:12px;color:#333;">{safe_line}</p>
+    <p>Give it a try — then tell us whether it actually fixed things for you. One tap, and it goes
+    straight back to the team.</p>
+    <p><a href="{safe_url}" style="background:#0a66c2;color:#fff;padding:10px 16px;border-radius:6px;
+    text-decoration:none;">See what changed</a></p>
+    <p style="color:#888;font-size:12px;">You're getting this because you sent us feedback about
+    it — we only send one of these per fix.</p>
+    </body></html>
+    """
+    return _dispatch_email(to_email, f"✅ You asked, we shipped (#{int(issue_number)})", html)
+
+
 def send_pin_email(
     to_email: str,
     pin: str,

--- a/src/cqc_lem/utilities/feedback/issue_service.py
+++ b/src/cqc_lem/utilities/feedback/issue_service.py
@@ -487,9 +487,11 @@ def build_duplicate_comment(classification: FeedbackClassification,
 
 # --- GitHub I/O ---------------------------------------------------------------------------------
 
-def _github_request(method: str, path: str, payload: dict = None) -> Optional[dict]:
-    """One GitHub REST call. Returns the parsed body, or None when unconfigured/failed — filing is
-    best-effort by design: a GitHub outage must never lose the feedback row."""
+def github_request(method: str, path: str, payload: dict = None) -> Optional[object]:
+    """One GitHub REST call, shared with the shipped-fix notifier (issue #502). Returns the parsed
+    body (a dict, or a list for collection endpoints), or None when unconfigured/failed — filing is
+    best-effort by design: a GitHub outage must never lose the feedback row. `path` may carry its
+    own query string."""
     token = github_token()
     if not token:
         log_warning("Feedback issue filing skipped — no FEEDBACK_GITHUB_TOKEN/GITHUB_TOKEN set",
@@ -523,8 +525,8 @@ def create_github_issue(title: str, body: str, labels: list,
     payload = {"title": title, "body": body, "labels": list(labels or [])}
     if assignees:
         payload["assignees"] = list(assignees)
-    data = _github_request("POST", "issues", payload)
-    number = (data or {}).get("number")
+    data = github_request("POST", "issues", payload)
+    number = data.get("number") if isinstance(data, dict) else None
     if number is None:
         return None
     log_info(f"Auto-filed feedback issue #{number}: {title}", api_provider="github")
@@ -535,7 +537,7 @@ def comment_on_issue(issue_number: int, body: str) -> bool:
     """Comment on an existing issue; True when GitHub accepted it."""
     if not issue_number:
         return False
-    return _github_request("POST", f"issues/{int(issue_number)}/comments",
+    return github_request("POST", f"issues/{int(issue_number)}/comments",
                            {"body": body}) is not None
 
 

--- a/src/cqc_lem/utilities/feedback/shipped.py
+++ b/src/cqc_lem/utilities/feedback/shipped.py
@@ -1,0 +1,251 @@
+"""Tell the people who asked that their fix shipped — issue #502, the LAST stage of the
+feedback->auto-work loop (docs/launch-and-marketing-plan.md §B.4).
+
+    capture (#496) ─► classify (#497) ─► file (#498) ─► ship ─► THIS ─► micro-CSAT ─► back to #496
+
+A merged PR that says `Closes #<issue>` is the only signal that something the pipeline built for a
+feedback cluster actually landed. This stage turns that into:
+
+    merged PR ──► closing issue #N ──► the cluster's reporters
+                     │                     ├─ one changelog line ("**Fixed:** … (#N)")
+                     │                     ├─ one email + one in-app notice, ONCE per reporter
+                     │                     └─ a scheduled micro-CSAT: "did this fix it?"
+                     └─ the cluster's feedback rows move to `resolved`
+
+The micro-CSAT answer is written back as an ordinary `feedback` row (source `csat`), so a "no, still
+broken" re-enters the very loop that produced the fix instead of dying in an analytics dashboard.
+
+Notify-once is a DB fact, not a timer: `shipped_notice_recipients` has (notice_id, user_id) as its
+primary key, so re-running this pass over the same merged PR adds nothing. Everything here is
+best-effort — a GitHub outage or a bounced email must never lose the notice, it just retries next
+pass (the recipient row is written only when the email actually went out).
+
+Privacy: nothing about a reporter ever reaches GitHub — this stage only READS merged PRs.
+
+Env:
+  FEEDBACK_GITHUB_TOKEN / GITHUB_TOKEN — token used to read merged PRs; no token == nothing runs
+  FEEDBACK_GITHUB_REPO                 — owner/name (default is this repo)
+  FEEDBACK_SHIPPED_LOOKBACK_HOURS      — how far back merged PRs are scanned (default 48)
+  FEEDBACK_FIX_CSAT_DELAY_HOURS        — how long after the notice the in-app CSAT is asked
+                                         (default 24; 0 = ask immediately)
+"""
+
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from cqc_lem.utilities.db import (
+    get_feedback_reporters_for_issue, get_shipped_notice_by_issue,
+    get_shipped_notice_recipient_ids, mark_feedback_resolved_for_issue, record_shipped_notice,
+    record_shipped_notice_recipient,
+)
+from cqc_lem.utilities.feedback.issue_service import github_request, github_token
+from cqc_lem.utilities.logger import log_debug, log_error, log_info, log_warning
+
+LOOKBACK_HOURS_DEFAULT = 48
+FIX_CSAT_DELAY_HOURS_DEFAULT = 24
+MAX_PRS_PER_PASS = 50
+MAX_CHANGELOG_CHARS = 512
+
+# GitHub's own closing keywords (https://docs.github.com/issues/tracking-your-work-with-issues/
+# using-keywords-in-issues-and-pull-requests) — the ONLY thing that counts as "this PR shipped that
+# issue". A bare `#123` reference is deliberately NOT matched: mentioning an issue isn't fixing it.
+_CLOSES_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b[\s:]+#(\d+)", re.IGNORECASE)
+
+# `feat(scope): summary (closes #12)` -> `summary`. Both halves are stripped so the changelog line
+# reads like a product note instead of a commit subject.
+_COMMIT_PREFIX_RE = re.compile(r"^\s*(\w+)(?:\([^)]*\))?!?:\s*")
+_TRAILING_REF_RE = re.compile(
+    r"\s*[(\[]?\s*(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s*:?\s*#\d+\s*[)\]]?\s*$",
+    re.IGNORECASE)
+
+# What each conventional-commit type means to a USER — the changelog line's lead-in.
+_CHANGE_LABELS: dict = {
+    'fix': 'Fixed', 'feat': 'New', 'perf': 'Faster', 'refactor': 'Improved',
+    'docs': 'Documented', 'style': 'Improved', 'chore': 'Improved', 'test': 'Improved',
+    'build': 'Improved', 'ci': 'Improved', 'revert': 'Reverted',
+}
+DEFAULT_CHANGE_LABEL = 'Improved'
+
+
+class ShipAction:
+    """What `notify_shipped_issue` did — the contract callers/tests assert on."""
+    NOTIFIED = 'notified'        # at least one reporter was told about this fix
+    NO_REPORTERS = 'no_reporters'  # the issue has no feedback cluster behind it — nothing to say
+    ALREADY_SENT = 'already_sent'  # every reporter had already been notified
+    ERROR = 'error'              # the changelog line could not be recorded; retried next pass
+
+
+def lookback_hours() -> int:
+    raw = (os.environ.get("FEEDBACK_SHIPPED_LOOKBACK_HOURS") or "").strip()
+    try:
+        return max(1, min(720, int(float(raw)))) if raw else LOOKBACK_HOURS_DEFAULT
+    except ValueError:
+        return LOOKBACK_HOURS_DEFAULT
+
+
+def fix_csat_delay_hours() -> int:
+    """How long a reporter keeps the fix before the in-app "did this fix it?" appears. This is the
+    'schedule' half of the micro-CSAT — asking in the same minute as the email measures nothing."""
+    raw = (os.environ.get("FEEDBACK_FIX_CSAT_DELAY_HOURS") or "").strip()
+    try:
+        return max(0, min(720, int(float(raw)))) if raw else FIX_CSAT_DELAY_HOURS_DEFAULT
+    except ValueError:
+        return FIX_CSAT_DELAY_HOURS_DEFAULT
+
+
+# --- Parsing / changelog copy (pure) -------------------------------------------------------------
+
+def closing_issue_numbers(*texts: Optional[str]) -> list:
+    """Every issue number a merged PR's title/body says it CLOSES, de-duplicated in first-seen
+    order. Only GitHub's closing keywords count, so "related to #12" never claims a fix shipped."""
+    found: list = []
+    for text in texts:
+        for match in _CLOSES_RE.finditer(text or ""):
+            number = int(match.group(1))
+            if number not in found:
+                found.append(number)
+    return found
+
+
+def humanize_title(pr_title: Optional[str]) -> tuple:
+    """(change_label, plain summary) from a conventional-commit PR title. `feat(dms): add X
+    (closes #9)` -> ('New', 'Add X'). An unprefixed title keeps its own words."""
+    title = (pr_title or "").strip()
+    label = DEFAULT_CHANGE_LABEL
+    prefix = _COMMIT_PREFIX_RE.match(title)
+    if prefix:
+        label = _CHANGE_LABELS.get(prefix.group(1).lower(), DEFAULT_CHANGE_LABEL)
+        title = title[prefix.end():]
+    title = _TRAILING_REF_RE.sub("", title).strip()
+    if title:
+        title = title[0].upper() + title[1:]
+    return label, title
+
+
+def build_changelog_line(pr_title: Optional[str], issue_number: int,
+                         pr_number: Optional[int] = None) -> str:
+    """The human-readable changelog entry for a shipped fix — what the reporter reads in the email
+    and the in-app notice, and what the "what's new" feed lists."""
+    label, summary = humanize_title(pr_title)
+    summary = summary or "A fix you reported"
+    refs = f"#{int(issue_number)}" + (f", PR #{int(pr_number)}" if pr_number else "")
+    return f"**{label}:** {summary} ({refs})"[:MAX_CHANGELOG_CHARS]
+
+
+# --- GitHub reads --------------------------------------------------------------------------------
+
+def _parse_github_time(value: Optional[str]) -> Optional[datetime]:
+    """GitHub's ISO-8601 `...Z` timestamp as an aware UTC datetime, or None when unparseable."""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def merged_pull_requests(hours: int = None, limit: int = MAX_PRS_PER_PASS) -> list:
+    """PRs merged into the default branch within the lookback window, newest first. Returns [] when
+    there is no token or GitHub is unreachable — this stage is best-effort."""
+    if not github_token():
+        log_warning("Shipped-fix notify skipped — no FEEDBACK_GITHUB_TOKEN/GITHUB_TOKEN set",
+                    api_provider="github")
+        return []
+    window = timedelta(hours=lookback_hours() if hours is None else max(1, int(hours)))
+    cutoff = datetime.now(timezone.utc) - window
+    data = github_request(
+        "GET", f"pulls?state=closed&sort=updated&direction=desc&per_page={int(limit)}")
+    if not isinstance(data, list):
+        return []
+    merged = []
+    for pr in data:
+        if not isinstance(pr, dict):
+            continue
+        merged_at = _parse_github_time(pr.get("merged_at"))
+        if merged_at and merged_at >= cutoff:
+            merged.append(pr)
+    return merged
+
+
+# --- Notification --------------------------------------------------------------------------------
+
+def _result(action: str, issue_number: Optional[int], **extra) -> dict:
+    return {"action": action, "issue_number": issue_number, **extra}
+
+
+def notify_shipped_issue(issue_number: int, pr_title: str = None,
+                         pr_number: int = None) -> dict:
+    """Take ONE shipped issue to its reporters: record the changelog line, email + queue the in-app
+    "you asked, we shipped" notice for every reporter who hasn't had one, and mark the cluster
+    resolved. Never raises; safe to re-run (each reporter is notified at most once)."""
+    reporters = get_feedback_reporters_for_issue(issue_number)
+    if not reporters:
+        log_debug(f"Issue #{issue_number} shipped but has no feedback reporters — no notice sent")
+        return _result(ShipAction.NO_REPORTERS, issue_number)
+
+    existing = get_shipped_notice_by_issue(issue_number)
+    line = (existing or {}).get("changelog_line") or build_changelog_line(
+        pr_title, issue_number, pr_number)
+    notice_id = (existing or {}).get("id") or record_shipped_notice(
+        issue_number, line, pr_number=pr_number, title=(pr_title or "").strip()[:255] or None)
+    if not notice_id:
+        return _result(ShipAction.ERROR, issue_number, reason="could not record changelog line")
+
+    from cqc_lem.utilities.notifications import notify_shipped_fix
+    # Read the ledger BEFORE sending: the recipient PK stops a duplicate ROW, but only this check
+    # stops a duplicate EMAIL when an overlapping window re-scans the same merged PR.
+    already = set(get_shipped_notice_recipient_ids(notice_id))
+    pending = [user_id for user_id in reporters if user_id not in already]
+    notified = 0
+    for user_id in pending:
+        try:
+            if not notify_shipped_fix(user_id, line, issue_number):
+                continue
+            # Written only AFTER the email went out, so a mail outage retries next pass instead of
+            # silently marking the reporter as told.
+            if record_shipped_notice_recipient(notice_id, user_id):
+                notified += 1
+        except Exception as e:
+            log_warning("Could not notify reporter of shipped fix", exc=e, user_id=user_id)
+
+    resolved = mark_feedback_resolved_for_issue(issue_number)
+    if not pending:
+        return _result(ShipAction.ALREADY_SENT, issue_number, notice_id=notice_id,
+                       reporters=len(reporters), resolved=resolved)
+    if not notified:
+        # Reporters were owed a notice and NONE could be delivered — a mail outage, not a no-op.
+        # Left un-ledgered on purpose so the next pass retries them.
+        return _result(ShipAction.ERROR, issue_number, notice_id=notice_id,
+                       reason="no notice could be delivered", reporters=len(reporters),
+                       resolved=resolved)
+    log_info(f"Shipped fix for issue #{issue_number} — told {notified} of {len(reporters)} "
+             f"reporter(s): {line}")
+    return _result(ShipAction.NOTIFIED, issue_number, notice_id=notice_id, notified=notified,
+                   reporters=len(reporters), resolved=resolved, changelog_line=line)
+
+
+def process_shipped_fixes(hours: int = None, limit: int = MAX_PRS_PER_PASS) -> dict:
+    """Scan recently merged PRs and close the loop on every feedback cluster they shipped (plan
+    §B.4). Idempotent: reporters already told are skipped, so this can run daily over an overlapping
+    window without re-emailing anyone."""
+    prs = merged_pull_requests(hours=hours, limit=limit)
+    counts: dict = {}
+    lines: list = []
+    for pr in prs:
+        issues = closing_issue_numbers(pr.get("title"), pr.get("body"))
+        for issue_number in issues:
+            try:
+                result = notify_shipped_issue(issue_number, pr_title=pr.get("title"),
+                                              pr_number=pr.get("number"))
+            except Exception as e:
+                log_error(f"Shipped-fix notify failed for issue #{issue_number}", exc=e)
+                counts[ShipAction.ERROR] = counts.get(ShipAction.ERROR, 0) + 1
+                continue
+            counts[result["action"]] = counts.get(result["action"], 0) + 1
+            if result.get("changelog_line"):
+                lines.append(result["changelog_line"])
+    log_info(f"Shipped-fix notify pass: {len(prs)} merged PR(s) — {counts or 'nothing to do'}")
+    return {"pull_requests": len(prs), "counts": counts, "changelog": lines}

--- a/src/cqc_lem/utilities/notifications.py
+++ b/src/cqc_lem/utilities/notifications.py
@@ -104,6 +104,28 @@ def notify_survey_prompt(user_id: int, survey: dict) -> bool:
         return False
 
 
+def notify_shipped_fix(user_id: int, changelog_line: str, issue_number: int) -> bool:
+    """Email a reporter that their fix shipped (issue #502). "Notified once" is the caller's job —
+    the shipped_notice_recipients PK — so this stays a pure send. Returns True only if an email
+    actually went out; a False keeps the reporter in the queue for the next pass."""
+    try:
+        email = get_user_email(user_id)
+        if not email:
+            return False
+        from cqc_lem.utilities.email import send_shipped_fix_email
+        sent = send_shipped_fix_email(email, changelog_line, issue_number)
+        if sent:
+            from cqc_lem.utilities.observability import track_shipped_notice
+            track_shipped_notice(user_id, int(issue_number))
+            log_info(f"Sent shipped-fix notice for issue #{issue_number}", user_id=user_id,
+                     action_type="shipped_notice")
+        return sent
+    except Exception as e:
+        log_warning("Could not send shipped-fix notice", exc=e, user_id=user_id,
+                    action_type="shipped_notice")
+        return False
+
+
 def notify_newsletter_draft_ready(user_id: int, edition_title: str, scheduled_for) -> bool:
     """Email the user that their newsletter draft is ready to review and when it auto-publishes.
     Non-fatal — returns True only if an email was actually sent."""

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -379,6 +379,16 @@ def track_survey_prompt(user_id: int, survey_key: str, **extra) -> None:
     )
 
 
+def track_shipped_notice(user_id: int, issue_number: int, **extra) -> None:
+    """Emit the "you asked, we shipped" notice we sent (issue #502), so notice → micro-CSAT response
+    is measurable against the GA satisfaction gate."""
+    posthog.capture(
+        distinct_id=str(user_id),
+        event="shipped_notice",
+        properties={"issue_number": issue_number, **extra},
+    )
+
+
 def track_survey_response(user_id: int, source: str, **extra) -> None:
     """Emit an NPS/review answer (issue #501) with its score/rating, so NPS and CSAT can be trended
     in PostHog next to the activation funnel."""

--- a/src/cqc_lem/utilities/surveys.py
+++ b/src/cqc_lem/utilities/surveys.py
@@ -10,14 +10,19 @@ so the "who gets asked what, when" policy is unit-testable without a DB, an emai
 posture as `onboarding.select_nudge`.
 
 A review row is also the gate on the extended trial (issue #499): `db.has_review_feedback`.
+
+Issue #502 adds a fourth, per-issue survey: the micro-CSAT asked after a fix the user reported
+ships ("did this fix it?"). Its key is BUILT (`fix_csat_<issue>`) rather than listed in `_SURVEYS`,
+and it is scheduled by the shipped-notice queue rather than by `select_survey`.
 """
 
 from datetime import datetime, timedelta
 from typing import Optional
 
 from cqc_lem.utilities.db import (
-    FeedbackSource, get_latest_feedback_at, get_onboarding_state, get_survey_prompts_sent,
-    get_user_subscription_info, has_review_feedback, insert_feedback, record_survey_prompt,
+    FeedbackSource, FeedbackStatus, get_latest_feedback_at, get_onboarding_state,
+    get_survey_prompts_sent, get_user_subscription_info, has_review_feedback, insert_feedback,
+    record_survey_prompt, update_feedback_triage,
 )
 from cqc_lem.utilities.logger import log_warning
 
@@ -25,6 +30,10 @@ from cqc_lem.utilities.logger import log_warning
 SURVEY_NPS_DAY3 = "nps_day3"
 SURVEY_NPS_TRIAL_END = "nps_trial_end"
 SURVEY_REVIEW_TRIAL_END = "review_trial_end"
+
+# The micro-CSAT that follows a shipped fix (issue #502) is per-ISSUE, so its key is built rather
+# than listed: `fix_csat_<issue>` (well inside survey_prompts.survey_key's VARCHAR(32)).
+FIX_CSAT_PREFIX = "fix_csat_"
 
 # Ask for NPS this long after the user activated — early enough that the "aha" is fresh, late enough
 # that they've seen automation run for a few days.
@@ -194,9 +203,52 @@ def record_review_response(user_id: Optional[int], rating: int, improvement: Opt
     return feedback_id
 
 
+def fix_csat_key(issue_number: int) -> str:
+    """The survey_prompts key for the "did this fix it?" ask on one shipped issue (issue #502)."""
+    return f"{FIX_CSAT_PREFIX}{int(issue_number)}"
+
+
+def is_fix_csat_key(survey_key: Optional[str]) -> bool:
+    """True for a per-issue micro-CSAT key. These are generated, not listed in `_SURVEYS`, so every
+    key check has to accept them too."""
+    key = (survey_key or "")
+    return key.startswith(FIX_CSAT_PREFIX) and key[len(FIX_CSAT_PREFIX):].isdigit()
+
+
+def _known_key(survey_key: Optional[str]) -> bool:
+    return survey_key in _SURVEYS or is_fix_csat_key(survey_key)
+
+
+def record_fix_csat_response(user_id: Optional[int], issue_number: int, resolved: bool,
+                             comment: Optional[str] = None,
+                             context: Optional[dict] = None) -> Optional[int]:
+    """Persist a "did this fix it?" answer (issue #502) as a `feedback` row (source='csat').
+
+    A "no, still broken" is left at status `new` ON PURPOSE: it re-enters the auto-work loop like any
+    other report, so the cluster gets re-opened rather than the dissatisfaction being buried in an
+    analytics event. A "yes" is stamped `resolved` immediately — there is nothing to classify, and
+    it must not burn an LLM call on every happy answer."""
+    key = fix_csat_key(issue_number)
+    text = (comment or "").strip()
+    body = text or (f"Confirmed fixed (issue #{int(issue_number)})" if resolved
+                    else f"Still not fixed (issue #{int(issue_number)})")
+    payload = {**(context or {}), "issue_number": int(issue_number), "resolved": bool(resolved),
+               "survey_key": key}
+    feedback_id = insert_feedback(body, user_id=user_id, source=FeedbackSource.CSAT,
+                                  type_hint="fix_csat", context=payload,
+                                  sentiment="positive" if resolved else "negative")
+    if feedback_id and resolved:
+        update_feedback_triage(feedback_id, status=FeedbackStatus.RESOLVED)
+    if feedback_id and user_id:
+        _record_answer(user_id, key)
+        _track_response(user_id, str(FeedbackSource.CSAT), issue_number=int(issue_number),
+                        resolved=bool(resolved))
+    return feedback_id
+
+
 def _record_answer(user_id: int, survey_key: Optional[str]) -> None:
     """Close the loop on the ask that produced this answer so nothing re-asks it."""
-    if survey_key in _SURVEYS:
+    if _known_key(survey_key):
         record_survey_prompt(user_id, survey_key)
 
 
@@ -211,7 +263,7 @@ def _track_response(user_id: int, source: str, **properties) -> None:
 
 def dismiss_survey(user_id: int, survey_key: str) -> bool:
     """User closed the modal without answering — record the ask so it isn't shown or emailed again."""
-    if survey_key not in _SURVEYS:
+    if not _known_key(survey_key):
         return False
     return record_survey_prompt(user_id, survey_key)
 

--- a/tests/integration/test_shipped_notify.py
+++ b/tests/integration/test_shipped_notify.py
@@ -55,11 +55,14 @@ class _FakeCursor:
                     if row["user_id"] not in users:
                         users.append(row["user_id"])
             self._result = [(u,) for u in users]
-        elif s.startswith("UPDATE feedback SET status = %s WHERE github_issue_number"):
+        elif s.startswith("UPDATE feedback f LEFT JOIN feedback s ON s.id = f.cluster_id"):
             status, issue = params[0], params[1]
+            seeds = {r["id"] for r in self.store["feedback"]
+                     if r.get("github_issue_number") == issue}
             for row in self.store["feedback"]:
-                if (row.get("github_issue_number") == issue
-                        and row["status"] not in ("resolved", "dismissed")):
+                if row["status"] in ("resolved", "dismissed"):
+                    continue
+                if row.get("github_issue_number") == issue or row.get("cluster_id") in seeds:
                     row["status"] = status
                     self.rowcount += 1
         elif s.startswith("UPDATE feedback SET status=%s WHERE id=%s"):
@@ -160,7 +163,8 @@ def client():
 
 @pytest.fixture
 def store():
-    """Two reporters (4 and 7) behind cluster/issue #498, plus one anonymous report and one
+    """Two reporters (4 and 7) behind cluster/issue #498, plus one anonymous report, one report
+    attached to the seed by `cluster_id` only (the issue number never propagated to it), and one
     unrelated report that must never be notified."""
     return {
         "feedback": [
@@ -172,6 +176,8 @@ def store():
              "cluster_id": 1, "github_issue_number": 498, "source": "widget"},
             {"id": 4, "user_id": 9, "body": "unrelated carousel bug", "status": "issue_created",
              "cluster_id": 4, "github_issue_number": 601, "source": "widget"},
+            {"id": 5, "user_id": 4, "body": "comment button does nothing", "status": "clustered",
+             "cluster_id": 1, "github_issue_number": None, "source": "widget"},
         ],
         "notices": [],
         "recipients": {},
@@ -216,8 +222,10 @@ class TestShippedNotifyLoop:
         # Only the two IDENTIFIED reporters behind #498 — never the anonymous row, never user 9.
         assert sorted(_emails(store)) == ["user4@example.com", "user7@example.com"]
         assert sorted(uid for (_n, uid) in store["recipients"]) == [4, 7]
-        # The cluster is closed out; the unrelated report is untouched.
+        # The cluster is closed out — including the row attached by cluster_id only, which is the
+        # same row the reporter mapping counted; the unrelated report is untouched.
         assert [r["status"] for r in store["feedback"][:3]] == ["resolved"] * 3
+        assert store["feedback"][4]["status"] == "resolved"
         assert store["feedback"][3]["status"] == "issue_created"
 
         # A second pass over the same (overlapping) window must not re-email anyone.
@@ -237,6 +245,27 @@ class TestShippedNotifyLoop:
         assert detail["notices"] == []
         # The changelog itself is public — only the ASK is scheduled.
         assert detail["changelog"][0]["issue_number"] == 498
+
+    def test_an_ack_inside_the_delay_cannot_burn_the_notice(self, client, store):
+        """The ack endpoint applies the SAME delay gate as the GET — otherwise a client could ack
+        (and CSAT) a notice it was never shown, and the notice would never surface afterwards."""
+        _run_pass(store)
+        store["recipients"][(1, 4)]["notified_at"] = datetime.now()  # notified just now
+
+        with patch.dict("os.environ", {"FEEDBACK_FIX_CSAT_DELAY_HOURS": "24"}):
+            ack = _call(client, store, "post", "/api/shipped/ack", json={
+                "session_token": "sess", "notice_id": 1, "resolved": True})
+        assert ack.status_code == 404
+        assert store["recipients"][(1, 4)]["seen_at"] is None
+
+        # Once the delay has elapsed the very same notice is surfaced and ackable.
+        store["recipients"][(1, 4)]["notified_at"] = datetime.now() - timedelta(hours=30)
+        with patch.dict("os.environ", {"FEEDBACK_FIX_CSAT_DELAY_HOURS": "24"}):
+            detail = _call(client, store, "get",
+                           "/api/user/shipped?session_token=sess").json()["detail"]
+            assert detail["notices"][0]["id"] == 1
+            assert _call(client, store, "post", "/api/shipped/ack", json={
+                "session_token": "sess", "notice_id": 1, "resolved": True}).status_code == 200
 
     def test_a_not_fixed_answer_re_enters_the_auto_work_loop(self, client, store):
         _run_pass(store)

--- a/tests/integration/test_shipped_notify.py
+++ b/tests/integration/test_shipped_notify.py
@@ -1,0 +1,283 @@
+"""Integration test for the "you asked, we shipped" loop (issue #502).
+
+Drives the REAL `utilities/feedback/shipped.py` pass (a merged PR that says `Closes #498`) and the
+REAL `GET /api/user/shipped` + `POST /api/shipped/ack` handlers through the REAL db.py SQL into a
+stateful fake cursor that models `feedback`, `shipped_notices`, `shipped_notice_recipients` and
+`survey_prompts` — so it is provable, without a MySQL container, that:
+
+  * only the reporters behind the cluster are notified, and only ONCE across repeated passes,
+  * the changelog line is generated and stored,
+  * the cluster's feedback rows end up `resolved`,
+  * the micro-CSAT is withheld until the reporter has had the fix (the delay), and
+  * a "not fixed" answer lands as a NEW feedback row — back at the top of the auto-work loop.
+"""
+import json
+from datetime import datetime, timedelta
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.integration
+
+_DB = "cqc_lem.utilities.db"
+_SHIPPED = "cqc_lem.utilities.feedback.shipped"
+
+_PR = {"number": 539, "title": "fix(feed): comments now post reliably (closes #498)",
+       "body": "Closes #498", "merged_at": "2026-07-25T09:00:00Z"}
+
+
+class _FakeCursor:
+    """Minimal MySQL-ish cursor over the in-memory feedback / shipped / survey_prompts store."""
+
+    def __init__(self, store, dictionary=False):
+        self.store = store
+        self.dictionary = dictionary
+        self._result = []
+        self.rowcount = 0
+        self.lastrowid = None
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        params = params or ()
+        self._result = []
+        self.rowcount = 0
+        self.lastrowid = None
+
+        if s.startswith("SELECT DISTINCT f.user_id FROM feedback"):
+            issue = params[0]
+            seeds = {r["id"] for r in self.store["feedback"]
+                     if r.get("github_issue_number") == issue}
+            users = []
+            for row in self.store["feedback"]:
+                if row.get("user_id") is None:
+                    continue
+                if row.get("github_issue_number") == issue or row.get("cluster_id") in seeds:
+                    if row["user_id"] not in users:
+                        users.append(row["user_id"])
+            self._result = [(u,) for u in users]
+        elif s.startswith("UPDATE feedback SET status = %s WHERE github_issue_number"):
+            status, issue = params[0], params[1]
+            for row in self.store["feedback"]:
+                if (row.get("github_issue_number") == issue
+                        and row["status"] not in ("resolved", "dismissed")):
+                    row["status"] = status
+                    self.rowcount += 1
+        elif s.startswith("UPDATE feedback SET status=%s WHERE id=%s"):
+            for row in self.store["feedback"]:
+                if row["id"] == params[1]:
+                    row["status"] = params[0]
+                    self.rowcount = 1
+        elif s.startswith("INSERT INTO feedback"):
+            row = {"id": len(self.store["feedback"]) + 1, "user_id": params[0],
+                   "source": params[1], "type_hint": params[2], "body": params[3],
+                   "context_json": json.loads(params[4]) if params[4] else None,
+                   "sentiment": params[5], "status": "new", "cluster_id": None,
+                   "github_issue_number": None, "created_at": datetime.now()}
+            self.store["feedback"].append(row)
+            self.lastrowid = row["id"]
+            self.rowcount = 1
+        elif s.startswith("SELECT id, github_issue_number, pr_number, title, changelog_line, "
+                          "shipped_at FROM shipped_notices WHERE github_issue_number"):
+            self._result = [dict(n) for n in self.store["notices"]
+                            if n["github_issue_number"] == params[0]]
+        elif s.startswith("INSERT IGNORE INTO shipped_notices"):
+            if any(n["github_issue_number"] == params[0] for n in self.store["notices"]):
+                return
+            notice = {"id": len(self.store["notices"]) + 1, "github_issue_number": params[0],
+                      "pr_number": params[1], "title": params[2], "changelog_line": params[3],
+                      "shipped_at": datetime.now()}
+            self.store["notices"].append(notice)
+            self.lastrowid = notice["id"]
+            self.rowcount = 1
+        elif s.startswith("SELECT id FROM shipped_notices WHERE github_issue_number"):
+            self._result = [(n["id"],) for n in self.store["notices"]
+                            if n["github_issue_number"] == params[0]]
+        elif s.startswith("SELECT id, github_issue_number, pr_number, title, changelog_line, "
+                          "shipped_at FROM shipped_notices ORDER BY"):
+            self._result = [dict(n) for n in reversed(self.store["notices"])][:params[0]]
+        elif s.startswith("SELECT user_id FROM shipped_notice_recipients"):
+            self._result = [(uid,) for (nid, uid) in self.store["recipients"]
+                            if nid == params[0]]
+        elif s.startswith("INSERT IGNORE INTO shipped_notice_recipients"):
+            key = (params[0], params[1])
+            if key in self.store["recipients"]:
+                return
+            self.store["recipients"][key] = {"notified_at": self.store["notified_at"],
+                                             "seen_at": None}
+            self.rowcount = 1
+        elif s.startswith("SELECT n.id, n.github_issue_number"):
+            user_id, delay_hours, limit = params
+            cutoff = datetime.now() - timedelta(hours=delay_hours)
+            rows = []
+            for (notice_id, uid), rec in self.store["recipients"].items():
+                if uid != user_id or rec["seen_at"] or rec["notified_at"] > cutoff:
+                    continue
+                notice = next(n for n in self.store["notices"] if n["id"] == notice_id)
+                rows.append({**notice, "notified_at": rec["notified_at"]})
+            self._result = rows[:limit]
+        elif s.startswith("UPDATE shipped_notice_recipients SET seen_at"):
+            rec = self.store["recipients"].get((params[0], params[1]))
+            if rec and not rec["seen_at"]:
+                rec["seen_at"] = datetime.now()
+                self.rowcount = 1
+        elif s.startswith("INSERT IGNORE INTO survey_prompts"):
+            if params[1] not in self.store["prompts"]:
+                self.store["prompts"][params[1]] = datetime.now()
+                self.rowcount = 1
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    def fetchone(self):
+        return self._result[0] if self._result else None
+
+    def fetchall(self):
+        return list(self._result)
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, store):
+        self.store = store
+
+    def cursor(self, *a, **k):
+        return _FakeCursor(self.store, dictionary=k.get("dictionary", False))
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from cqc_lem.api.main import app
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def store():
+    """Two reporters (4 and 7) behind cluster/issue #498, plus one anonymous report and one
+    unrelated report that must never be notified."""
+    return {
+        "feedback": [
+            {"id": 1, "user_id": 4, "body": "comments never post", "status": "issue_created",
+             "cluster_id": 1, "github_issue_number": 498, "source": "widget"},
+            {"id": 2, "user_id": 7, "body": "my comments go nowhere", "status": "clustered",
+             "cluster_id": 1, "github_issue_number": 498, "source": "widget"},
+            {"id": 3, "user_id": None, "body": "same here", "status": "clustered",
+             "cluster_id": 1, "github_issue_number": 498, "source": "widget"},
+            {"id": 4, "user_id": 9, "body": "unrelated carousel bug", "status": "issue_created",
+             "cluster_id": 4, "github_issue_number": 601, "source": "widget"},
+        ],
+        "notices": [],
+        "recipients": {},
+        "prompts": {},
+        "notified_at": datetime.now() - timedelta(hours=30),  # notified yesterday
+    }
+
+
+def _emails(store):
+    return store.setdefault("_emails", [])
+
+
+def _run_pass(store):
+    """One real `process_shipped_fixes` pass over one merged PR, with GitHub + SMTP faked."""
+    with patch(f"{_DB}.get_db_connection", side_effect=lambda *a, **k: _FakeConn(store)), \
+         patch(f"{_SHIPPED}.github_token", return_value="tok"), \
+         patch(f"{_SHIPPED}.github_request", return_value=[_PR]), \
+         patch(f"{_SHIPPED}._parse_github_time", return_value=datetime.now().astimezone()), \
+         patch("cqc_lem.utilities.notifications.get_user_email",
+               side_effect=lambda uid: f"user{uid}@example.com"), \
+         patch("cqc_lem.utilities.email._dispatch_email",
+               side_effect=lambda to, *a, **k: _emails(store).append(to) or True), \
+         patch("cqc_lem.utilities.observability.posthog"):
+        from cqc_lem.utilities.feedback.shipped import process_shipped_fixes
+        return process_shipped_fixes()
+
+
+def _call(client, store, method, path, **kwargs):
+    with patch(f"{_DB}.get_db_connection", side_effect=lambda *a, **k: _FakeConn(store)), \
+         patch("cqc_lem.api.main.get_session_user_id", return_value=4), \
+         patch("cqc_lem.utilities.observability.posthog"):
+        return getattr(client, method)(path, **kwargs)
+
+
+class TestShippedNotifyLoop:
+    def test_reporters_are_mapped_from_the_cluster_and_notified_exactly_once(self, store):
+        result = _run_pass(store)
+
+        assert result["counts"] == {"notified": 1}
+        assert result["changelog"] == [
+            "**Fixed:** Comments now post reliably (#498, PR #539)"]
+        # Only the two IDENTIFIED reporters behind #498 — never the anonymous row, never user 9.
+        assert sorted(_emails(store)) == ["user4@example.com", "user7@example.com"]
+        assert sorted(uid for (_n, uid) in store["recipients"]) == [4, 7]
+        # The cluster is closed out; the unrelated report is untouched.
+        assert [r["status"] for r in store["feedback"][:3]] == ["resolved"] * 3
+        assert store["feedback"][3]["status"] == "issue_created"
+
+        # A second pass over the same (overlapping) window must not re-email anyone.
+        _emails(store).clear()
+        again = _run_pass(store)
+        assert again["counts"] == {"already_sent": 1}
+        assert _emails(store) == []
+        assert len(store["notices"]) == 1  # one changelog line per shipped issue
+
+    def test_the_micro_csat_waits_until_the_reporter_has_had_the_fix(self, client, store):
+        _run_pass(store)
+        store["recipients"][(1, 4)]["notified_at"] = datetime.now()  # notified just now
+
+        with patch.dict("os.environ", {"FEEDBACK_FIX_CSAT_DELAY_HOURS": "24"}):
+            detail = _call(client, store, "get",
+                           "/api/user/shipped?session_token=sess").json()["detail"]
+        assert detail["notices"] == []
+        # The changelog itself is public — only the ASK is scheduled.
+        assert detail["changelog"][0]["issue_number"] == 498
+
+    def test_a_not_fixed_answer_re_enters_the_auto_work_loop(self, client, store):
+        _run_pass(store)
+
+        with patch.dict("os.environ", {"FEEDBACK_FIX_CSAT_DELAY_HOURS": "24"}):
+            detail = _call(client, store, "get",
+                           "/api/user/shipped?session_token=sess").json()["detail"]
+        notice = detail["notices"][0]
+        assert notice["changelog_line"] == "**Fixed:** Comments now post reliably (#498, PR #539)"
+
+        ack = _call(client, store, "post", "/api/shipped/ack", json={
+            "session_token": "sess", "notice_id": notice["id"], "resolved": False,
+            "comment": "still nothing on mobile"})
+        assert ack.status_code == 200
+
+        row = store["feedback"][-1]
+        assert row["source"] == "csat"
+        assert row["type_hint"] == "fix_csat"
+        assert row["body"] == "still nothing on mobile"
+        assert row["sentiment"] == "negative"
+        assert row["context_json"] == {"issue_number": 498, "resolved": False,
+                                       "survey_key": "fix_csat_498"}
+        # Left at `new` on purpose: the auto-filer picks it up and re-opens the problem.
+        assert row["status"] == "new"
+        assert "fix_csat_498" in store["prompts"]
+
+        # The notice is spent — the same user is not asked twice.
+        detail = _call(client, store, "get",
+                       "/api/user/shipped?session_token=sess").json()["detail"]
+        assert detail["notices"] == []
+
+    def test_a_fixed_answer_is_stored_resolved_and_never_re_classified(self, client, store):
+        _run_pass(store)
+        detail = _call(client, store, "get",
+                       "/api/user/shipped?session_token=sess").json()["detail"]
+
+        _call(client, store, "post", "/api/shipped/ack", json={
+            "session_token": "sess", "notice_id": detail["notices"][0]["id"], "resolved": True})
+
+        row = store["feedback"][-1]
+        assert row["source"] == "csat"
+        assert row["sentiment"] == "positive"
+        assert row["status"] == "resolved"
+        assert row["body"] == "Confirmed fixed (issue #498)"

--- a/tests/unit/api/test_shipped_api.py
+++ b/tests/unit/api/test_shipped_api.py
@@ -1,0 +1,103 @@
+"""Unit tests for the shipped-notice endpoints (issue #502)."""
+
+from datetime import datetime
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_M = "cqc_lem.api.main"
+_DB = "cqc_lem.utilities.db"
+_S = "cqc_lem.utilities.surveys"
+
+_NOTICE = {"id": 11, "github_issue_number": 498, "pr_number": 539, "title": "fix: x",
+           "changelog_line": "**Fixed:** Comments post (#498, PR #539)",
+           "shipped_at": datetime(2026, 7, 25, 10, 0), "notified_at": datetime(2026, 7, 25, 10, 5)}
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+class TestShippedNoticesEndpoint:
+    def test_returns_the_users_notices_and_the_changelog(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_DB}.get_unseen_shipped_notices", return_value=[_NOTICE]) as unseen, \
+             patch(f"{_DB}.get_recent_shipped_notices", return_value=[_NOTICE]), \
+             patch("cqc_lem.utilities.feedback.shipped.fix_csat_delay_hours", return_value=24):
+            resp = client.get("/api/user/shipped?session_token=tok")
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert detail["notices"] == [{
+            "id": 11, "issue_number": 498,
+            "changelog_line": "**Fixed:** Comments post (#498, PR #539)",
+            "shipped_at": "2026-07-25T10:00:00"}]
+        assert detail["changelog"][0]["issue_number"] == 498
+        # The configured delay is what schedules the micro-CSAT the notice carries.
+        assert unseen.call_args.kwargs["delay_hours"] == 24
+
+    def test_requires_a_valid_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.get("/api/user/shipped?session_token=bad")
+        assert resp.status_code == 401
+
+
+class TestAckEndpoint:
+    def test_records_the_micro_csat_and_marks_the_notice_seen(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_DB}.get_unseen_shipped_notices", return_value=[_NOTICE]), \
+             patch(f"{_DB}.mark_shipped_notice_seen", return_value=True) as seen, \
+             patch(f"{_S}.record_fix_csat_response", return_value=77) as record:
+            resp = client.post("/api/shipped/ack", json={
+                "session_token": "tok", "notice_id": 11, "resolved": False,
+                "comment": "still broken"})
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == {"acknowledged": True, "feedback_id": 77}
+        seen.assert_called_once_with(11, 42)
+        assert record.call_args.args == (42, 498, False)
+        assert record.call_args.kwargs["comment"] == "still broken"
+
+    def test_dismissal_without_an_answer_records_no_feedback(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_DB}.get_unseen_shipped_notices", return_value=[_NOTICE]), \
+             patch(f"{_DB}.mark_shipped_notice_seen", return_value=True), \
+             patch(f"{_S}.record_fix_csat_response") as record:
+            resp = client.post("/api/shipped/ack",
+                               json={"session_token": "tok", "notice_id": 11})
+        assert resp.json()["detail"] == {"acknowledged": True, "feedback_id": None}
+        record.assert_not_called()
+
+    def test_a_notice_addressed_to_someone_else_is_not_ackable(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_DB}.get_unseen_shipped_notices", return_value=[_NOTICE]), \
+             patch(f"{_DB}.mark_shipped_notice_seen") as seen, \
+             patch(f"{_S}.record_fix_csat_response") as record:
+            resp = client.post("/api/shipped/ack",
+                               json={"session_token": "tok", "notice_id": 999, "resolved": True})
+        assert resp.status_code == 404
+        seen.assert_not_called()
+        record.assert_not_called()
+
+    def test_requires_a_valid_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.post("/api/shipped/ack",
+                               json={"session_token": "bad", "notice_id": 11})
+        assert resp.status_code == 401

--- a/tests/unit/api/test_shipped_api.py
+++ b/tests/unit/api/test_shipped_api.py
@@ -63,8 +63,9 @@ class TestShippedNoticesEndpoint:
 class TestAckEndpoint:
     def test_records_the_micro_csat_and_marks_the_notice_seen(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=42), \
-             patch(f"{_DB}.get_unseen_shipped_notices", return_value=[_NOTICE]), \
+             patch(f"{_DB}.get_unseen_shipped_notices", return_value=[_NOTICE]) as unseen, \
              patch(f"{_DB}.mark_shipped_notice_seen", return_value=True) as seen, \
+             patch("cqc_lem.utilities.feedback.shipped.fix_csat_delay_hours", return_value=24), \
              patch(f"{_S}.record_fix_csat_response", return_value=77) as record:
             resp = client.post("/api/shipped/ack", json={
                 "session_token": "tok", "notice_id": 11, "resolved": False,
@@ -74,6 +75,23 @@ class TestAckEndpoint:
         seen.assert_called_once_with(11, 42)
         assert record.call_args.args == (42, 498, False)
         assert record.call_args.kwargs["comment"] == "still broken"
+        # Same delay gate as the GET — an ack can't outrun the notice it acknowledges.
+        assert unseen.call_args.kwargs["delay_hours"] == 24
+
+    def test_a_notice_still_inside_the_csat_delay_is_not_ackable(self, client):
+        """The delay gate is applied on ack too: acking early would consume the notice (and its
+        micro-CSAT) before the user was ever shown it."""
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_DB}.get_unseen_shipped_notices", return_value=[]) as unseen, \
+             patch(f"{_DB}.mark_shipped_notice_seen") as seen, \
+             patch("cqc_lem.utilities.feedback.shipped.fix_csat_delay_hours", return_value=24), \
+             patch(f"{_S}.record_fix_csat_response") as record:
+            resp = client.post("/api/shipped/ack", json={
+                "session_token": "tok", "notice_id": 11, "resolved": True})
+        assert resp.status_code == 404
+        assert unseen.call_args.kwargs["delay_hours"] == 24
+        seen.assert_not_called()
+        record.assert_not_called()
 
     def test_dismissal_without_an_answer_records_no_feedback(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=42), \

--- a/tests/unit/app/test_changelog_notify.py
+++ b/tests/unit/app/test_changelog_notify.py
@@ -1,0 +1,34 @@
+"""Unit tests for the daily shipped-fix changelog/notify beat task (issue #502)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_SHIPPED = "cqc_lem.utilities.feedback.shipped"
+
+
+class TestAutoChangelogNotify:
+    def test_summarises_the_pass(self):
+        with patch(f"{_SHIPPED}.process_shipped_fixes",
+                   return_value={"pull_requests": 3, "counts": {"notified": 2},
+                                 "changelog": ["**Fixed:** X (#498)"]}) as process:
+            from cqc_lem.app.run_scheduler import auto_changelog_notify
+            result = auto_changelog_notify(hours=12)
+        process.assert_called_once_with(hours=12)
+        assert result == "Shipped-fix notify: 3 merged PR(s) — {'notified': 2}"
+
+    def test_an_empty_pass_reads_as_nothing_to_do(self):
+        with patch(f"{_SHIPPED}.process_shipped_fixes",
+                   return_value={"pull_requests": 0, "counts": {}, "changelog": []}):
+            from cqc_lem.app.run_scheduler import auto_changelog_notify
+            assert auto_changelog_notify() == "Shipped-fix notify: 0 merged PR(s) — nothing to do"
+
+
+class TestBeatSchedule:
+    def test_task_runs_daily_after_the_survey_pass(self):
+        from cqc_lem.app.my_celery import app
+        entry = app.conf.beat_schedule["changelog-notify"]
+        assert entry["task"] == "cqc_lem.app.run_scheduler.auto_changelog_notify"
+        assert entry["schedule"].hour == {10}
+        assert entry["schedule"].minute == {0}

--- a/tests/unit/utilities/test_db_feedback.py
+++ b/tests/unit/utilities/test_db_feedback.py
@@ -83,7 +83,9 @@ class TestInsertFeedback:
 class TestFeedbackEnums:
     def test_source_values_match_the_migration_enum(self):
         from cqc_lem.utilities.db import FeedbackSource
-        assert {str(s) for s in FeedbackSource} == {"widget", "bug", "nps", "review", "passive"}
+        # 'csat' was appended by V20260725104900 for the post-fix micro-CSAT (issue #502).
+        assert {str(s) for s in FeedbackSource} == {"widget", "bug", "nps", "review", "passive",
+                                                    "csat"}
 
     def test_status_values_match_the_migration_enum(self):
         from cqc_lem.utilities.db import FeedbackStatus

--- a/tests/unit/utilities/test_db_shipped.py
+++ b/tests/unit/utilities/test_db_shipped.py
@@ -57,8 +57,19 @@ class TestResolveCluster:
             from cqc_lem.utilities.db import mark_feedback_resolved_for_issue
             assert mark_feedback_resolved_for_issue(498) == 3
         sql, params = cur.execute.call_args[0]
-        assert "status NOT IN" in sql
-        assert params == ("resolved", 498, "resolved", "dismissed")
+        assert "f.status NOT IN" in sql
+        assert params == ("resolved", 498, 498, "resolved", "dismissed")
+
+    def test_resolves_cluster_attached_rows_the_same_way_reporters_are_mapped(self):
+        """The UPDATE must span the same self-join as get_feedback_reporters_for_issue, or a row
+        attached by cluster_id before the issue number propagated stays open forever."""
+        conn, cur = _conn(rowcount=2)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import mark_feedback_resolved_for_issue
+            mark_feedback_resolved_for_issue(498)
+        sql = cur.execute.call_args[0][0]
+        assert "LEFT JOIN feedback s ON s.id = f.cluster_id" in sql
+        assert "f.github_issue_number = %s OR s.github_issue_number = %s" in sql
 
     def test_zero_on_no_issue_or_error(self):
         from cqc_lem.utilities.db import mark_feedback_resolved_for_issue

--- a/tests/unit/utilities/test_db_shipped.py
+++ b/tests/unit/utilities/test_db_shipped.py
@@ -1,0 +1,199 @@
+"""Unit tests for the shipped-notice DB helpers (issue #502)."""
+
+from datetime import datetime
+
+import mysql.connector
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(rowcount=1, fetchone=None, fetchall=None, lastrowid=None):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.rowcount = rowcount
+    cur.lastrowid = lastrowid
+    cur.fetchone.return_value = fetchone
+    cur.fetchall.return_value = fetchall or []
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+def _erroring_conn():
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.execute.side_effect = mysql.connector.Error("boom")
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestReporterMapping:
+    def test_maps_feedback_to_issue_and_cluster(self):
+        conn, cur = _conn(fetchall=[(4,), (7,)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_feedback_reporters_for_issue
+            assert get_feedback_reporters_for_issue(498) == [4, 7]
+        sql, params = cur.execute.call_args[0]
+        # Both the directly-stamped rows AND rows that only carry the seed's cluster_id.
+        assert "f.github_issue_number = %s OR s.github_issue_number = %s" in sql
+        assert "f.user_id IS NOT NULL" in sql
+        assert params == (498, 498)
+
+    def test_no_issue_number_and_db_errors_return_nothing(self):
+        from cqc_lem.utilities.db import get_feedback_reporters_for_issue
+        assert get_feedback_reporters_for_issue(None) == []
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert get_feedback_reporters_for_issue(498) == []
+
+
+class TestResolveCluster:
+    def test_moves_open_rows_to_resolved_and_leaves_dismissed_alone(self):
+        conn, cur = _conn(rowcount=3)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import mark_feedback_resolved_for_issue
+            assert mark_feedback_resolved_for_issue(498) == 3
+        sql, params = cur.execute.call_args[0]
+        assert "status NOT IN" in sql
+        assert params == ("resolved", 498, "resolved", "dismissed")
+
+    def test_zero_on_no_issue_or_error(self):
+        from cqc_lem.utilities.db import mark_feedback_resolved_for_issue
+        assert mark_feedback_resolved_for_issue(0) == 0
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert mark_feedback_resolved_for_issue(498) == 0
+
+
+class TestRecordShippedNotice:
+    def test_returns_the_new_notice_id(self):
+        conn, cur = _conn(lastrowid=11)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_shipped_notice
+            assert record_shipped_notice(498, "**Fixed:** X (#498)", pr_number=539,
+                                         title="fix: x") == 11
+        sql, params = cur.execute.call_args[0]
+        assert "INSERT IGNORE INTO shipped_notices" in sql
+        assert params == (498, 539, "fix: x", "**Fixed:** X (#498)")
+
+    def test_reuses_the_existing_row_when_the_insert_was_ignored(self):
+        conn, cur = _conn(lastrowid=0, fetchone=(11,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_shipped_notice
+            assert record_shipped_notice(498, "**Fixed:** X (#498)") == 11
+        assert "SELECT id FROM shipped_notices" in cur.execute.call_args[0][0]
+
+    def test_rejects_incomplete_input_and_survives_errors(self):
+        from cqc_lem.utilities.db import record_shipped_notice
+        assert record_shipped_notice(0, "line") is None
+        assert record_shipped_notice(498, "   ") is None
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert record_shipped_notice(498, "line") is None
+
+
+class TestRecipients:
+    def test_first_insert_wins_and_repeats_return_false(self):
+        from cqc_lem.utilities.db import record_shipped_notice_recipient
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert record_shipped_notice_recipient(11, 4) is True
+        assert "INSERT IGNORE INTO shipped_notice_recipients" in cur.execute.call_args[0][0]
+
+        conn, _cur = _conn(rowcount=0)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert record_shipped_notice_recipient(11, 4) is False
+
+    def test_reads_back_who_was_already_told(self):
+        from cqc_lem.utilities.db import get_shipped_notice_recipient_ids
+        conn, cur = _conn(fetchall=[(4,), (7,)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert get_shipped_notice_recipient_ids(11) == [4, 7]
+        assert cur.execute.call_args[0][1] == (11,)
+
+        assert get_shipped_notice_recipient_ids(None) == []
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert get_shipped_notice_recipient_ids(11) == []
+
+    def test_missing_ids_and_errors_are_false(self):
+        from cqc_lem.utilities.db import record_shipped_notice_recipient
+        assert record_shipped_notice_recipient(None, 4) is False
+        assert record_shipped_notice_recipient(11, None) is False
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert record_shipped_notice_recipient(11, 4) is False
+
+
+class TestUnseenNotices:
+    def test_delay_hours_is_what_schedules_the_csat(self):
+        row = {"id": 11, "github_issue_number": 498, "changelog_line": "**Fixed:** X (#498)",
+               "shipped_at": datetime(2026, 7, 25, 10, 0)}
+        conn, cur = _conn(fetchall=[row])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_unseen_shipped_notices
+            assert get_unseen_shipped_notices(4, delay_hours=24, limit=5) == [row]
+        sql, params = cur.execute.call_args[0]
+        assert "r.seen_at IS NULL" in sql
+        assert "INTERVAL %s HOUR" in sql
+        assert params == (4, 24, 5)
+
+    def test_negative_delay_is_clamped_and_errors_return_empty(self):
+        conn, cur = _conn(fetchall=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_unseen_shipped_notices
+            get_unseen_shipped_notices(4, delay_hours=-5)
+        assert cur.execute.call_args[0][1][1] == 0
+
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_unseen_shipped_notices
+            assert get_unseen_shipped_notices(4) == []
+
+
+class TestSeenAndChangelog:
+    def test_only_the_first_acknowledgement_writes(self):
+        from cqc_lem.utilities.db import mark_shipped_notice_seen
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert mark_shipped_notice_seen(11, 4) is True
+        assert "seen_at IS NULL" in cur.execute.call_args[0][0]
+
+        conn, _cur = _conn(rowcount=0)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert mark_shipped_notice_seen(11, 4) is False
+
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert mark_shipped_notice_seen(11, 4) is False
+
+    def test_changelog_is_newest_first(self):
+        rows = [{"id": 12, "changelog_line": "b"}, {"id": 11, "changelog_line": "a"}]
+        conn, cur = _conn(fetchall=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_recent_shipped_notices
+            assert get_recent_shipped_notices(2) == rows
+        sql, params = cur.execute.call_args[0]
+        assert "ORDER BY shipped_at DESC" in sql
+        assert params == (2,)
+
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_recent_shipped_notices
+            assert get_recent_shipped_notices() == []
+
+    def test_notice_lookup_by_issue(self):
+        row = {"id": 11, "github_issue_number": 498}
+        conn, cur = _conn(fetchone=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_shipped_notice_by_issue
+            assert get_shipped_notice_by_issue(498) == row
+        assert cur.execute.call_args[0][1] == (498,)
+
+        conn, _cur = _erroring_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_shipped_notice_by_issue
+            assert get_shipped_notice_by_issue(498) is None

--- a/tests/unit/utilities/test_shipped.py
+++ b/tests/unit/utilities/test_shipped.py
@@ -1,0 +1,241 @@
+"""Unit tests for the shipped-fix changelog + reporter notification (issue #502)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.feedback.shipped"
+
+
+def _pr(number=539, title="fix(feed): comments now post (closes #498)", body="Closes #498",
+        merged_hours_ago=1):
+    merged = (datetime.now(timezone.utc) - timedelta(hours=merged_hours_ago))
+    return {"number": number, "title": title, "body": body,
+            "merged_at": merged.strftime("%Y-%m-%dT%H:%M:%SZ")}
+
+
+class TestClosingIssueNumbers:
+    def test_matches_every_closing_keyword_across_title_and_body(self):
+        from cqc_lem.utilities.feedback.shipped import closing_issue_numbers
+        assert closing_issue_numbers("feat(dms): thing (closes #12)",
+                                     "Fixes #13\nResolved: #14\nclosed #15") == [12, 13, 14, 15]
+
+    def test_ignores_bare_references_and_dedupes(self):
+        from cqc_lem.utilities.feedback.shipped import closing_issue_numbers
+        # "related to #99" is a mention, not a fix — it must never claim someone's report shipped.
+        assert closing_issue_numbers("Closes #12", "related to #99, closes #12") == [12]
+
+    def test_empty_inputs_are_safe(self):
+        from cqc_lem.utilities.feedback.shipped import closing_issue_numbers
+        assert closing_issue_numbers(None, "") == []
+
+
+class TestChangelogLine:
+    def test_conventional_commit_becomes_human_copy(self):
+        from cqc_lem.utilities.feedback.shipped import build_changelog_line
+        line = build_changelog_line("fix(feed): comments now post reliably (closes #498)", 498, 539)
+        assert line == "**Fixed:** Comments now post reliably (#498, PR #539)"
+
+    def test_feature_and_unknown_types_get_their_own_label(self):
+        from cqc_lem.utilities.feedback.shipped import build_changelog_line, humanize_title
+        assert humanize_title("feat(dms): add follow-ups")[0] == "New"
+        assert humanize_title("perf(api): speed up stats")[0] == "Faster"
+        assert humanize_title("wat(api): something")[0] == "Improved"
+        assert build_changelog_line("A plain title", 7).startswith("**Improved:** A plain title")
+
+    def test_falls_back_when_the_title_is_only_a_prefix_and_ref(self):
+        from cqc_lem.utilities.feedback.shipped import build_changelog_line
+        assert build_changelog_line("fix: closes #3", 3) == "**Fixed:** A fix you reported (#3)"
+
+    def test_line_is_bounded(self):
+        from cqc_lem.utilities.feedback.shipped import MAX_CHANGELOG_CHARS, build_changelog_line
+        assert len(build_changelog_line("fix(x): " + "y" * 900, 1, 2)) <= MAX_CHANGELOG_CHARS
+
+
+class TestEnvKnobs:
+    def test_lookback_and_delay_defaults_and_clamps(self, monkeypatch):
+        from cqc_lem.utilities.feedback.shipped import (FIX_CSAT_DELAY_HOURS_DEFAULT,
+                                                        LOOKBACK_HOURS_DEFAULT,
+                                                        fix_csat_delay_hours, lookback_hours)
+        monkeypatch.delenv("FEEDBACK_SHIPPED_LOOKBACK_HOURS", raising=False)
+        monkeypatch.delenv("FEEDBACK_FIX_CSAT_DELAY_HOURS", raising=False)
+        assert lookback_hours() == LOOKBACK_HOURS_DEFAULT
+        assert fix_csat_delay_hours() == FIX_CSAT_DELAY_HOURS_DEFAULT
+
+        monkeypatch.setenv("FEEDBACK_SHIPPED_LOOKBACK_HOURS", "9999")
+        monkeypatch.setenv("FEEDBACK_FIX_CSAT_DELAY_HOURS", "0")
+        assert lookback_hours() == 720
+        assert fix_csat_delay_hours() == 0
+
+        monkeypatch.setenv("FEEDBACK_SHIPPED_LOOKBACK_HOURS", "junk")
+        monkeypatch.setenv("FEEDBACK_FIX_CSAT_DELAY_HOURS", "junk")
+        assert lookback_hours() == LOOKBACK_HOURS_DEFAULT
+        assert fix_csat_delay_hours() == FIX_CSAT_DELAY_HOURS_DEFAULT
+
+
+class TestMergedPullRequests:
+    def test_no_token_means_no_github_call(self):
+        from cqc_lem.utilities.feedback.shipped import merged_pull_requests
+        with patch(f"{_MOD}.github_token", return_value=None), \
+                patch(f"{_MOD}.github_request") as req:
+            assert merged_pull_requests() == []
+        req.assert_not_called()
+
+    def test_keeps_only_prs_merged_inside_the_window(self):
+        from cqc_lem.utilities.feedback.shipped import merged_pull_requests
+        rows = [_pr(number=1, merged_hours_ago=2),
+                _pr(number=2, merged_hours_ago=200),
+                {"number": 3, "merged_at": None},
+                {"number": 4, "merged_at": "not-a-date"},
+                "junk"]
+        with patch(f"{_MOD}.github_token", return_value="t"), \
+                patch(f"{_MOD}.github_request", return_value=rows):
+            merged = merged_pull_requests(hours=48)
+        assert [pr["number"] for pr in merged] == [1]
+
+    def test_non_list_response_is_not_an_error(self):
+        from cqc_lem.utilities.feedback.shipped import merged_pull_requests
+        with patch(f"{_MOD}.github_token", return_value="t"), \
+                patch(f"{_MOD}.github_request", return_value=None):
+            assert merged_pull_requests() == []
+
+
+class TestNotifyShippedIssue:
+    def test_notifies_every_reporter_once_and_resolves_the_cluster(self):
+        from cqc_lem.utilities.feedback.shipped import ShipAction, notify_shipped_issue
+        notify = MagicMock(return_value=True)
+        with patch(f"{_MOD}.get_feedback_reporters_for_issue", return_value=[4, 7]), \
+                patch(f"{_MOD}.get_shipped_notice_by_issue", return_value=None), \
+                patch(f"{_MOD}.record_shipped_notice", return_value=11) as record, \
+                patch(f"{_MOD}.get_shipped_notice_recipient_ids", return_value=[]), \
+                patch(f"{_MOD}.record_shipped_notice_recipient", return_value=True) as recip, \
+                patch(f"{_MOD}.mark_feedback_resolved_for_issue", return_value=3) as resolve, \
+                patch("cqc_lem.utilities.notifications.notify_shipped_fix", notify):
+            result = notify_shipped_issue(498, pr_title="fix(feed): comments post", pr_number=539)
+
+        assert result["action"] == ShipAction.NOTIFIED
+        assert result["notified"] == 2
+        assert result["resolved"] == 3
+        assert record.call_args[0][1].startswith("**Fixed:** Comments post")
+        assert [c[0][1] for c in recip.call_args_list] == [4, 7]
+        resolve.assert_called_once_with(498)
+
+    def test_a_reporter_already_on_the_ledger_is_never_emailed_again(self):
+        from cqc_lem.utilities.feedback.shipped import ShipAction, notify_shipped_issue
+        notify = MagicMock(return_value=True)
+        with patch(f"{_MOD}.get_feedback_reporters_for_issue", return_value=[4, 7]), \
+                patch(f"{_MOD}.get_shipped_notice_by_issue",
+                      return_value={"id": 11, "changelog_line": "**Fixed:** X (#498)"}), \
+                patch(f"{_MOD}.get_shipped_notice_recipient_ids", return_value=[4]), \
+                patch(f"{_MOD}.record_shipped_notice_recipient", return_value=True), \
+                patch(f"{_MOD}.mark_feedback_resolved_for_issue", return_value=0), \
+                patch("cqc_lem.utilities.notifications.notify_shipped_fix", notify):
+            result = notify_shipped_issue(498, pr_title="fix: x")
+        # User 4 was told on an earlier pass — only the new reporter hears about it.
+        assert [c[0][0] for c in notify.call_args_list] == [7]
+        assert result["action"] == ShipAction.NOTIFIED
+        assert result["notified"] == 1
+
+    def test_no_reporters_means_no_notice_and_no_writes(self):
+        from cqc_lem.utilities.feedback.shipped import ShipAction, notify_shipped_issue
+        with patch(f"{_MOD}.get_feedback_reporters_for_issue", return_value=[]), \
+                patch(f"{_MOD}.record_shipped_notice") as record:
+            result = notify_shipped_issue(500, pr_title="fix: x")
+        assert result["action"] == ShipAction.NO_REPORTERS
+        record.assert_not_called()
+
+    def test_reuses_the_existing_changelog_line_and_reports_already_sent(self):
+        from cqc_lem.utilities.feedback.shipped import ShipAction, notify_shipped_issue
+        existing = {"id": 11, "changelog_line": "**Fixed:** The original wording (#498)"}
+        notify = MagicMock(return_value=True)
+        with patch(f"{_MOD}.get_feedback_reporters_for_issue", return_value=[4]), \
+                patch(f"{_MOD}.get_shipped_notice_by_issue", return_value=existing), \
+                patch(f"{_MOD}.record_shipped_notice") as record, \
+                patch(f"{_MOD}.get_shipped_notice_recipient_ids", return_value=[4]), \
+                patch(f"{_MOD}.record_shipped_notice_recipient") as recip, \
+                patch(f"{_MOD}.mark_feedback_resolved_for_issue", return_value=0), \
+                patch("cqc_lem.utilities.notifications.notify_shipped_fix", notify):
+            result = notify_shipped_issue(498, pr_title="fix(feed): a NEW wording", pr_number=540)
+        assert result["action"] == ShipAction.ALREADY_SENT
+        # A second pass re-words nothing and re-sends nothing.
+        record.assert_not_called()
+        notify.assert_not_called()
+        recip.assert_not_called()
+
+    def test_a_failed_email_does_not_mark_the_reporter_as_told(self):
+        from cqc_lem.utilities.feedback.shipped import ShipAction, notify_shipped_issue
+        with patch(f"{_MOD}.get_feedback_reporters_for_issue", return_value=[4]), \
+                patch(f"{_MOD}.get_shipped_notice_by_issue", return_value=None), \
+                patch(f"{_MOD}.record_shipped_notice", return_value=11), \
+                patch(f"{_MOD}.get_shipped_notice_recipient_ids", return_value=[]), \
+                patch(f"{_MOD}.record_shipped_notice_recipient") as recip, \
+                patch(f"{_MOD}.mark_feedback_resolved_for_issue", return_value=1), \
+                patch("cqc_lem.utilities.notifications.notify_shipped_fix", return_value=False):
+            result = notify_shipped_issue(498, pr_title="fix: x")
+        recip.assert_not_called()
+        # An owed-but-undelivered notice is an error to retry, NOT "already sent".
+        assert result["action"] == ShipAction.ERROR
+
+    def test_a_raising_notifier_never_blocks_the_other_reporters(self):
+        from cqc_lem.utilities.feedback.shipped import ShipAction, notify_shipped_issue
+        with patch(f"{_MOD}.get_feedback_reporters_for_issue", return_value=[4, 7]), \
+                patch(f"{_MOD}.get_shipped_notice_by_issue", return_value=None), \
+                patch(f"{_MOD}.record_shipped_notice", return_value=11), \
+                patch(f"{_MOD}.get_shipped_notice_recipient_ids", return_value=[]), \
+                patch(f"{_MOD}.record_shipped_notice_recipient", return_value=True), \
+                patch(f"{_MOD}.mark_feedback_resolved_for_issue", return_value=1), \
+                patch("cqc_lem.utilities.notifications.notify_shipped_fix",
+                      side_effect=[RuntimeError("smtp down"), True]):
+            result = notify_shipped_issue(498, pr_title="fix: x")
+        assert result["action"] == ShipAction.NOTIFIED
+        assert result["notified"] == 1
+
+    def test_unrecordable_changelog_line_is_an_error_not_a_send(self):
+        from cqc_lem.utilities.feedback.shipped import ShipAction, notify_shipped_issue
+        notify = MagicMock()
+        with patch(f"{_MOD}.get_feedback_reporters_for_issue", return_value=[4]), \
+                patch(f"{_MOD}.get_shipped_notice_by_issue", return_value=None), \
+                patch(f"{_MOD}.record_shipped_notice", return_value=None), \
+                patch("cqc_lem.utilities.notifications.notify_shipped_fix", notify):
+            result = notify_shipped_issue(498, pr_title="fix: x")
+        assert result["action"] == ShipAction.ERROR
+        notify.assert_not_called()
+
+
+class TestProcessShippedFixes:
+    def test_walks_every_closing_issue_of_every_merged_pr(self):
+        from cqc_lem.utilities.feedback.shipped import ShipAction, process_shipped_fixes
+        prs = [_pr(number=539, title="fix(feed): a (closes #498)", body="Also closes #499")]
+        results = [{"action": ShipAction.NOTIFIED, "issue_number": 498,
+                    "changelog_line": "**Fixed:** A (#498)"},
+                   {"action": ShipAction.NO_REPORTERS, "issue_number": 499}]
+        with patch(f"{_MOD}.merged_pull_requests", return_value=prs), \
+                patch(f"{_MOD}.notify_shipped_issue", side_effect=results) as notify:
+            out = process_shipped_fixes()
+        assert out["pull_requests"] == 1
+        assert out["counts"] == {ShipAction.NOTIFIED: 1, ShipAction.NO_REPORTERS: 1}
+        assert out["changelog"] == ["**Fixed:** A (#498)"]
+        assert [c[0][0] for c in notify.call_args_list] == [498, 499]
+
+    def test_one_exploding_issue_does_not_abort_the_pass(self):
+        from cqc_lem.utilities.feedback.shipped import ShipAction, process_shipped_fixes
+        prs = [_pr(number=1, title="fix: a (closes #10)", body=""),
+               _pr(number=2, title="fix: b (closes #11)", body="")]
+        with patch(f"{_MOD}.merged_pull_requests", return_value=prs), \
+                patch(f"{_MOD}.notify_shipped_issue",
+                      side_effect=[RuntimeError("boom"),
+                                   {"action": ShipAction.NOTIFIED, "issue_number": 11}]):
+            out = process_shipped_fixes()
+        assert out["counts"] == {ShipAction.ERROR: 1, ShipAction.NOTIFIED: 1}
+
+    def test_a_pr_that_closes_nothing_is_skipped(self):
+        from cqc_lem.utilities.feedback.shipped import process_shipped_fixes
+        with patch(f"{_MOD}.merged_pull_requests",
+                   return_value=[_pr(title="chore: bump deps", body="see #12")]), \
+                patch(f"{_MOD}.notify_shipped_issue") as notify:
+            out = process_shipped_fixes()
+        assert out["counts"] == {}
+        notify.assert_not_called()

--- a/tests/unit/utilities/test_surveys_fix_csat.py
+++ b/tests/unit/utilities/test_surveys_fix_csat.py
@@ -1,0 +1,127 @@
+"""Unit tests for the post-fix micro-CSAT and the shipped-fix notification (issue #502)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_SURVEYS = "cqc_lem.utilities.surveys"
+_NOTIFY = "cqc_lem.utilities.notifications"
+
+
+class TestFixCsatKeys:
+    def test_key_is_per_issue_and_fits_the_ledger_column(self):
+        from cqc_lem.utilities.surveys import fix_csat_key, is_fix_csat_key
+        key = fix_csat_key(502)
+        assert key == "fix_csat_502"
+        assert len(key) <= 32
+        assert is_fix_csat_key(key)
+
+    def test_only_generated_keys_are_recognised(self):
+        from cqc_lem.utilities.surveys import is_fix_csat_key
+        assert not is_fix_csat_key("fix_csat_")
+        assert not is_fix_csat_key("fix_csat_abc")
+        assert not is_fix_csat_key("nps_day3")
+        assert not is_fix_csat_key(None)
+
+    def test_dismiss_accepts_a_generated_key_but_still_rejects_junk(self):
+        from cqc_lem.utilities.surveys import dismiss_survey
+        with patch(f"{_SURVEYS}.record_survey_prompt", return_value=True) as record:
+            assert dismiss_survey(4, "fix_csat_502") is True
+            assert dismiss_survey(4, "made_up_key") is False
+        record.assert_called_once_with(4, "fix_csat_502")
+
+
+class TestRecordFixCsatResponse:
+    def test_a_yes_is_stored_resolved_so_it_never_burns_a_classification(self):
+        from cqc_lem.utilities.db import FeedbackSource, FeedbackStatus
+        from cqc_lem.utilities.surveys import record_fix_csat_response
+        with patch(f"{_SURVEYS}.insert_feedback", return_value=77) as insert, \
+                patch(f"{_SURVEYS}.update_feedback_triage") as triage, \
+                patch(f"{_SURVEYS}.record_survey_prompt") as record, \
+                patch(f"{_SURVEYS}._track_response") as track:
+            assert record_fix_csat_response(4, 498, True) == 77
+
+        kwargs = insert.call_args.kwargs
+        assert kwargs["source"] == FeedbackSource.CSAT
+        assert kwargs["type_hint"] == "fix_csat"
+        assert kwargs["sentiment"] == "positive"
+        assert kwargs["context"]["issue_number"] == 498
+        assert kwargs["context"]["resolved"] is True
+        assert kwargs["context"]["survey_key"] == "fix_csat_498"
+        triage.assert_called_once_with(77, status=FeedbackStatus.RESOLVED)
+        record.assert_called_once_with(4, "fix_csat_498")
+        assert track.call_args[0][1] == "csat"
+
+    def test_a_no_stays_new_so_it_re_enters_the_auto_work_loop(self):
+        from cqc_lem.utilities.surveys import record_fix_csat_response
+        with patch(f"{_SURVEYS}.insert_feedback", return_value=78) as insert, \
+                patch(f"{_SURVEYS}.update_feedback_triage") as triage, \
+                patch(f"{_SURVEYS}.record_survey_prompt"), \
+                patch(f"{_SURVEYS}._track_response"):
+            assert record_fix_csat_response(4, 498, False, comment="still broken on mobile") == 78
+
+        assert insert.call_args[0][0] == "still broken on mobile"
+        assert insert.call_args.kwargs["sentiment"] == "negative"
+        triage.assert_not_called()
+
+    def test_body_falls_back_to_a_readable_line_when_no_comment_is_given(self):
+        from cqc_lem.utilities.surveys import record_fix_csat_response
+        with patch(f"{_SURVEYS}.insert_feedback", return_value=1) as insert, \
+                patch(f"{_SURVEYS}.update_feedback_triage"), \
+                patch(f"{_SURVEYS}.record_survey_prompt"), \
+                patch(f"{_SURVEYS}._track_response"):
+            record_fix_csat_response(4, 498, False, comment="   ")
+        assert insert.call_args[0][0] == "Still not fixed (issue #498)"
+
+    def test_a_failed_insert_records_no_ask_and_no_event(self):
+        from cqc_lem.utilities.surveys import record_fix_csat_response
+        with patch(f"{_SURVEYS}.insert_feedback", return_value=None), \
+                patch(f"{_SURVEYS}.update_feedback_triage") as triage, \
+                patch(f"{_SURVEYS}.record_survey_prompt") as record, \
+                patch(f"{_SURVEYS}._track_response") as track:
+            assert record_fix_csat_response(4, 498, True) is None
+        triage.assert_not_called()
+        record.assert_not_called()
+        track.assert_not_called()
+
+
+class TestNotifyShippedFix:
+    def test_sends_the_email_and_tracks_it(self):
+        from cqc_lem.utilities.notifications import notify_shipped_fix
+        with patch(f"{_NOTIFY}.get_user_email", return_value="a@b.co"), \
+                patch("cqc_lem.utilities.email.send_shipped_fix_email",
+                      return_value=True) as send, \
+                patch("cqc_lem.utilities.observability.track_shipped_notice") as track:
+            assert notify_shipped_fix(4, "**Fixed:** X (#498)", 498) is True
+        assert send.call_args[0] == ("a@b.co", "**Fixed:** X (#498)", 498)
+        track.assert_called_once_with(4, 498)
+
+    def test_no_email_address_means_no_send(self):
+        from cqc_lem.utilities.notifications import notify_shipped_fix
+        with patch(f"{_NOTIFY}.get_user_email", return_value=None), \
+                patch("cqc_lem.utilities.email.send_shipped_fix_email") as send:
+            assert notify_shipped_fix(4, "line", 498) is False
+        send.assert_not_called()
+
+    def test_a_raising_send_is_swallowed(self):
+        from cqc_lem.utilities.notifications import notify_shipped_fix
+        with patch(f"{_NOTIFY}.get_user_email", return_value="a@b.co"), \
+                patch("cqc_lem.utilities.email.send_shipped_fix_email",
+                      side_effect=RuntimeError("smtp down")):
+            assert notify_shipped_fix(4, "line", 498) is False
+
+
+class TestShippedFixEmail:
+    def test_escapes_the_changelog_line_and_names_the_issue(self):
+        from cqc_lem.utilities.email import send_shipped_fix_email
+        with patch("cqc_lem.utilities.email._dispatch_email", return_value=True) as dispatch:
+            assert send_shipped_fix_email("a@b.co", "**Fixed:** <script>x</script> (#498)",
+                                          498) is True
+        to_email, subject, html = dispatch.call_args[0]
+        assert to_email == "a@b.co"
+        assert "#498" in subject
+        assert "<script>" not in html
+        assert "&lt;script&gt;" in html
+        # The markdown emphasis of the stored line has no meaning in HTML — it is stripped.
+        assert "**" not in html


### PR DESCRIPTION
## What & why

Closes the feedback→auto-work loop (plan §B.4). Capture (#496) → classify (#497) → file (#498) → **ship → tell the people who asked → re-measure**. Until now a fix could land and the users who reported it never heard about it, and satisfaction was never re-measured.

When a PR that says `Closes #<issue>` merges, `auto_changelog_notify`:

1. maps the closing issue back through **feedback → issue → cluster** to its identified reporters (`get_feedback_reporters_for_issue` — matches both rows stamped with the issue and rows that only carry the seed's `cluster_id`; anonymous rows have nobody to tell),
2. generates a **human-readable changelog line** from the PR title (`fix(feed): comments now post reliably (closes #498)` → `**Fixed:** Comments now post reliably (#498, PR #539)`),
3. emails each reporter *once* ("You asked, we shipped: …") and queues the same notice **in-app**,
4. marks that cluster's `feedback` rows `resolved`,
5. **schedules a micro-CSAT** — "did this fix it?" — surfaced in-app only after `FEEDBACK_FIX_CSAT_DELAY_HOURS` (default 24) so the reporter has actually had the fix.

The CSAT answer **re-enters the loop**: a "not fixed" is written as a `feedback` row (`source='csat'`) left at status `new`, so the auto-filer picks it up and re-opens the problem instead of it dying in a dashboard. A "yes" is stored `resolved` immediately (nothing to classify — no LLM call per happy answer). Both emit PostHog (`shipped_notice` / `survey_response`) for the GA satisfaction gate.

**Notified once** is a DB fact, not a timer: `shipped_notice_recipients` has `(notice_id, user_id)` as its PK, *and* the ledger is read **before** sending — the PK alone would stop the duplicate row but not the duplicate email when an overlapping window re-scans the same PR. A recipient row is written only *after* the email actually goes out, so a mail outage retries next pass rather than silently marking someone as told.

## Changes

| Area | Change |
|---|---|
| `utilities/feedback/shipped.py` | New: closing-ref parsing, changelog copy, merged-PR read, per-issue notify, `process_shipped_fixes` |
| `app/run_scheduler.py` + `my_celery.py` | `auto_changelog_notify` (QueueOnce), beat daily **10:00 UTC** — after the 9:45 survey pass so nobody gets two emails in a minute; 48h lookback |
| `utilities/db.py` | `FeedbackSource.CSAT` + 8 shipped-notice/reporter helpers |
| `utilities/surveys.py` | Per-issue `fix_csat_<issue>` key on the existing `survey_prompts` ledger + `record_fix_csat_response` |
| `utilities/email.py` / `notifications.py` / `observability.py` | `send_shipped_fix_email` (escaped), `notify_shipped_fix`, `track_shipped_notice` |
| `api/main.py` | `GET /api/user/shipped`, `POST /api/shipped/ack` (ownership-checked) |
| SPA | `ShippedNotice.tsx` + `useShippedNotices.ts`, wired into `Layout` |
| Migration `V20260725104900` | `shipped_notices`, `shipped_notice_recipients`, additive `'csat'` on `feedback.source` — additive only, no data loss |
| `utilities/feedback/issue_service.py` | `_github_request` → public `github_request` (now shared with this stage) |

## Testing notes

60 new tests; `poetry run pytest tests/unit tests/integration` → **4573 passed, 2 skipped** locally.

- `tests/unit/utilities/test_shipped.py` — closing keywords vs bare `#N` mentions, changelog copy per commit type, lookback/delay env clamps, notify-once, undelivered-notice retry (reported as `error`, not `already_sent`), one exploding issue not aborting the pass.
- `tests/unit/utilities/test_db_shipped.py` — every new query, including the reporter self-join and the delay clamp.
- `tests/unit/utilities/test_surveys_fix_csat.py` — CSAT key shape/ledger, yes→`resolved` / no→`new` routing, email escaping.
- `tests/unit/api/test_shipped_api.py` + `tests/unit/app/test_changelog_notify.py` — endpoints (incl. 401/404 ownership) and the beat entry.
- `tests/integration/test_shipped_notify.py` — a real `process_shipped_fixes` pass over a stateful fake cursor: only the two identified reporters are emailed (not the anonymous row, not an unrelated cluster), a second pass emails nobody, the CSAT is withheld for the delay, and a "not fixed" answer lands back at status `new`.

The UI also passes `tsc -b` and `eslint` clean.

Closes #502

🤖 Generated with [Claude Code](https://claude.com/claude-code)