### PR TITLE
feat(observability): port cost-routing + content A/B experiments to PostHog Experiments (closes #652)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -648,8 +648,18 @@ COST_ROUTING_CONFIDENCE_Z=1.96
 # Days a rolled-back bucket is left alone before it may be re-proposed.
 COST_ROUTING_COOLDOWN_DAYS=28
 # Blast radius: share of users a new experiment starts on, and how many buckets may run at once.
+# NOTE (issue #652): once the `cost-routing-arm` PostHog experiment exists, the FLAG decides who is in
+# the treatment and this percentage is only the hash fallback for users PostHog has no answer for.
 COST_ROUTING_INITIAL_COHORT_PCT=0.1
 COST_ROUTING_MAX_EXPERIMENTS=1
+
+# --- PostHog Experiments (issue #652, docs/experiments.md) ---
+# ONE kill switch for every experiment in utilities/experiments.py. Off means every arm reads as its
+# CONTROL — the behaviour that shipped before the experiment existed — and no exposure is emitted.
+# There is no per-experiment env var on purpose: a toggle has a default worth honouring, an
+# experiment arm does not. Assignment needs POSTHOG_PERSONAL_API_KEY (local evaluation, see
+# docs/feature-flags.md); without it every arm is the control too.
+EXPERIMENTS_ENABLED=true
 
 # --- Codecov (coverage reporting) ---
 CODECOV_TOKEN=your_codecov_token

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,8 +129,10 @@ response = client.chat.completions.create(model="lem-simple", messages=[...])
 can additionally route a tier ONE step down for the treatment cohort of an active cost/quality
 experiment. `routing_policy.py` is the shared decision core — the app imports it, and docker-compose
 mounts that same file into the LiteLLM container — so it must stay **stdlib-only** (no `cqc_lem.*`
-imports). Off unless BOTH `COST_ROUTING_ENABLED` and `COST_AWARE_ROUTING_ENABLED` are set. See
-`docs/cost-performance-margin-plan.md` §D.1.1.
+imports). Off unless BOTH `COST_ROUTING_ENABLED` and `COST_AWARE_ROUTING_ENABLED` are set. Since
+issue #652 the treatment cohort comes from a PostHog experiment flag resolved app-side and handed to
+the router in the policy document's `arms` map (the hash stays as the fallback) — see
+`docs/experiments.md`. Also `docs/cost-performance-margin-plan.md` §D.1.1.
 
 See `ai_helper.py` for the per-function model assignment.
 
@@ -325,6 +327,47 @@ properties (`celery_task.state = 'FAILURE'`) rather than booleans: a boolean fil
 nothing yields an alert that never fires. Money tiles read `$ai_generation`, never `llm_call`.
 `mark_rate_limited()` emits `rate_limit_trip` (issue #650) because the breaker's WARNING log never
 reaches PostHog at the default `POSTHOG_LOG_LEVEL`.
+
+### Experiments (`utilities/experiments.py`, issue #652)
+
+LEM hand-rolled experimentation twice — the cost/quality down-routing cohort and the #396 media A/B
+harness — and neither could say whether a difference was real, or render anywhere a human looks. This
+module is the **adapter onto PostHog Experiments**, NOT a third implementation: the homegrown loops
+keep running, PostHog gets the arms, the exposures and the outcome labels. Full posture:
+`docs/experiments.md`.
+
+**An unresolvable experiment is the CONTROL arm** — no key, no flag, inconclusive evaluation,
+`EXPERIMENTS_ENABLED=false`, SDK raises. There is deliberately NO env fallback per experiment (a
+toggle has a default worth honouring, an arm does not), and `_raw_variant()` keeps "PostHog said
+control" apart from "PostHog said nothing" so `experiment_properties()` never stamps
+`$feature/x=control` on a metric event from someone who was never enrolled — a fabricated control arm
+makes a readout look populated. Assignment reuses `flags.py`'s ONE local-evaluation bootstrap (no
+second poller, zero network calls per lookup), so every experiment flag must use rollout-percentage /
+distinct-ID conditions only. Exposure is `$feature_flag_called` — PostHog's own event name and
+properties, not ours — emitted explicitly (flags.py suppresses it for hot toggles) and deduped per
+(experiment, person, arm) per process.
+
+Three registered experiments. **`cost-routing-arm`**: the arm is resolved app-side and written into
+each routing bucket as `arms: {"<user_id>": "treatment"}` INSIDE the policy document Redis already
+carries to the LiteLLM router — `routing_policy.py` is mounted into that container and must stay
+stdlib-only, so the decision is handed to it, never imported by it. `flag_arm()` reads the map,
+`assign_arm()` falls back to the original hash for anyone PostHog has no answer for (a PostHog outage
+moves no traffic), and `resolve_tier()` reports `assignment` so a live-experiment down-route is
+distinguishable from a fallback one. The flag decides WHO, `cohort_pct` decides WHETHER: a parked
+bucket can never be started by a flag, and the arms map is applied AFTER the weekly evaluation because
+the window being judged was routed under the PREVIOUS document's arms. **`comment-contract-prompt`**:
+the pilot LLM prompt experiment — the #617 contract's closing ask, measured on author-reply rate from
+#628's sweep, scoped to FRESH FEED comments only (the seed/second-wave/reply surfaces are never
+measured by that sweep) and with the six deterministically-graded rules IDENTICAL in both arms, or
+"passes the gate" would mean two different things. **`post-media-variant`**: the #396 adapter, whose
+arms are data (the combo that shipped) rather than a flag — `select_variant_winners` is untouched.
+
+`scripts/posthog_experiments.py` provisions the multivariate flags + experiment records
+(`--print-specs` / dry-run / `--apply` / `--rollout KEY=PCT`). It NEVER resets an existing flag's
+rollout: PostHog owns the ramp once an experiment runs, and an `--apply` that reverted it would
+re-cohort a live experiment. Read a readout honestly — at current volume everything here is
+underpowered by design (the small-sample caveat is in the doc), and never re-roll a running
+experiment's variants: that re-cohorts people and invalidates the attribution already collected.
 
 ### Content-quality telemetry (`utilities/content_quality.py`, issue #630)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,8 +351,11 @@ Three registered experiments. **`cost-routing-arm`**: the arm is resolved app-si
 each routing bucket as `arms: {"<user_id>": "treatment"}` INSIDE the policy document Redis already
 carries to the LiteLLM router — `routing_policy.py` is mounted into that container and must stay
 stdlib-only, so the decision is handed to it, never imported by it. `flag_arm()` reads the map,
-`assign_arm()` falls back to the original hash for anyone PostHog has no answer for (a PostHog outage
-moves no traffic), and `resolve_tier()` reports `assignment` so a live-experiment down-route is
+`assign_arm()` falls back to the original hash for anyone PostHog has no answer for, and a run that
+could not ASK PostHog at all carries the PREVIOUS document's map forward rather than wiping it
+(`resolve_cohort()` returns None for "couldn't ask" vs `{}` for "PostHog enrolled nobody") — so an
+outage moves no traffic instead of re-splitting a live cohort under the hash for a week.
+`resolve_tier()` reports `assignment` so a live-experiment down-route is
 distinguishable from a fallback one. The flag decides WHO, `cohort_pct` decides WHETHER: a parked
 bucket can never be started by a flag, and the arms map is applied AFTER the weekly evaluation because
 the window being judged was routed under the PREVIOUS document's arms. **`comment-contract-prompt`**:

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -1,0 +1,201 @@
+# Experiments (PostHog Experiments) — issue #652
+
+LEM hand-rolled experimentation twice before this.
+
+* **Cost/quality down-routing** (`utilities/cost_routing.py`, `utilities/routing_policy.py`,
+  [cost-performance-margin-plan.md](cost-performance-margin-plan.md) §D.1.1) grew its own cohort
+  hash, its own non-inferiority test and its own weekly email.
+* **The media A/B harness** (#396: `app/generate_variants.py`, `post_variants`,
+  `post_stats.select_variant_winners`) grew its own shipped-variant table and its own recency-weighted
+  winner ranking.
+
+Both work. Neither renders anywhere a human looks, and neither can say whether a difference is real
+with anything a statistician would sign. PostHog Experiments already has the multivariate flag, the
+exposure model, both stats engines (Bayesian + frequentist), CUPED and the readout — and it is billed
+with feature flags, which at LEM's volume is free.
+
+So `utilities/experiments.py` is an **adapter, not a third implementation**. The homegrown loops keep
+running exactly as they did; PostHog gets the arms, the exposures and the outcome labels.
+
+## The contract
+
+**An unresolvable experiment is the CONTROL arm.** No PostHog key, definitions not loaded, flag not
+defined, evaluation inconclusive, `EXPERIMENTS_ENABLED=false`, SDK raises — every one of those paths
+returns the spec's control variant, which is by construction the behaviour that shipped before the
+experiment existed.
+
+There is deliberately **no env-var fallback** here, unlike [feature flags](feature-flags.md): a toggle
+has a configured default worth honouring, an experiment arm does not.
+
+`resolve_variant()` never returns None, but internally `_raw_variant()` keeps *"PostHog said control"*
+and *"PostHog said nothing"* apart. That distinction is load-bearing:
+`experiment_properties()` will not stamp `$feature/<key>=control` on a metric event from someone who
+was never enrolled. A fabricated control arm is worse than a missing one — it makes the readout look
+populated.
+
+**Local evaluation only.** Assignment reuses the bootstrap in `utilities/flags.py` (personal API key,
+the SDK's background definition poller, the failed-load cooldown) — one poller per process, zero
+network requests per lookup, because these run inside feed loops. The consequence is a real constraint
+on every experiment flag: its release condition must use **rollout percentage / distinct-ID only**. A
+condition needing server-held person properties cannot be decided locally, and every Celery worker
+would silently fall back to control.
+
+**distinct_id is `str(user_id)`** (or the `"system"` sentinel) — the same convention
+`observability.py`, `flags.py` and the SPA use. That is the whole mechanism by which PostHog
+attributes an outcome to an arm: exposure and metric events must land on ONE person.
+
+## Exposure
+
+`utilities/flags.py` suppresses `$feature_flag_called` for boolean toggles (a per-feed-post event
+nobody reads). Experiments are the opposite — without exposures there is no readout at all — so
+`experiments.track_exposure()` emits it explicitly, **deduped per (experiment, person, arm) per
+process**, via `observability.track_experiment_exposure()`.
+
+The event name and the `$feature_flag` / `$feature_flag_response` properties are PostHog's, not ours.
+Renaming them silently empties every experiment readout.
+
+## The registry
+
+`EXPERIMENTS` in `utilities/experiments.py`. `key` is the PostHog flag key AND the experiment key AND
+the registry name — one identifier, so a rename cannot leave the code, the flag and the readout
+disagreeing. `variants[0]` is always the control.
+
+| Key | Arms | Assignment | Metrics | Owner |
+|---|---|---|---|---|
+| `cost-routing-arm` | `control`, `treatment` | flag (10% start) | `post_outcome`, `$ai_generation` | cost |
+| `comment-contract-prompt` | `control`, `author-question` | flag (50/50) | `comment_outcome` | content |
+| `post-media-variant` | `control` + one per shipped combo | shipped | `post_outcome` | content |
+
+### 1. `cost-routing-arm` — cohorting moved to the flag
+
+The hard constraint: `routing_policy.py` is **mounted into the LiteLLM container**, which has no LEM
+package and no LEM dependencies. It must stay stdlib-only, so it can never import `experiments.py`.
+
+So the flag DECISION is handed to it rather than looked up by it:
+
+1. The weekly `auto_weekly_cost_routing` run resolves the arm for every active user
+   (`cost_routing.resolve_cohort` → `experiments.assignments`), emitting one exposure each.
+2. The answers are written into each routing bucket as `arms: {"7": "treatment", ...}` — inside the
+   same policy document Redis already carries to the router.
+3. `routing_policy.flag_arm()` reads that map; `assign_arm()` prefers it and falls back to the
+   original SHA-256 hash for anyone it has no answer for. `resolve_tier()` reports which one decided
+   in its `assignment` field, so a down-route from a live experiment is distinguishable in the proxy
+   logs from one that came from the hash because PostHog was unreachable.
+
+Two properties fall out of that ordering, both intentional:
+
+* **The flag decides WHO, `cohort_pct` decides WHETHER.** A bucket the optimizer parked
+  (`cohort_pct <= 0`, `rolled_back`, `hold`) routes nothing no matter what the flag says. Inside a
+  running bucket the flag wins in both directions — including keeping a user in control at a cohort
+  the ramp would have swept up, which is exactly the permanent holdout the §D.3 quality gate needs to
+  stay measurable after adoption.
+* **The arms map is applied AFTER the weekly evaluation.** The window being judged was routed under
+  the PREVIOUS document's arms; grading it against a freshly-resolved cohort would score posts in the
+  arm they are about to be in.
+
+The map is capped at `ARMS_MAX_USERS` (500) and a truncation is logged — the users left out are
+silently hash-assigned, which is not something to discover from an empty readout.
+
+**Ramping.** PostHog owns the rollout once the experiment is running. `scripts/posthog_experiments.py`
+never resets an existing flag's percentage (an `--apply` that reverted a 50% ramp to the spec's 10%
+start would re-cohort a live experiment); move it deliberately:
+
+```bash
+python scripts/posthog_experiments.py --rollout cost-routing-arm=50 --apply
+```
+
+The weekly digest and the `routing_policy` PostHog event both report `cohort_assignment`,
+`cohort_enrolled` and `cohort_treatment_share`, so a divergence between the loop's ramp and the flag's
+is visible rather than inferred.
+
+### 2. `comment-contract-prompt` — the pilot LLM prompt experiment
+
+The variable is the **closing ask** of the #617 feed-comment quality contract
+(`content_framework.comment_contract_directive`):
+
+* `control` — four value-adds, any genuinely open question.
+* `author-question` — adds one rule: end on a question **only this author could answer** (their
+  numbers, their decision, what they saw). A question anyone in the thread could answer doesn't count.
+
+Metric: **author-reply rate** (D4) from the #628 T+24h outcome sweep, carried on `comment_outcome`.
+
+Three scoping decisions:
+
+* The six deterministically-graded rules are **identical in both arms**. An arm that loosened one
+  would change what "passes the gate" means and the arms would stop being comparable.
+* Only **fresh feed comments** are enrolled. Replies to a specific comment have their own
+  acknowledge-and-answer contract, and the seed / second-wave comments are never measured by the
+  outcome sweep — enrolling them would add exposures the metric can never cover.
+* The arm is resolved **at read time** on the outcome event, not stored per comment. PostHog's
+  assignment is deterministic per person for the life of the flag, so this is stable — but see the
+  caveat below.
+
+### 3. `post-media-variant` — the #396 harness adapter
+
+Its arms are DATA, not registry text: whichever media combo actually shipped. There is no flag to
+read, so `assignment` is `shipped` and `experiments.track_shipped_variant()` reports the arm that
+already happened. `record_shipped_variant()` is the exposure moment; `get_shipped_variant_keys()` is
+read once per stats sweep so each `post_outcome` event carries its variant as
+`$feature/post-media-variant`.
+
+Combo keys (`black-forest-labs/flux-dev|gen4_turbo|1:1`) are not valid PostHog variant keys, so
+`variant_slug()` slugifies them — with a stable digest suffix when a slug had to be truncated, so two
+long combos can never collapse into one arm. `scripts/posthog_experiments.py` derives the flag's arm
+list from `generate_variants.DEFAULT_COMBOS`, so it cannot drift from what the code can actually ship.
+
+`post_stats.select_variant_winners` is untouched. PostHog gets the stats engine; the homegrown ranking
+keeps its recency weighting, which is what the scheduler reads.
+
+## Provisioning
+
+An experiment in PostHog is two objects: a multivariate **flag** (arms + rollout) and an **experiment
+record** (which flag, which metrics). The code resolves variants without either existing — it just
+always answers control — so this script is what makes an experiment real, and it is code rather than
+UI clicks for the same reason `scripts/posthog_provision.py` is: a flag someone edited by hand is not
+reviewable.
+
+```bash
+python scripts/posthog_experiments.py --print-specs      # payloads, no network
+python scripts/posthog_experiments.py                    # dry run (default); exit 2 = changes pending
+python scripts/posthog_experiments.py --apply            # create missing flags + experiments
+python scripts/posthog_experiments.py --rollout comment-contract-prompt=50 --apply
+```
+
+Needs `POSTHOG_PERSONAL_API_KEY` with feature-flag and experiment read+write, plus
+`POSTHOG_PROJECT_ID`. It creates the flag first and reports the experiment as `blocked` in the same
+dry run — PostHog needs the flag id, and promising both in one pass would be a lie about what a
+follow-up `--apply` can do.
+
+Flag release conditions are created **property-free at 100%**, with the split living in the variant
+list, so local evaluation can always decide them (see the constraint above).
+
+## Reading the results honestly
+
+**The small-sample caveat.** At LEM's current volume — one active user, ~3 posts a week, a few dozen
+feed comments — none of these experiments will reach significance on anything subtler than a collapse.
+`MINIMUM_DETECTABLE_EFFECT` is set to a deliberately coarse 30% for that reason. The harness exists so
+the multi-user future has a measurement plane already wired and already emitting; treat a readout
+today as a smoke test that exposures and metrics are flowing, **not** as evidence a prompt is better.
+The #630 content-quality trend line and the #628 weekly comment report remain the signals to act on.
+
+**The attribution caveat.** Metric events are attributed to an arm by PERSON via the exposure, and the
+`$feature/<key>` labels are resolved when the outcome is read (up to 24h after the comment shipped,
+weekly for routing). PostHog's assignment is deterministic per distinct_id for the life of a flag, and
+raising a rollout only ADDS treatment members, so this is stable in practice. It is not stable across
+a **re-roll**: changing a flag's variant list, or lowering a rollout, re-cohorts people and invalidates
+already-collected attribution. Don't re-roll a running experiment — end it in PostHog and start a new
+one. (The cost-routing loop's own `generation` counter does exactly this for the hash path.)
+
+**Never sum the two LLM streams** when reading cost per arm — `$ai_generation` is the proxy's own
+`response_cost`, `llm_call` is LEM's estimate. See [llm-analytics.md](llm-analytics.md).
+
+## Safety
+
+Experiments are **not** a control plane. The 429 breaker, the automation pause, the suppression
+tripwire and the per-day caps stay in Redis/env, exactly as [feature flags](feature-flags.md) says —
+an arm that could pause an account would put account safety behind a percentage rollout.
+
+The one thing an experiment CAN do is change model tier (cost-routing) or prompt wording
+(comment-contract), and both are already fenced: down-routing can only ever route DOWN and is
+auto-rolled-back by the §D.3 quality gate, and every comment arm faces the same #617 contract,
+similarity gate and #625 slop lint before anything ships.

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -96,6 +96,14 @@ Two properties fall out of that ordering, both intentional:
 The map is capped at `ARMS_MAX_USERS` (500) and a truncation is logged — the users left out are
 silently hash-assigned, which is not something to discover from an empty readout.
 
+**An outage carries the cohort forward; an ended experiment clears it.** `resolve_cohort()` answers
+`None` when it could not ASK PostHog (no experiment plane, the lookup raised, routing parked) and
+`{}` when it asked and PostHog enrolled nobody. Only the second clears the map. The per-user
+fallback in `assign_arm` is not enough on its own here: wiping the whole map on an unreachable
+PostHog would re-split every enrolled user under the hash for a week — a *different* split,
+mid-experiment — which is the arm flip `assign_arm`'s own docstring exists to prevent, and it would
+contaminate both sides of the comparison the next weekly run reads.
+
 **Ramping.** PostHog owns the rollout once the experiment is running. `scripts/posthog_experiments.py`
 never resets an existing flag's percentage (an `--apply` that reverted a 50% ramp to the spec's 10%
 start would re-cohort a live experiment); move it deliberately:

--- a/scripts/posthog_experiments.py
+++ b/scripts/posthog_experiments.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""Provision the LEM PostHog EXPERIMENTS — the multivariate flags and the experiment records that
+turn `utilities/experiments.py`'s registry into a readout a human can open (issue #652).
+
+An experiment in PostHog is two objects: a multivariate feature flag (the arms + the rollout that
+decides who is in which) and an experiment record (which flag, which metrics, which stats engine).
+The code can resolve a variant without either of them existing — it just always answers "control" —
+so this script is what makes the experiment REAL, and it is code rather than UI clicks for the same
+reason scripts/posthog_provision.py is: a flag someone edited by hand is not reviewable.
+
+Split like the other two provisioners: PURE spec/plan logic (unit-tested) over a thin I/O layer.
+
+The one deliberate difference from #650's dashboards: this script NEVER changes an existing flag's
+rollout percentage. PostHog owns the ramp once an experiment is running, and an `--apply` that reset a
+50% ramp back to the spec's starting 10% would silently re-cohort a live experiment. Use
+`--rollout KEY=PCT` to move it on purpose.
+
+CLI (--dry-run and --apply are mutually exclusive):
+  --dry-run              Show what would be created against the live project. No writes. (default)
+  --apply                Create missing flags/experiments (and any --rollout change).
+  --print-specs          Print the registry + the payloads that would be sent. No network.
+  --rollout KEY=PCT      Set one experiment flag's treatment rollout (0-100). Needs --apply to write.
+Env:
+  POSTHOG_PERSONAL_API_KEY  Personal API key (required for network). Scopes: feature_flag and
+                            experiment read+write.
+  POSTHOG_PROJECT_ID        PostHog project id (default 475262 — "CQC LEM").
+  POSTHOG_APP_HOST          App host for the API (default https://us.posthog.com).
+Exit: 0 in sync / applied, 2 changes pending (--dry-run), 1 error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from typing import Optional
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+from cqc_lem.utilities.experiments import (  # noqa: E402
+    ASSIGNMENT_SHIPPED,
+    EXPERIMENTS,
+    ExperimentSpec,
+    variant_slug,
+)
+
+DEFAULT_PROJECT_ID = "475262"  # "CQC LEM" — not a secret; the key that reaches it is.
+DEFAULT_APP_HOST = "https://us.posthog.com"
+
+TAGS = ["lem", "experiment"]
+
+# PostHog's frequentist engine needs a minimum-detectable-effect to size the run. 30% is deliberately
+# coarse: at LEM's current single-user volume nothing subtler than "obviously different" will ever
+# reach significance, and claiming otherwise would be the small-sample lie docs/experiments.md warns
+# about.
+MINIMUM_DETECTABLE_EFFECT = 30
+
+
+def media_combo_arms() -> list:
+    """The media-variant arms, derived from the #396 harness's own combo matrix so they cannot drift
+    from what the code can actually ship.
+
+    Imported lazily: `cqc_lem.app` pulls in the Celery task modules and therefore the LLM client,
+    which needs `OPENAI_API_KEY`. A failure is raised, never swallowed into a short arm list — an arm
+    the code emits exposures for but the flag doesn't define reads as an EMPTY readout, which looks
+    exactly like "the experiment found nothing"."""
+    try:
+        from cqc_lem.app.generate_variants import DEFAULT_COMBOS, combo_key
+    except Exception as exc:  # pragma: no cover - environment, not logic
+        raise SystemExit(
+            f"Cannot read the media-variant combos: {exc}\n"
+            "This script needs the app package importable. Source the stack's .env (OPENAI_API_KEY, "
+            "…) or run it in a container:\n"
+            "  docker exec celery_worker python scripts/posthog_experiments.py --dry-run")
+    arms = []
+    for combo in DEFAULT_COMBOS:
+        slug = variant_slug(combo_key(combo))
+        if slug not in arms:
+            arms.append(slug)
+    return arms
+
+
+def variants_for(spec: ExperimentSpec) -> list:
+    """The arms a flag is created with.
+
+    A flag-assigned experiment's arms are its spec's. A SHIPPED-assignment one has data-defined arms
+    (see `media_combo_arms`) rather than arms duplicated into the registry, where they would drift the
+    first time a combo changed. The control arm always comes first: PostHog treats variant[0] as the
+    baseline in the readout."""
+    if spec.assignment != ASSIGNMENT_SHIPPED:
+        return list(spec.variants)
+    arms = [spec.control]
+    arms += [arm for arm in media_combo_arms() if arm not in arms]
+    return arms
+
+
+def rollout_percentages(spec: ExperimentSpec, variants: list) -> list:
+    """Even split across the treatment arms, with the remainder parked in control.
+
+    Integer percentages that sum to exactly 100 is a PostHog validation rule, so the remainder is
+    given to control rather than distributed — control absorbing a rounding point is harmless, a
+    payload PostHog rejects is not."""
+    treatments = [v for v in variants if v != spec.control]
+    if not treatments:
+        return [{"key": spec.control, "rollout_percentage": 100}]
+    total = max(0, min(100, int(round(spec.rollout_pct * 100))))
+    each = total // len(treatments)
+    allocated = each * len(treatments)
+    rows = [{"key": spec.control, "rollout_percentage": 100 - allocated}]
+    rows += [{"key": key, "rollout_percentage": each} for key in treatments]
+    return rows
+
+
+def flag_payload(spec: ExperimentSpec) -> dict:
+    """The multivariate flag body.
+
+    `groups` carries a single 100% release condition with no properties on purpose: local evaluation
+    (utilities/flags.py) cannot resolve a condition that needs person properties the server holds, and
+    a condition it can't resolve makes every Celery worker fall back to control — silently. The
+    variant split inside `multivariate` is what actually cohorts."""
+    variants = variants_for(spec)
+    return {
+        "key": spec.key,
+        "name": f"LEM experiment — {spec.key}",
+        "tags": TAGS,
+        "active": True,
+        "filters": {
+            "groups": [{"properties": [], "rollout_percentage": 100}],
+            "multivariate": {"variants": rollout_percentages(spec, variants)},
+        },
+    }
+
+
+def experiment_payload(spec: ExperimentSpec, flag_id: Optional[int] = None) -> dict:
+    """The experiment record. Metrics are named by their event so the readout is built on the events
+    LEM already emits (docs/experiments.md) rather than on a new bespoke one."""
+    payload = {
+        "name": f"LEM — {spec.key}",
+        "description": spec.description,
+        "feature_flag_key": spec.key,
+        "parameters": {
+            "feature_flag_variants": rollout_percentages(spec, variants_for(spec)),
+            "minimum_detectable_effect": MINIMUM_DETECTABLE_EFFECT,
+        },
+        "metrics": [{"kind": "ExperimentMetric", "metric_type": "mean",
+                     "source": {"kind": "EventsNode", "event": event}}
+                    for event in spec.metric_events],
+    }
+    if flag_id is not None:
+        payload["feature_flag"] = flag_id
+    return payload
+
+
+def build_specs() -> list:
+    """Every registered experiment, in registry order."""
+    return list(EXPERIMENTS.values())
+
+
+# ── pure planning (unit-tested) ──────────────────────────────────────────────────────
+
+def plan_actions(specs: list, existing_flags: dict, existing_experiments: dict,
+                 rollouts: Optional[dict] = None) -> list:
+    """Diff the registry against PostHog.
+
+    `existing_flags` maps flag key -> {"id", "variants" (arm keys), "active"}; `existing_experiments`
+    maps flag key -> {"id", "name"}. Returns ordered actions: `create_flag`, `update_flag_variants`
+    (an arm the code knows about that the flag does not — otherwise every worker resolving it would
+    fall back to control), `set_rollout`, `create_experiment`, `unchanged*`.
+
+    An existing flag's rollout is NEVER planned as drift: PostHog owns the ramp once the experiment
+    runs. Only an explicit `--rollout` moves it."""
+    actions: list = []
+    wanted_rollouts = {key: pct for key, pct in (rollouts or {}).items()}
+    for spec in specs:
+        wanted = variants_for(spec)
+        found = existing_flags.get(spec.key)
+        if found is None:
+            actions.append({"action": "create_flag", "flag": spec.key,
+                            "payload": flag_payload(spec)})
+        else:
+            missing = [arm for arm in wanted if arm not in (found.get("variants") or [])]
+            if missing or not found.get("active", True):
+                actions.append({"action": "update_flag_variants", "flag": spec.key,
+                                "flag_id": found.get("id"), "missing": missing,
+                                "payload": flag_payload(spec)})
+            else:
+                actions.append({"action": "unchanged_flag", "flag": spec.key,
+                                "flag_id": found.get("id")})
+        if spec.key in wanted_rollouts:
+            actions.append({"action": "set_rollout", "flag": spec.key,
+                            "flag_id": (found or {}).get("id"),
+                            "rollout_pct": wanted_rollouts[spec.key],
+                            "payload": rollout_payload(spec, wanted_rollouts[spec.key])})
+        if spec.key in existing_experiments:
+            actions.append({"action": "unchanged_experiment", "experiment": spec.key,
+                            "experiment_id": existing_experiments[spec.key].get("id")})
+        elif found is None:
+            # PostHog needs the flag id, and a dry run that promised both in one pass would be lying
+            # about what a follow-up --apply can do.
+            actions.append({"action": "blocked_experiment", "experiment": spec.key,
+                            "reason": f"flag '{spec.key}' does not exist yet"})
+        else:
+            actions.append({"action": "create_experiment", "experiment": spec.key,
+                            "payload": experiment_payload(spec, found.get("id"))})
+    return actions
+
+
+def rollout_payload(spec: ExperimentSpec, pct: float) -> dict:
+    """A rollout-only flag PATCH: the same variant list, re-split at `pct`."""
+    resized = ExperimentSpec(
+        key=spec.key, variants=spec.variants, owner=spec.owner,
+        metric_events=spec.metric_events, description=spec.description,
+        assignment=spec.assignment, rollout_pct=max(0.0, min(1.0, float(pct))))
+    return {"filters": {"groups": [{"properties": [], "rollout_percentage": 100}],
+                        "multivariate": {"variants": rollout_percentages(
+                            resized, variants_for(resized))}}}
+
+
+def parse_rollout(expression: str) -> dict:
+    """`--rollout comment-contract-prompt=50` → `{"comment-contract-prompt": 0.5}`. Raises ValueError
+    on an unregistered key or a percentage outside 0-100, so a typo can't quietly no-op."""
+    key, _, raw = expression.partition("=")
+    key = key.strip()
+    if key not in EXPERIMENTS:
+        raise ValueError(f"Unknown experiment '{key}'. Known: {', '.join(EXPERIMENTS)}")
+    try:
+        pct = float(raw.strip())
+    except ValueError:
+        raise ValueError(f"Rollout for '{key}' must be a number 0-100, got '{raw.strip()}'")
+    if not 0 <= pct <= 100:
+        raise ValueError(f"Rollout for '{key}' must be 0-100, got {pct}")
+    return {key: pct / 100.0}
+
+
+UNCHANGED_ACTIONS = ("unchanged_flag", "unchanged_experiment")
+
+
+def pending(actions: list) -> list:
+    return [a for a in actions if a["action"] not in UNCHANGED_ACTIONS]
+
+
+def summarize(actions: list) -> str:
+    counts: dict = {}
+    for action in actions:
+        counts[action["action"]] = counts.get(action["action"], 0) + 1
+    return ", ".join(f"{name}={counts[name]}" for name in sorted(counts)) or "nothing to do"
+
+
+def experiment_url(app_host: str, project_id: str, experiment_id) -> str:
+    return f"{app_host.rstrip('/')}/project/{project_id}/experiments/{experiment_id}"
+
+
+# ── I/O (mocked in tests) ────────────────────────────────────────────────────────────
+
+class PostHogClient:
+    """Thin PostHog REST wrapper — only the calls this provisioner needs."""
+
+    def __init__(self, api_key: str, project_id: str, app_host: str = DEFAULT_APP_HOST) -> None:
+        self.project_id = project_id
+        self.app_host = app_host.rstrip("/")
+        self._base = f"{self.app_host}/api/projects/{project_id}"
+        self._headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        import requests
+        response = requests.request(method, f"{self._base}{path}", headers=self._headers,
+                                    timeout=30, **kwargs)
+        response.raise_for_status()
+        return response.json() if response.content else {}
+
+    def _paged(self, path: str) -> list:
+        import requests
+        results, url = [], f"{self._base}{path}"
+        while url:
+            response = requests.get(url, headers=self._headers, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+            results.extend(payload.get("results", []))
+            url = payload.get("next")
+        return results
+
+    def list_flags(self) -> dict:
+        flags = {}
+        for item in self._paged("/feature_flags/?limit=100"):
+            if item.get("deleted"):
+                continue
+            multivariate = ((item.get("filters") or {}).get("multivariate") or {})
+            flags[item.get("key")] = {
+                "id": item.get("id"),
+                "active": item.get("active", True),
+                "variants": [v.get("key") for v in (multivariate.get("variants") or [])],
+            }
+        return flags
+
+    def list_experiments(self) -> dict:
+        """Keyed by FLAG key, not by experiment name — the flag is the identity the code shares with
+        PostHog, and an experiment someone renamed in the UI is still that experiment."""
+        experiments = {}
+        for item in self._paged("/experiments/?limit=100"):
+            if item.get("deleted"):
+                continue
+            key = item.get("feature_flag_key") or (item.get("feature_flag") or {}).get("key")
+            if key:
+                experiments[key] = {"id": item.get("id"), "name": item.get("name")}
+        return experiments
+
+    def create_flag(self, payload: dict) -> int:
+        return self._request("POST", "/feature_flags/", json=payload).get("id")
+
+    def update_flag(self, flag_id, payload: dict) -> None:
+        self._request("PATCH", f"/feature_flags/{flag_id}/", json=payload)
+
+    def create_experiment(self, payload: dict) -> int:
+        return self._request("POST", "/experiments/", json=payload).get("id")
+
+
+def apply_actions(client: PostHogClient, actions: list, dry_run: bool = True) -> list:
+    """Execute the plan. `dry_run` reports without writing. Returns the log lines emitted."""
+    flag_ids: dict = {}
+    log: list = []
+    for action in actions:
+        kind = action["action"]
+        if kind == "create_flag":
+            if dry_run:
+                log.append(f"[dry-run] create flag '{action['flag']}' with variants "
+                           f"{[v['key'] for v in action['payload']['filters']['multivariate']['variants']]}")
+                continue
+            flag_ids[action["flag"]] = client.create_flag(action["payload"])
+            log.append(f"created flag '{action['flag']}' -> {flag_ids[action['flag']]}")
+        elif kind == "update_flag_variants":
+            if dry_run:
+                log.append(f"[dry-run] update flag '{action['flag']}' (missing arms: "
+                           f"{action['missing'] or 'none'}, re-activating if disabled)")
+                continue
+            client.update_flag(action["flag_id"], action["payload"])
+            log.append(f"updated flag '{action['flag']}'")
+        elif kind == "set_rollout":
+            flag_id = action.get("flag_id") or flag_ids.get(action["flag"])
+            if dry_run:
+                log.append(f"[dry-run] set '{action['flag']}' treatment rollout to "
+                           f"{action['rollout_pct'] * 100:.0f}%")
+                continue
+            if flag_id is None:
+                log.append(f"skipped rollout for '{action['flag']}': flag does not exist yet")
+                continue
+            client.update_flag(flag_id, action["payload"])
+            log.append(f"set '{action['flag']}' treatment rollout to "
+                       f"{action['rollout_pct'] * 100:.0f}%")
+        elif kind == "create_experiment":
+            if dry_run:
+                log.append(f"[dry-run] create experiment '{action['experiment']}'")
+                continue
+            payload = dict(action["payload"])
+            if payload.get("feature_flag") is None:
+                payload["feature_flag"] = flag_ids.get(action["experiment"])
+            log.append(f"created experiment '{action['experiment']}' -> "
+                       f"{client.create_experiment(payload)}")
+        elif kind == "blocked_experiment":
+            log.append(f"skipped experiment '{action['experiment']}': {action['reason']}")
+    return log
+
+
+def _print_specs(rollouts: Optional[dict] = None) -> None:
+    for spec in build_specs():
+        print(f"\n-- {spec.key} ({spec.assignment}-assigned, owner={spec.owner})")
+        print(f"   arms: {variants_for(spec)}")
+        print(f"   metrics: {list(spec.metric_events)}")
+        print(json.dumps(flag_payload(spec), indent=2))
+        print(json.dumps(experiment_payload(spec), indent=2))
+    for key, pct in (rollouts or {}).items():
+        print(f"\n-- rollout {key} -> {pct * 100:.0f}%")
+        print(json.dumps(rollout_payload(EXPERIMENTS[key], pct), indent=2))
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Provision the LEM PostHog experiments (multivariate flags + experiment records).")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--apply", action="store_true", help="Write changes to PostHog.")
+    mode.add_argument("--dry-run", action="store_true", help="Report changes only (default).")
+    parser.add_argument("--print-specs", action="store_true",
+                        help="Print the registry and the payloads, then exit.")
+    parser.add_argument("--rollout", metavar="KEY=PCT", action="append",
+                        help="Set an experiment flag's treatment rollout percentage (0-100).")
+    args = parser.parse_args(argv)
+
+    rollouts: dict = {}
+    for expression in args.rollout or []:
+        try:
+            rollouts.update(parse_rollout(expression))
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+
+    if args.print_specs:
+        _print_specs(rollouts)
+        return 0
+
+    api_key = os.getenv("POSTHOG_PERSONAL_API_KEY", "")
+    if not api_key:
+        print("POSTHOG_PERSONAL_API_KEY is not set — cannot reach PostHog.", file=sys.stderr)
+        return 1
+    project_id = os.getenv("POSTHOG_PROJECT_ID", DEFAULT_PROJECT_ID)
+    app_host = os.getenv("POSTHOG_APP_HOST", DEFAULT_APP_HOST)
+    dry_run = args.dry_run or not args.apply
+
+    client = PostHogClient(api_key, project_id, app_host)
+    try:
+        flags, experiments = client.list_flags(), client.list_experiments()
+    except Exception as exc:
+        print(f"Failed to read PostHog state: {exc}", file=sys.stderr)
+        return 1
+
+    actions = plan_actions(build_specs(), flags, experiments, rollouts)
+    for line in apply_actions(client, actions, dry_run=dry_run):
+        print(line)
+    print(summarize(actions))
+
+    if not dry_run:
+        experiments = client.list_experiments()
+    for key, found in experiments.items():
+        if key in EXPERIMENTS:
+            print(f"{key}: {experiment_url(app_host, project_id, found.get('id'))}")
+
+    if dry_run and pending(actions):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/cqc_lem/app/generate_variants.py
+++ b/src/cqc_lem/app/generate_variants.py
@@ -89,12 +89,16 @@ def record_shipped_variant(user_id: int, post_id: int, combo: dict, *,
     combo that shipped IS the arm, so it is reported as one rather than looked up from a flag, and the
     post's `post_outcome` event carries the same variant. The homegrown ranking
     (`post_stats.select_variant_winners`) is untouched — PostHog gets the stats engine, the ranking
-    keeps its recency weighting."""
+    keeps its recency weighting. The exposure follows the DB write, not the other way round: the arm
+    a `post_outcome` event carries is read back out of `post_variants`, so an exposure for a row that
+    never landed would be an enrolment the metric can never cover."""
     key = combo_key(combo)
-    _track_shipped_variant_exposure(user_id, post_id, key)
-    return _db_record_shipped_variant(
+    recorded = _db_record_shipped_variant(
         user_id, post_id, key, combo=combo,
         batch_id=batch_id, variant_index=variant_index)
+    if recorded:
+        _track_shipped_variant_exposure(user_id, post_id, key)
+    return recorded
 
 
 def _track_shipped_variant_exposure(user_id: Optional[int], post_id: Optional[int],

--- a/src/cqc_lem/app/generate_variants.py
+++ b/src/cqc_lem/app/generate_variants.py
@@ -83,10 +83,29 @@ def record_shipped_variant(user_id: int, post_id: int, combo: dict, *,
                            batch_id: Optional[str] = None, variant_index: Optional[int] = None) -> bool:
     """Record which variant `combo` actually shipped for `post_id` so its outcome can be attributed
     later (issue #396 / D2). Derives the stable `combo_key` and persists via db; returns False on
-    any DB error rather than raising, so a shipping path is never broken by tracking."""
+    any DB error rather than raising, so a shipping path is never broken by tracking.
+
+    This is also the exposure moment for the PostHog side of the same experiment (issue #652): the
+    combo that shipped IS the arm, so it is reported as one rather than looked up from a flag, and the
+    post's `post_outcome` event carries the same variant. The homegrown ranking
+    (`post_stats.select_variant_winners`) is untouched — PostHog gets the stats engine, the ranking
+    keeps its recency weighting."""
+    key = combo_key(combo)
+    _track_shipped_variant_exposure(user_id, post_id, key)
     return _db_record_shipped_variant(
-        user_id, post_id, combo_key(combo), combo=combo,
+        user_id, post_id, key, combo=combo,
         batch_id=batch_id, variant_index=variant_index)
+
+
+def _track_shipped_variant_exposure(user_id: Optional[int], post_id: Optional[int],
+                                    key: str) -> None:
+    """Best-effort PostHog exposure for the shipped variant. Never raises: analytics can lose an
+    exposure, a post cannot lose its variant record."""
+    try:
+        from cqc_lem.utilities.experiments import POST_MEDIA_VARIANT, track_shipped_variant
+        track_shipped_variant(POST_MEDIA_VARIANT, key, user_id=user_id, post_id=post_id)
+    except Exception as e:
+        log_warning("Shipped-variant experiment exposure skipped", exc=e)
 
 
 def _public_url(batch_id: str, file_name: str) -> str:

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -35,6 +35,7 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     get_newsletter_settings, mark_newsletter_published, record_newsletter_subscriber_stat, \
     get_newsletter_edition, mark_edition_published, mark_edition_failed, \
     upsert_user_group, get_enabled_group_ids, record_post_stats, get_recent_posted_post_ids, \
+    get_shipped_variant_keys, \
     get_lead_magnet_settings, has_received_lead_magnet, record_lead_magnet_sent, \
     LogResultType, has_user_commented_on_post_url, get_post_url_from_log_for_user, get_post_message_from_log_for_user, \
     claim_post_for_comment, mark_post_commented, mark_post_reacted, release_post_claim, has_commented_post, \
@@ -2119,6 +2120,9 @@ def auto_scrape_post_stats(self, user_id: int):
     post_ids = get_recent_posted_post_ids(user_id)
     if not post_ids:
         return "No recent posts to scrape"
+    # One query for the whole sweep, so every outcome event can name the A/B variant its post shipped
+    # (issues #396/#652) without a lookup inside the Selenium loop.
+    shipped_variants = get_shipped_variant_keys(user_id)
     try:
         driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Post Stats",
                                                                    measurement_only=True)
@@ -2150,7 +2154,8 @@ def auto_scrape_post_stats(self, user_id: int):
             track_post_outcome(post_id=pid, reactions=counts.get("reactions", 0),
                                comments=counts.get("comments", 0), reposts=counts.get("reposts") or 0,
                                impressions=counts.get("impressions") or None,
-                               saves=counts.get("saves") or 0, user_id=user_id)
+                               saves=counts.get("saves") or 0, user_id=user_id,
+                               variant_key=shipped_variants.get(pid))
             scraped += 1
         return f"Scraped stats for {scraped} post(s)"
     finally:

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -300,6 +300,20 @@ def lint_repaired(draft: "str | None", content_type: str, redraft, **log_ctx) ->
     return current
 
 
+def _comment_contract_variant(user_id: int = None) -> "str | None":
+    """This user's arm of the comment-contract prompt experiment (issue #652). Never raises: a
+    PostHog problem must cost us the experiment, not the comment — and `comment_contract_directive`
+    treats None (like any unknown arm) as the control contract, which is the prompt that shipped
+    before the experiment existed."""
+    try:
+        from cqc_lem.utilities.experiments import COMMENT_CONTRACT_PROMPT, resolve_variant
+        return resolve_variant(COMMENT_CONTRACT_PROMPT, user_id)
+    except Exception as e:
+        log_warning("Comment-contract experiment lookup failed — using the control prompt", exc=e,
+                    user_id=user_id, action_type="comment")
+        return None
+
+
 def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=None, post_comment: str = None,
                          prefs: dict = None, profile_synthesis: str = None,
                          blueprint: dict = None, research: dict = None,
@@ -319,7 +333,12 @@ def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=No
     SKIPS the post. A template comment costs reach; a skipped post costs one comment.
 
     Replying to a specific comment (`post_comment`) keeps its own acknowledge-and-answer contract and
-    is not gated here."""
+    is not gated here.
+
+    The contract's closing ask is the pilot LLM prompt experiment (issue #652): `user_id` decides the
+    arm, and it is scoped to FRESH FEED comments only because that is the only surface the #628 T+24h
+    sweep measures author-reply rate on — the seed and second-wave comments would add exposures the
+    metric can never cover."""
     image_attached = "(image attached)" if post_img_url else ""
     _no_hashtags = "" if (prefs and prefs.get("use_hashtags")) else " without using any hashtags"
     user_comment = f"\n\nRespond to this Comment Directly: <comment>{post_comment}</comment>\n\nYou are responding as the author of the LinkedIn Content. Keep your response short and sweet{_no_hashtags}.\n\n" if post_comment else ""
@@ -393,7 +412,8 @@ def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=No
           preamble, no sign-off, no hashtags/emojis unless explicitly allowed below.
 
         Output ONLY the final comment text — no quotes, no labels, no explanation.""" + blueprint_block
-        + (_framework.comment_contract_directive() if post_comment is None else "")
+        + (_framework.comment_contract_directive(_comment_contract_variant(user_id))
+           if post_comment is None else "")
     }
 
     # User prompt to be sent with each API call

--- a/src/cqc_lem/utilities/ai/content_framework.py
+++ b/src/cqc_lem/utilities/ai/content_framework.py
@@ -1763,11 +1763,37 @@ def comment_similarity_report(draft: Optional[str], recent_comments: list) -> di
             "measure": measure, "too_similar": scores[best] > threshold}
 
 
-def comment_contract_directive() -> str:
+# Mirrors `experiments.COMMENT_CONTRACT_AUTHOR_QUESTION`. Kept as a literal (the same reason
+# ai/client.py mirrors observability's system sentinel) so the shared content core never imports the
+# experiment plumbing; tests/unit/utilities/test_experiments.py pins the two together.
+COMMENT_CONTRACT_AUTHOR_QUESTION_VARIANT = "author-question"
+
+# The pilot prompt variant (issue #652, `experiments.COMMENT_CONTRACT_AUTHOR_QUESTION`). Control
+# lets the closing ask be any of the four value-adds; this arm REQUIRES the comment to end on a
+# question only the post's author could answer, which is the shape most likely to earn the reply the
+# whole contract exists to earn. Measured against author-reply rate (D4) from the #628 outcome sweep.
+#
+# It is worded as an ADDITIONAL rule rather than a rewrite of rules 1-6 on purpose: the deterministic
+# `comment_contract_report` grades the same six rules in both arms, so an arm that loosened one of
+# them would change what "passes the gate" means and the two arms would no longer be comparable.
+COMMENT_AUTHOR_QUESTION_DIRECTIVE = (
+    "7. END ON A QUESTION ONLY THIS AUTHOR COULD ANSWER — about their specific numbers, their "
+    "decision, or what they saw happen. A question anyone in the thread could answer just as well "
+    "(\"what do you all think?\") does not count, and neither does a question the post already "
+    "answered. One question, at the end, and nothing after it.\n"
+)
+
+
+def comment_contract_directive(variant: Optional[str] = None) -> str:
     """The WRITER-side contract injected into every fresh feed-comment prompt. Rule 5 is the "Tip
     #8" framing: a comment's audience is the post's READERS, and its job is to add what the post
-    missed — flattery for the author earns nothing and is what the 2026 ranking demotes."""
+    missed — flattery for the author earns nothing and is what the 2026 ranking demotes.
+
+    `variant` is the arm of the pilot prompt experiment (#652). An unknown or missing variant is the
+    control contract, so a mis-provisioned flag can only ever produce today's prompt."""
     banned = ", ".join(f"'{p}'" for p in comment_filler_openers()[:8])
+    extra = (COMMENT_AUTHOR_QUESTION_DIRECTIVE
+             if variant == COMMENT_CONTRACT_AUTHOR_QUESTION_VARIANT else "")
     return (
         "\n\nCOMMENT QUALITY CONTRACT — a draft that misses ANY of these is thrown away and "
         "rewritten, so satisfy all of them:\n"
@@ -1786,6 +1812,7 @@ def comment_contract_directive() -> str:
         "LinkedIn's 2026 ranking demotes comments that only validate.\n"
         "6. Use your own words and rhythm every time — never reuse the shape, opening, or phrasing "
         "of a comment you have already left on another post.\n"
+        + extra
     )
 
 

--- a/src/cqc_lem/utilities/cost_routing.py
+++ b/src/cqc_lem/utilities/cost_routing.py
@@ -23,6 +23,13 @@ mounted into the LiteLLM container and must stay stdlib-only). Either one off me
 exactly as it did before this existed. Only features with a real quality signal
 (`MEASURABLE_FEATURES`) can be auto-experimented; everything else is reported as a human-gated
 recommendation, per §D.3.
+
+**Cohorting is PostHog's** since issue #652: the arm comes from the `cost-routing-arm` multivariate
+experiment flag, resolved HERE (app-side) and written into each routing bucket's `arms` map, because
+`routing_policy.py` is mounted into the LiteLLM container and must stay stdlib-only — the DECISION is
+handed to the router, never imported by it. Users PostHog has no answer for keep the original
+deterministic hash, so a PostHog outage moves no traffic. The ramp is still the optimizer's: the flag
+decides WHO is in the treatment, `cohort_pct` decides WHETHER the bucket routes at all.
 """
 from __future__ import annotations
 
@@ -50,14 +57,18 @@ from cqc_lem.utilities.env_constants import (
 from cqc_lem.utilities.flags import COST_ROUTING, flag_enabled
 from cqc_lem.utilities.logger import log_error, log_info, log_warning
 from cqc_lem.utilities.routing_policy import (
+    ARMS,
     ARM_CONTROL,
     ARM_TREATMENT,
+    ASSIGNMENT_FLAG,
+    ASSIGNMENT_HASH,
     POLICY_REDIS_KEY,
     POLICY_VERSION,
     ROUTING_STATES,
     STATE_ADOPTED,
     STATE_EXPERIMENT,
     STATE_ROLLED_BACK,
+    SYSTEM_USER_ID,
     TIER_COMPLEX,
     TIER_MEDIUM,
     assign_arm,
@@ -290,6 +301,65 @@ def split_observations(observations: Optional[Sequence[Mapping]], bucket: Mappin
     return arms
 
 
+# Most users the arms map may carry. The document is read from Redis on every router cache miss, so
+# it cannot grow unbounded — and a truncation is LOGGED rather than silently applied, because the
+# users left out are silently hash-assigned instead of flag-assigned.
+ARMS_MAX_USERS = 500
+
+
+def normalize_arms(arms: Optional[Mapping]) -> dict:
+    """The `arms` map as the policy document carries it: string user ids → a real arm name.
+
+    JSON has no integer keys, so ids are stringified HERE rather than at read time — `flag_arm` in the
+    stdlib-only core compares strings, and a document written with int keys would round-trip through
+    Redis as strings and match nothing. Anything that isn't a recognized arm is dropped: a bad value
+    must fall back to the hash, not route traffic."""
+    normalized = {}
+    for user_id, arm in (arms or {}).items():
+        if user_id is None or arm not in ARMS:
+            continue
+        key = str(user_id).strip()
+        if key and key.lower() != SYSTEM_USER_ID:
+            normalized[key] = arm
+    if len(normalized) <= ARMS_MAX_USERS:
+        return normalized
+    kept = dict(sorted(normalized.items())[:ARMS_MAX_USERS])
+    log_warning(f"Routing experiment resolved {len(normalized)} arms — only the first "
+                f"{ARMS_MAX_USERS} are carried in the policy document; the rest fall back to hash "
+                f"assignment", task_name="auto_weekly_cost_routing")
+    return kept
+
+
+def apply_arms(bucket: Mapping, arms: Optional[Mapping]) -> dict:
+    """Stamp the flag's cohort onto one bucket. A bucket that isn't routing carries no map — it moves
+    no traffic, so an assignment on it would only be stale data the next run has to reason about."""
+    updated = dict(bucket)
+    routing = updated.get("state") in ROUTING_STATES
+    resolved = normalize_arms(arms) if routing else {}
+    if resolved:
+        updated["arms"] = resolved
+        updated["assignment"] = ASSIGNMENT_FLAG
+    else:
+        updated.pop("arms", None)
+        updated["assignment"] = ASSIGNMENT_HASH
+    return updated
+
+
+def arms_summary(arms: Optional[Mapping]) -> dict:
+    """What the readout says about the cohort: how many users PostHog enrolled and what share of them
+    it put in the treatment. `treatment_share` is None (not 0.0) with nobody enrolled — "the flag
+    answered for nobody" and "the flag put nobody in the treatment" are different facts, and only one
+    of them means the experiment is running."""
+    resolved = normalize_arms(arms)
+    treatment = sum(1 for arm in resolved.values() if arm == ARM_TREATMENT)
+    return {
+        "assignment": ASSIGNMENT_FLAG if resolved else ASSIGNMENT_HASH,
+        "enrolled": len(resolved),
+        "treatment": treatment,
+        "treatment_share": round(treatment / len(resolved), 4) if resolved else None,
+    }
+
+
 def new_bucket(feature: str, from_tier: str, today: date, cohort_pct: float,
                generation: int = 1) -> dict:
     to_tier = cheaper_tier(from_tier)
@@ -356,14 +426,20 @@ def propose_buckets(observations: Optional[Sequence[Mapping]], existing: Mapping
 def build_routing_policy(previous: Optional[Mapping], observations: Optional[Sequence[Mapping]],
                          today: date, spend_by_feature: Optional[Mapping] = None,
                          thresholds: Optional[Mapping] = None,
-                         enabled: Optional[bool] = None) -> dict:
+                         enabled: Optional[bool] = None,
+                         arms: Optional[Mapping] = None) -> dict:
     """Evaluate every live bucket, then open new experiments in whatever slots are left, and return
     `{"policy": ..., "changes": [...], "recommendations": [...]}`.
 
     `enabled` is written INTO the document, so flipping the `cost-routing-enabled` flag off parks
     every bucket at once without erasing the experiment state the next run needs. `None` resolves it
     at CALL time (flag, else COST_ROUTING_ENABLED) rather than at import, which is what makes a flip
-    land on the next weekly run instead of the next deploy."""
+    land on the next weekly run instead of the next deploy.
+
+    `arms` is the PostHog experiment's cohort ({user_id: arm}, resolved by `collect_routing_report`).
+    It is applied AFTER the evaluation loop on purpose: the window being judged was routed under the
+    PREVIOUS document's arms, so evaluating against a freshly-resolved cohort would grade posts in the
+    arm they are about to be in rather than the one they were written in."""
     enabled = routing_enabled() if enabled is None else bool(enabled)
     limits = {**default_thresholds(), **(thresholds or {})}
     policy = normalize_policy(previous)
@@ -375,10 +451,10 @@ def build_routing_policy(previous: Optional[Mapping], observations: Optional[Seq
         if bucket.get("state") not in ROUTING_STATES:
             continue
         feature_rows = [row for row in rows if row.get("feature", "content") == bucket.get("feature")]
-        arms = split_observations(feature_rows, bucket)
-        metric = pick_metric(arms[ARM_TREATMENT] + arms[ARM_CONTROL])
-        comparison = compare_arms(summarize_arm(arms[ARM_TREATMENT], metric),
-                                  summarize_arm(arms[ARM_CONTROL], metric), limits)
+        arm_rows = split_observations(feature_rows, bucket)
+        metric = pick_metric(arm_rows[ARM_TREATMENT] + arm_rows[ARM_CONTROL])
+        comparison = compare_arms(summarize_arm(arm_rows[ARM_TREATMENT], metric),
+                                  summarize_arm(arm_rows[ARM_CONTROL], metric), limits)
         outcome = evaluate_bucket(bucket, comparison, today, limits)
         buckets[key] = outcome["bucket"]
         record = {"bucket": key, "action": outcome["action"], "reason": outcome["reason"],
@@ -394,6 +470,15 @@ def build_routing_policy(previous: Optional[Mapping], observations: Optional[Seq
             changes.append({"bucket": key, "action": ACTION_START, "bucket_state": bucket,
                             "reason": bucket["reason"], "comparison": None})
 
+    for key, bucket in list(buckets.items()):
+        buckets[key] = apply_arms(bucket, arms)
+    # The change records captured the pre-arms bucket, so refresh the ones that are still live —
+    # otherwise the digest and the PostHog event would report a cohort the document does not carry.
+    for record in changes + holds:
+        refreshed = buckets.get(record.get("bucket"))
+        if refreshed is not None:
+            record["bucket_state"] = refreshed
+
     return {
         "policy": {
             "version": POLICY_VERSION,
@@ -403,6 +488,7 @@ def build_routing_policy(previous: Optional[Mapping], observations: Optional[Seq
         },
         "changes": changes,
         "holds": holds,
+        "cohort": arms_summary(arms),
         "recommendations": recommend_unmeasurable(spend_by_feature),
     }
 
@@ -437,12 +523,19 @@ def render_routing_text(report: Mapping) -> str:
         lines.append(f"[{str(change.get('action', '')).upper()}] {change.get('bucket')}"
                      f"{f' → {state}' if state else ''}")
         lines.append(f"    {change.get('reason')}")
+    cohort = dict(report.get("cohort") or {})
+    if cohort:
+        share = cohort.get("treatment_share")
+        lines += ["", f"Cohorting: {cohort.get('assignment')} — {cohort.get('enrolled')} user(s) "
+                      f"enrolled in the PostHog experiment"
+                      + (f", {share * 100:.0f}% in treatment" if share is not None else "")]
     lines += ["", "Buckets:"]
     if not buckets:
         lines.append("  (none)")
     for key, bucket in buckets.items():
         lines.append(f"  {key}: {bucket.get('state')} → {bucket.get('to_tier')} "
-                     f"@ {float(bucket.get('cohort_pct') or 0) * 100:.0f}% cohort")
+                     f"@ {float(bucket.get('cohort_pct') or 0) * 100:.0f}% cohort "
+                     f"({bucket.get('assignment') or ASSIGNMENT_HASH}-assigned)")
     for recommendation in report.get("recommendations") or []:
         lines += ["", f"RECOMMENDATION: {recommendation.get('recommendation')}"]
     return "\n".join(lines)
@@ -532,6 +625,52 @@ def collect_quality_observations(days: int = COST_ROUTING_WINDOW_DAYS,
     return [{**row, "feature": "content"} for row in rows]
 
 
+def cohort_user_ids(observations: Optional[Sequence[Mapping]] = None) -> list:
+    """Who to resolve an arm for: every currently active user, plus anyone who published inside the
+    window. The union matters in both directions — an active user with no posts yet still needs an arm
+    before their first LLM call, and a user who has since gone inactive must keep the arm their
+    already-observed posts were written under, or the window's analysis loses a whole side."""
+    from cqc_lem.utilities.db import get_active_user_ids
+
+    ids = []
+    try:
+        ids = [int(user_id) for user_id in (get_active_user_ids() or [])]
+    except Exception as e:
+        log_warning("Could not list active users for the routing experiment cohort — falling back to "
+                    "the observed users only", exc=e, task_name="auto_weekly_cost_routing")
+    seen = set(ids)
+    for row in observations or []:
+        user_id = row.get("user_id")
+        if user_id is None or user_id in seen:
+            continue
+        seen.add(user_id)
+        ids.append(user_id)
+    return ids
+
+
+def resolve_cohort(observations: Optional[Sequence[Mapping]] = None) -> dict:
+    """`{user_id: arm}` from the PostHog `cost-routing-arm` experiment, or `{}` when it has no answer.
+
+    `{}` is the fail-open path and it is not an error: every bucket then falls back to the hash
+    assignment that shipped before #652, which is the same split it has always used.
+
+    The availability check comes FIRST so a project with no experiment plane doesn't pay for the
+    active-user scan it could never use an answer from."""
+    from cqc_lem.utilities.experiments import COST_ROUTING_ARM, assignments, enrollment_available
+
+    if not enrollment_available():
+        return {}
+    user_ids = cohort_user_ids(observations)
+    if not user_ids:
+        return {}
+    try:
+        return assignments(user_ids, COST_ROUTING_ARM)
+    except Exception as e:
+        log_warning("PostHog routing-experiment assignment failed — using hash cohorting", exc=e,
+                    task_name="auto_weekly_cost_routing")
+        return {}
+
+
 def collect_routing_report(days: int = COST_ROUTING_WINDOW_DAYS, today: Optional[date] = None,
                            thresholds: Optional[Mapping] = None,
                            enabled: Optional[bool] = None) -> dict:
@@ -542,7 +681,11 @@ def collect_routing_report(days: int = COST_ROUTING_WINDOW_DAYS, today: Optional
     the weekly run costs one Redis read/write instead of a cross-user posts+post_stats scan. It still
     republishes the parked (`enabled: false`) document so the proxy sees the flag flip, and any bucket
     left in it is judged on no data, which can only HOLD: turning the flag back on resumes exactly
-    where the loop left off, and no experiment can open while it is off."""
+    where the loop left off, and no experiment can open while it is off.
+
+    The PostHog cohort is resolved on the same condition: with routing off there is nothing to enrol
+    anyone INTO, and an exposure event for an experiment that isn't running would put control-arm
+    traffic in a readout that never had a treatment arm."""
     from cqc_lem.utilities.db import cost_ledger_available, get_cost_rollup
 
     enabled = routing_enabled() if enabled is None else bool(enabled)
@@ -550,7 +693,9 @@ def collect_routing_report(days: int = COST_ROUTING_WINDOW_DAYS, today: Optional
     observations = collect_quality_observations(days, end=today) if enabled else []
     spend = (get_cost_rollup(today - timedelta(days=max(int(days), 1)), today, group_by="feature")
              if enabled and cost_ledger_available() else {})
-    result = build_routing_policy(load_policy(), observations, today, spend, thresholds, enabled)
+    arms = resolve_cohort(observations) if enabled else {}
+    result = build_routing_policy(load_policy(), observations, today, spend, thresholds, enabled,
+                                  arms=arms)
     return {
         "date": today.isoformat(),
         "window_days": int(days),

--- a/src/cqc_lem/utilities/cost_routing.py
+++ b/src/cqc_lem/utilities/cost_routing.py
@@ -330,12 +330,31 @@ def normalize_arms(arms: Optional[Mapping]) -> dict:
     return kept
 
 
+def carried_arms(buckets: Optional[Mapping]) -> dict:
+    """The cohort the PREVIOUS document already carries, unioned across its routing buckets.
+
+    This is what a run that could not ASK PostHog falls back to. Wiping the map instead would send
+    every enrolled user back to the hash for a week — a different split, mid-experiment — which is
+    the exact arm-flipping `assign_arm` exists to prevent. "PostHog was unreachable" and "PostHog
+    enrolled nobody" are different facts here for the same reason `_raw_variant` keeps them apart."""
+    carried: dict = {}
+    for bucket in (buckets or {}).values():
+        if isinstance(bucket, Mapping) and bucket.get("state") in ROUTING_STATES:
+            carried.update(normalize_arms(bucket.get("arms")))
+    return carried
+
+
 def apply_arms(bucket: Mapping, arms: Optional[Mapping]) -> dict:
     """Stamp the flag's cohort onto one bucket. A bucket that isn't routing carries no map — it moves
-    no traffic, so an assignment on it would only be stale data the next run has to reason about."""
+    no traffic, so an assignment on it would only be stale data the next run has to reason about.
+
+    `arms=None` means the run could not ask PostHog at all, so the bucket keeps whatever cohort it
+    already carried; `{}` means PostHog answered for nobody (the experiment is over, or the flag is
+    at 0%) and the map is cleared back to hash assignment."""
     updated = dict(bucket)
     routing = updated.get("state") in ROUTING_STATES
-    resolved = normalize_arms(arms) if routing else {}
+    source = updated.get("arms") if arms is None else arms
+    resolved = normalize_arms(source) if routing else {}
     if resolved:
         updated["arms"] = resolved
         updated["assignment"] = ASSIGNMENT_FLAG
@@ -439,7 +458,10 @@ def build_routing_policy(previous: Optional[Mapping], observations: Optional[Seq
     `arms` is the PostHog experiment's cohort ({user_id: arm}, resolved by `collect_routing_report`).
     It is applied AFTER the evaluation loop on purpose: the window being judged was routed under the
     PREVIOUS document's arms, so evaluating against a freshly-resolved cohort would grade posts in the
-    arm they are about to be in rather than the one they were written in."""
+    arm they are about to be in rather than the one they were written in. `None` means the run could
+    not ASK PostHog (outage, key missing, experiments off) — the previous document's cohort is carried
+    forward untouched, because reshuffling a live cohort back onto the hash is exactly the mid-flight
+    arm flip the fallback exists to avoid."""
     enabled = routing_enabled() if enabled is None else bool(enabled)
     limits = {**default_thresholds(), **(thresholds or {})}
     policy = normalize_policy(previous)
@@ -470,8 +492,9 @@ def build_routing_policy(previous: Optional[Mapping], observations: Optional[Seq
             changes.append({"bucket": key, "action": ACTION_START, "bucket_state": bucket,
                             "reason": bucket["reason"], "comparison": None})
 
+    effective_arms = carried_arms(buckets) if arms is None else normalize_arms(arms)
     for key, bucket in list(buckets.items()):
-        buckets[key] = apply_arms(bucket, arms)
+        buckets[key] = apply_arms(bucket, effective_arms)
     # The change records captured the pre-arms bucket, so refresh the ones that are still live —
     # otherwise the digest and the PostHog event would report a cohort the document does not carry.
     for record in changes + holds:
@@ -488,7 +511,7 @@ def build_routing_policy(previous: Optional[Mapping], observations: Optional[Seq
         },
         "changes": changes,
         "holds": holds,
-        "cohort": arms_summary(arms),
+        "cohort": arms_summary(effective_arms),
         "recommendations": recommend_unmeasurable(spend_by_feature),
     }
 
@@ -648,27 +671,33 @@ def cohort_user_ids(observations: Optional[Sequence[Mapping]] = None) -> list:
     return ids
 
 
-def resolve_cohort(observations: Optional[Sequence[Mapping]] = None) -> dict:
-    """`{user_id: arm}` from the PostHog `cost-routing-arm` experiment, or `{}` when it has no answer.
+def resolve_cohort(observations: Optional[Sequence[Mapping]] = None) -> Optional[dict]:
+    """`{user_id: arm}` from the PostHog `cost-routing-arm` experiment.
 
-    `{}` is the fail-open path and it is not an error: every bucket then falls back to the hash
-    assignment that shipped before #652, which is the same split it has always used.
+    The two empty answers are NOT the same and callers must be able to tell them apart:
+
+    * `None` — we could not ASK (no experiment plane, no users to ask about, the lookup raised).
+      `build_routing_policy` then carries the previous document's cohort forward, so a PostHog
+      outage moves nobody: reverting a live cohort to the hash for a week would flip arms
+      mid-experiment and contaminate both sides of the very comparison this feeds.
+    * `{}` — we asked and PostHog enrolled nobody (flag deleted, or ramped to 0). The map is
+      cleared and every bucket falls back to the hash split that shipped before #652.
 
     The availability check comes FIRST so a project with no experiment plane doesn't pay for the
     active-user scan it could never use an answer from."""
     from cqc_lem.utilities.experiments import COST_ROUTING_ARM, assignments, enrollment_available
 
     if not enrollment_available():
-        return {}
+        return None
     user_ids = cohort_user_ids(observations)
     if not user_ids:
-        return {}
+        return None
     try:
         return assignments(user_ids, COST_ROUTING_ARM)
     except Exception as e:
-        log_warning("PostHog routing-experiment assignment failed — using hash cohorting", exc=e,
-                    task_name="auto_weekly_cost_routing")
-        return {}
+        log_warning("PostHog routing-experiment assignment failed — carrying the previous cohort",
+                    exc=e, task_name="auto_weekly_cost_routing")
+        return None
 
 
 def collect_routing_report(days: int = COST_ROUTING_WINDOW_DAYS, today: Optional[date] = None,
@@ -685,7 +714,9 @@ def collect_routing_report(days: int = COST_ROUTING_WINDOW_DAYS, today: Optional
 
     The PostHog cohort is resolved on the same condition: with routing off there is nothing to enrol
     anyone INTO, and an exposure event for an experiment that isn't running would put control-arm
-    traffic in a readout that never had a treatment arm."""
+    traffic in a readout that never had a treatment arm. It is not CLEARED while off either (the
+    cohort is carried forward, same as an outage) — "resumes exactly where the loop left off" has to
+    include who was in which arm, or a flag flip would reshuffle the cohort on the way back on."""
     from cqc_lem.utilities.db import cost_ledger_available, get_cost_rollup
 
     enabled = routing_enabled() if enabled is None else bool(enabled)
@@ -693,7 +724,7 @@ def collect_routing_report(days: int = COST_ROUTING_WINDOW_DAYS, today: Optional
     observations = collect_quality_observations(days, end=today) if enabled else []
     spend = (get_cost_rollup(today - timedelta(days=max(int(days), 1)), today, group_by="feature")
              if enabled and cost_ledger_available() else {})
-    arms = resolve_cohort(observations) if enabled else {}
+    arms = resolve_cohort(observations) if enabled else None
     result = build_routing_policy(load_policy(), observations, today, spend, thresholds, enabled,
                                   arms=arms)
     return {

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -5560,6 +5560,25 @@ def record_shipped_variant(user_id: int, post_id: int, variant_key: str,
         connection.close()
 
 
+def get_shipped_variant_keys(user_id: int) -> dict:
+    """``{post_id: variant_key}`` for every A/B variant this user has SHIPPED (issue #396).
+
+    Read once per stats sweep so each `post_outcome` event can carry the variant it belongs to
+    (issue #652) — the per-post alternative would be one query per post inside the Selenium loop.
+    An empty dict on any DB error: a missing experiment label must never cost us the outcome."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT post_id, variant_key FROM post_variants WHERE user_id=%s", (user_id,))
+        return {r[0]: r[1] for r in (cursor.fetchall() or []) if r[1]}
+    except mysql.connector.Error as err:
+        myprint(f"Could not get shipped variant keys for user {user_id} | Error: {err}")
+        return {}
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_variant_outcome_rows(user_id: int) -> list:
     """Realized outcomes for shipped A/B variants (issue #396 / D2). Joins each recorded shipped
     variant (`post_variants`) with its post's LATEST captured `post_stats` row → dicts of

--- a/src/cqc_lem/utilities/experiments.py
+++ b/src/cqc_lem/utilities/experiments.py
@@ -1,0 +1,391 @@
+"""ONE experiment surface — PostHog Experiments (issue #652, docs/experiments.md).
+
+LEM hand-rolled experimentation twice. The cost/quality loop (`cost_routing.py`) grew its own
+cohort hashing, its own non-inferiority test and its own weekly readout; the #396 media A/B harness
+grew its own shipped-variant table and its own winner ranking. Both work, and neither can answer
+"is this difference real" with anything a statistician would sign — and nothing rendered anywhere a
+human looks. PostHog Experiments already has the multivariate flag, the exposure model, both stats
+engines and the readout, so this module is the ADAPTER, not a third implementation:
+
+* **Assignment** — `resolve_variant()` reads a PostHog MULTIVARIATE flag by local evaluation, so a
+  cohort is reproducible from the flag instead of from a hash nobody can inspect.
+* **Exposure** — `$feature_flag_called` (what PostHog's experiment engine reads to decide which
+  variant a person was in), emitted ONCE per (experiment, person, variant) per process. flags.py
+  deliberately suppresses these for hot boolean toggles; an experiment without exposures has no
+  readout at all, so here they are emitted deliberately and deduped instead.
+* **Outcomes** — the metric events already exist (`post_outcome`, `comment_outcome`,
+  `$ai_generation`). PostHog attributes them to a variant BY PERSON via the exposure, so no new
+  event is needed; `experiment_properties()` additionally stamps `$feature/<key>` where the caller
+  already has the user in hand, which is what makes a property-based readout possible too.
+
+**An unresolvable experiment is the CONTROL arm.** No PostHog key, definitions not loaded, flag not
+defined, evaluation inconclusive, `EXPERIMENTS_ENABLED=false`, SDK raises — every one of those paths
+returns the spec's control variant, which is by construction the behaviour that shipped before the
+experiment existed. That is why there are no env-var fallbacks here (flags.py's contract): a toggle
+has a configured default worth honouring, an experiment arm does not.
+
+`_raw_variant()` keeps "PostHog said control" and "PostHog said nothing" apart, because
+`experiment_properties()` must NOT stamp `$feature/x=control` on a metric event when nobody was
+enrolled — a fabricated control arm is worse than a missing one, it makes the readout look
+populated.
+
+The local-evaluation bootstrap (personal key, background poller, retry cooldown) lives in flags.py —
+this module reuses it (lazily, see `_flag_surface`) rather than starting a second poller in the same
+worker. That constrains every registered flag the same way flags.py's registry is constrained: local
+evaluation cannot decide a release condition needing server-held person properties, so experiment
+flags must use rollout percentage / distinct-ID conditions only, or every worker silently reads
+control.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+import threading
+from dataclasses import dataclass
+from typing import Dict, Iterable, Mapping, Optional, Sequence
+
+import posthog
+
+from cqc_lem.utilities.logger import log_debug, log_warning
+from cqc_lem.utilities.routing_policy import ARM_CONTROL, ARM_TREATMENT, SYSTEM_USER_ID
+
+# Every experiment's control arm is named the same thing the routing policy already calls it, so the
+# arm vocabulary is ONE word across the flag, the policy document and the analysis.
+CONTROL = ARM_CONTROL
+
+# How PostHog decided the arm.
+ASSIGNMENT_FLAG = "flag"
+# The artifact itself decided it (the #396 media harness: whichever combo actually shipped). There is
+# no flag to read — the adapter's job is to report the arm that already happened.
+ASSIGNMENT_SHIPPED = "shipped"
+
+
+@dataclass(frozen=True)
+class ExperimentSpec:
+    """One experiment. `key` is the PostHog feature-flag key AND the experiment key AND this
+    registry's name — one identifier, so a rename can't leave the code, the flag and the experiment
+    readout disagreeing. `variants[0]` is the control by definition."""
+    key: str
+    variants: tuple
+    owner: str
+    metric_events: tuple
+    description: str
+    assignment: str = ASSIGNMENT_FLAG
+    # Share of enrolled traffic the flag should start the treatment on. Provisioned by
+    # scripts/posthog_experiments.py; PostHog owns it from then on.
+    rollout_pct: float = 0.5
+
+    @property
+    def control(self) -> str:
+        return self.variants[0]
+
+
+# --- The registry ------------------------------------------------------------------------------
+# Constants, not bare strings, at every call site: a typo'd key raises here instead of silently
+# resolving to the control arm somewhere in a Celery task.
+COST_ROUTING_ARM = "cost-routing-arm"
+COMMENT_CONTRACT_PROMPT = "comment-contract-prompt"
+POST_MEDIA_VARIANT = "post-media-variant"
+
+# The pilot prompt variant (G2). Named for what it changes, not "variant-b", so the readout says
+# which prompt won.
+COMMENT_CONTRACT_AUTHOR_QUESTION = "author-question"
+
+EXPERIMENTS: Dict[str, ExperimentSpec] = {
+    spec.key: spec for spec in (
+        ExperimentSpec(
+            key=COST_ROUTING_ARM,
+            variants=(ARM_CONTROL, ARM_TREATMENT),
+            owner="cost",
+            metric_events=("post_outcome", "$ai_generation"),
+            description=("Cost-aware down-routing cohort (docs/cost-performance-margin-plan.md "
+                         "§D.1.1). Treatment runs one model tier cheaper. Success = engagement rate "
+                         "holding (post_outcome) while $ai_generation cost falls. The arm is "
+                         "resolved app-side and handed to the LiteLLM router INSIDE the policy "
+                         "document — routing_policy.py must stay stdlib-only, so it can never "
+                         "import this module."),
+            # Matches COST_ROUTING_INITIAL_COHORT's 10% default: the ramp starts small because the
+            # treatment arm is spending real quality, not just money.
+            rollout_pct=0.1,
+        ),
+        ExperimentSpec(
+            key=COMMENT_CONTRACT_PROMPT,
+            variants=(CONTROL, COMMENT_CONTRACT_AUTHOR_QUESTION),
+            owner="content",
+            metric_events=("comment_outcome",),
+            description=("Pilot LLM prompt experiment (G2): the feed-comment quality contract's "
+                         "closing ask. Control offers four value-adds and any open question; "
+                         "treatment REQUIRES a question only the post's author could answer. "
+                         "Metric = author-reply rate (D4) from the #628 T+24h outcome sweep. At "
+                         "current single-user volume this is underpowered by design — see the "
+                         "small-sample caveat in docs/experiments.md."),
+        ),
+        ExperimentSpec(
+            key=POST_MEDIA_VARIANT,
+            # Data-defined: the arms are whichever media combos actually shipped, so the variant list
+            # is derived from generate_variants.DEFAULT_COMBOS at provisioning time rather than
+            # frozen here.
+            variants=(CONTROL,),
+            owner="content",
+            metric_events=("post_outcome",),
+            description=("Adapter for the #396 media A/B harness: the combo a post SHIPPED becomes "
+                         "its exposure, so post_outcome engagement can be read per variant in "
+                         "PostHog beside post_stats.select_variant_winners' own ranking."),
+            assignment=ASSIGNMENT_SHIPPED,
+        ),
+    )
+}
+
+# PostHog variant keys are slugs. A shipped media combo key is not ("…/flux-dev|gen4_turbo|1:1"), so
+# it is slugified — with a stable digest suffix when the slug had to be truncated, so two long combos
+# can never collapse into one arm.
+_SLUG_MAX = 60
+_SLUG_STRIP = re.compile(r"[^a-z0-9]+")
+
+# Exposure dedup. One entry per (experiment, distinct_id, variant) actually emitted. Bounded so a
+# multi-user worker can't grow it without limit; on overflow it is cleared, which re-emits at worst
+# one duplicate exposure per person (PostHog's readout counts a person once regardless).
+_EXPOSURE_CACHE_MAX = 5000
+_exposed: set = set()
+_exposure_lock = threading.Lock()
+
+# Latched lazy import of the flag surface — see `_flag_surface`.
+_flags_module = None
+_flags_unavailable = False
+
+_OFF_VALUES = ("0", "false", "no", "off", "disabled")
+
+
+def spec(key: str) -> ExperimentSpec:
+    found = EXPERIMENTS.get(key)
+    if found is None:
+        raise KeyError(f"Unregistered experiment '{key}' — add an ExperimentSpec to "
+                       "utilities/experiments.py")
+    return found
+
+
+def enabled() -> bool:
+    """The one kill switch. Off means every experiment reads as its control arm and no exposure is
+    emitted — the pre-experiment behaviour, everywhere, immediately."""
+    raw = (os.environ.get("EXPERIMENTS_ENABLED") or "").strip().lower()
+    return raw not in _OFF_VALUES if raw else True
+
+
+def distinct_id(user_id: Optional[int] = None) -> str:
+    """Same convention as observability.py and flags.py, so an exposure lands on the SAME PostHog
+    person the metric events do — which is the whole mechanism by which PostHog attributes an
+    outcome to an arm. The "system" sentinel is taken from routing_policy, the one stdlib-only copy
+    every side of the cost experiment already shares."""
+    return str(user_id) if user_id is not None else SYSTEM_USER_ID
+
+
+def variant_slug(value: Optional[str]) -> str:
+    """A PostHog-safe variant key for an arm whose name comes from data (a shipped media combo)."""
+    slug = _SLUG_STRIP.sub("-", str(value or "").strip().lower()).strip("-")
+    if not slug:
+        return CONTROL
+    if len(slug) <= _SLUG_MAX:
+        return slug
+    digest = hashlib.sha256(slug.encode("utf-8")).hexdigest()[:6]
+    return f"{slug[:_SLUG_MAX - 7].rstrip('-')}-{digest}"
+
+
+def _flag_surface():
+    """flags.py (#651), or None when it cannot be loaded.
+
+    Imported lazily and latched: this module holds no import-time dependency on the flag surface, and
+    a failure is reported ONCE rather than per feed comment — `_raw_variant` runs in hot loops, and a
+    warning per LLM call would be the noise that hides the next real one."""
+    global _flags_module, _flags_unavailable
+    if _flags_module is None and not _flags_unavailable:
+        try:
+            from cqc_lem.utilities import flags
+            _flags_module = flags
+        except Exception as exc:
+            _flags_unavailable = True
+            log_warning("Feature-flag surface unavailable — every experiment reads its control arm",
+                        exc=exc, api_provider="posthog")
+    return _flags_module
+
+
+def _local_evaluation_ready() -> bool:
+    """Whether a PostHog lookup is worth attempting.
+
+    flags.py owns the ONE local-evaluation bootstrap — personal API key, the SDK's background
+    definition poller and the failed-load cooldown. Experiments reuse it instead of starting a second
+    poller in the same process, so a flag flip and an experiment ramp become visible to a worker on
+    the same tick. Every not-ready path is the control arm."""
+    flags = _flag_surface()
+    if flags is None:
+        return False
+    try:
+        return flags.local_evaluation_available() and flags._ensure_loaded()
+    except Exception:
+        # flags._ensure_loaded() already swallows and logs its own load failures; anything reaching
+        # here is unexpected, and the answer is still "use the control arm".
+        return False
+
+
+def enrollment_available() -> bool:
+    """Whether PostHog can enrol anyone at all right now.
+
+    For callers that would have to do REAL WORK to produce a cohort — `cost_routing` lists every
+    active user before it can ask for their arms — so an experiment plane that is off costs a DB scan
+    it can never use. A per-call resolution doesn't need this: `_raw_variant` checks the same thing."""
+    return enabled() and _local_evaluation_ready()
+
+
+def _raw_variant(key: str, user_id: Optional[int] = None) -> Optional[str]:
+    """PostHog's answer for this experiment, or None when it has no usable one.
+
+    None is not the control arm: it means nobody was enrolled, which callers must be able to tell
+    apart (see `experiment_properties`). A value PostHog returns that is not one of the spec's
+    variants is also None — a flag reconfigured behind the code's back must not silently become an
+    arm the code has no branch for."""
+    experiment = spec(key)
+    if experiment.assignment != ASSIGNMENT_FLAG or not enabled():
+        return None
+    if not _local_evaluation_ready():
+        return None
+    try:
+        value = posthog.get_feature_flag(
+            key,
+            distinct_id(user_id),
+            # No network request, ever — this is checked per feed comment and per LLM call.
+            only_evaluate_locally=True,
+            # Exposure is emitted explicitly (and deduped) by `resolve_variant`, so the SDK's own
+            # per-call event would only duplicate it.
+            send_feature_flag_events=False,
+        )
+    except Exception as exc:
+        log_warning(f"Experiment '{key}' lookup failed — using the control arm", exc=exc,
+                    user_id=user_id, api_provider="posthog")
+        return None
+    if value is None or isinstance(value, bool):
+        # A boolean answer means the flag exists but is not multivariate — it carries no arm.
+        return None
+    text = str(value).strip()
+    if text not in experiment.variants:
+        log_warning(f"Experiment '{key}' returned unknown variant '{text}' — using the control arm",
+                    user_id=user_id, api_provider="posthog")
+        return None
+    return text
+
+
+def resolve_variant(key: str, user_id: Optional[int] = None, track: bool = True) -> str:
+    """The arm this user is in — always one of the spec's variants, control when PostHog has no
+    answer. Emits the exposure PostHog's readout is built on (once per person per variant per
+    process) unless `track=False`, which is for callers that only need to know the arm to LABEL
+    something that already happened."""
+    variant = _raw_variant(key, user_id)
+    if variant is None:
+        return spec(key).control
+    if track:
+        track_exposure(key, variant, user_id)
+    return variant
+
+
+def is_treatment(key: str, user_id: Optional[int] = None, track: bool = True) -> bool:
+    """Convenience for the two-arm experiments (`control`/`treatment`)."""
+    return resolve_variant(key, user_id, track=track) == ARM_TREATMENT
+
+
+def assignments(user_ids: Optional[Iterable], key: str) -> dict:
+    """`{user_id: variant}` for the users PostHog HAS an answer for — users it has no opinion on are
+    absent rather than defaulted, so a caller (the routing policy) can fall back to its own
+    assignment for them instead of quietly parking everyone in control.
+
+    Exposure is emitted for each enrolled user: this is the enrolment moment for a cohort that is
+    decided in bulk once a week rather than per request."""
+    resolved = {}
+    for user_id in user_ids or []:
+        if user_id is None:
+            continue
+        variant = _raw_variant(key, user_id)
+        if variant is None:
+            continue
+        resolved[user_id] = variant
+        track_exposure(key, variant, user_id)
+    return resolved
+
+
+def experiment_properties(user_id: Optional[int] = None,
+                          keys: Optional[Sequence[str]] = None,
+                          extra: Optional[Mapping[str, str]] = None) -> dict:
+    """`{"$feature/<key>": <variant>}` for a metric event.
+
+    PostHog attributes an outcome to an arm BY PERSON via the exposure event, so this is additive —
+    it makes a property-based readout (and a HogQL breakdown) possible without a join. Only
+    experiments PostHog actually enrolled this person in appear: stamping `control` on an event from
+    an unenrolled person would inflate the control arm with traffic that was never in the test.
+
+    `extra` carries arms the caller already knows (a shipped media variant), which have no flag to
+    read — those are slugified here so the caller never has to know PostHog's variant-key rules."""
+    props = {}
+    for key in keys or ():
+        variant = _raw_variant(key, user_id)
+        if variant is not None:
+            props[f"$feature/{key}"] = variant
+    for key, variant in (extra or {}).items():
+        if variant:
+            props[f"$feature/{key}"] = variant_slug(variant)
+    return props
+
+
+def track_exposure(key: str, variant: str, user_id: Optional[int] = None, **extra) -> bool:
+    """Emit ONE `$feature_flag_called` exposure, deduped per (experiment, person, variant).
+
+    Returns True when this call emitted it. Never raises: an experiment that cannot be measured must
+    still not break the code path it is measuring."""
+    identity = distinct_id(user_id)
+    token = (key, identity, str(variant))
+    with _exposure_lock:
+        if token in _exposed:
+            return False
+        if len(_exposed) >= _EXPOSURE_CACHE_MAX:
+            _exposed.clear()
+        _exposed.add(token)
+    try:
+        from cqc_lem.utilities.observability import track_experiment_exposure
+        track_experiment_exposure(key, variant, user_id=user_id, **extra)
+        log_debug(f"Experiment '{key}' exposure: {identity} → {variant}", user_id=user_id,
+                  api_provider="posthog")
+        return True
+    except Exception as exc:
+        log_warning(f"Experiment '{key}' exposure capture failed", exc=exc, user_id=user_id,
+                    api_provider="posthog")
+        return False
+
+
+def track_shipped_variant(key: str, shipped_key: Optional[str], user_id: Optional[int] = None,
+                          **extra) -> Optional[str]:
+    """Exposure for an `ASSIGNMENT_SHIPPED` experiment — the #396 harness adapter. The arm is
+    whatever combo shipped, so it is slugified into a PostHog variant key and reported as-is.
+    Returns the variant key, or None when there was nothing to report."""
+    if spec(key).assignment != ASSIGNMENT_SHIPPED or not enabled():
+        return None
+    if not shipped_key:
+        return None
+    variant = variant_slug(shipped_key)
+    track_exposure(key, variant, user_id, shipped_key=str(shipped_key), **extra)
+    return variant
+
+
+def registry_rows() -> list:
+    """The registry as plain dicts — for docs, the provisioning script and the registry test."""
+    return [{"key": s.key, "variants": list(s.variants), "control": s.control, "owner": s.owner,
+             "assignment": s.assignment, "rollout_pct": s.rollout_pct,
+             "metric_events": list(s.metric_events), "description": s.description}
+            for s in EXPERIMENTS.values()]
+
+
+def reset_exposure_cache() -> None:
+    """Drop the exposure dedup set AND the latched flag-surface import. For tests, and for a
+    long-lived process that legitimately wants to re-emit enrolment (a re-provisioned experiment)."""
+    global _flags_module, _flags_unavailable
+    with _exposure_lock:
+        _exposed.clear()
+    _flags_module = None
+    _flags_unavailable = False

--- a/src/cqc_lem/utilities/experiments.py
+++ b/src/cqc_lem/utilities/experiments.py
@@ -322,7 +322,11 @@ def experiment_properties(user_id: Optional[int] = None,
     an unenrolled person would inflate the control arm with traffic that was never in the test.
 
     `extra` carries arms the caller already knows (a shipped media variant), which have no flag to
-    read — those are slugified here so the caller never has to know PostHog's variant-key rules."""
+    read — those are slugified here so the caller never has to know PostHog's variant-key rules. The
+    kill switch covers those too: `EXPERIMENTS_ENABLED=false` must mean NO event carries an arm, or
+    a switched-off experiment still renders a populated property breakdown."""
+    if not enabled():
+        return {}
     props = {}
     for key in keys or ():
         variant = _raw_variant(key, user_id)

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -13,6 +13,11 @@ from urllib.parse import urlparse
 
 import posthog
 
+from cqc_lem.utilities.experiments import (
+    COMMENT_CONTRACT_PROMPT,
+    COST_ROUTING_ARM,
+    POST_MEDIA_VARIANT,
+)
 from cqc_lem.utilities.logger import log_warning
 
 posthog.api_key = os.getenv("POSTHOG_API_KEY", "")
@@ -509,13 +514,22 @@ def track_post_outcome(
 ) -> None:
     """Emit a LinkedIn post-outcome event so content performance (impressions / engagement rate) is
     queryable in PostHog alongside LLM cost. `engagement` / `engagement_rate` are derived with the
-    same weighting `post_stats` uses; `engagement_rate` is None when impressions are unknown."""
+    same weighting `post_stats` uses; `engagement_rate` is None when impressions are unknown.
+
+    This is the success metric of the cost-routing experiment (issue #652), so the user's arm rides
+    along as `$feature/cost-routing-arm` when PostHog enrolled them — `variant_key` (the #396 media
+    combo this post shipped, when the caller knows it) becomes the media experiment's arm the same
+    way."""
     from cqc_lem.utilities.post_stats import engagement_score, engagement_rate
+    shipped = extra.pop("variant_key", None)
     posthog.capture(
         distinct_id=str(user_id or "system"),
         event="post_outcome",
         properties={
+            **experiment_props(user_id, keys=(COST_ROUTING_ARM,),
+                               shipped={POST_MEDIA_VARIANT: shipped} if shipped else None),
             "post_id": post_id,
+            "variant_key": shipped,
             "reactions": int(reactions or 0),
             "comments": int(comments or 0),
             "reposts": int(reposts or 0),
@@ -591,12 +605,18 @@ def track_comment_outcome(
     """Emit one comment-outcome reading (issue #628) so comment→reply rate and the 'Most relevant'
     demotion signal are queryable next to the post outcomes they were meant to drive.
     `visible_most_relevant` stays None when the read was ambiguous — a boolean there would read as
-    a confirmed verdict the DOM never gave us."""
+    a confirmed verdict the DOM never gave us.
+
+    `author_replied` is the metric of the pilot prompt experiment (issue #652), so the user's arm
+    rides along. It is resolved HERE, at read time, rather than stored with the comment: PostHog's
+    assignment is deterministic per person for the life of the flag, and a per-comment copy would
+    still be wrong if the flag were re-rolled — see the attribution caveat in docs/experiments.md."""
     outcome = dict(outcome or {})
     posthog.capture(
         distinct_id=str(user_id or "system"),
         event="comment_outcome",
         properties={
+            **experiment_props(user_id, keys=(COMMENT_CONTRACT_PROMPT,)),
             "user_id": user_id,
             "log_id": log_id,
             "status": outcome.get("status"),
@@ -799,10 +819,55 @@ def track_routing_policy(report: dict) -> None:
             "changes": [{"bucket": c.get("bucket"), "action": c.get("action"),
                          "reason": c.get("reason")} for c in report.get("changes") or []],
             "buckets": [{"bucket": key, "state": b.get("state"), "to_tier": b.get("to_tier"),
-                         "cohort_pct": b.get("cohort_pct")} for key, b in buckets.items()],
+                         "cohort_pct": b.get("cohort_pct"),
+                         "assignment": b.get("assignment")} for key, b in buckets.items()],
+            # Whether the PostHog experiment (issue #652) actually cohorted this run, or the hash
+            # fallback did — a treatment share of None means nobody was enrolled.
+            **{f"cohort_{key}": value for key, value in (report.get("cohort") or {}).items()},
             "recommendations": report.get("recommendations") or [],
         },
     )
+
+
+def track_experiment_exposure(experiment: str, variant: str, user_id: Optional[int] = None,
+                              **extra) -> None:
+    """Emit one PostHog experiment EXPOSURE (issue #652).
+
+    The event name and the two `$feature_flag*` properties are not ours to rename: they are what
+    PostHog's experiment engine reads to decide which variant a person was in, and every metric
+    (post_outcome, comment_outcome, $ai_generation) is attributed to an arm through them. `experiment`
+    is carried as a plain property too so a HogQL readout can group without knowing PostHog's
+    internals.
+
+    Deduping is the CALLER's job (`experiments.track_exposure`) — this stays a dumb emitter like every
+    other tracker here."""
+    posthog.capture(
+        distinct_id=str(user_id if user_id is not None else "system"),
+        event="$feature_flag_called",
+        properties={
+            "$feature_flag": experiment,
+            "$feature_flag_response": variant,
+            f"$feature/{experiment}": variant,
+            "experiment": experiment,
+            "variant": variant,
+            "user_id": user_id,
+            **extra,
+        },
+    )
+
+
+def experiment_props(user_id: Optional[int] = None, keys: Optional[tuple] = None,
+                     shipped: Optional[dict] = None) -> dict:
+    """`$feature/<key>` properties for a metric event, or `{}` when experiments can't be resolved.
+
+    Wrapped here (rather than imported at each tracker) so an experiment plane that is down, missing
+    or misconfigured can never stop an outcome event from being recorded — the outcome is the
+    valuable half; its experiment label is not."""
+    try:
+        from cqc_lem.utilities.experiments import experiment_properties
+        return experiment_properties(user_id, keys=keys, extra=shipped)
+    except Exception:
+        return {}
 
 
 def track_cost_alert(alert: dict, day: Optional[str] = None) -> None:

--- a/src/cqc_lem/utilities/routing_policy.py
+++ b/src/cqc_lem/utilities/routing_policy.py
@@ -25,10 +25,16 @@ The policy itself is a JSON document in Redis (`lem:routing:policy`), written we
           "feature": "content", "from_tier": "lem-complex", "to_tier": "lem-medium",
           "state": "experiment",             # experiment | adopted | rolled_back | hold
           "cohort_pct": 0.1,                 # share of users routed DOWN (the treatment arm)
+          "arms": {"7": "treatment"},        # PostHog experiment's answer, resolved app-side (#652)
           "generation": 2, "started_on": "2026-07-18", "cooldown_until": null
         }
       }
     }
+
+`arms` is how the PostHog experiment reaches this file without it importing anything: `cost_routing.py`
+resolves the multivariate flag for each active user once per weekly run and writes the answers into
+the document Redis already carries to the router. A user missing from the map falls back to the hash,
+so a PostHog outage changes nothing about who is routed where.
 """
 from __future__ import annotations
 
@@ -55,6 +61,16 @@ ROUTING_STATES = frozenset({STATE_EXPERIMENT, STATE_ADOPTED})
 
 ARM_TREATMENT = "treatment"
 ARM_CONTROL = "control"
+
+ARMS = (ARM_CONTROL, ARM_TREATMENT)
+
+# How a user's arm was decided. `flag` means a PostHog experiment flag decided it and the decision was
+# resolved APP-SIDE and handed to this module inside the policy document (issue #652) — this file is
+# mounted into the LiteLLM container and must stay stdlib-only, so it can never call PostHog itself.
+# `hash` is the original deterministic fallback, and it is what runs whenever the document carries no
+# answer for a user: a PostHog outage must not move traffic.
+ASSIGNMENT_FLAG = "flag"
+ASSIGNMENT_HASH = "hash"
 
 # Placeholder a request carries in `metadata.user_id` when no user owns the call. It exists because
 # LiteLLM's PostHog logger uses that field verbatim as the event's distinct_id (issue #647), and an
@@ -143,11 +159,41 @@ def normalize_policy(policy: Optional[Mapping]) -> dict:
     }
 
 
+def flag_arm(user_id: Optional[Any], bucket: Optional[Mapping]) -> Optional[str]:
+    """The arm a PostHog experiment flag pinned this user to, or None when the document has no usable
+    answer for them (issue #652).
+
+    The map is written into the bucket as `arms: {"<user_id>": "treatment"|"control"}` by
+    `cost_routing.py`, which resolves the multivariate flag app-side once per weekly run. Keys are
+    compared as STRINGS because the document is JSON — an int user id survives a round-trip through
+    Redis as `"7"`, and reading it back as 7 would silently lose every assignment.
+
+    A value that is not one of `ARMS` is None, not a guess: a hand-edited document must fall back to
+    the hash rather than route traffic on a typo."""
+    if not isinstance(bucket, Mapping) or user_id is None:
+        return None
+    arms = bucket.get("arms")
+    if not isinstance(arms, Mapping):
+        return None
+    key = str(user_id).strip()
+    if not key or key.lower() == SYSTEM_USER_ID:
+        return None
+    arm = arms.get(key)
+    return arm if arm in ARMS else None
+
+
 def assign_arm(user_id: Optional[Any], bucket: Optional[Mapping]) -> str:
-    """Which A/B arm a user falls in for this bucket. Deterministic on (bucket id, user), so a user
-    keeps the same arm for the whole experiment — a user flipping arms mid-week would contaminate
-    both sides of the comparison. The bucket id carries a generation counter, so re-running a
-    previously rolled-back experiment reshuffles the cohort instead of re-testing the same users.
+    """Which A/B arm a user falls in for this bucket.
+
+    A PostHog experiment flag decides it when the policy document carries that user's assignment
+    (`flag_arm` above, issue #652), so the cohort is reproducible from the flag and the same split the
+    router applied is the split the weekly analysis reads. Everything else falls back to the original
+    hash, which is what keeps a PostHog outage from moving traffic.
+
+    The hash is deterministic on (bucket id, user), so a user keeps the same arm for the whole
+    experiment — a user flipping arms mid-week would contaminate both sides of the comparison. The
+    bucket id carries a generation counter, so re-running a previously rolled-back experiment
+    reshuffles the cohort instead of re-testing the same users.
 
     Traffic with no user id (system/housekeeping calls) always lands in control: it cannot be
     attributed to a cohort, so it must not silently join the treatment. That includes the
@@ -167,6 +213,13 @@ def assign_arm(user_id: Optional[Any], bucket: Optional[Mapping]) -> str:
         return ARM_CONTROL
     if user_id is None or str(user_id).strip().lower() in ("", SYSTEM_USER_ID):
         return ARM_CONTROL
+    # The flag decides WHO, the optimizer's ramp decides WHETHER: a parked bucket (pct <= 0, checked
+    # above) can never be started by a flag, but inside a running one the flag's answer wins — including
+    # when it keeps a user in control at a cohort the ramp would have swept up, which is exactly the
+    # permanent holdout the §D.3 quality gate needs to stay measurable.
+    pinned = flag_arm(user_id, bucket)
+    if pinned is not None:
+        return pinned
     if pct >= 1:
         return ARM_TREATMENT
     salt = f"{bucket.get('id') or bucket_key(bucket.get('feature'), bucket.get('from_tier'))}|{user_id}"
@@ -178,13 +231,17 @@ def resolve_tier(base_tier: Optional[str], feature: Optional[str], user_id: Opti
                  policy: Optional[Mapping]) -> dict:
     """Apply the cost-aware policy to a tier the complexity rules already chose.
 
-    Returns `{"tier", "base_tier", "arm", "applied", "bucket"}`. Every failure mode — no policy, a
-    disabled policy, an unknown bucket, a bucket that isn't routing, a control-arm user, a target
-    that isn't strictly cheaper — resolves to the base tier untouched. Down-routing is the only
+    Returns `{"tier", "base_tier", "arm", "assignment", "applied", "bucket"}`. Every failure mode — no
+    policy, a disabled policy, an unknown bucket, a bucket that isn't routing, a control-arm user, a
+    target that isn't strictly cheaper — resolves to the base tier untouched. Down-routing is the only
     thing this can do; it can never route a call UP or to a non-tier model.
+
+    `assignment` names what decided the arm (`flag` / `hash`), so a down-route that came from a
+    PostHog experiment is distinguishable in the logs from one that came from the hash fallback — the
+    difference between "the experiment is running" and "PostHog was unreachable".
     """
     result = {"tier": base_tier, "base_tier": base_tier, "arm": ARM_CONTROL,
-              "applied": False, "bucket": None}
+              "assignment": ASSIGNMENT_HASH, "applied": False, "bucket": None}
     if base_tier not in TIER_ORDER:
         return result
     policy = normalize_policy(policy)
@@ -202,6 +259,8 @@ def resolve_tier(base_tier: Optional[str], feature: Optional[str], user_id: Opti
 
     result["bucket"] = key
     result["arm"] = assign_arm(user_id, bucket)
+    if flag_arm(user_id, bucket) is not None:
+        result["assignment"] = ASSIGNMENT_FLAG
     if result["arm"] == ARM_TREATMENT:
         result["tier"] = target
         result["applied"] = True

--- a/tests/integration/test_variant_ab_harness.py
+++ b/tests/integration/test_variant_ab_harness.py
@@ -66,6 +66,10 @@ class _FakeCursor:
                     continue
                 self._result.append((v["variant_key"], self.posts[v["post_id"]]["scheduled_time"],
                                      r["reactions"], r["comments"], r["reposts"], r["impressions"]))
+        elif s.startswith("SELECT post_id, variant_key FROM post_variants"):
+            user_id = params[0]
+            self._result = [(v["post_id"], v["variant_key"]) for v in self.variants.values()
+                            if v["user_id"] == user_id]
         else:  # pragma: no cover - defensive
             raise AssertionError(f"unexpected SQL: {s}")
 
@@ -136,6 +140,28 @@ class TestVariantABHarness:
         assert [r["key"] for r in result["ranking"]] == ["B", "A"]
         assert result["ranking"][0]["samples"] == 2
         assert result["ranking"][0]["metric"] == "engagement_rate"  # every row has impressions
+
+    def test_shipped_variant_lookup_feeds_the_posthog_experiment_label(self):
+        """Issue #652: the stats sweep reads {post_id: variant_key} ONCE and puts each post's arm on
+        its `post_outcome` event, so PostHog can compare variants beside select_variant_winners."""
+        from cqc_lem.utilities.db import get_shipped_variant_keys, record_shipped_variant
+        from cqc_lem.utilities.experiments import POST_MEDIA_VARIANT, experiment_properties
+
+        posts = {1: _post(datetime(2026, 7, 23, 9, 0)), 2: _post(datetime(2026, 7, 22, 9, 0))}
+        variants = {}
+
+        def _conn(*a, **k):
+            return _FakeConn(posts, [], variants)
+
+        with patch(f"{_DB}.get_db_connection", side_effect=_conn):
+            record_shipped_variant(1, 1, "flux-dev|gen4_turbo|1:1")
+            record_shipped_variant(1, 2, "flux-1.1-pro|gen4_turbo|1:1")
+            record_shipped_variant(2, 3, "other-user")  # never leaks across users
+            shipped = get_shipped_variant_keys(1)
+
+        assert shipped == {1: "flux-dev|gen4_turbo|1:1", 2: "flux-1.1-pro|gen4_turbo|1:1"}
+        props = experiment_properties(1, extra={POST_MEDIA_VARIANT: shipped[1]})
+        assert props == {f"$feature/{POST_MEDIA_VARIANT}": "flux-dev-gen4-turbo-1-1"}
 
     def test_re_recording_overwrites_shipped_variant(self):
         from cqc_lem.utilities.db import record_shipped_variant, get_variant_outcome_rows

--- a/tests/unit/app/test_generate_variants.py
+++ b/tests/unit/app/test_generate_variants.py
@@ -167,3 +167,25 @@ class TestRecordShippedVariant:
         assert ok is True
         rec.assert_called_once_with(1, 99, "m|gen4_turbo|1:1|seed=7", combo=combo,
                                     batch_id="b1", variant_index=2)
+
+    def test_reports_the_shipped_combo_as_a_posthog_exposure(self):
+        """The #396 harness adapter (issue #652): the combo that shipped IS the arm, so PostHog can
+        read post_outcome per variant beside select_variant_winners' own ranking."""
+        with patch("cqc_lem.app.generate_variants._db_record_shipped_variant", return_value=True), \
+             patch("cqc_lem.utilities.experiments.track_shipped_variant") as exposure:
+            from cqc_lem.app.generate_variants import record_shipped_variant
+            record_shipped_variant(1, 99, {"image_model": "m", "video_model": "gen4_turbo",
+                                           "ratio": "1:1"})
+        assert exposure.call_args.args == ("post-media-variant", "m|gen4_turbo|1:1")
+        assert exposure.call_args.kwargs == {"user_id": 1, "post_id": 99}
+
+    def test_a_failed_exposure_never_costs_the_variant_record(self):
+        with patch("cqc_lem.app.generate_variants._db_record_shipped_variant",
+                   return_value=True) as rec, \
+             patch("cqc_lem.utilities.experiments.track_shipped_variant",
+                   side_effect=RuntimeError("posthog down")), \
+             patch("cqc_lem.app.generate_variants.log_warning") as warn:
+            from cqc_lem.app.generate_variants import record_shipped_variant
+            assert record_shipped_variant(1, 99, {"image_model": "m"}) is True
+        rec.assert_called_once()
+        assert warn.called

--- a/tests/unit/app/test_generate_variants.py
+++ b/tests/unit/app/test_generate_variants.py
@@ -179,6 +179,15 @@ class TestRecordShippedVariant:
         assert exposure.call_args.args == ("post-media-variant", "m|gen4_turbo|1:1")
         assert exposure.call_args.kwargs == {"user_id": 1, "post_id": 99}
 
+    def test_a_failed_db_write_reports_no_exposure(self):
+        """post_outcome reads the arm back out of post_variants, so an exposure for a row that never
+        landed would be an enrolment the metric can never cover."""
+        with patch("cqc_lem.app.generate_variants._db_record_shipped_variant", return_value=False), \
+             patch("cqc_lem.utilities.experiments.track_shipped_variant") as exposure:
+            from cqc_lem.app.generate_variants import record_shipped_variant
+            assert record_shipped_variant(1, 99, {"image_model": "m"}) is False
+        exposure.assert_not_called()
+
     def test_a_failed_exposure_never_costs_the_variant_record(self):
         with patch("cqc_lem.app.generate_variants._db_record_shipped_variant",
                    return_value=True) as rec, \

--- a/tests/unit/app/test_sweep_fixes.py
+++ b/tests/unit/app/test_sweep_fixes.py
@@ -118,6 +118,7 @@ class TestScrapeRecordsImpressions:
              patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
              patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://x/urn"), \
              patch(f"{_RA}._post_social_counts", return_value=counts), \
+             patch(f"{_RA}.get_shipped_variant_keys", return_value={}), \
              patch(f"{_RA}.record_post_stats") as rec, patch(f"{_RA}.quit_gracefully"):
             from cqc_lem.app.run_automation import auto_scrape_post_stats
             auto_scrape_post_stats.run(user_id=1)
@@ -125,6 +126,27 @@ class TestScrapeRecordsImpressions:
         assert rec.call_args.kwargs.get("impressions") == 153
         assert rec.call_args.kwargs.get("reposts") == 7
         assert rec.call_args.kwargs.get("saves") == 4
+
+    def test_outcome_event_carries_the_variant_the_post_shipped(self):
+        """Issue #652: the shipped A/B variant is looked up ONCE per sweep, not per post inside the
+        Selenium loop, and rides onto each post's outcome event as its experiment arm."""
+        counts = {"reactions": 5, "comments": 2, "reposts": 0, "impressions": 100, "saves": 0}
+        with patch(f"{_RA}.time.sleep"), \
+             patch(f"{_RA}.get_recent_posted_post_ids", return_value=[9, 10]), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://x/urn"), \
+             patch(f"{_RA}._post_social_counts", return_value=counts), \
+             patch(f"{_RA}._post_analytics_counts", return_value={}), \
+             patch(f"{_RA}.get_shipped_variant_keys", return_value={9: "flux|gen4|1:1"}) as keys, \
+             patch(f"{_RA}.record_post_stats"), \
+             patch(f"{_RA}.track_post_outcome") as outcome, patch(f"{_RA}.quit_gracefully"):
+            from cqc_lem.app.run_automation import auto_scrape_post_stats
+            auto_scrape_post_stats.run(user_id=1)
+        keys.assert_called_once_with(1)
+        variants = {call.kwargs["post_id"]: call.kwargs["variant_key"]
+                    for call in outcome.call_args_list}
+        # A post with no recorded variant is None, never a made-up arm.
+        assert variants == {9: "flux|gen4|1:1", 10: None}
 
     def test_analytics_page_signals_merge_over_detail_page(self):
         detail = {"reactions": 5, "comments": 2, "reposts": 0, "impressions": 0, "saves": 0}
@@ -135,6 +157,7 @@ class TestScrapeRecordsImpressions:
              patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://x/urn"), \
              patch(f"{_RA}._post_social_counts", return_value=detail), \
              patch(f"{_RA}._post_analytics_counts", return_value=analytics), \
+             patch(f"{_RA}.get_shipped_variant_keys", return_value={}), \
              patch(f"{_RA}.record_post_stats") as rec, patch(f"{_RA}.quit_gracefully"):
             from cqc_lem.app.run_automation import auto_scrape_post_stats
             auto_scrape_post_stats.run(user_id=1)

--- a/tests/unit/test_complexity_router.py
+++ b/tests/unit/test_complexity_router.py
@@ -179,3 +179,48 @@ def test_redis_url_prefers_the_shared_override(router_module, monkeypatch):
 def test_flag_parsing(router_module, monkeypatch, value, expected):
     monkeypatch.setenv("COST_AWARE_ROUTING_ENABLED", value)
     assert router_module._cost_routing_enabled() is expected
+
+
+# ── the PostHog experiment reaches the router through the document (issue #652) ──
+
+async def test_the_flag_cohort_survives_the_container_boundary(router_module, monkeypatch):
+    """The end-to-end reproducibility criterion: a PostHog answer resolved app-side must come out the
+    other side of Redis's JSON and decide this hook's down-route.
+
+    routing_policy.py cannot call PostHog (it is mounted into a container with no LEM install), so the
+    `arms` map in the policy document IS the hand-off. Building the document with the real
+    `cost_routing` code and serializing it the way `publish_policy` does is what pins that both halves
+    still agree — including that a JSON round-trip turns the int user id into a string key."""
+    from datetime import date
+
+    from cqc_lem.utilities import cost_routing
+
+    monkeypatch.setenv("COST_AWARE_ROUTING_ENABLED", "true")
+    previous = {"version": 1, "enabled": True, "buckets": {"content:lem-complex": {
+        "id": "content:lem-complex#1", "feature": "content", "from_tier": "lem-complex",
+        "to_tier": "lem-medium", "state": "experiment", "cohort_pct": 0.1}}}
+    # PostHog put user 4 in the treatment and user 5 in control; the 10% hash would have spared both.
+    built = cost_routing.build_routing_policy(previous, [], date(2026, 8, 1), enabled=True,
+                                             arms={4: "treatment", 5: "control"})
+    document = json.loads(json.dumps(built["policy"]))
+
+    router = router_module.LEMComplexityRouter()
+    router._policy, router._policy_fetched_at = document, float("inf")
+    assert await _route(router, "lem-complex", metadata={"feature": "content", "user_id": 4}) \
+        == "lem-medium"
+    assert await _route(router, "lem-complex", metadata={"feature": "content", "user_id": 5}) \
+        == "lem-complex"
+    # A user the experiment never answered for still gets the pre-#652 hash cohorting.
+    unenrolled = routing_policy_arm(router_module, document, 99)
+    assert unenrolled == routing_policy_hash_arm(router_module, document, 99)
+
+
+def routing_policy_arm(router_module, document, user_id):
+    bucket = document["buckets"]["content:lem-complex"]
+    return router_module.routing_policy.assign_arm(user_id, bucket)
+
+
+def routing_policy_hash_arm(router_module, document, user_id):
+    """The same bucket with its flag answers stripped — i.e. the hash-only decision."""
+    bucket = {k: v for k, v in document["buckets"]["content:lem-complex"].items() if k != "arms"}
+    return router_module.routing_policy.assign_arm(user_id, bucket)

--- a/tests/unit/test_posthog_experiments.py
+++ b/tests/unit/test_posthog_experiments.py
@@ -1,0 +1,208 @@
+"""Unit tests for scripts/posthog_experiments.py (issue #652).
+
+The script is what turns the code's experiment registry into something PostHog can render a readout
+from, so the tests pin the two things a wrong payload breaks silently: the ARM LIST (an arm the code
+resolves but the flag doesn't define makes every worker fall back to control) and the RAMP (an
+`--apply` that reset a live experiment's rollout would re-cohort it mid-run).
+"""
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "posthog_experiments.py"
+
+
+@pytest.fixture(scope="module")
+def mod():
+    spec = importlib.util.spec_from_file_location("lem_posthog_experiments", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _spec(mod, key):
+    return mod.EXPERIMENTS[key]
+
+
+# ── arm lists ──
+
+def test_flag_assigned_arms_come_straight_from_the_registry(mod):
+    spec = _spec(mod, "comment-contract-prompt")
+    assert mod.variants_for(spec) == list(spec.variants)
+    assert mod.variants_for(spec)[0] == spec.control
+
+
+def test_shipped_arms_are_derived_from_the_live_combo_matrix(mod):
+    """The media experiment's arms are data, not registry text — derived from DEFAULT_COMBOS so they
+    cannot drift the first time a combo changes."""
+    spec = _spec(mod, "post-media-variant")
+    arms = mod.variants_for(spec)
+    assert arms[0] == spec.control
+    assert set(mod.media_combo_arms()) <= set(arms)
+    assert len(arms) == len(set(arms)), "duplicate combos must collapse to one arm"
+
+
+# ── rollout maths ──
+
+@pytest.mark.parametrize("key", ["cost-routing-arm", "comment-contract-prompt",
+                                 "post-media-variant"])
+def test_rollout_percentages_always_sum_to_exactly_100(mod, key):
+    """PostHog rejects a multivariate flag whose variants don't total 100."""
+    spec = _spec(mod, key)
+    rows = mod.rollout_percentages(spec, mod.variants_for(spec))
+    assert sum(row["rollout_percentage"] for row in rows) == 100
+    assert rows[0]["key"] == spec.control
+    assert all(isinstance(row["rollout_percentage"], int) for row in rows)
+
+
+def test_the_remainder_is_parked_in_control_not_distributed(mod):
+    spec = _spec(mod, "post-media-variant")
+    arms = mod.variants_for(spec)
+    rows = {row["key"]: row["rollout_percentage"] for row in mod.rollout_percentages(spec, arms)}
+    treatments = [key for key in rows if key != spec.control]
+    assert len({rows[key] for key in treatments}) == 1  # even split across treatments
+    assert rows[spec.control] == 100 - sum(rows[key] for key in treatments)
+
+
+def test_flag_payload_uses_a_property_free_release_condition(mod):
+    """Local evaluation cannot resolve a condition that needs server-held person properties, and one
+    it cannot resolve makes every Celery worker silently read the control arm."""
+    payload = mod.flag_payload(_spec(mod, "cost-routing-arm"))
+    groups = payload["filters"]["groups"]
+    assert groups == [{"properties": [], "rollout_percentage": 100}]
+    assert payload["key"] == "cost-routing-arm"
+    assert payload["active"] is True
+
+
+def test_experiment_payload_measures_the_events_lem_already_emits(mod):
+    spec = _spec(mod, "cost-routing-arm")
+    payload = mod.experiment_payload(spec, flag_id=11)
+    assert payload["feature_flag_key"] == spec.key
+    assert payload["feature_flag"] == 11
+    events = [metric["source"]["event"] for metric in payload["metrics"]]
+    assert events == list(spec.metric_events)
+
+
+# ── planning ──
+
+def test_plan_creates_the_flag_then_blocks_the_experiment_on_it(mod):
+    actions = mod.plan_actions(mod.build_specs(), {}, {})
+    kinds = [a["action"] for a in actions]
+    assert kinds.count("create_flag") == len(mod.EXPERIMENTS)
+    # PostHog needs the flag id, so promising both in one dry-run pass would be a lie.
+    assert kinds.count("blocked_experiment") == len(mod.EXPERIMENTS)
+    assert mod.pending(actions)
+
+
+def test_plan_is_clean_when_flags_and_experiments_already_match(mod):
+    flags = {spec.key: {"id": i, "active": True, "variants": mod.variants_for(spec)}
+             for i, spec in enumerate(mod.build_specs())}
+    experiments = {spec.key: {"id": 100 + i} for i, spec in enumerate(mod.build_specs())}
+    actions = mod.plan_actions(mod.build_specs(), flags, experiments)
+    assert {a["action"] for a in actions} == {"unchanged_flag", "unchanged_experiment"}
+    assert mod.pending(actions) == []
+
+
+def test_plan_repairs_a_flag_missing_an_arm_the_code_resolves(mod):
+    spec = _spec(mod, "comment-contract-prompt")
+    flags = {spec.key: {"id": 3, "active": True, "variants": [spec.control]}}
+    actions = mod.plan_actions([spec], flags, {spec.key: {"id": 9}})
+    repair = next(a for a in actions if a["action"] == "update_flag_variants")
+    assert repair["missing"] == ["author-question"]
+    assert repair["flag_id"] == 3
+
+
+def test_plan_reactivates_a_disabled_flag(mod):
+    spec = _spec(mod, "comment-contract-prompt")
+    flags = {spec.key: {"id": 3, "active": False, "variants": mod.variants_for(spec)}}
+    actions = mod.plan_actions([spec], flags, {spec.key: {"id": 9}})
+    assert [a["action"] for a in actions] == ["update_flag_variants", "unchanged_experiment"]
+
+
+def test_an_existing_rollout_is_never_planned_as_drift(mod):
+    """PostHog owns the ramp once the experiment runs — an --apply that reset a 50% ramp to the
+    spec's 10% start would silently re-cohort a live experiment."""
+    spec = _spec(mod, "cost-routing-arm")
+    flags = {spec.key: {"id": 3, "active": True, "variants": mod.variants_for(spec)}}
+    actions = mod.plan_actions([spec], flags, {spec.key: {"id": 9}})
+    assert [a["action"] for a in actions] == ["unchanged_flag", "unchanged_experiment"]
+
+
+def test_explicit_rollout_is_planned_and_re_splits_the_variants(mod):
+    spec = _spec(mod, "cost-routing-arm")
+    flags = {spec.key: {"id": 3, "active": True, "variants": mod.variants_for(spec)}}
+    actions = mod.plan_actions([spec], flags, {spec.key: {"id": 9}}, rollouts={spec.key: 0.5})
+    rollout = next(a for a in actions if a["action"] == "set_rollout")
+    variants = {v["key"]: v["rollout_percentage"]
+                for v in rollout["payload"]["filters"]["multivariate"]["variants"]}
+    assert variants == {"control": 50, "treatment": 50}
+    assert mod.pending(actions)
+
+
+def test_creates_the_experiment_when_the_flag_already_exists(mod):
+    spec = _spec(mod, "cost-routing-arm")
+    flags = {spec.key: {"id": 3, "active": True, "variants": mod.variants_for(spec)}}
+    actions = mod.plan_actions([spec], flags, {})
+    create = next(a for a in actions if a["action"] == "create_experiment")
+    assert create["payload"]["feature_flag"] == 3
+
+
+# ── CLI parsing ──
+
+def test_parse_rollout_accepts_a_percentage(mod):
+    assert mod.parse_rollout("cost-routing-arm=25") == {"cost-routing-arm": 0.25}
+
+
+@pytest.mark.parametrize("expression", ["nope=10", "cost-routing-arm=abc",
+                                        "cost-routing-arm=101", "cost-routing-arm=-1"])
+def test_parse_rollout_rejects_typos_instead_of_no_opping(mod, expression):
+    with pytest.raises(ValueError):
+        mod.parse_rollout(expression)
+
+
+# ── apply ──
+
+def test_dry_run_writes_nothing(mod):
+    client = MagicMock()
+    log = mod.apply_actions(client, mod.plan_actions(mod.build_specs(), {}, {}), dry_run=True)
+    assert log and all(line.startswith("[dry-run]") or line.startswith("skipped")
+                       for line in log)
+    client.create_flag.assert_not_called()
+    client.create_experiment.assert_not_called()
+    client.update_flag.assert_not_called()
+
+
+def test_apply_creates_the_flag_and_reuses_its_id_for_the_experiment(mod):
+    spec = _spec(mod, "cost-routing-arm")
+    client = MagicMock()
+    client.create_flag.return_value = 42
+    actions = [{"action": "create_flag", "flag": spec.key, "payload": mod.flag_payload(spec)},
+               {"action": "create_experiment", "experiment": spec.key,
+                "payload": mod.experiment_payload(spec)}]
+    mod.apply_actions(client, actions, dry_run=False)
+    client.create_flag.assert_called_once()
+    assert client.create_experiment.call_args.args[0]["feature_flag"] == 42
+
+
+def test_apply_skips_a_rollout_for_a_flag_that_does_not_exist_yet(mod):
+    spec = _spec(mod, "cost-routing-arm")
+    client = MagicMock()
+    log = mod.apply_actions(client, [{"action": "set_rollout", "flag": spec.key, "flag_id": None,
+                                      "rollout_pct": 0.5,
+                                      "payload": mod.rollout_payload(spec, 0.5)}], dry_run=False)
+    client.update_flag.assert_not_called()
+    assert "does not exist yet" in log[0]
+
+
+def test_summarize_counts_every_action_kind(mod):
+    summary = mod.summarize(mod.plan_actions(mod.build_specs(), {}, {}))
+    assert "create_flag=" in summary and "blocked_experiment=" in summary
+
+
+def test_experiment_url_points_at_the_project(mod):
+    assert mod.experiment_url("https://us.posthog.com/", "475262", 7) == \
+        "https://us.posthog.com/project/475262/experiments/7"

--- a/tests/unit/utilities/ai/test_comment_contract.py
+++ b/tests/unit/utilities/ai/test_comment_contract.py
@@ -395,3 +395,54 @@ class TestRecentCommentHistoryQuery:
         sql, params = cursor.execute.call_args.args
         assert "FROM logs" in sql and "ORDER BY id DESC" in sql
         assert params == (7, LogActionType.COMMENT.value, LogResultType.SUCCESS.value, 25)
+
+
+class TestPromptExperiment:
+    """The pilot LLM prompt experiment (issue #652): the contract's closing ask is the variable, and
+    the six graded rules are deliberately NOT — an arm that loosened one would change what "passes
+    the gate" means and the two arms would stop being comparable."""
+
+    _RULE = "END ON A QUESTION ONLY THIS AUTHOR COULD ANSWER"
+
+    def test_treatment_adds_the_author_question_rule(self):
+        text = fw.comment_contract_directive(fw.COMMENT_CONTRACT_AUTHOR_QUESTION_VARIANT)
+        assert self._RULE in text
+        # The graded rules are untouched, so both arms face the same deterministic gate.
+        for rule in ("REFERENCE A SPECIFIC CLAIM", "WRITE FOR THE POST'S READERS",
+                     "NEVER open with validation filler"):
+            assert rule in text and rule in fw.comment_contract_directive()
+
+    @pytest.mark.parametrize("variant", [None, "", "control", "some-unknown-arm"])
+    def test_every_other_arm_is_the_control_contract(self, variant):
+        assert fw.comment_contract_directive(variant) == fw.comment_contract_directive()
+
+    def test_the_users_arm_reaches_the_feed_comment_prompt(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp(_GOOD)) as m, \
+             patch("cqc_lem.utilities.experiments.resolve_variant",
+                   return_value=fw.COMMENT_CONTRACT_AUTHOR_QUESTION_VARIANT) as resolve:
+            ai_helper.generate_ai_response(_POST, _profile(), user_id=7)
+        assert self._RULE in m.call_args.kwargs["messages"][0]["content"]
+        assert resolve.call_args.args[1] == 7
+
+    def test_a_broken_experiment_plane_still_writes_the_control_contract(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp(_GOOD)) as m, \
+             patch("cqc_lem.utilities.experiments.resolve_variant",
+                   side_effect=RuntimeError("posthog down")), \
+             patch(f"{_AI}.log_warning") as warn:
+            out = ai_helper.generate_ai_response(_POST, _profile(), user_id=7)
+        assert out == _GOOD
+        assert "COMMENT QUALITY CONTRACT" in m.call_args.kwargs["messages"][0]["content"]
+        assert self._RULE not in m.call_args.kwargs["messages"][0]["content"]
+        assert warn.called
+
+    def test_replying_to_a_comment_is_not_part_of_the_experiment(self):
+        """A reply has its own acknowledge-and-answer contract, and the #628 sweep never measures it,
+        so enrolling it would only add exposures the metric can't cover."""
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=_resp("Sure — here is the number.")), \
+             patch("cqc_lem.utilities.experiments.resolve_variant") as resolve:
+            ai_helper.generate_ai_response(_POST, _profile(), post_comment="what number?",
+                                           user_id=7)
+        resolve.assert_not_called()

--- a/tests/unit/utilities/test_cost_routing.py
+++ b/tests/unit/utilities/test_cost_routing.py
@@ -438,6 +438,25 @@ def test_apply_arms_clears_a_stale_map_when_posthog_answered_for_nobody():
     assert cleared["assignment"] == rp.ASSIGNMENT_HASH
 
 
+def test_apply_arms_carries_the_cohort_forward_when_posthog_could_not_be_asked():
+    """`None` is "we could not ask", not "nobody is enrolled" — wiping the map would send a live
+    cohort back to the hash for a week, which is the mid-experiment arm flip assign_arm exists to
+    prevent."""
+    kept = cr.apply_arms(_bucket(arms={"7": rp.ARM_TREATMENT}), None)
+    assert kept["arms"] == {"7": rp.ARM_TREATMENT}
+    assert kept["assignment"] == rp.ASSIGNMENT_FLAG
+
+
+def test_carried_arms_unions_only_the_buckets_that_route():
+    buckets = {
+        "content:lem-complex": _bucket(state=rp.STATE_EXPERIMENT, arms={"7": rp.ARM_TREATMENT}),
+        "comment:lem-medium": _bucket(state=rp.STATE_ADOPTED, arms={"8": rp.ARM_CONTROL}),
+        "video:lem-complex": _bucket(state=rp.STATE_ROLLED_BACK, arms={"9": rp.ARM_TREATMENT}),
+    }
+    assert cr.carried_arms(buckets) == {"7": rp.ARM_TREATMENT, "8": rp.ARM_CONTROL}
+    assert cr.carried_arms(None) == {}
+
+
 def test_arms_summary_separates_nobody_enrolled_from_nobody_treated():
     assert cr.arms_summary({})["treatment_share"] is None
     assert cr.arms_summary({})["assignment"] == rp.ASSIGNMENT_HASH
@@ -477,6 +496,53 @@ def test_build_routing_policy_judges_the_window_on_the_arms_that_were_in_force()
         str(u): rp.ARM_CONTROL for u in range(5)}
 
 
+def test_a_posthog_outage_moves_nobody_between_arms():
+    """The whole point of the hash fallback: an unreachable PostHog must leave the cohort exactly
+    where it was, not re-split it under the hash for a week."""
+    enrolled = {str(u): rp.ARM_TREATMENT for u in range(5)}
+    previous = {"version": 1, "enabled": True,
+                "buckets": {"content:lem-complex": _bucket(cohort_pct=0.1,
+                                                           arms=dict(enrolled))}}
+    result = cr.build_routing_policy(previous, [], TODAY, enabled=True, arms=None)
+    bucket = result["policy"]["buckets"]["content:lem-complex"]
+    assert bucket["arms"] == enrolled
+    assert bucket["assignment"] == rp.ASSIGNMENT_FLAG
+    assert result["cohort"]["enrolled"] == 5
+    # ...and the users stay in the arm they were in, rather than being re-drawn by the 10% hash.
+    assert all(rp.assign_arm(int(u), bucket) == rp.ARM_TREATMENT for u in enrolled)
+
+
+def test_an_ended_experiment_does_clear_the_cohort():
+    """`{}` is a real answer — PostHog enrolled nobody, so the hash split takes over again."""
+    previous = {"version": 1, "enabled": True,
+                "buckets": {"content:lem-complex": _bucket(cohort_pct=0.1,
+                                                           arms={"7": rp.ARM_TREATMENT})}}
+    result = cr.build_routing_policy(previous, [], TODAY, enabled=True, arms={})
+    bucket = result["policy"]["buckets"]["content:lem-complex"]
+    assert "arms" not in bucket and bucket["assignment"] == rp.ASSIGNMENT_HASH
+    assert result["cohort"]["assignment"] == rp.ASSIGNMENT_HASH
+
+
+def test_resolve_cohort_reports_none_when_it_could_not_ask():
+    with patch("cqc_lem.utilities.experiments.enrollment_available", return_value=False):
+        assert cr.resolve_cohort(_rows(1, 10)) is None
+    with patch("cqc_lem.utilities.experiments.enrollment_available", return_value=True), \
+         patch.object(cr, "cohort_user_ids", return_value=[]):
+        assert cr.resolve_cohort() is None
+
+
+def test_collect_routing_report_does_not_wipe_the_cohort_while_routing_is_off():
+    previous = {"version": 1, "enabled": True,
+                "buckets": {"content:lem-complex": _bucket(cohort_pct=0.1,
+                                                           arms={"7": rp.ARM_TREATMENT})}}
+    with patch.object(cr, "collect_quality_observations", return_value=[]), \
+         patch.object(cr, "resolve_cohort") as resolve, \
+         patch.object(cr, "load_policy", return_value=previous):
+        report = cr.collect_routing_report(days=7, today=TODAY, enabled=False)
+    resolve.assert_not_called()
+    assert report["policy"]["buckets"]["content:lem-complex"]["arms"] == {"7": rp.ARM_TREATMENT}
+
+
 def test_cohort_user_ids_unions_active_users_with_the_observed_window():
     with patch("cqc_lem.utilities.db.get_active_user_ids", return_value=[1, 2]):
         ids = cr.cohort_user_ids([{"user_id": 2}, {"user_id": 9}, {"user_id": None}])
@@ -493,7 +559,7 @@ def test_cohort_user_ids_survives_an_unreadable_user_table():
 def test_resolve_cohort_never_scans_users_when_posthog_cannot_enrol():
     with patch("cqc_lem.utilities.experiments.enrollment_available", return_value=False), \
          patch.object(cr, "cohort_user_ids") as listed:
-        assert cr.resolve_cohort(_rows(1, 10)) == {}
+        assert cr.resolve_cohort(_rows(1, 10)) is None
     listed.assert_not_called()
 
 
@@ -502,7 +568,7 @@ def test_resolve_cohort_falls_back_to_hash_cohorting_on_failure():
          patch.object(cr, "cohort_user_ids", return_value=[1]), \
          patch("cqc_lem.utilities.experiments.assignments", side_effect=RuntimeError("boom")), \
          patch.object(cr, "log_warning") as warned:
-        assert cr.resolve_cohort() == {}
+        assert cr.resolve_cohort() is None
     warned.assert_called_once()
 
 

--- a/tests/unit/utilities/test_cost_routing.py
+++ b/tests/unit/utilities/test_cost_routing.py
@@ -399,3 +399,127 @@ def test_main_exits_2_on_a_rollback():
     report["changes"] = []
     with patch.object(cr, "collect_routing_report", return_value=report):
         assert cr.main([]) == 0
+
+
+# ── PostHog cohorting (issue #652) ──
+# The arm now comes from a PostHog experiment flag, resolved here (app-side) and written into the
+# policy document the LiteLLM router reads — routing_policy.py must stay stdlib-only.
+
+def test_normalize_arms_stringifies_ids_and_drops_unusable_values():
+    """The document is JSON in Redis, so `flag_arm` compares STRING keys — an int key written here
+    would survive the round-trip as a string and match nothing on the way back."""
+    assert cr.normalize_arms({7: rp.ARM_TREATMENT, "8": rp.ARM_CONTROL}) == {
+        "7": rp.ARM_TREATMENT, "8": rp.ARM_CONTROL}
+    assert cr.normalize_arms({7: "TREATMENT", 8: None, None: rp.ARM_TREATMENT,
+                              rp.SYSTEM_USER_ID: rp.ARM_TREATMENT, "": rp.ARM_CONTROL}) == {}
+    assert cr.normalize_arms(None) == {}
+
+
+def test_normalize_arms_caps_the_document_and_says_so():
+    arms = {i: rp.ARM_TREATMENT for i in range(cr.ARMS_MAX_USERS + 10)}
+    with patch.object(cr, "log_warning") as warned:
+        capped = cr.normalize_arms(arms)
+    assert len(capped) == cr.ARMS_MAX_USERS
+    warned.assert_called_once()  # a silent truncation would read as full coverage
+
+
+def test_apply_arms_only_stamps_buckets_that_actually_route():
+    routing = cr.apply_arms(_bucket(state=rp.STATE_EXPERIMENT), {7: rp.ARM_TREATMENT})
+    assert routing["arms"] == {"7": rp.ARM_TREATMENT}
+    assert routing["assignment"] == rp.ASSIGNMENT_FLAG
+    parked = cr.apply_arms(_bucket(state=rp.STATE_ROLLED_BACK, arms={"7": rp.ARM_TREATMENT}),
+                           {7: rp.ARM_TREATMENT})
+    assert "arms" not in parked and parked["assignment"] == rp.ASSIGNMENT_HASH
+
+
+def test_apply_arms_clears_a_stale_map_when_posthog_answered_for_nobody():
+    cleared = cr.apply_arms(_bucket(arms={"7": rp.ARM_TREATMENT}), {})
+    assert "arms" not in cleared
+    assert cleared["assignment"] == rp.ASSIGNMENT_HASH
+
+
+def test_arms_summary_separates_nobody_enrolled_from_nobody_treated():
+    assert cr.arms_summary({})["treatment_share"] is None
+    assert cr.arms_summary({})["assignment"] == rp.ASSIGNMENT_HASH
+    summary = cr.arms_summary({7: rp.ARM_CONTROL, 8: rp.ARM_CONTROL})
+    assert summary["assignment"] == rp.ASSIGNMENT_FLAG
+    assert summary["enrolled"] == 2 and summary["treatment_share"] == 0.0
+    assert cr.arms_summary({7: rp.ARM_TREATMENT, 8: rp.ARM_CONTROL})["treatment_share"] == 0.5
+
+
+def test_build_routing_policy_writes_the_cohort_into_every_live_bucket():
+    previous = {"version": 1, "enabled": True,
+                "buckets": {"content:lem-complex": _bucket(cohort_pct=0.1)}}
+    result = cr.build_routing_policy(previous, _rows(3, 10), TODAY, enabled=True,
+                                     arms={7: rp.ARM_TREATMENT})
+    bucket = result["policy"]["buckets"]["content:lem-complex"]
+    assert bucket["arms"] == {"7": rp.ARM_TREATMENT}
+    assert result["cohort"]["enrolled"] == 1
+    # The digest reads the change records, so they must carry the cohort the document carries.
+    records = result["changes"] + result["holds"]
+    assert all(r["bucket_state"].get("arms") == {"7": rp.ARM_TREATMENT} for r in records)
+
+
+def test_build_routing_policy_judges_the_window_on_the_arms_that_were_in_force():
+    """The observed posts were routed under the PREVIOUS document's arms. Applying the fresh cohort
+    before evaluating would grade a post in the arm it is about to be in."""
+    previous_arms = {str(u): rp.ARM_TREATMENT for u in range(5)}
+    previous = {"version": 1, "enabled": True,
+                "buckets": {"content:lem-complex": _bucket(cohort_pct=0.5,
+                                                           arms=dict(previous_arms))}}
+    # Every observed user was treatment last week; this week PostHog would put them all in control.
+    result = cr.build_routing_policy(previous, _rows(5, 10), TODAY, enabled=True,
+                                     arms={u: rp.ARM_CONTROL for u in range(5)})
+    comparison = (result["changes"] + result["holds"])[0]["comparison"]
+    assert comparison["treatment"]["n"] == 5
+    assert comparison["control"]["n"] == 0
+    assert result["policy"]["buckets"]["content:lem-complex"]["arms"] == {
+        str(u): rp.ARM_CONTROL for u in range(5)}
+
+
+def test_cohort_user_ids_unions_active_users_with_the_observed_window():
+    with patch("cqc_lem.utilities.db.get_active_user_ids", return_value=[1, 2]):
+        ids = cr.cohort_user_ids([{"user_id": 2}, {"user_id": 9}, {"user_id": None}])
+    assert ids == [1, 2, 9]
+
+
+def test_cohort_user_ids_survives_an_unreadable_user_table():
+    with patch("cqc_lem.utilities.db.get_active_user_ids", side_effect=RuntimeError("no db")), \
+         patch.object(cr, "log_warning") as warned:
+        assert cr.cohort_user_ids([{"user_id": 4}]) == [4]
+    warned.assert_called_once()
+
+
+def test_resolve_cohort_never_scans_users_when_posthog_cannot_enrol():
+    with patch("cqc_lem.utilities.experiments.enrollment_available", return_value=False), \
+         patch.object(cr, "cohort_user_ids") as listed:
+        assert cr.resolve_cohort(_rows(1, 10)) == {}
+    listed.assert_not_called()
+
+
+def test_resolve_cohort_falls_back_to_hash_cohorting_on_failure():
+    with patch("cqc_lem.utilities.experiments.enrollment_available", return_value=True), \
+         patch.object(cr, "cohort_user_ids", return_value=[1]), \
+         patch("cqc_lem.utilities.experiments.assignments", side_effect=RuntimeError("boom")), \
+         patch.object(cr, "log_warning") as warned:
+        assert cr.resolve_cohort() == {}
+    warned.assert_called_once()
+
+
+def test_collect_routing_report_resolves_no_cohort_while_routing_is_off():
+    with patch.object(cr, "collect_quality_observations", return_value=[]), \
+         patch.object(cr, "resolve_cohort") as resolve, \
+         patch.object(cr, "load_policy", return_value={}):
+        report = cr.collect_routing_report(days=7, today=TODAY, enabled=False)
+    resolve.assert_not_called()
+    assert report["cohort"]["assignment"] == rp.ASSIGNMENT_HASH
+
+
+def test_render_routing_text_reports_which_side_cohorted():
+    report = cr.build_routing_policy(
+        {"version": 1, "enabled": True,
+         "buckets": {"content:lem-complex": _bucket(cohort_pct=0.1)}},
+        [], TODAY, enabled=True, arms={7: rp.ARM_TREATMENT})
+    text = cr.render_routing_text({"date": "2026-08-01", **report})
+    assert "Cohorting: flag" in text and "1 user(s) enrolled" in text
+    assert "flag-assigned" in text

--- a/tests/unit/utilities/test_experiments.py
+++ b/tests/unit/utilities/test_experiments.py
@@ -1,0 +1,262 @@
+"""Unit tests for the PostHog experiment surface (issue #652).
+
+The load-bearing behaviours, in order of how badly a regression would hurt:
+
+1. Nothing resolvable → the CONTROL arm, always. That is the whole safety contract.
+2. "PostHog said control" and "PostHog said nothing" stay apart, so a metric event is never labelled
+   with an arm nobody was enrolled in.
+3. Exposure fires ONCE per person per arm — these run in feed loops.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cqc_lem.utilities import experiments as ex
+from cqc_lem.utilities import routing_policy as rp
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.experiments"
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    monkeypatch.delenv("EXPERIMENTS_ENABLED", raising=False)
+    ex.reset_exposure_cache()
+    yield
+    ex.reset_exposure_cache()
+
+
+@pytest.fixture
+def enrolled():
+    """PostHog is reachable and answers with whatever the test sets `.return_value` to."""
+    with patch(f"{_MOD}._local_evaluation_ready", return_value=True), \
+            patch(f"{_MOD}.posthog") as mock_ph, \
+            patch(f"{_MOD}.track_exposure") as mock_exposure:
+        yield mock_ph, mock_exposure
+
+
+# ── registry ──
+
+def test_registry_keys_match_their_specs_and_control_is_first():
+    for key, spec in ex.EXPERIMENTS.items():
+        assert spec.key == key
+        assert spec.variants, f"{key} has no arms"
+        assert spec.control == spec.variants[0]
+        assert spec.metric_events, f"{key} has no metric event"
+
+
+def test_registry_rows_expose_every_field_docs_and_provisioning_need():
+    rows = {row["key"]: row for row in ex.registry_rows()}
+    assert set(rows) == set(ex.EXPERIMENTS)
+    row = rows[ex.COST_ROUTING_ARM]
+    assert row["control"] == rp.ARM_CONTROL
+    assert rp.ARM_TREATMENT in row["variants"]
+    assert row["assignment"] == ex.ASSIGNMENT_FLAG
+    assert "$ai_generation" in row["metric_events"]
+
+
+def test_comment_variant_name_matches_the_content_core_literal():
+    """content_framework keeps its own copy so the shared content core never imports PostHog — if
+    these two drift, the treatment arm silently renders the control prompt."""
+    from cqc_lem.utilities.ai.content_framework import COMMENT_CONTRACT_AUTHOR_QUESTION_VARIANT
+    assert COMMENT_CONTRACT_AUTHOR_QUESTION_VARIANT == ex.COMMENT_CONTRACT_AUTHOR_QUESTION
+    assert ex.COMMENT_CONTRACT_AUTHOR_QUESTION in ex.spec(ex.COMMENT_CONTRACT_PROMPT).variants
+
+
+def test_unregistered_experiment_raises_instead_of_defaulting():
+    with pytest.raises(KeyError):
+        ex.spec("not-an-experiment")
+
+
+# ── fail-to-control ──
+
+def test_no_local_evaluation_means_the_control_arm_and_no_exposure():
+    with patch(f"{_MOD}._local_evaluation_ready", return_value=False), \
+            patch(f"{_MOD}.track_exposure") as mock_exposure:
+        assert ex.resolve_variant(ex.COMMENT_CONTRACT_PROMPT, 7) == ex.CONTROL
+        assert ex.experiment_properties(7, keys=(ex.COMMENT_CONTRACT_PROMPT,)) == {}
+    mock_exposure.assert_not_called()
+
+
+def test_kill_switch_forces_control_even_when_posthog_would_answer(monkeypatch, enrolled):
+    mock_ph, mock_exposure = enrolled
+    mock_ph.get_feature_flag.return_value = ex.COMMENT_CONTRACT_AUTHOR_QUESTION
+    monkeypatch.setenv("EXPERIMENTS_ENABLED", "false")
+    assert ex.resolve_variant(ex.COMMENT_CONTRACT_PROMPT, 7) == ex.CONTROL
+    mock_ph.get_feature_flag.assert_not_called()
+    mock_exposure.assert_not_called()
+
+
+def test_lookup_failure_is_the_control_arm(enrolled):
+    mock_ph, _ = enrolled
+    mock_ph.get_feature_flag.side_effect = RuntimeError("posthog down")
+    assert ex.resolve_variant(ex.COMMENT_CONTRACT_PROMPT, 7) == ex.CONTROL
+
+
+@pytest.mark.parametrize("value", [None, True, False, "", "some-other-arm"])
+def test_unusable_flag_values_are_the_control_arm(enrolled, value):
+    """A boolean means the flag isn't multivariate; an unknown string means it was reconfigured
+    behind the code's back. Neither may become an arm the code has no branch for."""
+    mock_ph, _ = enrolled
+    mock_ph.get_feature_flag.return_value = value
+    assert ex.resolve_variant(ex.COMMENT_CONTRACT_PROMPT, 7) == ex.CONTROL
+    assert ex.experiment_properties(7, keys=(ex.COMMENT_CONTRACT_PROMPT,)) == {}
+
+
+def test_missing_flag_surface_reports_once_and_reads_as_not_ready(monkeypatch):
+    """Both halves of the lazy import have to be removed: the parent package caches an imported
+    submodule as an attribute, so blanking only `sys.modules` still resolves the real module."""
+    import sys
+
+    import cqc_lem.utilities as pkg
+
+    monkeypatch.delattr(pkg, "flags", raising=False)
+    monkeypatch.setitem(sys.modules, "cqc_lem.utilities.flags", None)
+    with patch(f"{_MOD}.log_warning") as mock_warn:
+        ex.reset_exposure_cache()
+        assert ex._local_evaluation_ready() is False
+        assert ex._local_evaluation_ready() is False
+    assert mock_warn.call_count == 1
+
+
+def test_local_evaluation_requires_both_availability_and_a_loaded_definition_set(monkeypatch):
+    import cqc_lem.utilities as pkg
+
+    flags = MagicMock()
+    flags.local_evaluation_available.return_value = True
+    flags._ensure_loaded.return_value = False
+    monkeypatch.setattr(pkg, "flags", flags)
+    ex.reset_exposure_cache()
+    assert ex._local_evaluation_ready() is False
+    flags._ensure_loaded.return_value = True
+    assert ex._local_evaluation_ready() is True
+
+
+# ── assignment ──
+
+def test_resolved_variant_is_returned_and_exposed(enrolled):
+    mock_ph, mock_exposure = enrolled
+    mock_ph.get_feature_flag.return_value = ex.COMMENT_CONTRACT_AUTHOR_QUESTION
+    assert ex.resolve_variant(ex.COMMENT_CONTRACT_PROMPT, 7) == ex.COMMENT_CONTRACT_AUTHOR_QUESTION
+    mock_exposure.assert_called_once_with(ex.COMMENT_CONTRACT_PROMPT,
+                                         ex.COMMENT_CONTRACT_AUTHOR_QUESTION, 7)
+
+
+def test_local_evaluation_only_never_makes_a_network_call(enrolled):
+    mock_ph, _ = enrolled
+    mock_ph.get_feature_flag.return_value = rp.ARM_TREATMENT
+    ex.resolve_variant(ex.COST_ROUTING_ARM, 7)
+    kwargs = mock_ph.get_feature_flag.call_args.kwargs
+    assert kwargs["only_evaluate_locally"] is True
+    # The SDK's own event would duplicate the deduped exposure this module emits.
+    assert kwargs["send_feature_flag_events"] is False
+
+
+def test_track_false_resolves_without_enrolling(enrolled):
+    mock_ph, mock_exposure = enrolled
+    mock_ph.get_feature_flag.return_value = rp.ARM_TREATMENT
+    assert ex.is_treatment(ex.COST_ROUTING_ARM, 7, track=False) is True
+    mock_exposure.assert_not_called()
+
+
+def test_shipped_assignment_never_consults_a_flag(enrolled):
+    mock_ph, _ = enrolled
+    assert ex.resolve_variant(ex.POST_MEDIA_VARIANT, 7) == ex.CONTROL
+    mock_ph.get_feature_flag.assert_not_called()
+
+
+def test_assignments_omits_users_posthog_has_no_answer_for(enrolled):
+    mock_ph, mock_exposure = enrolled
+    mock_ph.get_feature_flag.side_effect = lambda key, distinct_id, **kw: (
+        rp.ARM_TREATMENT if distinct_id == "7" else None)
+    assert ex.assignments([7, 8, None], ex.COST_ROUTING_ARM) == {7: rp.ARM_TREATMENT}
+    mock_exposure.assert_called_once_with(ex.COST_ROUTING_ARM, rp.ARM_TREATMENT, 7)
+
+
+def test_distinct_id_matches_the_shared_system_sentinel():
+    assert ex.distinct_id(7) == "7"
+    assert ex.distinct_id() == rp.SYSTEM_USER_ID
+
+
+# ── metric labelling ──
+
+def test_experiment_properties_labels_only_enrolled_persons(enrolled):
+    mock_ph, _ = enrolled
+    mock_ph.get_feature_flag.return_value = rp.ARM_TREATMENT
+    props = ex.experiment_properties(7, keys=(ex.COST_ROUTING_ARM,))
+    assert props == {f"$feature/{ex.COST_ROUTING_ARM}": rp.ARM_TREATMENT}
+
+
+def test_experiment_properties_slugifies_a_shipped_arm(enrolled):
+    props = ex.experiment_properties(
+        7, extra={ex.POST_MEDIA_VARIANT: "black-forest-labs/flux-dev|gen4_turbo|1:1"})
+    assert props == {f"$feature/{ex.POST_MEDIA_VARIANT}":
+                     "black-forest-labs-flux-dev-gen4-turbo-1-1"}
+
+
+def test_experiment_properties_drops_an_empty_shipped_arm():
+    assert ex.experiment_properties(7, extra={ex.POST_MEDIA_VARIANT: None}) == {}
+
+
+# ── exposure emission ──
+
+def test_exposure_is_emitted_once_per_person_and_arm():
+    with patch("cqc_lem.utilities.observability.track_experiment_exposure") as mock_track:
+        assert ex.track_exposure(ex.COST_ROUTING_ARM, rp.ARM_TREATMENT, 7) is True
+        assert ex.track_exposure(ex.COST_ROUTING_ARM, rp.ARM_TREATMENT, 7) is False
+        # A different person, and the same person in a different arm, are both new exposures.
+        assert ex.track_exposure(ex.COST_ROUTING_ARM, rp.ARM_TREATMENT, 8) is True
+        assert ex.track_exposure(ex.COST_ROUTING_ARM, rp.ARM_CONTROL, 7) is True
+    assert mock_track.call_count == 3
+
+
+def test_exposure_never_raises_when_capture_fails():
+    with patch("cqc_lem.utilities.observability.track_experiment_exposure",
+               side_effect=RuntimeError("boom")):
+        assert ex.track_exposure(ex.COST_ROUTING_ARM, rp.ARM_TREATMENT, 7) is False
+
+
+def test_exposure_cache_is_bounded():
+    with patch("cqc_lem.utilities.observability.track_experiment_exposure"):
+        for user_id in range(ex._EXPOSURE_CACHE_MAX + 5):
+            ex.track_exposure(ex.COST_ROUTING_ARM, rp.ARM_TREATMENT, user_id)
+    assert len(ex._exposed) <= ex._EXPOSURE_CACHE_MAX
+
+
+def test_track_shipped_variant_reports_the_combo_that_shipped():
+    with patch(f"{_MOD}.track_exposure") as mock_exposure:
+        variant = ex.track_shipped_variant(ex.POST_MEDIA_VARIANT, "flux-dev|gen4_turbo|1:1",
+                                           user_id=7, post_id=99)
+    assert variant == "flux-dev-gen4-turbo-1-1"
+    assert mock_exposure.call_args.args[:2] == (ex.POST_MEDIA_VARIANT, variant)
+    assert mock_exposure.call_args.kwargs["post_id"] == 99
+
+
+def test_track_shipped_variant_is_a_no_op_without_a_key_or_on_a_flag_experiment():
+    with patch(f"{_MOD}.track_exposure") as mock_exposure:
+        assert ex.track_shipped_variant(ex.POST_MEDIA_VARIANT, None, user_id=7) is None
+        assert ex.track_shipped_variant(ex.COST_ROUTING_ARM, "anything", user_id=7) is None
+    mock_exposure.assert_not_called()
+
+
+# ── slugs ──
+
+def test_variant_slug_is_posthog_safe_stable_and_collision_free():
+    assert ex.variant_slug("Flux Dev / gen4_turbo") == "flux-dev-gen4-turbo"
+    assert ex.variant_slug("") == ex.CONTROL
+    assert ex.variant_slug(None) == ex.CONTROL
+    long_a, long_b = "x" * 80 + "-a", "x" * 80 + "-b"
+    slug_a, slug_b = ex.variant_slug(long_a), ex.variant_slug(long_b)
+    assert len(slug_a) <= ex._SLUG_MAX and slug_a != slug_b
+    assert slug_a == ex.variant_slug(long_a)  # deterministic
+
+
+def test_enrollment_available_gates_the_expensive_cohort_path(monkeypatch):
+    with patch(f"{_MOD}._local_evaluation_ready", return_value=True):
+        assert ex.enrollment_available() is True
+        monkeypatch.setenv("EXPERIMENTS_ENABLED", "off")
+        assert ex.enrollment_available() is False
+    with patch(f"{_MOD}._local_evaluation_ready", return_value=False):
+        monkeypatch.delenv("EXPERIMENTS_ENABLED", raising=False)
+        assert ex.enrollment_available() is False

--- a/tests/unit/utilities/test_experiments.py
+++ b/tests/unit/utilities/test_experiments.py
@@ -199,6 +199,13 @@ def test_experiment_properties_drops_an_empty_shipped_arm():
     assert ex.experiment_properties(7, extra={ex.POST_MEDIA_VARIANT: None}) == {}
 
 
+def test_the_kill_switch_also_strips_a_shipped_arm_label(monkeypatch):
+    """A shipped arm has no flag to read, so it would otherwise sail past the kill switch and leave
+    a switched-off experiment rendering a populated property breakdown."""
+    monkeypatch.setenv("EXPERIMENTS_ENABLED", "false")
+    assert ex.experiment_properties(7, extra={ex.POST_MEDIA_VARIANT: "flux|gen4|1:1"}) == {}
+
+
 # ── exposure emission ──
 
 def test_exposure_is_emitted_once_per_person_and_arm():

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -576,7 +576,9 @@ class TestTrackRoutingPolicy:
         assert props["enabled"] is True and props["observations"] == 42
         assert props["change_count"] == 1 and props["rollback_count"] == 1
         assert props["buckets"][0] == {"bucket": "content:lem-complex", "state": "experiment",
-                                       "to_tier": "lem-medium", "cohort_pct": 0.1}
+                                       "to_tier": "lem-medium", "cohort_pct": 0.1,
+                                       # None until #652's cohort resolution writes one.
+                                       "assignment": None}
         # The full arm statistics stay out of the event body — the verdict is what a tile needs.
         assert "comparison" not in props["changes"][0]
 
@@ -824,3 +826,99 @@ class TestTrackCommentQuality:
 
         props = mock_ph.capture.call_args[1]["properties"]
         assert props["verdict"] is None and props["sample_size"] is None
+
+
+class TestExperimentTelemetry:
+    """Exposure + metric labelling for PostHog Experiments (issue #652)."""
+
+    def test_exposure_uses_posthogs_own_feature_flag_event(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_experiment_exposure
+            track_experiment_exposure("cost-routing-arm", "treatment", user_id=7, post_id=3)
+
+        _, kwargs = mock_ph.capture.call_args
+        # These names are PostHog's, not ours: the experiment engine reads them to decide which
+        # variant a person was in. Renaming them silently empties every readout.
+        assert kwargs["event"] == "$feature_flag_called"
+        assert kwargs["distinct_id"] == "7"
+        props = kwargs["properties"]
+        assert props["$feature_flag"] == "cost-routing-arm"
+        assert props["$feature_flag_response"] == "treatment"
+        assert props["$feature/cost-routing-arm"] == "treatment"
+        assert props["experiment"] == "cost-routing-arm"
+        assert props["post_id"] == 3
+
+    def test_exposure_without_a_user_lands_on_the_system_person(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_experiment_exposure
+            track_experiment_exposure("cost-routing-arm", "control")
+        assert mock_ph.capture.call_args.kwargs["distinct_id"] == "system"
+
+    def test_post_outcome_carries_the_users_routing_arm(self):
+        with patch(f"{_MOD}.posthog") as mock_ph, \
+             patch(f"{_MOD}.experiment_props",
+                   return_value={"$feature/cost-routing-arm": "treatment"}) as props_fn:
+            from cqc_lem.utilities.observability import track_post_outcome
+            track_post_outcome(post_id=9, reactions=1, comments=0, user_id=7)
+
+        assert props_fn.call_args.kwargs["keys"] == ("cost-routing-arm",)
+        assert mock_ph.capture.call_args.kwargs["properties"]["$feature/cost-routing-arm"] \
+            == "treatment"
+
+    def test_post_outcome_reports_the_shipped_media_variant_as_an_arm(self):
+        with patch(f"{_MOD}.posthog") as mock_ph, \
+             patch(f"{_MOD}.experiment_props", return_value={}) as props_fn:
+            from cqc_lem.utilities.observability import track_post_outcome
+            track_post_outcome(post_id=9, reactions=1, comments=0, user_id=7,
+                               variant_key="flux-dev|gen4_turbo|1:1")
+
+        assert props_fn.call_args.kwargs["shipped"] == {"post-media-variant":
+                                                        "flux-dev|gen4_turbo|1:1"}
+        props = mock_ph.capture.call_args.kwargs["properties"]
+        # The raw key stays readable on the event; the slug is what PostHog groups on.
+        assert props["variant_key"] == "flux-dev|gen4_turbo|1:1"
+
+    def test_post_outcome_without_a_variant_reports_none_not_a_label(self):
+        with patch(f"{_MOD}.posthog") as mock_ph, patch(f"{_MOD}.experiment_props") as props_fn:
+            props_fn.return_value = {}
+            from cqc_lem.utilities.observability import track_post_outcome
+            track_post_outcome(post_id=9, reactions=1, comments=0, user_id=7)
+        assert props_fn.call_args.kwargs["shipped"] is None
+        assert mock_ph.capture.call_args.kwargs["properties"]["variant_key"] is None
+
+    def test_comment_outcome_carries_the_prompt_arm(self):
+        with patch(f"{_MOD}.posthog") as mock_ph, \
+             patch(f"{_MOD}.experiment_props",
+                   return_value={"$feature/comment-contract-prompt": "author-question"}) as props_fn:
+            from cqc_lem.utilities.observability import track_comment_outcome
+            track_comment_outcome(7, 11, {"status": "checked", "author_replied": True})
+
+        assert props_fn.call_args.kwargs["keys"] == ("comment-contract-prompt",)
+        props = mock_ph.capture.call_args.kwargs["properties"]
+        assert props["$feature/comment-contract-prompt"] == "author-question"
+        assert props["author_replied"] is True
+
+    def test_experiment_props_never_breaks_the_outcome_event(self):
+        """An experiment plane that is down must cost us the label, not the measurement."""
+        from cqc_lem.utilities.observability import experiment_props
+        with patch("cqc_lem.utilities.experiments.experiment_properties",
+                   side_effect=RuntimeError("boom")):
+            assert experiment_props(7, keys=("cost-routing-arm",)) == {}
+
+    def test_routing_policy_event_reports_which_side_cohorted(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_routing_policy
+            track_routing_policy({
+                "date": "2026-08-01",
+                "policy": {"enabled": True, "buckets": {
+                    "content:lem-complex": {"state": "experiment", "to_tier": "lem-medium",
+                                            "cohort_pct": 0.1, "assignment": "flag"}}},
+                "cohort": {"assignment": "flag", "enrolled": 2, "treatment": 1,
+                           "treatment_share": 0.5},
+            })
+
+        props = mock_ph.capture.call_args.kwargs["properties"]
+        assert props["cohort_assignment"] == "flag"
+        assert props["cohort_enrolled"] == 2
+        assert props["cohort_treatment_share"] == 0.5
+        assert props["buckets"][0]["assignment"] == "flag"

--- a/tests/unit/utilities/test_post_stats.py
+++ b/tests/unit/utilities/test_post_stats.py
@@ -352,6 +352,7 @@ class TestScrapeStatsTask:
              patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
              patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://x/urn"), \
              patch(f"{_RA}._post_social_counts", return_value={"reactions": 12, "comments": 3}), \
+             patch(f"{_RA}.get_shipped_variant_keys", return_value={}), \
              patch(f"{_RA}.record_post_stats") as rec, patch(f"{_RA}.quit_gracefully"):
             from cqc_lem.app.run_automation import auto_scrape_post_stats
             result = auto_scrape_post_stats.run(user_id=1)

--- a/tests/unit/utilities/test_routing_policy.py
+++ b/tests/unit/utilities/test_routing_policy.py
@@ -121,7 +121,8 @@ def test_a_user_id_is_bucketed_the_same_as_an_int_or_a_string():
 def test_resolve_tier_downroutes_treatment_cohort():
     decision = rp.resolve_tier(rp.TIER_COMPLEX, "content", 1, _policy())
     assert decision == {"tier": rp.TIER_MEDIUM, "base_tier": rp.TIER_COMPLEX,
-                        "arm": rp.ARM_TREATMENT, "applied": True, "bucket": "content:lem-complex"}
+                        "arm": rp.ARM_TREATMENT, "assignment": rp.ASSIGNMENT_HASH,
+                        "applied": True, "bucket": "content:lem-complex"}
 
 
 def test_resolve_tier_leaves_control_cohort_alone():
@@ -159,3 +160,94 @@ def test_resolve_tier_matches_the_bucket_by_feature_and_tier():
     assert rp.resolve_tier(rp.TIER_MEDIUM, "comment", 3, policy)["tier"] == rp.TIER_SIMPLE
     assert rp.resolve_tier(rp.TIER_MEDIUM, "content", 3, policy)["tier"] == rp.TIER_MEDIUM
     assert rp.resolve_tier(rp.TIER_COMPLEX, "comment", 3, policy)["tier"] == rp.TIER_COMPLEX
+
+
+# ── flag-decided arms (issue #652) ──
+# The PostHog experiment resolves each user's arm APP-SIDE and hands it to this stdlib-only module
+# inside the policy document, so these tests are the whole contract of that hand-off.
+
+def test_flag_arm_reads_the_document_map_with_string_keys():
+    """The document round-trips through Redis as JSON, so an int user id comes back as "7". Reading
+    it back as 7 would silently lose every assignment."""
+    bucket = _bucket(cohort_pct=0.1, arms={"7": rp.ARM_TREATMENT, "8": rp.ARM_CONTROL})
+    assert rp.flag_arm(7, bucket) == rp.ARM_TREATMENT
+    assert rp.flag_arm("7", bucket) == rp.ARM_TREATMENT
+    assert rp.flag_arm(8, bucket) == rp.ARM_CONTROL
+    assert rp.flag_arm(9, bucket) is None
+
+
+@pytest.mark.parametrize("arms", [None, "junk", {}, {"7": "TREATMENT"}, {"7": None},
+                                  {"7": "experiment"}])
+def test_flag_arm_falls_back_rather_than_guessing(arms):
+    assert rp.flag_arm(7, _bucket(cohort_pct=0.1, arms=arms)) is None
+
+
+def test_flag_arm_ignores_the_analytics_sentinel_and_no_user():
+    bucket = _bucket(cohort_pct=0.1, arms={rp.SYSTEM_USER_ID: rp.ARM_TREATMENT,
+                                           "7": rp.ARM_TREATMENT})
+    assert rp.flag_arm(rp.SYSTEM_USER_ID, bucket) is None
+    assert rp.flag_arm(None, bucket) is None
+    assert rp.flag_arm(7, None) is None
+
+
+def test_flag_assignment_beats_the_hash_in_both_directions():
+    """The flag decides WHO: it can pull a user the hash left in control into the treatment, and it
+    can keep the holdout the ramp would have swept up."""
+    hashed = {u: rp.assign_arm(u, _bucket(cohort_pct=0.5)) for u in range(50)}
+    control_user = next(u for u, arm in hashed.items() if arm == rp.ARM_CONTROL)
+    treated_user = next(u for u, arm in hashed.items() if arm == rp.ARM_TREATMENT)
+    assert rp.assign_arm(control_user, _bucket(cohort_pct=0.5,
+                                               arms={str(control_user): rp.ARM_TREATMENT})) \
+        == rp.ARM_TREATMENT
+    assert rp.assign_arm(treated_user, _bucket(cohort_pct=0.5,
+                                               arms={str(treated_user): rp.ARM_CONTROL})) \
+        == rp.ARM_CONTROL
+    # Even at full cohort the flag's holdout survives — that holdout is what keeps the §D.3 quality
+    # gate measurable after adoption.
+    assert rp.assign_arm(7, _bucket(cohort_pct=1.0, arms={"7": rp.ARM_CONTROL})) == rp.ARM_CONTROL
+
+
+def test_a_parked_bucket_cannot_be_started_by_a_flag():
+    """cohort_pct is the optimizer's ramp and it decides WHETHER: a rolled-back bucket routes nothing
+    no matter what the experiment flag says."""
+    assert rp.assign_arm(7, _bucket(cohort_pct=0.0, arms={"7": rp.ARM_TREATMENT})) == rp.ARM_CONTROL
+
+
+def test_resolve_tier_reports_which_side_assigned_the_arm():
+    flagged = rp.resolve_tier(rp.TIER_COMPLEX, "content", 7,
+                              _policy(_bucket(cohort_pct=0.1, arms={"7": rp.ARM_TREATMENT})))
+    assert flagged["applied"] is True
+    assert flagged["assignment"] == rp.ASSIGNMENT_FLAG
+    unflagged = rp.resolve_tier(rp.TIER_COMPLEX, "content", 7, _policy(_bucket(cohort_pct=1.0)))
+    assert unflagged["assignment"] == rp.ASSIGNMENT_HASH
+
+
+def test_normalize_policy_preserves_the_arms_map():
+    """The router reads the document through normalize_policy — dropping `arms` there would silently
+    revert every flag assignment to the hash."""
+    policy = rp.normalize_policy(_policy(_bucket(cohort_pct=0.1, arms={"7": rp.ARM_TREATMENT})))
+    assert policy["buckets"]["content:lem-complex"]["arms"] == {"7": rp.ARM_TREATMENT}
+
+
+def test_the_decision_core_stays_stdlib_only():
+    """This file is MOUNTED into the LiteLLM container, which has no LEM package and none of LEM's
+    dependencies. #652 moved cohorting to PostHog, which makes `from cqc_lem.utilities.experiments
+    import ...` a tempting one-liner here — it would break routing in production the moment the proxy
+    reloaded the hook, and nothing else in CI would notice."""
+    import ast
+    import sys
+    from pathlib import Path
+
+    tree = ast.parse(Path(rp.__file__).read_text())
+    imported = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            imported.add(node.module.split(".")[0])
+        elif isinstance(node, ast.ImportFrom) and node.level:
+            raise AssertionError("routing_policy.py must not use relative imports — it is mounted "
+                                 "outside the package")
+    assert "cqc_lem" not in imported
+    assert imported <= set(sys.stdlib_module_names), (
+        f"non-stdlib imports in routing_policy.py: {imported - set(sys.stdlib_module_names)}")


### PR DESCRIPTION
## What & why

LEM hand-rolled experimentation twice: the cost/quality down-routing cohort (`routing_policy.py` / `cost_routing.py`, plan §D.1.1) and the #396 outcome-tracked media A/B harness. Both work. Neither can answer *"is this difference real"* with anything a statistician would sign, and neither renders anywhere a human looks. PostHog Experiments already has the multivariate flag, the exposure model, both stats engines (Bayesian + frequentist), CUPED and the readout — and it's billed with feature flags, so free at our volume.

`utilities/experiments.py` is therefore the **adapter, not a third implementation**. The homegrown loops keep running exactly as they did; PostHog gets the arms, the exposures and the outcome labels.

Full posture: **`docs/experiments.md`**.

### The contract

**An unresolvable experiment is the CONTROL arm** — no PostHog key, definitions not loaded, flag not defined, evaluation inconclusive, `EXPERIMENTS_ENABLED=false`, SDK raises. There is deliberately **no per-experiment env fallback** (unlike #651's flags: a toggle has a configured default worth honouring, an experiment arm does not), and `_raw_variant()` keeps *"PostHog said control"* apart from *"PostHog said nothing"* so `experiment_properties()` never stamps `$feature/x=control` on a metric event from someone who was never enrolled — a fabricated control arm makes a readout look populated.

Assignment reuses **flags.py's ONE local-evaluation bootstrap** rather than starting a second poller (zero network calls per lookup — these run in feed loops). Consequence, documented: every experiment flag must use rollout-percentage / distinct-ID conditions only.

Exposure is `$feature_flag_called` — PostHog's own event name and properties, not ours — emitted explicitly (flags.py suppresses it for hot toggles) and **deduped per (experiment, person, arm) per process**.

### 1. Cost-routing cohorting moved to the flag, without breaking stdlib-only

`routing_policy.py` is mounted into the LiteLLM container, so it can never import `experiments.py`. The DECISION is handed to it instead: the weekly run resolves each active user's arm app-side and writes it into each routing bucket as `arms: {"7": "treatment"}`, inside the policy document Redis already carries to the router.

- `flag_arm()` reads the map (string keys — the document round-trips as JSON); `assign_arm()` prefers it and **falls back to the original SHA-256 hash** for anyone PostHog has no answer for, so an outage moves no traffic.
- `resolve_tier()` now reports `assignment` (`flag`/`hash`) — the difference between *"the experiment is running"* and *"PostHog was unreachable"*.
- **The flag decides WHO, `cohort_pct` decides WHETHER**: a parked/rolled-back bucket can never be started by a flag, and inside a running one the flag wins both ways — including keeping a holdout the ramp would have swept up, which is what keeps the §D.3 quality gate measurable after adoption.
- Arms are applied **after** the weekly evaluation: the window being judged ran under the previous document's cohort.
- Map capped at 500 users, and a truncation is **logged** (the users left out are silently hash-assigned otherwise).

### 2. Pilot LLM prompt experiment (G2)

`comment-contract-prompt`: control vs. `author-question`, which adds one rule — end on a question **only this author could answer**. Metric is author-reply rate (D4) from #628's T+24h sweep, carried on `comment_outcome`.

Scoped deliberately: the six deterministically-graded contract rules are **identical in both arms** (an arm that loosened one would change what "passes the gate" means), and only **fresh feed comments** are enrolled — the seed / second-wave / reply surfaces are never measured by that sweep.

### 3. #396 harness adapter

The combo that shipped IS the arm (`assignment: shipped`, no flag to read). `record_shipped_variant()` is the exposure moment; a single `get_shipped_variant_keys()` query per stats sweep puts each post's variant on its `post_outcome` event. `select_variant_winners` is untouched — PostHog gets the stats engine, the ranking keeps its recency weighting.

### 4. Provisioning

`scripts/posthog_experiments.py` — `--print-specs` / dry-run (default) / `--apply` / `--rollout KEY=PCT`. It **never resets an existing flag's rollout**: PostHog owns the ramp once an experiment runs, and an `--apply` that reverted it would re-cohort a live experiment. Media arms are derived from `DEFAULT_COMBOS` so they can't drift from what the code can ship; flag conditions are property-free at 100% so local evaluation can always decide them.

### Honesty about the readout

At current volume (one active user, ~3 posts/week) none of this reaches significance on anything subtler than a collapse — `MINIMUM_DETECTABLE_EFFECT` is a deliberately coarse 30% and the small-sample caveat is spelled out in the doc. The harness exists so the multi-user future has a measurement plane already emitting. The attribution caveat (don't re-roll a running experiment's variants) is documented too.

### Bug found by the new tests

`build_routing_policy` shadowed its own incoming cohort with the per-bucket arm *split* (`arms = split_observations(...)`), so the resolved cohort never reached the document. Fixed (`arm_rows`).

## Dependency

Builds on **#651 / #688** (`utilities/flags.py`), which merged while this was in flight — rebased onto it, resolving `cost_routing.py`'s docstring and the `enabled: Optional[bool] = None` runtime-flag signature so the new `arms` parameter sits alongside #688's `routing_enabled()` rather than reverting it.

The `flags` import is still **lazy and latched** (documented in `_flag_surface`): experiments hold no import-time dependency on the flag surface, and any failure to load it reads as not-ready, which is the same fail-to-control path as a missing key.

## Acceptance criteria

| Criterion | Where |
|---|---|
| Cost-routing cohorting reproducible from the flag | `routing_policy.flag_arm` + `cost_routing.resolve_cohort`; `test_the_flag_cohort_survives_the_container_boundary` drives a PostHog answer → real policy document → JSON round-trip → the real LiteLLM hook's down-route |
| Exposure events land | `observability.track_experiment_exposure` (`$feature_flag_called` + `$feature_flag_response`), deduped in `experiments.track_exposure` |
| Experiment readout renders in PostHog | `scripts/posthog_experiments.py --apply` creates the multivariate flags + experiment records; metrics point at `post_outcome` / `comment_outcome` / `$ai_generation` |
| stdlib-only constraint verified by tests | `test_complexity_router.py` (unchanged, still green) + a new explicit AST guard, `test_the_decision_core_stays_stdlib_only` |

## Testing notes

- `poetry run pytest tests/unit -q` → **7089 passed** (81 new).
- New/extended: `tests/unit/utilities/test_experiments.py` (30), `tests/unit/test_posthog_experiments.py` (25), routing arms + stdlib guard, cohorting in `test_cost_routing.py`, exposure/metric labelling in `test_observability.py`, prompt-variant wiring in `test_comment_contract.py`, adapter in `test_generate_variants.py`, per-sweep variant lookup in `test_sweep_fixes.py`, `test_variant_ab_harness.py` (integration).
- The two `tests/integration/test_link_first_comment.py` failures locally are pre-existing on `main` (verified by stashing) — they need the service containers.
- Nothing turns on by itself: `EXPERIMENTS_ENABLED` defaults true but with no `POSTHOG_PERSONAL_API_KEY` (and cost routing still shipped OFF) every arm is the control and no flag exists until the provisioner is run.

Closes #652

🤖 Generated with [Claude Code](https://claude.com/claude-code)
