### PR TITLE
fix(engagement): reliable pre-post feed-commenting window + per-post observability (closes #547)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -54,6 +54,7 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     get_engager_candidates, get_profile_facts, count_invites_sent_today, ConnectionRequestStatus, \
     CatchupTouchStatus, insert_catchup_touch, has_catchup_touch, get_catchup_touch, \
     update_catchup_touch_status, count_catchup_touches_sent_today, max_catchup_touches_allowed
+from cqc_lem.utilities.engagement_window import record_pre_post_run
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
     load_profile_for_user
@@ -1915,7 +1916,12 @@ def auto_post_to_group(self, user_id: int, group_id: str):
 
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
                   queue='se_engage')
-def automate_commenting(self, user_id: int, loop_for_duration: int = None, future_forward: int = 60):
+def automate_commenting(self, user_id: int, loop_for_duration: int = None, future_forward: int = 60,
+                        post_id: int = None):
+    """Walk the feed and comment. `post_id` is set only by the pre-post warm-up dispatch
+    (auto_check_scheduled_posts) — it makes each pass record a per-post engagement-window marker so
+    a report can confirm the warm-up before that post actually happened (issue #547). It rides the
+    self-requeue kwargs, so every pass in the window accumulates onto the same marker."""
     global stop_all_thread
 
     myprint("Starting Automate Commenting Thread...")
@@ -1928,6 +1934,10 @@ def automate_commenting(self, user_id: int, loop_for_duration: int = None, futur
     if lock_token is None:
         myprint(f"Another commenting run is in progress for user {user_id} — skipping this cycle.")
         return "Skipped: another commenting run already in progress for this user."
+
+    if post_id:
+        log_info("Pre-post engagement window opened", post_id=post_id, user_id=user_id,
+                 task_name="automate_commenting")
 
     try:
         driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Auto Commenting")
@@ -1950,6 +1960,9 @@ def automate_commenting(self, user_id: int, loop_for_duration: int = None, futur
                                                       max_posts=10, deadline_ts=deadline_ts)
 
         result = f"Automate Commenting Task Completed. Commented on {post_commented_count} posts."
+
+        if post_id:
+            record_pre_post_run(post_id, user_id, post_commented_count)
 
         # Re-schedule the task in the queue for the future
         if loop_for_duration:

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -22,6 +22,11 @@ from cqc_lem.utilities.db import (
     get_approved_catchup_touches, get_orphaned_catchup_touches, update_catchup_touch_status,
     count_catchup_touches_sent_today, CatchupTouchStatus, max_catchup_touches_allowed,
 )
+from cqc_lem.utilities.engagement_window import (
+    plan_pre_post_window, record_pre_post_scheduled, record_pre_post_skipped,
+    PRE_POST_COMMENT_LEAD_MINUTES, PRE_POST_VIEWER_LEAD_MINUTES,
+    PRE_POST_SKIP_PAST_WINDOW, PRE_POST_SKIP_THROTTLED, PRE_POST_SKIP_USER_INACTIVE,
+)
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES, \
     COST_ROUTING_WINDOW_DAYS
 from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
@@ -31,7 +36,7 @@ from cqc_lem.utilities.notifications import notify_linkedin_session
 from cqc_lem.utilities.observability import attribute_llm_cost, llm_attribution, FEATURE_NEWSLETTER
 
 
-def _skip_if_throttled(name: str) -> bool:
+def _skip_if_throttled(name: str, **context) -> bool:
     """True when Selenium engagement should NOT fan out — either a manual automation pause OR an open
     429 circuit breaker cooldown is active. Beat dispatchers short-circuit on both so a rate-limited
     account isn't hammered: login_to_linkedin gates centrally too, but skipping at dispatch avoids
@@ -39,11 +44,11 @@ def _skip_if_throttled(name: str) -> bool:
     feed the instant the cooldown expires, which is what re-tripped the breaker into a doom loop.
     POSTING is API-driven and deliberately NOT gated."""
     if is_automation_paused():
-        log_info(f"{name} skipped — automation paused (~{automation_pause_remaining()}s left)")
+        log_info(f"{name} skipped — automation paused (~{automation_pause_remaining()}s left)", **context)
         return True
     cooldown = rate_limit_cooldown_remaining()
     if cooldown > 0:
-        log_info(f"{name} skipped — LinkedIn 429 breaker open (~{cooldown}s left)")
+        log_info(f"{name} skipped — LinkedIn 429 breaker open (~{cooldown}s left)", **context)
         return True
     return False
 
@@ -86,19 +91,42 @@ def auto_check_scheduled_posts(self):
                 "Skipping pre-post Selenium tasks — user not active/connected",
                 user_id=user_id, post_id=post_id, task_name="auto_check_scheduled_posts",
             )
-        elif not _skip_if_throttled("pre-post Selenium"):
-            base_kwargs = {'user_id': user_id, 'loop_for_duration': 60 * 15}
-
-            # Start the pre-post commenting task 15 minutes before scheduled post (loop for 15 minutes)
-            automate_commenting.apply_async(kwargs=base_kwargs, eta=scheduled_time - timedelta(minutes=15))
+            record_pre_post_skipped(post_id, user_id, PRE_POST_SKIP_USER_INACTIVE)
+        elif _skip_if_throttled("pre-post Selenium", user_id=user_id, post_id=post_id,
+                                task_name="auto_check_scheduled_posts"):
+            record_pre_post_skipped(post_id, user_id, PRE_POST_SKIP_THROTTLED)
+        else:
+            # Warm up the feed BEFORE the post goes live. A post picked up late (this scan looks back
+            # to yesterday) has less than the full lead left — or none at all — so the window is
+            # clamped rather than dispatched with an eta in the past, which Celery would run
+            # immediately and turn a "pre"-post warm-up into a during/after-post one.
+            comment_window = plan_pre_post_window(scheduled_time, PRE_POST_COMMENT_LEAD_MINUTES)
+            if comment_window is None:
+                record_pre_post_skipped(post_id, user_id, PRE_POST_SKIP_PAST_WINDOW)
+            else:
+                automate_commenting.apply_async(
+                    kwargs={'user_id': user_id, 'loop_for_duration': comment_window.duration_seconds,
+                            'post_id': post_id},
+                    eta=comment_window.eta,
+                )
+                record_pre_post_scheduled(post_id, user_id, comment_window)
 
             # The seed first comment is dispatched by post_to_linkedin itself once the post is live —
             # it needs the published post's URL, and (being API-driven) it must not be gated on the
             # Selenium throttle/active checks that guard the browser tasks here.
 
