### PR TITLE
feat(ui): reorder Story Bank card after Publishing card (closes #722)

### DIFF
--- a/src/cqc_lem/ui/src/pages/account/settings/SettingsHub.test.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/SettingsHub.test.tsx
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import SettingsHub from './SettingsHub'
+
+vi.mock('../../api/client', () => ({
+  default: { get: vi.fn(), put: vi.fn(), post: vi.fn(), delete: vi.fn() },
+}))
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ sessionToken: 'tok' }),
+}))
+
+vi.mock('../SettingsSaveContext', () => ({
+  SettingsSaveProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  SaveAllBar: () => <div data-testid="save-all-bar" />,
+  useRegisterSaveSection: vi.fn(),
+  sectionSaveCallbacks: () => ({ onSuccess: vi.fn(), onError: vi.fn() }),
+}))
+
+vi.mock('./EngagementPrefsContext', () => ({
+  EngagementPrefsProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useEngagementPrefs: () => ({ message: null }),
+}))
+
+vi.mock('./UserPrefsContext', () => ({
+  UserPrefsProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useUserPrefs: () => ({ message: null }),
+}))
+
+vi.mock('./ConflictsContext', () => ({
+  ConflictsProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useConflicts: () => ({ alertCounts: {} }),
+}))
+
+vi.mock('../SubscriptionCard', () => ({ default: () => <div data-testid="subscription-card" /> }))
+vi.mock('../VideoCreditsCard', () => ({ default: () => <div data-testid="video-credits-card" /> }))
+vi.mock('../TimezoneCard', () => ({ default: () => <div data-testid="timezone-card" /> }))
+vi.mock('../LoginLocationCard', () => ({ default: () => <div data-testid="login-location-card" /> }))
+vi.mock('../LinkedInLoginCard', () => ({ default: () => <div data-testid="linkedin-login-card" /> }))
+vi.mock('../LinkedInDisplayNameCard', () => ({ default: () => <div data-testid="linkedin-display-name-card" /> }))
+vi.mock('../CompanyPageCard', () => ({ default: () => <div data-testid="company-page-card" /> }))
+vi.mock('../ContentProfileCard', () => ({ default: () => <div data-testid="content-profile-card" /> }))
+vi.mock('../StoryBankCard', () => ({ default: () => <div data-testid="story-bank-card" /> }))
+vi.mock('../NewsletterCard', () => ({ default: () => <div data-testid="newsletter-card" /> }))
+vi.mock('../GroupsCard', () => ({ default: () => <div data-testid="groups-card" /> }))
+vi.mock('../DmTemplatesCard', () => ({ default: () => <div data-testid="dm-templates-card" /> }))
+vi.mock('../EngagementRosterCard', () => ({ default: () => <div data-testid="engagement-roster-card" /> }))
+vi.mock('../LeadMagnetCard', () => ({ default: () => <div data-testid="lead-magnet-card" /> }))
+
+vi.mock('./VoiceSection', () => ({ default: () => <div data-testid="voice-section" /> }))
+vi.mock('./ContentSection', () => ({ default: () => <div data-testid="content-section" /> }))
+vi.mock('./TargetingSection', () => ({ default: () => <div data-testid="targeting-section" /> }))
+vi.mock('./VolumeSection', () => ({ default: () => <div data-testid="volume-section" /> }))
+vi.mock('./OutreachSection', () => ({ default: () => <div data-testid="outreach-section" /> }))
+vi.mock('./SafetyCard', () => ({ default: () => <div data-testid="safety-card" /> }))
+
+function harness(initialEntry: string) {
+  return render(
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <SettingsHub />
+    </MemoryRouter>,
+  )
+}
+
+describe('SettingsHub card order', () => {
+  it('positions Story Bank after Publishing on the content section', () => {
+    harness('/account?section=content')
+    const profile = screen.getByTestId('content-profile-card')
+    const publishing = screen.getByTestId('content-section')
+    const storyBank = screen.getByTestId('story-bank-card')
+    expect(profile.compareDocumentPosition(publishing) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    expect(publishing.compareDocumentPosition(storyBank) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+  })
+
+  it('keeps every other section body mounted but hidden', () => {
+    harness('/account?section=content')
+    expect(screen.getByTestId('content-section').parentElement?.getAttribute('aria-hidden')).toBe('false')
+    expect(screen.getByTestId('voice-section').parentElement?.getAttribute('aria-hidden')).toBe('true')
+  })
+})

--- a/src/cqc_lem/ui/src/pages/account/settings/SettingsHub.tsx
+++ b/src/cqc_lem/ui/src/pages/account/settings/SettingsHub.tsx
@@ -32,7 +32,7 @@ function SectionBody({ section }: { section: SectionKey }) {
     case 'voice':
       return <VoiceSection />
     case 'content':
-      return <><ContentProfileCard /><StoryBankCard /><ContentSection /></>
+      return <><ContentProfileCard /><ContentSection /><StoryBankCard /></>
     case 'targeting':
       return <><EngagementRosterCard /><TargetingSection /><GroupsCard /></>
     case 'volume':


### PR DESCRIPTION
Reorders the cards in the Content & Publishing settings section so the Story Bank card appears after the Publishing card, as requested in the feedback report.

### What changed
- src/cqc_lem/ui/src/pages/account/settings/SettingsHub.tsx: swapped StoryBankCard and ContentSection in the 'content' section body, so the order is now Content & Profile → Publishing → Story Bank.

### Tests
- Added src/cqc_lem/ui/src/pages/account/settings/SettingsHub.test.tsx with a DOM-order assertion that Story Bank follows Publishing on /account?section=content, plus a regression test that inactive sections stay mounted-but-hidden.
- Local UI tests could not be run because the environment's Node version (v18.19.1) is below the toolchain requirement; CI is the source of truth.

Closes #722

🤖 Generated with [Claude Code](https://claude.com/claude-code)
