### PR TITLE
fix(observability): attribute LLM spend to serving model, add shadow cost, vendor price map (closes #752)

### DIFF
--- a/.litellm/model_prices_snapshot.json
+++ b/.litellm/model_prices_snapshot.json
@@ -1,0 +1,171 @@
+{
+  "_comment": "Committed snapshot of BerriAI/litellm model_prices_and_context_window.json plus LEM shadow-reference mappings for Ollama Cloud models. Source: https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json Fetched: 2026-07-28",
+  "models": {
+    "anthropic/claude-sonnet-4-6": {
+      "input_cost_per_token": 3e-06,
+      "output_cost_per_token": 1.5e-05,
+      "deprecation_date": null,
+      "mode": "chat"
+    },
+    "lem-complex": {
+      "input_cost_per_token": 3e-06,
+      "output_cost_per_token": 1.5e-05,
+      "mode": "chat"
+    },
+    "lem-embedding": {
+      "input_cost_per_token": 2e-08,
+      "output_cost_per_token": 0.0,
+      "mode": "embedding"
+    },
+    "lem-image": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "mode": "image_generation"
+    },
+    "lem-medium": {
+      "input_cost_per_token": 6e-07,
+      "output_cost_per_token": 2.4e-06,
+      "mode": "chat"
+    },
+    "lem-research": {
+      "input_cost_per_token": 1e-06,
+      "output_cost_per_token": 1e-06,
+      "mode": "chat"
+    },
+    "lem-router": {
+      "input_cost_per_token": 6e-07,
+      "output_cost_per_token": 2.4e-06,
+      "mode": "chat"
+    },
+    "lem-simple": {
+      "input_cost_per_token": 1.5e-07,
+      "output_cost_per_token": 6e-07,
+      "mode": "chat"
+    },
+    "lem-tts": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "mode": "audio_generation"
+    },
+    "openai/dall-e-3": {
+      "input_cost_per_token": null,
+      "output_cost_per_token": null,
+      "deprecation_date": null,
+      "mode": "image_generation"
+    },
+    "openai/deepseek-v4-flash": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o-mini"
+    },
+    "openai/deepseek-v4-pro": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o"
+    },
+    "openai/gemma4:31b": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o-mini"
+    },
+    "openai/glm-5.1": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o-mini"
+    },
+    "openai/gpt-4o": {
+      "input_cost_per_token": 2.5e-06,
+      "output_cost_per_token": 1e-05,
+      "deprecation_date": null,
+      "mode": "chat"
+    },
+    "openai/gpt-4o-mini": {
+      "input_cost_per_token": 1.5e-07,
+      "output_cost_per_token": 6e-07,
+      "deprecation_date": null,
+      "mode": "chat"
+    },
+    "openai/gpt-oss:120b": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o-mini"
+    },
+    "openai/gpt-oss:20b": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o-mini"
+    },
+    "openai/kimi-k2.5": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o"
+    },
+    "openai/kimi-k2.6": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o"
+    },
+    "openai/minimax-m2.5": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o-mini"
+    },
+    "openai/minimax-m2.7": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o-mini"
+    },
+    "openai/mistral-large-3:675b": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o"
+    },
+    "openai/qwen3.5:397b": {
+      "input_cost_per_token": 0.0,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "chat",
+      "shadow_reference": "openai/gpt-4o"
+    },
+    "openai/text-embedding-3-small": {
+      "input_cost_per_token": 2e-08,
+      "output_cost_per_token": 0.0,
+      "deprecation_date": null,
+      "mode": "embedding"
+    },
+    "openai/tts-1": {
+      "input_cost_per_token": null,
+      "output_cost_per_token": null,
+      "deprecation_date": null,
+      "mode": "audio_speech"
+    },
+    "perplexity/sonar": {
+      "input_cost_per_token": 1e-06,
+      "output_cost_per_token": 1e-06,
+      "deprecation_date": null,
+      "mode": "chat"
+    }
+  }
+}

--- a/docs/cost-performance-margin-plan.md
+++ b/docs/cost-performance-margin-plan.md
@@ -47,7 +47,7 @@ Every recurring cost, how it is incurred, and how we capture it:
 
 | # | Cost driver | Unit | Variable/Fixed | Scales with | Capture mechanism |
 |---|---|---|---|---|---|
