### PR TITLE
fix(agent-pipeline): reap abandoned agent:working claims + make the Ollama lane gauge see a broken proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,11 @@ downloads/
 eggs/
 .eggs/
 lib/
+# `lib/` above is the Python packaging rule, but it is unanchored — it matches a directory named
+# lib at ANY depth, which is why the agent pipeline's lib/ (its capacity/dispatch/lane libraries)
+# silently stayed out of the repo while the tick.sh beside it was tracked. Every other match is
+# under .venv/, which is ignored on its own line, so this negation loosens nothing else.
+!scripts/agent-pipeline/lib/
 lib64/
 parts/
 sdist/

--- a/scripts/agent-pipeline/RUNBOOK.md
+++ b/scripts/agent-pipeline/RUNBOOK.md
@@ -11,13 +11,53 @@ Repo: `christopherqueenconsulting/linkedin_engagement_manager`. Owner/escalation
 ## Ground rules (always)
 - **Obey `CLAUDE.md`** in the repo root — it overrides your defaults (logging via `cqc_lem.utilities.logger`,
   type hints, enums for status, no raw SQL outside `utilities/db.py`, LLM calls via the client aliases,
-  Selenium via `get_docker_driver()`, no hardcoded secrets, migrations advance from the highest existing V##).
+  Selenium via `get_docker_driver()`, no hardcoded secrets).
+- **DB migrations use TIMESTAMP versions.** A new migration file MUST be named `V<YYYYMMDDHHMMSS>__short_name.sql`
+  where the version is the UTC timestamp at authoring time — get it with `date -u +%Y%m%d%H%M%S`. NEVER use a bare
+  integer version (V57, V59, …) for a new migration, and NEVER rename an already-merged migration (Flyway tracks
+  applied ones by version+checksum — renaming breaks validation). Timestamps sort after all legacy integer
+  migrations, so two PRs can never collide.
 - **Stay scoped to the single issue.** Do not refactor unrelated code or touch other issues' files.
+- **Never close an issue that still has work left.** `Closes #N` in a PR body auto-closes #N the moment
+  the PR merges — so before you write it, re-read the issue and confirm your PR satisfies **every**
+  acceptance criterion. If any remains (an unchecked box you didn't implement, an explicit "Phase 2",
+  a "lands in a follow-up PR"), you MUST either file the follow-up issue and link it, or drop the
+  closing keyword. See **Phased work** below. This is not a formality: #548 shipped its Phase 1 and
+  its PR closed the issue, so Phase 2 was never filed and the remaining work silently vanished.
 - **Tests are mandatory:** new logic → `tests/unit/`; new API endpoints → `tests/integration/`. Target ≥80% patch coverage.
 - Run `poetry run pytest tests/unit -q` locally before pushing when the environment allows; **CI is the source of truth**.
 - **Never** edit files under `/opt/lem` (that is live prod), never run `docker`, never deploy, never touch secrets/`.env`.
 - Commit trailer: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
 - You are in a dedicated worktree already on the correct branch. Do not `git checkout main` or switch branches.
