### PR TITLE
fix(review): post-merge adversarial review of #661/#662/#665 (closes #670)

### DIFF
--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -1072,15 +1072,18 @@ def _score_and_persist_dwell(user_id: int, post_id: int, content: str) -> Option
 
 
 def _fabricated_specifics(content: str, story: Optional[dict],
-                          profile_synthesis: Optional[str] = None) -> list:
+                          profile_synthesis: Optional[str] = None,
+                          *extra_sources: Optional[str]) -> list:
     """First-person specifics in the draft that appear in NONE of the material we supplied — i.e.
     invented facts about the author (issue #620, enforcing the #416 no-fabrication rule). Only
     meaningful when a story entry was selected: with no entry there is no allow-list, so every
-    number would look fabricated and the check is skipped entirely."""
+    number would look fabricated and the check is skipped entirely. `extra_sources` covers other
+    text we legitimately handed the writer (e.g. the lead-magnet CTA directive, whose keyword or
+    resource name can carry a number) so it is never flagged as invented."""
     if not story or not content:
         return []
     return _story_bank.unsourced_specifics(
-        content, _story_bank.fact_sources(story, profile_synthesis))
+        content, _story_bank.fact_sources(story, profile_synthesis, *extra_sources))
 
 
 def _review_generated_post(user_id: int, stage: str, post_type: str, user_profile: LinkedInProfile,
@@ -1106,7 +1109,7 @@ def _review_generated_post(user_id: int, stage: str, post_type: str, user_profil
     too_similar = score > threshold
     missing_proof = not has_first_person_proof(content)
     proof_regen = missing_proof and _proof_regen_enabled()
-    fabricated = _fabricated_specifics(content, story, profile_synthesis)
+    fabricated = _fabricated_specifics(content, story, profile_synthesis, lead_magnet_cta)
     fabrication_regen = bool(fabricated) and _fabrication_regen_enabled()
     # No-fabrication guard (issue #619 / G4) — only on the archetypes whose value IS the specifics.
     # Checked against the user's verified story bank (#620 / G5), so a real number out of their own
@@ -1171,7 +1174,7 @@ def _review_generated_post(user_id: int, stage: str, post_type: str, user_profil
         log_warning("Post still lacks a concrete first-person lived detail after retry "
                     "(A2 proof slot); keeping second attempt",
                     user_id=user_id, post_id=post_id, task_name="create_text_post")
-    still_fabricated = _fabricated_specifics(second, story, profile_synthesis)
+    still_fabricated = _fabricated_specifics(second, story, profile_synthesis, lead_magnet_cta)
     if still_fabricated:
         log_warning(f"Post still states first-person specifics not in the story bank after retry "
                     f"({', '.join(still_fabricated)}); keeping second attempt",
@@ -1259,6 +1262,36 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
     if history_directive is None:
         history_directive = history_avoidance_directive(recent_texts)
 
+    # Story bank (issue #620): anchor the post to ONE thing the user actually did, and make that
+    # entry the ONLY personal specific the writer may state. An empty bank — or a bank with nothing
+    # related to the user's focus topics — ships the explicit no-fabrication fallback instead, so a
+    # missing story degrades to an industry observation rather than an invented anecdote. Recursive
+    # calls (type fallbacks / the review-gate retry) receive the directive so the whole post stays
+    # anchored to the same entry and the bank is read at most once per outermost call. Selected
+    # BEFORE the blueprint so the promo demotion below can still steer shape selection.
+    story = None
+    story_selected_here = story_directive is None
+    if story_selected_here:
+        story = _select_story_for_post(user_id, prefs, blueprint)
+        story_directive = _story_bank.story_directive(story)
+        if story:
+            myprint(f"Story bank anchor for post_id={post_id}: "
+                    f"[{story.get('kind')}] {story.get('title')}")
+        else:
+            myprint("No story bank entry available — writing a non-story archetype")
+
+    # Integration seam (#618 x #620): the promo slot demands a case study built on ONE real outcome
+    # number, but without a story-bank anchor the fabrication detector has no allow-list and is
+    # skipped entirely — so the one post most likely to invent a client figure would ship unchecked.
+    # A promo post the bank cannot ground is demoted to audience-value content instead (and NOT
+    # forced into the case_snapshot blueprint below). The plan row keeps its 'promo' class, which
+    # only makes the dashboard's mix-compliance ratio conservative.
+    if story_selected_here and story is None and content_mix == ContentMix.PROMO.value:
+        log_warning("Promo slot has no story-bank anchor — demoting this post to 'value' so a "
+                    "case study cannot be invented", user_id=user_id, post_id=post_id,
+                    task_name="create_text_post")
+        content_mix = ContentMix.VALUE.value
+
     # ONE assigned SHAPE per post from the SHARED framework core (content_framework): rotate away
     # from this user's recently used post archetypes/hook styles (V51 history) exactly the way
     # newsletter editions rotate — chosen in code, no extra LLM call.
@@ -1273,28 +1306,15 @@ def create_text_post(user_id: int, stage: str, post_type: str = None, user_profi
     myprint(f"Post blueprint: format={blueprint.get('format')} hook={blueprint.get('hook_style')} "
             f"cta={blueprint.get('cta_style')}")
 
-    # Story bank (issue #620): anchor the post to ONE thing the user actually did, and make that
-    # entry the ONLY personal specific the writer may state. An empty bank — or a bank with nothing
-    # related to the user's focus topics — ships the explicit no-fabrication fallback instead, so a
-    # missing story degrades to an industry observation rather than an invented anecdote. Recursive
-    # calls (type fallbacks / the review-gate retry) receive the directive so the whole post stays
-    # anchored to the same entry and the bank is read at most once per outermost call.
-    story = None
-    if story_directive is None:
-        story = _select_story_for_post(user_id, prefs, blueprint)
-        story_directive = _story_bank.story_directive(story)
-        # The no-fabrication allow-list a fact-anchored archetype (#619) writes against is exactly
-        # the entry it was handed — a number from some OTHER bank entry was never in this prompt, so
-        # the writer stating one would still be inventing. Carried ON the blueprint because that is
-        # what every post-prompt builder (and the recursive type fallbacks) already thread through —
-        # on a copy, so a blueprint the caller owns is never mutated behind its back.
+    # The no-fabrication allow-list a fact-anchored archetype (#619) writes against is exactly the
+    # entry the story bank handed us above — a number from some OTHER bank entry was never in this
+    # prompt, so the writer stating one would still be inventing. Carried ON the blueprint because
+    # that is what every post-prompt builder (and the recursive type fallbacks) already thread
+    # through — on a copy, so a blueprint the caller owns is never mutated behind its back. Only
+    # when the story was selected HERE: a recursive call was handed both, already paired.
+    if story_selected_here:
         blueprint = {**blueprint,
                      "fact_anchors": _story_bank.fact_sources(story) if story else []}
-        if story:
-            myprint(f"Story bank anchor for post_id={post_id}: "
-                    f"[{story.get('kind')}] {story.get('title')}")
-        else:
-            myprint("No story bank entry available — writing a non-story archetype")
 
     # Lead-magnet soft-ask: on a deterministic 1-in-N rotation (keyed off post_id so it's stable and
     # testable), weave the user's configured "comment KEYWORD and I'll DM it to you" CTA into the

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -227,6 +227,10 @@ ARTIFACT_CTA_POLICY = (
 
 # Precision over recall, the _SOFT_OFFER_RE philosophy: each pattern needs explicit meeting intent, so
 # ordinary prose ("we scheduled the migration", "let's talk about why this matters") is never flagged.
+# The verb-less forms below lean on these anchors for that intent: an ask either OPENS the sentence
+# (headline/imperative) or addresses the reader as "you". Mid-sentence, the same words are narrative.
+_SENTENCE_START = r"(?:^|[.?!\n:;])[^\w]{0,6}"
+_READER_ADDRESSED = r"(?:" + _SENTENCE_START + r"|\byou(?:'re|\s+are)?\s+)"
 _MEETING_ASK_PATTERNS: tuple = (
     r"\bbook(?:ing)?\s+(?:a|an|your|some|my)\s+(?:call|time|slot|demo|meeting|chat|consult\w*|session|intro\w*)",
     r"\bschedul(?:e|ing)\s+(?:a|an|your|some|our)\s+(?:call|time|demo|meeting|chat|consult\w*|session|intro\w*)",
@@ -243,15 +247,20 @@ _MEETING_ASK_PATTERNS: tuple = (
     r"(?:(?:free|quick|short|discovery|intro(?:ductory)?|strategy|\d{1,2}[- ]min(?:ute)?)\s+)+"
     r"(?:call|consult\w*|session|chat|demo)\b",
     # Same offer, framed as the reader's interest instead of a verb ("Want a free strategy session?").
-    # Still explicit meeting intent — narrative uses the past tense ("I wanted a quick call"), which
-    # cannot match.
-    r"\b(?:want|interested\s+in|up\s+for|ready\s+for|keen\s+on)\s+(?:a|an|your|some)?\s*"
+    # It must be addressed to the READER — opening the sentence, or an explicit "you" — because the
+    # identical words are ordinary third-person present narrative ("Most buyers want a quick call
+    # before they commit", "they're ready for a strategy session"), and the repair DELETES whatever
+    # matches. Past-tense narrative ("I wanted a quick call") cannot match either way.
+    _READER_ADDRESSED + r"(?:want|interested\s+in|up\s+for|ready\s+for|keen\s+on)\s+"
+    r"(?:a|an|your|some)?\s*"
     r"(?:(?:free|quick|short|discovery|intro(?:ductory)?|strategy|\d{1,2}[- ]min(?:ute)?)\s+)+"
     r"(?:call|consult\w*|session|chat|demo)s?\b",
     # Headline offer with no verb at all ("Free discovery call for the first 5 people") — matched
-    # ONLY when an unambiguous booking marker follows in the same sentence, so narrative that merely
-    # mentions a call ("I ran a discovery call with them last week") is still left alone.
-    r"\b(?:free|quick|short|discovery|intro(?:ductory)?|strategy|\d{1,2}[- ]min(?:ute)?)\s+"
+    # ONLY when it OPENS the sentence (a headline, never a clause inside narrative: "that quick call
+    # led to a sign up", "after our discovery call I told them to DM me") AND an unambiguous booking
+    # marker follows in the same sentence.
+    _SENTENCE_START + r"(?:(?:free|quick|short|discovery|intro(?:ductory)?|strategy|"
+    r"\d{1,2}[- ]min(?:ute)?)\s+)+"
     r"(?:call|consult\w*|session|chat|demo)s?\b[^.?!\n]{0,40}?"
     r"\b(?:link\s+in\s+(?:bio|comments)|sign\s+up\b|dm\s+me\b|comment\s+below\b|"
     r"for\s+the\s+first\s+\d+|(?:slots?|spots?)\s+(?:are\s+)?(?:open|available|left)\b)",
@@ -271,6 +280,9 @@ def meeting_ask_excerpts(content: Optional[str]) -> list:
     seen = []
     for match in _MEETING_ASK_RE.findall(content):
         phrase = (match if isinstance(match, str) else next((m for m in match if m), "")).strip()
+        # The verb-less patterns anchor on the END of the previous sentence, so a mid-post match
+        # carries its punctuation in — the excerpt is shown to a human, keep it readable.
+        phrase = re.sub(r"^[^\w]+", "", phrase).strip()
         if phrase and phrase.lower() not in [s.lower() for s in seen]:
             seen.append(phrase)
     return seen

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -233,7 +233,12 @@ _MEETING_ASK_PATTERNS: tuple = (
     r"\b(?:hop|jump|get)\s+on\s+a\s+(?:quick\s+)?(?:call|zoom|chat|huddle)",
     r"\bset\s+up\s+(?:a|some)\s+(?:call|time|meeting|chat|demo|consult\w*)",
     r"\blet'?s\s+(?:set\s+up|schedule|book|find|grab)\s+(?:a|some)?\s*(?:call|time|chat|coffee|meeting)",
-    r"\b(?:free|quick|short|discovery|intro(?:ductory)?|strategy|\d{1,2}[- ]min(?:ute)?)\s+"
+    # Offer-verb context is REQUIRED: a bare "discovery call" / "strategy session" noun phrase also
+    # appears in ordinary first-person narrative ("I ran a discovery call last week" — often the
+    # story-bank anecdote itself), and the repair DELETES matching sentences, so flagging the noun
+    # phrase alone would silently destroy real story content.
+    r"\b(?:grab|claim|snag|book|schedule|join|reserve|get|offer(?:ing)?)\s+(?:a|your|my|this|some)\s+"
+    r"(?:(?:free|quick|short|discovery|intro(?:ductory)?|strategy|\d{1,2}[- ]min(?:ute)?)\s+)+"
     r"(?:call|consult\w*|session|chat|demo)\b",
     r"\b(?:calendly|savvycal|my\s+calendar\s+link|calendar\s+link|link\s+to\s+my\s+calendar)\b",
     r"\bdm\s+me\s+(?:to|if\s+you\s+want\s+to|and\s+we(?:'ll|\s+will|\s+can))\s+"

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -228,18 +228,33 @@ ARTIFACT_CTA_POLICY = (
 # Precision over recall, the _SOFT_OFFER_RE philosophy: each pattern needs explicit meeting intent, so
 # ordinary prose ("we scheduled the migration", "let's talk about why this matters") is never flagged.
 _MEETING_ASK_PATTERNS: tuple = (
-    r"\bbook(?:ing)?\s+(?:a|your|some|my)\s+(?:call|time|slot|demo|meeting|chat|consult\w*|session|intro\w*)",
-    r"\bschedul(?:e|ing)\s+(?:a|your|some|our)\s+(?:call|time|demo|meeting|chat|consult\w*|session|intro\w*)",
+    r"\bbook(?:ing)?\s+(?:a|an|your|some|my)\s+(?:call|time|slot|demo|meeting|chat|consult\w*|session|intro\w*)",
+    r"\bschedul(?:e|ing)\s+(?:a|an|your|some|our)\s+(?:call|time|demo|meeting|chat|consult\w*|session|intro\w*)",
     r"\b(?:hop|jump|get)\s+on\s+a\s+(?:quick\s+)?(?:call|zoom|chat|huddle)",
     r"\bset\s+up\s+(?:a|some)\s+(?:call|time|meeting|chat|demo|consult\w*)",
     r"\blet'?s\s+(?:set\s+up|schedule|book|find|grab)\s+(?:a|some)?\s*(?:call|time|chat|coffee|meeting)",
     # Offer-verb context is REQUIRED: a bare "discovery call" / "strategy session" noun phrase also
     # appears in ordinary first-person narrative ("I ran a discovery call last week" — often the
     # story-bank anecdote itself), and the repair DELETES matching sentences, so flagging the noun
-    # phrase alone would silently destroy real story content.
-    r"\b(?:grab|claim|snag|book|schedule|join|reserve|get|offer(?:ing)?)\s+(?:a|your|my|this|some)\s+"
+    # phrase alone would silently destroy real story content. 'an' belongs in every article set —
+    # "intro"/"introductory" only ever takes it, so leaving it out made "book an intro call"
+    # unmatchable.
+    r"\b(?:grab|claim|snag|book|schedule|join|reserve|get|offer(?:ing)?)\s+(?:a|an|your|my|this|some)\s+"
     r"(?:(?:free|quick|short|discovery|intro(?:ductory)?|strategy|\d{1,2}[- ]min(?:ute)?)\s+)+"
     r"(?:call|consult\w*|session|chat|demo)\b",
+    # Same offer, framed as the reader's interest instead of a verb ("Want a free strategy session?").
+    # Still explicit meeting intent — narrative uses the past tense ("I wanted a quick call"), which
+    # cannot match.
+    r"\b(?:want|interested\s+in|up\s+for|ready\s+for|keen\s+on)\s+(?:a|an|your|some)?\s*"
+    r"(?:(?:free|quick|short|discovery|intro(?:ductory)?|strategy|\d{1,2}[- ]min(?:ute)?)\s+)+"
+    r"(?:call|consult\w*|session|chat|demo)s?\b",
+    # Headline offer with no verb at all ("Free discovery call for the first 5 people") — matched
+    # ONLY when an unambiguous booking marker follows in the same sentence, so narrative that merely
+    # mentions a call ("I ran a discovery call with them last week") is still left alone.
+    r"\b(?:free|quick|short|discovery|intro(?:ductory)?|strategy|\d{1,2}[- ]min(?:ute)?)\s+"
+    r"(?:call|consult\w*|session|chat|demo)s?\b[^.?!\n]{0,40}?"
+    r"\b(?:link\s+in\s+(?:bio|comments)|sign\s+up\b|dm\s+me\b|comment\s+below\b|"
+    r"for\s+the\s+first\s+\d+|(?:slots?|spots?)\s+(?:are\s+)?(?:open|available|left)\b)",
     r"\b(?:calendly|savvycal|my\s+calendar\s+link|calendar\s+link|link\s+to\s+my\s+calendar)\b",
     r"\bdm\s+me\s+(?:to|if\s+you\s+want\s+to|and\s+we(?:'ll|\s+will|\s+can))\s+"
     r"(?:discuss|chat|talk|connect|explore|scope|walk)",

--- a/tests/unit/app/test_content_mix_governor.py
+++ b/tests/unit/app/test_content_mix_governor.py
@@ -122,7 +122,8 @@ class TestMixFlowsIntoGeneration:
         assert text.call_args.kwargs["content_mix"] == "authority"
 
 
-def _run_text_post(generated, content_mix=None, lead_magnet=None, newsletter=None, post_id=77):
+def _run_text_post(generated, content_mix=None, lead_magnet=None, newsletter=None, post_id=77,
+                   stories=None):
     """Drive create_text_post with a stubbed generator, returning (content, generator, blueprint)."""
     from cqc_lem.app import run_content_plan as rcp
     from cqc_lem.utilities.ai.content_framework import select_blueprint as real_select
@@ -135,6 +136,8 @@ def _run_text_post(generated, content_mix=None, lead_magnet=None, newsletter=Non
         patch(f"{_RCP}.get_newsletter_settings", return_value=newsletter or _NO_NEWSLETTER),
         patch(f"{_RCP}.get_recent_post_texts", return_value=[]),
         patch(f"{_RCP}.get_recent_post_shape_history", return_value=[]),
+        patch(f"{_RCP}.get_story_bank_entries", return_value=stories or []),
+        patch(f"{_RCP}.record_story_bank_use"),
         patch(f"{_RCP}.get_shape_performance", return_value=None),
         patch(f"{_RCP}.select_blueprint", selector),
         patch(f"{_RCP}.update_db_post_shape"),
@@ -171,10 +174,24 @@ class TestCreateTextPostMixHandling:
         _, gen, _ = _run_text_post(_CLEAN, content_mix="authority")
         assert gen.call_args.kwargs["content_mix"] == "authority"
 
-    def test_promo_slot_is_forced_into_a_case_study_shape(self):
-        _, gen, selector = _run_text_post(_CLEAN, content_mix="promo")
+    _PROMO_STORY = {"id": 5, "kind": "client_win", "title": "Churn fix",
+                    "body": "We cut a client's churn from 9% to 4% in one quarter.",
+                    "happened_at": None, "used_count": 0, "last_used_at": None, "active": True}
+
+    def test_promo_slot_with_a_story_anchor_is_forced_into_a_case_study_shape(self):
+        _, gen, selector = _run_text_post(_CLEAN, content_mix="promo",
+                                          stories=[self._PROMO_STORY])
         assert selector.call_args.kwargs["guidance"] == "case_snapshot"
         assert gen.call_args.kwargs["blueprint"]["format"] == "case_snapshot"
+        assert gen.call_args.kwargs["content_mix"] == "promo"
+
+    def test_promo_without_a_story_anchor_is_demoted_to_value(self):
+        # Integration seam (#618 x #620): with no story anchor the fabrication gate has no
+        # allow-list and is skipped — a promo case study would be free to invent its outcome
+        # number. The slot must degrade to audience-value content, not an invented case study.
+        _, gen, selector = _run_text_post(_CLEAN, content_mix="promo")
+        assert selector.call_args.kwargs["guidance"] is None
+        assert gen.call_args.kwargs["content_mix"] == "value"
 
     def test_unclassified_post_keeps_pure_shape_rotation(self):
         _, gen, selector = _run_text_post(_CLEAN)

--- a/tests/unit/app/test_story_bank_post_anchor.py
+++ b/tests/unit/app/test_story_bank_post_anchor.py
@@ -83,13 +83,13 @@ class TestUseAccounting:
         use.assert_not_called()
 
 
-def _review(content, story=_STORY, second="second draft", **env):
+def _review(content, story=_STORY, second="second draft", lead_magnet_cta="", **env):
     from cqc_lem.app import run_content_plan as rcp
     with patch(f"{_RCP}.create_text_post", return_value=second) as retry, \
          patch(f"{_RCP}._check_post_alignment", return_value=True), \
          patch.dict("os.environ", env, clear=False):
         out = rcp._review_generated_post(
-            1, "awareness", "thought_leadership", MagicMock(), {}, 77, "", content, [],
+            1, "awareness", "thought_leadership", MagicMock(), {}, 77, lead_magnet_cta, content, [],
             prefs={}, profile_synthesis="", story=story, story_directive="STORY DIRECTIVE")
     return out, retry
 
@@ -109,6 +109,17 @@ class TestFabricationGate:
         retry.assert_called_once()
         assert retry.call_args.kwargs["story_directive"] == "STORY DIRECTIVE"
         assert "47" in retry.call_args.kwargs["history_directive"]
+
+    def test_lead_magnet_cta_numbers_are_not_flagged_as_fabricated(self):
+        # The CTA directive is material WE handed the writer — a number in the user's configured
+        # resource name ("my 5-step checklist") must not trigger a spurious regeneration that
+        # would then be steered to strip the CTA mechanic.
+        cta = "Lead magnet: comment AUDIT and I'll DM you my 5-step checklist."
+        content = ("I cut a client's onboarding from 12 days to 3. "
+                   "Comment AUDIT and I'll DM you my 5-step checklist.")
+        out, retry = _review(content, lead_magnet_cta=cta)
+        assert out == content
+        retry.assert_not_called()
 
     def test_regeneration_can_be_switched_off(self):
         out, retry = _review(self._INVENTED, POST_FABRICATION_REGEN_ENABLED="off")

--- a/tests/unit/utilities/ai/test_content_mix.py
+++ b/tests/unit/utilities/ai/test_content_mix.py
@@ -124,6 +124,17 @@ class TestMeetingAskDetector:
         "DM me to discuss your funnel.",
         "Reach out and we can discuss the details.",
         "Booking a consult is the fastest way in.",
+        # 'an' is the ONLY article "intro"/"introductory" ever takes — an offer-verb pattern that
+        # omits it cannot match the most natural phrasing of the ask it exists to catch.
+        "Book an intro call with me this week.",
+        "Schedule an introductory call if that helps.",
+        "Grab an intro session on my calendar.",
+        # The same ask framed as the reader's interest, or as a bare headline offer with a booking
+        # marker — no offer verb, still unambiguously a meeting ask.
+        "Want a free strategy session? Comment below.",
+        "Interested in a discovery call?",
+        "Free discovery call for the first 5 people who reply.",
+        "Free strategy session — link in comments.",
     ])
     def test_flags_meeting_asks(self, text):
         from cqc_lem.utilities.ai.content_alignment import contains_meeting_ask
@@ -140,6 +151,9 @@ class TestMeetingAskDetector:
         "I ran a discovery call with them last week and it changed the scope.",
         "Our last strategy session surfaced three gaps in the funnel.",
         "The 30-minute call with their CTO was where the real problem showed up.",
+        "I book discovery calls with new clients every Friday.",
+        "I wanted a quick call but they were booked solid.",
+        "That discovery call opened my eyes to the real bottleneck.",
         "",
         None,
     ])

--- a/tests/unit/utilities/ai/test_content_mix.py
+++ b/tests/unit/utilities/ai/test_content_mix.py
@@ -135,6 +135,11 @@ class TestMeetingAskDetector:
         "I called the vendor twice before anyone answered.",
         "Comment AUDIT and I'll DM you the checklist.",
         "What would you have done differently? Curious how others handle this.",
+        # First-person NARRATIVE about calls/sessions is often the story-bank anecdote itself —
+        # the repair deletes flagged sentences, so a bare noun phrase must never match (#620 seam).
+        "I ran a discovery call with them last week and it changed the scope.",
+        "Our last strategy session surfaced three gaps in the funnel.",
+        "The 30-minute call with their CTO was where the real problem showed up.",
         "",
         None,
     ])

--- a/tests/unit/utilities/ai/test_content_mix.py
+++ b/tests/unit/utilities/ai/test_content_mix.py
@@ -135,6 +135,12 @@ class TestMeetingAskDetector:
         "Interested in a discovery call?",
         "Free discovery call for the first 5 people who reply.",
         "Free strategy session — link in comments.",
+        # Both verb-less forms still have to fire mid-post, where the anchor is the end of the
+        # previous sentence rather than the start of the string.
+        "I had two people ask this week. Free discovery call — link in bio.",
+        "Here's the offer: free 30-minute call, spots are open.",
+        "So if you want a quick call, my calendar is open.",
+        "Up for a quick call? DM me.",
     ])
     def test_flags_meeting_asks(self, text):
         from cqc_lem.utilities.ai.content_alignment import contains_meeting_ask
@@ -154,6 +160,16 @@ class TestMeetingAskDetector:
         "I book discovery calls with new clients every Friday.",
         "I wanted a quick call but they were booked solid.",
         "That discovery call opened my eyes to the real bottleneck.",
+        # Same trap in the verb-less forms: THIRD-PERSON PRESENT narrative uses the exact words of
+        # the reader-interest ask, and a noun phrase buried mid-sentence sits within 40 characters
+        # of an ordinary "sign up" / "DM me" often enough to matter. Neither is an ask, and the
+        # repair deletes the whole sentence, so neither may match.
+        "Most buyers want a quick call before they commit to anything.",
+        "Clients want a free consultation before they'll even look at pricing.",
+        "They're ready for a strategy session long before we are.",
+        "My team was up for a quick call but the client ghosted us.",
+        "That quick call led to a sign up the same day.",
+        "After our discovery call I told them to DM me anytime.",
         "",
         None,
     ])
@@ -191,6 +207,18 @@ class TestReplaceMeetingAskCta:
         out = replace_meeting_ask_cta(self._DRAFT)
         assert contains_meeting_ask(out) is False
         assert "subscribe" not in out.lower() and "comment" not in out.lower()
+
+    def test_keeps_narrative_that_merely_mentions_a_call(self):
+        # The repair DELETES every sentence the detector matches, so a detector that over-reaches
+        # silently destroys story-bank content. Only the actual ask may go.
+        from cqc_lem.utilities.ai.content_alignment import replace_meeting_ask_cta
+        draft = ("Most buyers want a quick call before they commit.\n\n"
+                 "That quick call led to a sign up the same day.\n\n"
+                 "Want a free strategy session? Comment below.")
+        out = replace_meeting_ask_cta(draft, lead_magnet=_LM, post_id=2)
+        assert "Most buyers want a quick call" in out
+        assert "led to a sign up" in out
+        assert "strategy session" not in out.lower()
 
     def test_unchanged_when_there_is_no_meeting_ask(self):
         from cqc_lem.utilities.ai.content_alignment import replace_meeting_ask_cta


### PR DESCRIPTION
Post-merge adversarial review of the three PRs that merged CI-green but unreviewed during the review outage. Every diff was read line-by-line against its issue's acceptance criteria, the merged state of the shared files (`run_content_plan.py`, `ai_helper.py`, `db.py`, `content_alignment.py`) was re-verified, and the integration seams between the three were specifically attacked.

## PR #661 — Story bank & fact intake (#620)

**Verdict: PASS with one finding (fixed).**

Checked: migration (timestamp-versioned, FK + index, no ENUM hazards), API CRUD (session-scoped, 401/422/500 paths, cross-user scoping in `upsert`/`delete`), selection/rotation semantics (never-used first, longest-unused next, active-only, relevance via focus topics with a sane no-signal fallback), empty-bank no-fabrication fallback, use accounting (outermost call only, only when content shipped, DB failure non-fatal), fabrication detector scoping (first-person sentences only, skipped with no allow-list), onboarding nudge ordering (behind VOICE_SET, once, ahead of trial warning, safe with `started_at=None`), and the recursion paths (type fallbacks and review-gate retry reuse the same `story_directive`; the bank is read at most once per outermost call; no double `record_story_bank_use`).

**Finding (fixed):** the review gate's fabrication check treated only the story entry + profile synthesis as legitimate sources. The lead-magnet CTA directive — text *we* hand the writer, which can carry a number in the user's configured resource name ("my 5-step checklist") — was not a source, so a correctly woven CTA triggered a spurious regeneration whose repair directive explicitly steers the model to drop that number, fighting the keyword-listener mechanic that `ensure_lead_magnet_cta` then has to repair. `_fabricated_specifics` now accepts extra sources and the gate passes `lead_magnet_cta` (both first-draft and retry checks). Regression test added.

## PR #662 — 70/20/10 content mix governor (#618)

**Verdict: PASS with one finding (fixed).**

Checked: deterministic assignment (promo exactly 1-in-N with N clamped 10–30 so promo can never exceed the 10% ceiling; authority phased off promo indices; promo wins collisions; offset continues the cadence across plan boundaries), plan wiring (`_take_planned_post_type` claims a text post with a safe fallback, class persisted via `insert_planned_post`, read back for regenerates so the mix can't drift), the meeting-ask detector/repair/gate triple (repair is deterministic, no-artifact users get the ask dropped rather than an invented asset, existing keyword ask never doubled, gate lints ALL post types and holds at PENDING per the acceptance criteria), nullable `posts.content_mix` (unclassified never treated as promo, excluded from ratios), and the analytics endpoint (days clamped before both queries; empty plan is not a violation).

**Finding (fixed):** the bare-noun pattern in `_MEETING_ASK_PATTERNS` (`discovery call`, `strategy session`, `15-minute call` with no ask context) violated the file's own stated precision-over-recall rule: first-person *narrative* — "I ran a discovery call with them last week", frequently the story-bank anecdote itself — was flagged, and `replace_meeting_ask_cta` **deletes** flagged sentences, silently destroying real story content and tripping the `meeting_cta` hold on clean posts. The pattern now requires an offer-verb context (`grab/claim/snag/book/schedule/join/reserve/get/offer(ing)` + article); every previously listed positive still matches (verified by the existing parametrized tests) and three narrative negatives were added.

## PR #665 — Network activation (#623)

**Verdict: PASS, no code changes.**

Checked against all five scope items: name cleaning handles the exact production string plus aria-label, multiline SDUI stacks, screen-reader duplication, and non-name badge text without touching real names; degree detection fails open (missing badge = unknown, never "connected") at all three enforcement points (rank filter, file-time belt-and-braces, profile-page abort before hunting for a Connect button); ICP floor enforced before the request row exists and unscored candidates store NULL instead of the misleading `ICP_UNKNOWN`; `invite_to_connect_now`'s tuple return updated at both call sites with `result` initialized on every path; `failure_reason` written on every status transition (stale reasons cleared) and truncated to the column; funnel sourcing files drafts only — the approval status defers to `connection_request_mode` exactly as the issue specifies, dedups against `connection_requests` and existing funnel rows, respects a per-scan budget and an open-backlog ceiling, and comment drafts route through `generate_ai_response` so the #617 quality contract applies; the reply-check that unblocks the nurture queue cannot loop (the no-template branch in `process_user_followups` stops the row without re-enqueueing, and the nurture event type is excluded from getting a second check); every early exit now logs. Beat entry, queue lane, and 429/pause gating verified.

## Integration verdict

**One real seam defect found and fixed (#618 × #620):** a promo-classed post whose story bank was empty or irrelevant was forced into the `case_snapshot` blueprint *and* given the promo directive demanding "one specific real number or observable result" — while the fabrication detector was skipped entirely (no story = no allow-list) and the no-story fallback simultaneously forbade personal specifics. The post most likely to invent a client figure was the only one shipping with zero deterministic check, and the prompt actively pushed it to invent. Fix: story selection now runs before blueprint selection (no information is lost — `blueprint["subject"]` is always None at that point in this flow), and an ungroundable promo slot is demoted to `value` with a `log_warning` before the case-study blueprint or promo directive can attach. The plan row keeps its `promo` class, which only makes the dashboard's compliance ratio conservative. Recursive calls and the review-gate retry inherit the demoted class.

Other seams verified clean: all ~11 generator call sites thread `story_directive` AND `content_mix` consistently through every fallback/retry path; the mix repair's appended artifact CTA cannot trip the fabrication gate (runs after the review gate; with the #661 fix its numbers are sourced anyway); #665's funnel comment drafts reuse the shared comment core rather than a parallel prompt helper; #665's writes respect `max_invites_per_day` / `max_dms_per_day` and the approval gates (nothing new auto-sends).

`poetry run pytest tests/unit -q`: **5963 passed** (283 in the directly touched areas).

Closes #670

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXo94Rk9SDo5SkuESCu1mE
