### PR TITLE
feat(observability): KPI funnels, consolidated dashboards, threshold alerts + weekly report (closes #650)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -460,6 +460,10 @@ POSTHOG_PERSONAL_API_KEY=
 # PostHog project the dashboards live in, and the app host used to build their links.
 POSTHOG_PROJECT_ID=475262
 POSTHOG_APP_HOST=https://us.posthog.com
+# Recipient of the weekly LEM Growth dashboard email provisioned by scripts/posthog_provision.py
+# (issue #650, docs/kpi-dashboards.md) — the automated replacement for the hand-run perf report.
+# Unset falls back to the personal API key owner's own email.
+POSTHOG_REPORT_EMAIL=
 # --- PostHog in the SPA (issue #646) ---
 # Read by Vite at BUILD time and baked into the bundle, so they must be set for `npm run build`
 # (docker build-arg / CI env), not in the running container. Leave VITE_POSTHOG_KEY empty and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,25 @@ Every report links its recording: `session_replay_url()` in `observability.py` t
 uuid-ish, or a missing `POSTHOG_PROJECT_ID`, omits the line rather than guessing a URL. Full posture
 (who is recorded, what is masked, how to verify): `docs/session-replay.md`.
 
+### KPI funnels, dashboards, alerts + weekly report (issue #650)
+
+`scripts/posthog_provision.py` is the ONE place the business-KPI surface is defined — two
+consolidated dashboards (**LEM Health**: task failures, 429 trips, LLM spend/day, posts/day,
+follower delta, API errors · **LEM Growth**: the content-loop and signup→subscription funnels,
+onboarding drop-off, the comment→reply loop, ER/audience trends), four threshold alerts, and one
+weekly email subscription of Growth that replaces the hand-run perf-report cron. `--dry-run`
+(default) diffs, `--apply` converges, `--simulate 'NAME=VALUE'` proves an alert's threshold without
+waiting for a real breach. Details: `docs/kpi-dashboards.md`.
+
+It sits ON TOP of the cost/margin set (`scripts/posthog_dashboards.py`), which it does not replace.
+Both plan by insight NAME against the same project, so **insight names must stay unique across the
+two scripts** — a unit test fails the build if they collide. Alert-bearing tiles must stay native
+single-series `TrendsQuery` insights (a threshold is evaluated against one `series_index`), and they filter on STRING
+properties (`celery_task.state = 'FAILURE'`) rather than booleans: a boolean filter that matches
+nothing yields an alert that never fires. Money tiles read `$ai_generation`, never `llm_call`.
+`mark_rate_limited()` emits `rate_limit_trip` (issue #650) because the breaker's WARNING log never
+reaches PostHog at the default `POSTHOG_LOG_LEVEL`.
+
 ## CI Gates
 
 Before merging any PR, all of the following must pass:

--- a/docs/kpi-dashboards.md
+++ b/docs/kpi-dashboards.md
@@ -1,0 +1,125 @@
+# KPI funnels, dashboards, alerts and the weekly report (issue #650)
+
+LEM's PostHog project had 41 insights across 6 dashboards and still could not answer two questions:
+*do the business loops close?* and *did something break overnight?* Everything was a point metric,
+every watchdog was a hand-run cron, and the 2-week perf report was a human remembering to run it.
+
+`scripts/posthog_provision.py` defines the answer as code: two consolidated dashboards, the funnels
+over LEM's actual loops, four threshold alerts and one weekly email. Re-running it re-creates
+anything edited away in the UI, and does nothing at all when the project already matches.
+
+```bash
+# what would change (default; no writes)
+poetry run python scripts/posthog_provision.py --dry-run
+# create/update dashboards, insights, alerts and the weekly subscription
+poetry run python scripts/posthog_provision.py --apply
+# every tile's query, no network
+poetry run python scripts/posthog_provision.py --print-sql
+# would this reading page someone?
+poetry run python scripts/posthog_provision.py --simulate 'LEM — LinkedIn 429 spike=9'
+```
+
+Exit codes: `0` in sync / applied, `2` changes pending (dry run), `1` error.
+
+Env: `POSTHOG_PERSONAL_API_KEY` (scopes: `insight`, `dashboard`, `alert` and `subscription`
+read+write, plus `user:read` so alerts get a subscriber), `POSTHOG_PROJECT_ID`,
+`POSTHOG_APP_HOST`, `POSTHOG_REPORT_EMAIL` (weekly recipient; falls back to the key owner's email,
+overridable with `--email`).
+
+## The two dashboards
+
+**LEM Health** — is LEM running, and what is it costing? Celery failure count and rate, failing
+tasks by name, LinkedIn 429 breaker trips, LLM spend per day, posts published per day, follower
+delta and API error rate. The four alerts page off this dashboard's tiles.
+
+**LEM Growth** — do the loops close? The content-loop and signup→subscription funnels, onboarding
+step drop-off, the comment→reply engagement loop, comment visibility, engagement rate and audience
+growth. This is the dashboard that gets emailed weekly.
+
+These sit ON TOP of the existing cost/margin set (`scripts/posthog_dashboards.py`) rather than
+replacing it — Health/Growth is where you look first, Cost Explorer / Margin by Cohort / Engagement
+Lift / Unit-Economics Scorecard are the drill-downs. Both scripts plan by insight NAME against the
+same project, so **every insight name must stay unique across the two**; a unit test fails the build
+if they ever collide.
+
+## Funnels
+
+| Funnel | Steps | Window |
+|---|---|---|
+| Content loop | `content_plan_generated` → `post_approved` → `post_outcome` | 45 days |
+| Signup → subscription | `signup_started` → `signup_completed` → `trial_started` → `onboarding_step_completed` → `activated` → `subscription_started` | 30 days |
+
+The conversion windows are deliberately long: a content plan is 30 days of scheduled posts, so a
+plan → approve → posted → engaged chain spans weeks, not a session. The signup funnel joins across
+the pre-account boundary because `track_funnel_event` aliases the pseudonymous `signup_started`
+person onto the real user id.
+
+The **engagement loop** (comment → author reply → connection accepted → DM reply) is a HogQL
+conversion tile rather than a funnel: only the first two steps are instrumented today
+(`comment_outcome`, issue #628). Connection-accepted and DM-reply join it when that instrumentation
+lands — as steps, not as a rewrite.
+
+## Alerts
+
+Four of PostHog's five free alerts. Thresholds live in the script (not in env) so the value that
+pages someone is reviewable in a diff; change one and re-run `--apply`.
+
+| Alert | Reads | Fires when |
+|---|---|---|
+| comments per week below floor | `comment_outcome`, weekly | < `COMMENT_WEEKLY_FLOOR` (5) in a week |
+| LLM spend per day over cap | `$ai_generation.$ai_total_cost_usd`, daily | > `LLM_DAILY_COST_CAP_USD` ($15) |
+| Celery failure spike | `celery_task` where `state = FAILURE`, daily | > `CELERY_FAILURES_PER_DAY_CEILING` (25) |
+| LinkedIn 429 spike | `rate_limit_trip`, daily | > `RATE_LIMIT_TRIPS_PER_DAY_CEILING` (5) |
+
+Three details that are not arbitrary:
+
+- **Alert insights are native single-series trends queries.** PostHog can alert on trends, funnel
+  and SQL insights, but the threshold is evaluated against ONE series by index — a breakdown or a
+  second series makes `series_index: 0` ambiguous. The HogQL tiles beside them are for reading, not
+  paging.
+- **The comment floor is weekly, not daily.** Human pacing takes account-wide rest days (issue
+  #626); a daily floor would page on a perfectly healthy zero-comment day.
+- **The Celery filter is on `state` (a string), not `success` (a boolean).** A boolean property
+  filter that silently matches nothing produces an alert that never fires, which is worse than no
+  alert at all.
+
+`--simulate 'NAME=VALUE'` runs the same comparison PostHog runs server-side, so a breach can be
+proven without waiting for one. A non-numeric/missing reading is deliberately NOT a breach: an
+ingest gap is not an incident.
+
+### The 429 signal
+
+The breaker's trip only ever produced a WARNING log, and PostHog forwards `ERROR` and up by default
+— so the one event that says *LinkedIn is throttling us* was invisible to both dashboards and
+alerts. `mark_rate_limited()` now also emits `rate_limit_trip` (`cooldown_seconds`,
+`consecutive_trips`, `reason`) via `observability.track_rate_limit_trip`. It is system-scoped:
+LinkedIn rate-limits by egress IP, so a trip is an account-wide condition, never one user's. It
+never raises — the breaker must open even when analytics is down.
+
+## The weekly report
+
+One PostHog dashboard subscription emails **LEM Growth** every Monday 09:00 UTC. That is what
+replaces the hand-run perf-report cadence — no cron, no box, no one remembering.
+
+Subscriptions are matched on (dashboard, recipient, frequency) and explicitly **not** on
+`start_date`: PostHog advances that with every send, so diffing it would recreate the subscription
+on every run and mail the owner a duplicate each time.
+
+PostHog renders at most **6 tiles** into a subscription email (`MAX_ASSET_COUNT`), so Growth's tile
+order is the email's priority order — the funnels and the engagement loop come first, audience
+growth is the one that falls off the bottom. Free plans allow 5 subscriptions total; this uses one.
+
+## What renders empty, and why that's fine
+
+Several tiles read events that exist in code but have not flowed into this project yet
+(`comment_outcome`, `audience_snapshot`, the funnel events, and the SPA's `post_approved` /
+`content_plan_generated`). They resolve empty until those land — the same deliberate behaviour the
+cost/margin dashboards have. **The alerts are the exception**: a floor alert on an event that never
+arrives reads 0 and pages. Run `--apply` once the events are actually flowing, or expect the
+comments-floor alert to fire on its first evaluation.
+
+## Which LLM cost number
+
+`$ai_generation` (the proxy's own `response_cost`) — never `llm_call`, and never both summed. See
+`docs/llm-analytics.md` for the split: `llm_call` is LEM's estimate keyed by the tier alias asked
+for, `$ai_generation` is what actually served it. A unit test asserts no tile here reads `llm_call`.

--- a/docs/kpi-dashboards.md
+++ b/docs/kpi-dashboards.md
@@ -83,6 +83,11 @@ Three details that are not arbitrary:
   filter that silently matches nothing produces an alert that never fires, which is worse than no
   alert at all.
 
+Alerts are diffed on bounds, insight, enabled state **and subscribers**. An alert created by a run
+whose key lacked `user:read` has an empty `subscribed_users` and therefore emails nobody; matching
+on bounds alone would call that alert healthy forever, so a later run that can name the owner
+repairs it (adding to, never replacing, whoever is already subscribed).
+
 `--simulate 'NAME=VALUE'` runs the same comparison PostHog runs server-side, so a breach can be
 proven without waiting for one. A non-numeric/missing reading is deliberately NOT a breach: an
 ingest gap is not an incident.

--- a/scripts/posthog_provision.py
+++ b/scripts/posthog_provision.py
@@ -259,7 +259,7 @@ ORDER BY day ASC
             "user's FIRST reading has no previous day and is dropped — counting it would draw the "
             "whole existing audience as one day's growth.",
             _hogql(f"""
-SELECT day, sum(followers - prev) AS follower_delta, sum(followers) AS followers
+SELECT day, sum(followers - prev) AS follower_delta, sum(followers) AS total_followers
 FROM (
     SELECT day, user_key, followers,
            lagInFrame(followers) OVER (PARTITION BY user_key ORDER BY day
@@ -522,8 +522,14 @@ def plan_alerts(specs: list, existing_alerts: dict, insight_ids: dict,
                 subscribed_users: Optional[list] = None) -> list:
     """Diff the alert spec. An alert whose insight does not exist yet is `blocked` rather than
     created — PostHog needs the insight id, and reporting it as creatable would make a dry-run lie
-    about what a follow-up `--apply` can do in one pass."""
+    about what a follow-up `--apply` can do in one pass.
+
+    Subscribers are part of the diff: an alert PostHog created with an empty `subscribed_users`
+    (the key lacked `user:read` on the run that made it) emails nobody, and matching only on bounds
+    would call that alert healthy forever. A run that DOES know the owner repairs it. A run that
+    does not (`subscribed_users` empty) never reports drift it couldn't fix."""
     actions: list = []
+    wanted_subscribers = set(subscribed_users or [])
     for spec in specs:
         insight_id = insight_ids.get(spec["insight"])
         found = existing_alerts.get(spec["name"])
@@ -531,16 +537,23 @@ def plan_alerts(specs: list, existing_alerts: dict, insight_ids: dict,
             actions.append({"action": "blocked_alert", "alert": spec["name"],
                             "reason": f"insight '{spec['insight']}' does not exist yet"})
             continue
-        payload = alert_payload(spec, insight_id, subscribed_users)
         if found is None:
-            actions.append({"action": "create_alert", "alert": spec["name"], "payload": payload})
-        elif (found.get("bounds") == spec["bounds"] and found.get("insight_id") == insight_id
-                and found.get("enabled", True)):
+            actions.append({"action": "create_alert", "alert": spec["name"],
+                            "payload": alert_payload(spec, insight_id, subscribed_users)})
+            continue
+        current_subscribers = set(found.get("subscribed_users") or [])
+        if (found.get("bounds") == spec["bounds"] and found.get("insight_id") == insight_id
+                and found.get("enabled", True)
+                and wanted_subscribers <= current_subscribers):
             actions.append({"action": "unchanged_alert", "alert": spec["name"],
                             "alert_id": found["id"]})
         else:
+            # Union, not replace — a recipient the owner added in the UI is not ours to drop.
             actions.append({"action": "update_alert", "alert": spec["name"],
-                            "alert_id": found["id"], "payload": payload})
+                            "alert_id": found["id"],
+                            "payload": alert_payload(
+                                spec, insight_id,
+                                sorted(wanted_subscribers | current_subscribers, key=str))})
     return actions
 
 
@@ -666,6 +679,8 @@ class PostHogClient:
                 "bounds": {k: v for k, v in (configuration.get("bounds") or {}).items()
                            if v is not None},
                 "enabled": item.get("enabled", True),
+                "subscribed_users": [_user_id_of(u) for u in (item.get("subscribed_users") or [])
+                                     if _user_id_of(u) is not None],
             }
         return alerts
 
@@ -702,6 +717,14 @@ def _insight_id_of(insight) -> Optional[int]:
     if isinstance(insight, dict):
         return insight.get("id")
     return insight
+
+
+def _user_id_of(user) -> Optional[int]:
+    """An alert's subscriber, which PostHog serializes as a nested user object on read and a bare id
+    on write — the same two shapes as `insight`."""
+    if isinstance(user, dict):
+        return user.get("id")
+    return user
 
 
 def apply_actions(client: PostHogClient, actions: list, dry_run: bool = True) -> list:

--- a/scripts/posthog_provision.py
+++ b/scripts/posthog_provision.py
@@ -1,0 +1,867 @@
+#!/usr/bin/env python3
+"""Provision the LEM business-KPI PostHog surface — funnels, the two consolidated dashboards, the
+threshold alerts and the weekly report subscription (issue #650).
+
+41 insights and 6 dashboards existed before this, but nothing that showed LEM's actual business
+LOOPS end to end, and every metric watchdog was a hand-run cron. This script defines all four
+things as code so they are reviewable, reproducible and re-creatable if a tile is edited away in
+the UI:
+
+  • **LEM Health** — the operational dashboard: task failures, LinkedIn 429 breaker trips, LLM
+    spend per day (from PH2's `$ai_generation`, the post-fallback truth), comments/day, posts/day
+    and follower delta.
+  • **LEM Growth** — the funnel dashboard: the content loop (plan → approve → posted → engaged),
+    the onboarding/monetization funnel, the engagement loop (comment → author reply → our reply)
+    and the engagement-rate trends.
+  • **Threshold alerts** (4 of PostHog's 5 free ones) — comments below a weekly floor, LLM daily
+    spend over cap, Celery failure spike, 429 spike. They email the key's owner.
+  • **A weekly email subscription** of LEM Growth — this is what replaces the hand-run 2-week
+    perf-report cron.
+
+Alert insights are NATIVE single-series trends queries on purpose: an alert threshold is evaluated
+against one series by index, so anything with a breakdown or a second series makes `series_index`
+ambiguous. The rest are HogQL, like scripts/posthog_dashboards.py, and insight names are globally
+unique across BOTH scripts — each plans by name, so a shared name would make the two fight over one
+insight forever.
+
+Split the same way as scripts/posthog_dashboards.py: PURE spec/plan logic (unit-tested) and a thin
+I/O layer (the PostHog REST client, mocked in tests).
+
+CLI (--dry-run and --apply are mutually exclusive):
+  --dry-run             Show what would be created/updated against the live project. No writes. (default)
+  --apply               Create missing dashboards/insights/alerts/subscription and update drifted ones.
+  --print-sql           Print every tile's query (no network).
+  --simulate NAME=VALUE Report whether VALUE would breach the named alert's threshold. No network.
+  --email ADDR          Weekly-report recipient (default $POSTHOG_REPORT_EMAIL, else the key owner).
+Env:
+  POSTHOG_PERSONAL_API_KEY  Personal API key (required for network). Scopes: insight, dashboard,
+                            alert and subscription read+write, plus user:read for the subscriber id.
+  POSTHOG_PROJECT_ID        PostHog project id (default 475262 — "CQC LEM").
+  POSTHOG_APP_HOST          App host for the API (default https://us.posthog.com).
+  POSTHOG_REPORT_EMAIL      Weekly Growth-dashboard recipient. Falls back to the key owner's email.
+Exit: 0 in sync / applied, 2 changes pending (--dry-run), 1 error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+DEFAULT_PROJECT_ID = "475262"  # "CQC LEM" — not a secret; the key that reaches it is.
+DEFAULT_APP_HOST = "https://us.posthog.com"
+
+DASH_HEALTH = "LEM Health"
+DASH_GROWTH = "LEM Growth"
+
+TAGS = ["lem", "kpi", "health", "growth"]
+
+# Rolling windows, so "30d" means the same thing on every tile.
+OPS_WINDOW = "INTERVAL 30 DAY"
+GROWTH_WINDOW = "INTERVAL 90 DAY"
+# Publishes are derived from each post's FIRST outcome reading, so the inner scan has to reach back
+# further than the window it reports on — otherwise a post first measured before the window opens
+# would be counted as published on day one of it.
+PUBLISH_LOOKBACK = "INTERVAL 120 DAY"
+
+# Every event these dashboards read. Server-side ones come from utilities/observability.py, the SPA
+# ones from ui/src/utils/analytics.ts (PH1), and `$ai_generation` from the LiteLLM callback (PH2).
+SOURCE_EVENTS = (
+    "celery_task",
+    "api_call",
+    "rate_limit_trip",
+    "comment_outcome",
+    "post_outcome",
+    "audience_snapshot",
+    "onboarding_step",
+    "content_plan_generated",
+    "post_approved",
+    "signup_started",
+    "signup_completed",
+    "trial_started",
+    "onboarding_step_completed",
+    "activated",
+    "subscription_started",
+    "$ai_generation",
+)
+
+# ── Alert thresholds ─────────────────────────────────────────────────────────────────
+# Changing one of these and re-running `--apply` updates the live alert; they are here rather than
+# in env so the value that pages someone is reviewable in the diff.
+
+# A whole WEEK under this many measured comments means feed commenting is broken, not resting.
+# Deliberately weekly: human_pacing takes account-wide rest days (issue #626), so a daily floor
+# would page on a healthy zero-comment day.
+COMMENT_WEEKLY_FLOOR = 5
+# Daily LLM spend ceiling, in USD, read from the proxy's own `response_cost` (docs/llm-analytics.md).
+LLM_DAILY_COST_CAP_USD = 15.0
+# A day's Celery failures. Individual failures are already `$exception` issues (#648); this is the
+# "something systemic broke" line.
+CELERY_FAILURES_PER_DAY_CEILING = 25
+# 429 breaker trips per day. The breaker escalates its own cooldown, so more than a handful of trips
+# in a day is the doom loop re-forming (see utilities/linkedin/rate_limit.py).
+RATE_LIMIT_TRIPS_PER_DAY_CEILING = 5
+
+# Weekly report cadence: Monday 09:00 UTC, matching the other weekly LEM crons.
+REPORT_WEEKDAY = "monday"
+REPORT_HOUR_UTC = 9
+
+
+# ── query-node builders ──────────────────────────────────────────────────────────────
+
+def _hogql(sql: str, display: str, chart_settings: Optional[dict] = None) -> dict:
+    node: dict = {"kind": "DataVisualizationNode", "display": display,
+                  "source": {"kind": "HogQLQuery", "query": sql.strip()}}
+    if chart_settings:
+        node["chartSettings"] = chart_settings
+    return node
+
+
+def _line(x: str, ys: list, goal_lines: Optional[list] = None) -> dict:
+    settings: dict = {"xAxis": {"column": x}, "yAxis": [{"column": y} for y in ys],
+                      "showLegend": True, "showNullsAsZero": True}
+    if goal_lines:
+        settings["goalLines"] = goal_lines
+    return settings
+
+
+def _event_series(event: str, math: str = "total", math_property: Optional[str] = None,
+                  properties: Optional[list] = None) -> dict:
+    series: dict = {"kind": "EventsNode", "event": event, "name": event, "math": math}
+    if math_property:
+        series["math_property"] = math_property
+    if properties:
+        series["properties"] = properties
+    return series
+
+
+def _trends(series: dict, interval: str = "day", date_from: str = "-30d") -> dict:
+    """A native trends insight. PostHog alerts read trends, funnel and SQL insights, but the
+    threshold is evaluated against ONE series by index — so every alertable tile is a single-series
+    trend with no breakdown, where `series_index: 0` can only mean one thing."""
+    return {"kind": "InsightVizNode",
+            "source": {"kind": "TrendsQuery", "series": [series], "interval": interval,
+                       "dateRange": {"date_from": date_from},
+                       "trendsFilter": {"display": "ActionsLineGraph"}}}
+
+
+def _funnel(events: list, date_from: str = "-90d", window_days: int = 14) -> dict:
+    """An ordered funnel over `events`. The conversion window has to be generous: a content plan is
+    30 days long, so a plan → approve → post → engagement chain spans weeks, not a session."""
+    return {"kind": "InsightVizNode",
+            "source": {"kind": "FunnelsQuery",
+                       "series": [{"kind": "EventsNode", "event": e, "name": e} for e in events],
+                       "dateRange": {"date_from": date_from},
+                       "funnelsFilter": {"funnelVizType": "steps", "funnelOrderType": "ordered",
+                                         "funnelWindowInterval": window_days,
+                                         "funnelWindowIntervalUnit": "day"}}}
+
+
+def _tile(name: str, description: str, query: dict) -> dict:
+    return {"name": name, "description": description, "query": query}
+
+
+# ── LEM Health ───────────────────────────────────────────────────────────────────────
+
+# Alert-bearing insight names. Kept as constants because an alert references its insight BY NAME —
+# a rename on one side and not the other would silently orphan the alert.
+INSIGHT_CELERY_FAILURES = "Health — Celery task failures per day"
+INSIGHT_RATE_LIMIT_TRIPS = "Health — LinkedIn 429 breaker trips per day"
+INSIGHT_LLM_SPEND = "Health — LLM spend per day (USD, proxy-reported)"
+INSIGHT_COMMENTS_WEEKLY = "Health — Comments measured per week"
+
+
+def health_tiles() -> list:
+    """The operational dashboard: is LEM running, and what is it costing?"""
+    return [
+        _tile(
+            INSIGHT_CELERY_FAILURES,
+            "Celery tasks that ended in FAILURE, per day. Filters on `state` (a string) rather than "
+            "`success` (a boolean) so the alert can never silently match nothing.",
+            _trends(_event_series("celery_task", properties=[
+                {"key": "state", "value": ["FAILURE"], "operator": "exact", "type": "event"}])),
+        ),
+        _tile(
+            INSIGHT_RATE_LIMIT_TRIPS,
+            "Times the LinkedIn 429 circuit breaker opened, per day. The breaker escalates its own "
+            "cooldown, so a rising count is the doom loop re-forming — not just a slow day.",
+            _trends(_event_series("rate_limit_trip")),
+        ),
+        _tile(
+            INSIGHT_LLM_SPEND,
+            "Daily LLM spend as the PROXY reports it ($ai_generation.$ai_total_cost_usd) — the "
+            "post-fallback, post-down-route truth. Never add this to `llm_call` (docs/llm-analytics.md).",
+            _trends(_event_series("$ai_generation", math="sum",
+                                  math_property="$ai_total_cost_usd")),
+        ),
+        _tile(
+            INSIGHT_COMMENTS_WEEKLY,
+            "Comments the T+24h outcome sweep could measure, per week. Weekly on purpose: human "
+            "pacing takes account-wide rest days, so a daily floor would page on a healthy zero day.",
+            _trends(_event_series("comment_outcome"), interval="week", date_from="-90d"),
+        ),
+        _tile(
+            "Health — Celery task failure rate (daily %)",
+            "Share of finished Celery tasks that failed each day, with the volume behind it — a "
+            "spike in the rate on falling volume is a different problem than one on rising volume.",
+            _hogql(f"""
+SELECT toStartOfDay(timestamp) AS day,
+       count() AS tasks,
+       countIf(toString(properties.state) = 'FAILURE') AS failures,
+       round(100 * countIf(toString(properties.state) = 'FAILURE') / nullIf(count(), 0), 2) AS failure_pct
+FROM events
+WHERE event = 'celery_task' AND timestamp >= now() - {OPS_WINDOW}
+GROUP BY day
+ORDER BY day ASC
+""", "ActionsLineGraph", _line("day", ["failure_pct"])),
+        ),
+        _tile(
+            "Health — Failing tasks by name (7d)",
+            "Which task is actually failing. The first thing to look at when the failure-rate alert "
+            "fires — one broken beat can carry the whole rate.",
+            _hogql("""
+SELECT coalesce(toString(properties.task), 'unknown') AS task,
+       count() AS runs,
+       countIf(toString(properties.state) = 'FAILURE') AS failures,
+       round(100 * countIf(toString(properties.state) = 'FAILURE') / nullIf(count(), 0), 2) AS failure_pct,
+       round(avg(toFloat(properties.duration_ms)), 0) AS avg_duration_ms
+FROM events
+WHERE event = 'celery_task' AND timestamp >= now() - INTERVAL 7 DAY
+GROUP BY task
+HAVING failures > 0
+ORDER BY failures DESC
+LIMIT 50
+""", "ActionsTable"),
+        ),
+        _tile(
+            "Health — Posts published per day",
+            "Posts that reached LinkedIn, counted from each post's FIRST outcome reading (the stats "
+            "sweep re-reads a post daily, so a plain count would report the backlog, not publishes).",
+            _hogql(f"""
+SELECT toStartOfDay(first_seen) AS day, count() AS posts_published
+FROM (
+    SELECT toString(properties.post_id) AS post_id, min(timestamp) AS first_seen
+    FROM events
+    WHERE event = 'post_outcome' AND properties.post_id IS NOT NULL
+          AND timestamp >= now() - {PUBLISH_LOOKBACK}
+    GROUP BY post_id
+)
+WHERE first_seen >= now() - {OPS_WINDOW}
+GROUP BY day
+ORDER BY day ASC
+""", "ActionsBar", _line("day", ["posts_published"])),
+        ),
+        _tile(
+            "Health — Follower delta per day",
+            "Day-over-day follower change per user, from the audience snapshots (issue #627). A "
+            "user's FIRST reading has no previous day and is dropped — counting it would draw the "
+            "whole existing audience as one day's growth.",
+            _hogql(f"""
+SELECT day, sum(followers - prev) AS follower_delta, sum(followers) AS followers
+FROM (
+    SELECT day, user_key, followers,
+           lagInFrame(followers) OVER (PARTITION BY user_key ORDER BY day
+                                       ROWS BETWEEN 1 PRECEDING AND CURRENT ROW) AS prev
+    FROM (
+        SELECT toStartOfDay(timestamp) AS day,
+               distinct_id AS user_key,
+               max(toFloat(properties.follower_count)) AS followers
+        FROM events
+        WHERE event = 'audience_snapshot' AND properties.follower_count IS NOT NULL
+              AND timestamp >= now() - {OPS_WINDOW}
+        GROUP BY day, user_key
+    )
+)
+WHERE prev > 0
+GROUP BY day
+ORDER BY day ASC
+""", "ActionsLineGraph", _line("day", ["follower_delta"])),
+        ),
+        _tile(
+            "Health — API error rate (daily %)",
+            "5xx share of LEM's own API calls, with p95 latency beside it — the SPA-facing half of "
+            "'is it up', which the Celery tiles say nothing about.",
+            _hogql(f"""
+SELECT toStartOfDay(timestamp) AS day,
+       count() AS calls,
+       round(100 * countIf(toInt(properties.status_code) >= 500) / nullIf(count(), 0), 2) AS error_pct,
+       round(quantile(0.95)(toFloat(properties.latency_ms)), 0) AS p95_latency_ms
+FROM events
+WHERE event = 'api_call' AND timestamp >= now() - {OPS_WINDOW}
+GROUP BY day
+ORDER BY day ASC
+""", "ActionsLineGraph", _line("day", ["error_pct"])),
+        ),
+    ]
+
+
+# ── LEM Growth ───────────────────────────────────────────────────────────────────────
+
+def growth_tiles() -> list:
+    """The funnel dashboard: do LEM's business loops actually close?"""
+    return [
+        _tile(
+            "Growth — Content loop funnel",
+            "plan generated → post approved → post live and measured. The drop between step 2 and 3 "
+            "is approved content that never shipped; between 1 and 2 is content the user rejected.",
+            _funnel(["content_plan_generated", "post_approved", "post_outcome"],
+                    date_from="-90d", window_days=45),
+        ),
+        _tile(
+            "Growth — Signup → activation → subscription funnel",
+            "The acquisition funnel end to end. `signup_started` is pseudonymous until the account "
+            "exists — track_funnel_event aliases it onto the user id, so the funnel joins through.",
+            _funnel(["signup_started", "signup_completed", "trial_started",
+                     "onboarding_step_completed", "activated", "subscription_started"],
+                    date_from="-180d", window_days=30),
+        ),
+        _tile(
+            "Growth — Onboarding step drop-off",
+            "Users reaching each checklist step and the median hours it took them — where activation "
+            "stalls, at step granularity the funnel tile can't show.",
+            _hogql(f"""
+SELECT coalesce(toString(properties.step), 'unknown') AS step,
+       uniqExact(distinct_id) AS users,
+       round(median(toFloat(properties.hours_since_start)), 2) AS median_hours_since_start
+FROM events
+WHERE event = 'onboarding_step' AND timestamp >= now() - {GROWTH_WINDOW}
+GROUP BY step
+ORDER BY users DESC
+""", "ActionsBar", _line("step", ["users"])),
+        ),
+        _tile(
+            "Growth — Engagement loop (comment → author reply → our reply)",
+            "The engagement loop as conversion rates off comment_outcome (issue #628). The "
+            "connection-accepted and DM-reply steps join here once that instrumentation lands.",
+            _hogql(f"""
+SELECT toStartOfWeek(timestamp) AS week,
+       count() AS comments_measured,
+       countIf(toBool(properties.author_replied)) AS author_replies,
+       countIf(toBool(properties.our_reply_sent)) AS our_replies,
+       round(100 * countIf(toBool(properties.author_replied)) / nullIf(count(), 0), 2) AS author_reply_pct,
+       round(100 * countIf(toBool(properties.our_reply_sent))
+             / nullIf(countIf(toBool(properties.author_replied)), 0), 2) AS we_replied_back_pct
+FROM events
+WHERE event = 'comment_outcome' AND timestamp >= now() - {GROWTH_WINDOW}
+GROUP BY week
+ORDER BY week ASC
+""", "ActionsLineGraph", _line("week", ["author_reply_pct", "we_replied_back_pct"])),
+        ),
+        _tile(
+            "Growth — Comment visibility (Most-relevant demotion)",
+            "Share of readable comment readings still visible under LinkedIn's default sort. NULL "
+            "readings are excluded from the denominator — an unread sort control is not a demotion.",
+            _hogql(f"""
+SELECT toStartOfWeek(timestamp) AS week,
+       countIf(properties.visible_most_relevant IS NOT NULL) AS readable,
+       round(100 * countIf(toBool(properties.visible_most_relevant))
+             / nullIf(countIf(properties.visible_most_relevant IS NOT NULL), 0), 2) AS visible_pct
+FROM events
+WHERE event = 'comment_outcome' AND timestamp >= now() - {GROWTH_WINDOW}
+GROUP BY week
+ORDER BY week ASC
+""", "ActionsLineGraph", _line("week", ["visible_pct"])),
+        ),
+        _tile(
+            "Growth — Engagement rate & reach per week",
+            "The outcome the whole content loop exists to move: weekly median engagement rate with "
+            "the impressions and reactions underneath it.",
+            _hogql(f"""
+SELECT toStartOfWeek(timestamp) AS week,
+       count() AS readings,
+       round(median(toFloat(properties.engagement_rate)), 6) AS median_engagement_rate,
+       coalesce(sum(toFloat(properties.impressions)), 0) AS impressions,
+       coalesce(sum(toFloat(properties.reactions)), 0) AS reactions
+FROM events
+WHERE event = 'post_outcome' AND timestamp >= now() - {GROWTH_WINDOW}
+GROUP BY week
+ORDER BY week ASC
+""", "ActionsLineGraph", _line("week", ["median_engagement_rate"])),
+        ),
+        _tile(
+            "Growth — Audience growth per week",
+            "Followers, connections and profile views at each week's end — the audience side of the "
+            "same loop, so a reach change can be read against the audience that produced it.",
+            _hogql(f"""
+SELECT toStartOfWeek(timestamp) AS week,
+       max(toFloat(properties.follower_count)) AS followers,
+       max(toFloat(properties.connection_count)) AS connections,
+       sum(toFloat(properties.profile_views)) AS profile_views
+FROM events
+WHERE event = 'audience_snapshot' AND timestamp >= now() - {GROWTH_WINDOW}
+GROUP BY week
+ORDER BY week ASC
+""", "ActionsLineGraph", _line("week", ["followers", "connections"])),
+        ),
+    ]
+
+
+def build_specs() -> list:
+    """The full issue-#650 dashboard set. Pure — same input every run, so a diff against PostHog is
+    meaningful and `--apply` is idempotent."""
+    return [
+        {"name": DASH_HEALTH,
+         "description": "Is LEM running, and what is it costing? Celery failures, LinkedIn 429 "
+                        "breaker trips, proxy-reported LLM spend, comments/posts per day, follower "
+                        "delta and API error rate. The four threshold alerts page off this one.",
+         "tiles": health_tiles()},
+        {"name": DASH_GROWTH,
+         "description": "Do LEM's loops close? The content-loop and signup→subscription funnels, "
+                        "onboarding drop-off, the comment→reply engagement loop and the engagement "
+                        "rate/audience trends. Emailed to the owner weekly.",
+         "tiles": growth_tiles()},
+    ]
+
+
+# ── alerts & subscription specs ──────────────────────────────────────────────────────
+
+def alert_specs() -> list:
+    """The four threshold alerts (PostHog's free tier allows five). `bounds` is PostHog's own shape:
+    a value BELOW `lower` or ABOVE `upper` breaches."""
+    return [
+        {"name": "LEM — comments per week below floor",
+         "insight": INSIGHT_COMMENTS_WEEKLY,
+         "bounds": {"lower": COMMENT_WEEKLY_FLOOR},
+         "description": f"Fewer than {COMMENT_WEEKLY_FLOOR} comments measured in a week — feed "
+                        "commenting is broken, held or rate-limited."},
+        {"name": "LEM — LLM spend per day over cap",
+         "insight": INSIGHT_LLM_SPEND,
+         "bounds": {"upper": LLM_DAILY_COST_CAP_USD},
+         "description": f"Proxy-reported LLM spend over ${LLM_DAILY_COST_CAP_USD:g} in a day."},
+        {"name": "LEM — Celery failure spike",
+         "insight": INSIGHT_CELERY_FAILURES,
+         "bounds": {"upper": CELERY_FAILURES_PER_DAY_CEILING},
+         "description": f"More than {CELERY_FAILURES_PER_DAY_CEILING} task failures in a day — "
+                        "something systemic, not one bad task."},
+        {"name": "LEM — LinkedIn 429 spike",
+         "insight": INSIGHT_RATE_LIMIT_TRIPS,
+         "bounds": {"upper": RATE_LIMIT_TRIPS_PER_DAY_CEILING},
+         "description": f"More than {RATE_LIMIT_TRIPS_PER_DAY_CEILING} 429 breaker trips in a day."},
+    ]
+
+
+def evaluate_threshold(bounds: dict, value) -> dict:
+    """Would `value` breach these bounds? The same comparison PostHog runs server-side, exposed so
+    `--simulate` can prove an alert fires without waiting for a real breach.
+
+    A non-numeric value is NOT a breach — a missing reading means the insight had nothing to
+    evaluate, and paging on that would make every quiet ingest gap an incident."""
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return {"breach": False, "reason": "no numeric value to evaluate"}
+    lower, upper = bounds.get("lower"), bounds.get("upper")
+    if lower is not None and numeric < float(lower):
+        return {"breach": True, "reason": f"{numeric:g} is below the floor of {float(lower):g}"}
+    if upper is not None and numeric > float(upper):
+        return {"breach": True, "reason": f"{numeric:g} is above the cap of {float(upper):g}"}
+    return {"breach": False, "reason": f"{numeric:g} is within bounds"}
+
+
+def next_report_start(now: datetime) -> str:
+    """The first send time for the weekly subscription: the next REPORT_WEEKDAY at REPORT_HOUR_UTC,
+    always strictly in the future so PostHog doesn't backfill a send the moment it's created."""
+    weekdays = ["monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday"]
+    target = weekdays.index(REPORT_WEEKDAY)
+    start = now.astimezone(timezone.utc).replace(hour=REPORT_HOUR_UTC, minute=0, second=0,
+                                                 microsecond=0)
+    days_ahead = (target - start.weekday()) % 7
+    if days_ahead == 0 and start <= now.astimezone(timezone.utc):
+        days_ahead = 7
+    return (start + timedelta(days=days_ahead)).isoformat().replace("+00:00", "Z")
+
+
+def subscription_spec(email: str, now: Optional[datetime] = None) -> dict:
+    """The weekly Growth-dashboard email — the automated replacement for the hand-run perf report."""
+    return {"dashboard": DASH_GROWTH,
+            "title": "LEM Growth — weekly report",
+            "target_type": "email",
+            "target_value": email,
+            "frequency": "weekly",
+            "interval": 1,
+            "byweekday": [REPORT_WEEKDAY],
+            "start_date": next_report_start(now or datetime.now(timezone.utc))}
+
+
+# ── pure planning (unit-tested) ──────────────────────────────────────────────────────
+
+def plan_actions(specs: list, existing_dashboards: dict, existing_insights: dict) -> list:
+    """Diff the dashboard/insight spec against what PostHog already has.
+
+    `existing_dashboards` maps dashboard name -> id; `existing_insights` maps insight name ->
+    {"id", "query", "description", "dashboards"}. Returns ordered actions: `create_dashboard`,
+    `create_insight`, `update_insight`, `unchanged`. `description` is optional on the existing
+    record: when a caller omits it the spec value is assumed, so only a caller that actually reports
+    the stored description can trigger a description-drift update."""
+    actions: list = []
+    for spec in specs:
+        dashboard_id = existing_dashboards.get(spec["name"])
+        if dashboard_id is None:
+            actions.append({"action": "create_dashboard", "dashboard": spec["name"],
+                            "description": spec["description"]})
+        for tile in spec["tiles"]:
+            found = existing_insights.get(tile["name"])
+            if found is None:
+                actions.append({"action": "create_insight", "dashboard": spec["name"],
+                                "insight": tile["name"], "tile": tile})
+                continue
+            attached = dashboard_id is not None and dashboard_id in (found.get("dashboards") or [])
+            described = found.get("description", tile["description"]) == tile["description"]
+            if found.get("query") == tile["query"] and attached and described:
+                actions.append({"action": "unchanged", "dashboard": spec["name"],
+                                "insight": tile["name"], "insight_id": found["id"]})
+            else:
+                actions.append({"action": "update_insight", "dashboard": spec["name"],
+                                "insight": tile["name"], "insight_id": found["id"], "tile": tile})
+    return actions
+
+
+def plan_alerts(specs: list, existing_alerts: dict, insight_ids: dict,
+                subscribed_users: Optional[list] = None) -> list:
+    """Diff the alert spec. An alert whose insight does not exist yet is `blocked` rather than
+    created — PostHog needs the insight id, and reporting it as creatable would make a dry-run lie
+    about what a follow-up `--apply` can do in one pass."""
+    actions: list = []
+    for spec in specs:
+        insight_id = insight_ids.get(spec["insight"])
+        found = existing_alerts.get(spec["name"])
+        if insight_id is None:
+            actions.append({"action": "blocked_alert", "alert": spec["name"],
+                            "reason": f"insight '{spec['insight']}' does not exist yet"})
+            continue
+        payload = alert_payload(spec, insight_id, subscribed_users)
+        if found is None:
+            actions.append({"action": "create_alert", "alert": spec["name"], "payload": payload})
+        elif (found.get("bounds") == spec["bounds"] and found.get("insight_id") == insight_id
+                and found.get("enabled", True)):
+            actions.append({"action": "unchanged_alert", "alert": spec["name"],
+                            "alert_id": found["id"]})
+        else:
+            actions.append({"action": "update_alert", "alert": spec["name"],
+                            "alert_id": found["id"], "payload": payload})
+    return actions
+
+
+def alert_payload(spec: dict, insight_id, subscribed_users: Optional[list] = None) -> dict:
+    """PostHog's alert body. `series_index` 0 is the only series an alert-eligible insight has."""
+    return {"name": spec["name"],
+            "insight": insight_id,
+            "subscribed_users": list(subscribed_users or []),
+            "config": {"type": "TrendsAlertConfig", "series_index": 0},
+            "threshold": {"configuration": {"type": "absolute", "bounds": dict(spec["bounds"])}},
+            "condition": {"type": "absolute_value"},
+            "calculation_interval": "daily",
+            "enabled": True}
+
+
+def plan_subscriptions(specs: list, existing_subscriptions: list, dashboard_ids: dict) -> list:
+    """Diff the email subscriptions. Matched on (dashboard, recipient, frequency) and NOT on
+    `start_date`: PostHog advances that with every send, so comparing it would recreate the
+    subscription on every run."""
+    actions: list = []
+    for spec in specs:
+        dashboard_id = dashboard_ids.get(spec["dashboard"])
+        if dashboard_id is None:
+            actions.append({"action": "blocked_subscription", "subscription": spec["title"],
+                            "reason": f"dashboard '{spec['dashboard']}' does not exist yet"})
+            continue
+        match = next((s for s in existing_subscriptions
+                      if s.get("dashboard") == dashboard_id
+                      and (s.get("target_value") or "").strip().lower()
+                      == spec["target_value"].strip().lower()
+                      and s.get("frequency") == spec["frequency"]
+                      and not s.get("deleted")), None)
+        payload = {**{k: v for k, v in spec.items() if k != "dashboard"}, "dashboard": dashboard_id}
+        if match is None:
+            actions.append({"action": "create_subscription", "subscription": spec["title"],
+                            "payload": payload})
+        else:
+            actions.append({"action": "unchanged_subscription", "subscription": spec["title"],
+                            "subscription_id": match.get("id")})
+    return actions
+
+
+UNCHANGED_ACTIONS = ("unchanged", "unchanged_alert", "unchanged_subscription")
+
+
+def pending(actions: list) -> list:
+    return [a for a in actions if a["action"] not in UNCHANGED_ACTIONS]
+
+
+def summarize(actions: list) -> str:
+    counts: dict = {}
+    for action in actions:
+        counts[action["action"]] = counts.get(action["action"], 0) + 1
+    return ", ".join(f"{name}={counts[name]}" for name in sorted(counts)) or "nothing to do"
+
+
+def dashboard_url(app_host: str, project_id: str, dashboard_id) -> str:
+    return f"{app_host.rstrip('/')}/project/{project_id}/dashboard/{dashboard_id}"
+
+
+# ── I/O (mocked in tests) ────────────────────────────────────────────────────────────
+
+class PostHogClient:
+    """Thin PostHog REST wrapper — only the calls this provisioner needs."""
+
+    def __init__(self, api_key: str, project_id: str, app_host: str = DEFAULT_APP_HOST) -> None:
+        self.project_id = project_id
+        self.app_host = app_host.rstrip("/")
+        self._base = f"{self.app_host}/api/projects/{project_id}"
+        self._headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        import requests
+        response = requests.request(method, f"{self._base}{path}", headers=self._headers,
+                                    timeout=30, **kwargs)
+        response.raise_for_status()
+        return response.json() if response.content else {}
+
+    def _paged(self, path: str) -> list:
+        import requests
+        results, url = [], f"{self._base}{path}"
+        while url:
+            response = requests.get(url, headers=self._headers, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+            results.extend(payload.get("results", []))
+            url = payload.get("next")
+        return results
+
+    def whoami(self) -> dict:
+        """The personal-API-key owner — the default alert subscriber and report recipient. Needs
+        `user:read`; a key without it just means alerts are created with no subscriber."""
+        import requests
+        response = requests.get(f"{self.app_host}/api/users/@me/", headers=self._headers, timeout=30)
+        response.raise_for_status()
+        return response.json() or {}
+
+    def list_dashboards(self) -> dict:
+        return {d["name"]: d["id"] for d in self._paged("/dashboards/?limit=100")
+                if not d.get("deleted")}
+
+    def list_insights(self) -> dict:
+        insights = {}
+        for item in self._paged("/insights/?limit=100"):
+            if item.get("deleted"):
+                continue
+            insights[item.get("name")] = {
+                "id": item["id"],
+                "query": item.get("query"),
+                "description": item.get("description") or "",
+                "dashboards": [t.get("dashboard_id") for t in (item.get("dashboard_tiles") or [])
+                               ] or list(item.get("dashboards") or []),
+            }
+        return insights
+
+    def list_alerts(self) -> dict:
+        alerts = {}
+        for item in self._paged("/alerts/?limit=100"):
+            configuration = ((item.get("threshold") or {}).get("configuration") or {})
+            alerts[item.get("name")] = {
+                "id": item.get("id"),
+                "insight_id": _insight_id_of(item.get("insight")),
+                "bounds": {k: v for k, v in (configuration.get("bounds") or {}).items()
+                           if v is not None},
+                "enabled": item.get("enabled", True),
+            }
+        return alerts
+
+    def list_subscriptions(self) -> list:
+        return [s for s in self._paged("/subscriptions/?limit=100") if not s.get("deleted")]
+
+    def create_dashboard(self, name: str, description: str) -> int:
+        return self._request("POST", "/dashboards/", json={
+            "name": name, "description": description, "tags": TAGS, "pinned": True})["id"]
+
+    def create_insight(self, tile: dict, dashboard_id: int) -> int:
+        return self._request("POST", "/insights/", json={
+            "name": tile["name"], "description": tile["description"], "query": tile["query"],
+            "tags": TAGS, "dashboards": [dashboard_id]})["id"]
+
+    def update_insight(self, insight_id: int, tile: dict, dashboard_id: int) -> None:
+        self._request("PATCH", f"/insights/{insight_id}/", json={
+            "description": tile["description"], "query": tile["query"],
+            "dashboards": [dashboard_id]})
+
+    def create_alert(self, payload: dict) -> int:
+        return self._request("POST", "/alerts/", json=payload).get("id")
+
+    def update_alert(self, alert_id, payload: dict) -> None:
+        self._request("PATCH", f"/alerts/{alert_id}/", json=payload)
+
+    def create_subscription(self, payload: dict) -> int:
+        return self._request("POST", "/subscriptions/", json=payload).get("id")
+
+
+def _insight_id_of(insight) -> Optional[int]:
+    """PostHog returns an alert's insight as a bare id on some versions and a nested object on
+    others — normalize both so the diff doesn't churn."""
+    if isinstance(insight, dict):
+        return insight.get("id")
+    return insight
+
+
+def apply_actions(client: PostHogClient, actions: list, dry_run: bool = True) -> list:
+    """Execute the plan. `dry_run` reports without writing. Returns the log lines emitted."""
+    dashboard_ids: dict = {}
+    log: list = []
+    for action in actions:
+        kind = action["action"]
+        if kind == "create_dashboard":
+            name = action["dashboard"]
+            if dry_run:
+                log.append(f"[dry-run] create dashboard '{name}'")
+                continue
+            dashboard_ids[name] = client.create_dashboard(name, action["description"])
+            log.append(f"created dashboard '{name}' -> {dashboard_ids[name]}")
+        elif kind in ("create_insight", "update_insight"):
+            name = action["dashboard"]
+            verb = "create" if kind == "create_insight" else "update"
+            if dry_run:
+                log.append(f"[dry-run] {verb} insight '{action['insight']}' on '{name}'")
+                continue
+            dashboard_id = dashboard_ids.get(name)
+            if dashboard_id is None:
+                # The dashboard already existed, so no create_dashboard action filled the cache.
+                dashboard_id = client.list_dashboards().get(name)
+                dashboard_ids[name] = dashboard_id
+            if kind == "create_insight":
+                insight_id = client.create_insight(action["tile"], dashboard_id)
+                log.append(f"created insight '{action['insight']}' -> {insight_id}")
+            else:
+                client.update_insight(action["insight_id"], action["tile"], dashboard_id)
+                log.append(f"updated insight '{action['insight']}'")
+        elif kind == "create_alert":
+            if dry_run:
+                log.append(f"[dry-run] create alert '{action['alert']}'")
+                continue
+            log.append(f"created alert '{action['alert']}' -> {client.create_alert(action['payload'])}")
+        elif kind == "update_alert":
+            if dry_run:
+                log.append(f"[dry-run] update alert '{action['alert']}'")
+                continue
+            client.update_alert(action["alert_id"], action["payload"])
+            log.append(f"updated alert '{action['alert']}'")
+        elif kind == "create_subscription":
+            if dry_run:
+                log.append(f"[dry-run] create subscription '{action['subscription']}'")
+                continue
+            subscription_id = client.create_subscription(action["payload"])
+            log.append(f"created subscription '{action['subscription']}' -> {subscription_id}")
+        elif kind in ("blocked_alert", "blocked_subscription"):
+            log.append(f"skipped '{action.get('alert') or action.get('subscription')}': "
+                       f"{action['reason']}")
+    return log
+
+
+def _print_specs() -> None:
+    for spec in build_specs():
+        for tile in spec["tiles"]:
+            query = tile["query"]
+            print(f"\n-- {spec['name']} :: {tile['name']}")
+            if query["kind"] == "DataVisualizationNode":
+                print(query["source"]["query"])
+            else:
+                print(json.dumps(query["source"], indent=2))
+
+
+def _simulate(expression: str) -> int:
+    """`--simulate '<alert name>=<value>'` — the synthetic threshold breach the acceptance criteria
+    ask for, without waiting on live data."""
+    name, _, raw = expression.partition("=")
+    spec = next((s for s in alert_specs() if s["name"].lower() == name.strip().lower()), None)
+    if spec is None:
+        print(f"Unknown alert '{name.strip()}'. Known: "
+              + "; ".join(s["name"] for s in alert_specs()), file=sys.stderr)
+        return 1
+    verdict = evaluate_threshold(spec["bounds"], raw.strip())
+    print(f"{spec['name']}: {'BREACH' if verdict['breach'] else 'ok'} — {verdict['reason']}")
+    return 0
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Provision the LEM Health/Growth PostHog dashboards, alerts and weekly report.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--apply", action="store_true", help="Write changes to PostHog.")
+    mode.add_argument("--dry-run", action="store_true", help="Report changes only (default).")
+    parser.add_argument("--print-sql", action="store_true",
+                        help="Print every tile's query and exit.")
+    parser.add_argument("--simulate", metavar="NAME=VALUE",
+                        help="Report whether VALUE breaches the named alert's threshold, then exit.")
+    parser.add_argument("--email", help="Weekly-report recipient (default $POSTHOG_REPORT_EMAIL).")
+    args = parser.parse_args(argv)
+
+    if args.print_sql:
+        _print_specs()
+        return 0
+    if args.simulate:
+        return _simulate(args.simulate)
+
+    api_key = os.getenv("POSTHOG_PERSONAL_API_KEY", "")
+    if not api_key:
+        print("POSTHOG_PERSONAL_API_KEY is not set — cannot reach PostHog.", file=sys.stderr)
+        return 1
+    project_id = os.getenv("POSTHOG_PROJECT_ID", DEFAULT_PROJECT_ID)
+    app_host = os.getenv("POSTHOG_APP_HOST", DEFAULT_APP_HOST)
+    dry_run = args.dry_run or not args.apply
+
+    client = PostHogClient(api_key, project_id, app_host)
+    specs = build_specs()
+    try:
+        dashboards, insights = client.list_dashboards(), client.list_insights()
+        alerts, subscriptions = client.list_alerts(), client.list_subscriptions()
+    except Exception as exc:
+        print(f"Failed to read PostHog state: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        me = client.whoami()
+    except Exception as exc:
+        me = {}
+        print(f"Could not read the API key owner ({exc}) — alerts will have no subscriber.",
+              file=sys.stderr)
+    email = args.email or os.getenv("POSTHOG_REPORT_EMAIL") or me.get("email")
+    subscribed_users = [me["id"]] if me.get("id") else []
+
+    actions = plan_actions(specs, dashboards, insights)
+    for line in apply_actions(client, actions, dry_run=dry_run):
+        print(line)
+
+    # Alerts and the subscription reference ids the insight/dashboard pass may have just minted, so
+    # re-read before planning them. In a dry run nothing was written, so the pre-pass state stands.
+    if not dry_run:
+        dashboards, insights = client.list_dashboards(), client.list_insights()
+    insight_ids = {name: found["id"] for name, found in insights.items()}
+
+    alert_actions = plan_alerts(alert_specs(), alerts, insight_ids, subscribed_users)
+    for line in apply_actions(client, alert_actions, dry_run=dry_run):
+        print(line)
+
+    subscription_actions: list = []
+    if email:
+        subscription_actions = plan_subscriptions([subscription_spec(email)], subscriptions,
+                                                  dashboards)
+        for line in apply_actions(client, subscription_actions, dry_run=dry_run):
+            print(line)
+    else:
+        print("No recipient (set POSTHOG_REPORT_EMAIL or --email) — weekly report not provisioned.",
+              file=sys.stderr)
+
+    all_actions = actions + alert_actions + subscription_actions
+    print(summarize(all_actions))
+    for spec in specs:
+        dashboard_id = dashboards.get(spec["name"])
+        if dashboard_id:
+            print(f"{spec['name']}: {dashboard_url(app_host, project_id, dashboard_id)}")
+
+    if dry_run and pending(all_actions):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/cqc_lem/utilities/linkedin/rate_limit.py
+++ b/src/cqc_lem/utilities/linkedin/rate_limit.py
@@ -116,8 +116,15 @@ def mark_rate_limited(reason: str = "") -> None:
         # The warning above stops at the log; PostHog only forwards ERROR and up by default. Emit
         # the trip as its own event so the 429 dashboard tile and its spike alert have a signal
         # (issue #650). Imported here — observability reaches back into this module for Redis.
-        from cqc_lem.utilities.observability import track_rate_limit_trip
-        track_rate_limit_trip(seconds, trips, reason or "429")
+        # In its own try: the breaker is already OPEN by this point, so a telemetry failure must not
+        # fall into the handler below and log "Failed to set the circuit breaker" — that would send
+        # whoever is debugging a doom loop looking for a breaker that is in fact working.
+        try:
+            from cqc_lem.utilities.observability import track_rate_limit_trip
+            track_rate_limit_trip(seconds, trips, reason or "429")
+        except Exception as e:
+            log_warning("Failed to track LinkedIn 429 trip (breaker is open regardless)", exc=e,
+                        action_type="rate_limit")
     except Exception as e:
         log_warning("Failed to set LinkedIn 429 circuit breaker", exc=e, action_type="rate_limit")
 

--- a/src/cqc_lem/utilities/linkedin/rate_limit.py
+++ b/src/cqc_lem/utilities/linkedin/rate_limit.py
@@ -113,6 +113,11 @@ def mark_rate_limited(reason: str = "") -> None:
         client.set(_COOLDOWN_KEY, reason or "429", ex=seconds)
         log_warning(f"LinkedIn 429 circuit breaker OPEN for {seconds}s (consecutive trip #{trips}) "
                     "— Selenium engagement paused", action_type="rate_limit", http_status=429)
+        # The warning above stops at the log; PostHog only forwards ERROR and up by default. Emit
+        # the trip as its own event so the 429 dashboard tile and its spike alert have a signal
+        # (issue #650). Imported here — observability reaches back into this module for Redis.
+        from cqc_lem.utilities.observability import track_rate_limit_trip
+        track_rate_limit_trip(seconds, trips, reason or "429")
     except Exception as e:
         log_warning("Failed to set LinkedIn 429 circuit breaker", exc=e, action_type="rate_limit")
 

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -732,6 +732,27 @@ def track_capacity_alert(alert: dict, generated_at: Optional[str] = None) -> Non
     )
 
 
+def track_rate_limit_trip(seconds: int, trips: int, reason: str = "429") -> None:
+    """Emit one LinkedIn 429 breaker trip (issue #650) as a `rate_limit_trip` event.
+
+    Until now a trip only produced a WARNING log, which never reaches PostHog at the default
+    POSTHOG_LOG_LEVEL — so the one signal that says "LinkedIn is throttling us" was invisible to
+    both dashboards and alerts. `trips` is the CONSECUTIVE-trip counter, so an escalating doom loop
+    is distinguishable from a single unlucky session. Always system-scoped: LinkedIn rate-limits by
+    egress IP, so a trip is an account-wide condition, not one user's.
+
+    Never raises: the breaker must open even when analytics is down."""
+    try:
+        posthog.capture(
+            distinct_id="system",
+            event="rate_limit_trip",
+            properties={"cooldown_seconds": int(seconds), "consecutive_trips": int(trips),
+                        "reason": reason or "429"},
+        )
+    except Exception:
+        pass
+
+
 def session_replay_url(session_id: Optional[str]) -> Optional[str]:
     """The PostHog replay permalink for a browser session id (issue #649), or None when there is no
     id or no project configured — a link that can't be built is simply omitted, never guessed.

--- a/tests/unit/test_posthog_provision.py
+++ b/tests/unit/test_posthog_provision.py
@@ -1,0 +1,519 @@
+"""Unit tests for scripts/posthog_provision.py — the Health/Growth specs, the funnels, the alert
+thresholds, the weekly subscription and the create/update planner (issue #650)."""
+
+import importlib.util
+import pathlib
+import re
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+php = _load("posthog_provision")
+
+
+def _all_tiles():
+    return [(spec["name"], tile) for spec in php.build_specs() for tile in spec["tiles"]]
+
+
+def _hogql_tiles():
+    return [(dash, tile) for dash, tile in _all_tiles()
+            if tile["query"]["kind"] == "DataVisualizationNode"]
+
+
+def _sql(tile):
+    return tile["query"]["source"]["query"]
+
+
+def _tile_by_name(name):
+    return next(tile for _, tile in _all_tiles() if tile["name"] == name)
+
+
+class TestSpecs:
+    def test_two_consolidated_dashboards(self):
+        names = [spec["name"] for spec in php.build_specs()]
+        assert names == [php.DASH_HEALTH, php.DASH_GROWTH]
+        assert all(spec["tiles"] for spec in php.build_specs())
+
+    def test_tile_names_are_globally_unique(self):
+        # plan_actions() keys existing insights by name, so a duplicate would make two tiles fight
+        # over one insight forever.
+        names = [tile["name"] for _, tile in _all_tiles()]
+        assert len(names) == len(set(names))
+
+    def test_no_name_collision_with_the_cost_dashboards_script(self):
+        # Both provisioners plan by insight NAME against the same project. A shared name would make
+        # each one re-point the other's insight at its own dashboard on every run.
+        other = _load("posthog_dashboards")
+        theirs = {tile["name"] for spec in other.build_specs() for tile in spec["tiles"]}
+        ours = {tile["name"] for _, tile in _all_tiles()}
+        assert not (ours & theirs)
+        assert not ({spec["name"] for spec in php.build_specs()}
+                    & {spec["name"] for spec in other.build_specs()})
+
+    def test_every_tile_is_a_known_query_node(self):
+        for dashboard, tile in _all_tiles():
+            query = tile["query"]
+            assert query["kind"] in ("DataVisualizationNode", "InsightVizNode"), dashboard
+            assert query["source"]["kind"] in ("HogQLQuery", "TrendsQuery", "FunnelsQuery")
+            assert tile["description"]
+
+    def test_descriptions_fit_the_posthog_limit(self):
+        for _, tile in _all_tiles():
+            assert len(tile["description"]) <= 400, tile["name"]
+        for spec in php.build_specs():
+            assert len(spec["description"]) <= 400
+
+    def test_hogql_tiles_only_read_known_lem_events(self):
+        for dashboard, tile in _hogql_tiles():
+            referenced = set(re.findall(r"event (?:=|IN) \(?'([a-z_]+)'", _sql(tile)))
+            unknown = referenced - set(php.SOURCE_EVENTS)
+            assert not unknown, f"{dashboard}/{tile['name']} reads unknown events {unknown}"
+
+    def test_query_node_tiles_only_read_known_lem_events(self):
+        for dashboard, tile in _all_tiles():
+            if tile["query"]["kind"] != "InsightVizNode":
+                continue
+            events = {s["event"] for s in tile["query"]["source"]["series"]}
+            assert events <= set(php.SOURCE_EVENTS), f"{dashboard}/{tile['name']}"
+
+    def test_hogql_tiles_start_with_a_select(self):
+        for _, tile in _hogql_tiles():
+            assert _sql(tile).startswith(("SELECT", "WITH"))
+
+    def test_chart_axes_reference_columns_the_query_selects(self):
+        for dashboard, tile in _hogql_tiles():
+            settings = tile["query"].get("chartSettings")
+            if not settings:
+                continue
+            aliases = set(re.findall(r"AS (\w+)", _sql(tile)))
+            columns = [settings["xAxis"]["column"]] + [y["column"] for y in settings["yAxis"]]
+            missing = [c for c in columns if c not in aliases]
+            assert not missing, f"{dashboard}/{tile['name']} plots missing columns {missing}"
+
+    def test_funnels_are_ordered_and_have_a_conversion_window(self):
+        funnels = [tile for _, tile in _all_tiles()
+                   if tile["query"]["source"]["kind"] == "FunnelsQuery"]
+        assert len(funnels) == 2
+        for tile in funnels:
+            source = tile["query"]["source"]
+            assert len(source["series"]) >= 3
+            assert source["funnelsFilter"]["funnelOrderType"] == "ordered"
+            assert source["funnelsFilter"]["funnelWindowInterval"] > 0
+            assert source["funnelsFilter"]["funnelWindowIntervalUnit"] == "day"
+
+    def test_content_loop_funnel_follows_the_plan_to_engagement_path(self):
+        steps = [s["event"] for s in
+                 _tile_by_name("Growth — Content loop funnel")["query"]["source"]["series"]]
+        assert steps == ["content_plan_generated", "post_approved", "post_outcome"]
+
+    def test_signup_funnel_ends_at_subscription(self):
+        steps = [s["event"] for s in _tile_by_name(
+            "Growth — Signup → activation → subscription funnel")["query"]["source"]["series"]]
+        assert steps[0] == "signup_started" and steps[-1] == "subscription_started"
+
+    def test_celery_failure_tile_filters_on_the_state_string_not_the_boolean(self):
+        # A boolean property filter that doesn't match silently counts nothing — and an alert that
+        # never fires is worse than no alert.
+        series = _tile_by_name(php.INSIGHT_CELERY_FAILURES)["query"]["source"]["series"][0]
+        assert series["properties"] == [
+            {"key": "state", "value": ["FAILURE"], "operator": "exact", "type": "event"}]
+
+    def test_llm_spend_reads_the_proxy_cost_not_the_app_estimate(self):
+        series = _tile_by_name(php.INSIGHT_LLM_SPEND)["query"]["source"]["series"][0]
+        assert series["event"] == "$ai_generation"
+        assert (series["math"], series["math_property"]) == ("sum", "$ai_total_cost_usd")
+        # Summing both streams double-counts every call (docs/llm-analytics.md), so no tile query
+        # may read the app-side estimate.
+        assert "llm_call" not in str([tile["query"] for _, tile in _all_tiles()])
+
+    def test_comment_floor_tile_is_weekly(self):
+        # Human pacing takes account-wide rest days, so a daily floor would page on a healthy day.
+        source = _tile_by_name(php.INSIGHT_COMMENTS_WEEKLY)["query"]["source"]
+        assert source["interval"] == "week"
+
+    def test_publish_tile_counts_first_readings_only(self):
+        sql = _sql(_tile_by_name("Health — Posts published per day"))
+        assert "min(timestamp)" in sql and "GROUP BY post_id" in sql
+
+    def test_follower_delta_drops_the_first_reading(self):
+        sql = _sql(_tile_by_name("Health — Follower delta per day"))
+        assert "lagInFrame" in sql and "WHERE prev > 0" in sql
+
+    def test_demotion_tile_excludes_unreadable_readings_from_the_denominator(self):
+        sql = _sql(_tile_by_name("Growth — Comment visibility (Most-relevant demotion)"))
+        assert "visible_most_relevant IS NOT NULL" in sql
+
+
+class TestAlertSpecs:
+    def test_within_the_free_alert_budget(self):
+        assert 0 < len(php.alert_specs()) <= 5
+
+    def test_every_alert_points_at_a_tile_that_exists_and_is_alertable(self):
+        by_name = {tile["name"]: tile for _, tile in _all_tiles()}
+        for spec in php.alert_specs():
+            tile = by_name.get(spec["insight"])
+            assert tile is not None, spec["insight"]
+            source = tile["query"]["source"]
+            # An alert threshold is evaluated against ONE series by index — a breakdown or a second
+            # series makes `series_index: 0` ambiguous.
+            assert source["kind"] == "TrendsQuery"
+            assert len(source["series"]) == 1
+            assert "breakdownFilter" not in source
+
+    def test_alert_names_are_unique(self):
+        names = [spec["name"] for spec in php.alert_specs()]
+        assert len(names) == len(set(names))
+
+    def test_every_alert_has_exactly_one_meaningful_bound(self):
+        for spec in php.alert_specs():
+            bounds = spec["bounds"]
+            assert set(bounds) <= {"lower", "upper"} and bounds
+
+    def test_payload_matches_posthogs_alert_shape(self):
+        payload = php.alert_payload(php.alert_specs()[0], 42, [7])
+        assert payload["insight"] == 42
+        assert payload["subscribed_users"] == [7]
+        assert payload["config"] == {"type": "TrendsAlertConfig", "series_index": 0}
+        assert payload["threshold"]["configuration"]["type"] == "absolute"
+        assert payload["condition"] == {"type": "absolute_value"}
+        assert payload["enabled"] is True
+
+
+class TestEvaluateThreshold:
+    def test_below_floor_breaches(self):
+        verdict = php.evaluate_threshold({"lower": php.COMMENT_WEEKLY_FLOOR}, 0)
+        assert verdict["breach"] is True and "below" in verdict["reason"]
+
+    def test_at_the_floor_is_not_a_breach(self):
+        assert php.evaluate_threshold({"lower": 5}, 5)["breach"] is False
+
+    def test_above_cap_breaches(self):
+        verdict = php.evaluate_threshold({"upper": php.LLM_DAILY_COST_CAP_USD}, 99.5)
+        assert verdict["breach"] is True and "above" in verdict["reason"]
+
+    def test_within_bounds_is_quiet(self):
+        assert php.evaluate_threshold({"upper": 25}, 3)["breach"] is False
+
+    def test_missing_reading_is_not_a_breach(self):
+        # A gap in ingest is not an incident — paging on it would make every quiet hour an alert.
+        assert php.evaluate_threshold({"lower": 5}, None)["breach"] is False
+        assert php.evaluate_threshold({"lower": 5}, "")["breach"] is False
+
+    def test_string_values_are_compared_numerically(self):
+        assert php.evaluate_threshold({"upper": 5}, "6")["breach"] is True
+
+
+class TestReportSchedule:
+    def test_next_start_is_the_coming_monday_at_the_report_hour(self):
+        # 2026-07-26 is a Sunday.
+        start = php.next_report_start(datetime(2026, 7, 26, 12, 0, tzinfo=timezone.utc))
+        assert start == "2026-07-27T09:00:00Z"
+
+    def test_a_monday_before_the_hour_still_schedules_that_day(self):
+        start = php.next_report_start(datetime(2026, 7, 27, 3, 0, tzinfo=timezone.utc))
+        assert start == "2026-07-27T09:00:00Z"
+
+    def test_a_monday_after_the_hour_rolls_to_next_week(self):
+        start = php.next_report_start(datetime(2026, 7, 27, 10, 0, tzinfo=timezone.utc))
+        assert start == "2026-08-03T09:00:00Z"
+
+    def test_subscription_spec_targets_the_growth_dashboard_weekly(self):
+        spec = php.subscription_spec("owner@example.com",
+                                     now=datetime(2026, 7, 26, tzinfo=timezone.utc))
+        assert spec["dashboard"] == php.DASH_GROWTH
+        assert spec["target_type"] == "email"
+        assert spec["target_value"] == "owner@example.com"
+        assert spec["frequency"] == "weekly" and spec["byweekday"] == ["monday"]
+
+
+class TestPlanActions:
+    def test_empty_project_creates_everything(self):
+        actions = php.plan_actions(php.build_specs(), {}, {})
+        assert sum(1 for a in actions if a["action"] == "create_dashboard") == 2
+        assert all(a["action"] in ("create_dashboard", "create_insight") for a in actions)
+
+    def test_matching_state_is_unchanged(self):
+        specs = php.build_specs()
+        dashboards = {spec["name"]: i for i, spec in enumerate(specs, start=1)}
+        insights = {}
+        for i, spec in enumerate(specs, start=1):
+            for tile in spec["tiles"]:
+                insights[tile["name"]] = {"id": 900 + len(insights), "query": tile["query"],
+                                          "description": tile["description"], "dashboards": [i]}
+        actions = php.plan_actions(specs, dashboards, insights)
+        assert {a["action"] for a in actions} == {"unchanged"}
+        assert php.pending(actions) == []
+
+    def test_drifted_query_is_updated(self):
+        specs = php.build_specs()[:1]
+        tile = specs[0]["tiles"][0]
+        actions = php.plan_actions(
+            specs, {specs[0]["name"]: 1},
+            {tile["name"]: {"id": 5, "query": {"kind": "edited-away"},
+                            "description": tile["description"], "dashboards": [1]}})
+        update = next(a for a in actions if a["insight"] == tile["name"])
+        assert update["action"] == "update_insight" and update["insight_id"] == 5
+
+    def test_detached_insight_is_reattached(self):
+        specs = php.build_specs()[:1]
+        tile = specs[0]["tiles"][0]
+        actions = php.plan_actions(
+            specs, {specs[0]["name"]: 1},
+            {tile["name"]: {"id": 5, "query": tile["query"],
+                            "description": tile["description"], "dashboards": []}})
+        assert next(a for a in actions if a["insight"] == tile["name"])["action"] == "update_insight"
+
+    def test_description_drift_is_updated(self):
+        specs = php.build_specs()[:1]
+        tile = specs[0]["tiles"][0]
+        actions = php.plan_actions(
+            specs, {specs[0]["name"]: 1},
+            {tile["name"]: {"id": 5, "query": tile["query"], "description": "stale",
+                            "dashboards": [1]}})
+        assert next(a for a in actions if a["insight"] == tile["name"])["action"] == "update_insight"
+
+
+class TestPlanAlerts:
+    def _insight_ids(self):
+        return {spec["insight"]: i for i, spec in enumerate(php.alert_specs(), start=100)}
+
+    def test_missing_insight_blocks_rather_than_creates(self):
+        actions = php.plan_alerts(php.alert_specs(), {}, {})
+        assert {a["action"] for a in actions} == {"blocked_alert"}
+        assert php.pending(actions) == actions
+
+    def test_creates_when_the_insight_exists(self):
+        actions = php.plan_alerts(php.alert_specs(), {}, self._insight_ids(), [7])
+        assert {a["action"] for a in actions} == {"create_alert"}
+        assert actions[0]["payload"]["subscribed_users"] == [7]
+
+    def test_unchanged_when_bounds_and_insight_match(self):
+        ids = self._insight_ids()
+        existing = {spec["name"]: {"id": 1, "insight_id": ids[spec["insight"]],
+                                   "bounds": spec["bounds"], "enabled": True}
+                    for spec in php.alert_specs()}
+        actions = php.plan_alerts(php.alert_specs(), existing, ids)
+        assert {a["action"] for a in actions} == {"unchanged_alert"}
+
+    def test_threshold_drift_is_updated(self):
+        ids = self._insight_ids()
+        spec = php.alert_specs()[0]
+        existing = {spec["name"]: {"id": 1, "insight_id": ids[spec["insight"]],
+                                   "bounds": {"lower": 999}, "enabled": True}}
+        action = php.plan_alerts([spec], existing, ids)[0]
+        assert action["action"] == "update_alert" and action["alert_id"] == 1
+
+    def test_a_disabled_alert_is_re_enabled(self):
+        ids = self._insight_ids()
+        spec = php.alert_specs()[0]
+        existing = {spec["name"]: {"id": 1, "insight_id": ids[spec["insight"]],
+                                   "bounds": spec["bounds"], "enabled": False}}
+        assert php.plan_alerts([spec], existing, ids)[0]["action"] == "update_alert"
+
+
+class TestPlanSubscriptions:
+    def test_missing_dashboard_blocks(self):
+        spec = php.subscription_spec("owner@example.com")
+        assert php.plan_subscriptions([spec], [], {})[0]["action"] == "blocked_subscription"
+
+    def test_creates_when_absent(self):
+        spec = php.subscription_spec("owner@example.com")
+        action = php.plan_subscriptions([spec], [], {php.DASH_GROWTH: 9})[0]
+        assert action["action"] == "create_subscription"
+        assert action["payload"]["dashboard"] == 9
+
+    def test_existing_subscription_is_not_recreated_when_start_date_moved_on(self):
+        # PostHog advances start_date with every send; diffing it would recreate the weekly email
+        # on every run and spam the owner.
+        spec = php.subscription_spec("Owner@Example.com")
+        existing = [{"id": 3, "dashboard": 9, "target_value": "owner@example.com",
+                     "target_type": "email", "frequency": "weekly",
+                     "start_date": "1999-01-01T09:00:00Z"}]
+        action = php.plan_subscriptions([spec], existing, {php.DASH_GROWTH: 9})[0]
+        assert action["action"] == "unchanged_subscription" and action["subscription_id"] == 3
+
+    def test_a_different_recipient_creates_a_second_subscription(self):
+        spec = php.subscription_spec("new@example.com")
+        existing = [{"id": 3, "dashboard": 9, "target_value": "old@example.com",
+                     "frequency": "weekly"}]
+        assert php.plan_subscriptions([spec], existing,
+                                      {php.DASH_GROWTH: 9})[0]["action"] == "create_subscription"
+
+    def test_a_deleted_subscription_is_replaced(self):
+        spec = php.subscription_spec("owner@example.com")
+        existing = [{"id": 3, "dashboard": 9, "target_value": "owner@example.com",
+                     "frequency": "weekly", "deleted": True}]
+        assert php.plan_subscriptions([spec], existing,
+                                      {php.DASH_GROWTH: 9})[0]["action"] == "create_subscription"
+
+
+class TestApplyActions:
+    def _client(self):
+        client = MagicMock()
+        client.create_dashboard.return_value = 11
+        client.create_insight.return_value = 22
+        client.create_alert.return_value = 33
+        client.create_subscription.return_value = 44
+        client.list_dashboards.return_value = {php.DASH_HEALTH: 11, php.DASH_GROWTH: 12}
+        return client
+
+    def test_dry_run_writes_nothing(self):
+        client = self._client()
+        actions = php.plan_actions(php.build_specs(), {}, {})
+        log = php.apply_actions(client, actions, dry_run=True)
+        assert all(line.startswith("[dry-run]") for line in log)
+        client.create_dashboard.assert_not_called()
+        client.create_insight.assert_not_called()
+
+    def test_apply_creates_dashboards_before_their_insights(self):
+        client = self._client()
+        actions = php.plan_actions(php.build_specs(), {}, {})
+        php.apply_actions(client, actions, dry_run=False)
+        assert client.create_dashboard.call_count == 2
+        assert client.create_insight.call_count == len(_all_tiles())
+        # Every insight lands on the id the create returned, not on a re-listed guess.
+        assert all(call.args[1] == 11 for call in client.create_insight.call_args_list[:1])
+
+    def test_apply_looks_up_pre_existing_dashboards_for_new_insights(self):
+        client = self._client()
+        specs = php.build_specs()[:1]
+        actions = php.plan_actions(specs, {specs[0]["name"]: 11}, {})
+        php.apply_actions(client, actions, dry_run=False)
+        client.list_dashboards.assert_called()
+        assert all(call.args[1] == 11 for call in client.create_insight.call_args_list)
+
+    def test_apply_writes_alerts_and_subscriptions(self):
+        client = self._client()
+        ids = {spec["insight"]: 100 for spec in php.alert_specs()}
+        actions = php.plan_alerts(php.alert_specs(), {}, ids, [7])
+        actions += php.plan_subscriptions([php.subscription_spec("owner@example.com")], [],
+                                          {php.DASH_GROWTH: 12})
+        log = php.apply_actions(client, actions, dry_run=False)
+        assert client.create_alert.call_count == len(php.alert_specs())
+        assert client.create_subscription.call_count == 1
+        assert any("created subscription" in line for line in log)
+
+    def test_blocked_items_are_reported_not_written(self):
+        client = self._client()
+        log = php.apply_actions(client, php.plan_alerts(php.alert_specs(), {}, {}), dry_run=False)
+        client.create_alert.assert_not_called()
+        assert all(line.startswith("skipped") for line in log)
+
+    def test_summarize_counts_every_action_kind(self):
+        summary = php.summarize([{"action": "create_insight"}, {"action": "create_insight"},
+                                 {"action": "unchanged"}])
+        assert summary == "create_insight=2, unchanged=1"
+
+    def test_summarize_empty(self):
+        assert php.summarize([]) == "nothing to do"
+
+    def test_dashboard_url(self):
+        assert php.dashboard_url("https://us.posthog.com/", "1", 9) == \
+            "https://us.posthog.com/project/1/dashboard/9"
+
+
+class TestClientNormalization:
+    def test_alert_insight_id_accepts_both_api_shapes(self):
+        assert php._insight_id_of(7) == 7
+        assert php._insight_id_of({"id": 7, "name": "x"}) == 7
+        assert php._insight_id_of(None) is None
+
+
+class TestMain:
+    def _client(self, **overrides):
+        client = MagicMock()
+        client.list_dashboards.return_value = {}
+        client.list_insights.return_value = {}
+        client.list_alerts.return_value = {}
+        client.list_subscriptions.return_value = []
+        client.whoami.return_value = {"id": 7, "email": "owner@example.com"}
+        client.create_dashboard.return_value = 11
+        client.create_insight.return_value = 22
+        for key, value in overrides.items():
+            getattr(client, key).return_value = value
+        return client
+
+    def test_print_sql_needs_no_network(self, capsys, monkeypatch):
+        monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+        assert php.main(["--print-sql"]) == 0
+        out = capsys.readouterr().out
+        assert php.DASH_HEALTH in out and "FunnelsQuery" in out
+
+    def test_simulate_reports_a_synthetic_breach(self, capsys):
+        name = php.alert_specs()[0]["name"]
+        assert php.main([f"--simulate={name}=0"]) == 0
+        assert "BREACH" in capsys.readouterr().out
+
+    def test_simulate_reports_a_healthy_value(self, capsys):
+        spec = next(s for s in php.alert_specs() if "upper" in s["bounds"])
+        assert php.main([f"--simulate={spec['name']}=0"]) == 0
+        assert "ok" in capsys.readouterr().out
+
+    def test_simulate_unknown_alert_errors(self, capsys):
+        assert php.main(["--simulate=nope=1"]) == 1
+        assert "Unknown alert" in capsys.readouterr().err
+
+    def test_missing_api_key_is_an_error(self, monkeypatch, capsys):
+        monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+        assert php.main([]) == 1
+        assert "POSTHOG_PERSONAL_API_KEY" in capsys.readouterr().err
+
+    def test_dry_run_on_an_empty_project_reports_pending(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        monkeypatch.setenv("POSTHOG_REPORT_EMAIL", "owner@example.com")
+        client = self._client()
+        monkeypatch.setattr(php, "PostHogClient", lambda *a, **k: client)
+        assert php.main(["--dry-run"]) == 2
+        out = capsys.readouterr().out
+        assert "[dry-run] create dashboard" in out
+        client.create_dashboard.assert_not_called()
+
+    def test_apply_provisions_dashboards_alerts_and_the_report(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        monkeypatch.delenv("POSTHOG_REPORT_EMAIL", raising=False)
+        client = self._client()
+        # After the insight pass the ids exist, so alerts and the subscription can be planned.
+        created = {tile["name"]: {"id": 500 + i, "query": tile["query"],
+                                  "description": tile["description"], "dashboards": [11]}
+                   for i, (_, tile) in enumerate(_all_tiles())}
+        client.list_insights.side_effect = [{}, created]
+        client.list_dashboards.side_effect = [{}, {php.DASH_HEALTH: 11, php.DASH_GROWTH: 12},
+                                              {php.DASH_HEALTH: 11, php.DASH_GROWTH: 12}]
+        monkeypatch.setattr(php, "PostHogClient", lambda *a, **k: client)
+        assert php.main(["--apply"]) == 0
+        assert client.create_alert.call_count == len(php.alert_specs())
+        client.create_subscription.assert_called_once()
+        # Recipient falls back to the API key owner when POSTHOG_REPORT_EMAIL is unset.
+        assert client.create_subscription.call_args.args[0]["target_value"] == "owner@example.com"
+
+    def test_unreadable_state_is_an_error(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        client = self._client()
+        client.list_dashboards.side_effect = RuntimeError("boom")
+        monkeypatch.setattr(php, "PostHogClient", lambda *a, **k: client)
+        assert php.main(["--dry-run"]) == 1
+        assert "Failed to read PostHog state" in capsys.readouterr().err
+
+    def test_whoami_failure_still_provisions_dashboards(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        monkeypatch.delenv("POSTHOG_REPORT_EMAIL", raising=False)
+        client = self._client()
+        client.whoami.side_effect = RuntimeError("no user:read scope")
+        monkeypatch.setattr(php, "PostHogClient", lambda *a, **k: client)
+        assert php.main(["--dry-run"]) == 2
+        err = capsys.readouterr().err
+        assert "alerts will have no subscriber" in err
+        assert "weekly report not provisioned" in err

--- a/tests/unit/test_posthog_provision.py
+++ b/tests/unit/test_posthog_provision.py
@@ -89,6 +89,16 @@ class TestSpecs:
             events = {s["event"] for s in tile["query"]["source"]["series"]}
             assert events <= set(php.SOURCE_EVENTS), f"{dashboard}/{tile['name']}"
 
+    def test_no_aggregate_is_aliased_to_a_column_it_reads(self):
+        # ClickHouse rejects `sum(followers) AS followers` outright ("aggregate function is found
+        # inside another aggregate function") — the alias re-binds the name the other aggregates in
+        # the same SELECT read, so the whole tile renders an error, not a wrong number.
+        for dashboard, tile in _hogql_tiles():
+            collisions = [(fn, col) for fn, col, alias in re.findall(
+                r"\b(sum|count|avg|min|max|median|uniq|uniqExact|any)\s*\(\s*(\w+)\s*\)\s+AS\s+(\w+)",
+                _sql(tile)) if col == alias]
+            assert not collisions, f"{dashboard}/{tile['name']} self-aliases {collisions}"
+
     def test_hogql_tiles_start_with_a_select(self):
         for _, tile in _hogql_tiles():
             assert _sql(tile).startswith(("SELECT", "WITH"))
@@ -308,6 +318,37 @@ class TestPlanAlerts:
         actions = php.plan_alerts(php.alert_specs(), existing, ids)
         assert {a["action"] for a in actions} == {"unchanged_alert"}
 
+    def test_a_subscriberless_alert_is_repaired(self):
+        # An alert PostHog created with no subscribed_users emails nobody. Matching only on bounds
+        # would call it healthy forever, so the run that CAN name the owner adds them.
+        ids = self._insight_ids()
+        spec = php.alert_specs()[0]
+        existing = {spec["name"]: {"id": 1, "insight_id": ids[spec["insight"]],
+                                   "bounds": spec["bounds"], "enabled": True,
+                                   "subscribed_users": []}}
+        action = php.plan_alerts([spec], existing, ids, [7])[0]
+        assert action["action"] == "update_alert"
+        assert action["payload"]["subscribed_users"] == [7]
+
+    def test_an_extra_subscriber_added_in_the_ui_is_not_dropped(self):
+        ids = self._insight_ids()
+        spec = php.alert_specs()[0]
+        existing = {spec["name"]: {"id": 1, "insight_id": ids[spec["insight"]],
+                                   "bounds": {"lower": 999}, "enabled": True,
+                                   "subscribed_users": [9]}}
+        action = php.plan_alerts([spec], existing, ids, [7])[0]
+        assert action["payload"]["subscribed_users"] == [7, 9]
+
+    def test_an_unknown_owner_never_reports_subscriber_drift(self):
+        # whoami failed, so there is no one to add — reporting drift we can't fix would make every
+        # dry run exit 2 forever.
+        ids = self._insight_ids()
+        spec = php.alert_specs()[0]
+        existing = {spec["name"]: {"id": 1, "insight_id": ids[spec["insight"]],
+                                   "bounds": spec["bounds"], "enabled": True,
+                                   "subscribed_users": []}}
+        assert php.plan_alerts([spec], existing, ids, [])[0]["action"] == "unchanged_alert"
+
     def test_threshold_drift_is_updated(self):
         ids = self._insight_ids()
         spec = php.alert_specs()[0]
@@ -430,6 +471,12 @@ class TestClientNormalization:
         assert php._insight_id_of(7) == 7
         assert php._insight_id_of({"id": 7, "name": "x"}) == 7
         assert php._insight_id_of(None) is None
+
+    def test_subscriber_id_accepts_both_api_shapes(self):
+        # PostHog serializes subscribed_users as nested user objects on read, bare ids on write.
+        assert php._user_id_of(7) == 7
+        assert php._user_id_of({"id": 7, "email": "owner@example.com"}) == 7
+        assert php._user_id_of(None) is None
 
 
 class TestMain:

--- a/tests/unit/utilities/linkedin/test_rate_limit.py
+++ b/tests/unit/utilities/linkedin/test_rate_limit.py
@@ -136,10 +136,16 @@ class TestTripTelemetry:
     def test_tracking_failure_never_breaks_the_breaker(self, fake_redis):
         fake_redis.incr.return_value = 1
         with patch("cqc_lem.utilities.observability.track_rate_limit_trip",
-                   side_effect=RuntimeError("posthog down")):
+                   side_effect=RuntimeError("posthog down")), \
+                patch(f"{_MOD}.log_warning") as warned:
             from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited
             mark_rate_limited("x")  # must not raise
         fake_redis.set.assert_called_once()  # the cooldown was still written
+        # ...and the failure must not be reported as a breaker failure: the breaker IS open, and
+        # that message would send whoever is debugging a doom loop after the wrong thing.
+        messages = [call.args[0] for call in warned.call_args_list]
+        assert not any("Failed to set" in message for message in messages)
+        assert any("Failed to track" in message for message in messages)
 
 
 class TestCooldownRemaining:

--- a/tests/unit/utilities/linkedin/test_rate_limit.py
+++ b/tests/unit/utilities/linkedin/test_rate_limit.py
@@ -119,6 +119,29 @@ class TestMarkRateLimited:
         mark_rate_limited("x")  # must not raise
 
 
+class TestTripTelemetry:
+    """The trip is the only signal that says LinkedIn is throttling us, and the warning it logs
+    never reaches PostHog at the default POSTHOG_LOG_LEVEL — so it is emitted as its own event for
+    the Health dashboard's 429 tile and its spike alert (issue #650)."""
+
+    def test_trip_is_tracked_with_cooldown_and_consecutive_count(self, fake_redis, monkeypatch):
+        monkeypatch.setenv("LINKEDIN_RATE_LIMIT_COOLDOWN_SECONDS", "100")
+        monkeypatch.delenv("LINKEDIN_RATE_LIMIT_MAX_COOLDOWN_SECONDS", raising=False)
+        fake_redis.incr.return_value = 3  # cooldown = 100 * 2^2
+        with patch("cqc_lem.utilities.observability.track_rate_limit_trip") as tracked:
+            from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited
+            mark_rate_limited("auth wall")
+        tracked.assert_called_once_with(400, 3, "auth wall")
+
+    def test_tracking_failure_never_breaks_the_breaker(self, fake_redis):
+        fake_redis.incr.return_value = 1
+        with patch("cqc_lem.utilities.observability.track_rate_limit_trip",
+                   side_effect=RuntimeError("posthog down")):
+            from cqc_lem.utilities.linkedin.rate_limit import mark_rate_limited
+            mark_rate_limited("x")  # must not raise
+        fake_redis.set.assert_called_once()  # the cooldown was still written
+
+
 class TestCooldownRemaining:
     def test_returns_positive_ttl(self, fake_redis):
         fake_redis.ttl.return_value = 42

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -691,6 +691,37 @@ class TestTrackCapacityAlert:
         assert mock_ph.capture.call_args[1]["properties"] == {"generated_at": None}
 
 
+class TestTrackRateLimitTrip:
+    """Issue #650: the 429 breaker's own event, so the Health dashboard and its spike alert have a
+    signal — the trip's WARNING log never reaches PostHog at the default POSTHOG_LOG_LEVEL."""
+
+    def test_captures_the_trip_system_scoped(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_rate_limit_trip
+            track_rate_limit_trip(1800, 3, "auth wall")
+
+        mock_ph.capture.assert_called_once()
+        _, kwargs = mock_ph.capture.call_args
+        assert kwargs["event"] == "rate_limit_trip"
+        # LinkedIn throttles by egress IP — a trip is account-wide, not one user's.
+        assert kwargs["distinct_id"] == "system"
+        props = kwargs["properties"]
+        assert props["cooldown_seconds"] == 1800 and props["consecutive_trips"] == 3
+        assert props["reason"] == "auth wall"
+
+    def test_defaults_the_reason(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_rate_limit_trip
+            track_rate_limit_trip(60, 1, "")
+        assert mock_ph.capture.call_args[1]["properties"]["reason"] == "429"
+
+    def test_never_raises(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            mock_ph.capture.side_effect = RuntimeError("posthog down")
+            from cqc_lem.utilities.observability import track_rate_limit_trip
+            track_rate_limit_trip(60, 1)  # the breaker must still open
+
+
 class TestTrackCommentOutcome:
     """Issue #628: one event per comment we read back, and one weekly scorecard per user."""
 


### PR DESCRIPTION
## What & why

PostHog had 41 insights across 6 dashboards and still couldn't answer two questions: **do LEM's business loops close?** and **did something break overnight?** Every metric was a point reading, every watchdog was a hand-run cron, and the 2-week perf report was a human remembering to run it.

`scripts/posthog_provision.py` defines that surface as code — idempotent, `--dry-run` by default:

- **LEM Health** — Celery failures (count, rate, by task name), LinkedIn 429 breaker trips, proxy-reported LLM spend/day, posts published/day, follower delta, API error rate + p95.
- **LEM Growth** — the content-loop funnel (`content_plan_generated` → `post_approved` → `post_outcome`), the `signup_started` → … → `subscription_started` funnel, onboarding step drop-off, the comment → author-reply engagement loop, comment visibility and ER/audience trends.
- **Four threshold alerts** (of PostHog's 5 free): comments/week below floor, LLM spend/day over cap, Celery failure spike, 429 spike — emailed to the key owner.
- **One weekly email subscription** of LEM Growth, Monday 09:00 UTC. That is what replaces the hand-run perf-report cadence.

It sits **on top of** `scripts/posthog_dashboards.py` (cost/margin), which it does not replace — Health/Growth is the top level, the cost set is the drill-down.

## The one instrumentation change

The 429 alert had no signal to read. A breaker trip only ever produced a `log_warning`, and PostHog forwards `ERROR` and up by default — so the single event that says *LinkedIn is throttling us* was invisible to dashboards and alerts alike. `mark_rate_limited()` now also emits `rate_limit_trip` (`cooldown_seconds`, `consecutive_trips`, `reason`) via `observability.track_rate_limit_trip`. System-scoped (LinkedIn throttles by egress IP, so a trip is account-wide), and it never raises — the breaker must still open when analytics is down.

## Decisions worth reviewing

- **Alertable tiles are native single-series `TrendsQuery` insights.** PostHog can alert on trends/funnel/SQL insights, but the threshold is evaluated against one series by index — a breakdown or second series makes `series_index: 0` ambiguous.
- **They filter on the `state` STRING, not the `success` boolean.** A boolean property filter that silently matches nothing produces an alert that never fires, which is worse than no alert.
- **The comment floor is weekly, not daily.** Human pacing (#626) takes account-wide rest days; a daily floor would page on a perfectly healthy zero-comment day.
- **Comments are counted from `comment_outcome`** (the T+24h sweep) — the only per-comment event that exists. It lags a day; that's documented, not hidden.
- **Money tiles read `$ai_generation`, never `llm_call`** (docs/llm-analytics.md) — a test asserts no tile mixes the two streams.
- **Insight names must stay unique across both provisioner scripts.** Each plans by name against the same project, so a shared name would make them fight over one insight forever — a unit test fails the build if they ever collide.
- **Subscriptions diff on (dashboard, recipient, frequency), never `start_date`**, which PostHog advances on every send — diffing it would recreate the subscription and mail a duplicate every run.
- **Engagement loop is a HogQL conversion tile, not a funnel.** Only comment → author-reply is instrumented today; connection-accepted and DM-reply join it as steps when that data lands, rather than shipping a funnel with two permanently-empty steps.

## Notes for the owner

- Several tiles read events that exist in code but haven't flowed into the project yet (`comment_outcome`, `audience_snapshot`, the funnel events, the SPA's `post_approved`/`content_plan_generated`). They render empty until those land — same deliberate behaviour as the cost dashboards. **The alerts are the exception**: run `--apply` once those events are actually flowing, or the comments-floor alert reads 0 and fires on its first evaluation.
- PostHog renders at most 6 tiles into a subscription email, so Growth's tile order is the email's priority order; audience growth is the one that falls off the bottom.
- New env: `POSTHOG_REPORT_EMAIL` (falls back to the API key owner's email). The personal key needs `insight`/`dashboard`/`alert`/`subscription` read+write plus `user:read`.

## Testing

- `tests/unit/test_posthog_provision.py` — 66 tests over the specs, funnel shapes, alert/threshold evaluation, the planner (create/update/unchanged/blocked), `apply_actions` dry-run vs apply, and `main()` end to end with a mocked client.
- `--simulate 'NAME=VALUE'` runs the same comparison PostHog runs server-side, which is how the "fires on synthetic threshold breach" criterion is provable without live data.
- New coverage for `track_rate_limit_trip` and for the breaker emitting it (including that a tracking failure never stops the cooldown being written).
- Full unit suite green locally: **6730 passed**.

Docs: `docs/kpi-dashboards.md`, plus a CLAUDE.md subsection.

Closes #650

🤖 Generated with [Claude Code](https://claude.com/claude-code)