+
+## Phased work — an issue may be auto-closed ONLY when ALL its acceptance criteria are met
+Some issues are deliberately staged: a research/spike phase first, implementation after sign-off; or
+"2a → 2b → 2c" build orders. The failure mode this rule exists to prevent is real and has happened
+three times (#548, #568, #647): the first phase merged with `Closes #N` in the PR body, GitHub closed
+the issue, and the later phase — described only in prose inside a now-closed issue — was never filed
+and was lost.
+
+Before you open (or merge) a PR that closes an issue:
+1. **Re-read the issue body and its comments.** Look for unchecked acceptance boxes (`- [ ]`) you did
+   not implement, and for continuation wording: *Phase 2 / Part 2 / next phase / lands in a follow-up
+   PR / deferred to / tracked separately / out of scope for this issue / stretch*.
+2. If **nothing** remains → normal `Closes #N`. Tick the acceptance boxes in the issue body so the
+   record matches reality.
+3. If **something** remains, pick one — never neither:
+   - **(a) File the follow-up issue now.** Title it so the lineage is obvious
+     (`<original title> — Phase N (follow-up of #<orig>)`), quote the remaining scope from the
+     original, give it real acceptance criteria, and label it with the topical labels + `agent:ready`
+     + a `priority:` (+ `risk:*` if it needs the owner at merge). Then link it in **both** places:
+     `Follow-up: #<new>` in the PR body, and a comment on the original issue. Keep `Closes #N`.
+   - **(b) Don't claim the close.** Remove `Closes #N` from the PR body, write "Remaining on #N: …"
+     instead, and leave the issue open. Use this when the remainder is small or needs a decision
+     first.
+4. **Never** leave a later phase living only in prose. If it isn't an issue, it doesn't exist.
+
+`tick.sh` enforces this at the merge gate (`phase_guard_ok`): a PR whose closed issue declares a later
+phase with no linked follow-up is **not merged** — it gets a `🧩 phase-guard` comment, `needs-human` +
+`agent:blocked`, and the owner is assigned. Unchecked boxes alone only produce a warning comment, so
+clear them honestly. Clearing a hold = do (a) or (b), then re-label the PR `agent:working`.
 
 ## Escalate to a human instead of proceeding when:
 - The issue needs **live LinkedIn interaction / real credentials / a running Selenium session** you can't do headless.
@@ -26,31 +66,91 @@ Repo: `christopherqueenconsulting/linkedin_engagement_manager`. Owner/escalation
 - You've made **4+ fix attempts** on CI and it still fails, or you're otherwise stuck.
 
 To escalate: `gh issue edit <ISSUE> --add-label needs-human --add-assignee gitchrisqueen`, remove `agent:ready`
-(`--remove-label agent:ready`), post a comment explaining precisely what you need from the human, and if a
-PR exists convert it to draft (`gh pr ready --undo <PR>`) and label it `agent:blocked`. Then STOP.
+(`--remove-label agent:ready`), **post a Decision Comment (see below)**, and if a PR exists convert it to
+draft (`gh pr ready --undo <PR>`) and label it `agent:blocked`. Then STOP.
+
+## Decision Comment — REQUIRED whenever you hand anything to a human
+Any time you label something `needs-human` (in MODE=start with `RISK` set, or when escalating from any mode),
+you MUST leave a comment that turns the hold into **letter-pickable choices**, so the owner can decide by
+replying with just option letters. Never park a PR/issue with only prose — always give options + a recommendation.
+
+Rules:
+- **One numbered question per genuine decision** (usually 1–3). Do NOT invent decisions; if there's really only
+  one call to make, ask one question. CI failures and Copilot threads are NOT human decisions — you handle those.
+- Each question lists **lettered options A/B/C…**, each with its concrete consequence in a few words.
+- Mark the option you'd choose with `✅ *recommended*`, and end with an explicit **`My recommendation: 1A 2A …`**
+  line plus one sentence of why.
+- Tell the reader how to answer: *"Reply with one letter per question — e.g. `1A 2B` — or just `ok` to take all
+  recommendations."*
+- **Post the Decision Comment on the thread the human will actually be looking at**, and if you park both a PR
+  and its issue, put it on the PR and leave a one-line pointer on the issue. The runner watches BOTH threads for
+  the answer, so a reply on either unblocks the work — but the options have to exist somewhere findable.
+- Answers may arrive with extra context, with an option you never offered, or in plain prose (opening with
+  `@claude`, `decision:` or `go:`). All of those reach you; none of them are malformed. What does NOT unblock
+  work: a reply asking to hold ("don't merge yet", "hold off until…") or a free-form question — those stay
+  parked deliberately, so if you need a decision, ask something answerable.
+- Ground every option in what the PR actually does (real default values, real cadence, real flags) — read the
+  diff; don't guess.
+- If the only thing needed is a yes/no approval, still frame it as options (A approve / B change X / C don't ship).
+
+Template:
+```
+## 🧑‍⚖️ Human decision needed — reply with option letters
+Held (`needs-human`, risk: <reason>). <one line on what/why it needs you>.
+Reply one letter per question — e.g. `1A 2A` — or `ok` for all recommendations.
+
+### 1. <question>?
+- **A. <option>** — <consequence>  ✅ *recommended*
+- **B. <option>** — <consequence>
+- **C. <option>** — <consequence>
+
+**My recommendation: `1A`.** <one sentence why.>
+```
+
+After the owner replies with letters, a `MODE=revise` tick applies their choice; if they reply `ok`, apply every
+recommendation. Treat a bare-letters/`ok` reply as the instruction — no further questions needed.
 
 ---
 
 ## MODE=start  (env: ISSUE, WORKTREE, RISK, BRANCH)
 A fresh worktree on branch `$BRANCH` (from origin/main) is ready. Implement issue #$ISSUE.
-1. `gh issue view $ISSUE` — read the full issue (Why/Scope/Files/Acceptance).
+1. `gh issue view $ISSUE --comments` — read the full issue (Why/Scope/Files/Acceptance) **and its comments**.
+   If the issue was previously parked and a **Decision Comment** was posted on it, the owner's reply to that
+   comment is part of your instructions — the runner routes an answered issue back here. Apply it exactly as
+   MODE=revise does (see its step 1): letters map to the options named, context after the letters counts,
+   an off-menu answer wins over the options that were offered, and a side-instruction ("also open an issue
+   for X") becomes a linked issue rather than extra scope in this PR. If their answer changes the shape of
+   the work, say so in the PR body.
 2. Implement the smallest correct change that satisfies the acceptance criteria, following `CLAUDE.md`.
    Reuse existing utilities named in the issue; don't invent parallel helpers.
 3. Add/extend tests. Run unit tests locally if you can.
 4. Commit atomically with a clear conventional-commit message.
 5. `git push -u origin $BRANCH`.
-6. Open the PR:
+6. **Scope check BEFORE you claim the close** (see "Phased work" above). Re-read issue #$ISSUE: does this
+   PR satisfy **every** acceptance criterion? If any remains — an unchecked box you did not implement, or
+   an explicit later phase ("Phase 2", "lands in a follow-up PR", "deferred to") — do one of:
+   - **(a)** File the follow-up issue now — `<original title> — Phase N (follow-up of #$ISSUE)`, quoting
+     the remaining scope, labeled topical + `agent:ready` + a `priority:` (+ `risk:*` if it needs the
+     owner at merge); check it doesn't already exist (`gh issue list --search`). Link it as
+     `Follow-up: #<new>` in the PR body **and** comment it on #$ISSUE. Keep `Closes #$ISSUE`.
+   - **(b)** Omit `Closes #$ISSUE` from the PR body, state "Remaining on #$ISSUE: …", leave it open.
+
+   Never leave the remainder in prose only — the merge gate (`phase_guard_ok`) holds the PR if you do.
+7. Open the PR:
    `gh pr create --base main --head $BRANCH --title "<type>(<scope>): <summary> (closes #$ISSUE)"
     --body "<what & why, testing notes, 'Closes #$ISSUE'>" --label agent:working`
    End the PR body with: `🤖 Generated with [Claude Code](https://claude.com/claude-code)`.
-7. **Do NOT enable auto-merge.** Merge is controlled by the runner (`tick.sh`), which merges only after
-   CI is green AND Copilot has reviewed the current head AND every Copilot thread is resolved.
+8. **Do NOT enable auto-merge.** Merge is controlled by the runner (`tick.sh`), which merges only after
+   CI is green AND one fresh review exists (the runner's Claude adversarial review — or Copilot's,
+   which the runner requests ONLY on `risk:*`/`review:copilot` PRs since Copilot credits are metered)
+   AND every Copilot review thread (if any) is resolved. Do NOT request Copilot review yourself.
    - If `RISK=none`: leave the PR labeled `agent:working`. The runner takes it from here (fix → review → merge).
    - If `RISK` is non-empty (migration/security/live-linkedin/product-decision): add label `needs-human`,
-     assign `gitchrisqueen`, comment that it's held for human review before it deploys to prod, then **park it**
-     so the serial pipeline proceeds: `gh pr edit <pr> --add-label agent:blocked --remove-label agent:working`
-     and `gh issue edit <ISSUE> --add-label agent:blocked --remove-label agent:working`. The human owns it.
-8. STOP. (CI + Copilot review happen asynchronously; later ticks handle fix/review/merge.)
+     assign `gitchrisqueen`, **post a Decision Comment (see "Decision Comment" above) — lettered options +
+     a recommendation, NOT just prose** — then **park it** so the serial pipeline proceeds:
+     `gh pr edit <pr> --add-label agent:blocked --remove-label agent:working` and
+     `gh issue edit <ISSUE> --add-label agent:blocked --remove-label agent:working`. The human owns it.
+9. STOP. (CI + review happen asynchronously; later ticks handle fix/review/selfreview/merge.)
 
 ## MODE=fix  (env: PR, ISSUE, WORKTREE, BRANCH, ATTEMPTS)
 Required CI checks are failing on PR #$PR (attempt #$ATTEMPTS). The worktree is on `$BRANCH`.
@@ -98,6 +198,67 @@ do NOT blindly patch the branch:
    ~3 Claude attempts per branch, then escalates automatically.) STOP.
    Once the Dependabot PR is green, the existing `dependabot-auto-merge` workflow enqueues it — you do NOT merge it.
 
+## MODE=revise  (env: PR, BRANCH, WORKTREE, OWNER)
+The repo owner (@$OWNER) reviewed PR #$PR and requested changes (label `agent:revise`). Implement **their**
+feedback — this is distinct from Copilot's threads (that's MODE=review). Worktree is on `$BRANCH`.
+1. Gather ALL of the owner's feedback on this PR:
+   - Latest review: `gh pr view $PR --repo christopherqueenconsulting/linkedin_engagement_manager --json reviews` → the most recent review by `$OWNER` (its body + state).
+   - Inline review comments: `gh api repos/christopherqueenconsulting/linkedin_engagement_manager/pulls/$PR/comments` → those authored by `$OWNER`.
+   - Recent PR comments: `gh pr view $PR --json comments` → recent comments by `$OWNER`.
+   - **If a Decision Comment was posted, find it and read the owner's reply to it IN FULL.** That reply is the
+     authoritative instruction for this PR. Map each option letter to the option it names (`ok` = every
+     `✅ recommended` option) and implement exactly those choices — a bare-letters or `ok` reply IS the complete
+     instruction, do not re-ask. Three more shapes reach you here, and you MUST handle all of them:
+     - **Context or extra asks after the letters** — e.g. `1A 2C (also research hosted grid options) 3A`. The
+       parenthetical is not decoration, it is part of the instruction. Honour every clause.
+     - **Off-menu answers** — the owner may pick a letter you never offered, or answer in prose with a different
+       approach entirely (their reply may open with `@claude`, `decision:` or `go:`). **Their answer wins over
+       your options.** Don't argue the menu back at them. If what they asked is genuinely unsafe or contradicts
+       the code, implement the closest safe reading and explain the gap in your reply.
+     - **Side-instructions that don't belong in this PR** — "open an issue to research X", "check whether Y is
+       still true". Do NOT cram these into the diff. **First check whether the issue already exists**
+       (`gh issue list --search`, and read the PR comments — someone may have filed it already and said so); if
+       it does, link it instead of filing a duplicate. Otherwise create it with the repo's label conventions
+       (`agent:ready` + a `priority:` label, plus `risk:` if it needs the owner at merge). Either way, link it in
+       your reply comment so the owner can see the ask was captured rather than dropped.
+     Anything you deliberately did NOT do must be named in your reply — silence reads as "done".
+2. Implement each requested change, scoped to this PR, following `CLAUDE.md`. If a request is ambiguous or you
+   think it's wrong, implement your best interpretation AND leave a reply explaining — never silently skip it.
+3. Add/adjust tests; run `poetry run pytest tests/unit -q` on the touched areas if feasible.
+4. Commit (Claude co-author trailer) + `git push`.
+5. Reply summarizing what you changed: `gh pr comment $PR --body "Addressed your review: …"`.
+6. Hand the PR forward to merge:
+   `gh pr edit $PR --add-label agent:working --remove-label agent:revise --remove-label needs-human --remove-label agent:blocked`.
+   The runner then re-runs CI + Copilot review and merges it. STOP.
+   (If you could NOT safely implement a request, instead: `gh pr edit $PR --add-label needs-human --add-assignee $OWNER --remove-label agent:revise`, explain why, STOP.)
+
+## MODE=selfreview  (env: PR, ISSUE, BRANCH, WORKTREE, MARKER)
+You are the ADVERSARIAL REVIEWER for PR #$PR — you did NOT write this code and must not assume it
+works. Copilot reviews are budgeted (metered AI credits), so for most PRs YOU are the review gate.
+Your review is only worth running if it would catch what the author missed — hunt, don't skim.
+1. Read the PR: `gh pr view $PR --json title,body,files` and the full diff (`gh pr diff $PR`). Read the
+   linked issue's acceptance criteria. Read surrounding code the diff touches — bugs live at the seams.
+2. Review adversarially for: real defects (logic, edge cases, races, error paths), acceptance-criteria
+   gaps, CLAUDE.md convention violations (logger, db.py-only SQL, enums, tier aliases, get_docker_driver),
+   security/injection issues, test gaps on changed behavior, and silent failure modes. Style nits are NOT
+   findings — flag only what you would block a human PR for.
+   **Also check the close is honest:** if the PR says `Closes #N`, confirm the diff covers every acceptance
+   criterion and that no later phase is left untracked (see "Phased work"). A PR that closes an issue while
+   leaving scope behind IS a finding — fix it by filing + linking the follow-up, or by dropping the closing
+   keyword and saying what remains.
+3. For each REAL finding: FIX IT in the worktree (you are on $BRANCH), with tests where behavior changed.
+   Run the relevant unit tests locally. Commit (Claude co-author trailer) + `git push`.
+4. Post the verdict comment — the merge gate looks for the marker, so the comment MUST START with the
+   exact MARKER text, then one line per finding (or "no findings"):
+   `gh pr comment $PR --body "$MARKER — <PASS|FIXED n findings>
+   - <finding>: <what you changed>"`
+   Post the marker comment EVEN WHEN you found nothing (that IS the review evidence). Post it AFTER any
+   push, so the marker is newer than the head commit.
+5. If you find something you cannot safely fix (needs a product decision, or the whole approach is
+   wrong): do NOT post the marker; escalate instead — `needs-human` + `agent:blocked` on the PR and
+   issue, Decision Comment with options, STOP.
+6. STOP after posting the marker. The runner re-checks CI (your push re-triggers it) and merges.
+
 ## MODE=rebase  (env: PR, ISSUE, BRANCH, WORKTREE)
 PR #$PR is **CONFLICTING** with `main` — it went stale while other PRs merged. The worktree is on `$BRANCH`.
 Rebase it cleanly onto current `main`:
@@ -105,13 +266,22 @@ Rebase it cleanly onto current `main`:
 2. Resolve **every** conflict, preserving BOTH this PR's intent AND what landed on `main`. If `main` added
    overlapping code (e.g. another PR already added authenticity/attribution logic to the same file),
    **integrate** with it — do not clobber what's on main, and don't duplicate it.
-3. **Migration numbers:** if this PR adds `compose/local/database/migrations/V##__*.sql` and that number now
-   exists on `main`, rename yours to the next free `V##` and update any code/tests that reference it.
+3. **Migrations:** new migrations must be TIMESTAMP versions `V<YYYYMMDDHHMMSS>__name.sql` (`date -u +%Y%m%d%H%M%S`).
+   If a rebase surfaces a duplicate/again-conflicting version, rename the migration THIS PR adds (never a
+   migration already on `main`) to a fresh timestamp. Never reuse an integer version.
 4. Run `poetry run pytest tests/unit -q` on the touched areas if feasible.
 5. `git push --force-with-lease` (re-triggers CI + a fresh Copilot review). STOP.
 6. If the conflicts are too complex to resolve safely, escalate:
    `gh pr edit $PR --add-label needs-human --add-assignee gitchrisqueen`, comment exactly what conflicts, STOP.
 
 ---
+## Model labels (`agent:model:*`)
+Issues may carry `agent:model:sonnet` / `agent:model:haiku` / `agent:model:opus` — the runner passes
+that model to `claude --model` for every run on that issue. These labels are the OWNER's cost dial:
+never add, remove, or change them yourself. If an issue feels too hard for the model you're running
+as, don't grind — escalate with `needs-human` and say the model tier may be the problem. When
+CREATING side-instruction issues you may suggest a tier in a comment, but leave labeling to the owner
+(exception: trivial docs-only issues you create may carry `agent:model:sonnet` from the start).
+
 Keep each tick focused and finite. Prefer correctness and convention-compliance over speed — a clean PR that
-passes CI and Copilot review the first time is the goal.
+passes CI and review the first time is the goal.

--- a/scripts/agent-pipeline/docs/agent-pipeline-routing.md
+++ b/scripts/agent-pipeline/docs/agent-pipeline-routing.md
@@ -1,0 +1,314 @@
+# Agent Pipeline — Capacity-Aware Routing Runbook
+
+How the LEM agent pipeline (`/home/lem/agent-pipeline/tick.sh`) chooses between the **Claude
+subscription lane** and the **Ollama cloud lane (via LiteLLM)**, reports into PostHog, labels
+issues/PRs, and runs the Perplexity research MCP server.
+
+## TL;DR — lane selection
+
+Every `claude -p` run goes through `lib/run_lane.sh → lib/dispatch.sh → dispatch_lane()`, which
+applies the **>50% rule** to the two lanes' estimated capacity:
+
+| Claude | Ollama | SLOT | Decision |
+|---|---|---|---|
+| >50% | >50% | 1 | **Claude primary** (highest-priority issue) |
+| >50% | >50% | ≥2 | **Ollama parallel** (additional issues, horizontal throughput) |
+| ≤50% | >50% | any | **Ollama fallback** |
+| exhausted/unavailable | >50% | any | **Ollama fallback** (`fallback_from=claude`) |
+| >50% | ≤50% | any | **Claude only** |
+| ≤50% | ≤50% | any | **Degraded**: CAP forced to 1, new issue starts held; triage/merge/answer still run |
+
+Slot 1 always takes the highest-priority issue (`select_next_issue`), so when both lanes are
+healthy Claude gets the hardest task and Ollama handles the rest in parallel.
+
+## The >50% rule and capacity estimation
+
+`lib/capacity.sh` estimates each lane's capacity as a percentage and treats `> LANE_CAPACITY_THRESHOLD`
+(default 50) as "available". **Honest limitation:** neither Anthropic's Max subscription nor Ollama
+Cloud exposes a "remaining % this session/week" API, so the gauge estimates from rolling run
+outcomes plus a cheap health probe, and lets the owner pin it when they know the real headroom:
+
+- **Claude lane**
+  - `PAUSED_UNTIL` active (written when a run fails with a usage-limit message) → 0% (exhausted)
+  - a usage-limit hit within `CLAUDE_USAGE_COOLDOWN` (2h) → 25% (constrained)
+  - ≥3 failures within `CLAUDE_FAIL_WINDOW` (30m) → 40% (constrained)
+  - otherwise → 80% (healthy)
+  - **override:** `CLAUDE_CAPACITY_PCT=N` in `config.env` (empty = estimate)
+- **Ollama lane**
+  - `OLLAMA_LANE_ENABLED=0` → 0% (disabled)
+  - LiteLLM liveliness probe (`/health/liveliness`) down → 0% (unavailable)
+  - `OLLAMA_PROBE=1` → also sends a 1-token completion to confirm cloud is actually serving
+  - ≥2 failures within `OLLAMA_FAIL_WINDOW` (30m) → 30% (constrained)
+  - otherwise → 75% (healthy)
+  - **override:** `OLLAMA_CAPACITY_PCT=N` in `config.env` (empty = estimate)
+
+State lives in `/home/lem/agent-pipeline/state/<lane>.state` (inspectable/repairable). Set an
+override when you KNOW the real headroom, e.g. the subscription just reset:
+`CLAUDE_CAPACITY_PCT=90` (leave empty to resume the estimate).
+
+## Ollama cloud model tiers (cloud-only, by policy)
+
+Mapped in `.litellm/config.yaml` as `lem-agent-*` aliases (reusing `OLLAMA_CLOUD_URL` +
+`OLLAMA_CLOUD_API_KEY` already in `/opt/lem/.env`):
+
+| Alias | Cloud model | Use |
+|---|---|---|
+| `lem-agent-tier1` | `glm-5.2:cloud` | hardest long-horizon / architecture / multi-step (opt-in via `agent:tier:1` — slow thinking model, intermittently times out) |
+| `lem-agent-tier2` | `kimi-k2.7-code:cloud` | **default** coding lane: patches, tests, multi-file edits |
+| `lem-agent-tier2-alt` | `minimax-m3:cloud` | premium parallel / vision-capable alternate (opt-in via `agent:tier:2-alt`) |
+| `lem-agent-tier3` | `nemotron-3-super:cloud` | reviewer / reasoning lane (used for `MODE=selfreview`) or opt-in via `agent:tier:3` |
+
+LiteLLM falls hard tasks down the chain (`tier1→tier2→tier3`, `tier2→tier3`) before failing.
+**Local models are not used on this path** — the Ollama Max subscription is cloud-first.
+
+### How the Ollama lane executes (reuses the claude CLI)
+
+The Ollama lane runs the **same `claude -p` CLI** as the Claude lane, but pointed at LiteLLM:
+
+```
+ANTHROPIC_BASE_URL=http://127.0.0.1:4000 \
+ANTHROPIC_AUTH_TOKEN=$LITELLM_MASTER_KEY \
+claude -p "<RUNBOOK MODE prompt>" --model lem-agent-tier2 --dangerously-skip-permissions ...
+```
+
+LiteLLM serves the Anthropic `/v1/messages` endpoint and translates to the Ollama cloud model,
+so the entire RUNBOOK/MODE machinery (depfix/revise/rebase/fix/review/selfreview/start) is reused
+unchanged — only the model + base URL differ. If an Ollama-lane run fails, the capacity gauge
+records the outcome and the issue is retried on the next tick (possibly on Claude).
+
+## PostHog telemetry
+
+Reuses the EXISTING PostHog project keys from `/opt/lem/.env` (copied into
+`/home/lem/agent-pipeline/secrets.env` at setup) — **no second PostHog project**. Emitted by
+`lib/posthog.sh` (server-side `/capture`), best-effort, never blocks a tick. Common properties on
+every event: `lem_component`, `environment`, `repo`, `execution_id`, `worker_id`, `lane`,
+`provider`, `model`, `model_tier`, `route_reason`, `issue_number`, `pr_number`, `issue_priority`,
+`issue_type`.
+
+| Event | When | Extra props |
+|---|---|---|
+| `capacity_preflight` | once per tick | `claude_pct/status`, `ollama_pct/status`, `degraded` |
+| `routing_decision_made` | per run, after dispatch | `fallback_from/to`, `issue_url` |
+| `issue_queued` | issue selected for START | `issue_url` |
+| `issue_assigned` | run_lane starts | — |
+| `ai_call_started` | before `claude -p` | — |
+| `ai_call_completed` / `ai_call_failed` | after run | `success`, `latency_ms`, `error_type`, `tokens_*` (0 — see below), `estimated_cost` |
+| `issue_completed` / `issue_failed` | after run | `error_type/message` |
+| `pr_opened` / `pr_updated` | PR detected after run | `pr_number` |
+| `fallback_triggered` | `route_reason=fallback` | — |
+| `lane_escalation_triggered` | `route_reason=degraded/escalated` | — |
+| `mcp_research_started/completed/failed` | MCP tool call | `latency_ms`, `citations`, `error_type` |
+
+**Token/cost accounting:** the Ollama lane's per-call tokens + cost are owned by LiteLLM's native
+`$ai_generation` PostHog callback (configured in `.litellm/config.yaml`, fed `POSTHOG_API_KEY`/`POSTHOG_HOST`
+from the same `/opt/lem/.env`). The Claude lane is a flat-rate subscription (no per-call cost). The
+agent-pipeline's own `ai_call_*` events carry `tokens_*=0` deliberately — **do not sum** the two
+streams; join on `execution_id` + `model` for the full picture. (Same two-stream contract the LEM
+app uses: `llm_call` vs `$ai_generation`.)
+
+Filter dashboards by `lane`, `provider`, `model`, `model_tier`, `route_reason`, `repo`,
+`issue_number`, `pr_number`, `error_type`.
+
+## GitHub labels
+
+`lib/labels.sh` bootstraps (idempotent, first tick) and applies these `ai:*` labels so dashboards
+and `gh` filters can see which lane/model handled a thread:
+
+```
+ai:claude-subscription            ai:ollama-cloud
+ai:claude-subscription:sonnet     ai:ollama-cloud:tier1|tier2|tier2-alt|tier3
+ai:claude-subscription:haiku      ai:ollama-cloud:glm-5.2 | kimi-k2.7-code | minimax-m3 | nemotron-3-super
+ai:claude-subscription:opus
+ai:routed:parallel | fallback | escalated | degraded
+```
+
+Applied add-only to the issue (or PR when no issue) after each run. To force an Ollama tier on an
+issue, add `agent:tier:1` / `agent:tier:2-alt` / `agent:tier:3` (tier2 is the default; tier1 is
+opt-in only). To force a Claude model, the existing `agent:model:sonnet|haiku|opus` labels work.
+
+## Perplexity research MCP server
+
+`mcp/perplexity_server.py` is a FastMCP server exposing `research(query, recency)` and
+`fact_check(claim)` backed by Perplexity Sonar. It runs as a **persistent systemd service**
+(`lem-mcp-perplexity.service`) on streamable-http at `http://127.0.0.1:8765/mcp` (loopback only).
+Both lanes pass `--mcp-config /home/lem/agent-pipeline/mcp/mcp-config.json` to `claude -p`, so
+agent runs can do web research during issue handling. The server emits its own
+`mcp_research_*` PostHog events (same project).
+
+## systemd + VPS resource controls
+
+- **`lem-agent.slice`** — shared CPU/RAM ceiling (`CPUQuota=300%`, `MemoryMax=3G`) for host-side
+  agent-pipeline workers (the MCP service, and any future tick worker). Adding parallel lane
+  workers cannot each spend a full host.
+- **`lem-mcp-perplexity.service`** — lives in the slice, plus service-level guards
+  (`MemoryMax=1G`, `CPUQuota=120%`).
+- **LiteLLM** — capped **separately** via Docker `deploy.resources` (not in the slice): gunicorn
+  `--num_workers` (default 3, configurable via `LITELLM_NUM_WORKERS`) + `LITELLM_MEM_LIMIT`
+  (1500m) + `LITELLM_CPU_LIMIT` (2.5). Tune all of these in `config.env`.
+
+## Setup / first-time install (run once)
+
+```bash
+# 1) Reuse the existing prod keys for the host-side agent pipeline (mode 600, lem-owned).
+sudo bash -c '
+  set -e
+  SRC=/opt/lem/.env; DST=/home/lem/agent-pipeline/secrets.env
+  : > "$DST"
+  for k in POSTHOG_API_KEY POSTHOG_HOST LITELLM_MASTER_KEY OLLAMA_CLOUD_API_KEY \
+           OLLAMA_CLOUD_URL PERPLEXITY_API_KEY; do
+    v=$(grep -E "^${k}=" "$SRC" | head -1 | sed -E "s/^${k}=//" \
+        | sed -E "s/^\"(.*)\"$/\1/" | sed -E "s/^'\''(.*)'\''$/\1/")
+    [ -n "$v" ] && printf "%s=%s\n" "$k" "$v" >> "$DST"
+  done
+  chown lem:lem "$DST"; chmod 600 "$DST"'
+
+# 2) FastMCP Perplexity server venv + systemd unit.
+python3 -m venv /home/lem/agent-pipeline/mcp/.venv
+/home/lem/agent-pipeline/mcp/.venv/bin/pip install -q -r /home/lem/agent-pipeline/mcp/requirements.txt
+sudo install -d /etc/lem -m 755
+sudo bash -c '
+  SRC=/opt/lem/.env; DST=/etc/lem/mcp-perplexity.env
+  : > "$DST"
+  for k in PERPLEXITY_API_KEY POSTHOG_API_KEY POSTHOG_HOST; do
+    v=$(grep -E "^${k}=" "$SRC" | head -1 | sed -E "s/^${k}=//" \
+        | sed -E "s/^\"(.*)\"$/\1/" | sed -E "s/^'\''(.*)'\''$/\1/")
+    [ -n "$v" ] && printf "%s=%s\n" "$k" "$v" >> "$DST"
+  done
+  printf "ENVIRONMENT=production\nMCP_HOST=127.0.0.1\nMCP_PORT=8765\n" >> "$DST"
+  chmod 600 "$DST"; chown lem:lem "$DST"'
+sudo install -m 644 /home/lem/agent-pipeline/systemd/lem-agent.slice /etc/systemd/system/
+sudo install -m 644 /home/lem/agent-pipeline/systemd/lem-mcp-perplexity.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now lem-agent.slice lem-mcp-perplexity.service
+curl -fsS http://127.0.0.1:8765/mcp >/dev/null && echo "MCP up" || echo "MCP NOT up"
+
+# 3) LiteLLM aliases + gunicorn + loopback publish already applied to prod; recreate if not:
+#    sudo bash -c 'cd /opt/lem && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --no-deps --force-recreate litellm'
+```
+
+## Restart / reload
+
+```bash
+# MCP research server
+sudo systemctl restart lem-mcp-perplexity.service
+sudo systemctl status  lem-mcp-perplexity.service
+journalctl -u lem-mcp-perplexity -n 50          # or tail logs/mcp-perplexity.log
+
+# LiteLLM (container) — picks up .litellm/config.yaml changes
+sudo bash -c 'cd /opt/lem && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --no-deps --force-recreate litellm'
+curl -fsS http://127.0.0.1:4000/health/liveliness   # -> "I'm alive!"
+
+# tick.sh / agent pipeline — no daemon to restart; it is cron-driven every ~5 min. To force a tick:
+DRY_RUN=1 bash /home/lem/agent-pipeline/tick.sh     # validates routing without launching claude
+bash /home/lem/agent-pipeline/tick.sh              # real tick
+```
+
+## Lane health: liveliness is not usability
+
+`/health/liveliness` proves the LiteLLM **proxy** answers. It says nothing about whether the proxy
+will serve the tier alias the lane passes as `--model`. Those came apart on **2026-07-29**: the
+proxy was up, the gauge read `75 healthy`, and every run died on
+`anthropic_messages: Invalid model name passed in model=lem-agent-tier2` — 49 consecutive dead runs
+that each claimed an issue `agent:working` and then abandoned it. Two things made that invisible:
+
+- `_ollama_probe` classified on **curl's exit code**, and `curl -sS` (no `-f`) exits 0 on an HTTP
+  400 — so a hard rejection was recorded as a healthy probe.
+- `_maybe_probe_ollama` only fired after a **usage-limit**. A broken alias, a rotated key or a bad
+  `api_base` fails every run without ever matching the usage-limit regex, so the one failure mode
+  that had already eaten a day of backlog could never trigger recovery.
+
+Now: `_litellm_probe` classifies on the **HTTP status** (`0` served / `1` usage-limited / `2`
+broken) and leaves the reason in `state/.litellm_probe_detail`; `_ollama_alias_ok` validates the
+real tier alias and caches the verdict for `OLLAMA_ALIAS_TTL` (default 3600s — about one token an
+hour, not one per tick); a failing alias makes `ollama_capacity` report **`0 unavailable`** so
+dispatch routes to Claude instead of feeding issues into a lane that cannot run them. The probe also
+fires after `OLLAMA_FAIL_PROBE_AT` (default 3) consecutive plain failures.
+
+Check it by hand:
+
+```bash
+# prints 0 (served) / 1 (usage-limited) / 2 (broken)
+BASE=/home/lem/agent-pipeline . /home/lem/agent-pipeline/lib/capacity.sh
+_litellm_probe lem-agent-tier2 ; cat /home/lem/agent-pipeline/state/.litellm_probe_detail
+```
+
+## Stale-claim reaper
+
+`agent:working` is stamped when a run **starts**, and `select_next_issue` excludes it — so a run
+that dies before opening a PR parks its issue in a state nothing else leaves. On 2026-07-29/30
+sixteen issues accumulated there and the queue drained to zero while every tick logged
+`Pipeline idle` with both lanes green: silence was indistinguishable from done.
+
+`reap_stale_claims` runs once per tick (skipped under `DRY_RUN`) and returns an issue to
+`agent:ready` only when **all** of these hold, so live work is never yanked out from under a run:
+
+| Guard | Why |
+|---|---|
+| no OPEN PR linked (`pr_for_issue`) | a PR means the run got far enough to hand off |
+| branch claim lock is free | a concurrent slot working it holds that `flock` |
+| untouched for `STALE_CLAIM_MINUTES` (default 120) | label edits count as touches |
+| not `needs-human` / `agent:blocked` | already parked deliberately |
+
+Bounded by `STALE_CLAIM_MAX_REQUEUES` (default 3, counted in `state/requeue-<n>.count`, cleared
+once a PR appears): past that the issue gets `needs-human` + `agent:blocked`, the owner is assigned
+and a comment explains why, rather than cycling forever on whatever keeps killing the run. Emits
+`issue_reaped` to PostHog (`action: requeued|parked`). Log lines are prefixed `REAPER:`.
+
+> Stale `ai:*` routing labels are stripped on requeue, and the list is read **off the issue**, never
+> hardcoded — `gh issue edit` rejects the *entire* edit if any named label is unknown to the repo,
+> so one drifted name in a static list silently undoes the whole requeue. A hardcoded `ai:claude`
+> (the real label is `ai:claude-subscription`) did exactly that during testing.
+
+## Troubleshooting
+
+- **Issues stuck in `agent:working` with no PR** → the reaper handles this within
+  `STALE_CLAIM_MINUTES`. To force it now: `STALE_CLAIM_MINUTES=1 /home/lem/agent-pipeline/tick.sh`.
+  If an issue keeps coming back, look for `REAPER: … parking for a human` and read the failing run
+  in `logs/`.
+- **Ollama lane never used** → check `state/ollama.state` (including `alias_ok` / `alias_ok_ts`),
+  the gauge, and `OLLAMA_LANE_ENABLED`.
+  `OLLAMA_PROBE=1` adds a real completion probe (more accurate). Pin `OLLAMA_CAPACITY_PCT=80` to
+  force it healthy for testing.
+- **Claude lane never used / always degraded** → `CLAUDE_CAPACITY_PCT=90` to override a stale
+  estimate; clear `PAUSED_UNTIL` (`rm /home/lem/agent-pipeline/PAUSED_UNTIL`) if a usage-limit pause
+  is stale.
+- **LiteLLM `/v1/messages` 404 / model not found** → the `lem-agent-*` aliases aren't loaded:
+  recreate the container (above). Verify with `curl -X POST http://127.0.0.1:4000/v1/messages
+  -H "x-api-key: $LITELLM_MASTER_KEY" -H "anthropic-version: 2023-06-01" -H 'content-type:
+  application/json' -d '{"model":"lem-agent-tier2","max_tokens":5,"messages":[{"role":"user","content":"ok"}]}'`.
+- **Ollama cloud model times out** → `glm-5.2:cloud` (tier1) is a slow thinking model and
+  intermittently times out; that's why it's opt-in (`agent:tier:1`) and the default is tier2
+  (`kimi-k2.7-code:cloud`). LiteLLM's fallback chain should drop to tier2/tier3 automatically.
+- **No PostHog events** → `secrets.env` must have `POSTHOG_API_KEY` + `POSTHOG_HOST`; the
+  `capacity_preflight` event fires every tick — if it's absent, PostHog capture is failing
+  (logged to the tick log as `[posthog] capture failed ...`). Check the host in `secrets.env`.
+- **MCP research tool errors** → `tail logs/mcp-perplexity.log`; `PERPLEXITY_API_KEY` must be set
+  in `/etc/lem/mcp-perplexity.env`. The tool returns a short error string rather than raising, so
+  an agent run degrades gracefully.
+- **VPS memory pressure** → LiteLLM is capped (compose `deploy.resources`) + the slice caps
+  workers; lower `LITELLM_NUM_WORKERS` / `LITELLM_MEM_LIMIT` in `config.env` and recreate LiteLLM.
+- **Routing decision log lines** → `[dispatch] lane=… model=… reason=…` and `[dispatch] claude=…%
+  ollama=…% degraded=…` in `logs/tick-YYYYMMDD.log`.
+
+## Files changed
+
+| Path | Purpose |
+|---|---|
+| `tick.sh` | sources libs, preflight, `run_claude`→`run_lane`, degraded CAP/hold, `issue_queued`, `ISSUE_LABELS/PRIORITY` |
+| `config.env` | routing knobs (thresholds, lane enable, tiers, LiteLLM workers/limits, capacity overrides) |
+| `lib/posthog.sh` | server-side PostHog capture (reuses `/opt/lem/.env` keys) |
+| `lib/labels.sh` | `ai:*` label bootstrap + apply |
+| `lib/capacity.sh` | >50% gauge, rolling state, overrides |
+| `lib/dispatch.sh` | preflight + `dispatch_lane` (the rule + parallel split + tier selection) |
+| `lib/run_lane.sh` | lane execution, telemetry, outcome recording, labels, PR events |
+| `mcp/perplexity_server.py` | FastMCP Perplexity research/fact_check server |
+| `mcp/requirements.txt` | fastmcp dep |
+| `mcp/mcp-config.json` | claude `--mcp-config` target (loopback HTTP) |
+| `systemd/lem-agent.slice` | shared CPU/RAM ceiling for workers |
+| `systemd/lem-mcp-perplexity.service` | persistent MCP service (in the slice) |
+| `systemd/mcp-perplexity.env.template` | env file template (real file: `/etc/lem/mcp-perplexity.env`) |
+| `secrets.env` | reused prod keys (mode 600, NOT committed) |
+| (repo) `.litellm/config.yaml` | `lem-agent-*` Ollama cloud aliases + fallback chain |
+| (repo) `docker-compose.yml` | LiteLLM gunicorn `--num_workers` + `deploy.resources` limits |
+| (repo) `docker-compose.prod.yml` | LiteLLM `127.0.0.1:4000:4000` loopback publish + CPU/mem limits |
+| `/opt/lem/.litellm/config.yaml`, `/opt/lem/docker-compose*.yml` | same edits applied to prod (additive; must also land via PR→release or the next release reverts them) |

--- a/scripts/agent-pipeline/lib/capacity.sh
+++ b/scripts/agent-pipeline/lib/capacity.sh
@@ -1,0 +1,307 @@
+#!/usr/bin/env bash
+# Capacity-aware lane gauge for the agent pipeline.
+#
+# HONEST LIMITATION: neither the Anthropic Max subscription nor Ollama Cloud exposes a "remaining
+# % this session / this week" API. So this gauge ESTIMATES capacity from rolling run outcomes
+# (usage-limit hits, recent failures, the tick self-pause window) plus a cheap health probe, and
+# lets the owner pin it with an env override when they KNOW the real headroom. The >50% rule is
+# applied to this estimate. See docs/agent-pipeline-routing.md §Capacity.
+#
+# State lives in $BASE/state/<lane>.state (key=value), NOT Redis — the agent pipeline runs on the
+# host, not in the app's compose, and a flat file is trivially inspectable/repairable.
+BASE="${BASE:-/home/lem/agent-pipeline}"
+STATE_DIR="$BASE/state"
+mkdir -p "$STATE_DIR"
+
+# Thresholds (overridable via config.env / environment).
+LANE_CAPACITY_THRESHOLD="${LANE_CAPACITY_THRESHOLD:-50}"        # >this = "available"
+CLAUDE_USAGE_COOLDOWN="${CLAUDE_USAGE_COOLDOWN:-7200}"           # a usage-limit hit counts this long
+CLAUDE_FAIL_WINDOW="${CLAUDE_FAIL_WINDOW:-1800}"
+OLLAMA_FAIL_WINDOW="${OLLAMA_FAIL_WINDOW:-1800}"
+OLLAMA_LANE_ENABLED="${OLLAMA_LANE_ENABLED:-1}"
+OLLAMA_LITELLM_URL="${OLLAMA_LITELLM_URL:-http://127.0.0.1:4000}"
+OLLAMA_PROBE="${OLLAMA_PROBE:-0}"   # 1 = spend a tiny completion to confirm cloud (else liveliness only)
+OLLAMA_ALIAS_TTL="${OLLAMA_ALIAS_TTL:-3600}"   # how long a passing tier-alias check stays cached
+OLLAMA_FAIL_PROBE_AT="${OLLAMA_FAIL_PROBE_AT:-3}"  # consecutive plain failures that trigger a probe
+# Automatic usage-limit recovery (issue: Claude Max exhaustion must NOT require a human pin).
+# We can't READ remaining subscription usage (no API), so we PROBE: after a usage-limit hit, the
+# lane is hard-paused for USAGE_PAUSE_MINUTES; once that window passes, a cheap `claude -p "ok"`
+# probe runs at most every CLAUDE_PROBE_MIN_INTERVAL. A failed probe re-pauses; a successful probe
+# clears the limit marker and resumes the lane. This makes the Ollama fallback self-heal into
+# Claude the moment usage resets, with zero wasted real-issue attempts.
+USAGE_PAUSE_MINUTES="${USAGE_PAUSE_MINUTES:-60}"                 # pause a lane this long on a usage-limit
+CLAUDE_PROBE_MIN_INTERVAL="${CLAUDE_PROBE_MIN_INTERVAL:-3600}"   # probe at most this often (seconds)
+CLAUDE_PROBE_TIMEOUT="${CLAUDE_PROBE_TIMEOUT:-40}"              # the probe call's own timeout
+OLLAMA_PROBE_MIN_INTERVAL="${OLLAMA_PROBE_MIN_INTERVAL:-3600}"
+OLLAMA_PROBE_TIMEOUT="${OLLAMA_PROBE_TIMEOUT:-20}"
+CLAUDE_PAUSED_FILE="${CLAUDE_PAUSED_FILE:-$BASE/CLAUDE_PAUSED_UNTIL}"
+OLLAMA_PAUSED_FILE="${OLLAMA_PAUSED_FILE:-$BASE/OLLAMA_PAUSED_UNTIL}"
+UL_REGEX='usage limit|hit your limit|limit reached|credit balance|quota exceeded|rate limit|too many requests'
+
+_now() { date +%s; }
+
+_state_get() {  # <lane> <key>
+  local f="$STATE_DIR/$1.state" v
+  [ -f "$f" ] || { echo ""; return; }
+  v="$(grep -E "^$2=" "$f" 2>/dev/null | head -1 | sed -E "s/^$2=//")"
+  echo "$v"
+}
+_state_set() {  # <lane> <key> <value>
+  local f="$STATE_DIR/$1.state"
+  touch "$f"
+  if grep -qE "^$2=" "$f" 2>/dev/null; then
+    python3 -c '
+import sys
+f,k,v=sys.argv[1],sys.argv[2],sys.argv[3]
+lines=open(f).read().splitlines()
+out=[ (k+"="+v) if l.startswith(k+"=") else l for l in lines ]
+open(f,"w").write("\n".join(out)+"\n")
+' "$f" "$2" "$3"
+  else
+    printf '%s=%s\n' "$2" "$3" >> "$f"
+  fi
+}
+
+# Record a lane run outcome so the gauge learns. <lane> <ok 0|1> <usage_limit_hit 0|1>
+record_lane_outcome() {
+  local lane="$1" ok="$2" ul="${3:-0}"
+  local now; now=$(_now)
+  if [ "$ul" = "1" ]; then
+    _state_set "$lane" last_usage_limit_ts "$now"
+    _state_set "$lane" consecutive_failures 0
+    return 0
+  fi
+  if [ "$ok" = "1" ]; then
+    _state_set "$lane" last_success_ts "$now"
+    _state_set "$lane" consecutive_failures 0
+  else
+    _state_set "$lane" last_fail_ts "$now"
+    local cf; cf="$(_state_get "$lane" consecutive_failures)"; cf="${cf:-0}"
+    _state_set "$lane" consecutive_failures "$((cf+1))"
+  fi
+}
+
+# claude_capacity -> echoes "<pct> <status>"
+#   status: healthy | constrained | exhausted
+claude_capacity() {
+  local now; now=$(_now)
+  # Owner override wins when set (they know the real headroom).
+  if [ -n "${CLAUDE_CAPACITY_PCT:-}" ]; then
+    if [ "$CLAUDE_CAPACITY_PCT" -gt "$LANE_CAPACITY_THRESHOLD" ]; then echo "$CLAUDE_CAPACITY_PCT healthy"
+    else echo "$CLAUDE_CAPACITY_PCT constrained"; fi
+    return 0
+  fi
+  # Lane-specific hard pause (written by run_lane / the probe on a usage-limit hit) = exhausted.
+  # An EXPIRED pause is cleared here and falls through to the cooldown check below — the probe
+  # (run from capacity_preflight) decides whether to re-pause or resume.
+  if [ -f "$CLAUDE_PAUSED_FILE" ]; then
+    local pu; pu="$(cat "$CLAUDE_PAUSED_FILE" 2>/dev/null || echo 0)"
+    if [ "$now" -lt "${pu:-0}" ]; then echo "0 exhausted"; return 0; fi
+    rm -f "$CLAUDE_PAUSED_FILE"
+  fi
+  local ult; ult="$(_state_get claude last_usage_limit_ts)"; ult="${ult:-0}"
+  if [ "$ult" -gt 0 ] && [ "$((now - ult))" -lt "$CLAUDE_USAGE_COOLDOWN" ]; then echo "25 constrained"; return 0; fi
+  local cf; cf="$(_state_get claude consecutive_failures)"; cf="${cf:-0}"
+  local lft; lft="$(_state_get claude last_fail_ts)"; lft="${lft:-0}"
+  if [ "$cf" -ge 3 ] && [ "$((now - lft))" -lt "$CLAUDE_FAIL_WINDOW" ]; then echo "40 constrained"; return 0; fi
+  echo "80 healthy"
+}
+
+# ollama_capacity -> echoes "<pct> <status>"
+#   status: healthy | constrained | unavailable | disabled
+ollama_capacity() {
+  [ "$OLLAMA_LANE_ENABLED" = "1" ] || { echo "0 disabled"; return 0; }
+  if [ -n "${OLLAMA_CAPACITY_PCT:-}" ]; then
+    if [ "$OLLAMA_CAPACITY_PCT" -gt "$LANE_CAPACITY_THRESHOLD" ]; then echo "$OLLAMA_CAPACITY_PCT healthy"
+    else echo "$OLLAMA_CAPACITY_PCT constrained"; fi
+    return 0
+  fi
+  local now; now=$(_now)
+  # Lane-specific hard pause (Ollama Max subscription usage-limit). Expired pause clears + falls through.
+  if [ -f "$OLLAMA_PAUSED_FILE" ]; then
+    local pu; pu="$(cat "$OLLAMA_PAUSED_FILE" 2>/dev/null || echo 0)"
+    if [ "$now" -lt "${pu:-0}" ]; then echo "0 exhausted"; return 0; fi
+    rm -f "$OLLAMA_PAUSED_FILE"
+  fi
+  # Cheap probe: LiteLLM liveliness. A down proxy = no Ollama lane.
+  curl -fsS --max-time 2 "$OLLAMA_LITELLM_URL/health/liveliness" >/dev/null 2>&1 || { echo "0 unavailable"; return 0; }
+  # Liveliness proves the PROXY is up — NOT that it will serve the tier alias the lane passes as
+  # --model. Those came apart on 2026-07-29: proxy healthy, every run 400ing on an unresolvable
+  # `lem-agent-tier*`, gauge reading 75% the whole time, so the fallback kept claiming issues and
+  # stranding them `agent:working`. An unusable lane must read unavailable, not healthy.
+  _ollama_alias_ok || { echo "0 unavailable"; return 0; }
+  # Optional deeper probe: a 1-token completion to a cheap cloud tier (costs a fraction of a cent).
+  if [ "$OLLAMA_PROBE" = "1" ] && [ -f "$BASE/secrets.env" ]; then
+    . "$BASE/secrets.env" 2>/dev/null
+    local body='{"model":"lem-agent-tier3","max_tokens":1,"messages":[{"role":"user","content":"ok"}]}'
+    curl -fsS --max-time 15 -X POST "$OLLAMA_LITELLM_URL/v1/messages" \
+      -H "x-api-key: $LITELLM_MASTER_KEY" -H "anthropic-version: 2023-06-01" \
+      -H "content-type: application/json" -d "$body" >/dev/null 2>&1 || { echo "20 constrained"; return 0; }
+  fi
+  local cf; cf="$(_state_get ollama consecutive_failures)"; cf="${cf:-0}"
+  local lft; lft="$(_state_get ollama last_fail_ts)"; lft="${lft:-0}"
+  if [ "$cf" -ge 2 ] && [ "$((now - lft))" -lt "$OLLAMA_FAIL_WINDOW" ]; then echo "30 constrained"; return 0; fi
+  echo "75 healthy"
+}
+
+# lane_available <pct> -> 0 when pct > threshold (available), 1 otherwise (bash truth = 0 for true)
+lane_available() { [ "${1:-0}" -gt "$LANE_CAPACITY_THRESHOLD" ]; }
+
+# ── Automatic usage-limit recovery: the Claude probe ──────────────────────────
+# We cannot READ remaining Max-subscription usage (no API), so after a usage-limit hit we PROBE
+# before ever sending a real issue to the Claude lane again. A cheap `claude -p "ok"` either
+# succeeds (usage has reset → resume Claude) or fails with a usage-limit (still exhausted →
+# re-pause). Called from capacity_preflight, so it runs once per tick but is gated to at most once
+# per CLAUDE_PROBE_MIN_INTERVAL by last_probe_ts. Never runs while a hard pause is still active.
+#
+# Writes to the shared tick log ($_TICK_LOG) and to claude.state. Sets the CLAUDE_* env vars it
+# mutates so the caller's already-computed values stay correct for the rest of the tick.
+_claude_probe() {
+  # Returns 0 ok, 1 usage-limit, 2 other failure. Side effect: one real (tiny) Claude call.
+  local out rc
+  out="$(mktemp "${TMPDIR:-/tmp}/probe.XXXXXX")"
+  ( unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY 2>/dev/null || true
+    timeout "${CLAUDE_PROBE_TIMEOUT:-40}" claude -p "Reply with the single word OK." \
+      --dangerously-skip-permissions 2>&1 ) >"$out" 2>&1
+  rc=$?
+  if [ "$rc" -eq 0 ]; then rm -f "$out"; echo 0; return 0; fi
+  if grep -qiE "$UL_REGEX" "$out" 2>/dev/null; then rm -f "$out"; echo 1; return 0; fi
+  rm -f "$out"; echo 2; return 0
+}
+
+# Run a probe when Claude is in a post-limit state but NOT hard-paused, at most once per
+# CLAUDE_PROBE_MIN_INTERVAL. On success: clear the limit marker, mark healthy. On usage-limit
+# failure: re-pause CLAUDE_USAGE_PAUSE_MINUTES. Mutates CLAUDE_PCT/CLAUDE_STATUS/CLAUDE_AVAIL.
+_maybe_probe_claude() {
+  # Owner override = they're driving; don't second-guess it with a probe.
+  [ -n "${CLAUDE_CAPACITY_PCT:-}" ] && return 0
+  # Hard pause still active (claude_capacity said exhausted): nothing to probe yet.
+  [ "$CLAUDE_STATUS" = "exhausted" ] && return 0
+  local now ult pti
+  now=$(_now)
+  ult="$(_state_get claude last_usage_limit_ts)"; ult="${ult:-0}"
+  [ "$ult" -gt 0 ] || return 0   # never hit a limit -> trust the gauge, no probe needed
+  pti="$(_state_get claude last_probe_ts)"; pti="${pti:-0}"
+  [ "$((now - pti))" -ge "${CLAUDE_PROBE_MIN_INTERVAL:-3600}" ] || return 0   # probed too recently
+
+  local prc; prc="$(_claude_probe)"
+  _state_set claude last_probe_ts "$now"
+  local lg="${_TICK_LOG:-/dev/null}"
+  if [ "$prc" = "0" ]; then
+    _state_set claude last_usage_limit_ts 0
+    CLAUDE_PCT=80; CLAUDE_STATUS=healthy
+    lane_available "$CLAUDE_PCT"; CLAUDE_AVAIL=$?
+    echo "[$(date '+%F %T')] claude_probe OK — Claude recovered, resuming claude lane." >>"$lg" 2>/dev/null
+  else
+    # Still exhausted (1) or other failure (2): re-pause so we don't keep probing every tick.
+    echo "$((now + ${USAGE_PAUSE_MINUTES:-60} * 60))" > "$CLAUDE_PAUSED_FILE"
+    _state_set claude last_usage_limit_ts "$now"
+    CLAUDE_PCT=0; CLAUDE_STATUS=exhausted; CLAUDE_AVAIL=1
+    echo "[$(date '+%F %T')] claude_probe still exhausted (rc=$prc) — pausing claude lane ${USAGE_PAUSE_MINUTES:-60}m." >>"$lg" 2>/dev/null
+  fi
+  export CLAUDE_PCT CLAUDE_STATUS CLAUDE_AVAIL
+}
+
+# ── Ollama lane probe (mirror of the Claude probe) ────────────────────────────
+# After an Ollama-Cloud usage-limit, probe with a 1-token LiteLLM completion before dispatching a
+# real issue, at most once per OLLAMA_PROBE_MIN_INTERVAL. Same recovery contract as Claude.
+# Fire ONE 1-token /v1/messages call at <model> through LiteLLM and classify the result:
+#   0 = served OK   1 = usage/rate limited   2 = broken (HTTP error, unknown alias, proxy down)
+# Classification reads the HTTP STATUS, not curl's exit code. `curl -sS` (no -f) exits 0 on a 400,
+# so the old version reported "OK" for a proxy that was rejecting the alias outright — which is how
+# `anthropic_messages: Invalid model name passed in model=lem-agent-tier2` read as a healthy lane
+# through 49 consecutive dead runs on 2026-07-29. Leaves a short body excerpt in
+# _LITELLM_PROBE_DETAIL so the caller can log WHY, not just that it failed.
+_litellm_probe() {  # $1=model alias
+  [ -f "$BASE/secrets.env" ] && . "$BASE/secrets.env" 2>/dev/null
+  local model="${1:-lem-agent-tier3}" out code body_ul=0
+  out="$(mktemp "${TMPDIR:-/tmp}/oprobe.XXXXXX")"
+  code="$(curl -sS --max-time "${OLLAMA_PROBE_TIMEOUT:-20}" -o "$out" -w '%{http_code}' \
+            -X POST "$OLLAMA_LITELLM_URL/v1/messages" \
+            -H "x-api-key: ${LITELLM_MASTER_KEY:-}" -H "anthropic-version: 2023-06-01" \
+            -H "content-type: application/json" \
+            -d "{\"model\":\"$model\",\"max_tokens\":1,\"messages\":[{\"role\":\"user\",\"content\":\"ok\"}]}" \
+            2>/dev/null)"
+  grep -qiE "$UL_REGEX" "$out" 2>/dev/null && body_ul=1
+  # Callers read the class via $(...), i.e. from a SUBSHELL — an exported var would never reach
+  # them. Park the reason in a file so the log line can say WHY the lane was held.
+  printf 'http=%s %s' "$code" "$(head -c 220 "$out" 2>/dev/null | tr '\n' ' ')" > "$STATE_DIR/.litellm_probe_detail" 2>/dev/null
+  rm -f "$out"
+  [ "$body_ul" = "1" ] && { echo 1; return 0; }
+  case "$code" in
+    2*)  echo 0; return 0 ;;
+    429) echo 1; return 0 ;;
+  esac
+  echo 2
+}
+
+# ── Ollama lane probe (mirror of the Claude probe) ────────────────────────────
+# After an Ollama-Cloud usage-limit, probe with a 1-token LiteLLM completion before dispatching a
+# real issue, at most once per OLLAMA_PROBE_MIN_INTERVAL. Same recovery contract as Claude.
+_ollama_probe() {
+  _litellm_probe "${OLLAMA_PROBE_MODEL:-${OLLAMA_DEFAULT_TIER:-lem-agent-tier3}}"
+}
+
+# Is the tier alias the lane actually passes as --model really served by LiteLLM right now?
+# /health/liveliness only proves the PROXY answers; it says nothing about whether the alias
+# resolves. Cached in ollama.state for OLLAMA_ALIAS_TTL so this costs ~1 token an HOUR rather than
+# one per 5-minute tick. Returns 0 = alias served, 1 = not.
+_ollama_alias_ok() {
+  local now cached ts model prc
+  now=$(_now)
+  ts="$(_state_get ollama alias_ok_ts)"; ts="${ts:-0}"
+  cached="$(_state_get ollama alias_ok)"
+  if [ -n "$cached" ] && [ "$((now - ts))" -lt "${OLLAMA_ALIAS_TTL:-3600}" ]; then
+    [ "$cached" = "1" ]
+    return $?
+  fi
+  model="${OLLAMA_PROBE_MODEL:-${OLLAMA_DEFAULT_TIER:-lem-agent-tier2}}"
+  prc="$(_litellm_probe "$model")"
+  _state_set ollama alias_ok_ts "$now"
+  # A usage-limit (1) is NOT an alias fault — the pause/probe path owns that. Only a hard 2 holds.
+  if [ "$prc" = "2" ]; then
+    _state_set ollama alias_ok 0
+    echo "[$(date '+%F %T')] ollama alias probe FAILED for $model — $(cat "$STATE_DIR/.litellm_probe_detail" 2>/dev/null) — holding ollama lane." \
+      >>"${_TICK_LOG:-/dev/null}" 2>/dev/null
+    return 1
+  fi
+  _state_set ollama alias_ok 1
+  return 0
+}
+
+_maybe_probe_ollama() {
+  [ -n "${OLLAMA_CAPACITY_PCT:-}" ] && return 0
+  [ "$OLLAMA_LANE_ENABLED" = "1" ] || return 0
+  [ "$OLLAMA_STATUS" = "exhausted" ] && return 0   # hard pause still active
+  local now ult pti cf
+  now=$(_now)
+  ult="$(_state_get ollama last_usage_limit_ts)"; ult="${ult:-0}"
+  cf="$(_state_get ollama consecutive_failures)"; cf="${cf:-0}"
+  # Fire after a usage-limit (the original contract) OR after a run of plain failures. A broken
+  # alias, a rotated key or a bad api_base fails EVERY run without ever matching the usage-limit
+  # regex, so the usage-limit-only trigger could never notice the one failure mode that had already
+  # burned a day of the backlog.
+  { [ "$ult" -gt 0 ] || [ "$cf" -ge "${OLLAMA_FAIL_PROBE_AT:-3}" ]; } || return 0
+  pti="$(_state_get ollama last_probe_ts)"; pti="${pti:-0}"
+  [ "$((now - pti))" -ge "${OLLAMA_PROBE_MIN_INTERVAL:-3600}" ] || return 0
+  local prc; prc="$(_ollama_probe)"
+  _state_set ollama last_probe_ts "$now"
+  local lg="${_TICK_LOG:-/dev/null}"
+  if [ "$prc" = "0" ]; then
+    _state_set ollama last_usage_limit_ts 0
+    # The probe just PROVED the lane serves, so whatever ran the failure counter up was not the
+    # lane. Leaving it set would hold the gauge at "30 constrained" for the whole fail window.
+    _state_set ollama consecutive_failures 0
+    _state_set ollama alias_ok 1
+    _state_set ollama alias_ok_ts "$now"
+    OLLAMA_PCT=75; OLLAMA_STATUS=healthy
+    lane_available "$OLLAMA_PCT"; OLLAMA_AVAIL=$?
+    echo "[$(date '+%F %T')] ollama_probe OK — Ollama recovered, resuming ollama lane." >>"$lg" 2>/dev/null
+  else
+    echo "$((now + ${USAGE_PAUSE_MINUTES:-60} * 60))" > "$OLLAMA_PAUSED_FILE"
+    _state_set ollama last_usage_limit_ts "$now"
+    OLLAMA_PCT=0; OLLAMA_STATUS=exhausted; OLLAMA_AVAIL=1
+    echo "[$(date '+%F %T')] ollama_probe still exhausted (rc=$prc) — pausing ollama lane ${USAGE_PAUSE_MINUTES:-60}m." >>"$lg" 2>/dev/null
+  fi
+  export OLLAMA_PCT OLLAMA_STATUS OLLAMA_AVAIL
+}

