### PR TITLE
feat(ops): scan Ollama Cloud retirements + new models before they bite (closes #716)

### DIFF
--- a/.litellm/ollama_catalog_snapshot.json
+++ b/.litellm/ollama_catalog_snapshot.json
@@ -1,0 +1,114 @@
+{
+  "_comment": "Committed snapshot of ollama.com/api/tags, refreshed by scripts/model_health_check.py --catalog-apply. New tags here vs the live catalog become ONE agent:ready evaluation issue; do not hand-edit.",
+  "updated": "2026-07-27",
+  "models": {
+    "deepseek-v4-flash": {
+      "modified_at": "2026-04-24T00:00:00Z",
+      "size": 140000000000,
+      "parameter_size": "",
+      "family": ""
+    },
+    "deepseek-v4-pro": {
+      "modified_at": "2026-04-24T00:00:00Z",
+      "size": 1600000000000,
+      "parameter_size": "",
+      "family": ""
+    },
+    "gemma4:31b": {
+      "modified_at": "2026-04-02T09:00:00-08:00",
+      "size": 62546177752,
+      "parameter_size": "",
+      "family": ""
+    },
+    "glm-5.1": {
+      "modified_at": "2026-04-07T08:00:00-07:00",
+      "size": 1507728316928,
+      "parameter_size": "",
+      "family": ""
+    },
+    "glm-5.2": {
+      "modified_at": "2026-06-16T08:00:00-07:00",
+      "size": 0,
+      "parameter_size": "",
+      "family": ""
+    },
+    "gpt-oss:120b": {
+      "modified_at": "2025-08-05T00:00:00Z",
+      "size": 65290180781,
+      "parameter_size": "",
+      "family": ""
+    },
+    "gpt-oss:20b": {
+      "modified_at": "2025-08-05T00:00:00Z",
+      "size": 13780162412,
+      "parameter_size": "",
+      "family": ""
+    },
+    "kimi-k2.5": {
+      "modified_at": "2026-01-26T00:00:00Z",
+      "size": 1118481408000,
+      "parameter_size": "",
+      "family": ""
+    },
+    "kimi-k2.6": {
+      "modified_at": "2026-03-31T00:00:00Z",
+      "size": 595148192736,
+      "parameter_size": "",
+      "family": ""
+    },
+    "kimi-k2.7-code": {
+      "modified_at": "2026-06-12T00:00:00Z",
+      "size": 595148192736,
+      "parameter_size": "",
+      "family": ""
+    },
+    "minimax-m2.5": {
+      "modified_at": "2026-02-12T00:00:00Z",
+      "size": 230000000000,
+      "parameter_size": "",
+      "family": ""
+    },
+    "minimax-m2.7": {
+      "modified_at": "2026-03-18T00:00:00Z",
+      "size": 480836588544,
+      "parameter_size": "",
+      "family": ""
+    },
+    "minimax-m3": {
+      "modified_at": "2026-06-01T00:00:00Z",
+      "size": 0,
+      "parameter_size": "",
+      "family": ""
+    },
+    "mistral-large-3:675b": {
+      "modified_at": "2025-12-02T00:00:00Z",
+      "size": 682000000000,
+      "parameter_size": "",
+      "family": ""
+    },
+    "nemotron-3-nano:30b": {
+      "modified_at": "2025-12-15T00:00:00Z",
+      "size": 32645090390,
+      "parameter_size": "",
+      "family": ""
+    },
+    "nemotron-3-super": {
+      "modified_at": "2026-03-11T00:00:00Z",
+      "size": 230500000000,
+      "parameter_size": "",
+      "family": ""
+    },
+    "nemotron-3-ultra": {
+      "modified_at": "2026-06-04T00:00:00Z",
+      "size": 0,
+      "parameter_size": "",
+      "family": ""
+    },
+    "qwen3.5:397b": {
+      "modified_at": "2026-02-16T00:00:00Z",
+      "size": 397000000000,
+      "parameter_size": "",
+      "family": ""
+    }
+  }
+}

--- a/scripts/model_health_check.py
+++ b/scripts/model_health_check.py
@@ -35,6 +35,9 @@ CLI:
   --catalog-apply        Write the planned map additions + snapshot refresh to --map / --snapshot.
   --file-issues          File (or append to) the GitHub issues the catalog scan planned.
 Options:
+  --plan-file PATH       Act on a plan already emitted by --catalog-json ("-" = stdin) instead of
+                         re-scanning. Use it with --file-issues so the filing acts on the SAME
+                         reading the decision to file was made from.
   --config PATH          LiteLLM config to read (default .litellm/config.yaml).
   --map PATH             Upgrade map (default .litellm/model_upgrades.yaml).
   --snapshot PATH        Committed catalog snapshot (default .litellm/ollama_catalog_snapshot.json).
@@ -222,6 +225,15 @@ _MONTHS = {m.lower(): i for i, m in enumerate(
 _DOC_DATE_RE = re.compile(r"([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})")
 _ACCORDION_RE = re.compile(r'<Accordion\b[^>]*title="([^"]+)"')
 _HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.*?)\s*$")
+_MODEL_TAG_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._/-]*(?::[A-Za-z0-9._-]+)?")
+
+
+def is_model_tag(name: str) -> bool:
+    """Does this cell actually name a model? cloud.md is a REMOTE document whose cells end up as
+    values in model_upgrades.yaml — a file whose entries auto-swap the live LiteLLM config — and
+    that writer emits `"key": "value"` lines, so a cell carrying a quote or a newline would inject
+    extra mappings of its own. Anything that isn't a plain tag is dropped at the parse boundary."""
+    return bool(_MODEL_TAG_RE.fullmatch(str(name or "").strip()))
 
 
 def parse_doc_date(text: str) -> Optional[str]:
@@ -302,8 +314,10 @@ def parse_retirements(md_text: str) -> list[dict]:
             when, model, alternative = parse_doc_date(cells[0]), _cell_model(cells[1]), _cell_model(cells[2])
         else:
             when, model, alternative = accordion_date, _cell_model(cells[0]), _cell_model(cells[1])
-        if not model:
+        if not is_model_tag(model):
             continue
+        if not is_model_tag(alternative):
+            alternative = ""
         rows.append({"model": model, "alternative": alternative or None, "date": when,
                      "upcoming": bool(upcoming)})
     return rows
@@ -354,9 +368,13 @@ def append_upgrade_mappings(map_text: str, additions: dict, today: str) -> tuple
     """Append `"model": "replacement"` lines to the `upgrades:` block, comment-preserving.
 
     Keys already mapped are skipped, so re-running is a no-op and the file never grows duplicates.
+    Anything that isn't a plain model tag is refused here too (not only at the parse boundary):
+    this writer is the last step before a remote-sourced string lands in a file the reactive half
+    applies to the live config, so it never emits a value it didn't check.
     Returns (new_text, keys_added)."""
     existing = load_map(load_map_text(map_text))
-    fresh = {k: v for k, v in sorted((additions or {}).items()) if k not in existing}
+    fresh = {k: v for k, v in sorted((additions or {}).items())
+             if k not in existing and is_model_tag(k) and is_model_tag(v)}
     if not fresh:
         return map_text, []
     lines = map_text.splitlines()
@@ -1028,15 +1046,26 @@ def main(argv: Optional[list[str]] = None) -> int:
     ap.add_argument("--catalog-apply", action="store_true")
     ap.add_argument("--file-issues", action="store_true")
     ap.add_argument("--today", default=None)
+    ap.add_argument("--plan-file", metavar="PATH", default=None)
     ap.add_argument("--catalog-fixture", default=None)
     ap.add_argument("--no-usage-levels", action="store_true")
     ap.add_argument("--repo", default=DEFAULT_REPO)
     args = ap.parse_args(argv)
 
     if args.catalog_scan or args.catalog_json or args.catalog_apply or args.file_issues:
-        plan = _catalog_scan(args.config, args.map, args.snapshot,
-                             today=args.today or _today(), fixture=args.catalog_fixture,
-                             usage_levels=not args.no_usage_levels)
+        if args.plan_file:
+            # --catalog-json strips the raw catalog, so a reloaded plan can describe the snapshot
+            # refresh but can never write it. Refuse loudly rather than silently skipping the write.
+            if args.catalog_apply:
+                raise SystemExit("--plan-file cannot drive --catalog-apply "
+                                 "(the emitted plan omits the raw catalog)")
+            plan = json.loads(sys.stdin.read() if args.plan_file == "-"
+                              else _read_text(args.plan_file))
+            plan.setdefault("_catalog", None)
+        else:
+            plan = _catalog_scan(args.config, args.map, args.snapshot,
+                                 today=args.today or _today(), fixture=args.catalog_fixture,
+                                 usage_levels=not args.no_usage_levels)
         if args.catalog_json:
             print(json.dumps({k: v for k, v in plan.items() if k != "_catalog"}))
         else:

--- a/scripts/model_health_check.py
+++ b/scripts/model_health_check.py
@@ -1,24 +1,47 @@
 #!/usr/bin/env python3
 """Weekly LiteLLM model-health check.
 
-Probes every Ollama Cloud model the LiteLLM proxy is configured to use, detects any the
-provider has RETIRED (HTTP 410), and — for retirements with a verified-working replacement in
-.litellm/model_upgrades.yaml — rewrites the config to swap them. Comment-preserving: swaps are a
-single `model:` line replacement, so the rest of the YAML (comments, ordering) is untouched.
+Two halves, both driven by scripts/weekly_model_check.sh:
 
-This module is intentionally split into PURE logic (parsing, action planning, line rewriting —
-unit-tested) and I/O (provider/proxy probes — mocked in tests). The orchestration that applies to
-the live box, restarts litellm, smoke-tests and rolls back lives in scripts/weekly_model_check.sh.
+REACTIVE (the original): probe every Ollama Cloud model the LiteLLM proxy is configured to use,
+detect any the provider has RETIRED (HTTP 410), and — for retirements with a verified-working
+replacement in .litellm/model_upgrades.yaml — rewrite the config to swap them. Comment-preserving:
+swaps are a single `model:` line replacement, so the rest of the YAML is untouched.
+
+PROACTIVE (issue #716): a 410 is the LAST moment to find out. Ollama Cloud publishes its retirement
+schedule in advance and ships new models roughly monthly, so the check also reads
+docs.ollama.com/cloud.md and ollama.com/api/tags and reports what is about to change:
+  * a CONFIGURED model with a FUTURE retirement date -> alert now + pre-append the recommended
+    replacement to model_upgrades.yaml (the reactive half then swaps it before the sunset bites);
+  * new/removed catalog tags vs the committed snapshot (.litellm/ollama_catalog_snapshot.json) ->
+    ONE `agent:ready` evaluation issue for the new ones, snapshot refreshed in the same PR;
+  * a configured model trailing a newer version of its OWN family (minimax-m2.7 while minimax-m3
+    ships) -> ONE consolidated `agent:ready` upgrade issue carrying each candidate's usage level,
+    because a version bump that jumps usage tiers costs more quota and is an evaluation, never an
+    auto-swap.
+Every fetch degrades gracefully: an unreachable doc/catalog logs and skips, and the 410 probe stays
+the backstop. Repo-visible changes (map, snapshot) land via the existing open-PR path, never as
+silent edits on the box.
+
+This module is intentionally split into PURE logic (parsing, action planning, line rewriting,
+issue rendering — unit-tested) and I/O (provider probes, HTTP, `gh` — mocked in tests).
 
 CLI:
   --report [--json]      Probe + report model health and planned actions. No writes.
   --plan-json            Emit ONLY the machine-readable plan (for the shell orchestrator).
   --apply OUT            Write the swapped config to OUT (reads --config). Prints applied swaps.
-  --smoke-test           Call every tier via the proxy; exit non-zero if any tier fails.
+  --catalog-scan         Advance-retirement / new-model / family-version scan. No writes (dry run).
+  --catalog-json         Emit ONLY the machine-readable catalog plan (for the shell orchestrator).
+  --catalog-apply        Write the planned map additions + snapshot refresh to --map / --snapshot.
+  --file-issues          File (or append to) the GitHub issues the catalog scan planned.
 Options:
   --config PATH          LiteLLM config to read (default .litellm/config.yaml).
   --map PATH             Upgrade map (default .litellm/model_upgrades.yaml).
-Exit: 0 healthy/no-op, 2 swaps planned/applied, 3 manual alert needed, 1 error.
+  --snapshot PATH        Committed catalog snapshot (default .litellm/ollama_catalog_snapshot.json).
+  --today YYYY-MM-DD     Override today's date (dry-run proofs / tests).
+  --catalog-fixture DIR  Read cloud.md + tags.json from DIR instead of the network (offline proof).
+  --no-usage-levels      Skip the per-model usage-level fetch (one page request per candidate).
+Exit: 0 healthy/no-op, 2 swaps/actions planned or applied, 3 manual alert needed, 1 error.
 """
 from __future__ import annotations
 
@@ -26,10 +49,29 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import sys
+import urllib.request
+from datetime import date, datetime, timezone
 from typing import Callable, Optional
 
 _OLLAMA_MARKER = "OLLAMA_CLOUD_URL"  # api_base env ref that marks an Ollama Cloud deployment
+
+CLOUD_DOCS_URL = "https://docs.ollama.com/cloud.md"  # plain-markdown mirror; index at /llms.txt
+CATALOG_URL = "https://ollama.com/api/tags"
+MODEL_PAGE_URL = "https://ollama.com/library/{name}"
+DEFAULT_SNAPSHOT = ".litellm/ollama_catalog_snapshot.json"
+HTTP_TIMEOUT_SECONDS = 30
+GH_TIMEOUT_SECONDS = 60
+DEFAULT_REPO = "christopherqueenconsulting/linkedin_engagement_manager"
+
+# Title prefixes ARE the dedup key: an open issue whose title starts with one of these and whose
+# text already names a marker is never re-filed (label match would collide with every other
+# agent:ready issue — see #598).
+UPGRADE_TITLE_PREFIX = "Ollama model family upgrades available:"
+EVAL_TITLE_PREFIX = "Evaluate new Ollama Cloud models:"
+ISSUE_LABELS = ("agent:ready", "priority:medium", "infrastructure")
+MAX_TITLE_CHARS = 120
 
 
 # ─────────────────────────── pure logic (unit-tested) ────────────────────────────
@@ -171,6 +213,502 @@ def apply_swaps(config_text: str, swaps: list[dict]) -> tuple[str, int]:
     return text, count
 
 
+# ───────────── advance retirement scan — docs.ollama.com/cloud.md (pure) ─────────
+
+_MONTHS = {m.lower(): i for i, m in enumerate(
+    ["January", "February", "March", "April", "May", "June", "July", "August", "September",
+     "October", "November", "December"], start=1)}
+
+_DOC_DATE_RE = re.compile(r"([A-Za-z]+)\s+(\d{1,2}),\s*(\d{4})")
+_ACCORDION_RE = re.compile(r'<Accordion\b[^>]*title="([^"]+)"')
+_HEADING_RE = re.compile(r"^\s{0,3}(#{1,6})\s+(.*?)\s*$")
+
+
+def parse_doc_date(text: str) -> Optional[str]:
+    """"July 31, 2026" -> "2026-07-31". Month names are matched against an explicit table rather
+    than strptime("%B"), which is locale-dependent and would silently stop parsing on a box with a
+    non-English locale."""
+    m = _DOC_DATE_RE.search(str(text or ""))
+    if not m:
+        return None
+    month = _MONTHS.get(m.group(1).lower())
+    if not month:
+        return None
+    try:
+        return date(int(m.group(3)), month, int(m.group(2))).isoformat()
+    except ValueError:
+        return None
+
+
+def _table_cells(line: str) -> Optional[list[str]]:
+    """Split one markdown table row into cells, or None when the line isn't a table row."""
+    stripped = line.strip()
+    if not stripped.startswith("|"):
+        return None
+    parts = stripped.split("|")
+    if parts and parts[0].strip() == "":
+        parts = parts[1:]
+    if parts and parts[-1].strip() == "":
+        parts = parts[:-1]
+    return [p.strip() for p in parts]
+
+
+def _cell_model(cell: str) -> str:
+    return str(cell or "").strip().strip("`").strip()
+
+
+def parse_retirements(md_text: str) -> list[dict]:
+    """Parse the `## Retirements` section of cloud.md into
+    [{model, alternative, date, upcoming}] rows.
+
+    Two shapes live under it: a 3-column "Upcoming retirements" table carrying its own date per
+    row, and "Past retirements" accordions whose *title* carries the date for a 2-column table.
+    Only the Retirements section is read — the page's other tables (API params, capabilities) must
+    never be mistaken for a retirement schedule."""
+    rows: list[dict] = []
+    in_section = False
+    upcoming = False
+    accordion_date: Optional[str] = None
+    for raw in str(md_text or "").splitlines():
+        heading = _HEADING_RE.match(raw)
+        if heading:
+            title = heading.group(2).strip().lower()
+            if len(heading.group(1)) <= 2:  # "# …" / "## …" — a new top-level section
+                in_section = title.startswith("retirement")
+                upcoming = False
+                accordion_date = None
+            elif in_section:
+                upcoming = title.startswith("upcoming")
+                accordion_date = None
+            continue
+        if not in_section:
+            continue
+        acc = _ACCORDION_RE.search(raw)
+        if acc:
+            accordion_date = parse_doc_date(acc.group(1))
+            continue
+        if "</Accordion>" in raw:
+            accordion_date = None
+            continue
+        cells = _table_cells(raw)
+        if not cells or len(cells) < 2:
+            continue
+        if all(re.fullmatch(r":?-{2,}:?", c) for c in cells):  # separator row
+            continue
+        lowered = [c.lower() for c in cells]
+        if "model" in lowered or "retirement date" in lowered:  # header row
+            continue
+        if len(cells) >= 3:
+            when, model, alternative = parse_doc_date(cells[0]), _cell_model(cells[1]), _cell_model(cells[2])
+        else:
+            when, model, alternative = accordion_date, _cell_model(cells[0]), _cell_model(cells[1])
+        if not model:
+            continue
+        rows.append({"model": model, "alternative": alternative or None, "date": when,
+                     "upcoming": bool(upcoming)})
+    return rows
+
+
+def plan_retirement_notices(deployments: list[dict], retirements: list[dict], upgrades: dict,
+                            today: str, catalog: Optional[dict] = None) -> tuple[list[dict], dict]:
+    """Which CONFIGURED models are scheduled to die, and what to pre-append to the upgrade map.
+
+    Only FUTURE dates produce a notice — a date already past is a live 410 the reactive probe owns,
+    and re-reporting it every week would bury the one thing that is still actionable. A mapping is
+    only proposed when the docs name an alternative that the live catalog still carries (when the
+    catalog is available); "retired with nothing to move to" is a human call, so it alerts and
+    leaves the map alone rather than writing REMOVE and silencing itself."""
+    configured: dict[str, dict] = {}
+    for d in deployments:
+        if d["is_ollama"]:
+            configured.setdefault(d["bare"], d)
+    notices: list[dict] = []
+    additions: dict[str, str] = {}
+    seen: set[str] = set()
+    for r in sorted(retirements, key=lambda x: (x.get("date") or "", x.get("model") or "")):
+        bare = r.get("model") or ""
+        when = r.get("date")
+        if bare not in configured or bare in seen or not when or when <= today:
+            continue
+        seen.add(bare)
+        d = configured[bare]
+        alternative = r.get("alternative")
+        in_catalog = None if catalog is None else (alternative in catalog if alternative else False)
+        notices.append({"kind": "RETIREMENT_NOTICE", "group": d["group"], "model": d["model"],
+                        "bare": bare, "date": when, "days_until": _days_until(when, today),
+                        "alternative": alternative, "alternative_in_catalog": in_catalog,
+                        "mapped": bare in upgrades})
+        if alternative and bare not in upgrades and in_catalog is not False:
+            additions[bare] = alternative
+    return notices, additions
+
+
+def _days_until(when: str, today: str) -> Optional[int]:
+    try:
+        return (date.fromisoformat(when) - date.fromisoformat(today)).days
+    except (TypeError, ValueError):
+        return None
+
+
+def append_upgrade_mappings(map_text: str, additions: dict, today: str) -> tuple[str, list[str]]:
+    """Append `"model": "replacement"` lines to the `upgrades:` block, comment-preserving.
+
+    Keys already mapped are skipped, so re-running is a no-op and the file never grows duplicates.
+    Returns (new_text, keys_added)."""
+    existing = load_map(load_map_text(map_text))
+    fresh = {k: v for k, v in sorted((additions or {}).items()) if k not in existing}
+    if not fresh:
+        return map_text, []
+    lines = map_text.splitlines()
+    start = next((i for i, line in enumerate(lines) if re.match(r"\s*upgrades:\s*$", line)), None)
+    if start is None:  # no block to extend — create one rather than corrupting the file
+        lines += ["", "upgrades:"]
+        start = len(lines) - 1
+    insert_at = start + 1
+    for i in range(start + 1, len(lines)):
+        line = lines[i]
+        if line.strip() == "" or line.startswith((" ", "\t")):
+            if line.strip():
+                insert_at = i + 1
+            continue
+        break
+    block = [f"  # --- added by the advance-retirement scan ({today}) ---"]
+    block += [f'  "{k}": "{v}"' for k, v in fresh.items()]
+    lines[insert_at:insert_at] = block
+    return "\n".join(lines) + "\n", list(fresh)
+
+
+# ──────────────── catalog snapshot — ollama.com/api/tags (pure) ──────────────────
+
+def parse_catalog(payload: dict) -> dict:
+    """Normalize /api/tags into {tag: {modified_at, size, parameter_size, family}} — the fields the
+    snapshot diff and the evaluation issue body are built from."""
+    models: dict[str, dict] = {}
+    for entry in (payload or {}).get("models") or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or entry.get("model") or "").strip()
+        if not name:
+            continue
+        details = entry.get("details") or {}
+        models[name] = {
+            "modified_at": str(entry.get("modified_at") or ""),
+            "size": int(entry.get("size") or 0),
+            "parameter_size": str((details or {}).get("parameter_size") or ""),
+            "family": str((details or {}).get("family") or ""),
+        }
+    return models
+
+
+def load_snapshot_text(text: str) -> dict:
+    try:
+        doc = json.loads(text or "{}")
+    except ValueError:
+        return {}
+    return dict((doc or {}).get("models") or {})
+
+
+def render_snapshot(models: dict, updated: str) -> str:
+    doc = {
+        "_comment": "Committed snapshot of ollama.com/api/tags, refreshed by "
+                    "scripts/model_health_check.py --catalog-apply. New tags here vs the live "
+                    "catalog become ONE agent:ready evaluation issue; do not hand-edit.",
+        "updated": updated,
+        "models": {k: models[k] for k in sorted(models or {})},
+    }
+    return json.dumps(doc, indent=2, sort_keys=False) + "\n"
+
+
+def diff_catalog(snapshot: dict, current: dict) -> dict:
+    old, new = set(snapshot or {}), set(current or {})
+    return {"added": sorted(new - old), "removed": sorted(old - new)}
+
+
+# ───────────────── family-version scan — "are we a major behind?" (pure) ─────────
+
+_FUSED_RE = re.compile(r"^([a-z][a-z0-9]*?)(\d+(?:\.\d+)*)$")
+_NUM_RE = re.compile(r"^(\d+(?:\.\d+)*)$")
+
+
+def parse_model_version(name: str) -> tuple[str, Optional[tuple], str]:
+    """Split an Ollama tag into (family, version, size_tag).
+
+    The catalog spells versions three ways — fused into the name (`qwen3.5`, `gemma4`), as their own
+    dash-part (`glm-5.1`, `nemotron-3-nano`), or behind a one-letter marker (`minimax-m2.7`,
+    `deepseek-v4-flash`). The FIRST version-bearing part wins; everything around it is the family,
+    so a variant suffix stays part of the family key (`kimi-k2.7-code` -> `kimi-code`, never an
+    "upgrade" for plain `kimi-k2.6`). A size tag (`:397b`) is not a version — `gpt-oss:20b` comes
+    back unversioned, which is what keeps size-tagged families out of the comparison."""
+    text = str(name or "").strip().lower()
+    base, _, size_tag = text.partition(":")
+    if not base:
+        return "", None, size_tag
+    parts = base.split("-")
+    for i, part in enumerate(parts):
+        prefix = ""
+        num = _NUM_RE.match(part)
+        if num:
+            version_text = num.group(1)
+        else:
+            fused = _FUSED_RE.match(part)
+            if not fused:
+                continue
+            prefix, version_text = fused.group(1), fused.group(2)
+            if len(prefix) == 1:  # m2.7 / k2.6 / v4 — a version marker, not part of the name
+                prefix = ""
+        family_parts = parts[:i] + ([prefix] if prefix else []) + parts[i + 1:]
+        version = tuple(int(x) for x in version_text.split("."))
+        return "-".join(p for p in family_parts if p), version, size_tag
+    return base, None, size_tag
+
+
+def version_str(version: Optional[tuple]) -> str:
+    return ".".join(str(x) for x in version) if version else "unversioned"
+
+
+def plan_family_upgrades(deployments: list[dict], catalog: dict,
+                         retiring: Optional[set] = None,
+                         usage_lookup: Optional[Callable[[str], dict]] = None) -> list[dict]:
+    """Configured models that trail a newer version of their OWN family in the live catalog.
+
+    Candidates that the docs already list as retiring are excluded — recommending a model with a
+    sunset date on it is worse than saying nothing. `urgency` is "major" when the leading version
+    component moves (or when the configured tag is unversioned and a versioned sibling exists);
+    minor/patch bumps ride the same issue at lower urgency. Never a swap: `usage` levels are
+    attached precisely because a jump in tier burns more Ollama quota, which is a human call."""
+    retiring = set(retiring or ())
+    by_family: dict[str, list[tuple]] = {}
+    for name in sorted(catalog or {}):
+        if name in retiring:
+            continue
+        family, version, _ = parse_model_version(name)
+        if version is None:
+            continue
+        by_family.setdefault(family, []).append((version, name))
+
+    def usage(model: str) -> dict:
+        if not usage_lookup:
+            return {"level": None, "label": None}
+        try:
+            return usage_lookup(model) or {"level": None, "label": None}
+        except Exception:  # noqa: BLE001 - a usage lookup must never fail the scan
+            return {"level": None, "label": None}
+
+    out: list[dict] = []
+    seen: set[str] = set()
+    groups: dict[str, list[str]] = {}
+    for d in deployments:
+        if d["is_ollama"]:
+            groups.setdefault(d["bare"], []).append(d["group"])
+    for d in deployments:
+        if not d["is_ollama"] or d["bare"] in seen:
+            continue
+        bare = d["bare"]
+        family, version, _ = parse_model_version(bare)
+        candidates = by_family.get(family) or []
+        if not candidates:
+            continue
+        best_version, best_name = max(candidates)
+        current = version or ()
+        if best_name == bare or best_version <= current:
+            continue
+        seen.add(bare)
+        current_usage, candidate_usage = usage(bare), usage(best_name)
+        out.append({
+            "family": family, "groups": sorted(set(groups.get(bare) or [])),
+            "current": bare, "current_version": version_str(version),
+            "candidate": best_name, "candidate_version": version_str(best_version),
+            "urgency": "major" if (not version or best_version[0] > version[0]) else "minor",
+            "current_usage": current_usage, "candidate_usage": candidate_usage,
+            "usage_jump": _usage_jump(current_usage, candidate_usage),
+        })
+    return out
+
+
+def _usage_jump(current: dict, candidate: dict) -> Optional[bool]:
+    a, b = (current or {}).get("level"), (candidate or {}).get("level")
+    if a is None or b is None:
+        return None  # unread is never "no jump" — the issue says so in words
+    return b > a
+
+
+# ──────────────────── issue rendering + dedup (pure) ─────────────────────────────
+
+def upgrade_marker(upgrade: dict) -> str:
+    return f"{upgrade.get('current')} -> {upgrade.get('candidate')}"
+
+
+def _usage_text(usage: dict) -> str:
+    label, level = (usage or {}).get("label"), (usage or {}).get("level")
+    if label and level:
+        return f"{label} (level {level})"
+    return label or (f"level {level}" if level else "unknown")
+
+
+def _titled(prefix: str, items: list[str]) -> str:
+    title = f"{prefix} {', '.join(items)}"
+    if len(title) <= MAX_TITLE_CHARS:
+        return title
+    kept: list[str] = []
+    for item in items:
+        candidate = f"{prefix} {', '.join(kept + [item])} (+{len(items) - len(kept) - 1} more)"
+        if kept and len(candidate) > MAX_TITLE_CHARS:
+            break
+        kept.append(item)
+    return f"{prefix} {', '.join(kept)} (+{len(items) - len(kept)} more)"
+
+
+def build_upgrade_issue_title(upgrades: list[dict]) -> str:
+    return _titled(UPGRADE_TITLE_PREFIX, [upgrade_marker(u) for u in upgrades])
+
+
+def build_upgrade_issue_body(upgrades: list[dict], today: str) -> str:
+    lines = ["## Context",
+             f"The weekly model-health check ({today}) found configured Ollama Cloud models that "
+             "trail a newer version of their own family in ollama.com/api/tags. A newer major is "
+             "not automatically better *for us*: a bump that raises the model's usage level burns "
+             "more Ollama Cloud quota per call, so this is an evaluation, never an auto-swap.",
+             ""]
+    major = [u for u in upgrades if u.get("urgency") == "major"]
+    minor = [u for u in upgrades if u.get("urgency") != "major"]
+    for heading, group in (("### Major version behind", major), ("### Minor/patch behind", minor)):
+        if not group:
+            continue
+        lines += [heading, ""]
+        for u in group:
+            jump = u.get("usage_jump")
+            note = ("⚠️ usage level goes UP" if jump else
+                    "usage level unchanged or lower" if jump is False else
+                    "usage level unknown (page unavailable)")
+            lines += [
+                f"- **{upgrade_marker(u)}** (family `{u['family']}`, "
+                f"{u['current_version']} → {u['candidate_version']}) — "
+                f"tiers: {', '.join(u.get('groups') or []) or 'n/a'}",
+                f"  - usage: `{u['current']}` {_usage_text(u.get('current_usage'))} → "
+                f"`{u['candidate']}` {_usage_text(u.get('candidate_usage'))} — {note}",
+            ]
+        lines.append("")
+    lines += ["## Scope",
+              "- Evaluate each candidate against the tier it would serve (quality on the real "
+              "prompts, latency, and quota cost at the new usage level).",
+              "- If a swap is worth it, change `.litellm/config.yaml` — do NOT add it to "
+              "`.litellm/model_upgrades.yaml`, which is the RETIREMENT map and auto-swaps.",
+              "- Leave anything that jumps a usage tier alone unless the quality win justifies the "
+              "extra quota burn.",
+              "",
+              "## Acceptance",
+              "- A decision per candidate above (adopt or explicitly decline, with the reason).",
+              "- `poetry run pytest tests/unit -q` still passes if the config changed.",
+              "",
+              "Auto-filed by `scripts/model_health_check.py --file-issues` (issue #716). Dedup "
+              "markers (do not remove): " + ", ".join(f"`{upgrade_marker(u)}`" for u in upgrades)]
+    return "\n".join(lines)
+
+
+def build_eval_issue_title(new_tags: list[str]) -> str:
+    return _titled(EVAL_TITLE_PREFIX, list(new_tags))
+
+
+def build_eval_issue_body(new_tags: list[str], catalog: dict, today: str) -> str:
+    lines = ["## Context",
+             f"The weekly model-health check ({today}) found tags on ollama.com/api/tags that are "
+             "not in `.litellm/ollama_catalog_snapshot.json`. New Ollama Cloud models ship roughly "
+             "monthly and one of them may be a better fit (or a cheaper one) for a LiteLLM tier.",
+             "",
+             "## New tags", ""]
+    for name in new_tags:
+        info = (catalog or {}).get(name) or {}
+        bits = []
+        if info.get("parameter_size"):
+            bits.append(str(info["parameter_size"]))
+        if info.get("size"):
+            bits.append(f"{int(info['size']) / 1e9:.0f}GB")
+        if info.get("modified_at"):
+            bits.append(f"updated {str(info['modified_at'])[:10]}")
+        family, version, size_tag = parse_model_version(name)
+        bits.append(f"family `{family}`, version {version_str(version)}")
+        if size_tag:
+            bits.append(f"size tag `{size_tag}`")
+        lines.append(f"- `{name}` — {'; '.join(bits)}")
+    lines += ["",
+              "## Scope",
+              "- Read each model's page (https://ollama.com/library/<name>) for its usage level "
+              "and capabilities; a higher usage level costs more Ollama Cloud quota per call.",
+              "- Decide whether any belongs in a `lem-simple` / `lem-medium` / `lem-complex` "
+              "deployment in `.litellm/config.yaml`. Adopting one is a config change, not a "
+              "`model_upgrades.yaml` entry (that map is retirement-only and auto-swaps).",
+              "- Declining is a valid outcome — say so on the issue so the next scan's reader "
+              "knows it was considered.",
+              "",
+              "## Acceptance",
+              "- A decision per tag above.",
+              "- If a model is adopted, `scripts/weekly_model_check.sh`'s tier smoke test still "
+              "passes and `poetry run pytest tests/unit -q` is green.",
+              "",
+              "Auto-filed by `scripts/model_health_check.py --file-issues` (issue #716). Dedup "
+              "markers (do not remove): " + ", ".join(f"`{n}`" for n in new_tags)]
+    return "\n".join(lines)
+
+
+def build_append_comment(markers: list[str], body: str) -> str:
+    return ("The weekly model-health check found more of these since this issue was filed:\n\n"
+            + "\n".join(f"- `{m}`" for m in markers)
+            + "\n\n<details><summary>Full detail</summary>\n\n" + body + "\n\n</details>")
+
+
+def plan_issue(open_issues: list[dict], markers: list[str], *, title_prefix: str) -> dict:
+    """create / append / none for one consolidated issue.
+
+    Dedup is a literal marker search across the TITLE, BODY and COMMENTS of open issues carrying
+    this title prefix — comments count because that is where an append lands, and a label match
+    would collide with every other `agent:ready` issue (#598)."""
+    if not markers:
+        return {"action": "none", "markers": [], "number": None}
+    relevant = [i for i in (open_issues or [])
+                if str((i or {}).get("title") or "").startswith(title_prefix)]
+    chunks: list[str] = []
+    for issue in relevant:
+        chunks.append(str(issue.get("title") or ""))
+        chunks.append(str(issue.get("body") or ""))
+        for comment in issue.get("comments") or []:
+            chunks.append(str(comment.get("body") if isinstance(comment, dict) else comment or ""))
+    haystack = "\n".join(chunks)
+    fresh = [m for m in markers if m not in haystack]
+    if not fresh:
+        return {"action": "none", "markers": [], "number": relevant[0].get("number") if relevant else None}
+    if relevant:
+        return {"action": "append", "markers": fresh, "number": relevant[0].get("number")}
+    return {"action": "create", "markers": fresh, "number": None}
+
+
+_USAGE_LEVELS = {"low": 1, "medium": 2, "high": 3, "extra high": 4}
+
+
+def parse_usage_level(html: str) -> dict:
+    """Read the "Usage" stat off an ollama.com model page -> {level: 1-4|None, label: str|None}.
+
+    The page renders the level twice — as filled pips and as a word — so the word is preferred and
+    the pip count is the fallback when the wording changes. Reading stops at the next stat label so
+    a "Context"/"Size" value can never be mistaken for the usage word."""
+    text = str(html or "")
+    label_at = re.search(r">\s*Usage\s*</\w+>", text)
+    if not label_at:
+        return {"level": None, "label": None}
+    block = text[label_at.end():label_at.end() + 2000]
+    stop = re.search(r">\s*(?:Context|Size|Input|Output)\s*</\w+>", block)
+    if stop:
+        block = block[:stop.start()]
+    label = None
+    for chunk in re.findall(r">([^<>]+)<", block):
+        candidate = " ".join(chunk.split()).lower()
+        if candidate in _USAGE_LEVELS:
+            label = candidate
+            break
+    filled = len(re.findall(r"bg-neutral-900", block))
+    level = _USAGE_LEVELS.get(label) if label else (filled or None)
+    return {"level": level, "label": label}
+
+
 # ─────────────────────────────── I/O (mocked in tests) ───────────────────────────
 
 def probe_provider(bare_model: str, *, base_url: str, api_key: str, timeout: float = 30.0) -> str:
