### PR TITLE
perf(scheduler): stagger the fixed-time engagement fan-outs per user (closes #554)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,20 @@ CATCHUP_HARVEST_LINKEDIN_DRAFT=true
 # Default best posting hour per weekday (Monday..Sunday, 24h user-local hours) used by the content
 # planner until a user has enough post-stats for personalized times. Default = the 2026 peak model.
 DEFAULT_POSTING_HOURS=16,15,16,17,11,10,18
+# Staggered daily fan-outs (issue #554). Each beat ticks every 15 min and dispatches only the users
+# whose slot has come up: the window OPENS at <NAME>_ANCHOR_HOUR and every user gets a stable
+# hashed minute inside <NAME>_WINDOW_MINUTES, so N users spread out instead of hitting one Selenium
+# lane in the same minute. <NAME>_ANCHOR_TZ=local (default) anchors the hour on the USER's timezone;
+# utc anchors it globally. Set a window of 1 to put everyone back on the anchor minute at once.
+GOLDEN_HOUR_ANCHOR_HOUR=9
+GOLDEN_HOUR_WINDOW_MINUTES=180
+GOLDEN_HOUR_ANCHOR_TZ=local
+APPRECIATION_DM_ANCHOR_HOUR=8
+APPRECIATION_DM_WINDOW_MINUTES=120
+APPRECIATION_DM_ANCHOR_TZ=local
+GROUP_ENGAGEMENT_ANCHOR_HOUR=12
+GROUP_ENGAGEMENT_WINDOW_MINUTES=120
+GROUP_ENGAGEMENT_ANCHOR_TZ=local
 # DM conversation auto-nurture: when a lead replies to one of our DMs, draft the context-aware next
 # message instead of letting the thread go cold. The draft lands as a PENDING scheduled DM in the
 # same queue the operator already approves — nothing sends itself.

--- a/docs/scaling-plan.md
+++ b/docs/scaling-plan.md
@@ -147,15 +147,15 @@ lane, no browser):
 |---|---|---|---|
 | `check-scheduled-posts` | `*/10 min` | `post_to_linkedin` (ETA=post time) + **`automate_commenting` ETA = post − 15 min** + `automate_profile_viewer_engagement` ETA = post − 10 min + `auto_seed_comment_on_post` ETA = post + 3 min | celery / **se_engage** / se_outreach / se_content |
 | `check-scheduled-dms` | `*/10 min` | `send_scheduled_dm` (ETA) | se_outreach |
