### PR TITLE
fix(automation): stop the missing-Connect-button error paging the cron (closes #571)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -30,7 +30,7 @@ from cqc_lem.utilities.ai.content_alignment import humanize_text, split_link_for
     append_link_to_comment, resolve_artifact_delivery, ARTIFACT_KIND_LEAD_MAGNET
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
-    CONNECTION_REQUEST_SENT_MESSAGE, ALREADY_CONNECTED_MESSAGE, \
+    CONNECTION_REQUEST_SENT_MESSAGE, ALREADY_CONNECTED_MESSAGE, NO_CONNECT_BUTTON_MESSAGE, \
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
     get_newsletter_settings, mark_newsletter_published, record_newsletter_subscriber_stat, \
     get_newsletter_edition, mark_edition_published, mark_edition_failed, \
@@ -4884,6 +4884,35 @@ def _profile_is_first_degree(driver) -> bool:
     return False
 
 
+def _click_connect_affordance(driver, wait, user_id: int) -> bool:
+    """Click Connect on an open profile — the direct button first, else the one inside the
+    More-actions overflow. False when NEITHER is there, which is an ordinary outcome (an invite is
+    already pending, LinkedIn only offers Follow/Message on that profile, or the SDUI selector
+    drifted) and is why the miss is a WARNING and not an error (issue #571)."""
+    try:
+        click_element_wait_retry(driver, wait, '//main//button[contains(@aria-label, "Invite ")]',
+                                 "Finding Connect Button", max_retry=1, use_action_chain=True)
+        myprint("Found Connect Button and clicked it")
+        return True
+    except Exception:
+        pass  # No direct Connect button — LinkedIn buries it in the More menu on many profiles.
+
+    try:
+        click_element_wait_retry(driver, wait,
+                                 '//main//button[contains(@aria-label,"More actions")]',
+                                 "Finding More Button", max_retry=1, use_action_chain=True)
+        myprint("Found More Button and clicked it")
+
+        click_element_wait_retry(driver, wait, '//main//div[contains(@aria-label,"connect")]',
+                                 "Finding Connect Button", max_retry=1, use_action_chain=True)
+        myprint("Found Connect Button and clicked it")
+        return True
+    except Exception as e:
+        log_warning("No Connect option on this profile (direct button and More menu both missed)",
+                    exc=e, user_id=user_id, action_type="invite_connect")
+        return False
+
+
 def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -> "tuple[bool, str]":
     """Core connect-invite send: open the profile, click Connect (+ optional note), log the result.
     Returns (sent, result_message) — the message is the failure reason when `sent` is False, which
@@ -4918,36 +4947,13 @@ def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -
                            message=ALREADY_CONNECTED_MESSAGE)
             return False, ALREADY_CONNECTED_MESSAGE
 
-        # Locate the connect button
-        try:
-            click_element_wait_retry(driver, wait, '//main//button[contains(@aria-label, "Invite ")]',
-                                     "Finding Connect Button", max_retry=1, use_action_chain=True)
-
-            myprint("Found Connect Button and clicked it")
-
-
-        except Exception as ce:
-            # If it doesn't exist click the more then find the connect button there
-            try:
-                # Click the last more button
-                click_element_wait_retry(driver, wait,
-                                         '//main//button[contains(@aria-label,"More actions")]',
-                                         "Finding More Button", max_retry=1, use_action_chain=True)
-
-                # driver.find_elements(By.XPATH, '//main//button[contains(@aria-label,"More actions")]')[-1].click()
-
-                myprint("Found More Button and clicked it")
-
-                # Click the last connect button
-                click_element_wait_retry(driver, wait, '//main//div[contains(@aria-label,"connect")]',
-                                         "Finding Connect Button", max_retry=1, use_action_chain=True)
-
-                # driver.find_elements(By.XPATH, '//div[contains(@aria-label,"connect")]')[-1].click()
-
-                myprint("Found Connect Button and clicked it")
-            except Exception as e:
-                log_error("Failed to find more or connect button", exc=e, user_id=user_id, action_type="invite_connect")
-                result = f"Failed to find more or connect button: Error: {str(e)}"
+        # Locate the connect button. With no Connect dialog open the note/send steps below can only
+        # fail, and their errors would bury the real reason — so stop here with a named one instead.
+        if not _click_connect_affordance(driver, wait, user_id):
+            insert_new_log(user_id=user_id, action_type=LogActionType.ENGAGED,
+                           result=LogResultType.FAILURE, post_url=profile_url,
+                           message=NO_CONNECT_BUTTON_MESSAGE)
+            return False, NO_CONNECT_BUTTON_MESSAGE
 
         # If connection_message exist click the With note button
         if message:

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -378,6 +378,12 @@ CONNECTION_REQUEST_SENT_MESSAGE = "Connection Request Sent Successfully"
 # failure_reason so the Connections review UI explains a FAILED row instead of just colouring it red.
 ALREADY_CONNECTED_MESSAGE = "Already connected (1st-degree) — no invite to send"
 
+# The profile offered no Connect affordance at all — neither the direct button nor one inside the
+# More-actions menu (issue #571). Usually an invite is already pending or LinkedIn only offers
+# Follow/Message on that profile; either way there is nothing to send, so the invite stops here
+# rather than falling through to the note/send steps that can only fail after it.
+NO_CONNECT_BUTTON_MESSAGE = "No Connect option on this profile (invite may already be pending)"
+
 
 def store_cookies(user_email: str, cookies: list[dict]) -> None:
     connection = get_db_connection()

--- a/tests/unit/app/test_connection_requests.py
+++ b/tests/unit/app/test_connection_requests.py
@@ -3,6 +3,8 @@
 import pytest
 from unittest.mock import patch
 
+from cqc_lem.utilities.db import NO_CONNECT_BUTTON_MESSAGE
+
 pytestmark = pytest.mark.unit
 
 _RA = "cqc_lem.app.run_automation"
@@ -32,12 +34,12 @@ class TestSendConnectionRequest:
         with patch("cqc_lem.utilities.db.get_connection_request", return_value=self._req()), \
              patch("cqc_lem.utilities.db.count_invites_sent_today", return_value=0), \
              patch(f"{_RA}.get_engagement_preferences", return_value={"max_invites_per_day": 10}), \
-             patch(f"{_RA}.invite_to_connect_now", return_value=(False, "Failed to find more or connect button")), \
+             patch(f"{_RA}.invite_to_connect_now", return_value=(False, NO_CONNECT_BUTTON_MESSAGE)), \
              patch("cqc_lem.utilities.db.update_connection_request_status") as upd:
             ra.send_connection_request(3)
         from cqc_lem.utilities.db import ConnectionRequestStatus
         upd.assert_called_once_with(3, ConnectionRequestStatus.FAILED,
-                                   failure_reason="Failed to find more or connect button")
+                                   failure_reason=NO_CONNECT_BUTTON_MESSAGE)
 
     def test_defers_when_cap_reached(self):
         from cqc_lem.app import run_automation as ra

--- a/tests/unit/app/test_invite_connect_affordance.py
+++ b/tests/unit/app/test_invite_connect_affordance.py
@@ -1,0 +1,98 @@
+"""The Connect-affordance hunt on the invite send path (issue #571).
+
+`Failed to find more or connect button` paged the error cron for what is an ordinary outcome — a
+profile with no Connect option at all (invite already pending, Follow/Message-only, selector drift).
+Worse, the old code carried on into the note/send steps with no Connect dialog open, so the real
+reason was overwritten by a second, misleading error. These cover both halves.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+_INVITE_XPATH = '//main//button[contains(@aria-label, "Invite ")]'
+_MORE_XPATH = '//main//button[contains(@aria-label,"More actions")]'
+_MENU_CONNECT_XPATH = '//main//div[contains(@aria-label,"connect")]'
+
+
+def _clicker(found: set[str]):
+    """A click_element_wait_retry stand-in that only 'finds' the xpaths in `found`."""
+
+    def click(driver, wait, xpath, label, **kwargs):
+        if xpath in found:
+            return MagicMock()
+        raise Exception(f"no element for {xpath}")
+
+    return MagicMock(side_effect=click)
+
+
+def _invite(found: set[str], message: str = None):
+    from cqc_lem.app import run_automation as ra
+    click = _clicker(found)
+    with patch(f"{_RA}.get_user_password_pair_by_id", return_value=("e@x", "pw")), \
+         patch(f"{_RA}.get_driver_wait_pair", return_value=(MagicMock(), MagicMock())), \
+         patch(f"{_RA}.login_to_linkedin"), \
+         patch(f"{_RA}._profile_is_first_degree", return_value=False), \
+         patch(f"{_RA}.click_element_wait_retry", click), \
+         patch(f"{_RA}.log_error") as log_error, \
+         patch(f"{_RA}.log_warning") as log_warning, \
+         patch(f"{_RA}.insert_new_log") as insert_log, \
+         patch(f"{_RA}.record_action"), \
+         patch(f"{_RA}.quit_gracefully"):
+        sent, reason = ra.invite_to_connect_now(1, "https://x/in/jane", message)
+    return sent, reason, click, insert_log, log_error, log_warning
+
+
+def _clicked(click) -> list[str]:
+    return [call.args[2] for call in click.call_args_list]
+
+
+class TestNoConnectAffordance:
+    def test_a_profile_with_no_connect_option_stops_with_a_named_reason(self):
+        from cqc_lem.utilities.db import NO_CONNECT_BUTTON_MESSAGE
+        sent, reason, _click, insert_log, _err, _warn = _invite(found=set())
+        assert sent is False and reason == NO_CONNECT_BUTTON_MESSAGE
+        insert_log.assert_called_once()
+        assert insert_log.call_args.kwargs["message"] == NO_CONNECT_BUTTON_MESSAGE
+
+    def test_it_never_attempts_the_note_or_send_steps(self):
+        # With no Connect dialog open those can only fail, and their errors buried the real reason.
+        _sent, _reason, click, _log, _err, _warn = _invite(found=set(), message="hi jane")
+        attempted = _clicked(click)
+        assert attempted == [_INVITE_XPATH, _MORE_XPATH]
+
+    def test_the_miss_is_a_warning_not_an_error(self):
+        # It is an expected outcome and it degrades gracefully — it must not page the error cron.
+        _sent, _reason, _click, _log, log_error, log_warning = _invite(found=set())
+        log_error.assert_not_called()
+        log_warning.assert_called_once()
+        assert log_warning.call_args.kwargs["user_id"] == 1
+
+
+class TestConnectAffordanceStillWorks:
+    def test_the_direct_connect_button_sends_without_a_note(self):
+        from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
+        send_xpath = '//button[contains(@aria-label,"Send without a note")]'
+        sent, reason, click, _log, log_error, _warn = _invite(found={_INVITE_XPATH, send_xpath})
+        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
+        assert _MORE_XPATH not in _clicked(click)  # the overflow is only a fallback
+        log_error.assert_not_called()
+
+    def test_the_more_menu_is_the_fallback_when_the_direct_button_is_absent(self):
+        from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
+        send_xpath = '//button[contains(@aria-label,"Send without a note")]'
+        sent, reason, click, _log, _err, log_warning = _invite(
+            found={_MORE_XPATH, _MENU_CONNECT_XPATH, send_xpath})
+        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
+        assert _clicked(click)[:3] == [_INVITE_XPATH, _MORE_XPATH, _MENU_CONNECT_XPATH]
+        log_warning.assert_not_called()
+
+    def test_a_more_menu_without_a_connect_item_is_still_a_miss(self):
+        from cqc_lem.utilities.db import NO_CONNECT_BUTTON_MESSAGE
+        sent, reason, _click, _log, log_error, _warn = _invite(found={_MORE_XPATH})
+        assert sent is False and reason == NO_CONNECT_BUTTON_MESSAGE
+        log_error.assert_not_called()


### PR DESCRIPTION
## What & why

PostHog filed `Failed to find more or connect button` as an error. It is not one — it is an ordinary outcome of the invite send path: the profile offered **no Connect affordance at all** (an invite is already pending, LinkedIn only shows Follow/Message on that profile, or the SDUI selector drifted). It already degrades gracefully — `invite_to_connect_now` returns `(False, reason)`, `send_connection_request` stores that reason on the `connection_requests` row and log_warnings it — so per the issue's own triage guidance it is now a `log_warning`.

**The real defect the error was hiding.** After the miss, the flow fell through into the "Add a note" / "Send without a note" steps *with no Connect dialog open*. Those can only fail, and their own `log_error` overwrote `result` — so a profile with no Connect option was recorded (and shown in the Connections review UI) as an *add-a-note* failure, and every such invite produced two error events instead of one honest one.

## Changes

- New `_click_connect_affordance(driver, wait, user_id)` — the direct `Invite ` button first, the More-actions overflow as the fallback (same two selectors as before, unchanged). A miss is one `log_warning` and `False`.
- A miss now **stops the invite** with a named reason (`NO_CONNECT_BUTTON_MESSAGE`, added beside `ALREADY_CONNECTED_MESSAGE` in `db.py`) and one `ENGAGED`/`FAILURE` log row — mirroring the #623 1st-degree early exit — instead of cascading into the note/send steps.
- No selector, cadence, cap or rate-limit behaviour changed; `LinkedInRateLimited` still propagates from login as before.

## Testing

- New `tests/unit/app/test_invite_connect_affordance.py` (6 tests): no-affordance → named reason + one log row; note/send steps never attempted after a miss; warning-not-error; direct button still sends; the More menu is still the fallback; a More menu without a Connect item is still a miss.
- `tests/unit/app/test_connection_requests.py` updated to the new failure-reason constant.
- `poetry run pytest tests/unit -q` → **7441 passed** locally.

Closes #571

🤖 Generated with [Claude Code](https://claude.com/claude-code)