@@ -192,6 +730,93 @@ def probe_provider(bare_model: str, *, base_url: str, api_key: str, timeout: flo
 def smoke_test_tiers(tiers: list[str], call_tier: Callable[[str], bool]) -> dict:
     """Call each tier once via the proxy; return {tier: ok_bool}."""
     return {t: bool(call_tier(t)) for t in tiers}
+
+
+def http_get(url: str, headers: Optional[dict] = None,
+             timeout: float = HTTP_TIMEOUT_SECONDS) -> str:
+    """Plain stdlib GET. This tool runs from a host ops cron with no app venv guaranteed, so it
+    stays on urllib rather than taking a `requests` dependency."""
+    request = urllib.request.Request(url, headers=dict(headers or {}))
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310 - fixed hosts
+        return response.read().decode("utf-8", "replace")
+
+
+def fetch_cloud_docs(url: str = CLOUD_DOCS_URL) -> Optional[str]:
+    try:
+        return http_get(url)
+    except Exception as e:  # noqa: BLE001 - a doc outage must not fail the health check
+        print(f"  ! could not fetch {url}: {str(e)[:200]}", file=sys.stderr)
+        return None
+
+
+def fetch_catalog(api_key: str = "", url: str = CATALOG_URL) -> Optional[dict]:
+    headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}
+    try:
+        return json.loads(http_get(url, headers))
+    except Exception as e:  # noqa: BLE001 - same: degrade, the 410 probe is the backstop
+        print(f"  ! could not fetch {url}: {str(e)[:200]}", file=sys.stderr)
+        return None
+
+
+def fetch_usage_level(model: str) -> dict:
+    """Usage level for one tag. The page is keyed by the model name without its size tag."""
+    name = str(model or "").split(":", 1)[0]
+    try:
+        return parse_usage_level(http_get(MODEL_PAGE_URL.format(name=name)))
+    except Exception as e:  # noqa: BLE001
+        print(f"  ! could not read usage level for {name}: {str(e)[:120]}", file=sys.stderr)
+        return {"level": None, "label": None}
+
+
+class GitHubIssues:
+    """GitHub via the `gh` CLI — the cron host is already authenticated with it, so this needs no
+    token of its own (and never handles one)."""
+
+    def __init__(self, repo: str = DEFAULT_REPO) -> None:
+        self.repo = repo
+
+    def _run(self, args: list) -> subprocess.CompletedProcess:
+        return subprocess.run(args, capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS)
+
+    def open_issues(self, title_prefix: str) -> list[dict]:
+        """Open issues whose title starts with `title_prefix`, with bodies AND comments.
+
+        Listed and filtered client-side rather than handed to `--search`: the search index
+        tokenizes and lags, and a miss here means a DUPLICATE issue every week. The repo's open
+        backlog is small enough that one full list is cheaper than that risk.
+
+        Fails CLOSED (raises): an unreadable listing read as "nothing filed yet" would re-file the
+        same upgrade issue every week."""
+        result = self._run(["gh", "issue", "list", "--repo", self.repo, "--state", "open",
+                            "--limit", "200", "--json", "number,title,body,comments"])
+        if result.returncode != 0:
+            raise RuntimeError(f"gh issue list failed: {(result.stderr or '').strip()[:200]}")
+        try:
+            found = json.loads(result.stdout or "[]")
+        except ValueError:
+            raise RuntimeError("gh issue list returned unparseable JSON")
+        return [i for i in found
+                if isinstance(i, dict) and str(i.get("title") or "").startswith(title_prefix)]
+
+    def create(self, title: str, body: str, labels=ISSUE_LABELS) -> Optional[str]:
+        args = ["gh", "issue", "create", "--repo", self.repo, "--title", title, "--body", body]
+        for label in labels:
+            args += ["--label", label]
+        result = self._run(args)
+        if result.returncode != 0:
+            print(f"  ! gh issue create failed: {(result.stderr or '').strip()[:300]}",
+                  file=sys.stderr)
+            return None
+        return (result.stdout or "").strip()
+
+    def comment(self, number: int, body: str) -> bool:
+        result = self._run(["gh", "issue", "comment", str(number), "--repo", self.repo,
+                            "--body", body])
+        if result.returncode != 0:
+            print(f"  ! gh issue comment failed: {(result.stderr or '').strip()[:300]}",
+                  file=sys.stderr)
+            return False
+        return True
 
 
 # ─────────────────────────────────── CLI ─────────────────────────────────────────