-            # Schedule the pre-post profile viewer dm task 10 minutes before scheduled post (loop for 10 minutes)
-            base_kwargs['loop_for_duration'] = 60 * 10
-            automate_profile_viewer_engagement.apply_async(kwargs=base_kwargs, eta=scheduled_time - timedelta(minutes=10))
+            # Same clamp for the pre-post profile-viewer DM task (10-minute lead).
+            viewer_window = plan_pre_post_window(scheduled_time, PRE_POST_VIEWER_LEAD_MINUTES)
+            if viewer_window is None:
+                record_pre_post_skipped(post_id, user_id, PRE_POST_SKIP_PAST_WINDOW,
+                                        task_name="automate_profile_viewer_engagement")
+            else:
+                automate_profile_viewer_engagement.apply_async(
+                    kwargs={'user_id': user_id, 'loop_for_duration': viewer_window.duration_seconds},
+                    eta=viewer_window.eta,
+                )
+                record_pre_post_scheduled(post_id, user_id, viewer_window,
+                                          task_name="automate_profile_viewer_engagement")
 
     # Re-queue any posts that got stuck in 'scheduled' (task was lost, e.g. on container restart)
     # but never transitioned to 'posted'. The 2-hour gap ensures we don't race with a task

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -26,6 +26,7 @@ from cqc_lem.utilities.engagement_window import (
     plan_pre_post_window, record_pre_post_scheduled, record_pre_post_skipped,
     PRE_POST_COMMENT_LEAD_MINUTES, PRE_POST_VIEWER_LEAD_MINUTES,
     PRE_POST_SKIP_PAST_WINDOW, PRE_POST_SKIP_THROTTLED, PRE_POST_SKIP_USER_INACTIVE,
+    PRE_POST_TASK_VIEWER,
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES, \
     COST_ROUTING_WINDOW_DAYS
@@ -119,14 +120,14 @@ def auto_check_scheduled_posts(self):
             viewer_window = plan_pre_post_window(scheduled_time, PRE_POST_VIEWER_LEAD_MINUTES)
             if viewer_window is None:
                 record_pre_post_skipped(post_id, user_id, PRE_POST_SKIP_PAST_WINDOW,
-                                        task_name="automate_profile_viewer_engagement")
+                                        task_name=PRE_POST_TASK_VIEWER)
             else:
                 automate_profile_viewer_engagement.apply_async(
                     kwargs={'user_id': user_id, 'loop_for_duration': viewer_window.duration_seconds},
                     eta=viewer_window.eta,
                 )
                 record_pre_post_scheduled(post_id, user_id, viewer_window,
-                                          task_name="automate_profile_viewer_engagement")
+                                          task_name=PRE_POST_TASK_VIEWER)
 
     # Re-queue any posts that got stuck in 'scheduled' (task was lost, e.g. on container restart)
     # but never transitioned to 'posted'. The 2-hour gap ensures we don't race with a task

--- a/src/cqc_lem/utilities/engagement_window.py
+++ b/src/cqc_lem/utilities/engagement_window.py
@@ -1,0 +1,182 @@
+"""Pre-post engagement window (issue #547).
+
+The engagement-hacking intent behind the pre-post feed-commenting run is to be *active on the feed
+right before your own post publishes*. Two things kept that from being true in practice:
+
+1. `auto_check_scheduled_posts` looks back to "yesterday", so a post picked up at (or after) its
+   scheduled time produced an `eta` in the PAST — Celery then fired a "pre"-post warm-up loop that
+   ran DURING or AFTER publication. `plan_pre_post_window` clamps that: it fires ASAP (with a
+   shortened loop that still ends at the post time) when there is meaningfully less than the full
+   lead left, and returns None — don't dispatch at all — once the window has effectively closed.
+2. Nothing recorded whether the warm-up actually ran for a given post, so the window could not be
+   verified after the fact. The marker helpers below keep a small per-post stat in Redis (the same
+   runtime-state store the 429 breaker uses, so it survives deploys) alongside a PostHog event.
+
+Every marker helper fails OPEN: no Redis (or a Redis error) degrades to logging only, never to a
+failed dispatch.
+"""
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from cqc_lem.utilities.linkedin.rate_limit import shared_redis_client
+from cqc_lem.utilities.logger import log_info, log_warning
+from cqc_lem.utilities.observability import track_pre_post_engagement
+
+# Lead times the scheduler warms up with, kept here next to the planner that clamps them.
+PRE_POST_COMMENT_LEAD_MINUTES = 15
+PRE_POST_VIEWER_LEAD_MINUTES = 10
+
+# A warm-up shorter than this isn't engagement — it's one page load that lands on top of (or after)
+# the publish itself, so the window is treated as closed instead.
+MIN_PRE_POST_WINDOW_SECONDS = 120
+
+_MARKER_PREFIX = "engagement:prepost:"
+_MARKER_TTL_SECONDS = 7 * 24 * 60 * 60  # long enough for a weekly report to read it back
+
+PRE_POST_STATUS_SCHEDULED = "scheduled"
+PRE_POST_STATUS_SKIPPED = "skipped"
+
+# Skip reasons — stable strings so a report/dashboard can group by them.
+PRE_POST_SKIP_PAST_WINDOW = "past_window"
+PRE_POST_SKIP_THROTTLED = "throttled"
+PRE_POST_SKIP_USER_INACTIVE = "user_inactive"
+
+
+@dataclass(frozen=True)
+class PrePostWindow:
+    """When the pre-post engagement loop should start, and how long it may run."""
+
+    eta: datetime
+    duration_seconds: int
+    clamped: bool
+
+
+def _as_utc(value: datetime) -> datetime:
+    return value.replace(tzinfo=timezone.utc) if value.tzinfo is None else value
+
+
+def plan_pre_post_window(scheduled_time: datetime, lead_minutes: int,
+                         now: Optional[datetime] = None,
+                         min_window_seconds: int = MIN_PRE_POST_WINDOW_SECONDS) -> Optional[PrePostWindow]:
+    """The eta + loop duration for a pre-post engagement task, or None when the window has closed.
+
+    Full lead available → start exactly `lead_minutes` before the post. Less than that (a late
+    pickup) → start now and shorten the loop so it still ends at the post time rather than running
+    past it. At/after the post time — or too close to warm up meaningfully — → None.
+    """
+    now = _as_utc(now if now is not None else datetime.now(timezone.utc))
+    scheduled_time = _as_utc(scheduled_time)
+
+    lead_seconds = max(0, int(lead_minutes) * 60)
+    remaining = (scheduled_time - now).total_seconds()
+
+    if remaining <= max(0, int(min_window_seconds)):
+        return None
+
+    if remaining >= lead_seconds:
+        return PrePostWindow(eta=scheduled_time - timedelta(seconds=lead_seconds),
+                             duration_seconds=lead_seconds, clamped=False)
+
+    return PrePostWindow(eta=now, duration_seconds=int(remaining), clamped=True)
+
+
+def _marker_key(post_id: int) -> str:
+    return f"{_MARKER_PREFIX}{int(post_id)}"
+
+
+def _write_marker(post_id: int, fields: dict, increments: Optional[dict] = None) -> None:
+    client = shared_redis_client()
+    if client is None:
+        return
+    key = _marker_key(post_id)
+    try:
+        if fields:
+            client.hset(key, mapping={k: str(v) for k, v in fields.items() if v is not None})
+        for field, amount in (increments or {}).items():
+            client.hincrby(key, field, int(amount))
+        client.expire(key, _MARKER_TTL_SECONDS)
+    except Exception as e:
+        log_warning("Could not record pre-post engagement marker", exc=e, post_id=post_id)
+
+
+def record_pre_post_scheduled(post_id: int, user_id: int, window: PrePostWindow,
+                              task_name: str = "automate_commenting") -> None:
+    """Mark that the pre-post engagement window was dispatched for this post."""
+    log_info(
+        f"Pre-post engagement window scheduled for {window.eta.isoformat()} "
+        f"({window.duration_seconds}s{', clamped' if window.clamped else ''})",
+        post_id=post_id, user_id=user_id, task_name=task_name,
+    )
+    _write_marker(post_id, {
+        "user_id": user_id,
+        "status": PRE_POST_STATUS_SCHEDULED,
+        "task_name": task_name,
+        "eta": window.eta.isoformat(),
+        "window_seconds": window.duration_seconds,
+        "clamped": int(window.clamped),
+    })
+    track_pre_post_engagement(post_id, user_id, PRE_POST_STATUS_SCHEDULED, task_name=task_name,
+                              eta=window.eta.isoformat(), window_seconds=window.duration_seconds,
+                              clamped=window.clamped)
+
+
+def record_pre_post_skipped(post_id: int, user_id: int, reason: str,
+                            task_name: str = "automate_commenting") -> None:
+    """Mark that no pre-post engagement ran for this post, and why (throttle, inactive user, or a
+    window that already closed) — the skip is as important to a report as the run."""
+    log_warning(f"Pre-post engagement window skipped — {reason}",
+                post_id=post_id, user_id=user_id, task_name=task_name)
+    _write_marker(post_id, {
+        "user_id": user_id,
+        "status": PRE_POST_STATUS_SKIPPED,
+        "task_name": task_name,
+        "skip_reason": reason,
+    })
+    track_pre_post_engagement(post_id, user_id, PRE_POST_STATUS_SKIPPED, task_name=task_name,
+                              skip_reason=reason)
+
+
+def record_pre_post_run(post_id: int, user_id: int, comments: int,
+                        now: Optional[datetime] = None) -> None:
+    """Record one completed pre-post engagement pass and the comments it left. The loop re-queues
+    itself across the window, so runs/comments ACCUMULATE — the marker answers "pre-post commenting
+    ran N times for post X and left M comments"."""
+    ran_at = _as_utc(now if now is not None else datetime.now(timezone.utc))
+    log_info(f"Pre-post engagement pass complete — {comments} comment(s)",
+             post_id=post_id, user_id=user_id, task_name="automate_commenting")
+    _write_marker(post_id,
+                  {"user_id": user_id, "last_run_at": ran_at.isoformat()},
+                  {"runs": 1, "comments": max(0, int(comments or 0))})
+    track_pre_post_engagement(post_id, user_id, "ran", comments=int(comments or 0),
+                              ran_at=ran_at.isoformat())
+
+
+def get_pre_post_window_stat(post_id: int) -> dict:
+    """Read back a post's engagement-window marker (empty dict when unknown / Redis unavailable)."""
+    client = shared_redis_client()
+    if client is None:
+        return {}
+    try:
+        raw = client.hgetall(_marker_key(post_id))
+    except Exception as e:
+        log_warning("Could not read pre-post engagement marker", exc=e, post_id=post_id)
+        return {}
+    if not raw:
+        return {}
+
+    stat = {}
+    for key, value in raw.items():
+        name = key.decode("utf-8", "ignore") if isinstance(key, bytes) else str(key)
+        text = value.decode("utf-8", "ignore") if isinstance(value, bytes) else str(value)
+        stat[name] = text
+    for numeric in ("runs", "comments", "window_seconds", "user_id", "clamped"):
+        if numeric in stat:
+            try:
+                stat[numeric] = int(stat[numeric])
+            except ValueError:
+                pass
+    stat.setdefault("runs", 0)
+    stat.setdefault("comments", 0)
+    return stat

