### PR TITLE
fix(db): guard empty POST log rows for post_url lookup (closes #800)

### DIFF
--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -2538,19 +2538,21 @@ def get_post_age_minutes(user_id: int, post_id: int):
     return None if seconds is None else max(0.0, float(seconds) / 60.0)
 
 
-def get_post_url_from_log_for_user(user_id: int, post_id: int):
+def get_post_url_from_log_for_user(user_id: int, post_id: int) -> Optional[str]:
     connection = get_db_connection()
     cursor = connection.cursor()
 
     try:
-        cursor.execute("""SELECT post_url FROM logs 
-            WHERE user_id = %s AND post_id = %s AND action_type = %s AND result = %s  
-            ORDER BY created_at DESC 
+        cursor.execute("""SELECT post_url FROM logs
+            WHERE user_id = %s AND post_id = %s AND action_type = %s AND result = %s
+            ORDER BY created_at DESC
             LIMIT 1""",
                        (user_id, post_id, LogActionType.POST.value, LogResultType.SUCCESS.value))
-        post_url = cursor.fetchone()[0]
+        row = cursor.fetchone()
+        post_url = row[0] if row else None
     except mysql.connector.Error as err:
-        myprint(f"Could not get post url from log for user | Error: {err}")
+        log_warning("Could not get post url from log for user", exc=err,
+                    user_id=user_id, post_id=post_id)
         post_url = None
     finally:
         cursor.close()
@@ -2559,19 +2561,21 @@ def get_post_url_from_log_for_user(user_id: int, post_id: int):
     return post_url
 
 
-def get_post_message_from_log_for_user(user_id: int, post_id: int):
+def get_post_message_from_log_for_user(user_id: int, post_id: int) -> Optional[str]:
     connection = get_db_connection()
     cursor = connection.cursor()
 
     try:
-        cursor.execute("""SELECT message FROM logs 
+        cursor.execute("""SELECT message FROM logs
             WHERE user_id = %s AND post_id = %s AND action_type = %s AND result = %s
-            ORDER BY created_at DESC 
+            ORDER BY created_at DESC
             LIMIT 1""",
                        (user_id, post_id, LogActionType.POST.value, LogResultType.SUCCESS.value))
-        message = cursor.fetchone()[0]
+        row = cursor.fetchone()
+        message = row[0] if row else None
     except mysql.connector.Error as err:
-        myprint(f"Could not get post message from log for user | Error: {err}")
+        log_warning("Could not get post message from log for user", exc=err,
+                    user_id=user_id, post_id=post_id)
         message = None
     finally:
         cursor.close()

--- a/tests/unit/utilities/test_db.py
+++ b/tests/unit/utilities/test_db.py
@@ -5,6 +5,79 @@ from unittest.mock import MagicMock, patch, call
 from datetime import datetime, timezone
 
 
+_GET_CONN = "cqc_lem.utilities.db.get_db_connection"
+
+
+@pytest.mark.unit
+class TestPostUrlFromLogForUser:
+    """Issue #800: missing POST success log used to raise TypeError on cursor.fetchone()[0]."""
+
+    def test_returns_url_when_log_row_exists(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_url_from_log_for_user
+
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = ("https://www.linkedin.com/feed/update/urn:li:ugcPost:123",)
+
+            result = get_post_url_from_log_for_user(7, 42)
+
+        assert result == "https://www.linkedin.com/feed/update/urn:li:ugcPost:123"
+
+    def test_returns_none_when_no_log_row_exists(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_url_from_log_for_user
+
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = None
+
+            result = get_post_url_from_log_for_user(7, 42)
+
+        assert result is None
+
+    def test_returns_none_on_db_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_url_from_log_for_user
+        import mysql.connector
+
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("boom")
+
+            result = get_post_url_from_log_for_user(7, 42)
+
+        assert result is None
+
+
+@pytest.mark.unit
+class TestPostMessageFromLogForUser:
+    def test_returns_message_when_log_row_exists(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_message_from_log_for_user
+
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = ("Hello world",)
+
+            result = get_post_message_from_log_for_user(7, 42)
+
+        assert result == "Hello world"
+
+    def test_returns_none_when_no_log_row_exists(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_message_from_log_for_user
+
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].fetchone.return_value = None
+
+            result = get_post_message_from_log_for_user(7, 42)
+
+        assert result is None
+
+    def test_returns_none_on_db_error(self, mock_database_connection):
+        from cqc_lem.utilities.db import get_post_message_from_log_for_user
+        import mysql.connector
+
+        with patch(_GET_CONN, return_value=mock_database_connection["connection"]):
+            mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("boom")
+
+            result = get_post_message_from_log_for_user(7, 42)
+
+        assert result is None
+
+
 @pytest.mark.unit
 class TestPostStatusEnum:
     def test_enum_values(self):


### PR DESCRIPTION
## What & Why

Issue #800: PostHog error tracking reported `TypeError: 'NoneType' object is not subscriptable` on `GET /api/post_url/`.

Root cause: `get_post_url_from_log_for_user()` did `cursor.fetchone()[0]` directly. When no successful POST log row exists for the requested `(user_id, post_id)`, `fetchone()` returns `None`, and the subscript raised the exception. The same unsafe pattern existed in `get_post_message_from_log_for_user()`.

## Changes

- Read the row first; return `None` when `fetchone()` returns `None`.
- Downgrade MySQL errors from `myprint()` to a structured `log_warning()` with `user_id`/`post_id` context.
- Add `Optional[str]` return type hints.
- Add unit tests in `tests/unit/utilities/test_db.py` covering hit / miss / DB-error for both helpers.

## Testing

- `poetry run pytest tests/unit/api/test_post_url.py tests/unit/utilities/test_db.py -q -o addopts=""` passes (93 tests).
- The new tests exercise the exact missing-row path that previously raised.

Closes #800

🤖 Generated with [Claude Code](https://claude.com/claude-code)
