### PR TITLE
feat(flags): runtime feature flags with local evaluation + SPA bootstrap (closes #651)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -109,6 +109,8 @@ POST_RESEARCH_ENABLED=true
 # Feed comments: default FALSE. Comments run at high volume (many/day/user) and are already
 # grounded in the target post — a Perplexity call per comment would multiply API spend for
 # marginal value. Opt in only if you want research-backed comments.
+# ALSO a runtime feature flag (`comment-research-enabled`, docs/feature-flags.md) — this env var is
+# what it falls back to when PostHog has no answer, so it stays the source of truth for the fleet.
 COMMENT_RESEARCH_ENABLED=false
 # Lead-magnet soft-ask cadence: when a user has the "comment KEYWORD → DM" lead magnet enabled,
 # weave the compliant "comment KEYWORD and I'll DM it to you" CTA into roughly 1 in N generated
@@ -521,6 +523,20 @@ POSTHOG_APP_HOST=https://us.posthog.com
 # (issue #650, docs/kpi-dashboards.md) — the automated replacement for the hand-run perf report.
 # Unset falls back to the personal API key owner's own email.
 POSTHOG_REPORT_EMAIL=
+# --- Feature flags (issue #651, docs/feature-flags.md) ---
+# Runtime toggles evaluated LOCALLY in-process (no network call per check) from definitions polled
+# by the SDK. They need the POSTHOG_PERSONAL_API_KEY above (scope: feature_flag:read) in the app
+# containers — without it, and on every other failure path, every flag falls back to its own env
+# var and behaviour is exactly what it was before flags existed.
+# Master kill switch for the whole mechanism: false = env vars only, no polling, no lookups.
+POSTHOG_FLAGS_ENABLED=true
+# How often a worker re-reads flag definitions — i.e. the worst-case delay before a flip is live.
+# Also the cooldown between retries when a definition fetch fails, so an outage can't make every
+# flag check in a feed loop attempt its own fetch.
+POSTHOG_FLAG_POLL_SECONDS=30
+# Fleet default for `feed_fallback_when_empty` for users who have never SAVED engagement
+# preferences. A user's own saved setting always wins over this and over the flag.
+FEED_FALLBACK_WHEN_EMPTY_DEFAULT=true
 # --- PostHog in the SPA (issue #646) ---
 # Read by Vite at BUILD time and baked into the bundle, so they must be set for `npm run build`
 # (docker build-arg / CI env), not in the running container. Leave VITE_POSTHOG_KEY empty and the
@@ -611,6 +627,8 @@ INFRA_FIXED_MONTHLY=0
 # proxy on later would start at whatever cohort the sham ramp had reached.
 # Shipped OFF by owner decision (PR #529): the loop is dormant — while COST_ROUTING_ENABLED is false
 # the weekly task observes nothing and just republishes the parked policy. Flip BOTH to true to start.
+# The app side is ALSO a runtime feature flag (`cost-routing-enabled`, docs/feature-flags.md) that
+# falls back to this var; the proxy side stays env-only (routing_policy.py must remain stdlib-only).
 COST_ROUTING_ENABLED=false
 COST_AWARE_ROUTING_ENABLED=false
 # Where the policy document lives. MUST be the same Redis the app and the LiteLLM container share.
@@ -768,7 +786,9 @@ FEEDBACK_MAX_ISSUES_PER_USER_PER_DAY=3
 
 # --- Marketing video tutorials (issue #505) ---
 # Automated SPA how-to videos: headless capture -> grounded script -> TTS -> ffmpeg MP4 -> YouTube.
-# OFF by default (it renders and uploads public marketing assets).
+# OFF by default (it renders and uploads public marketing assets). ALSO a runtime feature flag
+# (`tutorial-videos-enabled`, docs/feature-flags.md) that gates BOTH the producer and the SPA
+# section; this env var is its fallback.
 TUTORIAL_VIDEOS_ENABLED=False
 # Where the capture browser points. Empty = this deployment's own public URL.
 TUTORIAL_SPA_BASE_URL=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -365,6 +365,35 @@ AI-detector (`AI_DETECTOR_*`) is OFF by default, sampled on a stable per-item dr
 and a REGRESSION SIGNAL ONLY per the #416 policy — it never rewrites or holds anything, and a missing
 key is a silent no-op.
 
+### Feature flags — runtime toggles (issue #651)
+
+`utilities/flags.py` is the ONE place a runtime toggle is read, and its contract is **fail open to
+the env var**: no personal API key, `POSTHOG_FLAGS_ENABLED=false`, definitions unloaded, flag
+undefined, evaluation inconclusive, SDK raises — every one of those returns the flag's own env var,
+so a deployment with no PostHog flags behaves exactly as it did before. Each registered flag keeps
+its env var as BOTH default and fallback; the registry (`FLAGS`, a `FlagSpec` per toggle with key /
+env var / default / owner) is the whole vocabulary, and call sites use the exported constant so a
+typo raises instead of silently reading `False` inside a Celery task.
+
+Lookups are `only_evaluate_locally=True` + `send_feature_flag_events=False`: definitions are polled
+into the process (`POSTHOG_FLAG_POLL_SECONDS`, default 30) and evaluated in memory, so a feed loop
+checking a flag per post makes ZERO network requests and a flip lands on a long-running worker
+without a restart. The one fetch is at a process's first check, and a failed fetch retries no more
+than once per poll interval. The price is a hard registry constraint: **flags must use rollout-%
+/ distinct-ID conditions only** — a person-property condition can't be decided locally and would
+silently fall back to env everywhere. distinct_id is `str(user_id)` / `"system"`, same as
+`observability.py`.
+
+Read the toggle at the CALL SITE, never into a module constant at import — an import-time read is
+exactly how a flag ends up doing nothing. Migrated so far: `comment-research-enabled`,
+`tutorial-videos-enabled`, `feed-fallback-when-empty-default` (fleet default only — a user's saved
+row always wins), `cost-routing-enabled`. **Safety controls are NOT flags**: the 429 breaker,
+`hold_commenting`, `pause_automation`/the suppression tripwire and every per-day cap stay in
+Redis/env, and `COST_AWARE_ROUTING_ENABLED` stays env-only because `routing_policy.py` must remain
+stdlib-only. The SPA bootstraps from `GET /api/flags` (server-resolved, so no flag flicker and no
+disagreement between browser, API and workers) via `hooks/useFeatureFlags.ts` — NOT through
+posthog-js, which stays the analytics surface. Full posture: `docs/feature-flags.md`.
+
 ## CI Gates
 
 Before merging any PR, all of the following must pass:

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -1,0 +1,131 @@
+# Feature flags (issue #651)
+
+LEM's operational toggles were env vars: changing one meant editing `/opt/lem/.env` and restarting
+the stack. PostHog feature flags make the same toggles changeable at runtime, with percentage
+rollouts and per-user targeting. `src/cqc_lem/utilities/flags.py` is the ONE place that knows how a
+flag is read; `GET /api/flags` is the ONE place the SPA reads them from.
+
+## The contract: fail open to the env var
+
+A flag service is a dependency. An engagement automation that changed behaviour because PostHog was
+unreachable would be worse than one that can't be toggled at all — so **every** path that isn't a
+clear PostHog answer returns the flag's env var:
+
+| Situation | Value used |
+|---|---|
+| `POSTHOG_FLAGS_ENABLED=false` | env var |
+| No `POSTHOG_API_KEY` or no `POSTHOG_PERSONAL_API_KEY` | env var |
+| Definitions not loaded yet / load failed | env var |
+| Flag not defined in PostHog | env var |
+| Flag defined but not decidable locally | env var |
+| SDK raises | env var |
+| Flag evaluates to `true` / `false` / a variant | **PostHog** |
+
+A deployment that never creates a single PostHog flag behaves exactly as it did before this existed.
+The env var is therefore not a legacy leftover — it is the documented answer to "what happens if
+PostHog is down", and it stays the default for every registered flag.
+
+## Local evaluation, and what it costs you
+
+Lookups pass `only_evaluate_locally=True`. The SDK's background poller pulls flag *definitions* into
+the process every `POSTHOG_FLAG_POLL_SECONDS` (default 30) and every lookup is evaluated in memory —
+so a Celery loop checking a flag per feed post makes **zero** network requests, and a flip reaches a
+long-running worker within one poll interval without a restart.
+
+The one network call is the definition fetch at a process's FIRST flag check (the SDK caps it at
+10s); a failure there falls back to env vars and is retried no more often than one poll interval, so
+an outage can never turn a feed loop into a fetch loop.
+
+The constraint local evaluation buys: a flag whose release condition needs person properties only the
+server holds **cannot be decided locally**, and every worker would silently fall back to its env var.
+
+> **Registered flags must use rollout percentage / distinct-ID conditions only.**
+
+`send_feature_flag_events=False` on every lookup, too: a `$feature_flag_called` event per checked
+feed post is volume nobody reads.
+
+`distinct_id` follows `observability.py`'s convention — `str(user_id)`, or the `"system"` sentinel —
+so a per-user rollout targets the SAME PostHog person that user's own events land on.
+
+## What is NOT a flag, and never will be
+
+Safety controls stay in Redis/env, where they are one authority a PostHog outage, a mis-targeted
+rollout or an errant %-ramp cannot touch:
+
+- the 429 breaker and `hold_commenting` (`utilities/linkedin/rate_limit.py`)
+- `pause_automation()` / the suppression tripwire (`utilities/suppression.py`)
+- every per-day cap (`max_comments_per_day`, `max_dms_per_day`, `max_invites_per_day`)
+- `COST_AWARE_ROUTING_ENABLED`, the proxy half of cost routing — `utilities/routing_policy.py` is
+  mounted into the LiteLLM container and must stay stdlib-only, so it can never import `flags.py`
+
+## The registry
+
+Flag key == registry name == the string in PostHog. Add a `FlagSpec` to `FLAGS` in
+`utilities/flags.py`; call sites use the module constant, never a bare string, so a typo raises
+instead of silently evaluating to `False` inside a Celery task.
+
+| Flag key | Env fallback | Default | Owner | What it governs |
+|---|---|---|---|---|
+| `comment-research-enabled` | `COMMENT_RESEARCH_ENABLED` | `false` | content | Per-comment web research (`content_research.py`). Expensive at feed volume — the toggle most worth trialling on a cohort. Scoped per user. |
+| `tutorial-videos-enabled` | `TUTORIAL_VIDEOS_ENABLED` | `false` | marketing | The weekly tutorial producer (`video_tutorials.py`) AND the SPA section that embeds its output — one toggle covers both. System-scoped. |
+| `feed-fallback-when-empty-default` | `FEED_FALLBACK_WHEN_EMPTY_DEFAULT` | `true` | engagement | Fleet default for `feed_fallback_when_empty` for users with no SAVED engagement row. A saved per-user setting always wins. |
+| `cost-routing-enabled` | `COST_ROUTING_ENABLED` | `false` | cost | App side of cost-aware down-routing (`cost_routing.py`) — written into the published routing policy. System-scoped. |
+
+## Adding a flag
+
+1. Add a `FlagSpec` to `FLAGS` (key, env var, default, owner, description) and export a constant.
+2. Add the env var to `.env.example` next to the feature it governs, noting that it is a flag
+   fallback.
+3. Replace the toggle read at the **call site**, not at import — a constant read at import time can't
+   be flipped without a deploy. That is the single most common way to make a flag do nothing.
+4. Create the flag in PostHog with the same key, using a rollout-percentage condition.
+5. Add a row to the table above.
+
+## The SPA
+
+`GET /api/flags` returns `{distinct_id, flags: {key: bool}, local_evaluation: bool}` — every
+registered flag, already resolved server-side. `local_evaluation: false` is the honest half: it means
+every value in the payload is an env default, not a PostHog decision.
+
+```tsx
+import { FLAGS, useFeatureFlag } from '../hooks/useFeatureFlags'
+
+const enabled = useFeatureFlag(FLAGS.tutorialVideos)   // fallback defaults to false
+```
+
+Three reasons the SPA reads flags from the API rather than from `posthog-js`:
+
+- it is a **bootstrap** — one payload, so a gated section renders correctly on the FIRST paint
+  instead of flickering from default to real value;
+- it is the SAME evaluation the API and the workers just did, so the three can't disagree;
+- it works with browser analytics fully off (no `VITE_POSTHOG_KEY`) — flags are a product control,
+  not an analytics feature.
+
+`utils/analytics.ts` stays the SPA's ONE PostHog surface for events/replay/identify. Don't add a
+second client-side posthog reader for flags; that reintroduces exactly the split-brain this endpoint
+removes.
+
+An absent or invalid session resolves the same flags for the `"system"` identity rather than 401ing —
+the landing page is logged out and still needs to know what to render.
+
+## Configuration
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `POSTHOG_FLAGS_ENABLED` | `true` | Master kill switch. `false` = env vars only, no polling, no lookups. |
+| `POSTHOG_PERSONAL_API_KEY` | — | Required for local evaluation (scope `feature_flag:read`). Must be present in the **app** containers, not only in the cron scripts' environment. |
+| `POSTHOG_FLAG_POLL_SECONDS` | `30` | Definition refresh interval — the worst-case delay before a flip is live. Doubles as the retry cooldown after a failed fetch. |
+
+## Verifying
+
+```bash
+# What this process resolves, and whether PostHog is actually deciding any of it
+docker exec celery_worker python -c \
+  "from cqc_lem.utilities.flags import bootstrap_payload; print(bootstrap_payload(1))"
+
+# The same payload the SPA bootstraps from
+curl -s "$LEM_URL/api/flags" | jq .detail
+```
+
+`local_evaluation: false` with a personal key set means the definition fetch failed — check the
+key's scopes and the worker's WARNING log (`PostHog feature-flag local evaluation unavailable`).

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -106,7 +106,10 @@ second client-side posthog reader for flags; that reintroduces exactly the split
 removes.
 
 An absent or invalid session resolves the same flags for the `"system"` identity rather than 401ing —
