### PR TITLE
fix(feedback): reject unknown triage statuses before the ENUM write (closes #668)

### DIFF
--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -7950,7 +7950,8 @@ def count_feedback_filed_by_user(user_id: int, hours: int = 24) -> int:
         connection.close()
 
 
-def update_feedback_triage(feedback_id: int, status: "FeedbackStatus" = None,
+def update_feedback_triage(feedback_id: int,
+                           status: Optional[Union["FeedbackStatus", str]] = None,
                            cluster_id: int = None, github_issue_number: int = None,
                            embedding: list = None, sentiment: str = None) -> bool:
     """Stamp the auto-triage result back onto a feedback row (issue #498). Only the arguments you
@@ -7965,10 +7966,12 @@ def update_feedback_triage(feedback_id: int, status: "FeedbackStatus" = None,
     if status is not None:
         try:
             status = FeedbackStatus(str(status).strip().lower())
-        except ValueError:
+        except ValueError as err:
+            # exc= is what turns this into a grouped PostHog $exception (issue #648) — the 1265 it
+            # replaces was one, so without it the refusal would page nobody and only land in Logs.
             log_error(f"Refusing to write unknown feedback status {str(status)!r} for feedback "
                       f"{feedback_id} — expected one of "
-                      f"{', '.join(s.value for s in FeedbackStatus)}")
+                      f"{', '.join(s.value for s in FeedbackStatus)}", exc=err)
             return False
         updates.append("status=%s")
         params.append(str(status))

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -7955,10 +7955,21 @@ def update_feedback_triage(feedback_id: int, status: "FeedbackStatus" = None,
                            embedding: list = None, sentiment: str = None) -> bool:
     """Stamp the auto-triage result back onto a feedback row (issue #498). Only the arguments you
     pass are written, so the filer can save an embedding on one pass and the cluster/issue on the
-    next without clobbering anything."""
+    next without clobbering anything.
+
+    `status` is checked against `FeedbackStatus` BEFORE the write (issue #668): the column is a
+    MySQL ENUM, so an out-of-vocabulary value used to surface as an opaque `1265 Data truncated for
+    column 'status'` AND roll back the cluster/issue/embedding travelling in the same UPDATE."""
     updates: list = []
     params: list = []
     if status is not None:
+        try:
+            status = FeedbackStatus(str(status).strip().lower())
+        except ValueError:
+            log_error(f"Refusing to write unknown feedback status {str(status)!r} for feedback "
+                      f"{feedback_id} — expected one of "
+                      f"{', '.join(s.value for s in FeedbackStatus)}")
+            return False
         updates.append("status=%s")
         params.append(str(status))
     if cluster_id is not None:
@@ -7983,7 +7994,9 @@ def update_feedback_triage(feedback_id: int, status: "FeedbackStatus" = None,
         connection.commit()
         return cursor.rowcount > 0
     except mysql.connector.Error as err:
-        log_error(f"Could not update feedback triage for {feedback_id}", exc=err)
+        columns = ", ".join(u.split("=")[0] for u in updates)
+        log_error(f"Could not update feedback triage for {feedback_id} (columns: {columns})",
+                  exc=err)
         return False
     finally:
         cursor.close()

--- a/tests/unit/api/test_feedback_api.py
+++ b/tests/unit/api/test_feedback_api.py
@@ -131,15 +131,25 @@ class TestFeedbackMigration:
     def test_status_enum_matches_the_feedback_status_vocabulary(self):
         # issue #668: a FeedbackStatus member with no matching ENUM value only fails in PRODUCTION,
         # as "1265 Data truncated for column 'status'" — never in a unit test. Catch it at build time.
+        # The vocabulary is the LAST declaration in version order, so widening the ENUM the only
+        # legal way — a new ALTER migration — satisfies this test. An already-merged migration must
+        # never be edited to appease it: Flyway validates applied ones by version+checksum.
         import glob
         import os
         import re
         from cqc_lem.utilities.db import FeedbackStatus
         root = os.path.join(os.path.dirname(__file__), "..", "..", "..",
                             "compose", "local", "database", "migrations")
-        with open(glob.glob(os.path.join(root, "V*__add_feedback.sql"))[0]) as f:
-            sql = f.read()
-        declared = re.search(r"status\s+ENUM\(([^)]*)\)", sql, re.IGNORECASE)
-        assert declared, "the add_feedback migration no longer declares status as an ENUM"
-        values = set(re.findall(r"'([^']*)'", declared.group(1)))
-        assert {s.value for s in FeedbackStatus} == values
+        declared = None
+        for path in sorted(glob.glob(os.path.join(root, "V*.sql"))):
+            with open(path) as f:
+                sql = f.read()
+            for statement in sql.split(";"):
+                if not re.search(r"TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?feedback`?\b",
+                                 statement, re.IGNORECASE):
+                    continue
+                match = re.search(r"\bstatus\s+ENUM\(([^)]*)\)", statement, re.IGNORECASE)
+                if match:
+                    declared = set(re.findall(r"'([^']*)'", match.group(1)))
+        assert declared, "no migration declares feedback.status as an ENUM"
+        assert {s.value for s in FeedbackStatus} == declared

--- a/tests/unit/api/test_feedback_api.py
+++ b/tests/unit/api/test_feedback_api.py
@@ -127,3 +127,19 @@ class TestFeedbackMigration:
         for col in ("user_id", "source", "type_hint", "body", "context_json", "embedding",
                     "cluster_id", "github_issue_number", "status", "sentiment", "created_at"):
             assert col in sql, f"missing column {col}"
+
+    def test_status_enum_matches_the_feedback_status_vocabulary(self):
+        # issue #668: a FeedbackStatus member with no matching ENUM value only fails in PRODUCTION,
+        # as "1265 Data truncated for column 'status'" — never in a unit test. Catch it at build time.
+        import glob
+        import os
+        import re
+        from cqc_lem.utilities.db import FeedbackStatus
+        root = os.path.join(os.path.dirname(__file__), "..", "..", "..",
+                            "compose", "local", "database", "migrations")
+        with open(glob.glob(os.path.join(root, "V*__add_feedback.sql"))[0]) as f:
+            sql = f.read()
+        declared = re.search(r"status\s+ENUM\(([^)]*)\)", sql, re.IGNORECASE)
+        assert declared, "the add_feedback migration no longer declares status as an ENUM"
+        values = set(re.findall(r"'([^']*)'", declared.group(1)))
+        assert {s.value for s in FeedbackStatus} == values

--- a/tests/unit/utilities/test_db_feedback.py
+++ b/tests/unit/utilities/test_db_feedback.py
@@ -260,8 +260,36 @@ class TestUpdateFeedbackTriage:
         import mysql.connector
         conn, cur = _dict_conn()
         cur.execute.side_effect = mysql.connector.Error("boom")
-        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.log_error") as log:
             from cqc_lem.utilities.db import update_feedback_triage, FeedbackStatus
             assert update_feedback_triage(3, status=FeedbackStatus.TRIAGED) is False
         cur.close.assert_called_once()
         conn.close.assert_called_once()
+        # The columns in flight are named, so the next 1265 says which ENUM rejected the value.
+        assert "status" in log.call_args[0][0]
+
+    def test_unknown_status_never_reaches_the_enum_column(self):
+        # issue #668: `feedback.status` is a MySQL ENUM — an out-of-vocabulary value used to blow up
+        # as an opaque "1265 Data truncated for column 'status'" and take the whole UPDATE with it.
+        with patch(f"{_DB}.get_db_connection") as get_conn, patch(f"{_DB}.log_error") as log:
+            from cqc_lem.utilities.db import update_feedback_triage
+            assert update_feedback_triage(1, status="pending", cluster_id=4) is False
+        get_conn.assert_not_called()
+        message = log.call_args[0][0]
+        assert "'pending'" in message and "issue_created" in message
+
+    def test_status_spelling_variants_are_accepted(self):
+        conn, cur = _dict_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_feedback_triage
+            assert update_feedback_triage(3, status=" Issue_Created ") is True
+        assert cur.execute.call_args[0][1] == ("issue_created", 3)
+
+    def test_every_feedback_status_member_is_writable(self):
+        from cqc_lem.utilities.db import update_feedback_triage, FeedbackStatus
+        for member in FeedbackStatus:
+            conn, cur = _dict_conn()
+            with patch(f"{_DB}.get_db_connection", return_value=conn):
+                assert update_feedback_triage(3, status=member) is True
+            assert cur.execute.call_args[0][1] == (member.value, 3)

--- a/tests/unit/utilities/test_db_feedback.py
+++ b/tests/unit/utilities/test_db_feedback.py
@@ -278,6 +278,9 @@ class TestUpdateFeedbackTriage:
         get_conn.assert_not_called()
         message = log.call_args[0][0]
         assert "'pending'" in message and "issue_created" in message
+        # exc= is what makes it a grouped PostHog $exception like the 1265 it replaces — a refusal
+        # logged without one would never reach error tracking or the issue filer.
+        assert isinstance(log.call_args.kwargs.get("exc"), ValueError)
 
     def test_status_spelling_variants_are_accepted(self):
         conn, cur = _dict_conn()


### PR DESCRIPTION
## What & why

The PostHog error-scan cron filed #668 for `Could not update feedback triage for 1` (2× on 2026-07-25). Pulling the captured stack trace out of PostHog Logs gives the real cause:

```
mysql.connector.errors.DatabaseError: 1265 (01000): Data truncated for column 'status' at row 1
  File "/app/src/cqc_lem/utilities/db.py", ... in update_feedback_triage
```

`feedback.status` is a MySQL ENUM (`new`/`triaged`/`clustered`/`issue_created`/`resolved`/`dismissed`), but `update_feedback_triage` accepted any `status` and pushed it through `str()` into the UPDATE. An out-of-vocabulary value therefore:

1. failed only at the database, as an opaque 1265 that names no value and no caller, and
2. took the **whole statement** down with it — a call that also carried `cluster_id`, `github_issue_number` or `embedding` lost all of them, leaving the row unstamped for the next pass to redo.

Both prod occurrences were isolated writes against row 1 with no surrounding task logs (the beat passes at `:00`/`:30` all succeeded, and the queue drained to `0 row(s)` right after — so the deployed ENUM does accept every `FeedbackStatus` member). The defect is that the function has no vocabulary check at all, so an ad-hoc or future caller passing a raw string turns into an unactionable production error.

## Changes

- `update_feedback_triage` coerces `status` through `FeedbackStatus` **before** opening a connection. Whitespace/case tolerant (`" Issue_Created "` → `issue_created`), so nothing that worked under MySQL's case-insensitive ENUM matching stops working.
- An unknown status is refused up front and logged by **name**, next to the allowed vocabulary — an actionable message instead of a truncation error. Still `log_error`: a caller passing a status that doesn't exist is a bug worth paging for.
- The `mysql.connector.Error` handler now names the columns that were in flight, so the next 1265 says which one rejected the value.
- Build-time guard: a unit test pins `FeedbackStatus` to the ENUM declared in `V20260725063146__add_feedback.sql`. Adding a member without a migration currently fails *only* in production, and only as this same 1265.

No migration and no schema change — the deployed ENUM is already correct.

## Testing

- `tests/unit/utilities/test_db_feedback.py` — unknown status never opens a connection and names the offending value; spelling variants normalize; every `FeedbackStatus` member round-trips to its ENUM value; the DB-error log names the columns.
- `tests/unit/api/test_feedback_api.py` — enum↔migration parity.
- `pytest tests/unit/utilities/test_db_feedback.py tests/unit/api/test_feedback_api.py` → 39 passed; the feedback/FAQ/survey service suites (268 tests) still pass.

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)
