### PR TITLE
fix(feedback): attach labels/assignees after issue creation (closes #598)

### DIFF
--- a/src/cqc_lem/utilities/feedback/issue_service.py
+++ b/src/cqc_lem/utilities/feedback/issue_service.py
@@ -513,16 +513,29 @@ def github_request(method: str, path: str, payload: dict = None) -> Optional[obj
 
 def create_github_issue(title: str, body: str, labels: list,
                         assignees: list = None) -> Optional[int]:
-    """Open an issue; returns its number or None."""
-    payload = {"title": title, "body": body, "labels": list(labels or [])}
-    if assignees:
-        payload["assignees"] = list(assignees)
-    data = github_request("POST", "issues", payload)
+    """Open an issue; returns its number or None.
+
+    Labels and assignees are attached in SEPARATE calls after creation (issue #598): GitHub
+    silently drops both when a fine-grained PAT supplies them in the create payload, so every
+    auto-filed issue landed label-less and the pipeline never picked it up. A failed attach is a
+    warning, never a lost issue — the row is already on GitHub by then."""
+    data = github_request("POST", "issues", {"title": title, "body": body})
     number = data.get("number") if isinstance(data, dict) else None
     if number is None:
         return None
+    number = int(number)
+    label_list = [str(label) for label in (labels or [])]
+    if label_list and github_request("POST", f"issues/{number}/labels",
+                                     {"labels": label_list}) is None:
+        log_warning(f"Auto-filed issue #{number} could not be labeled {label_list}",
+                    api_provider="github")
+    assignee_list = [str(assignee) for assignee in (assignees or [])]
+    if assignee_list and github_request("POST", f"issues/{number}/assignees",
+                                        {"assignees": assignee_list}) is None:
+        log_warning(f"Auto-filed issue #{number} could not be assigned to {assignee_list}",
+                    api_provider="github")
     log_info(f"Auto-filed feedback issue #{number}: {title}", api_provider="github")
-    return int(number)
+    return number
 
 
 def comment_on_issue(issue_number: int, body: str) -> bool:

--- a/tests/unit/utilities/test_feedback_issue_service.py
+++ b/tests/unit/utilities/test_feedback_issue_service.py
@@ -456,23 +456,52 @@ class TestGithubIO:
         response.json.return_value = payload if payload is not None else {}
         return response
 
-    def test_create_issue_posts_title_body_labels_and_returns_the_number(self, monkeypatch):
+    def test_create_issue_attaches_labels_and_assignees_after_creation(self, monkeypatch):
+        # Issue #598: a fine-grained PAT silently drops labels/assignees sent in the create
+        # payload, so they MUST ride on their own endpoints afterwards.
         svc = _mod()
         monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
         monkeypatch.setenv("FEEDBACK_GITHUB_REPO", "o/r")
         requests = MagicMock()
-        requests.request.return_value = self._response(201, {"number": 777})
+        requests.request.side_effect = [self._response(201, {"number": 777}),
+                                        self._response(200, [{"name": "bug"}]),
+                                        self._response(201, {"number": 777})]
         with patch.dict("sys.modules", {"requests": requests}):
-            got = svc.create_github_issue("t", "b", ["bug"], assignees=["gitchrisqueen"])
+            got = svc.create_github_issue("t", "b", ["bug", "agent:ready"],
+                                          assignees=["gitchrisqueen"])
         assert got == 777
-        method, url = requests.request.call_args[0]
-        assert method == "POST"
-        assert url == "https://api.github.com/repos/o/r/issues"
-        payload = requests.request.call_args.kwargs["json"]
-        assert payload == {"title": "t", "body": "b", "labels": ["bug"],
-                           "assignees": ["gitchrisqueen"]}
-        headers = requests.request.call_args.kwargs["headers"]
-        assert headers["Authorization"] == "Bearer tok"
+        calls = requests.request.call_args_list
+        assert [c[0] for c in calls] == [
+            ("POST", "https://api.github.com/repos/o/r/issues"),
+            ("POST", "https://api.github.com/repos/o/r/issues/777/labels"),
+            ("POST", "https://api.github.com/repos/o/r/issues/777/assignees")]
+        assert calls[0].kwargs["json"] == {"title": "t", "body": "b"}
+        assert calls[1].kwargs["json"] == {"labels": ["bug", "agent:ready"]}
+        assert calls[2].kwargs["json"] == {"assignees": ["gitchrisqueen"]}
+        assert calls[0].kwargs["headers"]["Authorization"] == "Bearer tok"
+
+    def test_create_issue_skips_the_attach_calls_when_there_is_nothing_to_attach(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        monkeypatch.setenv("FEEDBACK_GITHUB_REPO", "o/r")
+        requests = MagicMock()
+        requests.request.return_value = self._response(201, {"number": 12})
+        with patch.dict("sys.modules", {"requests": requests}):
+            assert svc.create_github_issue("t", "b", [], assignees=None) == 12
+        assert requests.request.call_count == 1
+
+    def test_failed_label_attach_still_returns_the_issue(self, monkeypatch):
+        # The issue is already on GitHub — losing its number would strand the feedback row.
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        monkeypatch.setenv("FEEDBACK_GITHUB_REPO", "o/r")
+        requests = MagicMock()
+        requests.request.side_effect = [self._response(201, {"number": 31}),
+                                        self._response(403, {"message": "forbidden"}),
+                                        self._response(403, {"message": "forbidden"})]
+        with patch.dict("sys.modules", {"requests": requests}):
+            assert svc.create_github_issue("t", "b", ["bug"], assignees=["gitchrisqueen"]) == 31
+        assert requests.request.call_count == 3
 
     def test_no_token_files_nothing(self, monkeypatch):
         svc = _mod()


### PR DESCRIPTION
## What

`create_github_issue()` sent `labels` (and `assignees`) inside the **issue-creation payload**. GitHub silently drops both when the caller authenticates with a **fine-grained PAT** — which `FEEDBACK_GITHUB_TOKEN` is. The issue is created, no error is returned, and it lands with **zero labels**.

Consequence: every auto-filed feedback issue was invisible to the pipeline (no `agent:ready`, no `feedback-loop`, no category/severity) — the feedback→auto-work loop was effectively non-functional. #596 was hand-labeled as a stopgap.

## Why this fix

`POST /issues/{n}/labels` and `POST /issues/{n}/assignees` honour a fine-grained PAT's `Issues: write` reliably, so labels/assignees are attached in separate calls right after creation. `labels_for_issue()` was already correct and every target label exists in the repo — they just never attached.

The attach calls are **tolerant**: a failure logs a warning via `log_warning` and `create_github_issue` still returns the number. The issue is already on GitHub at that point, and returning `None` would strand the feedback row (it would be re-filed on the next pass as a duplicate).

All three callers benefit from the one-place fix — `file_feedback_issue` (feedback loop), `faq_service` (FAQ issues), and `capacity_alerts`. The `risk:security` path noted in the issue is covered too: that path is exactly the `needs-human` + owner-assignee case, which now goes through the working `/assignees` endpoint.

## Testing

`tests/unit/utilities/test_feedback_issue_service.py`:
- `test_create_issue_attaches_labels_and_assignees_after_creation` — asserts the exact three-call sequence (create with `{title, body}` only, then `/issues/777/labels`, then `/issues/777/assignees`) with the right payload on each.
- `test_create_issue_skips_the_attach_calls_when_there_is_nothing_to_attach` — no labels/assignees means exactly one call.
- `test_failed_label_attach_still_returns_the_issue` — a 403 on both attach calls still yields the issue number.

`poetry run pytest tests/unit/utilities/test_feedback_issue_service.py tests/unit/utilities/test_feedback_faq_service.py tests/unit/utilities/test_capacity_alerts.py -q` → **289 passed**.

Post-deploy acceptance (the issue's second criterion) is observable on the next auto-filed feedback issue: it should carry `feedback-loop` + `agent:ready` plus its category/severity labels.

Closes #598

🤖 Generated with [Claude Code](https://claude.com/claude-code)