### PR TITLE
ci: scope tokens correctly — auto-merge uses RELEASE_DISPATCH_TOKEN, GHCR_PAT → read:packages

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,17 +5,16 @@ name: Dependabot Auto-Merge
 # change in the group, and our dependabot.yml groups are minor/patch-only, so grouped PRs
 # match the condition below while any major arrives as its own ungrouped PR.
 #
-# Token: uses GHCR_PAT (a PAT with contents:write + pull-requests:write) when present,
-# falling back to GITHUB_TOKEN. A PAT is needed because auto-merge enabled via the built-in
-# GITHUB_TOKEN does not reliably enter this repo's merge queue (bot-token actions don't kick
-# the queue) — the PAT behaves like a human enqueue, which is what actually drains it.
+# Token: uses RELEASE_DISPATCH_TOKEN (a fine-grained PAT with Contents:R/W + Pull requests:R/W)
+# when present, falling back to GITHUB_TOKEN. A PAT is needed because auto-merge enabled via the
+# built-in GITHUB_TOKEN does not reliably enter this repo's merge queue (bot-token actions don't
+# kick the queue) — the PAT behaves like a human enqueue, which is what actually drains it.
 #
 # NOTE: this job runs in the DEPENDABOT event context, which can ONLY read secrets from the
-# *Dependabot* secret store — not Actions secrets. GHCR_PAT currently lives only in the
-# Actions store, so here it resolves empty and this job falls back to GITHUB_TOKEN. To make
-# the event-driven auto-merge use the PAT too, also add GHCR_PAT under Settings → Secrets →
-# Dependabot. Not required for correctness: the scheduled reconciler (Actions context, which
-# CAN read GHCR_PAT) sweeps up ready PRs every 6h regardless.
+# *Dependabot* secret store — not Actions secrets. RELEASE_DISPATCH_TOKEN is set in BOTH the
+# Dependabot and the Actions stores, so the event-driven path uses the PAT here (and the
+# scheduled reconciler reads the Actions copy). GHCR_PAT is intentionally NOT used for merging
+# anymore — it is now scoped to read:packages only, for VPS image pulls.
 
 on:
   pull_request:
@@ -54,4 +53,4 @@ jobs:
         run: gh pr merge --auto "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-merge-reconciler.yml
+++ b/.github/workflows/dependabot-merge-reconciler.yml
@@ -5,7 +5,7 @@ name: Dependabot Merge Reconciler
 # and this one is rebased); the re-enqueue can then be missed, and GITHUB_TOKEN-enabled
 # auto-merge doesn't reliably enter the merge queue. This job re-enqueues Dependabot PRs that
 # ALREADY have auto-merge enabled (the auto-merge workflow only enables it for minor/patch —
-# MAJOR bumps never get it, so this never merges a major) using GHCR_PAT.
+# MAJOR bumps never get it, so this never merges a major) using RELEASE_DISPATCH_TOKEN.
 
 on:
   schedule:
@@ -21,15 +21,15 @@ jobs:
     name: Re-enqueue ready Dependabot PRs
     runs-on: ubuntu-latest
     env:
-      # Actions context → reads GHCR_PAT (contents+PR write) directly. Falls back to GITHUB_TOKEN.
-      GH_TOKEN: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
+      # Actions context → reads RELEASE_DISPATCH_TOKEN (Contents+PR write) directly. Falls back to GITHUB_TOKEN.
+      GH_TOKEN: ${{ secrets.RELEASE_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
       REPO: ${{ github.repository }}
     steps:
       - name: Verify merge-token scope
         run: |
           echo "Authenticated as: $(gh api user --jq .login 2>&1 || echo '<unknown>')"
           echo "Token permissions on $REPO: $(gh api "repos/$REPO" --jq '.permissions' 2>&1 || echo '<none>')"
-          echo "(push=true or admin=true means the token can merge; false ⇒ GHCR_PAT lacks contents/PR write.)"
+          echo "(push=true or admin=true means the token can merge; false ⇒ RELEASE_DISPATCH_TOKEN lacks contents/PR write.)"
 
       - name: Re-enqueue auto-merge-enabled Dependabot PRs
         run: |

--- a/.github/workflows/release-auto-merge.yml
+++ b/.github/workflows/release-auto-merge.yml
@@ -1,9 +1,9 @@
 name: Auto-merge Release PRs
 
 # Enables auto-merge on release-please PRs so a green release merges itself -> tag -> build -> VPS deploy,
-# with no manual "Merge when ready" click. Mirrors dependabot-auto-merge.yml: uses GHCR_PAT when present
-# (a PAT behaves like a human enqueue and reliably drains this repo's merge queue; the built-in
-# GITHUB_TOKEN from a bot action does not). No strategy flag — the merge queue fixes the strategy.
+# with no manual "Merge when ready" click. Mirrors dependabot-auto-merge.yml: uses RELEASE_DISPATCH_TOKEN
+# when present (a PAT behaves like a human enqueue and reliably drains this repo's merge queue; the
+# built-in GITHUB_TOKEN from a bot action does not). No strategy flag — the merge queue fixes the strategy.
 
 on:
   pull_request:
@@ -26,4 +26,4 @@ jobs:
         run: gh pr merge --auto "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GHCR_PAT || secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why
Finalizes the three-token split so each token is minimally scoped and only on the system that needs it:

| Token | Lives on | Scope | Job |
|---|---|---|---|
| `RELEASE_DISPATCH_TOKEN` | Actions + Dependabot | Contents R/W, PRs R/W | release-please PR authoring **+ auto-merge** |
| `GHCR_PAT` | Actions → VPS (docker config) | **read:packages only** | VPS image pull |
| `FEEDBACK_GITHUB_TOKEN` | VPS `/opt/lem/.env` | Issues R/W | feedback → GitHub issues |

Previously the auto-merge workflows read `secrets.GHCR_PAT` for `gh pr merge`, which forced `GHCR_PAT` to carry contents+PR write. Since `GHCR_PAT` is shipped to the VPS and persists in `/home/deploy/.docker/config.json`, that left a code-push-capable credential on the LinkedIn-scraping box. This change points auto-merge at `RELEASE_DISPATCH_TOKEN` so `GHCR_PAT` can be re-scoped to `read:packages` only.

## What changed
`secrets.GHCR_PAT` → `secrets.RELEASE_DISPATCH_TOKEN` in the `GH_TOKEN` of:
- `release-auto-merge.yml`
- `dependabot-auto-merge.yml` (event-driven path — now uses the Dependabot-store PAT copy instead of falling back to `GITHUB_TOKEN`)
- `dependabot-merge-reconciler.yml`

Comments updated to match. No change to `release-please.yml` or the VPS pull in `build-and-push.yml`/`deploy-vps.yml`.

## Prereqs (already done by owner, verified)
- `RELEASE_DISPATCH_TOKEN` present in **both** Actions and Dependabot secret stores (both stamped 2026-07-25 20:23).
- `GHCR_PAT` re-scoped to read:packages (owner to confirm on the GitHub token). Safe because the VPS only pulls; the image push in Actions uses `GITHUB_TOKEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)