### PR TITLE
feat(review): surface PENDING gate reasons + remediation in Content Studio (closes #421)

### DIFF
--- a/compose/local/database/migrations/V20260726000134__add_post_gate_reason.sql
+++ b/compose/local/database/migrations/V20260726000134__add_post_gate_reason.sql
@@ -1,0 +1,16 @@
+-- Why a draft is PENDING (issue #421). A quality gate (A1 authenticity below threshold, the
+-- near-duplicate check, missing media) demotes APPROVED -> PENDING, but the review queue had no way
+-- to show WHICH gate fired, the score it fired on, or what to do about it. Each gate now records a
+-- structured finding (gate, score, threshold, explanation, remediation, demoted) and they are stored
+-- here as a JSON array, alongside the raw scores in authenticity_score (V57) / dwell_score.
+-- NULL = no gate has evaluated this post, or it passed everything.
+ALTER TABLE posts ADD COLUMN gate_reason JSON NULL;
+
+-- The gate thresholds, per user. Both were deploy-wide env vars only (AUTHENTICITY_SCORE_MIN /
+-- POST_SIMILARITY_MAX), so a user who found the gates too strict (or too lax) for their risk
+-- appetite had no way to tune them. NULL = follow the env/code default, so behaviour is unchanged
+-- until the user sets one. Similarity is stored as a whole percent (the unit the SPA edits) and
+-- converted to the 0-1 overlap fraction the gate compares against.
+ALTER TABLE engagement_preferences
+    ADD COLUMN authenticity_score_min INT NULL AFTER personal_goals,
+    ADD COLUMN post_similarity_max_pct INT NULL AFTER authenticity_score_min;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -89,6 +89,9 @@ from cqc_lem.utilities.env_constants import LI_CLIENT_ID, LI_CLIENT_SECRET, LI_R
 import requests
 from cqc_lem.utilities.logger import myprint, log_warning, log_info, log_error
 from cqc_lem.utilities.mime_type_helper import get_file_mime_type
+from cqc_lem.utilities.quality_gates import (parse_gate_findings, clamp_threshold,
+                                             AUTHENTICITY_SCORE_MIN_BOUNDS,
+                                             SIMILARITY_MAX_PCT_BOUNDS)
 from cqc_lem.utilities.observability import (
     track_api_call, track_funnel_event, anonymous_distinct_id,
     FUNNEL_SIGNUP_STARTED, FUNNEL_SIGNUP_COMPLETED, FUNNEL_TRIAL_STARTED,
@@ -435,6 +438,11 @@ class PostRegenerateRequest(BaseModel):
     guidance: Optional[str] = None  # free-text "Added Guidance"; empty => fresh take honoring settings
 
 
+class PostRescoreRequest(BaseModel):
+    session_token: str
+    post_id: int
+
+
 class ScheduleDmRequest(BaseModel):
     session_token: str
     recipient_profile_url: str = Field(max_length=_LEN_DM_RECIPIENT_URL)
@@ -547,6 +555,9 @@ class EngagementPreferencesRequest(BaseModel):
     focus_topics: List[str] = []
     business_goals: Optional[str] = Field(default=None, max_length=_LEN_GOALS)
     personal_goals: Optional[str] = Field(default=None, max_length=_LEN_GOALS)
+    # Quality-gate sensitivity (issue #421). None = keep the deploy default.
+    authenticity_score_min: Optional[int] = None
+    post_similarity_max_pct: Optional[int] = None
     min_reactions: Optional[int] = None
     max_post_age_hours: Optional[int] = 24
     reply_to_own_comments: bool = True
@@ -619,6 +630,16 @@ class EngagementPreferencesRequest(BaseModel):
             return min(14, max(1, int(v)))
         except (TypeError, ValueError):
             return 2
+
+    @field_validator("authenticity_score_min")
+    @classmethod
+    def _clamp_authenticity_min(cls, v: Optional[int]) -> Optional[int]:
+        return clamp_threshold(v, *AUTHENTICITY_SCORE_MIN_BOUNDS)
+
+    @field_validator("post_similarity_max_pct")
+    @classmethod
+    def _clamp_similarity_max(cls, v: Optional[int]) -> Optional[int]:
+        return clamp_threshold(v, *SIMILARITY_MAX_PCT_BOUNDS)
 
     @field_validator("catchup_touch_mode")
     @classmethod
@@ -1433,6 +1454,9 @@ def get_posts_for_email(
             "post_type": post["post_type"],
             "status": post["status"],
             "carousel_slides": _parse_slides(post.get("carousel_slides")),
+            # Why a draft is being held, and what to do about it (issue #421).
+            "authenticity_score": post.get("authenticity_score"),
+            "gate_reason": parse_gate_findings(post.get("gate_reason")),
         }
         for post in posts
     ]
@@ -1888,6 +1912,14 @@ def get_engagement_preferences_endpoint(session_token: str) -> ResponseModel:
     # Read-only: the highest catch-up cap this plan allows, so the UI can bound the input and show
     # what upgrading unlocks (10/day is premium-only).
     prefs["max_catchup_touches_allowed"] = max_catchup_touches_allowed(user_id)
+    # Read-only: the deploy-wide gate thresholds, so the UI can show what "default" actually means
+    # for a user who hasn't overridden them (issue #421).
+    from cqc_lem.utilities.ai.content_alignment import authenticity_score_min
+    from cqc_lem.utilities.ai.content_framework import post_similarity_max
+    prefs["gate_defaults"] = {
+        "authenticity_score_min": authenticity_score_min(),
+        "post_similarity_max_pct": round(post_similarity_max() * 100),
+    }
     # Read-only: the last feed scan's reach funnel so the user can see when their targeting is too
     # strict (posts examined -> matched their filters -> commented).
     try:
@@ -2041,6 +2073,32 @@ def regenerate_post_endpoint(request: PostRegenerateRequest) -> ResponseModel:
     guidance = (request.guidance or "").strip() or None
     regenerate_post_task.apply_async(kwargs={"post_id": request.post_id, "guidance": guidance})
     return ResponseModel(status_code=200, detail="Regeneration started")
+
+
+@router.post("/user/post/rescore")
+def rescore_post_endpoint(request: PostRescoreRequest) -> ResponseModel:
+    """Re-run the quality gates on a pending/approved post's CURRENT content (issue #421) — the
+    'edit & re-score' half of the review flow. Save the edit first, then call this: a draft that now
+    clears every gate is promoted PENDING -> APPROVED without a full regenerate, and one that still
+    fails comes back with a fresh reason + remediation. Runs inline (one judge call) so the UI can
+    show the verdict immediately."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if get_post_user_id(request.post_id) != user_id:
+        raise HTTPException(status_code=404, detail="Post not found")
+    post_status = get_post_status(request.post_id)
+    if post_status not in (PostStatus.PENDING.value, PostStatus.APPROVED.value):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Post is '{post_status}' — only pending or approved posts can be re-scored")
+    from cqc_lem.app.run_content_plan import rescore_post
+    try:
+        result = rescore_post(request.post_id)
+    except Exception as e:
+        log_error("Could not re-score post", exc=e, user_id=user_id, post_id=request.post_id)
+        raise HTTPException(status_code=500, detail="Could not re-score this post")
+    return ResponseModel(status_code=200, detail=result)
 
 
 # --- Scheduled 1:1 DMs (issue #306) — mirrors the post scheduler endpoints ---

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -3,7 +3,7 @@ import json
 import os
 import random
 from datetime import datetime, timedelta
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 from urllib.parse import urlparse
 from xml.etree import ElementTree
 
@@ -701,10 +701,13 @@ def _score_and_persist_authenticity(user_id: int, post_id: int, content: str,
         myprint(f"Authenticity scoring skipped for post {post_id}: {e}")
 
 
-def evaluate_post_gates(post_id: int, content: str, post_type, video_url=None,
-                        engagement_prefs: dict = None, authenticity_score: Optional[int] = None,
-                        recent_texts: list = None, user_profile: LinkedInProfile = None,
-                        profile_synthesis: str = None) -> list:
+def evaluate_post_gates(post_id: int, content: str, post_type: Union[PostType, str, None],
+                        video_url: Optional[str] = None,
+                        engagement_prefs: Optional[dict] = None,
+                        authenticity_score: Optional[int] = None,
+                        recent_texts: Optional[list[str]] = None,
+                        user_profile: Optional[LinkedInProfile] = None,
+                        profile_synthesis: Optional[str] = None) -> list[dict]:
     """Run the quality gates over a FINISHED post and return their structured findings (issue #421).
 
     One evaluator for both callers: the content-plan status-setter (which knows the freshly persisted
@@ -741,8 +744,9 @@ def evaluate_post_gates(post_id: int, content: str, post_type, video_url=None,
     return findings
 
 
-def _gate_findings_for_post(user_id: int, post_id: int, content: str, post_type,
-                            video_url=None) -> list:
+def _gate_findings_for_post(user_id: int, post_id: int, content: str,
+                            post_type: Union[PostType, str, None],
+                            video_url: Optional[str] = None) -> list[dict]:
     """The generation-time gate pass: the gates that can hold a fresh draft (media + authenticity),
     evaluated against the user's own thresholds. Best-effort — the reason is review UX, so a prefs
     or score read that fails costs the explanation, never the post."""
@@ -764,7 +768,7 @@ def _gate_findings_for_post(user_id: int, post_id: int, content: str, post_type,
         return []
 
 
-def _persist_gate_findings(user_id: int, post_id: int, findings: list) -> None:
+def _persist_gate_findings(user_id: int, post_id: int, findings: list[dict]) -> None:
     """Best-effort write of the gate findings onto the post (issue #421). The reason is review UX —
     losing it must never fail generation or a re-score."""
     try:

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -29,7 +29,10 @@ from cqc_lem.utilities.db import count_ready_posts_within_buffer, get_planned_po
 from cqc_lem.utilities.db import get_recent_post_shape_history, update_db_post_shape, get_lead_magnet_settings, \
     get_shape_performance
 from cqc_lem.utilities.db import get_recent_post_texts, update_db_post_authenticity_score, \
-    get_post_authenticity_score, update_db_post_dwell_score
+    get_post_authenticity_score, update_db_post_dwell_score, update_db_post_gate_reason
+from cqc_lem.utilities.quality_gates import (authenticity_finding, similarity_finding,
+                                             focus_finding, missing_asset_finding,
+                                             demoting_findings)
 from cqc_lem.utilities.ai.content_framework import select_blueprint, history_avoidance_directive, \
     find_most_similar, post_similarity_max, has_first_person_proof, shape_for_dwell, dwell_report, \
     dwell_score_min
@@ -617,6 +620,10 @@ def regenerate_post(post_id: int, guidance: str = None) -> Optional[str]:
     # Re-score dwell for the regenerated body so the stored score never describes the old draft.
     _score_and_persist_dwell(user_id, post_id, content)
     update_db_post_content(post_id, content)
+    # Same for the gate findings (issue #421) — a reason left over from the previous draft would
+    # explain a hold that no longer exists. create_text_post already re-judged authenticity above.
+    _persist_gate_findings(user_id, post_id,
+                           _gate_findings_for_post(user_id, post_id, content, PostType.TEXT.value))
     update_db_post_status(post_id, PostStatus.PENDING)
     myprint(f"regenerate_post: post {post_id} regenerated → pending")
     return content
@@ -684,7 +691,7 @@ def _score_and_persist_authenticity(user_id: int, post_id: int, content: str,
         if result.get("flagged"):
             log_warning(
                 f"Post flagged as low-authenticity (score {result.get('score')} < "
-                f"{authenticity_score_min()}) — will hold for review: "
+                f"{authenticity_score_min(prefs)}) — will hold for review: "
                 f"{'; '.join(result.get('reasons') or []) or 'no reasons given'}",
                 user_id=user_id, post_id=post_id, task_name="create_text_post")
         else:
@@ -692,6 +699,148 @@ def _score_and_persist_authenticity(user_id: int, post_id: int, content: str,
                      user_id=user_id, post_id=post_id, task_name="create_text_post")
     except Exception as e:
         myprint(f"Authenticity scoring skipped for post {post_id}: {e}")
+
+
+def evaluate_post_gates(post_id: int, content: str, post_type, video_url=None,
+                        engagement_prefs: dict = None, authenticity_score: Optional[int] = None,
+                        recent_texts: list = None, user_profile: LinkedInProfile = None,
+                        profile_synthesis: str = None) -> list:
+    """Run the quality gates over a FINISHED post and return their structured findings (issue #421).
+
+    One evaluator for both callers: the content-plan status-setter (which knows the freshly persisted
+    authenticity score) and the re-score endpoint (which additionally supplies the user's post history
+    and profile, so the near-duplicate and focus-alignment gates can run against an edited draft).
+    A gate whose inputs are absent is skipped, never guessed. Every finding carries the score it
+    failed on, the threshold it failed against, and what the user can do about it.
+    """
+    findings = []
+    prefs = engagement_prefs or {}
+
+    if _post_missing_required_asset(post_id, post_type, video_url):
+        findings.append(missing_asset_finding(post_type))
+
+    if authenticity_score is not None and authenticity_gate_enabled():
+        threshold = authenticity_score_min(prefs)
+        if authenticity_score < threshold:
+            findings.append(authenticity_finding(authenticity_score, threshold))
+
+    if content and recent_texts:
+        threshold = post_similarity_max(prefs)
+        score, match = find_most_similar(content, recent_texts)
+        if score > threshold:
+            findings.append(similarity_finding(score, threshold, match))
+
+    topics = [str(t).strip() for t in (prefs.get("focus_topics") or []) if str(t).strip()]
+    if content and topics:
+        headline, about = profile_topic_dna(user_profile, profile_synthesis)
+        threshold = topic_authority_min()
+        score = topic_authority_score(content, topics, headline, about)
+        if score < threshold:
+            findings.append(focus_finding(score, threshold, topics))
+
+    return findings
+
+
+def _gate_findings_for_post(user_id: int, post_id: int, content: str, post_type,
+                            video_url=None) -> list:
+    """The generation-time gate pass: the gates that can hold a fresh draft (media + authenticity),
+    evaluated against the user's own thresholds. Best-effort — the reason is review UX, so a prefs
+    or score read that fails costs the explanation, never the post."""
+    try:
+        score = get_post_authenticity_score(post_id)
+    except Exception as e:
+        # An unreadable score only silences THAT gate — the media check still has to run, or a
+        # DB hiccup would let an assetless video post auto-approve.
+        myprint(f"Could not read the authenticity score for post {post_id}: {e}")
+        score = None
+    try:
+        return evaluate_post_gates(
+            post_id, content, post_type, video_url,
+            engagement_prefs=_engagement_prefs_or_empty(user_id),
+            authenticity_score=score)
+    except Exception as e:
+        log_warning("Could not evaluate the quality gates for this post", exc=e,
+                    user_id=user_id, post_id=post_id, task_name="create_content")
+        return []
+
+
+def _persist_gate_findings(user_id: int, post_id: int, findings: list) -> None:
+    """Best-effort write of the gate findings onto the post (issue #421). The reason is review UX —
+    losing it must never fail generation or a re-score."""
+    try:
+        update_db_post_gate_reason(post_id, findings)
+    except Exception as e:
+        myprint(f"Could not persist gate findings for post {post_id}: {e}")
+
+
+def _engagement_prefs_or_empty(user_id: int) -> dict:
+    """Engagement preferences for threshold resolution, never raising — a prefs read that fails just
+    means the gates fall back to the deploy-wide defaults."""
+    try:
+        return get_engagement_preferences(user_id) or {}
+    except Exception as e:
+        myprint(f"Could not load engagement preferences for user {user_id}: {e}")
+        return {}
+
+
+def rescore_post(post_id: int) -> dict:
+    """Re-run the quality gates on a post's CURRENT (possibly user-edited) content and update its
+    hold (issue #421). This is the 'edit & re-score' half of the review flow: a draft that now passes
+    every gate is promoted PENDING -> APPROVED without a full regenerate, and one that still fails
+    keeps a fresh, specific reason. Honors the user's auto-schedule preference — when they review
+    every post by hand, a passing re-score clears the reason but leaves the post PENDING for them.
+
+    Returns {passed, status, authenticity_score, findings, detail} — never raises for a missing post,
+    the caller turns that into a 404.
+    """
+    from cqc_lem.utilities.db import (get_post_type, get_post_video_url, get_post_user_id,
+                                      get_post_status)
+
+    user_id = get_post_user_id(post_id)
+    content = get_post_content(post_id)
+    if not user_id or not content:
+        return {"passed": False, "status": None, "authenticity_score": None, "findings": [],
+                "detail": "Post has no content to score"}
+
+    post_type = get_post_type(post_id)
+    post_type = post_type.value if isinstance(post_type, PostType) else post_type
+    prefs = _engagement_prefs_or_empty(user_id)
+    user_profile = load_profile_for_user(user_id)
+    try:
+        profile_synthesis = get_or_create_profile_synthesis(user_id, user_profile)
+    except Exception as e:
+        myprint(f"rescore_post: no profile synthesis for user {user_id}: {e}")
+        profile_synthesis = None
+
+    # Re-judge authenticity against the edited text — a stale score would let an unchanged hold
+    # survive a genuine rewrite (and vice versa).
+    _score_and_persist_authenticity(user_id, post_id, content, user_profile, profile_synthesis, prefs)
+    score = get_post_authenticity_score(post_id)
+
+    findings = evaluate_post_gates(
+        post_id, content, post_type, get_post_video_url(post_id), engagement_prefs=prefs,
+        authenticity_score=score,
+        # The post is already saved, so it would match ITSELF at 100% without this exclusion.
+        recent_texts=get_recent_post_texts(user_id, exclude_post_id=post_id),
+        user_profile=user_profile, profile_synthesis=profile_synthesis)
+    _persist_gate_findings(user_id, post_id, findings)
+
+    passed = not demoting_findings(findings)
+    status = get_post_status(post_id)
+    detail = "Still held for review" if not passed else "Passed every quality gate"
+    if passed and status == PostStatus.PENDING.value:
+        auto_schedule = bool((get_user_preferences(user_id) or {}).get("auto_schedule_posts", True))
+        if auto_schedule:
+            update_db_post_status(post_id, PostStatus.APPROVED)
+            status = PostStatus.APPROVED.value
+            detail = "Passed every quality gate — approved and queued"
+        else:
+            detail = ("Passed every quality gate — approve it when you're ready "
+                      "(auto-scheduling is off)")
+    log_info(f"Re-scored post {post_id}: {detail}", user_id=user_id, post_id=post_id,
+             task_name="rescore_post")
+    return {"passed": passed, "status": status, "authenticity_score": score,
+            "findings": findings, "detail": detail}
 
 
 def _score_and_persist_dwell(user_id: int, post_id: int, content: str) -> Optional[int]:
@@ -733,7 +882,7 @@ def _review_generated_post(user_id: int, stage: str, post_type: str, user_profil
     avoid/proof directive; still failing → log a structured warning and keep the second attempt
     (never loop, never hard-block). Also runs the cheap focus-alignment check on whatever content
     ships."""
-    threshold = post_similarity_max()
+    threshold = post_similarity_max(prefs)
     score, match = find_most_similar(content, recent_texts)
     too_similar = score > threshold
     missing_proof = not has_first_person_proof(content)
@@ -1583,24 +1732,19 @@ def _create_content_for_planned_post(post: dict, prefs: dict) -> bool:
         auto_schedule = bool((prefs or {}).get("auto_schedule_posts", True))
         new_status = PostStatus.APPROVED if auto_schedule else PostStatus.PENDING
 
-        # Never auto-approve a video/carousel post whose media failed to generate — hold it
-        # PENDING so the backfill task (or manual review) can complete the asset before it
-        # can be scheduled/posted. Prevents assetless posts going out.
-        if _post_missing_required_asset(post_id, post_type, video_url):
+        # Quality gates (issues #382 / #421): a video/carousel post whose media failed to generate,
+        # or a draft the authenticity judge scored below the user's minimum, is held PENDING for
+        # human review instead of auto-approved — and the REASON is recorded on the post so the
+        # review queue can explain the hold and what to do about it. Only downgrades an APPROVED;
+        # never upgrades a PENDING, never blocks when unscored.
+        gate_findings = _gate_findings_for_post(user_id, post_id, content, post_type, video_url)
+        held_by = demoting_findings(gate_findings)
+        if held_by and new_status == PostStatus.APPROVED:
             new_status = PostStatus.PENDING
-            myprint(f"post_id {post_id}: required media asset missing — holding PENDING")
-
-        # Authenticity gate (issue #382): demote an auto-approve to PENDING when the persisted
-        # LLM-judged authenticity score (set by create_text_post's scoring step) is below threshold,
-        # so a generic-AI-flagged draft gets human review before it can post. Only downgrades an
-        # APPROVED — never upgrades a PENDING, and never blocks when unscored (score None).
-        if new_status == PostStatus.APPROVED and authenticity_gate_enabled():
-            score = get_post_authenticity_score(post_id)
-            if score is not None and score < authenticity_score_min():
-                new_status = PostStatus.PENDING
-                log_warning(f"post_id {post_id}: authenticity score {score} < "
-                            f"{authenticity_score_min()} — holding PENDING for review",
-                            user_id=user_id, post_id=post_id, task_name="create_content")
+            log_warning(f"post_id {post_id}: held PENDING for review — "
+                        f"{'; '.join(f['explanation'] for f in held_by)}",
+                        user_id=user_id, post_id=post_id, task_name="create_content")
+        _persist_gate_findings(user_id, post_id, gate_findings)
 
         myprint(f"Updating post_id: {post_id} Status={new_status}")
         update_db_post_status(post_id, new_status)

--- a/src/cqc_lem/ui/src/components/PostGateReason.tsx
+++ b/src/cqc_lem/ui/src/components/PostGateReason.tsx
@@ -1,0 +1,113 @@
+import { Link } from 'react-router-dom'
+import { gateHold } from '../utils/gateFindings'
+import type { GateFinding } from '../utils/gateFindings'
+
+// Why a draft is sitting in PENDING (issue #421). A quality gate demoted it — show WHICH gate, the
+// score against the threshold it failed, and the two things the user can actually do: fix the draft
+// and re-score it, or loosen the threshold in Account settings.
+
+// Similarity/focus scores are 0-1 overlap fractions; authenticity is already a 0-100 score.
+const isFraction = (gate: string) => gate === 'similarity' || gate === 'focus_alignment'
+const fmtScore = (gate: string, value: number | null) =>
+  value === null || value === undefined
+    ? null
+    : isFraction(gate)
+      ? `${Math.round(value * 100)}%`
+      : `${Math.round(value)}`
+
+export default function PostGateReason({
+  findings,
+  status,
+  onRescore,
+  rescoring,
+  rescoreResult,
+}: {
+  findings: GateFinding[]
+  status: string
+  onRescore?: () => void
+  rescoring?: boolean
+  rescoreResult?: string | null
+}) {
+  // Always available on a pending post — that's where "edit, then re-score" lives, even for a
+  // draft held before this feature recorded reasons.
+  const pending = status === 'pending'
+  if (!findings.length && !rescoreResult && !pending) return null
+  const held = gateHold(findings)
+  const isHeld = held.length > 0 && pending
+
+  return (
+    <div
+      className={`rounded-lg border p-4 space-y-3 ${
+        isHeld ? 'bg-amber-50 border-amber-200' : 'bg-gray-50 border-gray-200'
+      }`}
+    >
+      <h4 className={`text-sm font-semibold ${isHeld ? 'text-amber-900' : 'text-gray-700'}`}>
+        {isHeld ? '⏸ Why this is pending' : 'Quality checks'}
+      </h4>
+
+      {!findings.length && (
+        <p className="text-sm text-gray-600">
+          No quality gate is holding this post. Edit it and re-score to re-run the checks.
+        </p>
+      )}
+
+      {findings.map((f) => {
+        const score = fmtScore(f.gate, f.score)
+        const threshold = fmtScore(f.gate, f.threshold)
+        return (
+          <div key={f.gate} className="space-y-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span
+                className={`px-2 py-0.5 rounded-full text-xs font-semibold ${
+                  f.demoted ? 'bg-amber-200 text-amber-900' : 'bg-gray-200 text-gray-700'
+                }`}
+              >
+                {f.label}
+              </span>
+              {score && (
+                <span className="text-xs text-gray-500">
+                  {f.gate === 'similarity' ? 'overlap' : 'score'} {score}
+                  {threshold && ` · your limit ${threshold}`}
+                </span>
+              )}
+              {!f.demoted && <span className="text-xs text-gray-400">advisory</span>}
+            </div>
+            <p className="text-sm text-gray-700">{f.explanation}</p>
+            <p className="text-sm text-gray-600">
+              <span className="font-medium">Fix: </span>
+              {f.remediation}
+            </p>
+            {!!f.details?.length && (
+              <ul className="text-xs text-gray-500 list-disc list-inside">
+                {f.details.map((d, i) => (
+                  <li key={i}>{d}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )
+      })}
+
+      <div className="flex flex-wrap items-center gap-2 pt-1">
+        {onRescore && (
+          <button
+            type="button"
+            onClick={onRescore}
+            disabled={rescoring}
+            className="bg-amber-600 text-white px-3 py-1.5 rounded-lg text-xs font-semibold hover:bg-amber-700 disabled:opacity-50 transition-colors"
+          >
+            {rescoring ? 'Re-scoring…' : 'Save & re-score'}
+          </button>
+        )}
+        <Link
+          to="/account#engagement"
+          className="text-xs font-semibold text-blue-700 underline hover:text-blue-800"
+        >
+          Adjust thresholds
+        </Link>
+      </div>
+
+      {rescoreResult && <p className="text-xs font-medium text-gray-700">{rescoreResult}</p>}
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -3,6 +3,9 @@ import { useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../api/client'
 import LinkedInPostPreview from '../components/LinkedInPostPreview'
+import PostGateReason from '../components/PostGateReason'
+import { gateHold } from '../utils/gateFindings'
+import type { GateFinding } from '../utils/gateFindings'
 import NewsletterQueue from './review/NewsletterQueue'
 import ScheduledDMs from './review/ScheduledDMs'
 import ConnectionRequests from './review/ConnectionRequests'
@@ -76,6 +79,18 @@ interface Post {
   status: string
   carousel_slides: string[] | null
   post_url?: string | null
+  // Quality-gate verdict (issue #421) — why a PENDING post is being held, and its A1 score.
+  authenticity_score?: number | null
+  gate_reason?: GateFinding[] | null
+}
+
+// What POST /user/post/rescore returns after re-running the gates on the saved content.
+interface RescoreResult {
+  passed: boolean
+  status: string | null
+  authenticity_score: number | null
+  findings: GateFinding[]
+  detail: string
 }
 
 interface PostsResponse {
@@ -157,6 +172,13 @@ export default function ContentStudio() {
   const [regenGuidance, setRegenGuidance] = useState('')
   const [regenNotice, setRegenNotice] = useState<string | null>(null)
 
+  // Verdict of the last "Save & re-score" run on the open post (issue #421).
+  const [rescoreResult, setRescoreResult] = useState<string | null>(null)
+
+  // The re-score verdict belongs to one post — drop it when a different one is opened.
+  const editingPostId = editingPost?.post_id ?? null
+  useEffect(() => { setRescoreResult(null) }, [editingPostId])
+
   const queryKey = ['posts', email, page, pageSize, sortOrder, sortBy, filterStatus, filterPostType, searchQuery]
 
   const { data, isLoading } = useQuery<{ detail: PostsResponse }>({
@@ -195,6 +217,36 @@ export default function ContentStudio() {
       qc.invalidateQueries({ queryKey: ['posts', email] })
       setEditingPost(null)
     },
+  })
+
+  // Save the edit, then re-run the quality gates on it (issue #421). Scoring the STORED content
+  // keeps the verdict honest — the gates judge exactly what would publish. A draft that now clears
+  // every gate is promoted back to APPROVED server-side, with no full regenerate.
+  const rescoreMutation = useMutation({
+    mutationFn: async (post: Post) => {
+      if (!sessionToken) throw new Error('No active session')
+      await api.post(`/update_post/?post_id=${post.post_id}`, {
+        content: post.content,
+        video_url: post.video_url,
+        post_type: post.post_type,
+        scheduled_datetime: post.scheduled_time,
+        email,
+        status: post.status,
+      })
+      const r = await api.post('/user/post/rescore', {
+        session_token: sessionToken,
+        post_id: post.post_id,
+      })
+      return r.data.detail as RescoreResult
+    },
+    onSuccess: (result) => {
+      setRescoreResult(result.detail)
+      setEditingPost((p) =>
+        p ? { ...p, status: result.status ?? p.status, gate_reason: result.findings,
+              authenticity_score: result.authenticity_score } : p)
+      qc.invalidateQueries({ queryKey: ['posts', email] })
+    },
+    onError: () => setRescoreResult('Could not re-score this post — please try again.'),
   })
 
   const bulkUpdateMutation = useMutation({
@@ -706,6 +758,12 @@ export default function ContentStudio() {
                     </div>
                   </div>
                   <p className="text-sm text-gray-700 line-clamp-2">{post.content}</p>
+                  {/* One-line "why" for a gate-held draft — the full reason + fix is in the editor. */}
+                  {post.status === 'pending' && gateHold(post.gate_reason).length > 0 && (
+                    <p className="text-xs text-amber-700 mt-1 truncate">
+                      ⏸ {gateHold(post.gate_reason).map((f) => f.label).join(' · ')} — click to see why
+                    </p>
+                  )}
                   {isDeckType(post.post_type) && post.carousel_slides && (
                     <p className="text-xs text-gray-400 mt-1">{post.carousel_slides.length} slides</p>
                   )}
@@ -789,6 +847,15 @@ export default function ContentStudio() {
               /* Editable form for non-posted statuses */
               <div className="bg-white rounded-lg border border-gray-200 shadow-sm p-5 space-y-4">
                 <h3 className="font-semibold text-gray-700">Edit Post #{editingPost.post_id}</h3>
+
+                {/* Why this draft is pending + how to clear it (issue #421). */}
+                <PostGateReason
+                  findings={editingPost.gate_reason ?? []}
+                  status={editingPost.status}
+                  onRescore={() => rescoreMutation.mutate(editingPost)}
+                  rescoring={rescoreMutation.isPending}
+                  rescoreResult={rescoreResult}
+                />
 
                 <textarea
                   rows={6}

--- a/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementSettingsCard.tsx
@@ -57,6 +57,10 @@ export default function EngagementSettingsCard() {
   // Server-provided ceiling for the catch-up cap — 10/day on Professional/Enterprise, 5/day otherwise.
   const catchupCapMax = engPrefs.max_catchup_touches_allowed ?? 5
 
+  // Server-provided defaults for the quality gates, shown as placeholders when the user hasn't
+  // overridden them (issue #421).
+  const gateDefaults = engPrefs.gate_defaults ?? { authenticity_score_min: 60, post_similarity_max_pct: 55 }
+
   // Every engagement section edits ONE shared object saved by ONE mutation, so a failure in any
   // field (e.g. an over-long value) fails the whole save. Show the result under whichever button
   // the user clicked — previously the message only rendered in the Targeting card, hiding errors
@@ -157,6 +161,49 @@ export default function EngagementSettingsCard() {
             onChange={(e) => setEng({ personal_goals: e.target.value })}
             placeholder="e.g. Build a reputation as a thoughtful voice in supply-chain tech"
             className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+        </div>
+        {/* Quality gates (issue #421) — the thresholds that decide whether a generated post is
+            auto-scheduled or held for your review. Blank = keep LEM's default. */}
+        <div className="border-t border-gray-100 pt-4 space-y-3">
+          <h3 className="text-sm font-semibold text-gray-700">Review thresholds</h3>
+          <p className="text-xs text-gray-500">
+            A draft that fails one of these is held as PENDING with the reason shown in Content
+            Studio, instead of being scheduled automatically. Leave blank to use the default.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Min. authenticity score
+              </label>
+              <input type="number" min={0} max={100}
+                value={engPrefs.authenticity_score_min ?? ''}
+                placeholder={`Default ${gateDefaults.authenticity_score_min}`}
+                onChange={(e) => setEng({
+                  authenticity_score_min: e.target.value === '' ? null : Number(e.target.value),
+                })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+              <p className="text-xs text-gray-400 mt-1">
+                0-100 — how human/specific a draft must read before it can auto-schedule. Higher
+                holds more posts for review; lower ships more of them unreviewed.
+              </p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Max. overlap with your recent posts
+              </label>
+              <input type="number" min={10} max={100}
+                value={engPrefs.post_similarity_max_pct ?? ''}
+                placeholder={`Default ${gateDefaults.post_similarity_max_pct}%`}
+                onChange={(e) => setEng({
+                  post_similarity_max_pct: e.target.value === '' ? null : Number(e.target.value),
+                })}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+              <p className="text-xs text-gray-400 mt-1">
+                10-100% word overlap against your own recent posts. Lower is stricter about
+                near-duplicates.
+              </p>
+            </div>
+          </div>
         </div>
         {saveBtn('Save Focus & Goals')}
       </div>

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -13,6 +13,9 @@ export type EngPrefs = {
   focus_topics: string[]
   business_goals: string | null
   personal_goals: string | null
+  // Quality-gate sensitivity (issue #421). null = use the deploy default in gate_defaults.
+  authenticity_score_min: number | null
+  post_similarity_max_pct: number | null
   min_reactions: number | null
   max_post_age_hours: number | null
   reply_to_own_comments: boolean
@@ -37,6 +40,8 @@ export type EngPrefs = {
   catchup_message_source: string
   // Read-only: the highest catch-up cap this plan allows (10/day is premium-only).
   max_catchup_touches_allowed?: number
+  // Read-only: the deploy-wide gate thresholds used when the user hasn't set their own.
+  gate_defaults?: { authenticity_score_min: number; post_similarity_max_pct: number }
   feed_reach?: FeedReach | null
 }
 

--- a/src/cqc_lem/ui/src/utils/gateFindings.ts
+++ b/src/cqc_lem/ui/src/utils/gateFindings.ts
@@ -1,0 +1,17 @@
+// A quality gate's verdict on a generated post (issue #421), as returned on `gate_reason` by
+// /posts/ and /user/post/rescore. `demoted` marks the findings that are actually HOLDING the post
+// at PENDING — the rest are advisory notes.
+export type GateFinding = {
+  gate: string
+  label: string
+  score: number | null
+  threshold: number | null
+  demoted: boolean
+  explanation: string
+  remediation: string
+  details?: string[]
+}
+
+export function gateHold(findings?: GateFinding[] | null): GateFinding[] {
+  return (findings ?? []).filter((f) => f.demoted)
+}

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -712,9 +712,17 @@ def voice_reference(profile, profile_synthesis: Optional[str] = None) -> str:
 AUTHENTICITY_SCORE_MIN_DEFAULT = 60
 
 
-def authenticity_score_min() -> int:
-    """Score below which a draft is demoted APPROVED -> PENDING. Read live (like post_similarity_max)
-    so ops/tests can tune AUTHENTICITY_SCORE_MIN without a restart. Clamped to 0-100."""
+def authenticity_score_min(prefs: dict = None) -> int:
+    """Score below which a draft is demoted APPROVED -> PENDING. The user's own setting
+    (engagement_preferences.authenticity_score_min, issue #421) wins when set; otherwise read live
+    (like post_similarity_max) so ops/tests can tune AUTHENTICITY_SCORE_MIN without a restart.
+    Clamped to 0-100."""
+    override = (prefs or {}).get("authenticity_score_min")
+    if override is not None:
+        try:
+            return max(0, min(100, int(override)))
+        except (TypeError, ValueError):
+            pass
     raw = (os.environ.get("AUTHENTICITY_SCORE_MIN") or "").strip()
     try:
         value = int(raw) if raw else AUTHENTICITY_SCORE_MIN_DEFAULT
@@ -1147,7 +1155,7 @@ def score_authenticity(content: str, profile=None, profile_synthesis: Optional[s
         parsed = _coerce_authenticity_result(resp.choices[0].message.content or "")
         if parsed is None:
             return passing
-        parsed["flagged"] = parsed["score"] < authenticity_score_min()
+        parsed["flagged"] = parsed["score"] < authenticity_score_min(prefs)
         return parsed
     except Exception:
         return passing

--- a/src/cqc_lem/utilities/ai/content_framework.py
+++ b/src/cqc_lem/utilities/ai/content_framework.py
@@ -859,9 +859,17 @@ def has_first_person_proof(text: Optional[str]) -> bool:
 POST_SIMILARITY_MAX_DEFAULT = 0.55
 
 
-def post_similarity_max() -> float:
-    """The similarity ceiling, read at call time (same live-env pattern as the research toggles in
-    content_research) so ops/tests can tune POST_SIMILARITY_MAX without a restart."""
+def post_similarity_max(prefs: dict = None) -> float:
+    """The similarity ceiling. The user's own setting (engagement_preferences.post_similarity_max_pct,
+    a whole percent — issue #421) wins when set; otherwise read at call time (same live-env pattern as
+    the research toggles in content_research) so ops/tests can tune POST_SIMILARITY_MAX without a
+    restart."""
+    override = (prefs or {}).get("post_similarity_max_pct")
+    if override is not None:
+        try:
+            return min(100, max(10, int(override))) / 100.0
+        except (TypeError, ValueError):
+            pass
     raw = (os.environ.get("POST_SIMILARITY_MAX") or "").strip()
     try:
         return float(raw) if raw else POST_SIMILARITY_MAX_DEFAULT

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -908,7 +908,8 @@ def get_posts(user_id: int, limit: int = 10, offset: int = 0,
         total = cursor.fetchone()['total']
 
         cursor.execute(
-            f"SELECT id, content, video_url, scheduled_time, post_type, status, carousel_slides "
+            f"SELECT id, content, video_url, scheduled_time, post_type, status, carousel_slides, "
+            f"authenticity_score, gate_reason "
             f"FROM posts {where} ORDER BY {sort_col} {order}, id {order} LIMIT %s OFFSET %s",
             params + [limit, offset]
         )
@@ -1333,6 +1334,45 @@ def get_post_authenticity_score(post_id: int) -> Optional[int]:
         connection.close()
 
 
+def update_db_post_gate_reason(post_id: int, findings: Optional[list]) -> bool:
+    """Persist WHY a post is held for review (issue #421): the quality gates' structured findings
+    (see utilities/quality_gates.py) as a JSON array on posts.gate_reason. An empty/None list clears
+    the column, so a post that passes on re-score stops showing a stale reason."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE posts SET gate_reason = %s WHERE id = %s",
+            (json.dumps(findings) if findings else None, post_id)
+        )
+        connection.commit()
+        success = cursor.rowcount == 1
+    except mysql.connector.Error as e:
+        success = False
+        myprint(f"Could not update gate reason for post {post_id}. Error: {e}")
+    finally:
+        cursor.close()
+        connection.close()
+    return success
+
+
+def get_post_gate_reason(post_id: int) -> list:
+    """The persisted quality-gate findings for a post (issue #421), or [] when it has none."""
+    from cqc_lem.utilities.quality_gates import parse_gate_findings
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT gate_reason FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+        return parse_gate_findings(row[0] if row else None)
+    except mysql.connector.Error as err:
+        myprint(f"Could not get gate reason for post {post_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def update_db_post_dwell_score(post_id: int, score: Optional[int]) -> bool:
     """Persist the deterministic 0-100 dwell-proxy score for a post (issue #391, dwell_score column).
     Advisory metric stored next to authenticity_score — it is never read back to gate a status, so a
@@ -1429,19 +1469,26 @@ def get_recent_post_shape_history(user_id: int, limit: int = 10) -> list:
         connection.close()
 
 
-def get_recent_post_texts(user_id: int, limit: int = 20) -> list:
+def get_recent_post_texts(user_id: int, limit: int = 20,
+                          exclude_post_id: Optional[int] = None) -> list:
     """Recent post CONTENT (pending/approved/posted, most-recent first) — the post-side dedup
     history (the newsletter's V49 subject dedup applied to posts). Feeds the opener/subject
     avoidance steering and the pre-persist similarity gate in create_text_post. Openers/subjects
-    are derived from content on demand, so no new column is needed."""
+    are derived from content on demand, so no new column is needed. `exclude_post_id` drops one post
+    from the history — needed when re-scoring an ALREADY-SAVED post (issue #421), which would
+    otherwise match itself at 100%."""
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
+        exclude_sql = " AND id <> %s" if exclude_post_id is not None else ""
+        params = ((user_id, exclude_post_id, int(limit)) if exclude_post_id is not None
+                  else (user_id, int(limit)))
         cursor.execute(
             "SELECT content FROM posts "
             "WHERE user_id = %s AND content IS NOT NULL AND content <> '' "
-            "AND status IN ('pending', 'approved', 'posted') "
-            "ORDER BY id DESC LIMIT %s", (user_id, int(limit)))
+            "AND status IN ('pending', 'approved', 'posted')"
+            f"{exclude_sql} "
+            "ORDER BY id DESC LIMIT %s", params)
         return [r[0] for r in cursor.fetchall()]
     except mysql.connector.Error as err:
         myprint(f"Could not get recent post texts for user {user_id} | Error: {err}")
@@ -2863,6 +2910,10 @@ _ENGAGEMENT_DEFAULTS: dict = {
     "include_topics": [], "exclude_topics": [], "include_keywords": [], "exclude_keywords": [],
     "include_authors": [], "exclude_authors": [], "post_types": [],
     "focus_topics": [], "business_goals": None, "personal_goals": None,
+    # Quality-gate thresholds (issue #421). None = follow the deploy default
+    # (AUTHENTICITY_SCORE_MIN / POST_SIMILARITY_MAX), so the gates behave exactly as before until
+    # the user tunes them.
+    "authenticity_score_min": None, "post_similarity_max_pct": None,
     "min_reactions": None, "max_post_age_hours": 24, "reply_to_own_comments": True,
     "max_comments_per_day": 20, "max_dms_per_day": 20, "max_invites_per_day": 10,
     "connection_request_mode": "auto_approve",
@@ -2889,7 +2940,8 @@ _ENGAGEMENT_BOOL_FIELDS = ("use_emojis", "use_hashtags", "reply_to_own_comments"
 _ENGAGEMENT_COLS = ("tone", "comment_length", "comment_style", "use_emojis", "use_hashtags",
                     "include_topics", "exclude_topics", "include_keywords", "exclude_keywords",
                     "include_authors", "exclude_authors", "post_types", "focus_topics",
-                    "business_goals", "personal_goals", "min_reactions",
+                    "business_goals", "personal_goals",
+                    "authenticity_score_min", "post_similarity_max_pct", "min_reactions",
                     "max_post_age_hours", "reply_to_own_comments", "max_comments_per_day",
                     "max_dms_per_day", "max_invites_per_day", "connection_request_mode",
                     "connection_targeting_mode", "connection_target_authors",
@@ -2990,6 +3042,14 @@ def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
                                              if _age is not None else 2)
     except (TypeError, ValueError):
         merged["reply_max_post_age_days"] = 2
+    # Quality-gate thresholds (issue #421): None means "use the deploy default", anything else is
+    # clamped to its valid band so an out-of-range slider can never make a gate un-passable.
+    from cqc_lem.utilities.quality_gates import (AUTHENTICITY_SCORE_MIN_BOUNDS,
+                                                 SIMILARITY_MAX_PCT_BOUNDS, clamp_threshold)
+    merged["authenticity_score_min"] = clamp_threshold(
+        merged.get("authenticity_score_min"), *AUTHENTICITY_SCORE_MIN_BOUNDS)
+    merged["post_similarity_max_pct"] = clamp_threshold(
+        merged.get("post_similarity_max_pct"), *SIMILARITY_MAX_PCT_BOUNDS)
     if merged.get("catchup_touch_mode") not in VALID_CATCHUP_TOUCH_MODES:
         merged["catchup_touch_mode"] = "pre_review"
     if merged.get("catchup_message_source") not in VALID_CATCHUP_MESSAGE_SOURCES:

--- a/src/cqc_lem/utilities/quality_gates.py
+++ b/src/cqc_lem/utilities/quality_gates.py
@@ -11,7 +11,7 @@ build/parse the same shape, and so the copy is unit-testable on its own.
 """
 
 import json
-from typing import Optional
+from typing import Any, Optional
 
 GATE_AUTHENTICITY = "authenticity"
 GATE_SIMILARITY = "similarity"
@@ -32,7 +32,7 @@ AUTHENTICITY_SCORE_MIN_BOUNDS = (0, 100)
 SIMILARITY_MAX_PCT_BOUNDS = (10, 100)
 
 
-def clamp_threshold(value, low: int, high: int) -> Optional[int]:
+def clamp_threshold(value: Any, low: int, high: int) -> Optional[int]:
     """Clamp a user-supplied threshold into [low, high]. None (and anything unparseable) stays None,
     which every reader treats as 'use the deploy default'."""
     if value is None or value == "":
@@ -43,7 +43,8 @@ def clamp_threshold(value, low: int, high: int) -> Optional[int]:
         return None
 
 
-def build_finding(gate: str, explanation: str, remediation: str, score=None, threshold=None,
+def build_finding(gate: str, explanation: str, remediation: str,
+                  score: Optional[float] = None, threshold: Optional[float] = None,
                   demoted: bool = True, details: Optional[list] = None) -> dict:
     """One gate result in the shape the SPA renders. `demoted` marks the findings that actually
     held the post at PENDING — the others are advisory notes shown alongside them."""
@@ -72,7 +73,8 @@ def authenticity_finding(score: int, threshold: int, reasons: Optional[list] = N
         score=score, threshold=threshold, details=reasons)
 
 
-def similarity_finding(score: float, threshold: float, matched_excerpt: str = None) -> dict:
+def similarity_finding(score: float, threshold: float,
+                       matched_excerpt: Optional[str] = None) -> dict:
     """Deterministic near-duplicate check against the user's own recent posts."""
     excerpt = (matched_excerpt or "").strip().replace("\n", " ")
     if len(excerpt) > 160:
@@ -114,7 +116,7 @@ def missing_asset_finding(post_type: str) -> dict:
         score=None, threshold=None)
 
 
-def parse_gate_findings(raw) -> list:
+def parse_gate_findings(raw: Any) -> list[dict]:
     """Coerce a persisted `posts.gate_reason` value (JSON string, bytes, or already-decoded list)
     into a list of findings. Anything unusable reads as 'no findings' — a malformed reason must
     never break the review queue."""
@@ -134,6 +136,6 @@ def parse_gate_findings(raw) -> list:
     return [f for f in raw if isinstance(f, dict) and f.get("gate")]
 
 
-def demoting_findings(findings: Optional[list]) -> list:
+def demoting_findings(findings: Optional[list[dict]]) -> list[dict]:
     """The findings that hold a post at PENDING (vs. the advisory notes)."""
     return [f for f in (findings or []) if isinstance(f, dict) and f.get("demoted")]

--- a/src/cqc_lem/utilities/quality_gates.py
+++ b/src/cqc_lem/utilities/quality_gates.py
@@ -1,0 +1,139 @@
+"""Structured demotion reasons + remediation for the post quality gates (issue #421).
+
+A draft that a gate demotes APPROVED -> PENDING used to be opaque in the review queue: the user saw
+a pending post with no reason, no score, and nothing to do about it. Every gate now records a
+FINDING here — gate name, the score against the threshold that failed it, a plain-English
+explanation, and the specific remediation — which is persisted on `posts.gate_reason` and rendered
+in Content Studio.
+
+Pure and dependency-free (no DB, no LLM, no env reads) so both the content pipeline and the API can
+build/parse the same shape, and so the copy is unit-testable on its own.
+"""
+
+import json
+from typing import Optional
+
+GATE_AUTHENTICITY = "authenticity"
+GATE_SIMILARITY = "similarity"
+GATE_FOCUS = "focus_alignment"
+GATE_MISSING_ASSET = "missing_asset"
+
+GATE_LABELS = {
+    GATE_AUTHENTICITY: "Authenticity",
+    GATE_SIMILARITY: "Near-duplicate",
+    GATE_FOCUS: "Off your focus topics",
+    GATE_MISSING_ASSET: "Missing media",
+}
+
+# The user-tunable thresholds behind these gates, in the units the SPA edits them in. Bounds are
+# enforced at the API boundary AND in db.update_engagement_preferences (the V52 lesson: one bad
+# value in the single-row upsert rolls back every section).
+AUTHENTICITY_SCORE_MIN_BOUNDS = (0, 100)
+SIMILARITY_MAX_PCT_BOUNDS = (10, 100)
+
+
+def clamp_threshold(value, low: int, high: int) -> Optional[int]:
+    """Clamp a user-supplied threshold into [low, high]. None (and anything unparseable) stays None,
+    which every reader treats as 'use the deploy default'."""
+    if value is None or value == "":
+        return None
+    try:
+        return min(high, max(low, int(value)))
+    except (TypeError, ValueError):
+        return None
+
+
+def build_finding(gate: str, explanation: str, remediation: str, score=None, threshold=None,
+                  demoted: bool = True, details: Optional[list] = None) -> dict:
+    """One gate result in the shape the SPA renders. `demoted` marks the findings that actually
+    held the post at PENDING — the others are advisory notes shown alongside them."""
+    return {
+        "gate": gate,
+        "label": GATE_LABELS.get(gate, gate),
+        "score": score,
+        "threshold": threshold,
+        "demoted": bool(demoted),
+        "explanation": explanation,
+        "remediation": remediation,
+        "details": [str(d) for d in (details or []) if str(d).strip()],
+    }
+
+
+def authenticity_finding(score: int, threshold: int, reasons: Optional[list] = None) -> dict:
+    """A1 authenticity judge scored the draft below the user's minimum (issue #382)."""
+    return build_finding(
+        GATE_AUTHENTICITY,
+        explanation=(f"The authenticity check scored this draft {score} out of 100 — below your "
+                     f"{threshold} minimum. LinkedIn's 2026 ranking demotes content that reads as "
+                     f"generic AI, so it is held for your review instead of auto-scheduled."),
+        remediation=("Raise the personal specificity: add a first-hand detail only you could write "
+                     "(a real number, a client moment, what you got wrong), cut interchangeable "
+                     "thought-leader phrasing, and make sure the take is clearly yours."),
+        score=score, threshold=threshold, details=reasons)
+
+
+def similarity_finding(score: float, threshold: float, matched_excerpt: str = None) -> dict:
+    """Deterministic near-duplicate check against the user's own recent posts."""
+    excerpt = (matched_excerpt or "").strip().replace("\n", " ")
+    if len(excerpt) > 160:
+        excerpt = excerpt[:157].rstrip() + "…"
+    return build_finding(
+        GATE_SIMILARITY,
+        explanation=(f"This draft overlaps {round(score * 100)}% with one of your recent posts — "
+                     f"above your {round(threshold * 100)}% ceiling. Reposting the same take "
+                     f"suppresses reach for both."),
+        remediation=("Change the angle, not the words: pick a different example, argue the opposite "
+                     "side, or move the post to a new sub-topic."),
+        score=round(float(score), 4), threshold=round(float(threshold), 4),
+        details=[f"Closest recent post: “{excerpt}”"] if excerpt else None)
+
+
+def focus_finding(score: float, threshold: float, topics: Optional[list] = None) -> dict:
+    """Topic-authority (Topic DNA) governor — advisory: an off-niche post is flagged, never held."""
+    topic_list = ", ".join([str(t).strip() for t in (topics or []) if str(t).strip()])
+    return build_finding(
+        GATE_FOCUS,
+        explanation=(f"This draft scores {round(score * 100)}% against your declared focus topics "
+                     f"(target {round(threshold * 100)}%). Posting off-niche dilutes the topic "
+                     f"authority that drives your reach."),
+        remediation=("Tie the post back to a focus topic explicitly, or add the topic to Content "
+                     "Focus & Goals if this is a direction you now want to be known for."
+                     + (f" Your focus topics: {topic_list}." if topic_list else "")),
+        score=round(float(score), 4), threshold=round(float(threshold), 4), demoted=False)
+
+
+def missing_asset_finding(post_type: str) -> dict:
+    """A video/carousel post whose media never rendered — held so it can't publish assetless."""
+    kind = "video" if str(post_type).lower() == "video" else "slides"
+    return build_finding(
+        GATE_MISSING_ASSET,
+        explanation=(f"This {str(post_type).lower()} post has no {kind} yet, so it cannot be "
+                     f"published as-is."),
+        remediation=("Wait for the media backfill to finish, re-generate the post, or switch it to "
+                     "a text post."),
+        score=None, threshold=None)
+
+
+def parse_gate_findings(raw) -> list:
+    """Coerce a persisted `posts.gate_reason` value (JSON string, bytes, or already-decoded list)
+    into a list of findings. Anything unusable reads as 'no findings' — a malformed reason must
+    never break the review queue."""
+    if raw is None or raw == "":
+        return []
+    if isinstance(raw, (bytes, bytearray)):
+        raw = raw.decode("utf-8", errors="replace")
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except (ValueError, TypeError):
+            return []
+    if isinstance(raw, dict):
+        raw = [raw]
+    if not isinstance(raw, list):
+        return []
+    return [f for f in raw if isinstance(f, dict) and f.get("gate")]
+
+
+def demoting_findings(findings: Optional[list]) -> list:
+    """The findings that hold a post at PENDING (vs. the advisory notes)."""
+    return [f for f in (findings or []) if isinstance(f, dict) and f.get("demoted")]

--- a/tests/integration/test_post_gate_reason_api.py
+++ b/tests/integration/test_post_gate_reason_api.py
@@ -1,0 +1,146 @@
+"""Integration tests for the pending-reason API surface (issue #421): the posts list carries the
+gate verdict the review UI renders, and /user/post/rescore re-runs the gates on the saved content
+(promoting a fixed draft PENDING -> APPROVED) while refusing posts that aren't the caller's."""
+
+import json
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.integration
+
+_API = "cqc_lem.api.main"
+
+_FINDING = {"gate": "authenticity", "label": "Authenticity", "score": 41, "threshold": 60,
+            "demoted": True, "explanation": "scored 41 of 100", "remediation": "add specifics",
+            "details": ["no concrete detail"]}
+
+
+def _client():
+    from fastapi.testclient import TestClient
+    from cqc_lem.api.main import app
+    return TestClient(app)
+
+
+class TestPostsListCarriesTheVerdict:
+    def _post_row(self, gate_reason):
+        return {
+            "id": 42, "content": "draft", "video_url": None,
+            "scheduled_time": "2026-08-01T12:00:00", "post_type": "text", "status": "pending",
+            "carousel_slides": None, "authenticity_score": 41, "gate_reason": gate_reason,
+        }
+
+    def test_gate_reason_and_score_are_returned(self):
+        with patch(f"{_API}.get_post_by_email",
+                   return_value=([self._post_row(json.dumps([_FINDING]))], 1)):
+            r = _client().get("/api/posts/?email=test@example.com")
+        assert r.status_code == 200
+        post = r.json()["detail"]["posts"][0]
+        assert post["authenticity_score"] == 41
+        assert post["gate_reason"] == [_FINDING]
+
+    def test_a_post_with_no_verdict_returns_an_empty_list(self):
+        with patch(f"{_API}.get_post_by_email", return_value=([self._post_row(None)], 1)):
+            r = _client().get("/api/posts/?email=test@example.com")
+        assert r.json()["detail"]["posts"][0]["gate_reason"] == []
+
+    def test_a_malformed_verdict_does_not_break_the_queue(self):
+        with patch(f"{_API}.get_post_by_email", return_value=([self._post_row("{oops")], 1)):
+            r = _client().get("/api/posts/?email=test@example.com")
+        assert r.status_code == 200
+        assert r.json()["detail"]["posts"][0]["gate_reason"] == []
+
+
+class TestRescoreEndpoint:
+    def test_promotes_a_post_that_now_passes(self):
+        result = {"passed": True, "status": "approved", "authenticity_score": 88,
+                  "findings": [], "detail": "Passed every quality gate — approved and queued"}
+        with patch(f"{_API}.get_session_user_id", return_value=1), \
+             patch(f"{_API}.get_post_user_id", return_value=1), \
+             patch(f"{_API}.get_post_status", return_value="pending"), \
+             patch("cqc_lem.app.run_content_plan.rescore_post", return_value=result) as rescore:
+            r = _client().post("/api/user/post/rescore",
+                               json={"session_token": "t", "post_id": 42})
+        assert r.status_code == 200
+        assert r.json()["detail"] == result
+        rescore.assert_called_once_with(42)
+
+    def test_returns_the_findings_when_it_still_fails(self):
+        result = {"passed": False, "status": "pending", "authenticity_score": 41,
+                  "findings": [_FINDING], "detail": "Still held for review"}
+        with patch(f"{_API}.get_session_user_id", return_value=1), \
+             patch(f"{_API}.get_post_user_id", return_value=1), \
+             patch(f"{_API}.get_post_status", return_value="pending"), \
+             patch("cqc_lem.app.run_content_plan.rescore_post", return_value=result):
+            r = _client().post("/api/user/post/rescore",
+                               json={"session_token": "t", "post_id": 42})
+        detail = r.json()["detail"]
+        assert detail["passed"] is False
+        assert detail["findings"][0]["remediation"] == "add specifics"
+
+    def test_401_without_a_session(self):
+        with patch(f"{_API}.get_session_user_id", return_value=None):
+            r = _client().post("/api/user/post/rescore",
+                               json={"session_token": "bad", "post_id": 42})
+        assert r.status_code == 401
+
+    def test_404_for_someone_elses_post(self):
+        with patch(f"{_API}.get_session_user_id", return_value=1), \
+             patch(f"{_API}.get_post_user_id", return_value=2):
+            r = _client().post("/api/user/post/rescore",
+                               json={"session_token": "t", "post_id": 42})
+        assert r.status_code == 404
+
+    @pytest.mark.parametrize("status", ["posted", "rejected", "scheduled"])
+    def test_409_outside_the_review_states(self, status):
+        with patch(f"{_API}.get_session_user_id", return_value=1), \
+             patch(f"{_API}.get_post_user_id", return_value=1), \
+             patch(f"{_API}.get_post_status", return_value=status):
+            r = _client().post("/api/user/post/rescore",
+                               json={"session_token": "t", "post_id": 42})
+        assert r.status_code == 409
+
+    def test_500_when_scoring_blows_up(self):
+        with patch(f"{_API}.get_session_user_id", return_value=1), \
+             patch(f"{_API}.get_post_user_id", return_value=1), \
+             patch(f"{_API}.get_post_status", return_value="pending"), \
+             patch("cqc_lem.app.run_content_plan.rescore_post", side_effect=RuntimeError("boom")):
+            r = _client().post("/api/user/post/rescore",
+                               json={"session_token": "t", "post_id": 42})
+        assert r.status_code == 500
+
+
+class TestThresholdPreferences:
+    def test_thresholds_round_trip_through_the_prefs_endpoints(self):
+        with patch(f"{_API}.get_session_user_id", return_value=1), \
+             patch(f"{_API}.update_engagement_preferences", return_value=True) as save:
+            r = _client().put("/api/user/engagement-preferences",
+                              json={"session_token": "t", "authenticity_score_min": 85,
+                                    "post_similarity_max_pct": 40})
+        assert r.status_code == 200
+        saved = save.call_args[0][1]
+        assert saved["authenticity_score_min"] == 85
+        assert saved["post_similarity_max_pct"] == 40
+
+    def test_out_of_range_thresholds_are_clamped_at_the_boundary(self):
+        with patch(f"{_API}.get_session_user_id", return_value=1), \
+             patch(f"{_API}.update_engagement_preferences", return_value=True) as save:
+            _client().put("/api/user/engagement-preferences",
+                          json={"session_token": "t", "authenticity_score_min": 500,
+                                "post_similarity_max_pct": 1})
+        saved = save.call_args[0][1]
+        assert saved["authenticity_score_min"] == 100
+        assert saved["post_similarity_max_pct"] == 10
+
+    def test_get_exposes_the_defaults_the_ui_shows_as_placeholders(self, monkeypatch):
+        monkeypatch.setenv("AUTHENTICITY_SCORE_MIN", "60")
+        monkeypatch.setenv("POST_SIMILARITY_MAX", "0.55")
+        with patch(f"{_API}.get_session_user_id", return_value=1), \
+             patch(f"{_API}.get_engagement_preferences",
+                   return_value={"authenticity_score_min": None,
+                                 "post_similarity_max_pct": None}), \
+             patch(f"{_API}.get_or_create_reply_inbound_token", return_value="tok"), \
+             patch(f"{_API}.get_gmail_forward_confirmation", return_value=None), \
+             patch(f"{_API}.max_catchup_touches_allowed", return_value=5):
+            r = _client().get("/api/user/engagement-preferences?session_token=t")
+        assert r.json()["detail"]["gate_defaults"] == {"authenticity_score_min": 60,
+                                                       "post_similarity_max_pct": 55}

--- a/tests/unit/app/test_post_gate_reasons.py
+++ b/tests/unit/app/test_post_gate_reasons.py
@@ -1,0 +1,227 @@
+"""Unit tests for the pending-reason surface in the content plan (issue #421): the gates record WHY
+a draft is held, the status-setter demotes on exactly the findings that demote, and 'edit &
+re-score' can move a fixed post PENDING -> APPROVED without a full regenerate."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RCP = "cqc_lem.app.run_content_plan"
+_DB = "cqc_lem.utilities.db"
+
+_POST = ("Cutting AI cost is a routing problem, not a model problem.\n\nLast quarter I routed our "
+         "simplest calls to a cheap model and dropped the bill by 38%.")
+_NEAR_DUP = ("Cutting AI cost is a routing problem, not a model problem. Last quarter I routed the "
+             "simplest calls to a cheap model and dropped our bill by 38% that way.")
+
+
+class TestEvaluatePostGates:
+    def _gates(self, **kwargs):
+        from cqc_lem.app import run_content_plan as rcp
+        kwargs.setdefault("post_type", "text")
+        kwargs.setdefault("content", _POST)
+        with patch(f"{_RCP}._post_missing_required_asset",
+                   return_value=kwargs.pop("missing_asset", False)):
+            return rcp.evaluate_post_gates(42, kwargs.pop("content"), kwargs.pop("post_type"),
+                                           **kwargs)
+
+    def test_a_clean_post_has_no_findings(self):
+        assert self._gates(authenticity_score=90, recent_texts=["something else entirely"]) == []
+
+    def test_low_authenticity_is_recorded_with_score_and_threshold(self):
+        findings = self._gates(authenticity_score=41,
+                               engagement_prefs={"authenticity_score_min": 60})
+        assert [f["gate"] for f in findings] == ["authenticity"]
+        assert findings[0]["score"] == 41 and findings[0]["threshold"] == 60
+        assert findings[0]["demoted"] is True
+
+    def test_the_users_own_threshold_decides(self):
+        # Same score, looser threshold -> no hold. This is the point of the setting.
+        assert self._gates(authenticity_score=41,
+                           engagement_prefs={"authenticity_score_min": 30}) == []
+
+    def test_unscored_posts_are_never_held(self):
+        assert self._gates(authenticity_score=None) == []
+
+    def test_disabled_gate_records_nothing(self, monkeypatch):
+        monkeypatch.setenv("AUTHENTICITY_GATE_ENABLED", "off")
+        assert self._gates(authenticity_score=1) == []
+
+    def test_near_duplicate_is_recorded_against_the_post_history(self):
+        findings = self._gates(content=_NEAR_DUP, recent_texts=[_POST])
+        assert [f["gate"] for f in findings] == ["similarity"]
+        assert findings[0]["score"] > findings[0]["threshold"]
+
+    def test_similarity_is_skipped_without_history(self):
+        assert self._gates(recent_texts=None) == []
+
+    def test_off_focus_is_advisory_only(self):
+        findings = self._gates(engagement_prefs={"focus_topics": ["deep sea fishing"]})
+        assert [f["gate"] for f in findings] == ["focus_alignment"]
+        assert findings[0]["demoted"] is False
+
+    def test_on_focus_post_is_not_flagged(self):
+        assert self._gates(engagement_prefs={"focus_topics": ["routing", "AI cost"]}) == []
+
+    def test_missing_media_is_recorded(self):
+        findings = self._gates(post_type="video", missing_asset=True)
+        assert [f["gate"] for f in findings] == ["missing_asset"]
+        assert findings[0]["demoted"] is True
+
+    def test_every_failing_gate_is_reported_not_just_the_first(self):
+        findings = self._gates(content=_NEAR_DUP, post_type="video", missing_asset=True,
+                               authenticity_score=10, recent_texts=[_POST],
+                               engagement_prefs={"focus_topics": ["deep sea fishing"]})
+        assert {f["gate"] for f in findings} == {"missing_asset", "authenticity", "similarity",
+                                                 "focus_alignment"}
+
+
+class TestStatusSetterRecordsTheReason:
+    """The reason has to be persisted where the review queue reads it, on the post itself."""
+
+    def _run(self, authenticity_score=None, missing_asset=False, auto_schedule=True):
+        from cqc_lem.app import run_content_plan as rcp
+        post = [{"user_id": 1, "id": 42, "post_type": "text", "buyer_stage": "awareness"}]
+        with patch(f"{_RCP}.get_planned_posts_within_buffer", return_value=post), \
+             patch(f"{_RCP}.count_ready_posts_within_buffer", return_value=0), \
+             patch(f"{_RCP}.create_content", return_value=(_POST, None)), \
+             patch(f"{_RCP}._score_and_persist_dwell"), \
+             patch(f"{_RCP}.update_db_post_content"), \
+             patch(f"{_RCP}.update_db_post_status") as status, \
+             patch(f"{_RCP}.update_db_post_gate_reason") as reason, \
+             patch(f"{_RCP}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RCP}.get_user_preferences",
+                   return_value={"auto_schedule_posts": auto_schedule}), \
+             patch(f"{_RCP}._post_missing_required_asset", return_value=missing_asset), \
+             patch(f"{_RCP}.get_post_authenticity_score", return_value=authenticity_score):
+            rcp.auto_create_weekly_content(user_id=1)
+        return status, reason
+
+    def test_a_passing_post_is_approved_with_no_reason(self):
+        from cqc_lem.utilities.db import PostStatus
+        status, reason = self._run(authenticity_score=95)
+        status.assert_called_once_with(42, PostStatus.APPROVED)
+        reason.assert_called_once_with(42, [])
+
+    def test_low_authenticity_demotes_and_explains(self, monkeypatch):
+        from cqc_lem.utilities.db import PostStatus
+        monkeypatch.setenv("AUTHENTICITY_SCORE_MIN", "60")
+        status, reason = self._run(authenticity_score=30)
+        status.assert_called_once_with(42, PostStatus.PENDING)
+        findings = reason.call_args[0][1]
+        assert findings[0]["gate"] == "authenticity" and findings[0]["score"] == 30
+        assert findings[0]["remediation"]
+
+    def test_missing_media_demotes_and_explains(self):
+        from cqc_lem.utilities.db import PostStatus
+        status, reason = self._run(missing_asset=True)
+        status.assert_called_once_with(42, PostStatus.PENDING)
+        assert reason.call_args[0][1][0]["gate"] == "missing_asset"
+
+    def test_manual_review_users_still_get_the_reason(self):
+        from cqc_lem.utilities.db import PostStatus
+        status, reason = self._run(authenticity_score=30, auto_schedule=False)
+        status.assert_called_once_with(42, PostStatus.PENDING)
+        assert reason.call_args[0][1][0]["gate"] == "authenticity"
+
+    def test_an_unreadable_score_still_leaves_the_media_gate_holding(self):
+        # A DB hiccup on the score read must not let an assetless video post auto-approve.
+        from cqc_lem.app import run_content_plan as rcp
+        from cqc_lem.utilities.db import PostStatus
+        post = [{"user_id": 1, "id": 42, "post_type": "video", "buyer_stage": "awareness"}]
+        with patch(f"{_RCP}.get_planned_posts_within_buffer", return_value=post), \
+             patch(f"{_RCP}.count_ready_posts_within_buffer", return_value=0), \
+             patch(f"{_RCP}.create_content", return_value=(_POST, None)), \
+             patch(f"{_RCP}._score_and_persist_dwell"), \
+             patch(f"{_RCP}.update_db_post_content"), \
+             patch(f"{_RCP}.update_db_post_status") as status, \
+             patch(f"{_RCP}.update_db_post_gate_reason") as reason, \
+             patch(f"{_RCP}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RCP}.get_user_preferences", return_value={"auto_schedule_posts": True}), \
+             patch(f"{_RCP}._post_missing_required_asset", return_value=True), \
+             patch(f"{_RCP}.get_post_authenticity_score", side_effect=RuntimeError("db down")):
+            rcp.auto_create_weekly_content(user_id=1)
+        status.assert_called_once_with(42, PostStatus.PENDING)
+        assert reason.call_args[0][1][0]["gate"] == "missing_asset"
+
+    def test_a_failed_reason_write_never_fails_the_post(self):
+        from cqc_lem.app import run_content_plan as rcp
+        post = [{"user_id": 1, "id": 42, "post_type": "text", "buyer_stage": "awareness"}]
+        with patch(f"{_RCP}.get_planned_posts_within_buffer", return_value=post), \
+             patch(f"{_RCP}.count_ready_posts_within_buffer", return_value=0), \
+             patch(f"{_RCP}.create_content", return_value=(_POST, None)), \
+             patch(f"{_RCP}._score_and_persist_dwell"), \
+             patch(f"{_RCP}.update_db_post_content") as content, \
+             patch(f"{_RCP}.update_db_post_status"), \
+             patch(f"{_RCP}.update_db_post_gate_reason", side_effect=RuntimeError("db down")), \
+             patch(f"{_RCP}.get_engagement_preferences", side_effect=RuntimeError("db down")), \
+             patch(f"{_RCP}.get_user_preferences", return_value={"auto_schedule_posts": True}), \
+             patch(f"{_RCP}._post_missing_required_asset", return_value=False), \
+             patch(f"{_RCP}.get_post_authenticity_score", return_value=None):
+            rcp.auto_create_weekly_content(user_id=1)
+        content.assert_called_once_with(42, _POST)
+
+
+class TestRescorePost:
+    def _rescore(self, content=_POST, score=90, status="pending", auto_schedule=True,
+                 recent=None, prefs=None):
+        from cqc_lem.app import run_content_plan as rcp
+        with patch(f"{_DB}.get_post_user_id", return_value=1), \
+             patch(f"{_RCP}.get_post_content", return_value=content), \
+             patch(f"{_DB}.get_post_type", return_value="text"), \
+             patch(f"{_DB}.get_post_video_url", return_value=None), \
+             patch(f"{_DB}.get_post_status", return_value=status), \
+             patch(f"{_RCP}.get_engagement_preferences", return_value=prefs or {}), \
+             patch(f"{_RCP}.load_profile_for_user", return_value=MagicMock()), \
+             patch(f"{_RCP}.get_or_create_profile_synthesis", return_value="voice"), \
+             patch(f"{_RCP}._score_and_persist_authenticity") as judge, \
+             patch(f"{_RCP}.get_post_authenticity_score", return_value=score), \
+             patch(f"{_RCP}.get_recent_post_texts", return_value=list(recent or [])) as history, \
+             patch(f"{_RCP}._post_missing_required_asset", return_value=False), \
+             patch(f"{_RCP}.update_db_post_gate_reason") as reason, \
+             patch(f"{_RCP}.update_db_post_status") as new_status, \
+             patch(f"{_RCP}.get_user_preferences",
+                   return_value={"auto_schedule_posts": auto_schedule}):
+            result = rcp.rescore_post(42)
+        return result, new_status, reason, judge, history
+
+    def test_a_fixed_post_is_promoted_without_a_regenerate(self):
+        from cqc_lem.utilities.db import PostStatus
+        result, status, reason, judge, _ = self._rescore(score=88)
+        assert result["passed"] is True and result["status"] == PostStatus.APPROVED.value
+        status.assert_called_once_with(42, PostStatus.APPROVED)
+        reason.assert_called_once_with(42, [])
+        # The edited text is re-judged — a stale score would survive a genuine rewrite.
+        assert judge.called
+
+    def test_a_still_failing_post_keeps_a_fresh_reason(self, monkeypatch):
+        monkeypatch.setenv("AUTHENTICITY_SCORE_MIN", "60")
+        result, status, reason, _, _ = self._rescore(score=20)
+        assert result["passed"] is False
+        assert result["findings"][0]["gate"] == "authenticity"
+        assert reason.call_args[0][1] == result["findings"]
+        status.assert_not_called()
+
+    def test_history_excludes_the_post_itself(self):
+        # The post is already saved, so it would otherwise match itself at 100%.
+        _, _, _, _, history = self._rescore(recent=["an older post"])
+        assert history.call_args.kwargs["exclude_post_id"] == 42
+
+    def test_manual_approval_users_are_not_auto_approved(self):
+        result, status, _, _, _ = self._rescore(score=95, auto_schedule=False)
+        assert result["passed"] is True and result["status"] == "pending"
+        status.assert_not_called()
+        assert "auto-scheduling is off" in result["detail"]
+
+    def test_an_approved_post_that_passes_stays_approved(self):
+        result, status, _, _, _ = self._rescore(score=95, status="approved")
+        assert result["passed"] is True and result["status"] == "approved"
+        status.assert_not_called()
+
+    def test_empty_post_is_reported_not_crashed(self):
+        from cqc_lem.app import run_content_plan as rcp
+        with patch(f"{_DB}.get_post_user_id", return_value=1), \
+             patch(f"{_RCP}.get_post_content", return_value=None):
+            result = rcp.rescore_post(42)
+        assert result["passed"] is False and result["findings"] == []

--- a/tests/unit/utilities/test_db_gate_reason.py
+++ b/tests/unit/utilities/test_db_gate_reason.py
@@ -1,0 +1,138 @@
+"""Unit tests for the DB side of the pending-reason surface (issue #421): the gate_reason
+round-trip, the self-exclusion the re-score path needs from the post history, and the clamping of
+the user-tunable gate thresholds in the single-row engagement upsert."""
+
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+_FINDING = {"gate": "authenticity", "label": "Authenticity", "score": 41, "threshold": 60,
+            "demoted": True, "explanation": "scored 41", "remediation": "add specifics",
+            "details": []}
+
+
+def _mock_conn(fetch_one=None, fetch_all=None, rowcount=1):
+    conn = MagicMock(); cur = MagicMock()
+    cur.fetchone.return_value = fetch_one
+    cur.fetchall.return_value = fetch_all or []
+    cur.rowcount = rowcount
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestUpdateDbPostGateReason:
+    def test_stores_the_findings_as_json(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_db_post_gate_reason
+            assert update_db_post_gate_reason(7, [_FINDING]) is True
+        sql, params = cur.execute.call_args[0]
+        assert "UPDATE posts SET gate_reason" in sql
+        assert json.loads(params[0]) == [_FINDING] and params[1] == 7
+
+    @pytest.mark.parametrize("findings", [None, []])
+    def test_no_findings_clears_the_column(self, findings):
+        # A post that passes on re-score must stop showing a stale reason.
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_db_post_gate_reason
+            assert update_db_post_gate_reason(7, findings) is True
+        assert cur.execute.call_args[0][1] == (None, 7)
+
+    def test_false_on_db_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_db_post_gate_reason
+            assert update_db_post_gate_reason(7, [_FINDING]) is False
+
+
+class TestGetPostGateReason:
+    def test_parses_the_stored_json(self):
+        conn, _ = _mock_conn(fetch_one=(json.dumps([_FINDING]),))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_gate_reason
+            assert get_post_gate_reason(7) == [_FINDING]
+
+    @pytest.mark.parametrize("row", [(None,), None])
+    def test_empty_when_never_evaluated(self, row):
+        conn, _ = _mock_conn(fetch_one=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_gate_reason
+            assert get_post_gate_reason(7) == []
+
+    def test_empty_on_db_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_gate_reason
+            assert get_post_gate_reason(7) == []
+
+
+class TestPostsQueryExposesTheVerdict:
+    def test_get_posts_selects_the_quality_columns(self):
+        conn, cur = _mock_conn(fetch_one={"total": 0}, fetch_all=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_posts
+            get_posts(1)
+        sql = cur.execute.call_args_list[-1][0][0]
+        assert "authenticity_score" in sql and "gate_reason" in sql
+
+
+class TestRecentPostTextsExclusion:
+    def test_excludes_the_post_being_rescored(self):
+        conn, cur = _mock_conn(fetch_all=[("older post",)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_recent_post_texts
+            assert get_recent_post_texts(1, limit=5, exclude_post_id=42) == ["older post"]
+        sql, params = cur.execute.call_args[0]
+        assert "id <> %s" in sql
+        assert params == (1, 42, 5)
+
+    def test_no_exclusion_keeps_the_original_query(self):
+        conn, cur = _mock_conn(fetch_all=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_recent_post_texts
+            get_recent_post_texts(1, limit=5)
+        sql, params = cur.execute.call_args[0]
+        assert "id <> %s" not in sql
+        assert params == (1, 5)
+
+
+class TestEngagementThresholdPersistence:
+    def _saved(self, prefs):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.max_catchup_touches_allowed", return_value=5):
+            from cqc_lem.utilities.db import update_engagement_preferences, _ENGAGEMENT_COLS
+            assert update_engagement_preferences(1, prefs) is True
+        values = cur.execute.call_args[0][1]
+        return dict(zip(_ENGAGEMENT_COLS, values[1:]))
+
+    def test_thresholds_persist(self):
+        saved = self._saved({"authenticity_score_min": 80, "post_similarity_max_pct": 40})
+        assert saved["authenticity_score_min"] == 80
+        assert saved["post_similarity_max_pct"] == 40
+
+    def test_unset_thresholds_stay_null(self):
+        # NULL means "follow the deploy default" — the gates must behave exactly as before.
+        saved = self._saved({})
+        assert saved["authenticity_score_min"] is None
+        assert saved["post_similarity_max_pct"] is None
+
+    def test_out_of_range_thresholds_are_clamped_not_rejected(self):
+        # The whole engagement upsert is ONE row (the V52 lesson): a bad value must not roll back
+        # every other section.
+        saved = self._saved({"authenticity_score_min": 999, "post_similarity_max_pct": 0})
+        assert saved["authenticity_score_min"] == 100
+        assert saved["post_similarity_max_pct"] == 10
+
+    def test_unparseable_threshold_falls_back_to_the_default(self):
+        saved = self._saved({"authenticity_score_min": "loose"})
+        assert saved["authenticity_score_min"] is None

--- a/tests/unit/utilities/test_quality_gates.py
+++ b/tests/unit/utilities/test_quality_gates.py
@@ -1,0 +1,122 @@
+"""Unit tests for the quality-gate reasons the review UI renders (issue #421): every finding carries
+the score it failed on, the threshold it failed against, and a specific remediation; the persisted
+JSON round-trips; and the user's own thresholds override the deploy defaults."""
+
+import json
+import pytest
+
+pytestmark = pytest.mark.unit
+
+from cqc_lem.utilities.quality_gates import (  # noqa: E402
+    GATE_AUTHENTICITY, GATE_SIMILARITY, GATE_FOCUS, GATE_MISSING_ASSET,
+    AUTHENTICITY_SCORE_MIN_BOUNDS, SIMILARITY_MAX_PCT_BOUNDS,
+    authenticity_finding, similarity_finding, focus_finding, missing_asset_finding,
+    clamp_threshold, parse_gate_findings, demoting_findings)
+
+
+class TestFindings:
+    def test_authenticity_carries_score_threshold_and_reasons(self):
+        f = authenticity_finding(41, 60, ["no concrete specifics", "buzzword filler"])
+        assert f["gate"] == GATE_AUTHENTICITY and f["demoted"] is True
+        assert f["score"] == 41 and f["threshold"] == 60
+        assert "41" in f["explanation"] and "60" in f["explanation"]
+        assert f["remediation"]
+        assert f["details"] == ["no concrete specifics", "buzzword filler"]
+
+    def test_similarity_reads_as_percentages_and_quotes_the_match(self):
+        f = similarity_finding(0.71, 0.55, "Why routing LLM calls by complexity cuts cost")
+        assert f["gate"] == GATE_SIMILARITY and f["demoted"] is True
+        assert "71%" in f["explanation"] and "55%" in f["explanation"]
+        assert "routing LLM calls" in f["details"][0]
+
+    def test_similarity_truncates_a_long_match(self):
+        f = similarity_finding(0.9, 0.55, "word " * 100)
+        assert len(f["details"][0]) < 200 and f["details"][0].endswith("”")
+
+    def test_similarity_without_a_match_has_no_details(self):
+        assert similarity_finding(0.9, 0.55, None)["details"] == []
+
+    def test_focus_alignment_is_advisory_and_names_the_topics(self):
+        f = focus_finding(0.02, 0.15, ["AI adoption", "B2B sales"])
+        assert f["gate"] == GATE_FOCUS
+        # #384 deliberately never blocks the pipeline on an off-niche post — it only warns.
+        assert f["demoted"] is False
+        assert "AI adoption" in f["remediation"]
+
+    @pytest.mark.parametrize("post_type,expected", [("video", "video"), ("carousel", "slides"),
+                                                    ("document", "slides")])
+    def test_missing_asset_names_the_missing_media(self, post_type, expected):
+        f = missing_asset_finding(post_type)
+        assert f["gate"] == GATE_MISSING_ASSET and f["demoted"] is True
+        assert expected in f["explanation"]
+        assert f["score"] is None and f["threshold"] is None
+
+    def test_every_finding_has_a_label_and_a_fix(self):
+        for f in (authenticity_finding(10, 60), similarity_finding(0.9, 0.55),
+                  focus_finding(0.0, 0.15, []), missing_asset_finding("video")):
+            assert f["label"] and f["explanation"] and f["remediation"]
+
+
+class TestParseGateFindings:
+    def test_round_trips_persisted_json(self):
+        findings = [authenticity_finding(41, 60), missing_asset_finding("video")]
+        assert parse_gate_findings(json.dumps(findings)) == findings
+
+    def test_accepts_bytes_and_decoded_values(self):
+        findings = [authenticity_finding(41, 60)]
+        assert parse_gate_findings(json.dumps(findings).encode()) == findings
+        assert parse_gate_findings(findings) == findings
+        assert parse_gate_findings(findings[0]) == findings
+
+    @pytest.mark.parametrize("raw", [None, "", "not json", "[1, 2]", '{"no": "gate"}', "42"])
+    def test_unusable_values_read_as_no_findings(self, raw):
+        # A malformed reason must never break the review queue.
+        assert parse_gate_findings(raw) == []
+
+    def test_demoting_findings_filters_out_advisories(self):
+        findings = [authenticity_finding(41, 60), focus_finding(0.0, 0.15, [])]
+        assert demoting_findings(findings) == [findings[0]]
+        assert demoting_findings(None) == []
+
+
+class TestClampThreshold:
+    @pytest.mark.parametrize("value,expected", [(None, None), ("", None), ("nope", None),
+                                                (-10, 0), (0, 0), (60, 60), (140, 100), ("75", 75)])
+    def test_authenticity_bounds(self, value, expected):
+        assert clamp_threshold(value, *AUTHENTICITY_SCORE_MIN_BOUNDS) == expected
+
+    @pytest.mark.parametrize("value,expected", [(None, None), (0, 10), (55, 55), (250, 100)])
+    def test_similarity_bounds(self, value, expected):
+        assert clamp_threshold(value, *SIMILARITY_MAX_PCT_BOUNDS) == expected
+
+
+class TestUserThresholdsOverrideDefaults:
+    def test_authenticity_min_prefers_the_users_setting(self, monkeypatch):
+        from cqc_lem.utilities.ai.content_alignment import authenticity_score_min
+        monkeypatch.setenv("AUTHENTICITY_SCORE_MIN", "60")
+        assert authenticity_score_min({"authenticity_score_min": 85}) == 85
+        # Unset / unusable overrides fall back to the deploy default.
+        assert authenticity_score_min({"authenticity_score_min": None}) == 60
+        assert authenticity_score_min({"authenticity_score_min": "bad"}) == 60
+        assert authenticity_score_min({}) == 60
+        assert authenticity_score_min() == 60
+
+    def test_authenticity_min_override_is_clamped(self, monkeypatch):
+        from cqc_lem.utilities.ai.content_alignment import authenticity_score_min
+        monkeypatch.delenv("AUTHENTICITY_SCORE_MIN", raising=False)
+        assert authenticity_score_min({"authenticity_score_min": 500}) == 100
+        assert authenticity_score_min({"authenticity_score_min": -5}) == 0
+
+    def test_similarity_max_prefers_the_users_percent(self, monkeypatch):
+        from cqc_lem.utilities.ai.content_framework import post_similarity_max
+        monkeypatch.setenv("POST_SIMILARITY_MAX", "0.55")
+        assert post_similarity_max({"post_similarity_max_pct": 40}) == pytest.approx(0.40)
+        assert post_similarity_max({"post_similarity_max_pct": None}) == pytest.approx(0.55)
+        assert post_similarity_max() == pytest.approx(0.55)
+
+    def test_similarity_max_override_is_clamped_into_a_usable_band(self, monkeypatch):
+        from cqc_lem.utilities.ai.content_framework import post_similarity_max
+        monkeypatch.delenv("POST_SIMILARITY_MAX", raising=False)
+        # 0% would flag every post as a duplicate of everything.
+        assert post_similarity_max({"post_similarity_max_pct": 0}) == pytest.approx(0.10)
+        assert post_similarity_max({"post_similarity_max_pct": 900}) == pytest.approx(1.0)


### PR DESCRIPTION
## What & why

When a quality gate demoted a draft APPROVED → PENDING, the review queue showed the post but not **which** gate fired, the score it fired on, or what to do about it. This makes the hold explainable, fixable, and tunable.

### Structured demotion reasons
- New `src/cqc_lem/utilities/quality_gates.py` — one pure (no DB/LLM/env) source for a gate **finding**: `gate`, `label`, `score`, `threshold`, `demoted`, `explanation`, `remediation`, `details`, plus parsing/clamping helpers shared by the pipeline and the API.
- Migration `V20260726000134` adds `posts.gate_reason JSON NULL` (alongside `authenticity_score`/`dwell_score`) and the two threshold columns on `engagement_preferences`.
- `evaluate_post_gates()` in `run_content_plan.py` is the single evaluator; the content-plan status-setter, `regenerate_post` and the re-score endpoint all go through it. It demotes on exactly the findings marked `demoted` — **media missing** and **authenticity below the minimum**, i.e. the same two gates that demote today. **Behaviour note:** off-focus (`focus_alignment`) is recorded as *advisory*, not a demotion — #384 deliberately never blocks the pipeline on an off-niche post, so it's surfaced with its score + fix rather than changing what gets held. The near-duplicate gate demotes only in the re-score path, where the full history is available.
- Persisting a reason is best-effort at every call site: a prefs/score/write failure costs the explanation, never the post (and an unreadable authenticity score still leaves the media gate holding).

### Edit & re-score
- `POST /user/post/rescore` (pending/approved only; 401/404/409/500 handled) re-judges authenticity on the **current** content and re-runs media, near-duplicate (history excludes the post itself, which would otherwise match at 100%) and focus checks. A draft that now clears every gate is promoted PENDING → APPROVED with no full regenerate; when the user has auto-scheduling off it stays PENDING with the reason cleared.

### UI
- `/posts/` returns `authenticity_score` + `gate_reason`; Content Studio's editor renders a "⏸ Why this is pending" panel — badge per gate, score vs *your* limit, the specific fix, "Save & re-score", and a link to the thresholds — and the list shows a one-line hint on held drafts.
- Account → Content Focus & Goals gains **Review thresholds**: min authenticity score (0-100) and max overlap with your recent posts (10-100%). Blank = the deploy default, which the API returns as `gate_defaults` for the placeholder. Values are clamped at the API boundary *and* in the DB upsert (the V52 single-row-rollback lesson).

## Testing

- `tests/unit/utilities/test_quality_gates.py` (34) — finding copy/shape, JSON round-trip + malformed-input safety, clamping, and per-user thresholds overriding `AUTHENTICITY_SCORE_MIN` / `POST_SIMILARITY_MAX`.
- `tests/unit/utilities/test_db_gate_reason.py` (15) — `gate_reason` write/read/clear, the posts query exposing the verdict, history self-exclusion, threshold persistence + clamping.
- `tests/unit/app/test_post_gate_reasons.py` (23) — every gate's finding, the status-setter demoting + recording, and re-score promotion / still-failing / manual-approval / degraded-DB paths.
- `tests/integration/test_post_gate_reason_api.py` (14) — posts-list verdict, the re-score endpoint's success and error codes, and the threshold round-trip.
- Full suite locally: `5453 unit passed`, `90 integration passed, 2 skipped`. SPA `tsc -b` clean; eslint clean on all touched/new files (one pre-existing error in `ContentStudio.tsx` untouched).

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)