-the landing page is logged out and still needs to know what to render.
+the landing page is logged out and still needs to know what to render. For the same reason
+`/api/flags` sits in `_PUBLIC_API_PREFIXES`, outside the `API_ACCESS_TOKENS` bearer gate: the landing
+page carries no bearer token, and the SPA's axios interceptor treats any 401 as a dead session, so a
+gated flags query would log a signed-in visitor out on `/`.
 
 ## Configuration
 

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -170,9 +170,15 @@ _API_ACCESS_TOKEN_SET = {t.strip() for t in API_ACCESS_TOKENS.split(",") if t.st
 # of /api/user/* stays gated.
 # /api/faq is public: it serves the published front-page FAQ (issue #506) to logged-out visitors on
 # the landing page. GET-only, no user data — same shape as /api/app-info.
+# /api/flags is public for the SAME reason (issue #651): the landing page bootstraps its feature
+# flags from it and carries no bearer token. Gating it would 401 the flags query, and the SPA's
+# axios interceptor treats ANY 401 as a dead session — it clears lem_session and redirects, so a
+# signed-in visitor hitting the landing page would be silently logged out. GET-only; it returns the
+# registry's own toggle values, and the optional session_token is self-authenticating (an invalid
+# one resolves the "system" identity rather than erroring) — same model as /api/user/linkedin-cookie.
 _PUBLIC_API_PREFIXES = ("/api/auth/", "/api/billing/webhook", "/api/assets",
                         "/api/linkedin/verification-pin", "/api/linkedin/comment-notification",
-                        "/api/app-info", "/api/faq",
+                        "/api/app-info", "/api/faq", "/api/flags",
                         "/api/extension/", "/api/user/linkedin-cookie")
 
 

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1074,6 +1074,22 @@ def shipped_notices_endpoint(session_token: str) -> ResponseModel:
     })
 
 
