### PR TITLE
feat(engagement): human-pacing engine — read-time delays, schedule jitter, variable daily volumes (closes #626)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -664,3 +664,33 @@ YOUTUBE_CLIENT_ID=
 YOUTUBE_CLIENT_SECRET=
 YOUTUBE_REFRESH_TOKEN=
 YOUTUBE_PRIVACY_STATUS=unlisted
+
+# --- Human-pacing engine (issue #626) -------------------------------------------------------
+# LinkedIn's comment-bot detection keys on CADENCE: engaging seconds after a post appears,
+# machine-exact daily start times, and a flat daily volume. Set false to restore the pre-#626
+# behaviour (full cap, no jitter, no read delay) — the whole engine is one switch.
+HUMAN_PACING_ENABLED=true
+# Read-time-realistic delay before commenting: reading time at PACING_READ_WPM plus a browse
+# allowance, clamped into [min, max]. The FLOOR is the point — a one-line post still costs 45s.
+# The ceiling is also what keeps the sleep inline-safe (a worker must never park >5 min).
+PACING_READ_MIN_SECONDS=45
+PACING_READ_MAX_SECONDS=240
+PACING_READ_WPM=240
+PACING_BROWSE_MIN_SECONDS=3
+PACING_BROWSE_MAX_SECONDS=25
+# Beat-dispatched engagement doesn't start on the crontab minute — it gets a random forward
+# countdown in this band (Celery eta scheduling, never an in-process sleep).
+PACING_JITTER_MIN_MINUTES=30
+PACING_JITTER_MAX_MINUTES=90
+# Replies to comments on the user's OWN post are exempt from the long delay (answering fast is
+# human) but still jittered, by seconds rather than by an hour.
+PACING_RESPONSIVE_JITTER_MAX_SECONDS=180
+# Each day's volume is a random draw from the user's cap rather than the cap every day, with
+# weekends quieter and the occasional full rest day. The draw is seeded on (user, action, date),
+# so a retry or a Redis outage re-derives the same budget instead of rolling a fresh one.
+PACING_BUDGET_MIN_RATIO=0.4
+PACING_BUDGET_MAX_RATIO=1.0
+PACING_REST_DAY_CHANCE=0.08
+PACING_WEEKEND_RATIO=0.55
+# Optional salt for the seeded draws — change it to reshuffle every user's budget/rest-day pattern.
+PACING_SEED=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,7 @@ src/cqc_lem/
 │   │   └── helper.py, profile.py, token_refresh.py
 │   ├── marketing/ Outbound production
 │   │   └── video_tutorials.py  automated SPA tutorial videos (capture→script→TTS→ffmpeg→YouTube)
+│   ├── human_pacing.py  ONE cadence engine (read delays, schedule jitter, variable daily volume, account governor)
 │   ├── db.py      All database access (no raw SQL outside this file)
 │   ├── proxy.py   Per-user static residential proxy resolution
 │   ├── geocoding.py  Login Location city/state geocoding
@@ -160,6 +161,7 @@ the on-time/resource curve that sizes it. See `docs/SELENIUM_GRID.md` and `docs/
 - **Reciprocity tracking** via the `post_engagers` table — boosts commenting back on people who engaged with us (`get_recent_engagers`).
 - **DMs**: appreciation (connection / recommendation / collaboration), profile-viewer outreach, and **multi-touch follow-up sequences** — all templated and voice-aligned (`build_dm_from_template`, `dm_templates`, `dm_followups`, `process_user_followups`).
 - **DM conversation auto-nurture** (`_nurture_after_reply`, `utilities/ai/dm_nurture.py`): a reply used to END a sequence — now it's classified (interested / objection / not-now / disinterest / neutral) and becomes an **approval-gated** context-aware next message queued as a `pending` row in `scheduled_dms` (`source='nurture'`), one open draft per thread, per-day draft cap, explicit disinterest stops the thread for good.
+- **Human pacing** (`utilities/human_pacing.py`, issue #626): the ONE place cadence is decided, consumed by commenting, replies, DMs and invites. Read-time delay before any comment (`pace_read` — length-scaled, floored at `PACING_READ_MIN_SECONDS`, ceilinged below `MAX_INLINE_SLEEP_SECONDS` so no worker ever parks >5 min); `dispatch_jitter_seconds` countdowns on every beat-dispatched engagement task (own-post replies use `PACE_RESPONSIVE` — jittered by seconds, not delayed by an hour); and `daily_budget`/`remaining_actions`, which turn each per-day cap into a stable random draw (weekend asymmetry + occasional account-wide rest days) under one account-level envelope, so the lanes can't each spend a full cap on the same day. Seeded on (user, action, date) and persisted in Redis, so a retry never re-rolls the day's budget. Fails open — no Redis, or `HUMAN_PACING_ENABLED=false`, restores the pre-#626 behaviour. Pacing only ever slows us down; the 429 breaker in `rate_limit.py` is the separate, harder gate.
 - Monthly **company-page invitations** (`utilities/linkedin/company_page_inviter.py`).
 
 ### Engagement configuration (`engagement_preferences` table, API in `api/main.py`, SPA in `ui/.../Account.tsx`)

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -58,6 +58,9 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     update_catchup_touch_status, count_catchup_touches_sent_today, max_catchup_touches_allowed, \
     get_engagement_targets, record_target_engagement, ENGAGEMENT_TARGET_WEEKLY_DEFAULT
 from cqc_lem.utilities.engagement_window import record_pre_post_run
+from cqc_lem.utilities.human_pacing import pace_read, record_action, remaining_actions, \
+    engagement_caps_from_prefs, dispatch_jitter_seconds, PACE_RESPONSIVE, \
+    ACTION_COMMENT, ACTION_DM, ACTION_INVITE, ACTION_REPLY
 from cqc_lem.utilities.linkedin.company_page_inviter import automate_invitations
 from cqc_lem.utilities.linkedin.helper import login_to_linkedin, get_my_profile, get_linkedin_profile_from_url, \
     load_profile_for_user, clean_person_name, connection_degree, is_first_degree
@@ -169,17 +172,8 @@ def get_feed_posts(driver, wait, num_posts=10):
     return posts
 
 
-def simulate_reading_time(content):
-    # Estimate reading time based on the number of words (average human reads 200-300 words per minute)
-    words = len(content.split())
-    read_time = words / 250 * 60  # Convert to seconds
-    # Round to integer
-    return round(read_time)
-
-
-def simulate_thinking_time():
-    # Random thinking time between 2 and 5 seconds
-    return round(random.uniform(2, 5))
+# Reading/thinking delays now come from utilities/human_pacing.py (issue #626) — one engine, with a
+# floor no human beats and a ceiling that keeps the sleep inline-safe.
 
 
 def simulate_writing_time(content):
@@ -1157,7 +1151,11 @@ def _engage_card(driver, wait, my_profile: LinkedInProfile, user_id: int, card, 
         release_post_claim(user_id, key)  # no comment generated (or none cleared the quality gate)
         return False
     driver.execute_script("arguments[0].scrollIntoView({block:'center'});", card)
-    time.sleep(simulate_reading_time(content) / 2 + simulate_thinking_time())
+    # Read-time-realistic delay (issue #626): scaled to the post's length and floored well above
+    # "instant", so we never comment faster than a human could have read the thing. The old
+    # half-reading-time + thinking-time pair could clear a short post in ~3s, which is the loudest
+    # cadence tell there is.
+    pace_read(content, user_id=user_id)
     # React BEFORE submitting the comment: posting re-renders the card and staled the element, so
     # the old post-comment reaction attempt silently failed. Skip our OWN posts. Non-fatal — a
     # missed reaction never blocks the comment.
@@ -1173,6 +1171,7 @@ def _engage_card(driver, wait, my_profile: LinkedInProfile, user_id: int, card, 
     mark_post_commented(user_id, key)
     insert_new_log(user_id=user_id, action_type=LogActionType.COMMENT,
                    result=LogResultType.SUCCESS, post_url=key, message=comment_text)
+    record_action(user_id, ACTION_COMMENT)  # account-level governor (issue #626)
     if recent_comments is not None:
         recent_comments.insert(0, comment_text)
     time.sleep(random.uniform(6, 14))  # human pacing between comments
@@ -1275,9 +1274,15 @@ def comment_on_feed_inline(driver, wait, my_profile: LinkedInProfile, user_id: i
     if engagers is None:
         engagers = get_recent_engagers(user_id)
     daily_cap = prefs.get("max_comments_per_day") or 20
-    remaining_today = max(0, daily_cap - count_comments_today(user_id))
+    # Human pacing (issue #626): today's allowance is a stable random draw from the cap (with
+    # weekend asymmetry and occasional rest days), and the account-level governor also caps the
+    # COMBINED comment/DM/invite traffic — so a flat "cap comments every day" volume signature
+    # never shows up, and the lanes can't each spend a full cap on the same day.
+    remaining_today = remaining_actions(user_id, ACTION_COMMENT, daily_cap,
+                                        count_comments_today(user_id),
+                                        caps=engagement_caps_from_prefs(prefs))
     if remaining_today <= 0:
-        myprint(f"Daily comment cap reached ({daily_cap}) — skipping")
+        myprint(f"Daily comment budget spent (cap {daily_cap}) — skipping")
         return 0
     max_posts = min(max_posts, remaining_today)
     max_age_min = (prefs.get("max_post_age_hours") or 24) * 60
@@ -2250,10 +2255,19 @@ def _golden_hour_sweep_countdowns(sweeps: int = _GOLDEN_HOUR_REPLY_SWEEPS,
     """Countdown seconds (from publish) for the golden-hour reply sweeps, spread evenly across the
     window so a comment left at any point in the golden hour is answered within window/sweeps minutes.
     e.g. 3 sweeps over 60 min → [1200, 2400, 3600] (20, 40, 60 min in). Sweep count is floored to 1
-    and capped at _GOLDEN_HOUR_MAX_SWEEPS so misconfiguration can't schedule an unbounded burst."""
+    and capped at _GOLDEN_HOUR_MAX_SWEEPS so misconfiguration can't schedule an unbounded burst.
+
+    Each slot carries a small RESPONSIVE jitter (issue #626): replying quickly to comments on your
+    OWN post is human, so these are exempt from the tens-of-minutes engagement jitter — but landing
+    on 20:00/40:00/60:00 after every single publish is a machine signature, so the exact minute
+    still moves. Jitter is additive (never earlier), so the last sweep still covers the window."""
     n = max(1, min(_GOLDEN_HOUR_MAX_SWEEPS, int(sweeps)))
     step = (window_minutes * 60) / n
-    return [int(round(step * i)) for i in range(1, n + 1)]
+    # Half a step is the hard jitter ceiling: even a misconfigured PACING_RESPONSIVE_JITTER_MAX_SECONDS
+    # can then never reorder two sweeps or collapse them onto the same minute.
+    jitter_cap = int(step // 2)
+    return [int(round(step * i)) + min(jitter_cap, dispatch_jitter_seconds(PACE_RESPONSIVE))
+            for i in range(1, n + 1)]
 
 
 # --- inbound hot-lead detection (issue #483) ---------------------------------------------------
@@ -2430,6 +2444,7 @@ def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my
         if response and _reply_to_comment_inline(driver, wait, comment, response, user_id=user_id):
             insert_new_log(user_id=user_id, post_id=post_id, action_type=LogActionType.REPLY,
                            result=LogResultType.SUCCESS, post_url=post_url, message=response)
+            record_action(user_id, ACTION_REPLY)  # tracked, but outside the outbound envelope (#626)
             comments_replied_count += 1
             time.sleep(random.uniform(5, 12))
         else:
@@ -2772,6 +2787,7 @@ def _followup_on_post_comment_replies(driver, wait, user_id: int, post_url: str,
                 record_comment_followup(user_id, post_key, reply_key, reacted=did_react, replied=True)
                 insert_new_log(user_id=user_id, action_type=LogActionType.REPLY,
                                result=LogResultType.SUCCESS, post_url=post_url, message=response)
+                record_action(user_id, ACTION_REPLY)  # tracked, outside the outbound envelope (#626)
                 time.sleep(random.uniform(5, 12))
     return result
 
@@ -3613,15 +3629,10 @@ def generate_and_post_comment(driver, wait, post_link, my_profile: LinkedInProfi
     # click_element_wait_retry(driver, wait, '//button[contains(@class, "see-more")]', "Clicking Read More Button",
     #                         parent_element=post['element'], max_try=0, element_always_expected=False)
 
-    # Simulate reading the post
-    read_time = simulate_reading_time(content) / 2
-    myprint(f"Simulated Reading... for {read_time} seconds")
-    time.sleep(read_time)
-
-    # Simulate thinking time
-    thinking_time = simulate_thinking_time()
-    myprint(f"Simulated Thinking... for {thinking_time} seconds")
-    time.sleep(thinking_time)
+    # Read-time-realistic delay before engaging (issue #626) — same floor/ceiling as the feed walk,
+    # so the permalink path can't be the fast one that gives the account away.
+    read_time = pace_read(content, user_id=user_id)
+    myprint(f"Simulated Reading... for {read_time:.0f} seconds")
 
     # Generate AI response — pass the user's engagement preferences so this path honors
     # tone/comment_length/style/emoji/hashtag settings exactly like the feed-commenting path
@@ -4035,6 +4046,8 @@ def send_dm_now(user_id: int, profile_url: str, message: str) -> bool:
         insert_new_log(user_id=user_id, action_type=LogActionType.DM,
                        result=LogResultType.SUCCESS if dm_sent else LogResultType.FAILURE,
                        post_url=profile_url, message=message)
+        if dm_sent:
+            record_action(user_id, ACTION_DM)  # account-level governor (issue #626)
 
         quit_gracefully(driver)  # Close the driver
 
@@ -4064,8 +4077,10 @@ def send_scheduled_dm(self, dm_id: int):
 
     user_id = dm["user_id"]
     prefs = get_engagement_preferences(user_id)
-    if count_dms_sent_today(user_id) >= int(prefs.get("max_dms_per_day") or 0):
-        myprint(f"send_scheduled_dm: daily DM cap reached for user {user_id}; deferring DM {dm_id}")
+    if remaining_actions(user_id, ACTION_DM, int(prefs.get("max_dms_per_day") or 0),
+                         count_dms_sent_today(user_id),
+                         caps=engagement_caps_from_prefs(prefs)) <= 0:
+        myprint(f"send_scheduled_dm: daily DM budget spent for user {user_id}; deferring DM {dm_id}")
         update_scheduled_dm_status(dm_id, ScheduledDmStatus.APPROVED)  # retry on the next scan
         return f"Scheduled DM {dm_id} deferred (daily DM cap reached)"
 
@@ -4317,6 +4332,8 @@ def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -
         insert_new_log(user_id=user_id, action_type=LogActionType.ENGAGED,
                        result=LogResultType.SUCCESS if invite_sent else LogResultType.FAILURE,
                        post_url=profile_url, message=result)
+        if invite_sent:
+            record_action(user_id, ACTION_INVITE)  # account-level governor (issue #626)
     finally:
         quit_gracefully(driver)  # Close the driver
 
@@ -4641,7 +4658,11 @@ def _fire_funnel_stage(user_id: int, target: dict) -> str:
         return f"target {target_id}: skipped {stage} (no draft)"
 
     if stage == OutreachStage.COMMENT:
-        if count_comments_today(user_id) >= int(prefs.get("max_comments_per_day") or 0):
+        # Same paced budget + account governor the feed walk spends against (issue #626), so the
+        # funnel can't quietly push the day past the account envelope.
+        if remaining_actions(user_id, ACTION_COMMENT, int(prefs.get("max_comments_per_day") or 0),
+                             count_comments_today(user_id),
+                             caps=engagement_caps_from_prefs(prefs)) <= 0:
             return f"target {target_id}: comment deferred (daily comment cap)"
         context_url = target.get("context_url")
         if not context_url:
@@ -4657,7 +4678,9 @@ def _fire_funnel_stage(user_id: int, target: dict) -> str:
                                               "message": draft})
         next_stage = OutreachStage.DM
     elif stage == OutreachStage.DM:
-        if count_dms_sent_today(user_id) >= int(prefs.get("max_dms_per_day") or 0):
+        if remaining_actions(user_id, ACTION_DM, int(prefs.get("max_dms_per_day") or 0),
+                             count_dms_sent_today(user_id),
+                             caps=engagement_caps_from_prefs(prefs)) <= 0:
             return f"target {target_id}: DM deferred (daily DM cap)"
         send_private_dm.apply_async(kwargs={"user_id": user_id, "profile_url": profile_url,
                                             "message": draft})

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -35,6 +35,10 @@ from cqc_lem.utilities.engagement_window import (
 )
 from cqc_lem.utilities.env_constants import SELENIUM_KEEP_VIDEOS_X_DAYS, CQC_LEM_POST_TIME_DELTA_MINUTES, \
     COST_ROUTING_WINDOW_DAYS
+from cqc_lem.utilities.human_pacing import (
+    dispatch_jitter_seconds, engagement_caps_from_prefs, remaining_actions,
+    ACTION_INVITE, PACE_RESPONSIVE,
+)
 from cqc_lem.utilities.logger import myprint, log_info, log_debug, log_warning
 from cqc_lem.utilities.linkedin.rate_limit import is_automation_paused, automation_pause_remaining, \
     rate_limit_cooldown_remaining
@@ -240,13 +244,19 @@ def auto_check_connection_requests(self):
         if user_id not in budgets:
             prefs = get_engagement_preferences(user_id)
             cap = int(prefs.get("max_invites_per_day") or 0)
-            budgets[user_id] = max(0, cap - count_invites_sent_today(user_id))
+            # Paced budget + account governor (issue #626) instead of the flat cap, so invite volume
+            # varies day to day and shares one envelope with commenting and DMs.
+            budgets[user_id] = remaining_actions(user_id, ACTION_INVITE, cap,
+                                                 count_invites_sent_today(user_id),
+                                                 caps=engagement_caps_from_prefs(prefs))
         if budgets[user_id] <= 0:
-            continue  # daily cap already met for this user — leave the rest 'approved' for tomorrow
+            continue  # daily budget already spent for this user — leave the rest 'approved' for tomorrow
         budgets[user_id] -= 1
-        # Mark 'sending' so it isn't re-dispatched on the next scan, then send.
+        # Mark 'sending' so it isn't re-dispatched on the next scan, then send. The countdown spreads
+        # the day's invites instead of firing the whole approved batch on one 5-minute beat tick.
         update_connection_request_status(request_id, ConnectionRequestStatus.SENDING)
-        send_connection_request.apply_async(kwargs={'request_id': request_id})
+        send_connection_request.apply_async(kwargs={'request_id': request_id},
+                                            countdown=dispatch_jitter_seconds())
         log_info(f"Connection request {request_id} dispatched",
                  user_id=user_id, task_name="auto_check_connection_requests")
         dispatched += 1
@@ -287,6 +297,7 @@ def auto_appreciate_dms():
 
         # No need to worry as this task is rate limited to 2 per minute
         automate_appreciation_dms_for_user.apply_async(kwargs=kwargs, retry=True,
+                                                       countdown=dispatch_jitter_seconds(),
                                                        retry_policy={
                                                            'max_retries': 3,
                                                            'interval_start': 60,
@@ -322,7 +333,11 @@ def auto_daily_engagement():
         # anyway must not burn theirs — connecting later in the day still earns a run.
         if not _stagger_due(user_id, STAGGER_GOLDEN_HOUR, "auto_daily_engagement"):
             continue  # not this user's slot yet (or already dispatched today)
-        automate_commenting.apply_async(kwargs={'user_id': user_id, 'loop_for_duration': 60 * 15})
+        # Human pacing (issue #626): the staggered slot is stable per user, so without this the run
+        # would start at the same clock minute every single day. A countdown of tens of minutes
+        # moves the actual start; the worker is never blocked (this is eta scheduling, not a sleep).
+        automate_commenting.apply_async(kwargs={'user_id': user_id, 'loop_for_duration': 60 * 15},
+                                        countdown=dispatch_jitter_seconds())
         dispatched += 1
     return f"Golden-hour engagement dispatched for {dispatched}/{len(users)} active user(s)"
 
@@ -355,7 +370,11 @@ def dispatch_scheduled_reply_sweeps():
             except Exception:
                 due = True
         if due:
-            sweep_reply_comments.apply_async(kwargs={'user_id': user_id})
+            # Replying to comments on the user's OWN post is the one engagement a human really does
+            # fast, so it keeps the RESPONSIVE profile (issue #626): the exact minute moves, the
+            # response stays timely.
+            sweep_reply_comments.apply_async(kwargs={'user_id': user_id},
+                                             countdown=dispatch_jitter_seconds(PACE_RESPONSIVE))
             dispatched += 1
     return f"Scheduled reply sweeps dispatched for {dispatched}/{len(users)} user(s)"
 
@@ -385,7 +404,8 @@ def dispatch_comment_followups():
             except Exception:
                 due = True
         if due:
-            sweep_comment_followups.apply_async(kwargs={'user_id': user_id})
+            sweep_comment_followups.apply_async(kwargs={'user_id': user_id},
+                                                countdown=dispatch_jitter_seconds())
             dispatched += 1
     return f"Comment follow-up sweeps dispatched for {dispatched}/{len(users)} user(s)"
 

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -221,6 +221,15 @@ def auto_check_scheduled_dms(self):
     return f"Scheduled {dispatched} DM(s); re-queued {len(orphaned)} orphaned DM(s)"
 
 
+# How long a request may sit in 'sending' before the reaper below assumes its send task was lost.
+_CONNECTION_ORPHAN_LOOKBACK_HOURS = 2
+# ...which is also the hard ceiling on the pacing countdown a dispatch may carry (issue #626): a
+# jitter longer than the orphan gap would let the reaper queue a SECOND send for a request whose
+# first one is still legitimately pending, i.e. invite the same person twice. The 15-minute margin
+# keeps a tuned-up PACING_JITTER_MAX_MINUTES from ever reaching that boundary.
+_MAX_INVITE_DISPATCH_DELAY_SECONDS = _CONNECTION_ORPHAN_LOOKBACK_HOURS * 3600 - 15 * 60
+
+
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, }, reject_on_worker_lost=True)
 def auto_check_connection_requests(self):
     """Scan for approved proactive connection requests and dispatch the send task, enforcing the
@@ -255,15 +264,17 @@ def auto_check_connection_requests(self):
         # Mark 'sending' so it isn't re-dispatched on the next scan, then send. The countdown spreads
         # the day's invites instead of firing the whole approved batch on one 5-minute beat tick.
         update_connection_request_status(request_id, ConnectionRequestStatus.SENDING)
-        send_connection_request.apply_async(kwargs={'request_id': request_id},
-                                            countdown=dispatch_jitter_seconds())
+        send_connection_request.apply_async(
+            kwargs={'request_id': request_id},
+            countdown=min(dispatch_jitter_seconds(), _MAX_INVITE_DISPATCH_DELAY_SECONDS))
         log_info(f"Connection request {request_id} dispatched",
                  user_id=user_id, task_name="auto_check_connection_requests")
         dispatched += 1
 
     # Re-queue requests stuck in 'sending' whose send task was lost (e.g. on container restart) —
-    # mirrors the orphaned-DM recovery. The 2-hour gap avoids racing an in-flight task.
-    orphaned = get_orphaned_connection_requests(lookback_hours=2)
+    # mirrors the orphaned-DM recovery. The lookback gap avoids racing an in-flight task — which is
+    # why the dispatch countdown above is clamped to stay inside it.
+    orphaned = get_orphaned_connection_requests(lookback_hours=_CONNECTION_ORPHAN_LOOKBACK_HOURS)
     for request_id, user_id in orphaned:
         log_warning(f"Re-queueing orphaned connection request {request_id}",
                     user_id=user_id, task_name="auto_check_connection_requests")
@@ -336,10 +347,28 @@ def auto_daily_engagement():
         # Human pacing (issue #626): the staggered slot is stable per user, so without this the run
         # would start at the same clock minute every single day. A countdown of tens of minutes
         # moves the actual start; the worker is never blocked (this is eta scheduling, not a sleep).
-        automate_commenting.apply_async(kwargs={'user_id': user_id, 'loop_for_duration': 60 * 15},
-                                        countdown=dispatch_jitter_seconds())
+        # The countdown rides the shim below rather than automate_commenting itself — see its
+        # docstring for why hanging it on a QueueOnce task would silently drop the pre-post run.
+        dispatch_golden_hour_engagement.apply_async(
+            kwargs={'user_id': user_id, 'loop_for_duration': 60 * 15},
+            countdown=dispatch_jitter_seconds())
         dispatched += 1
     return f"Golden-hour engagement dispatched for {dispatched}/{len(users)} active user(s)"
+
+
+@shared_task.task
+def dispatch_golden_hour_engagement(user_id: int, loop_for_duration: int = 60 * 15):
+    """Lock-free carrier for the golden-hour run's pacing countdown (issue #626).
+
+    `automate_commenting` is QueueOnce keyed on user_id, and celery-once takes that lock inside
+    apply_async — not when the task finally runs. Hanging the 30–90 min pacing countdown directly
+    on it would therefore hold the user's lock for the whole delay, and every pre-post warm-up
+    dispatch for that user in the meantime (same key, `graceful: True`) would be swallowed with no
+    error and no log — losing exactly the run that matters most. Carrying the countdown here keeps
+    the jitter while the lock is taken only at the moment the run is really queued."""
+    automate_commenting.apply_async(kwargs={'user_id': user_id,
+                                            'loop_for_duration': loop_for_duration})
+    return f"Golden-hour engagement queued for user {user_id}"
 
 
 @shared_task.task

--- a/src/cqc_lem/utilities/human_pacing.py
+++ b/src/cqc_lem/utilities/human_pacing.py
@@ -204,6 +204,10 @@ def daily_budget(user_id: int, action: str, cap: int, day: Optional[date] = None
     Persisted in Redis for the day so a mid-day cap edit (or a re-run) doesn't change the number
     already being spent against; the draw is seeded anyway, so with no Redis the same value is
     re-derived rather than re-rolled. Returns `cap` unchanged when pacing is disabled.
+
+    The stored value is still clamped to the CURRENT cap on the way out: stability must never make
+    us more aggressive than the user's own setting, so lowering a cap mid-day (the one edit someone
+    makes because they're worried about the account) takes effect immediately.
     """
     cap = max(0, int(cap or 0))
     if not pacing_enabled() or cap == 0:
@@ -215,7 +219,7 @@ def daily_budget(user_id: int, action: str, cap: int, day: Optional[date] = None
         try:
             stored = client.get(key)
             if stored is not None:
-                return max(0, int(stored))
+                return max(0, min(cap, int(stored)))
         except (ValueError, TypeError):
             pass  # corrupt value — fall through and re-derive
         except Exception as e:
@@ -301,9 +305,13 @@ def remaining_actions(user_id: int, action: str, cap: int, used_today: int,
     and what the account envelope has left across every lane. Pass `caps` (from
     `engagement_caps_from_prefs`) to engage the account-level governor; without it the envelope is
     just this lane and the call degrades to the per-lane budget.
+
+    With pacing disabled the envelope is skipped entirely, not just softened: the whole point of the
+    switch is that it restores the pre-#626 behaviour, and pre-#626 each lane spent its own cap with
+    no shared pool at all.
     """
     lane_left = max(0, daily_budget(user_id, action, cap, day) - max(0, int(used_today or 0)))
-    if not caps:
+    if not caps or not pacing_enabled():
         return lane_left
     envelope_left = max(0, account_envelope(user_id, caps, day) - actions_used_today(user_id, day=day))
     return min(lane_left, envelope_left)

--- a/src/cqc_lem/utilities/human_pacing.py
+++ b/src/cqc_lem/utilities/human_pacing.py
@@ -1,0 +1,309 @@
+"""Human-pacing engine — the one place engagement CADENCE is decided (issue #626).
+
+LinkedIn's comment-bot detection keys on cadence, not content: engaging seconds after a post
+appears, machine-exact daily start times, identical intervals, and a flat daily volume are all
+signals no human produces. Three knobs live here, plus the governor that keeps them honest:
+
+1. **Read-time delay** (`read_delay_seconds`) — before commenting we wait as long as it would take
+   to actually READ the target post (scaled by its length) plus a little browse time, floored at
+   `PACING_READ_MIN_SECONDS` and ceilinged at `PACING_READ_MAX_SECONDS`. We never interact faster
+   than a human could have read the thing.
+2. **Schedule jitter** (`dispatch_jitter_seconds`) — beat-dispatched engagement tasks get a random
+   forward countdown instead of firing on the crontab minute. The delay is forward-only because a
+   beat tick cannot dispatch into the past; the staggered per-user slot (issue #554) already
+   supplies the "±" half by spreading users across a window. Replies to comments on the user's OWN
+   post use the `PACE_RESPONSIVE` profile — answering fast is human, so those are jittered by
+   seconds, not by an hour.
+3. **Variable daily volume** (`daily_budget`) — each day's allowance is a random draw from the
+   user's configured cap (40–100% by default) with weekend asymmetry and occasional rest days,
+   rather than the same number every day. The draw is seeded from (user, action, day) so it is
+   STABLE: a retry, a second worker, or a Redis outage all re-derive the same number instead of
+   re-rolling a fresh (possibly larger) budget mid-day.
+
+`record_action` / `remaining_actions` are the account-level governor: every engagement lane
+(commenting, replies, DMs, invites) reports what it spent into one per-day counter, so the combined
+traffic can't exceed the account envelope even though each lane checks its own cap separately.
+
+Everything here fails OPEN. No Redis, or `HUMAN_PACING_ENABLED=false`, degrades to the pre-#626
+behaviour (full cap, no jitter, no added delay) rather than blocking engagement. The breaker in
+`utilities/linkedin/rate_limit.py` is a separate, harder gate and is unaffected — pacing only ever
+makes us slower, never more aggressive.
+
+Nothing here sleeps longer than `MAX_INLINE_SLEEP_SECONDS`: a Celery worker must never be parked on
+a long sleep, so anything beyond a read delay is expressed as an `apply_async(countdown=...)`.
+"""
+
+import hashlib
+import os
+import random
+import time
+from datetime import date, datetime, timezone
+from typing import Dict, Optional
+
+from cqc_lem.utilities.linkedin.rate_limit import shared_redis_client
+from cqc_lem.utilities.logger import log_debug, log_warning
+
+# Engagement lanes the governor accounts for. Each maps to one per-day cap in engagement_preferences.
+ACTION_COMMENT = "comment"
+ACTION_REPLY = "reply"
+ACTION_DM = "dm"
+ACTION_INVITE = "invite"
+ENGAGEMENT_ACTIONS = (ACTION_COMMENT, ACTION_REPLY, ACTION_DM, ACTION_INVITE)
+
+# Which preference key caps each lane.
+ACTION_CAP_PREF = {
+    ACTION_COMMENT: "max_comments_per_day",
+    ACTION_DM: "max_dms_per_day",
+    ACTION_INVITE: "max_invites_per_day",
+}
+
+# Lanes that spend the account envelope. Replies are deliberately NOT one of them: a reply is an
+# answer to someone who spoke to us on our OWN post, and going quiet on those to protect a
+# commenting budget is worse for the account than the cadence risk it would avoid (the G7 golden-hour
+# exemption). They are still recorded per-lane for visibility, and still jittered (PACE_RESPONSIVE) —
+# they just never consume what discretionary outbound spends.
+ENVELOPE_ACTIONS = (ACTION_COMMENT, ACTION_DM, ACTION_INVITE)
+
+# Jitter profiles.
+PACE_STANDARD = "standard"      # discretionary outbound — jitter by tens of minutes
+PACE_RESPONSIVE = "responsive"  # answering someone on our own post — jitter by seconds
+
+# A Celery worker parked on a sleep is a worker not doing work; long delays must be scheduled with
+# countdown/eta instead. Every inline pacing sleep this module hands out is clamped below this.
+MAX_INLINE_SLEEP_SECONDS = 300
+
+_DEFAULTS = {
+    "PACING_READ_MIN_SECONDS": 45.0,
+    "PACING_READ_MAX_SECONDS": 240.0,
+    "PACING_READ_WPM": 240.0,
+    "PACING_BROWSE_MIN_SECONDS": 3.0,
+    "PACING_BROWSE_MAX_SECONDS": 25.0,
+    "PACING_JITTER_MIN_MINUTES": 30.0,
+    "PACING_JITTER_MAX_MINUTES": 90.0,
+    "PACING_RESPONSIVE_JITTER_MAX_SECONDS": 180.0,
+    "PACING_BUDGET_MIN_RATIO": 0.4,
+    "PACING_BUDGET_MAX_RATIO": 1.0,
+    "PACING_REST_DAY_CHANCE": 0.08,
+    "PACING_WEEKEND_RATIO": 0.55,
+}
+
+_BUDGET_KEY = "pacing:budget:{action}:{user_id}:{day}"
+_USED_KEY = "pacing:used:{user_id}:{day}"
+_USED_TOTAL_FIELD = "total"
+# Long enough to outlast the day it was written on (any timezone), short enough to garbage-collect.
+_DAY_TTL_SECONDS = 36 * 60 * 60
+
+
+def pacing_enabled() -> bool:
+    """False turns the whole engine into a no-op — full cap, no jitter, no added read delay."""
+    return (os.environ.get("HUMAN_PACING_ENABLED") or "true").strip().lower() not in ("0", "false", "no")
+
+
+def _env_float(name: str) -> float:
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return _DEFAULTS[name]
+    try:
+        return float(raw)
+    except ValueError:
+        log_warning(f"{name} ignored (not a number: {raw!r})")
+        return _DEFAULTS[name]
+
+
+def _today(day: Optional[date] = None) -> date:
+    return day or datetime.now(timezone.utc).date()
+
+
+def _seeded_rng(*parts) -> random.Random:
+    """A Random seeded from the given parts — the same (user, action, day) always draws the same
+    numbers, which is what makes a day's budget survive retries and Redis outages alike."""
+    salt = os.environ.get("PACING_SEED") or ""
+    digest = hashlib.sha256(":".join([salt] + [str(p) for p in parts]).encode("utf-8")).digest()
+    return random.Random(int.from_bytes(digest[:8], "big"))
+
+
+# --- 1. read-time delay ------------------------------------------------------------------------
+
+def read_delay_seconds(content: str, rng: Optional[random.Random] = None) -> float:
+    """How long to wait before engaging with a post of this length, in seconds.
+
+    Reading time at `PACING_READ_WPM` plus a random browse/scroll allowance, clamped into
+    [`PACING_READ_MIN_SECONDS`, `PACING_READ_MAX_SECONDS`]. The floor is the point: a 12-word post
+    still costs 45s, because commenting three seconds after a post rendered is the single loudest
+    bot tell. Returns 0.0 when pacing is disabled.
+    """
+    if not pacing_enabled():
+        return 0.0
+    rng = rng or random
+    words = len((content or "").split())
+    wpm = max(1.0, _env_float("PACING_READ_WPM"))
+    reading = words / wpm * 60.0
+    browse = rng.uniform(_env_float("PACING_BROWSE_MIN_SECONDS"), _env_float("PACING_BROWSE_MAX_SECONDS"))
+    low = max(0.0, _env_float("PACING_READ_MIN_SECONDS"))
+    # The ceiling also keeps this sleep inline-safe: a worker never parks past MAX_INLINE_SLEEP_SECONDS.
+    high = min(float(MAX_INLINE_SLEEP_SECONDS), max(low, _env_float("PACING_READ_MAX_SECONDS")))
+    return min(high, max(low, reading + browse))
+
+
+def pace_read(content: str, user_id: Optional[int] = None) -> float:
+    """Sleep for `read_delay_seconds(content)` and return the delay actually used."""
+    delay = read_delay_seconds(content)
+    if delay <= 0:
+        return 0.0
+    log_debug(f"Human-pacing read delay {delay:.0f}s before engaging", user_id=user_id,
+              action_type="comment", duration_ms=int(delay * 1000))
+    time.sleep(delay)
+    return delay
+
+
+# --- 2. schedule jitter ------------------------------------------------------------------------
+
+def dispatch_jitter_seconds(profile: str = PACE_STANDARD,
+                            rng: Optional[random.Random] = None) -> int:
+    """A countdown (seconds) to hand `apply_async` so a beat-dispatched engagement task doesn't
+    start on the crontab's exact minute. `PACE_RESPONSIVE` keeps replies on our own post fast
+    (seconds of jitter) while still breaking the machine-exact timing. 0 when pacing is disabled."""
+    if not pacing_enabled():
+        return 0
+    rng = rng or random
+    if profile == PACE_RESPONSIVE:
+        return int(rng.uniform(0.0, max(0.0, _env_float("PACING_RESPONSIVE_JITTER_MAX_SECONDS"))))
+    low = max(0.0, _env_float("PACING_JITTER_MIN_MINUTES")) * 60.0
+    high = max(low, _env_float("PACING_JITTER_MAX_MINUTES") * 60.0)
+    return int(rng.uniform(low, high))
+
+
+# --- 3. variable daily volume ------------------------------------------------------------------
+
+def is_rest_day(user_id: int, day: Optional[date] = None) -> bool:
+    """True on the occasional day this account does no discretionary engagement at all. Account-level
+    (not per-lane) — a human who is offline is offline for everything."""
+    if not pacing_enabled():
+        return False
+    chance = min(1.0, max(0.0, _env_float("PACING_REST_DAY_CHANCE")))
+    return _seeded_rng("rest", user_id, _today(day).isoformat()).random() < chance
+
+
+def _draw_budget(user_id: int, action: str, cap: int, day: date) -> int:
+    rng = _seeded_rng("budget", user_id, action, day.isoformat())
+    low = max(0.0, _env_float("PACING_BUDGET_MIN_RATIO"))
+    high = max(low, _env_float("PACING_BUDGET_MAX_RATIO"))
+    ratio = rng.uniform(low, high)
+    if day.weekday() >= 5:  # Sat/Sun — real people post and comment less on weekends
+        ratio *= max(0.0, _env_float("PACING_WEEKEND_RATIO"))
+    if is_rest_day(user_id, day):
+        return 0
+    # A non-zero cap always keeps at least one action: the draw shapes volume, it must not silently
+    # zero out a lane the user explicitly enabled (that is what rest days are for).
+    return max(1, int(round(cap * ratio)))
+
+
+def daily_budget(user_id: int, action: str, cap: int, day: Optional[date] = None) -> int:
+    """Today's allowance for one engagement lane — a stable random draw from `cap`.
+
+    Persisted in Redis for the day so a mid-day cap edit (or a re-run) doesn't change the number
+    already being spent against; the draw is seeded anyway, so with no Redis the same value is
+    re-derived rather than re-rolled. Returns `cap` unchanged when pacing is disabled.
+    """
+    cap = max(0, int(cap or 0))
+    if not pacing_enabled() or cap == 0:
+        return cap
+    day = _today(day)
+    key = _BUDGET_KEY.format(action=action, user_id=int(user_id), day=day.isoformat())
+    client = shared_redis_client()
+    if client is not None:
+        try:
+            stored = client.get(key)
+            if stored is not None:
+                return max(0, int(stored))
+        except (ValueError, TypeError):
+            pass  # corrupt value — fall through and re-derive
+        except Exception as e:
+            log_warning("Could not read today's pacing budget", exc=e, user_id=user_id)
+            client = None
+    budget = _draw_budget(user_id, action, cap, day)
+    if client is not None:
+        try:
+            client.set(key, budget, ex=_DAY_TTL_SECONDS)
+        except Exception as e:
+            log_warning("Could not persist today's pacing budget", exc=e, user_id=user_id)
+    return budget
+
+
+def engagement_caps_from_prefs(prefs: Optional[dict]) -> Dict[str, int]:
+    """The per-lane caps the governor's envelope is built from, read off engagement_preferences.
+
+    Only ENVELOPE_ACTIONS appear — replies are outside the envelope on purpose (see above)."""
+    prefs = prefs or {}
+    caps: Dict[str, int] = {}
+    for action in ENVELOPE_ACTIONS:
+        try:
+            caps[action] = max(0, int(prefs.get(ACTION_CAP_PREF[action]) or 0))
+        except (TypeError, ValueError):
+            caps[action] = 0
+    return caps
+
+
+# --- the account-level governor ----------------------------------------------------------------
+
+def record_action(user_id: int, action: str, count: int = 1) -> None:
+    """Report one completed engagement action into the shared per-day counter. Best-effort.
+
+    Only ENVELOPE_ACTIONS add to the account total; a reply is counted in its own field so the day
+    can still be audited, without letting a busy thread on the user's own post eat the outbound
+    budget."""
+    if count <= 0:
+        return
+    client = shared_redis_client()
+    if client is None:
+        return
+    key = _USED_KEY.format(user_id=int(user_id), day=_today().isoformat())
+    try:
+        client.hincrby(key, action, int(count))
+        if action in ENVELOPE_ACTIONS:
+            client.hincrby(key, _USED_TOTAL_FIELD, int(count))
+        client.expire(key, _DAY_TTL_SECONDS)
+    except Exception as e:
+        log_warning("Could not record engagement action for pacing", exc=e, user_id=user_id)
+
+
+def actions_used_today(user_id: int, action: Optional[str] = None,
+                       day: Optional[date] = None) -> int:
+    """Actions this account has spent today across every lane (or in one lane when `action` is
+    given). 0 when Redis is unavailable — the governor then can't restrict anything, which is the
+    intended fail-open."""
+    client = shared_redis_client()
+    if client is None:
+        return 0
+    key = _USED_KEY.format(user_id=int(user_id), day=_today(day).isoformat())
+    try:
+        raw = client.hget(key, action or _USED_TOTAL_FIELD)
+    except Exception as e:
+        log_warning("Could not read today's pacing usage", exc=e, user_id=user_id)
+        return 0
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 0
+
+
+def account_envelope(user_id: int, caps: Dict[str, int], day: Optional[date] = None) -> int:
+    """The account's total engagement allowance today — the sum of every lane's paced budget. This
+    is what stops commenting, DMs and invites from each spending a full cap on the same day."""
+    return sum(daily_budget(user_id, action, cap, day) for action, cap in (caps or {}).items())
+
+
+def remaining_actions(user_id: int, action: str, cap: int, used_today: int,
+                      caps: Optional[Dict[str, int]] = None, day: Optional[date] = None) -> int:
+    """How many more `action`s this account may take right now.
+
+    The smaller of what the lane has left (its paced budget minus what the DB says it already spent)
+    and what the account envelope has left across every lane. Pass `caps` (from
+    `engagement_caps_from_prefs`) to engage the account-level governor; without it the envelope is
+    just this lane and the call degrades to the per-lane budget.
+    """
+    lane_left = max(0, daily_budget(user_id, action, cap, day) - max(0, int(used_today or 0)))
+    if not caps:
+        return lane_left
+    envelope_left = max(0, account_envelope(user_id, caps, day) - actions_used_today(user_id, day=day))
+    return min(lane_left, envelope_left)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,17 @@ def _humanize_disabled_by_default(monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _human_pacing_disabled_by_default(monkeypatch):
+    """Issue #626: the human-pacing engine is default-ON in production, where a comment costs a
+    45s–4min read delay and the day's volume is a random draw seeded on (user, action, TODAY'S
+    DATE). Both are poison for a test suite — real sleeps, and a budget that silently becomes 0 on
+    whichever calendar day the rest-day draw comes up. Default it OFF so unrelated tests keep the
+    pre-#626 behaviour (full cap, no delay, no jitter); the pacing tests turn it back on with
+    HUMAN_PACING_ENABLED=true and pin the day/RNG explicitly."""
+    monkeypatch.setenv("HUMAN_PACING_ENABLED", "false")
+
+
+@pytest.fixture(autouse=True)
 def _db_pool_disabled_by_default(monkeypatch):
     """Issue #555: get_db_connection() checks connections out of a per-process pool in production.
     The pool opens its connections through mysql-connector's own internal connect(), which the

--- a/tests/unit/app/test_comment_dedup.py
+++ b/tests/unit/app/test_comment_dedup.py
@@ -83,8 +83,7 @@ def _run_feed(boxes, *, claim_side_effect=None, has_commented=False, max_posts=1
         p("release_post_claim", new=release)
         p("log_warning")
         p("insert_new_log")
-        p("simulate_reading_time", return_value=0)
-        p("simulate_thinking_time", return_value=0)
+        p("pace_read", return_value=0.0)
         posted = ra.comment_on_feed_inline(driver, wait, MagicMock(), user_id=1, max_posts=max_posts)
 
     return {"posted": posted, "claim": claim, "post_inline": post_inline, "react": react,
@@ -186,8 +185,7 @@ class TestFeedDedup:
             p("log_warning")
             release = es.enter_context(patch(f"{_RA}.release_post_claim"))
             p("insert_new_log")
-            p("simulate_reading_time", return_value=0)
-            p("simulate_thinking_time", return_value=0)
+            p("pace_read", return_value=0.0)
             posted = ra.comment_on_feed_inline(driver, MagicMock(), MagicMock(), user_id=1, max_posts=1)
         assert posted == 0
         release.assert_called_with(1, "feedpost://fail")

--- a/tests/unit/app/test_configurable_engagement.py
+++ b/tests/unit/app/test_configurable_engagement.py
@@ -67,8 +67,7 @@ class TestProfileViewerCommentPrefs:
              patch(f"{_RA}.check_commented", return_value=False), \
              patch(f"{_RA}.get_element_wait_retry", return_value=el), \
              patch(f"{_RA}.getText", return_value="A post about supply chains."), \
-             patch(f"{_RA}.simulate_reading_time", return_value=0), \
-             patch(f"{_RA}.simulate_thinking_time", return_value=0), \
+             patch(f"{_RA}.pace_read", return_value=0.0), \
              patch(f"{_RA}.get_engagement_preferences", return_value=prefs) as get_prefs, \
              patch(f"{_RA}.generate_ai_response", return_value="Nice point.") as gen, \
              patch.object(ra.comment_on_post, "apply_async"):
@@ -91,8 +90,7 @@ class TestProfileViewerCommentPrefs:
              patch(f"{_RA}.check_commented", return_value=False), \
              patch(f"{_RA}.get_element_wait_retry", return_value=el), \
              patch(f"{_RA}.getText", return_value="A post."), \
-             patch(f"{_RA}.simulate_reading_time", return_value=0), \
-             patch(f"{_RA}.simulate_thinking_time", return_value=0), \
+             patch(f"{_RA}.pace_read", return_value=0.0), \
              patch(f"{_RA}.get_engagement_preferences", side_effect=RuntimeError("db down")), \
              patch(f"{_RA}.generate_ai_response", return_value="Nice point.") as gen, \
              patch.object(ra.comment_on_post, "apply_async"):

--- a/tests/unit/app/test_daily_engagement.py
+++ b/tests/unit/app/test_daily_engagement.py
@@ -35,21 +35,25 @@ class TestAutoDailyEngagement:
         with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2, 3]), \
              patch(f"{_RS}.has_linkedin_session", side_effect=lambda u: u != 3), \
              patch(f"{_RS}._stagger_due", return_value=True), \
-             patch(f"{_RS}.automate_commenting") as ac:
+             patch(f"{_RS}.dispatch_golden_hour_engagement") as shim:
             result = auto_daily_engagement()
-        assert ac.apply_async.call_count == 2                 # users 1 & 2 (3 has no session)
+        assert shim.apply_async.call_count == 2               # users 1 & 2 (3 has no session)
         assert "2/3" in result
 
     def test_golden_hour_stays_on_the_engage_lane(self):
         """Issue #553 gave the pre-post warm-up its own se_prepost lane by overriding queue= at
         that dispatch site only — the daily loop must keep falling through to the task's own
-        se_engage queue, or it would crowd out the deadline-bound warm-ups."""
-        from cqc_lem.app.run_scheduler import auto_daily_engagement
+        se_engage queue, or it would crowd out the deadline-bound warm-ups. The #626 jitter shim
+        sits in front of the dispatch, so check the hop that actually queues the Selenium run."""
+        from cqc_lem.app.run_scheduler import auto_daily_engagement, dispatch_golden_hour_engagement
         with patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
              patch(f"{_RS}.has_linkedin_session", return_value=True), \
              patch(f"{_RS}._stagger_due", return_value=True), \
-             patch(f"{_RS}.automate_commenting") as ac:
+             patch(f"{_RS}.dispatch_golden_hour_engagement") as shim:
             auto_daily_engagement()
+        assert "queue" not in shim.apply_async.call_args[1]
+        with patch(f"{_RS}.automate_commenting") as ac:
+            dispatch_golden_hour_engagement(user_id=1)
         assert "queue" not in ac.apply_async.call_args[1]
 
     def test_only_users_whose_slot_is_due_are_dispatched(self):
@@ -59,10 +63,10 @@ class TestAutoDailyEngagement:
         with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2, 3]), \
              patch(f"{_RS}.has_linkedin_session", return_value=True), \
              patch(f"{_RS}._stagger_due", side_effect=lambda u, *_: u == 2) as due, \
-             patch(f"{_RS}.automate_commenting") as ac:
+             patch(f"{_RS}.dispatch_golden_hour_engagement") as shim:
             result = auto_daily_engagement()
-        assert ac.apply_async.call_count == 1
-        assert ac.apply_async.call_args[1]["kwargs"]["user_id"] == 2
+        assert shim.apply_async.call_count == 1
+        assert shim.apply_async.call_args[1]["kwargs"]["user_id"] == 2
         assert due.call_args[0][1] is STAGGER_GOLDEN_HOUR
         assert "1/3" in result
 

--- a/tests/unit/app/test_human_pacing_integration.py
+++ b/tests/unit/app/test_human_pacing_integration.py
@@ -1,0 +1,229 @@
+"""The pacing engine wired into the engagement lanes (issue #626).
+
+test_human_pacing.py covers the engine itself; this file covers the seams — that the dispatchers
+actually pass a jittered countdown, that the lanes spend the paced budget rather than the raw cap,
+and that the governor's accounting is fed by the code paths that really post.
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+_RS = "cqc_lem.app.run_scheduler"
+
+
+@pytest.fixture
+def pacing_on(monkeypatch):
+    monkeypatch.setenv("HUMAN_PACING_ENABLED", "true")
+    monkeypatch.setenv("PACING_SEED", "issue-626-integration")
+    monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+
+
+class TestBeatDispatchJitter:
+    """Every beat-dispatched engagement task must start off the crontab minute."""
+
+    def test_golden_hour_commenting_is_dispatched_with_a_jitter_countdown(self, pacing_on):
+        from cqc_lem.app.run_scheduler import auto_daily_engagement
+        with patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
+             patch(f"{_RS}.has_linkedin_session", return_value=True), \
+             patch(f"{_RS}._stagger_due", return_value=True), \
+             patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.automate_commenting") as ac:
+            auto_daily_engagement()
+        assert 30 * 60 <= ac.apply_async.call_args[1]["countdown"] <= 90 * 60
+
+    def test_appreciation_dms_are_dispatched_with_a_jitter_countdown(self, pacing_on):
+        from cqc_lem.app.run_scheduler import auto_appreciate_dms
+        with patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
+             patch(f"{_RS}.has_linkedin_session", return_value=True), \
+             patch(f"{_RS}._stagger_due", return_value=True), \
+             patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.automate_appreciation_dms_for_user") as dm:
+            auto_appreciate_dms()
+        assert 30 * 60 <= dm.apply_async.call_args[1]["countdown"] <= 90 * 60
+
+    def test_own_post_reply_sweeps_stay_fast(self, pacing_on):
+        """G7 exemption: replying to comments on YOUR OWN post is human, so the sweep keeps the
+        RESPONSIVE profile — jittered by seconds, never delayed by an hour."""
+        from cqc_lem.app.run_scheduler import dispatch_scheduled_reply_sweeps
+        with patch(f"{_RS}.get_users_with_reply_mode", return_value=[1]), \
+             patch(f"{_RS}.has_linkedin_session", return_value=True), \
+             patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_engagement_preferences", return_value={"reply_sweeps_per_day": 2}), \
+             patch(f"{_RS}.sweep_reply_comments") as sweep:
+            dispatch_scheduled_reply_sweeps()
+        assert 0 <= sweep.apply_async.call_args[1]["countdown"] <= 180
+
+    def test_pacing_off_restores_the_immediate_dispatch(self, monkeypatch):
+        from cqc_lem.app.run_scheduler import auto_daily_engagement
+        monkeypatch.setenv("HUMAN_PACING_ENABLED", "false")
+        with patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
+             patch(f"{_RS}.has_linkedin_session", return_value=True), \
+             patch(f"{_RS}._stagger_due", return_value=True), \
+             patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.automate_commenting") as ac:
+            auto_daily_engagement()
+        assert ac.apply_async.call_args[1]["countdown"] == 0
+
+
+class TestGoldenHourSweepJitter:
+    def test_sweeps_are_jittered_but_never_reordered(self, pacing_on):
+        from cqc_lem.app.run_automation import (_golden_hour_sweep_countdowns, _GOLDEN_HOUR_MINUTES,
+                                                _GOLDEN_HOUR_MAX_SWEEPS)
+        for n in (1, 3, 6, _GOLDEN_HOUR_MAX_SWEEPS):
+            cds = _golden_hour_sweep_countdowns(n)
+            step = _GOLDEN_HOUR_MINUTES * 60 / n
+            assert len(cds) == n
+            assert cds == sorted(cds) and len(set(cds)) == n     # ordered, no collisions
+            for i, cd in enumerate(cds, start=1):
+                assert step * i <= cd <= step * i + step / 2      # forward-only, ≤ half a step
+
+    def test_a_misconfigured_jitter_cannot_push_a_sweep_past_the_next_one(self, pacing_on,
+                                                                          monkeypatch):
+        from cqc_lem.app.run_automation import _golden_hour_sweep_countdowns
+        monkeypatch.setenv("PACING_RESPONSIVE_JITTER_MAX_SECONDS", "100000")
+        cds = _golden_hour_sweep_countdowns(3)
+        assert cds == sorted(cds) and len(set(cds)) == 3
+
+    def test_the_publish_time_no_longer_predicts_the_sweep_minute(self, pacing_on):
+        from cqc_lem.app.run_automation import _golden_hour_sweep_countdowns
+        runs = {tuple(_golden_hour_sweep_countdowns(3)) for _ in range(30)}
+        assert len(runs) > 1  # landing on 20:00/40:00/60:00 after every publish is a signature
+
+
+class TestPacedBudgetsAtTheLanes:
+    def test_feed_commenting_stops_when_the_paced_budget_is_spent(self):
+        """The cap says 20 and nothing has been spent, but today's DRAW is 0 (rest day) — the run
+        must stop, which the raw-cap check could never do."""
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.count_comments_today", return_value=0), \
+             patch(f"{_RA}.remaining_actions", return_value=0) as remaining, \
+             patch(f"{_RA}.get_recent_engagers", return_value=set()):
+            posted = ra.comment_on_feed_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1,
+                                               prefs={"max_comments_per_day": 20})
+        assert posted == 0
+        assert remaining.call_args[0][2] == 20                      # the cap it drew against
+        assert remaining.call_args[1]["caps"]                       # governor engaged
+
+    def test_scheduled_dms_defer_on_the_paced_budget(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.db import ScheduledDmStatus
+        dm = {"id": 3, "user_id": 1, "recipient_profile_url": "https://x/in/jane",
+              "message": "hi jane", "status": "approved"}
+        with patch("cqc_lem.utilities.db.get_scheduled_dm", return_value=dm), \
+             patch("cqc_lem.utilities.db.count_dms_sent_today", return_value=0), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={"max_dms_per_day": 10}), \
+             patch(f"{_RA}.remaining_actions", return_value=0), \
+             patch(f"{_RA}.send_dm_now") as send, \
+             patch("cqc_lem.utilities.db.update_scheduled_dm_status") as upd:
+            out = ra.send_scheduled_dm(3)
+        send.assert_not_called()
+        upd.assert_called_once_with(3, ScheduledDmStatus.APPROVED)  # deferred, not failed
+        assert "deferred" in out
+
+    def test_connection_requests_spend_the_paced_invite_budget(self):
+        from cqc_lem.app.run_scheduler import auto_check_connection_requests
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_connection_requests", return_value=[(11, 7), (12, 7)]), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
+             patch(f"{_RS}.get_engagement_preferences", return_value={"max_invites_per_day": 10}), \
+             patch(f"{_RS}.count_invites_sent_today", return_value=0), \
+             patch(f"{_RS}.remaining_actions", return_value=1), \
+             patch(f"{_RS}.update_connection_request_status"), \
+             patch(f"{_RS}.get_orphaned_connection_requests", return_value=[]), \
+             patch(f"{_RS}.send_connection_request") as send:
+            result = auto_check_connection_requests()
+        assert send.apply_async.call_count == 1   # budget of 1, not the cap of 10
+        assert "1 connection request" in result
+
+    def test_connection_request_dispatch_is_jittered(self, pacing_on):
+        from cqc_lem.app.run_scheduler import auto_check_connection_requests
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_connection_requests", return_value=[(11, 7)]), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
+             patch(f"{_RS}.get_engagement_preferences", return_value={"max_invites_per_day": 10}), \
+             patch(f"{_RS}.count_invites_sent_today", return_value=0), \
+             patch(f"{_RS}.update_connection_request_status"), \
+             patch(f"{_RS}.get_orphaned_connection_requests", return_value=[]), \
+             patch(f"{_RS}.send_connection_request") as send:
+            auto_check_connection_requests()
+        assert 30 * 60 <= send.apply_async.call_args[1]["countdown"] <= 90 * 60
+
+
+class TestGovernorAccounting:
+    def test_a_landed_comment_is_reported_to_the_governor(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.human_pacing import ACTION_COMMENT
+        with patch(f"{_RA}.claim_post_for_comment", return_value=True), \
+             patch(f"{_RA}.select_blueprint", return_value={"format": "expander"}), \
+             patch(f"{_RA}.generate_ai_response", return_value="A real comment."), \
+             patch(f"{_RA}._author_is_me", return_value=False), \
+             patch(f"{_RA}.react_to_post_inline", return_value=True), \
+             patch(f"{_RA}.mark_post_reacted"), \
+             patch(f"{_RA}.post_comment_inline", return_value=True), \
+             patch(f"{_RA}.mark_post_commented"), \
+             patch(f"{_RA}.insert_new_log"), \
+             patch(f"{_RA}.pace_read", return_value=0.0), \
+             patch(f"{_RA}.time.sleep"), \
+             patch(f"{_RA}.record_action") as recorded:
+            ok = ra._engage_card(MagicMock(), MagicMock(), MagicMock(), 1, MagicMock(),
+                                 "feedurn://x", "a post body", "Jane", {}, "synth", [], [])
+        assert ok is True
+        recorded.assert_called_once_with(1, ACTION_COMMENT)
+
+    def test_a_skipped_comment_is_not_reported(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.claim_post_for_comment", return_value=True), \
+             patch(f"{_RA}.select_blueprint", return_value={"format": "expander"}), \
+             patch(f"{_RA}.generate_ai_response", return_value=None), \
+             patch(f"{_RA}.release_post_claim"), \
+             patch(f"{_RA}.record_action") as recorded:
+            ok = ra._engage_card(MagicMock(), MagicMock(), MagicMock(), 1, MagicMock(),
+                                 "feedurn://x", "a post body", "Jane", {}, "synth", [], [])
+        assert ok is False
+        recorded.assert_not_called()
+
+    def test_a_sent_invite_is_reported_and_a_failed_one_is_not(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.human_pacing import ACTION_INVITE
+        for sent in (True, False):
+            connect = MagicMock() if sent else MagicMock(side_effect=Exception("no button"))
+            with patch(f"{_RA}.get_user_password_pair_by_id", return_value=("e", "p")), \
+                 patch(f"{_RA}.get_driver_wait_pair", return_value=(MagicMock(), MagicMock())), \
+                 patch(f"{_RA}.login_to_linkedin"), \
+                 patch(f"{_RA}._profile_is_first_degree", return_value=False), \
+                 patch(f"{_RA}.click_element_wait_retry", connect), \
+                 patch(f"{_RA}.log_error"), \
+                 patch(f"{_RA}.insert_new_log"), \
+                 patch(f"{_RA}.quit_gracefully"), \
+                 patch(f"{_RA}.record_action") as recorded:
+                invite_sent, _reason = ra.invite_to_connect_now(1, "https://x/in/jane")
+            assert invite_sent is sent
+            if sent:
+                recorded.assert_called_once_with(1, ACTION_INVITE)
+            else:
+                recorded.assert_not_called()
+
+    def test_a_sent_dm_is_reported_and_a_failed_one_is_not(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.human_pacing import ACTION_DM
+        for sent in (True, False):
+            with patch(f"{_RA}.get_user_password_pair_by_id", return_value=("e", "p")), \
+                 patch(f"{_RA}.get_driver_wait_pair", return_value=(MagicMock(), MagicMock())), \
+                 patch(f"{_RA}.login_to_linkedin"), \
+                 patch(f"{_RA}.click_element_wait_retry"), \
+                 patch(f"{_RA}.get_element_wait_retry",
+                       return_value=MagicMock() if sent else None), \
+                 patch(f"{_RA}.simulate_typing"), \
+                 patch(f"{_RA}.time.sleep"), \
+                 patch(f"{_RA}.insert_new_log"), \
+                 patch(f"{_RA}.quit_gracefully"), \
+                 patch(f"{_RA}.record_action") as recorded:
+                result = ra.send_dm_now(1, "https://x/in/jane", "hi")
+            assert result is sent
+            if sent:
+                recorded.assert_called_once_with(1, ACTION_DM)
+            else:
+                recorded.assert_not_called()

--- a/tests/unit/app/test_human_pacing_integration.py
+++ b/tests/unit/app/test_human_pacing_integration.py
@@ -30,9 +30,28 @@ class TestBeatDispatchJitter:
              patch(f"{_RS}.has_linkedin_session", return_value=True), \
              patch(f"{_RS}._stagger_due", return_value=True), \
              patch(f"{_RS}._skip_if_throttled", return_value=False), \
-             patch(f"{_RS}.automate_commenting") as ac:
+             patch(f"{_RS}.dispatch_golden_hour_engagement") as shim:
             auto_daily_engagement()
-        assert 30 * 60 <= ac.apply_async.call_args[1]["countdown"] <= 90 * 60
+        assert 30 * 60 <= shim.apply_async.call_args[1]["countdown"] <= 90 * 60
+
+    def test_the_jitter_never_rides_the_queueonce_commenting_task_itself(self, pacing_on):
+        """celery-once locks on apply_async and (unlock_before_run) only releases when the task
+        RUNS. A 30–90 min countdown on automate_commenting would hold that user's key for the whole
+        delay and silently swallow the pre-post warm-up dispatch, which shares it."""
+        from cqc_lem.app.run_scheduler import auto_daily_engagement, dispatch_golden_hour_engagement
+        with patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
+             patch(f"{_RS}.has_linkedin_session", return_value=True), \
+             patch(f"{_RS}._stagger_due", return_value=True), \
+             patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.automate_commenting") as ac, \
+             patch(f"{_RS}.dispatch_golden_hour_engagement") as shim:
+            auto_daily_engagement()
+        ac.apply_async.assert_not_called()
+        # ...and the shim queues the real run with no countdown, so the lock is taken only then.
+        with patch(f"{_RS}.automate_commenting") as ac:
+            dispatch_golden_hour_engagement(user_id=1)
+        assert "countdown" not in ac.apply_async.call_args[1]
+        assert ac.apply_async.call_args[1]["kwargs"]["user_id"] == 1
 
     def test_appreciation_dms_are_dispatched_with_a_jitter_countdown(self, pacing_on):
         from cqc_lem.app.run_scheduler import auto_appreciate_dms
@@ -63,9 +82,9 @@ class TestBeatDispatchJitter:
              patch(f"{_RS}.has_linkedin_session", return_value=True), \
              patch(f"{_RS}._stagger_due", return_value=True), \
              patch(f"{_RS}._skip_if_throttled", return_value=False), \
-             patch(f"{_RS}.automate_commenting") as ac:
+             patch(f"{_RS}.dispatch_golden_hour_engagement") as shim:
             auto_daily_engagement()
-        assert ac.apply_async.call_args[1]["countdown"] == 0
+        assert shim.apply_async.call_args[1]["countdown"] == 0
 
 
 class TestGoldenHourSweepJitter:
@@ -150,6 +169,27 @@ class TestPacedBudgetsAtTheLanes:
              patch(f"{_RS}.send_connection_request") as send:
             auto_check_connection_requests()
         assert 30 * 60 <= send.apply_async.call_args[1]["countdown"] <= 90 * 60
+
+    def test_invite_jitter_can_never_outlast_the_orphan_recovery_gap(self, pacing_on, monkeypatch):
+        """A request is marked 'sending' at dispatch and re-queued once it has sat there for
+        _CONNECTION_ORPHAN_LOOKBACK_HOURS. A jitter longer than that gap would have the reaper send
+        a second invite to the same person while the first is still pending."""
+        from cqc_lem.app import run_scheduler as rs
+        monkeypatch.setenv("PACING_JITTER_MIN_MINUTES", "600")
+        monkeypatch.setenv("PACING_JITTER_MAX_MINUTES", "900")
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_connection_requests", return_value=[(11, 7)]), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
+             patch(f"{_RS}.get_engagement_preferences", return_value={"max_invites_per_day": 10}), \
+             patch(f"{_RS}.count_invites_sent_today", return_value=0), \
+             patch(f"{_RS}.update_connection_request_status"), \
+             patch(f"{_RS}.get_orphaned_connection_requests", return_value=[]) as orphans, \
+             patch(f"{_RS}.send_connection_request") as send:
+            rs.auto_check_connection_requests()
+        countdown = send.apply_async.call_args[1]["countdown"]
+        assert countdown == rs._MAX_INVITE_DISPATCH_DELAY_SECONDS
+        assert countdown < rs._CONNECTION_ORPHAN_LOOKBACK_HOURS * 3600
+        assert orphans.call_args[1]["lookback_hours"] == rs._CONNECTION_ORPHAN_LOOKBACK_HOURS
 
 
 class TestGovernorAccounting:

--- a/tests/unit/utilities/ai/test_comment_contract.py
+++ b/tests/unit/utilities/ai/test_comment_contract.py
@@ -336,8 +336,7 @@ class TestEngageCardWiring:
              patch(f"cqc_lem.app.run_automation.mark_post_reacted"), \
              patch(f"cqc_lem.app.run_automation.insert_new_log"), \
              patch(f"cqc_lem.app.run_automation._author_is_me", return_value=False), \
-             patch(f"cqc_lem.app.run_automation.simulate_reading_time", return_value=0), \
-             patch(f"cqc_lem.app.run_automation.simulate_thinking_time", return_value=0), \
+             patch(f"cqc_lem.app.run_automation.pace_read", return_value=0.0), \
              patch(f"cqc_lem.app.run_automation.time.sleep"):
             ok = ra._engage_card(MagicMock(), MagicMock(), MagicMock(), 1, MagicMock(),
                                  "feedurn://x", _POST, "Jane", {}, "synthesis", [], recent)
@@ -372,8 +371,7 @@ class TestPermalinkCommentPathSkips:
              patch(f"cqc_lem.app.run_automation.get_engagement_preferences", return_value={}), \
              patch(f"cqc_lem.app.run_automation.get_recent_comment_texts",
                    return_value=["an older comment"]) as history, \
-             patch(f"cqc_lem.app.run_automation.simulate_reading_time", return_value=0), \
-             patch(f"cqc_lem.app.run_automation.simulate_thinking_time", return_value=0), \
+             patch(f"cqc_lem.app.run_automation.pace_read", return_value=0.0), \
              patch(f"cqc_lem.app.run_automation.time.sleep"), \
              patch(f"cqc_lem.app.run_automation.generate_ai_response", return_value=None) as gen, \
              patch.object(ra.comment_on_post, "apply_async") as queued:

--- a/tests/unit/utilities/test_human_pacing.py
+++ b/tests/unit/utilities/test_human_pacing.py
@@ -1,0 +1,343 @@
+"""Unit tests for the human-pacing engine (issue #626).
+
+Everything here is seeded or env-pinned: a pacing value that can't be reproduced is a pacing value
+nobody can debug when LinkedIn throttles the account.
+"""
+
+import random
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_HP = "cqc_lem.utilities.human_pacing"
+
+_FRIDAY = date(2026, 7, 24)
+_SATURDAY = date(2026, 7, 25)
+_SUNDAY = date(2026, 7, 26)
+
+
+class FakeRedis:
+    """Just enough Redis for the budget key + the governor hash."""
+
+    def __init__(self):
+        self.strings = {}
+        self.hashes = {}
+        self.expires = []
+
+    def get(self, key):
+        value = self.strings.get(key)
+        return None if value is None else str(value).encode()
+
+    def set(self, key, value, ex=None):
+        self.strings[key] = value
+        if ex is not None:
+            self.expires.append((key, ex))
+        return True
+
+    def hincrby(self, key, field, amount):
+        bucket = self.hashes.setdefault(key, {})
+        bucket[field] = bucket.get(field, 0) + amount
+        return bucket[field]
+
+    def hget(self, key, field):
+        value = self.hashes.get(key, {}).get(field)
+        return None if value is None else str(value).encode()
+
+    def expire(self, key, ttl):
+        self.expires.append((key, ttl))
+        return True
+
+
+@pytest.fixture(autouse=True)
+def _pacing_on(monkeypatch):
+    """The suite defaults pacing OFF (tests/conftest.py); this module is what tests it ON."""
+    monkeypatch.setenv("HUMAN_PACING_ENABLED", "true")
+    monkeypatch.setenv("PACING_SEED", "issue-626")
+
+
+@pytest.fixture
+def fake_redis():
+    client = FakeRedis()
+    with patch(f"{_HP}.shared_redis_client", return_value=client):
+        yield client
+
+
+@pytest.fixture
+def no_redis():
+    with patch(f"{_HP}.shared_redis_client", return_value=None):
+        yield
+
+
+# --- 1. read-time delay ------------------------------------------------------------------------
+
+class TestReadDelay:
+    def test_even_a_one_line_post_costs_the_floor(self):
+        from cqc_lem.utilities.human_pacing import read_delay_seconds
+        # The whole point: commenting three seconds after a post rendered is the loudest bot tell.
+        assert read_delay_seconds("Hi.", rng=random.Random(1)) >= 45
+
+    def test_delay_scales_with_post_length(self):
+        from cqc_lem.utilities.human_pacing import read_delay_seconds
+        rng = random.Random(7)
+        short = read_delay_seconds(" ".join(["word"] * 60), rng=rng)
+        long_ = read_delay_seconds(" ".join(["word"] * 600), rng=random.Random(7))
+        assert long_ > short
+
+    def test_delay_is_capped_so_a_wall_of_text_cannot_park_a_worker(self):
+        from cqc_lem.utilities.human_pacing import read_delay_seconds, MAX_INLINE_SLEEP_SECONDS
+        delay = read_delay_seconds(" ".join(["word"] * 50_000), rng=random.Random(3))
+        assert delay <= 240
+        assert delay < MAX_INLINE_SLEEP_SECONDS  # acceptance: no worker blocks >5 min sleeping
+
+    def test_a_misconfigured_ceiling_still_cannot_exceed_the_inline_sleep_budget(self, monkeypatch):
+        from cqc_lem.utilities.human_pacing import read_delay_seconds, MAX_INLINE_SLEEP_SECONDS
+        monkeypatch.setenv("PACING_READ_MAX_SECONDS", "99999")
+        delay = read_delay_seconds(" ".join(["word"] * 50_000), rng=random.Random(3))
+        assert delay <= MAX_INLINE_SLEEP_SECONDS
+
+    def test_seeded_rng_reproduces_the_same_delay(self):
+        from cqc_lem.utilities.human_pacing import read_delay_seconds
+        post = " ".join(["word"] * 200)
+        assert read_delay_seconds(post, rng=random.Random(42)) == \
+               read_delay_seconds(post, rng=random.Random(42))
+
+    def test_browse_time_varies_between_runs(self):
+        from cqc_lem.utilities.human_pacing import read_delay_seconds
+        post = " ".join(["word"] * 200)
+        rng = random.Random(11)
+        assert len({read_delay_seconds(post, rng=rng) for _ in range(20)}) > 1
+
+    def test_disabled_adds_nothing(self, monkeypatch):
+        from cqc_lem.utilities.human_pacing import read_delay_seconds
+        monkeypatch.setenv("HUMAN_PACING_ENABLED", "false")
+        assert read_delay_seconds("a post", rng=random.Random(1)) == 0.0
+
+    def test_pace_read_sleeps_for_the_computed_delay(self):
+        from cqc_lem.utilities.human_pacing import pace_read
+        with patch(f"{_HP}.time.sleep") as slept:
+            used = pace_read("a short post")
+        assert used >= 45
+        slept.assert_called_once()
+        assert slept.call_args[0][0] == used
+
+    def test_pace_read_never_sleeps_when_disabled(self, monkeypatch):
+        from cqc_lem.utilities.human_pacing import pace_read
+        monkeypatch.setenv("HUMAN_PACING_ENABLED", "false")
+        with patch(f"{_HP}.time.sleep") as slept:
+            assert pace_read("a short post") == 0.0
+        slept.assert_not_called()
+
+
+# --- 2. schedule jitter ------------------------------------------------------------------------
+
+class TestDispatchJitter:
+    def test_standard_jitter_lands_in_the_configured_band(self):
+        from cqc_lem.utilities.human_pacing import dispatch_jitter_seconds
+        rng = random.Random(5)
+        values = [dispatch_jitter_seconds(rng=rng) for _ in range(200)]
+        assert all(30 * 60 <= v <= 90 * 60 for v in values)
+        assert len(set(values)) > 50  # a constant offset is not jitter
+
+    def test_responsive_jitter_keeps_own_post_replies_fast(self):
+        from cqc_lem.utilities.human_pacing import dispatch_jitter_seconds, PACE_RESPONSIVE
+        rng = random.Random(5)
+        values = [dispatch_jitter_seconds(PACE_RESPONSIVE, rng=rng) for _ in range(200)]
+        # G7 exemption: replying to comments on YOUR OWN post is human, so no tens-of-minutes delay.
+        assert all(0 <= v <= 180 for v in values)
+        assert len(set(values)) > 20
+
+    def test_band_is_env_tunable(self, monkeypatch):
+        from cqc_lem.utilities.human_pacing import dispatch_jitter_seconds
+        monkeypatch.setenv("PACING_JITTER_MIN_MINUTES", "5")
+        monkeypatch.setenv("PACING_JITTER_MAX_MINUTES", "10")
+        rng = random.Random(2)
+        assert all(300 <= dispatch_jitter_seconds(rng=rng) <= 600 for _ in range(50))
+
+    def test_inverted_band_does_not_produce_a_negative_countdown(self, monkeypatch):
+        from cqc_lem.utilities.human_pacing import dispatch_jitter_seconds
+        monkeypatch.setenv("PACING_JITTER_MIN_MINUTES", "90")
+        monkeypatch.setenv("PACING_JITTER_MAX_MINUTES", "30")
+        assert dispatch_jitter_seconds(rng=random.Random(1)) == 90 * 60
+
+    def test_disabled_is_no_countdown(self, monkeypatch):
+        from cqc_lem.utilities.human_pacing import dispatch_jitter_seconds
+        monkeypatch.setenv("HUMAN_PACING_ENABLED", "false")
+        assert dispatch_jitter_seconds() == 0
+
+
+# --- 3. variable daily volume ------------------------------------------------------------------
+
+class TestDailyBudget:
+    def test_budget_is_a_draw_inside_the_configured_ratio_band(self, monkeypatch, no_redis):
+        from cqc_lem.utilities.human_pacing import daily_budget, ACTION_COMMENT
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        budgets = [daily_budget(uid, ACTION_COMMENT, 20, _FRIDAY) for uid in range(1, 60)]
+        assert all(8 <= b <= 20 for b in budgets)          # 40%-100% of a cap of 20
+        assert len(set(budgets)) > 3                       # not the same number for everyone
+
+    def test_the_same_day_always_re_derives_the_same_budget(self, monkeypatch, no_redis):
+        """Acceptance: a retry (or a second worker, or a Redis outage) must not re-roll the day's
+        budget into a fresh, possibly larger one."""
+        from cqc_lem.utilities.human_pacing import daily_budget, ACTION_COMMENT
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        first = daily_budget(3, ACTION_COMMENT, 20, _FRIDAY)
+        assert all(daily_budget(3, ACTION_COMMENT, 20, _FRIDAY) == first for _ in range(5))
+
+    def test_different_days_draw_different_budgets(self, monkeypatch, no_redis):
+        from cqc_lem.utilities.human_pacing import daily_budget, ACTION_COMMENT
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        days = [date(2026, 7, d) for d in range(1, 25)]
+        assert len({daily_budget(3, ACTION_COMMENT, 20, d) for d in days}) > 3
+
+    def test_the_persisted_budget_survives_a_mid_day_cap_edit(self, fake_redis, monkeypatch):
+        from cqc_lem.utilities.human_pacing import daily_budget, ACTION_COMMENT
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        first = daily_budget(3, ACTION_COMMENT, 20, _FRIDAY)
+        assert daily_budget(3, ACTION_COMMENT, 200, _FRIDAY) == first  # read back, not re-drawn
+        assert any(ttl > 24 * 60 * 60 for _, ttl in fake_redis.expires)
+
+    def test_a_corrupt_stored_budget_is_re_derived(self, fake_redis, monkeypatch):
+        from cqc_lem.utilities.human_pacing import daily_budget, ACTION_COMMENT
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        key = f"pacing:budget:{ACTION_COMMENT}:3:{_FRIDAY.isoformat()}"
+        fake_redis.strings[key] = "not-a-number"
+        assert daily_budget(3, ACTION_COMMENT, 20, _FRIDAY) > 0
+
+    @pytest.mark.parametrize("weekend_day", [_SATURDAY, _SUNDAY])
+    def test_weekends_are_quieter_than_weekdays(self, monkeypatch, no_redis, weekend_day):
+        from cqc_lem.utilities.human_pacing import daily_budget, ACTION_COMMENT
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        # Pin the ratio draw so only the weekend factor moves.
+        monkeypatch.setenv("PACING_BUDGET_MIN_RATIO", "1")
+        monkeypatch.setenv("PACING_BUDGET_MAX_RATIO", "1")
+        assert daily_budget(3, ACTION_COMMENT, 20, _FRIDAY) == 20
+        assert daily_budget(3, ACTION_COMMENT, 20, weekend_day) == 11  # 20 * 0.55
+
+    def test_a_rest_day_spends_nothing(self, monkeypatch, no_redis):
+        from cqc_lem.utilities.human_pacing import daily_budget, is_rest_day, ACTION_COMMENT
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "1")
+        assert is_rest_day(3, _FRIDAY) is True
+        assert daily_budget(3, ACTION_COMMENT, 20, _FRIDAY) == 0
+
+    def test_rest_days_are_occasional_not_common(self, monkeypatch, no_redis):
+        """The distribution has to actually land near the configured rate — a rest day that never
+        fires is no cover, and one that fires constantly silently stops the product."""
+        from cqc_lem.utilities.human_pacing import is_rest_day
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0.1")
+        rests = sum(1 for uid in range(2000) if is_rest_day(uid, _FRIDAY))
+        assert 0.07 <= rests / 2000 <= 0.13
+
+    def test_a_rest_day_is_account_wide_not_per_lane(self, monkeypatch, no_redis):
+        from cqc_lem.utilities.human_pacing import daily_budget, ENGAGEMENT_ACTIONS
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "1")
+        assert all(daily_budget(3, a, 20, _FRIDAY) == 0 for a in ENGAGEMENT_ACTIONS)
+
+    def test_an_enabled_lane_is_never_silently_zeroed(self, monkeypatch, no_redis):
+        """Only a rest day may produce 0 — a tiny cap must still allow one action."""
+        from cqc_lem.utilities.human_pacing import daily_budget, ACTION_DM
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        assert all(daily_budget(uid, ACTION_DM, 1, _FRIDAY) == 1 for uid in range(1, 40))
+
+    def test_a_zero_cap_stays_zero(self, no_redis):
+        from cqc_lem.utilities.human_pacing import daily_budget, ACTION_INVITE
+        assert daily_budget(3, ACTION_INVITE, 0, _FRIDAY) == 0
+
+    def test_disabled_returns_the_raw_cap(self, monkeypatch, no_redis):
+        from cqc_lem.utilities.human_pacing import daily_budget, ACTION_COMMENT
+        monkeypatch.setenv("HUMAN_PACING_ENABLED", "false")
+        assert daily_budget(3, ACTION_COMMENT, 20, _SATURDAY) == 20
+
+
+# --- the account-level governor ----------------------------------------------------------------
+
+class TestGovernor:
+    def _caps(self):
+        from cqc_lem.utilities.human_pacing import engagement_caps_from_prefs
+        return engagement_caps_from_prefs({"max_comments_per_day": 20, "max_dms_per_day": 20,
+                                           "max_invites_per_day": 10})
+
+    def test_caps_are_read_off_engagement_preferences(self):
+        from cqc_lem.utilities.human_pacing import (engagement_caps_from_prefs, ACTION_COMMENT,
+                                                    ACTION_DM, ACTION_INVITE)
+        caps = engagement_caps_from_prefs({"max_comments_per_day": 20, "max_dms_per_day": 5,
+                                           "max_invites_per_day": None})
+        # No reply entry: replies share the comment cap, so counting them would double it.
+        assert caps == {ACTION_COMMENT: 20, ACTION_DM: 5, ACTION_INVITE: 0}
+
+    def test_garbage_caps_degrade_to_zero_rather_than_raising(self):
+        from cqc_lem.utilities.human_pacing import engagement_caps_from_prefs, ACTION_COMMENT
+        assert engagement_caps_from_prefs({"max_comments_per_day": "lots"})[ACTION_COMMENT] == 0
+
+    def test_actions_are_counted_per_lane_and_in_total(self, fake_redis):
+        from cqc_lem.utilities.human_pacing import (record_action, actions_used_today,
+                                                    ACTION_COMMENT, ACTION_DM)
+        record_action(1, ACTION_COMMENT, 3)
+        record_action(1, ACTION_DM)
+        assert actions_used_today(1, ACTION_COMMENT) == 3
+        assert actions_used_today(1, ACTION_DM) == 1
+        assert actions_used_today(1) == 4
+
+    def test_replies_are_tracked_but_do_not_spend_the_outbound_envelope(self, fake_redis):
+        """Going quiet on people who commented on the user's OWN post to protect a commenting
+        budget would be worse than the cadence risk — so replies count in their own field only."""
+        from cqc_lem.utilities.human_pacing import (record_action, actions_used_today,
+                                                    ACTION_REPLY, ENVELOPE_ACTIONS)
+        assert ACTION_REPLY not in ENVELOPE_ACTIONS
+        record_action(1, ACTION_REPLY, 12)
+        assert actions_used_today(1, ACTION_REPLY) == 12
+        assert actions_used_today(1) == 0            # the outbound envelope is untouched
+
+    def test_recording_nothing_is_a_no_op(self, fake_redis):
+        from cqc_lem.utilities.human_pacing import record_action, ACTION_COMMENT
+        record_action(1, ACTION_COMMENT, 0)
+        assert fake_redis.hashes == {}
+
+    def test_the_envelope_is_the_sum_of_every_lanes_budget(self, monkeypatch, no_redis):
+        from cqc_lem.utilities.human_pacing import account_envelope, daily_budget
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        caps = self._caps()
+        assert account_envelope(1, caps, _FRIDAY) == \
+               sum(daily_budget(1, a, c, _FRIDAY) for a, c in caps.items())
+
+    def test_remaining_is_the_lane_budget_minus_what_the_db_says_was_spent(self, monkeypatch, no_redis):
+        from cqc_lem.utilities.human_pacing import remaining_actions, daily_budget, ACTION_COMMENT
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        budget = daily_budget(1, ACTION_COMMENT, 20, _FRIDAY)
+        assert remaining_actions(1, ACTION_COMMENT, 20, 2, day=_FRIDAY) == budget - 2
+        assert remaining_actions(1, ACTION_COMMENT, 20, budget + 5, day=_FRIDAY) == 0
+
+    def test_the_combined_envelope_stops_a_lane_that_still_has_its_own_budget(self, fake_redis,
+                                                                             monkeypatch):
+        """The point of an ACCOUNT-level governor: commenting, DMs and invites each check their own
+        cap, so without a shared envelope the day's combined traffic is the sum of all three."""
+        from cqc_lem.utilities.human_pacing import (remaining_actions, account_envelope,
+                                                    record_action, ACTION_COMMENT, ACTION_DM)
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        caps = self._caps()
+        record_action(1, ACTION_DM, account_envelope(1, caps))   # other lanes ate the whole envelope
+        assert remaining_actions(1, ACTION_COMMENT, 20, 0, caps=caps) == 0
+        # ...and without the caps argument the call still degrades to the per-lane budget.
+        assert remaining_actions(1, ACTION_COMMENT, 20, 0) > 0
+
+    def test_without_redis_the_governor_fails_open(self, no_redis, monkeypatch):
+        from cqc_lem.utilities.human_pacing import remaining_actions, daily_budget, ACTION_COMMENT
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        assert remaining_actions(1, ACTION_COMMENT, 20, 0, caps=self._caps()) == \
+               daily_budget(1, ACTION_COMMENT, 20)
+
+    def test_a_redis_error_never_propagates(self, monkeypatch):
+        from cqc_lem.utilities.human_pacing import record_action, actions_used_today, ACTION_COMMENT
+
+        class Broken:
+            def __getattr__(self, _name):
+                def boom(*a, **k):
+                    raise RuntimeError("redis down")
+                return boom
+
+        with patch(f"{_HP}.shared_redis_client", return_value=Broken()), \
+             patch(f"{_HP}.log_warning"):
+            record_action(1, ACTION_COMMENT)
+            assert actions_used_today(1) == 0

--- a/tests/unit/utilities/test_human_pacing.py
+++ b/tests/unit/utilities/test_human_pacing.py
@@ -199,6 +199,17 @@ class TestDailyBudget:
         assert daily_budget(3, ACTION_COMMENT, 200, _FRIDAY) == first  # read back, not re-drawn
         assert any(ttl > 24 * 60 * 60 for _, ttl in fake_redis.expires)
 
+    def test_lowering_the_cap_mid_day_takes_effect_immediately(self, fake_redis, monkeypatch):
+        """Stability must never make us MORE aggressive than the user's own setting: someone who
+        drops their cap because they're worried about the account has to be obeyed now, not
+        tomorrow."""
+        from cqc_lem.utilities.human_pacing import daily_budget, ACTION_COMMENT
+        monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
+        monkeypatch.setenv("PACING_BUDGET_MIN_RATIO", "1")
+        monkeypatch.setenv("PACING_BUDGET_MAX_RATIO", "1")
+        assert daily_budget(3, ACTION_COMMENT, 20, _FRIDAY) == 20   # persists 20 for the day
+        assert daily_budget(3, ACTION_COMMENT, 3, _FRIDAY) == 3     # ...clamped to the new cap
+
     def test_a_corrupt_stored_budget_is_re_derived(self, fake_redis, monkeypatch):
         from cqc_lem.utilities.human_pacing import daily_budget, ACTION_COMMENT
         monkeypatch.setenv("PACING_REST_DAY_CHANCE", "0")
@@ -321,6 +332,16 @@ class TestGovernor:
         assert remaining_actions(1, ACTION_COMMENT, 20, 0, caps=caps) == 0
         # ...and without the caps argument the call still degrades to the per-lane budget.
         assert remaining_actions(1, ACTION_COMMENT, 20, 0) > 0
+
+    def test_disabling_pacing_removes_the_envelope_too(self, fake_redis, monkeypatch):
+        """HUMAN_PACING_ENABLED=false has to restore the PRE-#626 behaviour exactly. Pre-#626 each
+        lane spent its own cap and there was no shared pool, so a busy DM day must not be able to
+        shut commenting down through an envelope the switch is supposed to have turned off."""
+        from cqc_lem.utilities.human_pacing import (remaining_actions, record_action,
+                                                    ACTION_COMMENT, ACTION_DM)
+        record_action(1, ACTION_DM, 500)  # far past any envelope
+        monkeypatch.setenv("HUMAN_PACING_ENABLED", "false")
+        assert remaining_actions(1, ACTION_COMMENT, 20, 5, caps=self._caps()) == 15
 
     def test_without_redis_the_governor_fails_open(self, no_redis, monkeypatch):
         from cqc_lem.utilities.human_pacing import remaining_actions, daily_budget, ACTION_COMMENT


### PR DESCRIPTION
## What & why

LinkedIn's comment-bot detection keys on **cadence**, not content: engaging seconds after a post appears, machine-exact daily start times, identical intervals, and a flat daily volume. LEM commented immediately on selection and ran on fixed beat schedules with a constant per-day cap — a textbook machine signature.

`src/cqc_lem/utilities/human_pacing.py` is now the ONE place cadence is decided, consumed by commenting, replies, DMs and connection invites.

### 1. Read-time-realistic delay
`read_delay_seconds` / `pace_read` — reading time at `PACING_READ_WPM` plus a browse allowance, clamped into `[PACING_READ_MIN_SECONDS=45, PACING_READ_MAX_SECONDS=240]`. The **floor** is the point: a one-line post still costs 45s. The ceiling sits below `MAX_INLINE_SLEEP_SECONDS=300`, so **no worker ever parks >5 min sleeping**. Replaces the old `simulate_reading_time/2 + simulate_thinking_time` pair (both deleted), which could clear a short post in ~3s.

Wired into `_engage_card` (feed + roster) and `generate_and_post_comment` (permalink path), so no lane is the fast one that gives the account away.

### 2. Schedule jitter
`dispatch_jitter_seconds` returns a random forward countdown — `apply_async(countdown=…)`, i.e. eta scheduling, never an in-process sleep. Applied to `auto_daily_engagement`, `auto_appreciate_dms`, `dispatch_comment_followups` and `auto_check_connection_requests` (30–90 min).

**G7 exemption honoured:** replying to comments on the user's OWN post is human, so `dispatch_scheduled_reply_sweeps` and the golden-hour sweeps use `PACE_RESPONSIVE` — jittered by *seconds*, not delayed by an hour. Golden-hour jitter is additively capped at half a step, so a misconfigured value can never reorder or collapse two sweeps.

### 3. Variable daily volumes
`daily_budget` turns each per-day cap into a random draw (40–100% by default) with weekend asymmetry (`PACING_WEEKEND_RATIO=0.55`) and occasional **account-wide rest days** (`PACING_REST_DAY_CHANCE=0.08`). The draw is **seeded on (user, action, date)** and persisted in Redis for the day — so a retry, a second worker, a mid-day cap edit, or a Redis outage all re-derive the same number instead of re-rolling a fresh (possibly larger) budget. A non-zero cap never silently becomes 0; only a rest day does.

### 4. Account-level governor
`remaining_actions` takes the smaller of the lane's remaining paced budget and the remaining **account envelope** (the sum of every capped lane's budget), fed by `record_action` at every site where an action actually lands: comments (`_engage_card`), DMs (`send_dm_now`), invites (`invite_to_connect_now`). Replaces the raw-cap checks in `comment_on_feed_inline`, `send_scheduled_dm`, `_fire_funnel_stage` and `auto_check_connection_requests`, so the funnel can't quietly push the day past the envelope.

**Replies are tracked but deliberately stay OUTSIDE the envelope** (`ENVELOPE_ACTIONS`): going quiet on people who commented on the user's own post in order to protect a commenting budget is worse for the account than the cadence risk it would avoid. They are still jittered.

### Interplay & safety
- **Fails open everywhere.** No Redis, or `HUMAN_PACING_ENABLED=false`, restores the exact pre-#626 behaviour (full cap, no jitter, no added delay).
- The 429 breaker / kill-switch in `rate_limit.py` is untouched and still the harder gate — pacing only ever makes us slower, never more aggressive.
- No DB migration; all state is Redis + env.

## Testing notes

- `tests/unit/utilities/test_human_pacing.py` (36 tests) — the engine, all seeded or env-pinned: delay bounds + the inline-sleep ceiling (including a misconfigured `PACING_READ_MAX_SECONDS`), jitter bands + an inverted band, budget range/stability/persistence/corrupt-value re-derivation, weekend asymmetry, rest-day **distribution** (~10% over 2000 users), governor accounting, envelope enforcement, Redis-down fail-open, and a Redis that raises on every call.
- `tests/unit/app/test_human_pacing_integration.py` (15 tests) — every wiring seam: each dispatcher's countdown band, the responsive profile on own-post replies, golden-hour sweeps jittered-but-never-reordered, paced budgets at the commenting/DM/invite lanes, and `record_action` firing on success only (not on a gate-skipped comment, a failed DM, or a failed invite).
- The suite defaults `HUMAN_PACING_ENABLED=false` via an autouse fixture (same pattern as `HUMANIZE_ENABLED`) — otherwise every commenting test would sleep 45s+ and the day's budget would depend on the calendar date the CI job happens to run on. The pacing tests opt back in explicitly.
- Full unit suite: **6185 passed**.

Closes #626

🤖 Generated with [Claude Code](https://claude.com/claude-code)