--- a/src/cqc_lem/utilities/engagement_window.py
+++ b/src/cqc_lem/utilities/engagement_window.py
@@ -43,6 +43,12 @@ PRE_POST_SKIP_PAST_WINDOW = "past_window"
 PRE_POST_SKIP_THROTTLED = "throttled"
 PRE_POST_SKIP_USER_INACTIVE = "user_inactive"
 
+# The task each marker belongs to. One post dispatches BOTH pre-post tasks, so the marker is keyed
+# per task — otherwise the viewer dispatch (written second) would clobber the commenting window's
+# eta/window_seconds/clamped and the read-back would describe the wrong task.
+PRE_POST_TASK_COMMENTING = "automate_commenting"
+PRE_POST_TASK_VIEWER = "automate_profile_viewer_engagement"
+
 
 @dataclass(frozen=True)
 class PrePostWindow:
@@ -82,15 +88,16 @@ def plan_pre_post_window(scheduled_time: datetime, lead_minutes: int,
     return PrePostWindow(eta=now, duration_seconds=int(remaining), clamped=True)
 
 
-def _marker_key(post_id: int) -> str:
-    return f"{_MARKER_PREFIX}{int(post_id)}"
+def _marker_key(post_id: int, task_name: str = PRE_POST_TASK_COMMENTING) -> str:
+    return f"{_MARKER_PREFIX}{int(post_id)}:{task_name}"
 
 
-def _write_marker(post_id: int, fields: dict, increments: Optional[dict] = None) -> None:
+def _write_marker(post_id: int, task_name: str, fields: dict,
+                  increments: Optional[dict] = None) -> None:
     client = shared_redis_client()
     if client is None:
         return
-    key = _marker_key(post_id)
+    key = _marker_key(post_id, task_name)
     try:
         if fields:
             client.hset(key, mapping={k: str(v) for k, v in fields.items() if v is not None})
@@ -102,14 +109,14 @@ def _write_marker(post_id: int, fields: dict, increments: Optional[dict] = None)
 
 
 def record_pre_post_scheduled(post_id: int, user_id: int, window: PrePostWindow,
-                              task_name: str = "automate_commenting") -> None:
+                              task_name: str = PRE_POST_TASK_COMMENTING) -> None:
     """Mark that the pre-post engagement window was dispatched for this post."""
     log_info(
         f"Pre-post engagement window scheduled for {window.eta.isoformat()} "
         f"({window.duration_seconds}s{', clamped' if window.clamped else ''})",
         post_id=post_id, user_id=user_id, task_name=task_name,
     )
