### PR TITLE
feat(surveys): NPS/CSAT via PostHog Surveys, wired into the feedback loop (closes #653)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -537,6 +537,12 @@ POSTHOG_FLAG_POLL_SECONDS=30
 # Fleet default for `feed_fallback_when_empty` for users who have never SAVED engagement
 # preferences. A user's own saved setting always wins over this and over the flag.
 FEED_FALLBACK_WHEN_EMPTY_DEFAULT=true
+# --- Surveys (issue #653, docs/surveys.md) ---
+# ON hands NPS + the post-quality CSAT to PostHog Surveys (targeting, cadence, the 30-day
+# wait-between-surveys throttle) and stands the homegrown NPS asks down so nobody is prompted twice.
+# The bespoke asks — the review that unlocks the extended trial, the per-issue fix CSAT — are
+# unaffected either way. Provision the surveys first: `python scripts/posthog_surveys.py --apply`.
+POSTHOG_SURVEYS_ENABLED=false
 # --- PostHog in the SPA (issue #646) ---
 # Read by Vite at BUILD time and baked into the bundle, so they must be set for `npm run build`
 # (docker build-arg / CI env), not in the running container. Leave VITE_POSTHOG_KEY empty and the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,6 +394,36 @@ stdlib-only. The SPA bootstraps from `GET /api/flags` (server-resolved, so no fl
 disagreement between browser, API and workers) via `hooks/useFeatureFlags.ts` — NOT through
 posthog-js, which stays the analytics surface. Full posture: `docs/feature-flags.md`.
 
