### PR TITLE
feat(marketing): automated video-tutorial production pipeline (closes #505)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -530,3 +530,37 @@ FEEDBACK_DUPLICATE_SIMILARITY=0.82
 FEEDBACK_FEATURE_DEMAND_MIN=2
 # Abuse guard: how many of ONE user's reports may reach GitHub per 24h.
 FEEDBACK_MAX_ISSUES_PER_USER_PER_DAY=3
+
+# --- Marketing video tutorials (issue #505) ---
+# Automated SPA how-to videos: headless capture -> grounded script -> TTS -> ffmpeg MP4 -> YouTube.
+# OFF by default (it renders and uploads public marketing assets).
+TUTORIAL_VIDEOS_ENABLED=False
+# Where the capture browser points. Empty = this deployment's own public URL.
+TUTORIAL_SPA_BASE_URL=
+# A real session token (+ email) for the demo account whose screens the authenticated flows film.
+# Unset -> auth-only flows are skipped instead of being filmed at the login modal.
+TUTORIAL_DEMO_SESSION_TOKEN=
+TUTORIAL_DEMO_EMAIL=
+# Voice-over: openai (cheapest, via LiteLLM lem-tts) or elevenlabs (premium).
+TUTORIAL_TTS_PROVIDER=openai
+TUTORIAL_TTS_MODEL=lem-tts
+TUTORIAL_TTS_VOICE=alloy
+TUTORIAL_TTS_COST_PER_1K_CHARS=0.015
+ELEVENLABS_API_KEY=
+ELEVENLABS_VOICE_ID=
+ELEVENLABS_MODEL=eleven_turbo_v2_5
+ELEVENLABS_COST_PER_1K_CHARS=0.15
+# Hard narration cap (the one thing that makes TTS expensive) + render-compute attribution.
+TUTORIAL_MAX_NARRATION_CHARS=1400
+TUTORIAL_RENDER_COST_PER_MINUTE=0.01
+# Burn captions into the frame (needs an ffmpeg with libass); the .srt sidecar is always written.
+TUTORIAL_BURN_CAPTIONS=False
+# Optional lem-image thumbnail (costs money per render).
+TUTORIAL_THUMBNAIL_ENABLED=False
+# Re-film a flow at most this often even when the UI has not changed.
+TUTORIAL_REFRESH_DAYS=90
+# YouTube Data API v3 upload. All three empty -> the MP4 is produced but never published.
+YOUTUBE_CLIENT_ID=
+YOUTUBE_CLIENT_SECRET=
+YOUTUBE_REFRESH_TOKEN=
+YOUTUBE_PRIVACY_STATUS=unlisted

--- a/.litellm/config.yaml
+++ b/.litellm/config.yaml
@@ -86,6 +86,13 @@ model_list:
       model: openai/dall-e-3
       api_key: os.environ/OPENAI_API_KEY
 
+  # ── TTS: tutorial voice-over (issue #505). tts-1 is the cheapest useful option
+  # ($15 / 1M characters) and streams straight back as mp3 bytes.
+  - model_name: lem-tts
+    litellm_params:
+      model: openai/tts-1
+      api_key: os.environ/OPENAI_API_KEY
+
   # ── EMBEDDING: cheap vectors for feedback dedup/clustering (issue #498) ──────
   # No Ollama Cloud embedding equivalent; text-embedding-3-small is the cheapest useful option.
   # Callers MUST tolerate this being unavailable — feedback dedup falls back to token overlap.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ src/cqc_lem/
 │   │   ├── verification_pin.py    email-PIN LinkedIn verification flow
 │   │   ├── rate_limit.py          429/auth-wall backoff
 │   │   └── helper.py, profile.py, token_refresh.py
+│   ├── marketing/ Outbound production
+│   │   └── video_tutorials.py  automated SPA tutorial videos (capture→script→TTS→ffmpeg→YouTube)
 │   ├── db.py      All database access (no raw SQL outside this file)
 │   ├── proxy.py   Per-user static residential proxy resolution
 │   ├── geocoding.py  Login Location city/state geocoding
@@ -155,6 +157,11 @@ Use `click_element_wait_retry()` for all click interactions — it handles trans
 - Targeting: include/exclude topics/keywords/authors, `min_reactions`, `max_post_age_hours`, plus LLM topic-relevance scoring.
 - Voice: tone, `comment_length` (short/medium/long; default short), style, emoji/hashtag toggles.
 - Caps: `max_comments_per_day`, `max_dms_per_day`; DM template editor with follow-up steps; Login Location (city/state geocoding via `utilities/geocoding.py`, with admin override).
+
+### Marketing video tutorials (`utilities/marketing/video_tutorials.py`, beat `produce-feature-tutorial`)
+- One declarative `TutorialFlow` per feature (routes + the CSS anchors that prove the screen rendered) → headless SPA capture via `get_docker_driver()` → grounded script (`lem-medium`) → TTS voice-over (OpenAI `lem-tts` by default, ElevenLabs behind `TUTORIAL_TTS_PROVIDER`) → ffmpeg MP4 with branded intro/outro + `.srt` → 9:16 clip → YouTube Data API v3 upload.
+- **Fail-closed**: a missing UI anchor, an unparseable script, profanity, an over-cap narration or a fabricated number aborts BEFORE any TTS/publish spend. Cost is attributed per part (script tokens, TTS characters, render minutes) and totalled on the manifest record.
+- State lives in `assets/videos/tutorials/manifest.json` (no schema change); the SPA embeds it via `TutorialVideos.tsx`. Weekly cadence, and a flow is re-filmed only when its captured UI fingerprint changes. OFF unless `TUTORIAL_VIDEOS_ENABLED`.
 
 ### Anti-bot / session infra
 - Per-user static residential proxy (`utilities/proxy.py`) + an in-memory **MV3 proxy-auth extension** (`selenium_util.py`, MV2 background pages are disabled in current Chrome).

--- a/compose/local/Dockerfile
+++ b/compose/local/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update -y && apt-get install --no-install-suggests --no-install-reco
     # Curl needed for AWS health checks
     curl \
     netcat-traditional \
+    # ffmpeg + ffprobe render the marketing tutorial videos (issue #505)
+    ffmpeg \
     # cleaning up unused files
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     && rm -rf /var/lib/apt/lists/*

--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -150,6 +150,9 @@ task_routes = {
     'cqc_lem.app.run_automation.auto_post_to_group': {'queue': 'se_content'},
     'cqc_lem.app.run_automation.auto_publish_newsletter_edition': {'queue': 'se_content'},
     'cqc_lem.app.run_automation.auto_publish_edition': {'queue': 'se_content'},
+    # Marketing tutorial capture drives a browser against OUR OWN SPA (issue #505), not LinkedIn,
+    # but it still needs a Selenium session — so it shares the content lane.
+    'cqc_lem.app.run_scheduler.auto_produce_feature_tutorial': {'queue': 'se_content'},
 }
 
 

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -253,6 +253,13 @@ app.conf.update(
             # sync so tier MRR is current, and after the weekly margin report so they never overlap.
             'schedule': crontab(hour='13', minute='0')
         },
+        'produce-feature-tutorial': {
+            'task': 'cqc_lem.app.run_scheduler.auto_produce_feature_tutorial',
+            # Wednesdays 20:00 UTC — one tutorial a week (issue #505), off-peak and clear of the
+            # Selenium engagement lanes' busy hours. Runs until every top-level feature is covered,
+            # then only re-films a flow whose UI actually changed.
+            'schedule': crontab(hour='20', minute='0', day_of_week='wednesday')
+        },
         'weekly-cost-routing': {
             'task': 'cqc_lem.app.run_scheduler.auto_weekly_cost_routing',
             # Mondays 14:00 UTC — after the margin report (12:00) and the alert sweep (13:00), so a

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1359,5 +1359,28 @@ def auto_weekly_cost_routing(self, days: int = COST_ROUTING_WINDOW_DAYS):
             f"(published={result['published']}, emailed={result['emailed']})")
 
 
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True}, queue='se_content')
+def auto_produce_feature_tutorial(self, flow_key: str = None):
+    """Weekly: produce ONE automated SPA feature tutorial — headless capture, grounded script, TTS
+    voice-over, ffmpeg MP4 + vertical clip, YouTube publish (issue #505). Runs on the se_content
+    Selenium lane because it drives a real browser; it never touches LinkedIn, so the 429 breaker
+    does not gate it. Uncovered features come first, then anything whose UI has changed."""
+    from cqc_lem.utilities.marketing.video_tutorials import (TutorialCaptureError,
+                                                            TutorialGuardrailError,
+                                                            TutorialRenderError, produce_tutorial)
+
+    try:
+        record = produce_tutorial(flow_key=flow_key)
+    except (TutorialCaptureError, TutorialGuardrailError, TutorialRenderError) as e:
+        # Fail-closed and loudly: a stale flow / bad script must be fixed, not published.
+        log_warning("Feature tutorial production aborted", exc=e,
+                    task_name="auto_produce_feature_tutorial")
+        return f"Aborted: {e}"
+    if not record:
+        return "No tutorial produced"
+    return (f"Produced tutorial '{record['flow']}' ({record['duration_seconds']}s, "
+            f"${record['total_usd']}, youtube={'yes' if record.get('youtube_url') else 'no'})")
+
+
 if __name__ == "__main__":
     print("Process finished")

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1359,7 +1359,8 @@ def auto_weekly_cost_routing(self, days: int = COST_ROUTING_WINDOW_DAYS):
             f"(published={result['published']}, emailed={result['emailed']})")
 
 
-@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True}, queue='se_content')
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True}, queue='se_content',
+                  reject_on_worker_lost=True)
 def auto_produce_feature_tutorial(self, flow_key: str = None):
     """Weekly: produce ONE automated SPA feature tutorial — headless capture, grounded script, TTS
     voice-over, ffmpeg MP4 + vertical clip, YouTube publish (issue #505). Runs on the se_content

--- a/src/cqc_lem/ui/src/components/TutorialVideos.tsx
+++ b/src/cqc_lem/ui/src/components/TutorialVideos.tsx
@@ -1,0 +1,80 @@
+import { useEffect, useState } from 'react'
+import api from '../api/client'
+
+// Automated feature tutorials (issue #505). The video agent writes a manifest of finished
+// tutorials into the shared assets volume; this reads it and embeds whatever is there. Nothing
+// produced yet -> renders nothing, so the page never shows an empty "videos" shell.
+interface TutorialRecord {
+  flow: string
+  title: string
+  description?: string | null
+  video_url: string
+  captions_url?: string | null
+  thumbnail_url?: string | null
+  youtube_url?: string | null
+  duration_seconds?: number
+}
+
+const MANIFEST = '/assets?file_name=videos/tutorials/manifest.json'
+
+export default function TutorialVideos() {
+  const [videos, setVideos] = useState<TutorialRecord[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    api
+      .get(MANIFEST)
+      .then((r) => {
+        const records: TutorialRecord[] = Object.values(r.data?.videos ?? {})
+        if (!cancelled) setVideos(records.filter((v) => v?.video_url))
+      })
+      // No manifest yet (404) is the normal pre-first-tutorial state, not an error worth showing.
+      .catch(() => undefined)
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (videos.length === 0) return null
+
+  return (
+    <section id="tutorials" className="py-16 px-4 bg-white">
+      <div className="max-w-5xl mx-auto">
+        <h2 className="text-3xl font-bold text-center text-gray-800 mb-12">See it in action</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+          {videos.map((video) => (
+            <div key={video.flow} className="rounded-xl border border-gray-100 shadow-sm overflow-hidden">
+              <video
+                className="w-full bg-black"
+                controls
+                preload="none"
+                poster={video.thumbnail_url ?? undefined}
+              >
+                <source src={video.video_url} type="video/mp4" />
+                {video.captions_url && (
+                  <track kind="captions" src={video.captions_url} srcLang="en" label="English" default />
+                )}
+              </video>
+              <div className="p-5">
+                <h3 className="font-bold text-gray-800 mb-1">{video.title}</h3>
+                {video.description && (
+                  <p className="text-sm text-gray-600 leading-relaxed line-clamp-3">{video.description}</p>
+                )}
+                {video.youtube_url && (
+                  <a
+                    href={video.youtube_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="inline-block mt-3 text-sm font-medium text-blue-600 hover:underline"
+                  >
+                    Watch on YouTube →
+                  </a>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/cqc_lem/ui/src/pages/Landing.tsx
+++ b/src/cqc_lem/ui/src/pages/Landing.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { useAuth } from '../contexts/AuthContext'
+import TutorialVideos from '../components/TutorialVideos'
 
 function FaqItem({ question, answer }: { question: string; answer: string }) {
   const [open, setOpen] = useState(false)
@@ -112,6 +113,9 @@ export default function Landing() {
           </div>
         </div>
       </section>
+
+      {/* Automated feature tutorials (issue #505) — renders nothing until one is produced */}
+      <TutorialVideos />
 
       {/* Stats */}
       <section className="py-16 px-4 bg-white">

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -267,6 +267,44 @@ ADMIN_SECRET = get_constant_from_env('ADMIN_SECRET')
 # (local/dev) so only deployments that set it enforce token auth.
 API_ACCESS_TOKENS = get_constant_from_env('API_ACCESS_TOKENS', default_value='')
 
