### PR TITLE
feat(observability): funnel event instrumentation for launch/marketing analytics (closes #503)

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -83,7 +83,11 @@ from cqc_lem.utilities.env_constants import LI_CLIENT_ID, LI_CLIENT_SECRET, LI_R
 import requests
 from cqc_lem.utilities.logger import myprint, log_warning, log_info
 from cqc_lem.utilities.mime_type_helper import get_file_mime_type
-from cqc_lem.utilities.observability import track_api_call
+from cqc_lem.utilities.observability import (
+    track_api_call, track_funnel_event, anonymous_distinct_id,
+    FUNNEL_SIGNUP_STARTED, FUNNEL_SIGNUP_COMPLETED, FUNNEL_TRIAL_STARTED,
+    FUNNEL_SUBSCRIPTION_STARTED, FUNNEL_CHURNED,
+)
 from cqc_lem.utilities.utils import get_file_extension_from_filepath
 from fastapi import FastAPI, HTTPException, Request, status, APIRouter, Header, Depends
 from fastapi import File, Form, Query, UploadFile
@@ -275,13 +279,28 @@ class UserSettingsRequest(BaseModel):
     sitemap_url: Optional[str] = None
 
 
+class FunnelAttribution(BaseModel):
+    """Where a visitor came from, captured client-side on first landing (issue #503). Every field is
+    optional — a direct visit sends none of them."""
+    utm_source: Optional[str] = None
+    utm_medium: Optional[str] = None
+    utm_campaign: Optional[str] = None
+    utm_content: Optional[str] = None
+    utm_term: Optional[str] = None
+    referrer: Optional[str] = None
+    landing_page: Optional[str] = None
+    channel: Optional[str] = None
+
+
 class AuthInitRequest(BaseModel):
     email: str
+    attribution: Optional[FunnelAttribution] = None
 
 
 class AuthVerifyRequest(BaseModel):
     email: str
     pin: str
+    attribution: Optional[FunnelAttribution] = None
 
 
 class LogoutRequest(BaseModel):
@@ -1466,6 +1485,22 @@ def get_assets(file_name: str, content_type: Optional[str] = None,
         return FileResponse(status_code=200, path=file_path, media_type=mim_type, content_disposition_type=content_type)
 
 
+def _attribution_dict(attribution: Optional[FunnelAttribution]) -> dict:
+    return attribution.model_dump(exclude_none=True) if attribution else {}
+
+
+def _track_signup_funnel(user_id: int, email: str, attribution: dict, pin_bypassed: bool) -> None:
+    """`signup_completed` + `trial_started` for an account that was just created. Both are aliased
+    onto the anonymous id `signup_started` used, so the funnel joins end to end in PostHog; the trial
+    starts at the same instant because `add_user_by_email` opens the free trial on insert."""
+    from cqc_lem.utilities.env_constants import FREE_TRIAL_DAYS
+    anon_id = anonymous_distinct_id(email)
+    track_funnel_event(FUNNEL_SIGNUP_COMPLETED, user_id=user_id, attribution=attribution,
+                       alias_from=anon_id, method="email_pin", pin_bypassed=pin_bypassed)
+    track_funnel_event(FUNNEL_TRIAL_STARTED, user_id=user_id, attribution=attribution,
+                       trial_days=FREE_TRIAL_DAYS, tier="free_trial")
+
+
 # LinkedIn OAuth initiation — builds the authorization URL and redirects user to LinkedIn
 @router.post("/auth/email/init")
 def auth_email_init(request: AuthInitRequest) -> ResponseModel:
@@ -1474,6 +1509,11 @@ def auth_email_init(request: AuthInitRequest) -> ResponseModel:
         raise HTTPException(status_code=400, detail="Email is required")
 
     user_exists = bool(get_user_id(email))
+    attribution = _attribution_dict(request.attribution)
+    if not user_exists:
+        # A known email re-authenticating is a login, not a signup — only new emails enter the funnel.
+        track_funnel_event(FUNNEL_SIGNUP_STARTED, distinct_id=anonymous_distinct_id(email),
+                           attribution=attribution, method="email_pin")
     pin = generate_pin()
     pin_hash = hash_pin(pin, email)
 
@@ -1490,6 +1530,8 @@ def auth_email_init(request: AuthInitRequest) -> ResponseModel:
         session_token = create_session(user_id)
         if not session_token:
             raise HTTPException(status_code=500, detail="Could not create session")
+        if is_new_user:
+            _track_signup_funnel(user_id, email, attribution, pin_bypassed=True)
         return ResponseModel(status_code=200, detail={
             "bypass": True,
             "session_token": session_token,
@@ -1532,6 +1574,10 @@ def auth_email_verify(request: AuthVerifyRequest) -> ResponseModel:
     session_token = create_session(user_id)
     if not session_token:
         raise HTTPException(status_code=500, detail="Could not create session")
+
+    if is_new_user:
+        _track_signup_funnel(user_id, email, _attribution_dict(request.attribution),
+                             pin_bypassed=False)
 
     return ResponseModel(
         status_code=200,
@@ -2747,6 +2793,20 @@ def billing_create_portal_session(request: PortalSessionRequest) -> ResponseMode
     return ResponseModel(status_code=200, detail={"portal_url": url})
 
 
+def _track_billing_funnel(event: str, stripe_customer_id: str, **props) -> None:
+    """Funnel event for a Stripe lifecycle webhook. The webhook carries no UTMs — PostHog holds them
+    on the person from the `$set_once` written at signup — so only the plan facts ride along here.
+    The customer→user lookup is guarded: analytics must never fail a billing webhook, because Stripe
+    would retry it and the subscription state is already committed."""
+    try:
+        user = get_user_by_stripe_customer_id(stripe_customer_id) or {}
+        track_funnel_event(event, user_id=user.get("id"),
+                           distinct_id=f"stripe_{stripe_customer_id}",
+                           stripe_customer_id=stripe_customer_id, **props)
+    except Exception as e:
+        log_warning(f"Could not track billing funnel event '{event}'", exc=e)
+
+
 @router.post("/billing/webhook")
 async def billing_webhook(request: Request) -> dict:
     payload = await request.body()
@@ -2796,6 +2856,12 @@ async def billing_webhook(request: Request) -> dict:
         update_subscription_from_stripe(
             stripe_customer_id, db_status, tier, stripe_subscription_id, period_end
         )
+        # Only `created` — `updated` fires on every plan/status change and would double-count.
+        if event_type == "customer.subscription.created":
+            _track_billing_funnel(
+                FUNNEL_SUBSCRIPTION_STARTED, stripe_customer_id, tier=tier, status=db_status,
+                stripe_subscription_id=stripe_subscription_id,
+            )
 
     elif event_type == "customer.subscription.deleted":
         stripe_customer_id = data.get("customer")
@@ -2808,6 +2874,8 @@ async def billing_webhook(request: Request) -> dict:
         update_subscription_from_stripe(
             stripe_customer_id, "cancelled", None, stripe_subscription_id
         )
+        _track_billing_funnel(FUNNEL_CHURNED, stripe_customer_id, reason="subscription_deleted",
+                              stripe_subscription_id=stripe_subscription_id)
 
     # --- Invoice / payment events (fired on every billing cycle renewal) ---
     elif event_type == "invoice.payment_succeeded":

--- a/src/cqc_lem/ui/src/components/LoginModal.tsx
+++ b/src/cqc_lem/ui/src/components/LoginModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useAuth } from '../contexts/AuthContext'
 import api from '../api/client'
+import { getAttribution } from '../utils/attribution'
 
 type Step = 'email' | 'pin'
 
@@ -18,7 +19,10 @@ export default function LoginModal() {
     setError(null)
     setLoading(true)
     try {
-      const r = await api.post('/auth/email/init', { email: email.trim().toLowerCase() })
+      const r = await api.post('/auth/email/init', {
+        email: email.trim().toLowerCase(),
+        attribution: getAttribution(),
+      })
       const detail = r.data.detail
 
       if (detail.bypass) {
@@ -42,7 +46,7 @@ export default function LoginModal() {
     setError(null)
     setLoading(true)
     try {
-      const r = await api.post('/auth/email/verify', { email, pin })
+      const r = await api.post('/auth/email/verify', { email, pin, attribution: getAttribution() })
       const { session_token, email: verifiedEmail } = r.data.detail
       login(session_token, verifiedEmail)
     } catch (err: unknown) {

--- a/src/cqc_lem/ui/src/main.tsx
+++ b/src/cqc_lem/ui/src/main.tsx
@@ -2,6 +2,10 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { captureAttribution } from './utils/attribution'
+
+// Before the router can rewrite the URL — the landing UTMs are only there on the first paint.
+captureAttribution()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/cqc_lem/ui/src/utils/attribution.ts
+++ b/src/cqc_lem/ui/src/utils/attribution.ts
@@ -1,0 +1,53 @@
+// First-touch attribution for the launch funnel (issue #503). The UTMs are on the URL of the very
+// first page a visitor lands on, but signup happens later and possibly after several navigations —
+// so capture once into sessionStorage and replay it with the auth calls. First touch wins: a later
+// tagged link inside the same session must not overwrite the one that actually acquired the visit.
+
+export type Attribution = {
+  utm_source?: string
+  utm_medium?: string
+  utm_campaign?: string
+  utm_content?: string
+  utm_term?: string
+  referrer?: string
+  landing_page?: string
+}
+
+const STORAGE_KEY = 'lem_attribution'
+const UTM_KEYS = ['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'] as const
+
+function readStored(): Attribution | null {
+  try {
+    const raw = window.sessionStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as Attribution) : null
+  } catch {
+    return null
+  }
+}
+
+// Call once on app load, before the visitor can navigate away from the landing URL.
+export function captureAttribution(): Attribution {
+  const existing = readStored()
+  if (existing) return existing
+
+  const attribution: Attribution = {}
+  try {
+    const params = new URLSearchParams(window.location.search)
+    for (const key of UTM_KEYS) {
+      const value = params.get(key)?.trim()
+      if (value) attribution[key] = value
+    }
+    // An internal referrer tells us nothing about acquisition.
+    const referrer = document.referrer
+    if (referrer && !referrer.startsWith(window.location.origin)) attribution.referrer = referrer
+    attribution.landing_page = window.location.pathname
+    window.sessionStorage.setItem(STORAGE_KEY, JSON.stringify(attribution))
+  } catch {
+    // Private mode / storage disabled — the funnel event just lands in the "direct" bucket.
+  }
+  return attribution
+}
+
+export function getAttribution(): Attribution {
+  return readStored() ?? {}
+}

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -434,6 +434,18 @@ CHANNEL_PAID = "paid"
 CHANNEL_DIRECT = "direct"
 CHANNEL_OTHER = "other"
 
+CHANNELS = (
+    CHANNEL_LINKEDIN,
+    CHANNEL_NEWSLETTER,
+    CHANNEL_SEO,
+    CHANNEL_EMAIL,
+    CHANNEL_REFERRAL,
+    CHANNEL_AFFILIATE,
+    CHANNEL_PAID,
+    CHANNEL_DIRECT,
+    CHANNEL_OTHER,
+)
+
 # Client-supplied attribution is allow-listed: a funnel event's schema is ours, not the caller's.
 _ATTRIBUTION_KEYS = (
     "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
@@ -489,13 +501,16 @@ def _referrer_host(referrer) -> Optional[str]:
 
 def resolve_channel(attribution: Optional[dict]) -> str:
     """The acquisition channel a visit came from, derived from UTMs then the referrer. An explicit
-    `channel` always wins (a link we built already knows); paid mediums are checked before source so
-    `utm_source=google&utm_medium=cpc` is paid spend, not SEO. Anything with UTMs we don't recognise
-    is `other` rather than `direct` — a tagged visit was never direct."""
+    `channel` always wins (a link we built already knows) but only when it names one of `CHANNELS` —
+    a typo or an unknown value becomes `other` rather than a new bucket the CAC rollup can't group.
+    Paid mediums are checked before source so `utm_source=google&utm_medium=cpc` is paid spend, not
+    SEO. Anything with UTMs we don't recognise is `other` rather than `direct` — a tagged visit was
+    never direct."""
     data = attribution if isinstance(attribution, dict) else {}
     explicit = _clean_property(data.get("channel"))
     if explicit:
-        return explicit.lower()
+        normalized = explicit.lower()
+        return normalized if normalized in CHANNELS else CHANNEL_OTHER
 
     source = (_clean_property(data.get("utm_source")) or "").lower()
     medium = (_clean_property(data.get("utm_medium")) or "").lower()
@@ -566,7 +581,7 @@ def track_funnel_event(
             # Emit anyway — losing the event is worse than an extra name — but make the typo visible.
             log_warning(f"Unknown funnel event '{event}' — emitting anyway")
         attribution_props = normalize_attribution(attribution)
-        resolved_id = str(user_id) if user_id else (distinct_id or "anonymous")
+        resolved_id = str(user_id) if user_id is not None else (distinct_id or "anonymous")
         if alias_from and alias_from != resolved_id:
             posthog.alias(previous_id=alias_from, distinct_id=resolved_id)
         posthog.capture(

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -1,4 +1,5 @@
 import contextvars
+import hashlib
 import inspect
 import json
 import os
@@ -6,6 +7,7 @@ import time
 from contextlib import contextmanager
 from functools import wraps
 from typing import Iterator, Optional, Tuple
+from urllib.parse import urlparse
 
 import posthog
 
@@ -397,6 +399,188 @@ def track_survey_response(user_id: int, source: str, **extra) -> None:
         event="survey_response",
         properties={"source": source, **extra},
     )
+
+
+# --- Launch funnel (issue #503, docs/launch-and-marketing-plan.md §C.5 / §D.1) -------------------
+# Keep these event names STABLE — the PostHog funnel insights, the WARU north-star tile and the
+# per-channel CAC rollup all key off these exact strings.
+FUNNEL_SIGNUP_STARTED = "signup_started"
+FUNNEL_SIGNUP_COMPLETED = "signup_completed"
+FUNNEL_TRIAL_STARTED = "trial_started"
+FUNNEL_ONBOARDING_STEP_COMPLETED = "onboarding_step_completed"
+FUNNEL_ACTIVATED = "activated"
+FUNNEL_SUBSCRIPTION_STARTED = "subscription_started"
+FUNNEL_CHURNED = "churned"
+
+FUNNEL_EVENTS = (
+    FUNNEL_SIGNUP_STARTED,
+    FUNNEL_SIGNUP_COMPLETED,
+    FUNNEL_TRIAL_STARTED,
+    FUNNEL_ONBOARDING_STEP_COMPLETED,
+    FUNNEL_ACTIVATED,
+    FUNNEL_SUBSCRIPTION_STARTED,
+    FUNNEL_CHURNED,
+)
+
+# The acquisition channels every trial is attributed to (plan §C.5). Stable vocabulary — breakdowns
+# and CAC-per-channel are grouped on these values.
+CHANNEL_LINKEDIN = "linkedin"
+CHANNEL_NEWSLETTER = "newsletter"
+CHANNEL_SEO = "seo"
+CHANNEL_EMAIL = "email"
+CHANNEL_REFERRAL = "referral"
+CHANNEL_AFFILIATE = "affiliate"
+CHANNEL_PAID = "paid"
+CHANNEL_DIRECT = "direct"
+CHANNEL_OTHER = "other"
+
+# Client-supplied attribution is allow-listed: a funnel event's schema is ours, not the caller's.
+_ATTRIBUTION_KEYS = (
+    "utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term",
+    "referrer", "landing_page",
+)
+_ATTRIBUTION_MAX_LEN = 255
+
+# First match wins, so order encodes precedence: a `linkedin_newsletter` source is newsletter work,
+# not generic brand-LinkedIn traffic — hence the newsletter needles come before "linkedin".
+_SOURCE_CHANNEL_RULES = (
+    ("newsletter", CHANNEL_NEWSLETTER),
+    ("substack", CHANNEL_NEWSLETTER),
+    ("beehiiv", CHANNEL_NEWSLETTER),
+    ("affiliate", CHANNEL_AFFILIATE),
+    ("partner", CHANNEL_AFFILIATE),
+    ("linkedin", CHANNEL_LINKEDIN),
+    ("google", CHANNEL_SEO),
+    ("bing", CHANNEL_SEO),
+    ("duckduckgo", CHANNEL_SEO),
+    ("referral", CHANNEL_REFERRAL),
+)
+_MEDIUM_CHANNEL_RULES = (
+    ("affiliate", CHANNEL_AFFILIATE),
+    ("newsletter", CHANNEL_NEWSLETTER),
+    ("referral", CHANNEL_REFERRAL),
+    ("email", CHANNEL_EMAIL),
+    ("organic", CHANNEL_SEO),
+    ("seo", CHANNEL_SEO),
+    ("social", CHANNEL_LINKEDIN),
+)
+_PAID_MEDIUM_NEEDLES = ("cpc", "ppc", "paid")
+
+
+def _clean_property(value) -> Optional[str]:
+    """A trimmed string for a client-supplied property, or None when it carries no signal."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text[:_ATTRIBUTION_MAX_LEN] if text else None
+
+
+def _referrer_host(referrer) -> Optional[str]:
+    """The bare host a referrer came from, or None when there's no referrer to read."""
+    text = _clean_property(referrer)
+    if not text:
+        return None
+    try:
+        host = (urlparse(text).netloc or text).lower()
+    except ValueError:
+        host = text.lower()   # malformed URL (e.g. an unterminated IPv6 host) — match on the raw value
+    return host[4:] if host.startswith("www.") else host
+
+
+def resolve_channel(attribution: Optional[dict]) -> str:
+    """The acquisition channel a visit came from, derived from UTMs then the referrer. An explicit
+    `channel` always wins (a link we built already knows); paid mediums are checked before source so
+    `utm_source=google&utm_medium=cpc` is paid spend, not SEO. Anything with UTMs we don't recognise
+    is `other` rather than `direct` — a tagged visit was never direct."""
+    data = attribution if isinstance(attribution, dict) else {}
+    explicit = _clean_property(data.get("channel"))
+    if explicit:
+        return explicit.lower()
+
+    source = (_clean_property(data.get("utm_source")) or "").lower()
+    medium = (_clean_property(data.get("utm_medium")) or "").lower()
+    if any(needle in medium for needle in _PAID_MEDIUM_NEEDLES):
+        return CHANNEL_PAID
+    for needle, channel in _SOURCE_CHANNEL_RULES:
+        if needle in source:
+            return channel
+    for needle, channel in _MEDIUM_CHANNEL_RULES:
+        if needle in medium:
+            return channel
+    if source or medium or _clean_property(data.get("utm_campaign")):
+        return CHANNEL_OTHER
+
+    host = _referrer_host(data.get("referrer"))
+    if host:
+        for needle, channel in _SOURCE_CHANNEL_RULES:
+            if needle in host:
+                return channel
+        return CHANNEL_REFERRAL
+    return CHANNEL_DIRECT
+
+
+def normalize_attribution(attribution: Optional[dict]) -> dict:
+    """The allow-listed source/UTM properties for a funnel event plus the derived `channel`. Unknown
+    keys are dropped so a client can't widen the event schema, and `channel` is always present so a
+    PostHog breakdown never has an ungrouped bucket."""
+    data = attribution if isinstance(attribution, dict) else {}
+    props = {}
+    for key in _ATTRIBUTION_KEYS:
+        value = _clean_property(data.get(key))
+        if value:
+            props[key] = value
+    props["channel"] = resolve_channel(data)
+    return props
+
+
+def anonymous_distinct_id(email: str) -> str:
+    """Stable pseudonymous distinct_id for a visitor who has no user row yet, so `signup_started`
+    can be aliased onto the real user id once the account exists. The email is hashed — the funnel
+    needs a stable key, not the address itself."""
+    normalized = (email or "").strip().lower()
+    if not normalized:
+        return "anonymous"
+    return "anon_" + hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:32]
+
+
+def track_funnel_event(
+    event: str,
+    user_id: Optional[int] = None,
+    distinct_id: Optional[str] = None,
+    attribution: Optional[dict] = None,
+    alias_from: Optional[str] = None,
+    **extra,
+) -> None:
+    """Emit one acquisition → activation → monetization funnel event (plan §C.5) with its source/UTM
+    and `channel` properties.
+
+    First-touch attribution is ALSO written onto the PostHog person via `$set_once`, so the later
+    events that cannot know the UTMs — `subscription_started` from a Stripe webhook, `churned` — stay
+    attributable to the channel that brought the user in. `alias_from` merges the pre-signup
+    anonymous person into the identified one so the funnel joins end to end.
+
+    Never raises: analytics must not fail a signup or a billing webhook."""
+    from cqc_lem.utilities.logger import log_warning
+    try:
+        if event not in FUNNEL_EVENTS:
+            # Emit anyway — losing the event is worse than an extra name — but make the typo visible.
+            log_warning(f"Unknown funnel event '{event}' — emitting anyway")
+        attribution_props = normalize_attribution(attribution)
+        resolved_id = str(user_id) if user_id else (distinct_id or "anonymous")
+        if alias_from and alias_from != resolved_id:
+            posthog.alias(previous_id=alias_from, distinct_id=resolved_id)
+        posthog.capture(
+            distinct_id=resolved_id,
+            event=event,
+            properties={
+                **attribution_props,
+                "user_id": user_id,
+                "$set_once": {f"initial_{key}": value for key, value in attribution_props.items()},
+                **extra,
+            },
+        )
+    except Exception as e:
+        log_warning(f"Could not track funnel event '{event}'", exc=e, user_id=user_id)
 
 
 def track_task(

--- a/src/cqc_lem/utilities/onboarding.py
+++ b/src/cqc_lem/utilities/onboarding.py
@@ -142,11 +142,20 @@ def sync_onboarding_state(user_id: int) -> dict:
 def _track_step(user_id: int, step: "OnboardingStep", started_at: Optional[datetime]) -> None:
     """Emit the activation-funnel event. Never fatal — analytics must not break onboarding."""
     try:
-        from cqc_lem.utilities.observability import track_onboarding_step
+        from cqc_lem.utilities.observability import (
+            track_onboarding_step, track_funnel_event,
+            FUNNEL_ONBOARDING_STEP_COMPLETED, FUNNEL_ACTIVATED,
+        )
         hours = None
         if started_at:
             hours = round(max(0.0, (datetime.now() - started_at).total_seconds() / 3600.0), 2)
         track_onboarding_step(user_id, str(step), hours_since_start=hours)
+        # Same completion, second event: the checklist funnel (issue #503) is queried across signup
+        # → activation, so it needs one stable event name for every step rather than per-step names.
+        track_funnel_event(FUNNEL_ONBOARDING_STEP_COMPLETED, user_id=user_id, step=str(step),
+                           hours_since_start=hours)
+        if step == OnboardingStep.ACTIVATED:
+            track_funnel_event(FUNNEL_ACTIVATED, user_id=user_id, hours_since_start=hours)
         log_info(f"Onboarding step completed: {step}", user_id=user_id)
     except Exception as e:
         log_warning("Could not track onboarding step", exc=e, user_id=user_id)

--- a/tests/unit/api/test_funnel_events_api.py
+++ b/tests/unit/api/test_funnel_events_api.py
@@ -1,0 +1,187 @@
+"""Funnel-event emission from the signup and billing endpoints (issue #503)."""
+
+import pytest
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+pytestmark = pytest.mark.unit
+
+_MAIN = "cqc_lem.api.main"
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+ATTRIBUTION = {"utm_source": "linkedin", "utm_medium": "social", "utm_campaign": "beta",
+               "landing_page": "/"}
+
+
+def _events(mock_track) -> list:
+    return [c.args[0] for c in mock_track.call_args_list]
+
+
+class TestSignupFunnel:
+    INIT = "/api/auth/email/init"
+    VERIFY = "/api/auth/email/verify"
+
+    def test_new_email_starts_the_funnel_with_its_attribution(self, client):
+        with patch(f"{_MAIN}.get_user_id", return_value=None), \
+             patch(f"{_MAIN}.generate_pin", return_value="123456"), \
+             patch(f"{_MAIN}.hash_pin", return_value="hashed"), \
+             patch(f"{_MAIN}.send_pin_email", return_value=(True, False)), \
+             patch(f"{_MAIN}.create_pin_for_email", return_value=True), \
+             patch(f"{_MAIN}.track_funnel_event") as track:
+            resp = client.post(self.INIT, json={"email": "New@Example.com",
+                                                "attribution": ATTRIBUTION})
+
+        assert resp.status_code == 200
+        assert _events(track) == ["signup_started"]
+        kwargs = track.call_args.kwargs
+        assert kwargs["attribution"]["utm_source"] == "linkedin"
+        assert kwargs["attribution"]["landing_page"] == "/"
+        # Pre-signup there is no user row, so the event is keyed to a pseudonymous id.
+        assert kwargs["distinct_id"].startswith("anon_")
+
+    def test_known_email_is_a_login_not_a_signup(self, client):
+        with patch(f"{_MAIN}.get_user_id", return_value=5), \
+             patch(f"{_MAIN}.generate_pin", return_value="123456"), \
+             patch(f"{_MAIN}.hash_pin", return_value="hashed"), \
+             patch(f"{_MAIN}.send_pin_email", return_value=(True, False)), \
+             patch(f"{_MAIN}.create_pin_for_email", return_value=True), \
+             patch(f"{_MAIN}.track_funnel_event") as track:
+            resp = client.post(self.INIT, json={"email": "known@example.com"})
+
+        assert resp.status_code == 200
+        assert track.call_count == 0
+
+    def test_attribution_is_optional(self, client):
+        with patch(f"{_MAIN}.get_user_id", return_value=None), \
+             patch(f"{_MAIN}.generate_pin", return_value="123456"), \
+             patch(f"{_MAIN}.hash_pin", return_value="hashed"), \
+             patch(f"{_MAIN}.send_pin_email", return_value=(True, False)), \
+             patch(f"{_MAIN}.create_pin_for_email", return_value=True), \
+             patch(f"{_MAIN}.track_funnel_event") as track:
+            resp = client.post(self.INIT, json={"email": "bare@example.com"})
+
+        assert resp.status_code == 200
+        assert track.call_args.kwargs["attribution"] == {}
+
+    def test_bypass_signup_completes_and_starts_the_trial(self, client):
+        with patch(f"{_MAIN}.get_user_id", return_value=None), \
+             patch(f"{_MAIN}.generate_pin", return_value="123456"), \
+             patch(f"{_MAIN}.hash_pin", return_value="hashed"), \
+             patch(f"{_MAIN}.send_pin_email", return_value=(True, True)), \
+             patch(f"{_MAIN}.add_user_by_email", return_value=99), \
+             patch(f"{_MAIN}.create_session", return_value="tok"), \
+             patch(f"{_MAIN}.track_funnel_event") as track:
+            resp = client.post(self.INIT, json={"email": "bypass@example.com",
+                                                "attribution": ATTRIBUTION})
+
+        assert resp.status_code == 200
+        assert _events(track) == ["signup_started", "signup_completed", "trial_started"]
+        completed = track.call_args_list[1].kwargs
+        assert completed["user_id"] == 99
+        assert completed["pin_bypassed"] is True
+        # The anonymous signup_started person is merged into the real user.
+        assert completed["alias_from"] == track.call_args_list[0].kwargs["distinct_id"]
+        assert track.call_args_list[2].kwargs["trial_days"] > 0
+
+    def test_verify_completes_the_funnel_for_a_new_user(self, client):
+        with patch(f"{_MAIN}.hash_pin", return_value="hashed"), \
+             patch(f"{_MAIN}.verify_pin_for_email", return_value=True), \
+             patch(f"{_MAIN}.get_user_id", return_value=None), \
+             patch(f"{_MAIN}.add_user_by_email", return_value=12), \
+             patch(f"{_MAIN}.create_session", return_value="tok"), \
+             patch(f"{_MAIN}.track_funnel_event") as track:
+            resp = client.post(self.VERIFY, json={"email": "verify@example.com", "pin": "123456",
+                                                  "attribution": ATTRIBUTION})
+
+        assert resp.status_code == 200
+        assert _events(track) == ["signup_completed", "trial_started"]
+        assert track.call_args_list[0].kwargs["pin_bypassed"] is False
+        assert track.call_args_list[1].kwargs["attribution"]["utm_campaign"] == "beta"
+
+    def test_verify_emits_nothing_for_a_returning_user(self, client):
+        with patch(f"{_MAIN}.hash_pin", return_value="hashed"), \
+             patch(f"{_MAIN}.verify_pin_for_email", return_value=True), \
+             patch(f"{_MAIN}.get_user_id", return_value=8), \
+             patch(f"{_MAIN}.create_session", return_value="tok"), \
+             patch(f"{_MAIN}.track_funnel_event") as track:
+            resp = client.post(self.VERIFY, json={"email": "back@example.com", "pin": "123456"})
+
+        assert resp.status_code == 200
+        assert track.call_count == 0
+
+
+class TestBillingFunnel:
+    BASE = "/api/billing/webhook"
+
+    def _post(self, client, event: dict):
+        with patch("cqc_lem.utilities.stripe_util.validate_webhook", return_value=event), \
+             patch("cqc_lem.utilities.stripe_util.get_subscription_tier_from_price",
+                   return_value="starter"), \
+             patch("cqc_lem.utilities.stripe_util.stripe_status_to_db", return_value="active"), \
+             patch(f"{_MAIN}.update_subscription_from_stripe"), \
+             patch(f"{_MAIN}.get_user_by_stripe_customer_id", return_value={"id": 4}), \
+             patch(f"{_MAIN}.track_funnel_event") as track:
+            resp = client.post(self.BASE, content=b"{}",
+                               headers={"Stripe-Signature": "sig",
+                                        "Content-Type": "application/json"})
+        return resp, track
+
+    def test_subscription_created_emits_subscription_started(self, client):
+        resp, track = self._post(client, {"type": "customer.subscription.created", "data": {
+            "object": {"customer": "cus_a", "id": "sub_1", "status": "active",
+                       "items": {"data": [{"price": {"id": "price_starter"}}]}}}})
+        assert resp.status_code == 200
+        assert _events(track) == ["subscription_started"]
+        kwargs = track.call_args.kwargs
+        assert kwargs["user_id"] == 4
+        assert kwargs["tier"] == "starter"
+        assert kwargs["stripe_customer_id"] == "cus_a"
+
+    def test_subscription_updated_does_not_double_count(self, client):
+        resp, track = self._post(client, {"type": "customer.subscription.updated", "data": {
+            "object": {"customer": "cus_a", "id": "sub_1", "status": "active",
+                       "items": {"data": [{"price": {"id": "price_starter"}}]}}}})
+        assert resp.status_code == 200
+        assert track.call_count == 0
+
+    def test_subscription_deleted_emits_churned(self, client):
+        resp, track = self._post(client, {"type": "customer.subscription.deleted", "data": {
+            "object": {"customer": "cus_b", "id": "sub_2"}}})
+        assert resp.status_code == 200
+        assert _events(track) == ["churned"]
+        assert track.call_args.kwargs["reason"] == "subscription_deleted"
+
+    def test_a_failed_lookup_never_fails_the_webhook(self, client):
+        event = {"type": "customer.subscription.deleted",
+                 "data": {"object": {"customer": "cus_c", "id": "sub_3"}}}
+        with patch("cqc_lem.utilities.stripe_util.validate_webhook", return_value=event), \
+             patch(f"{_MAIN}.update_subscription_from_stripe"), \
+             patch(f"{_MAIN}.get_user_by_stripe_customer_id",
+                   side_effect=RuntimeError("db down")), \
+             patch(f"{_MAIN}.track_funnel_event") as track:
+            resp = client.post(self.BASE, content=b"{}",
+                               headers={"Stripe-Signature": "sig",
+                                        "Content-Type": "application/json"})
+        assert resp.status_code == 200
+        assert resp.json() == {"received": True}
+        assert track.call_count == 0

--- a/tests/unit/utilities/test_observability_funnel.py
+++ b/tests/unit/utilities/test_observability_funnel.py
@@ -1,0 +1,175 @@
+"""Unit tests for the launch-funnel tracker in cqc_lem.utilities.observability (issue #503)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.observability"
+
+
+class TestResolveChannel:
+    def test_explicit_channel_wins_and_is_lowercased(self):
+        from cqc_lem.utilities.observability import resolve_channel
+        assert resolve_channel({"channel": "Affiliate", "utm_source": "linkedin"}) == "affiliate"
+
+    def test_paid_medium_beats_a_search_engine_source(self):
+        from cqc_lem.utilities.observability import resolve_channel, CHANNEL_PAID
+        assert resolve_channel({"utm_source": "google", "utm_medium": "cpc"}) == CHANNEL_PAID
+
+    @pytest.mark.parametrize("source,expected", [
+        ("linkedin", "linkedin"),
+        ("lem-newsletter", "newsletter"),
+        ("substack", "newsletter"),
+        ("google", "seo"),
+        ("bing", "seo"),
+        ("partner-xyz", "affiliate"),
+    ])
+    def test_source_rules(self, source, expected):
+        from cqc_lem.utilities.observability import resolve_channel
+        assert resolve_channel({"utm_source": source}) == expected
+
+    @pytest.mark.parametrize("medium,expected", [
+        ("email", "email"),
+        ("newsletter", "newsletter"),
+        ("referral", "referral"),
+        ("organic", "seo"),
+        ("social", "linkedin"),
+        ("affiliate", "affiliate"),
+    ])
+    def test_medium_rules(self, medium, expected):
+        from cqc_lem.utilities.observability import resolve_channel
+        assert resolve_channel({"utm_medium": medium}) == expected
+
+    def test_unrecognised_utms_are_other_not_direct(self):
+        from cqc_lem.utilities.observability import resolve_channel, CHANNEL_OTHER
+        assert resolve_channel({"utm_source": "some-podcast"}) == CHANNEL_OTHER
+
+    def test_referrer_host_is_the_fallback(self):
+        from cqc_lem.utilities.observability import resolve_channel
+        assert resolve_channel({"referrer": "https://www.linkedin.com/feed/"}) == "linkedin"
+
+    def test_unknown_referrer_is_a_referral(self):
+        from cqc_lem.utilities.observability import resolve_channel, CHANNEL_REFERRAL
+        assert resolve_channel({"referrer": "https://news.ycombinator.com/"}) == CHANNEL_REFERRAL
+
+    def test_unparseable_referrer_still_resolves(self):
+        from cqc_lem.utilities.observability import resolve_channel, CHANNEL_REFERRAL
+        # urlparse raises on a malformed IPv6 URL — the channel must not blow up with it.
+        assert resolve_channel({"referrer": "http://["}) == CHANNEL_REFERRAL
+
+    def test_no_signal_is_direct(self):
+        from cqc_lem.utilities.observability import resolve_channel, CHANNEL_DIRECT
+        assert resolve_channel({}) == CHANNEL_DIRECT
+        assert resolve_channel(None) == CHANNEL_DIRECT
+        assert resolve_channel("not-a-dict") == CHANNEL_DIRECT
+
+
+class TestNormalizeAttribution:
+    def test_keeps_allowlisted_keys_and_derives_channel(self):
+        from cqc_lem.utilities.observability import normalize_attribution
+        props = normalize_attribution({
+            "utm_source": " linkedin ", "utm_campaign": "launch",
+            "landing_page": "/", "evil": "drop me", "utm_medium": "",
+        })
+        assert props == {"utm_source": "linkedin", "utm_campaign": "launch",
+                         "landing_page": "/", "channel": "linkedin"}
+
+    def test_channel_is_always_present(self):
+        from cqc_lem.utilities.observability import normalize_attribution, CHANNEL_DIRECT
+        assert normalize_attribution(None) == {"channel": CHANNEL_DIRECT}
+
+    def test_long_values_are_truncated(self):
+        from cqc_lem.utilities.observability import normalize_attribution, _ATTRIBUTION_MAX_LEN
+        props = normalize_attribution({"utm_campaign": "x" * 500})
+        assert len(props["utm_campaign"]) == _ATTRIBUTION_MAX_LEN
+
+
+class TestAnonymousDistinctId:
+    def test_is_stable_and_case_insensitive(self):
+        from cqc_lem.utilities.observability import anonymous_distinct_id
+        assert anonymous_distinct_id("A@b.com") == anonymous_distinct_id(" a@b.com ")
+
+    def test_does_not_contain_the_email(self):
+        from cqc_lem.utilities.observability import anonymous_distinct_id
+        anon = anonymous_distinct_id("someone@example.com")
+        assert anon.startswith("anon_") and "someone" not in anon
+
+    def test_blank_email_falls_back_to_anonymous(self):
+        from cqc_lem.utilities.observability import anonymous_distinct_id
+        assert anonymous_distinct_id("") == "anonymous"
+
+
+class TestTrackFunnelEvent:
+    def test_captures_event_with_channel_and_extras(self):
+        from cqc_lem.utilities.observability import track_funnel_event, FUNNEL_TRIAL_STARTED
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            track_funnel_event(FUNNEL_TRIAL_STARTED, user_id=7,
+                               attribution={"utm_source": "linkedin", "utm_medium": "social"},
+                               trial_days=14)
+
+        _, kwargs = mock_ph.capture.call_args
+        assert kwargs["distinct_id"] == "7"
+        assert kwargs["event"] == "trial_started"
+        props = kwargs["properties"]
+        assert props["channel"] == "linkedin"
+        assert props["utm_source"] == "linkedin"
+        assert props["user_id"] == 7
+        assert props["trial_days"] == 14
+
+    def test_sets_first_touch_person_properties_once(self):
+        from cqc_lem.utilities.observability import track_funnel_event, FUNNEL_SIGNUP_COMPLETED
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            track_funnel_event(FUNNEL_SIGNUP_COMPLETED, user_id=3,
+                               attribution={"utm_campaign": "beta"})
+
+        set_once = mock_ph.capture.call_args.kwargs["properties"]["$set_once"]
+        assert set_once == {"initial_utm_campaign": "beta", "initial_channel": "other"}
+
+    def test_anonymous_distinct_id_is_used_when_there_is_no_user(self):
+        from cqc_lem.utilities.observability import track_funnel_event, FUNNEL_SIGNUP_STARTED
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            track_funnel_event(FUNNEL_SIGNUP_STARTED, distinct_id="anon_abc")
+
+        assert mock_ph.capture.call_args.kwargs["distinct_id"] == "anon_abc"
+        assert mock_ph.alias.called is False
+
+    def test_falls_back_to_the_anonymous_bucket(self):
+        from cqc_lem.utilities.observability import track_funnel_event, FUNNEL_SIGNUP_STARTED
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            track_funnel_event(FUNNEL_SIGNUP_STARTED)
+
+        assert mock_ph.capture.call_args.kwargs["distinct_id"] == "anonymous"
+
+    def test_alias_merges_the_pre_signup_person(self):
+        from cqc_lem.utilities.observability import track_funnel_event, FUNNEL_SIGNUP_COMPLETED
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            track_funnel_event(FUNNEL_SIGNUP_COMPLETED, user_id=9, alias_from="anon_abc")
+
+        mock_ph.alias.assert_called_once_with(previous_id="anon_abc", distinct_id="9")
+
+    def test_alias_is_skipped_when_it_would_be_a_self_alias(self):
+        from cqc_lem.utilities.observability import track_funnel_event, FUNNEL_SIGNUP_STARTED
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            track_funnel_event(FUNNEL_SIGNUP_STARTED, distinct_id="anon_abc",
+                               alias_from="anon_abc")
+
+        assert mock_ph.alias.called is False
+
+    def test_unknown_event_warns_but_still_emits(self):
+        from cqc_lem.utilities.observability import track_funnel_event
+        with patch(f"{_MOD}.posthog") as mock_ph, \
+             patch("cqc_lem.utilities.logger.log_warning") as warn:
+            track_funnel_event("signup_startd", user_id=1)
+
+        assert warn.called
+        assert mock_ph.capture.call_args.kwargs["event"] == "signup_startd"
+
+    def test_never_raises_when_posthog_fails(self):
+        from cqc_lem.utilities.observability import track_funnel_event, FUNNEL_CHURNED
+        with patch(f"{_MOD}.posthog") as mock_ph, \
+             patch("cqc_lem.utilities.logger.log_warning") as warn:
+            mock_ph.capture.side_effect = RuntimeError("posthog down")
+            track_funnel_event(FUNNEL_CHURNED, user_id=1)
+
+        assert warn.called

--- a/tests/unit/utilities/test_observability_funnel.py
+++ b/tests/unit/utilities/test_observability_funnel.py
@@ -13,6 +13,12 @@ class TestResolveChannel:
         from cqc_lem.utilities.observability import resolve_channel
         assert resolve_channel({"channel": "Affiliate", "utm_source": "linkedin"}) == "affiliate"
 
+    def test_unknown_explicit_channel_falls_back_to_other(self):
+        from cqc_lem.utilities.observability import resolve_channel, CHANNEL_OTHER
+        # A typo or an invented value must not open a new bucket the CAC breakdown can't group.
+        assert resolve_channel({"channel": "linkdin"}) == CHANNEL_OTHER
+        assert resolve_channel({"channel": "tiktok", "utm_source": "google"}) == CHANNEL_OTHER
+
     def test_paid_medium_beats_a_search_engine_source(self):
         from cqc_lem.utilities.observability import resolve_channel, CHANNEL_PAID
         assert resolve_channel({"utm_source": "google", "utm_medium": "cpc"}) == CHANNEL_PAID
@@ -140,6 +146,13 @@ class TestTrackFunnelEvent:
             track_funnel_event(FUNNEL_SIGNUP_STARTED)
 
         assert mock_ph.capture.call_args.kwargs["distinct_id"] == "anonymous"
+
+    def test_user_id_zero_still_keys_to_the_user(self):
+        from cqc_lem.utilities.observability import track_funnel_event, FUNNEL_ACTIVATED
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            track_funnel_event(FUNNEL_ACTIVATED, user_id=0, distinct_id="anon_abc")
+
+        assert mock_ph.capture.call_args.kwargs["distinct_id"] == "0"
 
     def test_alias_merges_the_pre_signup_person(self):
         from cqc_lem.utilities.observability import track_funnel_event, FUNNEL_SIGNUP_COMPLETED

--- a/tests/unit/utilities/test_onboarding.py
+++ b/tests/unit/utilities/test_onboarding.py
@@ -172,6 +172,25 @@ class TestSyncOnboardingState:
         assert marked == [OnboardingStep.VOICE_SET, OnboardingStep.CAPS_ENABLED]
         assert track.call_count == 2
 
+    def test_each_step_also_emits_the_funnel_event_and_activation(self):
+        from cqc_lem.utilities.db import OnboardingStep
+        state = {"started_at": NOW - timedelta(hours=5)}
+        with patch(f"{_ON}.ensure_onboarding_state", return_value=True), \
+             patch(f"{_ON}.get_onboarding_state", return_value=state), \
+             patch(f"{_ON}.evaluate_steps", return_value={
+                 OnboardingStep.LINKEDIN_CONNECTED: True, OnboardingStep.ACTIVATED: True}), \
+             patch(f"{_ON}.mark_onboarding_step", return_value=True), \
+             patch("cqc_lem.utilities.observability.track_onboarding_step"), \
+             patch("cqc_lem.utilities.observability.track_funnel_event") as funnel:
+            from cqc_lem.utilities.onboarding import sync_onboarding_state
+            sync_onboarding_state(7)
+
+        events = [c.args[0] for c in funnel.call_args_list]
+        # One step event per completed step, plus the dedicated `activated` milestone.
+        assert events == ["onboarding_step_completed", "onboarding_step_completed", "activated"]
+        assert funnel.call_args_list[0].kwargs["step"] == str(OnboardingStep.LINKEDIN_CONNECTED)
+        assert funnel.call_args_list[-1].kwargs["user_id"] == 7
+
     def test_tracking_failure_does_not_break_the_sync(self):
         from cqc_lem.utilities.db import OnboardingStep
         with patch(f"{_ON}.ensure_onboarding_state", return_value=True), \


### PR DESCRIPTION
## What & why

Attribution, the GA gate and the optimization loop all need the acquisition→activation→monetization funnel in PostHog (docs/launch-and-marketing-plan.md §C.5 / §D.1). Until now only `llm_call` / `celery_task` / `api_call` were tracked, so there was no way to ask "how many trials did the newsletter bring, and how many activated".

Adds `track_funnel_event` to `utilities/observability.py` and emits all seven plan events from the paths that actually cause them:

| Event | Emit point |
|---|---|
| `signup_started` | `POST /auth/email/init`, only for an email we've never seen (a known email re-authenticating is a login, not a signup) |
| `signup_completed` + `trial_started` | wherever the user row is actually created — `POST /auth/email/verify` and the no-email-provider bypass branch of `/auth/email/init`. Both fire together because `add_user_by_email` opens the free trial on insert |
| `onboarding_step_completed` | `onboarding.sync_onboarding_state`, alongside the existing per-step event from #500 |
| `activated` | the same sync, when the `ACTIVATED` step flips (published post + first auto-engagement) |
| `subscription_started` | Stripe `customer.subscription.created` — deliberately NOT `updated`, which fires on every plan/status change and would double-count |
| `churned` | Stripe `customer.subscription.deleted` |

### Channel + UTM properties

Every event carries the allow-listed `utm_*` / `referrer` / `landing_page` properties plus a derived `channel` from the plan's vocabulary (`linkedin`, `newsletter`, `seo`, `email`, `referral`, `affiliate`, `paid`, `direct`, `other`), so each trial attributes to a channel and CAC-per-channel is computable. `resolve_channel` checks paid mediums before source, so `utm_source=google&utm_medium=cpc` is paid spend rather than SEO, and a tagged-but-unrecognised visit lands in `other` instead of being miscounted as `direct`.

Two things make the funnel actually join up end to end:

- **`$set_once` first-touch person properties** (`initial_channel`, `initial_utm_*`) — the Stripe webhook events carry no UTMs of their own, so PostHog holds them on the person from signup and `subscription_started` / `churned` stay attributable.
- **`alias_from`** — `signup_started` happens before a user row exists, so it's keyed to a pseudonymous `anon_<sha256(email)>` id which is then merged into the real user id at `signup_completed`.

`track_funnel_event` never raises (analytics must not fail a signup or a billing webhook that Stripe would retry), and the customer→user lookup in the webhook path is guarded for the same reason.

### SPA

`utils/attribution.ts` captures the landing UTMs + external referrer once into sessionStorage on first paint (first touch wins — a later tagged link in the same session must not overwrite what acquired the visit) and `LoginModal` replays them on both auth calls. Storage being unavailable just puts the event in the `direct` bucket.

No migration: attribution rides the event and the PostHog person, not a new column.

## Testing notes

- `tests/unit/utilities/test_observability_funnel.py` — channel resolution (explicit / paid-vs-source precedence / source rules / medium rules / referrer fallback / malformed referrer / unrecognised-UTM → `other` / no-signal → `direct`), property allow-listing + truncation, pseudonymous id stability, `$set_once`, aliasing (including the self-alias skip), unknown-event warning, and never-raises-on-PostHog-failure.
- `tests/unit/api/test_funnel_events_api.py` — signup funnel through both auth branches (new vs returning email, attribution optional), and the billing webhook (`created` emits, `updated` doesn't, `deleted` churns, a failed lookup still returns `{"received": true}`).
- `tests/unit/utilities/test_onboarding.py` — new case asserting each step completion emits the funnel event and that `ACTIVATED` also emits `activated`.
- `pytest tests/unit -q`: **4558 passed**. `tsc -b` on the SPA: clean.

Closes #503

🤖 Generated with [Claude Code](https://claude.com/claude-code)