+### Surveys — NPS/CSAT via PostHog (issue #653)
+
+LEM's four asks now have TWO owners, and the line between them is what an answer can DO. PostHog
+Surveys owns the two general-purpose ones — the **NPS** at 30 days past ACTIVATION (not signup; a
+stalled user's score is about onboarding) and the **post-quality CSAT** triggered by `post_approved`
+once `posts_approved >= 5` — because their targeting and cadence should be tunable without a deploy.
+`utilities/surveys.py` keeps the two bespoke ones: the trial-T-3d **review** (it is the #499
+extended-trial gate, which PostHog cannot unlock) and the per-issue **fix CSAT** (#502).
+
+Both PostHog surveys are type **`api`** and rendered headless in `PostHogSurveyModal.tsx`, not as
+PostHog's popover — a popover answer is a PostHog event and NOTHING ELSE, and the reason LEM asks for
+scores at all is the feedback→auto-work loop. So one answer takes two paths and is counted ONCE: the
+browser emits PostHog's own `survey sent` (native `$survey_response`/`$survey_questions` shape, so it
+shows up in the Surveys product), and the same answer POSTs to `/api/survey/posthog` where it becomes
+a `feedback` row that the classifier files as an issue. `track_survey_response` is deliberately NOT
+emitted on that path — two events per answer would double every response-rate number. A detractor
+(NPS ≤6 / CSAT ≤2) or ANY free text stays `new` so the loop files it; a happy score with no comment
+is stamped `resolved` on the spot rather than burning an LLM call per promoter.
+
+Rendering it ourselves means posthog-js never sees the ask, so `markSurveySeen()` is what advances
+its seen/wait-period bookkeeping — drop it and the 30-day `seenSurveyWaitPeriodInDays` throttle
+silently stops working. Targeting reads person properties the SPA sets at `$identify` off
+`GET /auth/session` (`onboarding_completed_at`, `posts_approved` — counted across
+approved/scheduled/posted, because an approved post moves on and a current-status count would reset
+the tally). `scripts/posthog_surveys.py` is the ONE place the surveys are defined (`--dry-run` diffs,
+`--apply` converges, `--launch` is a separate opt-in so an apply never starts collecting from a
+definition nobody read). The `posthog-surveys-enabled` flag stands the homegrown NPS asks down
+(`select_survey(nps_enabled=False)`) so nobody is prompted twice; the review offer is untouched.
+Full posture: `docs/surveys.md`.
+
 ## CI Gates
 
 Before merging any PR, all of the following must pass:

--- a/docs/surveys.md
+++ b/docs/surveys.md
@@ -1,0 +1,127 @@
+# Surveys (issue #653)
+
+LEM asks its users four different questions, and after this change they are owned by two different
+systems on purpose.
+
+| Ask | Owner | Why there |
+|---|---|---|
+| **NPS** — 30 days after activation | **PostHog Surveys** | Targeting and cadence should be tunable without a deploy |
+| **Post-quality CSAT** — after 5+ approvals | **PostHog Surveys** | Event-triggered; lands in the moment the user just judged a draft |
+| **Review** — trial T-3d | `utilities/surveys.py` | It is the extended-trial gate (#499); PostHog cannot unlock anything |
+| **Fix CSAT** — "did this fix it?" | `utilities/surveys.py` | Per-ISSUE (`fix_csat_<n>`), scheduled by the shipped-notice queue (#502) |
+
+The split is the whole design. PostHog is better at *deciding who to ask and when*; LEM's own
+`feedback` table is the only thing that can turn an answer into work.
+
+## One answer, two destinations, counted once
+
+A PostHog survey response takes both paths deliberately:
+
+1. The browser emits PostHog's own **`survey sent`**, with `$survey_id` / `$survey_response` /
+   `$survey_questions` in PostHog's native shape. That is what makes it a survey response in the
+   Surveys product — summarizable, chartable, countable there.
+2. The same answer is `POST`ed to **`/api/survey/posthog`**, where it becomes an ordinary `feedback`
+   row and enters the classifier → cluster → GitHub-issue pipeline like any bug report.
+
+`track_survey_response` — the homegrown `survey_response` event — is **not** emitted on this path.
+Two events for one answer would double every response-rate number on the dashboards. The `feedback`
+row carries `context_json.origin = "posthog_survey"` so anything counting rows out of MySQL can tell
+the two streams apart.
+
+### What reaches the auto-work loop
+
+| Answer | Feedback status | Effect |
+|---|---|---|
+| NPS ≤ 6, or CSAT ≤ 2 | `new` | Auto-filing pass classifies it and opens/`+1`s a feedback issue |
+| Any score **with** free text | `new` | Same — the text is the actionable part |
+| Happy score, no comment | `resolved` | Nothing to classify; must not burn an LLM call per promoter |
+
+## Why headless, not the popover
+
+Both surveys are created as PostHog **`api`** type, so posthog-js draws nothing and
+`PostHogSurveyModal.tsx` renders them in LEM's own modal. Two reasons, both load-bearing:
+
+- A popover answer is a PostHog event and **nothing else**. It would never reach the feedback loop,
+  which is the reason LEM asks for scores at all.
+- The popover renders bottom-right, exactly where the feedback widget already sits.
+
+The cost of rendering ourselves is that posthog-js never sees the ask, so its "already seen" and
+wait-period bookkeeping would never advance — `markSurveySeen()` is what closes that gap, and
+removing it turns the throttle off silently.
+
+## Targeting
+
+Expressed the PostHog way, against person properties the SPA sets at `$identify` (supplied by
+`GET /auth/session`):
+
+| Survey | Rule |
+|---|---|
+| NPS | `onboarding_completed_at` is before `-30d` |
+| CSAT | activation event `post_approved`, **and** person `posts_approved >= 5` |
+
+`onboarding_completed_at` is `onboarding_state.activated_at` — the activation "aha", **not** signup.
+A user who signed up and stalled has no opinion worth a score, and their detractor answer would be
+about onboarding rather than about the product.
+
+`posts_approved` counts posts in `approved`/`scheduled`/`posted`: an approved post moves on as
+automation runs, so counting the current status alone would reset the tally. The SPA advances the
+property itself on each approval (`recordPostApproval`), so the ask can fire on the approval that
+crosses the threshold rather than one session later. With no server baseline yet, only the event is
+sent — a made-up count would target the survey at the wrong people.
+
+Both surveys carry `seenSurveyWaitPeriodInDays = 30`, PostHog's cross-survey throttle: answering or
+dismissing **either** buys 30 days of silence from **both**.
+
+## No double-prompting
+
+`posthog-surveys-enabled` (flag registry, `POSTHOG_SURVEYS_ENABLED`) is the switch. When it is on,
+`next_survey_for_user` passes `nps_enabled=False` into `select_survey`, which retires
+`nps_day3` and `nps_trial_end` from **both** the in-app modal and the daily email beat. The review
+offer is untouched — it is the extended-trial gate.
+
+Answering in PostHog also closes the homegrown ask on its own, without any flag: the `feedback` row
+is what `next_survey_for_user` reads through `get_latest_feedback_at(user_id, NPS)`.
+
+The flag fails open to the env var like every other registered flag (`docs/feature-flags.md`), and
+a flag-lookup exception keeps the homegrown asks — the failure mode is "asked the old way", never
+"asked twice".
+
+## Provisioning
+
+`scripts/posthog_surveys.py` is the ONE place the two surveys are defined.
+
+```bash
+python scripts/posthog_surveys.py --print-spec       # both specs as JSON, no network
+python scripts/posthog_surveys.py --dry-run          # diff against the live project (exit 2 = pending)
+python scripts/posthog_surveys.py --apply            # create missing / update drifted
+python scripts/posthog_surveys.py --apply --launch   # ...and start one that has never run
+```
+
+`--apply` creates surveys as **drafts**. Launching is a separate opt-in so an apply can never start
+collecting responses from a definition nobody has read. Drift is measured on a narrow set of managed
+fields (`description`, `type`, `questions`, `conditions`, `schedule`, targeting groups) so an
+appearance tweak in the PostHog UI does not read as permanent drift, and property values are
+compared by value — PostHog echoes numbers back as strings.
+
+Needs `POSTHOG_PERSONAL_API_KEY` with survey read+write and feature-flag write (a targeting flag is
+created alongside each survey).
+
+## Configuration
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `POSTHOG_SURVEYS_ENABLED` | `false` | Flag fallback — PostHog owns NPS/CSAT and the homegrown NPS asks stand down |
+| `VITE_POSTHOG_KEY` | *(unset)* | No key means no posthog-js, so no PostHog survey is ever shown |
+
+## Verifying in a test account
+
+1. `python scripts/posthog_surveys.py --apply --launch`, then confirm both surveys are **Running**.
+2. Flip `posthog-surveys-enabled` on for your own distinct ID (`str(user_id)`).
+3. Sign in and confirm `onboarding_completed_at` / `posts_approved` are on your PostHog person.
+4. NPS: the modal appears on load once activation is 30+ days old. CSAT: approve a post in Content
+   Studio with 5+ approvals on file.
+5. Submit. Check three things: a `survey sent` event on the person, the response in PostHog →
+   Surveys, and a `feedback` row with `context_json.origin = "posthog_survey"`.
+6. Score it low and confirm the next `file-feedback-issues` pass (every 30 min) opens the issue.
+7. Reload — the survey must not reappear (`markSurveySeen` + the 30-day wait period), and
+   `GET /api/user/survey` must not be offering an NPS ask.

--- a/scripts/posthog_surveys.py
+++ b/scripts/posthog_surveys.py
@@ -237,6 +237,13 @@ def plan_actions(specs: list, existing: dict, launch: bool = False) -> list:
         found = existing.get(spec["name"])
         if not found:
             actions.append({"action": "create_survey", "survey": spec["name"], "spec": spec})
+            # A survey that does not exist yet has by definition never been started, so --launch
+            # covers the first run too — otherwise `--apply --launch` would silently leave both
+            # surveys as drafts and the operator would have to run the same command twice.
+            # `survey_id` is only known once the create returns; apply_actions resolves it.
+            if launch:
+                actions.append({"action": "launch_survey", "survey": spec["name"],
+                                "survey_id": None})
             continue
         drift = drifted_fields(spec, found)
         if drift:
@@ -317,6 +324,7 @@ def apply_actions(client: PostHogSurveyClient, actions: list, dry_run: bool = Tr
     """Execute the plan. `dry_run` reports without writing. Returns the log lines emitted."""
     log: list = []
     start_date = (now or datetime.now(timezone.utc)).isoformat()
+    created: dict = {}
     for action in actions:
         kind, name = action["action"], action.get("survey")
         if kind == "noop":
@@ -326,6 +334,7 @@ def apply_actions(client: PostHogSurveyClient, actions: list, dry_run: bool = Tr
                 log.append(f"[dry-run] create survey '{name}' (draft — launch it explicitly)")
                 continue
             survey_id = client.create_survey(create_payload(action["spec"]))
+            created[name] = survey_id
             log.append(f"created survey '{name}' -> {survey_id}")
         elif kind == "update_survey":
             fields = ", ".join(action.get("fields") or [])
@@ -338,7 +347,12 @@ def apply_actions(client: PostHogSurveyClient, actions: list, dry_run: bool = Tr
             if dry_run:
                 log.append(f"[dry-run] launch survey '{name}'")
                 continue
-            client.launch_survey(action["survey_id"], start_date)
+            # A launch planned alongside a create has no id until that create returned.
+            survey_id = action.get("survey_id") or created.get(name)
+            if not survey_id:
+                log.append(f"could not launch survey '{name}' — it was never created")
+                continue
+            client.launch_survey(survey_id, start_date)
             log.append(f"launched survey '{name}'")
     return log
 

--- a/scripts/posthog_surveys.py
+++ b/scripts/posthog_surveys.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python3
+"""Provision LEM's two PostHog Surveys — the 30-day NPS and the post-quality CSAT (issue #653).
+
+LEM already had survey capture: a `survey_prompts` ledger, a hand-written `select_survey` policy and
+an email beat. What it did not have was TARGETING it could change without a deploy, a throttle that
+spans every survey at once, or a place to read responses that wasn't a MySQL table. PostHog Surveys
+gives all three (1,500 responses/month on the free tier), so the two general-purpose asks move here
+and the bespoke ones — the review that unlocks the extended trial (#499), the per-issue "did this
+fix it?" (#502) — stay in `utilities/surveys.py` where they belong.
+
+Both surveys are created as type **`api`**: PostHog decides WHO and WHEN, the SPA renders the form.
+That is not a style choice. A popover survey's answer is a PostHog event and nothing else, and LEM's
+whole reason for asking is the feedback->auto-work loop that turns a complaint into a GitHub issue.
+Rendering headless in the SPA's own modal (`PostHogSurveyModal.tsx`) is what lets one answer become
+both a `survey sent` event AND a `feedback` row. It also keeps LEM's chrome: the popover would land
+on top of the feedback widget in the same corner.
+
+Targeting is expressed the PostHog way, against person properties the SPA sets at `$identify`
+(`GET /auth/session` supplies them):
+
+  • **NPS** — `onboarding_completed_at` is before `-30d`. Thirty days after ACTIVATION, not signup:
+    a user who signed up and stalled has no opinion worth a score, and their detractor answer would
+    be about onboarding rather than the product.
+  • **CSAT** — triggered by the `post_approved` event, gated on `posts_approved >= 5`. The event is
+    what makes it land in the moment the user just judged a draft; the property is what stops it
+    firing on someone's first ever approval.
+
+Both carry `seenSurveyWaitPeriodInDays`, which is PostHog's cross-survey throttle: answering (or
+dismissing) either one buys 30 days of silence from BOTH.
+
+Split like scripts/posthog_provision.py: PURE spec/plan logic (unit-tested) and a thin I/O layer.
+
+CLI (--dry-run and --apply are mutually exclusive):
+  --dry-run     Show what would be created/updated against the live project. No writes. (default)
+  --apply       Create missing surveys and update drifted ones.
+  --print-spec  Print both survey specs as JSON and exit (no network).
+  --launch      With --apply, also set start_date on a survey that has never been launched.
+Env:
+  POSTHOG_PERSONAL_API_KEY  Personal API key (required for network). Scopes: survey read+write,
+                            plus feature_flag write (a targeting flag is created with the survey).
+  POSTHOG_PROJECT_ID        PostHog project id (default 475262 — "CQC LEM").
+  POSTHOG_APP_HOST          App host for the API (default https://us.posthog.com).
+Exit: 0 in sync / applied, 2 changes pending (--dry-run), 1 error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Optional
+
+DEFAULT_PROJECT_ID = "475262"  # "CQC LEM" — not a secret; the key that reaches it is.
+DEFAULT_APP_HOST = "https://us.posthog.com"
+
+# Survey NAMES are the contract with two other places: utilities/surveys.py maps a name onto a
+# feedback source, and the SPA matches on it to know which form to render. A unit test holds this
+# copy and `utilities.surveys` to each other — this script stays importable without the app package.
+NPS_SURVEY_NAME = "LEM NPS"
+CSAT_SURVEY_NAME = "LEM CSAT — post quality"
+
+# Mirrors POSTHOG_NPS_AFTER_ACTIVATION_DAYS / POSTHOG_CSAT_MIN_APPROVALS / POSTHOG_SURVEY_WAIT_DAYS.
+NPS_AFTER_ACTIVATION_DAYS = 30
+CSAT_MIN_APPROVALS = 5
+SURVEY_WAIT_DAYS = 30
+
+# The person properties the rules read, set by the SPA at $identify off GET /auth/session.
+PERSON_ONBOARDING_COMPLETED = "onboarding_completed_at"
+PERSON_POSTS_APPROVED = "posts_approved"
+# The SPA event the CSAT rides on (ui/src/utils/analytics.ts EVENTS.postApproved).
+CSAT_TRIGGER_EVENT = "post_approved"
+
+# `api` = PostHog targets, LEM renders. See the module docstring for why this is load-bearing.
+SURVEY_TYPE = "api"
+
+# Only these keys are compared against what PostHog returns, so a field the UI adds (appearance
+# tweaks, folder, created_by) never shows up as permanent drift in --dry-run.
+MANAGED_FIELDS = ("description", "type", "questions", "conditions", "schedule")
+
+
+def _rating(question: str, scale: int, lower: str, upper: str,
+            description: Optional[str] = None) -> dict:
+    # scale 10 is PostHog's 0-10 NPS band; every other scale starts at 1.
+    return {"type": "rating", "question": question, "description": description,
+            "display": "number", "scale": scale,
+            "lowerBoundLabel": lower, "upperBoundLabel": upper, "optional": False}
+
+
+def _open(question: str, description: Optional[str] = None) -> dict:
+    # Always optional: a required "why" turns a 5-second ask into an abandoned one.
+    return {"type": "open", "question": question, "description": description, "optional": True}
+
+
+def nps_survey_spec() -> dict:
+    return {
+        "name": NPS_SURVEY_NAME,
+        "description": (
+            f"NPS, asked once a user is {NPS_AFTER_ACTIVATION_DAYS} days past activation. Rendered "
+            "headless by the SPA (issue #653); responses also land as `feedback` rows so detractors "
+            "open a report in the feedback->auto-work loop."),
+        "type": SURVEY_TYPE,
+        "schedule": "once",
+        "questions": [
+            _rating("How likely are you to recommend LEM to a colleague?", 10,
+                    "Not at all likely", "Extremely likely"),
+            _open("What's the main reason for your score?"),
+        ],
+        "conditions": {"seenSurveyWaitPeriodInDays": SURVEY_WAIT_DAYS},
+        "targeting_flag_filters": {
+            "groups": [{
+                "properties": [{
+                    "key": PERSON_ONBOARDING_COMPLETED,
+                    "type": "person",
+                    "operator": "is_date_before",
+                    "value": f"-{NPS_AFTER_ACTIVATION_DAYS}d",
+                }],
+                "rollout_percentage": 100,
+            }],
+        },
+    }
+
+
+def csat_survey_spec() -> dict:
+    return {
+        "name": CSAT_SURVEY_NAME,
+        "description": (
+            f"Post-quality CSAT, triggered by `{CSAT_TRIGGER_EVENT}` once a user has approved "
+            f"{CSAT_MIN_APPROVALS}+ posts. Asked in the moment they just judged a draft, so the "
+            "rating is about the writing rather than the product in general (issue #653)."),
+        "type": SURVEY_TYPE,
+        "schedule": "once",
+        "questions": [
+            _rating("How happy are you with the posts LEM writes for you?", 5,
+                    "Not happy", "Very happy"),
+            _open("What would make the writing better?"),
+        ],
+        "conditions": {
+            "seenSurveyWaitPeriodInDays": SURVEY_WAIT_DAYS,
+            # repeatedActivation so a user who dismisses without answering can be re-triggered by a
+            # later approval; the wait period above is what stops that becoming nagging.
+            "events": {"repeatedActivation": True, "values": [{"name": CSAT_TRIGGER_EVENT}]},
+        },
+        "targeting_flag_filters": {
+            "groups": [{
+                "properties": [{
+                    "key": PERSON_POSTS_APPROVED,
+                    "type": "person",
+                    "operator": "gte",
+                    "value": CSAT_MIN_APPROVALS,
+                }],
+                "rollout_percentage": 100,
+            }],
+        },
+    }
+
+
+def build_specs() -> list:
+    return [nps_survey_spec(), csat_survey_spec()]
+
+
+def create_payload(spec: dict) -> dict:
+    """What POST /surveys/ receives. `start_date` is deliberately absent — a survey is created as a
+    draft and launched explicitly (--launch), so an --apply can never start collecting responses
+    from a definition nobody has read."""
+    payload = {k: v for k, v in spec.items() if k != "targeting_flag_filters"}
+    payload["enable_partial_responses"] = False
+    if spec.get("targeting_flag_filters"):
+        payload["targeting_flag_filters"] = spec["targeting_flag_filters"]
+    return payload
+
+
+def update_payload(spec: dict) -> dict:
+    """What PATCH /surveys/<id>/ receives. Targeting filters are included: they are the rule most
+    likely to be tuned, and PostHog updates the survey's existing targeting flag in place."""
+    return create_payload(spec)
+
+
+def drifted_fields(spec: dict, existing: dict) -> list:
+    """Managed fields whose live value no longer matches the spec. Deliberately narrow — see
+    MANAGED_FIELDS."""
+    drift = []
+    for field in MANAGED_FIELDS:
+        want = spec.get(field)
+        if want is None:
+            continue
+        if _normalize(existing.get(field)) != _normalize(want):
+            drift.append(field)
+    if _targeting_drifted(spec, existing):
+        drift.append("targeting_flag_filters")
+    return drift
+
+
+def _targeting_drifted(spec: dict, existing: dict) -> bool:
+    want = spec.get("targeting_flag_filters")
+    if not want:
+        return False
+    live = (existing.get("targeting_flag") or {}).get("filters")
+    if not live:
+        return True
+    return _normalize(_targeting_groups(live)) != _normalize(_targeting_groups(want))
+
+
+def _targeting_groups(filters: object) -> list:
+    """Just the property groups. PostHog echoes back extra flag machinery (payloads, multivariate,
+    super_groups) that no spec here sets, and comparing the whole document would report drift on
+    every run."""
+    groups = (filters or {}).get("groups") if isinstance(filters, dict) else None
+    normalized = []
+    for group in groups or []:
+        normalized.append({
+            "rollout_percentage": group.get("rollout_percentage"),
+            "properties": [{k: p.get(k) for k in ("key", "type", "operator", "value")}
+                           for p in (group.get("properties") or [])],
+        })
+    return normalized
+
+
+def _normalize(value):
+    """Compare by VALUE, not by JSON text: PostHog returns numbers as strings in property filters
+    and drops explicit nulls, either of which would otherwise read as permanent drift."""
+    if isinstance(value, dict):
+        return {k: _normalize(v) for k, v in sorted(value.items()) if v is not None}
+    if isinstance(value, list):
+        return [_normalize(v) for v in value]
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return str(value)
+    return value
+
+
+def plan_actions(specs: list, existing: dict, launch: bool = False) -> list:
+    """Create/update/launch actions for each spec against the live surveys, keyed by name."""
+    actions = []
+    for spec in specs:
+        found = existing.get(spec["name"])
+        if not found:
+            actions.append({"action": "create_survey", "survey": spec["name"], "spec": spec})
+            continue
+        drift = drifted_fields(spec, found)
+        if drift:
+            actions.append({"action": "update_survey", "survey": spec["name"], "spec": spec,
+                            "survey_id": found.get("id"), "fields": drift})
+        else:
+            actions.append({"action": "noop", "survey": spec["name"]})
+        if launch and not found.get("start_date"):
+            actions.append({"action": "launch_survey", "survey": spec["name"],
+                            "survey_id": found.get("id")})
+    return actions
+
+
+def pending(actions: list) -> list:
+    return [a for a in actions if a["action"] != "noop"]
+
+
+def summarize(actions: list) -> str:
+    counts: dict = {}
+    for action in actions:
+        counts[action["action"]] = counts.get(action["action"], 0) + 1
+    if not pending(actions):
+        return "PostHog surveys in sync — nothing to do."
+    return "Pending: " + ", ".join(f"{v} {k}" for k, v in sorted(counts.items()) if k != "noop")
+
+
+def survey_url(app_host: str, project_id: str, survey_id) -> str:
+    return f"{app_host.rstrip('/')}/project/{project_id}/surveys/{survey_id}"
+
+
+class PostHogSurveyClient:
+    """Thin PostHog REST wrapper — only the survey calls this provisioner needs."""
+
+    def __init__(self, api_key: str, project_id: str, app_host: str = DEFAULT_APP_HOST) -> None:
+        self.project_id = project_id
+        self.app_host = app_host.rstrip("/")
+        self._base = f"{self.app_host}/api/projects/{project_id}"
+        self._headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        import requests
+        response = requests.request(method, f"{self._base}{path}", headers=self._headers,
+                                    timeout=30, **kwargs)
+        response.raise_for_status()
+        return response.json() if response.content else {}
+
+    def _paged(self, path: str) -> list:
+        import requests
+        results, url = [], f"{self._base}{path}"
+        while url:
+            response = requests.get(url, headers=self._headers, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+            results.extend(payload.get("results", []))
+            url = payload.get("next")
+        return results
+
+    def list_surveys(self) -> dict:
+        surveys = {}
+        for item in self._paged("/surveys/?limit=100"):
+            if item.get("archived"):
+                continue
+            surveys[item.get("name")] = item
+        return surveys
+
+    def create_survey(self, payload: dict):
+        return self._request("POST", "/surveys/", json=payload).get("id")
+
+    def update_survey(self, survey_id, payload: dict) -> None:
+        self._request("PATCH", f"/surveys/{survey_id}/", json=payload)
+
+    def launch_survey(self, survey_id, start_date: str) -> None:
+        self._request("PATCH", f"/surveys/{survey_id}/", json={"start_date": start_date})
+
+
+def apply_actions(client: PostHogSurveyClient, actions: list, dry_run: bool = True,
+                  now: Optional[datetime] = None) -> list:
+    """Execute the plan. `dry_run` reports without writing. Returns the log lines emitted."""
+    log: list = []
+    start_date = (now or datetime.now(timezone.utc)).isoformat()
+    for action in actions:
+        kind, name = action["action"], action.get("survey")
+        if kind == "noop":
+            log.append(f"survey '{name}' is in sync")
+        elif kind == "create_survey":
+            if dry_run:
+                log.append(f"[dry-run] create survey '{name}' (draft — launch it explicitly)")
+                continue
+            survey_id = client.create_survey(create_payload(action["spec"]))
+            log.append(f"created survey '{name}' -> {survey_id}")
+        elif kind == "update_survey":
+            fields = ", ".join(action.get("fields") or [])
+            if dry_run:
+                log.append(f"[dry-run] update survey '{name}' ({fields})")
+                continue
+            client.update_survey(action["survey_id"], update_payload(action["spec"]))
+            log.append(f"updated survey '{name}' ({fields})")
+        elif kind == "launch_survey":
+            if dry_run:
+                log.append(f"[dry-run] launch survey '{name}'")
+                continue
+            client.launch_survey(action["survey_id"], start_date)
+            log.append(f"launched survey '{name}'")
+    return log
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description="Provision LEM's PostHog NPS + CSAT surveys.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--apply", action="store_true", help="Write changes to PostHog.")
+    mode.add_argument("--dry-run", action="store_true", help="Report changes only (default).")
+    parser.add_argument("--print-spec", action="store_true",
+                        help="Print both survey specs as JSON and exit.")
+    parser.add_argument("--launch", action="store_true",
+                        help="Also launch a survey that has never been started.")
+    args = parser.parse_args(argv)
+
+    if args.print_spec:
+        print(json.dumps(build_specs(), indent=2, ensure_ascii=False))
+        return 0
+
+    api_key = os.getenv("POSTHOG_PERSONAL_API_KEY", "")
+    if not api_key:
+        print("POSTHOG_PERSONAL_API_KEY is not set — cannot reach PostHog.", file=sys.stderr)
+        return 1
+    project_id = os.getenv("POSTHOG_PROJECT_ID", DEFAULT_PROJECT_ID)
+    app_host = os.getenv("POSTHOG_APP_HOST", DEFAULT_APP_HOST)
+    dry_run = args.dry_run or not args.apply
+
+    client = PostHogSurveyClient(api_key, project_id, app_host)
+    try:
+        existing = client.list_surveys()
+    except Exception as exc:
+        print(f"Failed to read PostHog surveys: {exc}", file=sys.stderr)
+        return 1
+
+    actions = plan_actions(build_specs(), existing, launch=args.launch)
+    for line in apply_actions(client, actions, dry_run=dry_run):
+        print(line)
+    print(summarize(actions))
+    for name, survey in existing.items():
+        if name in {spec["name"] for spec in build_specs()}:
+            print(f"{name}: {survey_url(app_host, project_id, survey.get('id'))}")
+
+    if dry_run and pending(actions):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -928,6 +928,20 @@ class SurveyDismissRequest(BaseModel):
     survey_key: str = Field(min_length=1, max_length=_LEN_FEEDBACK_TYPE_HINT)
 
 
+class PostHogSurveyRequest(BaseModel):
+    """A PostHog Surveys answer relayed by the SPA (issue #653). `kind` says which of the two LEM
+    surveys answered — the score bounds are the KIND's, checked in the handler, because 0-10 and 1-5
+    can't both be a field constraint. `survey_id`/`survey_name` are PostHog's own, kept so a
+    `feedback` row can be lined up against the `survey sent` event the browser already emitted."""
+    session_token: str
+    kind: str = Field(min_length=1, max_length=_LEN_FEEDBACK_TYPE_HINT)
+    score: int = Field(ge=0, le=10)
+    comment: Optional[str] = Field(default=None, max_length=_LEN_FEEDBACK_BODY)
+    survey_id: Optional[str] = Field(default=None, max_length=64)
+    survey_name: Optional[str] = Field(default=None, max_length=128)
+    context: Optional[Dict[str, Any]] = None
+
+
 class ShippedNoticeAckRequest(BaseModel):
     """Acknowledging a "you asked, we shipped" notice (issue #502). `resolved` is the micro-CSAT:
     True/False answers "did this fix it?", None means the user just dismissed the notice."""
@@ -1046,10 +1060,41 @@ def dismiss_survey_endpoint(request: SurveyDismissRequest) -> ResponseModel:
                          detail={"dismissed": dismiss_survey(user_id, request.survey_key)})
 
 
+@router.post("/survey/posthog")
+def submit_posthog_survey_endpoint(request: PostHogSurveyRequest) -> ResponseModel:
+    """Capture a PostHog Surveys answer (issue #653) as a `feedback` row so it reaches the
+    feedback->auto-work loop. The browser has already emitted PostHog's own `survey sent`; this
+    handler deliberately does NOT emit the homegrown `survey_response` event, so one answer is
+    counted once."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    from cqc_lem.utilities.surveys import posthog_survey_kinds, record_posthog_survey_response
+    spec = posthog_survey_kinds().get(request.kind)
+    if spec is None:
+        raise HTTPException(status_code=422, detail=f"Unknown survey kind '{request.kind}'")
+    if not spec["min"] <= request.score <= spec["max"]:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Score {request.score} is outside {spec['min']}-{spec['max']} for "
+                   f"'{request.kind}'")
+
+    result = record_posthog_survey_response(
+        user_id, request.kind, request.score, comment=request.comment,
+        survey_id=request.survey_id, survey_name=request.survey_name,
+        context=_bounded_context(request.context))
+    if not result:
+        raise HTTPException(status_code=500, detail="Could not save your response")
+    log_info("PostHog survey response captured", user_id=user_id)
+    return ResponseModel(status_code=200, detail=result)
+
+
 @router.get("/user/survey")
 def survey_endpoint(session_token: str) -> ResponseModel:
     """The survey to show in-app right now (day-3 NPS, trial T-3d NPS, or the review that unlocks
-    the extended trial), or none (issue #501)."""
+    the extended trial), or none (issue #501). With PostHog Surveys on (issue #653) the NPS asks are
+    retired from this snapshot — PostHog is asking them."""
     user_id = get_session_user_id(session_token)
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
@@ -1822,6 +1867,11 @@ def auth_check_session(session_token: str) -> ResponseModel:
         "plan_status": profile.get("subscription_status"),
         "timezone": profile.get("timezone"),
         "created_at": _utc_iso(profile.get("created_at")),
+        # The two facts PostHog Surveys target on (issue #653). They ride on the session check
+        # because that is the call every authenticated page already makes — a survey that needed its
+        # own round trip would be a survey that never fired on the first page view.
+        "onboarding_completed_at": _utc_iso(profile.get("onboarding_completed_at")),
+        "posts_approved": int(profile.get("posts_approved") or 0),
     })
 
 

--- a/src/cqc_lem/ui/src/components/Layout.tsx
+++ b/src/cqc_lem/ui/src/components/Layout.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '../contexts/AuthContext'
 import AccountReadinessBanner from './AccountReadinessBanner'
 import FeedbackWidget from './FeedbackWidget'
 import Footer from './Footer'
+import PostHogSurveyModal from './PostHogSurveyModal'
 import ShippedNotice from './ShippedNotice'
 import SurveyModal from './SurveyModal'
 
@@ -83,6 +84,9 @@ export default function Layout() {
       <FeedbackWidget />
       {/* Survey modal — renders only when the server says a survey is due (issue #501) */}
       {user && <SurveyModal />}
+      {/* PostHog-targeted NPS/CSAT, drawn in LEM's own chrome (issue #653). Stands down whenever
+          the bespoke modal above has something to ask, so the two can never stack. */}
+      {user && <PostHogSurveyModal />}
     </div>
   )
 }

--- a/src/cqc_lem/ui/src/components/PostHogSurveyModal.tsx
+++ b/src/cqc_lem/ui/src/components/PostHogSurveyModal.tsx
@@ -11,8 +11,13 @@ import { useSurvey } from '../hooks/useSurvey'
 // PostHog. The two modals can never stack — a bespoke ask (the review that unlocks the extended
 // trial) outranks this one, because it is the one with something to give back.
 export default function PostHogSurveyModal() {
-  const { data: homegrown } = useSurvey()
-  const { parsed, submit, dismiss } = usePostHogSurvey()
+  const { data: homegrown, isLoading: homegrownLoading } = useSurvey()
+  // Until the bespoke snapshot has landed we do not yet know whether we are allowed to draw
+  // anything, and the hook must not claim a `survey shown` (or spend the 30-day wait period) for an
+  // ask this component would then refuse to render. `isLoading` — not `isPending` — because a query
+  // disabled for want of a session token is pending forever.
+  const blocked = homegrownLoading || !!homegrown?.survey
+  const { parsed, submit, dismiss } = usePostHogSurvey(blocked)
 
   const [score, setScore] = useState<number | null>(null)
   const [comment, setComment] = useState('')
@@ -20,7 +25,7 @@ export default function PostHogSurveyModal() {
   const [error, setError] = useState<string | null>(null)
   const [done, setDone] = useState(false)
 
-  if (!parsed || homegrown?.survey) return null
+  if (!parsed || blocked) return null
 
   const { rating, open } = parsed
   const choices = Array.from({ length: rating.max - rating.min + 1 }, (_, i) => rating.min + i)

--- a/src/cqc_lem/ui/src/components/PostHogSurveyModal.tsx
+++ b/src/cqc_lem/ui/src/components/PostHogSurveyModal.tsx
@@ -1,0 +1,124 @@
+import { useState } from 'react'
+import { usePostHogSurvey } from '../hooks/usePostHogSurvey'
+import { useSurvey } from '../hooks/useSurvey'
+
+// PostHog Surveys in LEM's own chrome (issue #653). PostHog decided this person should be asked;
+// this component draws the form, and the hook emits `survey sent` AND posts the answer into the
+// feedback->auto-work loop.
+//
+// Deliberately the same shell as SurveyModal rather than PostHog's popover: the popover renders
+// bottom-right, exactly where the feedback widget already lives, and its answer would never leave
+// PostHog. The two modals can never stack — a bespoke ask (the review that unlocks the extended
+// trial) outranks this one, because it is the one with something to give back.
+export default function PostHogSurveyModal() {
+  const { data: homegrown } = useSurvey()
+  const { parsed, submit, dismiss } = usePostHogSurvey()
+
+  const [score, setScore] = useState<number | null>(null)
+  const [comment, setComment] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [done, setDone] = useState(false)
+
+  if (!parsed || homegrown?.survey) return null
+
+  const { rating, open } = parsed
+  const choices = Array.from({ length: rating.max - rating.min + 1 }, (_, i) => rating.min + i)
+
+  async function send() {
+    if (score === null) return
+    setLoading(true)
+    setError(null)
+    try {
+      await submit(score, comment)
+      setDone(true)
+    } catch (err: unknown) {
+      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+      setError(typeof detail === 'string' ? detail : 'Could not save your answer. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-black/40 p-4">
+      <div className="relative w-full max-w-md bg-white border border-gray-200 rounded-xl shadow-xl p-5">
+        <button
+          onClick={dismiss}
+          className="absolute top-2 right-3 text-gray-400 hover:text-gray-600 text-xl leading-none"
+          aria-label="Close survey"
+        >
+          ×
+        </button>
+
+        {done ? (
+          <div className="pt-2">
+            <h2 className="text-sm font-bold text-gray-800 mb-1">Thanks 🙏</h2>
+            <p className="text-xs text-gray-500 mb-4">That goes straight to the team.</p>
+            <button
+              onClick={dismiss}
+              className="w-full bg-blue-600 text-white py-2 rounded-lg text-xs font-semibold hover:bg-blue-700 transition-colors"
+            >
+              Done
+            </button>
+          </div>
+        ) : (
+          <div className="space-y-3 pt-1">
+            <h2 className="text-sm font-bold text-gray-800">{rating.question}</h2>
+
+            <div
+              className="flex flex-wrap gap-1"
+              role="group"
+              aria-label={`Score ${rating.min} to ${rating.max}`}
+            >
+              {choices.map((n) => (
+                <button
+                  key={n}
+                  type="button"
+                  onClick={() => setScore(n)}
+                  aria-label={`Score ${n}`}
+                  aria-pressed={score === n}
+                  className={`w-8 h-8 rounded-lg border text-xs font-semibold ${
+                    score === n
+                      ? 'bg-blue-600 border-blue-600 text-white'
+                      : 'bg-white border-gray-300 text-gray-600 hover:border-blue-400'
+                  }`}
+                >
+                  {n}
+                </button>
+              ))}
+            </div>
+            {(rating.lowerBoundLabel || rating.upperBoundLabel) && (
+              <div className="flex justify-between text-[11px] text-gray-400">
+                <span>{rating.lowerBoundLabel}</span>
+                <span>{rating.upperBoundLabel}</span>
+              </div>
+            )}
+
+            {open && (
+              <textarea
+                rows={3}
+                maxLength={5000}
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                aria-label={open.question}
+                placeholder={open.question}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-xs focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+            )}
+
+            {error && <p className="text-xs text-red-600">{error}</p>}
+            <button
+              type="button"
+              onClick={send}
+              disabled={loading || score === null}
+              className="w-full bg-blue-600 text-white py-2 rounded-lg text-xs font-semibold hover:bg-blue-700 disabled:opacity-50 transition-colors"
+            >
+              {loading ? 'Sending…' : 'Submit'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/contexts/AuthContext.tsx
+++ b/src/cqc_lem/ui/src/contexts/AuthContext.tsx
@@ -16,6 +16,9 @@ interface SessionDetail {
   plan_status?: string | null
   timezone?: string | null
   created_at?: string | null
+  // What PostHog Surveys target on (issue #653).
+  onboarding_completed_at?: string | null
+  posts_approved?: number | null
 }
 
 interface AuthContextValue {
@@ -54,6 +57,8 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         planStatus: detail.plan_status,
         timezone: detail.timezone,
         createdAt: detail.created_at,
+        onboardingCompletedAt: detail.onboarding_completed_at,
+        postsApproved: detail.posts_approved,
       })
     }
   }

--- a/src/cqc_lem/ui/src/hooks/useFeatureFlags.ts
+++ b/src/cqc_lem/ui/src/hooks/useFeatureFlags.ts
@@ -23,6 +23,7 @@ export const FLAGS = {
   tutorialVideos: 'tutorial-videos-enabled',
   feedFallbackDefault: 'feed-fallback-when-empty-default',
   costRouting: 'cost-routing-enabled',
+  posthogSurveys: 'posthog-surveys-enabled',
 } as const
 
 export type FlagKey = (typeof FLAGS)[keyof typeof FLAGS]

--- a/src/cqc_lem/ui/src/hooks/usePostHogSurvey.flow.test.tsx
+++ b/src/cqc_lem/ui/src/hooks/usePostHogSurvey.flow.test.tsx
@@ -1,0 +1,170 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import type { ActiveSurvey } from '../utils/analytics'
+
+// The stateful half of the headless survey renderer (issue #653): one `survey shown` per ask, one
+// `survey sent` per answer even across a retry, and never a `dismissed` for a survey that was
+// actually completed — a survey product where those double up reports nonsense.
+
+const surveys: ActiveSurvey[] = []
+const capture = vi.fn()
+const markSurveySeen = vi.fn()
+const post = vi.fn()
+let flagEnabled = true
+let approvalListener: (() => void) | null = null
+
+vi.mock('../utils/analytics', () => ({
+  SURVEY_EVENTS: { shown: 'survey shown', sent: 'survey sent', dismissed: 'survey dismissed' },
+  analyticsEnabled: () => true,
+  capture: (...args: unknown[]) => capture(...args),
+  markSurveySeen: (...args: unknown[]) => markSurveySeen(...args),
+  activeMatchingSurveys: (cb: (s: ActiveSurvey[]) => void) => cb(surveys),
+  onPostApproval: (listener: () => void) => {
+    approvalListener = listener
+    return () => {
+      approvalListener = null
+    }
+  },
+}))
+vi.mock('../api/client', () => ({ default: { post: (...args: unknown[]) => post(...args) } }))
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ sessionToken: 'tok' }) }))
+vi.mock('./useFeatureFlags', () => ({
+  FLAGS: { posthogSurveys: 'posthog-surveys-enabled' },
+  useFeatureFlag: () => flagEnabled,
+}))
+
+const { SURVEY_NAMES, usePostHogSurvey } = await import('./usePostHogSurvey')
+
+function nps(): ActiveSurvey {
+  return {
+    id: '0199-nps',
+    name: SURVEY_NAMES.nps,
+    type: 'api',
+    questions: [
+      {
+        type: 'rating',
+        id: 'q-rating',
+        question: 'How likely are you to recommend LEM?',
+        display: 'number',
+        scale: 10,
+        lowerBoundLabel: 'Not likely',
+        upperBoundLabel: 'Very likely',
+      },
+      { type: 'open', id: 'q-open', question: 'Why?' },
+    ],
+    current_iteration: null,
+    current_iteration_start_date: null,
+  } as unknown as ActiveSurvey
+}
+
+function events(name: string) {
+  return capture.mock.calls.filter((call) => call[0] === name)
+}
+
+beforeEach(() => {
+  surveys.length = 0
+  surveys.push(nps())
+  capture.mockReset()
+  markSurveySeen.mockReset()
+  post.mockReset()
+  post.mockResolvedValue({ data: { detail: {} } })
+  flagEnabled = true
+})
+afterEach(cleanup)
+
+describe('usePostHogSurvey', () => {
+  it('shows the eligible survey once and records the ask with posthog-js', async () => {
+    const { result } = renderHook(() => usePostHogSurvey())
+    await waitFor(() => expect(result.current.parsed?.kind).toBe('nps'))
+    expect(events('survey shown')).toHaveLength(1)
+    // Without this, posthog's own seen/wait-period checks never advance and the 30-day throttle
+    // silently stops working — we render, so the SDK never sees the ask itself.
+    expect(markSurveySeen).toHaveBeenCalledWith('0199-nps', null)
+  })
+
+  it('shows nothing while the flag is off', async () => {
+    flagEnabled = false
+    const { result } = renderHook(() => usePostHogSurvey())
+    await waitFor(() => expect(result.current.parsed).toBeNull())
+    expect(capture).not.toHaveBeenCalled()
+  })
+
+  it('sends the answer to PostHog and to the feedback loop', async () => {
+    const { result } = renderHook(() => usePostHogSurvey())
+    await waitFor(() => expect(result.current.parsed).not.toBeNull())
+
+    await act(async () => {
+      await result.current.submit(3, '  The comments read like a bot  ')
+    })
+
+    const [sent] = events('survey sent')
+    expect(sent[1].$survey_id).toBe('0199-nps')
+    expect(sent[1].$survey_response).toBe(3)
+    expect(post).toHaveBeenCalledWith('/survey/posthog', {
+      session_token: 'tok',
+      kind: 'nps',
+      score: 3,
+      comment: 'The comments read like a bot',
+      survey_id: '0199-nps',
+      survey_name: SURVEY_NAMES.nps,
+    })
+  })
+
+  it('emits ONE survey sent even when the API call fails and the user retries', async () => {
+    post.mockRejectedValueOnce(new Error('502'))
+    const { result } = renderHook(() => usePostHogSurvey())
+    await waitFor(() => expect(result.current.parsed).not.toBeNull())
+
+    await act(async () => {
+      await expect(result.current.submit(9, '')).rejects.toThrow('502')
+    })
+    await act(async () => {
+      await result.current.submit(9, '')
+    })
+
+    expect(events('survey sent')).toHaveLength(1)
+    expect(post).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not record a dismissal for a survey that was answered', async () => {
+    const { result } = renderHook(() => usePostHogSurvey())
+    await waitFor(() => expect(result.current.parsed).not.toBeNull())
+
+    await act(async () => {
+      await result.current.submit(10, '')
+    })
+    act(() => result.current.dismiss())
+
+    expect(events('survey dismissed')).toHaveLength(0)
+    expect(result.current.parsed).toBeNull()
+  })
+
+  it('records a dismissal when the user closes without answering', async () => {
+    const { result } = renderHook(() => usePostHogSurvey())
+    await waitFor(() => expect(result.current.parsed).not.toBeNull())
+
+    act(() => result.current.dismiss())
+
+    expect(events('survey dismissed')).toHaveLength(1)
+    expect(result.current.parsed).toBeNull()
+  })
+
+  it('re-checks eligibility on an approval without re-showing the survey on screen', async () => {
+    const { result } = renderHook(() => usePostHogSurvey())
+    await waitFor(() => expect(result.current.parsed).not.toBeNull())
+
+    act(() => approvalListener?.())
+    await waitFor(() => expect(events('survey shown')).toHaveLength(1))
+    expect(result.current.parsed?.survey.id).toBe('0199-nps')
+  })
+
+  it('shows a survey that only becomes eligible after an approval', async () => {
+    surveys.length = 0
+    const { result } = renderHook(() => usePostHogSurvey())
+    await waitFor(() => expect(result.current.parsed).toBeNull())
+
+    surveys.push(nps())
+    act(() => approvalListener?.())
+    await waitFor(() => expect(result.current.parsed?.kind).toBe('nps'))
+  })
+})

--- a/src/cqc_lem/ui/src/hooks/usePostHogSurvey.flow.test.tsx
+++ b/src/cqc_lem/ui/src/hooks/usePostHogSurvey.flow.test.tsx
@@ -82,6 +82,23 @@ describe('usePostHogSurvey', () => {
     expect(markSurveySeen).toHaveBeenCalledWith('0199-nps', null)
   })
 
+  it('claims nothing while paused, then asks once it is allowed to draw', async () => {
+    // Paused means a bespoke ask owns the screen (or we do not know yet). `survey shown` and
+    // markSurveySeen are claims the user SAW it — emitting either here would understate the
+    // response rate and spend the 30-day wait period on an ask nobody ever rendered.
+    const { result, rerender } = renderHook(({ paused }) => usePostHogSurvey(paused), {
+      initialProps: { paused: true },
+    })
+    await waitFor(() => expect(result.current.parsed).toBeNull())
+    expect(capture).not.toHaveBeenCalled()
+    expect(markSurveySeen).not.toHaveBeenCalled()
+
+    rerender({ paused: false })
+    await waitFor(() => expect(result.current.parsed?.kind).toBe('nps'))
+    expect(events('survey shown')).toHaveLength(1)
+    expect(markSurveySeen).toHaveBeenCalledTimes(1)
+  })
+
   it('shows nothing while the flag is off', async () => {
     flagEnabled = false
     const { result } = renderHook(() => usePostHogSurvey())

--- a/src/cqc_lem/ui/src/hooks/usePostHogSurvey.test.tsx
+++ b/src/cqc_lem/ui/src/hooks/usePostHogSurvey.test.tsx
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import { parseSurvey, surveyEventProps, surveyResponseProps, SURVEY_NAMES } from './usePostHogSurvey'
+import type { ActiveSurvey } from '../utils/analytics'
+
+// The pure half of the headless survey renderer (issue #653): which survey we agree to draw, and
+// the `survey sent` payload PostHog's Surveys product reads. Both are contracts with something
+// outside this repo, so they get asserted rather than eyeballed.
+
+afterEach(() => vi.restoreAllMocks())
+
+function survey(overrides: Record<string, unknown> = {}): ActiveSurvey {
+  return {
+    id: '0199-nps',
+    name: SURVEY_NAMES.nps,
+    type: 'api',
+    questions: [
+      {
+        type: 'rating',
+        id: 'q-rating',
+        question: 'How likely are you to recommend LEM to a colleague?',
+        display: 'number',
+        scale: 10,
+        lowerBoundLabel: 'Not at all likely',
+        upperBoundLabel: 'Extremely likely',
+      },
+      { type: 'open', id: 'q-open', question: "What's the main reason for your score?" },
+    ],
+    current_iteration: null,
+    current_iteration_start_date: null,
+    ...overrides,
+  } as unknown as ActiveSurvey
+}
+
+describe('parseSurvey', () => {
+  it('reads the NPS survey as a 0-10 band', () => {
+    const parsed = parseSurvey([survey()])
+    expect(parsed?.kind).toBe('nps')
+    expect(parsed?.rating.min).toBe(0)
+    expect(parsed?.rating.max).toBe(10)
+    expect(parsed?.rating.lowerBoundLabel).toBe('Not at all likely')
+    expect(parsed?.open?.question).toBe("What's the main reason for your score?")
+  })
+
+  it('reads the CSAT survey as a 1-5 scale', () => {
+    // PostHog's 10-point rating IS the NPS band and starts at 0; every other scale starts at 1.
+    const csat = survey({
+      id: '0199-csat',
+      name: SURVEY_NAMES.csat,
+      questions: [
+        { type: 'rating', id: 'r', question: 'How happy are you?', display: 'number', scale: 5 },
+      ],
+    })
+    const parsed = parseSurvey([csat])
+    expect(parsed?.kind).toBe('csat')
+    expect(parsed?.rating.min).toBe(1)
+    expect(parsed?.rating.max).toBe(5)
+    expect(parsed?.open).toBeNull()
+  })
+
+  it('ignores a survey LEM does not own', () => {
+    // Someone creating a marketing survey in the PostHog UI must not have it drawn by a component
+    // that only knows how to render a rating plus an optional "why".
+    expect(parseSurvey([survey({ name: 'Pricing research' })])).toBeNull()
+  })
+
+  it('skips one of ours that has no rating question', () => {
+    const broken = survey({ questions: [{ type: 'open', id: 'o', question: 'Thoughts?' }] })
+    expect(parseSurvey([broken])).toBeNull()
+  })
+
+  it('picks the first LEM survey out of a mixed list', () => {
+    const parsed = parseSurvey([survey({ name: 'Pricing research' }), survey()])
+    expect(parsed?.survey.id).toBe('0199-nps')
+  })
+
+  it('is empty for an empty eligible set', () => {
+    expect(parseSurvey([])).toBeNull()
+  })
+})
+
+describe('survey event properties', () => {
+  it('carries the survey identity on every event so shown and sent line up', () => {
+    expect(surveyEventProps(survey())).toEqual({
+      $survey_id: '0199-nps',
+      $survey_name: SURVEY_NAMES.nps,
+      $survey_iteration: null,
+      $survey_iteration_start_date: null,
+    })
+  })
+
+  it('reports an iteration when the survey is on one', () => {
+    const props = surveyEventProps(
+      survey({ current_iteration: 2, current_iteration_start_date: '2026-07-01T00:00:00Z' })
+    )
+    expect(props.$survey_iteration).toBe(2)
+    expect(props.$survey_iteration_start_date).toBe('2026-07-01T00:00:00Z')
+  })
+
+  it('emits the response in PostHog own shape — by index AND by question id', () => {
+    const props = surveyResponseProps(survey(), [9, 'It sounds like me'])
+    expect(props.$survey_response).toBe(9)
+    expect(props.$survey_response_1).toBe('It sounds like me')
+    expect(props['$survey_response_q-rating']).toBe(9)
+    expect(props['$survey_response_q-open']).toBe('It sounds like me')
+    expect(props.$survey_completed).toBe(true)
+    expect(props.$survey_questions).toEqual([
+      {
+        id: 'q-rating',
+        question: 'How likely are you to recommend LEM to a colleague?',
+        response: 9,
+      },
+      { id: 'q-open', question: "What's the main reason for your score?", response: 'It sounds like me' },
+    ])
+  })
+
+  it('leaves a skipped open question out of the response keys but keeps it in the questions list', () => {
+    const props = surveyResponseProps(survey(), [10, null])
+    expect(props.$survey_response).toBe(10)
+    expect('$survey_response_1' in props).toBe(false)
+    expect((props.$survey_questions as Array<{ response: unknown }>)[1].response).toBeNull()
+  })
+
+  it('does not treat a zero score as a skipped answer', () => {
+    // A detractor scoring 0 is the single most important response there is; a falsy check here
+    // would silently drop it.
+    const props = surveyResponseProps(survey(), [0, null])
+    expect(props.$survey_response).toBe(0)
+  })
+})
+
+describe('recordPostApproval', () => {
+  beforeEach(() => vi.resetModules())
+
+  it('notifies survey subscribers so the CSAT can be re-checked at the approval', async () => {
+    const analytics = await import('../utils/analytics')
+    const seen: number[] = []
+    const off = analytics.onPostApproval(() => seen.push(1))
+    analytics.recordPostApproval({ post_id: 1 })
+    analytics.recordPostApproval({ post_id: 2 })
+    off()
+    analytics.recordPostApproval({ post_id: 3 })
+    expect(seen).toHaveLength(2)
+  })
+
+  it('survives a listener that throws — analytics must never break an approval', async () => {
+    const analytics = await import('../utils/analytics')
+    const off = analytics.onPostApproval(() => {
+      throw new Error('boom')
+    })
+    expect(() => analytics.recordPostApproval()).not.toThrow()
+    off()
+  })
+})

--- a/src/cqc_lem/ui/src/hooks/usePostHogSurvey.ts
+++ b/src/cqc_lem/ui/src/hooks/usePostHogSurvey.ts
@@ -1,0 +1,211 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import api from '../api/client'
+import { useAuth } from '../contexts/AuthContext'
+import { FLAGS, useFeatureFlag } from './useFeatureFlags'
+import {
+  SURVEY_EVENTS,
+  activeMatchingSurveys,
+  analyticsEnabled,
+  capture,
+  markSurveySeen,
+  onPostApproval,
+} from '../utils/analytics'
+import type { ActiveSurvey } from '../utils/analytics'
+
+// PostHog Surveys, rendered headless (issue #653, docs/surveys.md).
+//
+// PostHog owns WHO gets asked and WHEN — targeting on person properties, event triggers and the
+// wait-between-surveys throttle, all editable without a deploy. This hook owns the rest: it renders
+// the survey in LEM's own modal, emits PostHog's native `survey shown`/`sent`/`dismissed` so the
+// response shows up in the Surveys product, AND posts the same answer to the API so it becomes a
+// `feedback` row in the auto-work loop. A popover survey would have given us the first half only,
+// and a score nobody can act on is not worth asking for.
+
+// The names are the contract with scripts/posthog_surveys.py (which creates the surveys) and
+// utilities/surveys.py (which maps a kind onto a feedback source). Matching on name is also the
+// guard that stops an unrelated survey someone creates in the PostHog UI from being drawn by a
+// component that only knows how to render a rating plus an optional "why".
+export const SURVEY_NAMES = {
+  nps: 'LEM NPS',
+  csat: 'LEM CSAT — post quality',
+} as const
+
+export type SurveyKind = keyof typeof SURVEY_NAMES
+
+type RatingQuestion = {
+  index: number
+  question: string
+  scale: number
+  min: number
+  max: number
+  lowerBoundLabel: string
+  upperBoundLabel: string
+}
+
+type OpenQuestion = { index: number; question: string }
+
+export interface ParsedSurvey {
+  kind: SurveyKind
+  survey: ActiveSurvey
+  rating: RatingQuestion
+  open: OpenQuestion | null
+}
+
+function kindOf(name: string | undefined): SurveyKind | null {
+  const match = (Object.keys(SURVEY_NAMES) as SurveyKind[]).find((k) => SURVEY_NAMES[k] === name)
+  return match ?? null
+}
+
+// PostHog's 10-point rating IS the 0-10 NPS band; every other scale starts at 1. That single rule
+// is why the same component can draw both surveys.
+function boundsFor(scale: number): { min: number; max: number } {
+  return scale === 10 ? { min: 0, max: 10 } : { min: 1, max: scale }
+}
+
+/** The first LEM survey in `surveys` we know how to draw, or null. Pure — the modal's whole
+ * decision, testable without posthog-js. */
+export function parseSurvey(surveys: ActiveSurvey[]): ParsedSurvey | null {
+  for (const survey of surveys ?? []) {
+    const kind = kindOf(survey?.name)
+    if (!kind) continue
+    const questions = survey.questions ?? []
+    const ratingIndex = questions.findIndex((q) => q.type === 'rating')
+    if (ratingIndex < 0) continue
+    const rating = questions[ratingIndex] as { question: string; scale?: number }
+    const scale = Number(rating.scale) || 10
+    const openIndex = questions.findIndex((q) => q.type === 'open')
+    return {
+      kind,
+      survey,
+      rating: {
+        index: ratingIndex,
+        question: rating.question,
+        scale,
+        ...boundsFor(scale),
+        lowerBoundLabel:
+          (questions[ratingIndex] as { lowerBoundLabel?: string }).lowerBoundLabel || '',
+        upperBoundLabel:
+          (questions[ratingIndex] as { upperBoundLabel?: string }).upperBoundLabel || '',
+      },
+      open:
+        openIndex >= 0
+          ? { index: openIndex, question: questions[openIndex].question }
+          : null,
+    }
+  }
+  return null
+}
+
+/** The identity properties every survey event carries, so `survey shown` and `survey sent` line up
+ * on the same survey in PostHog. */
+export function surveyEventProps(survey: ActiveSurvey): Record<string, unknown> {
+  return {
+    $survey_id: survey.id,
+    $survey_name: survey.name,
+    $survey_iteration: survey.current_iteration ?? null,
+    $survey_iteration_start_date: survey.current_iteration_start_date ?? null,
+  }
+}
+
+/** `survey sent` properties in PostHog's own shape: `$survey_response` for the first question,
+ * `$survey_response_<n>` for the rest, the by-question-id keys the newer schema reads, and
+ * `$survey_questions` carrying the text alongside each answer. Emitting what the SDK emits is what
+ * makes a headless response indistinguishable from a popover one in the Surveys product. */
+export function surveyResponseProps(
+  survey: ActiveSurvey,
+  answers: Array<string | number | null>
+): Record<string, unknown> {
+  const props: Record<string, unknown> = { ...surveyEventProps(survey), $survey_completed: true }
+  const questions = (survey.questions ?? []).map((question, index) => {
+    const response = answers[index] ?? null
+    const filled = response !== null && response !== ''
+    if (filled) {
+      props[index === 0 ? '$survey_response' : `$survey_response_${index}`] = response
+      if (question.id) props[`$survey_response_${question.id}`] = response
+    }
+    return { id: question.id, question: question.question, response }
+  })
+  props.$survey_questions = questions
+  return props
+}
+
+export interface PostHogSurveyState {
+  parsed: ParsedSurvey | null
+  submit: (score: number, comment: string) => Promise<void>
+  dismiss: () => void
+}
+
+/** The PostHog survey to show right now, plus the two ways it ends. */
+export function usePostHogSurvey(): PostHogSurveyState {
+  const { sessionToken } = useAuth()
+  const enabled = useFeatureFlag(FLAGS.posthogSurveys, false)
+  const [parsed, setParsed] = useState<ParsedSurvey | null>(null)
+  const [closed, setClosed] = useState(false)
+  // An approval is the ONE moment CSAT eligibility can newly become true, so it re-runs the check
+  // with a forced reload instead of the SPA polling PostHog for a state that changes twice a month.
+  const [approvals, setApprovals] = useState(0)
+  // Ask-once bookkeeping for THIS page load. markSurveySeen() covers reloads; this covers the
+  // re-check an approval triggers while the same survey is already on screen.
+  const shown = useRef<string | null>(null)
+  // The survey we have already emitted `survey sent` for. It makes the response event idempotent
+  // across a retry after a failed POST, and it is what stops the "Done" button on the thank-you
+  // screen recording a DISMISSAL of a survey the user actually completed.
+  const sent = useRef<string | null>(null)
+
+  useEffect(() => onPostApproval(() => setApprovals((n) => n + 1)), [])
+
+  useEffect(() => {
+    // Nothing to clear on the way out: with the flag off (or analytics off, or logged out) nothing
+    // was ever set, and a logout unmounts the modal Layout only renders for a signed-in user.
+    if (!enabled || !sessionToken || !analyticsEnabled()) return
+    let live = true
+    activeMatchingSurveys((surveys) => {
+      if (!live) return
+      const next = parseSurvey(surveys)
+      if (!next) return
+      if (shown.current === next.survey.id) return
+      shown.current = next.survey.id
+      setClosed(false)
+      setParsed(next)
+      capture(SURVEY_EVENTS.shown, surveyEventProps(next.survey))
+      // Record the ask with posthog-js itself, or its seen/wait-period checks — the throttle the
+      // whole design leans on — would never know this survey was displayed.
+      markSurveySeen(next.survey.id, next.survey.current_iteration)
+    }, approvals > 0)
+    return () => {
+      live = false
+    }
+  }, [enabled, sessionToken, approvals])
+
+  const dismiss = useCallback(() => {
+    setClosed(true)
+    if (!parsed || sent.current === parsed.survey.id) return
+    capture(SURVEY_EVENTS.dismissed, surveyEventProps(parsed.survey))
+  }, [parsed])
+
+  const submit = useCallback(
+    async (score: number, comment: string) => {
+      if (!parsed) return
+      const answers: Array<string | number | null> = []
+      answers[parsed.rating.index] = score
+      if (parsed.open) answers[parsed.open.index] = comment.trim() || null
+      // PostHog first: the analytics record of the response must not depend on LEM's API being up.
+      // Once per survey, so a retry after a failed POST doesn't count the answer twice.
+      if (sent.current !== parsed.survey.id) {
+        sent.current = parsed.survey.id
+        capture(SURVEY_EVENTS.sent, surveyResponseProps(parsed.survey, answers))
+      }
+      await api.post('/survey/posthog', {
+        session_token: sessionToken,
+        kind: parsed.kind,
+        score,
+        comment: comment.trim() || null,
+        survey_id: parsed.survey.id,
+        survey_name: parsed.survey.name,
+      })
+    },
+    [parsed, sessionToken]
+  )
+
+  return { parsed: closed ? null : parsed, submit, dismiss }
+}

--- a/src/cqc_lem/ui/src/hooks/usePostHogSurvey.ts
+++ b/src/cqc_lem/ui/src/hooks/usePostHogSurvey.ts
@@ -135,8 +135,14 @@ export interface PostHogSurveyState {
   dismiss: () => void
 }
 
-/** The PostHog survey to show right now, plus the two ways it ends. */
-export function usePostHogSurvey(): PostHogSurveyState {
+/** The PostHog survey to show right now, plus the two ways it ends.
+ *
+ * `paused` is the caller saying "I would not draw it even if you found one" — a bespoke ask already
+ * has the screen, or the snapshot that decides has not landed yet. It has to gate the LOOKUP, not
+ * just the render: `survey shown` and `markSurveySeen()` are claims that the user saw the ask, and
+ * emitting them for a survey nobody drew both understates the response rate and burns the 30-day
+ * wait period that silences BOTH surveys. */
+export function usePostHogSurvey(paused = false): PostHogSurveyState {
   const { sessionToken } = useAuth()
   const enabled = useFeatureFlag(FLAGS.posthogSurveys, false)
   const [parsed, setParsed] = useState<ParsedSurvey | null>(null)
@@ -157,7 +163,7 @@ export function usePostHogSurvey(): PostHogSurveyState {
   useEffect(() => {
     // Nothing to clear on the way out: with the flag off (or analytics off, or logged out) nothing
     // was ever set, and a logout unmounts the modal Layout only renders for a signed-in user.
-    if (!enabled || !sessionToken || !analyticsEnabled()) return
+    if (paused || !enabled || !sessionToken || !analyticsEnabled()) return
     let live = true
     activeMatchingSurveys((surveys) => {
       if (!live) return
@@ -175,7 +181,7 @@ export function usePostHogSurvey(): PostHogSurveyState {
     return () => {
       live = false
     }
-  }, [enabled, sessionToken, approvals])
+  }, [paused, enabled, sessionToken, approvals])
 
   const dismiss = useCallback(() => {
     setClosed(true)

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -17,7 +17,7 @@ import ComposePost from './content/ComposePost'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
 import { formatInTimezone, toZonedInputValue, zonedInputToUtcIso } from '../utils/datetime'
-import { EVENTS, capture, maskProps } from '../utils/analytics'
+import { EVENTS, capture, maskProps, recordPostApproval } from '../utils/analytics'
 
 // Consolidated content hub: compose posts, schedule DMs, manage newsletters, and review/edit
 // existing content — one page, four tabs, synced to ?tab= for deep-linking.
@@ -213,12 +213,16 @@ export default function ContentStudio() {
     if (status !== 'approved' && status !== 'rejected') return
     const post = posts.find((p) => p.post_id === postId)
     if (post?.status === status) return
-    capture(status === 'approved' ? EVENTS.postApproved : EVENTS.postRejected, {
+    const properties = {
       post_id: postId,
       post_type: post?.post_type ?? null,
       archetype: post?.archetype ?? null,
       ...extra,
-    })
+    }
+    // An approval also advances the `posts_approved` person property the CSAT survey is gated on
+    // (issue #653) — same event either way, one extra person update on the approve path.
+    if (status === 'approved') recordPostApproval(properties)
+    else capture(EVENTS.postRejected, properties)
   }
 
   const updateMutation = useMutation({

--- a/src/cqc_lem/ui/src/utils/analytics.ts
+++ b/src/cqc_lem/ui/src/utils/analytics.ts
@@ -8,7 +8,7 @@
 // Disabled means DISABLED: with no VITE_POSTHOG_KEY the posthog-js chunk is never imported, so the
 // build ships it as a separate lazy chunk the browser never fetches and no request is ever made.
 
-import type { PostHog } from 'posthog-js'
+import type { PostHog, Survey } from 'posthog-js'
 
 const KEY = import.meta.env.VITE_POSTHOG_KEY as string | undefined
 const HOST = (import.meta.env.VITE_POSTHOG_HOST as string | undefined) || 'https://us.i.posthog.com'
@@ -184,7 +184,16 @@ export type AnalyticsIdentity = {
   planStatus?: string | null
   timezone?: string | null
   createdAt?: string | null
+  // The two facts PostHog Surveys target on (issue #653). Both are set on EVERY identify because
+  // both change — an approval count frozen at $set_once would gate the CSAT forever.
+  onboardingCompletedAt?: string | null
+  postsApproved?: number | null
 }
+
+// The approval count this browser last told PostHog about, so recordPostApproval() can keep the
+// person property in step within a session instead of waiting for the next session check. null
+// means we never had a server-side baseline and must not invent one.
+let approvedCount: number | null = null
 
 // Unify the anonymous browser person with the backend's str(user_id) person. Plan facts are set on
 // every call (they change); the signup date is $set_once so a later call can't rewrite history.
@@ -195,14 +204,88 @@ export function identifyUser(identity: AnalyticsIdentity): void {
   if (identity.plan) props.plan = identity.plan
   if (identity.planStatus) props.plan_status = identity.planStatus
   if (identity.timezone) props.timezone = identity.timezone
+  if (identity.onboardingCompletedAt) props.onboarding_completed_at = identity.onboardingCompletedAt
+  if (typeof identity.postsApproved === 'number') {
+    approvedCount = identity.postsApproved
+    props.posts_approved = identity.postsApproved
+  }
   const setOnce = identity.createdAt ? { created_at: identity.createdAt } : undefined
   withClient((ph) => ph.identify(String(identity.userId), props, setOnce))
+}
+
+// A post-review decision that went APPROVED. Captures the product event and advances the
+// `posts_approved` person property the CSAT survey is gated on, so the ask can fire on the approval
+// that crosses the threshold rather than one session later. With no server baseline (analytics
+// identified before the session check landed) only the event is sent — a made-up count would target
+// the survey at the wrong people.
+export function recordPostApproval(properties?: Record<string, unknown>): void {
+  capture(EVENTS.postApproved, properties)
+  if (approvedCount !== null) {
+    const total = (approvedCount += 1)
+    withClient((ph) => ph.setPersonProperties({ posts_approved: total }))
+  }
+  approvalListeners.forEach((listener) => {
+    try {
+      listener()
+    } catch {
+      // A listener must never break the capture that triggered it.
+    }
+  })
+}
+
+// The CSAT survey is triggered by an approval, and its eligibility can only change AT one — so the
+// survey hook subscribes here rather than polling. Kept in this module because it is the same event
+// `recordPostApproval` reports to PostHog; two places emitting "a post was approved" would drift.
+const approvalListeners = new Set<() => void>()
+
+export function onPostApproval(listener: () => void): () => void {
+  approvalListeners.add(listener)
+  return () => {
+    approvalListeners.delete(listener)
+  }
 }
 
 // Logout must break the link between this browser and the person, or the next user on the same
 // machine inherits their events.
 export function resetAnalytics(): void {
+  approvedCount = null
   withClient((ph) => ph.reset())
+}
+
+// --- PostHog Surveys, rendered headless (issue #653) ------------------------------------------
+// The surveys themselves are `api` type, so posthog-js never draws anything: it decides WHO is
+// eligible and we draw the form. These three wrappers are the whole surface the survey components
+// need, which keeps this module the SPA's ONE PostHog reader.
+
+export const SURVEY_EVENTS = {
+  shown: 'survey shown',
+  sent: 'survey sent',
+  dismissed: 'survey dismissed',
+} as const
+
+export type ActiveSurvey = Survey
+
+// Surveys whose targeting + display conditions the current person satisfies right now. `reload`
+// forces a fresh fetch — used right after an event that can newly qualify someone (a post
+// approval), where the cached definition set would still say "not eligible".
+export function activeMatchingSurveys(
+  callback: (surveys: ActiveSurvey[]) => void,
+  reload = false
+): void {
+  if (!KEY) {
+    callback([])
+    return
+  }
+  withClient((ph) => ph.getActiveMatchingSurveys((surveys) => callback(surveys ?? []), reload))
+}
+
+// Tell posthog-js we displayed this survey. Without it the SDK has no record of the ask, so its
+// "already seen" and wait-between-surveys checks would offer the same survey again on every load —
+// those checks are local state the SDK only writes when IT renders.
+export function markSurveySeen(surveyId: string, iteration?: number | null): void {
+  // `surveys` is a tree-shakeable extension, so it is legitimately absent in a build that dropped
+  // it — an optional call, not a defensive one.
+  withClient((ph) => ph.surveys?.markSurveyAsSeen?.(surveyId, { iteration: iteration ?? null }))
 }
 
 export function capture(event: string, properties?: Record<string, unknown>): void {

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2784,15 +2784,25 @@ def get_user_analytics_profile(user_id: int) -> dict:
     """The non-sensitive person facts the SPA sets on the PostHog person at $identify (issue #646):
     plan tier/status, timezone and the signup timestamp. `users` has no created_at column, so the
     signup time is trial_started_at falling back to updated_at — the same convention the cohort
-    query uses. Never returns credentials; the SPA already knows the email."""
+    query uses. Never returns credentials; the SPA already knows the email.
+
+    Issue #653 adds the two facts PostHog Surveys TARGET on: when onboarding actually completed (the
+    activation "aha", not signup — a user who signed up and stalled has no opinion worth surveying)
+    and how many posts the user has ever approved. "Ever approved" is deliberately not
+    `status='approved'`: an approved post moves on to scheduled and then posted, so counting the
+    current status alone would reset the tally the moment automation ran."""
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            "SELECT subscription_tier, subscription_status, timezone, "
-            "COALESCE(trial_started_at, updated_at) AS created_at "
-            "FROM users WHERE id = %s",
-            (user_id,))
+            "SELECT u.subscription_tier, u.subscription_status, u.timezone, "
+            "COALESCE(u.trial_started_at, u.updated_at) AS created_at, "
+            "o.activated_at AS onboarding_completed_at, "
+            "(SELECT COUNT(*) FROM posts p WHERE p.user_id = u.id "
+            " AND p.status IN (%s, %s, %s)) AS posts_approved "
+            "FROM users u LEFT JOIN onboarding_state o ON o.user_id = u.id "
+            "WHERE u.id = %s",
+            (str(PostStatus.APPROVED), str(PostStatus.SCHEDULED), str(PostStatus.POSTED), user_id))
         row = cursor.fetchone()
         return row or {}
     except mysql.connector.Error as err:

--- a/src/cqc_lem/utilities/flags.py
+++ b/src/cqc_lem/utilities/flags.py
@@ -70,6 +70,7 @@ COMMENT_RESEARCH = "comment-research-enabled"
 TUTORIAL_VIDEOS = "tutorial-videos-enabled"
 FEED_FALLBACK_DEFAULT = "feed-fallback-when-empty-default"
 COST_ROUTING = "cost-routing-enabled"
+POSTHOG_SURVEYS = "posthog-surveys-enabled"
 
 FLAGS: Dict[str, FlagSpec] = {
     spec.key: spec for spec in (
@@ -109,6 +110,17 @@ FLAGS: Dict[str, FlagSpec] = {
                          "into the routing policy document. The proxy's own "
                          "COST_AWARE_ROUTING_ENABLED is a SEPARATE switch and is deliberately NOT a "
                          "flag: routing_policy.py must stay stdlib-only."),
+        ),
+        FlagSpec(
+            key=POSTHOG_SURVEYS,
+            env_var="POSTHOG_SURVEYS_ENABLED",
+            default=False,
+            owner="growth",
+            description=("PostHog Surveys own NPS + the post-quality CSAT (issue #653). ON hands "
+                         "those two asks to PostHog's targeting and stands the homegrown NPS "
+                         "scheduler down, so a user is never prompted twice. The bespoke asks — the "
+                         "review that unlocks the extended trial, the per-issue fix CSAT — are "
+                         "unaffected either way."),
         ),
     )
 }

--- a/src/cqc_lem/utilities/surveys.py
+++ b/src/cqc_lem/utilities/surveys.py
@@ -14,6 +14,10 @@ A review row is also the gate on the extended trial (issue #499): `db.has_review
 Issue #502 adds a fourth, per-issue survey: the micro-CSAT asked after a fix the user reported
 ships ("did this fix it?"). Its key is BUILT (`fix_csat_<issue>`) rather than listed in `_SURVEYS`,
 and it is scheduled by the shipped-notice queue rather than by `select_survey`.
+
+Issue #653 hands TWO asks to PostHog Surveys — the NPS and a post-quality CSAT — while leaving the
+bespoke ones here. See the "PostHog Surveys" section at the bottom of this module and docs/surveys.md
+for who owns what and why nothing is ever asked twice.
 """
 
 from datetime import datetime, timedelta
@@ -110,12 +114,16 @@ def select_survey(activated_at: Optional[datetime] = None,
                   nps_answered_at: Optional[datetime] = None,
                   review_answered_at: Optional[datetime] = None,
                   sent_keys=(), last_sent_at: Optional[datetime] = None,
-                  now: Optional[datetime] = None) -> Optional[dict]:
+                  now: Optional[datetime] = None, nps_enabled: bool = True) -> Optional[dict]:
     """The one survey worth asking this user right now, or None.
 
     Rules: each survey is asked at most once (`sent_keys`); at most one ask per
     SURVEY_COOLDOWN_HOURS (`last_sent_at`); an already-answered survey is never re-asked. At trial
-    T-3d the review offer outranks NPS — it is the ask that gives the user something back."""
+    T-3d the review offer outranks NPS — it is the ask that gives the user something back.
+
+    `nps_enabled=False` retires the two homegrown NPS asks because PostHog Surveys now own NPS
+    (issue #653). The review offer is NOT retired with them: it is the extended-trial gate (#499),
+    which PostHog has no way to unlock."""
     now = now or datetime.now()
     if last_sent_at and now - last_sent_at < timedelta(hours=SURVEY_COOLDOWN_HOURS):
         return None
@@ -127,7 +135,7 @@ def select_survey(activated_at: Optional[datetime] = None,
     if trial_ending and not review_answered_at and SURVEY_REVIEW_TRIAL_END not in sent:
         return _survey(SURVEY_REVIEW_TRIAL_END)
 
-    if not nps_answered_at:
+    if nps_enabled and not nps_answered_at:
         if (activated_at and SURVEY_NPS_DAY3 not in sent
                 and now - activated_at >= timedelta(days=NPS_AFTER_ACTIVATION_DAYS)):
             return _survey(SURVEY_NPS_DAY3)
@@ -148,6 +156,10 @@ def next_survey_for_user(user_id: int) -> Optional[dict]:
         review_answered_at=get_latest_feedback_at(user_id, FeedbackSource.REVIEW),
         sent_keys=set(sent),
         last_sent_at=max(sent.values()) if sent else None,
+        # Read at the CALL SITE, never into a module constant — an import-time read is how a flag
+        # ends up doing nothing (docs/feature-flags.md). This is the ONE gate that stops the email
+        # beat and the in-app modal double-prompting a user PostHog is already asking.
+        nps_enabled=not posthog_surveys_enabled(user_id),
     )
 
 
@@ -276,3 +288,132 @@ def send_survey_prompt(user_id: int, survey: dict) -> bool:
         return False
     record_survey_prompt(user_id, survey["key"])
     return True
+
+
+# --- PostHog Surveys (issue #653) ---------------------------------------------------------------
+# PostHog owns the SCHEDULING of two asks — who gets them, when, and how long between surveys — and
+# this module owns what happens to the ANSWER. The split is deliberate: PostHog's targeting is
+# runtime-editable and its wait-between-surveys throttle is one rule instead of four; but a response
+# that only ever became a PostHog event would never reach the feedback->auto-work loop, which is the
+# whole reason LEM collects scores at all.
+#
+# So a response arrives TWICE on purpose and is counted ONCE:
+#   • the browser emits PostHog's own `survey sent` (that is what makes it a PostHog survey response,
+#     visible in the Surveys product and summarizable there), and
+#   • it POSTs the same answer here, where it becomes an ordinary `feedback` row and enters the
+#     classifier -> cluster -> GitHub issue pipeline like any bug report.
+# `track_survey_response` — the HOMEGROWN `survey_response` event — is deliberately NOT emitted on
+# this path. Two events for one answer would double every response-rate number on the dashboards.
+
+# The survey NAMES are the contract between three places that must agree: scripts/posthog_surveys.py
+# creates them, the SPA matches on them to know which form to render, and the API maps them onto a
+# feedback source. One string, not three.
+POSTHOG_NPS_SURVEY_NAME = "LEM NPS"
+POSTHOG_CSAT_SURVEY_NAME = "LEM CSAT — post quality"
+
+POSTHOG_KIND_NPS = "nps"
+POSTHOG_KIND_CSAT = "csat"
+
+# The post-quality CSAT is a 1-5 rating, same scale as the review form.
+CSAT_MIN, CSAT_MAX = 1, 5
+# At or below these, the answer is a complaint: it stays `new` so the auto-filing pass turns it into
+# a feedback issue. NPS's own banding already calls 0-6 a detractor.
+CSAT_LOW_SCORE = 2
+NPS_DETRACTOR_MAX = 6
+
+# Ask for NPS this long after the user ACTIVATED (the onboarding "aha", not signup). Mirrored by the
+# targeting rule in scripts/posthog_surveys.py — the number lives here so the test can hold the two
+# to each other.
+POSTHOG_NPS_AFTER_ACTIVATION_DAYS = 30
+# The CSAT is event-triggered on `post_approved`, but only once the user has approved enough posts to
+# have an opinion about the writing.
+POSTHOG_CSAT_MIN_APPROVALS = 5
+# Nobody sees a second PostHog survey inside this many days, whichever one they saw first.
+POSTHOG_SURVEY_WAIT_DAYS = 30
+
+_POSTHOG_KINDS: dict = {
+    POSTHOG_KIND_NPS: {
+        "survey_name": POSTHOG_NPS_SURVEY_NAME,
+        "source": FeedbackSource.NPS,
+        "type_hint": "nps",
+        "min": NPS_MIN, "max": NPS_MAX,
+    },
+    POSTHOG_KIND_CSAT: {
+        "survey_name": POSTHOG_CSAT_SURVEY_NAME,
+        "source": FeedbackSource.CSAT,
+        "type_hint": "post_quality_csat",
+        "min": CSAT_MIN, "max": CSAT_MAX,
+    },
+}
+
+
+def posthog_survey_kinds() -> dict:
+    """The registry as plain data — the SPA contract test and the provisioning script both read it
+    rather than re-listing the names."""
+    return {kind: dict(spec) for kind, spec in _POSTHOG_KINDS.items()}
+
+
+def posthog_surveys_enabled(user_id: Optional[int] = None) -> bool:
+    """Whether PostHog owns NPS/CSAT for this user. Fails open to POSTHOG_SURVEYS_ENABLED, so a
+    PostHog outage leaves the homegrown scheduler exactly as it was."""
+    try:
+        from cqc_lem.utilities.flags import POSTHOG_SURVEYS, flag_enabled
+        return flag_enabled(POSTHOG_SURVEYS, user_id)
+    except Exception as e:
+        log_warning("Could not resolve the PostHog-surveys flag — keeping the homegrown asks",
+                    exc=e, user_id=user_id)
+        return False
+
+
+def is_low_score(kind: str, score: int) -> bool:
+    """A score that should open a feedback report rather than be filed away as a happy answer."""
+    if kind == POSTHOG_KIND_NPS:
+        return int(score) <= NPS_DETRACTOR_MAX
+    return int(score) <= CSAT_LOW_SCORE
+
+
+def posthog_response_sentiment(kind: str, score: int) -> str:
+    return nps_bucket(int(score)) if kind == POSTHOG_KIND_NPS else review_sentiment(int(score))
+
+
+def record_posthog_survey_response(user_id: Optional[int], kind: str, score: int,
+                                   comment: Optional[str] = None,
+                                   survey_id: Optional[str] = None,
+                                   survey_name: Optional[str] = None,
+                                   context: Optional[dict] = None) -> Optional[dict]:
+    """Persist one PostHog survey answer as a `feedback` row so it enters the auto-work loop.
+
+    A low score, or ANY free text, is left at status `new` — that is what turns it into a feedback
+    issue. A happy score with nothing written is stamped `resolved` on the spot: there is nothing to
+    classify, and a promoter who typed nothing must not burn an LLM call every time one lands.
+
+    Returns None when the kind/score is unusable (the endpoint validates too — this is the belt).
+    """
+    spec = _POSTHOG_KINDS.get(kind)
+    if spec is None:
+        return None
+    try:
+        value = int(score)
+    except (TypeError, ValueError):
+        return None
+    if not spec["min"] <= value <= spec["max"]:
+        return None
+
+    text = (comment or "").strip()
+    body = text or f"{kind.upper()} {value}/{spec['max']} — no comment"
+    low = is_low_score(kind, value)
+    payload = {**(context or {}), "score": value, "survey_kind": kind,
+               "posthog_survey_id": survey_id, "posthog_survey_name": survey_name,
+               # The marker that says "PostHog already counted this response" — anything reading
+               # feedback rows for survey volume must not add it to the `survey_response` stream.
+               "origin": "posthog_survey"}
+    feedback_id = insert_feedback(body, user_id=user_id, source=spec["source"],
+                                  type_hint=spec["type_hint"], context=payload,
+                                  sentiment=posthog_response_sentiment(kind, value))
+    if not feedback_id:
+        return None
+    actionable = bool(low or text)
+    if not actionable:
+        update_feedback_triage(feedback_id, status=FeedbackStatus.RESOLVED)
+    return {"feedback_id": feedback_id, "sentiment": posthog_response_sentiment(kind, value),
+            "low_score": low, "actionable": actionable}

--- a/tests/integration/test_survey_capture.py
+++ b/tests/integration/test_survey_capture.py
@@ -46,6 +46,14 @@ class _FakeCursor:
         elif s.startswith("SELECT 1 FROM feedback"):
             self._result = [(1,)] if any(r["user_id"] == params[0] and r["source"] == params[1]
                                          for r in self.store["feedback"]) else []
+        elif s.startswith("UPDATE feedback SET"):
+            row = next((r for r in self.store["feedback"] if r["id"] == params[-1]), None)
+            if row is not None:
+                for column, value in zip(
+                        [c.split("=")[0] for c in s.split("SET ", 1)[1].split(" WHERE")[0].split(", ")],
+                        params[:-1]):
+                    row[column] = value
+                self.rowcount = 1
         elif s.startswith("INSERT IGNORE INTO survey_prompts"):
             if params[1] not in self.store["prompts"]:
                 self.store["prompts"][params[1]] = datetime.now()
@@ -187,4 +195,65 @@ class TestSurveyCapture:
         detail = _call(client, store, "get",
                        "/api/user/survey?session_token=sess-abc").json()["detail"]
         # The review ask is spent; the cooldown holds the next ask back for a day.
+        assert detail["survey"] is None
+
+
+class TestPostHogSurveyCapture:
+    """POST /api/survey/posthog — a PostHog survey answer becoming a `feedback` row, and the
+    homegrown NPS ask standing down so nobody is prompted twice (issue #653)."""
+
+    def test_a_detractor_lands_as_a_new_feedback_row_the_loop_will_file(self, client, store):
+        response = _call(client, store, "post", "/api/survey/posthog", json={
+            "session_token": "sess-abc", "kind": "nps", "score": 3,
+            "comment": "The comments read like a bot", "survey_id": "0199-nps",
+            "survey_name": "LEM NPS", "context": {"route": "/content"}})
+
+        assert response.status_code == 200
+        detail = response.json()["detail"]
+        assert detail["low_score"] is True and detail["actionable"] is True
+
+        row = store["feedback"][0]
+        assert row["source"] == "nps"
+        assert row["sentiment"] == "detractor"
+        assert row["body"] == "The comments read like a bot"
+        assert row["context_json"]["origin"] == "posthog_survey"
+        assert row["context_json"]["posthog_survey_id"] == "0199-nps"
+        # Left at the DB default (`new`) — that is what makes the auto-filing pass pick it up.
+        assert "status" not in row
+
+    def test_a_happy_csat_with_no_comment_is_resolved_and_never_files_an_issue(self, client, store):
+        response = _call(client, store, "post", "/api/survey/posthog", json={
+            "session_token": "sess-abc", "kind": "csat", "score": 5, "survey_id": "0199-csat",
+            "survey_name": "LEM CSAT — post quality"})
+
+        assert response.status_code == 200
+        assert response.json()["detail"]["actionable"] is False
+        row = store["feedback"][0]
+        assert row["source"] == "csat"
+        assert row["sentiment"] == "positive"
+        assert row["status"] == "resolved"
+
+    def test_a_posthog_answer_closes_the_homegrown_nps_ask_too(self, client, store):
+        # No survey_prompts row is written (PostHog owns that ledger), but the `feedback` row itself
+        # is what `next_survey_for_user` reads — so the email beat can't re-ask what was answered.
+        _call(client, store, "post", "/api/survey/posthog",
+              json={"session_token": "sess-abc", "kind": "nps", "score": 9})
+        assert store["prompts"] == {}
+
+        store["subscription"] = {"subscription_status": "active", "trial_ends_at": None}
+        detail = _call(client, store, "get",
+                       "/api/user/survey?session_token=sess-abc").json()["detail"]
+        assert detail["survey"] is None
+
+    def test_the_nps_ask_stands_down_while_posthog_owns_it(self, client, store):
+        # Same user, same state: PostHog off -> the day-3 NPS is due; PostHog on -> nothing, because
+        # PostHog is asking. That is the "no double-prompt" acceptance criterion.
+        store["subscription"] = {"subscription_status": "active", "trial_ends_at": None}
+        detail = _call(client, store, "get",
+                       "/api/user/survey?session_token=sess-abc").json()["detail"]
+        assert detail["survey"]["key"] == "nps_day3"
+
+        with patch("cqc_lem.utilities.flags.flag_enabled", return_value=True):
+            detail = _call(client, store, "get",
+                           "/api/user/survey?session_token=sess-abc").json()["detail"]
         assert detail["survey"] is None

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -252,6 +252,8 @@ class TestAuthCheckSession:
             "subscription_status": "active",
             "timezone": "America/Chicago",
             "created_at": datetime(2026, 1, 2, 3, 4, 5),
+            "onboarding_completed_at": datetime(2026, 2, 3, 4, 5, 6),
+            "posts_approved": 12,
         }
         with patch(f"{_MAIN}.get_session_user_id", return_value=7), \
              patch(f"{_MAIN}.get_user_email", return_value="me@example.com"), \
@@ -262,6 +264,9 @@ class TestAuthCheckSession:
         assert detail["plan_status"] == "active"
         assert detail["timezone"] == "America/Chicago"
         assert detail["created_at"] == "2026-01-02T03:04:05Z"
+        # What PostHog Surveys target on (issue #653).
+        assert detail["onboarding_completed_at"] == "2026-02-03T04:05:06Z"
+        assert detail["posts_approved"] == 12
 
     def test_missing_profile_row_leaves_person_facts_null(self, client):
         with patch(f"{_MAIN}.get_session_user_id", return_value=7), \
@@ -273,6 +278,9 @@ class TestAuthCheckSession:
         assert detail["plan_status"] is None
         assert detail["timezone"] is None
         assert detail["created_at"] is None
+        assert detail["onboarding_completed_at"] is None
+        # A user who has approved nothing is 0, never null — the survey rule is a `>=` comparison.
+        assert detail["posts_approved"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/api/test_survey_api.py
+++ b/tests/unit/api/test_survey_api.py
@@ -152,3 +152,64 @@ class TestDismissAndSnapshot:
         with patch(f"{_M}.get_session_user_id", return_value=None):
             resp = client.get("/api/user/survey?session_token=bad")
         assert resp.status_code == 401
+
+
+class TestPostHogSurveyEndpoint:
+    """POST /survey/posthog — the bridge from a PostHog survey answer into the feedback loop
+    (issue #653)."""
+
+    def test_an_nps_answer_is_persisted_with_its_posthog_identifiers(self, client):
+        result = {"feedback_id": 501, "sentiment": "detractor", "low_score": True,
+                  "actionable": True}
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_posthog_survey_response", return_value=result) as record:
+            resp = client.post("/api/survey/posthog", json={
+                "session_token": "tok", "kind": "nps", "score": 3,
+                "comment": "The comments read like a bot", "survey_id": "0199",
+                "survey_name": "LEM NPS", "context": {"route": "/content"}})
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == result
+        assert record.call_args.args == (42, "nps", 3)
+        assert record.call_args.kwargs["survey_id"] == "0199"
+        assert record.call_args.kwargs["comment"] == "The comments read like a bot"
+        assert record.call_args.kwargs["context"] == {"route": "/content"}
+
+    def test_a_csat_answer_uses_the_csat_scale(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_posthog_survey_response",
+                   return_value={"feedback_id": 502}) as record:
+            resp = client.post("/api/survey/posthog", json={
+                "session_token": "tok", "kind": "csat", "score": 5})
+        assert resp.status_code == 200
+        assert record.call_args.args == (42, "csat", 5)
+
+    def test_a_score_outside_the_kind_scale_is_rejected(self, client):
+        # 6 is a legal NPS score and an impossible CSAT one — the bound is the KIND's, which a
+        # single field constraint could never express.
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_posthog_survey_response") as record:
+            resp = client.post("/api/survey/posthog", json={
+                "session_token": "tok", "kind": "csat", "score": 6})
+        assert resp.status_code == 422
+        record.assert_not_called()
+
+    def test_an_unknown_kind_is_rejected(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_posthog_survey_response") as record:
+            resp = client.post("/api/survey/posthog", json={
+                "session_token": "tok", "kind": "pmf", "score": 5})
+        assert resp.status_code == 422
+        record.assert_not_called()
+
+    def test_401_without_a_session(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            resp = client.post("/api/survey/posthog",
+                               json={"session_token": "bad", "kind": "nps", "score": 5})
+        assert resp.status_code == 401
+
+    def test_500_when_the_row_cannot_be_saved(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=42), \
+             patch(f"{_S}.record_posthog_survey_response", return_value=None):
+            resp = client.post("/api/survey/posthog",
+                               json={"session_token": "tok", "kind": "nps", "score": 5})
+        assert resp.status_code == 500

--- a/tests/unit/test_posthog_surveys.py
+++ b/tests/unit/test_posthog_surveys.py
@@ -1,0 +1,276 @@
+"""Unit tests for scripts/posthog_surveys.py — the NPS/CSAT survey specs, the targeting rules and
+the create/update planner (issue #653)."""
+
+import copy
+import importlib.util
+import pathlib
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+phs = _load("posthog_surveys")
+
+
+def _spec(name):
+    return next(s for s in phs.build_specs() if s["name"] == name)
+
+
+def _live(spec, **overrides):
+    """What PostHog would return for a survey created from `spec` — the shape drift is measured
+    against, including the targeting flag echoed back under its own key. Deep-copied: a test that
+    edits the "live" side must not edit the spec it is being compared to."""
+    spec = copy.deepcopy(spec)
+    live = {k: v for k, v in spec.items() if k != "targeting_flag_filters"}
+    live.update({"id": "0199-abc", "archived": False, "start_date": None,
+                 "targeting_flag": {"filters": spec.get("targeting_flag_filters")}})
+    live.update(overrides)
+    return live
+
+
+class TestSpecs:
+    def test_both_surveys_are_defined(self):
+        assert [s["name"] for s in phs.build_specs()] == [phs.NPS_SURVEY_NAME,
+                                                          phs.CSAT_SURVEY_NAME]
+
+    def test_survey_names_are_unique(self):
+        # plan_actions keys the live set by name; a duplicate would make two specs fight over one
+        # survey forever.
+        names = [s["name"] for s in phs.build_specs()]
+        assert len(names) == len(set(names))
+
+    def test_both_are_api_surveys_so_the_spa_renders_them(self):
+        # A popover survey's answer is a PostHog event and nothing else — it would never reach the
+        # feedback->auto-work loop, which is the whole reason LEM asks.
+        assert all(s["type"] == "api" for s in phs.build_specs())
+
+    def test_every_survey_leads_with_a_rating_and_ends_with_an_optional_open_question(self):
+        for spec in phs.build_specs():
+            questions = spec["questions"]
+            assert questions[0]["type"] == "rating"
+            assert questions[0]["optional"] is False
+            assert questions[-1]["type"] == "open"
+            # A required "why" turns a 5-second ask into an abandoned one.
+            assert questions[-1]["optional"] is True
+
+    def test_nps_uses_the_zero_to_ten_band_and_csat_a_five_point_scale(self):
+        assert _spec(phs.NPS_SURVEY_NAME)["questions"][0]["scale"] == 10
+        assert _spec(phs.CSAT_SURVEY_NAME)["questions"][0]["scale"] == 5
+
+    def test_rating_scales_are_ones_posthog_supports(self):
+        for spec in phs.build_specs():
+            assert spec["questions"][0]["scale"] in (2, 3, 5, 7, 10)
+            assert spec["questions"][0]["display"] in ("number", "emoji")
+
+    def test_every_survey_carries_the_cross_survey_wait_period(self):
+        # Answering or dismissing either survey buys silence from BOTH — that is the throttle the
+        # "no double-prompt" promise leans on.
+        for spec in phs.build_specs():
+            assert spec["conditions"]["seenSurveyWaitPeriodInDays"] == phs.SURVEY_WAIT_DAYS
+
+    def test_nps_targets_thirty_days_past_activation_not_signup(self):
+        groups = _spec(phs.NPS_SURVEY_NAME)["targeting_flag_filters"]["groups"]
+        prop = groups[0]["properties"][0]
+        assert prop["key"] == phs.PERSON_ONBOARDING_COMPLETED
+        assert prop["type"] == "person"
+        assert prop["operator"] == "is_date_before"
+        assert prop["value"] == f"-{phs.NPS_AFTER_ACTIVATION_DAYS}d"
+        assert groups[0]["rollout_percentage"] == 100
+
+    def test_csat_is_triggered_by_an_approval_and_gated_on_the_approval_count(self):
+        spec = _spec(phs.CSAT_SURVEY_NAME)
+        events = spec["conditions"]["events"]
+        assert [e["name"] for e in events["values"]] == [phs.CSAT_TRIGGER_EVENT]
+        assert events["repeatedActivation"] is True
+        prop = spec["targeting_flag_filters"]["groups"][0]["properties"][0]
+        assert prop["key"] == phs.PERSON_POSTS_APPROVED
+        assert prop["operator"] == "gte"
+        assert prop["value"] == phs.CSAT_MIN_APPROVALS
+
+    def test_nps_has_no_event_trigger(self):
+        # NPS is a time-based ask; an event trigger would make it fire on whatever the user happened
+        # to be doing at day 30.
+        assert "events" not in _spec(phs.NPS_SURVEY_NAME)["conditions"]
+
+    def test_descriptions_are_present_and_fit_the_posthog_limit(self):
+        for spec in phs.build_specs():
+            assert spec["description"]
+            assert len(spec["description"]) <= 400
+
+
+class TestPayloads:
+    def test_the_create_payload_never_launches_the_survey(self):
+        # A survey created by --apply must not start collecting responses from a definition nobody
+        # has read; --launch is the explicit second step.
+        payload = phs.create_payload(_spec(phs.NPS_SURVEY_NAME))
+        assert "start_date" not in payload
+        assert payload["enable_partial_responses"] is False
+        assert payload["type"] == "api"
+
+    def test_the_create_payload_carries_the_targeting_filters(self):
+        payload = phs.create_payload(_spec(phs.CSAT_SURVEY_NAME))
+        assert payload["targeting_flag_filters"]["groups"][0]["properties"]
+
+    def test_the_update_payload_keeps_targeting_so_a_tuned_rule_actually_lands(self):
+        assert "targeting_flag_filters" in phs.update_payload(_spec(phs.NPS_SURVEY_NAME))
+
+
+class TestDrift:
+    def test_an_untouched_survey_reports_no_drift(self):
+        spec = _spec(phs.NPS_SURVEY_NAME)
+        assert phs.drifted_fields(spec, _live(spec)) == []
+
+    def test_posthog_stringifying_a_number_is_not_drift(self):
+        # PostHog echoes property-filter values back as strings; comparing JSON text would report
+        # drift on every single run.
+        spec = _spec(phs.CSAT_SURVEY_NAME)
+        live = _live(spec)
+        live["targeting_flag"]["filters"]["groups"][0]["properties"][0]["value"] = "5"
+        assert phs.drifted_fields(spec, live) == []
+
+    def test_extra_flag_machinery_posthog_adds_is_not_drift(self):
+        spec = _spec(phs.NPS_SURVEY_NAME)
+        live = _live(spec)
+        live["targeting_flag"]["filters"]["multivariate"] = None
+        live["targeting_flag"]["filters"]["payloads"] = {}
+        live["created_by"] = {"id": 7}
+        assert phs.drifted_fields(spec, live) == []
+
+    def test_a_changed_question_is_drift(self):
+        spec = _spec(phs.NPS_SURVEY_NAME)
+        live = _live(spec)
+        live["questions"] = [dict(spec["questions"][0], question="Rate us")]
+        assert "questions" in phs.drifted_fields(spec, live)
+
+    def test_a_removed_wait_period_is_drift(self):
+        spec = _spec(phs.CSAT_SURVEY_NAME)
+        live = _live(spec)
+        live["conditions"] = {"events": spec["conditions"]["events"]}
+        assert "conditions" in phs.drifted_fields(spec, live)
+
+    def test_a_missing_targeting_flag_is_drift(self):
+        spec = _spec(phs.NPS_SURVEY_NAME)
+        live = _live(spec)
+        live["targeting_flag"] = None
+        assert "targeting_flag_filters" in phs.drifted_fields(spec, live)
+
+    def test_a_widened_rollout_is_drift(self):
+        spec = _spec(phs.NPS_SURVEY_NAME)
+        live = _live(spec)
+        live["targeting_flag"]["filters"]["groups"][0]["rollout_percentage"] = 10
+        assert "targeting_flag_filters" in phs.drifted_fields(spec, live)
+
+
+class TestPlan:
+    def test_missing_surveys_are_created(self):
+        actions = phs.plan_actions(phs.build_specs(), {})
+        assert [a["action"] for a in actions] == ["create_survey", "create_survey"]
+
+    def test_an_in_sync_survey_is_a_noop(self):
+        specs = phs.build_specs()
+        existing = {s["name"]: _live(s) for s in specs}
+        assert {a["action"] for a in phs.plan_actions(specs, existing)} == {"noop"}
+
+    def test_a_drifted_survey_is_updated_and_names_the_fields(self):
+        specs = phs.build_specs()
+        existing = {s["name"]: _live(s) for s in specs}
+        existing[phs.NPS_SURVEY_NAME]["description"] = "edited in the UI"
+        actions = phs.plan_actions(specs, existing)
+        update = next(a for a in actions if a["action"] == "update_survey")
+        assert update["survey"] == phs.NPS_SURVEY_NAME
+        assert update["fields"] == ["description"]
+        assert update["survey_id"] == "0199-abc"
+
+    def test_launch_is_only_planned_for_a_survey_that_never_started(self):
+        specs = phs.build_specs()
+        existing = {s["name"]: _live(s) for s in specs}
+        existing[phs.CSAT_SURVEY_NAME]["start_date"] = "2026-07-01T00:00:00Z"
+        actions = phs.plan_actions(specs, existing, launch=True)
+        launched = [a["survey"] for a in actions if a["action"] == "launch_survey"]
+        assert launched == [phs.NPS_SURVEY_NAME]
+
+    def test_nothing_launches_without_the_flag(self):
+        specs = phs.build_specs()
+        existing = {s["name"]: _live(s) for s in specs}
+        assert not [a for a in phs.plan_actions(specs, existing) if a["action"] == "launch_survey"]
+
+    def test_pending_and_summary_read_the_plan(self):
+        assert phs.summarize(phs.plan_actions(phs.build_specs(), {})).startswith("Pending:")
+        specs = phs.build_specs()
+        in_sync = phs.plan_actions(specs, {s["name"]: _live(s) for s in specs})
+        assert phs.pending(in_sync) == []
+        assert "in sync" in phs.summarize(in_sync)
+
+
+class TestApply:
+    def test_dry_run_writes_nothing(self):
+        client = MagicMock()
+        log = phs.apply_actions(client, phs.plan_actions(phs.build_specs(), {}), dry_run=True)
+        client.create_survey.assert_not_called()
+        assert all(line.startswith("[dry-run]") for line in log)
+
+    def test_apply_creates_updates_and_launches(self):
+        client = MagicMock()
+        client.create_survey.return_value = "0199-new"
+        specs = phs.build_specs()
+        existing = {specs[1]["name"]: _live(specs[1], description="edited")}
+        actions = phs.plan_actions(specs, existing, launch=True)
+        now = datetime(2026, 7, 27, 12, 0, tzinfo=timezone.utc)
+        phs.apply_actions(client, actions, dry_run=False, now=now)
+
+        client.create_survey.assert_called_once()
+        assert client.create_survey.call_args.args[0]["name"] == phs.NPS_SURVEY_NAME
+        client.update_survey.assert_called_once()
+        client.launch_survey.assert_called_once_with("0199-abc", now.isoformat())
+
+    def test_an_archived_survey_is_invisible_to_the_planner(self):
+        # list_surveys drops archived rows, so an archived survey re-creates rather than being
+        # patched back to life under a name the SPA is matching on.
+        client = phs.PostHogSurveyClient("key", "1")
+        client._paged = lambda path: [{"name": phs.NPS_SURVEY_NAME, "archived": True},
+                                      {"name": phs.CSAT_SURVEY_NAME, "archived": False, "id": 2}]
+        assert set(client.list_surveys()) == {phs.CSAT_SURVEY_NAME}
+
+
+class TestCli:
+    def test_print_spec_needs_no_network(self, capsys):
+        assert phs.main(["--print-spec"]) == 0
+        assert phs.NPS_SURVEY_NAME in capsys.readouterr().out
+
+    def test_missing_api_key_is_an_error(self, monkeypatch, capsys):
+        monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+        assert phs.main([]) == 1
+        assert "POSTHOG_PERSONAL_API_KEY" in capsys.readouterr().err
+
+    def test_dry_run_exits_2_when_changes_are_pending(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        monkeypatch.setattr(phs.PostHogSurveyClient, "list_surveys", lambda self: {})
+        assert phs.main(["--dry-run"]) == 2
+        assert "[dry-run] create survey" in capsys.readouterr().out
+
+    def test_dry_run_exits_0_when_in_sync(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        monkeypatch.setattr(phs.PostHogSurveyClient, "list_surveys",
+                            lambda self: {s["name"]: _live(s) for s in phs.build_specs()})
+        assert phs.main(["--dry-run"]) == 0
+
+    def test_an_unreadable_project_is_an_error_not_a_blind_create(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+
+        def boom(self):
+            raise RuntimeError("401")
+        monkeypatch.setattr(phs.PostHogSurveyClient, "list_surveys", boom)
+        assert phs.main(["--apply"]) == 1
+        assert "Failed to read PostHog surveys" in capsys.readouterr().err

--- a/tests/unit/test_posthog_surveys.py
+++ b/tests/unit/test_posthog_surveys.py
@@ -201,6 +201,14 @@ class TestPlan:
         launched = [a["survey"] for a in actions if a["action"] == "launch_survey"]
         assert launched == [phs.NPS_SURVEY_NAME]
 
+    def test_a_survey_that_does_not_exist_yet_is_launched_too(self):
+        # `--apply --launch` on a virgin project must leave both surveys RUNNING; planning a launch
+        # only for surveys that already exist would leave them as drafts and quietly require a
+        # second run of the same command.
+        actions = phs.plan_actions(phs.build_specs(), {}, launch=True)
+        assert [a["action"] for a in actions] == ["create_survey", "launch_survey",
+                                                  "create_survey", "launch_survey"]
+
     def test_nothing_launches_without_the_flag(self):
         specs = phs.build_specs()
         existing = {s["name"]: _live(s) for s in specs}
@@ -233,7 +241,18 @@ class TestApply:
         client.create_survey.assert_called_once()
         assert client.create_survey.call_args.args[0]["name"] == phs.NPS_SURVEY_NAME
         client.update_survey.assert_called_once()
-        client.launch_survey.assert_called_once_with("0199-abc", now.isoformat())
+        # The just-created survey is launched under the id its POST returned, alongside the
+        # already-existing one.
+        assert [call.args for call in client.launch_survey.call_args_list] == [
+            ("0199-new", now.isoformat()), ("0199-abc", now.isoformat())]
+
+    def test_a_launch_whose_create_never_happened_is_reported_not_crashed(self):
+        client = MagicMock()
+        client.create_survey.return_value = None
+        actions = phs.plan_actions([phs.nps_survey_spec()], {}, launch=True)
+        log = phs.apply_actions(client, actions, dry_run=False)
+        client.launch_survey.assert_not_called()
+        assert any("could not launch" in line for line in log)
 
     def test_an_archived_survey_is_invisible_to_the_planner(self):
         # list_surveys drops archived rows, so an archived survey re-creates rather than being

--- a/tests/unit/utilities/test_db_analytics_profile.py
+++ b/tests/unit/utilities/test_db_analytics_profile.py
@@ -20,18 +20,39 @@ def _conn(fetch_one=None):
 
 
 class TestGetUserAnalyticsProfile:
-    def test_returns_plan_timezone_and_signup(self):
+    def test_returns_plan_timezone_signup_and_the_survey_targeting_facts(self):
         row = {
             "subscription_tier": "premium",
             "subscription_status": "active",
             "timezone": "America/Chicago",
             "created_at": datetime(2026, 1, 2, 3, 4, 5),
+            "onboarding_completed_at": datetime(2026, 2, 3, 4, 5, 6),
+            "posts_approved": 12,
         }
         conn, cur = _conn(fetch_one=row)
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import get_user_analytics_profile
             assert get_user_analytics_profile(7) == row
-        assert cur.execute.call_args[0][1] == (7,)
+        assert cur.execute.call_args[0][1][-1] == 7
+
+    def test_the_approval_tally_survives_a_post_moving_on(self):
+        # An approved post becomes scheduled and then posted; counting status='approved' alone would
+        # reset the CSAT survey's gate the moment automation ran.
+        conn, cur = _conn(fetch_one={})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_analytics_profile
+            get_user_analytics_profile(1)
+        statuses = set(cur.execute.call_args[0][1][:-1])
+        assert statuses == {"approved", "scheduled", "posted"}
+
+    def test_onboarding_completion_comes_from_activation_not_signup(self):
+        conn, cur = _conn(fetch_one={})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_user_analytics_profile
+            get_user_analytics_profile(1)
+        sql = " ".join(cur.execute.call_args[0][0].split()).lower()
+        assert "o.activated_at as onboarding_completed_at" in sql
+        assert "left join onboarding_state" in sql
 
     def test_selects_no_credentials(self):
         conn, cur = _conn(fetch_one={})

--- a/tests/unit/utilities/test_flags.py
+++ b/tests/unit/utilities/test_flags.py
@@ -58,7 +58,8 @@ class TestRegistry:
 
     def test_exported_constants_are_all_registered(self):
         for key in (flags.COMMENT_RESEARCH, flags.TUTORIAL_VIDEOS,
-                    flags.FEED_FALLBACK_DEFAULT, flags.COST_ROUTING):
+                    flags.FEED_FALLBACK_DEFAULT, flags.COST_ROUTING,
+                    flags.POSTHOG_SURVEYS):
             assert key in flags.FLAGS
 
     def test_safety_controls_are_not_flags(self):

--- a/tests/unit/utilities/test_surveys_posthog.py
+++ b/tests/unit/utilities/test_surveys_posthog.py
@@ -1,0 +1,177 @@
+"""Unit tests for the PostHog Surveys half of `utilities/surveys.py` (issue #653).
+
+Two things are load-bearing and both are asserted here: a PostHog answer becomes a `feedback` row
+(so it reaches the auto-work loop) WITHOUT emitting the homegrown `survey_response` event (so one
+answer is counted once), and the homegrown NPS scheduler stands down when PostHog owns NPS (so
+nobody is prompted twice)."""
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from cqc_lem.utilities import surveys
+from cqc_lem.utilities.db import FeedbackSource, FeedbackStatus
+
+pytestmark = pytest.mark.unit
+
+_S = "cqc_lem.utilities.surveys"
+
+
+class TestKindRegistry:
+    def test_both_surveys_are_registered_with_their_scales(self):
+        kinds = surveys.posthog_survey_kinds()
+        assert set(kinds) == {surveys.POSTHOG_KIND_NPS, surveys.POSTHOG_KIND_CSAT}
+        assert (kinds["nps"]["min"], kinds["nps"]["max"]) == (0, 10)
+        assert (kinds["csat"]["min"], kinds["csat"]["max"]) == (1, 5)
+        assert kinds["nps"]["source"] == FeedbackSource.NPS
+        assert kinds["csat"]["source"] == FeedbackSource.CSAT
+
+    def test_the_registry_is_a_copy(self):
+        # The SPA contract test and the API handler both read it; a caller must not be able to
+        # mutate the module's own registry through the returned dict.
+        surveys.posthog_survey_kinds()["nps"]["max"] = 99
+        assert surveys.posthog_survey_kinds()["nps"]["max"] == 10
+
+    def test_survey_names_match_the_provisioning_script(self):
+        import importlib.util
+        import pathlib
+        path = (pathlib.Path(__file__).resolve().parents[3] / "scripts" / "posthog_surveys.py")
+        spec = importlib.util.spec_from_file_location("posthog_surveys", path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        assert module.NPS_SURVEY_NAME == surveys.POSTHOG_NPS_SURVEY_NAME
+        assert module.CSAT_SURVEY_NAME == surveys.POSTHOG_CSAT_SURVEY_NAME
+        assert module.NPS_AFTER_ACTIVATION_DAYS == surveys.POSTHOG_NPS_AFTER_ACTIVATION_DAYS
+        assert module.CSAT_MIN_APPROVALS == surveys.POSTHOG_CSAT_MIN_APPROVALS
+        assert module.SURVEY_WAIT_DAYS == surveys.POSTHOG_SURVEY_WAIT_DAYS
+
+
+class TestLowScore:
+    @pytest.mark.parametrize("score,low", [(0, True), (6, True), (7, False), (10, False)])
+    def test_nps_detractors_are_low(self, score, low):
+        assert surveys.is_low_score("nps", score) is low
+
+    @pytest.mark.parametrize("score,low", [(1, True), (2, True), (3, False), (5, False)])
+    def test_csat_one_and_two_are_low(self, score, low):
+        assert surveys.is_low_score("csat", score) is low
+
+
+class TestRecordPostHogResponse:
+    def test_nps_lands_as_a_feedback_row_with_the_posthog_origin(self):
+        with patch(f"{_S}.insert_feedback", return_value=77) as insert, \
+             patch(f"{_S}.update_feedback_triage") as triage:
+            result = surveys.record_posthog_survey_response(
+                4, "nps", 3, comment="The comments read like a bot",
+                survey_id="01900", survey_name="LEM NPS", context={"route": "/content"})
+
+        assert result == {"feedback_id": 77, "sentiment": "detractor",
+                          "low_score": True, "actionable": True}
+        assert insert.call_args.args[0] == "The comments read like a bot"
+        assert insert.call_args.kwargs["source"] == FeedbackSource.NPS
+        context = insert.call_args.kwargs["context"]
+        assert context["origin"] == "posthog_survey"
+        assert context["posthog_survey_id"] == "01900"
+        assert context["score"] == 3
+        assert context["route"] == "/content"
+        # A detractor stays `new` — that IS the feedback report.
+        triage.assert_not_called()
+
+    def test_a_happy_answer_with_no_comment_is_resolved_on_the_spot(self):
+        with patch(f"{_S}.insert_feedback", return_value=78), \
+             patch(f"{_S}.update_feedback_triage") as triage:
+            result = surveys.record_posthog_survey_response(4, "csat", 5)
+
+        assert result["actionable"] is False
+        triage.assert_called_once_with(78, status=FeedbackStatus.RESOLVED)
+
+    def test_a_happy_answer_WITH_a_comment_stays_in_the_loop(self):
+        with patch(f"{_S}.insert_feedback", return_value=79) as insert, \
+             patch(f"{_S}.update_feedback_triage") as triage:
+            result = surveys.record_posthog_survey_response(4, "csat", 5,
+                                                            comment="Add a carousel template")
+
+        assert result["actionable"] is True
+        triage.assert_not_called()
+        assert insert.call_args.args[0] == "Add a carousel template"
+
+    def test_no_comment_still_writes_a_readable_body(self):
+        with patch(f"{_S}.insert_feedback", return_value=80) as insert, \
+             patch(f"{_S}.update_feedback_triage"):
+            surveys.record_posthog_survey_response(4, "nps", 9)
+        assert insert.call_args.args[0] == "NPS 9/10 — no comment"
+
+    def test_the_homegrown_survey_response_event_is_never_emitted(self):
+        # PostHog's own `survey sent` already counted this answer in the browser. A second event
+        # here would double every response-rate number on the dashboards.
+        with patch(f"{_S}.insert_feedback", return_value=81), \
+             patch(f"{_S}.update_feedback_triage"), \
+             patch(f"{_S}._track_response") as track, \
+             patch(f"{_S}.record_survey_prompt") as ledger:
+            surveys.record_posthog_survey_response(4, "nps", 10)
+        track.assert_not_called()
+        ledger.assert_not_called()
+
+    @pytest.mark.parametrize("kind,score", [("nps", 11), ("nps", -1), ("csat", 0), ("csat", 6),
+                                            ("bogus", 5)])
+    def test_an_unusable_kind_or_score_writes_nothing(self, kind, score):
+        with patch(f"{_S}.insert_feedback") as insert:
+            assert surveys.record_posthog_survey_response(4, kind, score) is None
+        insert.assert_not_called()
+
+    def test_a_failed_insert_reports_nothing_rather_than_a_half_result(self):
+        with patch(f"{_S}.insert_feedback", return_value=None), \
+             patch(f"{_S}.update_feedback_triage") as triage:
+            assert surveys.record_posthog_survey_response(4, "nps", 2) is None
+        triage.assert_not_called()
+
+    def test_a_non_numeric_score_is_rejected(self):
+        with patch(f"{_S}.insert_feedback") as insert:
+            assert surveys.record_posthog_survey_response(4, "nps", None) is None
+        insert.assert_not_called()
+
+
+class TestHomegrownStandDown:
+    def _activated(self, days=10):
+        return datetime.now() - timedelta(days=days)
+
+    def test_nps_is_selected_while_posthog_is_off(self):
+        chosen = surveys.select_survey(activated_at=self._activated())
+        assert chosen["key"] == surveys.SURVEY_NPS_DAY3
+
+    def test_nps_is_retired_when_posthog_owns_it(self):
+        assert surveys.select_survey(activated_at=self._activated(), nps_enabled=False) is None
+
+    def test_the_review_offer_survives_the_stand_down(self):
+        # The review is the extended-trial gate (#499) — PostHog has no way to unlock that, so it
+        # must keep being asked even when PostHog owns NPS.
+        chosen = surveys.select_survey(activated_at=self._activated(),
+                                       trial_ends_at=datetime.now() + timedelta(days=2),
+                                       nps_enabled=False)
+        assert chosen["key"] == surveys.SURVEY_REVIEW_TRIAL_END
+
+    def test_trial_end_nps_is_retired_too(self):
+        chosen = surveys.select_survey(trial_ends_at=datetime.now() + timedelta(days=2),
+                                       review_answered_at=datetime.now(), nps_enabled=False)
+        assert chosen is None
+
+    def test_next_survey_for_user_reads_the_flag_at_the_call_site(self):
+        with patch(f"{_S}.get_onboarding_state",
+                   return_value={"activated_at": self._activated()}), \
+             patch(f"{_S}.get_user_subscription_info", return_value={}), \
+             patch(f"{_S}.get_survey_prompts_sent", return_value={}), \
+             patch(f"{_S}.get_latest_feedback_at", return_value=None), \
+             patch(f"{_S}.posthog_surveys_enabled", return_value=True) as flag:
+            assert surveys.next_survey_for_user(4) is None
+        flag.assert_called_once_with(4)
+
+
+class TestFlagResolution:
+    def test_a_flag_lookup_failure_keeps_the_homegrown_asks(self):
+        with patch("cqc_lem.utilities.flags.flag_enabled", side_effect=RuntimeError("posthog down")):
+            assert surveys.posthog_surveys_enabled(4) is False
+
+    def test_the_flag_is_read_per_user(self):
+        with patch("cqc_lem.utilities.flags.flag_enabled", return_value=True) as flag:
+            assert surveys.posthog_surveys_enabled(9) is True
+        assert flag.call_args.args == ("posthog-surveys-enabled", 9)


### PR DESCRIPTION
## What & why

PostHog Surveys now own the two general-purpose asks, while the bespoke ones stay in `utilities/surveys.py`. The line between the two owners is **what an answer can DO**.

| Ask | Owner | Why there |
|---|---|---|
| **NPS** — 30 days after activation | PostHog Surveys | Targeting/cadence tunable without a deploy |
| **Post-quality CSAT** — after 5+ approvals | PostHog Surveys | Event-triggered, so it lands in the moment the user just judged a draft |
| **Review** — trial T-3d | `utilities/surveys.py` | It is the #499 extended-trial gate; PostHog cannot unlock anything |
| **Fix CSAT** — "did this fix it?" | `utilities/surveys.py` | Per-issue (`fix_csat_<n>`), scheduled by the shipped-notice queue (#502) |

### Headless, not the popover

Both surveys are created as PostHog **`api`** type and rendered in LEM's own modal (`PostHogSurveyModal.tsx`). A popover answer is a PostHog event and **nothing else** — it would never reach the feedback→auto-work loop, which is the reason LEM asks for scores at all. (The popover also renders bottom-right, exactly where the feedback widget already sits.)

So one answer takes two paths and is **counted once**:

1. The browser emits PostHog's native **`survey sent`** (`$survey_response` / `$survey_questions`, by index *and* by question id), so it shows up in the Surveys product.
2. The same answer POSTs to **`/api/survey/posthog`**, becoming a `feedback` row that the classifier files as a GitHub issue.

`track_survey_response` — the homegrown `survey_response` event — is deliberately **not** emitted on that path; two events per answer would double every response-rate number. The row carries `context_json.origin = "posthog_survey"` so anything counting rows out of MySQL can still tell the streams apart.

| Answer | Feedback status | Effect |
|---|---|---|
| NPS ≤ 6, or CSAT ≤ 2 | `new` | Auto-filing pass opens / `+1`s a feedback issue |
| Any score **with** free text | `new` | The text is the actionable part |
| Happy score, no comment | `resolved` | Nothing to classify; must not burn an LLM call per promoter |

Because we render, posthog-js never sees the ask — `markSurveySeen()` is what advances its seen/wait-period bookkeeping. Drop it and the 30-day `seenSurveyWaitPeriodInDays` throttle silently stops working.

### Targeting

Person properties set at `$identify` off `GET /auth/session`:

- **NPS** — `onboarding_completed_at is_date_before -30d`. That is `onboarding_state.activated_at`, the activation "aha", **not** signup: a user who signed up and stalled has no opinion worth a score, and their detractor answer would be about onboarding.
- **CSAT** — activation event `post_approved` **and** person `posts_approved >= 5`. The count spans `approved`/`scheduled`/`posted`, because an approved post moves on as automation runs and a current-status count would reset the tally. The SPA advances the property itself on each approval (`recordPostApproval`), so the ask fires on the approval that crosses the threshold rather than one session later.

### No double-prompting

`posthog-surveys-enabled` (registry flag, `POSTHOG_SURVEYS_ENABLED`, default off) makes `next_survey_for_user` pass `nps_enabled=False` into `select_survey`, retiring `nps_day3` + `nps_trial_end` from **both** the in-app modal and the daily email beat. The review offer is untouched. It fails open to the env var, and a flag-lookup exception keeps the homegrown asks — the failure mode is "asked the old way", never "asked twice". Answering in PostHog also closes the homegrown ask on its own with no flag involved, since the `feedback` row is what `get_latest_feedback_at(user_id, NPS)` reads.

### Provisioning

`scripts/posthog_surveys.py` is the ONE place the surveys are defined — same pure-spec/plan + thin-client split as `posthog_provision.py`.

```bash
python scripts/posthog_surveys.py --print-spec       # both specs as JSON, no network
python scripts/posthog_surveys.py --dry-run          # diff (exit 2 = pending)
python scripts/posthog_surveys.py --apply --launch   # converge, then start
```

`--apply` creates **drafts**; `--launch` is a separate opt-in so an apply can never start collecting from a definition nobody has read. Drift is measured on a narrow managed-field set (appearance tweaks in the UI are not drift) and property values compare by value, because PostHog echoes numbers back as strings.

## Testing

- `tests/unit/utilities/test_surveys_posthog.py` (30) — response → feedback row, resolve-happy-answers, the no-double-count guard, and the homegrown stand-down. Includes a contract test holding the script's survey names/thresholds to `utilities/surveys.py`.
- `tests/unit/test_posthog_surveys.py` (35) — specs, targeting rules, drift detection, planner, CLI exit codes.
- `tests/unit/api/test_survey_api.py` (+6) — the endpoint, including a CSAT `score=6` that is a legal NPS score and an impossible CSAT one.
- `tests/integration/test_survey_capture.py` (+4) — through the real db.py SQL: a detractor lands as `new`, a happy CSAT as `resolved`, and the NPS ask provably disappears with the flag on.
- `src/cqc_lem/ui/src/hooks/usePostHogSurvey{,.flow}.test.tsx` (21) — parse + `survey sent` payload shape (a 0 score is not a skipped answer), and the flow: one `survey sent` across a failed-POST retry, never a `dismissed` after an answer.

Run locally: `pytest tests/unit -q` → 7114 passed (2 pre-existing failures in `test_error_capture_middleware.py`, present on the branch base — verified with `git stash`). `npm test` → 112 passed; `npm run build` clean.

## Rollout

1. `python scripts/posthog_surveys.py --apply --launch`
2. Flip `posthog-surveys-enabled` (or set `POSTHOG_SURVEYS_ENABLED=true`)

Nothing changes until both happen. Full verification steps in `docs/surveys.md`.

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)