+# --- Marketing video tutorials (issue #505) ---
+# Fully-automated SPA how-to videos: headless capture -> grounded script -> TTS -> ffmpeg MP4 ->
+# YouTube. OFF by default: it renders + uploads public marketing assets, so it only runs where
+# someone deliberately turned it on.
+TUTORIAL_VIDEOS_ENABLED = isTrue(get_constant_from_env('TUTORIAL_VIDEOS_ENABLED', default_value='False'))
+# Where the capture browser points. Defaults to this deployment's own public URL.
+TUTORIAL_SPA_BASE_URL = get_constant_from_env('TUTORIAL_SPA_BASE_URL', default_value='')
+# A real LEM session token (+ its email) for the demo account whose screens the authenticated
+# flows capture. Without it, auth-only flows are skipped rather than filmed at a login modal.
+TUTORIAL_DEMO_SESSION_TOKEN = get_constant_from_env('TUTORIAL_DEMO_SESSION_TOKEN', default_value='')
+TUTORIAL_DEMO_EMAIL = get_constant_from_env('TUTORIAL_DEMO_EMAIL', default_value='')
+# Voice-over provider: 'openai' (default, cheapest — routed through LiteLLM like every other model)
+# or 'elevenlabs' (premium, needs ELEVENLABS_API_KEY + ELEVENLABS_VOICE_ID).
+TUTORIAL_TTS_PROVIDER = get_constant_from_env('TUTORIAL_TTS_PROVIDER', default_value='openai')
+TUTORIAL_TTS_MODEL = get_constant_from_env('TUTORIAL_TTS_MODEL', default_value='lem-tts')
+TUTORIAL_TTS_VOICE = get_constant_from_env('TUTORIAL_TTS_VOICE', default_value='alloy')
+# OpenAI tts-1 list price is $15.00 / 1M characters.
+TUTORIAL_TTS_COST_PER_1K_CHARS = float(get_constant_from_env('TUTORIAL_TTS_COST_PER_1K_CHARS', default_value='0.015'))
+ELEVENLABS_API_KEY = get_constant_from_env('ELEVENLABS_API_KEY')
+ELEVENLABS_VOICE_ID = get_constant_from_env('ELEVENLABS_VOICE_ID', default_value='')
+ELEVENLABS_MODEL = get_constant_from_env('ELEVENLABS_MODEL', default_value='eleven_turbo_v2_5')
+ELEVENLABS_COST_PER_1K_CHARS = float(get_constant_from_env('ELEVENLABS_COST_PER_1K_CHARS', default_value='0.15'))
+# Hard cap on narration length — a runaway script is the one thing that makes TTS expensive.
+TUTORIAL_MAX_NARRATION_CHARS = int(get_constant_from_env('TUTORIAL_MAX_NARRATION_CHARS', default_value='1400'))
+# Local ffmpeg render compute, attributed per video so a tutorial's true cost is visible.
+TUTORIAL_RENDER_COST_PER_MINUTE = float(get_constant_from_env('TUTORIAL_RENDER_COST_PER_MINUTE', default_value='0.01'))
+# Burn captions into the frame (needs an ffmpeg with libass). The .srt sidecar is always written.
+TUTORIAL_BURN_CAPTIONS = isTrue(get_constant_from_env('TUTORIAL_BURN_CAPTIONS', default_value='False'))
+TUTORIAL_THUMBNAIL_ENABLED = isTrue(get_constant_from_env('TUTORIAL_THUMBNAIL_ENABLED', default_value='False'))
+# Re-film a flow at most this often even when nothing in the UI changed.
+TUTORIAL_REFRESH_DAYS = int(get_constant_from_env('TUTORIAL_REFRESH_DAYS', default_value='90'))
+# YouTube Data API v3 upload. Publishing no-ops (the MP4 still lands in assets) unless all three
+# OAuth values are present. 'unlisted' by default so nothing goes public unreviewed.
+YOUTUBE_CLIENT_ID = get_constant_from_env('YOUTUBE_CLIENT_ID', default_value='')
+YOUTUBE_CLIENT_SECRET = get_constant_from_env('YOUTUBE_CLIENT_SECRET')
+YOUTUBE_REFRESH_TOKEN = get_constant_from_env('YOUTUBE_REFRESH_TOKEN')
+YOUTUBE_PRIVACY_STATUS = get_constant_from_env('YOUTUBE_PRIVACY_STATUS', default_value='unlisted')
+
 # Set other constants here
 USE_DOCKER_BROWSER = isTrue(get_constant_from_env('USE_DOCKER_BROWSER', default_value='True'))
 

