### PR TITLE
feat(infra): Selenium Grid horizontal path + concurrency/scale load test (closes #556)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -487,6 +487,18 @@ NGROK_JAEGER_PREFIX=your-app-jaeger
 SELENIUM_HUB_HOST=selenium-chrome
 SELENIUM_HUB_PORT=4444
 SELENIUM_KEEP_VIDEOS_X_DAYS=7
+# Selenium Grid (Phase 2, docker-compose.grid.yml — NOT enabled by default; see docs/SELENIUM_GRID.md).
+# Each node runs one session, so the node count IS the browser-session cap and MUST equal the summed
+# SELENIUM_CONCURRENCY of the lane workers (se_engage + se_prepost + se_outreach + se_content).
+# SELENIUM_HUB_HOST is overridden to `selenium-hub` by the overlay itself — leave it alone here.
+SELENIUM_GRID_NODES=8
+# Bind address for the Grid event bus (4442/4443). Loopback unless nodes run on a SECOND box, in
+# which case set the primary box's PRIVATE (WireGuard/VPC) address — never 0.0.0.0: registering a
+# node needs no credentials.
+SELENIUM_GRID_BUS_BIND=127.0.0.1
+# Bind address for the hub's WebDriver port. Loopback, matching how docker-compose.prod.yml binds
+# the standalone's 4444 today; host-side tooling reaches it over an SSH tunnel.
+SELENIUM_GRID_HUB_BIND=127.0.0.1
 # Egress proxy for the automation browser. Resolution order (zero user setup):
 #   1. per-user override users.proxy_url
 #   2. REGION_PROXIES matched to the user's stored country (auto — no user action)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,6 +137,13 @@ Always use `get_docker_driver()` from `selenium_util.py`. It connects to `seleni
 
 Use `click_element_wait_retry()` for all click interactions — it handles transient DOM timing issues.
 
+Browser capacity is a **fixed pool of Chrome session slots shared by the Celery Selenium lanes**, and
+`SE_NODE_MAX_SESSIONS` must always equal the summed `SELENIUM_CONCURRENCY` of those lanes —
+`tests/unit/app/test_selenium_capacity.py` fails the build if they drift. The Phase-2 horizontal path
+(`docker-compose.grid.yml`: hub + N single-session nodes, optionally on a 2nd VPS) carries the same
+invariant with node count as the cap, and `python -m cqc_lem.utilities.selenium_load_test` produces
+the on-time/resource curve that sizes it. See `docs/SELENIUM_GRID.md` and `docs/scaling-plan.md`.
+
 ## Feature Areas
 
 ### Content generation & scheduling (`app/run_content_plan.py`, `app/run_scheduler.py`, `utilities/ai/ai_helper.py`)

--- a/docker-compose.grid-node.yml
+++ b/docker-compose.grid-node.yml
@@ -1,0 +1,81 @@
+# Selenium Grid NODES ONLY — for a second box (issue #556, docs/scaling-plan.md §5b/§5c).
+#
+# A standalone compose project you run on a SECOND VPS. No app, no database, no hub: just Chrome
+# nodes that register into the hub on the primary box. That is the whole reason Phase 2 is a Grid —
+# past ~8 concurrent sessions the primary box is out of Chrome budget (§4), and the next sessions
+# have to come from somewhere else without the app tier changing at all.
+#
+#   # on the second box, in a directory holding this file and a .env with the vars below:
+#   docker compose -f docker-compose.grid-node.yml up -d
+#
+# Required in that .env:
+#   SELENIUM_GRID_HUB_HOST=10.10.0.1     # PRIVATE address of the primary box (WireGuard/VPC)
+#   SELENIUM_GRID_NODE_HOST=10.10.0.2    # PRIVATE address of THIS box, as the hub must reach it
+#
+# The primary box must publish the event bus on its private address (SELENIUM_GRID_BUS_BIND in
+# docker-compose.grid.yml) and firewall it to this box only: registering a node needs no
+# credentials, so an internet-reachable bus is an open door into the Grid.
+#
+# Why four explicit services instead of `deploy.replicas`: the hub calls each node back on
+# SE_NODE_HOST:SE_NODE_PORT, so every node needs its OWN fixed port that is reachable from the
+# other box. Replicas would all advertise the same port and only one of them would ever be
+# routable. `network_mode: host` keeps the advertised port and the listening port identical.
+# Add nodes by copying a block with the next port; remove them by deleting one.
+#
+# CAPACITY INVARIANT: the lanes' summed SELENIUM_CONCURRENCY must equal TOTAL slots across BOTH
+# boxes (primary SELENIUM_GRID_NODES + the nodes here). The unit test can only see the primary's
+# default, so adding this box is a deliberate change to the lane concurrencies too —
+# see docs/SELENIUM_GRID.md.
+x-grid-node: &grid-node
+  image: selenium/node-chrome:latest
+  # Host networking, deliberately: the node must advertise an address the HUB can dial, and a
+  # bridge-network container's IP is private to this box.
+  network_mode: host
+  shm_size: 2g
+  environment: &grid-node-env
+    SE_EVENT_BUS_HOST: ${SELENIUM_GRID_HUB_HOST}
+    SE_EVENT_BUS_PUBLISH_PORT: 4442
+    SE_EVENT_BUS_SUBSCRIBE_PORT: 4443
+    SE_NODE_HOST: ${SELENIUM_GRID_NODE_HOST}
+    # One session per node: a crashed Chrome costs one session, and capacity is added by adding
+    # nodes rather than by raising a number inside one container.
+    SE_NODE_MAX_SESSIONS: 1
+    SE_NODE_OVERRIDE_MAX_SESSIONS: true
+    SE_NODE_SESSION_TIMEOUT: 600
+    SE_LOG_LEVEL: WARN
+  restart: unless-stopped
+  deploy:
+    resources:
+      limits:
+        # Same per-session budget as the primary box's nodes (§5b): ~1 vCPU / 1.5 GB + 2 GB shm.
+        cpus: '1.0'
+        memory: 1536m
+
+services:
+  selenium-node-1:
+    <<: *grid-node
+    container_name: selenium-node-1
+    environment:
+      <<: *grid-node-env
+      SE_NODE_PORT: 5561
+
+  selenium-node-2:
+    <<: *grid-node
+    container_name: selenium-node-2
+    environment:
+      <<: *grid-node-env
+      SE_NODE_PORT: 5562
+
+  selenium-node-3:
+    <<: *grid-node
+    container_name: selenium-node-3
+    environment:
+      <<: *grid-node-env
+      SE_NODE_PORT: 5563
+
+  selenium-node-4:
+    <<: *grid-node
+    container_name: selenium-node-4
+    environment:
+      <<: *grid-node-env
+      SE_NODE_PORT: 5564

--- a/docker-compose.grid.yml
+++ b/docker-compose.grid.yml
@@ -1,0 +1,178 @@
+# Selenium Grid overlay — Phase 2 of docs/scaling-plan.md (issue #556).
+#
+# The base file runs ONE `selenium/standalone-chrome` with 8 session slots. That is the top of this
+# box's Chrome budget (§4): the next capacity increase has to be horizontal, not a bigger number.
+# This overlay swaps that single container for a **hub + N single-session nodes**, so sessions scale
+# with node count and nodes can be moved to a second VPS without touching the app tier —
+# `get_docker_driver()` already targets `${SELENIUM_HUB_HOST}:${SELENIUM_HUB_PORT}/wd/hub`, which is
+# the hub's address as much as it was the standalone's.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.grid.yml up -d
+#
+# NOT enabled by default. Prod runs the standalone until the capacity monitor (§5e) says the cap is
+# the operating point; see docs/SELENIUM_GRID.md for the cutover runbook and the load-test evidence
+# that should precede it.
+#
+# INVARIANT (same one the standalone carries): total session slots == the sum of every lane
+# worker's SELENIUM_CONCURRENCY. Here total slots = SELENIUM_GRID_NODES x SE_NODE_MAX_SESSIONS(=1),
+# so the default node count IS the cap: 8 nodes = se_engage 3 + se_prepost 2 + se_outreach 2 +
+# se_content 1. Raising the node count without raising the lanes buys idle nodes; raising the lanes
+# without the nodes makes tasks queue on session creation and miss their window. Change both in the
+# same commit — tests/unit/app/test_selenium_capacity.py fails the build if they drift.
+services:
+  selenium-hub:
+    image: selenium/hub:latest
+    container_name: selenium-hub
+    hostname: selenium-hub
+    ports:
+      # Same port as the standalone, so SELENIUM_HUB_PORT and every tool that speaks to it
+      # (tools/selenium_mcp_server.py, the capacity monitor's /status poll) are unchanged. Bound to
+      # LOOPBACK by default because this overlay composes after docker-compose.prod.yml, whose whole
+      # point for `ports` is that 4444 is not publicly reachable — a default of "all interfaces"
+      # here would silently undo that hardening on the cutover.
+      # NOTE: there is no 7900 on a hub. noVNC lives on the NODES, and replicas cannot publish the
+      # same host port, so "watch the live browser" is lost on a Grid — attach to one node instead:
+      #   docker compose port <node-container> 7900   (or run one node with an explicit mapping).
+      - "${SELENIUM_GRID_HUB_BIND:-127.0.0.1}:${SELENIUM_HUB_PORT}:4444"
+      # Event bus. Only nodes speak these, and node-on-the-same-box reaches them over the compose
+      # network without any publishing at all — so the default bind is loopback. Set
+      # SELENIUM_GRID_BUS_BIND to the box's PRIVATE (WireGuard/VPC) address, never 0.0.0.0, when
+      # nodes live on a second host: an internet-reachable event bus is an unauthenticated way to
+      # register a node into the Grid. See docs/SELENIUM_GRID.md.
+      - "${SELENIUM_GRID_BUS_BIND:-127.0.0.1}:4442:4442"
+      - "${SELENIUM_GRID_BUS_BIND:-127.0.0.1}:4443:4443"
+    environment:
+      - SE_LOG_LEVEL=WARN
+      # How long a new-session request may sit in the hub's queue before it is rejected. The
+      # standalone had no queue — a request either got a slot or blocked in the client. Keep this
+      # comfortably longer than a Chrome startup burst but shorter than the 15-minute windows the
+      # lanes are trying to hit, so a starved Grid surfaces as an error, not as a silent 10-minute stall.
+      - SE_SESSION_REQUEST_TIMEOUT=300
+      - SE_SESSION_RETRY_INTERVAL=5
+    restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          # The hub only routes — it runs no browser (§5b: ~0.5 vCPU / 512 MB).
+          cpus: '0.5'
+          memory: 512m
+    healthcheck:
+      # Same shape as the standalone's check, and for the same reason: a hub that answers but has
+      # zero nodes registered has zero capacity, so "UP" must mean "a browser can actually start".
+      test: ["CMD-SHELL", "curl -fsS http://localhost:4444/status | python3 -c \"import sys,json; d=json.load(sys.stdin); sys.exit(0 if any(n.get('availability')=='UP' for n in d['value']['nodes']) else 1)\""]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 30s
+
+  selenium-node-chrome:
+    image: selenium/node-chrome:latest
+    # No container_name: this service is replicated, and Compose refuses to scale a named service.
+    # Nodes are addressed by the hub over the event bus, never by us, so they need no stable name.
+    # No chrome-profile volume either — a named volume shared by N replicas is one profile
+    # directory with N Chromes writing into it, which corrupts it. Each node gets its own.
+    shm_size: 2g
+    depends_on:
+      # service_started, NOT service_healthy: the hub is only "healthy" once a node has registered,
+      # so waiting for health here would deadlock the pair. Nodes retry the bus on their own.
+      selenium-hub:
+        condition: service_started
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+      # ONE session per node is the whole point of the horizontal path: a crashed Chrome takes down
+      # one session instead of all of them, and capacity is added by adding nodes (here or on a
+      # second box), not by raising a number inside a single container.
+      - SE_NODE_MAX_SESSIONS=1
+      - SE_NODE_OVERRIDE_MAX_SESSIONS=true
+      - SE_NODE_SESSION_TIMEOUT=600
+      - SE_LOG_LEVEL=WARN
+    restart: unless-stopped
+    deploy:
+      # Total slots = replicas x SE_NODE_MAX_SESSIONS. 8 == the summed lane concurrency (see the
+      # invariant at the top) and is drop-in parity with the standalone it replaces.
+      replicas: ${SELENIUM_GRID_NODES:-8}
+      resources:
+        limits:
+          # §5b's budget: ~1 vCPU / 1.5 GB + 2 GB shm per additional concurrent session. Note this
+          # costs MORE RAM than the standalone for the same 8 sessions (8 x 1.5 GB + 8 node JVMs
+          # vs one 8 GB container) — that extra is what buys fault isolation and the second box.
+          cpus: '1.0'
+          memory: 1536m
+
+  # The standalone is retired by this overlay, not deleted: `profiles` keeps it defined (so
+  # `docker compose -f ... -f docker-compose.grid.yml --profile standalone up selenium-chrome` can
+  # still bring it back for an instant rollback) while excluding it from a normal `up`.
+  selenium-chrome:
+    profiles: ["standalone"]
+
+  # Every service that waited on the standalone now waits on the hub, and points at it. `!override`
+  # replaces the whole depends_on map rather than merging into it — a merged map would still name
+  # selenium-chrome, which this overlay has profiled out. SELENIUM_HUB_HOST is set per-service
+  # because `environment` beats `env_file`, so .env's `selenium-chrome` default needs no edit.
+  celery_worker:
+    environment:
+      - SELENIUM_HUB_HOST=selenium-hub
+    depends_on: !override
+      redis:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+      selenium-hub:
+        condition: service_healthy
+
+  celery_worker_selenium:
+    environment:
+      - SELENIUM_HUB_HOST=selenium-hub
+    depends_on: !override
+      redis:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+      selenium-hub:
+        condition: service_healthy
+
+  celery_worker_selenium_prepost:
+    environment:
+      - SELENIUM_HUB_HOST=selenium-hub
+    depends_on: !override
+      redis:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+      selenium-hub:
+        condition: service_healthy
+
+  celery_worker_selenium_outreach:
+    environment:
+      - SELENIUM_HUB_HOST=selenium-hub
+    depends_on: !override
+      redis:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+      selenium-hub:
+        condition: service_healthy
+
+  celery_worker_selenium_content:
+    environment:
+      - SELENIUM_HUB_HOST=selenium-hub
+    depends_on: !override
+      redis:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+      selenium-hub:
+        condition: service_healthy
+
+  celery_beat:
+    environment:
+      - SELENIUM_HUB_HOST=selenium-hub
+    depends_on: !override
+      redis:
+        condition: service_healthy
+      mysql:
+        condition: service_healthy
+      selenium-hub:
+        condition: service_healthy

--- a/docker-compose.grid.yml
+++ b/docker-compose.grid.yml
@@ -57,9 +57,12 @@ services:
           cpus: '0.5'
           memory: 512m
     healthcheck:
-      # Same shape as the standalone's check, and for the same reason: a hub that answers but has
-      # zero nodes registered has zero capacity, so "UP" must mean "a browser can actually start".
-      test: ["CMD-SHELL", "curl -fsS http://localhost:4444/status | python3 -c \"import sys,json; d=json.load(sys.stdin); sys.exit(0 if any(n.get('availability')=='UP' for n in d['value']['nodes']) else 1)\""]
+      # Same MEANING as the standalone's check — a hub that answers but has zero nodes registered has
+      # zero capacity, so "UP" must mean "a browser can actually start" — but pure shell rather than
+      # the standalone's `python3 -c`: selenium/hub is a JRE image and carries no Python, so a check
+      # that shelled out to it would make the hub permanently unhealthy and strand every service that
+      # depends on it. `tr -d` first so the probe doesn't depend on how the hub spaces its JSON.
+      test: ["CMD-SHELL", "curl -fsS http://localhost:4444/status | tr -d ' \\n' | grep -q '\"availability\":\"UP\"'"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -92,6 +95,12 @@ services:
     deploy:
       # Total slots = replicas x SE_NODE_MAX_SESSIONS. 8 == the summed lane concurrency (see the
       # invariant at the top) and is drop-in parity with the standalone it replaces.
+      # `deploy.replicas` is honoured by `docker compose up` in Compose **v2** (v1 ignored the whole
+      # `deploy` key outside Swarm — as it also would for the resource limits the base compose file
+      # already relies on). Because a wrong node count is a silent capacity regression, not an error,
+      # the cutover VERIFIES the slot count against /status before trusting it, and
+      # `--scale selenium-node-chrome=$SELENIUM_GRID_NODES` is the explicit override if a host ever
+      # disagrees. See docs/SELENIUM_GRID.md §2.
       replicas: ${SELENIUM_GRID_NODES:-8}
       resources:
         limits:

--- a/docs/SELENIUM_GRID.md
+++ b/docs/SELENIUM_GRID.md
@@ -44,6 +44,17 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compos
 `SELENIUM_GRID_NODES` in `/opt/lem/.env` sets the node count (default 8). **Raising it requires
 raising the lane concurrencies in the same commit** — the unit test fails the build otherwise.
 
+Node count is declared as `deploy.replicas`, which **Compose v2 applies on a plain `up`** (Compose v1
+ignored the whole `deploy:` key outside Swarm — as it would also ignore the resource limits the base
+compose file already depends on, so v2 is a prerequisite of this stack, not just of this overlay).
+Getting it wrong is silent — you get *fewer browsers*, not an error — so **verify the slot count
+below before running an engagement cycle on it**, and if a host ever disagrees, say it explicitly:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.grid.yml \
+  up -d --scale selenium-node-chrome="${SELENIUM_GRID_NODES:-8}"
+```
+
 Rollback is one flag, because the overlay parks the standalone rather than deleting it:
 
 ```sh
@@ -79,9 +90,16 @@ documented, deliberate two-file change.
 ### Verify
 
 ```sh
+# node count AND slot count — both must equal SELENIUM_GRID_NODES (one session per node)
 curl -s localhost:4444/status | jq '.value.nodes | length, [.[].slots[]] | length'
+docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.grid.yml \
+  ps selenium-node-chrome | tail -n +2 | wc -l
 docker exec celery_worker_selenium python -m cqc_lem.utilities.capacity_alerts
 ```
+
+Fewer slots than lanes is the one failure this cutover can produce quietly: the stack comes up, the
+hub is healthy, and time-sensitive tasks simply start queueing on session creation. Check it here,
+not from the logs.
 
 The capacity monitor (`auto_capacity_watch`, §5e) reads the same `/status` endpoint and needs no
 change: a hub reports slots exactly like the standalone did.
@@ -158,7 +176,9 @@ cohort onboarding without parsing the table. `--json` emits the whole thing mach
 | 50 | **57.7%** | 148 | 320 min | 14 (engage 6, prepost 4, outreach 2, content 2) | 16.8 GB | 15.5 vCPU (194%) | at ceiling |
 | 100 | **17.7%** | 576 | 640 min | 27 (engage 12, prepost 7, outreach 4, content 4) | 32.4 GB | 28.5 vCPU (356%) | exceeds one VPS |
 
-With `--stagger-hours 4` (§5d's per-user golden-hour offset, **not yet implemented**):
+With `--stagger-hours 4` (§5d's per-user golden-hour offset — **shipped in #554** while this harness
+was in review, so these rows are now a *prediction to be checked*, not a proposal; the re-run that
+confirms or refutes them is **#634**):
 
 | Users | On-time % | Sessions needed | Host CPU | Verdict |
 |---|---|---|---|---|
@@ -171,9 +191,12 @@ Three things fall out of this:
 1. **Today's 8 slots are right for ~10 users and nothing more.** On-time collapses to 58% at 50
    users and 18% at 100 — the §2 prediction ("tasks miss their window, the box does not fall over"),
    quantified.
-2. **Staggering is the cheapest win and it is still unimplemented.** It cuts the sessions needed at
-   50 users from 14 to 11 and lifts on-time from 58% → 84% *with no new hardware*. Do it before
-   buying anything.
+2. **Staggering is the cheapest win, and it has now shipped (#554).** The model says it cuts the
+   sessions needed at 50 users from 14 to 11 and lifts on-time from 58% → 84% *with no new hardware* —
+   which is why it went first, before any spend. What is NOT yet done is proving it: the model still
+   fans every user out at one 13:00 UTC minute at `--stagger-hours 0`, whereas #554 gives each user a
+   hashed slot inside a 3-hour window **in their own timezone**. Teaching the workload model that
+   shape and re-running the curve is **#634**, and until it lands these two tables are a prediction.
 3. **`se_prepost` is the lane §4 never modelled.** At 100 users it needs 7 slots on its own, because
    a 15-minute warm-up with a 5-minute tolerance cannot absorb posts arriving every 2.4 minutes. It
    is the first lane to break and the least forgiving.
@@ -185,9 +208,19 @@ Three things fall out of this:
 
 ---
 
-## 5. The decision point: 16 vCPU / 64 GB, or a second box
+## 5. The decision point: 16 vCPU / 64 GB, a second box — or someone else's grid
 
-Both are real options at ~50 users, and the load test picks between them by what has to scale.
+**Status: deliberately undecided (owner call on #556, 2026-07-26).** Nothing is bought until the
+capacity monitor (§5e) says the cap is the operating point, and the option set is widened first:
+**#633** prices hosted/cloud grids (AWS Fargate/EC2 nodes, Device Farm, BrowserStack, Sauce Labs,
+LambdaTest, Browserless, Browserbase, Steel) against the two self-managed baselines below, keyed to
+this section's sessions-needed curve. That comparison is a spike, not a foregone conclusion: most of
+that market is *test* infrastructure and may disqualify itself on datacenter egress IPs (we route
+per-user residential proxies on purpose), per-minute billing against long-lived logged-in sessions,
+ToS clauses on social automation, and whether the MV3 proxy-auth extension can load at all.
+
+The two self-managed options are both real at ~50 users, and the load test picks between them by what
+has to scale.
 
 | | **A. Upgrade to 16 vCPU / 64 GB** | **B. Second VPS running Grid nodes** |
 |---|---|---|
@@ -198,12 +231,17 @@ Both are real options at ~50 users, and the load test picks between them by what
 | Egress | unchanged (per-user proxies do the egress, `EGRESS_AT_SCALE.md`) | unchanged — nodes egress through the same per-user proxies |
 | Ceiling | ~16 sessions ≈ **50–60 users staggered**; then this decision repeats | none in practice |
 
-**Recommendation:** **stagger first, then A, then B.** Staggering costs nothing and moves 50 users
-from 58% to 84% on-time. A single 16 vCPU / 64 GB box covers the ~14 sessions that 50 users need
-(16.8 GB Chrome + ~6 GB app tier fits 64 GB with room) at a fraction of the operational cost of a
-second host, and B's fault isolation only starts paying when Chrome and the app tier are genuinely
-competing — which is the 100-user row, not the 50-user one. Take B when the load test says **more
-than ~16 sessions** are needed, which is 100 users at any stagger.
+**Where this stands:** staggering went first and has shipped (#554) — it was the only free move.
+Between A and B, A is the cheaper answer *if* the choice were made today: one 16 vCPU / 64 GB box
+covers the ~14 sessions that 50 users need (16.8 GB Chrome + ~6 GB app tier fits 64 GB with room) at
+a fraction of the operational cost of a second host, and B's fault isolation only starts paying when
+Chrome and the app tier genuinely compete — the 100-user row, not the 50-user one. B is the answer
+past **~16 sessions**, i.e. 100 users at any stagger.
+
+But the choice is **not** being made today. The sequence the owner set is: bank the stagger (done) →
+re-measure it (#634) → price hosted alternatives beside A and B (#633) → decide when §5e files a
+breach. Buying either box now would pay for capacity the curve cannot yet prove is needed, and would
+foreclose an option that has not been costed.
 
 The Grid is worth cutting over to **before** either, at the same 8 nodes: it is capacity-neutral,
 it makes a crashed Chrome cost one session instead of all of them, and it is the thing that makes B
@@ -216,9 +254,10 @@ a config change rather than a migration.
 1. Capacity monitor (§5e) has filed a `session_saturation` or `lane_backlog` breach — i.e. the cap
    is the operating point, not a busy afternoon.
 2. Run the load test at the target cohort size; record the curve in the issue.
-3. Implement the golden-hour stagger (§5d) and re-run. If it clears the SLO, stop here.
+3. ✅ Golden-hour stagger shipped (#554). Re-run the curve against the staggered arrivals (#634) —
+   if it clears the SLO, stop here.
 4. Cut over to the Grid at the SAME node count as today's cap (8). Verify `/status` shows 8 slots
-   and a full engagement cycle runs green.
+   (see §2 — a short node count is silent) and a full engagement cycle runs green.
 5. Only then change the numbers: raise `SELENIUM_GRID_NODES` **and** the lane concurrencies in one
    commit, sized by the load test's "sessions needed" column, on a box (or boxes) that §5c says can
    pay for them.

--- a/docs/SELENIUM_GRID.md
+++ b/docs/SELENIUM_GRID.md
@@ -1,0 +1,224 @@
+# Selenium Grid — the horizontal browser path (Phase 2)
+
+**Status:** built, NOT enabled in prod · **Issue:** #556 · **Plan:** `docs/scaling-plan.md` §5b/§5c
+
+Prod runs **one `selenium/standalone-chrome`** with 8 session slots. §4 of the scaling plan puts the
+top of this box's Chrome budget at ~8 sessions, so 8 is not a step on a ladder — it is the ceiling.
+The next capacity increase has to be **horizontal**: a Grid hub with N single-session nodes, where
+nodes can live on a second box.
+
+Nothing in the app changes. `get_docker_driver()` already talks to
+`${SELENIUM_HUB_HOST}:${SELENIUM_HUB_PORT}/wd/hub`, which is the hub's address exactly as it was the
+standalone's — the seam was always there.
+
+---
+
+## 1. What ships here
+
+| File | What it is |
+|---|---|
+| `docker-compose.grid.yml` | Overlay: hub + N nodes on the primary box; parks the standalone behind a `standalone` profile; repoints every service that waited on it. |
+| `docker-compose.grid-node.yml` | A nodes-only compose project for a **second VPS**. |
+| `src/cqc_lem/utilities/selenium_load_test.py` | The concurrency/scale load test (§3 below). |
+| `tests/unit/app/test_selenium_capacity.py` | Extended: the cap == Σ-lanes invariant is enforced for the Grid too (node count **is** the cap). |
+
+### The invariant travels with the topology
+
+`SE_NODE_MAX_SESSIONS == the sum of every lane worker's SELENIUM_CONCURRENCY` (§5a) becomes
+`SELENIUM_GRID_NODES × 1 == the same sum`, because each `selenium/node-chrome` runs exactly one
+session. Below it, lanes block on session creation and time-sensitive tasks miss their window; above
+it, nodes are paid for and idle. The default is **8 nodes**, matching today's
+`se_engage 3 + se_prepost 2 + se_outreach 2 + se_content 1` — so the cutover is capacity-neutral by
+design, and the change of capacity is a separate, deliberate decision.
+
+---
+
+## 2. Running it
+
+### Primary box (hub + local nodes)
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.prod.yml -f docker-compose.grid.yml up -d
+```
+
+`SELENIUM_GRID_NODES` in `/opt/lem/.env` sets the node count (default 8). **Raising it requires
+raising the lane concurrencies in the same commit** — the unit test fails the build otherwise.
+
+Rollback is one flag, because the overlay parks the standalone rather than deleting it:
+
+```sh
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d   # back to the standalone
+```
+
+### Second box (nodes only)
+
+On the second VPS, in a directory holding `docker-compose.grid-node.yml` and a `.env`:
+
+```sh
+SELENIUM_GRID_HUB_HOST=10.10.0.1     # PRIVATE address of the primary box
+SELENIUM_GRID_NODE_HOST=10.10.0.2    # PRIVATE address of THIS box, as the hub must reach it
+```
+
+```sh
+docker compose -f docker-compose.grid-node.yml up -d
+```
+
+On the primary box, set `SELENIUM_GRID_BUS_BIND` to its **private** address so the event bus is
+reachable from the second box — never `0.0.0.0`. **Registering a node into a Grid requires no
+credentials**, so an internet-reachable event bus (4442/4443) is an open door: put the two boxes on
+WireGuard or a private VPC network and firewall those ports to the peer only.
+
+The second box's nodes use `network_mode: host` with one fixed `SE_NODE_PORT` each, because the hub
+calls each node back on `SE_NODE_HOST:SE_NODE_PORT` and replicas would all advertise the same port.
+Add capacity by copying a node block with the next port.
+
+**With a second box, the invariant spans both boxes:** summed lane concurrency must equal
+primary nodes + second-box nodes. The unit test can only see the primary's default, so this is a
+documented, deliberate two-file change.
+
+### Verify
+
+```sh
+curl -s localhost:4444/status | jq '.value.nodes | length, [.[].slots[]] | length'
+docker exec celery_worker_selenium python -m cqc_lem.utilities.capacity_alerts
+```
+
+The capacity monitor (`auto_capacity_watch`, §5e) reads the same `/status` endpoint and needs no
+change: a hub reports slots exactly like the standalone did.
+
+### What the cutover costs you
+
+**noVNC on port 7900 goes away.** The hub has no browser; noVNC lives on the nodes, and replicas
+cannot all publish the same host port. To watch a live session, map 7900 on one node
+(`docker compose port <node-container> 7900`) or keep a single explicitly-mapped node for debugging.
+`tools/selenium_mcp_server.py` is unaffected — it drives 4444, which is still the hub.
+
+Both 4444 and the event bus bind to **loopback** by default (`SELENIUM_GRID_HUB_BIND`,
+`SELENIUM_GRID_BUS_BIND`), matching how `docker-compose.prod.yml` hardens the standalone today.
+
+---
+
+## 3. The load test
+
+`python -m cqc_lem.utilities.selenium_load_test` answers the question Phase 2 gates the cohort on:
+**at N users, what fraction of each user's engagement work starts inside its window, and what would
+it cost to serve the demand?**
+
+```sh
+# the curve, on today's deployed topology
+python -m cqc_lem.utilities.selenium_load_test --users 10,50,100
+
+# what-if: staggered golden hour (§5d), a 16-node Grid, Phase-2 lane concurrencies
+python -m cqc_lem.utilities.selenium_load_test --users 50 --nodes 16 --stagger-hours 4 \
+  --lanes se_engage=7,se_prepost=4,se_outreach=3,se_content=2
+
+# validate a DEPLOYED Grid with real browsers (run inside a container that can reach the hub)
+docker exec celery_worker_selenium python -m cqc_lem.utilities.selenium_load_test \
+  --users 10 --live --live-sessions 8 --hold-seconds 60 --live-user-id 1
+```
+
+Exit code **2** when the largest simulated scale exceeds one VPS, so a cron/CI caller can gate a
+cohort onboarding without parsing the table. `--json` emits the whole thing machine-readably.
+
+### Two modes, both needed
+
+* **simulate** (default) — a discrete-event model of the real topology: per-lane Celery slots plus a
+  global session cap, fed §4's per-user daily workload and §3's actual fan-out times. A task holds
+  its lane slot *while* it waits for a browser, which is why raising a lane without raising the cap
+  does nothing. It runs in a second, in CI, and is the only way to get a number for 100 users
+  without first buying the box that could host them.
+* **live** (`--live`) — opens N REAL concurrent sessions against the hub and measures acquisition
+  wait, busy slots and host headroom. This validates the model on the topology actually deployed.
+  It deliberately does **not** write to the capacity monitor's rolling window: synthetic waits there
+  would file a capacity issue about a load test.
+
+### Reading the output
+
+* **"Sessions needed"** is the smallest per-lane concurrency (and therefore cap) that starts 95% of
+  the day's work inside its window — *not* the instantaneous peak. Arrivals are spiky by
+  construction (§3's single crontabs), so the raw peak would ask for a browser per user, while the
+  tolerances say a golden-hour loop has the golden window to start in. Lanes are solved
+  independently, which is exact rather than approximate: with the invariant held, no lane can be
+  blocked by another lane's browser.
+* **Tolerances are the product requirement**, and they differ by an order of magnitude: pre-post
+  commenting has 5 minutes (its whole job is to run *before* the post), a golden-hour loop has the
+  2-hour window §4's `C ≥ N ÷ (W×4)` formula assumes, and §3's off-peak batch (appreciation DMs,
+  stats scrape) has 4 hours because nothing breaks if they slide.
+* **Simulated session wait is 0 whenever the invariant holds** — work queues on its *lane*, not on a
+  browser. A non-zero p95 in simulation means the cap is under-provisioned; for a real acquisition
+  wait, use `--live`.
+
+---
+
+## 4. Measured curve (2026-07-26, today's topology: 8 slots, lanes 3/2/2/1)
+
+| Users | On-time % | Late jobs | Delay p95 | Sessions needed | Chrome mem | Host CPU | Verdict |
+|---|---|---|---|---|---|---|---|
+| 10 | **100%** | 0 | 60 min | 5 (engage 2, prepost 1, outreach 1, content 1) | 6.0 GB | 6.5 vCPU (81%) | fits |
+| 50 | **57.7%** | 148 | 320 min | 14 (engage 6, prepost 4, outreach 2, content 2) | 16.8 GB | 15.5 vCPU (194%) | at ceiling |
+| 100 | **17.7%** | 576 | 640 min | 27 (engage 12, prepost 7, outreach 4, content 4) | 32.4 GB | 28.5 vCPU (356%) | exceeds one VPS |
+
+With `--stagger-hours 4` (§5d's per-user golden-hour offset, **not yet implemented**):
+
+| Users | On-time % | Sessions needed | Host CPU | Verdict |
+|---|---|---|---|---|
+| 10 | 100% | 4 | 5.5 vCPU (69%) | fits |
+| 50 | **84.0%** | 11 | 12.5 vCPU (156%) | at ceiling |
+| 100 | **31.1%** | 20 | 21.5 vCPU (269%) | exceeds one VPS |
+
+Three things fall out of this:
+
+1. **Today's 8 slots are right for ~10 users and nothing more.** On-time collapses to 58% at 50
+   users and 18% at 100 — the §2 prediction ("tasks miss their window, the box does not fall over"),
+   quantified.
+2. **Staggering is the cheapest win and it is still unimplemented.** It cuts the sessions needed at
+   50 users from 14 to 11 and lifts on-time from 58% → 84% *with no new hardware*. Do it before
+   buying anything.
+3. **`se_prepost` is the lane §4 never modelled.** At 100 users it needs 7 slots on its own, because
+   a 15-minute warm-up with a 5-minute tolerance cannot absorb posts arriving every 2.4 minutes. It
+   is the first lane to break and the least forgiving.
+
+> The harness is more complete than §4's back-of-envelope, which modelled only the commenting loops
+> and put 50 users at 8–10 sessions. Adding the once-a-day batch fan-outs (appreciation DMs, stats
+> scrape) and the `se_prepost` lane added by #553 is what takes 50 users to 14. Same box, same
+> assumptions (1.2 GB + 1 vCPU per session, §4) — more of the actual workload.
+
+---
+
+## 5. The decision point: 16 vCPU / 64 GB, or a second box
+
+Both are real options at ~50 users, and the load test picks between them by what has to scale.
+
+| | **A. Upgrade to 16 vCPU / 64 GB** | **B. Second VPS running Grid nodes** |
+|---|---|---|
+| Sessions it buys | ~16 concurrent (2× today) | ~8 per added box, unbounded by adding boxes |
+| Cost shape | one bigger monthly bill; no new ops surface | a second bill + a private network to run and firewall |
+| Failure domain | still ONE box — it takes the app tier with it | app tier survives a Chrome-box outage |
+| Ops cost | a resize + a restart | WireGuard/VPC, a second host to patch, node registration to monitor |
+| Egress | unchanged (per-user proxies do the egress, `EGRESS_AT_SCALE.md`) | unchanged — nodes egress through the same per-user proxies |
+| Ceiling | ~16 sessions ≈ **50–60 users staggered**; then this decision repeats | none in practice |
+
+**Recommendation:** **stagger first, then A, then B.** Staggering costs nothing and moves 50 users
+from 58% to 84% on-time. A single 16 vCPU / 64 GB box covers the ~14 sessions that 50 users need
+(16.8 GB Chrome + ~6 GB app tier fits 64 GB with room) at a fraction of the operational cost of a
+second host, and B's fault isolation only starts paying when Chrome and the app tier are genuinely
+competing — which is the 100-user row, not the 50-user one. Take B when the load test says **more
+than ~16 sessions** are needed, which is 100 users at any stagger.
+
+The Grid is worth cutting over to **before** either, at the same 8 nodes: it is capacity-neutral,
+it makes a crashed Chrome cost one session instead of all of them, and it is the thing that makes B
+a config change rather than a migration.
+
+---
+
+## 6. Cutover checklist
+
+1. Capacity monitor (§5e) has filed a `session_saturation` or `lane_backlog` breach — i.e. the cap
+   is the operating point, not a busy afternoon.
+2. Run the load test at the target cohort size; record the curve in the issue.
+3. Implement the golden-hour stagger (§5d) and re-run. If it clears the SLO, stop here.
+4. Cut over to the Grid at the SAME node count as today's cap (8). Verify `/status` shows 8 slots
+   and a full engagement cycle runs green.
+5. Only then change the numbers: raise `SELENIUM_GRID_NODES` **and** the lane concurrencies in one
+   commit, sized by the load test's "sessions needed" column, on a box (or boxes) that §5c says can
+   pay for them.

--- a/docs/scaling-plan.md
+++ b/docs/scaling-plan.md
@@ -303,8 +303,8 @@ per additional concurrent session**.
 > separate decisions. The invariant travels with it: node count × 1 session == summed lane
 > concurrency, enforced by the same `tests/unit/app/test_selenium_capacity.py`. Prod stays on the
 > standalone until §5e says the cap is the operating point. Runbook, the second-box setup, the
-> **16 vCPU / 64 GB vs second-box decision table**, and the cutover checklist:
-> **`docs/SELENIUM_GRID.md`**.
+> **16 vCPU / 64 GB vs second-box decision table** (held open pending the hosted-grid costing in
+> #633), and the cutover checklist: **`docs/SELENIUM_GRID.md`**.
 
 ### 5c. Resource plan by scale
 
@@ -316,9 +316,11 @@ per additional concurrent session**.
 > 50+** because it modelled only the commenting loops, not the once-a-day batch fan-outs or the
 > `se_prepost` lane #553 added afterwards; and **`se_prepost` is the first lane to break** (7 slots
 > of its own at 100 users — a 15-minute warm-up with a 5-minute window cannot absorb posts arriving
-> every 2.4 minutes). Staggering (§5d) is still the cheapest fix: at 50 users it takes on-time from
-> 57.7% → 84.0% and sessions needed from 14 → 11, with no new hardware. Full curve, both modes and
-> the reading guide: `docs/SELENIUM_GRID.md` §3–§4.
+> every 2.4 minutes). Staggering (§5d) was the cheapest fix and has since shipped (#554): the model
+> puts 50 users at 57.7% → 84.0% on-time and 14 → 11 sessions with no new hardware. That is still a
+> **prediction** — the model fans users out at one 13:00 UTC minute, not at #554's per-user local
+> slots, so re-running the curve against the shipped stagger is #634. Full curve, both modes and the
+> reading guide: `docs/SELENIUM_GRID.md` §3–§4.
 
 | Active users | Concurrent Chrome sessions | vCPU | RAM | Topology | Verdict on current VPS (8 vCPU / 31 GB) |
 |---|---|---|---|---|---|
@@ -421,12 +423,15 @@ have stopped holding:
   on-time/resource curve at any scale, plus a `--live` mode that opens real concurrent sessions
   against a deployed Grid. Run it before onboarding the cohort; it exits 2 when a scale exceeds
   one VPS.
-- **Stagger the golden-hour fan-out** (§5d) — still unimplemented, and the load test says it is the
-  single biggest on-time win available for free.
+- ✅ **Stagger the golden-hour fan-out** (§5d, #554) — the load test's biggest free on-time win, taken
+  first. Verifying it against the harness (which still models the pre-#554 single fan-out) is #634.
 - Lane concurrency 3–4 each; per-user 429 breaker keys; per-user rate pacing.
-- Upgrade to **16 vCPU / 64 GB** or split app-tier / Chrome-tier across two boxes — decision table
-  in `docs/SELENIUM_GRID.md` §5 (short version: upgrade covers ~16 sessions ≈ 50–60 staggered
-  users at far lower ops cost; take the second box past ~16 sessions, i.e. at 100 users).
+- **Hardware/topology: deliberately undecided** (owner call on #556). Upgrading to **16 vCPU / 64 GB**
+  and splitting the Chrome tier onto a second box are compared in `docs/SELENIUM_GRID.md` §5 (short
+  version: upgrade covers ~16 sessions ≈ 50–60 staggered users at far lower ops cost; second box past
+  ~16 sessions, i.e. at 100 users) — but nothing is bought until §5e files a breach, and **#633**
+  first prices hosted/cloud grids (AWS, BrowserStack/Sauce/LambdaTest/Browserless/Browserbase/Steel)
+  beside both, against this curve and against our residential-proxy egress requirement.
 
 **Phase 3 — ~100 users:**
 - Grid nodes across 2+ hosts; dedicated Chrome host(s).

--- a/docs/scaling-plan.md
+++ b/docs/scaling-plan.md
@@ -296,7 +296,29 @@ nodes can be added on a second box without touching the app tier — the same
 512 MB; each node = 1 Chrome ≈ 1 vCPU / 1.5 GB + 2 GB shm. Budget **~2 GB + ~1 vCPU
 per additional concurrent session**.
 
+> **BUILT, not enabled (issue #556).** Option C now exists as `docker-compose.grid.yml`
+> (hub + N single-session nodes, standalone parked behind a `standalone` profile for instant
+> rollback) plus `docker-compose.grid-node.yml` for nodes on a second box. It defaults to **8
+> nodes** — capacity-neutral with today's standalone, so the cutover and the capacity change are
+> separate decisions. The invariant travels with it: node count × 1 session == summed lane
+> concurrency, enforced by the same `tests/unit/app/test_selenium_capacity.py`. Prod stays on the
+> standalone until §5e says the cap is the operating point. Runbook, the second-box setup, the
+> **16 vCPU / 64 GB vs second-box decision table**, and the cutover checklist:
+> **`docs/SELENIUM_GRID.md`**.
+
 ### 5c. Resource plan by scale
+
+> **Measured by the load test (issue #556), 2026-07-26.** The table below was the estimate; running
+> `python -m cqc_lem.utilities.selenium_load_test --users 10,50,100` against today's topology
+> (8 slots, lanes 3/2/2/1) gives the on-time curve behind it: **10 users 100% on time, 50 users
+> 57.7%, 100 users 17.7%**, needing **5 / 14 / 27** sessions respectively to hold 95% on-time.
+> Two corrections to the estimate: the "concurrent Chrome sessions" column below **under-counts at
+> 50+** because it modelled only the commenting loops, not the once-a-day batch fan-outs or the
+> `se_prepost` lane #553 added afterwards; and **`se_prepost` is the first lane to break** (7 slots
+> of its own at 100 users — a 15-minute warm-up with a 5-minute window cannot absorb posts arriving
+> every 2.4 minutes). Staggering (§5d) is still the cheapest fix: at 50 users it takes on-time from
+> 57.7% → 84.0% and sessions needed from 14 → 11, with no new hardware. Full curve, both modes and
+> the reading guide: `docs/SELENIUM_GRID.md` §3–§4.
 
 | Active users | Concurrent Chrome sessions | vCPU | RAM | Topology | Verdict on current VPS (8 vCPU / 31 GB) |
 |---|---|---|---|---|---|
@@ -391,10 +413,20 @@ have stopped holding:
 - All fits the current 8 vCPU / 31 GB box.
 
 **Phase 2 — ~50 users:**
-- Move Chrome to **Selenium Grid** (hub + 2–3 nodes); nodes can go on a **2nd VPS**.
+- ✅ **Selenium Grid built** (#556): `docker-compose.grid.yml` (hub + N nodes) and
+  `docker-compose.grid-node.yml` (nodes on a **2nd VPS**). Not enabled — cut over at the same 8
+  nodes first (capacity-neutral, buys fault isolation), then change the numbers. See
+  `docs/SELENIUM_GRID.md`.
+- ✅ **Load test built** (#556): `python -m cqc_lem.utilities.selenium_load_test` — simulated
+  on-time/resource curve at any scale, plus a `--live` mode that opens real concurrent sessions
+  against a deployed Grid. Run it before onboarding the cohort; it exits 2 when a scale exceeds
+  one VPS.
+- **Stagger the golden-hour fan-out** (§5d) — still unimplemented, and the load test says it is the
+  single biggest on-time win available for free.
 - Lane concurrency 3–4 each; per-user 429 breaker keys; per-user rate pacing.
-- Upgrade to **16 vCPU / 64 GB** or split app-tier / Chrome-tier across two boxes.
-- Load-test the topology (see issue) before onboarding the cohort.
+- Upgrade to **16 vCPU / 64 GB** or split app-tier / Chrome-tier across two boxes — decision table
+  in `docs/SELENIUM_GRID.md` §5 (short version: upgrade covers ~16 sessions ≈ 50–60 staggered
+  users at far lower ops cost; take the second box past ~16 sessions, i.e. at 100 users).
 
 **Phase 3 — ~100 users:**
 - Grid nodes across 2+ hosts; dedicated Chrome host(s).

--- a/src/cqc_lem/utilities/selenium_load_test.py
+++ b/src/cqc_lem/utilities/selenium_load_test.py
@@ -108,8 +108,11 @@ WORKLOAD: tuple[JobSpec, ...] = (
     # before the post goes live, so a few minutes late means it did nothing — the tightest window here.
     JobSpec("prepost_commenting", "se_prepost", 15.0, 5.0,
             arrival=ARRIVAL_POST, post_offset_minutes=-15.0, staggerable=False),
-    # The single 13:00 UTC fan-out (§3). Tolerance = the 2-hour golden window §4's C ≥ N ÷ (W×4)
-    # formula assumes — this is the spike --stagger-hours exists to flatten.
+    # The single 13:00 UTC fan-out (§3) — i.e. arrivals as they were BEFORE #554 staggered them, which
+    # is what makes `--stagger-hours 0` vs `3` a before/after comparison rather than two guesses.
+    # Modelling the shipped per-user slots (a hashed minute inside a 3 h window in the user's OWN
+    # timezone) is issue #634, together with the post-stagger re-run of this curve.
+    # Tolerance = the 2-hour golden window §4's C ≥ N ÷ (W×4) formula assumes.
     JobSpec("golden_hour_commenting", "se_engage", 15.0, 120.0, starts=(13 * 60,)),
     # Dispatched every 30 min and Redis-gated to the user's cadence, so a sweep that starts within
     # the next dispatch interval is indistinguishable from one that started on its own tick.
@@ -398,9 +401,14 @@ def summarize(results: Sequence[JobResult], topology: Topology, users: int,
     on_time = [result for result in results if result.on_time]
     peak = concurrency_peak(results)
     required = dict(required or {})
+    # `cap` travels as-is, including None: the search returning None means NO session count reaches
+    # the target (some lane is late no matter how many browsers it gets), and reporting the simulated
+    # peak there would read as a real sizing answer to a cohort decision. `unreachable_lane` says why.
+    cap = required.get("cap")
     # Resources are projected for the topology that would MEET the SLO, not the one that is starving:
-    # "what would it cost to serve these users" is the question a cohort decision turns on.
-    needed = required.get("cap") or peak
+    # "what would it cost to serve these users" is the question a cohort decision turns on. With no
+    # such topology, the peak is the only honest thing left to price — the row is marked unreachable.
+    projected = peak if cap is None else cap
     per_lane: dict[str, dict] = {}
     for lane in topology.lanes:
         lane_results = [result for result in results if result.job.lane == lane]
@@ -427,13 +435,17 @@ def summarize(results: Sequence[JobResult], topology: Topology, users: int,
         "session_wait_p95_minutes": _round(_percentile(waits, 0.95)),
         "session_wait_max_minutes": _round(max(waits)) if waits else None,
         "peak_sessions": peak,
-        "sessions_needed": needed,
+        "sessions_needed": cap,
+        "unreachable_lane": required.get("unreachable_lane"),
+        # What the resource columns below were priced for — equal to sessions_needed unless the SLO
+        # is unreachable, in which case it is the simulated peak.
+        "projected_sessions": projected,
         "required_lanes": required.get("lanes") or {},
         "required_on_time_pct": required.get("on_time_pct"),
         "target_on_time_pct": required.get("target_on_time_pct"),
         "session_utilisation_pct": _round(100.0 * peak / topology.session_cap) if topology.session_cap else None,
         "per_lane": per_lane,
-        **project_resources(needed, topology.label),
+        **project_resources(projected, topology.label),
     }
 
 
@@ -469,16 +481,24 @@ def render_curve(rows: Sequence[Mapping]) -> str:
         header += "  ⚠️ cap != summed lane concurrency (scaling-plan.md §5a invariant)"
     target = first.get("target_on_time_pct")
     lines = [header, "",
-             "| Users | On-time % (today) | Late jobs | Delay p95 | Worst delay | Sessions needed | "
-             "Chrome mem | Host CPU | Verdict |",
+             ("| Users | On-time % (today) | Late jobs | Delay p95 | Worst delay | Sessions needed | "
+              + "Chrome mem | Host CPU | Verdict |"),
              "|---|---|---|---|---|---|---|---|---|"]
     for row in rows:
         needed = row.get("sessions_needed")
         lanes_needed = ", ".join(f"{lane} {count}" for lane, count in (row.get("required_lanes") or {}).items())
+        if needed is None:
+            # No session count reaches the target on some lane. Printing the fallback number here
+            # would be read as a capacity target; say plainly that there isn't one, and drop the
+            # lane split — the search returned no lanes to show.
+            lane = row.get("unreachable_lane")
+            needed_cell = f"unreachable ({lane})" if lane else "unreachable"
+        else:
+            needed_cell = f"{needed}{f' ({lanes_needed})' if lanes_needed else ''}"
         lines.append(
             f"| {row.get('users')} | {row.get('on_time_pct')}% | {row.get('late_jobs')} | "
             f"{row.get('queue_delay_p95_minutes')} min | {row.get('worst_delay_minutes')} min | "
-            f"{needed}{f' ({lanes_needed})' if lanes_needed else ''} | {row.get('chrome_mem_gb')} GB | "
+            f"{needed_cell} | {row.get('chrome_mem_gb')} GB | "
             f"{row.get('host_cpu')} vCPU ({row.get('host_cpu_pct')}%) | {row.get('verdict')} |")
     worst = min(rows, key=lambda row: row.get("on_time_pct") if row.get("on_time_pct") is not None else 100)
     lines += ["", f"Per-lane on-time at the worst scale ({worst.get('users')} users):"]
@@ -487,15 +507,17 @@ def render_curve(rows: Sequence[Mapping]) -> str:
                      f"p95 delay {stats.get('p95_delay_minutes')} min")
     lines += [
         "",
-        f"\"Sessions needed\" = the smallest per-lane concurrency (and therefore cap) that starts "
-        f"{target}% of the day's work inside its window; the lane split is shown beside it.",
-        "Simulated session wait is 0 whenever the cap covers the lanes: with the §5a invariant held "
-        "(cap == summed lane concurrency) work queues on its LANE, never on a browser. A non-zero "
-        "p95 means the cap is under-provisioned. For the real acquisition wait on a deployed Grid, "
-        "use --live.",
-        f"Projections assume {MEM_PER_SESSION_GB} GB and {CPU_PER_SESSION} vCPU per Chrome session, "
-        f"plus a {BASELINE_CPU} vCPU / {BASELINE_MEM_GB:g} GB app tier, on a {HOST_CPUS} vCPU / "
-        f"{HOST_MEM_GB:g} GB host (docs/scaling-plan.md §1/§4).",
+        (f"\"Sessions needed\" = the smallest per-lane concurrency (and therefore cap) that starts "
+         + f"{target}% of the day's work inside its window; the lane split is shown beside it. "
+         + "\"unreachable (lane)\" means no session count reaches it on that lane — that row's "
+         + "resource columns are priced off the SIMULATED PEAK instead, and are not a sizing target."),
+        ("Simulated session wait is 0 whenever the cap covers the lanes: with the §5a invariant held "
+         + "(cap == summed lane concurrency) work queues on its LANE, never on a browser. A non-zero "
+         + "p95 means the cap is under-provisioned. For the real acquisition wait on a deployed Grid, "
+         + "use --live."),
+        (f"Projections assume {MEM_PER_SESSION_GB} GB and {CPU_PER_SESSION} vCPU per Chrome session, "
+         + f"plus a {BASELINE_CPU} vCPU / {BASELINE_MEM_GB:g} GB app tier, on a {HOST_CPUS} vCPU / "
+         + f"{HOST_MEM_GB:g} GB host (docs/scaling-plan.md §1/§4)."),
     ]
     return "\n".join(lines)
 

--- a/src/cqc_lem/utilities/selenium_load_test.py
+++ b/src/cqc_lem/utilities/selenium_load_test.py
@@ -1,0 +1,677 @@
+"""Concurrency / scale load-test harness for the Selenium topology (issue #556).
+
+`docs/scaling-plan.md` says the failure mode at scale is **"tasks miss their window"**, not "the box
+falls over" (§2/§3), and Phase 2 gates a Grid + VPS decision on *"load-test the topology before
+onboarding the cohort"*. This module is that test. It answers one question at a given user count:
+
+    with THESE lane concurrencies and THIS many Chrome session slots, what fraction of each user's
+    engagement work starts inside its window — and what would it cost to serve the demand?
+
+Two modes, because both are needed and neither substitutes for the other:
+
+* **simulate** (default, no browsers) — a discrete-event model of the real topology: per-lane Celery
+  slots plus a global Chrome session cap, fed the actual per-user daily workload from §4 and the
+  actual fan-out times from §3. Runs anywhere, in CI, in a second, and is the only way to get a
+  number for 50/100 users *without* first buying the box that could host them. Every projection it
+  prints is arithmetic on measured inputs, never a guess about how fast Chrome is.
+* **live** (`--live`, opt-in) — opens N REAL concurrent sessions against the hub and measures
+  session-acquisition wait, busy slots and host headroom. This is what validates the model's
+  assumptions on the topology actually deployed, at whatever concurrency the box can take.
+
+Structured like `utilities/capacity_alerts.py`: PURE functions first (what the unit tests pin), then
+the live/measuring layer, then the CLI. Nothing here writes to the capacity monitor's rolling
+windows — synthetic load must never be mistaken for production evidence by `auto_capacity_watch`.
+"""
+from __future__ import annotations
+
+import argparse
+import heapq
+import json
+import math
+import time
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence
+
+from cqc_lem.utilities.logger import log_info, log_warning
+
+# ───────────────────────────── topology defaults ─────────────────────────────
+# These MIRROR docker-compose.yml. tests/unit/app/test_selenium_capacity.py asserts they match, so a
+# lane bump that forgets this file fails the build instead of quietly load-testing the old topology.
+DEFAULT_LANES: dict[str, int] = {"se_engage": 3, "se_prepost": 2, "se_outreach": 2, "se_content": 1}
+DEFAULT_SESSION_CAP = 8
+# selenium/node-chrome runs one session per node (docker-compose.grid.yml), so on a Grid the node
+# count IS the session cap.
+GRID_NODE_SESSIONS = 1
+
+# ───────────────────────────── resource model (scaling-plan §4/§5b) ─────────────────────────────
+# A LinkedIn Selenium session peaks 0.7–1.5 GB; the midpoint is what the projections use.
+MEM_PER_SESSION_GB = 1.2
+CPU_PER_SESSION = 1.0
+# The node JVM that wraps each Chrome on a Grid — the price of fault isolation (§5b).
+GRID_NODE_OVERHEAD_GB = 0.3
+GRID_HUB_CPU = 0.5
+GRID_HUB_MEM_GB = 0.5
+# Everything that is not Chrome, measured on the live box (§1: ~4 GB across app containers, load
+# ~0.8 on 8 cores at 1 user; headroom for the app tier at N users is folded in here).
+BASELINE_CPU = 1.5
+BASELINE_MEM_GB = 6.0
+# The current production VPS (§1).
+HOST_CPUS = 8
+HOST_MEM_GB = 31.0
+# Verdict boundaries, calibrated to reproduce §5c's own three rows from its own numbers:
+# "fits" = peak demand stays inside the cores and under 70% of RAM (10 users: 6-8 vCPU, 10-12 GB).
+# "at ceiling" = the box is oversubscribed at the peak but survives it, because the peaks are brief
+# and the alternative is idle hardware the rest of the day (50 users: 12-14 vCPU on 8 cores).
+# "exceeds one VPS" = 2x the cores or past RAM — no amount of scheduling fixes that (100 users).
+CPU_OVERSUBSCRIPTION_LIMIT = 2.0
+MEM_FITS_PCT = 70.0
+MEM_CEILING_PCT = 100.0
+
+VERDICT_FITS = "fits"
+VERDICT_AT_CEILING = "at ceiling"
+VERDICT_EXCEEDS = "exceeds one VPS"
+
+# ───────────────────────────── workload model (scaling-plan §3/§4) ─────────────────────────────
+ARRIVAL_FANOUT = "fanout"  # a single crontab that dispatches for every active user at once
+ARRIVAL_POST = "post"      # anchored to the user's own scheduled post time
+
+# Users' posts are spread across the afternoon peak band (minutes from UTC midnight). Deterministic,
+# not random: the same command must produce the same curve so two runs can be compared.
+POST_BAND = (12 * 60, 16 * 60)
+
+
+@dataclass(frozen=True)
+class JobSpec:
+    """One recurring Selenium job in a user's day.
+
+    `tolerance_minutes` is what "on time" MEANS for that job, and it differs by an order of
+    magnitude: the pre-post warm-up exists to run BEFORE a post goes live, so five minutes late is a
+    miss; a golden-hour loop only has to land inside the hour.
+    """
+    name: str
+    lane: str
+    duration_minutes: float
+    tolerance_minutes: float
+    arrival: str = ARRIVAL_FANOUT
+    # ARRIVAL_FANOUT: minutes-of-day the crontab fires, one entry per daily occurrence.
+    starts: tuple[int, ...] = ()
+    # ARRIVAL_POST: minutes relative to the user's post time (the eta offsets in run_scheduler.py).
+    post_offset_minutes: float = 0.0
+    staggerable: bool = True
+
+
+# Sums to ~68 Selenium-minutes/user/day — the §4 table this plan's math is built on. The tolerances
+# are the product requirement, not a guess: they are why 100 users do not need 100 browsers.
+WORKLOAD: tuple[JobSpec, ...] = (
+    # eta = post − 15 min, on the dedicated se_prepost lane (#553). Its ONLY job is to warm the feed
+    # before the post goes live, so a few minutes late means it did nothing — the tightest window here.
+    JobSpec("prepost_commenting", "se_prepost", 15.0, 5.0,
+            arrival=ARRIVAL_POST, post_offset_minutes=-15.0, staggerable=False),
+    # The single 13:00 UTC fan-out (§3). Tolerance = the 2-hour golden window §4's C ≥ N ÷ (W×4)
+    # formula assumes — this is the spike --stagger-hours exists to flatten.
+    JobSpec("golden_hour_commenting", "se_engage", 15.0, 120.0, starts=(13 * 60,)),
+    # Dispatched every 30 min and Redis-gated to the user's cadence, so a sweep that starts within
+    # the next dispatch interval is indistinguishable from one that started on its own tick.
+    JobSpec("reply_sweep", "se_engage", 4.0, 30.0, starts=(11 * 60, 19 * 60)),
+    # eta = post − 10 min (run_scheduler.py), so it is post-anchored, not a crontab.
+    JobSpec("profile_viewer_engagement", "se_outreach", 10.0, 30.0,
+            arrival=ARRIVAL_POST, post_offset_minutes=-10.0, staggerable=False),
+    # §3's "fixed off-peak batch": nothing about an appreciation DM or a stats scrape breaks if it
+    # runs an hour or three into the morning, so their windows are wide on purpose. Giving these the
+    # same tolerance as a golden-hour loop would demand browsers the product does not actually need.
+    JobSpec("appreciation_dms", "se_outreach", 10.0, 240.0, starts=(8 * 60,)),
+    JobSpec("content_tasks", "se_content", 10.0, 240.0, starts=(23 * 60,)),
+)
+
+
+@dataclass(frozen=True)
+class Job:
+    user_id: int
+    name: str
+    lane: str
+    ready_at: float       # minutes from UTC midnight — when the task hits its queue
+    duration: float
+    tolerance: float
+
+
+@dataclass(frozen=True)
+class Topology:
+    lanes: Mapping[str, int]
+    session_cap: int
+    label: str = "standalone"
+
+    @property
+    def requested_concurrency(self) -> int:
+        return sum(self.lanes.values())
+
+    @property
+    def matches_invariant(self) -> bool:
+        """The cap == Σ lanes rule from §5a. Below it lanes block on session creation; above it,
+        slots are paid for and idle."""
+        return self.requested_concurrency == self.session_cap
+
+
+@dataclass(frozen=True)
+class JobResult:
+    job: Job
+    started_at: float
+    # When a lane slot first came free for this job. Everything after it was spent waiting on a
+    # Chrome session, which is the number that says "the cap, not the lane, is the constraint".
+    lane_ready_at: float
+
+    @property
+    def queue_delay(self) -> float:
+        return self.started_at - self.job.ready_at
+
+    @property
+    def session_wait(self) -> float:
+        return self.started_at - self.lane_ready_at
+
+    @property
+    def on_time(self) -> bool:
+        return self.queue_delay <= self.job.tolerance
+
+
+def default_topology(session_cap: int = DEFAULT_SESSION_CAP,
+                     lanes: Optional[Mapping[str, int]] = None,
+                     label: str = "standalone") -> Topology:
+    return Topology(lanes=dict(lanes or DEFAULT_LANES), session_cap=session_cap, label=label)
+
+
+def grid_topology(nodes: int, lanes: Optional[Mapping[str, int]] = None) -> Topology:
+    """A Grid's cap is its node count (one session per node), so `--nodes` is the only knob."""
+    return Topology(lanes=dict(lanes or DEFAULT_LANES),
+                    session_cap=nodes * GRID_NODE_SESSIONS, label=f"grid/{nodes}-nodes")
+
+
+def _on_time_pct(results: Sequence[JobResult]) -> Optional[float]:
+    if not results:
+        return None
+    return 100.0 * sum(1 for result in results if result.on_time) / len(results)
+
+
+def required_topology(users: int, base: Topology, target_on_time_pct: float = 95.0,
+                      stagger_hours: float = 0.0, specs: Sequence[JobSpec] = WORKLOAD,
+                      max_lane_concurrency: int = 64) -> dict:
+    """Smallest per-lane concurrency (and therefore session cap) that starts `target_on_time_pct` of
+    the day's work inside its window at `users` users.
+
+    Solved **one lane at a time**, which is exact rather than an approximation: §5a's invariant says
+    the cap equals the summed lane concurrency, so no lane can ever be blocked by another lane's
+    browser — the lanes are independent queues and their answers simply add up. Solving instead for a
+    single cap split in today's 3:2:2:1 ratio would inflate the total badly, because the ratio that
+    is right for one user's day is not the ratio N users need (se_content's once-a-day batch scales
+    with N exactly like se_engage's loops do).
+
+    This — not the instantaneous peak of an unconstrained run — is what "sessions needed" means. The
+    arrival pattern is spiky by construction (§3's single crontabs), so the raw peak asks for one
+    browser per user; the tolerances say a golden-hour loop has the golden window to start in.
+    """
+    jobs = build_workload(users, stagger_hours=stagger_hours, specs=specs)
+    unknown = {job.lane for job in jobs} - set(base.lanes)
+    if unknown:
+        raise ValueError(f"workload references lanes with no concurrency configured: {sorted(unknown)}")
+    if not jobs:
+        return {"cap": None, "lanes": {}, "on_time_pct": None, "target_on_time_pct": target_on_time_pct}
+    lanes: dict[str, int] = {}
+    for lane in base.lanes:
+        lane_jobs = [job for job in jobs if job.lane == lane]
+        if not lane_jobs:
+            lanes[lane] = 1
+            continue
+        for concurrency in range(1, max_lane_concurrency + 1):
+            solo = Topology(lanes={lane: concurrency}, session_cap=concurrency, label=base.label)
+            if (_on_time_pct(simulate(lane_jobs, solo)) or 0.0) >= target_on_time_pct:
+                lanes[lane] = concurrency
+                break
+        else:
+            # Unreachable by adding browsers: some job is late no matter what (a 15-minute loop with
+            # a 5-minute tolerance cannot start on time behind another copy of itself).
+            return {"cap": None, "lanes": {}, "on_time_pct": None,
+                    "target_on_time_pct": target_on_time_pct, "searched_to": max_lane_concurrency,
+                    "unreachable_lane": lane}
+    cap = sum(lanes.values())
+    joint = simulate(jobs, Topology(lanes=lanes, session_cap=cap, label=base.label))
+    return {"cap": cap, "lanes": lanes, "on_time_pct": _round(_on_time_pct(joint)),
+            "target_on_time_pct": target_on_time_pct}
+
+
+# ───────────────────────────── pure: workload ─────────────────────────────
+
+def _post_time(user_index: int, users: int, band: tuple[int, int]) -> float:
+    """Spread users' scheduled posts evenly across the peak band. Deterministic by index so a run is
+    reproducible and two topologies can be compared on identical arrivals."""
+    start, end = band
+    if users <= 1:
+        return float(start)
+    return start + (end - start) * (user_index / users)
+
+
+def build_workload(users: int, stagger_hours: float = 0.0,
+                   specs: Sequence[JobSpec] = WORKLOAD,
+                   post_band: tuple[int, int] = POST_BAND) -> list[Job]:
+    """The day's Selenium jobs for `users` active users.
+
+    `stagger_hours` is §5d's highest-leverage proposal: instead of every user's golden-hour loop
+    landing on one crontab minute, spread the fan-out over a window. 0 reproduces today's behaviour.
+    """
+    if users < 0:
+        raise ValueError("users must be >= 0")
+    if stagger_hours < 0:
+        raise ValueError("stagger_hours must be >= 0")
+    spread = stagger_hours * 60.0
+    jobs: list[Job] = []
+    for index in range(users):
+        offset = (spread * index / users) if (spread and users) else 0.0
+        for spec in specs:
+            if spec.arrival == ARRIVAL_POST:
+                ready_times = [_post_time(index, users, post_band) + spec.post_offset_minutes]
+            else:
+                shift = offset if spec.staggerable else 0.0
+                ready_times = [start + shift for start in spec.starts]
+            for ready in ready_times:
+                jobs.append(Job(user_id=index + 1, name=spec.name, lane=spec.lane,
+                                ready_at=float(ready), duration=spec.duration_minutes,
+                                tolerance=spec.tolerance_minutes))
+    return jobs
+
+
+# ───────────────────────────── pure: simulation ─────────────────────────────
+
+def simulate(jobs: Sequence[Job], topology: Topology) -> list[JobResult]:
+    """Discrete-event run of `jobs` through `topology`.
+
+    A task needs BOTH a free lane slot and a free Chrome session, and it holds the lane slot while it
+    waits for the session — that coupling is the real system (`--prefetch-multiplier=1` means one
+    in-flight task per concurrency slot, blocked or not) and it is why raising a lane without raising
+    the cap does nothing. Ties go to whoever queued first, which is how the broker hands them out.
+    """
+    if not jobs:
+        return []
+    unknown = {job.lane for job in jobs} - set(topology.lanes)
+    if unknown:
+        raise ValueError(f"workload references lanes with no concurrency configured: {sorted(unknown)}")
+    # A zero would not "run slowly", it would strand every job on that lane forever and quietly
+    # report on-time % over the jobs that did run. Refuse the topology instead.
+    starved = sorted(lane for lane in {job.lane for job in jobs} if topology.lanes[lane] < 1)
+    if starved or topology.session_cap < 1:
+        raise ValueError(f"lane concurrency and session cap must be >= 1 (starved lanes: {starved}, "
+                         f"cap: {topology.session_cap})")
+
+    pending: dict[str, deque[Job]] = defaultdict(deque)
+    for job in sorted(jobs, key=lambda j: (j.ready_at, j.lane, j.user_id, j.name)):
+        pending[job.lane].append(job)
+
+    busy_lane: dict[str, int] = defaultdict(int)
+    running: list[tuple[float, str]] = []  # heap of (end_time, lane)
+    sessions = 0
+    lane_ready: dict[int, float] = {}
+    results: list[JobResult] = []
+    now = min(job.ready_at for job in jobs)
+
+    while any(pending.values()) or running:
+        while running and running[0][0] <= now:
+            _, lane = heapq.heappop(running)
+            busy_lane[lane] -= 1
+            sessions -= 1
+
+        while True:
+            eligible = [(queue[0].ready_at, lane) for lane, queue in pending.items()
+                        if queue and queue[0].ready_at <= now and busy_lane[lane] < topology.lanes[lane]]
+            if not eligible:
+                break
+            # Mark eligibility BEFORE the cap check: a job whose lane slot is free but which cannot
+            # get a browser is, from this instant on, waiting on the session cap and nothing else.
+            for _, lane in eligible:
+                lane_ready.setdefault(id(pending[lane][0]), now)
+            if sessions >= topology.session_cap:
+                break
+            lane = min(eligible)[1]
+            job = pending[lane].popleft()
+            busy_lane[lane] += 1
+            sessions += 1
+            heapq.heappush(running, (now + job.duration, lane))
+            results.append(JobResult(job=job, started_at=now, lane_ready_at=lane_ready[id(job)]))
+
+        upcoming = [queue[0].ready_at for queue in pending.values() if queue and queue[0].ready_at > now]
+        if running:
+            upcoming.append(running[0][0])
+        if not upcoming:
+            break
+        now = min(upcoming)
+    return results
+
+
+def concurrency_peak(results: Sequence[JobResult]) -> int:
+    """Highest number of simultaneously open sessions across the run."""
+    events: list[tuple[float, int]] = []
+    for result in results:
+        events.append((result.started_at, 1))
+        events.append((result.started_at + result.job.duration, -1))
+    # -1 before +1 at the same instant: a session that ends exactly when another starts is a handover,
+    # not two concurrent browsers.
+    events.sort(key=lambda event: (event[0], event[1]))
+    peak = current = 0
+    for _, delta in events:
+        current += delta
+        peak = max(peak, current)
+    return peak
+
+
+def _percentile(values: Sequence[float], pct: float) -> Optional[float]:
+    """Nearest-rank — the reported number is one that actually happened, not an interpolation."""
+    if not values:
+        return None
+    ordered = sorted(values)
+    rank = max(1, min(len(ordered), math.ceil(pct * len(ordered))))
+    return float(ordered[rank - 1])
+
+
+def _round(value: Optional[float], digits: int = 1) -> Optional[float]:
+    return None if value is None else round(float(value), digits)
+
+
+def project_resources(sessions: int, topology_label: str) -> dict:
+    """What `sessions` concurrent Chrome sessions cost, and whether this VPS can pay it (§5c)."""
+    grid = topology_label.startswith("grid")
+    chrome_mem = sessions * MEM_PER_SESSION_GB + (sessions * GRID_NODE_OVERHEAD_GB + GRID_HUB_MEM_GB if grid else 0.0)
+    cpu = sessions * CPU_PER_SESSION + BASELINE_CPU + (GRID_HUB_CPU if grid else 0.0)
+    mem = chrome_mem + BASELINE_MEM_GB
+    cpu_pct = cpu / HOST_CPUS * 100
+    mem_pct = mem / HOST_MEM_GB * 100
+    if cpu_pct <= 100 and mem_pct <= MEM_FITS_PCT:
+        verdict = VERDICT_FITS
+    elif cpu_pct <= CPU_OVERSUBSCRIPTION_LIMIT * 100 and mem_pct <= MEM_CEILING_PCT:
+        verdict = VERDICT_AT_CEILING
+    else:
+        verdict = VERDICT_EXCEEDS
+    return {"chrome_mem_gb": _round(chrome_mem), "total_mem_gb": _round(mem), "host_cpu": _round(cpu, 2),
+            "host_cpu_pct": _round(cpu_pct), "host_mem_pct": _round(mem_pct), "verdict": verdict}
+
+
+def summarize(results: Sequence[JobResult], topology: Topology, users: int,
+              stagger_hours: float = 0.0, required: Optional[Mapping] = None) -> dict:
+    """One row of the on-time / resource curve."""
+    delays = [result.queue_delay for result in results]
+    waits = [result.session_wait for result in results]
+    on_time = [result for result in results if result.on_time]
+    peak = concurrency_peak(results)
+    required = dict(required or {})
+    # Resources are projected for the topology that would MEET the SLO, not the one that is starving:
+    # "what would it cost to serve these users" is the question a cohort decision turns on.
+    needed = required.get("cap") or peak
+    per_lane: dict[str, dict] = {}
+    for lane in topology.lanes:
+        lane_results = [result for result in results if result.job.lane == lane]
+        if not lane_results:
+            continue
+        per_lane[lane] = {
+            "jobs": len(lane_results),
+            "on_time_pct": _round(100.0 * sum(1 for r in lane_results if r.on_time) / len(lane_results)),
+            "p95_delay_minutes": _round(_percentile([r.queue_delay for r in lane_results], 0.95)),
+        }
+    return {
+        "users": users,
+        "topology": topology.label,
+        "session_cap": topology.session_cap,
+        "lanes": dict(topology.lanes),
+        "cap_matches_lanes": topology.matches_invariant,
+        "stagger_hours": stagger_hours,
+        "jobs": len(results),
+        "on_time_pct": _round(100.0 * len(on_time) / len(results)) if results else None,
+        "late_jobs": len(results) - len(on_time),
+        "queue_delay_p95_minutes": _round(_percentile(delays, 0.95)),
+        "worst_delay_minutes": _round(max(delays)) if delays else None,
+        "session_wait_p50_minutes": _round(_percentile(waits, 0.50)),
+        "session_wait_p95_minutes": _round(_percentile(waits, 0.95)),
+        "session_wait_max_minutes": _round(max(waits)) if waits else None,
+        "peak_sessions": peak,
+        "sessions_needed": needed,
+        "required_lanes": required.get("lanes") or {},
+        "required_on_time_pct": required.get("on_time_pct"),
+        "target_on_time_pct": required.get("target_on_time_pct"),
+        "session_utilisation_pct": _round(100.0 * peak / topology.session_cap) if topology.session_cap else None,
+        "per_lane": per_lane,
+        **project_resources(needed, topology.label),
+    }
+
+
+def run_scale(users: int, topology: Topology, stagger_hours: float = 0.0,
+              specs: Sequence[JobSpec] = WORKLOAD, target_on_time_pct: float = 95.0) -> dict:
+    """One scale, two answers: what the CURRENT topology delivers, and the smallest topology that
+    would hit the SLO. The gap between them is the decision this harness exists to inform."""
+    jobs = build_workload(users, stagger_hours=stagger_hours, specs=specs)
+    required = required_topology(users, topology, target_on_time_pct=target_on_time_pct,
+                                 stagger_hours=stagger_hours, specs=specs)
+    return summarize(simulate(jobs, topology), topology, users,
+                     stagger_hours=stagger_hours, required=required)
+
+
+def run_curve(user_counts: Sequence[int], topology: Topology, stagger_hours: float = 0.0,
+              specs: Sequence[JobSpec] = WORKLOAD, target_on_time_pct: float = 95.0) -> list[dict]:
+    return [run_scale(users, topology, stagger_hours=stagger_hours, specs=specs,
+                      target_on_time_pct=target_on_time_pct) for users in user_counts]
+
+
+# ───────────────────────────── pure: rendering ─────────────────────────────
+
+def render_curve(rows: Sequence[Mapping]) -> str:
+    """The on-time / resource curve `docs/scaling-plan.md` §5c asks for, as a markdown table that can
+    be pasted straight into the plan."""
+    if not rows:
+        return "No scales simulated."
+    first = rows[0]
+    lanes = ", ".join(f"{lane} {count}" for lane, count in (first.get("lanes") or {}).items())
+    header = (f"Topology: {first.get('topology')} — {first.get('session_cap')} session slot(s); "
+              f"lanes {lanes}; stagger {first.get('stagger_hours')}h")
+    if not first.get("cap_matches_lanes"):
+        header += "  ⚠️ cap != summed lane concurrency (scaling-plan.md §5a invariant)"
+    target = first.get("target_on_time_pct")
+    lines = [header, "",
+             "| Users | On-time % (today) | Late jobs | Delay p95 | Worst delay | Sessions needed | "
+             "Chrome mem | Host CPU | Verdict |",
+             "|---|---|---|---|---|---|---|---|---|"]
+    for row in rows:
+        needed = row.get("sessions_needed")
+        lanes_needed = ", ".join(f"{lane} {count}" for lane, count in (row.get("required_lanes") or {}).items())
+        lines.append(
+            f"| {row.get('users')} | {row.get('on_time_pct')}% | {row.get('late_jobs')} | "
+            f"{row.get('queue_delay_p95_minutes')} min | {row.get('worst_delay_minutes')} min | "
+            f"{needed}{f' ({lanes_needed})' if lanes_needed else ''} | {row.get('chrome_mem_gb')} GB | "
+            f"{row.get('host_cpu')} vCPU ({row.get('host_cpu_pct')}%) | {row.get('verdict')} |")
+    worst = min(rows, key=lambda row: row.get("on_time_pct") if row.get("on_time_pct") is not None else 100)
+    lines += ["", f"Per-lane on-time at the worst scale ({worst.get('users')} users):"]
+    for lane, stats in (worst.get("per_lane") or {}).items():
+        lines.append(f"  {lane}: {stats.get('on_time_pct')}% on time over {stats.get('jobs')} job(s), "
+                     f"p95 delay {stats.get('p95_delay_minutes')} min")
+    lines += [
+        "",
+        f"\"Sessions needed\" = the smallest per-lane concurrency (and therefore cap) that starts "
+        f"{target}% of the day's work inside its window; the lane split is shown beside it.",
+        "Simulated session wait is 0 whenever the cap covers the lanes: with the §5a invariant held "
+        "(cap == summed lane concurrency) work queues on its LANE, never on a browser. A non-zero "
+        "p95 means the cap is under-provisioned. For the real acquisition wait on a deployed Grid, "
+        "use --live.",
+        f"Projections assume {MEM_PER_SESSION_GB} GB and {CPU_PER_SESSION} vCPU per Chrome session, "
+        f"plus a {BASELINE_CPU} vCPU / {BASELINE_MEM_GB:g} GB app tier, on a {HOST_CPUS} vCPU / "
+        f"{HOST_MEM_GB:g} GB host (docs/scaling-plan.md §1/§4).",
+    ]
+    return "\n".join(lines)
+
+
+def render_live(measured: Mapping) -> str:
+    lines = [f"Live Selenium load test — {measured.get('requested')} requested session(s), "
+             f"{measured.get('acquired')} acquired, {measured.get('failed')} failed",
+             f"  session wait: p50 {measured.get('wait_p50_seconds')}s, "
+             f"p95 {measured.get('wait_p95_seconds')}s, max {measured.get('wait_max_seconds')}s",
+             f"  grid slots: peak {measured.get('peak_busy_sessions')} busy of "
+             f"{measured.get('max_sessions')}",
+             f"  host: load peak {measured.get('peak_load1')} on {measured.get('cpus')} core(s), "
+             f"RAM available {measured.get('mem_available_min_gb')} GB at the trough "
+             f"(~{measured.get('mem_consumed_gb')} GB consumed by the run)"]
+    for error in (measured.get("errors") or [])[:5]:
+        lines.append(f"  error: {error}")
+    return "\n".join(lines)
+
+
+# ───────────────────────────── live measurement ─────────────────────────────
+
+def _sample_environment() -> dict:
+    """One capacity + host sample, reusing the monitor's collectors so live numbers and the
+    production alert numbers can never disagree about what "busy" means."""
+    from cqc_lem.utilities.capacity_alerts import collect_host_headroom, collect_selenium_capacity
+    return {"capacity": collect_selenium_capacity(), "host": collect_host_headroom()}
+
+
+def _open_and_hold(hold_seconds: float, user_id: Optional[int], index: int) -> dict:
+    """Open one real browser session, hold it, close it. Returns the acquisition wait."""
+    from cqc_lem.utilities.selenium_util import get_docker_driver, quit_gracefully
+
+    started = time.monotonic()
+    driver = None
+    try:
+        driver = get_docker_driver(session_name=f"LoadTest-{index}", user_id=user_id)
+        wait = time.monotonic() - started
+        time.sleep(max(0.0, hold_seconds))
+        return {"index": index, "wait_seconds": round(wait, 2), "error": None}
+    except Exception as e:
+        return {"index": index, "wait_seconds": round(time.monotonic() - started, 2), "error": f"{type(e).__name__}: {e}"}
+    finally:
+        if driver is not None:
+            quit_gracefully(driver)
+
+
+def measure_live_sessions(sessions: int, hold_seconds: float = 30.0,
+                          user_id: Optional[int] = None, sample_interval: float = 2.0) -> dict:
+    """Open `sessions` REAL concurrent sessions against the hub and measure what it costs.
+
+    This is the validation step Phase 2 gates the cohort on: the simulation says how many slots the
+    demand wants, this says whether the deployed Grid can actually hand them out and what the box
+    looks like while it does. Deliberately does NOT feed `record_session_wait()` — synthetic waits in
+    the monitor's rolling window would file a capacity issue about a load test.
+    """
+    from concurrent.futures import ThreadPoolExecutor
+
+    if sessions < 1:
+        raise ValueError("sessions must be >= 1")
+    samples: list[dict] = []
+    stop = False
+
+    def _sampler() -> None:
+        while not stop:
+            try:
+                samples.append(_sample_environment())
+            except Exception as e:  # a sampler that dies must not take the run with it
+                log_warning("Load-test sampler failed", exc=e, task_name="selenium_load_test")
+            time.sleep(sample_interval)
+
+    import threading
+    sampler = threading.Thread(target=_sampler, daemon=True)
+    baseline = _sample_environment()
+    sampler.start()
+    log_info(f"Opening {sessions} concurrent Selenium session(s) for {hold_seconds}s",
+             task_name="selenium_load_test")
+    try:
+        with ThreadPoolExecutor(max_workers=sessions) as pool:
+            outcomes = list(pool.map(lambda index: _open_and_hold(hold_seconds, user_id, index), range(sessions)))
+    finally:
+        stop = True
+        sampler.join(timeout=sample_interval + 1)
+    samples.append(_sample_environment())
+    return summarize_live(sessions, outcomes, baseline, samples)
+
+
+def summarize_live(requested: int, outcomes: Sequence[Mapping], baseline: Mapping,
+                   samples: Sequence[Mapping]) -> dict:
+    """Pure reducer over what `measure_live_sessions` collected — separated so the unit tests can
+    pin the arithmetic without a browser."""
+    ok = [outcome for outcome in outcomes if not outcome.get("error")]
+    waits = [float(outcome["wait_seconds"]) for outcome in ok]
+    capacities = [sample.get("capacity") for sample in samples if sample.get("capacity")]
+    hosts = [sample.get("host") for sample in samples if sample.get("host")]
+    base_host = baseline.get("host") or {}
+    mem_floor = min((host.get("mem_available_gb") for host in hosts
+                     if host.get("mem_available_gb") is not None), default=None)
+    base_mem = base_host.get("mem_available_gb")
+    return {
+        "requested": requested,
+        "acquired": len(ok),
+        "failed": len(outcomes) - len(ok),
+        "wait_p50_seconds": _round(_percentile(waits, 0.50), 2),
+        "wait_p95_seconds": _round(_percentile(waits, 0.95), 2),
+        "wait_max_seconds": _round(max(waits), 2) if waits else None,
+        "peak_busy_sessions": max((capacity.get("busy_sessions", 0) for capacity in capacities), default=None),
+        "max_sessions": max((capacity.get("max_sessions", 0) for capacity in capacities), default=None),
+        "peak_load1": max((host.get("load1", 0) for host in hosts), default=None),
+        "cpus": base_host.get("cpus"),
+        "mem_available_min_gb": mem_floor,
+        "mem_consumed_gb": _round(base_mem - mem_floor) if (base_mem is not None and mem_floor is not None) else None,
+        "errors": [outcome.get("error") for outcome in outcomes if outcome.get("error")],
+    }
+
+
+# ───────────────────────────── CLI ─────────────────────────────
+
+def parse_lanes(raw: str) -> dict[str, int]:
+    """`se_engage=3,se_prepost=2,...` → dict. Explicit so a what-if run can model Phase 2's
+    "concurrency 3–4 per lane" without editing compose."""
+    lanes: dict[str, int] = {}
+    for part in raw.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        name, sep, value = part.partition("=")
+        if not sep or not value.strip().isdigit():
+            raise ValueError(f"bad lane spec {part!r} — expected name=concurrency")
+        lanes[name.strip()] = int(value)
+    if not lanes:
+        raise ValueError("no lanes parsed")
+    return lanes
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="LEM Selenium concurrency / scale load test")
+    parser.add_argument("--users", default="10,50,100",
+                        help="comma-separated active-user counts to simulate (default 10,50,100)")
+    parser.add_argument("--session-cap", type=int, default=DEFAULT_SESSION_CAP,
+                        help=f"Chrome session slots (default {DEFAULT_SESSION_CAP}, the standalone's cap)")
+    parser.add_argument("--nodes", type=int, default=None,
+                        help="model a Grid of N single-session nodes instead of the standalone")
+    parser.add_argument("--lanes", default=None,
+                        help="lane concurrencies, e.g. se_engage=4,se_prepost=3,se_outreach=3,se_content=2")
+    parser.add_argument("--stagger-hours", type=float, default=0.0,
+                        help="spread the fixed-time fan-outs over this many hours (scaling-plan §5d)")
+    parser.add_argument("--target-on-time", type=float, default=95.0,
+                        help="on-time %% the 'sessions needed' search must reach (default 95)")
+    parser.add_argument("--live", action="store_true",
+                        help="ALSO open real concurrent sessions against the hub and measure them")
+    parser.add_argument("--live-sessions", type=int, default=4, help="how many real sessions to open")
+    parser.add_argument("--hold-seconds", type=float, default=30.0, help="how long to hold each real session")
+    parser.add_argument("--live-user-id", type=int, default=None,
+                        help="user whose proxy/geo profile the real sessions should use")
+    parser.add_argument("--json", action="store_true", help="print the full result as JSON")
+    args = parser.parse_args(argv)
+
+    lanes = parse_lanes(args.lanes) if args.lanes else None
+    topology = grid_topology(args.nodes, lanes) if args.nodes else default_topology(args.session_cap, lanes)
+    user_counts = [int(part) for part in args.users.split(",") if part.strip()]
+    rows = run_curve(user_counts, topology, stagger_hours=args.stagger_hours,
+                     target_on_time_pct=args.target_on_time)
+
+    measured = measure_live_sessions(args.live_sessions, hold_seconds=args.hold_seconds,
+                                     user_id=args.live_user_id) if args.live else None
+    if args.json:
+        print(json.dumps({"curve": rows, "live": measured}))
+    else:
+        print(render_curve(rows))
+        if measured:
+            print("")
+            print(render_live(measured))
+    # Exit 2 when the modelled topology cannot serve the largest scale, so a CI/cron caller can gate
+    # a cohort onboarding on it without parsing the table.
+    return 2 if any(row.get("verdict") == VERDICT_EXCEEDS for row in rows) else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry
+    raise SystemExit(main())

--- a/tests/unit/app/test_selenium_capacity.py
+++ b/tests/unit/app/test_selenium_capacity.py
@@ -147,7 +147,15 @@ class TestGridOverlay:
 
     def test_the_hub_is_not_healthy_until_a_node_can_actually_serve(self):
         # A hub with zero registered nodes answers /status but has no capacity.
-        assert "availability')=='UP'" in _service_block(GRID_OVERLAY, "selenium-hub")
+        hub = _config_only(_service_block(GRID_OVERLAY, "selenium-hub"))
+        assert r'\"availability\":\"UP\"' in hub
+
+    def test_the_hub_healthcheck_needs_no_interpreter_in_the_image(self):
+        # selenium/hub is a JRE image with no Python — the standalone's `python3 -c` probe would
+        # never pass there, leaving the hub permanently unhealthy and every dependant stranded.
+        hub = _config_only(_service_block(GRID_OVERLAY, "selenium-hub"))
+        healthcheck = hub.split("healthcheck:")[1]
+        assert "python" not in healthcheck
 
     def test_nodes_wait_only_for_the_hub_to_start(self):
         # service_healthy here would deadlock: the hub is healthy only once a node registers.

--- a/tests/unit/app/test_selenium_capacity.py
+++ b/tests/unit/app/test_selenium_capacity.py
@@ -17,6 +17,7 @@ pytestmark = pytest.mark.unit
 REPO_ROOT = Path(__file__).resolve().parents[3]
 COMPOSE = (REPO_ROOT / "docker-compose.yml").read_text()
 PROD_OVERLAY = (REPO_ROOT / "docker-compose.prod.yml").read_text()
+GRID_OVERLAY = (REPO_ROOT / "docker-compose.grid.yml").read_text()
 
 
 def _service_block(compose: str, name: str) -> str:
@@ -94,3 +95,87 @@ class TestChromeResourceBudget:
         memory = int(re.search(r"memory: (\d+)g", chrome).group(1))
         # ~1-1.5g per LinkedIn session; 8g is the agreed ceiling on the 31 GiB box.
         assert _max_sessions(COMPOSE) <= memory <= 8
+
+
+class TestGridOverlay:
+    """docker-compose.grid.yml is the Phase-2 horizontal path (issue #556). It replaces the
+    standalone with hub + N single-session nodes, so the SAME cap == Σ-lanes invariant has to hold
+    there — only now the cap is the node count. See docs/SELENIUM_GRID.md."""
+
+    @staticmethod
+    def _node_block() -> str:
+        return _service_block(GRID_OVERLAY, "selenium-node-chrome")
+
+    def test_default_node_count_equals_the_summed_lane_concurrency(self):
+        # One session per node, so replicas IS the session cap. A Grid that starts with fewer slots
+        # than the lanes request would make the cutover itself a capacity regression.
+        replicas = int(re.search(r"replicas: \$\{SELENIUM_GRID_NODES:-(\d+)\}", self._node_block()).group(1))
+        sessions_per_node = int(re.search(r"SE_NODE_MAX_SESSIONS=(\d+)", self._node_block()).group(1))
+        assert sessions_per_node == 1
+        assert replicas * sessions_per_node == sum(_lane_concurrencies(COMPOSE).values())
+
+    def test_the_overlay_does_not_restate_lane_concurrency(self):
+        # The lanes stay defined in one place; the overlay only moves where the browsers live.
+        # Comments are stripped first — the invariant is explained there, not redefined.
+        assert "SELENIUM_CONCURRENCY" not in _config_only(GRID_OVERLAY)
+
+    def test_node_resources_match_the_documented_per_session_budget(self):
+        # scaling-plan.md §5b budgets ~1 vCPU / 1.5 GB + 2 GB shm per additional session. Nodes
+        # sized below that are the "slow session looks non-human to LinkedIn" failure, one per node.
+        node = self._node_block()
+        assert re.search(r"cpus: '1\.0'", node)
+        assert re.search(r"memory: 1536m", node)
+        assert re.search(r"shm_size: 2g", node)
+
+    def test_the_standalone_is_parked_behind_a_profile_not_deleted(self):
+        # Keeping it defined is the rollback: --profile standalone brings the old browser pool back
+        # without reverting the overlay.
+        assert 'profiles: ["standalone"]' in _service_block(GRID_OVERLAY, "selenium-chrome")
+
+    def test_every_service_that_waited_on_the_standalone_now_waits_on_the_hub(self):
+        waiters = [name for name in re.findall(r"\n  ([\w-]+):\n", COMPOSE)
+                   if "selenium-chrome:\n        condition" in _service_block(COMPOSE, name)]
+        assert waiters, "no service depends on selenium-chrome — did the base compose change?"
+        for name in waiters:
+            block = _service_block(GRID_OVERLAY, name)
+            # `!override` (not a merge) so the replaced map cannot still name the profiled-out
+            # standalone, which would make the whole stack wait on a container that never starts.
+            assert "depends_on: !override" in block, name
+            assert "selenium-chrome" not in block, name
+            assert "selenium-hub" in block, name
+            assert "SELENIUM_HUB_HOST=selenium-hub" in block, name
+
+    def test_the_hub_is_not_healthy_until_a_node_can_actually_serve(self):
+        # A hub with zero registered nodes answers /status but has no capacity.
+        assert "availability')=='UP'" in _service_block(GRID_OVERLAY, "selenium-hub")
+
+    def test_nodes_wait_only_for_the_hub_to_start(self):
+        # service_healthy here would deadlock: the hub is healthy only once a node registers.
+        assert "condition: service_started" in self._node_block()
+
+    def test_the_event_bus_is_not_published_to_the_world_by_default(self):
+        # Registering a node needs no credentials, so a reachable bus is an open door into the Grid.
+        hub = _service_block(GRID_OVERLAY, "selenium-hub")
+        for port in ("4442", "4443"):
+            assert f'"${{SELENIUM_GRID_BUS_BIND:-127.0.0.1}}:{port}:{port}"' in hub
+
+    def test_the_hub_port_defaults_to_loopback_like_the_standalone_does_in_prod(self):
+        # This overlay composes AFTER docker-compose.prod.yml, which binds the standalone's 4444 to
+        # loopback on purpose. A hub published on all interfaces would undo that on the cutover.
+        hub = _service_block(GRID_OVERLAY, "selenium-hub")
+        assert '"${SELENIUM_GRID_HUB_BIND:-127.0.0.1}:${SELENIUM_HUB_PORT}:4444"' in hub
+
+
+class TestLoadTestMirrorsTheDeployedTopology:
+    """The load-test harness projects a VPS/second-box decision from these numbers, so they must be
+    the numbers actually deployed — not a snapshot of them (issue #556)."""
+
+    def test_default_lanes_match_compose(self):
+        from cqc_lem.utilities.selenium_load_test import DEFAULT_LANES
+
+        assert DEFAULT_LANES == _lane_concurrencies(COMPOSE)
+
+    def test_default_session_cap_matches_compose(self):
+        from cqc_lem.utilities.selenium_load_test import DEFAULT_SESSION_CAP
+
+        assert DEFAULT_SESSION_CAP == _max_sessions(COMPOSE)

--- a/tests/unit/utilities/test_selenium_load_test.py
+++ b/tests/unit/utilities/test_selenium_load_test.py
@@ -1,0 +1,380 @@
+"""Unit tests for the Selenium concurrency/scale load-test harness (issue #556).
+
+The harness is the evidence a VPS-upgrade / second-box decision gets made on, so the parts under
+test here are the ones that would make that evidence wrong: the queueing model, the "sessions
+needed" search, and the resource projection.
+"""
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from cqc_lem.utilities import selenium_load_test as slt
+
+pytestmark = pytest.mark.unit
+
+
+def _job(lane: str, ready: float, duration: float = 10.0, tolerance: float = 30.0,
+         user_id: int = 1, name: str = "job") -> slt.Job:
+    return slt.Job(user_id=user_id, name=name, lane=lane, ready_at=ready,
+                   duration=duration, tolerance=tolerance)
+
+
+def _topology(lanes: dict, cap: int = None) -> slt.Topology:
+    return slt.Topology(lanes=lanes, session_cap=cap if cap is not None else sum(lanes.values()))
+
+
+class TestBuildWorkload:
+    def test_every_user_gets_every_occurrence_of_every_job(self):
+        occurrences = sum(max(1, len(spec.starts)) for spec in slt.WORKLOAD)
+        assert len(slt.build_workload(7)) == 7 * occurrences
+
+    def test_daily_selenium_minutes_per_user_match_the_plan(self):
+        # §4's table totals ~65-70 Selenium-minutes/user/day; every projection downstream is built
+        # on it, so a drifting workload must fail here rather than quietly re-scale the curve.
+        jobs = slt.build_workload(1)
+        assert 65 <= sum(job.duration for job in jobs) <= 70
+
+    def test_unstaggered_fanout_lands_every_user_on_the_same_minute(self):
+        golden = [job for job in slt.build_workload(20) if job.name == "golden_hour_commenting"]
+        assert {job.ready_at for job in golden} == {13 * 60}
+
+    def test_stagger_spreads_the_fanout_over_the_window(self):
+        golden = [job for job in slt.build_workload(20, stagger_hours=4)
+                  if job.name == "golden_hour_commenting"]
+        readies = sorted(job.ready_at for job in golden)
+        assert readies[0] == 13 * 60
+        # 20 users over 4h = one every 12 minutes, last one 12 minutes short of the window's end.
+        assert readies[-1] == pytest.approx(13 * 60 + 4 * 60 - 12)
+
+    def test_post_anchored_jobs_ignore_the_stagger_and_keep_their_eta_offset(self):
+        # The pre-post warm-up is pinned to the user's post, not to a crontab — staggering the
+        # crontabs must not move it, or the simulation would claim a fix the code cannot deliver.
+        jobs = slt.build_workload(4, stagger_hours=4)
+        prepost = sorted(job.ready_at for job in jobs if job.name == "prepost_commenting")
+        viewer = sorted(job.ready_at for job in jobs if job.name == "profile_viewer_engagement")
+        assert prepost == sorted(slt._post_time(i, 4, slt.POST_BAND) - 15 for i in range(4))
+        assert viewer == sorted(slt._post_time(i, 4, slt.POST_BAND) - 10 for i in range(4))
+
+    def test_zero_users_is_an_empty_day_not_an_error(self):
+        assert slt.build_workload(0) == []
+
+    @pytest.mark.parametrize("users,stagger", [(-1, 0), (5, -1)])
+    def test_negative_inputs_are_rejected(self, users, stagger):
+        with pytest.raises(ValueError):
+            slt.build_workload(users, stagger_hours=stagger)
+
+
+class TestSimulate:
+    def test_one_slot_serializes_and_reports_the_delay(self):
+        jobs = [_job("se_engage", 0, duration=10) for _ in range(3)]
+        results = slt.simulate(jobs, _topology({"se_engage": 1}))
+        assert sorted(result.started_at for result in results) == [0, 10, 20]
+        assert sorted(result.queue_delay for result in results) == [0, 10, 20]
+
+    def test_lane_concurrency_runs_jobs_side_by_side(self):
+        jobs = [_job("se_engage", 0, duration=10) for _ in range(3)]
+        results = slt.simulate(jobs, _topology({"se_engage": 3}))
+        assert all(result.started_at == 0 for result in results)
+        assert all(result.on_time for result in results)
+
+    def test_a_lane_cannot_borrow_another_lanes_slot(self):
+        jobs = [_job("se_engage", 0, duration=10), _job("se_engage", 0, duration=10),
+                _job("se_content", 0, duration=10)]
+        results = slt.simulate(jobs, _topology({"se_engage": 1, "se_content": 1}))
+        starts = {(result.job.lane, result.started_at) for result in results}
+        assert starts == {("se_engage", 0), ("se_engage", 10), ("se_content", 0)}
+
+    def test_an_under_provisioned_cap_shows_up_as_session_wait(self):
+        # Two lanes with a slot each but only one browser: one job holds a lane slot while it waits
+        # on Chrome. That gap is exactly the "cap < sum of lanes" failure §5a warns about.
+        jobs = [_job("se_engage", 0, duration=10), _job("se_content", 0, duration=10)]
+        results = slt.simulate(jobs, slt.Topology(lanes={"se_engage": 1, "se_content": 1}, session_cap=1))
+        waits = sorted(result.session_wait for result in results)
+        assert waits == [0, 10]
+
+    def test_a_cap_that_covers_the_lanes_never_makes_anything_wait_for_a_browser(self):
+        jobs = slt.build_workload(25)
+        results = slt.simulate(jobs, slt.default_topology())
+        assert max(result.session_wait for result in results) == 0
+
+    def test_a_job_that_is_not_ready_yet_does_not_hold_the_slot(self):
+        jobs = [_job("se_engage", 100, duration=10), _job("se_engage", 0, duration=10)]
+        results = slt.simulate(jobs, _topology({"se_engage": 1}))
+        assert sorted(result.started_at for result in results) == [0, 100]
+
+    def test_every_job_eventually_starts(self):
+        jobs = slt.build_workload(30)
+        assert len(slt.simulate(jobs, slt.default_topology())) == len(jobs)
+
+    def test_an_empty_day_simulates_to_nothing(self):
+        assert slt.simulate([], slt.default_topology()) == []
+
+    def test_a_lane_with_no_configured_concurrency_is_refused(self):
+        with pytest.raises(ValueError, match="no concurrency configured"):
+            slt.simulate([_job("se_nowhere", 0)], _topology({"se_engage": 1}))
+
+    def test_a_zero_slot_lane_is_refused_rather_than_stranding_its_jobs(self):
+        # Silently dropping them would report on-time % over the jobs that DID run — a confident
+        # all-clear for a topology that runs nothing.
+        with pytest.raises(ValueError, match="must be >= 1"):
+            slt.simulate([_job("se_engage", 0)], _topology({"se_engage": 0}))
+
+
+class TestConcurrencyPeak:
+    def test_counts_simultaneous_sessions(self):
+        results = slt.simulate([_job("se_engage", 0, duration=10) for _ in range(4)],
+                               _topology({"se_engage": 4}))
+        assert slt.concurrency_peak(results) == 4
+
+    def test_a_handover_is_not_two_browsers(self):
+        results = slt.simulate([_job("se_engage", 0, duration=10), _job("se_engage", 10, duration=10)],
+                               _topology({"se_engage": 2}))
+        assert slt.concurrency_peak(results) == 1
+
+    def test_nothing_running_is_a_peak_of_zero(self):
+        assert slt.concurrency_peak([]) == 0
+
+
+class TestPercentile:
+    def test_nearest_rank_returns_a_value_that_happened(self):
+        assert slt._percentile([1, 2, 3, 4, 100], 0.95) == 100
+        assert slt._percentile([1, 2, 3, 4], 0.5) == 2
+
+    def test_empty_is_unknown_not_zero(self):
+        assert slt._percentile([], 0.95) is None
+
+
+class TestRequiredTopology:
+    def test_it_finds_the_smallest_lane_concurrency_that_meets_the_target(self):
+        # 4 jobs of 10 min ready together, tolerance 30: with 1 slot the last starts 30 min late
+        # (on time), so one slot suffices; with tolerance 10 it needs two.
+        spec = slt.JobSpec("j", "se_engage", 10.0, 30.0, starts=(0,))
+        assert slt.required_topology(4, _topology({"se_engage": 1}), target_on_time_pct=100,
+                                     specs=(spec,))["lanes"] == {"se_engage": 1}
+        tight = slt.JobSpec("j", "se_engage", 10.0, 10.0, starts=(0,))
+        assert slt.required_topology(4, _topology({"se_engage": 1}), target_on_time_pct=100,
+                                     specs=(tight,))["lanes"] == {"se_engage": 2}
+
+    def test_the_cap_is_the_sum_of_the_lanes_so_the_invariant_holds_by_construction(self):
+        required = slt.required_topology(50, slt.default_topology())
+        assert required["cap"] == sum(required["lanes"].values())
+
+    def test_the_answer_actually_meets_the_target_it_was_asked_for(self):
+        required = slt.required_topology(50, slt.default_topology(), target_on_time_pct=95)
+        assert required["on_time_pct"] >= 95
+
+    def test_more_users_never_need_fewer_sessions(self):
+        caps = [slt.required_topology(users, slt.default_topology())["cap"] for users in (10, 50, 100)]
+        assert caps == sorted(caps)
+
+    def test_staggering_the_fanouts_lowers_the_requirement(self):
+        # §5d calls this the single highest-leverage change; if the model didn't show it, the model
+        # would be arguing for hardware instead of scheduling.
+        assert (slt.required_topology(100, slt.default_topology(), stagger_hours=4)["cap"]
+                < slt.required_topology(100, slt.default_topology())["cap"])
+
+    def test_an_impossible_window_reports_no_answer_rather_than_a_huge_one(self):
+        # A 15-minute loop that must start within 1 minute of a fan-out can never be met for
+        # everyone by adding browsers — the harness must say so, not return the search ceiling.
+        impossible = slt.JobSpec("j", "se_engage", 15.0, 1.0, starts=(0,))
+        required = slt.required_topology(4, _topology({"se_engage": 1}), target_on_time_pct=100,
+                                         specs=(impossible,), max_lane_concurrency=3)
+        assert required["cap"] is None and required["unreachable_lane"] == "se_engage"
+
+    def test_zero_users_need_nothing(self):
+        assert slt.required_topology(0, slt.default_topology())["cap"] is None
+
+
+class TestProjectResources:
+    def test_ten_users_worth_of_sessions_fit_the_current_box(self):
+        # §5c: 10 users = 4-6 concurrent sessions = "fits comfortably".
+        assert slt.project_resources(5, "standalone")["verdict"] == slt.VERDICT_FITS
+
+    def test_fifty_users_worth_sits_at_the_ceiling(self):
+        # §5c: 50 users = "at/over the ceiling" on 8 vCPU / 31 GB.
+        assert slt.project_resources(14, "standalone")["verdict"] == slt.VERDICT_AT_CEILING
+
+    def test_a_hundred_users_worth_exceeds_one_vps(self):
+        # §5c: 100 users = "exceeds one VPS" — the second box / 16 vCPU decision point.
+        assert slt.project_resources(27, "standalone")["verdict"] == slt.VERDICT_EXCEEDS
+
+    def test_a_grid_costs_more_ram_than_a_standalone_for_the_same_sessions(self):
+        # The node JVM per Chrome plus the hub — the price of fault isolation (§5b). Reporting them
+        # as equal would understate the box a Grid needs.
+        grid = slt.project_resources(8, "grid/8-nodes")
+        standalone = slt.project_resources(8, "standalone")
+        assert grid["chrome_mem_gb"] > standalone["chrome_mem_gb"]
+        assert grid["host_cpu"] > standalone["host_cpu"]
+
+
+class TestSummarizeAndCurve:
+    def test_the_current_topology_degrades_as_users_are_added(self):
+        rows = slt.run_curve([10, 50, 100], slt.default_topology())
+        on_time = [row["on_time_pct"] for row in rows]
+        assert on_time == sorted(on_time, reverse=True)
+        assert on_time[0] > on_time[-1]
+
+    def test_resources_are_projected_for_the_topology_that_would_meet_the_slo(self):
+        row = slt.run_scale(50, slt.default_topology())
+        assert row["chrome_mem_gb"] == pytest.approx(row["sessions_needed"] * slt.MEM_PER_SESSION_GB)
+        # ...and NOT for the starving one it is currently running on.
+        assert row["sessions_needed"] > row["session_cap"]
+
+    def test_the_row_records_whether_the_simulated_topology_holds_the_invariant(self):
+        assert slt.run_scale(10, slt.default_topology())["cap_matches_lanes"] is True
+        starved = slt.Topology(lanes=dict(slt.DEFAULT_LANES), session_cap=4)
+        assert slt.run_scale(10, starved)["cap_matches_lanes"] is False
+
+    def test_per_lane_detail_covers_every_lane_that_ran(self):
+        row = slt.run_scale(10, slt.default_topology())
+        assert set(row["per_lane"]) == set(slt.DEFAULT_LANES)
+        assert all(0 <= stats["on_time_pct"] <= 100 for stats in row["per_lane"].values())
+
+    def test_grid_topology_turns_node_count_into_the_session_cap(self):
+        topology = slt.grid_topology(12)
+        assert topology.session_cap == 12 * slt.GRID_NODE_SESSIONS
+        assert topology.label == "grid/12-nodes"
+
+
+class TestRender:
+    def test_the_curve_renders_a_row_per_scale(self):
+        text = slt.render_curve(slt.run_curve([10, 50], slt.default_topology()))
+        assert "| 10 |" in text and "| 50 |" in text
+        assert "Sessions needed" in text
+
+    def test_a_broken_invariant_is_called_out_in_the_header(self):
+        starved = slt.Topology(lanes=dict(slt.DEFAULT_LANES), session_cap=4)
+        assert "invariant" in slt.render_curve(slt.run_curve([10], starved))
+
+    def test_nothing_simulated_says_so(self):
+        assert slt.render_curve([]) == "No scales simulated."
+
+    def test_live_output_reports_failures_it_saw(self):
+        text = slt.render_live(slt.summarize_live(
+            2, [{"wait_seconds": 1.0, "error": None}, {"wait_seconds": 9.0, "error": "TimeoutError: no slot"}],
+            {"host": {"cpus": 8, "mem_available_gb": 20.0}}, []))
+        assert "1 acquired, 1 failed" in text
+        assert "TimeoutError" in text
+
+
+class TestParseLanes:
+    def test_parses_a_what_if_lane_split(self):
+        assert slt.parse_lanes("se_engage=4, se_content=2") == {"se_engage": 4, "se_content": 2}
+
+    @pytest.mark.parametrize("raw", ["se_engage", "se_engage=x", ""])
+    def test_rejects_junk(self, raw):
+        with pytest.raises(ValueError):
+            slt.parse_lanes(raw)
+
+
+class TestLiveMeasurement:
+    def test_it_reduces_waits_slots_and_host_headroom(self):
+        outcomes = [{"wait_seconds": 1.0, "error": None}, {"wait_seconds": 5.0, "error": None},
+                    {"wait_seconds": 2.0, "error": None}]
+        baseline = {"capacity": {"max_sessions": 8, "busy_sessions": 0},
+                    "host": {"load1": 0.8, "cpus": 8, "mem_available_gb": 24.0}}
+        samples = [baseline,
+                   {"capacity": {"max_sessions": 8, "busy_sessions": 3},
+                    "host": {"load1": 4.2, "cpus": 8, "mem_available_gb": 20.4}}]
+        measured = slt.summarize_live(3, outcomes, baseline, samples)
+        assert measured["acquired"] == 3 and measured["failed"] == 0
+        assert measured["wait_max_seconds"] == 5.0
+        assert measured["peak_busy_sessions"] == 3
+        assert measured["peak_load1"] == 4.2
+        assert measured["mem_consumed_gb"] == pytest.approx(3.6)
+
+    def test_unreadable_grid_and_host_are_unknown_not_zero(self):
+        measured = slt.summarize_live(1, [{"wait_seconds": 1.0, "error": None}], {}, [{}])
+        assert measured["peak_busy_sessions"] is None
+        assert measured["mem_consumed_gb"] is None
+
+    def test_it_opens_the_requested_number_of_real_sessions(self):
+        with patch.object(slt, "_sample_environment", return_value={"capacity": None, "host": None}), \
+             patch.object(slt, "_open_and_hold",
+                          side_effect=lambda hold, user_id, index: {"index": index, "wait_seconds": 1.0,
+                                                                    "error": None}) as opener:
+            measured = slt.measure_live_sessions(3, hold_seconds=0, sample_interval=0.01)
+        assert opener.call_count == 3
+        assert measured["acquired"] == 3
+
+    def test_synthetic_load_never_feeds_the_production_capacity_monitor(self):
+        # A load test that wrote into the monitor's rolling window would file a capacity issue
+        # about itself and poison the evidence the real decision is made on.
+        with patch.object(slt, "_sample_environment", return_value={"capacity": None, "host": None}), \
+             patch.object(slt, "_open_and_hold", return_value={"index": 0, "wait_seconds": 1.0, "error": None}), \
+             patch("cqc_lem.utilities.capacity_alerts.record_session_wait") as recorder:
+            slt.measure_live_sessions(1, hold_seconds=0, sample_interval=0.01)
+        recorder.assert_not_called()
+
+    def test_one_session_is_timed_and_always_closed(self):
+        driver = object()
+        with patch("cqc_lem.utilities.selenium_util.get_docker_driver", return_value=driver) as opener, \
+             patch("cqc_lem.utilities.selenium_util.quit_gracefully") as closer:
+            outcome = slt._open_and_hold(0.0, user_id=7, index=2)
+        assert outcome["error"] is None and outcome["wait_seconds"] >= 0
+        assert opener.call_args.kwargs["user_id"] == 7
+        closer.assert_called_once_with(driver)
+
+    def test_a_session_that_never_opens_is_reported_not_raised(self):
+        # A Grid at capacity rejects the request; that IS the measurement, not a crash.
+        with patch("cqc_lem.utilities.selenium_util.get_docker_driver", side_effect=TimeoutError("no slot")), \
+             patch("cqc_lem.utilities.selenium_util.quit_gracefully") as closer:
+            outcome = slt._open_and_hold(0.0, user_id=None, index=0)
+        assert outcome["error"] == "TimeoutError: no slot"
+        closer.assert_not_called()
+
+    def test_the_environment_sample_reuses_the_capacity_monitors_collectors(self):
+        # Live numbers and the production alert's numbers must never disagree about "busy".
+        with patch("cqc_lem.utilities.capacity_alerts.collect_selenium_capacity",
+                   return_value={"max_sessions": 8, "busy_sessions": 2}), \
+             patch("cqc_lem.utilities.capacity_alerts.collect_host_headroom", return_value={"load1": 1.0}):
+            assert slt._sample_environment() == {"capacity": {"max_sessions": 8, "busy_sessions": 2},
+                                                 "host": {"load1": 1.0}}
+
+    @pytest.mark.parametrize("sessions", [0, -1])
+    def test_it_refuses_a_nonsensical_session_count(self, sessions):
+        with pytest.raises(ValueError):
+            slt.measure_live_sessions(sessions)
+
+    def test_a_failing_session_is_counted_not_raised(self):
+        with patch.object(slt, "_sample_environment", return_value={"capacity": None, "host": None}), \
+             patch.object(slt, "_open_and_hold",
+                          side_effect=lambda hold, user_id, index: {"index": index, "wait_seconds": 12.0,
+                                                                    "error": "SessionNotCreatedException"}):
+            measured = slt.measure_live_sessions(2, hold_seconds=0, sample_interval=0.01)
+        assert measured["acquired"] == 0 and measured["failed"] == 2
+        assert measured["wait_max_seconds"] is None
+
+
+class TestCli:
+    def test_default_run_prints_the_curve(self, capsys):
+        assert slt.main(["--users", "10"]) == 0
+        assert "| 10 |" in capsys.readouterr().out
+
+    def test_json_output_is_machine_readable(self, capsys):
+        slt.main(["--users", "10", "--json"])
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["live"] is None
+        assert payload["curve"][0]["users"] == 10
+
+    def test_it_exits_2_when_the_scale_exceeds_one_vps(self, capsys):
+        # So a cron/CI caller can gate a cohort onboarding without parsing the table.
+        assert slt.main(["--users", "100"]) == 2
+
+    def test_nodes_models_a_grid_instead_of_the_standalone(self, capsys):
+        slt.main(["--users", "10", "--nodes", "12"])
+        assert "grid/12-nodes" in capsys.readouterr().out
+
+    def test_live_is_opt_in(self, capsys):
+        with patch.object(slt, "measure_live_sessions") as live:
+            slt.main(["--users", "10"])
+        live.assert_not_called()
+
+    def test_live_measures_and_renders(self, capsys):
+        with patch.object(slt, "measure_live_sessions", return_value=slt.summarize_live(
+                1, [{"wait_seconds": 2.0, "error": None}], {"host": {"cpus": 8}}, [])) as live:
+            slt.main(["--users", "10", "--live", "--live-sessions", "1", "--hold-seconds", "0"])
+        live.assert_called_once()
+        assert "Live Selenium load test" in capsys.readouterr().out

--- a/tests/unit/utilities/test_selenium_load_test.py
+++ b/tests/unit/utilities/test_selenium_load_test.py
@@ -25,6 +25,15 @@ def _topology(lanes: dict, cap: int = None) -> slt.Topology:
     return slt.Topology(lanes=lanes, session_cap=cap if cap is not None else sum(lanes.values()))
 
 
+# A 15-minute loop that must start within a minute of the fan-out: more users than browsers can ever
+# start at once, so no session count reaches 100% on-time and the search has no answer to give.
+IMPOSSIBLE = slt.JobSpec("j", "se_engage", 15.0, 1.0, starts=(0,))
+
+
+def _unreachable_row() -> dict:
+    return slt.run_scale(70, slt.default_topology(), specs=(IMPOSSIBLE,), target_on_time_pct=100)
+
+
 class TestBuildWorkload:
     def test_every_user_gets_every_occurrence_of_every_job(self):
         occurrences = sum(max(1, len(spec.starts)) for spec in slt.WORKLOAD)
@@ -222,6 +231,18 @@ class TestSummarizeAndCurve:
         # ...and NOT for the starving one it is currently running on.
         assert row["sessions_needed"] > row["session_cap"]
 
+    def test_an_unreachable_slo_reports_no_sessions_needed_instead_of_a_number(self):
+        # The search found no session count that works. Falling back to the simulated peak here
+        # would read as "provision this many and you're fine" — the opposite of what it found.
+        row = _unreachable_row()
+        assert row["sessions_needed"] is None
+        assert row["unreachable_lane"] == "se_engage"
+
+    def test_an_unreachable_row_still_prices_what_it_actually_ran(self):
+        row = _unreachable_row()
+        assert row["projected_sessions"] == row["peak_sessions"]
+        assert row["chrome_mem_gb"] == pytest.approx(row["peak_sessions"] * slt.MEM_PER_SESSION_GB)
+
     def test_the_row_records_whether_the_simulated_topology_holds_the_invariant(self):
         assert slt.run_scale(10, slt.default_topology())["cap_matches_lanes"] is True
         starved = slt.Topology(lanes=dict(slt.DEFAULT_LANES), session_cap=4)
@@ -243,6 +264,13 @@ class TestRender:
         text = slt.render_curve(slt.run_curve([10, 50], slt.default_topology()))
         assert "| 10 |" in text and "| 50 |" in text
         assert "Sessions needed" in text
+
+    def test_an_unreachable_slo_renders_as_a_marker_not_a_number(self):
+        # Operators read the "Sessions needed" column as a target to provision to. When there is no
+        # such number, the cell has to say so — and there is no lane split to hang off it either.
+        text = slt.render_curve([_unreachable_row()])
+        assert "unreachable (se_engage)" in text
+        assert "| None |" not in text
 
     def test_a_broken_invariant_is_called_out_in_the_header(self):
         starved = slt.Topology(lanes=dict(slt.DEFAULT_LANES), session_cap=4)


### PR DESCRIPTION
Phase 2 of `docs/scaling-plan.md`. The standalone Chrome's 8 session slots are the top of this box's
Chrome budget (§4), so the next capacity increase has to be **horizontal** — and the cohort decision
behind it needs measured evidence, not §5c's estimate.

## Grid topology

- **`docker-compose.grid.yml`** — hub + N single-session `node-chrome` replicas (~1 vCPU / 1.5 GB +
  2 GB shm each, §5b's budget). Defaults to **8 nodes**, which is capacity-neutral with today's
  standalone, so the cutover and any capacity change stay separate decisions.
  - The standalone is **parked behind a `standalone` profile, not deleted** — rollback is one flag.
  - All six services that waited on `selenium-chrome` now wait on (and point at) the hub via
    `depends_on: !override`; a merged map would still name a container the overlay profiles out.
  - Nodes wait for the hub with `service_started`, not `service_healthy` — the hub is only healthy
    once a node registers, so health would deadlock the pair.
  - Hub port **and** event bus bind to loopback by default, matching how `docker-compose.prod.yml`
    hardens the standalone. Registering a node needs no credentials, so an exposed bus is an open door.
- **`docker-compose.grid-node.yml`** — nodes-only compose project for a **second VPS**. Explicit
  numbered services on host networking, because the hub calls each node back on
  `SE_NODE_HOST:SE_NODE_PORT` and replicas would all advertise the same port.
- The **cap == Σ lane concurrency** invariant travels with the topology: on a Grid the node count IS
  the cap, and `tests/unit/app/test_selenium_capacity.py` now enforces that too (plus that the
  load-test's defaults match compose, so a lane bump can't leave the harness modelling old numbers).

`get_docker_driver()` is unchanged — it already targets `${SELENIUM_HUB_HOST}:${SELENIUM_HUB_PORT}/wd/hub`,
which is the hub's address exactly as it was the standalone's.

## Load test — `python -m cqc_lem.utilities.selenium_load_test`

- **simulate** (default, no browsers) — discrete-event model of the real topology: per-lane Celery
  slots plus a global session cap, with a task **holding its lane slot while it waits for a browser**
  (which is why raising a lane without raising the cap does nothing). Fed §4's per-user daily
  workload and §3's actual fan-out times. Reports on-time %, delay p95/worst, session wait,
  **sessions needed** to hold a 95% SLO, and projected Chrome RAM / host CPU with a
  fits / at-ceiling / exceeds verdict.
- **live** (`--live`) — opens N real concurrent sessions against a deployed hub and measures
  acquisition wait, busy slots and host headroom, reusing the capacity monitor's own collectors so
  the two can never disagree about "busy". Deliberately does **not** write to the monitor's rolling
  window: synthetic waits there would file a capacity issue about a load test.
- Exits **2** when the largest scale exceeds one VPS, so a cron/CI caller can gate cohort onboarding
  without parsing the table. `--json` for machine consumption.

### Measured curve (today's topology: 8 slots, lanes 3/2/2/1)

| Users | On-time % | Sessions needed | Chrome mem | Host CPU | Verdict |
|---|---|---|---|---|---|
| 10 | **100%** | 5 | 6.0 GB | 6.5 vCPU (81%) | fits |
| 50 | **57.7%** | 14 | 16.8 GB | 15.5 vCPU (194%) | at ceiling |
| 100 | **17.7%** | 27 | 32.4 GB | 28.5 vCPU (356%) | exceeds one VPS |

Three findings, all folded back into `scaling-plan.md`:

1. §5c **under-counted at 50+** — it modelled only the commenting loops, not the once-a-day batch
   fan-outs or the `se_prepost` lane #553 added afterwards. Same assumptions, more of the workload.
2. **`se_prepost` is the first lane to break** (7 slots of its own at 100 users): a 15-minute warm-up
   with a 5-minute window cannot absorb posts arriving every 2.4 minutes.
3. **Staggering the golden hour (§5d) is still the cheapest win and still unimplemented** — at 50
   users it takes on-time 57.7% → 84.0% and sessions needed 14 → 11, with no new hardware.

## Docs

`docs/SELENIUM_GRID.md` — runbook, second-box setup + its security requirements, what the cutover
costs (noVNC moves to the nodes), the measured curve with a reading guide, the **16 vCPU / 64 GB vs
second-box decision table**, and a cutover checklist. `scaling-plan.md` §5b/§5c/§6 updated to point
at it.

## Testing

- `tests/unit/utilities/test_selenium_load_test.py` — 63 tests, **98% coverage** of the new module:
  the queueing model (serialization, lane isolation, under-provisioned cap showing up as session
  wait, refusing a zero-slot lane rather than silently stranding its jobs), the sessions-needed
  search (monotonicity, meets the target it was asked for, reports "unreachable" instead of the
  search ceiling), the resource verdicts pinned to §5c's own three rows, live reduction with
  unknown-≠-zero handling, and the CLI.
- `tests/unit/app/test_selenium_capacity.py` — 8 new Grid-overlay guards.
- Full unit suite: **5542 passed**.

## Risk

`risk:product-decision` — new prod topology and a likely resource/VPS commitment. **Nothing is
enabled by this PR**: prod keeps running the standalone until the overlay is explicitly composed in.
Held for owner decision at merge.

Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)