### PR TITLE
docs(format): live-validation findings — document post path + saves/impressions scraping (closes #404)

### DIFF
--- a/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
+++ b/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
@@ -52,7 +52,7 @@ left), `--probe-composer` dumps the composer's real control labels in one run �
 deck renders in-feed as a swipeable **document**, not a multi-image share. `probe_document_render`
 answers this by capturing the media anchors of a published post (§4, check 2). It needs one document
 post to exist on the account first — that publish is C1's acceptance step and is human-gated
-(`risk:live-linkedin`).
+(`risk:live-linkedin`). Tracked as **#644**.
 
 ## 2. Saves and impressions are scrapeable — on the author's analytics page only
 
@@ -85,7 +85,7 @@ correct, not a bug), and it is a Selenium read, so it rides the same 429 breaker
 version added **member post stats**. If that surface exposes impressions/saves for the authenticated
 member, it would replace this Selenium scrape with an API read that no SDUI churn or 429 can break.
 That is a token probe, not a browser session — cheap to settle, and worth settling before investing
-further in scraping. Filed as a follow-up rather than folded into this spike.
+further in scraping. Filed as **#645** rather than folded into this spike.
 
 ## 3. Selector map (with provenance)
 
@@ -135,14 +135,15 @@ what need updating.
 
 **C1 (#390) — native document posts:** implementation complete (publish path, `PostType.DOCUMENT`,
 balancer, migration). Remaining: publish one document post on the live account and run check 1 to
