### PR TITLE
feat(ui): instrument the SPA with PostHog — identify, autocapture, product events (closes #646)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -450,6 +450,13 @@ POSTHOG_PERSONAL_API_KEY=
 # PostHog project the dashboards live in, and the app host used to build their links.
 POSTHOG_PROJECT_ID=475262
 POSTHOG_APP_HOST=https://us.posthog.com
+# --- PostHog in the SPA (issue #646) ---
+# Read by Vite at BUILD time and baked into the bundle, so they must be set for `npm run build`
+# (docker build-arg / CI env), not in the running container. Leave VITE_POSTHOG_KEY empty and the
+# SPA never even fetches the posthog-js chunk — browser analytics is fully off.
+# This is the PROJECT key (phc_…), which is public by design — never the personal API key.
+VITE_POSTHOG_KEY=
+VITE_POSTHOG_HOST=https://us.i.posthog.com
 
 # --- Unit economics / margin report (docs/cost-performance-margin-plan.md §C.1) ---
 # Monthly price per subscription tier, used to compute MRR for contribution margin. Defaults match

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -146,6 +146,10 @@ CAPSOLVER_API_KEY=
 POSTHOG_API_KEY=CHANGE_ME
 POSTHOG_HOST=https://us.i.posthog.com
 POSTHOG_LOG_LEVEL=ERROR
+# Browser-side PostHog (issue #646). BUILD-time only — the SPA bundle bakes these in, so setting
+# them here does nothing; they are passed as docker build-args (CI: UI_POSTHOG_KEY secret).
+# VITE_POSTHOG_KEY=phc_...
+# VITE_POSTHOG_HOST=https://us.i.posthog.com
 
 # =============================================================================
 # Tunnel & Networking (Ngrok) — DISABLED in prod (Cloudflare Tunnel is used)

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -54,6 +54,8 @@ jobs:
           build-args: |
             INSTALL_DEV_DEPS=false
             VITE_API_TOKEN=${{ secrets.UI_API_TOKEN }}
+            VITE_POSTHOG_KEY=${{ secrets.UI_POSTHOG_KEY }}
+            VITE_POSTHOG_HOST=${{ vars.UI_POSTHOG_HOST }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/ui-build.yml
+++ b/.github/workflows/ui-build.yml
@@ -29,3 +29,5 @@ jobs:
         run: npm run build
         env:
           VITE_API_TOKEN: ${{ secrets.UI_API_TOKEN }}
+          VITE_POSTHOG_KEY: ${{ secrets.UI_POSTHOG_KEY }}
+          VITE_POSTHOG_HOST: ${{ vars.UI_POSTHOG_HOST }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,37 @@ from cqc_lem.utilities.observability import track_llm_call, track_task, track_ap
 
 PostHog receives LLM usage (model, tokens, latency, cost) and Celery task metrics for fine-tuning decisions.
 
+### Browser-side analytics (SPA, issue #646)
+
+The SPA has ONE PostHog surface — `ui/src/utils/analytics.ts`. Never call `posthog` directly from a
+component; import from there so the key, the privacy defaults and the distinct_id convention stay
+in one place.
+
+```ts
+import { EVENTS, capture, maskProps } from '../utils/analytics'
+
+capture(EVENTS.postApproved, { post_id, post_type, archetype })
+
+// Any editor holding the user's own content (DM, story, draft post):
+<textarea {...maskProps('w-full border rounded-lg px-3 py-2 text-sm')} />
+```
+
+- **distinct_id is `String(user_id)`** — identical to `observability.py`'s server-side convention,
+  so a user's browser and Celery/API events land on ONE PostHog person. `$identify` fires from
+  `AuthContext` off `GET /auth/session` (plan, plan_status, timezone; `created_at` as `$set_once`)
+  and `posthog.reset()` fires on logout. Never put credentials or LinkedIn data on the person.
+- **Env-gated at BUILD time.** `VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST` are baked into the bundle by
+  Vite (docker build-arg / CI secret `UI_POSTHOG_KEY`), not read from the running container. With no
+  key, `posthog-js` is never imported — it is a lazy chunk the browser never fetches — and every
+  `capture`/`identify` is a no-op.
+- **Autocapture is on**, with `mask_all_element_attributes` and pageviews owned by the router
+  (`capture_pageview: false` + a `usePageviews()` hook, so in-app navigation is counted). Web vitals
+  ride on `capture_performance`. Replay is off here — that's PH4.
+- `maskProps()` adds BOTH the `ph-no-capture` class (autocapture skips the element) and
+  `data-ph-mask` (replay's `maskTextSelector`). Use it on every new content editor.
+- New product events go in `EVENTS` — that vocabulary is what PostHog insights key off, so add to it
+  rather than passing a bare string.
+
 ## CI Gates
 
 Before merging any PR, all of the following must pass:

--- a/compose/local/Dockerfile
+++ b/compose/local/Dockerfile
@@ -33,6 +33,12 @@ WORKDIR /ui
 # Empty by default so dev images stay tokenless; CI passes the prod token.
 ARG VITE_API_TOKEN=""
 ENV VITE_API_TOKEN=${VITE_API_TOKEN}
+# Browser-side PostHog (issue #646). Empty key = the SPA ships with analytics fully disabled and
+# never fetches the posthog-js chunk.
+ARG VITE_POSTHOG_KEY=""
+ENV VITE_POSTHOG_KEY=${VITE_POSTHOG_KEY}
+ARG VITE_POSTHOG_HOST=""
+ENV VITE_POSTHOG_HOST=${VITE_POSTHOG_HOST}
 COPY ./src/cqc_lem/ui/package.json ./src/cqc_lem/ui/package-lock.json ./
 RUN npm ci
 COPY ./src/cqc_lem/ui ./

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -42,7 +42,8 @@ from cqc_lem.utilities.db import (
     max_catchup_touches_allowed,
     create_pin_for_email, verify_pin_for_email, delete_pin_for_email,
     create_session, get_session_user_id, delete_session,
-    add_user_by_email, get_user_email, get_user_token_info, store_linkedin_li_at,
+    add_user_by_email, get_user_email, get_user_analytics_profile, get_user_token_info,
+    store_linkedin_li_at,
     has_linkedin_session, get_user_password_pair_by_id,
     get_company_linked_in_url_for_user, update_company_linked_in_url_for_user,
     get_user_subscription_info, get_user_preferences, update_user_preferences,
@@ -1539,6 +1540,9 @@ def get_posts_for_email(
             "post_type": post["post_type"],
             "status": post["status"],
             "carousel_slides": _parse_slides(post.get("carousel_slides")),
+            # The SHAPE this draft was written to (V51 posts.archetype) — the review UI reports it
+            # on post_approved / post_rejected so approval rate can be broken down by archetype.
+            "archetype": post.get("archetype"),
             # Why a draft is being held, and what to do about it (issue #421).
             "authenticity_score": post.get("authenticity_score"),
             "gate_reason": parse_gate_findings(post.get("gate_reason")),
@@ -1779,7 +1783,18 @@ def auth_check_session(session_token: str) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
     email = get_user_email(user_id)
-    return ResponseModel(status_code=200, detail={"user_id": user_id, "email": email})
+    # Person facts the SPA sets on the PostHog person at $identify (issue #646). Plan/timezone/
+    # signup only — never credentials — and the session check is the one call every authenticated
+    # page already makes, so identify needs no extra round trip.
+    profile = get_user_analytics_profile(user_id)
+    return ResponseModel(status_code=200, detail={
+        "user_id": user_id,
+        "email": email,
+        "plan": profile.get("subscription_tier"),
+        "plan_status": profile.get("subscription_status"),
+        "timezone": profile.get("timezone"),
+        "created_at": _utc_iso(profile.get("created_at")),
+    })
 
 
 @router.get("/user/token_status")

--- a/src/cqc_lem/ui/package-lock.json
+++ b/src/cqc_lem/ui/package-lock.json
@@ -13,6 +13,7 @@
         "@types/jszip": "^3.4.1",
         "axios": "^1.18.0",
         "jszip": "^3.10.1",
+        "posthog-js": "^1.407.2",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
         "react-router-dom": "^7.18.1",
@@ -1161,6 +1162,28 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@posthog/browser-common": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@posthog/browser-common/-/browser-common-0.2.1.tgz",
+      "integrity": "sha512-FTVPsRw6GBKWvFwN26TNIQNNYPR9FsUj+B+CKhk/ht63IRzn4yYFtFOjcmW+bfXvNHuRADs6APbZ6Haz1kpoAw==",
+      "dependencies": {
+        "@posthog/core": "^1.45.1",
+        "@posthog/types": "^1.398.0"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.45.1.tgz",
+      "integrity": "sha512-tLtvzomavb2PPWdGYKsusyIzIeL2Px47v348Smibkay7sMy/83TyPk+Ptsp2NdeOgJsbuwSxWkR2+XA0aSCAaA==",
+      "dependencies": {
+        "@posthog/types": "^1.398.0"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.398.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.398.0.tgz",
+      "integrity": "sha512-sJMkl4k+u8yS/0fjHsKqE9xTdsAh30a2WvgChiptellnVoE0e8QJKFgqOMD2sk8FaEArPdeFklAhXvmENAt3Sg=="
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.1.5.tgz",
@@ -2248,6 +2271,12 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/scope-manager": {
       "version": "8.65.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
@@ -2701,6 +2730,16 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -2834,6 +2873,14 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3241,6 +3288,11 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.9.tgz",
+      "integrity": "sha512-zdxgIEddhfsyCaWpJ2SdXEP8ZMrKJ6+5jl4OupODcywU0IhRk6gdXuVGcPICyfx2H97hVK7xmJtRLPjkxAX8Vw=="
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -4357,6 +4409,39 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.407.2",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.407.2.tgz",
+      "integrity": "sha512-5deTvXopn+NJWEmCUw8Ix/ms3cv2+60WJ73Vgbvu2wSkZY/FIj2uqAgCnq7IewGpGC+tH7CAbPYFzH6hw8eW1w==",
+      "dependencies": {
+        "@posthog/browser-common": "^0.2.0",
+        "@posthog/core": "^1.45.1",
+        "@posthog/types": "^1.398.0",
+        "core-js": "^3.49.0",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.29.3",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.3.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.7",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.7.tgz",
+      "integrity": "sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      },
+      "peerDependencies": {
+        "preact-render-to-string": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "preact-render-to-string": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4407,6 +4492,11 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw=="
     },
     "node_modules/react": {
       "version": "19.2.8",
@@ -5522,6 +5612,11 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.3.0.tgz",
+      "integrity": "sha512-q6LWsLatGYZp5VGBIOvbTj6JBV2nOmC8KvWztXBmwJcfFAzhwKwbOxhUH306XY3CcaZDUlSmSuNPBsCn0bFu+g=="
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/src/cqc_lem/ui/package.json
+++ b/src/cqc_lem/ui/package.json
@@ -17,6 +17,7 @@
     "@types/jszip": "^3.4.1",
     "axios": "^1.18.0",
     "jszip": "^3.10.1",
+    "posthog-js": "^1.407.2",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
     "react-router-dom": "^7.18.1",

--- a/src/cqc_lem/ui/src/App.tsx
+++ b/src/cqc_lem/ui/src/App.tsx
@@ -1,4 +1,5 @@
-import { BrowserRouter, Routes, Route, Navigate, useSearchParams } from 'react-router-dom'
+import { useEffect } from 'react'
+import { BrowserRouter, Routes, Route, Navigate, useSearchParams, useLocation } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import Layout from './components/Layout'
@@ -9,6 +10,7 @@ import Account from './pages/Account'
 import Avatars from './pages/Avatars'
 import ContentStudio from './pages/ContentStudio'
 import Landing from './pages/Landing'
+import { capturePageview } from './utils/analytics'
 
 const queryClient = new QueryClient()
 
@@ -22,8 +24,16 @@ function LegacyReviewRedirect() {
   return <Navigate to={`/content?tab=${target}`} replace />
 }
 
+// posthog's own pageview listener only fires on a full page load, so a SPA route change would be
+// invisible. The search string is part of the key — /content?tab=dms is a different screen.
+function usePageviews() {
+  const { pathname, search } = useLocation()
+  useEffect(() => { capturePageview() }, [pathname, search])
+}
+
 function AppRoutes() {
   const { user, isLoginModalOpen } = useAuth()
+  usePageviews()
 
   return (
     <>

--- a/src/cqc_lem/ui/src/components/FeedbackWidget.tsx
+++ b/src/cqc_lem/ui/src/components/FeedbackWidget.tsx
@@ -3,6 +3,7 @@ import { useLocation } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 import { useAppInfo } from '../hooks/useAppInfo'
 import api from '../api/client'
+import { EVENTS, analyticsSessionId, capture } from '../utils/analytics'
 
 const TYPE_HINTS = [
   { value: 'bug', label: '🐞 Something is broken' },
@@ -14,17 +15,6 @@ const TYPE_HINTS = [
 
 // Base64 inflates a file by ~4/3, and the API caps the encoded data URL at 2,000,000 chars.
 const MAX_SCREENSHOT_BYTES = 1_400_000
-
-// PostHog is loaded (when configured) as a global script, not an npm dep — read the session id
-// defensively so the widget works with or without it.
-function posthogSessionId(): string | undefined {
-  const ph = (window as unknown as { posthog?: { get_session_id?: () => string } }).posthog
-  try {
-    return ph?.get_session_id?.()
-  } catch {
-    return undefined
-  }
-}
 
 function readAsDataUrl(file: File): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -94,7 +84,7 @@ export default function FeedbackWidget() {
           route: `${location.pathname}${location.search}`,
           user_id: user?.userId ?? null,
           app_version: appInfo?.version ?? null,
-          posthog_session_id: posthogSessionId() ?? null,
+          posthog_session_id: analyticsSessionId() ?? null,
           user_agent: navigator.userAgent,
           viewport: `${window.innerWidth}x${window.innerHeight}`,
         },
@@ -111,7 +101,7 @@ export default function FeedbackWidget() {
   if (!isOpen) {
     return (
       <button
-        onClick={() => setIsOpen(true)}
+        onClick={() => { setIsOpen(true); capture(EVENTS.feedbackOpened, { route: location.pathname }) }}
         className="fixed bottom-4 right-4 z-40 bg-blue-600 text-white text-xs font-semibold px-3.5 py-2 rounded-full shadow-lg hover:bg-blue-700 transition-colors"
         aria-label="Feedback / Report a bug"
       >

--- a/src/cqc_lem/ui/src/contexts/AuthContext.tsx
+++ b/src/cqc_lem/ui/src/contexts/AuthContext.tsx
@@ -1,10 +1,21 @@
-import { createContext, useContext, useState, useEffect } from 'react'
+import { createContext, useContext, useState, useEffect, useRef } from 'react'
 import type { ReactNode } from 'react'
 import api from '../api/client'
+import { identifyUser, resetAnalytics } from '../utils/analytics'
 
 interface AuthUser {
   email: string
   userId?: number
+}
+
+// GET /auth/session — identity plus the non-sensitive person facts PostHog is identified with.
+interface SessionDetail {
+  user_id: number
+  email: string
+  plan?: string | null
+  plan_status?: string | null
+  timezone?: string | null
+  created_at?: string | null
 }
 
 interface AuthContextValue {
@@ -27,6 +38,31 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [sessionToken, setSessionToken] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
+  // Identify once per user per page load — re-identifying on every session check would burn a
+  // $identify on each mount for no new information.
+  const identifiedUserId = useRef<number | null>(null)
+
+  function applySession(detail: SessionDetail, token: string) {
+    setSessionToken(token)
+    setUser({ email: detail.email, userId: detail.user_id })
+    if (detail.user_id && identifiedUserId.current !== detail.user_id) {
+      identifiedUserId.current = detail.user_id
+      identifyUser({
+        userId: detail.user_id,
+        email: detail.email,
+        plan: detail.plan,
+        planStatus: detail.plan_status,
+        timezone: detail.timezone,
+        createdAt: detail.created_at,
+      })
+    }
+  }
+
+  function loadSession(token: string): Promise<void> {
+    return api
+      .get(`/auth/session?session_token=${encodeURIComponent(token)}`)
+      .then((r) => applySession(r.data.detail as SessionDetail, token))
+  }
 
   useEffect(() => {
     const storedToken = localStorage.getItem(SESSION_KEY)
@@ -34,18 +70,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setIsLoading(false)
       return
     }
-    api
-      .get(`/auth/session?session_token=${encodeURIComponent(storedToken)}`)
-      .then((r) => {
-        const { email, user_id } = r.data.detail
-        setSessionToken(storedToken)
-        setUser({ email, userId: user_id })
-      })
+    loadSession(storedToken)
       .catch(() => {
         localStorage.removeItem(SESSION_KEY)
         localStorage.removeItem('lem_email')
       })
       .finally(() => setIsLoading(false))
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   function login(token: string, email: string) {
@@ -54,6 +85,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setSessionToken(token)
     setUser({ email })
     setIsLoginModalOpen(false)
+    // The verify response carries no user id, so read the session back: it resolves the id every
+    // authenticated feature already needs AND the person facts to identify with. A failure here
+    // leaves the optimistic (email-only) user in place rather than bouncing a valid login.
+    loadSession(token).catch(() => {})
   }
 
   async function logout() {
@@ -68,6 +103,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem('lem_sitemap_url')
     setSessionToken(null)
     setUser(null)
+    // Break the browser↔person link, or the next person to sign in on this machine inherits it.
+    identifiedUserId.current = null
+    resetAnalytics()
   }
 
   return (

--- a/src/cqc_lem/ui/src/main.tsx
+++ b/src/cqc_lem/ui/src/main.tsx
@@ -3,9 +3,13 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { captureAttribution } from './utils/attribution'
+import { initAnalytics } from './utils/analytics'
 
 // Before the router can rewrite the URL — the landing UTMs are only there on the first paint.
 captureAttribution()
+
+// No-op (and no posthog-js chunk fetched) when VITE_POSTHOG_KEY is unset.
+initAnalytics()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -17,6 +17,7 @@ import ComposePost from './content/ComposePost'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
 import { formatInTimezone, toZonedInputValue, zonedInputToUtcIso } from '../utils/datetime'
+import { EVENTS, capture, maskProps } from '../utils/analytics'
 
 // Consolidated content hub: compose posts, schedule DMs, manage newsletters, and review/edit
 // existing content — one page, four tabs, synced to ?tab= for deep-linking.
@@ -79,6 +80,8 @@ interface Post {
   status: string
   carousel_slides: string[] | null
   post_url?: string | null
+  // The SHAPE the draft was written to (V51 posts.archetype) — reported with the review decision.
+  archetype?: string | null
   // Quality-gate verdict (issue #421) — why a PENDING post is being held, and its A1 score.
   authenticity_score?: number | null
   gate_reason?: GateFinding[] | null
@@ -203,6 +206,21 @@ export default function ContentStudio() {
   const total = data?.detail?.total ?? 0
   const totalPages = Math.max(1, Math.ceil(total / pageSize))
 
+  // The review decision is the product moment autocapture can't name: a click on "Save Changes"
+  // says nothing about which way the draft went. Only a real STATUS TRANSITION counts — re-saving
+  // (or re-deleting) a post that already has that status is an edit, not a second decision.
+  const capturePostDecision = (postId: number, status: string, extra: Record<string, unknown> = {}) => {
+    if (status !== 'approved' && status !== 'rejected') return
+    const post = posts.find((p) => p.post_id === postId)
+    if (post?.status === status) return
+    capture(status === 'approved' ? EVENTS.postApproved : EVENTS.postRejected, {
+      post_id: postId,
+      post_type: post?.post_type ?? null,
+      archetype: post?.archetype ?? null,
+      ...extra,
+    })
+  }
+
   const updateMutation = useMutation({
     mutationFn: (post: Post) =>
       api.post(`/update_post/?post_id=${post.post_id}`, {
@@ -213,7 +231,9 @@ export default function ContentStudio() {
         email,
         status: post.status,
       }),
-    onSuccess: () => {
+    onSuccess: (_res, post) => {
+      // post_type is editable in this dialog, so report what was SAVED, not the stale list row.
+      capturePostDecision(post.post_id, post.status, { source: 'editor', post_type: post.post_type })
       qc.invalidateQueries({ queryKey: ['posts', email] })
       setEditingPost(null)
     },
@@ -252,7 +272,12 @@ export default function ContentStudio() {
   const bulkUpdateMutation = useMutation({
     mutationFn: (body: { post_ids: number[]; status?: string; scheduled_datetime?: string }) =>
       api.post('/posts/bulk_update/', body),
-    onSuccess: () => {
+    onSuccess: (_res, body) => {
+      // One event per post, not one per click — an approval rate broken down by archetype needs
+      // the same unit whether the user approved from the editor or from the bulk bar.
+      if (body.status) {
+        for (const id of body.post_ids) capturePostDecision(id, body.status, { source: 'bulk' })
+      }
       qc.invalidateQueries({ queryKey: ['posts', email] })
       setSelectedIds(new Set())
       setBulkDate('')
@@ -261,7 +286,9 @@ export default function ContentStudio() {
 
   const bulkDeleteMutation = useMutation({
     mutationFn: (post_ids: number[]) => api.delete('/posts/', { data: { post_ids } }),
-    onSuccess: () => {
+    onSuccess: (_res, post_ids) => {
+      // The delete endpoint is a soft delete (status=rejected) — the same decision, another door.
+      for (const id of post_ids) capturePostDecision(id, 'rejected', { source: 'bulk_delete' })
       qc.invalidateQueries({ queryKey: ['posts', email] })
       setSelectedIds(new Set())
     },
@@ -271,6 +298,7 @@ export default function ContentStudio() {
   const deleteMutation = useMutation({
     mutationFn: (post_id: number) => api.delete('/posts/', { data: { post_ids: [post_id] } }),
     onSuccess: (_res, post_id) => {
+      capturePostDecision(post_id, 'rejected', { source: 'delete' })
       qc.invalidateQueries({ queryKey: ['posts', email] })
       setConfirmDeletePost(null)
       setSelectedIds((prev) => { const n = new Set(prev); n.delete(post_id); return n })
@@ -323,7 +351,10 @@ export default function ContentStudio() {
       api.get(`/user_id/?email=${encodeURIComponent(email)}`).then((r) =>
         api.post(`/create_weekly_content/?user_id=${r.data.detail}`)
       ),
-    onSuccess: () => qc.invalidateQueries({ queryKey: ['content-generation-status', sessionToken] }),
+    onSuccess: () => {
+      capture(EVENTS.contentPlanGenerated, { source: 'content_studio' })
+      qc.invalidateQueries({ queryKey: ['content-generation-status', sessionToken] })
+    },
   })
 
   // A finished run expires server-side within the hour, so there's no staleness to reason about
@@ -861,7 +892,7 @@ export default function ContentStudio() {
                   rows={6}
                   value={editingPost.content}
                   onChange={(e) => setEditingPost({ ...editingPost, content: e.target.value })}
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                  {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none')}
                 />
 
                 <div>

--- a/src/cqc_lem/ui/src/pages/account/DmTemplatesCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/DmTemplatesCard.tsx
@@ -7,6 +7,7 @@ import type { DmTemplate } from './types'
 import { useRegisterSaveSection } from './SettingsSaveContext'
 import PlaceholderChips from './PlaceholderChips'
 import { FIELD_LIMITS } from './fieldLimits'
+import { EVENTS, capture, maskProps } from '../../utils/analytics'
 
 export default function DmTemplatesCard() {
   const { sessionToken } = useAuth()
@@ -58,6 +59,11 @@ export default function DmTemplatesCard() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['dm-templates'] })
       setSavedSig(JSON.stringify(dmTemplates))
+      capture(EVENTS.dmTemplateSaved, {
+        templates: dmTemplates.filter((t) => t.template_text.trim()).length,
+        // How many events have a follow-up sequence configured, not the message bodies.
+        followup_steps: dmTemplates.filter((t) => t.step > 0 && t.template_text.trim()).length,
+      })
       setDmMsg({ ok: true, text: 'DM templates saved.' })
       setTimeout(() => setDmMsg(null), 3000)
     },
@@ -112,7 +118,7 @@ export default function DmTemplatesCard() {
                 <textarea value={t.template_text} rows={2} maxLength={FIELD_LIMITS.dm_template}
                   onChange={(e) => updateTemplate(ev.key, t.step, { template_text: e.target.value })}
                   placeholder="Leave blank for the default message"
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+                  {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm')} />
               </div>
             ))}
             <button type="button" onClick={() => addFollowupStep(ev.key)}

--- a/src/cqc_lem/ui/src/pages/account/DmTemplatesCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/DmTemplatesCard.tsx
@@ -4,7 +4,7 @@ import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import { DM_EVENTS } from './types'
 import type { DmTemplate } from './types'
-import { useRegisterSaveSection } from './SettingsSaveContext'
+import { useRegisterSaveSection, sectionSaveCallbacks } from './SettingsSaveContext'
 import PlaceholderChips from './PlaceholderChips'
 import { FIELD_LIMITS } from './fieldLimits'
 import { EVENTS, capture, maskProps } from '../../utils/analytics'
@@ -129,7 +129,8 @@ export default function DmTemplatesCard() {
       {dmMsg && (
         <p className={`text-sm font-medium ${dmMsg.ok ? 'text-green-600' : 'text-red-600'}`}>{dmMsg.text}</p>
       )}
-      <button type="button" onClick={() => dmMutation.mutate()} disabled={dmMutation.isPending}
+      <button type="button" onClick={() => dmMutation.mutate(undefined, sectionSaveCallbacks('dm-templates'))}
+        disabled={dmMutation.isPending}
         className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
         {dmMutation.isPending ? 'Saving…' : 'Save DM Templates'}
       </button>

--- a/src/cqc_lem/ui/src/pages/account/EngagementRosterCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/EngagementRosterCard.tsx
@@ -4,7 +4,7 @@ import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import { TARGET_CATEGORIES } from './types'
 import type { EngagementTarget, EngagementTargetCategory } from './types'
-import { useRegisterSaveSection } from './SettingsSaveContext'
+import { useRegisterSaveSection, sectionSaveCallbacks } from './SettingsSaveContext'
 
 type RosterResponse = { targets: EngagementTarget[]; suggestions: EngagementTarget[] }
 
@@ -183,7 +183,8 @@ export default function EngagementRosterCard() {
       )}
 
       {msg && <p className={`text-sm font-medium ${msg.ok ? 'text-green-600' : 'text-red-600'}`}>{msg.text}</p>}
-      <button type="button" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}
+      <button type="button" onClick={() => saveMutation.mutate(undefined, sectionSaveCallbacks('engagement-roster'))}
+        disabled={saveMutation.isPending}
         className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
         {saveMutation.isPending ? 'Saving…' : 'Save Roster'}
       </button>

--- a/src/cqc_lem/ui/src/pages/account/GroupsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/GroupsCard.tsx
@@ -4,7 +4,7 @@ import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import Toggle from '../../components/Toggle'
 import type { UserGroup } from './types'
-import { useRegisterSaveSection } from './SettingsSaveContext'
+import { useRegisterSaveSection, sectionSaveCallbacks } from './SettingsSaveContext'
 
 export default function GroupsCard() {
   const { sessionToken } = useAuth()
@@ -71,7 +71,8 @@ export default function GroupsCard() {
         ))}
       </div>
       {groupsMsg && <p className={`text-sm font-medium ${groupsMsg.ok ? 'text-green-600' : 'text-red-600'}`}>{groupsMsg.text}</p>}
-      <button type="button" onClick={() => groupsMutation.mutate()} disabled={groupsMutation.isPending}
+      <button type="button" onClick={() => groupsMutation.mutate(undefined, sectionSaveCallbacks('groups'))}
+        disabled={groupsMutation.isPending}
         className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
         {groupsMutation.isPending ? 'Saving…' : 'Save Group Settings'}
       </button>

--- a/src/cqc_lem/ui/src/pages/account/LeadMagnetCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/LeadMagnetCard.tsx
@@ -4,9 +4,10 @@ import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import Toggle from '../../components/Toggle'
 import type { LeadMagnet } from './types'
-import { useRegisterSaveSection } from './SettingsSaveContext'
+import { useRegisterSaveSection, sectionSaveCallbacks } from './SettingsSaveContext'
 import PlaceholderChips from './PlaceholderChips'
 import { FIELD_LIMITS } from './fieldLimits'
+import { maskProps } from '../../utils/analytics'
 
 export default function LeadMagnetCard() {
   const { sessionToken } = useAuth()
@@ -63,7 +64,8 @@ export default function LeadMagnetCard() {
             <label className="block text-sm font-medium text-gray-700 mb-1">DM message (may include your link)</label>
             <textarea value={leadMagnet.message || ''} onChange={(e) => setLm({ message: e.target.value })} rows={3}
               maxLength={FIELD_LIMITS.lm_message}
-              placeholder="Thanks for the interest! Here's the resource: …" className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+              placeholder="Thanks for the interest! Here's the resource: …"
+              {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm')} />
             <div className="mt-1.5">
               <PlaceholderChips placeholders={[
                 { token: '{first_name}', desc: "The commenter's first name" },
@@ -73,7 +75,8 @@ export default function LeadMagnetCard() {
         </>
       )}
       {lmMsg && <p className={`text-sm font-medium ${lmMsg.ok ? 'text-green-600' : 'text-red-600'}`}>{lmMsg.text}</p>}
-      <button type="button" onClick={() => lmMutation.mutate()} disabled={lmMutation.isPending}
+      <button type="button" onClick={() => lmMutation.mutate(undefined, sectionSaveCallbacks('lead-magnet'))}
+        disabled={lmMutation.isPending}
         className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
         {lmMutation.isPending ? 'Saving…' : 'Save Lead Magnet'}
       </button>

--- a/src/cqc_lem/ui/src/pages/account/SettingsSaveContext.test.tsx
+++ b/src/cqc_lem/ui/src/pages/account/SettingsSaveContext.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { SettingsSaveProvider, SaveAllBar, useRegisterSaveSection } from './SettingsSaveContext'
+
+const capture = vi.fn()
+vi.mock('../../utils/analytics', () => ({
+  capture: (...args: unknown[]) => capture(...args),
+  EVENTS: { prefsSaved: 'prefs_saved' },
+}))
+
+function Section({ id, save }: { id: string; save: () => Promise<boolean> }) {
+  useRegisterSaveSection(id, id, true, save)
+  return null
+}
+
+function harness(sections: { id: string; save: () => Promise<boolean> }[]) {
+  return render(
+    <SettingsSaveProvider>
+      {sections.map((s) => <Section key={s.id} id={s.id} save={s.save} />)}
+      <SaveAllBar />
+    </SettingsSaveProvider>
+  )
+}
+
+beforeEach(() => capture.mockClear())
+afterEach(cleanup)
+
+describe('prefs_saved instrumentation (issue #646)', () => {
+  it('reports one event per saved section, named by section', async () => {
+    harness([
+      { id: 'voice', save: () => Promise.resolve(true) },
+      { id: 'targeting', save: () => Promise.resolve(true) },
+    ])
+    fireEvent.click(screen.getByRole('button', { name: /Save All/ }))
+    await waitFor(() => expect(capture).toHaveBeenCalledTimes(2))
+    expect(capture).toHaveBeenCalledWith('prefs_saved', { section: 'voice', ok: true })
+    expect(capture).toHaveBeenCalledWith('prefs_saved', { section: 'targeting', ok: true })
+  })
+
+  it('records a failed save as ok:false rather than dropping it', async () => {
+    harness([
+      { id: 'voice', save: () => Promise.reject(new Error('500')) },
+      { id: 'volume', save: () => Promise.resolve(false) },
+    ])
+    fireEvent.click(screen.getByRole('button', { name: /Save All/ }))
+    await waitFor(() => expect(capture).toHaveBeenCalledTimes(2))
+    expect(capture).toHaveBeenCalledWith('prefs_saved', { section: 'voice', ok: false })
+    expect(capture).toHaveBeenCalledWith('prefs_saved', { section: 'volume', ok: false })
+  })
+})

--- a/src/cqc_lem/ui/src/pages/account/SettingsSaveContext.test.tsx
+++ b/src/cqc_lem/ui/src/pages/account/SettingsSaveContext.test.tsx
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
-import { SettingsSaveProvider, SaveAllBar, useRegisterSaveSection } from './SettingsSaveContext'
+import {
+  SettingsSaveProvider, SaveAllBar, useRegisterSaveSection, sectionSaveCallbacks,
+} from './SettingsSaveContext'
 
 const capture = vi.fn()
 vi.mock('../../utils/analytics', () => ({
@@ -46,5 +48,14 @@ describe('prefs_saved instrumentation (issue #646)', () => {
     await waitFor(() => expect(capture).toHaveBeenCalledTimes(2))
     expect(capture).toHaveBeenCalledWith('prefs_saved', { section: 'voice', ok: false })
     expect(capture).toHaveBeenCalledWith('prefs_saved', { section: 'volume', ok: false })
+  })
+
+  // A card's own Save button never goes through saveAll, so it has to report the same event or
+  // prefs_saved silently counts only the Save All users.
+  it('reports the same event from a card own save button', () => {
+    sectionSaveCallbacks('groups').onSuccess()
+    expect(capture).toHaveBeenCalledWith('prefs_saved', { section: 'groups', ok: true })
+    sectionSaveCallbacks('lead-magnet').onError()
+    expect(capture).toHaveBeenCalledWith('prefs_saved', { section: 'lead-magnet', ok: false })
   })
 })

--- a/src/cqc_lem/ui/src/pages/account/SettingsSaveContext.tsx
+++ b/src/cqc_lem/ui/src/pages/account/SettingsSaveContext.tsx
@@ -96,6 +96,18 @@ export function useRegisterSaveSection(
   }, [id, label, isDirty, register, unregister])
 }
 
+// Most cards ALSO keep their own Save button, which calls their mutation directly and never goes
+// through saveAll — so without this, prefs_saved would only ever count the users who happen to use
+// Save All and every rate built on it would be wrong. Spread onto the card's own mutate() call:
+//   onClick={() => groupsMutation.mutate(undefined, sectionSaveCallbacks('groups'))}
+// `section` must be the SAME id the card registers, or the two doors report different sections.
+export function sectionSaveCallbacks(section: string): { onSuccess: () => void; onError: () => void } {
+  return {
+    onSuccess: () => capture(EVENTS.prefsSaved, { section, ok: true }),
+    onError: () => capture(EVENTS.prefsSaved, { section, ok: false }),
+  }
+}
+
 // beforeunload (tab close / refresh) + capture-phase interception of in-app <a> navigation.
 // BrowserRouter (not a data router) can't use useBlocker, so we intercept link clicks before
 // React Router handles them and confirm before allowing a route change away from this page.

--- a/src/cqc_lem/ui/src/pages/account/SettingsSaveContext.tsx
+++ b/src/cqc_lem/ui/src/pages/account/SettingsSaveContext.tsx
@@ -2,6 +2,7 @@ import {
   createContext, useCallback, useContext, useEffect, useMemo, useRef, useState,
   type ReactNode,
 } from 'react'
+import { EVENTS, capture } from '../../utils/analytics'
 
 // One shared registry so every settings section exposes the SAME save it already uses (single
 // source of truth). "Save All" saves only the DIRTY sections (never clobbering untouched ones),
@@ -50,12 +51,14 @@ export function SettingsSaveProvider({ children }: { children: ReactNode }) {
     setSavingAll(true)
     setSummary(null)
     const results: { label: string; ok: boolean }[] = []
-    for (const [, s] of dirty) {
+    for (const [id, s] of dirty) {
       try {
         const ok = await s.save()
         results.push({ label: s.label, ok: ok !== false })
+        capture(EVENTS.prefsSaved, { section: id, ok: ok !== false })
       } catch {
         results.push({ label: s.label, ok: false })
+        capture(EVENTS.prefsSaved, { section: id, ok: false })
       }
     }
     setSavingAll(false)

--- a/src/cqc_lem/ui/src/pages/account/StoryBankCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/StoryBankCard.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../../contexts/AuthContext'
 import { STORY_KINDS } from './types'
 import type { StoryEntry, StoryKind } from './types'
 import { useRegisterSaveSection } from './SettingsSaveContext'
+import { EVENTS, capture, maskProps } from '../../utils/analytics'
 
 type StoryBankResponse = { entries: StoryEntry[]; kinds: StoryKind[]; target_entries: number }
 
@@ -70,6 +71,16 @@ export default function StoryBankCard() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['story-bank'] })
       setSavedSig(JSON.stringify(entries))
+      // Fired on the SAVE, not on "+ Add entry" — a blank row the user abandons never became an
+      // entry. Counts and kinds only; the entry text is the user's own material.
+      const added = entries.filter((e) => !e.id && e.body.trim())
+      if (added.length) {
+        capture(EVENTS.storyBankEntryAdded, {
+          added: added.length,
+          total: entries.filter((e) => e.body.trim()).length,
+          kinds: [...new Set(added.map((e) => e.kind))],
+        })
+      }
       setMsg({ ok: true, text: 'Story bank saved.' })
       setTimeout(() => setMsg(null), 3000)
     },
@@ -140,7 +151,7 @@ export default function StoryBankCard() {
               onChange={(ev) => update(idx, { body: ev.target.value })}
               aria-label="What actually happened"
               placeholder="What actually happened — the real numbers, names, dates and outcome. Write it how you'd tell a colleague."
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+              {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm')} />
             {typeof e.used_count === 'number' && e.used_count > 0 && (
               <p className="text-[11px] text-gray-400">
                 Used in {e.used_count} post{e.used_count === 1 ? '' : 's'} — LEM rotates to your

--- a/src/cqc_lem/ui/src/pages/account/StoryBankCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/StoryBankCard.tsx
@@ -4,7 +4,7 @@ import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import { STORY_KINDS } from './types'
 import type { StoryEntry, StoryKind } from './types'
-import { useRegisterSaveSection } from './SettingsSaveContext'
+import { useRegisterSaveSection, sectionSaveCallbacks } from './SettingsSaveContext'
 import { EVENTS, capture, maskProps } from '../../utils/analytics'
 
 type StoryBankResponse = { entries: StoryEntry[]; kinds: StoryKind[]; target_entries: number }
@@ -166,7 +166,8 @@ export default function StoryBankCard() {
         className="text-xs text-blue-600 font-medium hover:text-blue-700">+ Add entry</button>
 
       {msg && <p className={`text-sm font-medium ${msg.ok ? 'text-green-600' : 'text-red-600'}`}>{msg.text}</p>}
-      <button type="button" onClick={() => saveMutation.mutate()} disabled={saveMutation.isPending}
+      <button type="button" onClick={() => saveMutation.mutate(undefined, sectionSaveCallbacks('story-bank'))}
+        disabled={saveMutation.isPending}
         className="w-full bg-blue-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors">
         {saveMutation.isPending ? 'Saving…' : 'Save Story Bank'}
       </button>

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
@@ -7,6 +7,7 @@ import TopicAuthorityMeter from '../../components/TopicAuthorityMeter'
 import { useAuth } from '../../contexts/AuthContext'
 import { useUserTimezone } from '../../hooks/useUserTimezone'
 import { zonedInputToUtcIso } from '../../utils/datetime'
+import { maskProps } from '../../utils/analytics'
 
 const POST_TYPES = ['TEXT', 'VIDEO', 'CAROUSEL'] as const
 type PostType = typeof POST_TYPES[number]
@@ -267,7 +268,7 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
               onChange={(e) => setContent(e.target.value)}
               rows={postType === 'CAROUSEL' ? 3 : 8}
               maxLength={MAX_CHARS}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none')}
               placeholder={postType === 'CAROUSEL' ? 'Optional intro text for the carousel post… (auto-filled after generation)' : 'What would you like to share?'}
             />
           </div>
@@ -470,7 +471,7 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
                         rows={2}
                         value={slide}
                         onChange={(e) => updateSlide(idx, e.target.value)}
-                        className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+                        {...maskProps('flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none')}
                         placeholder={`Slide ${idx + 1} text…`}
                       />
                       {slides.length > 1 && (

--- a/src/cqc_lem/ui/src/pages/review/CatchupTouches.tsx
+++ b/src/cqc_lem/ui/src/pages/review/CatchupTouches.tsx
@@ -4,6 +4,7 @@ import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import { formatInTimezone } from '../../utils/datetime'
 import { CATCHUP_EVENTS } from '../account/types'
+import { maskProps } from '../../utils/analytics'
 
 // LinkedIn Catch-up congratulations (issue #482). LEM scans your Catch-up feed daily, scores each
 // milestone against your targeting, and queues LinkedIn's own suggested congratulations (or an
@@ -152,7 +153,7 @@ export default function CatchupTouches({ userTimezone }: { userTimezone: string 
                   <textarea value={messageValue} rows={3} maxLength={MESSAGE_MAX}
                     onChange={(e) => setEdits((prev) => ({ ...prev, [t.id]: e.target.value }))}
                     placeholder="Your congratulations message…"
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+                    {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm')} />
                   <div className="flex gap-2 flex-wrap">
                     <button onClick={() => saveMutation.mutate({ id: t.id, message: messageValue })}
                       disabled={!editing || saveMutation.isPending}

--- a/src/cqc_lem/ui/src/pages/review/ConnectionRequests.tsx
+++ b/src/cqc_lem/ui/src/pages/review/ConnectionRequests.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import { formatInTimezone } from '../../utils/datetime'
+import { maskProps } from '../../utils/analytics'
 
 // Proactive, human-approved connection requests (issue #398). Add ICP-targeted prospects, approve
 // them, and LEM sends the invite (reusing invite_to_connect) on a slow, daily-capped drip that honors
@@ -119,7 +120,7 @@ export default function ConnectionRequests({ userTimezone }: { userTimezone: str
         </div>
         <textarea value={note} onChange={(e) => setNote(e.target.value)} rows={2} maxLength={NOTE_MAX}
           placeholder="Connection note (optional, ≤300 chars)"
-          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+          {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm')} />
         <div className="flex flex-wrap items-center gap-3">
           <button onClick={() => createMutation.mutate()} disabled={!canSubmit || createMutation.isPending}
             className="px-4 py-2 bg-blue-600 text-white rounded-lg text-sm font-semibold hover:bg-blue-700 disabled:opacity-50">

--- a/src/cqc_lem/ui/src/pages/review/LeadsInbox.tsx
+++ b/src/cqc_lem/ui/src/pages/review/LeadsInbox.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import { formatInTimezone } from '../../utils/datetime'
+import { maskProps } from '../../utils/analytics'
 
 // Inbound hot leads (issue #483): buying signals ("how much?", "can you help with X?", "DM me")
 // caught in comments, replies, and DMs the automation already reads. Nothing is ever sent
@@ -159,7 +160,7 @@ export default function LeadsInbox({ userTimezone }: { userTimezone: string }) {
                 <textarea value={draftFor(s)} rows={3} maxLength={DRAFT_MAX}
                   onChange={(e) => setDrafts({ ...drafts, [s.id]: e.target.value })}
                   placeholder="Your response…"
-                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+                  {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm')} />
                 <div className="flex gap-2">
                   <button
                     onClick={() => actionMutation.mutate({ id: s.id, action: 'approve', draft_response: draftFor(s) })}

--- a/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
+++ b/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
@@ -5,6 +5,7 @@ import { useAuth } from '../../contexts/AuthContext'
 import NewsletterArticlePreview from '../../components/NewsletterArticlePreview'
 import { formatInTimezone, toZonedInputValue, zonedInputToUtcIso } from '../../utils/datetime'
 import type { NewsletterDraft, NewsletterEdition } from '../account/types'
+import { maskProps } from '../../utils/analytics'
 
 const STATUS_COLORS: Record<string, string> = {
   draft: 'bg-yellow-100 text-yellow-700',
@@ -208,7 +209,7 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">Body</label>
               <textarea value={draftEdit.body || ''} onChange={(e) => setDe({ body: e.target.value })} rows={10}
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500" />
+                {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-blue-500')} />
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">

--- a/src/cqc_lem/ui/src/pages/review/OutreachFunnel.tsx
+++ b/src/cqc_lem/ui/src/pages/review/OutreachFunnel.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
+import { maskProps } from '../../utils/analytics'
 
 // Comment-first outreach funnel (issue #399): a sequenced, APPROVAL-GATED value-comment -> connect
 // -> DM funnel keyed to a target list. Every stage is drafted as 'pending' and only fires once a
@@ -135,7 +136,7 @@ export default function OutreachFunnel() {
           className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
         <textarea value={draft} onChange={(e) => setDraft(e.target.value)} rows={3} maxLength={DRAFT_MAX}
           placeholder="Your value-adding comment…"
-          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+          {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm')} />
         <div className="flex flex-wrap items-center gap-3">
           <button onClick={() => createMutation.mutate('pending')} disabled={!canSubmit || createMutation.isPending}
             className="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50">
@@ -197,7 +198,7 @@ export default function OutreachFunnel() {
                     onChange={(e) => setEdits((prev) => ({ ...prev, [t.id]: e.target.value }))}
                     rows={3} maxLength={DRAFT_MAX}
                     placeholder={t.stage === 'comment' ? 'Comment text…' : t.stage === 'connect' ? 'Connection note…' : 'DM message…'}
-                    className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+                    {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm')} />
                   <div className="flex gap-2 flex-wrap">
                     <button onClick={() => saveMutation.mutate({ id: t.id, draft_text: draftValue })}
                       disabled={!editing || saveMutation.isPending}

--- a/src/cqc_lem/ui/src/pages/review/ScheduledDMs.tsx
+++ b/src/cqc_lem/ui/src/pages/review/ScheduledDMs.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import { formatInTimezone, zonedInputToUtcIso } from '../../utils/datetime'
+import { maskProps } from '../../utils/analytics'
 
 // Schedule 1:1 DMs to chosen recipients at chosen times (issue #306), mirroring the scheduled-posts
 // preview/approve workflow. Drafts are 'pending'; approving queues them for the scanner to send at
@@ -116,7 +117,7 @@ export default function ScheduledDMs({ userTimezone }: { userTimezone: string })
         </div>
         <textarea value={body} onChange={(e) => setBody(e.target.value)} rows={3} maxLength={MSG_MAX}
           placeholder="Your message…"
-          className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm" />
+          {...maskProps('w-full border border-gray-300 rounded-lg px-3 py-2 text-sm')} />
         <div className="flex flex-wrap items-center gap-3">
           <label className="flex items-center gap-2 text-xs text-gray-500">
             <input type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)}

--- a/src/cqc_lem/ui/src/utils/analytics.test.ts
+++ b/src/cqc_lem/ui/src/utils/analytics.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+// One fake posthog-js shared by every import of the module under test.
+const ph = {
+  init: vi.fn(),
+  capture: vi.fn(),
+  identify: vi.fn(),
+  reset: vi.fn(),
+  get_session_id: vi.fn(() => 'sess-123'),
+}
+vi.mock('posthog-js', () => ({ posthog: ph }))
+
+// The key is read at module scope, so each case stubs it and re-imports.
+async function loadAnalytics(key?: string) {
+  vi.resetModules()
+  if (key) vi.stubEnv('VITE_POSTHOG_KEY', key)
+  else vi.stubEnv('VITE_POSTHOG_KEY', '')
+  return import('./analytics')
+}
+
+beforeEach(() => {
+  Object.values(ph).forEach((fn) => fn.mockClear())
+  delete (window as unknown as { posthog?: unknown }).posthog
+})
+
+afterEach(() => {
+  vi.unstubAllEnvs()
+})
+
+describe('with no VITE_POSTHOG_KEY', () => {
+  it('reports itself disabled and never loads posthog-js', async () => {
+    const a = await loadAnalytics()
+    expect(a.analyticsEnabled()).toBe(false)
+    await expect(a.initAnalytics()).resolves.toBeNull()
+    expect(ph.init).not.toHaveBeenCalled()
+  })
+
+  it('swallows every capture, identify and reset', async () => {
+    const a = await loadAnalytics()
+    a.capture('post_approved', { post_id: 1 })
+    a.capturePageview()
+    a.identifyUser({ userId: 5 })
+    a.resetAnalytics()
+    await Promise.resolve()
+    expect(ph.capture).not.toHaveBeenCalled()
+    expect(ph.identify).not.toHaveBeenCalled()
+    expect(ph.reset).not.toHaveBeenCalled()
+  })
+
+  it('still resolves a session id from a script-tag posthog', async () => {
+    const a = await loadAnalytics()
+    ;(window as unknown as { posthog?: unknown }).posthog = { get_session_id: () => 'legacy-1' }
+    expect(a.analyticsSessionId()).toBe('legacy-1')
+  })
+
+  it('reports no session id when nothing is loaded', async () => {
+    const a = await loadAnalytics()
+    expect(a.analyticsSessionId()).toBeUndefined()
+  })
+})
+
+describe('with a key configured', () => {
+  it('inits with the SPA privacy defaults and router-owned pageviews', async () => {
+    const a = await loadAnalytics('phc_test')
+    expect(a.analyticsEnabled()).toBe(true)
+    await a.initAnalytics()
+    expect(ph.init).toHaveBeenCalledTimes(1)
+    const [key, config] = ph.init.mock.calls[0]
+    expect(key).toBe('phc_test')
+    expect(config.capture_pageview).toBe(false)
+    expect(config.autocapture).toBe(true)
+    expect(config.mask_all_element_attributes).toBe(true)
+    expect(config.capture_performance).toEqual({ web_vitals: true })
+    expect(config.session_recording.maskAllInputs).toBe(true)
+    expect(config.session_recording.maskTextSelector).toBe('[data-ph-mask]')
+  })
+
+  it('inits only once no matter how many callers ask', async () => {
+    const a = await loadAnalytics('phc_test')
+    await Promise.all([a.initAnalytics(), a.initAnalytics(), a.initAnalytics()])
+    expect(ph.init).toHaveBeenCalledTimes(1)
+  })
+
+  it('identifies on the backend distinct_id convention with plan facts', async () => {
+    const a = await loadAnalytics('phc_test')
+    a.identifyUser({
+      userId: 42,
+      email: 'me@example.com',
+      plan: 'premium',
+      planStatus: 'active',
+      timezone: 'America/Chicago',
+      createdAt: '2026-01-02T03:04:05Z',
+    })
+    await vi.waitFor(() => expect(ph.identify).toHaveBeenCalled())
+    expect(ph.identify).toHaveBeenCalledWith(
+      '42',
+      {
+        email: 'me@example.com',
+        plan: 'premium',
+        plan_status: 'active',
+        timezone: 'America/Chicago',
+      },
+      { created_at: '2026-01-02T03:04:05Z' }
+    )
+  })
+
+  it('omits person properties it was not given', async () => {
+    const a = await loadAnalytics('phc_test')
+    a.identifyUser({ userId: 42 })
+    await vi.waitFor(() => expect(ph.identify).toHaveBeenCalled())
+    expect(ph.identify).toHaveBeenCalledWith('42', {}, undefined)
+  })
+
+  it('captures product events and router pageviews', async () => {
+    const a = await loadAnalytics('phc_test')
+    a.capture(a.EVENTS.postApproved, { post_type: 'text', archetype: 'build_receipt' })
+    a.capturePageview()
+    await vi.waitFor(() => expect(ph.capture).toHaveBeenCalledTimes(2))
+    expect(ph.capture).toHaveBeenCalledWith('post_approved', {
+      post_type: 'text', archetype: 'build_receipt',
+    })
+    expect(ph.capture.mock.calls[1][0]).toBe('$pageview')
+  })
+
+  it('resets the person on logout', async () => {
+    const a = await loadAnalytics('phc_test')
+    a.resetAnalytics()
+    await vi.waitFor(() => expect(ph.reset).toHaveBeenCalled())
+  })
+
+  it('exposes the client for the feedback widget session id', async () => {
+    const a = await loadAnalytics('phc_test')
+    await a.initAnalytics()
+    expect(a.analyticsSessionId()).toBe('sess-123')
+  })
+
+  it('never lets a posthog error reach the caller', async () => {
+    const a = await loadAnalytics('phc_test')
+    ph.capture.mockImplementationOnce(() => { throw new Error('blocked') })
+    expect(() => a.capture('post_rejected')).not.toThrow()
+    ph.get_session_id.mockImplementationOnce(() => { throw new Error('blocked') })
+    await a.initAnalytics()
+    expect(a.analyticsSessionId()).toBeUndefined()
+  })
+})
+
+describe('maskProps', () => {
+  it('marks an editor for both autocapture opt-out and replay masking', async () => {
+    const a = await loadAnalytics()
+    expect(a.maskProps('w-full text-sm')).toEqual({
+      className: 'w-full text-sm ph-no-capture',
+      'data-ph-mask': 'true',
+    })
+  })
+
+  it('works with no base class', async () => {
+    const a = await loadAnalytics()
+    expect(a.maskProps().className).toBe('ph-no-capture')
+  })
+})

--- a/src/cqc_lem/ui/src/utils/analytics.ts
+++ b/src/cqc_lem/ui/src/utils/analytics.ts
@@ -1,0 +1,140 @@
+// The SPA's ONE PostHog surface (issue #646). Everything browser-side — init, $identify,
+// autocapture, pageviews, web vitals and the named product events — goes through here so there is
+// a single place that knows the key, the privacy defaults and the distinct_id convention.
+//
+// distinct_id is String(user_id), exactly what the backend uses (observability.py), so a user's
+// server events and browser events land on the SAME PostHog person.
+//
+// Disabled means DISABLED: with no VITE_POSTHOG_KEY the posthog-js chunk is never imported, so the
+// build ships it as a separate lazy chunk the browser never fetches and no request is ever made.
+
+import type { PostHog } from 'posthog-js'
+
+const KEY = import.meta.env.VITE_POSTHOG_KEY as string | undefined
+const HOST = (import.meta.env.VITE_POSTHOG_HOST as string | undefined) || 'https://us.i.posthog.com'
+
+// Any element carrying this attribute holds the user's own content (a DM, a story, a draft post).
+// Its text is masked in replay (PH4) and it is opted out of autocapture entirely.
+export const MASK_ATTRIBUTE = 'data-ph-mask'
+export const MASK_SELECTOR = `[${MASK_ATTRIBUTE}]`
+// posthog-js's own element opt-out class — autocapture skips an element (and its descendants)
+// carrying it. Applied alongside MASK_ATTRIBUTE, which only replay understands.
+export const MASK_CLASS = 'ph-no-capture'
+// Spread onto a content editor to mask it in both surfaces: <textarea {...maskProps('w-full …')} />
+export function maskProps(className = ''): { className: string } & Record<string, string> {
+  return { className: `${className} ${MASK_CLASS}`.trim(), [MASK_ATTRIBUTE]: 'true' }
+}
+
+export function analyticsEnabled(): boolean {
+  return !!KEY
+}
+
+let client: PostHog | null = null
+let loading: Promise<PostHog | null> | null = null
+
+export function initAnalytics(): Promise<PostHog | null> {
+  if (!KEY) return Promise.resolve(null)
+  if (loading) return loading
+  loading = import('posthog-js')
+    .then(({ posthog }) => {
+      posthog.init(KEY, {
+        api_host: HOST,
+        // The router owns pageviews — posthog's own listener fires once per full page load and
+        // would miss every in-app navigation.
+        capture_pageview: false,
+        capture_pageleave: true,
+        autocapture: true,
+        // Attribute values can carry content (a post title in aria-label, a draft in value).
+        mask_all_element_attributes: true,
+        capture_performance: { web_vitals: true },
+        // Replay is issue #650 (PH4). Session ids still resolve with it off, which is all the
+        // feedback widget needs.
+        disable_session_recording: true,
+        session_recording: { maskAllInputs: true, maskTextSelector: MASK_SELECTOR },
+      })
+      // The feedback widget and any legacy script-tag reader look for window.posthog.
+      ;(window as unknown as { posthog?: PostHog }).posthog = posthog
+      client = posthog
+      return posthog
+    })
+    .catch(() => {
+      // Blocked by an ad blocker or a bad key — analytics must never take the app down with it.
+      return null
+    })
+  return loading
+}
+
+function withClient(fn: (ph: PostHog) => void): void {
+  if (!KEY) return
+  ;(loading ?? initAnalytics()).then((ph) => {
+    if (!ph) return
+    try {
+      fn(ph)
+    } catch {
+      // Never let an analytics call surface as a UI error.
+    }
+  })
+}
+
+export type AnalyticsIdentity = {
+  userId: number
+  email?: string | null
+  plan?: string | null
+  planStatus?: string | null
+  timezone?: string | null
+  createdAt?: string | null
+}
+
+// Unify the anonymous browser person with the backend's str(user_id) person. Plan facts are set on
+// every call (they change); the signup date is $set_once so a later call can't rewrite history.
+// Deliberately no LinkedIn credentials, cookies or profile data — email is the only PII.
+export function identifyUser(identity: AnalyticsIdentity): void {
+  const props: Record<string, unknown> = {}
+  if (identity.email) props.email = identity.email
+  if (identity.plan) props.plan = identity.plan
+  if (identity.planStatus) props.plan_status = identity.planStatus
+  if (identity.timezone) props.timezone = identity.timezone
+  const setOnce = identity.createdAt ? { created_at: identity.createdAt } : undefined
+  withClient((ph) => ph.identify(String(identity.userId), props, setOnce))
+}
+
+// Logout must break the link between this browser and the person, or the next user on the same
+// machine inherits their events.
+export function resetAnalytics(): void {
+  withClient((ph) => ph.reset())
+}
+
+export function capture(event: string, properties?: Record<string, unknown>): void {
+  withClient((ph) => ph.capture(event, properties))
+}
+
+export function capturePageview(): void {
+  withClient((ph) =>
+    ph.capture('$pageview', {
+      $current_url: window.location.href,
+      path: window.location.pathname,
+    })
+  )
+}
+
+// Synchronous on purpose — the feedback widget attaches it to a report at submit time. Falls back
+// to a window-global posthog so a script-tag install still resolves.
+export function analyticsSessionId(): string | undefined {
+  const ph = client ?? (window as unknown as { posthog?: PostHog }).posthog
+  try {
+    return ph?.get_session_id?.() || undefined
+  } catch {
+    return undefined
+  }
+}
+
+// The moments autocapture cannot name. Keep this vocabulary stable — PostHog insights key off it.
+export const EVENTS = {
+  postApproved: 'post_approved',
+  postRejected: 'post_rejected',
+  prefsSaved: 'prefs_saved',
+  dmTemplateSaved: 'dm_template_saved',
+  storyBankEntryAdded: 'story_bank_entry_added',
+  contentPlanGenerated: 'content_plan_generated',
+  feedbackOpened: 'feedback_opened',
+} as const

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1024,7 +1024,7 @@ def get_posts(user_id: int, limit: int = 10, offset: int = 0,
 
         cursor.execute(
             f"SELECT id, content, video_url, scheduled_time, post_type, status, carousel_slides, "
-            f"authenticity_score, gate_reason "
+            f"authenticity_score, gate_reason, archetype "
             f"FROM posts {where} ORDER BY {sort_col} {order}, id {order} LIMIT %s OFFSET %s",
             params + [limit, offset]
         )
@@ -2738,6 +2738,29 @@ def get_user_email(user_id: int) -> Optional[str]:
     except mysql.connector.Error as err:
         myprint(f"Could not get email for user_id {user_id} | Error: {err}")
         return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_user_analytics_profile(user_id: int) -> dict:
+    """The non-sensitive person facts the SPA sets on the PostHog person at $identify (issue #646):
+    plan tier/status, timezone and the signup timestamp. `users` has no created_at column, so the
+    signup time is trial_started_at falling back to updated_at — the same convention the cohort
+    query uses. Never returns credentials; the SPA already knows the email."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT subscription_tier, subscription_status, timezone, "
+            "COALESCE(trial_started_at, updated_at) AS created_at "
+            "FROM users WHERE id = %s",
+            (user_id,))
+        row = cursor.fetchone()
+        return row or {}
+    except mysql.connector.Error as err:
+        myprint(f"Could not get analytics profile for user_id {user_id} | Error: {err}")
+        return {}
     finally:
         cursor.close()
         connection.close()

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -238,12 +238,41 @@ class TestAuthCheckSession:
 
     def test_valid_session_returns_user_id_and_email(self, client):
         with patch(f"{_MAIN}.get_session_user_id", return_value=7), \
-             patch(f"{_MAIN}.get_user_email", return_value="me@example.com"):
+             patch(f"{_MAIN}.get_user_email", return_value="me@example.com"), \
+             patch(f"{_MAIN}.get_user_analytics_profile", return_value={}):
             resp = client.get(self.BASE, params={"session_token": "valid-token-abc"})
         assert resp.status_code == 200
         detail = resp.json()["detail"]
         assert detail["user_id"] == 7
         assert detail["email"] == "me@example.com"
+
+    def test_returns_person_facts_for_posthog_identify(self, client):
+        profile = {
+            "subscription_tier": "premium",
+            "subscription_status": "active",
+            "timezone": "America/Chicago",
+            "created_at": datetime(2026, 1, 2, 3, 4, 5),
+        }
+        with patch(f"{_MAIN}.get_session_user_id", return_value=7), \
+             patch(f"{_MAIN}.get_user_email", return_value="me@example.com"), \
+             patch(f"{_MAIN}.get_user_analytics_profile", return_value=profile):
+            resp = client.get(self.BASE, params={"session_token": "valid-token-abc"})
+        detail = resp.json()["detail"]
+        assert detail["plan"] == "premium"
+        assert detail["plan_status"] == "active"
+        assert detail["timezone"] == "America/Chicago"
+        assert detail["created_at"] == "2026-01-02T03:04:05Z"
+
+    def test_missing_profile_row_leaves_person_facts_null(self, client):
+        with patch(f"{_MAIN}.get_session_user_id", return_value=7), \
+             patch(f"{_MAIN}.get_user_email", return_value="me@example.com"), \
+             patch(f"{_MAIN}.get_user_analytics_profile", return_value={}):
+            resp = client.get(self.BASE, params={"session_token": "valid-token-abc"})
+        detail = resp.json()["detail"]
+        assert detail["plan"] is None
+        assert detail["plan_status"] is None
+        assert detail["timezone"] is None
+        assert detail["created_at"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utilities/test_db_analytics_profile.py
+++ b/tests/unit/utilities/test_db_analytics_profile.py
@@ -1,0 +1,56 @@
+"""get_user_analytics_profile — the person facts the SPA identifies with (issue #646)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+from datetime import datetime
+
+import mysql.connector
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(fetch_one=None):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.fetchone.return_value = fetch_one
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestGetUserAnalyticsProfile:
+    def test_returns_plan_timezone_and_signup(self):
+        row = {
+            "subscription_tier": "premium",
+            "subscription_status": "active",
+            "timezone": "America/Chicago",
+            "created_at": datetime(2026, 1, 2, 3, 4, 5),
+        }
+        conn, cur = _conn(fetch_one=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_analytics_profile
+            assert get_user_analytics_profile(7) == row
+        assert cur.execute.call_args[0][1] == (7,)
+
+    def test_selects_no_credentials(self):
+        conn, cur = _conn(fetch_one={})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_analytics_profile
+            get_user_analytics_profile(1)
+        sql = cur.execute.call_args[0][0].lower()
+        for secret in ("password", "access_token", "refresh_token", "linkedin"):
+            assert secret not in sql
+
+    def test_unknown_user_returns_empty_dict(self):
+        conn, _ = _conn(fetch_one=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_analytics_profile
+            assert get_user_analytics_profile(999) == {}
+
+    def test_db_error_returns_empty_dict(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_analytics_profile
+            assert get_user_analytics_profile(1) == {}


### PR DESCRIPTION
## What & why

The React SPA had **zero** PostHog. No `posthog-js` dependency meant no pageviews, no autocapture, no web vitals and no session context — and `FeedbackWidget.tsx` has been calling `window.posthog?.get_session_id()` against nothing for as long as it has existed. Backend events already used `distinct_id=str(user_id)`, but with no `$identify` anywhere, every PostHog person was an anonymous shell.

This adds the browser half, as **one** surface: `ui/src/utils/analytics.ts`. Components never touch `posthog` directly, so the key, the privacy defaults and the distinct_id convention live in exactly one place.

### Off means off
`posthog-js` is loaded through a **dynamic import** gated on `VITE_POSTHOG_KEY`. With no key, Vite ships it as a lazy chunk the browser never fetches, `initAnalytics()` resolves `null`, and every `capture`/`identify`/`reset` is a no-op — no network calls, no cost.

### One person, not two
`$identify` fires from `AuthContext` with `String(user_id)` — byte-for-byte the convention `observability.py` uses server-side — so a user's Celery/API events and their browser events land on the same person. Person properties are `plan` / `plan_status` / `timezone`, plus `created_at` as `$set_once`; `GET /auth/session` now returns them (`users` has no `created_at`, so signup time is `trial_started_at` falling back to `updated_at`, the same convention the cohort query uses). **No LinkedIn credentials, cookies or profile data** — email is the only PII. `logout()` calls `posthog.reset()`.

Side benefit: `login()` now reads the session back, so `user.userId` is populated immediately instead of only after the next page load (it was previously `undefined` for the whole first session — which also meant feedback reports filed right after login carried `user_id: null`).

### Privacy defaults
Autocapture is on with `mask_all_element_attributes`. `maskProps()` stamps both `ph-no-capture` (autocapture skips the element) and `data-ph-mask` (replay's `maskTextSelector`, ready for PH4) onto every editor holding the user's own content: draft posts, carousel slides, DM templates, scheduled DM drafts and story bank entries.

### Pageviews + web vitals
`capture_pageview: false` and a `usePageviews()` hook off the router, because posthog's own listener only fires on a full page load and would miss every in-app navigation (`?tab=` included — that's a different screen). Web vitals ride on `capture_performance`. Replay stays off; that's PH4.

### Product events
The moments autocapture can't name, all in the `EVENTS` vocabulary:

| Event | Where | Properties |
|---|---|---|
| `post_approved` / `post_rejected` | Content Studio editor, bulk bar, soft delete | `post_id`, `post_type`, `archetype`, `source` |
| `prefs_saved` | the one Save All registry | `section`, `ok` |
| `dm_template_saved` | DM Templates card | `templates`, `followup_steps` |
| `story_bank_entry_added` | Story Bank save | `added`, `total`, `kinds` |
| `content_plan_generated` | Generate Weekly Content | `source` |
| `feedback_opened` | Feedback widget | `route` |

Two deliberate calls there: a post decision fires only on a real **status transition** (re-saving an already-approved draft is an edit, not a second approval), and `story_bank_entry_added` fires on the SAVE, not on "+ Add entry" — a blank row the user abandons never became an entry. `/posts/` now returns `posts.archetype` (V51) so the decision can carry the shape the draft was written to.

## Testing

- `src/utils/analytics.test.ts` — disabled path never loads posthog-js and swallows every call; init config (pageview ownership, mask flags, web vitals, replay masking selector); init-once; identify shape incl. `$set_once` and omitted props; pageview/product capture; reset; session-id fallback to a script-tag posthog; a throwing posthog never reaching the caller; `maskProps`.
- `SettingsSaveContext.test.tsx` — one `prefs_saved` per saved section, and a failed save recorded as `ok:false` rather than dropped.
- `tests/unit/utilities/test_db_analytics_profile.py` — including an assertion that the SELECT touches no credential column.
- `tests/unit/api/test_main_general.py` — the new `/auth/session` person facts, and the empty-profile fallback.

`poetry run pytest tests/unit -k "posts or db"` → 1505 passed. `tsc -b` clean, `eslint` clean on the new files. The local box is on node 18, so `vitest` and `vite build` (which need ≥20.19) run in CI, not here.

**Not verifiable headless:** the acceptance line "events verified against a dev PostHog key" needs a real browser against a dev project — worth a manual pass once `UI_POSTHOG_KEY` is set. CI builds with the secret unset, which exercises the fully-disabled path.

## Deploy note

`VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST` are **build-time** (Vite bakes them into the bundle), wired as Dockerfile build args and passed by both UI workflows. Browser analytics stays off until the repo secret `UI_POSTHOG_KEY` (the public `phc_…` project key, never the personal API key) and the `UI_POSTHOG_HOST` variable are set.

Prerequisite for PH4 (replay) and PH8 (surveys).

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)