### PR TITLE
fix(infra): graceful worker shutdown + maintenance mode so deploys never lose in-flight Celery tasks (closes #549)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,13 @@ CELERY_FLOWER_PASSWORD=your_flower_password
 CELERY_FLOWER_STATE_SAVE_INTERVAL=5000
 CELERY_WORKER_HOST=celery-worker-host
 CELERY_WORKER_NAME=worker@%h
+# Graceful shutdown / deploy drain (issue #549). How long Docker waits for a worker's warm
+# shutdown before SIGKILL — must exceed the longest task (video generation ~6 min).
+CELERY_STOP_GRACE_PERIOD=8m
+# Redis visibility timeout. Defaults to CELERY_LONGEST_TASK_SECONDS (default 3600) + 15 min; keep
+# it above the longest task or task_acks_late can re-deliver a still-running task to another worker.
+#CELERY_LONGEST_TASK_SECONDS=3600
+#CELERY_VISIBILITY_TIMEOUT=4500
 
 
 # =============================================================================

--- a/compose/local/Dockerfile
+++ b/compose/local/Dockerfile
@@ -98,6 +98,8 @@ COPY ./compose/local/entrypoint /entrypoint
 COPY ./compose/local/wait-for-it /wait-for-it
 COPY ./compose/local/fastapi/start /start-fastapi
 COPY ./compose/local/fastapi/start-cloud /start-fastapi-cloud
+# Shared privilege-dropping exec-er — keeps celery as the signal-receiving process (issue #549)
+COPY ./compose/local/celery/run-as-celery /run-as-celery
 COPY ./compose/local/celery/worker/start /start-celeryworker
 COPY ./compose/local/celery/worker/start-solo-pool /start-celeryworker-solo
 COPY ./compose/local/celery/worker/start-selenium /start-celeryworker-selenium
@@ -105,7 +107,7 @@ COPY ./compose/local/celery/beat/start /start-celerybeat
 COPY ./compose/local/celery/flower/start /start-flower
 COPY ./compose/local/celery/flower/start-no-wait /start-flower-no-wait
 
-RUN chmod +x /entrypoint /wait-for-it /start-fastapi \
+RUN chmod +x /entrypoint /wait-for-it /start-fastapi /run-as-celery \
     /start-fastapi-cloud /start-celeryworker /start-celeryworker-solo \
     /start-celeryworker-selenium /start-celerybeat /start-flower /start-flower-no-wait
 

--- a/compose/local/celery/beat/start
+++ b/compose/local/celery/beat/start
@@ -39,5 +39,7 @@ fi
 
 # Start Celery Beat
 echo "Starting Celery Beat"
-celery --app cqc_lem.app.my_celery beat -l info
+# exec so beat REPLACES this shell and receives Docker's SIGTERM directly — otherwise the signal
+# stops at this script and beat is SIGKILLed without flushing its schedule state (issue #549).
+exec celery --app cqc_lem.app.my_celery beat -l info
 

--- a/compose/local/celery/run-as-celery
+++ b/compose/local/celery/run-as-celery
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Run the given command as the non-root celery user, REPLACING this shell (exec) so the
+# celery process — not a wrapper shell — is what Docker signals on stop.
+#
+# The workers used to launch as `su $CELERY_USER -c "… celery … worker …"` without exec: the
+# start script stayed PID 1, Docker's SIGTERM went to that shell, and Celery never received the
+# warm-shutdown signal. In-flight tasks (6-min video generation, commenting loops, DM sweeps)
+# were SIGKILLed by the stop grace period instead of finishing. See issue #549.
+set -o errexit
+set -o nounset
+
+CELERY_USER="${CELERY_USER:-celeryworker}"
+# `su` sets HOME for the target user; setpriv does NOT — it would leave HOME=/root, and boto3
+# would stop finding the ~/.aws credentials mounted at /home/celeryworker/.aws. Set it ourselves.
+CELERY_HOME="$(getent passwd "$CELERY_USER" | cut -d: -f6)"
+CELERY_HOME="${CELERY_HOME:-/home/$CELERY_USER}"
+
+# 'su' on Debian resets PATH to the system default, stripping /app/.venv/bin even when the
+# Docker ENV sets it — pass the venv explicitly to whichever exec-er we use below.
+VENV_ENV="VIRTUAL_ENV=/app/.venv PATH=/app/.venv/bin:/usr/local/bin:/usr/bin:/bin"
+
+if [ "$(id -u)" -ne 0 ]; then
+  # Already unprivileged (e.g. a container run with `user:`) — nothing to drop.
+  exec env $VENV_ENV "$@"
+fi
+
+# setpriv drops privileges IN PLACE: no extra process sits between PID 1 and celery, so the
+# signal needs no forwarding at all. Preferred whenever util-linux is present.
+if command -v setpriv >/dev/null 2>&1; then
+  exec setpriv --reuid="$CELERY_USER" --regid="$CELERY_USER" --init-groups \
+    env HOME="$CELERY_HOME" USER="$CELERY_USER" LOGNAME="$CELERY_USER" $VENV_ENV "$@"
+fi
+
+# Fallback: util-linux `su` does forward SIGTERM to its child, and the inner `exec` makes that
+# child celery itself rather than another shell. %q-quote so arguments survive the -c string.
+printf -v QUOTED_CMD '%q ' "$@"
+exec su "$CELERY_USER" -c "exec env $VENV_ENV $QUOTED_CMD"

--- a/compose/local/celery/worker/start
+++ b/compose/local/celery/worker/start
@@ -23,17 +23,18 @@ CELERY_USER=celeryworker
 #printf "Changing ownership of the application directory to: %s\n" "$CELERY_USER"
 #chown -R $CELERY_USER:$CELERY_USER /app
 
-# Explicitly pass VIRTUAL_ENV and PATH: 'su' on Debian Bookworm resets PATH to
-# the system default, stripping /app/.venv/bin even when Docker ENV is set.
-VENV_ACTIVATE="VIRTUAL_ENV=/app/.venv PATH=/app/.venv/bin:/usr/local/bin:/usr/bin:/bin"
+export CELERY_USER
 
 printf "Starting Celery Worker as: %s\n" "$CELERY_USER"
+# exec through /run-as-celery so celery REPLACES this shell and receives Docker's SIGTERM
+# directly — that signal is what triggers Celery's warm shutdown (stop consuming, finish the
+# running tasks, then exit). See compose/local/celery/run-as-celery and issue #549.
 # concurrency=2: handles only non-Selenium tasks (scheduler, content plan, Stripe, etc.)
 # Selenium tasks are routed to the se_engage/se_outreach/se_content lane queues and
 # consumed by the celery_worker_selenium* lane workers.
-su $CELERY_USER -c "$VENV_ACTIVATE celery --app cqc_lem.app.my_celery worker \
+exec /run-as-celery celery --app cqc_lem.app.my_celery worker \
   --loglevel=INFO \
   --concurrency=2 \
   --queues=celery \
   --hostname=main-worker@%h \
-  -E"
+  -E

--- a/compose/local/celery/worker/start-selenium
+++ b/compose/local/celery/worker/start-selenium
@@ -4,10 +4,7 @@ set -o errexit
 set -o nounset
 
 CELERY_USER=celeryworker
-
-# Explicitly pass VIRTUAL_ENV and PATH: 'su' on Debian Bookworm resets PATH to
-# the system default, stripping /app/.venv/bin even when Docker ENV is set.
-VENV_ACTIVATE="VIRTUAL_ENV=/app/.venv PATH=/app/.venv/bin:/usr/local/bin:/usr/bin:/bin"
+export CELERY_USER
 
 # One script serves all three Selenium lane workers. Each container sets
 # SELENIUM_QUEUES / SELENIUM_CONCURRENCY to claim its lane(s). Defaults consume
@@ -18,13 +15,15 @@ SELENIUM_CONCURRENCY="${SELENIUM_CONCURRENCY:-4}"
 
 printf "Starting Celery Selenium Worker as: %s (queues=%s concurrency=%s)\n" \
   "$CELERY_USER" "$SELENIUM_QUEUES" "$SELENIUM_CONCURRENCY"
+# exec through /run-as-celery so celery REPLACES this shell and gets Docker's SIGTERM directly —
+# Selenium tasks are the longest-running ones, so warm shutdown matters most here (issue #549).
 # concurrency — number of Chrome sessions this lane may open (SE_NODE_MAX_SESSIONS gates the pool)
 # prefetch-multiplier=1 — never pre-fetch another Selenium task while one is running
 # queues — consume only this container's reserved lane(s); main worker keeps the default queue
-su $CELERY_USER -c "$VENV_ACTIVATE celery --app cqc_lem.app.my_celery worker \
+exec /run-as-celery celery --app cqc_lem.app.my_celery worker \
   --loglevel=INFO \
-  --concurrency=$SELENIUM_CONCURRENCY \
+  --concurrency="$SELENIUM_CONCURRENCY" \
   --prefetch-multiplier=1 \
-  --queues=$SELENIUM_QUEUES \
-  --hostname=selenium-${SELENIUM_QUEUES//,/-}-worker@%h \
-  -E"
+  --queues="$SELENIUM_QUEUES" \
+  --hostname="selenium-${SELENIUM_QUEUES//,/-}-worker@%h" \
+  -E

--- a/compose/local/celery/worker/start-solo-pool
+++ b/compose/local/celery/worker/start-solo-pool
@@ -26,9 +26,13 @@ CELERY_USER=celeryworker
 #    chmod 755 /app/logs
 
 
-# Explicitly pass VIRTUAL_ENV and PATH: 'su' on Debian Bookworm resets PATH to
-# the system default, stripping /app/.venv/bin even when Docker ENV is set.
-VENV_ACTIVATE="VIRTUAL_ENV=/app/.venv PATH=/app/.venv/bin:/usr/local/bin:/usr/bin:/bin"
+export CELERY_USER
 
 printf "Starting Celery Worker as: %s\n" "$CELERY_USER"
-su $CELERY_USER -c "$VENV_ACTIVATE celery --app cqc_lem.app.my_celery worker --pool=solo --concurrency=1 --queues=$CELERY_QUEUE --loglevel=INFO -E"
+# exec through /run-as-celery so Docker's SIGTERM reaches celery and warm-shuts it down (#549).
+exec /run-as-celery celery --app cqc_lem.app.my_celery worker \
+  --pool=solo \
+  --concurrency=1 \
+  --queues="$CELERY_QUEUE" \
+  --loglevel=INFO \
+  -E

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,10 @@ services:
     container_name: celery_worker
     hostname: ${CELERY_WORKER_HOST}
     command: /start-celeryworker
+    # Docker's default is 10s — far shorter than a video generation (~6 min) or a commenting
+    # loop, so a deploy SIGKILLed running tasks. Give Celery's warm shutdown room to finish
+    # what is running (it exits as soon as it drains, so this is a ceiling, not a delay). #549
+    stop_grace_period: ${CELERY_STOP_GRACE_PERIOD:-8m}
     deploy:
       resources:
         limits:
@@ -107,6 +111,9 @@ services:
     image: ${DOCKER_IMAGE_NAME}
     container_name: celery_worker_selenium
     command: /start-celeryworker-selenium
+    # Selenium lanes run the longest tasks in the stack — let warm shutdown finish them
+    # instead of Docker's 10s default SIGKILL (issue #549).
+    stop_grace_period: ${CELERY_STOP_GRACE_PERIOD:-8m}
     deploy:
       resources:
         limits:
@@ -143,6 +150,9 @@ services:
     image: ${DOCKER_IMAGE_NAME}
     container_name: celery_worker_selenium_outreach
     command: /start-celeryworker-selenium
+    # Selenium lanes run the longest tasks in the stack — let warm shutdown finish them
+    # instead of Docker's 10s default SIGKILL (issue #549).
+    stop_grace_period: ${CELERY_STOP_GRACE_PERIOD:-8m}
     deploy:
       resources:
         limits:
@@ -179,6 +189,9 @@ services:
     image: ${DOCKER_IMAGE_NAME}
     container_name: celery_worker_selenium_content
     command: /start-celeryworker-selenium
+    # Selenium lanes run the longest tasks in the stack — let warm shutdown finish them
+    # instead of Docker's 10s default SIGKILL (issue #549).
+    stop_grace_period: ${CELERY_STOP_GRACE_PERIOD:-8m}
     deploy:
       resources:
         limits:
@@ -215,6 +228,8 @@ services:
     image: ${DOCKER_IMAGE_NAME}
     container_name: celery_beat
     command: /start-celerybeat
+    # Beat holds no task work — a short grace is enough to flush its schedule state.
+    stop_grace_period: 30s
     volumes_from:
       - web_app
     env_file:

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -109,9 +109,43 @@ approval) SSHes in and runs `scripts/deploy.sh vX.Y.Z`, which:
 1. checks out the tag (syncs compose + Flyway migrations),
 2. validates the server `.env` (`check_env.sh`),
 3. pulls the GHCR image,
