### PR TITLE
feat(content-generation): add date selector for filtering posts by date range (closes #727)

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1626,6 +1626,8 @@ def get_posts_for_email(
     status_filter: Optional[str] = Query(default=None),
     post_type_filter: Optional[str] = Query(default=None, pattern='^(text|video|carousel|document)$'),
     search: Optional[str] = Query(default=None, max_length=500),
+    start_date: Optional[datetime] = Query(default=None),
+    end_date: Optional[datetime] = Query(default=None),
 ) -> ResponseModel:
     if not email:
         raise HTTPException(status_code=400, detail="Email is required")
@@ -1635,6 +1637,7 @@ def get_posts_for_email(
         email, limit=page_size, offset=offset,
         sort_order=sort_order, status_filter=status_filter,
         post_type_filter=post_type_filter, search=search, sort_by=sort_by,
+        start_date=start_date, end_date=end_date,
     )
 
     posts_list = [

--- a/src/cqc_lem/ui/src/pages/ContentStudio.date.test.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.date.test.tsx
@@ -1,0 +1,187 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import ContentStudio, { getTodayInTz, resolveDateRange } from './ContentStudio'
+
+const get = vi.fn()
+const post = vi.fn()
+
+vi.mock('../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'test@example.com', userId: 1 }, sessionToken: 'tok' }),
+}))
+
+vi.mock('../hooks/useUserTimezone', () => ({
+  useUserTimezone: () => 'America/New_York',
+}))
+
+vi.mock('../utils/analytics', () => ({
+  capture: vi.fn(),
+  recordPostApproval: vi.fn(),
+  maskProps: (className: string) => ({ className }),
+  EVENTS: { postApproved: 'post_approved', postRejected: 'post_rejected' },
+}))
+
+vi.mock('./content/ComposePost', () => ({
+  default: () => null,
+}))
+vi.mock('./review/NewsletterQueue', () => ({
+  default: () => null,
+}))
+vi.mock('./review/ScheduledDMs', () => ({
+  default: () => null,
+}))
+vi.mock('./review/ConnectionRequests', () => ({
+  default: () => null,
+}))
+vi.mock('./review/OutreachFunnel', () => ({
+  default: () => null,
+}))
+vi.mock('./review/LeadsInbox', () => ({
+  default: () => null,
+}))
+vi.mock('./review/LeadsPipeline', () => ({
+  default: () => null,
+}))
+vi.mock('./review/CatchupTouches', () => ({
+  default: () => null,
+}))
+
+const POST_BASE = {
+  post_id: 1,
+  content: 'Draft content',
+  video_url: null,
+  scheduled_time: '2026-07-30T14:00:00Z',
+  carousel_slides: null,
+  post_url: null,
+  archetype: null,
+  authenticity_score: null,
+  gate_reason: null,
+  rejection_reason: null,
+}
+
+function payload(data: unknown) {
+  return { data: { detail: data } }
+}
+
+function harness(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <MemoryRouter initialEntries={['/?tab=review']}>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+  vi.useFakeTimers()
+  // Pin system time to 2026-07-29 12:00 UTC -> 08:00 EDT
+  vi.setSystemTime(new Date('2026-07-29T12:00:00Z'))
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+  vi.useRealTimers()
+})
+
+function mockPosts(posts: unknown[]) {
+  get.mockImplementation((path: string) => {
+    if (path.startsWith('/posts/')) return Promise.resolve(payload({ posts, total: posts.length, page: 1, page_size: 10 }))
+    if (path.startsWith('/user/timezone')) return Promise.resolve(payload({ timezone: 'America/New_York' }))
+    if (path.startsWith('/content_generation_status')) return Promise.resolve(payload(null))
+    return Promise.resolve(payload({}))
+  })
+}
+
+describe('ContentStudio date range helpers', () => {
+  it('getTodayInTz returns the wall date in the user timezone', () => {
+    expect(getTodayInTz('America/New_York')).toBe('2026-07-29')
+    expect(getTodayInTz('UTC')).toBe('2026-07-29')
+    // A timezone well ahead of UTC should already be the next day at this UTC instant.
+    expect(getTodayInTz('Asia/Tokyo')).toBe('2026-07-29')
+  })
+
+  it('resolveDateRange handles preset ranges relative to user today', () => {
+    expect(resolveDateRange('today', 'America/New_York')).toEqual({
+      start: '2026-07-29',
+      end: '2026-07-29',
+    })
+    expect(resolveDateRange('yesterday', 'America/New_York')).toEqual({
+      start: '2026-07-28',
+      end: '2026-07-28',
+    })
+    expect(resolveDateRange('last7days', 'America/New_York')).toEqual({
+      start: '2026-07-23',
+      end: '2026-07-29',
+    })
+    expect(resolveDateRange('last30days', 'America/New_York')).toEqual({
+      start: '2026-06-30',
+      end: '2026-07-29',
+    })
+    expect(resolveDateRange('thisMonth', 'America/New_York')).toEqual({
+      start: '2026-07-01',
+      end: '2026-07-31',
+    })
+    expect(resolveDateRange('next30days', 'America/New_York')).toEqual({
+      start: '2026-07-29',
+      end: '2026-08-27',
+    })
+  })
+
+  it('resolveDateRange custom returns provided dates', () => {
+    expect(resolveDateRange('custom', 'America/New_York', '2026-01-01', '2026-01-31')).toEqual({
+      start: '2026-01-01',
+      end: '2026-01-31',
+    })
+  })
+
+  it('resolveDateRange ALL returns null bounds', () => {
+    expect(resolveDateRange('ALL', 'America/New_York')).toEqual({ start: null, end: null })
+  })
+})
+
+describe('ContentStudio date range filter', () => {
+  it('sends start_date and end_date when the Today preset is selected', async () => {
+    mockPosts([{ ...POST_BASE, post_type: 'text', status: 'pending' }])
+    harness(<ContentStudio />)
+
+    await waitFor(() => expect(screen.getByText('Draft content')).toBeDefined())
+
+    const dateSelect = screen.getByLabelText('Date range preset')
+    fireEvent.change(dateSelect, { target: { value: 'today' } })
+
+    await waitFor(() => {
+      const calls = get.mock.calls.filter((c: unknown[]) => (c[0] as string).startsWith('/posts/'))
+      const latest = calls[calls.length - 1][0] as string
+      expect(latest).toContain('start_date=')
+      expect(latest).toContain('end_date=')
+    })
+  })
+
+  it('shows custom date inputs only when the Custom preset is selected', async () => {
+    mockPosts([{ ...POST_BASE, post_type: 'text', status: 'pending' }])
+    harness(<ContentStudio />)
+
+    await waitFor(() => expect(screen.getByText('Draft content')).toBeDefined())
+
+    expect(screen.queryByLabelText('Custom start date')).toBeNull()
+
+    const dateSelect = screen.getByLabelText('Date range preset')
+    fireEvent.change(dateSelect, { target: { value: 'custom' } })
+
+    expect(screen.getByLabelText('Custom start date')).toBeDefined()
+    expect(screen.getByLabelText('Custom end date')).toBeDefined()
+  })
+})

