### PR TITLE
feat(automation): alert on newsletter publish None path with failed step (closes #747)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1584,18 +1584,24 @@ def _fill_edition_description(driver, wait, subtitle: str) -> bool:
         return False
 
 
-def _fill_and_publish_article(driver, wait, title: str, body: str, subtitle: str = None) -> "str | None":
+def _fill_and_publish_article(driver, wait, title: str, body: str, subtitle: str = None) -> "tuple[str | None, str | None]":
     """Fill LinkedIn's article editor (title textarea + contenteditable body) and run the
     Next → Publish flow. On the publish dialog, best-effort fills the edition description with
-    `subtitle`. Returns the published article URL, or None. Best-effort — the multi-step publish
-    dialog varies, so this is validated on a supervised first real run."""
+    `subtitle`.
+
+    Best-effort — the multi-step publish dialog varies, so this is validated on a supervised first
+    real run. Returns `(published_url, None)` on success, or `(None, failed_step)` on failure,
+    where `failed_step` names the selector/action that could not be completed so callers can log an
+    actionable error instead of a silent "did not complete"."""
     title_el = find_first(driver, wait, [(By.CSS_SELECTOR, "textarea[placeholder='Title']")],
                           "Article title", required=False)
+    if title_el is None:
+        return (None, "article_title")
     body_el = find_first(driver, wait, [(By.CSS_SELECTOR, "div[role='textbox'][aria-label*='Article editor']"),
                                         (By.CSS_SELECTOR, "div[role='textbox']")],
                          "Article body", visible_only=True, required=False)
-    if title_el is None or body_el is None:
-        return None
+    if body_el is None:
+        return (None, "article_body")
     title_el.click()
     title_el.send_keys(_strip_non_bmp(title))
     time.sleep(random.uniform(1, 2))
@@ -1604,14 +1610,14 @@ def _fill_and_publish_article(driver, wait, title: str, body: str, subtitle: str
     time.sleep(random.uniform(2, 3))
     if click_first(driver, wait, [(By.XPATH, "//button[normalize-space()='Next']")],
                    "Article Next", required=False) is None:
-        return None
+        return (None, "article_next")
     time.sleep(random.uniform(2, 4))
     _fill_edition_description(driver, wait, subtitle)   # best-effort; never blocks publishing
     if click_first(driver, wait, [(By.XPATH, "//button[normalize-space()='Publish']")],
                    "Article Publish", required=False) is None:
-        return None
+        return (None, "article_publish")
     time.sleep(random.uniform(4, 7))
-    return driver.current_url
+    return (driver.current_url, None)
 
 
 def _tagged_edition_body(body: str, edition_id: "int | None" = None) -> str:
@@ -1650,13 +1656,15 @@ def auto_publish_newsletter_edition(self, user_id: int):
             return "No newsletter edition generated"
         driver.get("https://www.linkedin.com/article/new/")
         time.sleep(random.uniform(6, 9))
-        url = _fill_and_publish_article(driver, wait, edition["title"],
-                                        _tagged_edition_body(edition["body"]),
-                                        subtitle=edition.get("subtitle"))
+        url, failed_step = _fill_and_publish_article(driver, wait, edition["title"],
+                                                      _tagged_edition_body(edition["body"]),
+                                                      subtitle=edition.get("subtitle"))
         if url:
             mark_newsletter_published(user_id, url)
             myprint(f"Published newsletter edition for user {user_id}: {edition['title']}")
             return f"Published newsletter: {edition['title']}"
+        log_error("Newsletter publish flow did not complete",
+                  user_id=user_id, task_name="auto_publish_newsletter_edition", failed_step=failed_step)
         return "Newsletter publish flow did not complete"
     except Exception as e:
         log_error("Newsletter publish error", exc=e, user_id=user_id, task_name="auto_publish_newsletter_edition")
@@ -1683,13 +1691,15 @@ def auto_publish_edition(self, edition_id: int):
     try:
         driver.get("https://www.linkedin.com/article/new/")
         time.sleep(random.uniform(6, 9))
-        url = _fill_and_publish_article(driver, wait, edition["title"],
-                                        _tagged_edition_body(edition["body"], edition_id),
-                                        subtitle=edition.get("subtitle"))
+        url, failed_step = _fill_and_publish_article(driver, wait, edition["title"],
+                                                      _tagged_edition_body(edition["body"], edition_id),
+                                                      subtitle=edition.get("subtitle"))
         if url:
             mark_edition_published(edition_id, url)
             myprint(f"Published newsletter edition {edition_id} for user {user_id}: {edition['title']}")
             return f"Published newsletter edition: {edition['title']}"
+        log_error("Newsletter edition publish flow did not complete",
+                  user_id=user_id, task_name="auto_publish_edition", edition_id=edition_id, failed_step=failed_step)
         mark_edition_failed(edition_id)
         return "Newsletter edition publish flow did not complete"
     except Exception as e:

--- a/tests/unit/app/test_newsletter_publish.py
+++ b/tests/unit/app/test_newsletter_publish.py
@@ -31,7 +31,7 @@ class TestAutoPublishNewsletterEdition:
         with patch(f"{_RA}.get_newsletter_settings", return_value={"enabled": True, "topic": "reach", "align_with_blog": False}), \
              patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
              patch(f"{_RA}.generate_newsletter_edition", return_value=edition), \
-             patch(f"{_RA}._fill_and_publish_article", return_value="https://x/pulse/5-levers") as fill, \
+             patch(f"{_RA}._fill_and_publish_article", return_value=("https://x/pulse/5-levers", None)) as fill, \
              patch(f"{_RA}.mark_newsletter_published") as mark, \
              patch(f"{_RA}.quit_gracefully"):
             result = auto_publish_newsletter_edition.run(user_id=1)
@@ -82,7 +82,7 @@ class TestAutoPublishEdition:
                    "subtitle": "The reach levers.", "body": "Hook\n\nSECTION\n\nBody."}
         with patch(f"{_RA}.get_newsletter_edition", return_value=edition), \
              patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
-             patch(f"{_RA}._fill_and_publish_article", return_value="https://x/pulse/5-levers") as fill, \
+             patch(f"{_RA}._fill_and_publish_article", return_value=("https://x/pulse/5-levers", None)) as fill, \
              patch(f"{_RA}.mark_edition_published") as mark, \
              patch(f"{_RA}.mark_edition_failed") as fail, \
              patch(f"{_RA}.quit_gracefully"):
@@ -97,13 +97,37 @@ class TestAutoPublishEdition:
         edition = {"id": 9, "user_id": 1, "status": "draft", "title": "T", "subtitle": None, "body": "B"}
         with patch(f"{_RA}.get_newsletter_edition", return_value=edition), \
              patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
-             patch(f"{_RA}._fill_and_publish_article", return_value=None), \
+             patch(f"{_RA}._fill_and_publish_article", return_value=(None, "article_publish")), \
              patch(f"{_RA}.mark_edition_published") as mark, \
              patch(f"{_RA}.mark_edition_failed") as fail, \
+             patch(f"{_RA}.log_error") as log_err, \
              patch(f"{_RA}.quit_gracefully"):
             result = auto_publish_edition.run(edition_id=9)
         mark.assert_not_called()
         fail.assert_called_once_with(9)
+        log_err.assert_called_once()
+        assert log_err.call_args.kwargs.get("user_id") == 1
+        assert log_err.call_args.kwargs.get("task_name") == "auto_publish_edition"
+        assert log_err.call_args.kwargs.get("edition_id") == 9
+        assert log_err.call_args.kwargs.get("failed_step") == "article_publish"
+        assert "did not complete" in result
+
+    def test_logs_error_when_flow_incomplete_for_generated_edition(self):
+        from cqc_lem.app.run_automation import auto_publish_newsletter_edition
+        edition = {"title": "5 Levers", "subtitle": "S", "body": "B"}
+        with patch(f"{_RA}.get_newsletter_settings", return_value={"enabled": True, "topic": "reach"}), \
+             patch(f"{_RA}.get_current_profile", return_value=(MagicMock(), MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.generate_newsletter_edition", return_value=edition), \
+             patch(f"{_RA}._fill_and_publish_article", return_value=(None, "article_title")), \
+             patch(f"{_RA}.mark_newsletter_published") as mark, \
+             patch(f"{_RA}.log_error") as log_err, \
+             patch(f"{_RA}.quit_gracefully"):
+            result = auto_publish_newsletter_edition.run(user_id=1)
+        mark.assert_not_called()
+        log_err.assert_called_once()
+        assert log_err.call_args.kwargs.get("user_id") == 1
+        assert log_err.call_args.kwargs.get("task_name") == "auto_publish_newsletter_edition"
+        assert log_err.call_args.kwargs.get("failed_step") == "article_title"
         assert "did not complete" in result
 
 


### PR DESCRIPTION
## What & why
Issue #747 — the R3 spike (#406) left newsletter publishing silently no-opping when `_fill_and_publish_article` failed. The task returned a "did not complete" string and (for editions) marked the edition failed, but nothing reached PostHog, so a broken article-editor flow could sit unnoticed for weeks.

This PR makes the failure actionable:
- `_fill_and_publish_article` now returns `(published_url, failed_step)`. On failure, `failed_step` names the selector/action that could not complete (`article_title`, `article_body`, `article_next`, `article_publish`).
- Both `auto_publish_newsletter_edition` and `auto_publish_edition` emit `log_error(...)` with `user_id`, `task_name`, `edition_id` (where applicable), and `failed_step` on the None path, so PostHog receives the event per the `CLAUDE.md` logging contract.
- Happy path is unchanged: success still marks published and returns the same messages.

## Testing
- Updated existing unit tests to match the new return shape.
- Added `test_marks_failed_when_flow_incomplete` assertions verifying `log_error` is called with the expected context and `mark_edition_failed` still runs.
- Added `test_logs_error_when_flow_incomplete_for_generated_edition` covering the `auto_publish_newsletter_edition` None branch.
- `poetry run pytest tests/unit/app/test_newsletter_publish.py -q` passes (36 passed).

Closes #747

Follow-up for the article-editor selector validation live pass: #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)
