### PR TITLE
fix(automation): key feed comments on the activity URN from the card's ancestors (closes #580)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -506,17 +506,90 @@ def _normalize_post_text(content: str) -> str:
     return t
 
 
+# The URN-less fallback hashes a PREFIX of the body, not all of it: LinkedIn's collapsed card
+# truncates a long post (~3 lines) while the expanded render carries the whole thing, so hashing
+# everything mints TWO keys for one post across a re-render — which is how #474 recurred as #580.
+# Truncation happens well past 120 characters, so a 120-char prefix is byte-identical in both.
+_FEED_KEY_PREFIX_CHARS = 120
+# Extra shorter prefix for the per-run fingerprint set: it still matches when a render truncates
+# even earlier than the canonical prefix (narrow window, aggressive "…more" collapse).
+_FEED_FP_PREFIX_CHARS = (60, _FEED_KEY_PREFIX_CHARS)
+
+
+def _norm_prefix(content: str, limit: int) -> str:
+    """Normalized post text cut to `limit` chars on a word boundary — the same prefix for the
+    collapsed and the expanded render of one post."""
+    norm = _normalize_post_text(content)
+    if len(norm) <= limit:
+        return norm
+    head, sep, _tail = norm[:limit].rpartition(" ")
+    return head if sep else norm[:limit]
+
+
+def _content_digest(author: str, content: str, limit: int) -> str:
+    """Short sha1 over the author + a truncation-proof normalized body prefix."""
+    payload = f"{(author or '').strip().lower()}|{_norm_prefix(content, limit)}"
+    return hashlib.sha1(payload.encode("utf-8", "ignore")).hexdigest()[:20]
+
+
 def _feed_post_key(author: str, content: str) -> str:
-    """Last-resort dedup key when no stable URN/permalink is available. Hashes the NORMALIZED
-    text (see _normalize_post_text) so it's stable across see-more/whitespace re-renders."""
-    norm = _normalize_post_text(content)[:240]
-    digest = hashlib.sha1(f"{(author or '').strip().lower()}|{norm}".encode("utf-8", "ignore")).hexdigest()[:20]
-    return f"feedpost://{digest}"
+    """Last-resort dedup key when no stable URN/permalink is available. Hashes the author plus a
+    NORMALIZED, truncation-proof body prefix (see _norm_prefix) so the collapsed and the expanded
+    render of one post produce ONE key."""
+    return f"feedpost://{_content_digest(author, content, _FEED_KEY_PREFIX_CHARS)}"
 
 
-def _feed_post_urn_from_card(card) -> "str | None":
-    """The canonical urn:li:(activity|ugcPost|share):<id> for a feed card, read from any data
-    attribute or anywhere in the card's HTML. Returns the lowercased URN or None."""
+def _feed_content_fingerprints(author: str, content: str) -> "set[str]":
+    """Render-stable per-run fingerprints of a post's text at several prefix lengths — a second
+    dedup guard so that even on the URN-less fallback path (or when a URN is found on one pass and
+    not the next) a re-render can't re-key the post and earn it a second comment."""
+    return {f"fp{n}:{_content_digest(author, content, n)}" for n in _FEED_FP_PREFIX_CHARS}
+
+
+# The activity URN lives in a data-* attribute on the feed-update CONTAINER, which sits ABOVE the
+# comment-button ancestor `_card_for_textbox` returns — so scanning only that card's outerHTML found
+# nothing on the live 2026 feed and every comment fell back to the content hash (issue #580). Walk
+# UP instead, reading each element's OWN attribute values, and stop at the first ancestor spanning
+# more than one post card so we can never pick up a SIBLING post's URN. Descendant attributes are
+# checked last (a reshare embeds the original post's URN, so containers outrank children).
+_URN_SCAN_JS = r"""
+const RE = /urn:li:(?:activity|ugcPost|share):\d+/i;
+const attrHit = (el) => {
+  if (!el || !el.attributes) return null;
+  for (const a of el.attributes) { const m = RE.exec(a.value || ''); if (m) return m[0]; }
+  return null;
+};
+const el = arguments[0];
+let hit = attrHit(el);
+if (hit) return hit;
+let p = el.parentElement, depth = 0;
+while (p && depth < 12) {
+  if (p.querySelectorAll && p.querySelectorAll("button[aria-label='Comment']").length > 1) break;
+  hit = attrHit(p);
+  if (hit) return hit;
+  p = p.parentElement; depth++;
+}
+if (el.querySelectorAll) {
+  for (const d of el.querySelectorAll('*')) { hit = attrHit(d); if (hit) return hit; }
+}
+return null;
+"""
+
+
+def _feed_post_urn_from_card(card, driver=None) -> "str | None":
+    """The canonical urn:li:(activity|ugcPost|share):<id> for a feed card. Reads data-* attributes
+    on the card, on its ancestors (never past an element that spans more than one post) and on its
+    descendants, then falls back to a regex over the card's own HTML. Lowercased URN or None."""
+    runner = driver if driver is not None else getattr(card, "parent", None)
+    if runner is not None:
+        try:
+            found = runner.execute_script(_URN_SCAN_JS, card)
+        except Exception:
+            found = None
+        if isinstance(found, str):
+            m = _URN_RE.search(found)
+            if m:
+                return m.group(0).lower()
     try:
         html = card.get_attribute("outerHTML")
     except Exception:
@@ -527,27 +600,27 @@ def _feed_post_urn_from_card(card) -> "str | None":
     return m.group(0).lower() if m else None
 
 
-def _stable_feed_post_key(card, author: str, content: str) -> str:
-    """Single canonical dedup key for a feed post, stable across re-renders. Prefers the URN
-    (from the permalink anchor OR anywhere in the card HTML) so permalink-present and
-    permalink-absent renders of the same post map to ONE key; only falls back to the normalized
-    content hash when no URN can be found."""
-    urn = None
+def _feed_post_identity(card, author: str, content: str, driver=None) -> "tuple[str, str]":
+    """(dedup key, key SOURCE) for a feed post. Source is 'permalink' | 'card' | 'hash' — recorded
+    on the run so we can confirm live that feed comments key on the stable activity URN and not on
+    the volatile content hash (issue #580)."""
     permalink = _post_permalink_from_card(card)
     if permalink:
         m = _URN_RE.search(permalink)
-        urn = m.group(0).lower() if m else None
-    if not urn:
-        urn = _feed_post_urn_from_card(card)
+        if m:
+            return f"feedurn://{m.group(0).lower()}", "permalink"
+    urn = _feed_post_urn_from_card(card, driver=driver)
     if urn:
-        return f"feedurn://{urn}"
-    return _feed_post_key(author, content)
+        return f"feedurn://{urn}", "card"
+    return _feed_post_key(author, content), "hash"
 
 
-def _feed_content_fingerprint(author: str, content: str) -> str:
-    """A render-stable per-run fingerprint of the post's text — a second dedup guard so that even
-    on the URN-less fallback path an unstable render can't sneak a second comment through."""
-    return "fp:" + _feed_post_key(author, content)
+def _stable_feed_post_key(card, author: str, content: str, driver=None) -> str:
+    """Single canonical dedup key for a feed post, stable across re-renders. Prefers the URN
+    (from the permalink anchor OR the card/ancestor data attributes) so permalink-present and
+    permalink-absent renders of the same post map to ONE key; only falls back to the normalized
+    content hash when no URN can be found."""
+    return _feed_post_identity(card, author, content, driver=driver)[0]
 
 
 def _post_permalink_from_card(card):
@@ -1011,6 +1084,11 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
     # empty-filter fallback. examined = posts we looked at; hard = passed excludes/recency/min-reactions;
     # include = also matched the user's include topics/keywords/authors.
     examined_keys, hard_keys, include_keys = set(), set(), set()
+    # Which SOURCE produced each post's dedup key (permalink / card URN / content hash). Surfaced on
+    # the funnel + logs so a live run proves feed comments key on the stable URN — a hash-keyed
+    # comment is the duplicate-prone path that caused #474/#580.
+    key_source_by_key: dict = {}
+    posted_key_sources: dict = {}
     strict_misses, fallback_active, fallback_used = 0, False, False
     # Posts that cleared excludes + dedup but failed ONLY the recency/min-reactions gates. Tracked
     # apart from the permanent `seen` set so the empty-feed fallback can RECONSIDER them (relaxing