--- a/scripts/agent-pipeline/lib/dispatch.sh
+++ b/scripts/agent-pipeline/lib/dispatch.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# Capacity-aware dispatcher for the agent pipeline.
+#
+# Decides which LANE handles a run (Claude subscription vs Ollama cloud via LiteLLM) and which
+# MODEL/TIER to use, applying the >50% rule from the task:
+#
+#   Claude >50% AND Ollama >50%  -> Claude PRIMARY (slot 1) + Ollama PARALLEL (slot >=2)
+#   Claude <=50%, Ollama >50%   -> Ollama (fallback)
+#   Claude exhausted/away       -> Ollama (fallback, fallback_from=claude)
+#   Claude >50%, Ollama <=50%    -> Claude only
+#   both constrained            -> degraded (pick the higher-pct lane, low concurrency)
+#
+# Sources capacity.sh + posthog.sh + labels.sh. Two entry points:
+#   capacity_preflight   — call ONCE near the top of tick.sh (sets CLAUDE_AVAIL/OLLAMA_AVAIL/DEGRADED
+#                           so the CAP / degraded-mode logic can react before any run).
+#   dispatch_lane         — call inside run_claude; sets LANE/AGENT_MODEL/AGENT_TIER/ROUTE_REASON
+#                           (+FALLBACK_FROM/FALLBACK_TO) and emits a routing_decision_made event.
+BASE="${BASE:-/home/lem/agent-pipeline}"
+# shellcheck disable=SC1091
+. "$BASE/lib/capacity.sh"
+# shellcheck disable=SC1091
+. "$BASE/lib/posthog.sh" 2>/dev/null || true
+
+OLLAMA_PARALLEL_ENABLED="${OLLAMA_PARALLEL_ENABLED:-1}"
+OLLAMA_DEFAULT_TIER="${OLLAMA_DEFAULT_TIER:-lem-agent-tier2}"   # kimi-k2.7-code:cloud
+
+# ── preflight (once per tick) ───────────────────────────────────────────────
+capacity_preflight() {
+  local c o cp ct op ot
+  read -r cp ct <<<"$(claude_capacity)"
+  read -r op ot <<<"$(ollama_capacity)"
+  CLAUDE_PCT="$cp"; CLAUDE_STATUS="$ct"
+  OLLAMA_PCT="$op"; OLLAMA_STATUS="$ot"
+  lane_available "$cp"; CLAUDE_AVAIL=$?     # 0 = available, 1 = not (bash truth)
+  lane_available "$op"; OLLAMA_AVAIL=$?
+  # Auto-recovery: if Claude is in a post-limit state (not hard-paused), probe once per interval to
+  # decide whether usage has reset BEFORE we'd dispatch a real issue to it. May flip CLAUDE_*.
+  _maybe_probe_claude 2>/dev/null || true
+  # Same recovery contract for the Ollama lane (so an Ollama-Cloud limit self-heals too).
+  _maybe_probe_ollama 2>/dev/null || true
+  # Degraded = neither lane clearly above threshold. tick.sh forces CAP=1 and skips new starts.
+  if [ "$CLAUDE_AVAIL" -ne 0 ] && [ "$OLLAMA_AVAIL" -ne 0 ]; then
+    DEGRADED=1
+  else
+    DEGRADED=0
+  fi
+  export CLAUDE_PCT CLAUDE_STATUS OLLAMA_PCT OLLAMA_STATUS CLAUDE_AVAIL OLLAMA_AVAIL DEGRADED
+  # One heartbeat event per tick so a quiet dashboard still shows capacity state.
+  posthog_capture "capacity_preflight" "agent-pipeline" \
+    "{\"claude_pct\":$cp,\"claude_status\":\"$ct\",\"ollama_pct\":$op,\"ollama_status\":\"$ot\",\"degraded\":$DEGRADED}"
+  echo "[dispatch] claude=$cp%($ct) ollama=$op%($ot) degraded=$DEGRADED" >> "${_TICK_LOG:-/dev/null}" 2>/dev/null || true
+}
+
+# ── tier selection for the Ollama lane ──────────────────────────────────────
+# Issue labels can force a tier: agent:tier:1 | agent:tier:2-alt | agent:tier:3.
+# Otherwise MODE drives it: review/reasoning -> tier3 (nemotron), everything else -> default tier2.
+# tier1 (glm-5.2:cloud) is opt-in only — it is a slow thinking model and intermittently times out,
+# so it is reserved for issues the owner explicitly flags as hardest long-horizon work.
+_pick_ollama_tier() {
+  local labels="${ISSUE_LABELS:-}"
+  if [ -n "$labels" ]; then
+    case " $labels " in
+      *" agent:tier:1 "*)     echo "lem-agent-tier1"     ; return ;;
+      *" agent:tier:3 "*)     echo "lem-agent-tier3"     ; return ;;
+      *" agent:tier:2-alt "*) echo "lem-agent-tier2-alt" ; return ;;
+    esac
+  fi
+  case "${MODE:-}" in
+    selfreview|review) echo "lem-agent-tier3" ;;   # nemotron = reviewer/reasoning lane
+    *)                 echo "$OLLAMA_DEFAULT_TIER" ;;
+  esac
+}
+
+# ── per-run dispatch (inside run_claude) ─────────────────────────────────────
+# $1 = claude_model_hint (sonnet|haiku|opus|"" from model_for_issue). Exports LANE etc.
+dispatch_lane() {
+  local claude_hint="${1:-}"
+  LANE=""; AGENT_MODEL=""; AGENT_TIER=""; ROUTE_REASON=""; FALLBACK_FROM=""; FALLBACK_TO=""
+
+  # Determine issue/PR context for telemetry + tier labels (env set by tick.sh before the call).
+  local num="${ISSUE:-${PR:-}}"
+  local kind="issue"; [ -n "${PR:-}" ] && kind="pr"
+  local issue_url=""; [ -n "${ISSUE:-}" ] && issue_url="https://github.com/${SLUG:-christopherqueenconsulting/linkedin_engagement_manager}/issues/$ISSUE"
+
+  if [ "$CLAUDE_AVAIL" -eq 0 ] && [ "$OLLAMA_AVAIL" -eq 0 ]; then
+    # Both healthy: slot 1 = Claude primary (highest-priority issue), slot >=2 = Ollama parallel.
+    if [ "${SLOT:-1}" -ge 2 ] && [ "$OLLAMA_PARALLEL_ENABLED" = "1" ]; then
+      LANE="ollama"; AGENT_TIER="$(_pick_ollama_tier)"; AGENT_MODEL="$AGENT_TIER"; ROUTE_REASON="parallel"
+    else
+      LANE="claude"; AGENT_MODEL="$claude_hint"; ROUTE_REASON="primary"
+    fi
+  elif [ "$OLLAMA_AVAIL" -eq 0 ]; then
+    # Claude constrained/exhausted, Ollama healthy -> Ollama fallback.
+    LANE="ollama"; AGENT_TIER="$(_pick_ollama_tier)"; AGENT_MODEL="$AGENT_TIER"; ROUTE_REASON="fallback"
+    FALLBACK_FROM="claude"; FALLBACK_TO="ollama"
+  elif [ "$CLAUDE_AVAIL" -eq 0 ]; then
+    # Claude healthy, Ollama constrained -> Claude only.
+    LANE="claude"; AGENT_MODEL="$claude_hint"; ROUTE_REASON="primary"
+  else
+    # Both constrained: degraded. Pick the higher-pct lane; flag low concurrency. Ties go to
+    # Ollama (its failures are free — they don't burn the Max subscription like a Claude attempt does).
+    LANE="degraded"; ROUTE_REASON="degraded"
+    if [ "${CLAUDE_PCT:-0}" -gt "${OLLAMA_PCT:-0}" ]; then
+      LANE="claude"; AGENT_MODEL="$claude_hint"
+    else
+      LANE="ollama"; AGENT_TIER="$(_pick_ollama_tier)"; AGENT_MODEL="$AGENT_TIER"
+    fi
+  fi
+
+  export LANE AGENT_MODEL AGENT_TIER ROUTE_REASON FALLBACK_FROM FALLBACK_TO
+
+  local provider="$LANE"
+  [ "$LANE" = "ollama" ] && provider="ollama-cloud"
+  local model_tier="${AGENT_TIER:-}"
+  [ "$LANE" = "claude" ] && model_tier="${AGENT_MODEL:-default}"
+  posthog_capture "routing_decision_made" "agent-pipeline" "$(python3 -c '
+import json,os
+print(json.dumps({
+  "lane": os.environ.get("LANE",""),
+  "provider": os.environ.get("provider",""),
+  "model": os.environ.get("AGENT_MODEL",""),
+  "model_tier": os.environ.get("model_tier",""),
+  "route_reason": os.environ.get("ROUTE_REASON",""),
+  "fallback_from": os.environ.get("FALLBACK_FROM",""),
+  "fallback_to": os.environ.get("FALLBACK_TO",""),
+  "issue_number": os.environ.get("ISSUE",""),
+  "pr_number": os.environ.get("PR",""),
+  "issue_url": os.environ.get("issue_url",""),
+  "worker_id": os.environ.get("WORKER_ID",""),
+  "issue_priority": os.environ.get("ISSUE_PRIORITY",""),
+  "issue_type": os.environ.get("MODE",""),
+}) if os.environ.get("ISSUE") or os.environ.get("PR") else {})
+' 2>/dev/null)" || true
+  echo "[dispatch] lane=$LANE model=${AGENT_MODEL:-default} tier=${AGENT_TIER:-} reason=$ROUTE_REASON" >> "${_TICK_LOG:-/dev/null}" 2>/dev/null || true
+}

