### PR TITLE
docs(workflow): phased-work rule — an issue closes only when all its acceptance criteria are met

### DIFF
--- a/docs/AGENT_WORKFLOW_PLAYBOOK.md
+++ b/docs/AGENT_WORKFLOW_PLAYBOOK.md
@@ -79,6 +79,45 @@ branch `feature/claude-issue-<N>`, PR titled `…(closes #N)`, adversarial revie
 Conventions agents follow (so don't fight them in the issue): migrations are timestamp-versioned
 (`V<YYYYMMDDHHMMSS>__name.sql`), ≥80% patch coverage, all repo rules in `CLAUDE.md`.
 
+## Phased work — one phase, one issue
+
+Staged work (research → implementation, or a `2a → 2b → 2c` build order) is normal here. What is
+**not** allowed is describing a later phase only in prose inside an issue that is about to close.
+
+`Closes #N` in a PR body closes #N the instant the PR merges. GitHub does not care that the body
+said "Phase 2 lands in a follow-up PR" — the issue goes closed, drops off every `agent:ready` and
+`needs-human` query, and the remaining work becomes invisible. That is not hypothetical: **#548**
+(avatar likeness/preview/guardrails), **#568** (encrypt LinkedIn secrets at rest, passkeys) and the
+stretch half of **#647** all shipped phase one and lost the rest this way; they had to be
+re-discovered by an audit and re-filed months of pipeline-time later as #744, #745 and #746.
+
+**The rule: an issue may be closed only when ALL of its acceptance criteria are met.**
+
+### Writing a phased issue
+- Put **only the phase you want built now** in `## Acceptance`. If the later phase has real scope,
+  it belongs in its own issue, not in a paragraph.
+- If phase two genuinely can't be specified yet (it depends on what the research finds), say so in
+  `## Scope` **and** make "file the follow-up issue for phase two" an explicit acceptance box. Then
+  the phase-two issue exists before this one can honestly close.
+- Title follow-ups so the lineage is obvious: `<original title> — Phase N (follow-up of #<orig>)`,
+  quote the remaining scope from the original, and give it its own testable acceptance.
+- Label the follow-up like any other work — topicals + `agent:ready` + a `priority:*` (+ `risk:*` if
+  merge needs sign-off). An unlabeled follow-up is invisible; see the TL;DR.
+- Cross-link both ways: `Follow-up: #<new>` in the PR body, and a comment on the original issue.
+
+### When you close the first phase
+Before merging a PR that says `Closes #N`, check #N for leftovers — unchecked `- [ ]` boxes you
+didn't implement, or wording like *Phase 2 / Part 2 / next phase / deferred to / out of scope for
+this issue / stretch*. If anything remains, do one of exactly two things:
+
+1. **File the follow-up issue and link it** — then `Closes #N` is honest.
+2. **Drop `Closes #N`** — write "Remaining on #N: …" instead and leave the issue open.
+
+The pipeline enforces this at the merge gate: a PR whose closed issue declares a later phase with no
+linked follow-up is **not merged**. It gets a `🧩 phase-guard` comment, `needs-human` +
+`agent:blocked`, and the owner is assigned. Unchecked boxes alone only produce a warning comment —
+so tick the boxes you actually satisfied, and don't leave a phase living in prose.
+
 ## Decision Comments — how to answer when something waits on you
 
 When an agent parks work, it posts a comment titled **“🧑‍⚖️ Human decision needed — reply with
@@ -135,6 +174,10 @@ gh issue list --label agent:ready --state open --limit 200
 # --limit matters: gh returns only 30 rows by default, so a bare list silently misses the tail.
 gh issue list --state open --limit 200 --json number,title,labels \
   --jq '.[] | select((.labels|map(.name)) as $l | ([$l[] | select(startswith("agent:") or . == "needs-human")] | length) == 0) | "#\(.number) \(.title)"'
+
+# Closed issues that may have dropped a later phase (audit the "Phased work" rule)
+gh issue list --state closed --limit 300 --json number,title,body \
+  --jq '.[] | select((.body // "") | test("(?i)phase [2-9]|part [2-9]|next phase|follow-up (pr|issue)|deferred to")) | "#\(.number) \(.title)"'
 
 # Put an issue into the flow
 gh issue edit <N> --add-label agent:ready --add-label priority:medium

--- a/docs/AGENT_WORKFLOW_PLAYBOOK.md
+++ b/docs/AGENT_WORKFLOW_PLAYBOOK.md
@@ -88,8 +88,8 @@ Staged work (research → implementation, or a `2a → 2b → 2c` build order) i
 said "Phase 2 lands in a follow-up PR" — the issue goes closed, drops off every `agent:ready` and
 `needs-human` query, and the remaining work becomes invisible. That is not hypothetical: **#548**
 (avatar likeness/preview/guardrails), **#568** (encrypt LinkedIn secrets at rest, passkeys) and the
-stretch half of **#647** all shipped phase one and lost the rest this way; they had to be
-re-discovered by an audit and re-filed months of pipeline-time later as #744, #745 and #746.
+stretch half of **#647** all shipped phase one and lost the rest this way; none of it was noticed
+until an audit of every closed issue re-discovered it and re-filed it as #744, #745 and #746.
 
 **The rule: an issue may be closed only when ALL of its acceptance criteria are met.**
 
@@ -117,6 +117,14 @@ The pipeline enforces this at the merge gate: a PR whose closed issue declares a
 linked follow-up is **not merged**. It gets a `🧩 phase-guard` comment, `needs-human` +
 `agent:blocked`, and the owner is assigned. Unchecked boxes alone only produce a warning comment —
 so tick the boxes you actually satisfied, and don't leave a phase living in prose.
+
+Clearing the hold is a two-part manual step — the guard **strips `agent:working`**, and a PR without
+it is invisible to the merge loop no matter how you fixed the scope. So do one of the two above,
+then put the PR back in the flow:
+
+```bash
+gh pr edit <N> --add-label agent:working --remove-label needs-human --remove-label agent:blocked
+```
 
 ## Decision Comments — how to answer when something waits on you
 
@@ -175,9 +183,11 @@ gh issue list --label agent:ready --state open --limit 200
 gh issue list --state open --limit 200 --json number,title,labels \
   --jq '.[] | select((.labels|map(.name)) as $l | ([$l[] | select(startswith("agent:") or . == "needs-human")] | length) == 0) | "#\(.number) \(.title)"'
 
-# Closed issues that may have dropped a later phase (audit the "Phased work" rule)
+# Closed issues that may have dropped a later phase (audit the "Phased work" rule).
+# Markers match the merge gate's own list PLUS "stretch" — #647 lost its stretch half and says
+# nothing about a "phase", so a narrower regex reports a false all-clear on exactly that case.
 gh issue list --state closed --limit 300 --json number,title,body \
-  --jq '.[] | select((.body // "") | test("(?i)phase [2-9]|part [2-9]|next phase|follow-up (pr|issue)|deferred to")) | "#\(.number) \(.title)"'
+  --jq '.[] | select((.body // "") | test("(?i)phase [2-9]|part [2-9]|next phase|later phase|follow-up (pr|issue)|lands? in a follow-up|deferred to|out of scope for this issue|will be handled in|tracked separately|stretch")) | "#\(.number) \(.title)"'
 
 # Put an issue into the flow
 gh issue edit <N> --add-label agent:ready --add-label priority:medium


### PR DESCRIPTION
## What & why

Issue #548 was closed when its Phase 1 PR merged. The PR body said Phase 2 would land separately — GitHub closed the issue anyway, and Phase 2 was never filed, so the remaining work silently vanished. An audit of all 166 closed issues found the same failure three times:

| Original | What shipped | What was dropped | Re-filed as |
|---|---|---|---|
| #548 | Phase 1 research + the video-language fix | avatar likeness/gender attributes, preview + approval gate, guardrails, `Avatars.tsx` rework | #744 |
| #568 | Phase 1 research doc only (`docs/AUTH_SECURITY_DESIGN.md`) | 2a encryption-at-rest → 2b identity/session hardening → 2c passkeys (LinkedIn password, `li_at`, OAuth + session tokens are all still plaintext) | #745 |
| #647 | the `$ai_generation` callback | the `$ai_trace`/`$ai_span` half — `docs/llm-analytics.md` still says "tracked as the stretch half of #647", but #647 is closed | #746 |

(#406's spike recommendations were dropped the same way and are now #747.)

## What changed

`docs/AGENT_WORKFLOW_PLAYBOOK.md` — a new **"Phased work — one phase, one issue"** section documenting the rule for humans and contributors:

- An issue may be closed **only when ALL of its acceptance criteria are met**.
- How to write a phased issue: only the current phase goes in `## Acceptance`; if phase two can't be specified yet, "file the follow-up issue" becomes an explicit acceptance box.
- Follow-up naming (`<original title> — Phase N (follow-up of #<orig>)`), labeling (`agent:ready` + `priority:*` + topicals, `risk:*` where needed) and two-way cross-linking.
- When closing a first phase: either file + link the follow-up, or drop `Closes #N` and say what remains — never neither.
- A cheat-sheet query for auditing closed issues for phase markers.

## Not in this repo

The enforcement lives on the VPS runner (`/home/lem/agent-pipeline/`, not version-controlled here) and is already in place:
- `RUNBOOK.md` — a ground rule, a "Phased work" section, a scope check in `MODE=start` before the PR is opened, and an honest-close check in `MODE=selfreview`.
- `tick.sh` — `phase_guard_ok()` runs at every merge path. A PR closing an issue that declares a later phase with no linked follow-up is held: `🧩 phase-guard` comment, `needs-human` + `agent:blocked`, owner assigned. Unchecked boxes alone only warn. Fail-open on any `gh`/`jq` error, and toggleable with `PHASE_GUARD=0`.

## Testing

Docs-only change — no code paths touched. The runner-side guard was validated against live issue data (`#548`/`#568` → phase marker detected, `#421` → boxes-only warning, `#583` → clean) and with `bash -n` + a full `DRY_RUN=1` tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXo94Rk9SDo5SkuESCu1mE