@@ -1039,19 +1117,21 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
                 continue
             author = _post_author_from_card(card)
             # Canonical URN-based key (stable across re-renders); normalized content hash only
-            # when no URN exists. `fp` is a second, render-stable fingerprint so even the URN-less
-            # fallback path can't slip a second comment through on a "…see more"/re-render (#474).
-            key = _stable_feed_post_key(card, author, content)
-            fp = _feed_content_fingerprint(author, content)
-            if key in seen or fp in seen:
+            # when no URN exists. `fps` are render-stable fingerprints at several prefix lengths, so
+            # even the URN-less fallback path can't slip a second comment through when a re-render
+            # truncates the body differently (#474, recurred as #580).
+            key, key_source = _feed_post_identity(card, author, content, driver=driver)
+            fps = _feed_content_fingerprints(author, content)
+            if key in seen or (fps & seen):
                 continue
+            key_source_by_key[key] = key_source
             examined_keys.add(key)
             # Persistent, cross-run/worker dedup: skip anything already claimed or commented
             # (commented_posts ledger), plus historical SUCCESS comment logs, plus hard excludes.
             if (has_commented_post(user_id, key) or has_user_commented_on_post_url(user_id, key)
                     or not _passes_hard_excludes(content, author, prefs)):
                 seen.add(key)
-                seen.add(fp)
+                seen.update(fps)
                 continue
             # Recency + min-reactions are soft gates: when the whole feed fails them the empty-feed
             # fallback relaxes them (below), so a reject here goes to soft_seen (reconsiderable),
@@ -1070,13 +1150,14 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             meta = {"author": author, "age_minutes": age, "comments": counts["comments"],
                     "reactions": counts["reactions"], "relevant": _literal_relevant(content, author, prefs)}
             hard_keys.add(key)
-            candidates.append((_score_feed_post(meta, prefs, engagers), key, card, content, author, age, fp))
+            candidates.append((_score_feed_post(meta, prefs, engagers), key, card, content, author, age,
+                               fps, key_source))
 
         if candidates:
             candidates.sort(key=lambda c: c[0], reverse=True)
-            score, key, card, content, author, age, fp = candidates[0]
-            seen.add(key)   # decided on this one either way
-            seen.add(fp)    # and its render-stable fingerprint (URN-less fallback guard)
+            score, key, card, content, author, age, fps, key_source = candidates[0]
+            seen.add(key)        # decided on this one either way
+            seen.update(fps)     # and its render-stable fingerprints (URN-less fallback guard)
             # Include gate (may use the LLM topic classifier) on the chosen post. If the feed keeps
             # producing nothing that matches the user's include filters, RELAX to fallback for the rest
             # of the run — comment on the best feed post regardless of include (LinkedIn already curates
@@ -1120,6 +1201,9 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
                     mark_post_commented(user_id, key)
                     insert_new_log(user_id=user_id, action_type=LogActionType.COMMENT,
                                    result=LogResultType.SUCCESS, post_url=key, message=comment_text)
+                    posted_key_sources[key_source] = posted_key_sources.get(key_source, 0) + 1
+                    log_info(f"Feed comment keyed by {key_source} ({key})", user_id=user_id,
+                             action_type="comment", task_name="comment_on_feed_inline")
                     posted += 1
                     myprint(f"Commented on {author or 'a'}'s post "
                             f"(score {score:.2f}, age {'?' if age is None else str(age) + 'm'}) ({posted}/{max_posts})")
@@ -1148,18 +1232,29 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
         scrolls += 1
         time.sleep(random.uniform(2.5, 4))
 
+    examined_key_sources: dict = {}
+    for source in key_source_by_key.values():
+        examined_key_sources[source] = examined_key_sources.get(source, 0) + 1
     set_feed_funnel(user_id, {
         "examined": len(examined_keys),
         "passed_filters": len(hard_keys),      # cleared excludes + recency + min-reactions
         "matched_topics": len(include_keys),   # also matched include topics/keywords/authors
         "commented": posted,
         "fallback_used": fallback_used,
+        "key_sources": examined_key_sources,           # every post we looked at
+        "commented_key_sources": posted_key_sources,   # only the ones we commented on
         "max_post_age_hours": prefs.get("max_post_age_hours") or 24,
         "min_reactions": min_reactions,
         "at": datetime.now().isoformat(),
     })
