### PR TITLE
fix(automation): stop paging on empty invitation manager (closes #570)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2852,7 +2852,7 @@ def accept_connection_request(user_id: int) -> dict[str, str]:
     return invitation_data
 
 
-def _next_pending_invitation(driver: WebDriver, accepted_urls: set) -> "Tuple[str, str, WebElement] | None":
+def _next_pending_invitation(driver: WebDriver, accepted_urls: set[str]) -> tuple[str, str, WebElement] | None:
     """The next (profile_url, name, accept_button) still awaiting acceptance, read from a FRESH card
     query. Cards we already accepted are skipped by URL because LinkedIn sometimes leaves the accepted
     card in place instead of removing it."""

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2779,44 +2779,97 @@ def automate_reply_commenting(self, user_id: int, post_id: int, loop_for_duratio
     return result
 
 
-def accept_connection_request(user_id: int):
-    """Accept connection requests for the given user."""
+# Ordered fallback chain for the invitation-manager cards. The pre-SDUI `invitation-card__container`
+# class is gone, so prefer data-view-name, then the semantic list item, then any card that actually
+# carries an Accept button.
+_INVITATION_CARD_LOCATORS = [
+    (By.CSS_SELECTOR, "div[data-view-name='invitation-card']"),
+    (By.CSS_SELECTOR, "li[data-view-name='invitation-card']"),
+    (By.XPATH, "//div[contains(@class,'invitation-card')]"),
+    (By.XPATH, "//main//li[.//button[contains(@aria-label,'Accept')]]"),
+]
+_INVITATION_PROFILE_LINK_LOCATORS = [
+    (By.CSS_SELECTOR, "a[data-view-name='invitation-card-profile-link']"),
+    (By.CSS_SELECTOR, "a[href*='/in/']"),
+]
+_INVITATION_ACCEPT_LOCATORS = [
+    (By.XPATH, ".//button[contains(@aria-label,'Accept')]"),
+    (By.XPATH, ".//button[normalize-space()='Accept']"),
+]
+
+
+def accept_connection_request(user_id: int) -> dict[str, str]:
+    """Accept pending connection requests and return {profile_url: name} for the ones we accepted.
+
+    Zero pending invitations is the normal steady state, so an empty invitation manager returns an
+    empty dict quietly — it is not an error. Each accept is paired with its own card so we only DM
+    people whose click actually landed, and the cards are re-queried after every click because
+    accepting re-renders the list (holding the original list went stale after the first accept).
+    """
 
     user_email, user_password = get_user_password_pair_by_id(user_id)
 
     driver, wait = get_driver_wait_pair(session_name='Accept Connection Requests', user_id=user_id)
 
-    login_to_linkedin(driver, wait, user_email, user_password)
-
-    # Navigate to the invitations manager page
-    driver.get("https://www.linkedin.com/mynetwork/invitation-manager/")
+    invitation_data: dict[str, str] = {}
 
     try:
+        login_to_linkedin(driver, wait, user_email, user_password)
 
-        # Get all the invitation use the href and text (invitee name) to send a DM
-        invitations = get_elements_as_list_wait_stale(wait,
-                                                      "(//div[contains(@class,'invitation-card__container')]//div[contains(@class,'details')]//a)[2]",
-                                                      "Finding Invitation Names and Urls")
+        driver.get("https://www.linkedin.com/mynetwork/invitation-manager/")
+        wait_for_ajax(driver)
+        time.sleep(random.uniform(2, 4))
 
-        # For each invitation store the url and name to a dict using url as the key
-        invitation_data = {invitation.get_attribute('href'): getText(invitation) for invitation in invitations}
+        pending = find_all_first(driver, _INVITATION_CARD_LOCATORS)
+        if not pending:
+            log_info("No pending connection invitations", user_id=user_id, action_type="accept_connection")
+            return {}
 
-        # Find and click all the accept buttons
-        accept_buttons = get_elements_as_list_wait_stale(wait, '//button[contains(@aria-label,"Accept")]',
-                                                         "Finding Accept Buttons")
-
-        for accept_button in accept_buttons:
-            accept_button.click()
-            time.sleep(2)  # Wait for 2 seconds
+        for _ in range(len(pending)):
+            target = _next_pending_invitation(driver, set(invitation_data))
+            if target is None:
+                break
+            profile_url, name, accept_button = target
+            try:
+                accept_button.click()
+            except (StaleElementReferenceException, ElementNotInteractableException,
+                    NoSuchElementException, WebDriverException) as e:
+                log_warning("Could not accept a connection invitation", exc=e, user_id=user_id,
+                            action_type="accept_connection")
+                break
+            if profile_url:
+                invitation_data[profile_url] = name
+            time.sleep(random.uniform(2, 4))
 
     except Exception as e:
-        log_error("Error while accepting connection requests", exc=e, user_id=user_id, action_type="accept_connection")
-        invitation_data = {}
+        # Best-effort surface: a miss here costs us appreciation DMs for a cycle, nothing more.
+        log_warning("Error while accepting connection requests", exc=e, user_id=user_id,
+                    action_type="accept_connection")
     finally:
         quit_gracefully(driver)
 
     # Return the invitations list
     return invitation_data
+
+
+def _next_pending_invitation(driver: WebDriver, accepted_urls: set) -> "Tuple[str, str, WebElement] | None":
+    """The next (profile_url, name, accept_button) still awaiting acceptance, read from a FRESH card
+    query. Cards we already accepted are skipped by URL because LinkedIn sometimes leaves the accepted
+    card in place instead of removing it."""
+    for card in find_all_first(driver, _INVITATION_CARD_LOCATORS):
+        link = _first_in_card(card, _INVITATION_PROFILE_LINK_LOCATORS)
+        try:
+            profile_url = _normalize_profile_url(link.get_attribute("href") or "") if link is not None else ""
+            name = (getText(link) or "").strip().split("\n")[0] if link is not None else ""
+        except (StaleElementReferenceException, NoSuchElementException):
+            continue
+        if profile_url and profile_url in accepted_urls:
+            continue
+        accept_button = _first_in_card(card, _INVITATION_ACCEPT_LOCATORS)
+        if accept_button is None:
+            continue
+        return profile_url, name, accept_button
+    return None
 
 
 def get_recent_recommendations(driver, wait) -> dict[str, str]:
@@ -3154,10 +3207,12 @@ def automate_appreciation_dms_for_user(self, user_id: int, loop_for_duration: in
 
         result = "Appreciation DMs Sent"
 
+        my_profile = load_profile_for_user(user_id)  # cached DB read — only supplies {headline}
+
         # After Accepting a Connection Request:
         invitations_accepted = accept_connection_request(user_id)
         for profile_url, name in invitations_accepted.items():
-            first_name = name.split(" ")[0]
+            first_name = (name or "").strip().split(" ")[0] or "there"
             message = build_dm_from_template(user_id, "connection_accepted", first_name, my_profile)
             if message:
                 send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url, "message": message})

--- a/tests/unit/app/test_accept_connection_requests.py
+++ b/tests/unit/app/test_accept_connection_requests.py
@@ -1,0 +1,141 @@
+"""Unit tests for accept_connection_request (issue #570).
+
+An empty invitation manager is the normal steady state and must NOT page the error cron, and
+accepting must pair each click with its own card so we only DM people we actually connected with.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+
+def _card(href="https://www.linkedin.com/in/jane?trk=x", link_text="Jane Doe", accept=True):
+    """A mock invitation card: find_elements answers the profile-link chain first, then the
+    accept-button chain (the locator chains are disjoint, so dispatch on the selector value)."""
+    link = MagicMock()
+    link.get_attribute.return_value = href
+    link.text = link_text
+    button = MagicMock()
+
+    card = MagicMock()
+
+    def _find(_by, value):
+        if "Accept" in value or "accept" in value:
+            return [button] if accept else []
+        return [link] if href else []
+
+    card.find_elements.side_effect = _find
+    card.accept_button = button
+    return card
+
+
+@pytest.fixture(autouse=True)
+def _no_sleeps():
+    with patch("time.sleep"):
+        yield
+
+
+@pytest.fixture
+def _session():
+    """Patch out login/driver/teardown so only the invitation logic is exercised."""
+    driver = MagicMock()
+    with patch(f"{_RA}.get_user_password_pair_by_id", return_value=("u@e.com", "pw")), \
+         patch(f"{_RA}.get_driver_wait_pair", return_value=(driver, MagicMock())), \
+         patch(f"{_RA}.login_to_linkedin"), \
+         patch(f"{_RA}.wait_for_ajax"), \
+         patch(f"{_RA}.quit_gracefully") as quit_mock:
+        yield driver, quit_mock
+
+
+class TestAcceptConnectionRequest:
+    def test_no_pending_invitations_is_not_an_error(self, _session):
+        """The common case: zero invitations returns {} and never calls log_error (#570)."""
+        from cqc_lem.app.run_automation import accept_connection_request
+        driver, quit_mock = _session
+        with patch(f"{_RA}.find_all_first", return_value=[]), \
+             patch(f"{_RA}.log_error") as err, \
+             patch(f"{_RA}.log_warning") as warn, \
+             patch(f"{_RA}.log_info") as info:
+            assert accept_connection_request(1) == {}
+        err.assert_not_called()
+        warn.assert_not_called()
+        info.assert_called_once()
+        quit_mock.assert_called_once_with(driver)
+
+    def test_accepts_each_card_and_returns_profile_url_to_name(self, _session):
+        from cqc_lem.app.run_automation import accept_connection_request
+        jane = _card(href="https://www.linkedin.com/in/jane/?trk=x", link_text="Jane Doe")
+        john = _card(href="https://www.linkedin.com/in/john", link_text="John Smith")
+        with patch(f"{_RA}.find_all_first", return_value=[jane, john]):
+            result = accept_connection_request(1)
+        assert result == {"https://www.linkedin.com/in/jane": "Jane Doe",
+                          "https://www.linkedin.com/in/john": "John Smith"}
+        jane.accept_button.click.assert_called_once()
+        john.accept_button.click.assert_called_once()
+
+    def test_does_not_reaccept_a_card_linkedin_left_in_place(self, _session):
+        """LinkedIn sometimes keeps the accepted card rendered — the URL ledger stops a double click."""
+        from cqc_lem.app.run_automation import accept_connection_request
+        jane = _card(href="https://www.linkedin.com/in/jane", link_text="Jane Doe")
+        with patch(f"{_RA}.find_all_first", return_value=[jane, jane]):
+            result = accept_connection_request(1)
+        assert result == {"https://www.linkedin.com/in/jane": "Jane Doe"}
+        jane.accept_button.click.assert_called_once()
+
+    def test_a_failed_click_is_warned_not_errored_and_is_not_dmed(self, _session):
+        """A stale/blocked accept must not enter the return dict — we only DM people we connected with."""
+        from selenium.common import ElementNotInteractableException
+        from cqc_lem.app.run_automation import accept_connection_request
+        jane = _card(href="https://www.linkedin.com/in/jane", link_text="Jane Doe")
+        jane.accept_button.click.side_effect = ElementNotInteractableException("covered")
+        with patch(f"{_RA}.find_all_first", return_value=[jane]), \
+             patch(f"{_RA}.log_error") as err, \
+             patch(f"{_RA}.log_warning") as warn:
+            assert accept_connection_request(1) == {}
+        err.assert_not_called()
+        warn.assert_called_once()
+
+    def test_cards_without_an_accept_button_are_skipped(self, _session):
+        from cqc_lem.app.run_automation import accept_connection_request
+        pending = _card(href="https://www.linkedin.com/in/jane", link_text="Jane Doe")
+        already = _card(href="https://www.linkedin.com/in/john", link_text="John Smith", accept=False)
+        with patch(f"{_RA}.find_all_first", return_value=[already, pending]):
+            result = accept_connection_request(1)
+        assert result == {"https://www.linkedin.com/in/jane": "Jane Doe"}
+
+    def test_unexpected_failure_warns_instead_of_paging_the_error_cron(self, _session):
+        from cqc_lem.app.run_automation import accept_connection_request
+        driver, quit_mock = _session
+        driver.get.side_effect = RuntimeError("browser died")
+        with patch(f"{_RA}.log_error") as err, patch(f"{_RA}.log_warning") as warn:
+            assert accept_connection_request(1) == {}
+        err.assert_not_called()
+        warn.assert_called_once()
+        quit_mock.assert_called_once_with(driver)
+
+
+class TestNextPendingInvitation:
+    def test_returns_none_when_no_card_has_an_accept_button(self):
+        from cqc_lem.app.run_automation import _next_pending_invitation
+        card = _card(href="https://www.linkedin.com/in/jane", accept=False)
+        with patch(f"{_RA}.find_all_first", return_value=[card]):
+            assert _next_pending_invitation(MagicMock(), set()) is None
+
+    def test_accepts_a_card_with_no_readable_profile_link(self):
+        """A missing name/url must not block the accept — it just yields no DM target."""
+        from cqc_lem.app.run_automation import _next_pending_invitation
+        card = _card(href="", link_text="")
+        with patch(f"{_RA}.find_all_first", return_value=[card]):
+            profile_url, name, button = _next_pending_invitation(MagicMock(), set())
+        assert profile_url == ""
+        assert name == ""
+        assert button is card.accept_button
+
+    def test_skips_already_accepted_urls(self):
+        from cqc_lem.app.run_automation import _next_pending_invitation
+        card = _card(href="https://www.linkedin.com/in/jane")
+        with patch(f"{_RA}.find_all_first", return_value=[card]):
+            assert _next_pending_invitation(MagicMock(), {"https://www.linkedin.com/in/jane"}) is None


### PR DESCRIPTION
PostHog filed #570 for `Error while accepting connection requests` (3× in a 5-minute window). It is not a real error — it is the *normal* case being logged at ERROR.

## Root cause

`accept_connection_request` looked up invitation cards with the pre-SDUI XPath `//div[contains(@class,"invitation-card__container")]//div[contains(@class,"details")]//a` via `get_elements_as_list_wait_stale`. That helper wraps `wait.until(lambda d: d.find_elements(...))`, and **an empty list is falsy** — so zero pending invitations (the steady state) burned three retries and then raised `TimeoutException` straight into `log_error`. The class-based anchors are also gone under LinkedIn SDUI, so the lookup would miss even when invitations *do* exist.

Two further defects on the same path:

- The accept loop iterated a card list captured **before** the first click. Accepting re-renders the invitation list, so every element after the first went stale.
- `invitation_data` was built from **all** name links up front, independent of which accepts landed — so a failed accept could still produce a "thanks for connecting" DM to someone we never connected with.
- The caller, `automate_appreciation_dms_for_user`, referenced an **unassigned** `my_profile` — a `NameError` that would fire the moment the accept flow returned a non-empty dict (i.e. it was masked only by the flow being broken).

## Changes

- Ordered SDUI-first locator chains (`_INVITATION_CARD_LOCATORS` / `_INVITATION_PROFILE_LINK_LOCATORS` / `_INVITATION_ACCEPT_LOCATORS`) resolved through the existing resilient `find_all_first` / `_first_in_card` helpers — no new parallel helper.
- Empty invitation manager → `log_info` + `{}`. The residual catch-all is `log_warning`: this is a best-effort surface, a miss costs one cycle of appreciation DMs and nothing more.
- `_next_pending_invitation` re-queries the cards after every accept and pairs each click with its own card, deduping by normalized profile URL (LinkedIn sometimes leaves the accepted card rendered). Only people whose click actually landed are returned for a DM.
- Assign `my_profile` in `automate_appreciation_dms_for_user` via `load_profile_for_user` (cached DB read — it only supplies `{headline}`), and default a blank invitee name to `there`.

## Testing

New `tests/unit/app/test_accept_connection_requests.py` — 9 cases covering: empty manager logs info and never `log_error`; each card accepted and mapped to its name; no re-accept of a card LinkedIn left in place; a failed click warns and is excluded from the DM map; cards without an accept button are skipped; an unexpected failure warns instead of paging; and the `_next_pending_invitation` selection rules.

```
tests/unit/app/test_accept_connection_requests.py .........  9 passed
tests/unit                                                   5485 passed
```

No migration, no schema change, no config change.

Closes #570

🤖 Generated with [Claude Code](https://claude.com/claude-code)