### PR TITLE
feat(content-generation): Add rejection reason field and prompt to regenerate rejected posts (closes #713)

### DIFF
--- a/compose/local/database/migrations/V20260728064209__add_post_rejection_reason.sql
+++ b/compose/local/database/migrations/V20260728064209__add_post_rejection_reason.sql
@@ -1,0 +1,5 @@
+-- Rejection reason field for posts (issue #713).
+-- When a user rejects/deletes a draft, capture WHY so a later regeneration can avoid the same issue.
+-- Nullable TEXT so existing rows and soft-deletes without a reason backfill cleanly.
+ALTER TABLE posts
+    ADD COLUMN rejection_reason TEXT NULL AFTER gate_reason;

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -85,7 +85,7 @@ from cqc_lem.utilities.db import (
     get_user_timezone, update_user_timezone,
     get_user_geo, update_user_location, get_user_content_language,
     replace_video_url_base, get_post_type, get_post_buyer_stage, get_post_status,
-    update_db_post_carousel_slides,
+    update_db_post_carousel_slides, update_db_post_rejection_reason,
     get_post_url_from_log_for_user,
     insert_feedback, FeedbackSource,
     get_latest_review_feedback_id, get_early_adopter_grant, extend_trial_for_user,
@@ -286,6 +286,7 @@ class PostRequest(BaseModel):
     carousel_slides: Optional[List[str]] = None
     use_avatar: Optional[bool] = False
     video_quality: Optional[str] = "standard"  # standard | premium | premium_top
+    rejection_reason: Optional[str] = Field(default=None, max_length=1000)
 
 
 class AvatarCreditCheckoutRequest(BaseModel):
@@ -320,6 +321,7 @@ class BulkUpdateRequest(BaseModel):
 
 class BulkDeleteRequest(BaseModel):
     post_ids: List[int]
+    rejection_reason: Optional[str] = Field(default=None, max_length=1000)
 
 
 class UserSettingsRequest(BaseModel):
@@ -1652,6 +1654,8 @@ def get_posts_for_email(
             # Why a draft is being held, and what to do about it (issue #421).
             "authenticity_score": post.get("authenticity_score"),
             "gate_reason": parse_gate_findings(post.get("gate_reason")),
+            # Why the user rejected/deleted this draft (issue #713) — surfaced when regenerating.
+            "rejection_reason": post.get("rejection_reason"),
         }
         for post in posts
     ]
@@ -1685,7 +1689,8 @@ def delete_posts_endpoint(request: BulkDeleteRequest) -> ResponseModel:
     if not request.post_ids:
         raise HTTPException(status_code=400, detail="post_ids is required")
 
-    if soft_delete_posts(request.post_ids):
+    reason = (request.rejection_reason or "").strip() or None
+    if soft_delete_posts(request.post_ids, rejection_reason=reason):
         return ResponseModel(status_code=200, detail="Posts deleted successfully")
     else:
         raise HTTPException(status_code=405, detail="Posts could not be deleted")
@@ -1713,6 +1718,9 @@ def update_post(post_id: int, post: PostRequest) -> ResponseModel:
     myprint(f"Received Post Request: {post}")
 
     if update_db_post(post.content, post.video_url, post.scheduled_datetime, post.post_type, post_id, post.status):
+        reason = (post.rejection_reason or "").strip() or None
+        if reason:
+            update_db_post_rejection_reason(post_id, reason)
         return ResponseModel(status_code=200, detail="Post updated successful")
     else:
         raise HTTPException(status_code=405, detail="Post could not be updated")
@@ -2288,15 +2296,19 @@ def regenerate_post_endpoint(request: PostRegenerateRequest) -> ResponseModel:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
     if get_post_user_id(request.post_id) != user_id:
         raise HTTPException(status_code=404, detail="Post not found")
-    # Regeneration resets the post to PENDING — only sensible from the review states. Regenerating
-    # a scheduled/posted/rejected post would silently yank it out of (or back into) the pipeline.
+    # Regeneration resets the post to PENDING — sensible from the review states and from rejected,
+    # where the stored rejection reason becomes the default guidance so the same issue is avoided.
     post_status = get_post_status(request.post_id)
-    if post_status not in (PostStatus.PENDING.value, PostStatus.APPROVED.value):
+    if post_status not in (PostStatus.PENDING.value, PostStatus.APPROVED.value, PostStatus.REJECTED.value):
         raise HTTPException(
             status_code=409,
-            detail=f"Post is '{post_status}' — only pending or approved posts can be regenerated")
+            detail=f"Post is '{post_status}' — only pending, approved, or rejected posts can be regenerated")
     from cqc_lem.app.run_content_plan import regenerate_post_task
+    from cqc_lem.utilities.db import get_post_rejection_reason
     guidance = (request.guidance or "").strip() or None
+    # A rejected post with no explicit guidance inherits its stored rejection reason.
+    if guidance is None and post_status == PostStatus.REJECTED.value:
+        guidance = get_post_rejection_reason(request.post_id)
     regenerate_post_task.apply_async(kwargs={"post_id": request.post_id, "guidance": guidance})
     return ResponseModel(status_code=200, detail="Regeneration started")
 

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -327,12 +327,12 @@ export default function ContentStudio() {
   // Regenerate a single post with optional freeform guidance — runs the async generation task
   // server-side (honors saved settings + guidance), then resets the post to PENDING for re-review.
   const regenerateMutation = useMutation({
-    mutationFn: (vars: { post_id: number; guidance: string }) => {
+    mutationFn: (vars: { post_id: number; guidance?: string | null }) => {
       if (!sessionToken) return Promise.reject(new Error('No active session'))
       return api.post('/user/post/regenerate', {
         session_token: sessionToken,
         post_id: vars.post_id,
-        guidance: vars.guidance.trim() || null,
+        guidance: vars.guidance?.trim() || null,
       })
     },
     onSuccess: () => {

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -87,6 +87,8 @@ interface Post {
   // Quality-gate verdict (issue #421) — why a PENDING post is being held, and its A1 score.
   authenticity_score?: number | null
   gate_reason?: GateFinding[] | null
+  // Why the user rejected/deleted this draft (issue #713) — used when regenerating.
+  rejection_reason?: string | null
 }
 
 // What POST /user/post/rescore returns after re-running the gates on the saved content.
@@ -157,6 +159,7 @@ export default function ContentStudio() {
 
   // Quick-delete confirmation + regenerate-with-suggestions state
   const [confirmDeletePost, setConfirmDeletePost] = useState<Post | null>(null)
+  const [deleteRejectionReason, setDeleteRejectionReason] = useState('')
   const [regenGuidance, setRegenGuidance] = useState('')
   const [regenNotice, setRegenNotice] = useState<string | null>(null)
 
@@ -283,13 +286,39 @@ export default function ContentStudio() {
     },
   })
 
+  // Regenerate a rejected post, seeding guidance with its stored rejection reason.
+  const regenerateRejectedMutation = useMutation({
+    mutationFn: (post_id: number) => {
+      if (!sessionToken) return Promise.reject(new Error('No active session'))
+      return api.post('/user/post/regenerate', {
+        session_token: sessionToken,
+        post_id,
+        // Pass the stored reason explicitly so the API uses it as guidance.
+        guidance: editingPost?.rejection_reason || undefined,
+      })
+    },
+    onSuccess: () => {
+      setRegenNotice('Regenerating… this post will return to PENDING with fresh content shortly.')
+      setEditingPost(null)
+      setTimeout(() => qc.invalidateQueries({ queryKey: ['posts', email] }), 2500)
+      setTimeout(() => setRegenNotice(null), 8000)
+    },
+    onError: () => setRegenNotice('Could not start regeneration — please try again.'),
+  })
+
   // Quick per-post delete (reuses the same soft-delete endpoint as the bulk flow, one id).
   const deleteMutation = useMutation({
-    mutationFn: (post_id: number) => api.delete('/posts/', { data: { post_ids: [post_id] } }),
+    mutationFn: (post_id: number) => api.delete('/posts/', {
+      data: { post_ids: [post_id], rejection_reason: deleteRejectionReason.trim() || undefined },
+    }),
     onSuccess: (_res, post_id) => {
-      capturePostDecision(post_id, 'rejected', { source: 'delete' })
+      capturePostDecision(post_id, 'rejected', {
+        source: 'delete',
+        has_rejection_reason: deleteRejectionReason.trim().length > 0,
+      })
       qc.invalidateQueries({ queryKey: ['posts', email] })
       setConfirmDeletePost(null)
+      setDeleteRejectionReason('')
       setSelectedIds((prev) => { const n = new Set(prev); n.delete(post_id); return n })
       if (editingPost?.post_id === post_id) setEditingPost(null)
     },
@@ -790,6 +819,11 @@ export default function ContentStudio() {
                       ⏸ {gateHold(post.gate_reason).map((f) => f.label).join(' · ')} — click to see why
                     </p>
                   )}
+                  {post.status === 'rejected' && post.rejection_reason && (
+                    <p className="text-xs text-red-700 mt-1 truncate">
+                      ✎ {post.rejection_reason}
+                    </p>
+                  )}
                   {isDeckType(post.post_type) && post.carousel_slides && (
                     <p className="text-xs text-gray-400 mt-1">{post.carousel_slides.length} slides</p>
                   )}
@@ -988,7 +1022,7 @@ export default function ContentStudio() {
                 {/* Regenerate with suggestions — mirrors the newsletter flow. Runs the generation
                     pipeline server-side (honors saved voice/tone, focus/goals, emoji/hashtag prefs)
                     PLUS the optional guidance, then resets the post to PENDING for re-review. */}
-                {editingPost.post_type === 'text' && (
+                {(editingPost.post_type === 'text' || editingPost.status === 'rejected') && (
                   <div className="border-t border-gray-100 pt-4 space-y-2">
                     <label className="block text-xs font-medium text-gray-600">
                       Added Guidance <span className="font-normal text-gray-400">(optional)</span>
@@ -1001,7 +1035,10 @@ export default function ContentStudio() {
                       className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
                     />
                     <button
-                      onClick={() => regenerateMutation.mutate({ post_id: editingPost.post_id, guidance: regenGuidance })}
+                      onClick={() => {
+                        const guidance = regenGuidance.trim() || editingPost.rejection_reason || undefined
+                        regenerateMutation.mutate({ post_id: editingPost.post_id, guidance })
+                      }}
                       disabled={regenerateMutation.isPending}
                       className="w-full bg-indigo-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-colors"
                     >
@@ -1009,6 +1046,26 @@ export default function ContentStudio() {
                     </button>
                     <p className="text-xs text-gray-400">
                       Regeneration replaces this post's content and returns it to PENDING for review.
+                    </p>
+                  </div>
+                )}
+
+                {/* Rejected posts get a one-click "regenerate with the reason" prompt (issue #713). */}
+                {editingPost.status === 'rejected' && editingPost.rejection_reason && (
+                  <div className="border-t border-gray-100 pt-4 space-y-2">
+                    <p className="text-xs text-gray-600">
+                      This post was rejected because:
+                      <span className="block mt-1 text-red-700 font-medium">{editingPost.rejection_reason}</span>
+                    </p>
+                    <button
+                      onClick={() => regenerateRejectedMutation.mutate(editingPost.post_id)}
+                      disabled={regenerateRejectedMutation.isPending}
+                      className="w-full bg-indigo-600 text-white py-2 rounded-lg text-sm font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                    >
+                      {regenerateRejectedMutation.isPending ? 'Starting…' : 'Regenerate using this feedback'}
+                    </button>
+                    <p className="text-xs text-gray-400">
+                      We'll use the rejection reason as guidance so the new draft avoids the same issue.
                     </p>
                   </div>
                 )}
@@ -1042,6 +1099,21 @@ export default function ContentStudio() {
               and will disappear from all views. You can't undo this from the UI.
             </p>
             <p className="text-xs text-gray-500 line-clamp-3 bg-gray-50 rounded p-2">{confirmDeletePost.content}</p>
+            <div className="space-y-2">
+              <label className="block text-xs font-medium text-gray-600">
+                Why are you removing this? <span className="font-normal text-gray-400">(optional)</span>
+              </label>
+              <textarea
+                value={deleteRejectionReason}
+                onChange={(e) => setDeleteRejectionReason(e.target.value)}
+                rows={2}
+                placeholder="e.g. too salesy, wrong tone, not relevant to my audience"
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 resize-none"
+              />
+              <p className="text-xs text-gray-400">
+                Your reason will help future drafts avoid the same issue.
+              </p>
+            </div>
             <div className="flex gap-2 justify-end">
               <button
                 onClick={() => setConfirmDeletePost(null)}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1424,7 +1424,8 @@ def bulk_update_posts(post_ids: list[int], status: Optional[PostStatus] = None,
         connection.commit()
         success = cursor.rowcount > 0
     except mysql.connector.Error as e:
-        myprint(f"Could not bulk update posts. An error occurred: {e}")
+        from cqc_lem.utilities.logger import log_error
+        log_error("Could not bulk update posts", exc=e)
         success = False
     finally:
         cursor.close()
@@ -1441,6 +1442,7 @@ def update_db_post_rejection_reason(post_id: int, rejection_reason: Optional[str
     """Persist WHY a post was rejected (issue #713) so a later regeneration can avoid the same issue.
 
     Empty or whitespace-only input is stored as NULL so the UI doesn't render a blank reason."""
+    from cqc_lem.utilities.logger import log_error
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
@@ -1452,7 +1454,7 @@ def update_db_post_rejection_reason(post_id: int, rejection_reason: Optional[str
         success = cursor.rowcount == 1
     except mysql.connector.Error as e:
         success = False
-        myprint(f"Could not update rejection reason for post {post_id}. Error: {e}")
+        log_error(f"Could not update rejection reason for post {post_id}", exc=e, post_id=post_id)
     finally:
         cursor.close()
         connection.close()
@@ -1468,7 +1470,8 @@ def get_post_rejection_reason(post_id: int) -> Optional[str]:
         row = cursor.fetchone()
         return row[0] if row else None
     except mysql.connector.Error as err:
-        myprint(f"Could not get rejection reason for post {post_id} | Error: {err}")
+        from cqc_lem.utilities.logger import log_error
+        log_error(f"Could not get rejection reason for post {post_id}", exc=err, post_id=post_id)
         return None
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1045,7 +1045,7 @@ def get_posts(user_id: int, limit: int = 10, offset: int = 0,
 
         cursor.execute(
             f"SELECT id, content, video_url, scheduled_time, post_type, status, carousel_slides, "
-            f"authenticity_score, gate_reason, archetype "
+            f"authenticity_score, gate_reason, rejection_reason, archetype "
             f"FROM posts {where} ORDER BY {sort_col} {order}, id {order} LIMIT %s OFFSET %s",
             params + [limit, offset]
         )
@@ -1380,11 +1380,12 @@ def get_carousel_slides(post_id: int) -> list[str]:
     return []
 
 
-_ALLOWED_POST_CLAUSES = frozenset({"status = %s", "scheduled_time = %s"})
+_ALLOWED_POST_CLAUSES = frozenset({"status = %s", "scheduled_time = %s", "rejection_reason = %s"})
 
 
 def bulk_update_posts(post_ids: list[int], status: Optional[PostStatus] = None,
-                      scheduled_time: Optional[datetime] = None) -> bool:
+                      scheduled_time: Optional[datetime] = None,
+                      rejection_reason: Optional[str] = None) -> bool:
     if not post_ids:
         return False
 
@@ -1402,6 +1403,9 @@ def bulk_update_posts(post_ids: list[int], status: Optional[PostStatus] = None,
         if scheduled_time is not None:
             sets.append("scheduled_time = %s")
             params.append(to_naive_utc(scheduled_time))
+        if rejection_reason is not None:
+            sets.append("rejection_reason = %s")
+            params.append((rejection_reason or "").strip() or None)
 
         if not sets:
             return False
@@ -1429,8 +1433,46 @@ def bulk_update_posts(post_ids: list[int], status: Optional[PostStatus] = None,
     return success
 
 
-def soft_delete_posts(post_ids: list[int]) -> bool:
-    return bulk_update_posts(post_ids, status=PostStatus.REJECTED)
+def soft_delete_posts(post_ids: list[int], rejection_reason: Optional[str] = None) -> bool:
+    return bulk_update_posts(post_ids, status=PostStatus.REJECTED, rejection_reason=rejection_reason)
+
+
+def update_db_post_rejection_reason(post_id: int, rejection_reason: Optional[str]) -> bool:
+    """Persist WHY a post was rejected (issue #713) so a later regeneration can avoid the same issue.
+
+    Empty or whitespace-only input is stored as NULL so the UI doesn't render a blank reason."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE posts SET rejection_reason = %s WHERE id = %s",
+            ((rejection_reason or "").strip() or None, post_id)
+        )
+        connection.commit()
+        success = cursor.rowcount == 1
+    except mysql.connector.Error as e:
+        success = False
+        myprint(f"Could not update rejection reason for post {post_id}. Error: {e}")
+    finally:
+        cursor.close()
+        connection.close()
+    return success
+
+
+def get_post_rejection_reason(post_id: int) -> Optional[str]:
+    """The persisted rejection reason for a post (issue #713), or None when it has none."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT rejection_reason FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+        return row[0] if row else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not get rejection reason for post {post_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
 
 
 def update_db_post_carousel_slides(post_id: int, slides: list[str]) -> bool:

--- a/tests/unit/api/test_main_posts.py
+++ b/tests/unit/api/test_main_posts.py
@@ -279,7 +279,34 @@ class TestDeletePostsEndpoint:
                 "/api/posts/",
                 json={"post_ids": [7, 8, 9]},
             )
-        mock_delete.assert_called_once_with([7, 8, 9])
+        mock_delete.assert_called_once_with([7, 8, 9], rejection_reason=None)
+
+    def test_passes_rejection_reason_to_soft_delete(self, client):
+        with patch(f"{_DB}.soft_delete_posts", return_value=True) as mock_delete:
+            resp = client.request(
+                "DELETE",
+                "/api/posts/",
+                json={"post_ids": [7], "rejection_reason": "Too salesy"},
+            )
+        assert resp.status_code == 200
+        mock_delete.assert_called_once_with([7], rejection_reason="Too salesy")
+
+    def test_blank_rejection_reason_becomes_none(self, client):
+        with patch(f"{_DB}.soft_delete_posts", return_value=True) as mock_delete:
+            client.request(
+                "DELETE",
+                "/api/posts/",
+                json={"post_ids": [7], "rejection_reason": "   "},
+            )
+        mock_delete.assert_called_once_with([7], rejection_reason=None)
+
+    def test_rejection_reason_too_long_returns_422(self, client):
+        resp = client.request(
+            "DELETE",
+            "/api/posts/",
+            json={"post_ids": [7], "rejection_reason": "x" * 1001},
+        )
+        assert resp.status_code == 422
 
 
 # ---------------------------------------------------------------------------
@@ -337,3 +364,27 @@ class TestUpdatePost:
         assert resp.status_code == 200
         call_args = mock_update.call_args
         assert call_args.args[1] == "https://example.com/video.mp4"
+
+    def test_rejection_reason_persisted_on_update(self, client):
+        body = dict(_POST_BODY, status="rejected", rejection_reason="Not relevant")
+        with patch(f"{_DB}.update_db_post", return_value=True), \
+             patch(f"{_DB}.update_db_post_rejection_reason", return_value=True) as mock_reason:
+            resp = client.post(
+                "/api/update_post/",
+                params={"post_id": 10},
+                json=body,
+            )
+        assert resp.status_code == 200
+        mock_reason.assert_called_once_with(10, "Not relevant")
+
+    def test_blank_rejection_reason_not_persisted(self, client):
+        body = dict(_POST_BODY, status="rejected", rejection_reason="   ")
+        with patch(f"{_DB}.update_db_post", return_value=True), \
+             patch(f"{_DB}.update_db_post_rejection_reason") as mock_reason:
+            resp = client.post(
+                "/api/update_post/",
+                params={"post_id": 10},
+                json=body,
+            )
+        assert resp.status_code == 200
+        mock_reason.assert_not_called()

--- a/tests/unit/api/test_post_regenerate_api.py
+++ b/tests/unit/api/test_post_regenerate_api.py
@@ -54,9 +54,9 @@ class TestRegeneratePostEndpoint:
         assert resp.status_code == 200
         assert task.apply_async.call_args.kwargs["kwargs"]["guidance"] is None
 
-    @pytest.mark.parametrize("status", ["scheduled", "posted", "rejected", "error", "planning", None])
+    @pytest.mark.parametrize("status", ["scheduled", "posted", "error", "planning", None])
     def test_409_when_post_not_in_review_state(self, client, status):
-        # Regeneration resets a post to PENDING — allowed only from pending/approved.
+        # Regeneration resets a post to PENDING — allowed from pending/approved/rejected.
         with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
              patch("cqc_lem.api.main.get_post_user_id", return_value=_USER), \
              patch("cqc_lem.api.main.get_post_status", return_value=status), \
@@ -64,8 +64,43 @@ class TestRegeneratePostEndpoint:
             resp = client.post("/api/user/post/regenerate",
                                json={"session_token": _SESSION, "post_id": 7})
         assert resp.status_code == 409
-        assert "only pending or approved" in resp.json()["detail"]
+        assert "only pending, approved, or rejected" in resp.json()["detail"]
         task.apply_async.assert_not_called()
+
+    def test_rejected_post_uses_stored_reason_as_guidance(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_status", return_value="rejected"), \
+             patch("cqc_lem.utilities.db.get_post_rejection_reason", return_value="Too salesy"), \
+             patch("cqc_lem.app.run_content_plan.regenerate_post_task") as task:
+            resp = client.post("/api/user/post/regenerate",
+                               json={"session_token": _SESSION, "post_id": 7})
+        assert resp.status_code == 200
+        task.apply_async.assert_called_once()
+        assert task.apply_async.call_args.kwargs["kwargs"]["guidance"] == "Too salesy"
+
+    def test_rejected_post_explicit_guidance_overrides_stored_reason(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_status", return_value="rejected"), \
+             patch("cqc_lem.utilities.db.get_post_rejection_reason") as mock_reason, \
+             patch("cqc_lem.app.run_content_plan.regenerate_post_task") as task:
+            resp = client.post("/api/user/post/regenerate",
+                               json={"session_token": _SESSION, "post_id": 7, "guidance": "Punchier"})
+        assert resp.status_code == 200
+        mock_reason.assert_not_called()
+        assert task.apply_async.call_args.kwargs["kwargs"]["guidance"] == "Punchier"
+
+    def test_rejected_post_without_reason_allows_regeneration(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_status", return_value="rejected"), \
+             patch("cqc_lem.utilities.db.get_post_rejection_reason", return_value=None), \
+             patch("cqc_lem.app.run_content_plan.regenerate_post_task") as task:
+            resp = client.post("/api/user/post/regenerate",
+                               json={"session_token": _SESSION, "post_id": 7})
+        assert resp.status_code == 200
+        assert task.apply_async.call_args.kwargs["kwargs"]["guidance"] is None
 
     def test_404_when_not_owner(self, client):
         with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \

--- a/tests/unit/utilities/test_db.py
+++ b/tests/unit/utilities/test_db.py
@@ -100,6 +100,94 @@ class TestUpdateDbPostContent:
 
 
 @pytest.mark.unit
+class TestUpdateDbPostRejectionReason:
+    def test_executes_update_with_reason(self, mock_database_connection):
+        from cqc_lem.utilities.db import update_db_post_rejection_reason
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].rowcount = 1
+
+            result = update_db_post_rejection_reason(19, "Too promotional")
+
+            assert result is True
+            args = mock_database_connection["cursor"].execute.call_args[0]
+            assert "UPDATE" in args[0].upper()
+            assert "rejection_reason" in args[0].lower()
+            assert "Too promotional" in args[1]
+            assert 19 in args[1]
+
+    def test_blank_reason_stored_as_null(self, mock_database_connection):
+        from cqc_lem.utilities.db import update_db_post_rejection_reason
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].rowcount = 1
+
+            update_db_post_rejection_reason(19, "   ")
+
+            args = mock_database_connection["cursor"].execute.call_args[0]
+            assert args[1][0] is None
+
+    def test_returns_false_on_db_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import update_db_post_rejection_reason
+        import mysql.connector
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
+
+            assert update_db_post_rejection_reason(19, "reason") is False
+
+
+@pytest.mark.unit
+class TestGetPostRejectionReason:
+    def test_returns_reason_when_present(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_rejection_reason
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = ("Too salesy",)
+
+            assert get_post_rejection_reason(19) == "Too salesy"
+
+    def test_returns_none_when_missing(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_rejection_reason
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = (None,)
+
+            assert get_post_rejection_reason(19) is None
+
+    def test_returns_none_on_db_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_rejection_reason
+        import mysql.connector
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("err")
+
+            assert get_post_rejection_reason(19) is None
+
+
+@pytest.mark.unit
+class TestSoftDeletePosts:
+    def test_passes_rejection_reason_to_bulk_update(self, mock_database_connection):
+        from cqc_lem.utilities.db import soft_delete_posts, PostStatus
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].rowcount = 1
+
+            soft_delete_posts([7, 8], rejection_reason="Too long")
+
+            args = mock_database_connection["cursor"].execute.call_args[0]
+            assert PostStatus.REJECTED.value in args[1]
+            assert "Too long" in args[1]
+
+
+@pytest.mark.unit
 class TestUpdateDbPostVideoUrl:
     def test_executes_update_with_url(self, mock_database_connection):
         from cqc_lem.utilities.db import update_db_post_video_url


### PR DESCRIPTION
## What
Implements issue #713: when a user rejects/deletes a post, capture an optional rejection reason; surface it in the review UI; and allow one-click regeneration that feeds the stored reason into the generation guidance so the same issue is avoided.

## How
- Added a timestamped Flyway migration to add  (TEXT, nullable).
- Added DB helpers  /  and extended  /  to persist the reason.
- Extended API request models:
  -  accepts an optional .
  -  accepts an optional .
  -  now allows  posts and seeds guidance from the stored reason when no explicit guidance is provided.
- Updated :
  - Delete confirmation modal now prompts for an optional reason.
  - Rejected posts display the reason in the list and in the editor.
  - Rejected posts with a reason get a dedicated "Regenerate using this feedback" button.

## Testing
- Added unit tests for DB helpers, soft-delete reason propagation, update endpoint reason persistence, and regenerate API behavior for rejected posts (stored reason as default guidance, explicit guidance override, no reason case).
- Full unit suite: 8102 passed.

Closes #713

🤖 Generated with [Claude Code](https://claude.com/claude-code)