+@router.get("/flags")
+def get_feature_flags(session_token: Optional[str] = None) -> ResponseModel:
+    """Server-evaluated feature flags for the SPA (issue #651, docs/feature-flags.md).
+
+    This is the SPA's flag BOOTSTRAP: values are resolved server-side with PostHog local evaluation
+    (or the env fallback) and shipped in one payload, so the browser renders the right thing on the
+    FIRST paint instead of flickering while a client-side flag request lands — and so the SPA, the
+    API and the Celery workers can never disagree about a flag's value.
+
+    An invalid or absent session resolves the SAME flags for the `"system"` identity rather than
+    401ing: the landing page is logged out and still needs to know what to render."""
+    from cqc_lem.utilities.flags import bootstrap_payload
+    user_id = get_session_user_id(session_token) if session_token else None
+    return ResponseModel(status_code=200, detail=bootstrap_payload(user_id))
+
+
 @router.get("/faq")
 def faq_endpoint() -> ResponseModel:
     """Public: the front-page FAQ (issue #506). Serves only the published entries, in display

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1843,8 +1843,10 @@ def auto_weekly_cost_routing(self, days: int = COST_ROUTING_WINDOW_DAYS):
     down-route experiment against the §D.3 quality gate (engagement non-inferiority +
     `posts.authenticity_score`), promotes the ones that hold, **auto-rolls-back** the ones that
     don't, opens at most `COST_ROUTING_MAX_EXPERIMENTS` new ones, and publishes the policy the
-    LiteLLM complexity router reads. While COST_ROUTING_ENABLED is off it observes nothing and only
-    republishes the parked policy, so the loop is dormant until the flag is turned on."""
+    LiteLLM complexity router reads. While the `cost-routing-enabled` flag is off (its fallback is
+    COST_ROUTING_ENABLED) it observes nothing and only republishes the parked policy, so the loop is
+    dormant until the flag is turned on — and because that is resolved per run, turning it on takes
+    effect on the next weekly beat rather than the next deploy."""
     from cqc_lem.utilities.cost_routing import apply_routing_report, collect_routing_report
 
     report = collect_routing_report(days=days)

--- a/src/cqc_lem/ui/src/components/TutorialVideos.tsx
+++ b/src/cqc_lem/ui/src/components/TutorialVideos.tsx
@@ -1,9 +1,14 @@
 import { useEffect, useState } from 'react'
 import api from '../api/client'
+import { FLAGS, useFeatureFlag } from '../hooks/useFeatureFlags'
 
 // Automated feature tutorials (issue #505). The video agent writes a manifest of finished
 // tutorials into the shared assets volume; this reads it and embeds whatever is there. Nothing
 // produced yet -> renders nothing, so the page never shows an empty "videos" shell.
+//
+// Gated by the same `tutorial-videos-enabled` flag that gates the PRODUCER (issue #651), so one
+// runtime toggle covers both filming the tutorials and showing them — no deploy to pull the
+// section. Fallback is OFF: an unreachable API must not publish a marketing section.
 interface TutorialRecord {
   flow: string
   title: string
@@ -19,8 +24,10 @@ const MANIFEST = '/assets?file_name=videos/tutorials/manifest.json'
 
 export default function TutorialVideos() {
   const [videos, setVideos] = useState<TutorialRecord[]>([])
+  const enabled = useFeatureFlag(FLAGS.tutorialVideos)
 
   useEffect(() => {
+    if (!enabled) return
     let cancelled = false
     api
       .get(MANIFEST)
@@ -33,9 +40,9 @@ export default function TutorialVideos() {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [enabled])
 
-  if (videos.length === 0) return null
+  if (!enabled || videos.length === 0) return null
 
   return (
     <section id="tutorials" className="py-16 px-4 bg-white">

--- a/src/cqc_lem/ui/src/hooks/useFeatureFlags.test.tsx
+++ b/src/cqc_lem/ui/src/hooks/useFeatureFlags.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { FLAGS, useFeatureFlag, useFeatureFlags } from './useFeatureFlags'
+
+const get = vi.fn()
+vi.mock('../api/client', () => ({ default: { get: (...args: unknown[]) => get(...args) } }))
+
+function payload(flags: Record<string, boolean>, localEvaluation = true) {
+  return { data: { detail: { distinct_id: 'system', flags, local_evaluation: localEvaluation } } }
+}
+
+function harness(ui: ReactNode) {
+  // retry:false so an error case resolves in one tick instead of on the query's own back-off.
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+function Probe({ fallback }: { fallback?: boolean }) {
+  const enabled = useFeatureFlag(FLAGS.tutorialVideos, fallback)
+  const { isLoading } = useFeatureFlags()
+  return <span data-testid="value">{isLoading ? 'loading' : String(enabled)}</span>
+}
+
+beforeEach(() => {
+  get.mockReset()
+  localStorage.clear()
+})
+afterEach(cleanup)
+
+describe('useFeatureFlag (issue #651)', () => {
+  it('renders the fallback until the bootstrap lands, then the server value', async () => {
+    get.mockReturnValue(new Promise(() => {})) // never resolves
+    harness(<Probe />)
+    expect(screen.getByTestId('value').textContent).toBe('loading')
+
+    cleanup()
+    get.mockResolvedValue(payload({ [FLAGS.tutorialVideos]: true }))
+    harness(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('true'))
+  })
+
+  it('falls back to the SAFE value when the API is unreachable — never turns a feature on', async () => {
+    get.mockRejectedValue(new Error('network down'))
+    harness(<Probe />)
+    await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('false'))
+  })
+
+  it('honours an explicit fallback for a flag missing from the payload', async () => {
+    get.mockResolvedValue(payload({ 'some-other-flag': true }))
+    harness(<Probe fallback />)
+    await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('true'))
+  })
+
+  it('reports a server false even though the flag key IS present', async () => {
+    get.mockResolvedValue(payload({ [FLAGS.tutorialVideos]: false }))
+    harness(<Probe fallback />)
+    await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('false'))
+  })
+
+  it('sends the session token so a per-user rollout can reach this browser', async () => {
+    localStorage.setItem('lem_session', 'tok en')
+    get.mockResolvedValue(payload({}))
+    harness(<Probe />)
+    await waitFor(() => expect(get).toHaveBeenCalled())
+    expect(get).toHaveBeenCalledWith('/flags?session_token=tok%20en')
+  })
+
+  it('asks anonymously when there is no session — the landing page is logged out', async () => {
+    get.mockResolvedValue(payload({}))
+    harness(<Probe />)
+    await waitFor(() => expect(get).toHaveBeenCalled())
+    expect(get).toHaveBeenCalledWith('/flags')
+  })
+})

--- a/src/cqc_lem/ui/src/hooks/useFeatureFlags.test.tsx
+++ b/src/cqc_lem/ui/src/hooks/useFeatureFlags.test.tsx
@@ -12,8 +12,11 @@ function payload(flags: Record<string, boolean>, localEvaluation = true) {
 }
 
 function harness(ui: ReactNode) {
-  // retry:false so an error case resolves in one tick instead of on the query's own back-off.
-  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  // retryDelay:0, NOT retry:false — useFeatureFlags() sets `retry: 1` on the query itself (one
+  // transient blip must not drop the whole bootstrap), and a per-query option beats a client
+  // default, so the retry happens either way. Only the back-off is a default, and left at the
+  // real one (~1s) the error case settles slower than waitFor's 1s timeout.
+  const client = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } })
   return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
 }
 

--- a/src/cqc_lem/ui/src/hooks/useFeatureFlags.ts
+++ b/src/cqc_lem/ui/src/hooks/useFeatureFlags.ts
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query'
+import api from '../api/client'
+
+// Runtime feature flags in the SPA (issue #651, docs/feature-flags.md).
+//
+// The values come from the SERVER (`GET /api/flags`), already resolved by utilities/flags.py with
+// PostHog local evaluation and the env-var fallback. That is deliberate and it is the whole point:
+//
+// - It is a BOOTSTRAP — one payload, resolved before the browser asks, so a gated section renders
+//   correctly on the first paint instead of flickering from default to real value.
+// - It is the SAME evaluation the API and the Celery workers just did, so the three can never
+//   disagree about a flag.
+// - It still works with browser analytics fully off (no VITE_POSTHOG_KEY): flags are a product
+//   control, not an analytics feature, and must not depend on posthog-js loading.
+//
+// Flags are NOT read through posthog-js here. analytics.ts stays the SPA's ONE PostHog surface for
+// events/replay/identify; adding a second client-side posthog reader would reintroduce exactly the
+// split-brain this endpoint removes.
+
+// Keys mirror utilities/flags.py FLAGS — same string on both sides, no second registry.
+export const FLAGS = {
+  commentResearch: 'comment-research-enabled',
+  tutorialVideos: 'tutorial-videos-enabled',
+  feedFallbackDefault: 'feed-fallback-when-empty-default',
+  costRouting: 'cost-routing-enabled',
+} as const
+
+export type FlagKey = (typeof FLAGS)[keyof typeof FLAGS]
+
+export interface FlagBootstrap {
+  distinct_id: string
+  flags: Record<string, boolean>
+  // false = every value above is an env default, not a PostHog decision.
+  local_evaluation: boolean
+}
+
+const EMPTY: FlagBootstrap = { distinct_id: 'system', flags: {}, local_evaluation: false }
+
+export function useFeatureFlags() {
+  return useQuery({
+    queryKey: ['feature-flags'],
+    queryFn: () => {
+      // Not a hook dependency on purpose: the flags query is mounted app-wide, and an anonymous
+      // visitor must get a payload rather than an error.
+      const token = localStorage.getItem('lem_session')
+      const qs = token ? `?session_token=${encodeURIComponent(token)}` : ''
+      return api.get(`/flags${qs}`).then((r) => r.data.detail as FlagBootstrap)
+    },
+    // A flag flip should reach an open tab without a reload, but polling every render is waste —
+    // the worker-side poll interval (30s) is the cadence this mirrors.
+    staleTime: 30 * 1000,
+    refetchOnWindowFocus: true,
+    // An unreachable API must never turn a gated feature on. `fallback` below owns that decision.
+    retry: 1,
+  })
+}
+
+/**
+ * One flag's value. `fallback` is what to render while the payload is in flight OR when the API is
+ * unreachable — so pass the SAFE value (usually the off/hidden one), exactly like the server falls
+ * back to its env var.
+ */
+export function useFeatureFlag(key: FlagKey, fallback = false): boolean {
+  const { data } = useFeatureFlags()
+  const flags = (data ?? EMPTY).flags
+  return key in flags ? flags[key] : fallback
+}

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -330,10 +330,12 @@ def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=No
         blueprint = _framework.select_blueprint("comment")
     blueprint_block = _framework.blueprint_directive("comment", blueprint) if post_comment is None else ""
 
-    # Optional, tightly-gated background facts: research_topic returns empty immediately unless
-    # COMMENT_RESEARCH_ENABLED is explicitly on, so the default path makes NO research call.
+    # Optional, tightly-gated background facts: research_topic returns empty immediately unless the
+    # `comment-research-enabled` flag (default COMMENT_RESEARCH_ENABLED) is on, so the default path
+    # makes NO research call. `user_id` is what lets a rollout reach one cohort (issue #651).
     if research is None and post_comment is None:
-        research = research_topic(str(post_content or "")[:300], content_type="comment", prefs=prefs)
+        research = research_topic(str(post_content or "")[:300], content_type="comment", prefs=prefs,
+                                  user_id=user_id)
     findings = str((research or {}).get("findings") or "").strip()
     research_block = (
         "\n\nOptional background facts (use at most ONE, only when it genuinely strengthens the "

--- a/src/cqc_lem/utilities/ai/content_research.py
+++ b/src/cqc_lem/utilities/ai/content_research.py
@@ -14,10 +14,14 @@ COST POLICY (per-type toggles, all under the CONTENT_RESEARCH_ENABLED master swi
   worth one search call each.
 - comment — COMMENT_RESEARCH_ENABLED, default OFF. Comments run at HIGH volume (many per day per
   user) and are already grounded in their primary source: the TARGET POST. Firing a Perplexity
-  search per comment would multiply API spend for marginal value, so comment research is opt-in."""
+  search per comment would multiply API spend for marginal value, so comment research is opt-in.
+  This is the one type ALSO carried by a runtime feature flag (issue #651): it is the expensive,
+  reversible toggle worth trialling on a cohort without a deploy. The env var stays its default and
+  its fallback — see utilities/flags.py."""
 
 import os
 
+from cqc_lem.utilities.flags import COMMENT_RESEARCH, flag_enabled
 from cqc_lem.utilities.logger import log_debug, log_warning
 
 _EMPTY: dict = {"findings": "", "sources": []}
@@ -58,11 +62,16 @@ def _bool_env(name: str, default: bool) -> bool:
     return raw.strip().lower() not in ("0", "false", "no", "off")
 
 
-def research_enabled(content_type: str) -> bool:
-    """Master switch AND the per-type toggle must both allow research."""
+def research_enabled(content_type: str, user_id: int = None) -> bool:
+    """Master switch AND the per-type toggle must both allow research. The comment toggle is
+    additionally flag-controlled (issue #651) and can therefore be trialled per-user; the flag falls
+    back to COMMENT_RESEARCH_ENABLED whenever PostHog has no answer."""
     if not _bool_env("CONTENT_RESEARCH_ENABLED", True):
         return False
     env_name, default = _TYPE_TOGGLES.get(content_type, _TYPE_TOGGLES["comment"])
+    # Unknown types already inherit the comment toggle, so they inherit its flag too.
+    if env_name == _TYPE_TOGGLES["comment"][0]:
+        return flag_enabled(COMMENT_RESEARCH, user_id=user_id)
     return _bool_env(env_name, default)
 
 
@@ -112,12 +121,13 @@ def _research_via_litellm(query: str, max_sources: int) -> dict:
 
 def research_topic(subject: str, content_type: str = "newsletter", blueprint: dict = None,
                    context_description: str = None, prefs: dict = None,
-                   max_sources: int = 5) -> dict:
+                   max_sources: int = 5, user_id: int = None) -> dict:
     """One research call for one piece of content. Returns {'findings': str, 'sources': [{'url':
     ...}]}; empty findings on toggle-off, missing key, or any failure — callers always generate
-    regardless."""
+    regardless. `user_id` only scopes the flag lookup (issue #651) — pass it where a per-user
+    rollout should be able to reach this call."""
     subject = (subject or "").strip()
-    if not subject or not research_enabled(content_type):
+    if not subject or not research_enabled(content_type, user_id=user_id):
         return dict(_EMPTY)
     query = _build_research_query(subject, content_type, blueprint, context_description, prefs)
     try:

--- a/src/cqc_lem/utilities/cost_routing.py
+++ b/src/cqc_lem/utilities/cost_routing.py
@@ -16,10 +16,13 @@ The loop, once a week:
    `utilities/routing_policy.py` is the single shared decision core, so router and optimizer can
    never disagree about which bucket a call belongs to.
 
-Two independent flags gate it: `COST_ROUTING_ENABLED` (this side — writes `enabled` into the policy)
-and `COST_AWARE_ROUTING_ENABLED` (the proxy side). Either one off means the router routes exactly as
-it did before this existed. Only features with a real quality signal (`MEASURABLE_FEATURES`) can be
-auto-experimented; everything else is reported as a human-gated recommendation, per §D.3.
+Two independent flags gate it: the `cost-routing-enabled` feature flag (this side — writes `enabled`
+into the policy; falls back to `COST_ROUTING_ENABLED`, see utilities/flags.py) and
+`COST_AWARE_ROUTING_ENABLED` (the proxy side, deliberately still an env var — `routing_policy.py` is
+mounted into the LiteLLM container and must stay stdlib-only). Either one off means the router routes
+exactly as it did before this existed. Only features with a real quality signal
+(`MEASURABLE_FEATURES`) can be auto-experimented; everything else is reported as a human-gated
+recommendation, per §D.3.
 """
 from __future__ import annotations
 
@@ -37,7 +40,6 @@ from cqc_lem.utilities.env_constants import (
     COST_ROUTING_AUTH_MAX_DROP,
     COST_ROUTING_CONFIDENCE_Z,
     COST_ROUTING_COOLDOWN_DAYS,
-    COST_ROUTING_ENABLED,
     COST_ROUTING_INITIAL_COHORT,
     COST_ROUTING_MAX_EXPERIMENTS,
     COST_ROUTING_MAX_QUALITY_DROP,
@@ -45,6 +47,7 @@ from cqc_lem.utilities.env_constants import (
     COST_ROUTING_WINDOW_DAYS,
     MARGIN_REPORT_EMAIL,
 )
+from cqc_lem.utilities.flags import COST_ROUTING, flag_enabled
 from cqc_lem.utilities.logger import log_error, log_info, log_warning
 from cqc_lem.utilities.routing_policy import (
     ARM_CONTROL,
@@ -93,6 +96,13 @@ CANDIDATE_TIERS = (TIER_COMPLEX, TIER_MEDIUM)
 # revocable — the permanent holdout is what keeps auto-rollback (§D.3) alive after full rollout.
 ADOPTED_COHORT_PCT = 0.9
 COHORT_RAMP_TAIL = (0.5, ADOPTED_COHORT_PCT)
+
+
+def routing_enabled() -> bool:
+    """Is the app side of cost-aware routing on RIGHT NOW? Runtime flag first, `COST_ROUTING_ENABLED`
+    as its default and fallback (issue #651). System-scoped: this is a fleet-wide experiment
+    governor, not a per-user setting."""
+    return flag_enabled(COST_ROUTING)
 
 
 def default_thresholds() -> dict:
@@ -346,12 +356,15 @@ def propose_buckets(observations: Optional[Sequence[Mapping]], existing: Mapping
 def build_routing_policy(previous: Optional[Mapping], observations: Optional[Sequence[Mapping]],
                          today: date, spend_by_feature: Optional[Mapping] = None,
                          thresholds: Optional[Mapping] = None,
-                         enabled: bool = COST_ROUTING_ENABLED) -> dict:
+                         enabled: Optional[bool] = None) -> dict:
     """Evaluate every live bucket, then open new experiments in whatever slots are left, and return
     `{"policy": ..., "changes": [...], "recommendations": [...]}`.
 
-    `enabled` is written INTO the document, so flipping `COST_ROUTING_ENABLED` off parks every bucket
-    at once without erasing the experiment state the next run needs."""
+    `enabled` is written INTO the document, so flipping the `cost-routing-enabled` flag off parks
+    every bucket at once without erasing the experiment state the next run needs. `None` resolves it
+    at CALL time (flag, else COST_ROUTING_ENABLED) rather than at import, which is what makes a flip
+    land on the next weekly run instead of the next deploy."""
+    enabled = routing_enabled() if enabled is None else bool(enabled)
     limits = {**default_thresholds(), **(thresholds or {})}
     policy = normalize_policy(previous)
     buckets = dict(policy.get("buckets") or {})
@@ -521,17 +534,18 @@ def collect_quality_observations(days: int = COST_ROUTING_WINDOW_DAYS,
 
 def collect_routing_report(days: int = COST_ROUTING_WINDOW_DAYS, today: Optional[date] = None,
                            thresholds: Optional[Mapping] = None,
-                           enabled: bool = COST_ROUTING_ENABLED) -> dict:
+                           enabled: Optional[bool] = None) -> dict:
     """Read the live policy, the window's quality observations and (when the ledger is capturing) the
     per-feature spend, then build the next policy.
 
-    While `COST_ROUTING_ENABLED` is off nothing is being routed, so the window is not scanned at all —
+    While cost routing is off nothing is being routed, so the window is not scanned at all —
     the weekly run costs one Redis read/write instead of a cross-user posts+post_stats scan. It still
     republishes the parked (`enabled: false`) document so the proxy sees the flag flip, and any bucket
     left in it is judged on no data, which can only HOLD: turning the flag back on resumes exactly
     where the loop left off, and no experiment can open while it is off."""
     from cqc_lem.utilities.db import cost_ledger_available, get_cost_rollup
 
+    enabled = routing_enabled() if enabled is None else bool(enabled)
     today = today or _today()
     observations = collect_quality_observations(days, end=today) if enabled else []
     spend = (get_cost_rollup(today - timedelta(days=max(int(days), 1)), today, group_by="feature")

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -3170,6 +3170,9 @@ _ENGAGEMENT_DEFAULTS: dict = {
     "default_buyer_stage": None,
     "default_video_quality": "standard",
     "reply_check_mode": "event", "reply_sweeps_per_day": 2, "reply_max_post_age_days": 2,
+    # feed_fallback_when_empty's FLEET default is runtime-controlled by the
+    # `feed-fallback-when-empty-default` flag (issue #651) via _code_engagement_defaults(); the
+    # value here is what that flag falls back to. A saved row always wins over both.
     "feed_fallback_when_empty": True, "link_in_first_comment": True,
     # Catch-up congratulations (issue #482): small cap, human approval, and only the BD-relevant
     # milestone types out of the box — a generic "Congrats!" at volume is worse than nothing.
@@ -3260,6 +3263,16 @@ def _select_engagement_row(user_id: int) -> Optional[dict]:
         connection.close()
 
 
+def _code_engagement_defaults(user_id: int) -> dict:
+    """`_ENGAGEMENT_DEFAULTS` with the one field whose FLEET default is runtime-controlled resolved
+    for this user (issue #651). Only reached when the user has no saved row: once they save one, the
+    column holds their own explicit 0/1 and the flag can never override it."""
+    from cqc_lem.utilities.flags import FEED_FALLBACK_DEFAULT, flag_enabled
+    defaults = dict(_ENGAGEMENT_DEFAULTS)
+    defaults["feed_fallback_when_empty"] = flag_enabled(FEED_FALLBACK_DEFAULT, user_id=user_id)
+    return defaults
+
+
 def get_engagement_preferences(user_id: int) -> dict:
     """Return the user's engagement preferences (voice/targeting/caps) with code-level
     defaults when no row exists — so behaviour is unchanged until the user customizes."""
@@ -3267,8 +3280,8 @@ def get_engagement_preferences(user_id: int) -> dict:
         row = _select_engagement_row(user_id)
     except mysql.connector.Error as err:
         myprint(f"Could not get engagement prefs for user_id {user_id} | Error: {err}")
-        return dict(_ENGAGEMENT_DEFAULTS)
-    return dict(_ENGAGEMENT_DEFAULTS) if row is None else row
+        return _code_engagement_defaults(user_id)
+    return _code_engagement_defaults(user_id) if row is None else row
 
 
 def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
@@ -3286,7 +3299,7 @@ def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
         log_error("Could not read engagement prefs before update — aborting write",
                   exc=err, user_id=user_id)
         return False
-    base = {**_ENGAGEMENT_DEFAULTS,
+    base = {**_code_engagement_defaults(user_id),
             **{k: v for k, v in (existing or {}).items() if k in _ENGAGEMENT_DEFAULTS}}
     merged = {**base, **{k: v for k, v in prefs.items() if k in _ENGAGEMENT_DEFAULTS}}
 

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -247,8 +247,9 @@ COST_ALERT_EMAIL          = get_constant_from_env('COST_ALERT_EMAIL', default_va
 # Cost-aware down-routing (docs/cost-performance-margin-plan.md §D.1(1)). OFF by default: this can
 # change which model writes a user's content, so it ships flag-gated and cohort-scoped. The LiteLLM
 # proxy has its own switch (COST_AWARE_ROUTING_ENABLED) — BOTH must be on for a call to down-route.
-COST_ROUTING_ENABLED      = (get_constant_from_env('COST_ROUTING_ENABLED', default_value='false')
-                             or '').strip().lower() in ('1', 'true', 'yes', 'on')
+# The app-side switch itself is NOT read here: `COST_ROUTING_ENABLED` is a runtime feature flag
+# (utilities/flags.py, issue #651) whose fallback is that same env var, resolved at CALL time so a
+# flip doesn't need a deploy. Reading it here too would freeze a second copy at import.
 # Days of post outcomes each weekly evaluation reads.
 COST_ROUTING_WINDOW_DAYS  = int(get_constant_from_env('COST_ROUTING_WINDOW_DAYS', default_value='28'))
 # Posts required PER ARM before a bucket is judged at all — below this the experiment just runs on.
@@ -307,8 +308,9 @@ API_ACCESS_TOKENS = get_constant_from_env('API_ACCESS_TOKENS', default_value='')
 # --- Marketing video tutorials (issue #505) ---
 # Fully-automated SPA how-to videos: headless capture -> grounded script -> TTS -> ffmpeg MP4 ->
 # YouTube. OFF by default: it renders + uploads public marketing assets, so it only runs where
-# someone deliberately turned it on.
-TUTORIAL_VIDEOS_ENABLED = isTrue(get_constant_from_env('TUTORIAL_VIDEOS_ENABLED', default_value='False'))
+# someone deliberately turned it on. The switch itself is a runtime feature flag
+# (`tutorial-videos-enabled`, utilities/flags.py) whose fallback is TUTORIAL_VIDEOS_ENABLED — not
+# read here, because a value frozen at import can't be flipped without a deploy.
 # Where the capture browser points. Defaults to this deployment's own public URL.
 TUTORIAL_SPA_BASE_URL = get_constant_from_env('TUTORIAL_SPA_BASE_URL', default_value='')
 # A real LEM session token (+ its email) for the demo account whose screens the authenticated

--- a/src/cqc_lem/utilities/flags.py
+++ b/src/cqc_lem/utilities/flags.py
@@ -1,0 +1,292 @@
+"""ONE runtime feature-flag surface (issue #651, docs/feature-flags.md).
+
+LEM's operational toggles are env vars, so changing one means editing `/opt/lem/.env` and restarting
+the stack. PostHog flags make the same toggles runtime-changeable (and %-rollout / per-user
+targetable) — but a flag service is a dependency, and an engagement automation that changes
+behaviour because PostHog was unreachable would be worse than one that can't be toggled at all.
+
+So the contract here is **fail-open to the env var**, in both directions:
+
+- No `POSTHOG_PERSONAL_API_KEY`, no project key, `POSTHOG_FLAGS_ENABLED=false`, definitions not
+  loaded, flag not defined in PostHog, evaluation inconclusive, SDK raises — every one of those
+  paths returns the env var's value. A deployment that never creates a single PostHog flag behaves
+  EXACTLY as it did before this module existed.
+- Every registered flag keeps its env var as both its default and its fallback, so the env var
+  stays the answer to "what happens if PostHog is down".
+
+**Local evaluation only.** `only_evaluate_locally=True` on every lookup: flag definitions are polled
+into the process by the SDK's background poller and evaluated in-process, so a Celery loop checking
+a flag per feed post makes ZERO network requests. The consequence is a real constraint on the
+registry — a flag whose release condition needs person properties the server holds cannot be decided
+locally, and every worker would silently fall back to its env var. **Registered flags must use
+rollout percentage / distinct-ID conditions only.**
+
+`send_feature_flag_events=False` for the same reason: these are checked in hot loops, and a
+`$feature_flag_called` event per feed post is noise nobody reads.
+
+**Safety controls are NOT flags and never will be.** The 429 breaker, the automation pause, the
+suppression tripwire and the per-day caps stay in Redis/env, where they are one authority that a
+PostHog outage, a mis-targeted rollout or an errant %-ramp cannot touch.
+
+distinct_id follows the same convention as `observability.py` — `str(user_id)`, or the `"system"`
+sentinel — so a per-user flag targets the SAME PostHog person the user's own events land on.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import posthog
+
+from cqc_lem.utilities.logger import log_debug, log_warning
+
+# Same sentinel observability.py uses for events with no user — one PostHog person, one convention.
+SYSTEM_DISTINCT_ID = "system"
+
+# Values that read as "off" in an env var or a flag variant. Everything else is on, so a flag set to
+# a real variant name (an experiment arm) counts as enabled.
+_OFF_VALUES = ("0", "false", "no", "off", "disabled", "control")
+
+
+@dataclass(frozen=True)
+class FlagSpec:
+    """One registered toggle. `key` is the PostHog flag key AND this registry's name — one
+    identifier, so a rename can't leave the code and PostHog disagreeing."""
+    key: str
+    env_var: str
+    default: bool
+    owner: str
+    description: str
+
+
+# --- The registry ------------------------------------------------------------------------------
+# Constants, not bare strings, at every call site: a typo'd flag name raises here instead of
+# silently evaluating to False somewhere in a Celery task.
+COMMENT_RESEARCH = "comment-research-enabled"
+TUTORIAL_VIDEOS = "tutorial-videos-enabled"
+FEED_FALLBACK_DEFAULT = "feed-fallback-when-empty-default"
+COST_ROUTING = "cost-routing-enabled"
+
+FLAGS: Dict[str, FlagSpec] = {
+    spec.key: spec for spec in (
+        FlagSpec(
+            key=COMMENT_RESEARCH,
+            env_var="COMMENT_RESEARCH_ENABLED",
+            default=False,
+            owner="content",
+            description=("Per-comment web research (content_research.py). OFF by default — comments "
+                         "run at high volume and are already grounded in the target post, so this "
+                         "multiplies Perplexity spend. Flip on to trial richer comments."),
+        ),
+        FlagSpec(
+            key=TUTORIAL_VIDEOS,
+            env_var="TUTORIAL_VIDEOS_ENABLED",
+            default=False,
+            owner="marketing",
+            description=("The weekly marketing tutorial producer (video_tutorials.py) and the SPA "
+                         "section that embeds its output. OFF by default — it renders and publishes "
+                         "public assets."),
+        ),
+        FlagSpec(
+            key=FEED_FALLBACK_DEFAULT,
+            env_var="FEED_FALLBACK_WHEN_EMPTY_DEFAULT",
+            default=True,
+            owner="engagement",
+            description=("Default for `feed_fallback_when_empty` for users who have never SAVED an "
+                         "engagement-preferences row. An explicit per-user setting always wins — "
+                         "this only moves the fleet default."),
+        ),
+        FlagSpec(
+            key=COST_ROUTING,
+            env_var="COST_ROUTING_ENABLED",
+            default=False,
+            owner="cost",
+            description=("App side of cost-aware down-routing (cost_routing.py) — writes `enabled` "
+                         "into the routing policy document. The proxy's own "
+                         "COST_AWARE_ROUTING_ENABLED is a SEPARATE switch and is deliberately NOT a "
+                         "flag: routing_policy.py must stay stdlib-only."),
+        ),
+    )
+}
+
+_POLL_INTERVAL_DEFAULT = 30
+
+_load_lock = threading.Lock()
+_loaded = False
+# When the last load was ATTEMPTED, so a persistently failing load can't turn every flag check in a
+# feed loop into a fresh definition fetch. None = never attempted.
+_last_load_attempt: Optional[float] = None
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    return raw.strip().lower() not in _OFF_VALUES
+
+
+def _spec(key: str) -> FlagSpec:
+    spec = FLAGS.get(key)
+    if spec is None:
+        raise KeyError(f"Unregistered feature flag '{key}' — add a FlagSpec to utilities/flags.py")
+    return spec
+
+
+def _now() -> float:
+    """Indirection so the retry cooldown is testable without patching the time module itself."""
+    return time.monotonic()
+
+
+def _poll_interval() -> int:
+    try:
+        value = int((os.getenv("POSTHOG_FLAG_POLL_SECONDS") or "").strip()
+                    or _POLL_INTERVAL_DEFAULT)
+    except ValueError:
+        return _POLL_INTERVAL_DEFAULT
+    return max(value, 1)
+
+
+def distinct_id(user_id: Optional[int] = None) -> str:
+    return str(user_id) if user_id is not None else SYSTEM_DISTINCT_ID
+
+
+def env_default(key: str) -> bool:
+    """The value this flag has with PostHog out of the picture — the fallback AND the default."""
+    spec = _spec(key)
+    return _bool_env(spec.env_var, spec.default)
+
+
+def local_evaluation_available() -> bool:
+    """Whether a PostHog lookup is even worth attempting. A personal API key is what makes LOCAL
+    evaluation possible; without it the SDK would fall back to a network call per check, which this
+    module never does."""
+    if not _bool_env("POSTHOG_FLAGS_ENABLED", True):
+        return False
+    if not (os.getenv("POSTHOG_API_KEY") or "").strip():
+        return False
+    if not (os.getenv("POSTHOG_PERSONAL_API_KEY") or "").strip():
+        return False
+    return not getattr(posthog, "disabled", False)
+
+
+def _ensure_loaded() -> bool:
+    """Load flag definitions once per process and start the SDK's background poller.
+
+    The poller is what makes a flag flip visible to a long-lived Celery worker without a restart:
+    definitions refresh every `POSTHOG_FLAG_POLL_SECONDS` and every subsequent lookup reads the
+    refreshed set out of memory. The load itself is ONE blocking fetch at the process's first flag
+    check (the SDK caps it at 10s); everything after it is in-memory."""
+    global _loaded, _last_load_attempt
+    if _loaded:
+        return True
+    with _load_lock:
+        if _loaded:
+            return True
+        # A failed load retries — but no more than once per poll interval, or a PostHog outage would
+        # make every flag check in a feed loop attempt its own fetch.
+        now = _now()
+        if _last_load_attempt is not None and now - _last_load_attempt < _poll_interval():
+            return False
+        _last_load_attempt = now
+        try:
+            # observability.py is the ONE place posthog's module config (api key, host, disabled)
+            # lives. Imported lazily HERE — not at module import — so this module can't create an
+            # import cycle, and so the config is applied before setup() builds the client.
+            import cqc_lem.utilities.observability  # noqa: F401
+
+            posthog.personal_api_key = (os.getenv("POSTHOG_PERSONAL_API_KEY") or "").strip()
+            posthog.poll_interval = _poll_interval()
+            client = posthog.setup()
+            # setup() REUSES an existing client, and the first capture() may well have built one
+            # before a personal key was ever set — that client would never poll. Push the settings
+            # onto it directly so an already-running process still gets local evaluation.
+            client.personal_api_key = posthog.personal_api_key
+            client.poll_interval = posthog.poll_interval
+            posthog.load_feature_flags()
+            _loaded = True
+            log_debug(f"PostHog feature-flag local evaluation loaded "
+                      f"(poll every {posthog.poll_interval}s)", api_provider="posthog")
+        except Exception as exc:
+            # Never poison the process: a failed load just means every flag reads its env var
+            # until the cooldown above lets the next attempt through.
+            log_warning("PostHog feature-flag local evaluation unavailable — using env defaults",
+                        exc=exc, api_provider="posthog")
+            return False
+    return True
+
+
+def _coerce(value) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if not text:
+        return None
+    return text not in _OFF_VALUES
+
+
+def resolve_flag(key: str, user_id: Optional[int] = None) -> Optional[bool]:
+    """PostHog's answer for this flag, or None when it has no usable one (every fallback path)."""
+    if not local_evaluation_available() or not _ensure_loaded():
+        return None
+    try:
+        value = posthog.get_feature_flag(
+            key,
+            distinct_id(user_id),
+            # No network request, ever — this runs inside feed loops. An undecidable flag returns
+            # None and the caller falls back to the env var.
+            only_evaluate_locally=True,
+            # A $feature_flag_called per checked feed post is volume nobody reads.
+            send_feature_flag_events=False,
+        )
+    except Exception as exc:
+        log_warning(f"Feature flag '{key}' lookup failed — using env default", exc=exc,
+                    user_id=user_id, api_provider="posthog")
+        return None
+    return _coerce(value)
+
+
+def flag_enabled(key: str, user_id: Optional[int] = None) -> bool:
+    """The value of a registered toggle: PostHog's if it has one, otherwise the env var's."""
+    value = resolve_flag(key, user_id)
+    if value is None:
+        return env_default(key)
+    return value
+
+
+def all_flags(user_id: Optional[int] = None) -> Dict[str, bool]:
+    """Every registered flag resolved for one identity — the SPA's bootstrap payload, so the browser
+    renders with the SAME values the API and the workers just used instead of flickering."""
+    return {key: flag_enabled(key, user_id) for key in FLAGS}
+
+
+def bootstrap_payload(user_id: Optional[int] = None) -> dict:
+    """What `GET /api/flags` returns. `local_evaluation` is the honest half: false means every value
+    below is an env default, not a PostHog decision."""
+    resolved = all_flags(user_id)
+    return {
+        "distinct_id": distinct_id(user_id),
+        "flags": resolved,
+        "local_evaluation": local_evaluation_available() and _loaded,
+    }
+
+
+def registry_rows() -> list:
+    """The registry as plain dicts — for docs generation and the admin/registry test."""
+    return [{"key": spec.key, "env_var": spec.env_var, "default": spec.default,
+             "owner": spec.owner, "description": spec.description}
+            for spec in FLAGS.values()]
+
+
+def reset_flag_state() -> None:
+    """Drop the loaded-definitions latch AND the retry cooldown. For tests (and a future admin
+    reload); the SDK's own poller is left alone."""
+    global _loaded, _last_load_attempt
+    with _load_lock:
+        _loaded = False
+        _last_load_attempt = None

--- a/src/cqc_lem/utilities/marketing/video_tutorials.py
+++ b/src/cqc_lem/utilities/marketing/video_tutorials.py
@@ -44,9 +44,10 @@ from cqc_lem.utilities.env_constants import (API_URL_FINAL, ELEVENLABS_API_KEY,
                                              TUTORIAL_THUMBNAIL_ENABLED,
                                              TUTORIAL_TTS_COST_PER_1K_CHARS, TUTORIAL_TTS_MODEL,
                                              TUTORIAL_TTS_PROVIDER, TUTORIAL_TTS_VOICE,
-                                             TUTORIAL_VIDEOS_ENABLED, WAIT_DEFAULT_TIMEOUT,
+                                             WAIT_DEFAULT_TIMEOUT,
                                              YOUTUBE_CLIENT_ID, YOUTUBE_CLIENT_SECRET,
                                              YOUTUBE_PRIVACY_STATUS, YOUTUBE_REFRESH_TOKEN)
+from cqc_lem.utilities.flags import TUTORIAL_VIDEOS, flag_enabled
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text
 from cqc_lem.utilities.logger import log_debug, log_error, log_info, log_warning
 from cqc_lem.utilities.observability import FEATURE_MARKETING, track_media_cost
@@ -696,8 +697,12 @@ def produce_tutorial(flow_key: Optional[str] = None, driver=None) -> Optional[di
     """Produce (and publish) ONE tutorial end to end. Returns the manifest record, or None when
     the pipeline is disabled or there is nothing due. Raises on capture/guardrail/render failure —
     a broken tutorial must never reach YouTube."""
-    if not TUTORIAL_VIDEOS_ENABLED:
-        log_info("Tutorial production skipped — TUTORIAL_VIDEOS_ENABLED is off", task_name=TASK_NAME)
+    # Runtime toggle (issue #651): the `tutorial-videos-enabled` flag, falling back to
+    # TUTORIAL_VIDEOS_ENABLED whenever PostHog has no answer. Checked HERE rather than read at
+    # import so a flip lands on the next beat instead of the next deploy.
+    if not flag_enabled(TUTORIAL_VIDEOS):
+        log_info("Tutorial production skipped — the tutorial-videos-enabled flag is off",
+                 task_name=TASK_NAME)
         return None
 
     manifest = load_manifest()

--- a/tests/integration/test_flags_endpoint.py
+++ b/tests/integration/test_flags_endpoint.py
@@ -93,6 +93,22 @@ class TestFlagBootstrap:
         assert detail["local_evaluation"] is True
         assert all(detail["flags"].values())
 
+    def test_stays_outside_the_bearer_gate_for_a_logged_out_visitor(self, client):
+        """The landing page bootstraps its flags from here and carries no bearer token. If the gate
+        covered this path the query would 401 — and the SPA's axios interceptor reads ANY 401 as a
+        dead session, clearing lem_session and redirecting, so a signed-in visitor landing on `/`
+        would be logged out by a marketing section."""
+        from cqc_lem.api.main import _api_token_required, _PUBLIC_API_PREFIXES
+
+        assert "/api/flags" in _PUBLIC_API_PREFIXES
+        with patch(f"{_M}._API_ACCESS_TOKEN_SET", {"secret"}):
+            assert _api_token_required("/api/flags") is False
+            # The exact leaf only — the boundary rule must not open a future /api/flags-admin.
+            assert _api_token_required("/api/flags-admin") is True
+            response = _get(client, "/api/flags")
+
+        assert response.status_code == 200
+
     def test_posthog_decision_beats_the_env_var_in_the_payload(self, client, monkeypatch):
         monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
         monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")

--- a/tests/integration/test_flags_endpoint.py
+++ b/tests/integration/test_flags_endpoint.py
@@ -1,0 +1,104 @@
+"""Integration test for the SPA's feature-flag bootstrap endpoint (issue #651).
+
+Drives the real GET /api/flags handler through the real utilities/flags.py resolution, so the
+payload the browser bootstraps from is provably the SAME evaluation the API and the Celery workers
+just did — including the fail-open-to-env-var path, which is the whole contract.
+"""
+from contextlib import contextmanager
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from cqc_lem.utilities import flags
+
+pytestmark = pytest.mark.integration
+
+_M = "cqc_lem.api.main"
+
+
+@pytest.fixture
+def client():
+    from fastapi.testclient import TestClient
+    from cqc_lem.api.main import app
+    return TestClient(app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _clean_flag_state(monkeypatch):
+    for name in ("POSTHOG_FLAGS_ENABLED", "POSTHOG_API_KEY", "POSTHOG_PERSONAL_API_KEY",
+                 "COMMENT_RESEARCH_ENABLED", "TUTORIAL_VIDEOS_ENABLED",
+                 "FEED_FALLBACK_WHEN_EMPTY_DEFAULT", "COST_ROUTING_ENABLED"):
+        monkeypatch.delenv(name, raising=False)
+    flags.reset_flag_state()
+    yield
+    flags.reset_flag_state()
+
+
+@contextmanager
+def _posthog_says(value):
+    with patch("cqc_lem.utilities.flags.posthog") as ph:
+        ph.disabled = False
+        ph.setup.return_value = MagicMock()
+        ph.get_feature_flag.return_value = value
+        yield ph
+
+
+def _get(client, url):
+    with patch("cqc_lem.utilities.observability.posthog"):
+        return client.get(url)
+
+
+class TestFlagBootstrap:
+    def test_returns_every_registered_flag(self, client):
+        response = _get(client, "/api/flags")
+
+        assert response.status_code == 200
+        detail = response.json()["detail"]
+        assert set(detail["flags"]) == set(flags.FLAGS)
+        assert all(isinstance(v, bool) for v in detail["flags"].values())
+
+    def test_without_posthog_the_payload_is_the_env_defaults(self, client, monkeypatch):
+        """The landing page must render correctly on a deployment with no PostHog at all."""
+        monkeypatch.setenv("TUTORIAL_VIDEOS_ENABLED", "true")
+
+        detail = _get(client, "/api/flags").json()["detail"]
+
+        assert detail["local_evaluation"] is False
+        assert detail["flags"][flags.TUTORIAL_VIDEOS] is True
+        assert detail["flags"][flags.COMMENT_RESEARCH] is False
+
+    def test_no_session_resolves_the_system_identity_rather_than_401ing(self, client):
+        detail = _get(client, "/api/flags").json()["detail"]
+
+        assert detail["distinct_id"] == "system"
+
+    def test_an_invalid_session_still_serves_flags(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            detail = _get(client, "/api/flags?session_token=stale").json()["detail"]
+
+        assert detail["distinct_id"] == "system"
+        assert set(detail["flags"]) == set(flags.FLAGS)
+
+    def test_a_valid_session_scopes_the_payload_to_that_user(self, client, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+
+        with patch(f"{_M}.get_session_user_id", return_value=42), _posthog_says(True) as ph:
+            detail = _get(client, "/api/flags?session_token=good").json()["detail"]
+
+        # distinct_id is str(user_id) — observability.py's convention, so a per-user rollout targets
+        # the same PostHog person that user's own events land on.
+        assert detail["distinct_id"] == "42"
+        assert ph.get_feature_flag.call_args.args[1] == "42"
+        assert detail["local_evaluation"] is True
+        assert all(detail["flags"].values())
+
+    def test_posthog_decision_beats_the_env_var_in_the_payload(self, client, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        monkeypatch.setenv("TUTORIAL_VIDEOS_ENABLED", "true")
+
+        with _posthog_says(False):
+            detail = _get(client, "/api/flags").json()["detail"]
+
+        assert detail["flags"][flags.TUTORIAL_VIDEOS] is False

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -53,3 +53,17 @@ def _no_real_redis():
     blocked = ConnectionError("redis blocked in unit tests")
     with patch("redis.Redis.from_url", side_effect=blocked):
         yield
+
+
+@pytest.fixture(autouse=True)
+def _feature_flags_env_only(monkeypatch):
+    """Issue #651: the flag wrapper polls PostHog for flag DEFINITIONS the first time any flag is
+    checked. `tests/conftest.py` calls load_dotenv(), so a dev box with a real
+    POSTHOG_PERSONAL_API_KEY in .env would make the unit lane reach the network — and worse, make
+    a test's outcome depend on whichever rollout is live in PostHog right now. Pin the whole lane
+    to the fail-open (env var) path, which is exactly what CI already gets; tests/unit/utilities/
+    test_flags.py turns the backend back on with an explicitly faked SDK.
+    """
+    monkeypatch.setenv("POSTHOG_FLAGS_ENABLED", "false")
+    from cqc_lem.utilities import flags
+    flags.reset_flag_state()

--- a/tests/unit/utilities/test_flag_migrations.py
+++ b/tests/unit/utilities/test_flag_migrations.py
@@ -1,0 +1,154 @@
+"""The first migrated cohort of toggles (issue #651) actually follows its flag.
+
+A flag that nothing reads is worse than no flag at all, and the classic way to ship one is to leave
+the toggle read at IMPORT time — which is unflippable. These tests drive each migrated toggle
+through `flags.flag_enabled` and prove three things per toggle: PostHog wins when it answers, the
+env var wins when it doesn't, and the value is resolved at CALL time.
+"""
+
+from contextlib import contextmanager
+from datetime import date
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from cqc_lem.utilities import flags
+
+pytestmark = pytest.mark.unit
+
+_PH = "cqc_lem.utilities.flags.posthog"
+
+
+@contextmanager
+def _posthog_says(value):
+    """A faked, CONFIGURED SDK returning one value for every flag lookup."""
+    with patch(_PH) as ph:
+        ph.disabled = False
+        ph.setup.return_value = MagicMock()
+        ph.get_feature_flag.return_value = value
+        yield ph
+
+
+@pytest.fixture(autouse=True)
+def _backend_available(monkeypatch):
+    monkeypatch.setenv("POSTHOG_FLAGS_ENABLED", "true")
+    monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+    monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+    flags.reset_flag_state()
+    yield
+    flags.reset_flag_state()
+
+
+class TestCommentResearch:
+    def test_flag_on_enables_research_for_a_comment_the_env_var_would_block(self, monkeypatch):
+        from cqc_lem.utilities.ai import content_research as cr
+        monkeypatch.delenv("COMMENT_RESEARCH_ENABLED", raising=False)
+        with _posthog_says(True):
+            assert cr.research_enabled("comment", user_id=5) is True
+
+    def test_flag_off_blocks_research_the_env_var_would_allow(self, monkeypatch):
+        from cqc_lem.utilities.ai import content_research as cr
+        monkeypatch.setenv("COMMENT_RESEARCH_ENABLED", "true")
+        with _posthog_says(False):
+            assert cr.research_enabled("comment", user_id=5) is False
+
+    def test_master_switch_still_wins_over_the_flag(self, monkeypatch):
+        """CONTENT_RESEARCH_ENABLED is the kill switch for ALL research and was deliberately not
+        migrated — a flag must never be able to turn research back on against it."""
+        from cqc_lem.utilities.ai import content_research as cr
+        monkeypatch.setenv("CONTENT_RESEARCH_ENABLED", "false")
+        with _posthog_says(True):
+            assert cr.research_enabled("comment", user_id=5) is False
+
+    def test_user_id_reaches_the_lookup_so_a_rollout_can_target_a_cohort(self, monkeypatch):
+        from cqc_lem.utilities.ai import content_research as cr
+        with _posthog_says(True) as ph:
+            cr.research_enabled("comment", user_id=77)
+        assert ph.get_feature_flag.call_args.args == (flags.COMMENT_RESEARCH, "77")
+
+    def test_newsletter_and_post_toggles_stay_env_only(self, monkeypatch):
+        from cqc_lem.utilities.ai import content_research as cr
+        monkeypatch.setenv("POST_RESEARCH_ENABLED", "false")
+        with _posthog_says(True) as ph:
+            assert cr.research_enabled("post") is False
+        ph.get_feature_flag.assert_not_called()
+
+
+class TestTutorialVideos:
+    def test_flag_off_skips_production_even_with_the_env_var_on(self, monkeypatch):
+        from cqc_lem.utilities.marketing import video_tutorials as vt
+        monkeypatch.setenv("TUTORIAL_VIDEOS_ENABLED", "true")
+        with _posthog_says(False):
+            assert vt.produce_tutorial() is None
+
+    def test_flag_is_read_per_call_not_at_import(self, monkeypatch):
+        """The toggle used to be a module constant. If it still were, the second call below would
+        return the first call's answer."""
+        from cqc_lem.utilities.marketing import video_tutorials as vt
+        monkeypatch.setenv("TUTORIAL_VIDEOS_ENABLED", "false")
+        with _posthog_says(False):
+            assert vt.produce_tutorial() is None
+        # Reaching PAST the gate is all this asserts — an unknown flow key raises only once the
+        # toggle has let the call through. Producing a real tutorial needs the whole capture stack.
+        with _posthog_says(True) as ph, pytest.raises(ValueError, match="Unknown tutorial flow"):
+            vt.produce_tutorial(flow_key="nope-not-a-flow")
+        assert ph.get_feature_flag.called
+
+
+class TestCostRouting:
+    def test_routing_enabled_follows_the_flag(self, monkeypatch):
+        from cqc_lem.utilities import cost_routing as cr
+        monkeypatch.delenv("COST_ROUTING_ENABLED", raising=False)
+        with _posthog_says(True):
+            assert cr.routing_enabled() is True
+        with _posthog_says(False):
+            assert cr.routing_enabled() is False
+
+    def test_report_resolves_the_flag_at_call_time(self, monkeypatch):
+        """`enabled=None` (the default) must consult the flag NOW — the old default argument froze
+        COST_ROUTING_ENABLED at import, so a flip needed a deploy."""
+        from cqc_lem.utilities import cost_routing as cr
+        monkeypatch.delenv("COST_ROUTING_ENABLED", raising=False)
+        with patch.object(cr, "collect_quality_observations", return_value=[]) as observe, \
+             patch.object(cr, "load_policy", return_value={}), \
+             patch("cqc_lem.utilities.db.cost_ledger_available", return_value=False), \
+             _posthog_says(True):
+            report = cr.collect_routing_report(days=7, today=date(2026, 8, 1))
+        observe.assert_called_once()
+        assert report["policy"]["enabled"] is True
+
+    def test_explicit_enabled_argument_still_wins(self, monkeypatch):
+        from cqc_lem.utilities import cost_routing as cr
+        with patch.object(cr, "collect_quality_observations") as observe, \
+             patch.object(cr, "load_policy", return_value={}), \
+             _posthog_says(True):
+            report = cr.collect_routing_report(days=7, today=date(2026, 8, 1), enabled=False)
+        observe.assert_not_called()
+        assert report["policy"]["enabled"] is False
+
+
+class TestFeedFallbackDefault:
+    """The flag moves the FLEET default only; a user's saved row always wins."""
+
+    def _prefs(self, row):
+        from cqc_lem.utilities import db
+        with patch.object(db, "_select_engagement_row", return_value=row):
+            return db.get_engagement_preferences(1)
+
+    def test_flag_sets_the_default_for_a_user_with_no_saved_row(self, monkeypatch):
+        monkeypatch.delenv("FEED_FALLBACK_WHEN_EMPTY_DEFAULT", raising=False)
+        with _posthog_says(False):
+            assert self._prefs(None)["feed_fallback_when_empty"] is False
+        with _posthog_says(True):
+            assert self._prefs(None)["feed_fallback_when_empty"] is True
+
+    def test_a_saved_row_beats_the_flag(self):
+        from cqc_lem.utilities.db import _ENGAGEMENT_DEFAULTS
+        saved = {**_ENGAGEMENT_DEFAULTS, "feed_fallback_when_empty": False}
+        with _posthog_says(True):
+            assert self._prefs(saved)["feed_fallback_when_empty"] is False
+
+    def test_env_var_is_the_fallback_when_posthog_has_no_answer(self, monkeypatch):
+        monkeypatch.setenv("FEED_FALLBACK_WHEN_EMPTY_DEFAULT", "false")
+        with _posthog_says(None):
+            assert self._prefs(None)["feed_fallback_when_empty"] is False

--- a/tests/unit/utilities/test_flags.py
+++ b/tests/unit/utilities/test_flags.py
@@ -1,0 +1,254 @@
+"""Unit tests for the runtime feature-flag wrapper (issue #651).
+
+The whole point of this module is what happens when PostHog does NOT answer, so most of these tests
+are fallback tests: no key, key but no definitions, undefined flag, SDK raising. Every one of them
+must land on the flag's env var, because that is the guarantee that lets a safety-critical
+automation depend on this at all.
+"""
+
+from contextlib import contextmanager
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from cqc_lem.utilities import flags
+
+pytestmark = pytest.mark.unit
+
+_PH = "cqc_lem.utilities.flags.posthog"
+
+
+@contextmanager
+def _sdk():
+    """A stand-in posthog module that is CONFIGURED (not disabled) — a bare MagicMock's truthy
+    `.disabled` would read as "PostHog turned off" and quietly take every test down the fallback
+    path this file is trying to distinguish from."""
+    with patch(_PH) as ph:
+        ph.disabled = False
+        ph.setup.return_value = MagicMock(personal_api_key=None, poll_interval=None)
+        yield ph
+
+
+@pytest.fixture(autouse=True)
+def _clean_flag_state(monkeypatch):
+    for name in ("POSTHOG_FLAGS_ENABLED", "POSTHOG_API_KEY", "POSTHOG_PERSONAL_API_KEY",
+                 "POSTHOG_FLAG_POLL_SECONDS",
+                 "COMMENT_RESEARCH_ENABLED", "TUTORIAL_VIDEOS_ENABLED",
+                 "FEED_FALLBACK_WHEN_EMPTY_DEFAULT", "COST_ROUTING_ENABLED"):
+        monkeypatch.delenv(name, raising=False)
+    flags.reset_flag_state()
+    yield
+    flags.reset_flag_state()
+
+
+def _with_backend(monkeypatch):
+    """The env a deployment that CAN evaluate locally has."""
+    monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+    monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+
+
+class TestRegistry:
+    def test_every_spec_is_keyed_by_its_own_key(self):
+        for key, spec in flags.FLAGS.items():
+            assert spec.key == key
+
+    def test_env_vars_are_unique_per_flag(self):
+        env_vars = [spec.env_var for spec in flags.FLAGS.values()]
+        assert len(env_vars) == len(set(env_vars))
+
+    def test_exported_constants_are_all_registered(self):
+        for key in (flags.COMMENT_RESEARCH, flags.TUTORIAL_VIDEOS,
+                    flags.FEED_FALLBACK_DEFAULT, flags.COST_ROUTING):
+            assert key in flags.FLAGS
+
+    def test_safety_controls_are_not_flags(self):
+        """The 429 breaker, the automation pause and the per-day caps stay in Redis/env."""
+        forbidden = ("pause", "breaker", "rate-limit", "cap", "suppression")
+        for key in flags.FLAGS:
+            assert not any(word in key for word in forbidden), key
+
+    def test_unregistered_flag_raises_rather_than_silently_reading_false(self):
+        with pytest.raises(KeyError):
+            flags.flag_enabled("not-a-real-flag")
+
+    def test_registry_rows_expose_the_documented_columns(self):
+        row = next(r for r in flags.registry_rows() if r["key"] == flags.COMMENT_RESEARCH)
+        assert row["env_var"] == "COMMENT_RESEARCH_ENABLED"
+        assert row["default"] is False
+        assert row["owner"] and row["description"]
+
+
+class TestEnvDefault:
+    def test_unset_env_uses_the_spec_default(self):
+        assert flags.env_default(flags.COMMENT_RESEARCH) is False
+        assert flags.env_default(flags.FEED_FALLBACK_DEFAULT) is True
+
+    @pytest.mark.parametrize("raw", ["0", "false", "FALSE", "no", "off", " off "])
+    def test_off_values(self, monkeypatch, raw):
+        monkeypatch.setenv("FEED_FALLBACK_WHEN_EMPTY_DEFAULT", raw)
+        assert flags.env_default(flags.FEED_FALLBACK_DEFAULT) is False
+
+    @pytest.mark.parametrize("raw", ["1", "true", "TRUE", "yes", "on"])
+    def test_on_values(self, monkeypatch, raw):
+        monkeypatch.setenv("COMMENT_RESEARCH_ENABLED", raw)
+        assert flags.env_default(flags.COMMENT_RESEARCH) is True
+
+    def test_blank_env_is_treated_as_unset(self, monkeypatch):
+        monkeypatch.setenv("FEED_FALLBACK_WHEN_EMPTY_DEFAULT", "   ")
+        assert flags.env_default(flags.FEED_FALLBACK_DEFAULT) is True
+
+
+class TestFallsBackToEnvWhenPostHogCannotAnswer:
+    def test_no_keys_at_all_never_touches_the_sdk(self, monkeypatch):
+        monkeypatch.setenv("COMMENT_RESEARCH_ENABLED", "true")
+        with patch(_PH) as ph:
+            assert flags.flag_enabled(flags.COMMENT_RESEARCH) is True
+        ph.get_feature_flag.assert_not_called()
+        ph.load_feature_flags.assert_not_called()
+
+    def test_project_key_without_a_personal_key_is_not_local_evaluation(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+        monkeypatch.setenv("TUTORIAL_VIDEOS_ENABLED", "true")
+        with patch(_PH) as ph:
+            assert flags.flag_enabled(flags.TUTORIAL_VIDEOS) is True
+        ph.get_feature_flag.assert_not_called()
+
+    def test_master_kill_switch_disables_lookups_entirely(self, monkeypatch):
+        _with_backend(monkeypatch)
+        monkeypatch.setenv("POSTHOG_FLAGS_ENABLED", "false")
+        monkeypatch.setenv("COST_ROUTING_ENABLED", "true")
+        with patch(_PH) as ph:
+            assert flags.flag_enabled(flags.COST_ROUTING) is True
+        ph.get_feature_flag.assert_not_called()
+
+    def test_undefined_flag_in_posthog_falls_back(self, monkeypatch):
+        _with_backend(monkeypatch)
+        monkeypatch.setenv("COMMENT_RESEARCH_ENABLED", "true")
+        with _sdk() as ph:
+            ph.get_feature_flag.return_value = None  # not defined / not decidable locally
+            assert flags.flag_enabled(flags.COMMENT_RESEARCH) is True
+
+    def test_sdk_raising_falls_back(self, monkeypatch):
+        _with_backend(monkeypatch)
+        monkeypatch.setenv("COMMENT_RESEARCH_ENABLED", "true")
+        with _sdk() as ph:
+            ph.get_feature_flag.side_effect = RuntimeError("posthog exploded")
+            assert flags.flag_enabled(flags.COMMENT_RESEARCH) is True
+
+    def test_definition_load_failure_falls_back(self, monkeypatch):
+        _with_backend(monkeypatch)
+        monkeypatch.setenv("COMMENT_RESEARCH_ENABLED", "true")
+        with _sdk() as ph:
+            ph.load_feature_flags.side_effect = RuntimeError("unreachable")
+            assert flags.flag_enabled(flags.COMMENT_RESEARCH) is True
+            ph.get_feature_flag.assert_not_called()
+
+    def test_a_failing_load_retries_at_most_once_per_poll_interval(self, monkeypatch):
+        """Without the cooldown a PostHog outage would make every flag check in a feed loop attempt
+        its own definition fetch."""
+        _with_backend(monkeypatch)
+        monkeypatch.setenv("POSTHOG_FLAG_POLL_SECONDS", "30")
+        clock = [1000.0]
+        monkeypatch.setattr(flags, "_now", lambda: clock[0])
+        with _sdk() as ph:
+            ph.load_feature_flags.side_effect = RuntimeError("unreachable")
+            flags.flag_enabled(flags.COMMENT_RESEARCH)
+            flags.flag_enabled(flags.COMMENT_RESEARCH)
+            assert ph.load_feature_flags.call_count == 1
+
+            clock[0] += 31
+            flags.flag_enabled(flags.COMMENT_RESEARCH)
+            assert ph.load_feature_flags.call_count == 2
+
+
+class TestPostHogDecides:
+    def test_flag_off_overrides_an_env_var_that_is_on(self, monkeypatch):
+        _with_backend(monkeypatch)
+        monkeypatch.setenv("COMMENT_RESEARCH_ENABLED", "true")
+        with _sdk() as ph:
+            ph.get_feature_flag.return_value = False
+            assert flags.flag_enabled(flags.COMMENT_RESEARCH) is False
+
+    def test_flag_on_overrides_an_env_var_that_is_off(self, monkeypatch):
+        _with_backend(monkeypatch)
+        with _sdk() as ph:
+            ph.get_feature_flag.return_value = True
+            assert flags.flag_enabled(flags.COMMENT_RESEARCH) is True
+
+    @pytest.mark.parametrize("variant,expected", [
+        ("control", False), ("off", False), ("disabled", False),
+        ("treatment", True), ("cheap-tier", True),
+    ])
+    def test_multivariate_values_coerce(self, monkeypatch, variant, expected):
+        _with_backend(monkeypatch)
+        with _sdk() as ph:
+            ph.get_feature_flag.return_value = variant
+            assert flags.flag_enabled(flags.COMMENT_RESEARCH) is expected
+
+
+class TestLocalEvaluation:
+    def test_lookups_never_make_a_network_request(self, monkeypatch):
+        _with_backend(monkeypatch)
+        with _sdk() as ph:
+            ph.get_feature_flag.return_value = True
+            flags.flag_enabled(flags.COMMENT_RESEARCH, user_id=7)
+        kwargs = ph.get_feature_flag.call_args.kwargs
+        assert kwargs["only_evaluate_locally"] is True
+        assert kwargs["send_feature_flag_events"] is False
+
+    def test_definitions_load_once_and_the_poller_keeps_them_fresh(self, monkeypatch):
+        _with_backend(monkeypatch)
+        monkeypatch.setenv("POSTHOG_FLAG_POLL_SECONDS", "15")
+        with _sdk() as ph:
+            ph.get_feature_flag.return_value = False
+            assert flags.flag_enabled(flags.COMMENT_RESEARCH) is False
+            # A flip lands in the poller's refreshed definitions; the next in-process lookup sees it
+            # without any further load call.
+            ph.get_feature_flag.return_value = True
+            assert flags.flag_enabled(flags.COMMENT_RESEARCH) is True
+            assert ph.load_feature_flags.call_count == 1
+            assert ph.setup.return_value.poll_interval == 15
+
+    def test_settings_are_pushed_onto_an_already_built_client(self, monkeypatch):
+        """setup() reuses a client that a prior capture() may have built with no personal key —
+        that client would never poll."""
+        _with_backend(monkeypatch)
+        with _sdk() as ph:
+            ph.get_feature_flag.return_value = True
+            flags.flag_enabled(flags.COMMENT_RESEARCH)
+        assert ph.setup.return_value.personal_api_key == "phx_test"
+
+    def test_distinct_id_matches_the_observability_convention(self):
+        assert flags.distinct_id(42) == "42"
+        assert flags.distinct_id(None) == "system"
+
+    def test_user_id_scopes_the_lookup(self, monkeypatch):
+        _with_backend(monkeypatch)
+        with _sdk() as ph:
+            ph.get_feature_flag.return_value = True
+            flags.flag_enabled(flags.COMMENT_RESEARCH, user_id=7)
+        assert ph.get_feature_flag.call_args.args[1] == "7"
+
+
+class TestBootstrapPayload:
+    def test_every_registered_flag_is_present(self, monkeypatch):
+        payload = flags.bootstrap_payload(3)
+        assert set(payload["flags"]) == set(flags.FLAGS)
+        assert payload["distinct_id"] == "3"
+
+    def test_local_evaluation_is_false_without_a_backend(self):
+        assert flags.bootstrap_payload()["local_evaluation"] is False
+
+    def test_values_are_the_env_defaults_without_a_backend(self, monkeypatch):
+        monkeypatch.setenv("TUTORIAL_VIDEOS_ENABLED", "true")
+        payload = flags.bootstrap_payload()
+        assert payload["flags"][flags.TUTORIAL_VIDEOS] is True
+        assert payload["flags"][flags.COMMENT_RESEARCH] is False
+
+    def test_local_evaluation_is_true_once_definitions_load(self, monkeypatch):
+        _with_backend(monkeypatch)
+        with _sdk() as ph:
+            ph.get_feature_flag.return_value = True
+            payload = flags.bootstrap_payload(1)
+        assert payload["local_evaluation"] is True
+        assert all(payload["flags"].values())

--- a/tests/unit/utilities/test_video_tutorials.py
+++ b/tests/unit/utilities/test_video_tutorials.py
@@ -26,7 +26,9 @@ def _isolated_assets(tmp_path, monkeypatch):
     monkeypatch.setattr(vt, "TUTORIAL_SPA_BASE_URL", "https://lem.test")
     monkeypatch.setattr(vt, "API_URL_FINAL", "https://lem.test")
     monkeypatch.setattr(vt, "TUTORIAL_DEMO_SESSION_TOKEN", "")
-    monkeypatch.setattr(vt, "TUTORIAL_VIDEOS_ENABLED", True)
+    # The producer is gated by the `tutorial-videos-enabled` FLAG now (issue #651); with the
+    # unit lane pinned to env-only flags, setting the env var IS setting the flag.
+    monkeypatch.setenv("TUTORIAL_VIDEOS_ENABLED", "true")
     monkeypatch.setattr(vt, "TUTORIAL_THUMBNAIL_ENABLED", False)
     monkeypatch.setattr(vt, "YOUTUBE_CLIENT_ID", "")
     monkeypatch.setattr(vt, "YOUTUBE_CLIENT_SECRET", "")
@@ -486,7 +488,7 @@ class TestProduceTutorial:
         return element
 
     def test_disabled_pipeline_produces_nothing(self, monkeypatch):
-        monkeypatch.setattr(vt, "TUTORIAL_VIDEOS_ENABLED", False)
+        monkeypatch.setenv("TUTORIAL_VIDEOS_ENABLED", "false")
         assert vt.produce_tutorial() is None
 
     def test_unknown_flow_key_raises(self):


### PR DESCRIPTION
## What & why

LEM's operational toggles were env vars — changing one meant editing `/opt/lem/.env` and restarting the stack. This adds **`src/cqc_lem/utilities/flags.py`**, the ONE place a runtime toggle is read, backed by PostHog feature flags with in-process **local evaluation**.

The contract is **fail open to the env var**. Every path that isn't a clear PostHog answer — no personal API key, `POSTHOG_FLAGS_ENABLED=false`, definitions unloaded, flag undefined in PostHog, evaluation inconclusive, SDK raises — returns the flag's own env var. A deployment that never creates a single PostHog flag behaves *exactly* as it did before this landed. Each registered flag keeps its env var as both default and fallback.

### Local evaluation (and its constraint)

Every lookup passes `only_evaluate_locally=True` + `send_feature_flag_events=False`: definitions are polled into the process (`POSTHOG_FLAG_POLL_SECONDS`, default 30) and evaluated in memory, so **a feed loop checking a flag per post makes zero network requests**, and a flip reaches a long-running Celery worker within one poll interval without a restart. The single fetch happens at a process's first flag check, and a failed fetch retries no more than once per poll interval — an outage can't turn a feed loop into a fetch loop.

The price is a real registry constraint, documented and called out in the module docstring: **registered flags must use rollout-percentage / distinct-ID conditions only.** A person-property release condition can't be decided locally and would silently fall back to env everywhere.

### Migrated cohort

Each is read at the **call site** — an import-time constant can't be flipped, which is the classic way to ship a flag that does nothing.

| Flag | Env fallback | Scope |
|---|---|---|
| `comment-research-enabled` | `COMMENT_RESEARCH_ENABLED` | per user (`user_id` plumbed through `research_topic`) |
| `tutorial-videos-enabled` | `TUTORIAL_VIDEOS_ENABLED` | system — gates the producer AND the SPA section |
| `feed-fallback-when-empty-default` | `FEED_FALLBACK_WHEN_EMPTY_DEFAULT` | fleet default only; a user's saved row always wins |
| `cost-routing-enabled` | `COST_ROUTING_ENABLED` | system |

`COST_ROUTING_ENABLED` / `TUTORIAL_VIDEOS_ENABLED` are no longer frozen into `env_constants` — two readers of one var, one of them unflippable, is worse than none.

### Explicitly NOT migrated

Safety controls stay in Redis/env, where they're one authority a PostHog outage or an errant %-ramp can't touch: the 429 breaker, `hold_commenting`, `pause_automation`/the suppression tripwire, and every per-day cap. `COST_AWARE_ROUTING_ENABLED` (the proxy half of cost routing) stays env-only because `routing_policy.py` is mounted into the LiteLLM container and must remain stdlib-only. A unit test asserts no safety-shaped key enters the registry.

### SPA

`GET /api/flags` returns `{distinct_id, flags, local_evaluation}` — every registered flag, resolved **server-side**. `hooks/useFeatureFlags.ts` consumes it; `TutorialVideos.tsx` is the first consumer.

One deviation from the issue text worth flagging: the issue suggested `posthog-js/react` hooks. I did **not** use them, for three reasons — (1) it *is* the bootstrap: one server payload means a gated section renders correctly on the first paint instead of flickering, and posthog-js's `bootstrap` option needs the flags *before* `init()`, which the SPA can't have; (2) it's the same evaluation the API and workers just did, so browser/API/worker can never disagree; (3) it works with browser analytics fully off (no `VITE_POSTHOG_KEY`) — flags are a product control, not an analytics feature. `utils/analytics.ts` stays the SPA's ONE PostHog surface per CLAUDE.md; a second client-side posthog reader would reintroduce exactly the split-brain the endpoint removes. Happy to swap if you'd rather have the SDK hooks.

An absent/invalid session resolves flags for the `"system"` identity rather than 401ing — the landing page is logged out and still needs to know what to render.

## Testing

- `tests/unit/utilities/test_flags.py` (42) — registry integrity, env coercion, every fail-open path, variant coercion, local-eval kwargs, definitions-load-once + poll interval, retry cooldown, distinct_id convention, bootstrap payload.
- `tests/unit/utilities/test_flag_migrations.py` (13) — each migrated toggle provably follows its flag, the env var wins when PostHog doesn't answer, `CONTENT_RESEARCH_ENABLED` still overrides the flag, and cost routing resolves at call time rather than import.
- `tests/integration/test_flags_endpoint.py` (6) — the real endpoint through the real resolution: no-PostHog payload, anonymous vs. session-scoped identity, PostHog beating the env var.
- `src/cqc_lem/ui/src/hooks/useFeatureFlags.test.tsx` (6) — fallback while in flight, safe fallback on an unreachable API, session token passthrough.
- `tests/unit/conftest.py` pins the unit lane to env-only flags: `tests/conftest.py` calls `load_dotenv()`, so a dev box with a real `POSTHOG_PERSONAL_API_KEY` would otherwise make unit tests reach the network and depend on whichever rollout is live.

`poetry run pytest tests/unit -q` → **6923 passed**. `tests/integration` → 112 passed, 17 skipped (2 pre-existing failures in `test_link_first_comment.py` need the Redis service container; they fail identically on a clean tree). Vitest/tsc run in CI (`UI Build`) — no vitest in this box's node_modules.

## Deployment note

Local evaluation needs `POSTHOG_PERSONAL_API_KEY` (scope `feature_flag:read`) **in the app containers**. It's already in `.env.example` and the app services use `env_file: .env`, so if it's set on the box this works on deploy; if it isn't, every flag simply reads its env var and nothing changes. No migration, no schema change.

Docs: `docs/feature-flags.md` (registry, fail-open table, how to add a flag, verification commands) + a CLAUDE.md section.

Closes #651

🤖 Generated with [Claude Code](https://claude.com/claude-code)