-    myprint(f"Feed scan: examined {len(examined_keys)}, passed filters {len(hard_keys)}, "
-            f"matched topics {len(include_keys)}, commented {posted}, fallback={fallback_used}")
+    log_info(f"Feed scan: examined {len(examined_keys)}, passed filters {len(hard_keys)}, "
+             f"matched topics {len(include_keys)}, commented {posted}, fallback={fallback_used}, "
+             f"key sources {examined_key_sources}", user_id=user_id, action_type="comment",
+             task_name="comment_on_feed_inline")
+    if posted_key_sources.get("hash"):
+        log_warning(f"{posted_key_sources['hash']} of {posted} feed comments used an unstable "
+                    f"content-hash key — no activity URN on those cards (duplicate risk, #580)",
+                    user_id=user_id, action_type="comment", task_name="comment_on_feed_inline")
     return posted
 
 
@@ -2554,7 +2649,7 @@ def _scrape_activity_comment_urns(driver, wait, my_profile) -> dict:
             card = _card_for_textbox(driver, box) or box
             url = _post_permalink_from_card(card)
             if not url:
-                urn = _feed_post_urn_from_card(card)
+                urn = _feed_post_urn_from_card(card, driver=driver)
                 url = f"https://www.linkedin.com/feed/update/{urn}/" if urn else None
             if url:
                 mapping[_normalize_post_text(text)[:200]] = url

--- a/tests/unit/app/test_comment_dedup.py
+++ b/tests/unit/app/test_comment_dedup.py
@@ -24,7 +24,7 @@ def _box(text):
 
 def _run_feed(boxes, *, claim_side_effect=None, has_commented=False, max_posts=10,
               author="Jane Author", is_me=False, react_returns=True, post_returns=True,
-              prefs=None, matches=True):
+              prefs=None, matches=True, real_key=False, urn_scan=None):
     """Drive comment_on_feed_inline with all the SDUI/DB collaborators mocked. Returns a dict of
     the key mocks so assertions can inspect calls."""
     from cqc_lem.app import run_automation as ra
