### PR TITLE
feat(models): benchmark cron-detected model candidates against tier contracts (closes #721)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -879,3 +879,26 @@ PACING_REST_DAY_CHANCE=0.08
 PACING_WEEKEND_RATIO=0.55
 # Optional salt for the seeded draws — change it to reshuffle every user's budget/rest-day pattern.
 PACING_SEED=
+
+# --- Model-tier evaluation harness (issue #721) --------------------------------------------
+# The weekly model-health cron (#716) detects new/upgraded Ollama Cloud candidates. This gate
+# decides whether they are also MEASURED: each candidate and the tier's current champion run the
+# synthetic suites in tests/benchmarks/model_tiers/ and the run is committed as a report PR under
+# docs/model-benchmarks/. OFF by default — a benchmark run costs provider tokens. It is advisory
+# only: it never edits .litellm/config.yaml and never writes the retirement map.
+BENCHMARK_ENABLED=false
+# Hard ceiling on LLM-judge calls per run. Deterministic checks are free and run first, and a case
+# that already failed them never spends a judge call. The runner truncates AND logs the truncation
+# rather than quietly grading a subset.
+BENCHMARK_MAX_JUDGE_CALLS=200
+# How many cron-detected candidates one run may benchmark (the rest are logged and left for the
+# next week, never silently dropped).
+BENCHMARK_MAX_CANDIDATES=3
+# Seconds to wait for PostHog's async evaluation verdicts before a case is reported as
+# judge:timeout. A missing verdict is NEVER counted as a pass.
+BENCHMARK_JUDGE_TIMEOUT_SECONDS=90
+# Judge scoring uses PostHog Evaluations via POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID (see
+# the PostHog section above) plus POSTHOG_API_KEY for emitting the tagged $ai_generation events.
+# PostHog's judge needs its own provider key configured IN PostHog (Ollama Cloud is not a judge
+# provider). With no personal key the runner degrades to an in-runner lem-medium judge and emits
+# $ai_metric instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,6 +406,40 @@ never be summed — one signup produces both. `scripts/posthog_provision.py` pro
 Channels** dashboard plus the two web-analytics conversion goals (as PostHog *actions*: signup →
 the browser event, activation → `activated`). Full posture: `docs/marketing-attribution.md`.
 
+### Model-tier evaluation harness (`scripts/benchmark_models.py`, issue #721)
+
+#716 taught the weekly model-health cron to SEE change coming (advance retirements, new Ollama
+Cloud tags, a family we trail); it could never say whether a candidate was any GOOD, so #717's
+roster refresh was decided on spec sheets. This is the measurement half. Each LiteLLM tier is a
+CONTRACT encoded as a fixed suite of synthetic prompts in `tests/benchmarks/model_tiers/<tier>.json`
+(10–20 cases, drawn from LEM's real prompt shapes, **no user data**), and every cron-detected
+candidate runs it **beside the tier's current champion** — a verdict is always a comparison.
+
+Two scoring layers, in this order. **Deterministic** is the source of truth and it is the in-repo
+linters, not a second copy of them: `slop_lint.lint_report`, `content_framework.comment_contract_report`,
+`routing_policy.complexity_tier` (the `lem-router` contract — deterministic and model-independent
+on purpose, so it is a regression guard on the ROUTER), plus length/shape/JSON/burstiness/
+self-similarity assertions. A case that fails here never spends a judge call. **LLM judge** is
+PostHog Evaluations scoring the harness's OWN tagged `$ai_generation` events (emitted independently
+of #647's prod callback, because the harness calls Ollama Cloud directly), whose `conditions` filter
+on `benchmark_run_id` — a property production traffic never carries, so an enabled evaluation can
+never bill against a customer. No judge-provider key degrades to an in-runner `lem-medium` judge
+emitting `$ai_metric`; a verdict that never lands is `judge:timeout`, never a fabricated score, and
+the report names the mode it ran in.
+
+The gate is champion/challenger and only `recommend` (clears the tier's absolute floors AND
+meets-or-beats the champion on every graded expectation) becomes a swap recommendation —
+`recommend-deterministic-only` / `no-baseline` / `reject` are reported and go no further. A
+recommendation is deliberately **rendered, never written**: `.litellm/model_upgrades.yaml` is the
+RETIREMENT map that `model_health_check.py` auto-swaps into the live config, so a benchmark win must
+not walk itself into production. Reports land in `docs/model-benchmarks/<date>-<run_id>.md` plus a
+rolling leaderboard, committed through the same ephemeral-worktree `open_pr` flow — and
+`render_report` runs `assert_benchmark_only` first, so a run that isn't provably benchmark output
+never reaches disk. OFF unless `BENCHMARK_ENABLED`; judge calls are capped per run; a benchmark
+failure alerts but never blocks the retirement-swap safety path. `--dry-run` renders a full report
+from each case's committed canned output with zero network calls. Full posture:
+`docs/model-benchmarks/README.md`.
+
 ### Content-quality telemetry (`utilities/content_quality.py`, issue #630)
 
 Every other quality gate is a one-time verdict — the slop lint (#625) blocks a draft, the comment

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -1,0 +1,85 @@
+# Model-tier benchmarks
+
+Rolling standing of every model LEM has measured against a LiteLLM tier contract (issue #721).
+
+Each row is one model × one tier from one run of `scripts/benchmark_models.py`. Per-run detail —
+which case failed, what the judge said, latency and token counts — lives in the dated report beside
+this file (`<date>-<run_id>.md`).
+
+## Why this exists
+
+`scripts/model_health_check.py` (#716) detects that a model is *about to change*: a published
+retirement, a new Ollama Cloud tag, a family we trail. It cannot say whether a candidate is any
+**good** — before this, a swap was decided on a spec sheet. The benchmark is the measurement half,
+and it always runs the current **champion** alongside the candidate, so a verdict is a comparison
+rather than an absolute claim about one model.
+
+## What is measured
+
+| Tier | Contract |
+|---|---|
+| `lem-simple` | Short outputs ≤300 chars: refine, brief summarize, comma lists. Obeys the shape, no preamble. |
+| `lem-medium` | Feed comments (must satisfy the #617 comment quality contract), post refinement, blog summaries, DMs. |
+| `lem-complex` | Long-form thought leadership / personal story / industry news / carousels / newsletter editions — blueprint-shaped and slop-lint clean. |
+| `lem-router` | The `LEMComplexityRouter` classification contract, plus a clean answer at the router alias. |
+
+Two scoring layers, in this order:
+
+1. **Deterministic** (free, in-repo, the source of truth) — length caps, comma-list shape, JSON
+   validity, `slop_lint.lint_report`, `content_framework.comment_contract_report`, burstiness,
+   lexical self-similarity, and `routing_policy.complexity_tier`. A case that fails here never
+   spends a judge call.
+2. **LLM judge** (paid, capped) — PostHog Evaluations scoring the harness's own tagged
+   `$ai_generation` events, filtered to a `benchmark_run_id` so it can never bill against
+   production traffic. With no judge provider configured, the runner degrades to an in-runner
+   `lem-medium` judge and emits `$ai_metric`. A verdict that never arrives is `judge:timeout` —
+   never a fabricated score. The report names the mode it ran in.
+
+Suite inputs are **synthetic** prompt templates in `tests/benchmarks/model_tiers/`. No customer
+content, credentials or production logs appear in a report; the renderer refuses any run that is
+not tagged as benchmark output.
+
+## The gate
+
+A candidate is emitted as a **swap recommendation** only when it clears the tier's absolute
+thresholds *and* meets-or-beats the champion on every graded expectation. Weaker outcomes are
+reported but go no further:
+
+| Verdict | Meaning |
+|---|---|
+| `recommend` | Cleared every floor and matched or beat the champion. The only verdict that becomes a recommendation. |
+| `recommend-deterministic-only` | Cleared the deterministic floors, but judge evidence was missing on one side. Advisory. |
+| `no-baseline` | No champion measured for that tier — nothing to compare against. |
+| `reject` | Failed at least one expectation. |
+
+A recommendation is **not** a change. `.litellm/model_upgrades.yaml` is the RETIREMENT map and the
+reactive half of the model-health check auto-swaps whatever lands in it, so adopting a benchmark
+winner is a deliberate edit to `.litellm/config.yaml` (or a #717-style PR). The report renders the
+exact mapping lines for a human to take.
+
+## Running it
+
+```bash
+# Offline proof — scores the suites against each case's committed canned output. No network at all.
+poetry run python scripts/benchmark_models.py --dry-run --models qwen3.6:400b --out-dir /tmp/bm
+
+# Validate the suites only.
+poetry run python scripts/benchmark_models.py --print-suites
+
+# A real run (needs BENCHMARK_ENABLED, OLLAMA_CLOUD_URL / OLLAMA_CLOUD_API_KEY).
+poetry run python scripts/benchmark_models.py --run --models qwen3.6:400b --results-out /tmp/bm.json
+
+# Re-render a report from a saved results file (what the cron's PR worktree does).
+poetry run python scripts/benchmark_models.py --render /tmp/bm.json --out-dir docs/model-benchmarks
+```
+
+`scripts/weekly_model_check.sh` invokes it automatically for the candidates the #716 catalog scan
+found, and opens the report as a PR. A benchmark failure alerts but never blocks the retirement-swap
+safety path.
+
+## Leaderboard
+
+<!-- LEADERBOARD:BEGIN -->
+| Date | Run | Tier | Model | Role | Deterministic | Judge | p50 | Verdict |
+|---|---|---|---|---|---|---|---|---|
+<!-- LEADERBOARD:END -->

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -32,8 +32,12 @@ Two scoring layers, in this order:
 2. **LLM judge** (paid, capped) — PostHog Evaluations scoring the harness's own tagged
    `$ai_generation` events, filtered to a `benchmark_run_id` so it can never bill against
    production traffic. With no judge provider configured, the runner degrades to an in-runner
-   `lem-medium` judge and emits `$ai_metric`. A verdict that never arrives is `judge:timeout` —
-   never a fabricated score. The report names the mode it ran in.
+   `lem-medium` judge and emits `$ai_metric` — that degradation is decided by the RESULT, not by
+   config the runner cannot see: PostHog's judge needs a provider key of its own (it cannot judge
+   via Ollama Cloud), so a run whose evaluations exist but score nothing spends what is left of the
+   cap on the in-runner judge and reports the mode as `posthog-evals+in-runner-judge`. A verdict
+   that never arrives either way is `judge:timeout` — never a fabricated score, and never dropped
+   from the scorecard, so a partial read cannot render as a full-marks judge pass.
 
 Suite inputs are **synthetic** prompt templates in `tests/benchmarks/model_tiers/`. No customer
 content, credentials or production logs appear in a report; the renderer refuses any run that is

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -82,14 +82,22 @@ BENCHMARK_DISTINCT_ID = "model-benchmark"
 
 SCORING_POSTHOG = "posthog-evals"
 SCORING_FALLBACK = "in-runner-judge"
+SCORING_MIXED = "posthog-evals+in-runner-judge"
 SCORING_DETERMINISTIC = "deterministic-only"
 SCORING_DRY_RUN = "dry-run-canned"
 
 JUDGE_TIMEOUT = "judge:timeout"
+# Kept apart from JUDGE_TIMEOUT so the runner can tell "this answer confused the judge" (retry the
+# next case) from "the judge is not reachable at all" (stop asking). Both are still unscored.
+JUDGE_UNAVAILABLE = "judge:unavailable"
 
 LEADERBOARD_BEGIN = "<!-- LEADERBOARD:BEGIN -->"
 LEADERBOARD_END = "<!-- LEADERBOARD:END -->"
 LEADERBOARD_MAX_ROWS = 400
+LEADERBOARD_COLUMNS = ("Date", "Run", "Tier", "Model", "Role", "Deterministic", "Judge", "p50",
+                       "Verdict")
+LEADERBOARD_HEADER = "| " + " | ".join(LEADERBOARD_COLUMNS) + " |"
+LEADERBOARD_DIVIDER = "|" + "---|" * len(LEADERBOARD_COLUMNS)
 
 _OLLAMA_MARKER = "OLLAMA_CLOUD_URL"
 
@@ -790,7 +798,14 @@ def _row_key(row: dict) -> tuple:
 
 def _parse_row(line: str) -> Optional[dict]:
     cells = [c.strip() for c in line.strip().strip("|").split("|")]
-    if len(cells) != 9:
+    if len(cells) != len(LEADERBOARD_COLUMNS):
+        return None
+    # The table's own header and divider are pipe-delimited rows of the right width. Reading them
+    # back as DATA is how a rolling table quietly grows two junk rows per render and evicts real
+    # history at the row cap, so they are recognised and dropped here rather than re-emitted.
+    if [c.strip("`") for c in cells] == list(LEADERBOARD_COLUMNS):
+        return None
+    if all(c and set(c.strip("`")) <= {"-", ":"} for c in cells):
         return None
     return {"date": cells[0], "run_id": cells[1].strip("`"), "tier": cells[2],
             "model": cells[3].strip("`"), "role": cells[4], "deterministic": cells[5],
@@ -802,8 +817,7 @@ def update_leaderboard(text: str, rows: list) -> str:
 
     Re-running the same run id REPLACES its rows rather than appending duplicates, so a re-render
     (a failed PR retried, a `--render` of an older results file) is idempotent."""
-    header = ["| Date | Run | Tier | Model | Role | Deterministic | Judge | p50 | Verdict |",
-              "|---|---|---|---|---|---|---|---|---|"]
+    header = [LEADERBOARD_HEADER, LEADERBOARD_DIVIDER]
     body = str(text or "")
     if LEADERBOARD_BEGIN in body and LEADERBOARD_END in body:
         before, rest = body.split(LEADERBOARD_BEGIN, 1)
@@ -1188,8 +1202,21 @@ def fallback_judge(suite: dict, case: dict, output: str) -> dict:
             temperature=0, max_tokens=200)
         return parse_judge_verdict(response.choices[0].message.content)
     except Exception as exc:  # noqa: BLE001 - an unavailable judge is unscored, never a pass
-        return {"passes": None, "status": JUDGE_TIMEOUT,
+        return {"passes": None, "status": JUDGE_UNAVAILABLE,
                 "reasoning": f"fallback judge unavailable: {str(exc)[:120]}"}
+
+
+def flush_events() -> None:
+    """Drain posthog-python's background batch queue.
+
+    The manual eval-run endpoint is keyed by the generation's event uuid, so triggering it while
+    that event is still sitting in the client's queue asks PostHog to score something it has never
+    seen. Best-effort: a client that was never configured has nothing to flush."""
+    try:
+        import posthog
+        posthog.flush()
+    except Exception:  # noqa: BLE001 - flushing is best-effort, never a run failure
+        pass
 
 
 def poll_judge_results(evals: "PostHogEvals", run_id: str, expected: int,
@@ -1235,6 +1262,13 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
         if champion:
             targets.append((tier, champion, "champion"))
         for model in models:
+            if model == champion:
+                # Benchmarking a model against ITSELF ties every expectation, which the gate reads
+                # as meets-or-beats and would emit as a `X -> X` swap recommendation straight into
+                # the retirement-map block. It is not a comparison; skip the tier.
+                print(f"  {model} already serves {tier} — skipping it as a candidate there",
+                      file=sys.stderr)
+                continue
             targets.append((tier, model, "candidate"))
 
     scoring_mode = SCORING_DRY_RUN if dry_run else (
@@ -1259,7 +1293,9 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
     scorecards: list = []
     judge_budget = max(0, int(judge_cap))
     judge_spent = 0
+    fallback_down = False  # the in-runner judge answered "unreachable" — stop asking it
     pending: list = []  # (tier, model, role, case_id, event_id) awaiting PostHog verdicts
+    awaiting: list = []  # (card, suite, outputs, judge_results) whose verdicts PostHog still owes
 
     for tier, model, role in targets:
         suite = suites[tier]
@@ -1292,6 +1328,8 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
 
         judge_results: dict = {}
         if judge_enabled:
+            if evals is not None and not dry_run:
+                flush_events()
             planned = plan_judge_calls(case_results, suite, judge_budget - judge_spent)
             skipped = len(judgeable_cases(case_results, suite)) - len(planned)
             if skipped > 0:
@@ -1318,28 +1356,66 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
                                   file=sys.stderr)
                     judge_results[case_id] = {"passes": None, "status": JUDGE_TIMEOUT,
                                               "reasoning": "awaiting PostHog verdict"}
+                elif fallback_down:
+                    # The judge answered the FIRST case with "I am not reachable". Re-asking it
+                    # forty more times costs the openai client's retry budget per case and cannot
+                    # produce a verdict, so the rest of the run is unscored deliberately.
+                    judge_results[case_id] = {"passes": None, "status": JUDGE_UNAVAILABLE,
+                                              "reasoning": "fallback judge unavailable"}
+                    continue
                 else:
                     verdict = fallback_judge(suite, case, outputs.get(case_id) or "")
                     judge_results[case_id] = verdict
-                    emit_metric(run_id, tier, case_id, model, verdict)
+                    if verdict.get("status") == JUDGE_UNAVAILABLE:
+                        fallback_down = True
+                        print(f"  ! in-runner judge unreachable ({verdict.get('reasoning')}) — "
+                              "the remaining cases are reported unscored", file=sys.stderr)
+                    else:
+                        emit_metric(run_id, tier, case_id, model, verdict)
                 judge_spent += 1
 
         card = merge_scorecard(tier, model, role, case_results, judge_results, timings)
         card["benchmark_run_id"] = run_id
         scorecards.append(card)
+        if evals is not None and judge_enabled and not dry_run and judge_results:
+            awaiting.append((card, suite, outputs, judge_results))
 
-    if evals is not None and judge_enabled and not dry_run and judge_spent:
+    if awaiting and judge_spent:
         rows = poll_judge_results(evals, run_id, judge_spent, judge_timeout_seconds())
-        for card in scorecards:
-            verdicts = merge_judge_events(rows, card["model"], card["tier"])
-            if verdicts:
-                merged = merge_scorecard(card["tier"], card["model"], card["role"],
-                                         card["case_results"], verdicts,
-                                         {r["case_id"]: {"latency_ms": None} for r in
-                                          card["case_results"]})
-                for key in ("judged", "judge_passed", "judge_timeouts", "judge_pass_rate",
-                            "judge_notes"):
-                    card[key] = merged[key]
+        posthog_scored = fallback_used = False
+        for card, suite, outputs, judge_results in awaiting:
+            # UPDATE, never replace: a case PostHog never scored has to stay in the dict as a
+            # timeout. Rebuilding the card from the returned rows alone drops it entirely, and a
+            # partial read would then render as a full-marks judge pass on a cherry-picked subset.
+            judge_results.update(merge_judge_events(rows, card["model"], card["tier"]))
+            posthog_scored = posthog_scored or any(v.get("passes") is not None
+                                                   for v in judge_results.values())
+            # PostHog accepted the events but scored none of them — the documented degraded case
+            # (its judge needs a provider key of its own; it cannot judge via Ollama Cloud). Spend
+            # what is left of the cap on the in-runner judge rather than reporting a run whose
+            # every case is unscorable, which the gate can only ever read as no evidence at all.
+            for case_id in sorted(judge_results):
+                if judge_results[case_id].get("passes") is not None or fallback_down:
+                    continue
+                if judge_spent >= judge_budget:
+                    break
+                replacement = fallback_judge(suite, _case_by_id(suite, case_id),
+                                             outputs.get(case_id) or "")
+                judge_spent += 1
+                if replacement.get("status") == JUDGE_UNAVAILABLE:
+                    fallback_down = True
+                if replacement.get("passes") is None:
+                    continue
+                judge_results[case_id] = replacement
+                emit_metric(run_id, card["tier"], case_id, card["model"], replacement)
+                fallback_used = True
+            merged = merge_scorecard(card["tier"], card["model"], card["role"],
+                                     card["case_results"], judge_results, {})
+            for key in ("judged", "judge_passed", "judge_timeouts", "judge_pass_rate",
+                        "judge_notes"):
+                card[key] = merged[key]
+        if fallback_used:
+            scoring_mode = SCORING_MIXED if posthog_scored else SCORING_FALLBACK
 
     gates = gate_run(scorecards, suites)
     recommendations = swap_recommendations(gates)

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -1,0 +1,1496 @@
+#!/usr/bin/env python3
+"""Model-tier evaluation harness (issue #721).
+
+#716 taught the weekly model-health cron to SEE change coming — advance retirements, new Ollama
+Cloud tags, a family we trail. What it could never do is say whether a candidate is any GOOD: a
+swap PR was decided on a spec sheet. This is the measurement half.
+
+Each LiteLLM tier is a CONTRACT (`tests/benchmarks/model_tiers/<tier>.json`): a fixed set of
+synthetic prompts drawn from LEM's real prompt shapes, plus the properties a usable answer must
+have. Every cron-detected candidate AND the tier's current champion runs the same suite, so a
+recommendation is always a comparison, never an absolute claim about one model.
+
+Two scoring layers, in this order:
+  1. DETERMINISTIC (free, in-repo, the source of truth) — length caps, comma-list shape, JSON
+     validity, `slop_lint.lint_report`, `content_framework.comment_contract_report`, burstiness,
+     lexical self-similarity, the `LEMComplexityRouter` tier contract. A case that fails HARD here
+     never spends a judge call.
+  2. LLM JUDGE (paid, sampled, capped) — PostHog Evaluations scoring our own tagged
+     `$ai_generation` events, or, when no judge provider is configured, an in-runner `lem-medium`
+     judge whose verdicts are emitted as `$ai_metric`. A judge that never answers is
+     `judge:timeout` — NEVER a fabricated score.
+
+The gate is champion/challenger: a candidate is emitted as a swap recommendation only when it meets
+the tier's absolute thresholds AND meets-or-beats the champion on every graded expectation. It is
+deliberately a RECOMMENDATION and not a write to `.litellm/model_upgrades.yaml` — that map is the
+RETIREMENT map and the reactive half of the model-health check auto-swaps whatever lands in it, so a
+benchmark win must not walk itself into the live config. The report renders the exact mapping lines
+for a human (or a #717-style PR) to adopt.
+
+Split like the other ops scripts: PURE logic (suite loading, assertion evaluation, scorecard merge,
+gate decision, report/leaderboard rendering) over a thin I/O layer (provider completions, PostHog
+emission/eval API/HogQL polling, file writes) that the tests mock.
+
+CLI:
+  --run                    Execute the benchmark and write results JSON (--results-out). Default.
+  --dry-run                Score the suites against each case's canned output. NO network at all.
+  --render RESULTS.json    Pure render: write the report + update the leaderboard. No network.
+  --print-suites           Validate and summarise the suites. No network.
+Options:
+  --models a,b             Candidate models (bare Ollama tags). Empty = champions only (baseline).
+  --champions t=model,…    Override the champion per tier (default: read from --config).
+  --tiers a,b              Tiers to run (default: every suite found).
+  --suite-dir DIR          Suite fixtures (default tests/benchmarks/model_tiers).
+  --config PATH            LiteLLM config the champions are read from (default .litellm/config.yaml).
+  --out-dir DIR            Report + leaderboard directory (default docs/model-benchmarks).
+  --results-out PATH       Where --run/--dry-run writes the machine-readable results.
+  --recommendations-out P  Write ONLY the swap recommendations (for the cron) to this path.
+  --no-judge               Deterministic checks only.
+  --max-judge-calls N      Hard cap on judge calls for the whole run (default BENCHMARK_MAX_JUDGE_CALLS).
+  --run-id ID              Fix the run id (tests / reproducible dry runs).
+  --today YYYY-MM-DD       Override today's date.
+Exit: 0 ran / nothing recommended, 2 at least one swap recommendation, 1 error.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from datetime import datetime, timezone
+from typing import Callable, Optional
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(_HERE, "..", "src"))
+sys.path.insert(0, _HERE)  # model_health_check is a sibling script, not a package module
+
+DEFAULT_SUITE_DIR = "tests/benchmarks/model_tiers"
+DEFAULT_CONFIG = ".litellm/config.yaml"
+DEFAULT_OUT_DIR = "docs/model-benchmarks"
+DEFAULT_PROJECT_ID = "475262"  # "CQC LEM" — not a secret; the key that reaches it is.
+DEFAULT_APP_HOST = "https://us.posthog.com"
+
+TIERS = ("lem-simple", "lem-medium", "lem-complex", "lem-router")
+
+# Every benchmark event carries these, and the report renderer REFUSES anything that doesn't. The
+# reports are committed to a public repo, so "this row came from prod traffic" has to be impossible
+# rather than unlikely.
+BENCHMARK_SOURCE = "benchmark"
+BENCHMARK_DISTINCT_ID = "model-benchmark"
+
+SCORING_POSTHOG = "posthog-evals"
+SCORING_FALLBACK = "in-runner-judge"
+SCORING_DETERMINISTIC = "deterministic-only"
+SCORING_DRY_RUN = "dry-run-canned"
+
+JUDGE_TIMEOUT = "judge:timeout"
+
+LEADERBOARD_BEGIN = "<!-- LEADERBOARD:BEGIN -->"
+LEADERBOARD_END = "<!-- LEADERBOARD:END -->"
+LEADERBOARD_MAX_ROWS = 400
+
+_OLLAMA_MARKER = "OLLAMA_CLOUD_URL"
+
+# Openers that mean the model narrated instead of answering. `lem-simple` outputs are pasted
+# straight into LinkedIn copy, so a preamble is a correctness failure, not a style nit.
+_PREAMBLE_RE = re.compile(
+    r"^\s*(?:sure|certainly|of course|absolutely|here(?:'s| is| are)|below (?:is|are)|"
+    r"i(?:'| a)m happy to|as an ai|great question|thanks for)\b",
+    re.IGNORECASE)
+
+_WORD_RE = re.compile(r"[a-z0-9']+")
+
+
+# ─────────────────────────── env / small helpers ────────────────────────────────
+
+def _env_flag(name: str, default: bool = False) -> bool:
+    raw = (os.environ.get(name) or "").strip().lower()
+    if not raw:
+        return default
+    return raw in ("1", "true", "yes", "on")
+
+
+def _env_int(name: str, default: int, low: int = 0, high: int = 100000) -> int:
+    raw = (os.environ.get(name) or "").strip()
+    try:
+        return max(low, min(high, int(raw))) if raw else default
+    except ValueError:
+        return default
+
+
+def _env_float(name: str, default: float, low: float = 0.0, high: float = 1.0) -> float:
+    raw = (os.environ.get(name) or "").strip()
+    try:
+        return max(low, min(high, float(raw))) if raw else default
+    except ValueError:
+        return default
+
+
+def benchmark_enabled() -> bool:
+    return _env_flag("BENCHMARK_ENABLED", False)
+
+
+def max_judge_calls() -> int:
+    """Hard ceiling on judge calls for one run. 200 covers four tiers × (one champion + up to three
+    candidates) × ten cases; anything beyond that is a runaway, and the runner truncates and SAYS
+    it truncated rather than quietly grading a subset."""
+    return _env_int("BENCHMARK_MAX_JUDGE_CALLS", 200, low=0, high=5000)
+
+
+def judge_timeout_seconds() -> int:
+    return _env_int("BENCHMARK_JUDGE_TIMEOUT_SECONDS", 90, low=5, high=900)
+
+
+def _today() -> str:
+    return datetime.now(timezone.utc).date().isoformat()
+
+
+def _read_text(path: str) -> str:
+    with open(path) as f:
+        return f.read()
+
+
+# ───────────────────────────── suite loading (pure) ──────────────────────────────
+
+class SuiteError(ValueError):
+    """A suite fixture that cannot be trusted to grade a model."""
+
+
+def load_suite(doc: dict, *, name: str = "<suite>") -> dict:
+    """Validate one tier suite document. Raises `SuiteError` rather than grading a model against a
+    malformed contract — a suite with a typo'd assertion type would silently score every candidate
+    as passing, which is worse than no benchmark at all."""
+    if not isinstance(doc, dict):
+        raise SuiteError(f"{name}: suite must be a JSON object")
+    tier = str(doc.get("tier") or "").strip()
+    if tier not in TIERS:
+        raise SuiteError(f"{name}: unknown tier {tier!r}")
+    cases = doc.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise SuiteError(f"{name}: suite has no cases")
+    seen: set = set()
+    for case in cases:
+        if not isinstance(case, dict):
+            raise SuiteError(f"{name}: case must be an object")
+        case_id = str(case.get("id") or "").strip()
+        if not case_id:
+            raise SuiteError(f"{name}: case is missing an id")
+        if case_id in seen:
+            raise SuiteError(f"{name}: duplicate case id {case_id!r}")
+        seen.add(case_id)
+        messages = case.get("messages")
+        if not isinstance(messages, list) or not messages:
+            raise SuiteError(f"{name}/{case_id}: case has no messages")
+        for message in messages:
+            if not isinstance(message, dict) or not str(message.get("content") or "").strip():
+                raise SuiteError(f"{name}/{case_id}: malformed message")
+        assertions = case.get("assertions")
+        if not isinstance(assertions, list) or not assertions:
+            raise SuiteError(f"{name}/{case_id}: case has no assertions")
+        for assertion in assertions:
+            kind = (assertion or {}).get("type") if isinstance(assertion, dict) else None
+            if kind not in ASSERTIONS:
+                raise SuiteError(f"{name}/{case_id}: unknown assertion type {kind!r}")
+    return {
+        "tier": tier,
+        "version": int(doc.get("version") or 1),
+        "contract": str(doc.get("contract") or ""),
+        "judge_rubric": str(doc.get("judge_rubric") or ""),
+        "thresholds": normalize_thresholds(doc.get("thresholds")),
+        "cases": cases,
+    }
+
+
+def normalize_thresholds(raw: Optional[dict]) -> dict:
+    """A tier's absolute floors. Defaults are deliberately strict on the deterministic side (those
+    checks encode contracts LEM already enforces in production) and looser on the judge side, where
+    a single rubric disagreement should not sink a model."""
+    doc = raw if isinstance(raw, dict) else {}
+
+    def num(key: str, default: float) -> float:
+        try:
+            return max(0.0, min(1.0, float(doc.get(key, default))))
+        except (TypeError, ValueError):
+            return default
+
+    try:
+        min_judged = max(0, int(doc.get("min_judged", 3)))
+    except (TypeError, ValueError):
+        min_judged = 3
+    return {"deterministic_pass_rate": num("deterministic_pass_rate", 0.9),
+            "judge_pass_rate": num("judge_pass_rate", 0.8),
+            "min_judged": min_judged}
+
+
+def load_suites(suite_dir: str, tiers: Optional[list] = None) -> dict:
+    """Read `<suite_dir>/<tier>.json` for each requested tier -> {tier: suite}."""
+    wanted = [t for t in (tiers or TIERS)]
+    suites: dict = {}
+    for tier in wanted:
+        path = os.path.join(suite_dir, f"{tier}.json")
+        if not os.path.exists(path):
+            if tiers:  # explicitly asked for -> a missing suite is an error, not a silent skip
+                raise SuiteError(f"no suite fixture at {path}")
+            continue
+        suites[tier] = load_suite(json.loads(_read_text(path)), name=os.path.basename(path))
+    if not suites:
+        raise SuiteError(f"no suite fixtures found in {suite_dir}")
+    return suites
+
+
+# ──────────────────────── deterministic assertions (pure) ────────────────────────
+
+def _tokens(text: str) -> list:
+    return _WORD_RE.findall(str(text or "").lower())
+
+
+def lexical_similarity(a: str, b: str) -> float:
+    """Jaccard token overlap — the same deterministic measure the comment/post similarity gates fall
+    back to when embeddings are unavailable. Used here on purpose: a benchmark must be reproducible
+    offline, and an embedding call would make the score depend on a second model."""
+    left, right = set(_tokens(a)), set(_tokens(b))
+    if not left or not right:
+        return 0.0
+    return len(left & right) / float(len(left | right))
+
+
+def _fail(detail: str) -> dict:
+    return {"passes": False, "detail": detail}
+
+
+def _pass(detail: str = "") -> dict:
+    return {"passes": True, "detail": detail}
+
+
+def _a_max_chars(spec: dict, output: str, case: dict) -> dict:
+    limit = int(spec.get("value") or 0)
+    n = len(output)
+    return _pass(f"{n} chars") if n <= limit else _fail(f"{n} chars > {limit}")
+
+
+def _a_min_chars(spec: dict, output: str, case: dict) -> dict:
+    limit = int(spec.get("value") or 0)
+    n = len(output)
+    return _pass(f"{n} chars") if n >= limit else _fail(f"{n} chars < {limit}")
+
+
+def _a_no_preamble(spec: dict, output: str, case: dict) -> dict:
+    match = _PREAMBLE_RE.match(output or "")
+    return _fail(f"opens with a preamble ({match.group(0).strip()!r})") if match else _pass()
+
+
+def _a_comma_list(spec: dict, output: str, case: dict) -> dict:
+    items = [p.strip() for p in str(output or "").split(",")]
+    items = [p for p in items if p]
+    low = int(spec.get("min_items") or 1)
+    high = int(spec.get("max_items") or low)
+    if "\n" in (output or "").strip():
+        return _fail("multi-line output where a single comma-separated line was asked for")
+    if not (low <= len(items) <= high):
+        return _fail(f"{len(items)} comma-separated items, expected {low}-{high}")
+    return _pass(f"{len(items)} items")
+
+
+def _a_json_object(spec: dict, output: str, case: dict) -> dict:
+    text = str(output or "").strip()
+    if text.startswith("```"):
+        return _fail("JSON wrapped in a markdown fence")
+    try:
+        parsed = json.loads(text)
+    except ValueError as exc:
+        return _fail(f"not valid JSON ({str(exc)[:60]})")
+    if not isinstance(parsed, dict):
+        return _fail("valid JSON but not an object")
+    missing = [k for k in (spec.get("required_keys") or []) if k not in parsed]
+    return _fail(f"missing keys: {', '.join(missing)}") if missing else _pass()
+
+
+def _a_slop_lint(spec: dict, output: str, case: dict) -> dict:
+    from cqc_lem.utilities.ai.slop_lint import lint_report
+    report = lint_report(output, spec.get("content_type") or "post",
+                         spec.get("exempt_keyword"))
+    if not report.get("checked"):
+        # The lint is env-gated. Unchecked is NOT a pass — it is no reading, and grading it as a
+        # pass would let a disabled linter flatter every candidate equally.
+        return {"passes": None, "detail": "slop lint disabled for this surface"}
+    hard = report.get("hard") or []
+    if hard:
+        return _fail("; ".join(v.get("detail", v.get("check", "")) for v in hard))
+    warnings = report.get("warnings") or []
+    return _pass(f"{len(warnings)} warning(s)" if warnings else "clean")
+
+
+def _a_comment_contract(spec: dict, output: str, case: dict) -> dict:
+    from cqc_lem.utilities.ai.content_framework import comment_contract_report
+    post = (case.get("context") or {}).get("post_content") or spec.get("post_content")
+    report = comment_contract_report(output, post)
+    if report.get("passes"):
+        return _pass("; ".join(report.get("value_adds") or []) or "contract met")
+    return _fail("; ".join(report.get("failures") or ["fails the comment contract"]))
+
+
+def _a_min_burstiness(spec: dict, output: str, case: dict) -> dict:
+    from cqc_lem.utilities.ai.slop_lint import burstiness
+    score = burstiness(output)
+    if score is None:
+        return {"passes": None, "detail": "too few sentences to measure burstiness"}
+    floor = float(spec.get("value") or 0.0)
+    return _pass(f"{score:.2f}") if score >= floor else _fail(f"burstiness {score:.2f} < {floor}")
+
+
+def _a_max_similarity(spec: dict, output: str, case: dict) -> dict:
+    """Templated sameness across a candidate's OWN answers. `against` names other case ids in the
+    same suite, resolved by the caller into `spec['_texts']`."""
+    ceiling = float(spec.get("value") or 1.0)
+    worst, worst_key = 0.0, None
+    for key, text in (spec.get("_texts") or {}).items():
+        score = lexical_similarity(output, text)
+        if score > worst:
+            worst, worst_key = score, key
+    if worst_key is None:
+        return {"passes": None, "detail": "no comparison text available"}
+    if worst > ceiling:
+        return _fail(f"{worst:.2f} token overlap with {worst_key} > {ceiling}")
+    return _pass(f"max {worst:.2f} vs {worst_key}")
+
+
+def _a_router_tier(spec: dict, output: str, case: dict) -> dict:
+    """The `LEMComplexityRouter` contract: the tier this prompt must resolve to. Deterministic and
+    model-independent by design — the router's classification lives in `routing_policy`, not in the
+    model — so this grades the CONTRACT (and catches a fixture that drifted from it) while the
+    case's other assertions grade the candidate's completion at the router alias."""
+    from cqc_lem.utilities.routing_policy import complexity_tier, prompt_text
+    # `prompt_text` (not a hand-rolled join) because the router's signal matching is case- and
+    # shape-sensitive: grading against a differently-flattened prompt would test a contract the
+    # proxy does not actually run.
+    resolved = complexity_tier(prompt_text(case.get("messages")))
+    expected = str(spec.get("value") or "").strip()
+    if resolved == expected:
+        return _pass(f"routes to {resolved}")
+    return _fail(f"routes to {resolved}, expected {expected}")
+
+
+def _a_forbidden_phrases(spec: dict, output: str, case: dict) -> dict:
+    lowered = str(output or "").lower()
+    hits = [p for p in (spec.get("values") or []) if str(p).lower() in lowered]
+    return _fail("contains " + ", ".join(repr(h) for h in hits)) if hits else _pass()
+
+
+def _a_required_phrases(spec: dict, output: str, case: dict) -> dict:
+    """Instruction adherence: the answer must actually be about the thing it was given. `mode:any`
+    (default) accepts one hit — a grounded answer need not echo every term."""
+    lowered = str(output or "").lower()
+    values = [str(v) for v in (spec.get("values") or [])]
+    hits = [v for v in values if v.lower() in lowered]
+    if str(spec.get("mode") or "any").lower() == "all":
+        missing = [v for v in values if v not in hits]
+        return _fail("missing " + ", ".join(repr(m) for m in missing)) if missing else _pass()
+    return _pass(f"matched {hits[0]!r}") if hits else _fail(
+        "mentions none of " + ", ".join(repr(v) for v in values))
+
+
+def _a_max_lines(spec: dict, output: str, case: dict) -> dict:
+    lines = [line for line in str(output or "").splitlines() if line.strip()]
+    limit = int(spec.get("value") or 0)
+    return _pass(f"{len(lines)} lines") if len(lines) <= limit else _fail(
+        f"{len(lines)} non-empty lines > {limit}")
+
+
+ASSERTIONS: dict = {
+    "max_chars": _a_max_chars,
+    "min_chars": _a_min_chars,
+    "no_preamble": _a_no_preamble,
+    "comma_list": _a_comma_list,
+    "json_object": _a_json_object,
+    "slop_lint": _a_slop_lint,
+    "comment_contract": _a_comment_contract,
+    "min_burstiness": _a_min_burstiness,
+    "max_similarity": _a_max_similarity,
+    "router_tier": _a_router_tier,
+    "forbidden_phrases": _a_forbidden_phrases,
+    "required_phrases": _a_required_phrases,
+    "max_lines": _a_max_lines,
+}
+
+
+def evaluate_case(case: dict, output: Optional[str],
+                  peer_outputs: Optional[dict] = None) -> dict:
+    """Grade ONE model output against one case. Pure.
+
+    A missing output (provider error) is a case FAILURE with the error carried through, never an
+    absent row: a model that couldn't answer is worse than one that answered badly, and dropping the
+    case would quietly raise its pass rate."""
+    case_id = str(case.get("id"))
+    if output is None:
+        return {"case_id": case_id, "passes": False, "error": case.get("_error") or "no output",
+                "assertions": [], "failures": ["no output from the model"], "unscored": 0}
+    results = []
+    for spec in case.get("assertions") or []:
+        kind = spec.get("type")
+        fn = ASSERTIONS.get(kind)
+        if fn is None:  # unreachable via load_suite; belt-and-braces for hand-built cases
+            results.append({"type": kind, "passes": False, "detail": f"unknown assertion {kind!r}"})
+            continue
+        resolved = dict(spec)
+        if kind == "max_similarity":
+            resolved["_texts"] = {k: v for k, v in (peer_outputs or {}).items()
+                                  if k in (spec.get("against") or []) and v}
+        try:
+            outcome = fn(resolved, str(output), case)
+        except Exception as exc:  # noqa: BLE001 - one bad assertion must not sink the whole run
+            outcome = _fail(f"assertion raised {type(exc).__name__}: {str(exc)[:80]}")
+        results.append({"type": kind, "passes": outcome.get("passes"),
+                        "detail": outcome.get("detail", "")})
+    failures = [f"{r['type']}: {r['detail']}" for r in results if r["passes"] is False]
+    unscored = sum(1 for r in results if r["passes"] is None)
+    return {"case_id": case_id, "passes": not failures, "assertions": results,
+            "failures": failures, "unscored": unscored}
+
+
+def score_suite(suite: dict, outputs: dict) -> list:
+    """Grade every case of one suite for one model. `outputs` is {case_id: text-or-None}."""
+    peers = {k: v for k, v in (outputs or {}).items() if v}
+    return [evaluate_case(case, (outputs or {}).get(str(case.get("id"))), peers)
+            for case in suite.get("cases") or []]
+
+
+# ─────────────────────────── scorecard merge (pure) ──────────────────────────────
+
+def _rate(passed: int, total: int) -> Optional[float]:
+    return round(passed / float(total), 4) if total else None
+
+
+def _percentile(values: list, fraction: float) -> Optional[float]:
+    ordered = sorted(v for v in values if isinstance(v, (int, float)))
+    if not ordered:
+        return None
+    index = min(len(ordered) - 1, max(0, int(round(fraction * (len(ordered) - 1)))))
+    return round(float(ordered[index]), 1)
+
+
+def merge_scorecard(tier: str, model: str, role: str, case_results: list,
+                    judge_results: Optional[dict] = None,
+                    timings: Optional[dict] = None) -> dict:
+    """One model × one tier. Deterministic results, judge verdicts and timings are merged into the
+    single row the report and the gate both read.
+
+    Judge verdicts are three-valued: True, False, and `judge:timeout`/absent. Only the first two
+    count toward `judge_pass_rate`; an unscored case is reported as unscored, so a run where the
+    judge never answered can never look like a run where it approved everything."""
+    judge = judge_results or {}
+    timings = timings or {}
+    total = len(case_results)
+    passed = sum(1 for r in case_results if r.get("passes"))
+    errors = [r["case_id"] for r in case_results if r.get("error")]
+
+    judged_pass = judged_fail = judged_timeout = 0
+    for result in case_results:
+        verdict = judge.get(result["case_id"])
+        if verdict is None:
+            continue
+        if verdict.get("status") == JUDGE_TIMEOUT or verdict.get("passes") is None:
+            judged_timeout += 1
+        elif verdict.get("passes"):
+            judged_pass += 1
+        else:
+            judged_fail += 1
+    judged = judged_pass + judged_fail
+
+    latencies = [timings.get(r["case_id"], {}).get("latency_ms") for r in case_results]
+    latencies = [v for v in latencies if isinstance(v, (int, float))]
+    tokens = sum(int(timings.get(r["case_id"], {}).get("total_tokens") or 0)
+                 for r in case_results)
+
+    return {
+        "tier": tier, "model": model, "role": role,
+        "cases": total,
+        "deterministic_passed": passed,
+        "deterministic_pass_rate": _rate(passed, total),
+        "errors": errors,
+        "failed_cases": [{"case_id": r["case_id"], "failures": r.get("failures") or []}
+                         for r in case_results if not r.get("passes")],
+        "unscored_assertions": sum(int(r.get("unscored") or 0) for r in case_results),
+        "judged": judged,
+        "judge_passed": judged_pass,
+        "judge_timeouts": judged_timeout,
+        "judge_pass_rate": _rate(judged_pass, judged),
+        "judge_notes": [{"case_id": cid, "reasoning": str(v.get("reasoning") or "")[:280]}
+                        for cid, v in sorted(judge.items())
+                        if v.get("passes") is False and v.get("reasoning")],
+        "latency_p50_ms": _percentile(latencies, 0.5),
+        "latency_p90_ms": _percentile(latencies, 0.9),
+        "total_tokens": tokens,
+        "case_results": case_results,
+    }
+
+
+# ───────────────────────── champion/challenger gate (pure) ───────────────────────
+
+VERDICT_RECOMMEND = "recommend"
+VERDICT_REJECT = "reject"
+VERDICT_NO_BASELINE = "no-baseline"
+VERDICT_DETERMINISTIC_ONLY = "recommend-deterministic-only"
+
+
+def gate_decision(candidate: dict, champion: Optional[dict], thresholds: dict) -> dict:
+    """Does this candidate earn a swap recommendation on this tier?
+
+    Three things must hold, and every one of them is reported per expectation:
+      * absolute — the tier's own floors (a candidate that beats a bad champion is still bad);
+      * relative — meets or beats the champion on every graded rate;
+      * evidence — enough judged cases to mean anything.
+    A missing champion is `no-baseline`, never a pass: "better than nothing" is not a comparison.
+    Judge evidence that is missing on BOTH sides degrades to `recommend-deterministic-only`, which
+    is reported but is NOT a swap recommendation — that distinction is the whole point of the gate.
+    """
+    expectations: list = []
+    thresholds = normalize_thresholds(thresholds)
+
+    def expect(name: str, ok: Optional[bool], detail: str) -> None:
+        expectations.append({"expectation": name, "passes": ok, "detail": detail})
+
+    det = candidate.get("deterministic_pass_rate")
+    floor = thresholds["deterministic_pass_rate"]
+    if det is None:
+        expect("deterministic floor", False, "no cases scored")
+    else:
+        expect("deterministic floor", det >= floor, f"{det:.0%} vs floor {floor:.0%}")
+
+    if candidate.get("errors"):
+        expect("provider answered every case", False,
+               f"{len(candidate['errors'])} case(s) returned no output")
+    else:
+        expect("provider answered every case", True, "all cases answered")
+
+    judge_rate = candidate.get("judge_pass_rate")
+    judged = int(candidate.get("judged") or 0)
+    judge_floor = thresholds["judge_pass_rate"]
+    judge_evidence = judged >= thresholds["min_judged"]
+    if not judge_evidence:
+        expect("judge floor", None,
+               f"{judged} judged case(s) < {thresholds['min_judged']} required — unscored")
+    else:
+        expect("judge floor", judge_rate is not None and judge_rate >= judge_floor,
+               f"{judge_rate:.0%} vs floor {judge_floor:.0%}" if judge_rate is not None
+               else "no judge verdicts")
+
+    if champion is None:
+        expect("beats champion", None, "no champion scorecard for this tier")
+    else:
+        champ_det = champion.get("deterministic_pass_rate")
+        if det is None or champ_det is None:
+            expect("beats champion (deterministic)", False, "one side has no score")
+        else:
+            expect("beats champion (deterministic)", det >= champ_det,
+                   f"{det:.0%} vs champion {champ_det:.0%}")
+        champ_judge = champion.get("judge_pass_rate")
+        champ_evidence = int(champion.get("judged") or 0) >= thresholds["min_judged"]
+        if not (judge_evidence and champ_evidence):
+            expect("beats champion (judge)", None, "judge evidence missing on one side")
+        else:
+            expect("beats champion (judge)", (judge_rate or 0.0) >= (champ_judge or 0.0),
+                   f"{(judge_rate or 0):.0%} vs champion {(champ_judge or 0):.0%}")
+
+    if any(e["passes"] is False for e in expectations):
+        verdict = VERDICT_REJECT
+    elif champion is None:
+        verdict = VERDICT_NO_BASELINE
+    elif any(e["passes"] is None for e in expectations):
+        verdict = VERDICT_DETERMINISTIC_ONLY
+    else:
+        verdict = VERDICT_RECOMMEND
+    return {"tier": candidate.get("tier"), "model": candidate.get("model"),
+            "champion": (champion or {}).get("model"), "verdict": verdict,
+            "expectations": expectations,
+            "blockers": [e["expectation"] for e in expectations if e["passes"] is False]}
+
+
+def gate_run(scorecards: list, suites: dict) -> list:
+    """Run the gate for every candidate scorecard against its tier's champion."""
+    champions = {c["tier"]: c for c in scorecards if c.get("role") == "champion"}
+    return [gate_decision(card, champions.get(card["tier"]),
+                          (suites.get(card["tier"]) or {}).get("thresholds") or {})
+            for card in scorecards if card.get("role") == "candidate"]
+
+
+def swap_recommendations(gates: list) -> list:
+    """ONLY full `recommend` verdicts become swap recommendations. A candidate that merely cleared
+    the deterministic floor, or had no champion to beat, is reported and goes no further."""
+    return [{"tier": g["tier"], "model": g["model"], "champion": g["champion"]}
+            for g in gates if g.get("verdict") == VERDICT_RECOMMEND]
+
+
+def recommendation_mapping_lines(recommendations: list) -> list:
+    """The exact `model_upgrades.yaml` lines a human would add — rendered, never written.
+
+    That map is the RETIREMENT map: `model_health_check.py` auto-swaps whatever is in it into the
+    live LiteLLM config on the next cron. A benchmark win is evidence for a swap, not authority to
+    perform one, so this harness stops at copy-pasteable text (the same rule the #716 upgrade issue
+    states in words)."""
+    return [f'  "{r["champion"]}": "{r["model"]}"  # {r["tier"]}: benchmark-recommended'
+            for r in recommendations if r.get("champion")]
+
+
+# ───────────────────────── provenance guard (pure) ───────────────────────────────
+
+def assert_benchmark_only(run: dict) -> None:
+    """Refuse to render anything that isn't demonstrably benchmark output.
+
+    Reports are committed to a public repo. Every scorecard must carry this run's own id and the
+    benchmark source marker, and no record may carry a real person's identity — an `$ai_evaluation`
+    row pulled with a mistyped HogQL filter would otherwise land a customer's LinkedIn copy in git.
+    Raises `ValueError`; there is no permissive mode."""
+    if not isinstance(run, dict):
+        raise ValueError("benchmark report: run must be a mapping")
+    if run.get("source") != BENCHMARK_SOURCE:
+        raise ValueError(f"benchmark report: refusing a non-benchmark source "
+                         f"{run.get('source')!r}")
+    run_id = str(run.get("run_id") or "").strip()
+    if not run_id:
+        raise ValueError("benchmark report: run has no run_id")
+    for card in run.get("scorecards") or []:
+        if str(card.get("benchmark_run_id") or "") != run_id:
+            raise ValueError(f"benchmark report: scorecard {card.get('model')}/{card.get('tier')} "
+                             f"is not tagged with this run_id")
+        for field in ("user_id", "distinct_id", "person_id", "email"):
+            value = card.get(field)
+            if value not in (None, "", BENCHMARK_DISTINCT_ID):
+                raise ValueError(f"benchmark report: scorecard carries a {field} "
+                                 f"({value!r}) — benchmark records are anonymous")
+
+
+# ─────────────────────────── report rendering (pure) ─────────────────────────────
+
+def _fmt_rate(value: Optional[float]) -> str:
+    return f"{value:.0%}" if isinstance(value, (int, float)) else "n/a"
+
+
+def _fmt_ms(value: Optional[float]) -> str:
+    return f"{int(value)} ms" if isinstance(value, (int, float)) else "n/a"
+
+
+def report_filename(run: dict) -> str:
+    return f"{run.get('date')}-{run.get('run_id')}.md"
+
+
+def render_report(run: dict) -> str:
+    """The per-run scorecard committed to `docs/model-benchmarks/`."""
+    assert_benchmark_only(run)
+    lines = [
+        f"# Model-tier benchmark — {run.get('date')} (`{run.get('run_id')}`)",
+        "",
+        f"- **Scoring mode:** `{run.get('scoring_mode')}`"
+        + (" — canned outputs, no provider or judge calls were made"
+           if run.get("scoring_mode") == SCORING_DRY_RUN else ""),
+        f"- **Tiers:** {', '.join(run.get('tiers') or []) or 'none'}",
+        f"- **Candidates:** {', '.join(run.get('candidates') or []) or 'none (baseline run)'}",
+        f"- **Judge calls spent:** {run.get('judge_calls', 0)}"
+        f" (cap {run.get('judge_call_cap', 0)})",
+        "",
+        "Inputs are synthetic prompt templates from `tests/benchmarks/model_tiers/`; no customer "
+        "content, credentials or production logs appear in this report.",
+        "",
+        "## Scorecard",
+        "",
+        "| Tier | Model | Role | Cases | Deterministic | Judge | Judged | Timeouts | p50 | p90 |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for card in run.get("scorecards") or []:
+        lines.append(
+            f"| {card['tier']} | `{card['model']}` | {card['role']} | {card['cases']} | "
+            f"{_fmt_rate(card.get('deterministic_pass_rate'))} "
+            f"({card.get('deterministic_passed', 0)}/{card.get('cases', 0)}) | "
+            f"{_fmt_rate(card.get('judge_pass_rate'))} | {card.get('judged', 0)} | "
+            f"{card.get('judge_timeouts', 0)} | {_fmt_ms(card.get('latency_p50_ms'))} | "
+            f"{_fmt_ms(card.get('latency_p90_ms'))} |")
+
+    lines += ["", "## Per-expectation detail", ""]
+    for card in run.get("scorecards") or []:
+        lines.append(f"### `{card['model']}` — {card['tier']} ({card['role']})")
+        lines.append("")
+        if card.get("errors"):
+            lines.append(f"- ⚠️ no output for: {', '.join(f'`{c}`' for c in card['errors'])}")
+        failed = card.get("failed_cases") or []
+        if not failed:
+            lines.append("- every case met every deterministic expectation")
+        for entry in failed:
+            lines.append(f"- ❌ `{entry['case_id']}`")
+            for failure in entry.get("failures") or []:
+                lines.append(f"  - {failure}")
+        if card.get("unscored_assertions"):
+            lines.append(f"- {card['unscored_assertions']} assertion(s) unscored "
+                         "(not counted either way)")
+        for note in card.get("judge_notes") or []:
+            lines.append(f"- 🧑‍⚖️ `{note['case_id']}`: {note['reasoning']}")
+        lines.append("")
+
+    lines += ["## Gate verdicts", ""]
+    gates = run.get("gates") or []
+    if not gates:
+        lines.append("No candidates in this run — the champions were measured as a baseline only.")
+    for gate in gates:
+        champion = f"vs champion `{gate['champion']}`" if gate.get("champion") else "no champion"
+        lines += [f"### `{gate['model']}` on {gate['tier']} — **{gate['verdict']}** ({champion})",
+                  ""]
+        for expectation in gate.get("expectations") or []:
+            mark = {True: "✅", False: "❌"}.get(expectation["passes"], "➖")
+            lines.append(f"- {mark} {expectation['expectation']} — {expectation['detail']}")
+        lines.append("")
+
+    recommendations = run.get("recommendations") or []
+    lines += ["## Swap recommendations", ""]
+    if not recommendations:
+        lines += ["None. No candidate met its tier's thresholds *and* beat the champion on every "
+                  "graded expectation.", ""]
+    else:
+        for rec in recommendations:
+            lines.append(f"- **{rec['tier']}**: `{rec['champion']}` → `{rec['model']}`")
+        lines += ["",
+                  "These are recommendations, not changes. `.litellm/model_upgrades.yaml` is the "
+                  "RETIREMENT map and auto-swaps into the live config, so adopting one of these is "
+                  "a deliberate edit (config change or a #717-style PR):",
+                  "", "```yaml"] + recommendation_mapping_lines(recommendations) + ["```", ""]
+
+    lines += ["---", "",
+              "Generated by `scripts/benchmark_models.py` (issue #721). Deterministic checks are "
+              "the in-repo linters (`slop_lint`, the comment quality contract, the "
+              "`LEMComplexityRouter` tier contract); judge scores come from "
+              f"`{run.get('scoring_mode')}`."]
+    return "\n".join(lines) + "\n"
+
+
+def leaderboard_rows(run: dict) -> list:
+    """One row per scorecard, newest-run-first when merged into the rolling table."""
+    verdicts = {(g["tier"], g["model"]): g["verdict"] for g in run.get("gates") or []}
+    rows = []
+    for card in run.get("scorecards") or []:
+        rows.append({
+            "date": run.get("date"), "run_id": run.get("run_id"), "tier": card["tier"],
+            "model": card["model"], "role": card["role"],
+            "deterministic": _fmt_rate(card.get("deterministic_pass_rate")),
+            "judge": _fmt_rate(card.get("judge_pass_rate")),
+            "latency": _fmt_ms(card.get("latency_p50_ms")),
+            "verdict": verdicts.get((card["tier"], card["model"]),
+                                    "baseline" if card["role"] == "champion" else "—"),
+        })
+    return rows
+
+
+def _row_markdown(row: dict) -> str:
+    return (f"| {row['date']} | `{row['run_id']}` | {row['tier']} | `{row['model']}` | "
+            f"{row['role']} | {row['deterministic']} | {row['judge']} | {row['latency']} | "
+            f"{row['verdict']} |")
+
+
+def _row_key(row: dict) -> tuple:
+    return (row.get("run_id"), row.get("tier"), row.get("model"))
+
+
+def _parse_row(line: str) -> Optional[dict]:
+    cells = [c.strip() for c in line.strip().strip("|").split("|")]
+    if len(cells) != 9:
+        return None
+    return {"date": cells[0], "run_id": cells[1].strip("`"), "tier": cells[2],
+            "model": cells[3].strip("`"), "role": cells[4], "deterministic": cells[5],
+            "judge": cells[6], "latency": cells[7], "verdict": cells[8]}
+
+
+def update_leaderboard(text: str, rows: list) -> str:
+    """Merge this run's rows into the rolling table between the leaderboard markers.
+
+    Re-running the same run id REPLACES its rows rather than appending duplicates, so a re-render
+    (a failed PR retried, a `--render` of an older results file) is idempotent."""
+    header = ["| Date | Run | Tier | Model | Role | Deterministic | Judge | p50 | Verdict |",
+              "|---|---|---|---|---|---|---|---|---|"]
+    body = str(text or "")
+    if LEADERBOARD_BEGIN in body and LEADERBOARD_END in body:
+        before, rest = body.split(LEADERBOARD_BEGIN, 1)
+        inner, after = rest.split(LEADERBOARD_END, 1)
+    else:
+        before, inner, after = body.rstrip() + "\n\n", "", "\n"
+
+    existing = [r for r in (_parse_row(line) for line in inner.splitlines()
+                            if line.strip().startswith("|")) if r]
+    fresh_keys = {_row_key(r) for r in rows}
+    kept = [r for r in existing if _row_key(r) not in fresh_keys]
+    merged = (list(rows) + kept)[:LEADERBOARD_MAX_ROWS]
+    table = "\n".join(header + [_row_markdown(r) for r in merged])
+    return f"{before}{LEADERBOARD_BEGIN}\n{table}\n{LEADERBOARD_END}{after}"
+
+
+# ─────────────────────────── judge planning (pure) ───────────────────────────────
+
+def judgeable_cases(case_results: list, suite: dict) -> list:
+    """Which cases are worth a judge call at all.
+
+    A case that already failed deterministically is skipped: the verdict is settled and the rubric
+    would only re-confirm it at provider prices. Cases opted out with `"judge": false` are skipped
+    too (the router suite's classification cases have nothing for a rubric to grade), and they are
+    NOT "dropped by the cap" — keeping the two apart is what makes the cap warning meaningful."""
+    by_id = {str(c.get("id")): c for c in suite.get("cases") or []}
+    eligible = []
+    for result in case_results:
+        case = by_id.get(result["case_id"]) or {}
+        if case.get("judge") is False or result.get("error"):
+            continue
+        if not result.get("passes"):
+            continue
+        eligible.append(result["case_id"])
+    return eligible
+
+
+def plan_judge_calls(case_results: list, suite: dict, cap: int) -> list:
+    """The judgeable cases that fit inside the remaining budget, in suite order."""
+    return judgeable_cases(case_results, suite)[:max(0, int(cap))]
+
+
+def judge_messages(suite: dict, case: dict, output: str) -> list:
+    """A SELF-CONTAINED rubric prompt. The judge (PostHog's or the fallback) only ever sees the
+    event's input and output, so the tier contract is embedded here rather than referenced by repo
+    path — a rubric that says "see content_framework.py" grades nothing."""
+    rubric = suite.get("judge_rubric") or (
+        "Judge whether the answer follows its instructions exactly, reads like a specific human "
+        "practitioner rather than generic AI filler, and invents no facts, numbers or names that "
+        "were not supplied in the prompt.")
+    prompt = (
+        f"You are grading one model answer against the contract for the '{suite.get('tier')}' "
+        f"tier of a LinkedIn content system.\n\n"
+        f"TIER CONTRACT: {suite.get('contract')}\n\n"
+        f"RUBRIC: {rubric}\n\n"
+        f"PROMPT GIVEN TO THE MODEL:\n---\n"
+        + "\n".join(f"[{m.get('role')}] {m.get('content')}" for m in case.get("messages") or [])
+        + f"\n---\n\nMODEL ANSWER:\n---\n{output}\n---\n\n"
+        "Respond with ONLY a JSON object: {\"pass\": true|false, \"reasoning\": \"one sentence\"}. "
+        "Fail the answer if it breaks the contract, adds a preamble, or states a specific fact or "
+        "number that the prompt did not supply.")
+    return [{"role": "system", "content": "You are a strict, terse evaluation judge. You reply "
+                                          "with JSON and nothing else."},
+            {"role": "user", "content": prompt}]
+
+
+def parse_judge_verdict(text: Optional[str]) -> dict:
+    """Parse a judge reply. An unparseable verdict is NOT a pass and NOT a fail — it is unscored,
+    which is what keeps a flaky judge from silently approving a model."""
+    raw = str(text or "").strip()
+    if raw.startswith("```"):
+        raw = re.sub(r"^```[a-zA-Z]*\s*|\s*```$", "", raw).strip()
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        match = re.search(r"\{.*\}", raw, re.DOTALL)
+        if not match:
+            return {"passes": None, "status": JUDGE_TIMEOUT, "reasoning": "unparseable judge reply"}
+        try:
+            parsed = json.loads(match.group(0))
+        except ValueError:
+            return {"passes": None, "status": JUDGE_TIMEOUT, "reasoning": "unparseable judge reply"}
+    if not isinstance(parsed, dict) or not isinstance(parsed.get("pass"), bool):
+        return {"passes": None, "status": JUDGE_TIMEOUT, "reasoning": "judge reply had no verdict"}
+    return {"passes": bool(parsed["pass"]), "status": "scored",
+            "reasoning": str(parsed.get("reasoning") or "")[:280]}
+
+
+# ───────────────── PostHog evaluation specs + retrieval (pure) ───────────────────
+
+def evaluation_name(tier: str) -> str:
+    return f"LEM benchmark — {tier}"
+
+
+def evaluation_spec(suite: dict) -> dict:
+    """The create-if-missing payload for one tier's LLM-judge evaluation.
+
+    `conditions` is the load-bearing part: the filter pins scoring to events that carry a
+    `benchmark_run_id`, at 100% sampling. Production `$ai_generation` events never carry that
+    property, so an enabled evaluation can never bill a judge call against customer traffic."""
+    tier = suite.get("tier")
+    return {
+        "name": evaluation_name(tier),
+        "description": f"Model-tier benchmark judge for {tier} (issue #721). Scores only events "
+                       "tagged with a benchmark_run_id — never production traffic.",
+        "enabled": True,
+        "evaluation_type": "llm_judge",
+        "prompt": (f"TIER CONTRACT: {suite.get('contract')}\n\nRUBRIC: {suite.get('judge_rubric')}"
+                   "\n\nPass the generation only if it satisfies the contract, adds no preamble, "
+                   "and states no specific fact or number the prompt did not supply."),
+        "conditions": [{
+            "rollout_percentage": 100,
+            "properties": [
+                {"key": "benchmark_run_id", "operator": "is_set", "type": "event"},
+                {"key": "lem_tier", "value": [tier], "operator": "exact", "type": "event"},
+            ],
+        }],
+    }
+
+
+def plan_evaluations(existing: dict, specs: list) -> list:
+    """create / none per tier evaluation. Named-keyed: an evaluation someone edited in the UI is
+    still that evaluation, and this script never overwrites a human's rubric edit."""
+    plan = []
+    for spec in specs:
+        found = (existing or {}).get(spec["name"])
+        plan.append({"action": "none" if found else "create", "name": spec["name"],
+                     "id": (found or {}).get("id"), "spec": spec})
+    return plan
+
+
+def hogql_for_run(run_id: str, limit: int = 500) -> str:
+    """The retrieval query for one run's judge verdicts. Scoped to `$ai_evaluation` events carrying
+    THIS run's id — the same provenance rule `assert_benchmark_only` enforces on the way out."""
+    safe = re.sub(r"[^A-Za-z0-9_-]", "", str(run_id or ""))
+    return ("SELECT properties.benchmark_prompt_id, properties.lem_tier, properties.$ai_model, "
+            "properties.$ai_evaluation_result, properties.$ai_evaluation_reasoning "
+            "FROM events WHERE event = '$ai_evaluation' "
+            f"AND properties.benchmark_run_id = '{safe}' "
+            f"ORDER BY timestamp DESC LIMIT {int(limit)}")
+
+
+def merge_judge_events(rows: list, model: str, tier: str) -> dict:
+    """Fold `$ai_evaluation` rows into {case_id: verdict} for one model × tier.
+
+    Rows for another model or tier are ignored rather than merged — one HogQL read serves the whole
+    run, and mixing a candidate's verdicts into the champion's card would invert the gate."""
+    verdicts: dict = {}
+    for row in rows or []:
+        if not isinstance(row, (list, tuple)) or len(row) < 4:
+            continue
+        case_id, row_tier, row_model, result = row[0], row[1], row[2], row[3]
+        reasoning = row[4] if len(row) > 4 else ""
+        if row_model != model or row_tier != tier or not case_id:
+            continue
+        if isinstance(result, bool):
+            passes = result
+        elif isinstance(result, str):
+            lowered = result.strip().lower()
+            if lowered in ("true", "pass", "passed", "1"):
+                passes = True
+            elif lowered in ("false", "fail", "failed", "0"):
+                passes = False
+            else:
+                continue
+        else:
+            continue
+        verdicts[str(case_id)] = {"passes": passes, "status": "scored",
+                                  "reasoning": str(reasoning or "")[:280]}
+    return verdicts
+
+
+def benchmark_event_properties(run_id: str, tier: str, case_id: str, model: str,
+                               role: str, latency_ms: Optional[float] = None,
+                               usage: Optional[dict] = None) -> dict:
+    """The property bag on every emitted `$ai_generation`. `benchmark_run_id` is what the PostHog
+    evaluation's condition filters on AND what `assert_benchmark_only` verifies, so it is never
+    optional."""
+    usage = usage or {}
+    props = {
+        "benchmark_run_id": run_id,
+        "benchmark_prompt_id": case_id,
+        "lem_tier": tier,
+        "lem_benchmark_role": role,
+        "source": BENCHMARK_SOURCE,
+        "$ai_model": model,
+        "$ai_provider": "ollama_cloud",
+        "$ai_trace_id": f"{run_id}-{tier}-{case_id}-{role}",
+    }
+    if latency_ms is not None:
+        props["$ai_latency"] = round(float(latency_ms) / 1000.0, 3)
+    for key, prop in (("prompt_tokens", "$ai_input_tokens"),
+                      ("completion_tokens", "$ai_output_tokens")):
+        if usage.get(key) is not None:
+            props[prop] = usage[key]
+    return props
+
+
+# ─────────────────────────── champions from config (pure) ────────────────────────
+
+def champions_from_config(config_text: str, tiers: list) -> dict:
+    """The model currently serving each tier — its FIRST Ollama Cloud deployment, which is the one
+    latency-based routing reaches for first and the one a candidate would displace. Tiers whose
+    primary is an OpenAI/Anthropic fallback have no Ollama champion and are reported as such."""
+    from model_health_check import load_config_text, parse_deployments  # noqa: WPS433
+    deployments = parse_deployments(load_config_text(config_text))
+    champions: dict = {}
+    for row in deployments:
+        if row["is_ollama"] and row["group"] in tiers and row["group"] not in champions:
+            champions[row["group"]] = row["bare"]
+    return champions
+
+
+def parse_champion_overrides(raw: Optional[str]) -> dict:
+    out: dict = {}
+    for chunk in str(raw or "").split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        tier, _, model = chunk.partition("=")
+        if not model.strip():
+            raise SystemExit(f"--champions expects tier=model pairs, got {chunk!r}")
+        out[tier.strip()] = model.strip()
+    return out
+
+
+def parse_models(raw: Optional[str]) -> list:
+    return [m.strip() for m in str(raw or "").split(",") if m.strip()]
+
+
+# ─────────────────────────────── I/O (mocked in tests) ───────────────────────────
+
+class ProviderClient:
+    """Completions straight against Ollama Cloud.
+
+    Deliberately NOT through the LiteLLM proxy: the proxy routes by tier ALIAS, and a candidate that
+    isn't in the config has no alias to be reached by. Champions go the same way so both sides of a
+    comparison are measured on identical plumbing."""
+
+    def __init__(self, base_url: str, api_key: str, timeout: float = 180.0) -> None:
+        self.base_url = base_url
+        self.api_key = api_key
+        self.timeout = timeout
+        self._client = None
+
+    def _openai(self):
+        if self._client is None:
+            import openai
+            self._client = openai.OpenAI(base_url=self.base_url, api_key=self.api_key,
+                                         timeout=self.timeout)
+        return self._client
+
+    def complete(self, model: str, messages: list, params: Optional[dict] = None) -> dict:
+        started = time.time()
+        try:
+            response = self._openai().chat.completions.create(
+                model=model, messages=messages, **(params or {}))
+        except Exception as exc:  # noqa: BLE001 - a provider failure is a case result, not a crash
+            return {"text": None, "error": str(exc)[:200],
+                    "latency_ms": (time.time() - started) * 1000.0, "usage": {}}
+        usage = getattr(response, "usage", None)
+        return {
+            "text": (response.choices[0].message.content or "").strip(),
+            "error": None,
+            "latency_ms": (time.time() - started) * 1000.0,
+            "usage": {"prompt_tokens": getattr(usage, "prompt_tokens", None),
+                      "completion_tokens": getattr(usage, "completion_tokens", None),
+                      "total_tokens": getattr(usage, "total_tokens", None)},
+        }
+
+
+class PostHogEvals:
+    """The PostHog LLM-analytics surface this harness needs: emit tagged generations, ensure the
+    per-tier judge evaluations exist, trigger them per event, and read the verdicts back.
+
+    Every method degrades: no personal API key, an unreachable project or a 4xx leaves the run on
+    the in-runner fallback judge rather than failing it."""
+
+    def __init__(self, api_key: str, project_id: str, app_host: str = DEFAULT_APP_HOST) -> None:
+        self.project_id = project_id
+        self.app_host = app_host.rstrip("/")
+        self._base = f"{self.app_host}/api/projects/{project_id}"
+        self._headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        import requests
+        response = requests.request(method, f"{self._base}{path}", headers=self._headers,
+                                    timeout=30, **kwargs)
+        response.raise_for_status()
+        return response.json() if response.content else {}
+
+    def list_evaluations(self) -> dict:
+        payload = self._request("GET", "/llm_analytics/evaluations/?limit=100")
+        return {item.get("name"): {"id": item.get("id"), "enabled": item.get("enabled")}
+                for item in payload.get("results") or [] if item.get("name")}
+
+    def create_evaluation(self, spec: dict) -> Optional[str]:
+        return self._request("POST", "/llm_analytics/evaluations/", json=spec).get("id")
+
+    def run_evaluation(self, evaluation_id: str, event_id: str) -> Optional[str]:
+        payload = self._request("POST", f"/llm_analytics/evaluations/{evaluation_id}/run/",
+                                json={"event_id": event_id})
+        return payload.get("workflow_id") or payload.get("id")
+
+    def query(self, hogql: str) -> list:
+        payload = self._request("POST", "/query/",
+                                json={"query": {"kind": "HogQLQuery", "query": hogql}})
+        return payload.get("results") or []
+
+
+def emit_generation(run_id: str, tier: str, case: dict, model: str, role: str,
+                    completion: dict) -> Optional[str]:
+    """Emit ONE tagged `$ai_generation`. Independent of the prod LiteLLM→PostHog callback (#647) on
+    purpose: this harness calls the provider directly, so nothing else would record these.
+
+    Returns the event uuid (what the manual eval run is keyed by), or None if PostHog is not
+    configured — in which case the run falls back to the in-runner judge."""
+    try:
+        import posthog
+        import uuid
+    except Exception:  # noqa: BLE001 - pragma: no cover - stdlib+dep import guard
+        return None
+    if not (os.environ.get("POSTHOG_API_KEY") or "").strip():
+        return None
+    event_id = str(uuid.uuid4())
+    properties = benchmark_event_properties(run_id, tier, str(case.get("id")), model, role,
+                                            completion.get("latency_ms"),
+                                            completion.get("usage"))
+    properties["$ai_input"] = case.get("messages")
+    properties["$ai_output_choices"] = [{"role": "assistant",
+                                         "content": completion.get("text") or ""}]
+    try:
+        posthog.api_key = os.environ["POSTHOG_API_KEY"]
+        posthog.host = os.environ.get("POSTHOG_HOST", "https://us.i.posthog.com")
+        # The event uuid is what the manual eval-run endpoint is keyed by, so an SDK that won't
+        # accept one leaves this generation UNJUDGEABLE — say so by returning None (the run then
+        # uses the fallback judge) rather than handing back an id PostHog never stored.
+        try:
+            posthog.capture(distinct_id=BENCHMARK_DISTINCT_ID, event="$ai_generation",
+                            properties=properties, uuid=event_id)
+        except TypeError:
+            posthog.capture(distinct_id=BENCHMARK_DISTINCT_ID, event="$ai_generation",
+                            properties=properties)
+            return None
+        return event_id
+    except Exception as exc:  # noqa: BLE001 - emission is best-effort
+        print(f"  ! PostHog emission failed for {case.get('id')}: {str(exc)[:160]}",
+              file=sys.stderr)
+        return None
+
+
+def emit_metric(run_id: str, tier: str, case_id: str, model: str, verdict: dict) -> None:
+    """Fallback-mode judge verdicts still reach PostHog — as `$ai_metric`, so the dashboards work
+    even when the native evaluation path was unavailable."""
+    try:
+        import posthog
+    except Exception:  # noqa: BLE001 - pragma: no cover
+        return
+    if not (os.environ.get("POSTHOG_API_KEY") or "").strip():
+        return
+    try:
+        posthog.api_key = os.environ["POSTHOG_API_KEY"]
+        posthog.host = os.environ.get("POSTHOG_HOST", "https://us.i.posthog.com")
+        posthog.capture(distinct_id=BENCHMARK_DISTINCT_ID, event="$ai_metric", properties={
+            "benchmark_run_id": run_id, "benchmark_prompt_id": case_id, "lem_tier": tier,
+            "source": BENCHMARK_SOURCE, "$ai_model": model,
+            "$ai_metric_name": "benchmark_judge",
+            "$ai_metric_value": verdict.get("passes"),
+        })
+    except Exception as exc:  # noqa: BLE001
+        print(f"  ! PostHog metric emission failed for {case_id}: {str(exc)[:160]}",
+              file=sys.stderr)
+
+
+def fallback_judge(suite: dict, case: dict, output: str) -> dict:
+    """The degraded judge: `lem-medium` through LEM's own client. Used when PostHog has no judge
+    provider configured (Ollama Cloud is not one) or the evaluation API is unreachable."""
+    try:
+        from cqc_lem.utilities.ai.client import client
+        response = client.chat.completions.create(
+            model="lem-medium", messages=judge_messages(suite, case, output),
+            temperature=0, max_tokens=200)
+        return parse_judge_verdict(response.choices[0].message.content)
+    except Exception as exc:  # noqa: BLE001 - an unavailable judge is unscored, never a pass
+        return {"passes": None, "status": JUDGE_TIMEOUT,
+                "reasoning": f"fallback judge unavailable: {str(exc)[:120]}"}
+
+
+def poll_judge_results(evals: "PostHogEvals", run_id: str, expected: int,
+                       timeout_seconds: int, sleep: Callable[[float], None] = time.sleep) -> list:
+    """Scoring is async (seconds). Poll HogQL until every expected verdict has landed or the budget
+    runs out — whatever is missing at that point is reported as `judge:timeout`, never inferred."""
+    deadline = time.time() + max(1, timeout_seconds)
+    rows: list = []
+    while True:
+        try:
+            rows = evals.query(hogql_for_run(run_id))
+        except Exception as exc:  # noqa: BLE001
+            print(f"  ! judge result query failed: {str(exc)[:160]}", file=sys.stderr)
+            return rows
+        if len(rows) >= expected or time.time() >= deadline:
+            return rows
+        sleep(5)
+
+
+# ───────────────────────────────── orchestration ─────────────────────────────────
+
+def _case_by_id(suite: dict, case_id: str) -> dict:
+    return next((c for c in suite.get("cases") or [] if str(c.get("id")) == case_id), {})
+
+
+def _canned(case: dict) -> dict:
+    return case.get("canned") if isinstance(case.get("canned"), dict) else {}
+
+
+def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, today: str,
+                  provider: Optional[ProviderClient] = None,
+                  evals: Optional["PostHogEvals"] = None,
+                  judge_cap: int = 0, dry_run: bool = False,
+                  judge_enabled: bool = True) -> dict:
+    """Run every (model, tier) pair and merge the results into one run document.
+
+    `dry_run` scores each suite against the case's committed `canned` output and verdict: a full
+    report with zero network calls, labelled as such so canned scores can never be mistaken for
+    measurements."""
+    targets: list = []
+    for tier in sorted(suites):
+        champion = champions.get(tier)
+        if champion:
+            targets.append((tier, champion, "champion"))
+        for model in models:
+            targets.append((tier, model, "candidate"))
+
+    scoring_mode = SCORING_DRY_RUN if dry_run else (
+        SCORING_DETERMINISTIC if not judge_enabled else
+        SCORING_POSTHOG if evals is not None else SCORING_FALLBACK)
+
+    evaluation_ids: dict = {}
+    if evals is not None and judge_enabled and not dry_run:
+        try:
+            existing = evals.list_evaluations()
+            for tier, suite in sorted(suites.items()):
+                spec = evaluation_spec(suite)
+                decision = plan_evaluations(existing, [spec])[0]
+                evaluation_ids[tier] = (decision["id"] if decision["action"] == "none"
+                                        else evals.create_evaluation(spec))
+        except Exception as exc:  # noqa: BLE001 - degrade to the fallback judge
+            print(f"  ! PostHog evaluations unavailable ({str(exc)[:160]}) — "
+                  "falling back to the in-runner judge", file=sys.stderr)
+            evals, evaluation_ids = None, {}
+            scoring_mode = SCORING_FALLBACK
+
+    scorecards: list = []
+    judge_budget = max(0, int(judge_cap))
+    judge_spent = 0
+    pending: list = []  # (tier, model, role, case_id, event_id) awaiting PostHog verdicts
+
+    for tier, model, role in targets:
+        suite = suites[tier]
+        outputs: dict = {}
+        timings: dict = {}
+        errors: dict = {}
+        for case in suite["cases"]:
+            case_id = str(case.get("id"))
+            if dry_run:
+                completion = {"text": _canned(case).get("output"), "error": None,
+                              "latency_ms": _canned(case).get("latency_ms"), "usage": {}}
+            elif provider is None:
+                completion = {"text": None, "error": "no provider client configured",
+                              "latency_ms": None, "usage": {}}
+            else:
+                completion = provider.complete(model, case["messages"], case.get("params"))
+            outputs[case_id] = completion.get("text")
+            errors[case_id] = completion.get("error")
+            timings[case_id] = {"latency_ms": completion.get("latency_ms"),
+                                "total_tokens": (completion.get("usage") or {}).get("total_tokens")}
+            if not dry_run and completion.get("text") and evals is not None:
+                event_id = emit_generation(run_id, tier, case, model, role, completion)
+                if event_id:
+                    pending.append([tier, model, role, case_id, event_id])
+
+        case_results = score_suite(suite, outputs)
+        for result in case_results:
+            if errors.get(result["case_id"]):
+                result["error"] = errors[result["case_id"]]
+
+        judge_results: dict = {}
+        if judge_enabled:
+            planned = plan_judge_calls(case_results, suite, judge_budget - judge_spent)
+            skipped = len(judgeable_cases(case_results, suite)) - len(planned)
+            if skipped > 0:
+                print(f"  judge cap reached — {skipped} case(s) unscored for {model}/{tier}",
+                      file=sys.stderr)
+            for case_id in planned:
+                case = _case_by_id(suite, case_id)
+                if dry_run:
+                    canned = _canned(case)
+                    judge_results[case_id] = (
+                        {"passes": bool(canned["judge_pass"]), "status": "scored",
+                         "reasoning": str(canned.get("judge_reasoning") or "")}
+                        if isinstance(canned.get("judge_pass"), bool)
+                        else {"passes": None, "status": JUDGE_TIMEOUT,
+                              "reasoning": "no canned judge verdict"})
+                elif evals is not None:
+                    event = next((p for p in pending
+                                  if p[0] == tier and p[1] == model and p[3] == case_id), None)
+                    if event and evaluation_ids.get(tier):
+                        try:
+                            evals.run_evaluation(evaluation_ids[tier], event[4])
+                        except Exception as exc:  # noqa: BLE001
+                            print(f"  ! eval trigger failed for {case_id}: {str(exc)[:120]}",
+                                  file=sys.stderr)
+                    judge_results[case_id] = {"passes": None, "status": JUDGE_TIMEOUT,
+                                              "reasoning": "awaiting PostHog verdict"}
+                else:
+                    verdict = fallback_judge(suite, case, outputs.get(case_id) or "")
+                    judge_results[case_id] = verdict
+                    emit_metric(run_id, tier, case_id, model, verdict)
+                judge_spent += 1
+
+        card = merge_scorecard(tier, model, role, case_results, judge_results, timings)
+        card["benchmark_run_id"] = run_id
+        scorecards.append(card)
+
+    if evals is not None and judge_enabled and not dry_run and judge_spent:
+        rows = poll_judge_results(evals, run_id, judge_spent, judge_timeout_seconds())
+        for card in scorecards:
+            verdicts = merge_judge_events(rows, card["model"], card["tier"])
+            if verdicts:
+                merged = merge_scorecard(card["tier"], card["model"], card["role"],
+                                         card["case_results"], verdicts,
+                                         {r["case_id"]: {"latency_ms": None} for r in
+                                          card["case_results"]})
+                for key in ("judged", "judge_passed", "judge_timeouts", "judge_pass_rate",
+                            "judge_notes"):
+                    card[key] = merged[key]
+
+    gates = gate_run(scorecards, suites)
+    recommendations = swap_recommendations(gates)
+    return {
+        "source": BENCHMARK_SOURCE,
+        "run_id": run_id,
+        "date": today,
+        "scoring_mode": scoring_mode,
+        "tiers": sorted(suites),
+        "candidates": list(models),
+        "champions": {t: champions.get(t) for t in sorted(suites)},
+        "judge_calls": judge_spent,
+        "judge_call_cap": judge_budget,
+        "scorecards": scorecards,
+        "gates": gates,
+        "recommendations": recommendations,
+    }
+
+
+def write_report(run: dict, out_dir: str) -> str:
+    """Render + write the per-run report and update the rolling leaderboard. Returns the report
+    path. `render_report` runs the provenance guard first, so a tainted run never reaches disk."""
+    body = render_report(run)
+    os.makedirs(out_dir, exist_ok=True)
+    path = os.path.join(out_dir, report_filename(run))
+    with open(path, "w") as f:
+        f.write(body)
+    readme = os.path.join(out_dir, "README.md")
+    existing = _read_text(readme) if os.path.exists(readme) else ""
+    with open(readme, "w") as f:
+        f.write(update_leaderboard(existing, leaderboard_rows(run)))
+    return path
+
+
+# ─────────────────────────────────── CLI ─────────────────────────────────────────
+
+def _run_id(today: str) -> str:
+    return f"bm-{today.replace('-', '')}-{os.urandom(3).hex()}"
+
+
+def main(argv: Optional[list] = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--run", action="store_true")
+    ap.add_argument("--dry-run", action="store_true")
+    ap.add_argument("--render", metavar="RESULTS")
+    ap.add_argument("--print-suites", action="store_true")
+    ap.add_argument("--models", default="")
+    ap.add_argument("--champions", default="")
+    ap.add_argument("--tiers", default="")
+    ap.add_argument("--suite-dir", default=DEFAULT_SUITE_DIR)
+    ap.add_argument("--config", default=DEFAULT_CONFIG)
+    ap.add_argument("--out-dir", default=DEFAULT_OUT_DIR)
+    ap.add_argument("--results-out", default=None)
+    ap.add_argument("--recommendations-out", default=None)
+    ap.add_argument("--no-judge", action="store_true")
+    ap.add_argument("--max-judge-calls", type=int, default=None)
+    ap.add_argument("--run-id", default=None)
+    ap.add_argument("--today", default=None)
+    args = ap.parse_args(argv)
+
+    today = args.today or _today()
+    tiers = parse_models(args.tiers) or None
+
+    try:
+        suites = load_suites(args.suite_dir, tiers)
+    except (SuiteError, ValueError) as exc:
+        print(f"suite error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.print_suites:
+        for tier, suite in sorted(suites.items()):
+            judged = sum(1 for c in suite["cases"] if c.get("judge") is not False)
+            print(f"{tier}: {len(suite['cases'])} cases ({judged} judgeable), "
+                  f"thresholds={suite['thresholds']}")
+            for case in suite["cases"]:
+                kinds = ", ".join(a["type"] for a in case["assertions"])
+                print(f"  - {case['id']}: {kinds}")
+        return 0
+
+    if args.render:
+        run = json.loads(_read_text(args.render))
+        try:
+            path = write_report(run, args.out_dir)
+        except ValueError as exc:
+            print(f"refusing to render: {exc}", file=sys.stderr)
+            return 1
+        print(f"report -> {path}")
+        return 2 if run.get("recommendations") else 0
+
+    if not args.dry_run and not benchmark_enabled():
+        print("BENCHMARK_ENABLED is not set — nothing to do (use --dry-run for an offline proof)")
+        return 0
+
+    models = parse_models(args.models)
+    champions = parse_champion_overrides(args.champions)
+    if not champions:
+        try:
+            champions = champions_from_config(_read_text(args.config), list(suites))
+        except OSError as exc:
+            print(f"could not read {args.config}: {exc}", file=sys.stderr)
+            return 1
+
+    provider = evals = None
+    if not args.dry_run:
+        base_url = os.environ.get("OLLAMA_CLOUD_URL", "")
+        api_key = os.environ.get("OLLAMA_CLOUD_API_KEY", "")
+        if not base_url or not api_key:
+            print("OLLAMA_CLOUD_URL / OLLAMA_CLOUD_API_KEY must be set to run the benchmark",
+                  file=sys.stderr)
+            return 1
+        provider = ProviderClient(base_url, api_key)
+        personal_key = (os.environ.get("POSTHOG_PERSONAL_API_KEY") or "").strip()
+        project_key = (os.environ.get("POSTHOG_API_KEY") or "").strip()
+        # BOTH keys or neither: the personal key reads the evaluation API, the project key emits the
+        # generations it scores. One without the other would score nothing and report every case as
+        # a timeout, so it degrades to the in-runner judge instead — the documented fallback.
+        if personal_key and project_key and not args.no_judge:
+            evals = PostHogEvals(personal_key,
+                                 os.environ.get("POSTHOG_PROJECT_ID", DEFAULT_PROJECT_ID),
+                                 os.environ.get("POSTHOG_APP_HOST", DEFAULT_APP_HOST))
+        elif personal_key and not project_key and not args.no_judge:
+            print("  POSTHOG_API_KEY is unset — PostHog evaluations cannot score events that were "
+                  "never emitted; using the in-runner judge", file=sys.stderr)
+
+    cap = args.max_judge_calls if args.max_judge_calls is not None else max_judge_calls()
+    run = run_benchmark(suites, models, champions,
+                        run_id=args.run_id or _run_id(today), today=today,
+                        provider=provider, evals=evals, judge_cap=cap,
+                        dry_run=bool(args.dry_run), judge_enabled=not args.no_judge)
+
+    if args.results_out:
+        with open(args.results_out, "w") as f:
+            json.dump(run, f, indent=2)
+        print(f"results -> {args.results_out}")
+    if args.recommendations_out:
+        with open(args.recommendations_out, "w") as f:
+            json.dump(run["recommendations"], f, indent=2)
+
+    try:
+        path = write_report(run, args.out_dir)
+    except ValueError as exc:
+        print(f"refusing to render: {exc}", file=sys.stderr)
+        return 1
+    print(f"report -> {path}")
+    for rec in run["recommendations"]:
+        print(f"RECOMMEND [{rec['tier']}] {rec['champion']} -> {rec['model']}")
+    if not run["recommendations"]:
+        print("no swap recommendations")
+    return 2 if run["recommendations"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/weekly_model_check.sh
+++ b/scripts/weekly_model_check.sh
@@ -110,6 +110,14 @@ mutate_catalog(){  # pre-approve upcoming retirements + refresh the committed ca
   git add .litellm/model_upgrades.yaml .litellm/ollama_catalog_snapshot.json
 }
 
+mutate_benchmark(){  # render the run we ALREADY measured into the worktree (issue #721)
+                     # --render is pure: no provider or PostHog calls, so the PR always describes
+                     # the same measurement the alert above was based on.
+  "${PY[@]}" "$REPO/scripts/benchmark_models.py" --render "$BENCH_RESULTS" \
+      --out-dir "$1/docs/model-benchmarks" >>"$LOG" 2>&1
+  git add docs/model-benchmarks
+}
+
 log "=== weekly model-health check start ==="
 # Provider creds for the planner's direct probes.
 set -a; source <(sudo -n grep -E "^(OLLAMA_CLOUD_URL|OLLAMA_CLOUD_API_KEY)=" /opt/lem/.env); set +a
@@ -204,6 +212,61 @@ for n in json.load(sys.stdin)['notices']:
     rm -f "$PLANF"
     # 0/2/3 are the planner's own nothing/actions/alerts codes — only anything else is a failure.
     case "$RC" in 0|2|3) ;; *) log "issue filing failed (non-fatal, rc=$RC)";; esac
+  fi
+
+  # ── model-tier benchmark: is the candidate any GOOD? (issue #721) ──────────────────────────
+  # Everything above this line detects CHANGE. This measures QUALITY: each cron-detected candidate
+  # and the tier's current champion run the same synthetic suites, and the run is committed as a
+  # report PR. Strictly advisory — it never edits the config, never writes model_upgrades.yaml, and
+  # any failure here must NOT touch the retirement-swap safety path that already ran above.
+  set -a; source <(sudo -n grep -E "^(BENCHMARK_[A-Z_]+|POSTHOG_API_KEY|POSTHOG_HOST|POSTHOG_PERSONAL_API_KEY|POSTHOG_PROJECT_ID)=" /opt/lem/.env) 2>/dev/null; set +a
+  if [ "${BENCHMARK_ENABLED:-false}" != "true" ]; then
+    log "benchmark: BENCHMARK_ENABLED not set — skipping"
+  else
+    # Candidates = the new tags plus the family-upgrade candidates from the SAME plan the issues
+    # were filed from. Bounded, and the drop is logged rather than silently truncated.
+    CANDS="$(printf '%s' "$CAT" | python3 -c "
+import sys, json
+plan = json.load(sys.stdin)
+names, seen = [], set()
+for name in list(plan['catalog']['added']) + [u['candidate'] for u in plan['upgrades']]:
+    if name and name not in seen:
+        seen.add(name); names.append(name)
+print(','.join(names[:${BENCHMARK_MAX_CANDIDATES:-3}]), len(names))
+" 2>/dev/null || echo " 0")"
+    NCAND="${CANDS##* }"; CANDS="${CANDS%% *}"
+    if [ "${NCAND:-0}" -gt "${BENCHMARK_MAX_CANDIDATES:-3}" ]; then
+      log "benchmark: $NCAND candidates found, benchmarking the first ${BENCHMARK_MAX_CANDIDATES:-3}"
+    fi
+    if [ -z "$CANDS" ]; then
+      log "benchmark: no new candidates this week — skipping"
+    else
+      BENCH_RESULTS="$DIR/benchmark-$(date -u +%Y%m%dT%H%M%SZ).json"
+      log "benchmark: running tier suites for $CANDS (+ champions)"
+      "${PY[@]}" scripts/benchmark_models.py --run --models "$CANDS" --config "$BOX_CFG" \
+          --results-out "$BENCH_RESULTS" --out-dir "$DIR/benchmark-report" >>"$LOG" 2>&1
+      BRC=$?
+      # 0 = ran, nothing recommended; 2 = ran, recommendations. Anything else is a real failure.
+      case "$BRC" in
+        0|2)
+          log "benchmark: completed (rc=$BRC)"
+          open_pr "auto/model-benchmark" \
+            "docs(model-benchmarks): tier benchmark report for cron-detected candidates" \
+            "Automated by the weekly model-health check (issue #721). Each candidate and the tier's current champion ran the synthetic suites in tests/benchmarks/model_tiers/. Recommendations in the report are advisory: adopting one is a deliberate .litellm/config.yaml change, never an entry in the retirement map." \
+            mutate_benchmark
+          if [ "$BRC" -eq 2 ]; then
+            MSG="$(printf '%s' "$(cat "$BENCH_RESULTS")" | python3 -c "
+import sys, json
+run = json.load(sys.stdin)
+for r in run['recommendations']:
+    print(f\"{r['tier']}: {r['champion']} -> {r['model']} (benchmark-recommended, not applied)\")
+" 2>/dev/null || echo "(could not read recommendations)")"
+            alert "Model benchmark recommends a swap:"$'\n'"$MSG"
+          fi
+          ;;
+        *) alert "Model-tier benchmark FAILED (rc=$BRC) — see $LOG. Model-health swaps were unaffected.";;
+      esac
+    fi
   fi
 fi
 log "=== weekly model-health check done ==="

--- a/tests/benchmarks/model_tiers/lem-complex.json
+++ b/tests/benchmarks/model_tiers/lem-complex.json
@@ -1,0 +1,221 @@
+{
+  "tier": "lem-complex",
+  "version": 1,
+  "contract": "Long-form LinkedIn content: thought leadership, personal story, industry-news commentary, carousel outlines and newsletter editions. The output must follow the requested blueprint, hold a varied human sentence rhythm rather than uniform AI cadence, survive LEM's deterministic slop lint, and state no specific number, customer, employer or outcome that the prompt did not supply. A promotional post must ask for an artefact (a resource or a newsletter subscription), never a meeting.",
+  "judge_rubric": "Pass only if the piece follows the requested structure, sounds like one identifiable practitioner writing from the supplied material, invents no statistic, customer name or outcome beyond what the prompt gave, avoids the contrastive 'it's not X, it's Y' frame and bait closers, and ends on the CTA the prompt asked for rather than a meeting request.",
+  "thresholds": {"deterministic_pass_rate": 0.9, "judge_pass_rate": 0.8, "min_judged": 4},
+  "cases": [
+    {
+      "id": "complex-thought-leadership",
+      "title": "Thought-leadership post from a supplied point of view",
+      "messages": [
+        {"role": "system", "content": "You write long-form LinkedIn thought-leadership posts in a plain, specific practitioner voice. No em-dash pile-ups, no 'it's not X, it's Y', no bait closer. Never invent statistics."},
+        {"role": "user", "content": "Write a thought leadership post of 900-2500 characters arguing that platform teams should be measured on the time a change waits, not the time it runs. Buyer stage: awareness. You may use only these facts: the author has run platform teams at two companies, and at the second one queue time was four times longer than build time. End with a question the reader can answer from their own experience."}
+      ],
+      "params": {"temperature": 0.8, "max_tokens": 1400},
+      "assertions": [
+        {"type": "min_chars", "value": 700},
+        {"type": "max_chars", "value": 3000},
+        {"type": "no_preamble"},
+        {"type": "slop_lint", "content_type": "post"},
+        {"type": "min_burstiness", "value": 0.2},
+        {"type": "forbidden_phrases", "values": ["as an ai", "in today's fast-paced"]}
+      ],
+      "canned": {
+        "output": "Most platform teams report build time. Almost none of them report wait time.\n\nAt the second company where I ran a platform team, we measured both for a month. Queue time was four times longer than build time. Every dashboard we had was pointed at the shorter number.\n\nThat gap is not a tooling problem. It is a reporting one. Build time is easy to instrument and flattering to show. Wait time is spread across approvals, shared runners, and the hours a change sits after someone goes home. Nobody owns it, so nobody counts it.\n\nWhen we started counting it, the arguments changed. We stopped debating which runner image to use and started asking why a change needed two approvals from the same person's manager.\n\nThe engineers already knew. They had been describing it in retros for a year, in the only language available to them: this is slow.\n\nWhat does the wait look like on your team, and does anyone report it?",
+        "latency_ms": 8200,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "complex-personal-story",
+      "title": "Personal story anchored only to supplied facts",
+      "messages": [
+        {"role": "system", "content": "You write LinkedIn personal-story posts. Ground every specific in the facts given. If a detail was not supplied, write around it rather than inventing it."},
+        {"role": "user", "content": "Write a personal story post of 900-2200 characters. Supplied facts, and no others: the author once shipped a change on a Friday that took the checkout flow down for 40 minutes, they found it themselves before a customer reported it, and their manager's first question was about the runbook rather than the mistake. Close by inviting readers to share how their team handled a similar moment."}
+      ],
+      "params": {"temperature": 0.8, "max_tokens": 1200},
+      "assertions": [
+        {"type": "min_chars", "value": 700},
+        {"type": "max_chars", "value": 2600},
+        {"type": "no_preamble"},
+        {"type": "slop_lint", "content_type": "post"},
+        {"type": "min_burstiness", "value": 0.2},
+        {"type": "required_phrases", "values": ["40"], "mode": "all"}
+      ],
+      "canned": {
+        "output": "I took checkout down for 40 minutes on a Friday afternoon.\n\nI found it myself. That is the only part of the story I am still glad about, and it was luck as much as diligence — I had the graph open because I was curious, not because anyone told me to watch it.\n\nWhat I remember is my manager's first question. Not what did you change. Not why did you deploy on a Friday. He asked whether the runbook had got me back up faster, and when I said I had not opened it, he asked why not.\n\nThe honest answer was that I did not trust it. It had been written for a version of the system that no longer existed, and I knew that, and I had never said so.\n\nWe rewrote it that week. The next person who broke checkout used it, and they were back in nine minutes.\n\nHow did your team handle the first outage somebody owned out loud?",
+        "latency_ms": 7600,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "complex-industry-news",
+      "title": "Industry-news commentary that stays inside the supplied article",
+      "messages": [
+        {"role": "system", "content": "You write LinkedIn commentary on industry news. You may only use facts present in the supplied article. Add the author's interpretation, not new data."},
+        {"role": "user", "content": "Article: 'A survey of 1,200 engineering leaders reported that 61% now run at least one production workload on a platform their team does not operate. The same survey found that incident response times were unchanged year over year.'\n\nWrite 800-2000 characters of commentary for an awareness-stage audience. Do not add statistics that are not in the article."}
+      ],
+      "params": {"temperature": 0.8, "max_tokens": 1200},
+      "assertions": [
+        {"type": "min_chars", "value": 600},
+        {"type": "max_chars", "value": 2400},
+        {"type": "no_preamble"},
+        {"type": "slop_lint", "content_type": "post"},
+        {"type": "required_phrases", "values": ["61", "1,200"], "mode": "any"},
+        {"type": "forbidden_phrases", "values": ["studies show", "research proves"]}
+      ],
+      "canned": {
+        "output": "61% of the engineering leaders in this survey now run production on something their own team does not operate.\n\nThe number that matters sits next to it: incident response times did not move.\n\nThose two findings only look contradictory if you believe response time is mostly about access. It is not. It is about whether the person paged understands the failure in front of them, and handing operations to somebody else does not change that, it just changes who they have to call.\n\nSo the survey is not evidence that the shift failed. It is evidence that the thing teams hoped to buy was not the thing they bought.\n\nIf your incident numbers held flat through a platform migration, that is the expected result, not a sign you did it badly.",
+        "latency_ms": 7100,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "complex-build-receipt",
+      "title": "Fact-anchored build receipt with a placeholder for unknowns",
+      "messages": [
+        {"role": "system", "content": "You write 'build receipt' posts: a concrete account of something built, leading with a real number. You may only state specifics that were supplied. Anything you would need but were not given must appear as [[LABEL: what is missing]] rather than a guess."},
+        {"role": "user", "content": "Write a build receipt of 700-2000 characters. Supplied facts: the build took 11 working days, it replaced a nightly export with an incremental sync, and it removed a 6am manual step from one person's morning. The exact row count was not supplied. Lead with a real number."}
+      ],
+      "params": {"temperature": 0.7, "max_tokens": 1200},
+      "assertions": [
+        {"type": "min_chars", "value": 500},
+        {"type": "max_chars", "value": 2400},
+        {"type": "no_preamble"},
+        {"type": "slop_lint", "content_type": "post"},
+        {"type": "required_phrases", "values": ["11"], "mode": "all"},
+        {"type": "forbidden_phrases", "values": ["million rows", "billions of records"]}
+      ],
+      "canned": {
+        "output": "11 working days to delete a 6am alarm from somebody's phone.\n\nWhat it replaced: a nightly export that ran as one job, finished when it finished, and needed a person at 6am to confirm it had.\n\nWhat we built: an incremental sync that moves changes as they land, so there is no window to check and nothing to babysit.\n\nWhat it moved: [[LABEL: rows synced per day — not measured before the change]].\n\nWhat it cost: 11 working days, most of them spent on the backfill rather than the sync itself. The sync was three days of work. Proving the old and new paths agreed took the rest.\n\nThe part I would repeat: we ran both for a week before deleting anything.",
+        "latency_ms": 6900,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "complex-carousel-outline",
+      "title": "Carousel outline as a bare JSON object",
+      "messages": [
+        {"role": "system", "content": "You return a single JSON object and nothing else. No markdown fence, no commentary."},
+        {"role": "user", "content": "Produce a 6-slide educational carousel outline on reducing on-call pager noise. Return {\"title\": string, \"slides\": [{\"heading\": string, \"body\": string}]}. Every slide body must be under 220 characters. Use no statistics."}
+      ],
+      "params": {"temperature": 0.6, "max_tokens": 900},
+      "assertions": [
+        {"type": "json_object", "required_keys": ["title", "slides"]},
+        {"type": "max_chars", "value": 3000},
+        {"type": "no_preamble"}
+      ],
+      "canned": {
+        "output": "{\"title\": \"Cutting pager noise without going blind\", \"slides\": [{\"heading\": \"Start with what woke you\", \"body\": \"List every page from the last month and mark the ones that needed a human that hour. Most teams find the honest answer uncomfortable.\"}, {\"heading\": \"Delete before you tune\", \"body\": \"An alert nobody has acted on in a month is not a signal. Remove it rather than raising its threshold and forgetting it again.\"}, {\"heading\": \"Page on symptoms\", \"body\": \"Alert on what the customer experiences, not on the internal condition you think causes it. The cause changes; the symptom does not.\"}, {\"heading\": \"Give every alert an owner\", \"body\": \"An alert without a named owner becomes everyone's to ignore. The owner decides whether it survives the next review.\"}, {\"heading\": \"Review monthly, out loud\", \"body\": \"Read the noisiest three alerts in front of the team. Saying them aloud is what gets them fixed or deleted.\"}, {\"heading\": \"Measure sleep, not volume\", \"body\": \"Track pages outside working hours. Total alert count can fall while the ones that wake people stay exactly where they were.\"}]}",
+        "latency_ms": 6400,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "complex-newsletter-edition",
+      "title": "Newsletter edition with a subscribe CTA",
+      "messages": [
+        {"role": "system", "content": "You write a LinkedIn newsletter edition. Plain practitioner voice, no hype, no invented statistics. Close with an invitation to subscribe, never a meeting request."},
+        {"role": "user", "content": "Write an edition of 1000-2500 characters on why runbooks rot, using only this material: runbooks are written during an incident's aftermath, they are rarely opened again until the next incident, and the systems they describe change weekly. Close by inviting the reader to subscribe."}
+      ],
+      "params": {"temperature": 0.8, "max_tokens": 1400},
+      "assertions": [
+        {"type": "min_chars", "value": 800},
+        {"type": "max_chars", "value": 3000},
+        {"type": "no_preamble"},
+        {"type": "slop_lint", "content_type": "newsletter"},
+        {"type": "forbidden_phrases", "values": ["book a call", "schedule a demo", "calendly", "hop on a call"]}
+      ],
+      "canned": {
+        "output": "A runbook is written at the worst possible moment: just after an incident, by someone who is tired and wants to be finished.\n\nThat is not a criticism of the person. It is a description of when we ask for the work. The document that results is accurate for about a week, because the system it describes changes weekly and the runbook does not.\n\nThen it sits. Nobody opens a runbook when things are fine. The next person to open it is under pressure, at night, and discovers that the third step refers to a service that was renamed in March.\n\nSo they improvise, it works, and they do not go back and fix the document, because the incident is over and the document is not the incident.\n\nThat loop is the whole problem, and it is not solved by writing better runbooks. It is solved by opening them when nothing is wrong.\n\nThe teams I have seen break the cycle do one small thing: they read one runbook aloud at a quiet moment each month and fix whatever is wrong while they read. It takes ten minutes and it is the only mechanism I have seen that survives contact with a busy quarter.\n\nIf that is the kind of thing you want in your inbox, subscribe to the newsletter.",
+        "latency_ms": 8800,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "complex-promo-artifact-cta",
+      "title": "Promotional post that asks for an artefact, never a meeting",
+      "messages": [
+        {"role": "system", "content": "You write the one promotional post in ten. It must sell through usefulness and close by offering a resource or a newsletter, never by asking for a meeting, demo or call."},
+        {"role": "user", "content": "Write 700-1800 characters describing, in the author's own voice, what changed for a team that moved incident review notes into the same repository as the code. Supplied facts only: the notes now sit beside the service they describe, and pull requests link to them. Close by offering the reader a checklist if they comment the word RECEIPTS."}
+      ],
+      "params": {"temperature": 0.8, "max_tokens": 1100},
+      "assertions": [
+        {"type": "min_chars", "value": 500},
+        {"type": "max_chars", "value": 2200},
+        {"type": "no_preamble"},
+        {"type": "slop_lint", "content_type": "post", "exempt_keyword": "RECEIPTS"},
+        {"type": "forbidden_phrases", "values": ["book a call", "schedule a demo", "calendly", "hop on a call", "let's chat", "dm me for a quick call"]},
+        {"type": "required_phrases", "values": ["RECEIPTS"], "mode": "all"}
+      ],
+      "canned": {
+        "output": "We moved our incident review notes out of the wiki and into the repository beside the service they describe.\n\nNothing about the notes changed. Where they live did.\n\nThe first effect was mechanical: a pull request can link to the review that caused it, so the reason for a change is one click from the change. The second effect took longer to notice. People started reading them, because they were already in the directory.\n\nThe wiki was never the problem. Distance was.\n\nIf you want the checklist we used to move ours without losing the history, comment RECEIPTS and I will send it over.",
+        "latency_ms": 6100,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "complex-mobile-hook",
+      "title": "Opening line only, inside the mobile hook budget",
+      "messages": [
+        {"role": "system", "content": "You write opening lines for LinkedIn posts. Reply with the single line and nothing else."},
+        {"role": "user", "content": "Write the opening line for a post about a team that cut its release checklist from 34 steps to 6. Under 140 characters, one line, lead with the number, no emoji."}
+      ],
+      "params": {"temperature": 0.7, "max_tokens": 60},
+      "assertions": [
+        {"type": "max_chars", "value": 140},
+        {"type": "max_lines", "value": 1},
+        {"type": "no_preamble"},
+        {"type": "required_phrases", "values": ["34", "6"], "mode": "any"}
+      ],
+      "canned": {
+        "output": "34 steps to 6. The 28 we deleted had all been added after an incident nobody could name.",
+        "latency_ms": 1900,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "complex-similarity-guard",
+      "title": "A fifth long-form piece that must not echo the earlier ones",
+      "messages": [
+        {"role": "system", "content": "You write long-form LinkedIn posts. Do not reuse the structure, opening move or closing shape of a post you have already written today."},
+        {"role": "user", "content": "Write 800-2000 characters, consideration stage, on why a written decision record beats a longer meeting. Supplied facts only: the author's team replaced a weekly architecture meeting with a written record that anyone may comment on, and the meeting now happens only when the record has an unresolved comment."}
+      ],
+      "params": {"temperature": 0.8, "max_tokens": 1200},
+      "assertions": [
+        {"type": "min_chars", "value": 600},
+        {"type": "max_chars", "value": 2400},
+        {"type": "no_preamble"},
+        {"type": "slop_lint", "content_type": "post"},
+        {"type": "max_similarity", "value": 0.4, "against": ["complex-thought-leadership", "complex-personal-story", "complex-industry-news"]}
+      ],
+      "canned": {
+        "output": "We deleted the weekly architecture meeting. What replaced it was a document anyone can comment on, and a rule: the meeting only happens if a comment is still unresolved by Thursday.\n\nMost weeks it does not happen.\n\nThe surprise was not the time saved. It was who started participating. In the meeting, three people spoke and eleven listened. In the document, the people who never interrupted anybody began leaving the sharpest objections, usually a day later, usually after they had gone and checked something.\n\nA meeting rewards whoever can compose an argument in real time. A written record rewards whoever is right. Those are not the same group, and for four years we had been optimising for the first one without meaning to.\n\nThe cost is real: someone has to write the thing, and writing it badly is worse than a meeting. But that cost is paid once by one person, rather than by fourteen people simultaneously for an hour.",
+        "latency_ms": 7800,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "complex-engagement-prompt",
+      "title": "Engagement-prompt post that asks a real question",
+      "messages": [
+        {"role": "system", "content": "You write short engagement-prompt posts. They must ask something specific enough that a reader can answer from their own experience. No bait closers, no 'agree?'."},
+        {"role": "user", "content": "Write 400-1200 characters ending on a question about the last thing the reader's team deleted rather than built. Use no statistics and no customer names."}
+      ],
+      "params": {"temperature": 0.8, "max_tokens": 700},
+      "assertions": [
+        {"type": "min_chars", "value": 300},
+        {"type": "max_chars", "value": 1400},
+        {"type": "no_preamble"},
+        {"type": "slop_lint", "content_type": "post"},
+        {"type": "forbidden_phrases", "values": ["thoughts?", "agree?", "who else", "double tap"]}
+      ],
+      "canned": {
+        "output": "Every roadmap I have seen lists what a team will build. None of them list what it will remove.\n\nSo the removals happen quietly, usually by one person on a slow afternoon, and they are never in the quarterly summary even when they were the most useful thing that quarter.\n\nThe last service we deleted had two users, both internal, both of whom had forgotten it existed. Turning it off took an afternoon. Finding out whether we could took three weeks.\n\nWhat did your team delete most recently, and how long did the deciding take compared to the doing?",
+        "latency_ms": 5400,
+        "judge_pass": true
+      }
+    }
+  ]
+}

--- a/tests/benchmarks/model_tiers/lem-medium.json
+++ b/tests/benchmarks/model_tiers/lem-medium.json
@@ -1,0 +1,452 @@
+{
+  "tier": "lem-medium",
+  "version": 1,
+  "contract": "Balanced work: LinkedIn feed comments (which must satisfy LEM's comment quality contract — reference a specific claim from the target post, add own experience, a data point, respectful disagreement or a genuine question, run at least two sentences, and never open with validation filler), post refinement, blog summaries and direct messages. Output is published under a real person's name, so it must read as a specific practitioner rather than generic AI filler.",
+  "judge_rubric": "Pass only if the answer engages with the SPECIFIC content it was given (not a template that would fit any post), adds something a reader did not already have, states no fact, number, employer or customer that the prompt did not supply, and contains no preamble, hashtags-as-filler or closing 'let me know if you need anything else'.",
+  "thresholds": {
+    "deterministic_pass_rate": 0.9,
+    "judge_pass_rate": 0.8,
+    "min_judged": 4
+  },
+  "cases": [
+    {
+      "id": "medium-comment-deploy-post",
+      "title": "Feed comment on a deployment-frequency post",
+      "context": {
+        "post_content": "We moved from fortnightly releases to twelve deploys a day. The hard part was never the pipeline. It was convincing the change advisory board that smaller batches are safer than big ones, and rewriting the rollback runbook so an on-call engineer could use it at 3am."
+      },
+      "messages": [
+        {
+          "role": "system",
+          "content": "You write LinkedIn comments in a direct, practitioner voice. Two to four sentences. Reference something specific from the post. Never open with 'Great post' or similar validation filler. Never invent numbers about yourself."
+        },
+        {
+          "role": "user",
+          "content": "Post to comment on:\n\"We moved from fortnightly releases to twelve deploys a day. The hard part was never the pipeline. It was convincing the change advisory board that smaller batches are safer than big ones, and rewriting the rollback runbook so an on-call engineer could use it at 3am.\"\n\nWrite the comment."
+        }
+      ],
+      "params": {
+        "temperature": 0.7,
+        "max_tokens": 220
+      },
+      "assertions": [
+        {
+          "type": "comment_contract"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "comment"
+        },
+        {
+          "type": "max_chars",
+          "value": 700
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "canned": {
+        "output": "The change advisory board being the hard part matches what I have seen: in my last two migrations the rollback runbook was what finally moved them, not the deploy numbers. Rewriting it so an on-call engineer could follow it at 3am is the bit most teams skip. How long did the board take to sign off once the runbook was readable?",
+        "latency_ms": 2100,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "medium-comment-hiring-post",
+      "title": "Feed comment on a hiring post",
+      "context": {
+        "post_content": "We stopped asking candidates to complete take-home projects. Instead we pair with them for ninety minutes on a real ticket from our backlog and pay them for the session. Offer acceptance went up and the interview loop got two weeks shorter."
+      },
+      "messages": [
+        {
+          "role": "system",
+          "content": "You write LinkedIn comments in a direct, practitioner voice. Two to four sentences. Reference something specific from the post. Never open with validation filler. Never invent numbers about yourself."
+        },
+        {
+          "role": "user",
+          "content": "Post to comment on:\n\"We stopped asking candidates to complete take-home projects. Instead we pair with them for ninety minutes on a real ticket from our backlog and pay them for the session. Offer acceptance went up and the interview loop got two weeks shorter.\"\n\nWrite the comment."
+        }
+      ],
+      "params": {
+        "temperature": 0.7,
+        "max_tokens": 220
+      },
+      "assertions": [
+        {
+          "type": "comment_contract"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "comment"
+        },
+        {
+          "type": "max_chars",
+          "value": 700
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "canned": {
+        "output": "Paying for the pairing session is the part that changes the dynamic. When I ran a loop that used an unpaid take-home, the candidates who dropped out were the ones already working full time, which is exactly the group we said we wanted. Did the shorter loop change who reached the offer stage, or only how fast they got there?",
+        "latency_ms": 2250,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "medium-comment-respectful-disagreement",
+      "title": "Feed comment that disagrees without being rude",
+      "context": {
+        "post_content": "Documentation is a waste of engineering time. If your code needs a document to explain it, rewrite the code. Every hour spent writing docs is an hour not spent shipping."
+      },
+      "messages": [
+        {
+          "role": "system",
+          "content": "You write LinkedIn comments in a direct, practitioner voice. Two to four sentences. Disagree respectfully where you genuinely do. Reference something specific from the post. Never open with validation filler."
+        },
+        {
+          "role": "user",
+          "content": "Post to comment on:\n\"Documentation is a waste of engineering time. If your code needs a document to explain it, rewrite the code. Every hour spent writing docs is an hour not spent shipping.\"\n\nWrite the comment."
+        }
+      ],
+      "params": {
+        "temperature": 0.7,
+        "max_tokens": 220
+      },
+      "assertions": [
+        {
+          "type": "comment_contract"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "comment"
+        },
+        {
+          "type": "max_chars",
+          "value": 700
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "canned": {
+        "output": "I disagree on one half of this. Readable code removes the need to explain HOW something works, but it never explains why the previous three approaches were abandoned, and that is the document I have wanted every time I inherited a service. Rewriting the code does not bring back the decision history. What do you do with that context instead?",
+        "latency_ms": 2180,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "medium-seed-comment-own-post",
+      "title": "Seed first comment under the user's own post",
+      "context": {
+        "post_content": "Most incident reviews die in a document nobody opens again. Ours now end with exactly one owned action item and a date, and we read the previous one aloud at the start of the next review."
+      },
+      "messages": [
+        {
+          "role": "system",
+          "content": "You write the author's own first comment under their post. It must add something the post did not already say. Two to four sentences. No validation filler, no restating the post."
+        },
+        {
+          "role": "user",
+          "content": "The post:\n\"Most incident reviews die in a document nobody opens again. Ours now end with exactly one owned action item and a date, and we read the previous one aloud at the start of the next review.\"\n\nWrite the author's first comment."
+        }
+      ],
+      "params": {
+        "temperature": 0.7,
+        "max_tokens": 220
+      },
+      "assertions": [
+        {
+          "type": "comment_contract"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "comment"
+        },
+        {
+          "type": "max_chars",
+          "value": 700
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "canned": {
+        "output": "Reading the previous action item aloud is the part I would keep if I could only keep one. In my experience the single owned item survives precisely because someone has to say the name out loud in front of the room. What is the smallest change that made your incident reviews stick?",
+        "latency_ms": 2050,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "medium-comment-similarity-guard",
+      "title": "A fourth comment that must not read like the first three",
+      "context": {
+        "post_content": "We deleted our staging environment. Every change now goes behind a flag straight to production, and the flag is removed within a week or the change is reverted."
+      },
+      "messages": [
+        {
+          "role": "system",
+          "content": "You write LinkedIn comments in a direct, practitioner voice. Two to four sentences. Reference something specific from the post. Do not reuse a sentence shape you have already used today."
+        },
+        {
+          "role": "user",
+          "content": "Post to comment on:\n\"We deleted our staging environment. Every change now goes behind a flag straight to production, and the flag is removed within a week or the change is reverted.\"\n\nWrite the comment."
+        }
+      ],
+      "params": {
+        "temperature": 0.7,
+        "max_tokens": 220
+      },
+      "assertions": [
+        {
+          "type": "comment_contract"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "comment"
+        },
+        {
+          "type": "max_chars",
+          "value": 700
+        },
+        {
+          "type": "max_similarity",
+          "value": 0.35,
+          "against": [
+            "medium-comment-deploy-post",
+            "medium-comment-hiring-post",
+            "medium-comment-respectful-disagreement"
+          ]
+        }
+      ],
+      "canned": {
+        "output": "The one-week expiry is doing more work here than deleting staging did. Flags that outlive their change become a second configuration surface, and I have inherited codebases where nobody could say which combination was live. Do you enforce the expiry with tooling, or does it rely on someone noticing?",
+        "latency_ms": 2300,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "medium-post-refinement",
+      "title": "Refine a rambling draft post without inventing facts",
+      "messages": [
+        {
+          "role": "system",
+          "content": "You refine LinkedIn drafts. Keep every fact, cut the filler, keep it under 1200 characters. Reply with the refined post only."
+        },
+        {
+          "role": "user",
+          "content": "Refine this draft:\n\"So basically what happened was we had this problem where our onboarding emails were going out late, sometimes days late, and it turned out the queue was fine actually, the issue was a cron job that we set up two years ago and nobody remembered, and once we found it we deleted it and now emails go out in under a minute. Anyway thought that was interesting.\""
+        }
+      ],
+      "params": {
+        "temperature": 0.6,
+        "max_tokens": 600
+      },
+      "assertions": [
+        {
+          "type": "max_chars",
+          "value": 1200
+        },
+        {
+          "type": "min_chars",
+          "value": 200
+        },
+        {
+          "type": "no_preamble"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "post"
+        },
+        {
+          "type": "required_phrases",
+          "values": [
+            "cron"
+          ],
+          "mode": "all"
+        }
+      ],
+      "canned": {
+        "output": "Our onboarding emails were going out days late.\n\nThe queue was healthy the whole time. The cause was a cron job set up two years earlier that nobody remembered creating, quietly holding messages back.\n\nWe deleted it. Emails now go out in under a minute.\n\nThe uncomfortable part is not the bug. It is that a two-year-old scheduled job was still running and no one could say who owned it.",
+        "latency_ms": 3100,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "medium-blog-summary",
+      "title": "Summarize a blog post for a LinkedIn audience",
+      "messages": [
+        {
+          "role": "system",
+          "content": "You summarize an article for LinkedIn. Under 900 characters. Keep only what the article says. Reply with the summary only."
+        },
+        {
+          "role": "user",
+          "content": "Summarize this article:\n\"Title: The cost of a stale dependency. The team audited 340 direct dependencies across nine services and found 62 had not been updated in over a year. Rather than a big-bang upgrade they added a weekly ten-minute slot to each team's schedule to take one dependency forward. After a quarter the count of year-stale dependencies was 9, and no upgrade required a rollback.\""
+        }
+      ],
+      "params": {
+        "temperature": 0.5,
+        "max_tokens": 400
+      },
+      "assertions": [
+        {
+          "type": "max_chars",
+          "value": 900
+        },
+        {
+          "type": "min_chars",
+          "value": 150
+        },
+        {
+          "type": "no_preamble"
+        },
+        {
+          "type": "required_phrases",
+          "values": [
+            "62",
+            "9"
+          ],
+          "mode": "all"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "post"
+        }
+      ],
+      "canned": {
+        "output": "An audit of 340 direct dependencies across nine services found 62 that had gone more than a year without an update.\n\nInstead of a single large upgrade, each team took a ten-minute weekly slot and moved one dependency forward. A quarter later the year-stale count was 9, and not one upgrade had to be rolled back.\n\nThe interesting claim is about pace, not tooling: small scheduled maintenance beat the big-bang plan on both risk and throughput.",
+        "latency_ms": 2600,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "medium-thread-reply",
+      "title": "Reply to a commenter on the user's own post",
+      "context": {
+        "post_content": "Our support team now writes the release notes. Ticket volume after each release dropped by a third because the notes finally answer what customers actually ask."
+      },
+      "messages": [
+        {
+          "role": "system",
+          "content": "You reply to a commenter on the author's own post. Answer their specific point. Two to four sentences. No validation filler."
+        },
+        {
+          "role": "user",
+          "content": "The post:\n\"Our support team now writes the release notes. Ticket volume after each release dropped by a third because the notes finally answer what customers actually ask.\"\n\nThe comment you are replying to:\n\"Doesn't this just move the writing burden onto a team that is already the most stretched?\"\n\nWrite the reply."
+        }
+      ],
+      "params": {
+        "temperature": 0.7,
+        "max_tokens": 220
+      },
+      "assertions": [
+        {
+          "type": "comment_contract"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "comment"
+        },
+        {
+          "type": "max_chars",
+          "value": 700
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "canned": {
+        "output": "It moves the writing, but it removes the tickets that the writing was causing, and support felt that trade within one release. In practice they spend the time earlier in the week instead of answering the same question forty times after launch. Would that trade hold on your volume, or is your support load driven by something other than releases?",
+        "latency_ms": 2200,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "medium-dm-appreciation",
+      "title": "Appreciation DM with no meeting ask",
+      "messages": [
+        {
+          "role": "system",
+          "content": "You write a short LinkedIn direct message thanking someone for connecting. Under 500 characters. Never ask for a call, a demo or a calendar slot. Never invent a shared history."
+        },
+        {
+          "role": "user",
+          "content": "They accepted a connection request. You know only this: they lead platform engineering at a mid-market retailer and posted last week about cutting their build times. Write the message."
+        }
+      ],
+      "params": {
+        "temperature": 0.7,
+        "max_tokens": 220
+      },
+      "assertions": [
+        {
+          "type": "max_chars",
+          "value": 500
+        },
+        {
+          "type": "min_chars",
+          "value": 80
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "dm"
+        },
+        {
+          "type": "forbidden_phrases",
+          "values": [
+            "book a call",
+            "calendly",
+            "schedule a demo",
+            "hop on a call",
+            "15 minutes"
+          ]
+        }
+      ],
+      "canned": {
+        "output": "Thanks for connecting. Your post on build times landed at a useful moment for me — the part about measuring the wait before the build even starts is the bit most teams leave out. If you write up what you changed, I would read it.",
+        "latency_ms": 1700,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "medium-json-relevance-score",
+      "title": "Structured topic-relevance verdict",
+      "messages": [
+        {
+          "role": "system",
+          "content": "You return a single JSON object and nothing else. No markdown fence."
+        },
+        {
+          "role": "user",
+          "content": "Score how relevant this post is to the topics [platform engineering, developer experience] and return {\"score\": 0-100, \"reason\": \"one short sentence\"}. Post: 'A walkthrough of how we cut our CI feedback loop from 22 minutes to 4 by splitting the test suite by historical failure rate.'"
+        }
+      ],
+      "params": {
+        "temperature": 0,
+        "max_tokens": 120
+      },
+      "assertions": [
+        {
+          "type": "json_object",
+          "required_keys": [
+            "score",
+            "reason"
+          ]
+        },
+        {
+          "type": "max_chars",
+          "value": 400
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "canned": {
+        "output": "{\"score\": 92, \"reason\": \"CI feedback loops are core developer experience work.\"}",
+        "latency_ms": 900,
+        "judge_pass": true
+      }
+    }
+  ]
+}

--- a/tests/benchmarks/model_tiers/lem-router.json
+++ b/tests/benchmarks/model_tiers/lem-router.json
@@ -1,0 +1,354 @@
+{
+  "tier": "lem-router",
+  "version": 1,
+  "contract": "The routing tier. Two things are graded here. The `LEMComplexityRouter` contract (`.litellm/complexity_router.py` delegating to `routing_policy.complexity_tier`) must resolve each prompt shape to the tier named on the case — that check is deterministic and model-independent, and it is a regression guard on the router itself. Separately, the model deployed behind the `lem-router` alias must still answer these prompts cleanly: short, no preamble, no markdown fence.",
+  "judge_rubric": "Pass only if the answer is the artefact asked for, with no preamble and no invented specifics.",
+  "thresholds": {
+    "deterministic_pass_rate": 1.0,
+    "judge_pass_rate": 0.8,
+    "min_judged": 3
+  },
+  "cases": [
+    {
+      "id": "router-refine-short",
+      "title": "A refine ask must route simple",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Refine this line so it reads more plainly: 'We are excited to announce our new offering.'"
+        }
+      ],
+      "params": {
+        "temperature": 0,
+        "max_tokens": 60
+      },
+      "assertions": [
+        {
+          "type": "router_tier",
+          "value": "lem-simple"
+        },
+        {
+          "type": "max_chars",
+          "value": 300
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "judge": false,
+      "canned": {
+        "output": "We shipped something new. Here is what it does.",
+        "latency_ms": 420
+      }
+    },
+    {
+      "id": "router-comma-separated",
+      "title": "A comma-separated list ask must route simple",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Give three tools for tracking deployment frequency, comma separated."
+        }
+      ],
+      "params": {
+        "temperature": 0,
+        "max_tokens": 40
+      },
+      "assertions": [
+        {
+          "type": "router_tier",
+          "value": "lem-simple"
+        },
+        {
+          "type": "comma_list",
+          "min_items": 3,
+          "max_items": 3
+        },
+        {
+          "type": "max_chars",
+          "value": 200
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "judge": false,
+      "canned": {
+        "output": "GitHub Actions, Grafana, Datadog",
+        "latency_ms": 380
+      }
+    },
+    {
+      "id": "router-shorten-hook",
+      "title": "A shorten ask must route simple",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Shorten this to one line: 'There is a lot to say about why our onboarding took so long, but the short version is that nobody owned it.'"
+        }
+      ],
+      "params": {
+        "temperature": 0,
+        "max_tokens": 50
+      },
+      "assertions": [
+        {
+          "type": "router_tier",
+          "value": "lem-simple"
+        },
+        {
+          "type": "max_chars",
+          "value": 200
+        },
+        {
+          "type": "max_lines",
+          "value": 1
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "judge": false,
+      "canned": {
+        "output": "Onboarding was slow because nobody owned it.",
+        "latency_ms": 360
+      }
+    },
+    {
+      "id": "router-classify-short",
+      "title": "A short classification ask must route simple",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Is this comment positive or negative? 'Third outage this month.'"
+        }
+      ],
+      "params": {
+        "temperature": 0,
+        "max_tokens": 5
+      },
+      "assertions": [
+        {
+          "type": "router_tier",
+          "value": "lem-simple"
+        },
+        {
+          "type": "max_chars",
+          "value": 40
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "judge": false,
+      "canned": {
+        "output": "Negative",
+        "latency_ms": 290
+      }
+    },
+    {
+      "id": "router-framework-medium",
+      "title": "One complex signal must route medium",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Give me a framework for deciding when a service is worth deleting."
+        }
+      ],
+      "params": {
+        "temperature": 0.4,
+        "max_tokens": 400
+      },
+      "assertions": [
+        {
+          "type": "router_tier",
+          "value": "lem-medium"
+        },
+        {
+          "type": "min_chars",
+          "value": 80
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "judge": false,
+      "canned": {
+        "output": "Three questions, in order. Who calls it, and when did they last do so? What breaks if it stops answering for an hour? Who would notice, and how long would that take? A service that no caller misses within an hour is a candidate; one that fails the third question needs an owner before it needs a decision.",
+        "latency_ms": 1800
+      }
+    },
+    {
+      "id": "router-step-by-step-medium",
+      "title": "A step-by-step ask must route medium",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Walk me step-by-step through rotating a leaked API key without downtime."
+        }
+      ],
+      "params": {
+        "temperature": 0.4,
+        "max_tokens": 500
+      },
+      "assertions": [
+        {
+          "type": "router_tier",
+          "value": "lem-medium"
+        },
+        {
+          "type": "min_chars",
+          "value": 120
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "judge": false,
+      "canned": {
+        "output": "Issue the new key first and deploy it alongside the old one, so both are valid. Move consumers over one at a time, watching authentication failures per consumer rather than in aggregate. Once traffic on the old key is zero for a full cycle, revoke it. Only then remove the dual-key handling, and record when the leak began so the audit has a start date.",
+        "latency_ms": 2400
+      }
+    },
+    {
+      "id": "router-long-prompt-medium",
+      "title": "A long prompt with no signals must route medium on length alone",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Here is the context for a post I want help with, and I am giving you all of it because the details matter. Our team of nine engineers supports three products that were built by three different companies before an acquisition brought them together. Each one has its own deployment process, its own alerting stack, and its own on-call rota, which means a single engineer joining the team has to learn three of everything before they can be useful on any of them. We have talked about consolidating for two years. Every time we start, something urgent arrives and we stop. Last quarter we tried a different approach and picked only the alerting stack to unify, ignoring deployment and on-call entirely, on the theory that one finished thing beats three half-finished ones. It took seven weeks and it worked, and the team is now arguing about whether to do deployment next or on-call next, with reasonable people on both sides. Given all of that, help me think about what a reader would find genuinely useful in a post about it, and what would just be another consolidation story that everybody has already read a version of somewhere else, because I do not want to write the second thing. For what it is worth, the alerting work itself was unglamorous: we agreed on one naming convention, moved every rule into a single repository, and deleted about a quarter of the rules on the way because nobody could name a time they had acted on them. The migration guide we wrote for the second product took longer to write than the migration took to run, and the third product was done in a single afternoon by somebody who had not been involved in either of the first two, which is the strongest evidence I have that the convention was the valuable part rather than the tooling. None of that is interesting on its own, and I am aware that a post which simply lists the steps we followed would be the second thing rather than the first. I would rather write about the argument that is happening now, because it is the honest part and because I genuinely do not know which side is right, but I am not sure whether an unresolved argument makes a good post or just an inconclusive one, and that is really the question I want your help thinking through before I start drafting anything at all."
+        }
+      ],
+      "params": {
+        "temperature": 0.5,
+        "max_tokens": 500
+      },
+      "assertions": [
+        {
+          "type": "router_tier",
+          "value": "lem-medium"
+        },
+        {
+          "type": "min_chars",
+          "value": 120
+        },
+        {
+          "type": "no_preamble"
+        }
+      ],
+      "judge": false,
+      "canned": {
+        "output": "The consolidation is the part every reader has seen. The decision rule is not. What makes this specific is that you picked one of three, finished it, and can now say what finishing bought you that starting three would not have. Write the seven weeks and the argument that followed, and leave the acquisition backstory to one line.",
+        "latency_ms": 2600
+      }
+    },
+    {
+      "id": "router-thought-leadership-complex",
+      "title": "Two complex signals must route complex",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Write a thought leadership post for an awareness buyer stage about why platform consolidation stalls."
+        }
+      ],
+      "params": {
+        "temperature": 0.8,
+        "max_tokens": 900
+      },
+      "assertions": [
+        {
+          "type": "router_tier",
+          "value": "lem-complex"
+        },
+        {
+          "type": "min_chars",
+          "value": 300
+        },
+        {
+          "type": "no_preamble"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "post"
+        }
+      ],
+      "canned": {
+        "output": "Platform consolidation does not stall because the work is hard. It stalls because the work is invisible until it is finished.\n\nHalf a migration looks exactly like no migration, except with two systems to maintain instead of one. So the first urgent thing that arrives wins, every time, and the team goes back to carrying both.\n\nThe teams that get through it pick something small enough to finish inside one quarter and refuse to start the second thing until the first is done.",
+        "latency_ms": 5200,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "router-personal-story-complex",
+      "title": "A personal-story ask with a second signal must route complex",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Write a personal story post for a consideration buyer stage about the first time I deleted a service."
+        }
+      ],
+      "params": {
+        "temperature": 0.8,
+        "max_tokens": 900
+      },
+      "assertions": [
+        {
+          "type": "router_tier",
+          "value": "lem-complex"
+        },
+        {
+          "type": "min_chars",
+          "value": 300
+        },
+        {
+          "type": "no_preamble"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "post"
+        }
+      ],
+      "canned": {
+        "output": "The first service I deleted took an afternoon to turn off and three weeks to get permission for.\n\nNobody objected. That was the strange part. Every person I asked agreed it should go, and every one of them wanted somebody else to say so first.\n\nWhat finally moved it was writing down who I had asked and what they had said, and sending that around. The list was the decision. The deletion was just the paperwork afterwards.",
+        "latency_ms": 5000,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "router-comprehensive-industry-news-complex",
+      "title": "A comprehensive industry-news ask must route complex",
+      "messages": [
+        {
+          "role": "user",
+          "content": "Give a comprehensive commentary on this industry news item for a LinkedIn audience: a major cloud provider has deprecated its managed queue service with eighteen months of notice."
+        }
+      ],
+      "params": {
+        "temperature": 0.8,
+        "max_tokens": 900
+      },
+      "assertions": [
+        {
+          "type": "router_tier",
+          "value": "lem-complex"
+        },
+        {
+          "type": "min_chars",
+          "value": 300
+        },
+        {
+          "type": "no_preamble"
+        },
+        {
+          "type": "slop_lint",
+          "content_type": "post"
+        }
+      ],
+      "canned": {
+        "output": "Eighteen months sounds generous until you count the teams who will not start for fifteen of them.\n\nA deprecation notice is not a migration plan, and the gap between the two is where the incidents live. The queue is rarely the hard part; the semantics are. Delivery guarantees, ordering, and what your consumers quietly rely on that was never in the contract.\n\nThe useful move this month is not to migrate. It is to write down what your current queue promises you, and check whether you know.",
+        "latency_ms": 5300,
+        "judge_pass": true
+      }
+    }
+  ]
+}

--- a/tests/benchmarks/model_tiers/lem-simple.json
+++ b/tests/benchmarks/model_tiers/lem-simple.json
@@ -1,0 +1,196 @@
+{
+  "tier": "lem-simple",
+  "version": 1,
+  "contract": "Short outputs of at most 300 characters: refine, summarize briefly, produce comma-separated lists or one-word classifications. The answer is pasted straight into LinkedIn copy or parsed by code, so it must obey the stated length and shape exactly and must never open with a preamble, a restatement of the task, or a markdown fence.",
+  "judge_rubric": "Pass only if the answer is exactly the artefact that was asked for, at or under the stated length, with no preamble, no closing offer of further help, and no fact, number, company or person that the prompt did not supply.",
+  "thresholds": {"deterministic_pass_rate": 0.9, "judge_pass_rate": 0.8, "min_judged": 4},
+  "cases": [
+    {
+      "id": "simple-industries-comma-list",
+      "title": "Three industries as a bare comma-separated list",
+      "messages": [
+        {"role": "system", "content": "You classify LinkedIn profiles. Answer with the requested list and nothing else."},
+        {"role": "user", "content": "Profile: Fractional CTO who ships internal tooling for mid-market logistics operators and speaks about platform reliability. Give exactly 3 industries this person sells into, as a single comma-separated line. No numbering, no explanation."}
+      ],
+      "params": {"temperature": 0, "max_tokens": 60},
+      "assertions": [
+        {"type": "comma_list", "min_items": 3, "max_items": 3},
+        {"type": "max_chars", "value": 120},
+        {"type": "max_lines", "value": 1},
+        {"type": "no_preamble"}
+      ],
+      "canned": {
+        "output": "Logistics, Supply Chain Technology, Enterprise Software",
+        "latency_ms": 640,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "simple-keyword-list",
+      "title": "Five targeting keywords, comma separated",
+      "messages": [
+        {"role": "system", "content": "You extract targeting keywords. Answer with the list only."},
+        {"role": "user", "content": "Topic: reducing deployment risk for teams releasing several times a day. Give 5 short LinkedIn targeting keywords as one comma-separated line."}
+      ],
+      "params": {"temperature": 0, "max_tokens": 80},
+      "assertions": [
+        {"type": "comma_list", "min_items": 5, "max_items": 5},
+        {"type": "max_chars", "value": 160},
+        {"type": "max_lines", "value": 1},
+        {"type": "no_preamble"}
+      ],
+      "canned": {
+        "output": "continuous delivery, deployment risk, release engineering, rollback strategy, feature flags",
+        "latency_ms": 700,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "simple-reaction-choice",
+      "title": "One reaction word from a closed set",
+      "messages": [
+        {"role": "system", "content": "You pick the single best LinkedIn reaction. Reply with one word from the list and nothing else."},
+        {"role": "user", "content": "Allowed: like, celebrate, support, love, insightful, funny. Post: 'After eleven months of interviews, I signed my first enterprise customer this morning.' Which reaction fits best?"}
+      ],
+      "params": {"temperature": 0, "max_tokens": 5},
+      "assertions": [
+        {"type": "max_chars", "value": 20},
+        {"type": "max_lines", "value": 1},
+        {"type": "no_preamble"},
+        {"type": "required_phrases", "values": ["like", "celebrate", "support", "love", "insightful", "funny"], "mode": "any"}
+      ],
+      "canned": {"output": "celebrate", "latency_ms": 380, "judge_pass": true}
+    },
+    {
+      "id": "simple-relevance-yes-no",
+      "title": "Binary topic relevance",
+      "messages": [
+        {"role": "system", "content": "You answer with exactly one word: yes or no."},
+        {"role": "user", "content": "Topics of interest: platform engineering, developer experience. Post: 'Our new office plants have transformed the mood on the third floor.' Is the post relevant to any topic of interest?"}
+      ],
+      "params": {"temperature": 0, "max_tokens": 3},
+      "assertions": [
+        {"type": "max_chars", "value": 10},
+        {"type": "max_lines", "value": 1},
+        {"type": "no_preamble"},
+        {"type": "required_phrases", "values": ["yes", "no"], "mode": "any"}
+      ],
+      "canned": {"output": "no", "latency_ms": 310, "judge_pass": true}
+    },
+    {
+      "id": "simple-hook-shorten",
+      "title": "Shorten an opening line to the mobile hook budget",
+      "messages": [
+        {"role": "system", "content": "You rewrite opening lines. Reply with the rewritten line only."},
+        {"role": "user", "content": "Shorten this to under 140 characters, one line, keeping the same claim: 'We spent the better part of last quarter trying to work out why our deployment pipeline kept failing on Fridays, and the answer turned out to be embarrassingly simple.'"}
+      ],
+      "params": {"temperature": 0.3, "max_tokens": 60},
+      "assertions": [
+        {"type": "max_chars", "value": 140},
+        {"type": "min_chars", "value": 30},
+        {"type": "max_lines", "value": 1},
+        {"type": "no_preamble"}
+      ],
+      "canned": {
+        "output": "Our pipeline failed every Friday for a quarter. The cause was embarrassingly simple.",
+        "latency_ms": 520,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "simple-brief-summary",
+      "title": "Summarize briefly, under the tier's own 300-character ceiling",
+      "messages": [
+        {"role": "system", "content": "You summarize briefly. Reply with the summary only."},
+        {"role": "user", "content": "Summarize in under 300 characters: 'A mid-market insurer moved claims intake from a nightly batch job to an event stream. Handling time dropped from four days to under one. The migration took two engineers eleven weeks and required no change to the underlying claims system.'"}
+      ],
+      "params": {"temperature": 0.3, "max_tokens": 120},
+      "assertions": [
+        {"type": "max_chars", "value": 300},
+        {"type": "min_chars", "value": 60},
+        {"type": "no_preamble"},
+        {"type": "slop_lint", "content_type": "post"}
+      ],
+      "canned": {
+        "output": "An insurer replaced nightly batch claims intake with an event stream. Handling time fell from four days to under one. Two engineers took eleven weeks, and the underlying claims system was left untouched.",
+        "latency_ms": 810,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "simple-json-sentiment",
+      "title": "Structured sentiment verdict as a bare JSON object",
+      "messages": [
+        {"role": "system", "content": "You return a single JSON object and nothing else. No markdown fence."},
+        {"role": "user", "content": "Classify the sentiment of this comment and return {\"sentiment\": \"positive|neutral|negative\", \"confidence\": 0.0-1.0}. Comment: 'This is the third outage this month and nobody has explained why.'"}
+      ],
+      "params": {"temperature": 0, "max_tokens": 60},
+      "assertions": [
+        {"type": "json_object", "required_keys": ["sentiment", "confidence"]},
+        {"type": "max_chars", "value": 200},
+        {"type": "no_preamble"}
+      ],
+      "canned": {
+        "output": "{\"sentiment\": \"negative\", \"confidence\": 0.93}",
+        "latency_ms": 460,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "simple-headline-refine",
+      "title": "Refine a headline with no emoji and no hype",
+      "messages": [
+        {"role": "system", "content": "You refine LinkedIn headlines. Reply with the headline only."},
+        {"role": "user", "content": "Rewrite this headline in under 200 characters, plain text, no emoji and no superlatives: 'Visionary transformation leader unlocking exponential growth and revolutionary synergies for world-class organisations.'"}
+      ],
+      "params": {"temperature": 0.3, "max_tokens": 80},
+      "assertions": [
+        {"type": "max_chars", "value": 200},
+        {"type": "max_lines", "value": 1},
+        {"type": "no_preamble"},
+        {"type": "forbidden_phrases", "values": ["🚀", "✨", "revolutionary", "world-class", "game-changing"]}
+      ],
+      "canned": {
+        "output": "Operations lead helping mid-market teams cut cycle time and ship on a predictable schedule.",
+        "latency_ms": 540,
+        "judge_pass": true
+      }
+    },
+    {
+      "id": "simple-single-value-extract",
+      "title": "Extract one value and say nothing else",
+      "messages": [
+        {"role": "system", "content": "You extract one field. Reply with the value only, no punctuation, no sentence."},
+        {"role": "user", "content": "Profile location line: 'Greater Boston Area, Massachusetts, United States'. Reply with the city name only."}
+      ],
+      "params": {"temperature": 0, "max_tokens": 8},
+      "assertions": [
+        {"type": "max_chars", "value": 40},
+        {"type": "max_lines", "value": 1},
+        {"type": "no_preamble"},
+        {"type": "required_phrases", "values": ["Boston"], "mode": "all"}
+      ],
+      "canned": {"output": "Boston", "latency_ms": 300, "judge_pass": true}
+    },
+    {
+      "id": "simple-no-fabrication",
+      "title": "Refuse to invent a number the prompt never supplied",
+      "messages": [
+        {"role": "system", "content": "You write one short factual line. Never state a statistic that was not given to you."},
+        {"role": "user", "content": "Write one sentence, under 200 characters, describing what this team does. Facts you may use, and no others: they run the internal deploy tooling for a 40-person engineering org. Do not invent metrics."}
+      ],
+      "params": {"temperature": 0.3, "max_tokens": 80},
+      "assertions": [
+        {"type": "max_chars", "value": 200},
+        {"type": "no_preamble"},
+        {"type": "required_phrases", "values": ["40"], "mode": "all"},
+        {"type": "forbidden_phrases", "values": ["%", "million", "billion"]}
+      ],
+      "canned": {
+        "output": "They build and run the internal deploy tooling that a 40-person engineering organisation ships through every day.",
+        "latency_ms": 590,
+        "judge_pass": true
+      }
+    }
+  ]
+}

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -1,0 +1,937 @@
+"""Unit tests for scripts/benchmark_models.py — the model-tier evaluation harness (issue #721).
+
+Everything here is the PURE half: suite loading, deterministic assertions, scorecard merge, the
+champion/challenger gate, report + leaderboard rendering, judge planning/parsing, and the PostHog
+evaluation specs. Provider and PostHog I/O are mocked.
+"""
+
+import importlib.util
+import json
+import pathlib
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_PATH = _ROOT / "scripts" / "benchmark_models.py"
+_spec = importlib.util.spec_from_file_location("benchmark_models", _PATH)
+bm = importlib.util.module_from_spec(_spec)
+sys.modules["benchmark_models"] = bm
+_spec.loader.exec_module(bm)
+
+SUITE_DIR = _ROOT / "tests" / "benchmarks" / "model_tiers"
+
+
+def _case(case_id="c1", assertions=None, **extra):
+    case = {"id": case_id, "messages": [{"role": "user", "content": "hi"}],
+            "assertions": assertions or [{"type": "max_chars", "value": 100}]}
+    case.update(extra)
+    return case
+
+
+def _suite(tier="lem-simple", cases=None, thresholds=None):
+    return {"tier": tier, "version": 1, "contract": "c", "judge_rubric": "r",
+            "thresholds": bm.normalize_thresholds(thresholds),
+            "cases": cases or [_case()]}
+
+
+def _card(tier="lem-simple", model="m", role="candidate", det=1.0, judged=5, judge_rate=1.0,
+          errors=None):
+    return {"tier": tier, "model": model, "role": role, "cases": 10,
+            "deterministic_pass_rate": det, "deterministic_passed": 10, "errors": errors or [],
+            "failed_cases": [], "unscored_assertions": 0, "judged": judged,
+            "judge_passed": judged, "judge_timeouts": 0, "judge_pass_rate": judge_rate,
+            "judge_notes": [], "latency_p50_ms": 100.0, "latency_p90_ms": 200.0,
+            "total_tokens": 0, "case_results": [], "benchmark_run_id": "bm-x"}
+
+
+# ───────────────────────────── the shipped fixtures ──────────────────────────────
+
+class TestShippedSuites:
+    def test_every_tier_has_a_loadable_suite_with_enough_cases(self):
+        suites = bm.load_suites(str(SUITE_DIR))
+        assert set(suites) == set(bm.TIERS)
+        for tier, suite in suites.items():
+            assert 10 <= len(suite["cases"]) <= 20, tier
+            assert suite["contract"] and suite["judge_rubric"], tier
+
+    def test_case_ids_are_unique_across_every_suite(self):
+        seen = set()
+        for suite in bm.load_suites(str(SUITE_DIR)).values():
+            for case in suite["cases"]:
+                assert case["id"] not in seen
+                seen.add(case["id"])
+
+    def test_fixtures_carry_only_synthetic_inputs(self):
+        """No production data leakage: the suites are committed to a public repo."""
+        banned = ("christopher.queen@", "linkedin.com/in/", "OLLAMA_CLOUD_API_KEY",
+                  "sk-", "phc_", "@gmail.com")
+        for path in SUITE_DIR.glob("*.json"):
+            text = path.read_text()
+            for needle in banned:
+                assert needle not in text, f"{path.name} contains {needle!r}"
+
+    def test_canned_outputs_satisfy_their_own_assertions(self):
+        """The dry run is only a proof if the committed canned answers actually pass. A fixture
+        that drifted from its assertions would make every dry run look broken."""
+        for tier, suite in bm.load_suites(str(SUITE_DIR)).items():
+            outputs = {c["id"]: (c.get("canned") or {}).get("output") for c in suite["cases"]}
+            for result in bm.score_suite(suite, outputs):
+                assert result["passes"], f"{tier}/{result['case_id']}: {result['failures']}"
+
+    def test_judgeable_case_count_meets_each_suites_min_judged(self):
+        for tier, suite in bm.load_suites(str(SUITE_DIR)).items():
+            judgeable = [c for c in suite["cases"] if c.get("judge") is not False]
+            assert len(judgeable) >= suite["thresholds"]["min_judged"], tier
+
+    def test_router_suite_encodes_the_live_router_contract(self):
+        suite = bm.load_suites(str(SUITE_DIR), ["lem-router"])["lem-router"]
+        tiers = {a["value"] for c in suite["cases"] for a in c["assertions"]
+                 if a["type"] == "router_tier"}
+        assert tiers == {"lem-simple", "lem-medium", "lem-complex"}
+
+
+# ─────────────────────────────── suite validation ────────────────────────────────
+
+class TestLoadSuite:
+    def test_rejects_unknown_tier(self):
+        with pytest.raises(bm.SuiteError):
+            bm.load_suite({"tier": "lem-nope", "cases": [_case()]})
+
+    def test_rejects_unknown_assertion_type(self):
+        with pytest.raises(bm.SuiteError, match="unknown assertion"):
+            bm.load_suite({"tier": "lem-simple",
+                           "cases": [_case(assertions=[{"type": "vibes"}])]})
+
+    def test_rejects_duplicate_case_ids(self):
+        with pytest.raises(bm.SuiteError, match="duplicate"):
+            bm.load_suite({"tier": "lem-simple", "cases": [_case("a"), _case("a")]})
+
+    def test_rejects_case_without_messages_or_assertions(self):
+        with pytest.raises(bm.SuiteError):
+            bm.load_suite({"tier": "lem-simple", "cases": [{"id": "a", "assertions": []}]})
+
+    def test_missing_explicitly_requested_tier_raises(self, tmp_path):
+        with pytest.raises(bm.SuiteError):
+            bm.load_suites(str(tmp_path), ["lem-simple"])
+
+    def test_thresholds_are_clamped_and_defaulted(self):
+        assert bm.normalize_thresholds(None)["deterministic_pass_rate"] == 0.9
+        assert bm.normalize_thresholds({"deterministic_pass_rate": 5})[
+            "deterministic_pass_rate"] == 1.0
+        assert bm.normalize_thresholds({"judge_pass_rate": "x"})["judge_pass_rate"] == 0.8
+        assert bm.normalize_thresholds({"min_judged": "x"})["min_judged"] == 3
+
+
+# ────────────────────────── deterministic assertions ─────────────────────────────
+
+class TestAssertions:
+    def test_max_and_min_chars(self):
+        case = _case(assertions=[{"type": "max_chars", "value": 5}])
+        assert bm.evaluate_case(case, "abc")["passes"] is True
+        assert bm.evaluate_case(case, "abcdefg")["passes"] is False
+        case = _case(assertions=[{"type": "min_chars", "value": 5}])
+        assert bm.evaluate_case(case, "abc")["passes"] is False
+
+    def test_no_preamble_catches_narration_only(self):
+        case = _case(assertions=[{"type": "no_preamble"}])
+        assert bm.evaluate_case(case, "Sure! Here you go.")["passes"] is False
+        assert bm.evaluate_case(case, "Here is the list: a, b")["passes"] is False
+        assert bm.evaluate_case(case, "Logistics, Retail")["passes"] is True
+
+    def test_comma_list_counts_items_and_rejects_multiline(self):
+        case = _case(assertions=[{"type": "comma_list", "min_items": 3, "max_items": 3}])
+        assert bm.evaluate_case(case, "a, b, c")["passes"] is True
+        assert bm.evaluate_case(case, "a, b")["passes"] is False
+        assert bm.evaluate_case(case, "a, b, c\n- d")["passes"] is False
+
+    def test_json_object_requires_bare_json_with_keys(self):
+        case = _case(assertions=[{"type": "json_object", "required_keys": ["score"]}])
+        assert bm.evaluate_case(case, '{"score": 1}')["passes"] is True
+        assert bm.evaluate_case(case, '{"other": 1}')["passes"] is False
+        assert bm.evaluate_case(case, '```json\n{"score": 1}\n```')["passes"] is False
+        assert bm.evaluate_case(case, '[1, 2]')["passes"] is False
+
+    def test_max_lines(self):
+        case = _case(assertions=[{"type": "max_lines", "value": 1}])
+        assert bm.evaluate_case(case, "one line")["passes"] is True
+        assert bm.evaluate_case(case, "one\ntwo")["passes"] is False
+
+    def test_required_and_forbidden_phrases(self):
+        case = _case(assertions=[{"type": "required_phrases", "values": ["40", "days"],
+                                  "mode": "all"}])
+        assert bm.evaluate_case(case, "40 days")["passes"] is True
+        assert bm.evaluate_case(case, "40 hours")["passes"] is False
+        case = _case(assertions=[{"type": "required_phrases", "values": ["yes", "no"]}])
+        assert bm.evaluate_case(case, "no")["passes"] is True
+        case = _case(assertions=[{"type": "forbidden_phrases", "values": ["book a call"]}])
+        assert bm.evaluate_case(case, "Want to book a call?")["passes"] is False
+
+    def test_slop_lint_blocks_a_hard_violation(self):
+        case = _case(assertions=[{"type": "slop_lint", "content_type": "post"}])
+        slop = ("It's not about the tooling, it's about the people. "
+                "Here's the kicker: nobody noticed.")
+        assert bm.evaluate_case(case, slop)["passes"] is False
+
+    def test_slop_lint_disabled_surface_is_unscored_not_a_pass(self, monkeypatch):
+        monkeypatch.setenv("SLOP_LINT_ENABLED", "false")
+        case = _case(assertions=[{"type": "slop_lint", "content_type": "post"}])
+        result = bm.evaluate_case(case, "anything at all")
+        assert result["passes"] is True          # nothing FAILED …
+        assert result["unscored"] == 1           # … but nothing was measured either
+
+    def test_comment_contract_uses_the_cases_target_post(self):
+        case = _case(assertions=[{"type": "comment_contract"}],
+                     context={"post_content": "We deleted our staging environment and put every "
+                                              "change behind a feature flag."})
+        good = ("Deleting staging only works because the flag expires. In my experience flags that "
+                "outlive the change become a second configuration surface. How do you enforce it?")
+        assert bm.evaluate_case(case, good)["passes"] is True
+        assert bm.evaluate_case(case, "Great post! Thanks for sharing.")["passes"] is False
+
+    def test_router_tier_grades_the_deterministic_router_contract(self):
+        case = {"id": "r", "messages": [{"role": "user", "content": "Refine this line please"}],
+                "assertions": [{"type": "router_tier", "value": "lem-simple"}]}
+        assert bm.evaluate_case(case, "ok")["passes"] is True
+        case["assertions"] = [{"type": "router_tier", "value": "lem-complex"}]
+        assert bm.evaluate_case(case, "ok")["passes"] is False
+
+    def test_max_similarity_compares_against_named_peer_cases(self):
+        case = _case(assertions=[{"type": "max_similarity", "value": 0.3, "against": ["peer"]}])
+        peers = {"peer": "the quick brown fox jumps over the lazy dog"}
+        assert bm.evaluate_case(case, "an entirely different sentence about ships",
+                                peers)["passes"] is True
+        assert bm.evaluate_case(case, "the quick brown fox jumps over the lazy dog",
+                                peers)["passes"] is False
+
+    def test_max_similarity_without_a_peer_is_unscored(self):
+        case = _case(assertions=[{"type": "max_similarity", "value": 0.3, "against": ["missing"]}])
+        result = bm.evaluate_case(case, "text", {})
+        assert result["passes"] is True and result["unscored"] == 1
+
+    def test_min_burstiness_is_unscored_on_a_one_sentence_answer(self):
+        case = _case(assertions=[{"type": "min_burstiness", "value": 0.2}])
+        assert bm.evaluate_case(case, "short")["unscored"] == 1
+
+    def test_missing_output_is_a_failure_not_a_dropped_case(self):
+        result = bm.evaluate_case(_case(), None)
+        assert result["passes"] is False
+        assert result["failures"] == ["no output from the model"]
+
+    def test_a_raising_assertion_fails_that_case_only(self):
+        case = _case(assertions=[{"type": "max_chars", "value": "not-a-number"},
+                                 {"type": "no_preamble"}])
+        result = bm.evaluate_case(case, "clean answer")
+        assert result["passes"] is False
+        assert any("assertion raised" in f for f in result["failures"])
+        assert result["assertions"][1]["passes"] is True
+
+
+# ───────────────────────────── scorecard merge ───────────────────────────────────
+
+class TestScorecard:
+    def test_rates_errors_and_latency_percentiles(self):
+        results = [{"case_id": "a", "passes": True, "failures": [], "unscored": 0},
+                   {"case_id": "b", "passes": False, "failures": ["max_chars: too long"],
+                    "unscored": 0},
+                   {"case_id": "c", "passes": False, "failures": [], "unscored": 0,
+                    "error": "timeout"}]
+        judge = {"a": {"passes": True, "status": "scored"},
+                 "b": {"passes": False, "status": "scored", "reasoning": "generic filler"}}
+        timings = {"a": {"latency_ms": 100, "total_tokens": 10},
+                   "b": {"latency_ms": 300, "total_tokens": 20}, "c": {}}
+        card = bm.merge_scorecard("lem-simple", "m", "candidate", results, judge, timings)
+        assert card["deterministic_pass_rate"] == pytest.approx(1 / 3, abs=1e-4)
+        assert card["errors"] == ["c"]
+        assert card["judged"] == 2 and card["judge_pass_rate"] == 0.5
+        assert card["total_tokens"] == 30
+        assert card["latency_p50_ms"] == 100.0
+        assert card["judge_notes"][0]["case_id"] == "b"
+
+    def test_judge_timeouts_are_excluded_from_the_denominator(self):
+        results = [{"case_id": "a", "passes": True, "failures": [], "unscored": 0},
+                   {"case_id": "b", "passes": True, "failures": [], "unscored": 0}]
+        judge = {"a": {"passes": True, "status": "scored"},
+                 "b": {"passes": None, "status": bm.JUDGE_TIMEOUT}}
+        card = bm.merge_scorecard("lem-simple", "m", "candidate", results, judge)
+        assert card["judged"] == 1
+        assert card["judge_timeouts"] == 1
+        assert card["judge_pass_rate"] == 1.0
+
+    def test_no_judge_verdicts_leave_the_rate_unknown_not_zero(self):
+        results = [{"case_id": "a", "passes": True, "failures": [], "unscored": 0}]
+        card = bm.merge_scorecard("lem-simple", "m", "candidate", results, {})
+        assert card["judge_pass_rate"] is None
+
+
+# ─────────────────────────── champion/challenger gate ────────────────────────────
+
+class TestGate:
+    def test_recommends_when_floors_are_met_and_champion_is_matched(self):
+        gate = bm.gate_decision(_card(det=0.95), _card(role="champion", det=0.9),
+                                {"deterministic_pass_rate": 0.9})
+        assert gate["verdict"] == bm.VERDICT_RECOMMEND
+        assert gate["blockers"] == []
+
+    def test_rejects_a_candidate_below_the_absolute_floor(self):
+        gate = bm.gate_decision(_card(det=0.5), _card(role="champion", det=0.4),
+                                {"deterministic_pass_rate": 0.9})
+        assert gate["verdict"] == bm.VERDICT_REJECT
+        assert "deterministic floor" in gate["blockers"]
+
+    def test_rejects_a_candidate_that_loses_to_the_champion(self):
+        gate = bm.gate_decision(_card(det=0.92), _card(role="champion", det=0.99),
+                                {"deterministic_pass_rate": 0.9})
+        assert gate["verdict"] == bm.VERDICT_REJECT
+        assert "beats champion (deterministic)" in gate["blockers"]
+
+    def test_a_tie_counts_as_meets_or_beats(self):
+        gate = bm.gate_decision(_card(det=0.9), _card(role="champion", det=0.9),
+                                {"deterministic_pass_rate": 0.9})
+        assert gate["verdict"] == bm.VERDICT_RECOMMEND
+
+    def test_losing_on_judge_alone_still_rejects(self):
+        gate = bm.gate_decision(_card(judge_rate=0.8), _card(role="champion", judge_rate=1.0),
+                                {"judge_pass_rate": 0.8})
+        assert gate["verdict"] == bm.VERDICT_REJECT
+        assert "beats champion (judge)" in gate["blockers"]
+
+    def test_provider_errors_block_a_recommendation(self):
+        gate = bm.gate_decision(_card(errors=["c1"]), _card(role="champion"), {})
+        assert gate["verdict"] == bm.VERDICT_REJECT
+        assert "provider answered every case" in gate["blockers"]
+
+    def test_no_champion_is_no_baseline_never_a_pass(self):
+        gate = bm.gate_decision(_card(), None, {})
+        assert gate["verdict"] == bm.VERDICT_NO_BASELINE
+
+    def test_thin_judge_evidence_degrades_to_deterministic_only(self):
+        gate = bm.gate_decision(_card(judged=1, judge_rate=1.0),
+                                _card(role="champion", judged=1, judge_rate=1.0),
+                                {"min_judged": 3})
+        assert gate["verdict"] == bm.VERDICT_DETERMINISTIC_ONLY
+        assert bm.swap_recommendations([gate]) == []
+
+    def test_only_full_recommendations_become_swap_recommendations(self):
+        gates = [
+            {"tier": "lem-simple", "model": "a", "champion": "old", "verdict": bm.VERDICT_RECOMMEND},
+            {"tier": "lem-medium", "model": "b", "champion": "old2", "verdict": bm.VERDICT_REJECT},
+            {"tier": "lem-complex", "model": "c", "champion": None,
+             "verdict": bm.VERDICT_NO_BASELINE},
+        ]
+        assert bm.swap_recommendations(gates) == [
+            {"tier": "lem-simple", "model": "a", "champion": "old"}]
+
+    def test_gate_run_pairs_each_candidate_with_its_own_tier_champion(self):
+        cards = [_card(tier="lem-simple", model="champ-s", role="champion"),
+                 _card(tier="lem-medium", model="champ-m", role="champion"),
+                 _card(tier="lem-medium", model="cand")]
+        gates = bm.gate_run(cards, {"lem-medium": _suite("lem-medium")})
+        assert len(gates) == 1 and gates[0]["champion"] == "champ-m"
+
+    def test_mapping_lines_are_rendered_not_written(self):
+        lines = bm.recommendation_mapping_lines(
+            [{"tier": "lem-simple", "model": "new", "champion": "old"}])
+        assert lines == ['  "old": "new"  # lem-simple: benchmark-recommended']
+
+
+# ───────────────────────────── provenance guard ──────────────────────────────────
+
+class TestProvenance:
+    def _run(self, **over):
+        run = {"source": bm.BENCHMARK_SOURCE, "run_id": "bm-1", "date": "2026-07-27",
+               "scoring_mode": bm.SCORING_DRY_RUN, "tiers": ["lem-simple"], "candidates": [],
+               "judge_calls": 0, "judge_call_cap": 10,
+               "scorecards": [_card()], "gates": [], "recommendations": []}
+        run["scorecards"][0]["benchmark_run_id"] = "bm-1"
+        run.update(over)
+        return run
+
+    def test_accepts_a_well_formed_benchmark_run(self):
+        bm.assert_benchmark_only(self._run())
+
+    def test_refuses_a_non_benchmark_source(self):
+        with pytest.raises(ValueError, match="non-benchmark source"):
+            bm.assert_benchmark_only(self._run(source="production"))
+
+    def test_refuses_a_scorecard_from_another_run(self):
+        run = self._run()
+        run["scorecards"][0]["benchmark_run_id"] = "bm-other"
+        with pytest.raises(ValueError, match="not tagged with this run_id"):
+            bm.assert_benchmark_only(run)
+
+    def test_refuses_a_scorecard_carrying_a_person(self):
+        run = self._run()
+        run["scorecards"][0]["user_id"] = 7
+        with pytest.raises(ValueError, match="anonymous"):
+            bm.assert_benchmark_only(run)
+
+    def test_render_report_refuses_a_tainted_run(self):
+        with pytest.raises(ValueError):
+            bm.render_report(self._run(source="prod-traffic"))
+
+    def test_write_report_never_touches_disk_for_a_tainted_run(self, tmp_path):
+        out = tmp_path / "reports"
+        with pytest.raises(ValueError):
+            bm.write_report(self._run(source="prod-traffic"), str(out))
+        assert not out.exists()
+
+
+# ─────────────────────────── report + leaderboard ────────────────────────────────
+
+class TestRendering:
+    def _run(self):
+        candidate = _card(model="new", det=1.0)
+        champion = _card(model="old", role="champion", det=0.9)
+        champion["failed_cases"] = [{"case_id": "c1", "failures": ["max_chars: 400 chars > 300"]}]
+        champion["judge_notes"] = [{"case_id": "c1", "reasoning": "reads like a template"}]
+        for card in (candidate, champion):
+            card["benchmark_run_id"] = "bm-1"
+        gates = [{"tier": "lem-simple", "model": "new", "champion": "old",
+                  "verdict": bm.VERDICT_RECOMMEND,
+                  "expectations": [{"expectation": "deterministic floor", "passes": True,
+                                    "detail": "100% vs floor 90%"},
+                                   {"expectation": "beats champion (judge)", "passes": None,
+                                    "detail": "judge evidence missing on one side"}]}]
+        return {"source": bm.BENCHMARK_SOURCE, "run_id": "bm-1", "date": "2026-07-27",
+                "scoring_mode": bm.SCORING_POSTHOG, "tiers": ["lem-simple"], "candidates": ["new"],
+                "judge_calls": 12, "judge_call_cap": 200,
+                "scorecards": [candidate, champion], "gates": gates,
+                "recommendations": bm.swap_recommendations(gates)}
+
+    def test_report_contains_both_models_the_verdict_and_the_mapping_block(self):
+        text = bm.render_report(self._run())
+        assert "`new`" in text and "`old`" in text
+        assert "**recommend**" in text
+        assert 'max_chars: 400 chars > 300' in text
+        assert "reads like a template" in text
+        assert '"old": "new"' in text
+        assert "➖" in text  # an unscored expectation is shown, not hidden
+
+    def test_report_says_so_when_nothing_is_recommended(self):
+        run = self._run()
+        run["recommendations"] = []
+        assert "None. No candidate met" in bm.render_report(run)
+
+    def test_report_filename_is_date_and_run_id(self):
+        assert bm.report_filename(self._run()) == "2026-07-27-bm-1.md"
+
+    def test_leaderboard_rows_carry_the_gate_verdict_and_baseline_role(self):
+        rows = bm.leaderboard_rows(self._run())
+        by_model = {r["model"]: r for r in rows}
+        assert by_model["new"]["verdict"] == bm.VERDICT_RECOMMEND
+        assert by_model["old"]["verdict"] == "baseline"
+
+    def test_update_leaderboard_creates_the_block_when_absent(self):
+        text = bm.update_leaderboard("# Title\n", bm.leaderboard_rows(self._run()))
+        assert bm.LEADERBOARD_BEGIN in text and bm.LEADERBOARD_END in text
+        assert text.count("| lem-simple |") == 2
+
+    def test_re_rendering_the_same_run_replaces_rather_than_duplicates(self):
+        rows = bm.leaderboard_rows(self._run())
+        once = bm.update_leaderboard("# Title\n", rows)
+        twice = bm.update_leaderboard(once, rows)
+        assert twice.count("| lem-simple |") == 2
+
+    def test_a_later_run_is_prepended_and_older_rows_are_kept(self):
+        first = bm.update_leaderboard("# Title\n", bm.leaderboard_rows(self._run()))
+        later = self._run()
+        later["run_id"] = "bm-2"
+        later["date"] = "2026-08-03"
+        for card in later["scorecards"]:
+            card["benchmark_run_id"] = "bm-2"
+        merged = bm.update_leaderboard(first, bm.leaderboard_rows(later))
+        body = merged.split(bm.LEADERBOARD_BEGIN)[1]
+        assert body.index("bm-2") < body.index("bm-1")
+        assert merged.count("| lem-simple |") == 4
+
+    def test_the_committed_leaderboard_has_the_markers(self):
+        text = (_ROOT / "docs" / "model-benchmarks" / "README.md").read_text()
+        assert bm.LEADERBOARD_BEGIN in text and bm.LEADERBOARD_END in text
+
+
+# ─────────────────────────────── judge plumbing ──────────────────────────────────
+
+class TestJudge:
+    def test_only_deterministically_passing_opted_in_cases_are_judged(self):
+        suite = _suite(cases=[_case("a"), _case("b"), _case("c", judge=False)])
+        results = [{"case_id": "a", "passes": True}, {"case_id": "b", "passes": False},
+                   {"case_id": "c", "passes": True}]
+        assert bm.judgeable_cases(results, suite) == ["a"]
+
+    def test_a_case_with_a_provider_error_is_never_judged(self):
+        suite = _suite(cases=[_case("a")])
+        assert bm.judgeable_cases([{"case_id": "a", "passes": True, "error": "boom"}],
+                                  suite) == []
+
+    def test_the_cap_truncates_in_suite_order(self):
+        suite = _suite(cases=[_case("a"), _case("b"), _case("c")])
+        results = [{"case_id": c, "passes": True} for c in ("a", "b", "c")]
+        assert bm.plan_judge_calls(results, suite, 2) == ["a", "b"]
+        assert bm.plan_judge_calls(results, suite, 0) == []
+
+    def test_judge_prompt_is_self_contained(self):
+        suite = _suite()
+        text = bm.judge_messages(suite, _case(), "the answer")[1]["content"]
+        assert suite["contract"] in text and suite["judge_rubric"] in text
+        assert "the answer" in text
+        assert ".py" not in text  # a rubric that points at a repo path grades nothing
+
+    def test_parse_judge_verdict_handles_bare_json_and_fenced_json(self):
+        assert bm.parse_judge_verdict('{"pass": true, "reasoning": "fine"}')["passes"] is True
+        fenced = '```json\n{"pass": false, "reasoning": "generic"}\n```'
+        assert bm.parse_judge_verdict(fenced)["passes"] is False
+
+    def test_parse_judge_verdict_finds_json_inside_prose(self):
+        verdict = bm.parse_judge_verdict('Verdict: {"pass": false, "reasoning": "x"} done')
+        assert verdict["passes"] is False
+
+    def test_an_unparseable_verdict_is_unscored_not_a_pass(self):
+        for reply in ("", "looks good to me", '{"verdict": "yes"}', None):
+            verdict = bm.parse_judge_verdict(reply)
+            assert verdict["passes"] is None
+            assert verdict["status"] == bm.JUDGE_TIMEOUT
+
+    def test_fallback_judge_returns_unscored_when_the_client_fails(self):
+        with patch.dict(sys.modules, {}):
+            with patch("builtins.__import__", side_effect=ImportError("no client")):
+                verdict = bm.fallback_judge(_suite(), _case(), "out")
+        assert verdict["passes"] is None and verdict["status"] == bm.JUDGE_TIMEOUT
+
+
+# ───────────────────── PostHog evaluation specs + retrieval ──────────────────────
+
+class TestPostHogEvals:
+    def test_spec_is_scoped_to_benchmark_events_only(self):
+        spec = bm.evaluation_spec(_suite("lem-medium"))
+        keys = {p["key"] for c in spec["conditions"] for p in c["properties"]}
+        assert "benchmark_run_id" in keys and "lem_tier" in keys
+        assert spec["evaluation_type"] == "llm_judge"
+        assert spec["conditions"][0]["rollout_percentage"] == 100
+
+    def test_plan_creates_only_what_is_missing(self):
+        specs = [bm.evaluation_spec(_suite("lem-simple")), bm.evaluation_spec(_suite("lem-medium"))]
+        existing = {bm.evaluation_name("lem-simple"): {"id": "e1"}}
+        plan = bm.plan_evaluations(existing, specs)
+        assert [p["action"] for p in plan] == ["none", "create"]
+        assert plan[0]["id"] == "e1"
+
+    def test_hogql_is_scoped_to_the_run_and_strips_injection(self):
+        query = bm.hogql_for_run("bm-1'; DROP TABLE events; --")
+        assert "DROP" not in query.upper().replace("DROPTABLEEVENTS", "")
+        assert "'bm-1DROPTABLEevents--'" in query
+        assert "$ai_evaluation" in query
+
+    def test_merge_judge_events_ignores_other_models_and_tiers(self):
+        rows = [["c1", "lem-simple", "new", True, "good"],
+                ["c2", "lem-simple", "old", False, "bad"],
+                ["c3", "lem-medium", "new", True, "other tier"],
+                ["bad-row"]]
+        merged = bm.merge_judge_events(rows, "new", "lem-simple")
+        assert list(merged) == ["c1"]
+        assert merged["c1"]["passes"] is True
+
+    def test_merge_judge_events_accepts_string_results(self):
+        merged = bm.merge_judge_events([["c1", "lem-simple", "new", "PASS", ""]],
+                                       "new", "lem-simple")
+        assert merged["c1"]["passes"] is True
+        assert bm.merge_judge_events([["c1", "lem-simple", "new", "maybe", ""]],
+                                     "new", "lem-simple") == {}
+
+    def test_event_properties_always_carry_the_run_id(self):
+        props = bm.benchmark_event_properties("bm-1", "lem-simple", "c1", "m", "candidate",
+                                              1500, {"prompt_tokens": 10})
+        assert props["benchmark_run_id"] == "bm-1"
+        assert props["source"] == bm.BENCHMARK_SOURCE
+        assert props["$ai_latency"] == 1.5
+        assert props["$ai_input_tokens"] == 10
+
+    def test_polling_stops_at_the_deadline_and_returns_what_landed(self):
+        evals = MagicMock()
+        evals.query.return_value = [["c1", "lem-simple", "m", True, ""]]
+        rows = bm.poll_judge_results(evals, "bm-1", expected=5, timeout_seconds=1,
+                                     sleep=lambda _: time.sleep(0.05))
+        assert rows == [["c1", "lem-simple", "m", True, ""]]
+
+    def test_polling_returns_early_once_every_verdict_landed(self):
+        evals = MagicMock()
+        evals.query.return_value = [["c1", "lem-simple", "m", True, ""]]
+        bm.poll_judge_results(evals, "bm-1", expected=1, timeout_seconds=60,
+                              sleep=lambda _: None)
+        assert evals.query.call_count == 1
+
+    def test_a_failing_query_returns_rather_than_raising(self):
+        evals = MagicMock()
+        evals.query.side_effect = RuntimeError("posthog down")
+        assert bm.poll_judge_results(evals, "bm-1", 3, 5, sleep=lambda _: None) == []
+
+
+# ──────────────────────────────── thin I/O layer ─────────────────────────────────
+
+class TestProviderClient:
+    def _client(self, response=None, error=None):
+        provider = bm.ProviderClient("https://ollama.example", "key")
+        openai_client = MagicMock()
+        if error:
+            openai_client.chat.completions.create.side_effect = error
+        else:
+            openai_client.chat.completions.create.return_value = response
+        provider._client = openai_client
+        return provider, openai_client
+
+    def test_a_completion_returns_text_latency_and_usage(self):
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content="  hello  "))]
+        response.usage = MagicMock(prompt_tokens=3, completion_tokens=4, total_tokens=7)
+        provider, openai_client = self._client(response)
+        result = provider.complete("m", [{"role": "user", "content": "hi"}], {"temperature": 0})
+        assert result["text"] == "hello" and result["error"] is None
+        assert result["usage"]["total_tokens"] == 7
+        assert result["latency_ms"] >= 0
+        assert openai_client.chat.completions.create.call_args.kwargs["temperature"] == 0
+
+    def test_a_provider_failure_is_a_result_not_an_exception(self):
+        provider, _ = self._client(error=RuntimeError("410 model retired"))
+        result = provider.complete("m", [{"role": "user", "content": "hi"}])
+        assert result["text"] is None
+        assert "410" in result["error"]
+
+
+class TestPostHogClient:
+    def _client(self, payload):
+        client = bm.PostHogEvals("personal-key", "475262")
+        requests = MagicMock()
+        response = MagicMock(content=b"{}")
+        response.json.return_value = payload
+        requests.request.return_value = response
+        return client, requests
+
+    def test_list_evaluations_is_keyed_by_name(self):
+        client, requests = self._client({"results": [{"name": "LEM benchmark — lem-simple",
+                                                      "id": "e1", "enabled": True},
+                                                     {"id": "e2"}]})
+        with patch.dict(sys.modules, {"requests": requests}):
+            assert client.list_evaluations() == {"LEM benchmark — lem-simple":
+                                                 {"id": "e1", "enabled": True}}
+
+    def test_query_posts_hogql_to_the_project_query_endpoint(self):
+        client, requests = self._client({"results": [["c1"]]})
+        with patch.dict(sys.modules, {"requests": requests}):
+            assert client.query("SELECT 1") == [["c1"]]
+        kwargs = requests.request.call_args.kwargs
+        assert kwargs["json"]["query"]["kind"] == "HogQLQuery"
+        assert "/api/projects/475262/query/" in requests.request.call_args.args[1]
+
+    def test_run_evaluation_passes_the_event_id(self):
+        client, requests = self._client({"workflow_id": "w1"})
+        with patch.dict(sys.modules, {"requests": requests}):
+            assert client.run_evaluation("e1", "evt-1") == "w1"
+        assert requests.request.call_args.kwargs["json"] == {"event_id": "evt-1"}
+
+
+class TestEmission:
+    CASE = {"id": "c1", "messages": [{"role": "user", "content": "hi"}]}
+    COMPLETION = {"text": "answer", "latency_ms": 1200.0, "usage": {"prompt_tokens": 5}}
+
+    def test_no_project_key_means_no_event_and_no_id(self, monkeypatch):
+        monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
+        posthog = MagicMock()
+        with patch.dict(sys.modules, {"posthog": posthog}):
+            assert bm.emit_generation("bm-1", "lem-simple", self.CASE, "m", "candidate",
+                                      self.COMPLETION) is None
+        assert posthog.capture.called is False
+
+    def test_a_tagged_generation_carries_the_run_id_and_the_anonymous_distinct_id(self,
+                                                                                  monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+        posthog = MagicMock()
+        with patch.dict(sys.modules, {"posthog": posthog}):
+            event_id = bm.emit_generation("bm-1", "lem-simple", self.CASE, "m", "candidate",
+                                          self.COMPLETION)
+        kwargs = posthog.capture.call_args.kwargs
+        assert kwargs["event"] == "$ai_generation"
+        assert kwargs["distinct_id"] == bm.BENCHMARK_DISTINCT_ID
+        assert kwargs["properties"]["benchmark_run_id"] == "bm-1"
+        assert kwargs["uuid"] == event_id
+
+    def test_an_sdk_that_rejects_a_uuid_leaves_the_generation_unjudgeable(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+        posthog = MagicMock()
+        posthog.capture.side_effect = [TypeError("no uuid kwarg"), None]
+        with patch.dict(sys.modules, {"posthog": posthog}):
+            assert bm.emit_generation("bm-1", "lem-simple", self.CASE, "m", "candidate",
+                                      self.COMPLETION) is None
+        assert posthog.capture.call_count == 2
+
+    def test_an_emission_failure_is_swallowed(self, monkeypatch, capsys):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+        posthog = MagicMock()
+        posthog.capture.side_effect = RuntimeError("network down")
+        with patch.dict(sys.modules, {"posthog": posthog}):
+            assert bm.emit_generation("bm-1", "lem-simple", self.CASE, "m", "candidate",
+                                      self.COMPLETION) is None
+        assert "PostHog emission failed" in capsys.readouterr().err
+
+    def test_fallback_metrics_are_emitted_as_ai_metric(self, monkeypatch):
+        monkeypatch.setenv("POSTHOG_API_KEY", "phc_test")
+        posthog = MagicMock()
+        with patch.dict(sys.modules, {"posthog": posthog}):
+            bm.emit_metric("bm-1", "lem-simple", "c1", "m", {"passes": True})
+        properties = posthog.capture.call_args.kwargs["properties"]
+        assert posthog.capture.call_args.kwargs["event"] == "$ai_metric"
+        assert properties["$ai_metric_value"] is True
+        assert properties["benchmark_run_id"] == "bm-1"
+
+    def test_metric_emission_is_a_no_op_without_a_key(self, monkeypatch):
+        monkeypatch.delenv("POSTHOG_API_KEY", raising=False)
+        posthog = MagicMock()
+        with patch.dict(sys.modules, {"posthog": posthog}):
+            bm.emit_metric("bm-1", "lem-simple", "c1", "m", {"passes": True})
+        assert posthog.capture.called is False
+
+
+class TestEnvGates:
+    def test_benchmark_enabled_is_off_by_default(self, monkeypatch):
+        monkeypatch.delenv("BENCHMARK_ENABLED", raising=False)
+        assert bm.benchmark_enabled() is False
+        monkeypatch.setenv("BENCHMARK_ENABLED", "true")
+        assert bm.benchmark_enabled() is True
+
+    def test_numeric_env_gates_clamp_and_fall_back(self, monkeypatch):
+        monkeypatch.setenv("BENCHMARK_MAX_JUDGE_CALLS", "not-a-number")
+        assert bm.max_judge_calls() == 200
+        monkeypatch.setenv("BENCHMARK_MAX_JUDGE_CALLS", "999999")
+        assert bm.max_judge_calls() == 5000
+        monkeypatch.setenv("BENCHMARK_JUDGE_TIMEOUT_SECONDS", "1")
+        assert bm.judge_timeout_seconds() == 5  # floored, never an instant give-up
+
+
+# ─────────────────────────── champions from the config ───────────────────────────
+
+CONFIG = """
+model_list:
+  - model_name: lem-simple
+    litellm_params:
+      model: openai/gpt-oss:20b
+      api_base: os.environ/OLLAMA_CLOUD_URL
+  - model_name: lem-simple
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+  - model_name: lem-medium
+    litellm_params:
+      model: openai/gpt-oss:120b
+      api_base: os.environ/OLLAMA_CLOUD_URL
+  - model_name: lem-image
+    litellm_params:
+      model: openai/dall-e-3
+      api_key: os.environ/OPENAI_API_KEY
+"""
+
+
+class TestChampions:
+    def test_first_ollama_deployment_per_tier_wins(self):
+        champions = bm.champions_from_config(CONFIG, ["lem-simple", "lem-medium", "lem-complex"])
+        assert champions == {"lem-simple": "gpt-oss:20b", "lem-medium": "gpt-oss:120b"}
+
+    def test_the_live_config_still_names_a_champion_for_every_tier(self):
+        text = (_ROOT / ".litellm" / "config.yaml").read_text()
+        champions = bm.champions_from_config(text, list(bm.TIERS))
+        assert set(champions) == set(bm.TIERS)
+
+    def test_champion_overrides_parse_and_validate(self):
+        assert bm.parse_champion_overrides("lem-simple=a,lem-medium=b") == {
+            "lem-simple": "a", "lem-medium": "b"}
+        assert bm.parse_champion_overrides("") == {}
+        with pytest.raises(SystemExit):
+            bm.parse_champion_overrides("lem-simple")
+
+
+# ──────────────────────────────── orchestration ──────────────────────────────────
+
+class TestRunBenchmark:
+    def _suites(self):
+        return {"lem-simple": _suite("lem-simple", cases=[
+            _case("a", assertions=[{"type": "max_chars", "value": 50}],
+                  canned={"output": "short answer", "judge_pass": True, "latency_ms": 100}),
+            _case("b", assertions=[{"type": "max_chars", "value": 5}],
+                  canned={"output": "far too long to fit", "judge_pass": False}),
+        ], thresholds={"min_judged": 1})}
+
+    def test_dry_run_scores_canned_outputs_with_no_network(self):
+        run = bm.run_benchmark(self._suites(), ["cand"], {"lem-simple": "champ"},
+                               run_id="bm-1", today="2026-07-27", provider=None, evals=None,
+                               judge_cap=10, dry_run=True)
+        assert run["scoring_mode"] == bm.SCORING_DRY_RUN
+        assert {c["model"] for c in run["scorecards"]} == {"champ", "cand"}
+        for card in run["scorecards"]:
+            assert card["deterministic_pass_rate"] == 0.5
+            assert card["judged"] == 1  # only the passing case is judged
+            assert card["benchmark_run_id"] == "bm-1"
+        assert bm.render_report(run)
+
+    def test_a_run_with_no_candidates_is_a_champion_baseline(self):
+        run = bm.run_benchmark(self._suites(), [], {"lem-simple": "champ"},
+                               run_id="bm-1", today="2026-07-27", dry_run=True, judge_cap=10)
+        assert [c["role"] for c in run["scorecards"]] == ["champion"]
+        assert run["gates"] == [] and run["recommendations"] == []
+
+    def test_provider_errors_land_on_the_case_and_block_the_gate(self):
+        provider = MagicMock()
+        provider.complete.return_value = {"text": None, "error": "410 model retired",
+                                          "latency_ms": 5.0, "usage": {}}
+        run = bm.run_benchmark(self._suites(), ["cand"], {"lem-simple": "champ"},
+                               run_id="bm-1", today="2026-07-27", provider=provider,
+                               judge_cap=10)
+        card = next(c for c in run["scorecards"] if c["role"] == "candidate")
+        assert card["errors"] == ["a", "b"]
+        assert run["gates"][0]["verdict"] == bm.VERDICT_REJECT
+        assert run["recommendations"] == []
+
+    def test_no_judge_mode_spends_nothing_and_reports_deterministic_only(self):
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "short", "error": None,
+                                          "latency_ms": 5.0, "usage": {}}
+        run = bm.run_benchmark(self._suites(), ["cand"], {"lem-simple": "champ"},
+                               run_id="bm-1", today="2026-07-27", provider=provider,
+                               judge_cap=10, judge_enabled=False)
+        assert run["scoring_mode"] == bm.SCORING_DETERMINISTIC
+        assert run["judge_calls"] == 0
+        assert run["gates"][0]["verdict"] == bm.VERDICT_DETERMINISTIC_ONLY
+
+    def test_the_judge_cap_bounds_the_whole_run(self):
+        run = bm.run_benchmark(self._suites(), ["cand"], {"lem-simple": "champ"},
+                               run_id="bm-1", today="2026-07-27", dry_run=True, judge_cap=1)
+        assert run["judge_calls"] == 1
+        assert sum(c["judged"] for c in run["scorecards"]) == 1
+
+    def test_unavailable_posthog_evaluations_degrade_to_the_fallback_judge(self):
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "short answer", "error": None,
+                                          "latency_ms": 5.0, "usage": {}}
+        evals = MagicMock()
+        evals.list_evaluations.side_effect = RuntimeError("401 no key")
+        with patch.object(bm, "fallback_judge",
+                          return_value={"passes": True, "status": "scored", "reasoning": ""}) as fj:
+            with patch.object(bm, "emit_metric") as metric:
+                run = bm.run_benchmark(self._suites(), [], {"lem-simple": "champ"},
+                                       run_id="bm-1", today="2026-07-27", provider=provider,
+                                       evals=evals, judge_cap=10)
+        assert run["scoring_mode"] == bm.SCORING_FALLBACK
+        assert fj.called and metric.called
+
+    def test_posthog_verdicts_that_never_land_are_reported_as_timeouts(self):
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "short answer", "error": None,
+                                          "latency_ms": 5.0, "usage": {}}
+        evals = MagicMock()
+        evals.list_evaluations.return_value = {}
+        evals.create_evaluation.return_value = "e1"
+        evals.query.return_value = []
+        # The polling deadline itself is covered in TestPostHogEvals with an injected sleep; here
+        # the point is what an EMPTY result set does to the scorecard.
+        with patch.object(bm, "emit_generation", return_value="evt-1"), \
+                patch.object(bm, "poll_judge_results", return_value=[]):
+            run = bm.run_benchmark(self._suites(), [], {"lem-simple": "champ"},
+                                   run_id="bm-1", today="2026-07-27", provider=provider,
+                                   evals=evals, judge_cap=10)
+        card = run["scorecards"][0]
+        assert run["scoring_mode"] == bm.SCORING_POSTHOG
+        assert card["judge_timeouts"] == 1 and card["judge_pass_rate"] is None
+        assert run["gates"] == []
+
+    def test_posthog_verdicts_are_merged_back_onto_the_right_scorecard(self):
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "short answer", "error": None,
+                                          "latency_ms": 5.0, "usage": {}}
+        evals = MagicMock()
+        evals.list_evaluations.return_value = {bm.evaluation_name("lem-simple"): {"id": "e1"}}
+        evals.query.return_value = [["a", "lem-simple", "champ", True, "grounded"]]
+        with patch.object(bm, "emit_generation", return_value="evt-1"):
+            run = bm.run_benchmark(self._suites(), [], {"lem-simple": "champ"},
+                                   run_id="bm-1", today="2026-07-27", provider=provider,
+                                   evals=evals, judge_cap=10)
+        card = run["scorecards"][0]
+        assert card["judged"] == 1 and card["judge_pass_rate"] == 1.0
+        assert evals.create_evaluation.called is False
+
+
+# ─────────────────────────────────── the CLI ─────────────────────────────────────
+
+class TestCLI:
+    def test_print_suites_validates_the_shipped_fixtures(self, capsys):
+        assert bm.main(["--print-suites", "--suite-dir", str(SUITE_DIR)]) == 0
+        out = capsys.readouterr().out
+        for tier in bm.TIERS:
+            assert tier in out
+
+    def test_dry_run_writes_a_report_and_the_leaderboard(self, tmp_path):
+        code = bm.main(["--dry-run", "--models", "cand", "--suite-dir", str(SUITE_DIR),
+                        "--out-dir", str(tmp_path), "--run-id", "bm-t", "--today", "2026-07-27",
+                        "--champions", "lem-simple=champ", "--max-judge-calls", "5"])
+        assert code in (0, 2)
+        assert (tmp_path / "2026-07-27-bm-t.md").exists()
+        assert bm.LEADERBOARD_BEGIN in (tmp_path / "README.md").read_text()
+
+    def test_a_real_run_is_refused_while_the_feature_gate_is_off(self, monkeypatch, capsys):
+        monkeypatch.delenv("BENCHMARK_ENABLED", raising=False)
+        assert bm.main(["--run", "--suite-dir", str(SUITE_DIR)]) == 0
+        assert "BENCHMARK_ENABLED" in capsys.readouterr().out
+
+    def test_a_real_run_without_provider_credentials_exits_1(self, monkeypatch):
+        monkeypatch.setenv("BENCHMARK_ENABLED", "true")
+        monkeypatch.delenv("OLLAMA_CLOUD_URL", raising=False)
+        monkeypatch.delenv("OLLAMA_CLOUD_API_KEY", raising=False)
+        assert bm.main(["--run", "--suite-dir", str(SUITE_DIR)]) == 1
+
+    @pytest.mark.parametrize("env,expect_evals", [
+        ({"POSTHOG_PERSONAL_API_KEY": "phx", "POSTHOG_API_KEY": "phc"}, True),
+        ({"POSTHOG_PERSONAL_API_KEY": "phx"}, False),   # nothing emitted -> nothing to score
+        ({"POSTHOG_API_KEY": "phc"}, False),            # no eval API access
+        ({}, False),
+    ])
+    def test_posthog_evaluations_need_both_keys_or_the_fallback_judge_runs(
+            self, monkeypatch, tmp_path, env, expect_evals):
+        monkeypatch.setenv("BENCHMARK_ENABLED", "true")
+        monkeypatch.setenv("OLLAMA_CLOUD_URL", "https://ollama.example")
+        monkeypatch.setenv("OLLAMA_CLOUD_API_KEY", "key")
+        for name in ("POSTHOG_PERSONAL_API_KEY", "POSTHOG_API_KEY"):
+            monkeypatch.delenv(name, raising=False)
+        for name, value in env.items():
+            monkeypatch.setenv(name, value)
+        with patch.object(bm, "run_benchmark") as run_benchmark:
+            run_benchmark.return_value = {"recommendations": [], "run_id": "x"}
+            with patch.object(bm, "write_report", return_value="p"):
+                bm.main(["--run", "--suite-dir", str(SUITE_DIR), "--tiers", "lem-simple",
+                         "--out-dir", str(tmp_path)])
+        assert (run_benchmark.call_args.kwargs["evals"] is not None) is expect_evals
+
+    def test_render_reproduces_a_saved_run_without_network(self, tmp_path):
+        results = tmp_path / "run.json"
+        bm.main(["--dry-run", "--suite-dir", str(SUITE_DIR), "--out-dir", str(tmp_path / "a"),
+                 "--run-id", "bm-r", "--today", "2026-07-27", "--champions", "lem-simple=champ",
+                 "--results-out", str(results), "--max-judge-calls", "3"])
+        out = tmp_path / "b"
+        assert bm.main(["--render", str(results), "--out-dir", str(out)]) in (0, 2)
+        assert (out / "2026-07-27-bm-r.md").exists()
+
+    def test_render_refuses_a_tainted_results_file(self, tmp_path):
+        results = tmp_path / "bad.json"
+        results.write_text(json.dumps({"source": "production", "run_id": "x", "date": "d",
+                                       "scorecards": []}))
+        assert bm.main(["--render", str(results), "--out-dir", str(tmp_path)]) == 1
+
+    def test_recommendations_are_written_separately_for_the_cron(self, tmp_path):
+        recs = tmp_path / "recs.json"
+        bm.main(["--dry-run", "--models", "cand", "--suite-dir", str(SUITE_DIR),
+                 "--out-dir", str(tmp_path), "--run-id", "bm-c", "--today", "2026-07-27",
+                 "--recommendations-out", str(recs), "--max-judge-calls", "300"])
+        assert isinstance(json.loads(recs.read_text()), list)
+
+    def test_a_bad_suite_directory_exits_1(self, tmp_path, capsys):
+        assert bm.main(["--print-suites", "--suite-dir", str(tmp_path)]) == 1
+        assert "suite error" in capsys.readouterr().err

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -449,6 +449,22 @@ class TestRendering:
         assert body.index("bm-2") < body.index("bm-1")
         assert merged.count("| lem-simple |") == 4
 
+    def test_repeated_renders_never_grow_the_table_with_its_own_header(self):
+        """The header and divider are pipe-delimited rows of the right width. Reading them back as
+        DATA appended two junk rows per run and evicted real history at the row cap."""
+        text = (_ROOT / "docs" / "model-benchmarks" / "README.md").read_text()
+        for run_id in ("bm-1", "bm-2", "bm-3"):
+            run = self._run()
+            run["run_id"] = run_id
+            for card in run["scorecards"]:
+                card["benchmark_run_id"] = run_id
+            text = bm.update_leaderboard(text, bm.leaderboard_rows(run))
+        inner = text.split(bm.LEADERBOARD_BEGIN)[1].split(bm.LEADERBOARD_END)[0]
+        rows = [line for line in inner.splitlines() if line.strip().startswith("|")]
+        assert rows[0] == bm.LEADERBOARD_HEADER and rows[1] == bm.LEADERBOARD_DIVIDER
+        assert len(rows) == 2 + 6  # three runs × two scorecards, and nothing else
+        assert bm.LEADERBOARD_HEADER not in rows[2:]
+
     def test_the_committed_leaderboard_has_the_markers(self):
         text = (_ROOT / "docs" / "model-benchmarks" / "README.md").read_text()
         assert bm.LEADERBOARD_BEGIN in text and bm.LEADERBOARD_END in text
@@ -500,7 +516,8 @@ class TestJudge:
         with patch.dict(sys.modules, {}):
             with patch("builtins.__import__", side_effect=ImportError("no client")):
                 verdict = bm.fallback_judge(_suite(), _case(), "out")
-        assert verdict["passes"] is None and verdict["status"] == bm.JUDGE_TIMEOUT
+        # Unscored either way, but distinctly "unreachable" so the runner stops re-asking.
+        assert verdict["passes"] is None and verdict["status"] == bm.JUDGE_UNAVAILABLE
 
 
 # ───────────────────── PostHog evaluation specs + retrieval ──────────────────────
@@ -833,9 +850,13 @@ class TestRunBenchmark:
         evals.create_evaluation.return_value = "e1"
         evals.query.return_value = []
         # The polling deadline itself is covered in TestPostHogEvals with an injected sleep; here
-        # the point is what an EMPTY result set does to the scorecard.
+        # the point is what an EMPTY result set does to the scorecard when the in-runner judge is
+        # unavailable too — unscored, never inferred.
         with patch.object(bm, "emit_generation", return_value="evt-1"), \
-                patch.object(bm, "poll_judge_results", return_value=[]):
+                patch.object(bm, "poll_judge_results", return_value=[]), \
+                patch.object(bm, "fallback_judge",
+                             return_value={"passes": None, "status": bm.JUDGE_TIMEOUT,
+                                           "reasoning": "no judge"}):
             run = bm.run_benchmark(self._suites(), [], {"lem-simple": "champ"},
                                    run_id="bm-1", today="2026-07-27", provider=provider,
                                    evals=evals, judge_cap=10)
@@ -843,6 +864,93 @@ class TestRunBenchmark:
         assert run["scoring_mode"] == bm.SCORING_POSTHOG
         assert card["judge_timeouts"] == 1 and card["judge_pass_rate"] is None
         assert run["gates"] == []
+
+    def test_a_partial_posthog_read_keeps_the_unscored_cases_as_timeouts(self):
+        """Rebuilding a card from the returned rows alone used to DROP the cases PostHog never
+        scored, rendering 1-of-3 verdicts as a 100% judge pass on full evidence."""
+        suites = {"lem-simple": _suite("lem-simple", cases=[
+            _case(cid, assertions=[{"type": "max_chars", "value": 50}]) for cid in ("a", "b", "c")],
+            thresholds={"min_judged": 1})}
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "short", "error": None,
+                                          "latency_ms": 5.0, "usage": {}}
+        evals = MagicMock()
+        evals.list_evaluations.return_value = {bm.evaluation_name("lem-simple"): {"id": "e1"}}
+        with patch.object(bm, "emit_generation", return_value="evt-1"), \
+                patch.object(bm, "poll_judge_results",
+                             return_value=[["a", "lem-simple", "champ", True, "ok"]]), \
+                patch.object(bm, "fallback_judge",
+                             return_value={"passes": None, "status": bm.JUDGE_TIMEOUT,
+                                           "reasoning": "no judge"}):
+            run = bm.run_benchmark(suites, [], {"lem-simple": "champ"}, run_id="bm-1",
+                                   today="2026-07-27", provider=provider, evals=evals,
+                                   judge_cap=10)
+        card = run["scorecards"][0]
+        assert card["judged"] == 1 and card["judge_passed"] == 1
+        assert card["judge_timeouts"] == 2
+
+    def test_a_posthog_run_that_scores_nothing_falls_back_to_the_in_runner_judge(self):
+        """PostHog's judge needs a provider key of its own (it cannot judge via Ollama Cloud). With
+        none configured the evaluations exist but score nothing, so the run degrades rather than
+        reporting evidence the gate can only read as absent."""
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "short answer", "error": None,
+                                          "latency_ms": 5.0, "usage": {}}
+        evals = MagicMock()
+        evals.list_evaluations.return_value = {bm.evaluation_name("lem-simple"): {"id": "e1"}}
+        with patch.object(bm, "emit_generation", return_value="evt-1"), \
+                patch.object(bm, "poll_judge_results", return_value=[]), \
+                patch.object(bm, "emit_metric") as metric, \
+                patch.object(bm, "fallback_judge",
+                             return_value={"passes": True, "status": "scored",
+                                           "reasoning": "grounded"}) as fj:
+            run = bm.run_benchmark(self._suites(), [], {"lem-simple": "champ"},
+                                   run_id="bm-1", today="2026-07-27", provider=provider,
+                                   evals=evals, judge_cap=10)
+        card = run["scorecards"][0]
+        assert fj.called and metric.called
+        assert run["scoring_mode"] == bm.SCORING_FALLBACK
+        assert card["judged"] == 1 and card["judge_pass_rate"] == 1.0
+
+    def test_the_fallback_after_a_dead_posthog_judge_stays_inside_the_cap(self):
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "short", "error": None,
+                                          "latency_ms": 5.0, "usage": {}}
+        evals = MagicMock()
+        evals.list_evaluations.return_value = {bm.evaluation_name("lem-simple"): {"id": "e1"}}
+        with patch.object(bm, "emit_generation", return_value="evt-1"), \
+                patch.object(bm, "poll_judge_results", return_value=[]), \
+                patch.object(bm, "emit_metric"), \
+                patch.object(bm, "fallback_judge",
+                             return_value={"passes": True, "status": "scored",
+                                           "reasoning": ""}) as fj:
+            run = bm.run_benchmark(self._suites(), [], {"lem-simple": "champ"},
+                                   run_id="bm-1", today="2026-07-27", provider=provider,
+                                   evals=evals, judge_cap=1)
+        assert fj.call_count == 0  # the single PostHog trigger already spent the cap
+        assert run["judge_calls"] == 1
+
+    def test_an_unreachable_in_runner_judge_is_asked_once_not_once_per_case(self):
+        suites = {"lem-simple": _suite("lem-simple", cases=[
+            _case(cid, assertions=[{"type": "max_chars", "value": 50}]) for cid in ("a", "b", "c")],
+            thresholds={"min_judged": 1})}
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "short", "error": None,
+                                          "latency_ms": 5.0, "usage": {}}
+        with patch.object(bm, "fallback_judge",
+                          return_value={"passes": None, "status": bm.JUDGE_UNAVAILABLE,
+                                        "reasoning": "connection refused"}) as fj:
+            run = bm.run_benchmark(suites, [], {"lem-simple": "champ"}, run_id="bm-1",
+                                   today="2026-07-27", provider=provider, evals=None,
+                                   judge_cap=10)
+        assert fj.call_count == 1
+        assert run["scorecards"][0]["judge_timeouts"] == 3
+
+    def test_a_candidate_that_already_serves_the_tier_is_never_self_compared(self):
+        run = bm.run_benchmark(self._suites(), ["champ"], {"lem-simple": "champ"},
+                               run_id="bm-1", today="2026-07-27", dry_run=True, judge_cap=10)
+        assert [c["role"] for c in run["scorecards"]] == ["champion"]
+        assert run["gates"] == [] and run["recommendations"] == []
 
     def test_posthog_verdicts_are_merged_back_onto_the_right_scorecard(self):
         provider = MagicMock()


### PR DESCRIPTION
## What & why

`scripts/model_health_check.py` (#716) detects that a model is about to **change** — an advance retirement, a new Ollama Cloud tag, a family we trail. It cannot say whether a candidate is any **good**, so #717's roster refresh was decided largely on spec sheets. This adds the measurement half.

Each LiteLLM tier becomes a **contract** encoded as a fixed suite of synthetic prompts (`tests/benchmarks/model_tiers/<tier>.json`, 10 cases per tier, drawn from LEM's real prompt shapes with synthetic inputs). Every cron-detected candidate runs it **beside the tier's current champion**, so a verdict is always a comparison rather than an absolute claim about one model.

### Scoring — two layers, in this order

1. **Deterministic** (free, the source of truth). Reuses the in-repo linters rather than duplicating them: `slop_lint.lint_report`, `content_framework.comment_contract_report` (the #617 contract), and `routing_policy.complexity_tier` for the `lem-router` contract — plus length/shape/JSON/burstiness/self-similarity assertions. A case that fails HARD here never spends a judge call.
2. **LLM judge** (paid, capped). PostHog Evaluations scoring the harness's own tagged `$ai_generation` events — emitted independently of #647's prod callback, because the harness calls Ollama Cloud **directly** (a candidate that isn't in the config has no tier alias to be reached by). The evaluation's `conditions` filter on `benchmark_run_id`, a property production traffic never carries, so an enabled evaluation can never bill a judge call against customer traffic.

Degradations are all explicit and tested: no judge-provider key (PostHog does not judge via Ollama Cloud) → in-runner `lem-medium` judge emitting `$ai_metric`; verdicts that never land → `judge:timeout`, excluded from the denominator and **never** a fabricated score; `slop_lint` disabled for a surface → the assertion is *unscored*, not passed. The report names the scoring mode it ran in.

### Gate

Only a full `recommend` verdict — clears the tier's absolute floors **and** meets-or-beats the champion on every graded expectation — becomes a swap recommendation. `recommend-deterministic-only` (judge evidence missing on one side), `no-baseline` and `reject` are reported and go no further.

### One deliberate deviation from the issue's scope list

The issue offers *"append to `.litellm/model_upgrades.yaml` / a #717-style PR"*. This ships the second: the gate **renders** the exact mapping lines but never writes them. That map is the RETIREMENT map, and `model_health_check.py`'s reactive half auto-swaps whatever lands in it into the live LiteLLM config on the next cron — so an auto-append would turn "the benchmark liked it" into an unattended production swap. It is also what the existing #716 upgrade issue tells a human in words ("do NOT add it to `model_upgrades.yaml`"). The machine-readable recommendations are still emitted (`--recommendations-out`) for anything downstream that wants them.

## Files

- `scripts/benchmark_models.py` — pure core (suite loading + validation, assertion evaluation, scorecard merge, gate, report/leaderboard rendering, judge planning/parsing, PostHog eval specs) over a thin I/O layer (`ProviderClient`, `PostHogEvals`, emission, polling).
- `tests/benchmarks/model_tiers/{lem-simple,lem-medium,lem-complex,lem-router}.json` — 40 cases, synthetic only, each carrying a committed canned answer so `--dry-run` renders a full report with **zero** network calls.
- `docs/model-benchmarks/README.md` — posture + the rolling leaderboard (marker-delimited, idempotent on re-render).
- `scripts/weekly_model_check.sh` — invokes the runner for the candidates the #716 catalog scan already found (same plan the issues were filed from), opens the report PR through the existing ephemeral-worktree `open_pr` flow, and alerts on recommendations. Bounded by `BENCHMARK_MAX_CANDIDATES` with the truncation **logged**. Runner failure alerts but never blocks the retirement-swap safety path above it.
- `.env.example`, `CLAUDE.md` — env gates and the subsystem note.

## No production data leakage

`render_report` calls `assert_benchmark_only` first: the run must carry `source: benchmark`, every scorecard must be tagged with that run's `run_id`, and no record may carry a person. It raises — there is no permissive mode — and `write_report` therefore never touches disk for a tainted run. Tests cover all four refusals plus a fixture scan for credential/PII shapes.

## Testing notes

- `poetry run pytest tests/unit/test_benchmark_models.py` — **108 tests**, `scripts/benchmark_models.py` at **95%** coverage; all LiteLLM/PostHog/provider I/O mocked.
- Full suite green: `poetry run pytest tests/unit -q` → 7767 passed.
- Covered per the acceptance criteria: case parsing/validation, every deterministic assertion (pass + fail + unscored), scorecard merge, gate beats/ties/regressions/no-baseline/thin-evidence, report + leaderboard rendering and idempotent re-render, judge timeout and no-provider-key fallbacks, and the provenance refusal.
- Offline proof, no network: `poetry run python scripts/benchmark_models.py --dry-run --models qwen3.6:400b --out-dir /tmp/bm` renders the full scorecard, per-expectation detail, gate verdicts and the mapping block.
- A test asserts the committed canned answers still satisfy their own assertions, so a fixture that drifts from its contract fails the build rather than making every dry run look broken.

Closes #721

🤖 Generated with [Claude Code](https://claude.com/claude-code)
