### PR TITLE
feat(analytics): follower & audience telemetry with daily capture (closes #627)

### DIFF
--- a/compose/local/database/migrations/V20260726160255__add_follower_stats.sql
+++ b/compose/local/database/migrations/V20260726160255__add_follower_stats.sql
@@ -1,0 +1,19 @@
+-- Follower & audience telemetry (issue #627). LEM tracked post stats, newsletter subscribers and
+-- engagers, but never the AUDIENCE itself — follower growth and profile views are the primary
+-- outcome of the whole system and were invisible.
+--
+-- One row per daily capture run. Every count is NULLABLE on purpose: the capture is best-effort
+-- Selenium against LinkedIn's SDUI, and a missing anchor must record "not measured" rather than a
+-- zero that would read as "lost all followers" in the growth deltas. profile_views and
+-- search_appearances only exist on the author's own analytics surface, so they are frequently NULL.
+CREATE TABLE IF NOT EXISTS follower_stats (
+    id                 INT AUTO_INCREMENT PRIMARY KEY,
+    user_id            INT NOT NULL,
+    follower_count     INT NULL,   -- "N followers" on the user's own profile; NULL when unreadable
+    connection_count   INT NULL,   -- "N connections"; NULL when unreadable ("500+" reads as 500)
+    profile_views      INT NULL,   -- own-profile analytics; NULL when the surface isn't accessible
+    search_appearances INT NULL,   -- own-profile analytics; NULL when the surface isn't accessible
+    captured_at        DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    KEY idx_user_captured (user_id, captured_at),
+    FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);

--- a/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
+++ b/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
@@ -99,6 +99,8 @@ Nothing below is a guess; the provenance column says where each came from.
 | Reactions/comments/reposts/saves rows | line pair `<Label>` → `<count>` (label-first) | `_stacked_counts` / `_STACKED_LABEL_FIRST` | live grab 2026-07-23 |
 | Social-bar counts (detail view) | regex `<count> <label>` on the card text | `_COMMENTS_RE` … `_SAVES_RE` | in-repo, live-used |
 | Post permalink on a feed card | `a[href*='/feed/update/']` | `_post_permalink_from_card` | in-repo, live-used |
+| Follower / connection counts | page text of `main` on the user's own profile → `parse_follower_count` / `parse_connection_count` | `capture_audience_snapshot` (#627) | in-repo, **best-effort / unvalidated** — first real run should be supervised |
+| Profile views / search appearances | `https://www.linkedin.com/analytics/profile-views/` (falls back to `/analytics/search-appearances/`), value-first line pair | `capture_audience_snapshot` (#627) | in-repo, **best-effort / unvalidated** |
 | Feed composer trigger | `//button[contains(normalize-space(),'Start a post') or contains(@aria-label,'Start a post') or contains(@aria-label,'Create a post')]` | `auto_post_to_group`, `probe_composer` | in-repo, **best-effort / unvalidated** (F2 #403) |
 | Document upload control | — | — | **unmapped by design** (§1); `--probe-composer` captures it |
 | Document media card | — | — | **unmapped**; `probe_document_render` captures it |

--- a/scripts/perf_snapshot.sh
+++ b/scripts/perf_snapshot.sh
@@ -33,7 +33,11 @@ q(){ sudo -n docker exec --env-file "$PWF" mysql_db mysql -u"$DBU" -N -B -e "$1"
 U=1
 DAY="SELECT COUNT(*) FROM $DBN.logs WHERE user_id=$U AND result='success' AND created_at>=NOW()-INTERVAL 1 DAY AND action_type="
 c1d=$(q "${DAY}'comment';"); r1d=$(q "${DAY}'reply';"); d1d=$(q "${DAY}'dm';"); e1d=$(q "${DAY}'engaged';"); p1d=$(q "${DAY}'post';")
-ps=$(q "SELECT CONCAT_WS(',',COUNT(DISTINCT post_id),COALESCE(SUM(reactions),0),COALESCE(SUM(comments),0),COALESCE(SUM(impressions),0)) FROM $DBN.post_stats WHERE user_id=$U;")
+# LATEST stat row per post only. post_stats is append-only — the nightly scrape writes a fresh
+# CUMULATIVE row per post every run, so summing every row multiplied each post's reactions /
+# impressions by how many times it had been scraped (issue #627). MAX(id) GROUP BY post_id is the
+# same latest-row-per-post pattern db.py uses for every analytics read.
+ps=$(q "SELECT CONCAT_WS(',',COUNT(DISTINCT post_id),COALESCE(SUM(reactions),0),COALESCE(SUM(comments),0),COALESCE(SUM(impressions),0)) FROM $DBN.post_stats WHERE user_id=$U AND id IN (SELECT MAX(id) FROM $DBN.post_stats WHERE user_id=$U GROUP BY post_id);")
 eng=$(q "SELECT COUNT(*) FROM $DBN.post_engagers WHERE user_id=$U;")
 fu=$(q "SELECT COUNT(*) FROM $DBN.comment_followups WHERE user_id=$U;")
 cp=$(q "SELECT COUNT(*) FROM $DBN.commented_posts WHERE user_id=$U;")

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -57,6 +57,7 @@ from cqc_lem.utilities.db import (
     get_user_timezone,
     get_user_groups, set_groups_enabled, get_post_engagement_rows, get_post_performance_rows,
     get_content_mix_counts,
+    get_follower_stats, get_daily_action_counts,
     get_lead_magnet_settings, update_lead_magnet_settings,
     get_dm_templates, upsert_dm_templates,
     get_engagement_targets, upsert_engagement_targets, delete_engagement_target,
@@ -2657,6 +2658,34 @@ def get_engagement_analytics_endpoint(session_token: str, days: int = 90) -> Res
         # post has engagement data yet.
         "content_mix": content_mix_compliance(get_content_mix_counts(user_id, days=days)),
     })
+
+
+@router.get("/user/audience-growth")
+def get_audience_growth_endpoint(session_token: str, days: int = 90) -> ResponseModel:
+    """Follower/audience telemetry for the analytics dashboard's growth panel (issue #627): the
+    daily follower series with 7/30-day deltas, the latest profile-view and search-appearance
+    readings, and the user's daily posting/commenting activity to overlay on the same window.
+    Audience growth is the system's primary outcome — post engagement is the leading indicator."""
+    from cqc_lem.utilities.audience_stats import (GROWTH_WINDOWS, build_activity_series,
+                                                  follower_growth)
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    days = max(1, min(int(days), 365))
+    # The 7/30-day deltas need a baseline that predates the window being charted, so read enough
+    # history to cover the longest growth window on top of it.
+    history_days = days + max(GROWTH_WINDOWS)
+    growth = follower_growth(get_follower_stats(user_id, days=history_days))
+    growth["series"] = [p for p in growth["series"] if p["date"] >= _window_start(days)]
+    return ResponseModel(status_code=200, detail={
+        **growth,
+        "activity": build_activity_series(get_daily_action_counts(user_id, days=days)),
+        "days": days,
+    })
+
+
+def _window_start(days: int) -> str:
+    return (datetime.now(timezone.utc).date() - timedelta(days=int(days))).isoformat()
 
 
 class LeadMagnetRequest(BaseModel):

--- a/src/cqc_lem/app/celeryconfig.py
+++ b/src/cqc_lem/app/celeryconfig.py
@@ -161,6 +161,7 @@ task_routes = {
     # --- se_content: seeding, stats, group + newsletter publishing --------
     'cqc_lem.app.run_automation.auto_seed_comment_on_post': {'queue': 'se_content'},
     'cqc_lem.app.run_automation.auto_scrape_post_stats': {'queue': 'se_content'},
+    'cqc_lem.app.run_automation.capture_follower_stats': {'queue': 'se_content'},
     'cqc_lem.app.run_automation.auto_sync_user_groups': {'queue': 'se_content'},
     'cqc_lem.app.run_automation.auto_post_to_group': {'queue': 'se_content'},
     'cqc_lem.app.run_automation.auto_publish_newsletter_edition': {'queue': 'se_content'},

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -175,6 +175,12 @@ app.conf.update(
             'task': 'cqc_lem.app.run_scheduler.auto_scrape_stats',
             'schedule': crontab(hour='23', minute='0')  # Nightly: capture post engagement for time recs
         },
+        'capture-follower-stats': {
+            'task': 'cqc_lem.app.run_scheduler.auto_capture_follower_stats',
+            # Nightly at 23:40 — after the 23:00 post-stats scrape, so a day's audience snapshot and
+            # its content outcomes land in the same night and the growth panel can overlay them.
+            'schedule': crontab(hour='23', minute='40')
+        },
         'rebuild-lead-scores': {
             'task': 'cqc_lem.app.run_scheduler.rebuild_lead_scores',
             # Nightly at 3:30 AM — after the 11 PM stats scrape, so the morning hot-leads list

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -2052,9 +2052,13 @@ def _read_page_text(driver, url: str) -> str:
     time.sleep(random.uniform(4, 6))
     for tag in ("main", "body"):
         try:
-            return driver.find_element(By.TAG_NAME, tag).text or ""
+            text = driver.find_element(By.TAG_NAME, tag).text or ""
         except Exception:
             continue
+        # An EMPTY <main> is as unread as a missing one (LinkedIn renders parts of the analytics
+        # surface outside it, and a half-hydrated shell reads blank), so keep falling back.
+        if text.strip():
+            return text
     return ""
 
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -56,7 +56,10 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     get_engager_candidates, get_profile_facts, count_invites_sent_today, ConnectionRequestStatus, \
     CatchupTouchStatus, insert_catchup_touch, has_catchup_touch, get_catchup_touch, \
     update_catchup_touch_status, count_catchup_touches_sent_today, max_catchup_touches_allowed, \
-    get_engagement_targets, record_target_engagement, ENGAGEMENT_TARGET_WEEKLY_DEFAULT
+    get_engagement_targets, record_target_engagement, ENGAGEMENT_TARGET_WEEKLY_DEFAULT, \
+    record_follower_stat, get_linkedin_profile_url_by_user_id
+from cqc_lem.utilities.audience_stats import parse_follower_count, parse_connection_count, \
+    parse_profile_views, parse_search_appearances
 from cqc_lem.utilities.engagement_window import record_pre_post_run
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
@@ -68,8 +71,8 @@ from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited, _redis_cl
     acquire_run_lock, release_run_lock
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text
 from cqc_lem.utilities.logger import myprint, log_error, log_info, log_warning
-from cqc_lem.utilities.observability import track_post_outcome, attribute_llm_cost, llm_attribution, \
-    FEATURE_COMMENT, FEATURE_CONTENT, FEATURE_DM
+from cqc_lem.utilities.observability import track_post_outcome, track_audience_snapshot, \
+    attribute_llm_cost, llm_attribution, FEATURE_COMMENT, FEATURE_CONTENT, FEATURE_DM
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
     get_element_wait_retry, get_elements_as_list_wait_stale, getText, close_tab, get_driver_wait_pair, quit_gracefully, \
     wait_for_ajax, find_first, click_first, find_all_first
@@ -2027,6 +2030,90 @@ def auto_scrape_post_stats(self, user_id: int):
                                saves=counts.get("saves") or 0, user_id=user_id)
             scraped += 1
         return f"Scraped stats for {scraped} post(s)"
+    finally:
+        quit_gracefully(driver)
+
+
+# The author's OWN analytics surface. Profile views and search appearances are rendered as summary
+# cards on the profile-views page, so that one load usually yields both; the search-appearances page
+# is only opened when it didn't.
+_PROFILE_VIEWS_URL = "https://www.linkedin.com/analytics/profile-views/"
+_SEARCH_APPEARANCES_URL = "https://www.linkedin.com/analytics/search-appearances/"
+
+
+def _read_page_text(driver, url: str) -> str:
+    """Navigate and return the page's visible text (prefers <main>, falls back to <body>). Empty
+    string when the page can't be read — never raises."""
+    try:
+        driver.get(url)
+    except Exception as e:
+        log_warning("Could not open page for audience capture", exc=e, task_name="capture_follower_stats")
+        return ""
+    time.sleep(random.uniform(4, 6))
+    for tag in ("main", "body"):
+        try:
+            return driver.find_element(By.TAG_NAME, tag).text or ""
+        except Exception:
+            continue
+    return ""
+
+
+def capture_audience_snapshot(driver, profile_url: "str | None") -> dict:
+    """Read the user's follower/connection counts off their own profile and their profile-view /
+    search-appearance counts off their own analytics surface (issue #627).
+
+    Best-effort PER SIGNAL and fail-closed: a missing anchor leaves that key None (recorded as SQL
+    NULL = "not measured"), never 0, and never raises — a LinkedIn DOM change must not take the
+    daily capture, or anything downstream of it, down with it."""
+    counts = {"follower_count": None, "connection_count": None,
+              "profile_views": None, "search_appearances": None}
+    if profile_url:
+        text = _read_page_text(driver, profile_url)
+        counts["follower_count"] = parse_follower_count(text)
+        counts["connection_count"] = parse_connection_count(text)
+    else:
+        log_warning("No LinkedIn profile URL — skipping follower capture",
+                    task_name="capture_follower_stats")
+    analytics_text = _read_page_text(driver, _PROFILE_VIEWS_URL)
+    counts["profile_views"] = parse_profile_views(analytics_text)
+    counts["search_appearances"] = parse_search_appearances(analytics_text)
+    if counts["search_appearances"] is None:
+        counts["search_appearances"] = parse_search_appearances(
+            _read_page_text(driver, _SEARCH_APPEARANCES_URL))
+    return counts
+
+
+@shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
+                  queue='se_content')
+def capture_follower_stats(self, user_id: int):
+    """Daily audience telemetry: snapshot the user's follower/connection counts and (when the
+    surface is reachable) their profile views + search appearances (issue #627). Audience growth is
+    the outcome the whole system exists to produce and was previously untracked. One row per run
+    feeds the growth panel's 7/30-day deltas; unreadable signals are stored as NULL."""
+    try:
+        driver, wait, user_email, my_profile = get_current_profile(user_id=user_id,
+                                                                  session_name="Audience Stats")
+    except Exception as e:
+        log_error("Error getting profile for audience capture", exc=e, user_id=user_id,
+                  task_name="capture_follower_stats")
+        return f"Failed: {e}"
+    try:
+        profile_url = get_linkedin_profile_url_by_user_id(user_id)
+        if not profile_url:
+            candidate = getattr(my_profile, "profile_url", None)
+            profile_url = str(candidate) if candidate else None
+        counts = capture_audience_snapshot(driver, profile_url)
+        if not record_follower_stat(user_id, **counts):
+            log_warning("No audience signal readable — snapshot skipped", user_id=user_id,
+                        task_name="capture_follower_stats")
+            return "No audience signals readable"
+        track_audience_snapshot(user_id=user_id, **counts)
+        log_info("Audience snapshot captured", user_id=user_id, task_name="capture_follower_stats")
+        return (f"Followers: {counts['follower_count'] if counts['follower_count'] is not None else 'unknown'}; "
+                f"profile views: {counts['profile_views'] if counts['profile_views'] is not None else 'unknown'}")
+    except Exception as e:
+        log_error("Audience capture error", exc=e, user_id=user_id, task_name="capture_follower_stats")
+        return f"Audience capture error: {e}"
     finally:
         quit_gracefully(driver)
 

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -802,6 +802,23 @@ def auto_scrape_stats():
 
 
 @shared_task.task
+def auto_capture_follower_stats():
+    """Daily: snapshot each active user's follower/connection counts and profile views (issue #627).
+    Selenium-backed, so it respects the global throttle breaker, and it only dispatches for users
+    who actually have a LinkedIn session to read the numbers with."""
+    if _skip_if_throttled("auto_capture_follower_stats"):
+        return "Automation throttled"
+    from cqc_lem.app.run_automation import capture_follower_stats
+    users = get_active_user_ids()
+    n = 0
+    for uid in users:
+        if has_linkedin_session(uid):
+            capture_follower_stats.apply_async(kwargs={'user_id': uid})
+            n += 1
+    return f"Audience capture dispatched for {n}/{len(users)} user(s)"
+
+
+@shared_task.task
 def auto_send_due_followups():
     """Dispatch a per-user Selenium task to send due DM follow-ups (each gated by reply-detection)."""
     if _skip_if_throttled("auto_send_due_followups"):

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -125,6 +125,13 @@ function deltaColor(d: AudienceDelta | null | undefined): string {
   return d.delta > 0 ? 'text-green-600' : 'text-red-600'
 }
 
+// The baseline is the newest capture on or BEFORE the window edge, so after a run of failed
+// captures a "7-day change" can really span longer. Name the date it was measured from rather than
+// letting the tile imply a window it didn't cover.
+function deltaSince(d: AudienceDelta | null | undefined): string {
+  return d ? `since ${shortDate(d.from_date)}` : 'not enough history'
+}
+
 // "2026-07-20" → "Jul 20" for compact chart/table axes (dates are tz-agnostic calendar days).
 const _MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 function shortDate(iso: string): string {
@@ -370,6 +377,7 @@ export default function Dashboard() {
                       {formatDelta(audience?.deltas?.[w])}
                     </p>
                     <p className="text-xs text-gray-500 mt-0.5">{w}-day change</p>
+                    <p className="text-[10px] text-gray-400">{deltaSince(audience?.deltas?.[w])}</p>
                   </div>
                 ))}
                 <div>

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -64,6 +64,45 @@ interface Analytics {
   content_mix?: ContentMix
 }
 
+// Follower & audience telemetry (#627). Every count is nullable: a capture that could not read a
+// number stores NULL ("not measured"), never 0.
+interface AudiencePoint {
+  date: string
+  follower_count: number | null
+  connection_count: number | null
+  profile_views: number | null
+  search_appearances: number | null
+}
+
+interface AudienceDelta {
+  delta: number
+  from: number
+  to: number
+  from_date: string
+  pct: number | null
+}
+
+interface ActivityPoint {
+  date: string
+  posts: number
+  comments: number
+  replies: number
+  dms: number
+}
+
+interface AudienceGrowth {
+  series: AudiencePoint[]
+  activity: ActivityPoint[]
+  follower_count: number | null
+  captured_at: string | null
+  connection_count: number | null
+  profile_views: number | null
+  search_appearances: number | null
+  deltas: Record<string, AudienceDelta | null>
+  samples: number
+  days: number
+}
+
 const MIX_LABELS: Record<string, string> = {
   value: 'Audience value',
   authority: 'Authority education',
@@ -72,6 +111,18 @@ const MIX_LABELS: Record<string, string> = {
 
 function formatPct(ratio: number | null | undefined): string {
   return ratio == null ? '—' : `${Math.round(ratio * 100)}%`
+}
+
+// A follower delta is null until there is a baseline snapshot old enough to measure against —
+// show "—" rather than inventing growth from a two-day history.
+function formatDelta(d: AudienceDelta | null | undefined): string {
+  if (!d) return '—'
+  return `${d.delta > 0 ? '+' : ''}${d.delta.toLocaleString()}`
+}
+
+function deltaColor(d: AudienceDelta | null | undefined): string {
+  if (!d || d.delta === 0) return 'text-gray-800'
+  return d.delta > 0 ? 'text-green-600' : 'text-red-600'
 }
 
 // "2026-07-20" → "Jul 20" for compact chart/table axes (dates are tz-agnostic calendar days).
@@ -170,6 +221,17 @@ export default function Dashboard() {
     staleTime: 5 * 60 * 1000,
   })
 
+  // Follower growth / profile views, overlaid with what we actually did each day (#627).
+  const { data: audience } = useQuery({
+    queryKey: ['audience-growth', sessionToken],
+    queryFn: () =>
+      api
+        .get(`/user/audience-growth?session_token=${encodeURIComponent(sessionToken!)}&days=90`)
+        .then((r) => r.data.detail as AudienceGrowth),
+    enabled: !!sessionToken,
+    staleTime: 5 * 60 * 1000,
+  })
+
   const { data: statsData } = useQuery<{ detail: DashboardStats }>({
     queryKey: ['dashboard-stats', email],
     queryFn: () => api.get(`/dashboard/stats/?email=${encodeURIComponent(email)}`).then((r) => r.data),
@@ -222,6 +284,25 @@ export default function Dashboard() {
   const rateTrend: LinePoint[] = trend.map((t) => ({ x: shortDate(t.date), y: t.engagement_rate }))
   const impressionTrend: LinePoint[] = trend.map((t) => ({ x: shortDate(t.date), y: t.impressions }))
 
+  // Audience growth panel. The follower line and the activity line share the same day window so
+  // growth reads next to the work that drove it (two single-series charts, never a dual axis).
+  const audienceSeries = audience?.series ?? []
+  const activitySeries = audience?.activity ?? []
+  const hasAudience = audienceSeries.length > 0
+  // Both charts run over the UNION of days so they line up point-for-point; a day with no capture
+  // is a gap in the follower line (null), not a zero.
+  const audienceByDate = new Map(audienceSeries.map((p) => [p.date, p]))
+  const activityByDate = new Map(activitySeries.map((a) => [a.date, a]))
+  const audienceDays = [...new Set([...audienceByDate.keys(), ...activityByDate.keys()])].sort()
+  const followerTrend: LinePoint[] = audienceDays.map((d) => ({
+    x: shortDate(d),
+    y: audienceByDate.get(d)?.follower_count ?? null,
+  }))
+  const activityTrend: LinePoint[] = audienceDays.map((d) => {
+    const a = activityByDate.get(d)
+    return { x: shortDate(d), y: a ? a.posts + a.comments + a.replies + a.dms : 0 }
+  })
+
   const formatBoard = postStats?.rankings?.format ?? []
   const hookBoard = postStats?.rankings?.hook_style ?? []
 
@@ -260,6 +341,77 @@ export default function Dashboard() {
         <StatCard label="Pending review" value={stats.pending_review} color="border-yellow-500" />
         <StatCard label="Total posted" value={stats.posted_total} color="border-green-500" />
       </div>
+
+      {/* Audience growth — follower/profile-view telemetry next to the activity that drove it (#627) */}
+      {sessionToken && (
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-6">
+          <div className="flex items-baseline justify-between">
+            <h2 className="text-lg font-semibold text-gray-700">Audience Growth</h2>
+            <span className="text-xs text-gray-400">Last {audience?.days ?? 90} days</span>
+          </div>
+
+          {!hasAudience ? (
+            <p className="text-sm text-gray-400 py-4 text-center">
+              Gathering data — follower and profile-view tracking captures once a night from your
+              LinkedIn session.
+            </p>
+          ) : (
+            <>
+              <div className="grid grid-cols-2 sm:grid-cols-5 gap-4">
+                <div>
+                  <p className="text-2xl font-bold text-gray-800">
+                    {audience?.follower_count != null ? compactNumber(audience.follower_count) : '—'}
+                  </p>
+                  <p className="text-xs text-gray-500 mt-0.5">Followers</p>
+                </div>
+                {['7', '30'].map((w) => (
+                  <div key={w}>
+                    <p className={`text-2xl font-bold ${deltaColor(audience?.deltas?.[w])}`}>
+                      {formatDelta(audience?.deltas?.[w])}
+                    </p>
+                    <p className="text-xs text-gray-500 mt-0.5">{w}-day change</p>
+                  </div>
+                ))}
+                <div>
+                  <p className="text-2xl font-bold text-gray-800">
+                    {audience?.profile_views != null ? compactNumber(audience.profile_views) : '—'}
+                  </p>
+                  <p className="text-xs text-gray-500 mt-0.5">Profile views</p>
+                </div>
+                <div>
+                  <p className="text-2xl font-bold text-gray-800">
+                    {audience?.connection_count != null ? compactNumber(audience.connection_count) : '—'}
+                  </p>
+                  <p className="text-xs text-gray-500 mt-0.5">Connections</p>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+                <LineChart
+                  title="Followers"
+                  subtitle="Captured nightly from your own profile"
+                  points={followerTrend}
+                  format={compactNumber}
+                  valueLabel="Followers"
+                  emptyMessage="No follower count captured yet."
+                />
+                <LineChart
+                  title="Engagement activity"
+                  subtitle="Posts, comments, replies and DMs sent, by day"
+                  points={activityTrend}
+                  format={compactNumber}
+                  valueLabel="Actions"
+                  emptyMessage="No automation activity in this window."
+                />
+              </div>
+              <p className="text-xs text-gray-400">
+                Profile views and search appearances come from LinkedIn's own analytics surface — a
+                blank means the capture couldn't read that number, not that it was zero.
+              </p>
+            </>
+          )}
+        </div>
+      )}
 
       {/* Engagement analytics — trends, leaderboards, and per-post drill-down from post_stats (#395) */}
       {sessionToken && (

--- a/src/cqc_lem/utilities/audience_stats.py
+++ b/src/cqc_lem/utilities/audience_stats.py
@@ -1,0 +1,218 @@
+"""Audience telemetry — parsing LinkedIn's follower/connection/profile-view labels and deriving
+the growth series the analytics dashboard renders (issue #627). Pure functions: no DB, no Selenium,
+so the label parsing and the delta math are unit-testable without a browser (the #403/#404
+validation pattern — browser steps stay thin, the parsing is tested).
+
+Follower growth is the primary outcome of the whole system; post engagement is the leading
+indicator. A count that could not be read is None everywhere here — never 0 — because a zero would
+show up in a delta as "lost the entire audience".
+"""
+
+import re
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Iterable, Mapping, Optional, Sequence
+
+# LinkedIn renders audience counts as "1,234 followers", "3.2K followers", "500+ connections", and
+# on the analytics surface as "48 profile views" / "12 search appearances".
+_SUFFIX_MULTIPLIER = {"": 1, "K": 1_000, "M": 1_000_000}
+
+FOLLOWER_LABEL = r"followers?"
+CONNECTION_LABEL = r"connections?"
+PROFILE_VIEW_LABEL = r"profile views?"
+SEARCH_APPEARANCE_LABEL = r"search appearances?"
+
+# Growth windows reported on the dashboard panel.
+GROWTH_WINDOWS = (7, 30)
+
+
+def parse_labeled_count(text: Optional[str], label: str) -> Optional[int]:
+    """Pull the count belonging to `label` out of LinkedIn label text.
+    "1,234 followers" -> 1234, "3.2K followers" -> 3200, "500+ connections" -> 500,
+    and the analytics card layout "48\\nProfile views" -> 48.
+
+    Precedence is deliberate: LinkedIn writes the number BEFORE the label everywhere it renders one
+    (inline on the profile, stacked above the caption on the analytics cards), so a number
+    immediately preceding the label wins. The gap it may span is at most one line break, so a count
+    belonging to some OTHER card further up the page can't bind to this label. A label with no
+    number in front of it falls back to the first number just after it. Returns None when no count
+    is present — callers persist that as NULL, which is distinct from a real zero."""
+    if not text:
+        return None
+    number = r"(\d[\d.,]*)[ \t]*([KkMm]?)\+?"
+    for pattern in (rf"{number}[ \t]*\n?[ \t]*{label}", rf"{label}[^\d\n]{{0,20}}\n?[ \t]*{number}"):
+        match = re.search(pattern, text, flags=re.IGNORECASE)
+        if match:
+            value = _to_number(match.group(1), match.group(2))
+            if value is not None:
+                return value
+    return None
+
+
+def _to_number(raw: str, suffix: str) -> Optional[int]:
+    """"3.2" + "K" -> 3200. A K/M suffix means the digits are a rounded magnitude, so the comma is a
+    decimal separator in some locales — but LinkedIn renders en-US here, so commas are thousands."""
+    try:
+        value = float(raw.replace(",", ""))
+    except ValueError:
+        return None
+    return int(value * _SUFFIX_MULTIPLIER.get(suffix.upper(), 1))
+
+
+def parse_follower_count(text: Optional[str]) -> Optional[int]:
+    return parse_labeled_count(text, FOLLOWER_LABEL)
+
+
+def parse_connection_count(text: Optional[str]) -> Optional[int]:
+    return parse_labeled_count(text, CONNECTION_LABEL)
+
+
+def parse_profile_views(text: Optional[str]) -> Optional[int]:
+    return parse_labeled_count(text, PROFILE_VIEW_LABEL)
+
+
+def parse_search_appearances(text: Optional[str]) -> Optional[int]:
+    return parse_labeled_count(text, SEARCH_APPEARANCE_LABEL)
+
+
+def _as_date(value: Any) -> Optional[date]:
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).date()
+        except ValueError:
+            return None
+    return None
+
+
+def _optional_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def build_follower_series(rows: Iterable[Mapping]) -> list:
+    """Daily audience series, oldest first, for the growth panel. `rows` are the snapshot dicts from
+    `db.get_follower_stats` (any order). Multiple captures on the same calendar day collapse to the
+    LAST one — a re-run is a correction, not another data point, so summing would inflate exactly
+    the way the post-stats snapshot bug did. Missing counts stay None."""
+    buckets: dict = {}
+    for row in rows:
+        if not row:
+            continue
+        day = _as_date(row.get("captured_at"))
+        if day is None:
+            continue
+        order = _sort_key(row)
+        prior = buckets.get(day)
+        # Keep the latest capture of the day, tie-broken by row id so a re-run on the same second
+        # still resolves deterministically.
+        if prior is not None and prior["_order"] > order:
+            continue
+        buckets[day] = {
+            "date": day.isoformat(),
+            "follower_count": _optional_int(row.get("follower_count")),
+            "connection_count": _optional_int(row.get("connection_count")),
+            "profile_views": _optional_int(row.get("profile_views")),
+            "search_appearances": _optional_int(row.get("search_appearances")),
+            "_order": order,
+        }
+    series = []
+    for day in sorted(buckets):
+        point = dict(buckets[day])
+        point.pop("_order", None)
+        series.append(point)
+    return series
+
+
+def _sort_key(row: Mapping) -> tuple:
+    captured = row.get("captured_at")
+    stamp = captured.isoformat() if isinstance(captured, (datetime, date)) else str(captured or "")
+    return stamp, _optional_int(row.get("id")) or 0
+
+
+def _latest_with(series: Sequence[Mapping], field: str) -> Optional[Mapping]:
+    for point in reversed(series):
+        if point.get(field) is not None:
+            return point
+    return None
+
+
+def _on_or_before(series: Sequence[Mapping], field: str, cutoff: date) -> Optional[Mapping]:
+    """The newest point on/before `cutoff` that actually carries `field` — the baseline a delta is
+    measured from. None when the history doesn't reach back that far."""
+    best = None
+    for point in series:
+        day = _as_date(point.get("date"))
+        if day is None or day > cutoff or point.get(field) is None:
+            continue
+        best = point
+    return best
+
+
+def follower_growth(rows: Iterable[Mapping], windows: Sequence[int] = GROWTH_WINDOWS,
+                    now: Optional[datetime] = None) -> dict:
+    """Growth summary for the dashboard panel: the current follower/connection counts, the latest
+    profile-view + search-appearance readings, and a follower delta per window in `windows`
+    (7/30-day by default).
+
+    A delta is None unless there is a baseline snapshot on or before `today - window` that carried a
+    follower count — with a shorter history the honest answer is "not enough data", not a delta
+    measured against the oldest row we happen to have (which would read as explosive growth on day
+    two). Pure — no DB."""
+    series = build_follower_series(rows)
+    reference = (now or datetime.now(timezone.utc)).date()
+    latest = _latest_with(series, "follower_count")
+    deltas: dict = {}
+    for window in windows:
+        baseline = _on_or_before(series, "follower_count", reference - timedelta(days=int(window)))
+        if latest is None or baseline is None or baseline is latest:
+            deltas[str(window)] = None
+            continue
+        delta = latest["follower_count"] - baseline["follower_count"]
+        start = baseline["follower_count"]
+        deltas[str(window)] = {
+            "delta": delta,
+            "from": start,
+            "to": latest["follower_count"],
+            "from_date": baseline["date"],
+            "pct": round(delta / start, 5) if start else None,
+        }
+    views = _latest_with(series, "profile_views")
+    appearances = _latest_with(series, "search_appearances")
+    connections = _latest_with(series, "connection_count")
+    return {
+        "series": series,
+        "follower_count": latest["follower_count"] if latest else None,
+        "captured_at": latest["date"] if latest else None,
+        "connection_count": connections["connection_count"] if connections else None,
+        "profile_views": views["profile_views"] if views else None,
+        "search_appearances": appearances["search_appearances"] if appearances else None,
+        "deltas": deltas,
+        "samples": len(series),
+    }
+
+
+def build_activity_series(rows: Iterable[Mapping]) -> list:
+    """Daily posting/commenting activity, oldest first, for the overlay on the growth chart —
+    follower growth is only readable next to what we actually DID that day. `rows` are the
+    `{date, action_type, count}` dicts from `db.get_daily_action_counts`."""
+    buckets: dict = {}
+    for row in rows:
+        if not row:
+            continue
+        day = _as_date(row.get("date"))
+        if day is None:
+            continue
+        bucket = buckets.setdefault(day, {"date": day.isoformat(), "posts": 0, "comments": 0,
+                                          "replies": 0, "dms": 0})
+        key = {"post": "posts", "comment": "comments", "reply": "replies", "dm": "dms"}.get(
+            str(row.get("action_type") or "").lower())
+        if key:
+            bucket[key] += int(row.get("count") or 0)
+    return [buckets[day] for day in sorted(buckets)]

--- a/src/cqc_lem/utilities/audience_stats.py
+++ b/src/cqc_lem/utilities/audience_stats.py
@@ -24,6 +24,9 @@ SEARCH_APPEARANCE_LABEL = r"search appearances?"
 # Growth windows reported on the dashboard panel.
 GROWTH_WINDOWS = (7, 30)
 
+_ALL_LABELS = (FOLLOWER_LABEL, CONNECTION_LABEL, PROFILE_VIEW_LABEL, SEARCH_APPEARANCE_LABEL)
+_NUMBER = r"(\d[\d.,]*)[ \t]*([KkMm]?)\+?"
+
 
 def parse_labeled_count(text: Optional[str], label: str) -> Optional[int]:
     """Pull the count belonging to `label` out of LinkedIn label text.
@@ -33,19 +36,38 @@ def parse_labeled_count(text: Optional[str], label: str) -> Optional[int]:
     Precedence is deliberate: LinkedIn writes the number BEFORE the label everywhere it renders one
     (inline on the profile, stacked above the caption on the analytics cards), so a number
     immediately preceding the label wins. The gap it may span is at most one line break, so a count
-    belonging to some OTHER card further up the page can't bind to this label. A label with no
-    number in front of it falls back to the first number just after it. Returns None when no count
-    is present — callers persist that as NULL, which is distinct from a real zero."""
+    belonging to some OTHER card further up the page can't bind to this label — and a number that
+    is already the VALUE of a different label in front of it (`_claimed_by_another_label`) is
+    skipped, so a stacked label-first page can't hand every metric the first card's number. A label
+    with no number in front of it falls back to the first number just after it. Returns None when no
+    count is present — callers persist that as NULL, which is distinct from a real zero."""
     if not text:
         return None
-    number = r"(\d[\d.,]*)[ \t]*([KkMm]?)\+?"
-    for pattern in (rf"{number}[ \t]*\n?[ \t]*{label}", rf"{label}[^\d\n]{{0,20}}\n?[ \t]*{number}"):
-        match = re.search(pattern, text, flags=re.IGNORECASE)
-        if match:
-            value = _to_number(match.group(1), match.group(2))
-            if value is not None:
-                return value
-    return None
+    for match in re.finditer(rf"{_NUMBER}[ \t]*\n?[ \t]*{label}", text, flags=re.IGNORECASE):
+        if _claimed_by_another_label(text, match.start(), label):
+            continue
+        value = _to_number(match.group(1), match.group(2))
+        if value is not None:
+            return value
+    match = re.search(rf"{label}[^\d\n]{{0,20}}\n?[ \t]*{_NUMBER}", text, flags=re.IGNORECASE)
+    return _to_number(match.group(1), match.group(2)) if match else None
+
+
+def _claimed_by_another_label(text: str, start: int, label: str) -> bool:
+    """True when the number starting at `start` is really the value of a DIFFERENT audience label
+    sitting immediately in front of it — LinkedIn's label-first card stack ("Profile views\\n288\\n
+    Search appearances\\n88") would otherwise hand 288 to search appearances too, silently recording
+    one metric's number under another. The other label only owns the number if it doesn't already
+    have one of its own in front of it (the value-first layout, where "4,312 followers\\n500+
+    connections" leaves 500 legitimately ours)."""
+    head = text[:start]
+    for other in _ALL_LABELS:
+        if other == label:
+            continue
+        owner = re.search(rf"{other}[^\d]{{0,3}}$", head, flags=re.IGNORECASE)
+        if owner and not re.search(rf"{_NUMBER}[ \t]*\n?[ \t]*$", head[:owner.start()]):
+            return True
+    return False
 
 
 def _to_number(raw: str, suffix: str) -> Optional[int]:

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -5887,6 +5887,83 @@ def get_latest_newsletter_subscriber_count(user_id: int) -> "int | None":
         connection.close()
 
 
+def record_follower_stat(user_id: int, follower_count: Optional[int] = None,
+                         connection_count: Optional[int] = None,
+                         profile_views: Optional[int] = None,
+                         search_appearances: Optional[int] = None) -> bool:
+    """Append one audience snapshot for the user (issue #627). Every count is optional: a value the
+    capture could not read is stored as NULL, never 0, so the growth deltas can tell "not measured"
+    apart from "the audience really is that size". Returns False when NOTHING was readable — there
+    is no point writing an all-NULL row that only adds noise to the series."""
+    if all(v is None for v in (follower_count, connection_count, profile_views, search_appearances)):
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "INSERT INTO follower_stats (user_id, follower_count, connection_count, profile_views, "
+            "search_appearances) VALUES (%s, %s, %s, %s, %s)",
+            (user_id, follower_count, connection_count, profile_views, search_appearances))
+        connection.commit()
+        return cursor.rowcount == 1
+    except mysql.connector.Error as err:
+        myprint(f"Could not record follower stat for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_follower_stats(user_id: int, days: Optional[int] = None, limit: int = 400) -> list:
+    """The user's audience snapshots, most recent first (issue #627). `days` optionally windows to
+    captures within the last N days. Each item:
+    id, follower_count, connection_count, profile_views, search_appearances, captured_at."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        window = "AND captured_at >= (NOW() - INTERVAL %s DAY) " if days is not None else ""
+        params = (user_id, days, limit) if days is not None else (user_id, limit)
+        cursor.execute(
+            "SELECT id, follower_count, connection_count, profile_views, search_appearances, "
+            "captured_at FROM follower_stats WHERE user_id = %s " + window +
+            "ORDER BY captured_at DESC, id DESC LIMIT %s", params)
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        myprint(f"Could not get follower stats for user {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_daily_action_counts(user_id: int, days: int = 90,
+                            action_types: Optional[list] = None) -> list:
+    """Daily count of the user's SUCCESSFUL automation actions, for overlaying what we DID on the
+    audience-growth chart (issue #627). Defaults to the outbound actions a follower can react to:
+    posts, feed comments, replies and DMs. Returns dicts of {date, action_type, count}."""
+    types = [LogActionType.POST.value, LogActionType.COMMENT.value, LogActionType.REPLY.value,
+             LogActionType.DM.value] if action_types is None else list(action_types)
+    if not types:
+        return []
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        placeholders = ",".join(["%s"] * len(types))
+        cursor.execute(
+            "SELECT DATE(created_at) AS `date`, action_type, COUNT(*) AS `count` FROM logs "
+            f"WHERE user_id = %s AND result = %s AND action_type IN ({placeholders}) "
+            "AND created_at >= (NOW() - INTERVAL %s DAY) "
+            "GROUP BY DATE(created_at), action_type ORDER BY `date` ASC",
+            (user_id, LogResultType.SUCCESS.value, *types, days))
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        myprint(f"Could not get daily action counts for user {user_id} | Error: {err}")
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_newsletter_due_user_ids(now) -> list:
     """User IDs whose newsletter is enabled and due per its cadence (weekly/biweekly/monthly)."""
     connection = get_db_connection()

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -473,6 +473,31 @@ def track_post_outcome(
     )
 
 
+def track_audience_snapshot(
+    user_id: Optional[int],
+    follower_count: Optional[int] = None,
+    connection_count: Optional[int] = None,
+    profile_views: Optional[int] = None,
+    search_appearances: Optional[int] = None,
+    **extra,
+) -> None:
+    """Emit one audience-telemetry snapshot (issue #627) so follower growth and profile views are
+    queryable in PostHog next to the content outcomes that drove them. Unreadable counts stay None
+    (not 0) — a zero would read as a real collapse in a growth chart."""
+    posthog.capture(
+        distinct_id=str(user_id or "system"),
+        event="audience_snapshot",
+        properties={
+            "user_id": user_id,
+            "follower_count": follower_count,
+            "connection_count": connection_count,
+            "profile_views": profile_views,
+            "search_appearances": search_appearances,
+            **extra,
+        },
+    )
+
+
 def track_pre_post_engagement(post_id: int, user_id: Optional[int], status: str, **extra) -> None:
     """Emit the per-post pre-post engagement-window marker (issue #547) — dispatched, skipped (with
     the reason) or ran (with the comment count) — so a report can confirm the warm-up before a post

--- a/tests/unit/api/test_api_coverage_misc.py
+++ b/tests/unit/api/test_api_coverage_misc.py
@@ -429,6 +429,52 @@ class TestEngagementAnalytics:
         assert resp.status_code == 401
 
 
+class TestAudienceGrowth:
+    """Follower & audience telemetry endpoint (issue #627)."""
+
+    def _rows(self):
+        from datetime import datetime, timedelta, timezone
+        today = datetime.now(timezone.utc).replace(tzinfo=None)
+        return [
+            {"id": 2, "captured_at": today, "follower_count": 1100, "connection_count": 500,
+             "profile_views": 48, "search_appearances": 12},
+            {"id": 1, "captured_at": today - timedelta(days=10), "follower_count": 1000,
+             "connection_count": 480, "profile_views": None, "search_appearances": None},
+        ]
+
+    def test_returns_series_deltas_and_activity(self, client):
+        from datetime import datetime, timezone
+        activity = [{"date": datetime.now(timezone.utc).date(), "action_type": "comment", "count": 6}]
+        with patch(f"{_M}.get_session_user_id", return_value=_UID), \
+             patch(f"{_M}.get_follower_stats", return_value=self._rows()) as fetch, \
+             patch(f"{_M}.get_daily_action_counts", return_value=activity) as acts:
+            resp = client.get(f"/api/user/audience-growth?session_token={_TOK}&days=30")
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        assert detail["follower_count"] == 1100 and detail["profile_views"] == 48
+        assert detail["deltas"]["7"]["delta"] == 100
+        assert detail["activity"][0]["comments"] == 6
+        assert detail["days"] == 30
+        # The 7/30-day deltas need a baseline older than the charted window, so the read reaches
+        # further back than `days`.
+        assert fetch.call_args[1]["days"] == 60
+        assert acts.call_args[1]["days"] == 30
+
+    def test_days_clamped(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_UID), \
+             patch(f"{_M}.get_follower_stats", return_value=[]) as fetch, \
+             patch(f"{_M}.get_daily_action_counts", return_value=[]):
+            resp = client.get(f"/api/user/audience-growth?session_token={_TOK}&days=9999")
+        assert resp.status_code == 200
+        assert fetch.call_args[1]["days"] == 395           # 365 clamp + the 30-day baseline reach
+        assert resp.json()["detail"]["series"] == []
+
+    def test_401_without_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.get("/api/user/audience-growth?session_token=bad")
+        assert resp.status_code == 401
+
+
 class TestLeadMagnetAndPassword:
     def test_get_lead_magnet(self, client):
         settings = {"enabled": True, "keyword": "GUIDE", "message": "here you go"}

--- a/tests/unit/app/test_follower_capture.py
+++ b/tests/unit/app/test_follower_capture.py
@@ -1,0 +1,278 @@
+"""Follower & audience telemetry capture (issue #627): the Selenium snapshot, its task, the daily
+dispatcher, and the db accessors that persist/read it. All I/O mocked."""
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+_RS = "cqc_lem.app.run_scheduler"
+_DB = "cqc_lem.utilities.db"
+
+_PROFILE_TEXT = "Christopher Queen\nFounder\n4,312 followers\n500+ connections"
+_ANALYTICS_TEXT = "48\nProfile views\nPast 90 days\n12\nSearch appearances\nPrevious week"
+
+
+def _driver(texts):
+    """A driver whose <main> text is taken from `texts` in navigation order."""
+    driver = MagicMock()
+    seq = list(texts)
+
+    def _find(_by, _tag):
+        el = MagicMock()
+        el.text = seq.pop(0) if seq else ""
+        return el
+
+    driver.find_element.side_effect = _find
+    return driver
+
+
+class TestCaptureAudienceSnapshot:
+    def test_reads_every_signal(self):
+        from cqc_lem.app.run_automation import capture_audience_snapshot
+        driver = _driver([_PROFILE_TEXT, _ANALYTICS_TEXT])
+        with patch(f"{_RA}.time.sleep"):
+            counts = capture_audience_snapshot(driver, "https://www.linkedin.com/in/me/")
+        assert counts == {"follower_count": 4312, "connection_count": 500,
+                          "profile_views": 48, "search_appearances": 12}
+        assert driver.get.call_args_list[0].args[0] == "https://www.linkedin.com/in/me/"
+
+    def test_missing_anchor_is_none_never_zero(self):
+        # A DOM change must record "not measured", not a zero that reads as a lost audience.
+        from cqc_lem.app.run_automation import capture_audience_snapshot
+        driver = _driver(["Christopher Queen\nFounder", "", ""])
+        with patch(f"{_RA}.time.sleep"):
+            counts = capture_audience_snapshot(driver, "https://www.linkedin.com/in/me/")
+        assert set(counts.values()) == {None}
+
+    def test_no_profile_url_skips_the_profile_load(self):
+        from cqc_lem.app.run_automation import capture_audience_snapshot
+        driver = _driver([_ANALYTICS_TEXT])
+        with patch(f"{_RA}.time.sleep"):
+            counts = capture_audience_snapshot(driver, None)
+        assert counts["follower_count"] is None and counts["profile_views"] == 48
+        assert len(driver.get.call_args_list) == 1
+
+    def test_search_appearances_page_only_opened_when_needed(self):
+        from cqc_lem.app.run_automation import capture_audience_snapshot
+        # Analytics page yielded views but no appearances → second analytics page is opened.
+        driver = _driver([_PROFILE_TEXT, "48\nProfile views", "31\nSearch appearances"])
+        with patch(f"{_RA}.time.sleep"):
+            counts = capture_audience_snapshot(driver, "https://www.linkedin.com/in/me/")
+        assert counts["search_appearances"] == 31
+        assert len(driver.get.call_args_list) == 3
+
+    def test_navigation_failure_does_not_raise(self):
+        from cqc_lem.app.run_automation import capture_audience_snapshot
+        driver = MagicMock()
+        driver.get.side_effect = Exception("auth wall")
+        with patch(f"{_RA}.time.sleep"):
+            counts = capture_audience_snapshot(driver, "https://www.linkedin.com/in/me/")
+        assert set(counts.values()) == {None}
+
+    def test_falls_back_to_body_when_main_is_absent(self):
+        from cqc_lem.app.run_automation import capture_audience_snapshot
+        driver = MagicMock()
+        body = MagicMock()
+        body.text = _PROFILE_TEXT
+
+        def _find(_by, tag):
+            if tag == "main":
+                raise Exception("no main")
+            return body
+
+        driver.find_element.side_effect = _find
+        with patch(f"{_RA}.time.sleep"):
+            counts = capture_audience_snapshot(driver, "https://www.linkedin.com/in/me/")
+        assert counts["follower_count"] == 4312
+
+
+class TestCaptureFollowerStatsTask:
+    def _patches(self, counts, profile_url="https://www.linkedin.com/in/me/"):
+        return (patch(f"{_RA}.get_current_profile",
+                      return_value=(MagicMock(), MagicMock(), "e@x.com", MagicMock())),
+                patch(f"{_RA}.get_linkedin_profile_url_by_user_id", return_value=profile_url),
+                patch(f"{_RA}.capture_audience_snapshot", return_value=counts),
+                patch(f"{_RA}.quit_gracefully"))
+
+    def test_records_and_tracks_the_snapshot(self):
+        from cqc_lem.app.run_automation import capture_follower_stats
+        counts = {"follower_count": 4312, "connection_count": 500,
+                  "profile_views": 48, "search_appearances": 12}
+        p1, p2, p3, p4 = self._patches(counts)
+        with p1, p2, p3, p4, \
+             patch(f"{_RA}.record_follower_stat", return_value=True) as rec, \
+             patch(f"{_RA}.track_audience_snapshot") as track:
+            result = capture_follower_stats.run(user_id=1)
+        assert rec.call_args.kwargs == counts
+        assert track.call_args.kwargs["follower_count"] == 4312
+        assert "4312" in result
+
+    def test_unreadable_snapshot_writes_nothing(self):
+        from cqc_lem.app.run_automation import capture_follower_stats
+        counts = dict.fromkeys(
+            ("follower_count", "connection_count", "profile_views", "search_appearances"))
+        p1, p2, p3, p4 = self._patches(counts)
+        with p1, p2, p3, p4, \
+             patch(f"{_RA}.record_follower_stat", return_value=False), \
+             patch(f"{_RA}.track_audience_snapshot") as track:
+            result = capture_follower_stats.run(user_id=1)
+        assert result == "No audience signals readable"
+        track.assert_not_called()
+
+    def test_falls_back_to_the_scraped_profile_url(self):
+        from cqc_lem.app.run_automation import capture_follower_stats
+        profile = MagicMock()
+        profile.profile_url = "https://www.linkedin.com/in/scraped/"
+        with patch(f"{_RA}.get_current_profile",
+                   return_value=(MagicMock(), MagicMock(), "e", profile)), \
+             patch(f"{_RA}.get_linkedin_profile_url_by_user_id", return_value=None), \
+             patch(f"{_RA}.capture_audience_snapshot", return_value={}) as snap, \
+             patch(f"{_RA}.record_follower_stat", return_value=True), \
+             patch(f"{_RA}.track_audience_snapshot"), patch(f"{_RA}.quit_gracefully"):
+            capture_follower_stats.run(user_id=1)
+        assert snap.call_args.args[1] == "https://www.linkedin.com/in/scraped/"
+
+    def test_login_failure_returns_without_raising(self):
+        from cqc_lem.app.run_automation import capture_follower_stats
+        with patch(f"{_RA}.get_current_profile", side_effect=Exception("429")):
+            assert "Failed" in capture_follower_stats.run(user_id=1)
+
+    def test_capture_error_still_quits_the_driver(self):
+        from cqc_lem.app.run_automation import capture_follower_stats
+        with patch(f"{_RA}.get_current_profile",
+                   return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_linkedin_profile_url_by_user_id", return_value="u"), \
+             patch(f"{_RA}.capture_audience_snapshot", side_effect=Exception("boom")), \
+             patch(f"{_RA}.quit_gracefully") as quit_:
+            result = capture_follower_stats.run(user_id=1)
+        assert "error" in result.lower()
+        quit_.assert_called_once()
+
+
+class TestDispatcher:
+    def test_dispatches_only_users_with_a_session(self):
+        from cqc_lem.app.run_scheduler import auto_capture_follower_stats
+        task = MagicMock()
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1, 2, 3]), \
+             patch(f"{_RS}.has_linkedin_session", side_effect=lambda uid: uid != 2), \
+             patch(f"{_RA}.capture_follower_stats", task):
+            result = auto_capture_follower_stats.run()
+        assert task.apply_async.call_count == 2
+        assert "2/3" in result
+
+    def test_throttled_run_dispatches_nothing(self):
+        from cqc_lem.app.run_scheduler import auto_capture_follower_stats
+        task = MagicMock()
+        with patch(f"{_RS}._skip_if_throttled", return_value=True), \
+             patch(f"{_RA}.capture_follower_stats", task):
+            assert auto_capture_follower_stats.run() == "Automation throttled"
+        task.apply_async.assert_not_called()
+
+    def test_beat_schedule_registers_the_nightly_capture(self):
+        from cqc_lem.app.my_celery import app
+        entry = app.conf.beat_schedule["capture-follower-stats"]
+        assert entry["task"] == "cqc_lem.app.run_scheduler.auto_capture_follower_stats"
+
+
+class TestFollowerStatDb:
+    def _conn(self, fetchall=None, rowcount=1):
+        conn, cur = MagicMock(), MagicMock()
+        cur.fetchall.return_value = fetchall or []
+        cur.rowcount = rowcount
+        conn.cursor.return_value = cur
+        return conn, cur
+
+    def test_record_persists_nullable_counts(self):
+        from cqc_lem.utilities.db import record_follower_stat
+        conn, cur = self._conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert record_follower_stat(1, follower_count=4312, connection_count=None,
+                                        profile_views=48, search_appearances=None) is True
+        assert "INSERT INTO follower_stats" in cur.execute.call_args[0][0]
+        assert cur.execute.call_args[0][1] == (1, 4312, None, 48, None)
+
+    def test_all_null_snapshot_is_not_written(self):
+        from cqc_lem.utilities.db import record_follower_stat
+        conn, cur = self._conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn) as get_conn:
+            assert record_follower_stat(1) is False
+        get_conn.assert_not_called()
+        cur.execute.assert_not_called()
+
+    def test_record_swallows_db_error(self):
+        import mysql.connector
+        from cqc_lem.utilities.db import record_follower_stat
+        conn, cur = self._conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert record_follower_stat(1, follower_count=5) is False
+
+    def test_get_stats_windows_by_days(self):
+        from cqc_lem.utilities.db import get_follower_stats
+        rows = [{"id": 1, "follower_count": 10, "captured_at": datetime(2026, 7, 26)}]
+        conn, cur = self._conn(fetchall=rows)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert get_follower_stats(1, days=30) == rows
+        sql, params = cur.execute.call_args[0]
+        assert "INTERVAL %s DAY" in sql and params == (1, 30, 400)
+
+    def test_get_stats_without_window_omits_the_interval(self):
+        from cqc_lem.utilities.db import get_follower_stats
+        conn, cur = self._conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            get_follower_stats(1)
+        sql, params = cur.execute.call_args[0]
+        assert "INTERVAL" not in sql and params == (1, 400)
+
+    def test_get_stats_swallows_db_error(self):
+        import mysql.connector
+        from cqc_lem.utilities.db import get_follower_stats
+        conn, cur = self._conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert get_follower_stats(1) == []
+
+    def test_daily_action_counts_only_counts_successes(self):
+        from cqc_lem.utilities.db import get_daily_action_counts
+        conn, cur = self._conn(fetchall=[{"date": "2026-07-26", "action_type": "comment", "count": 4}])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert get_daily_action_counts(1, days=30)[0]["count"] == 4
+        sql, params = cur.execute.call_args[0]
+        assert "GROUP BY DATE(created_at), action_type" in sql
+        assert params == (1, "success", "post", "comment", "reply", "dm", 30)
+
+    def test_daily_action_counts_honours_explicit_types(self):
+        from cqc_lem.utilities.db import get_daily_action_counts
+        conn, cur = self._conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            get_daily_action_counts(1, days=7, action_types=["post"])
+        assert cur.execute.call_args[0][1] == (1, "success", "post", 7)
+
+    def test_daily_action_counts_with_no_types_hits_no_db(self):
+        from cqc_lem.utilities.db import get_daily_action_counts
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            assert get_daily_action_counts(1, action_types=[]) == []
+        get_conn.assert_not_called()
+
+    def test_daily_action_counts_swallows_db_error(self):
+        import mysql.connector
+        from cqc_lem.utilities.db import get_daily_action_counts
+        conn, cur = self._conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            assert get_daily_action_counts(1) == []
+
+
+class TestAudienceSnapshotEvent:
+    def test_emits_posthog_event_with_null_preserved(self):
+        from cqc_lem.utilities.observability import track_audience_snapshot
+        with patch("cqc_lem.utilities.observability.posthog") as ph:
+            track_audience_snapshot(user_id=1, follower_count=4312, profile_views=None)
+        props = ph.capture.call_args.kwargs["properties"]
+        assert ph.capture.call_args.kwargs["event"] == "audience_snapshot"
+        assert props["follower_count"] == 4312 and props["profile_views"] is None

--- a/tests/unit/app/test_follower_capture.py
+++ b/tests/unit/app/test_follower_capture.py
@@ -89,6 +89,22 @@ class TestCaptureAudienceSnapshot:
             counts = capture_audience_snapshot(driver, "https://www.linkedin.com/in/me/")
         assert counts["follower_count"] == 4312
 
+    def test_falls_back_to_body_when_main_is_empty(self):
+        # A half-hydrated <main> reads blank; that is as unread as a missing one, so the body
+        # fallback must still run instead of recording an all-NULL snapshot.
+        from cqc_lem.app.run_automation import capture_audience_snapshot
+        driver = MagicMock()
+
+        def _find(_by, tag):
+            el = MagicMock()
+            el.text = "   \n " if tag == "main" else _PROFILE_TEXT
+            return el
+
+        driver.find_element.side_effect = _find
+        with patch(f"{_RA}.time.sleep"):
+            counts = capture_audience_snapshot(driver, "https://www.linkedin.com/in/me/")
+        assert counts["follower_count"] == 4312 and counts["connection_count"] == 500
+
 
 class TestCaptureFollowerStatsTask:
     def _patches(self, counts, profile_url="https://www.linkedin.com/in/me/"):

--- a/tests/unit/app/test_selenium_queue_routing.py
+++ b/tests/unit/app/test_selenium_queue_routing.py
@@ -45,6 +45,7 @@ SELENIUM_TASK_LANES = {
     # se_content
     "auto_seed_comment_on_post": "se_content",
     "auto_scrape_post_stats": "se_content",
+    "capture_follower_stats": "se_content",
     "auto_sync_user_groups": "se_content",
     "auto_post_to_group": "se_content",
     "auto_publish_newsletter_edition": "se_content",

--- a/tests/unit/utilities/test_audience_stats.py
+++ b/tests/unit/utilities/test_audience_stats.py
@@ -59,6 +59,22 @@ class TestLabelParsing:
         # A page that only renders followers must not yield a connection count from the same digits.
         assert parse_connection_count("4,000 followers") is None
 
+    def test_stacked_label_first_cards_do_not_share_one_number(self):
+        # A wholly label-first page: every metric after the first would otherwise inherit the FIRST
+        # card's number (288 recorded as search appearances, 4312 as connections) — a silently WRONG
+        # count is worse than the NULL this module exists to prefer.
+        analytics = "Profile views\n288\nSearch appearances\n88"
+        assert parse_profile_views(analytics) == 288
+        assert parse_search_appearances(analytics) == 88
+        profile = "Followers\n4,312\nConnections\n500"
+        assert parse_follower_count(profile) == 4312
+        assert parse_connection_count(profile) == 500
+
+    def test_value_first_neighbour_still_owns_the_next_number(self):
+        # The mirror case: "followers" already HAS its number in front of it, so the 500 that
+        # follows belongs to connections and must not be rejected as someone else's.
+        assert parse_connection_count("4,312 followers\n500+ connections") == 500
+
 
 class TestFollowerSeries:
     def test_collapses_same_day_captures_to_the_latest(self):

--- a/tests/unit/utilities/test_audience_stats.py
+++ b/tests/unit/utilities/test_audience_stats.py
@@ -1,0 +1,165 @@
+"""Follower & audience telemetry — label parsing and growth derivation (issue #627)."""
+
+from datetime import datetime
+
+import pytest
+
+from cqc_lem.utilities.audience_stats import (build_activity_series, build_follower_series,
+                                              follower_growth, parse_connection_count,
+                                              parse_follower_count, parse_labeled_count,
+                                              parse_profile_views, parse_search_appearances)
+
+pytestmark = pytest.mark.unit
+
+
+class TestLabelParsing:
+    @pytest.mark.parametrize("text,expected", [
+        ("1,234 followers", 1234),
+        ("3.2K followers", 3200),
+        ("1.1M followers", 1_100_000),
+        ("7 followers", 7),
+        ("1 follower", 1),
+        ("Followers\n2,048", 2048),
+    ])
+    def test_follower_shapes(self, text, expected):
+        assert parse_follower_count(text) == expected
+
+    @pytest.mark.parametrize("text,expected", [
+        ("500+ connections", 500),
+        ("312 connections", 312),
+        ("1 connection", 1),
+    ])
+    def test_connection_shapes(self, text, expected):
+        assert parse_connection_count(text) == expected
+
+    def test_analytics_card_layout(self):
+        # LinkedIn stacks the number ABOVE its caption on the analytics cards.
+        page = "48\nProfile views\nPast 90 days\n12\nSearch appearances\nPrevious week"
+        assert parse_profile_views(page) == 48
+        assert parse_search_appearances(page) == 12
+
+    def test_label_first_layout_is_the_fallback(self):
+        assert parse_profile_views("Profile views: 48") == 48
+
+    def test_a_distant_number_does_not_bind_to_the_label(self):
+        # Two line breaks away is another card's number, not this label's.
+        assert parse_search_appearances("9,001\n\n\nSearch appearances") is None
+
+    def test_missing_count_is_none_not_zero(self):
+        # NULL means "not measured"; a 0 would read as a real collapse in a growth delta.
+        assert parse_follower_count("Followers") is None
+        assert parse_follower_count("") is None
+        assert parse_follower_count(None) is None
+        assert parse_profile_views("nothing to see") is None
+
+    def test_unparseable_number_is_none(self):
+        assert parse_labeled_count("..,, followers", r"followers?") is None
+
+    def test_does_not_cross_wire_labels(self):
+        # A page that only renders followers must not yield a connection count from the same digits.
+        assert parse_connection_count("4,000 followers") is None
+
+
+class TestFollowerSeries:
+    def test_collapses_same_day_captures_to_the_latest(self):
+        rows = [
+            {"id": 2, "captured_at": datetime(2026, 7, 20, 23, 40), "follower_count": 110,
+             "connection_count": None, "profile_views": None, "search_appearances": None},
+            {"id": 1, "captured_at": datetime(2026, 7, 20, 6, 0), "follower_count": 100,
+             "connection_count": None, "profile_views": None, "search_appearances": None},
+        ]
+        series = build_follower_series(rows)
+        # A re-run is a CORRECTION, not another data point — summing is the bug this issue fixes
+        # on the post-stats side, and it must not be reintroduced here.
+        assert len(series) == 1
+        assert series[0]["follower_count"] == 110
+
+    def test_sorted_ascending_and_keeps_nulls(self):
+        rows = [
+            {"id": 2, "captured_at": datetime(2026, 7, 21), "follower_count": None,
+             "connection_count": 500, "profile_views": 9, "search_appearances": None},
+            {"id": 1, "captured_at": datetime(2026, 7, 20), "follower_count": 100,
+             "connection_count": 499, "profile_views": None, "search_appearances": 4},
+        ]
+        series = build_follower_series(rows)
+        assert [p["date"] for p in series] == ["2026-07-20", "2026-07-21"]
+        assert series[1]["follower_count"] is None
+        assert series[1]["profile_views"] == 9
+
+    def test_ignores_rows_without_a_usable_date(self):
+        assert build_follower_series([None, {}, {"captured_at": "not-a-date"}]) == []
+
+    def test_accepts_iso_string_timestamps(self):
+        series = build_follower_series([{"id": 1, "captured_at": "2026-07-20T23:40:00Z",
+                                        "follower_count": 42}])
+        assert series[0]["date"] == "2026-07-20" and series[0]["follower_count"] == 42
+
+
+def _row(day: int, followers, **extra):
+    base = {"id": day, "captured_at": datetime(2026, 7, day, 23, 40), "follower_count": followers,
+            "connection_count": None, "profile_views": None, "search_appearances": None}
+    base.update(extra)
+    return base
+
+
+class TestFollowerGrowth:
+    def test_deltas_measured_from_the_window_baseline(self):
+        rows = [_row(1, 1000), _row(20, 1050), _row(26, 1100)]
+        now = datetime(2026, 7, 26, 12, 0)
+        growth = follower_growth(rows, now=now)
+        assert growth["follower_count"] == 1100
+        # 7-day baseline = newest snapshot on/before Jul 19 → Jul 1's 1000.
+        assert growth["deltas"]["7"]["delta"] == 100
+        assert growth["deltas"]["7"]["from_date"] == "2026-07-01"
+        assert growth["deltas"]["30"] is None          # history doesn't reach back 30 days
+        assert growth["samples"] == 3
+
+    def test_pct_is_relative_to_the_baseline(self):
+        growth = follower_growth([_row(1, 200), _row(26, 250)], now=datetime(2026, 7, 26))
+        assert growth["deltas"]["7"]["pct"] == pytest.approx(0.25)
+
+    def test_no_baseline_yields_no_delta_not_explosive_growth(self):
+        # One snapshot: a delta against itself would read as +1100 from zero.
+        growth = follower_growth([_row(26, 1100)], now=datetime(2026, 7, 26))
+        assert growth["deltas"] == {"7": None, "30": None}
+        assert growth["follower_count"] == 1100
+
+    def test_negative_delta_is_preserved(self):
+        growth = follower_growth([_row(1, 1200), _row(26, 1150)], now=datetime(2026, 7, 26))
+        assert growth["deltas"]["7"]["delta"] == -50
+
+    def test_latest_non_null_wins_per_signal(self):
+        rows = [_row(20, 900, profile_views=48, search_appearances=12),
+                _row(26, 950)]           # newest capture couldn't read the analytics surface
+        growth = follower_growth(rows, now=datetime(2026, 7, 26))
+        assert growth["follower_count"] == 950
+        assert growth["profile_views"] == 48
+        assert growth["search_appearances"] == 12
+
+    def test_empty_history(self):
+        growth = follower_growth([], now=datetime(2026, 7, 26))
+        assert growth["follower_count"] is None and growth["series"] == []
+        assert growth["deltas"]["30"] is None
+
+    def test_baseline_skips_days_with_no_follower_reading(self):
+        rows = [_row(1, 1000), _row(18, None), _row(26, 1100)]
+        growth = follower_growth(rows, now=datetime(2026, 7, 26))
+        assert growth["deltas"]["7"]["from"] == 1000
+
+
+class TestActivitySeries:
+    def test_buckets_action_types_per_day(self):
+        rows = [
+            {"date": datetime(2026, 7, 20).date(), "action_type": "comment", "count": 5},
+            {"date": datetime(2026, 7, 20).date(), "action_type": "post", "count": 1},
+            {"date": datetime(2026, 7, 21).date(), "action_type": "dm", "count": 2},
+        ]
+        series = build_activity_series(rows)
+        assert series[0] == {"date": "2026-07-20", "posts": 1, "comments": 5, "replies": 0, "dms": 0}
+        assert series[1]["dms"] == 2
+
+    def test_ignores_unknown_action_types_and_bad_rows(self):
+        rows = [None, {"date": None, "action_type": "post", "count": 3},
+                {"date": datetime(2026, 7, 20).date(), "action_type": "engaged", "count": 9}]
+        series = build_activity_series(rows)
+        assert series == [{"date": "2026-07-20", "posts": 0, "comments": 0, "replies": 0, "dms": 0}]


### PR DESCRIPTION
## What & why

Audience growth is the primary outcome of the whole system and it was **invisible**. LEM tracked post stats, newsletter subscribers and engagers — but never the user's own follower count or profile views. (Lara Acosta's operating metric is profile visits, not likes.)

### Follower telemetry
- **Migration `V20260726160255__add_follower_stats.sql`** — `follower_stats`: one row per capture with `follower_count`, `connection_count`, `profile_views`, `search_appearances`. Every count is **NULLABLE on purpose**: a missing anchor records "not measured", never a `0` that would read as a collapsed audience in a growth delta.
- **`utilities/audience_stats.py`** (pure, no DB/Selenium — the #403/#404 pattern: thin browser layer, unit-tested parsing):
  - LinkedIn label parsing (`1,234 followers`, `3.2K followers`, `500+ connections`, the stacked `48\nProfile views` analytics card). Precedence is number-**before**-label (how LinkedIn renders it everywhere), bounded to at most one line break so another card's number can't silently bind to this label.
  - `follower_growth()` — daily series + 7/30-day deltas. A delta stays `None` until a baseline snapshot old enough to measure against exists, so a two-day history can't report explosive growth. Same-day re-captures collapse to the latest row (a re-run is a correction, not another data point).
- **`capture_follower_stats`** Celery task on the `se_content` lane, dispatched nightly at **23:40** by `auto_capture_follower_stats` — after the 23:00 post-stats scrape, so a night's audience snapshot and its content outcomes land together. Throttle-breaker aware and session-gated. **Fail-closed per signal**: a LinkedIn DOM change leaves that count NULL, logs, and never raises or blocks other automation. An all-NULL snapshot is not written at all.
- **`db.py`**: `record_follower_stat`, `get_follower_stats`, `get_daily_action_counts` (the activity overlay).
- **`GET /user/audience-growth`** + an **Audience Growth panel** on the Dashboard (#395 surface): followers, 7/30-day change, profile views, connections, and two aligned single-series charts — followers over time and daily posting/commenting/DM activity over the same day window (never a dual axis, per the existing chart convention).
- **PostHog `audience_snapshot` event** per capture, so follower growth is queryable next to the content outcomes that drove it.

### Measurement bug fix
`scripts/perf_snapshot.sh` summed **every** `post_stats` row per post. `post_stats` is append-only and each nightly scrape writes a fresh *cumulative* row, so cumulative reactions/comments/impressions were multiplied by how many times each post had been scraped. Now restricted to `id IN (SELECT MAX(id) … GROUP BY post_id)` — the same latest-row-per-post pattern every analytics read in `db.py` already uses. (`db.py` itself was already correct everywhere; the script was the only offender.)

## Testing notes

- `tests/unit/utilities/test_audience_stats.py` — 28 tests: label shapes, the cross-wiring guard (a number two line breaks up must not bind), NULL-not-zero, same-day collapse, baseline/window delta semantics, negative deltas, activity bucketing.
- `tests/unit/app/test_follower_capture.py` — 25 tests with mocked driver + DB: full snapshot read, missing anchor → all-None, no profile URL, conditional second analytics page, navigation failure swallowed, `<body>` fallback, task record/track/skip paths, driver always quit, dispatcher session-gating + throttle, beat registration, and every db accessor incl. error paths.
- `tests/unit/api/test_api_coverage_misc.py::TestAudienceGrowth` — endpoint shape, the wider baseline read (`days + 30`), the `days` clamp, and 401.
- `tests/unit/app/test_selenium_queue_routing.py` — the new task's `se_content` lane.
- Full local suite: **6190 passed**. SPA typechecks clean (the only `tsc` errors in this sandbox come from a stale `node_modules` missing `vitest`, unrelated to this diff).

The LinkedIn selectors are best-effort and **unvalidated against a live session** — they are registered as such in `docs/LIVE_VALIDATION_FORMAT_AND_STATS.md`'s selector map, and the fail-closed design means an unread count is a NULL in the series rather than a broken run. The first real nightly capture is worth eyeballing.

Closes #627

🤖 Generated with [Claude Code](https://claude.com/claude-code)