@@ -32,6 +32,8 @@ def _run_feed(boxes, *, claim_side_effect=None, has_commented=False, max_posts=1
     driver = MagicMock()
     driver.find_elements.return_value = boxes
     wait = MagicMock()
+    # The ancestor/attribute URN scan runs through the driver; a non-str return means "no URN".
+    driver.execute_script.return_value = urn_scan
 
     # A stable content->key map (simulates _feed_post_key: same content => same key).
     def _key(a, content):
@@ -55,7 +57,8 @@ def _run_feed(boxes, *, claim_side_effect=None, has_commented=False, max_posts=1
         p("_card_for_textbox", side_effect=lambda d, b: MagicMock())
         p("_post_author_from_card", return_value=author)
         p("_post_permalink_from_card", return_value=None)
-        p("_feed_post_key", side_effect=_key)
+        if not real_key:
+            p("_feed_post_key", side_effect=_key)
         p("_author_is_me", return_value=is_me)
         p("has_commented_post", return_value=has_commented)
         p("has_user_commented_on_post_url", return_value=False)
@@ -101,6 +104,33 @@ class TestFeedDedup:
         r = _run_feed([_box(same), _box(same)])
         assert r["posted"] == 1
         assert r["post_inline"].call_count == 1
+
+    def test_rerendered_truncation_does_not_earn_a_second_comment(self):
+        # #580: the collapsed card truncates a long post, the expanded render carries the whole
+        # body. Hashing everything made those two renders two keys -> two comments on one post.
+        full = ("Most teams do not have a data problem, they have a definitions problem: three "
+                "dashboards, three revenue numbers, and nobody willing to own the discrepancy in "
+                "the weekly review where the very same question gets asked all over again.")
+        truncated = full[:160].rsplit(" ", 1)[0] + "…see more"
+        r = _run_feed([_box(truncated), _box(full)], real_key=True)
+        assert r["posted"] == 1
+        assert r["post_inline"].call_count == 1
+
+    def test_urn_from_ancestor_scan_is_the_dedup_key(self):
+        # With no permalink on the card, the ancestor data-* scan must still produce a feedurn://
+        # key — the whole point of #580 (a hash key is the duplicate-prone fallback).
+        r = _run_feed([_box("A feed post whose activity urn lives on an ancestor node.")],
+                      real_key=True, urn_scan="urn:li:activity:7486221543367397377")
+        assert r["posted"] == 1
+        assert r["claim"].call_args[0][1] == "feedurn://urn:li:activity:7486221543367397377"
+        assert r["funnel"]["commented_key_sources"] == {"card": 1}
+
+    def test_funnel_records_hash_key_source_when_no_urn(self):
+        r = _run_feed([_box("A feed post with no activity urn anywhere on the card.")],
+                      real_key=True)
+        assert r["posted"] == 1
+        assert r["funnel"]["commented_key_sources"] == {"hash": 1}
+        assert r["funnel"]["key_sources"] == {"hash": 1}
 
     def test_lost_claim_race_is_noop(self):
         # claim returns False (another run/worker already holds it) => no LLM, no comment.

--- a/tests/unit/app/test_feed_dedup_key.py
+++ b/tests/unit/app/test_feed_dedup_key.py
@@ -1,8 +1,12 @@
-"""Unit tests for the stable feed dedup key + normalization — issue #474.
+"""Unit tests for the stable feed dedup key + normalization — issues #474 and #580.
 
 The bug: the dedup key was a hash of the post's rendered text, so a "…see more" toggle or our
 own just-posted comment mutated the text and produced a NEW key for the SAME post, defeating
 every dedup layer and posting a second comment. These lock in URN-first, render-stable keys.
+
+#580 (recurrence): on the live feed EVERY comment still fell back to the content hash, because the
+URN lives on an ancestor of the card `_card_for_textbox` returns — the outerHTML scan never saw it —
+and the hash covered the whole body, which differs between the truncated and the expanded render.
 """
 
 import pytest
@@ -16,15 +20,21 @@ def _fns():
     # collection time, which fails in CI (no OPENAI_API_KEY).
     from cqc_lem.app.run_automation import (
         _normalize_post_text, _feed_post_key, _feed_post_urn_from_card,
-        _stable_feed_post_key, _feed_content_fingerprint,
+        _stable_feed_post_key, _feed_content_fingerprints,
     )
     return (_normalize_post_text, _feed_post_key, _feed_post_urn_from_card,
-            _stable_feed_post_key, _feed_content_fingerprint)
+            _stable_feed_post_key, _feed_content_fingerprints)
 
 
-def _card(outer_html=None, permalink_href=None):
+def _card(outer_html=None, permalink_href=None, scan_result=None, scan_raises=False):
+    """A feed card. `scan_result` is what the ancestor/attribute URN scan (a JS call through the
+    driver) returns — MagicMock's default is a non-str sentinel, i.e. 'scan found nothing'."""
     card = MagicMock()
     card.get_attribute.return_value = outer_html or ""
+    if scan_raises:
+        card.parent.execute_script.side_effect = RuntimeError("stale element")
+    elif scan_result is not None:
+        card.parent.execute_script.return_value = scan_result
     if permalink_href is not None:
         anchor = MagicMock()
         anchor.get_attribute.return_value = permalink_href
@@ -79,6 +89,58 @@ class TestUrnExtraction:
         card.get_attribute.side_effect = RuntimeError("stale")
         assert _fns()[2](card) is None
 
+    def test_ancestor_attribute_scan_wins_over_card_html(self):
+        # The #580 case: the card's own HTML has NO urn — the feed-update ancestor's data-id does.
+        urn_from_card = _fns()[2]
+        card = _card(outer_html="<div>no urn in the comment-button ancestor</div>",
+                     scan_result="urn:li:activity:7486221543367397377")
+        assert urn_from_card(card) == "urn:li:activity:7486221543367397377"
+
+    def test_scan_result_is_lowercased_and_extracted(self):
+        urn_from_card = _fns()[2]
+        card = _card(outer_html="<div>nothing</div>",
+                     scan_result="urn:li:comment:(urn:li:ugcPost:42,99)")
+        assert urn_from_card(card) == "urn:li:ugcpost:42"
+
+    def test_explicit_driver_is_used_for_the_scan(self):
+        urn_from_card = _fns()[2]
+        driver = MagicMock()
+        driver.execute_script.return_value = "urn:li:share:7"
+        card = _card(outer_html="<div>nothing</div>")
+        assert urn_from_card(card, driver=driver) == "urn:li:share:7"
+        driver.execute_script.assert_called_once()
+
+    def test_scan_failure_falls_back_to_card_html(self):
+        urn_from_card = _fns()[2]
+        card = _card(outer_html='<div data-urn="urn:li:activity:5">x</div>', scan_raises=True)
+        assert urn_from_card(card) == "urn:li:activity:5"
+
+    def test_non_string_scan_result_falls_back_to_card_html(self):
+        # execute_script can return null/undefined -> None; must not be treated as a URN.
+        urn_from_card = _fns()[2]
+        card = _card(outer_html='<div data-urn="urn:li:activity:6">x</div>', scan_result=None)
+        card.parent.execute_script.return_value = None
+        assert urn_from_card(card) == "urn:li:activity:6"
+
+
+class TestFeedPostIdentity:
+    def _identity(self):
+        from cqc_lem.app.run_automation import _feed_post_identity
+        return _feed_post_identity
+
+    def test_permalink_source(self):
+        key, source = self._identity()(
+            _card(permalink_href="https://www.linkedin.com/feed/update/urn:li:activity:11/"), "A", "x")
+        assert (key, source) == ("feedurn://urn:li:activity:11", "permalink")
+
+    def test_card_source(self):
+        key, source = self._identity()(_card(scan_result="urn:li:activity:12"), "A", "x")
+        assert (key, source) == ("feedurn://urn:li:activity:12", "card")
+
+    def test_hash_source(self):
+        key, source = self._identity()(_card(outer_html="<div>no urn</div>"), "A", "a post body here")
+        assert source == "hash" and key.startswith("feedpost://")
+
 
 class TestStableFeedPostKey:
     def test_prefers_urn_and_is_render_independent(self):
@@ -106,6 +168,44 @@ class TestStableFeedPostKey:
 
 class TestContentFingerprint:
     def test_fingerprint_is_render_stable_and_distinct_namespace(self):
-        fp = _fns()[4]
-        assert fp("Jane", "Post …see more") == fp("Jane", "Post")
-        assert fp("Jane", "Post").startswith("fp:")
+        fps = _fns()[4]
+        assert fps("Jane", "Post …see more") == fps("Jane", "Post")
+        assert all(f.startswith("fp") for f in fps("Jane", "Post"))
+        assert len(fps("Jane", "Post")) >= 1
+
+    def test_truncated_render_shares_a_fingerprint_with_the_expanded_one(self):
+        # A long post the collapsed card truncates mid-way; the expanded render has the full body.
+        fps = _fns()[4]
+        full = ("Teams keep buying another dashboard when the real problem is that nobody trusts "
+                "the numbers in the one they already own, and no tool on the market fixes trust "
+                "for you — that part is a conversation your leadership has to have out loud.")
+        truncated = full[:160].rsplit(" ", 1)[0] + "…see more"
+        assert fps("Jane", truncated) & fps("Jane", full)
+
+    def test_different_posts_share_no_fingerprint(self):
+        fps = _fns()[4]
+        assert not (fps("Jane", "Data quality is a people problem, not a tooling problem.")
+                    & fps("Jane", "Hiring senior engineers is a distribution problem."))
+
+
+class TestTruncationProofFallbackKey:
+    def test_truncated_and_expanded_render_share_one_fallback_key(self):
+        # The #580 fallback bug: hashing the WHOLE body gave the collapsed and expanded renders of
+        # one post two different keys, so the ledger/claim guards protected nothing.
+        _, feed_post_key, *_ = _fns()
+        full = ("Most teams do not have a data problem, they have a definitions problem: three "
+                "dashboards, three revenue numbers, and nobody willing to own the discrepancy in "
+                "the weekly review where the very same question gets asked all over again.")
+        truncated = full[:160].rsplit(" ", 1)[0] + "…see more"
+        assert feed_post_key("Jane Doe", truncated) == feed_post_key("Jane Doe", full)
+
+    def test_short_posts_still_key_on_their_whole_body(self):
+        _, feed_post_key, *_ = _fns()
+        assert feed_post_key("Jane", "Short and complete post.") != \
+               feed_post_key("Jane", "Short and complete post!")
+
+    def test_norm_prefix_cuts_on_a_word_boundary(self):
+        from cqc_lem.app.run_automation import _norm_prefix
+        assert _norm_prefix("alpha beta gamma delta", 12) == "alpha beta"
+        assert _norm_prefix("alpha beta", 50) == "alpha beta"
+        assert _norm_prefix("supercalifragilistic", 5) == "super"  # no boundary to cut on


### PR DESCRIPTION
## What & why

Feed commenting posted **duplicate comments on the same post again** for user 1 (4 posts × 2 comments, 2026-07-25) — a recurrence of #474. Every comment that day used a `feedpost://` content-hash key, never the `feedurn://` key #474 introduced, so the `commented_posts` UNIQUE constraint and the atomic claim were protecting an unstable key.

Two root causes, both fixed in `src/cqc_lem/app/run_automation.py`:

### 1. The URN was never found on live feed cards
`_feed_post_urn_from_card` regexed only the `outerHTML` of the card returned by `_card_for_textbox` — the *nearest* ancestor holding the Comment button. The activity URN lives in a `data-*` attribute on the **feed-update container above that**, so the scan came back empty every time.

The scan now (in this order):
1. the card's own attribute values,
2. each **ancestor's own attribute values**, walking up — and stopping at the first ancestor that contains more than one `button[aria-label='Comment']`, so a **sibling post's URN can never be picked up**,
3. descendant attribute values (containers outrank children: a reshare embeds the *original* post's URN),
4. the previous `outerHTML` regex as a last resort.

It runs as one JS pass through the driver (`_URN_SCAN_JS`); `_feed_post_urn_from_card(card, driver=None)` falls back to `card.parent` when no driver is passed, and any scripting failure degrades to the old HTML regex.

### 2. The content-hash fallback still wasn't re-render-stable
It hashed 240 chars of the normalized body, but the **collapsed card truncates a long post** while the expanded render carries the whole thing → two keys for one post. The fallback now hashes the author plus a **120-char word-boundary prefix** (`_norm_prefix`); LinkedIn truncates well past that, so both renders produce the identical prefix. The per-run in-memory guard was widened from one fingerprint to a **set at 60 and 120 chars** (`_feed_content_fingerprints`), so even a render that truncates earlier than the canonical prefix still matches a post we already acted on — and so does the case where a URN is found on one pass but not the next.

### 3. Key-source telemetry (acceptance criterion)
`_feed_post_identity()` returns `(key, source)` where source is `permalink` / `card` / `hash`. The run records it:
- per posted comment: `log_info("Feed comment keyed by <source> (<key>)", …)`
- run summary `log_info` with the source counts,
- `log_warning` when **any** comment fell back to a hash key (the duplicate-prone path),
- and `key_sources` / `commented_key_sources` on the feed funnel in Redis (already surfaced via `/api` → `feed_reach`; extra JSON fields are additive, no UI change needed).

That's how the live run gets verified: after deploy, a feed run should report `commented_key_sources: {"card": N}` (or `permalink`) and **no** `hash`.

## Testing

- `tests/unit/app/test_feed_dedup_key.py` — widened URN extraction (ancestor scan wins over card HTML, URN extracted+lowercased out of a `urn:li:comment:(…)` wrapper, explicit driver, scan exception / non-string result both fall back to the HTML regex), `_feed_post_identity` sources, truncation-proof fallback key, `_norm_prefix` word-boundary cut, multi-length fingerprints.
- `tests/unit/app/test_comment_dedup.py` — loop-level regressions: a truncated + expanded render of the same post yields **one** comment; an ancestor-scan URN becomes the claim key (`feedurn://…`); the funnel records the key source.
- Full suite: `5056 passed`.

## Note on live validation

The issue flags that pinpointing the exact attribute needs a supervised live-feed DOM session. This change doesn't guess a single selector — it scans **all** attribute values on the card, its ancestors and its descendants for the URN pattern, which is robust to wherever LinkedIn puts it, and the key-source telemetry is what confirms it on the real feed. **The live run on user 1's account is still required** to close the acceptance criteria; if `commented_key_sources` still shows `hash` after this ships, the logged warning plus the funnel will say so immediately.

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)