### PR TITLE
fix(outreach): activate the network flywheel — clean names, skip 1st-degree, source the funnel, unblock DM nurture (closes #623)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,6 +189,15 @@ DM_NURTURE_INTENT_LLM_ENABLED=true
 # sourcing scan may file per user, independent of their max_invites_per_day. Keeps sourcing a
 # trickle of high-fit people rather than a queue that looks like list-blasting.
 MAX_NEW_CONNECT_TARGETS_PER_SCAN=5
+# Network activation (issue #623). The stock DM templates are step-0 only, so a sequence used to end
+# the moment the first DM went out and nobody's reply was ever read. When a step has no next
+# template we now come back after this many hours to look for a reply — a reply becomes an
+# approval-gated nurture draft, silence ends the sequence as before.
+DM_REPLY_CHECK_DELAY_HOURS=48
+# Outreach-funnel sourcing: how many NEW comment->connect->DM targets one scan may file per user,
+# and how deep the approval backlog may get before sourcing stops adding to it.
+MAX_NEW_FUNNEL_TARGETS_PER_SCAN=5
+MAX_OPEN_FUNNEL_TARGETS=25
 
 # --- Ollama (local + cloud model hosting) ---
 OLLAMA_API_KEY=your_ollama_api_key

--- a/compose/local/database/migrations/V20260726074650__add_network_activation_fields.sql
+++ b/compose/local/database/migrations/V20260726074650__add_network_activation_fields.sql
@@ -1,0 +1,18 @@
+-- Network activation (issue #623). The 2026-07-26 production audit found the whole outbound layer
+-- idle: connection_requests had ONE row ever (it targeted an existing 1st-degree connection, with
+-- LinkedIn badge text scraped into the name), outreach_funnel_targets and scheduled_dms had none.
+-- Two columns close the two data gaps behind that.
+
+-- The connection-degree badge LinkedIn renders next to an engager's name, captured at scrape time.
+-- Without it the connection-targeting scan cannot tell a 2nd-degree prospect (worth an invite) from
+-- someone we are ALREADY connected to (an invite that can only fail). VARCHAR, not ENUM: LinkedIn
+-- has renamed these badges before and adding an ENUM value costs a migration (see CLAUDE.md).
+-- NULL means "LinkedIn didn't render a badge" — unknown, NOT "not connected".
+ALTER TABLE post_engagers
+    ADD COLUMN connection_degree VARCHAR(8) NULL AFTER engager_profile_url;
+
+-- Why a send failed, so a 'failed' row in the Connections review UI says something more useful than
+-- FAILED. invite_to_connect_now already produces this text ("Already connected (1st-degree)",
+-- "Failed to find more or connect button: …") — it just had nowhere to live.
+ALTER TABLE connection_requests
+    ADD COLUMN failure_reason VARCHAR(512) NULL AFTER reasons;

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -187,6 +187,12 @@ app.conf.update(
             # is actually engaging. Files a few targets a day; sending stays daily-capped + approved.
             'schedule': crontab(hour='4', minute='0')
         },
+        'scan-outreach-funnel-targets': {
+            'task': 'cqc_lem.app.run_scheduler.auto_scan_outreach_funnel_targets',
+            # Daily at 4:20 AM — after the 4:00 connection-candidate scan, so anyone already filed
+            # as a connection request that run is excluded from the funnel rather than worked twice.
+            'schedule': crontab(hour='4', minute='20')
+        },
         'clen-up-stale-profiles': {
             'task': 'cqc_lem.app.run_scheduler.auto_clean_stale_profiles',
             'schedule': crontab(hour='3', minute='0', )  # Run every day at 3:00 AM

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -29,7 +29,7 @@ from cqc_lem.utilities.ai.content_alignment import humanize_text, split_link_for
     append_link_to_comment
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
-    CONNECTION_REQUEST_SENT_MESSAGE, \
+    CONNECTION_REQUEST_SENT_MESSAGE, ALREADY_CONNECTED_MESSAGE, \
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
     get_newsletter_settings, mark_newsletter_published, record_newsletter_subscriber_stat, \
     get_newsletter_edition, mark_edition_published, mark_edition_failed, \
@@ -58,7 +58,7 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
 from cqc_lem.utilities.engagement_window import record_pre_post_run
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
-    load_profile_for_user
+    load_profile_for_user, clean_person_name, connection_degree, is_first_degree
 from cqc_lem.utilities.linkedin.poster import share_on_linkedin, share_carousel_on_linkedin, \
     share_document_on_linkedin, comment_on_linkedin_post, object_urn_from_post_url
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
@@ -2378,10 +2378,14 @@ def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my
         # (if enabled) DM them the resource when their comment contains the trigger keyword.
         try:
             _link = comment.find_element(By.CSS_SELECTOR, "a[href*='/in/']")
-            _ename = ((_link.text or "") or (_link.get_attribute("aria-label") or "")).strip().split("\n")[0]
+            # SDUI packs "Name Verified Profile 1st" into one link — keep the name, keep the badge
+            # separately (it tells the connection scan who we're already connected to, issue #623).
+            _eraw = (_link.text or "") or (_link.get_attribute("aria-label") or "")
+            _ename = clean_person_name(_eraw)
+            _edegree = connection_degree(_eraw)
             _eprofile = (_link.get_attribute("href") or "").split("?")[0]
             if _ename and _ename.lower() != (my_profile.full_name or "").lower():
-                upsert_engager(user_id, _ename, _eprofile)
+                upsert_engager(user_id, _ename, _eprofile, connection_degree=_edegree)
                 # Inbound intent (#483): this commenter may be raising their hand — flag + draft.
                 if leads_flagged < _MAX_LEAD_FLAGS_PER_SWEEP and _flag_lead_signal(
                         user_id, comment_text, LeadSignalSource.POST_COMMENT, f"post:{post_id}",
@@ -4092,12 +4096,36 @@ def _send_lead_response(signal_id: int) -> str:
         quit_gracefully(driver)
 
 
-def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -> bool:
+# The connection-degree badge on a profile page. Only used to ABORT a pointless invite, so a
+# selector that stops matching costs nothing but the old behaviour (issue #623).
+_PROFILE_DEGREE_LOCATORS = [
+    (By.CSS_SELECTOR, "main span.dist-value"),
+    (By.CSS_SELECTOR, "main span.distance-badge"),
+    (By.XPATH, "//main//span[contains(@class,'distance-badge')]"),
+]
+
+
+def _profile_is_first_degree(driver) -> bool:
+    """True only when the profile page SAYS 1st degree. Fails open (False) on any read problem —
+    a missed badge just means we try the invite, which is the old behaviour."""
+    try:
+        for by, selector in _PROFILE_DEGREE_LOCATORS:
+            for element in driver.find_elements(by, selector):
+                if is_first_degree(element.text or ""):
+                    return True
+    except Exception as e:
+        log_warning("Could not read the connection-degree badge; attempting the invite anyway",
+                    exc=e, action_type="invite_connect")
+    return False
+
+
+def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -> "tuple[bool, str]":
     """Core connect-invite send: open the profile, click Connect (+ optional note), log the result.
-    Returns True on success. Shared by invite_to_connect (reactive profile-viewer flow) and
-    send_connection_request (issue #398 approval-gated proactive flow) so both use the same send +
-    log path (mirrors send_dm_now). Re-raises LinkedInRateLimited when the kill-switch / 429 breaker
-    is open so callers can defer rather than record a false failure."""
+    Returns (sent, result_message) — the message is the failure reason when `sent` is False, which
+    the proactive flow stores on the request row (issue #623). Shared by invite_to_connect (reactive
+    profile-viewer flow) and send_connection_request (issue #398 approval-gated proactive flow) so
+    both use the same send + log path (mirrors send_dm_now). Re-raises LinkedInRateLimited when the
+    kill-switch / 429 breaker is open so callers can defer rather than record a false failure."""
     user_email, user_password = get_user_password_pair_by_id(user_id)
 
     driver, wait = get_driver_wait_pair(session_name='Invite to Connect', user_id=user_id)
@@ -4114,6 +4142,16 @@ def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -
             driver.get(profile_url)
 
         myprint(f"Inviting to connect: {profile_url}")
+
+        # Already connected? There is no Connect button to find — bail with a reason instead of
+        # burning a session hunting for one and recording an opaque failure.
+        if _profile_is_first_degree(driver):
+            log_info("Skipping invite: already a 1st-degree connection", user_id=user_id,
+                     action_type="invite_connect")
+            insert_new_log(user_id=user_id, action_type=LogActionType.ENGAGED,
+                           result=LogResultType.FAILURE, post_url=profile_url,
+                           message=ALREADY_CONNECTED_MESSAGE)
+            return False, ALREADY_CONNECTED_MESSAGE
 
         # Locate the connect button
         try:
@@ -4221,7 +4259,7 @@ def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -
     finally:
         quit_gracefully(driver)  # Close the driver
 
-    return invite_sent
+    return invite_sent, result
 
 
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'keys': ['user_id', 'profile_url']},
@@ -4230,11 +4268,14 @@ def invite_to_connect(self, user_id: int, profile_url: str, message: str = None)
     """Send a LinkedIn connection request (reactive profile-viewer flow). Thin wrapper over
     invite_to_connect_now; a throttle / kill-switch defers silently."""
     try:
-        sent = invite_to_connect_now(user_id, profile_url, message)
+        sent, reason = invite_to_connect_now(user_id, profile_url, message)
     except LinkedInRateLimited as e:
         myprint(f"invite_to_connect deferred (throttled): {e}")
         return "Invitation deferred (LinkedIn throttled)"
-    return CONNECTION_REQUEST_SENT_MESSAGE if sent else "Connection Request Failed"
+    if sent:
+        return CONNECTION_REQUEST_SENT_MESSAGE
+    log_warning(f"Connection request failed: {reason}", user_id=user_id, action_type="invite_connect")
+    return f"Connection Request Failed: {reason}"
 
 
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'keys': ['request_id']},
@@ -4258,13 +4299,17 @@ def send_connection_request(self, request_id: int):
         return f"Connection request {request_id} deferred (daily invite cap reached)"
 
     try:
-        sent = invite_to_connect_now(user_id, req["recipient_profile_url"], req["message"])
+        sent, reason = invite_to_connect_now(user_id, req["recipient_profile_url"], req["message"])
     except LinkedInRateLimited as e:
         myprint(f"send_connection_request: throttled, deferring {request_id}: {e}")
         update_connection_request_status(request_id, ConnectionRequestStatus.APPROVED)  # retry on next scan
         return f"Connection request {request_id} deferred (LinkedIn throttled)"
+    if not sent:
+        log_warning(f"Connection request {request_id} failed: {reason}", user_id=user_id,
+                    action_type="invite_connect")
     update_connection_request_status(
-        request_id, ConnectionRequestStatus.SENT if sent else ConnectionRequestStatus.FAILED)
+        request_id, ConnectionRequestStatus.SENT if sent else ConnectionRequestStatus.FAILED,
+        failure_reason=(None if sent else reason))
     return f"Connection request {request_id} -> {'sent' if sent else 'failed'}"
 
 
@@ -4308,7 +4353,8 @@ def _harvest_post_commenters(driver, post_url: str, author_name: str, now: datet
     for comment in _comment_items_from_thread(driver)[:limit]:
         try:
             link = comment.find_element(By.CSS_SELECTOR, "a[href*='/in/']")
-            name = ((link.text or "") or (link.get_attribute("aria-label") or "")).strip().split("\n")[0]
+            raw = (link.text or "") or (link.get_attribute("aria-label") or "")
+            name = clean_person_name(raw)
             url = (link.get_attribute("href") or "").split("?")[0]
         except Exception:
             continue
@@ -4316,7 +4362,8 @@ def _harvest_post_commenters(driver, post_url: str, author_name: str, now: datet
             continue
         signals.append(CandidateSignal(person_name=name, person_profile_url=url,
                                        source=SOURCE_ADJACENT_POST, context_url=post_url,
-                                       context_author=author_name, occurred_at=now))
+                                       context_author=author_name, occurred_at=now,
+                                       connection_degree=connection_degree(raw)))
     return signals
 
 
@@ -4398,16 +4445,22 @@ def scan_connection_candidates(self, user_id: int, max_new: int = None):
     prefs = get_engagement_preferences(user_id)
     mode = str(prefs.get("connection_targeting_mode") or "suggest")
     if mode == "off":
+        log_info("Connection targeting is off for this user", user_id=user_id,
+                 task_name="scan_connection_candidates", action_type="connection_targeting")
         return f"Connection targeting off for user {user_id}"
 
     budget = _connect_target_budget(user_id, prefs, max_new)
     if budget <= 0:
+        log_warning("Connection targeting filed nothing: no invite budget left (daily cap already "
+                    "spent or fully queued)", user_id=user_id,
+                    task_name="scan_connection_candidates", action_type="connection_targeting")
         return f"No invite budget left for user {user_id}"
 
     now = datetime.now(timezone.utc).replace(tzinfo=None)
     signals = [CandidateSignal(person_name=row.get("person_name"),
                                person_profile_url=row.get("person_profile_url"),
-                               source=SOURCE_OWN_POST, occurred_at=row.get("occurred_at"))
+                               source=SOURCE_OWN_POST, occurred_at=row.get("occurred_at"),
+                               connection_degree=row.get("connection_degree"))
                for row in get_engager_candidates(user_id, days=_CONNECT_ENGAGER_LOOKBACK_DAYS)]
 
     authors = [str(a).strip() for a in (prefs.get("connection_target_authors") or []) if str(a or "").strip()]
@@ -4427,27 +4480,50 @@ def scan_connection_candidates(self, user_id: int, max_new: int = None):
                 quit_gracefully(driver)
 
     if not signals:
+        log_warning("Connection targeting filed nothing: nobody has engaged with this user's "
+                    "content in the lookback window and no adjacent authors are configured",
+                    user_id=user_id, task_name="scan_connection_candidates",
+                    action_type="connection_targeting")
         return f"No connection candidates found for user {user_id}"
 
     terms = target_terms_from_prefs(prefs)
     urls = sorted({s.person_profile_url for s in signals if s.person_profile_url})
+    min_icp = int(prefs.get("min_connection_icp_score") or 0)
     candidates = rank_candidates(signals, now, facts_by_url=get_profile_facts(urls),
-                                 target_terms=terms,
-                                 min_icp=int(prefs.get("min_connection_icp_score") or 0),
+                                 target_terms=terms, min_icp=min_icp,
                                  exclude_keys=get_requested_person_keys(user_id),
                                  limit=budget)
     if not candidates:
+        log_warning("Connection targeting filed nothing: every candidate was already requested, "
+                    "already a 1st-degree connection, or below the ICP floor", user_id=user_id,
+                    task_name="scan_connection_candidates", action_type="connection_targeting")
         return f"No new connection candidates for user {user_id} (all deduped or below ICP floor)"
 
     status = _target_status_for_mode(mode, prefs)
     topic = terms[0] if terms else None
     filed = 0
     for candidate in candidates:
+        # Belt and braces on the two gates that produced the only request production ever filed —
+        # an invite to an existing connection, scored below the user's own floor (issue #623).
+        if is_first_degree(candidate.connection_degree or ""):
+            log_info(f"Skipping {candidate.person_name or candidate.person_profile_url}: already a "
+                     f"1st-degree connection", user_id=user_id,
+                     task_name="scan_connection_candidates", action_type="connection_targeting")
+            continue
+        if candidate.known_fit and candidate.icp_score < min_icp:
+            log_info(f"Skipping {candidate.person_name or candidate.person_profile_url}: ICP "
+                     f"{candidate.icp_score} below the floor of {min_icp}", user_id=user_id,
+                     task_name="scan_connection_candidates", action_type="connection_targeting")
+            continue
         note = _draft_connect_note(user_id, candidate, topic=topic)
         request_id = insert_connection_request(
             user_id, candidate.person_profile_url, message=note,
             recipient_name=candidate.person_name, status=status,
-            source=candidate.source, icp_score=candidate.icp_score, reasons=candidate.reasons)
+            source=candidate.source,
+            # No facts to score against means no score. Storing ICP_UNKNOWN here filed rows that
+            # read as "below your floor" to whoever approves them; `reasons` says fit is unverified.
+            icp_score=(candidate.icp_score if candidate.known_fit else None),
+            reasons=candidate.reasons)
         if not request_id:
             continue
         filed += 1

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -25,6 +25,7 @@ from cqc_lem.utilities.ai.dm_nurture import classify_reply_intent, is_stop_inten
 from cqc_lem.utilities.connection_targeting import CandidateSignal, ScoredCandidate, \
     CONNECT_NOTE_LIMIT, SOURCE_ADJACENT_POST, SOURCE_OWN_POST, default_connect_note, \
     rank_candidates, target_terms_from_prefs
+from cqc_lem.utilities.lead_scoring import person_key
 from cqc_lem.utilities.ai.content_alignment import humanize_text, split_link_for_first_comment, \
     append_link_to_comment
 from cqc_lem.utilities.date import convert_viewed_on_to_date
@@ -46,6 +47,7 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     set_profile_synthesis, get_duplicate_comment_posts, get_recent_comment_texts, count_dms_sent_today, \
     get_approved_outreach_targets, update_outreach_target, update_outreach_target_status, \
     OutreachStage, OutreachStatus, insert_outreach_target, get_outreach_target_by_url, \
+    count_open_outreach_targets, \
     insert_lead_signal, has_lead_signal, get_lead_signal, update_lead_signal, \
     LeadSignalSource, LeadSignalChannel, LeadSignalStatus, \
     insert_scheduled_dm, has_open_scheduled_dm, count_scheduled_dms_created_today, \
@@ -3188,15 +3190,50 @@ def build_dm_from_template(user_id: int, event_type: str, first_name: str,
         return rendered.strip()
 
 
+# How long after an outbound DM we come back to look for a reply when the user has configured no
+# further step in that sequence. Long enough that a same-day reply has landed, short enough that the
+# thread is still warm when we draft the next message.
+_REPLY_CHECK_DEFAULT_DELAY_HOURS = 48
+
+
+def _reply_check_delay_hours() -> int:
+    try:
+        return max(1, int(os.environ.get("DM_REPLY_CHECK_DELAY_HOURS")
+                          or _REPLY_CHECK_DEFAULT_DELAY_HOURS))
+    except ValueError:
+        return _REPLY_CHECK_DEFAULT_DELAY_HOURS
+
+
 def enqueue_next_followup(user_id: int, profile_url: str, first_name: str, event_type: str, current_step: int) -> None:
     """If a follow-up template exists for the next step, schedule it at now + its delay_hours.
-    due_at is stored as naive UTC to match the rest of the system (see get_due_followups)."""
+    due_at is stored as naive UTC to match the rest of the system (see get_due_followups).
+
+    When there is NO next step, schedule a REPLY CHECK at that same step anyway (issue #623). The
+    stock templates are step-0 only, so this branch used to end the thread the moment the first DM
+    went out: nothing was ever queued in dm_followups, process_user_followups therefore never ran,
+    nobody's reply was ever read, and the #485 auto-nurture that turns a reply into an approval-gated
+    next message could not fire — scheduled_dms had zero rows in production from V53 to now. The
+    check costs one thread open: a reply becomes a nurture draft, and silence hits the existing
+    "no template for this step" branch in process_user_followups and stops the sequence. This is the
+    same shape _schedule_catchup_followup already used for catch-up touches (#482), generalized to
+    every sequence."""
     try:
         nxt = get_dm_template(user_id, event_type, current_step + 1)
+        now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
         if nxt:
-            now_utc = datetime.now(timezone.utc).replace(tzinfo=None)
             due = now_utc + timedelta(hours=int(nxt.get("delay_hours", 24) or 24))
             enqueue_followup(user_id, profile_url, first_name, event_type, current_step + 1, due)
+            return
+        if not _nurture_enabled() or str(event_type) == NURTURE_EVENT_TYPE:
+            # Nurture schedules its own re-check; with nurture off there is nothing to check for.
+            log_info(f"No step {current_step + 1} template for '{event_type}' — sequence ends here",
+                     user_id=user_id, action_type="followup")
+            return
+        due = now_utc + timedelta(hours=_reply_check_delay_hours())
+        enqueue_followup(user_id, profile_url, first_name, event_type, current_step + 1, due)
+        log_info(f"No step {current_step + 1} template for '{event_type}' — queued a reply check "
+                 f"in {_reply_check_delay_hours()}h so a reply can become a nurture draft",
+                 user_id=user_id, action_type="followup")
     except Exception as e:
         log_warning("Failed to enqueue next follow-up", exc=e, action_type="followup", user_id=user_id)
 
@@ -3306,7 +3343,14 @@ def _nurture_after_reply(user_id: int, followup: dict, their_message: str,
     profile_url = followup.get("profile_url") or ""
     first_name = followup.get("first_name") or ""
     try:
-        if not _nurture_enabled() or not str(their_message or "").strip():
+        if not _nurture_enabled():
+            log_warning("DM nurture is disabled (DM_NURTURE_ENABLED) — a reply was read but no next "
+                        "message will be drafted", user_id=user_id, action_type="dm")
+            return None
+        if not str(their_message or "").strip():
+            log_warning(f"DM nurture: a reply from {first_name or profile_url} was detected but its "
+                        f"text could not be read — nothing to draft against",
+                        user_id=user_id, action_type="dm")
             return None
 
         verdict = classify_reply_intent(their_message)
@@ -3347,6 +3391,9 @@ def _nurture_after_reply(user_id: int, followup: dict, their_message: str,
         if not message:
             message = build_dm_from_template(user_id, NURTURE_EVENT_TYPE, first_name, my_profile, step=step)
         if not message:
+            log_warning(f"DM nurture: no draft could be produced for {first_name or profile_url} "
+                        f"(step {step}) — the LLM returned nothing and no 'nurture' template exists "
+                        f"for that step", user_id=user_id, action_type="dm")
             return None
 
         due = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=nurture_delay_hours(intent))
@@ -3355,6 +3402,8 @@ def _nurture_after_reply(user_id: int, followup: dict, their_message: str,
                                     recipient_name=first_name or None, status=status,
                                     source=SCHEDULED_DM_SOURCE_NURTURE)
         if not dm_id:
+            log_warning(f"DM nurture: drafted a next message for {first_name or profile_url} but "
+                        f"the scheduled_dms insert failed", user_id=user_id, action_type="dm")
             return None
         log_info(f"DM nurture: drafted a '{intent}' next message for {first_name or profile_url} "
                  f"(step {step}, {status})", user_id=user_id, action_type="dm")
@@ -3378,6 +3427,12 @@ def process_user_followups(self, user_id: int, max_per_run: int = 20):
     due = [f for f in get_due_followups(datetime.now(timezone.utc).replace(tzinfo=None))
            if f["user_id"] == user_id]
     if not due:
+        # Not routine: this task is only dispatched for users who HAVE due rows, so an empty list
+        # means the row was consumed between dispatch and run — or nothing is being enqueued at all,
+        # which is exactly how the nurture queue stayed empty for months (issue #623).
+        log_warning("Follow-up run found nothing due — no reply will be read and no nurture draft "
+                    "will be queued for this user", user_id=user_id,
+                    task_name="process_user_followups", action_type="followup")
         return "No due follow-ups"
     try:
         driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Follow-ups")
@@ -3435,6 +3490,27 @@ def process_user_followups(self, user_id: int, max_per_run: int = 20):
     return f"Sent {sent} follow-up(s); drafted {nurtured} nurture reply(ies)"
 
 
+def _dispatch_appreciation_dms(user_id: int, my_profile: LinkedInProfile, event_type: str,
+                               recipients: dict) -> int:
+    """Send the step-0 appreciation DM for one trigger event to everyone it fired for, and put each
+    thread on the follow-up sequencer. Returns how many were dispatched. A missing template used to
+    drop the recipient in silence — now it says so, because a template gap here is the difference
+    between a nurture pipeline and an empty one (issue #623)."""
+    sent = 0
+    for profile_url, name in (recipients or {}).items():
+        first_name = clean_person_name(name).split(" ")[0] or "there"
+        message = build_dm_from_template(user_id, event_type, first_name, my_profile)
+        if not message:
+            log_warning(f"No '{event_type}' DM template for step 0 — skipping the appreciation DM "
+                        f"to {first_name}", user_id=user_id, action_type="dm")
+            continue
+        send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url,
+                                            "message": message})
+        enqueue_next_followup(user_id, profile_url, first_name, event_type, 0)
+        sent += 1
+    return sent
+
+
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
                   reject_on_worker_lost=True, rate_limit='2/m', queue='se_outreach')
 def automate_appreciation_dms_for_user(self, user_id: int, loop_for_duration: int = None, future_forward: int = 60):
@@ -3455,30 +3531,15 @@ def automate_appreciation_dms_for_user(self, user_id: int, loop_for_duration: in
 
         # After Accepting a Connection Request:
         invitations_accepted = accept_connection_request(user_id)
-        for profile_url, name in invitations_accepted.items():
-            first_name = (name or "").strip().split(" ")[0] or "there"
-            message = build_dm_from_template(user_id, "connection_accepted", first_name, my_profile)
-            if message:
-                send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url, "message": message})
-                enqueue_next_followup(user_id, profile_url, first_name, "connection_accepted", 0)
+        _dispatch_appreciation_dms(user_id, my_profile, "connection_accepted", invitations_accepted)
 
         # After Receiving a Recommendation — thank the recommender
-        recommendations_received = get_recent_recommendations(driver, wait)
-        for profile_url, name in recommendations_received.items():
-            first_name = name.split(" ")[0]
-            message = build_dm_from_template(user_id, "recommendation_received", first_name, my_profile)
-            if message:
-                send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url, "message": message})
-                enqueue_next_followup(user_id, profile_url, first_name, "recommendation_received", 0)
+        _dispatch_appreciation_dms(user_id, my_profile, "recommendation_received",
+                                   get_recent_recommendations(driver, wait))
 
         # After a Successful Collaboration — express gratitude and offer to connect further
