### PR TITLE
fix(logging): set OTLP service.name so PostHog logs aren't 'unknown_service'

### DIFF
--- a/src/cqc_lem/utilities/logger.py
+++ b/src/cqc_lem/utilities/logger.py
@@ -14,6 +14,25 @@ LOGGING_FILENAME = "logs/cqc_lem_" + _today.strftime("%Y_%m_%d") + ".log"
 os.makedirs("logs", exist_ok=True)
 
 
+def _otlp_resource():
+    """OTel Resource identifying LEM in PostHog Logs. Without this the provider defaults to
+    'unknown_service' — set a real service.name so logs are filterable, tag the version from the
+    deployed image tag, and use the container hostname as the instance id so each worker
+    (web_app / celery_worker / *_selenium / *_content) is distinguishable."""
+    from opentelemetry.sdk.resources import Resource
+    attrs = {
+        "service.name": os.getenv("OTEL_SERVICE_NAME", "cqc-lem"),
+        "service.instance.id": os.getenv("HOSTNAME", "") or "unknown-instance",
+    }
+    version = os.getenv("IMAGE_TAG", "")
+    if version:
+        attrs["service.version"] = version
+    env = os.getenv("DEPLOY_ENV", "")
+    if env:
+        attrs["deployment.environment"] = env
+    return Resource.create(attrs)
+
+
 def _build_posthog_handler(level: int) -> Optional[logging.Handler]:
     """Build an OTLP-backed LoggingHandler that ships logs to PostHog Logs."""
     api_key = os.getenv("POSTHOG_API_KEY", "")
@@ -30,7 +49,7 @@ def _build_posthog_handler(level: int) -> Optional[logging.Handler]:
         endpoint=f"{host}/i/v1/logs",
         headers={"Authorization": f"Bearer {api_key}"},
     )
-    provider = LoggerProvider()
+    provider = LoggerProvider(resource=_otlp_resource())
     provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
     set_logger_provider(provider)
 

--- a/tests/unit/utilities/test_logger.py
+++ b/tests/unit/utilities/test_logger.py
@@ -233,3 +233,46 @@ class TestLoggerConfiguration:
             return  # no key configured — handler absent, nothing to assert
         expected = getattr(logging, os.getenv("POSTHOG_LOG_LEVEL", "ERROR").upper(), logging.ERROR)
         assert ph_handlers[0].level == expected
+
+
+# ---------------------------------------------------------------------------
+# OTLP resource (service.name) — issue: logs were landing under 'unknown_service'
+# ---------------------------------------------------------------------------
+
+@patch.dict(os.environ, {"HOSTNAME": "celery_worker_selenium", "IMAGE_TAG": "v0.70.0", "DEPLOY_ENV": "prod"}, clear=False)
+def test_otlp_resource_sets_service_name_and_instance():
+    from cqc_lem.utilities.logger import _otlp_resource
+    attrs = _otlp_resource().attributes
+    assert attrs["service.name"] == "cqc-lem"
+    assert attrs["service.instance.id"] == "celery_worker_selenium"
+    assert attrs["service.version"] == "v0.70.0"
+    assert attrs["deployment.environment"] == "prod"
+
+
+@patch.dict(os.environ, {"OTEL_SERVICE_NAME": "cqc-lem-web"}, clear=False)
+def test_otlp_resource_service_name_overridable():
+    from cqc_lem.utilities.logger import _otlp_resource
+    assert _otlp_resource().attributes["service.name"] == "cqc-lem-web"
+
+
+def test_otlp_resource_defaults_when_env_absent():
+    from cqc_lem.utilities.logger import _otlp_resource
+    with patch.dict(os.environ, {}, clear=True):
+        attrs = _otlp_resource().attributes
+        assert attrs["service.name"] == "cqc-lem"
+        assert attrs["service.instance.id"] == "unknown-instance"
+        assert "service.version" not in attrs  # not set when IMAGE_TAG absent
+
+
+def test_posthog_handler_provider_carries_the_resource():
+    """The LoggerProvider must be built WITH the resource (regression: was LoggerProvider())."""
+    import cqc_lem.utilities.logger as mod
+    with patch.dict(os.environ, {"POSTHOG_API_KEY": "phc_x"}, clear=False), \
+         patch("opentelemetry.sdk._logs.LoggerProvider") as LP, \
+         patch("opentelemetry.sdk._logs.LoggingHandler"), \
+         patch("opentelemetry.sdk._logs.export.BatchLogRecordProcessor"), \
+         patch("opentelemetry.exporter.otlp.proto.http._log_exporter.OTLPLogExporter"), \
+         patch("opentelemetry._logs.set_logger_provider"):
+        mod._build_posthog_handler(logging.ERROR)
+    assert "resource" in LP.call_args.kwargs
+    assert LP.call_args.kwargs["resource"].attributes["service.name"] == "cqc-lem"


### PR DESCRIPTION
PostHog Logs were all landing under `unknown_service` because the OTLP `LoggerProvider` was built with no `Resource`. This adds `_otlp_resource()` — `service.name=cqc-lem` (overridable via `OTEL_SERVICE_NAME`), `service.instance.id` from the container `HOSTNAME` (so web_app / celery_worker / *_selenium / *_content are distinguishable in PostHog), plus optional `service.version` (`IMAGE_TAG`) and `deployment.environment` (`DEPLOY_ENV`) — and builds the provider with it. Makes the error-scan cron's logs properly filterable. 4 unit tests; logger suite green (24). 🤖 Generated with [Claude Code](https://claude.com/claude-code)