### PR TITLE
feat(observability): LLM analytics — LiteLLM→PostHog native callback ($ai_generation) (closes #647)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -441,6 +441,9 @@ CONTENT_GENERATION_RESULT_TTL_SECONDS=3600
 # --- PostHog (analytics) ---
 POSTHOG_API_KEY=your_posthog_api_key
 POSTHOG_HOST=https://us.i.posthog.com
+# Both are also passed to the litellm container (as POSTHOG_API_KEY / POSTHOG_API_URL), where the
+# native posthog callback emits one $ai_generation per LLM call — issue #647, docs/llm-analytics.md.
+# Prompts/completions are redacted before they reach it (litellm_settings.turn_off_message_logging).
 # Minimum log level forwarded to PostHog (DEBUG/INFO/WARNING/ERROR/CRITICAL). Default: ERROR
 POSTHOG_LOG_LEVEL=ERROR
 # Personal API key (insight + dashboard write scope) used by scripts/posthog_dashboards.py to

--- a/.litellm/config.yaml
+++ b/.litellm/config.yaml
@@ -134,6 +134,22 @@ litellm_settings:
     port: 6379
   custom_callbacks:
     - /app/.litellm/complexity_router.py
+  # ── LLM analytics → PostHog (issue #647, docs/llm-analytics.md) ──────────────
+  # LiteLLM's native logger (>=1.77.3) emits ONE $ai_generation / $ai_embedding per call with the
+  # provider model, tokens, response_cost and latency — the proxy's own accounting, so it needs no
+  # app-side estimate. distinct_id comes from the request's `metadata.user_id`, which
+  # utilities/ai/client.py stamps on every lem-* call; every other metadata key (feature) rides
+  # along as an event property. Needs POSTHOG_API_KEY in this container — see docker-compose.yml.
+  # The app's own `llm_call` event stays: it is what the cost ledger and margin report are built on.
+  # Do NOT sum spend across both streams — see the doc for which insight uses which.
+  success_callback: ["posthog"]
+  failure_callback: ["posthog"]
+  # Prompts and completions are the USER'S LinkedIn material (profile synthesis, story-bank
+  # anecdotes, draft DMs). LEM's analytics contract is that none of it leaves the stack, so the
+  # logging pipeline redacts $ai_input/$ai_output_choices before any callback sees them — the same
+  # rule the SPA follows with maskProps(). Metrics (tokens/cost/latency/model) are unaffected.
+  # Flip to false only deliberately: it turns PostHog's generation view into full conversation text.
+  turn_off_message_logging: true
   drop_params: true
   request_timeout: 180
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -204,6 +204,30 @@ from cqc_lem.utilities.observability import track_llm_call, track_task, track_ap
 
 PostHog receives LLM usage (model, tokens, latency, cost) and Celery task metrics for fine-tuning decisions.
 
+### LLM analytics (LiteLLM → PostHog, issue #647)
+
+There are TWO LLM streams in PostHog and they must never be summed together — see
+`docs/llm-analytics.md` for the full split.
+
+- **`llm_call`** (app, `track_llm_call`) — LEM's cost ESTIMATE, keyed by the tier alias the caller
+  asked for. It is what `cost_ledger`, the margin report and the budget alerts are built on, so
+  **every money question uses this one**.
+- **`$ai_generation`** / **`$ai_embedding`** (proxy) — LiteLLM's native `posthog` callback emits one
+  per call with the model that ACTUALLY served it (post-fallback, post-down-route), the provider's
+  own `response_cost`, tokens and latency. This is PostHog's LLM-analytics product; **use it for
+  latency, error rate, model mix and volume**.
+
+`utilities/ai/client.py` stamps `metadata: {user_id, feature}` on every `lem-*` request — attribution
+lives in the ONE client, not at the ~10 call sites, because a call that skips it is invisible to both
+cost routing and analytics. `metadata.user_id` becomes the event's distinct_id and falls back to the
+`"system"` sentinel (same one `observability.py` uses, same person the SPA's `String(user_id)`
+resolves to), so a user's browser, Celery and proxy events land on ONE PostHog person. Don't remove
+`_attach_routing_metadata` from `_call_llm`: it is what lets an explicit `_track_user_id` beat the
+ambient `llm_attribution()` scope.
+
+Prompts and completions are redacted (`litellm_settings.turn_off_message_logging`) — they are the
+user's own LinkedIn material, and the SPA masks the same content.
+
 ### Browser-side analytics (SPA, issue #646)
 
 The SPA has ONE PostHog surface — `ui/src/utils/analytics.ts`. Never call `posthog` directly from a

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -391,6 +391,14 @@ services:
       - COST_AWARE_ROUTING_ENABLED=${COST_AWARE_ROUTING_ENABLED:-false}
       - COST_ROUTING_REDIS_URL=${COST_ROUTING_REDIS_URL:-redis://redis:6379/0}
       - COST_ROUTING_POLICY_TTL_SECONDS=${COST_ROUTING_POLICY_TTL_SECONDS:-60}
+      # LLM analytics (issue #647): the native posthog callback in .litellm/config.yaml reads these
+      # two names specifically. Same project key + host the app and the SPA report to, so a user's
+      # $ai_generation lands on the same PostHog person as their llm_call and browser events.
+      # Without POSTHOG_API_KEY the logger fails to initialize and LiteLLM swallows it as
+      # non-blocking: calls still complete, they just emit no $ai_generation. Silent, so if the
+      # events don't show up, check this env var in /opt/lem/.env first.
+      - POSTHOG_API_KEY=${POSTHOG_API_KEY}
+      - POSTHOG_API_URL=${POSTHOG_HOST:-https://us.i.posthog.com}
     restart: unless-stopped
     healthcheck:
       test: ["CMD-SHELL", "python3 -c \"import urllib.request; urllib.request.urlopen('http://localhost:4000/health/liveliness')\" 2>/dev/null || exit 1"]

--- a/docs/llm-analytics.md
+++ b/docs/llm-analytics.md
@@ -1,0 +1,89 @@
+# LLM analytics — LiteLLM → PostHog (`$ai_generation`)
+
+Issue #647. Every LEM model call goes through the LiteLLM proxy, so the proxy is the one place that
+sees the *real* model, the *real* token counts and the provider's *own* cost number. LiteLLM's
+native PostHog logger publishes that as PostHog's first-class LLM-analytics event — no app code runs
+per call, so nothing can be forgotten at a new call site.
+
+## What ships
+
+| Where | What |
+|---|---|
+| `.litellm/config.yaml` | `litellm_settings.success_callback` / `failure_callback` include `posthog`; `turn_off_message_logging: true` |
+| `docker-compose.yml` (`litellm`) | `POSTHOG_API_KEY`, `POSTHOG_API_URL` (from the app's `POSTHOG_HOST`) |
+| `utilities/ai/client.py` | stamps `metadata: {user_id, feature}` on every `lem-*` request |
+
+Requires LiteLLM **≥ 1.77.3** for the logger, and the `posthog serilization fix` (BerriAI/litellm
+[#20668](https://github.com/BerriAI/litellm/pull/20668), 2026-02-07) for the batch-send crash
+reported as [#18332](https://github.com/BerriAI/litellm/issues/18332) — the batch is now written
+with `safe_dumps`, so a non-JSON-serializable value in the proxy's own metadata (`UserAPIKeyAuth`)
+degrades to a string instead of dropping every event. The stack runs
+`ghcr.io/berriai/litellm:main-latest`, which is well past both.
+
+## Failure mode
+
+The callback is best-effort by construction: LiteLLM initializes it lazily and treats a failure as
+non-blocking (`_init_custom_logger_compatible_class` logs and returns `None`). A missing
+`POSTHOG_API_KEY` therefore costs no generations — it just silently produces no events. If
+`$ai_generation` is missing in PostHog, check that env var on the box before anything else.
+
+## Event shape
+
+`$ai_generation` (`$ai_embedding` for `client.embeddings.create`), one per call:
+
+- `$ai_model`, `$ai_provider` — the model that actually served it, *after* fallbacks and cost-aware
+  down-routing. This is the honest answer to "what did `lem-complex` really run on?"
+- `$ai_input_tokens`, `$ai_output_tokens`, `$ai_total_cost_usd`, `$ai_latency`
+- `$ai_is_error` / `$ai_error` on the failure callback
+- `$ai_trace_id`, `$ai_span_id`
+- `feature` — LEM's own bucket (`content` / `comment` / `dm` / `newsletter` / `marketing` /
+  `system`), from the request metadata
+- **distinct_id** = the request's `metadata.user_id`
+
+### Attribution
+
+`utilities/ai/client.py` attaches `metadata` to every request whose model is a `lem-*` tier alias,
+reading the ambient `llm_attribution()` scope. It lives in the client, not at the call sites,
+because a call that skips it is invisible in cost routing *and* lands on an anonymous PostHog
+person — a silent failure nobody would notice. `_call_llm` still sets its own metadata first so an
+explicit `_track_user_id` / `_track_feature` beats the ambient scope.
+
+Unattributed traffic sends `user_id: "system"` rather than omitting the field: LiteLLM would
+otherwise fall back to the trace id and mint a throwaway person per call. `"system"` is the same
+sentinel `observability.py` uses server-side and the SPA's `String(user_id)` convention rounds out —
+one PostHog person per user across browser, app and proxy. `routing_policy.assign_arm` reads that
+sentinel exactly like a missing id, so system traffic still lands in the experiment's control arm.
+
+### Privacy
+
+`turn_off_message_logging: true` redacts `$ai_input` / `$ai_output_choices` before any callback sees
+them. LEM's prompts are the user's own LinkedIn material — profile synthesis, story-bank anecdotes,
+draft DMs — and the SPA already masks exactly that content (`maskProps`). Metrics are unaffected.
+Turning it off gives PostHog's generation view the full conversation text; that is a deliberate
+product decision, not a default.
+
+## De-dupe: which stream answers which question
+
+Both streams fire on every call. **Never sum spend across them.**
+
+| | `llm_call` (app, `observability.track_llm_call`) | `$ai_generation` (proxy) |
+|---|---|---|
+| Cost | LEM's *estimate* from `estimate_llm_cost_usd`, zeroed on a cache hit | the provider's own `response_cost` |
+| Model | the tier alias the caller asked for (`model`, plus `model_tier`) | the provider model that served it |
+| Feeds | `cost_ledger` rollups, the margin report, budget alerts (§C/§E of the margin plan) | PostHog's LLM-analytics product: generations, traces, per-model/user breakdowns, evals |
+| Use for | anything a dollar figure is reported from | latency, error rate, model mix, per-user/feature volume |
+
+Rule of thumb: **money questions use `llm_call`** (it is the ledger's source and joins to Stripe);
+**everything else uses `$ai_generation`** (it is the truth about what ran). An insight must pick one
+— a "total LLM spend" chart that unions both double-counts every call.
+
+Caveat worth knowing when the two are compared: a LiteLLM **cache hit** still emits
+`$ai_generation`, at `$ai_total_cost_usd` 0 like `llm_call`'s `cached` path, but its
+`$ai_input_tokens` are the served request's, so token volume reads higher than billable tokens.
+
+## Not in scope here
+
+`$ai_trace` / `$ai_span` hierarchies — wrapping a post's full generation chain
+(research → draft → review → humanize) into one readable trace. Every event already carries a
+`$ai_trace_id`, but it is per-call; grouping them is app-side work via the `posthog-python` AI
+helpers. Tracked as the stretch half of #647.

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import openai
 import replicate
 from cqc_lem import assets_dir
-from cqc_lem.utilities.ai.client import client
+from cqc_lem.utilities.ai.client import client, attribution_metadata
 from cqc_lem.utilities.ai import content_framework as _framework
 # The ONE alignment core (voice + prefs + LEM purpose + promo policy) shared by newsletters,
 # posts, and comments. The underscore aliases keep this module's long-standing internal API
@@ -48,17 +48,21 @@ load_dotenv()
 
 
 def _attach_routing_metadata(kwargs: dict, user_id, feature) -> None:
-    """Send this call's (user, feature) to the LiteLLM proxy as request `metadata`, so the
-    complexity router can look the call's cost-aware routing bucket up (issue #494). Same two
-    dimensions cost is attributed by — the experiment bucket and the spend bucket must mean the
-    same thing. Only tier aliases are routable, so nothing is attached to raw provider models.
-    Best-effort: an existing `extra_body` from the caller wins over ours."""
+    """Send this call's (user, feature) to the LiteLLM proxy as request `metadata`, so the complexity
+    router can look the call's cost-aware routing bucket up (issue #494) and PostHog can attribute
+    the `$ai_generation` the proxy emits (issue #647). Same two dimensions cost is attributed by —
+    the experiment bucket, the spend bucket and the analytics person must mean the same thing.
+
+    The client attaches this from the ambient scope for every request already; doing it here is what
+    lets `_call_llm`'s explicit `_track_user_id`/`_track_feature` beat that scope. Only tier aliases
+    are routable, so nothing is attached to raw provider models. Best-effort: an existing
+    `extra_body` from the caller wins over ours."""
     if not str(kwargs.get("model") or "").startswith("lem-"):
         return
     extra_body = kwargs.setdefault("extra_body", {})
     if not isinstance(extra_body, dict) or "metadata" in extra_body:
         return
-    extra_body["metadata"] = {"feature": feature, "user_id": user_id}
+    extra_body["metadata"] = attribution_metadata(user_id, feature)
 
 
 def _call_llm(**kwargs):

--- a/src/cqc_lem/utilities/ai/client.py
+++ b/src/cqc_lem/utilities/ai/client.py
@@ -1,8 +1,88 @@
 import os
+from typing import Any, Optional, Tuple
 
 from openai import OpenAI
 
-client = OpenAI(
+from cqc_lem.utilities.routing_policy import SYSTEM_USER_ID
+
+# Only tier aliases are routable AND priced by the proxy, so nothing is attached to a call that
+# named a raw provider model directly.
+_TIER_PREFIX = "lem-"
+
+# Mirrors observability.FEATURE_SYSTEM. Kept as a literal so this module never imports observability
+# eagerly — that would drag the DB and PostHog into every `from ...ai.client import client`.
+_SYSTEM_FEATURE = "system"
+
+
+def current_attribution() -> Tuple[Optional[Any], Optional[str]]:
+    """(user_id, feature) for the LLM call happening right now, or (None, None) if attribution is
+    unavailable. Imported lazily: observability pulls in the DB and PostHog, and this module is the
+    one every AI helper imports first."""
+    try:
+        from cqc_lem.utilities.observability import current_llm_attribution, FEATURE_SYSTEM
+        user_id, feature = current_llm_attribution()
+        return user_id, feature or FEATURE_SYSTEM
+    except Exception:
+        return None, None
+
+
+def attribution_metadata(user_id: Optional[Any], feature: Optional[str]) -> dict:
+    """The `metadata` block a LiteLLM request carries. Two consumers, one shape:
+
+    * the complexity router's cost-aware down-routing reads (feature, user_id) as the experiment
+      bucket — the same two dimensions cost is attributed by (issue #494);
+    * LiteLLM's PostHog logger uses `user_id` verbatim as the `$ai_generation` distinct_id and
+      turns every other key into an event property (issue #647).
+
+    `user_id` therefore falls back to the SYSTEM_USER_ID sentinel rather than being omitted: an
+    absent one mints a throwaway anonymous person per call, while the sentinel is exactly what
+    observability.py sends server-side, so proxy and app events land on ONE PostHog person.
+    """
+    return {
+        "feature": feature or _SYSTEM_FEATURE,
+        "user_id": user_id if user_id is not None else SYSTEM_USER_ID,
+    }
+
+
+def _attach_attribution(options) -> None:
+    """Fill in this request's `metadata` from the ambient llm_attribution() scope.
+
+    Runs for every endpoint the client exposes (chat, embeddings, images, speech) because they all
+    build one JSON body. A caller that set its own metadata — `_call_llm` does, so an explicit
+    `_track_user_id` can beat the ambient scope — always wins.
+    """
+    body = getattr(options, "json_data", None)
+    if not isinstance(body, dict) or options.files:
+        return
+    if not str(body.get("model") or "").startswith(_TIER_PREFIX):
+        return
+    extra = getattr(options, "extra_json", None)
+    if "metadata" in body or (isinstance(extra, dict) and "metadata" in extra):
+        return
+    merged = dict(extra) if isinstance(extra, dict) else {}
+    merged["metadata"] = attribution_metadata(*current_attribution())
+    options.extra_json = merged
+
+
+class AttributedOpenAI(OpenAI):
+    """The OpenAI client with LEM's who/what stamped onto every proxied request.
+
+    Attribution lives here rather than at the ~10 call sites because a call that skips it is
+    invisible in cost routing and lands on an anonymous PostHog person — a silent failure nobody
+    would notice. `_build_request` is the one place the SDK funnels every endpoint through;
+    tests/unit/utilities/ai/test_client_attribution.py drives a real request build so an SDK upgrade
+    that moves the hook fails CI instead of quietly dropping attribution.
+    """
+
+    def _build_request(self, options, **kwargs):
+        try:
+            _attach_attribution(options)
+        except Exception:
+            pass  # attribution is observability, never a reason to lose the generation
+        return super()._build_request(options, **kwargs)
+
+
+client = AttributedOpenAI(
     api_key=os.getenv("LITELLM_MASTER_KEY", os.getenv("OPENAI_API_KEY")),
     base_url=os.getenv("LITELLM_BASE_URL", "http://litellm:4000"),
 )

--- a/src/cqc_lem/utilities/routing_policy.py
+++ b/src/cqc_lem/utilities/routing_policy.py
@@ -56,6 +56,13 @@ ROUTING_STATES = frozenset({STATE_EXPERIMENT, STATE_ADOPTED})
 ARM_TREATMENT = "treatment"
 ARM_CONTROL = "control"
 
+# Placeholder a request carries in `metadata.user_id` when no user owns the call. It exists because
+# LiteLLM's PostHog logger uses that field verbatim as the event's distinct_id (issue #647), and an
+# absent one would mint a fresh anonymous person per call — "system" is the same sentinel
+# observability.py uses server-side, so all of LEM's system traffic lands on ONE person. It is NOT a
+# user id, so `assign_arm` must read it exactly like a missing one.
+SYSTEM_USER_ID = "system"
+
 POLICY_VERSION = 1
 POLICY_REDIS_KEY = "lem:routing:policy"
 
@@ -143,7 +150,9 @@ def assign_arm(user_id: Optional[Any], bucket: Optional[Mapping]) -> str:
     previously rolled-back experiment reshuffles the cohort instead of re-testing the same users.
 
     Traffic with no user id (system/housekeeping calls) always lands in control: it cannot be
-    attributed to a cohort, so it must not silently join the treatment.
+    attributed to a cohort, so it must not silently join the treatment. That includes the
+    SYSTEM_USER_ID placeholder — it is an analytics distinct_id, not a user, and hashing it would
+    put every unattributed call in the same arm.
 
     SHA-256 is used purely as a uniform, stable hash of (bucket, user) — nothing here is a secret —
     but a weak digest has no upside for that and trips security scanners, so don't "optimize" it back.
@@ -156,7 +165,7 @@ def assign_arm(user_id: Optional[Any], bucket: Optional[Mapping]) -> str:
         return ARM_CONTROL
     if pct <= 0:
         return ARM_CONTROL
-    if user_id is None or str(user_id).strip() == "":
+    if user_id is None or str(user_id).strip().lower() in ("", SYSTEM_USER_ID):
         return ARM_CONTROL
     if pct >= 1:
         return ARM_TREATMENT

--- a/tests/unit/utilities/ai/test_client_attribution.py
+++ b/tests/unit/utilities/ai/test_client_attribution.py
@@ -107,6 +107,32 @@ class TestAttributionMetadata:
         assert recorder.bodies[-1]["metadata"] == {"feature": "comment", "user_id": 5}
 
 
+class TestTheSharedClient:
+    """The tests above build their own AttributedOpenAI, so they all still pass if the module-level
+    `client` — the ONE instance every AI helper imports — is ever rebuilt as a plain `OpenAI()`.
+    That regression would silently strip distinct_id + feature off every proxy event and leave no
+    other trace, which is exactly the failure this design exists to prevent. Pin it here."""
+
+    def test_the_shared_client_is_the_attributed_one(self):
+        from cqc_lem.utilities.ai.client import AttributedOpenAI, client
+        assert isinstance(client, AttributedOpenAI)
+
+    def test_the_shared_client_stamps_the_request_it_actually_builds(self):
+        """Driven through the real singleton's own request builder — no network, no substitute
+        client — so the assertion covers the object production uses."""
+        from openai._models import FinalRequestOptions
+
+        from cqc_lem.utilities.ai.client import client
+        options = FinalRequestOptions.construct(
+            method="post", url="/chat/completions",
+            json_data={"model": "lem-medium", "messages": [{"role": "user", "content": "hi"}]},
+        )
+        with patch("cqc_lem.utilities.observability.current_llm_attribution",
+                   return_value=(11, "newsletter")):
+            request = client._build_request(options)
+        assert json.loads(request.content)["metadata"] == {"feature": "newsletter", "user_id": 11}
+
+
 class TestAttributionMetadataShape:
     def test_zero_is_a_user_id_not_a_missing_one(self):
         from cqc_lem.utilities.ai.client import attribution_metadata

--- a/tests/unit/utilities/ai/test_client_attribution.py
+++ b/tests/unit/utilities/ai/test_client_attribution.py
@@ -1,0 +1,121 @@
+"""Every request the shared client sends through the LiteLLM proxy carries who/what it is for, so
+the proxy-side `$ai_generation` lands on the right PostHog person and the cost-routing hook can find
+the call's bucket (issue #647).
+
+These build REAL requests through the OpenAI SDK rather than asserting on a mocked `create()`: the
+injection point is an SDK internal, and an SDK upgrade that moves it must fail here rather than
+silently drop attribution in production.
+"""
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.unit
+
+# Imported inside the helpers, not at module scope: importing the client module CONSTRUCTS the
+# shared client, which needs an API key that the session-scoped env fixture only sets after
+# collection.
+
+_CHAT_RESPONSE = {
+    "id": "x", "object": "chat.completion", "created": 0, "model": "m",
+    "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+}
+
+
+class _Recorder(httpx.BaseTransport):
+    def __init__(self):
+        self.bodies = []
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.bodies.append(json.loads(request.content))
+        return httpx.Response(200, json=_CHAT_RESPONSE)
+
+
+def _client() -> tuple:
+    from cqc_lem.utilities.ai.client import AttributedOpenAI
+    recorder = _Recorder()
+    client = AttributedOpenAI(api_key="k", base_url="http://litellm:4000", max_retries=0,
+                              http_client=httpx.Client(transport=recorder))
+    return client, recorder
+
+
+def _sent_metadata(model="lem-complex", attribution=(7, "content"), **kwargs):
+    client, recorder = _client()
+    with patch("cqc_lem.utilities.observability.current_llm_attribution", return_value=attribution):
+        try:
+            client.chat.completions.create(model=model, messages=[{"role": "user", "content": "hi"}],
+                                           **kwargs)
+        except Exception:  # a stub response body only has to be good enough to build the request
+            pass
+    assert recorder.bodies, "no request was sent"
+    return recorder.bodies[-1].get("metadata")
+
+
+class TestAttributionMetadata:
+    def test_scope_user_and_feature_ride_along(self):
+        assert _sent_metadata() == {"feature": "content", "user_id": 7}
+
+    def test_unattributed_calls_use_the_system_sentinel(self):
+        """No user must NOT mean no distinct_id — PostHog would mint an anonymous person per call."""
+        assert _sent_metadata(attribution=(None, None)) == {"feature": "system", "user_id": "system"}
+
+    def test_raw_provider_models_are_not_tagged(self):
+        assert _sent_metadata(model="gpt-4o-mini") is None
+
+    def test_a_callers_own_metadata_wins(self):
+        """_call_llm's explicit _track_user_id/_track_feature arrive this way and must not be lost."""
+        sent = _sent_metadata(extra_body={"metadata": {"feature": "newsletter", "user_id": 9}})
+        assert sent == {"feature": "newsletter", "user_id": 9}
+
+    def test_a_callers_other_extra_body_fields_survive(self):
+        client, recorder = _client()
+        with patch("cqc_lem.utilities.observability.current_llm_attribution", return_value=(3, "dm")):
+            try:
+                client.chat.completions.create(model="lem-simple",
+                                               messages=[{"role": "user", "content": "hi"}],
+                                               extra_body={"tags": ["a"]})
+            except Exception:
+                pass
+        body = recorder.bodies[-1]
+        assert body["tags"] == ["a"]
+        assert body["metadata"] == {"feature": "dm", "user_id": 3}
+
+    def test_attribution_failure_never_breaks_the_call(self):
+        client, recorder = _client()
+        with patch("cqc_lem.utilities.observability.current_llm_attribution",
+                   side_effect=RuntimeError("boom")):
+            try:
+                client.chat.completions.create(model="lem-complex",
+                                               messages=[{"role": "user", "content": "hi"}])
+            except Exception:
+                pass
+        # The generation still went out; it just carries the sentinel instead of a user.
+        assert recorder.bodies[-1]["metadata"] == {"feature": "system", "user_id": "system"}
+
+    def test_embeddings_are_attributed_too(self):
+        """Embeddings bypass _call_llm entirely (comment dedup, feedback clustering) — the client is
+        the only thing standing between them and an anonymous $ai_embedding."""
+        client, recorder = _client()
+        with patch("cqc_lem.utilities.observability.current_llm_attribution",
+                   return_value=(5, "comment")):
+            try:
+                client.embeddings.create(model="lem-embedding", input=["a"])
+            except Exception:
+                pass
+        assert recorder.bodies[-1]["metadata"] == {"feature": "comment", "user_id": 5}
+
+
+class TestAttributionMetadataShape:
+    def test_zero_is_a_user_id_not_a_missing_one(self):
+        from cqc_lem.utilities.ai.client import attribution_metadata
+        assert attribution_metadata(0, "content")["user_id"] == 0
+
+    def test_the_sentinel_matches_the_server_side_distinct_id_convention(self):
+        from cqc_lem.utilities.ai.client import attribution_metadata
+        from cqc_lem.utilities.observability import FEATURE_SYSTEM
+        meta = attribution_metadata(None, None)
+        # observability.py captures system events as distinct_id=str(user_id or "system").
+        assert str(meta["user_id"]) == "system"
+        assert meta["feature"] == FEATURE_SYSTEM

--- a/tests/unit/utilities/ai/test_litellm_posthog_config.py
+++ b/tests/unit/utilities/ai/test_litellm_posthog_config.py
@@ -1,0 +1,54 @@
+"""Guards for the LiteLLM→PostHog analytics wiring (issue #647, docs/llm-analytics.md).
+
+None of this is app code, so nothing fails at runtime when it drifts — the proxy just silently
+stops emitting `$ai_generation`, or (worse) starts shipping the user's prompts. Only these
+assertions notice. Read as text rather than parsed as YAML, matching test_selenium_capacity.py:
+these files configure containers this suite can't run, so the assertion is on what ships.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+CONFIG = (REPO_ROOT / ".litellm" / "config.yaml").read_text()
+COMPOSE = (REPO_ROOT / "docker-compose.yml").read_text()
+
+
+def _uncommented(text: str) -> str:
+    # Every key below is matched as a substring, so prose in the comments must not satisfy it.
+    return "\n".join(line for line in text.splitlines() if not line.strip().startswith("#"))
+
+
+def _litellm_service() -> str:
+    return _uncommented(re.split(r"\n  (?=\w)", COMPOSE.split("\n  litellm:\n")[1])[0])
+
+
+CONFIG_SETTINGS = _uncommented(CONFIG)
+
+
+class TestPostHogCallback:
+    def test_success_and_failure_are_both_reported(self):
+        """A success-only stream makes the error rate meaningless — a broken model looks like silence."""
+        assert re.search(r'success_callback:\s*\[.*"posthog".*\]', CONFIG_SETTINGS)
+        assert re.search(r'failure_callback:\s*\[.*"posthog".*\]', CONFIG_SETTINGS)
+
+    def test_the_complexity_router_is_still_mounted(self):
+        """success_callback and custom_callbacks are separate keys — adding one must not shadow the
+        cost-aware routing hook (issue #494)."""
+        assert "custom_callbacks:" in CONFIG_SETTINGS
+        assert "/app/.litellm/complexity_router.py" in CONFIG_SETTINGS
+
+    def test_prompts_and_completions_are_redacted(self):
+        """$ai_input/$ai_output_choices would otherwise carry the user's own LinkedIn material —
+        the SPA masks exactly this content, and the proxy must not leak it out the back."""
+        assert re.search(r"turn_off_message_logging:\s*true", CONFIG_SETTINGS)
+
+    def test_the_proxy_container_gets_the_posthog_credentials(self):
+        """The logger reads these two names specifically; POSTHOG_HOST is the app's own var, so both
+        halves of the stack report to one project."""
+        service = _litellm_service()
+        assert "- POSTHOG_API_KEY=${POSTHOG_API_KEY}" in service
+        assert "- POSTHOG_API_URL=${POSTHOG_HOST" in service

--- a/tests/unit/utilities/ai/test_routing_metadata.py
+++ b/tests/unit/utilities/ai/test_routing_metadata.py
@@ -40,6 +40,15 @@ class TestRoutingMetadata:
         # The tracking kwargs are still popped — they must never reach the proxy as request fields.
         assert "_track_user_id" not in sent and "_track_feature" not in sent
 
+    def test_unattributed_calls_carry_the_system_sentinel(self):
+        """LiteLLM's PostHog logger uses metadata.user_id as the $ai_generation distinct_id, so an
+        unattributed call must still name one — otherwise every housekeeping call mints its own
+        anonymous person (issue #647)."""
+        with patch("cqc_lem.utilities.observability.current_llm_attribution",
+                   return_value=(None, None)):
+            sent = _call("lem-simple")
+        assert sent["extra_body"]["metadata"] == {"feature": "system", "user_id": "system"}
+
     def test_raw_provider_models_are_not_tagged(self):
         """Only tier aliases are routable, so nothing is attached to a raw provider model."""
         assert "extra_body" not in _call("gpt-4o-mini")

--- a/tests/unit/utilities/test_routing_policy.py
+++ b/tests/unit/utilities/test_routing_policy.py
@@ -102,6 +102,20 @@ def test_assign_arm_without_user_is_control():
     assert rp.assign_arm(1, _bucket(cohort_pct="junk")) == rp.ARM_CONTROL
 
 
+def test_assign_arm_treats_the_analytics_sentinel_as_no_user():
+    """Requests carry user_id="system" so PostHog has a distinct_id (issue #647). It is not a user,
+    so hashing it would drop ALL unattributed traffic into one arm instead of control."""
+    assert rp.assign_arm(rp.SYSTEM_USER_ID, _bucket(cohort_pct=1.0)) == rp.ARM_CONTROL
+    assert rp.assign_arm("System", _bucket(cohort_pct=1.0)) == rp.ARM_CONTROL
+
+
+def test_a_user_id_is_bucketed_the_same_as_an_int_or_a_string():
+    """client.py may send the id as an int; the sentinel forces the field's type to vary. Cohort
+    assignment must not flip when it does, or a user changes arm mid-experiment."""
+    bucket = _bucket(cohort_pct=0.5)
+    assert all(rp.assign_arm(u, bucket) == rp.assign_arm(str(u), bucket) for u in range(50))
+
+
 # ── the routing decision itself ──
 
 def test_resolve_tier_downroutes_treatment_cohort():


### PR DESCRIPTION
## What & why

PH2 of the PostHog milestone. Every LEM model call already flows through the LiteLLM proxy, but PostHog only ever saw the app's own `llm_call` **estimate** — the LLM-analytics product (generations, per-model cost/latency, per-user/feature breakdowns, evals) sat unused.

LiteLLM's native `posthog` callback makes the proxy the canonical analytics stream: one `$ai_generation` (`$ai_embedding` for embeddings) per call carrying `$ai_model`/`$ai_provider` (**the model that actually served it**, post-fallback and post-down-route), `$ai_input_tokens`/`$ai_output_tokens`, the provider's own `$ai_total_cost_usd`, `$ai_latency`, and — via `failure_callback` — `$ai_is_error`/`$ai_error`, so a broken model reads as errors instead of silence.

### Attribution lives in the ONE client

`utilities/ai/client.py` now stamps `metadata: {user_id, feature}` on every `lem-*` request, read from the ambient `llm_attribution()` scope. It goes there rather than at the ~10 direct call sites (embeddings for comment dedup and feedback clustering, `content_research`, `tools`, `carousel_creator`, image/TTS) because a call that skips it is invisible to cost routing **and** lands on an anonymous PostHog person — a silent failure nobody would notice. `_call_llm` still sets its own metadata first, which is what lets an explicit `_track_user_id`/`_track_feature` beat the ambient scope.

`metadata.user_id` is what LiteLLM uses **verbatim** as the event's distinct_id, so unattributed traffic now sends the same `"system"` sentinel `observability.py` uses server-side (and the SPA's `String(user_id)` resolves to) — one PostHog person per user across browser, Celery and proxy, instead of a throwaway anonymous person per housekeeping call.

That sentinel is not a user, so `routing_policy.assign_arm` reads it exactly like a missing id: unattributed traffic still lands in the cost experiment's **control** arm rather than all hashing into one arm together. Real ids are unchanged (the salt is `f"...|{user_id}"`, so int `7` and `"7"` bucket identically — there's a test).

### Privacy

`turn_off_message_logging: true` redacts `$ai_input`/`$ai_output_choices` before any callback sees them. LEM's prompts are the user's own LinkedIn material (profile synthesis, story-bank anecdotes, draft DMs) and the SPA already masks exactly that content with `maskProps()`. Metrics are unaffected. Flipping it to false gives PostHog's generation view full conversation text — a deliberate decision, not a default.

### De-dupe

Both streams fire per call and **must never be summed**. `docs/llm-analytics.md` + a new CLAUDE.md subsection spell out the split: money questions use `llm_call` (it is the `cost_ledger`/margin-report source and joins to Stripe); latency, error rate, model mix and volume use `$ai_generation` (it is the truth about what ran). Also documents the cache-hit caveat — a LiteLLM cache hit emits `$ai_generation` at cost 0 but with the served request's input tokens.

## Version verification (issue asked for this)

- Callback requires LiteLLM **≥1.77.3**.
- The reported proxy serialization bug (BerriAI/litellm#18332, `Object of type UserAPIKeyAuth is not JSON serializable`, reported on v1.80.8) was fixed by `posthog serilization fix (#20668)` on 2026-02-07 — the batch is now written with `safe_dumps`.
- The stack runs `ghcr.io/berriai/litellm:main-latest`, which is well past both. **No pin/upgrade needed for this issue.** (Worth noting separately: `main-latest` is unpinned in general — out of scope here, but a candidate for its own issue.)
- Known upstream wart: the logger copies raw request metadata into event properties, and LiteLLM's proxy puts a `user_api_key_auth` object there. `safe_dumps` stops it crashing, so it lands as a stringified property containing the master key's **hash** (not the key). Noise, not a leak.

## Failure mode

The callback is best-effort by construction — LiteLLM initializes it lazily and `_init_custom_logger_compatible_class` swallows the failure (`return None`). A missing `POSTHOG_API_KEY` in the litellm container costs **no** generations; it just silently emits no events. That's the first thing to check if `$ai_generation` doesn't appear.

## Testing

- `tests/unit/utilities/ai/test_client_attribution.py` (new, 9 tests) — drives **real** request builds through the OpenAI SDK against a recording transport, so an SDK upgrade that moves the injection point fails CI instead of quietly dropping attribution. Covers: scope attribution, the `"system"` sentinel, raw provider models untagged, a caller's own metadata winning, other `extra_body` fields surviving, attribution errors never losing the generation, and embeddings.
- `tests/unit/utilities/ai/test_litellm_posthog_config.py` (new, 4 tests) — the config half has no runtime guard, so these assert both callbacks are wired, the complexity-router `custom_callbacks` hook isn't shadowed, message logging is off, and the compose service gets both env names.
- `test_routing_metadata.py` + `test_routing_policy.py` extended for the sentinel and int/str bucket stability.
- Full unit suite: **6555 passed**. No cost-ledger regressions.

## Not in this PR

The issue's explicit stretch item — `$ai_trace`/`$ai_span` hierarchies wrapping a post's generation chain (research → draft → review → humanize) into one readable trace. Every event already carries a `$ai_trace_id`, but it is per-call; grouping is app-side `posthog-python` work and the issue says a separate PR is fine.

Closes #647

🤖 Generated with [Claude Code](https://claude.com/claude-code)