-        recent_collaborators = get_recent_collaborators(driver, wait)
-        for profile_url, name in recent_collaborators.items():
-            first_name = name.split(" ")[0]
-            message = build_dm_from_template(user_id, "collaboration", first_name, my_profile)
-            if message:
-                send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url, "message": message})
-                enqueue_next_followup(user_id, profile_url, first_name, "collaboration", 0)
+        _dispatch_appreciation_dms(user_id, my_profile, "collaboration",
+                                   get_recent_collaborators(driver, wait))
 
         # Re-schedule the task in the queue for the future
         if loop_for_duration:
@@ -3831,7 +3892,7 @@ def engage_with_profile_viewer(self, user_id: int, viewer_url, viewer_name):
                     if not able_to_comment:
                         myprint("No activities, unable to or already left comment")
 
-                        first_name = viewer_name.split(" ")[0]
+                        first_name = clean_person_name(viewer_name).split(" ")[0] or "there"
                         profile_url_str = str(profile.profile_url)
                         acting_user_id = get_user_id(my_profile.email)
 
@@ -4633,6 +4694,185 @@ def process_outreach_funnel(self, user_id: int, max_per_run: int = 25):
             update_outreach_target_status(target["id"], OutreachStatus.FAILED)
             results.append(f"target {target['id']}: error")
     return "; ".join(results)
