### PR TITLE
feat(observability): PostHog advanced-surface spike — CDP destination + evaluation doc (closes #655)

### DIFF
--- a/docs/posthog-advanced-surface.md
+++ b/docs/posthog-advanced-surface.md
@@ -1,0 +1,202 @@
+# PostHog advanced surface — CDP destinations, Workflows, Logs, Scouts/Inbox (issue #655)
+
+Milestone 15 (#646–655) adopted PostHog's core products one at a time — LLM analytics, error
+tracking, session replay, feature flags, surveys, KPI dashboards. This is a scoped SPIKE on four
+newer/adjacent surfaces, each evaluated against what LEM already has rather than adopted on
+principle. Scope was deliberately "docs + minimal config, no heavy build" — see the Acceptance in
+the issue.
+
+## TL;DR
+
+| Surface | Call | One line |
+|---|---|---|
+| CDP realtime destinations | **Adopt (scoped)** | Shipped one, inert until a webhook/Slack URL is supplied — see below |
+| Workflows | **Skip** | Keep the existing `onboarding.py`/`notifications.py` nudge machinery; Workflows needs a new email channel (DNS) and lives outside git review |
+| Logs (OTLP ingestion) | **Already adopted** | `logger.py` has shipped ERROR+ records to PostHog Logs over OTLP since issue #647/#648 — nothing to migrate |
+| Scouts / Self-driving Inbox | **Skip** (code-fixing) / **Watch** (observability-gap audits) | Overlaps LEM's own error→issue→agent pipeline but is capped at 3 runs/month free and blind to `CLAUDE.md`/`RUNBOOK.md` |
+
+## 1. CDP realtime destinations
+
+### What they add over what LEM already has
+
+Every ops signal LEM ships today is either a daily rollup or a cron:
+
+- The four `scripts/posthog_provision.py` threshold alerts (issue #650) — `calculation_interval:
+  daily`, emails the key owner once a day's evaluation breaches.
+- `scripts/posthog_error_issues.py` (issue #648) — a daily host cron that turns a new/active PostHog
+  error-tracking issue into a GitHub issue.
+
+CDP destinations are PostHog's realtime layer: a HogFunction fires within seconds of the triggering
+event being captured, not at the next scheduled evaluation. That gap matters most for exactly the
+signal where the daily cadence already contributed to the original incident — the LinkedIn 429
+breaker (`utilities/linkedin/rate_limit.py`) escalates its OWN cooldown, so minutes of delay while
+the doom loop re-forms costs real automation time (see `feed-commenting-429-doom-loop` in prior
+runbook history). A same-minute ping is worth materially more than a same-day one there; it is not
+obviously worth more for, say, a weekly comment-floor breach.
+
+### What's live in this PostHog project today
+
+Verified directly against the project (475262, "CQC LEM") before writing any code: **zero** CDP
+destinations, zero third-party integrations (`slack`, `github`, or any other `kind`) are configured.
+Every destination channel PostHog offers for a realtime ping — Slack, Discord, Microsoft Teams,
+Linear, GitHub, GitLab, or a generic webhook — needs either an OAuth integration (can't be completed
+headless, from an agent pipeline tick) or a bare `https://` endpoint to point at. Neither exists yet.
+
+### What shipped
+
+`scripts/posthog_ops_destination.py` (+ `tests/unit/test_posthog_ops_destination.py`), in the exact
+dry-run/`--apply` + pure-plan/thin-client split every other `posthog_*.py` script in this repo uses:
+
+```bash
+scripts/posthog_ops_destination.py --print-payload   # the HogFunction body, no network
+scripts/posthog_ops_destination.py                   # dry run (exit 2 = a change is pending)
+scripts/posthog_ops_destination.py --apply           # create/update it
+```
+
+It provisions ONE `internal_destination` (`template-webhook`) filtered on `rate_limit_trip` — LEM's
+own "the 429 breaker just tripped" event, already emitted by `mark_rate_limited()` (issue #650). The
+destination URL comes from `POSTHOG_OPS_WEBHOOK_URL`, read only at provision time, never hardcoded.
+
+Rather than fabricate a target or paste in a credential the pipeline shouldn't be handling
+unsupervised, the script is **inert by default**: with no `POSTHOG_OPS_WEBHOOK_URL` set, both
+`--dry-run` and `--apply` report exactly what's missing and exit `0` — the same "degrade to a
+no-op, never fail the run" shape `scripts/posthog_annotate.py` already uses for a missing
+`POSTHOG_PERSONAL_API_KEY`. Going live is one step for a human: add a Slack
+[incoming-webhook URL](https://api.slack.com/messaging/webhooks) (free at any volume LEM would
+generate) or any other `https://` endpoint as `POSTHOG_OPS_WEBHOOK_URL` in `/opt/lem/.env`, then run
+`--apply` once.
+
+### Cost
+
+CDP destinations share the "Data pipelines" free tier: **10K events/month**. LEM's own alert ceiling
+for this exact event (`RATE_LIMIT_TRIPS_PER_DAY_CEILING = 5` in `posthog_provision.py`) puts a worst
+case around 150/month — over an order of magnitude under the cap. No new always-on spend.
+
+### Call
+
+**Adopt the pattern**; the one destination proved out is deliberately left unapplied pending the
+one piece of information only a human can supply (which channel to ping). This is not a "needs a
+product decision" park — the code merges and does nothing until the env var exists, same as several
+already-merged `posthog_*.py` scripts.
+
+## 2. Workflows — evaluated against a "posts awaiting approval" nudge
+
+Workflows graduated alpha → beta → GA within 2026 and is PostHog's no-code trigger/delay/branch/
+dispatch builder (event, webhook, or scheduled-audience triggers; email/Slack/SMS/webhook
+dispatches), built and edited entirely in the PostHog UI.
+
+**Setup cost.** Any email dispatch needs a Workflows "channel" first — four DNS records on the
+sending domain, verified before a single email can go out. LEM doesn't send transactional email
+through PostHog anywhere today; `utilities/email.py` (SendGrid, with SMTP fallback) already owns
+every one of the ~10 existing notification types, verified and in production, with one shared
+branded template layer (`_footer_html`/`_footer_text`, `_html_to_text`). Standing up a second,
+parallel email pipeline for one reminder is exactly the kind of "no heavy build" this spike is
+supposed to avoid.
+
+**What LEM already has for this shape of problem.** `utilities/onboarding.py` (issue #500) is a
+near-exact prior art: `select_nudge()` is a PURE function over a checklist + timestamps (which nudge,
+if any, fires next — one-shot per key, `NUDGE_COOLDOWN_HOURS` between any two nudges), unit-tested
+without touching the DB, and `notifications.py`'s `notify_onboarding_nudge` sends it through the one
+email pipeline. A "posts awaiting approval" reminder is a small, natural extension of that exact
+shape — one more rule and one more `send_*_email` template — not a new product. (No such issue exists
+yet; searched for `awaiting approval` / `pending_approval` / `posts_pending` across the codebase and
+found only the raw `PostStatus.PENDING` enum value — this would be new scope for whoever files it.)
+
+A Workflow, by contrast, lives outside git: its branching logic isn't something `pytest tests/unit`
+covers, and CLAUDE.md's ≥80% patch-coverage bar has no meaning against a no-code canvas edited
+in-browser.
+
+### Call
+
+**Skip** for this use case. Build the eventual "posts awaiting approval" nudge as a sibling of the
+existing onboarding-nudge machinery, not a Workflow.
+
+**Watch:** reconsider if LEM ever wants a non-engineer editing outreach cadence without a PR — a
+genuinely different value proposition than what a single-operator, code-reviewed project needs today.
+
+## 3. Logs — already adopted
+
+`utilities/logger.py`'s `_build_posthog_handler` has shipped every `ERROR`+ log record (threshold
+`POSTHOG_LOG_LEVEL`, default `ERROR`) to **PostHog Logs** over OTLP HTTP
+(`{POSTHOG_HOST}/i/v1/logs`) since issue #647/#648 — before this spike, not as a result of it. Each
+record carries a proper OTel `Resource` (`service.name`, `service.instance.id` from `$HOSTNAME`,
+`service.version` from `IMAGE_TAG`, `deployment.environment`), so every worker (`web_app`,
+`celery_worker`, `*_selenium*`, `*_content`) is distinguishable in the Logs UI.
+
+There is no separate "Logs OTel ingestion" surface to evaluate migrating TO — the OTLP exporter
+already wired into `logger.py` *is* PostHog Logs' own ingestion path. The spike's question
+("replacement for the logger.py PostHog handler") had a stale premise: the replacement already
+happened, two milestones ago.
+
+**Cost:** the free tier is 50 GB ingested/month. LEM only forwards `ERROR`/`CRITICAL` — a small slice
+of what the local `RotatingFileHandler` (250 MB × 10 backups, every level) captures — nowhere near
+that cap at current volume.
+
+### Call
+
+**Already adopted.** No action. One thing worth flagging as a genuine, deliberate future trade-off
+rather than a migration: dropping `POSTHOG_LOG_LEVEL` to `WARNING` or `INFO` for a season would trade
+free-tier headroom for full-text log search across the fleet instead of `ssh` + `grep` — an owner
+call, not a code change.
+
+## 4. Scouts / Self-driving Inbox — overlap with LEM's own agent pipeline
+
+"Self-driving" (open beta) is PostHog's own autonomous loop: **Scouts** are skills that read PostHog
+data and emit **signals** (canonical categories include Health checks, Ingestion warnings, Insight
+alerts, Logs, Observability gaps, MCP tool calls); once a human marks a signal Actionable, an
+**Inbox** implementation agent clones the repo into a sandbox, branches, edits, runs local tests, and
+opens a labeled PR — "Nothing ships without you," the human still reviews and merges.
+
+### The overlap is direct
+
+LEM already runs this exact shape, end to end, and has for several milestones: `scripts/
+posthog_error_issues.py` turns a PostHog error-tracking issue into an `agent:ready` + `bug` GitHub
+issue; the agent pipeline this very PR was produced by (`RUNBOOK.md`, `tick.sh`) picks it up, branches,
+edits, tests, and opens a PR gated by CI + review before merge. Self-driving Inbox would be a second,
+PostHog-authored version of the same loop, running in parallel with ours on the same repo.
+
+### What Self-driving Inbox cannot do that LEM's own pipeline already does
+
+- **Follow `RUNBOOK.md`'s contract** — the `MODE=start` Why/Scope/Files/Acceptance shape, the
+  `agent:ready`/`agent:working`/`needs-human` label state machine, the Decision Comment protocol for
+  handing an ambiguous call back to the owner. An Inbox PR has no access to this repo's house rules.
+- **Honor `CLAUDE.md` conventions** — the structured logger, `db.py`-only SQL, `PostStatus`/`PostType`
+  enums, LiteLLM tier aliases, `get_docker_driver()`. Nothing outside this repo's own agent pipeline
+  reads that file before writing code.
+- **Merge through LEM's own gate** — required CI checks, a Copilot review on `risk:*` PRs, an
+  adversarial self-review marker before the runner merges. Inbox PRs are reviewed and merged directly
+  by the owner in GitHub, bypassing that gate unless manually re-routed.
+- **Scale to LEM's actual volume** — Self-driving is metered separately, at **3 scout runs/month on
+  the free tier**. LEM ships multiple releases a day (`docs/zero-downtime-deploys.md`, four-times-daily
+  cadence) and this very issue is one of dozens the pipeline works through in a comparable window.
+  3/month is roughly two orders of magnitude under what the existing pipeline already does.
+
+### Where it would add something LEM doesn't have
+
+The "Observability gaps" and "Insight alerts" scout categories are a genuinely different job: a
+periodic self-audit for "this high-volume event has no insight/dashboard/alert" or "this alert fired
+and nobody looked." `scripts/posthog_provision.py` defines the KPI dashboards as code, but nothing
+today re-checks whether a *later* `track_*()` call (a future issue's new event) ever got a tile. That
+is complementary, not redundant, with the error→issue→agent loop.
+
+### Call
+
+**Skip** wiring Inbox into the code-fixing loop — direct redundancy, a two-orders-of-magnitude volume
+mismatch, and blind to this repo's conventions and merge gate. **Watch** the observability-gap/
+insight-alert scout categories as an occasional manual audit (a few minutes, run after a big
+instrumentation push or once a quarter) — never as a standing automation that could open PRs outside
+`RUNBOOK.md`'s process. Revisit the whole call if Self-driving's free-tier cap changes materially, or
+if it ships a way to hand a scout this repo's own `CLAUDE.md`/`RUNBOOK.md` so its output could route
+through OUR gate instead of around it.
+
+## What shipped in this PR
+
+- `scripts/posthog_ops_destination.py` + `tests/unit/test_posthog_ops_destination.py` — the CDP
+  destination described in §1, inert until `POSTHOG_OPS_WEBHOOK_URL` is set.
+- This document.
+
+## Open follow-up (not a blocker)
+
+Set `POSTHOG_OPS_WEBHOOK_URL` in `/opt/lem/.env` to a Slack incoming-webhook URL (or any other
+`https://` endpoint) and run `scripts/posthog_ops_destination.py --apply` to make the realtime
+429-breaker ping live.

--- a/docs/posthog-advanced-surface.md
+++ b/docs/posthog-advanced-surface.md
@@ -53,9 +53,13 @@ scripts/posthog_ops_destination.py                   # dry run (exit 2 = a chang
 scripts/posthog_ops_destination.py --apply           # create/update it
 ```
 
-It provisions ONE `internal_destination` (`template-webhook`) filtered on `rate_limit_trip` — LEM's
-own "the 429 breaker just tripped" event, already emitted by `mark_rate_limited()` (issue #650). The
+It provisions ONE `destination` (`template-webhook`) filtered on `rate_limit_trip` — LEM's own "the
+429 breaker just tripped" event, already emitted by `mark_rate_limited()` (issue #650). The
 destination URL comes from `POSTHOG_OPS_WEBHOOK_URL`, read only at provision time, never hardcoded.
+(Deliberately not `internal_destination`: that type is reserved for PostHog's own internal-only
+signals like `$insight_alert_firing`/`$activity_log_entry_created`, which never share a pipeline
+with an ordinary captured event like `rate_limit_trip` — verified against the PostHog API docs and
+MCP before writing this script.)
 
 Rather than fabricate a target or paste in a credential the pipeline shouldn't be handling
 unsupervised, the script is **inert by default**: with no `POSTHOG_OPS_WEBHOOK_URL` set, both

--- a/scripts/posthog_ops_destination.py
+++ b/scripts/posthog_ops_destination.py
@@ -43,7 +43,14 @@ DEFAULT_APP_HOST = "https://us.posthog.com"
 DESTINATION_NAME = "LEM ops ping — LinkedIn 429 breaker tripped"
 TRIGGER_EVENT = "rate_limit_trip"
 TEMPLATE_ID = "template-webhook"
-FUNCTION_TYPE = "internal_destination"
+# `destination` (not `internal_destination`): internal_destination is PostHog's reserved type for
+# its OWN internal-only signals ($insight_alert_firing, $activity_log_entry_created, ...) — those
+# don't flow through the regular event stream, and neither does an internal_destination function
+# fire for anything else. `rate_limit_trip` is an ordinary captured event (it already backs a
+# regular trends insight in posthog_provision.py), so it needs the standard `destination` type that
+# consumes the normal event-ingestion pipeline; `internal_destination` would create successfully but
+# never actually fire.
+FUNCTION_TYPE = "destination"
 DESCRIPTION = (
     "Realtime ping the moment the LinkedIn 429 circuit breaker trips (utilities/linkedin/"
     "rate_limit.py), rather than waiting for the daily 'LEM — LinkedIn 429 spike' threshold "

--- a/scripts/posthog_ops_destination.py
+++ b/scripts/posthog_ops_destination.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Provision ONE realtime PostHog CDP destination — an ops ping the instant the LinkedIn 429
+breaker trips (issue #655, PH10 spike).
+
+Every ops signal LEM has today is either a daily/weekly rollup (the four #650 threshold alerts,
+evaluated `calculation_interval: daily`) or a cron (`scripts/posthog_error_issues.py`, run once a
+day). CDP destinations are PostHog's realtime layer: a HogFunction fires within seconds of the
+`rate_limit_trip` event actually being captured, instead of waiting for the next scheduled
+evaluation. This script proves that layer out with the ONE event where a same-minute ping is worth
+more than a same-day one — the breaker escalates its own cooldown (`utilities/linkedin/rate_limit.py`),
+so the doom loop re-forming is exactly the case where 23 hours of delay costs real automation time.
+
+Split like every other posthog_*.py script: PURE plan logic (unit-tested) and a thin I/O client
+(mocked in tests).
+
+CLI (--dry-run and --apply are mutually exclusive):
+  --dry-run        Report what would change. No writes. (default)
+  --apply          Create/update the destination.
+  --print-payload  Print the HogFunction payload for a placeholder URL and exit. No network.
+Env:
+  POSTHOG_PERSONAL_API_KEY  Personal API key (required for network). Scope: hog_function read+write.
+  POSTHOG_PROJECT_ID        PostHog project id (default 475262 — "CQC LEM").
+  POSTHOG_APP_HOST          App host for the API (default https://us.posthog.com).
+  POSTHOG_OPS_WEBHOOK_URL   https:// URL the ping is delivered to (a Slack incoming-webhook URL, a
+                            Discord webhook, or any generic https endpoint). Absent = there is
+                            nothing to point the destination at yet: the script explains what's
+                            missing and exits 0 rather than failing a run that has no channel
+                            configured — the same "degrade to a no-op, never a failure" shape as
+                            scripts/posthog_annotate.py's missing key.
+Exit: 0 nothing to do / applied / no webhook URL configured yet, 2 a change is pending (--dry-run
+with a URL set), 1 error (unreachable PostHog, missing personal API key).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Optional
+
+DEFAULT_PROJECT_ID = "475262"  # "CQC LEM" — not a secret; the key that reaches it is.
+DEFAULT_APP_HOST = "https://us.posthog.com"
+
+DESTINATION_NAME = "LEM ops ping — LinkedIn 429 breaker tripped"
+TRIGGER_EVENT = "rate_limit_trip"
+TEMPLATE_ID = "template-webhook"
+FUNCTION_TYPE = "internal_destination"
+DESCRIPTION = (
+    "Realtime ping the moment the LinkedIn 429 circuit breaker trips (utilities/linkedin/"
+    "rate_limit.py), rather than waiting for the daily 'LEM — LinkedIn 429 spike' threshold "
+    "alert (issue #650) to evaluate. See docs/posthog-advanced-surface.md."
+)
+PLACEHOLDER_URL = "https://example.com/lem-ops-webhook"
+
+
+# ── pure planning (unit-tested) ──────────────────────────────────────────────────────
+
+def destination_filters() -> dict:
+    return {"events": [{"id": TRIGGER_EVENT, "type": "events"}]}
+
+
+def destination_payload(webhook_url: str) -> dict:
+    """The HogFunction body PostHog expects for a webhook-template internal destination."""
+    return {
+        "type": FUNCTION_TYPE,
+        "name": DESTINATION_NAME,
+        "description": DESCRIPTION,
+        "template_id": TEMPLATE_ID,
+        "enabled": True,
+        "filters": destination_filters(),
+        "inputs": {"url": {"value": webhook_url}},
+    }
+
+
+def _webhook_url_of(existing: dict) -> Optional[str]:
+    return ((existing.get("inputs") or {}).get("url") or {}).get("value")
+
+
+def plan_destination(existing: Optional[dict], webhook_url: str) -> dict:
+    """Diff the destination spec against what PostHog already has. `webhook_url` empty means there
+    is nothing to point the destination at — that is `blocked`, not `create`, so a dry-run never
+    claims a follow-up `--apply` could create it as-is."""
+    if not webhook_url:
+        return {"action": "blocked",
+                "reason": "POSTHOG_OPS_WEBHOOK_URL is not set — nothing to point the destination at"}
+    payload = destination_payload(webhook_url)
+    if existing is None:
+        return {"action": "create", "payload": payload}
+    if (existing.get("filters") == payload["filters"] and existing.get("enabled", True)
+            and _webhook_url_of(existing) == webhook_url):
+        return {"action": "unchanged", "id": existing.get("id")}
+    return {"action": "update", "id": existing.get("id"), "payload": payload}
+
+
+def apply_plan(client: "PostHogFunctionsClient", action: dict, dry_run: bool) -> str:
+    """Execute the plan. `dry_run` reports without writing. Returns the one log line emitted."""
+    kind = action["action"]
+    if kind == "blocked":
+        return f"skipped '{DESTINATION_NAME}': {action['reason']}"
+    if kind == "unchanged":
+        return f"unchanged '{DESTINATION_NAME}' (id={action['id']})"
+    verb = "create" if kind == "create" else "update"
+    if dry_run:
+        return f"[dry-run] {verb} destination '{DESTINATION_NAME}'"
+    if kind == "create":
+        created = client.create(action["payload"])
+        return f"created destination '{DESTINATION_NAME}' -> {created.get('id')}"
+    client.update(action["id"], action["payload"])
+    return f"updated destination '{DESTINATION_NAME}' (id={action['id']})"
+
+
+# ── I/O (mocked in tests) ────────────────────────────────────────────────────────────
+
+class PostHogFunctionsClient:
+    """Thin PostHog REST wrapper — only the `hog_functions` calls this script needs."""
+
+    def __init__(self, api_key: str, project_id: str, app_host: str = DEFAULT_APP_HOST) -> None:
+        self.app_host = app_host.rstrip("/")
+        self._base = f"{self.app_host}/api/projects/{project_id}"
+        self._headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    def _paged(self, path: str) -> list:
+        import requests
+        results, url = [], f"{self._base}{path}"
+        while url:
+            response = requests.get(url, headers=self._headers, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+            results.extend(payload.get("results", []))
+            url = payload.get("next")
+        return results
+
+    def find_destination(self, name: str) -> Optional[dict]:
+        for item in self._paged(f"/hog_functions/?type={FUNCTION_TYPE}&limit=100"):
+            if item.get("name") == name and not item.get("deleted"):
+                return item
+        return None
+
+    def create(self, payload: dict) -> dict:
+        import requests
+        response = requests.post(f"{self._base}/hog_functions/", headers=self._headers,
+                                 json=payload, timeout=30)
+        response.raise_for_status()
+        return response.json() if response.content else {}
+
+    def update(self, function_id, payload: dict) -> None:
+        import requests
+        response = requests.patch(f"{self._base}/hog_functions/{function_id}/",
+                                  headers=self._headers, json=payload, timeout=30)
+        response.raise_for_status()
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Provision the LEM ops-ping realtime CDP destination (429 breaker trip).")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--apply", action="store_true", help="Write changes to PostHog.")
+    mode.add_argument("--dry-run", action="store_true", help="Report changes only (default).")
+    parser.add_argument("--print-payload", action="store_true",
+                        help="Print the HogFunction payload for a placeholder URL and exit.")
+    args = parser.parse_args(argv)
+
+    if args.print_payload:
+        import json
+        print(json.dumps(destination_payload(PLACEHOLDER_URL), indent=2))
+        return 0
+
+    api_key = os.getenv("POSTHOG_PERSONAL_API_KEY", "")
+    if not api_key:
+        print("POSTHOG_PERSONAL_API_KEY is not set — cannot reach PostHog.", file=sys.stderr)
+        return 1
+
+    project_id = os.getenv("POSTHOG_PROJECT_ID", DEFAULT_PROJECT_ID)
+    app_host = os.getenv("POSTHOG_APP_HOST", DEFAULT_APP_HOST)
+    dry_run = args.dry_run or not args.apply
+    webhook_url = os.getenv("POSTHOG_OPS_WEBHOOK_URL", "").strip()
+
+    client = PostHogFunctionsClient(api_key, project_id, app_host)
+    try:
+        existing = client.find_destination(DESTINATION_NAME)
+    except Exception as exc:
+        print(f"Failed to read PostHog state: {exc}", file=sys.stderr)
+        return 1
+
+    action = plan_destination(existing, webhook_url)
+    print(apply_plan(client, action, dry_run))
+
+    if action["action"] == "blocked":
+        print("Set POSTHOG_OPS_WEBHOOK_URL to a Slack incoming-webhook (or any https:// webhook) "
+              "URL, then re-run with --apply.", file=sys.stderr)
+        return 0
+    if dry_run and action["action"] in ("create", "update"):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(main())

--- a/tests/unit/test_posthog_ops_destination.py
+++ b/tests/unit/test_posthog_ops_destination.py
@@ -29,7 +29,7 @@ class TestDestinationPayload:
 
     def test_payload_shape(self):
         payload = pod.destination_payload("https://hooks.example.com/x")
-        assert payload["type"] == "internal_destination"
+        assert payload["type"] == "destination"
         assert payload["template_id"] == "template-webhook"
         assert payload["name"] == pod.DESTINATION_NAME
         assert payload["enabled"] is True

--- a/tests/unit/test_posthog_ops_destination.py
+++ b/tests/unit/test_posthog_ops_destination.py
@@ -1,0 +1,226 @@
+"""Unit tests for scripts/posthog_ops_destination.py — the realtime 429-breaker-trip CDP
+destination (issue #655, PH10 spike)."""
+
+import importlib.util
+import pathlib
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+pod = _load("posthog_ops_destination")
+
+
+class TestDestinationPayload:
+    def test_filters_on_the_rate_limit_trip_event(self):
+        assert pod.destination_filters() == {
+            "events": [{"id": "rate_limit_trip", "type": "events"}]}
+
+    def test_payload_shape(self):
+        payload = pod.destination_payload("https://hooks.example.com/x")
+        assert payload["type"] == "internal_destination"
+        assert payload["template_id"] == "template-webhook"
+        assert payload["name"] == pod.DESTINATION_NAME
+        assert payload["enabled"] is True
+        assert payload["inputs"] == {"url": {"value": "https://hooks.example.com/x"}}
+        assert payload["filters"] == pod.destination_filters()
+
+
+class TestPlanDestination:
+    def test_no_webhook_url_is_blocked(self):
+        action = pod.plan_destination(None, "")
+        assert action["action"] == "blocked"
+        assert "POSTHOG_OPS_WEBHOOK_URL" in action["reason"]
+
+    def test_blocked_even_if_destination_already_exists(self):
+        # An empty URL is never actionable, regardless of what's already live.
+        existing = {"id": 1, "filters": pod.destination_filters(), "enabled": True,
+                    "inputs": {"url": {"value": "https://old.example.com"}}}
+        action = pod.plan_destination(existing, "")
+        assert action["action"] == "blocked"
+
+    def test_create_when_missing(self):
+        action = pod.plan_destination(None, "https://hooks.example.com/x")
+        assert action["action"] == "create"
+        assert action["payload"]["inputs"]["url"]["value"] == "https://hooks.example.com/x"
+
+    def test_unchanged_when_identical(self):
+        existing = {"id": 7, "filters": pod.destination_filters(), "enabled": True,
+                    "inputs": {"url": {"value": "https://hooks.example.com/x"}}}
+        action = pod.plan_destination(existing, "https://hooks.example.com/x")
+        assert action == {"action": "unchanged", "id": 7}
+
+    def test_update_when_url_drifted(self):
+        existing = {"id": 7, "filters": pod.destination_filters(), "enabled": True,
+                    "inputs": {"url": {"value": "https://old.example.com"}}}
+        action = pod.plan_destination(existing, "https://new.example.com")
+        assert action["action"] == "update"
+        assert action["id"] == 7
+        assert action["payload"]["inputs"]["url"]["value"] == "https://new.example.com"
+
+    def test_update_when_disabled(self):
+        existing = {"id": 7, "filters": pod.destination_filters(), "enabled": False,
+                    "inputs": {"url": {"value": "https://hooks.example.com/x"}}}
+        action = pod.plan_destination(existing, "https://hooks.example.com/x")
+        assert action["action"] == "update"
+
+    def test_update_when_filters_drifted(self):
+        existing = {"id": 7, "filters": {"events": []}, "enabled": True,
+                    "inputs": {"url": {"value": "https://hooks.example.com/x"}}}
+        action = pod.plan_destination(existing, "https://hooks.example.com/x")
+        assert action["action"] == "update"
+
+
+class TestApplyPlan:
+    def test_blocked_logs_and_never_touches_the_client(self):
+        client = MagicMock()
+        line = pod.apply_plan(client, {"action": "blocked", "reason": "no url"}, dry_run=False)
+        assert "skipped" in line and "no url" in line
+        client.create.assert_not_called()
+        client.update.assert_not_called()
+
+    def test_unchanged_logs_and_never_touches_the_client(self):
+        client = MagicMock()
+        line = pod.apply_plan(client, {"action": "unchanged", "id": 3}, dry_run=False)
+        assert "unchanged" in line
+        client.create.assert_not_called()
+
+    def test_dry_run_create_never_touches_the_client(self):
+        client = MagicMock()
+        line = pod.apply_plan(client, {"action": "create", "payload": {}}, dry_run=True)
+        assert "[dry-run] create" in line
+        client.create.assert_not_called()
+
+    def test_apply_create_calls_the_client(self):
+        client = MagicMock()
+        client.create.return_value = {"id": 42}
+        line = pod.apply_plan(client, {"action": "create", "payload": {"x": 1}}, dry_run=False)
+        client.create.assert_called_once_with({"x": 1})
+        assert "created destination" in line and "42" in line
+
+    def test_apply_update_calls_the_client(self):
+        client = MagicMock()
+        line = pod.apply_plan(
+            client, {"action": "update", "id": 9, "payload": {"x": 1}}, dry_run=False)
+        client.update.assert_called_once_with(9, {"x": 1})
+        assert "updated destination" in line
+
+
+class TestMain:
+    def test_print_payload_needs_no_network(self, capsys):
+        assert pod.main(["--print-payload"]) == 0
+        out = capsys.readouterr().out
+        assert pod.PLACEHOLDER_URL in out
+        assert "template-webhook" in out
+
+    def test_missing_api_key_is_an_error(self, monkeypatch, capsys):
+        monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+        assert pod.main([]) == 1
+        assert "POSTHOG_PERSONAL_API_KEY" in capsys.readouterr().err
+
+    def test_no_webhook_url_exits_zero_with_instructions(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        monkeypatch.delenv("POSTHOG_OPS_WEBHOOK_URL", raising=False)
+        client = MagicMock()
+        client.find_destination.return_value = None
+        monkeypatch.setattr(pod, "PostHogFunctionsClient", lambda *a, **k: client)
+        assert pod.main(["--apply"]) == 0
+        err = capsys.readouterr().err
+        assert "POSTHOG_OPS_WEBHOOK_URL" in err
+        client.create.assert_not_called()
+
+    def test_dry_run_with_url_reports_pending(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        monkeypatch.setenv("POSTHOG_OPS_WEBHOOK_URL", "https://hooks.example.com/x")
+        client = MagicMock()
+        client.find_destination.return_value = None
+        monkeypatch.setattr(pod, "PostHogFunctionsClient", lambda *a, **k: client)
+        assert pod.main(["--dry-run"]) == 2
+        assert "[dry-run] create" in capsys.readouterr().out
+        client.create.assert_not_called()
+
+    def test_apply_with_url_creates_the_destination(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        monkeypatch.setenv("POSTHOG_OPS_WEBHOOK_URL", "https://hooks.example.com/x")
+        client = MagicMock()
+        client.find_destination.return_value = None
+        client.create.return_value = {"id": 42}
+        monkeypatch.setattr(pod, "PostHogFunctionsClient", lambda *a, **k: client)
+        assert pod.main(["--apply"]) == 0
+        client.create.assert_called_once()
+        assert client.create.call_args.args[0]["inputs"]["url"]["value"] == \
+            "https://hooks.example.com/x"
+        assert "created destination" in capsys.readouterr().out
+
+    def test_apply_unchanged_is_a_noop(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        monkeypatch.setenv("POSTHOG_OPS_WEBHOOK_URL", "https://hooks.example.com/x")
+        client = MagicMock()
+        client.find_destination.return_value = {
+            "id": 7, "filters": pod.destination_filters(), "enabled": True,
+            "inputs": {"url": {"value": "https://hooks.example.com/x"}}}
+        monkeypatch.setattr(pod, "PostHogFunctionsClient", lambda *a, **k: client)
+        assert pod.main(["--apply"]) == 0
+        client.create.assert_not_called()
+        client.update.assert_not_called()
+        assert "unchanged" in capsys.readouterr().out
+
+    def test_read_failure_is_an_error(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_PERSONAL_API_KEY", "phx_test")
+        client = MagicMock()
+        client.find_destination.side_effect = RuntimeError("boom")
+        monkeypatch.setattr(pod, "PostHogFunctionsClient", lambda *a, **k: client)
+        assert pod.main([]) == 1
+        assert "Failed to read PostHog state" in capsys.readouterr().err
+
+
+class TestPostHogFunctionsClient:
+    def test_create_posts_to_the_right_url(self):
+        from unittest.mock import patch
+        client = pod.PostHogFunctionsClient("phx_test", "475262", "https://us.posthog.com")
+        response = MagicMock()
+        response.content = b'{"id": 1}'
+        response.json.return_value = {"id": 1}
+        with patch("requests.post", return_value=response) as post:
+            client.create({"name": "x"})
+        assert post.call_args.args[0] == \
+            "https://us.posthog.com/api/projects/475262/hog_functions/"
+        assert post.call_args.kwargs["headers"]["Authorization"] == "Bearer phx_test"
+
+    def test_update_patches_the_function_id(self):
+        from unittest.mock import patch
+        client = pod.PostHogFunctionsClient("phx_test", "475262", "https://us.posthog.com")
+        response = MagicMock()
+        response.content = b""
+        with patch("requests.patch", return_value=response) as patch_call:
+            client.update(9, {"name": "x"})
+        assert patch_call.call_args.args[0] == \
+            "https://us.posthog.com/api/projects/475262/hog_functions/9/"
+
+    def test_find_destination_filters_by_name_and_skips_deleted(self):
+        from unittest.mock import patch
+        client = pod.PostHogFunctionsClient("phx_test", "475262", "https://us.posthog.com")
+        response = MagicMock()
+        response.json.return_value = {
+            "results": [
+                {"name": "other", "id": 1},
+                {"name": pod.DESTINATION_NAME, "id": 2, "deleted": True},
+                {"name": pod.DESTINATION_NAME, "id": 3},
+            ],
+            "next": None,
+        }
+        response.raise_for_status = MagicMock()
+        with patch("requests.get", return_value=response):
+            found = client.find_destination(pod.DESTINATION_NAME)
+        assert found["id"] == 3


### PR DESCRIPTION
## What & why

PH10 spike (#655): scoped evaluation of four newer/adjacent PostHog surfaces — CDP realtime
destinations, Workflows, Logs OTel ingestion, and Scouts/Self-driving Inbox — each measured against
what LEM already has, per the issue's "docs + minimal config, no heavy build" scope.

**Deliverable:** `docs/posthog-advanced-surface.md`, with a clear adopt/skip/watch call for each
surface:

| Surface | Call |
|---|---|
| CDP realtime destinations | **Adopt (scoped)** — shipped one, inert until a webhook/Slack URL exists |
| Workflows | **Skip** — keep the existing `onboarding.py`/`notifications.py` nudge machinery |
| Logs (OTLP ingestion) | **Already adopted** — `logger.py` has shipped to PostHog Logs since #647/#648 |
| Scouts / Self-driving Inbox | **Skip** for code-fixing (overlaps this repo's own agent pipeline, capped at 3 runs/month) / **Watch** for observability-gap audits |

**Working destination:** `scripts/posthog_ops_destination.py` provisions one realtime CDP
destination — an ops ping the instant the LinkedIn 429 breaker trips (`rate_limit_trip`), rather
than waiting for the existing daily threshold alert (#650) to evaluate. Same dry-run/`--apply`/
pure-plan-plus-thin-client shape as `posthog_provision.py`/`posthog_annotate.py`.

I checked this PostHog project directly before writing any code: zero CDP destinations and zero
third-party integrations (Slack, GitHub, etc.) exist today, and standing one up needs either an
OAuth flow (can't complete headless) or an owner-supplied `https://` URL. Rather than fabricate a
target, the script is inert by default — with no `POSTHOG_OPS_WEBHOOK_URL` set, `--dry-run` and
`--apply` both explain what's missing and exit 0, the same "degrade to a no-op, never fail the run"
pattern `posthog_annotate.py` already uses for a missing API key. **One open follow-up, not a
blocker:** set `POSTHOG_OPS_WEBHOOK_URL` in `/opt/lem/.env` to a Slack incoming-webhook URL (or any
other webhook) and run `--apply` to make the ping live.

The Logs finding is worth calling out: the issue asked to evaluate OTel ingestion as a *replacement*
for the logger.py PostHog handler, but `logger.py`'s handler already ships over OTLP to PostHog Logs
— that migration happened two milestones ago (#647/#648), so there's nothing left to migrate.

## Testing

- `poetry run pytest tests/unit/test_posthog_ops_destination.py -q` — 24 new tests (pure
  plan/payload logic + the thin REST client, all mocked — no network).
- `poetry run pytest tests/unit/test_posthog_ops_destination.py tests/unit/test_posthog_annotate.py tests/unit/test_posthog_provision.py -q` — 126 passed, no regressions in the sibling posthog_*.py scripts.

Closes #655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)