### PR TITLE
feat(content): progress notification + status for post generation (closes #545)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -326,6 +326,13 @@ LEM_APP_URL=https://lem.christopherqueenconsulting.com
 # Throttle for the connect/re-validate LinkedIn-session emails — at most one per user
 # per this many days (login auto-detect + the daily missing-session sweep). Default: 7.
 LINKEDIN_SESSION_EMAIL_THROTTLE_DAYS=7
+# How long (seconds) a weekly content-generation progress record lives in Redis — what the
+# Content Studio polls for "generating X of N". Runtime-only state, so it just needs to
+# outlive the run (video posts take ~6 min each). Default: 86400 (1 day).
+CONTENT_GENERATION_STATUS_TTL_SECONDS=86400
+# How long the FINISHED result ("5 posts are ready to review") keeps showing in the Content
+# Studio before it expires on its own. Default: 3600 (1 hour).
+CONTENT_GENERATION_RESULT_TTL_SECONDS=3600
 
 # Observability & CI
 # =============================================================================

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -75,7 +75,8 @@ from cqc_lem.utilities.db import (
     insert_feedback, FeedbackSource,
     get_latest_review_feedback_id, get_early_adopter_grant, extend_trial_for_user,
 )
-from cqc_lem.utilities.content_generation_status import mark_queued, get_generation_status
+from cqc_lem.utilities.content_generation_status import mark_queued, get_generation_status, \
+    clear_generation_status
 from cqc_lem.utilities.email import generate_pin, hash_pin, send_pin_email
 from cqc_lem.utilities.linkedin.verification_pin import (
     extract_pin_from_text, extract_token_from_address, submit_pin_by_token)
@@ -86,7 +87,7 @@ from cqc_lem.utilities.linkedin.token_refresh import (
 from cqc_lem.utilities.env_constants import LI_CLIENT_ID, LI_CLIENT_SECRET, LI_REDIRECT_URL, LI_STATE_SALT, ADMIN_SECRET, API_ACCESS_TOKENS, \
     DEFAULT_IMAGE_MODEL, DEFAULT_VIDEO_MODEL, DEFAULT_VIDEO_RATIO
 import requests
-from cqc_lem.utilities.logger import myprint, log_warning, log_info
+from cqc_lem.utilities.logger import myprint, log_warning, log_info, log_error
 from cqc_lem.utilities.mime_type_helper import get_file_mime_type
 from cqc_lem.utilities.observability import (
     track_api_call, track_funnel_event, anonymous_distinct_id,
@@ -1310,6 +1311,7 @@ def schedule_post(post: PostRequest) -> ResponseModel:
 
 @router.post("/create_weekly_content/", responses={
     200: {"description": "Weekly content created successfully"},
+    500: {"description": "Could not queue content generation"},
     **{k: v for k, v in error_responses.items() if k in [400]}
 })
 def create_weekly_content(user_id: int) -> ResponseModel:
@@ -1322,10 +1324,18 @@ def create_weekly_content(user_id: int) -> ResponseModel:
 
     # Chain: plan posts for the rest of the month first, then fill content for this week.
     # This ensures the user always has PLANNING rows before content generation runs.
-    celery_chain(
-        plan_content_for_user.si(user_id=user_id),
-        auto_create_weekly_content.si(user_id=user_id),
-    ).apply_async()
+    try:
+        celery_chain(
+            plan_content_for_user.si(user_id=user_id),
+            auto_create_weekly_content.si(user_id=user_id),
+        ).apply_async()
+    except Exception as e:
+        # Nothing will ever run, so drop the 'queued' record rather than leaving the SPA polling
+        # a run that never starts (it would otherwise sit there until the TTL expires).
+        clear_generation_status(user_id)
+        log_error("Could not dispatch weekly content generation", exc=e, user_id=user_id)
+        raise HTTPException(status_code=500, detail="Could not queue content generation")
+
     return ResponseModel(status_code=200, detail="Weekly content created successfully")
 
 

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -75,6 +75,7 @@ from cqc_lem.utilities.db import (
     insert_feedback, FeedbackSource,
     get_latest_review_feedback_id, get_early_adopter_grant, extend_trial_for_user,
 )
+from cqc_lem.utilities.content_generation_status import mark_queued, get_generation_status
 from cqc_lem.utilities.email import generate_pin, hash_pin, send_pin_email
 from cqc_lem.utilities.linkedin.verification_pin import (
     extract_pin_from_text, extract_token_from_address, submit_pin_by_token)
@@ -1315,6 +1316,10 @@ def create_weekly_content(user_id: int) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=400, detail="User ID is required")
 
+    # Generation runs for minutes in the background, so publish a 'queued' progress record now —
+    # the SPA polls /content_generation_status/ and would otherwise show nothing (issue #545).
+    mark_queued(user_id)
+
     # Chain: plan posts for the rest of the month first, then fill content for this week.
     # This ensures the user always has PLANNING rows before content generation runs.
     celery_chain(
@@ -1322,6 +1327,20 @@ def create_weekly_content(user_id: int) -> ResponseModel:
         auto_create_weekly_content.si(user_id=user_id),
     ).apply_async()
     return ResponseModel(status_code=200, detail="Weekly content created successfully")
+
+
+@router.get("/content_generation_status/", responses={
+    200: {"description": "Content generation progress"},
+    **{k: v for k, v in error_responses.items() if k in [401]}
+})
+def get_content_generation_status_endpoint(session_token: str) -> ResponseModel:
+    """Progress of the caller's weekly content-generation run — queued → in_progress (X of N) →
+    done/failed. `detail` is None when no run is being tracked (nothing started, or it aged out).
+    Scoped by session rather than a user_id query param so one user can't poll another's run."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail=get_generation_status(user_id))
 
 
 @router.post("/invite_to_li_company_page/", responses={

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -49,7 +49,7 @@ from cqc_lem.utilities.linkedin.helper import get_my_profile, load_profile_for_u
 from cqc_lem.utilities.linkedin.rate_limit import acquire_run_lock, release_run_lock
 from cqc_lem.utilities.linkedin_formatter import sanitize_for_linkedin, strip_engagement_bait
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
-from cqc_lem.utilities.logger import myprint, log_info, log_warning
+from cqc_lem.utilities.logger import myprint, log_info, log_warning, log_error
 from cqc_lem.utilities.observability import attribute_llm_cost, llm_attribution, FEATURE_CONTENT
 from cqc_lem.utilities.selenium_util import get_driver_wait_pair, quit_gracefully
 from cqc_lem.utilities.utils import get_best_posting_time, get_post_time, create_folder_if_not_exists, save_video_url_to_dir
@@ -1486,12 +1486,16 @@ def _top_up_buffer_for_user(user_id: int, requested: bool = False) -> None:
         # when the (fail-open) progress store is unavailable.
         generated = 0
         failed = 0
-        for post in planned_posts:
-            if _create_content_for_planned_post(post, prefs):
-                generated += 1
-            else:
-                failed += 1
-        mark_finished(user_id)
+        try:
+            for post in planned_posts:
+                if _create_content_for_planned_post(post, prefs):
+                    generated += 1
+                else:
+                    failed += 1
+        finally:
+            # Always close the run out: an unexpected raise here would otherwise strand the SPA
+            # on 'in_progress' until the key's TTL expires.
+            mark_finished(user_id)
         if generated:
             notify_content_generation_ready(user_id, generated, failed)
     finally:
@@ -1520,72 +1524,81 @@ def _create_content_for_planned_post(post: dict, prefs: dict) -> bool:
         record_post_failed(user_id, post_id)
         return False
 
-    # Copy the video from url to our assets/video folder and store it to the database for later retrieval via api call
-    ai_video = False
-    if video_url:
-        # AI (Runway) output is a remote http URL; Pexels fallback is a local path.
-        ai_video = str(video_url).startswith("http")
-        # Define and create assets_dir / videos
-        videos_dir = os.path.join(assets_dir, 'videos', 'runwayml')
-        create_folder_if_not_exists(videos_dir)
-        video_file_path = save_video_url_to_dir(video_url, videos_dir)
-        myprint(f"Video from url: {video_url} | Saved to: {video_file_path}")
-        # Attach AI Content Credentials to AI-generated video only (not stock).
+    # Everything past generation (video download, dwell scoring, the DB writes) can raise too.
+    # Contain it here so one bad post is counted as failed and skipped instead of aborting the
+    # whole run — which would leave the remaining posts ungenerated and the progress record stuck.
+    try:
+        # Copy the video from url to our assets/video folder and store it to the database for later retrieval via api call
+        ai_video = False
+        if video_url:
+            # AI (Runway) output is a remote http URL; Pexels fallback is a local path.
+            ai_video = str(video_url).startswith("http")
+            # Define and create assets_dir / videos
+            videos_dir = os.path.join(assets_dir, 'videos', 'runwayml')
+            create_folder_if_not_exists(videos_dir)
+            video_file_path = save_video_url_to_dir(video_url, videos_dir)
+            myprint(f"Video from url: {video_url} | Saved to: {video_file_path}")
+            # Attach AI Content Credentials to AI-generated video only (not stock).
+            if ai_video:
+                try:
+                    from cqc_lem.utilities.c2pa_helper import add_ai_content_credentials
+                    add_ai_content_credentials(video_file_path)
+                except Exception as e:
+                    myprint(f"C2PA signing skipped for post_id={post_id}: {e}")
+            # Get the file name from the video file path
+            video_file_name = os.path.basename(video_file_path)
+
+            # The video url is our api prefix + 'assets?file=videos/runwayml' +  video_file_name
+            api_video_url = f"{API_URL_FINAL}/api/assets?file_name=videos/runwayml/{video_file_name}"
+            myprint(f"Video URL: {api_video_url}")
+
+            # Update the database with the video url
+            update_db_post_video_url(post_id, api_video_url)
+
+        # Disclose AI-generated visuals in the caption (caption-line fallback for C2PA)
         if ai_video:
-            try:
-                from cqc_lem.utilities.c2pa_helper import add_ai_content_credentials
-                add_ai_content_credentials(video_file_path)
-            except Exception as e:
-                myprint(f"C2PA signing skipped for post_id={post_id}: {e}")
-        # Get the file name from the video file path
-        video_file_name = os.path.basename(video_file_path)
+            content = _apply_ai_disclosure(content)
 
-        # The video url is our api prefix + 'assets?file=videos/runwayml' +  video_file_name
-        api_video_url = f"{API_URL_FINAL}/api/assets?file_name=videos/runwayml/{video_file_name}"
-        myprint(f"Video URL: {api_video_url}")
+        # Dwell-proxy score (issue #391 — C2) for EVERY post type: the text post, the carousel
+        # caption, and the video caption all live or die on holding the reader past the fold.
+        # Deterministic and advisory — recorded next to the authenticity score, never a gate.
+        _score_and_persist_dwell(user_id, post_id, content)
 
-        # Update the database with the video url
-        update_db_post_video_url(post_id, api_video_url)
+        # Update the database with the created content
+        myprint(f"Updating content for post_id: {post_id}")
+        update_db_post_content(post_id, content)
 
-    # Disclose AI-generated visuals in the caption (caption-line fallback for C2PA)
-    if ai_video:
-        content = _apply_ai_disclosure(content)
+        # Respect the user's auto_schedule_posts preference (fetched once per user by the caller):
+        # True → APPROVED (Celery will pick it up); False → PENDING (manual review required)
+        auto_schedule = bool((prefs or {}).get("auto_schedule_posts", True))
+        new_status = PostStatus.APPROVED if auto_schedule else PostStatus.PENDING
 
-    # Dwell-proxy score (issue #391 — C2) for EVERY post type: the text post, the carousel
-    # caption, and the video caption all live or die on holding the reader past the fold.
-    # Deterministic and advisory — recorded next to the authenticity score, never a gate.
-    _score_and_persist_dwell(user_id, post_id, content)
-
-    # Update the database with the created content
-    myprint(f"Updating content for post_id: {post_id}")
-    update_db_post_content(post_id, content)
-
-    # Respect the user's auto_schedule_posts preference (fetched once per user by the caller):
-    # True → APPROVED (Celery will pick it up); False → PENDING (manual review required)
-    auto_schedule = bool((prefs or {}).get("auto_schedule_posts", True))
-    new_status = PostStatus.APPROVED if auto_schedule else PostStatus.PENDING
-
-    # Never auto-approve a video/carousel post whose media failed to generate — hold it
-    # PENDING so the backfill task (or manual review) can complete the asset before it
-    # can be scheduled/posted. Prevents assetless posts going out.
-    if _post_missing_required_asset(post_id, post_type, video_url):
-        new_status = PostStatus.PENDING
-        myprint(f"post_id {post_id}: required media asset missing — holding PENDING")
-
-    # Authenticity gate (issue #382): demote an auto-approve to PENDING when the persisted
-    # LLM-judged authenticity score (set by create_text_post's scoring step) is below threshold,
-    # so a generic-AI-flagged draft gets human review before it can post. Only downgrades an
-    # APPROVED — never upgrades a PENDING, and never blocks when unscored (score None).
-    if new_status == PostStatus.APPROVED and authenticity_gate_enabled():
-        score = get_post_authenticity_score(post_id)
-        if score is not None and score < authenticity_score_min():
+        # Never auto-approve a video/carousel post whose media failed to generate — hold it
+        # PENDING so the backfill task (or manual review) can complete the asset before it
+        # can be scheduled/posted. Prevents assetless posts going out.
+        if _post_missing_required_asset(post_id, post_type, video_url):
             new_status = PostStatus.PENDING
-            log_warning(f"post_id {post_id}: authenticity score {score} < "
-                        f"{authenticity_score_min()} — holding PENDING for review",
-                        user_id=user_id, post_id=post_id, task_name="create_content")
+            myprint(f"post_id {post_id}: required media asset missing — holding PENDING")
 
-    myprint(f"Updating post_id: {post_id} Status={new_status}")
-    update_db_post_status(post_id, new_status)
+        # Authenticity gate (issue #382): demote an auto-approve to PENDING when the persisted
+        # LLM-judged authenticity score (set by create_text_post's scoring step) is below threshold,
+        # so a generic-AI-flagged draft gets human review before it can post. Only downgrades an
+        # APPROVED — never upgrades a PENDING, and never blocks when unscored (score None).
+        if new_status == PostStatus.APPROVED and authenticity_gate_enabled():
+            score = get_post_authenticity_score(post_id)
+            if score is not None and score < authenticity_score_min():
+                new_status = PostStatus.PENDING
+                log_warning(f"post_id {post_id}: authenticity score {score} < "
+                            f"{authenticity_score_min()} — holding PENDING for review",
+                            user_id=user_id, post_id=post_id, task_name="create_content")
+
+        myprint(f"Updating post_id: {post_id} Status={new_status}")
+        update_db_post_status(post_id, new_status)
+    except Exception as e:
+        log_error(f"Skipping post_id {post_id}: storing generated content failed", exc=e,
+                  user_id=user_id, post_id=post_id, task_name="auto_create_weekly_content")
+        record_post_failed(user_id, post_id)
+        return False
 
     record_post_generated(user_id, post_id)
     return True

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -38,6 +38,9 @@ from cqc_lem.utilities.ai.content_alignment import (
     personal_proof_directive, topic_authority_score, topic_authority_min, profile_topic_dna,
     content_matches_focus, score_authenticity, authenticity_gate_enabled, authenticity_score_min,
     humanize_text)
+from cqc_lem.utilities.content_generation_status import mark_in_progress, mark_finished, \
+    record_post_generated, record_post_failed
+from cqc_lem.utilities.notifications import notify_content_generation_ready
 from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_RATIO, \
     DEFAULT_IMAGE_RATIO, AI_DISCLOSURE_ENABLED, AI_DISCLOSURE_TEXT, \
     STANDARD_VIDEO_MODEL, PREMIUM_VIDEO_MODEL, PREMIUM_TOP_VIDEO_MODEL, \
@@ -1423,10 +1426,25 @@ def auto_create_weekly_content(user_id: int = None):
         user_ids = get_user_ids_with_planned_posts_within_buffer() or []
 
     for uid in user_ids:
-        _top_up_buffer_for_user(uid)
+        # Only a run the API queued for one user has a 'queued' progress record waiting on it.
+        _top_up_buffer_for_user(uid, requested=user_id is not None)
 
 
-def _top_up_buffer_for_user(user_id: int) -> None:
+def _close_out_empty_run(user_id: int, requested: bool) -> None:
+    """Finish a requested run that generated nothing (issue #545).
+
+    `/create_weekly_content/` publishes 'queued' at dispatch, so a top-up that returns early
+    (lock lost, buffer already full, nothing planned) must still close the record out or the SPA
+    polls a queued run that never reports anything. The beat run publishes nothing up front, so
+    it has nothing to close.
+    """
+    if not requested:
+        return
+    mark_in_progress(user_id, [])
+    mark_finished(user_id)
+
+
+def _top_up_buffer_for_user(user_id: int, requested: bool = False) -> None:
     """Generate this user's buffer delta under a single-flight lock.
 
     The count → select → generate sequence is read-then-write: overlapping runs for the same user
@@ -1439,6 +1457,7 @@ def _top_up_buffer_for_user(user_id: int) -> None:
     lock_token = acquire_run_lock(lock_name, ttl_seconds=_BUFFER_LOCK_TTL_SECONDS)
     if lock_token is None:
         myprint(f"user_id {user_id}: another buffer top-up is in progress — skipping this cycle.")
+        _close_out_empty_run(user_id, requested)
         return
 
     try:
@@ -1448,24 +1467,42 @@ def _top_up_buffer_for_user(user_id: int) -> None:
         if already_ready >= buffer_max:
             myprint(f"user_id {user_id}: buffer already full ({already_ready}/{buffer_max} ready "
                     f"within {buffer_days} days). Skipping content creation.")
+            _close_out_empty_run(user_id, requested)
             return
 
         planned_posts = get_planned_posts_within_buffer(user_id, buffer_days, buffer_max, already_ready)
         if not planned_posts:
             myprint(f"user_id {user_id}: no planned posts within {buffer_days} days. "
                     f"Skipping content creation.")
+            _close_out_empty_run(user_id, requested)
             return
 
         myprint(f"user_id {user_id}: generating {len(planned_posts)} post(s) to top buffer up to "
                 f"{buffer_max} ready within {buffer_days} days ({already_ready} already ready)")
+        # Progress for the SPA (issue #545) — published for the beat run too, so a user who never
+        # clicked Generate still sees why fresh drafts appeared.
+        mark_in_progress(user_id, [int(post['id']) for post in planned_posts])
+        # Counted locally rather than read back from Redis so the completion email still goes out
+        # when the (fail-open) progress store is unavailable.
+        generated = 0
+        failed = 0
         for post in planned_posts:
-            _create_content_for_planned_post(post, prefs)
+            if _create_content_for_planned_post(post, prefs):
+                generated += 1
+            else:
+                failed += 1
+        mark_finished(user_id)
+        if generated:
+            notify_content_generation_ready(user_id, generated, failed)
     finally:
         release_run_lock(lock_name, lock_token)
 
 
-def _create_content_for_planned_post(post: dict, prefs: dict) -> None:
-    """Generate, store and status one planning post. Never raises — a bad post is skipped."""
+def _create_content_for_planned_post(post: dict, prefs: dict) -> bool:
+    """Generate, store and status one planning post. Never raises — a bad post is skipped.
+
+    Returns True when the post now has content, False when it could not be generated.
+    """
     user_id = post['user_id']
     post_id = post['id']
     post_type = post['post_type']
@@ -1475,11 +1512,13 @@ def _create_content_for_planned_post(post: dict, prefs: dict) -> None:
         content, video_url = create_content(user_id, post_type, stage, post_id=post_id)
     except Exception as e:
         myprint(f"Skipping post_id {post_id}: content generation raised {type(e).__name__}: {e}")
-        return
+        record_post_failed(user_id, post_id)
+        return False
 
     if content is None:
         myprint(f"Skipping post_id {post_id}: content generation returned None")
-        return
+        record_post_failed(user_id, post_id)
+        return False
 
     # Copy the video from url to our assets/video folder and store it to the database for later retrieval via api call
     ai_video = False
@@ -1547,6 +1586,9 @@ def _create_content_for_planned_post(post: dict, prefs: dict) -> None:
 
     myprint(f"Updating post_id: {post_id} Status={new_status}")
     update_db_post_status(post_id, new_status)
+
+    record_post_generated(user_id, post_id)
+    return True
 
 
 def is_blog_post(url):

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -31,7 +31,7 @@ const VIEWS: { key: View; label: string }[] = [
 ]
 const VIEW_KEYS = VIEWS.map((v) => v.key) as string[]
 
-type Status = 'ALL' | 'pending' | 'approved' | 'scheduled' | 'posted' | 'rejected'
+type Status = 'ALL' | 'pending' | 'approved' | 'scheduled' | 'posted' | 'rejected' | 'error'
 const STATUSES: { label: string; value: Status }[] = [
   { label: 'ALL', value: 'ALL' },
   { label: 'PENDING', value: 'pending' },
@@ -39,6 +39,9 @@ const STATUSES: { label: string; value: Status }[] = [
   { label: 'SCHEDULED', value: 'scheduled' },
   { label: 'POSTED', value: 'posted' },
   { label: 'REJECTED', value: 'rejected' },
+  // Generation/posting failed (e.g. media never rendered) — needs a manual fix, so it gets
+  // its own filter instead of hiding inside ALL.
+  { label: 'ERROR', value: 'error' },
 ]
 
 type PostTypeFilter = 'ALL' | 'text' | 'video' | 'carousel' | 'document'
@@ -88,7 +91,25 @@ const STATUS_COLORS: Record<string, string> = {
   posted: 'bg-blue-100 text-blue-700',
   rejected: 'bg-red-100 text-red-700',
   scheduled: 'bg-purple-100 text-purple-700',
+  error: 'bg-red-100 text-red-700',
 }
+
+// Progress of a weekly content-generation run, polled while it is running (issue #545).
+type GenerationState = 'queued' | 'in_progress' | 'done' | 'failed'
+interface GenerationStatus {
+  state: GenerationState
+  total: number
+  completed: number
+  failed: number
+  post_ids: number[]
+  ready_post_ids: number[]
+  failed_post_ids: number[]
+  started_at: string | null
+  finished_at: string | null
+  updated_at?: string | null
+}
+const isGenerationRunning = (s?: GenerationStatus | null) =>
+  !!s && (s.state === 'queued' || s.state === 'in_progress')
 
 export default function ContentStudio() {
   const { user, sessionToken } = useAuth()
@@ -226,12 +247,44 @@ export default function ContentStudio() {
     onError: () => setRegenNotice('Could not start regeneration — please try again.'),
   })
 
+  // Generation takes minutes (each video post is a ~6-min render), so poll progress while a run
+  // is queued/in-progress and stop as soon as it finishes.
+  const { data: genStatus } = useQuery<GenerationStatus | null>({
+    queryKey: ['content-generation-status', sessionToken],
+    queryFn: async () => {
+      const r = await api.get('/content_generation_status/', { params: { session_token: sessionToken } })
+      return (r.data.detail ?? null) as GenerationStatus | null
+    },
+    enabled: !!sessionToken,
+    refetchInterval: (query) => (isGenerationRunning(query.state.data) ? 5_000 : false),
+  })
+
+  // When a run finishes, pull in the posts it just created (finished_at is only set once the
+  // run reaches done/failed, so this fires exactly once per run).
+  const finishedAt = genStatus?.finished_at ?? null
+  useEffect(() => {
+    if (finishedAt) qc.invalidateQueries({ queryKey: ['posts', email] })
+  }, [finishedAt, email, qc])
+
   const weeklyMutation = useMutation({
     mutationFn: () =>
       api.get(`/user_id/?email=${encodeURIComponent(email)}`).then((r) =>
         api.post(`/create_weekly_content/?user_id=${r.data.detail}`)
       ),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['content-generation-status', sessionToken] }),
   })
+
+  // A finished run expires server-side within the hour, so there's no staleness to reason about
+  // here — the user can also dismiss the result early.
+  const [dismissedRunStartedAt, setDismissedRunStartedAt] = useState<string | null>(null)
+  const showGenBanner = !!genStatus && genStatus.started_at !== dismissedRunStartedAt
+
+  const generating = weeklyMutation.isPending || isGenerationRunning(genStatus)
+  const generateLabel = !generating
+    ? 'Generate Weekly Content'
+    : genStatus?.state === 'in_progress' && genStatus.total > 0
+      ? `Generating ${genStatus.completed + genStatus.failed} of ${genStatus.total}…`
+      : 'Generating content…'
 
   const { data: postUrlData, isLoading: postUrlLoading } = useQuery<{ detail: { post_url: string | null } }>({
     queryKey: ['post_url', editingPost?.post_id, email],
@@ -295,10 +348,10 @@ export default function ContentStudio() {
         {view === 'review' && (
           <button
             onClick={() => weeklyMutation.mutate()}
-            disabled={weeklyMutation.isPending}
+            disabled={generating}
             className="bg-green-600 text-white px-4 py-2 rounded-lg text-sm font-semibold hover:bg-green-700 disabled:opacity-50 transition-colors"
           >
-            {weeklyMutation.isPending ? 'Generating content…' : 'Generate Weekly Content'}
+            {generateLabel}
           </button>
         )}
         {view === 'review' && (
@@ -310,6 +363,64 @@ export default function ContentStudio() {
           </button>
         )}
       </div>
+
+      {/* Generation progress — generation runs for minutes in the background, so show what
+          it is doing instead of leaving the page looking unchanged (issue #545). */}
+      {showGenBanner && genStatus && (
+        <div
+          className={`rounded-lg border p-3 text-sm ${
+            isGenerationRunning(genStatus)
+              ? 'bg-blue-50 border-blue-200 text-blue-800'
+              : genStatus.state === 'failed'
+                ? 'bg-red-50 border-red-200 text-red-800'
+                : 'bg-green-50 border-green-200 text-green-800'
+          }`}
+        >
+          <div className="flex items-center justify-between gap-3 flex-wrap">
+            <span className="font-semibold">
+              {genStatus.state === 'queued' && 'Queued — starting content generation…'}
+              {genStatus.state === 'in_progress' &&
+                (genStatus.total > 0
+                  ? `Generating your posts — ${genStatus.completed + genStatus.failed} of ${genStatus.total} done`
+                  : 'Generating your posts…')}
+              {genStatus.state === 'done' &&
+                `${genStatus.completed} ${genStatus.completed === 1 ? 'post is' : 'posts are'} ready to review`}
+              {genStatus.state === 'failed' && 'Content generation failed — no posts were created'}
+            </span>
+            {isGenerationRunning(genStatus) ? (
+              <span className="text-xs">
+                This takes a few minutes — video posts render last. You can leave this page; we'll
+                email you when it's done.
+              </span>
+            ) : (
+              <button
+                onClick={() => setDismissedRunStartedAt(genStatus.started_at)}
+                aria-label="Dismiss generation status"
+                className="text-xs font-semibold underline"
+              >
+                Dismiss
+              </button>
+            )}
+          </div>
+          {genStatus.total > 0 && (
+            <div className="mt-2 h-2 w-full rounded-full bg-white/70 overflow-hidden">
+              <div
+                className="h-full bg-blue-600 transition-all"
+                style={{
+                  width: `${Math.min(100, Math.round(
+                    ((genStatus.completed + genStatus.failed) / genStatus.total) * 100))}%`,
+                }}
+              />
+            </div>
+          )}
+          {genStatus.failed > 0 && (
+            <p className="mt-2 text-xs">
+              {genStatus.failed} {genStatus.failed === 1 ? 'post' : 'posts'} couldn't be generated
+              (usually a media failure) — they stay in your plan and are retried on the next run.
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Content tabs */}
       <div className="flex flex-wrap gap-1 border-b border-gray-200">
@@ -545,10 +656,10 @@ export default function ContentStudio() {
               ) : (
                 <button
                   onClick={() => weeklyMutation.mutate()}
-                  disabled={weeklyMutation.isPending}
+                  disabled={generating}
                   className="bg-green-600 text-white px-6 py-2.5 rounded-lg text-sm font-semibold hover:bg-green-700 disabled:opacity-50 transition-colors"
                 >
-                  {weeklyMutation.isPending ? 'Generating content…' : 'Generate Weekly Content'}
+                  {generateLabel}
                 </button>
               )}
             </div>

--- a/src/cqc_lem/utilities/content_generation_status.py
+++ b/src/cqc_lem/utilities/content_generation_status.py
@@ -18,13 +18,25 @@ import json
 import os
 from datetime import datetime, timezone
 from enum import StrEnum
-from typing import Optional
+from typing import Any, Optional, Protocol
 
 from cqc_lem.utilities.logger import log_debug
 
 _KEY_PREFIX = "content_generation:status:"
 _DEFAULT_TTL_SECONDS = 24 * 60 * 60
 _DEFAULT_RESULT_TTL_SECONDS = 60 * 60
+
+
+class RedisLike(Protocol):
+    """The slice of the Redis API this module uses — structural, so `redis.Redis` and the test
+    doubles both satisfy it without importing `redis` at module scope (it is imported lazily so
+    the module keeps working, no-opping, when the client is unavailable)."""
+
+    def get(self, name: str) -> Any: ...
+
+    def set(self, name: str, value: str, ex: Optional[int] = None) -> Any: ...
+
+    def delete(self, *names: str) -> Any: ...
 
 
 class ContentGenerationState(StrEnum):
@@ -53,7 +65,7 @@ def _result_ttl_seconds() -> int:
         return _DEFAULT_RESULT_TTL_SECONDS
 
 
-def _redis_client():
+def _redis_client() -> Optional[RedisLike]:
     """Redis handle for the progress key, or None if unavailable (progress then no-ops).
 
     Mirrors the 429 breaker's resolution order: the Celery broker URL when it points at Redis,
@@ -82,7 +94,7 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _read(client, user_id: int) -> Optional[dict]:
+def _read(client: RedisLike, user_id: int) -> Optional[dict]:
     try:
         raw = client.get(_key(user_id))
     except Exception:
@@ -96,7 +108,7 @@ def _read(client, user_id: int) -> Optional[dict]:
     return status if isinstance(status, dict) else None
 
 
-def _write(client, user_id: int, status: dict, ttl: Optional[int] = None) -> None:
+def _write(client: RedisLike, user_id: int, status: dict, ttl: Optional[int] = None) -> None:
     status["updated_at"] = _now()
     try:
         client.set(_key(user_id), json.dumps(status), ex=ttl if ttl is not None else _ttl_seconds())

--- a/src/cqc_lem/utilities/content_generation_status.py
+++ b/src/cqc_lem/utilities/content_generation_status.py
@@ -1,0 +1,209 @@
+"""Per-user progress for a weekly content-generation run (issue #545).
+
+`/create_weekly_content/` fires an async Celery chain and returns immediately, but the run
+takes minutes (each video post is a ~6-minute Runway/Veo call). Without a progress signal the
+SPA looks broken, so the run publishes a lightweight status the UI can poll: queued →
+in_progress (X of N) → done/failed.
+
+State lives in Redis, not the DB: it is short-lived runtime progress (like the 429 breaker),
+so it survives deploys without a migration and expires on its own. Fails open — when Redis is
+unavailable every write no-ops and `get_generation_status` returns None, so generation itself
+never breaks because progress reporting is down.
+
+One task owns a user's key at a time (the chain is serial per user), so the read-modify-write
+counters below don't need locking.
+"""
+
+import json
+import os
+from datetime import datetime, timezone
+from enum import StrEnum
+from typing import Optional
+
+from cqc_lem.utilities.logger import log_debug
+
+_KEY_PREFIX = "content_generation:status:"
+_DEFAULT_TTL_SECONDS = 24 * 60 * 60
+_DEFAULT_RESULT_TTL_SECONDS = 60 * 60
+
+
+class ContentGenerationState(StrEnum):
+    """Lifecycle of one weekly content-generation run for a user."""
+    QUEUED = 'queued'            # chain dispatched, generation hasn't started yet
+    IN_PROGRESS = 'in_progress'  # generating, `completed`/`failed` of `total` done
+    DONE = 'done'                # finished; `failed` may still be > 0 (partial success)
+    FAILED = 'failed'            # finished with nothing generated
+
+
+def _ttl_seconds() -> int:
+    try:
+        return int(os.getenv("CONTENT_GENERATION_STATUS_TTL_SECONDS", str(_DEFAULT_TTL_SECONDS)))
+    except ValueError:
+        return _DEFAULT_TTL_SECONDS
+
+
+def _result_ttl_seconds() -> int:
+    """A FINISHED run expires sooner than a running one: "5 posts are ready to review" is useful
+    right after the run and just noise a day later, and expiring it server-side keeps the SPA from
+    having to reason about how stale a result is."""
+    try:
+        return int(os.getenv("CONTENT_GENERATION_RESULT_TTL_SECONDS",
+                             str(_DEFAULT_RESULT_TTL_SECONDS)))
+    except ValueError:
+        return _DEFAULT_RESULT_TTL_SECONDS
+
+
+def _redis_client():
+    """Redis handle for the progress key, or None if unavailable (progress then no-ops).
+
+    Mirrors the 429 breaker's resolution order: the Celery broker URL when it points at Redis,
+    else the result backend (on AWS the broker is SQS), else the local default.
+    """
+    try:
+        import redis
+    except Exception:
+        return None
+    url = os.getenv("CELERY_BROKER_URL", "")
+    if not url.startswith("redis"):
+        url = os.getenv("CELERY_RESULT_BACKEND", "")
+    if not url.startswith("redis"):
+        url = f"redis://redis:{os.getenv('REDIS_PORT', '6379')}/0"
+    try:
+        return redis.Redis.from_url(url, socket_timeout=2, socket_connect_timeout=2)
+    except Exception:
+        return None
+
+
+def _key(user_id: int) -> str:
+    return f"{_KEY_PREFIX}{int(user_id)}"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _read(client, user_id: int) -> Optional[dict]:
+    try:
+        raw = client.get(_key(user_id))
+    except Exception:
+        return None
+    if not raw:
+        return None
+    try:
+        status = json.loads(raw)
+    except (TypeError, ValueError):
+        return None
+    return status if isinstance(status, dict) else None
+
+
+def _write(client, user_id: int, status: dict, ttl: Optional[int] = None) -> None:
+    status["updated_at"] = _now()
+    try:
+        client.set(_key(user_id), json.dumps(status), ex=ttl if ttl is not None else _ttl_seconds())
+    except Exception as e:
+        log_debug(f"Could not persist content generation status: {e}", user_id=user_id)
+
+
+def mark_queued(user_id: int) -> None:
+    """Record that a generation run was dispatched, before any post is processed. Called by the
+    API so the SPA gets an immediate 'queued' the moment the user clicks Generate."""
+    client = _redis_client()
+    if client is None:
+        return
+    _write(client, user_id, {
+        "state": str(ContentGenerationState.QUEUED),
+        "total": 0,
+        "completed": 0,
+        "failed": 0,
+        "post_ids": [],
+        "ready_post_ids": [],
+        "failed_post_ids": [],
+        "started_at": _now(),
+        "finished_at": None,
+    })
+
+
+def mark_in_progress(user_id: int, post_ids: list[int]) -> None:
+    """Start the run with the posts it will generate — this is where `total` becomes known."""
+    client = _redis_client()
+    if client is None:
+        return
+    existing = _read(client, user_id) or {}
+    _write(client, user_id, {
+        "state": str(ContentGenerationState.IN_PROGRESS),
+        "total": len(post_ids),
+        "completed": 0,
+        "failed": 0,
+        "post_ids": [int(p) for p in post_ids],
+        "ready_post_ids": [],
+        "failed_post_ids": [],
+        "started_at": existing.get("started_at") or _now(),
+        "finished_at": None,
+    })
+
+
+def _record(user_id: int, post_id: int, failed: bool) -> None:
+    client = _redis_client()
+    if client is None:
+        return
+    status = _read(client, user_id)
+    if status is None:
+        return
+    bucket = "failed_post_ids" if failed else "ready_post_ids"
+    ids = status.get(bucket) or []
+    if int(post_id) not in ids:
+        ids.append(int(post_id))
+    status[bucket] = ids
+    status["failed" if failed else "completed"] = len(ids)
+    status["state"] = str(ContentGenerationState.IN_PROGRESS)
+    _write(client, user_id, status)
+
+
+def record_post_generated(user_id: int, post_id: int) -> None:
+    """One more post finished generating."""
+    _record(user_id, post_id, failed=False)
+
+
+def record_post_failed(user_id: int, post_id: int) -> None:
+    """One post could not be generated — surfaced per-post in the SPA so a media failure is
+    visible instead of silently missing from the batch."""
+    _record(user_id, post_id, failed=True)
+
+
+def mark_finished(user_id: int) -> Optional[dict]:
+    """Close out the run and return the final status (None when nothing was tracked).
+
+    FAILED only when the run produced nothing; a partial run stays DONE and reports its
+    `failed` count so the user still sees what is ready to review.
+    """
+    client = _redis_client()
+    if client is None:
+        return None
+    status = _read(client, user_id)
+    if status is None:
+        return None
+    completed = int(status.get("completed", 0))
+    failed = int(status.get("failed", 0))
+    status["state"] = str(ContentGenerationState.FAILED if failed and not completed
+                          else ContentGenerationState.DONE)
+    status["finished_at"] = _now()
+    _write(client, user_id, status, ttl=_result_ttl_seconds())
+    return status
+
+
+def get_generation_status(user_id: int) -> Optional[dict]:
+    """Current progress for the user, or None when no run is being tracked."""
+    client = _redis_client()
+    if client is None:
+        return None
+    return _read(client, user_id)
+
+
+def clear_generation_status(user_id: int) -> None:
+    client = _redis_client()
+    if client is None:
+        return
+    try:
+        client.delete(_key(user_id))
+    except Exception as e:
+        log_debug(f"Could not clear content generation status: {e}", user_id=user_id)

--- a/src/cqc_lem/utilities/email.py
+++ b/src/cqc_lem/utilities/email.py
@@ -364,6 +364,32 @@ def send_newsletter_draft_ready_email(to_email: str, edition_title: str,
         to_email, f"📝 Your newsletter draft is ready: {title}", html, high_priority=True)
 
 
+def send_content_generation_ready_email(to_email: str, ready_count: int,
+                                        failed_count: int = 0) -> bool:
+    """Email a user that their weekly content finished generating (issue #545). Generation runs
+    for minutes in the background, so this is the "come back and review" signal."""
+    import os
+    base = (os.getenv("LEM_APP_URL") or "https://lem.christopherqueenconsulting.com").rstrip("/")
+    url = f"{base}/content?tab=review"
+    plural = "post" if ready_count == 1 else "posts"
+    failed_note = (f"<p>{failed_count} {'post' if failed_count == 1 else 'posts'} couldn't be "
+                   f"generated (usually a media generation failure) — they stay in your plan and "
+                   f"we'll retry them on the next run.</p>") if failed_count else ""
+    html = f"""
+    <html><body style="font-family:Arial,Helvetica,sans-serif;color:#222;">
+    <h2>Your {ready_count} {plural} {'is' if ready_count == 1 else 'are'} ready to review</h2>
+    <p>We finished generating this week's content. Review, edit, or approve it before it
+    goes out.</p>
+    {failed_note}
+    <p><a href="{url}" style="background:#0a66c2;color:#fff;padding:10px 16px;border-radius:6px;
+    text-decoration:none;">Review your content</a></p>
+    </body></html>
+    """
+    return _dispatch_email(
+        to_email, f"✅ Your {ready_count} LinkedIn {plural} {'is' if ready_count == 1 else 'are'} "
+                  f"ready to review", html)
+
+
 def send_onboarding_nudge_email(to_email: str, subject: str, headline: str, body: str,
                                 cta_label: str, cta_path: str = "/account") -> bool:
     """Nudge a user who stalled part-way through activation (issue #500). Copy is supplied by the

--- a/src/cqc_lem/utilities/notifications.py
+++ b/src/cqc_lem/utilities/notifications.py
@@ -145,6 +145,28 @@ def notify_faq_answer(user_id: int, question: str, answer: str) -> bool:
         return False
 
 
+def notify_content_generation_ready(user_id: int, ready_count: int, failed_count: int = 0) -> bool:
+    """Email the user that their weekly content finished generating (issue #545). Sent once per
+    run by the generation task — no throttling ledger, the run itself is the trigger. Non-fatal:
+    returns True only if an email was actually sent."""
+    try:
+        if ready_count <= 0:
+            return False
+        email = get_user_email(user_id)
+        if not email:
+            return False
+        from cqc_lem.utilities.email import send_content_generation_ready_email
+        sent = send_content_generation_ready_email(email, ready_count, failed_count)
+        if sent:
+            log_info(f"Sent content-generation-ready email for {ready_count} post(s)",
+                     user_id=user_id, action_type="content_generation")
+        return sent
+    except Exception as e:
+        log_warning("Could not send content-generation-ready email", exc=e, user_id=user_id,
+                    action_type="content_generation")
+        return False
+
+
 def notify_newsletter_draft_ready(user_id: int, edition_title: str, scheduled_for) -> bool:
     """Email the user that their newsletter draft is ready to review and when it auto-publishes.
     Non-fatal — returns True only if an email was actually sent."""

--- a/tests/unit/api/test_content_generation_status_api.py
+++ b/tests/unit/api/test_content_generation_status_api.py
@@ -1,0 +1,89 @@
+"""Unit tests for GET /api/content_generation_status/ and the queued-on-dispatch progress
+record written by POST /api/create_weekly_content/ (issue #545)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_SESSION = "tok"
+_USER = 7
+_STATUS = {
+    "state": "in_progress",
+    "total": 3,
+    "completed": 1,
+    "failed": 0,
+    "post_ids": [1, 2, 3],
+    "ready_post_ids": [1],
+    "failed_post_ids": [],
+    "started_at": "2026-07-25T10:00:00+00:00",
+    "finished_at": None,
+}
+
+
+class TestContentGenerationStatusEndpoint:
+    def test_returns_status_for_the_session_user(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_generation_status", return_value=_STATUS) as get_status:
+            resp = client.get("/api/content_generation_status/",
+                              params={"session_token": _SESSION})
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == _STATUS
+        get_status.assert_called_once_with(_USER)
+
+    def test_returns_null_when_no_run_tracked(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_generation_status", return_value=None):
+            resp = client.get("/api/content_generation_status/",
+                              params={"session_token": _SESSION})
+        assert resp.status_code == 200
+        assert resp.json()["detail"] is None
+
+    def test_rejects_invalid_session(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None), \
+             patch("cqc_lem.api.main.get_generation_status") as get_status:
+            resp = client.get("/api/content_generation_status/", params={"session_token": "bad"})
+        assert resp.status_code == 401
+        get_status.assert_not_called()
+
+    def test_requires_a_session_token(self, client):
+        resp = client.get("/api/content_generation_status/")
+        assert resp.status_code == 422
+
+
+class TestCreateWeeklyContentMarksQueued:
+    def test_marks_queued_before_dispatch(self, client):
+        with patch("cqc_lem.api.main.mark_queued") as queued, \
+             patch("cqc_lem.api.main.celery_chain") as chain:
+            resp = client.post("/api/create_weekly_content/", params={"user_id": _USER})
+        assert resp.status_code == 200
+        queued.assert_called_once_with(_USER)
+        chain.return_value.apply_async.assert_called_once()
+
+    def test_missing_user_id_does_not_mark_queued(self, client):
+        with patch("cqc_lem.api.main.mark_queued") as queued:
+            resp = client.post("/api/create_weekly_content/", params={"user_id": 0})
+        assert resp.status_code == 400
+        queued.assert_not_called()

--- a/tests/unit/api/test_content_generation_status_api.py
+++ b/tests/unit/api/test_content_generation_status_api.py
@@ -87,3 +87,13 @@ class TestCreateWeeklyContentMarksQueued:
             resp = client.post("/api/create_weekly_content/", params={"user_id": 0})
         assert resp.status_code == 400
         queued.assert_not_called()
+
+    def test_dispatch_failure_clears_the_queued_record(self, client):
+        """A broker outage must not strand the SPA polling a run that will never start."""
+        with patch("cqc_lem.api.main.mark_queued"), \
+             patch("cqc_lem.api.main.clear_generation_status") as cleared, \
+             patch("cqc_lem.api.main.celery_chain") as chain:
+            chain.return_value.apply_async.side_effect = OSError("broker unreachable")
+            resp = client.post("/api/create_weekly_content/", params={"user_id": _USER})
+        assert resp.status_code == 500
+        cleared.assert_called_once_with(_USER)

--- a/tests/unit/app/test_content_generation_progress.py
+++ b/tests/unit/app/test_content_generation_progress.py
@@ -145,6 +145,33 @@ class TestProgressTracking:
         progress["finished"].assert_called_once_with(1)
         progress["generated"].assert_not_called()
 
+    def test_persist_failure_counts_as_failed_and_run_continues(self, progress):
+        """A raise AFTER generation (video download, DB write) must not abort the whole run."""
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        patches = _generation_patches(
+            [_planned(1, 11), _planned(1, 12)],
+            **{"update_db_post_content": {"side_effect": [RuntimeError("db gone"), None]}})
+        with _Patched(patches):
+            auto_create_weekly_content(user_id=1)
+
+        progress["failed"].assert_called_once_with(1, 11)
+        progress["generated"].assert_called_once_with(1, 12)
+        progress["finished"].assert_called_once_with(1)
+        progress["notify"].assert_called_once_with(1, 1, 1)
+
+    def test_unexpected_raise_still_finishes_the_run(self, progress):
+        """Belt-and-braces: even if the per-post loop blows up, the record can't stay in_progress."""
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        patches = _generation_patches([_planned(1, 11)])
+        with _Patched(patches), \
+                patch(f"{_RCP}._create_content_for_planned_post",
+                      side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError):
+                auto_create_weekly_content(user_id=1)
+
+        progress["finished"].assert_called_once_with(1)
+        progress["notify"].assert_not_called()
+
     def test_no_planned_posts_and_no_user_tracks_nothing(self, progress):
         """The beat run never published a 'queued' record, so there is nothing to close out."""
         from cqc_lem.app.run_content_plan import auto_create_weekly_content

--- a/tests/unit/app/test_content_generation_progress.py
+++ b/tests/unit/app/test_content_generation_progress.py
@@ -1,0 +1,156 @@
+"""Progress + completion-notification wiring for auto_create_weekly_content (issue #545)."""
+
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RCP = "cqc_lem.app.run_content_plan"
+
+
+def _planned(user_id: int, post_id: int, post_type: str = "text"):
+    return {"user_id": user_id, "id": post_id, "post_type": post_type, "buyer_stage": "awareness"}
+
+
+def _generation_patches(planned, create_content_result=("Post text", None), **overrides):
+    """The DB/AI seams the buffer top-up touches, all mocked to a happy path."""
+    ctx = {
+        "acquire_run_lock": {"return_value": "tok"},
+        "release_run_lock": {},
+        "count_ready_posts_within_buffer": {"return_value": 0},
+        "get_planned_posts_within_buffer": {"return_value": planned},
+        "create_content": {"return_value": create_content_result},
+        "update_db_post_content": {},
+        "update_db_post_status": {},
+        "get_user_preferences": {"return_value": {"auto_schedule_posts": True}},
+        "_post_missing_required_asset": {"return_value": False},
+        "get_post_authenticity_score": {"return_value": None},
+        "_score_and_persist_dwell": {},
+    }
+    ctx.update(overrides)
+    return {name: patch(f"{_RCP}.{name}", **kwargs) for name, kwargs in ctx.items()}
+
+
+class _Patched:
+    """Start/stop a dict of patches and expose them by name."""
+
+    def __init__(self, patches: dict):
+        self._patches = patches
+        self.mocks = {}
+
+    def __enter__(self):
+        for name, p in self._patches.items():
+            self.mocks[name] = p.start()
+        return self.mocks
+
+    def __exit__(self, *exc):
+        for p in self._patches.values():
+            p.stop()
+        return False
+
+
+@pytest.fixture
+def progress():
+    """Patch the progress store + notifier where run_content_plan imported them."""
+    with patch(f"{_RCP}.mark_in_progress") as in_progress, \
+         patch(f"{_RCP}.mark_finished") as finished, \
+         patch(f"{_RCP}.record_post_generated") as generated, \
+         patch(f"{_RCP}.record_post_failed") as failed, \
+         patch(f"{_RCP}.notify_content_generation_ready") as notify:
+        yield {"in_progress": in_progress, "finished": finished, "generated": generated,
+               "failed": failed, "notify": notify}
+
+
+class TestProgressTracking:
+    def test_run_publishes_progress_and_notifies(self, progress):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        with _Patched(_generation_patches([_planned(1, 11), _planned(1, 12)])):
+            auto_create_weekly_content(user_id=1)
+
+        progress["in_progress"].assert_called_once_with(1, [11, 12])
+        assert [c.args for c in progress["generated"].call_args_list] == [(1, 11), (1, 12)]
+        progress["failed"].assert_not_called()
+        progress["finished"].assert_called_once_with(1)
+        progress["notify"].assert_called_once_with(1, 2, 0)
+
+    def test_generation_exception_counts_as_failed(self, progress):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        patches = _generation_patches(
+            [_planned(1, 11)], **{"create_content": {"side_effect": RuntimeError("AI down")}})
+        with _Patched(patches):
+            auto_create_weekly_content(user_id=1)
+
+        progress["failed"].assert_called_once_with(1, 11)
+        progress["generated"].assert_not_called()
+        progress["finished"].assert_called_once_with(1)
+        progress["notify"].assert_not_called()  # nothing ready to review
+
+    def test_empty_content_counts_as_failed(self, progress):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        patches = _generation_patches(
+            [_planned(1, 11), _planned(1, 12)],
+            **{"create_content": {"side_effect": [(None, None), ("Post text", None)]}})
+        with _Patched(patches):
+            auto_create_weekly_content(user_id=1)
+
+        progress["failed"].assert_called_once_with(1, 11)
+        progress["generated"].assert_called_once_with(1, 12)
+        progress["notify"].assert_called_once_with(1, 1, 1)  # 1 ready, 1 failed
+
+    def test_progress_is_per_user_on_the_all_users_run(self, progress):
+        """The daily beat run passes user_id=None — each owner gets their own progress + email."""
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        by_user = {1: [_planned(1, 11)], 2: [_planned(2, 21), _planned(2, 22)]}
+        patches = _generation_patches(
+            None,
+            **{"get_planned_posts_within_buffer": {"side_effect": lambda uid, *a, **kw: by_user[uid]}})
+        with _Patched(patches), \
+                patch(f"{_RCP}.get_user_ids_with_planned_posts_within_buffer", return_value=[1, 2]):
+            auto_create_weekly_content()
+
+        assert [c.args for c in progress["in_progress"].call_args_list] == [(1, [11]), (2, [21, 22])]
+        assert [c.args for c in progress["finished"].call_args_list] == [(1,), (2,)]
+        assert [c.args for c in progress["notify"].call_args_list] == [(1, 1, 0), (2, 2, 0)]
+
+    def test_no_planned_posts_closes_out_the_queued_run(self, progress):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        with _Patched(_generation_patches([])):
+            auto_create_weekly_content(user_id=1)
+
+        progress["in_progress"].assert_called_once_with(1, [])
+        progress["finished"].assert_called_once_with(1)
+        progress["notify"].assert_not_called()
+
+    def test_full_buffer_closes_out_the_queued_run(self, progress):
+        """Nothing to generate is still an ANSWER — the SPA must stop showing 'queued'."""
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        patches = _generation_patches([_planned(1, 11)],
+                                      **{"count_ready_posts_within_buffer": {"return_value": 99}})
+        with _Patched(patches):
+            auto_create_weekly_content(user_id=1)
+
+        progress["in_progress"].assert_called_once_with(1, [])
+        progress["finished"].assert_called_once_with(1)
+        progress["generated"].assert_not_called()
+
+    def test_lock_loser_closes_out_the_queued_run(self, progress):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        patches = _generation_patches([_planned(1, 11)],
+                                      **{"acquire_run_lock": {"return_value": None}})
+        with _Patched(patches):
+            auto_create_weekly_content(user_id=1)
+
+        progress["in_progress"].assert_called_once_with(1, [])
+        progress["finished"].assert_called_once_with(1)
+        progress["generated"].assert_not_called()
+
+    def test_no_planned_posts_and_no_user_tracks_nothing(self, progress):
+        """The beat run never published a 'queued' record, so there is nothing to close out."""
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        with _Patched(_generation_patches([])), \
+                patch(f"{_RCP}.get_user_ids_with_planned_posts_within_buffer", return_value=[1]):
+            auto_create_weekly_content()
+
+        progress["in_progress"].assert_not_called()
+        progress["finished"].assert_not_called()

--- a/tests/unit/utilities/test_content_generation_notify.py
+++ b/tests/unit/utilities/test_content_generation_notify.py
@@ -1,0 +1,66 @@
+"""Unit tests for the content-generation-ready notification + email (issue #545)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.notifications"
+_EMAIL = "cqc_lem.utilities.email"
+
+
+class TestNotifyContentGenerationReady:
+    def test_sends_with_counts(self):
+        from cqc_lem.utilities.notifications import notify_content_generation_ready
+        with patch(f"{_MOD}.get_user_email", return_value="u@e.com"), \
+             patch(f"{_EMAIL}.send_content_generation_ready_email", return_value=True) as send:
+            assert notify_content_generation_ready(4, 3, 1) is True
+        send.assert_called_once_with("u@e.com", 3, 1)
+
+    def test_skips_when_nothing_generated(self):
+        from cqc_lem.utilities.notifications import notify_content_generation_ready
+        with patch(f"{_MOD}.get_user_email") as get_email, \
+             patch(f"{_EMAIL}.send_content_generation_ready_email") as send:
+            assert notify_content_generation_ready(4, 0, 2) is False
+        get_email.assert_not_called()
+        send.assert_not_called()
+
+    def test_skips_when_user_has_no_email(self):
+        from cqc_lem.utilities.notifications import notify_content_generation_ready
+        with patch(f"{_MOD}.get_user_email", return_value=None), \
+             patch(f"{_EMAIL}.send_content_generation_ready_email") as send:
+            assert notify_content_generation_ready(4, 1) is False
+        send.assert_not_called()
+
+    def test_send_failure_returns_false(self):
+        from cqc_lem.utilities.notifications import notify_content_generation_ready
+        with patch(f"{_MOD}.get_user_email", return_value="u@e.com"), \
+             patch(f"{_EMAIL}.send_content_generation_ready_email", return_value=False):
+            assert notify_content_generation_ready(4, 1) is False
+
+    def test_exception_is_swallowed(self):
+        from cqc_lem.utilities.notifications import notify_content_generation_ready
+        with patch(f"{_MOD}.get_user_email", side_effect=RuntimeError("db down")):
+            assert notify_content_generation_ready(4, 1) is False
+
+
+class TestContentGenerationReadyEmail:
+    def test_singular_copy_and_review_link(self, monkeypatch):
+        monkeypatch.setenv("LEM_APP_URL", "https://app.example.com/")
+        from cqc_lem.utilities.email import send_content_generation_ready_email
+        with patch(f"{_EMAIL}._dispatch_email", return_value=True) as dispatch:
+            assert send_content_generation_ready_email("u@e.com", 1) is True
+        to_email, subject, html = dispatch.call_args[0]
+        assert to_email == "u@e.com"
+        assert "1 LinkedIn post is ready" in subject
+        assert "https://app.example.com/content?tab=review" in html
+        assert "couldn't be generated" not in html
+
+    def test_plural_copy_and_failure_note(self, monkeypatch):
+        monkeypatch.setenv("LEM_APP_URL", "https://app.example.com")
+        from cqc_lem.utilities.email import send_content_generation_ready_email
+        with patch(f"{_EMAIL}._dispatch_email", return_value=True) as dispatch:
+            send_content_generation_ready_email("u@e.com", 3, 2)
+        subject, html = dispatch.call_args[0][1], dispatch.call_args[0][2]
+        assert "3 LinkedIn posts are ready" in subject
+        assert "2 posts couldn't be generated" in html

--- a/tests/unit/utilities/test_content_generation_status.py
+++ b/tests/unit/utilities/test_content_generation_status.py
@@ -1,0 +1,253 @@
+"""Unit tests for the weekly content-generation progress store (issue #545)."""
+
+import json
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.content_generation_status"
+
+
+class FakeRedis:
+    """Minimal in-memory stand-in — just the get/set/delete the store uses."""
+
+    def __init__(self):
+        self.store: dict[str, str] = {}
+        self.ttls: dict[str, int] = {}
+
+    def get(self, key):
+        return self.store.get(key)
+
+    def set(self, key, value, ex=None):
+        self.store[key] = value
+        self.ttls[key] = ex
+
+    def delete(self, key):
+        self.store.pop(key, None)
+
+
+@pytest.fixture
+def fake_redis():
+    client = FakeRedis()
+    with patch(f"{_MOD}._redis_client", return_value=client):
+        yield client
+
+
+@pytest.fixture
+def no_redis():
+    with patch(f"{_MOD}._redis_client", return_value=None):
+        yield
+
+
+class TestTtlSeconds:
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CONTENT_GENERATION_STATUS_TTL_SECONDS", raising=False)
+        from cqc_lem.utilities.content_generation_status import _ttl_seconds
+        assert _ttl_seconds() == 86400
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("CONTENT_GENERATION_STATUS_TTL_SECONDS", "60")
+        from cqc_lem.utilities.content_generation_status import _ttl_seconds
+        assert _ttl_seconds() == 60
+
+    def test_bad_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("CONTENT_GENERATION_STATUS_TTL_SECONDS", "soon")
+        from cqc_lem.utilities.content_generation_status import _ttl_seconds
+        assert _ttl_seconds() == 86400
+
+
+class TestResultTtlSeconds:
+    def test_default_when_unset(self, monkeypatch):
+        monkeypatch.delenv("CONTENT_GENERATION_RESULT_TTL_SECONDS", raising=False)
+        from cqc_lem.utilities.content_generation_status import _result_ttl_seconds
+        assert _result_ttl_seconds() == 3600
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("CONTENT_GENERATION_RESULT_TTL_SECONDS", "30")
+        from cqc_lem.utilities.content_generation_status import _result_ttl_seconds
+        assert _result_ttl_seconds() == 30
+
+    def test_bad_env_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("CONTENT_GENERATION_RESULT_TTL_SECONDS", "later")
+        from cqc_lem.utilities.content_generation_status import _result_ttl_seconds
+        assert _result_ttl_seconds() == 3600
+
+
+class TestRedisClient:
+    def test_prefers_redis_broker_url(self, monkeypatch):
+        monkeypatch.setenv("CELERY_BROKER_URL", "redis://broker:6379/0")
+        from cqc_lem.utilities.content_generation_status import _redis_client
+        with patch("redis.Redis.from_url") as from_url:
+            _redis_client()
+        assert from_url.call_args[0][0] == "redis://broker:6379/0"
+
+    def test_falls_back_to_result_backend_when_broker_not_redis(self, monkeypatch):
+        monkeypatch.setenv("CELERY_BROKER_URL", "sqs://")
+        monkeypatch.setenv("CELERY_RESULT_BACKEND", "redis://backend:6379/1")
+        from cqc_lem.utilities.content_generation_status import _redis_client
+        with patch("redis.Redis.from_url") as from_url:
+            _redis_client()
+        assert from_url.call_args[0][0] == "redis://backend:6379/1"
+
+    def test_returns_none_when_connection_fails(self, monkeypatch):
+        monkeypatch.setenv("CELERY_BROKER_URL", "redis://broker:6379/0")
+        from cqc_lem.utilities.content_generation_status import _redis_client
+        with patch("redis.Redis.from_url", side_effect=ConnectionError("down")):
+            assert _redis_client() is None
+
+
+class TestLifecycle:
+    def test_queued_then_in_progress_then_done(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationState, get_generation_status, mark_finished, mark_in_progress,
+            mark_queued, record_post_generated)
+
+        mark_queued(3)
+        status = get_generation_status(3)
+        assert status["state"] == ContentGenerationState.QUEUED
+        assert status["total"] == 0
+        assert status["started_at"]
+
+        mark_in_progress(3, [11, 12])
+        status = get_generation_status(3)
+        assert status["state"] == ContentGenerationState.IN_PROGRESS
+        assert status["total"] == 2
+        assert status["post_ids"] == [11, 12]
+
+        record_post_generated(3, 11)
+        assert get_generation_status(3)["completed"] == 1
+
+        record_post_generated(3, 12)
+        final = mark_finished(3)
+        assert final["state"] == ContentGenerationState.DONE
+        assert final["completed"] == 2
+        assert final["ready_post_ids"] == [11, 12]
+        assert final["finished_at"]
+
+    def test_in_progress_keeps_original_started_at(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            get_generation_status, mark_in_progress, mark_queued)
+        mark_queued(3)
+        queued_at = get_generation_status(3)["started_at"]
+        mark_in_progress(3, [1])
+        assert get_generation_status(3)["started_at"] == queued_at
+
+    def test_partial_failure_still_done(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationState, mark_finished, mark_in_progress, record_post_failed,
+            record_post_generated)
+        mark_in_progress(4, [1, 2])
+        record_post_generated(4, 1)
+        record_post_failed(4, 2)
+        final = mark_finished(4)
+        assert final["state"] == ContentGenerationState.DONE
+        assert final["completed"] == 1
+        assert final["failed"] == 1
+        assert final["failed_post_ids"] == [2]
+
+    def test_total_failure_is_failed(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationState, mark_finished, mark_in_progress, record_post_failed)
+        mark_in_progress(5, [9])
+        record_post_failed(5, 9)
+        assert mark_finished(5)["state"] == ContentGenerationState.FAILED
+
+    def test_empty_run_finishes_done(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationState, mark_finished, mark_in_progress)
+        mark_in_progress(6, [])
+        final = mark_finished(6)
+        assert final["state"] == ContentGenerationState.DONE
+        assert final["total"] == 0
+
+    def test_recording_the_same_post_twice_counts_once(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            get_generation_status, mark_in_progress, record_post_generated)
+        mark_in_progress(7, [1])
+        record_post_generated(7, 1)
+        record_post_generated(7, 1)
+        assert get_generation_status(7)["completed"] == 1
+
+    def test_status_is_per_user(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            get_generation_status, mark_in_progress)
+        mark_in_progress(1, [10])
+        mark_in_progress(2, [20, 21])
+        assert get_generation_status(1)["total"] == 1
+        assert get_generation_status(2)["total"] == 2
+
+    def test_clear_removes_status(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            clear_generation_status, get_generation_status, mark_queued)
+        mark_queued(8)
+        clear_generation_status(8)
+        assert get_generation_status(8) is None
+
+    def test_ttl_applied_on_write(self, fake_redis, monkeypatch):
+        monkeypatch.setenv("CONTENT_GENERATION_STATUS_TTL_SECONDS", "120")
+        from cqc_lem.utilities.content_generation_status import mark_queued
+        mark_queued(9)
+        assert fake_redis.ttls["content_generation:status:9"] == 120
+
+    def test_finished_run_gets_the_shorter_result_ttl(self, fake_redis, monkeypatch):
+        monkeypatch.setenv("CONTENT_GENERATION_STATUS_TTL_SECONDS", "120")
+        monkeypatch.setenv("CONTENT_GENERATION_RESULT_TTL_SECONDS", "30")
+        from cqc_lem.utilities.content_generation_status import mark_finished, mark_in_progress
+        mark_in_progress(9, [1])
+        assert fake_redis.ttls["content_generation:status:9"] == 120
+        mark_finished(9)
+        assert fake_redis.ttls["content_generation:status:9"] == 30
+
+
+class TestFailsOpen:
+    def test_all_writes_noop_without_redis(self, no_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            clear_generation_status, get_generation_status, mark_finished, mark_in_progress,
+            mark_queued, record_post_failed, record_post_generated)
+        mark_queued(1)
+        mark_in_progress(1, [1, 2])
+        record_post_generated(1, 1)
+        record_post_failed(1, 2)
+        clear_generation_status(1)
+        assert mark_finished(1) is None
+        assert get_generation_status(1) is None
+
+    def test_record_and_finish_ignore_missing_status(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            get_generation_status, mark_finished, record_post_generated)
+        record_post_generated(2, 5)
+        assert get_generation_status(2) is None
+        assert mark_finished(2) is None
+
+    def test_unreadable_payload_is_treated_as_missing(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import get_generation_status
+        fake_redis.store["content_generation:status:3"] = "not json"
+        assert get_generation_status(3) is None
+
+    def test_non_dict_payload_is_treated_as_missing(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import get_generation_status
+        fake_redis.store["content_generation:status:3"] = json.dumps([1, 2])
+        assert get_generation_status(3) is None
+
+    def test_read_error_is_swallowed(self):
+        client = MagicMock()
+        client.get.side_effect = RuntimeError("redis exploded")
+        with patch(f"{_MOD}._redis_client", return_value=client):
+            from cqc_lem.utilities.content_generation_status import get_generation_status
+            assert get_generation_status(1) is None
+
+    def test_write_error_is_swallowed(self):
+        client = MagicMock()
+        client.set.side_effect = RuntimeError("redis exploded")
+        with patch(f"{_MOD}._redis_client", return_value=client):
+            from cqc_lem.utilities.content_generation_status import mark_queued
+            mark_queued(1)  # must not raise
+
+    def test_delete_error_is_swallowed(self):
+        client = MagicMock()
+        client.delete.side_effect = RuntimeError("redis exploded")
+        with patch(f"{_MOD}._redis_client", return_value=client):
+            from cqc_lem.utilities.content_generation_status import clear_generation_status
+            clear_generation_status(1)  # must not raise


### PR DESCRIPTION
## What & why

Clicking **Generate Weekly Content** fired an async Celery chain and returned `200` immediately. Generation then ran for minutes (each video post is a ~6-min Runway/Veo call) with zero feedback, so the feature read as broken. This adds per-user progress, a poll endpoint, a completion email, and a Content Studio progress UI.

## Changes

**Progress store — `utilities/content_generation_status.py` (new)**
- Per-user record in Redis: `state` (`queued` / `in_progress` / `done` / `failed`), `total`, `completed`, `failed`, `post_ids`, `ready_post_ids`, `failed_post_ids`, timestamps.
- Runtime-only state (same rationale as the 429 breaker) → **no migration**, survives deploys, expires on its own: `CONTENT_GENERATION_STATUS_TTL_SECONDS` (default 1 day) while running, `CONTENT_GENERATION_RESULT_TTL_SECONDS` (default 1 hour) once finished, so a stale "ready to review" can't linger in the UI.
- **Fails open**: with Redis unavailable every write no-ops and reads return `None` — generation never breaks because progress reporting is down.

**Task — `app/run_content_plan.py`**
- `auto_create_weekly_content` marks each post's **owner** in progress (the daily beat run passes `user_id=None` and generates for every user, so progress is keyed off `post['user_id']`, not the argument), records per-post success/failure, then closes the run out.
- A run that finds no planned posts now also closes out the `queued` record the API opened — otherwise the SPA would poll a run that never reports.
- Sends `notify_content_generation_ready` per user, counted **locally** rather than read back from Redis, so the email still goes out when the progress store is down.

**API — `api/main.py`**
- `POST /create_weekly_content/` marks the run `queued` at dispatch, so the SPA gets a state immediately.
- `GET /content_generation_status/` returns the caller's progress (`detail: null` when nothing is tracked). Scoped by `session_token` rather than the `?user_id=` the issue sketched, matching every other user-scoped GET here — otherwise anyone could poll another user's run.

**Notification — `utilities/notifications.py` + `utilities/email.py`**
- `notify_content_generation_ready(user_id, ready_count, failed_count)` mirroring `notify_newsletter_draft_ready`; email links to `/content?tab=review` and notes any posts that failed.

**SPA — `ui/src/pages/ContentStudio.tsx`**
- Polls the endpoint every 5s only while a run is `queued`/`in_progress`, then stops.
- Progress banner: state line, `X of N` bar, failure note, dismiss; button label becomes `Generating 2 of 5…`.
- Post list auto-refreshes when a run finishes.
- New **ERROR** status filter + badge colour so a post whose media generation failed is visible instead of hiding in ALL.

## Testing

- 45 new unit tests: progress-store lifecycle + fail-open paths (97% line coverage on the new module), task wiring (per-user grouping, failure counting, empty-run close-out), endpoint auth/shape, notification + email copy.
- `pytest tests/unit` — **5101 passed**.
- `tsc -b` clean; `eslint` on the touched file reports only the two pre-existing errors.

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)