+
+
+# --- Outreach funnel sourcing (issue #623) — the funnel had a processor but no input -------------
+# outreach_funnel_targets had ZERO rows in production since the table shipped: the only way in was
+# the API, and nothing ever called it. These are the three warm surfaces we already track, drained
+# into the SAME approval-gated funnel #399 built. Nothing here sends: every target lands as a draft
+# whose first stage still needs approval (or the user's auto-approve mode), and each fired stage
+# still drops back to 'pending' for a fresh one.
+_MAX_NEW_FUNNEL_TARGETS_PER_SCAN = _connect_env_int("MAX_NEW_FUNNEL_TARGETS_PER_SCAN", 5)
+# Depth at which sourcing stops: an approval queue nobody works through is the same as no queue.
+_MAX_OPEN_FUNNEL_TARGETS = _connect_env_int("MAX_OPEN_FUNNEL_TARGETS", 25)
+_MAX_ROSTER_AUTHORS_PER_FUNNEL_SCAN = 5
+_FUNNEL_ENGAGER_LOOKBACK_DAYS = 14
+
+
+def _funnel_prospects_from_roster(driver, user_id: int, roster: list, my_name: str,
+                                  now: datetime) -> list:
+    """The engagement roster (G1, issue #616) and the people commenting on its posts, each paired
+    with the post that put them on our radar — the comment stage needs something to comment ON.
+    Each roster author is best-effort: one unreachable profile must not lose the others."""
+    from cqc_lem.utilities.linkedin.scrapper import get_profile_recent_activity
+
+    prospects: list = []
+    for target in roster[:_MAX_ROSTER_AUTHORS_PER_FUNNEL_SCAN]:
+        author_url = str(target.get("profile_url") or "").strip()
+        if not author_url:
+            continue
+        try:
+            activity = get_profile_recent_activity(driver, author_url) or []
+        except Exception as e:
+            log_warning("Could not read a roster author's recent activity", exc=e, user_id=user_id,
+                        action_type="outreach_funnel")
+            continue
+        post = next((p for p in activity if (p or {}).get("link")), None)
+        if not post:
+            log_warning(f"Roster author {author_url} has no recent post to comment on — skipping",
+                        user_id=user_id, action_type="outreach_funnel")
+            continue
+        author_name = clean_person_name(target.get("name") or "") or _author_display_name(author_url)
+        post_text = str(post.get("text") or "")
+        prospects.append({"profile_url": author_url, "name": author_name,
+                          "context_url": post["link"], "context_text": post_text,
+                          "stage": OutreachStage.COMMENT})
+        try:
+            commenters = _harvest_post_commenters(driver, post["link"], author_name, now)
+        except Exception as e:
+            log_warning("Could not harvest commenters from a roster post", exc=e, user_id=user_id,
+                        action_type="outreach_funnel")
+            continue
+        for signal in commenters:
+            prospects.append({"profile_url": signal.person_profile_url, "name": signal.person_name,
+                              "context_url": post["link"], "context_text": post_text,
+                              "stage": OutreachStage.COMMENT})
+    me = (my_name or "").strip().lower()
+    return [p for p in prospects if (p["name"] or "").strip().lower() != me]
+
+
+def _funnel_prospects_from_engagers(user_id: int) -> list:
+    """People who engaged with the user's OWN posts. They start at the CONNECT stage: they already
+    engaged with us, so there is no third-party post to comment on first — and anyone the badge says
+    we're already connected to is dropped, since connecting is the only thing this funnel adds."""
+    prospects: list = []
+    for row in get_engager_candidates(user_id, days=_FUNNEL_ENGAGER_LOOKBACK_DAYS):
+        if is_first_degree(row.get("connection_degree") or ""):
+            continue
+        prospects.append({"profile_url": row.get("person_profile_url"),
+                          "name": clean_person_name(row.get("person_name") or ""),
+                          "context_url": None, "context_text": "",
+                          "stage": OutreachStage.CONNECT})
+    return prospects
+
+
+def _draft_funnel_comment(user_id: int, prospect: dict, my_profile: LinkedInProfile,
+                          prefs: dict = None, profile_synthesis: str = None) -> str:
+    """Pre-draft the comment-stage text from the post itself, using the same grounded generator the
+    feed uses (so the quality contract and similarity gate apply). Returns '' when the post text is
+    unreadable or the gate rejects every attempt — the operator writes it themselves rather than a
+    template comment going out under their name."""
+    content = (prospect.get("context_text") or "").strip()
+    if not content or my_profile is None:
+        return ""
+    try:
+        return (generate_ai_response(content, my_profile, None, prefs=prefs,
+                                     profile_synthesis=profile_synthesis, user_id=user_id) or "").strip()
+    except Exception as e:
+        log_warning("Funnel comment draft failed; leaving it for the operator", exc=e,
+                    user_id=user_id, action_type="outreach_funnel")
+        return ""
+
+
+@shared_task.task(bind=True, base=QueueOnce,
+                  once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  reject_on_worker_lost=True, rate_limit='1/m', queue='se_outreach')
+def scan_outreach_funnel_targets(self, user_id: int, max_new: int = None):
+    """Populate the comment-first outreach funnel from the roster, roster-post commenters, and the
+    user's own post engagers (issue #623). Files drafts only — the approval gate, the per-stage
+    re-approval, and the daily comment/DM caps in process_outreach_funnel all still apply."""
+    prefs = get_engagement_preferences(user_id)
+    if str(prefs.get("connection_targeting_mode") or "suggest") == "off":
+        log_info("Outreach sourcing is off for this user (connection_targeting_mode=off)",
+                 user_id=user_id, task_name="scan_outreach_funnel_targets",
+                 action_type="outreach_funnel")
+        return f"Outreach funnel sourcing off for user {user_id}"
+
+    open_targets = count_open_outreach_targets(user_id)
+    ceiling = _MAX_NEW_FUNNEL_TARGETS_PER_SCAN if max_new is None else int(max_new)
+    budget = max(0, min(ceiling, _MAX_OPEN_FUNNEL_TARGETS - open_targets))
+    if budget <= 0:
+        log_warning(f"Outreach funnel sourcing filed nothing: {open_targets} target(s) are already "
+                    f"waiting for approval", user_id=user_id,
+                    task_name="scan_outreach_funnel_targets", action_type="outreach_funnel")
+        return f"Outreach funnel backlog full for user {user_id}"
+
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    roster = [t for t in get_engagement_targets(user_id, active_only=True) if t.get("profile_url")]
+    prospects: list = []
+    my_profile = None
+    synthesis = None
+    if roster:
+        driver = None
+        try:
+            driver, _wait, _user_email, my_profile = get_current_profile(
+                user_id=user_id, session_name="Outreach Funnel Sourcing")
+            synthesis = get_or_create_profile_synthesis(user_id, my_profile)
+            prospects.extend(_funnel_prospects_from_roster(driver, user_id, roster,
+                                                           my_profile.full_name, now))
+        except Exception as e:
+            # Own-post engagers stand on their own — degrade, don't abort the whole scan.
+            log_warning("Roster sourcing for the outreach funnel failed; using post engagers only",
+                        exc=e, user_id=user_id, task_name="scan_outreach_funnel_targets",
+                        action_type="outreach_funnel")
+        finally:
+            if driver is not None:
+                quit_gracefully(driver)
+    else:
+        log_warning("No active engagement-roster targets — the funnel can only source from post "
+                    "engagers until a roster is configured", user_id=user_id,
+                    task_name="scan_outreach_funnel_targets", action_type="outreach_funnel")
+    prospects.extend(_funnel_prospects_from_engagers(user_id))
+
+    if not prospects:
+        log_warning("Outreach funnel sourcing filed nothing: the engagement roster produced no "
+                    "posts and nobody has engaged with this user's content in the lookback window",
+                    user_id=user_id, task_name="scan_outreach_funnel_targets",
+                    action_type="outreach_funnel")
+        return f"No outreach funnel prospects for user {user_id}"
+
+    # A target already in connection_requests is being worked by the #398/#486 path — two outbound
+    # tracks aimed at one person is exactly the over-automation this stays gated against.
+    requested = get_requested_person_keys(user_id)
+    status = _target_status_for_mode("auto_queue", prefs)
+    seen: set = set()
+    filed = 0
+    for prospect in prospects:
+        if filed >= budget:
+            break
+        url = str(prospect.get("profile_url") or "").strip()
+        if not url:
+            continue
+        key = person_key(prospect.get("name"), url)
+        if key in seen or key in requested:
+            continue
+        seen.add(key)
+        if get_outreach_target_by_url(user_id, url):
+            continue
+        stage = prospect["stage"]
+        draft = (_draft_funnel_comment(user_id, prospect, my_profile, prefs=prefs,
+                                       profile_synthesis=synthesis)
+                 if stage == OutreachStage.COMMENT
+                 else _draft_funnel_stage(user_id, stage, {"target_name": prospect.get("name")}))
+        target_id = insert_outreach_target(user_id, url, target_name=prospect.get("name") or None,
+                                           context_url=prospect.get("context_url"),
+                                           draft_text=(draft or None), stage=stage, status=status)
+        if not target_id:
+            continue
+        filed += 1
+        log_info(f"Outreach funnel target filed at the {stage} stage", user_id=user_id,
+                 task_name="scan_outreach_funnel_targets", action_type="outreach_funnel")
+    return f"Filed {filed} outreach funnel target(s) as '{status}' for user {user_id}"
 
 
 # --- LinkedIn Catch-up automation (issue #482) — trigger-event congratulations, approval-gated ---

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -846,6 +846,21 @@ def auto_scan_connection_candidates():
     return f"Dispatched connection targeting for {len(user_ids)} user(s)"
 
 