-confirm it renders as a document card. No code change is expected; if the verdict comes back `image`,
+confirm it renders as a document card — tracked as **#644** (`risk:live-linkedin`, `priority:high`),
+so R1 (#404) closes with this note. No code change is expected; if the verdict comes back `image`,
 the legacy fallback silently took over and the finding is an API-provisioning bug, not a format bug.
 
 **B2 (#387) — reposts/impressions/saves:** implementation complete and consistent with the live
-layout as of 2026-07-23. Remaining: none from this spike. Recommended (separate issues, not this PR):
-probe the `202506` member-post-stats API as a churn-proof replacement for the analytics scrape, and
-fold the analytics-page rows into the F2 (#403) selector-liveness sweep so drift is detected by cron
-rather than by a run of zeroes.
+layout as of 2026-07-23. Remaining: none from this spike. Split out as separate issues:
+**#645** probes the `202506` member-post-stats API as a churn-proof replacement for the analytics
+scrape, and its "keep the scrape" outcome folds the analytics-page rows into the F2 (#403)
+selector-liveness sweep so drift is detected by cron rather than by a run of zeroes.
 
 ## Sources
 

--- a/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
+++ b/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
@@ -1,0 +1,153 @@
+# Live Validation — Document Post Path & Saves/Impressions Scraping
+
+**Spike:** R1 / issue #404 — "Live LinkedIn validation: document post path + saves/impressions scraping"
+**Grounds:** C1 (#390, native document/PDF posts) and B2 (#387, capture reposts/impressions/saves)
+**Date:** 2026-07-26 · **Probe:** `scripts/linkedin_live_validation.py` (read-only)
+
+## TL;DR
+
+| Question | Answer | Evidence grade |
+|---|---|---|
+| Document post publish path — **API or UI**? | **API.** Versioned `/rest/documents` → `/rest/posts`. No Selenium composer is used, or needed. | **Documented + shipped** (R3 #406 against `li-lms-2026-07`; `poster.py`) |
+| Current **SDUI anchors for document upload** | **None exist in LEM and none are invented here** — the UI path is not on the publish route. Capturable on demand via `--probe-composer`. | **Deliberately unmapped** |
+| Does a published document render as a **document card**? | Unconfirmed — needs one live post. | **OPEN** (C1's own acceptance) |
+| Are **saves** scrapeable? | **Yes**, own posts only, on `/analytics/post-summary/<activity-urn>/`. | **Live grab 2026-07-23** (encoded in `_stacked_counts`) |
+| Are **impressions** scrapeable? | **Yes**, same page (Discovery hero, value-first layout). Blank on the post detail view. | **Live grab 2026-07-23** |
+
+**Net scope change: none for B2, one live confirmation left for C1.** Both features are built and
+merged; this spike's job was to say whether their assumptions hold, and they do. What is genuinely
+unresolved is a single end-to-end act — publish one native document and look at it — which needs a
+real account and so is the owner's call, not the agent's.
+
+> **Honesty note.** This note was written headless: no LinkedIn session was driven. Every row above
+> carries its evidence grade, and no DOM selector appears here that was not either (a) already in the
+> repo or (b) captured in the 2026-07-23 owner grab. Rather than guess at the document-composer
+> anchors, the probe script captures them on a live session in one command.
+
+---
+
+## 1. Document posts publish through the API, not the UI
+
+`share_document_on_linkedin` (`utilities/linkedin/poster.py:439`) is the whole path, and it is HTTP
+only:
+
+1. `POST /rest/documents?action=initializeUpload` → `uploadUrl` + `urn:li:document:…` (`upload_document`)
+2. `PUT` the PDF bytes to `uploadUrl`
+3. `POST /rest/posts` with `content.media = {title, id: <document urn>}` (`_create_document_post_versioned`)
+
+with `_create_document_post_legacy` (assets upload + `ugcPost` `shareMediaCategory=DOCUMENT`) as the
+fallback for a token whose app is not provisioned for the versioned API. Routing is wired end to end:
+`PostType.DOCUMENT` (`db.py:186`, migration `V20260723234736`), the content-plan balancer
+(`run_content_plan.py:65`), and the publish switch (`run_automation.py:5172`).
+
+**Why there is no SDUI anchor map for document upload.** LEM never opens the composer to publish a
+document, so no anchors exist to drift — the failure modes are HTTP ones (`426` retired version, `403`
+unprovisioned app), and both are already handled: an explicit 426 `log_error` in `upload_document`,
+plus the weekly `scripts/linkedin_version_check.py` cron that keeps `LI_API_VERSION` inside the live
+window. Writing a speculative composer selector chain here would create the maintenance burden it
+claims to remove. If a UI fallback ever becomes necessary (app deprovisioned with no versioned path
+left), `--probe-composer` dumps the composer's real control labels in one run — see §4.
+
+**What is still open for C1** is not the path but the *product* claim behind it: that the API-published
+deck renders in-feed as a swipeable **document**, not a multi-image share. `probe_document_render`
+answers this by capturing the media anchors of a published post (§4, check 2). It needs one document
+post to exist on the account first — that publish is C1's acceptance step and is human-gated
+(`risk:live-linkedin`).
+
+## 2. Saves and impressions are scrapeable — on the author's analytics page only
+
+| Signal | Post detail page | `/analytics/post-summary/<urn>/` | Stored as |
+|---|---|---|---|
+| reactions | ✅ social bar | ✅ Engagement breakdown | `post_stats.reactions` |
+| comments | ✅ social bar | ✅ Engagement breakdown | `post_stats.comments` |
+| reposts | ✅ social bar ("reposts", older UIs "shares") | ✅ Engagement breakdown | `post_stats.reposts` |
+| **impressions** | ❌ not rendered | ✅ **Discovery hero** | `post_stats.impressions` (nullable) |
+| **saves** | ❌ not rendered | ✅ Engagement breakdown | `post_stats.saves` (migration `V20260723211520`) |
+
+Three properties of that page, all from the 2026-07-23 owner grab and already encoded in
+`run_automation.py`:
+
+- **The URN differs from the permalink's.** The logged permalink carries a `share`/`ugcPost` URN;
+  analytics keys off the **activity** URN LinkedIn redirects to. `_post_analytics_counts` therefore
+  resolves the URN from `driver.current_url` *after* the redirect, falling back to the stored URL.
+- **Label and value are separate elements, in opposite orders.** The Discovery hero reads value-first
+  (`72` / `Impressions`); the Engagement breakdown reads label-first (`Reposts` / `0`). `_stacked_counts`
+  pairs a label line only with an adjacent **bare count** line, which is what keeps prose like
+  "Save this checklist" out of the numbers.
+- **Merge by max, never overwrite.** `auto_scrape_post_stats` takes `max(detail, analytics)` per signal
+  so a view that does not render a signal cannot zero out one the other view did.
+
+**Access limits worth knowing:** the analytics page exists only for the **author's own** posts, so
+saves/impressions are unavailable for third-party feed posts (`_post_social_counts` returns 0 there —
+correct, not a bug), and it is a Selenium read, so it rides the same 429 breaker as the rest.
+
+**Follow-up lead (not verified here):** R3 recorded that LinkedIn's `202506` Community Management
+version added **member post stats**. If that surface exposes impressions/saves for the authenticated
+member, it would replace this Selenium scrape with an API read that no SDUI churn or 429 can break.
+That is a token probe, not a browser session — cheap to settle, and worth settling before investing
+further in scraping. Filed as a follow-up rather than folded into this spike.
+
+## 3. Selector map (with provenance)
+
+Nothing below is a guess; the provenance column says where each came from.
+
+| What | Locator | Used by | Provenance |
+|---|---|---|---|
+| Post detail / analytics container | `By.TAG_NAME, "main"` | `auto_scrape_post_stats`, `_post_analytics_counts` | in-repo, live-used |
+| Analytics page | `https://www.linkedin.com/analytics/post-summary/{activity_urn}/` | `_ANALYTICS_URL` | live grab 2026-07-23 |
+| Impressions row | line pair `<count>` → `Impressions` (value-first) | `_stacked_counts` / `_STACKED_VALUE_FIRST` | live grab 2026-07-23 |
+| Reactions/comments/reposts/saves rows | line pair `<Label>` → `<count>` (label-first) | `_stacked_counts` / `_STACKED_LABEL_FIRST` | live grab 2026-07-23 |
+| Social-bar counts (detail view) | regex `<count> <label>` on the card text | `_COMMENTS_RE` … `_SAVES_RE` | in-repo, live-used |
+| Post permalink on a feed card | `a[href*='/feed/update/']` | `_post_permalink_from_card` | in-repo, live-used |
+| Feed composer trigger | `//button[contains(normalize-space(),'Start a post') or contains(@aria-label,'Start a post') or contains(@aria-label,'Create a post')]` | `auto_post_to_group`, `probe_composer` | in-repo, **best-effort / unvalidated** (F2 #403) |
+| Document upload control | — | — | **unmapped by design** (§1); `--probe-composer` captures it |
+| Document media card | — | — | **unmapped**; `probe_document_render` captures it |
+
+## 4. Running the live validation
+
+`scripts/linkedin_live_validation.py` is read-only: it navigates and reads, publishes nothing,
+comments on nothing, and changes no settings. `scripts/` is not baked into the image, so pipe it in
+on stdin exactly like the weekly version probe does:
+
+```bash
+sudo docker exec -i celery_worker_selenium python - \
+    --user-id 1 --post-url 'https://www.linkedin.com/feed/update/urn:li:activity:<id>/' \
+    < scripts/linkedin_live_validation.py
+```
+
+It emits one JSON report:
+
+1. **`document_render`** — the media anchors the post renders (`data-testid` / `class` / `aria-label`)
+   plus a `document` / `image` / `unknown` verdict. Run it against a **document** post to close C1's
+   acceptance, and against an existing carousel post first as a control.
+2. **`post_stats`** — per signal, whether a non-zero value came from the detail page, the analytics
+   page, both, or neither, plus the raw label neighbourhoods from each page so a `0` can be read as
+   "the post has none" versus "the layout drifted".
+3. **`composer`** *(only with `--probe-composer`)* — the composer's control labels and any
+   document-upload affordance among them. It opens the composer and closes it with Escape; nothing is
+   attached or posted.
+
+Paste the JSON into #404. If `post_stats` shows a signal sourced from `none` while the analytics page
+plainly shows a number, the `*_lines` arrays contain the drifted layout and this note's §3 rows are
+what need updating.
+
+## 5. Scope updates
+
+**C1 (#390) — native document posts:** implementation complete (publish path, `PostType.DOCUMENT`,
+balancer, migration). Remaining: publish one document post on the live account and run check 1 to
+confirm it renders as a document card. No code change is expected; if the verdict comes back `image`,
+the legacy fallback silently took over and the finding is an API-provisioning bug, not a format bug.
+
+**B2 (#387) — reposts/impressions/saves:** implementation complete and consistent with the live
+layout as of 2026-07-23. Remaining: none from this spike. Recommended (separate issues, not this PR):
+probe the `202506` member-post-stats API as a churn-proof replacement for the analytics scrape, and
+fold the analytics-page rows into the F2 (#403) selector-liveness sweep so drift is detected by cron
+rather than by a run of zeroes.
+
+## Sources
+
+- `docs/FORMAT_API_FEASIBILITY.md` (R3 / #406) — API surface for documents, articles, newsletters.
+- In-repo: `utilities/linkedin/poster.py` (document API path), `app/run_automation.py`
+  (`_post_social_counts`, `_stacked_counts`, `_post_analytics_counts`, `auto_scrape_post_stats`),
+  `utilities/db.py` (`record_post_stats`, `PostType`).
+- Migrations `V20260723211520__add_post_stats_saves.sql`, `V20260723234736__add_document_post_type.sql`.

--- a/scripts/linkedin_live_validation.py
+++ b/scripts/linkedin_live_validation.py
@@ -122,7 +122,7 @@ def classify_media_anchor(anchor: dict) -> str:
     return "unknown"
 
 
-def media_verdict(anchors: list) -> str:
+def media_verdict(anchors: Optional[list[dict]]) -> str:
     """Overall render kind. A document post also carries image nodes (the rendered page
     thumbnails), so a single document token decides it; only the absence of one makes it an
     image share."""
@@ -134,7 +134,7 @@ def media_verdict(anchors: list) -> str:
     return "unknown"
 
 
-def find_document_affordance(labels: list) -> Optional[str]:
+def find_document_affordance(labels: Optional[list[str]]) -> Optional[str]:
     """The composer control that starts a document upload, by its visible/aria label."""
     for label in labels or []:
         if "document" in (label or "").lower():

--- a/scripts/linkedin_live_validation.py
+++ b/scripts/linkedin_live_validation.py
@@ -72,7 +72,7 @@ return out;
 """
 
 
-def label_lines(text: str) -> list:
+def label_lines(text: Optional[str]) -> list[str]:
     """Every recognized count label with its neighbouring lines, as 'prev | line | next'.
 
     This is the drift check: the parser pairs a label with an adjacent bare count, so the raw
@@ -134,7 +134,7 @@ def media_verdict(anchors: Optional[list[dict]]) -> str:
     return "unknown"
 
 
-def find_document_affordance(labels: Optional[list[str]]) -> Optional[str]:
+def find_document_affordance(labels: Optional[list[Optional[str]]]) -> Optional[str]:
     """The composer control that starts a document upload, by its visible/aria label."""
     for label in labels or []:
         if "document" in (label or "").lower():
@@ -227,12 +227,16 @@ def probe_composer(driver, sleep=time.sleep) -> dict:
             label = (button.get_attribute("aria-label") or button.text or "").strip()
             if label:
                 controls.append(label)
-    except Exception:
-        pass
+    except Exception as e:
+        # Best-effort capture: the composer re-renders while we enumerate, so a stale element
+        # mid-loop is expected. Report whatever we collected instead of losing the whole probe.
+        controls.append(f"<enumeration stopped: {type(e).__name__}>")
 
     try:
         ActionChains(driver).send_keys(Keys.ESCAPE).perform()
     except Exception:
+        # Closing the composer is courtesy only — the driver is quit right after in main(), and
+        # a failed Escape must not mask the anchors this probe exists to report.
         pass
     return {"opened": True, "controls": controls,
             "document_affordance": find_document_affordance(controls)}

--- a/scripts/linkedin_live_validation.py
+++ b/scripts/linkedin_live_validation.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Live LinkedIn validation probe — R1 spike (issue #404).
+
+Answers, against a REAL logged-in session, the two questions
+``docs/LIVE_VALIDATION_FORMAT_AND_STATS.md`` cannot settle from the desk:
+
+  1. Does a published native document post render as a DOCUMENT card (and what DOM tokens
+     identify it), or as a multi-image share? — grounds C1 (#390).
+  2. Which of reactions/comments/reposts/impressions/saves are actually scrapeable, and from
+     which page — the post detail view or ``/analytics/post-summary/``? — grounds B2 (#387).
+
+**Read-only.** It navigates and reads: it publishes nothing, comments on nothing, sends no
+invites or DMs and changes no settings. ``--probe-composer`` additionally OPENS the post
+composer to capture the "add a document" affordance's anchors and closes it with Escape without
+attaching or posting anything.
+
+Run it from inside a Selenium worker so the login/cookie/proxy stack is the production one
+(``scripts/`` is not baked into the image, so pipe the file in on stdin, the same way
+``weekly_linkedin_version_check.sh`` runs the version probe)::
+
+    sudo docker exec -i celery_worker_selenium python - \
+        --user-id 1 --post-url 'https://www.linkedin.com/feed/update/urn:li:activity:123/' \
+        < scripts/linkedin_live_validation.py
+
+The report is JSON on stdout — paste it into the issue. The parsing/verdict logic is pure and
+unit-tested; the browser steps take injected callables so they are mocked in tests.
+"""
+
+import argparse
+import json
+import sys
+import time
+from typing import Optional
+
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+
+SIGNALS = ("reactions", "comments", "reposts", "impressions", "saves")
+ANALYTICS_URL = "https://www.linkedin.com/analytics/post-summary/{urn}/"
+FEED_URL = "https://www.linkedin.com/feed/"
+
+# Whole-line labels worth echoing back with their neighbours. The analytics page renders each
+# label and its value in separate elements, so seeing the neighbouring lines is what tells us
+# whether the layout is still value-first ("72 / Impressions") or label-first ("Reposts / 0")
+# — i.e. whether _stacked_counts still matches reality.
+_LABELS = frozenset({"reactions", "comments", "reposts", "shares", "saves", "impressions"})
+
+# A media container's identity lives in its data-testid / class / aria-label. Documents and
+# image shares are DIFFERENT feed objects, so the token that appears here is the answer to "did
+# this publish as a native document?".
+_DOC_TOKENS = ("document",)
+_IMAGE_TOKENS = ("image", "carousel")
+_MEDIA_TOKENS = _DOC_TOKENS + _IMAGE_TOKENS
+
+# Collect the media-bearing nodes under <main> without asserting any selector we have not seen
+# live: match on the tokens above across the attributes SDUI actually keys off.
+_MEDIA_JS = """
+const out = [];
+const root = document.querySelector('main') || document.body;
+for (const el of root.querySelectorAll('[data-testid],[class],[aria-label]')) {
+  const attrs = {
+    tag: el.tagName.toLowerCase(),
+    testid: el.getAttribute('data-testid') || '',
+    cls: el.getAttribute('class') || '',
+    aria: el.getAttribute('aria-label') || '',
+  };
+  const blob = (attrs.testid + ' ' + attrs.cls + ' ' + attrs.aria).toLowerCase();
+  if (arguments[0].some(t => blob.includes(t))) { out.push(attrs); }
+  if (out.length >= 40) { break; }
+}
+return out;
+"""
+
+
+def label_lines(text: str) -> list:
+    """Every recognized count label with its neighbouring lines, as 'prev | line | next'.
+
+    This is the drift check: the parser pairs a label with an adjacent bare count, so the raw
+    neighbourhood is exactly what a reviewer needs to see when a signal comes back 0.
+    """
+    lines = [ln.strip() for ln in (text or "").splitlines()]
+    lines = [ln for ln in lines if ln]
+    out = []
+    for i, line in enumerate(lines):
+        if line.lower().rstrip(":") in _LABELS:
+            prev = lines[i - 1] if i else ""
+            nxt = lines[i + 1] if i + 1 < len(lines) else ""
+            out.append(f"{prev} | {line} | {nxt}")
+    return out
+
+
+def signal_sources(detail: dict, analytics: dict) -> dict:
+    """Per signal, which page actually yielded a non-zero value.
+
+    'none' is a real finding, not a failure: it means that signal is not scrapeable from either
+    page for this post (or the post genuinely has none of it — the raw lines disambiguate).
+    """
+    out = {}
+    for signal in SIGNALS:
+        detail_value = int(detail.get(signal) or 0)
+        analytics_value = int(analytics.get(signal) or 0)
+        if detail_value and analytics_value:
+            source = "both"
+        elif detail_value:
+            source = "detail"
+        elif analytics_value:
+            source = "analytics"
+        else:
+            source = "none"
+        out[signal] = {"detail": detail_value, "analytics": analytics_value,
+                       "source": source, "value": max(detail_value, analytics_value)}
+    return out
+
+
+def classify_media_anchor(anchor: dict) -> str:
+    """'document' / 'image' / 'unknown' for one captured media node."""
+    blob = " ".join(str(v) for v in anchor.values()).lower()
+    if any(token in blob for token in _DOC_TOKENS):
+        return "document"
+    if any(token in blob for token in _IMAGE_TOKENS):
+        return "image"
+    return "unknown"
+
+
+def media_verdict(anchors: list) -> str:
+    """Overall render kind. A document post also carries image nodes (the rendered page
+    thumbnails), so a single document token decides it; only the absence of one makes it an
+    image share."""
+    kinds = {classify_media_anchor(a) for a in anchors or []}
+    if "document" in kinds:
+        return "document"
+    if "image" in kinds:
+        return "image"
+    return "unknown"
+
+
+def find_document_affordance(labels: list) -> Optional[str]:
+    """The composer control that starts a document upload, by its visible/aria label."""
+    for label in labels or []:
+        if "document" in (label or "").lower():
+            return label
+    return None
+
+
+def _social_counts(container) -> dict:
+    # Imported lazily: the probe must exercise the SAME parser the scraper ships (#387), but
+    # importing the Celery module at load time would drag the whole task graph into the tests.
+    from cqc_lem.app.run_automation import _post_social_counts
+    return _post_social_counts(container)
+
+
+def _activity_urn(driver, post_url: str) -> Optional[str]:
+    from cqc_lem.utilities.linkedin.poster import object_urn_from_post_url
+    current = getattr(driver, "current_url", None)
+    return (object_urn_from_post_url(current if isinstance(current, str) else "")
+            or object_urn_from_post_url(post_url or ""))
+
+
+def _read_main(driver, counts_fn) -> tuple:
+    try:
+        container = driver.find_element(By.TAG_NAME, "main")
+    except Exception:
+        return "", {}
+    try:
+        text = container.text or ""
+    except Exception:
+        text = ""
+    return text, counts_fn(container)
+
+
+def probe_post_stats(driver, post_url: str, counts_fn=_social_counts, sleep=time.sleep) -> dict:
+    """B2: read the counts off the post detail page, then off the author's analytics page."""
+    driver.get(post_url)
+    sleep(5)
+    detail_text, detail_counts = _read_main(driver, counts_fn)
+
+    urn = _activity_urn(driver, post_url)
+    analytics_text, analytics_counts = "", {}
+    if urn:
+        driver.get(ANALYTICS_URL.format(urn=urn))
+        sleep(5)
+        analytics_text, analytics_counts = _read_main(driver, counts_fn)
+
+    return {"post_url": post_url, "activity_urn": urn,
+            "signals": signal_sources(detail_counts, analytics_counts),
+            "detail_lines": label_lines(detail_text),
+            "analytics_lines": label_lines(analytics_text)}
+
+
+def probe_document_render(driver, post_url: str, sleep=time.sleep) -> dict:
+    """C1: capture the media anchors a published post renders, so 'native document vs
+    multi-image share' stops being an assumption."""
+    driver.get(post_url)
+    sleep(5)
+    try:
+        anchors = driver.execute_script(_MEDIA_JS, list(_MEDIA_TOKENS)) or []
+    except Exception as e:
+        return {"post_url": post_url, "verdict": "unknown", "error": str(e), "anchors": []}
+    return {"post_url": post_url, "verdict": media_verdict(anchors),
+            "anchors": [dict(a, kind=classify_media_anchor(a)) for a in anchors]}
+
+
+def probe_composer(driver, sleep=time.sleep) -> dict:
+    """Open the feed composer, capture its attach-control labels (the document-upload anchors
+    LEM has never needed, because documents publish through the API), then close it."""
+    from cqc_lem.utilities.selenium_util import click_first, find_first
+    from selenium.webdriver import ActionChains
+    from selenium.webdriver.support.ui import WebDriverWait
+
+    wait = WebDriverWait(driver, 10)
+    driver.get(FEED_URL)
+    sleep(5)
+    # Same locator chain auto_post_to_group uses for the share box — one composer, one map.
+    opened = click_first(driver, wait, [(By.XPATH,
+        "//button[contains(normalize-space(),'Start a post') or contains(@aria-label,'Start a post') "
+        "or contains(@aria-label,'Create a post')]")], "Composer share box", required=False)
+    if opened is None:
+        return {"opened": False, "controls": [], "document_affordance": None}
+    sleep(3)
+
+    dialog = find_first(driver, wait, [(By.CSS_SELECTOR, "div[role='dialog']")], "Composer dialog",
+                        visible_only=True, required=False)
+    controls = []
+    root = dialog if dialog is not None else driver
+    try:
+        for button in root.find_elements(By.TAG_NAME, "button"):
+            label = (button.get_attribute("aria-label") or button.text or "").strip()
+            if label:
+                controls.append(label)
+    except Exception:
+        pass
+
+    try:
+        ActionChains(driver).send_keys(Keys.ESCAPE).perform()
+    except Exception:
+        pass
+    return {"opened": True, "controls": controls,
+            "document_affordance": find_document_affordance(controls)}
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description="Read-only live LinkedIn validation probe (#404)")
+    parser.add_argument("--user-id", type=int, default=1, help="user whose session drives the probe")
+    parser.add_argument("--post-url", help="permalink of one of that user's OWN published posts")
+    parser.add_argument("--probe-composer", action="store_true",
+                        help="also open the post composer to capture document-upload anchors")
+    args = parser.parse_args(argv)
+
+    if not args.post_url and not args.probe_composer:
+        parser.error("nothing to probe — pass --post-url and/or --probe-composer")
+
+    from cqc_lem.app.run_automation import get_current_profile
+    from cqc_lem.utilities.selenium_util import quit_gracefully
+
+    driver, _wait, _email, _profile = get_current_profile(user_id=args.user_id,
+                                                         session_name="Live Validation")
+    report = {"user_id": args.user_id}
+    try:
+        if args.post_url:
+            report["document_render"] = probe_document_render(driver, args.post_url)
+            report["post_stats"] = probe_post_stats(driver, args.post_url)
+        if args.probe_composer:
+            report["composer"] = probe_composer(driver)
+    finally:
+        quit_gracefully(driver)
+
+    print(json.dumps(report, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit/test_linkedin_live_validation.py
+++ b/tests/unit/test_linkedin_live_validation.py
@@ -162,6 +162,20 @@ class TestProbeComposer:
         assert report["opened"] is True
         assert report["document_affordance"] == "Add a document"
 
+    def test_a_stale_control_mid_enumeration_still_reports_what_was_captured(self, monkeypatch):
+        driver = MagicMock()
+        dialog = MagicMock()
+        dialog.find_elements.side_effect = Exception("stale element")
+        monkeypatch.setattr("cqc_lem.utilities.selenium_util.click_first",
+                            lambda *a, **k: MagicMock())
+        monkeypatch.setattr("cqc_lem.utilities.selenium_util.find_first",
+                            lambda *a, **k: dialog)
+
+        report = llv.probe_composer(driver, sleep=lambda s: None)
+        assert report["opened"] is True
+        assert report["controls"] == ["<enumeration stopped: Exception>"]
+        assert report["document_affordance"] is None
+
     def test_reports_a_composer_that_never_opened(self, monkeypatch):
         monkeypatch.setattr("cqc_lem.utilities.selenium_util.click_first", lambda *a, **k: None)
         report = llv.probe_composer(MagicMock(), sleep=lambda s: None)

--- a/tests/unit/test_linkedin_live_validation.py
+++ b/tests/unit/test_linkedin_live_validation.py
@@ -1,0 +1,175 @@
+"""Unit tests for the live LinkedIn validation probe (scripts/linkedin_live_validation.py)."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "linkedin_live_validation.py"
+_spec = importlib.util.spec_from_file_location("linkedin_live_validation", SCRIPT)
+llv = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(llv)
+
+# The two layouts the 2026-07-23 owner grab found on /analytics/post-summary/: the Discovery hero
+# stacks value-first, the Engagement breakdown label-first.
+ANALYTICS_TEXT = "Discovery\n72\nImpressions\nEngagement\nReactions\n4\nComments\n1\nReposts\n0\nSaves\n3"
+
+
+def _fake_driver(text: str = "", current_url: str = ""):
+    driver = MagicMock()
+    element = MagicMock()
+    element.text = text
+    driver.find_element.return_value = element
+    driver.current_url = current_url
+    return driver
+
+
+@pytest.mark.unit
+class TestLabelLines:
+    def test_captures_each_label_with_its_neighbours(self):
+        lines = llv.label_lines(ANALYTICS_TEXT)
+        assert "72 | Impressions | Engagement" in lines
+        assert "Engagement | Reactions | 4" in lines
+        assert "1 | Reposts | 0" in lines
+
+    def test_ignores_prose_that_merely_contains_a_label_word(self):
+        assert llv.label_lines("Save this checklist for later\nSomething else") == []
+
+    def test_blank_text_is_empty(self):
+        assert llv.label_lines("") == []
+        assert llv.label_lines(None) == []
+
+
+@pytest.mark.unit
+class TestSignalSources:
+    def test_attributes_each_signal_to_the_page_that_yielded_it(self):
+        out = llv.signal_sources({"reactions": 4, "comments": 1},
+                                 {"reactions": 4, "impressions": 72, "saves": 3})
+        assert out["reactions"]["source"] == "both"
+        assert out["comments"]["source"] == "detail"
+        assert out["impressions"]["source"] == "analytics"
+        assert out["saves"]["source"] == "analytics"
+        assert out["reposts"]["source"] == "none"
+
+    def test_value_is_the_max_so_a_blank_view_cannot_zero_a_signal(self):
+        out = llv.signal_sources({"impressions": 0}, {"impressions": 72})
+        assert out["impressions"]["value"] == 72
+
+    def test_missing_and_none_values_are_treated_as_zero(self):
+        out = llv.signal_sources({}, {"saves": None})
+        assert out["saves"] == {"detail": 0, "analytics": 0, "source": "none", "value": 0}
+
+
+@pytest.mark.unit
+class TestMediaClassification:
+    def test_document_token_wins_over_image_nodes(self):
+        anchors = [{"testid": "", "cls": "update-components-image", "aria": ""},
+                   {"testid": "document-container", "cls": "", "aria": ""}]
+        assert llv.media_verdict(anchors) == "document"
+
+    def test_image_share_has_no_document_token(self):
+        anchors = [{"testid": "", "cls": "update-components-image", "aria": "carousel"}]
+        assert llv.media_verdict(anchors) == "image"
+
+    def test_no_anchors_is_unknown_not_a_verdict(self):
+        assert llv.media_verdict([]) == "unknown"
+        assert llv.classify_media_anchor({"cls": "feed-shared-text"}) == "unknown"
+
+    def test_aria_label_alone_identifies_a_document(self):
+        assert llv.classify_media_anchor({"aria": "Document: 2026 playbook"}) == "document"
+
+
+@pytest.mark.unit
+class TestFindDocumentAffordance:
+    def test_matches_the_add_a_document_control(self):
+        assert llv.find_document_affordance(["Add a photo", "Add a document"]) == "Add a document"
+
+    def test_returns_none_when_the_composer_offers_no_document_control(self):
+        assert llv.find_document_affordance(["Add a photo", "Celebrate an occasion"]) is None
+        assert llv.find_document_affordance(None) is None
+
+
+@pytest.mark.unit
+class TestProbePostStats:
+    def test_visits_the_analytics_page_for_the_redirected_activity_urn(self, monkeypatch):
+        driver = _fake_driver(ANALYTICS_TEXT,
+                              current_url="https://www.linkedin.com/feed/update/urn:li:activity:99/")
+        monkeypatch.setattr(llv, "_activity_urn", lambda d, u: "urn:li:activity:99")
+        report = llv.probe_post_stats(driver, "https://www.linkedin.com/feed/update/urn:li:share:1/",
+                                      counts_fn=lambda c: {"impressions": 72, "saves": 3},
+                                      sleep=lambda s: None)
+
+        assert report["activity_urn"] == "urn:li:activity:99"
+        assert driver.get.call_args_list[-1][0][0] == \
+            "https://www.linkedin.com/analytics/post-summary/urn:li:activity:99/"
+        assert report["signals"]["saves"]["value"] == 3
+        assert "72 | Impressions | Engagement" in report["analytics_lines"]
+
+    def test_skips_the_analytics_hop_when_no_urn_resolves(self, monkeypatch):
+        driver = _fake_driver("4 reactions")
+        monkeypatch.setattr(llv, "_activity_urn", lambda d, u: None)
+        report = llv.probe_post_stats(driver, "https://example.com/not-a-post",
+                                      counts_fn=lambda c: {"reactions": 4}, sleep=lambda s: None)
+
+        assert driver.get.call_count == 1
+        assert report["signals"]["reactions"]["source"] == "detail"
+        assert report["analytics_lines"] == []
+
+    def test_a_missing_main_container_yields_empty_counts_not_a_crash(self, monkeypatch):
+        driver = MagicMock()
+        driver.find_element.side_effect = Exception("no main")
+        monkeypatch.setattr(llv, "_activity_urn", lambda d, u: None)
+        report = llv.probe_post_stats(driver, "https://www.linkedin.com/feed/update/urn:li:share:1/",
+                                      counts_fn=lambda c: {"reactions": 4}, sleep=lambda s: None)
+        assert report["signals"]["reactions"]["source"] == "none"
+
+
+@pytest.mark.unit
+class TestProbeDocumentRender:
+    def test_reports_the_verdict_and_tags_each_anchor(self):
+        driver = MagicMock()
+        driver.execute_script.return_value = [{"tag": "div", "testid": "document-container",
+                                               "cls": "", "aria": ""}]
+        report = llv.probe_document_render(driver, "https://www.linkedin.com/feed/update/x/",
+                                           sleep=lambda s: None)
+        assert report["verdict"] == "document"
+        assert report["anchors"][0]["kind"] == "document"
+
+    def test_a_script_failure_is_reported_not_raised(self):
+        driver = MagicMock()
+        driver.execute_script.side_effect = Exception("boom")
+        report = llv.probe_document_render(driver, "https://www.linkedin.com/feed/update/x/",
+                                           sleep=lambda s: None)
+        assert report["verdict"] == "unknown"
+        assert "boom" in report["error"]
+
+
+@pytest.mark.unit
+class TestProbeComposer:
+    def test_captures_control_labels_and_the_document_affordance(self, monkeypatch):
+        driver = MagicMock()
+        button = MagicMock()
+        button.get_attribute.return_value = "Add a document"
+        dialog = MagicMock()
+        dialog.find_elements.return_value = [button]
+        monkeypatch.setattr("cqc_lem.utilities.selenium_util.click_first",
+                            lambda *a, **k: MagicMock())
+        monkeypatch.setattr("cqc_lem.utilities.selenium_util.find_first",
+                            lambda *a, **k: dialog)
+
+        report = llv.probe_composer(driver, sleep=lambda s: None)
+        assert report["opened"] is True
+        assert report["document_affordance"] == "Add a document"
+
+    def test_reports_a_composer_that_never_opened(self, monkeypatch):
+        monkeypatch.setattr("cqc_lem.utilities.selenium_util.click_first", lambda *a, **k: None)
+        report = llv.probe_composer(MagicMock(), sleep=lambda s: None)
+        assert report == {"opened": False, "controls": [], "document_affordance": None}
+
+
+@pytest.mark.unit
+class TestMain:
+    def test_requires_something_to_probe(self):
+        with pytest.raises(SystemExit):
+            llv.main([])


### PR DESCRIPTION
## What & why

R1 (#404) is the live-validation spike behind **C1 (#390, native document posts)** and **B2 (#387, reposts/impressions/saves)**. It asks two questions and wants a findings note + selector map back.

**Answers:**

| Question | Answer | Evidence |
|---|---|---|
| Document publish path — API or UI? | **API** — versioned `/rest/documents` → `/rest/posts`. The composer is never opened. | R3 (#406) + shipped `poster.py` path |
| Current SDUI anchors for document upload | **None exist, and none are invented here** — the UI is not on the publish route. Capturable on demand. | see note §1 |
| Are saves scrapeable? | **Yes** — `/analytics/post-summary/<activity-urn>/`, author's own posts only. | live grab 2026-07-23, already encoded in `_stacked_counts` |
| Are impressions scrapeable? | **Yes** — same page (Discovery hero, value-first layout); blank on the post detail view. | same |

**Net scope change: none for B2; C1 has exactly one live confirmation left** — publish one document post and check it renders as a document card rather than a multi-image share. That act needs a real account, which is why this is held.

## What's in the diff

- `docs/LIVE_VALIDATION_FORMAT_AND_STATS.md` — the findings note: publish-path verdict, the saves/impressions availability table, the three gotchas the analytics page carries (share-URN → activity-URN redirect, the two *opposite* stacked layouts, merge-by-max), a **selector map with a provenance column**, and updated C1/B2 scope.
- `scripts/linkedin_live_validation.py` — a **read-only** probe that closes the remaining live questions in one command. It navigates and reads: publishes nothing, comments on nothing, changes no settings. `--probe-composer` opens the composer to capture the document-upload control labels and closes it with Escape without attaching or posting.
- `tests/unit/test_linkedin_live_validation.py` — 20 unit tests over the parsing/verdict logic and all three probes (driver mocked), mirroring the `linkedin_version_check.py` test pattern.

## Honesty note

This ran headless — **no LinkedIn session was driven.** Every claim in the note carries an evidence grade, and no selector appears that wasn't already in the repo or captured in the 2026-07-23 owner grab. Rather than guess at the document-composer anchors, the probe captures them live.

## Testing

- `pytest tests/unit/test_linkedin_live_validation.py -q` → 20 passed
- Full unit suite → 5687 passed
- No source, schema, or runtime behaviour changes: doc + script + tests only.

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)