### PR TITLE
fix(ui): let comma-separated settings fields accept commas and spaces (closes #638)

### DIFF
--- a/src/cqc_lem/ui/src/pages/account/settings/CsvInput.test.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/CsvInput.test.tsx
@@ -1,0 +1,84 @@
+import { useState } from 'react'
+import { describe, expect, it, afterEach, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import CsvInput from './CsvInput'
+
+afterEach(cleanup)
+
+// The real wiring: the parsed array is state OWNED BY THE PARENT and handed straight back down,
+// which is what used to erase the separator on every keystroke (issue #638).
+function Harness({ initial = [], onChange }: { initial?: string[]; onChange?: (v: string[]) => void }) {
+  const [values, setValues] = useState<string[]>(initial)
+  return (
+    <>
+      <CsvInput
+        aria-label="topics"
+        value={values}
+        onChange={(v) => {
+          setValues(v)
+          onChange?.(v)
+        }}
+      />
+      <span data-testid="parsed">{JSON.stringify(values)}</span>
+    </>
+  )
+}
+
+const box = () => screen.getByLabelText('topics') as HTMLInputElement
+
+describe('CsvInput', () => {
+  it('lets a comma be typed instead of collapsing it back to the previous entry', () => {
+    render(<Harness />)
+    fireEvent.change(box(), { target: { value: 'ai' } })
+    fireEvent.change(box(), { target: { value: 'ai,' } })
+    expect(box().value).toBe('ai,')
+  })
+
+  it('keeps the space after a comma while the next entry is being typed', () => {
+    render(<Harness initial={['ai']} />)
+    fireEvent.change(box(), { target: { value: 'ai, ' } })
+    expect(box().value).toBe('ai, ')
+    fireEvent.change(box(), { target: { value: 'ai, sales' } })
+    expect(box().value).toBe('ai, sales')
+    expect(screen.getByTestId('parsed').textContent).toBe('["ai","sales"]')
+  })
+
+  it('publishes trimmed values with the empties dropped', () => {
+    const onChange = vi.fn()
+    render(<Harness onChange={onChange} />)
+    fireEvent.change(box(), { target: { value: ' ai ,, sales ' } })
+    expect(onChange).toHaveBeenLastCalledWith(['ai', 'sales'])
+  })
+
+  it('renders the saved list as comma-separated text', () => {
+    render(<Harness initial={['ai', 'sales']} />)
+    expect(box().value).toBe('ai, sales')
+  })
+
+  it('tidies the text on blur once the user is done typing', () => {
+    render(<Harness />)
+    fireEvent.change(box(), { target: { value: 'ai,, sales ,' } })
+    fireEvent.blur(box())
+    expect(box().value).toBe('ai, sales')
+  })
+
+  it('adopts a value changed from outside (preferences loading, a one-click fix)', () => {
+    function External() {
+      const [values, setValues] = useState<string[]>(['ai'])
+      return (
+        <>
+          <CsvInput aria-label="topics" value={values} onChange={setValues} />
+          <button onClick={() => setValues(['leadership', 'hiring'])}>replace</button>
+        </>
+      )
+    }
+    render(<External />)
+    fireEvent.click(screen.getByRole('button', { name: 'replace' }))
+    expect(box().value).toBe('leadership, hiring')
+  })
+
+  it('starts empty for an unset list rather than rendering null', () => {
+    render(<CsvInput aria-label="topics" value={null} onChange={() => {}} />)
+    expect(box().value).toBe('')
+  })
+})

--- a/src/cqc_lem/ui/src/pages/account/settings/CsvInput.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/CsvInput.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState, type InputHTMLAttributes } from 'react'
+import { csv, parseCsv } from '../types'
+import { inputClass } from './Field'
+
+type Props = {
+  value: string[] | undefined | null
+  onChange: (values: string[]) => void
+} & Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'onChange' | 'type'>
+
+/**
+ * A comma-separated list box you can actually type a comma into. Binding the input straight to
+ * `csv(list)` round-tripped every keystroke through `parseCsv`, which trims and drops empty
+ * entries — so "ai," and "ai, " both collapsed back to "ai" before the next character landed and
+ * the separator could never be entered (issue #638). The raw text lives here; only the parsed
+ * array is published upward, and the value is tidied on blur.
+ */
+export default function CsvInput({ value, onChange, className = inputClass, ...rest }: Props) {
+  const incoming = csv(value)
+  const [text, setText] = useState(incoming)
+  // The canonical form of what WE last published. A prop equal to it is our own edit coming back
+  // around, and overwriting the box with it is exactly what ate the comma.
+  const echoed = useRef(incoming)
+
+  useEffect(() => {
+    if (incoming === echoed.current) return
+    echoed.current = incoming
+    setText(incoming)
+  }, [incoming])
+
+  const publish = (next: string) => {
+    setText(next)
+    const parsed = parseCsv(next)
+    echoed.current = csv(parsed)
+    onChange(parsed)
+  }
+
+  return (
+    <input
+      type="text"
+      value={text}
+      className={className}
+      onChange={(e) => publish(e.target.value)}
+      onBlur={() => setText(echoed.current)}
+      {...rest}
+    />
+  )
+}

--- a/src/cqc_lem/ui/src/pages/account/settings/CsvInput.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/CsvInput.tsx
@@ -35,13 +35,15 @@ export default function CsvInput({ value, onChange, className = inputClass, ...r
   }
 
   return (
+    // `rest` is spread FIRST so a caller's stray onBlur can't silently replace the tidy handler
+    // and put the box back to the round-tripping behaviour this component exists to stop.
     <input
+      {...rest}
       type="text"
       value={text}
       className={className}
       onChange={(e) => publish(e.target.value)}
       onBlur={() => setText(echoed.current)}
-      {...rest}
     />
   )
 }

--- a/src/cqc_lem/ui/src/pages/account/settings/OutreachSection.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/OutreachSection.tsx
@@ -1,4 +1,5 @@
-import { csv, parseCsv, CATCHUP_EVENTS } from '../types'
+import { CATCHUP_EVENTS } from '../types'
+import CsvInput from './CsvInput'
 import { useEngagementPrefs } from './EngagementPrefsContext'
 import { Advanced, Field, SectionCard, inputClass } from './Field'
 
@@ -30,10 +31,9 @@ export default function OutreachSection() {
           </Field>
         </div>
         <Field settingKey="connection_target_authors">
-          <input type="text" value={csv(eng.connection_target_authors)}
-            onChange={(e) => setEng({ connection_target_authors: parseCsv(e.target.value) })}
-            placeholder="https://www.linkedin.com/in/their-slug, https://www.linkedin.com/in/another"
-            className={inputClass} />
+          <CsvInput value={eng.connection_target_authors}
+            onChange={(values) => setEng({ connection_target_authors: values })}
+            placeholder="https://www.linkedin.com/in/their-slug, https://www.linkedin.com/in/another" />
         </Field>
         <Advanced>
           <Field settingKey="min_connection_icp_score">

--- a/src/cqc_lem/ui/src/pages/account/settings/TargetingSection.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/TargetingSection.tsx
@@ -1,6 +1,6 @@
 import Toggle from '../../../components/Toggle'
-import { csv, parseCsv } from '../types'
 import type { EngPrefs } from '../types'
+import CsvInput from './CsvInput'
 import { useEngagementPrefs } from './EngagementPrefsContext'
 import { Field, SectionCard, inputClass } from './Field'
 
@@ -62,9 +62,9 @@ export default function TargetingSection() {
       <FeedReachFunnel />
       {FILTERS.map(([field, key]) => (
         <Field key={key} settingKey={key}>
-          <input type="text" value={csv(eng[field] as string[])}
-            onChange={(e) => setEng({ [field]: parseCsv(e.target.value) } as Partial<EngPrefs>)}
-            placeholder="comma, separated, values" className={inputClass} />
+          <CsvInput value={eng[field] as string[]}
+            onChange={(values) => setEng({ [field]: values } as Partial<EngPrefs>)}
+            placeholder="comma, separated, values" />
         </Field>
       ))}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/src/cqc_lem/ui/src/pages/account/settings/VoiceSection.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/VoiceSection.tsx
@@ -1,6 +1,6 @@
 import Toggle from '../../../components/Toggle'
-import { csv, parseCsv } from '../types'
 import { FIELD_LIMITS } from '../fieldLimits'
+import CsvInput from './CsvInput'
 import { useEngagementPrefs } from './EngagementPrefsContext'
 import { useUserPrefs } from './UserPrefsContext'
 import { Field, SectionCard, inputClass } from './Field'
@@ -64,9 +64,9 @@ export default function VoiceSection() {
         blurb="These steer the ANGLE of your content and keep it aligned to your goals. They never override the subject of the post being engaged with, and LEM never promotes internal tools."
       >
         <Field settingKey="focus_topics">
-          <input type="text" value={csv(eng.focus_topics)}
-            onChange={(e) => setEng({ focus_topics: parseCsv(e.target.value) })}
-            placeholder="e.g. B2B sales, leadership, AI adoption" className={inputClass} />
+          <CsvInput value={eng.focus_topics}
+            onChange={(values) => setEng({ focus_topics: values })}
+            placeholder="e.g. B2B sales, leadership, AI adoption" />
         </Field>
         <Field settingKey="business_goals">
           <textarea value={eng.business_goals || ''} rows={2} maxLength={FIELD_LIMITS.goals}

--- a/src/cqc_lem/ui/src/pages/account/settings/csvFields.test.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/csvFields.test.tsx
@@ -1,0 +1,95 @@
+import { StrictMode, useEffect, useState, type ComponentType } from 'react'
+import { describe, expect, it, afterEach, vi } from 'vitest'
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import type { EngPrefs } from '../types'
+import OutreachSection from './OutreachSection'
+import TargetingSection from './TargetingSection'
+import VoiceSection from './VoiceSection'
+
+// CsvInput.test.tsx proves the component; this proves the WIRING. Issue #638 was reported against
+// the real settings boxes, and a harness of our own making can't catch a section that goes back to
+// binding an <input> straight to csv()/parseCsv().
+let eng: Partial<EngPrefs> = {}
+const subscribers = new Set<() => void>()
+
+vi.mock('./EngagementPrefsContext', () => ({
+  useEngagementPrefs: () => {
+    const [, rerender] = useState(0)
+    useEffect(() => {
+      const sub = () => rerender((n) => n + 1)
+      subscribers.add(sub)
+      return () => { subscribers.delete(sub) }
+    }, [])
+    return {
+      eng,
+      setEng: (patch: Partial<EngPrefs>) => {
+        eng = { ...eng, ...patch }
+        subscribers.forEach((sub) => sub())
+      },
+      catchupAllowed: 5,
+    }
+  },
+}))
+
+vi.mock('./ConflictsContext', () => ({
+  useConflicts: () => ({ findings: [], alertCounts: {}, applyFix: () => {} }),
+}))
+
+vi.mock('./UserPrefsContext', () => ({
+  useUserPrefs: () => ({ prefs: null, setPrefs: () => {}, effectiveLanguage: null }),
+}))
+
+afterEach(() => { cleanup(); eng = {} })
+
+const box = (settingKey: string) =>
+  within(screen.getByTestId(`field-${settingKey}`)).getByRole('textbox') as HTMLInputElement
+
+// Every list setting the report covered, and the section that renders it.
+const CSV_FIELDS: [string, ComponentType][] = [
+  ['include_topics', TargetingSection],
+  ['exclude_topics', TargetingSection],
+  ['include_keywords', TargetingSection],
+  ['exclude_keywords', TargetingSection],
+  ['include_authors', TargetingSection],
+  ['exclude_authors', TargetingSection],
+  ['focus_topics', VoiceSection],
+  ['connection_target_authors', OutreachSection],
+]
+
+describe('comma-separated settings fields', () => {
+  it.each(CSV_FIELDS)('lets a comma and the space after it be typed into %s', (key, Section) => {
+    render(<Section />)
+    for (const keystroke of ['a', 'ai', 'ai,', 'ai, ', 'ai, s', 'ai, sales']) {
+      fireEvent.change(box(key), { target: { value: keystroke } })
+      expect(box(key).value).toBe(keystroke)
+    }
+    expect(eng[key as keyof EngPrefs]).toEqual(['ai', 'sales'])
+  })
+
+  it('renders a saved list and leaves the other filters alone while one is edited', () => {
+    eng = { include_topics: ['ai', 'sales'] }
+    render(<TargetingSection />)
+    expect(box('include_topics').value).toBe('ai, sales')
+    fireEvent.change(box('exclude_topics'), { target: { value: 'crypto,' } })
+    expect(box('exclude_topics').value).toBe('crypto,')
+    expect(box('include_topics').value).toBe('ai, sales')
+    expect(eng.exclude_topics).toEqual(['crypto'])
+  })
+
+  it('tidies on blur and still accepts a fresh separator afterwards', () => {
+    render(<TargetingSection />)
+    fireEvent.change(box('include_topics'), { target: { value: 'ai,, sales ,' } })
+    fireEvent.blur(box('include_topics'))
+    expect(box('include_topics').value).toBe('ai, sales')
+    fireEvent.change(box('include_topics'), { target: { value: 'ai, sales,' } })
+    expect(box('include_topics').value).toBe('ai, sales,')
+    expect(eng.include_topics).toEqual(['ai', 'sales'])
+  })
+
+  it('survives StrictMode double-rendering', () => {
+    eng = { include_topics: ['ai'] }
+    render(<StrictMode><TargetingSection /></StrictMode>)
+    fireEvent.change(box('include_topics'), { target: { value: 'ai, ' } })
+    expect(box('include_topics').value).toBe('ai, ')
+  })
+})


### PR DESCRIPTION
## What & why

Reported via in-app feedback: *"Many settings asking for comma separated values don't allow the user to enter commas or spaces. Something is blocking when trying to type in the fields."*

Reproduced. The eight list settings in the Account settings hub bound their `<input>` straight to `csv(list)` while publishing `parseCsv(e.target.value)` on every keystroke:

```tsx
<input value={csv(eng.focus_topics)} onChange={(e) => setEng({ focus_topics: parseCsv(e.target.value) })} />
```

`parseCsv` trims each entry and drops empty ones, so `"ai,"` → `["ai"]` → `"ai"` and `"ai, "` → `"ai"`. The typed character was parsed away and the box re-rendered without it before the next keystroke landed — the comma and the space after it could literally never be entered. The only way to get a second entry in was to paste it.

## The fix

New `settings/CsvInput.tsx` holds the raw text in local state and publishes only the parsed array upward:

- A prop equal to the canonical form of what it last published is its **own echo** and is ignored — that's the write-back that ate the separator.
- A value changed from **outside** (preferences loading, a one-click conflict fix, a preset) still replaces the box.
- On **blur** the text is tidied to the canonical `a, b` form, so `"ai,, sales ,"` settles as `"ai, sales"`.

Wired into all eight affected fields — `include/exclude_topics`, `include/exclude_keywords`, `include/exclude_authors` (Targeting), `focus_topics` (Voice), `connection_target_authors` (Outreach). No API, model or storage change: the same `string[]` is sent on save.

## Testing

- New `CsvInput.test.tsx` (7 tests) drives the component through a harness that owns the parsed array and hands it straight back down — the exact wiring that caused the bug. Covers typing a comma, typing the space after it, trimmed/empty-filtered publishing, rendering a saved list, blur tidying, an external replacement, and a null value.
- Full SPA suite green locally: `npm test` → 16 files, 170 tests passed. `npm run build` (tsc -b + vite build) and `eslint` on the touched files are clean.

Closes #638

🤖 Generated with [Claude Code](https://claude.com/claude-code)