--- a/scripts/agent-pipeline/lib/labels.sh
+++ b/scripts/agent-pipeline/lib/labels.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# GitHub issue/PR labeling for the agent pipeline — encodes which LANE + MODEL + TIER handled a
+# thread, in a human-readable and machine-filterable `ai:*` scheme. Idempotent: missing labels are
+# created on first use; applying is add-only (we never remove another lane's label here — the tick
+# state machine owns agent:working/agent:ready transitions).
+#
+# Scheme:
+#   ai:claude-subscription            ai:ollama-cloud
+#   ai:claude-subscription:<model>    ai:ollama-cloud:<tier>
+#                                    ai:ollama-cloud:<modelslug>
+#   ai:routed:parallel | ai:routed:fallback | ai:routed:escalated | ai:routed:degraded
+# Model slugs: glm-5.2, kimi-k2.7-code, minimax-m3, nemotron-3-super; claude: sonnet|haiku|opus.
+BASE="${BASE:-/home/lem/agent-pipeline}"
+SLUG="${SLUG:-christopherqueenconsulting/linkedin_engagement_manager}"
+
+# Anthropic lane model → label slug (the claude CLI --model hint we passed).
+_claude_model_slug() {
+  case "${1:-}" in
+    sonnet|haiku|opus) echo "$1" ;;
+    *)                 echo "" ;;
+  esac
+}
+
+# Ollama tier alias (lem-agent-tierN[-alt]) → the cloud model slug used in labels.
+# Mirrors the .litellm/config.yaml lem-agent-* mapping.
+_ollama_model_slug() {
+  case "${1:-}" in
+    lem-agent-tier1)     echo "glm-5.2" ;;
+    lem-agent-tier2)     echo "kimi-k2.7-code" ;;
+    lem-agent-tier2-alt) echo "minimax-m3" ;;
+    lem-agent-tier3)     echo "nemotron-3-super" ;;
+    *)                   echo "" ;;
+  esac
+}
+
+_ollama_tier_label() {
+  case "${1:-}" in
+    lem-agent-tier1)     echo "ai:ollama-cloud:tier1" ;;
+    lem-agent-tier2)     echo "ai:ollama-cloud:tier2" ;;
+    lem-agent-tier2-alt) echo "ai:ollama-cloud:tier2-alt" ;;
+    lem-agent-tier3)     echo "ai:ollama-cloud:tier3" ;;
+    *)                   echo "" ;;
+  esac
+}
+
+# The full label set we promise exists. Created once by ensure_ai_labels.
+AI_LABELS=(
+  "ai:claude-subscription"
+  "ai:claude-subscription:sonnet"
+  "ai:claude-subscription:haiku"
+  "ai:claude-subscription:opus"
+  "ai:ollama-cloud"
+  "ai:ollama-cloud:tier1"
+  "ai:ollama-cloud:tier2"
+  "ai:ollama-cloud:tier2-alt"
+  "ai:ollama-cloud:tier3"
+  "ai:ollama-cloud:glm-5.2"
+  "ai:ollama-cloud:kimi-k2.7-code"
+  "ai:ollama-cloud:minimax-m3"
+  "ai:ollama-cloud:nemotron-3-super"
+  "ai:routed:parallel"
+  "ai:routed:fallback"
+  "ai:routed:escalated"
+  "ai:routed:degraded"
+)
+
+# Create any missing ai:* labels in the repo. Safe to run every tick (skips existing). One gh call
+# per missing label — the set is tiny and fixed, so this is cheap and only writes the first time.
+ensure_ai_labels() {
+  local existing missing
+  existing="$(gh label list --repo "$SLUG" --limit 200 --json name --jq '.[].name' 2>/dev/null || true)"
+  for l in "${AI_LABELS[@]}"; do
+    case "$existing" in *"$l"*) continue ;; esac
+    # Purple family (#7c5cff) for lane/tier labels, slate (#6b7280) for routed:* reasons.
+    local color="7c5cff"
+    case "$l" in ai:routed:*) color="6b7280" ;; esac
+    gh label create --repo "$SLUG" "$l" --color "$color" \
+      --description "AI lane/model tag (agent pipeline)" >/dev/null 2>&1 || true
+  done
+}
+
+# lane_labels_for <lane> <agent_model_or_alias> <route_reason>
+# Echoes the space-separated label set to ADD for this run (lane + model + route reason).
+lane_labels_for() {
+  local lane="$1" model="$2" reason="${3:-}"
+  local out=""
+  case "$lane" in
+    claude)
+      out="ai:claude-subscription"
+      local cs; cs="$(_claude_model_slug "$model")"
+      [ -n "$cs" ] && out="$out ai:claude-subscription:$cs" ;;
+    ollama)
+      out="ai:ollama-cloud"
+      local ts ms
+      ts="$(_ollama_tier_label "$model")"; ms="$(_ollama_model_slug "$model")"
+      [ -n "$ts" ] && out="$out $ts"
+      [ -n "$ms" ] && out="$out ai:ollama-cloud:$ms" ;;
+  esac
+  case "$reason" in
+    parallel)   out="$out ai:routed:parallel" ;;
+    fallback)   out="$out ai:routed:fallback" ;;
+    escalated)  out="$out ai:routed:escalated" ;;
+    degraded)   out="$out ai:routed:degraded" ;;
+  esac
+  echo "$out"
+}
+
+# apply_lane_labels <pr|issue> <number> <lane> <model_or_alias> <route_reason>
+# Adds the lane/model/route labels to the thread. Errors are swallowed (labeling is observability,
+# not control flow) — the state machine's own labels are what gate work.
+apply_lane_labels() {
+  local kind="$1" num="$2" lane="$3" model="$4" reason="${5:-}"
+  local labels; labels="$(lane_labels_for "$lane" "$model" "$reason")"
+  [ -n "$labels" ] || return 0
+  # gh's --add-label splits on COMMAS (or repeated flags), not spaces — a space-separated
+  # string is parsed as one bogus label that doesn't exist and silently no-ops. lane_labels_for
+  # joins with spaces, so collapse to commas here. Label names contain colons but no spaces.
+  local clabels="${labels// /,}"
+  local cmd
+  if [ "$kind" = "pr" ]; then cmd=(gh pr edit "$num" --repo "$SLUG" --add-label "$clabels")
+  else                     cmd=(gh issue edit "$num" --repo "$SLUG" --add-label "$clabels"); fi
+  "${cmd[@]}" >/dev/null 2>&1 || true
+}

