### PR TITLE
fix(scheduling): one timezone contract from picker to executed instant (closes #546)

### DIFF
--- a/docs/timezone-contract.md
+++ b/docs/timezone-contract.md
@@ -1,0 +1,93 @@
+# Timezone Contract
+
+One rule, four layers. Every scheduled instant in LEM — posts, newsletter editions, scheduled DMs —
+obeys it, so the time a user sees is the time the automation actually fires.
+
+> **UTC is the only storage and transport zone. The user's IANA timezone is the only display and
+> input zone. Conversion happens exactly twice: at the SPA boundary.**
+
+Why it matters: the post scheduler *and* the pre-post engagement window key off the same
+`scheduled_time` (feed commenting runs at `scheduled_time − 15 min`, profile-viewer DMs at
+`− 10 min`). A display/storage disagreement of one UTC offset doesn't just mislabel a row — it fires
+the whole golden-hour sequence hours away from the peak it was aimed at.
+
+## 1. Storage — naive UTC
+
+| Table | Column |
+|---|---|
+| `posts` | `scheduled_time` |
+| `newsletter_editions` | `scheduled_for` |
+| `scheduled_dms` | `scheduled_time` |
+
+These are MySQL `DATETIME`s holding **UTC with no offset**. Two things keep that true:
+
+- `get_db_connection()` pins the session with `time_zone='+00:00'`, so `NOW()`, `UTC_TIMESTAMP()`
+  and `CURDATE()` are all UTC — server-side comparisons need no conversion.
+- Every write goes through **`db.to_naive_utc()`**. Aware datetimes are converted to UTC and
+  stripped; naive ones are assumed to already be UTC.
+
+`to_naive_utc` is not cosmetic. `mysql-connector` serializes a `datetime` from its wall-clock fields
+and **silently drops `tzinfo`** — hand it an aware `14:00-04:00` and it stores `14:00`, four hours
+early, with no error. Never pass a caller-supplied datetime straight into a scheduling column.
+
+## 2. Scheduling — compute local, store UTC
+
+`get_post_time()` / `get_best_posting_time()` return the user's **local** wall clock (the 2026 peak
+model, or the user's own learned best hour). The caller converts to UTC before storing —
+see `run_content_plan.plan_content_for_user`.
+
+`recommend_post_times()` takes a `tz=` argument and buckets each post's stored UTC time into that
+zone before ranking. Omitting it yields UTC hours, which callers that feed the result back into the
+scheduler must not do: `get_post_time` treats the returned hour as local and converts it to UTC, so
+a UTC-bucketed hour would be shifted by the user's offset **twice**.
+
+Newsletter slots use `newsletter.next_publish_datetime(..., tz, ...)`, which localizes the
+publish-day/hour in the user's zone (DST-safe via `pytz.localize`) and returns naive UTC.
+
+## 3. Transport — explicit `Z`
+
+Every datetime leaving the API is serialized with `api.main._utc_iso()`, which emits a trailing
+`Z`. Without the offset a browser parses the string as *local* time, and every rendered value is
+wrong by the viewer's offset.
+
+Inbound, request models declare `datetime` fields; the SPA always sends an explicit-UTC ISO string,
+and `to_naive_utc` normalizes whatever arrives.
+
+## 4. Display & input — the user's timezone, never the browser's
+
+The user's zone comes from `GET /user/timezone` (Account → Login Location), read in the SPA via the
+`useUserTimezone()` hook. It is **not** `Intl.DateTimeFormat().resolvedOptions().timeZone` — that is
+only the last-resort fallback while the query is in flight. A user whose Login Location differs from
+their device (travel, VPN, or deliberately targeting an audience in another zone) must still see and
+set times in their configured zone.
+
+`src/utils/datetime.ts` owns all three conversions:
+
+| Helper | Direction |
+|---|---|
+| `formatInTimezone(iso, tz)` | UTC ISO → display string in `tz` |
+| `toZonedInputValue(iso, tz)` | UTC ISO → `<input type="datetime-local">` value in `tz` |
+| `zonedInputToUtcIso(value, tz)` | `datetime-local` value read as `tz` → UTC ISO with `Z` |
+
+A `datetime-local` input carries **no timezone**. Its value must be the same wall clock
+`formatInTimezone` renders beside it, or the editor and its own label disagree about one post. On
+the way back out, `new Date(value).toISOString()` is always wrong — it interprets the value in the
+browser's zone. Use `zonedInputToUtcIso`, which measures the zone's real offset at that instant
+(DST-correct) via `Intl.DateTimeFormat.formatToParts`.
+
+## 5. Execution — same instant
+
+`auto_check_scheduled_posts`, `auto_check_scheduled_dms` and the newsletter publisher read the naive
+UTC column, attach `timezone.utc`, and pass the aware datetime as the Celery `eta`. Pre-post tasks
+are offset from that same instant, so the whole sequence stays anchored to the stored time.
+
+## Adding a new scheduled thing
+
+1. Store naive UTC; route the write through `to_naive_utc()`.
+2. Serialize it out through `_utc_iso()`.
+3. Render with `formatInTimezone()`; edit with `toZonedInputValue()` / `zonedInputToUtcIso()`.
+4. Compute any "good time to do this" in the user's zone, then convert once for storage.
+
+Regression coverage: `tests/unit/utilities/test_timezone_contract.py` round-trips a wall clock the
+user picks → UTC storage → display → executed instant across several offsets and both DST
+transitions, asserting zero drift.

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1962,16 +1962,15 @@ def get_newsletter_draft_endpoint(session_token: str) -> ResponseModel:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
     editions = get_pending_newsletter_editions(user_id)
     for e in editions:
-        sched = e.get("scheduled_for")
-        if sched is not None:
-            e["scheduled_for"] = sched.isoformat() if hasattr(sched, "isoformat") else str(sched)
+        if e.get("scheduled_for") is not None:
+            e["scheduled_for"] = _utc_iso(e["scheduled_for"])
     # next_publish is the slot AFTER the last edition already queued, so the UI can show what's next.
     anchor = get_latest_edition_scheduled_for(user_id)
     next_pub = _compute_next_publish(user_id, anchor=anchor)
     settings = get_newsletter_settings(user_id)
     return ResponseModel(status_code=200, detail={
         "editions": editions,
-        "next_publish": next_pub.isoformat() if next_pub is not None else None,
+        "next_publish": _utc_iso(next_pub),
         "max_queued_drafts": settings.get("max_queued_drafts", 1),
         "generate_lead_days": settings.get("generate_lead_days", 3),
     })
@@ -2059,9 +2058,13 @@ def list_scheduled_dms_endpoint(session_token: str, status_filter: Optional[str]
     user_id = get_session_user_id(session_token)
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
-    return ResponseModel(status_code=200,
-                         detail=get_scheduled_dms(user_id, status_filter=status_filter, page=page,
-                                                  page_size=page_size, sort_order=sort_order))
+    result = get_scheduled_dms(user_id, status_filter=status_filter, page=page,
+                               page_size=page_size, sort_order=sort_order)
+    for dm in result.get("dms", []):
+        for key in ("scheduled_time", "created_at", "updated_at"):
+            if dm.get(key) is not None:
+                dm[key] = _utc_iso(dm[key])
+    return ResponseModel(status_code=200, detail=result)
 
 
 @router.put("/dm")
@@ -2462,10 +2465,14 @@ def get_post_stats_endpoint(session_token: str) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
     rows = get_post_engagement_rows(user_id)
+    # Recommendations are shown as "post on Wednesday at 4pm" — that hour has to be the user's own
+    # wall clock, not the UTC the stats are stored in.
+    user_tz = get_user_timezone(user_id)
     return ResponseModel(status_code=200, detail={
-        "recommendations": recommend_post_times(rows),
+        "recommendations": recommend_post_times(rows, tz=user_tz),
         "rankings": rank_content_attributes(rows, top_n=5),
         "sample_size": len(rows),
+        "timezone": user_tz,
     })
 
 

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -193,10 +193,10 @@ def plan_content_for_user(self, user_id: int):
         # enough post-stats, else the 2026 default peak model.
         post_time = get_post_time(post_date.date(), user_id)
 
-        # get_best_posting_time returns the user's LOCAL audience time (e.g. 2pm). Convert
-        # it from the user's timezone to UTC for storage, because the scheduler treats
-        # stored scheduled_time as UTC. Without this, a 14:00 local post was stored as
-        # 14:00 UTC and fired hours off the intended local time.
+        # get_post_time returns the user's LOCAL audience time (e.g. 2pm). Convert it from the
+        # user's timezone to UTC for storage — scheduled_time is naive UTC by contract
+        # (docs/timezone-contract.md). Without this, a 14:00 local post was stored as 14:00 UTC
+        # and fired hours off the intended local time.
         scheduled_datetime = datetime.combine(post_date, post_time)
         try:
             user_tz = pytz.timezone(get_user_timezone(user_id))
@@ -204,7 +204,8 @@ def plan_content_for_user(self, user_id: int):
                 user_tz.localize(scheduled_datetime).astimezone(pytz.utc).replace(tzinfo=None)
             )
         except Exception as e:
-            myprint(f"Timezone conversion failed for user {user_id} — storing as UTC: {e}")
+            log_warning(f"Timezone conversion failed for user {user_id} — storing as UTC",
+                        exc=e, user_id=user_id, task_name="plan_content_for_user")
 
         daily_plan.append({
             "scheduled_datetime": scheduled_datetime,

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -13,7 +13,7 @@ import CatchupTouches from './review/CatchupTouches'
 import ComposePost from './content/ComposePost'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
-import { formatInTimezone } from '../utils/datetime'
+import { formatInTimezone, toZonedInputValue, zonedInputToUtcIso } from '../utils/datetime'
 
 // Consolidated content hub: compose posts, schedule DMs, manage newsletters, and review/edit
 // existing content — one page, four tabs, synced to ?tab= for deep-linking.
@@ -598,10 +598,11 @@ export default function ContentStudio() {
             />
             <button
               onClick={() => {
-                if (!bulkDate) return
+                const utc = zonedInputToUtcIso(bulkDate, userTimezone)
+                if (!utc) return
                 bulkUpdateMutation.mutate({
                   post_ids: Array.from(selectedIds),
-                  scheduled_datetime: new Date(bulkDate).toISOString(),
+                  scheduled_datetime: utc,
                 })
               }}
               disabled={!bulkDate || bulkUpdateMutation.isPending}
@@ -862,8 +863,14 @@ export default function ContentStudio() {
                     <label className="block text-xs font-medium text-gray-600 mb-1">Scheduled Time</label>
                     <input
                       type="datetime-local"
-                      value={editingPost.scheduled_time?.slice(0, 16) ?? ''}
-                      onChange={(e) => setEditingPost({ ...editingPost, scheduled_time: e.target.value })}
+                      value={toZonedInputValue(editingPost.scheduled_time, userTimezone)}
+                      onChange={(e) =>
+                        setEditingPost({
+                          ...editingPost,
+                          scheduled_time:
+                            zonedInputToUtcIso(e.target.value, userTimezone) ?? editingPost.scheduled_time,
+                        })
+                      }
                       className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                     />
                   </div>

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
@@ -6,6 +6,7 @@ import LinkedInPostPreview from '../../components/LinkedInPostPreview'
 import TopicAuthorityMeter from '../../components/TopicAuthorityMeter'
 import { useAuth } from '../../contexts/AuthContext'
 import { useUserTimezone } from '../../hooks/useUserTimezone'
+import { zonedInputToUtcIso } from '../../utils/datetime'
 
 const POST_TYPES = ['TEXT', 'VIDEO', 'CAROUSEL'] as const
 type PostType = typeof POST_TYPES[number]
@@ -162,6 +163,9 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
     if (!email) { setResult({ ok: false, msg: 'Set your email in Account settings first.' }); return }
     if (!content.trim()) { setResult({ ok: false, msg: 'Post content is required.' }); return }
     if (!scheduledAt) { setResult({ ok: false, msg: 'Scheduled date/time is required.' }); return }
+    // The picker is a bare wall clock — read it in the user's timezone, not the browser's.
+    const scheduledUtc = zonedInputToUtcIso(scheduledAt, userTimezone)
+    if (!scheduledUtc) { setResult({ ok: false, msg: 'Scheduled date/time is not valid.' }); return }
     if (postType === 'CAROUSEL') {
       const activeSlides = carouselMode === 'ai' ? generatedSlideUrls : slides.filter((s) => s.trim())
       if (activeSlides.length === 0) {
@@ -176,7 +180,7 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
       const payload: Record<string, unknown> = {
         content,
         post_type: postType.toLowerCase(),
-        scheduled_datetime: new Date(scheduledAt).toISOString(),
+        scheduled_datetime: scheduledUtc,
         email,
         status,
         use_avatar: postType !== 'TEXT' && useAvatar && hasActiveAvatar,
@@ -525,7 +529,9 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
 
           {/* Schedule date/time */}
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Schedule Date &amp; Time</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Schedule Date &amp; Time <span className="font-normal text-gray-400">({userTimezone})</span>
+            </label>
             <input
               type="datetime-local"
               value={scheduledAt}

--- a/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
+++ b/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
@@ -3,7 +3,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import NewsletterArticlePreview from '../../components/NewsletterArticlePreview'
-import { formatInTimezone } from '../../utils/datetime'
+import { formatInTimezone, toZonedInputValue, zonedInputToUtcIso } from '../../utils/datetime'
 import type { NewsletterDraft, NewsletterEdition } from '../account/types'
 
 const STATUS_COLORS: Record<string, string> = {
@@ -13,14 +13,6 @@ const STATUS_COLORS: Record<string, string> = {
 
 // e.g. "case_study" -> "Case Study" for the format/hook badges.
 const prettyKey = (k: string) => k.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
-
-// UTC ISO string -> value for a <input type="datetime-local"> (local wall-clock, minute precision).
-const toLocalInput = (iso?: string | null): string => {
-  if (!iso) return ''
-  const d = new Date(iso)
-  if (isNaN(d.getTime())) return ''
-  return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16)
-}
 
 export default function NewsletterQueue({ userTimezone }: { userTimezone: string }) {
   const { user, sessionToken } = useAuth()
@@ -219,11 +211,15 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500" />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Publish date &amp; time</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Publish date &amp; time <span className="font-normal text-gray-400">({userTimezone})</span>
+              </label>
               <input
                 type="datetime-local"
-                value={toLocalInput(draftEdit.scheduled_for)}
-                onChange={(e) => setDe({ scheduled_for: e.target.value ? new Date(e.target.value).toISOString() : draftEdit.scheduled_for })}
+                value={toZonedInputValue(draftEdit.scheduled_for, userTimezone)}
+                onChange={(e) =>
+                  setDe({ scheduled_for: zonedInputToUtcIso(e.target.value, userTimezone) ?? draftEdit.scheduled_for })
+                }
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
               />
             </div>

--- a/src/cqc_lem/ui/src/pages/review/ScheduledDMs.tsx
+++ b/src/cqc_lem/ui/src/pages/review/ScheduledDMs.tsx
@@ -63,14 +63,14 @@ export default function ScheduledDMs({ userTimezone }: { userTimezone: string })
   const invalidate = () => qc.invalidateQueries({ queryKey: ['scheduled-dms'] })
 
   const createMutation = useMutation({
-    mutationFn: (status: 'pending' | 'approved') =>
+    mutationFn: (v: { status: 'pending' | 'approved'; scheduledUtc: string }) =>
       api.post('/schedule_dm', {
         session_token: sessionToken,
         recipient_profile_url: url.trim(),
         recipient_name: name.trim() || null,
         message: body,
-        scheduled_datetime: zonedInputToUtcIso(when, userTimezone),
-        status,
+        scheduled_datetime: v.scheduledUtc,
+        status: v.status,
       }),
     onSuccess: () => {
       invalidate(); setUrl(''); setName(''); setBody(''); setWhen('')
@@ -78,6 +78,14 @@ export default function ScheduledDMs({ userTimezone }: { userTimezone: string })
     },
     onError: () => flash(false, 'Could not schedule — check the fields and try again.'),
   })
+
+  // The picker is a bare wall clock — read it in the user's timezone, not the browser's. An
+  // unparseable value yields null, which the API would reject with a 422; catch it here instead.
+  const submit = (status: 'pending' | 'approved') => {
+    const scheduledUtc = zonedInputToUtcIso(when, userTimezone)
+    if (!scheduledUtc) { flash(false, 'Scheduled date/time is not valid.'); return }
+    createMutation.mutate({ status, scheduledUtc })
+  }
 
   const actionMutation = useMutation({
     mutationFn: (v: { id: number; action: 'approve' | 'cancel' }) =>
@@ -115,11 +123,11 @@ export default function ScheduledDMs({ userTimezone }: { userTimezone: string })
               className="border border-gray-300 rounded-lg px-3 py-2 text-sm" />
             {userTimezone}
           </label>
-          <button onClick={() => createMutation.mutate('pending')} disabled={!canSubmit || createMutation.isPending}
+          <button onClick={() => submit('pending')} disabled={!canSubmit || createMutation.isPending}
             className="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50">
             Save draft
           </button>
-          <button onClick={() => createMutation.mutate('approved')} disabled={!canSubmit || createMutation.isPending}
+          <button onClick={() => submit('approved')} disabled={!canSubmit || createMutation.isPending}
             className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50">
             {createMutation.isPending ? 'Scheduling…' : 'Approve & schedule'}
           </button>

--- a/src/cqc_lem/ui/src/pages/review/ScheduledDMs.tsx
+++ b/src/cqc_lem/ui/src/pages/review/ScheduledDMs.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
-import { formatInTimezone } from '../../utils/datetime'
+import { formatInTimezone, zonedInputToUtcIso } from '../../utils/datetime'
 
 // Schedule 1:1 DMs to chosen recipients at chosen times (issue #306), mirroring the scheduled-posts
 // preview/approve workflow. Drafts are 'pending'; approving queues them for the scanner to send at
@@ -69,7 +69,7 @@ export default function ScheduledDMs({ userTimezone }: { userTimezone: string })
         recipient_profile_url: url.trim(),
         recipient_name: name.trim() || null,
         message: body,
-        scheduled_datetime: new Date(when).toISOString(),
+        scheduled_datetime: zonedInputToUtcIso(when, userTimezone),
         status,
       }),
     onSuccess: () => {
@@ -110,8 +110,11 @@ export default function ScheduledDMs({ userTimezone }: { userTimezone: string })
           placeholder="Your message…"
           className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
         <div className="flex flex-wrap items-center gap-3">
-          <input type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)}
-            className="border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+          <label className="flex items-center gap-2 text-xs text-gray-500">
+            <input type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)}
+              className="border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+            {userTimezone}
+          </label>
           <button onClick={() => createMutation.mutate('pending')} disabled={!canSubmit || createMutation.isPending}
             className="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50">
             Save draft

--- a/src/cqc_lem/ui/src/utils/datetime.ts
+++ b/src/cqc_lem/ui/src/utils/datetime.ts
@@ -1,10 +1,33 @@
+// Timezone contract (docs/timezone-contract.md): the backend stores and serves every scheduling
+// instant in UTC; the SPA renders and edits it in the USER'S configured timezone (Account → Login
+// Location, served by /user/timezone), never the browser's. Times are always shown 12-hour.
+
 // Backend datetimes are UTC. They were historically serialized as naive ISO (no 'Z'/offset); the
 // API now emits an explicit 'Z', but we still defensively append one when it's missing so
 // `new Date()` parses them as UTC rather than the viewer's local time — otherwise every rendered
-// time is off by the browser's UTC offset. Times are always shown 12-hour (never 24h).
+// time is off by the browser's UTC offset.
 function toUtcDate(isoString: string): Date {
   const hasOffset = /[zZ]$|[+-]\d\d:?\d\d$/.test(isoString)
   return new Date(hasOffset ? isoString : isoString + 'Z')
+}
+
+// Milliseconds `tz` is ahead of UTC at the given instant (DST-correct, because it asks Intl for the
+// wall clock that timezone actually shows at that instant).
+function tzOffsetMs(date: Date, tz: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  }).formatToParts(date)
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value ?? '0')
+  // hour12:false renders midnight as '24' in some engines — normalize it back to 0.
+  const asUtc = Date.UTC(get('year'), get('month') - 1, get('day'), get('hour') % 24, get('minute'), get('second'))
+  return asUtc - date.getTime()
 }
 
 export function formatInTimezone(
@@ -25,5 +48,39 @@ export function formatInTimezone(
     }).format(toUtcDate(isoString))
   } catch {
     return toUtcDate(isoString).toLocaleString('en-US', { hour12: true })
+  }
+}
+
+// UTC ISO string -> the `YYYY-MM-DDTHH:mm` value for an <input type="datetime-local">, expressed in
+// the user's timezone. A `datetime-local` input has no timezone of its own, so its value MUST be
+// the same wall clock formatInTimezone renders next to it — otherwise the editor and the label
+// above it show two different times for one post.
+export function toZonedInputValue(isoString: string | null | undefined, tz: string): string {
+  if (!isoString) return ''
+  const d = toUtcDate(isoString)
+  if (isNaN(d.getTime())) return ''
+  try {
+    return new Date(d.getTime() + tzOffsetMs(d, tz)).toISOString().slice(0, 16)
+  } catch {
+    return ''
+  }
+}
+
+// The inverse: a `datetime-local` wall clock the user typed, read as being in the user's timezone,
+// converted to the explicit-UTC ISO string the API stores. Using `new Date(value).toISOString()`
+// instead would interpret it in the BROWSER's timezone, so a user whose Login Location differs from
+// their device (travel, VPN, a deliberately different audience timezone) would schedule hours off.
+export function zonedInputToUtcIso(value: string | null | undefined, tz: string): string | null {
+  if (!value) return null
+  // Read the typed wall clock as if it were UTC, then subtract the zone's real offset at that
+  // instant. Re-measuring the offset at the candidate instant settles DST boundary cases.
+  const wallClockAsUtc = Date.parse(`${value.slice(0, 16)}:00Z`)
+  if (isNaN(wallClockAsUtc)) return null
+  try {
+    let instant = wallClockAsUtc - tzOffsetMs(new Date(wallClockAsUtc), tz)
+    instant = wallClockAsUtc - tzOffsetMs(new Date(instant), tz)
+    return new Date(instant).toISOString()
+  } catch {
+    return new Date(wallClockAsUtc).toISOString()
   }
 }

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -60,6 +60,22 @@ def get_db_connection():
     )
 
 
+def to_naive_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    """The one storage-side timezone conversion (see docs/timezone-contract.md).
+
+    Every scheduling column in this schema (posts.scheduled_time, scheduled_dms.scheduled_time,
+    newsletter_editions.scheduled_for, …) holds NAIVE UTC. An aware datetime is converted to UTC;
+    a naive one is assumed to already be UTC. Normalizing here rather than at each call site matters
+    because mysql-connector serializes a datetime from its wall-clock fields and silently DROPS
+    tzinfo — an aware non-UTC value would otherwise be stored as its local wall clock, i.e. off by
+    the sender's UTC offset, and the post/DM would fire hours away from what the user scheduled."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt
+    return dt.astimezone(timezone.utc).replace(tzinfo=None)
+
+
 class PostType(StrEnum):
     TEXT = 'text'
     CAROUSEL = 'carousel'
@@ -580,10 +596,7 @@ def insert_post(email: str, content: str, scheduled_time: datetime, post_type: P
     cursor = connection.cursor()
 
     try:
-        if scheduled_time.tzinfo is None:
-            scheduled_time = scheduled_time.replace(tzinfo=timezone.utc)
-        else:
-            scheduled_time = scheduled_time.astimezone(timezone.utc)
+        scheduled_time = to_naive_utc(scheduled_time)
 
         slides_json = json.dumps(carousel_slides) if carousel_slides else None
 
@@ -612,11 +625,7 @@ def insert_planned_post(user_id: int, scheduled_time: datetime, post_type: PostT
     success = False
 
     try:
-        # Convert scheduled_time to UTC
-        if scheduled_time.tzinfo is None:
-            scheduled_time = scheduled_time.replace(tzinfo=timezone.utc)
-        else:
-            scheduled_time = scheduled_time.astimezone(timezone.utc)
+        scheduled_time = to_naive_utc(scheduled_time)
 
         cursor.execute("""
             INSERT INTO posts (scheduled_time, post_type, user_id, buyer_stage, status, content)
@@ -643,11 +652,7 @@ def update_db_post(content: str, video_url: str, scheduled_time: datetime, post_
 
     try:
 
-        # Convert scheduled_time to UTC
-        if scheduled_time.tzinfo is None:
-            scheduled_time = scheduled_time.replace(tzinfo=timezone.utc)
-        else:
-            scheduled_time = scheduled_time.astimezone(timezone.utc)
+        scheduled_time = to_naive_utc(scheduled_time)
 
         cursor.execute(
             "UPDATE posts SET content = %s, video_url = %s, scheduled_time =%s, post_type = %s, status = %s WHERE id = %s",
@@ -1215,12 +1220,8 @@ def bulk_update_posts(post_ids: list[int], status: Optional[PostStatus] = None,
             sets.append("status = %s")
             params.append(status.value)
         if scheduled_time is not None:
-            if scheduled_time.tzinfo is None:
-                scheduled_time = scheduled_time.replace(tzinfo=timezone.utc)
-            else:
-                scheduled_time = scheduled_time.astimezone(timezone.utc)
             sets.append("scheduled_time = %s")
-            params.append(scheduled_time)
+            params.append(to_naive_utc(scheduled_time))
 
         if not sets:
             return False
@@ -3136,7 +3137,7 @@ def insert_scheduled_dm(user_id: int, recipient_profile_url: str, message: str,
             "INSERT INTO scheduled_dms (user_id, recipient_profile_url, recipient_name, message, "
             "source, scheduled_time, status) VALUES (%s,%s,%s,%s,%s,%s,%s)",
             (user_id, recipient_profile_url, recipient_name, message,
-             str(source) if source else None, scheduled_time, str(status)))
+             str(source) if source else None, to_naive_utc(scheduled_time), str(status)))
         connection.commit()
         return cursor.lastrowid
     except mysql.connector.Error as err:
@@ -3317,7 +3318,7 @@ def update_scheduled_dm(dm_id: int, recipient_profile_url: str = None, recipient
                         status: "ScheduledDmStatus" = None) -> bool:
     fields, params = [], []
     for col, val in (("recipient_profile_url", recipient_profile_url), ("recipient_name", recipient_name),
-                     ("message", message), ("scheduled_time", scheduled_time)):
+                     ("message", message), ("scheduled_time", to_naive_utc(scheduled_time))):
         if val is not None:
             fields.append(f"{col} = %s")
             params.append(val)
@@ -5330,7 +5331,7 @@ def create_newsletter_edition(user_id: int, title: str, subtitle: str, body: str
             "hook_style, opening_line, blueprint, body, scheduled_for) "
             "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
             (user_id, title, subtitle, subject, edition_format, hook_style, opening_line,
-             json.dumps(blueprint) if blueprint else None, body, scheduled_for))
+             json.dumps(blueprint) if blueprint else None, body, to_naive_utc(scheduled_for)))
         connection.commit()
         return cursor.lastrowid
     except mysql.connector.IntegrityError as err:
@@ -5430,8 +5431,7 @@ def update_newsletter_edition(edition_id: int, user_id: int, title: str = None,
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
-        if scheduled_for is not None and getattr(scheduled_for, "tzinfo", None) is not None:
-            scheduled_for = scheduled_for.astimezone(timezone.utc).replace(tzinfo=None)
+        scheduled_for = to_naive_utc(scheduled_for)
         cursor.execute(
             "UPDATE newsletter_editions SET "
             "title = COALESCE(%s, title), subtitle = COALESCE(%s, subtitle), "

--- a/src/cqc_lem/utilities/post_stats.py
+++ b/src/cqc_lem/utilities/post_stats.py
@@ -3,8 +3,9 @@
 comparison set carries impressions, and always recency-weighted so stale posts fade out."""
 
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone, tzinfo
 from typing import Any, Iterable, Mapping, Optional, Sequence, Tuple
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 _WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
 
@@ -111,20 +112,41 @@ def _group_metrics(rows: Iterable[Sequence], rate_mode: bool, now: Optional[date
                    "metric": METRIC_RATE if rate_mode else METRIC_COUNT}
 
 
+def _local_wall_clock(scheduled: datetime, zone: Optional[tzinfo]) -> datetime:
+    """Stored scheduled_time is naive UTC (docs/timezone-contract.md); a "best hour" is only
+    meaningful as the AUDIENCE's wall clock, so shift it into the user's zone before bucketing."""
+    if zone is None:
+        return scheduled
+    aware = scheduled.replace(tzinfo=timezone.utc) if scheduled.tzinfo is None else scheduled
+    return aware.astimezone(zone)
+
+
 def recommend_post_times(rows: Iterable[Sequence], top_n: int = 3, min_posts: int = 3,
                          now: Optional[datetime] = None,
-                         half_life_days: float = RECENCY_HALF_LIFE_DAYS) -> list:
+                         half_life_days: float = RECENCY_HALF_LIFE_DAYS,
+                         tz: Optional[str] = None) -> list:
     """rows: iterable of `db.get_post_engagement_rows` tuples (at minimum
     (scheduled_time[datetime], reactions, comments, reposts)). Returns the top (weekday, hour)
     buckets by recency-weighted average engagement per post — or engagement RATE when every row
-    has impressions. Empty until >= min_posts of data so we don't recommend off noise."""
+    has impressions. Empty until >= min_posts of data so we don't recommend off noise.
+
+    `tz` is the user's IANA timezone: the returned weekday/hour are that zone's wall clock, which is
+    what callers need — get_post_time hands the hour straight back to the scheduler as a LOCAL time
+    to be converted to UTC for storage, so bucketing the raw UTC hour would shift every
+    recommendation by the user's offset twice. Omitted (or unknown) means UTC."""
     usable = [row for row in rows if row and _cell(row, _IDX_SCHEDULED) is not None]
     if len(usable) < min_posts:
         return []
+    zone = None
+    if tz:
+        try:
+            zone = ZoneInfo(tz)
+        except (ZoneInfoNotFoundError, ValueError):
+            zone = None
     rate_mode = _rate_mode(usable)
     buckets = defaultdict(list)
     for row in usable:
-        scheduled = row[_IDX_SCHEDULED]
+        scheduled = _local_wall_clock(row[_IDX_SCHEDULED], zone)
         buckets[(scheduled.weekday(), scheduled.hour)].append(row)
     ranked = []
     for (weekday, hour), bucket_rows in buckets.items():

--- a/src/cqc_lem/utilities/utils.py
+++ b/src/cqc_lem/utilities/utils.py
@@ -112,16 +112,18 @@ def get_best_posting_time(selected_date: date):
 
 
 def get_post_time(selected_date: date, user_id: int = None):
-    """Best posting time for a date. Prefers the user's own data-driven best hour for that weekday
-    (learned by recommend_post_times, Phase 3) and falls back to the 2026 default model until enough
-    data exists. Keeps the default's minutes so times aren't all on the hour."""
+    """Best posting time for a date, as the user's LOCAL wall clock — callers convert it to UTC for
+    storage (docs/timezone-contract.md). Prefers the user's own data-driven best hour for that
+    weekday (learned by recommend_post_times, Phase 3) and falls back to the 2026 default model
+    until enough data exists. Keeps the default's minutes so times aren't all on the hour."""
     default = get_best_posting_time(selected_date)
     if user_id is None:
         return default
     try:
-        from cqc_lem.utilities.db import get_post_engagement_rows
+        from cqc_lem.utilities.db import get_post_engagement_rows, get_user_timezone
         from cqc_lem.utilities.post_stats import recommend_post_times
-        recs = recommend_post_times(get_post_engagement_rows(user_id), top_n=7)
+        recs = recommend_post_times(get_post_engagement_rows(user_id), top_n=7,
+                                    tz=get_user_timezone(user_id))
         for r in recs:
             if r["weekday_num"] == selected_date.weekday():
                 return time(r["hour"], default.minute)

--- a/tests/unit/api/test_api_coverage_misc.py
+++ b/tests/unit/api/test_api_coverage_misc.py
@@ -367,11 +367,16 @@ class TestUserSettingsAndGroups:
         recs = [{"weekday_num": 2, "hour": 15}]
         with patch(f"{_M}.get_session_user_id", return_value=_UID), \
              patch(f"{_M}.get_post_engagement_rows", return_value=rows), \
+             patch(f"{_M}.get_user_timezone", return_value="America/New_York"), \
              patch("cqc_lem.utilities.post_stats.recommend_post_times",
-                   return_value=recs):
+                   return_value=recs) as mock_recs:
             resp = client.get(f"/api/user/post-stats?session_token={_TOK}")
         detail = resp.json()["detail"]
         assert detail["recommendations"] == recs and detail["sample_size"] == 1
+        # Recommended hours are rendered as the user's own wall clock, so the ranking must be
+        # bucketed in their timezone rather than the UTC the stats are stored in (issue #546).
+        assert detail["timezone"] == "America/New_York"
+        assert mock_recs.call_args.kwargs["tz"] == "America/New_York"
 
 
 class TestEngagementAnalytics:

--- a/tests/unit/api/test_dm_scheduler_api.py
+++ b/tests/unit/api/test_dm_scheduler_api.py
@@ -80,6 +80,21 @@ class TestListDms:
         assert resp.status_code == 200
         assert lst.call_args.kwargs["status_filter"] == "pending"
 
+    def test_datetimes_serialized_as_explicit_utc(self, client):
+        """Issue #546 — db.get_scheduled_dms isoformats naive UTC with no offset; the endpoint must
+        stamp the 'Z' or the SPA parses it as local time and shows the wrong send time."""
+        from datetime import datetime
+        dms = [{"id": 3, "scheduled_time": datetime(2026, 8, 1, 13, 0),
+                "created_at": datetime(2026, 7, 30, 8, 0), "updated_at": None}]
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_U), \
+             patch("cqc_lem.api.main.get_scheduled_dms",
+                   return_value={"dms": dms, "total": 1, "page": 1, "page_size": 25}):
+            resp = client.get(f"/api/dms?session_token={_S}")
+        row = resp.json()["detail"]["dms"][0]
+        assert row["scheduled_time"] == "2026-08-01T13:00:00Z"
+        assert row["created_at"] == "2026-07-30T08:00:00Z"
+        assert row["updated_at"] is None
+
 
 class TestUpdateAndCancel:
     def test_approve(self, client):