@@ -225,15 +850,206 @@ def _detect(config_path: str, map_path: str) -> dict:
             "alerts": [a for a in actions if a["kind"] == "ALERT"]}
 
 
+def _today() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _fixture_sources(directory: str) -> tuple[Optional[str], Optional[dict], Callable[[str], dict]]:
+    """Offline stand-ins for the three network reads, so `--catalog-scan --catalog-fixture DIR`
+    proves the whole plan (alert -> map PR -> issue bodies) without touching the network."""
+    docs_path = os.path.join(directory, "cloud.md")
+    tags_path = os.path.join(directory, "tags.json")
+    docs = _read_text(docs_path) if os.path.exists(docs_path) else None
+    catalog: Optional[dict] = None
+    if os.path.exists(tags_path):
+        catalog = json.loads(_read_text(tags_path))
+
+    def usage(model: str) -> dict:
+        name = str(model or "").split(":", 1)[0]
+        page = os.path.join(directory, "usage", f"{name}.html")
+        return parse_usage_level(_read_text(page)) if os.path.exists(page) else {"level": None,
+                                                                                "label": None}
+
+    return docs, catalog, usage
+
+
+def _catalog_scan(config_path: str, map_path: str, snapshot_path: str, *, today: str,
+                  fixture: Optional[str] = None, usage_levels: bool = True) -> dict:
+    """The proactive half: what is about to retire, what is new, and what family we trail.
+
+    Nothing here writes; `--catalog-apply` / `--file-issues` act on the plan this returns."""
+    deployments = parse_deployments(load_config_text(_read_text(config_path)))
+    upgrades = load_map(load_map_text(_read_text(map_path)))
+
+    usage_fn: Optional[Callable[[str], dict]] = None
+    if fixture:
+        docs_text, catalog_payload, usage_fn = _fixture_sources(fixture)
+    else:
+        docs_text = fetch_cloud_docs()
+        catalog_payload = fetch_catalog(os.environ.get("OLLAMA_CLOUD_API_KEY", ""))
+        if usage_levels:
+            cache: dict[str, dict] = {}
+
+            def usage_fn(model: str) -> dict:  # noqa: F811 - only bound on the network path
+                if model not in cache:
+                    cache[model] = fetch_usage_level(model)
+                return cache[model]
+
+    retirements = parse_retirements(docs_text) if docs_text is not None else []
+    catalog = parse_catalog(catalog_payload) if catalog_payload is not None else None
+
+    notices, additions = plan_retirement_notices(deployments, retirements, upgrades, today, catalog)
+
+    # A missing snapshot is SEEDED, not diffed — a first run must not file an evaluation issue for
+    # the entire catalog.
+    seeded = not os.path.exists(snapshot_path)
+    snapshot = {} if seeded else load_snapshot_text(_read_text(snapshot_path))
+    if catalog is None:
+        catalog_diff = {"added": [], "removed": []}
+        family_upgrades: list[dict] = []
+    else:
+        catalog_diff = {"added": [], "removed": []} if seeded else diff_catalog(snapshot, catalog)
+        family_upgrades = plan_family_upgrades(
+            deployments, catalog, {r["model"] for r in retirements},
+            usage_fn if usage_levels else None)
+
+    snapshot_changed = catalog is not None and catalog != snapshot
+    plan = {
+        "today": today,
+        "sources": {"docs": docs_text is not None, "catalog": catalog is not None,
+                    "snapshot_seeded": seeded},
+        "notices": notices,
+        "map_additions": additions,
+        "catalog": {**catalog_diff, "total": len(catalog or {})},
+        "upgrades": family_upgrades,
+        "snapshot_changed": snapshot_changed,
+        "repo_changes": bool(additions) or snapshot_changed,
+    }
+    plan["issues"] = {
+        "upgrade": {"markers": [upgrade_marker(u) for u in family_upgrades],
+                    "title": build_upgrade_issue_title(family_upgrades) if family_upgrades else "",
+                    "body": build_upgrade_issue_body(family_upgrades, today) if family_upgrades else ""},
+        "evaluation": {"markers": list(catalog_diff["added"]),
+                       "title": build_eval_issue_title(catalog_diff["added"]) if catalog_diff["added"] else "",
+                       "body": build_eval_issue_body(catalog_diff["added"], catalog or {}, today)
+                       if catalog_diff["added"] else ""},
+    }
+    plan["_catalog"] = catalog  # consumed by --catalog-apply; stripped from --catalog-json output
+    return plan
+
+
+def _print_catalog_plan(plan: dict) -> None:
+    sources = plan["sources"]
+    print(f"Ollama catalog scan ({plan['today']}): docs={'ok' if sources['docs'] else 'UNAVAILABLE'}"
+          f" catalog={'ok' if sources['catalog'] else 'UNAVAILABLE'}"
+          f" tags={plan['catalog']['total']}")
+    if sources["snapshot_seeded"]:
+        print("  snapshot missing — seeding it this run (no evaluation issue filed)")
+    for n in plan["notices"]:
+        alt = n["alternative"] or "no alternative published"
+        print(f"  RETIRING [{n['group']}] {n['bare']} on {n['date']} "
+              f"({n['days_until']}d) -> {alt}"
+              f"{'' if n['mapped'] else ' [not yet mapped]'}")
+    for k, v in plan["map_additions"].items():
+        print(f"  MAP + \"{k}\": \"{v}\"")
+    for name in plan["catalog"]["added"]:
+        print(f"  NEW TAG {name}")
+    for name in plan["catalog"]["removed"]:
+        print(f"  GONE TAG {name}")
+    for u in plan["upgrades"]:
+        print(f"  UPGRADE ({u['urgency']}) {upgrade_marker(u)} — usage "
+              f"{_usage_text(u['current_usage'])} -> {_usage_text(u['candidate_usage'])}")
+    for kind in ("upgrade", "evaluation"):
+        spec = plan["issues"][kind]
+        if spec["markers"]:
+            print(f"\n--- {kind} issue ---\n{spec['title']}\n\n{spec['body']}\n")
+    if not (plan["notices"] or plan["map_additions"] or plan["catalog"]["added"]
+            or plan["catalog"]["removed"] or plan["upgrades"]):
+        print("  nothing to do")
+
+
+def _catalog_apply(plan: dict, map_path: str, snapshot_path: str) -> None:
+    added = []
+    if plan["map_additions"]:
+        text, added = append_upgrade_mappings(_read_text(map_path), plan["map_additions"],
+                                              plan["today"])
+        if added:
+            with open(map_path, "w") as f:
+                f.write(text)
+    for key in added:
+        print(f"mapped {key} -> {plan['map_additions'][key]} in {map_path}")
+    if plan["snapshot_changed"] and plan["_catalog"] is not None:
+        with open(snapshot_path, "w") as f:
+            f.write(render_snapshot(plan["_catalog"], plan["today"]))
+        print(f"snapshot refreshed ({plan['catalog']['total']} tags) -> {snapshot_path}")
+
+
+def _file_issues(plan: dict, github: GitHubIssues) -> int:
+    """File/append the consolidated issues. Never raises: a GitHub failure leaves the work for next
+    week rather than failing the weekly check."""
+    filed = 0
+    for kind, prefix in (("upgrade", UPGRADE_TITLE_PREFIX), ("evaluation", EVAL_TITLE_PREFIX)):
+        spec = plan["issues"][kind]
+        if not spec["markers"]:
+            continue
+        try:
+            existing = github.open_issues(prefix)
+        except Exception as e:  # noqa: BLE001 - fail closed: skip rather than risk a duplicate
+            print(f"  ! dedup lookup failed for {kind} issue: {e}", file=sys.stderr)
+            continue
+        decision = plan_issue(existing, spec["markers"], title_prefix=prefix)
+        if decision["action"] == "none":
+            print(f"  {kind} issue: already filed (#{decision['number']})")
+        elif decision["action"] == "append":
+            if github.comment(decision["number"], build_append_comment(decision["markers"],
+                                                                      spec["body"])):
+                print(f"  {kind} issue: appended {len(decision['markers'])} to "
+                      f"#{decision['number']}")
+                filed += 1
+        else:
+            url = github.create(spec["title"], spec["body"])
+            if url:
+                print(f"  {kind} issue: filed {url}")
+                filed += 1
+    return filed
+
+
 def main(argv: Optional[list[str]] = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--config", default=".litellm/config.yaml")
     ap.add_argument("--map", default=".litellm/model_upgrades.yaml")
+    ap.add_argument("--snapshot", default=DEFAULT_SNAPSHOT)
     ap.add_argument("--report", action="store_true")
     ap.add_argument("--json", action="store_true")
     ap.add_argument("--plan-json", action="store_true")
     ap.add_argument("--apply", metavar="OUT")
+    ap.add_argument("--catalog-scan", action="store_true")
+    ap.add_argument("--catalog-json", action="store_true")
+    ap.add_argument("--catalog-apply", action="store_true")
+    ap.add_argument("--file-issues", action="store_true")
+    ap.add_argument("--today", default=None)
+    ap.add_argument("--catalog-fixture", default=None)
+    ap.add_argument("--no-usage-levels", action="store_true")
+    ap.add_argument("--repo", default=DEFAULT_REPO)
     args = ap.parse_args(argv)
+
+    if args.catalog_scan or args.catalog_json or args.catalog_apply or args.file_issues:
+        plan = _catalog_scan(args.config, args.map, args.snapshot,
+                             today=args.today or _today(), fixture=args.catalog_fixture,
+                             usage_levels=not args.no_usage_levels)
+        if args.catalog_json:
+            print(json.dumps({k: v for k, v in plan.items() if k != "_catalog"}))
+        else:
+            _print_catalog_plan(plan)
+        if args.catalog_apply:
+            _catalog_apply(plan, args.map, args.snapshot)
+        if args.file_issues:
+            _file_issues(plan, GitHubIssues(args.repo))
+        if plan["notices"]:
+            return 3
+        if plan["repo_changes"] or plan["upgrades"] or plan["catalog"]["added"]:
+            return 2
+        return 0
 
     result = _detect(args.config, args.map)
 

--- a/scripts/weekly_model_check.sh
+++ b/scripts/weekly_model_check.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 # Weekly LiteLLM model-health orchestrator (host cron, runs as `lem`).
 #
-# Flow: plan (scripts/model_health_check.py against the LIVE box config) -> for retirements with a
-# verified replacement, back up + apply the swap on the box, restart litellm, smoke-test every tier,
-# and ROLL BACK on any failure; on success open a PR so the change lands in git and alert. When no
-# swap is needed but a tier is 410-ing (a stale litellm that wasn't restarted after a deploy), just
+# REACTIVE flow: plan (scripts/model_health_check.py against the LIVE box config) -> for retirements
+# with a verified replacement, back up + apply the swap on the box, restart litellm, smoke-test every
+# tier, and ROLL BACK on any failure; on success open a PR so the change lands in git and alert. When
+# no swap is needed but a tier is 410-ing (a stale litellm that wasn't restarted after a deploy), just
 # restart + re-verify. Manual-only retirements (REMOVE / unknown / no working replacement) alert.
+#
+# PROACTIVE flow (issue #716): after the probe, scan Ollama Cloud's published retirement schedule and
+# live catalog. A configured model with a FUTURE sunset alerts now and gets its replacement
+# pre-appended to model_upgrades.yaml (so the reactive half swaps it before the 410); new catalog
+# tags and configured models trailing a newer version of their own family become agent:ready issues.
+# Repo-visible changes (map, snapshot) go out as a PR — never a silent edit on the box.
 #
 # Safe by construction: a replacement is provider-verified before use, changes are smoke-tested
 # before they're kept, and deploy.sh resets .litellm before its checkout so an on-box hotfix can
@@ -18,6 +24,7 @@ export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/home/
 REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 BOX_CFG="/opt/lem/.litellm/config.yaml"
 MAP="$REPO/.litellm/model_upgrades.yaml"
+SNAP="$REPO/.litellm/ollama_catalog_snapshot.json"
 DIR="/home/lem/model-check"
 LOG="$DIR/model_check.log"
 COMPOSE="sudo -n docker compose -f /opt/lem/docker-compose.yml -f /opt/lem/docker-compose.prod.yml"
@@ -69,25 +76,38 @@ smoke(){  # 0 iff every tier answers
   return $bad
 }
 
-open_pr(){  # mirror the same swap into the repo via an EPHEMERAL worktree — never touches the
-            # shared dev checkout's branch/working tree (a human may be working there).
-  local wt; wt="$(mktemp -d /tmp/model-upgrade-wt.XXXXXX)"
+open_pr(){  # $1=branch $2=title $3=body $4=mutate-fn (runs inside the worktree, stages its files)
+            # Mirrors a change into the repo via an EPHEMERAL worktree — never touches the shared
+            # dev checkout's branch/working tree (a human may be working there).
+  local branch="$1" title="$2" body="$3" mutate="$4" wt
+  wt="$(mktemp -d /tmp/model-upgrade-wt.XXXXXX)"
   ( cd "$REPO" && git fetch -q origin main \
-      && git worktree add -q -B auto/model-upgrade "$wt" origin/main ) || { log "worktree add failed"; return 1; }
+      && git worktree add -q -B "$branch" "$wt" origin/main ) || { log "worktree add failed ($branch)"; return 1; }
   (
     cd "$wt" || exit 1
-    "${PY[@]}" "$REPO/scripts/model_health_check.py" --apply "$wt/.litellm/config.yaml" \
-        --config "$wt/.litellm/config.yaml" --map "$wt/.litellm/model_upgrades.yaml" >>"$LOG" 2>&1
-    git add .litellm/config.yaml
-    git commit -q -m "fix(litellm): auto-swap retired Ollama model(s) [weekly model-health check]" \
-        -m "Opened by scripts/weekly_model_check.sh after verifying the replacement against the provider and smoke-testing every tier on the live box." >>"$LOG" 2>&1 || { log "no repo diff to PR"; exit 0; }
-    git push -q -u origin auto/model-upgrade >>"$LOG" 2>&1
-    gh pr create --base main --head auto/model-upgrade \
-       --title "fix(litellm): auto-swap retired Ollama model(s)" \
-       --body "Automated by the weekly model-health check. The replacement was verified against Ollama Cloud and every tier smoke-tested on the box before this PR." >>"$LOG" 2>&1 \
-       && log "PR opened" || log "PR create skipped (maybe one already open)"
+    "$mutate" "$wt" || exit 1
+    git commit -q -m "$title" \
+        -m "Opened by scripts/weekly_model_check.sh." >>"$LOG" 2>&1 || { log "no repo diff to PR ($branch)"; exit 0; }
+    # The branch is bot-owned and recreated from origin/main every run, so a stale remote head is
+    # replaced rather than left to fail the push (which used to drop the PR silently).
+    git push -q -u origin "$branch" >>"$LOG" 2>&1 || git push -q -f -u origin "$branch" >>"$LOG" 2>&1
+    gh pr create --base main --head "$branch" --title "$title" --body "$body" >>"$LOG" 2>&1 \
+       && log "PR opened ($branch)" || log "PR create skipped ($branch; maybe one already open)"
   )
   ( cd "$REPO" && git worktree remove --force "$wt" 2>/dev/null ) || true
+}
+
+mutate_swap(){  # re-plan against the worktree's own config so the PR diff matches the box change
+  "${PY[@]}" "$REPO/scripts/model_health_check.py" --apply "$1/.litellm/config.yaml" \
+      --config "$1/.litellm/config.yaml" --map "$1/.litellm/model_upgrades.yaml" >>"$LOG" 2>&1
+  git add .litellm/config.yaml
+}
+
+mutate_catalog(){  # pre-approve upcoming retirements + refresh the committed catalog snapshot
+  "${PY[@]}" "$REPO/scripts/model_health_check.py" --catalog-scan --catalog-apply \
+      --config "$1/.litellm/config.yaml" --map "$1/.litellm/model_upgrades.yaml" \
+      --snapshot "$1/.litellm/ollama_catalog_snapshot.json" --no-usage-levels >>"$LOG" 2>&1
+  git add .litellm/model_upgrades.yaml .litellm/ollama_catalog_snapshot.json
 }
 
 log "=== weekly model-health check start ==="
@@ -95,6 +115,11 @@ log "=== weekly model-health check start ==="
 set -a; source <(sudo -n grep -E "^(OLLAMA_CLOUD_URL|OLLAMA_CLOUD_API_KEY)=" /opt/lem/.env); set +a
 
 cd "$REPO"
+# The upgrade map this run READS is the cron clone's copy, and last week's pre-approved mapping only
+# reaches it once its PR merged — fast-forward so an approved swap actually fires. Best-effort: a
+# dirty or detached clone just keeps working with what it has.
+git pull -q --ff-only >>"$LOG" 2>&1 || log "repo fast-forward skipped (clone not on a clean main?)"
+
 PLAN="$("${PY[@]}" scripts/model_health_check.py --plan-json --config "$BOX_CFG" --map "$MAP" 2>>"$LOG")"
 [ -z "$PLAN" ] && { log "planner produced no output — aborting"; exit 1; }
 NSWAP=$(printf '%s' "$PLAN" | python3 -c "import sys,json;print(len(json.load(sys.stdin)['swaps']))" 2>/dev/null || echo 0)
@@ -115,7 +140,9 @@ if [ "$NSWAP" -gt 0 ]; then
   restart_litellm
   if smoke; then
     log "swaps verified — keeping"
-    open_pr
+    open_pr "auto/model-upgrade" "fix(litellm): auto-swap retired Ollama model(s)" \
+      "Automated by the weekly model-health check. The replacement was verified against Ollama Cloud and every tier smoke-tested on the box before this PR." \
+      mutate_swap
     alert "Applied + verified $NSWAP model swap(s); PR opened to make it durable."
   else
     log "smoke FAILED after swaps — rolling back to $BK"
@@ -130,6 +157,45 @@ else
     log "no swaps but a tier failed — restarting litellm (likely stale config after a deploy)"
     restart_litellm
     if smoke; then log "recovered after restart"; else alert "Tiers still failing after litellm restart — manual review."; fi
+  fi
+fi
+
+# ── proactive scan: published retirement schedule + live catalog (issue #716) ────────────────
+# Read-only against the box; the only writes are a PR and GitHub issues. Any fetch failure inside
+# the scanner degrades to "skip that source" — the 410 probe above stays the backstop, so this
+# block must never be allowed to fail the run.
+CAT="$("${PY[@]}" scripts/model_health_check.py --catalog-json --config "$BOX_CFG" --map "$MAP" \
+        --snapshot "$SNAP" 2>>"$LOG")"
+if [ -z "$CAT" ]; then
+  log "catalog scan produced no output — skipping (410 probe remains the backstop)"
+else
+  read -r NOTICE NEWTAG NUPG REPOCH <<<"$(printf '%s' "$CAT" | python3 -c "
+import sys, json
+p = json.load(sys.stdin)
+print(len(p['notices']), len(p['catalog']['added']), len(p['upgrades']), int(bool(p['repo_changes'])))
+" 2>/dev/null || echo "0 0 0 0")"
+  log "catalog scan: retirement-notices=$NOTICE new-tags=$NEWTAG family-upgrades=$NUPG repo-changes=$REPOCH"
+
+  if [ "${NOTICE:-0}" -gt 0 ]; then
+    MSG=$(printf '%s' "$CAT" | python3 -c "
+import sys, json
+for n in json.load(sys.stdin)['notices']:
+    print(f\"{n['group']}: {n['bare']} retires {n['date']} (in {n['days_until']} days) -> \"
+          f\"{n['alternative'] or 'NO published alternative — needs a manual call'}\")
+")
+    alert "Ollama Cloud retirements scheduled for models we still run:"$'\n'"$MSG"
+  fi
+
+  if [ "${REPOCH:-0}" -gt 0 ]; then
+    open_pr "auto/ollama-catalog" \
+      "chore(litellm): pre-approve upcoming Ollama retirements + refresh catalog snapshot" \
+      "Automated by the weekly model-health check (issue #716). Appends the vendor's own recommended replacement for any configured model with a published retirement date, so the swap is pre-approved before the 410, and refreshes .litellm/ollama_catalog_snapshot.json." \
+      mutate_catalog
+  fi
+
+  if [ "${NEWTAG:-0}" -gt 0 ] || [ "${NUPG:-0}" -gt 0 ]; then
+    "${PY[@]}" scripts/model_health_check.py --file-issues --config "$BOX_CFG" --map "$MAP" \
+        --snapshot "$SNAP" >>"$LOG" 2>&1 || log "issue filing failed (non-fatal)"
   fi
 fi
 log "=== weekly model-health check done ==="

--- a/scripts/weekly_model_check.sh
+++ b/scripts/weekly_model_check.sh
@@ -194,8 +194,16 @@ for n in json.load(sys.stdin)['notices']:
   fi
 
   if [ "${NEWTAG:-0}" -gt 0 ] || [ "${NUPG:-0}" -gt 0 ]; then
-    "${PY[@]}" scripts/model_health_check.py --file-issues --config "$BOX_CFG" --map "$MAP" \
-        --snapshot "$SNAP" >>"$LOG" 2>&1 || log "issue filing failed (non-fatal)"
+    # File from the plan we ALREADY have, not a fresh scan. A second scan re-reads docs.ollama.com
+    # and /api/tags, and a transient outage there would file nothing and say nothing — while the
+    # snapshot PR opened just above makes those tags no longer "new", so the issue would be lost for
+    # good rather than retried next week.
+    PLANF="$(mktemp)"; printf '%s' "$CAT" >"$PLANF"
+    "${PY[@]}" scripts/model_health_check.py --file-issues --plan-file "$PLANF" >>"$LOG" 2>&1
+    RC=$?
+    rm -f "$PLANF"
+    # 0/2/3 are the planner's own nothing/actions/alerts codes — only anything else is a failure.
+    case "$RC" in 0|2|3) ;; *) log "issue filing failed (non-fatal, rc=$RC)";; esac
   fi
 fi
 log "=== weekly model-health check done ==="

--- a/tests/unit/fixtures/ollama/cloud.md
+++ b/tests/unit/fixtures/ollama/cloud.md
@@ -1,0 +1,284 @@
+> ## Documentation Index
+> Fetch the complete documentation index at: https://docs.ollama.com/llms.txt
+> Use this file to discover all available pages before exploring further.
+
+# Cloud
+
+## Cloud Models
+
+Ollama's cloud models are a new kind of model in Ollama that can run without a powerful GPU. Instead, cloud models are automatically offloaded to Ollama's cloud service while offering the same capabilities as local models, making it possible to keep using your local tools while running larger models that wouldn't fit on a personal computer.
+
+### Supported models
+
+For a list of supported models, see Ollama's [model library](https://ollama.com/search?c=cloud).
+
+### Running Cloud models
+
+Ollama's cloud models require an account on [ollama.com](https://ollama.com). To sign in or create an account, run:
+
+```
+ollama signin
+```
+
+<Tabs>
+  <Tab title="CLI">
+    To run a cloud model, open the terminal and run:
+
+    ```
+    ollama run gpt-oss:120b-cloud
+    ```
+  </Tab>
+
+  <Tab title="Python">
+    First, pull a cloud model so it can be accessed:
+
+    ```
+    ollama pull gpt-oss:120b-cloud
+    ```
+
+    Next, install [Ollama's Python library](https://github.com/ollama/ollama-python):
+
+    ```
+    pip install ollama
+    ```
+
+    Next, create and run a simple Python script:
+
+    ```python theme={"system"}
+    from ollama import Client
+
+    client = Client()
+
+    messages = [
+      {
+        'role': 'user',
+        'content': 'Why is the sky blue?',
+      },
+    ]
+
+    for part in client.chat('gpt-oss:120b-cloud', messages=messages, stream=True):
+      print(part['message']['content'], end='', flush=True)
+    ```
+  </Tab>
+
+  <Tab title="JavaScript">
+    First, pull a cloud model so it can be accessed:
+
+    ```
+    ollama pull gpt-oss:120b-cloud
+    ```
+
+    Next, install [Ollama's JavaScript library](https://github.com/ollama/ollama-js):
+
+    ```
+    npm i ollama
+    ```
+
+    Then use the library to run a cloud model:
+
+    ```typescript theme={"system"}
+    import { Ollama } from "ollama";
+
+    const ollama = new Ollama();
+
+    const response = await ollama.chat({
+      model: "gpt-oss:120b-cloud",
+      messages: [{ role: "user", content: "Explain quantum computing" }],
+      stream: true,
+    });
+
+    for await (const part of response) {
+      process.stdout.write(part.message.content);
+    }
+    ```
+  </Tab>
+
+  <Tab title="cURL">
+    First, pull a cloud model so it can be accessed:
+
+    ```
+    ollama pull gpt-oss:120b-cloud
+    ```
+
+    Run the following cURL command to run the command via Ollama's API:
+
+    ```
+    curl http://localhost:11434/api/chat -d '{
+      "model": "gpt-oss:120b-cloud",
+      "messages": [{
+        "role": "user",
+        "content": "Why is the sky blue?"
+      }],
+      "stream": false
+    }'
+    ```
+  </Tab>
+</Tabs>
+
+## Cloud API access
+
+Cloud models can also be accessed directly on ollama.com's API. In this mode, ollama.com acts as a remote Ollama host.
+
+### Authentication
+
+For direct access to ollama.com's API, first create an [API key](https://ollama.com/settings/keys).
+
+Then, set the `OLLAMA_API_KEY` environment variable to your API key.
+
+```
+export OLLAMA_API_KEY=your_api_key
+```
+
+### Listing models
+
+For models available directly via Ollama's API, models can be listed via:
+
+```
+curl https://ollama.com/api/tags
+```
+
+### Generating a response
+
+<Tabs>
+  <Tab title="Python">
+    First, install [Ollama's Python library](https://github.com/ollama/ollama-python)
+
+    ```
+    pip install ollama
+    ```
+
+    Then make a request
+
+    ```python theme={"system"}
+    import os
+    from ollama import Client
+
+    client = Client(
+        host="https://ollama.com",
+        headers={'Authorization': 'Bearer ' + os.environ.get('OLLAMA_API_KEY')}
+    )
+
+    messages = [
+      {
+        'role': 'user',
+        'content': 'Why is the sky blue?',
+      },
+    ]
+
+    for part in client.chat('gpt-oss:120b', messages=messages, stream=True):
+      print(part['message']['content'], end='', flush=True)
+    ```
+  </Tab>
+
+  <Tab title="JavaScript">
+    First, install [Ollama's JavaScript library](https://github.com/ollama/ollama-js):
+
+    ```
+    npm i ollama
+    ```
+
+    Next, make a request to the model:
+
+    ```typescript theme={"system"}
+    import { Ollama } from "ollama";
+
+    const ollama = new Ollama({
+      host: "https://ollama.com",
+      headers: {
+        Authorization: "Bearer " + process.env.OLLAMA_API_KEY,
+      },
+    });
+
+    const response = await ollama.chat({
+      model: "gpt-oss:120b",
+      messages: [{ role: "user", content: "Explain quantum computing" }],
+      stream: true,
+    });
+
+    for await (const part of response) {
+      process.stdout.write(part.message.content);
+    }
+    ```
+  </Tab>
+
+  <Tab title="cURL">
+    Generate a response via Ollama's chat API:
+
+    ```
+    curl https://ollama.com/api/chat \
+      -H "Authorization: Bearer $OLLAMA_API_KEY" \
+      -d '{
+        "model": "gpt-oss:120b",
+        "messages": [{
+          "role": "user",
+          "content": "Why is the sky blue?"
+        }],
+        "stream": false
+      }'
+    ```
+  </Tab>
+</Tabs>
+
+## Local only
+
+Ollama can run in local-only mode by [disabling Ollama's cloud](./faq#how-do-i-disable-ollama-cloud) features.
+
+## Retirements
+
+Ollama will occasionally deprecate and retire older cloud models as newer and better open-source models are released.
+Tools and applications relying on Ollama Cloud models may need to be updated to keep working. Impacted users will be
+notified in advance of model deprecation and retirement. Deprecations will be communicated through email and on the
+Ollama website.
+
+Ollama Cloud model retirement does not affect local models.
+
+### Upcoming retirements
+
+| Retirement date | Model          | Recommended alternative |
+| --------------- | -------------- | ----------------------- |
+| July 31, 2026   | `minimax-m2.5` | `minimax-m2.7`          |
+| July 31, 2026   | `kimi-k2.5`    | `kimi-k2.6`             |
+
+### Past retirements
+
+<AccordionGroup>
+  <Accordion title="July 15, 2026">
+    | Model                    | Recommended alternative |
+    | ------------------------ | ----------------------- |
+    | `deepseek-v3.1:671b`     | `deepseek-v4-flash`     |
+    | `deepseek-v3.2`          | `deepseek-v4-flash`     |
+    | `devstral-2:123b`        | `mistral-large-3:675b`  |
+    | `devstral-small-2:24b`   |                         |
+    | `ministral-3:14b`        |                         |
+    | `ministral-3:3b`         |                         |
+    | `ministral-3:8b`         |                         |
+    | `gemini-3-flash-preview` | `minimax-m3`            |
+    | `gemma3:12b`             | `gemma4:31b`            |
+    | `gemma3:27b`             | `gemma4:31b`            |
+    | `gemma3:4b`              | `gemma4:31b`            |
+    | `glm-4.7`                | `glm-5.2`               |
+    | `glm-5`                  | `glm-5.2`               |
+    | `minimax-m2.1`           | `minimax-m3`            |
+    | `qwen3-coder-next`       | `qwen3.5:397b`          |
+    | `qwen3-coder:480b`       | `qwen3.5:397b`          |
+  </Accordion>
+
+  <Accordion title="June 30, 2026">
+    | Model      | Recommended alternative |
+    | ---------- | ----------------------- |
+    | `rnj-1:8b` |                         |
+  </Accordion>
+
+  <Accordion title="June 16, 2026">
+    | Model                    | Recommended alternative |
+    | ------------------------ | ----------------------- |
+    | `kimi-k2-thinking`       | `kimi-k2.6`             |
+    | `kimi-k2:1t`             | `kimi-k2.6`             |
+    | `minimax-m2`             | `minimax-m3`            |
+    | `glm-4.6`                | `glm-5.1`               |
+    | `qwen3-next:80b`         | `qwen3.5`               |
+    | `qwen3-vl:235b`          | `qwen3.5`               |
+    | `qwen3-vl:235b-instruct` | `qwen3.5`               |
+    | `cogito-2.1:671b`        | `deepseek-v4-flash`     |
+  </Accordion>
+</AccordionGroup>

--- a/tests/unit/fixtures/ollama/tags.json
+++ b/tests/unit/fixtures/ollama/tags.json
@@ -1,0 +1,274 @@
+{
+    "models": [
+        {
+            "name": "glm-5.1",
+            "model": "glm-5.1",
+            "modified_at": "2026-04-07T08:00:00-07:00",
+            "size": 1507728316928,
+            "digest": "882e35812821",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "minimax-m3",
+            "model": "minimax-m3",
+            "modified_at": "2026-06-01T00:00:00Z",
+            "size": 0,
+            "digest": "9ce5291d9c0e",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "gemma4:31b",
+            "model": "gemma4:31b",
+            "modified_at": "2026-04-02T09:00:00-08:00",
+            "size": 62546177752,
+            "digest": "221b330d11a8",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "nemotron-3-super",
+            "model": "nemotron-3-super",
+            "modified_at": "2026-03-11T00:00:00Z",
+            "size": 230500000000,
+            "digest": "da11955bb451",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "gpt-oss:20b",
+            "model": "gpt-oss:20b",
+            "modified_at": "2025-08-05T00:00:00Z",
+            "size": 13780162412,
+            "digest": "05afbac4bad6",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "minimax-m2.5",
+            "model": "minimax-m2.5",
+            "modified_at": "2026-02-12T00:00:00Z",
+            "size": 230000000000,
+            "digest": "1361fbbdd94e",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "kimi-k2.5",
+            "model": "kimi-k2.5",
+            "modified_at": "2026-01-26T00:00:00Z",
+            "size": 1118481408000,
+            "digest": "89c148d8ace8",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "qwen3.5:397b",
+            "model": "qwen3.5:397b",
+            "modified_at": "2026-02-16T00:00:00Z",
+            "size": 397000000000,
+            "digest": "b909ca2f1b7f",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "glm-5.2",
+            "model": "glm-5.2",
+            "modified_at": "2026-06-16T08:00:00-07:00",
+            "size": 0,
+            "digest": "f553240f6dc4",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "nemotron-3-nano:30b",
+            "model": "nemotron-3-nano:30b",
+            "modified_at": "2025-12-15T00:00:00Z",
+            "size": 32645090390,
+            "digest": "a4b4f1851393",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "nemotron-3-ultra",
+            "model": "nemotron-3-ultra",
+            "modified_at": "2026-06-04T00:00:00Z",
+            "size": 0,
+            "digest": "4eecabff7a75",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "kimi-k2.6",
+            "model": "kimi-k2.6",
+            "modified_at": "2026-03-31T00:00:00Z",
+            "size": 595148192736,
+            "digest": "4764ecb21f85",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "deepseek-v4-pro",
+            "model": "deepseek-v4-pro",
+            "modified_at": "2026-04-24T00:00:00Z",
+            "size": 1600000000000,
+            "digest": "079ba36ea28c",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "deepseek-v4-flash",
+            "model": "deepseek-v4-flash",
+            "modified_at": "2026-04-24T00:00:00Z",
+            "size": 140000000000,
+            "digest": "ac252c581d64",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "minimax-m2.7",
+            "model": "minimax-m2.7",
+            "modified_at": "2026-03-18T00:00:00Z",
+            "size": 480836588544,
+            "digest": "d1008bea3761",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "kimi-k2.7-code",
+            "model": "kimi-k2.7-code",
+            "modified_at": "2026-06-12T00:00:00Z",
+            "size": 595148192736,
+            "digest": "1a7e88d8c572",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "gpt-oss:120b",
+            "model": "gpt-oss:120b",
+            "modified_at": "2025-08-05T00:00:00Z",
+            "size": 65290180781,
+            "digest": "d98fe6ba01e6",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        },
+        {
+            "name": "mistral-large-3:675b",
+            "model": "mistral-large-3:675b",
+            "modified_at": "2025-12-02T00:00:00Z",
+            "size": 682000000000,
+            "digest": "f7e3b2a16d5c",
+            "details": {
+                "parent_model": "",
+                "format": "",
+                "family": "",
+                "families": null,
+                "parameter_size": "",
+                "quantization_level": ""
+            }
+        }
+    ]
+}

--- a/tests/unit/fixtures/ollama/usage/deepseek-v4-pro.html
+++ b/tests/unit/fixtures/ollama/usage/deepseek-v4-pro.html
@@ -1,0 +1,44 @@
+<div  class="!mt-8 grid grid-cols-3 overflow-hidden rounded-lg border border-neutral-200 bg-white">
+  
+  
+	  <div   class="min-h-24 min-w-0 border-neutral-200 px-4 py-3 md:px-5 md:py-4 border-r">
+    <div class="text-[13px] font-medium text-neutral-500">Usage</div>
+    
+    <div class="mt-3 flex min-w-0 flex-col gap-1">
+      <div   class="flex h-5 items-center gap-1">
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-900"></span>
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-900"></span>
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-900"></span>
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-900"></span>
+        
+      </div>
+      
+      <span class="min-w-0 break-words text-xs leading-tight text-neutral-700 sm:text-[14px] sm:leading-5">extra high</span>
+      
+    </div>
+    
+  </div>
+  
+	  <div   class="min-h-24 min-w-0 border-neutral-200 px-4 py-3 md:px-5 md:py-4 border-r">
+    <div class="text-[13px] font-medium text-neutral-500">Context</div>
+    
+    <div class="mt-3 flex min-w-0 flex-col gap-1">
+      <span class="shrink-0 text-xl font-medium leading-none text-black">1M</span>
+      
+      <span class="min-w-0 break-words text-[13px] leading-tight text-neutral-700 sm:text-sm">tokens</span>
+      
+    </div>
+    
+  </div>
+  
+	  <div   class="min-h-24 min-w-0 border-neutral-200 px-4 py-3 md:px-5 md:py-4 ">
+    <div class="text-[13px] font-medium text-neutral-500">Size</div>
+    
+    <div class="mt-3 flex min-w-0 flex-col gap-1">
+      <span class="shrink-0 text-xl font-medium leading-none text-black">1.6T</span>
+      
+      

--- a/tests/unit/fixtures/ollama/usage/minimax-m2.7.html
+++ b/tests/unit/fixtures/ollama/usage/minimax-m2.7.html
@@ -1,0 +1,44 @@
+<div  class="!mt-8 grid grid-cols-3 overflow-hidden rounded-lg border border-neutral-200 bg-white">
+  
+  
+	  <div   class="min-h-24 min-w-0 border-neutral-200 px-4 py-3 md:px-5 md:py-4 border-r">
+    <div class="text-[13px] font-medium text-neutral-500">Usage</div>
+    
+    <div class="mt-3 flex min-w-0 flex-col gap-1">
+      <div   class="flex h-5 items-center gap-1">
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-900"></span>
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-900"></span>
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-200"></span>
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-200"></span>
+        
+      </div>
+      
+      <span class="min-w-0 break-words text-xs leading-tight text-neutral-700 sm:text-[14px] sm:leading-5">medium</span>
+      
+    </div>
+    
+  </div>
+  
+	  <div   class="min-h-24 min-w-0 border-neutral-200 px-4 py-3 md:px-5 md:py-4 border-r">
+    <div class="text-[13px] font-medium text-neutral-500">Context</div>
+    
+    <div class="mt-3 flex min-w-0 flex-col gap-1">
+      <span class="shrink-0 text-xl font-medium leading-none text-black">200K</span>
+      
+      <span class="min-w-0 break-words text-[13px] leading-tight text-neutral-700 sm:text-sm">tokens</span>
+      
+    </div>
+    
+  </div>
+  
+	  <div   class="min-h-24 min-w-0 border-neutral-200 px-4 py-3 md:px-5 md:py-4 ">
+    <div class="text-[13px] font-medium text-neutral-500">Size</div>
+    
+    <div class="mt-3 flex min-w-0 flex-col gap-1">
+      <span class="shrink-0 text-xl font-medium leading-none text-black">229B</span>
+      
+      <s

--- a/tests/unit/fixtures/ollama/usage/minimax-m3.html
+++ b/tests/unit/fixtures/ollama/usage/minimax-m3.html
@@ -1,0 +1,53 @@
+<div  class="!mt-8 grid grid-cols-3 overflow-hidden rounded-lg border border-neutral-200 bg-white">
+  
+  
+	  <div   class="min-h-24 min-w-0 border-neutral-200 px-4 py-3 md:px-5 md:py-4 border-r">
+    <div class="text-[13px] font-medium text-neutral-500">Usage</div>
+    
+    <div class="mt-3 flex min-w-0 flex-col gap-1">
+      <div   class="flex h-5 items-center gap-1">
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-900"></span>
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-900"></span>
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-900"></span>
+        
+        <span  class="block h-1.5 w-5 rounded-full bg-neutral-200"></span>
+        
+      </div>
+      
+      <span class="min-w-0 break-words text-xs leading-tight text-neutral-700 sm:text-[14px] sm:leading-5">high</span>
+      
+    </div>
+    
+  </div>
+  
+	  <div   class="min-h-24 min-w-0 border-neutral-200 px-4 py-3 md:px-5 md:py-4 ">
+    <div class="text-[13px] font-medium text-neutral-500">Context</div>
+    
+    <div class="mt-3 flex min-w-0 flex-col gap-1">
+      <span class="shrink-0 text-xl font-medium leading-none text-black">512K</span>
+      
+      <span class="min-w-0 break-words text-[13px] leading-tight text-neutral-700 sm:text-sm">tokens</span>
+      
+    </div>
+    
+  </div>
+  
+</div>
+
+
+    </div>
+  </div>
+	
+  <div class="py-8">
+    
+      
+
+
+<section data-usage-section class="mb-8">
+  <div class="relative rounded-lg border border-neutral-200 overflow-hidden bg-white">
+    <div class="flex items-center justify-between bg-white pt-1 pl-[7px] pr-3">
+      <div class="flex">
+        <button t

--- a/tests/unit/test_model_health_check.py
+++ b/tests/unit/test_model_health_check.py
@@ -1,6 +1,7 @@
 """Unit tests for scripts/model_health_check.py — the pure planning/rewriting logic."""
 
 import importlib.util
+import json
 import pathlib
 
 import pytest
@@ -8,10 +9,14 @@ import pytest
 pytestmark = pytest.mark.unit
 
 # The tool lives under scripts/ (not an importable package) — load it by path.
-_PATH = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "model_health_check.py"
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_PATH = _ROOT / "scripts" / "model_health_check.py"
 _spec = importlib.util.spec_from_file_location("model_health_check", _PATH)
 mhc = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(mhc)
+
+# Real captures of the two sources the proactive scan reads (issue #716).
+FIXTURES = _ROOT / "tests" / "unit" / "fixtures" / "ollama"
 
 
 def _cfg():
@@ -165,3 +170,625 @@ class TestApplySwaps:
                 "      model: openai/gpt-oss:20b\n")
         new, n = mhc.apply_swaps(text, [{"old": "openai/gpt-oss:20b", "new": "openai/gpt-oss:21b"}])
         assert n == 2 and "20b" not in new
+
+
+# ══════════════════ issue #716 — proactive scan (advance retirements, catalog, families) ═════════
+
+def _cloud_md():
+    return (FIXTURES / "cloud.md").read_text()
+
+
+def _tags():
+    return json.loads((FIXTURES / "tags.json").read_text())
+
+
+def _ollama_cfg(*models):
+    return {"model_list": [
+        {"model_name": "lem-medium", "litellm_params": {
+            "model": f"openai/{m}", "api_base": "os.environ/OLLAMA_CLOUD_URL"}}
+        for m in models]}
+
+
+class TestParseRetirements:
+    def test_real_cloud_md_upcoming_rows(self):
+        rows = mhc.parse_retirements(_cloud_md())
+        upcoming = {r["model"]: r for r in rows if r["upcoming"]}
+        assert upcoming["minimax-m2.5"] == {"model": "minimax-m2.5", "alternative": "minimax-m2.7",
+                                            "date": "2026-07-31", "upcoming": True}
+        assert upcoming["kimi-k2.5"]["alternative"] == "kimi-k2.6"
+
+    def test_past_accordion_rows_inherit_the_accordion_date(self):
+        rows = {r["model"]: r for r in mhc.parse_retirements(_cloud_md()) if not r["upcoming"]}
+        assert rows["kimi-k2:1t"]["date"] == "2026-06-16"       # June 16, 2026 accordion
+        assert rows["ministral-3:8b"]["date"] == "2026-07-15"   # July 15, 2026 accordion
+        assert rows["qwen3-coder:480b"]["alternative"] == "qwen3.5:397b"
+
+    def test_missing_alternative_is_none_not_empty_string(self):
+        rows = {r["model"]: r for r in mhc.parse_retirements(_cloud_md())}
+        assert rows["devstral-small-2:24b"]["alternative"] is None
+
+    def test_header_and_separator_rows_are_not_models(self):
+        names = {r["model"] for r in mhc.parse_retirements(_cloud_md())}
+        assert not any(n.lower() in {"model", "retirement date", "recommended alternative"}
+                       for n in names)
+        assert not any(set(n) <= {"-", ":"} for n in names)
+
+    def test_tables_outside_the_retirements_section_are_ignored(self):
+        md = ("## Something else\n\n| Model | Recommended alternative |\n"
+              "| ----- | ----------------------- |\n| `not-a-retirement` | `x` |\n"
+              "\n## Retirements\n\n### Upcoming retirements\n\n"
+              "| Retirement date | Model | Recommended alternative |\n"
+              "| --- | --- | --- |\n| March 3, 2027 | `real-1` | `real-2` |\n")
+        rows = mhc.parse_retirements(md)
+        assert [r["model"] for r in rows] == ["real-1"]
+        assert rows[0]["date"] == "2027-03-03"
+
+    def test_unparseable_or_empty_input_is_empty(self):
+        assert mhc.parse_retirements("") == []
+        assert mhc.parse_retirements(None) == []
+
+    def test_parse_doc_date_rejects_garbage(self):
+        assert mhc.parse_doc_date("Smarch 3, 2026") is None
+        assert mhc.parse_doc_date("February 31, 2026") is None
+        assert mhc.parse_doc_date("") is None
+
+
+class TestRetirementNotices:
+    def _rows(self, *models):
+        return mhc.parse_deployments(_ollama_cfg(*models))
+
+    def test_future_retirement_of_a_configured_model_alerts_and_maps(self):
+        notices, additions = mhc.plan_retirement_notices(
+            self._rows("minimax-m2.5"), mhc.parse_retirements(_cloud_md()), {}, "2026-07-20",
+            mhc.parse_catalog(_tags()))
+        assert [n["bare"] for n in notices] == ["minimax-m2.5"]
+        assert notices[0]["date"] == "2026-07-31" and notices[0]["days_until"] == 11
+        assert notices[0]["mapped"] is False
+        assert additions == {"minimax-m2.5": "minimax-m2.7"}
+
+    def test_already_past_retirement_is_the_410_probes_job(self):
+        notices, additions = mhc.plan_retirement_notices(
+            self._rows("minimax-m2.5"), mhc.parse_retirements(_cloud_md()), {}, "2026-08-01", None)
+        assert notices == [] and additions == {}
+
+    def test_same_day_is_not_future(self):
+        notices, _ = mhc.plan_retirement_notices(
+            self._rows("minimax-m2.5"), mhc.parse_retirements(_cloud_md()), {}, "2026-07-31", None)
+        assert notices == []
+
+    def test_already_mapped_still_notices_but_adds_nothing(self):
+        notices, additions = mhc.plan_retirement_notices(
+            self._rows("minimax-m2.5"), mhc.parse_retirements(_cloud_md()),
+            {"minimax-m2.5": "minimax-m2.7"}, "2026-07-20", None)
+        assert notices[0]["mapped"] is True
+        assert additions == {}
+
+    def test_alternative_missing_from_the_catalog_is_never_auto_mapped(self):
+        retirements = [{"model": "minimax-m2.5", "alternative": "ghost-model",
+                        "date": "2026-07-31", "upcoming": True}]
+        notices, additions = mhc.plan_retirement_notices(
+            self._rows("minimax-m2.5"), retirements, {}, "2026-07-20", {"minimax-m2.7": {}})
+        assert notices[0]["alternative_in_catalog"] is False
+        assert additions == {}
+
+    def test_no_published_alternative_alerts_without_writing_remove(self):
+        retirements = [{"model": "minimax-m2.5", "alternative": None,
+                        "date": "2026-07-31", "upcoming": True}]
+        notices, additions = mhc.plan_retirement_notices(
+            self._rows("minimax-m2.5"), retirements, {}, "2026-07-20", None)
+        assert notices and notices[0]["alternative"] is None
+        assert additions == {}
+
+    def test_unconfigured_models_are_not_our_problem(self):
+        notices, additions = mhc.plan_retirement_notices(
+            self._rows("gpt-oss:20b"), mhc.parse_retirements(_cloud_md()), {}, "2026-07-20", None)
+        assert notices == [] and additions == {}
+
+    def test_non_ollama_deployment_is_never_noticed(self):
+        cfg = {"model_list": [{"model_name": "lem-medium", "litellm_params": {
+            "model": "openai/minimax-m2.5", "api_key": "os.environ/OPENAI_API_KEY"}}]}
+        notices, _ = mhc.plan_retirement_notices(
+            mhc.parse_deployments(cfg), mhc.parse_retirements(_cloud_md()), {}, "2026-07-20", None)
+        assert notices == []
+
+
+class TestAppendUpgradeMappings:
+    MAP = ('# header comment\nupgrades:\n  # existing\n  "kimi-k2:1t": "REMOVE"\n')
+
+    def test_appends_inside_the_block_and_keeps_comments(self):
+        text, added = mhc.append_upgrade_mappings(self.MAP, {"minimax-m2.5": "minimax-m2.7"},
+                                                  "2026-07-20")
+        assert added == ["minimax-m2.5"]
+        assert "# header comment" in text and '"kimi-k2:1t": "REMOVE"' in text
+        assert '  "minimax-m2.5": "minimax-m2.7"' in text
+        assert mhc.load_map(mhc.load_map_text(text)) == {"kimi-k2:1t": "REMOVE",
+                                                         "minimax-m2.5": "minimax-m2.7"}
+
+    def test_existing_key_is_never_duplicated(self):
+        text, added = mhc.append_upgrade_mappings(self.MAP, {"kimi-k2:1t": "kimi-k2.6"},
+                                                  "2026-07-20")
+        assert added == [] and text == self.MAP
+
+    def test_is_idempotent(self):
+        once, _ = mhc.append_upgrade_mappings(self.MAP, {"a": "b"}, "2026-07-20")
+        twice, added = mhc.append_upgrade_mappings(once, {"a": "b"}, "2026-07-21")
+        assert twice == once and added == []
+
+    def test_creates_the_block_when_the_file_has_none(self):
+        text, added = mhc.append_upgrade_mappings("# only a comment\n", {"a": "b"}, "2026-07-20")
+        assert added == ["a"]
+        assert mhc.load_map(mhc.load_map_text(text)) == {"a": "b"}
+
+    def test_does_not_append_past_the_block_into_a_later_section(self):
+        src = 'upgrades:\n  "a": "b"\n\nother:\n  "x": "y"\n'
+        text, _ = mhc.append_upgrade_mappings(src, {"c": "d"}, "2026-07-20")
+        assert text.index('"c": "d"') < text.index("other:")
+        assert mhc.load_map(mhc.load_map_text(text)) == {"a": "b", "c": "d"}
+
+
+class TestCatalogSnapshot:
+    def test_parse_catalog_from_the_real_tags_payload(self):
+        catalog = mhc.parse_catalog(_tags())
+        assert "minimax-m3" in catalog and "gpt-oss:20b" in catalog
+        assert catalog["gpt-oss:20b"]["size"] > 0
+
+    def test_parse_catalog_tolerates_junk_rows(self):
+        assert mhc.parse_catalog({"models": [None, {}, {"name": "  "}, {"model": "x"}]}) == {
+            "x": {"modified_at": "", "size": 0, "parameter_size": "", "family": ""}}
+        assert mhc.parse_catalog(None) == {}
+
+    def test_snapshot_round_trip(self):
+        catalog = mhc.parse_catalog(_tags())
+        assert mhc.load_snapshot_text(mhc.render_snapshot(catalog, "2026-07-27")) == catalog
+
+    def test_snapshot_of_unreadable_json_is_empty_not_an_exception(self):
+        assert mhc.load_snapshot_text("{not json") == {}
+
+    def test_diff_reports_added_and_removed(self):
+        assert mhc.diff_catalog({"a": {}, "b": {}}, {"b": {}, "c": {}}) == {"added": ["c"],
+                                                                            "removed": ["a"]}
+
+    def test_committed_snapshot_matches_the_real_catalog_shape(self):
+        snapshot = mhc.load_snapshot_text((_ROOT / ".litellm"
+                                           / "ollama_catalog_snapshot.json").read_text())
+        assert snapshot, "the committed snapshot must not be empty — an empty one files every tag"
+        assert "gpt-oss:20b" in snapshot  # a model config.yaml actually runs
+
+
+class TestParseModelVersion:
+    @pytest.mark.parametrize("name,family,version,size_tag", [
+        ("minimax-m2.7", "minimax", (2, 7), ""),
+        ("minimax-m3", "minimax", (3,), ""),
+        ("qwen3.5:397b", "qwen", (3, 5), "397b"),
+        ("glm-5.1", "glm", (5, 1), ""),
+        ("glm-5.2", "glm", (5, 2), ""),
+        ("kimi-k2.6", "kimi", (2, 6), ""),
+        ("kimi-k2.7-code", "kimi-code", (2, 7), ""),
+        ("kimi-k2:1t", "kimi", (2,), "1t"),
+        ("gemma4:31b", "gemma", (4,), "31b"),
+        ("gemma3:12b", "gemma", (3,), "12b"),
+        ("deepseek-v4-flash", "deepseek-flash", (4,), ""),
+        ("deepseek-v4-pro", "deepseek-pro", (4,), ""),
+        ("nemotron-3-nano:30b", "nemotron-nano", (3,), "30b"),
+        ("nemotron-3-super", "nemotron-super", (3,), ""),
+        ("nemotron-3-ultra", "nemotron-ultra", (3,), ""),
+        ("mistral-large-3:675b", "mistral-large", (3,), "675b"),
+        ("qwen3-coder:480b", "qwen-coder", (3,), "480b"),
+        ("ministral-3:8b", "ministral", (3,), "8b"),
+        ("gpt-oss:20b", "gpt-oss", None, "20b"),      # size-tagged, not versioned
+        ("gpt-oss:120b", "gpt-oss", None, "120b"),
+    ])
+    def test_real_catalog_names(self, name, family, version, size_tag):
+        assert mhc.parse_model_version(name) == (family, version, size_tag)
+
+    def test_every_live_catalog_tag_parses(self):
+        for name in mhc.parse_catalog(_tags()):
+            family, _version, _tag = mhc.parse_model_version(name)
+            assert family, name
+
+    def test_empty_input(self):
+        assert mhc.parse_model_version("") == ("", None, "")
+        assert mhc.parse_model_version(None) == ("", None, "")
+
+    def test_version_str(self):
+        assert mhc.version_str((2, 7)) == "2.7"
+        assert mhc.version_str(None) == "unversioned"
+        assert mhc.version_str(()) == "unversioned"
+
+
+class TestPlanFamilyUpgrades:
+    def _rows(self, *models):
+        return mhc.parse_deployments(_ollama_cfg(*models))
+
+    def test_major_bump_against_the_real_catalog(self):
+        out = mhc.plan_family_upgrades(self._rows("minimax-m2.7"), mhc.parse_catalog(_tags()))
+        assert len(out) == 1
+        assert out[0]["candidate"] == "minimax-m3" and out[0]["urgency"] == "major"
+        assert out[0]["groups"] == ["lem-medium"]
+
+    def test_minor_bump_is_reported_at_lower_urgency(self):
+        out = mhc.plan_family_upgrades(self._rows("glm-5.1"), mhc.parse_catalog(_tags()))
+        assert out[0]["candidate"] == "glm-5.2" and out[0]["urgency"] == "minor"
+
+    def test_current_newest_produces_nothing(self):
+        assert mhc.plan_family_upgrades(self._rows("minimax-m3"), mhc.parse_catalog(_tags())) == []
+        assert mhc.plan_family_upgrades(self._rows("qwen3.5:397b"),
+                                        mhc.parse_catalog(_tags())) == []
+
+    def test_a_variant_is_never_offered_as_the_base_models_upgrade(self):
+        # kimi-k2.7-code is a coding variant, not a newer kimi-k2.6.
+        assert mhc.plan_family_upgrades(self._rows("kimi-k2.6"), mhc.parse_catalog(_tags())) == []
+
+    def test_size_tagged_unversioned_model_with_no_versioned_sibling_is_skipped(self):
+        assert mhc.plan_family_upgrades(self._rows("gpt-oss:20b"), mhc.parse_catalog(_tags())) == []
+
+    def test_unversioned_current_with_a_versioned_sibling_is_a_major(self):
+        out = mhc.plan_family_upgrades(self._rows("gpt-oss:20b"), {"gpt-oss2": {}})
+        assert out[0]["urgency"] == "major" and out[0]["current_version"] == "unversioned"
+
+    def test_a_retiring_candidate_is_never_recommended(self):
+        catalog = {"minimax-m2.5": {}, "minimax-m2.7": {}}
+        out = mhc.plan_family_upgrades(self._rows("minimax-m2.5"), catalog,
+                                       retiring={"minimax-m2.7"})
+        assert out == []
+
+    def test_non_ollama_deployments_are_ignored(self):
+        cfg = {"model_list": [{"model_name": "lem-medium", "litellm_params": {
+            "model": "openai/minimax-m2.7", "api_key": "os.environ/OPENAI_API_KEY"}}]}
+        assert mhc.plan_family_upgrades(mhc.parse_deployments(cfg),
+                                        mhc.parse_catalog(_tags())) == []
+
+    def test_duplicate_deployments_report_once_with_every_tier(self):
+        cfg = {"model_list": [
+            {"model_name": "lem-medium", "litellm_params": {
+                "model": "openai/minimax-m2.7", "api_base": "os.environ/OLLAMA_CLOUD_URL"}},
+            {"model_name": "lem-complex", "litellm_params": {
+                "model": "openai/minimax-m2.7", "api_base": "os.environ/OLLAMA_CLOUD_URL"}}]}
+        out = mhc.plan_family_upgrades(mhc.parse_deployments(cfg), mhc.parse_catalog(_tags()))
+        assert len(out) == 1 and out[0]["groups"] == ["lem-complex", "lem-medium"]
+
+    def test_usage_levels_ride_along_and_flag_a_tier_jump(self):
+        levels = {"minimax-m2.7": {"level": 2, "label": "medium"},
+                  "minimax-m3": {"level": 3, "label": "high"}}
+        out = mhc.plan_family_upgrades(self._rows("minimax-m2.7"), mhc.parse_catalog(_tags()),
+                                       usage_lookup=lambda m: levels.get(m))
+        assert out[0]["usage_jump"] is True
+        assert out[0]["candidate_usage"]["label"] == "high"
+
+    def test_an_unreadable_usage_page_is_none_not_no_jump(self):
+        def boom(_model):
+            raise RuntimeError("ollama.com down")
+
+        out = mhc.plan_family_upgrades(self._rows("minimax-m2.7"), mhc.parse_catalog(_tags()),
+                                       usage_lookup=boom)
+        assert out[0]["usage_jump"] is None
+
+
+class TestParseUsageLevel:
+    def test_real_model_pages(self):
+        assert mhc.parse_usage_level((FIXTURES / "usage" / "minimax-m2.7.html").read_text()) == {
+            "level": 2, "label": "medium"}
+        assert mhc.parse_usage_level((FIXTURES / "usage" / "minimax-m3.html").read_text()) == {
+            "level": 3, "label": "high"}
+        assert mhc.parse_usage_level((FIXTURES / "usage" / "deepseek-v4-pro.html").read_text()) == {
+            "level": 4, "label": "extra high"}
+
+    def test_missing_usage_block(self):
+        assert mhc.parse_usage_level("<html><body>nothing</body></html>") == {"level": None,
+                                                                              "label": None}
+        assert mhc.parse_usage_level("") == {"level": None, "label": None}
+
+    def test_reading_stops_before_the_next_stat(self):
+        # "low" appears only AFTER the Context label — it must not be read as the usage level.
+        html = ('<div>Usage</div><span class="bg-neutral-900"></span>'
+                '<div>Context</div><span>low</span>')
+        assert mhc.parse_usage_level(html) == {"level": 1, "label": None}
+
+
+class TestIssueRendering:
+    UPGRADES = [{"family": "minimax", "groups": ["lem-medium"], "current": "minimax-m2.7",
+                 "current_version": "2.7", "candidate": "minimax-m3", "candidate_version": "3",
+                 "urgency": "major", "current_usage": {"level": 2, "label": "medium"},
+                 "candidate_usage": {"level": 3, "label": "high"}, "usage_jump": True}]
+
+    def test_upgrade_marker_and_title(self):
+        assert mhc.upgrade_marker(self.UPGRADES[0]) == "minimax-m2.7 -> minimax-m3"
+        title = mhc.build_upgrade_issue_title(self.UPGRADES)
+        assert title.startswith(mhc.UPGRADE_TITLE_PREFIX)
+        assert "minimax-m2.7 -> minimax-m3" in title
+
+    def test_upgrade_body_names_the_usage_jump_and_the_never_auto_swap_rule(self):
+        body = mhc.build_upgrade_issue_body(self.UPGRADES, "2026-07-27")
+        assert "minimax-m2.7 -> minimax-m3" in body
+        assert "medium (level 2)" in body and "high (level 3)" in body
+        assert "usage level goes UP" in body
+        assert "model_upgrades.yaml" in body  # says explicitly not to add it there
+
+    def test_unknown_usage_is_worded_as_unknown_not_as_no_jump(self):
+        upgrade = {**self.UPGRADES[0], "usage_jump": None,
+                   "current_usage": {"level": None, "label": None},
+                   "candidate_usage": {"level": None, "label": None}}
+        assert "usage level unknown" in mhc.build_upgrade_issue_body([upgrade], "2026-07-27")
+
+    def test_minor_upgrades_get_their_own_section(self):
+        minor = {**self.UPGRADES[0], "urgency": "minor"}
+        body = mhc.build_upgrade_issue_body([minor], "2026-07-27")
+        assert "Minor/patch behind" in body and "Major version behind" not in body
+
+    def test_eval_title_and_body_from_the_real_catalog(self):
+        catalog = mhc.parse_catalog(_tags())
+        title = mhc.build_eval_issue_title(["minimax-m3", "glm-5.2"])
+        assert title == f"{mhc.EVAL_TITLE_PREFIX} minimax-m3, glm-5.2"
+        body = mhc.build_eval_issue_body(["minimax-m3"], catalog, "2026-07-27")
+        assert "`minimax-m3`" in body and "family `minimax`" in body
+
+    def test_long_title_is_truncated_but_the_body_keeps_every_marker(self):
+        names = [f"some-rather-long-model-name-{i}" for i in range(12)]
+        title = mhc.build_eval_issue_title(names)
+        assert len(title) <= mhc.MAX_TITLE_CHARS
+        assert "more)" in title
+        body = mhc.build_eval_issue_body(names, {}, "2026-07-27")
+        assert all(n in body for n in names)
+
+
+class TestPlanIssue:
+    def test_creates_when_nothing_open(self):
+        assert mhc.plan_issue([], ["a -> b"], title_prefix=mhc.UPGRADE_TITLE_PREFIX) == {
+            "action": "create", "markers": ["a -> b"], "number": None}
+
+    def test_no_markers_is_never_an_issue(self):
+        assert mhc.plan_issue([], [], title_prefix=mhc.UPGRADE_TITLE_PREFIX)["action"] == "none"
+
+    def test_marker_already_in_an_open_issue_body_is_not_refiled(self):
+        open_issues = [{"number": 9, "title": mhc.UPGRADE_TITLE_PREFIX + " x",
+                        "body": "markers: `a -> b`", "comments": []}]
+        out = mhc.plan_issue(open_issues, ["a -> b"], title_prefix=mhc.UPGRADE_TITLE_PREFIX)
+        assert out == {"action": "none", "markers": [], "number": 9}
+
+    def test_marker_in_a_comment_counts_as_filed(self):
+        open_issues = [{"number": 9, "title": mhc.UPGRADE_TITLE_PREFIX + " x", "body": "",
+                        "comments": [{"body": "found more: `a -> b`"}]}]
+        assert mhc.plan_issue(open_issues, ["a -> b"],
+                              title_prefix=mhc.UPGRADE_TITLE_PREFIX)["action"] == "none"
+
+    def test_new_marker_appends_to_the_open_issue(self):
+        open_issues = [{"number": 9, "title": mhc.UPGRADE_TITLE_PREFIX + " x",
+                        "body": "`a -> b`", "comments": []}]
+        out = mhc.plan_issue(open_issues, ["a -> b", "c -> d"],
+                             title_prefix=mhc.UPGRADE_TITLE_PREFIX)
+        assert out == {"action": "append", "markers": ["c -> d"], "number": 9}
+
+    def test_an_unrelated_open_issue_does_not_count(self):
+        open_issues = [{"number": 9, "title": "Something else entirely", "body": "`a -> b`",
+                        "comments": []}]
+        assert mhc.plan_issue(open_issues, ["a -> b"],
+                              title_prefix=mhc.UPGRADE_TITLE_PREFIX)["action"] == "create"
+
+    def test_append_comment_carries_the_markers_and_the_detail(self):
+        text = mhc.build_append_comment(["c -> d"], "FULL BODY")
+        assert "`c -> d`" in text and "FULL BODY" in text
+
+
+class _FakeGitHub:
+    def __init__(self, open_issues=None, fail_lookup=False):
+        self._open = open_issues or []
+        self._fail = fail_lookup
+        self.created = []
+        self.comments = []
+
+    def open_issues(self, title_prefix):
+        if self._fail:
+            raise RuntimeError("gh exploded")
+        return [i for i in self._open if str(i.get("title", "")).startswith(title_prefix)]
+
+    def create(self, title, body, labels=mhc.ISSUE_LABELS):
+        self.created.append((title, body))
+        return "https://github.com/x/y/issues/1"
+
+    def comment(self, number, body):
+        self.comments.append((number, body))
+        return True
+
+
+def _plan_with_issues(upgrade_markers=(), eval_markers=()):
+    return {"issues": {
+        "upgrade": {"markers": list(upgrade_markers), "title": "T-up", "body": "B-up"},
+        "evaluation": {"markers": list(eval_markers), "title": "T-ev", "body": "B-ev"}}}
+
+
+class TestFileIssues:
+    def test_files_both_issues(self):
+        gh = _FakeGitHub()
+        assert mhc._file_issues(_plan_with_issues(["a -> b"], ["new-tag"]), gh) == 2
+        assert [t for t, _ in gh.created] == ["T-up", "T-ev"]
+
+    def test_nothing_to_file(self):
+        gh = _FakeGitHub()
+        assert mhc._file_issues(_plan_with_issues(), gh) == 0
+        assert gh.created == []
+
+    def test_appends_instead_of_refiling(self):
+        gh = _FakeGitHub([{"number": 7, "title": mhc.UPGRADE_TITLE_PREFIX + " a -> b",
+                           "body": "`a -> b`", "comments": []}])
+        assert mhc._file_issues(_plan_with_issues(["a -> b", "c -> d"]), gh) == 1
+        assert gh.created == [] and gh.comments[0][0] == 7
+
+    def test_a_failed_dedup_lookup_skips_rather_than_duplicating(self):
+        gh = _FakeGitHub(fail_lookup=True)
+        assert mhc._file_issues(_plan_with_issues(["a -> b"]), gh) == 0
+        assert gh.created == []
+
+
+class TestGitHubIssuesClient:
+    def _proc(self, returncode=0, stdout="", stderr=""):
+        class P:
+            pass
+        p = P()
+        p.returncode, p.stdout, p.stderr = returncode, stdout, stderr
+        return p
+
+    def test_open_issues_filters_by_title_prefix(self, monkeypatch):
+        gh = mhc.GitHubIssues("o/n")
+        payload = json.dumps([{"number": 1, "title": mhc.UPGRADE_TITLE_PREFIX + " x"},
+                              {"number": 2, "title": "unrelated"}])
+        monkeypatch.setattr(gh, "_run", lambda args: self._proc(stdout=payload))
+        assert [i["number"] for i in gh.open_issues(mhc.UPGRADE_TITLE_PREFIX)] == [1]
+
+    def test_open_issues_fails_closed_on_a_gh_error(self, monkeypatch):
+        gh = mhc.GitHubIssues("o/n")
+        monkeypatch.setattr(gh, "_run", lambda args: self._proc(returncode=1, stderr="boom"))
+        with pytest.raises(RuntimeError):
+            gh.open_issues(mhc.UPGRADE_TITLE_PREFIX)
+
+    def test_open_issues_fails_closed_on_unparseable_json(self, monkeypatch):
+        gh = mhc.GitHubIssues("o/n")
+        monkeypatch.setattr(gh, "_run", lambda args: self._proc(stdout="{nope"))
+        with pytest.raises(RuntimeError):
+            gh.open_issues(mhc.UPGRADE_TITLE_PREFIX)
+
+    def test_create_passes_every_label_and_returns_the_url(self, monkeypatch):
+        gh = mhc.GitHubIssues("o/n")
+        seen = {}
+
+        def run(args):
+            seen["args"] = args
+            return self._proc(stdout="https://github.com/o/n/issues/5\n")
+
+        monkeypatch.setattr(gh, "_run", run)
+        assert gh.create("T", "B") == "https://github.com/o/n/issues/5"
+        for label in mhc.ISSUE_LABELS:
+            assert label in seen["args"]
+
+    def test_create_failure_is_none_not_a_raise(self, monkeypatch):
+        gh = mhc.GitHubIssues("o/n")
+        monkeypatch.setattr(gh, "_run", lambda args: self._proc(returncode=1, stderr="nope"))
+        assert gh.create("T", "B") is None
+
+    def test_comment_reports_success_and_failure(self, monkeypatch):
+        gh = mhc.GitHubIssues("o/n")
+        monkeypatch.setattr(gh, "_run", lambda args: self._proc())
+        assert gh.comment(3, "body") is True
+        monkeypatch.setattr(gh, "_run", lambda args: self._proc(returncode=1))
+        assert gh.comment(3, "body") is False
+
+
+class TestFetchDegradation:
+    def test_docs_fetch_failure_is_none(self, monkeypatch):
+        monkeypatch.setattr(mhc, "http_get", lambda *a, **k: (_ for _ in ()).throw(OSError("down")))
+        assert mhc.fetch_cloud_docs() is None
+
+    def test_catalog_fetch_failure_is_none(self, monkeypatch):
+        monkeypatch.setattr(mhc, "http_get", lambda *a, **k: (_ for _ in ()).throw(OSError("down")))
+        assert mhc.fetch_catalog("key") is None
+
+    def test_catalog_sends_the_bearer_token_when_one_is_set(self, monkeypatch):
+        seen = {}
+
+        def fake(url, headers=None, timeout=None):
+            seen["headers"] = headers
+            return '{"models": []}'
+
+        monkeypatch.setattr(mhc, "http_get", fake)
+        mhc.fetch_catalog("sekret")
+        assert seen["headers"] == {"Authorization": "Bearer sekret"}
+        mhc.fetch_catalog("")
+        assert seen["headers"] == {}
+
+    def test_usage_fetch_failure_is_unknown_not_a_raise(self, monkeypatch):
+        monkeypatch.setattr(mhc, "http_get", lambda *a, **k: (_ for _ in ()).throw(OSError("down")))
+        assert mhc.fetch_usage_level("minimax-m3") == {"level": None, "label": None}
+
+    def test_usage_fetch_strips_the_size_tag_from_the_page_url(self, monkeypatch):
+        seen = {}
+
+        def fake(url, headers=None, timeout=None):
+            seen["url"] = url
+            return (FIXTURES / "usage" / "minimax-m3.html").read_text()
+
+        monkeypatch.setattr(mhc, "http_get", fake)
+        assert mhc.fetch_usage_level("qwen3.5:397b")["label"] == "high"
+        assert seen["url"].endswith("/library/qwen3.5")
+
+
+class TestCatalogScanCLI:
+    """The dry-run proof required by the issue: a future-dated retirement of a CONFIGURED model
+    produces the alert + the map addition, and a new tag renders the evaluation issue — all with
+    the network replaced by the committed fixtures."""
+
+    def _workspace(self, tmp_path, model="minimax-m2.5", drop=("minimax-m3", "glm-5.2")):
+        (tmp_path / "config.yaml").write_text(
+            "model_list:\n"
+            "  - model_name: lem-medium\n"
+            "    litellm_params:\n"
+            f"      model: openai/{model}\n"
+            "      api_base: os.environ/OLLAMA_CLOUD_URL\n")
+        (tmp_path / "map.yaml").write_text('upgrades:\n  "kimi-k2:1t": "REMOVE"\n')
+        catalog = mhc.parse_catalog(_tags())
+        (tmp_path / "snapshot.json").write_text(
+            mhc.render_snapshot({k: v for k, v in catalog.items() if k not in drop}, "2026-07-01"))
+        return [f"--config={tmp_path / 'config.yaml'}", f"--map={tmp_path / 'map.yaml'}",
+                f"--snapshot={tmp_path / 'snapshot.json'}", f"--catalog-fixture={FIXTURES}",
+                "--today=2026-07-20"]
+
+    def test_dry_run_reports_everything_and_writes_nothing(self, tmp_path, capsys):
+        args = self._workspace(tmp_path)
+        before = (tmp_path / "map.yaml").read_text(), (tmp_path / "snapshot.json").read_text()
+        code = mhc.main(["--catalog-scan", *args])
+        out = capsys.readouterr().out
+        assert code == 3  # a configured model is scheduled to retire — alert-worthy
+        assert "RETIRING [lem-medium] minimax-m2.5 on 2026-07-31 (11d) -> minimax-m2.7" in out
+        assert 'MAP + "minimax-m2.5": "minimax-m2.7"' in out
+        assert "NEW TAG minimax-m3" in out and "NEW TAG glm-5.2" in out
+        assert mhc.EVAL_TITLE_PREFIX in out and mhc.UPGRADE_TITLE_PREFIX in out
+        assert ((tmp_path / "map.yaml").read_text(),
+                (tmp_path / "snapshot.json").read_text()) == before
+
+    def test_catalog_apply_writes_the_map_and_snapshot(self, tmp_path, capsys):
+        args = self._workspace(tmp_path)
+        mhc.main(["--catalog-apply", *args])
+        assert mhc.load_map(mhc.load_map_text((tmp_path / "map.yaml").read_text())) == {
+            "kimi-k2:1t": "REMOVE", "minimax-m2.5": "minimax-m2.7"}
+        snapshot = mhc.load_snapshot_text((tmp_path / "snapshot.json").read_text())
+        assert "minimax-m3" in snapshot and "glm-5.2" in snapshot
+        # Re-running changes nothing further.
+        second = (tmp_path / "map.yaml").read_text(), (tmp_path / "snapshot.json").read_text()
+        mhc.main(["--catalog-apply", *args])
+        assert ((tmp_path / "map.yaml").read_text(),
+                (tmp_path / "snapshot.json").read_text()) == second
+
+    def test_catalog_json_is_machine_readable_and_hides_the_raw_catalog(self, tmp_path, capsys):
+        args = self._workspace(tmp_path)
+        mhc.main(["--catalog-json", *args])
+        plan = json.loads(capsys.readouterr().out)
+        assert "_catalog" not in plan
+        assert plan["repo_changes"] is True
+        assert [n["bare"] for n in plan["notices"]] == ["minimax-m2.5"]
+        assert plan["catalog"]["added"] == ["glm-5.2", "minimax-m3"]
+
+    def test_clean_config_is_exit_zero(self, tmp_path, capsys):
+        args = self._workspace(tmp_path, model="minimax-m3", drop=())
+        assert mhc.main(["--catalog-scan", *args]) == 0
+        assert "nothing to do" in capsys.readouterr().out
+
+    def test_a_missing_snapshot_is_seeded_not_reported_as_a_catalog_of_new_tags(self, tmp_path,
+                                                                                capsys):
+        args = self._workspace(tmp_path, model="minimax-m3", drop=())
+        (tmp_path / "snapshot.json").unlink()
+        code = mhc.main(["--catalog-scan", *args])
+        out = capsys.readouterr().out
+        assert "NEW TAG" not in out and "seeding it this run" in out
+        assert code == 2  # the snapshot itself still needs writing
+
+    def test_the_repo_config_and_committed_snapshot_are_clean_today(self, tmp_path, capsys):
+        """Guards the shipped state: no configured model is scheduled to retire, and the committed
+        snapshot matches the catalog fixture, so a fresh run files nothing spurious."""
+        code = mhc.main(["--catalog-scan", "--no-usage-levels",
+                         f"--config={_ROOT / '.litellm' / 'config.yaml'}",
+                         f"--map={_ROOT / '.litellm' / 'model_upgrades.yaml'}",
+                         f"--snapshot={_ROOT / '.litellm' / 'ollama_catalog_snapshot.json'}",
+                         f"--catalog-fixture={FIXTURES}", "--today=2026-07-27"])
+        out = capsys.readouterr().out
+        assert "RETIRING" not in out and "NEW TAG" not in out
+        # minimax-m2.7 trails minimax-m3 — the owner's example, reported as an evaluation only.
+        assert "UPGRADE (major) minimax-m2.7 -> minimax-m3" in out
+        assert code == 2

--- a/tests/unit/test_model_health_check.py
+++ b/tests/unit/test_model_health_check.py
@@ -1,8 +1,10 @@
 """Unit tests for scripts/model_health_check.py — the pure planning/rewriting logic."""
 
 import importlib.util
+import io
 import json
 import pathlib
+import sys
 
 import pytest
 
@@ -232,6 +234,24 @@ class TestParseRetirements:
         assert mhc.parse_doc_date("February 31, 2026") is None
         assert mhc.parse_doc_date("") is None
 
+    def test_a_cell_that_is_not_a_model_tag_is_dropped(self):
+        """cloud.md is remote and its cells become model_upgrades.yaml values, which the reactive
+        half applies to the live config — a quote or newline there must never reach that writer."""
+        md = ('## Retirements\n\n### Upcoming retirements\n\n'
+              "| Retirement date | Model | Recommended alternative |\n| --- | --- | --- |\n"
+              '| March 3, 2027 | `real-1` | `evil" injected: "yes` |\n'
+              '| March 3, 2027 | `see the migration guide` | `real-2` |\n'
+              '| March 3, 2027 | `real-3` | `real-4` |\n')
+        rows = mhc.parse_retirements(md)
+        assert [(r["model"], r["alternative"]) for r in rows] == [("real-1", None),
+                                                                  ("real-3", "real-4")]
+
+    def test_is_model_tag(self):
+        for good in ("minimax-m2.7", "kimi-k2:1t", "qwen3.5:397b", "REMOVE", "gpt-oss:20b"):
+            assert mhc.is_model_tag(good)
+        for bad in ("", None, 'a" b', "a\nb", "see the docs", "-leading-dash", "a`b"):
+            assert not mhc.is_model_tag(bad)
+
 
 class TestRetirementNotices:
     def _rows(self, *models):
@@ -324,6 +344,14 @@ class TestAppendUpgradeMappings:
         text, _ = mhc.append_upgrade_mappings(src, {"c": "d"}, "2026-07-20")
         assert text.index('"c": "d"') < text.index("other:")
         assert mhc.load_map(mhc.load_map_text(text)) == {"a": "b", "c": "d"}
+
+    def test_a_non_tag_value_can_never_inject_extra_mappings(self):
+        """Last line of defence: the writer refuses anything it hasn't checked, so a poisoned
+        cell that reached this far still cannot add a mapping of its own."""
+        text, added = mhc.append_upgrade_mappings(
+            self.MAP, {"good": "fine", "victim": 'evil"\n  "injected": "yes'}, "2026-07-20")
+        assert added == ["good"]
+        assert mhc.load_map(mhc.load_map_text(text)) == {"kimi-k2:1t": "REMOVE", "good": "fine"}
 
 
 class TestCatalogSnapshot:
@@ -590,6 +618,10 @@ class _FakeGitHub:
         return True
 
 
+def _boom(*a, **k):
+    raise AssertionError("the catalog must not be re-scanned when a plan was supplied")
+
+
 def _plan_with_issues(upgrade_markers=(), eval_markers=()):
     return {"issues": {
         "upgrade": {"markers": list(upgrade_markers), "title": "T-up", "body": "B-up"},
@@ -778,6 +810,44 @@ class TestCatalogScanCLI:
         out = capsys.readouterr().out
         assert "NEW TAG" not in out and "seeding it this run" in out
         assert code == 2  # the snapshot itself still needs writing
+
+    def test_file_issues_acts_on_a_saved_plan_without_rescanning(self, tmp_path, capsys,
+                                                                 monkeypatch):
+        """The orchestrator files from the plan it already read. A second scan would re-fetch
+        docs/api-tags, and an outage there would file NOTHING and say nothing — while the snapshot
+        PR opened in the same run makes those tags no longer 'new', losing the issue for good."""
+        args = self._workspace(tmp_path)
+        mhc.main(["--catalog-json", *args])
+        plan_path = tmp_path / "plan.json"
+        plan_path.write_text(capsys.readouterr().out)
+
+        monkeypatch.setattr(mhc, "_catalog_scan", _boom)  # a re-scan would be a bug
+        gh = _FakeGitHub()
+        monkeypatch.setattr(mhc, "GitHubIssues", lambda repo: gh)
+        assert mhc.main(["--file-issues", f"--plan-file={plan_path}"]) == 3
+        titles = [t for t, _ in gh.created]
+        assert any(t.startswith(mhc.EVAL_TITLE_PREFIX) for t in titles)
+        assert any(t.startswith(mhc.UPGRADE_TITLE_PREFIX) for t in titles)
+
+    def test_a_saved_plan_reads_from_stdin_too(self, tmp_path, capsys, monkeypatch):
+        args = self._workspace(tmp_path)
+        mhc.main(["--catalog-json", *args])
+        monkeypatch.setattr(sys, "stdin", io.StringIO(capsys.readouterr().out))
+        monkeypatch.setattr(mhc, "_catalog_scan", _boom)
+        gh = _FakeGitHub()
+        monkeypatch.setattr(mhc, "GitHubIssues", lambda repo: gh)
+        assert mhc.main(["--file-issues", "--plan-file=-"]) == 3
+        assert gh.created
+
+    def test_a_saved_plan_can_never_drive_the_snapshot_write(self, tmp_path, capsys):
+        """--catalog-json strips the raw catalog, so applying from a saved plan would silently skip
+        the snapshot refresh. Refuse instead."""
+        args = self._workspace(tmp_path)
+        mhc.main(["--catalog-json", *args])
+        plan_path = tmp_path / "plan.json"
+        plan_path.write_text(capsys.readouterr().out)
+        with pytest.raises(SystemExit):
+            mhc.main(["--catalog-apply", f"--plan-file={plan_path}"])
 
     def test_the_repo_config_and_committed_snapshot_are_clean_today(self, tmp_path, capsys):
         """Guards the shipped state: no configured model is scheduled to retire, and the committed


### PR DESCRIPTION
## What & why

The weekly model-health cron (`scripts/weekly_model_check.sh` + `model_health_check.py`, Sun 09:00 UTC) was purely **reactive**: it found a retirement only once the model already returned 410, and it never noticed that a newer model in a family we run had shipped — `minimax-m3` has been available while `.litellm/config.yaml` sat on `minimax-m2.7`. Ollama publishes both facts in advance, so the check now reads them.

Three new scans in `scripts/model_health_check.py`, all pure + unit-tested, all degrading to a skip when a source is unreachable (the 410 probe remains the backstop):

### 1. Advance retirement scan
Parses `docs.ollama.com/cloud.md`'s retirement tables — the "Upcoming" rows carry their own date, the "Past" ones inherit their `<Accordion title="…">` date. For a **configured** model with a **future** date: alert now with the date + published alternative, and pre-append that mapping to `.litellm/model_upgrades.yaml` so the existing swap path applies it *before* the sunset.

Load-bearing choices:
- A date already **past** produces nothing — that's a live 410 the probe owns, and re-reporting it weekly would bury the actionable one.
- A retirement with **no published alternative** alerts but writes **nothing**. Writing `REMOVE` would make the check label its own unhandled retirement "known" and stop asking.
- An alternative that isn't in the live catalog is never auto-mapped.

### 2. New-model discovery
Diffs `ollama.com/api/tags` (Bearer `$OLLAMA_CLOUD_API_KEY` when set) against the committed `.litellm/ollama_catalog_snapshot.json`. New tags → ONE `agent:ready` evaluation issue; the snapshot is refreshed in the same PR. Removed tags we don't use → snapshot only. A **missing** snapshot is SEEDED, never reported as a catalog of 18 new tags.

### 3. Family-version scan (owner addendum)
`parse_model_version` handles the three spellings the real catalog uses — fused (`qwen3.5:397b`), own dash-part (`glm-5.1`, `nemotron-3-nano:30b`, `mistral-large-3:675b`) and one-letter marker (`minimax-m2.7`, `deepseek-v4-flash`). A variant suffix stays **in the family key** (`kimi-k2.7-code` → `kimi-code`), so a coding variant is never offered as an upgrade for plain `kimi-k2.6`. A size tag is not a version, so `gpt-oss:20b` comes back unversioned and stays out of the comparison.

When a configured model trails its family, ONE consolidated `agent:ready` issue is filed, major bumps first and minor/patch below. Each side's **usage level** is scraped from its `ollama.com/library/<name>` page: `minimax-m2.7` is *medium*, `minimax-m3` is *high*, and a tier jump means more quota burn — so this is always an **evaluation**, never an auto-swap, and the body says so. An unread usage page is `None`, never "no jump". A candidate that is itself scheduled to retire is never recommended.

### Dedup (#598 lesson)
Literal marker match across the **title, body AND comments** of open issues carrying the matching title prefix — comments count because that is where an append lands. Issues are **listed and filtered client-side** rather than handed to `--search` (the search index tokenizes and lags; a miss there is a duplicate every week), and the lookup **fails closed**: an unreadable listing skips the filing instead of re-filing.

### Orchestrator
`weekly_model_check.sh` runs the scan after the probe, emails the retirement notices on the existing path, opens the map/snapshot changes as a PR, and files the issues. `open_pr` is now parameterised over branch/title/body/mutation (the swap PR is unchanged in behaviour beyond a force fallback on a stale bot branch). It also `git pull --ff-only`s the cron clone first — the map the run READS is the clone's copy, so without that a mapping pre-approved and merged last week would never reach the run that would apply it.

## Current state, run live against this branch

```
$ python3 scripts/model_health_check.py --catalog-scan --today 2026-07-27
Ollama catalog scan (2026-07-27): docs=ok catalog=ok tags=18
  UPGRADE (major) minimax-m2.7 -> minimax-m3 — usage medium (level 2) -> high (level 3)
```

Exactly the gap the addendum named. No configured model is scheduled to retire and the committed snapshot matches the live catalog, so nothing spurious would be filed.

## Testing

- `113 passed` in `tests/unit/test_model_health_check.py` (was 34); full suite `7597 passed`.
- Fixtures are **real captures** committed under `tests/unit/fixtures/ollama/`: `cloud.md`, `tags.json`, and three model pages (`minimax-m2.7` medium / `minimax-m3` high / `deepseek-v4-pro` extra high).
- Covered: the markdown-table parser (upcoming + accordion dates, empty alternatives, header/separator rows, tables *outside* the Retirements section), notice/mapping planning, comment-preserving + idempotent map append, snapshot parse/render/diff, the version parser across every name the addendum lists, family-upgrade planning, usage-level parsing, issue rendering + title truncation, dedup planning, the `gh` client (fail-closed), and every fetch's degradation path.
- **Dry-run proof, offline:** `--catalog-scan --catalog-fixture tests/unit/fixtures/ollama` drives the whole CLI with the network replaced. `TestCatalogScanCLI` asserts a future-dated retirement of a configured model → alert + map addition, a new tag → rendered evaluation issue, `--catalog-apply` writes and is idempotent, and dry-run writes nothing.

No `src/` code, no migration, no secrets. `scripts/` stays stdlib-only (urllib, not `requests`) — it runs from a host ops cron with no app venv guaranteed.

Closes #716

🤖 Generated with [Claude Code](https://claude.com/claude-code)