--- a/scripts/agent-pipeline/lib/posthog.sh
+++ b/scripts/agent-pipeline/lib/posthog.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# PostHog server-side telemetry for the agent pipeline — best-effort, NEVER breaks a tick.
+# Reuses the EXISTING PostHog project keys from /opt/lem/.env (copied into secrets.env by setup)
+# — this is the SAME PostHog project the LEM app + SPA report to, so agent-pipeline events sit
+# alongside llm_call / $ai_generation / browser events for the same accounts. No second project.
+#
+# Usage:
+#   posthog_capture "<event>" "<distinct_id>" "<json-properties>"   # emits one event
+#   posthog_metric ...                                              # (reserved)
+#
+# Properties are a JSON object string. We add common props (lem_component, environment, repo,
+# execution_id, worker_id, timestamp) on every event so dashboards can filter by lane/model/tier.
+# Failures (no key, network, PostHog down) are logged to the tick log and swallowed — telemetry
+# must never cost the pipeline a run.
+BASE="${BASE:-/home/lem/agent-pipeline}"
+[ -f "$BASE/secrets.env" ] && . "$BASE/secrets.env"
+
+POSTHOG_API_KEY="${POSTHOG_API_KEY:-}"
+POSTHOG_HOST="${POSTHOG_HOST:-https://us.i.posthog.com}"
+# Strip a trailing slash so "$POSTHOG_HOST/capture" is always well-formed.
+POSTHOG_HOST="${POSTHOG_HOST%/}"
+
+# Shared identity + run context. execution_id is per-tick-process (set by tick.sh); worker_id is
+# the slot number; both propagate into every event for tracing a run across its lifecycle.
+LEM_COMPONENT="${LEM_COMPONENT:-agent-pipeline}"
+ENVIRONMENT="${ENVIRONMENT:-production}"
+REPO="${REPO:-christopherqueenconsulting/linkedin_engagement_manager}"
+EXECUTION_ID="${EXECUTION_ID:-}"
+WORKER_ID="${WORKER_ID:-}"
+_TICK_LOG="${_TICK_LOG:-/dev/null}"
+_ph_log() { echo "[posthog] $*" >> "$_TICK_LOG" 2>/dev/null || true; }
+
+posthog_capture() {
+  local event="$1" distinct_id="$2" props="${3:-{\}}"
+  [ -n "$POSTHOG_API_KEY" ] || { _ph_log "no POSTHOG_API_KEY — skipping '$event'"; return 0; }
+  [ -n "$event" ] || return 0
+  distinct_id="${distinct_id:-agent-pipeline}"
+  # Merge common props into the caller's props. python3 is on the PATH (LEM uses it); if absent,
+  # fall back to sending props as-is — never fail the event over a merge.
+  local body
+  if command -v python3 >/dev/null 2>&1; then
+    body="$(python3 -c '
+import json, sys, os
+event, did, props = sys.argv[1], sys.argv[2], sys.argv[3]
+common = {
+    "lem_component": os.environ.get("LEM_COMPONENT","agent-pipeline"),
+    "environment":   os.environ.get("ENVIRONMENT","production"),
+    "repo":          os.environ.get("REPO","christopherqueenconsulting/linkedin_engagement_manager"),
+    "execution_id":  os.environ.get("EXECUTION_ID",""),
+    "worker_id":     os.environ.get("WORKER_ID",""),
+}
+try:
+    p = json.loads(props) if props else {}
+    if not isinstance(p, dict): p = {}
+except Exception:
+    p = {}
+p = {**common, **p}
+print(json.dumps({"api_key": os.environ["POSTHOG_API_KEY"], "event": event,
+                  "distinct_id": did, "properties": p}))
+' "$event" "$distinct_id" "$props" 2>/dev/null)" || body=""
+  fi
+  if [ -z "$body" ]; then
+    # Minimal fallback: send the caller's props verbatim wrapped with api_key/event/distinct_id.
+    body="{\"api_key\":\"$POSTHOG_API_KEY\",\"event\":\"$event\",\"distinct_id\":\"$distinct_id\",\"properties\":$props}"
+  fi
+  # Fire-and-forget with a short timeout. 2s is enough for PostHog's capture endpoint; a slow
+  # PostHog must not stall a tick. Errors go to the tick log only.
+  curl -fsS --max-time 3 -X POST "$POSTHOG_HOST/capture" \
+    -H "content-type: application/json" -d "$body" >/dev/null 2>&1 \
+    || _ph_log "capture failed for '$event' (host=$POSTHOG_HOST)"
+  return 0
+}