-| `daily-golden-hour-engagement` | **`13:00` (all users at once)** | `automate_commenting` (15-min loop) per active user | **se_engage** |
+| `daily-golden-hour-engagement` | `*/15 min` tick; each user dispatched at their own slot (#554) | `automate_commenting` (15-min loop) per active user | **se_engage** |
 | `dispatch-scheduled-reply-sweeps` | `*/30 min` | `sweep_reply_comments` per scheduled-mode user (Redis-gated to cadence) | se_engage |
 | `send-due-dm-followups` | `*/30 min` | `process_user_followups` per user | se_outreach |
 | `publish-scheduled-newsletters` | `:05 hourly` | `auto_publish_edition` per due edition | se_content |
 
 ### Fixed off-peak batch (all single crontabs, fan out over active users)
 
-`generate-newsletter-drafts` 10:00 · `send-appreciation-dms` 08:00 ·
-`group-engagement` 16:00 · `group-posts` Tue 15:00 · `scrape-post-stats` 23:00 ·
+`generate-newsletter-drafts` 10:00 · `send-appreciation-dms` 08:00 local (staggered, #554) ·
+`group-engagement` 12:00 local (staggered, #554) · `group-posts` Tue 15:00 · `scrape-post-stats` 23:00 ·
 `sync-user-groups` Mon 07:00 · `refresh-profile-syntheses` Mon 04:30 ·
 `invite_to_company_pages` 1st 05:00 · `backfill-missing-assets` `*/3h` ·
 content-plan 01:00 / 01:30 · Stripe sync 06:00 · cleanups 02:00/03:00.
@@ -173,12 +173,13 @@ latency/cost, not the browser.
    (concurrency 2). If ≥3 users have posts within the same ~15-minute span, the 3rd+
    task waits behind a running 15-minute loop and fires **after** its window — the
    pre-post comment burst lands late or after the post is already live.
-2. **The single `13:00` golden-hour fan-out.** `auto_daily_engagement` dispatches
-   one 15-minute `automate_commenting` loop per active user, all at once, onto
-   `se_engage`. Throughput = 2 slots ÷ 15 min = **~8 users/hour**. At 50 users the
-   queue takes **~6 hours** to drain; the last users' "golden-hour" engagement runs
-   in the afternoon. `QueueOnce(keys=['user_id'])` prevents double-runs but does not
-   add throughput.
+2. **The single `13:00` golden-hour fan-out — FIXED by #554.** `auto_daily_engagement`
+   used to dispatch one 15-minute `automate_commenting` loop per active user, all at
+   once, onto `se_engage`. Throughput = 2 slots ÷ 15 min = **~8 users/hour**, so at 50
+   users the queue took **~6 hours** to drain and the last users' "golden hour" ran in
+   the afternoon. `QueueOnce(keys=['user_id'])` prevented double-runs but added no
+   throughput. It is now a `*/15 min` tick that dispatches only the users whose staggered
+   per-user slot has come up (§5d), so arrivals match what the lane can drain.
 3. **`se_content` / `se_outreach` single-slot lanes.** Newsletter publishing, stats
    scrape, group sync/posts all share one `se_content` slot; DMs, followups, invites,
    profile-viewer engagement share one `se_outreach` slot. Fine for 1 user, serial
@@ -329,10 +330,20 @@ concurrency rises:
   user** — otherwise one user trips the breaker for everyone. **Key the breaker per
   user/proxy** before onboarding many users on distinct IPs (today's global key is
   correct only while everyone shares one IP). See `AUTOMATION_COOLDOWN.md`.
-- **Stagger fixed-time fan-outs.** Replace the single `13:00` golden-hour crontab
-  with a per-user offset (spread across the user's local peak window) so N users don't
-  hit `se_engage` in the same minute. This flattens the concurrency spike and is the
-  single highest-leverage change for "on-time" behavior at low cost.
+- **Stagger fixed-time fan-outs. APPLIED (issue #554).** The single `13:00` golden-hour
+  crontab is gone. `daily-golden-hour-engagement`, `send-appreciation-dms` and
+  `group-engagement` now tick every 15 min (`STAGGER_TICK_MINUTES`) and each dispatches
+  only the users whose slot has come up: `plan_daily_slot` in
+  `utilities/engagement_window.py` gives every user a stable hashed minute inside a window
+  that opens at an anchor hour **in that user's own timezone** (golden hour 09:00 local
+  +0–180 min, appreciation DMs 08:00 local +0–120, groups 12:00 local +0–120; all three
+  retunable with `<NAME>_ANCHOR_HOUR` / `<NAME>_WINDOW_MINUTES` / `<NAME>_ANCHOR_TZ`, and a
+  window of `1` restores "everyone at once"). A Redis claim (`engagement:slot:<NAME>:<user>`)
+  keeps it to one run per user per day and lets a slot missed by a beat outage — or by an
+  open 429 breaker — catch up on a later tick instead of being lost for the day. Per-user
+  `QueueOnce` and the per-day caps are untouched. With a 3-hour window, `se_engage` sees
+  ~1 golden-hour loop per 15-min tick at 12 users instead of 12 at once — the table in §4
+  reads off the staggered rows now.
 - **Human pacing per session** (already present via loop durations + jitter) must not
   be shortened to gain throughput — add sessions, not speed.
 
@@ -381,7 +392,8 @@ have stopped holding:
 - ✅ `SE_NODE_MAX_SESSIONS → 8`, `shm → 8g`, Chrome cpus `4 → 8` (#552) — the four lanes
   now sum to 8, the top of this box's Chrome budget (§4).
 - ✅ Capacity monitor (§5e) to detect when these numbers stop holding (#552).
-- **Stagger `auto_daily_engagement`** by per-user offset.
+- ✅ **Stagger the fixed-time fan-outs** by per-user offset (#554) — `auto_daily_engagement`,
+  `auto_appreciate_dms`, `auto_group_engagement`.
 - All fits the current 8 vCPU / 31 GB box.
 
 **Phase 2 — ~50 users:**

--- a/docs/scaling-plan.md
+++ b/docs/scaling-plan.md
@@ -338,9 +338,11 @@ concurrency rises:
   that opens at an anchor hour **in that user's own timezone** (golden hour 09:00 local
   +0–180 min, appreciation DMs 08:00 local +0–120, groups 12:00 local +0–120; all three
   retunable with `<NAME>_ANCHOR_HOUR` / `<NAME>_WINDOW_MINUTES` / `<NAME>_ANCHOR_TZ`, and a
-  window of `1` restores "everyone at once"). A Redis claim (`engagement:slot:<NAME>:<user>`)
-  keeps it to one run per user per day and lets a slot missed by a beat outage — or by an
-  open 429 breaker — catch up on a later tick instead of being lost for the day. Per-user
+  window of `1` restores "everyone at once"). A Redis claim
+  (`engagement:slot:<NAME>:<user>:<local date>`) keeps it to one run per user per local day
+  and lets a slot missed by a beat outage — or by an open 429 breaker — catch up on a later
+  tick instead of being lost for the day; keying the claim by the slot's own date is what
+  keeps such a late catch-up from still being held at the next day's slot. Per-user
   `QueueOnce` and the per-day caps are untouched. With a 3-hour window, `se_engage` sees
   ~1 golden-hour loop per 15-min tick at 12 users instead of 12 at once — the table in §4
   reads off the staggered rows now.

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -9,6 +9,7 @@ from celery.app.control import Inspect
 
 from cqc_lem.app import celeryconfig
 from cqc_lem.app.celeryconfig import broker_url
+from cqc_lem.utilities.engagement_window import STAGGER_TICK_MINUTES
 from cqc_lem.utilities.env_constants import CODE_TRACING, AWS_REGION
 from cqc_lem.utilities.jaeger_tracer_helper import get_jaeger_tracer
 from cqc_lem.utilities.logger import myprint, logger
@@ -122,7 +123,10 @@ app.conf.update(
         },
         'daily-golden-hour-engagement': {
             'task': 'cqc_lem.app.run_scheduler.auto_daily_engagement',
-            'schedule': crontab(hour='13', minute='0')  # Daily peak-hour feed commenting (~9am ET), on top of pre-post
+            # Ticks every STAGGER_TICK_MINUTES; the task itself dispatches only the users whose
+            # staggered slot has come up, spreading peak-hour feed commenting across each user's
+            # local window instead of handing se_engage the whole fleet at once (issue #554).
+            'schedule': crontab(minute=f'*/{STAGGER_TICK_MINUTES}')
         },
         'dispatch-comment-followups': {
             'task': 'cqc_lem.app.run_scheduler.dispatch_comment_followups',
@@ -160,7 +164,8 @@ app.conf.update(
         },
         'group-engagement': {
             'task': 'cqc_lem.app.run_scheduler.auto_group_engagement',
-            'schedule': crontab(hour='16', minute='0')  # Daily value-add commenting in enabled groups
+            # Daily value-add commenting in enabled groups, at each user's staggered slot (#554)
+            'schedule': crontab(minute=f'*/{STAGGER_TICK_MINUTES}')
         },
         'group-posts': {
             'task': 'cqc_lem.app.run_scheduler.auto_group_posts',
@@ -212,7 +217,7 @@ app.conf.update(
         },
         'send-appreciation-dms': {
             'task': 'cqc_lem.app.run_scheduler.auto_appreciate_dms',
-            'schedule': crontab(hour='8', minute='0')  # Run every day at 8:00 AM
+            'schedule': crontab(minute=f'*/{STAGGER_TICK_MINUTES}')  # per-user staggered slot (#554)
         },
         'rollup-llm-costs': {
             'task': 'cqc_lem.app.run_scheduler.auto_rollup_llm_costs',

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1,6 +1,7 @@
 import os
 import shutil
 from datetime import timedelta, datetime, timezone
+from typing import Tuple
 
 from celery_once import QueueOnce
 
@@ -22,12 +23,15 @@ from cqc_lem.utilities.db import (
     get_users_with_reply_mode, get_engagement_preferences,
     get_approved_catchup_touches, get_orphaned_catchup_touches, update_catchup_touch_status,
     count_catchup_touches_sent_today, CatchupTouchStatus, max_catchup_touches_allowed,
+    get_user_timezone,
 )
 from cqc_lem.utilities.engagement_window import (
     plan_pre_post_window, record_pre_post_scheduled, record_pre_post_skipped,
     PRE_POST_COMMENT_LEAD_MINUTES, PRE_POST_VIEWER_LEAD_MINUTES,
     PRE_POST_SKIP_PAST_WINDOW, PRE_POST_SKIP_THROTTLED, PRE_POST_SKIP_USER_INACTIVE,
     PRE_POST_TASK_VIEWER,
+    claim_daily_slot, plan_daily_slot, stagger_config,
+    STAGGER_APPRECIATION_DM, STAGGER_GOLDEN_HOUR, STAGGER_GROUP_ENGAGEMENT,
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES, \
     COST_ROUTING_WINDOW_DAYS
@@ -54,6 +58,26 @@ def _skip_if_throttled(name: str, **context) -> bool:
         return True
     return False
 
+
+def _stagger_due(user_id: int, fanout: Tuple[str, int, int], task_name: str) -> bool:
+    """True when THIS beat tick owns the user's staggered slot for `fanout` today (issue #554).
+
+    The fan-out beats run every STAGGER_TICK_MINUTES and dispatch only the users whose slot has
+    come up, so N users spread across the window instead of landing on one lane in one minute.
+    Redis holds the once-a-day claim, which also buys a catch-up: a slot missed because the beat
+    (or the 429 breaker) was down fires at the next tick instead of being lost for the day. With
+    no Redis the strict one-tick window keeps it to a single dispatch."""
+    config = stagger_config(fanout)
+    tz_name = get_user_timezone(user_id) if config.local else "UTC"
+    slot = plan_daily_slot(user_id, config, tz_name)
+    if not slot.reached:
+        return False
+    claimed = claim_daily_slot(user_id, config.name)
+    due = slot.in_tick_window if claimed is None else claimed
+    if due:
+        log_debug(f"{task_name} slot due (local {slot.local_at:%H:%M}, +{slot.offset_minutes}m)",
+                  user_id=user_id, task_name=task_name)
+    return due
 
 
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, }, reject_on_worker_lost=True)
@@ -244,10 +268,14 @@ def auto_check_connection_requests(self):
 def auto_appreciate_dms():
     if _skip_if_throttled("auto_appreciate_dms"):
         return "Automation throttled"
-    # For each user schedule appreciate DMS
+    # For each user schedule appreciate DMS — at that user's staggered slot, so the single
+    # se_outreach lane isn't handed the whole fleet in one minute (issue #554).
     users = get_active_user_ids()
+    dispatched = 0
 
     for user_id in users:
+        if not _stagger_due(user_id, STAGGER_APPRECIATION_DM, "auto_appreciate_dms"):
+            continue
         # Send appreciation DM for 5 minutes
         kwargs = {
             'user_id': user_id,
@@ -261,20 +289,25 @@ def auto_appreciate_dms():
                                                            'interval_start': 60,
                                                            'interval_step': 30
                                                        })
+        dispatched += 1
     if len(users) == 0:
         return f"No Active Users"
     else:
-        return f"Started Appreciate DM Process for {len(users)} user(s)"
+        return f"Started Appreciate DM Process for {dispatched}/{len(users)} user(s)"
 
 
 @shared_task.task
 def auto_daily_engagement():
-    """Daily golden-hour feed-commenting run — fires EVERY day at a peak engagement window, on
-    top of the pre-post commenting that already runs around each scheduled post. This gives a
-    consistent daily reciprocity burst even when a post is (or isn't) scheduled. Volume stays safe
-    because both this run and the pre-post runs share the per-day comment cap (enforced in
-    comment_on_feed_inline), and QueueOnce (keys=['user_id']) prevents overlapping double-runs for
-    the same user."""
+    """Daily golden-hour feed-commenting run — fires EVERY day inside each user's own peak
+    engagement window, on top of the pre-post commenting that already runs around each scheduled
+    post. This gives a consistent daily reciprocity burst even when a post is (or isn't) scheduled.
+
+    The beat ticks every STAGGER_TICK_MINUTES and dispatches only the users whose staggered slot
+    has come up (issue #554): `se_engage` drains ~8 of these 15-minute loops an hour, so fanning
+    the whole fleet out at one crontab pushed later users hours past the window they were meant
+    for. Volume stays safe because this run and the pre-post runs share the per-day comment cap
+    (enforced in comment_on_feed_inline), and QueueOnce (keys=['user_id']) prevents overlapping
+    double-runs for the same user."""
     if _skip_if_throttled("auto_daily_engagement"):
         return "Automation throttled"
     users = get_active_user_ids()
@@ -282,6 +315,10 @@ def auto_daily_engagement():
     for user_id in users:
         if not has_linkedin_session(user_id):
             continue  # no session → the Selenium task would just fail and waste a Chrome slot
+        # Session check first: the slot claim is consumed for the day, so a user who couldn't run
+        # anyway must not burn theirs — connecting later in the day still earns a run.
+        if not _stagger_due(user_id, STAGGER_GOLDEN_HOUR, "auto_daily_engagement"):
+            continue  # not this user's slot yet (or already dispatched today)
         automate_commenting.apply_async(kwargs={'user_id': user_id, 'loop_for_duration': 60 * 15})
         dispatched += 1
     return f"Golden-hour engagement dispatched for {dispatched}/{len(users)} active user(s)"
@@ -714,14 +751,16 @@ def auto_sync_groups():
 
 @shared_task.task
 def auto_group_engagement():
-    """Daily value-add commenting in each active user's ENABLED groups (shares the per-day cap)."""
+    """Daily value-add commenting in each active user's ENABLED groups (shares the per-day cap),
+    at that user's staggered slot so the single se_content lane drains evenly (issue #554)."""
     if _skip_if_throttled("auto_group_engagement"):
         return "Automation throttled"
     from cqc_lem.app.run_automation import auto_comment_in_groups
     users = get_active_user_ids()
     n = 0
     for uid in users:
-        if has_linkedin_session(uid):
+        if has_linkedin_session(uid) and _stagger_due(uid, STAGGER_GROUP_ENGAGEMENT,
+                                                      "auto_group_engagement"):
             auto_comment_in_groups.apply_async(kwargs={'user_id': uid})
             n += 1
     return f"Group commenting dispatched for {n}/{len(users)} user(s)"

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -64,15 +64,16 @@ def _stagger_due(user_id: int, fanout: Tuple[str, int, int], task_name: str) -> 
 
     The fan-out beats run every STAGGER_TICK_MINUTES and dispatch only the users whose slot has
     come up, so N users spread across the window instead of landing on one lane in one minute.
-    Redis holds the once-a-day claim, which also buys a catch-up: a slot missed because the beat
-    (or the 429 breaker) was down fires at the next tick instead of being lost for the day. With
-    no Redis the strict one-tick window keeps it to a single dispatch."""
+    Redis holds the claim, keyed by the slot's local date, which also buys a catch-up: a slot
+    missed because the beat (or the 429 breaker) was down fires at the next tick instead of being
+    lost for the day, and a claim written that late still can't reach tomorrow's slot. With no
+    Redis the strict one-tick window keeps it to a single dispatch."""
     config = stagger_config(fanout)
     tz_name = get_user_timezone(user_id) if config.local else "UTC"
     slot = plan_daily_slot(user_id, config, tz_name)
     if not slot.reached:
         return False
-    claimed = claim_daily_slot(user_id, config.name)
+    claimed = claim_daily_slot(user_id, config.name, slot.local_at.date().isoformat())
     due = slot.in_tick_window if claimed is None else claimed
     if due:
         log_debug(f"{task_name} slot due (local {slot.local_at:%H:%M}, +{slot.offset_minutes}m)",
@@ -274,6 +275,8 @@ def auto_appreciate_dms():
     dispatched = 0
 
     for user_id in users:
+        if not has_linkedin_session(user_id):
+            continue  # no session → the Selenium DM run would fail, and it must not spend the slot
         if not _stagger_due(user_id, STAGGER_APPRECIATION_DM, "auto_appreciate_dms"):
             continue
         # Send appreciation DM for 5 minutes

--- a/src/cqc_lem/utilities/engagement_window.py
+++ b/src/cqc_lem/utilities/engagement_window.py
@@ -215,9 +215,11 @@ STAGGER_APPRECIATION_DM = ("APPRECIATION_DM", 8, 120)
 STAGGER_GROUP_ENGAGEMENT = ("GROUP_ENGAGEMENT", 12, 120)
 
 _SLOT_CLAIM_PREFIX = "engagement:slot:"
-# Shorter than a day so today's claim can never block tomorrow's slot, longer than any plausible
-# beat outage so a claimed slot isn't re-dispatched later the same day.
-_SLOT_CLAIM_TTL_SECONDS = 20 * 60 * 60
+# The claim key carries the slot's local DATE, so "once per user per day" holds no matter when the
+# claim was written: a late catch-up (beat or 429 breaker down until the evening) claims THAT day's
+# key and leaves tomorrow's untouched. The TTL is then only garbage collection — it just has to
+# outlast the rest of the day it was claimed on.
+_SLOT_CLAIM_TTL_SECONDS = 26 * 60 * 60
 
 _MINUTES_PER_DAY = 24 * 60
 
@@ -308,16 +310,20 @@ def plan_daily_slot(user_id: int, config: StaggerConfig, tz_name: Optional[str] 
     )
 
 
-def claim_daily_slot(user_id: int, name: str,
+def claim_daily_slot(user_id: int, name: str, day: str,
                      ttl_seconds: int = _SLOT_CLAIM_TTL_SECONDS) -> Optional[bool]:
-    """Claim today's slot for this user/fan-out: True when this caller won it, False when it was
-    already taken today, None when Redis can't answer (the caller then falls back to the strict
-    one-tick window instead of dispatching blind)."""
+    """Claim one day's slot for this user/fan-out: True when this caller won it, False when it was
+    already taken for that day, None when Redis can't answer (the caller then falls back to the
+    strict one-tick window instead of dispatching blind).
+
+    `day` is the slot's date on the anchor clock (`DailySlot.local_at`) — keying by it is what
+    keeps a late catch-up claim from spilling into the next local day's slot.
+    """
     client = shared_redis_client()
     if client is None:
         return None
     try:
-        return bool(client.set(f"{_SLOT_CLAIM_PREFIX}{name}:{int(user_id)}", "1",
+        return bool(client.set(f"{_SLOT_CLAIM_PREFIX}{name}:{int(user_id)}:{day}", "1",
                                nx=True, ex=int(ttl_seconds)))
     except Exception as e:
         log_warning("Could not claim daily engagement slot", exc=e, user_id=user_id)

--- a/src/cqc_lem/utilities/engagement_window.py
+++ b/src/cqc_lem/utilities/engagement_window.py
@@ -1,4 +1,7 @@
-"""Pre-post engagement window (issue #547).
+"""Engagement windows — when engagement fires (issues #547, #554).
+
+Two windows live here: the pre-post warm-up around each scheduled post (#547), and the daily
+per-user slot that spreads a fleet-wide beat across a window instead of one minute (#554).
 
 The engagement-hacking intent behind the pre-post feed-commenting run is to be *active on the feed
 right before your own post publishes*. Two things kept that from being true in practice:
@@ -16,9 +19,12 @@ Every marker helper fails OPEN: no Redis (or a Redis error) degrades to logging 
 failed dispatch.
 """
 
+import hashlib
+import os
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Optional
+from typing import Optional, Tuple
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from cqc_lem.utilities.linkedin.rate_limit import shared_redis_client
 from cqc_lem.utilities.logger import log_info, log_warning
@@ -190,3 +196,139 @@ def get_pre_post_window_stat(post_id: int, task_name: str = PRE_POST_TASK_COMMEN
     stat.setdefault("runs", 0)
     stat.setdefault("comments", 0)
     return stat
+
+
+# --- Daily fan-out staggering (issue #554) ---------------------------------------------------
+#
+# A single crontab that hands every active user a 15-minute Selenium loop at the same minute makes
+# the whole fleet queue on one lane: `se_engage` drains ~8 users/hour, so at 50 users the last
+# "golden hour" run lands ~6 hours after the window it was meant for (docs/scaling-plan.md §3).
+# Instead every user gets a stable minute inside a window that opens at an anchor hour in THEIR
+# timezone, and the beat runs every STAGGER_TICK_MINUTES to dispatch whoever has come due.
+
+STAGGER_TICK_MINUTES = 15  # beat cadence for the staggered fan-outs; also one slot's width
+
+# Per-fan-out defaults. Each is overridable at runtime with <NAME>_ANCHOR_HOUR /
+# <NAME>_WINDOW_MINUTES / <NAME>_ANCHOR_TZ, read at call time so ops can retune without a restart.
+STAGGER_GOLDEN_HOUR = ("GOLDEN_HOUR", 9, 180)
+STAGGER_APPRECIATION_DM = ("APPRECIATION_DM", 8, 120)
+STAGGER_GROUP_ENGAGEMENT = ("GROUP_ENGAGEMENT", 12, 120)
+
+_SLOT_CLAIM_PREFIX = "engagement:slot:"
+# Shorter than a day so today's claim can never block tomorrow's slot, longer than any plausible
+# beat outage so a claimed slot isn't re-dispatched later the same day.
+_SLOT_CLAIM_TTL_SECONDS = 20 * 60 * 60
+
+_MINUTES_PER_DAY = 24 * 60
+
+
+@dataclass(frozen=True)
+class StaggerConfig:
+    """Where a fan-out's window opens, how wide it is, and whose clock it opens on."""
+
+    name: str
+    anchor_hour: int
+    window_minutes: int
+    local: bool  # anchor in each user's own timezone (True) or in UTC (False)
+
+
+@dataclass(frozen=True)
+class DailySlot:
+    """One user's dispatch minute for one fan-out, today."""
+
+    at: datetime           # the slot in UTC (logging / observability)
+    local_at: datetime     # the same minute on the anchor clock
+    offset_minutes: int    # spread from the anchor hour
+    reached: bool          # the slot has arrived (stays True for the rest of the local day)
+    in_tick_window: bool   # ...and this is the first beat tick after it
+
+
+def _env_int(key: str, default: int, low: int, high: int) -> int:
+    raw = (os.environ.get(key) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        log_warning(f"{key} ignored (not an integer: {raw!r})")
+        return default
+    if not low <= value <= high:
+        log_warning(f"{key} ignored (outside {low}-{high}: {value})")
+        return default
+    return value
+
+
+def stagger_config(fanout: Tuple[str, int, int]) -> StaggerConfig:
+    """Resolve one of the STAGGER_* fan-out defaults against the environment."""
+    name, anchor_hour, window_minutes = fanout
+    return StaggerConfig(
+        name=name,
+        anchor_hour=_env_int(f"{name}_ANCHOR_HOUR", anchor_hour, 0, 23),
+        # A 1-minute window is the escape hatch: every user lands on the anchor minute, i.e. the
+        # pre-#554 "everyone at once" behavior, without a code change.
+        window_minutes=_env_int(f"{name}_WINDOW_MINUTES", window_minutes, 1, _MINUTES_PER_DAY),
+        local=(os.environ.get(f"{name}_ANCHOR_TZ") or "local").strip().lower() != "utc",
+    )
+
+
+def stagger_offset_minutes(user_id: int, window_minutes: int, salt: str = "") -> int:
+    """A user's stable minute inside the window. Hashed (not user_id % window) so ids that were
+    created together don't clump, and salted per fan-out so the same user isn't first — or last —
+    in every window of the day."""
+    window = max(1, int(window_minutes))
+    digest = hashlib.sha256(f"{salt}:{int(user_id)}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") % window
+
+
+def plan_daily_slot(user_id: int, config: StaggerConfig, tz_name: Optional[str] = None,
+                    now: Optional[datetime] = None,
+                    tick_minutes: int = STAGGER_TICK_MINUTES) -> DailySlot:
+    """Today's dispatch slot for this user/fan-out, and whether it is due now.
+
+    The comparison is pure wall clock on the anchor timezone, so a user keeps the same local
+    minute across DST changes, and a window that runs past midnight wraps into the small hours
+    rather than falling off the end of the day (which would never fire).
+    """
+    now_utc = _as_utc(now if now is not None else datetime.now(timezone.utc))
+    zone = _zone(tz_name) if config.local else timezone.utc
+    local_now = now_utc.astimezone(zone)
+
+    offset = stagger_offset_minutes(user_id, config.window_minutes, config.name)
+    minute_of_day = (config.anchor_hour * 60 + offset) % _MINUTES_PER_DAY
+    midnight = local_now.replace(hour=0, minute=0, second=0, microsecond=0)
+    slot_local = midnight + timedelta(minutes=minute_of_day)
+
+    elapsed = (local_now.replace(tzinfo=None) - slot_local.replace(tzinfo=None)).total_seconds() / 60
+    return DailySlot(
+        at=slot_local.astimezone(timezone.utc),
+        local_at=slot_local,
+        offset_minutes=offset,
+        reached=elapsed >= 0,
+        in_tick_window=0 <= elapsed < max(1, int(tick_minutes)),
+    )
+
+
+def claim_daily_slot(user_id: int, name: str,
+                     ttl_seconds: int = _SLOT_CLAIM_TTL_SECONDS) -> Optional[bool]:
+    """Claim today's slot for this user/fan-out: True when this caller won it, False when it was
+    already taken today, None when Redis can't answer (the caller then falls back to the strict
+    one-tick window instead of dispatching blind)."""
+    client = shared_redis_client()
+    if client is None:
+        return None
+    try:
+        return bool(client.set(f"{_SLOT_CLAIM_PREFIX}{name}:{int(user_id)}", "1",
+                               nx=True, ex=int(ttl_seconds)))
+    except Exception as e:
+        log_warning("Could not claim daily engagement slot", exc=e, user_id=user_id)
+        return None
+
+
+def _zone(tz_name: Optional[str]):
+    if not tz_name:
+        return timezone.utc
+    try:
+        return ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, ValueError):
+        log_warning(f"Unknown timezone {tz_name!r} for engagement slot — anchoring in UTC")
+        return timezone.utc

--- a/tests/unit/app/test_daily_engagement.py
+++ b/tests/unit/app/test_daily_engagement.py
@@ -1,6 +1,8 @@
 """Unit tests for the no-post-day standalone commenting run."""
 
 import pytest
+from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 pytestmark = pytest.mark.unit
@@ -32,6 +34,7 @@ class TestAutoDailyEngagement:
         # Runs every day now (no post-day skip); only the no-session user is excluded.
         with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2, 3]), \
              patch(f"{_RS}.has_linkedin_session", side_effect=lambda u: u != 3), \
+             patch(f"{_RS}._stagger_due", return_value=True), \
              patch(f"{_RS}.automate_commenting") as ac:
             result = auto_daily_engagement()
         assert ac.apply_async.call_count == 2                 # users 1 & 2 (3 has no session)
@@ -44,6 +47,101 @@ class TestAutoDailyEngagement:
         from cqc_lem.app.run_scheduler import auto_daily_engagement
         with patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
              patch(f"{_RS}.has_linkedin_session", return_value=True), \
+             patch(f"{_RS}._stagger_due", return_value=True), \
              patch(f"{_RS}.automate_commenting") as ac:
             auto_daily_engagement()
         assert "queue" not in ac.apply_async.call_args[1]
+
+    def test_only_users_whose_slot_is_due_are_dispatched(self):
+        """The beat now ticks every 15 minutes (issue #554) — a tick must hand se_engage only the
+        users whose staggered slot came up, not the whole fleet."""
+        from cqc_lem.app.run_scheduler import auto_daily_engagement, STAGGER_GOLDEN_HOUR
+        with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2, 3]), \
+             patch(f"{_RS}.has_linkedin_session", return_value=True), \
+             patch(f"{_RS}._stagger_due", side_effect=lambda u, *_: u == 2) as due, \
+             patch(f"{_RS}.automate_commenting") as ac:
+            result = auto_daily_engagement()
+        assert ac.apply_async.call_count == 1
+        assert ac.apply_async.call_args[1]["kwargs"]["user_id"] == 2
+        assert due.call_args[0][1] is STAGGER_GOLDEN_HOUR
+        assert "1/3" in result
+
+    def test_a_user_without_a_session_does_not_burn_their_slot(self):
+        """The claim is once-a-day, so it must not be spent on a user who can't run anyway —
+        connecting later in the day still earns that day's golden-hour run."""
+        from cqc_lem.app.run_scheduler import auto_daily_engagement
+        with patch(f"{_RS}.get_active_user_ids", return_value=[9]), \
+             patch(f"{_RS}.has_linkedin_session", return_value=False), \
+             patch(f"{_RS}._stagger_due", return_value=True) as due, \
+             patch(f"{_RS}.automate_commenting"):
+            auto_daily_engagement()
+        due.assert_not_called()
+
+
+class TestStaggerDue:
+    """The gate every staggered fan-out shares (issue #554)."""
+
+    def _slot(self, reached=True, in_tick_window=True):
+        return SimpleNamespace(reached=reached, in_tick_window=in_tick_window, offset_minutes=42,
+                               local_at=datetime(2026, 7, 25, 9, 42),
+                               at=datetime(2026, 7, 25, 13, 42))
+
+    def _run(self, slot, claimed, tz="America/New_York"):
+        from cqc_lem.app.run_scheduler import _stagger_due, STAGGER_GOLDEN_HOUR
+        with patch(f"{_RS}.get_user_timezone", return_value=tz) as get_tz, \
+             patch(f"{_RS}.plan_daily_slot", return_value=slot) as plan, \
+             patch(f"{_RS}.claim_daily_slot", return_value=claimed) as claim:
+            result = _stagger_due(7, STAGGER_GOLDEN_HOUR, "auto_daily_engagement")
+        return result, get_tz, plan, claim
+
+    def test_not_due_before_the_slot_and_no_claim_is_spent(self):
+        result, _, _, claim = self._run(self._slot(reached=False, in_tick_window=False), True)
+        assert result is False
+        claim.assert_not_called()
+
+    def test_due_when_the_slot_is_claimed(self):
+        result, _, _, claim = self._run(self._slot(), True)
+        assert result is True
+        claim.assert_called_once()
+
+    def test_already_dispatched_today_is_not_due_again(self):
+        result, _, _, _ = self._run(self._slot(in_tick_window=True), False)
+        assert result is False
+
+    def test_missed_tick_catches_up_on_the_next_one(self):
+        """Beat (or the 429 breaker) down over the slot → the claim is still free, so the run
+        happens later that day instead of being lost."""
+        result, _, _, _ = self._run(self._slot(in_tick_window=False), True)
+        assert result is True
+
+    def test_without_redis_falls_back_to_the_strict_tick_window(self):
+        assert self._run(self._slot(in_tick_window=True), None)[0] is True
+        assert self._run(self._slot(in_tick_window=False), None)[0] is False
+
+    def test_local_anchor_plans_on_the_users_timezone(self):
+        _, get_tz, plan, _ = self._run(self._slot(), True)
+        get_tz.assert_called_once_with(7)
+        assert plan.call_args[0][2] == "America/New_York"
+
+    def test_utc_anchor_skips_the_timezone_lookup(self, monkeypatch):
+        monkeypatch.setenv("GOLDEN_HOUR_ANCHOR_TZ", "utc")
+        _, get_tz, plan, _ = self._run(self._slot(), True)
+        get_tz.assert_not_called()
+        assert plan.call_args[0][2] == "UTC"
+
+
+class TestStaggeredBeatSchedule:
+    """The per-user slot only works if the beat actually ticks at STAGGER_TICK_MINUTES — a
+    once-a-day crontab would fire one arbitrary slot and drop everyone else (issue #554)."""
+
+    def _schedule(self):
+        from cqc_lem.app.my_celery import app
+        return app.conf.beat_schedule
+
+    @pytest.mark.parametrize("entry", ["daily-golden-hour-engagement", "send-appreciation-dms",
+                                       "group-engagement"])
+    def test_staggered_fanouts_tick_at_the_stagger_cadence(self, entry):
+        from cqc_lem.utilities.engagement_window import STAGGER_TICK_MINUTES
+        expected = set(range(0, 60, STAGGER_TICK_MINUTES))
+        assert self._schedule()[entry]["schedule"].minute == expected
+        assert self._schedule()[entry]["schedule"].hour == set(range(24))

--- a/tests/unit/app/test_daily_engagement.py
+++ b/tests/unit/app/test_daily_engagement.py
@@ -104,6 +104,12 @@ class TestStaggerDue:
         assert result is True
         claim.assert_called_once()
 
+    def test_the_claim_is_keyed_to_the_slots_local_date(self):
+        """A catch-up claimed late in the day must not still be held at tomorrow's slot — the
+        claim carries the local date rather than relying on a flat sub-day TTL."""
+        _, _, _, claim = self._run(self._slot(), True)
+        assert claim.call_args[0][2] == "2026-07-25"
+
     def test_already_dispatched_today_is_not_due_again(self):
         result, _, _, _ = self._run(self._slot(in_tick_window=True), False)
         assert result is False

--- a/tests/unit/app/test_groups.py
+++ b/tests/unit/app/test_groups.py
@@ -68,7 +68,21 @@ class TestGroupDispatchers:
         from cqc_lem.app.run_scheduler import auto_group_engagement
         with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \
              patch(f"{_RS}.has_linkedin_session", side_effect=lambda u: u == 1), \
+             patch(f"{_RS}._stagger_due", return_value=True), \
              patch("cqc_lem.app.run_automation.auto_comment_in_groups") as t:
             result = auto_group_engagement()
         t.apply_async.assert_called_once()
+        assert "1/2" in result
+
+    def test_group_engagement_waits_for_each_users_slot(self):
+        """Issue #554: the beat ticks every 15 min, so a connected user still only runs when
+        their staggered slot on the single se_content lane comes up."""
+        from cqc_lem.app.run_scheduler import auto_group_engagement, STAGGER_GROUP_ENGAGEMENT
+        with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \
+             patch(f"{_RS}.has_linkedin_session", return_value=True), \
+             patch(f"{_RS}._stagger_due", side_effect=lambda u, *_: u == 2) as due, \
+             patch("cqc_lem.app.run_automation.auto_comment_in_groups") as t:
+            result = auto_group_engagement()
+        t.apply_async.assert_called_once_with(kwargs={'user_id': 2})
+        assert due.call_args[0][1] is STAGGER_GROUP_ENGAGEMENT
         assert "1/2" in result

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -25,6 +25,7 @@ _PATCH_GET_ORPHANED = f"{_MOD}.get_orphaned_scheduled_posts"
 _PATCH_UPDATE_POST_STATUS = f"{_MOD}.update_db_post_status"
 _PATCH_POST_TO_LINKEDIN = f"{_MOD}.post_to_linkedin"
 _PATCH_APPRECIATE = f"{_MOD}.automate_appreciation_dms_for_user"
+_PATCH_STAGGER_DUE = f"{_MOD}._stagger_due"
 _PATCH_CLEAN_INVITES = f"{_MOD}.clean_stale_invites"
 _PATCH_UPDATE_STALE = f"{_MOD}.update_stale_profile"
 _PATCH_AUTOMATE_COMMENTING = f"{_MOD}.automate_commenting"
@@ -675,6 +676,7 @@ class TestAutoAppreciateDms:
         mock_task = _async_task_mock()
 
         with patch(_PATCH_GET_ACTIVE, return_value=[42]), \
+             patch(_PATCH_STAGGER_DUE, return_value=True), \
              patch(_PATCH_APPRECIATE, mock_task):
             from cqc_lem.app.run_scheduler import auto_appreciate_dms
             result = auto_appreciate_dms.run()
@@ -683,24 +685,42 @@ class TestAutoAppreciateDms:
         call_kwargs = mock_task.apply_async.call_args[1]
         assert call_kwargs["kwargs"]["user_id"] == 42
         assert call_kwargs["kwargs"]["loop_for_duration"] == 60 * 5
-        assert "1 user" in result
+        assert "1/1 user" in result
 
     def test_multiple_users_calls_apply_async_for_each(self):
         mock_task = _async_task_mock()
         users = [1, 2, 3]
 
         with patch(_PATCH_GET_ACTIVE, return_value=users), \
+             patch(_PATCH_STAGGER_DUE, return_value=True), \
              patch(_PATCH_APPRECIATE, mock_task):
             from cqc_lem.app.run_scheduler import auto_appreciate_dms
             result = auto_appreciate_dms.run()
 
         assert mock_task.apply_async.call_count == 3
-        assert "3 user" in result
+        assert "3/3 user" in result
+
+    def test_only_users_whose_slot_is_due_are_dispatched(self):
+        """Issue #554: the beat ticks every 15 min and the single se_outreach lane gets only the
+        users whose staggered slot came up — not every active user at once."""
+        mock_task = _async_task_mock()
+
+        with patch(_PATCH_GET_ACTIVE, return_value=[1, 2, 3]), \
+             patch(_PATCH_STAGGER_DUE, side_effect=lambda u, *_: u == 3) as due, \
+             patch(_PATCH_APPRECIATE, mock_task):
+            from cqc_lem.app.run_scheduler import auto_appreciate_dms, STAGGER_APPRECIATION_DM
+            result = auto_appreciate_dms.run()
+
+        mock_task.apply_async.assert_called_once()
+        assert mock_task.apply_async.call_args[1]["kwargs"]["user_id"] == 3
+        assert due.call_args[0][1] is STAGGER_APPRECIATION_DM
+        assert "1/3 user" in result
 
     def test_apply_async_includes_retry_policy(self):
         mock_task = _async_task_mock()
 
         with patch(_PATCH_GET_ACTIVE, return_value=[10]), \
+             patch(_PATCH_STAGGER_DUE, return_value=True), \
              patch(_PATCH_APPRECIATE, mock_task):
             from cqc_lem.app.run_scheduler import auto_appreciate_dms
             auto_appreciate_dms.run()

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -26,6 +26,7 @@ _PATCH_UPDATE_POST_STATUS = f"{_MOD}.update_db_post_status"
 _PATCH_POST_TO_LINKEDIN = f"{_MOD}.post_to_linkedin"
 _PATCH_APPRECIATE = f"{_MOD}.automate_appreciation_dms_for_user"
 _PATCH_STAGGER_DUE = f"{_MOD}._stagger_due"
+_PATCH_HAS_SESSION = f"{_MOD}.has_linkedin_session"
 _PATCH_CLEAN_INVITES = f"{_MOD}.clean_stale_invites"
 _PATCH_UPDATE_STALE = f"{_MOD}.update_stale_profile"
 _PATCH_AUTOMATE_COMMENTING = f"{_MOD}.automate_commenting"
@@ -676,6 +677,7 @@ class TestAutoAppreciateDms:
         mock_task = _async_task_mock()
 
         with patch(_PATCH_GET_ACTIVE, return_value=[42]), \
+             patch(_PATCH_HAS_SESSION, return_value=True), \
              patch(_PATCH_STAGGER_DUE, return_value=True), \
              patch(_PATCH_APPRECIATE, mock_task):
             from cqc_lem.app.run_scheduler import auto_appreciate_dms
@@ -692,6 +694,7 @@ class TestAutoAppreciateDms:
         users = [1, 2, 3]
 
         with patch(_PATCH_GET_ACTIVE, return_value=users), \
+             patch(_PATCH_HAS_SESSION, return_value=True), \
              patch(_PATCH_STAGGER_DUE, return_value=True), \
              patch(_PATCH_APPRECIATE, mock_task):
             from cqc_lem.app.run_scheduler import auto_appreciate_dms
@@ -706,6 +709,7 @@ class TestAutoAppreciateDms:
         mock_task = _async_task_mock()
 
         with patch(_PATCH_GET_ACTIVE, return_value=[1, 2, 3]), \
+             patch(_PATCH_HAS_SESSION, return_value=True), \
              patch(_PATCH_STAGGER_DUE, side_effect=lambda u, *_: u == 3) as due, \
              patch(_PATCH_APPRECIATE, mock_task):
             from cqc_lem.app.run_scheduler import auto_appreciate_dms, STAGGER_APPRECIATION_DM
@@ -716,10 +720,27 @@ class TestAutoAppreciateDms:
         assert due.call_args[0][1] is STAGGER_APPRECIATION_DM
         assert "1/3 user" in result
 
+    def test_a_user_without_a_session_does_not_burn_their_slot(self):
+        """The DM run is a Selenium login too, so a user with no stored session must be dropped
+        BEFORE the once-a-day claim — reconnecting later still earns that day's outreach."""
+        mock_task = _async_task_mock()
+
+        with patch(_PATCH_GET_ACTIVE, return_value=[9]), \
+             patch(_PATCH_HAS_SESSION, return_value=False), \
+             patch(_PATCH_STAGGER_DUE, return_value=True) as due, \
+             patch(_PATCH_APPRECIATE, mock_task):
+            from cqc_lem.app.run_scheduler import auto_appreciate_dms
+            result = auto_appreciate_dms.run()
+
+        due.assert_not_called()
+        mock_task.apply_async.assert_not_called()
+        assert "0/1 user" in result
+
     def test_apply_async_includes_retry_policy(self):
         mock_task = _async_task_mock()
 
         with patch(_PATCH_GET_ACTIVE, return_value=[10]), \
+             patch(_PATCH_HAS_SESSION, return_value=True), \
              patch(_PATCH_STAGGER_DUE, return_value=True), \
              patch(_PATCH_APPRECIATE, mock_task):
             from cqc_lem.app.run_scheduler import auto_appreciate_dms

--- a/tests/unit/utilities/test_engagement_window.py
+++ b/tests/unit/utilities/test_engagement_window.py
@@ -411,3 +411,38 @@ class TestClaimDailySlot:
         client.set.side_effect = RuntimeError("redis down")
         with patch(f"{_MOD}.shared_redis_client", return_value=client):
             assert claim_daily_slot(7, "GOLDEN_HOUR") is None
+
+
+class TestApprovedFanoutDefaults:
+    """The three shipped windows are a product decision the owner signed off on in PR #607
+    (`1A 2A 3A`): golden hour 09:00 + 3h, appreciation DMs 08:00 + 2h, groups 12:00 + 2h — each
+    anchored on the USER's clock, not UTC. The rest of the suite exercises a local literal, so
+    without this the constants could drift away from the approved values silently. Retuning is an
+    env change (`<NAME>_ANCHOR_HOUR` / `_WINDOW_MINUTES` / `_ANCHOR_TZ`); changing these numbers is
+    changing the default every deployment inherits, so it needs the same sign-off again.
+    """
+
+    @pytest.mark.parametrize("fanout,expected", [
+        ("STAGGER_GOLDEN_HOUR", ("GOLDEN_HOUR", 9, 180)),
+        ("STAGGER_APPRECIATION_DM", ("APPRECIATION_DM", 8, 120)),
+        ("STAGGER_GROUP_ENGAGEMENT", ("GROUP_ENGAGEMENT", 12, 120)),
+    ])
+    def test_anchor_hour_and_window_match_the_approved_decision(self, fanout, expected):
+        import cqc_lem.utilities.engagement_window as mod
+        assert getattr(mod, fanout) == expected
+
+    @pytest.mark.parametrize("fanout", ["STAGGER_GOLDEN_HOUR", "STAGGER_APPRECIATION_DM",
+                                        "STAGGER_GROUP_ENGAGEMENT"])
+    def test_each_fanout_anchors_on_the_users_own_clock(self, monkeypatch, fanout):
+        import cqc_lem.utilities.engagement_window as mod
+        name = getattr(mod, fanout)[0]
+        for suffix in ("_ANCHOR_HOUR", "_WINDOW_MINUTES", "_ANCHOR_TZ"):
+            monkeypatch.delenv(f"{name}{suffix}", raising=False)
+        assert mod.stagger_config(getattr(mod, fanout)).local is True
+
+    def test_every_window_is_wide_enough_to_stagger(self):
+        """A window narrower than the beat cadence would put the whole fleet back on one tick."""
+        import cqc_lem.utilities.engagement_window as mod
+        for fanout in (mod.STAGGER_GOLDEN_HOUR, mod.STAGGER_APPRECIATION_DM,
+                       mod.STAGGER_GROUP_ENGAGEMENT):
+            assert fanout[2] >= mod.STAGGER_TICK_MINUTES

--- a/tests/unit/utilities/test_engagement_window.py
+++ b/tests/unit/utilities/test_engagement_window.py
@@ -238,3 +238,176 @@ class TestGetPrePostWindowStat:
         mock_redis.hgetall.side_effect = RuntimeError("redis down")
 
         assert get_pre_post_window_stat(26) == {}
+
+
+# ---------------------------------------------------------------------------
+# Daily fan-out staggering (issue #554)
+# ---------------------------------------------------------------------------
+
+_FANOUT = ("GOLDEN_HOUR", 9, 180)
+
+
+def _config(**overrides):
+    from cqc_lem.utilities.engagement_window import StaggerConfig
+    fields = {"name": "GOLDEN_HOUR", "anchor_hour": 9, "window_minutes": 180, "local": True}
+    fields.update(overrides)
+    return StaggerConfig(**fields)
+
+
+class TestStaggerOffsetMinutes:
+    def test_offset_is_stable_and_inside_the_window(self):
+        from cqc_lem.utilities.engagement_window import stagger_offset_minutes
+        for user_id in range(1, 60):
+            first = stagger_offset_minutes(user_id, 180, "GOLDEN_HOUR")
+            assert 0 <= first < 180
+            assert stagger_offset_minutes(user_id, 180, "GOLDEN_HOUR") == first
+
+    def test_consecutive_users_do_not_clump(self):
+        """user_id % window would put ids 1..50 on 50 consecutive minutes AND on the same minute in
+        every window; the salted hash has to spread them instead."""
+        from cqc_lem.utilities.engagement_window import stagger_offset_minutes
+        offsets = [stagger_offset_minutes(u, 180, "GOLDEN_HOUR") for u in range(1, 51)]
+        assert len(set(offsets)) > 30                          # spread, not a 50-minute run
+        assert offsets != [stagger_offset_minutes(u, 180, "APPRECIATION_DM") for u in range(1, 51)]
+
+    def test_window_of_one_puts_everyone_on_the_anchor_minute(self):
+        from cqc_lem.utilities.engagement_window import stagger_offset_minutes
+        assert {stagger_offset_minutes(u, 1, "GOLDEN_HOUR") for u in range(1, 30)} == {0}
+
+
+class TestStaggerConfig:
+    def test_defaults_when_env_is_unset(self, monkeypatch):
+        from cqc_lem.utilities.engagement_window import stagger_config
+        for key in ("GOLDEN_HOUR_ANCHOR_HOUR", "GOLDEN_HOUR_WINDOW_MINUTES", "GOLDEN_HOUR_ANCHOR_TZ"):
+            monkeypatch.delenv(key, raising=False)
+        config = stagger_config(_FANOUT)
+        assert (config.anchor_hour, config.window_minutes, config.local) == (9, 180, True)
+
+    def test_env_overrides_are_read_at_call_time(self, monkeypatch):
+        from cqc_lem.utilities.engagement_window import stagger_config
+        monkeypatch.setenv("GOLDEN_HOUR_ANCHOR_HOUR", "14")
+        monkeypatch.setenv("GOLDEN_HOUR_WINDOW_MINUTES", "60")
+        monkeypatch.setenv("GOLDEN_HOUR_ANCHOR_TZ", "UTC")
+        config = stagger_config(_FANOUT)
+        assert (config.anchor_hour, config.window_minutes, config.local) == (14, 60, False)
+
+    @pytest.mark.parametrize("bad", ["nine", "24", "-1", ""])
+    def test_invalid_anchor_hour_falls_back_to_the_default(self, monkeypatch, bad):
+        from cqc_lem.utilities.engagement_window import stagger_config
+        monkeypatch.setenv("GOLDEN_HOUR_ANCHOR_HOUR", bad)
+        assert stagger_config(_FANOUT).anchor_hour == 9
+
+    def test_invalid_window_falls_back_to_the_default(self, monkeypatch):
+        from cqc_lem.utilities.engagement_window import stagger_config
+        monkeypatch.setenv("GOLDEN_HOUR_WINDOW_MINUTES", "0")
+        assert stagger_config(_FANOUT).window_minutes == 180
+
+
+class TestPlanDailySlot:
+    def test_slot_sits_between_the_anchor_and_the_window_close(self):
+        from cqc_lem.utilities.engagement_window import plan_daily_slot
+        for user_id in range(1, 40):
+            slot = plan_daily_slot(user_id, _config(), "UTC", now=_NOW)
+            assert slot.local_at.hour * 60 + slot.local_at.minute >= 9 * 60
+            assert slot.local_at.hour * 60 + slot.local_at.minute < 9 * 60 + 180
+
+    def test_not_reached_before_the_anchor(self):
+        from cqc_lem.utilities.engagement_window import plan_daily_slot
+        before = datetime(2026, 7, 25, 8, 0, tzinfo=timezone.utc)
+        slot = plan_daily_slot(7, _config(), "UTC", now=before)
+        assert slot.reached is False and slot.in_tick_window is False
+
+    def test_due_on_the_first_tick_after_the_slot_only(self):
+        from cqc_lem.utilities.engagement_window import plan_daily_slot
+        config = _config()
+        slot = plan_daily_slot(7, config, "UTC", now=_NOW)
+        at = slot.local_at.replace(tzinfo=timezone.utc)
+
+        assert plan_daily_slot(7, config, "UTC", now=at).in_tick_window is True
+        assert plan_daily_slot(7, config, "UTC", now=at + timedelta(minutes=14)).in_tick_window is True
+        assert plan_daily_slot(7, config, "UTC", now=at + timedelta(minutes=15)).in_tick_window is False
+        assert plan_daily_slot(7, config, "UTC", now=at - timedelta(minutes=1)).in_tick_window is False
+
+    def test_reached_stays_true_after_the_tick_for_catch_up(self):
+        from cqc_lem.utilities.engagement_window import plan_daily_slot
+        config = _config()
+        at = plan_daily_slot(7, config, "UTC", now=_NOW).local_at.replace(tzinfo=timezone.utc)
+        late = plan_daily_slot(7, config, "UTC", now=at + timedelta(hours=5))
+        assert late.reached is True and late.in_tick_window is False
+
+    def test_local_anchor_uses_the_users_timezone(self):
+        """Anchor 9 with a 1-minute window = 09:00 local, which is 13:00 UTC in New York and
+        16:00 UTC in Los Angeles — the whole point of anchoring per user."""
+        from cqc_lem.utilities.engagement_window import plan_daily_slot
+        config = _config(window_minutes=1)
+        east = plan_daily_slot(7, config, "America/New_York", now=_NOW)
+        west = plan_daily_slot(7, config, "America/Los_Angeles", now=_NOW)
+        assert east.at.hour == 13 and west.at.hour == 16
+        assert east.local_at.hour == west.local_at.hour == 9
+
+    def test_utc_anchor_ignores_the_user_timezone(self):
+        from cqc_lem.utilities.engagement_window import plan_daily_slot
+        slot = plan_daily_slot(7, _config(local=False, window_minutes=1), "America/Los_Angeles",
+                               now=_NOW)
+        assert slot.at.hour == 9
+
+    def test_unknown_timezone_falls_back_to_utc(self):
+        from cqc_lem.utilities.engagement_window import plan_daily_slot
+        slot = plan_daily_slot(7, _config(window_minutes=1), "Mars/Olympus_Mons", now=_NOW)
+        assert slot.at.hour == 9
+
+    def test_window_past_midnight_wraps_instead_of_never_firing(self):
+        from cqc_lem.utilities.engagement_window import plan_daily_slot
+        config = _config(anchor_hour=23, window_minutes=180)
+        late_night = datetime(2026, 7, 25, 23, 59, tzinfo=timezone.utc)
+        slots = [plan_daily_slot(u, config, "UTC", now=late_night) for u in range(1, 40)]
+        assert any(s.local_at.hour < 2 for s in slots)         # wrapped into the small hours
+        assert all(s.local_at.date() == late_night.date() for s in slots)
+
+    def test_every_user_gets_exactly_one_tick_per_day(self):
+        """The property the whole design rests on: with the beat ticking every 15 minutes, each
+        user's slot matches exactly one tick — no misses, no doubles."""
+        from cqc_lem.utilities.engagement_window import plan_daily_slot
+        config = _config()
+        start = datetime(2026, 7, 25, 0, 0, tzinfo=timezone.utc)
+        ticks = [start + timedelta(minutes=15 * i) for i in range(96)]
+        for user_id in range(1, 25):
+            due = [t for t in ticks if plan_daily_slot(user_id, config, "UTC", now=t).in_tick_window]
+            assert len(due) == 1
+
+    def test_dst_change_keeps_the_same_local_minute(self):
+        from cqc_lem.utilities.engagement_window import plan_daily_slot
+        config = _config()
+        winter = plan_daily_slot(7, config, "America/New_York",
+                                 now=datetime(2026, 1, 15, 18, 0, tzinfo=timezone.utc))
+        summer = plan_daily_slot(7, config, "America/New_York",
+                                 now=datetime(2026, 7, 15, 18, 0, tzinfo=timezone.utc))
+        assert (winter.local_at.hour, winter.local_at.minute) == (summer.local_at.hour,
+                                                                  summer.local_at.minute)
+        assert winter.at.hour == summer.at.hour + 1            # ...which is a different UTC hour
+
+
+class TestClaimDailySlot:
+    def test_returns_none_without_redis(self):
+        from cqc_lem.utilities.engagement_window import claim_daily_slot
+        with patch(f"{_MOD}.shared_redis_client", return_value=None):
+            assert claim_daily_slot(7, "GOLDEN_HOUR") is None
+
+    def test_claims_once_per_day_with_a_sub_day_ttl(self):
+        from cqc_lem.utilities.engagement_window import claim_daily_slot
+        client = MagicMock()
+        client.set.side_effect = [True, None]                  # nx=True: second caller loses
+        with patch(f"{_MOD}.shared_redis_client", return_value=client):
+            assert claim_daily_slot(7, "GOLDEN_HOUR") is True
+            assert claim_daily_slot(7, "GOLDEN_HOUR") is False
+        key, value = client.set.call_args[0]
+        assert key == "engagement:slot:GOLDEN_HOUR:7"
+        assert client.set.call_args[1]["nx"] is True
+        assert 0 < client.set.call_args[1]["ex"] < 24 * 60 * 60
+
+    def test_redis_error_degrades_to_unknown(self):
+        from cqc_lem.utilities.engagement_window import claim_daily_slot
+        client = MagicMock()
+        client.set.side_effect = RuntimeError("redis down")
+        with patch(f"{_MOD}.shared_redis_client", return_value=client):
+            assert claim_daily_slot(7, "GOLDEN_HOUR") is None

--- a/tests/unit/utilities/test_engagement_window.py
+++ b/tests/unit/utilities/test_engagement_window.py
@@ -391,26 +391,37 @@ class TestClaimDailySlot:
     def test_returns_none_without_redis(self):
         from cqc_lem.utilities.engagement_window import claim_daily_slot
         with patch(f"{_MOD}.shared_redis_client", return_value=None):
-            assert claim_daily_slot(7, "GOLDEN_HOUR") is None
+            assert claim_daily_slot(7, "GOLDEN_HOUR", "2026-07-25") is None
 
-    def test_claims_once_per_day_with_a_sub_day_ttl(self):
+    def test_claims_once_per_day(self):
         from cqc_lem.utilities.engagement_window import claim_daily_slot
         client = MagicMock()
         client.set.side_effect = [True, None]                  # nx=True: second caller loses
         with patch(f"{_MOD}.shared_redis_client", return_value=client):
-            assert claim_daily_slot(7, "GOLDEN_HOUR") is True
-            assert claim_daily_slot(7, "GOLDEN_HOUR") is False
+            assert claim_daily_slot(7, "GOLDEN_HOUR", "2026-07-25") is True
+            assert claim_daily_slot(7, "GOLDEN_HOUR", "2026-07-25") is False
         key, value = client.set.call_args[0]
-        assert key == "engagement:slot:GOLDEN_HOUR:7"
+        assert key == "engagement:slot:GOLDEN_HOUR:7:2026-07-25"
         assert client.set.call_args[1]["nx"] is True
-        assert 0 < client.set.call_args[1]["ex"] < 24 * 60 * 60
+        assert client.set.call_args[1]["ex"] > 24 * 60 * 60    # outlasts the day it was claimed on
+
+    def test_a_late_claim_cannot_block_the_next_days_slot(self):
+        """A catch-up dispatched late in the day writes a claim that would still be alive at
+        tomorrow's slot under a flat TTL — the local date in the key is what prevents that."""
+        from cqc_lem.utilities.engagement_window import claim_daily_slot
+        client = MagicMock()
+        client.set.return_value = True
+        with patch(f"{_MOD}.shared_redis_client", return_value=client):
+            claim_daily_slot(7, "GOLDEN_HOUR", "2026-07-25")
+            claim_daily_slot(7, "GOLDEN_HOUR", "2026-07-26")
+        assert client.set.call_args_list[0][0][0] != client.set.call_args_list[1][0][0]
 
     def test_redis_error_degrades_to_unknown(self):
         from cqc_lem.utilities.engagement_window import claim_daily_slot
         client = MagicMock()
         client.set.side_effect = RuntimeError("redis down")
         with patch(f"{_MOD}.shared_redis_client", return_value=client):
-            assert claim_daily_slot(7, "GOLDEN_HOUR") is None
+            assert claim_daily_slot(7, "GOLDEN_HOUR", "2026-07-25") is None
 
 
 class TestApprovedFanoutDefaults:


### PR DESCRIPTION
## What

Replaces the single `13:00 UTC` `daily-golden-hour-engagement` crontab (and the same shape on `send-appreciation-dms` / `group-engagement`) with a **per-user staggered slot**.

Each of the three beats now ticks every `STAGGER_TICK_MINUTES` (15) and dispatches only the users whose slot has come up:

| Fan-out | Lane | Window (default) | Was |
|---|---|---|---|
| `daily-golden-hour-engagement` | `se_engage` | **09:00 local + 0–180 min** | 13:00 UTC, all users |
| `send-appreciation-dms` | `se_outreach` | **08:00 local + 0–120 min** | 08:00 UTC, all users |
| `group-engagement` | `se_content` | **12:00 local + 0–120 min** | 16:00 UTC, all users |

`plan_daily_slot()` (new, in `utilities/engagement_window.py` next to the pre-post window planner from #547) gives every user a **stable hashed minute** inside a window that opens at an anchor hour **in that user's own timezone** (`users.timezone`, via `get_user_timezone`). The hash is salted per fan-out, so a user isn't first — or last — in every window of the day, and consecutive user ids don't clump the way `user_id % window` would.

## Why

`se_engage` drains ~8 fifteen-minute `automate_commenting` loops an hour. Fanning the whole fleet out at one minute meant the 9th user ran an hour late and the 50th ~6 hours late — their "golden hour" landed in the afternoon. See `docs/scaling-plan.md` §3/§5d (PR #551); this was called out there as the single highest-leverage, lowest-cost change for on-time behavior.

With a 3-hour window, `se_engage` sees ~1 loop per tick at 12 users instead of 12 at once.

## Behavior notes

- **Once per user per day**, enforced by a Redis claim (`engagement:slot:<NAME>:<user_id>`, sub-day TTL). That claim also buys a **catch-up**: a slot missed because the beat was down — or because `_skip_if_throttled` short-circuited on an open 429 breaker — fires at a later tick the same day instead of being lost. Previously a breaker open at 13:00 cost the whole day's golden hour.
- **No Redis → no double-dispatch**: the gate falls back to the strict one-tick window.
- **Per-user `QueueOnce(keys=['user_id'])` and the per-day caps** (`max_comments_per_day`, `max_dms_per_day`) are untouched — this changes *when* work is dispatched, never how much.
- A user with no LinkedIn session is skipped **before** the claim is spent, so connecting later in the day still earns that day's run.
- Fully retunable without a deploy: `<NAME>_ANCHOR_HOUR` / `<NAME>_WINDOW_MINUTES` / `<NAME>_ANCHOR_TZ` (`local` default, or `utc`), read at call time. **`<NAME>_WINDOW_MINUTES=1` puts everyone back on the anchor minute** — the escape hatch to the old behavior with no code change.

## Testing

`poetry run pytest tests/unit -q` → **5491 passed**.

New/updated unit coverage:
- `tests/unit/utilities/test_engagement_window.py` — offset stability + spread + per-fan-out salting; env parsing and fallbacks; local vs UTC anchoring (09:00 local = 13:00 UTC in NY, 16:00 UTC in LA); unknown timezone → UTC; DST keeps the same *local* minute; a window crossing midnight wraps instead of never firing; and the property the design rests on — **every user matches exactly one of the 96 daily ticks**.
- `tests/unit/app/test_daily_engagement.py` — the shared `_stagger_due` gate (not-yet-due spends no claim, claimed → due, already-claimed → not due again, missed-tick catch-up, no-Redis fallback, local vs UTC timezone lookup), only-due-users dispatch, no-session doesn't burn a slot, and a beat-schedule test pinning all three entries to `STAGGER_TICK_MINUTES`.
- `tests/unit/app/test_groups.py`, `tests/unit/app/test_run_scheduler.py` — the group and appreciation-DM fan-outs now wait for each user's slot.

Docs: `docs/scaling-plan.md` §3/§5d/Phase-1 marked applied; `.env.example` documents the nine new tunables.

Closes #554

🤖 Generated with [Claude Code](https://claude.com/claude-code)