### PR TITLE
feat(marketing): dogfooding self-marketing — brand account under phase-gated outbound caps (closes #504)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -215,6 +215,19 @@ EARLY_ADOPTER_P1_SLOTS=100
 # Optional Stripe coupon ID applied when a grant holder converts. Empty = extended trial only.
 EARLY_ADOPTER_COUPON_ID=
 
+# =============================================================================
+# Launch phase & brand (dogfooding) account — issue #504
+# =============================================================================
+# P0 private early-adopter / P1 open beta / P2 GA. Sets the brand account's daily
+# comment/DM/connect caps and connect approval posture (see utilities/brand_account.py).
+LAUNCH_PHASE=P0
+# The LEM brand LinkedIn account, onboarded as a normal user (same caps, 429 backoff, proxy).
+# OFF by default — it sends real outbound.
+BRAND_ACCOUNT_ENABLED=False
+BRAND_ACCOUNT_EMAIL=
+# Trial signup URL the brand's content/DMs steer toward. Empty = no CTA seeded.
+BRAND_SIGNUP_URL=
+
 # --- Stripe Test (use sk_test_* keys for test mode) ---
 STRIPE_API_KEY=sk_test_your_stripe_secret_key
 STRIPE_WEBHOOK_SECRET=whsec_your_webhook_signing_secret

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -79,6 +79,12 @@ app.conf.update(
             # cadence keeps the drip human-paced while staying responsive (no volume prospecting).
             'schedule': crontab(minute='*/5')
         },
+        'sync-brand-account': {
+            'task': 'cqc_lem.app.run_scheduler.auto_sync_brand_account',
+            # Just before the content plan runs, so the brand's phase caps/posture are already in
+            # place for the day's dogfooding run (issue #504). No-ops unless BRAND_ACCOUNT_ENABLED.
+            'schedule': crontab(hour='0', minute='45')
+        },
         'generate-content-plan': {
             'task': 'cqc_lem.app.run_content_plan.auto_generate_content',
             'schedule': crontab(hour='1', minute='0')  # Run every day at 1:00 AM

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -892,6 +892,43 @@ def auto_check_catchup_touches():
 
 
 @shared_task.task
+def auto_sync_brand_account():
+    """Daily: hold the LEM brand (dogfooding) account's outbound volume at whatever the current
+    LAUNCH_PHASE allows (issue #504).
+
+    Everything the brand actually DOES — the 30-day content plan, feed commenting, connect targeting,
+    appreciation/outreach DMs + follow-ups, the newsletter, company-page invites — already reaches it
+    through the same per-active-user beats as any paying customer, under the same caps, 429 backoff
+    and per-user proxy. So this task adds no outreach of its own: it only re-asserts the phase's caps
+    and connect posture onto the brand's engagement preferences, so advancing a phase (or a manual
+    cap edit) can never leave brand outbound running hotter than was signed off on.
+    """
+    from cqc_lem.utilities.brand_account import current_launch_phase, get_brand_user_id, \
+        sync_brand_preferences
+
+    user_id = get_brand_user_id()
+    if user_id is None:
+        return "Brand account not configured"
+
+    phase = current_launch_phase()
+    applied = sync_brand_preferences(phase)
+    if applied is None:
+        return f"Brand account sync failed (phase {phase})"
+
+    # The brand only engages while it counts as an active user — surface the gap rather than letting
+    # a disconnected/lapsed brand account look like it is quietly marketing.
+    if user_id not in set(get_active_user_ids()):
+        log_warning("Brand account is not active/connected — its automation will not run",
+                    user_id=user_id, task_name="auto_sync_brand_account")
+
+    log_info(f"Brand account synced to launch phase {phase}",
+             user_id=user_id, task_name="auto_sync_brand_account")
+    return (f"Brand account {user_id} synced to phase {phase} "
+            f"(comments/day {applied['max_comments_per_day']}, DMs/day {applied['max_dms_per_day']}, "
+            f"invites/day {applied['max_invites_per_day']})")
+
+
+@shared_task.task
 def auto_notify_missing_linkedin_session():
     """Email active users who have no validated LinkedIn session cookie, prompting them
     to connect — automation can't run without one. Throttled per-user inside

--- a/src/cqc_lem/utilities/brand_account.py
+++ b/src/cqc_lem/utilities/brand_account.py
@@ -1,0 +1,128 @@
+"""Config + policy for the LEM brand (dogfooding) account — issue #504.
+
+The brand account is a FIRST-CLASS user of LEM, not a special case: its 30-day content plan, feed
+commenting, connect targeting, appreciation/outreach DMs + follow-ups, newsletter and company-page
+invites all reach it through the same per-active-user beat tasks a paying customer goes through, and
+its volume is enforced by the same `engagement_preferences` caps, 429 backoff (`rate_limit.py`) and
+per-user proxy. So this module owns no outreach primitives at all — it only decides WHAT the brand
+user's caps and focus topics should be for the current `LAUNCH_PHASE`, so self-marketing can never
+quietly run hotter than the owner signed off on.
+"""
+
+from typing import Optional
+
+from cqc_lem.utilities.env_constants import (BRAND_ACCOUNT_EMAIL, BRAND_ACCOUNT_ENABLED,
+                                             BRAND_SIGNUP_URL, LAUNCH_PHASE)
+from cqc_lem.utilities.logger import log_debug, log_warning
+
+# Rollout phases from the launch plan (docs/launch-and-marketing-plan.md §A.1): P0 private
+# early-adopter, P1 open beta, P2 GA. Advancing a phase is the owner's call.
+LAUNCH_PHASES = ("P0", "P1", "P2")
+DEFAULT_LAUNCH_PHASE = "P0"
+
+# The ICP's pains, verbatim from the launch plan §C.2 — the brand posts about the problem LEM
+# solves, so every post doubles as a live demo of the product's own output.
+BRAND_FOCUS_TOPICS = (
+    "consistent LinkedIn presence without the grind",
+    "solo-founder pipeline",
+    "AI content that sounds like you",
+)
+
+# Hard ceilings: the brand is NEVER special-cased to go faster than a paying user, so no phase may
+# raise a cap above the product's own out-of-the-box defaults (see _ENGAGEMENT_DEFAULTS in db.py).
+BRAND_CAP_CEILINGS = {"max_comments_per_day": 20, "max_dms_per_day": 20, "max_invites_per_day": 10}
+
+# Outbound volume + approval posture per phase. Volume ramps only as the account warms and the
+# ToS-safety signals hold; P0 additionally keeps a human on every connect (`pre_review`) and files
+# sourced targets as drafts only (`suggest`).
+PHASE_OUTBOUND_POLICY = {
+    "P0": {"max_comments_per_day": 8, "max_dms_per_day": 5, "max_invites_per_day": 5,
+           "connection_request_mode": "pre_review", "connection_targeting_mode": "suggest"},
+    "P1": {"max_comments_per_day": 15, "max_dms_per_day": 10, "max_invites_per_day": 8,
+           "connection_request_mode": "auto_approve", "connection_targeting_mode": "auto_queue"},
+    "P2": {"max_comments_per_day": 20, "max_dms_per_day": 15, "max_invites_per_day": 10,
+           "connection_request_mode": "auto_approve", "connection_targeting_mode": "auto_queue"},
+}
+
+
+def current_launch_phase() -> str:
+    """The active rollout phase. An unrecognized value falls back to the most conservative phase
+    rather than failing open — a typo in the deployment .env must never widen outbound volume."""
+    phase = (LAUNCH_PHASE or "").strip().upper()
+    if phase not in LAUNCH_PHASES:
+        if phase:
+            log_warning(f"Unknown LAUNCH_PHASE '{LAUNCH_PHASE}' — falling back to {DEFAULT_LAUNCH_PHASE}")
+        return DEFAULT_LAUNCH_PHASE
+    return phase
+
+
+def brand_outbound_policy(phase: Optional[str] = None) -> dict:
+    """The brand's caps + approval posture for `phase` (defaults to the active one), clamped to the
+    per-user ceilings."""
+    resolved = (phase or current_launch_phase()).strip().upper()
+    policy = dict(PHASE_OUTBOUND_POLICY.get(resolved) or PHASE_OUTBOUND_POLICY[DEFAULT_LAUNCH_PHASE])
+    for cap, ceiling in BRAND_CAP_CEILINGS.items():
+        policy[cap] = max(0, min(ceiling, int(policy.get(cap) or 0)))
+    return policy
+
+
+def get_brand_user_id() -> Optional[int]:
+    """The brand account's user id, or None when dogfooding is off, no email is configured, or no
+    user matches it — every caller treats None as "there is no brand account to drive"."""
+    if not BRAND_ACCOUNT_ENABLED:
+        return None
+    email = (BRAND_ACCOUNT_EMAIL or "").strip()
+    if not email:
+        log_warning("Brand account enabled but BRAND_ACCOUNT_EMAIL is unset — skipping")
+        return None
+    from cqc_lem.utilities.db import get_user_id
+    user_id = get_user_id(email)
+    if not user_id:
+        log_warning(f"Brand account email {email} does not match any user — skipping")
+        return None
+    return int(user_id)
+
+
+def is_brand_user(user_id: int) -> bool:
+    """Whether `user_id` is the brand account (for attribution/observability, not for privileges)."""
+    brand_id = get_brand_user_id()
+    return brand_id is not None and int(user_id) == brand_id
+
+
+def brand_preference_overrides(existing: Optional[dict] = None, phase: Optional[str] = None) -> dict:
+    """The engagement-preference fields the brand policy owns, given the account's current prefs.
+
+    Caps and approval posture are ALWAYS re-asserted from the phase — that is the volume gate, so a
+    manual edit in the SPA must not survive it. The seeded content fields (focus topics, business
+    goals) are only filled when empty, so the owner can retune the brand's messaging without this
+    task stomping it back every night.
+    """
+    overrides = brand_outbound_policy(phase)
+    current = existing or {}
+    if not [t for t in (current.get("focus_topics") or []) if str(t).strip()]:
+        overrides["focus_topics"] = list(BRAND_FOCUS_TOPICS)
+    signup_url = (BRAND_SIGNUP_URL or "").strip()
+    if signup_url and not (current.get("business_goals") or "").strip():
+        overrides["business_goals"] = f"Drive free-trial signups at {signup_url}"
+    return overrides
+
+
+def sync_brand_preferences(phase: Optional[str] = None) -> Optional[dict]:
+    """Push the current phase's outbound policy onto the brand account's engagement preferences.
+
+    Returns the applied overrides, or None when there is no brand account to sync. The whole upsert
+    is one row (the V52 incident), so the existing prefs are merged in rather than replaced — voice,
+    tone and targeting the owner set stay exactly as they are.
+    """
+    user_id = get_brand_user_id()
+    if user_id is None:
+        return None
+    from cqc_lem.utilities.db import get_engagement_preferences, update_engagement_preferences
+    resolved_phase = (phase or current_launch_phase()).strip().upper()
+    existing = get_engagement_preferences(user_id) or {}
+    overrides = brand_preference_overrides(existing, resolved_phase)
+    if not update_engagement_preferences(user_id, {**existing, **overrides}):
+        log_warning("Could not sync brand account preferences", user_id=user_id)
+        return None
+    log_debug(f"Brand account synced to phase {resolved_phase}", user_id=user_id)
+    return overrides

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -190,6 +190,17 @@ EARLY_ADOPTER_P1_SLOTS    = int(get_constant_from_env('EARLY_ADOPTER_P1_SLOTS', 
 # Optional Stripe coupon applied at conversion for grant holders. Empty = no discount, trial only.
 EARLY_ADOPTER_COUPON_ID   = get_constant_from_env('EARLY_ADOPTER_COUPON_ID', default_value='')
 
+# Rollout phase (docs/launch-and-marketing-plan.md §A.1): P0 private early-adopter / P1 open beta /
+# P2 GA. It is the single knob that sets the brand account's outbound volume (see brand_account.py);
+# anything unrecognized falls back to P0 so a typo can never widen outbound.
+LAUNCH_PHASE              = get_constant_from_env('LAUNCH_PHASE', default_value='P0')
+# Dogfooding self-marketing (issue #504): the LEM brand LinkedIn account onboarded as a first-class
+# user. OFF by default — it sends real outbound, so each environment opts in explicitly.
+BRAND_ACCOUNT_ENABLED     = isTrue(get_constant_from_env('BRAND_ACCOUNT_ENABLED', default_value='False'))
+BRAND_ACCOUNT_EMAIL       = get_constant_from_env('BRAND_ACCOUNT_EMAIL', default_value='')
+# Trial signup URL the brand's content/DMs steer toward. Empty = no CTA seeded.
+BRAND_SIGNUP_URL          = get_constant_from_env('BRAND_SIGNUP_URL', default_value='')
+
 # Unit-economics inputs for the margin report (docs/cost-performance-margin-plan.md §C.1). Monthly
 # tier prices mirror the SPA pricing table — override per environment instead of editing code so a
 # price change never needs a deploy.

--- a/tests/unit/app/test_brand_account.py
+++ b/tests/unit/app/test_brand_account.py
@@ -1,0 +1,253 @@
+"""Unit tests for the LEM brand (dogfooding) account policy + scheduling glue (issue #504)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_BA = "cqc_lem.utilities.brand_account"
+_DB = "cqc_lem.utilities.db"
+_RS = "cqc_lem.app.run_scheduler"
+
+
+def _enabled(email="brand@lem.test", signup_url="", phase="P0"):
+    """Patch the module-level env constants brand_account read at import time."""
+    return [
+        patch(f"{_BA}.BRAND_ACCOUNT_ENABLED", True),
+        patch(f"{_BA}.BRAND_ACCOUNT_EMAIL", email),
+        patch(f"{_BA}.BRAND_SIGNUP_URL", signup_url),
+        patch(f"{_BA}.LAUNCH_PHASE", phase),
+    ]
+
+
+class _Patched:
+    """Apply a list of patchers as one context manager."""
+
+    def __init__(self, patchers):
+        self._patchers = patchers
+
+    def __enter__(self):
+        for p in self._patchers:
+            p.start()
+        return self
+
+    def __exit__(self, *exc):
+        for p in reversed(self._patchers):
+            p.stop()
+        return False
+
+
+class TestCurrentLaunchPhase:
+    def test_reads_the_configured_phase(self):
+        from cqc_lem.utilities.brand_account import current_launch_phase
+        with patch(f"{_BA}.LAUNCH_PHASE", "p1"):
+            assert current_launch_phase() == "P1"
+
+    def test_unknown_phase_falls_back_to_the_most_conservative(self):
+        from cqc_lem.utilities.brand_account import current_launch_phase
+        with patch(f"{_BA}.LAUNCH_PHASE", "GA"):
+            assert current_launch_phase() == "P0"
+
+    def test_empty_phase_falls_back_without_warning(self):
+        from cqc_lem.utilities.brand_account import current_launch_phase
+        with patch(f"{_BA}.LAUNCH_PHASE", ""), patch(f"{_BA}.log_warning") as warn:
+            assert current_launch_phase() == "P0"
+        warn.assert_not_called()
+
+
+class TestBrandOutboundPolicy:
+    def test_volume_ramps_with_the_phase(self):
+        from cqc_lem.utilities.brand_account import brand_outbound_policy
+        p0, p1, p2 = (brand_outbound_policy(p) for p in ("P0", "P1", "P2"))
+        for cap in ("max_comments_per_day", "max_dms_per_day", "max_invites_per_day"):
+            assert p0[cap] < p1[cap] <= p2[cap]
+
+    def test_p0_keeps_a_human_on_every_connect(self):
+        from cqc_lem.utilities.brand_account import brand_outbound_policy
+        policy = brand_outbound_policy("P0")
+        assert policy["connection_request_mode"] == "pre_review"
+        assert policy["connection_targeting_mode"] == "suggest"
+
+    def test_no_phase_exceeds_the_per_user_ceilings(self):
+        from cqc_lem.utilities.brand_account import (BRAND_CAP_CEILINGS, LAUNCH_PHASES,
+                                                     brand_outbound_policy)
+        for phase in LAUNCH_PHASES:
+            policy = brand_outbound_policy(phase)
+            for cap, ceiling in BRAND_CAP_CEILINGS.items():
+                assert policy[cap] <= ceiling
+
+    def test_an_over_ceiling_phase_entry_is_clamped(self):
+        from cqc_lem.utilities.brand_account import brand_outbound_policy
+        hot = {"P2": {"max_comments_per_day": 500, "max_dms_per_day": 500,
+                      "max_invites_per_day": 500, "connection_request_mode": "auto_approve",
+                      "connection_targeting_mode": "auto_queue"}}
+        with patch(f"{_BA}.PHASE_OUTBOUND_POLICY", hot):
+            assert brand_outbound_policy("P2") == {
+                "max_comments_per_day": 20, "max_dms_per_day": 20, "max_invites_per_day": 10,
+                "connection_request_mode": "auto_approve",
+                "connection_targeting_mode": "auto_queue"}
+
+    def test_defaults_to_the_active_phase(self):
+        from cqc_lem.utilities.brand_account import brand_outbound_policy
+        with patch(f"{_BA}.LAUNCH_PHASE", "P1"):
+            assert brand_outbound_policy() == brand_outbound_policy("P1")
+
+
+class TestGetBrandUserId:
+    def test_none_when_disabled(self):
+        from cqc_lem.utilities.brand_account import get_brand_user_id
+        with patch(f"{_BA}.BRAND_ACCOUNT_ENABLED", False), \
+             patch(f"{_DB}.get_user_id") as lookup:
+            assert get_brand_user_id() is None
+        lookup.assert_not_called()
+
+    def test_none_when_email_missing(self):
+        from cqc_lem.utilities.brand_account import get_brand_user_id
+        with _Patched(_enabled(email="  ")), patch(f"{_DB}.get_user_id") as lookup:
+            assert get_brand_user_id() is None
+        lookup.assert_not_called()
+
+    def test_none_when_no_user_matches(self):
+        from cqc_lem.utilities.brand_account import get_brand_user_id
+        with _Patched(_enabled()), patch(f"{_DB}.get_user_id", return_value=None):
+            assert get_brand_user_id() is None
+
+    def test_resolves_the_configured_email(self):
+        from cqc_lem.utilities.brand_account import get_brand_user_id
+        with _Patched(_enabled()), patch(f"{_DB}.get_user_id", return_value=7) as lookup:
+            assert get_brand_user_id() == 7
+        lookup.assert_called_once_with("brand@lem.test")
+
+    def test_is_brand_user(self):
+        from cqc_lem.utilities.brand_account import is_brand_user
+        with _Patched(_enabled()), patch(f"{_DB}.get_user_id", return_value=7):
+            assert is_brand_user(7) is True
+            assert is_brand_user(8) is False
+
+
+class TestBrandPreferenceOverrides:
+    def test_seeds_icp_focus_topics_when_none_set(self):
+        from cqc_lem.utilities.brand_account import BRAND_FOCUS_TOPICS, brand_preference_overrides
+        overrides = brand_preference_overrides({"focus_topics": []}, "P0")
+        assert overrides["focus_topics"] == list(BRAND_FOCUS_TOPICS)
+
+    def test_keeps_owner_tuned_focus_topics(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        overrides = brand_preference_overrides({"focus_topics": ["agency growth"]}, "P0")
+        assert "focus_topics" not in overrides
+
+    def test_blank_focus_topics_count_as_unset(self):
+        from cqc_lem.utilities.brand_account import BRAND_FOCUS_TOPICS, brand_preference_overrides
+        overrides = brand_preference_overrides({"focus_topics": ["  "]}, "P0")
+        assert overrides["focus_topics"] == list(BRAND_FOCUS_TOPICS)
+
+    def test_seeds_the_signup_cta_when_configured(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        with patch(f"{_BA}.BRAND_SIGNUP_URL", "https://lem.test/trial"):
+            overrides = brand_preference_overrides({}, "P0")
+        assert overrides["business_goals"] == "Drive free-trial signups at https://lem.test/trial"
+
+    def test_no_cta_without_a_signup_url_and_never_over_existing_goals(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        with patch(f"{_BA}.BRAND_SIGNUP_URL", ""):
+            assert "business_goals" not in brand_preference_overrides({}, "P0")
+        with patch(f"{_BA}.BRAND_SIGNUP_URL", "https://lem.test/trial"):
+            assert "business_goals" not in brand_preference_overrides({"business_goals": "mine"}, "P0")
+
+    def test_caps_are_always_reasserted_over_a_manual_edit(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        overrides = brand_preference_overrides({"max_comments_per_day": 999}, "P0")
+        assert overrides["max_comments_per_day"] == 8
+
+
+class TestSyncBrandPreferences:
+    def test_no_brand_account_is_a_no_op(self):
+        from cqc_lem.utilities.brand_account import sync_brand_preferences
+        with patch(f"{_BA}.BRAND_ACCOUNT_ENABLED", False), \
+             patch(f"{_DB}.update_engagement_preferences") as upsert:
+            assert sync_brand_preferences() is None
+        upsert.assert_not_called()
+
+    def test_merges_phase_policy_onto_existing_prefs(self):
+        from cqc_lem.utilities.brand_account import sync_brand_preferences
+        existing = {"tone": "warm", "max_comments_per_day": 20, "focus_topics": ["agency growth"]}
+        with _Patched(_enabled(phase="P1")), \
+             patch(f"{_DB}.get_user_id", return_value=7), \
+             patch(f"{_DB}.get_engagement_preferences", return_value=existing), \
+             patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
+            applied = sync_brand_preferences()
+        saved = upsert.call_args.args[1]
+        assert upsert.call_args.args[0] == 7
+        assert saved["tone"] == "warm"                        # voice the owner set survives
+        assert saved["focus_topics"] == ["agency growth"]     # so do their focus topics
+        assert saved["max_comments_per_day"] == 15            # but the phase cap wins
+        assert applied["max_dms_per_day"] == 10
+
+    def test_explicit_phase_argument_overrides_the_env(self):
+        from cqc_lem.utilities.brand_account import sync_brand_preferences
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.get_user_id", return_value=7), \
+             patch(f"{_DB}.get_engagement_preferences", return_value={}), \
+             patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
+            sync_brand_preferences("p2")
+        assert upsert.call_args.args[1]["max_comments_per_day"] == 20
+
+    def test_returns_none_when_the_upsert_fails(self):
+        from cqc_lem.utilities.brand_account import sync_brand_preferences
+        with _Patched(_enabled()), \
+             patch(f"{_DB}.get_user_id", return_value=7), \
+             patch(f"{_DB}.get_engagement_preferences", return_value={}), \
+             patch(f"{_DB}.update_engagement_preferences", return_value=False):
+            assert sync_brand_preferences() is None
+
+
+class TestAutoSyncBrandAccount:
+    def test_no_op_when_not_configured(self):
+        from cqc_lem.app.run_scheduler import auto_sync_brand_account
+        with patch(f"{_BA}.get_brand_user_id", return_value=None), \
+             patch(f"{_BA}.sync_brand_preferences") as sync:
+            assert auto_sync_brand_account() == "Brand account not configured"
+        sync.assert_not_called()
+
+    def test_syncs_and_reports_the_applied_caps(self):
+        from cqc_lem.app.run_scheduler import auto_sync_brand_account
+        applied = {"max_comments_per_day": 8, "max_dms_per_day": 5, "max_invites_per_day": 5}
+        with patch(f"{_BA}.get_brand_user_id", return_value=7), \
+             patch(f"{_BA}.current_launch_phase", return_value="P0"), \
+             patch(f"{_BA}.sync_brand_preferences", return_value=applied) as sync, \
+             patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
+             patch(f"{_RS}.log_warning") as warn:
+            result = auto_sync_brand_account()
+        sync.assert_called_once_with("P0")
+        warn.assert_not_called()
+        assert "synced to phase P0" in result
+        assert "comments/day 8" in result
+
+    def test_warns_when_the_brand_account_is_not_active(self):
+        from cqc_lem.app.run_scheduler import auto_sync_brand_account
+        applied = {"max_comments_per_day": 8, "max_dms_per_day": 5, "max_invites_per_day": 5}
+        with patch(f"{_BA}.get_brand_user_id", return_value=7), \
+             patch(f"{_BA}.current_launch_phase", return_value="P0"), \
+             patch(f"{_BA}.sync_brand_preferences", return_value=applied), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \
+             patch(f"{_RS}.log_warning") as warn:
+            auto_sync_brand_account()
+        assert warn.call_count == 1
+
+    def test_reports_a_failed_sync_without_touching_the_user_list(self):
+        from cqc_lem.app.run_scheduler import auto_sync_brand_account
+        with patch(f"{_BA}.get_brand_user_id", return_value=7), \
+             patch(f"{_BA}.current_launch_phase", return_value="P1"), \
+             patch(f"{_BA}.sync_brand_preferences", return_value=None), \
+             patch(f"{_RS}.get_active_user_ids") as actives:
+            assert auto_sync_brand_account() == "Brand account sync failed (phase P1)"
+        actives.assert_not_called()
+
+
+class TestBeatSchedule:
+    def test_task_is_registered_daily_before_the_content_plan(self):
+        from cqc_lem.app.my_celery import app
+        entry = app.conf.beat_schedule["sync-brand-account"]
+        assert entry["task"] == "cqc_lem.app.run_scheduler.auto_sync_brand_account"
+        assert entry["schedule"].hour == {0}
+        assert entry["schedule"].minute == {45}


### PR DESCRIPTION
## What & why

Flagship marketing channel from the launch plan §C.2: **LEM markets LEM** by running the product's own automation on a dedicated brand LinkedIn account.

The brand account is onboarded as a **first-class user, not a special case**. Its 30-day content plan (`plan_content_for_user` / `auto_generate_content`), feed commenting (`automate_commenting`), connect targeting (`scan_connection_candidates` → `send_connection_request`), appreciation/outreach DMs + follow-ups (`automate_appreciation_dms_for_user`, `process_user_followups`), newsletter and monthly company-page invites all already reach it through the existing per-active-user beat tasks, under the same `engagement_preferences` caps, 429 backoff (`rate_limit.py`) and per-user proxy as any paying customer. **No new outreach primitives were added** — the only new code is the config/seed and the scheduling glue that holds its volume at whatever the launch phase allows.

## Changes

- **`utilities/brand_account.py`** (new) — the whole policy core:
  - `LAUNCH_PHASE` → `PHASE_OUTBOUND_POLICY`: P0 `8` comments / `5` DMs / `5` invites per day + `pre_review` connects + `suggest` targeting → P1 `15`/`10`/`8` + `auto_approve`/`auto_queue` → P2 `20`/`15`/`10`.
  - `BRAND_CAP_CEILINGS` clamp every phase to the product's own out-of-the-box defaults (20/20/10), so the brand can never be special-cased to go faster than a user.
  - An unrecognized `LAUNCH_PHASE` falls back to **P0** — a typo in a deployment `.env` can never widen outbound.
  - Seeds the ICP-pain `focus_topics` and the trial-signup CTA (`business_goals`) **only when unset**, so owner retuning in the SPA sticks.
- **`app/run_scheduler.py`** — `auto_sync_brand_account()`: daily beat that re-asserts the phase policy onto the brand's prefs (merging, not replacing — voice/tone/targeting survive) and warns when the brand account isn't active/connected.
- **`app/my_celery.py`** — beat entry `sync-brand-account` at 00:45 UTC, just before the 01:00 content plan.
- **Config** (`env_constants.py`, `.env.example`) — `LAUNCH_PHASE` (default `P0`), `BRAND_ACCOUNT_ENABLED` (**off by default** — it sends real outbound), `BRAND_ACCOUNT_EMAIL`, `BRAND_SIGNUP_URL`. Fully disabled, the beat task no-ops.

## Testing

- New `tests/unit/app/test_brand_account.py` — 28 tests: phase resolution + fallback, cap ramp/ceiling clamping, brand-user resolution, seed-only-when-unset semantics, prefs merge, and the beat task's four paths (unconfigured / synced / inactive-warning / failed sync).
- **100% coverage** on `utilities/brand_account.py`; full unit suite green (4841 passed).

Closes #504

🤖 Generated with [Claude Code](https://claude.com/claude-code)