--- a/scripts/agent-pipeline/lib/run_lane.sh
+++ b/scripts/agent-pipeline/lib/run_lane.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# Lane executor — the single place a `claude -p` run is launched, wrapped with capacity-aware lane
+# env, PostHog lifecycle telemetry, outcome recording, and GitHub labeling. run_claude() in tick.sh
+# delegates here so every MODE (depfix/revise/rebase/fix/review/selfreview/start) gets identical
+# routing + observability without per-call-site edits. Runs headless with --dangerously-skip-permissions
+# (the same flag tick.sh's original run_claude uses) so the unattended cron pipeline can execute.
+#
+# Env read (set by tick.sh before each call): MODE, ISSUE, PR, BRANCH, WORKTREE, RISK, SLOT,
+#   WORKER_ID, EXECUTION_ID, _TICK_LOG, LOG, LOGDIR, CLAUDE_TIMEOUT, DRY_RUN.
+# Args: $1=worktree  $2=prompt  $3=claude_model_hint (sonnet|haiku|opus|"" — used only on the claude lane)
+#
+# Telemetry contract:
+#   - This wrapper owns the LIFECYCLE view (issue_assigned, ai_call_started/completed/failed,
+#     issue_completed/failed, fallback_triggered, lane_escalation_triggered) with latency + success.
+#   - Per-call TOKEN/COST for the Ollama lane is owned by LiteLLM's native $ai_generation PostHog
+#     callback (already configured in .litellm/config.yaml) — never duplicated here. The Claude
+#     lane is a flat-rate subscription, so it carries no per-call cost. tokens_* are 0 here by
+#     design; join on execution_id + model for the full picture.
+BASE="${BASE:-/home/lem/agent-pipeline}"
+# shellcheck disable=SC1091
+. "$BASE/lib/dispatch.sh"
+# shellcheck disable=SC1091
+. "$BASE/lib/labels.sh" 2>/dev/null || true
+[ -f "$BASE/secrets.env" ] && . "$BASE/secrets.env" 2>/dev/null
+
+MCP_CONFIG="$BASE/mcp/mcp-config.json"
+OLLAMA_LITELLM_URL="${OLLAMA_LITELLM_URL:-http://127.0.0.1:4000}"
+
+# Emit one lifecycle/AI event with the common context. <event> <extra-json-via-_EMIT_EXTRA>
+_emit() {
+  posthog_capture "$1" "agent-pipeline" "$(python3 -c '
+import json,os
+base={"lem_component":"agent-pipeline","environment":os.environ.get("ENVIRONMENT","production"),
+ "repo":os.environ.get("REPO","christopherqueenconsulting/linkedin_engagement_manager"),
+ "execution_id":os.environ.get("EXECUTION_ID",""),"worker_id":os.environ.get("WORKER_ID",""),
+ "lane":os.environ.get("LANE",""),"provider":("ollama-cloud" if os.environ.get("LANE")=="ollama" else "claude-subscription"),
+ "model":os.environ.get("AGENT_MODEL",""),"model_tier":os.environ.get("AGENT_TIER",""),
+ "route_reason":os.environ.get("ROUTE_REASON",""),"issue_number":os.environ.get("ISSUE",""),
+ "pr_number":os.environ.get("PR",""),"issue_priority":os.environ.get("ISSUE_PRIORITY",""),
+ "issue_type":os.environ.get("MODE","")}
+extra={}
+try: extra=json.loads(os.environ.get("_EMIT_EXTRA","{}") or "{}")
+except Exception: extra={}
+print(json.dumps({**base,**extra}))
+' 2>/dev/null)" || true
+}
+
+run_lane() {  # $1=worktree  $2=prompt  $3=claude_model_hint
+  local wt="$1" prompt="$2" hint="${3:-}" out rc t0 ms
+  if [ "${DRY_RUN:-0}" = "1" ]; then
+    dispatch_lane "$hint"
+    log "DRY_RUN: would run lane=$LANE model=${AGENT_MODEL:-default} tier=${AGENT_TIER:-} in $wt"
+    return 0
+  fi
+
+  dispatch_lane "$hint"
+  _emit "issue_assigned"
+  _emit "ai_call_started"
+  [ "$ROUTE_REASON" = "fallback" ] && _emit "fallback_triggered"
+  { [ "$ROUTE_REASON" = "degraded" ] || [ "$ROUTE_REASON" = "escalated" ]; } && _emit "lane_escalation_triggered"
+
+  [ -n "${AGENT_TIER:-}" ] && log "using lane=$LANE model=${AGENT_TIER} (reason=$ROUTE_REASON)"
+  [ -z "${AGENT_TIER:-}" ] && [ -n "${AGENT_MODEL:-}" ] && log "using lane=$LANE model=$AGENT_MODEL (reason=$ROUTE_REASON)"
+
+  out="$(mktemp "${LOGDIR:-/tmp}/run.XXXXXX")"
+  t0="$(date +%s)"
+
+  # claude lane = owner's Max login (no env override). ollama lane = same CLI pointed at LiteLLM.
+  local model_arg=() mcp_arg=()
+  if [ "$LANE" = "ollama" ]; then
+    model_arg=(--model "${AGENT_TIER}")
+  else
+    [ -n "${AGENT_MODEL:-}" ] && model_arg=(--model "$AGENT_MODEL")
+  fi
+  [ -f "$MCP_CONFIG" ] && mcp_arg=(--mcp-config "$MCP_CONFIG")
+
+  if [ "$LANE" = "ollama" ]; then
+    ( cd "$wt" && \
+      ANTHROPIC_BASE_URL="$OLLAMA_LITELLM_URL" \
+      ANTHROPIC_AUTH_TOKEN="$LITELLM_MASTER_KEY" \
+      ANTHROPIC_API_KEY="$LITELLM_MASTER_KEY" \
+      timeout "${CLAUDE_TIMEOUT:-45m}" claude -p "$prompt" \
+        --dangerously-skip-permissions --add-dir "$BASE" "${model_arg[@]}" "${mcp_arg[@]}" ) >"$out" 2>&1
+    rc=$?
+  else
+    ( cd "$wt" && \
+      unset ANTHROPIC_BASE_URL ANTHROPIC_AUTH_TOKEN ANTHROPIC_API_KEY 2>/dev/null || true
+      timeout "${CLAUDE_TIMEOUT:-45m}" claude -p "$prompt" \
+        --dangerously-skip-permissions --add-dir "$BASE" "${model_arg[@]}" "${mcp_arg[@]}" ) >"$out" 2>&1
+    rc=$?
+  fi
+  ms=$(( ($(date +%s) - t0) * 1000 ))
+  cat "$out" >> "${LOG:-/dev/null}"
+
+  # Usage-limit detection — only on a FAILED run. Lane-specific: a Claude usage-limit pauses ONLY
+  # the Claude lane (Ollama keeps working the backlog); an Ollama usage-limit pauses only Ollama.
+  # The probe loop in capacity.sh re-pauses hourly and resumes the lane the moment a probe succeeds.
+  local ul=0
+  if [ $rc -ne 0 ] && grep -qiE "$UL_REGEX" "$out" 2>/dev/null; then
+    ul=1
+    local pause_file="$CLAUDE_PAUSED_FILE"
+    [ "$LANE" = "ollama" ] && pause_file="$OLLAMA_PAUSED_FILE"
+    echo "$(( $(date +%s) + ${USAGE_PAUSE_MINUTES:-60} * 60 ))" > "$pause_file"
+    log "usage/rate limit on a failed $LANE run — pausing $LANE lane for ${USAGE_PAUSE_MINUTES:-60}m."
+  fi
+  record_lane_outcome "$LANE" $([ $rc -eq 0 ] && echo 1 || echo 0) "$ul"
+
+  _EMIT_EXTRA="{\"success\":$([ $rc -eq 0 ] && echo true || echo false),\"latency_ms\":$ms,\"retry_count\":0,\"tokens_in\":0,\"tokens_out\":0,\"total_tokens\":0,\"estimated_cost\":0,\"error_type\":\"$([ $rc -ne 0 ] && echo nonzero_exit)\",\"fallback_from\":\"${FALLBACK_FROM}\",\"fallback_to\":\"${FALLBACK_TO}\"}" \
+    _emit "$([ $rc -eq 0 ] && echo ai_call_completed || echo ai_call_failed)"
+
+  local kind="pr" num="${ISSUE:-${PR:-}}"
+  [ -n "${ISSUE:-}" ] && kind="issue"
+  [ -n "$num" ] && apply_lane_labels "$kind" "$num" "$LANE" "${AGENT_TIER:-${AGENT_MODEL:-}}" "$ROUTE_REASON"
+
+  # Best-effort PR telemetry: for a fresh START the agent opens a PR during the run; for the other
+  # MODEs the PR already existed and was updated. Detected once here so every MODE gets it.
+  if [ $rc -eq 0 ]; then
+    if [ "${MODE:-}" = "start" ] && [ -n "${ISSUE:-}" ]; then
+      local _pr; _pr="$(pr_for_issue "$ISSUE" 2>/dev/null)"
+      if [ -n "$_pr" ]; then
+        PR="$_pr"; export PR
+        _EMIT_EXTRA="{\"pr_number\":$_pr}" _emit "pr_opened"
+        apply_lane_labels pr "$_pr" "$LANE" "${AGENT_TIER:-${AGENT_MODEL:-}}" "$ROUTE_REASON"
+      fi
+    elif [ -n "${PR:-}" ]; then
+      _EMIT_EXTRA="{\"pr_number\":$PR}" _emit "pr_updated"
+    fi
+  fi
+
+  if [ $rc -eq 0 ]; then
+    _emit "issue_completed"
+  else
+    _EMIT_EXTRA="{\"error_type\":\"nonzero_exit\",\"error_message\":\"claude rc=$rc ($LANE)\"}" _emit "issue_failed"
+    log "$LANE claude exited rc=$rc (timeout/interrupt/limit) — will retry next tick."
+  fi
+  rm -f "$out"
+  return $rc
+}

--- a/scripts/agent-pipeline/tick.sh
+++ b/scripts/agent-pipeline/tick.sh
@@ -67,7 +67,7 @@ capacity_preflight 2>/dev/null || true  # sets CLAUDE_PCT/OLLAMA_PCT/CLAUDE_AVAI
 
 # --- guards ---
 # DRY_RUN is inert (no pushes, no Claude, no merges) so it may validate even while paused.
-if [ -f "$PAUSED" ] && [ "$DRY_RUN" != "1" ]; then log "PAUSED file present — skipping."; exit 0; fi
+if [ -f "$PAUSED" ] && [ "$DRY_RUN" != "1" ]; then log "PAUSED file present — skipping."; TICK_OUTCOME="skipped"; TICK_REASON="paused"; exit 0; fi
 # Usage-limit pause is now LANE-SPECIFIC (CLAUDE_PAUSED_UNTIL / OLLAMA_PAUSED_UNTIL, written by
 # run_lane and the probe in capacity.sh) and gated per-lane inside capacity_preflight + dispatch_lane
 # — a Claude usage-limit no longer idles the Ollama lane, and the probe loop resumes Claude the
@@ -82,7 +82,7 @@ if [ -f "$PAUSED" ] && [ "$DRY_RUN" != "1" ]; then log "PAUSED file present — 
 case "${CLAUDE_STATUS:-}:${OLLAMA_STATUS:-}" in
   exhausted:exhausted|exhausted:unavailable|exhausted:disabled)
     log "both lanes exhausted/unavailable (claude=${CLAUDE_STATUS} ollama=${OLLAMA_STATUS}) — idling until a probe/liveliness recovers one."