--- a/src/cqc_lem/ui/src/pages/ContentStudio.date.test.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.date.test.tsx
@@ -85,15 +85,11 @@ function harness(ui: ReactNode) {
 beforeEach(() => {
   get.mockReset()
   post.mockReset()
-  vi.useFakeTimers()
-  // Pin system time to 2026-07-29 12:00 UTC -> 08:00 EDT
-  vi.setSystemTime(new Date('2026-07-29T12:00:00Z'))
 })
 
 afterEach(() => {
   cleanup()
   vi.clearAllMocks()
-  vi.useRealTimers()
 })
 
 function mockPosts(posts: unknown[]) {
@@ -106,6 +102,16 @@ function mockPosts(posts: unknown[]) {
 }
 
 describe('ContentStudio date range helpers', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // Pin system time to 2026-07-29 12:00 UTC -> 08:00 EDT
+    vi.setSystemTime(new Date('2026-07-29T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('getTodayInTz returns the wall date in the user timezone', () => {
     expect(getTodayInTz('America/New_York')).toBe('2026-07-29')
     expect(getTodayInTz('UTC')).toBe('2026-07-29')

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -16,7 +16,7 @@ import CatchupTouches from './review/CatchupTouches'
 import ComposePost from './content/ComposePost'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
-import { formatInTimezone, toZonedInputValue, zonedInputToUtcIso } from '../utils/datetime'
+import { formatInTimezone, toZonedInputValue, zonedInputToUtcIso, zonedDateToUtcStart, zonedDateToUtcEnd } from '../utils/datetime'
 import { emptyRunExplanation, isGenerationRunning } from '../utils/generationStatus'
 import type { GenerationStatus } from '../utils/generationStatus'
 import { EVENTS, capture, maskProps, recordPostApproval } from '../utils/analytics'
@@ -63,6 +63,18 @@ const POST_TYPE_FILTERS: { label: string; value: PostTypeFilter }[] = [
 // is published as a single PDF instead of a multi-image share.
 const isDeckType = (postType: string) => postType === 'carousel' || postType === 'document'
 
+type DateRangeFilter = 'ALL' | 'today' | 'yesterday' | 'last7days' | 'last30days' | 'thisMonth' | 'next30days' | 'custom'
+const DATE_RANGE_FILTERS: { label: string; value: DateRangeFilter }[] = [
+  { label: 'All dates', value: 'ALL' },
+  { label: 'Today', value: 'today' },
+  { label: 'Yesterday', value: 'yesterday' },
+  { label: 'Last 7 days', value: 'last7days' },
+  { label: 'Last 30 days', value: 'last30days' },
+  { label: 'This month', value: 'thisMonth' },
+  { label: 'Next 30 days', value: 'next30days' },
+  { label: 'Custom', value: 'custom' },
+]
+
 type SortBy = 'scheduled_time' | 'status' | 'post_type' | 'id'
 const SORT_BY_OPTIONS: { label: string; value: SortBy }[] = [
   { label: 'Scheduled time', value: 'scheduled_time' },
@@ -72,6 +84,65 @@ const SORT_BY_OPTIONS: { label: string; value: SortBy }[] = [
 ]
 
 const PAGE_SIZE_OPTIONS = [10, 25, 50]
+
+// Return YYYY-MM-DD for *today* in the user's configured timezone so preset ranges
+// line up with the wall clock the rest of the UI uses.
+export function getTodayInTz(tz: string): string {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).formatToParts(new Date())
+    const get = (type: string) => parts.find((p) => p.type === type)?.value ?? '0'
+    return `${get('year')}-${get('month')}-${get('day')}`
+  } catch {
+    return new Date().toISOString().slice(0, 10)
+  }
+}
+
+// Given a preset (or custom) date range, return the user-timezone wall dates that bound it.
+export function resolveDateRange(
+  preset: DateRangeFilter,
+  tz: string,
+  customStart?: string,
+  customEnd?: string,
+): { start: string | null; end: string | null } {
+  const today = getTodayInTz(tz)
+  const [year, month, day] = today.split('-').map(Number)
+  switch (preset) {
+    case 'ALL':
+      return { start: null, end: null }
+    case 'today':
+      return { start: today, end: today }
+    case 'yesterday': {
+      const d = new Date(Date.UTC(year, month - 1, day - 1))
+      return { start: d.toISOString().slice(0, 10), end: d.toISOString().slice(0, 10) }
+    }
+    case 'last7days': {
+      const d = new Date(Date.UTC(year, month - 1, day - 6))
+      return { start: d.toISOString().slice(0, 10), end: today }
+    }
+    case 'last30days': {
+      const d = new Date(Date.UTC(year, month - 1, day - 29))
+      return { start: d.toISOString().slice(0, 10), end: today }
+    }
+    case 'thisMonth': {
+      const start = `${year}-${String(month).padStart(2, '0')}-01`
+      const end = new Date(Date.UTC(year, month, 0)).toISOString().slice(0, 10)
+      return { start, end }
+    }
+    case 'next30days': {
+      const d = new Date(Date.UTC(year, month - 1, day + 29))
+      return { start: today, end: d.toISOString().slice(0, 10) }
+    }
+    case 'custom':
+      return { start: customStart || null, end: customEnd || null }
+    default:
+      return { start: null, end: null }
+  }
+}
 
 interface Post {
   post_id: number
@@ -131,6 +202,9 @@ export default function ContentStudio() {
   // Filter / sort / pagination state
   const [filterStatus, setFilterStatus] = useState<Status>('ALL')
   const [filterPostType, setFilterPostType] = useState<PostTypeFilter>('ALL')
+  const [dateRange, setDateRange] = useState<DateRangeFilter>('ALL')
+  const [customStartDate, setCustomStartDate] = useState<string>('')
+  const [customEndDate, setCustomEndDate] = useState<string>('')
   const [sortBy, setSortBy] = useState<SortBy>('scheduled_time')
   const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc')
   const [page, setPage] = useState(1)
@@ -170,7 +244,14 @@ export default function ContentStudio() {
   const editingPostId = editingPost?.post_id ?? null
   useEffect(() => { setRescoreResult(null) }, [editingPostId])
 
-  const queryKey = ['posts', email, page, pageSize, sortOrder, sortBy, filterStatus, filterPostType, searchQuery]
+  const { start: filterStartDate, end: filterEndDate } = resolveDateRange(
+    dateRange, userTimezone, customStartDate, customEndDate
+  )
+
+  const queryKey = [
+    'posts', email, page, pageSize, sortOrder, sortBy,
+    filterStatus, filterPostType, dateRange, filterStartDate, filterEndDate, searchQuery,
+  ]
 
   const { data, isLoading } = useQuery<{ detail: PostsResponse }>({
     queryKey,
@@ -184,6 +265,8 @@ export default function ContentStudio() {
       })
       if (filterStatus !== 'ALL') params.set('status_filter', filterStatus)
       if (filterPostType !== 'ALL') params.set('post_type_filter', filterPostType)
+      if (filterStartDate) params.set('start_date', zonedDateToUtcStart(filterStartDate, userTimezone) ?? '')
+      if (filterEndDate) params.set('end_date', zonedDateToUtcEnd(filterEndDate, userTimezone) ?? '')
       if (searchQuery) params.set('search', searchQuery)
       return api.get(`/posts/?${params.toString()}`).then((r) => r.data)
     },
@@ -427,11 +510,18 @@ export default function ContentStudio() {
     if (newFilter !== undefined) setFilterStatus(newFilter)
   }
 
-  const hasActiveFilters = filterStatus !== 'ALL' || filterPostType !== 'ALL' || searchQuery !== ''
+  const hasActiveFilters =
+    filterStatus !== 'ALL' ||
+    filterPostType !== 'ALL' ||
+    dateRange !== 'ALL' ||
+    searchQuery !== ''
 
   function clearFilters() {
     setFilterStatus('ALL')
     setFilterPostType('ALL')
+    setDateRange('ALL')
+    setCustomStartDate('')
+    setCustomEndDate('')
     setSearchInput('')
     setSearchQuery('')
     setSortBy('scheduled_time')
@@ -620,7 +710,7 @@ export default function ContentStudio() {
         </p>
       </div>
 
-      {/* Sort + type filter + page-size controls */}
+      {/* Sort + type filter + date range + page-size controls */}
       <div className="flex items-center gap-3 flex-wrap text-sm">
         <label className="flex items-center gap-1.5 text-xs text-gray-600">
           <span>Type</span>
@@ -634,6 +724,38 @@ export default function ContentStudio() {
             ))}
           </select>
         </label>
+        <label className="flex items-center gap-1.5 text-xs text-gray-600">
+          <span>Date</span>
+          <select
+            value={dateRange}
+            onChange={(e) => { setDateRange(e.target.value as DateRangeFilter); setPage(1); setSelectedIds(new Set()) }}
+            aria-label="Date range preset"
+            className="border border-gray-300 rounded-lg px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500"
+          >
+            {DATE_RANGE_FILTERS.map((d) => (
+              <option key={d.value} value={d.value}>{d.label}</option>
+            ))}
+          </select>
+        </label>
+        {dateRange === 'custom' && (
+          <div className="flex items-center gap-1.5 text-xs text-gray-600">
+            <input
+              type="date"
+              value={customStartDate}
+              onChange={(e) => { setCustomStartDate(e.target.value); setPage(1); setSelectedIds(new Set()) }}
+              aria-label="Custom start date"
+              className="border border-gray-300 rounded-lg px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+            <span>to</span>
+            <input
+              type="date"
+              value={customEndDate}
+              onChange={(e) => { setCustomEndDate(e.target.value); setPage(1); setSelectedIds(new Set()) }}
+              aria-label="Custom end date"
+              className="border border-gray-300 rounded-lg px-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500"
+            />
+          </div>
+        )}
         <label className="flex items-center gap-1.5 text-xs text-gray-600">
           <span>Sort by</span>
           <select

--- a/src/cqc_lem/ui/src/utils/datetime.test.ts
+++ b/src/cqc_lem/ui/src/utils/datetime.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+import { zonedDateToUtcStart, zonedDateToUtcEnd, toZonedInputValue, zonedInputToUtcIso } from './datetime'
+
+describe('zonedDateToUtcStart', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    // DST is in effect in July for America/New_York (EDT, UTC-4)
+    vi.setSystemTime(new Date('2026-07-29T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('converts user-timezone wall midnight to UTC', () => {
+    expect(zonedDateToUtcStart('2026-07-29', 'America/New_York')).toBe('2026-07-29T04:00:00.000Z')
+    expect(zonedDateToUtcStart('2026-07-29', 'UTC')).toBe('2026-07-29T00:00:00.000Z')
+  })
+
+  it('returns null for empty input', () => {
+    expect(zonedDateToUtcStart('', 'America/New_York')).toBeNull()
+    expect(zonedDateToUtcStart(null, 'America/New_York')).toBeNull()
+  })
+})
+
+describe('zonedDateToUtcEnd', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-29T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('converts user-timezone wall end-of-day to UTC', () => {
+    // 23:59:59.999 EDT -> 03:59:59.999 UTC the next calendar day
+    expect(zonedDateToUtcEnd('2026-07-29', 'America/New_York')).toBe('2026-07-30T03:59:59.999Z')
+    expect(zonedDateToUtcEnd('2026-07-29', 'UTC')).toBe('2026-07-29T23:59:59.999Z')
+  })
+
+  it('returns null for empty input', () => {
+    expect(zonedDateToUtcEnd('', 'America/New_York')).toBeNull()
+  })
+})
+
+describe('round-trip datetime-local conversion', () => {
+  it('zonedInputToUtcIso and toZonedInputValue are inverses for a known instant', () => {
+    const tz = 'America/New_York'
+    const utcIso = '2026-07-29T14:00:00.000Z'
+    const inputValue = toZonedInputValue(utcIso, tz)
+    expect(inputValue).not.toBe('')
+    expect(zonedInputToUtcIso(inputValue, tz)).toBe(utcIso)
+  })
+})

--- a/src/cqc_lem/ui/src/utils/datetime.ts
+++ b/src/cqc_lem/ui/src/utils/datetime.ts
@@ -11,6 +11,21 @@ function toUtcDate(isoString: string): Date {
   return new Date(hasOffset ? isoString : isoString + 'Z')
 }
 
+// Increment a `YYYY-MM-DD` string by exactly one calendar day using UTC date arithmetic so the
+// result is independent of the browser's local timezone.
+function _nextDateString(value: string): string | null {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!match) return null
+  const y = Number(match[1])
+  const m = Number(match[2]) - 1
+  const d = Number(match[3])
+  const next = new Date(Date.UTC(y, m, d + 1))
+  const yy = next.getUTCFullYear()
+  const mm = String(next.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(next.getUTCDate()).padStart(2, '0')
+  return `${yy}-${mm}-${dd}`
+}
+
 // Milliseconds `tz` is ahead of UTC at the given instant (DST-correct, because it asks Intl for the
 // wall clock that timezone actually shows at that instant).
 function tzOffsetMs(date: Date, tz: string): number {
@@ -105,13 +120,12 @@ export function zonedDateToUtcStart(value: string | null | undefined, tz: string
 // END of that day in the user's timezone. Used for inclusive end-date filters.
 export function zonedDateToUtcEnd(value: string | null | undefined, tz: string): string | null {
   if (!value) return null
-  const wallClockAsUtc = Date.parse(`${value}T23:59:59.999Z`)
-  if (isNaN(wallClockAsUtc)) return null
-  try {
-    let instant = wallClockAsUtc - tzOffsetMs(new Date(wallClockAsUtc), tz)
-    instant = wallClockAsUtc - tzOffsetMs(new Date(instant), tz)
-    return new Date(instant).toISOString()
-  } catch {
-    return new Date(wallClockAsUtc).toISOString()
-  }
+  // End-of-day is one millisecond before the start of the next wall day. Reusing the start-of-day
+  // conversion keeps DST transitions correct and avoids the millisecond drift the offset-based
+  // approach introduced when it rounded fractional seconds.
+  const nextDay = _nextDateString(value)
+  if (!nextDay) return null
+  const nextDayStart = zonedDateToUtcStart(nextDay, tz)
+  if (!nextDayStart) return null
+  return new Date(new Date(nextDayStart).getTime() - 1).toISOString()
 }

--- a/src/cqc_lem/ui/src/utils/datetime.ts
+++ b/src/cqc_lem/ui/src/utils/datetime.ts
@@ -84,3 +84,34 @@ export function zonedInputToUtcIso(value: string | null | undefined, tz: string)
     return new Date(wallClockAsUtc).toISOString()
   }
 }
+
+// Convert a user-timezone wall date (YYYY-MM-DD) to an explicit-UTC ISO string at the
+// START of that day in the user's timezone. The backend stores naive UTC, so we strip the
+// trailing 'Z' and offset — the API layer re-attaches UTC interpretation where needed.
+export function zonedDateToUtcStart(value: string | null | undefined, tz: string): string | null {
+  if (!value) return null
+  const wallClockAsUtc = Date.parse(`${value}T00:00:00Z`)
+  if (isNaN(wallClockAsUtc)) return null
+  try {
+    let instant = wallClockAsUtc - tzOffsetMs(new Date(wallClockAsUtc), tz)
+    instant = wallClockAsUtc - tzOffsetMs(new Date(instant), tz)
+    return new Date(instant).toISOString()
+  } catch {
+    return new Date(wallClockAsUtc).toISOString()
+  }
+}
+
+// Convert a user-timezone wall date (YYYY-MM-DD) to an explicit-UTC ISO string at the
+// END of that day in the user's timezone. Used for inclusive end-date filters.
+export function zonedDateToUtcEnd(value: string | null | undefined, tz: string): string | null {
+  if (!value) return null
+  const wallClockAsUtc = Date.parse(`${value}T23:59:59.999Z`)
+  if (isNaN(wallClockAsUtc)) return null
+  try {
+    let instant = wallClockAsUtc - tzOffsetMs(new Date(wallClockAsUtc), tz)
+    instant = wallClockAsUtc - tzOffsetMs(new Date(instant), tz)
+    return new Date(instant).toISOString()
+  } catch {
+    return new Date(wallClockAsUtc).toISOString()
+  }
+}

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1043,7 +1043,9 @@ def build_content_search_clause(search: Optional[str], column: str = 'content') 
 def get_posts(user_id: int, limit: int = 10, offset: int = 0,
               sort_order: str = 'asc', status_filter: Optional[str] = None,
               post_type_filter: Optional[str] = None, search: Optional[str] = None,
-              sort_by: str = 'scheduled_time') -> tuple[list, int]:
+              sort_by: str = 'scheduled_time',
+              start_date: Optional[datetime] = None,
+              end_date: Optional[datetime] = None) -> tuple[list, int]:
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
 
@@ -1059,6 +1061,12 @@ def get_posts(user_id: int, limit: int = 10, offset: int = 0,
         if post_type_filter:
             where += " AND post_type = %s"
             params.append(post_type_filter.lower())
+        if start_date is not None:
+            where += " AND scheduled_time >= %s"
+            params.append(to_naive_utc(start_date))
+        if end_date is not None:
+            where += " AND scheduled_time <= %s"
+            params.append(to_naive_utc(end_date))
         search_sql, search_params = build_content_search_clause(search)
         if search_sql:
             where += f" AND ({search_sql})"
@@ -1236,7 +1244,9 @@ def get_posted_posts(user_id: int):
 def get_post_by_email(email: str, limit: int = 10, offset: int = 0,
                       sort_order: str = 'asc', status_filter: Optional[str] = None,
                       post_type_filter: Optional[str] = None, search: Optional[str] = None,
-                      sort_by: str = 'scheduled_time') -> tuple[list, int]:
+                      sort_by: str = 'scheduled_time',
+                      start_date: Optional[datetime] = None,
+                      end_date: Optional[datetime] = None) -> tuple[list, int]:
     user_id = get_user_id(email)
 
     if not user_id:
@@ -1245,7 +1255,8 @@ def get_post_by_email(email: str, limit: int = 10, offset: int = 0,
 
     return get_posts(user_id, limit=limit, offset=offset, sort_order=sort_order,
                      status_filter=status_filter, post_type_filter=post_type_filter,
-                     search=search, sort_by=sort_by)
+                     search=search, sort_by=sort_by,
+                     start_date=start_date, end_date=end_date)
 
 
 def get_post_content(post_id: int):

--- a/tests/unit/api/test_main_posts.py
+++ b/tests/unit/api/test_main_posts.py
@@ -98,6 +98,8 @@ class TestGetPostsForEmail:
             post_type_filter=None,
             search=None,
             sort_by="scheduled_time",
+            start_date=None,
+            end_date=None,
         )
 
     def test_sort_order_desc(self, client):
@@ -116,6 +118,8 @@ class TestGetPostsForEmail:
             post_type_filter=None,
             search=None,
             sort_by="scheduled_time",
+            start_date=None,
+            end_date=None,
         )
 
     def test_status_filter_forwarded(self, client):
@@ -134,6 +138,8 @@ class TestGetPostsForEmail:
             post_type_filter=None,
             search=None,
             sort_by="scheduled_time",
+            start_date=None,
+            end_date=None,
         )
 
     def test_post_type_and_search_and_sort_by_forwarded(self, client):
@@ -157,6 +163,8 @@ class TestGetPostsForEmail:
             post_type_filter="carousel",
             search="ai AND marketing",
             sort_by="status",
+            start_date=None,
+            end_date=None,
         )
 
     def test_invalid_post_type_filter_422(self, client):
@@ -188,6 +196,29 @@ class TestGetPostsForEmail:
         assert resp.status_code == 200
         assert resp.json()["detail"]["total"] == 0
         assert resp.json()["detail"]["posts"] == []
+
+    def test_date_range_params_forwarded(self, client):
+        with patch(f"{_DB}.get_post_by_email", return_value=([], 0)) as mock_get:
+            resp = client.get(
+                "/api/posts/",
+                params={
+                    "email": "test@example.com",
+                    "start_date": "2026-07-01T00:00:00Z",
+                    "end_date": "2026-07-31T23:59:59Z",
+                },
+            )
+        assert resp.status_code == 200
+        mock_get.assert_called_once()
+        _, kwargs = mock_get.call_args
+        assert kwargs["start_date"] is not None
+        assert kwargs["end_date"] is not None
+
+    def test_malformed_start_date_returns_422(self, client):
+        resp = client.get(
+            "/api/posts/",
+            params={"email": "test@example.com", "start_date": "not-a-date"},
+        )
+        assert resp.status_code == 422
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utilities/test_db.py
+++ b/tests/unit/utilities/test_db.py
@@ -320,6 +320,55 @@ class TestGetPosts:
 
             assert posts == [] and total == 0
 
+    def test_start_date_filter_adds_lower_bound(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_posts
+        from datetime import datetime, timezone
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"total": 0}
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            start = datetime(2026, 7, 1, 0, 0, 0, tzinfo=timezone.utc)
+            get_posts(42, start_date=start)
+
+            count_sql, count_params = mock_database_connection["cursor"].execute.call_args_list[0][0]
+            assert "scheduled_time >= %s" in count_sql
+            assert datetime(2026, 7, 1, 0, 0, 0) in count_params
+
+    def test_end_date_filter_adds_upper_bound(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_posts
+        from datetime import datetime, timezone
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"total": 0}
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            end = datetime(2026, 7, 31, 12, 30, 0, tzinfo=timezone.utc)
+            get_posts(42, end_date=end)
+
+            count_sql, count_params = mock_database_connection["cursor"].execute.call_args_list[0][0]
+            assert "scheduled_time <= %s" in count_sql
+            assert datetime(2026, 7, 31, 12, 30, 0) in count_params
+
+    def test_date_range_converts_offset_to_naive_utc(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_posts
+        from datetime import datetime, timezone, timedelta
+
+        with patch("cqc_lem.utilities.db.get_db_connection") as mock_conn:
+            mock_conn.return_value = mock_database_connection["connection"]
+            mock_database_connection["cursor"].fetchone.return_value = {"total": 0}
+            mock_database_connection["cursor"].fetchall.return_value = []
+
+            # EDT (UTC-4) midnight -> 04:00 UTC naive
+            edt = timezone(timedelta(hours=-4))
+            start = datetime(2026, 7, 15, 0, 0, 0, tzinfo=edt)
+            get_posts(42, start_date=start)
+
+            count_params = mock_database_connection["cursor"].execute.call_args_list[0][0][1]
+            assert datetime(2026, 7, 15, 4, 0, 0) in count_params
+
 
 @pytest.mark.unit
 class TestBuildContentSearchClause:
@@ -419,6 +468,7 @@ class TestGetPostByEmail:
         mock_gp.assert_called_once_with(
             7, limit=5, offset=10, sort_order='desc', status_filter='approved',
             post_type_filter='video', search='ai OR ml', sort_by='status',
+            start_date=None, end_date=None,
         )
 
 

--- a/tests/unit/utilities/test_db_extended.py
+++ b/tests/unit/utilities/test_db_extended.py
@@ -491,7 +491,8 @@ class TestGetPostByEmail:
             assert total == 1
             mock_get_posts.assert_called_once_with(
                 42, limit=5, offset=10, sort_order="desc", status_filter="pending",
-                post_type_filter=None, search=None, sort_by="scheduled_time"
+                post_type_filter=None, search=None, sort_by="scheduled_time",
+                start_date=None, end_date=None
             )
 
 


### PR DESCRIPTION
## What
Adds a date range selector to the Content Studio "Review & Edit" post list. Users can pick a preset range (today, yesterday, last 7/30 days, this month, next 30 days) or enter a custom start/end date pair.

## How
- Extended  with optional  and  query parameters.
- Passed those bounds through  and , applying them as inclusive UTC filters on .
- Added preset + custom date UI controls to , wired into the existing filter/query key state.
- Added / helpers so the user's Login Location timezone is respected.

## Testing
- Updated  and  to cover the new query parameter flow and SQL bounds.
- Added UI unit tests for the preset/date helper logic and the custom input toggle.
- Python unit tests pass locally; UI tests require Node 20+ and are left for CI (the local runner is on Node 18).

Closes #727

🤖 Generated with [Claude Code](https://claude.com/claude-code)