-| 1 | **LLM inference** (OpenAI / Claude / Ollama Cloud / OpenRouter via LiteLLM) | per call (tokens) | Variable | usage volume × tier | `track_llm_call` `cost_usd` (already) + **add `user_id`, `feature`, `model_tier`** |
+| 1 | **LLM inference** (OpenAI / Claude / Ollama Cloud / OpenRouter via LiteLLM) | per call (tokens) | Variable | usage volume × tier | `track_llm_call` `cost_usd`, keyed by the **serving model** with the tier alias preserved as `model_tier`; plus `shadow_cost_usd` for subscription-priced models |
 | 2 | **Research** (Perplexity Sonar `lem-research`) | per edition/call | Variable | newsletters; comments OFF by default (`COMMENT_RESEARCH_ENABLED`) | Same `llm_call` path, `feature="research"` |
 | 3 | **Media — video** (RunwayML gen4/gen4.5/premium) | per render (sec × rate) | Variable, spiky | video posts | **New** `track_media_cost` using existing `estimate_video_cost` |
 | 4 | **Media — image** (DALL-E 3 `lem-image`) | per image | Variable | carousels/posts w/ imagery | `track_media_cost`, priced per image (add to cost table) |
@@ -462,13 +462,14 @@ Quality guardrail (must hold): cohort engagement_rate · median authenticity_sco
 
 | Risk | Mitigation |
 |---|---|
-| **Unattributed / runaway LLM spend** | Fix (1) makes all cost attributable; unattributed-spend alert; per-user ceiling |
+| **Unattributed / runaway LLM spend** | Serving-model attribution + unattributed-spend alert + per-user ceiling |
+| **Subscription traffic hides true unit cost** | `shadow_cost_usd` is tracked separately for Ollama Cloud models so the "what if we left?" decision has a number |
 | **Proxy cost linear in users** | Prefer regional egress pools (`EGRESS_AT_SCALE.md`); reserve per-user residential for users whose trust needs it; accrue + monitor |
 | **Media cost spikes** | Keep premium video credit-gated (already, `video_credit_ledger`); media reuse; spike alert |
 | **PostHog ingestion cost** | Roll high-volume LLM events into daily `cost_ledger` rollups; sample verbose events; watch our own event count |
 | **Over-aggressive cost cutting degrades engagement** | Quality gate on every auto-change; `risk:product-decision` gate; cohort-scoped + auto-rollback |
 | **Privacy of per-user cost/revenue data** | Cost/margin dashboards are internal-only; per-user financials access-controlled; never surfaced in user-facing UI |
-| **Estimated vs. actual LLM cost drift** | `estimate_llm_cost_usd` is coarse; periodically reconcile against LiteLLM/provider actuals and refresh `LLM_COST_PER_1K` |
+| **Estimated vs. actual LLM cost drift** | `estimate_llm_cost_usd` now derives from `.litellm/model_prices_snapshot.json`; refresh the snapshot periodically and override via `LLM_COST_PER_1K` if needed |
 
 ---
 

--- a/docs/llm-analytics.md
+++ b/docs/llm-analytics.md
@@ -64,18 +64,32 @@ product decision, not a default.
 
 ## De-dupe: which stream answers which question
 
-Both streams fire on every call. **Never sum spend across them.**
+Three streams fire around every call. **Never sum spend or token counts across them.**
 
 | | `llm_call` (app, `observability.track_llm_call`) | `$ai_generation` (proxy) |
 |---|---|---|
 | Cost | LEM's *estimate* from `estimate_llm_cost_usd`, zeroed on a cache hit | the provider's own `response_cost` |
