### PR TITLE
feat(engagement): target-creator roster (50/30/20) + on-topic-only commenting (closes #616)

### DIFF
--- a/compose/local/database/migrations/V20260726043337__add_engagement_targets.sql
+++ b/compose/local/database/migrations/V20260726043337__add_engagement_targets.sql
@@ -1,0 +1,28 @@
+-- Target-creator engagement roster (issue #616): the curated list of accounts LEM comments on
+-- FIRST, before it ever touches the home feed. The 2026 growth analysis found the feed funnel
+-- examined 21 posts, matched 0 include_topics, and then fell back to commenting on off-ICP posts —
+-- which under Topic Authority ranking actively damages distribution. Every fast-growing native
+-- creator studied grew from high-volume substantive comments on 50-100 curated accounts blended
+-- ~50% peers / 30% ICP / 20% large creators.
+--
+-- category                is the blend bucket the rotation draws from.
+-- max_comments_per_week   is the per-author anti-pod cap (never repeatedly engage one account).
+-- comments_this_week      / week_start are that cap's rolling counter, reset on a new ISO week.
+-- source                  'user' = added by the operator, 'suggested' = seeded from post_engagers.
+CREATE TABLE IF NOT EXISTS engagement_targets (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    user_id INT NOT NULL,
+    profile_url VARCHAR(512) NOT NULL,
+    name VARCHAR(255) NULL,
+    category ENUM('peer','icp','creator') NOT NULL DEFAULT 'peer',
+    max_comments_per_week TINYINT UNSIGNED NOT NULL DEFAULT 2,
+    active TINYINT(1) NOT NULL DEFAULT 1,
+    last_engaged_at DATETIME NULL,
+    comments_this_week INT NOT NULL DEFAULT 0,
+    week_start DATE NULL,
+    source ENUM('user','suggested') NOT NULL DEFAULT 'user',
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    UNIQUE KEY uq_engagement_targets_user_profile (user_id, profile_url),
+    INDEX idx_engagement_targets_user_active (user_id, active)
+);

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -57,6 +57,9 @@ from cqc_lem.utilities.db import (
     get_user_groups, set_groups_enabled, get_post_engagement_rows, get_post_performance_rows,
     get_lead_magnet_settings, update_lead_magnet_settings,
     get_dm_templates, upsert_dm_templates,
+    get_engagement_targets, upsert_engagement_targets, delete_engagement_target,
+    suggest_engagement_targets, ENGAGEMENT_TARGET_CATEGORIES, ENGAGEMENT_TARGET_SOURCES,
+    ENGAGEMENT_TARGET_WEEKLY_DEFAULT, ENGAGEMENT_TARGET_WEEKLY_MAX,
     update_subscription_from_stripe, update_user_linkedin_token,
     get_users_with_stripe_subscriptions,
     update_user_linkedin_password,
@@ -374,6 +377,8 @@ _VALID_VIDEO_QUALITIES = ("standard", "premium", "premium_top")  # engagement_pr
 _LEN_LM_KEYWORD = 128     # lead_magnet_settings.keyword VARCHAR(128)
 _LEN_LM_MESSAGE = 2000    # lead_magnet_settings.message (TEXT; app cap)
 _LEN_DM_TEMPLATE = 2000   # dm_templates.template_text (TEXT; app cap)
+_LEN_TARGET_PROFILE_URL = 512  # engagement_targets.profile_url VARCHAR(512)
+_LEN_TARGET_NAME = 255         # engagement_targets.name VARCHAR(255)
 _LEN_NL_TITLE = 255       # newsletter_settings.title VARCHAR(255)
 _LEN_NL_TOPIC = 512       # newsletter_settings.topic VARCHAR(512)
 _LEN_DM_RECIPIENT_URL = 512   # scheduled_dms.recipient_profile_url VARCHAR(512)
@@ -680,6 +685,42 @@ class DmTemplateItem(BaseModel):
 class DmTemplatesRequest(BaseModel):
     session_token: str
     templates: List[DmTemplateItem] = []
+
+
+class EngagementTargetItem(BaseModel):
+    profile_url: str = Field(max_length=_LEN_TARGET_PROFILE_URL)
+    name: Optional[str] = Field(default=None, max_length=_LEN_TARGET_NAME)
+    category: str = "peer"
+    max_comments_per_week: int = ENGAGEMENT_TARGET_WEEKLY_DEFAULT
+    active: bool = True
+    source: str = "user"
+
+    @field_validator("category")
+    @classmethod
+    def _valid_category(cls, v: str) -> str:
+        return v if v in ENGAGEMENT_TARGET_CATEGORIES else "peer"
+
+    @field_validator("source")
+    @classmethod
+    def _valid_source(cls, v: str) -> str:
+        return v if v in ENGAGEMENT_TARGET_SOURCES else "user"
+
+    @field_validator("max_comments_per_week")
+    @classmethod
+    def _clamp_weekly_cap(cls, v: int) -> int:
+        # Clamped, never rejected: the per-author cap is a safety rail, so an out-of-range slider
+        # must not 422 away the operator's whole roster edit.
+        return max(0, min(ENGAGEMENT_TARGET_WEEKLY_MAX, int(v)))
+
+
+class EngagementTargetsRequest(BaseModel):
+    session_token: str
+    targets: List[EngagementTargetItem] = []
+
+
+class EngagementTargetDeleteRequest(BaseModel):
+    session_token: str
+    profile_url: str = Field(max_length=_LEN_TARGET_PROFILE_URL)
 
 
 class LinkedInPasswordRequest(BaseModel):
@@ -2621,6 +2662,38 @@ def update_dm_templates_endpoint(request: DmTemplatesRequest) -> ResponseModel:
     if not upsert_dm_templates(user_id, [t.model_dump() for t in request.templates]):
         raise HTTPException(status_code=500, detail="Could not update DM templates")
     return ResponseModel(status_code=200, detail="DM templates updated")
+
+
+@router.get("/user/engagement-targets")
+def get_engagement_targets_endpoint(session_token: str) -> ResponseModel:
+    """The user's engagement roster plus seed suggestions for an empty one (issue #616)."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail={
+        "targets": get_engagement_targets(user_id),
+        "suggestions": suggest_engagement_targets(user_id),
+    })
+
+
+@router.put("/user/engagement-targets")
+def update_engagement_targets_endpoint(request: EngagementTargetsRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if not upsert_engagement_targets(user_id, [t.model_dump() for t in request.targets]):
+        raise HTTPException(status_code=500, detail="Could not update engagement roster")
+    return ResponseModel(status_code=200, detail="Engagement roster updated")
+
+
+@router.delete("/user/engagement-targets")
+def delete_engagement_target_endpoint(request: EngagementTargetDeleteRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if not delete_engagement_target(user_id, request.profile_url):
+        raise HTTPException(status_code=500, detail="Could not remove roster target")
+    return ResponseModel(status_code=200, detail="Roster target removed")
 
 
 @router.put("/user/linkedin-password")

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -998,9 +998,19 @@ def passes_topic_gate(content: str, prefs: dict) -> bool:
     if not topics:
         return True
     text = (content or "").lower()
-    if any(str(t).lower() in text for t in topics):
+    if any(_mentions_topic(text, t) for t in topics):
         return True
     return post_is_relevant(content, topics)
+
+
+def _mentions_topic(text: str, topic: str) -> bool:
+    """Whole-term match for the gate's literal short-circuit. Substring matching would let a short
+    topic ("HR") fire on an unrelated word ("thrive") and skip the classifier entirely, so the term
+    has to be bounded by non-word characters on both sides."""
+    term = str(topic or "").strip().lower()
+    if not term:
+        return False
+    return re.search(rf"(?<!\w){re.escape(term)}(?!\w)", text) is not None
 
 
 # Roster blend (issue #616): the mix every fast-growing native creator studied engaged on —

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -53,7 +53,8 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     insert_connection_request, count_open_connection_requests, get_requested_person_keys, \
     get_engager_candidates, get_profile_facts, count_invites_sent_today, ConnectionRequestStatus, \
     CatchupTouchStatus, insert_catchup_touch, has_catchup_touch, get_catchup_touch, \
-    update_catchup_touch_status, count_catchup_touches_sent_today, max_catchup_touches_allowed
+    update_catchup_touch_status, count_catchup_touches_sent_today, max_catchup_touches_allowed, \
+    get_engagement_targets, record_target_engagement, ENGAGEMENT_TARGET_WEEKLY_DEFAULT
 from cqc_lem.utilities.engagement_window import record_pre_post_run
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
@@ -975,6 +976,90 @@ def post_matches_preferences(content: str, author: str, prefs: dict) -> bool:
     return False
 
 
+def _topic_gate_topics(prefs: dict) -> list:
+    """The topics a candidate post is judged on-topic against: the user's focus_topics (what they
+    want authority in), falling back to include_topics when no focus is set."""
+    focus = [t for t in ((prefs or {}).get("focus_topics") or []) if t]
+    if focus:
+        return focus
+    return [t for t in ((prefs or {}).get("include_topics") or []) if t]
+
+
+def passes_topic_gate(content: str, prefs: dict) -> bool:
+    """Hard on-topic gate (issue #616). Under 2026 Topic Authority ranking an off-topic comment
+    actively damages distribution, so a post that isn't about the user's focus topics is NEVER
+    commented on — not by the strict path and not by the empty-filter fallback, which is exactly
+    how the 2026-07-25 funnel ended up commenting on AI-in-HR posts for a non-HR account.
+
+    With no topics configured there is nothing to be off-topic against, so the gate is inert. A
+    literal topic mention short-circuits the classifier; the classifier itself fails OPEN (a
+    lem-simple hiccup must not silence all engagement)."""
+    topics = _topic_gate_topics(prefs)
+    if not topics:
+        return True
+    text = (content or "").lower()
+    if any(str(t).lower() in text for t in topics):
+        return True
+    return post_is_relevant(content, topics)
+
+
+# Roster blend (issue #616): the mix every fast-growing native creator studied engaged on —
+# ~50% peers, 30% ICP, 20% large creators. Buckets that run dry spill their slots to the others.
+_ROSTER_MIX = (("peer", 0.5), ("icp", 0.3), ("creator", 0.2))
+# Anti-pod: at most ONE comment per roster author per run, on top of their weekly cap. Repeatedly
+# engaging the same account in a session is the pod signature LinkedIn demotes.
+_ROSTER_MAX_POSTS_PER_AUTHOR = 1
+
+
+def _target_staleness(target: dict) -> tuple:
+    """Rotation sort key: never-engaged targets first, then least-recently-engaged."""
+    last = target.get("last_engaged_at")
+    if last is None:
+        return (0, 0.0)
+    try:
+        return (1, last.timestamp())
+    except AttributeError:
+        return (1, 0.0)
+
+
+def select_roster_targets(targets: list, limit: int) -> list:
+    """Which roster authors to engage this run: active targets still under their per-author weekly
+    cap, drawn in the 50/30/20 peer/ICP/creator blend, least-recently-engaged first."""
+    if limit <= 0:
+        return []
+    eligible = []
+    for t in targets or []:
+        if not t.get("active", True):
+            continue
+        cap = int(t.get("max_comments_per_week") or ENGAGEMENT_TARGET_WEEKLY_DEFAULT)
+        if int(t.get("comments_this_week") or 0) >= cap:
+            continue
+        eligible.append(t)
+    buckets = {category: [] for category, _ in _ROSTER_MIX}
+    for t in sorted(eligible, key=_target_staleness):
+        buckets[t.get("category") if t.get("category") in buckets else "peer"].append(t)
+    picked = []
+    for category, share in _ROSTER_MIX:
+        quota = int(limit * share)
+        picked.extend(buckets[category][:quota])
+        buckets[category] = buckets[category][quota:]
+    # Rounding + short buckets leave slots over; fill them with the stalest targets left, whatever
+    # their category, so a lopsided roster still uses the whole run budget.
+    leftovers = sorted([t for b in buckets.values() for t in b], key=_target_staleness)
+    picked.extend(leftovers[:max(0, limit - len(picked))])
+    return picked[:limit]
+
+
+def _roster_activity_url(profile_url: str) -> str:
+    """A roster author's recent-activity page — the roster's equivalent of the home feed."""
+    base = str(profile_url or "").strip().rstrip("/")
+    if not base:
+        return ""
+    if "/recent-activity/" in base:
+        return base + "/"
+    return f"{base}/recent-activity/all/"
+
+
 def _switch_feed_to_recent(driver, wait) -> None:
     """Best-effort: flip the feed sort from 'Top' to 'Recent' so golden-hour posts surface for
     commenting. Silent no-op if the 'Sort by' control isn't present."""
@@ -1036,13 +1121,135 @@ def get_feed_funnel(user_id: int) -> "dict | None":
         return None
 
 
+def _engage_card(driver, wait, my_profile: LinkedInProfile, user_id: int, card, key: str,
+                 content: str, author: str, prefs: dict, profile_synthesis,
+                 used_comment_shapes: list) -> bool:
+    """Claim -> generate -> react -> comment on ONE post card. True only when the comment actually
+    landed. Shared by the roster pass and the feed walk so both go through the same at-most-once
+    claim, the same per-run blueprint rotation, and the same react-before-submit ordering."""
+    if not claim_post_for_comment(user_id, key):
+        return False
+    comment_blueprint = select_blueprint("comment", recent_formats=used_comment_shapes)
+    with llm_attribution(user_id=user_id, feature=FEATURE_COMMENT):
+        comment_text = generate_ai_response(content, my_profile, None, prefs=prefs,
+                                            profile_synthesis=profile_synthesis,
+                                            blueprint=comment_blueprint)
+    if comment_text and comment_blueprint.get("format"):
+        used_comment_shapes.insert(0, comment_blueprint["format"])
+    if not comment_text:
+        release_post_claim(user_id, key)  # no comment generated — release the claim
+        return False
+    driver.execute_script("arguments[0].scrollIntoView({block:'center'});", card)
+    time.sleep(simulate_reading_time(content) / 2 + simulate_thinking_time())
+    # React BEFORE submitting the comment: posting re-renders the card and staled the element, so
+    # the old post-comment reaction attempt silently failed. Skip our OWN posts. Non-fatal — a
+    # missed reaction never blocks the comment.
+    if not _author_is_me(author, my_profile):
+        if react_to_post_inline(driver, wait, card, post_content=content,
+                                comment_text=comment_text, user_id=user_id):
+            mark_post_reacted(user_id, key)
+        else:
+            log_warning("Could not leave a reaction on post", user_id=user_id, action_type="comment")
+    if not post_comment_inline(driver, wait, card, comment_text, user_id=user_id):
+        release_post_claim(user_id, key)  # posting failed — let a later run retry
+        return False
+    mark_post_commented(user_id, key)
+    insert_new_log(user_id=user_id, action_type=LogActionType.COMMENT,
+                   result=LogResultType.SUCCESS, post_url=key, message=comment_text)
+    time.sleep(random.uniform(6, 14))  # human pacing between comments
+    return True
+
+
+def comment_on_roster_posts(driver, wait, my_profile: LinkedInProfile, user_id: int, max_posts: int,
+                            prefs: dict, profile_synthesis, used_comment_shapes: list, seen: set,
+                            deadline_ts: float = None) -> dict:
+    """Comment on the user's CURATED engagement roster before the home feed ever gets a look
+    (issue #616): each selected target's recent-activity page is opened, and the first post that
+    clears hard excludes, the dedup ledger and the on-topic gate gets a comment.
+
+    Fail-closed by design — an author page that renders no commentable card (selector drift, an
+    auth wall, a profile with only reshares) is logged and skipped, never guessed at. Returns the
+    run counters the caller folds into the feed funnel."""
+    stats = {"posted": 0, "targets_visited": 0, "examined": 0, "off_topic_skipped": 0,
+             "key_sources": {}, "commented_key_sources": {}}
+    if max_posts <= 0:
+        return stats
+    targets = get_engagement_targets(user_id, active_only=True)
+    if not targets:
+        return stats
+    for target in select_roster_targets(targets, max_posts):
+        if stats["posted"] >= max_posts or (deadline_ts and time.time() >= deadline_ts):
+            break
+        profile_url = target.get("profile_url")
+        url = _roster_activity_url(profile_url)
+        if not url:
+            continue
+        try:
+            driver.get(url)
+            wait_for_ajax(driver)
+        except Exception as e:
+            log_warning("Could not open roster target's activity page", exc=e, user_id=user_id,
+                        action_type="comment", task_name="comment_on_roster_posts")
+            continue
+        time.sleep(random.uniform(2, 4))
+        stats["targets_visited"] += 1
+        weekly_left = max(0, int(target.get("max_comments_per_week") or ENGAGEMENT_TARGET_WEEKLY_DEFAULT)
+                          - int(target.get("comments_this_week") or 0))
+        allowed_here = min(_ROSTER_MAX_POSTS_PER_AUTHOR, weekly_left, max_posts - stats["posted"])
+        posted_here = 0
+        for box in driver.find_elements(By.CSS_SELECTOR, _FEED_POST_TEXT_SEL):
+            if posted_here >= allowed_here or (deadline_ts and time.time() >= deadline_ts):
+                break
+            try:
+                content = (box.text or "").strip()
+            except StaleElementReferenceException:
+                continue
+            if len(content) < 20:
+                continue
+            card = _card_for_textbox(driver, box)
+            if card is None:
+                continue  # no comment affordance on this item — not a commentable post
+            author = _post_author_from_card(card) or (target.get("name") or "")
+            key, key_source = _feed_post_identity(card, author, content, driver=driver)
+            fps = _feed_content_fingerprints(author, content)
+            if key in seen or (fps & seen):
+                continue
+            stats["examined"] += 1
+            stats["key_sources"][key_source] = stats["key_sources"].get(key_source, 0) + 1
+            seen.add(key)
+            seen.update(fps)
+            if (has_commented_post(user_id, key) or has_user_commented_on_post_url(user_id, key)
+                    or not _passes_hard_excludes(content, author, prefs)):
+                continue
+            if not passes_topic_gate(content, prefs):
+                stats["off_topic_skipped"] += 1
+                log_info(f"Skipped roster post by {author or profile_url}: off-topic for the "
+                         f"user's focus topics", user_id=user_id, action_type="comment",
+                         task_name="comment_on_roster_posts")
+                continue
+            if _engage_card(driver, wait, my_profile, user_id, card, key, content, author, prefs,
+                            profile_synthesis, used_comment_shapes):
+                posted_here += 1
+                stats["posted"] += 1
+                stats["commented_key_sources"][key_source] = \
+                    stats["commented_key_sources"].get(key_source, 0) + 1
+                record_target_engagement(user_id, profile_url)
+                myprint(f"Commented on roster target {author or profile_url} "
+                        f"({target.get('category')})")
+        if posted_here == 0:
+            log_info(f"No commentable on-topic post found for roster target {profile_url}",
+                     user_id=user_id, action_type="comment", task_name="comment_on_roster_posts")
+    return stats
+
+
 def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: int,
                            max_posts: int = 10, deadline_ts: float = None, prefs: dict = None,
                            engagers: set = None) -> int:
-    """Walk the SDUI feed and comment inline, prioritizing by a scoring matrix instead of DOM
-    order: recency-dominant (golden hour), then relevance, reciprocity (people who engaged with
-    us), and healthy activity. Applies targeting filters + per-day cap + a max-post-age gate.
-    Returns the number of comments posted."""
+    """Comment on the user's curated engagement ROSTER first (issue #616), then walk the SDUI feed
+    for whatever budget is left, prioritizing by a scoring matrix instead of DOM order:
+    recency-dominant (golden hour), then relevance, reciprocity (people who engaged with us), and
+    healthy activity. Applies targeting filters + per-day cap + a max-post-age gate, and never
+    comments on a post that fails the on-topic gate. Returns the total number of comments posted."""
     from selenium.common.exceptions import StaleElementReferenceException
     if prefs is None:
         prefs = get_engagement_preferences(user_id)
@@ -1059,7 +1266,6 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
     # Stable VOICE synthesis (cached weekly, lazily created on first use) — the voice source for every
     # comment this run, in place of the bloated/volatile full profile JSON.
     profile_synthesis = get_or_create_profile_synthesis(user_id, my_profile)
-    _switch_feed_to_recent(driver, wait)  # surface golden-hour posts; scoring still ranks them
 
     # Per-run comment ANGLE rotation from the shared framework core: each comment this run gets a
     # different archetype (Expander, Storyteller, Questioner, ...) so a day's comments never all
@@ -1068,6 +1274,18 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
     used_comment_shapes: list = []
 
     posted, seen, scrolls = 0, set(), 0
+    # Roster FIRST (issue #616): curated peers / ICP / large creators outrank whatever the home
+    # feed happens to serve. An empty roster returns zeros here and the run degrades to the plain
+    # feed walk below. `seen` is shared, so a roster post can never be re-commented from the feed.
+    roster_stats = comment_on_roster_posts(driver, wait, my_profile, user_id, max_posts, prefs,
+                                           profile_synthesis, used_comment_shapes, seen,
+                                           deadline_ts=deadline_ts)
+    posted = roster_stats["posted"]
+    off_topic_skipped = 0
+
+    if roster_stats["targets_visited"]:
+        navigate_to_feed(driver, wait)  # the roster pass navigated away from the feed
+    _switch_feed_to_recent(driver, wait)  # surface golden-hour posts; scoring still ranks them
     # Reach funnel (surfaced to the user so they can tell when their targeting is too strict) and the
     # empty-filter fallback. examined = posts we looked at; hard = passed excludes/recency/min-reactions;
     # include = also matched the user's include topics/keywords/authors.
@@ -1153,6 +1371,15 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             if not fallback_active and fallback_enabled and strict_misses >= _FEED_FALLBACK_AFTER_MISSES:
                 fallback_active = True
                 myprint("Feed targeting matched nothing — falling back to top feed posts for this run")
+            # On-topic gate FIRST and unconditionally (issue #616): the fallback may widen WHICH
+            # posts qualify, but it may never put a comment on a post that is off-topic for the
+            # user's focus topics — that is what damaged distribution in the 2026-07-25 funnel.
+            if not passes_topic_gate(content, prefs):
+                off_topic_skipped += 1
+                log_info(f"Skipped feed post by {author or 'unknown author'}: off-topic for the "
+                         f"user's focus topics", user_id=user_id, action_type="comment",
+                         task_name="comment_on_feed_inline")
+                continue
             if fallback_active:
                 fallback_used = True
             elif post_matches_preferences(content, author, prefs):
@@ -1160,46 +1387,17 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
             else:
                 strict_misses += 1
                 continue
-            # Atomically claim the post BEFORE spending an LLM call or commenting. If a prior/
-            # concurrent run already holds it, we lose the race here and move on — at most one
-            # comment per post per user, across the pre-post run, the golden-hour run, and retries.
-            if not claim_post_for_comment(user_id, key):
-                continue
-            comment_blueprint = select_blueprint("comment", recent_formats=used_comment_shapes)
-            with llm_attribution(user_id=user_id, feature=FEATURE_COMMENT):
-                comment_text = generate_ai_response(content, my_profile, None, prefs=prefs,
-                                                    profile_synthesis=profile_synthesis,
-                                                    blueprint=comment_blueprint)
-            if comment_text and comment_blueprint.get("format"):
-                used_comment_shapes.insert(0, comment_blueprint["format"])
-            if comment_text:
-                driver.execute_script("arguments[0].scrollIntoView({block:'center'});", card)
-                time.sleep(simulate_reading_time(content) / 2 + simulate_thinking_time())
-                # React BEFORE submitting the comment: posting re-renders the card and staled the
-                # element, so the old post-comment reaction attempt silently failed. Skip our OWN
-                # posts. Non-fatal — a missed reaction never blocks the comment.
-                if not _author_is_me(author, my_profile):
-                    if react_to_post_inline(driver, wait, card, post_content=content,
-                                            comment_text=comment_text, user_id=user_id):
-                        mark_post_reacted(user_id, key)
-                    else:
-                        log_warning("Could not leave a reaction on post", user_id=user_id,
-                                    action_type="comment")
-                if post_comment_inline(driver, wait, card, comment_text, user_id=user_id):
-                    mark_post_commented(user_id, key)
-                    insert_new_log(user_id=user_id, action_type=LogActionType.COMMENT,
-                                   result=LogResultType.SUCCESS, post_url=key, message=comment_text)
-                    posted_key_sources[key_source] = posted_key_sources.get(key_source, 0) + 1
-                    log_info(f"Feed comment keyed by {key_source} ({key})", user_id=user_id,
-                             action_type="comment", task_name="comment_on_feed_inline")
-                    posted += 1
-                    myprint(f"Commented on {author or 'a'}'s post "
-                            f"(score {score:.2f}, age {'?' if age is None else str(age) + 'm'}) ({posted}/{max_posts})")
-                    time.sleep(random.uniform(6, 14))  # human pacing between comments
-                else:
-                    release_post_claim(user_id, key)  # posting failed — let a later run retry
-            else:
-                release_post_claim(user_id, key)  # no comment generated — release the claim
+            # _engage_card atomically claims the post BEFORE spending an LLM call or commenting. If
+            # a prior/concurrent run already holds it, we lose the race there and move on — at most
+            # one comment per post per user, across the pre-post run, the golden-hour run, and retries.
+            if _engage_card(driver, wait, my_profile, user_id, card, key, content, author, prefs,
+                            profile_synthesis, used_comment_shapes):
+                posted_key_sources[key_source] = posted_key_sources.get(key_source, 0) + 1
+                log_info(f"Feed comment keyed by {key_source} ({key})", user_id=user_id,
+                         action_type="comment", task_name="comment_on_feed_inline")
+                posted += 1
+                myprint(f"Commented on {author or 'a'}'s post "
+                        f"(score {score:.2f}, age {'?' if age is None else str(age) + 'm'}) ({posted}/{max_posts})")
             continue  # DOM re-rendered / candidate consumed — re-gather from the top
         # Nothing cleared the hard filters this pass. If the whole feed keeps coming up empty
         # (0 posts past excludes + recency + min-reactions) but some only missed the recency/
@@ -1223,11 +1421,24 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
     examined_key_sources: dict = {}
     for source in key_source_by_key.values():
         examined_key_sources[source] = examined_key_sources.get(source, 0) + 1
+    for source, count in roster_stats["key_sources"].items():
+        examined_key_sources[source] = examined_key_sources.get(source, 0) + count
+    for source, count in roster_stats["commented_key_sources"].items():
+        posted_key_sources[source] = posted_key_sources.get(source, 0) + count
+    feed_commented = posted - roster_stats["posted"]
+    off_topic_total = off_topic_skipped + roster_stats["off_topic_skipped"]
     set_feed_funnel(user_id, {
-        "examined": len(examined_keys),
+        "examined": len(examined_keys) + roster_stats["examined"],
         "passed_filters": len(hard_keys),      # cleared excludes + recency + min-reactions
         "matched_topics": len(include_keys),   # also matched include topics/keywords/authors
         "commented": posted,
+        # Roster-sourced vs feed-sourced split (issue #616): a healthy account comments mostly on
+        # its curated roster, so this is the number that says whether the roster is actually working.
+        "roster_commented": roster_stats["posted"],
+        "feed_commented": feed_commented,
+        "roster_targets_visited": roster_stats["targets_visited"],
+        "roster_examined": roster_stats["examined"],
+        "off_topic_skipped": off_topic_total,  # failed the on-topic gate — never commented on
         "fallback_used": fallback_used,
         "key_sources": examined_key_sources,           # every post we looked at
         "commented_key_sources": posted_key_sources,   # only the ones we commented on
@@ -1235,8 +1446,10 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
         "min_reactions": min_reactions,
         "at": datetime.now().isoformat(),
     })
-    log_info(f"Feed scan: examined {len(examined_keys)}, passed filters {len(hard_keys)}, "
-             f"matched topics {len(include_keys)}, commented {posted}, fallback={fallback_used}, "
+    log_info(f"Engagement scan: examined {len(examined_keys) + roster_stats['examined']}, "
+             f"passed filters {len(hard_keys)}, matched topics {len(include_keys)}, "
+             f"commented {posted} (roster {roster_stats['posted']} / feed {feed_commented}), "
+             f"off-topic skipped {off_topic_total}, fallback={fallback_used}, "
              f"key sources {examined_key_sources}", user_id=user_id, action_type="comment",
              task_name="comment_on_feed_inline")
     if posted_key_sources.get("hash"):

--- a/src/cqc_lem/ui/src/pages/account/EngagementRosterCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementRosterCard.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import api from '../../api/client'
+import { useAuth } from '../../contexts/AuthContext'
+import { TARGET_CATEGORIES } from './types'
+import type { EngagementTarget, EngagementTargetCategory } from './types'
+import { useRegisterSaveSection } from './SettingsSaveContext'
+
+type RosterResponse = { targets: EngagementTarget[]; suggestions: EngagementTarget[] }
+
+const blank = (): EngagementTarget => ({
+  profile_url: '', name: '', category: 'peer', max_comments_per_week: 2, active: true, source: 'user',
+})
+
+// The blend the rotation aims for — shown live so the operator can see how far their roster is from
+// the 50/30/20 mix the commenting task draws on.
+function MixBar({ targets }: { targets: EngagementTarget[] }) {
+  const active = targets.filter((t) => t.active && t.profile_url.trim())
+  if (active.length === 0) return null
+  return (
+    <div className="flex flex-wrap gap-3 text-xs text-gray-600" data-testid="roster-mix">
+      {TARGET_CATEGORIES.map((c) => {
+        const n = active.filter((t) => t.category === c.key).length
+        return (
+          <span key={c.key}>
+            {c.label}: <span className="font-semibold">{n}</span> (
+            {Math.round((n / active.length) * 100)}%)
+          </span>
+        )
+      })}
+    </div>
+  )
+}
+
+/**
+ * Target-creator engagement roster (issue #616). LEM comments on these accounts' recent posts
+ * BEFORE it looks at the home feed, at most `max_comments_per_week` times each so the rotation
+ * never reads like a pod.
+ */
+export default function EngagementRosterCard() {
+  const { sessionToken } = useAuth()
+  const queryClient = useQueryClient()
+  const [targets, setTargets] = useState<EngagementTarget[]>([])
+  const [savedSig, setSavedSig] = useState<string | null>(null)
+  const [init, setInit] = useState(false)
+  const [msg, setMsg] = useState<{ ok: boolean; text: string } | null>(null)
+
+  const { data } = useQuery({
+    queryKey: ['engagement-targets', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/engagement-targets?session_token=${encodeURIComponent(sessionToken!)}`)
+        .then((r) => r.data.detail as RosterResponse),
+    enabled: !!sessionToken,
+    staleTime: 60 * 1000,
+  })
+
+  useEffect(() => {
+    if (data && !init) {
+      setTargets(data.targets)
+      setSavedSig(JSON.stringify(data.targets))
+      setInit(true)
+    }
+  }, [data, init])
+
+  const update = (idx: number, patch: Partial<EngagementTarget>) =>
+    setTargets((ts) => ts.map((t, i) => (i === idx ? { ...t, ...patch } : t)))
+  const addRow = () => setTargets((ts) => [...ts, blank()])
+  const addSuggestion = (s: EngagementTarget) =>
+    setTargets((ts) => (ts.some((t) => t.profile_url === s.profile_url) ? ts : [...ts, { ...s }]))
+
+  const removeMutation = useMutation({
+    mutationFn: (profile_url: string) =>
+      api.delete('/user/engagement-targets', { data: { session_token: sessionToken, profile_url } }),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['engagement-targets'] }),
+  })
+  const removeRow = (idx: number) => {
+    const target = targets[idx]
+    setTargets((ts) => ts.filter((_, i) => i !== idx))
+    // Only a row that was actually saved needs a server-side delete; a never-saved draft row just
+    // disappears from local state.
+    if (target?.id) removeMutation.mutate(target.profile_url)
+  }
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      api.put('/user/engagement-targets', {
+        session_token: sessionToken,
+        targets: targets.filter((t) => t.profile_url.trim()),
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['engagement-targets'] })
+      setSavedSig(JSON.stringify(targets))
+      setMsg({ ok: true, text: 'Engagement roster saved.' })
+      setTimeout(() => setMsg(null), 3000)
+    },
+    onError: () => {
+      setMsg({ ok: false, text: 'Could not save — try again.' })
+      setTimeout(() => setMsg(null), 5000)
+    },
+  })
+
+  const isDirty = init && savedSig !== null && JSON.stringify(targets) !== savedSig
+  useRegisterSaveSection('engagement-roster', 'Engagement Roster', isDirty,
+    async () => { await saveMutation.mutateAsync(); return true })
+
+  if (!init) return null
+
+  const suggestions = (data?.suggestions ?? []).filter(
+    (s) => !targets.some((t) => t.profile_url === s.profile_url))
+
+  return (
+    <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4"
+         data-testid="engagement-roster">
+      <h2 className="text-base font-semibold text-gray-700">Engagement Roster</h2>
+      <p className="text-xs text-gray-500">
+        LEM comments on these accounts' recent posts <span className="font-semibold">before</span> it
+        looks at your home feed, at most the set number of times per week each. Aim for 50–100
+        accounts, roughly 50% peers / 30% ICP / 20% large creators. Off-topic posts are always
+        skipped, roster or not.
+      </p>
+      <MixBar targets={targets} />
+
+      <div className="space-y-2">
+        {targets.map((t, idx) => (
+          <div key={t.id ?? `new-${idx}`} className="grid grid-cols-1 sm:grid-cols-12 gap-2 items-center">
+            <input type="text" value={t.profile_url} maxLength={512}
+              onChange={(e) => update(idx, { profile_url: e.target.value })}
+              placeholder="https://www.linkedin.com/in/their-handle"
+              aria-label="Profile URL"
+              className="sm:col-span-5 border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+            <input type="text" value={t.name ?? ''} maxLength={255}
+              onChange={(e) => update(idx, { name: e.target.value })}
+              placeholder="Name (optional)" aria-label="Name"
+              className="sm:col-span-3 border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+            <select value={t.category} aria-label="Category"
+              onChange={(e) => update(idx, { category: e.target.value as EngagementTargetCategory })}
+              className="sm:col-span-2 border border-gray-300 rounded-lg px-2 py-2 text-sm">
+              {TARGET_CATEGORIES.map((c) => (
+                <option key={c.key} value={c.key} title={c.hint}>{c.label}</option>
+              ))}
+            </select>
+            <label className="sm:col-span-1 flex items-center gap-1 text-xs text-gray-500">
+              <input type="number" min={0} max={14} value={t.max_comments_per_week}
+                onChange={(e) => update(idx, { max_comments_per_week: Number(e.target.value) })}
+                aria-label="Max comments per week"
+                className="w-14 border border-gray-300 rounded px-1 py-1" />
+              /wk
+            </label>
+            <div className="sm:col-span-1 flex items-center justify-end gap-2 text-xs">
+              <label className="flex items-center gap-1 text-gray-500">
+                <input type="checkbox" checked={t.active} aria-label="Active"
+                  onChange={(e) => update(idx, { active: e.target.checked })} />
+                On
+              </label>
+              <button type="button" onClick={() => removeRow(idx)}
+                className="text-red-500 hover:text-red-600">×</button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <button type="button" onClick={addRow}
+        className="text-xs text-blue-600 font-medium hover:text-blue-700">+ Add account</button>
+
+      {suggestions.length > 0 && (
+        <div className="border-t border-gray-100 pt-3 space-y-2">
+          <p className="text-xs text-gray-500">
+            Suggested seeds — people who recently engaged with your posts. Add them, then set the
+            right category:
+          </p>
+          <div className="flex flex-wrap gap-2">
+            {suggestions.map((s) => (
+              <button key={s.profile_url} type="button" onClick={() => addSuggestion(s)}
+                className="text-xs bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-full px-3 py-1">
+                + {s.name || s.profile_url}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {msg && <p className={`text-sm font-medium ${msg.ok ? 'text-green-600' : 'text-red-600'}`}>{msg.text}</p>}
+      <button type="button" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}
+        className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
+        {saveMutation.isPending ? 'Saving…' : 'Save Roster'}
+      </button>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/pages/account/EngagementRosterCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementRosterCard.tsx
@@ -154,6 +154,8 @@ export default function EngagementRosterCard() {
                 On
               </label>
               <button type="button" onClick={() => removeRow(idx)}
+                aria-label={`Remove ${t.name || t.profile_url || 'account'}`}
+                title="Remove account"
                 className="text-red-500 hover:text-red-600">×</button>
             </div>
           </div>

--- a/src/cqc_lem/ui/src/pages/account/settings/SettingsHub.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/SettingsHub.tsx
@@ -9,6 +9,7 @@ import ContentProfileCard from '../ContentProfileCard'
 import NewsletterCard from '../NewsletterCard'
 import GroupsCard from '../GroupsCard'
 import DmTemplatesCard from '../DmTemplatesCard'
+import EngagementRosterCard from '../EngagementRosterCard'
 import LeadMagnetCard from '../LeadMagnetCard'
 import { SettingsSaveProvider, SaveAllBar } from '../SettingsSaveContext'
 import { EngagementPrefsProvider, useEngagementPrefs } from './EngagementPrefsContext'
@@ -31,7 +32,7 @@ function SectionBody({ section }: { section: SectionKey }) {
     case 'content':
       return <><ContentProfileCard /><ContentSection /></>
     case 'targeting':
-      return <><TargetingSection /><GroupsCard /></>
+      return <><EngagementRosterCard /><TargetingSection /><GroupsCard /></>
     case 'volume':
       return <VolumeSection />
     case 'outreach':

--- a/src/cqc_lem/ui/src/pages/account/settings/TargetingSection.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/TargetingSection.tsx
@@ -29,6 +29,21 @@ function FeedReachFunnel() {
         commented on <span className="font-semibold">{reach.commented}</span>
         {reach.fallback_used ? ' (used the fallback)' : ''}.
       </p>
+      {(reach.roster_commented ?? 0) + (reach.feed_commented ?? 0) > 0 && (
+        <p className="mt-1">
+          <span className="font-semibold">{reach.roster_commented ?? 0}</span> from your roster
+          {typeof reach.roster_targets_visited === 'number'
+            ? ` (${reach.roster_targets_visited} accounts visited)`
+            : ''}
+          , <span className="font-semibold">{reach.feed_commented ?? 0}</span> from the feed.
+        </p>
+      )}
+      {(reach.off_topic_skipped ?? 0) > 0 && (
+        <p className="mt-1">
+          Skipped <span className="font-semibold">{reach.off_topic_skipped}</span> off-topic post
+          {reach.off_topic_skipped === 1 ? '' : 's'} — commenting off your focus topics hurts reach.
+        </p>
+      )}
     </div>
   )
 }

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -75,10 +75,38 @@ export type FeedReach = {
   matched_topics: number
   commented: number
   fallback_used: boolean
+  // Roster-sourced vs feed-sourced split + the on-topic gate's rejections (issue #616).
+  roster_commented?: number
+  feed_commented?: number
+  roster_targets_visited?: number
+  roster_examined?: number
+  off_topic_skipped?: number
   max_post_age_hours?: number
   min_reactions?: number
   at?: string
 }
+
+export type EngagementTargetCategory = 'peer' | 'icp' | 'creator'
+
+// One account on the curated engagement roster. last_engaged_at / comments_this_week are written
+// by the commenting task and are read-only here.
+export type EngagementTarget = {
+  id?: number
+  profile_url: string
+  name: string | null
+  category: EngagementTargetCategory
+  max_comments_per_week: number
+  active: boolean
+  source: 'user' | 'suggested'
+  last_engaged_at?: string | null
+  comments_this_week?: number
+}
+
+export const TARGET_CATEGORIES: { key: EngagementTargetCategory; label: string; hint: string }[] = [
+  { key: 'peer', label: 'Peer', hint: 'Creators at your level — aim for ~50% of the roster' },
+  { key: 'icp', label: 'ICP', hint: 'Buyers / prospects — aim for ~30%' },
+  { key: 'creator', label: 'Large creator', hint: 'Big audiences you borrow reach from — ~20%' },
+]
 
 export type DmTemplate = {
   event_type: string

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3237,8 +3237,9 @@ def _clean_target_row(row: dict) -> dict:
 
 
 def get_engagement_targets(user_id: int, active_only: bool = False) -> list:
-    """The user's engagement roster, newest-configured last. `comments_this_week` is already
-    week-aware (0 once the stored week_start is not the current week)."""
+    """The user's engagement roster, grouped by category and oldest-configured first within each
+    category. `comments_this_week` is already week-aware (0 once the stored week_start is not the
+    current week)."""
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
     try:
@@ -3250,7 +3251,7 @@ def get_engagement_targets(user_id: int, active_only: bool = False) -> list:
         cursor.execute(sql, (user_id,))
         return [_clean_target_row(r) for r in (cursor.fetchall() or [])]
     except mysql.connector.Error as err:
-        myprint(f"Could not list engagement targets for user_id {user_id} | Error: {err}")
+        log_error("Could not list engagement targets", exc=err, user_id=user_id)
         return []
     finally:
         cursor.close()
@@ -3292,7 +3293,7 @@ def upsert_engagement_targets(user_id: int, targets: list) -> bool:
         connection.commit()
         return True
     except mysql.connector.Error as err:
-        myprint(f"Could not upsert engagement targets for user_id {user_id} | Error: {err}")
+        log_error("Could not upsert engagement targets", exc=err, user_id=user_id)
         return False
     finally:
         cursor.close()
@@ -3308,7 +3309,7 @@ def delete_engagement_target(user_id: int, profile_url: str) -> bool:
         connection.commit()
         return True
     except mysql.connector.Error as err:
-        myprint(f"Could not delete engagement target for user_id {user_id} | Error: {err}")
+        log_error("Could not delete engagement target", exc=err, user_id=user_id)
         return False
     finally:
         cursor.close()
@@ -3331,7 +3332,7 @@ def record_target_engagement(user_id: int, profile_url: str) -> bool:
         connection.commit()
         return cursor.rowcount > 0
     except mysql.connector.Error as err:
-        myprint(f"Could not record target engagement for user_id {user_id} | Error: {err}")
+        log_error("Could not record target engagement", exc=err, user_id=user_id)
         return False
     finally:
         cursor.close()
@@ -3343,6 +3344,8 @@ def suggest_engagement_targets(user_id: int, limit: int = 20) -> list:
     (post_engagers), minus anyone already on the roster. Costs no scraping. Suggested as 'icp' —
     someone reacting to your content is far likelier to be a buyer than a peer — and the operator
     re-categorizes in the editor."""
+    if limit <= 0:
+        return []
     existing = {str(t.get("profile_url") or "").rstrip("/").lower()
                 for t in get_engagement_targets(user_id)}
     out = []

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3205,6 +3205,160 @@ def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
         connection.close()
 
 
+# --- Target-creator engagement roster (issue #616) ---
+# A curated list of accounts to comment on FIRST, ahead of the home feed. The blend the rotation
+# aims for is 50% peers / 30% ICP / 20% large creators; the per-author weekly cap is the anti-pod
+# guard so the same account never absorbs a run's whole comment budget.
+ENGAGEMENT_TARGET_CATEGORIES = ("peer", "icp", "creator")
+ENGAGEMENT_TARGET_SOURCES = ("user", "suggested")
+ENGAGEMENT_TARGET_WEEKLY_DEFAULT = 2
+ENGAGEMENT_TARGET_WEEKLY_MAX = 14
+_ENGAGEMENT_TARGET_COLS = ("id", "profile_url", "name", "category", "max_comments_per_week",
+                           "active", "last_engaged_at", "comments_this_week", "week_start",
+                           "source")
+
+
+def engagement_week_start(today: Optional[date] = None) -> date:
+    """Monday of the week `today` falls in — the reset boundary for the per-author weekly cap."""
+    today = today or datetime.now().date()
+    return today - timedelta(days=today.weekday())
+
+
+def _clean_target_row(row: dict) -> dict:
+    """Normalize a roster row: bools as bools, and a STALE weekly counter reported as 0 so a target
+    whose cap was spent last week is immediately eligible again without a reset job."""
+    row["active"] = bool(row.get("active"))
+    if row.get("week_start") != engagement_week_start():
+        row["comments_this_week"] = 0
+    row["comments_this_week"] = int(row.get("comments_this_week") or 0)
+    row["max_comments_per_week"] = int(row.get("max_comments_per_week")
+                                       or ENGAGEMENT_TARGET_WEEKLY_DEFAULT)
+    return row
+
+
+def get_engagement_targets(user_id: int, active_only: bool = False) -> list:
+    """The user's engagement roster, newest-configured last. `comments_this_week` is already
+    week-aware (0 once the stored week_start is not the current week)."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        sql = (f"SELECT {', '.join(_ENGAGEMENT_TARGET_COLS)} FROM engagement_targets "
+               f"WHERE user_id=%s")
+        if active_only:
+            sql += " AND active=1"
+        sql += " ORDER BY category, id"
+        cursor.execute(sql, (user_id,))
+        return [_clean_target_row(r) for r in (cursor.fetchall() or [])]
+    except mysql.connector.Error as err:
+        myprint(f"Could not list engagement targets for user_id {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def upsert_engagement_targets(user_id: int, targets: list) -> bool:
+    """Upsert roster rows keyed on (user_id, profile_url). Only the editable fields are written —
+    last_engaged_at / the weekly counter belong to the automation, so an edit never resets a cap."""
+    rows = []
+    for t in targets or []:
+        url = str(t.get("profile_url") or "").strip()
+        if not url:
+            continue
+        category = t.get("category")
+        source = t.get("source")
+        cap = t.get("max_comments_per_week")
+        try:
+            cap = int(cap) if cap is not None else ENGAGEMENT_TARGET_WEEKLY_DEFAULT
+        except (TypeError, ValueError):
+            cap = ENGAGEMENT_TARGET_WEEKLY_DEFAULT
+        rows.append((
+            user_id, url, (t.get("name") or None),
+            category if category in ENGAGEMENT_TARGET_CATEGORIES else "peer",
+            max(0, min(ENGAGEMENT_TARGET_WEEKLY_MAX, cap)),
+            1 if t.get("active", True) else 0,
+            source if source in ENGAGEMENT_TARGET_SOURCES else "user"))
+    if not rows:
+        return True
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.executemany(
+            "INSERT INTO engagement_targets (user_id, profile_url, name, category, "
+            "max_comments_per_week, active, source) VALUES (%s,%s,%s,%s,%s,%s,%s) "
+            "ON DUPLICATE KEY UPDATE name=VALUES(name), category=VALUES(category), "
+            "max_comments_per_week=VALUES(max_comments_per_week), active=VALUES(active), "
+            "source=VALUES(source)", rows)
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not upsert engagement targets for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def delete_engagement_target(user_id: int, profile_url: str) -> bool:
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("DELETE FROM engagement_targets WHERE user_id=%s AND profile_url=%s",
+                       (user_id, str(profile_url or "").strip()))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not delete engagement target for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_target_engagement(user_id: int, profile_url: str) -> bool:
+    """Count one comment against a roster author's weekly cap and stamp last_engaged_at. The
+    counter resets in the same statement when the stored week_start is not the current week, so a
+    new week always starts from 1 without a separate reset job."""
+    week = engagement_week_start()
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE engagement_targets SET "
+            "comments_this_week = IF(week_start = %s, comments_this_week + 1, 1), "
+            "week_start = %s, last_engaged_at = NOW() "
+            "WHERE user_id=%s AND profile_url=%s", (week, week, user_id, str(profile_url or "").strip()))
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not record target engagement for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def suggest_engagement_targets(user_id: int, limit: int = 20) -> list:
+    """Seed candidates for an empty roster: people who recently engaged with the user's OWN posts
+    (post_engagers), minus anyone already on the roster. Costs no scraping. Suggested as 'icp' —
+    someone reacting to your content is far likelier to be a buyer than a peer — and the operator
+    re-categorizes in the editor."""
+    existing = {str(t.get("profile_url") or "").rstrip("/").lower()
+                for t in get_engagement_targets(user_id)}
+    out = []
+    for cand in get_engager_candidates(user_id, days=60):
+        url = str(cand.get("person_profile_url") or "").strip()
+        if not url or url.rstrip("/").lower() in existing:
+            continue
+        existing.add(url.rstrip("/").lower())
+        out.append({"profile_url": url, "name": cand.get("person_name"), "category": "icp",
+                    "max_comments_per_week": ENGAGEMENT_TARGET_WEEKLY_DEFAULT,
+                    "active": True, "source": "suggested"})
+        if len(out) >= limit:
+            break
+    return out
+
+
 def get_or_create_reply_inbound_token(user_id: int) -> Optional[str]:
     """The user's PERSISTENT inbound token for the comment-notification forwarding address
     (reply+<token>@parse-domain). Minted once and stored on the users row so the Gmail forward

--- a/tests/unit/api/test_engagement_targets_api.py
+++ b/tests/unit/api/test_engagement_targets_api.py
@@ -1,0 +1,123 @@
+"""Unit tests for the /api/user/engagement-targets roster CRUD (issue #616)."""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_SESSION = "tok"
+_USER = 5
+_URL = "https://www.linkedin.com/in/jane"
+
+
+class TestGetEngagementTargets:
+    def test_returns_targets_and_suggestions(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_engagement_targets",
+                   return_value=[{"profile_url": _URL, "category": "peer"}]), \
+             patch("cqc_lem.api.main.suggest_engagement_targets",
+                   return_value=[{"profile_url": "https://x/in/bob", "category": "icp"}]):
+            resp = client.get(f"/api/user/engagement-targets?session_token={_SESSION}")
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert detail["targets"][0]["profile_url"] == _URL
+        assert detail["suggestions"][0]["category"] == "icp"
+
+    def test_401(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.get("/api/user/engagement-targets?session_token=bad")
+        assert resp.status_code == 401
+
+
+class TestUpdateEngagementTargets:
+    def test_upserts(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.upsert_engagement_targets", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-targets", json={
+                "session_token": _SESSION,
+                "targets": [{"profile_url": _URL, "name": "Jane", "category": "creator",
+                             "max_comments_per_week": 3, "active": True, "source": "user"}]})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1][0]["category"] == "creator"
+
+    def test_unknown_category_falls_back_to_peer(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.upsert_engagement_targets", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-targets", json={
+                "session_token": _SESSION,
+                "targets": [{"profile_url": _URL, "category": "influencer"}]})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1][0]["category"] == "peer"
+
+    def test_out_of_range_weekly_cap_is_clamped_not_rejected(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.upsert_engagement_targets", return_value=True) as upd:
+            resp = client.put("/api/user/engagement-targets", json={
+                "session_token": _SESSION,
+                "targets": [{"profile_url": _URL, "max_comments_per_week": 999}]})
+        assert resp.status_code == 200
+        assert upd.call_args[0][1][0]["max_comments_per_week"] == 14
+
+    def test_over_long_url_is_422(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER):
+            resp = client.put("/api/user/engagement-targets", json={
+                "session_token": _SESSION, "targets": [{"profile_url": "h" * 513}]})
+        assert resp.status_code == 422
+
+    def test_500_on_failure(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.upsert_engagement_targets", return_value=False):
+            resp = client.put("/api/user/engagement-targets",
+                              json={"session_token": _SESSION, "targets": []})
+        assert resp.status_code == 500
+
+    def test_401(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.put("/api/user/engagement-targets",
+                              json={"session_token": "bad", "targets": []})
+        assert resp.status_code == 401
+
+
+class TestDeleteEngagementTarget:
+    def test_deletes(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.delete_engagement_target", return_value=True) as dele:
+            resp = client.request("DELETE", "/api/user/engagement-targets",
+                                  json={"session_token": _SESSION, "profile_url": _URL})
+        assert resp.status_code == 200
+        dele.assert_called_once_with(_USER, _URL)
+
+    def test_500_on_failure(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.delete_engagement_target", return_value=False):
+            resp = client.request("DELETE", "/api/user/engagement-targets",
+                                  json={"session_token": _SESSION, "profile_url": _URL})
+        assert resp.status_code == 500
+
+    def test_401(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            resp = client.request("DELETE", "/api/user/engagement-targets",
+                                  json={"session_token": "bad", "profile_url": _URL})
+        assert resp.status_code == 401

--- a/tests/unit/app/test_comment_dedup.py
+++ b/tests/unit/app/test_comment_dedup.py
@@ -68,6 +68,9 @@ def _run_feed(boxes, *, claim_side_effect=None, has_commented=False, max_posts=1
         p("_literal_relevant", return_value=True)
         p("_score_feed_post", return_value=1.0)
         p("post_matches_preferences", return_value=matches)
+        # Empty roster: the run degrades to the plain feed walk (issue #616 acceptance).
+        p("get_engagement_targets", return_value=[])
+        p("post_is_relevant", return_value=True)
         funnel_holder = {}
         p("set_feed_funnel", side_effect=lambda uid, f: funnel_holder.update(f))
         p("claim_post_for_comment", new=claim)
@@ -169,6 +172,8 @@ class TestFeedDedup:
             p("_literal_relevant", return_value=True)
             p("_score_feed_post", return_value=1.0)
             p("post_matches_preferences", return_value=True)
+            p("get_engagement_targets", return_value=[])
+            p("post_is_relevant", return_value=True)
             p("_author_is_me", return_value=False)
             p("claim_post_for_comment", return_value=True)
             p("generate_ai_response", return_value="A comment.")

--- a/tests/unit/app/test_engagement_roster.py
+++ b/tests/unit/app/test_engagement_roster.py
@@ -1,0 +1,328 @@
+"""Unit tests for the target-creator engagement roster (issue #616): 50/30/20 selection, the
+per-author weekly cap, the on-topic gate, and the roster-vs-feed funnel diagnostics."""
+
+import pytest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+from contextlib import ExitStack
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep():
+    with patch(f"{_RA}.time.sleep"):
+        yield
+
+
+def _target(url, category="peer", *, last=None, cap=2, used=0, active=True, name=None):
+    return {"id": abs(hash(url)) % 10000, "profile_url": url, "name": name or url,
+            "category": category, "max_comments_per_week": cap, "active": active,
+            "last_engaged_at": last, "comments_this_week": used, "source": "user"}
+
+
+class TestSelectRosterTargets:
+    def test_blends_fifty_thirty_twenty(self):
+        from cqc_lem.app.run_automation import select_roster_targets
+        targets = ([_target(f"peer{i}", "peer") for i in range(10)]
+                   + [_target(f"icp{i}", "icp") for i in range(10)]
+                   + [_target(f"cre{i}", "creator") for i in range(10)])
+        picked = select_roster_targets(targets, 10)
+        assert len(picked) == 10
+        by_cat = {c: sum(1 for t in picked if t["category"] == c) for c in ("peer", "icp", "creator")}
+        assert by_cat == {"peer": 5, "icp": 3, "creator": 2}
+
+    def test_never_engaged_targets_come_first(self):
+        from cqc_lem.app.run_automation import select_roster_targets
+        recent = _target("recent", "peer", last=datetime.now())
+        stale = _target("stale", "peer", last=datetime.now() - timedelta(days=9))
+        fresh = _target("never", "peer", last=None)
+        picked = select_roster_targets([recent, stale, fresh], 2)
+        assert [t["profile_url"] for t in picked] == ["never", "stale"]
+
+    def test_weekly_cap_excludes_a_spent_author(self):
+        from cqc_lem.app.run_automation import select_roster_targets
+        spent = _target("spent", "peer", cap=2, used=2)
+        left = _target("left", "peer", cap=2, used=1)
+        picked = select_roster_targets([spent, left], 5)
+        assert [t["profile_url"] for t in picked] == ["left"]
+
+    def test_inactive_targets_are_skipped(self):
+        from cqc_lem.app.run_automation import select_roster_targets
+        picked = select_roster_targets([_target("off", "peer", active=False)], 5)
+        assert picked == []
+
+    def test_short_buckets_spill_their_slots(self):
+        # Roster is peers-only: the ICP/creator quotas must not go to waste.
+        from cqc_lem.app.run_automation import select_roster_targets
+        targets = [_target(f"peer{i}", "peer") for i in range(6)]
+        assert len(select_roster_targets(targets, 5)) == 5
+
+    def test_zero_limit_picks_nothing(self):
+        from cqc_lem.app.run_automation import select_roster_targets
+        assert select_roster_targets([_target("a")], 0) == []
+
+
+class TestActivityUrl:
+    def test_builds_recent_activity_url(self):
+        from cqc_lem.app.run_automation import _roster_activity_url
+        assert _roster_activity_url("https://www.linkedin.com/in/jane/") == \
+            "https://www.linkedin.com/in/jane/recent-activity/all/"
+
+    def test_keeps_an_explicit_activity_url(self):
+        from cqc_lem.app.run_automation import _roster_activity_url
+        assert _roster_activity_url("https://www.linkedin.com/in/jane/recent-activity/all") == \
+            "https://www.linkedin.com/in/jane/recent-activity/all/"
+
+    def test_blank_url_is_empty(self):
+        from cqc_lem.app.run_automation import _roster_activity_url
+        assert _roster_activity_url("  ") == ""
+
+
+class TestTopicGate:
+    def test_inert_without_configured_topics(self):
+        from cqc_lem.app.run_automation import passes_topic_gate
+        with patch(f"{_RA}.post_is_relevant") as classifier:
+            assert passes_topic_gate("anything at all", {}) is True
+        classifier.assert_not_called()  # nothing to be off-topic against — and no LLM spend
+
+    def test_literal_focus_topic_short_circuits_the_classifier(self):
+        from cqc_lem.app.run_automation import passes_topic_gate
+        with patch(f"{_RA}.post_is_relevant") as classifier:
+            assert passes_topic_gate("Our RevOps rollout went sideways",
+                                     {"focus_topics": ["RevOps"]}) is True
+        classifier.assert_not_called()
+
+    def test_off_topic_post_is_rejected(self):
+        from cqc_lem.app.run_automation import passes_topic_gate
+        with patch(f"{_RA}.post_is_relevant", return_value=False):
+            assert passes_topic_gate("AI in HR hiring screens", {"focus_topics": ["RevOps"]}) is False
+
+    def test_focus_topics_win_over_include_topics(self):
+        from cqc_lem.app.run_automation import passes_topic_gate
+        with patch(f"{_RA}.post_is_relevant", return_value=True) as classifier:
+            passes_topic_gate("some post", {"focus_topics": ["RevOps"], "include_topics": ["HR"]})
+        assert classifier.call_args[0][1] == ["RevOps"]
+
+    def test_falls_back_to_include_topics(self):
+        from cqc_lem.app.run_automation import passes_topic_gate
+        with patch(f"{_RA}.post_is_relevant", return_value=True) as classifier:
+            passes_topic_gate("some post", {"include_topics": ["HR tech"]})
+        assert classifier.call_args[0][1] == ["HR tech"]
+
+
+def _box(text):
+    b = MagicMock()
+    b.text = text
+    return b
+
+
+def _run_roster(boxes, targets, *, prefs=None, relevant=True, engage=True, max_posts=5):
+    """Drive comment_on_roster_posts with every Selenium/DB collaborator mocked."""
+    from cqc_lem.app import run_automation as ra
+
+    driver = MagicMock()
+    driver.find_elements.return_value = boxes
+    driver.execute_script.return_value = None  # no URN on the card -> hash key
+
+    engage_mock = MagicMock(return_value=engage)
+    record = MagicMock(return_value=True)
+    seen = set()
+
+    with ExitStack() as es:
+        p = lambda name, **kw: es.enter_context(patch(f"{_RA}.{name}", **kw))
+        p("get_engagement_targets", return_value=targets)
+        p("wait_for_ajax")
+        p("_card_for_textbox", side_effect=lambda d, b: MagicMock())
+        p("_post_author_from_card", return_value="Jane Author")
+        p("_post_permalink_from_card", return_value=None)
+        p("has_commented_post", return_value=False)
+        p("has_user_commented_on_post_url", return_value=False)
+        p("_passes_hard_excludes", return_value=True)
+        p("post_is_relevant", return_value=relevant)
+        p("_engage_card", new=engage_mock)
+        p("record_target_engagement", new=record)
+        stats = ra.comment_on_roster_posts(driver, MagicMock(), MagicMock(), 1, max_posts,
+                                           prefs or {}, "synthesis", [], seen)
+    return {"stats": stats, "engage": engage_mock, "record": record, "driver": driver, "seen": seen}
+
+
+class TestCommentOnRosterPosts:
+    def test_empty_roster_is_a_noop(self):
+        r = _run_roster([_box("A post long enough to be scanned here.")], [])
+        assert r["stats"]["posted"] == 0
+        assert r["stats"]["targets_visited"] == 0
+        r["driver"].get.assert_not_called()  # never opens a browser page for an empty roster
+
+    def test_visits_activity_page_and_comments(self):
+        r = _run_roster([_box("A roster author's post, long enough to scan.")],
+                        [_target("https://www.linkedin.com/in/jane", "peer")])
+        assert r["stats"]["posted"] == 1
+        assert r["stats"]["targets_visited"] == 1
+        r["driver"].get.assert_called_once_with(
+            "https://www.linkedin.com/in/jane/recent-activity/all/")
+        r["record"].assert_called_once_with(1, "https://www.linkedin.com/in/jane")
+
+    def test_one_comment_per_author_per_run(self):
+        # Three posts on one author's page — anti-pod means we take exactly one.
+        boxes = [_box(f"Roster author post number {i}, long enough to scan.") for i in range(3)]
+        r = _run_roster(boxes, [_target("https://www.linkedin.com/in/jane", "peer")])
+        assert r["stats"]["posted"] == 1
+        assert r["engage"].call_count == 1
+
+    def test_off_topic_roster_post_is_never_commented_on(self):
+        r = _run_roster([_box("Wholly unrelated content of sufficient length.")],
+                        [_target("https://www.linkedin.com/in/jane", "peer")],
+                        prefs={"focus_topics": ["RevOps"]}, relevant=False)
+        assert r["stats"]["posted"] == 0
+        assert r["stats"]["off_topic_skipped"] == 1
+        r["engage"].assert_not_called()
+        r["record"].assert_not_called()
+
+    def test_author_at_weekly_cap_is_not_visited(self):
+        r = _run_roster([_box("A roster author's post, long enough to scan.")],
+                        [_target("https://www.linkedin.com/in/jane", "peer", cap=2, used=2)])
+        assert r["stats"]["targets_visited"] == 0
+        r["driver"].get.assert_not_called()
+
+    def test_seen_keys_block_the_later_feed_walk(self):
+        r = _run_roster([_box("A roster author's post, long enough to scan.")],
+                        [_target("https://www.linkedin.com/in/jane", "peer")])
+        assert r["seen"], "roster keys must be shared so the feed walk can't re-comment them"
+
+    def test_page_without_commentable_cards_is_skipped(self):
+        from cqc_lem.app import run_automation as ra
+        driver = MagicMock()
+        driver.find_elements.return_value = [_box("An item with no comment affordance at all.")]
+        with ExitStack() as es:
+            p = lambda name, **kw: es.enter_context(patch(f"{_RA}.{name}", **kw))
+            p("get_engagement_targets", return_value=[_target("https://www.linkedin.com/in/jane")])
+            p("wait_for_ajax")
+            p("_card_for_textbox", return_value=None)  # fail closed
+            engage = es.enter_context(patch(f"{_RA}._engage_card"))
+            stats = ra.comment_on_roster_posts(driver, MagicMock(), MagicMock(), 1, 5, {},
+                                               "synthesis", [], set())
+        assert stats["posted"] == 0
+        engage.assert_not_called()
+
+    def test_deadline_stops_the_roster_pass(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.get_engagement_targets",
+                   return_value=[_target("https://www.linkedin.com/in/jane")]), \
+             patch(f"{_RA}._engage_card") as engage:
+            driver = MagicMock()
+            stats = ra.comment_on_roster_posts(driver, MagicMock(), MagicMock(), 1, 5, {},
+                                               "synthesis", [], set(), deadline_ts=1.0)
+        assert stats["posted"] == 0
+        driver.get.assert_not_called()
+        engage.assert_not_called()
+
+    def test_navigation_failure_moves_on(self):
+        from cqc_lem.app import run_automation as ra
+        driver = MagicMock()
+        driver.get.side_effect = Exception("auth wall")
+        with ExitStack() as es:
+            p = lambda name, **kw: es.enter_context(patch(f"{_RA}.{name}", **kw))
+            p("get_engagement_targets", return_value=[_target("https://www.linkedin.com/in/jane")])
+            p("wait_for_ajax")
+            p("log_warning")
+            engage = es.enter_context(patch(f"{_RA}._engage_card"))
+            stats = ra.comment_on_roster_posts(driver, MagicMock(), MagicMock(), 1, 5, {},
+                                               "synthesis", [], set())
+        assert stats["posted"] == 0 and stats["targets_visited"] == 0
+        engage.assert_not_called()
+
+
+def _run_feed(boxes, *, prefs=None, relevant=True, roster_stats=None, matches=True):
+    """Drive comment_on_feed_inline end-to-end with the roster pass stubbed, so the assertions are
+    about the feed walk's on-topic gate and the merged funnel."""
+    from cqc_lem.app import run_automation as ra
+
+    driver = MagicMock()
+    driver.find_elements.return_value = boxes
+    driver.execute_script.return_value = None
+    engage = MagicMock(return_value=True)
+    funnel = {}
+    empty_roster = {"posted": 0, "targets_visited": 0, "examined": 0, "off_topic_skipped": 0,
+                    "key_sources": {}, "commented_key_sources": {}}
+
+    with ExitStack() as es:
+        p = lambda name, **kw: es.enter_context(patch(f"{_RA}.{name}", **kw))
+        p("get_engagement_preferences", return_value=prefs or {"max_comments_per_day": 20})
+        p("get_recent_engagers", return_value=set())
+        p("count_comments_today", return_value=0)
+        p("get_or_create_profile_synthesis", return_value="synthesis")
+        p("comment_on_roster_posts", return_value=roster_stats or empty_roster)
+        p("navigate_to_feed")
+        p("_switch_feed_to_recent")
+        p("_card_for_textbox", side_effect=lambda d, b: MagicMock())
+        p("_post_author_from_card", return_value="Jane Author")
+        p("_post_permalink_from_card", return_value=None)
+        p("has_commented_post", return_value=False)
+        p("has_user_commented_on_post_url", return_value=False)
+        p("_passes_hard_excludes", return_value=True)
+        p("_post_age_minutes", return_value=10)
+        p("_post_social_counts", return_value={"comments": 0, "reactions": 0})
+        p("_literal_relevant", return_value=True)
+        p("_score_feed_post", return_value=1.0)
+        p("post_matches_preferences", return_value=matches)
+        p("post_is_relevant", return_value=relevant)
+        p("_engage_card", new=engage)
+        p("set_feed_funnel", side_effect=lambda uid, f: funnel.update(f))
+        posted = ra.comment_on_feed_inline(driver, MagicMock(), MagicMock(), user_id=1, max_posts=5)
+    return {"posted": posted, "engage": engage, "funnel": funnel}
+
+
+class TestFeedOnTopicGate:
+    def test_off_topic_feed_post_is_never_commented_on(self):
+        r = _run_feed([_box("AI in HR hiring screens, a post of adequate length.")],
+                      prefs={"max_comments_per_day": 20, "focus_topics": ["RevOps"]},
+                      relevant=False)
+        assert r["posted"] == 0
+        r["engage"].assert_not_called()
+        assert r["funnel"]["off_topic_skipped"] == 1
+
+    def test_fallback_cannot_comment_on_an_off_topic_post(self):
+        # The empty-filter fallback widens WHICH posts qualify — it must never widen past the
+        # on-topic gate, which is exactly what produced the off-ICP comments in the 2026-07 funnel.
+        boxes = [_box(f"Off-topic post number {i} of adequate scanning length.") for i in range(9)]
+        r = _run_feed(boxes, matches=False,
+                      prefs={"max_comments_per_day": 20, "include_topics": ["RevOps"],
+                             "feed_fallback_when_empty": True},
+                      relevant=False)
+        assert r["posted"] == 0
+        r["engage"].assert_not_called()
+        assert r["funnel"]["fallback_used"] is False
+
+    def test_on_topic_post_still_gets_a_comment(self):
+        r = _run_feed([_box("A RevOps pipeline post of adequate scanning length.")],
+                      prefs={"max_comments_per_day": 20, "focus_topics": ["RevOps"]})
+        assert r["posted"] == 1
+        assert r["funnel"]["off_topic_skipped"] == 0
+
+
+class TestFunnelSourceSplit:
+    def test_roster_and_feed_counts_are_reported_separately(self):
+        roster = {"posted": 2, "targets_visited": 3, "examined": 4, "off_topic_skipped": 1,
+                  "key_sources": {"card": 4}, "commented_key_sources": {"card": 2}}
+        r = _run_feed([_box("A feed post of entirely adequate scanning length.")],
+                      roster_stats=roster)
+        f = r["funnel"]
+        assert f["commented"] == 3            # 2 roster + 1 feed
+        assert f["roster_commented"] == 2 and f["feed_commented"] == 1
+        assert f["roster_targets_visited"] == 3
+        assert f["examined"] == 5             # 4 roster + 1 feed
+        assert f["off_topic_skipped"] == 1
+        assert f["key_sources"] == {"card": 4, "hash": 1}
+        assert f["commented_key_sources"] == {"hash": 1, "card": 2}
+
+    def test_roster_comments_count_against_the_run_budget(self):
+        # The roster used the whole budget: the feed walk must not comment again on top of it.
+        roster = {"posted": 5, "targets_visited": 5, "examined": 5, "off_topic_skipped": 0,
+                  "key_sources": {}, "commented_key_sources": {}}
+        r = _run_feed([_box("A feed post of entirely adequate scanning length.")],
+                      roster_stats=roster)
+        assert r["posted"] == 5
+        r["engage"].assert_not_called()

--- a/tests/unit/app/test_engagement_roster.py
+++ b/tests/unit/app/test_engagement_roster.py
@@ -95,6 +95,20 @@ class TestTopicGate:
                                      {"focus_topics": ["RevOps"]}) is True
         classifier.assert_not_called()
 
+    def test_short_topic_inside_another_word_does_not_short_circuit(self):
+        from cqc_lem.app.run_automation import passes_topic_gate
+        with patch(f"{_RA}.post_is_relevant", return_value=False) as classifier:
+            assert passes_topic_gate("How we thrive on shorter sprints",
+                                     {"focus_topics": ["HR"]}) is False
+        classifier.assert_called_once()  # "thrive" is not an HR mention — the classifier decides
+
+    def test_multi_word_topic_matches_on_a_word_boundary(self):
+        from cqc_lem.app.run_automation import passes_topic_gate
+        with patch(f"{_RA}.post_is_relevant") as classifier:
+            assert passes_topic_gate("Notes on our RevOps tooling stack.",
+                                     {"focus_topics": ["revops tooling"]}) is True
+        classifier.assert_not_called()
+
     def test_off_topic_post_is_rejected(self):
         from cqc_lem.app.run_automation import passes_topic_gate
         with patch(f"{_RA}.post_is_relevant", return_value=False):

--- a/tests/unit/utilities/test_db_engagement_targets.py
+++ b/tests/unit/utilities/test_db_engagement_targets.py
@@ -1,0 +1,153 @@
+"""Unit tests for the engagement-roster DB helpers (issue #616)."""
+
+import pytest
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _mock_conn(fetch_all=None):
+    conn = MagicMock()
+    cursor = MagicMock()
+    cursor.fetchall.return_value = fetch_all or []
+    cursor.rowcount = 1
+    conn.cursor.return_value = cursor
+    return conn, cursor
+
+
+class TestWeekStart:
+    def test_monday_is_the_boundary(self):
+        from cqc_lem.utilities.db import engagement_week_start
+        assert engagement_week_start(date(2026, 7, 26)) == date(2026, 7, 20)   # a Sunday
+        assert engagement_week_start(date(2026, 7, 20)) == date(2026, 7, 20)   # the Monday itself
+
+
+class TestGetEngagementTargets:
+    def _row(self, **kw):
+        from cqc_lem.utilities.db import engagement_week_start
+        row = {"id": 1, "profile_url": "https://x/in/jane", "name": "Jane", "category": "peer",
+               "max_comments_per_week": 2, "active": 1, "last_engaged_at": None,
+               "comments_this_week": 2, "week_start": engagement_week_start(), "source": "user"}
+        row.update(kw)
+        return row
+
+    def test_normalizes_active_flag(self):
+        conn, _ = _mock_conn(fetch_all=[self._row(active=1)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_targets
+            rows = get_engagement_targets(1)
+        assert rows[0]["active"] is True
+
+    def test_stale_week_counter_reads_as_zero(self):
+        # A cap spent LAST week must not keep an author out of this week's rotation.
+        from cqc_lem.utilities.db import engagement_week_start
+        stale = engagement_week_start() - timedelta(days=7)
+        conn, _ = _mock_conn(fetch_all=[self._row(week_start=stale, comments_this_week=2)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_targets
+            rows = get_engagement_targets(1)
+        assert rows[0]["comments_this_week"] == 0
+
+    def test_current_week_counter_is_kept(self):
+        conn, _ = _mock_conn(fetch_all=[self._row(comments_this_week=2)])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_targets
+            rows = get_engagement_targets(1)
+        assert rows[0]["comments_this_week"] == 2
+
+    def test_active_only_filters_in_sql(self):
+        conn, cursor = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_targets
+            get_engagement_targets(1, active_only=True)
+        assert "active=1" in cursor.execute.call_args[0][0]
+
+    def test_db_error_returns_empty(self):
+        import mysql.connector
+        conn, cursor = _mock_conn()
+        cursor.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engagement_targets
+            assert get_engagement_targets(1) == []
+
+
+class TestUpsertEngagementTargets:
+    def test_upserts_and_clamps(self):
+        conn, cursor = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import upsert_engagement_targets
+            ok = upsert_engagement_targets(1, [
+                {"profile_url": "https://x/in/jane", "category": "bogus",
+                 "max_comments_per_week": 99, "source": "elsewhere"}])
+        assert ok is True
+        row = cursor.executemany.call_args[0][1][0]
+        assert row[3] == "peer"     # unknown category -> peer
+        assert row[4] == 14         # cap clamped to the max
+        assert row[6] == "user"     # unknown source -> user
+
+    def test_blank_url_rows_are_dropped(self):
+        conn, cursor = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import upsert_engagement_targets
+            assert upsert_engagement_targets(1, [{"profile_url": "   "}]) is True
+        cursor.executemany.assert_not_called()
+
+    def test_non_numeric_cap_falls_back_to_the_default(self):
+        conn, cursor = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import upsert_engagement_targets, ENGAGEMENT_TARGET_WEEKLY_DEFAULT
+            upsert_engagement_targets(1, [{"profile_url": "https://x/in/j", "max_comments_per_week": "lots"}])
+        assert cursor.executemany.call_args[0][1][0][4] == ENGAGEMENT_TARGET_WEEKLY_DEFAULT
+
+    def test_does_not_write_the_weekly_counter(self):
+        # An operator editing the roster must never reset an author's spent cap.
+        conn, cursor = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import upsert_engagement_targets
+            upsert_engagement_targets(1, [{"profile_url": "https://x/in/j"}])
+        sql = cursor.executemany.call_args[0][0]
+        assert "comments_this_week" not in sql and "last_engaged_at" not in sql
+
+
+class TestRecordTargetEngagement:
+    def test_increments_and_stamps(self):
+        conn, cursor = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_target_engagement
+            assert record_target_engagement(1, "https://x/in/jane") is True
+        sql = cursor.execute.call_args[0][0]
+        assert "comments_this_week + 1" in sql and "last_engaged_at = NOW()" in sql
+
+    def test_missing_row_is_false(self):
+        conn, cursor = _mock_conn()
+        cursor.rowcount = 0
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_target_engagement
+            assert record_target_engagement(1, "https://x/in/nobody") is False
+
+
+class TestSuggestEngagementTargets:
+    def test_excludes_accounts_already_on_the_roster(self):
+        with patch(f"{_DB}.get_engagement_targets",
+                   return_value=[{"profile_url": "https://x/in/jane/"}]), \
+             patch(f"{_DB}.get_engager_candidates", return_value=[
+                 {"person_name": "Jane", "person_profile_url": "https://x/in/jane"},
+                 {"person_name": "Bob", "person_profile_url": "https://x/in/bob"}]):
+            from cqc_lem.utilities.db import suggest_engagement_targets
+            out = suggest_engagement_targets(1)
+        assert [s["name"] for s in out] == ["Bob"]
+        assert out[0]["source"] == "suggested" and out[0]["category"] == "icp"
+
+    def test_honours_the_limit_and_dedups(self):
+        with patch(f"{_DB}.get_engagement_targets", return_value=[]), \
+             patch(f"{_DB}.get_engager_candidates", return_value=[
+                 {"person_name": "A", "person_profile_url": "https://x/in/a"},
+                 {"person_name": "A again", "person_profile_url": "https://x/in/a"},
+                 {"person_name": "B", "person_profile_url": "https://x/in/b"},
+                 {"person_name": "No URL", "person_profile_url": ""}]):
+            from cqc_lem.utilities.db import suggest_engagement_targets
+            out = suggest_engagement_targets(1, limit=2)
+        assert [s["profile_url"] for s in out] == ["https://x/in/a", "https://x/in/b"]

--- a/tests/unit/utilities/test_db_engagement_targets.py
+++ b/tests/unit/utilities/test_db_engagement_targets.py
@@ -151,3 +151,12 @@ class TestSuggestEngagementTargets:
             from cqc_lem.utilities.db import suggest_engagement_targets
             out = suggest_engagement_targets(1, limit=2)
         assert [s["profile_url"] for s in out] == ["https://x/in/a", "https://x/in/b"]
+
+    def test_non_positive_limit_returns_nothing_without_querying(self):
+        with patch(f"{_DB}.get_engagement_targets") as roster, \
+             patch(f"{_DB}.get_engager_candidates") as candidates:
+            from cqc_lem.utilities.db import suggest_engagement_targets
+            assert suggest_engagement_targets(1, limit=0) == []
+            assert suggest_engagement_targets(1, limit=-3) == []
+        roster.assert_not_called()
+        candidates.assert_not_called()


### PR DESCRIPTION
## What & why

The 2026-07-25 feed funnel (`linkedin:feed_funnel:1`) examined 21 posts, matched **0** include_topics, and the empty-filter fallback then commented on off-ICP posts (AI-in-HR/hiring). Under 2026 Topic Authority ranking that off-topic commenting actively *damages* distribution. `include_authors` had never been populated, so there was no curated list to draw from at all — while every fast-growing native creator studied grew from high-volume substantive comments on a roster of 50–100 accounts split ~50% peers / 30% ICP / 20% large creators.

This PR adds that roster and makes it the FIRST source of comments, and turns topic relevance into a hard gate.

### Roster
- **Migration** `V20260726043337__add_engagement_targets.sql` — `engagement_targets` (user_id, profile_url, name, category ENUM('peer','icp','creator'), max_comments_per_week default 2, active, last_engaged_at, source ENUM('user','suggested')), plus `comments_this_week`/`week_start` as the weekly cap's rolling counter (reset in the same UPDATE on a new ISO week — no reset job).
- **`db.py`**: `get_engagement_targets`, `upsert_engagement_targets`, `delete_engagement_target`, `record_target_engagement`, `suggest_engagement_targets` (seeds from `post_engagers`, so suggestions cost no scraping). The upsert deliberately never writes `comments_this_week`/`last_engaged_at`, so editing the roster can't reset a spent cap.
- **`comment_on_roster_posts`** (`run_automation.py`): opens each selected target's `/recent-activity/all/` page and comments on the first post that clears hard excludes, the dedup ledger and the on-topic gate. One comment per author per run on top of the weekly cap (anti-pod). Fail-closed per the #403/#404 pattern — a page with no commentable card, a nav failure or an auth wall is logged and skipped, never guessed at.
- **`select_roster_targets`**: pure function — active + under-cap targets only, drawn in the 50/30/20 blend, least-recently-engaged first; short buckets spill their slots so a lopsided roster still uses the budget.
- `seen` is shared between the roster pass and the feed walk, so a roster post can never earn a second comment from the feed.

### On-topic-only commenting
`passes_topic_gate()` runs **before** the include check and applies in the fallback path too: the fallback may widen *which* posts qualify, but never past focus-topic relevance. A literal topic mention short-circuits the classifier; the classifier itself still fails open (a `lem-simple` hiccup must not silence all engagement). With no topics configured the gate is inert.

### Diagnostics + UI
- Feed funnel now carries `roster_commented` / `feed_commented` / `roster_targets_visited` / `roster_examined` / `off_topic_skipped`, merged key sources, and one combined log line.
- New `EngagementRosterCard` in Settings → Targeting: per-row profile URL, name, category, weekly cap, active toggle, live mix percentages, and one-click "suggested seeds". API CRUD at `GET/PUT/DELETE /api/user/engagement-targets`.
- The Targeting section's funnel readout shows the roster/feed split and the off-topic skip count.

## Testing notes
- `tests/unit/app/test_engagement_roster.py` — 50/30/20 blend, rotation order, weekly cap, inactive skip, bucket spill; activity-URL building; the topic gate (inert / literal short-circuit / rejection / focus-over-include); the roster pass (empty roster no-op, visit+comment+record, one-per-author, off-topic never commented, capped author never visited, shared `seen`, no-card and nav-failure fail-closed, deadline); the feed-level gate (fallback can't comment off-topic) and the funnel source split.
- `tests/unit/utilities/test_db_engagement_targets.py` — week boundary, stale-counter reset on read, `active_only` SQL, clamping/validation on upsert, counter never overwritten by an edit, `record_target_engagement`, suggestion dedup/limit.
- `tests/unit/api/test_engagement_targets_api.py` — GET/PUT/DELETE happy paths, 401s, 500s, category/source fallback, cap clamped (not 422'd), over-long URL → 422.
- `tests/unit/app/test_comment_dedup.py` updated to stub an empty roster — which is also the acceptance check that behaviour degrades to the previous feed flow.
- Full local unit suite: **5586 passed**.

Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)