-    exit 0 ;;
+    TICK_OUTCOME="skipped"; TICK_REASON="both_lanes_exhausted"; exit 0 ;;
 esac
 
 # --- concurrency: slots scale with the backlog (1 + ready/SCALE_PER_ISSUES, capped) ---
@@ -113,7 +113,8 @@ for _s in $(seq 1 "$CAP"); do
   eval "exec $((10 + _s))>\"$BASE/locks/slot-${_s}.lock\""
   if flock -n $((10 + _s)); then SLOT="$_s"; break; fi
 done
-if [ -z "$SLOT" ]; then log "all $CAP agent slot(s) busy — skipping."; exit 0; fi
+if [ -z "$SLOT" ]; then log "all $CAP agent slot(s) busy — skipping."; TICK_OUTCOME="skipped"; TICK_REASON="all_slots_busy"; exit 0; fi
+export WORKER_ID="$SLOT"   # so posthog_capture events tagged with this slot
 [ "$CAP" -gt 1 ] && log "slot $SLOT/$CAP (ready issues: $READY_COUNT)"
 
 # Per-branch work claim so concurrent slots never touch the same PR/issue. Re-opening fd 10
@@ -122,6 +123,72 @@ claim_branch() {  # $1=branch -> 0 claimed, 1 busy
   exec 10>"$BASE/locks/br-$(echo "$1" | tr '/' '_').lock"
   flock -n 10
 }
+
+# --- tick outcome → PostHog ---
+# One tick_outcome event per tick lifecycle, emitted via an EXIT trap so every code path is
+# captured (success, skip, error, kill). Vars are set by the caller before `exit`; the trap
+# reads them, builds a JSON dict, and fires posthog_capture. Telemetry is best-effort —
+# posthog_capture is fire-and-forget and never breaks a tick.
+TICK_T0="$SECONDS"                       # wall-clock seconds since shell start
+TICK_OUTCOME="unknown"                   # dispatched | skipped | error | nothing_to_do
+TICK_REASON=""                           # free-form: "both_lanes_exhausted", "no_ready", "all_slots_busy", "paused", "all_prs_clean", "mode_start", "mode_fix", "mode_review", "mode_merge", "mode_selfreview", "mode_rebase", "mode_depfix", "mode_revise", "escalate"
+TICK_MODE=""                             # mode name if a Claude run was dispatched
+TICK_ISSUE=""                            # issue number dispatched
+TICK_PR=""                               # PR number processed
+TICK_BRANCH=""                           # branch
+TICK_LANE="${LANE:-}"                    # claude | ollama
+TICK_MODEL="${AGENT_MODEL:-${AGENT_TIER:-}}"  # model or tier alias
+TICK_ROUTE_REASON="${ROUTE_REASON:-}"    # healthy | fallback | degraded
+TICK_CLAUDE_PCT="${CLAUDE_PCT:-}"
+TICK_OLLAMA_PCT="${OLLAMA_PCT:-}"
+TICK_READY_COUNT="${READY_COUNT:-0}"
+TICK_CAP="${CAP:-1}"
+export TICK_OUTCOME TICK_REASON TICK_MODE TICK_ISSUE TICK_PR TICK_BRANCH TICK_LANE TICK_MODEL TICK_ROUTE_REASON TICK_CLAUDE_PCT TICK_OLLAMA_PCT TICK_READY_COUNT TICK_CAP
+
+# Build and emit the tick_outcome event. Reads the var block above; called once by the EXIT
+# trap below so every code path (success, skip, error, kill) emits exactly one event.
+#
+# We also write the event to a local NDJSON mirror at $LOGDIR/tick-outcomes.ndjson in ADDITION
+# to PostHog — the local file is the source of truth for FAILURE MODES PostHog can't see (no key,
+# network down, project rate-limited). Inspect with:
+#   tail -f /home/lem/agent-pipeline/logs/tick-outcomes.ndjson
+#   jq -c 'select(.tick_outcome=="dispatched")' .../tick-outcomes.ndjson
+TICK_OUTCOMES_LOG="${LOGDIR}/tick-outcomes.ndjson"
+emit_tick_outcome() {
+  local dur_ms=$(( (SECONDS - TICK_T0) * 1000 ))
+  local ts; ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  local payload
+  payload="$(__TICK_DUR_MS="$dur_ms" __TICK_TS="$ts" python3 -c '
+import json, os
+out = {
+  "tick_outcome": os.environ.get("TICK_OUTCOME","unknown"),
+  "reason":       os.environ.get("TICK_REASON",""),
+  "mode":         os.environ.get("TICK_MODE",""),
+  "slot":         os.environ.get("WORKER_ID","") or os.environ.get("SLOT",""),
+  "ready_count":  int(os.environ.get("TICK_READY_COUNT","0") or 0),
+  "cap":          int(os.environ.get("TICK_CAP","1") or 1),
+  "lane":         os.environ.get("TICK_LANE",""),
+  "model":        os.environ.get("TICK_MODEL",""),
+  "route_reason": os.environ.get("TICK_ROUTE_REASON",""),
+  "claude_pct":   int(os.environ.get("TICK_CLAUDE_PCT","0") or 0),
+  "ollama_pct":   int(os.environ.get("TICK_OLLAMA_PCT","0") or 0),
+  "issue_number": int(os.environ.get("TICK_ISSUE","0") or 0),
+  "pr_number":    int(os.environ.get("TICK_PR","0") or 0),
+  "branch":       os.environ.get("TICK_BRANCH",""),
+  "duration_ms":  int(os.environ.get("__TICK_DUR_MS","0") or 0),
+  "ts":           os.environ.get("__TICK_TS",""),
+}
+print(json.dumps(out))
+' 2>/dev/null)" || payload="{\"tick_outcome\":\"error\"}"
+  # Mirror to local NDJSON so the owner can inspect tick outcomes even when PostHog is down.
+  [ -n "$TICK_OUTCOMES_LOG" ] && echo "$payload" >> "$TICK_OUTCOMES_LOG" 2>/dev/null || true
+  posthog_capture "tick_outcome" "agent-pipeline" "$payload" 2>/dev/null || true
+}
+
+# Emit on every exit (success, explicit exit, error). The trap fires LAST; if a code path already
+# called emit_tick_outcome inline, the trap call is a no-op for repeat emission (PostHog accepts
+# duplicates — the duplicate is harmless and the inline call gives us a single clean event).
+trap '__TICK_DUR_MS=$(( (SECONDS - TICK_T0) * 1000 )); emit_tick_outcome' EXIT
 
 # --- helpers ---
 epoch() { date -d "$1" +%s 2>/dev/null || echo 0; }
@@ -394,7 +461,21 @@ add_worktree() {  # $1=branch  $2=base(ref)  -> path on stdout
     git -C "$REPO" worktree add "$wt" "origin/$branch" >/dev/null 2>&1
     git -C "$wt" checkout -B "$branch" "origin/$branch" >/dev/null 2>&1
   else
+    # Origin ref missing. If a stale local branch already exists (tip is on $base), `git worktree
+    # add -b` would silently fail and cd would break — delete the stale ref first.
+    if git -C "$REPO" show-ref --verify --quiet "refs/heads/$branch"; then
+      local tip
+      tip="$(git -C "$REPO" rev-parse --verify "$branch" 2>/dev/null)" || tip=""
+      if [ -n "$tip" ] && git -C "$REPO" merge-base --is-ancestor "$tip" "$base" 2>/dev/null; then
+        log "add_worktree: deleting stale local $branch (tip on $base) before creating worktree." >&2
+        git -C "$REPO" branch -D "$branch" >/dev/null 2>&1 || true
+      fi
+    fi
     git -C "$REPO" worktree add -b "$branch" "$wt" "$base" >/dev/null 2>&1
+  fi
+  if [ ! -d "$wt" ]; then
+    log "add_worktree: FAILED to create $wt (branch=$branch base=$base). Check git worktree list." >&2
+    return 1
   fi
   echo "$wt"
 }
