### PR TITLE
docs(infra): cost/feasibility spike — hosted grids vs self-managed VPS scaling (closes #633)

### DIFF
--- a/docs/SELENIUM_GRID.md
+++ b/docs/SELENIUM_GRID.md
@@ -235,17 +235,21 @@ this:
 
 ## 5. The decision point: 16 vCPU / 64 GB, a second box — or someone else's grid
 
-**Status: default path set, hardware not yet bought (#633, 2026-07-27).** Nothing is bought until
-the capacity monitor (§5e in `docs/scaling-plan.md`) says the cap is the operating point. #633
-widened the option set and priced hosted/cloud grids (AWS Fargate/EC2 nodes, Device Farm,
+**Status: decided — self-managed, hardware not yet bought (#633, 2026-07-27).** The "someone else's
+grid" third option in this section's title is **closed**: LEM stays self-managed and no hosted
+vendor is pursued. Nothing is bought until the capacity monitor (§5e in `docs/scaling-plan.md`)
+says the cap is the operating point.
+
+#633 widened the option set and priced hosted/cloud grids (AWS Fargate/EC2 nodes, Device Farm,
 BrowserStack, Sauce Labs, LambdaTest, TestingBot, Browserless, Browserbase, Steel) against the two
 self-managed baselines below — full comparison: `docs/scaling-cost-options.md`. As suspected, most
 of that market disqualifies itself on session length (Device Farm caps at 40 min, the QA clouds at
 30 min–3 hr with no confirmed login persistence), explicit ToS (Sauce Labs bans non-testing social
-media use in writing), or protocol (Browserless is CDP-first, not Selenium) — Steel.dev and
-Browserbase are the two that fit LEM's pattern on paper and are cheaper than AWS, but both have an
-open question blocking use (a Selenium-compatibility check, and for Steel a real ToS read) and
-neither is recommended over self-managed today.
+media use in writing), or protocol (Browserless is CDP-first, not Selenium). Steel.dev and
+Browserbase were the two that fit LEM's pattern on paper and beat AWS on cost, but each carried an
+unresolved blocker (a Selenium-compatibility check, and for Steel a real ToS read) — and the owner's
+call was to **not spend the time resolving them**. They are out with the rest of the market; no
+vendor spike is scheduled at any user tier.
 
 **#633 also corrects this section's own premise: Option A below assumed an in-place resize that
 does not exist.** Hostinger's VPS line tops out at the box LEM already runs (8 vCPU / 32 GB) — a 16

--- a/docs/SELENIUM_GRID.md
+++ b/docs/SELENIUM_GRID.md
@@ -235,14 +235,24 @@ this:
 
 ## 5. The decision point: 16 vCPU / 64 GB, a second box — or someone else's grid
 
-**Status: deliberately undecided (owner call on #556, 2026-07-26).** Nothing is bought until the
-capacity monitor (§5e) says the cap is the operating point, and the option set is widened first:
-**#633** prices hosted/cloud grids (AWS Fargate/EC2 nodes, Device Farm, BrowserStack, Sauce Labs,
-LambdaTest, Browserless, Browserbase, Steel) against the two self-managed baselines below, keyed to
-this section's sessions-needed curve. That comparison is a spike, not a foregone conclusion: most of
-that market is *test* infrastructure and may disqualify itself on datacenter egress IPs (we route
-per-user residential proxies on purpose), per-minute billing against long-lived logged-in sessions,
-ToS clauses on social automation, and whether the MV3 proxy-auth extension can load at all.
+**Status: default path set, hardware not yet bought (#633, 2026-07-27).** Nothing is bought until
+the capacity monitor (§5e in `docs/scaling-plan.md`) says the cap is the operating point. #633
+widened the option set and priced hosted/cloud grids (AWS Fargate/EC2 nodes, Device Farm,
+BrowserStack, Sauce Labs, LambdaTest, TestingBot, Browserless, Browserbase, Steel) against the two
+self-managed baselines below — full comparison: `docs/scaling-cost-options.md`. As suspected, most
+of that market disqualifies itself on session length (Device Farm caps at 40 min, the QA clouds at
+30 min–3 hr with no confirmed login persistence), explicit ToS (Sauce Labs bans non-testing social
+media use in writing), or protocol (Browserless is CDP-first, not Selenium) — Steel.dev and
+Browserbase are the two that fit LEM's pattern on paper and are cheaper than AWS, but both have an
+open question blocking use (a Selenium-compatibility check, and for Steel a real ToS read) and
+neither is recommended over self-managed today.
+
+**#633 also corrects this section's own premise: Option A below assumed an in-place resize that
+does not exist.** Hostinger's VPS line tops out at the box LEM already runs (8 vCPU / 32 GB) — a 16
+vCPU/64 GB box is only available by switching provider entirely (~$315/mo Hetzner, ~$504/mo
+DigitalOcean), which is a full migration (DNS, data, Docker stack, Cloudflare Tunnel cutover), not
+a plan change. Read the row below with that correction; **Option B is the default now**, not a
+close second.
 
 The two self-managed options are both real at ~50 users, and the load test picks between them by what
 has to scale.
@@ -250,25 +260,31 @@ has to scale.
 | | **A. Upgrade to 16 vCPU / 64 GB** | **B. Second VPS running Grid nodes** |
 |---|---|---|
 | Sessions it buys | ~16 concurrent (2× today) | ~8 per added box, unbounded by adding boxes |
-| Cost shape | one bigger monthly bill; no new ops surface | a second bill + a private network to run and firewall |
+| Cost shape | one bigger monthly bill (**now a different provider's bill** — see below) | a second, same-provider bill + a private network to run and firewall |
 | Failure domain | still ONE box — it takes the app tier with it | app tier survives a Chrome-box outage |
-| Ops cost | a resize + a restart | WireGuard/VPC, a second host to patch, node registration to monitor |
+| Ops cost | **a full migration** (DNS, data, Docker stack, Cloudflare Tunnel cutover) — Hostinger has no bigger tier to resize into | same-provider: a second host to patch + node registration to monitor, no migration |
 | Egress | unchanged (per-user proxies do the egress, `EGRESS_AT_SCALE.md`) | unchanged — nodes egress through the same per-user proxies |
 | Ceiling | ~16 sessions ≈ **50–60 users staggered**; then this decision repeats | none in practice |
 
-**Where this stands:** staggering went first and has shipped (#554), and re-measuring it (#634) found
-the 50-user curve is now **15** sessions, not the originally-predicted 11 — the shared `se_outreach`
-lane needs its own fix first (**#696**) before staggering delivers the win the plan banked on.
-Between A and B, A is still the cheaper answer *if* the choice were made today: one 16 vCPU / 64 GB
-box covers the ~15 sessions that 50 users need (18.0 GB Chrome + ~6 GB app tier fits 64 GB with room)
-at a fraction of the operational cost of a second host, and B's fault isolation only starts paying
-when Chrome and the app tier genuinely compete — the 100-user row, not the 50-user one. B is the
-answer past **~16 sessions**, i.e. 100 users at any stagger.
+**Where this stands (updated by #633):** staggering went first and has shipped (#554) — it was the
+only free move — and re-measuring it (#634) found the 50-user curve is now **15** sessions, not the
+originally-predicted 11: the shared `se_outreach` lane needs its own fix first (**#696**) before
+staggering delivers the win the plan banked on.
 
-But the choice is **not** being made today. The sequence the owner set is: bank the stagger (done) →
-re-measure it (done, #634 — result: fix #696 first) → price hosted alternatives beside A and B
-(#633) → decide when §5e files a breach. Buying either box now would pay for capacity the curve
-cannot yet prove is needed, and would foreclose an option that has not been costed.
+**A is no longer the cheaper answer today.** #633 found Hostinger's VPS line tops out at the box LEM
+already runs, so "upgrade to 16 vCPU / 64 GB" now means switching provider entirely (~$315/mo
+Hetzner, ~$504/mo DigitalOcean) plus a real migration project, not a resize. B (a second
+same-provider box, already built as `docker-compose.grid-node.yml`) is cheaper in absolute terms at
+every tier this plan projects (~$52–200/mo vs. A's ~$315–504/mo) **and** carries none of A's
+one-time migration risk. That reverses the old reading of the 50-user row — A's edge there was
+operational simplicity, and the migration eats it. **B is the default path**, not just the answer
+past ~16 sessions.
+
+The choice is **still not being made today** — nothing is bought until §5e files a breach. What
+#633 resolved is *which* option to reach for when that happens: B, not A. The sequence that
+remains: bank the stagger (done) → re-measure it (done, #634 — result: fix #696 first, then re-run)
+→ cut over the Grid at parity → scale nodes per §6's checklist when §5e says the cap is the
+operating point.
 
 The Grid is worth cutting over to **before** either, at the same 8 nodes: it is capacity-neutral,
 it makes a crashed Chrome cost one session instead of all of them, and it is the thing that makes B

--- a/docs/scaling-cost-options.md
+++ b/docs/scaling-cost-options.md
@@ -1,0 +1,275 @@
+# Selenium Hosting — Cost & Feasibility Comparison (Hosted/Cloud vs Self-Managed)
+
+**Status:** Research spike, no infra changes · **Issue:** #633 (spike; risk: product-decision) ·
+**Date:** 2026-07-27 · **Owner:** Chris
+
+> Companion docs: `docs/scaling-plan.md` (the compute/concurrency plan this spike widens),
+> `docs/SELENIUM_GRID.md` (the self-managed Grid that's already **built, not enabled** — §5 there
+> parked the "16 vCPU/64 GB vs second box" decision pending this doc), `docs/EGRESS_AT_SCALE.md`
+> (why residential egress + ToS posture are load-bearing requirements below, not nice-to-haves).
+
+## TL;DR
+
+- **The premise that self-managed Option A ("upgrade to 16 vCPU / 64 GB") is a cheap in-place
+  resize is wrong.** Hostinger's VPS line **tops out at KVM8 (8 vCPU / 32 GB)** — there is no
+  bigger tier to resize into. A 16 vCPU/64 GB box is real money (~$315/mo Hetzner, ~$504/mo
+  DigitalOcean) **and a full cross-provider migration** (DNS, data, Docker stack, Cloudflare
+  Tunnel cutover), not a plan change. This flips `SELENIUM_GRID.md` §5's "A is cheaper if the
+  choice were made today" call — see §6 below.
+- **A second same-provider Hostinger box (Option B) is still the cheapest, lowest-risk, lowest-effort
+  path** — ~$26–50/mo, same panel, no new vendor relationship, no ToS exposure, and it's exactly
+  what `docker-compose.grid-node.yml` already targets.
+- **Almost all of the hosted/cloud market is disqualified for LEM's specific use case** — a
+  logged-in, cookie-persisted, days-to-weeks LinkedIn session over a per-user residential proxy —
+  not because of price, but structurally:
+  - **AWS Device Farm**: hard 40-minute session cap, `--user-data-dir` explicitly blocked. Cannot
+    hold a login. Disqualified outright, independent of price.
+  - **QA-testing clouds** (BrowserStack, Sauce Labs, LambdaTest, TestingBot): built for short,
+    ephemeral, own-app test runs. **Sauce Labs' Acceptable Use Policy explicitly bans "any social
+    media site other than for purposes of software testing"** — a direct textual conflict with
+    LEM's use case, not an inference. The others aren't as explicit but no vendor confirms
+    cross-session cookie persistence, and none is a clean fit.
+  - **Browserless**: disqualified on protocol — CDP/Puppeteer-first, not native Selenium
+    WebDriver, so it fails the "zero app-code-change" bar `get_docker_driver()` was built around.
+  - **ZenRows / ScrapingBee**: structural mismatch — per-request scraping APIs, not persistent
+    browser sessions. ZenRows' closest product caps session TTL at 1–15 minutes.
+- **Two vendors are a genuine, cheap fit on paper: Steel.dev and Browserbase.** Both are built for
+  exactly LEM's pattern — persistent authenticated sessions (`Profiles`/`Contexts` API), BYOP
+  (bring-your-own residential proxy, at no extra charge on Steel), custom extension loading, and
+  no session-length ceiling that matters at LEM's scale. Both are **cheaper than every AWS option
+  and cheaper than a Hetzner/DO primary-box upgrade** — Steel.dev ~$33–430/mo and Browserbase
+  ~$47–399/mo across the 10→100 user range, vs. AWS Fargate's ~$165–1,115/mo. Two things are
+  **not yet verified** and block acting on this: Steel's actual ToS text (redirects to a Google
+  Doc this research pass couldn't extract), and whether either vendor's WebDriver path is a true
+  URL-repoint into `get_docker_driver()` or needs a connection wrapper (Browserbase confirmed
+  needs one; Steel's Selenium support is documented but CDP-first).
+- **AWS Fargate/EC2 Grid nodes are real and technically workable** (residential-proxy egress layers
+  on cleanly; on-demand session-length is unbounded) **but cost more than every self-managed and
+  Steel/Browserbase option at every tier**, and add real new ops surface (NAT/ASG/ECS) LEM doesn't
+  otherwise need. Fargate Spot / EC2 Spot are not recommended as primary capacity — a 2-minute-warning
+  reclaim mid-comment/mid-DM risks a half-submitted action on a live account and the kind of session
+  churn that trips LinkedIn's own anti-bot detection.
+- **Recommendation (detail in §6, decision trigger in `docs/scaling-plan.md` §5f):** stay on the
+  self-managed path (Option B, same-provider Hostinger boxes, using the Grid that's already built)
+  as the default horizontal scale-out — it's cheap, proven, and carries zero new ToS/vendor risk.
+  Run one **cheap, non-committal technical spike** against Steel.dev and/or Browserbase (both have
+  free tiers) to settle the two open unknowns above, because if either clears, it's a materially
+  lower-ops alternative at the 100-user tier. Do **not** pursue AWS-hosted Grid nodes, AWS Device
+  Farm, or any QA-testing cloud (BrowserStack/Sauce Labs/LambdaTest/TestingBot/Browserless/
+  ZenRows/ScrapingBee) — each is either disqualified outright or strictly worse on both cost and
+  fit than what's already available.
+
+---
+
+## 1. What this is keyed to
+
+Per `docs/SELENIUM_GRID.md` §4, the load test (`selenium_load_test.py`, issue #556) measured how
+many concurrent Chrome sessions keep 95% of engagement work inside its window, on today's topology
+(8 slots, lanes 3/2/2/1):
+
+| Users | Sessions needed (measured, pre-stagger) | Sessions needed (staggered, **predicted** — re-run is #634) |
+|---|---|---|
+| 10 | 5 | 4 |
+| 50 | 14 | 11 |
+| 100 | 27 | 20 |
+
+Every cost column below is priced at **both** numbers as `staggered (measured)` — e.g. `4 (5)` —
+because the staggered curve is still a prediction pending #634, and pricing the conservative
+(measured) number avoids under-provisioning if #634 comes back worse than modeled. Ratio used
+throughout: **~1 vCPU + ~1.2–1.5 GB RAM per concurrent Chrome session** (matches §4's measured 8
+slots ≈ 6.5–8 vCPU / 6–8 GB), and **~65–70 active Selenium-minutes/user/day** (§4's per-user
+workload total) for any vendor billed by browser-minute rather than by concurrency tier.
+
+All prices below accessed **2026-07-27**; this market moves fast — re-verify before committing
+money, per the issue's own instruction.
+
+---
+
+## 2. Cost comparison chart
+
+### 2a. Self-managed baselines
+
+| Option | $/mo @ 10 users | $/mo @ 50 users | $/mo @ 100 users | Setup/ops effort | Residential egress | ToS risk | Session-length fit | Rollback difficulty | Verdict |
+|---|---|---|---|---|---|---|---|---|---|
+| **A. Upgrade primary box to ~16 vCPU/64 GB** | n/a — plan doesn't exist on current provider | ~$315/mo (Hetzner CCX43) or ~$504/mo (DO 16vCPU/64GB) | same box, at its ceiling (~50–60 staggered users per `SELENIUM_GRID.md` §5) | **High** — Hostinger has no such tier, so this is a **full cross-provider migration** (DNS, MySQL/Redis/assets data, Docker stack, Cloudflare Tunnel), not a resize | Unchanged — per-user proxies do the egress, independent of host | None (self-managed) | Unlimited (own box) | Migration is itself hard to reverse quickly (a second cutover) | **Not a resize anymore — corrects `SELENIUM_GRID.md` §5's premise. Only worth it if the app tier also needs headroom the second-box path doesn't give.** |
+| **B. Second VPS running Grid nodes (same provider)** | ~$0 marginal (10 users' 4–5 sessions fit the existing 8-slot box) | ~$52–100/mo (2 Hostinger KVM8 boxes, 16 slots) | ~$78–200/mo (3–4 boxes, 24–32 slots) | **Low** — same panel, same provider, `docker-compose.grid-node.yml` already built for this exact topology (issue #556) | Unchanged | None (self-managed) | Unlimited | **Lowest** — one flag reverts the Grid overlay to `standalone` (`docs/SELENIUM_GRID.md` §2) | **Cheapest, lowest-risk, already built. Default horizontal path.** |
+
+Hostinger KVM8 (the current box's own tier) prices **$25.99–29.99/mo promo, ~$49.99/mo at
+renewal** — [hostinger.com/vps-hosting](https://www.hostinger.com/vps-hosting), accessed
+2026-07-27. Hostinger's lineup has **no tier above KVM8** — confirmed by searching its full VPS
+plan list; nothing between KVM8 and an unlisted, unpriced dedicated-server quote. Hetzner's
+CCX43 (16 vCPU/64 GB) and CCX33 (8 vCPU/32 GB, the Option-B-equivalent second box on Hetzner) both
+reflect Hetzner's **June 15, 2026 price increase** (CCX line +121–122%, DRAM-cost-driven,
+new-orders/resizes only — existing servers keep old pricing) —
+[northflank.com/blog/hetzner-cloud-server-price-increases](https://northflank.com/blog/hetzner-cloud-server-price-increases),
+corroborated by
+[wz-it.com](https://wz-it.com/en/blog/hetzner-price-increase-june-2026-cpx-ccx-alternatives/),
+accessed 2026-07-27. DigitalOcean 16vCPU/64GB General Purpose droplet: **$504/mo**
+($0.75/hr) — [digitalocean.com/pricing/droplets](https://www.digitalocean.com/pricing/droplets),
+accessed 2026-07-27.
+
+**Migration/ops effort, qualitatively:** an in-place Hostinger resize would be the cheapest ops
+path *if it existed* (Hostinger's own docs describe resizes elsewhere in their lineup as
+~10 minutes of panel work). It doesn't exist at this spec, so Option A is now a real migration —
+DNS cutover, full data migration, Docker stack + secrets re-provisioning, Cloudflare Tunnel
+re-pointing, a cutover window with real downtime risk absent a staged blue-green cutover. A
+second box on the **same** provider (Option B) needs no such project — Hetzner additionally
+offers native, unmetered private networking (VPC) between same-region boxes, which the mixed
+Hostinger-primary + Hetzner-second-box combination would not get (that pairing needs WireGuard
+instead).
+
+### 2b. AWS-hosted Grid nodes
+
+| Option | $/mo @ 10 users (4 or 5 sessions) | $/mo @ 50 users (11 or 14) | $/mo @ 100 users (20 or 27) | Setup/ops effort | Residential egress | ToS risk | Session-length fit | Rollback difficulty | Verdict |
+|---|---|---|---|---|---|---|---|---|---|
+| **ECS/Fargate Grid nodes (on-demand)** | $165–206/mo | $454–578/mo | $826–1,115/mo | **Medium** — real, documented community pattern (not first-party AWS), needs a hub + service discovery + autoscaler on top of the container images LEM already runs | Yes — proxy-auth extension runs inside the Chrome container, host-independent; watch NAT Gateway ($0.045/hr + $0.045/GB) if nodes sit in a private subnet | None found specific to this pattern | Unlimited on-demand; **Spot is not viable** (2-min reclaim kills mid-session login state and risks a half-submitted LinkedIn action) | Low-medium — same Docker images, just repoint the hub URL | **Workable but pricier than self-managed at every tier, plus new ops surface (NAT/ASG/ECS)** |
+| **EC2 Grid nodes (on-demand, c5.2xlarge, ~7 sessions/instance)** | $248/mo (1 instance) | $496/mo (2 instances) | $745–993/mo (3–4 instances) | **High** — you own AMI/patching, ASG, health checks; effectively a second, cloud-hosted twin of the existing infra | Same as Fargate | None found | Best AWS fit — unbounded on-demand session length; Spot viable only as a burst/overflow tier with cookies persisted externally | Low-medium | **Cheapest AWS option but most AWS ops burden; still costs more than Option B at every tier** |
+| **AWS Device Farm (Desktop Browser Testing)** | disqualified | disqualified | disqualified | N/A | Unsupported path (AWS datacenter IPs; loading LEM's proxy-auth extension is explicitly "not officially supported") | Not confirmed as a ToS ban, but moot | **Hard 40-min session cap; `--user-data-dir` explicitly blocked** — cannot hold a login at all | N/A | **DISQUALIFIED — cannot hold a session past 40 minutes or persist a login, at any price** |
+
+Fargate on-demand: **$0.04048/vCPU-hr + $0.004445/GB-hr**
+([aws.amazon.com/fargate/pricing](https://aws.amazon.com/fargate/pricing/)); EC2 c5.2xlarge
+on-demand: **$0.34/hr**
+([economize.cloud/resources/aws/pricing/ec2/c5.2xlarge](https://www.economize.cloud/resources/aws/pricing/ec2/c5.2xlarge/));
+Device Farm: **$0.005/browser-instance-minute**, session caps confirmed directly from
+[docs.aws.amazon.com/devicefarm/latest/testgrid/techref-support.html](https://docs.aws.amazon.com/devicefarm/latest/testgrid/techref-support.html).
+All accessed 2026-07-27; NAT Gateway and EC2/Fargate Spot figures are flagged in the source
+research as **approximate** (Spot pricing renders client-side and moves in real time — pull a
+live quote before budgeting off it).
+
+### 2c. Commercial browser-automation / QA-cloud vendors
+
+| Vendor | $/mo @ 10 users | $/mo @ 50 users | $/mo @ 100 users | Native Selenium? | Residential egress | ToS risk | Session-length fit | Custom extension | Verdict |
+|---|---|---|---|---|---|---|---|---|---|
+| **BrowserStack Automate** | ~$325–400 (unverified extrapolation — multi-parallel pricing is sales-gated) | ~$1,100–1,350 | ~$2,100–2,600 | Yes | **No** — datacenter only; "Local Testing" is an inbound tunnel, not outbound-through-your-proxy | Product framed around testing *your own* app; no confirmed cross-session cookie persistence for Automate | 2 hr cap, 90s idle default | Yes (`.crx` load) | **Disqualified** — no residential egress, no confirmed login persistence |
+| **Sauce Labs** | ~$900–1,500 (unverified) | ~$2,500–4,000 | ~$5,000–8,000 | Yes | **No** — same inbound-tunnel model | **Explicit AUP ban**: "any social media site other than for purposes of software testing," plus a ban on unattended/not-logged-in processes | 3 hr cap | Yes | **Disqualified — direct, written ToS conflict, not an inference** |
+| **LambdaTest** | ~$580–750 (unverified, 5-parallel estimate; 14/27 sales-gated) | unpublished | unpublished | Yes | Unconfirmed `LT_PROXY_HOST` capability — may route outbound traffic through an external proxy, not verified live | No explicit ban found | 30 min auto-cap | Yes | **Weak candidate — not disqualified in writing, but no confirmed login persistence and unpublished pricing at scale; needs a live spike before serious evaluation** |
+| **TestingBot** | ~$90/mo flat (Automated Pro, nominally unlimited minutes/concurrency) | ~$90/mo flat (same caveat) | ~$90/mo flat (same caveat) | Yes | Unknown — no proxy/egress info published | No explicit ban found | Not published | Yes (Playwright-documented; presumed same for Selenium) | **Thinnest documentation of any vendor surveyed — cannot recommend without a direct vendor conversation on real limits behind "unlimited"** |
+| **Browserless** | ~$140/mo (Starter) | ~$350/mo + likely overage (Scale) | ~$350/mo + overage, or Enterprise | **No — CDP/Puppeteer/BQL-first** | Yes, paid (6 units/MB residential) + self-hosted BYOP | No explicit ban found | 15–60 min by plan | Yes | **Disqualified on protocol — not native Selenium WebDriver, fails the zero-app-code-change requirement** |
+| **Steel.dev** | ~$33–35/mo | ~$280–290/mo | ~$410–430/mo | Partial — Selenium documented, but CDP-first; may need a connection wrapper | **Yes** — managed residential proxies, Dedicated IPs, **free BYOP on all plans including free tier** | **Not independently verified** — real ToS is a Google Doc this research pass couldn't extract | 15 min–24 hr by plan; **explicit Profiles API persists cookies/login/extensions across separate sessions** | Yes (persists via Profiles) | **Strongest cost fit found — pending a direct Selenium-compatibility check and a real ToS read** |
+| **Browserbase** | ~$47–50/mo | ~$203–218/mo | ~$374–399/mo | Yes, but needs a **custom `RemoteConnection` wrapper** — not a pure `SELENIUM_HUB_HOST` repoint | **Yes** — residential by default (201 countries, geo-targeting) + BYOP | No explicit ban found; vendor markets a "Social Media Scraper" use case as intended use | 6 hr default cap; **explicit Contexts API persists cookies (incl. session cookies) across separate sessions** | Yes | **Strongest overall fit — mature docs, no ToS red flag, only friction is the Selenium wrapper and unconfirmed per-user IP stability across days (not just within a session)** |
+| **ZenRows / ScrapingBee** | not modeled — different billing unit (per-request, not per-minute/concurrency) | not modeled | not modeled | No | Bundled but moot | Neither explicitly names LinkedIn; ScrapingBee's AUP explicitly puts LinkedIn's own ToS risk back on the customer | **1–15 min hard cap (ZenRows Scraping Browser); no session concept at all (ScrapingBee)** | N/A | **Disqualified — structural mismatch, not a policy one. Cannot hold a login for more than 15 minutes at best.** |
+
+Full per-vendor pricing tiers, quotes, and source URLs are in the research notes this table was
+built from (BrowserStack, Sauce Labs, LambdaTest, TestingBot: browserstack.com/support/faq,
+saucelabs.com/doc/acceptable-use-policy, testmuai.com/pricing, testingbot.com/pricing; Browserless:
+browserless.io/pricing; Steel.dev: docs.steel.dev/overview/pricinglimits,
+docs.steel.dev/overview/profiles-api; Browserbase: docs.browserbase.com/platform/browser/
+core-features/contexts, browserbase.com/pricing; ZenRows/ScrapingBee: docs.zenrows.com/
+first-steps/pricing, scrapingbee.com/acceptable-use-policy — all accessed 2026-07-27).
+
+---
+
+## 3. Deal-breaker checklist (from the issue), scored
+
+| Check | AWS Fargate/EC2 | AWS Device Farm | BrowserStack/Sauce/LambdaTest/TestingBot | Browserless | Steel.dev / Browserbase | ZenRows/ScrapingBee | Self-managed (A/B) |
+|---|---|---|---|---|---|---|---|
+| Datacenter-only egress (no residential path) | Layerable (proxy inside container) | Yes, unsupported to change | Yes — no outbound-through-proxy mechanism found | Layerable (paid or BYOP) | **No — residential/BYOP native** | Bundled but moot | N/A — own box, own proxy |
+| Per-minute billing vs. multi-minute logged-in sessions | On-demand: fine. Spot: mismatched | Mismatched (40 min cap) | Mismatched (30 min–3 hr caps, no persistence) | Mismatched (15–60 min caps) | **Fits** (hour/day-scale, persisted) | Mismatched (1–15 min cap) | N/A |
+| ToS forbids social-automation/scraping | Not found | Not confirmed, moot (technical disqualifier) | **Sauce Labs: explicit ban.** Others: not found in writing | Not found | Steel: **unverified** (couldn't read real ToS). Browserbase: not found, positive signal (markets this use case) | Not found, but customer bears the risk explicitly | N/A |
+| Can load the MV3 proxy-auth extension | Yes (own container) | Unsupported | Yes (BrowserStack/TestingBot confirmed); N/A for the rest given other disqualifiers | Yes | Yes | No | N/A |
+
+---
+
+## 4. Self-managed detail
+
+See §2a. The one material new finding: **Hostinger's VPS line has no plan above KVM8 (8 vCPU /
+32 GB)** — `SELENIUM_GRID.md` §5's "Option A: Upgrade to 16 vCPU / 64 GB" implicitly assumed an
+in-place resize of the current box. That assumption is wrong; a 16 vCPU/64 GB box is only
+available by switching provider entirely (Hetzner or DigitalOcean), which is a full migration
+project, not a plan change. This is the single biggest correction this spike makes to the existing
+plan — see §6.
+
+## 5. AWS detail
+
+See §2b. Full technical detail (Fargate Spot interruption mechanics, EC2 packing math, Device
+Farm's exact disqualifying capability limits, NAT Gateway/data-transfer pricing) is preserved in
+the research this table summarizes; the short version is **all AWS paths cost more than the
+self-managed alternative at every tier and add ops surface LEM doesn't otherwise carry**, and
+Device Farm is a hard no regardless of price.
+
+## 6. Recommendation
+
+**Do not pursue:** AWS Device Farm (disqualified — cannot hold a session), any of the four
+QA-testing clouds (BrowserStack, Sauce Labs, LambdaTest, TestingBot — disqualified or unproven,
+Sauce Labs explicitly banned in writing), Browserless (wrong protocol), ZenRows/ScrapingBee
+(wrong computing model), and AWS Fargate/EC2 Grid nodes (technically fine, but strictly more
+expensive and more ops-heavy than what's already built and cheaper).
+
+**Default path stays self-managed, Option B** — additional same-provider Hostinger boxes running
+Grid nodes only, cut over via the already-built `docker-compose.grid-node.yml` /
+`docker-compose.grid.yml` (issue #556). It is the cheapest option at every tier (~$0–200/mo across
+10→100 users), carries zero new vendor/ToS risk, and needs no new capability — just more of what
+LEM already runs. `SELENIUM_GRID.md` §5's "Option A" (vertical upgrade) should be treated as
+**effectively retired**: the box it assumed doesn't exist on the current provider, and a
+cross-provider migration to buy 16 vCPU/64 GB costs more (~$315–504/mo) and carries more one-time
+risk (DNS/data/stack cutover) than just adding a second box for the same or lower steady-state
+cost.
+
+**One cheap, non-committal spike is worth running before the ~50-user trigger:** both Steel.dev
+and Browserbase are purpose-built for LEM's exact pattern (persistent authenticated sessions over
+a residential/BYOP proxy) and are materially cheaper than every AWS option — and cheaper than
+adding a third/fourth self-managed box at the 100-user tier, with none of the VPS patching/ops
+burden. Two things block a real decision and should be resolved with their free tiers before any
+spend: (1) does either vendor's Selenium path actually drop into `get_docker_driver()` cleanly, or
+does it need a real connector rewrite (Browserbase confirmed needs a `RemoteConnection` wrapper;
+Steel's Selenium support is documented but CDP-first), and (2) Steel's actual ToS terms (this
+research pass could not extract them — a direct legal read is needed before it's a candidate at
+all). This is exploration, not a purchase — nothing here should move traffic off the self-managed
+path until both are answered.
+
+**Decision trigger:** carried into `docs/scaling-plan.md` §5f — the self-managed Grid cutover
+happens per `SELENIUM_GRID.md` §6's existing checklist (capacity monitor breach → re-run the
+staggered load test → cut over at parity → then scale nodes/lanes together). Steel.dev/Browserbase
+only enter the decision if the spike above clears both open questions **and** the 100-user tier is
+actually approaching — below that, self-managed Option B is cheaper and lower-risk on its own.
+
+---
+
+## Open questions to verify before committing money
+
+- [ ] Live Fargate Spot / EC2 Spot pricing (this pass used an AWS-documentation example range for
+      EC2 Spot and an approximated ratio for Fargate Spot memory — neither is a live quote).
+- [ ] Hetzner/DigitalOcean exact bandwidth costs if a 16 vCPU/64 GB box is ever provisioned in a
+      US region (Hetzner's US bandwidth allowance dropped sharply — 1 TB/mo vs 20 TB/mo in EU —
+      alongside its June 2026 price increase).
+- [ ] BrowserStack/Sauce Labs/LambdaTest real multi-parallel pricing at 5/14/27 concurrent sessions
+      — all are sales-gated above 1 parallel; the figures above are third-party extrapolations, not
+      vendor quotes. Moot unless one of them is reconsidered, which is not recommended here.
+- [ ] TestingBot's actual fair-use ceiling behind "unlimited" on Automated Pro — the $90/mo flat
+      price is suspiciously cheap relative to every other vendor and needs a direct vendor
+      conversation before it's trusted.
+- [ ] Steel.dev's real Terms of Service (the public link redirects to a Google Doc this research
+      pass could not extract) — read it directly before treating Steel as a candidate.
+- [ ] Confirm live, with either Steel.dev or Browserbase support: does a `contextId`/`profileId`
+      reused days apart get the **same** residential egress IP each time (not just the same
+      geo-target), matching LEM's "one stable IP per user, pinned for the life of the account"
+      requirement (`EGRESS_AT_SCALE.md`)? Geo-targeting alone doesn't guarantee IP stability across
+      separate sessions.
+- [ ] Confirm Selenium (not CDP-wrapped) compatibility with `get_docker_driver()` for both Steel.dev
+      and Browserbase with a working code spike, not documentation alone.
+
+---
+
+## Sources
+
+**AWS:** aws.amazon.com/fargate/pricing · aws.amazon.com/device-farm/faqs ·
+docs.aws.amazon.com/devicefarm/latest/testgrid/techref-support.html ·
+economize.cloud/resources/aws/pricing/ec2/c5.2xlarge · aws.amazon.com/vpc/pricing ·
+egresscost.com/aws/data-transfer-pricing · github.com/taktakpeops/selenium-grid-ecs-fargate ·
+code.mendhak.com/selenium-grid-ecs (all accessed 2026-07-27)
+
+**Self-managed:** hostinger.com/vps-hosting · digitalocean.com/pricing/droplets ·
+northflank.com/blog/hetzner-cloud-server-price-increases ·
+wz-it.com/en/blog/hetzner-price-increase-june-2026-cpx-ccx-alternatives (all accessed 2026-07-27)
+
+**Commercial vendors:** browserstack.com/terms · browserstack.com/support/faq/automate ·
+saucelabs.com/doc/acceptable-use-policy · saucelabs.com/pricing · testmuai.com/pricing ·
+testmuai.com/legal/aup · testingbot.com/pricing · testingbot.com/terms · browserless.io/pricing ·
+browserless.io/terms-of-service · docs.steel.dev/overview/pricinglimits ·
+docs.steel.dev/overview/profiles-api/overview · steel.dev/blog/dedicated-ips ·
+docs.browserbase.com/platform/browser/core-features/contexts ·
+docs.browserbase.com/platform/identity/proxies · browserbase.com/terms-of-service ·
+docs.zenrows.com/first-steps/pricing · docs.zenrows.com/forbidden-sites ·
+scrapingbee.com/acceptable-use-policy (all accessed 2026-07-27)
+
+**LinkedIn ToS context:** linkedin.com/help/linkedin/answer/a1341387 (accessed 2026-07-27)

--- a/docs/scaling-cost-options.md
+++ b/docs/scaling-cost-options.md
@@ -88,15 +88,20 @@ Per `docs/SELENIUM_GRID.md` §4, the load test (`selenium_load_test.py`, issue #
 many concurrent Chrome sessions keep 95% of engagement work inside its window, on today's topology
 (8 slots, lanes 3/2/2/1):
 
-| Users | Sessions needed (measured, pre-stagger) | Sessions needed (staggered, **predicted** — re-run is #634) |
-|---|---|---|
-| 10 | 5 | 4 |
-| 50 | 14 | 11 |
-| 100 | 27 | 20 |
+| Users | Sessions needed (measured, pre-stagger) | Staggered, **predicted** (what the pricing below used) | Staggered, **measured** (#634, 2026-07-27) |
+|---|---|---|---|
+| 10 | 5 | 4 | 5 |
+| 50 | 14 | 11 | **15** |
+| 100 | 27 | 20 | **28** |
 
-Every cost column below is priced at **both** numbers as `staggered (measured)` — e.g. `4 (5)` —
-because the staggered curve is still a prediction pending #634, and pricing the conservative
-(measured) number avoids under-provisioning if #634 comes back worse than modeled. Ratio used
+Every cost column below is priced at **both** of the first two numbers as `staggered (measured)` —
+e.g. `4 (5)` — because when this spike was written the staggered curve was still a prediction
+pending #634, and pricing the conservative (pre-stagger measured) number avoided under-provisioning
+if #634 came back worse than modeled. **It did:** #634 landed at 5 / 15 / 28, i.e. at or just above
+the conservative column, so **read the parenthesised (measured) figure in every table below as the
+live one** — the optimistic figure never materialised. One session more at 50 and 100 users moves
+no verdict here: it is within Option B's next box, and it makes the hosted per-session vendors
+slightly *more* expensive, not less. Ratio used
 throughout: **~1 vCPU + ~1.2–1.5 GB RAM per concurrent Chrome session** (matches §4's measured 8
 slots ≈ 6.5–8 vCPU / 6–8 GB), and **~65–70 active Selenium-minutes/user/day** (§4's per-user
 workload total) for any vendor billed by browser-minute rather than by concurrency tier.

--- a/docs/scaling-cost-options.md
+++ b/docs/scaling-cost-options.md
@@ -60,7 +60,7 @@ assumed does not exist on the current provider (§4, §6).
   (persistent authenticated sessions via a `Profiles`/`Contexts` API, BYOP residential proxy — free
   on Steel, custom extension loading, no session-length ceiling that matters at LEM's scale) and
   both price below every AWS option — Steel.dev ~$33–430/mo and Browserbase ~$47–399/mo across the
-  10→100 user range, vs. AWS Fargate's ~$165–1,115/mo. Each also carried an unresolved blocker:
+  10→100 user range, vs. AWS Fargate's ~$165–1,156/mo. Each also carried an unresolved blocker:
   Steel's actual ToS text (redirects to a Google Doc this research pass couldn't extract), and
   whether either vendor's WebDriver path is a true URL-repoint into `get_docker_driver()` or needs
   a connection wrapper (Browserbase confirmed needs one; Steel's Selenium support is documented but
@@ -97,11 +97,13 @@ many concurrent Chrome sessions keep 95% of engagement work inside its window, o
 Every cost column below is priced at **both** of the first two numbers as `staggered (measured)` —
 e.g. `4 (5)` — because when this spike was written the staggered curve was still a prediction
 pending #634, and pricing the conservative (pre-stagger measured) number avoided under-provisioning
-if #634 came back worse than modeled. **It did:** #634 landed at 5 / 15 / 28, i.e. at or just above
-the conservative column, so **read the parenthesised (measured) figure in every table below as the
-live one** — the optimistic figure never materialised. One session more at 50 and 100 users moves
-no verdict here: it is within Option B's next box, and it makes the hosted per-session vendors
-slightly *more* expensive, not less. Ratio used
+if #634 came back worse than modeled. **It did, by one session at both tiers:** #634 landed at
+5 / 15 / 28, one above the 5 / 14 / 27 pre-stagger-measured column the tables below were originally
+priced against. That one session doesn't move any verdict, but it does cross a real pricing
+boundary for continuous-billing vendors (Fargate) and a discrete instance boundary for EC2 — both
+have been recomputed below against the corrected 15 / 28 figures, so **read the parenthesised
+(measured) figure in every table below as the live one, and the dollar amounts as already keyed to
+it**, not to the optimistic prediction. Ratio used
 throughout: **~1 vCPU + ~1.2–1.5 GB RAM per concurrent Chrome session** (matches §4's measured 8
 slots ≈ 6.5–8 vCPU / 6–8 GB), and **~65–70 active Selenium-minutes/user/day** (§4's per-user
 workload total) for any vendor billed by browser-minute rather than by concurrency tier.
@@ -146,10 +148,10 @@ instead).
 
 ### 2b. AWS-hosted Grid nodes
 
-| Option | $/mo @ 10 users (4 or 5 sessions) | $/mo @ 50 users (11 or 14) | $/mo @ 100 users (20 or 27) | Setup/ops effort | Residential egress | ToS risk | Session-length fit | Rollback difficulty | Verdict |
+| Option | $/mo @ 10 users (4 or 5 sessions) | $/mo @ 50 users (11 or 15) | $/mo @ 100 users (20 or 28) | Setup/ops effort | Residential egress | ToS risk | Session-length fit | Rollback difficulty | Verdict |
 |---|---|---|---|---|---|---|---|---|---|
-| **ECS/Fargate Grid nodes (on-demand)** | $165–206/mo | $454–578/mo | $826–1,115/mo | **Medium** — real, documented community pattern (not first-party AWS), needs a hub + service discovery + autoscaler on top of the container images LEM already runs | Yes — proxy-auth extension runs inside the Chrome container, host-independent; watch NAT Gateway ($0.045/hr + $0.045/GB) if nodes sit in a private subnet | None found specific to this pattern | Unlimited on-demand; **Spot is not viable** (2-min reclaim kills mid-session login state and risks a half-submitted LinkedIn action) | Low-medium — same Docker images, just repoint the hub URL | **Workable but pricier than self-managed at every tier, plus new ops surface (NAT/ASG/ECS)** |
-| **EC2 Grid nodes (on-demand, c5.2xlarge, ~7 sessions/instance)** | $248/mo (1 instance) | $496/mo (2 instances) | $745–993/mo (3–4 instances) | **High** — you own AMI/patching, ASG, health checks; effectively a second, cloud-hosted twin of the existing infra | Same as Fargate | None found | Best AWS fit — unbounded on-demand session length; Spot viable only as a burst/overflow tier with cookies persisted externally | Low-medium | **Cheapest AWS option but most AWS ops burden; still costs more than Option B at every tier** |
+| **ECS/Fargate Grid nodes (on-demand)** | $165–206/mo | $454–620/mo | $826–1,156/mo | **Medium** — real, documented community pattern (not first-party AWS), needs a hub + service discovery + autoscaler on top of the container images LEM already runs | Yes — proxy-auth extension runs inside the Chrome container, host-independent; watch NAT Gateway ($0.045/hr + $0.045/GB) if nodes sit in a private subnet | None found specific to this pattern | Unlimited on-demand; **Spot is not viable** (2-min reclaim kills mid-session login state and risks a half-submitted LinkedIn action) | Low-medium — same Docker images, just repoint the hub URL | **Workable but pricier than self-managed at every tier, plus new ops surface (NAT/ASG/ECS)** |
+| **EC2 Grid nodes (on-demand, c5.2xlarge, ~7 sessions/instance)** | $248/mo (1 instance) | $496–745/mo (2 instances at predicted 11; **measured 15 needs 3**) | $745–993/mo (3–4 instances) | **High** — you own AMI/patching, ASG, health checks; effectively a second, cloud-hosted twin of the existing infra | Same as Fargate | None found | Best AWS fit — unbounded on-demand session length; Spot viable only as a burst/overflow tier with cookies persisted externally | Low-medium | **Cheapest AWS option but most AWS ops burden; still costs more than Option B at every tier** |
 | **AWS Device Farm (Desktop Browser Testing)** | disqualified | disqualified | disqualified | N/A | Unsupported path (AWS datacenter IPs; loading LEM's proxy-auth extension is explicitly "not officially supported") | Not confirmed as a ToS ban, but moot | **Hard 40-min session cap; `--user-data-dir` explicitly blocked** — cannot hold a login at all | N/A | **DISQUALIFIED — cannot hold a session past 40 minutes or persist a login, at any price** |
 
 Fargate on-demand: **$0.04048/vCPU-hr + $0.004445/GB-hr**

--- a/docs/scaling-cost-options.md
+++ b/docs/scaling-cost-options.md
@@ -8,6 +8,28 @@
 > parked the "16 vCPU/64 GB vs second box" decision pending this doc), `docs/EGRESS_AT_SCALE.md`
 > (why residential egress + ToS posture are load-bearing requirements below, not nice-to-haves).
 
+## Decision (owner, 2026-07-27, PR #694)
+
+**LEM stays self-managed. The hosted/cloud grid market is ruled out — all of it.** That means AWS
+(Fargate Grid nodes, EC2 Grid nodes, Device Farm) **and all eight commercial vendors surveyed
+below**, including Steel.dev and Browserbase, which this spike had flagged as the two structural
+fits worth one more look. No vendor spike is planned and none is scheduled at any user tier.
+
+Everything below is retained as the **evidence for that decision**, not as a shortlist. Two things
+follow from that framing and matter when reading it:
+
+- The per-vendor verdicts are what the research found, not standing recommendations. Where a vendor
+  is described as a "fit" or "worth a spike", read that as *what the numbers said before the call
+  was made* — the call went the other way.
+- Prices and terms here were accessed 2026-07-27 and this market moves fast. Nothing in this doc
+  should be treated as a live quote if the question is ever reopened; it would need re-researching
+  from scratch.
+
+The self-managed path itself is settled the same day: **Option B — a second same-provider Hostinger
+box running Grid nodes (`docker-compose.grid-node.yml`, already built) — is the default horizontal
+scale-out.** Option A ("upgrade to 16 vCPU / 64 GB") is retired, because the in-place resize it
+assumed does not exist on the current provider (§4, §6).
+
 ## TL;DR
 
 - **The premise that self-managed Option A ("upgrade to 16 vCPU / 64 GB") is a cheap in-place
@@ -33,31 +55,30 @@
     WebDriver, so it fails the "zero app-code-change" bar `get_docker_driver()` was built around.
   - **ZenRows / ScrapingBee**: structural mismatch — per-request scraping APIs, not persistent
     browser sessions. ZenRows' closest product caps session TTL at 1–15 minutes.
-- **Two vendors are a genuine, cheap fit on paper: Steel.dev and Browserbase.** Both are built for
-  exactly LEM's pattern — persistent authenticated sessions (`Profiles`/`Contexts` API), BYOP
-  (bring-your-own residential proxy, at no extra charge on Steel), custom extension loading, and
-  no session-length ceiling that matters at LEM's scale. Both are **cheaper than every AWS option
-  and cheaper than a Hetzner/DO primary-box upgrade** — Steel.dev ~$33–430/mo and Browserbase
-  ~$47–399/mo across the 10→100 user range, vs. AWS Fargate's ~$165–1,115/mo. Two things are
-  **not yet verified** and block acting on this: Steel's actual ToS text (redirects to a Google
-  Doc this research pass couldn't extract), and whether either vendor's WebDriver path is a true
-  URL-repoint into `get_docker_driver()` or needs a connection wrapper (Browserbase confirmed
-  needs one; Steel's Selenium support is documented but CDP-first).
+- **Two vendors were the only genuine fit on paper — Steel.dev and Browserbase — and they are ruled
+  out too, by decision rather than by disqualification.** Both are built for exactly LEM's pattern
+  (persistent authenticated sessions via a `Profiles`/`Contexts` API, BYOP residential proxy — free
+  on Steel, custom extension loading, no session-length ceiling that matters at LEM's scale) and
+  both price below every AWS option — Steel.dev ~$33–430/mo and Browserbase ~$47–399/mo across the
+  10→100 user range, vs. AWS Fargate's ~$165–1,115/mo. Each also carried an unresolved blocker:
+  Steel's actual ToS text (redirects to a Google Doc this research pass couldn't extract), and
+  whether either vendor's WebDriver path is a true URL-repoint into `get_docker_driver()` or needs
+  a connection wrapper (Browserbase confirmed needs one; Steel's Selenium support is documented but
+  CDP-first). The owner's call (2026-07-27) was to not spend engineering time resolving either —
+  self-managed only.
 - **AWS Fargate/EC2 Grid nodes are real and technically workable** (residential-proxy egress layers
   on cleanly; on-demand session-length is unbounded) **but cost more than every self-managed and
   Steel/Browserbase option at every tier**, and add real new ops surface (NAT/ASG/ECS) LEM doesn't
   otherwise need. Fargate Spot / EC2 Spot are not recommended as primary capacity — a 2-minute-warning
   reclaim mid-comment/mid-DM risks a half-submitted action on a live account and the kind of session
   churn that trips LinkedIn's own anti-bot detection.
-- **Recommendation (detail in §6, decision trigger in `docs/scaling-plan.md` §5f):** stay on the
-  self-managed path (Option B, same-provider Hostinger boxes, using the Grid that's already built)
-  as the default horizontal scale-out — it's cheap, proven, and carries zero new ToS/vendor risk.
-  Run one **cheap, non-committal technical spike** against Steel.dev and/or Browserbase (both have
-  free tiers) to settle the two open unknowns above, because if either clears, it's a materially
-  lower-ops alternative at the 100-user tier. Do **not** pursue AWS-hosted Grid nodes, AWS Device
-  Farm, or any QA-testing cloud (BrowserStack/Sauce Labs/LambdaTest/TestingBot/Browserless/
-  ZenRows/ScrapingBee) — each is either disqualified outright or strictly worse on both cost and
-  fit than what's already available.
+- **Decision (detail in §6, decision trigger in `docs/scaling-plan.md` §5f): self-managed only.**
+  The default horizontal scale-out is Option B — additional same-provider Hostinger boxes running
+  the Grid that's already built. It's cheap, proven, and carries zero new ToS/vendor risk. Nothing
+  in the hosted/cloud market is pursued: not AWS Grid nodes, not Device Farm, not the QA-testing
+  clouds (BrowserStack/Sauce Labs/LambdaTest/TestingBot/Browserless/ZenRows/ScrapingBee), and not
+  Steel.dev or Browserbase. The first group is disqualified on its own merits; the last two are a
+  deliberate owner call to keep the stack on infrastructure LEM already owns and operates.
 
 ---
 
@@ -145,8 +166,8 @@ live quote before budgeting off it).
 | **LambdaTest** | ~$580–750 (unverified, 5-parallel estimate; 14/27 sales-gated) | unpublished | unpublished | Yes | Unconfirmed `LT_PROXY_HOST` capability — may route outbound traffic through an external proxy, not verified live | No explicit ban found | 30 min auto-cap | Yes | **Weak candidate — not disqualified in writing, but no confirmed login persistence and unpublished pricing at scale; needs a live spike before serious evaluation** |
 | **TestingBot** | ~$90/mo flat (Automated Pro, nominally unlimited minutes/concurrency) | ~$90/mo flat (same caveat) | ~$90/mo flat (same caveat) | Yes | Unknown — no proxy/egress info published | No explicit ban found | Not published | Yes (Playwright-documented; presumed same for Selenium) | **Thinnest documentation of any vendor surveyed — cannot recommend without a direct vendor conversation on real limits behind "unlimited"** |
 | **Browserless** | ~$140/mo (Starter) | ~$350/mo + likely overage (Scale) | ~$350/mo + overage, or Enterprise | **No — CDP/Puppeteer/BQL-first** | Yes, paid (6 units/MB residential) + self-hosted BYOP | No explicit ban found | 15–60 min by plan | Yes | **Disqualified on protocol — not native Selenium WebDriver, fails the zero-app-code-change requirement** |
-| **Steel.dev** | ~$33–35/mo | ~$280–290/mo | ~$410–430/mo | Partial — Selenium documented, but CDP-first; may need a connection wrapper | **Yes** — managed residential proxies, Dedicated IPs, **free BYOP on all plans including free tier** | **Not independently verified** — real ToS is a Google Doc this research pass couldn't extract | 15 min–24 hr by plan; **explicit Profiles API persists cookies/login/extensions across separate sessions** | Yes (persists via Profiles) | **Strongest cost fit found — pending a direct Selenium-compatibility check and a real ToS read** |
-| **Browserbase** | ~$47–50/mo | ~$203–218/mo | ~$374–399/mo | Yes, but needs a **custom `RemoteConnection` wrapper** — not a pure `SELENIUM_HUB_HOST` repoint | **Yes** — residential by default (201 countries, geo-targeting) + BYOP | No explicit ban found; vendor markets a "Social Media Scraper" use case as intended use | 6 hr default cap; **explicit Contexts API persists cookies (incl. session cookies) across separate sessions** | Yes | **Strongest overall fit — mature docs, no ToS red flag, only friction is the Selenium wrapper and unconfirmed per-user IP stability across days (not just within a session)** |
+| **Steel.dev** | ~$33–35/mo | ~$280–290/mo | ~$410–430/mo | Partial — Selenium documented, but CDP-first; may need a connection wrapper | **Yes** — managed residential proxies, Dedicated IPs, **free BYOP on all plans including free tier** | **Not independently verified** — real ToS is a Google Doc this research pass couldn't extract | 15 min–24 hr by plan; **explicit Profiles API persists cookies/login/extensions across separate sessions** | Yes (persists via Profiles) | **Strongest cost fit found, but NOT PURSUED** — its Selenium-compatibility check and real ToS read were never run; ruled out with the rest of the hosted market (2026-07-27) |
+| **Browserbase** | ~$47–50/mo | ~$203–218/mo | ~$374–399/mo | Yes, but needs a **custom `RemoteConnection` wrapper** — not a pure `SELENIUM_HUB_HOST` repoint | **Yes** — residential by default (201 countries, geo-targeting) + BYOP | No explicit ban found; vendor markets a "Social Media Scraper" use case as intended use | 6 hr default cap; **explicit Contexts API persists cookies (incl. session cookies) across separate sessions** | Yes | **Strongest overall fit, but NOT PURSUED** — mature docs, no ToS red flag; the Selenium wrapper and per-user IP stability across days were never verified; ruled out with the rest of the hosted market (2026-07-27) |
 | **ZenRows / ScrapingBee** | not modeled — different billing unit (per-request, not per-minute/concurrency) | not modeled | not modeled | No | Bundled but moot | Neither explicitly names LinkedIn; ScrapingBee's AUP explicitly puts LinkedIn's own ToS risk back on the customer | **1–15 min hard cap (ZenRows Scraping Browser); no session concept at all (ScrapingBee)** | N/A | **Disqualified — structural mismatch, not a policy one. Cannot hold a login for more than 15 minutes at best.** |
 
 Full per-vendor pricing tiers, quotes, and source URLs are in the research notes this table was
@@ -165,7 +186,7 @@ first-steps/pricing, scrapingbee.com/acceptable-use-policy — all accessed 2026
 |---|---|---|---|---|---|---|---|
 | Datacenter-only egress (no residential path) | Layerable (proxy inside container) | Yes, unsupported to change | Yes — no outbound-through-proxy mechanism found | Layerable (paid or BYOP) | **No — residential/BYOP native** | Bundled but moot | N/A — own box, own proxy |
 | Per-minute billing vs. multi-minute logged-in sessions | On-demand: fine. Spot: mismatched | Mismatched (40 min cap) | Mismatched (30 min–3 hr caps, no persistence) | Mismatched (15–60 min caps) | **Fits** (hour/day-scale, persisted) | Mismatched (1–15 min cap) | N/A |
-| ToS forbids social-automation/scraping | Not found | Not confirmed, moot (technical disqualifier) | **Sauce Labs: explicit ban.** Others: not found in writing | Not found | Steel: **unverified** (couldn't read real ToS). Browserbase: not found, positive signal (markets this use case) | Not found, but customer bears the risk explicitly | N/A |
+| ToS forbids social-automation/scraping | Not found | Not confirmed, moot (technical disqualifier) | **Sauce Labs: explicit ban.** Others: not found in writing | Not found | Steel: **never verified** (couldn't read real ToS; not pursued). Browserbase: not found, positive signal (markets this use case) | Not found, but customer bears the risk explicitly | N/A |
 | Can load the MV3 proxy-auth extension | Yes (own container) | Unsupported | Yes (BrowserStack/TestingBot confirmed); N/A for the rest given other disqualifiers | Yes | Yes | No | N/A |
 
 ---
@@ -187,15 +208,21 @@ the research this table summarizes; the short version is **all AWS paths cost mo
 self-managed alternative at every tier and add ops surface LEM doesn't otherwise carry**, and
 Device Farm is a hard no regardless of price.
 
-## 6. Recommendation
+## 6. Decision
 
-**Do not pursue:** AWS Device Farm (disqualified — cannot hold a session), any of the four
-QA-testing clouds (BrowserStack, Sauce Labs, LambdaTest, TestingBot — disqualified or unproven,
-Sauce Labs explicitly banned in writing), Browserless (wrong protocol), ZenRows/ScrapingBee
-(wrong computing model), and AWS Fargate/EC2 Grid nodes (technically fine, but strictly more
-expensive and more ops-heavy than what's already built and cheaper).
+**Nothing hosted is pursued — the whole surveyed market is out.** AWS Device Farm (disqualified —
+cannot hold a session), the four QA-testing clouds (BrowserStack, Sauce Labs, LambdaTest,
+TestingBot — disqualified or unproven, Sauce Labs explicitly banned in writing), Browserless (wrong
+protocol), ZenRows/ScrapingBee (wrong computing model), AWS Fargate/EC2 Grid nodes (technically
+fine, but strictly more expensive and more ops-heavy than what's already built and cheaper) — and
+also **Steel.dev and Browserbase**, the two that fit LEM's pattern on paper and beat AWS on cost.
+Those last two are an owner call rather than a technical disqualification (2026-07-27): the open
+questions blocking them (a real Selenium-compatibility spike, and Steel's unreadable ToS) were
+judged not worth the engineering time against a self-managed path that is already built, already
+cheaper at every tier this plan projects, and already understood operationally. **No vendor spike
+is scheduled, at any tier.**
 
-**Default path stays self-managed, Option B** — additional same-provider Hostinger boxes running
+**The path is self-managed, Option B** — additional same-provider Hostinger boxes running
 Grid nodes only, cut over via the already-built `docker-compose.grid-node.yml` /
 `docker-compose.grid.yml` (issue #556). It is the cheapest option at every tier (~$0–200/mo across
 10→100 users), carries zero new vendor/ToS risk, and needs no new capability — just more of what
@@ -205,48 +232,35 @@ cross-provider migration to buy 16 vCPU/64 GB costs more (~$315–504/mo) and ca
 risk (DNS/data/stack cutover) than just adding a second box for the same or lower steady-state
 cost.
 
-**One cheap, non-committal spike is worth running before the ~50-user trigger:** both Steel.dev
-and Browserbase are purpose-built for LEM's exact pattern (persistent authenticated sessions over
-a residential/BYOP proxy) and are materially cheaper than every AWS option — and cheaper than
-adding a third/fourth self-managed box at the 100-user tier, with none of the VPS patching/ops
-burden. Two things block a real decision and should be resolved with their free tiers before any
-spend: (1) does either vendor's Selenium path actually drop into `get_docker_driver()` cleanly, or
-does it need a real connector rewrite (Browserbase confirmed needs a `RemoteConnection` wrapper;
-Steel's Selenium support is documented but CDP-first), and (2) Steel's actual ToS terms (this
-research pass could not extract them — a direct legal read is needed before it's a candidate at
-all). This is exploration, not a purchase — nothing here should move traffic off the self-managed
-path until both are answered.
-
 **Decision trigger:** carried into `docs/scaling-plan.md` §5f — the self-managed Grid cutover
 happens per `SELENIUM_GRID.md` §6's existing checklist (capacity monitor breach → re-run the
-staggered load test → cut over at parity → then scale nodes/lanes together). Steel.dev/Browserbase
-only enter the decision if the spike above clears both open questions **and** the 100-user tier is
-actually approaching — below that, self-managed Option B is cheaper and lower-risk on its own.
+staggered load test → cut over at parity → then scale nodes/lanes together). That sequence is now
+the whole decision; there is no hosted-vendor branch waiting on a spike, and no vendor re-enters it
+at the 50- or 100-user tier.
 
 ---
 
-## Open questions to verify before committing money
+## Open questions — only the ones the self-managed path still needs
 
-- [ ] Live Fargate Spot / EC2 Spot pricing (this pass used an AWS-documentation example range for
-      EC2 Spot and an approximated ratio for Fargate Spot memory — neither is a live quote).
-- [ ] Hetzner/DigitalOcean exact bandwidth costs if a 16 vCPU/64 GB box is ever provisioned in a
-      US region (Hetzner's US bandwidth allowance dropped sharply — 1 TB/mo vs 20 TB/mo in EU —
-      alongside its June 2026 price increase).
-- [ ] BrowserStack/Sauce Labs/LambdaTest real multi-parallel pricing at 5/14/27 concurrent sessions
-      — all are sales-gated above 1 parallel; the figures above are third-party extrapolations, not
-      vendor quotes. Moot unless one of them is reconsidered, which is not recommended here.
-- [ ] TestingBot's actual fair-use ceiling behind "unlimited" on Automated Pro — the $90/mo flat
-      price is suspiciously cheap relative to every other vendor and needs a direct vendor
-      conversation before it's trusted.
-- [ ] Steel.dev's real Terms of Service (the public link redirects to a Google Doc this research
-      pass could not extract) — read it directly before treating Steel as a candidate.
-- [ ] Confirm live, with either Steel.dev or Browserbase support: does a `contextId`/`profileId`
-      reused days apart get the **same** residential egress IP each time (not just the same
-      geo-target), matching LEM's "one stable IP per user, pinned for the life of the account"
-      requirement (`EGRESS_AT_SCALE.md`)? Geo-targeting alone doesn't guarantee IP stability across
-      separate sessions.
-- [ ] Confirm Selenium (not CDP-wrapped) compatibility with `get_docker_driver()` for both Steel.dev
-      and Browserbase with a working code spike, not documentation alone.
+The hosted-vendor unknowns this spike surfaced (Steel's unreadable ToS, Selenium-vs-CDP
+compatibility for Steel/Browserbase, per-user residential-IP stability across days, real
+multi-parallel pricing from the sales-gated QA clouds, TestingBot's fair-use ceiling behind
+"unlimited", live Fargate/EC2 Spot quotes) are **closed as not-applicable** — the decision above
+means none of them gates anything. They're recorded in §2b/§2c so a future reader can see what was
+and wasn't verified, not as a to-do list.
+
+What's still genuinely open, on the path actually being taken:
+
+- [ ] Hostinger KVM8 renewal pricing at the point a second box is actually bought — the ~$26–30/mo
+      figures above are promotional; renewal is ~$49.99/mo, and Option B's steady-state cost at
+      3–4 boxes should be budgeted at renewal rates, not promo.
+- [ ] Private networking between two Hostinger boxes: Hetzner offers native unmetered VPC between
+      same-region hosts, Hostinger's equivalent wasn't confirmed in this pass. If there isn't one,
+      the Grid hub↔node link needs WireGuard, which is a small but real setup item on the Option B
+      cutover checklist (`SELENIUM_GRID.md` §6).
+- [ ] Hetzner/DigitalOcean US bandwidth allowances remain worth knowing **only** if a
+      cross-provider move is ever reconsidered for reasons other than Selenium capacity (Hetzner's
+      US allowance dropped to 1 TB/mo vs 20 TB/mo in EU alongside its June 2026 price increase).
 
 ---
 

--- a/docs/scaling-plan.md
+++ b/docs/scaling-plan.md
@@ -448,22 +448,22 @@ ToS-risk requirements. Full comparison, cost tables and sources: `docs/scaling-c
   default path; **Option B (a second same-provider box running Grid nodes, already built as
   `docker-compose.grid-node.yml`) is now the clear default** — cheapest at every tier, no new
   vendor/ToS risk, no migration.
-- **Two vendors are a genuine, cheap fit on paper and worth one more look before scaling
-  hardware:** Steel.dev and Browserbase are purpose-built for persistent authenticated browser
-  sessions over a residential/BYOP proxy (`Profiles`/`Contexts` APIs persist cookies/login across
-  sessions the way LEM needs) and price well under both AWS and a third/fourth self-managed box at
-  the 100-user tier (~$410–430/mo and ~$374–399/mo respectively vs. Fargate's ~$826–1,115/mo). Two
-  things are unverified and block using either: whether their Selenium path is a true
-  `get_docker_driver()` URL-repoint or needs a connector rewrite, and (Steel only) its actual ToS
-  text, which this spike could not extract. **Recommended: a small, non-committal spike against
-  both free tiers to answer those two questions — not a purchase, not a path change today.**
+- **The two vendors that did fit are ruled out by decision, not by disqualification.** Steel.dev
+  and Browserbase are purpose-built for persistent authenticated browser sessions over a
+  residential/BYOP proxy (`Profiles`/`Contexts` APIs persist cookies/login across sessions the way
+  LEM needs) and price well under both AWS and a third/fourth self-managed box at the 100-user tier
+  (~$410–430/mo and ~$374–399/mo respectively vs. Fargate's ~$826–1,115/mo). Each still carried an
+  unresolved blocker — whether its Selenium path is a true `get_docker_driver()` URL-repoint or
+  needs a connector rewrite, and (Steel only) an actual ToS text this spike could not extract.
+  **Owner decision, 2026-07-27 (PR #694): don't spend the engineering time. No vendor spike, no
+  purchase, at any tier.** LEM stays on infrastructure it owns and operates.
 
 **Decision trigger:** unchanged from `SELENIUM_GRID.md` §6 — cut the self-managed Grid over at the
 capacity monitor's first breach, at parity (8 nodes), then scale nodes/lanes together per the
-load test's sessions-needed column. The hosted-vendor question is no longer blocking that
-decision: self-managed Option B is cheaper and lower-risk at every tier this plan currently
-projects, so it proceeds on its own. Steel.dev/Browserbase re-enter the decision only if the spike
-above clears **and** the 100-user tier is genuinely approaching.
+load test's sessions-needed column. That is now the entire decision: there is no hosted-vendor
+branch waiting on a spike and no vendor re-enters at the 50- or 100-user tier. `#633`'s market
+survey is kept in `docs/scaling-cost-options.md` as the evidence behind that call, and its prices
+(accessed 2026-07-27) would need re-researching from scratch if it were ever reopened.
 
 ---
 
@@ -508,9 +508,10 @@ above clears **and** the 100-user tier is genuinely approaching.
   (`docker-compose.grid-node.yml`) is the default horizontal path** — cheapest at every tier, no
   new vendor/ToS risk. #633 also priced the hosted/cloud market (AWS, BrowserStack/Sauce/
   LambdaTest/TestingBot/Browserless/Browserbase/Steel) against this curve and LEM's
-  residential-proxy/ToS requirements: almost all of it is disqualified outright, and the two
-  vendors that fit (Steel.dev, Browserbase) are worth a non-committal spike but not yet a path
-  change — see `docs/scaling-cost-options.md`. Nothing is bought until §5e files a breach.
+  residential-proxy/ToS requirements: almost all of it is disqualified outright, and the two that
+  did fit (Steel.dev, Browserbase) were **ruled out by owner decision** — the whole hosted market is
+  out, no vendor spike is planned — see `docs/scaling-cost-options.md`. Nothing is bought until §5e
+  files a breach.
 
 **Phase 3 — ~100 users:**
 - Grid nodes across 2+ hosts; dedicated Chrome host(s).

--- a/docs/scaling-plan.md
+++ b/docs/scaling-plan.md
@@ -424,6 +424,47 @@ have stopped holding:
 - **It never changes a limit by itself.** Raising the cap spends real RAM/CPU on a shared box
   (§5c), so the monitor's whole job is to put that decision in front of a human with evidence.
 
+### 5f. Hosted/cloud grid options — resolved by #633
+
+**Issue #633 priced the option set §5b's "someone else runs the browsers" line deferred**, against
+this section's sessions-needed curve and against `EGRESS_AT_SCALE.md`'s residential-proxy and
+ToS-risk requirements. Full comparison, cost tables and sources: `docs/scaling-cost-options.md`.
+
+- **Almost the entire hosted/cloud market is disqualified for LEM's use case**, not on price —
+  AWS Device Farm cannot hold a session past 40 minutes; the QA-testing clouds (BrowserStack,
+  Sauce Labs, LambdaTest, TestingBot) are built for short own-app test runs and **Sauce Labs'
+  Acceptable Use Policy explicitly bans "any social media site other than for purposes of software
+  testing"**; Browserless is CDP-first, not native Selenium; ZenRows/ScrapingBee cap at 1–15
+  minutes. None of these fit a logged-in, cookie-persisted, days-to-weeks LinkedIn session.
+- **AWS Fargate/EC2 Grid nodes are technically workable** (residential-proxy egress layers on
+  cleanly regardless of host) **but cost strictly more than self-managed at every tier** — e.g.
+  Fargate on-demand ~$454–578/mo at the 50-user tier vs. a second Hostinger box's ~$52–100/mo —
+  and add ops surface (NAT/ASG/ECS) the current stack doesn't otherwise carry. Not recommended.
+- **The one correction this spike makes to this plan:** `SELENIUM_GRID.md` §5's "Option A —
+  upgrade to 16 vCPU / 64 GB" assumed an in-place resize. **Hostinger's VPS line has no plan above
+  the current KVM8 (8 vCPU / 32 GB)** — a 16 vCPU/64 GB box is only available by switching provider
+  entirely (~$315/mo Hetzner, ~$504/mo DigitalOcean), which is a full migration (DNS, data, Docker
+  stack, Cloudflare Tunnel cutover), not a plan change. **Option A is effectively retired** as the
+  default path; **Option B (a second same-provider box running Grid nodes, already built as
+  `docker-compose.grid-node.yml`) is now the clear default** — cheapest at every tier, no new
+  vendor/ToS risk, no migration.
+- **Two vendors are a genuine, cheap fit on paper and worth one more look before scaling
+  hardware:** Steel.dev and Browserbase are purpose-built for persistent authenticated browser
+  sessions over a residential/BYOP proxy (`Profiles`/`Contexts` APIs persist cookies/login across
+  sessions the way LEM needs) and price well under both AWS and a third/fourth self-managed box at
+  the 100-user tier (~$410–430/mo and ~$374–399/mo respectively vs. Fargate's ~$826–1,115/mo). Two
+  things are unverified and block using either: whether their Selenium path is a true
+  `get_docker_driver()` URL-repoint or needs a connector rewrite, and (Steel only) its actual ToS
+  text, which this spike could not extract. **Recommended: a small, non-committal spike against
+  both free tiers to answer those two questions — not a purchase, not a path change today.**
+
+**Decision trigger:** unchanged from `SELENIUM_GRID.md` §6 — cut the self-managed Grid over at the
+capacity monitor's first breach, at parity (8 nodes), then scale nodes/lanes together per the
+load test's sessions-needed column. The hosted-vendor question is no longer blocking that
+decision: self-managed Option B is cheaper and lower-risk at every tier this plan currently
+projects, so it proceeds on its own. Steel.dev/Browserbase re-enter the decision only if the spike
+above clears **and** the 100-user tier is genuinely approaching.
+
 ---
 
 ## 6. Phased rollout tied to the launch
@@ -460,12 +501,16 @@ have stopped holding:
   pre-#554 baseline, because the staggered appreciation-DM tail can now bleed into the pre-post
   profile-viewer window on the shared `se_outreach` lane. Fix tracked as **#696**.
 - Lane concurrency 3–4 each; per-user 429 breaker keys; per-user rate pacing.
-- **Hardware/topology: deliberately undecided** (owner call on #556). Upgrading to **16 vCPU / 64 GB**
-  and splitting the Chrome tier onto a second box are compared in `docs/SELENIUM_GRID.md` §5 (short
-  version: upgrade covers ~16 sessions ≈ 50–60 staggered users at far lower ops cost; second box past
-  ~16 sessions, i.e. at 100 users) — but nothing is bought until §5e files a breach, and **#633**
-  first prices hosted/cloud grids (AWS, BrowserStack/Sauce/LambdaTest/Browserless/Browserbase/Steel)
-  beside both, against this curve and against our residential-proxy egress requirement.
+- **Hardware/topology: default path set, nothing bought yet** (§5f, #633). The "upgrade to 16
+  vCPU / 64 GB" comparison in `docs/SELENIUM_GRID.md` §5 assumed an in-place resize that doesn't
+  exist on the current provider — that option is now a full cross-provider migration, not a plan
+  change, and is effectively retired. **A second same-provider box running Grid nodes
+  (`docker-compose.grid-node.yml`) is the default horizontal path** — cheapest at every tier, no
+  new vendor/ToS risk. #633 also priced the hosted/cloud market (AWS, BrowserStack/Sauce/
+  LambdaTest/TestingBot/Browserless/Browserbase/Steel) against this curve and LEM's
+  residential-proxy/ToS requirements: almost all of it is disqualified outright, and the two
+  vendors that fit (Steel.dev, Browserbase) are worth a non-committal spike but not yet a path
+  change — see `docs/scaling-cost-options.md`. Nothing is bought until §5e files a breach.
 
 **Phase 3 — ~100 users:**
 - Grid nodes across 2+ hosts; dedicated Chrome host(s).

--- a/docs/scaling-plan.md
+++ b/docs/scaling-plan.md
@@ -438,7 +438,7 @@ ToS-risk requirements. Full comparison, cost tables and sources: `docs/scaling-c
   minutes. None of these fit a logged-in, cookie-persisted, days-to-weeks LinkedIn session.
 - **AWS Fargate/EC2 Grid nodes are technically workable** (residential-proxy egress layers on
   cleanly regardless of host) **but cost strictly more than self-managed at every tier** — e.g.
-  Fargate on-demand ~$454–578/mo at the 50-user tier vs. a second Hostinger box's ~$52–100/mo —
+  Fargate on-demand ~$454–620/mo at the 50-user tier vs. a second Hostinger box's ~$52–100/mo —
   and add ops surface (NAT/ASG/ECS) the current stack doesn't otherwise carry. Not recommended.
 - **The one correction this spike makes to this plan:** `SELENIUM_GRID.md` §5's "Option A —
   upgrade to 16 vCPU / 64 GB" assumed an in-place resize. **Hostinger's VPS line has no plan above
@@ -452,7 +452,7 @@ ToS-risk requirements. Full comparison, cost tables and sources: `docs/scaling-c
   and Browserbase are purpose-built for persistent authenticated browser sessions over a
   residential/BYOP proxy (`Profiles`/`Contexts` APIs persist cookies/login across sessions the way
   LEM needs) and price well under both AWS and a third/fourth self-managed box at the 100-user tier
-  (~$410–430/mo and ~$374–399/mo respectively vs. Fargate's ~$826–1,115/mo). Each still carried an
+  (~$410–430/mo and ~$374–399/mo respectively vs. Fargate's ~$826–1,156/mo). Each still carried an
   unresolved blocker — whether its Selenium path is a true `get_docker_driver()` URL-repoint or
   needs a connector rewrite, and (Steel only) an actual ToS text this spike could not extract.
   **Owner decision, 2026-07-27 (PR #694): don't spend the engineering time. No vendor spike, no


### PR DESCRIPTION
## What & why

R4 spike from the growth-roadmap doc: #556's load test measured the sessions LEM needs at 10/50/100
users (5/14/27, or 4/11/20 with the shipped stagger — #634 confirms), but the "16 vCPU/64 GB vs a
second VPS" decision in `docs/SELENIUM_GRID.md` §5 was deliberately left open pending a wider option
set. This spike prices that wider set and writes the recommendation up.

## What's in the diff

- **New `docs/scaling-cost-options.md`** — cost/feasibility comparison across:
  - **AWS**: Fargate Grid nodes, EC2 Grid nodes, Device Farm (disqualified — hard 40-min session cap,
    `--user-data-dir` explicitly blocked, so it can't hold a login).
  - **8 commercial browser-grid vendors**: BrowserStack, Sauce Labs (explicit AUP ban on non-testing
    social-media use), LambdaTest, TestingBot, Browserless (CDP-first, not Selenium), Steel.dev,
    Browserbase, ZenRows/ScrapingBee (1–15 min session cap). Steel.dev and Browserbase are the two
    vendors that structurally fit LEM's pattern (persistent authenticated sessions, residential/BYOP
    proxy, custom extension support) and are cheaper than every AWS option — but each has one open
    question (a Selenium-compatibility check, and for Steel a real ToS read) that blocks using either
    today.
  - **Self-managed baselines**: current Hostinger box, a same-provider second box, and Hetzner/
    DigitalOcean equivalents.
  - Every number is cited with a source URL and access date (2026-07-27); this market moves fast.
- **`docs/scaling-plan.md`** — new §5f section with the resolved recommendation + decision trigger,
  and an update to the Phase-2 rollout note.
- **`docs/SELENIUM_GRID.md`** §5 — corrects the "Option A: upgrade to 16 vCPU/64 GB" framing. That
  assumed an in-place Hostinger resize; Hostinger's VPS line has no tier above the box LEM already
  runs, so a 16 vCPU/64 GB box is only available via a full cross-provider migration (~$315/mo
  Hetzner, ~$504/mo DigitalOcean) — not a plan change. This flips the section's own prior conclusion
  that Option A was cheaper "if the choice were made today"; **Option B (a second same-provider box,
  already built as `docker-compose.grid-node.yml`) is now the default.**

## Recommendation (why this is `risk:product-decision`)

Docs/analysis only — no infra changes. The doc recommends: don't pursue AWS Device Farm or any of
the QA-testing clouds (disqualified or unproven); don't pursue AWS Fargate/EC2 Grid nodes (costs
more than self-managed at every tier); keep the self-managed second-box path as the default; and run
one small, non-committal spike against Steel.dev/Browserbase's free tiers before the ~50-user trigger,
since if either clears its open question they're materially cheaper at the 100-user tier than adding
more self-managed boxes. See the Decision Comment on this PR.

## Testing

Docs only, no code changes — no tests to run.

Closes #633.

🤖 Generated with [Claude Code](https://claude.com/claude-code)