--- a/src/cqc_lem/utilities/marketing/video_tutorials.py
+++ b/src/cqc_lem/utilities/marketing/video_tutorials.py
@@ -1,0 +1,795 @@
+"""Automated SPA video-tutorial production (issue #505).
+
+One declarative flow per feature -> one finished tutorial:
+
+  capture (real SPA, headless Chrome) -> grounded script (lem-medium) -> TTS voice-over
+  -> ffmpeg MP4 (branded intro/outro + captions) -> vertical clip -> YouTube -> manifest
+
+Everything is FAIL-CLOSED and ordered cheapest-first: capture runs before a single token is
+spent, and a flow whose declared UI anchors no longer exist raises instead of narrating a
+screen that has moved. Narration is grounded in the flow definition + the text actually read
+off the captured screens, and audited for fabricated specifics before any TTS spend.
+
+Cost per video is attributed in three parts: script tokens (via `_call_llm` -> track_llm_call),
+TTS characters and local render minutes (both via `track_media_cost`), and the total is stored
+on the manifest record so a tutorial's true cost is answerable per video.
+
+The no-self-promo guardrail from `content_alignment` is deliberately NOT applied here: this is
+LEM's own product marketing, the one content type where naming the product IS the point.
+"""
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timezone, timedelta
+from typing import Optional
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
+
+from cqc_lem import assets_dir
+from cqc_lem.utilities.ai.content_alignment import (apply_contractions, cap_em_dashes,
+                                                    find_ai_tell_words, humanize_text)
+from cqc_lem.utilities.env_constants import (API_URL_FINAL, ELEVENLABS_API_KEY,
+                                             ELEVENLABS_COST_PER_1K_CHARS, ELEVENLABS_MODEL,
+                                             ELEVENLABS_VOICE_ID, TUTORIAL_BURN_CAPTIONS,
+                                             TUTORIAL_DEMO_EMAIL, TUTORIAL_DEMO_SESSION_TOKEN,
+                                             TUTORIAL_MAX_NARRATION_CHARS,
+                                             TUTORIAL_REFRESH_DAYS,
+                                             TUTORIAL_RENDER_COST_PER_MINUTE,
+                                             TUTORIAL_SPA_BASE_URL,
+                                             TUTORIAL_THUMBNAIL_ENABLED,
+                                             TUTORIAL_TTS_COST_PER_1K_CHARS, TUTORIAL_TTS_MODEL,
+                                             TUTORIAL_TTS_PROVIDER, TUTORIAL_TTS_VOICE,
+                                             TUTORIAL_VIDEOS_ENABLED, WAIT_DEFAULT_TIMEOUT,
+                                             YOUTUBE_CLIENT_ID, YOUTUBE_CLIENT_SECRET,
+                                             YOUTUBE_PRIVACY_STATUS, YOUTUBE_REFRESH_TOKEN)
+from cqc_lem.utilities.linkedin_formatter import normalize_public_text
+from cqc_lem.utilities.logger import log_debug, log_error, log_info, log_warning
+from cqc_lem.utilities.observability import FEATURE_MARKETING, track_media_cost
+from cqc_lem.utilities.utils import create_folder_if_not_exists
+
+TASK_NAME = "produce_feature_tutorial"
+
+# 1920x1080 landscape master; the dogfooding clip is 1080x1920 of the same render.
+FRAME_WIDTH, FRAME_HEIGHT = 1920, 1080
+VERTICAL_WIDTH, VERTICAL_HEIGHT = 1080, 1920
+CARD_SECONDS = 3.0          # branded intro/outro card hold
+SEGMENT_PAD_SECONDS = 0.5   # breathing room after each narrated segment
+FPS = 30
+
+
+class TutorialCaptureError(RuntimeError):
+    """The SPA did not render the flow we declared — never narrate a screen we could not verify."""
+
+
+class TutorialGuardrailError(RuntimeError):
+    """The generated script failed a publish guardrail (length, profanity, ungrounded claim)."""
+
+
+class TutorialRenderError(RuntimeError):
+    """ffmpeg is unavailable or failed — no half-rendered MP4 is ever published."""
+
+
+@dataclass(frozen=True)
+class TutorialStep:
+    caption: str                      # on-screen caption AND what this beat of the script covers
+    path: str                         # SPA route, relative to the tutorial base URL
+    wait_for: Optional[str] = None    # CSS selector that MUST exist, or the flow is stale
+    click: Optional[str] = None       # CSS selector clicked after the frame is captured
+    seconds: float = 4.0              # minimum hold for this frame
+
+
+@dataclass(frozen=True)
+class TutorialFlow:
+    key: str
+    title: str
+    feature: str                      # grounded one-liner: the only feature claim the script may make
+    steps: tuple = ()
+    requires_auth: bool = False       # capture needs the demo account's session seeded
+    tags: tuple = ("linkedin", "automation", "tutorial")
+
+
+# The declarative flow registry. Routes/selectors mirror the real SPA (`ui/src/App.tsx`); a
+# selector that disappears fails the capture, which is exactly how a UI change gets noticed.
+TUTORIAL_FLOWS: dict[str, TutorialFlow] = {
+    "getting-started": TutorialFlow(
+        key="getting-started",
+        title="Getting started with LinkedIn Engagement Manager",
+        feature=("LEM automates LinkedIn engagement end to end: it plans and schedules a month of "
+                 "posts, comments on your feed, and replies to your own posts, all in your own voice."),
+        steps=(
+            TutorialStep(caption="What LEM does", path="/", wait_for="h1", seconds=5.0),
+            TutorialStep(caption="The feature set", path="/#features", wait_for="#features",
+                         seconds=6.0),
+            TutorialStep(caption="Pick a plan and sign in", path="/#pricing", wait_for="#pricing",
+                         seconds=5.0),
+        ),
+    ),
+    "content-studio": TutorialFlow(
+        key="content-studio",
+        title="Reviewing and approving posts in the Content Studio",
+        feature=("The Content Studio is where every generated post, newsletter and DM waits for "
+                 "your approval before it is published or sent."),
+        steps=(
+            TutorialStep(caption="Open the Content Studio", path="/content", wait_for="main",
+                         seconds=5.0),
+            TutorialStep(caption="Review what is queued", path="/content?tab=review",
+                         wait_for="main", seconds=6.0),
+            TutorialStep(caption="Newsletter editions", path="/content?tab=newsletters",
+                         wait_for="main", seconds=5.0),
+        ),
+        requires_auth=True,
+    ),
+    "engagement-preferences": TutorialFlow(
+        key="engagement-preferences",
+        title="Setting your engagement preferences",
+        feature=("Account preferences control who LEM engages with, the voice it writes in, and how "
+                 "many comments and DMs it may send per day."),
+        steps=(
+            TutorialStep(caption="Open your account settings", path="/account", wait_for="main",
+                         seconds=5.0),
+            TutorialStep(caption="Targeting, voice and daily caps", path="/account",
+                         wait_for="main", seconds=7.0),
+        ),
+        requires_auth=True,
+    ),
+}
+
+
+# --- paths + manifest ------------------------------------------------------------------------
+# The manifest lives in the shared assets volume (survives deploys) and doubles as the SPA embed
+# source, so shipping this feature needs no schema change.
+
+def tutorials_dir() -> str:
+    path = os.path.join(assets_dir, "videos", "tutorials")
+    create_folder_if_not_exists(path)
+    return path
+
+
+def manifest_path() -> str:
+    return os.path.join(tutorials_dir(), "manifest.json")
+
+
+def load_manifest() -> dict:
+    try:
+        with open(manifest_path(), "r", encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, ValueError):
+        return {"videos": {}}
+    if not isinstance(data, dict) or not isinstance(data.get("videos"), dict):
+        return {"videos": {}}
+    return data
+
+
+def save_manifest(manifest: dict) -> None:
+    with open(manifest_path(), "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+
+
+def asset_url(relative_path: str) -> str:
+    """Public /api/assets URL for a file under assets_dir — what the SPA embeds."""
+    return f"{API_URL_FINAL}/api/assets?file_name={relative_path.lstrip('/')}"
+
+
+def spa_base_url() -> str:
+    return (TUTORIAL_SPA_BASE_URL or API_URL_FINAL).rstrip("/")
+
+
+def ui_fingerprint(markers: list) -> str:
+    """Hash of the text read off each captured screen. A changed fingerprint means the UI moved,
+    which is the trigger to re-film — the "refresh on UI-change" half of the cadence."""
+    joined = "\n".join(re.sub(r"\s+", " ", str(m or "")).strip()[:400] for m in markers)
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()[:16]
+
+
+def _flow_available(flow: TutorialFlow) -> bool:
+    return bool(not flow.requires_auth or TUTORIAL_DEMO_SESSION_TOKEN)
+
+
+def next_flow(manifest: Optional[dict] = None) -> Optional[TutorialFlow]:
+    """The one flow worth producing this run: an uncovered feature first (the weekly cadence runs
+    until every top-level feature has a tutorial), then the stalest covered one."""
+    manifest = manifest if manifest is not None else load_manifest()
+    videos = manifest.get("videos") or {}
+    candidates = [f for f in TUTORIAL_FLOWS.values() if _flow_available(f)]
+    uncovered = [f for f in candidates if f.key not in videos]
+    if uncovered:
+        return uncovered[0]
+    cutoff = datetime.now(timezone.utc) - timedelta(days=TUTORIAL_REFRESH_DAYS)
+    stale = [f for f in candidates if _produced_before(videos.get(f.key), cutoff)]
+    if stale:
+        return sorted(stale, key=lambda f: str((videos.get(f.key) or {}).get("produced_at") or ""))[0]
+    return None
+
+
+def is_current(record: Optional[dict], fingerprint: str) -> bool:
+    """True when an existing tutorial still shows today's UI and is inside the refresh window —
+    the two conditions that make re-filming pure spend."""
+    if not record:
+        return False
+    if record.get("fingerprint") != fingerprint:
+        return False
+    cutoff = datetime.now(timezone.utc) - timedelta(days=TUTORIAL_REFRESH_DAYS)
+    return not _produced_before(record, cutoff)
+
+
+def _produced_before(record: Optional[dict], cutoff: datetime) -> bool:
+    raw = (record or {}).get("produced_at")
+    if not raw:
+        return True
+    try:
+        produced = datetime.fromisoformat(str(raw))
+    except ValueError:
+        return True
+    if produced.tzinfo is None:
+        produced = produced.replace(tzinfo=timezone.utc)
+    return produced < cutoff
+
+
+# --- capture ---------------------------------------------------------------------------------
+
+def _seed_demo_session(driver, base_url: str) -> None:
+    """Put the demo account's session token where the SPA's AuthContext reads it, so protected
+    routes render the real product instead of the login modal."""
+    driver.get(f"{base_url}/")
+    driver.execute_script(
+        "window.localStorage.setItem('lem_session', arguments[0]);"
+        "window.localStorage.setItem('lem_email', arguments[1]);",
+        TUTORIAL_DEMO_SESSION_TOKEN, TUTORIAL_DEMO_EMAIL or "demo@example.com",
+    )
+
+
+def capture_flow(flow: TutorialFlow, driver=None) -> dict:
+    """Screenshot every step of `flow` against the running SPA. Raises TutorialCaptureError the
+    moment a declared anchor is missing or a screenshot fails — a tutorial is never built on a
+    screen we could not verify."""
+    from cqc_lem.utilities.selenium_util import click_first, find_first, get_docker_driver
+
+    if flow.requires_auth and not TUTORIAL_DEMO_SESSION_TOKEN:
+        raise TutorialCaptureError(
+            f"Flow '{flow.key}' needs an authenticated SPA session but TUTORIAL_DEMO_SESSION_TOKEN is unset")
+
+    base_url = spa_base_url()
+    frames_dir = os.path.join(tutorials_dir(), flow.key, "frames")
+    create_folder_if_not_exists(frames_dir)
+    owns_driver = driver is None
+    # No user_id on purpose: this session hits OUR OWN SPA, never LinkedIn, so it wants neither a
+    # residential proxy nor a user's geo profile.
+    driver = driver or get_docker_driver(headless=True, session_name="TutorialCapture")
+    wait = WebDriverWait(driver, WAIT_DEFAULT_TIMEOUT)
+    frames, markers = [], []
+    try:
+        if flow.requires_auth:
+            _seed_demo_session(driver, base_url)
+        for index, step in enumerate(flow.steps):
+            driver.get(f"{base_url}{step.path}")
+            if step.wait_for:
+                element = find_first(driver, wait, [(By.CSS_SELECTOR, step.wait_for)],
+                                     f"tutorial:{flow.key}:{index}", required=False)
+                if element is None:
+                    raise TutorialCaptureError(
+                        f"Flow '{flow.key}' step {index} anchor '{step.wait_for}' not found at "
+                        f"{step.path} — the UI changed, re-declare the flow before publishing")
+                markers.append(_element_text(element))
+            frame_path = os.path.join(frames_dir, f"{index:02d}.png")
+            if not driver.save_screenshot(frame_path):
+                raise TutorialCaptureError(f"Flow '{flow.key}' step {index} screenshot failed")
+            frames.append(frame_path)
+            if step.click:
+                click_first(driver, wait, [(By.CSS_SELECTOR, step.click)],
+                            f"tutorial:{flow.key}:{index}:click", required=False)
+    finally:
+        if owns_driver:
+            try:
+                driver.quit()
+            except Exception as e:
+                log_warning("Tutorial capture driver quit failed", exc=e, task_name=TASK_NAME)
+
+    log_info(f"Tutorial capture: {len(frames)} frame(s) for '{flow.key}'", task_name=TASK_NAME)
+    return {"frames": frames, "markers": markers, "fingerprint": ui_fingerprint(markers)}
+
+
+def _element_text(element) -> str:
+    try:
+        return str(element.text or "")
+    except Exception:
+        return ""
+
+
+# --- script ----------------------------------------------------------------------------------
+
+_SCRIPT_SYSTEM = (
+    "You write the voice-over script for a short screen-recorded product tutorial. You will be given "
+    "the feature description, the ordered on-screen steps, and the text actually visible on each "
+    "captured screen.\n\n"
+    "HARD RULES:\n"
+    "- Narrate ONLY what the steps and the captured screen text support. Never invent a feature, a "
+    "menu, a number, a price, a statistic, a customer, or a result.\n"
+    "- One short spoken paragraph per step, 2 sentences max, written the way a person talks.\n"
+    "- Second person ('you'), present tense, no marketing hype, no AI cliches (no seamless, robust, "
+    "leverage, unlock, elevate, journey, game-changing).\n"
+    "- Naming the product is expected; this is its own tutorial.\n\n"
+    "Return ONLY a JSON object, no prose or code fences:\n"
+    '{"intro": "...", "segments": ["...", "..."], "outro": "...", "youtube_title": "...", '
+    '"youtube_description": "..."}\n'
+    "`segments` MUST have exactly one entry per step, in order. `intro` says what the viewer will "
+    "learn, `outro` is one plain next-step line."
+)
+
+# Numbers/prices are the fabrication that costs credibility, so they must be traceable to the
+# flow definition or the captured screens.
+_NUMERIC_CLAIM_RE = re.compile(r"(?:\$\s?\d[\d,.]*|\d[\d,.]*\s?%|\b\d[\d,.]*\b)")
+_PROFANITY = frozenset({
+    "shit", "shitty", "fuck", "fucking", "fucked", "bullshit", "asshole", "bastard", "bitch",
+    "dick", "damn", "goddamn", "crap", "piss", "cunt", "twat", "wanker",
+})
+
+
+def _script_prompt(flow: TutorialFlow, capture: dict) -> str:
+    lines = [f"Feature: {flow.feature}", f"Tutorial title: {flow.title}", "", "Steps:"]
+    markers = capture.get("markers") or []
+    for index, step in enumerate(flow.steps):
+        seen = re.sub(r"\s+", " ", str(markers[index] if index < len(markers) else "")).strip()
+        lines.append(f"{index + 1}. {step.caption} (route {step.path})")
+        if seen:
+            lines.append(f"   Text visible on this screen: {seen[:400]}")
+    return "\n".join(lines)
+
+
+def grounding_text(flow: TutorialFlow, capture: dict) -> str:
+    parts = [flow.title, flow.feature] + [s.caption for s in flow.steps] + [s.path for s in flow.steps]
+    parts += [str(m) for m in (capture.get("markers") or [])]
+    return "\n".join(parts)
+
+
+def ungrounded_claims(narration: str, allowed: str) -> list:
+    """Numeric/price claims in the narration that appear nowhere in the flow definition or the
+    captured screen text. Deterministic — no LLM, so the gate itself can never hallucinate."""
+    allowed_numbers = set(_NUMERIC_CLAIM_RE.findall(allowed or ""))
+    allowed_norm = {n.replace(" ", "") for n in allowed_numbers}
+    out = []
+    for hit in _NUMERIC_CLAIM_RE.findall(narration or ""):
+        if hit.replace(" ", "") not in allowed_norm and hit not in out:
+            out.append(hit)
+    return out
+
+
+def check_narration(narration: str, allowed: str) -> None:
+    """Publish guardrails, in fail-closed order: something to say, inside the TTS budget, clean,
+    and free of invented specifics."""
+    text = (narration or "").strip()
+    if not text:
+        raise TutorialGuardrailError("Script produced no narration")
+    if len(text) > TUTORIAL_MAX_NARRATION_CHARS:
+        raise TutorialGuardrailError(
+            f"Narration is {len(text)} chars, over the {TUTORIAL_MAX_NARRATION_CHARS} cap")
+    words = {w.lower().strip(".,!?;:") for w in text.split()}
+    profane = sorted(words & _PROFANITY)
+    if profane:
+        raise TutorialGuardrailError(f"Narration contains disallowed language: {', '.join(profane)}")
+    invented = ungrounded_claims(text, allowed)
+    if invented:
+        raise TutorialGuardrailError(
+            f"Narration contains ungrounded specifics: {', '.join(invented[:5])}")
+
+
+def _spoken(text: str) -> str:
+    """Plain, TTS-safe prose: at most one em-dash (capped BEFORE normalization folds them into
+    hyphens), no smart punctuation to mispronounce, and the contractions a person actually says."""
+    return apply_contractions(normalize_public_text(cap_em_dashes(str(text or ""), 1)).strip())
+
+
+def generate_script(flow: TutorialFlow, capture: dict) -> dict:
+    """Brand-voice, grounded narration for a captured flow. Raises TutorialGuardrailError before
+    any TTS/publish spend if the result is unusable."""
+    from cqc_lem.utilities.ai.ai_helper import _call_llm
+
+    response = _call_llm(
+        model="lem-medium",
+        messages=[{"role": "system", "content": _SCRIPT_SYSTEM},
+                  {"role": "user", "content": _script_prompt(flow, capture)}],
+        temperature=0.5,
+        _track_feature=FEATURE_MARKETING,
+    )
+    raw = (response.choices[0].message.content or "").strip()
+    data = _coerce_script(raw, len(flow.steps))
+    if data is None:
+        raise TutorialGuardrailError(f"Could not parse a script for flow '{flow.key}'")
+
+    intro = _spoken(data["intro"]) or f"Here is how {flow.title.lower()} works."
+    outro = _spoken(data["outro"]) or "That is the whole flow. Try it on your own account."
+    segments = [{"caption": step.caption, "narration": _spoken(narration), "seconds": step.seconds}
+                for step, narration in zip(flow.steps, data["segments"])]
+    segments = ([{"caption": flow.title, "narration": intro, "seconds": CARD_SECONDS}] + segments
+                + [{"caption": "Next step", "narration": outro, "seconds": CARD_SECONDS}])
+
+    narration = " ".join(s["narration"] for s in segments).strip()
+    check_narration(narration, grounding_text(flow, capture))
+    tells = find_ai_tell_words(narration)
+    if tells:
+        log_warning(f"Tutorial narration still carries AI-tell words: {', '.join(tells[:5])}",
+                    task_name=TASK_NAME)
+
+    title = _spoken(data["youtube_title"]) or flow.title
+    # The description is read, not spoken, so it gets the full READER-mode de-slop pass.
+    description = humanize_text(data["youtube_description"], content_type="post") or flow.feature
+    return {"segments": segments, "narration": narration, "title": title[:100],
+            "description": description[:4500]}
+
+
+def _coerce_script(raw: str, step_count: int) -> Optional[dict]:
+    match = re.search(r"\{.*\}", raw or "", re.DOTALL)
+    if not match:
+        return None
+    try:
+        data = json.loads(match.group(0))
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    segments = data.get("segments")
+    if isinstance(segments, str):
+        segments = [segments]
+    if not isinstance(segments, list) or len(segments) < step_count:
+        return None
+    return {
+        "intro": str(data.get("intro") or ""),
+        "outro": str(data.get("outro") or ""),
+        "segments": [str(s or "") for s in segments[:step_count]],
+        "youtube_title": str(data.get("youtube_title") or ""),
+        "youtube_description": str(data.get("youtube_description") or ""),
+    }
+
+
+# --- voice-over ------------------------------------------------------------------------------
+
+def tts_cost_usd(chars: int, provider: Optional[str] = None) -> float:
+    provider = (provider or TUTORIAL_TTS_PROVIDER or "openai").lower()
+    rate = ELEVENLABS_COST_PER_1K_CHARS if provider == "elevenlabs" else TUTORIAL_TTS_COST_PER_1K_CHARS
+    return round(rate * max(0, int(chars or 0)) / 1000.0, 6)
+
+
+def _tts_openai(text: str, out_path: str) -> None:
+    from cqc_lem.utilities.ai.client import client
+    response = client.audio.speech.create(model=TUTORIAL_TTS_MODEL, voice=TUTORIAL_TTS_VOICE,
+                                          input=text)
+    # openai>=1.x exposes both write_to_file and raw .content depending on the response wrapper.
+    if hasattr(response, "write_to_file"):
+        response.write_to_file(out_path)
+        return
+    with open(out_path, "wb") as f:
+        f.write(response.content)
+
+
+def _tts_elevenlabs(text: str, out_path: str) -> None:
+    import requests
+    if not (ELEVENLABS_API_KEY and ELEVENLABS_VOICE_ID):
+        raise TutorialRenderError("TUTORIAL_TTS_PROVIDER=elevenlabs but no API key / voice id is set")
+    response = requests.post(
+        f"https://api.elevenlabs.io/v1/text-to-speech/{ELEVENLABS_VOICE_ID}",
+        headers={"xi-api-key": ELEVENLABS_API_KEY, "accept": "audio/mpeg"},
+        json={"text": text, "model_id": ELEVENLABS_MODEL},
+        timeout=120,
+    )
+    response.raise_for_status()
+    with open(out_path, "wb") as f:
+        f.write(response.content)
+
+
+def synthesize_segment(text: str, out_path: str) -> str:
+    """One narrated segment to an mp3, with its characters billed to the marketing feature."""
+    provider = (TUTORIAL_TTS_PROVIDER or "openai").lower()
+    if provider == "elevenlabs":
+        _tts_elevenlabs(text, out_path)
+    else:
+        _tts_openai(text, out_path)
+    track_media_cost("audio", provider, tts_cost_usd(len(text), provider),
+                     feature=FEATURE_MARKETING, qty=len(text),
+                     model=ELEVENLABS_MODEL if provider == "elevenlabs" else TUTORIAL_TTS_MODEL)
+    return out_path
+
+
+# --- render ----------------------------------------------------------------------------------
+
+def _ffmpeg_bin(name: str = "ffmpeg") -> str:
+    path = shutil.which(name)
+    if not path:
+        raise TutorialRenderError(f"{name} is not installed — cannot render a tutorial video")
+    return path
+
+
+def _run(cmd: list) -> str:
+    log_debug(f"ffmpeg: {' '.join(cmd[:6])}...", task_name=TASK_NAME)
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise TutorialRenderError(f"{os.path.basename(cmd[0])} failed: {(result.stderr or '')[-500:]}")
+    return result.stdout or ""
+
+
+def audio_duration(path: str) -> float:
+    out = _run([_ffmpeg_bin("ffprobe"), "-v", "error", "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1", path])
+    try:
+        return float((out or "").strip())
+    except ValueError:
+        return 0.0
+
+
+def brand_card(text: str, out_path: str, subtitle: str = "") -> str:
+    """Branded intro/outro frame. PIL only — no design service, no network."""
+    import textwrap
+    from PIL import Image, ImageDraw
+    image = Image.new("RGB", (FRAME_WIDTH, FRAME_HEIGHT), (11, 34, 64))  # LEM deep blue
+    draw = ImageDraw.Draw(image)
+    title_font, sub_font = _card_fonts()
+    lines = textwrap.wrap(str(text or ""), width=28) or [""]
+    line_height = 92
+    top = FRAME_HEIGHT // 2 - 40 - (len(lines) - 1) * line_height // 2
+    for index, line in enumerate(lines):
+        _centered(draw, line, top + index * line_height, title_font, (255, 255, 255))
+    if subtitle:
+        _centered(draw, subtitle, top + len(lines) * line_height + 40, sub_font, (146, 180, 219))
+    image.save(out_path)
+    return out_path
+
+
+def _card_fonts():
+    from PIL import ImageFont
+    for candidate in ("/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+                      "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"):
+        if os.path.exists(candidate):
+            return ImageFont.truetype(candidate, 72), ImageFont.truetype(candidate, 40)
+    return ImageFont.load_default(size=72), ImageFont.load_default(size=40)
+
+
+def _centered(draw, text: str, y: int, font, fill: tuple) -> None:
+    left, top, right, bottom = draw.textbbox((0, 0), text, font=font)
+    draw.text(((FRAME_WIDTH - (right - left)) / 2, y - (bottom - top) / 2), text, font=font, fill=fill)
+
+
+def _srt_timestamp(seconds: float) -> str:
+    total_ms = int(round(max(0.0, seconds) * 1000))
+    hours, rem = divmod(total_ms, 3600000)
+    minutes, rem = divmod(rem, 60000)
+    secs, ms = divmod(rem, 1000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{ms:03d}"
+
+
+def write_captions(segments: list, out_path: str) -> str:
+    """SRT sidecar built from the REAL per-segment audio durations, so captions match the voice."""
+    blocks, clock = [], 0.0
+    for index, segment in enumerate(segments, start=1):
+        end = clock + float(segment.get("duration") or 0.0)
+        blocks.append(f"{index}\n{_srt_timestamp(clock)} --> {_srt_timestamp(end)}\n"
+                      f"{segment.get('narration') or segment.get('caption') or ''}\n")
+        clock = end
+    with open(out_path, "w", encoding="utf-8") as f:
+        f.write("\n".join(blocks))
+    return out_path
+
+
+def concat_audio(paths: list, out_path: str) -> str:
+    list_file = f"{out_path}.txt"
+    with open(list_file, "w", encoding="utf-8") as f:
+        for path in paths:
+            f.write(f"file '{os.path.abspath(path)}'\n")
+    _run([_ffmpeg_bin(), "-y", "-f", "concat", "-safe", "0", "-i", list_file, "-c", "copy", out_path])
+    return out_path
+
+
+def assemble_video(segments: list, audio_path: str, out_path: str,
+                   captions_path: Optional[str] = None) -> str:
+    """Frames (held for their segment's real audio duration) + voice-over -> H.264 MP4."""
+    list_file = f"{out_path}.frames.txt"
+    with open(list_file, "w", encoding="utf-8") as f:
+        for segment in segments:
+            f.write(f"file '{os.path.abspath(segment['frame'])}'\n")
+            f.write(f"duration {max(0.5, float(segment['duration'])):.3f}\n")
+        # The concat demuxer drops the final entry's duration, so the last frame is repeated.
+        f.write(f"file '{os.path.abspath(segments[-1]['frame'])}'\n")
+
+    video_filter = (f"scale={FRAME_WIDTH}:{FRAME_HEIGHT}:force_original_aspect_ratio=decrease,"
+                    f"pad={FRAME_WIDTH}:{FRAME_HEIGHT}:(ow-iw)/2:(oh-ih)/2,setsar=1")
+    if captions_path and TUTORIAL_BURN_CAPTIONS:
+        video_filter += f",subtitles={captions_path}"
+    _run([_ffmpeg_bin(), "-y", "-f", "concat", "-safe", "0", "-i", list_file, "-i", audio_path,
+          "-vf", video_filter, "-r", str(FPS), "-c:v", "libx264", "-pix_fmt", "yuv420p",
+          "-c:a", "aac", "-b:a", "128k", "-shortest", out_path])
+    return out_path
+
+
+def render_vertical_clip(mp4_path: str, out_path: str) -> str:
+    """9:16 cut of the same render — the clip the dogfooding agents post."""
+    _run([_ffmpeg_bin(), "-y", "-i", mp4_path, "-vf",
+          f"scale={VERTICAL_WIDTH}:{VERTICAL_HEIGHT}:force_original_aspect_ratio=decrease,"
+          f"pad={VERTICAL_WIDTH}:{VERTICAL_HEIGHT}:(ow-iw)/2:(oh-ih)/2,setsar=1",
+          "-c:v", "libx264", "-pix_fmt", "yuv420p", "-c:a", "copy", out_path])
+    return out_path
+
+
+def generate_thumbnail(flow: TutorialFlow, out_dir: str) -> Optional[str]:
+    """Optional lem-image thumbnail (off by default — it costs money per render)."""
+    if not TUTORIAL_THUMBNAIL_ENABLED:
+        return None
+    try:
+        from cqc_lem.utilities.ai.ai_helper import generate_dall_e_image_from_prompt
+        from cqc_lem.utilities.utils import save_video_url_to_dir
+        urls = generate_dall_e_image_from_prompt(
+            f"Clean, flat product-tutorial thumbnail illustrating: {flow.title}. "
+            "No text, no logos, calm blue palette.")
+        if not urls:
+            return None
+        return save_video_url_to_dir(urls[0], out_dir)
+    except Exception as e:
+        log_warning("Tutorial thumbnail generation failed", exc=e, task_name=TASK_NAME)
+        return None
+
+
+# --- publish ---------------------------------------------------------------------------------
+
+def youtube_configured() -> bool:
+    return bool(YOUTUBE_CLIENT_ID and YOUTUBE_CLIENT_SECRET and YOUTUBE_REFRESH_TOKEN)
+
+
+def _youtube_access_token() -> str:
+    import requests
+    response = requests.post("https://oauth2.googleapis.com/token", timeout=30, data={
+        "client_id": YOUTUBE_CLIENT_ID, "client_secret": YOUTUBE_CLIENT_SECRET,
+        "refresh_token": YOUTUBE_REFRESH_TOKEN, "grant_type": "refresh_token",
+    })
+    response.raise_for_status()
+    token = (response.json() or {}).get("access_token")
+    if not token:
+        raise RuntimeError("YouTube token refresh returned no access_token")
+    return token
+
+
+def publish_to_youtube(mp4_path: str, title: str, description: str,
+                       tags: Optional[list] = None) -> Optional[str]:
+    """Resumable upload via the YouTube Data API v3 (plain requests — no extra SDK). Returns the
+    watch URL, or None when YouTube is not configured or the upload fails: an unpublished MP4 is
+    still a usable asset, so this never fails the whole production."""
+    if not youtube_configured():
+        log_info("YouTube publish skipped — no OAuth credentials configured", task_name=TASK_NAME)
+        return None
+    import requests
+    try:
+        token = _youtube_access_token()
+        metadata = {
+            "snippet": {"title": title[:100], "description": description[:5000],
+                        "tags": list(tags or [])[:15], "categoryId": "28"},
+            "status": {"privacyStatus": YOUTUBE_PRIVACY_STATUS, "selfDeclaredMadeForKids": False},
+        }
+        start = requests.post(
+            "https://www.googleapis.com/upload/youtube/v3/videos",
+            params={"uploadType": "resumable", "part": "snippet,status"},
+            headers={"Authorization": f"Bearer {token}", "Content-Type": "application/json"},
+            json=metadata, timeout=60)
+        start.raise_for_status()
+        upload_url = start.headers.get("Location")
+        if not upload_url:
+            raise RuntimeError("YouTube resumable session returned no upload URL")
+        with open(mp4_path, "rb") as f:
+            upload = requests.put(upload_url, data=f,
+                                  headers={"Authorization": f"Bearer {token}",
+                                           "Content-Type": "video/mp4"}, timeout=900)
+        upload.raise_for_status()
+        video_id = (upload.json() or {}).get("id")
+        if not video_id:
+            raise RuntimeError("YouTube upload returned no video id")
+        log_info(f"Published tutorial to YouTube: {video_id}", task_name=TASK_NAME)
+        return f"https://www.youtube.com/watch?v={video_id}"
+    except Exception as e:
+        log_error("YouTube tutorial upload failed", exc=e, task_name=TASK_NAME)
+        return None
+
+
+# --- orchestration ---------------------------------------------------------------------------
+
+def produce_tutorial(flow_key: Optional[str] = None, driver=None) -> Optional[dict]:
+    """Produce (and publish) ONE tutorial end to end. Returns the manifest record, or None when
+    the pipeline is disabled or there is nothing due. Raises on capture/guardrail/render failure —
+    a broken tutorial must never reach YouTube."""
+    if not TUTORIAL_VIDEOS_ENABLED:
+        log_info("Tutorial production skipped — TUTORIAL_VIDEOS_ENABLED is off", task_name=TASK_NAME)
+        return None
+
+    manifest = load_manifest()
+    if flow_key:
+        flow = TUTORIAL_FLOWS.get(flow_key)
+        if flow is None:
+            raise ValueError(f"Unknown tutorial flow {flow_key!r}. Known: {sorted(TUTORIAL_FLOWS)}")
+        if not _flow_available(flow):
+            log_warning(f"Tutorial flow '{flow_key}' needs a demo session — skipped",
+                        task_name=TASK_NAME)
+            return None
+    else:
+        flow = next_flow(manifest)
+    if flow is None:
+        log_info("Tutorial production: every feature flow is covered and current", task_name=TASK_NAME)
+        return None
+
+    work_dir = os.path.join(tutorials_dir(), flow.key)
+    create_folder_if_not_exists(work_dir)
+
+    capture = capture_flow(flow, driver=driver)
+    existing = (manifest.get("videos") or {}).get(flow.key)
+    # An explicit flow_key is a deliberate re-film request; the scheduled pass stops here when the
+    # captured UI still matches what we already published.
+    if not flow_key and is_current(existing, capture["fingerprint"]):
+        log_info(f"Tutorial '{flow.key}' is current (UI unchanged) — nothing to re-film",
+                 task_name=TASK_NAME)
+        return None
+
+    script = generate_script(flow, capture)
+    segments = script["segments"]
+
+    # Frames: branded intro card, one captured screen per step, branded outro card.
+    frames = ([brand_card(flow.title[:90], os.path.join(work_dir, "intro.png"),
+                          subtitle="LinkedIn Engagement Manager")]
+              + capture["frames"]
+              + [brand_card("Try it on your account", os.path.join(work_dir, "outro.png"),
+                            subtitle=spa_base_url())])
+    if len(frames) != len(segments):
+        raise TutorialRenderError(
+            f"Frame/segment mismatch for '{flow.key}': {len(frames)} frames vs {len(segments)} segments")
+
+    audio_dir = os.path.join(work_dir, "audio")
+    create_folder_if_not_exists(audio_dir)
+    audio_paths = []
+    for index, segment in enumerate(segments):
+        segment["frame"] = frames[index]
+        audio_path = synthesize_segment(segment["narration"], os.path.join(audio_dir, f"{index:02d}.mp3"))
+        audio_paths.append(audio_path)
+        segment["duration"] = max(float(segment.get("seconds") or 0.0),
+                                  audio_duration(audio_path) + SEGMENT_PAD_SECONDS)
+
+    voiceover = concat_audio(audio_paths, os.path.join(work_dir, "voiceover.mp3"))
+    captions = write_captions(segments, os.path.join(work_dir, f"{flow.key}.srt"))
+    mp4 = assemble_video(segments, voiceover, os.path.join(work_dir, f"{flow.key}.mp4"), captions)
+    vertical = render_vertical_clip(mp4, os.path.join(work_dir, f"{flow.key}-vertical.mp4"))
+    thumbnail = generate_thumbnail(flow, work_dir)
+
+    duration_seconds = round(sum(float(s["duration"]) for s in segments), 2)
+    render_usd = round(TUTORIAL_RENDER_COST_PER_MINUTE * duration_seconds / 60.0, 6)
+    track_media_cost("video", "local-ffmpeg", render_usd, feature=FEATURE_MARKETING,
+                     qty=duration_seconds, model="ffmpeg-libx264",
+                     meta={"flow": flow.key, "kind": "tutorial"})
+    narration_chars = len(script["narration"])
+    total_usd = round(tts_cost_usd(narration_chars) + render_usd, 6)
+
+    youtube_url = publish_to_youtube(mp4, script["title"], script["description"], list(flow.tags))
+
+    record = {
+        "flow": flow.key,
+        "title": script["title"],
+        "description": script["description"],
+        "produced_at": datetime.now(timezone.utc).isoformat(),
+        "fingerprint": capture["fingerprint"],
+        "duration_seconds": duration_seconds,
+        "narration_chars": narration_chars,
+        "tts_provider": (TUTORIAL_TTS_PROVIDER or "openai").lower(),
+        "tts_usd": tts_cost_usd(narration_chars),
+        "render_usd": render_usd,
+        "total_usd": total_usd,
+        "video_url": asset_url(_relative_asset(mp4)),
+        "vertical_url": asset_url(_relative_asset(vertical)),
+        "captions_url": asset_url(_relative_asset(captions)),
+        "thumbnail_url": asset_url(_relative_asset(thumbnail)) if thumbnail else None,
+        "youtube_url": youtube_url,
+    }
+    manifest.setdefault("videos", {})[flow.key] = record
+    manifest["updated_at"] = record["produced_at"]
+    save_manifest(manifest)
+    log_info(f"Tutorial '{flow.key}' produced: {duration_seconds}s, ${total_usd} "
+             f"({narration_chars} narration chars), youtube={'yes' if youtube_url else 'no'}",
+             task_name=TASK_NAME)
+    return record
+
+
+def _relative_asset(path: str) -> str:
+    return os.path.relpath(path, assets_dir).replace(os.sep, "/")

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -111,11 +111,15 @@ FEATURE_CONTENT = "content"
 FEATURE_COMMENT = "comment"
 FEATURE_DM = "dm"
 FEATURE_NEWSLETTER = "newsletter"
+# Outbound/marketing production (video tutorials, issue #505) — spend that acquires users rather
+# than serving one, so it must never blend into a user's per-feature content cost.
+FEATURE_MARKETING = "marketing"
 FEATURE_SYSTEM = "system"
 
 # First match wins, so the order encodes precedence: `dispatch_comment_followups` is comment work,
 # and `automate_profile_viewer_engagement` is outreach DM work despite ending in "engagement".
 _TASK_FEATURE_RULES = (
+    ("tutorial", FEATURE_MARKETING),
     ("newsletter", FEATURE_NEWSLETTER),
     ("edition", FEATURE_NEWSLETTER),
     ("profile_viewer", FEATURE_DM),

--- a/tests/unit/app/test_feature_tutorials.py
+++ b/tests/unit/app/test_feature_tutorials.py
@@ -1,0 +1,67 @@
+"""Unit tests for the weekly feature-tutorial beat task (issue #505)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_VT = "cqc_lem.utilities.marketing.video_tutorials"
+
+
+def _record(**overrides):
+    record = {"flow": "getting-started", "duration_seconds": 32.5, "total_usd": 0.021,
+              "youtube_url": "https://www.youtube.com/watch?v=abc"}
+    record.update(overrides)
+    return record
+
+
+class TestAutoProduceFeatureTutorial:
+    def test_reports_the_produced_tutorial_and_its_cost(self):
+        with patch(f"{_VT}.produce_tutorial", return_value=_record()) as produce:
+            from cqc_lem.app.run_scheduler import auto_produce_feature_tutorial
+            result = auto_produce_feature_tutorial()
+        produce.assert_called_once_with(flow_key=None)
+        assert "getting-started" in result and "$0.021" in result and "youtube=yes" in result
+
+    def test_notes_when_the_render_was_not_published(self):
+        with patch(f"{_VT}.produce_tutorial", return_value=_record(youtube_url=None)):
+            from cqc_lem.app.run_scheduler import auto_produce_feature_tutorial
+            assert "youtube=no" in auto_produce_feature_tutorial()
+
+    def test_nothing_due_is_not_a_failure(self):
+        with patch(f"{_VT}.produce_tutorial", return_value=None):
+            from cqc_lem.app.run_scheduler import auto_produce_feature_tutorial
+            assert auto_produce_feature_tutorial() == "No tutorial produced"
+
+    def test_a_specific_flow_can_be_requested(self):
+        with patch(f"{_VT}.produce_tutorial", return_value=_record(flow="content-studio")) as produce:
+            from cqc_lem.app.run_scheduler import auto_produce_feature_tutorial
+            auto_produce_feature_tutorial(flow_key="content-studio")
+        produce.assert_called_once_with(flow_key="content-studio")
+
+    @pytest.mark.parametrize("error", ["TutorialCaptureError", "TutorialGuardrailError",
+                                       "TutorialRenderError"])
+    def test_pipeline_failures_abort_the_task_without_raising(self, error):
+        from cqc_lem.utilities.marketing import video_tutorials as vt
+        exc = getattr(vt, error)("stale UI")
+        with patch(f"{_VT}.produce_tutorial", side_effect=exc):
+            from cqc_lem.app.run_scheduler import auto_produce_feature_tutorial
+            result = auto_produce_feature_tutorial()
+        assert result == "Aborted: stale UI"
+
+    def test_an_unexpected_error_still_surfaces(self):
+        with patch(f"{_VT}.produce_tutorial", side_effect=RuntimeError("disk full")):
+            from cqc_lem.app.run_scheduler import auto_produce_feature_tutorial
+            with pytest.raises(RuntimeError, match="disk full"):
+                auto_produce_feature_tutorial()
+
+
+class TestBeatSchedule:
+    def test_runs_weekly_on_the_selenium_content_lane(self):
+        from cqc_lem.app import celeryconfig
+        from cqc_lem.app.my_celery import app
+        entry = app.conf.beat_schedule["produce-feature-tutorial"]
+        assert entry["task"] == "cqc_lem.app.run_scheduler.auto_produce_feature_tutorial"
+        assert entry["schedule"].hour == {20}
+        assert entry["schedule"].day_of_week == {3}  # Wednesday
+        assert celeryconfig.task_routes[entry["task"]] == {"queue": "se_content"}

--- a/tests/unit/utilities/test_video_tutorials.py
+++ b/tests/unit/utilities/test_video_tutorials.py
@@ -1,0 +1,582 @@
+"""Unit tests for the automated video-tutorial pipeline (issue #505).
+
+Every external boundary is mocked — Selenium capture, TTS, ffmpeg/ffprobe and the YouTube upload —
+so the whole production runs end to end in-process. The guardrails get the most attention: this
+pipeline publishes to a public channel, so "fails closed" has to be pinned, not assumed.
+"""
+
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cqc_lem.utilities.marketing import video_tutorials as vt
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.marketing.video_tutorials"
+
+
+@pytest.fixture(autouse=True)
+def _isolated_assets(tmp_path, monkeypatch):
+    monkeypatch.setattr(vt, "assets_dir", str(tmp_path))
+    monkeypatch.setattr(vt, "TUTORIAL_SPA_BASE_URL", "https://lem.test")
+    monkeypatch.setattr(vt, "API_URL_FINAL", "https://lem.test")
+    monkeypatch.setattr(vt, "TUTORIAL_DEMO_SESSION_TOKEN", "")
+    monkeypatch.setattr(vt, "TUTORIAL_VIDEOS_ENABLED", True)
+    monkeypatch.setattr(vt, "TUTORIAL_THUMBNAIL_ENABLED", False)
+    monkeypatch.setattr(vt, "YOUTUBE_CLIENT_ID", "")
+    monkeypatch.setattr(vt, "YOUTUBE_CLIENT_SECRET", "")
+    monkeypatch.setattr(vt, "YOUTUBE_REFRESH_TOKEN", "")
+    yield
+
+
+def _flow(steps=2, requires_auth=False, key="sample"):
+    return vt.TutorialFlow(
+        key=key,
+        title="Sample feature tour",
+        feature="The sample feature does exactly one grounded thing.",
+        steps=tuple(vt.TutorialStep(caption=f"Step {i}", path=f"/s{i}", wait_for="main",
+                                    seconds=3.0)
+                    for i in range(steps)),
+        requires_auth=requires_auth,
+    )
+
+
+def _driver(screenshot=True):
+    def _save(path):
+        if not screenshot:
+            return False
+        with open(path, "wb") as f:
+            f.write(b"png")
+        return True
+
+    driver = MagicMock()
+    driver.save_screenshot.side_effect = _save
+    return driver
+
+
+def _capture(markers=("Dashboard", "Review queue"), frames=("/tmp/a.png", "/tmp/b.png")):
+    return {"frames": list(frames), "markers": list(markers),
+            "fingerprint": vt.ui_fingerprint(list(markers))}
+
+
+_ORDINALS = ("first", "second", "third", "fourth", "fifth")
+
+
+def _script_json(segments=2, **overrides):
+    # Deliberately digit-free: a number the captured screens do not contain would (correctly)
+    # trip the ungrounded-claim guardrail.
+    payload = {
+        "intro": "Here is the sample feature.",
+        "segments": [f"You open the {_ORDINALS[i]} screen and read what is there."
+                     for i in range(segments)],
+        "outro": "Open your own account and try it.",
+        "youtube_title": "Sample feature tour",
+        "youtube_description": "A short tour of the sample feature.",
+    }
+    payload.update(overrides)
+    return json.dumps(payload)
+
+
+def _llm_response(content):
+    return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=content))])
+
+
+class TestFlowRegistry:
+    def test_every_declared_flow_is_capturable(self):
+        assert vt.TUTORIAL_FLOWS
+        for key, flow in vt.TUTORIAL_FLOWS.items():
+            assert flow.key == key
+            assert flow.steps, f"{key} has no steps"
+            for step in flow.steps:
+                assert step.caption and step.path.startswith("/")
+                assert step.wait_for, f"{key} step '{step.caption}' has no verifiable UI anchor"
+
+
+class TestManifest:
+    def test_round_trips_and_tolerates_a_corrupt_file(self):
+        assert vt.load_manifest() == {"videos": {}}
+        vt.save_manifest({"videos": {"a": {"produced_at": "2026-07-01T00:00:00+00:00"}}})
+        assert "a" in vt.load_manifest()["videos"]
+        with open(vt.manifest_path(), "w", encoding="utf-8") as f:
+            f.write("{not json")
+        assert vt.load_manifest() == {"videos": {}}
+
+    def test_asset_url_is_a_public_api_assets_link(self):
+        assert vt.asset_url("videos/tutorials/x.mp4") == \
+            "https://lem.test/api/assets?file_name=videos/tutorials/x.mp4"
+
+
+class TestFingerprintAndCadence:
+    def test_fingerprint_changes_only_when_the_ui_text_changes(self):
+        base = vt.ui_fingerprint(["Dashboard", "Review"])
+        assert base == vt.ui_fingerprint(["Dashboard ", " Review"])
+        assert base != vt.ui_fingerprint(["Dashboard", "Reviewed"])
+
+    def test_next_flow_prefers_an_uncovered_public_feature(self):
+        flow = vt.next_flow({"videos": {}})
+        assert flow is not None and not flow.requires_auth
+
+    def test_next_flow_skips_auth_flows_without_a_demo_session(self):
+        covered = {"videos": {k: {"produced_at": "2999-01-01T00:00:00+00:00",
+                                  "fingerprint": "x"}
+                              for k, f in vt.TUTORIAL_FLOWS.items() if not f.requires_auth}}
+        assert vt.next_flow(covered) is None
+
+    def test_next_flow_returns_an_auth_flow_once_a_demo_session_exists(self, monkeypatch):
+        monkeypatch.setattr(vt, "TUTORIAL_DEMO_SESSION_TOKEN", "tok")
+        covered = {"videos": {k: {"produced_at": "2999-01-01T00:00:00+00:00"}
+                              for k, f in vt.TUTORIAL_FLOWS.items() if not f.requires_auth}}
+        flow = vt.next_flow(covered)
+        assert flow is not None and flow.requires_auth
+
+    def test_next_flow_refilms_the_stalest_covered_flow(self, monkeypatch):
+        monkeypatch.setattr(vt, "TUTORIAL_REFRESH_DAYS", 1)
+        videos = {k: {"produced_at": "2020-01-01T00:00:00+00:00"}
+                  for k, f in vt.TUTORIAL_FLOWS.items() if not f.requires_auth}
+        videos[sorted(videos)[0]]["produced_at"] = "2019-01-01T00:00:00+00:00"
+        assert vt.next_flow({"videos": videos}).key == sorted(videos)[0]
+
+    def test_is_current_requires_both_a_matching_ui_and_a_fresh_render(self, monkeypatch):
+        record = {"fingerprint": "abc", "produced_at": "2999-01-01T00:00:00+00:00"}
+        assert vt.is_current(record, "abc") is True
+        assert vt.is_current(record, "changed") is False
+        assert vt.is_current(None, "abc") is False
+        monkeypatch.setattr(vt, "TUTORIAL_REFRESH_DAYS", 1)
+        assert vt.is_current({"fingerprint": "abc", "produced_at": "2020-01-01T00:00:00+00:00"},
+                             "abc") is False
+        assert vt.is_current({"fingerprint": "abc", "produced_at": "not-a-date"}, "abc") is False
+
+
+class TestCapture:
+    def test_captures_one_frame_per_step_and_fingerprints_the_ui(self, monkeypatch):
+        driver = _driver()
+        element = MagicMock()
+        element.text = "Dashboard heading"
+        with patch("cqc_lem.utilities.selenium_util.find_first", return_value=element), \
+             patch("cqc_lem.utilities.selenium_util.click_first") as click:
+            result = vt.capture_flow(_flow(steps=2), driver=driver)
+        assert len(result["frames"]) == 2
+        assert all(os.path.exists(p) for p in result["frames"])
+        assert result["fingerprint"] == vt.ui_fingerprint(["Dashboard heading"] * 2)
+        assert driver.get.call_args_list[0][0][0] == "https://lem.test/s0"
+        click.assert_not_called()
+        driver.quit.assert_not_called()  # caller-owned drivers are left open
+
+    def test_clicks_a_step_that_declares_one(self):
+        flow = vt.TutorialFlow(key="clicky", title="t", feature="f", steps=(
+            vt.TutorialStep(caption="c", path="/x", wait_for="main", click="button.next"),))
+        element = MagicMock()
+        element.text = "x"
+        with patch("cqc_lem.utilities.selenium_util.find_first", return_value=element), \
+             patch("cqc_lem.utilities.selenium_util.click_first") as click:
+            vt.capture_flow(flow, driver=_driver())
+        assert click.call_count == 1
+
+    def test_missing_anchor_fails_closed(self):
+        with patch("cqc_lem.utilities.selenium_util.find_first", return_value=None):
+            with pytest.raises(vt.TutorialCaptureError, match="anchor"):
+                vt.capture_flow(_flow(steps=1), driver=_driver())
+
+    def test_failed_screenshot_fails_closed(self):
+        driver = MagicMock()
+        driver.save_screenshot.return_value = False
+        element = MagicMock()
+        element.text = "x"
+        with patch("cqc_lem.utilities.selenium_util.find_first", return_value=element):
+            with pytest.raises(vt.TutorialCaptureError, match="screenshot"):
+                vt.capture_flow(_flow(steps=1), driver=driver)
+
+    def test_auth_flow_without_a_demo_session_never_opens_a_browser(self):
+        with patch("cqc_lem.utilities.selenium_util.get_docker_driver") as get_driver:
+            with pytest.raises(vt.TutorialCaptureError, match="TUTORIAL_DEMO_SESSION_TOKEN"):
+                vt.capture_flow(_flow(steps=1, requires_auth=True))
+        get_driver.assert_not_called()
+
+    def test_auth_flow_seeds_the_demo_session_before_filming(self, monkeypatch):
+        monkeypatch.setattr(vt, "TUTORIAL_DEMO_SESSION_TOKEN", "tok-123")
+        monkeypatch.setattr(vt, "TUTORIAL_DEMO_EMAIL", "demo@lem.test")
+        driver = _driver()
+        element = MagicMock()
+        element.text = "x"
+        with patch("cqc_lem.utilities.selenium_util.find_first", return_value=element):
+            vt.capture_flow(_flow(steps=1, requires_auth=True), driver=driver)
+        script_args = driver.execute_script.call_args[0]
+        assert "lem_session" in script_args[0]
+        assert script_args[1] == "tok-123" and script_args[2] == "demo@lem.test"
+
+    def test_owned_driver_is_always_quit(self):
+        driver = _driver()
+        with patch("cqc_lem.utilities.selenium_util.get_docker_driver", return_value=driver), \
+             patch("cqc_lem.utilities.selenium_util.find_first", return_value=None):
+            with pytest.raises(vt.TutorialCaptureError):
+                vt.capture_flow(_flow(steps=1))
+        driver.quit.assert_called_once()
+
+
+class TestScriptGeneration:
+    def test_builds_intro_step_and_outro_segments(self):
+        flow = _flow(steps=2)
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_response(_script_json(2))) as call:
+            script = vt.generate_script(flow, _capture())
+        assert [s["caption"] for s in script["segments"]] == \
+            [flow.title, "Step 0", "Step 1", "Next step"]
+        assert script["title"] == "Sample feature tour"
+        assert call.call_args.kwargs["model"] == "lem-medium"
+        assert call.call_args.kwargs["_track_feature"] == "marketing"
+
+    def test_prompt_is_grounded_in_the_captured_screen_text(self):
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_response(_script_json(2))) as call:
+            vt.generate_script(_flow(steps=2), _capture(markers=["Review queue is empty"]))
+        prompt = call.call_args.kwargs["messages"][1]["content"]
+        assert "Review queue is empty" in prompt
+
+    def test_narration_is_tts_safe_plain_text(self):
+        raw = _script_json(1, intro="It is “ready” — truly — to go.")
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_response(raw)):
+            script = vt.generate_script(_flow(steps=1), _capture())
+        intro = script["segments"][0]["narration"]
+        assert "“" not in intro and "—" not in intro
+        assert intro.startswith("It's")
+
+    def test_unparseable_reply_raises_before_any_spend(self):
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_response("sorry, no script today")):
+            with pytest.raises(vt.TutorialGuardrailError, match="parse"):
+                vt.generate_script(_flow(steps=1), _capture())
+
+    def test_too_few_segments_raises(self):
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_response(_script_json(1))):
+            with pytest.raises(vt.TutorialGuardrailError):
+                vt.generate_script(_flow(steps=3), _capture())
+
+    def test_fabricated_number_raises(self):
+        raw = _script_json(1, outro="It saves you 14 hours every single week.")
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_response(raw)):
+            with pytest.raises(vt.TutorialGuardrailError, match="ungrounded"):
+                vt.generate_script(_flow(steps=1), _capture())
+
+    def test_number_that_appears_on_the_captured_screen_is_allowed(self):
+        raw = _script_json(1, outro="The queue holds 12 drafts.")
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_response(raw)):
+            script = vt.generate_script(_flow(steps=1), _capture(markers=["12 drafts waiting"]))
+        assert "12 drafts" in script["narration"]
+
+    def test_profanity_raises(self):
+        raw = _script_json(1, outro="This damn thing just works.")
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_response(raw)):
+            with pytest.raises(vt.TutorialGuardrailError, match="disallowed language"):
+                vt.generate_script(_flow(steps=1), _capture())
+
+    def test_over_long_narration_raises(self, monkeypatch):
+        monkeypatch.setattr(vt, "TUTORIAL_MAX_NARRATION_CHARS", 40)
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_response(_script_json(2))):
+            with pytest.raises(vt.TutorialGuardrailError, match="over the"):
+                vt.generate_script(_flow(steps=2), _capture())
+
+    def test_empty_narration_raises(self):
+        with pytest.raises(vt.TutorialGuardrailError, match="no narration"):
+            vt.check_narration("   ", "anything")
+
+    def test_ungrounded_claims_ignores_formatting_differences(self):
+        assert vt.ungrounded_claims("costs $ 29 a month", "the plan is $29") == []
+        assert vt.ungrounded_claims("saves 40%", "no numbers here") == ["40%"]
+
+
+class TestVoiceOver:
+    def test_openai_provider_writes_audio_and_bills_the_characters(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vt, "TUTORIAL_TTS_PROVIDER", "openai")
+        out = str(tmp_path / "seg.mp3")
+        response = SimpleNamespace(content=b"mp3-bytes")
+        with patch("cqc_lem.utilities.ai.client.client.audio.speech.create",
+                   return_value=response) as create, \
+             patch(f"{_MOD}.track_media_cost") as track:
+            vt.synthesize_segment("hello there", out)
+        assert open(out, "rb").read() == b"mp3-bytes"
+        assert create.call_args.kwargs["model"] == "lem-tts"
+        kind, provider, usd = track.call_args[0]
+        assert (kind, provider) == ("audio", "openai")
+        assert usd == pytest.approx(0.015 * len("hello there") / 1000)
+        assert track.call_args.kwargs["feature"] == "marketing"
+
+    def test_openai_write_to_file_wrapper_is_used_when_present(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vt, "TUTORIAL_TTS_PROVIDER", "openai")
+        out = str(tmp_path / "seg.mp3")
+        response = MagicMock()
+        response.write_to_file.side_effect = lambda p: open(p, "wb").write(b"x")
+        with patch("cqc_lem.utilities.ai.client.client.audio.speech.create",
+                   return_value=response), patch(f"{_MOD}.track_media_cost"):
+            vt.synthesize_segment("hi", out)
+        response.write_to_file.assert_called_once_with(out)
+
+    def test_elevenlabs_provider_posts_to_the_premium_api(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vt, "TUTORIAL_TTS_PROVIDER", "elevenlabs")
+        monkeypatch.setattr(vt, "ELEVENLABS_API_KEY", "k")
+        monkeypatch.setattr(vt, "ELEVENLABS_VOICE_ID", "v1")
+        out = str(tmp_path / "seg.mp3")
+        response = MagicMock(content=b"eleven")
+        with patch("requests.post", return_value=response) as post, \
+             patch(f"{_MOD}.track_media_cost") as track:
+            vt.synthesize_segment("hello", out)
+        assert "v1" in post.call_args[0][0]
+        assert open(out, "rb").read() == b"eleven"
+        assert track.call_args[0][1] == "elevenlabs"
+
+    def test_elevenlabs_without_credentials_fails_closed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vt, "TUTORIAL_TTS_PROVIDER", "elevenlabs")
+        monkeypatch.setattr(vt, "ELEVENLABS_API_KEY", "")
+        with pytest.raises(vt.TutorialRenderError, match="elevenlabs"):
+            vt.synthesize_segment("hello", str(tmp_path / "x.mp3"))
+
+    def test_cost_rates_differ_per_provider(self):
+        assert vt.tts_cost_usd(1000, "openai") == pytest.approx(0.015)
+        assert vt.tts_cost_usd(1000, "elevenlabs") == pytest.approx(0.15)
+        assert vt.tts_cost_usd(0) == 0.0
+
+
+def _fake_ffmpeg(duration: str = "4.0"):
+    """Stand-in for ffmpeg/ffprobe that also CREATES its output file, so callers that read the
+    render back (the YouTube upload) work against a real path."""
+    def _run(cmd, capture_output=True, text=True):
+        if os.path.basename(cmd[0]) == "ffprobe":
+            return SimpleNamespace(returncode=0, stdout=duration, stderr="")
+        with open(cmd[-1], "wb") as f:
+            f.write(b"\x00mp4")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+    return _run
+
+
+class TestRender:
+    def test_missing_ffmpeg_fails_closed(self, monkeypatch):
+        monkeypatch.setattr(vt.shutil, "which", lambda name: None)
+        with pytest.raises(vt.TutorialRenderError, match="not installed"):
+            vt.audio_duration("/tmp/a.mp3")
+
+    def test_ffmpeg_failure_surfaces_stderr(self, monkeypatch):
+        monkeypatch.setattr(vt.shutil, "which", lambda name: f"/usr/bin/{name}")
+        with patch("subprocess.run", return_value=SimpleNamespace(returncode=1, stdout="",
+                                                                 stderr="boom")):
+            with pytest.raises(vt.TutorialRenderError, match="boom"):
+                vt.audio_duration("/tmp/a.mp3")
+
+    def test_audio_duration_tolerates_unparseable_output(self, monkeypatch):
+        monkeypatch.setattr(vt.shutil, "which", lambda name: f"/usr/bin/{name}")
+        with patch("subprocess.run", return_value=SimpleNamespace(returncode=0, stdout="n/a",
+                                                                 stderr="")):
+            assert vt.audio_duration("/tmp/a.mp3") == 0.0
+
+    def test_brand_card_renders_a_real_landscape_png(self, tmp_path):
+        from PIL import Image
+        path = vt.brand_card("Sample feature", str(tmp_path / "card.png"), subtitle="lem.test")
+        with Image.open(path) as image:
+            assert image.size == (vt.FRAME_WIDTH, vt.FRAME_HEIGHT)
+
+    def test_captions_use_the_real_segment_durations(self, tmp_path):
+        segments = [{"narration": "First line.", "duration": 2.5},
+                    {"narration": "Second line.", "duration": 1.25}]
+        srt = vt.write_captions(segments, str(tmp_path / "c.srt"))
+        body = open(srt, encoding="utf-8").read()
+        assert "00:00:00,000 --> 00:00:02,500" in body
+        assert "00:00:02,500 --> 00:00:03,750" in body
+        assert "Second line." in body
+
+    def test_assemble_video_holds_each_frame_for_its_narration(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vt.shutil, "which", lambda name: f"/usr/bin/{name}")
+        frame = str(tmp_path / "f.png")
+        open(frame, "wb").write(b"png")
+        segments = [{"frame": frame, "duration": 3.0}, {"frame": frame, "duration": 5.5}]
+        out = str(tmp_path / "out.mp4")
+        with patch("subprocess.run", side_effect=_fake_ffmpeg()) as run:
+            vt.assemble_video(segments, str(tmp_path / "a.mp3"), out)
+        concat = open(f"{out}.frames.txt", encoding="utf-8").read()
+        assert "duration 3.000" in concat and "duration 5.500" in concat
+        assert concat.count("file '") == 3  # last frame repeated for the concat demuxer
+        cmd = run.call_args[0][0]
+        assert "libx264" in cmd and cmd[-1] == out
+        assert "subtitles=" not in " ".join(cmd)
+
+    def test_captions_are_burned_in_only_when_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vt.shutil, "which", lambda name: f"/usr/bin/{name}")
+        monkeypatch.setattr(vt, "TUTORIAL_BURN_CAPTIONS", True)
+        frame = str(tmp_path / "f.png")
+        open(frame, "wb").write(b"png")
+        with patch("subprocess.run", side_effect=_fake_ffmpeg()) as run:
+            vt.assemble_video([{"frame": frame, "duration": 1.0}], str(tmp_path / "a.mp3"),
+                              str(tmp_path / "o.mp4"), str(tmp_path / "c.srt"))
+        assert "subtitles=" in " ".join(run.call_args[0][0])
+
+    def test_vertical_clip_is_nine_by_sixteen(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vt.shutil, "which", lambda name: f"/usr/bin/{name}")
+        with patch("subprocess.run", side_effect=_fake_ffmpeg()) as run:
+            vt.render_vertical_clip(str(tmp_path / "in.mp4"), str(tmp_path / "v.mp4"))
+        assert f"scale={vt.VERTICAL_WIDTH}:{vt.VERTICAL_HEIGHT}" in " ".join(run.call_args[0][0])
+
+    def test_thumbnail_is_off_by_default_and_never_raises(self, tmp_path, monkeypatch):
+        assert vt.generate_thumbnail(_flow(), str(tmp_path)) is None
+        monkeypatch.setattr(vt, "TUTORIAL_THUMBNAIL_ENABLED", True)
+        with patch("cqc_lem.utilities.ai.ai_helper.generate_dall_e_image_from_prompt",
+                   side_effect=RuntimeError("no image")):
+            assert vt.generate_thumbnail(_flow(), str(tmp_path)) is None
+
+    def test_thumbnail_is_saved_when_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(vt, "TUTORIAL_THUMBNAIL_ENABLED", True)
+        with patch("cqc_lem.utilities.ai.ai_helper.generate_dall_e_image_from_prompt",
+                   return_value=["https://img.test/a.png"]), \
+             patch("cqc_lem.utilities.utils.save_video_url_to_dir",
+                   return_value=str(tmp_path / "a.png")) as save:
+            assert vt.generate_thumbnail(_flow(), str(tmp_path)) == str(tmp_path / "a.png")
+        save.assert_called_once()
+
+
+class TestYouTubePublish:
+    def test_skipped_without_credentials(self, tmp_path):
+        assert vt.youtube_configured() is False
+        with patch("requests.post") as post:
+            assert vt.publish_to_youtube(str(tmp_path / "a.mp4"), "t", "d") is None
+        post.assert_not_called()
+
+    def _configure(self, monkeypatch):
+        monkeypatch.setattr(vt, "YOUTUBE_CLIENT_ID", "cid")
+        monkeypatch.setattr(vt, "YOUTUBE_CLIENT_SECRET", "secret")
+        monkeypatch.setattr(vt, "YOUTUBE_REFRESH_TOKEN", "refresh")
+
+    def test_resumable_upload_returns_the_watch_url(self, tmp_path, monkeypatch):
+        self._configure(monkeypatch)
+        mp4 = str(tmp_path / "a.mp4")
+        open(mp4, "wb").write(b"\x00")
+        token = MagicMock(headers={}, **{"json.return_value": {"access_token": "at"}})
+        session = MagicMock(headers={"Location": "https://upload.test/x"})
+        session.json.return_value = {}
+        done = MagicMock()
+        done.json.return_value = {"id": "vid123"}
+        with patch("requests.post", side_effect=[token, session]) as post, \
+             patch("requests.put", return_value=done):
+            url = vt.publish_to_youtube(mp4, "Title", "Body", ["lem"])
+        assert url == "https://www.youtube.com/watch?v=vid123"
+        assert post.call_args.kwargs["json"]["status"]["privacyStatus"] == "unlisted"
+
+    def test_upload_failure_returns_none_rather_than_losing_the_render(self, tmp_path, monkeypatch):
+        self._configure(monkeypatch)
+        with patch("requests.post", side_effect=RuntimeError("network down")):
+            assert vt.publish_to_youtube(str(tmp_path / "a.mp4"), "t", "d") is None
+
+    def test_missing_upload_location_is_reported_as_a_failure(self, tmp_path, monkeypatch):
+        self._configure(monkeypatch)
+        token = MagicMock(headers={}, **{"json.return_value": {"access_token": "at"}})
+        session = MagicMock(headers={})
+        with patch("requests.post", side_effect=[token, session]):
+            assert vt.publish_to_youtube(str(tmp_path / "a.mp4"), "t", "d") is None
+
+
+class TestProduceTutorial:
+    def _patched(self, monkeypatch, duration="4.0"):
+        monkeypatch.setattr(vt.shutil, "which", lambda name: f"/usr/bin/{name}")
+        element = MagicMock()
+        element.text = "Powerful Features"
+        return element
+
+    def test_disabled_pipeline_produces_nothing(self, monkeypatch):
+        monkeypatch.setattr(vt, "TUTORIAL_VIDEOS_ENABLED", False)
+        assert vt.produce_tutorial() is None
+
+    def test_unknown_flow_key_raises(self):
+        with pytest.raises(ValueError, match="Unknown tutorial flow"):
+            vt.produce_tutorial(flow_key="nope")
+
+    def test_auth_flow_requested_without_a_session_is_skipped(self):
+        auth_key = next(k for k, f in vt.TUTORIAL_FLOWS.items() if f.requires_auth)
+        assert vt.produce_tutorial(flow_key=auth_key) is None
+
+    def test_nothing_to_do_when_every_flow_is_current(self, monkeypatch):
+        vt.save_manifest({"videos": {k: {"produced_at": "2999-01-01T00:00:00+00:00"}
+                                     for k, f in vt.TUTORIAL_FLOWS.items()
+                                     if not f.requires_auth}})
+        assert vt.produce_tutorial() is None
+
+    def test_end_to_end_produces_publishes_and_prices_one_tutorial(self, monkeypatch):
+        element = self._patched(monkeypatch)
+        monkeypatch.setattr(vt, "YOUTUBE_CLIENT_ID", "cid")
+        monkeypatch.setattr(vt, "YOUTUBE_CLIENT_SECRET", "secret")
+        monkeypatch.setattr(vt, "YOUTUBE_REFRESH_TOKEN", "refresh")
+        flow = vt.next_flow({"videos": {}})
+        segments = len(flow.steps)
+        token = MagicMock(headers={}, **{"json.return_value": {"access_token": "at"}})
+        session = MagicMock(headers={"Location": "https://upload.test/x"})
+        done = MagicMock()
+        done.json.return_value = {"id": "vid999"}
+
+        with patch("cqc_lem.utilities.selenium_util.get_docker_driver",
+                   return_value=_driver()) as get_driver, \
+             patch("cqc_lem.utilities.selenium_util.find_first", return_value=element), \
+             patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_llm_response(_script_json(segments))), \
+             patch("cqc_lem.utilities.ai.client.client.audio.speech.create",
+                   return_value=SimpleNamespace(content=b"mp3")), \
+             patch("subprocess.run", side_effect=_fake_ffmpeg("4.0")), \
+             patch("requests.post", side_effect=[token, session]), \
+             patch("requests.put", return_value=done), \
+             patch(f"{_MOD}.track_media_cost") as track:
+            record = vt.produce_tutorial()
+
+        get_driver.assert_called_once()
+        assert record["flow"] == flow.key
+        assert record["youtube_url"] == "https://www.youtube.com/watch?v=vid999"
+        # intro card + one frame per step + outro card, each held for max(declared, narration+pad)
+        expected = sum(max(s, 4.0 + vt.SEGMENT_PAD_SECONDS)
+                       for s in ([vt.CARD_SECONDS] + [st.seconds for st in flow.steps]
+                                 + [vt.CARD_SECONDS]))
+        assert record["duration_seconds"] == pytest.approx(expected)
+        assert record["narration_chars"] > 0
+        assert record["tts_usd"] > 0 and record["render_usd"] > 0
+        assert record["total_usd"] == pytest.approx(record["tts_usd"] + record["render_usd"])
+        assert record["video_url"].endswith(f"videos/tutorials/{flow.key}/{flow.key}.mp4")
+        assert record["vertical_url"].endswith(f"{flow.key}-vertical.mp4")
+        assert record["captions_url"].endswith(f"{flow.key}.srt")
+        assert record["thumbnail_url"] is None
+        # Cost is attributed per part: one audio row per segment + one render row.
+        kinds = [c[0][0] for c in track.call_args_list]
+        assert kinds.count("audio") == segments + 2 and kinds.count("video") == 1
+        # Persisted for the SPA embed, keyed by flow.
+        assert vt.load_manifest()["videos"][flow.key]["youtube_url"] == record["youtube_url"]
+
+    def test_second_run_skips_a_flow_whose_ui_has_not_changed(self, monkeypatch):
+        element = self._patched(monkeypatch)
+        flow = vt.next_flow({"videos": {}})
+        vt.save_manifest({"videos": {flow.key: {
+            "produced_at": "2999-01-01T00:00:00+00:00",
+            "fingerprint": vt.ui_fingerprint(["Powerful Features"] * len(flow.steps)),
+        }}})
+        with patch("cqc_lem.utilities.selenium_util.get_docker_driver", return_value=_driver()), \
+             patch("cqc_lem.utilities.selenium_util.find_first", return_value=element), \
+             patch("cqc_lem.utilities.ai.ai_helper._call_llm") as call:
+            assert vt.produce_tutorial(flow_key=None) is None
+        call.assert_not_called()
+
+    def test_capture_failure_aborts_before_any_llm_or_tts_call(self, monkeypatch):
+        self._patched(monkeypatch)
+        with patch("cqc_lem.utilities.selenium_util.get_docker_driver", return_value=_driver()), \
+             patch("cqc_lem.utilities.selenium_util.find_first", return_value=None), \
+             patch("cqc_lem.utilities.ai.ai_helper._call_llm") as call, \
+             patch("cqc_lem.utilities.ai.client.client.audio.speech.create") as tts:
+            with pytest.raises(vt.TutorialCaptureError):
+                vt.produce_tutorial()
+        call.assert_not_called()
+        tts.assert_not_called()
+
+    def test_guardrail_failure_aborts_before_tts_spend(self, monkeypatch):
+        element = self._patched(monkeypatch)
+        raw = _script_json(3, outro="We save teams 97 hours a month.")
+        with patch("cqc_lem.utilities.selenium_util.get_docker_driver", return_value=_driver()), \
+             patch("cqc_lem.utilities.selenium_util.find_first", return_value=element), \
+             patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_llm_response(raw)), \
+             patch("cqc_lem.utilities.ai.client.client.audio.speech.create") as tts:
+            with pytest.raises(vt.TutorialGuardrailError):
+                vt.produce_tutorial()
+        tts.assert_not_called()

--- a/tests/unit/utilities/test_video_tutorials.py
+++ b/tests/unit/utilities/test_video_tutorials.py
@@ -7,6 +7,7 @@ pipeline publishes to a public channel, so "fails closed" has to be pinned, not 
 
 import json
 import os
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -299,7 +300,8 @@ class TestVoiceOver:
                    return_value=response) as create, \
              patch(f"{_MOD}.track_media_cost") as track:
             vt.synthesize_segment("hello there", out)
-        assert open(out, "rb").read() == b"mp3-bytes"
+        written = Path(out).read_bytes()
+        assert written == b"mp3-bytes"
         assert create.call_args.kwargs["model"] == "lem-tts"
         kind, provider, usd = track.call_args[0]
         assert (kind, provider) == ("audio", "openai")
@@ -310,7 +312,7 @@ class TestVoiceOver:
         monkeypatch.setattr(vt, "TUTORIAL_TTS_PROVIDER", "openai")
         out = str(tmp_path / "seg.mp3")
         response = MagicMock()
-        response.write_to_file.side_effect = lambda p: open(p, "wb").write(b"x")
+        response.write_to_file.side_effect = lambda p: Path(p).write_bytes(b"x")
         with patch("cqc_lem.utilities.ai.client.client.audio.speech.create",
                    return_value=response), patch(f"{_MOD}.track_media_cost"):
             vt.synthesize_segment("hi", out)
@@ -326,7 +328,8 @@ class TestVoiceOver:
              patch(f"{_MOD}.track_media_cost") as track:
             vt.synthesize_segment("hello", out)
         assert "v1" in post.call_args[0][0]
-        assert open(out, "rb").read() == b"eleven"
+        written = Path(out).read_bytes()
+        assert written == b"eleven"
         assert track.call_args[0][1] == "elevenlabs"
 
     def test_elevenlabs_without_credentials_fails_closed(self, tmp_path, monkeypatch):
@@ -382,7 +385,7 @@ class TestRender:
         segments = [{"narration": "First line.", "duration": 2.5},
                     {"narration": "Second line.", "duration": 1.25}]
         srt = vt.write_captions(segments, str(tmp_path / "c.srt"))
-        body = open(srt, encoding="utf-8").read()
+        body = Path(srt).read_text(encoding="utf-8")
         assert "00:00:00,000 --> 00:00:02,500" in body
         assert "00:00:02,500 --> 00:00:03,750" in body
         assert "Second line." in body
@@ -390,12 +393,12 @@ class TestRender:
     def test_assemble_video_holds_each_frame_for_its_narration(self, tmp_path, monkeypatch):
         monkeypatch.setattr(vt.shutil, "which", lambda name: f"/usr/bin/{name}")
         frame = str(tmp_path / "f.png")
-        open(frame, "wb").write(b"png")
+        Path(frame).write_bytes(b"png")
         segments = [{"frame": frame, "duration": 3.0}, {"frame": frame, "duration": 5.5}]
         out = str(tmp_path / "out.mp4")
         with patch("subprocess.run", side_effect=_fake_ffmpeg()) as run:
             vt.assemble_video(segments, str(tmp_path / "a.mp3"), out)
-        concat = open(f"{out}.frames.txt", encoding="utf-8").read()
+        concat = Path(f"{out}.frames.txt").read_text(encoding="utf-8")
         assert "duration 3.000" in concat and "duration 5.500" in concat
         assert concat.count("file '") == 3  # last frame repeated for the concat demuxer
         cmd = run.call_args[0][0]
@@ -406,7 +409,7 @@ class TestRender:
         monkeypatch.setattr(vt.shutil, "which", lambda name: f"/usr/bin/{name}")
         monkeypatch.setattr(vt, "TUTORIAL_BURN_CAPTIONS", True)
         frame = str(tmp_path / "f.png")
-        open(frame, "wb").write(b"png")
+        Path(frame).write_bytes(b"png")
         with patch("subprocess.run", side_effect=_fake_ffmpeg()) as run:
             vt.assemble_video([{"frame": frame, "duration": 1.0}], str(tmp_path / "a.mp3"),
                               str(tmp_path / "o.mp4"), str(tmp_path / "c.srt"))
@@ -450,7 +453,7 @@ class TestYouTubePublish:
     def test_resumable_upload_returns_the_watch_url(self, tmp_path, monkeypatch):
         self._configure(monkeypatch)
         mp4 = str(tmp_path / "a.mp4")
-        open(mp4, "wb").write(b"\x00")
+        Path(mp4).write_bytes(b"\x00")
         token = MagicMock(headers={}, **{"json.return_value": {"access_token": "at"}})
         session = MagicMock(headers={"Location": "https://upload.test/x"})
         session.json.return_value = {}


### PR DESCRIPTION
## What & why

Agent-produced video content pillar (issue #505): fully-automated short SPA how-to videos for onboarding + marketing. One declaratively-defined feature flow in, one finished, published tutorial out:

```
headless SPA capture (get_docker_driver) -> grounded brand-voice script (lem-medium)
  -> TTS voice-over -> ffmpeg MP4 (branded intro/outro + .srt) -> 9:16 clip
  -> YouTube Data API v3 -> manifest the SPA embeds
```

### New `utilities/marketing/video_tutorials.py`
- **Flow registry** — `TutorialFlow` / `TutorialStep`: route, the CSS anchor that PROVES the screen rendered, an optional click, and a minimum hold. Three flows ship: `getting-started` (public), `content-studio` and `engagement-preferences` (need a demo session).
- **Capture** — one screenshot per step via `get_docker_driver()` + the resilient `find_first`/`click_first` helpers. Auth flows seed the demo account's `lem_session` token so protected routes render the real product instead of the login modal; without `TUTORIAL_DEMO_SESSION_TOKEN` those flows are skipped, never filmed at a modal.
- **Script** — `lem-medium` via `_call_llm` (so tokens land in PostHog), grounded in the flow definition *plus the text actually read off the captured screens*. Reuses `content_alignment` (`cap_em_dashes` / `apply_contractions` / `find_ai_tell_words` / `humanize_text`) and `normalize_public_text` for TTS-safe plain prose. The no-self-promo guardrail is deliberately NOT applied — this is LEM's own product marketing.
- **TTS** — OpenAI via the existing LiteLLM path (new `lem-tts` alias -> `openai/tts-1`, the cheapest option) with ElevenLabs available behind `TUTORIAL_TTS_PROVIDER=elevenlabs`. Per-segment audio, so frame holds and captions match the real voice durations.
- **Render** — ffmpeg concat demuxer + AAC, PIL-drawn branded intro/outro cards, `.srt` sidecar always written (burn-in optional), plus a 1080x1920 clip for the dogfooding agents. Optional `lem-image` thumbnail, off by default.
- **Publish** — resumable YouTube upload with plain `requests` (no new SDK), `unlisted` by default. A failed upload returns `None` rather than losing the render.

### Guardrails (fail-closed, cheapest-first)
Capture runs before a single token is spent; the script is gated before a single TTS character is. Any of these aborts the production: a declared UI anchor is gone (**the UI-change detector**), a screenshot fails, the script is unparseable or short a segment, narration exceeds `TUTORIAL_MAX_NARRATION_CHARS`, profanity, or a **numeric/price claim that appears nowhere in the flow definition or the captured screens** (deterministic — no LLM in the gate).

### Cadence & cost
Weekly beat `produce-feature-tutorial` (Wed 20:00 UTC) on the `se_content` Selenium lane — it drives a browser but never touches LinkedIn, so the 429 breaker doesn't gate it. Uncovered features come first; a covered flow is re-filmed only when its captured UI fingerprint changes (or after `TUTORIAL_REFRESH_DAYS`). Cost is attributed in three parts — script tokens (`FEATURE_MARKETING`), TTS characters and render minutes (`track_media_cost`) — and totalled per video on the manifest record.

### Deliberate scope notes
- **No migration.** State lives in `assets/videos/tutorials/manifest.json` in the shared assets volume (survives deploys) and doubles as the SPA embed source, so this ships with zero schema risk. `TutorialVideos.tsx` reads it via the public `/api/assets` route and renders nothing until a tutorial exists.
- `ffmpeg`/`ffprobe` added to the app image; the pipeline raises rather than half-rendering if they're missing.
- OFF by default (`TUTORIAL_VIDEOS_ENABLED=False`) — it renders and uploads public marketing assets, so it only runs where someone turns it on. YouTube publishing additionally no-ops until the three OAuth values are set.

## Testing

- `tests/unit/utilities/test_video_tutorials.py` — 54 tests, **96% coverage** of the new module. Selenium, TTS, ffmpeg/ffprobe and the YouTube upload are all mocked, including a full end-to-end production that asserts the record, the per-part cost rows, the asset URLs and the persisted manifest (the acceptance criterion), plus every guardrail's abort path.
- `tests/unit/app/test_feature_tutorials.py` — 9 tests for the beat task, its abort handling and the schedule/queue routing.
- Full unit suite: **4876 passed** locally. UI typecheck (`tsc -b`) and eslint clean on the new component.

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)