### PR TITLE
fix(automation): drop dead pre-SDUI feed sort that paged 11x/24h (closes #569)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -121,27 +121,10 @@ def navigate_to_feed(driver, wait):
         driver.get("https://www.linkedin.com/feed/")
         wait_for_ajax(driver)
 
-    try:
-        # Find and click the "Sort by" dropdown
-        click_element_wait_retry(driver, wait, '//button/hr',
-                                 "Clicking Sort By Dropdown", use_action_chain=True)
-
-        # time.sleep(1)
-        wait_for_ajax(driver)
-
-        # Select "Recent" from the dropdown
-        click_element_wait_retry(driver, wait, '//div[contains(@class,"artdeco-dropdown")]/ul/li[2]',
-                                 "Selecting Recent Option", max_retry=0, use_action_chain=True)
-
-        wait_for_ajax(driver)
-        time.sleep(3)  # Wait for the page to refresh with recent posts
-
-        myprint("Feed Sorted By Recent Items First")
-
-    except Exception as e:
-        log_error("Error during feed sort", exc=e)
-
-    # are_you_satisfied()
+    # SDUI removed the '//button/hr' sort control this used to click, so the legacy sort block here
+    # raised (and paged) on every run. _switch_feed_to_recent owns the sort now: resilient selectors,
+    # best-effort, warns instead of erroring when the control isn't there.
+    _switch_feed_to_recent(driver, wait)
 
 
 def get_feed_posts(driver, wait, num_posts=10):
@@ -999,6 +982,10 @@ def _switch_feed_to_recent(driver, wait) -> None:
         btn = find_first(driver, wait, [(By.XPATH, "//button[contains(normalize-space(),'Sort by')]")],
                          "Feed sort control", required=False)
         if btn is None:
+            return
+        # The control reads "Sort by: Recent" once flipped — skip re-opening the menu so the second
+        # caller in a run (navigate_to_feed then comment_on_feed_inline) is a cheap no-op.
+        if "recent" in (btn.text or "").lower():
             return
         driver.execute_script("arguments[0].click();", btn)
         time.sleep(random.uniform(1, 2))

--- a/tests/unit/app/test_feed_sort.py
+++ b/tests/unit/app/test_feed_sort.py
@@ -1,0 +1,91 @@
+"""Unit tests for the feed 'Recent' sort — issue #569 (`Error during feed sort` paging 11x/24h)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.app.run_automation"
+
+
+class TestSwitchFeedToRecent:
+    def test_no_op_when_sort_control_missing(self):
+        from cqc_lem.app.run_automation import _switch_feed_to_recent
+        driver = MagicMock()
+        with patch(f"{_MOD}.find_first", return_value=None) as find_first:
+            _switch_feed_to_recent(driver, MagicMock())
+        assert find_first.call_count == 1
+        driver.execute_script.assert_not_called()
+
+    def test_skips_when_already_sorted_by_recent(self):
+        from cqc_lem.app.run_automation import _switch_feed_to_recent
+        driver = MagicMock()
+        btn = MagicMock()
+        btn.text = "Sort by: Recent"
+        with patch(f"{_MOD}.find_first", return_value=btn):
+            _switch_feed_to_recent(driver, MagicMock())
+        driver.execute_script.assert_not_called()
+
+    def test_clicks_sort_then_recent_option(self):
+        from cqc_lem.app.run_automation import _switch_feed_to_recent
+        driver = MagicMock()
+        btn = MagicMock()
+        btn.text = "Sort by: Top"
+        opt = MagicMock()
+        with patch(f"{_MOD}.find_first", side_effect=[btn, opt]), \
+             patch(f"{_MOD}.time.sleep"):
+            _switch_feed_to_recent(driver, MagicMock())
+        clicked = [c.args[1] for c in driver.execute_script.call_args_list]
+        assert clicked == [btn, opt]
+
+    def test_selector_miss_warns_and_does_not_raise(self):
+        from cqc_lem.app.run_automation import _switch_feed_to_recent
+        driver = MagicMock()
+        driver.execute_script.side_effect = RuntimeError("element not interactable")
+        btn = MagicMock()
+        btn.text = "Sort by: Top"
+        with patch(f"{_MOD}.find_first", return_value=btn), \
+             patch(f"{_MOD}.time.sleep"), \
+             patch(f"{_MOD}.log_warning") as log_warning, \
+             patch(f"{_MOD}.log_error") as log_error:
+            _switch_feed_to_recent(driver, MagicMock())
+        assert log_warning.called
+        log_error.assert_not_called()
+
+
+class TestNavigateToFeed:
+    def test_navigates_then_delegates_sort(self):
+        from cqc_lem.app.run_automation import navigate_to_feed
+        driver = MagicMock()
+        driver.current_url = "https://www.linkedin.com/in/someone/"
+        with patch(f"{_MOD}.wait_for_ajax"), \
+             patch(f"{_MOD}._switch_feed_to_recent") as switch:
+            navigate_to_feed(driver, MagicMock())
+        driver.get.assert_called_once_with("https://www.linkedin.com/feed/")
+        assert switch.called
+
+    def test_skips_navigation_when_already_on_feed(self):
+        from cqc_lem.app.run_automation import navigate_to_feed
+        driver = MagicMock()
+        driver.current_url = "https://www.linkedin.com/feed/"
+        with patch(f"{_MOD}.wait_for_ajax"), \
+             patch(f"{_MOD}._switch_feed_to_recent") as switch:
+            navigate_to_feed(driver, MagicMock())
+        driver.get.assert_not_called()
+        assert switch.called
+
+    def test_sort_failure_does_not_page_as_error(self):
+        from cqc_lem.app.run_automation import navigate_to_feed
+        driver = MagicMock()
+        driver.current_url = "https://www.linkedin.com/feed/"
+        driver.execute_script.side_effect = RuntimeError("stale sort control")
+        btn = MagicMock()
+        btn.text = "Sort by: Top"
+        with patch(f"{_MOD}.wait_for_ajax"), \
+             patch(f"{_MOD}.find_first", return_value=btn), \
+             patch(f"{_MOD}.time.sleep"), \
+             patch(f"{_MOD}.log_error") as log_error, \
+             patch(f"{_MOD}.log_warning") as log_warning:
+            navigate_to_feed(driver, MagicMock())
+        log_error.assert_not_called()
+        assert log_warning.called


### PR DESCRIPTION
## What & why

PostHog filed #569: `Error during feed sort` fired **11x in 24h**.

Root cause: `navigate_to_feed()` still drove LinkedIn's **pre-SDUI** sort control —
`click_element_wait_retry(driver, wait, '//button/hr', ...)` plus an `artdeco-dropdown` `li[2]`
option. Those anchors are gone (see CLAUDE.md → *LinkedIn SDUI*), so the block raised on **every**
commenting run, after spending the click-retry waits, and reported it via `log_error`.

It was also redundant: the SDUI-aware sort already exists as `_switch_feed_to_recent()` and is
called by `comment_on_feed_inline()` — the only thing `navigate_to_feed()`'s caller does next.

## Changes

- `navigate_to_feed()` now delegates the sort to the existing `_switch_feed_to_recent()` helper
  (resilient `find_first` selector chain, best-effort, `log_warning` on a miss instead of
  `log_error`). No new helper introduced.
- `_switch_feed_to_recent()` returns early when the control already reads `Sort by: Recent`, so the
  second call in a run (`navigate_to_feed` → `comment_on_feed_inline`) is a cheap no-op rather than
  re-opening and re-clicking the menu.

Net effect: the feed is still sorted by Recent (now via selectors that actually match current
LinkedIn), the error stops paging the PostHog cron, and each run drops a failed retry loop.

## Testing

New `tests/unit/app/test_feed_sort.py` (7 tests):
- `_switch_feed_to_recent`: no-op when the sort control is missing; skips when already sorted Recent;
  clicks sort-then-Recent when on Top; a click failure warns and never raises.
- `navigate_to_feed`: navigates when off-feed, skips navigation when already on the feed, delegates
  the sort, and a sort failure produces `log_warning` and **not** `log_error`.

```
poetry run pytest tests/unit -q
5476 passed in 28.59s
```

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)