+@shared_task.task
+def auto_scan_outreach_funnel_targets():
+    """Dispatch per-user sourcing for the comment-first outreach funnel (issue #623). The funnel
+    processor (#399) has always existed; nothing ever fed it, so outreach_funnel_targets had zero
+    rows in production. Sourcing scrapes the roster's recent posts, so it IS gated on the 429
+    breaker / manual pause. It only FILES drafts — approval and the daily caps still gate sends."""
+    if _skip_if_throttled("auto_scan_outreach_funnel_targets"):
+        return "Automation throttled"
+    from cqc_lem.app.run_automation import scan_outreach_funnel_targets
+    user_ids = get_active_user_ids()
+    for uid in user_ids:
+        scan_outreach_funnel_targets.apply_async(kwargs={"user_id": uid})
+    return f"Dispatched outreach funnel sourcing for {len(user_ids)} user(s)"
+
+
 # Lead scoring & CRM-lite pipeline (issue #484). Nothing here touches LinkedIn — it re-reads
 # engagement we already stored — so it is deliberately NOT gated on the 429 breaker / pause: a
 # rate-limited account still deserves an accurate hot-leads list.

--- a/src/cqc_lem/ui/src/pages/review/ConnectionRequests.tsx
+++ b/src/cqc_lem/ui/src/pages/review/ConnectionRequests.tsx
@@ -17,10 +17,13 @@ interface ConnectionRequest {
   message: string | null
   status: string
   created_at: string
-  // Targeting provenance (issue #486) — null for hand-added targets.
+  // Targeting provenance (issue #486) — null for hand-added targets. icp_score is null when we have
+  // no profile facts to score fit against (issue #623), which is most engagers.
   source: string | null
   icp_score: number | null
   reasons: string | null
+  // Why a send failed (issue #623) — e.g. already connected, or no Connect button on the profile.
+  failure_reason: string | null
 }
 
 const SOURCE_LABELS: Record<string, string> = {
@@ -166,11 +169,16 @@ export default function ConnectionRequests({ userTimezone }: { userTimezone: str
                     {SOURCE_LABELS[req.source] ?? req.source}
                   </span>
                 )}
-                {req.icp_score != null && (
+                {req.icp_score != null ? (
                   <span className="text-xs text-gray-500">ICP fit {req.icp_score}/100</span>
+                ) : (
+                  req.source && <span className="text-xs text-gray-400">ICP fit unverified</span>
                 )}
                 {req.reasons && <span className="text-xs text-gray-500 truncate">· {req.reasons}</span>}
               </div>
+            )}
+            {req.status === 'failed' && req.failure_reason && (
+              <p className="text-xs text-red-600 mb-1">Why it failed: {req.failure_reason}</p>
             )}
             {req.message && <p className="text-sm text-gray-700 whitespace-pre-wrap line-clamp-3">{req.message}</p>}
             {['pending', 'approved', 'sending'].includes(req.status) && (

--- a/src/cqc_lem/utilities/connection_targeting.py
+++ b/src/cqc_lem/utilities/connection_targeting.py
@@ -35,6 +35,10 @@ WARMTH_WEIGHT = 0.4
 # Default ICP floor for people we have facts on. Mirrors the DB default (min_connection_icp_score).
 MIN_ICP_DEFAULT = 55
 
+# Connection-degree badges that make a connection request pointless: we are already connected, so
+# LinkedIn shows Message where Connect would be and the invite can only fail (issue #623).
+EXCLUDED_DEGREES = ("1st",)
+
 # LinkedIn caps a connection-request note at 300 characters.
 CONNECT_NOTE_LIMIT = 300
 
@@ -48,6 +52,7 @@ class CandidateSignal:
     context_url: str = ""       # the post they engaged with
     context_author: str = ""    # whose post it was ('' for our own)
     occurred_at: Optional[datetime] = None
+    connection_degree: Optional[str] = None  # '1st'/'2nd'/'3rd+' badge, None when unrendered
 
 
 @dataclass
@@ -65,6 +70,7 @@ class ScoredCandidate:
     context_url: str = ""
     context_author: str = ""
     reasons: str = ""
+    connection_degree: Optional[str] = None
     last_seen_at: Optional[datetime] = None
     signals: list = field(default_factory=list)
 
@@ -95,7 +101,8 @@ def _primary_source(signals: Iterable[CandidateSignal]) -> str:
             else SOURCE_ADJACENT_POST)
 
 
-def _describe(candidate_signals: list, icp: int, known_fit: bool, now: datetime) -> str:
+def _describe(candidate_signals: list, icp: int, known_fit: bool, now: datetime,
+              degree: str = None) -> str:
     """Plain-language WHY, for the operator approving the request."""
     own = sum(1 for s in candidate_signals if s.source == SOURCE_OWN_POST)
     adjacent = [s for s in candidate_signals if s.source == SOURCE_ADJACENT_POST]
@@ -111,6 +118,9 @@ def _describe(candidate_signals: list, icp: int, known_fit: bool, now: datetime)
     if stamps:
         days = max(0, int((now - _align(max(stamps), now)).total_seconds() // 86400))
         parts.append("engaged today" if days == 0 else f"last engaged {days}d ago")
+
+    if degree:
+        parts.append(f"{degree}-degree")
 
     if not known_fit:
         parts.append("ICP fit unknown (profile not scraped)")
@@ -158,6 +168,8 @@ def score_candidate(signals: list, now: datetime, facts: dict = None,
     stamps = [s.occurred_at for s in signals if s.occurred_at]
     name = next((s.person_name for s in signals if s.person_name), None)
     url = next((s.person_profile_url for s in signals if s.person_profile_url), None)
+    # Any sighting that DID render a badge settles the degree; the rest simply didn't show one.
+    degree = next((s.connection_degree for s in signals if s.connection_degree), None)
     return ScoredCandidate(
         person_key=person_key(name, url),
         person_name=name,
@@ -170,7 +182,8 @@ def score_candidate(signals: list, now: datetime, facts: dict = None,
         known_fit=known_fit,
         context_url=lead_signal.context_url or "",
         context_author=lead_signal.context_author or "",
-        reasons=_describe(list(signals), icp, known_fit, now),
+        reasons=_describe(list(signals), icp, known_fit, now, degree=degree),
+        connection_degree=degree,
         last_seen_at=max(stamps) if stamps else None,
         signals=list(signals),
     )
@@ -179,21 +192,28 @@ def score_candidate(signals: list, now: datetime, facts: dict = None,
 def rank_candidates(signals: Iterable[CandidateSignal], now: datetime, facts_by_url: dict = None,
                     target_terms: Iterable[str] = None, min_icp: int = MIN_ICP_DEFAULT,
                     exclude_keys: Iterable[str] = None, require_profile_url: bool = True,
-                    limit: int = None) -> list:
+                    exclude_degrees: Iterable[str] = EXCLUDED_DEGREES, limit: int = None) -> list:
     """Rank connection candidates, best first.
 
     `exclude_keys` are person_keys we already asked (any connection_requests row, any status) — the
     dedup that keeps a nightly re-scan from re-inviting the same person.
 
+    `exclude_degrees` drops people whose scraped badge SAYS we're already connected (issue #623:
+    the only connection request production ever filed went to a 1st-degree connection and could
+    only fail). A candidate with NO badge is unknown, not connected — it is kept, because LinkedIn
+    doesn't render the badge on every surface and failing closed here would stop outreach entirely.
+
     The `min_icp` floor applies ONLY to people we have profile facts for. Most engagers have never
     been scraped, so they score ICP_UNKNOWN; rejecting them would reject nearly everyone and throw
     away the warm-engager signal this whole feature exists to use. They're kept, ranked on warmth,
-    and their `reasons` says the fit is unverified so the approver can see it.
+    and their `reasons` says the fit is unverified so the approver can see it — and the request row
+    stores NO icp_score for them, so nothing is ever filed that reads as below the user's floor.
 
     `require_profile_url` drops name-only sightings: without a /in/ URL there is nobody to invite.
     """
     facts_by_slug = {profile_slug(k): v for k, v in (facts_by_url or {}).items() if profile_slug(k)}
     excluded = {str(k) for k in (exclude_keys or []) if k}
+    blocked_degrees = {str(d).lower() for d in (exclude_degrees or []) if d}
     out: list = []
     for key, person_signals in group_signals(signals).items():
         if key in excluded:
@@ -204,6 +224,8 @@ def rank_candidates(signals: Iterable[CandidateSignal], now: datetime, facts_by_
                                               if s.person_profile_url), "")), {}),
                                     target_terms=target_terms)
         if require_profile_url and not candidate.person_profile_url:
+            continue
+        if str(candidate.connection_degree or "").lower() in blocked_degrees:
             continue
         if candidate.known_fit and candidate.icp_score < int(min_icp or 0):
             continue

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -4062,6 +4062,26 @@ def get_approved_outreach_targets(user_id: int) -> list:
         connection.close()
 
 
+def count_open_outreach_targets(user_id: int) -> int:
+    """Funnel targets still awaiting a human or a stage fire (pending / approved, not completed).
+    The sourcing scan (issue #623) stops adding once this backlog is deep enough — a review queue
+    nobody works through is the same as no queue at all."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) FROM outreach_funnel_targets WHERE user_id=%s "
+            "AND status IN ('pending','approved') AND stage <> 'completed'", (user_id,))
+        r = cursor.fetchone()
+        return int(r[0]) if r else 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not count open outreach targets for user {user_id} | Error: {err}")
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_users_with_approved_outreach() -> list:
     """Distinct user_ids that have at least one approved, non-completed funnel target (dispatcher)."""
     connection = get_db_connection()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -374,6 +374,10 @@ class LogResultType(StrEnum):
 # combined daily invite budget is counted from these log rows (see count_invites_sent_today).
 CONNECTION_REQUEST_SENT_MESSAGE = "Connection Request Sent Successfully"
 
+# Why a proactive invite was abandoned before it was attempted (issue #623). Stored as the request's
+# failure_reason so the Connections review UI explains a FAILED row instead of just colouring it red.
+ALREADY_CONNECTED_MESSAGE = "Already connected (1st-degree) — no invite to send"
+
 
 def store_cookies(user_email: str, cookies: list[dict]) -> None:
     connection = get_db_connection()
@@ -3702,7 +3706,8 @@ def count_invites_sent_today(user_id: int) -> int:
 # source/icp_score/reasons carry issue #486's targeting provenance (which engagement surfaced this
 # person, how well they fit) so the operator approving a request can see why it exists.
 _CONN_REQ_COLS = ("id", "user_id", "recipient_profile_url", "recipient_name", "message",
-                  "source", "icp_score", "reasons", "status", "created_at", "updated_at")
+                  "source", "icp_score", "reasons", "failure_reason", "status",
+                  "created_at", "updated_at")
 
 
 def insert_connection_request(user_id: int, recipient_profile_url: str, message: str = None,
@@ -3820,12 +3825,17 @@ def get_orphaned_connection_requests(lookback_hours: int = 2) -> list:
         connection.close()
 
 
-def update_connection_request_status(request_id: int, status: "ConnectionRequestStatus") -> bool:
+def update_connection_request_status(request_id: int, status: "ConnectionRequestStatus",
+                                     failure_reason: str = None) -> bool:
+    """Move a request to `status`. `failure_reason` records WHY a send failed (issue #623) — it is
+    written on every call, so a request that later succeeds or is deferred clears the stale reason
+    instead of showing yesterday's failure next to today's status."""
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
-        cursor.execute("UPDATE connection_requests SET status = %s WHERE id = %s",
-                       (str(status), request_id))
+        cursor.execute("UPDATE connection_requests SET status = %s, failure_reason = %s WHERE id = %s",
+                       (str(status), (str(failure_reason)[:512] if failure_reason else None),
+                        request_id))
         connection.commit()
         return cursor.rowcount > 0
     except mysql.connector.Error as err:
@@ -3914,14 +3924,15 @@ def get_requested_person_keys(user_id: int) -> set:
 
 def get_engager_candidates(user_id: int, days: int = 30) -> list:
     """People who recently engaged with the user's OWN posts, as connection-targeting candidates:
-    [{'person_name', 'person_profile_url', 'occurred_at'}]. Only rows with a profile URL — without
-    one there is nobody to invite. Read from post_engagers, so this costs no scraping."""
+    [{'person_name', 'person_profile_url', 'connection_degree', 'occurred_at'}]. Only rows with a
+    profile URL — without one there is nobody to invite. Read from post_engagers, so this costs no
+    scraping. `connection_degree` lets the caller drop people we're already connected to (#623)."""
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
             "SELECT engager_name AS person_name, engager_profile_url AS person_profile_url, "
-            "last_engaged_at AS occurred_at FROM post_engagers "
+            "connection_degree, last_engaged_at AS occurred_at FROM post_engagers "
             "WHERE user_id=%s AND engager_profile_url IS NOT NULL "
             "AND last_engaged_at >= (NOW() - INTERVAL %s DAY) ORDER BY last_engaged_at DESC",
             (user_id, days))
@@ -4339,20 +4350,25 @@ def has_scheduled_post_today(user_id: int) -> bool:
         connection.close()
 
 
-def upsert_engager(user_id: int, engager_name: str, engager_profile_url: str = None) -> bool:
+def upsert_engager(user_id: int, engager_name: str, engager_profile_url: str = None,
+                   connection_degree: str = None) -> bool:
     """Record that `engager_name` engaged with the user's post (or refresh their last-engaged
-    time). No-op on a blank name or if the table isn't present yet."""
+    time). No-op on a blank name or if the table isn't present yet. `connection_degree` is the
+    scraped badge ('1st'/'2nd'/'3rd+', issue #623) — COALESCEd, so a later sighting that rendered no
+    badge never erases a degree we already know."""
     if not engager_name or not engager_name.strip():
         return False
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         cursor.execute(
-            "INSERT INTO post_engagers (user_id, engager_name, engager_profile_url, last_engaged_at) "
-            "VALUES (%s,%s,%s,NOW()) ON DUPLICATE KEY UPDATE "
+            "INSERT INTO post_engagers (user_id, engager_name, engager_profile_url, "
+            "connection_degree, last_engaged_at) VALUES (%s,%s,%s,%s,NOW()) ON DUPLICATE KEY UPDATE "
             "engager_profile_url=COALESCE(VALUES(engager_profile_url), engager_profile_url), "
+            "connection_degree=COALESCE(VALUES(connection_degree), connection_degree), "
             "last_engaged_at=NOW()",
-            (user_id, engager_name.strip()[:255], (engager_profile_url or None)))
+            (user_id, engager_name.strip()[:255], (engager_profile_url or None),
+             (connection_degree or None)))
         connection.commit()
         return True
     except mysql.connector.Error as err:

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -1,5 +1,6 @@
 import os
 import random
+import re
 import time
 from typing import Optional
 
@@ -26,6 +27,71 @@ def _human_pause(min_seconds: float, max_seconds: float) -> None:
     if os.getenv("LINKEDIN_HUMANIZE_DELAYS", "true").lower() == "false":
         return
     time.sleep(random.uniform(min_seconds, max_seconds))
+
+
+# --- Scraped display-name hygiene (issue #623) --------------------------------------------------
+# LinkedIn's SDUI renders badge and status text INSIDE the same <a> as the person's name, so a naive
+# `link.text` read stores things like "Harshal Karanpuriya Verified Profile 1st" as somebody's name.
+# That name then goes out in a connection note and poisons every name-keyed dedup we have. Every
+# place we scrape a person's name runs it through clean_person_name(); connection_degree() reads the
+# badge we just stripped, so callers can skip people we are ALREADY connected to instead of burning
+# an invite slot on them.
+
+# aria-labels wrap the name in a sentence ("View Jane Doe's profile") — the name is inside it.
+_NAME_FROM_ARIA_RE = re.compile(r"view\s+(.+?)['’]s\s+(?:profile|graphic)", re.IGNORECASE)
+_DEGREE_RE = re.compile(r"(?<!\w)(1st|2nd|3rd\+?)(?!\w)", re.IGNORECASE)
+# Badge / status / degree text LinkedIn renders alongside the name. Deliberately does NOT include
+# button words (Connect / Message / Follow): those live in sibling elements, and stripping them
+# would mangle a real name that happens to contain one.
+_NAME_NOISE_RE = re.compile(
+    r"(?:\bview\s+.+?['’]s\s+(?:profile|graphic)\b"
+    r"|\b(?:1st|2nd|3rd)\+?(?:\s*degree)?(?:\s*connection)?\b"
+    r"|\bverified\s+profile\b|\bverified\b|\bpremium(?:\s+member)?\b|\binfluencer\b"
+    r"|\bopen\s+to\s+work\b|\b(?:is\s+)?hiring\b"
+    r"|\bstatus\s+is\s+(?:online|offline|reachable)\b)",
+    re.IGNORECASE)
+# SDUI stacks name / badge / degree as separate lines or bullet-separated spans.
+_NAME_SEGMENT_RE = re.compile(r"[\n\r•·|]+")
+
+
+def _collapse_repeated_name(name: str) -> str:
+    """LinkedIn renders the name twice (visible + screen-reader copy) inside one link, which
+    `.text` flattens to "Jane Doe Jane Doe". Fold an exact doubling back to one."""
+    parts = name.split()
+    half = len(parts) // 2
+    if half and len(parts) % 2 == 0 and parts[:half] == parts[half:]:
+        return " ".join(parts[:half])
+    return name
+
+
+def clean_person_name(raw: str) -> str:
+    """A scraped display name with LinkedIn's badge/status/degree text removed. Returns '' when
+    nothing name-like survives (a link whose text was only a status badge)."""
+    text = str(raw or "").replace("\u00a0", " ")
+    aria = _NAME_FROM_ARIA_RE.search(text)
+    if aria:
+        text = aria.group(1)
+    for segment in _NAME_SEGMENT_RE.split(text):
+        candidate = " ".join(_NAME_NOISE_RE.sub(" ", segment).split()).strip(" ,-–—")
+        if candidate:
+            return _collapse_repeated_name(candidate)[:255]
+    return ""
+
+
+def connection_degree(raw: str) -> Optional[str]:
+    """The connection-degree badge ('1st' / '2nd' / '3rd+') carried in scraped name text, or None
+    when LinkedIn didn't render one (it omits the badge on your own card and on some SDUI surfaces)."""
+    match = _DEGREE_RE.search(str(raw or ""))
+    if not match:
+        return None
+    degree = match.group(1).lower()
+    return "3rd+" if degree.startswith("3rd") else degree
+
+
+def is_first_degree(raw: str) -> bool:
+    """True only when the badge SAYS 1st. A missing badge is unknown, not 'not connected' — callers
+    that skip on this must fail open, or a selector drift silently stops all outreach."""
+    return connection_degree(raw) == "1st"
 
 
 def _text_is_transport_error(body: str) -> bool:

--- a/tests/unit/app/test_connection_requests.py
+++ b/tests/unit/app/test_connection_requests.py
@@ -19,12 +19,12 @@ class TestSendConnectionRequest:
         with patch("cqc_lem.utilities.db.get_connection_request", return_value=self._req()), \
              patch("cqc_lem.utilities.db.count_invites_sent_today", return_value=0), \
              patch(f"{_RA}.get_engagement_preferences", return_value={"max_invites_per_day": 10}), \
-             patch(f"{_RA}.invite_to_connect_now", return_value=True) as send, \
+             patch(f"{_RA}.invite_to_connect_now", return_value=(True, "Connection Request Sent Successfully")) as send, \
              patch("cqc_lem.utilities.db.update_connection_request_status") as upd:
             out = ra.send_connection_request(3)
         send.assert_called_once_with(1, "https://x/in/jane", "hi jane")
         from cqc_lem.utilities.db import ConnectionRequestStatus
-        upd.assert_called_once_with(3, ConnectionRequestStatus.SENT)
+        upd.assert_called_once_with(3, ConnectionRequestStatus.SENT, failure_reason=None)
         assert "sent" in out
 
     def test_failed_send_marks_failed(self):
@@ -32,11 +32,12 @@ class TestSendConnectionRequest:
         with patch("cqc_lem.utilities.db.get_connection_request", return_value=self._req()), \
              patch("cqc_lem.utilities.db.count_invites_sent_today", return_value=0), \
              patch(f"{_RA}.get_engagement_preferences", return_value={"max_invites_per_day": 10}), \
-             patch(f"{_RA}.invite_to_connect_now", return_value=False), \
+             patch(f"{_RA}.invite_to_connect_now", return_value=(False, "Failed to find more or connect button")), \
              patch("cqc_lem.utilities.db.update_connection_request_status") as upd:
             ra.send_connection_request(3)
         from cqc_lem.utilities.db import ConnectionRequestStatus
-        upd.assert_called_once_with(3, ConnectionRequestStatus.FAILED)
+        upd.assert_called_once_with(3, ConnectionRequestStatus.FAILED,
+                                   failure_reason="Failed to find more or connect button")
 
     def test_defers_when_cap_reached(self):
         from cqc_lem.app import run_automation as ra
@@ -84,7 +85,7 @@ class TestInviteToConnectWrapper:
 
     def test_returns_success_string(self):
         from cqc_lem.app import run_automation as ra
-        with patch(f"{_RA}.invite_to_connect_now", return_value=True):
+        with patch(f"{_RA}.invite_to_connect_now", return_value=(True, "ok")):
             out = ra.invite_to_connect(1, "https://x/in/jane")
         assert out == "Connection Request Sent Successfully"
 

--- a/tests/unit/app/test_dm_followups.py
+++ b/tests/unit/app/test_dm_followups.py
@@ -18,12 +18,44 @@ class TestEnqueueNextFollowup:
         enq.assert_called_once()
         assert enq.call_args[0][4] == 1  # next_step
 
-    def test_no_enqueue_when_no_next_template(self):
+    def test_queues_a_reply_check_when_no_next_template(self, monkeypatch):
+        # Issue #623: the stock templates are step-0 only, so this branch used to end every thread
+        # the moment the first DM went out — dm_followups stayed empty and the nurture flywheel
+        # never turned. Now it schedules a reply check at the same (template-less) step.
         from cqc_lem.app.run_automation import enqueue_next_followup
+        monkeypatch.delenv("DM_NURTURE_ENABLED", raising=False)
+        with patch(f"{_RA}.get_dm_template", return_value=None), \
+             patch(f"{_RA}.enqueue_followup") as enq:
+            enqueue_next_followup(1, "p", "Jane", "connection_accepted", 0)
+        enq.assert_called_once()
+        assert enq.call_args[0][3] == "connection_accepted"  # NOT the nurture sequence
+        assert enq.call_args[0][4] == 1
+
+    def test_no_reply_check_when_nurture_is_disabled(self, monkeypatch):
+        from cqc_lem.app.run_automation import enqueue_next_followup
+        monkeypatch.setenv("DM_NURTURE_ENABLED", "false")
         with patch(f"{_RA}.get_dm_template", return_value=None), \
              patch(f"{_RA}.enqueue_followup") as enq:
             enqueue_next_followup(1, "p", "Jane", "connection_accepted", 0)
         enq.assert_not_called()
+
+    def test_nurture_sequence_does_not_get_a_second_reply_check(self, monkeypatch):
+        # _nurture_after_reply enqueues its own re-check; a second one here would double the walk.
+        from cqc_lem.app.run_automation import enqueue_next_followup
+        monkeypatch.delenv("DM_NURTURE_ENABLED", raising=False)
+        with patch(f"{_RA}.get_dm_template", return_value=None), \
+             patch(f"{_RA}.enqueue_followup") as enq:
+            enqueue_next_followup(1, "p", "Jane", "nurture", 0)
+        enq.assert_not_called()
+
+    def test_reply_check_delay_is_configurable(self, monkeypatch):
+        from cqc_lem.app import run_automation as ra
+        monkeypatch.setenv("DM_REPLY_CHECK_DELAY_HOURS", "6")
+        assert ra._reply_check_delay_hours() == 6
+        monkeypatch.setenv("DM_REPLY_CHECK_DELAY_HOURS", "not-a-number")
+        assert ra._reply_check_delay_hours() == ra._REPLY_CHECK_DEFAULT_DELAY_HOURS
+        monkeypatch.delenv("DM_REPLY_CHECK_DELAY_HOURS")
+        assert ra._reply_check_delay_hours() == ra._REPLY_CHECK_DEFAULT_DELAY_HOURS
 
 
 def _due(**kw):

--- a/tests/unit/app/test_network_activation.py
+++ b/tests/unit/app/test_network_activation.py
@@ -1,0 +1,333 @@
+"""Network activation (issue #623).
+
+The production audit found the whole outbound layer idle: one connection request EVER (aimed at an
+existing 1st-degree connection, scored below the user's own ICP floor), no outreach funnel targets,
+no scheduled DMs. These cover the four fixes — degree skip, ICP floor at file time, funnel sourcing,
+and the reply check that unblocks the nurture queue — plus the logging that makes a silent early
+exit impossible.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+_RS = "cqc_lem.app.run_scheduler"
+
+
+def _prefs(**over):
+    prefs = {"connection_targeting_mode": "suggest", "connection_request_mode": "auto_approve",
+             "max_invites_per_day": 10, "min_connection_icp_score": 55,
+             "connection_target_authors": [], "focus_topics": ["revenue operations"]}
+    prefs.update(over)
+    return prefs
+
+
+def _engager(name="Jane Doe", slug="jane-doe", degree=None):
+    return {"person_name": name, "person_profile_url": f"https://www.linkedin.com/in/{slug}",
+            "connection_degree": degree, "occurred_at": datetime(2026, 7, 25, 9, 0, 0)}
+
+
+def _scan_connections(prefs=None, engagers=None, facts=None):
+    from cqc_lem.app import run_automation as ra
+    patches = {
+        "get_engagement_preferences": prefs if prefs is not None else _prefs(),
+        "count_invites_sent_today": 0,
+        "count_open_connection_requests": 0,
+        "get_engager_candidates": [_engager()] if engagers is None else engagers,
+        "get_requested_person_keys": set(),
+        "get_profile_facts": facts or {},
+    }
+    with patch.multiple(_RA, **{k: MagicMock(return_value=v) for k, v in patches.items()}), \
+         patch(f"{_RA}.get_ai_message_refinement", return_value="Refined note"), \
+         patch(f"{_RA}.insert_connection_request", return_value=7) as insert:
+        return ra.scan_connection_candidates.run(user_id=1), insert
+
+
+class TestFirstDegreeIsNeverInvited:
+    def test_an_already_connected_engager_is_not_filed(self):
+        out, insert = _scan_connections(engagers=[_engager(degree="1st")])
+        insert.assert_not_called()
+        assert "No new connection candidates" in out
+
+    def test_a_second_degree_engager_is_still_filed(self):
+        _out, insert = _scan_connections(engagers=[_engager(degree="2nd")])
+        assert insert.call_count == 1
+        assert "2nd-degree" in insert.call_args.kwargs["reasons"]
+
+    def test_an_unbadged_engager_is_still_filed(self):
+        # A missing badge is unknown, not connected — failing closed here would stop all outreach.
+        _out, insert = _scan_connections(engagers=[_engager(degree=None)])
+        assert insert.call_count == 1
+
+    def test_the_send_path_aborts_on_a_first_degree_profile(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.db import ALREADY_CONNECTED_MESSAGE
+        badge = MagicMock()
+        badge.text = "1st"
+        driver = MagicMock()
+        driver.find_elements.return_value = [badge]
+        with patch(f"{_RA}.get_user_password_pair_by_id", return_value=("e@x", "pw")), \
+             patch(f"{_RA}.get_driver_wait_pair", return_value=(driver, MagicMock())), \
+             patch(f"{_RA}.login_to_linkedin"), \
+             patch(f"{_RA}.click_element_wait_retry") as click, \
+             patch(f"{_RA}.insert_new_log") as log, \
+             patch(f"{_RA}.quit_gracefully"):
+            sent, reason = ra.invite_to_connect_now(1, "https://x/in/jane")
+        assert sent is False and reason == ALREADY_CONNECTED_MESSAGE
+        click.assert_not_called()  # never hunts for a Connect button that cannot exist
+        log.assert_called_once()
+
+    def test_an_unreadable_badge_does_not_block_the_invite(self):
+        from cqc_lem.app import run_automation as ra
+        driver = MagicMock()
+        driver.find_elements.side_effect = Exception("stale element")
+        assert ra._profile_is_first_degree(driver) is False
+
+
+class TestIcpFloorAtFileTime:
+    def test_a_scored_candidate_below_the_floor_is_never_filed(self):
+        facts = {"https://www.linkedin.com/in/jane-doe": {"job_title": "intern",
+                                                          "industry": "retail"}}
+        out, insert = _scan_connections(facts=facts, prefs=_prefs(min_connection_icp_score=90))
+        insert.assert_not_called()
+        assert "No new connection candidates" in out
+
+    def test_an_unscored_candidate_files_with_no_icp_score(self):
+        # The one production row stored ICP_UNKNOWN (50) against a floor of 55, so it read as
+        # below the user's own threshold. No facts now means no number at all.
+        _out, insert = _scan_connections()
+        assert insert.call_args.kwargs["icp_score"] is None
+        assert "ICP fit unknown" in insert.call_args.kwargs["reasons"]
+
+    def test_a_scored_candidate_above_the_floor_keeps_its_score(self):
+        facts = {"https://www.linkedin.com/in/jane-doe": {
+            "job_title": "VP Revenue Operations", "company_name": "Acme",
+            "industry": "revenue operations"}}
+        _out, insert = _scan_connections(facts=facts)
+        assert insert.call_args.kwargs["icp_score"] >= 55
+
+
+class TestFailureReasonIsRecorded:
+    def test_a_failed_send_stores_why(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.db import ConnectionRequestStatus
+        req = {"id": 3, "user_id": 1, "recipient_profile_url": "https://x/in/jane",
+               "message": "hi", "status": "approved"}
+        with patch("cqc_lem.utilities.db.get_connection_request", return_value=req), \
+             patch("cqc_lem.utilities.db.count_invites_sent_today", return_value=0), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={"max_invites_per_day": 10}), \
+             patch(f"{_RA}.invite_to_connect_now", return_value=(False, "Already connected")), \
+             patch("cqc_lem.utilities.db.update_connection_request_status") as upd:
+            ra.send_connection_request(3)
+        upd.assert_called_once_with(3, ConnectionRequestStatus.FAILED,
+                                    failure_reason="Already connected")
+
+
+class TestReplyCheckUnblocksNurture:
+    """The chain that left scheduled_dms empty since V53: stock DM templates are step-0 only, so
+    enqueue_next_followup found no step 1, queued nothing, and process_user_followups never ran."""
+
+    def test_an_appreciation_dm_now_leaves_a_reply_check_behind(self, monkeypatch):
+        from cqc_lem.app import run_automation as ra
+        monkeypatch.delenv("DM_NURTURE_ENABLED", raising=False)
+        with patch(f"{_RA}.build_dm_from_template", return_value="hi Jane"), \
+             patch(f"{_RA}.send_private_dm") as dm, \
+             patch(f"{_RA}.get_dm_template", return_value=None), \
+             patch(f"{_RA}.enqueue_followup") as enq:
+            sent = ra._dispatch_appreciation_dms(1, MagicMock(), "connection_accepted",
+                                                 {"https://x/in/jane": "Jane Doe • 1st"})
+        assert sent == 1
+        dm.apply_async.assert_called_once()
+        enq.assert_called_once()  # the thread stays on the sequencer instead of going cold
+
+    def test_the_recipient_name_is_cleaned_before_it_reaches_the_template(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.build_dm_from_template", return_value="hi") as build, \
+             patch(f"{_RA}.send_private_dm"), \
+             patch(f"{_RA}.enqueue_next_followup"):
+            ra._dispatch_appreciation_dms(1, MagicMock(), "connection_accepted",
+                                          {"https://x/in/h": "Harshal Karanpuriya Verified Profile 1st"})
+        assert build.call_args[0][2] == "Harshal"
+
+    def test_a_missing_template_is_logged_not_swallowed(self, caplog):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.build_dm_from_template", return_value=None), \
+             patch(f"{_RA}.send_private_dm") as dm:
+            sent = ra._dispatch_appreciation_dms(1, MagicMock(), "collaboration",
+                                                 {"https://x/in/jane": "Jane"})
+        assert sent == 0
+        dm.apply_async.assert_not_called()
+        assert "No 'collaboration' DM template" in caplog.text
+
+    def test_an_empty_followup_run_says_so(self, caplog):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.get_due_followups", return_value=[]):
+            out = ra.process_user_followups.run(user_id=1)
+        assert out == "No due follow-ups"
+        assert "no nurture draft" in caplog.text
+
+    def test_nurture_says_so_when_it_is_switched_off(self, monkeypatch, caplog):
+        from cqc_lem.app import run_automation as ra
+        monkeypatch.setenv("DM_NURTURE_ENABLED", "false")
+        assert ra._nurture_after_reply(1, {"profile_url": "https://x/in/j"}, "sure, tell me more",
+                                       MagicMock()) is None
+        assert "DM nurture is disabled" in caplog.text
+
+
+def _roster(**over):
+    row = {"profile_url": "https://www.linkedin.com/in/guru-gary", "name": "Guru Gary • 1st",
+           "category": "creator", "active": True}
+    row.update(over)
+    return row
+
+
+def _scan_funnel(prefs=None, roster=None, engagers=None, open_targets=0, requested=None,
+                 existing=None, max_new=None, commenters=None, activity=None):
+    from cqc_lem.app import run_automation as ra
+    with patch(f"{_RA}.get_engagement_preferences",
+               return_value=prefs if prefs is not None else _prefs()), \
+         patch(f"{_RA}.count_open_outreach_targets", return_value=open_targets), \
+         patch(f"{_RA}.get_engagement_targets", return_value=roster if roster is not None else []), \
+         patch(f"{_RA}.get_engager_candidates", return_value=engagers or []), \
+         patch(f"{_RA}.get_requested_person_keys", return_value=requested or set()), \
+         patch(f"{_RA}.get_outreach_target_by_url", return_value=existing), \
+         patch(f"{_RA}.get_or_create_profile_synthesis", return_value="voice"), \
+         patch(f"{_RA}.generate_ai_response", return_value="A grounded comment."), \
+         patch(f"{_RA}.get_ai_message_refinement", return_value="Refined note"), \
+         patch(f"{_RA}.insert_outreach_target", return_value=11) as insert, \
+         patch(f"{_RA}._harvest_post_commenters", return_value=commenters or []), \
+         patch("cqc_lem.utilities.linkedin.scrapper.get_profile_recent_activity",
+               return_value=activity if activity is not None
+               else [{"link": "https://x/feed/update/1", "text": "Post body"}]), \
+         patch(f"{_RA}.get_current_profile") as profile, \
+         patch(f"{_RA}.quit_gracefully"):
+        profile.return_value = (MagicMock(), MagicMock(), "me@x.com",
+                                MagicMock(full_name="Me Myself"))
+        return ra.scan_outreach_funnel_targets.run(user_id=1, max_new=max_new), insert
+
+
+class TestOutreachFunnelSourcing:
+    def test_a_roster_author_becomes_a_comment_stage_draft(self):
+        from cqc_lem.utilities.db import OutreachStage, OutreachStatus
+        out, insert = _scan_funnel(roster=[_roster()])
+        assert insert.call_count == 1
+        kwargs = insert.call_args.kwargs
+        assert kwargs["stage"] == OutreachStage.COMMENT
+        assert kwargs["context_url"] == "https://x/feed/update/1"
+        assert kwargs["draft_text"] == "A grounded comment."
+        assert kwargs["target_name"] == "Guru Gary"  # badge text stripped
+        assert kwargs["status"] == OutreachStatus.APPROVED  # auto_approve mode
+        assert "Filed 1" in out
+
+    def test_pre_review_mode_files_a_draft_for_approval(self):
+        from cqc_lem.utilities.db import OutreachStatus
+        _out, insert = _scan_funnel(roster=[_roster()],
+                                    prefs=_prefs(connection_request_mode="pre_review"))
+        assert insert.call_args.kwargs["status"] == OutreachStatus.PENDING
+
+    def test_commenters_on_a_roster_post_are_sourced_with_that_post(self):
+        from cqc_lem.utilities.connection_targeting import CandidateSignal
+        commenter = CandidateSignal(person_name="Guru Fan",
+                                    person_profile_url="https://www.linkedin.com/in/guru-fan")
+        _out, insert = _scan_funnel(roster=[_roster()], commenters=[commenter])
+        urls = [c.args[1] for c in insert.call_args_list]
+        assert "https://www.linkedin.com/in/guru-fan" in urls
+
+    def test_post_engagers_start_at_the_connect_stage(self):
+        from cqc_lem.utilities.db import OutreachStage
+        _out, insert = _scan_funnel(engagers=[_engager(degree="2nd")])
+        assert insert.call_args.kwargs["stage"] == OutreachStage.CONNECT
+        assert insert.call_args.kwargs["context_url"] is None
+
+    def test_an_already_connected_engager_is_not_sourced(self):
+        out, insert = _scan_funnel(engagers=[_engager(degree="1st")])
+        insert.assert_not_called()
+        assert "No outreach funnel prospects" in out
+
+    def test_someone_already_in_connection_requests_is_skipped(self):
+        out, insert = _scan_funnel(engagers=[_engager(degree="2nd")],
+                                   requested={"in:jane-doe"})
+        insert.assert_not_called()
+        assert "Filed 0" in out
+
+    def test_a_target_already_in_the_funnel_is_skipped(self):
+        _out, insert = _scan_funnel(engagers=[_engager(degree="2nd")], existing={"id": 1})
+        insert.assert_not_called()
+
+    def test_targeting_off_sources_nothing(self):
+        out, insert = _scan_funnel(prefs=_prefs(connection_targeting_mode="off"),
+                                   engagers=[_engager(degree="2nd")])
+        insert.assert_not_called()
+        assert "off" in out
+
+    def test_a_deep_approval_backlog_stops_sourcing(self, caplog):
+        out, insert = _scan_funnel(engagers=[_engager(degree="2nd")], open_targets=25)
+        insert.assert_not_called()
+        assert "backlog full" in out
+        assert "already waiting for approval" in caplog.text
+
+    def test_the_per_scan_budget_is_respected(self):
+        engagers = [_engager(name=f"P{i}", slug=f"p{i}", degree="2nd") for i in range(8)]
+        _out, insert = _scan_funnel(engagers=engagers, max_new=2)
+        assert insert.call_count == 2
+
+    def test_an_empty_roster_and_no_engagers_is_logged(self, caplog):
+        out, insert = _scan_funnel()
+        insert.assert_not_called()
+        assert "No outreach funnel prospects" in out
+        assert "only source from post engagers" in caplog.text
+
+    def test_roster_scraping_failure_still_sources_engagers(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.get_engagement_preferences", return_value=_prefs()), \
+             patch(f"{_RA}.count_open_outreach_targets", return_value=0), \
+             patch(f"{_RA}.get_engagement_targets", return_value=[_roster()]), \
+             patch(f"{_RA}.get_engager_candidates", return_value=[_engager(degree="2nd")]), \
+             patch(f"{_RA}.get_requested_person_keys", return_value=set()), \
+             patch(f"{_RA}.get_outreach_target_by_url", return_value=None), \
+             patch(f"{_RA}.get_ai_message_refinement", return_value="Refined note"), \
+             patch(f"{_RA}.get_current_profile", side_effect=RuntimeError("no session")), \
+             patch(f"{_RA}.insert_outreach_target", return_value=11) as insert:
+            out = ra.scan_outreach_funnel_targets.run(user_id=1)
+        assert insert.call_count == 1 and "Filed 1" in out
+
+    def test_a_gated_comment_draft_leaves_the_text_to_the_operator(self):
+        from cqc_lem.app import run_automation as ra
+        # generate_ai_response returns None when the #617 quality gate rejects every attempt.
+        with patch(f"{_RA}.generate_ai_response", return_value=None):
+            assert ra._draft_funnel_comment(1, {"context_text": "Post body"}, MagicMock()) == ""
+        with patch(f"{_RA}.generate_ai_response", side_effect=RuntimeError("llm down")):
+            assert ra._draft_funnel_comment(1, {"context_text": "Post body"}, MagicMock()) == ""
+        assert ra._draft_funnel_comment(1, {"context_text": ""}, MagicMock()) == ""
+
+
+class TestSourcingDispatch:
+    def test_dispatches_per_active_user(self):
+        from cqc_lem.app import run_scheduler as rs
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \
+             patch(f"{_RA}.scan_outreach_funnel_targets.apply_async") as dispatch:
+            out = rs.auto_scan_outreach_funnel_targets()
+        assert dispatch.call_count == 2
+        assert "2 user(s)" in out
+
+    def test_skips_when_throttled(self):
+        from cqc_lem.app import run_scheduler as rs
+        with patch(f"{_RS}._skip_if_throttled", return_value=True), \
+             patch(f"{_RA}.scan_outreach_funnel_targets.apply_async") as dispatch:
+            out = rs.auto_scan_outreach_funnel_targets()
+        dispatch.assert_not_called()
+        assert out == "Automation throttled"
+
+    def test_beat_schedule_includes_the_scan(self):
+        from cqc_lem.app.my_celery import app
+        entry = app.conf.beat_schedule["scan-outreach-funnel-targets"]
+        assert entry["task"] == "cqc_lem.app.run_scheduler.auto_scan_outreach_funnel_targets"
+
+    def test_sourcing_runs_on_the_outreach_lane(self):
+        from cqc_lem.app import run_automation as ra
+        assert ra.scan_outreach_funnel_targets.queue == "se_outreach"

--- a/tests/unit/utilities/linkedin/test_person_name_cleaning.py
+++ b/tests/unit/utilities/linkedin/test_person_name_cleaning.py
@@ -1,0 +1,93 @@
+"""Scraped display-name hygiene + connection-degree detection (issue #623).
+
+The strings here are the shapes LinkedIn's SDUI actually produces inside a profile link — including
+the exact value that landed in production's one and only connection_requests row.
+"""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture()
+def helper():
+    # Imported lazily: helper.py pulls in the AI client, which needs the session env fixture.
+    from cqc_lem.utilities.linkedin import helper as h
+    return h
+
+
+class TestCleanPersonName:
+    def test_strips_verified_badge_and_degree_from_the_production_row(self, helper):
+        assert helper.clean_person_name("Harshal Karanpuriya Verified Profile 1st") == \
+            "Harshal Karanpuriya"
+
+    def test_strips_bullet_separated_degree(self, helper):
+        assert helper.clean_person_name("Jane Doe • 2nd") == "Jane Doe"
+        assert helper.clean_person_name("Jane Doe · 3rd+") == "Jane Doe"
+
+    def test_strips_multiline_sdui_stack(self, helper):
+        raw = "Jane Doe\nJane Doe\n• 3rd+\nSenior Director at Acme"
+        assert helper.clean_person_name(raw) == "Jane Doe"
+
+    def test_takes_the_name_out_of_an_aria_label(self, helper):
+        assert helper.clean_person_name("View Jane Doe’s profile") == "Jane Doe"
+        assert helper.clean_person_name("View Jane Doe's profile") == "Jane Doe"
+
+    def test_skips_leading_status_badges(self, helper):
+        assert helper.clean_person_name("Status is online\nJane Doe\n• 1st") == "Jane Doe"
+        assert helper.clean_person_name("Status is offline\nJane Doe") == "Jane Doe"
+
+    def test_collapses_the_duplicated_screen_reader_copy(self, helper):
+        assert helper.clean_person_name("Jane Doe Jane Doe") == "Jane Doe"
+
+    def test_strips_degree_written_out_in_full(self, helper):
+        assert helper.clean_person_name("Jane Doe 1st degree connection") == "Jane Doe"
+
+    def test_strips_premium_influencer_and_hiring_badges(self, helper):
+        assert helper.clean_person_name("Jane Doe Premium") == "Jane Doe"
+        assert helper.clean_person_name("Jane Doe Influencer 2nd") == "Jane Doe"
+        assert helper.clean_person_name("Jane Doe is hiring") == "Jane Doe"
+        assert helper.clean_person_name("Jane Doe Open to work") == "Jane Doe"
+
+    def test_normalizes_whitespace_and_non_breaking_spaces(self, helper):
+        assert helper.clean_person_name("  Jane   Doe  ") == "Jane Doe"
+        assert helper.clean_person_name("Jane Doe  • 1st") == "Jane Doe"
+
+    def test_keeps_credentials_and_punctuation_in_a_real_name(self, helper):
+        assert helper.clean_person_name("Jane Doe, PhD") == "Jane Doe, PhD"
+        assert helper.clean_person_name("Renée O'Brien-Smith 2nd") == "Renée O'Brien-Smith"
+
+    def test_returns_empty_when_nothing_name_like_survives(self, helper):
+        assert helper.clean_person_name("• 1st") == ""
+        assert helper.clean_person_name("Status is online") == ""
+        assert helper.clean_person_name("") == ""
+        assert helper.clean_person_name(None) == ""
+
+    def test_caps_at_the_column_width(self, helper):
+        assert len(helper.clean_person_name("x" * 400)) == 255
+
+
+class TestConnectionDegree:
+    @pytest.mark.parametrize("raw,expected", [
+        ("Jane Doe Verified Profile 1st", "1st"),
+        ("Jane Doe • 2nd", "2nd"),
+        ("Jane Doe • 3rd", "3rd+"),
+        ("Jane Doe • 3rd+", "3rd+"),
+        ("Jane Doe 1ST DEGREE CONNECTION", "1st"),
+        ("Jane Doe", None),
+        ("", None),
+        (None, None),
+    ])
+    def test_reads_the_badge(self, helper, raw, expected):
+        assert helper.connection_degree(raw) == expected
+
+    def test_does_not_fire_on_a_word_that_merely_contains_a_degree_token(self, helper):
+        assert helper.connection_degree("Jane Doe1st") is None
+        assert helper.connection_degree("Christ2ndsen") is None
+
+    def test_is_first_degree_only_on_an_explicit_first_degree_badge(self, helper):
+        assert helper.is_first_degree("Jane Doe • 1st") is True
+        assert helper.is_first_degree("Jane Doe • 2nd") is False
+        # A missing badge is UNKNOWN, not "not connected" — callers must fail open.
+        assert helper.is_first_degree("Jane Doe") is False
+        assert helper.is_first_degree("") is False

--- a/tests/unit/utilities/test_db_network_activation.py
+++ b/tests/unit/utilities/test_db_network_activation.py
@@ -1,0 +1,98 @@
+"""DB layer for network activation (issue #623): engager connection-degree capture, connection
+request failure reasons, and the outreach-funnel backlog counter."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _mock_conn(fetch_one=None, fetch_all=None):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.fetchone.return_value = fetch_one
+    cur.fetchall.return_value = fetch_all or []
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestEngagerConnectionDegree:
+    def test_degree_is_written_and_coalesced(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import upsert_engager
+            assert upsert_engager(1, "Jane Doe", "https://x/in/jane", connection_degree="2nd") is True
+        sql, params = cur.execute.call_args[0]
+        assert "connection_degree" in sql
+        # A later sighting with no badge must not erase a degree we already know.
+        assert "connection_degree=COALESCE(VALUES(connection_degree), connection_degree)" in sql
+        assert params[3] == "2nd"
+
+    def test_missing_degree_is_stored_as_null(self):
+        conn, cur = _mock_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import upsert_engager
+            upsert_engager(1, "Jane Doe", "https://x/in/jane")
+        assert cur.execute.call_args[0][1][3] is None
+
+    def test_candidates_expose_the_degree(self):
+        rows = [{"person_name": "Jane", "person_profile_url": "https://x/in/jane",
+                 "connection_degree": "1st", "occurred_at": None}]
+        conn, cur = _mock_conn(fetch_all=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_engager_candidates
+            out = get_engager_candidates(1)
+        assert "connection_degree" in cur.execute.call_args[0][0]
+        assert out[0]["connection_degree"] == "1st"
+
+
+class TestConnectionRequestFailureReason:
+    def test_failure_reason_is_stored_and_truncated(self):
+        conn, cur = _mock_conn()
+        cur.rowcount = 1
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import (update_connection_request_status,
+                                              ConnectionRequestStatus)
+            assert update_connection_request_status(3, ConnectionRequestStatus.FAILED,
+                                                    failure_reason="x" * 900) is True
+        sql, params = cur.execute.call_args[0]
+        assert "failure_reason" in sql
+        assert len(params[1]) == 512
+
+    def test_a_status_change_without_a_reason_clears_the_old_one(self):
+        conn, cur = _mock_conn()
+        cur.rowcount = 1
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import (update_connection_request_status,
+                                              ConnectionRequestStatus)
+            update_connection_request_status(3, ConnectionRequestStatus.SENT)
+        assert cur.execute.call_args[0][1][1] is None
+
+    def test_failure_reason_is_selected_for_the_review_ui(self):
+        conn, cur = _mock_conn(fetch_one={"id": 3})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_connection_request
+            get_connection_request(3)
+        assert "failure_reason" in cur.execute.call_args[0][0]
+
+
+class TestOpenOutreachTargetCount:
+    def test_counts_pending_and_approved_only(self):
+        conn, cur = _mock_conn(fetch_one=(4,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_open_outreach_targets
+            assert count_open_outreach_targets(1) == 4
+        sql = cur.execute.call_args[0][0]
+        assert "'pending','approved'" in sql and "stage <> 'completed'" in sql
+
+    def test_zero_when_the_query_fails(self):
+        import mysql.connector
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.execute.side_effect = mysql.connector.Error("no such table")
+        conn.cursor.return_value = cur
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_open_outreach_targets
+            assert count_open_outreach_targets(1) == 0


### PR DESCRIPTION
## Why

The 2026-07-26 production audit found the entire outbound layer idle, and every symptom traced to a missing input or a silent early exit:

| Table | Rows ever | Why |
|---|---|---|
| `connection_requests` | 1 (failed) | recipient name was `Harshal Karanpuriya Verified Profile 1st` (SDUI badge text scraped into the name), the target was an existing **1st-degree** connection, and it stored `icp_score 50` against a floor of `55` |
| `outreach_funnel_targets` | 0 | #399 shipped a processor; **nothing ever produced a target** — the only way in was an API nobody calls |
| `scheduled_dms` | 0 | the stock DM templates are **step-0 only**, so `enqueue_next_followup` found no step 1 and queued nothing → `dm_followups` stayed empty → `process_user_followups` never ran → no reply was ever read → #485 nurture could never draft |
| `post_engagers` | 1 | — |

## What changed

**Name + degree hygiene** (`utilities/linkedin/helper.py`)
`clean_person_name` / `connection_degree` / `is_first_degree` strip LinkedIn's badge, status and degree text out of a scraped display name and keep the degree as its own signal. Applied at every capture site: the reply sweep, adjacent-post commenter harvest, appreciation DMs, profile-viewer DMs.

**Never invite someone we're already connected to**
New nullable `post_engagers.connection_degree` captures the badge at scrape time. `rank_candidates` drops 1st-degree candidates and `scan_connection_candidates` re-checks before filing. `invite_to_connect_now` also aborts on a 1st-degree profile page rather than hunting for a Connect button that cannot exist. **Fail-open throughout**: a missing badge is *unknown*, not "not connected" — failing closed on a selector drift would stop all outreach.

**ICP floor honoured at file time**
Candidates with no profile facts now file with **no `icp_score`** instead of `ICP_UNKNOWN` (50), so no row ever reads as below the user's own floor; `reasons` still says the fit is unverified. Scored candidates below the floor are skipped before insert.

**`failure_reason`**
New nullable `connection_requests.failure_reason`. `invite_to_connect_now` returns `(sent, reason)`; `send_connection_request` stores it; the Connections review UI shows *"Why it failed: …"* on failed rows and *"ICP fit unverified"* when there's no score.

**Outreach funnel sourcing** — new `scan_outreach_funnel_targets` (daily 04:20 UTC, `se_outreach` lane)
Fills #399's funnel from the three warm surfaces we already track:
- the **engagement roster** (G1 / #616) — the author, paired with their most recent post
- **commenters on roster posts** — paired with that same post
- **`post_engagers`** — start at the *connect* stage (they already engaged with us, so there's no third-party post to comment on first)

Comment-stage drafts come from the same grounded generator + #617 quality/similarity gate the feed uses; a gated draft is left blank for the operator rather than shipping a template comment. Deduped against `connection_requests` *and* existing funnel rows, capped per scan (`MAX_NEW_FUNNEL_TARGETS_PER_SCAN=5`) and by approval-backlog depth (`MAX_OPEN_FUNNEL_TARGETS=25`). Nothing sends: targets file as drafts under the user's existing `connection_request_mode`, and each fired stage still drops back to `pending` for a fresh approval.

**Reply check unblocks nurture**
When a sequence has no next-step template, `enqueue_next_followup` now queues a **reply check** at that step (`DM_REPLY_CHECK_DELAY_HOURS=48`) instead of ending the thread. A reply becomes an approval-gated nurture draft; silence hits the existing "no template for this step" branch and stops the sequence — it can never send an extra DM. This is the shape `_schedule_catchup_followup` already used for catch-up touches (#482), generalized.

**Silence is no longer possible**
Every DM / nurture / targeting early exit now logs *why* (`log_warning` for "the pipeline did nothing", `log_info` for a deliberate per-candidate skip), so an idle flywheel shows up in PostHog instead of returning a string nobody reads.

## Migration

`V20260726074650__add_network_activation_fields.sql` — two nullable columns (`post_engagers.connection_degree`, `connection_requests.failure_reason`). Additive only, no backfill, no data loss.

## Testing

- `tests/unit/utilities/linkedin/test_person_name_cleaning.py` — 22 tests over the real SDUI name shapes, including the exact production value; degree parsing, aria-label extraction, and the fail-open contract.
- `tests/unit/app/test_network_activation.py` — 1st-degree skip (source + send), ICP floor at file time, failure-reason recording, funnel sourcing (all three surfaces, dedup, caps, degraded roster, gated draft), reply-check enqueue, and the early-exit log assertions.
- `tests/unit/utilities/test_db_network_activation.py` — degree COALESCE, failure-reason write/clear/truncate, backlog counter.
- `tests/unit/app/test_dm_followups.py` — the old "no next template → enqueue nothing" test asserted the bug; replaced with the reply-check behaviour plus nurture-off and no-double-check cases.

`poetry run pytest tests/unit -q` → **5797 passed**.

## Notes for review

- The one judgement call: an engager we have **no profile facts** for is still filed (ranked on warmth, `icp_score` NULL) rather than rejected by the floor. Rejecting them would reject nearly every engager — most are never scraped — and throw away the warm-engager signal the feature exists to use. The fix is that such a row no longer *claims* a score below the user's threshold.
- Funnel sourcing reuses `connection_targeting_mode=off` as the "don't source outbound" switch rather than adding a new preference.

Closes #623

🤖 Generated with [Claude Code](https://claude.com/claude-code)