-    _write_marker(post_id, {
+    _write_marker(post_id, task_name, {
         "user_id": user_id,
         "status": PRE_POST_STATUS_SCHEDULED,
         "task_name": task_name,
@@ -123,12 +130,12 @@ def record_pre_post_scheduled(post_id: int, user_id: int, window: PrePostWindow,
 
 
 def record_pre_post_skipped(post_id: int, user_id: int, reason: str,
-                            task_name: str = "automate_commenting") -> None:
+                            task_name: str = PRE_POST_TASK_COMMENTING) -> None:
     """Mark that no pre-post engagement ran for this post, and why (throttle, inactive user, or a
     window that already closed) — the skip is as important to a report as the run."""
     log_warning(f"Pre-post engagement window skipped — {reason}",
                 post_id=post_id, user_id=user_id, task_name=task_name)
-    _write_marker(post_id, {
+    _write_marker(post_id, task_name, {
         "user_id": user_id,
         "status": PRE_POST_STATUS_SKIPPED,
         "task_name": task_name,
@@ -138,28 +145,29 @@ def record_pre_post_skipped(post_id: int, user_id: int, reason: str,
                               skip_reason=reason)
 
 
-def record_pre_post_run(post_id: int, user_id: int, comments: int,
+def record_pre_post_run(post_id: int, user_id: int, comments: Optional[int],
                         now: Optional[datetime] = None) -> None:
     """Record one completed pre-post engagement pass and the comments it left. The loop re-queues
     itself across the window, so runs/comments ACCUMULATE — the marker answers "pre-post commenting
     ran N times for post X and left M comments"."""
     ran_at = _as_utc(now if now is not None else datetime.now(timezone.utc))
     log_info(f"Pre-post engagement pass complete — {comments} comment(s)",
-             post_id=post_id, user_id=user_id, task_name="automate_commenting")
-    _write_marker(post_id,
+             post_id=post_id, user_id=user_id, task_name=PRE_POST_TASK_COMMENTING)
+    _write_marker(post_id, PRE_POST_TASK_COMMENTING,
                   {"user_id": user_id, "last_run_at": ran_at.isoformat()},
                   {"runs": 1, "comments": max(0, int(comments or 0))})
     track_pre_post_engagement(post_id, user_id, "ran", comments=int(comments or 0),
                               ran_at=ran_at.isoformat())
 
 
-def get_pre_post_window_stat(post_id: int) -> dict:
-    """Read back a post's engagement-window marker (empty dict when unknown / Redis unavailable)."""
+def get_pre_post_window_stat(post_id: int, task_name: str = PRE_POST_TASK_COMMENTING) -> dict:
+    """Read back a post's engagement-window marker for one pre-post task (defaults to feed
+    commenting; empty dict when unknown / Redis unavailable)."""
     client = shared_redis_client()
     if client is None:
         return {}
     try:
-        raw = client.hgetall(_marker_key(post_id))
+        raw = client.hgetall(_marker_key(post_id, task_name))
     except Exception as e:
         log_warning("Could not read pre-post engagement marker", exc=e, post_id=post_id)
         return {}
@@ -176,7 +184,9 @@ def get_pre_post_window_stat(post_id: int) -> dict:
             try:
                 stat[numeric] = int(stat[numeric])
             except ValueError:
-                pass
+                # A marker field is only ever observability data — a corrupt/non-numeric value is
+                # surfaced verbatim rather than dropped, so a reader can see what was actually there.
+                continue
     stat.setdefault("runs", 0)
     stat.setdefault("comments", 0)
     return stat

--- a/src/cqc_lem/utilities/linkedin/rate_limit.py
+++ b/src/cqc_lem/utilities/linkedin/rate_limit.py
@@ -77,6 +77,12 @@ def _redis_client():
         return None
 
 
+def shared_redis_client():
+    """Public handle to the same Redis this breaker uses (None when unavailable), so other
+    runtime-state helpers reuse one URL-resolution rule instead of re-deriving it."""
+    return _redis_client()
+
+
 def mark_rate_limited(reason: str = "") -> None:
     client = _redis_client()
     if client is None:

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -473,6 +473,22 @@ def track_post_outcome(
     )
 
 
+def track_pre_post_engagement(post_id: int, user_id: Optional[int], status: str, **extra) -> None:
+    """Emit the per-post pre-post engagement-window marker (issue #547) — dispatched, skipped (with
+    the reason) or ran (with the comment count) — so a report can confirm the warm-up before a post
+    actually fired instead of inferring it from task logs."""
+    posthog.capture(
+        distinct_id=str(user_id or "system"),
+        event="pre_post_engagement",
+        properties={
+            "post_id": post_id,
+            "user_id": user_id,
+            "status": status,
+            **extra,
+        },
+    )
+
+
 def track_margin_report(report: dict) -> None:
     """Emit the weekly unit-economics scorecard (plan §E.1.4) as one `margin_report` event so the
     PostHog tiles read system margin, cohort margin and LTV:CAC without re-deriving them. Per-user

--- a/tests/unit/app/test_pre_post_engagement_marker.py
+++ b/tests/unit/app/test_pre_post_engagement_marker.py
@@ -1,0 +1,62 @@
+"""Unit tests for the per-post pre-post engagement marker in automate_commenting (issue #547)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.app.run_automation"
+
+
+@pytest.fixture
+def commenting_env():
+    """Patch away Selenium/LinkedIn so only the marker wiring is under test."""
+    with patch(f"{_MOD}.get_current_profile", return_value=(MagicMock(), MagicMock(), "a@b.c", MagicMock())), \
+         patch(f"{_MOD}.navigate_to_feed"), \
+         patch(f"{_MOD}.quit_gracefully"), \
+         patch(f"{_MOD}.comment_on_feed_inline", return_value=3) as feed, \
+         patch(f"{_MOD}.record_pre_post_run") as record:
+        yield feed, record
+
+
+class TestPrePostEngagementMarker:
+    def test_records_run_when_dispatched_for_a_post(self, commenting_env):
+        _, record = commenting_env
+        from cqc_lem.app.run_automation import automate_commenting
+
+        automate_commenting.run(user_id=7, post_id=42)
+
+        record.assert_called_once_with(42, 7, 3)
+
+    def test_no_marker_for_the_daily_golden_hour_run(self, commenting_env):
+        """The daily/golden-hour run has no post to attribute to — it must not write a marker."""
+        _, record = commenting_env
+        from cqc_lem.app.run_automation import automate_commenting
+
+        automate_commenting.run(user_id=7)
+
+        record.assert_not_called()
+
+    def test_post_id_rides_the_self_requeue(self, commenting_env):
+        """The window is walked by a self-requeueing loop, so post_id must survive each hop or
+        only the first pass would be recorded."""
+        from cqc_lem.app.run_automation import automate_commenting
+
+        with patch.object(automate_commenting, "apply_async") as requeue:
+            automate_commenting.run(user_id=7, loop_for_duration=900, post_id=42)
+
+        requeue.assert_called_once()
+        kwargs = requeue.call_args[1]["kwargs"]
+        assert kwargs["post_id"] == 42
+        assert kwargs["user_id"] == 7
+        assert kwargs["loop_for_duration"] < 900
+
+    def test_marker_not_written_when_another_run_holds_the_lock(self, commenting_env):
+        _, record = commenting_env
+        from cqc_lem.app.run_automation import automate_commenting
+
+        with patch(f"{_MOD}.acquire_run_lock", return_value=None):
+            result = automate_commenting.run(user_id=7, post_id=42)
+
+        assert "Skipped" in result
+        record.assert_not_called()

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -1,7 +1,7 @@
 """Unit tests for cqc_lem.app.run_scheduler Celery tasks."""
 
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 pytestmark = pytest.mark.unit
@@ -29,6 +29,8 @@ _PATCH_CLEAN_INVITES = f"{_MOD}.clean_stale_invites"
 _PATCH_UPDATE_STALE = f"{_MOD}.update_stale_profile"
 _PATCH_AUTOMATE_COMMENTING = f"{_MOD}.automate_commenting"
 _PATCH_AUTOMATE_PROFILE_VIEWER = f"{_MOD}.automate_profile_viewer_engagement"
+_PATCH_RECORD_SCHEDULED = f"{_MOD}.record_pre_post_scheduled"
+_PATCH_RECORD_SKIPPED = f"{_MOD}.record_pre_post_skipped"
 
 
 @pytest.fixture(autouse=True)
@@ -49,6 +51,11 @@ def _async_task_mock() -> MagicMock:
     m = MagicMock()
     m.apply_async = MagicMock()
     return m
+
+
+def _future_dt(minutes: int = 60) -> datetime:
+    """A scheduled time far enough ahead that the pre-post engagement window is still open."""
+    return datetime.now(timezone.utc) + timedelta(minutes=minutes)
 
 
 # ---------------------------------------------------------------------------
@@ -234,7 +241,8 @@ class TestAutoCheckScheduledPosts:
         assert result == "No Post to Schedule"
 
     def test_one_post_schedules_it_and_calls_apply_async(self):
-        scheduled_dt = datetime(2025, 6, 20, 14, 0, 0, tzinfo=timezone.utc)
+        # Future time: the pre-post warm-up is only dispatched while its window is still open.
+        scheduled_dt = _future_dt()
         posts = [(42, scheduled_dt, 7)]  # (post_id, scheduled_time, user_id)
 
         mock_post_task = _async_task_mock()
@@ -395,7 +403,7 @@ class TestAutoCheckScheduledPosts:
 
     def test_mixed_active_and_inactive_users_filtered_correctly(self):
         """Active users get Selenium tasks; inactive users get only post_to_linkedin."""
-        scheduled_dt = datetime(2025, 6, 20, 14, 0, 0, tzinfo=timezone.utc)
+        scheduled_dt = _future_dt()
         posts = [
             (10, scheduled_dt, 60),   # active user
             (11, scheduled_dt, 70),   # inactive user
@@ -423,6 +431,145 @@ class TestAutoCheckScheduledPosts:
         # Verify the Selenium tasks were for the active user (user_id=60)
         assert mock_commenting_task.apply_async.call_args[1]["kwargs"]["user_id"] == 60
 
+    # -- pre-post engagement window (issue #547) ----------------------------------------------
+
+    def test_full_lead_available_schedules_15_minutes_before_post(self):
+        """With the whole lead left, commenting starts exactly 15 min before and loops 15 min."""
+        scheduled_dt = _future_dt(60)
+        posts = [(42, scheduled_dt, 7)]
+
+        mock_commenting_task = _async_task_mock()
+        mock_profile_task = _async_task_mock()
+
+        with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_GET_ACTIVE, return_value=[7]), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
+             patch(_PATCH_UPDATE_POST_STATUS), \
+             patch(_PATCH_POST_TO_LINKEDIN, _async_task_mock()), \
+             patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
+             patch(_PATCH_AUTOMATE_PROFILE_VIEWER, mock_profile_task):
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            auto_check_scheduled_posts.run()
+
+        call = mock_commenting_task.apply_async.call_args[1]
+        assert call["eta"] == scheduled_dt - timedelta(minutes=15)
+        assert call["kwargs"]["loop_for_duration"] == 15 * 60
+        assert call["kwargs"]["post_id"] == 42  # marker key for per-post observability
+
+        viewer_call = mock_profile_task.apply_async.call_args[1]
+        assert viewer_call["eta"] == scheduled_dt - timedelta(minutes=10)
+        assert viewer_call["kwargs"]["loop_for_duration"] == 10 * 60
+
+    def test_late_pickup_clamps_eta_to_now_and_shortens_loop(self):
+        """A post picked up 5 min before its time gets an eta that is NOT in the past, and a loop
+        that ends at the post time instead of running past it."""
+        scheduled_dt = _future_dt(5)
+        posts = [(43, scheduled_dt, 7)]
+
+        mock_commenting_task = _async_task_mock()
+
+        with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_GET_ACTIVE, return_value=[7]), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
+             patch(_PATCH_UPDATE_POST_STATUS), \
+             patch(_PATCH_POST_TO_LINKEDIN, _async_task_mock()), \
+             patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
+             patch(_PATCH_AUTOMATE_PROFILE_VIEWER, _async_task_mock()):
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            auto_check_scheduled_posts.run()
+
+        call = mock_commenting_task.apply_async.call_args[1]
+        assert call["eta"] <= scheduled_dt
+        assert call["eta"] >= scheduled_dt - timedelta(minutes=15)
+        assert 0 < call["kwargs"]["loop_for_duration"] <= 5 * 60
+
+    def test_post_past_its_time_gets_no_pre_post_tasks(self):
+        """The stale-eta bug: a post already at/past its scheduled time must NOT trigger a
+        'pre'-post warm-up loop that would actually run during/after publication."""
+        scheduled_dt = datetime(2025, 6, 20, 14, 0, 0, tzinfo=timezone.utc)
+        posts = [(44, scheduled_dt, 7)]
+
+        mock_post_task = _async_task_mock()
+        mock_commenting_task = _async_task_mock()
+        mock_profile_task = _async_task_mock()
+
+        with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_GET_ACTIVE, return_value=[7]), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
+             patch(_PATCH_UPDATE_POST_STATUS), \
+             patch(_PATCH_POST_TO_LINKEDIN, mock_post_task), \
+             patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
+             patch(_PATCH_AUTOMATE_PROFILE_VIEWER, mock_profile_task), \
+             patch(_PATCH_RECORD_SKIPPED) as mock_skipped:
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            auto_check_scheduled_posts.run()
+
+        mock_post_task.apply_async.assert_called_once()  # the post itself still publishes
+        mock_commenting_task.apply_async.assert_not_called()
+        mock_profile_task.apply_async.assert_not_called()
+        reasons = {c[0][2] for c in mock_skipped.call_args_list}
+        assert reasons == {"past_window"}
+
+    def test_scheduled_window_is_recorded_per_post(self):
+        """A dispatched window leaves a per-post marker so a report can confirm it fired."""
+        scheduled_dt = _future_dt(60)
+        posts = [(45, scheduled_dt, 7)]
+
+        with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_GET_ACTIVE, return_value=[7]), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
+             patch(_PATCH_UPDATE_POST_STATUS), \
+             patch(_PATCH_POST_TO_LINKEDIN, _async_task_mock()), \
+             patch(_PATCH_AUTOMATE_COMMENTING, _async_task_mock()), \
+             patch(_PATCH_AUTOMATE_PROFILE_VIEWER, _async_task_mock()), \
+             patch(_PATCH_RECORD_SCHEDULED) as mock_scheduled:
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            auto_check_scheduled_posts.run()
+
+        assert mock_scheduled.call_count == 2  # commenting + profile viewer
+        post_ids = {c[0][0] for c in mock_scheduled.call_args_list}
+        assert post_ids == {45}
+
+    def test_throttled_skip_is_recorded_with_reason(self):
+        """A throttle/pause skip is still gated (correct) but must be visible per post."""
+        scheduled_dt = _future_dt(60)
+        posts = [(46, scheduled_dt, 7)]
+
+        mock_commenting_task = _async_task_mock()
+
+        with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_GET_ACTIVE, return_value=[7]), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
+             patch(_PATCH_UPDATE_POST_STATUS), \
+             patch(f"{_MOD}.rate_limit_cooldown_remaining", return_value=900), \
+             patch(_PATCH_POST_TO_LINKEDIN, _async_task_mock()), \
+             patch(_PATCH_AUTOMATE_COMMENTING, mock_commenting_task), \
+             patch(_PATCH_AUTOMATE_PROFILE_VIEWER, _async_task_mock()), \
+             patch(_PATCH_RECORD_SKIPPED) as mock_skipped:
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            auto_check_scheduled_posts.run()
+
+        mock_commenting_task.apply_async.assert_not_called()
+        mock_skipped.assert_called_once()
+        assert mock_skipped.call_args[0][2] == "throttled"
+
+    def test_inactive_user_skip_is_recorded_with_reason(self):
+        scheduled_dt = _future_dt(60)
+        posts = [(47, scheduled_dt, 70)]
+
+        with patch(_PATCH_GET_POSTS, return_value=posts), \
+             patch(_PATCH_GET_ACTIVE, return_value=[60]), \
+             patch(_PATCH_GET_ORPHANED, return_value=[]), \
+             patch(_PATCH_UPDATE_POST_STATUS), \
+             patch(_PATCH_POST_TO_LINKEDIN, _async_task_mock()), \
+             patch(_PATCH_AUTOMATE_COMMENTING, _async_task_mock()), \
+             patch(_PATCH_AUTOMATE_PROFILE_VIEWER, _async_task_mock()), \
+             patch(_PATCH_RECORD_SKIPPED) as mock_skipped:
+            from cqc_lem.app.run_scheduler import auto_check_scheduled_posts
+            auto_check_scheduled_posts.run()
+
+        mock_skipped.assert_called_once()
+        assert mock_skipped.call_args[0][2] == "user_inactive"
 
     def test_orphaned_scheduled_post_is_requeued(self):
         """Posts stuck in 'scheduled' status (task lost on restart) must be re-dispatched."""

--- a/tests/unit/utilities/linkedin/test_rate_limit.py
+++ b/tests/unit/utilities/linkedin/test_rate_limit.py
@@ -189,6 +189,11 @@ class TestRedisClientSelection:
             mod = importlib.import_module(_MOD)
             assert mod._redis_client() is None
 
+    def test_shared_client_exposes_the_same_handle(self, fake_redis):
+        """Other runtime-state helpers (e.g. the pre-post engagement marker) reuse this handle."""
+        from cqc_lem.utilities.linkedin.rate_limit import shared_redis_client
+        assert shared_redis_client() is fake_redis
+
 
 class TestAutomationPause:
     def test_pause_sets_key_with_ttl(self, fake_redis):

--- a/tests/unit/utilities/test_engagement_window.py
+++ b/tests/unit/utilities/test_engagement_window.py
@@ -1,0 +1,212 @@
+"""Unit tests for cqc_lem.utilities.engagement_window (issue #547)."""
+
+import pytest
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.engagement_window"
+
+_NOW = datetime(2026, 7, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def mock_redis():
+    """A working Redis handle for the marker helpers (the unit lane blocks the real one)."""
+    client = MagicMock()
+    with patch(f"{_MOD}.shared_redis_client", return_value=client), \
+         patch(f"{_MOD}.track_pre_post_engagement"):
+        yield client
+
+
+@pytest.fixture
+def mock_track():
+    with patch(f"{_MOD}.shared_redis_client", return_value=None), \
+         patch(f"{_MOD}.track_pre_post_engagement") as tracker:
+        yield tracker
+
+
+class TestPlanPrePostWindow:
+    def test_full_lead_available_starts_lead_minutes_before(self):
+        from cqc_lem.utilities.engagement_window import plan_pre_post_window
+        window = plan_pre_post_window(_NOW + timedelta(hours=1), 15, now=_NOW)
+
+        assert window is not None
+        assert window.eta == _NOW + timedelta(minutes=45)
+        assert window.duration_seconds == 15 * 60
+        assert window.clamped is False
+
+    def test_exactly_one_lead_away_is_not_clamped(self):
+        from cqc_lem.utilities.engagement_window import plan_pre_post_window
+        window = plan_pre_post_window(_NOW + timedelta(minutes=15), 15, now=_NOW)
+
+        assert window.eta == _NOW
+        assert window.duration_seconds == 15 * 60
+        assert window.clamped is False
+
+    def test_late_pickup_clamps_eta_to_now(self):
+        """The stale-eta case: less than the lead left → fire ASAP, never with an eta in the past."""
+        from cqc_lem.utilities.engagement_window import plan_pre_post_window
+        window = plan_pre_post_window(_NOW + timedelta(minutes=6), 15, now=_NOW)
+
+        assert window.eta == _NOW
+        assert window.duration_seconds == 6 * 60  # loop ends at the post, not 15 min later
+        assert window.clamped is True
+
+    def test_post_at_its_scheduled_time_returns_none(self):
+        from cqc_lem.utilities.engagement_window import plan_pre_post_window
+        assert plan_pre_post_window(_NOW, 15, now=_NOW) is None
+
+    def test_post_past_its_scheduled_time_returns_none(self):
+        from cqc_lem.utilities.engagement_window import plan_pre_post_window
+        assert plan_pre_post_window(_NOW - timedelta(hours=3), 15, now=_NOW) is None
+
+    def test_window_shorter_than_minimum_returns_none(self):
+        """60s of runway is a page load, not a warm-up — don't spin up a browser for it."""
+        from cqc_lem.utilities.engagement_window import plan_pre_post_window
+        assert plan_pre_post_window(_NOW + timedelta(seconds=60), 15, now=_NOW) is None
+
+    def test_minimum_window_is_configurable(self):
+        from cqc_lem.utilities.engagement_window import plan_pre_post_window
+        window = plan_pre_post_window(_NOW + timedelta(seconds=60), 15, now=_NOW, min_window_seconds=30)
+
+        assert window is not None
+        assert window.duration_seconds == 60
+
+    def test_naive_scheduled_time_is_treated_as_utc(self):
+        from cqc_lem.utilities.engagement_window import plan_pre_post_window
+        naive = (_NOW + timedelta(hours=1)).replace(tzinfo=None)
+        window = plan_pre_post_window(naive, 15, now=_NOW)
+
+        assert window.eta == _NOW + timedelta(minutes=45)
+
+    def test_naive_now_is_treated_as_utc(self):
+        from cqc_lem.utilities.engagement_window import plan_pre_post_window
+        window = plan_pre_post_window(_NOW + timedelta(hours=1), 15, now=_NOW.replace(tzinfo=None))
+
+        assert window.eta == _NOW + timedelta(minutes=45)
+
+    def test_defaults_to_current_time(self):
+        from cqc_lem.utilities.engagement_window import plan_pre_post_window
+        window = plan_pre_post_window(datetime.now(timezone.utc) + timedelta(hours=2), 10)
+
+        assert window is not None
+        assert window.duration_seconds == 10 * 60
+
+    def test_viewer_lead_is_shorter_than_comment_lead(self):
+        from cqc_lem.utilities.engagement_window import (
+            PRE_POST_COMMENT_LEAD_MINUTES, PRE_POST_VIEWER_LEAD_MINUTES)
+        assert PRE_POST_VIEWER_LEAD_MINUTES < PRE_POST_COMMENT_LEAD_MINUTES
+
+
+class TestMarkers:
+    def test_scheduled_marker_written_to_redis(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import PrePostWindow, record_pre_post_scheduled
+        window = PrePostWindow(eta=_NOW, duration_seconds=900, clamped=False)
+        record_pre_post_scheduled(11, 7, window)
+
+        key, mapping = mock_redis.hset.call_args[0][0], mock_redis.hset.call_args[1]["mapping"]
+        assert key == "engagement:prepost:11"
+        assert mapping["status"] == "scheduled"
+        assert mapping["window_seconds"] == "900"
+        assert mapping["task_name"] == "automate_commenting"
+        mock_redis.expire.assert_called_once()
+
+    def test_skipped_marker_records_reason(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import record_pre_post_skipped
+        record_pre_post_skipped(12, 7, "throttled")
+
+        mapping = mock_redis.hset.call_args[1]["mapping"]
+        assert mapping["status"] == "skipped"
+        assert mapping["skip_reason"] == "throttled"
+
+    def test_run_marker_accumulates_runs_and_comments(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import record_pre_post_run
+        record_pre_post_run(13, 7, 3, now=_NOW)
+
+        increments = {c[0][1]: c[0][2] for c in mock_redis.hincrby.call_args_list}
+        assert increments == {"runs": 1, "comments": 3}
+        assert mock_redis.hset.call_args[1]["mapping"]["last_run_at"] == _NOW.isoformat()
+
+    def test_run_marker_handles_no_comments(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import record_pre_post_run
+        record_pre_post_run(14, 7, None)
+
+        increments = {c[0][1]: c[0][2] for c in mock_redis.hincrby.call_args_list}
+        assert increments == {"runs": 1, "comments": 0}
+
+    def test_markers_fail_open_without_redis(self, mock_track):
+        from cqc_lem.utilities.engagement_window import (
+            PrePostWindow, record_pre_post_run, record_pre_post_scheduled, record_pre_post_skipped)
+        record_pre_post_scheduled(15, 7, PrePostWindow(eta=_NOW, duration_seconds=900, clamped=True))
+        record_pre_post_skipped(15, 7, "past_window")
+        record_pre_post_run(15, 7, 1)
+
+        # No Redis → no crash, and the PostHog event still carries the observability signal.
+        statuses = [c[0][2] for c in mock_track.call_args_list]
+        assert statuses == ["scheduled", "skipped", "ran"]
+
+    def test_marker_write_error_is_swallowed(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import record_pre_post_skipped
+        mock_redis.hset.side_effect = RuntimeError("redis down")
+
+        record_pre_post_skipped(16, 7, "past_window")  # must not raise
+
+    def test_tracks_posthog_event_for_dispatch(self):
+        from cqc_lem.utilities.engagement_window import PrePostWindow, record_pre_post_scheduled
+        with patch(f"{_MOD}.shared_redis_client", return_value=None), \
+             patch(f"{_MOD}.track_pre_post_engagement") as tracker:
+            record_pre_post_scheduled(17, 7, PrePostWindow(eta=_NOW, duration_seconds=300, clamped=True))
+
+        args, kwargs = tracker.call_args
+        assert args == (17, 7, "scheduled")
+        assert kwargs["clamped"] is True
+        assert kwargs["window_seconds"] == 300
+
+
+class TestGetPrePostWindowStat:
+    def test_returns_decoded_stat(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import get_pre_post_window_stat
+        mock_redis.hgetall.return_value = {
+            b"status": b"scheduled", b"runs": b"2", b"comments": b"5",
+            b"window_seconds": b"900", b"user_id": b"7", b"clamped": b"0",
+        }
+        stat = get_pre_post_window_stat(21)
+
+        assert stat["status"] == "scheduled"
+        assert stat["runs"] == 2
+        assert stat["comments"] == 5
+        assert stat["user_id"] == 7
+
+    def test_defaults_counters_when_never_run(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import get_pre_post_window_stat
+        mock_redis.hgetall.return_value = {b"status": b"skipped", b"skip_reason": b"throttled"}
+        stat = get_pre_post_window_stat(22)
+
+        assert stat["runs"] == 0
+        assert stat["comments"] == 0
+        assert stat["skip_reason"] == "throttled"
+
+    def test_non_numeric_counter_is_left_as_text(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import get_pre_post_window_stat
+        mock_redis.hgetall.return_value = {b"runs": b"n/a"}
+
+        assert get_pre_post_window_stat(23)["runs"] == "n/a"
+
+    def test_unknown_post_returns_empty_dict(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import get_pre_post_window_stat
+        mock_redis.hgetall.return_value = {}
+
+        assert get_pre_post_window_stat(24) == {}
+
+    def test_no_redis_returns_empty_dict(self):
+        from cqc_lem.utilities.engagement_window import get_pre_post_window_stat
+        with patch(f"{_MOD}.shared_redis_client", return_value=None):
+            assert get_pre_post_window_stat(25) == {}
+
+    def test_read_error_returns_empty_dict(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import get_pre_post_window_stat
+        mock_redis.hgetall.side_effect = RuntimeError("redis down")
+
+        assert get_pre_post_window_stat(26) == {}

--- a/tests/unit/utilities/test_engagement_window.py
+++ b/tests/unit/utilities/test_engagement_window.py
@@ -107,11 +107,32 @@ class TestMarkers:
         record_pre_post_scheduled(11, 7, window)
 
         key, mapping = mock_redis.hset.call_args[0][0], mock_redis.hset.call_args[1]["mapping"]
-        assert key == "engagement:prepost:11"
+        assert key == "engagement:prepost:11:automate_commenting"
         assert mapping["status"] == "scheduled"
         assert mapping["window_seconds"] == "900"
         assert mapping["task_name"] == "automate_commenting"
         mock_redis.expire.assert_called_once()
+
+    def test_each_pre_post_task_gets_its_own_marker(self, mock_redis):
+        """Both pre-post tasks fire for the SAME post — the viewer dispatch must not overwrite the
+        commenting window's eta/duration (Copilot review, PR #594)."""
+        from cqc_lem.utilities.engagement_window import (
+            PRE_POST_TASK_COMMENTING, PRE_POST_TASK_VIEWER, PrePostWindow, record_pre_post_scheduled)
+        record_pre_post_scheduled(18, 7, PrePostWindow(eta=_NOW, duration_seconds=900, clamped=False))
+        record_pre_post_scheduled(18, 7, PrePostWindow(eta=_NOW, duration_seconds=600, clamped=False),
+                                  task_name=PRE_POST_TASK_VIEWER)
+
+        writes = {c[0][0]: c[1]["mapping"] for c in mock_redis.hset.call_args_list}
+        assert writes[f"engagement:prepost:18:{PRE_POST_TASK_COMMENTING}"]["window_seconds"] == "900"
+        assert writes[f"engagement:prepost:18:{PRE_POST_TASK_VIEWER}"]["window_seconds"] == "600"
+
+    def test_run_marker_targets_the_commenting_key(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import record_pre_post_run
+        record_pre_post_run(19, 7, 2)
+
+        assert mock_redis.hset.call_args[0][0] == "engagement:prepost:19:automate_commenting"
+        assert all(c[0][0] == "engagement:prepost:19:automate_commenting"
+                   for c in mock_redis.hincrby.call_args_list)
 
     def test_skipped_marker_records_reason(self, mock_redis):
         from cqc_lem.utilities.engagement_window import record_pre_post_skipped
@@ -193,6 +214,13 @@ class TestGetPrePostWindowStat:
         mock_redis.hgetall.return_value = {b"runs": b"n/a"}
 
         assert get_pre_post_window_stat(23)["runs"] == "n/a"
+
+    def test_reads_the_requested_task_marker(self, mock_redis):
+        from cqc_lem.utilities.engagement_window import PRE_POST_TASK_VIEWER, get_pre_post_window_stat
+        mock_redis.hgetall.return_value = {b"status": b"scheduled"}
+        get_pre_post_window_stat(27, task_name=PRE_POST_TASK_VIEWER)
+
+        assert mock_redis.hgetall.call_args[0][0] == f"engagement:prepost:27:{PRE_POST_TASK_VIEWER}"
 
     def test_unknown_post_returns_empty_dict(self, mock_redis):
         from cqc_lem.utilities.engagement_window import get_pre_post_window_stat

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -268,6 +268,31 @@ class TestEstimateLlmCost:
         assert cost == pytest.approx(3 / 1000.0 * 0.00015)
 
 
+class TestTrackPrePostEngagement:
+    def test_captures_pre_post_engagement_event(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_pre_post_engagement
+            track_pre_post_engagement(42, 7, "ran", comments=3)
+
+        mock_ph.capture.assert_called_once()
+        _, kwargs = mock_ph.capture.call_args
+        assert kwargs["event"] == "pre_post_engagement"
+        assert kwargs["distinct_id"] == "7"
+        props = kwargs["properties"]
+        assert props["post_id"] == 42
+        assert props["status"] == "ran"
+        assert props["comments"] == 3
+
+    def test_falls_back_to_system_distinct_id(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_pre_post_engagement
+            track_pre_post_engagement(42, None, "skipped", skip_reason="throttled")
+
+        _, kwargs = mock_ph.capture.call_args
+        assert kwargs["distinct_id"] == "system"
+        assert kwargs["properties"]["skip_reason"] == "throttled"
+
+
 class TestTrackPostOutcome:
     def test_captures_post_outcome_event(self):
         with patch(f"{_MOD}.posthog") as mock_ph:


### PR DESCRIPTION
## What & why

The pre-post feed-commenting run exists to make you **active on the feed right before your own post publishes**. Two things kept that from being reliable — and unverifiable after the fact.

**1. Stale eta → the "pre"-post run wasn't pre-post.**
`auto_check_scheduled_posts` scans back to "yesterday", so a post picked up at (or after) its scheduled time produced `eta = scheduled_time - 15 min` **in the past**. Celery fires those immediately, so the warm-up ran *during or after* publication — and a post already past its time still triggered a pointless "pre"-post loop.

New `plan_pre_post_window()` clamps the window:

| Runway left | Behaviour |
|---|---|
| ≥ full lead | eta = `scheduled_time − lead`, loop = full lead (unchanged) |
| < lead, > 2 min | eta = **now**, loop shortened so it ends **at** the post time (never past it) |
| ≤ 2 min / at / past post time | **not dispatched** — the window is closed |

Applied to both pre-post tasks: commenting (15-min lead) and profile-viewer DMs (10-min lead).

**2. No per-post observability.**
`automate_commenting` now accepts the `post_id` of the post it is warming up for (set only by the pre-post dispatch; the daily golden-hour run is unaffected). It rides the self-requeue kwargs, so every pass in the window **accumulates** onto one marker:

- **Redis** (`engagement:prepost:<post_id>`, 7-day TTL — the same runtime-state store the 429 breaker uses, so it survives deploys): `status`, `eta`, `window_seconds`, `clamped`, `runs`, `comments`, `last_run_at`, `skip_reason`. Read it back with `get_pre_post_window_stat(post_id)`.
- **PostHog** `pre_post_engagement` event (`scheduled` / `skipped` / `ran`).
- **Structured logs** at each transition.

Skips are recorded too, with a stable reason — `throttled`, `user_inactive`, `past_window` — so the throttle/pause gate stays correct (it should skip) but is no longer invisible. `_skip_if_throttled` now carries `post_id`/`user_id` context into its log line.

Every marker path **fails open**: no Redis (or a Redis error) degrades to logging only, never to a failed dispatch. No schema change, no migration.

Times are compared in UTC throughout, matching the scheduling TZ contract from #546 (naive DB datetimes are treated as UTC, as elsewhere in this task).

Not addressed here (out of scope for this issue's acceptance criteria): worker restarts interrupting the loop mid-window, and post sparsity — the latter is the dominant cause and is handled by the content-buffer issue.

## Files

- `src/cqc_lem/utilities/engagement_window.py` (new) — window planner + marker helpers
- `src/cqc_lem/app/run_scheduler.py` — clamped dispatch + skip markers
- `src/cqc_lem/app/run_automation.py` — `post_id` kwarg → per-pass marker
- `src/cqc_lem/utilities/observability.py` — `track_pre_post_engagement`
- `src/cqc_lem/utilities/linkedin/rate_limit.py` — public `shared_redis_client()` so the marker reuses one Redis URL rule

## Testing

`poetry run pytest tests/unit -q` → **5266 passed**. 28 new unit tests; **100 % coverage of the new module**:

- eta clamping: full lead, exactly one lead away, late pickup, at/past post time, sub-minimum runway, naive-datetime handling
- scheduler dispatch: 15-min eta + `post_id` kwarg, clamped late pickup, no tasks for a past post, markers for scheduled/throttled/inactive
- marker accumulation across the self-requeue, `None` comment counts, fail-open with no Redis, swallowed Redis errors, stat read-back

Two existing scheduler tests used a hard-coded 2025 scheduled time; they now use a future time, since a past-time post deliberately no longer dispatches a warm-up.

Closes #547

🤖 Generated with [Claude Code](https://claude.com/claude-code)