### PR TITLE
feat(outbound): resolve the brand account as user 1 by convention (closes #736)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -396,11 +396,10 @@ EARLY_ADOPTER_COUPON_ID=
 # P0 private early-adopter / P1 open beta / P2 GA. Sets the brand account's daily
 # comment/DM/connect caps and connect approval posture (see utilities/brand_account.py).
 LAUNCH_PHASE=P0
-# The LEM brand LinkedIn account, onboarded as a normal user (same caps, 429 backoff, proxy).
-# OFF by default — it sends real outbound.
-BRAND_ACCOUNT_ENABLED=False
-BRAND_ACCOUNT_EMAIL=
-# Trial signup URL the brand's content/DMs steer toward. Empty = no CTA seeded.
+# The LEM brand LinkedIn account is user 1 by convention (issue #736) — no configuration needed.
+# Set this ONLY to seat the brand on a different account; blank/invalid = user 1.
+BRAND_USER_ID=
+# Trial signup URL the brand's content/DMs steer toward. Empty falls back to PUBLIC_BASE_URL.
 BRAND_SIGNUP_URL=
 # Extra hosts whose analytics we own (marketing site, blog, docs) — comma separated, bare host or
 # full URL. Only these plus PUBLIC_BASE_URL/BRAND_SIGNUP_URL get UTM-tagged on outbound links.

--- a/docs/launch-and-marketing-plan.md
+++ b/docs/launch-and-marketing-plan.md
@@ -37,7 +37,7 @@ re-file work that already exists. Sections A–D remain the plan of record for e
 | Onboarding/activation checklist + stalled-user nudges (A.3) | **Shipped** | `OnboardingChecklist.tsx`, `onboarding_state` (`V20260725090900__add_onboarding_state.sql`), `onboarding-nudges` beat |
 | Extended-trial endpoint + cohort slots (A.2) | **Shipped** | `POST /trial/extend`, `extend_trial_for_user`, `early_adopter_slots` / `early_adopter_grants`, `EARLY_ADOPTER_*` + `LAUNCH_PHASE` env |
 | Funnel instrumentation (C.5) | **Shipped** | `track_funnel_event` in `observability.py` |
-| Brand-account dogfooding (C.2) | **Partial** | `sync-brand-account` beat (`auto_sync_brand_account`), gated by `BRAND_ACCOUNT_ENABLED`; the brand runs the existing content/engagement/newsletter tasks |
+| Brand-account dogfooding (C.2) | **Partial** | `sync-brand-account` beat (`auto_sync_brand_account`); the brand user is **user 1 by convention** (issue #736, no env var required) and runs the existing content/engagement/newsletter tasks |
 | Passive-signal mining (B.1) | **Planned** | — |
 | SEO, email-nurture, referral, lead-magnet, retargeting and partner/affiliate agents (C.3, C.4) | **Planned** | — |
 | Analytics agent: CAC / channel-ROI rollups + optimization loop (C.5) | **Planned** | — |
@@ -232,9 +232,15 @@ economics, brand-voice guardrails) — never pressing "post."
 
 ### C.2 Dogfooding as the flagship channel — **LEM markets LEM**
 
-The single most credible proof that LEM works is LEM growing its own audience with LEM. A dedicated **LEM brand
-LinkedIn account** is onboarded as a first-class user of the product and runs the exact same automation users
-pay for:
+The single most credible proof that LEM works is LEM growing its own audience with LEM. The **LEM brand
+LinkedIn account** is a first-class user of the product and runs the exact same automation users pay for.
+
+**Who the brand account is: user 1, by convention (issue #736).** The first account on the box is the owner's
+own, it doubles as the brand account permanently, and `brand_account.brand_user_id()` resolves it with **zero
+configuration** — the earlier `BRAND_ACCOUNT_ENABLED` / `BRAND_ACCOUNT_EMAIL` pair was wiring that only ever
+failed closed, and kept this whole engine dormant in prod because two env vars were never set. An optional
+`BRAND_USER_ID` seats the brand elsewhere; blank or invalid falls back to user 1 rather than switching
+self-marketing off. What the brand does:
 
 1. **Content about the problem LEM solves.** The brand account's `focus_topics` are set to the ICP's pains
    ("consistent LinkedIn presence without the grind", "solo-founder pipeline", "AI content that sounds like
@@ -259,6 +265,16 @@ pay for:
 (`utilities/linkedin/rate_limit.py`), per-user proxy (`utilities/proxy.py`), and per-day caps as any user — so
 self-marketing can never exceed ToS-safe volume. Outbound cadence for the brand is a `risk:product-decision`
 config (daily connect/DM caps) the owner signs off once.
+
+**The collision guard (issue #736).** Because the brand user is *also* the owner's ordinary LEM account, the
+nightly `sync_brand_preferences` applies the phase policy as a **ceiling, not an assignment**: it can only pull
+`max_comments_per_day` / `max_dms_per_day` / `max_invites_per_day` DOWN to the phase's number, and only tighten
+`connection_request_mode` / `connection_targeting_mode` (strictness order `pre_review` > `auto_approve`, `off` >
+`suggest` > `auto_queue`). A value the owner tuned STRICTER by hand survives the sync — honouring it can never
+widen outbound, and stomping it every night is the one real risk this convention introduces. The seeded content
+fields (`focus_topics`, `business_goals`) stay fill-only-when-empty as before, everything else on the row is
+untouched (only the policy fields are sent — issue #639), and any field the sync does change is named
+before → after in one INFO line, so an edit to the owner's own settings is never silent.
 
 ### C.3 Other automated channels (each agent-run)
 

--- a/docs/marketing-attribution.md
+++ b/docs/marketing-attribution.md
@@ -23,7 +23,9 @@ This closes the loop at the **source**: one helper, applied at every surface tha
   params the destination's analytics reads — stamping them on a Reuters article we cited pollutes
   someone else's reporting and attributes nothing to us. The owned set is `PUBLIC_BASE_URL`,
   `BRAND_SIGNUP_URL` and anything in the new `MARKETING_OWNED_DOMAINS` env (comma-separated, bare
-  host or full URL), plus their subdomains. A bare entry is normalized the same way a parsed URL's
+  host or full URL), plus their subdomains. `BRAND_SIGNUP_URL` itself defaults to `PUBLIC_BASE_URL`
+  (issue #736) — the landing page is the signup surface, so the CTA needs no extra config. A bare
+  entry is normalized the same way a parsed URL's
   host is (`www.` and any port stripped), or the comparison would silently never match and the
   domain you configured would go untagged. With none of them configured **nothing is tagged** —
   the pre-#658 behaviour exactly.
@@ -109,8 +111,10 @@ skips the goals (`blocked_goal`) rather than failing the whole provisioning run.
 
 ## Verifying end to end
 
-1. `MARKETING_OWNED_DOMAINS` and `BRAND_SIGNUP_URL` are set in the environment. Without them nothing
-   is tagged and every tile reads `(none)` — that row against a campaign you are running is the tell.
+1. `PUBLIC_BASE_URL` is set (the trial CTA falls back to it when `BRAND_SIGNUP_URL` is unset — issue
+   #736), and `MARKETING_OWNED_DOMAINS` lists any marketing site/blog/docs host. With none of them
+   set nothing is tagged and every tile reads `(none)` — that row against a campaign you are running
+   is the tell.
 2. `poetry run python scripts/posthog_provision.py --dry-run` → the Channels dashboard and both goals
    appear as pending; `--apply` converges them.
 3. Open a brand post's CTA link. `$pageview` should carry `utm_source=linkedin` and the post campaign.

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -85,7 +85,8 @@ app.conf.update(
         'sync-brand-account': {
             'task': 'cqc_lem.app.run_scheduler.auto_sync_brand_account',
             # Just before the content plan runs, so the brand's phase caps/posture are already in
-            # place for the day's dogfooding run (issue #504). No-ops unless BRAND_ACCOUNT_ENABLED.
+            # place for the day's dogfooding run (issue #504). The brand user is user 1 by
+            # convention (issue #736), so this needs no configuration to do its work.
             'schedule': crontab(hour='0', minute='45')
         },
         'generate-content-plan': {

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1328,14 +1328,14 @@ def auto_sync_brand_account():
     and per-user proxy. So this task adds no outreach of its own: it only re-asserts the phase's caps
     and connect posture onto the brand's engagement preferences, so advancing a phase (or a manual
     cap edit) can never leave brand outbound running hotter than was signed off on.
+
+    The brand user is user 1 by convention (issue #736), so this always has an account to sync — no
+    env var can leave it dormant, and the only reported failure is a failed write.
     """
-    from cqc_lem.utilities.brand_account import current_launch_phase, get_brand_user_id, \
+    from cqc_lem.utilities.brand_account import brand_user_id, current_launch_phase, \
         sync_brand_preferences
 
-    user_id = get_brand_user_id()
-    if user_id is None:
-        return "Brand account not configured"
-
+    user_id = brand_user_id()
     phase = current_launch_phase()
     applied = sync_brand_preferences(phase)
     if applied is None:

--- a/src/cqc_lem/utilities/brand_account.py
+++ b/src/cqc_lem/utilities/brand_account.py
@@ -4,18 +4,23 @@ The brand account is a FIRST-CLASS user of LEM, not a special case: its 30-day c
 commenting, connect targeting, appreciation/outreach DMs + follow-ups, newsletter and company-page
 invites all reach it through the same per-active-user beat tasks a paying customer goes through, and
 its volume is enforced by the same `engagement_preferences` caps, 429 backoff (`rate_limit.py`) and
-per-user proxy. So this module owns no outreach primitives at all — it only decides WHAT the brand
-user's caps and focus topics should be for the current `LAUNCH_PHASE`, so self-marketing can never
-quietly run hotter than the owner signed off on.
+per-user proxy. So this module owns no outreach primitives at all — it only decides WHO the brand
+user is, and WHAT its caps and focus topics should be for the current `LAUNCH_PHASE`, so
+self-marketing can never quietly run hotter than the owner signed off on.
 """
 
-from typing import Optional
+from typing import Any, Optional
 
-from cqc_lem.utilities.env_constants import (BRAND_ACCOUNT_EMAIL, BRAND_ACCOUNT_ENABLED,
-                                             LAUNCH_PHASE)
-from cqc_lem.utilities.logger import log_debug, log_warning
+from cqc_lem.utilities.env_constants import BRAND_USER_ID, LAUNCH_PHASE
+from cqc_lem.utilities.logger import log_debug, log_info, log_warning
 from cqc_lem.utilities.marketing.attribution import (CAMPAIGN_BRAND_PROFILE, MEDIUM_PROFILE,
                                                      SOURCE_LINKEDIN, signup_url)
+
+# The brand account is user 1 BY CONVENTION (issue #736): the first account onboarded on the box is
+# the owner's own, and it permanently doubles as the LEM brand account. The old
+# BRAND_ACCOUNT_ENABLED/BRAND_ACCOUNT_EMAIL pair kept the whole self-marketing engine dormant for
+# months because two env vars were never set in prod — a wiring flag that only ever failed closed.
+DEFAULT_BRAND_USER_ID = 1
 
 # Rollout phases from the launch plan (docs/launch-and-marketing-plan.md §A.1): P0 private
 # early-adopter, P1 open beta, P2 GA. Advancing a phase is the owner's call.
@@ -46,6 +51,19 @@ PHASE_OUTBOUND_POLICY = {
            "connection_request_mode": "auto_approve", "connection_targeting_mode": "auto_queue"},
 }
 
+# The phase's numeric caps. Since the brand user is also the owner's ORDINARY account (#736), the
+# phase is applied as a CEILING, not as an assignment: it can only ever pull a cap DOWN. A cap the
+# owner tuned lower by hand is stricter than the policy, so honouring it can never widen outbound —
+# and stomping it nightly is exactly the silent overwrite this convention would otherwise introduce.
+CAP_FIELDS = ("max_comments_per_day", "max_dms_per_day", "max_invites_per_day")
+
+# Same rule for the approval posture, which has no numeric scale: strictest first. `pre_review` /
+# `off` gate more than the phase does, so a hand-set stricter mode survives the sync.
+MODE_STRICTNESS = {
+    "connection_request_mode": ("pre_review", "auto_approve"),
+    "connection_targeting_mode": ("off", "suggest", "auto_queue"),
+}
+
 
 def current_launch_phase() -> str:
     """The active rollout phase. An unrecognized value falls back to the most conservative phase
@@ -68,39 +86,72 @@ def brand_outbound_policy(phase: Optional[str] = None) -> dict:
     return policy
 
 
-def get_brand_user_id() -> Optional[int]:
-    """The brand account's user id, or None when dogfooding is off, no email is configured, or no
-    user matches it — every caller treats None as "there is no brand account to drive"."""
-    if not BRAND_ACCOUNT_ENABLED:
-        return None
-    email = (BRAND_ACCOUNT_EMAIL or "").strip()
-    if not email:
-        log_warning("Brand account enabled but BRAND_ACCOUNT_EMAIL is unset — skipping")
-        return None
-    from cqc_lem.utilities.db import get_user_id
-    user_id = get_user_id(email)
-    if not user_id:
-        log_warning(f"Brand account email {email} does not match any user — skipping")
-        return None
-    return int(user_id)
+def brand_user_id() -> int:
+    """The brand account's user id — user 1 unless a deployment explicitly overrides it.
+
+    Never None: the brand engine has to run with ZERO configuration, so an unset, blank or
+    unparseable `BRAND_USER_ID` resolves to the convention rather than switching self-marketing off.
+    """
+    raw = str(BRAND_USER_ID or "").strip()
+    if not raw:
+        return DEFAULT_BRAND_USER_ID
+    try:
+        override = int(raw)
+    except (TypeError, ValueError):
+        log_warning(f"Unparseable BRAND_USER_ID '{BRAND_USER_ID}' — using user {DEFAULT_BRAND_USER_ID}")
+        return DEFAULT_BRAND_USER_ID
+    if override <= 0:
+        log_warning(f"BRAND_USER_ID '{BRAND_USER_ID}' is not a valid user id — "
+                    f"using user {DEFAULT_BRAND_USER_ID}")
+        return DEFAULT_BRAND_USER_ID
+    return override
 
 
-def is_brand_user(user_id: int) -> bool:
+def is_brand_user(user_id: Any) -> bool:
     """Whether `user_id` is the brand account (for attribution/observability, not for privileges)."""
-    brand_id = get_brand_user_id()
-    return brand_id is not None and int(user_id) == brand_id
+    try:
+        return int(user_id) == brand_user_id()
+    except (TypeError, ValueError):
+        return False
+
+
+def _capped(current: Any, ceiling: int) -> int:
+    """`current` held under the phase's ceiling. A missing/unreadable saved value takes the ceiling —
+    "no opinion" is not the same as "the owner asked for less"."""
+    try:
+        saved = int(current)
+    except (TypeError, ValueError):
+        return ceiling
+    return max(0, min(ceiling, saved))
+
+
+def _strictest(current: Any, phase_value: str, order: tuple) -> str:
+    """Whichever of the saved and phase values gates more (`order` is strictest-first). A saved value
+    outside the known vocabulary is not comparable, so the phase's wins."""
+    if current not in order:
+        return phase_value
+    if phase_value not in order:
+        return str(current)
+    return str(current) if order.index(str(current)) < order.index(phase_value) else phase_value
 
 
 def brand_preference_overrides(existing: Optional[dict] = None, phase: Optional[str] = None) -> dict:
     """The engagement-preference fields the brand policy owns, given the account's current prefs.
 
-    Caps and approval posture are ALWAYS re-asserted from the phase — that is the volume gate, so a
-    manual edit in the SPA must not survive it. The seeded content fields (focus topics, business
-    goals) are only filled when empty, so the owner can retune the brand's messaging without this
-    task stomping it back every night.
+    Caps and approval posture are re-asserted from the phase as a CEILING — that is the volume gate,
+    so a manual edit can never raise brand outbound above what was signed off on, but a value the
+    owner tuned STRICTER survives (the brand user is also his ordinary account, issue #736, and
+    clamping down is the only direction that matters for safety). The seeded content fields (focus
+    topics, business goals) are only filled when empty, so he can retune the brand's messaging
+    without this task stomping it back every night.
     """
-    overrides = brand_outbound_policy(phase)
+    policy = brand_outbound_policy(phase)
     current = existing or {}
+    overrides = dict(policy)
+    for cap in CAP_FIELDS:
+        overrides[cap] = _capped(current.get(cap), policy[cap])
+    for field, order in MODE_STRICTNESS.items():
+        overrides[field] = _strictest(current.get(field), policy[field], order)
     if not [t for t in (current.get("focus_topics") or []) if str(t).strip()]:
         overrides["focus_topics"] = list(BRAND_FOCUS_TOPICS)
     # The goal line is read by the content prompts, so the URL in it is the one the brand's posts
@@ -111,25 +162,53 @@ def brand_preference_overrides(existing: Optional[dict] = None, phase: Optional[
     return overrides
 
 
+def _comparable(value: Any) -> Any:
+    """`value` in a shape two sources can be compared in — the DB hands back strings for numbers the
+    policy holds as ints, and focus topics as a list."""
+    if isinstance(value, (list, tuple)):
+        return tuple(str(item).strip() for item in value)
+    if value is None or isinstance(value, bool):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return str(value).strip()
+
+
+def preference_changes(existing: Optional[dict], overrides: dict) -> dict:
+    """The fields this sync would actually change, as `{field: (before, after)}`. The brand user is
+    the owner's own account, so a sync that edits his settings has to be readable in the logs rather
+    than inferred from a nightly "synced" line that says the same thing whether it changed anything
+    or not."""
+    current = existing or {}
+    return {field: (current.get(field), value) for field, value in overrides.items()
+            if _comparable(current.get(field)) != _comparable(value)}
+
+
 def sync_brand_preferences(phase: Optional[str] = None) -> Optional[dict]:
     """Push the current phase's outbound policy onto the brand account's engagement preferences.
 
-    Returns the applied overrides, or None when there is no brand account to sync. The whole upsert
-    is one row (the V52 incident), so ONLY the policy fields are sent — voice, tone and targeting the
-    owner set are preserved by `update_engagement_preferences`, which merges over the saved row and
-    aborts when it can't read it (issue #639). Re-sending `existing` here would defeat that abort:
-    a transient read error makes `get_engagement_preferences` return code defaults, and this nightly
-    task would then write all 39 of them over the brand account's real settings.
+    Returns the applied overrides, or None when the upsert failed. The whole upsert is one row (the
+    V52 incident), so ONLY the policy fields are sent — voice, tone and targeting the owner set are
+    preserved by `update_engagement_preferences`, which merges over the saved row and aborts when it
+    can't read it (issue #639). Re-sending `existing` here would defeat that abort: a transient read
+    error makes `get_engagement_preferences` return code defaults, and this nightly task would then
+    write all 39 of them over the brand account's real settings.
     """
-    user_id = get_brand_user_id()
-    if user_id is None:
-        return None
+    user_id = brand_user_id()
     from cqc_lem.utilities.db import get_engagement_preferences, update_engagement_preferences
     resolved_phase = (phase or current_launch_phase()).strip().upper()
     existing = get_engagement_preferences(user_id) or {}
     overrides = brand_preference_overrides(existing, resolved_phase)
+    changes = preference_changes(existing, overrides)
     if not update_engagement_preferences(user_id, overrides):
         log_warning("Could not sync brand account preferences", user_id=user_id)
         return None
-    log_debug(f"Brand account synced to phase {resolved_phase}", user_id=user_id)
+    if changes:
+        summary = ", ".join(f"{field}: {before!r} -> {after!r}"
+                            for field, (before, after) in sorted(changes.items()))
+        log_info(f"Brand phase {resolved_phase} changed engagement preferences — {summary}",
+                 user_id=user_id, task_name="sync_brand_preferences")
+    else:
+        log_debug(f"Brand account already at phase {resolved_phase}", user_id=user_id)
     return overrides

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -201,11 +201,13 @@ EARLY_ADOPTER_COUPON_ID   = get_constant_from_env('EARLY_ADOPTER_COUPON_ID', def
 # P2 GA. It is the single knob that sets the brand account's outbound volume (see brand_account.py);
 # anything unrecognized falls back to P0 so a typo can never widen outbound.
 LAUNCH_PHASE              = get_constant_from_env('LAUNCH_PHASE', default_value='P0')
-# Dogfooding self-marketing (issue #504): the LEM brand LinkedIn account onboarded as a first-class
-# user. OFF by default — it sends real outbound, so each environment opts in explicitly.
-BRAND_ACCOUNT_ENABLED     = isTrue(get_constant_from_env('BRAND_ACCOUNT_ENABLED', default_value='False'))
-BRAND_ACCOUNT_EMAIL       = get_constant_from_env('BRAND_ACCOUNT_EMAIL', default_value='')
-# Trial signup URL the brand's content/DMs steer toward. Empty = no CTA seeded.
+# Dogfooding self-marketing (issue #504): the LEM brand LinkedIn account IS user 1 by convention
+# (issue #736) — the first account on the box is the owner's own, and it always will be. No env var
+# is required for the brand engine to run; this is an OPTIONAL override for a deployment that
+# genuinely seats the brand elsewhere. Empty/unparseable = the convention (see brand_account.py).
+BRAND_USER_ID             = get_constant_from_env('BRAND_USER_ID', default_value='')
+# Trial signup URL the brand's content/DMs steer toward. Empty falls back to PUBLIC_BASE_URL (the
+# landing page IS the signup surface), so a normal deployment needs no extra config.
 BRAND_SIGNUP_URL          = get_constant_from_env('BRAND_SIGNUP_URL', default_value='')
 # Extra hosts whose analytics we own (marketing site, blog, docs) — comma separated, bare host or
 # full URL. UTM tagging is applied to these and to PUBLIC_BASE_URL/BRAND_SIGNUP_URL ONLY: stamping

--- a/src/cqc_lem/utilities/marketing/attribution.py
+++ b/src/cqc_lem/utilities/marketing/attribution.py
@@ -233,11 +233,18 @@ def campaign_for_tutorial(flow_key: Optional[str] = None) -> str:
 
 # --- LEM's own destinations -----------------------------------------------------------------------
 
+def signup_landing() -> str:
+    """Where a trial CTA points. `BRAND_SIGNUP_URL` when the deployment names one, otherwise this
+    deployment's own public base URL — the landing page IS the signup surface, so the brand engine
+    needs no extra configuration to have a link to publish (issue #736). Empty only when neither is
+    set, which every caller reads as "there is no CTA link to publish"."""
+    return str(BRAND_SIGNUP_URL or "").strip() or str(PUBLIC_BASE_URL or "").strip()
+
+
 def signup_url(source: str, medium: str, campaign: str, content: Optional[str] = None,
                ref: Optional[str] = None) -> str:
-    """The trial signup URL, tagged. Empty string when BRAND_SIGNUP_URL is unset — every caller
-    treats that as "there is no CTA link to publish", exactly as it did before this module."""
-    base = str(BRAND_SIGNUP_URL or "").strip()
+    """The trial signup URL, tagged. Empty string when there is no landing page configured at all."""
+    base = signup_landing()
     if not base:
         return ""
     return build_utm_url(base, source, medium, campaign, content=content, ref=ref)
@@ -261,7 +268,7 @@ def referral_url(user_id: Optional[int], base: Optional[str] = None) -> str:
     code = referral_code(user_id)
     if not code:
         return ""
-    landing = str(base or BRAND_SIGNUP_URL or "").strip()
+    landing = str(base or "").strip() or signup_landing()
     if not landing:
         return ""
     return build_utm_url(landing, SOURCE_REFERRAL, MEDIUM_REFERRAL, CAMPAIGN_REFERRAL, ref=code)

--- a/tests/unit/app/test_brand_account.py
+++ b/tests/unit/app/test_brand_account.py
@@ -13,12 +13,13 @@ _DB = "cqc_lem.utilities.db"
 _RS = "cqc_lem.app.run_scheduler"
 
 
-def _enabled(email="brand@lem.test", signup_url="", phase="P0"):
-    """Patch the module-level env constants brand_account read at import time."""
+def _enabled(brand_user_id="", signup_url="", phase="P0"):
+    """Patch the module-level env constants brand_account read at import time. Issue #736: the brand
+    user resolves with NO env at all, so the default here is the empty override."""
     return [
-        patch(f"{_BA}.BRAND_ACCOUNT_ENABLED", True),
-        patch(f"{_BA}.BRAND_ACCOUNT_EMAIL", email),
+        patch(f"{_BA}.BRAND_USER_ID", brand_user_id),
         patch(f"{_ATTR}.BRAND_SIGNUP_URL", signup_url),
+        patch(f"{_ATTR}.PUBLIC_BASE_URL", ""),
         patch(f"{_BA}.LAUNCH_PHASE", phase),
     ]
 
@@ -96,36 +97,42 @@ class TestBrandOutboundPolicy:
             assert brand_outbound_policy() == brand_outbound_policy("P1")
 
 
-class TestGetBrandUserId:
-    def test_none_when_disabled(self):
-        from cqc_lem.utilities.brand_account import get_brand_user_id
-        with patch(f"{_BA}.BRAND_ACCOUNT_ENABLED", False), \
-             patch(f"{_DB}.get_user_id") as lookup:
-            assert get_brand_user_id() is None
+class TestBrandUserId:
+    """Issue #736: the brand account is user 1 by convention. No env var may be REQUIRED for the
+    self-marketing engine to run — the old enabled/email pair kept it dormant for months."""
+
+    def test_resolves_user_one_with_no_configuration_at_all(self):
+        from cqc_lem.utilities.brand_account import brand_user_id
+        with _Patched(_enabled()), patch(f"{_DB}.get_user_id") as lookup:
+            assert brand_user_id() == 1
         lookup.assert_not_called()
 
-    def test_none_when_email_missing(self):
-        from cqc_lem.utilities.brand_account import get_brand_user_id
-        with _Patched(_enabled(email="  ")), patch(f"{_DB}.get_user_id") as lookup:
-            assert get_brand_user_id() is None
-        lookup.assert_not_called()
+    def test_explicit_override_is_honored(self):
+        from cqc_lem.utilities.brand_account import brand_user_id
+        with _Patched(_enabled(brand_user_id=" 7 ")):
+            assert brand_user_id() == 7
 
-    def test_none_when_no_user_matches(self):
-        from cqc_lem.utilities.brand_account import get_brand_user_id
-        with _Patched(_enabled()), patch(f"{_DB}.get_user_id", return_value=None):
-            assert get_brand_user_id() is None
-
-    def test_resolves_the_configured_email(self):
-        from cqc_lem.utilities.brand_account import get_brand_user_id
-        with _Patched(_enabled()), patch(f"{_DB}.get_user_id", return_value=7) as lookup:
-            assert get_brand_user_id() == 7
-        lookup.assert_called_once_with("brand@lem.test")
+    @pytest.mark.parametrize("bad", ["nope", "0", "-3", "1.5", None])
+    def test_an_unusable_override_falls_back_to_the_convention(self, bad):
+        """Falling back — never returning None. A typo must not switch self-marketing off silently."""
+        from cqc_lem.utilities.brand_account import brand_user_id
+        with _Patched(_enabled(brand_user_id=bad)):
+            assert brand_user_id() == 1
 
     def test_is_brand_user(self):
         from cqc_lem.utilities.brand_account import is_brand_user
-        with _Patched(_enabled()), patch(f"{_DB}.get_user_id", return_value=7):
-            assert is_brand_user(7) is True
+        with _Patched(_enabled()):
+            assert is_brand_user(1) is True
+            assert is_brand_user("1") is True
             assert is_brand_user(8) is False
+            assert is_brand_user(None) is False
+            assert is_brand_user("not-an-id") is False
+
+    def test_is_brand_user_follows_the_override(self):
+        from cqc_lem.utilities.brand_account import is_brand_user
+        with _Patched(_enabled(brand_user_id="7")):
+            assert is_brand_user(7) is True
+            assert is_brand_user(1) is False
 
 
 class TestBrandPreferenceOverrides:
@@ -168,14 +175,95 @@ class TestBrandPreferenceOverrides:
         overrides = brand_preference_overrides({"max_comments_per_day": 999}, "P0")
         assert overrides["max_comments_per_day"] == 8
 
+    def test_a_missing_cap_takes_the_phase_value(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        overrides = brand_preference_overrides({}, "P1")
+        assert overrides["max_comments_per_day"] == 15
+        assert overrides["max_dms_per_day"] == 10
+        assert overrides["max_invites_per_day"] == 8
+
+    def test_an_unreadable_cap_takes_the_phase_value(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        overrides = brand_preference_overrides({"max_dms_per_day": "many"}, "P1")
+        assert overrides["max_dms_per_day"] == 10
+
+
+class TestOwnerTunedSettingsSurvive:
+    """Issue #736 — the brand user is ALSO the owner's ordinary account, so the phase policy is a
+    CEILING, not an assignment: it only ever tightens."""
+
+    def test_a_hand_tuned_lower_cap_is_kept(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        overrides = brand_preference_overrides({"max_comments_per_day": 3}, "P1")
+        assert overrides["max_comments_per_day"] == 3       # his stricter number survives
+        assert overrides["max_dms_per_day"] == 10           # the ones he never set take the phase
+
+    def test_a_cap_of_zero_is_a_real_choice_not_an_unset_value(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        assert brand_preference_overrides({"max_invites_per_day": 0}, "P2")["max_invites_per_day"] == 0
+
+    def test_a_stricter_connect_posture_is_kept_but_a_looser_one_is_not(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        strict = brand_preference_overrides(
+            {"connection_request_mode": "pre_review", "connection_targeting_mode": "off"}, "P2")
+        assert strict["connection_request_mode"] == "pre_review"
+        assert strict["connection_targeting_mode"] == "off"
+        loose = brand_preference_overrides(
+            {"connection_request_mode": "auto_approve", "connection_targeting_mode": "auto_queue"},
+            "P0")
+        assert loose["connection_request_mode"] == "pre_review"
+        assert loose["connection_targeting_mode"] == "suggest"
+
+    def test_an_unknown_saved_mode_falls_back_to_the_phase(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        overrides = brand_preference_overrides({"connection_targeting_mode": "bogus"}, "P1")
+        assert overrides["connection_targeting_mode"] == "auto_queue"
+
+    def test_the_ceiling_can_never_be_raised_above_the_phase(self):
+        from cqc_lem.utilities.brand_account import (CAP_FIELDS, LAUNCH_PHASES,
+                                                     brand_outbound_policy,
+                                                     brand_preference_overrides)
+        hand_tuned = {cap: 999 for cap in CAP_FIELDS}
+        for phase in LAUNCH_PHASES:
+            policy = brand_outbound_policy(phase)
+            overrides = brand_preference_overrides(hand_tuned, phase)
+            for cap in CAP_FIELDS:
+                assert overrides[cap] == policy[cap]
+
+
+class TestPreferenceChanges:
+    def test_reports_only_what_actually_changes(self):
+        from cqc_lem.utilities.brand_account import preference_changes
+        existing = {"max_comments_per_day": 8, "max_dms_per_day": 20}
+        changes = preference_changes(existing, {"max_comments_per_day": 8, "max_dms_per_day": 5})
+        assert changes == {"max_dms_per_day": (20, 5)}
+
+    def test_a_string_column_matching_an_int_policy_is_not_a_change(self):
+        """The DB can hand a cap back as a string — reporting that as an edit to the owner's own
+        settings every single night would make the log useless."""
+        from cqc_lem.utilities.brand_account import preference_changes
+        assert preference_changes({"max_dms_per_day": "5"}, {"max_dms_per_day": 5}) == {}
+
+    def test_focus_topic_lists_compare_by_value(self):
+        from cqc_lem.utilities.brand_account import preference_changes
+        assert preference_changes({"focus_topics": ["a", "b"]}, {"focus_topics": ["a", "b"]}) == {}
+        assert preference_changes({"focus_topics": []}, {"focus_topics": ["a"]}) == {
+            "focus_topics": ([], ["a"])}
+
+    def test_an_unset_field_is_a_change(self):
+        from cqc_lem.utilities.brand_account import preference_changes
+        assert preference_changes({}, {"connection_request_mode": "pre_review"}) == {
+            "connection_request_mode": (None, "pre_review")}
+
 
 class TestSyncBrandPreferences:
-    def test_no_brand_account_is_a_no_op(self):
+    def test_syncs_user_one_with_no_configuration(self):
         from cqc_lem.utilities.brand_account import sync_brand_preferences
-        with patch(f"{_BA}.BRAND_ACCOUNT_ENABLED", False), \
-             patch(f"{_DB}.update_engagement_preferences") as upsert:
-            assert sync_brand_preferences() is None
-        upsert.assert_not_called()
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.get_engagement_preferences", return_value={}), \
+             patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
+            assert sync_brand_preferences() is not None
+        assert upsert.call_args.args[0] == 1
 
     def test_sends_only_the_policy_fields(self):
         """Issue #639: the upsert merges over the SAVED row, so this task must send its policy
@@ -184,12 +272,11 @@ class TestSyncBrandPreferences:
         from cqc_lem.utilities.brand_account import sync_brand_preferences
         existing = {"tone": "warm", "max_comments_per_day": 20, "focus_topics": ["agency growth"]}
         with _Patched(_enabled(phase="P1")), \
-             patch(f"{_DB}.get_user_id", return_value=7), \
              patch(f"{_DB}.get_engagement_preferences", return_value=existing), \
              patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
             applied = sync_brand_preferences()
         saved = upsert.call_args.args[1]
-        assert upsert.call_args.args[0] == 7
+        assert upsert.call_args.args[0] == 1
         assert "tone" not in saved                            # voice the owner set is never rewritten
         assert "focus_topics" not in saved                    # nor their non-empty focus topics
         assert saved["max_comments_per_day"] == 15            # but the phase cap wins
@@ -202,7 +289,6 @@ class TestSyncBrandPreferences:
         from cqc_lem.utilities.brand_account import sync_brand_preferences
         from cqc_lem.utilities.db import _ENGAGEMENT_DEFAULTS
         with _Patched(_enabled(phase="P0")), \
-             patch(f"{_DB}.get_user_id", return_value=7), \
              patch(f"{_DB}.get_engagement_preferences", return_value=dict(_ENGAGEMENT_DEFAULTS)), \
              patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
             sync_brand_preferences()
@@ -215,7 +301,6 @@ class TestSyncBrandPreferences:
     def test_explicit_phase_argument_overrides_the_env(self):
         from cqc_lem.utilities.brand_account import sync_brand_preferences
         with _Patched(_enabled(phase="P0")), \
-             patch(f"{_DB}.get_user_id", return_value=7), \
              patch(f"{_DB}.get_engagement_preferences", return_value={}), \
              patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
             sync_brand_preferences("p2")
@@ -224,24 +309,67 @@ class TestSyncBrandPreferences:
     def test_returns_none_when_the_upsert_fails(self):
         from cqc_lem.utilities.brand_account import sync_brand_preferences
         with _Patched(_enabled()), \
-             patch(f"{_DB}.get_user_id", return_value=7), \
              patch(f"{_DB}.get_engagement_preferences", return_value={}), \
              patch(f"{_DB}.update_engagement_preferences", return_value=False):
             assert sync_brand_preferences() is None
 
+    def test_does_not_clobber_the_owners_stricter_caps(self):
+        """The collision this convention introduces (#736): user 1 is the owner's own account."""
+        from cqc_lem.utilities.brand_account import sync_brand_preferences
+        existing = {"max_comments_per_day": 2, "max_dms_per_day": 1, "max_invites_per_day": 1,
+                    "connection_request_mode": "pre_review", "connection_targeting_mode": "off",
+                    "tone": "warm", "focus_topics": ["agency growth"]}
+        with _Patched(_enabled(phase="P2")), \
+             patch(f"{_DB}.get_engagement_preferences", return_value=existing), \
+             patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
+            sync_brand_preferences()
+        saved = upsert.call_args.args[1]
+        assert saved["max_comments_per_day"] == 2
+        assert saved["max_dms_per_day"] == 1
+        assert saved["max_invites_per_day"] == 1
+        assert saved["connection_request_mode"] == "pre_review"
+        assert saved["connection_targeting_mode"] == "off"
+
+    def test_logs_every_field_it_changes(self):
+        from cqc_lem.utilities.brand_account import sync_brand_preferences
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.get_engagement_preferences", return_value={"max_dms_per_day": 20}), \
+             patch(f"{_DB}.update_engagement_preferences", return_value=True), \
+             patch(f"{_BA}.log_info") as info:
+            sync_brand_preferences()
+        message = info.call_args.args[0]
+        assert "max_dms_per_day: 20 -> 5" in message
+        assert info.call_args.kwargs["user_id"] == 1
+
+    def test_an_unchanged_account_logs_no_edit(self):
+        """A nightly INFO line that fires whether or not anything moved is not a change log."""
+        from cqc_lem.utilities.brand_account import brand_preference_overrides, \
+            sync_brand_preferences
+        settled = dict(brand_preference_overrides({}, "P0"))
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.get_engagement_preferences", return_value=settled), \
+             patch(f"{_DB}.update_engagement_preferences", return_value=True), \
+             patch(f"{_BA}.log_info") as info:
+            sync_brand_preferences()
+        info.assert_not_called()
+
 
 class TestAutoSyncBrandAccount:
-    def test_no_op_when_not_configured(self):
+    def test_runs_with_no_env_configuration_at_all(self):
+        """Issue #736's whole point: the beat used to return 'not configured' every night in prod."""
         from cqc_lem.app.run_scheduler import auto_sync_brand_account
-        with patch(f"{_BA}.get_brand_user_id", return_value=None), \
-             patch(f"{_BA}.sync_brand_preferences") as sync:
-            assert auto_sync_brand_account() == "Brand account not configured"
-        sync.assert_not_called()
+        applied = {"max_comments_per_day": 8, "max_dms_per_day": 5, "max_invites_per_day": 5}
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_BA}.sync_brand_preferences", return_value=applied) as sync, \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1]):
+            result = auto_sync_brand_account()
+        sync.assert_called_once_with("P0")
+        assert result.startswith("Brand account 1 synced to phase P0")
 
     def test_syncs_and_reports_the_applied_caps(self):
         from cqc_lem.app.run_scheduler import auto_sync_brand_account
         applied = {"max_comments_per_day": 8, "max_dms_per_day": 5, "max_invites_per_day": 5}
-        with patch(f"{_BA}.get_brand_user_id", return_value=7), \
+        with patch(f"{_BA}.brand_user_id", return_value=7), \
              patch(f"{_BA}.current_launch_phase", return_value="P0"), \
              patch(f"{_BA}.sync_brand_preferences", return_value=applied) as sync, \
              patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
@@ -255,7 +383,7 @@ class TestAutoSyncBrandAccount:
     def test_warns_when_the_brand_account_is_not_active(self):
         from cqc_lem.app.run_scheduler import auto_sync_brand_account
         applied = {"max_comments_per_day": 8, "max_dms_per_day": 5, "max_invites_per_day": 5}
-        with patch(f"{_BA}.get_brand_user_id", return_value=7), \
+        with patch(f"{_BA}.brand_user_id", return_value=7), \
              patch(f"{_BA}.current_launch_phase", return_value="P0"), \
              patch(f"{_BA}.sync_brand_preferences", return_value=applied), \
              patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \
@@ -265,7 +393,7 @@ class TestAutoSyncBrandAccount:
 
     def test_reports_a_failed_sync_without_touching_the_user_list(self):
         from cqc_lem.app.run_scheduler import auto_sync_brand_account
-        with patch(f"{_BA}.get_brand_user_id", return_value=7), \
+        with patch(f"{_BA}.brand_user_id", return_value=7), \
              patch(f"{_BA}.current_launch_phase", return_value="P1"), \
              patch(f"{_BA}.sync_brand_preferences", return_value=None), \
              patch(f"{_RS}.get_active_user_ids") as actives:

--- a/tests/unit/utilities/test_marketing_attribution.py
+++ b/tests/unit/utilities/test_marketing_attribution.py
@@ -231,9 +231,18 @@ class TestSignupAndReferralUrls:
         assert out.startswith("https://lem.test/trial?")
         assert _params(out)["utm_campaign"] == "brand-profile"
 
-    def test_no_signup_url_configured_yields_nothing_to_publish(self):
+    def test_no_signup_url_falls_back_to_the_public_base(self):
+        """Issue #736: the landing page IS the signup surface, so the brand's CTA needs no extra
+        config — `BRAND_SIGNUP_URL` is an override, not a requirement."""
         from cqc_lem.utilities.marketing.attribution import signup_url
         with _Patched(_owned(signup="")):
+            out = signup_url("linkedin", "profile", "brand-profile")
+        assert out.startswith("https://app.lem.test?")
+        assert _params(out)["utm_campaign"] == "brand-profile"
+
+    def test_no_landing_page_at_all_yields_nothing_to_publish(self):
+        from cqc_lem.utilities.marketing.attribution import signup_url
+        with _Patched(_owned(public="", signup="")):
             assert signup_url("linkedin", "profile", "brand-profile") == ""
 
     def test_referral_url_shape(self):
@@ -247,8 +256,13 @@ class TestSignupAndReferralUrls:
         from cqc_lem.utilities.marketing.attribution import referral_url
         with _Patched(_owned()):
             assert referral_url(None) == ""
-        with _Patched(_owned(signup="")):
+        with _Patched(_owned(public="", signup="")):
             assert referral_url(7) == ""
+
+    def test_referral_url_falls_back_to_the_public_base(self):
+        from cqc_lem.utilities.marketing.attribution import referral_url
+        with _Patched(_owned(signup="")):
+            assert referral_url(7).startswith("https://app.lem.test?")
 
     def test_referral_code_rejects_a_non_numeric_user(self):
         from cqc_lem.utilities.marketing.attribution import referral_code


### PR DESCRIPTION
## What & why

The self-marketing engine (#504) has been **dormant in prod since it shipped** — not because of a bug, but because `BRAND_ACCOUNT_ENABLED` / `BRAND_ACCOUNT_EMAIL` were never set on the box. That pair was wiring that could only ever fail closed. Per the owner decision on #736, **user_id 1 IS the LEM brand account, permanently**, so it is now resolved by convention.

### Brand resolution
- `brand_account.brand_user_id() -> int` replaces `get_brand_user_id() -> Optional[int]`. It **never returns None**: unset, blank, non-numeric, `0` or negative `BRAND_USER_ID` all fall back to user 1, so a typo can't silently switch self-marketing off.
- `BRAND_ACCOUNT_ENABLED` / `BRAND_ACCOUNT_EMAIL` are gone from `env_constants.py`, `.env.example` and every call site, along with the email→id DB lookup. `.env.prod.example` never carried them.
- The optional override is `BRAND_USER_ID` — it costs nothing and the **default works with zero configuration**.
- `is_brand_user(user_id)` is now `int(user_id) == brand_user_id()`, and returns `False` rather than raising on a non-numeric argument.
- `auto_sync_brand_account` can no longer return `"Brand account not configured"` (which is what it returned in prod every night at 00:45); the only failure it reports now is a failed write.

### The collision guard (the one real risk)
User 1 is also the owner's **ordinary** LEM account, and the nightly sync used to *assert* the phase's caps and connect posture over anything he tuned by hand. The phase policy is now applied as a **ceiling, not an assignment**:

- `max_comments_per_day` / `max_dms_per_day` / `max_invites_per_day` are only ever pulled **down** to the phase number (`_capped`). A hand-tuned `3` survives P1's `15`; a hand-tuned `999` still clamps to `15`. `0` is honoured as a real choice; a missing or unreadable value takes the phase's.
- `connection_request_mode` / `connection_targeting_mode` are only ever **tightened** (`_strictest`, strictness order `pre_review > auto_approve` and `off > suggest > auto_queue`). An unknown saved value isn't comparable, so the phase's wins.
- Honouring a stricter value can never widen outbound, so the volume gate is intact — this only stops the sync stomping settings it doesn't own.
- Seeded content fields (`focus_topics`, `business_goals`) keep the existing fill-only-when-empty split, and only the policy fields are still sent to the upsert (the #639 abort is preserved).
- **Nothing is silent:** `preference_changes()` diffs before/after and `sync_brand_preferences` logs every field it actually changes in one INFO line (`max_dms_per_day: 20 -> 5`). A settled account logs nothing at INFO — a line that fires whether or not anything moved is not a change log. The diff normalizes string-vs-int columns so a DB `"5"` against a policy `5` isn't reported as a nightly edit.

### `BRAND_SIGNUP_URL`
Stays (it's a real content input), but is now an override rather than a requirement: `attribution.signup_landing()` falls back to `PUBLIC_BASE_URL` — the landing page *is* the signup surface (there is no `/signup` route). `signup_url()` and `referral_url()` both read it, so the brand's trial CTA also needs no extra config. Empty only when neither is set, which every caller still reads as "no CTA link to publish".

### Docs
`docs/launch-and-marketing-plan.md` §C.2 gains a "who the brand account is" paragraph and a "collision guard" block; the status table row and `docs/marketing-attribution.md`'s owned-host / verification notes are updated.

## Testing

`poetry run pytest tests/unit -q` → **7917 passed**.

New/changed coverage in `tests/unit/app/test_brand_account.py`:
- resolution with **no env at all** → user 1; explicit override honoured; parametrized unusable overrides (`nope` / `0` / `-3` / `1.5` / `None`) all fall back; `is_brand_user` across ints, strings, `None` and junk, and following the override.
- `TestOwnerTunedSettingsSurvive`: stricter cap kept, `0` kept, stricter posture kept while a looser one is tightened, unknown mode falls back, and a property check that no phase can ever be raised above its own policy.
- `TestPreferenceChanges`: only real changes reported, `"5"` vs `5` is not a change, list-valued focus topics compare by value, unset field is a change.
- sync-level: syncs user 1 with no config, does not clobber the owner's stricter caps under P2, logs every changed field with `user_id=1`, and logs no edit for a settled account.
- `test_marketing_attribution.py`: signup/referral URLs fall back to `PUBLIC_BASE_URL`; empty only when neither is configured.

Related: #659 (owner activation checklist — this removes two of its four steps), #504.

Closes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)