@@ -433,6 +514,74 @@ run_claude() {  # $1=worktree  $2=prompt  $3=model (optional; empty = CLI defaul
 # --- state machine ---
 git -C "$REPO" fetch origin --prune >/dev/null 2>&1
 
+# ---- STALE-CLAIM REAPER: return abandoned agent:working issues to the queue ----------------
+# `agent:working` is stamped the moment a run STARTS, and select_next_issue excludes it. So any run
+# that dies before opening a PR — a killed worktree, a 400 from the proxy, a timeout, a reboot —
+# parks its issue in a state nothing ever leaves. There is no other exit from that state: on
+# 2026-07-29/30 sixteen issues accumulated there and the queue drained to zero while every tick
+# cheerfully logged "Pipeline idle" with both lanes green. Silence looked identical to done.
+#
+# An issue is reaped only when ALL of these hold, so live work is never yanked out from under a run:
+#   - no OPEN PR is linked to it (pr_for_issue) — a PR means the run got far enough to hand off
+#   - its branch claim lock is FREE — a concurrent slot working it holds that flock
+#   - it has not been touched for STALE_CLAIM_MINUTES (label edits count as touches)
+# Bounded: after STALE_CLAIM_MAX_REQUEUES round trips the issue is parked for a human instead of
+# cycling forever on whatever keeps killing it.
+STALE_CLAIM_MINUTES="${STALE_CLAIM_MINUTES:-120}"
+STALE_CLAIM_MAX_REQUEUES="${STALE_CLAIM_MAX_REQUEUES:-3}"
+reap_stale_claims() {
+  local now cutoff n upd pr lockf cnt drop
+  now="$(date +%s)"
+  cutoff=$(( now - STALE_CLAIM_MINUTES * 60 ))
+  for n in $(gh issue list --repo "$SLUG" --state open --limit 100 --label "agent:working" \
+               --json number,labels \
+               --jq '.[] | select((.labels|map(.name)) | (index("needs-human")|not) and (index("agent:blocked")|not)) | .number' 2>/dev/null); do
+    upd="$(gh issue view "$n" --repo "$SLUG" --json updatedAt --jq .updatedAt 2>/dev/null)"
+    [ -n "$upd" ] || continue
+    [ "$(epoch "$upd")" -lt "$cutoff" ] || continue
+    pr="$(pr_for_issue "$n" 2>/dev/null)"
+    # A PR means the run handed off — clear any requeue history so a future stall starts from zero
+    # rather than inheriting a count from a problem that has since been solved.
+    [ -n "$pr" ] && { rm -f "$BASE/state/requeue-$n.count"; continue; }
+    # A slot actively working this issue holds the branch claim. Probe it on a throwaway fd so we
+    # never disturb this tick's own claim on fd 10. Both branch prefixes the pipeline creates.
+    for lockf in "$BASE/locks/br-feature_claude-issue-$n.lock" "$BASE/locks/br-fix_claude-issue-$n.lock"; do
+      [ -e "$lockf" ] || continue
+      exec 9>"$lockf"
+      if ! flock -n 9; then exec 9>&-; continue 2; fi
+      exec 9>&-
+    done
+    cnt="$(cat "$BASE/state/requeue-$n.count" 2>/dev/null || echo 0)"
+    cnt=$((cnt + 1))
+    if [ "$cnt" -gt "$STALE_CLAIM_MAX_REQUEUES" ]; then
+      log "REAPER: issue #$n abandoned $((cnt - 1))x with no PR — parking for a human."
+      gh issue edit "$n" --repo "$SLUG" --add-label needs-human --add-label agent:blocked \
+        --add-assignee "$ASSIGNEE" --remove-label agent:working >/dev/null 2>&1
+      gh issue comment "$n" --repo "$SLUG" --body "🧹 Pipeline reaper: this issue was claimed \`agent:working\` and abandoned without a PR $((cnt - 1)) times (limit \`STALE_CLAIM_MAX_REQUEUES\`). Something is killing the run before it can hand off, so re-queueing it again would just burn slots. Parked for a human — check \`$LOGDIR\` for the failing run." >/dev/null 2>&1
+      posthog_capture "issue_reaped" "agent-pipeline" "{\"issue_number\":$n,\"action\":\"parked\",\"requeue_count\":$((cnt - 1))}" 2>/dev/null || true
+      continue
+    fi
+    # Drop the stale ai:* routing labels too: they describe the lane of the run that DIED, and
+    # leaving them makes the next run's labels a lie about which provider did the work. Read the
+    # list OFF THE ISSUE instead of hardcoding it — `gh issue edit` rejects the ENTIRE edit if any
+    # named label is unknown to the repo, so one drifted name in a static list silently undoes the
+    # whole requeue. That is not hypothetical: a hardcoded 'ai:claude' (the real label is
+    # 'ai:claude-subscription') failed exactly this way in testing, leaving the issue claimed.
+    drop="$(gh issue view "$n" --repo "$SLUG" --json labels \
+              --jq '[.labels[].name | select(startswith("ai:"))] | join(",")' 2>/dev/null)"
+    if ! gh issue edit "$n" --repo "$SLUG" --add-label agent:ready --remove-label agent:working \
+           ${drop:+--remove-label "$drop"} >/dev/null 2>&1; then
+      log "REAPER: label update FAILED for issue #$n — leaving the claim in place for the next tick."
+      continue
+    fi
+    # Count only a requeue that actually landed, so a failing edit can't exhaust the retry budget.
+    echo "$cnt" > "$BASE/state/requeue-$n.count"
+    log "REAPER: issue #$n stale in agent:working since $upd with no PR — returned to agent:ready (requeue $cnt/$STALE_CLAIM_MAX_REQUEUES)."
+    posthog_capture "issue_reaped" "agent-pipeline" "{\"issue_number\":$n,\"action\":\"requeued\",\"requeue_count\":$cnt}" 2>/dev/null || true
+  done
+}
+[ "$DRY_RUN" = "1" ] || reap_stale_claims
+
 # ---- PRIORITY LANE: Dependabot CI failures (labeled agent:depfix by the router workflow) ----
 # Handled before roadmap work so dependency PRs get unblocked fast. One Claude call per tick.
 DEPFIX="$(gh pr list --repo "$SLUG" --state open --label "agent:depfix" \
@@ -444,6 +593,7 @@ if [ -n "$DEPFIX" ]; then
   CLAUDE_TRIES="$(git -C "$REPO" log "origin/$DBR" --grep='Co-Authored-By: Claude' --format=%h 2>/dev/null | wc -l | tr -d ' ')"
   if [ "${CLAUDE_TRIES:-0}" -ge 3 ]; then
     log "Dependabot PR #$DPR still failing after $CLAUDE_TRIES Claude attempts — escalating."
+    TICK_OUTCOME="escalated"; TICK_REASON="depfix_exhausted"; TICK_PR="$DPR"; TICK_BRANCH="$DBR"
     if [ "$DRY_RUN" != "1" ]; then
       gh pr edit "$DPR" --repo "$SLUG" --add-label needs-human --remove-label agent:depfix >/dev/null 2>&1
       gh issue comment "$DPR" --repo "$SLUG" --body "🚧 Claude couldn't fix CI after $CLAUDE_TRIES attempts on this Dependabot PR. Assigning @$ASSIGNEE." >/dev/null 2>&1
@@ -452,6 +602,7 @@ if [ -n "$DEPFIX" ]; then
     exit 0
   fi
   log "Dependabot PR #$DPR failing — invoking depfix (priority lane, try $((CLAUDE_TRIES+1)))."
+  TICK_OUTCOME="dispatched"; TICK_REASON="mode_depfix"; TICK_MODE="depfix"; TICK_PR="$DPR"; TICK_BRANCH="$DBR"
   if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would run MODE=depfix for #$DPR ($DBR)."; exit 0; fi
   if ! claim_branch "$DBR"; then
     log "Dependabot PR #$DPR already claimed by another slot — moving on."
@@ -561,8 +712,9 @@ for MPR in $(gh pr list --repo "$SLUG" --state open --label "agent:working" \
   if [ "$(epoch "$MBEST")" -lt "$(epoch "$MHD")" ] \
      && [ "$(( $(date +%s) - $(epoch "$MHD") ))" -lt "${REVIEW_GRACE_SECONDS:-1200}" ]; then continue; fi
   # Last gate before any merge: closing an issue must not drop a declared later phase.
-  phase_guard_ok "$MPR" || exit 0
+  phase_guard_ok "$MPR" || { TICK_OUTCOME="skipped"; TICK_REASON="phase_guard_parked"; TICK_PR="$MPR"; exit 0; }
   log "MERGE-READY FAST PATH: PR #$MPR fully passes the gate — merging ahead of revise/fix work."
+  TICK_OUTCOME="dispatched"; TICK_REASON="mode_merge_fastpath"; TICK_MODE="merge"; TICK_PR="$MPR"
   if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would fast-path merge #$MPR."; exit 0; fi
   gh pr merge --auto "$(gh pr view "$MPR" --repo "$SLUG" --json url --jq .url)" >/dev/null 2>&1 \
     && gh pr comment "$MPR" --repo "$SLUG" --body "✅ CI green, review satisfied & all threads resolved — merging (fast path)." >/dev/null 2>&1
@@ -581,6 +733,7 @@ for RJSON in $(gh pr list --repo "$SLUG" --state open --label "agent:revise" \
     continue
   fi
   log "PR #$RPR — owner requested changes (agent:revise) — implementing their feedback."
+  TICK_OUTCOME="dispatched"; TICK_REASON="mode_revise"; TICK_MODE="revise"; TICK_PR="$RPR"; TICK_BRANCH="$RBR"
   if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would run MODE=revise for #$RPR ($RBR)."; exit 0; fi
   WT="$(add_worktree "$RBR" origin/main)"
   export MODE=revise PR="$RPR" BRANCH="$RBR" WORKTREE="$WT"
@@ -615,6 +768,7 @@ for PR_JSON in $(gh pr list --repo "$SLUG" --state open --label "agent:working" 
     if git -C "$WT" rebase origin/main >/dev/null 2>&1; then
       if git -C "$WT" push --force-with-lease origin "$BRANCH" >/dev/null 2>&1; then
         log "PR #$PR — scripted clean rebase onto main (no Claude); CI/Copilot re-triggered."
+        TICK_OUTCOME="dispatched"; TICK_REASON="mode_rebase_scripted"; TICK_MODE="rebase"; TICK_PR="$PR"; TICK_BRANCH="$BRANCH"
         exit 0
       fi
       log "PR #$PR — scripted rebase clean but push rejected — falling back to Claude MODE=rebase."
@@ -622,6 +776,7 @@ for PR_JSON in $(gh pr list --repo "$SLUG" --state open --label "agent:working" 
       git -C "$WT" rebase --abort >/dev/null 2>&1
       log "PR #$PR — real conflicts — invoking Claude MODE=rebase."
     fi
+    TICK_OUTCOME="dispatched"; TICK_REASON="mode_rebase"; TICK_MODE="rebase"; TICK_PR="$PR"; TICK_BRANCH="$BRANCH"
     export MODE=rebase PR ISSUE WORKTREE="$WT" BRANCH
     run_claude "$WT" "Read $RUNBOOK and follow MODE=rebase. PR=$PR ISSUE=$ISSUE BRANCH=$BRANCH."
     exit 0
@@ -642,6 +797,7 @@ for PR_JSON in $(gh pr list --repo "$SLUG" --state open --label "agent:working" 
     if ! claim_branch "$BRANCH"; then log "PR #$PR claimed by another slot — trying next."; continue; fi
     if [ "${ATTEMPTS:-1}" -ge "$MAX_FIX_ATTEMPTS" ]; then
       log "PR #$PR failing after $ATTEMPTS attempts — escalating to human."
+      TICK_OUTCOME="escalated"; TICK_REASON="fix_exhausted"; TICK_PR="$PR"; TICK_BRANCH="$BRANCH"
       if [ "$DRY_RUN" != "1" ]; then
         gh pr edit "$PR" --repo "$SLUG" --add-label needs-human --add-label agent:blocked --remove-label agent:working >/dev/null 2>&1
         gh pr ready --undo "$PR" --repo "$SLUG" >/dev/null 2>&1
@@ -653,6 +809,7 @@ for PR_JSON in $(gh pr list --repo "$SLUG" --state open --label "agent:working" 
       exit 0
     fi
     log "PR #$PR CI failing (attempt $ATTEMPTS) — invoking fix."
+    TICK_OUTCOME="dispatched"; TICK_REASON="mode_fix"; TICK_MODE="fix"; TICK_PR="$PR"; TICK_BRANCH="$BRANCH"
     WT="$(add_worktree "$BRANCH" origin/main)"
     export MODE=fix PR ISSUE WORKTREE="$WT" BRANCH ATTEMPTS
     run_claude "$WT" "Read $RUNBOOK and follow MODE=fix. PR=$PR ISSUE=$ISSUE BRANCH=$BRANCH ATTEMPTS=$ATTEMPTS." "$(model_for_issue "$ISSUE")"
@@ -663,6 +820,7 @@ for PR_JSON in $(gh pr list --repo "$SLUG" --state open --label "agent:working" 
   if [ "${UNRESOLVED:-0}" -gt 0 ]; then
     if ! claim_branch "$BRANCH"; then log "PR #$PR claimed by another slot — trying next."; continue; fi
     log "PR #$PR — $UNRESOLVED unresolved Copilot thread(s) — invoking review-address."
+    TICK_OUTCOME="dispatched"; TICK_REASON="mode_review"; TICK_MODE="review"; TICK_PR="$PR"; TICK_BRANCH="$BRANCH"
     WT="$(add_worktree "$BRANCH" origin/main)"
     export MODE=review PR ISSUE WORKTREE="$WT" BRANCH
     run_claude "$WT" "Read $RUNBOOK and follow MODE=review. PR=$PR ISSUE=$ISSUE BRANCH=$BRANCH." "$(model_for_issue "$ISSUE")"
@@ -703,7 +861,7 @@ for PR_JSON in $(gh pr list --repo "$SLUG" --state open --label "agent:working" 
           log "PR #$PR — Copilot review overdue; REVIEW_FALLBACK=hold — waiting."
           continue ;;
         merge)
-          phase_guard_ok "$PR" || exit 0
+          phase_guard_ok "$PR" || { TICK_OUTCOME="skipped"; TICK_REASON="phase_guard_parked"; TICK_PR="$PR"; exit 0; }
           log "PR #$PR — Copilot review overdue; REVIEW_FALLBACK=merge — merging with warning."
           if [ "$DRY_RUN" != "1" ]; then
             gh pr merge --auto "$(gh pr view "$PR" --repo "$SLUG" --json url --jq .url)" >/dev/null 2>&1 \
@@ -720,6 +878,7 @@ for PR_JSON in $(gh pr list --repo "$SLUG" --state open --label "agent:working" 
     else
       if ! claim_branch "$BRANCH"; then log "PR #$PR claimed by another slot — trying next."; continue; fi
       log "PR #$PR — green, no fresh review — invoking Claude adversarial review."
+      TICK_OUTCOME="dispatched"; TICK_REASON="mode_selfreview"; TICK_MODE="selfreview"; TICK_PR="$PR"; TICK_BRANCH="$BRANCH"
       if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would run MODE=selfreview for #$PR."; exit 0; fi
       WT="$(add_worktree "$BRANCH" origin/main)"
       export MODE=selfreview PR ISSUE WORKTREE="$WT" BRANCH
@@ -729,9 +888,10 @@ for PR_JSON in $(gh pr list --repo "$SLUG" --state open --label "agent:working" 
   fi
 
   # 5) Green + fresh review (Copilot or Claude marker) + all threads resolved -> merge.
-  # Same last gate as the fast path: never close an issue that still declares a later phase.
-  phase_guard_ok "$PR" || exit 0
+  # Same last gate as the fast path: never close an issue that still declares a declared later phase.
+  phase_guard_ok "$PR" || { TICK_OUTCOME="skipped"; TICK_REASON="phase_guard_parked"; TICK_PR="$PR"; TICK_BRANCH="$BRANCH"; exit 0; }
   log "PR #$PR — merge gate satisfied. Merging."
+  TICK_OUTCOME="dispatched"; TICK_REASON="mode_merge"; TICK_MODE="merge"; TICK_PR="$PR"; TICK_BRANCH="$BRANCH"
   if [ "$DRY_RUN" != "1" ]; then
     gh pr merge --auto "$(gh pr view "$PR" --repo "$SLUG" --json url --jq .url)" >/dev/null 2>&1 \
       && gh pr comment "$PR" --repo "$SLUG" --body "✅ CI green, review satisfied & all threads resolved — merging." >/dev/null 2>&1
@@ -749,12 +909,12 @@ fi
 # prioritize triage/merge/answer work (already done above). Hold new starts until a lane recovers.
 if [ "${DEGRADED:-0}" = "1" ]; then
   log "DEGRADED: holding new issue start (both lanes constrained). Triage/merge/answer lanes ran."
-  exit 0
+  TICK_OUTCOME="skipped"; TICK_REASON="degraded_hold_new_start"; exit 0
 fi
 ISSUE="$(select_next_issue)"
 if [ -z "$ISSUE" ]; then
   log "No agent:ready issues remaining. Pipeline idle."
-  exit 0
+  TICK_OUTCOME="nothing_to_do"; TICK_REASON="no_ready"; exit 0
 fi
 RISK="$(gh issue view "$ISSUE" --repo "$SLUG" --json labels \
         | jq -r '[.labels[].name|select(startswith("risk:"))|sub("risk:";"")]|join(" ")')"
@@ -767,12 +927,22 @@ fi
 MODEL="$(model_for_issue "$ISSUE")"
 log "Starting issue #$ISSUE (risk=$RISK${MODEL:+, model=$MODEL}) on $BRANCH."
 posthog_capture "issue_queued" "agent-pipeline" "{\"issue_number\":$ISSUE,\"issue_url\":\"https://github.com/$SLUG/issues/$ISSUE\",\"worker_id\":\"${WORKER_ID:-}\",\"issue_priority\":\"${ISSUE_PRIORITY:-}\",\"issue_type\":\"start\"}" 2>/dev/null || true
+TICK_OUTCOME="dispatched"; TICK_REASON="mode_start"; TICK_MODE="start"; TICK_ISSUE="$ISSUE"; TICK_BRANCH="$BRANCH"
 if [ "$DRY_RUN" = "1" ]; then
   log "DRY_RUN: would create worktree $BRANCH and run MODE=start for #$ISSUE."
   exit 0
 fi
 gh issue edit "$ISSUE" --repo "$SLUG" --add-label agent:working --remove-label agent:ready >/dev/null 2>&1
 WT="$(add_worktree "$BRANCH" origin/main)"
+# add_worktree returning empty means it could not build the tree. Handing that to run_claude would
+# `cd ""` — i.e. run the agent in $HOME, against the wrong repo — while the issue sits claimed as
+# agent:working. Give the claim straight back instead; the reaper is the backstop, not the plan.
+if [ -z "$WT" ] || [ ! -d "$WT" ]; then
+  log "Issue #$ISSUE — worktree creation failed for $BRANCH; returning it to agent:ready."
+  gh issue edit "$ISSUE" --repo "$SLUG" --add-label agent:ready --remove-label agent:working >/dev/null 2>&1
+  TICK_OUTCOME="failed"; TICK_REASON="worktree_create_failed"
+  exit 1
+fi
 export MODE=start ISSUE WORKTREE="$WT" BRANCH RISK
 run_claude "$WT" "Read $RUNBOOK and follow MODE=start. ISSUE=$ISSUE BRANCH=$BRANCH RISK=$RISK WORKTREE=$WT." "$MODEL"
 exit 0


### PR DESCRIPTION
## Why

The pipeline sat idle for ~18 hours with a full backlog. Both lanes reported healthy, every tick logged `Pipeline idle`, and nothing was wrong with Claude. 16 issues were stranded in `agent:working` — which `select_next_issue` excludes — so the ready queue read zero. **Silence was indistinguishable from done.**

Three defects all had to hold for that to happen, and each is fixed here.

## 1. No stale-claim reaper

`agent:working` is stamped the moment a run **starts**. A run that dies before opening a PR leaves its issue in a state nothing else exits — no retry, no alert, no timeout.

`reap_stale_claims` runs once per tick (skipped under `DRY_RUN`) and returns an issue to `agent:ready` only when **all** of these hold, so live work is never yanked out from under a run:

| Guard | Why |
|---|---|
| no OPEN PR linked (`pr_for_issue`) | a PR means the run got far enough to hand off |
| branch claim lock free | a concurrent slot working it holds that `flock` |
| untouched for `STALE_CLAIM_MINUTES` (default 120) | label edits count as touches |
| not `needs-human` / `agent:blocked` | already parked deliberately |

Bounded by `STALE_CLAIM_MAX_REQUEUES` (default 3): past that the issue gets `needs-human` + `agent:blocked`, the owner is assigned, and a comment explains why — rather than cycling forever on whatever keeps killing the run. Emits `issue_reaped` to PostHog.

## 2. The Ollama gauge could not see an unusable lane

`/health/liveliness` proves the **proxy** answers. It says nothing about whether the proxy will serve the tier alias the lane passes as `--model`. Those came apart on 2026-07-29: proxy up, gauge steady at `75 healthy`, and **49 consecutive runs** dying on `anthropic_messages: Invalid model name passed in model=lem-agent-tier2` — each one claiming an issue and abandoning it.

Two causes:

- `_ollama_probe` classified on **curl's exit code**, and `curl -sS` (no `-f`) exits 0 on an HTTP 400 — a hard rejection recorded as a healthy probe.
- `_maybe_probe_ollama` only fired after a **usage-limit**. A broken alias, rotated key or bad `api_base` fails every run without matching the usage-limit regex, so the one failure mode that had already eaten a day of backlog could never trigger recovery.

Now `_litellm_probe` classifies on **HTTP status** (`0` served / `1` usage-limited / `2` broken) and records the reason; `_ollama_alias_ok` validates the real tier alias, cached for `OLLAMA_ALIAS_TTL` (~1 token an hour, not one per tick); a failing alias reports **`0 unavailable`** so dispatch routes to Claude instead of feeding issues into a lane that cannot run them. The probe also fires after `OLLAMA_FAIL_PROBE_AT` consecutive plain failures.

## 3. `add_worktree` returned a corrupted path

It echoes the worktree path on stdout — but `log()` tees to stdout too, so `WT="$(add_worktree …)"` captured the log line *plus* the path:

```
run_lane.sh: line 78: cd: $'[2026-07-29 20:15:09] add_worktree: deleting stale local …\n/home/lem/agent-pipeline/work/feature/claude-issue-600': No such file or directory
```

Both log calls now go to stderr. The start path also refuses an empty/missing worktree rather than handing `cd ""` to the agent — that silently ran it in `$HOME` against the wrong repo while the issue stayed claimed.

## Repo sync

`scripts/agent-pipeline/` had drifted well behind the live host copy (worktree self-heal, PostHog tick outcomes, phase guard, review economy — 45 KB vs 58 KB). This brings it to parity and starts tracking `lib/`, which was **never** in the repo: the unanchored `lib/` rule in `.gitignore` matches a directory named `lib` at *any* depth. Every other match is under `.venv/`, ignored on its own line, so the negation loosens nothing else.

## Validation (on the box, against the live pipeline)

- Reaper exercised on a throwaway issue (#806, closed) through requeue 1→2→3 and the human-park bound; label strip verified; confirmed it **skips an in-flight run** (branch lock held by the live #745 run).
- Caught during testing: a hardcoded `ai:*` removal list failed the **entire** `gh issue edit` on one unknown label (`ai:claude` — the real label is `ai:claude-subscription`), silently undoing the requeue. The list is now read off the issue.
- Alias probe reproduces the 2026-07-29 failure as `0 unavailable` with the reason logged, and passes for the real tier.
- End-to-end `claude -p --model lem-agent-tier2` through LiteLLM returns clean; `/v1/messages` and `/v1/chat/completions` both verified.
- Live ticks since the change report `claude=80%(healthy) ollama=75%(healthy) degraded=0` and dispatched issue #745 on `lane=claude reason=primary`.

## Note

The live host copy under `/home/lem/agent-pipeline/` is **already running** these changes (that is where they were developed and tested). This PR is what keeps them from being lost — the host copy is not deployed from the repo, so the repo is the maintained record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVoFVsj7fCSLzgoQWSZrBW