### PR TITLE
fix(content): explain an empty Generate run and pull planned posts forward (closes #719)

### DIFF
--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -2093,6 +2093,14 @@ def _close_out_empty_run(user_id: int, requested: bool,
                buffer_days=buffer_days, ready_count=ready_count, buffer_max=buffer_max)
 
 
+# The pull-forward cap counts EVERY future ready post, not the buffer's own 30-day ceiling:
+# `plan_content_for_user` appends a whole month after the LAST planning row, so a laid-out plan
+# routinely reaches ~60 days out. Counting over MAX_CONTENT_BUFFER_DAYS would not see the posts a
+# pull-forward click just generated past day 30, and each further click would re-earn the full cap
+# further down the calendar — the exact runaway the cap exists to stop.
+_PULL_FORWARD_READY_HORIZON_DAYS = 365
+
+
 def _pull_forward_planned_posts(user_id: int, buffer_days: int,
                                 buffer_max: int) -> Tuple[list[dict], int]:
     """The next planned posts BEYOND the buffer window, plus how many are already ready ahead.
@@ -2101,10 +2109,10 @@ def _pull_forward_planned_posts(user_id: int, buffer_days: int,
     rejected — rejected slots are never re-planned) used to no-op forever, because the plan only
     ever appends after the last planning row and the top-up only looks `buffer_days` ahead
     (issue #719). Pulling the next slots forward is bounded by the SAME ceiling, counted across
-    the whole planning horizon rather than the buffer window — otherwise repeated clicks would
-    walk the buffer cap down the calendar and generate the entire month.
+    everything already generated ahead rather than the buffer window — otherwise repeated clicks
+    would walk the buffer cap down the calendar and generate the entire plan.
     """
-    ready_ahead = count_ready_posts_within_buffer(user_id, MAX_CONTENT_BUFFER_DAYS)
+    ready_ahead = count_ready_posts_within_buffer(user_id, _PULL_FORWARD_READY_HORIZON_DAYS)
     limit = buffer_max - ready_ahead
     if limit <= 0:
         return [], ready_ahead

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -24,6 +24,7 @@ from cqc_lem.utilities.db import get_post_type_counts, insert_planned_post, upda
     update_db_post_video_url, update_db_post_status, PostType, get_user_preferences, \
     update_db_post_carousel_slides, get_post_content, get_user_timezone, get_engagement_preferences
 from cqc_lem.utilities.db import count_ready_posts_within_buffer, get_planned_posts_within_buffer, \
+    get_next_planned_posts_after_buffer, get_next_planned_post_date, \
     get_user_ids_with_planned_posts_within_buffer, DEFAULT_CONTENT_BUFFER_DAYS, \
     DEFAULT_CONTENT_BUFFER_MAX_POSTS, MAX_CONTENT_BUFFER_DAYS, MAX_CONTENT_BUFFER_POSTS, \
     DEFAULT_POSTS_PER_WEEK, POSTS_PER_WEEK_MIN, POSTS_PER_WEEK_MAX, \
@@ -51,7 +52,7 @@ from cqc_lem.utilities.ai import story_bank as _story_bank
 from cqc_lem.utilities.ai.slop_lint import (lint_report as slop_lint_report,
                                             slop_retry_directive, violation_reasons)
 from cqc_lem.utilities.content_generation_status import mark_in_progress, mark_finished, \
-    record_post_generated, record_post_failed
+    record_post_generated, record_post_failed, mark_empty, ContentGenerationEmptyReason
 from cqc_lem.utilities.notifications import notify_content_generation_ready
 from cqc_lem.utilities.env_constants import API_URL_FINAL, DEFAULT_VIDEO_RATIO, \
     DEFAULT_IMAGE_RATIO, AI_DISCLOSURE_ENABLED, AI_DISCLOSURE_TEXT, \
@@ -2063,18 +2064,51 @@ def auto_create_weekly_content(user_id: int = None):
         _top_up_buffer_for_user(uid, requested=user_id is not None)
 
 
-def _close_out_empty_run(user_id: int, requested: bool) -> None:
-    """Finish a requested run that generated nothing (issue #545).
+def _next_planned_at(user_id: int) -> Optional[datetime]:
+    """When the user's next planning slot is due — best effort, never fails the run (issue #719)."""
+    try:
+        return get_next_planned_post_date(user_id)
+    except Exception as e:
+        log_warning(f"Could not read the next planned post date for user {user_id}", exc=e,
+                    user_id=user_id, task_name="auto_create_weekly_content")
+        return None
+
+
+def _close_out_empty_run(user_id: int, requested: bool,
+                         reason: ContentGenerationEmptyReason,
+                         buffer_days: Optional[int] = None,
+                         ready_count: Optional[int] = None,
+                         buffer_max: Optional[int] = None) -> None:
+    """Finish a requested run that generated nothing, saying WHY (issues #545, #719).
 
     `/create_weekly_content/` publishes 'queued' at dispatch, so a top-up that returns early
     (lock lost, buffer already full, nothing planned) must still close the record out or the SPA
     polls a queued run that never reports anything. The beat run publishes nothing up front, so
-    it has nothing to close.
+    it has nothing to close. The reason rides along because "0 posts are ready to review" on its
+    own reads as a broken button rather than as an answer.
     """
     if not requested:
         return
-    mark_in_progress(user_id, [])
-    mark_finished(user_id)
+    mark_empty(user_id, reason, next_planned_at=_next_planned_at(user_id),
+               buffer_days=buffer_days, ready_count=ready_count, buffer_max=buffer_max)
+
+
+def _pull_forward_planned_posts(user_id: int, buffer_days: int,
+                                buffer_max: int) -> Tuple[list[dict], int]:
+    """The next planned posts BEYOND the buffer window, plus how many are already ready ahead.
+
+    An explicit Generate click on a user whose near-term slots were all consumed (posted, or
+    rejected — rejected slots are never re-planned) used to no-op forever, because the plan only
+    ever appends after the last planning row and the top-up only looks `buffer_days` ahead
+    (issue #719). Pulling the next slots forward is bounded by the SAME ceiling, counted across
+    the whole planning horizon rather than the buffer window — otherwise repeated clicks would
+    walk the buffer cap down the calendar and generate the entire month.
+    """
+    ready_ahead = count_ready_posts_within_buffer(user_id, MAX_CONTENT_BUFFER_DAYS)
+    limit = buffer_max - ready_ahead
+    if limit <= 0:
+        return [], ready_ahead
+    return get_next_planned_posts_after_buffer(user_id, buffer_days, limit) or [], ready_ahead
 
 
 def _top_up_buffer_for_user(user_id: int, requested: bool = False) -> None:
@@ -2090,7 +2124,7 @@ def _top_up_buffer_for_user(user_id: int, requested: bool = False) -> None:
     lock_token = acquire_run_lock(lock_name, ttl_seconds=_BUFFER_LOCK_TTL_SECONDS)
     if lock_token is None:
         myprint(f"user_id {user_id}: another buffer top-up is in progress — skipping this cycle.")
-        _close_out_empty_run(user_id, requested)
+        _close_out_empty_run(user_id, requested, ContentGenerationEmptyReason.ALREADY_RUNNING)
         return
 
     try:
@@ -2100,14 +2134,33 @@ def _top_up_buffer_for_user(user_id: int, requested: bool = False) -> None:
         if already_ready >= buffer_max:
             myprint(f"user_id {user_id}: buffer already full ({already_ready}/{buffer_max} ready "
                     f"within {buffer_days} days). Skipping content creation.")
-            _close_out_empty_run(user_id, requested)
+            _close_out_empty_run(user_id, requested, ContentGenerationEmptyReason.BUFFER_FULL,
+                                 buffer_days=buffer_days, ready_count=already_ready,
+                                 buffer_max=buffer_max)
             return
 
         planned_posts = get_planned_posts_within_buffer(user_id, buffer_days, buffer_max, already_ready)
+        if not planned_posts and requested:
+            # A user who clicked Generate asked for something to happen — so look past the window
+            # rather than no-opping on an empty one (issue #719). The beat keeps its narrow window:
+            # generating a week early on autopilot is spend nobody asked for.
+            planned_posts, ready_ahead = _pull_forward_planned_posts(user_id, buffer_days, buffer_max)
+            if planned_posts:
+                log_info(f"user_id {user_id}: no planned posts within {buffer_days} days — pulling "
+                         f"{len(planned_posts)} upcoming post(s) forward on explicit request",
+                         user_id=user_id, task_name="auto_create_weekly_content")
+            elif ready_ahead >= buffer_max:
+                myprint(f"user_id {user_id}: {ready_ahead} post(s) already generated ahead "
+                        f"(cap {buffer_max}). Skipping content creation.")
+                _close_out_empty_run(user_id, requested, ContentGenerationEmptyReason.BUFFER_FULL,
+                                     buffer_days=buffer_days, ready_count=ready_ahead,
+                                     buffer_max=buffer_max)
+                return
         if not planned_posts:
             myprint(f"user_id {user_id}: no planned posts within {buffer_days} days. "
                     f"Skipping content creation.")
-            _close_out_empty_run(user_id, requested)
+            _close_out_empty_run(user_id, requested, ContentGenerationEmptyReason.NO_PLANNED_SLOTS,
+                                 buffer_days=buffer_days)
             return
 
         myprint(f"user_id {user_id}: generating {len(planned_posts)} post(s) to top buffer up to "

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -17,6 +17,8 @@ import ComposePost from './content/ComposePost'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
 import { formatInTimezone, toZonedInputValue, zonedInputToUtcIso } from '../utils/datetime'
+import { emptyRunExplanation, isGenerationRunning } from '../utils/generationStatus'
+import type { GenerationStatus } from '../utils/generationStatus'
 import { EVENTS, capture, maskProps, recordPostApproval } from '../utils/analytics'
 
 // Consolidated content hub: compose posts, schedule DMs, manage newsletters, and review/edit
@@ -111,23 +113,6 @@ const STATUS_COLORS: Record<string, string> = {
   scheduled: 'bg-purple-100 text-purple-700',
   error: 'bg-red-100 text-red-700',
 }
-
-// Progress of a weekly content-generation run, polled while it is running (issue #545).
-type GenerationState = 'queued' | 'in_progress' | 'done' | 'failed'
-interface GenerationStatus {
-  state: GenerationState
-  total: number
-  completed: number
-  failed: number
-  post_ids: number[]
-  ready_post_ids: number[]
-  failed_post_ids: number[]
-  started_at: string | null
-  finished_at: string | null
-  updated_at?: string | null
-}
-const isGenerationRunning = (s?: GenerationStatus | null) =>
-  !!s && (s.state === 'queued' || s.state === 'in_progress')
 
 export default function ContentStudio() {
   const { user, sessionToken } = useAuth()
@@ -365,6 +350,7 @@ export default function ContentStudio() {
   // here — the user can also dismiss the result early.
   const [dismissedRunStartedAt, setDismissedRunStartedAt] = useState<string | null>(null)
   const showGenBanner = !!genStatus && genStatus.started_at !== dismissedRunStartedAt
+  const emptyRun = genStatus ? emptyRunExplanation(genStatus, userTimezone) : null
 
   const generating = weeklyMutation.isPending || isGenerationRunning(genStatus)
   const generateLabel = !generating
@@ -460,7 +446,9 @@ export default function ContentStudio() {
               ? 'bg-blue-50 border-blue-200 text-blue-800'
               : genStatus.state === 'failed'
                 ? 'bg-red-50 border-red-200 text-red-800'
-                : 'bg-green-50 border-green-200 text-green-800'
+                : emptyRun
+                  ? 'bg-amber-50 border-amber-200 text-amber-900'
+                  : 'bg-green-50 border-green-200 text-green-800'
           }`}
         >
           <div className="flex items-center justify-between gap-3 flex-wrap">
@@ -471,7 +459,9 @@ export default function ContentStudio() {
                   ? `Generating your posts — ${genStatus.completed + genStatus.failed} of ${genStatus.total} done`
                   : 'Generating your posts…')}
               {genStatus.state === 'done' &&
-                `${genStatus.completed} ${genStatus.completed === 1 ? 'post is' : 'posts are'} ready to review`}
+                (emptyRun
+                  ? emptyRun.headline
+                  : `${genStatus.completed} ${genStatus.completed === 1 ? 'post is' : 'posts are'} ready to review`)}
               {genStatus.state === 'failed' && 'Content generation failed — no posts were created'}
             </span>
             {isGenerationRunning(genStatus) ? (
@@ -500,6 +490,7 @@ export default function ContentStudio() {
               />
             </div>
           )}
+          {emptyRun && <p className="mt-2 text-xs">{emptyRun.detail}</p>}
           {genStatus.failed > 0 && (
             <p className="mt-2 text-xs">
               {genStatus.failed} {genStatus.failed === 1 ? 'post' : 'posts'} couldn't be generated

--- a/src/cqc_lem/ui/src/utils/generationStatus.test.ts
+++ b/src/cqc_lem/ui/src/utils/generationStatus.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest'
+import { emptyRunExplanation, isGenerationRunning } from './generationStatus'
+import type { GenerationState, GenerationStatus } from './generationStatus'
+
+const status = (over: Partial<GenerationStatus> = {}): GenerationStatus => ({
+  state: 'done',
+  total: 0,
+  completed: 0,
+  failed: 0,
+  post_ids: [],
+  ready_post_ids: [],
+  failed_post_ids: [],
+  started_at: '2026-07-27T13:52:00+00:00',
+  finished_at: '2026-07-27T13:52:59+00:00',
+  ...over,
+})
+
+const TZ = 'America/New_York'
+
+describe('isGenerationRunning', () => {
+  it('is true while queued or in progress', () => {
+    const running: GenerationState[] = ['queued', 'in_progress']
+    running.forEach((state) => expect(isGenerationRunning(status({ state }))).toBe(true))
+  })
+
+  it('is false once the run is finished', () => {
+    const finished: GenerationState[] = ['done', 'failed']
+    finished.forEach((state) => expect(isGenerationRunning(status({ state }))).toBe(false))
+  })
+
+  it('is false with nothing tracked', () => {
+    expect(isGenerationRunning(null)).toBe(false)
+  })
+})
+
+describe('emptyRunExplanation', () => {
+  it('names the next planned slot when nothing is due yet (issue #719)', () => {
+    const e = emptyRunExplanation(
+      status({ reason: 'no_planned_slots', reason_detail: { next_planned_at: '2026-08-03T13:30:00+00:00', buffer_days: 5 } }),
+      TZ,
+    )
+    expect(e?.headline).toContain('Nothing to generate right now')
+    expect(e?.detail).toContain('Aug 3')
+    expect(e?.detail).toContain('5 days before each planned slot')
+  })
+
+  it('renders the slot date in the USER timezone, not the browser one', () => {
+    // 03:30 UTC on Aug 4 is still Aug 3 in New York — a naive read would show the wrong day.
+    const e = emptyRunExplanation(
+      status({ reason: 'no_planned_slots', reason_detail: { next_planned_at: '2026-08-04T03:30:00+00:00' } }),
+      TZ,
+    )
+    expect(e?.detail).toContain('Aug 3')
+  })
+
+  it('falls back to a plan-level explanation with no upcoming slot at all', () => {
+    const e = emptyRunExplanation(status({ reason: 'no_planned_slots', reason_detail: {} }), TZ)
+    expect(e?.detail).toContain('no upcoming posts left to generate')
+    expect(e?.detail).not.toContain('undefined')
+  })
+
+  it('reports what is already waiting when the buffer is full', () => {
+    const e = emptyRunExplanation(
+      status({ reason: 'buffer_full', reason_detail: { ready_count: 5, buffer_max: 5, buffer_days: 5, next_planned_at: '2026-08-03T13:30:00+00:00' } }),
+      TZ,
+    )
+    expect(e?.detail).toContain('5 posts are already generated')
+    expect(e?.detail).toContain('Aug 3')
+  })
+
+  it('says post, singular, for a single ready post', () => {
+    const e = emptyRunExplanation(
+      status({ reason: 'buffer_full', reason_detail: { ready_count: 1 } }),
+      TZ,
+    )
+    expect(e?.detail).toContain('1 post is already generated')
+  })
+
+  it('explains a run that lost the single-flight lock', () => {
+    const e = emptyRunExplanation(status({ reason: 'already_running' }), TZ)
+    expect(e?.headline).toContain('already in progress')
+  })
+
+  it('stays out of the way when posts were generated', () => {
+    expect(
+      emptyRunExplanation(status({ total: 2, completed: 2, reason: 'buffer_full' }), TZ),
+    ).toBeNull()
+  })
+
+  it('stays out of the way for a pre-#719 run that carries no reason', () => {
+    expect(emptyRunExplanation(status(), TZ)).toBeNull()
+  })
+
+  it('stays out of the way while the run is still going', () => {
+    expect(
+      emptyRunExplanation(status({ state: 'in_progress', reason: 'buffer_full' }), TZ),
+    ).toBeNull()
+  })
+})

--- a/src/cqc_lem/ui/src/utils/generationStatus.ts
+++ b/src/cqc_lem/ui/src/utils/generationStatus.ts
@@ -1,0 +1,78 @@
+// Progress of a weekly content-generation run (issue #545) and the copy for a run that finished
+// with nothing to do (issue #719). Kept out of ContentStudio.tsx so the wording is unit-testable:
+// "0 posts are ready to review" with no reason is what made a working button read as broken.
+
+import { formatInTimezone } from './datetime'
+
+export type GenerationState = 'queued' | 'in_progress' | 'done' | 'failed'
+export type GenerationEmptyReason = 'buffer_full' | 'no_planned_slots' | 'already_running'
+
+export interface GenerationStatus {
+  state: GenerationState
+  total: number
+  completed: number
+  failed: number
+  post_ids: number[]
+  ready_post_ids: number[]
+  failed_post_ids: number[]
+  started_at: string | null
+  finished_at: string | null
+  updated_at?: string | null
+  // Absent on runs that generated posts — only an empty run carries a reason.
+  reason?: GenerationEmptyReason | null
+  reason_detail?: {
+    next_planned_at?: string | null
+    buffer_days?: number | null
+    ready_count?: number | null
+    buffer_max?: number | null
+  } | null
+}
+
+export const isGenerationRunning = (s?: GenerationStatus | null) =>
+  !!s && (s.state === 'queued' || s.state === 'in_progress')
+
+// A run that generated nothing is an ANSWER, not a failure — so say why and what happens next.
+// Returns null whenever the default "N posts are ready to review" line is the right one.
+export function emptyRunExplanation(
+  s: GenerationStatus,
+  tz: string,
+): { headline: string; detail: string } | null {
+  if (s.state !== 'done' || s.total > 0 || !s.reason) return null
+  const d = s.reason_detail ?? {}
+  // Date only: the hour a slot happens to sit at is noise in an explanation.
+  const nextPlanned = d.next_planned_at
+    ? formatInTimezone(d.next_planned_at, tz, {
+        month: 'short',
+        day: 'numeric',
+        hour: undefined,
+        minute: undefined,
+      })
+    : null
+  const bufferDays = d.buffer_days ?? 5
+  const days = `${bufferDays} ${bufferDays === 1 ? 'day' : 'days'}`
+
+  if (s.reason === 'already_running') {
+    return {
+      headline: 'A generation run is already in progress',
+      detail: "We didn't start a second one — give the current run a few minutes to finish.",
+    }
+  }
+  if (s.reason === 'buffer_full') {
+    const ready = d.ready_count ?? 0
+    return {
+      headline: "Nothing to generate right now — you're already stocked up",
+      detail:
+        `${ready} ${ready === 1 ? 'post is' : 'posts are'} already generated and waiting for you. ` +
+        `We generate more automatically as those get published.` +
+        (nextPlanned ? ` Your next planned post is ${nextPlanned}.` : ''),
+    }
+  }
+  return {
+    headline: 'Nothing to generate right now — no slots are due yet',
+    detail: nextPlanned
+      ? `Your next planned post is ${nextPlanned}. Generation starts automatically about ` +
+        `${days} before each planned slot.`
+      : 'Your plan has no upcoming posts left to generate. The next month is planned ' +
+        'automatically — or add one now with "+ Schedule a post".',
+  }
+}

--- a/src/cqc_lem/utilities/content_generation_status.py
+++ b/src/cqc_lem/utilities/content_generation_status.py
@@ -47,6 +47,18 @@ class ContentGenerationState(StrEnum):
     FAILED = 'failed'            # finished with nothing generated
 
 
+class ContentGenerationEmptyReason(StrEnum):
+    """Why a run legitimately generated nothing (issue #719).
+
+    'done, 0 posts' is an ANSWER, not a failure — but rendered without the reason the SPA said
+    only "0 posts are ready to review", which reads as broken. Each value maps to one sentence
+    the user can act on, so the reason travels with the status instead of living in worker logs.
+    """
+    BUFFER_FULL = 'buffer_full'              # enough ready posts already sit in the window
+    NO_PLANNED_SLOTS = 'no_planned_slots'    # nothing left planned to generate from
+    ALREADY_RUNNING = 'already_running'      # another top-up holds the single-flight lock
+
+
 def _ttl_seconds() -> int:
     try:
         return int(os.getenv("CONTENT_GENERATION_STATUS_TTL_SECONDS", str(_DEFAULT_TTL_SECONDS)))
@@ -92,6 +104,19 @@ def _key(user_id: int) -> str:
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _utc_iso(dt: Optional[datetime]) -> Optional[str]:
+    """Serialize a scheduling instant with an EXPLICIT UTC offset (docs/timezone-contract.md).
+
+    Scheduling rows are stored naive-UTC; emitting them naive would let the SPA read them as the
+    viewer's local time and render the wrong "next planned post" date.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc).isoformat()
 
 
 def _read(client: RedisLike, user_id: int) -> Optional[dict]:
@@ -199,6 +224,45 @@ def mark_finished(user_id: int) -> Optional[dict]:
     status["state"] = str(ContentGenerationState.FAILED if failed and not completed
                           else ContentGenerationState.DONE)
     status["finished_at"] = _now()
+    _write(client, user_id, status, ttl=_result_ttl_seconds())
+    return status
+
+
+def mark_empty(user_id: int,
+               reason: "ContentGenerationEmptyReason | str",
+               next_planned_at: Optional[datetime] = None,
+               buffer_days: Optional[int] = None,
+               ready_count: Optional[int] = None,
+               buffer_max: Optional[int] = None) -> Optional[dict]:
+    """Close out a run that generated nothing, WITH the reason it did (issue #719).
+
+    Replaces the `mark_in_progress(user_id, []) + mark_finished(user_id)` pair for the early-exit
+    paths: same terminal DONE/0 record the SPA already understands, plus `reason` and the numbers
+    behind it so the banner can say "your next planned post is Aug 3" instead of "0 posts".
+    """
+    client = _redis_client()
+    if client is None:
+        return None
+    existing = _read(client, user_id) or {}
+    detail = {
+        "next_planned_at": _utc_iso(next_planned_at),
+        "buffer_days": int(buffer_days) if buffer_days is not None else None,
+        "ready_count": int(ready_count) if ready_count is not None else None,
+        "buffer_max": int(buffer_max) if buffer_max is not None else None,
+    }
+    status = {
+        "state": str(ContentGenerationState.DONE),
+        "total": 0,
+        "completed": 0,
+        "failed": 0,
+        "post_ids": [],
+        "ready_post_ids": [],
+        "failed_post_ids": [],
+        "started_at": existing.get("started_at") or _now(),
+        "finished_at": _now(),
+        "reason": str(reason),
+        "reason_detail": {k: v for k, v in detail.items() if v is not None},
+    }
     _write(client, user_id, status, ttl=_result_ttl_seconds())
     return status
 

--- a/src/cqc_lem/utilities/content_generation_status.py
+++ b/src/cqc_lem/utilities/content_generation_status.py
@@ -193,6 +193,12 @@ def _record(user_id: int, post_id: int, failed: bool) -> None:
     status[bucket] = ids
     status["failed" if failed else "completed"] = len(ids)
     status["state"] = str(ContentGenerationState.IN_PROGRESS)
+    # A run that is producing posts is not an empty one. A second click while this run is still
+    # generating writes an ALREADY_RUNNING record over this very key (issue #719), and carrying
+    # that reason forward would have the finished run tell the user to wait for a run that is
+    # already done instead of naming the posts it made.
+    status.pop("reason", None)
+    status.pop("reason_detail", None)
     _write(client, user_id, status)
 
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2112,6 +2112,64 @@ def get_planned_posts_within_buffer(user_id: int,
     return planned_content
 
 
+def get_next_planned_posts_after_buffer(user_id: int, days: int, limit: int) -> list[dict]:
+    """The soonest status=planning posts due BEYOND the buffer window, soonest first (issue #719).
+
+    The pull-forward list for an explicitly requested run: when the window holds no planning rows
+    (every near-term slot was posted or rejected, and rejected slots are never re-planned) the
+    Generate button would otherwise no-op forever. Forward-only — a planning row already in the
+    past is a stale slot, and generating content for a time that has passed would publish it
+    immediately.
+    """
+    limit = int(limit)
+    if limit <= 0:
+        return []
+
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT user_id, id, post_type, buyer_stage, content_mix, scheduled_time FROM posts"
+            " WHERE status = 'planning' AND user_id = %s"
+            " AND scheduled_time > NOW() + INTERVAL %s DAY"
+            " ORDER BY scheduled_time ASC, id ASC LIMIT %s",
+            (user_id, int(days), limit),
+        )
+        planned_content = cursor.fetchall()
+    except mysql.connector.Error as err:
+        myprint(f"Could not get planned posts after buffer for user_id {user_id} | Error: {err}")
+        planned_content = []
+    finally:
+        cursor.close()
+        connection.close()
+
+    return planned_content
+
+
+def get_next_planned_post_date(user_id: int) -> Optional[datetime]:
+    """When this user's soonest UPCOMING planning slot is due, or None when nothing is planned.
+
+    Feeds the "nothing to generate right now" explanation (issue #719) — without a date the SPA
+    can only say a run produced nothing, which reads as a broken feature.
+    """
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "SELECT MIN(scheduled_time) FROM posts"
+            " WHERE status = 'planning' AND user_id = %s AND scheduled_time > NOW()",
+            (user_id,),
+        )
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not get next planned post date for user_id {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_user_ids_with_planned_posts_within_buffer(days: int = MAX_CONTENT_BUFFER_DAYS) -> list[int]:
     """User IDs that have any status=planning post due within the next `days` days.
 

--- a/tests/unit/app/test_content_generation_progress.py
+++ b/tests/unit/app/test_content_generation_progress.py
@@ -1,5 +1,6 @@
 """Progress + completion-notification wiring for auto_create_weekly_content (issue #545)."""
 
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -20,6 +21,8 @@ def _generation_patches(planned, create_content_result=("Post text", None), **ov
         "release_run_lock": {},
         "count_ready_posts_within_buffer": {"return_value": 0},
         "get_planned_posts_within_buffer": {"return_value": planned},
+        "get_next_planned_posts_after_buffer": {"return_value": []},
+        "get_next_planned_post_date": {"return_value": None},
         "create_content": {"return_value": create_content_result},
         "update_db_post_content": {},
         "update_db_post_status": {},
@@ -55,11 +58,12 @@ def progress():
     """Patch the progress store + notifier where run_content_plan imported them."""
     with patch(f"{_RCP}.mark_in_progress") as in_progress, \
          patch(f"{_RCP}.mark_finished") as finished, \
+         patch(f"{_RCP}.mark_empty") as empty, \
          patch(f"{_RCP}.record_post_generated") as generated, \
          patch(f"{_RCP}.record_post_failed") as failed, \
          patch(f"{_RCP}.notify_content_generation_ready") as notify:
-        yield {"in_progress": in_progress, "finished": finished, "generated": generated,
-               "failed": failed, "notify": notify}
+        yield {"in_progress": in_progress, "finished": finished, "empty": empty,
+               "generated": generated, "failed": failed, "notify": notify}
 
 
 class TestProgressTracking:
@@ -118,8 +122,8 @@ class TestProgressTracking:
         with _Patched(_generation_patches([])):
             auto_create_weekly_content(user_id=1)
 
-        progress["in_progress"].assert_called_once_with(1, [])
-        progress["finished"].assert_called_once_with(1)
+        progress["empty"].assert_called_once()
+        progress["in_progress"].assert_not_called()
         progress["notify"].assert_not_called()
 
     def test_full_buffer_closes_out_the_queued_run(self, progress):
@@ -130,8 +134,8 @@ class TestProgressTracking:
         with _Patched(patches):
             auto_create_weekly_content(user_id=1)
 
-        progress["in_progress"].assert_called_once_with(1, [])
-        progress["finished"].assert_called_once_with(1)
+        progress["empty"].assert_called_once()
+        progress["in_progress"].assert_not_called()
         progress["generated"].assert_not_called()
 
     def test_lock_loser_closes_out_the_queued_run(self, progress):
@@ -141,8 +145,8 @@ class TestProgressTracking:
         with _Patched(patches):
             auto_create_weekly_content(user_id=1)
 
-        progress["in_progress"].assert_called_once_with(1, [])
-        progress["finished"].assert_called_once_with(1)
+        progress["empty"].assert_called_once()
+        progress["in_progress"].assert_not_called()
         progress["generated"].assert_not_called()
 
     def test_persist_failure_counts_as_failed_and_run_continues(self, progress):
@@ -181,3 +185,109 @@ class TestProgressTracking:
 
         progress["in_progress"].assert_not_called()
         progress["finished"].assert_not_called()
+        progress["empty"].assert_not_called()
+
+
+class TestEmptyRunReason:
+    """'0 posts are ready to review' with no reason reads as a broken button (issue #719)."""
+
+    def _reason(self, progress):
+        call = progress["empty"].call_args
+        return call.args[1], call.kwargs
+
+    def test_lock_loser_reports_already_running(self, progress):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        from cqc_lem.utilities.content_generation_status import ContentGenerationEmptyReason
+        patches = _generation_patches([_planned(1, 11)],
+                                      **{"acquire_run_lock": {"return_value": None}})
+        with _Patched(patches):
+            auto_create_weekly_content(user_id=1)
+
+        reason, _ = self._reason(progress)
+        assert reason == ContentGenerationEmptyReason.ALREADY_RUNNING
+
+    def test_full_buffer_reports_the_counts(self, progress):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        from cqc_lem.utilities.content_generation_status import ContentGenerationEmptyReason
+        patches = _generation_patches(
+            [_planned(1, 11)],
+            **{"count_ready_posts_within_buffer": {"return_value": 5},
+               "get_user_preferences": {"return_value": {"content_buffer_days": 5,
+                                                         "content_buffer_max_posts": 5}}})
+        with _Patched(patches):
+            auto_create_weekly_content(user_id=1)
+
+        reason, kwargs = self._reason(progress)
+        assert reason == ContentGenerationEmptyReason.BUFFER_FULL
+        assert kwargs["ready_count"] == 5 and kwargs["buffer_max"] == 5
+        assert kwargs["buffer_days"] == 5
+
+    def test_nothing_planned_reports_the_next_slot_date(self, progress):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        from cqc_lem.utilities.content_generation_status import ContentGenerationEmptyReason
+        next_at = datetime(2026, 8, 3, 13, 30)
+        with _Patched(_generation_patches(
+                [], **{"get_next_planned_post_date": {"return_value": next_at}})):
+            auto_create_weekly_content(user_id=1)
+
+        reason, kwargs = self._reason(progress)
+        assert reason == ContentGenerationEmptyReason.NO_PLANNED_SLOTS
+        assert kwargs["next_planned_at"] == next_at
+
+    def test_unreadable_next_slot_date_still_closes_the_run(self, progress):
+        """The explanation is best-effort — a DB hiccup must not strand the SPA on 'queued'."""
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        with _Patched(_generation_patches(
+                [], **{"get_next_planned_post_date": {"side_effect": RuntimeError("db gone")}})):
+            auto_create_weekly_content(user_id=1)
+
+        _, kwargs = self._reason(progress)
+        assert kwargs["next_planned_at"] is None
+
+
+class TestPullForward:
+    """An explicit click on an empty window pulls the next planned posts forward (issue #719)."""
+
+    def test_requested_run_generates_the_next_planned_posts(self, progress):
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        patches = _generation_patches(
+            [], **{"get_next_planned_posts_after_buffer": {"return_value": [_planned(1, 31)]}})
+        with _Patched(patches) as mocks:
+            auto_create_weekly_content(user_id=1)
+
+        progress["in_progress"].assert_called_once_with(1, [31])
+        progress["generated"].assert_called_once_with(1, 31)
+        progress["empty"].assert_not_called()
+        # Bounded by the same ceiling, counted across the whole planning horizon.
+        assert mocks["get_next_planned_posts_after_buffer"].call_args.args[2] == 5
+
+    def test_beat_run_never_pulls_forward(self, progress):
+        """Generating a week early on autopilot is spend nobody asked for."""
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        patches = _generation_patches(
+            [], **{"get_next_planned_posts_after_buffer": {"return_value": [_planned(1, 31)]}})
+        with _Patched(patches) as mocks, \
+                patch(f"{_RCP}.get_user_ids_with_planned_posts_within_buffer", return_value=[1]):
+            auto_create_weekly_content()
+
+        mocks["get_next_planned_posts_after_buffer"].assert_not_called()
+        progress["generated"].assert_not_called()
+
+    def test_repeated_clicks_cannot_walk_the_cap_down_the_calendar(self, progress):
+        """Everything ahead is already generated — report it instead of generating the month."""
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        from cqc_lem.utilities.content_generation_status import ContentGenerationEmptyReason
+        # 0 ready inside the 5-day window, 5 ready across the 30-day horizon.
+        ready_by_days = {5: 0, 30: 5}
+        patches = _generation_patches(
+            [],
+            **{"count_ready_posts_within_buffer": {
+                "side_effect": lambda uid, days: ready_by_days[days]},
+               "get_next_planned_posts_after_buffer": {"return_value": [_planned(1, 31)]}})
+        with _Patched(patches) as mocks:
+            auto_create_weekly_content(user_id=1)
+
+        mocks["get_next_planned_posts_after_buffer"].assert_not_called()
+        progress["generated"].assert_not_called()
+        assert progress["empty"].call_args.args[1] == ContentGenerationEmptyReason.BUFFER_FULL
+        assert progress["empty"].call_args.kwargs["ready_count"] == 5

--- a/tests/unit/app/test_content_generation_progress.py
+++ b/tests/unit/app/test_content_generation_progress.py
@@ -275,10 +275,11 @@ class TestPullForward:
 
     def test_repeated_clicks_cannot_walk_the_cap_down_the_calendar(self, progress):
         """Everything ahead is already generated — report it instead of generating the month."""
-        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        from cqc_lem.app.run_content_plan import (auto_create_weekly_content,
+                                                  _PULL_FORWARD_READY_HORIZON_DAYS)
         from cqc_lem.utilities.content_generation_status import ContentGenerationEmptyReason
-        # 0 ready inside the 5-day window, 5 ready across the 30-day horizon.
-        ready_by_days = {5: 0, 30: 5}
+        # 0 ready inside the 5-day window, 5 ready across everything generated ahead.
+        ready_by_days = {5: 0, _PULL_FORWARD_READY_HORIZON_DAYS: 5}
         patches = _generation_patches(
             [],
             **{"count_ready_posts_within_buffer": {
@@ -291,3 +292,24 @@ class TestPullForward:
         progress["generated"].assert_not_called()
         assert progress["empty"].call_args.args[1] == ContentGenerationEmptyReason.BUFFER_FULL
         assert progress["empty"].call_args.kwargs["ready_count"] == 5
+
+    def test_cap_counts_posts_generated_past_the_buffer_ceiling(self, progress):
+        """A pulled-forward post can land past MAX_CONTENT_BUFFER_DAYS — the plan appends a month
+        after the LAST planning row, so a laid-out plan reaches ~60 days out. Counting the cap over
+        the 30-day ceiling would not see those, and the next click would re-earn the whole cap."""
+        from cqc_lem.app.run_content_plan import auto_create_weekly_content
+        from cqc_lem.utilities.content_generation_status import ContentGenerationEmptyReason
+        from cqc_lem.utilities.db import MAX_CONTENT_BUFFER_DAYS
+        # Nothing ready within 30 days; the 5 already generated all sit BEYOND day 30.
+        ready_by_days = {5: 0, MAX_CONTENT_BUFFER_DAYS: 0}
+        patches = _generation_patches(
+            [],
+            **{"count_ready_posts_within_buffer": {
+                "side_effect": lambda uid, days: ready_by_days.get(days, 5)},
+               "get_next_planned_posts_after_buffer": {"return_value": [_planned(1, 31)]}})
+        with _Patched(patches) as mocks:
+            auto_create_weekly_content(user_id=1)
+
+        mocks["get_next_planned_posts_after_buffer"].assert_not_called()
+        progress["generated"].assert_not_called()
+        assert progress["empty"].call_args.args[1] == ContentGenerationEmptyReason.BUFFER_FULL

--- a/tests/unit/app/test_run_content_plan.py
+++ b/tests/unit/app/test_run_content_plan.py
@@ -21,16 +21,25 @@ class TestAutoCreateWeeklyContent:
                                  "content_buffer_max_posts": 5}) as prefs:
             yield prefs
 
+    @pytest.fixture
+    def no_pull_forward(self):
+        """Nothing planned beyond the buffer window either (issue #719's pull-forward path)."""
+        with patch(f"{_RCP}.get_next_planned_posts_after_buffer", return_value=[]), \
+             patch(f"{_RCP}.get_next_planned_post_date", return_value=None):
+            yield
+
     @patch(f"{_RCP}.count_ready_posts_within_buffer", return_value=0)
     @patch(f"{_RCP}.get_planned_posts_within_buffer", return_value=None)
-    def test_does_not_crash_when_planned_posts_is_none(self, mock_planned, mock_ready):
+    def test_does_not_crash_when_planned_posts_is_none(self, mock_planned, mock_ready,
+                                                       no_pull_forward):
         from cqc_lem.app.run_content_plan import auto_create_weekly_content
         # Should not raise TypeError: 'NoneType' is not iterable
         auto_create_weekly_content(user_id=1)
 
     @patch(f"{_RCP}.count_ready_posts_within_buffer", return_value=0)
     @patch(f"{_RCP}.get_planned_posts_within_buffer", return_value=[])
-    def test_does_not_crash_when_planned_posts_is_empty(self, mock_planned, mock_ready):
+    def test_does_not_crash_when_planned_posts_is_empty(self, mock_planned, mock_ready,
+                                                        no_pull_forward):
         from cqc_lem.app.run_content_plan import auto_create_weekly_content
         auto_create_weekly_content(user_id=1)
 

--- a/tests/unit/utilities/test_content_generation_status.py
+++ b/tests/unit/utilities/test_content_generation_status.py
@@ -1,6 +1,7 @@
 """Unit tests for the weekly content-generation progress store (issue #545)."""
 
 import json
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -199,6 +200,64 @@ class TestLifecycle:
         assert fake_redis.ttls["content_generation:status:9"] == 120
         mark_finished(9)
         assert fake_redis.ttls["content_generation:status:9"] == 30
+
+
+class TestMarkEmpty:
+    """A run that generated nothing must say WHY, not just report 0 posts (issue #719)."""
+
+    def test_records_reason_and_detail(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationEmptyReason, ContentGenerationState, get_generation_status,
+            mark_empty, mark_queued)
+        mark_queued(1)
+        queued_at = get_generation_status(1)["started_at"]
+
+        returned = mark_empty(1, ContentGenerationEmptyReason.NO_PLANNED_SLOTS,
+                              next_planned_at=datetime(2026, 8, 3, 13, 30), buffer_days=5)
+        status = get_generation_status(1)
+        assert returned == status
+        assert status["state"] == ContentGenerationState.DONE
+        assert status["total"] == 0 and status["completed"] == 0 and status["failed"] == 0
+        assert status["reason"] == "no_planned_slots"
+        assert status["reason_detail"]["next_planned_at"] == "2026-08-03T13:30:00+00:00"
+        assert status["reason_detail"]["buffer_days"] == 5
+        assert status["started_at"] == queued_at  # same run the SPA has been polling
+        assert status["finished_at"]
+
+    def test_buffer_full_carries_the_counts(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationEmptyReason, get_generation_status, mark_empty)
+        mark_empty(2, ContentGenerationEmptyReason.BUFFER_FULL, buffer_days=5,
+                   ready_count=5, buffer_max=5)
+        detail = get_generation_status(2)["reason_detail"]
+        assert detail == {"buffer_days": 5, "ready_count": 5, "buffer_max": 5}
+
+    def test_unknown_values_are_omitted_not_zeroed(self, fake_redis):
+        """None means 'we don't know', which must never render as 0 posts ready."""
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationEmptyReason, get_generation_status, mark_empty)
+        mark_empty(3, ContentGenerationEmptyReason.ALREADY_RUNNING)
+        assert get_generation_status(3)["reason_detail"] == {}
+
+    def test_aware_next_planned_is_normalized_to_utc(self, fake_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationEmptyReason, get_generation_status, mark_empty)
+        aware = datetime(2026, 8, 3, 9, 0, tzinfo=timezone(timedelta(hours=-4)))
+        mark_empty(4, ContentGenerationEmptyReason.BUFFER_FULL, next_planned_at=aware)
+        assert get_generation_status(4)["reason_detail"]["next_planned_at"] == \
+            "2026-08-03T13:00:00+00:00"
+
+    def test_gets_the_shorter_result_ttl(self, fake_redis, monkeypatch):
+        monkeypatch.setenv("CONTENT_GENERATION_RESULT_TTL_SECONDS", "30")
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationEmptyReason, mark_empty)
+        mark_empty(5, ContentGenerationEmptyReason.BUFFER_FULL)
+        assert fake_redis.ttls["content_generation:status:5"] == 30
+
+    def test_noops_without_redis(self, no_redis):
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationEmptyReason, mark_empty)
+        assert mark_empty(1, ContentGenerationEmptyReason.BUFFER_FULL) is None
 
 
 class TestFailsOpen:

--- a/tests/unit/utilities/test_content_generation_status.py
+++ b/tests/unit/utilities/test_content_generation_status.py
@@ -259,6 +259,23 @@ class TestMarkEmpty:
             ContentGenerationEmptyReason, mark_empty)
         assert mark_empty(1, ContentGenerationEmptyReason.BUFFER_FULL) is None
 
+    def test_a_run_that_produces_posts_drops_a_stale_reason(self, fake_redis):
+        """A second click while the first run is still generating writes ALREADY_RUNNING over the
+        same key. Carrying that forward would have the finished run tell the user to wait for a
+        run that is already done, instead of naming the posts it made."""
+        from cqc_lem.utilities.content_generation_status import (
+            ContentGenerationEmptyReason, ContentGenerationState, get_generation_status,
+            mark_empty, mark_finished, mark_in_progress, record_post_generated)
+        mark_in_progress(6, [101])
+        mark_empty(6, ContentGenerationEmptyReason.ALREADY_RUNNING)
+        record_post_generated(6, 101)
+        status = mark_finished(6)
+
+        assert status["state"] == ContentGenerationState.DONE
+        assert status["completed"] == 1
+        assert "reason" not in status and "reason_detail" not in status
+        assert "reason" not in get_generation_status(6)
+
 
 class TestFailsOpen:
     def test_all_writes_noop_without_redis(self, no_redis):

--- a/tests/unit/utilities/test_db_content_buffer.py
+++ b/tests/unit/utilities/test_db_content_buffer.py
@@ -89,6 +89,69 @@ class TestGetPlannedPostsWithinBuffer:
             assert get_planned_posts_within_buffer(1, 5, 5, 0) == []
 
 
+class TestGetNextPlannedPostsAfterBuffer:
+    """The pull-forward list for an explicitly requested run (issue #719)."""
+    _ROWS = [{"user_id": 1, "id": 31, "post_type": "text", "buyer_stage": "awareness"}]
+
+    def test_selects_only_slots_beyond_the_window(self):
+        conn, cur = _mock_conn(fetch_all=self._ROWS)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_next_planned_posts_after_buffer
+            assert get_next_planned_posts_after_buffer(1, 5, 4) == self._ROWS
+        sql, params = cur.execute.call_args[0]
+        assert "status = 'planning'" in sql
+        assert "scheduled_time > NOW() + INTERVAL %s DAY" in sql
+        assert "ORDER BY scheduled_time ASC" in sql
+        assert "scheduled_time FROM posts" in sql  # the day-type key rides along (issue #621)
+        assert params == (1, 5, 4)
+
+    @pytest.mark.parametrize("limit", [0, -1])
+    def test_no_budget_queries_nothing(self, limit):
+        conn, cur = _mock_conn(fetch_all=self._ROWS)
+        with patch(f"{_DB}.get_db_connection", return_value=conn) as get_conn:
+            from cqc_lem.utilities.db import get_next_planned_posts_after_buffer
+            assert get_next_planned_posts_after_buffer(1, 5, limit) == []
+        get_conn.assert_not_called()
+        cur.execute.assert_not_called()
+
+    def test_empty_on_db_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_next_planned_posts_after_buffer
+            assert get_next_planned_posts_after_buffer(1, 5, 4) == []
+
+
+class TestGetNextPlannedPostDate:
+    def test_returns_the_soonest_upcoming_planning_slot(self):
+        import datetime as dt
+        due = dt.datetime(2026, 8, 3, 13, 30)
+        conn, cur = _mock_conn(fetch_one=(due,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_next_planned_post_date
+            assert get_next_planned_post_date(1) == due
+        sql, params = cur.execute.call_args[0]
+        assert "MIN(scheduled_time)" in sql
+        assert "status = 'planning'" in sql
+        assert "scheduled_time > NOW()" in sql
+        assert params == (1,)
+
+    def test_none_when_nothing_is_planned(self):
+        conn, _ = _mock_conn(fetch_one=(None,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_next_planned_post_date
+            assert get_next_planned_post_date(1) is None
+
+    def test_none_on_db_error(self):
+        import mysql.connector
+        conn, cur = _mock_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_next_planned_post_date
+            assert get_next_planned_post_date(1) is None
+
+
 class TestGetUserIdsWithPlannedPostsWithinBuffer:
     def test_returns_distinct_user_ids(self):
         conn, cur = _mock_conn(fetch_all=[(4,), (9,)])


### PR DESCRIPTION
## What & why

Clicking **Generate Weekly Content** could legitimately generate nothing, and the SPA reported only "0 posts are ready to review" — no reason, no next step. The owner hit this in prod (user 1, 2026-07-27) and reasonably read it as content generation being broken. Both tasks ran fine; they exited on long-standing early-exit guards (`plan_content_for_user` only appends after the last planning row, `_top_up_buffer_for_user` only looks `content_buffer_days` ahead, and every late-July slot had already been posted or rejected).

Both halves of the issue's proposed fix are implemented.

### 1. Communicate the reason

`_close_out_empty_run` now records WHY it closed empty, via a new `mark_empty()` in `content_generation_status.py`:

| reason | when |
|---|---|
| `already_running` | another top-up holds the single-flight lock |
| `buffer_full` | enough ready posts already sit ahead |
| `no_planned_slots` | nothing left planned to generate from |

It writes the same terminal `done`/`total=0` record the SPA already understands, plus `reason` and a `reason_detail` carrying `next_planned_at`, `buffer_days`, `ready_count`, `buffer_max`. Unknown values are **omitted rather than zeroed** — "we don't know" must never render as "0 posts ready". `next_planned_at` is serialized with an explicit UTC offset per `docs/timezone-contract.md`, so the SPA renders the slot date in the user's own timezone.

`GET /content_generation_status/` already returns the whole payload, so there is no API change.

The ContentStudio banner renders the explanation in **amber** (not a green success) with the headline replaced, e.g.:

> **Nothing to generate right now — no slots are due yet**
> Your next planned post is Aug 3. Generation starts automatically about 5 days before each planned slot.

### 2. Make the button useful

An explicit click now looks PAST the buffer window: when the window holds no `planning` rows, `_pull_forward_planned_posts` fetches the next planned posts beyond it and generates them (new `get_next_planned_posts_after_buffer` / `get_next_planned_post_date` in `db.py`, forward-only — a planning row already in the past is a stale slot).

Bounded by the **same** `content_buffer_max_posts` ceiling, but counted across the whole 30-day planning horizon rather than the 5-day window — otherwise repeated clicks would walk the cap down the calendar and generate the entire month. Once everything ahead is generated, a further click reports `buffer_full` with the count instead of spending more.

The **beat run never pulls forward** (`requested=True` only): generating a week early on autopilot is spend nobody asked for.

### Deliberately not in scope

Rejected slots still leave permanent holes in the plan — `plan_content_for_user` only ever appends after the last planning row. The issue offered re-planning those as an alternative to pull-forward; pull-forward is what's implemented, so the button always either generates or explains itself, but the plan itself is unchanged.

## Testing notes

- `poetry run pytest tests/unit -q` → **7661 passed** locally.
- New Python tests: `mark_empty` payload/TTL/UTC-normalization/fails-open (`test_content_generation_status.py`), per-exit reason + detail assertions, pull-forward, beat-run-never-pulls-forward, and the repeated-click cap (`test_content_generation_progress.py`), SQL shape + error paths for both new db helpers (`test_db_content_buffer.py`).
- New vitest suite `src/utils/generationStatus.test.ts` covers the user-facing copy: next-slot date rendered in the USER timezone, singular/plural, the no-upcoming-slot fallback, and that the helper stays out of the way for runs that generated posts or that carry no reason (pre-#719 payloads).
- The empty-run banner copy was extracted to `ui/src/utils/generationStatus.ts` so the wording is unit-testable outside the page component.
- vitest could not be run locally (node 18 on this box; the repo needs newer) — CI's `ui-build` job is the check.

Closes #719

🤖 Generated with [Claude Code](https://claude.com/claude-code)
