### PR TITLE
feat(analytics): probe the member post-stats API as a scrape replacement (closes #645)

### DIFF
--- a/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
+++ b/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
@@ -119,7 +119,7 @@ things LEM cannot do for itself: the LinkedIn app approved for the Community Man
 **every connected user re-consenting**, because a scope change invalidates the existing grant.
 That is an owner decision, tracked as the follow-up below.
 
-**Four details that will bite whoever does the cutover:**
+**Five details that will bite whoever does the cutover:**
 
 - **The entity URN is the OPPOSITE of the scrape's.** This finder takes a `share` or `ugcPost`
   URN (`entity=(share:…)` / `entity=(ugc:…)`); the analytics *page* keys off the **activity** URN
@@ -133,12 +133,18 @@ That is an owner decision, tracked as the follow-up below.
 - **`202506` is not enough for saves.** `POST_SAVE` only exists from `202604`. LEM's
   `LI_API_VERSION` default is `202606` (`env_constants.py`), which clears every floor above — but a
   pin rolled back to satisfy something else would silently drop saves as a `400`.
+- **`aggregation=TOTAL` is the only one that serves every signal.** Under `DAILY`, LinkedIn does
+  not serve `IMPRESSION` for a post entity (nor `MEMBERS_REACHED`, `LINK_CLICKS`,
+  `FOLLOWER_GAINED_FROM_CONTENT`, `PROFILE_VIEW_FROM_CONTENT` at all) — and it says so with the
+  **same `400` "query type … metric type" shape as a version gap**, so the two are easy to confuse.
+  The probe flags the combination itself and names the aggregation ahead of the version, and the
+  cutover wants `TOTAL` anyway: `post_stats` stores lifetime counts.
 
 **The probe ships even though it is blocked:** `scripts/linkedin_post_stats_api_probe.py` is
-read-only, stdlib-only and needs no browser, and it separates the three answers that demand
-different fixes — `403` (permission), `426` (retired `LI_API_VERSION`), `400`/absent metric
-(version predates the metric) — then compares whatever it *does* get against the latest stored
-`post_stats` row:
+read-only, stdlib-only and needs no browser, and it separates the answers that demand different
+fixes — `403` (permission), `426` (retired `LI_API_VERSION`), `400`/absent metric (version predates
+the metric) and the `400` that is really an unsupported `aggregation` — then compares whatever it
+*does* get against the latest stored `post_stats` row:
 
 ```bash
 sudo docker exec -i celery_worker python - --user-id 1 --post-id <post id> \

--- a/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
+++ b/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
@@ -3,6 +3,8 @@
 **Spike:** R1 / issue #404 — "Live LinkedIn validation: document post path + saves/impressions scraping"
 **Grounds:** C1 (#390, native document/PDF posts) and B2 (#387, capture reposts/impressions/saves)
 **Date:** 2026-07-26 · **Probe:** `scripts/linkedin_live_validation.py` (read-only)
+**Updated:** 2026-07-27 (#645) — §2a settles the member post-stats API lead ·
+**Probe:** `scripts/linkedin_post_stats_api_probe.py` (read-only, no browser)
 
 ## TL;DR
 
@@ -13,6 +15,7 @@
 | Does a published document render as a **document card**? | Unconfirmed — needs one live post. | **OPEN** (C1's own acceptance) |
 | Are **saves** scrapeable? | **Yes**, own posts only, on `/analytics/post-summary/<activity-urn>/`. | **Live grab 2026-07-23** (encoded in `_stacked_counts`) |
 | Are **impressions** scrapeable? | **Yes**, same page (Discovery hero, value-first layout). Blank on the post detail view. | **Live grab 2026-07-23** |
+| Can an **API** replace that scrape? | **The endpoint exists** (`memberCreatorPostAnalytics`, impressions + saves + more) — but it needs `r_member_postAnalytics`, which **LEM's token does not request**. Scrape stays. | **Documented** (`li-lms-2026-07`) + **in-repo verified** (§2a) |
 
 **Net scope change: none for B2, one live confirmation left for C1.** Both features are built and
 merged; this spike's job was to say whether their assumptions hold, and they do. What is genuinely
@@ -81,11 +84,77 @@ Three properties of that page, all from the 2026-07-23 owner grab and already en
 saves/impressions are unavailable for third-party feed posts (`_post_social_counts` returns 0 there —
 correct, not a bug), and it is a Selenium read, so it rides the same 429 breaker as the rest.
 
-**Follow-up lead (not verified here):** R3 recorded that LinkedIn's `202506` Community Management
-version added **member post stats**. If that surface exposes impressions/saves for the authenticated
-member, it would replace this Selenium scrape with an API read that no SDUI churn or 429 can break.
-That is a token probe, not a browser session — cheap to settle, and worth settling before investing
-further in scraping. Filed as **#645** rather than folded into this spike.
+### 2a. The member post-stats API exists and returns exactly these signals — LEM's token cannot read it
+
+R3's follow-up lead is now settled on the API side and **blocked on a permission**, not on a
+capability. `GET /rest/memberCreatorPostAnalytics` returns per-post analytics for the
+**authenticated member's own** posts over plain HTTP — no browser, no DOM, no Selenium lane, and
+immune to the 429 breaker:
+
+```
+GET https://api.linkedin.com/rest/memberCreatorPostAnalytics
+    ?q=entity&entity=(share:urn%3Ali%3Ashare%3A<id>)&queryType=IMPRESSION&aggregation=TOTAL
+LinkedIn-Version: <YYYYMM>   X-Restli-Protocol-Version: 2.0.0   Authorization: Bearer <member token>
+```
+
+| Signal LEM stores | API `queryType` | Live since | Evidence grade |
+|---|---|---|---|
+| `post_stats.impressions` | `IMPRESSION` | `202506` (the `q=entity` finder) | **Documented** — `li-lms-2026-07` |
+| `post_stats.reactions` | `REACTION` | `202506` | **Documented** |
+| `post_stats.comments` | `COMMENT` | `202506` | **Documented** |
+| `post_stats.reposts` | `RESHARE` | `202506` | **Documented** |
+| `post_stats.saves` | `POST_SAVE` | **`202604`** — later than the finder | **Documented** |
+
+The same surface also exposes `MEMBERS_REACHED`, `POST_SEND`, `LINK_CLICKS`,
+`PREMIUM_CTA_CLICKS`, `FOLLOWER_GAINED_FROM_CONTENT` and `PROFILE_VIEW_FROM_CONTENT` — none of
+which the scrape can reach, and the last two of which would answer questions #627 currently
+approximates from the profile-analytics pages.
+
+**Why it does not replace the scrape today.** The endpoint requires the
+**`r_member_postAnalytics`** permission (a Community Management API product permission). LEM's
+authorize call asks for `openid profile email w_member_social` (`api/main.py`, `linkedin_auth_init`),
+so **the stored member token has no claim on this endpoint and will answer `403`** — a
+scope-and-app-provisioning fact, verifiable in-repo, not a code defect. Granting it needs two
+things LEM cannot do for itself: the LinkedIn app approved for the Community Management API, and
+**every connected user re-consenting**, because a scope change invalidates the existing grant.
+That is an owner decision, tracked as the follow-up below.
+
+**Four details that will bite whoever does the cutover:**
+
+- **The entity URN is the OPPOSITE of the scrape's.** This finder takes a `share` or `ugcPost`
+  URN (`entity=(share:…)` / `entity=(ugc:…)`); the analytics *page* keys off the **activity** URN
+  that `_post_analytics_counts` resolves by following the redirect. The two ids are **not**
+  interchangeable — so the API wants the URN in the logged permalink, which is precisely the one
+  the scrape throws away.
+- **One `queryType` per request.** Five stored signals means five GETs per post, so a cutover is
+  5× the request count of one page load, not 1×.
+- **`metricType` changed shape in `202605`** (object → bare string). A parser that understands one
+  shape reads a perfectly good response from the other side of that line as empty.
+- **`202506` is not enough for saves.** `POST_SAVE` only exists from `202604`. LEM's
+  `LI_API_VERSION` default is `202606` (`env_constants.py`), which clears every floor above — but a
+  pin rolled back to satisfy something else would silently drop saves as a `400`.
+
+**The probe ships even though it is blocked:** `scripts/linkedin_post_stats_api_probe.py` is
+read-only, stdlib-only and needs no browser, and it separates the three answers that demand
+different fixes — `403` (permission), `426` (retired `LI_API_VERSION`), `400`/absent metric
+(version predates the metric) — then compares whatever it *does* get against the latest stored
+`post_stats` row:
+
+```bash
+sudo docker exec -i celery_worker python - --user-id 1 --post-id <post id> \
+    < scripts/linkedin_post_stats_api_probe.py
+```
+
+> **Honesty note.** The rows above are graded **Documented** and **in-repo verified**; the live
+> HTTP status is **not recorded here** because this pass ran headless with no access to a member
+> token. The instrument is what shipped, so the moment the permission question is answered the
+> probe records the real status, response shape and scrape-vs-API deltas in one command — and if
+> the answer is "no", it records the `403` as evidence rather than as a hunch.
+
+**Outcome: the scrape stays.** It is the only source available under the permissions LEM actually
+holds, and it works. Tracked forward as **#695** (request `r_member_postAnalytics`, then run the
+probe and cut over behind the existing merge-by-max), with the analytics-page rows folded into the
+F2 (#403) selector-liveness sweep so drift is caught by cron rather than by a run of zeroes.
 
 ## 3. Selector map (with provenance)
 
@@ -133,6 +202,11 @@ Paste the JSON into #404. If `post_stats` shows a signal sourced from `none` whi
 plainly shows a number, the `*_lines` arrays contain the drifted layout and this note's §3 rows are
 what need updating.
 
+`scripts/linkedin_post_stats_api_probe.py` (§2a) is the **other** read-only probe and needs no
+browser at all — it runs on any container with the DB and outbound HTTPS, holds no Selenium lane
+and is 429-immune. Run it from the same worktree the same way, `--post-id` being a LEM post id so
+it can compare the API against the scrape's own stored row.
+
 ## 5. Scope updates
 
 **C1 (#390) — native document posts:** implementation complete (publish path, `PostType.DOCUMENT`,
@@ -142,15 +216,23 @@ so R1 (#404) closes with this note. No code change is expected; if the verdict c
 the legacy fallback silently took over and the finding is an API-provisioning bug, not a format bug.
 
 **B2 (#387) — reposts/impressions/saves:** implementation complete and consistent with the live
-layout as of 2026-07-23. Remaining: none from this spike. Split out as separate issues:
-**#645** probes the `202506` member-post-stats API as a churn-proof replacement for the analytics
-scrape, and its "keep the scrape" outcome folds the analytics-page rows into the F2 (#403)
-selector-liveness sweep so drift is detected by cron rather than by a run of zeroes.
+layout as of 2026-07-23. Remaining: none from this spike. Split out as **#645**, which is now
+settled (§2a): the member post-stats API exists and would replace the scrape, but LEM's token has
+no `r_member_postAnalytics` claim on it, so **the scrape stays** and the API cutover moved to
+**#695** behind an owner decision. The "keep the scrape" branch of that outcome is what makes the
+analytics-page rows (§3) part of the F2 (#403) selector-liveness sweep — with no API alternative
+available, drift on that page has to be caught by cron rather than by a run of zeroes.
 
 ## Sources
 
 - `docs/FORMAT_API_FEASIBILITY.md` (R3 / #406) — API surface for documents, articles, newsletters.
+- [Member Post Statistics — Microsoft Learn (`li-lms-2026-07`)](https://learn.microsoft.com/en-us/linkedin/marketing/community-management/members/post-statistics?view=li-lms-2026-07)
+  — the `memberCreatorPostAnalytics` finders, permission, metric list and error table behind §2a.
+- [Recent Marketing API Changes — Microsoft Learn](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/recent-changes)
+  — `202506` added the `q=entity` finder; `202605` changed `metricType` from object to string.
 - In-repo: `utilities/linkedin/poster.py` (document API path), `app/run_automation.py`
   (`_post_social_counts`, `_stacked_counts`, `_post_analytics_counts`, `auto_scrape_post_stats`),
-  `utilities/db.py` (`record_post_stats`, `PostType`).
+  `utilities/db.py` (`record_post_stats`, `get_latest_post_stats`, `PostType`),
+  `api/main.py` (`linkedin_auth_init` — the granted scope list), and
+  `scripts/linkedin_post_stats_api_probe.py` (the §2a probe).
 - Migrations `V20260723211520__add_post_stats_saves.sql`, `V20260723234736__add_document_post_type.sql`.

--- a/scripts/linkedin_post_stats_api_probe.py
+++ b/scripts/linkedin_post_stats_api_probe.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Member post-stats API probe — issue #645.
+
+Impressions and saves reach LEM through a **Selenium scrape** of
+``/analytics/post-summary/<activity-urn>/`` (``_post_analytics_counts`` in
+``app/run_automation.py``). That works, but it breaks on any SDUI relayout and rides the
+same 429 breaker as the rest of the Selenium lanes.
+
+LinkedIn's versioned ``GET /rest/memberCreatorPostAnalytics`` returns the same numbers for the
+**authenticated member's own** posts over HTTP, with no browser and no DOM. This script settles
+whether LEM's stored member token can actually read it — and, when it can, whether the numbers
+agree with what the scrape already stored.
+
+**Read-only.** Every call is a GET. It publishes nothing and writes nothing back to the DB.
+It is a token probe, not a browser session, so it holds no Selenium lane and is 429-immune.
+
+``scripts/`` is not baked into the image, so pipe it in on stdin like the weekly version probe::
+
+    sudo docker exec -i celery_worker python - --user-id 1 --post-id 123 \
+        < scripts/linkedin_post_stats_api_probe.py
+
+One JSON report on stdout — paste it into the issue. No token or response header is ever echoed.
+
+Three facts the report is built to separate, because they demand different fixes:
+
+* **403** — the token was never granted ``r_member_postAnalytics`` (a Community Management API
+  permission). LEM's authorize call asks for ``openid profile email w_member_social``
+  (``api/main.py``), so this is the expected answer today and it is a *scope + app-provisioning*
+  problem, not a code one.
+* **426** — ``LI_API_VERSION`` is retired. Unrelated to this surface; fix the pin.
+* **400 / absent metric** — the pinned version predates the metric. ``q=entity`` (single-post
+  stats) landed in ``202506``; ``POST_SAVE`` only in ``202604``. The report states the floor for
+  every metric it asks for so a 400 is never misread as "LinkedIn does not expose saves".
+
+The parsing/verdict logic is pure and unit-tested; the HTTP call is injected so tests never
+touch the network.
+"""
+
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Callable, Optional
+
+API_URL = "https://api.linkedin.com/rest/memberCreatorPostAnalytics"
+REQUIRED_PERMISSION = "r_member_postAnalytics"
+
+# The finder that takes a single post. Aggregated ("q=me") stats have been available longer but
+# cannot be attributed to a post_stats row, so they are not what this probe is about.
+ENTITY_FINDER_MIN_VERSION = "202506"
+# Before this version metricType came back as {"com.linkedin...MetricTypeV1": "REACTION"};
+# from it, as a bare string. Both shapes are parsed — a probe that only understood one would
+# read a perfectly good response as empty.
+STRING_METRIC_TYPE_MIN_VERSION = "202605"
+
+# queryType -> the post_stats column the scrape stores it in.
+METRIC_COLUMNS = {
+    "IMPRESSION": "impressions",
+    "REACTION": "reactions",
+    "COMMENT": "comments",
+    "RESHARE": "reposts",
+    "POST_SAVE": "saves",
+}
+# The oldest LinkedIn-Version that serves each metric through the entity finder.
+METRIC_MIN_VERSION = {
+    "IMPRESSION": ENTITY_FINDER_MIN_VERSION,
+    "REACTION": ENTITY_FINDER_MIN_VERSION,
+    "COMMENT": ENTITY_FINDER_MIN_VERSION,
+    "RESHARE": ENTITY_FINDER_MIN_VERSION,
+    "POST_SAVE": "202604",
+}
+DEFAULT_METRICS = tuple(METRIC_COLUMNS)
+
+# The entity finder takes a share or ugcPost URN. An ACTIVITY urn — which is what the analytics
+# PAGE keys off, and what _post_analytics_counts resolves by following the redirect — is not a
+# valid entity here, and the numeric ids are not interchangeable. Say so rather than guess.
+_URN_RE = re.compile(r"urn:li:(share|ugcPost|activity):[0-9]+")
+_ENTITY_KEYS = {"share": "share", "ugcPost": "ugc"}
+
+_BODY_EXCERPT = 300
+
+
+class ProbeError(RuntimeError):
+    """The probe could not be run at all (no token, no usable URN)."""
+
+
+def urn_from_post_url(post_url: Optional[str]) -> Optional[str]:
+    """Pull the share/ugcPost/activity URN out of a feed permalink."""
+    match = _URN_RE.search(post_url or "")
+    return match.group(0) if match else None
+
+
+def urn_type(urn: Optional[str]) -> Optional[str]:
+    match = _URN_RE.fullmatch((urn or "").strip())
+    return match.group(1) if match else None
+
+
+def entity_param(urn: Optional[str]) -> Optional[str]:
+    """Build the finder's ``entity`` value, e.g. ``(share:urn%3Ali%3Ashare%3A123)``.
+
+    None when the URN is missing, malformed, or an activity URN (unsupported entity type)."""
+    key = _ENTITY_KEYS.get(urn_type(urn) or "")
+    if not key:
+        return None
+    return f"({key}:{urllib.parse.quote(urn.strip(), safe='')})"
+
+
+def version_supports(configured: Optional[str], minimum: str) -> Optional[bool]:
+    """Is ``configured`` at or past ``minimum``? None when the pin isn't a YYYYMM string."""
+    if not configured or not str(configured).isdigit() or len(str(configured)) != 6:
+        return None
+    return int(configured) >= int(minimum)
+
+
+def metric_type_name(raw) -> Optional[str]:
+    """Read metricType in either the pre-202605 object shape or the bare-string shape."""
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, dict):
+        for value in raw.values():
+            if isinstance(value, str):
+                return value
+    return None
+
+
+def metric_total(payload, metric: str) -> Optional[int]:
+    """Total count for ``metric`` across the response's elements.
+
+    None — never 0 — when the response carries no matching element: "LinkedIn returned nothing
+    for this metric" and "this post has zero" are different facts, and merging them would let an
+    unprovisioned surface look like a post nobody saw."""
+    if not isinstance(payload, dict):
+        return None
+    elements = payload.get("elements")
+    if not isinstance(elements, list):
+        return None
+    total, matched = 0, False
+    for element in elements:
+        if not isinstance(element, dict):
+            continue
+        name = metric_type_name(element.get("metricType"))
+        if name is not None and name != metric:
+            continue
+        count = element.get("count")
+        if isinstance(count, bool) or not isinstance(count, int):
+            continue
+        total += count
+        matched = True
+    return total if matched else None
+
+
+def classify_status(status: int, body: str) -> str:
+    """Name the failure mode so the report says what to FIX, not just that it broke."""
+    if status == 200:
+        return "ok"
+    if status == 401:
+        return "unauthorized"
+    if status == 403:
+        return "forbidden"
+    if status == 426:
+        return "version_retired"
+    if status == 429:
+        return "throttled"
+    if status == 400:
+        # LinkedIn's own error table answers an unknown queryType/aggregation pairing with a 400
+        # naming both. That is "the pinned version does not serve this metric", not a malformed
+        # request, and the fix is LI_API_VERSION — so it must not read as a coding bug.
+        lowered = (body or "").lower()
+        if "query type" in lowered or "querytype" in lowered or "metric type" in lowered:
+            return "unsupported_metric"
+        return "bad_request"
+    if 500 <= status < 600:
+        return "server_error"
+    return f"http_{status}"
+
+
+def http_get_json(url: str, token: str, version: str, timeout: int = 20) -> tuple[int, str]:
+    """GET the versioned API. Returns (status, body). Never raises for an HTTP status."""
+    request = urllib.request.Request(url, headers={
+        "Authorization": f"Bearer {token}",
+        "LinkedIn-Version": version,
+        "X-Restli-Protocol-Version": "2.0.0",
+    })
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.status, response.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")
+    except urllib.error.URLError as e:
+        raise ProbeError(f"could not reach LinkedIn: {e}") from e
+
+
+def build_url(entity: str, metric: str, aggregation: str = "TOTAL") -> str:
+    return (f"{API_URL}?q=entity&entity={entity}&queryType={metric}"
+            f"&aggregation={aggregation}")
+
+
+def probe_metric(entity: str, metric: str, token: str, version: str,
+                 aggregation: str = "TOTAL", fetch: Optional[Callable] = None) -> dict:
+    """Probe ONE metric. Records status, classification, count and the response's shape."""
+    fetch = fetch or http_get_json
+    result = {
+        "metric": metric,
+        "column": METRIC_COLUMNS.get(metric),
+        "min_version": METRIC_MIN_VERSION.get(metric),
+        "version_ok": version_supports(version, METRIC_MIN_VERSION.get(metric, "000000")),
+    }
+    status, body = fetch(build_url(entity, metric, aggregation), token, version)
+    result["http_status"] = status
+    result["status"] = classify_status(status, body)
+    try:
+        payload = json.loads(body) if body else None
+    except ValueError:
+        payload = None
+    if result["status"] == "ok" and isinstance(payload, dict):
+        result["count"] = metric_total(payload, metric)
+        result["element_count"] = len(payload.get("elements") or [])
+        result["metric_type_shape"] = _metric_type_shape(payload)
+    else:
+        result["count"] = None
+        result["error"] = _error_excerpt(payload, body)
+    return result
+
+
+def _metric_type_shape(payload: dict) -> Optional[str]:
+    """'string' or 'object' — evidence of which side of the 202605 change served us."""
+    for element in payload.get("elements") or []:
+        if isinstance(element, dict) and "metricType" in element:
+            return "string" if isinstance(element["metricType"], str) else "object"
+    return None
+
+
+def _error_excerpt(payload, body: str) -> str:
+    """LinkedIn's own error message, truncated. Response bodies here carry no user content."""
+    if isinstance(payload, dict):
+        for key in ("message", "code", "status"):
+            value = payload.get(key)
+            if isinstance(value, str) and value:
+                return value[:_BODY_EXCERPT]
+    return (body or "")[:_BODY_EXCERPT]
+
+
+def compare_counts(results: list, stored: Optional[dict]) -> dict:
+    """API count vs the number the scrape stored, per signal.
+
+    ``match`` is None whenever either side is unknown — an unread signal is never graded as a
+    disagreement, and never as agreement either."""
+    comparison = {}
+    for result in results:
+        column = result.get("column")
+        if not column:
+            continue
+        api_value = result.get("count")
+        stored_value = (stored or {}).get(column)
+        comparison[column] = {
+            "api": api_value,
+            "scrape": stored_value,
+            "match": None if api_value is None or stored_value is None
+            else api_value == stored_value,
+            "delta": None if api_value is None or stored_value is None
+            else api_value - stored_value,
+        }
+    return comparison
+
+
+def verdict(results: list, comparison: dict) -> dict:
+    """One overall answer plus the action it implies."""
+    statuses = {r.get("status") for r in results}
+    if not results:
+        return {"outcome": "not_probed", "reason": "no metrics probed"}
+    if "forbidden" in statuses:
+        return {"outcome": "blocked",
+                "reason": f"403 — the token lacks {REQUIRED_PERMISSION} (or the app is not "
+                          f"provisioned for the Community Management API); keep the scrape"}
+    if "unauthorized" in statuses:
+        return {"outcome": "error",
+                "reason": "401 — the stored member token is expired or invalid; re-probe after "
+                          "reconnecting LinkedIn"}
+    if "version_retired" in statuses:
+        return {"outcome": "error",
+                "reason": "426 — LI_API_VERSION is retired; bump it and re-probe"}
+    if statuses == {"ok"}:
+        graded = [c for c in comparison.values() if c["match"] is not None]
+        mismatched = [k for k, c in comparison.items() if c["match"] is False]
+        if not graded:
+            return {"outcome": "available",
+                    "reason": "every metric returned, but no stored scrape row to compare against"}
+        if mismatched:
+            return {"outcome": "available_mismatch",
+                    "reason": f"every metric returned; disagrees with the scrape on "
+                              f"{', '.join(sorted(mismatched))}"}
+        return {"outcome": "available_match",
+                "reason": f"every metric returned and agrees with the scrape on "
+                          f"{len(graded)} signal(s)"}
+    if "unsupported_metric" in statuses:
+        stale = sorted(r["metric"] for r in results
+                       if r.get("status") == "unsupported_metric" and r.get("version_ok") is False)
+        if stale:
+            return {"outcome": "partial",
+                    "reason": f"LinkedIn-Version predates {', '.join(stale)} "
+                              f"(floor: {', '.join(sorted({METRIC_MIN_VERSION[m] for m in stale}))})"
+                              f" — bump LI_API_VERSION and re-probe"}
+    failed = sorted(s for s in statuses if s != "ok")
+    return {"outcome": "partial", "reason": f"some metrics failed: {', '.join(failed)}"}
+
+
+def build_report(entity_urn: str, entity: str, version: str, results: list,
+                 stored: Optional[dict]) -> dict:
+    comparison = compare_counts(results, stored)
+    return {
+        "probe": "memberCreatorPostAnalytics",
+        "entity_urn": entity_urn,
+        "entity_param": entity,
+        "linkedin_version": version,
+        "required_permission": REQUIRED_PERMISSION,
+        "entity_finder_min_version": ENTITY_FINDER_MIN_VERSION,
+        "metric_type_string_since": STRING_METRIC_TYPE_MIN_VERSION,
+        "metrics": results,
+        "comparison": comparison,
+        "verdict": verdict(results, comparison),
+    }
+
+
+def _resolve_from_db(args, need_url: bool) -> tuple[Optional[str], Optional[str], Optional[dict]]:
+    """(token, post_url, stored_stats) — the DB is only touched for what was NOT passed in, so a
+    fully-specified probe runs anywhere the DB does not (and tests never import it)."""
+    token, post_url, stored = args.token, args.post_url, None
+    if token and (post_url or not need_url) and args.post_id is None:
+        return token, post_url, None
+    from cqc_lem.utilities.db import get_latest_post_stats, get_post_url_from_log_for_user, \
+        get_user_access_token
+    if not token:
+        token = get_user_access_token(args.user_id)
+    if args.post_id is not None:
+        post_url = post_url or get_post_url_from_log_for_user(args.user_id, args.post_id)
+        stored = get_latest_post_stats(args.user_id, args.post_id)
+    return token, post_url, stored
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description="Probe LinkedIn member post stats (read-only)")
+    parser.add_argument("--user-id", type=int, default=1, help="whose stored token to probe with")
+    parser.add_argument("--post-id", type=int, help="LEM post id — resolves the URL and the "
+                                                    "stored scrape row to compare against")
+    parser.add_argument("--post-url", help="post permalink (skips the log lookup)")
+    parser.add_argument("--entity-urn", help="share/ugcPost URN (skips URL parsing entirely)")
+    parser.add_argument("--token", help="access token (default: the user's, from the DB)")
+    parser.add_argument("--version", help="LinkedIn-Version (default: LI_API_VERSION)")
+    parser.add_argument("--metrics", nargs="+", default=list(DEFAULT_METRICS),
+                        choices=list(METRIC_COLUMNS))
+    parser.add_argument("--aggregation", default="TOTAL", choices=["TOTAL", "DAILY"])
+    args = parser.parse_args(argv)
+
+    version = args.version
+    if not version:
+        from cqc_lem.utilities.env_constants import LI_API_VERSION
+        version = LI_API_VERSION
+
+    try:
+        token, post_url, stored = _resolve_from_db(args, need_url=not args.entity_urn)
+        if not token:
+            raise ProbeError(f"no LinkedIn access token for user {args.user_id}")
+        entity_urn = args.entity_urn or urn_from_post_url(post_url)
+        if not entity_urn:
+            raise ProbeError("no share/ugcPost URN — pass --entity-urn, --post-url or --post-id")
+        entity = entity_param(entity_urn)
+        if not entity:
+            raise ProbeError(
+                f"{entity_urn} is not a valid entity for this finder — it takes share/ugcPost "
+                f"URNs, and an activity URN's id is not interchangeable with them")
+        results = [probe_metric(entity, metric, token, version, args.aggregation)
+                   for metric in args.metrics]
+    except ProbeError as e:
+        print(json.dumps({"probe": "memberCreatorPostAnalytics",
+                          "verdict": {"outcome": "error", "reason": str(e)}}))
+        return 1
+
+    print(json.dumps(build_report(entity_urn, entity, version, results, stored), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/linkedin_post_stats_api_probe.py
+++ b/scripts/linkedin_post_stats_api_probe.py
@@ -31,6 +31,9 @@ Three facts the report is built to separate, because they demand different fixes
 * **400 / absent metric** — the pinned version predates the metric. ``q=entity`` (single-post
   stats) landed in ``202506``; ``POST_SAVE`` only in ``202604``. The report states the floor for
   every metric it asks for so a 400 is never misread as "LinkedIn does not expose saves".
+* **400 under ``--aggregation DAILY``** — LinkedIn serves some metrics under ``TOTAL`` only
+  (``IMPRESSION`` among them, for a post entity) and answers the rest with the SAME 400 shape as a
+  version gap. That one is named separately, because the fix is the operator's own flag.
 
 The parsing/verdict logic is pure and unit-tested; the HTTP call is injected so tests never
 touch the network.
@@ -74,6 +77,16 @@ METRIC_MIN_VERSION = {
 }
 DEFAULT_METRICS = tuple(METRIC_COLUMNS)
 
+# LinkedIn documents DAILY as unsupported for these queryTypes ("Daily impression metrics are not
+# supported if given entity is post", plus the MEMBERS_REACHED/LINK_CLICKS/FOLLOWER_GAINED_FROM_
+# CONTENT/PROFILE_VIEW_FROM_CONTENT note). Those 400s carry the SAME "query type ... metric type"
+# error shape as a version gap, so without this the probe would send whoever reads the report off
+# to bump LI_API_VERSION over a flag they set themselves. TOTAL — the default — clears all of it.
+DAILY_UNSUPPORTED_METRICS = frozenset({
+    "IMPRESSION", "MEMBERS_REACHED", "LINK_CLICKS",
+    "FOLLOWER_GAINED_FROM_CONTENT", "PROFILE_VIEW_FROM_CONTENT",
+})
+
 # The entity finder takes a share or ugcPost URN. An ACTIVITY urn — which is what the analytics
 # PAGE keys off, and what _post_analytics_counts resolves by following the redirect — is not a
 # valid entity here, and the numeric ids are not interchangeable. Say so rather than guess.
@@ -113,6 +126,11 @@ def version_supports(configured: Optional[str], minimum: str) -> Optional[bool]:
     if not configured or not str(configured).isdigit() or len(str(configured)) != 6:
         return None
     return int(configured) >= int(minimum)
+
+
+def aggregation_supports(metric: str, aggregation: str) -> bool:
+    """Is this metric served under this aggregation? Only DAILY is ever restricted."""
+    return not (str(aggregation).upper() == "DAILY" and metric in DAILY_UNSUPPORTED_METRICS)
 
 
 def metric_type_name(raw) -> Optional[str]:
@@ -207,6 +225,8 @@ def probe_metric(entity: str, metric: str, token: str, version: str,
         "column": METRIC_COLUMNS.get(metric),
         "min_version": METRIC_MIN_VERSION.get(metric),
         "version_ok": version_supports(version, METRIC_MIN_VERSION.get(metric, "000000")),
+        "aggregation": aggregation,
+        "aggregation_ok": aggregation_supports(metric, aggregation),
     }
     status, body = fetch(build_url(entity, metric, aggregation), token, version)
     result["http_status"] = status
@@ -274,7 +294,8 @@ def verdict(results: list, comparison: dict) -> dict:
     if "forbidden" in statuses:
         return {"outcome": "blocked",
                 "reason": f"403 — the token lacks {REQUIRED_PERMISSION} (or the app is not "
-                          f"provisioned for the Community Management API); keep the scrape"}
+                          f"provisioned for the Community Management API, or the probed post is "
+                          f"not this member's own); keep the scrape"}
     if "unauthorized" in statuses:
         return {"outcome": "error",
                 "reason": "401 — the stored member token is expired or invalid; re-probe after "
@@ -296,6 +317,16 @@ def verdict(results: list, comparison: dict) -> dict:
                 "reason": f"every metric returned and agrees with the scrape on "
                           f"{len(graded)} signal(s)"}
     if "unsupported_metric" in statuses:
+        # The aggregation is checked FIRST: it is the one cause the operator introduced with a
+        # flag, and LinkedIn answers it with the same 400 shape as a version gap. Blaming
+        # LI_API_VERSION for a --aggregation DAILY run would send them to fix the wrong thing.
+        by_aggregation = sorted(r["metric"] for r in results
+                                if r.get("status") == "unsupported_metric"
+                                and r.get("aggregation_ok") is False)
+        if by_aggregation:
+            return {"outcome": "partial",
+                    "reason": f"LinkedIn does not serve {', '.join(by_aggregation)} under DAILY "
+                              f"aggregation — re-probe with --aggregation TOTAL"}
         stale = sorted(r["metric"] for r in results
                        if r.get("status") == "unsupported_metric" and r.get("version_ok") is False)
         if stale:
@@ -308,13 +339,16 @@ def verdict(results: list, comparison: dict) -> dict:
 
 
 def build_report(entity_urn: str, entity: str, version: str, results: list,
-                 stored: Optional[dict]) -> dict:
+                 stored: Optional[dict], aggregation: str = "TOTAL") -> dict:
     comparison = compare_counts(results, stored)
     return {
         "probe": "memberCreatorPostAnalytics",
         "entity_urn": entity_urn,
         "entity_param": entity,
         "linkedin_version": version,
+        # Recorded because it changes which metrics LinkedIn will serve at all — a report pasted
+        # into an issue without it cannot be read.
+        "aggregation": aggregation,
         "required_permission": REQUIRED_PERMISSION,
         "entity_finder_min_version": ENTITY_FINDER_MIN_VERSION,
         "metric_type_string_since": STRING_METRIC_TYPE_MIN_VERSION,
@@ -378,7 +412,8 @@ def main(argv: Optional[list] = None) -> int:
                           "verdict": {"outcome": "error", "reason": str(e)}}))
         return 1
 
-    print(json.dumps(build_report(entity_urn, entity, version, results, stored), indent=2))
+    print(json.dumps(build_report(entity_urn, entity, version, results, stored,
+                                  args.aggregation), indent=2))
     return 0
 
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -5418,6 +5418,27 @@ def record_post_stats(user_id: int, post_id: int, reactions: Optional[int], comm
         connection.close()
 
 
+def get_latest_post_stats(user_id: int, post_id: int) -> Optional[dict]:
+    """The most recent captured counts for one post, or None when nothing was ever captured.
+
+    `impressions` stays NULL when the capture never read one — the API probe (#645) grades a
+    signal it cannot compare as ungraded rather than as a disagreement."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT reactions, comments, reposts, impressions, saves, captured_at "
+            "FROM post_stats WHERE user_id=%s AND post_id=%s ORDER BY id DESC LIMIT 1",
+            (user_id, post_id))
+        return cursor.fetchone()
+    except mysql.connector.Error as err:
+        myprint(f"Could not read post stats for user {user_id} post {post_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_recent_posted_post_ids(user_id: int, days: int = 21) -> list:
     connection = get_db_connection()
     cursor = connection.cursor()

--- a/tests/unit/test_linkedin_post_stats_api_probe.py
+++ b/tests/unit/test_linkedin_post_stats_api_probe.py
@@ -75,6 +75,20 @@ class TestVersionSupport:
 
 
 @pytest.mark.unit
+class TestAggregationSupport:
+    def test_total_serves_every_metric_lem_stores(self):
+        for metric in probe.DEFAULT_METRICS:
+            assert probe.aggregation_supports(metric, "TOTAL") is True
+
+    def test_daily_does_not_serve_impressions_for_a_post_entity(self):
+        assert probe.aggregation_supports("IMPRESSION", "DAILY") is False
+
+    def test_daily_serves_the_engagement_metrics(self):
+        for metric in ("REACTION", "COMMENT", "RESHARE", "POST_SAVE"):
+            assert probe.aggregation_supports(metric, "DAILY") is True
+
+
+@pytest.mark.unit
 class TestMetricParsing:
     def test_reads_the_bare_string_metric_type(self):
         assert probe.metric_type_name("REACTION") == "REACTION"
@@ -175,6 +189,21 @@ class TestProbeMetric:
         assert result["version_ok"] is False
         assert result["min_version"] == "202604"
 
+    def test_a_daily_unsupported_metric_is_flagged_before_the_response_is_read(self):
+        result = probe.probe_metric("(share:x)", "IMPRESSION", "tok", "202606",
+                                    aggregation="DAILY",
+                                    fetch=_fetch(400, {"message": "Unsupported query type DAILY "
+                                                                  "for metric type IMPRESSION."}))
+        assert result["aggregation"] == "DAILY"
+        assert result["aggregation_ok"] is False
+        assert result["version_ok"] is True
+
+    def test_total_leaves_every_metric_servable(self):
+        result = probe.probe_metric("(share:x)", "IMPRESSION", "tok", "202606",
+                                    fetch=_fetch(200, _ok_payload("IMPRESSION", 72)))
+        assert result["aggregation"] == "TOTAL"
+        assert result["aggregation_ok"] is True
+
     def test_url_carries_the_finder_entity_and_aggregation(self):
         seen = {}
 
@@ -252,6 +281,22 @@ class TestVerdict:
         assert "POST_SAVE" in outcome["reason"] and "202604" in outcome["reason"]
         assert "LI_API_VERSION" in outcome["reason"]
 
+    def test_a_daily_only_restriction_blames_the_flag_not_the_version(self):
+        """LinkedIn answers a DAILY-unsupported metric with the same 400 shape as a version gap.
+        Sending the operator to bump LI_API_VERSION over their own --aggregation flag would waste
+        the exact debugging session this probe exists to prevent."""
+        results = [{"status": "unsupported_metric", "metric": "IMPRESSION",
+                    "version_ok": True, "aggregation_ok": False}]
+        outcome = probe.verdict(results, {})
+        assert outcome["outcome"] == "partial"
+        assert "DAILY" in outcome["reason"] and "--aggregation TOTAL" in outcome["reason"]
+        assert "LI_API_VERSION" not in outcome["reason"]
+
+    def test_the_aggregation_cause_is_named_ahead_of_the_version_one(self):
+        results = [{"status": "unsupported_metric", "metric": "IMPRESSION",
+                    "version_ok": False, "aggregation_ok": False}]
+        assert "DAILY" in probe.verdict(results, {})["reason"]
+
     def test_an_unsupported_metric_on_a_new_enough_pin_is_just_partial(self):
         """version_ok True means the pin clears the floor — blaming LI_API_VERSION there would
         send whoever reads this report to fix the wrong thing."""
@@ -287,6 +332,12 @@ class TestBuildReport:
         assert report["metric_type_string_since"] == "202605"
         assert report["comparison"]["saves"]["match"] is True
         assert report["verdict"]["outcome"] == "available_match"
+
+    def test_report_records_the_aggregation_it_ran_under(self):
+        """The report is pasted into an issue; without the aggregation, a metric that came back
+        empty cannot be told apart from one LinkedIn refuses to serve that way."""
+        report = probe.build_report("urn:li:share:7", "(share:x)", "202606", [], None, "DAILY")
+        assert report["aggregation"] == "DAILY"
 
     def test_report_is_json_serialisable(self):
         results = [probe.probe_metric("(share:x)", "COMMENT", "tok", "202606",

--- a/tests/unit/test_linkedin_post_stats_api_probe.py
+++ b/tests/unit/test_linkedin_post_stats_api_probe.py
@@ -1,0 +1,330 @@
+"""Unit tests for the member post-stats API probe (scripts/linkedin_post_stats_api_probe.py)."""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "linkedin_post_stats_api_probe.py"
+_spec = importlib.util.spec_from_file_location("linkedin_post_stats_api_probe", SCRIPT)
+probe = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(probe)
+
+
+def _fetch(status: int, payload) -> callable:
+    body = payload if isinstance(payload, str) else json.dumps(payload)
+    return lambda *_a, **_k: (status, body)
+
+
+def _ok_payload(metric: str, count: int, string_shape: bool = True) -> dict:
+    metric_type = metric if string_shape else {
+        "com.linkedin.adsexternalapi.memberanalytics.v1.CreatorPostAnalyticsMetricTypeV1": metric}
+    return {"elements": [{"count": count, "metricType": metric_type,
+                          "targetEntity": {"share": "urn:li:share:7"}}],
+            "paging": {"count": 10, "start": 0, "links": []}}
+
+
+@pytest.mark.unit
+class TestUrnHandling:
+    def test_pulls_a_share_urn_out_of_a_permalink(self):
+        url = "https://www.linkedin.com/feed/update/urn:li:share:7325786486870552578/"
+        assert probe.urn_from_post_url(url) == "urn:li:share:7325786486870552578"
+
+    def test_pulls_a_ugcpost_urn_out_of_a_permalink(self):
+        url = "https://www.linkedin.com/feed/update/urn:li:ugcPost:644315644/"
+        assert probe.urn_from_post_url(url) == "urn:li:ugcPost:644315644"
+
+    def test_no_urn_in_the_url_is_none(self):
+        assert probe.urn_from_post_url("https://www.linkedin.com/feed/") is None
+        assert probe.urn_from_post_url(None) is None
+
+    def test_share_entity_param_is_url_encoded(self):
+        assert probe.entity_param("urn:li:share:123") == "(share:urn%3Ali%3Ashare%3A123)"
+
+    def test_ugcpost_entity_param_uses_the_ugc_key(self):
+        assert probe.entity_param("urn:li:ugcPost:123") == "(ugc:urn%3Ali%3AugcPost%3A123)"
+
+    def test_activity_urn_is_rejected(self):
+        """The analytics PAGE keys off the activity URN; this finder does not, and the ids are
+        not interchangeable. Guessing one from the other would probe the wrong post."""
+        assert probe.entity_param("urn:li:activity:123") is None
+
+    def test_garbage_urn_is_rejected(self):
+        assert probe.entity_param("urn:li:person:123") is None
+        assert probe.entity_param(None) is None
+        assert probe.entity_param("") is None
+
+
+@pytest.mark.unit
+class TestVersionSupport:
+    def test_pin_at_or_past_the_floor_supports_the_metric(self):
+        assert probe.version_supports("202606", "202604") is True
+        assert probe.version_supports("202604", "202604") is True
+
+    def test_pin_below_the_floor_does_not(self):
+        assert probe.version_supports("202506", "202604") is False
+
+    def test_unusable_pin_is_undecidable(self):
+        for pin in (None, "", "latest", "2026", "2026060"):
+            assert probe.version_supports(pin, "202604") is None
+
+    def test_post_save_has_a_later_floor_than_the_entity_finder(self):
+        assert probe.METRIC_MIN_VERSION["POST_SAVE"] == "202604"
+        assert probe.METRIC_MIN_VERSION["IMPRESSION"] == probe.ENTITY_FINDER_MIN_VERSION
+
+
+@pytest.mark.unit
+class TestMetricParsing:
+    def test_reads_the_bare_string_metric_type(self):
+        assert probe.metric_type_name("REACTION") == "REACTION"
+
+    def test_reads_the_pre_202605_object_metric_type(self):
+        assert probe.metric_type_name(
+            {"com.linkedin.x.CreatorPostAnalyticsMetricTypeV1": "REACTION"}) == "REACTION"
+
+    def test_unreadable_metric_type_is_none(self):
+        assert probe.metric_type_name(None) is None
+        assert probe.metric_type_name({"a": 1}) is None
+
+    def test_total_from_a_string_shaped_response(self):
+        assert probe.metric_total(_ok_payload("IMPRESSION", 72), "IMPRESSION") == 72
+
+    def test_total_from_an_object_shaped_response(self):
+        payload = _ok_payload("IMPRESSION", 72, string_shape=False)
+        assert probe.metric_total(payload, "IMPRESSION") == 72
+
+    def test_daily_elements_are_summed(self):
+        payload = {"elements": [{"count": 10, "metricType": "REACTION"},
+                                {"count": 20, "metricType": "REACTION"}]}
+        assert probe.metric_total(payload, "REACTION") == 30
+
+    def test_other_metrics_are_ignored(self):
+        payload = {"elements": [{"count": 10, "metricType": "REACTION"},
+                                {"count": 999, "metricType": "COMMENT"}]}
+        assert probe.metric_total(payload, "REACTION") == 10
+
+    def test_no_matching_element_is_none_not_zero(self):
+        """An unprovisioned or empty surface must never read as 'this post got zero'."""
+        assert probe.metric_total({"elements": []}, "REACTION") is None
+        assert probe.metric_total({}, "REACTION") is None
+        assert probe.metric_total("nope", "REACTION") is None
+
+    def test_a_real_zero_is_kept(self):
+        assert probe.metric_total(_ok_payload("POST_SAVE", 0), "POST_SAVE") == 0
+
+    def test_non_integer_counts_are_skipped(self):
+        payload = {"elements": [{"count": "10", "metricType": "REACTION"},
+                                {"count": True, "metricType": "REACTION"}]}
+        assert probe.metric_total(payload, "REACTION") is None
+
+
+@pytest.mark.unit
+class TestClassifyStatus:
+    @pytest.mark.parametrize("status,expected", [
+        (200, "ok"), (400, "bad_request"), (401, "unauthorized"), (403, "forbidden"),
+        (426, "version_retired"), (429, "throttled"), (500, "server_error"),
+        (503, "server_error"), (418, "http_418"),
+    ])
+    def test_each_status_names_its_own_fix(self, status, expected):
+        assert probe.classify_status(status, "{}") == expected
+
+    def test_400_naming_the_query_type_is_a_version_gap_not_a_coding_bug(self):
+        body = '{"message":"Unsupported query type TOTAL for metric type POST_SAVE."}'
+        assert probe.classify_status(400, body) == "unsupported_metric"
+
+    def test_a_plain_400_stays_a_bad_request(self):
+        assert probe.classify_status(400, '{"message":"malformed entity"}') == "bad_request"
+        assert probe.classify_status(400, "") == "bad_request"
+
+
+@pytest.mark.unit
+class TestProbeMetric:
+    def test_ok_records_count_and_shape(self):
+        result = probe.probe_metric("(share:x)", "IMPRESSION", "tok", "202606",
+                                    fetch=_fetch(200, _ok_payload("IMPRESSION", 72)))
+        assert result["status"] == "ok"
+        assert result["count"] == 72
+        assert result["column"] == "impressions"
+        assert result["metric_type_shape"] == "string"
+        assert result["version_ok"] is True
+
+    def test_object_shape_is_reported_as_object(self):
+        result = probe.probe_metric("(share:x)", "REACTION", "tok", "202604",
+                                    fetch=_fetch(200, _ok_payload("REACTION", 3, False)))
+        assert result["metric_type_shape"] == "object"
+        assert result["count"] == 3
+
+    def test_403_carries_linkedins_own_message(self):
+        result = probe.probe_metric("(share:x)", "POST_SAVE", "tok", "202606",
+                                    fetch=_fetch(403, {"message": "Not enough permissions",
+                                                       "status": 403}))
+        assert result["status"] == "forbidden"
+        assert result["count"] is None
+        assert result["error"] == "Not enough permissions"
+
+    def test_unparseable_body_falls_back_to_an_excerpt(self):
+        result = probe.probe_metric("(share:x)", "COMMENT", "tok", "202606",
+                                    fetch=_fetch(500, "<html>boom</html>"))
+        assert result["status"] == "server_error"
+        assert "boom" in result["error"]
+
+    def test_a_pin_below_the_metric_floor_is_flagged(self):
+        result = probe.probe_metric("(share:x)", "POST_SAVE", "tok", "202506",
+                                    fetch=_fetch(400, {"message": "unknown queryType"}))
+        assert result["version_ok"] is False
+        assert result["min_version"] == "202604"
+
+    def test_url_carries_the_finder_entity_and_aggregation(self):
+        seen = {}
+
+        def fetch(url, token, version):
+            seen["url"] = url
+            return 200, json.dumps(_ok_payload("REACTION", 1))
+
+        probe.probe_metric("(share:urn%3Ali%3Ashare%3A7)", "REACTION", "tok", "202606",
+                           aggregation="DAILY", fetch=fetch)
+        assert "q=entity" in seen["url"]
+        assert "entity=(share:urn%3Ali%3Ashare%3A7)" in seen["url"]
+        assert "queryType=REACTION" in seen["url"]
+        assert "aggregation=DAILY" in seen["url"]
+
+
+@pytest.mark.unit
+class TestCompareCounts:
+    def test_agreement_is_a_match(self):
+        results = [{"column": "reactions", "count": 5}]
+        comparison = probe.compare_counts(results, {"reactions": 5})
+        assert comparison["reactions"] == {"api": 5, "scrape": 5, "match": True, "delta": 0}
+
+    def test_disagreement_carries_the_delta(self):
+        results = [{"column": "impressions", "count": 80}]
+        comparison = probe.compare_counts(results, {"impressions": 72})
+        assert comparison["impressions"]["match"] is False
+        assert comparison["impressions"]["delta"] == 8
+
+    def test_a_missing_side_is_ungraded_not_a_mismatch(self):
+        results = [{"column": "saves", "count": None}, {"column": "impressions", "count": 3}]
+        comparison = probe.compare_counts(results, {"saves": 2, "impressions": None})
+        assert comparison["saves"]["match"] is None
+        assert comparison["impressions"]["match"] is None
+
+    def test_no_stored_row_grades_nothing(self):
+        comparison = probe.compare_counts([{"column": "reactions", "count": 5}], None)
+        assert comparison["reactions"]["match"] is None
+
+
+@pytest.mark.unit
+class TestVerdict:
+    def test_403_on_any_metric_blocks_and_names_the_permission(self):
+        results = [{"status": "ok"}, {"status": "forbidden"}]
+        outcome = probe.verdict(results, {})
+        assert outcome["outcome"] == "blocked"
+        assert probe.REQUIRED_PERMISSION in outcome["reason"]
+
+    def test_401_is_an_error_not_a_block(self):
+        assert probe.verdict([{"status": "unauthorized"}], {})["outcome"] == "error"
+
+    def test_426_points_at_the_version_pin(self):
+        outcome = probe.verdict([{"status": "version_retired"}], {})
+        assert outcome["outcome"] == "error"
+        assert "LI_API_VERSION" in outcome["reason"]
+
+    def test_all_ok_and_matching(self):
+        comparison = {"reactions": {"match": True}, "saves": {"match": True}}
+        assert probe.verdict([{"status": "ok"}], comparison)["outcome"] == "available_match"
+
+    def test_all_ok_but_disagreeing(self):
+        comparison = {"reactions": {"match": True}, "impressions": {"match": False}}
+        outcome = probe.verdict([{"status": "ok"}], comparison)
+        assert outcome["outcome"] == "available_mismatch"
+        assert "impressions" in outcome["reason"]
+
+    def test_all_ok_with_nothing_to_compare(self):
+        comparison = {"reactions": {"match": None}}
+        assert probe.verdict([{"status": "ok"}], comparison)["outcome"] == "available"
+
+    def test_a_metric_below_the_version_floor_names_the_floor(self):
+        results = [{"status": "ok", "metric": "REACTION"},
+                   {"status": "unsupported_metric", "metric": "POST_SAVE", "version_ok": False}]
+        outcome = probe.verdict(results, {})
+        assert outcome["outcome"] == "partial"
+        assert "POST_SAVE" in outcome["reason"] and "202604" in outcome["reason"]
+        assert "LI_API_VERSION" in outcome["reason"]
+
+    def test_an_unsupported_metric_on_a_new_enough_pin_is_just_partial(self):
+        """version_ok True means the pin clears the floor — blaming LI_API_VERSION there would
+        send whoever reads this report to fix the wrong thing."""
+        results = [{"status": "unsupported_metric", "metric": "POST_SAVE", "version_ok": True}]
+        outcome = probe.verdict(results, {})
+        assert outcome["outcome"] == "partial"
+        assert "LI_API_VERSION" not in outcome["reason"]
+
+    def test_mixed_failures_are_partial(self):
+        outcome = probe.verdict([{"status": "ok"}, {"status": "throttled"}], {})
+        assert outcome["outcome"] == "partial"
+        assert "throttled" in outcome["reason"]
+
+    def test_nothing_probed(self):
+        assert probe.verdict([], {})["outcome"] == "not_probed"
+
+    def test_403_wins_over_a_successful_metric(self):
+        """One readable metric must not make an unreadable surface look usable."""
+        comparison = {"reactions": {"match": True}}
+        results = [{"status": "ok"}, {"status": "forbidden"}]
+        assert probe.verdict(results, comparison)["outcome"] == "blocked"
+
+
+@pytest.mark.unit
+class TestBuildReport:
+    def test_report_names_the_permission_and_version_floors(self):
+        results = [probe.probe_metric("(share:x)", "POST_SAVE", "tok", "202606",
+                                      fetch=_fetch(200, _ok_payload("POST_SAVE", 4)))]
+        report = probe.build_report("urn:li:share:7", "(share:x)", "202606", results,
+                                    {"saves": 4})
+        assert report["required_permission"] == "r_member_postAnalytics"
+        assert report["entity_finder_min_version"] == "202506"
+        assert report["metric_type_string_since"] == "202605"
+        assert report["comparison"]["saves"]["match"] is True
+        assert report["verdict"]["outcome"] == "available_match"
+
+    def test_report_is_json_serialisable(self):
+        results = [probe.probe_metric("(share:x)", "COMMENT", "tok", "202606",
+                                      fetch=_fetch(403, {"message": "denied"}))]
+        report = probe.build_report("urn:li:share:7", "(share:x)", "202606", results, None)
+        assert json.loads(json.dumps(report))["verdict"]["outcome"] == "blocked"
+
+
+@pytest.mark.unit
+class TestMain:
+    def test_an_activity_urn_fails_with_an_explanation_not_a_probe(self, capsys):
+        code = probe.main(["--entity-urn", "urn:li:activity:123", "--token", "t",
+                           "--version", "202606"])
+        assert code == 1
+        report = json.loads(capsys.readouterr().out)
+        assert report["verdict"]["outcome"] == "error"
+        assert "share/ugcPost" in report["verdict"]["reason"]
+
+    def test_no_urn_at_all_fails_before_any_network_call(self, capsys):
+        code = probe.main(["--token", "t", "--version", "202606"])
+        assert code == 1
+        assert "no share/ugcPost URN" in json.loads(capsys.readouterr().out)["verdict"]["reason"]
+
+    def test_happy_path_prints_a_report(self, capsys, monkeypatch):
+        monkeypatch.setattr(probe, "http_get_json",
+                            lambda url, token, version, timeout=20:
+                            (200, json.dumps(_ok_payload("REACTION", 5))))
+        code = probe.main(["--entity-urn", "urn:li:share:7", "--token", "t",
+                           "--version", "202606", "--metrics", "REACTION"])
+        assert code == 0
+        report = json.loads(capsys.readouterr().out)
+        assert report["metrics"][0]["count"] == 5
+        assert report["entity_param"] == "(share:urn%3Ali%3Ashare%3A7)"
+
+    def test_the_token_is_never_echoed_into_the_report(self, capsys, monkeypatch):
+        monkeypatch.setattr(probe, "http_get_json",
+                            lambda url, token, version, timeout=20:
+                            (403, json.dumps({"message": "Not enough permissions"})))
+        probe.main(["--entity-urn", "urn:li:share:7", "--token", "s3cr3t-token",
+                    "--version", "202606", "--metrics", "REACTION"])
+        assert "s3cr3t-token" not in capsys.readouterr().out

--- a/tests/unit/utilities/test_db_latest_post_stats.py
+++ b/tests/unit/utilities/test_db_latest_post_stats.py
@@ -1,0 +1,39 @@
+"""Unit tests for get_latest_post_stats — the scrape's own numbers, read back for the #645 probe."""
+
+import mysql.connector
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_GET_CONN = "cqc_lem.utilities.db.get_db_connection"
+
+
+class TestGetLatestPostStats:
+    def test_returns_the_latest_capture(self, mock_database_connection):
+        row = {"reactions": 12, "comments": 3, "reposts": 1, "impressions": 72, "saves": 4}
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = row
+            from cqc_lem.utilities.db import get_latest_post_stats
+            assert get_latest_post_stats(1, 9) == row
+        sql = mock_database_connection["cursor"].execute.call_args[0][0]
+        assert "ORDER BY id DESC" in sql and "LIMIT 1" in sql
+
+    def test_no_capture_yet_is_none(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = None
+            from cqc_lem.utilities.db import get_latest_post_stats
+            assert get_latest_post_stats(1, 9) is None
+
+    def test_a_db_error_is_none_not_a_raise(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("boom")
+            from cqc_lem.utilities.db import get_latest_post_stats
+            assert get_latest_post_stats(1, 9) is None
+
+    def test_scoped_to_the_owning_user(self, mock_database_connection):
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = None
+            from cqc_lem.utilities.db import get_latest_post_stats
+            get_latest_post_stats(7, 42)
+        assert mock_database_connection["cursor"].execute.call_args[0][1] == (7, 42)


### PR DESCRIPTION
## What & why

Impressions and saves come from a **Selenium scrape** of `/analytics/post-summary/<activity-urn>/`
(`_post_analytics_counts` in `app/run_automation.py`). It works, but it breaks on any SDUI relayout
and rides the same 429 breaker as every other Selenium lane — so stats stop whenever engagement
automation is paused. R3 (#406) left a lead that LinkedIn's `202506` member post-stats surface might
replace it with an API read no DOM churn or browser rate limit can break.

**The lead is settled, and the answer is "yes, but blocked on a permission."**

`GET /rest/memberCreatorPostAnalytics?q=entity&entity=(share:…)&queryType=…` returns exactly the
signals LEM stores for the authenticated member's own posts — over plain HTTP, no browser:

| Stored signal | `queryType` | Live since |
|---|---|---|
| `impressions` | `IMPRESSION` | `202506` (the `q=entity` finder) |
| `reactions` / `comments` / `reposts` | `REACTION` / `COMMENT` / `RESHARE` | `202506` |
| `saves` | `POST_SAVE` | **`202604`** — later than the finder |

It requires the **`r_member_postAnalytics`** permission. `linkedin_auth_init` (`api/main.py`) asks
for `openid profile email w_member_social`, so **the stored member token will answer `403`** — an
in-repo verifiable fact, not a code defect. Granting it needs Community Management API approval on
the app *and* re-consent from every connected user (a scope change invalidates the grant), neither
of which an agent can do. **So the scrape stays**, and the cutover is #695 behind an owner decision.

## What shipped

- **`scripts/linkedin_post_stats_api_probe.py`** — read-only, stdlib-only, **no browser** (holds no
  Selenium lane, 429-immune). It separates the three answers that demand different fixes: `403`
  (permission), `426` (retired `LI_API_VERSION`), and a `400` naming the `queryType` (the pin
  predates the metric — LinkedIn's own documented error shape), then compares whatever it *does*
  get against the latest stored `post_stats` row.
- **`db.get_latest_post_stats`** — reads the scrape's own numbers back for that comparison. All SQL
  stays in `db.py`.
- **`docs/LIVE_VALIDATION_FORMAT_AND_STATS.md` §2a** — the "Follow-up lead (not verified here)"
  paragraph becomes a graded finding, plus the TL;DR row, §4 pointer, §5 scope update and sources.
- **#695** filed (`needs-human`, `risk:product-decision`) for the permission + cutover.

Four traps the doc and the probe both record, because each would have cost a debugging session:

- **The entity URN is the OPPOSITE of the scrape's.** The finder takes a `share`/`ugcPost` URN; the
  analytics *page* keys off the **activity** URN `_post_analytics_counts` resolves via the redirect.
  The ids are not interchangeable, so the probe **refuses** an activity URN rather than guessing.
- **One `queryType` per request** — five signals is five GETs per post, not one.
- **`metricType` changed shape in `202605`** (object → bare string). The probe parses both; a
  single-shape parser reads a good response from the other side of that line as empty.
- **`POST_SAVE` needs `202604`+.** LEM's `LI_API_VERSION` default `202606` clears it; a rollback
  would silently `400` saves.

## Honesty note — read this before merging

**The live HTTP status is not recorded.** This pass ran headless with no access to a member token
(the runbook forbids `docker`, prod paths and secrets), so acceptance item 1 is *not* met by this
PR. What it ships instead is the instrument that makes recording it a one-liner:

```bash
sudo docker exec -i celery_worker python - --user-id 1 --post-id <post id> \
    < scripts/linkedin_post_stats_api_probe.py
```

Every row in §2a carries an evidence grade — **Documented** (`li-lms-2026-07`) or **in-repo
verified** — and none is presented as a live observation. The expected result today is `403`; the
probe records that as evidence rather than leaving it a hunch.

## Testing notes

- `tests/unit/test_linkedin_post_stats_api_probe.py` — 59 tests over URN handling (including the
  activity-URN refusal), version floors, both `metricType` shapes, status classification, the
  API-vs-scrape comparison (an unknown side is **ungraded**, never a mismatch and never zero),
  verdicts, and that the token never reaches the report.
- `tests/unit/utilities/test_db_latest_post_stats.py` — the new reader, including user scoping and
  DB-error degradation.
- Full suite: `7424 passed` locally.

Closes #645

🤖 Generated with [Claude Code](https://claude.com/claude-code)
