### PR TITLE
fix(automation): make the connection-request note best-effort (closes #573)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -31,6 +31,7 @@ from cqc_lem.utilities.ai.content_alignment import humanize_text, split_link_for
 from cqc_lem.utilities.date import convert_viewed_on_to_date
 from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, insert_new_log, LogActionType, \
     CONNECTION_REQUEST_SENT_MESSAGE, ALREADY_CONNECTED_MESSAGE, NO_CONNECT_BUTTON_MESSAGE, \
+    INVITE_NOT_SENT_MESSAGE, CONNECT_NOTE_MAX_CHARS, \
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
     get_newsletter_settings, mark_newsletter_published, record_newsletter_subscriber_stat, \
     get_newsletter_edition, mark_edition_published, mark_edition_failed, \
@@ -4963,6 +4964,62 @@ def _click_connect_affordance(driver, wait, user_id: int) -> bool:
         return False
 
 
+def _add_connect_note(driver, wait, message: str, user_id: int) -> bool:
+    """Type a personalized note into an OPEN Connect dialog. Best-effort by design (issue #573):
+    LinkedIn hides the note affordance once a free account's personalized-invite quota is spent, and
+    a note that can't be attached must not cost us the invite — the caller sends it bare instead. So
+    every miss here is a WARNING, and the note is stripped of non-BMP characters first because
+    ChromeDriver's send_keys raises on the emoji an AI-written note routinely carries."""
+    try:
+        click_element_wait_retry(driver, wait, '//button[contains(@aria-label,"Add a note")]',
+                                 "Finding Add a Note Button", max_retry=1, use_action_chain=True)
+
+        message_box = click_element_wait_retry(driver, wait, '//textarea[@id="custom-message"]',
+                                               "Finding Message Box", max_retry=1, use_action_chain=True)
+        message_box.clear()
+
+        for _ in range(3):
+            if len(message) > CONNECT_NOTE_MAX_CHARS:
+                message = get_ai_message_refinement(message, CONNECT_NOTE_MAX_CHARS)
+            else:
+                break
+
+        message_box.send_keys(_strip_non_bmp(message)[:CONNECT_NOTE_MAX_CHARS])
+
+        # The Send button only enables once the textarea has registered input.
+        time.sleep(2)
+        myprint("Added note to the connection request")
+        return True
+    except Exception as e:
+        log_warning("Could not attach a note to the connection request; sending it without one",
+                    exc=e, user_id=user_id, action_type="invite_connect")
+        return False
+
+
+# The Send button's aria-label differs between the bare dialog and the one carrying a note, and a
+# note attempt can leave the dialog in either state — so both are tried, preferred label first.
+_SEND_INVITE_XPATHS = ('//button[contains(@aria-label,"Send invitation")]',
+                       '//button[contains(@aria-label,"Send without a note")]')
+
+
+def _submit_connect_invite(driver, wait, user_id: int, with_note: bool) -> bool:
+    """Click Send on the open Connect dialog. False only when NEITHER Send affordance is clickable,
+    which loses the invite outright — that one stays an error (issue #573)."""
+    xpaths = _SEND_INVITE_XPATHS if with_note else tuple(reversed(_SEND_INVITE_XPATHS))
+    for xpath in xpaths:
+        try:
+            click_element_wait_retry(driver, wait, xpath, "Finding Send Connection Button",
+                                     max_retry=1, use_action_chain=True)
+            myprint("Found Send Connection Button and clicked it")
+            return True
+        except Exception:
+            continue  # wrong label for this dialog state — try the other one
+
+    log_error("Failed to send the connection request (no Send button on the open Connect dialog)",
+              user_id=user_id, action_type="invite_connect")
+    return False
+
+
 def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -> "tuple[bool, str]":
     """Core connect-invite send: open the profile, click Connect (+ optional note), log the result.
     Returns (sent, result_message) — the message is the failure reason when `sent` is False, which
@@ -5005,65 +5062,13 @@ def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -
                            message=NO_CONNECT_BUTTON_MESSAGE)
             return False, NO_CONNECT_BUTTON_MESSAGE
 
-        # If connection_message exist click the With note button
-        if message:
-            try:
-                click_element_wait_retry(driver, wait, '//button[contains(@aria-label,"Add a note")]',
-                                         "Finding Add a Note Button", use_action_chain=True)
+        # The note is an optional extra on an invite we already decided to send — a missing note
+        # affordance must not abandon an open Connect dialog, so the invite goes out bare (#573).
+        noted = bool(message) and _add_connect_note(driver, wait, message, user_id)
 
-                myprint("Found Add a Note Button and clicked it")
-
-                # Find the message box
-                message_box = click_element_wait_retry(driver, wait, '//textarea[@id="custom-message"]',
-                                                       "Finding Message Box", use_action_chain=True)
-
-                myprint("Found Message and clicked it")
-
-                # Clear the message box
-                message_box.clear()
-
-                myprint("Cleared the message box")
-
-                # Message must be less than 300 characters. Try 3 times to get a revised message under that limit
-                for i in range(3):
-                    # Check Message character length
-                    if len(message) > 300:
-                        message = get_ai_message_refinement(message, 300)
-                    else:
-                        break
-
-                # Put the text in the message box
-                message_box.send_keys(message)
-
-                myprint("Added message to message box")
-
-                # Sleep so send button can become active
-                time.sleep(2)
-
-                myprint("Waited for send button to activate")
-
-                # Click the send button
-                click_element_wait_retry(driver, wait,
-                                         '//button[contains(@aria-label,"Send invitation")]',
-                                         "Finding Send Connection Button", use_action_chain=True)
-
-                myprint("Found Send Connection Button and clicked it")
-                result = CONNECTION_REQUEST_SENT_MESSAGE
-            except Exception as e:
-                log_error("Failed to add a note to connection request", exc=e, user_id=user_id, action_type="invite_connect")
-                result = f"Failed to Add a note. Error: {str(e)}"
-        else:
-            # Else click send connection
-            try:
-                click_element_wait_retry(driver, wait,
-                                         '//button[contains(@aria-label,"Send without a note")]',
-                                         "Finding Send Without Note Button", use_action_chain=True)
-
-                myprint("Found Send Without a Note Button and clicked it")
-                result = CONNECTION_REQUEST_SENT_MESSAGE
-            except Exception as e:
-                log_error("Failed to find send-without-note connection button", exc=e, user_id=user_id, action_type="invite_connect")
-                result = f"Failed to find send without a note connection button. Error: {str(e)}"
+        result = (CONNECTION_REQUEST_SENT_MESSAGE
+                  if _submit_connect_invite(driver, wait, user_id, with_note=noted)
+                  else INVITE_NOT_SENT_MESSAGE)
     except LinkedInRateLimited:
         # Kill-switch / 429 breaker is open — let the caller defer instead of logging a false failure.
         raise

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -5006,17 +5006,21 @@ def _submit_connect_invite(driver, wait, user_id: int, with_note: bool) -> bool:
     """Click Send on the open Connect dialog. False only when NEITHER Send affordance is clickable,
     which loses the invite outright — that one stays an error (issue #573)."""
     xpaths = _SEND_INVITE_XPATHS if with_note else tuple(reversed(_SEND_INVITE_XPATHS))
+    last_error: Exception = None
     for xpath in xpaths:
         try:
             click_element_wait_retry(driver, wait, xpath, "Finding Send Connection Button",
                                      max_retry=1, use_action_chain=True)
             myprint("Found Send Connection Button and clicked it")
             return True
-        except Exception:
-            continue  # wrong label for this dialog state — try the other one
+        except Exception as e:
+            last_error = e  # wrong label for this dialog state — try the other one
 
+    # exc= is what turns this into a fingerprinted PostHog issue (the loop that filed #573); an
+    # exc-less log_error only reaches Logs, so the one failure we deliberately keep as an error
+    # would never page anyone.
     log_error("Failed to send the connection request (no Send button on the open Connect dialog)",
-              user_id=user_id, action_type="invite_connect")
+              exc=last_error, user_id=user_id, action_type="invite_connect")
     return False
 
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -384,6 +384,15 @@ ALREADY_CONNECTED_MESSAGE = "Already connected (1st-degree) — no invite to sen
 # rather than falling through to the note/send steps that can only fail after it.
 NO_CONNECT_BUTTON_MESSAGE = "No Connect option on this profile (invite may already be pending)"
 
+# The Connect dialog opened but neither Send affordance could be clicked, so nothing went out
+# (issue #573). Unlike a missing note this does NOT degrade gracefully — the invite is lost — which
+# is why it stays an error and gets its own reason on the request row.
+INVITE_NOT_SENT_MESSAGE = "Connect dialog opened but the invitation could not be sent"
+
+# LinkedIn's hard cap on a connection-request note. Also the point past which a drafted note is
+# refined down rather than typed and silently truncated by the textarea's own maxlength.
+CONNECT_NOTE_MAX_CHARS = 300
+
 
 def store_cookies(user_email: str, cookies: list[dict]) -> None:
     connection = get_db_connection()

--- a/tests/unit/app/test_invite_connect_note.py
+++ b/tests/unit/app/test_invite_connect_note.py
@@ -1,0 +1,132 @@
+"""The note half of the invite send path (issue #573).
+
+`Failed to add a note to connection request` paged the error cron, and behind that error the whole
+invite was abandoned with the Connect dialog already open — LinkedIn hides the note affordance once
+a free account's personalized-invite quota is spent, and an AI-written note routinely carries emoji
+that ChromeDriver's send_keys refuses to type. Both now degrade to a bare invite; only a dialog with
+no Send button at all is still an error.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+_INVITE_XPATH = '//main//button[contains(@aria-label, "Invite ")]'
+_NOTE_XPATH = '//button[contains(@aria-label,"Add a note")]'
+_TEXTAREA_XPATH = '//textarea[@id="custom-message"]'
+_SEND_XPATH = '//button[contains(@aria-label,"Send invitation")]'
+_SEND_BARE_XPATH = '//button[contains(@aria-label,"Send without a note")]'
+
+_NOTE_DIALOG = {_INVITE_XPATH, _NOTE_XPATH, _TEXTAREA_XPATH, _SEND_XPATH}
+
+
+def _clicker(found: set[str], box: MagicMock = None):
+    """A click_element_wait_retry stand-in that only 'finds' the xpaths in `found`."""
+
+    def click(driver, wait, xpath, label, **kwargs):
+        if xpath not in found:
+            raise Exception(f"no element for {xpath}")
+        return box if (box is not None and xpath == _TEXTAREA_XPATH) else MagicMock()
+
+    return MagicMock(side_effect=click)
+
+
+def _invite(found: set[str], message: str = None, box: MagicMock = None, refined: str = "short note"):
+    from cqc_lem.app import run_automation as ra
+    click = _clicker(found, box)
+    with patch(f"{_RA}.get_user_password_pair_by_id", return_value=("e@x", "pw")), \
+         patch(f"{_RA}.get_driver_wait_pair", return_value=(MagicMock(), MagicMock())), \
+         patch(f"{_RA}.login_to_linkedin"), \
+         patch(f"{_RA}._profile_is_first_degree", return_value=False), \
+         patch(f"{_RA}.click_element_wait_retry", click), \
+         patch(f"{_RA}.get_ai_message_refinement", return_value=refined) as refine, \
+         patch(f"{_RA}.time.sleep"), \
+         patch(f"{_RA}.log_error") as log_error, \
+         patch(f"{_RA}.log_warning") as log_warning, \
+         patch(f"{_RA}.insert_new_log") as insert_log, \
+         patch(f"{_RA}.record_action") as record_action, \
+         patch(f"{_RA}.quit_gracefully"):
+        sent, reason = ra.invite_to_connect_now(1, "https://x/in/jane", message)
+    return sent, reason, click, insert_log, log_error, log_warning, refine, record_action
+
+
+def _clicked(click) -> list[str]:
+    return [call.args[2] for call in click.call_args_list]
+
+
+class TestNoteIsBestEffort:
+    def test_a_missing_note_affordance_still_sends_the_invite(self):
+        from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
+        # LinkedIn offers only the bare dialog once the personalized-invite quota is spent.
+        sent, reason, click, insert_log, log_error, log_warning, _r, record = _invite(
+            found={_INVITE_XPATH, _SEND_BARE_XPATH}, message="hi jane")
+        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
+        assert _SEND_BARE_XPATH in _clicked(click)
+        assert insert_log.call_args.kwargs["message"] == CONNECTION_REQUEST_SENT_MESSAGE
+        record.assert_called_once()  # a bare invite still spends the account-level budget
+        log_error.assert_not_called()
+        log_warning.assert_called_once()
+
+    def test_a_note_that_cannot_be_typed_still_sends_the_invite(self):
+        from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
+        box = MagicMock()
+        box.send_keys.side_effect = Exception("ChromeDriver only supports characters in the BMP")
+        sent, reason, _click, _log, log_error, log_warning, _r, _rec = _invite(
+            found=_NOTE_DIALOG | {_SEND_BARE_XPATH}, message="hi jane", box=box)
+        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
+        log_error.assert_not_called()
+        log_warning.assert_called_once()
+
+    def test_the_note_is_stripped_of_non_bmp_characters_before_typing(self):
+        box = MagicMock()
+        _sent, _reason, _click, _log, _err, _warn, _r, _rec = _invite(
+            found=_NOTE_DIALOG, message="hi jane \U0001F600", box=box)
+        typed = box.send_keys.call_args.args[0]
+        assert "\U0001F600" not in typed and typed.startswith("hi jane")
+
+    def test_an_over_long_note_is_refined_and_capped(self):
+        from cqc_lem.utilities.db import CONNECT_NOTE_MAX_CHARS
+        box = MagicMock()
+        _sent, _reason, _click, _log, _err, _warn, refine, _rec = _invite(
+            found=_NOTE_DIALOG, message="x" * 400, box=box, refined="y" * 500)
+        assert refine.call_args.args[1] == CONNECT_NOTE_MAX_CHARS
+        # Refinement can come back long; the textarea's own maxlength would truncate it silently.
+        assert len(box.send_keys.call_args.args[0]) == CONNECT_NOTE_MAX_CHARS
+
+
+class TestNoteHappyPath:
+    def test_a_note_is_typed_and_the_invite_sent(self):
+        from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
+        box = MagicMock()
+        sent, reason, click, _log, log_error, log_warning, refine, _rec = _invite(
+            found=_NOTE_DIALOG, message="hi jane", box=box)
+        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
+        assert _clicked(click) == [_INVITE_XPATH, _NOTE_XPATH, _TEXTAREA_XPATH, _SEND_XPATH]
+        box.clear.assert_called_once()
+        box.send_keys.assert_called_once_with("hi jane")
+        refine.assert_not_called()  # already under the limit
+        log_error.assert_not_called()
+        log_warning.assert_not_called()
+
+    def test_an_invite_with_no_note_never_opens_the_note_composer(self):
+        _sent, _reason, click, _log, _err, _warn, _r, _rec = _invite(
+            found={_INVITE_XPATH, _SEND_BARE_XPATH})
+        assert _clicked(click) == [_INVITE_XPATH, _SEND_BARE_XPATH]
+
+
+class TestSendFailureIsStillAnError:
+    def test_a_dialog_with_no_send_button_reports_a_named_failure(self):
+        from cqc_lem.utilities.db import INVITE_NOT_SENT_MESSAGE
+        box = MagicMock()
+        sent, reason, click, insert_log, log_error, _warn, _r, record = _invite(
+            found=_NOTE_DIALOG - {_SEND_XPATH}, message="hi jane", box=box)
+        assert sent is False and reason == INVITE_NOT_SENT_MESSAGE
+        assert insert_log.call_args.kwargs["message"] == INVITE_NOT_SENT_MESSAGE
+        record.assert_not_called()  # nothing was sent, so nothing is spent
+        # Both Send labels are tried before giving up — the dialog can be in either state.
+        assert _clicked(click)[-2:] == [_SEND_XPATH, _SEND_BARE_XPATH]
+        log_error.assert_called_once()

--- a/tests/unit/app/test_invite_connect_note.py
+++ b/tests/unit/app/test_invite_connect_note.py
@@ -130,3 +130,5 @@ class TestSendFailureIsStillAnError:
         # Both Send labels are tried before giving up — the dialog can be in either state.
         assert _clicked(click)[-2:] == [_SEND_XPATH, _SEND_BARE_XPATH]
         log_error.assert_called_once()
+        # exc= is what makes it a fingerprinted PostHog issue rather than a log line nobody reads.
+        assert isinstance(log_error.call_args.kwargs.get("exc"), Exception)


### PR DESCRIPTION
## What & why

`Failed to add a note to connection request` (issue #573) was a `log_error` on a path that did **not** degrade gracefully. Every step of the note branch — the "Add a note" button, the `#custom-message` textarea, typing, and the Send click — sat inside one `try`, and any miss abandoned an **already open** Connect dialog. The invite was never sent, the run recorded an ENGAGED/FAILURE row, and a plain send-without-note (which was right there) would have worked.

Two concrete causes behind the filed occurrence:

- LinkedIn hides the note affordance once a free account's personalized-invite quota is spent — the dialog then offers only "Send without a note".
- The note was typed **raw**. ChromeDriver's `send_keys` raises `WebDriverException` on non-BMP characters (the documented emoji gotcha), and an AI-drafted connection note routinely carries one. Every other composer in `run_automation.py` already goes through `_strip_non_bmp`; this one didn't.

## The change

- **`_add_connect_note`** — attaches the note to an open dialog. Strips non-BMP characters, refines an over-long note down to `CONNECT_NOTE_MAX_CHARS` (300, now a named constant instead of a repeated literal) and hard-caps it, and returns `False` on any miss with a **`log_warning`** — the invite still goes out, bare. That is the fix for the paging error: it now genuinely degrades.
- **`_submit_connect_invite`** — clicks Send, trying **both** aria-labels (`Send invitation` / `Send without a note`), preferred one first, because a partial note attempt can leave the dialog in either state. Failing *both* loses the invite outright, so that stays a `log_error` and reports the new `INVITE_NOT_SENT_MESSAGE` — which `send_connection_request` (#398) stores as the request's `failure_reason` instead of the old raw-exception f-string.
- `invite_to_connect_now` drops to three lines for the send: note (optional) → submit → result.

Behaviour note for review: an approved proactive request (#398) whose note can't be attached is now **sent without the note** rather than failed. It's still the invite the human approved, it still counts against the daily invite budget (`record_action` / `count_invites_sent_today` both key off `CONNECTION_REQUEST_SENT_MESSAGE`), and the dropped note is a WARNING in the logs.

## Testing

New `tests/unit/app/test_invite_connect_note.py` (7 cases): missing note affordance still sends; a `send_keys` BMP failure still sends; non-BMP stripped before typing; over-long note refined + capped; happy path types the note and clicks the right Send; a no-note invite never opens the composer; a dialog with no Send button at all reports `INVITE_NOT_SENT_MESSAGE`, spends no budget, tries both labels, and logs an error.

`poetry run pytest tests/unit -q` → **7457 passed**.

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
