### PR TITLE
docs(agent): agent lane validation for Ollama cloud lane (closes #757)

### DIFF
--- a/docs/agent-lane-validation.md
+++ b/docs/agent-lane-validation.md
@@ -1,0 +1,5 @@
+# Agent lane validation
+
+Latest LiteLLM proxy stable release version: **v1.78.5-stable** (from the GitHub releases listing at https://github.com/BerriAI/litellm/releases).
+
+This file was produced by the Ollama cloud agent lane (claude CLI → LiteLLM → Ollama cloud).


### PR DESCRIPTION
**What:** One-time validation of the Ollama cloud agent lane.

- Used the Perplexity research MCP tool to look up the latest stable LiteLLM proxy release.
- Created `docs/agent-lane-validation.md` with the result and a note identifying the Ollama cloud agent lane as the producer.

**Source:** Latest stable release shown in the LiteLLM GitHub releases listing at https://github.com/BerriAI/litellm/releases.

Closes #757

🤖 Generated with [Claude Code](https://claude.com/claude-code)