-| Model | the tier alias the caller asked for (`model`, plus `model_tier`) | the provider model that served it |
+| Model | the **serving model** LiteLLM actually ran (`model`), with the requested tier alias preserved as `model_tier` | the provider model that served it |
 | Feeds | `cost_ledger` rollups, the margin report, budget alerts (§C/§E of the margin plan) | PostHog's LLM-analytics product: generations, traces, per-model/user breakdowns, evals |
 | Use for | anything a dollar figure is reported from | latency, error rate, model mix, per-user/feature volume |
 
 Rule of thumb: **money questions use `llm_call`** (it is the ledger's source and joins to Stripe);
 **everything else uses `$ai_generation`** (it is the truth about what ran). An insight must pick one
 — a "total LLM spend" chart that unions both double-counts every call.
+
+### The third stream: `shadow_cost_usd`
+
+For subscription-priced models (Ollama Cloud), the real marginal cost is $0, so both `cost_usd`
+and `$ai_total_cost_usd` read $0. That is correct for today's bill, but it hides what the same
+usage would cost if LEM left the subscription. `llm_call` therefore carries a separate
+`shadow_cost_usd` property for those models — a hand-picked metered reference price documented in
+`.litellm/model_prices_snapshot.json`.
+
+| Stream | What it answers | Do NOT use it for |
+|---|---|---|
+| `cost_usd` (`llm_call`) | What LEM's ledger/margin report books today | summing with `shadow_cost_usd` — they're different decisions |
+| `$ai_total_cost_usd` (`$ai_generation`) | The provider's actual metered charge (often $0 for Ollama Cloud) | the "what if we left?" question |
+| `shadow_cost_usd` (`llm_call`) | What the same tokens would cost at a metered reference | billing or the margin report |
 
 Caveat worth knowing when the two are compared: a LiteLLM **cache hit** still emits
 `$ai_generation`, at `$ai_total_cost_usd` 0 like `llm_call`'s `cached` path, but its

--- a/poetry.lock
+++ b/poetry.lock
@@ -989,7 +989,7 @@ files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\" or platform_system == \"Windows\"", dev = "sys_platform == \"win32\"", mcp = "sys_platform != \"emscripten\" and platform_system == \"Windows\"", streamlit = "platform_system == \"Windows\"", test = "sys_platform == \"win32\""}
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\"", mcp = "sys_platform != \"emscripten\" and platform_system == \"Windows\"", streamlit = "platform_system == \"Windows\"", test = "sys_platform == \"win32\""}
 
 [[package]]
 name = "comm"

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -65,12 +65,33 @@ def _attach_routing_metadata(kwargs: dict, user_id, feature) -> None:
     extra_body["metadata"] = attribution_metadata(user_id, feature)
 
 