--- a/tests/unit/api/test_newsletter_api.py
+++ b/tests/unit/api/test_newsletter_api.py
@@ -153,8 +153,11 @@ class TestNewsletterDraft:
         assert resp.status_code == 200
         detail = resp.json()["detail"]
         assert detail["editions"][0]["id"] == 4
-        assert detail["editions"][0]["scheduled_for"].startswith("2026-07-07")
+        # Explicit-UTC 'Z' (issue #546) — without it the browser parses the string as LOCAL time
+        # and the queue renders every edition off by the viewer's offset.
+        assert detail["editions"][0]["scheduled_for"] == "2026-07-07T13:00:00Z"
         assert detail["next_publish"] is not None
+        assert detail["next_publish"].endswith("Z")
         assert detail["max_queued_drafts"] == 3 and detail["generate_lead_days"] == 14
 
     def test_get_empty_when_no_editions(self, client):

--- a/tests/unit/utilities/test_guardrails_and_peaktime.py
+++ b/tests/unit/utilities/test_guardrails_and_peaktime.py
@@ -45,5 +45,6 @@ class TestGetPostTime:
         d = dt.date(2026, 7, 8)  # Wednesday (weekday 2)
         recs = [{"weekday_num": 2, "hour": 19, "avg_engagement": 50, "sample": 4}]
         with patch("cqc_lem.utilities.db.get_post_engagement_rows", return_value=[("x",)] * 4), \
