### PR TITLE
feat(observability): capture $exception into PostHog error tracking (closes #648)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -446,9 +446,16 @@ POSTHOG_HOST=https://us.i.posthog.com
 # Prompts/completions are redacted before they reach it (litellm_settings.turn_off_message_logging).
 # Minimum log level forwarded to PostHog (DEBUG/INFO/WARNING/ERROR/CRITICAL). Default: ERROR
 POSTHOG_LOG_LEVEL=ERROR
+# Error tracking (issue #648, docs/error-tracking.md). Both default ON and only need setting to
+# turn capture OFF: AUTOCAPTURE is the excepthook for uncaught exceptions, CAPTURE is the
+# log_error/log_critical(exc=...) forwarding. Logs are unaffected either way.
+POSTHOG_EXCEPTION_AUTOCAPTURE=true
+POSTHOG_EXCEPTION_CAPTURE=true
 # Personal API key (insight + dashboard write scope) used by scripts/posthog_dashboards.py to
 # provision the cost/margin dashboards (§E.1), and — read-only — by the daily budget alerts to read
 # LLM cache-hit rate (§E.2). Optional in the stack: unset just skips the cache-hit check.
+# Also read (scope query:read) by scripts/error_to_issues.sh, the daily error-tracking-issue ->
+# GitHub-issue cron.
 POSTHOG_PERSONAL_API_KEY=
 # PostHog project the dashboards live in, and the app host used to build their links.
 POSTHOG_PROJECT_ID=475262

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -56,6 +56,12 @@ jobs:
             VITE_API_TOKEN=${{ secrets.UI_API_TOKEN }}
             VITE_POSTHOG_KEY=${{ secrets.UI_POSTHOG_KEY }}
             VITE_POSTHOG_HOST=${{ vars.UI_POSTHOG_HOST }}
+            POSTHOG_CLI_ENV_ID=${{ vars.POSTHOG_PROJECT_ID }}
+            POSTHOG_CLI_HOST=${{ vars.POSTHOG_APP_HOST }}
+          # Personal API key with error_tracking:write — a build secret, never an ARG, so it can't
+          # be read back out of the image history. Absent = the upload step skips itself.
+          secrets: |
+            posthog_cli_token=${{ secrets.POSTHOG_CLI_TOKEN }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -228,6 +228,28 @@ ambient `llm_attribution()` scope.
 Prompts and completions are redacted (`litellm_settings.turn_off_message_logging`) — they are the
 user's own LinkedIn material, and the SPA masks the same content.
 
+### Error tracking (`$exception` → issues, issue #648)
+
+Errors reach PostHog TWICE on purpose, and the two are not redundant — see `docs/error-tracking.md`.
+
+- **Logs** (`logger.py` → PostHog Logs) keep the message and its structured context. Unchanged.
+- **`$exception`** is the grouped, fingerprinted ISSUE — what alerting and the error→GitHub-issue
+  cron are built on. Emitted by `posthog.enable_exception_autocapture` (uncaught), by
+  `log_error`/`log_critical` **when `exc=` is passed**, by the `task_failure`/`task_retry` handlers in
+  `my_celery.py`, by the unhandled branch of `api/main.py`'s `observability_middleware`, and by
+  `posthog-js` in the SPA.
+
+Use `observability.capture_exception(exc, user_id=..., **context)` for anything you catch and do NOT
+re-raise; everything else is already covered. It is safe to call twice with the same exception
+object — `posthog.capture_exception` is idempotent per instance, so the log call and the Celery
+signal do not double-count. A route's own `HTTPException` is NEVER captured: a 4xx is a response,
+not an issue.
+
+`scripts/posthog_error_issues.py` (cron: `scripts/error_to_issues.sh`) files ONE `agent:ready` GitHub
+issue per ACTIVE PostHog issue, deduped on `posthog-issue-<issue_id>` across open AND closed issues.
+It replaced the old log-grep scan, whose sha1-of-the-message dedup refiled any error with an id in
+its text every single day. Don't add a second dedup layer — the fingerprint IS the dedup.
+
 ### Browser-side analytics (SPA, issue #646)
 
 The SPA has ONE PostHog surface — `ui/src/utils/analytics.ts`. Never call `posthog` directly from a

--- a/Needs_From_Chris.md
+++ b/Needs_From_Chris.md
@@ -48,6 +48,30 @@ POSTHOG_HOST=https://us.i.posthog.com
 
 ---
 
+## PostHog Error Tracking (issue #648 — `docs/error-tracking.md`)
+
+Code is shipped and default-ON; these three are configuration only, and each is independently
+optional (skipping one costs that one thing, nothing else).
+
+- [ ] **Point the daily cron at the new scan.** The old `~/error-to-issues/scan.sh` grepped LOGS and
+  refiled the same error every day; the replacement reads error-tracking issues and dedups on the
+  issue id. As `lem`: `crontab -e` and swap the line for
+  `30 8 * * * /home/lem/linkedin_engagement_manager/scripts/error_to_issues.sh`.
+  Dry-run it first: `scripts/posthog_error_issues.py` (exit 2 just means "issues pending").
+  _Until this is switched, the old cron keeps filing duplicate-prone issues._
+
+- [ ] **`POSTHOG_CLI_TOKEN`** (repo **secret**) — personal API key with `error_tracking:write`, plus
+  repo **variables** `POSTHOG_PROJECT_ID=475262` and `POSTHOG_APP_HOST=https://us.posthog.com`.
+  Used by the release image build to upload SPA source maps. _Without it, browser stack traces stay
+  minified; nothing else changes and no source map is ever served either way._
+
+- [ ] **Alerts** — in [error tracking → configuration →
+  Alerting](https://us.posthog.com/project/475262/error_tracking/configuration#selectedSetting=error-tracking-alerting),
+  create an "issue created or reopened" notification to email, and enable spike detection. This is
+  the real-time half: the cron files the work item, the alert tells you.
+
+---
+
 ## Ollama (Optional — Local Model Fallback)
 
 Ollama runs locally inside Docker. No API key needed, but the first run will download model weights (~2 GB for llama3.2:3b). This happens automatically when the container starts. No action needed unless you want to pre-pull a specific model.

--- a/compose/local/Dockerfile
+++ b/compose/local/Dockerfile
@@ -39,10 +39,31 @@ ARG VITE_POSTHOG_KEY=""
 ENV VITE_POSTHOG_KEY=${VITE_POSTHOG_KEY}
 ARG VITE_POSTHOG_HOST=""
 ENV VITE_POSTHOG_HOST=${VITE_POSTHOG_HOST}
+# Source-map upload for error tracking (issue #648). The INJECTED bundle is what must ship — the
+# chunk ids posthog-cli writes into the JS are how a captured stack finds its map — so this runs
+# here, inside the stage that produces dist/, and not as a separate CI build.
+ARG POSTHOG_CLI_ENV_ID=""
+ENV POSTHOG_CLI_ENV_ID=${POSTHOG_CLI_ENV_ID}
+ARG POSTHOG_CLI_HOST=""
+ENV POSTHOG_CLI_HOST=${POSTHOG_CLI_HOST}
 COPY ./src/cqc_lem/ui/package.json ./src/cqc_lem/ui/package-lock.json ./
 RUN npm ci
 COPY ./src/cqc_lem/ui ./
 RUN npm run build
+# Best-effort by construction: no token (dev/local builds) or a failed upload must never fail a
+# release build — it only costs readable stack traces. The .map files are deleted either way, so a
+# build that skips the upload still never serves them.
+RUN --mount=type=secret,id=posthog_cli_token \
+    if [ -s /run/secrets/posthog_cli_token ] && [ -n "$POSTHOG_CLI_ENV_ID" ]; then \
+      POSTHOG_CLI_TOKEN="$(cat /run/secrets/posthog_cli_token)"; export POSTHOG_CLI_TOKEN; \
+      ( npm install -g @posthog/cli \
+        && posthog-cli sourcemap inject --directory dist \
+        && posthog-cli sourcemap upload --directory dist ) \
+        || echo "posthog-cli source-map upload failed — shipping minified stacks"; \
+    else \
+      echo "posthog-cli source-map upload skipped — no POSTHOG_CLI_TOKEN/POSTHOG_CLI_ENV_ID"; \
+    fi; \
+    find dist -name '*.map' -delete
 
 FROM base AS builder
 

--- a/docs/error-tracking.md
+++ b/docs/error-tracking.md
@@ -1,0 +1,115 @@
+# Error tracking — `$exception` → PostHog issues → GitHub issues
+
+Issue #648 (PH3). Before this, an error reached PostHog only as a LOG line, and a nightly cron
+grepped those logs, grouped them by the exact message string and hashed it into a dedup marker. Any
+error whose message carried an id ("Post 41 failed to post") therefore filed a brand-new GitHub
+issue every single day, and nothing grouped, counted or alerted.
+
+PostHog Error Tracking already does the hard part: it groups `$exception` events into **issues** by
+fingerprint. The issue IS the dedup key, so the whole homegrown layer collapses into "one PostHog
+issue id ↔ one GitHub issue".
+
+## What emits `$exception`
+
+| Surface | How |
+|---|---|
+| Any Python process | `posthog.enable_exception_autocapture` — set in `utilities/observability.py`, catches UNCAUGHT exceptions via the excepthook |
+| Anything logged with `exc=` | `log_error` / `log_critical` also call `capture_exception` (`utilities/logger.py`) |
+| Celery tasks | `task_failure` + `task_retry` handlers in `app/my_celery.py`, with `task_name`, `task_id` and the dispatched `user_id` |
+| FastAPI routes | the unhandled-exception branch of `observability_middleware` in `api/main.py`, with `route` + `method` |
+| The SPA | `posthog-js` `capture_exceptions` (unhandled errors + rejections), plus `captureException()` from `ui/src/utils/analytics.ts` for anything the app catches itself |
+
+Two rules the surfaces above encode:
+
+- **A 4xx is not an error.** A route's own `HTTPException` is turned into a response before the
+  middleware sees it, so only genuine 500s file an issue.
+- **`console.error` is not an error either.** It is noisy and routinely carries the user's own
+  content in the message, so browser console capture stays off.
+
+Double counting is not a concern: `posthog.capture_exception` is idempotent per exception
+*instance*, so a task that does `log_error(..., exc=e)` and then re-raises produces ONE occurrence,
+not one per layer that saw it.
+
+Kill switches (both default ON, both read at import):
+
+| Env | Effect |
+|---|---|
+| `POSTHOG_EXCEPTION_AUTOCAPTURE=false` | no excepthook capture |
+| `POSTHOG_EXCEPTION_CAPTURE=false` | `log_error`/`log_critical` stop forwarding |
+
+With no `POSTHOG_API_KEY` at all, `posthog.disabled` is already True and nothing is sent.
+
+## Readable stack traces (source maps)
+
+The SPA ships minified, so a browser stack is unreadable without source maps. `vite.config.ts` emits
+them (`build.sourcemap: true`) and the **image build** (`compose/local/Dockerfile`, ui-builder stage)
+runs `posthog-cli sourcemap inject` + `upload` right after `npm run build`.
+
+It has to happen there, not in a separate CI job: `inject` writes chunk ids INTO the bundle, and the
+injected bundle is the one that must ship, or an uploaded map can never be matched to a stack.
+
+Every `.map` is deleted from `dist/` afterwards, so source maps are never served — including on
+builds that skip the upload entirely. The upload is best-effort: a missing token or a CLI failure
+costs readable stacks, never a release.
+
+CI wiring (`.github/workflows/build-and-push.yml`):
+
+| Name | Kind | Value |
+|---|---|---|
+| `POSTHOG_CLI_TOKEN` | repo **secret** (BuildKit secret, never an ARG) | personal API key with `error_tracking:write` |
+| `POSTHOG_PROJECT_ID` | repo variable → `POSTHOG_CLI_ENV_ID` | `475262` |
+| `POSTHOG_APP_HOST` | repo variable → `POSTHOG_CLI_HOST` | `https://us.posthog.com` |
+
+## error → GitHub issues (`scripts/posthog_error_issues.py`)
+
+Daily host cron, run by `scripts/error_to_issues.sh` (as `lem`), replacing
+`~/error-to-issues/scan.sh`:
+
+```
+30 8 * * * /home/lem/linkedin_engagement_manager/scripts/error_to_issues.sh
+```
+
+One HogQL query reads the error-tracking columns the `events` table exposes (`issue_id`,
+`issue_name`, `issue_status`, `issue_first_seen`) and groups by `issue_id`. For each ACTIVE issue
+with no GitHub issue carrying its marker, it files one `agent:ready` + `bug` issue shaped for the
+pipeline's `MODE=start` (Why / Scope / Files / Acceptance), with a link to the PostHog issue for the
+stack trace.
+
+- **Dedup is the id**, not the message: the body carries `posthog-issue-<issue_id>`, and the next
+  run searches for that literal string across open AND closed issues. Closed counts — a fixed
+  exception that trickles in for one more day must not reopen the backlog item.
+- **Fail closed**: if the GitHub search itself fails, the run aborts rather than treating "cannot
+  read" as "nothing filed" and duplicating the whole window.
+- **Resolved/suppressed PostHog issues are never filed** — triage done in PostHog stays done.
+- `--max-new` (default 10) caps a bad deploy at 10 tickets per run; the rest wait for the next one.
+
+```bash
+scripts/posthog_error_issues.py --print-sql          # the HogQL, no network
+scripts/posthog_error_issues.py                      # dry run (exit 2 = issues pending)
+scripts/posthog_error_issues.py --apply --hours 24   # file them
+```
+
+Needs `POSTHOG_PERSONAL_API_KEY` (scope `query:read`) — the wrapper reads it from `/opt/lem/.env` —
+and an authenticated `gh` CLI.
+
+## Alerts (PostHog UI)
+
+Alerting is configuration, not code — it lives in
+[error tracking → configuration → Alerting](https://us.posthog.com/project/475262/error_tracking/configuration#selectedSetting=error-tracking-alerting):
+
+1. **Issue created or reopened** → destination email (`christopher.queen@gmail.com`). This is the
+   real-time counterpart of the daily cron: the cron files the work item, the alert tells a human.
+2. **Spike detection** → same destination, configured under
+   `#selectedSetting=error-tracking-spike-detection`. A spike on an ALREADY-filed issue is
+   deliberately not a second GitHub issue; it is an alert.
+
+The org also gets a weekly Error Tracking digest email per project, which needs no setup.
+
+## Reading the data
+
+- Issues, statuses and stack traces: `https://us.posthog.com/project/475262/error_tracking`
+- The raw events: `SELECT issue_id, issue_name, count() FROM events WHERE event = '$exception'
+  GROUP BY issue_id, issue_name` in SQL insights.
+- Logs (`utilities/logger.py` → PostHog Logs) are still there and still carry the message and
+  structured context — they are the CONTEXT around an exception. Alerting moved to issues; logs did
+  not go away.

--- a/scripts/error_to_issues.sh
+++ b/scripts/error_to_issues.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Daily error->issues cron (host cron, runs as `lem`) — issue #648.
+#
+# Replaces the old ~/error-to-issues/scan.sh, which grepped PostHog LOGS for ERROR/FATAL bodies and
+# hand-rolled dedup off a sha1 of the message string. This one reads PostHog Error Tracking ISSUES,
+# where grouping is already done by fingerprint, and files ONE GitHub issue per PostHog issue id.
+#
+# Cron (as `lem`):
+#   30 8 * * * /home/lem/linkedin_engagement_manager/scripts/error_to_issues.sh
+set -uo pipefail
+export PATH="/home/lem/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export HOME="${HOME:-/home/lem}"
+
+# Self-locate the repo root so this can run from a dedicated cron clone (overridable for tests).
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+DIR="${ERROR_ISSUES_DIR:-/home/lem/error-to-issues}"
+LOG="$DIR/error-to-issues.log"
+mkdir -p "$DIR"
+log(){ echo "[$(date -u +%FT%TZ)] $*" | tee -a "$LOG" >&2; }
+
+# Python with `requests`. Prefer the stable dev-checkout venv; fall back to poetry inside REPO.
+_DEV_VENV_PY="/home/lem/linkedin_engagement_manager/.venv/bin/python"
+if [ -x "$_DEV_VENV_PY" ]; then PY=("$_DEV_VENV_PY"); else PY=(poetry run python); fi
+
+# Personal API key (query:read). Env wins; otherwise read it off the box's prod env file.
+if [ -z "${POSTHOG_PERSONAL_API_KEY:-}" ]; then
+  POSTHOG_PERSONAL_API_KEY=$(sudo -n grep -E '^POSTHOG_PERSONAL_API_KEY=' /opt/lem/.env 2>/dev/null \
+    | cut -d= -f2- | tr -d '"' | tr -d "'")
+  export POSTHOG_PERSONAL_API_KEY
+fi
+if [ -z "${POSTHOG_PERSONAL_API_KEY:-}" ]; then
+  log "No POSTHOG_PERSONAL_API_KEY set — skipping. Add it to /opt/lem/.env to enable."
+  exit 0
+fi
+
+log "=== error->issues scan start ==="
+cd "$REPO" || { log "repo not found: $REPO"; exit 1; }
+"${PY[@]}" scripts/posthog_error_issues.py --apply "$@" 2>&1 | tee -a "$LOG"
+rc=${PIPESTATUS[0]}
+log "=== error->issues scan done (exit $rc) ==="
+exit "$rc"

--- a/scripts/posthog_error_issues.py
+++ b/scripts/posthog_error_issues.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""Open ONE GitHub issue per PostHog error-tracking ISSUE (issue #648).
+
+This replaces the log-grep scan the daily cron used to run. That version read PostHog *Logs* for
+ERROR/FATAL bodies, grouped them by the exact message string and hand-rolled dedup with a sha1 of
+that string — so one exception with a variable message ("Post 41 failed", "Post 42 failed") filed a
+new GitHub issue every day. PostHog Error Tracking already groups `$exception` events into ISSUES by
+fingerprint, so the grouping IS the dedup: one PostHog issue id maps to exactly one GitHub issue,
+forever, and the marker in the body is that id.
+
+Filing rule: an ACTIVE PostHog issue with at least `--min-occurrences` exceptions inside the window
+and no GitHub issue carrying its marker. A brand-new issue therefore files on the next run, and a
+long-running one is filed once and never again — spikes on an already-filed issue are PostHog's own
+alert's job (docs/error-tracking.md), not a second GitHub issue.
+
+Split like scripts/model_health_check.py and scripts/posthog_dashboards.py: PURE logic (query,
+titles, bodies, planning — unit-tested) and a thin I/O layer (the PostHog query API and the `gh`
+CLI, mocked in tests). Deliberately imports nothing from `cqc_lem`: this runs from a host cron clone
+with no app env, DB or broker.
+
+CLI (--dry-run and --apply are mutually exclusive):
+  --dry-run              Show what would be filed. No writes. (default)
+  --apply                File the missing GitHub issues.
+  --print-sql            Print the HogQL and exit (no network).
+Options:
+  --hours N              Lookback window in hours (default 24).
+  --min-occurrences N    Ignore issues with fewer exceptions than this in the window (default 1).
+  --max-new N            Cap issues filed per run (default 10); the rest wait for the next run.
+Env:
+  POSTHOG_PERSONAL_API_KEY  Personal API key with query:read (required for network).
+  POSTHOG_PROJECT_ID        PostHog project id (default 475262 — "CQC LEM").
+  POSTHOG_APP_HOST          App host for the API (default https://us.posthog.com).
+  ERROR_ISSUE_REPO          owner/name to file into (default this repo).
+Exit: 0 nothing to do / applied, 2 issues pending (--dry-run), 1 error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from typing import Optional
+
+DEFAULT_PROJECT_ID = "475262"  # "CQC LEM" — not a secret; the key that reaches it is.
+DEFAULT_APP_HOST = "https://us.posthog.com"
+DEFAULT_REPO = "christopherqueenconsulting/linkedin_engagement_manager"
+
+# Written into every filed body and searched for on the next run. The PostHog issue id IS the dedup
+# key — do not change the prefix without migrating the issues already carrying it.
+MARKER_PREFIX = "posthog-issue-"
+
+LABELS = ("agent:ready", "bug")
+
+DEFAULT_HOURS = 24
+DEFAULT_MIN_OCCURRENCES = 1
+DEFAULT_MAX_NEW = 10
+# Ceiling on rows pulled back; far above any realistic day, so it only ever caps a runaway.
+QUERY_LIMIT = 100
+MAX_TITLE_CHARS = 120
+GH_TIMEOUT_SECONDS = 60
+QUERY_TIMEOUT_SECONDS = 60
+
+# The columns the query selects, in order — parse_rows() zips these onto each result row rather than
+# trusting the API to echo a `columns` array back.
+COLUMNS = ("issue_id", "name", "description", "status", "first_seen", "last_seen",
+           "occurrences", "users", "lib", "task_name", "route")
+
+
+# ─────────────────────────── pure logic (unit-tested) ────────────────────────────
+
+def build_query(hours: int = DEFAULT_HOURS, min_occurrences: int = DEFAULT_MIN_OCCURRENCES,
+                limit: int = QUERY_LIMIT) -> str:
+    """The HogQL behind one run. `issue_*` are the error-tracking columns the events table exposes,
+    so the grouping PostHog already did is read straight off the exception events — no second query
+    against the issues table, and no client-side fingerprinting."""
+    hours = max(1, int(hours or DEFAULT_HOURS))
+    minimum = max(1, int(min_occurrences or 1))
+    return (
+        "SELECT issue_id, any(issue_name) AS name, any(issue_description) AS description, "
+        "any(issue_status) AS status, min(issue_first_seen) AS first_seen, "
+        "max(timestamp) AS last_seen, count() AS occurrences, uniq(distinct_id) AS users, "
+        "any(properties.$lib) AS lib, any(properties.task_name) AS task_name, "
+        "any(properties.route) AS route "
+        "FROM events "
+        f"WHERE event = '$exception' AND timestamp > now() - INTERVAL {hours} HOUR "
+        "GROUP BY issue_id "
+        f"HAVING occurrences >= {minimum} "
+        f"ORDER BY occurrences DESC LIMIT {int(limit)}"
+    )
+
+
+def parse_rows(results: Optional[list]) -> list:
+    """Query rows -> dicts keyed by COLUMNS. Rows with no issue id are dropped: an exception whose
+    issue has not been created yet (ingestion lag) has nothing stable to dedup on, and it will be
+    grouped by the next run."""
+    rows = []
+    for row in results or []:
+        if not isinstance(row, (list, tuple)):
+            continue
+        item = {key: (row[index] if index < len(row) else None)
+                for index, key in enumerate(COLUMNS)}
+        issue_id = str(item.get("issue_id") or "").strip()
+        if not issue_id:
+            continue
+        item["issue_id"] = issue_id
+        rows.append(item)
+    return rows
+
+
+def marker(issue_id: str) -> str:
+    return f"{MARKER_PREFIX}{issue_id}"
+
+
+def is_actionable(row: dict) -> bool:
+    """Only ACTIVE issues become GitHub work. One a human already resolved or suppressed in PostHog
+    must never come back as a fresh backlog item just because a straggler event landed."""
+    status = str((row or {}).get("status") or "active").strip().lower()
+    return status in ("", "active")
+
+
+def issue_url(issue_id: str, project_id: str = DEFAULT_PROJECT_ID,
+              app_host: str = DEFAULT_APP_HOST) -> str:
+    return f"{app_host.rstrip('/')}/project/{project_id}/error_tracking/{issue_id}"
+
+
+def _text(value) -> str:
+    return str(value if value is not None else "").strip()
+
+
+def build_title(row: dict) -> str:
+    """`fix(errors): <exception type>: <message> (Nx/24h)` — reads like the commit that closes it."""
+    name = _text(row.get("name")) or "Unknown exception"
+    description = _text(row.get("description"))
+    summary = f"{name}: {description}" if description else name
+    summary = " ".join(summary.split())
+    suffix = f" ({int(row.get('occurrences') or 0)}x)"
+    head = f"fix(errors): {summary}"
+    if len(head) + len(suffix) > MAX_TITLE_CHARS:
+        head = head[:MAX_TITLE_CHARS - len(suffix)]
+    return head + suffix
+
+
+def build_body(row: dict, hours: int = DEFAULT_HOURS, project_id: str = DEFAULT_PROJECT_ID,
+               app_host: str = DEFAULT_APP_HOST) -> str:
+    """The `MODE=start` body the pipeline reads: Why / Scope / Files / Acceptance, plus the marker
+    that makes this run idempotent."""
+    issue_id = _text(row.get("issue_id"))
+    context = [f"- Occurrences (last {hours}h): **{int(row.get('occurrences') or 0)}** across "
+               f"{int(row.get('users') or 0)} distinct actor(s)",
+               f"- First seen: `{_text(row.get('first_seen')) or 'unknown'}` · "
+               f"last seen: `{_text(row.get('last_seen')) or 'unknown'}`"]
+    if _text(row.get("task_name")):
+        context.append(f"- Celery task: `{_text(row.get('task_name'))}`")
+    if _text(row.get("route")):
+        context.append(f"- API route: `{_text(row.get('route'))}`")
+    if _text(row.get("lib")):
+        context.append(f"- SDK: `{_text(row.get('lib'))}`")
+
+    lines = ["## Why",
+             f"PostHog error tracking grouped this exception into an issue that is still active: "
+             f"**{_text(row.get('name')) or 'Unknown exception'}**",
+             "",
+             f"> {_text(row.get('description')) or '(no message captured)'}",
+             ""]
+    lines += context
+    lines += ["",
+              f"[Open the issue in PostHog]({issue_url(issue_id, project_id, app_host)}) — it has "
+              f"the stack trace, the grouped occurrences and the affected people.",
+              "",
+              "## Scope",
+              "- Fix the root cause of the exception, not the symptom.",
+              "- If it is an EXPECTED best-effort failure that already degrades gracefully (a "
+              "Selenium selector miss, a third-party timeout the caller retries), stop raising it "
+              "into error tracking: catch it and `log_warning(...)` instead, or add a suppression "
+              "rule in PostHog.",
+              "- Keep the change scoped to this exception — no unrelated refactors.",
+              "",
+              "## Files",
+              "Start from the stack trace on the PostHog issue; add/extend the unit tests:",
+              "- `tests/unit/`",
+              "",
+              "## Acceptance",
+              "- The exception no longer occurs (or is deliberately downgraded to a warning).",
+              "- A unit test covers the failing path (≥80% patch coverage).",
+              "- All required CI gates pass.",
+              "",
+              f"Auto-filed from PostHog Error Tracking. Dedup marker (do not remove): "
+              f"`{marker(issue_id)}`"]
+    return "\n".join(lines)
+
+
+def plan_actions(rows: list, filed_markers, max_new: int = DEFAULT_MAX_NEW) -> list:
+    """What this run would do, in order: one `create` per actionable issue that has no GitHub issue
+    yet, `skip` for everything else with the reason. Capped at `max_new` so a bad deploy that
+    produces 50 new issues does not open 50 tickets in one go — the rest are `deferred` and picked up
+    by the next run."""
+    already = {str(m) for m in (filed_markers or set())}
+    seen = set()
+    actions = []
+    created = 0
+    for row in rows or []:
+        issue_id = _text(row.get("issue_id"))
+        key = marker(issue_id)
+        if key in seen:
+            continue
+        seen.add(key)
+        if not is_actionable(row):
+            actions.append({"action": "skip", "reason": "not active", "row": row, "marker": key})
+        elif key in already:
+            actions.append({"action": "skip", "reason": "already filed", "row": row,
+                            "marker": key})
+        elif created >= max(0, int(max_new)):
+            actions.append({"action": "deferred", "reason": "max-new reached", "row": row,
+                            "marker": key})
+        else:
+            actions.append({"action": "create", "row": row, "marker": key})
+            created += 1
+    return actions
+
+
+def pending(actions: list) -> list:
+    return [a for a in actions or [] if a.get("action") == "create"]
+
+
+def summarize(actions: list) -> str:
+    counts: dict = {}
+    for action in actions or []:
+        counts[action["action"]] = counts.get(action["action"], 0) + 1
+    if not counts:
+        return "no error-tracking issues in the window"
+    return ", ".join(f"{count} {name}" for name, count in sorted(counts.items()))
+
+
+# ─────────────────────────────── I/O (mocked in tests) ───────────────────────────
+
+class PostHogQueryClient:
+    """Minimal client for the HogQL query endpoint — the same one the old shell scan used."""
+
+    def __init__(self, api_key: str, project_id: str, app_host: str = DEFAULT_APP_HOST) -> None:
+        self.api_key = api_key
+        self.project_id = project_id
+        self.app_host = app_host.rstrip("/")
+
+    def query(self, hogql: str) -> list:
+        import requests
+        response = requests.post(
+            f"{self.app_host}/api/projects/{self.project_id}/query/",
+            headers={"Authorization": f"Bearer {self.api_key}",
+                     "Content-Type": "application/json"},
+            json={"query": {"kind": "HogQLQuery", "query": hogql}},
+            timeout=QUERY_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        return payload.get("results") or []
+
+
+class GitHubIssues:
+    """GitHub via the `gh` CLI — the cron host is already authenticated with it, so this needs no
+    token of its own (and never handles one)."""
+
+    def __init__(self, repo: str = DEFAULT_REPO) -> None:
+        self.repo = repo
+
+    def _run(self, args: list) -> subprocess.CompletedProcess:
+        return subprocess.run(args, capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS)
+
+    def is_filed(self, issue_marker: str) -> bool:
+        """True when ANY issue — open or closed — already carries this marker. Closed counts: a
+        fixed exception that trickles in for another day must not reopen the backlog item.
+
+        GitHub's search tokenizes on hyphens, so a UUID marker can match a NEIGHBOURING issue; the
+        returned bodies are re-checked for the literal marker so dedup stays exact."""
+        result = self._run(["gh", "issue", "list", "--repo", self.repo, "--state", "all",
+                            "--search", issue_marker, "--json", "number,body"])
+        if result.returncode != 0:
+            # Fail CLOSED: an unreadable search must never be read as "nothing filed yet", or a
+            # GitHub outage turns into a duplicate for every issue in the window.
+            raise RuntimeError(f"gh issue list failed: {(result.stderr or '').strip()[:200]}")
+        try:
+            found = json.loads(result.stdout or "[]")
+        except ValueError:
+            raise RuntimeError("gh issue list returned unparseable JSON")
+        return any(issue_marker in (item.get("body") or "") for item in found
+                   if isinstance(item, dict))
+
+    def create(self, title: str, body: str, labels=LABELS) -> Optional[str]:
+        args = ["gh", "issue", "create", "--repo", self.repo, "--title", title, "--body", body]
+        for label in labels:
+            args += ["--label", label]
+        result = self._run(args)
+        if result.returncode != 0:
+            print(f"  ! gh issue create failed: {(result.stderr or '').strip()[:300]}",
+                  file=sys.stderr)
+            return None
+        return (result.stdout or "").strip()
+
+
+def filed_markers(github: GitHubIssues, rows: list) -> set:
+    """Which of these issues already have a GitHub issue. One search per issue id: exact-marker
+    search is what makes the dedup id-based rather than text-similarity based."""
+    found = set()
+    for row in rows or []:
+        key = marker(_text(row.get("issue_id")))
+        if github.is_filed(key):
+            found.add(key)
+    return found
+
+
+def apply_actions(github: GitHubIssues, actions: list, dry_run: bool = True) -> list:
+    """File the planned issues (or, in dry-run, just report them). Never raises on a GitHub failure:
+    a row that fails to file is left unfiled and retried by the next run."""
+    applied = []
+    for action in pending(actions):
+        row = action["row"]
+        title = build_title(row)
+        if dry_run:
+            print(f"  would file: {title}")
+            continue
+        url = github.create(title, action["body"])
+        if url:
+            print(f"  filed: {url} — {title}")
+            applied.append({**action, "url": url})
+    return applied
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="File GitHub issues from PostHog error-tracking issues.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_true", help="Show what would be filed (default).")
+    mode.add_argument("--apply", action="store_true", help="File the missing GitHub issues.")
+    parser.add_argument("--print-sql", action="store_true", help="Print the HogQL and exit.")
+    parser.add_argument("--hours", type=int, default=DEFAULT_HOURS)
+    parser.add_argument("--min-occurrences", type=int, default=DEFAULT_MIN_OCCURRENCES)
+    parser.add_argument("--max-new", type=int, default=DEFAULT_MAX_NEW)
+    args = parser.parse_args(argv)
+
+    hogql = build_query(args.hours, args.min_occurrences)
+    if args.print_sql:
+        print(hogql)
+        return 0
+
+    api_key = os.getenv("POSTHOG_PERSONAL_API_KEY", "")
+    if not api_key:
+        print("POSTHOG_PERSONAL_API_KEY is not set — cannot reach PostHog.", file=sys.stderr)
+        return 1
+    project_id = os.getenv("POSTHOG_PROJECT_ID", DEFAULT_PROJECT_ID)
+    app_host = os.getenv("POSTHOG_APP_HOST", DEFAULT_APP_HOST)
+    repo = os.getenv("ERROR_ISSUE_REPO", DEFAULT_REPO)
+
+    try:
+        results = PostHogQueryClient(api_key, project_id, app_host).query(hogql)
+    except Exception as e:
+        print(f"PostHog query failed: {e}", file=sys.stderr)
+        return 1
+
+    rows = parse_rows(results)
+    github = GitHubIssues(repo)
+    try:
+        already = filed_markers(github, rows)
+    except Exception as e:
+        print(f"GitHub dedup lookup failed: {e}", file=sys.stderr)
+        return 1
+
+    actions = plan_actions(rows, already, args.max_new)
+    for action in actions:
+        if action["action"] == "create":
+            action["body"] = build_body(action["row"], args.hours, project_id, app_host)
+    print(f"PostHog: {len(rows)} error-tracking issue(s) in the last {args.hours}h "
+          f"— {summarize(actions)}")
+
+    dry_run = not args.apply
+    apply_actions(github, actions, dry_run=dry_run)
+    if dry_run:
+        return 2 if pending(actions) else 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -103,7 +103,7 @@ from cqc_lem.utilities.quality_gates import (parse_gate_findings, clamp_threshol
                                              AUTHENTICITY_SCORE_MIN_BOUNDS,
                                              SIMILARITY_MAX_PCT_BOUNDS)
 from cqc_lem.utilities.observability import (
-    track_api_call, track_funnel_event, anonymous_distinct_id,
+    capture_exception, track_api_call, track_funnel_event, anonymous_distinct_id,
     FUNNEL_SIGNUP_STARTED, FUNNEL_SIGNUP_COMPLETED, FUNNEL_TRIAL_STARTED,
     FUNNEL_SUBSCRIPTION_STARTED, FUNNEL_CHURNED,
 )
@@ -136,6 +136,12 @@ async def observability_middleware(request: Request, call_next):
         response = await call_next(request)
         status_code = response.status_code
         return response
+    except Exception as e:
+        # Only UNHANDLED exceptions reach here — a route's own HTTPException is turned into a
+        # response by FastAPI's handler further in, so 4xx never files an error-tracking issue.
+        capture_exception(e, route=request.url.path, method=request.method,
+                          source="fastapi.middleware")
+        raise
     finally:
         track_api_call(
             route=request.url.path,

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -1,10 +1,12 @@
 import time as _time
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 from celery import Celery
 from celery import current_app
 from celery.schedules import crontab
-from celery.signals import worker_process_init, task_received, task_success, task_sent, task_prerun, task_postrun
+from celery.signals import (worker_process_init, task_received, task_success, task_sent,
+                            task_prerun, task_postrun, task_failure, task_retry)
 from celery.app.control import Inspect
 
 from cqc_lem.app import celeryconfig
@@ -13,7 +15,7 @@ from cqc_lem.utilities.engagement_window import STAGGER_TICK_MINUTES
 from cqc_lem.utilities.env_constants import CODE_TRACING, AWS_REGION
 from cqc_lem.utilities.jaeger_tracer_helper import get_jaeger_tracer
 from cqc_lem.utilities.logger import myprint, logger
-from cqc_lem.utilities.observability import track_task
+from cqc_lem.utilities.observability import capture_exception, track_task
 from cqc_lem.utilities.utils import get_cloudwatch_client
 
 # AWS deployment: uses SQS as broker (see celeryconfig.py CELERY_BROKER_URL)
@@ -418,6 +420,51 @@ def on_task_postrun(task_id: str = None, task=None, state: str = None, **kwargs)
         duration_ms=int((_time.time() - start) * 1000),
         success=(state == "SUCCESS"),
         state=state or "UNKNOWN",
+    )
+
+
+def _task_user_id(kwargs) -> Optional[int]:
+    """The user a task was dispatched for. Every per-user task in LEM carries `user_id` in its
+    kwargs, which is the only attribution a signal handler can see."""
+    if not isinstance(kwargs, dict):
+        return None
+    user_id = kwargs.get("user_id")
+    try:
+        return int(user_id) if user_id is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+@task_failure.connect(weak=False)
+def on_task_failure(task_id: str = None, exception: BaseException = None, sender=None,
+                    kwargs: dict = None, einfo=None, **_) -> None:
+    """File a failed task's exception as a grouped PostHog error-tracking issue (issue #648). Celery
+    swallows the traceback into its own logger, so without this the only trace of a crashed task is
+    a log line — nothing that groups, counts or alerts."""
+    capture_exception(
+        exception,
+        user_id=_task_user_id(kwargs),
+        task_name=getattr(sender, "name", None),
+        task_id=task_id,
+        source="celery.task_failure",
+    )
+
+
+@task_retry.connect(weak=False)
+def on_task_retry(request=None, reason=None, sender=None, einfo=None, **_) -> None:
+    """A retry is a failure that will be tried again — worth the same issue so a task that only ever
+    succeeds on its 3rd attempt is still visible. `reason` is the exception when the retry was
+    raised from one; anything else (a bare `self.retry()`) carries no exception to group and is
+    skipped rather than filed as a synthetic one."""
+    if not isinstance(reason, BaseException):
+        return
+    capture_exception(
+        reason,
+        user_id=_task_user_id(getattr(request, "kwargs", None)),
+        task_name=getattr(sender, "name", None),
+        task_id=getattr(request, "id", None),
+        retries=getattr(request, "retries", None),
+        source="celery.task_retry",
     )
 
 

--- a/src/cqc_lem/ui/src/utils/analytics.test.ts
+++ b/src/cqc_lem/ui/src/utils/analytics.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 const ph = {
   init: vi.fn(),
   capture: vi.fn(),
+  captureException: vi.fn(),
   identify: vi.fn(),
   reset: vi.fn(),
   get_session_id: vi.fn(() => 'sess-123'),
@@ -39,10 +40,12 @@ describe('with no VITE_POSTHOG_KEY', () => {
     const a = await loadAnalytics()
     a.capture('post_approved', { post_id: 1 })
     a.capturePageview()
+    a.captureException(new Error('nope'))
     a.identifyUser({ userId: 5 })
     a.resetAnalytics()
     await Promise.resolve()
     expect(ph.capture).not.toHaveBeenCalled()
+    expect(ph.captureException).not.toHaveBeenCalled()
     expect(ph.identify).not.toHaveBeenCalled()
     expect(ph.reset).not.toHaveBeenCalled()
   })
@@ -73,6 +76,26 @@ describe('with a key configured', () => {
     expect(config.capture_performance).toEqual({ web_vitals: true })
     expect(config.session_recording.maskAllInputs).toBe(true)
     expect(config.session_recording.maskTextSelector).toBe('[data-ph-mask]')
+  })
+
+  it('autocaptures unhandled exceptions but never console.error', async () => {
+    const a = await loadAnalytics('phc_test')
+    await a.initAnalytics()
+    const [, config] = ph.init.mock.calls[0]
+    expect(config.capture_exceptions).toEqual({
+      capture_unhandled_errors: true,
+      capture_unhandled_rejections: true,
+      capture_console_errors: false,
+    })
+  })
+
+  it('captures a caught error through captureException, not capture()', async () => {
+    const a = await loadAnalytics('phc_test')
+    const err = new Error('save failed')
+    a.captureException(err, { surface: 'account' })
+    await vi.waitFor(() => expect(ph.captureException).toHaveBeenCalled())
+    expect(ph.captureException).toHaveBeenCalledWith(err, { surface: 'account' })
+    expect(ph.capture).not.toHaveBeenCalled()
   })
 
   it('inits only once no matter how many callers ask', async () => {

--- a/src/cqc_lem/ui/src/utils/analytics.ts
+++ b/src/cqc_lem/ui/src/utils/analytics.ts
@@ -47,6 +47,14 @@ export function initAnalytics(): Promise<PostHog | null> {
         // Attribute values can carry content (a post title in aria-label, a draft in value).
         mask_all_element_attributes: true,
         capture_performance: { web_vitals: true },
+        // Error tracking (issue #648). Unhandled errors and rejections become grouped $exception
+        // issues; console.error stays OFF — it is noisy and routinely carries user content in the
+        // message, which the rest of this module goes out of its way to keep out of PostHog.
+        capture_exceptions: {
+          capture_unhandled_errors: true,
+          capture_unhandled_rejections: true,
+          capture_console_errors: false,
+        },
         // Replay is issue #650 (PH4). Session ids still resolve with it off, which is all the
         // feedback widget needs.
         disable_session_recording: true,
@@ -106,6 +114,13 @@ export function resetAnalytics(): void {
 
 export function capture(event: string, properties?: Record<string, unknown>): void {
   withClient((ph) => ph.capture(event, properties))
+}
+
+// A caught error worth an error-tracking issue (an API failure the user was shown, a render the
+// boundary rescued). Autocapture only sees what reaches window, so anything we catch needs this.
+// Never `capture('$exception', …)` — only captureException produces a groupable stack trace.
+export function captureException(error: unknown, properties?: Record<string, unknown>): void {
+  withClient((ph) => ph.captureException(error, properties))
 }
 
 export function capturePageview(): void {

--- a/src/cqc_lem/ui/vite.config.ts
+++ b/src/cqc_lem/ui/vite.config.ts
@@ -14,5 +14,8 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+    // Source maps exist only so PostHog error tracking (issue #648) can un-minify a stack trace.
+    // The image build uploads them and then DELETES every .map from dist, so they are never served.
+    sourcemap: true,
   },
 })

--- a/src/cqc_lem/utilities/logger.py
+++ b/src/cqc_lem/utilities/logger.py
@@ -103,6 +103,29 @@ if _posthog_handler is not None:
 
 _PRIMITIVE_TYPES = (bool, str, bytes, int, float)
 
+# Errors reach PostHog twice on purpose (issue #648): the log stream keeps the message for CONTEXT,
+# and the same exception is captured as a grouped $exception so alerting can move to issues. Off
+# with POSTHOG_EXCEPTION_CAPTURE=false.
+_CAPTURE_EXCEPTIONS = (os.getenv("POSTHOG_EXCEPTION_CAPTURE", "") or "").strip().lower() not in (
+    "0", "false", "no", "off")
+
+
+def _capture(exc: Optional[BaseException], message: str, level: str, context: dict) -> None:
+    """Forward a logged exception to PostHog Error Tracking. Imported lazily because
+    observability.py imports this module — and swallowing everything (including a caller's context
+    key colliding with a named argument), since a telemetry failure must never turn a logged error
+    into a raised one."""
+    if exc is None or not _CAPTURE_EXCEPTIONS:
+        return
+    try:
+        from cqc_lem.utilities.observability import capture_exception
+        props = dict(context)
+        props["log_message"] = message
+        props["log_level"] = level
+        capture_exception(exc, **props)
+    except Exception:
+        pass
+
 
 def _extra(**kwargs) -> dict:
     # Structured-log backends (PostHog/OTel) only accept primitive attribute values, so coerce
@@ -154,9 +177,11 @@ def log_error(
     exc: Optional[BaseException] = None,
     **context,
 ) -> None:
-    """Log at ERROR level. Pass exc= to capture exception info and stack trace."""
+    """Log at ERROR level. Pass exc= to capture exception info and stack trace, and to file the
+    exception as a grouped PostHog error-tracking issue."""
     if exc is not None:
         logger.error(message, exc_info=exc, extra=_extra(**context))
+        _capture(exc, message, "ERROR", _extra(**context))
     else:
         logger.error(message, extra=_extra(**context))
 
@@ -166,8 +191,10 @@ def log_critical(
     exc: Optional[BaseException] = None,
     **context,
 ) -> None:
-    """Log at CRITICAL level. Pass exc= to capture exception info and stack trace."""
+    """Log at CRITICAL level. Pass exc= to capture exception info and stack trace, and to file the
+    exception as a grouped PostHog error-tracking issue."""
     if exc is not None:
         logger.critical(message, exc_info=exc, extra=_extra(**context))
+        _capture(exc, message, "CRITICAL", _extra(**context))
     else:
         logger.critical(message, extra=_extra(**context))

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -28,6 +28,22 @@ if not posthog.api_key:
     posthog.disabled = True
 
 
+def _env_flag(name: str, default: bool = True) -> bool:
+    raw = (os.getenv(name) or "").strip().lower()
+    if not raw:
+        return default
+    return raw not in ("0", "false", "no", "off")
+
+
+# Error tracking (issue #648). posthog-python installs its own sys.excepthook / threading hook, so
+# an exception that kills a process is captured as a grouped $exception issue without any call site
+# knowing about it. It only ever fires for UNCAUGHT exceptions — everything LEM catches reaches
+# PostHog through capture_exception() below (from log_error/log_critical, the Celery signals and the
+# FastAPI middleware). Read at import so the flag is set before posthog.setup() builds the client.
+EXCEPTION_AUTOCAPTURE_ENABLED = bool(posthog.api_key) and _env_flag("POSTHOG_EXCEPTION_AUTOCAPTURE")
+posthog.enable_exception_autocapture = EXCEPTION_AUTOCAPTURE_ENABLED
+
+
 # Approximate USD cost per 1K tokens as (input, output), keyed by the model string passed to
 # track_llm_call — the tier alias (lem-*) in normal operation, or a raw model name. These are
 # coarse blended estimates for cost TREND analytics, not billing; override any entry with the
@@ -220,6 +236,41 @@ def current_llm_attribution() -> Tuple[Optional[int], Optional[str]]:
         user_id = user_id if user_id is not None else task_user_id
         feature = feature or feature_from_task_name(task_name)
     return user_id, feature
+
+
+# --- Error tracking (issue #648) -----------------------------------------------------------
+# PostHog groups $exception events into ISSUES by fingerprint, so the dedup the old log-grep cron
+# hand-rolled is done for us. Every capture below is best-effort: telemetry must never be the reason
+# a task or a request fails.
+
+def capture_exception(exc: Optional[BaseException] = None, user_id: Optional[int] = None,
+                      **context) -> None:
+    """Send one caught exception to PostHog Error Tracking with LEM's context on it.
+
+    `posthog.capture_exception` is idempotent per exception INSTANCE, so a task that logs
+    `log_error(exc=e)` and then re-raises produces ONE occurrence, not two — the Celery signal
+    handler capturing the same object is a no-op.
+
+    The task name/user default to the running Celery task's, so a call site that knows nothing about
+    its context still lands attributed. distinct_id follows the same convention as every other
+    event here: the user id, or the `"system"` sentinel."""
+    if posthog.disabled:
+        return
+    try:
+        task_name, task_user_id = _current_task_context()
+        properties = {k: v for k, v in context.items() if v is not None}
+        properties.setdefault("task_name", task_name)
+        if user_id is None:
+            user_id = task_user_id
+        properties["user_id"] = user_id
+        posthog.capture_exception(
+            exc,
+            distinct_id=str(user_id if user_id is not None else "system"),
+            properties={k: v for k, v in properties.items() if v is not None},
+        )
+    except Exception as e:
+        # A logger call here would recurse straight back into capture_exception via log_error.
+        log_warning(f"Could not capture exception in PostHog: {e}")
 
 
 def _model_tier(model: Optional[str]) -> Optional[str]:

--- a/tests/unit/api/test_error_capture_middleware.py
+++ b/tests/unit/api/test_error_capture_middleware.py
@@ -1,0 +1,63 @@
+"""Unit tests for the FastAPI unhandled-exception capture in the observability middleware
+(issue #648)."""
+
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def app_with_probe_routes():
+    """The real app plus two probe routes: one that raises an unhandled error, one that raises the
+    HTTPException a route uses for a normal 4xx."""
+    with patch("cqc_lem.utilities.observability.track_api_call"):
+        from cqc_lem.api.main import app
+
+        @app.get("/__probe_boom")
+        async def _boom():
+            raise RuntimeError("probe boom")
+
+        @app.get("/__probe_http_error")
+        async def _http_error():
+            raise HTTPException(status_code=404, detail="Not found")
+
+        yield app
+
+
+@pytest.fixture(scope="module")
+def client(app_with_probe_routes):
+    from fastapi.testclient import TestClient
+    with TestClient(app_with_probe_routes, raise_server_exceptions=False) as tc:
+        yield tc
+
+
+class TestUnhandledExceptionCapture:
+    def test_unhandled_route_error_is_captured_with_route_context(self, client):
+        with patch("cqc_lem.api.main.capture_exception") as mock_capture:
+            response = client.get("/__probe_boom")
+
+        assert response.status_code == 500
+        mock_capture.assert_called_once()
+        args, kwargs = mock_capture.call_args
+        assert isinstance(args[0], RuntimeError)
+        assert kwargs["route"] == "/__probe_boom"
+        assert kwargs["method"] == "GET"
+        assert kwargs["source"] == "fastapi.middleware"
+
+    def test_http_exception_is_not_captured(self, client):
+        """A 404/401 is a normal response, not an error-tracking issue — capturing it would drown
+        real crashes in expected 4xx noise."""
+        with patch("cqc_lem.api.main.capture_exception") as mock_capture:
+            response = client.get("/__probe_http_error")
+
+        assert response.status_code == 404
+        mock_capture.assert_not_called()
+
+    def test_healthy_request_is_not_captured(self, client):
+        with patch("cqc_lem.api.main.capture_exception") as mock_capture:
+            client.get("/health")
+
+        mock_capture.assert_not_called()

--- a/tests/unit/app/test_celery_error_signals.py
+++ b/tests/unit/app/test_celery_error_signals.py
@@ -1,0 +1,96 @@
+"""Unit tests for the Celery task_failure / task_retry error-tracking handlers (issue #648)."""
+
+import pytest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.app.my_celery"
+
+
+def _sender(name: str = "cqc_lem.app.run_automation.automate_commenting"):
+    return SimpleNamespace(name=name)
+
+
+class TestTaskFailure:
+    def test_captures_the_exception_with_task_and_user_context(self):
+        error = RuntimeError("selenium died")
+        with patch(f"{_MOD}.capture_exception") as mock_capture:
+            from cqc_lem.app.my_celery import on_task_failure
+            on_task_failure(task_id="abc-123", exception=error, sender=_sender(),
+                            kwargs={"user_id": 5})
+
+        mock_capture.assert_called_once()
+        args, kwargs = mock_capture.call_args
+        assert args[0] is error
+        assert kwargs["user_id"] == 5
+        assert kwargs["task_id"] == "abc-123"
+        assert kwargs["task_name"] == "cqc_lem.app.run_automation.automate_commenting"
+        assert kwargs["source"] == "celery.task_failure"
+
+    def test_system_task_without_a_user_still_files(self):
+        with patch(f"{_MOD}.capture_exception") as mock_capture:
+            from cqc_lem.app.my_celery import on_task_failure
+            on_task_failure(task_id="abc", exception=ValueError("x"), sender=_sender(), kwargs={})
+
+        assert mock_capture.call_args[1]["user_id"] is None
+
+    @pytest.mark.parametrize("kwargs", [None, {"user_id": None}, {"user_id": "not-an-int"}, "junk"])
+    def test_unusable_user_id_is_dropped_not_raised(self, kwargs):
+        with patch(f"{_MOD}.capture_exception") as mock_capture:
+            from cqc_lem.app.my_celery import on_task_failure
+            on_task_failure(task_id="abc", exception=ValueError("x"), sender=_sender(),
+                            kwargs=kwargs)
+
+        assert mock_capture.call_args[1]["user_id"] is None
+
+    def test_string_user_id_is_coerced(self):
+        with patch(f"{_MOD}.capture_exception") as mock_capture:
+            from cqc_lem.app.my_celery import on_task_failure
+            on_task_failure(task_id="abc", exception=ValueError("x"), sender=_sender(),
+                            kwargs={"user_id": "9"})
+
+        assert mock_capture.call_args[1]["user_id"] == 9
+
+
+class TestTaskRetry:
+    def test_captures_the_reason_when_it_is_an_exception(self):
+        reason = ConnectionError("429 from LinkedIn")
+        request = SimpleNamespace(id="req-1", kwargs={"user_id": 2}, retries=1)
+        with patch(f"{_MOD}.capture_exception") as mock_capture:
+            from cqc_lem.app.my_celery import on_task_retry
+            on_task_retry(request=request, reason=reason, sender=_sender())
+
+        args, kwargs = mock_capture.call_args
+        assert args[0] is reason
+        assert kwargs["user_id"] == 2
+        assert kwargs["task_id"] == "req-1"
+        assert kwargs["retries"] == 1
+        assert kwargs["source"] == "celery.task_retry"
+
+    @pytest.mark.parametrize("reason", [None, "rate limited", 42])
+    def test_non_exception_reason_files_nothing(self, reason):
+        with patch(f"{_MOD}.capture_exception") as mock_capture:
+            from cqc_lem.app.my_celery import on_task_retry
+            on_task_retry(request=SimpleNamespace(id="r", kwargs={}, retries=0), reason=reason,
+                          sender=_sender())
+
+        mock_capture.assert_not_called()
+
+    def test_missing_request_does_not_raise(self):
+        with patch(f"{_MOD}.capture_exception") as mock_capture:
+            from cqc_lem.app.my_celery import on_task_retry
+            on_task_retry(request=None, reason=ValueError("x"), sender=_sender())
+
+        assert mock_capture.call_args[1]["user_id"] is None
+
+
+class TestSignalsAreConnected:
+    def test_failure_and_retry_handlers_are_wired_to_celery(self):
+        from celery.signals import task_failure, task_retry
+        from cqc_lem.app.my_celery import on_task_failure, on_task_retry
+
+        # weak=False, so the receiver tuples hold the function itself rather than a weakref.
+        assert on_task_failure in [receiver for _, receiver in task_failure.receivers]
+        assert on_task_retry in [receiver for _, receiver in task_retry.receivers]

--- a/tests/unit/test_posthog_error_issues.py
+++ b/tests/unit/test_posthog_error_issues.py
@@ -1,0 +1,263 @@
+"""Unit tests for scripts/posthog_error_issues.py — the PostHog-issue -> GitHub-issue filer that
+replaces the log-grep cron (issue #648)."""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "posthog_error_issues.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("posthog_error_issues", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["posthog_error_issues"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _row(mod, issue_id="11111111-2222-3333-4444-555555555555", **overrides):
+    row = {"issue_id": issue_id, "name": "RuntimeError", "description": "selenium session died",
+           "status": "active", "first_seen": "2026-07-25T00:00:00Z",
+           "last_seen": "2026-07-26T00:00:00Z", "occurrences": 12, "users": 2,
+           "lib": "posthog-python", "task_name": "automate_commenting", "route": None}
+    row.update(overrides)
+    return row
+
+
+class TestBuildQuery:
+    def test_selects_the_error_tracking_columns_and_window(self, mod):
+        sql = mod.build_query(hours=6, min_occurrences=3)
+        assert "event = '$exception'" in sql
+        assert "INTERVAL 6 HOUR" in sql
+        assert "GROUP BY issue_id" in sql
+        assert "HAVING occurrences >= 3" in sql
+
+    def test_clamps_nonsense_inputs(self, mod):
+        sql = mod.build_query(hours=0, min_occurrences=0)
+        assert "INTERVAL 24 HOUR" in sql
+        assert "HAVING occurrences >= 1" in sql
+
+
+class TestParseRows:
+    def test_zips_columns_onto_rows(self, mod):
+        rows = mod.parse_rows([["id-1", "RuntimeError", "boom", "active", "t0", "t1", 3, 1,
+                               "posthog-python", "automate_commenting", None]])
+        assert rows[0]["issue_id"] == "id-1"
+        assert rows[0]["name"] == "RuntimeError"
+        assert rows[0]["occurrences"] == 3
+
+    def test_drops_rows_without_an_issue_id(self, mod):
+        assert mod.parse_rows([["", "RuntimeError"], [None, "x"]]) == []
+
+    def test_tolerates_short_rows_and_garbage(self, mod):
+        rows = mod.parse_rows([["id-1", "RuntimeError"], "not-a-row", None])
+        assert len(rows) == 1
+        assert rows[0]["occurrences"] is None
+
+    def test_handles_no_results(self, mod):
+        assert mod.parse_rows(None) == []
+
+
+class TestActionability:
+    @pytest.mark.parametrize("status", ["active", "ACTIVE", "", None])
+    def test_active_issues_are_filed(self, mod, status):
+        assert mod.is_actionable(_row(mod, status=status)) is True
+
+    @pytest.mark.parametrize("status", ["resolved", "suppressed", "archived", "pending_release"])
+    def test_triaged_issues_are_left_alone(self, mod, status):
+        assert mod.is_actionable(_row(mod, status=status)) is False
+
+
+class TestTitleAndBody:
+    def test_title_is_conventional_commit_shaped_with_the_count(self, mod):
+        title = mod.build_title(_row(mod))
+        assert title.startswith("fix(errors): RuntimeError: selenium session died")
+        assert title.endswith("(12x)")
+
+    def test_title_is_truncated_but_keeps_the_count(self, mod):
+        title = mod.build_title(_row(mod, description="x" * 400))
+        assert len(title) <= mod.MAX_TITLE_CHARS
+        assert title.endswith("(12x)")
+
+    def test_title_survives_a_nameless_issue(self, mod):
+        assert "Unknown exception" in mod.build_title(_row(mod, name=None, description=None))
+
+    def test_body_carries_the_marker_context_and_posthog_link(self, mod):
+        row = _row(mod)
+        body = mod.build_body(row, hours=24, project_id="475262")
+        assert mod.marker(row["issue_id"]) in body
+        assert "automate_commenting" in body
+        assert "error_tracking/" + row["issue_id"] in body
+        assert "## Acceptance" in body
+
+    def test_body_omits_context_it_does_not_have(self, mod):
+        body = mod.build_body(_row(mod, task_name=None, route=None, lib=None))
+        assert "Celery task:" not in body
+        assert "API route:" not in body
+
+
+class TestPlanActions:
+    def test_files_one_issue_per_unfiled_active_issue(self, mod):
+        rows = [_row(mod, issue_id="a"), _row(mod, issue_id="b")]
+        actions = mod.plan_actions(rows, filed_markers=set())
+        assert [a["action"] for a in actions] == ["create", "create"]
+
+    def test_an_already_filed_issue_is_never_filed_twice(self, mod):
+        rows = [_row(mod, issue_id="a")]
+        actions = mod.plan_actions(rows, filed_markers={mod.marker("a")})
+        assert actions[0]["action"] == "skip"
+        assert actions[0]["reason"] == "already filed"
+        assert mod.pending(actions) == []
+
+    def test_resolved_issues_are_skipped(self, mod):
+        actions = mod.plan_actions([_row(mod, issue_id="a", status="resolved")], set())
+        assert actions[0]["action"] == "skip"
+        assert actions[0]["reason"] == "not active"
+
+    def test_max_new_defers_the_rest(self, mod):
+        rows = [_row(mod, issue_id=str(i)) for i in range(5)]
+        actions = mod.plan_actions(rows, set(), max_new=2)
+        assert [a["action"] for a in actions] == ["create", "create", "deferred", "deferred",
+                                                  "deferred"]
+
+    def test_duplicate_ids_in_one_batch_file_once(self, mod):
+        rows = [_row(mod, issue_id="a"), _row(mod, issue_id="a")]
+        assert len(mod.pending(mod.plan_actions(rows, set()))) == 1
+
+    def test_summarize_counts_the_outcomes(self, mod):
+        actions = mod.plan_actions([_row(mod, issue_id="a"),
+                                    _row(mod, issue_id="b", status="resolved")], set())
+        assert "1 create" in mod.summarize(actions)
+        assert "1 skip" in mod.summarize(actions)
+
+    def test_summarize_on_an_empty_window(self, mod):
+        assert "no error-tracking issues" in mod.summarize([])
+
+
+class TestGitHubIssues:
+    def _completed(self, stdout="", returncode=0, stderr=""):
+        return SimpleNamespace(stdout=stdout, returncode=returncode, stderr=stderr)
+
+    def test_is_filed_requires_the_literal_marker_in_the_body(self, mod):
+        gh = mod.GitHubIssues("owner/repo")
+        # GitHub's tokenized search can return a NEIGHBOURING issue; it must not count as filed.
+        with patch.object(gh, "_run", return_value=self._completed(
+                '[{"number": 4, "body": "posthog-issue-someone-else"}]')):
+            assert gh.is_filed("posthog-issue-a") is False
+
+        with patch.object(gh, "_run", return_value=self._completed(
+                '[{"number": 4, "body": "marker: posthog-issue-a here"}]')):
+            assert gh.is_filed("posthog-issue-a") is True
+
+    def test_is_filed_raises_when_the_search_fails(self, mod):
+        gh = mod.GitHubIssues("owner/repo")
+        with patch.object(gh, "_run", return_value=self._completed(returncode=1, stderr="401")):
+            with pytest.raises(RuntimeError):
+                gh.is_filed("posthog-issue-a")
+
+    def test_is_filed_raises_on_unparseable_output(self, mod):
+        gh = mod.GitHubIssues("owner/repo")
+        with patch.object(gh, "_run", return_value=self._completed("not json")):
+            with pytest.raises(RuntimeError):
+                gh.is_filed("posthog-issue-a")
+
+    def test_create_returns_the_issue_url(self, mod):
+        gh = mod.GitHubIssues("owner/repo")
+        with patch.object(gh, "_run", return_value=self._completed(
+                "https://github.com/owner/repo/issues/9\n")) as run:
+            assert gh.create("t", "b") == "https://github.com/owner/repo/issues/9"
+        args = run.call_args[0][0]
+        assert "--label" in args and "agent:ready" in args and "bug" in args
+
+    def test_create_returns_none_when_gh_fails(self, mod):
+        gh = mod.GitHubIssues("owner/repo")
+        with patch.object(gh, "_run", return_value=self._completed(returncode=1, stderr="boom")):
+            assert gh.create("t", "b") is None
+
+
+class TestApplyActions:
+    def test_dry_run_files_nothing(self, mod):
+        gh = MagicMock()
+        actions = mod.plan_actions([_row(mod, issue_id="a")], set())
+        actions[0]["body"] = "body"
+        mod.apply_actions(gh, actions, dry_run=True)
+        gh.create.assert_not_called()
+
+    def test_apply_files_each_pending_issue(self, mod):
+        gh = MagicMock()
+        gh.create.return_value = "https://github.com/o/r/issues/1"
+        actions = mod.plan_actions([_row(mod, issue_id="a")], set())
+        actions[0]["body"] = "body"
+        applied = mod.apply_actions(gh, actions, dry_run=False)
+        assert len(applied) == 1
+        gh.create.assert_called_once()
+
+    def test_a_failed_create_is_not_counted_as_applied(self, mod):
+        gh = MagicMock()
+        gh.create.return_value = None
+        actions = mod.plan_actions([_row(mod, issue_id="a")], set())
+        actions[0]["body"] = "body"
+        assert mod.apply_actions(gh, actions, dry_run=False) == []
+
+
+class TestMain:
+    def test_print_sql_needs_no_network(self, mod, capsys):
+        assert mod.main(["--print-sql"]) == 0
+        assert "$exception" in capsys.readouterr().out
+
+    def test_missing_api_key_is_an_error(self, mod, monkeypatch):
+        monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+        assert mod.main([]) == 1
+
+    def test_dry_run_reports_pending_with_exit_2(self, mod, monkeypatch):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        with patch.object(mod.PostHogQueryClient, "query",
+                          return_value=[["a", "RuntimeError", "boom", "active", "t0", "t1", 3, 1,
+                                         "posthog-python", "automate_commenting", None]]), \
+             patch.object(mod.GitHubIssues, "is_filed", return_value=False), \
+             patch.object(mod.GitHubIssues, "create") as create:
+            assert mod.main([]) == 2
+        create.assert_not_called()
+
+    def test_apply_files_and_exits_zero(self, mod, monkeypatch):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        with patch.object(mod.PostHogQueryClient, "query",
+                          return_value=[["a", "RuntimeError", "boom", "active", "t0", "t1", 3, 1,
+                                         "posthog-python", "automate_commenting", None]]), \
+             patch.object(mod.GitHubIssues, "is_filed", return_value=False), \
+             patch.object(mod.GitHubIssues, "create",
+                          return_value="https://github.com/o/r/issues/1") as create:
+            assert mod.main(["--apply"]) == 0
+        create.assert_called_once()
+
+    def test_nothing_pending_exits_zero(self, mod, monkeypatch):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        with patch.object(mod.PostHogQueryClient, "query", return_value=[]), \
+             patch.object(mod.GitHubIssues, "create") as create:
+            assert mod.main([]) == 0
+        create.assert_not_called()
+
+    def test_a_posthog_failure_exits_one_without_filing(self, mod, monkeypatch):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        with patch.object(mod.PostHogQueryClient, "query", side_effect=RuntimeError("500")), \
+             patch.object(mod.GitHubIssues, "create") as create:
+            assert mod.main(["--apply"]) == 1
+        create.assert_not_called()
+
+    def test_a_github_lookup_failure_exits_one_without_filing(self, mod, monkeypatch):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        with patch.object(mod.PostHogQueryClient, "query",
+                          return_value=[["a", "RuntimeError", "boom", "active", "t0", "t1", 3, 1,
+                                         "posthog-python", None, None]]), \
+             patch.object(mod.GitHubIssues, "is_filed", side_effect=RuntimeError("gh down")), \
+             patch.object(mod.GitHubIssues, "create") as create:
+            assert mod.main(["--apply"]) == 1
+        create.assert_not_called()

--- a/tests/unit/utilities/test_error_tracking.py
+++ b/tests/unit/utilities/test_error_tracking.py
@@ -1,0 +1,152 @@
+"""Unit tests for PostHog error tracking — capture_exception + the log_error/log_critical
+forwarding (issue #648)."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_OBS = "cqc_lem.utilities.observability"
+_LOG = "cqc_lem.utilities.logger"
+
+
+class TestCaptureException:
+    def test_sends_exception_with_context_and_system_distinct_id(self):
+        error = ValueError("boom")
+        with patch(f"{_OBS}.posthog") as mock_ph, \
+             patch(f"{_OBS}._current_task_context", return_value=(None, None)):
+            mock_ph.disabled = False
+            from cqc_lem.utilities.observability import capture_exception
+            capture_exception(error, task_name="automate_commenting", source="unit")
+
+        mock_ph.capture_exception.assert_called_once()
+        args, kwargs = mock_ph.capture_exception.call_args
+        assert args[0] is error
+        assert kwargs["distinct_id"] == "system"
+        assert kwargs["properties"]["task_name"] == "automate_commenting"
+        assert kwargs["properties"]["source"] == "unit"
+
+    def test_user_id_becomes_the_distinct_id(self):
+        with patch(f"{_OBS}.posthog") as mock_ph, \
+             patch(f"{_OBS}._current_task_context", return_value=(None, None)):
+            mock_ph.disabled = False
+            from cqc_lem.utilities.observability import capture_exception
+            capture_exception(ValueError("boom"), user_id=42)
+
+        _, kwargs = mock_ph.capture_exception.call_args
+        assert kwargs["distinct_id"] == "42"
+        assert kwargs["properties"]["user_id"] == 42
+
+    def test_falls_back_to_the_running_celery_task_context(self):
+        with patch(f"{_OBS}.posthog") as mock_ph, \
+             patch(f"{_OBS}._current_task_context", return_value=("auto_check_scheduled_posts", 7)):
+            mock_ph.disabled = False
+            from cqc_lem.utilities.observability import capture_exception
+            capture_exception(ValueError("boom"))
+
+        _, kwargs = mock_ph.capture_exception.call_args
+        assert kwargs["distinct_id"] == "7"
+        assert kwargs["properties"]["task_name"] == "auto_check_scheduled_posts"
+
+    def test_explicit_context_beats_the_ambient_task(self):
+        with patch(f"{_OBS}.posthog") as mock_ph, \
+             patch(f"{_OBS}._current_task_context", return_value=("ambient_task", 7)):
+            mock_ph.disabled = False
+            from cqc_lem.utilities.observability import capture_exception
+            capture_exception(ValueError("boom"), user_id=1, task_name="explicit_task")
+
+        _, kwargs = mock_ph.capture_exception.call_args
+        assert kwargs["distinct_id"] == "1"
+        assert kwargs["properties"]["task_name"] == "explicit_task"
+
+    def test_none_context_values_are_dropped(self):
+        with patch(f"{_OBS}.posthog") as mock_ph, \
+             patch(f"{_OBS}._current_task_context", return_value=(None, None)):
+            mock_ph.disabled = False
+            from cqc_lem.utilities.observability import capture_exception
+            capture_exception(ValueError("boom"), route=None, post_id=5)
+
+        _, kwargs = mock_ph.capture_exception.call_args
+        assert "route" not in kwargs["properties"]
+        assert "task_name" not in kwargs["properties"]
+        assert kwargs["properties"]["post_id"] == 5
+
+    def test_no_op_when_posthog_is_disabled(self):
+        with patch(f"{_OBS}.posthog") as mock_ph:
+            mock_ph.disabled = True
+            from cqc_lem.utilities.observability import capture_exception
+            capture_exception(ValueError("boom"))
+
+        mock_ph.capture_exception.assert_not_called()
+
+    def test_never_raises_when_posthog_fails(self):
+        with patch(f"{_OBS}.posthog") as mock_ph, \
+             patch(f"{_OBS}._current_task_context", return_value=(None, None)), \
+             patch(f"{_OBS}.log_warning") as mock_warn:
+            mock_ph.disabled = False
+            mock_ph.capture_exception.side_effect = RuntimeError("posthog down")
+            from cqc_lem.utilities.observability import capture_exception
+            capture_exception(ValueError("boom"))
+
+        mock_warn.assert_called_once()
+
+
+class TestLoggerForwarding:
+    def test_log_error_with_exc_files_an_issue(self):
+        error = ValueError("boom")
+        with patch(f"{_OBS}.capture_exception") as mock_capture:
+            from cqc_lem.utilities.logger import log_error
+            log_error("Automation task failed", exc=error, user_id=3,
+                      task_name="automate_commenting")
+
+        mock_capture.assert_called_once()
+        args, kwargs = mock_capture.call_args
+        assert args[0] is error
+        assert kwargs["user_id"] == 3
+        assert kwargs["task_name"] == "automate_commenting"
+        assert kwargs["log_level"] == "ERROR"
+        assert kwargs["log_message"] == "Automation task failed"
+
+    def test_log_critical_with_exc_files_an_issue(self):
+        with patch(f"{_OBS}.capture_exception") as mock_capture:
+            from cqc_lem.utilities.logger import log_critical
+            log_critical("Suppression tripwire", exc=RuntimeError("nope"))
+
+        assert mock_capture.call_args[1]["log_level"] == "CRITICAL"
+
+    def test_log_error_without_exc_files_nothing(self):
+        with patch(f"{_OBS}.capture_exception") as mock_capture:
+            from cqc_lem.utilities.logger import log_error
+            log_error("Something went wrong", user_id=3)
+
+        mock_capture.assert_not_called()
+
+    def test_log_warning_never_files(self):
+        with patch(f"{_OBS}.capture_exception") as mock_capture:
+            from cqc_lem.utilities.logger import log_warning
+            log_warning("Perplexity unavailable", exc=RuntimeError("timeout"))
+
+        mock_capture.assert_not_called()
+
+    def test_non_primitive_context_is_coerced_before_capture(self):
+        element = MagicMock()
+        with patch(f"{_OBS}.capture_exception") as mock_capture:
+            from cqc_lem.utilities.logger import log_error
+            log_error("Selenium failed", exc=RuntimeError("stale"), element=element)
+
+        assert isinstance(mock_capture.call_args[1]["element"], str)
+
+    def test_capture_failure_never_breaks_logging(self):
+        with patch(f"{_OBS}.capture_exception", side_effect=RuntimeError("posthog down")):
+            from cqc_lem.utilities.logger import log_error
+            log_error("Automation task failed", exc=ValueError("boom"))
+
+    def test_kill_switch_stops_forwarding(self):
+        # POSTHOG_EXCEPTION_CAPTURE=false resolves to this flag at import; patching it exercises the
+        # same branch without reloading the module (which would re-add every log handler).
+        with patch(f"{_LOG}._CAPTURE_EXCEPTIONS", False), \
+             patch(f"{_OBS}.capture_exception") as mock_capture:
+            from cqc_lem.utilities.logger import log_error
+            log_error("Automation task failed", exc=ValueError("boom"))
+
+        mock_capture.assert_not_called()


### PR DESCRIPTION
## What & why

Errors only ever reached PostHog as **log lines**, and the daily `~/error-to-issues` cron grepped those logs, grouped them by the exact message string and hashed it into a dedup marker. Any error whose message carries an id — `Post 41 failed to post` — therefore filed a brand-new GitHub issue every single day, and nothing grouped, counted or alerted.

PostHog Error Tracking already groups `$exception` events into **issues** by fingerprint. The issue IS the dedup key, so the homegrown layer collapses into "one PostHog issue id ↔ one GitHub issue".

### Capture

| Surface | How |
|---|---|
| Any Python process | `posthog.enable_exception_autocapture` (`utilities/observability.py`) — uncaught exceptions |
| Anything logged with `exc=` | `log_error`/`log_critical` also call `capture_exception`; the log stream is unchanged and still carries the message + structured context |
| Celery | `task_failure` + `task_retry` handlers in `my_celery.py` with `task_name`, `task_id`, dispatched `user_id` |
| FastAPI | the unhandled branch of `observability_middleware` with `route` + `method` |
| SPA | `posthog-js` `capture_exceptions` (unhandled errors + rejections) and a `captureException()` helper on the one analytics surface |

Two deliberate exclusions: a route's own `HTTPException` is turned into a response before the middleware sees it, so **a 4xx never files an issue**; and browser **`console.error` capture stays off** — it is noisy and routinely carries the user's own content.

No double counting: `posthog.capture_exception` is idempotent per exception *instance*, so a task that does `log_error(..., exc=e)` and re-raises produces ONE occurrence, not one per layer. Both paths have kill switches (`POSTHOG_EXCEPTION_AUTOCAPTURE`, `POSTHOG_EXCEPTION_CAPTURE`), and with no `POSTHOG_API_KEY` nothing is sent at all.

### Readable stacks

`vite.config.ts` emits source maps and the **ui-builder stage** of the image runs `posthog-cli sourcemap inject` + `upload`. It has to be there rather than in a separate CI job: `inject` writes chunk ids INTO the bundle, and the injected bundle is the one that must ship or an uploaded map can never be matched. Every `.map` is deleted from `dist/` afterwards, so source maps are never served — including on builds that skip the upload. Missing token or failed upload = minified stacks, never a failed release.

### Cron migration

`scripts/posthog_error_issues.py` (cron wrapper `scripts/error_to_issues.sh`) reads the error-tracking columns off `events`, groups by `issue_id`, and files ONE `agent:ready`+`bug` issue per **active** PostHog issue with no GitHub issue yet — body shaped for `MODE=start`, with a link to the PostHog issue for the stack trace.

- Dedup marker is `posthog-issue-<issue_id>`, searched across **open AND closed** issues (a fixed exception that trickles in for one more day must not reopen the ticket), and the returned bodies are re-checked for the literal marker because GitHub's search tokenizes on hyphens.
- **Fail closed**: if the GitHub search itself fails, the run aborts rather than reading "cannot read" as "nothing filed" and duplicating the whole window.
- Resolved/suppressed PostHog issues are never filed; `--max-new` (default 10) caps a bad deploy at 10 tickets per run.

### Scope notes

- **Alerts are PostHog UI configuration**, not code — new-issue/reopened notification + spike detection, documented in `docs/error-tracking.md` and listed in `Needs_From_Chris.md` along with the cron switch and the `POSTHOG_CLI_TOKEN` secret. Each is independently optional; skipping one costs only that one thing.
- The source-map upload landed in the **release** build (`build-and-push.yml` → Dockerfile) rather than `ui-build.yml`, which only runs on PRs — uploading PR builds to PostHog would be wrong, and the shipped bundle is the one that needs matching maps.

## Testing

- `tests/unit/utilities/test_error_tracking.py` — capture context/attribution/distinct_id, disabled path, never-raises, logger forwarding + the kill switch (14 tests)
- `tests/unit/app/test_celery_error_signals.py` — failure/retry handlers, user-id coercion, non-exception retry reasons, signals actually connected (13)
- `tests/unit/api/test_error_capture_middleware.py` — 500 captured with route context, `HTTPException` and healthy requests not captured (3)
- `tests/unit/test_posthog_error_issues.py` — query, parsing, planning, marker dedup, `gh` I/O and every `main()` exit code (41)
- SPA: `analytics.test.ts` covers the `capture_exceptions` config and `captureException`
- `poetry run pytest tests/unit -q` → **6628 passed**; `tsc -b` clean; the HogQL was executed against the live project to confirm the columns and aggregate syntax parse.

Closes #648

🤖 Generated with [Claude Code](https://claude.com/claude-code)