+def _resolve_serving_model(response, requested_model: str) -> str:
+    """The model LiteLLM actually served the call with, after routing/fallback/down-routing.
+
+    LiteLLM returns the deployed model id in `response.model` (OpenAI SDK shape) or inside
+    `_hidden_params.model` / `_hidden_params.model_id`. When neither is present, the requested
+    alias is the best fallback — spend is then priced by the tier the caller asked for."""
+    if response is None:
+        return requested_model
+    serving = getattr(response, "model", None)
+    if serving:
+        return str(serving)
+    hidden = getattr(response, "_hidden_params", None) or {}
+    for key in ("model", "model_id"):
+        val = hidden.get(key)
+        if val:
+            return str(val)
+    return requested_model
+
+
 def _call_llm(**kwargs):
     """Thin wrapper around client.chat.completions.create that logs model, latency, and token usage.
 
     Cost attribution: pass `_track_user_id` / `_track_feature` to say who and what this call is for —
     both are popped before the LiteLLM call. Omitted values fall back to the ambient
-    `llm_attribution()` scope, then to the running Celery task's name."""
+    `llm_attribution()` scope, then to the running Celery task's name. The serving model (what
+    LiteLLM actually ran) is captured from the response and passed to `track_llm_call` separately
+    from the requested tier alias, so fallback/down-routed calls price by the real model."""
     track_user_id = kwargs.pop("_track_user_id", None)
     track_feature = kwargs.pop("_track_feature", None)
     model = kwargs.get("model", "unknown")
@@ -95,9 +116,12 @@ def _call_llm(**kwargs):
         usage = getattr(response, "usage", None)
         prompt_tokens = int(getattr(usage, "prompt_tokens", 0) or 0) if usage else 0
         completion_tokens = int(getattr(usage, "completion_tokens", 0) or 0) if usage else 0
+        serving_model = _resolve_serving_model(response, model)
         log_debug(
-            f"LLM call completed in {duration_ms}ms — {prompt_tokens}+{completion_tokens} tokens",
-            ai_model=model,
+            f"LLM call completed in {duration_ms}ms — {prompt_tokens}+{completion_tokens} tokens"
+            f" (serving: {serving_model})",
+            ai_model=serving_model,
+            model_tier=model,
             duration_ms=duration_ms,
         )
         try:
@@ -105,6 +129,8 @@ def _call_llm(**kwargs):
             user_id, feature = _attribution()
             track_llm_call(
                 model=model,
+                serving_model=serving_model,
+                model_tier=model,
                 prompt_tokens=prompt_tokens,
                 completion_tokens=completion_tokens,
                 latency_ms=duration_ms,

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -53,10 +53,12 @@ posthog.enable_exception_autocapture = EXCEPTION_AUTOCAPTURE_ENABLED
 _SESSION_ID_RE = re.compile(r"[A-Za-z0-9._-]{8,64}")
 
 
-# Approximate USD cost per 1K tokens as (input, output), keyed by the model string passed to
-# track_llm_call — the tier alias (lem-*) in normal operation, or a raw model name. These are
-# coarse blended estimates for cost TREND analytics, not billing; override any entry with the
-# LLM_COST_PER_1K env var (JSON: {"lem-complex": [0.003, 0.015], ...}).
+# Approximate USD cost per 1K tokens as (input, output). Sources, in precedence order:
+#   1. LLM_COST_PER_1K env var (JSON override)
+#   2. .litellm/model_prices_snapshot.json (vendored LiteLLM map + LEM shadow references)
+#   3. Hardcoded tier-alias fallbacks below for models absent from the map.
+# The vendored map is keyed by the SERVING model LiteLLM returns (e.g. openai/gpt-4o-mini),
+# not the lem-* tier alias, so fallback/down-routed calls are priced by the model that actually ran.
 _DEFAULT_COST_PER_1K = {
     "lem-simple": (0.00015, 0.00060),
     "lem-medium": (0.00060, 0.00240),
@@ -66,6 +68,11 @@ _DEFAULT_COST_PER_1K = {
     "lem-image": (0.0, 0.0),
 }
 
+_LLM_PRICE_SNAPSHOT_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))),
+    ".litellm", "model_prices_snapshot.json"
+)
+
 
 # Cache the parsed cost table keyed by the raw LLM_COST_PER_1K value so track_llm_call() — which
 # runs on every LLM invocation — doesn't reparse the JSON each call. Rebuilt only when the env var
@@ -73,6 +80,25 @@ _DEFAULT_COST_PER_1K = {
 _UNSET = object()
 _cost_table_cache: Optional[dict] = None
 _cost_table_raw = _UNSET
+_vendored_specs_cache: Optional[dict] = None
+
+
+def _vendored_specs() -> dict:
+    """The vendored price map as {model_id: spec_dict}, or {} when the snapshot is missing.
+
+    The map contains both LiteLLM's metered prices and LEM's hand-picked shadow references for
+    subscription-only models (Ollama Cloud). It is read once per process; a missing file is not
+    fatal — the hardcoded tier fallbacks take over."""
+    global _vendored_specs_cache
+    if _vendored_specs_cache is not None:
+        return _vendored_specs_cache
+    try:
+        with open(_LLM_PRICE_SNAPSHOT_PATH, "r", encoding="utf-8") as fh:
+            doc = json.load(fh)
+        _vendored_specs_cache = dict((doc or {}).get("models") or {})
+    except Exception:
+        _vendored_specs_cache = {}
+    return _vendored_specs_cache
 
 
 def _cost_table() -> dict:
@@ -80,7 +106,22 @@ def _cost_table() -> dict:
     raw = os.getenv("LLM_COST_PER_1K")
     if _cost_table_cache is not None and raw == _cost_table_raw:
         return _cost_table_cache
-    table = dict(_DEFAULT_COST_PER_1K)
+    # Start with vendored map (serving models), then overlay the legacy tier-alias fallbacks.
+    table: dict = {}
+    for model_id, spec in _vendored_specs().items():
+        inp = spec.get("input_cost_per_token")
+        out = spec.get("output_cost_per_token")
+        if inp is None or out is None:
+            continue
+        rates = (float(inp) * 1000.0, float(out) * 1000.0)
+        table[model_id] = rates
+        # Also index by the bare model name so a LiteLLM response like "gpt-oss:20b" resolves when
+        # the snapshot key is "openai/gpt-oss:20b".
+        if "/" in model_id:
+            bare = model_id.split("/", 1)[1]
+            if bare and bare not in table:
+                table[bare] = rates
+    table.update(_DEFAULT_COST_PER_1K)
     if raw:
         try:
             for key, val in json.loads(raw).items():
@@ -95,9 +136,10 @@ def _cost_table() -> dict:
 
 
 def estimate_llm_cost_usd(model: str, prompt_tokens: int, completion_tokens: int) -> float:
-    """Coarse USD cost estimate for a completion from a per-1K-token price table (env-overridable
-    via LLM_COST_PER_1K). Unknown models fall back to a substring match then the lem-medium rate so
-    a real call's cost signal is never silently zero. Returns 0.0 when there are no tokens."""
+    """Coarse USD cost estimate for a completion from the per-1K-token table. The serving model
+    (what LiteLLM actually ran) is looked up first; unknown serving models fall back to a substring
+    match and then the lem-medium rate so a real call's cost signal is never silently zero.
+    Returns 0.0 when there are no tokens."""
     prompt = int(prompt_tokens or 0)
     completion = int(completion_tokens or 0)
     if not prompt and not completion:
@@ -105,11 +147,51 @@ def estimate_llm_cost_usd(model: str, prompt_tokens: int, completion_tokens: int
     table = _cost_table()
     rates = table.get(model)
     if rates is None:
-        key = next((k for k in table if k != "lem-image" and k in (model or "")), None)
+        key = next((k for k in table if k != "lem-image" and (k in (model or "") or
+                    ((model or "").endswith(k) if "/" in k else False))), None)
         rates = table[key] if key else table["lem-medium"]
     # No rounding: a few prompt tokens on a cheap tier round to 0.0 at 6dp, which would erase the
     # non-zero cost signal for real calls. PostHog handles display rounding.
     return (prompt / 1000.0) * rates[0] + (completion / 1000.0) * rates[1]
+
+
+def estimate_shadow_cost_usd(model: str, prompt_tokens: int, completion_tokens: int) -> Optional[float]:
+    """Shadow cost for subscription/zero-priced traffic.
+
+    For models whose own LiteLLM price is 0.0 (Ollama Cloud on a flat-rate subscription), this returns
+    what the same tokens would cost at the hand-picked metered reference documented in
+    .litellm/model_prices_snapshot.json. For already-metered models it returns None — shadow cost
+    is only meaningful where the real marginal cost is hidden by a subscription.
+    """
+    prompt = int(prompt_tokens or 0)
+    completion = int(completion_tokens or 0)
+    if not prompt and not completion:
+        return None
+    specs = _vendored_specs()
+    spec = specs.get(model)
+    if spec is None and "/" in (model or ""):
+        bare = model.split("/", 1)[1]
+        spec = specs.get(bare)
+    if not spec:
+        return None
+    own_in = spec.get("input_cost_per_token")
+    own_out = spec.get("output_cost_per_token")
+    if own_in is not None and own_out is not None and (float(own_in) > 0 or float(own_out) > 0):
+        # Already metered — no shadow needed.
+        return None
+    shadow_ref = spec.get("shadow_reference")
+    if not shadow_ref:
+        return None
+    shadow_spec = specs.get(shadow_ref)
+    if shadow_spec is None and "/" in shadow_ref:
+        shadow_spec = specs.get(shadow_ref.split("/", 1)[1])
+    if not shadow_spec:
+        return None
+    ref_in = shadow_spec.get("input_cost_per_token")
+    ref_out = shadow_spec.get("output_cost_per_token")
+    if ref_in is None or ref_out is None:
+        return None
+    return prompt * float(ref_in) + completion * float(ref_out)
 
 
 def _extract_token_usage(result) -> Tuple[int, int]:
@@ -298,29 +380,44 @@ def track_llm_call(
     feature: Optional[str] = None,
     model_tier: Optional[str] = None,
     cached: bool = False,
+    serving_model: Optional[str] = None,
 ) -> None:
-    cost_usd = 0.0 if cached else estimate_llm_cost_usd(model, prompt_tokens, completion_tokens)
+    """Emit one `llm_call` event and accrue spend to the daily cost rollup.
+
+    `model` is the requested tier alias (or raw model) for backward compatibility.
+    `serving_model`, when provided, is the model LiteLLM actually ran — including after fallback
+    or cost-aware down-routing. Spend is priced by the SERVING model so a fallback to a paid
+    provider is visible in the ledger. The requested alias is preserved as `model_tier` so
+    per-tier reporting survives."""
+    resolved_model = serving_model or model
     tier = model_tier or _model_tier(model)
+    cost_usd = 0.0 if cached else estimate_llm_cost_usd(resolved_model, prompt_tokens, completion_tokens)
+    shadow_cost_usd = None if cached else estimate_shadow_cost_usd(resolved_model, prompt_tokens, completion_tokens)
+    properties = {
+        "model": resolved_model,
+        "prompt_tokens": prompt_tokens,
+        "completion_tokens": completion_tokens,
+        "total_tokens": prompt_tokens + completion_tokens,
+        # A cache hit never reached the provider, so it cost nothing — keeping it at the
+        # estimated rate would inflate summed spend on every repeated prompt.
+        "cost_usd": cost_usd,
+        "latency_ms": latency_ms,
+        "success": success,
+        "user_id": user_id,
+        # Floor the bucket here, not just in the callers: a PostHog breakdown on `feature`
+        # needs every llm_call to carry one, including direct calls that omit it.
+        "feature": feature or FEATURE_SYSTEM,
+        "model_tier": tier,
+        "cached": bool(cached),
+    }
+    if shadow_cost_usd is not None:
+        # Shadow cost is a separate decision signal: what the same call would cost if the
+        # subscription model were billed at the metered reference. It never enters cost_usd.
+        properties["shadow_cost_usd"] = shadow_cost_usd
     posthog.capture(
         distinct_id=str(user_id or "system"),
         event="llm_call",
-        properties={
-            "model": model,
-            "prompt_tokens": prompt_tokens,
-            "completion_tokens": completion_tokens,
-            "total_tokens": prompt_tokens + completion_tokens,
-            # A cache hit never reached the provider, so it cost nothing — keeping it at the
-            # estimated rate would inflate summed spend on every repeated prompt.
-            "cost_usd": cost_usd,
-            "latency_ms": latency_ms,
-            "success": success,
-            "user_id": user_id,
-            # Floor the bucket here, not just in the callers: a PostHog breakdown on `feature`
-            # needs every llm_call to carry one, including direct calls that omit it.
-            "feature": feature or FEATURE_SYSTEM,
-            "model_tier": tier,
-            "cached": bool(cached),
-        },
+        properties=properties,
     )
     # One ledger row per call would grow unbounded at LEM's call volume, so spend accumulates in a
     # per-day Redis bucket that the daily rollup task collapses into cost_ledger rows.

--- a/tests/unit/utilities/ai/test_llm_cost_attribution.py
+++ b/tests/unit/utilities/ai/test_llm_cost_attribution.py
@@ -95,3 +95,83 @@ class TestCallLlmAttribution:
         with patch(f"{_AI}.client", client), \
              patch(f"{_OBS}.track_llm_call", side_effect=RuntimeError("posthog down")):
             assert _call_llm(model="lem-simple", messages=[]) is not None
+
+
+class TestServingModelCapture:
+    def test_serving_model_from_response_model_is_passed_to_tracker(self):
+        resp = SimpleNamespace(
+            usage=SimpleNamespace(prompt_tokens=30, completion_tokens=70),
+            model="openai/gpt-4o-mini",
+        )
+        _, track = _call(model="lem-simple", messages=[], _response=resp)
+
+        kwargs = track.call_args[1]
+        assert kwargs["serving_model"] == "openai/gpt-4o-mini"
+        assert kwargs["model_tier"] == "lem-simple"
+        assert kwargs["model"] == "lem-simple"  # requested alias
+
+    def test_serving_model_from_hidden_params_when_response_model_missing(self):
+        resp = SimpleNamespace(
+            usage=SimpleNamespace(prompt_tokens=30, completion_tokens=70),
+            _hidden_params={"model": "openai/gpt-4o"},
+        )
+        _, track = _call(model="lem-complex", messages=[], _response=resp)
+
+        kwargs = track.call_args[1]
+        assert kwargs["serving_model"] == "openai/gpt-4o"
+
+    def test_down_routed_call_passes_serving_model_separate_from_tier(self):
+        """A lem-complex call that fell back to gpt-4o-mini still reports the original tier."""
+        resp = SimpleNamespace(
+            usage=SimpleNamespace(prompt_tokens=30, completion_tokens=70),
+            model="openai/gpt-4o-mini",
+        )
+        _, track = _call(model="lem-complex", messages=[], _response=resp)
+
+        kwargs = track.call_args[1]
+        assert kwargs["serving_model"] == "openai/gpt-4o-mini"
+        assert kwargs["model_tier"] == "lem-complex"
+
+    def test_ollama_serving_model_is_passed_to_tracker(self):
+        resp = SimpleNamespace(
+            usage=SimpleNamespace(prompt_tokens=30, completion_tokens=70),
+            model="openai/qwen3.5:397b",
+        )
+        _, track = _call(model="lem-complex", messages=[], _response=resp)
+
+        kwargs = track.call_args[1]
+        assert kwargs["serving_model"] == "openai/qwen3.5:397b"
+        assert kwargs["model_tier"] == "lem-complex"
+
+    def test_bare_ollama_model_name_is_passed_to_tracker(self):
+        resp = SimpleNamespace(
+            usage=SimpleNamespace(prompt_tokens=30, completion_tokens=70),
+            model="qwen3.5:397b",
+        )
+        _, track = _call(model="lem-complex", messages=[], _response=resp)
+
+        kwargs = track.call_args[1]
+        assert kwargs["serving_model"] == "qwen3.5:397b"
+
+    def test_serving_model_missing_falls_back_to_requested_alias(self):
+        resp = SimpleNamespace(usage=SimpleNamespace(prompt_tokens=30, completion_tokens=70))
+        _, track = _call(model="lem-simple", messages=[], _response=resp)
+
+        kwargs = track.call_args[1]
+        assert kwargs["serving_model"] == "lem-simple"
+        assert kwargs["model_tier"] == "lem-simple"
+
+    def test_failed_call_reports_requested_alias_as_serving_model(self):
+        from cqc_lem.utilities.ai.ai_helper import _call_llm
+        client = MagicMock()
+        client.chat.completions.create.side_effect = RuntimeError("provider down")
+        with patch(f"{_AI}.client", client), patch(f"{_OBS}.track_llm_call") as track:
+            with pytest.raises(RuntimeError):
+                _call_llm(model="lem-complex", messages=[], _track_user_id=8)
+
+        kwargs = track.call_args[1]
+        assert kwargs["model"] == "lem-complex"
+        # On failure there is no response to extract a serving model from; the function
+        # intentionally passes the requested alias as the model argument so cost attribution
+        # falls back to the tier rate.
+        assert kwargs.get("serving_model", kwargs["model"]) == "lem-complex"

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -267,6 +267,58 @@ class TestEstimateLlmCost:
         assert cost > 0.0
         assert cost == pytest.approx(3 / 1000.0 * 0.00015)
 
+    def test_vendored_map_prices_by_serving_model(self):
+        from cqc_lem.utilities.observability import estimate_llm_cost_usd
+        # openai/gpt-4o-mini from the vendored LiteLLM map: 1.5e-7 in / 6e-7 out per token.
+        assert estimate_llm_cost_usd("openai/gpt-4o-mini", 1000, 1000) == pytest.approx(0.00075)
+
+    def test_bare_serving_model_name_resolves_via_vendored_map(self):
+        from cqc_lem.utilities.observability import estimate_llm_cost_usd
+        # LiteLLM may return just "gpt-4o-mini"; the snapshot is keyed by "openai/gpt-4o-mini".
+        assert estimate_llm_cost_usd("gpt-4o-mini", 1000, 1000) == pytest.approx(0.00075)
+
+    def test_ollama_serving_model_is_zero_marginal_cost(self):
+        from cqc_lem.utilities.observability import estimate_llm_cost_usd
+        assert estimate_llm_cost_usd("openai/qwen3.5:397b", 1000, 1000) == 0.0
+
+    def test_map_miss_falls_back_to_legacy_tier_alias(self):
+        from cqc_lem.utilities.observability import estimate_llm_cost_usd
+        # An unknown serving model that contains a tier alias substring still resolves.
+        assert estimate_llm_cost_usd("openai/lem-simple-v2", 1000, 0) == pytest.approx(0.00015)
+
+    def test_env_override_takes_precedence_over_vendored_map(self):
+        with patch.dict("os.environ", {"LLM_COST_PER_1K": '{"openai/gpt-4o-mini": [1.0, 2.0]}'}):
+            from cqc_lem.utilities.observability import estimate_llm_cost_usd
+            assert estimate_llm_cost_usd("openai/gpt-4o-mini", 1000, 1000) == pytest.approx(3.0)
+
+
+class TestEstimateShadowCost:
+    def test_zero_tokens_no_shadow(self):
+        from cqc_lem.utilities.observability import estimate_shadow_cost_usd
+        assert estimate_shadow_cost_usd("openai/qwen3.5:397b", 0, 0) is None
+
+    def test_ollama_model_emits_shadow_at_reference(self):
+        from cqc_lem.utilities.observability import estimate_shadow_cost_usd
+        # qwen3.5:397b maps to openai/gpt-4o as the hand-picked metered reference.
+        assert estimate_shadow_cost_usd("openai/qwen3.5:397b", 1000, 1000) == pytest.approx(0.0125)
+
+    def test_small_ollama_model_emits_shadow_at_cheaper_reference(self):
+        from cqc_lem.utilities.observability import estimate_shadow_cost_usd
+        # gpt-oss:20b maps to openai/gpt-4o-mini.
+        assert estimate_shadow_cost_usd("openai/gpt-oss:20b", 1000, 1000) == pytest.approx(0.00075)
+
+    def test_metered_model_has_no_shadow(self):
+        from cqc_lem.utilities.observability import estimate_shadow_cost_usd
+        assert estimate_shadow_cost_usd("openai/gpt-4o-mini", 1000, 1000) is None
+
+    def test_tier_alias_has_no_shadow(self):
+        from cqc_lem.utilities.observability import estimate_shadow_cost_usd
+        assert estimate_shadow_cost_usd("lem-simple", 1000, 1000) is None
+
+    def test_unknown_model_has_no_shadow(self):
+        from cqc_lem.utilities.observability import estimate_shadow_cost_usd
+        assert estimate_shadow_cost_usd("some-unknown", 1000, 1000) is None
+
 
 class TestTrackPrePostEngagement:
     def test_captures_pre_post_engagement_event(self):
@@ -385,6 +437,91 @@ class TestCostAttributionDimensions:
         assert llm_cache_hit(SimpleNamespace(_hidden_params={"cache_hit": True})) is True
         assert llm_cache_hit(SimpleNamespace(_hidden_params={"cache_hit": False})) is False
         assert llm_cache_hit(SimpleNamespace()) is False
+
+    def test_serving_model_prices_cost_and_preserves_tier(self):
+        with patch(f"{_MOD}.posthog") as mock_ph, patch(f"{_MOD}._accrue_llm_cost") as accrue:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(
+                model="lem-simple",
+                serving_model="openai/gpt-4o-mini",
+                prompt_tokens=1000,
+                completion_tokens=1000,
+                latency_ms=100,
+                user_id=7,
+                feature="content",
+            )
+
+        props = mock_ph.capture.call_args[1]["properties"]
+        assert props["model"] == "openai/gpt-4o-mini"  # serving model is the event model
+        assert props["model_tier"] == "lem-simple"      # requested alias preserved
+        # Cost priced by serving model, not the lem-simple fallback.
+        assert props["cost_usd"] == pytest.approx(0.00075)
+        # Accrual is keyed by the tier alias (model_tier) and passes only cost_usd.
+        usd, tokens, user_id, feature, model_tier = accrue.call_args[0]
+        assert model_tier == "lem-simple"
+        assert usd == pytest.approx(0.00075)
+
+    def test_down_routed_call_to_metered_provider_changes_cost(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(
+                model="lem-complex",
+                serving_model="openai/gpt-4o-mini",
+                prompt_tokens=1000,
+                completion_tokens=1000,
+                latency_ms=100,
+            )
+
+        props = mock_ph.capture.call_args[1]["properties"]
+        assert props["model_tier"] == "lem-complex"
+        assert props["cost_usd"] == pytest.approx(0.00075)
+
+    def test_ollama_serving_model_emits_shadow_cost(self):
+        with patch(f"{_MOD}.posthog") as mock_ph, patch(f"{_MOD}._accrue_llm_cost") as accrue:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(
+                model="lem-complex",
+                serving_model="openai/qwen3.5:397b",
+                prompt_tokens=1000,
+                completion_tokens=1000,
+                latency_ms=100,
+            )
+
+        props = mock_ph.capture.call_args[1]["properties"]
+        assert props["model"] == "openai/qwen3.5:397b"
+        assert props["cost_usd"] == 0.0
+        assert props["shadow_cost_usd"] == pytest.approx(0.0125)
+        # Shadow cost never enters the durable ledger.
+        usd = accrue.call_args[0][0]
+        assert usd == 0.0
+
+    def test_cache_hit_zeroes_cost_and_shadow(self):
+        with patch(f"{_MOD}.posthog") as mock_ph, patch(f"{_MOD}._accrue_llm_cost") as accrue:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(
+                model="lem-complex",
+                serving_model="openai/qwen3.5:397b",
+                prompt_tokens=1000,
+                completion_tokens=1000,
+                latency_ms=100,
+                cached=True,
+            )
+
+        props = mock_ph.capture.call_args[1]["properties"]
+        assert props["cost_usd"] == 0.0
+        assert "shadow_cost_usd" not in props
+        assert accrue.call_args[0][0] == 0.0
+
+    def test_no_serving_model_uses_requested_alias(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_llm_call
+            track_llm_call(model="lem-simple", prompt_tokens=1000, completion_tokens=1000,
+                           latency_ms=10)
+
+        props = mock_ph.capture.call_args[1]["properties"]
+        assert props["model"] == "lem-simple"
+        assert props["model_tier"] == "lem-simple"
+        assert props["cost_usd"] == pytest.approx(0.00075)
 
 
 class TestFeatureFromTaskName:


### PR DESCRIPTION
## What & why
Issue #752 found that LEM's LLM cost attribution was booked against the requested tier alias (e.g. ) rather than the model LiteLLM actually served after fallback or cost-aware down-routing, and that Ollama Cloud subscription traffic reported $0 with no shadow cost for the "what if we left?" decision.

This PR:
- Captures the serving model from  /  in  and passes it to  as , while preserving the requested alias as .
- Prices  by the serving model via a vendored  (LiteLLM price map + LEM shadow references), with legacy tier aliases as fallback.
- Emits  for subscription-only Ollama Cloud models, explicitly keeping it out of .
- Adds  and updates  to use the snapshot.
- Updates  and  to document the three cost streams (real marginal / booked / shadow) and which decision each supports.

## Testing
-  — 150 passed.
- New tests cover serving-model extraction (response.model, hidden params, fallback, down-routed), shadow-cost computation, map-miss fallback, and a proof that  never lands in .

Closes #752

🤖 Generated with [Claude Code](https://claude.com/claude-code)