-4. runs Flyway migrations (idempotent),
-5. `docker compose up -d`,
-6. waits for `/health`, **auto-rolls-back** to `.last_good_tag` on failure.
+4. **enters maintenance mode** — stops `celery_beat`, pauses dispatch, cancels each worker's
+   queue consumers, then drains in-flight tasks (see below),
+5. runs Flyway migrations (idempotent),
+6. `docker compose up -d`,
+7. waits for `/health`, **auto-rolls-back** to `.last_good_tag` on failure,
+8. **leaves maintenance mode** — restores consumers and resumes dispatch (on the rollback path too).
+
+## Deploys and in-flight Celery tasks (issue #549)
+
+A deploy recreates the app containers, which SIGTERMs the workers. Three layers keep long tasks
+(6-min video generation, commenting loops, DM sweeps) from being killed and lost:
+
+1. **Warm shutdown reaches Celery.** `compose/local/celery/run-as-celery` `exec`s the worker
+   (dropping to `celeryworker` via `setpriv`, falling back to `su`) so the celery process — not a
+   wrapper shell — receives SIGTERM. It then stops consuming and finishes what is running.
+   `stop_grace_period` (`CELERY_STOP_GRACE_PERIOD`, default **8m**) gives it room before SIGKILL.
+2. **Nothing new is picked up during the window.** Maintenance mode pauses dispatch through the
+   existing Redis kill-switch (`pause_automation`, reason `deploy`) and cancels each worker's own
+   queue consumers, then polls `inspect active` until idle. Tune with `MAINT_PAUSE_SECONDS`
+   (default 1800 — a TTL, so a crashed deploy can't leave automation off) and `DRAIN_TIMEOUT`
+   (default 480s). A pre-existing 429/manual pause is **not** lifted at the end.
+3. **Anything still interrupted is re-run.** `task_acks_late` + `task_reject_on_worker_lost` are
+   global, so an un-finished task is re-delivered instead of dropped. Re-runs are safe:
+   `post_to_linkedin` short-circuits on `PostStatus.POSTED`, comments go through the
+   `commented_posts` claim ledger (a claim abandoned by a killed worker is taken over after
+   `CLAIM_STALE_MINUTES`), and the dispatchers are `QueueOnce`-locked. `CELERY_VISIBILITY_TIMEOUT`
+   (default: longest task + 15m) must stay above the longest task so acks_late can't hand a
+   still-running task to a second worker.
+
+Inspect or drive it by hand from the box:
+
+```bash
+docker compose exec -T celery_worker python -m cqc_lem.utilities.maintenance status
+docker compose exec -T celery_worker python -m cqc_lem.utilities.maintenance begin --pause-seconds 900
+docker compose exec -T celery_worker python -m cqc_lem.utilities.maintenance drain --timeout 300
+docker compose exec -T celery_worker python -m cqc_lem.utilities.maintenance end
+```
 
 ## Manual redeploy / rollback
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -14,8 +14,28 @@ COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.yml"
 LAST_GOOD_FILE="${ROOT_DIR}/.last_good_tag"
 ENV_FILE="${ROOT_DIR}/.env"
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
+# Maintenance window (issue #549): how long dispatch stays paused (TTL — it self-clears if this
+# script dies) and how long we wait for in-flight tasks to finish before recreating the workers.
+MAINT_PAUSE_SECONDS="${MAINT_PAUSE_SECONDS:-1800}"
+DRAIN_TIMEOUT="${DRAIN_TIMEOUT:-480}"
 
 log() { echo "[deploy $(date -u +%H:%M:%S)] $*"; }
+
+# Run a maintenance-mode subcommand inside whichever app container is up. Best-effort by design:
+# a stack that can't answer must not block the deploy (warm shutdown + acks_late still protect
+# in-flight work), so every call site tolerates a non-zero exit.
+maint() {
+  local sub="$1"; shift
+  local svc
+  for svc in celery_worker web_app; do
+    if docker ps --format '{{.Names}}' | grep -qx "${svc}"; then
+      ${COMPOSE} exec -T "${svc}" python -m cqc_lem.utilities.maintenance "${sub}" "$@"
+      return $?
+    fi
+  done
+  log "WARN: no running app container — skipping maintenance ${sub}"
+  return 0
+}
 
 # Persist IMAGE_TAG into .env so a reboot or a manual `compose up` (run without
 # this script) stays on the deployed tag. We only `export` IMAGE_TAG for our own
@@ -65,6 +85,17 @@ export IMAGE_TAG="${TAG}"
 log "Pulling images for IMAGE_TAG=${TAG}"
 ${COMPOSE} pull
 
+# 4b. Enter maintenance mode BEFORE anything touches the workers: stop beat so no new schedule
+#     fires, pause dispatch, cancel each worker's queue consumers, then wait for what is already
+#     running (video generation, commenting loops, DM sweeps) to finish. Without this the
+#     recreate below killed live tasks mid-flight (issue #549).
+log "Entering maintenance mode (pause ${MAINT_PAUSE_SECONDS}s); stopping celery_beat"
+${COMPOSE} stop celery_beat || log "WARN: could not stop celery_beat (continuing)"
+maint begin --pause-seconds "${MAINT_PAUSE_SECONDS}" || log "WARN: maintenance begin failed (continuing)"
+log "Draining in-flight Celery tasks (up to ${DRAIN_TIMEOUT}s)"
+maint drain --timeout "${DRAIN_TIMEOUT}" \
+  || log "WARN: drain timed out — remaining tasks get re-queued on shutdown (task_acks_late)"
+
 # 5. Migrations first — Flyway is idempotent (repair + migrate, baselineOnMigrate).
 log "Running database migrations"
 ${COMPOSE} up -d mysql
@@ -102,8 +133,14 @@ if [[ "${healthy}" != true ]]; then
     persist_image_tag "${prev}"
     ${COMPOSE} up -d --remove-orphans
   fi
+  # Never leave the rolled-back stack paused — the pause has a TTL, but automation should
+  # resume the moment the old release is back up.
+  maint end || log "WARN: could not clear maintenance mode (pause TTL will expire it)"
   exit 1
 fi
+
+# 7b. Healthy on the new tag — lift the pause and restore consumers.
+maint end || log "WARN: could not clear maintenance mode (pause TTL will expire it)"
 
 # 8. Record the new good tag and prune old artifacts.
 echo "${TAG}" > "${LAST_GOOD_FILE}"

--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -39,8 +39,24 @@ redis_backend_health_check_interval = 300
 timezone = os.getenv('CELERY_TIMEZONE') or 'UTC'
 enable_utc = True
 
-# Prevent task messages from being lost
-task_acks_late = True,
+# Prevent task messages from being lost. acks_late defers the broker ACK until AFTER the task
+# returns, so a worker killed mid-task (deploy recreate, OOM, SIGKILL) leaves the message
+# un-acked and the broker re-delivers it instead of dropping it. Was `True,` — a one-tuple; it
+# happened to be truthy, but a stray comma is not a config value.
+task_acks_late = True
+
+# Re-queue a task whose worker process died mid-execution (the pool child was killed) rather
+# than marking it failed and losing the work. Several tasks already set this per-decorator;
+# making it global means every task — including new ones — survives a deploy the same way.
+# Safe here because the re-runnable tasks are idempotent: posting short-circuits on
+# PostStatus.POSTED, comments/DMs dedup on the commented_posts / dm ledgers, and the
+# high-volume dispatchers are QueueOnce-locked.
+task_reject_on_worker_lost = True
+
+# Celery 5 deprecation: leaving this unset warns on every boot. False keeps a task RUNNING
+# through a transient broker disconnect (it re-acks on reconnect) instead of cancelling it —
+# which is the whole point of not losing in-flight work.
+worker_cancel_long_running_tasks_on_connection_loss = False
 
 # Set the maximum time in seconds that the ETA scheduler can sleep between rechecking the schedule.
 # Default: 1.0 seconds.
@@ -60,8 +76,16 @@ worker_max_tasks_per_child = 10
 
 # Gets the max between all the parameters of timeout in the tasks
 max_timeout = 60 * 60  # This value must be bigger than the maximum soft timeout set for a task to prevent an infinity loop
-broker_transport_options = {'visibility_timeout': max_timeout + 60,# 60 seconds of margin
-                            'max_retries':5}
+
+# Redis visibility timeout — how long the broker waits for an ACK before handing the message to
+# ANOTHER worker. With task_acks_late this must stay comfortably ABOVE the longest task plus the
+# deploy drain window (stop_grace_period 8m), or a long task still running past the timeout gets
+# re-delivered and runs twice concurrently — the classic acks_late + Redis double-run trap.
+# 60s of margin was not enough once workers may take a full grace period to shut down.
+longest_task_seconds = int(os.getenv('CELERY_LONGEST_TASK_SECONDS', str(max_timeout)))
+visibility_timeout = int(os.getenv('CELERY_VISIBILITY_TIMEOUT', str(longest_task_seconds + (15 * 60))))
+broker_transport_options = {'visibility_timeout': visibility_timeout,
+                            'max_retries': 5}
 
 
 def get_aws_sqs(queue_name: str,

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -4030,13 +4030,16 @@ def claim_post_for_comment(user_id: int, post_key: str, stale_after_minutes: int
                 (user_id, str(post_key)[:255], max(1, int(stale_after_minutes))))
             connection.commit()
             if cursor.rowcount == 1:
-                myprint(f"Took over a stale comment claim for user {user_id} | {post_key}")
+                log_info(f"Took over a stale comment claim | {post_key}",
+                         user_id=user_id, action_type="comment")
                 return True
         except mysql.connector.Error as err:
-            myprint(f"Could not take over stale comment claim for user {user_id} | Error: {err}")
+            log_error("Could not take over stale comment claim", exc=err,
+                      user_id=user_id, action_type="comment")
         return False
     except mysql.connector.Error as err:
-        myprint(f"Could not claim post for comment for user {user_id} | Error: {err}")
+        log_error("Could not claim post for comment", exc=err,
+                  user_id=user_id, action_type="comment")
         return False
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3994,11 +3994,21 @@ def get_recent_engagers(user_id: int, days: int = 14) -> set:
         connection.close()
 
 
-def claim_post_for_comment(user_id: int, post_key: str) -> bool:
+CLAIM_STALE_MINUTES = 60
+
+
+def claim_post_for_comment(user_id: int, post_key: str, stale_after_minutes: int = CLAIM_STALE_MINUTES) -> bool:
     """Atomically claim a feed post for commenting. Returns True only for the caller that WON the
     claim (safe to comment); False if the post was already claimed/commented by any prior or
     concurrent run — the loser must back off. The UNIQUE (user_id, post_key) constraint resolves
-    the race at the DB, so this is safe across sequential re-scans, retries, and parallel workers."""
+    the race at the DB, so this is safe across sequential re-scans, retries, and parallel workers.
+
+    A claim left in 'claimed' state for longer than `stale_after_minutes` is taken over: the run
+    that made it died before it could comment OR release (a worker SIGKILLed by a deploy has no
+    chance to run its except-branch release). Without the takeover, a task re-queued by
+    task_acks_late would keep short-circuiting on its own abandoned claim and the comment would be
+    lost for good — see issue #549. The window is far longer than a comment run, so a takeover
+    can't race a task that is genuinely still working."""
     if not post_key or not str(post_key).strip():
         return False
     connection = get_db_connection()
@@ -4010,7 +4020,20 @@ def claim_post_for_comment(user_id: int, post_key: str) -> bool:
         connection.commit()
         return cursor.rowcount == 1
     except mysql.connector.IntegrityError:
-        # Duplicate key — another run/worker already holds this post.
+        # Duplicate key — someone holds this post. Only a STALE, never-posted claim is takeable;
+        # a 'commented' row is never reclaimed, so this can't cause a double comment.
+        try:
+            cursor.execute(
+                "UPDATE commented_posts SET status='claimed', updated_at=CURRENT_TIMESTAMP "
+                "WHERE user_id=%s AND post_key=%s AND status='claimed' "
+                "AND updated_at < NOW() - INTERVAL %s MINUTE",
+                (user_id, str(post_key)[:255], max(1, int(stale_after_minutes))))
+            connection.commit()
+            if cursor.rowcount == 1:
+                myprint(f"Took over a stale comment claim for user {user_id} | {post_key}")
+                return True
+        except mysql.connector.Error as err:
+            myprint(f"Could not take over stale comment claim for user {user_id} | Error: {err}")
         return False
     except mysql.connector.Error as err:
         myprint(f"Could not claim post for comment for user {user_id} | Error: {err}")

--- a/src/cqc_lem/utilities/linkedin/rate_limit.py
+++ b/src/cqc_lem/utilities/linkedin/rate_limit.py
@@ -177,6 +177,24 @@ def automation_pause_remaining() -> int:
     return ttl if ttl and ttl > 0 else 0
 
 
+def automation_pause_reason() -> "str | None":
+    """The reason string stored with the current pause, or None when nothing is paused.
+
+    Lets a caller tell ITS OWN pause apart from someone else's — the deploy maintenance mode
+    (utilities/maintenance.py) only lifts a pause it set, so a 429/manual pause survives a deploy.
+    """
+    client = _redis_client()
+    if client is None:
+        return None
+    try:
+        value = client.get(_PAUSE_KEY)
+    except Exception:
+        return None
+    if value is None:
+        return None
+    return value.decode("utf-8", "ignore") if isinstance(value, bytes) else str(value)
+
+
 def is_automation_paused() -> bool:
     return automation_pause_remaining() > 0
 

--- a/src/cqc_lem/utilities/maintenance.py
+++ b/src/cqc_lem/utilities/maintenance.py
@@ -115,12 +115,20 @@ def active_task_count() -> int:
     return sum(len(tasks or []) for tasks in replies.values())
 
 
-def _store_consumer_snapshot(mapping: Dict[str, List[str]]) -> None:
+def _snapshot_ttl_seconds(pause_seconds: int) -> int:
+    """The snapshot must outlive the window it describes, or end_maintenance() would have nothing
+    to restore consumers from. Scale with the caller's pause (a long manual window included) and
+    never go below the default deploy window."""
+    return max(int(pause_seconds), DEFAULT_PAUSE_SECONDS) * 2
+
+
+def _store_consumer_snapshot(mapping: Dict[str, List[str]],
+                             pause_seconds: int = DEFAULT_PAUSE_SECONDS) -> None:
     client = _redis_client()
     if client is None or not mapping:
         return
     try:
-        client.set(_CONSUMERS_KEY, json.dumps(mapping), ex=DEFAULT_PAUSE_SECONDS * 2)
+        client.set(_CONSUMERS_KEY, json.dumps(mapping), ex=_snapshot_ttl_seconds(pause_seconds))
     except Exception as e:
         log_warning("Could not persist the maintenance consumer snapshot", exc=e)
 
@@ -169,7 +177,7 @@ def begin_maintenance(pause_seconds: int = DEFAULT_PAUSE_SECONDS,
     if queues is not None:
         wanted = set(queues)
         mapping = {w: [q for q in qs if q in wanted] for w, qs in mapping.items()}
-    _store_consumer_snapshot(mapping)
+    _store_consumer_snapshot(mapping, seconds)
 
     cancelled = 0
     for worker, worker_queues in mapping.items():

--- a/src/cqc_lem/utilities/maintenance.py
+++ b/src/cqc_lem/utilities/maintenance.py
@@ -1,0 +1,285 @@
+"""Deploy maintenance mode — pause, drain, deploy, resume (issue #549).
+
+`scripts/deploy.sh` recreates every app container, which SIGTERMs the Celery workers. Warm
+shutdown (`compose/local/celery/run-as-celery` + `stop_grace_period`) lets a task that is ALREADY
+running finish, but nothing stopped a worker from reserving NEW work in the seconds before the
+recreate — a task started at T-1s is still mid-flight when the grace period expires.
+
+Maintenance mode closes that window around the recreate:
+
+1. ``begin_maintenance`` — pause dispatch via the existing Redis kill-switch
+   (``pause_automation``), then ``cancel_consumer`` each worker's own queues so no further
+   message is reserved. The (worker, queue) pairs are snapshotted into Redis first so they can be
+   restored even from a different process later.
+2. ``drain_workers`` — poll ``inspect active`` until nothing is executing, or a bounded timeout.
+3. ``end_maintenance`` — restore the snapshotted consumers and lift the pause, but ONLY if the
+   pause is still ours (a 429 breaker pause must outlive the deploy).
+
+Everything fails OPEN: if Redis or the broker is unreachable these are no-ops and the deploy
+proceeds exactly as it did before. The pause carries a TTL, so even an aborted deploy cannot
+leave automation switched off for good.
+
+Also usable as a CLI from inside a container::
+
+    python -m cqc_lem.utilities.maintenance begin --pause-seconds 1800
+    python -m cqc_lem.utilities.maintenance drain --timeout 480
+    python -m cqc_lem.utilities.maintenance end
+    python -m cqc_lem.utilities.maintenance status
+"""
+
+import argparse
+import json
+import sys
+import time
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# Reuse the breaker's Redis handle so the maintenance flag lands in the same place as the pause
+# it extends (same URL resolution, same fail-open semantics) rather than re-deriving the URL.
+from cqc_lem.utilities.linkedin.rate_limit import (
+    _redis_client,
+    automation_pause_reason,
+    automation_pause_remaining,
+    pause_automation,
+    resume_automation,
+)
+from cqc_lem.utilities.logger import log_info, log_warning
+
+_MAINTENANCE_KEY = "lem:maintenance"
+_CONSUMERS_KEY = "lem:maintenance:consumers"
+
+MAINTENANCE_REASON = "deploy"
+DEFAULT_PAUSE_SECONDS = 30 * 60
+DEFAULT_DRAIN_TIMEOUT_SECONDS = 8 * 60  # matches the workers' stop_grace_period
+DEFAULT_POLL_SECONDS = 5
+INSPECT_TIMEOUT_SECONDS = 10
+
+# Used only when the Celery config can't be imported (e.g. a stripped CLI context).
+FALLBACK_QUEUES: Tuple[str, ...] = ("celery", "se_engage", "se_outreach", "se_content")
+
+
+def queue_names() -> Tuple[str, ...]:
+    """Every queue the stack consumes, straight from celeryconfig so lanes can't drift apart."""
+    try:
+        from cqc_lem.app.celeryconfig import task_queues
+        names = tuple(q.name for q in task_queues if getattr(q, "name", None))
+        return names or FALLBACK_QUEUES
+    except Exception:
+        return FALLBACK_QUEUES
+
+
+def _control() -> Any:
+    from cqc_lem.app.my_celery import app
+    return app.control
+
+
+def _inspect() -> Any:
+    return _control().inspect(timeout=INSPECT_TIMEOUT_SECONDS)
+
+
+def maintenance_remaining() -> int:
+    """Seconds left on the maintenance flag, or 0 when not in maintenance / Redis is down."""
+    client = _redis_client()
+    if client is None:
+        return 0
+    try:
+        ttl = client.ttl(_MAINTENANCE_KEY)
+    except Exception:
+        return 0
+    return ttl if ttl and ttl > 0 else 0
+
+
+def is_maintenance_mode() -> bool:
+    return maintenance_remaining() > 0
+
+
+def worker_queue_map() -> Dict[str, List[str]]:
+    """{worker hostname: [queue names it consumes]} — empty when no worker replies."""
+    try:
+        replies = _inspect().active_queues() or {}
+    except Exception as e:
+        log_warning("Could not inspect worker queues for maintenance mode", exc=e)
+        return {}
+    mapping: Dict[str, List[str]] = {}
+    for worker, queues in replies.items():
+        mapping[worker] = [q.get("name") for q in (queues or []) if q.get("name")]
+    return mapping
+
+
+def active_task_count() -> int:
+    """Tasks currently EXECUTING across all workers. 0 when nobody replies (nothing to drain)."""
+    try:
+        replies = _inspect().active() or {}
+    except Exception as e:
+        log_warning("Could not inspect active tasks — treating the stack as drained", exc=e)
+        return 0
+    return sum(len(tasks or []) for tasks in replies.values())
+
+
+def _store_consumer_snapshot(mapping: Dict[str, List[str]]) -> None:
+    client = _redis_client()
+    if client is None or not mapping:
+        return
+    try:
+        client.set(_CONSUMERS_KEY, json.dumps(mapping), ex=DEFAULT_PAUSE_SECONDS * 2)
+    except Exception as e:
+        log_warning("Could not persist the maintenance consumer snapshot", exc=e)
+
+
+def _load_consumer_snapshot() -> Dict[str, List[str]]:
+    client = _redis_client()
+    if client is None:
+        return {}
+    try:
+        raw = client.get(_CONSUMERS_KEY)
+    except Exception:
+        return {}
+    if not raw:
+        return {}
+    try:
+        data = json.loads(raw.decode("utf-8", "ignore") if isinstance(raw, bytes) else raw)
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def begin_maintenance(pause_seconds: int = DEFAULT_PAUSE_SECONDS,
+                      queues: Optional[Iterable[str]] = None) -> bool:
+    """Pause dispatch and stop every worker from reserving new messages.
+
+    Returns True when the maintenance flag was stored (Redis reachable); the consumer
+    cancellation itself is best-effort — a broker that won't answer must not block a deploy.
+    """
+    seconds = max(1, int(pause_seconds))
+    stored = False
+    client = _redis_client()
+    if client is not None:
+        try:
+            client.set(_MAINTENANCE_KEY, MAINTENANCE_REASON, ex=seconds)
+            stored = True
+        except Exception as e:
+            log_warning("Could not set the maintenance flag", exc=e)
+
+    pause_automation(seconds, MAINTENANCE_REASON)
+
+    # Cancel each worker's OWN queues only, and remember the pairs: broadcasting add_consumer on
+    # resume would otherwise make e.g. the main worker consume a Selenium lane and break lane
+    # isolation. A worker recreated by the deploy simply comes back consuming its configured
+    # --queues, so a restore aimed at its old (now gone) hostname is a harmless no-op.
+    mapping = worker_queue_map()
+    if queues is not None:
+        wanted = set(queues)
+        mapping = {w: [q for q in qs if q in wanted] for w, qs in mapping.items()}
+    _store_consumer_snapshot(mapping)
+
+    cancelled = 0
+    for worker, worker_queues in mapping.items():
+        for queue in worker_queues:
+            try:
+                _control().cancel_consumer(queue, destination=[worker])
+                cancelled += 1
+            except Exception as e:
+                log_warning(f"Could not cancel consumer {queue} on {worker}", exc=e)
+
+    log_info(f"Maintenance mode ON for {seconds}s — paused dispatch, cancelled {cancelled} "
+             f"queue consumer(s) across {len(mapping)} worker(s)")
+    return stored
+
+
+def drain_workers(timeout_seconds: int = DEFAULT_DRAIN_TIMEOUT_SECONDS,
+                  poll_seconds: int = DEFAULT_POLL_SECONDS,
+                  sleep: Any = time.sleep) -> int:
+    """Wait for running tasks to finish. Returns how many are STILL running (0 = fully drained).
+
+    A non-zero return is not fatal: with task_acks_late those tasks are re-queued when the
+    worker dies and re-run on the new one.
+    """
+    deadline = time.monotonic() + max(0, int(timeout_seconds))
+    remaining = active_task_count()
+    while remaining > 0 and time.monotonic() < deadline:
+        log_info(f"Draining Celery workers — {remaining} task(s) still running")
+        sleep(max(1, int(poll_seconds)))
+        remaining = active_task_count()
+    if remaining:
+        log_warning(f"Drain timed out with {remaining} task(s) still running — they will be "
+                    "re-queued on shutdown (task_acks_late)")
+    else:
+        log_info("Celery workers drained — no tasks running")
+    return remaining
+
+
+def end_maintenance(queues: Optional[Iterable[str]] = None) -> bool:
+    """Restore consumers and lift the deploy pause. Returns True if the pause was ours to lift."""
+    snapshot = _load_consumer_snapshot()
+    wanted = set(queues) if queues is not None else None
+    for worker, worker_queues in snapshot.items():
+        for queue in worker_queues:
+            if wanted is not None and queue not in wanted:
+                continue
+            try:
+                _control().add_consumer(queue, destination=[worker])
+            except Exception as e:
+                log_warning(f"Could not restore consumer {queue} on {worker}", exc=e)
+
+    client = _redis_client()
+    if client is not None:
+        try:
+            client.delete(_MAINTENANCE_KEY, _CONSUMERS_KEY)
+        except Exception as e:
+            log_warning("Could not clear the maintenance flag", exc=e)
+
+    # Only lift a pause WE set — a 429 breaker pause or an operator's manual pause has to
+    # survive the deploy, otherwise a release would silently un-throttle a rate-limited account.
+    reason = automation_pause_reason()
+    if reason is not None and reason != MAINTENANCE_REASON:
+        log_info(f"Maintenance mode OFF — leaving the existing '{reason}' pause in place "
+                 f"({automation_pause_remaining()}s left)")
+        return False
+    resume_automation()
+    log_info("Maintenance mode OFF — dispatch resumed")
+    return True
+
+
+def status() -> Dict[str, Any]:
+    return {
+        "maintenance": is_maintenance_mode(),
+        "maintenance_remaining": maintenance_remaining(),
+        "pause_reason": automation_pause_reason(),
+        "pause_remaining": automation_pause_remaining(),
+        "active_tasks": active_task_count(),
+        "worker_queues": worker_queue_map(),
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="cqc_lem.utilities.maintenance",
+                                     description="Celery deploy maintenance mode (issue #549)")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    begin = sub.add_parser("begin", help="pause dispatch and stop consuming new tasks")
+    begin.add_argument("--pause-seconds", type=int, default=DEFAULT_PAUSE_SECONDS)
+
+    drain = sub.add_parser("drain", help="wait for in-flight tasks to finish")
+    drain.add_argument("--timeout", type=int, default=DEFAULT_DRAIN_TIMEOUT_SECONDS)
+    drain.add_argument("--poll", type=int, default=DEFAULT_POLL_SECONDS)
+
+    sub.add_parser("end", help="restore consumers and lift the deploy pause")
+    sub.add_parser("status", help="print the current maintenance/pause/active-task state")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "begin":
+        begin_maintenance(pause_seconds=args.pause_seconds)
+        return 0
+    if args.command == "drain":
+        # Non-zero tells deploy.sh the drain timed out so it can log it; the deploy continues
+        # either way because acks_late re-queues whatever is still running.
+        return 1 if drain_workers(timeout_seconds=args.timeout, poll_seconds=args.poll) else 0
+    if args.command == "end":
+        end_maintenance()
+        return 0
+    print(json.dumps(status(), default=str))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    sys.exit(main())

--- a/tests/unit/app/test_worker_shutdown.py
+++ b/tests/unit/app/test_worker_shutdown.py
@@ -1,0 +1,137 @@
+"""Guards for graceful worker shutdown + task durability (issue #549).
+
+These assert the *infrastructure* contract that keeps a deploy from losing in-flight tasks:
+Celery must receive Docker's SIGTERM (exec, not a wrapper shell), Docker must wait long enough
+for the warm shutdown to finish, and an interrupted task must be re-queued rather than dropped.
+Each of these regressed silently before — nothing in the app code would fail without them.
+"""
+
+import importlib
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKER_SCRIPTS = (
+    "compose/local/celery/worker/start",
+    "compose/local/celery/worker/start-selenium",
+    "compose/local/celery/worker/start-solo-pool",
+)
+
+
+def _read(rel_path: str) -> str:
+    return (REPO_ROOT / rel_path).read_text()
+
+
+class TestWorkerStartScripts:
+    @pytest.mark.parametrize("script", WORKER_SCRIPTS)
+    def test_execs_the_worker_so_sigterm_reaches_celery(self, script: str):
+        assert re.search(r"^exec /run-as-celery celery ", _read(script), re.MULTILINE)
+
+    @pytest.mark.parametrize("script", WORKER_SCRIPTS)
+    def test_never_launches_celery_under_a_non_exec_su(self, script: str):
+        # The original bug: `su … -c "celery … worker"` left the shell as PID 1, so TERM never
+        # reached Celery and in-flight tasks were SIGKILLed at the grace period.
+        assert not re.search(r"^\s*su\s", _read(script), re.MULTILINE)
+
+    def test_beat_is_exec_ed_too(self):
+        assert re.search(r"^exec celery --app cqc_lem\.app\.my_celery beat",
+                         _read("compose/local/celery/beat/start"), re.MULTILINE)
+
+    def test_run_as_celery_execs_every_branch(self):
+        body = _read("compose/local/celery/run-as-celery")
+        # setpriv (preferred), su (fallback) and the already-unprivileged path must all exec.
+        assert "exec setpriv" in body
+        assert "exec su " in body
+        assert "exec env" in body
+
+    def test_setpriv_branch_keeps_the_celery_user_home(self):
+        # setpriv (unlike su) does not set HOME — without this boto3 would look for the mounted
+        # ~/.aws credentials under /root instead of /home/celeryworker.
+        body = _read("compose/local/celery/run-as-celery")
+        setpriv_line = body.split("exec setpriv")[1].split("\n\n")[0]
+        assert 'HOME="$CELERY_HOME"' in setpriv_line
+
+    def test_run_as_celery_is_shipped_and_executable(self):
+        dockerfile = _read("compose/local/Dockerfile")
+        assert "COPY ./compose/local/celery/run-as-celery /run-as-celery" in dockerfile
+        assert "/run-as-celery" in dockerfile.split("RUN chmod +x")[1]
+
+
+class TestStopGracePeriod:
+    def test_every_worker_service_waits_out_a_long_task(self):
+        compose = _read("docker-compose.yml")
+        # Docker's 10s default is shorter than a ~6 min video generation.
+        services = re.split(r"\n  (?=\w)", compose)
+        worker_blocks = [s for s in services if s.startswith("celery_worker")]
+        assert len(worker_blocks) == 4  # main + three Selenium lanes
+        for block in worker_blocks:
+            assert "stop_grace_period: ${CELERY_STOP_GRACE_PERIOD:-8m}" in block, block[:60]
+
+    def test_beat_has_its_own_short_grace(self):
+        compose = _read("docker-compose.yml")
+        beat = compose.split("\n  celery_beat:")[1]
+        assert "stop_grace_period: 30s" in beat.split("\n  flower:")[0]
+
+
+class TestTaskDurability:
+    @pytest.fixture(autouse=True)
+    def _config(self, monkeypatch):
+        monkeypatch.delenv("CELERY_VISIBILITY_TIMEOUT", raising=False)
+        monkeypatch.delenv("CELERY_LONGEST_TASK_SECONDS", raising=False)
+        from cqc_lem.app import celeryconfig
+        yield importlib.reload(celeryconfig)
+        importlib.reload(celeryconfig)
+
+    def test_acks_late_is_a_bool_not_a_tuple(self, _config):
+        # Was `task_acks_late = True,` — truthy by accident, not a config value.
+        assert _config.task_acks_late is True
+
+    def test_worker_lost_tasks_are_requeued(self, _config):
+        assert _config.task_reject_on_worker_lost is True
+
+    def test_long_tasks_survive_a_broker_blip(self, _config):
+        assert _config.worker_cancel_long_running_tasks_on_connection_loss is False
+
+    def test_visibility_timeout_clears_the_longest_task_plus_drain(self, _config):
+        visibility = _config.broker_transport_options["visibility_timeout"]
+        # Must exceed the longest task AND the 8m stop_grace_period, or acks_late re-delivers a
+        # still-running task to a second worker (the acks_late + Redis double-run trap).
+        assert visibility >= _config.max_timeout + (8 * 60)
+
+    def test_visibility_timeout_is_env_tunable(self, monkeypatch):
+        monkeypatch.setenv("CELERY_VISIBILITY_TIMEOUT", "9999")
+        from cqc_lem.app import celeryconfig
+        reloaded = importlib.reload(celeryconfig)
+        assert reloaded.broker_transport_options["visibility_timeout"] == 9999
+
+    def test_longest_task_seconds_widens_the_window(self, monkeypatch):
+        monkeypatch.setenv("CELERY_LONGEST_TASK_SECONDS", "7200")
+        from cqc_lem.app import celeryconfig
+        reloaded = importlib.reload(celeryconfig)
+        assert reloaded.broker_transport_options["visibility_timeout"] == 7200 + (15 * 60)
+
+
+class TestDeployMaintenanceWiring:
+    """deploy.sh must actually pause → drain → deploy → resume."""
+
+    def test_pauses_and_drains_before_recreating(self):
+        deploy = _read("scripts/deploy.sh")
+        begin = deploy.index("maint begin")
+        drain = deploy.index("maint drain")
+        recreate = deploy.index("${COMPOSE} up -d --remove-orphans")
+        assert begin < drain < recreate
+
+    def test_stops_beat_before_draining(self):
+        deploy = _read("scripts/deploy.sh")
+        assert deploy.index("${COMPOSE} stop celery_beat") < deploy.index("maint drain")
+
+    def test_resumes_on_success_and_on_rollback(self):
+        deploy = _read("scripts/deploy.sh")
+        assert deploy.count("maint end") == 2
+
+    def test_calls_the_real_maintenance_module(self):
+        assert "python -m cqc_lem.utilities.maintenance" in _read("scripts/deploy.sh")

--- a/tests/unit/utilities/linkedin/test_rate_limit.py
+++ b/tests/unit/utilities/linkedin/test_rate_limit.py
@@ -226,3 +226,32 @@ class TestAutomationPause:
         with patch(f"{_MOD}._redis_client", return_value=None):
             from cqc_lem.utilities.linkedin.rate_limit import is_automation_paused
             assert is_automation_paused() is False
+
+
+class TestAutomationPauseReason:
+    """The reason lets maintenance mode lift only ITS OWN pause (issue #549)."""
+
+    def test_returns_decoded_reason(self, fake_redis):
+        fake_redis.get.return_value = b"deploy"
+        from cqc_lem.utilities.linkedin.rate_limit import automation_pause_reason
+        assert automation_pause_reason() == "deploy"
+
+    def test_returns_str_value_unchanged(self, fake_redis):
+        fake_redis.get.return_value = "429"
+        from cqc_lem.utilities.linkedin.rate_limit import automation_pause_reason
+        assert automation_pause_reason() == "429"
+
+    def test_none_when_not_paused(self, fake_redis):
+        fake_redis.get.return_value = None
+        from cqc_lem.utilities.linkedin.rate_limit import automation_pause_reason
+        assert automation_pause_reason() is None
+
+    def test_none_when_no_redis(self):
+        with patch(f"{_MOD}._redis_client", return_value=None):
+            from cqc_lem.utilities.linkedin.rate_limit import automation_pause_reason
+            assert automation_pause_reason() is None
+
+    def test_none_on_redis_error(self, fake_redis):
+        fake_redis.get.side_effect = RuntimeError("boom")
+        from cqc_lem.utilities.linkedin.rate_limit import automation_pause_reason
+        assert automation_pause_reason() is None

--- a/tests/unit/utilities/test_db_commented_posts.py
+++ b/tests/unit/utilities/test_db_commented_posts.py
@@ -104,3 +104,57 @@ class TestGetDuplicateCommentPosts:
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import get_duplicate_comment_posts
             assert get_duplicate_comment_posts(1) == []
+
+
+class TestStaleClaimTakeover:
+    """A worker SIGKILLed by a deploy leaves a 'claimed' row it can never release; the re-queued
+    task (task_acks_late) must be able to take it over or the comment is lost (issue #549)."""
+
+    def _dup_then(self, update_rowcount):
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.execute.side_effect = [mysql.connector.IntegrityError("dup"), None]
+        type(cur).rowcount = property(lambda self: update_rowcount)
+        conn.cursor.return_value = cur
+        return conn, cur
+
+    def test_takes_over_a_stale_claim(self):
+        conn, cur = self._dup_then(update_rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import claim_post_for_comment
+            assert claim_post_for_comment(1, "feedpost://abc") is True
+        sql, params = cur.execute.call_args[0]
+        assert "UPDATE commented_posts SET status='claimed'" in sql
+        # Never reclaims a row that already posted, and only past the staleness window.
+        assert "status='claimed'" in sql and "INTERVAL %s MINUTE" in sql
+        assert params[2] == 60
+
+    def test_fresh_claim_is_not_stolen(self):
+        conn, _ = self._dup_then(update_rowcount=0)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import claim_post_for_comment
+            assert claim_post_for_comment(1, "feedpost://abc") is False
+
+    def test_custom_window_is_passed_through(self):
+        conn, cur = self._dup_then(update_rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import claim_post_for_comment
+            assert claim_post_for_comment(1, "feedpost://abc", stale_after_minutes=5) is True
+        assert cur.execute.call_args[0][1][2] == 5
+
+    def test_window_floors_at_one_minute(self):
+        conn, cur = self._dup_then(update_rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import claim_post_for_comment
+            claim_post_for_comment(1, "feedpost://abc", stale_after_minutes=0)
+        assert cur.execute.call_args[0][1][2] == 1
+
+    def test_takeover_error_returns_false(self):
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.execute.side_effect = [mysql.connector.IntegrityError("dup"),
+                                   mysql.connector.Error("takeover boom")]
+        conn.cursor.return_value = cur
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import claim_post_for_comment
+            assert claim_post_for_comment(1, "feedpost://abc") is False

--- a/tests/unit/utilities/test_maintenance.py
+++ b/tests/unit/utilities/test_maintenance.py
@@ -126,6 +126,27 @@ class TestBeginMaintenance:
         assert snapshot == {"main-worker@a": ["celery"],
                             "selenium-se_engage-worker@b": ["se_engage"]}
 
+    def test_snapshot_outlives_a_long_pause_window(self, fake_redis, fake_control):
+        # A manual `begin --pause-seconds` longer than the default must not leave the snapshot
+        # expiring mid-window, or end_maintenance() has no consumers to restore.
+        _inspect_of(fake_control).active_queues.return_value = {"w": [{"name": "celery"}]}
+        from cqc_lem.utilities import maintenance
+        long_pause = maintenance.DEFAULT_PAUSE_SECONDS * 3
+        with patch(f"{_MOD}.pause_automation", return_value=True):
+            maintenance.begin_maintenance(pause_seconds=long_pause)
+        snapshot_call = [c for c in fake_redis.set.call_args_list
+                         if c.args[0] == "lem:maintenance:consumers"][0]
+        assert snapshot_call.kwargs["ex"] == long_pause * 2
+
+    def test_snapshot_ttl_floors_at_the_default_window(self, fake_redis, fake_control):
+        _inspect_of(fake_control).active_queues.return_value = {"w": [{"name": "celery"}]}
+        from cqc_lem.utilities import maintenance
+        with patch(f"{_MOD}.pause_automation", return_value=True):
+            maintenance.begin_maintenance(pause_seconds=60)
+        snapshot_call = [c for c in fake_redis.set.call_args_list
+                         if c.args[0] == "lem:maintenance:consumers"][0]
+        assert snapshot_call.kwargs["ex"] == maintenance.DEFAULT_PAUSE_SECONDS * 2
+
     def test_filters_to_requested_queues(self, fake_redis, fake_control):
         _inspect_of(fake_control).active_queues.return_value = {
             "main-worker@a": [{"name": "celery"}, {"name": "se_engage"}],

--- a/tests/unit/utilities/test_maintenance.py
+++ b/tests/unit/utilities/test_maintenance.py
@@ -1,0 +1,278 @@
+"""Unit tests for deploy maintenance mode (utilities/maintenance.py, issue #549)."""
+
+import json
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.maintenance"
+
+
+@pytest.fixture
+def fake_redis():
+    client = MagicMock()
+    with patch(f"{_MOD}._redis_client", return_value=client):
+        yield client
+
+
+@pytest.fixture
+def no_redis():
+    with patch(f"{_MOD}._redis_client", return_value=None):
+        yield
+
+
+@pytest.fixture
+def fake_control():
+    control = MagicMock()
+    with patch(f"{_MOD}._control", return_value=control):
+        yield control
+
+
+def _inspect_of(control):
+    return control.inspect.return_value
+
+
+class TestQueueNames:
+    def test_reads_queues_from_celeryconfig(self):
+        from cqc_lem.utilities.maintenance import queue_names
+        names = queue_names()
+        assert "celery" in names
+        assert {"se_engage", "se_outreach", "se_content"} <= set(names)
+
+    def test_falls_back_when_config_unavailable(self):
+        from cqc_lem.utilities import maintenance
+        with patch.dict("sys.modules", {"cqc_lem.app.celeryconfig": None}):
+            assert maintenance.queue_names() == maintenance.FALLBACK_QUEUES
+
+
+class TestMaintenanceFlag:
+    def test_remaining_reads_ttl(self, fake_redis):
+        fake_redis.ttl.return_value = 120
+        from cqc_lem.utilities.maintenance import is_maintenance_mode, maintenance_remaining
+        assert maintenance_remaining() == 120
+        assert is_maintenance_mode() is True
+
+    def test_not_set_is_zero(self, fake_redis):
+        fake_redis.ttl.return_value = -2
+        from cqc_lem.utilities.maintenance import is_maintenance_mode, maintenance_remaining
+        assert maintenance_remaining() == 0
+        assert is_maintenance_mode() is False
+
+    def test_fails_open_without_redis(self, no_redis):
+        from cqc_lem.utilities.maintenance import maintenance_remaining
+        assert maintenance_remaining() == 0
+
+    def test_redis_error_is_swallowed(self, fake_redis):
+        fake_redis.ttl.side_effect = RuntimeError("boom")
+        from cqc_lem.utilities.maintenance import maintenance_remaining
+        assert maintenance_remaining() == 0
+
+
+class TestInspection:
+    def test_worker_queue_map(self, fake_control):
+        _inspect_of(fake_control).active_queues.return_value = {
+            "main-worker@a": [{"name": "celery"}],
+            "selenium-se_engage-worker@b": [{"name": "se_engage"}, {"no_name": 1}],
+        }
+        from cqc_lem.utilities.maintenance import worker_queue_map
+        assert worker_queue_map() == {
+            "main-worker@a": ["celery"],
+            "selenium-se_engage-worker@b": ["se_engage"],
+        }
+
+    def test_worker_queue_map_on_broker_error(self, fake_control):
+        _inspect_of(fake_control).active_queues.side_effect = RuntimeError("no broker")
+        from cqc_lem.utilities.maintenance import worker_queue_map
+        assert worker_queue_map() == {}
+
+    def test_active_task_count_sums_workers(self, fake_control):
+        _inspect_of(fake_control).active.return_value = {"a": [{}, {}], "b": [{}], "c": None}
+        from cqc_lem.utilities.maintenance import active_task_count
+        assert active_task_count() == 3
+
+    def test_active_task_count_no_replies_is_zero(self, fake_control):
+        _inspect_of(fake_control).active.return_value = None
+        from cqc_lem.utilities.maintenance import active_task_count
+        assert active_task_count() == 0
+
+    def test_active_task_count_on_broker_error(self, fake_control):
+        _inspect_of(fake_control).active.side_effect = RuntimeError("no broker")
+        from cqc_lem.utilities.maintenance import active_task_count
+        assert active_task_count() == 0
+
+
+class TestBeginMaintenance:
+    def test_pauses_cancels_and_snapshots(self, fake_redis, fake_control):
+        _inspect_of(fake_control).active_queues.return_value = {
+            "main-worker@a": [{"name": "celery"}],
+            "selenium-se_engage-worker@b": [{"name": "se_engage"}],
+        }
+        from cqc_lem.utilities import maintenance
+        with patch(f"{_MOD}.pause_automation", return_value=True) as pause:
+            assert maintenance.begin_maintenance(pause_seconds=600) is True
+
+        pause.assert_called_once_with(600, maintenance.MAINTENANCE_REASON)
+        fake_redis.set.assert_any_call("lem:maintenance", "deploy", ex=600)
+        # Consumers are cancelled per (worker, queue) — never broadcast, or the main worker
+        # would come back consuming a Selenium lane.
+        cancelled = {(c.args[0], tuple(c.kwargs["destination"]))
+                     for c in fake_control.cancel_consumer.call_args_list}
+        assert cancelled == {("celery", ("main-worker@a",)),
+                             ("se_engage", ("selenium-se_engage-worker@b",))}
+        snapshot = json.loads(
+            [c for c in fake_redis.set.call_args_list if c.args[0] == "lem:maintenance:consumers"][0].args[1])
+        assert snapshot == {"main-worker@a": ["celery"],
+                            "selenium-se_engage-worker@b": ["se_engage"]}
+
+    def test_filters_to_requested_queues(self, fake_redis, fake_control):
+        _inspect_of(fake_control).active_queues.return_value = {
+            "main-worker@a": [{"name": "celery"}, {"name": "se_engage"}],
+        }
+        from cqc_lem.utilities.maintenance import begin_maintenance
+        with patch(f"{_MOD}.pause_automation", return_value=True):
+            begin_maintenance(pause_seconds=60, queues=["se_engage"])
+        fake_control.cancel_consumer.assert_called_once_with(
+            "se_engage", destination=["main-worker@a"])
+
+    def test_cancel_failure_does_not_abort(self, fake_redis, fake_control):
+        _inspect_of(fake_control).active_queues.return_value = {"w": [{"name": "celery"}]}
+        fake_control.cancel_consumer.side_effect = RuntimeError("broker down")
+        from cqc_lem.utilities.maintenance import begin_maintenance
+        with patch(f"{_MOD}.pause_automation", return_value=True):
+            assert begin_maintenance(pause_seconds=60) is True
+
+    def test_fails_open_without_redis(self, no_redis, fake_control):
+        _inspect_of(fake_control).active_queues.return_value = {}
+        from cqc_lem.utilities.maintenance import begin_maintenance
+        with patch(f"{_MOD}.pause_automation", return_value=False):
+            assert begin_maintenance(pause_seconds=60) is False
+
+    def test_redis_set_error_reports_not_stored(self, fake_redis, fake_control):
+        fake_redis.set.side_effect = RuntimeError("boom")
+        _inspect_of(fake_control).active_queues.return_value = {}
+        from cqc_lem.utilities.maintenance import begin_maintenance
+        with patch(f"{_MOD}.pause_automation", return_value=True):
+            assert begin_maintenance(pause_seconds=60) is False
+
+
+class TestDrainWorkers:
+    def test_returns_zero_once_drained(self):
+        from cqc_lem.utilities.maintenance import drain_workers
+        with patch(f"{_MOD}.active_task_count", side_effect=[2, 1, 0]):
+            assert drain_workers(timeout_seconds=60, poll_seconds=1, sleep=lambda s: None) == 0
+
+    def test_returns_remaining_on_timeout(self):
+        from cqc_lem.utilities.maintenance import drain_workers
+        with patch(f"{_MOD}.active_task_count", return_value=3):
+            assert drain_workers(timeout_seconds=0, poll_seconds=1, sleep=lambda s: None) == 3
+
+    def test_no_wait_when_already_idle(self):
+        sleeps = []
+        from cqc_lem.utilities.maintenance import drain_workers
+        with patch(f"{_MOD}.active_task_count", return_value=0):
+            assert drain_workers(timeout_seconds=60, poll_seconds=1, sleep=sleeps.append) == 0
+        assert sleeps == []
+
+
+class TestEndMaintenance:
+    def test_restores_consumers_and_resumes(self, fake_redis, fake_control):
+        fake_redis.get.return_value = json.dumps({"main-worker@a": ["celery"]}).encode()
+        from cqc_lem.utilities.maintenance import end_maintenance
+        with patch(f"{_MOD}.automation_pause_reason", return_value="deploy"), \
+                patch(f"{_MOD}.resume_automation", return_value=True) as resume:
+            assert end_maintenance() is True
+        fake_control.add_consumer.assert_called_once_with("celery", destination=["main-worker@a"])
+        resume.assert_called_once()
+        fake_redis.delete.assert_called_once_with("lem:maintenance", "lem:maintenance:consumers")
+
+    def test_leaves_a_foreign_pause_alone(self, fake_redis, fake_control):
+        """A 429 breaker pause must survive a deploy — only our own pause is lifted."""
+        fake_redis.get.return_value = None
+        from cqc_lem.utilities.maintenance import end_maintenance
+        with patch(f"{_MOD}.automation_pause_reason", return_value="429"), \
+                patch(f"{_MOD}.automation_pause_remaining", return_value=900), \
+                patch(f"{_MOD}.resume_automation") as resume:
+            assert end_maintenance() is False
+        resume.assert_not_called()
+
+    def test_resumes_when_nothing_is_paused(self, fake_redis, fake_control):
+        fake_redis.get.return_value = None
+        from cqc_lem.utilities.maintenance import end_maintenance
+        with patch(f"{_MOD}.automation_pause_reason", return_value=None), \
+                patch(f"{_MOD}.resume_automation", return_value=True) as resume:
+            assert end_maintenance() is True
+        resume.assert_called_once()
+
+    def test_add_consumer_failure_is_swallowed(self, fake_redis, fake_control):
+        fake_redis.get.return_value = json.dumps({"w": ["celery"]}).encode()
+        fake_control.add_consumer.side_effect = RuntimeError("gone")
+        from cqc_lem.utilities.maintenance import end_maintenance
+        with patch(f"{_MOD}.automation_pause_reason", return_value="deploy"), \
+                patch(f"{_MOD}.resume_automation", return_value=True):
+            assert end_maintenance() is True
+
+    def test_only_restores_requested_queues(self, fake_redis, fake_control):
+        fake_redis.get.return_value = json.dumps({"w": ["celery", "se_engage"]}).encode()
+        from cqc_lem.utilities.maintenance import end_maintenance
+        with patch(f"{_MOD}.automation_pause_reason", return_value="deploy"), \
+                patch(f"{_MOD}.resume_automation", return_value=True):
+            end_maintenance(queues=["se_engage"])
+        fake_control.add_consumer.assert_called_once_with("se_engage", destination=["w"])
+
+    def test_corrupt_snapshot_is_ignored(self, fake_redis, fake_control):
+        fake_redis.get.return_value = b"not-json"
+        from cqc_lem.utilities.maintenance import end_maintenance
+        with patch(f"{_MOD}.automation_pause_reason", return_value="deploy"), \
+                patch(f"{_MOD}.resume_automation", return_value=True):
+            assert end_maintenance() is True
+        fake_control.add_consumer.assert_not_called()
+
+    def test_works_without_redis(self, no_redis, fake_control):
+        from cqc_lem.utilities.maintenance import end_maintenance
+        with patch(f"{_MOD}.automation_pause_reason", return_value=None), \
+                patch(f"{_MOD}.resume_automation", return_value=False):
+            assert end_maintenance() is True
+        fake_control.add_consumer.assert_not_called()
+
+
+class TestStatus:
+    def test_reports_state(self, fake_redis, fake_control):
+        fake_redis.ttl.return_value = 60
+        _inspect_of(fake_control).active.return_value = {"w": [{}]}
+        _inspect_of(fake_control).active_queues.return_value = {"w": [{"name": "celery"}]}
+        from cqc_lem.utilities.maintenance import status
+        with patch(f"{_MOD}.automation_pause_reason", return_value="deploy"), \
+                patch(f"{_MOD}.automation_pause_remaining", return_value=60):
+            state = status()
+        assert state["maintenance"] is True
+        assert state["active_tasks"] == 1
+        assert state["worker_queues"] == {"w": ["celery"]}
+
+
+class TestCli:
+    def test_begin_subcommand(self):
+        from cqc_lem.utilities.maintenance import main
+        with patch(f"{_MOD}.begin_maintenance", return_value=True) as begin:
+            assert main(["begin", "--pause-seconds", "300"]) == 0
+        begin.assert_called_once_with(pause_seconds=300)
+
+    def test_drain_subcommand_exit_codes(self):
+        from cqc_lem.utilities.maintenance import main
+        with patch(f"{_MOD}.drain_workers", return_value=0):
+            assert main(["drain", "--timeout", "5", "--poll", "1"]) == 0
+        with patch(f"{_MOD}.drain_workers", return_value=2):
+            assert main(["drain"]) == 1
+
+    def test_end_subcommand(self):
+        from cqc_lem.utilities.maintenance import main
+        with patch(f"{_MOD}.end_maintenance", return_value=True) as end:
+            assert main(["end"]) == 0
+        end.assert_called_once()
+
+    def test_status_subcommand_prints_json(self, capsys):
+        from cqc_lem.utilities.maintenance import main
+        with patch(f"{_MOD}.status", return_value={"maintenance": False}):
+            assert main(["status"]) == 0
+        assert json.loads(capsys.readouterr().out) == {"maintenance": False}


### PR DESCRIPTION
## Why

Every deploy recreates the app containers, which SIGTERMs the Celery workers. Three things meant in-flight tasks were **killed and lost**:

1. Workers launched as `su $CELERY_USER -c "… celery … worker …"` without `exec` — the start script stayed PID 1, so Docker's SIGTERM went to the shell and **Celery never got its warm-shutdown signal**.
2. No `stop_grace_period` → Docker's 10s default, far shorter than a ~6-min video generation or a commenting loop.
3. Nothing stopped a worker from reserving *new* work in the seconds before the recreate.

## What changed

### A. Warm shutdown actually works
- **New `compose/local/celery/run-as-celery`** — `exec`s the worker after dropping privileges (`setpriv`, `su` fallback), so the celery process is what receives SIGTERM. It sets `HOME` for the target user, which `setpriv` (unlike `su`) does not — otherwise boto3 would stop finding the mounted `~/.aws` credentials.
- All three worker start scripts + `beat/start` now `exec` their process; the Dockerfile ships and `chmod +x`es the helper.
- `stop_grace_period: ${CELERY_STOP_GRACE_PERIOD:-8m}` on all four worker services (`30s` on beat). It's a ceiling, not a delay — Celery exits as soon as it drains.

### B. An interrupted task is never lost
- `celeryconfig.py`: `task_acks_late = True` is a **bool** again (it was `True,` — a stray one-tuple), `task_reject_on_worker_lost = True` globally, and `worker_cancel_long_running_tasks_on_connection_loss = False` (also clears the Celery 5 boot deprecation warning).
- Redis `visibility_timeout` now clears the longest task **plus the drain window** (`CELERY_LONGEST_TASK_SECONDS` + 15m → 4500s, both env-tunable). 60s of margin wasn't enough once a worker may take a full 8m grace period to stop — that's the classic acks_late + Redis double-run trap.
- **Idempotency audit** of the re-runnable paths: `post_to_linkedin` already short-circuits on `PostStatus.POSTED`; `comment_on_post` dedups on `has_commented_post` + the atomic `commented_posts` claim; DMs/followups/dispatchers are `QueueOnce`-locked. One real gap found and fixed: a worker **SIGKILLed** mid-comment can't run its `release_post_claim` except-branch, so its `claimed` row blocked the re-queued task forever (task re-run = silent no-op). `claim_post_for_comment` now takes over a claim left `claimed` for > `CLAIM_STALE_MINUTES` (60) — never a `commented` row, so it can't cause a double comment.

### C. Pause → drain → deploy → resume
- **New `src/cqc_lem/utilities/maintenance.py`** (+ CLI: `python -m cqc_lem.utilities.maintenance begin|drain|end|status`):
  - `begin` — pauses dispatch through the **existing** `pause_automation` Redis kill-switch (reason `deploy`, TTL-bounded) and `cancel_consumer`s each worker's *own* queues. The (worker, queue) pairs are snapshotted to Redis first, so a restore can't broadcast and make the main worker start consuming a Selenium lane.
  - `drain` — polls `inspect active` until idle or a bounded timeout.
  - `end` — restores the snapshotted consumers and lifts the pause **only if it's still ours**, so a 429-breaker or manual pause survives the deploy.
  - Everything fails **open**: unreachable Redis/broker = no-op, deploy proceeds as before.
- `scripts/deploy.sh` stops `celery_beat`, `begin`s, `drain`s (`DRAIN_TIMEOUT`, default 480s), migrates + recreates, then `end`s — on the rollback path too. Every maintenance call tolerates failure so it can never block a release.
- `docs/DEPLOYMENT.md` documents the three layers and the manual CLI; `.env.example` gains the new knobs (deliberately **not** added to `.env.prod.example`, so `check_env.sh` doesn't fail a deploy on a box that hasn't set them — all have defaults).

## Testing

`4863 passed` (`poetry run pytest tests/unit -q`), 53 of them new:
- `tests/unit/utilities/test_maintenance.py` (31) — begin/drain/end/status/CLI, per-worker consumer cancel + restore, foreign-pause protection, corrupt snapshot, and every fail-open path.
- `tests/unit/app/test_worker_shutdown.py` (22) — the infra contract that regressed silently before: every start script `exec`s and no longer shells out through `su`, the helper is shipped/executable and keeps `HOME`, all four workers carry a grace period, the durability settings and visibility-timeout math, and that `deploy.sh` really orders stop-beat → pause → drain → recreate → resume.
- Extensions to `test_rate_limit.py` (pause-reason accessor) and `test_db_commented_posts.py` (stale-claim takeover: takes over stale, never steals fresh, never reclaims `commented`).

**Still needs a live check** (acceptance criteria): trigger a deploy while a long task runs on the owner's account and confirm it completes or is cleanly re-queued.

Closes #549

🤖 Generated with [Claude Code](https://claude.com/claude-code)