+             patch("cqc_lem.utilities.db.get_user_timezone", return_value="America/New_York"), \
              patch("cqc_lem.utilities.post_stats.recommend_post_times", return_value=recs):
             assert utils.get_post_time(d, user_id=1).hour == 19

--- a/tests/unit/utilities/test_timezone_contract.py
+++ b/tests/unit/utilities/test_timezone_contract.py
@@ -1,0 +1,270 @@
+"""Regression coverage for the single timezone contract (docs/timezone-contract.md).
+
+The chain under test is the one a user actually experiences:
+
+    wall clock picked in the user's tz
+      -> UTC ISO sent by the SPA           (zonedInputToUtcIso, mirrored here)
+      -> naive UTC stored in the DB        (db.to_naive_utc)
+      -> explicit-'Z' ISO served back      (api.main._utc_iso)
+      -> wall clock displayed in the tz    (formatInTimezone, mirrored here)
+      -> aware instant handed to Celery    (run_scheduler's naive->utc attach)
+
+A break anywhere in that chain shifts a post AND its pre-post engagement window by the user's
+offset, so every hop is asserted for zero drift — including across both DST transitions.
+"""
+
+import datetime as dt
+from unittest.mock import MagicMock, patch
+from zoneinfo import ZoneInfo
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn():
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.rowcount = 1
+    cur.lastrowid = 1
+    conn.cursor.return_value = cur
+    return conn, cur
+
+# One zone per interesting offset shape: DST + negative, DST + positive, half-hour, no DST at all.
+ZONES = ["America/New_York", "Europe/London", "Asia/Kolkata", "Australia/Sydney", "UTC"]
+
+# Wall clocks the user might pick, including both US DST boundaries (spring-forward Mar 8 2026,
+# fall-back Nov 1 2026) and the ambiguous hour right after fall-back.
+WALL_CLOCKS = [
+    dt.datetime(2026, 1, 15, 16, 0),   # winter
+    dt.datetime(2026, 3, 7, 16, 0),    # day before spring-forward
+    dt.datetime(2026, 3, 9, 16, 0),    # day after spring-forward
+    dt.datetime(2026, 7, 4, 9, 30),    # summer
+    dt.datetime(2026, 10, 31, 16, 0),  # day before fall-back
+    dt.datetime(2026, 11, 1, 1, 30),   # ambiguous hour on fall-back day
+    dt.datetime(2026, 11, 2, 16, 0),   # day after fall-back
+]
+
+
+def _spa_submits(wall_clock: dt.datetime, tz: str) -> dt.datetime:
+    """What the SPA sends: the picked wall clock read in the user's tz, as an aware UTC instant.
+    Mirrors `zonedInputToUtcIso` in ui/src/utils/datetime.ts."""
+    return wall_clock.replace(tzinfo=ZoneInfo(tz)).astimezone(dt.timezone.utc)
+
+
+def _spa_displays(iso: str, tz: str) -> dt.datetime:
+    """What the SPA renders: the served ISO string localized to the user's tz. Mirrors
+    `formatInTimezone` / `toZonedInputValue`, including their defensive naive-means-UTC parse."""
+    parsed = dt.datetime.fromisoformat(iso.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    return parsed.astimezone(ZoneInfo(tz)).replace(tzinfo=None)
+
+
+class TestToNaiveUtc:
+    def test_aware_is_converted_and_stripped(self):
+        from cqc_lem.utilities.db import to_naive_utc
+        aware = dt.datetime(2026, 7, 4, 14, 0, tzinfo=ZoneInfo("America/New_York"))
+        assert to_naive_utc(aware) == dt.datetime(2026, 7, 4, 18, 0)
+
+    def test_naive_is_assumed_utc_and_left_alone(self):
+        from cqc_lem.utilities.db import to_naive_utc
+        naive = dt.datetime(2026, 7, 4, 18, 0)
+        assert to_naive_utc(naive) == naive
+        assert to_naive_utc(naive).tzinfo is None
+
+    def test_none_passes_through(self):
+        """update_newsletter_edition uses None to mean 'leave this column alone' (COALESCE)."""
+        from cqc_lem.utilities.db import to_naive_utc
+        assert to_naive_utc(None) is None
+
+    def test_utc_aware_is_unchanged_apart_from_tzinfo(self):
+        from cqc_lem.utilities.db import to_naive_utc
+        aware = dt.datetime(2026, 7, 4, 18, 0, tzinfo=dt.timezone.utc)
+        assert to_naive_utc(aware) == dt.datetime(2026, 7, 4, 18, 0)
+
+
+class TestUtcIsoSerialization:
+    def test_naive_gets_explicit_z(self):
+        from cqc_lem.api.main import _utc_iso
+        assert _utc_iso(dt.datetime(2026, 7, 4, 18, 0)) == "2026-07-04T18:00:00Z"
+
+    def test_aware_is_converted_to_utc(self):
+        from cqc_lem.api.main import _utc_iso
+        aware = dt.datetime(2026, 7, 4, 14, 0, tzinfo=ZoneInfo("America/New_York"))
+        assert _utc_iso(aware) == "2026-07-04T18:00:00Z"
+
+    def test_none_passes_through(self):
+        from cqc_lem.api.main import _utc_iso
+        assert _utc_iso(None) is None
+
+
+class TestRoundTrip:
+    @pytest.mark.parametrize("tz", ZONES)
+    @pytest.mark.parametrize("wall_clock", WALL_CLOCKS)
+    def test_picked_time_survives_the_full_chain(self, tz, wall_clock):
+        """UI tz -> stored UTC -> served ISO -> displayed tz, with zero drift."""
+        from cqc_lem.api.main import _utc_iso
+        from cqc_lem.utilities.db import to_naive_utc
+
+        stored = to_naive_utc(_spa_submits(wall_clock, tz))
+        assert stored.tzinfo is None, "scheduling columns hold NAIVE UTC"
+
+        displayed = _spa_displays(_utc_iso(stored), tz)
+        assert displayed == wall_clock
+
+    @pytest.mark.parametrize("tz", ZONES)
+    @pytest.mark.parametrize("wall_clock", WALL_CLOCKS)
+    def test_executed_instant_matches_the_displayed_time(self, tz, wall_clock):
+        """The scheduler re-attaches UTC to the naive column and uses that as the Celery eta
+        (run_scheduler.auto_check_scheduled_posts). That instant must be the one the user saw."""
+        from cqc_lem.utilities.db import to_naive_utc
+
+        intended = _spa_submits(wall_clock, tz)
+        stored = to_naive_utc(intended)
+        eta = stored.replace(tzinfo=dt.timezone.utc)
+
+        assert eta == intended
+        assert eta.astimezone(ZoneInfo(tz)).replace(tzinfo=None) == wall_clock
+
+    @pytest.mark.parametrize("tz", ZONES)
+    def test_pre_post_engagement_window_tracks_the_same_instant(self, tz):
+        """Feed commenting fires at eta - 15min and profile-viewer DMs at eta - 10min. Both are
+        derived from the stored instant, so they must land 15/10 minutes before the DISPLAYED
+        time — the whole point of the golden-hour window."""
+        from cqc_lem.utilities.db import to_naive_utc
+
+        wall_clock = dt.datetime(2026, 7, 4, 16, 0)
+        eta = to_naive_utc(_spa_submits(wall_clock, tz)).replace(tzinfo=dt.timezone.utc)
+
+        commenting_local = (eta - dt.timedelta(minutes=15)).astimezone(ZoneInfo(tz))
+        dm_local = (eta - dt.timedelta(minutes=10)).astimezone(ZoneInfo(tz))
+
+        assert commenting_local.replace(tzinfo=None) == dt.datetime(2026, 7, 4, 15, 45)
+        assert dm_local.replace(tzinfo=None) == dt.datetime(2026, 7, 4, 15, 50)
+
+    def test_dst_transition_shifts_the_utc_instant_not_the_wall_clock(self):
+        """4pm New York is 20:00 UTC in winter and 20:00-1h in summer. The user always sees 4pm;
+        the stored UTC is what moves. A fixed-offset conversion would get one of these wrong."""
+        from cqc_lem.utilities.db import to_naive_utc
+
+        winter = to_naive_utc(_spa_submits(dt.datetime(2026, 1, 15, 16, 0), "America/New_York"))
+        summer = to_naive_utc(_spa_submits(dt.datetime(2026, 7, 15, 16, 0), "America/New_York"))
+
+        assert winter.hour == 21  # EST, UTC-5
+        assert summer.hour == 20  # EDT, UTC-4
+
+
+class TestSchedulingWritesNormalizeToUtc:
+    """mysql-connector formats a datetime from its wall-clock fields and DROPS tzinfo, so an aware
+    non-UTC value reaches the column shifted by the sender's offset with no error raised. Every
+    scheduling write must therefore convert BEFORE it hands the value to the cursor."""
+
+    # 14:00 in New York on July 4 2026 (EDT, UTC-4) is 18:00 UTC.
+    AWARE = dt.datetime(2026, 7, 4, 14, 0, tzinfo=ZoneInfo("America/New_York"))
+    EXPECTED = dt.datetime(2026, 7, 4, 18, 0)
+
+    def test_insert_scheduled_dm(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import insert_scheduled_dm
+            insert_scheduled_dm(1, "https://x/in/jane", "hi", self.AWARE)
+        stored = cur.execute.call_args[0][1][5]
+        assert stored == self.EXPECTED and stored.tzinfo is None
+
+    def test_update_scheduled_dm(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_scheduled_dm
+            update_scheduled_dm(7, scheduled_time=self.AWARE)
+        stored = cur.execute.call_args[0][1][0]
+        assert stored == self.EXPECTED and stored.tzinfo is None
+
+    def test_insert_post(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.get_user_id", return_value=1):
+            from cqc_lem.utilities.db import PostType, insert_post
+            insert_post("a@b.co", "body", self.AWARE, PostType.TEXT)
+        stored = cur.execute.call_args[0][1][1]
+        assert stored == self.EXPECTED and stored.tzinfo is None
+
+    def test_bulk_update_posts(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import bulk_update_posts
+            bulk_update_posts([1, 2], scheduled_time=self.AWARE)
+        stored = cur.execute.call_args[0][1][0]
+        assert stored == self.EXPECTED and stored.tzinfo is None
+
+    def test_create_newsletter_edition(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import create_newsletter_edition
+            create_newsletter_edition(1, "T", "S", "B", self.AWARE)
+        stored = cur.execute.call_args[0][1][-1]
+        assert stored == self.EXPECTED and stored.tzinfo is None
+
+    def test_update_newsletter_edition_keeps_none_as_leave_alone(self):
+        """scheduled_for=None means COALESCE-to-existing, not 'clear the column'."""
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_newsletter_edition
+            update_newsletter_edition(3, 1, title="T")
+        assert cur.execute.call_args[0][1][-3] is None
+
+
+class TestRecommendPostTimesTimezone:
+    """recommend_post_times buckets stored UTC times; get_post_time hands the result straight back
+    to the scheduler as a LOCAL time. Bucketing in UTC would shift it by the offset a second time."""
+
+    def _row(self, scheduled, reactions=10):
+        return (scheduled, reactions, 0, 0, None, None, None, None, None, None)
+
+    def test_buckets_use_the_users_wall_clock(self):
+        from cqc_lem.utilities.post_stats import recommend_post_times
+        # 20:00, 21:00, 22:00 UTC == 16:00, 17:00, 18:00 EDT on a Saturday in July.
+        rows = [self._row(dt.datetime(2026, 7, 4, 20, 0), 100),
+                self._row(dt.datetime(2026, 7, 4, 21, 0), 1),
+                self._row(dt.datetime(2026, 7, 4, 22, 0), 1)]
+        top = recommend_post_times(rows, top_n=1, min_posts=3, tz="America/New_York")[0]
+        assert top["hour"] == 16
+        assert top["weekday"] == "Saturday"
+
+    def test_weekday_can_roll_back_a_day(self):
+        """01:00 UTC Monday is 21:00 Sunday in New York — the weekday flips, not just the hour."""
+        from cqc_lem.utilities.post_stats import recommend_post_times
+        rows = [self._row(dt.datetime(2026, 7, 6, 1, 0), 100),
+                self._row(dt.datetime(2026, 7, 13, 1, 0), 100),
+                self._row(dt.datetime(2026, 7, 20, 1, 0), 100)]
+        top = recommend_post_times(rows, top_n=1, min_posts=3, tz="America/New_York")[0]
+        assert top["weekday"] == "Sunday"
+        assert top["hour"] == 21
+
+    def test_defaults_to_utc_when_tz_omitted(self):
+        from cqc_lem.utilities.post_stats import recommend_post_times
+        rows = [self._row(dt.datetime(2026, 7, 4, 20, 0), 100),
+                self._row(dt.datetime(2026, 7, 4, 21, 0), 1),
+                self._row(dt.datetime(2026, 7, 4, 22, 0), 1)]
+        assert recommend_post_times(rows, top_n=1, min_posts=3)[0]["hour"] == 20
+
+    def test_unknown_tz_falls_back_to_utc_instead_of_raising(self):
+        from cqc_lem.utilities.post_stats import recommend_post_times
+        rows = [self._row(dt.datetime(2026, 7, 4, 20, 0), 100),
+                self._row(dt.datetime(2026, 7, 4, 21, 0), 1),
+                self._row(dt.datetime(2026, 7, 4, 22, 0), 1)]
+        assert recommend_post_times(rows, top_n=1, min_posts=3, tz="Mars/Olympus")[0]["hour"] == 20
+
+    def test_get_post_time_asks_for_the_users_zone(self):
+        """The learned hour must come back as a LOCAL time, because plan_content_for_user converts
+        it local->UTC before storing."""
+        from cqc_lem.utilities.utils import get_post_time
+        recs = [{"weekday_num": 5, "hour": 16, "sample": 3}]
+        with patch("cqc_lem.utilities.db.get_post_engagement_rows", return_value=[object()]), \
+             patch("cqc_lem.utilities.db.get_user_timezone", return_value="America/New_York"), \
+             patch("cqc_lem.utilities.post_stats.recommend_post_times", return_value=recs) as rec:
+            result = get_post_time(dt.date(2026, 7, 4), user_id=1)
+        assert result.hour == 16
+        assert rec.call_args.kwargs["tz"] == "America/New_York"

--- a/tests/unit/utilities/test_utils_coverage.py
+++ b/tests/unit/utilities/test_utils_coverage.py
@@ -215,6 +215,7 @@ class TestGetPostTime:
         # 2026-07-08 is a Wednesday (weekday 2); default is 16:00
         recs = [{"weekday_num": 2, "hour": 9}]
         with patch("cqc_lem.utilities.db.get_post_engagement_rows", return_value=[]), \
+             patch("cqc_lem.utilities.db.get_user_timezone", return_value="America/New_York"), \
              patch("cqc_lem.utilities.post_stats.recommend_post_times", return_value=recs):
             assert get_post_time(date(2026, 7, 8), user_id=1) == time(9, 0)
 


### PR DESCRIPTION
## What & why

Audits the display → storage → execution path for scheduled posts, newsletter editions and scheduled DMs, writes the contract down, and fixes the places that broke it.

This wasn't cosmetic. Feed commenting fires at `scheduled_time − 15 min` and profile-viewer DMs at `− 10 min`, so a post whose stored instant disagreed with its displayed time dragged the entire golden-hour engagement window along with it.

**The contract** (`docs/timezone-contract.md`): UTC is the only storage and transport zone; the user's IANA timezone is the only display and input zone; conversion happens exactly twice, at the SPA boundary.

## What was actually broken

**Storage — `insert_scheduled_dm` / `update_scheduled_dm` had no normalization at all.** `mysql-connector` serializes a `datetime` from its wall-clock fields and silently drops `tzinfo`, so an aware `14:00-04:00` landed in the column as `14:00` — four hours early, no error raised. Now every scheduling write goes through the new `db.to_naive_utc()`, which also replaces four copies of the same inline conversion in the post writers.

**Scheduling — a double shift.** `recommend_post_times` bucketed posts by their raw *UTC* hour, but `get_post_time` hands that hour straight back to the scheduler as a *local* time to be converted to UTC for storage. A New York user's 4pm winner (21:00 UTC) came back as "21:00 local" and was stored as 02:00 UTC the next day — wrong hour *and* wrong weekday. `recommend_post_times` now takes `tz=` and buckets in the user's zone; `get_post_time` and `/user/post-stats` pass it.

**Transport — missing `Z`.** Newsletter `scheduled_for` / `next_publish` and the scheduled-DM list were serialized as naive ISO, which a browser parses as *local* time. Both now go through `_utc_iso`.

**Display & input — `datetime-local` in the wrong zone.** The Content Studio edit modal sliced the raw UTC ISO into the picker, so the editor showed a different time than the `formatInTimezone` label directly above it. Every save path used `new Date(v).toISOString()`, which reads the value in the *browser's* zone rather than the user's configured one — wrong whenever Login Location and device disagree (travel, VPN, or deliberately targeting another audience). New `toZonedInputValue` / `zonedInputToUtcIso` helpers (DST-correct via `Intl.formatToParts`) now back Content Studio, ComposePost, ScheduledDMs and NewsletterQueue, each labelled with the zone it's editing in.

Verified as already correct and left alone: the `time_zone='+00:00'` session pin (so `NOW()`/`CURDATE()` are UTC), the content-plan local→UTC conversion, `next_publish_datetime`'s DST-safe localize, and the executor re-attaching UTC for the Celery `eta`.

## Testing

`tests/unit/utilities/test_timezone_contract.py` round-trips a picked wall clock through **UI tz → stored UTC → served ISO → displayed tz → executed instant** across 5 zones × 7 dates — both DST transitions, the ambiguous hour after fall-back, and a half-hour offset — asserting zero drift. It also asserts the pre-post engagement window still lands 15/10 minutes before the *displayed* time, that each write normalizes, and that bucketing is tz-aware.

- 5229 unit tests pass (88 new)
- `tsc -b` clean
- eslint: no new findings (the 6 reported on `ContentStudio.tsx` / `NewsletterQueue.tsx` are identical on `main`)

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)