### PR TITLE
feat(ui): auto-updating front-page FAQ backed by faq_entries (closes #506)

### DIFF
--- a/compose/local/database/migrations/V20260725155210__add_faq_entries.sql
+++ b/compose/local/database/migrations/V20260725155210__add_faq_entries.sql
@@ -1,0 +1,45 @@
+-- Public, front-page FAQ (issue #506). The last consumer of the feedback->auto-work loop: questions
+-- the classifier routes to FAQ (`FeedbackRoute.FAQ`, no code change needed) are clustered and the
+-- auto-FAQ pass keeps the published answers here current, so the landing page answers what people
+-- actually ask instead of hardcoded marketing copy.
+--
+--   cluster_id -> the feedback cluster this answer came from (NULL for the hand-written seeds).
+--                 Plain INT, like `feedback.cluster_id` — clusters are ids, not their own table.
+--   status     -> only 'published' rows are served publicly; 'draft' is an auto-generated answer
+--                 awaiting review, 'archived' is retired copy kept for history.
+--   sort_order -> display order on the landing page, lowest first (ties broken by id).
+CREATE TABLE IF NOT EXISTS faq_entries (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    question VARCHAR(512) NOT NULL,
+    answer TEXT NOT NULL,
+    cluster_id INT NULL,
+    status ENUM('published','draft','archived') NOT NULL DEFAULT 'published',
+    sort_order INT NOT NULL DEFAULT 0,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uniq_faq_question (question),
+    INDEX idx_faq_published (status, sort_order),
+    INDEX idx_faq_cluster (cluster_id)
+);
+
+-- Seed answers (INSERT IGNORE: re-running never duplicates a question, and never overwrites an
+-- answer the auto-FAQ pass has since improved).
+INSERT IGNORE INTO faq_entries (question, answer, sort_order) VALUES
+('What does the automation actually do?',
+ 'LEM writes and schedules your LinkedIn content, then engages for you: it comments on relevant posts in your feed, replies to comments on your own posts, seeds a first comment under what you publish, and sends appreciation and follow-up DMs. Every action follows the targeting rules, tone and per-day caps you set, and posts go through a preview/approval step before anything is published.',
+ 10),
+('How much does it cost, and is there a free trial?',
+ 'Every plan starts with a 14-day free trial — no credit card required. After the trial, Starter is $29/month, Professional is $79/month and Enterprise is $199/month. The trial gives you the full Professional feature set so you can evaluate content generation, scheduling and engagement automation before you pay.',
+ 20),
+('Is this against LinkedIn''s Terms of Service?',
+ 'LinkedIn''s User Agreement restricts automated tools, so LEM is built to act like you, not like a bot: it works from your own logged-in session, keeps human-like pacing with per-day caps, and never mass-messages, scrapes profiles in bulk, or resells LinkedIn data. Content is approval-gated by default, so you decide what gets posted. You are responsible for your own account, and you can pause automation or reduce caps at any time.',
+ 30),
+('What happens to my data and my LinkedIn credentials?',
+ 'Your credentials and session cookies are stored encrypted and used only to run the automation you configured — we never sell or share your data, and we don''t use your content to train public models. Generated posts, comments and DMs stay in your account, and deleting your account removes them.',
+ 40),
+('How does the AI match my voice?',
+ 'LEM builds a voice profile from your existing LinkedIn posts and profile plus the tone, style, emoji and hashtag preferences you set on the Account page. Every post, comment and DM is generated against that profile and your focus topics, and you can edit or reject anything in the preview step — those edits feed back into how future drafts read.',
+ 50),
+('Can I cancel anytime?',
+ 'Yes. There are no long-term contracts and no cancellation fees — cancel whenever you like and your account stays active through the end of the current billing period. You can also pause the automation without cancelling if you just need a break.',
+ 60);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -153,10 +153,23 @@ _PUBLIC_API_PREFIXES = ("/api/auth/", "/api/billing/webhook", "/api/assets",
                         "/api/extension/", "/api/user/linkedin-cookie")
 
 
+def _is_public_api_path(path: str) -> bool:
+    # An entry ending in "/" opens that whole subtree; every other entry matches only itself or a
+    # path segment beneath it. Without the boundary, "/api/faq" would also unlock a future
+    # "/api/faq-admin".
+    for prefix in _PUBLIC_API_PREFIXES:
+        if prefix.endswith("/"):
+            if path.startswith(prefix):
+                return True
+        elif path == prefix or path.startswith(prefix + "/"):
+            return True
+    return False
+
+
 def _api_token_required(path: str) -> bool:
     if not _API_ACCESS_TOKEN_SET or not path.startswith("/api/"):
         return False
-    return not any(path.startswith(p) for p in _PUBLIC_API_PREFIXES)
+    return not _is_public_api_path(path)
 
 
 def _bearer_token(authorization: Optional[str]) -> Optional[str]:

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -145,9 +145,11 @@ _API_ACCESS_TOKEN_SET = {t.strip() for t in API_ACCESS_TOKENS.split(",") if t.st
 # self-authenticating: the handler validates the user's own LEM session_token and 401s if
 # it's invalid — same model as the /api/auth/ endpoints. This exact leaf path only; the rest
 # of /api/user/* stays gated.
+# /api/faq is public: it serves the published front-page FAQ (issue #506) to logged-out visitors on
+# the landing page. GET-only, no user data — same shape as /api/app-info.
 _PUBLIC_API_PREFIXES = ("/api/auth/", "/api/billing/webhook", "/api/assets",
                         "/api/linkedin/verification-pin", "/api/linkedin/comment-notification",
-                        "/api/app-info",
+                        "/api/app-info", "/api/faq",
                         "/api/extension/", "/api/user/linkedin-cookie")
 
 
@@ -931,6 +933,18 @@ def shipped_notices_endpoint(session_token: str) -> ResponseModel:
         "changelog": [{"issue_number": n.get("github_issue_number"),
                        "changelog_line": n.get("changelog_line"),
                        "shipped_at": n.get("shipped_at")} for n in get_recent_shipped_notices()],
+    })
+
+
+@router.get("/faq")
+def faq_endpoint() -> ResponseModel:
+    """Public: the front-page FAQ (issue #506). Serves only the published entries, in display
+    order — the SPA falls back to its built-in copy if this is empty or unreachable."""
+    from cqc_lem.utilities.db import get_published_faq_entries
+    return ResponseModel(status_code=200, detail={
+        "entries": [{"id": e.get("id"), "question": e.get("question"), "answer": e.get("answer"),
+                     "updated_at": _utc_iso(e.get("updated_at"))}
+                    for e in get_published_faq_entries()],
     })
 
 

--- a/src/cqc_lem/ui/src/pages/FAQ.tsx
+++ b/src/cqc_lem/ui/src/pages/FAQ.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from 'react'
+import api from '../api/client'
+
+// Front-page FAQ (issue #506). Entries come from `faq_entries` via the public GET /api/faq, which
+// the auto-FAQ pass keeps current from the questions users actually ask. The seeded copy below is
+// the fallback ONLY — if the API is unreachable the landing page still answers the basics rather
+// than showing an empty section.
+interface FaqEntry {
+  id: number
+  question: string
+  answer: string
+  updated_at?: string | null
+}
+
+const FALLBACK_ENTRIES: FaqEntry[] = [
+  {
+    id: -1,
+    question: 'What does the automation actually do?',
+    answer:
+      'LEM writes and schedules your LinkedIn content, then engages for you: it comments on relevant posts in your feed, replies to comments on your own posts, seeds a first comment under what you publish, and sends appreciation and follow-up DMs. Every action follows the targeting rules, tone and per-day caps you set, and posts go through a preview/approval step before anything is published.',
+  },
+  {
+    id: -2,
+    question: 'How much does it cost, and is there a free trial?',
+    answer:
+      'Every plan starts with a 14-day free trial — no credit card required. After the trial, Starter is $29/month, Professional is $79/month and Enterprise is $199/month. The trial gives you the full Professional feature set so you can evaluate content generation, scheduling and engagement automation before you pay.',
+  },
+  {
+    id: -3,
+    question: "Is this against LinkedIn's Terms of Service?",
+    answer:
+      "LinkedIn's User Agreement restricts automated tools, so LEM is built to act like you, not like a bot: it works from your own logged-in session, keeps human-like pacing with per-day caps, and never mass-messages, scrapes profiles in bulk, or resells LinkedIn data. Content is approval-gated by default, so you decide what gets posted. You are responsible for your own account, and you can pause automation or reduce caps at any time.",
+  },
+  {
+    id: -4,
+    question: 'What happens to my data and my LinkedIn credentials?',
+    answer:
+      "Your credentials and session cookies are stored encrypted and used only to run the automation you configured — we never sell or share your data, and we don't use your content to train public models. Generated posts, comments and DMs stay in your account, and deleting your account removes them.",
+  },
+  {
+    id: -5,
+    question: 'How does the AI match my voice?',
+    answer:
+      'LEM builds a voice profile from your existing LinkedIn posts and profile plus the tone, style, emoji and hashtag preferences you set on the Account page. Every post, comment and DM is generated against that profile and your focus topics, and you can edit or reject anything in the preview step — those edits feed back into how future drafts read.',
+  },
+  {
+    id: -6,
+    question: 'Can I cancel anytime?',
+    answer:
+      'Yes. There are no long-term contracts and no cancellation fees — cancel whenever you like and your account stays active through the end of the current billing period. You can also pause the automation without cancelling if you just need a break.',
+  },
+]
+
+function FaqItem({ question, answer }: { question: string; answer: string }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        className="w-full flex justify-between items-center px-5 py-4 text-left font-medium text-gray-800 hover:bg-gray-50 transition-colors"
+      >
+        <span>{question}</span>
+        <span className="text-gray-400 text-lg leading-none">{open ? '−' : '+'}</span>
+      </button>
+      {open && (
+        <div className="px-5 pb-4 text-sm text-gray-600 leading-relaxed">
+          {answer}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function FAQ() {
+  const [entries, setEntries] = useState<FaqEntry[]>(FALLBACK_ENTRIES)
+
+  useEffect(() => {
+    let cancelled = false
+    api
+      .get('/faq')
+      .then((r) => {
+        const published: FaqEntry[] = r.data?.detail?.entries ?? []
+        const usable = published.filter((e) => e?.question && e?.answer)
+        if (!cancelled && usable.length > 0) setEntries(usable)
+      })
+      // Unreachable API on a public page is not worth an error state — keep the seeded copy.
+      .catch(() => undefined)
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <section id="faq" className="py-20 px-4 bg-white">
+      <div className="max-w-3xl mx-auto">
+        <h2 className="text-3xl font-bold text-center text-gray-800 mb-12">Frequently Asked Questions</h2>
+        <div className="space-y-3">
+          {entries.map((entry) => (
+            <FaqItem key={entry.id} question={entry.question} answer={entry.answer} />
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/cqc_lem/ui/src/pages/Landing.tsx
+++ b/src/cqc_lem/ui/src/pages/Landing.tsx
@@ -1,27 +1,6 @@
-import { useState } from 'react'
 import { useAuth } from '../contexts/AuthContext'
 import TutorialVideos from '../components/TutorialVideos'
-
-function FaqItem({ question, answer }: { question: string; answer: string }) {
-  const [open, setOpen] = useState(false)
-  return (
-    <div className="border border-gray-200 rounded-lg overflow-hidden">
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        className="w-full flex justify-between items-center px-5 py-4 text-left font-medium text-gray-800 hover:bg-gray-50 transition-colors"
-      >
-        <span>{question}</span>
-        <span className="text-gray-400 text-lg leading-none">{open ? '−' : '+'}</span>
-      </button>
-      {open && (
-        <div className="px-5 pb-4 text-sm text-gray-600 leading-relaxed">
-          {answer}
-        </div>
-      )}
-    </div>
-  )
-}
+import FAQ from './FAQ'
 
 export default function Landing() {
   const { openLoginModal } = useAuth()
@@ -250,30 +229,8 @@ export default function Landing() {
         </div>
       </section>
 
-      {/* FAQ */}
-      <section className="py-20 px-4 bg-white">
-        <div className="max-w-3xl mx-auto">
-          <h2 className="text-3xl font-bold text-center text-gray-800 mb-12">Frequently Asked Questions</h2>
-          <div className="space-y-3">
-            <FaqItem
-              question="How does the AI content generation work?"
-              answer="Our AI analyzes your industry, writing style, and audience engagement patterns to create personalized content that matches your brand voice. It uses advanced language models to generate compelling posts, carousels, and video scripts while ensuring appropriate tone and sentiment."
-            />
-            <FaqItem
-              question="Is my LinkedIn account safe?"
-              answer="Absolutely. We use LinkedIn's official API and follow all platform guidelines. Your credentials are encrypted and stored securely. We never perform actions without your explicit approval (unless you enable auto-approval features)."
-            />
-            <FaqItem
-              question="Can I cancel anytime?"
-              answer="Yes, you can cancel your subscription at any time. No long-term contracts or cancellation fees. Your account will remain active until the end of your current billing period."
-            />
-            <FaqItem
-              question="What's included in the free trial?"
-              answer="The 14-day free trial includes access to all Professional plan features with no limitations. You can generate content, schedule posts, and use automation features to fully evaluate the platform."
-            />
-          </div>
-        </div>
-      </section>
+      {/* FAQ — served from `faq_entries` and kept current by the auto-FAQ pass (issue #506) */}
+      <FAQ />
 
       {/* CTA */}
       <section className="py-20 px-4 bg-gradient-to-br from-blue-600 to-purple-700 text-white text-center">

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -7027,9 +7027,13 @@ def get_recent_shipped_notices(limit: int = 10) -> list:
 def get_published_faq_entries(limit: int = 50) -> list:
     """The published FAQ shown on the landing page, in display order. Only PUBLISHED rows leave the
     database — drafts written by the auto-FAQ pass stay unpublished until reviewed."""
-    connection = get_db_connection()
-    cursor = connection.cursor(dictionary=True)
+    # Connect inside the try: an unreachable database must degrade to an empty FAQ, never bubble an
+    # exception up into the logged-out landing page.
+    connection = None
+    cursor = None
     try:
+        connection = get_db_connection()
+        cursor = connection.cursor(dictionary=True)
         cursor.execute(
             "SELECT id, question, answer, cluster_id, updated_at FROM faq_entries "
             "WHERE status = %s ORDER BY sort_order ASC, id ASC LIMIT %s",
@@ -7039,8 +7043,10 @@ def get_published_faq_entries(limit: int = 50) -> list:
         log_error("Could not get published FAQ entries", exc=err)
         return []
     finally:
-        cursor.close()
-        connection.close()
+        if cursor is not None:
+            cursor.close()
+        if connection is not None:
+            connection.close()
 
 
 # --- Onboarding / activation checklist (issue #500) ---------------------------------

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -211,6 +211,14 @@ class FeedbackStatus(StrEnum):
     DISMISSED = 'dismissed'          # not actionable
 
 
+class FaqStatus(StrEnum):
+    """Lifecycle of a public FAQ answer (issue #506). Only PUBLISHED rows are served on the front
+    page — an auto-generated answer lands as DRAFT until it is reviewed."""
+    PUBLISHED = 'published'
+    DRAFT = 'draft'
+    ARCHIVED = 'archived'
+
+
 class OnboardingStep(StrEnum):
     """Steps of the activation checklist (issue #500), in the order a user completes them.
     ACTIVATED is the "aha" moment: first AI post published AND first automated comment/DM sent."""
@@ -7009,6 +7017,26 @@ def get_recent_shipped_notices(limit: int = 10) -> list:
         return cursor.fetchall() or []
     except mysql.connector.Error as err:
         log_error("Could not get recent shipped notices", exc=err)
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+# --- Public FAQ (issue #506) --------------------------------------------------------
+def get_published_faq_entries(limit: int = 50) -> list:
+    """The published FAQ shown on the landing page, in display order. Only PUBLISHED rows leave the
+    database — drafts written by the auto-FAQ pass stay unpublished until reviewed."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT id, question, answer, cluster_id, updated_at FROM faq_entries "
+            "WHERE status = %s ORDER BY sort_order ASC, id ASC LIMIT %s",
+            (FaqStatus.PUBLISHED.value, int(limit)))
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        log_error("Could not get published FAQ entries", exc=err)
         return []
     finally:
         cursor.close()

--- a/tests/integration/test_faq_endpoint.py
+++ b/tests/integration/test_faq_endpoint.py
@@ -1,0 +1,118 @@
+"""Integration test for the public front-page FAQ (issue #506).
+
+Drives the real GET /api/faq handler through the real db.py SQL into a stateful fake cursor that
+models `faq_entries` — so it is provable, without a MySQL container, that only published entries
+reach the landing page, that they arrive in display order, and that the migration seeds the topics
+the front page promises (pricing/trial, ToS, data/privacy, voice, what the automation does,
+cancellation).
+"""
+import re
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.integration
+
+_DB = "cqc_lem.utilities.db"
+_MIGRATION = (Path(__file__).resolve().parents[2]
+              / "compose/local/database/migrations/V20260725155210__add_faq_entries.sql")
+
+
+class _FakeCursor:
+    """Minimal MySQL-ish cursor over an in-memory faq_entries store."""
+
+    def __init__(self, store, dictionary=False):
+        self.store = store
+        self.dictionary = dictionary
+        self._result = []
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.split())
+        params = params or ()
+        if s.startswith("SELECT id, question, answer, cluster_id, updated_at FROM faq_entries"):
+            rows = [r for r in self.store if r["status"] == params[0]]
+            rows.sort(key=lambda r: (r["sort_order"], r["id"]))
+            self._result = [{k: r[k] for k in ("id", "question", "answer", "cluster_id", "updated_at")}
+                            for r in rows[:params[1]]]
+        else:  # pragma: no cover - defensive
+            raise AssertionError(f"unexpected SQL: {s}")
+
+    def fetchall(self):
+        return list(self._result)
+
+    def close(self):
+        pass
+
+
+class _FakeConn:
+    def __init__(self, store):
+        self.store = store
+
+    def cursor(self, *a, **k):
+        return _FakeCursor(self.store, dictionary=k.get("dictionary", False))
+
+    def close(self):
+        pass
+
+
+def _entry(entry_id, question, sort_order, status="published", cluster_id=None):
+    return {"id": entry_id, "question": question, "answer": f"answer {entry_id}",
+            "cluster_id": cluster_id, "status": status, "sort_order": sort_order,
+            "updated_at": datetime(2026, 7, 25, 12, 0)}
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from cqc_lem.api.main import app
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture
+def store():
+    return [
+        _entry(2, "Can I cancel anytime?", 60),
+        _entry(1, "What does the automation actually do?", 10),
+        _entry(3, "Why is my post stuck?", 20, status="draft", cluster_id=12),
+        _entry(4, "Old pricing?", 30, status="archived"),
+    ]
+
+
+def _get_faq(client, store):
+    with patch(f"{_DB}.get_db_connection", side_effect=lambda *a, **k: _FakeConn(store)), \
+         patch("cqc_lem.utilities.observability.posthog"):
+        return client.get("/api/faq")
+
+
+class TestPublicFaq:
+    def test_serves_only_published_entries_in_display_order(self, client, store):
+        response = _get_faq(client, store)
+
+        assert response.status_code == 200
+        entries = response.json()["detail"]["entries"]
+        assert [e["question"] for e in entries] == [
+            "What does the automation actually do?", "Can I cancel anytime?"]
+        # An auto-generated draft awaiting review must never leak onto the public page.
+        assert all("stuck" not in e["question"] for e in entries)
+        assert entries[0]["updated_at"] == "2026-07-25T12:00:00Z"
+        assert "cluster_id" not in entries[0]
+
+    def test_an_unpublished_faq_returns_an_empty_list_not_an_error(self, client):
+        """The SPA falls back to its seeded copy — the front page must not break on an empty FAQ."""
+        response = _get_faq(client, [_entry(9, "Draft only", 10, status="draft")])
+
+        assert response.status_code == 200
+        assert response.json()["detail"]["entries"] == []
+
+
+class TestSeedEntries:
+    def test_the_migration_seeds_every_promised_topic(self):
+        sql = _MIGRATION.read_text(encoding="utf-8")
+        assert "INSERT IGNORE INTO faq_entries" in sql  # re-running never duplicates a question
+        for topic in ("free trial", "Terms of Service", "credentials", "voice",
+                      "automation actually do", "cancel anytime"):
+            assert topic in sql
+        questions = re.findall(r"^\('(.+?)',$", sql, flags=re.MULTILINE)
+        assert len(questions) == 6

--- a/tests/unit/api/test_api_token_gate.py
+++ b/tests/unit/api/test_api_token_gate.py
@@ -76,6 +76,28 @@ class TestApiTokenRequired:
         with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", {"tok"}):
             assert main_mod._api_token_required(path) is False
 
+    @pytest.mark.parametrize("path", [
+        "/api/faq-admin",              # sibling of the public /api/faq
+        "/api/app-info-internal",
+        "/api/assets-private",
+        "/api/billing/webhook-replay",
+        "/api/user/linkedin-cookie-export",
+    ])
+    def test_a_public_entry_does_not_unlock_its_siblings(self, main_mod, path):
+        """Public entries match on a path-segment boundary, not a bare string prefix."""
+        with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", {"tok"}):
+            assert main_mod._api_token_required(path) is True
+
+    @pytest.mark.parametrize("path", [
+        "/api/auth/email/init",                          # trailing-slash entry: whole subtree
+        "/api/extension/linkedin-connect.zip",
+        "/api/linkedin/verification-pin/inbound",        # leaf entry: segments below it stay public
+        "/api/linkedin/comment-notification/inbound",
+    ])
+    def test_public_subpaths_stay_public(self, main_mod, path):
+        with patch.object(main_mod, "_API_ACCESS_TOKEN_SET", {"tok"}):
+            assert main_mod._api_token_required(path) is False
+
 
 # ---------------------------------------------------------------------------
 # Middleware behavior via TestClient

--- a/tests/unit/api/test_faq_api.py
+++ b/tests/unit/api/test_faq_api.py
@@ -1,0 +1,61 @@
+"""Unit tests for the public FAQ endpoint (issue #506)."""
+
+from datetime import datetime
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_M = "cqc_lem.api.main"
+_DB = "cqc_lem.utilities.db"
+
+_ENTRY = {"id": 3, "question": "Can I cancel anytime?", "answer": "Yes.", "cluster_id": 12,
+          "updated_at": datetime(2026, 7, 25, 12, 0)}
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+class TestFaqEndpoint:
+    def test_serves_the_published_entries(self, client):
+        with patch(f"{_DB}.get_published_faq_entries", return_value=[_ENTRY]):
+            resp = client.get("/api/faq")
+        assert resp.status_code == 200
+        # cluster_id is internal plumbing for the auto-FAQ pass — not public copy.
+        assert resp.json()["detail"] == {"entries": [{
+            "id": 3, "question": "Can I cancel anytime?", "answer": "Yes.",
+            "updated_at": "2026-07-25T12:00:00Z"}]}
+
+    def test_an_empty_faq_is_not_an_error(self, client):
+        """The SPA falls back to its seeded copy on an empty list, so this must stay a 200."""
+        with patch(f"{_DB}.get_published_faq_entries", return_value=[]):
+            resp = client.get("/api/faq")
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == {"entries": []}
+
+    def test_is_reachable_by_a_logged_out_visitor(self):
+        """The landing page carries no bearer token — /api/faq must stay outside the token gate."""
+        from cqc_lem.api.main import _api_token_required, _PUBLIC_API_PREFIXES
+        assert "/api/faq" in _PUBLIC_API_PREFIXES
+        with patch(f"{_M}._API_ACCESS_TOKEN_SET", {"secret"}):
+            assert _api_token_required("/api/faq") is False
+            assert _api_token_required("/api/user/shipped") is True

--- a/tests/unit/utilities/test_db_faq.py
+++ b/tests/unit/utilities/test_db_faq.py
@@ -61,3 +61,21 @@ class TestGetPublishedFaqEntries:
             assert get_published_faq_entries() == []
         log.assert_called_once()
         conn.close.assert_called_once()
+
+    def test_an_unreachable_database_still_returns_an_empty_list(self):
+        """MySQL down means get_db_connection() itself raises — the landing page must not 500."""
+        with patch(f"{_DB}.get_db_connection", side_effect=mysql.connector.Error("no route")), \
+             patch(f"{_DB}.log_error") as log:
+            from cqc_lem.utilities.db import get_published_faq_entries
+            assert get_published_faq_entries() == []
+        log.assert_called_once()
+
+    def test_a_failing_cursor_still_returns_an_empty_list(self):
+        conn = MagicMock()
+        conn.cursor.side_effect = mysql.connector.Error("cursor boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.log_error") as log:
+            from cqc_lem.utilities.db import get_published_faq_entries
+            assert get_published_faq_entries() == []
+        log.assert_called_once()
+        conn.close.assert_called_once()

--- a/tests/unit/utilities/test_db_faq.py
+++ b/tests/unit/utilities/test_db_faq.py
@@ -1,0 +1,63 @@
+"""Unit tests for the public FAQ DB helper (issue #506)."""
+
+from datetime import datetime
+
+import mysql.connector
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+_ROW = {"id": 3, "question": "Can I cancel anytime?", "answer": "Yes.", "cluster_id": None,
+        "updated_at": datetime(2026, 7, 25, 12, 0)}
+
+
+def _conn(fetchall=None):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.fetchall.return_value = fetchall
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestGetPublishedFaqEntries:
+    def test_returns_published_entries_in_display_order(self):
+        conn, cur = _conn(fetchall=[_ROW])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_published_faq_entries
+            assert get_published_faq_entries() == [_ROW]
+        sql, params = cur.execute.call_args[0]
+        # Drafts written by the auto-FAQ pass must never reach the public page.
+        assert "WHERE status = %s" in sql
+        assert "ORDER BY sort_order ASC, id ASC" in sql
+        assert params == ("published", 50)
+        conn.cursor.assert_called_once_with(dictionary=True)
+        cur.close.assert_called_once()
+        conn.close.assert_called_once()
+
+    def test_limit_is_coerced_to_an_int(self):
+        conn, cur = _conn(fetchall=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_published_faq_entries
+            assert get_published_faq_entries(limit="5") == []
+        assert cur.execute.call_args[0][1] == ("published", 5)
+
+    def test_no_rows_returns_an_empty_list(self):
+        conn, _cur = _conn(fetchall=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_published_faq_entries
+            assert get_published_faq_entries() == []
+
+    def test_db_errors_are_swallowed_so_the_public_page_still_renders(self):
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        conn.cursor.return_value = cur
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.log_error") as log:
+            from cqc_lem.utilities.db import get_published_faq_entries
+            assert get_published_faq_entries() == []
+        log.assert_called_once()
+        conn.close.assert_called_once()


### PR DESCRIPTION
## What & why

The landing page FAQ was four hardcoded answers baked into `Landing.tsx` — one of which claimed "we use LinkedIn's official API", which is not how the automation works. This moves the FAQ into data so the auto-FAQ pass (the last consumer of the feedback→auto-work loop: questions the classifier routes to `FeedbackRoute.FAQ`) can keep the published answers current from what users actually ask.

- **Migration** `V20260725155210__add_faq_entries.sql` — `faq_entries` (question, answer, `cluster_id`, `status`, `sort_order`, `updated_at`), unique on question, plus `INSERT IGNORE` seeds for the six promised topics: what the automation does, pricing/trial, LinkedIn ToS, data/credentials, how the AI matches your voice, cancellation. `cluster_id` is a plain INT like `feedback.cluster_id` (clusters are ids, not a table).
- **`db.py`** — `FaqStatus` StrEnum (`published`/`draft`/`archived`) + `get_published_faq_entries()`; only `published` rows leave the DB, so an auto-generated draft never reaches the public page. DB errors return `[]` rather than breaking the landing page.
- **`api/main.py`** — public `GET /api/faq` (added to `_PUBLIC_API_PREFIXES`, alongside `/api/app-info`: GET-only, no user data, and the logged-out landing page carries no bearer token). `cluster_id` is internal and is not serialized.
- **UI** — new `pages/FAQ.tsx` fetches `/faq` and renders the accordion; `Landing.tsx` now just renders `<FAQ />`. The seeded copy ships in the component as a **fallback only**, so an empty/unreachable API leaves the front page answering the basics instead of showing an empty section.

## Testing

- `tests/unit/utilities/test_db_faq.py` — status filter, display ordering, limit coercion, error path.
- `tests/unit/api/test_faq_api.py` — response shape (no `cluster_id`), empty FAQ stays a 200, and the token gate leaves `/api/faq` reachable while `/api/user/shipped` stays gated.
- `tests/integration/test_faq_endpoint.py` — real handler → real `db.py` SQL → stateful fake `faq_entries` cursor: only published entries, in order, drafts never leak; plus a check that the migration seeds all six topics.
- `poetry run pytest tests/unit/api tests/unit/utilities/test_db.py` + the new files: 660 passed. `npm ci && npx tsc -b` clean.

Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)