### PR TITLE
feat(avatar): likeness fidelity, preview gate + usage guardrails (refs #744)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -373,6 +373,10 @@ DEFAULT_VIDEO_RATIO=960:960
 DEFAULT_IMAGE_MODEL=black-forest-labs/flux-dev
 DEFAULT_IMAGE_RATIO=1:1
 
+# Avatar preview/approval gate: how many times a user may re-roll their avatar's preview
+# samples. Sits on top of the credit ledger — samples cost inference money but no training credit.
+AVATAR_SAMPLE_REGEN_MAX=3
+
 # Append a "created with AI" line to AI-visual post captions (guaranteed-visible disclosure).
 AI_DISCLOSURE_ENABLED=true
 AI_DISCLOSURE_TEXT=\n\n(Visuals created with AI)

--- a/compose/local/database/migrations/V20260731144005__add_avatar_fidelity_and_guardrails.sql
+++ b/compose/local/database/migrations/V20260731144005__add_avatar_fidelity_and_guardrails.sql
@@ -1,0 +1,37 @@
+-- Avatar likeness fidelity, preview/approval gate and usage guardrails
+-- (issue #744 — Phase 2 of #548, decisions 3A + 4A).
+--
+-- 3A: the user SELF-DECLARES gender presentation and an optional age band. Nothing infers them,
+-- no model ever classifies the user's face, and NULL means "not declared" — which renders an
+-- empty subject clause rather than a guess.
+--
+-- 4A: an avatar is unusable until its sample renders have been seen and APPROVED, use is opt-in
+-- per content surface (default OFF), and `avatar_disabled` is the explicit "don't use my avatar"
+-- switch that forces the base-Flux / Pexels path.
+
+ALTER TABLE avatar_trainings
+    ADD COLUMN gender_presentation     VARCHAR(32) NULL,
+    ADD COLUMN age_band                VARCHAR(16) NULL,
+    ADD COLUMN attributes_confirmed_at DATETIME    NULL,
+    ADD COLUMN approval_status         ENUM('pending','approved','rejected') NOT NULL DEFAULT 'pending',
+    ADD COLUMN approved_at             DATETIME    NULL,
+    ADD COLUMN sample_paths            TEXT        NULL,
+    ADD COLUMN samples_generated_at    DATETIME    NULL,
+    ADD COLUMN sample_regen_count      INT         NOT NULL DEFAULT 0;
+
+-- Per-user guardrails. Every opt-in defaults to 0: an avatar that has never been previewed and
+-- approved must never reach a published post (that is exactly how the wrong-gender renders in
+-- #548 shipped), so existing rows deliberately land in the OFF state too.
+ALTER TABLE users
+    ADD COLUMN avatar_disabled       TINYINT(1) NOT NULL DEFAULT 0,
+    ADD COLUMN avatar_use_post_image TINYINT(1) NOT NULL DEFAULT 0,
+    ADD COLUMN avatar_use_carousel   TINYINT(1) NOT NULL DEFAULT 0,
+    ADD COLUMN avatar_use_video      TINYINT(1) NOT NULL DEFAULT 0;
+
+-- use_avatar is the compose-time toggle (PostRequest.use_avatar), which until now was accepted by
+-- the API and dropped. NULL = follow the per-user opt-ins; 0/1 = this post overrides them.
+-- avatar_media records that generated media for this post actually came out of the avatar LoRA,
+-- so the caption disclosure can be applied to avatar images and not just to video.
+ALTER TABLE posts
+    ADD COLUMN use_avatar   TINYINT(1) NULL,
+    ADD COLUMN avatar_media TINYINT(1) NOT NULL DEFAULT 0;

--- a/docs/AVATAR_FIDELITY_AND_VIDEO_LANGUAGE.md
+++ b/docs/AVATAR_FIDELITY_AND_VIDEO_LANGUAGE.md
@@ -226,13 +226,20 @@ Ordered by risk-reduction per unit of work. Items 1–2 are the reported product
   `users.avatar_use_post_image` / `_carousel` / `_video` (default **OFF**) → the approval gate. It
   **fails closed**: any error resolving the policy declines the avatar.
 - `PostRequest.use_avatar` — accepted and dropped before — is persisted by `schedule_post` and
-  `update_post`.
+  `update_post`. It stays **three-valued**: omitted means "follow my opt-ins", so `ComposePost.tsx`
+  sends it only once the author has actually moved the toggle, and shows the account opt-in for
+  that surface until they do. An untouched default-off toggle sending a plain `false` would be an
+  explicit per-post opt-out and would silently outrank the very toggles this section adds.
 - Provenance: `generate_post_image()` C2PA-signs every real avatar render and sets
   `posts.avatar_media`, which `_create_content_for_planned_post` reads so `_apply_ai_disclosure()`
   covers avatar images (carousel slides included), not just video. A base-Flux fallback render
   claims neither.
 - Sample regeneration is capped by `AVATAR_SAMPLE_REGEN_MAX` (default 3) on top of the credit
-  ledger — samples cost inference money but no training credit.
+  ledger — samples cost inference money but no training credit. The cap is **reserved in the
+  write** (`claim_avatar_sample_render`) before a render is queued, and the automatic first render
+  claims `samples_generated_at` the same way: a counter that only moves when a render finishes is
+  not a cap, because two clicks (or two status polls) both pass the same reading. A render that
+  ships no images hands the reservation back.
 - **Operator note:** every guardrail defaults OFF, including for accounts that already have an
   active avatar. After this migration an existing avatar must be previewed and approved, and its
   content types opted in, before it is used again. That is deliberate — a never-previewed avatar is

--- a/docs/AVATAR_FIDELITY_AND_VIDEO_LANGUAGE.md
+++ b/docs/AVATAR_FIDELITY_AND_VIDEO_LANGUAGE.md
@@ -1,16 +1,18 @@
-# Avatar Fidelity, Preview, Guardrails & Video Language — Phase 1 Research
+# Avatar Fidelity, Preview, Guardrails & Video Language
 
-Issue: [#548](https://github.com/christopherqueenconsulting/linkedin_engagement_manager/issues/548)
-Date: 2026-07-25 · Status: **research complete; owner signed off `1A 2A 3A 4A` — see §5**
+Issues: [#548](https://github.com/christopherqueenconsulting/linkedin_engagement_manager/issues/548)
+(research + item 1) · [#744](https://github.com/christopherqueenconsulting/linkedin_engagement_manager/issues/744)
+(items 2–4)
+Date: 2026-07-25, updated 2026-07-31 · Status: **owner signed off `1A 2A 3A 4A` (§5); all four
+Phase 2 items implemented — one supervised live avatar render still outstanding**
 
-This document root-causes the four reported defects against the code as it exists on `main`,
+This document root-causes the four reported defects against the code as it existed on `main`,
 records what the underlying models can and cannot be conditioned on, and lays out the Phase 2
 implementation plan.
 
-**What ships in this PR:** the research below, plus **Phase 2 item 1 only** — the video-language
-fix (§2.1), which the owner asked for ahead of the rest so the two posts that shipped with a
-foreign-language voiceover (#34, #36) can be regenerated. Items 2–4 (likeness attributes, preview
-+ approval gate, guardrails) land in a follow-up PR and close the issue.
+**Shipped in #548 / PR #597:** the research below plus **Phase 2 item 1** — the video-language
+fix (§2.1). **Shipped in #744:** items 2–4 (likeness attributes, preview + approval gate,
+guardrails) — see §4 for the built shape of each.
 
 ---
 
@@ -184,36 +186,57 @@ Ordered by risk-reduction per unit of work. Items 1–2 are the reported product
 - Validation: after deploy, `regenerate_post_video_task(34)` / `(36)` on the owner's account and
   confirm the audio.
 
-**2. Likeness / gender fidelity.** (Decision 3A — user self-declares, never inferred)
-- Migration (timestamp version): add nullable `gender_presentation VARCHAR(32)`, `age_band VARCHAR(16)`,
-  `attributes_confirmed_at DATETIME` to `avatar_trainings`. (`users.content_language` already landed
-  with item 1.)
-- New `utilities/avatar/attributes.py`: `subject_clause(avatar) -> str` producing one canonical phrase
-  (e.g. `"a man in his 40s"`) from **stored, user-declared** values. Empty string when unset — never
-  guessed.
-- Inject it in two places: into `_profile_visual_context()` so the prompt-authoring LLM never invents a
-  conflicting subject, and into `generate_post_image()`'s final prompt next to the trigger word.
-- Thread `ratio` through `generate_image_with_avatar()` → `get_flux_image_via_replicate(aspect_ratio=…)`.
-- Only prepend the trigger word when the scene actually depicts the author (person-bearing prompts);
-  `_generate_avatar_slide_image()` routes object/concept queries to base Flux or Pexels instead.
+**2. Likeness / gender fidelity.** ✅ **shipped in #744** (Decision 3A — user self-declares, never inferred)
+- Migration `V20260731144005__add_avatar_fidelity_and_guardrails.sql`: nullable
+  `gender_presentation VARCHAR(32)`, `age_band VARCHAR(16)`, `attributes_confirmed_at DATETIME` on
+  `avatar_trainings`. (`users.content_language` already landed with item 1.)
+- `utilities/avatar/attributes.py` is the ONE place attributes become prompt text.
+  `subject_clause(avatar)` renders one canonical phrase (`"a man in his 40s"`) from **stored,
+  user-declared** values; `""` when unset. `"prefer-not-to-say"` is a storable choice that
+  contributes no noun, and an age band alone renders the neutral `"a person in their 40s"` —
+  stating an age is not a claim about gender. Nothing here reads a photo.
+- Injected in two places: `subject_directive()` leads `_profile_visual_context()` so the
+  prompt-authoring LLM never invents a conflicting subject, and `apply_subject_clause()` puts the
+  clause beside the trigger word in `generate_post_image()`'s final Replicate prompt.
+- `ratio` threads through `generate_image_with_avatar()` →
+  `get_flux_image_via_replicate(aspect_ratio=…)`.
+- The trigger word only reaches person-bearing scenes: `generate_post_image(depicts_person=…)`,
+  driven by `carousel_creator._query_depicts_person()` — a `personal_story` slide is about the
+  author by definition, anything else needs a person term in the derived query.
 
-**3. Preview + approval gate.** (Decision 4A)
-- On transition to `succeeded`, render N=3 sample images through the avatar LoRA (fixed prompt set:
-  headshot, at-desk, speaking-to-camera) and persist their asset paths (new `avatar_samples` table or a
-  JSON column — one row per avatar).
-- New endpoints: `GET /avatar/training/{id}/samples`, `POST /avatar/training/{id}/approve`,
-  `POST /avatar/training/{id}/reject`.
-- `set_active_avatar()` refuses avatars that are not approved.
-- `Avatars.tsx`: sample gallery, Approve / Reject + Regenerate, attribute & language settings,
-  guardrail toggles, credit/usage visibility.
+**3. Preview + approval gate.** ✅ **shipped in #744** (Decision 4A)
+- `utilities/avatar/samples.py` renders three fixed scenes (headshot, at-desk, speaking-to-camera)
+  through the LoRA using the SAME subject clause a production image uses, so what the user approves
+  is what they get. Paths persist as JSON on `avatar_trainings.sample_paths` (one row per avatar).
+  Rendering runs in `app/run_avatar.render_avatar_samples_task`, queued when a training first
+  reaches `succeeded`; a base-Flux fallback render is discarded rather than shown as "your avatar".
+- Endpoints: `GET`/`POST /avatar/training/{id}/samples` (read / capped re-roll),
+  `POST …/approve`, `POST …/reject`, `PUT …/attributes`, `GET`/`PUT /avatar/preferences`.
+- `set_active_avatar()` **and** the activate endpoint refuse an avatar that is not `approved`;
+  approving requires rendered samples to exist. Rejecting also deactivates. New samples reset an
+  earlier verdict to `pending` — the user approved the images they saw.
+- `Avatars.tsx`: sample gallery, Approve / Reject / Regenerate, attribute controls, guardrail
+  toggles and credit/usage visibility. (Content language stays in Account → Preferences, where
+  item 1 put it.)
 
-**4. Guardrails.** (Decision 4A — full set)
-- Honor `PostRequest.use_avatar` (currently dead) in the compose path.
-- Per-user, per-content-type opt-in (`avatar_use_*` columns or an engagement-preference section),
-  default **off** until the avatar is approved.
-- Extend `_apply_ai_disclosure()` + C2PA to any post whose media used the avatar, not just video.
-- Regeneration cap on top of the credit ledger; an explicit "don't use my avatar" switch that forces
-  the base-Flux / Pexels path.
+**4. Guardrails.** ✅ **shipped in #744** (Decision 4A — full set)
+- `utilities/avatar/guardrails.resolve_avatar_for()` is the ONE gate; `None` always means "use base
+  Flux / Pexels". Precedence: `users.avatar_disabled` (the explicit "don't use my avatar" switch) →
+  `posts.use_avatar` (the compose-time choice, three-valued, NULL = no choice) →
+  `users.avatar_use_post_image` / `_carousel` / `_video` (default **OFF**) → the approval gate. It
+  **fails closed**: any error resolving the policy declines the avatar.
+- `PostRequest.use_avatar` — accepted and dropped before — is persisted by `schedule_post` and
+  `update_post`.
+- Provenance: `generate_post_image()` C2PA-signs every real avatar render and sets
+  `posts.avatar_media`, which `_create_content_for_planned_post` reads so `_apply_ai_disclosure()`
+  covers avatar images (carousel slides included), not just video. A base-Flux fallback render
+  claims neither.
+- Sample regeneration is capped by `AVATAR_SAMPLE_REGEN_MAX` (default 3) on top of the credit
+  ledger — samples cost inference money but no training credit.
+- **Operator note:** every guardrail defaults OFF, including for accounts that already have an
+  active avatar. After this migration an existing avatar must be previewed and approved, and its
+  content types opted in, before it is used again. That is deliberate — a never-previewed avatar is
+  exactly what shipped the wrong-gender renders.
 
 **Testing.** Item 1's coverage ships here: `_audio_direction` across every model in `VIDEO_MODELS`,
 the language/marker content, prompt-trimming, the `create_runway_video` audio gate, language
@@ -221,10 +244,19 @@ resolution precedence + fail-soft paths, pipeline threading, and the settings en
 (`tests/unit/utilities/test_content_language.py`, `tests/unit/utilities/ai/test_ai_helper_media.py`,
 `tests/unit/utilities/ai/test_video_models_premium.py`, `tests/unit/app/test_video_tier_pipeline.py`,
 `tests/integration/test_content_language_settings.py`).
-Items 2–4 still owe: `subject_clause` (unset → empty, never inferred), ratio threading, trigger-word
-gating, the approval gate on `set_active_avatar`, and integration coverage for the new avatar
-endpoints. Target ≥90% patch coverage per the issue. Regenerating posts #34/#36 plus one supervised
-avatar render on the owner's account are the live validation cases.
+Items 2–4's coverage ships with #744: `subject_clause` (unset → empty, never inferred),
+the guardrail precedence + fail-closed posture, sample rendering and its fallback discard, ratio
+threading, trigger-word gating, the approval gate on `set_active_avatar` and the activate endpoint,
+the avatar-image disclosure, and the new endpoints
+(`tests/unit/utilities/avatar/test_attributes.py`, `…/test_guardrails.py`, `…/test_samples.py`,
+`tests/unit/app/test_run_avatar_task.py`, `tests/unit/app/test_avatar_media_disclosure.py`,
+`tests/unit/utilities/ai/test_ai_helper_avatar_image.py`,
+`tests/unit/utilities/test_db_avatar_fidelity.py`,
+`tests/integration/test_avatar_preview_api.py`).
+
+**Still outstanding:** one supervised avatar render on the owner's account after deploy — declare
+attributes, review the three samples, approve, opt a content type in, generate. That is a human
+step and is why #744 stays open until it is done.
 
 ---
 

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -81,6 +81,7 @@ from cqc_lem.utilities.db import (
     update_avatar_training_status, set_active_avatar,
     get_avatar_trainings, get_active_avatar, get_avatar_training,
     update_avatar_attributes, set_avatar_approval,
+    claim_avatar_sample_render, release_avatar_sample_render,
     get_avatar_preferences, update_avatar_preferences, update_post_use_avatar,
     AVATAR_APPROVAL_APPROVED, AVATAR_APPROVAL_REJECTED,
     get_user_timezone, update_user_timezone,
@@ -4131,13 +4132,16 @@ def sync_avatar_training_status(avatar_db_id: int, session_token: str) -> Respon
 def _queue_avatar_samples_if_due(avatar: dict, user_id: int) -> None:
     """Kick off the preview renders the moment a training reaches 'succeeded' (issue #744).
 
-    Idempotent by the stored sample list, so polling the status endpoint repeatedly cannot spend
-    inference money over and over. Best-effort: a broker hiccup must not fail the status read —
-    the SPA's explicit "Regenerate samples" action is the recovery path.
+    The claim is what makes this idempotent: a repeated (or double-clicked) status poll arriving
+    while the first render is still running loses the claim and queues nothing, so polling cannot
+    spend inference money over and over. Best-effort: a broker hiccup must not fail the status
+    read — the claim is handed back so the next poll can try again.
     """
     if avatar.get("status") != "succeeded" or not avatar.get("model_ref"):
         return
     if avatar.get("sample_paths"):
+        return
+    if not claim_avatar_sample_render(user_id, avatar["id"]):
         return
     try:
         from cqc_lem.app.run_avatar import render_avatar_samples_task
@@ -4147,6 +4151,7 @@ def _queue_avatar_samples_if_due(avatar: dict, user_id: int) -> None:
         render_avatar_samples_task.apply_async(
             kwargs={"avatar_id": avatar["id"], "user_id": user_id}, retry=False)
     except Exception as e:
+        release_avatar_sample_render(user_id, avatar["id"])
         log_error("Could not queue avatar sample rendering", exc=e, user_id=user_id)
 
 
@@ -4186,7 +4191,7 @@ def get_avatar_samples(avatar_db_id: int, session_token: str) -> ResponseModel:
 
 @router.post("/avatar/training/{avatar_db_id}/samples", responses={
     200: {"description": "Sample regeneration queued"},
-    **{k: v for k, v in error_responses.items() if k in [400, 401, 404, 429]}
+    **{k: v for k, v in error_responses.items() if k in [400, 401, 404, 429, 500]}
 })
 def regenerate_avatar_samples(avatar_db_id: int, request: AvatarActivateRequest) -> ResponseModel:
     """Re-roll the preview set. Capped by AVATAR_SAMPLE_REGEN_MAX on top of the credit ledger —
@@ -4200,15 +4205,25 @@ def regenerate_avatar_samples(avatar_db_id: int, request: AvatarActivateRequest)
         raise HTTPException(status_code=400, detail="Only a succeeded training can render samples")
 
     from cqc_lem.utilities.env_constants import AVATAR_SAMPLE_REGEN_MAX
-    if avatar["sample_regen_count"] >= AVATAR_SAMPLE_REGEN_MAX:
+    # Reserve the re-roll in the same statement that checks the cap. Reading the counter and
+    # queueing separately let a double-click (the counter only moves when a render FINISHES)
+    # queue two full three-image renders against one reading — an unbounded spend is exactly
+    # what the cap exists to stop. The task hands the reservation back if it renders nothing.
+    if not claim_avatar_sample_render(user_id, avatar_db_id, regeneration=True,
+                                      max_regenerations=AVATAR_SAMPLE_REGEN_MAX):
         raise HTTPException(
             status_code=429,
             detail=f"Sample regeneration limit reached ({AVATAR_SAMPLE_REGEN_MAX}). "
                    f"Train a new avatar with better photos instead.")
 
-    from cqc_lem.app.run_avatar import render_avatar_samples_task
-    render_avatar_samples_task.apply_async(
-        kwargs={"avatar_id": avatar_db_id, "user_id": user_id, "count_regeneration": True})
+    try:
+        from cqc_lem.app.run_avatar import render_avatar_samples_task
+        render_avatar_samples_task.apply_async(
+            kwargs={"avatar_id": avatar_db_id, "user_id": user_id, "count_regeneration": True})
+    except Exception as e:
+        release_avatar_sample_render(user_id, avatar_db_id, regeneration=True)
+        log_error("Could not queue avatar sample regeneration", exc=e, user_id=user_id)
+        raise HTTPException(status_code=500, detail="Could not queue sample regeneration")
     return ResponseModel(status_code=200, detail="Sample regeneration queued")
 
 

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -79,7 +79,10 @@ from cqc_lem.utilities.db import (
     get_video_credit_ledger_entry_by_session, update_post_video_quality,
     deduct_avatar_credit, insert_avatar_training,
     update_avatar_training_status, set_active_avatar,
-    get_avatar_trainings, get_active_avatar,
+    get_avatar_trainings, get_active_avatar, get_avatar_training,
+    update_avatar_attributes, set_avatar_approval,
+    get_avatar_preferences, update_avatar_preferences,
+    AVATAR_APPROVAL_APPROVED, AVATAR_APPROVAL_REJECTED,
     get_user_timezone, update_user_timezone,
     get_user_geo, update_user_location, get_user_content_language,
     replace_video_url_base, get_post_type, get_post_buyer_stage, get_post_status,
@@ -282,7 +285,9 @@ class PostRequest(BaseModel):
     email: Optional[str] = None
     status: Optional[PostStatus] = PostStatus.PENDING
     carousel_slides: Optional[List[str]] = None
-    use_avatar: Optional[bool] = False
+    # None = no compose-time choice, so the user's per-content-type avatar opt-ins decide
+    # (issue #744). True/False is an explicit override for this post.
+    use_avatar: Optional[bool] = None
     video_quality: Optional[str] = "standard"  # standard | premium | premium_top
     rejection_reason: Optional[str] = Field(default=None, max_length=1000)
 
@@ -309,6 +314,23 @@ class UpgradeVideoRequest(BaseModel):
 
 class AvatarActivateRequest(BaseModel):
     session_token: str
+
+
+class AvatarAttributesRequest(BaseModel):
+    """Self-declared likeness attributes (issue #744, decision 3A). Both fields are optional and
+    a null clears the declaration — an undeclared attribute renders no subject clause at all."""
+    session_token: str
+    gender_presentation: Optional[str] = None
+    age_band: Optional[str] = None
+
+
+class AvatarPreferencesRequest(BaseModel):
+    """Per-user avatar guardrails. Every flag is optional so the SPA can PATCH one toggle."""
+    session_token: str
+    avatar_disabled: Optional[bool] = None
+    avatar_use_post_image: Optional[bool] = None
+    avatar_use_carousel: Optional[bool] = None
+    avatar_use_video: Optional[bool] = None
 
 
 class BulkUpdateRequest(BaseModel):
@@ -1520,7 +1542,8 @@ def schedule_post(post: PostRequest) -> ResponseModel:
     if insert_post(post.email, post.content, post.scheduled_datetime, post.post_type,
                    video_url=post.video_url, carousel_slides=post.carousel_slides,
                    video_quality=post.video_quality or "standard",
-                   status=post.status or PostStatus.PENDING):
+                   status=post.status or PostStatus.PENDING,
+                   use_avatar=post.use_avatar):
         return ResponseModel(status_code=200, detail="Post scheduled successfully")
     else:
         raise HTTPException(status_code=404, detail="Could not schedule post")
@@ -4088,6 +4111,7 @@ def sync_avatar_training_status(avatar_db_id: int, session_token: str) -> Respon
         raise HTTPException(status_code=404, detail="Training not found")
 
     if match["status"] in ("succeeded", "failed", "canceled"):
+        _queue_avatar_samples_if_due(match, user_id)
         return ResponseModel(status_code=200, detail=match)
 
     from cqc_lem.utilities.avatar.replicate_avatar import poll_training_status
@@ -4096,7 +4120,182 @@ def sync_avatar_training_status(avatar_db_id: int, session_token: str) -> Respon
     match["status"] = new_status
     if model_ref:
         match["model_ref"] = model_ref
+    _queue_avatar_samples_if_due(match, user_id)
     return ResponseModel(status_code=200, detail=match)
+
+
+def _queue_avatar_samples_if_due(avatar: dict, user_id: int) -> None:
+    """Kick off the preview renders the moment a training reaches 'succeeded' (issue #744).
+
+    Idempotent by the stored sample list, so polling the status endpoint repeatedly cannot spend
+    inference money over and over. Best-effort: a broker hiccup must not fail the status read —
+    the SPA's explicit "Regenerate samples" action is the recovery path.
+    """
+    if avatar.get("status") != "succeeded" or not avatar.get("model_ref"):
+        return
+    if avatar.get("sample_paths"):
+        return
+    try:
+        from cqc_lem.app.run_avatar import render_avatar_samples_task
+        # retry=False: this is a side-effect of a status poll the SPA makes every 20s. A broker
+        # outage must fail it in one attempt, not hold the HTTP response open through a retry
+        # ladder — the next poll (or the explicit Regenerate button) queues it again.
+        render_avatar_samples_task.apply_async(
+            kwargs={"avatar_id": avatar["id"], "user_id": user_id}, retry=False)
+    except Exception as e:
+        log_error("Could not queue avatar sample rendering", exc=e, user_id=user_id)
+
+
+def _require_own_avatar(user_id: int, avatar_db_id: int) -> dict:
+    avatar = get_avatar_training(user_id, avatar_db_id)
+    if not avatar:
+        raise HTTPException(status_code=404, detail="Training not found")
+    return avatar
+
+
+@router.get("/avatar/training/{avatar_db_id}/samples", responses={
+    200: {"description": "Avatar samples returned"},
+    **{k: v for k, v in error_responses.items() if k in [401, 404]}
+})
+def get_avatar_samples(avatar_db_id: int, session_token: str) -> ResponseModel:
+    """The rendered preview set plus everything the approval UI needs to decide."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    avatar = _require_own_avatar(user_id, avatar_db_id)
+    from cqc_lem.utilities.avatar.samples import sample_payload
+    from cqc_lem.utilities.env_constants import AVATAR_SAMPLE_REGEN_MAX
+    return ResponseModel(status_code=200, detail={
+        "avatar_id": avatar["id"],
+        "status": avatar["status"],
+        "approval_status": avatar["approval_status"],
+        "samples": sample_payload(avatar),
+        "samples_generated_at": avatar["samples_generated_at"],
+        "sample_regen_count": avatar["sample_regen_count"],
+        "sample_regen_remaining": max(0, AVATAR_SAMPLE_REGEN_MAX - avatar["sample_regen_count"]),
+        "gender_presentation": avatar["gender_presentation"],
+        "age_band": avatar["age_band"],
+        "attributes_confirmed_at": avatar["attributes_confirmed_at"],
+    })
+
+
+@router.post("/avatar/training/{avatar_db_id}/samples", responses={
+    200: {"description": "Sample regeneration queued"},
+    **{k: v for k, v in error_responses.items() if k in [400, 401, 404, 429]}
+})
+def regenerate_avatar_samples(avatar_db_id: int, request: AvatarActivateRequest) -> ResponseModel:
+    """Re-roll the preview set. Capped by AVATAR_SAMPLE_REGEN_MAX on top of the credit ledger —
+    samples cost inference money but no training credit, so without a cap this is unbounded."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    avatar = _require_own_avatar(user_id, avatar_db_id)
+    if avatar["status"] != "succeeded" or not avatar["model_ref"]:
+        raise HTTPException(status_code=400, detail="Only a succeeded training can render samples")
+
+    from cqc_lem.utilities.env_constants import AVATAR_SAMPLE_REGEN_MAX
+    if avatar["sample_regen_count"] >= AVATAR_SAMPLE_REGEN_MAX:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Sample regeneration limit reached ({AVATAR_SAMPLE_REGEN_MAX}). "
+                   f"Train a new avatar with better photos instead.")
+
+    from cqc_lem.app.run_avatar import render_avatar_samples_task
+    render_avatar_samples_task.apply_async(
+        kwargs={"avatar_id": avatar_db_id, "user_id": user_id, "count_regeneration": True})
+    return ResponseModel(status_code=200, detail="Sample regeneration queued")
+
+
+@router.put("/avatar/training/{avatar_db_id}/attributes", responses={
+    200: {"description": "Attributes saved"},
+    **{k: v for k, v in error_responses.items() if k in [401, 404, 500]}
+})
+def update_avatar_attributes_endpoint(avatar_db_id: int,
+                                      request: AvatarAttributesRequest) -> ResponseModel:
+    """Store the user's SELF-DECLARED likeness attributes (issue #744, decision 3A).
+
+    Nothing here inspects the user's photos — an unrecognized value is stored as NULL, which
+    renders an empty subject clause rather than a guess.
+    """
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    _require_own_avatar(user_id, avatar_db_id)
+    if not update_avatar_attributes(user_id, avatar_db_id,
+                                    request.gender_presentation, request.age_band):
+        raise HTTPException(status_code=500, detail="Could not save avatar attributes")
+    return ResponseModel(status_code=200, detail=get_avatar_training(user_id, avatar_db_id))
+
+
+@router.post("/avatar/training/{avatar_db_id}/approve", responses={
+    200: {"description": "Avatar approved"},
+    **{k: v for k, v in error_responses.items() if k in [400, 401, 404, 500]}
+})
+def approve_avatar(avatar_db_id: int, request: AvatarActivateRequest) -> ResponseModel:
+    """Approve an avatar for use. Requires samples to exist — approving an avatar nobody has
+    seen is the exact blind activation this gate was added to remove."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    avatar = _require_own_avatar(user_id, avatar_db_id)
+    if avatar["status"] != "succeeded":
+        raise HTTPException(status_code=400, detail="Only succeeded trainings can be approved")
+    if not avatar["sample_paths"]:
+        raise HTTPException(status_code=400,
+                            detail="Render preview samples before approving this avatar")
+
+    if not set_avatar_approval(user_id, avatar_db_id, AVATAR_APPROVAL_APPROVED):
+        raise HTTPException(status_code=500, detail="Could not approve avatar")
+    return ResponseModel(status_code=200, detail="Avatar approved")
+
+
+@router.post("/avatar/training/{avatar_db_id}/reject", responses={
+    200: {"description": "Avatar rejected"},
+    **{k: v for k, v in error_responses.items() if k in [401, 404, 500]}
+})
+def reject_avatar(avatar_db_id: int, request: AvatarActivateRequest) -> ResponseModel:
+    """Reject an avatar. Also deactivates it — leaving a rejected likeness active would keep
+    publishing exactly the media the user just rejected."""
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    _require_own_avatar(user_id, avatar_db_id)
+    if not set_avatar_approval(user_id, avatar_db_id, AVATAR_APPROVAL_REJECTED):
+        raise HTTPException(status_code=500, detail="Could not reject avatar")
+    return ResponseModel(status_code=200, detail="Avatar rejected")
+
+
+@router.get("/avatar/preferences", responses={
+    200: {"description": "Avatar guardrail preferences returned"},
+    **{k: v for k, v in error_responses.items() if k in [401]}
+})
+def get_avatar_preferences_endpoint(session_token: str) -> ResponseModel:
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    return ResponseModel(status_code=200, detail=get_avatar_preferences(user_id))
+
+
+@router.put("/avatar/preferences", responses={
+    200: {"description": "Avatar guardrail preferences updated"},
+    **{k: v for k, v in error_responses.items() if k in [400, 401, 500]}
+})
+def update_avatar_preferences_endpoint(request: AvatarPreferencesRequest) -> ResponseModel:
+    user_id = get_session_user_id(request.session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+
+    prefs = request.model_dump(exclude={"session_token"}, exclude_none=True)
+    if not prefs:
+        raise HTTPException(status_code=400, detail="No preferences supplied")
+    if not update_avatar_preferences(user_id, prefs):
+        raise HTTPException(status_code=500, detail="Could not update avatar preferences")
+    return ResponseModel(status_code=200, detail=get_avatar_preferences(user_id))
 
 
 @router.put("/avatar/training/{avatar_db_id}/activate", responses={
@@ -4108,12 +4307,12 @@ def activate_avatar(avatar_db_id: int, request: AvatarActivateRequest) -> Respon
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
 
-    trainings = get_avatar_trainings(user_id)
-    match = next((t for t in trainings if t["id"] == avatar_db_id), None)
-    if not match:
-        raise HTTPException(status_code=404, detail="Training not found")
+    match = _require_own_avatar(user_id, avatar_db_id)
     if match["status"] != "succeeded":
         raise HTTPException(status_code=400, detail="Only succeeded trainings can be activated")
+    if match["approval_status"] != AVATAR_APPROVAL_APPROVED:
+        raise HTTPException(status_code=400,
+                            detail="Review the preview samples and approve this avatar first")
 
     if set_active_avatar(user_id, avatar_db_id):
         return ResponseModel(status_code=200, detail="Avatar activated")

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -81,7 +81,7 @@ from cqc_lem.utilities.db import (
     update_avatar_training_status, set_active_avatar,
     get_avatar_trainings, get_active_avatar, get_avatar_training,
     update_avatar_attributes, set_avatar_approval,
-    get_avatar_preferences, update_avatar_preferences,
+    get_avatar_preferences, update_avatar_preferences, update_post_use_avatar,
     AVATAR_APPROVAL_APPROVED, AVATAR_APPROVAL_REJECTED,
     get_user_timezone, update_user_timezone,
     get_user_geo, update_user_location, get_user_content_language,
@@ -1745,6 +1745,10 @@ def update_post(post_id: int, post: PostRequest) -> ResponseModel:
         reason = (post.rejection_reason or "").strip() or None
         if reason:
             update_db_post_rejection_reason(post_id, reason)
+        # Only on an explicit value: omitting the field means "leave my choice alone", not
+        # "clear it" (issue #744 — use_avatar is three-valued).
+        if post.use_avatar is not None:
+            update_post_use_avatar(post_id, post.use_avatar)
         return ResponseModel(status_code=200, detail="Post updated successful")
     else:
         raise HTTPException(status_code=405, detail="Post could not be updated")

--- a/src/cqc_lem/app/__init__.py
+++ b/src/cqc_lem/app/__init__.py
@@ -1,4 +1,5 @@
 from . import run_automation
 from . import run_scheduler
 from . import run_content_plan
+from . import run_avatar
 from . import aws_test_celery_task

--- a/src/cqc_lem/app/generate_variants.py
+++ b/src/cqc_lem/app/generate_variants.py
@@ -146,10 +146,17 @@ def _generate_one_variant(idx: int, combo: dict, source_text: str, profile, user
     }
 
     # 1. Image prompt + image
-    image_prompt = get_flux_image_prompt_from_ai(source_text, profile=profile, ratio=img_ratio)
+    # The declared subject clause has to reach the prompt author, not just the Replicate call —
+    # otherwise the LLM invents a person for the LoRA to contradict (issue #744).
+    from cqc_lem.utilities.avatar.guardrails import AVATAR_SURFACE_POST_IMAGE, resolve_avatar_for
+    avatar = resolve_avatar_for(user_id, surface=AVATAR_SURFACE_POST_IMAGE, post_id=post_id)
+    image_prompt = get_flux_image_prompt_from_ai(source_text, profile=profile, ratio=img_ratio,
+                                                 avatar=avatar)
     result["image_prompt"] = image_prompt
     if user_id:
-        image_path = generate_post_image(image_prompt, user_id, ratio=img_ratio, image_model=image_model)
+        image_path = generate_post_image(image_prompt, user_id, ratio=img_ratio,
+                                         image_model=image_model,
+                                         surface=AVATAR_SURFACE_POST_IMAGE, post_id=post_id)
     else:
         image_path = generate_flux1_image_from_prompt(image_prompt, ratio=img_ratio, image_model=image_model)
 

--- a/src/cqc_lem/app/run_avatar.py
+++ b/src/cqc_lem/app/run_avatar.py
@@ -8,20 +8,28 @@ from typing import Optional
 
 from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.utilities.db import (AVATAR_APPROVAL_PENDING, get_avatar_training,
-                                  set_avatar_approval, update_avatar_samples)
+                                  release_avatar_sample_render, set_avatar_approval,
+                                  update_avatar_samples)
 from cqc_lem.utilities.logger import log_info, log_warning
 
 
 @shared_task.task
 def render_avatar_samples_task(avatar_id: int, user_id: int,
                                count_regeneration: bool = False) -> Optional[int]:
-    """Render + persist the sample set for one avatar. Returns how many samples were stored."""
+    """Render + persist the sample set for one avatar. Returns how many samples were stored.
+
+    The caller reserved this render before queueing (``claim_avatar_sample_render``); every path
+    that ships no images hands the reservation back, so a failed render never costs the user one
+    of their re-rolls and never wedges the automatic first render.
+    """
     avatar = get_avatar_training(user_id, avatar_id)
     if not avatar:
+        release_avatar_sample_render(user_id, avatar_id, regeneration=count_regeneration)
         log_warning("Avatar sample render skipped: avatar not found", user_id=user_id,
                     task_name="render_avatar_samples")
         return None
     if avatar.get("status") != "succeeded" or not avatar.get("model_ref"):
+        release_avatar_sample_render(user_id, avatar_id, regeneration=count_regeneration)
         log_warning("Avatar sample render skipped: training has not succeeded", user_id=user_id,
                     task_name="render_avatar_samples")
         return None
@@ -29,11 +37,12 @@ def render_avatar_samples_task(avatar_id: int, user_id: int,
     from cqc_lem.utilities.avatar.samples import render_avatar_samples
     samples = render_avatar_samples(avatar)
     if not samples:
+        release_avatar_sample_render(user_id, avatar_id, regeneration=count_regeneration)
         log_warning("Avatar sample render produced nothing — leaving the avatar un-approvable",
                     user_id=user_id, task_name="render_avatar_samples")
         return 0
 
-    update_avatar_samples(avatar_id, samples, count_regeneration=count_regeneration)
+    update_avatar_samples(avatar_id, samples)
     # New samples invalidate an earlier verdict: the user approved the images they SAW, and these
     # are different images. Re-approving is one click; publishing an unreviewed likeness is not.
     if avatar.get("approval_status") != AVATAR_APPROVAL_PENDING:

--- a/src/cqc_lem/app/run_avatar.py
+++ b/src/cqc_lem/app/run_avatar.py
@@ -1,0 +1,43 @@
+"""Avatar background work — sample rendering for the preview/approval gate (issue #744).
+
+Rendering three LoRA images takes tens of seconds, far too long for the HTTP request that
+notices the training finished, so it runs here. The task is idempotent: it re-renders the fixed
+scene set and overwrites the stored paths.
+"""
+from typing import Optional
+
+from cqc_lem.app.my_celery import app as shared_task
+from cqc_lem.utilities.db import (AVATAR_APPROVAL_PENDING, get_avatar_training,
+                                  set_avatar_approval, update_avatar_samples)
+from cqc_lem.utilities.logger import log_info, log_warning
+
+
+@shared_task.task
+def render_avatar_samples_task(avatar_id: int, user_id: int,
+                               count_regeneration: bool = False) -> Optional[int]:
+    """Render + persist the sample set for one avatar. Returns how many samples were stored."""
+    avatar = get_avatar_training(user_id, avatar_id)
+    if not avatar:
+        log_warning("Avatar sample render skipped: avatar not found", user_id=user_id,
+                    task_name="render_avatar_samples")
+        return None
+    if avatar.get("status") != "succeeded" or not avatar.get("model_ref"):
+        log_warning("Avatar sample render skipped: training has not succeeded", user_id=user_id,
+                    task_name="render_avatar_samples")
+        return None
+
+    from cqc_lem.utilities.avatar.samples import render_avatar_samples
+    samples = render_avatar_samples(avatar)
+    if not samples:
+        log_warning("Avatar sample render produced nothing — leaving the avatar un-approvable",
+                    user_id=user_id, task_name="render_avatar_samples")
+        return 0
+
+    update_avatar_samples(avatar_id, samples, count_regeneration=count_regeneration)
+    # New samples invalidate an earlier verdict: the user approved the images they SAW, and these
+    # are different images. Re-approving is one click; publishing an unreviewed likeness is not.
+    if avatar.get("approval_status") != AVATAR_APPROVAL_PENDING:
+        set_avatar_approval(user_id, avatar_id, AVATAR_APPROVAL_PENDING)
+    log_info(f"Stored {len(samples)} avatar samples", user_id=user_id,
+             task_name="render_avatar_samples")
+    return len(samples)

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -631,6 +631,20 @@ def _post_missing_required_asset(post_id: int, post_type, video_url) -> bool:
     return False
 
 
+def _post_used_avatar_media(post_id: Optional[int]) -> bool:
+    """Did any generated media for this post come out of the avatar LoRA? (issue #744)
+
+    Fail-soft: an unreadable flag must not cost the post its content, and the video branch still
+    triggers the disclosure independently.
+    """
+    try:
+        from cqc_lem.utilities.db import post_used_avatar_media
+        return post_used_avatar_media(post_id)
+    except Exception as e:
+        log_warning("Could not read the avatar-media flag for disclosure", exc=e, post_id=post_id)
+        return False
+
+
 def _apply_ai_disclosure(content: str) -> str:
     """Append the AI-visuals disclosure line to a caption (idempotent)."""
     if not AI_DISCLOSURE_ENABLED or not content:
@@ -666,8 +680,9 @@ def _generate_video_src(user_id: int, text_content: str, profile, post_id: int =
     from cqc_lem.utilities.ai.video_models import is_premium, supports_audio
     from cqc_lem.utilities.geocoding import DEFAULT_CONTENT_LANGUAGE
     from cqc_lem.utilities.ai.ai_helper import generate_post_image
+    from cqc_lem.utilities.avatar.guardrails import AVATAR_SURFACE_VIDEO, resolve_avatar_for
     from cqc_lem.utilities.db import (get_post_video_quality, get_video_credit_balance,
-                                      deduct_video_credits, refund_video_credits, get_active_avatar,
+                                      deduct_video_credits, refund_video_credits,
                                       get_default_video_quality, get_user_content_language)
 
     quality = get_post_video_quality(post_id) if post_id else "standard"
@@ -688,18 +703,23 @@ def _generate_video_src(user_id: int, text_content: str, profile, post_id: int =
             myprint(f"Premium video requested but no credits for user {user_id} — using standard")
 
     try:
-        image_prompt = get_flux_image_prompt_from_ai(text_content, profile=profile, ratio=DEFAULT_IMAGE_RATIO)
+        # The avatar is resolved BEFORE the image prompt is authored: its declared subject clause
+        # is what stops the prompt LLM inventing a person of a different gender for the LoRA to
+        # then contradict (issue #744). None here means the guardrails said no.
+        avatar = resolve_avatar_for(user_id, surface=AVATAR_SURFACE_VIDEO, post_id=post_id)
+        has_avatar = avatar is not None
+        image_prompt = get_flux_image_prompt_from_ai(text_content, profile=profile,
+                                                    ratio=DEFAULT_IMAGE_RATIO, avatar=avatar)
         # Audio-capable (premium/Veo) renders need the user's language in the prompt — Veo has no
         # language parameter and invents a voiceover otherwise (issue #548). Silent models skip
         # the lookup entirely.
         language = get_user_content_language(user_id) if supports_audio(model) else DEFAULT_CONTENT_LANGUAGE
         motion = get_runway_ml_video_prompt_from_ai(text_content, image_prompt, model=model,
                                                     language=language)[:512]
-        avatar = get_active_avatar(user_id) if user_id else None
-        has_avatar = bool(avatar and avatar.get("status") == "succeeded" and avatar.get("model_ref"))
         if is_premium(model):
             if has_avatar:
-                image_path = generate_post_image(image_prompt, user_id, ratio="9:16")
+                image_path = generate_post_image(image_prompt, user_id, ratio="9:16",
+                                                 surface=AVATAR_SURFACE_VIDEO, post_id=post_id)
                 src = create_runway_video(image_path, motion, model=model, ratio="9:16", audio=audio,
                                           user_id=user_id, post_id=post_id)
             else:
@@ -714,7 +734,8 @@ def _generate_video_src(user_id: int, text_content: str, profile, post_id: int =
             # (avatar likeness regardless of tier; premium only adds the higher-quality Veo motion +
             # credit spend). generate_post_image falls back to base Flux.1 when there is no avatar.
             if has_avatar:
-                image_path = generate_post_image(image_prompt, user_id, ratio=DEFAULT_IMAGE_RATIO)
+                image_path = generate_post_image(image_prompt, user_id, ratio=DEFAULT_IMAGE_RATIO,
+                                                 surface=AVATAR_SURFACE_VIDEO, post_id=post_id)
             else:
                 image_path = generate_flux1_image_from_prompt(image_prompt, ratio=DEFAULT_IMAGE_RATIO)
             src = create_runway_video(image_path, motion, model=model, ratio=DEFAULT_VIDEO_RATIO,
@@ -2331,8 +2352,11 @@ def _create_content_for_planned_post(post: dict, prefs: dict) -> bool:
             # Update the database with the video url
             update_db_post_video_url(post_id, api_video_url)
 
-        # Disclose AI-generated visuals in the caption (caption-line fallback for C2PA)
-        if ai_video:
+        # Disclose AI-generated visuals in the caption (caption-line fallback for C2PA).
+        # A synthetic likeness of a real person needs the disclosure at least as much as a
+        # stock-motion video does, so ANY media that came out of the avatar LoRA counts —
+        # carousel slides and post images included, not just video (issue #744).
+        if ai_video or _post_used_avatar_media(post_id):
             content = _apply_ai_disclosure(content)
 
         # Dwell-proxy score (issue #391 — C2) for EVERY post type: the text post, the carousel

--- a/src/cqc_lem/ui/src/pages/Avatars.tsx
+++ b/src/cqc_lem/ui/src/pages/Avatars.tsx
@@ -19,6 +19,28 @@ const STATUS_COLORS: Record<string, string> = {
   canceled:   'bg-gray-100 text-gray-600',
 }
 
+const APPROVAL_COLORS: Record<string, string> = {
+  pending:  'bg-amber-100 text-amber-800',
+  approved: 'bg-green-100 text-green-800',
+  rejected: 'bg-red-100 text-red-800',
+}
+
+// Mirrors utilities/avatar/attributes.py — the user picks; nothing is ever inferred from photos.
+const GENDER_OPTIONS = [
+  { value: '',                  label: 'Not specified' },
+  { value: 'man',               label: 'Man' },
+  { value: 'woman',             label: 'Woman' },
+  { value: 'non-binary',        label: 'Non-binary' },
+  { value: 'prefer-not-to-say', label: 'Prefer not to say' },
+]
+const AGE_OPTIONS = ['', '20s', '30s', '40s', '50s', '60s', '70+']
+
+const GUARDRAILS = [
+  { key: 'avatar_use_post_image', label: 'Post images',    hint: 'Standalone images generated for a post' },
+  { key: 'avatar_use_carousel',   label: 'Carousel slides', hint: 'Slide artwork on personal-story carousels' },
+  { key: 'avatar_use_video',      label: 'Video frames',    hint: 'The source frame every generated video is built from' },
+] as const
+
 type Training = {
   id: number
   training_id: string
@@ -26,7 +48,33 @@ type Training = {
   trigger_word: string
   status: string
   is_active: boolean
+  gender_presentation: string | null
+  age_band: string | null
+  attributes_confirmed_at: string | null
+  approval_status: string
+  approved_at: string | null
+  sample_paths: { label: string; path: string }[]
+  samples_generated_at: string | null
+  sample_regen_count: number
   created_at: string | null
+}
+
+type Samples = {
+  avatar_id: number
+  approval_status: string
+  samples: { label: string; url: string }[]
+  samples_generated_at: string | null
+  sample_regen_count: number
+  sample_regen_remaining: number
+  gender_presentation: string | null
+  age_band: string | null
+}
+
+type AvatarPreferences = {
+  avatar_disabled: boolean
+  avatar_use_post_image: boolean
+  avatar_use_carousel: boolean
+  avatar_use_video: boolean
 }
 
 export default function Avatars() {
@@ -57,9 +105,30 @@ export default function Avatars() {
     },
     enabled: !!sessionToken,
     refetchInterval: (query) =>
-      (query.state.data ?? []).some((t: Training) => ['starting', 'processing'].includes(t.status))
+      (query.state.data ?? []).some((t: Training) =>
+        ['starting', 'processing'].includes(t.status) ||
+        // Samples render in the background after training succeeds — keep polling until they land,
+        // or the gallery stays empty until the user reloads the page.
+        (t.status === 'succeeded' && (t.sample_paths?.length ?? 0) === 0))
         ? 20_000
         : false,
+  })
+
+  // --- Guardrails ---
+  const { data: prefs } = useQuery({
+    queryKey: ['avatar-preferences', sessionToken],
+    queryFn: async () => {
+      const r = await api.get('/avatar/preferences', { params: { session_token: sessionToken } })
+      return r.data.detail as AvatarPreferences
+    },
+    enabled: !!sessionToken,
+  })
+
+  const prefsMutation = useMutation({
+    mutationFn: async (patch: Partial<AvatarPreferences>) => {
+      await api.put('/avatar/preferences', { session_token: sessionToken, ...patch })
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['avatar-preferences'] }),
   })
 
   // --- Buy credits ---
@@ -139,6 +208,7 @@ export default function Avatars() {
   const balance = creditData?.balance ?? 0
   const hasCredits = balance > 0
   const inProgress = trainings.some((t) => ['starting', 'processing'].includes(t.status))
+  const avatarOff = !!prefs?.avatar_disabled
 
   const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
     setFiles(e.target.files)
@@ -149,7 +219,7 @@ export default function Avatars() {
     <div className="max-w-4xl mx-auto px-4 py-8 space-y-10">
       <h1 className="text-2xl font-bold text-gray-900">My Avatars</h1>
 
-      {/* Credit balance */}
+      {/* Credit balance + usage */}
       <div
         className="flex items-center justify-between bg-blue-50 border border-blue-200 rounded-xl px-6 py-4"
         data-testid="avatar-credit-balance"
@@ -157,16 +227,66 @@ export default function Avatars() {
         <div>
           <p className="text-sm text-blue-700 font-medium">Avatar Training Credits</p>
           <p className="text-3xl font-bold text-blue-900">{balance}</p>
+          <p className="text-xs text-blue-700 mt-1" data-testid="avatar-usage-summary">
+            {trainings.length} training{trainings.length === 1 ? '' : 's'} used ·{' '}
+            {trainings.filter((t) => t.approval_status === 'approved').length} approved
+          </p>
         </div>
-        {hasCredits && (
+        {hasCredits ? (
           <span className="text-sm text-blue-700">
             {balance === 1 ? '1 training available' : `${balance} trainings available`}
           </span>
-        )}
-        {!hasCredits && (
+        ) : (
           <span className="text-sm text-gray-500">Purchase credits below to train your first avatar</span>
         )}
       </div>
+
+      {/* Guardrails */}
+      <section data-testid="avatar-guardrails">
+        <h2 className="text-lg font-semibold text-gray-800 mb-1">Where your avatar may be used</h2>
+        <p className="text-sm text-gray-500 mb-4">
+          Off by default. Your avatar is only used on the content types you switch on here, and only
+          after you have approved its preview images. Posts you compose can override this per post.
+        </p>
+
+        <div className="border border-gray-200 rounded-xl divide-y divide-gray-100 bg-white">
+          <label className="flex items-start gap-3 px-5 py-4 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={avatarOff}
+              onChange={(e) => prefsMutation.mutate({ avatar_disabled: e.target.checked })}
+              data-testid="avatar-disabled-toggle"
+              className="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500"
+            />
+            <span>
+              <span className="block text-sm font-semibold text-gray-800">Don’t use my avatar</span>
+              <span className="block text-xs text-gray-500">
+                Forces every image and video back to stock or generic AI artwork. Overrides everything below.
+              </span>
+            </span>
+          </label>
+
+          {GUARDRAILS.map((g) => (
+            <label
+              key={g.key}
+              className={`flex items-start gap-3 px-5 py-4 ${avatarOff ? 'opacity-50' : 'cursor-pointer'}`}
+            >
+              <input
+                type="checkbox"
+                disabled={avatarOff}
+                checked={!!prefs?.[g.key]}
+                onChange={(e) => prefsMutation.mutate({ [g.key]: e.target.checked })}
+                data-testid={`avatar-toggle-${g.key}`}
+                className="mt-0.5 h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+              />
+              <span>
+                <span className="block text-sm font-medium text-gray-800">{g.label}</span>
+                <span className="block text-xs text-gray-500">{g.hint}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </section>
 
       {/* Pricing */}
       <section>
@@ -284,58 +404,244 @@ export default function Avatars() {
             {trainings.map((t) => (
               <div
                 key={t.id}
-                className={`border rounded-xl px-5 py-4 flex items-center justify-between gap-4 ${
+                data-testid={`avatar-card-${t.id}`}
+                className={`border rounded-xl px-5 py-4 space-y-4 ${
                   t.is_active ? 'border-green-400 bg-green-50' : 'border-gray-200 bg-white'
                 }`}
               >
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <span className="font-mono text-sm font-semibold text-gray-800">
-                      {t.trigger_word}
-                    </span>
-                    {t.is_active && (
-                      <span className="text-xs bg-green-600 text-white px-2 py-0.5 rounded-full font-medium">
-                        Active
+                <div className="flex items-center justify-between gap-4">
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="font-mono text-sm font-semibold text-gray-800">
+                        {t.trigger_word}
                       </span>
-                    )}
-                    <span
-                      className={`text-xs px-2 py-0.5 rounded-full font-medium ${
-                        STATUS_COLORS[t.status] ?? 'bg-gray-100 text-gray-600'
-                      }`}
-                    >
-                      {t.status}
-                    </span>
+                      {t.is_active && (
+                        <span className="text-xs bg-green-600 text-white px-2 py-0.5 rounded-full font-medium">
+                          Active
+                        </span>
+                      )}
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                          STATUS_COLORS[t.status] ?? 'bg-gray-100 text-gray-600'
+                        }`}
+                      >
+                        {t.status}
+                      </span>
+                      {t.status === 'succeeded' && (
+                        <span
+                          data-testid={`avatar-approval-${t.id}`}
+                          className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                            APPROVAL_COLORS[t.approval_status] ?? 'bg-gray-100 text-gray-600'
+                          }`}
+                        >
+                          {t.approval_status}
+                        </span>
+                      )}
+                    </div>
+                    <p className="text-xs text-gray-400 mt-0.5">
+                      Started {t.created_at ? new Date(t.created_at).toLocaleDateString() : '—'}
+                    </p>
                   </div>
-                  <p className="text-xs text-gray-400 mt-0.5">
-                    Started {t.created_at ? new Date(t.created_at).toLocaleDateString() : '—'}
-                  </p>
+
+                  <div className="flex gap-2 flex-shrink-0">
+                    {['starting', 'processing'].includes(t.status) && (
+                      <button
+                        onClick={() => syncMutation.mutate(t.id)}
+                        disabled={syncMutation.isPending}
+                        className="text-xs px-3 py-1.5 rounded-lg border border-blue-300 text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+                      >
+                        Refresh
+                      </button>
+                    )}
+                    {t.status === 'succeeded' && !t.is_active && (
+                      <button
+                        onClick={() => activateMutation.mutate(t.id)}
+                        disabled={activateMutation.isPending || t.approval_status !== 'approved'}
+                        title={t.approval_status !== 'approved'
+                          ? 'Approve the preview images first'
+                          : undefined}
+                        className="text-xs px-3 py-1.5 rounded-lg bg-green-600 hover:bg-green-700 text-white font-medium disabled:opacity-50"
+                      >
+                        Set Active
+                      </button>
+                    )}
+                  </div>
                 </div>
 
-                <div className="flex gap-2 flex-shrink-0">
-                  {['starting', 'processing'].includes(t.status) && (
-                    <button
-                      onClick={() => syncMutation.mutate(t.id)}
-                      disabled={syncMutation.isPending}
-                      className="text-xs px-3 py-1.5 rounded-lg border border-blue-300 text-blue-700 hover:bg-blue-50 disabled:opacity-50"
-                    >
-                      Refresh
-                    </button>
-                  )}
-                  {t.status === 'succeeded' && !t.is_active && (
-                    <button
-                      onClick={() => activateMutation.mutate(t.id)}
-                      disabled={activateMutation.isPending}
-                      className="text-xs px-3 py-1.5 rounded-lg bg-green-600 hover:bg-green-700 text-white font-medium disabled:opacity-50"
-                    >
-                      Set Active
-                    </button>
-                  )}
-                </div>
+                {t.status === 'succeeded' && (
+                  <AvatarReviewPanel training={t} sessionToken={sessionToken ?? ''} />
+                )}
               </div>
             ))}
           </div>
         </section>
       )}
+    </div>
+  )
+}
+
+function AvatarReviewPanel({ training, sessionToken }: { training: Training; sessionToken: string }) {
+  const queryClient = useQueryClient()
+  const [gender, setGender] = useState(training.gender_presentation ?? '')
+  const [ageBand, setAgeBand] = useState(training.age_band ?? '')
+  const [actionError, setActionError] = useState('')
+
+  const { data: samples } = useQuery({
+    queryKey: ['avatar-samples', training.id, training.samples_generated_at],
+    queryFn: async () => {
+      const r = await api.get(`/avatar/training/${training.id}/samples`, {
+        params: { session_token: sessionToken },
+      })
+      return r.data.detail as Samples
+    },
+    enabled: !!sessionToken,
+  })
+
+  const invalidate = () => {
+    queryClient.invalidateQueries({ queryKey: ['avatar-trainings'] })
+    queryClient.invalidateQueries({ queryKey: ['avatar-samples', training.id] })
+  }
+
+  const onError = (err: unknown) => {
+    setActionError(
+      (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+      ?? 'Something went wrong. Please try again.')
+  }
+
+  const attributesMutation = useMutation({
+    mutationFn: async () => {
+      await api.put(`/avatar/training/${training.id}/attributes`, {
+        session_token: sessionToken,
+        gender_presentation: gender || null,
+        age_band: ageBand || null,
+      })
+    },
+    onSuccess: () => { setActionError(''); invalidate() },
+    onError,
+  })
+
+  const verdictMutation = useMutation({
+    mutationFn: async (verdict: 'approve' | 'reject') => {
+      await api.post(`/avatar/training/${training.id}/${verdict}`, { session_token: sessionToken })
+    },
+    onSuccess: () => { setActionError(''); invalidate() },
+    onError,
+  })
+
+  const regenerateMutation = useMutation({
+    mutationFn: async () => {
+      await api.post(`/avatar/training/${training.id}/samples`, { session_token: sessionToken })
+    },
+    onSuccess: () => { setActionError(''); invalidate() },
+    onError,
+  })
+
+  const gallery = samples?.samples ?? []
+  const regenRemaining = samples?.sample_regen_remaining ?? 0
+
+  return (
+    <div className="border-t border-gray-100 pt-4 space-y-4">
+      {/* Declared attributes */}
+      <div>
+        <p className="text-sm font-medium text-gray-800">How should you be described?</p>
+        <p className="text-xs text-gray-500 mb-2">
+          Written into every image prompt so the generator can’t invent someone else. You choose
+          these — we never guess them from your photos, and leaving them blank adds nothing.
+        </p>
+        <div className="flex flex-wrap items-end gap-3">
+          <label className="text-xs text-gray-600">
+            <span className="block mb-1">Gender presentation</span>
+            <select
+              value={gender}
+              onChange={(e) => setGender(e.target.value)}
+              data-testid={`avatar-gender-${training.id}`}
+              className="rounded-lg border border-gray-300 px-2 py-1.5 text-sm"
+            >
+              {GENDER_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>{o.label}</option>
+              ))}
+            </select>
+          </label>
+          <label className="text-xs text-gray-600">
+            <span className="block mb-1">Age band</span>
+            <select
+              value={ageBand}
+              onChange={(e) => setAgeBand(e.target.value)}
+              data-testid={`avatar-age-${training.id}`}
+              className="rounded-lg border border-gray-300 px-2 py-1.5 text-sm"
+            >
+              {AGE_OPTIONS.map((o) => (
+                <option key={o} value={o}>{o || 'Not specified'}</option>
+              ))}
+            </select>
+          </label>
+          <button
+            onClick={() => attributesMutation.mutate()}
+            disabled={attributesMutation.isPending}
+            className="text-xs px-3 py-1.5 rounded-lg border border-blue-300 text-blue-700 hover:bg-blue-50 disabled:opacity-50"
+          >
+            {attributesMutation.isPending ? 'Saving…' : 'Save'}
+          </button>
+        </div>
+      </div>
+
+      {/* Preview gallery */}
+      <div>
+        <p className="text-sm font-medium text-gray-800 mb-2">Preview</p>
+        {gallery.length === 0 ? (
+          <p className="text-xs text-gray-500" data-testid={`avatar-samples-empty-${training.id}`}>
+            Preview images are still rendering. This takes a minute or two after training finishes.
+          </p>
+        ) : (
+          <div className="grid grid-cols-3 gap-3" data-testid={`avatar-samples-${training.id}`}>
+            {gallery.map((s) => (
+              <figure key={s.label} className="space-y-1">
+                <img
+                  src={s.url}
+                  alt={`${training.trigger_word} ${s.label} sample`}
+                  loading="lazy"
+                  className="w-full aspect-square object-cover rounded-lg border border-gray-200"
+                />
+                <figcaption className="text-[11px] text-gray-500 text-center">
+                  {s.label.replace('_', ' ')}
+                </figcaption>
+              </figure>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {actionError && <p className="text-sm text-red-600">{actionError}</p>}
+
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          onClick={() => verdictMutation.mutate('approve')}
+          disabled={verdictMutation.isPending || gallery.length === 0}
+          data-testid={`avatar-approve-${training.id}`}
+          className="text-xs px-3 py-1.5 rounded-lg bg-green-600 hover:bg-green-700 text-white font-medium disabled:opacity-50"
+        >
+          Approve — this looks like me
+        </button>
+        <button
+          onClick={() => verdictMutation.mutate('reject')}
+          disabled={verdictMutation.isPending}
+          data-testid={`avatar-reject-${training.id}`}
+          className="text-xs px-3 py-1.5 rounded-lg border border-red-300 text-red-700 hover:bg-red-50 disabled:opacity-50"
+        >
+          Reject
+        </button>
+        <button
+          onClick={() => regenerateMutation.mutate()}
+          disabled={regenerateMutation.isPending || regenRemaining <= 0}
+          data-testid={`avatar-regenerate-${training.id}`}
+          className="text-xs px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+        >
+          Regenerate previews
+        </button>
+        <span className="text-[11px] text-gray-500">
+          {regenRemaining} regeneration{regenRemaining === 1 ? '' : 's'} left
+        </span>
+      </div>
     </div>
   )
 }

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
@@ -54,7 +54,9 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
   const [scheduledAt, setScheduledAt] = useState('')
   const [submitting, setSubmitting] = useState(false)
   const [result, setResult] = useState<{ ok: boolean; msg: string } | null>(null)
-  const [useAvatar, setUseAvatar] = useState(false)
+  // null = the author never touched the toggle, so their account opt-ins decide (issue #744).
+  // Sending a plain `false` here would be an explicit per-post opt-out, which outranks those.
+  const [useAvatar, setUseAvatar] = useState<boolean | null>(null)
   const [videoQuality, setVideoQuality] = useState<'standard' | 'premium' | 'premium_top'>('standard')
 
   // Carousel AI generation state
@@ -72,6 +74,20 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
     queryFn: async () => {
       const r = await api.get('/avatar/credits', { params: { session_token: sessionToken } })
       return r.data.detail as { balance: number; active_avatar: { trigger_word: string; status: string } | null }
+    },
+    enabled: !!sessionToken,
+  })
+
+  const { data: avatarPrefs } = useQuery({
+    queryKey: ['avatar-preferences', sessionToken],
+    queryFn: async () => {
+      const r = await api.get('/avatar/preferences', { params: { session_token: sessionToken } })
+      return r.data.detail as {
+        avatar_disabled: boolean
+        avatar_use_post_image: boolean
+        avatar_use_carousel: boolean
+        avatar_use_video: boolean
+      }
     },
     enabled: !!sessionToken,
   })
@@ -110,6 +126,16 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
   const templates = templatesData ?? []
   const activeAvatar = avatarData?.active_avatar
   const hasActiveAvatar = activeAvatar?.status === 'succeeded'
+  // The Avatars-page opt-in for THIS surface is what the toggle shows until the author moves it,
+  // so an untouched toggle mirrors the account setting instead of contradicting it.
+  const avatarSurfaceDefault = !avatarPrefs || avatarPrefs.avatar_disabled
+    ? false
+    : postType === 'VIDEO'
+      ? avatarPrefs.avatar_use_video
+      : postType === 'CAROUSEL'
+        ? avatarPrefs.avatar_use_carousel
+        : avatarPrefs.avatar_use_post_image
+  const avatarChecked = (useAvatar ?? avatarSurfaceDefault) && hasActiveAvatar
   const MAX_CHARS = 3000
 
   const bestTimeSuggestion = scheduledAt ? getBestPostingTime(new Date(scheduledAt)) : null
@@ -184,7 +210,11 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
         scheduled_datetime: scheduledUtc,
         email,
         status,
-        use_avatar: postType !== 'TEXT' && useAvatar && hasActiveAvatar,
+      }
+      // Only send a compose-time choice when there IS one: the field is three-valued and an
+      // explicit false outranks the per-content-type opt-ins on the Avatars page (issue #744).
+      if (postType !== 'TEXT' && useAvatar !== null) {
+        payload.use_avatar = useAvatar && hasActiveAvatar
       }
       if (postType === 'VIDEO') {
         payload.video_url = videoUrl || null
@@ -505,6 +535,7 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
                 {hasActiveAvatar ? (
                   <p className="text-xs text-gray-500">
                     Uses <span className="font-mono font-semibold">{activeAvatar?.trigger_word}</span> in the image prompt
+                    {useAvatar === null && ' · following your Avatars settings'}
                   </p>
                 ) : (
                   <p className="text-xs text-gray-400">
@@ -519,7 +550,7 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
                 <input
                   type="checkbox"
                   className="sr-only peer"
-                  checked={useAvatar && hasActiveAvatar}
+                  checked={avatarChecked}
                   disabled={!hasActiveAvatar}
                   onChange={(e) => setUseAvatar(e.target.checked)}
                 />

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -29,6 +29,7 @@ from cqc_lem.utilities.ai.content_alignment import (
 from cqc_lem.utilities.ai import slop_lint as _slop
 from cqc_lem.utilities.ai.content_research import research_topic
 from cqc_lem.utilities.ai.tools import search_recent_news
+from cqc_lem.utilities.avatar.guardrails import AVATAR_SURFACE_POST_IMAGE
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text, PLAIN_PUNCTUATION_DIRECTIVE, \
     linkedin_post_format_directive, enforce_post_readability
@@ -2758,20 +2759,26 @@ def generate_dall_e_image_from_prompt(prompt: str, size: str = "1024x1024") -> l
     return response.data or []
 
 
-def _profile_visual_context(profile: "LinkedInProfile | None") -> str:
-    """Short brand/context line for image prompts, built from a user's profile."""
-    if profile is None:
-        return ""
+def _profile_visual_context(profile: "LinkedInProfile | None",
+                            subject_directive: str = "") -> str:
+    """Short brand/context line for image prompts, built from a user's profile.
+
+    ``subject_directive`` carries the user's SELF-DECLARED likeness (issue #744). It leads the
+    context because the system prompt below actively pushes the model to invent a person: with
+    nothing stating who that person is, the LLM picked a gender freely and FLUX then rendered
+    that invented gender over the avatar LoRA's identity.
+    """
     bits = []
-    if profile.job_title:
-        bits.append(f"a {profile.job_title}")
-    if profile.industry:
-        bits.append(f"in the {profile.industry} industry")
-    if profile.company_name:
-        bits.append(f"at {profile.company_name}")
+    if profile is not None:
+        if profile.job_title:
+            bits.append(f"a {profile.job_title}")
+        if profile.industry:
+            bits.append(f"in the {profile.industry} industry")
+        if profile.company_name:
+            bits.append(f"at {profile.company_name}")
     if not bits:
-        return ""
-    return (
+        return subject_directive
+    return subject_directive + (
         "The author is " + " ".join(bits) + ". "
         "Make the visual feel on-brand, credible, and relevant to this professional "
         "context.\n\n"
@@ -2779,14 +2786,15 @@ def _profile_visual_context(profile: "LinkedInProfile | None") -> str:
 
 
 def get_flux_image_prompt_from_ai(post_content: str, *, profile: "LinkedInProfile | None" = None,
-                                  ratio: str = "1:1") -> str:
+                                  ratio: str = "1:1", avatar: "dict | None" = None) -> str:
     """Generate a Flux.1 image prompt from the post content and optional profile.
 
     The prompt is engineered for a single attention-drawing focal subject and brand
     alignment — the image must stop a prospect mid-scroll, not be abstract art.
     """
+    from cqc_lem.utilities.avatar.attributes import subject_directive
 
-    profile_context = _profile_visual_context(profile)
+    profile_context = _profile_visual_context(profile, subject_directive(avatar))
 
     prompt = f"""{profile_context}Here is a LinkedIn post: <post_content>{post_content}</post_content>.
 
@@ -2938,19 +2946,54 @@ def generate_flux1_image_from_prompt(prompt: str, *, ratio: str = DEFAULT_IMAGE_
 
 
 def generate_post_image(prompt: str, user_id: int, *, ratio: str = DEFAULT_IMAGE_RATIO,
-                        image_model: str = DEFAULT_IMAGE_MODEL) -> str:
-    """Generate a LinkedIn post image, using the user's active avatar LoRA when available.
+                        image_model: str = DEFAULT_IMAGE_MODEL,
+                        surface: str = AVATAR_SURFACE_POST_IMAGE,
+                        post_id: "int | None" = None,
+                        depicts_person: bool = True) -> str:
+    """Generate a LinkedIn post image, using the user's avatar LoRA when the guardrails allow it.
 
-    Falls back to the base Flux.1 model when the user has no active succeeded avatar.
+    Falls back to the base Flux.1 model whenever ``resolve_avatar_for`` declines (issue #744):
+    no approved avatar, the surface's opt-in is off, this post opted out, or the user switched
+    their avatar off entirely.
+
+    ``depicts_person=False`` is the object/concept case — a slide about a dashboard is not a
+    scene the author appears in, and prepending the trigger word there asked the LoRA to insert
+    the user's face into a scene never written to contain a person.
     """
-    from cqc_lem.utilities.db import get_active_avatar
+    from cqc_lem.utilities.avatar.attributes import apply_subject_clause
+    from cqc_lem.utilities.avatar.guardrails import resolve_avatar_for
     from cqc_lem.utilities.avatar.replicate_avatar import generate_image_with_avatar
 
-    avatar = get_active_avatar(user_id)
-    if avatar and avatar.get("status") == "succeeded" and avatar.get("model_ref"):
-        full_prompt = f"{avatar['trigger_word']}, {prompt}"
-        return generate_image_with_avatar(full_prompt, avatar["model_ref"])
+    avatar = resolve_avatar_for(user_id, surface=surface, post_id=post_id) if depicts_person else None
+    if avatar:
+        full_prompt = apply_subject_clause(prompt, avatar)
+        path, used_avatar = generate_image_with_avatar(
+            full_prompt, avatar["model_ref"], ratio=ratio, fallback_prompt=prompt)
+        if used_avatar:
+            _record_avatar_media(path, post_id, user_id)
+        return path
     return generate_flux1_image_from_prompt(prompt, ratio=ratio, image_model=image_model)
+
+
+def _record_avatar_media(image_path: str, post_id: "int | None", user_id: "int | None") -> None:
+    """Provenance for a synthetic likeness of a real person: C2PA on the file, a durable flag on
+    the post so the caption disclosure covers avatar images and not just video (issue #744).
+
+    Best-effort on both halves — provenance must never break media generation.
+    """
+    try:
+        from cqc_lem.utilities.c2pa_helper import add_ai_content_credentials
+        add_ai_content_credentials(image_path)
+    except Exception as e:
+        log_warning("C2PA signing skipped for avatar image", exc=e, user_id=user_id,
+                    post_id=post_id)
+    if post_id:
+        try:
+            from cqc_lem.utilities.db import mark_post_avatar_media
+            mark_post_avatar_media(post_id)
+        except Exception as e:
+            log_warning("Could not flag avatar media on post", exc=e, user_id=user_id,
+                        post_id=post_id)
 
 
 MAX_MOTION_PROMPT_CHARS = 512

--- a/src/cqc_lem/utilities/avatar/attributes.py
+++ b/src/cqc_lem/utilities/avatar/attributes.py
@@ -1,0 +1,95 @@
+"""User-declared likeness attributes → the ONE canonical subject phrase for image prompts.
+
+Issue #744 (Phase 2 of #548), decision 3A. FLUX has no attribute API: an avatar LoRA is
+conditioned entirely through prompt text, and at `steps=1000` it does not reliably override an
+explicit contradicting gender noun the prompt-authoring LLM invented. So the user's own declared
+attributes have to be written into the prompt.
+
+Two rules hold this module together:
+  * NOTHING here infers anything. There is no classifier, no heuristic on the user's photos, no
+    guess from a name. Every value comes from what the user picked in the SPA.
+  * An undeclared attribute renders NOTHING. `subject_clause()` returns "" so the prompt is left
+    exactly as it was — an empty clause is the honest answer, an invented one is the bug.
+"""
+from typing import Optional
+
+# value -> (noun phrase, possessive pronoun). "prefer-not-to-say" is a real, storable choice that
+# deliberately contributes no noun — declining to declare must not be read as "unset, ask again".
+GENDER_PRESENTATIONS: dict[str, tuple[str, str]] = {
+    "man": ("a man", "his"),
+    "woman": ("a woman", "her"),
+    "non-binary": ("a non-binary person", "their"),
+    "prefer-not-to-say": ("", ""),
+}
+
+AGE_BANDS: tuple[str, ...] = ("20s", "30s", "40s", "50s", "60s", "70+")
+
+_NEUTRAL_NOUN = "a person"
+_NEUTRAL_POSSESSIVE = "their"
+
+
+def normalize_gender_presentation(value: Optional[str]) -> Optional[str]:
+    """Canonical gender-presentation key, or None when unset/unrecognized."""
+    key = (value or "").strip().lower().replace("_", "-")
+    return key if key in GENDER_PRESENTATIONS else None
+
+
+def normalize_age_band(value: Optional[str]) -> Optional[str]:
+    """Canonical age band, or None when unset/unrecognized."""
+    band = (value or "").strip().lower()
+    return band if band in AGE_BANDS else None
+
+
+def _age_phrase(age_band: str, possessive: str) -> str:
+    # "70+" is a band, not a decade — spelling it "in his 70+" reads as a typo to the model.
+    if age_band == "70+":
+        return f"in {possessive} 70s or older"
+    return f"in {possessive} {age_band}"
+
+
+def subject_clause(avatar: Optional[dict]) -> str:
+    """One canonical subject phrase from stored, user-declared values — "" when unset.
+
+    e.g. ``"a man in his 40s"``, ``"a woman"``, ``"a person in their 30s"``. The neutral noun is
+    used when only the age band was declared: stating an age is not a claim about gender.
+    """
+    if not avatar:
+        return ""
+    gender = normalize_gender_presentation(avatar.get("gender_presentation"))
+    age_band = normalize_age_band(avatar.get("age_band"))
+
+    noun, possessive = GENDER_PRESENTATIONS.get(gender or "", ("", ""))
+    if not noun:
+        if not age_band:
+            return ""
+        noun, possessive = _NEUTRAL_NOUN, _NEUTRAL_POSSESSIVE
+
+    if not age_band:
+        return noun
+    return f"{noun} {_age_phrase(age_band, possessive)}"
+
+
+def subject_directive(avatar: Optional[dict]) -> str:
+    """The instruction handed to the prompt-authoring LLM so it never invents a conflicting subject.
+
+    Empty when no attributes are declared — the prompt then reads exactly as it did before #744.
+    """
+    clause = subject_clause(avatar)
+    if not clause:
+        return ""
+    return (
+        f"When a person appears in the image it IS the author — {clause}. "
+        "Describe that person consistently and never contradict this description.\n\n"
+    )
+
+
+def apply_subject_clause(prompt: str, avatar: Optional[dict]) -> str:
+    """Prefix the trigger word + declared subject clause onto a Replicate prompt.
+
+    The trigger word has to lead (it is what activates the LoRA) and the clause sits immediately
+    beside it, before the free-form scene description that may otherwise describe someone else.
+    """
+    trigger = ((avatar or {}).get("trigger_word") or "").strip()
+    clause = subject_clause(avatar)
+    parts = [p for p in (trigger, clause, (prompt or "").strip()) if p]
+    return ", ".join(parts)

--- a/src/cqc_lem/utilities/avatar/guardrails.py
+++ b/src/cqc_lem/utilities/avatar/guardrails.py
@@ -1,0 +1,101 @@
+"""The ONE gate on whether a user's avatar may be used for a piece of generated media.
+
+Issue #744 (Phase 2 of #548), decision 4A. Before this, "does the user have an active avatar"
+was the entire policy: a never-previewed LoRA rendered a synthetic likeness of a real person
+straight onto a published post, and the compose-time `use_avatar` toggle was accepted by the API
+and dropped. Every caller that used to ask ``get_active_avatar()`` asks ``resolve_avatar_for()``
+instead, and `None` always means "render with base Flux / Pexels".
+
+Precedence, strongest first:
+  1. ``users.avatar_disabled`` — the explicit "don't use my avatar" switch. Nothing overrides it.
+  2. ``posts.use_avatar`` — the compose-time choice for THIS post (NULL = no choice made).
+  3. ``users.avatar_use_<surface>`` — the per-content-type opt-in, default OFF.
+  4. The avatar itself must be succeeded, have a model_ref, AND be ``approved``.
+
+It fails CLOSED: any error resolving the policy returns None. A missed avatar render is a
+slightly less personal image; a wrong one is a synthetic likeness of a real person, published.
+"""
+from typing import Optional
+
+from cqc_lem.utilities.logger import log_debug, log_warning
+
+AVATAR_SURFACE_POST_IMAGE = "post_image"
+AVATAR_SURFACE_CAROUSEL = "carousel"
+AVATAR_SURFACE_VIDEO = "video"
+
+AVATAR_SURFACES: tuple[str, ...] = (
+    AVATAR_SURFACE_POST_IMAGE,
+    AVATAR_SURFACE_CAROUSEL,
+    AVATAR_SURFACE_VIDEO,
+)
+
+_PREF_BY_SURFACE: dict[str, str] = {
+    AVATAR_SURFACE_POST_IMAGE: "avatar_use_post_image",
+    AVATAR_SURFACE_CAROUSEL: "avatar_use_carousel",
+    AVATAR_SURFACE_VIDEO: "avatar_use_video",
+}
+
+DEFAULT_AVATAR_PREFERENCES: dict[str, bool] = {
+    "avatar_disabled": False,
+    "avatar_use_post_image": False,
+    "avatar_use_carousel": False,
+    "avatar_use_video": False,
+}
+
+
+def avatar_is_usable(avatar: Optional[dict]) -> bool:
+    """A trained avatar the user has actually previewed and approved."""
+    if not avatar:
+        return False
+    return (
+        avatar.get("status") == "succeeded"
+        and bool(avatar.get("model_ref"))
+        and avatar.get("approval_status") == "approved"
+    )
+
+
+def resolve_avatar_for(user_id: Optional[int], *, surface: str,
+                       post_id: Optional[int] = None) -> Optional[dict]:
+    """The user's avatar when policy allows it on this surface, else None (use base Flux/Pexels)."""
+    if not user_id:
+        return None
+    if surface not in _PREF_BY_SURFACE:
+        raise ValueError(f"Unknown avatar surface: {surface}")
+
+    try:
+        from cqc_lem.utilities.db import (get_active_avatar, get_avatar_preferences,
+                                          get_post_use_avatar)
+
+        prefs = get_avatar_preferences(user_id)
+        if prefs.get("avatar_disabled"):
+            log_debug("Avatar use declined: user opted out entirely", user_id=user_id,
+                      action_type="avatar_guardrail")
+            return None
+
+        post_choice = get_post_use_avatar(post_id) if post_id else None
+        if post_choice is False:
+            log_debug("Avatar use declined: post opted out at compose time", user_id=user_id,
+                      post_id=post_id, action_type="avatar_guardrail")
+            return None
+        if post_choice is not True and not prefs.get(_PREF_BY_SURFACE[surface]):
+            log_debug(f"Avatar use declined: {surface} opt-in is off", user_id=user_id,
+                      action_type="avatar_guardrail")
+            return None
+
+        avatar = get_active_avatar(user_id)
+        if not avatar_is_usable(avatar):
+            log_debug("Avatar use declined: no approved active avatar", user_id=user_id,
+                      action_type="avatar_guardrail")
+            return None
+        return avatar
+    except Exception as e:
+        # Fail closed — see the module docstring.
+        log_warning("Avatar guardrail check failed, falling back to the base model", exc=e,
+                    user_id=user_id, action_type="avatar_guardrail")
+        return None
+
+
+def avatar_allowed_for(user_id: Optional[int], *, surface: str,
+                       post_id: Optional[int] = None) -> bool:
+    """Boolean form of :func:`resolve_avatar_for` for callers that only branch on it."""
+    return resolve_avatar_for(user_id, surface=surface, post_id=post_id) is not None

--- a/src/cqc_lem/utilities/avatar/replicate_avatar.py
+++ b/src/cqc_lem/utilities/avatar/replicate_avatar.py
@@ -128,15 +128,26 @@ def poll_training_status(training_id: str) -> tuple[str, Optional[str]]:
         return "processing", None
 
 
-def generate_image_with_avatar(prompt: str, model_ref: str) -> str:
-    """Run inference on a trained avatar LoRA model. Returns a local file path.
+def generate_image_with_avatar(prompt: str, model_ref: str, *,
+                               ratio: str = "1:1",
+                               fallback_prompt: Optional[str] = None) -> tuple[str, bool]:
+    """Run inference on a trained avatar LoRA model. Returns ``(local_file_path, used_avatar)``.
 
-    Delegates to the existing get_flux_image_via_replicate utility so all
-    file-saving logic stays in one place.
+    ``ratio`` is threaded through to Replicate's ``aspect_ratio`` — it used to be dropped here, so
+    the 9:16 source frame for premium avatar video was rendered square and then cropped by the
+    video model (issue #744).
+
+    ``used_avatar`` is False when inference raised and the base Flux fallback produced the image.
+    The caller must not claim avatar provenance (AI disclosure, C2PA) for an image the avatar
+    never touched, and the fallback runs on ``fallback_prompt`` so the LoRA trigger word — a
+    nonsense token to the base model — is not fed to it.
+
+    Delegates to the existing get_flux_image_via_replicate utility so all file-saving logic
+    stays in one place.
     """
     from cqc_lem.utilities.ai.ai_helper import get_flux_image_via_replicate
     try:
-        return get_flux_image_via_replicate(prompt, ref=model_ref)
+        return get_flux_image_via_replicate(prompt, ref=model_ref, aspect_ratio=ratio), True
     except Exception as exc:
         log_warning(
             "Avatar inference failed, falling back to base Flux model",
@@ -144,4 +155,4 @@ def generate_image_with_avatar(prompt: str, model_ref: str) -> str:
             action_type="avatar_inference_fallback",
         )
         from cqc_lem.utilities.ai.ai_helper import generate_flux1_image_from_prompt
-        return generate_flux1_image_from_prompt(prompt)
+        return generate_flux1_image_from_prompt(fallback_prompt or prompt, ratio=ratio), False

--- a/src/cqc_lem/utilities/avatar/samples.py
+++ b/src/cqc_lem/utilities/avatar/samples.py
@@ -1,0 +1,105 @@
+"""Sample renders that let a user SEE their avatar before it is published on their behalf.
+
+Issue #744 (Phase 2 of #548), decision 4A. Activation used to be reachable straight from
+``succeeded``, so the first time anyone saw their avatar was on a live post — which is how a
+male user's posts shipped with a female likeness and nobody could catch it first.
+
+Three fixed scenes are rendered through the LoRA (headshot, at-desk, speaking-to-camera) using
+the same subject clause production images use, so what the user approves is what they will get.
+"""
+import os
+import shutil
+from typing import Optional
+
+from cqc_lem import assets_dir
+from cqc_lem.utilities.logger import log_info, log_warning
+from cqc_lem.utilities.utils import create_folder_if_not_exists
+
+# (label, scene). No trigger word here — apply_subject_clause prepends it together with the
+# user's declared attributes, exactly as generate_post_image does for a real post.
+AVATAR_SAMPLE_SCENES: tuple[tuple[str, str], ...] = (
+    ("headshot",
+     "a professional headshot portrait, neutral studio background, soft natural lighting, "
+     "looking directly at the camera, photorealistic"),
+    ("at_desk",
+     "seated at a modern desk with a laptop in a bright office, working, candid editorial "
+     "photograph, shallow depth of field"),
+    ("speaking",
+     "speaking to the camera in a bright modern office, mid-sentence, confident and warm, "
+     "editorial photograph"),
+)
+
+SAMPLE_RATIO = "1:1"
+_SAMPLE_SUBDIR = os.path.join("images", "avatar_samples")
+
+
+def sample_relative_dir(avatar_id: int) -> str:
+    """Path of an avatar's sample folder RELATIVE to assets_dir (what /api/assets resolves)."""
+    return f"{_SAMPLE_SUBDIR}/{avatar_id}".replace(os.sep, "/")
+
+
+def render_avatar_samples(avatar: dict) -> list[dict]:
+    """Render the fixed sample set for ``avatar``. Returns ``[{"label", "path"}]``.
+
+    Never raises: one failed scene is skipped rather than losing the ones that worked, and an
+    avatar with no renderable samples simply stays un-approvable (which is the safe state).
+    """
+    from cqc_lem.utilities.avatar.attributes import apply_subject_clause
+    from cqc_lem.utilities.avatar.replicate_avatar import generate_image_with_avatar
+
+    avatar_id = avatar.get("id")
+    model_ref = avatar.get("model_ref")
+    if not avatar_id or not model_ref:
+        return []
+
+    rel_dir = sample_relative_dir(int(avatar_id))
+    out_dir = os.path.join(assets_dir, *rel_dir.split("/"))
+    create_folder_if_not_exists(out_dir)
+
+    rendered: list[dict] = []
+    for label, scene in AVATAR_SAMPLE_SCENES:
+        try:
+            prompt = apply_subject_clause(scene, avatar)
+            path, used_avatar = generate_image_with_avatar(prompt, model_ref, ratio=SAMPLE_RATIO)
+            if not used_avatar:
+                # A base-Flux fallback image is a picture of a stranger. Showing it as "your
+                # avatar" is worse than showing nothing — the whole point is a truthful preview.
+                log_warning("Avatar sample fell back to the base model — discarding it",
+                            action_type="avatar_sample")
+                continue
+            ext = os.path.splitext(path)[1] or ".webp"
+            dest = os.path.join(out_dir, f"{label}{ext}")
+            if os.path.abspath(path) != os.path.abspath(dest):
+                shutil.copy2(path, dest)
+            _sign_best_effort(dest)
+            rendered.append({"label": label, "path": f"{rel_dir}/{os.path.basename(dest)}"})
+        except Exception as e:
+            log_warning(f"Avatar sample '{label}' failed to render", exc=e,
+                        action_type="avatar_sample", api_provider="replicate")
+
+    log_info(f"Rendered {len(rendered)}/{len(AVATAR_SAMPLE_SCENES)} avatar samples",
+             action_type="avatar_sample")
+    return rendered
+
+
+def _sign_best_effort(file_path: str) -> None:
+    try:
+        from cqc_lem.utilities.c2pa_helper import add_ai_content_credentials
+        add_ai_content_credentials(file_path)
+    except Exception as e:
+        log_warning("C2PA signing skipped for avatar sample", exc=e, action_type="avatar_sample")
+
+
+def sample_asset_url(relative_path: str, api_url: Optional[str] = None) -> str:
+    from cqc_lem.utilities.env_constants import API_URL_FINAL
+    base = api_url or API_URL_FINAL
+    return f"{base}/api/assets?file_name={relative_path}"
+
+
+def sample_payload(avatar: dict) -> list[dict]:
+    """Serialize an avatar's stored samples for the SPA."""
+    return [
+        {"label": s.get("label"), "url": sample_asset_url(s.get("path", ""))}
+        for s in (avatar.get("sample_paths") or [])
+        if isinstance(s, dict) and s.get("path")
+    ]

--- a/src/cqc_lem/utilities/carousel_creator.py
+++ b/src/cqc_lem/utilities/carousel_creator.py
@@ -315,21 +315,43 @@ def _should_include_slide_image(post_id: Optional[int], slide_index: int) -> boo
     return _seeded_unit(post_id, slide_index, "include") < CAROUSEL_IMAGE_RATE
 
 
-def _user_has_active_avatar(user_id: Optional[int]) -> bool:
+def _user_has_active_avatar(user_id: Optional[int], post_id: Optional[int] = None) -> bool:
+    """Is the user's avatar usable for a CAROUSEL slide right now? (issue #744 guardrails)"""
     if user_id is None:
         return False
-    try:
-        from cqc_lem.utilities.db import get_active_avatar
-        avatar = get_active_avatar(user_id)
-        return bool(avatar and avatar.get("status") == "succeeded" and avatar.get("model_ref"))
-    except Exception:
-        return False
+    from cqc_lem.utilities.avatar.guardrails import AVATAR_SURFACE_CAROUSEL, avatar_allowed_for
+    return avatar_allowed_for(user_id, surface=AVATAR_SURFACE_CAROUSEL, post_id=post_id)
+
+
+# A derived slide query is usually a THING, not a scene the author stands in. Only queries that
+# read as a person get the avatar; everything else goes to base Flux / Pexels, because prepending
+# the LoRA trigger word to "quarterly dashboard metrics" asked it to insert the user's face into a
+# scene never written to contain a person (issue #744).
+_PERSON_QUERY_TERMS: set[str] = {
+    "person", "people", "team", "founder", "leader", "leadership", "colleague", "colleagues",
+    "client", "clients", "customer", "customers", "candidate", "mentor", "manager", "employee",
+    "employees", "speaker", "audience", "meeting", "interview", "conversation", "handshake",
+    "portrait", "headshot", "founder's", "coworker", "coworkers", "presenter", "presentation",
+    "teacher", "student", "engineer", "developer", "designer", "consultant", "recruiter",
+}
+
+
+def _query_depicts_person(query: Optional[str], content_type: Optional[str]) -> bool:
+    """True when the slide's scene plausibly contains the author.
+
+    ``personal_story`` slides are about the author by definition, so they qualify regardless of
+    the derived keywords — that is precisely the narrative the avatar exists to illustrate.
+    """
+    if (content_type or "") in CAROUSEL_AVATAR_RELEVANT_TYPES:
+        return True
+    words = {w.strip(".,:;!?\"'()[]").lower() for w in (query or "").split()}
+    return bool(words & _PERSON_QUERY_TERMS)
 
 
 def _should_generate_with_replicate(post_id: Optional[int], slide_index: int,
                                     user_id: Optional[int], content_type: Optional[str]) -> bool:
     """Replicate generation is gated: globally enabled, avatar-relevant content type,
-    a deterministic low-rate sample, AND the user actually has an active avatar."""
+    a deterministic low-rate sample, AND the user's guardrails allow the avatar here."""
     from cqc_lem.utilities.env_constants import CAROUSEL_REPLICATE_ENABLED, CAROUSEL_REPLICATE_RATE
     if not CAROUSEL_REPLICATE_ENABLED or user_id is None:
         return False
@@ -337,15 +359,19 @@ def _should_generate_with_replicate(post_id: Optional[int], slide_index: int,
         return False
     if _seeded_unit(post_id, slide_index, "source") >= CAROUSEL_REPLICATE_RATE:
         return False
-    return _user_has_active_avatar(user_id)
+    return _user_has_active_avatar(user_id, post_id)
 
 
-def _generate_avatar_slide_image(query: str, user_id: int) -> Optional[str]:
+def _generate_avatar_slide_image(query: str, user_id: int, post_id: Optional[int] = None,
+                                 content_type: Optional[str] = None) -> Optional[str]:
     from cqc_lem.utilities.logger import log_warning
     try:
         from cqc_lem.utilities.ai.ai_helper import generate_post_image
+        from cqc_lem.utilities.avatar.guardrails import AVATAR_SURFACE_CAROUSEL
         prompt = f"{query}, professional, clean minimal background, high quality, editorial"
-        path = generate_post_image(prompt, user_id)
+        path = generate_post_image(prompt, user_id, surface=AVATAR_SURFACE_CAROUSEL,
+                                   post_id=post_id,
+                                   depicts_person=_query_depicts_person(query, content_type))
         return path or None
     except Exception as e:
         log_warning("Carousel avatar image generation failed, falling back to Pexels",
@@ -378,7 +404,7 @@ def select_slide_image(
     query = derive_image_query(title, content, content_type)
 
     if _should_generate_with_replicate(post_id, slide_index, user_id, content_type):
-        generated = _generate_avatar_slide_image(query, user_id)
+        generated = _generate_avatar_slide_image(query, user_id, post_id, content_type)
         if generated:
             return generated
         # fall through to Pexels on generation failure

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -7927,36 +7927,100 @@ def set_avatar_approval(user_id: int, avatar_id: int, status: str) -> bool:
         connection.close()
 
 
-def update_avatar_samples(avatar_id: int, sample_paths: list[dict],
-                          count_regeneration: bool = False) -> bool:
+def update_avatar_samples(avatar_id: int, sample_paths: list[dict]) -> bool:
     """Persist rendered sample assets for an avatar (one JSON list per row).
 
-    ``count_regeneration`` increments the counter the regeneration cap is enforced against — the
-    first automatic render after training must not spend one of the user's regenerations.
+    The regeneration counter is NOT touched here — it is reserved before any inference is paid
+    for by :func:`claim_avatar_sample_render`.
     """
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
         payload = json.dumps(sample_paths or [])
-        if count_regeneration:
-            cursor.execute(
-                """UPDATE avatar_trainings
-                   SET sample_paths = %s, samples_generated_at = UTC_TIMESTAMP(),
-                       sample_regen_count = sample_regen_count + 1
-                   WHERE id = %s""",
-                (payload, avatar_id),
-            )
-        else:
-            cursor.execute(
-                """UPDATE avatar_trainings
-                   SET sample_paths = %s, samples_generated_at = UTC_TIMESTAMP()
-                   WHERE id = %s""",
-                (payload, avatar_id),
-            )
+        cursor.execute(
+            """UPDATE avatar_trainings
+               SET sample_paths = %s, samples_generated_at = UTC_TIMESTAMP()
+               WHERE id = %s""",
+            (payload, avatar_id),
+        )
         connection.commit()
         return cursor.rowcount > 0
     except mysql.connector.Error as err:
         myprint(f"Could not store avatar samples for avatar {avatar_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def claim_avatar_sample_render(user_id: int, avatar_id: int, *, regeneration: bool = False,
+                               max_regenerations: int = 0) -> bool:
+    """Reserve ONE sample render before any inference is paid for. True when the claim won.
+
+    Both callers used to read a counter, decide, and only write it once the render FINISHED —
+    minutes later. Two status syncs (a double-clicked Refresh) or two Regenerate clicks therefore
+    both passed the same reading and each queued a full three-image render, so the cap the
+    regeneration limit exists to be was not one. Reserving inside the UPDATE makes the decision
+    atomic: exactly one caller can win.
+    """
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        if regeneration:
+            cursor.execute(
+                """UPDATE avatar_trainings
+                   SET sample_regen_count = sample_regen_count + 1
+                   WHERE id = %s AND user_id = %s AND sample_regen_count < %s""",
+                (avatar_id, user_id, max_regenerations),
+            )
+        else:
+            # The FIRST render after a training succeeds: samples_generated_at is the claim marker,
+            # so a second poll arriving mid-render finds it set and stands down.
+            cursor.execute(
+                """UPDATE avatar_trainings
+                   SET samples_generated_at = UTC_TIMESTAMP()
+                   WHERE id = %s AND user_id = %s
+                     AND samples_generated_at IS NULL AND sample_paths IS NULL""",
+                (avatar_id, user_id),
+            )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not claim a sample render for avatar {avatar_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def release_avatar_sample_render(user_id: int, avatar_id: int, *,
+                                 regeneration: bool = False) -> bool:
+    """Give a reservation back when the render produced nothing.
+
+    A user must not lose a regeneration to a render that shipped no images, and a failed first
+    render must leave the automatic path able to try again.
+    """
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        if regeneration:
+            cursor.execute(
+                """UPDATE avatar_trainings
+                   SET sample_regen_count = GREATEST(sample_regen_count - 1, 0)
+                   WHERE id = %s AND user_id = %s""",
+                (avatar_id, user_id),
+            )
+        else:
+            cursor.execute(
+                """UPDATE avatar_trainings
+                   SET samples_generated_at = NULL
+                   WHERE id = %s AND user_id = %s AND sample_paths IS NULL""",
+                (avatar_id, user_id),
+            )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not release the sample-render claim for avatar {avatar_id} | Error: {err}")
         return False
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -744,7 +744,8 @@ def get_user_id(email: str):
 
 def insert_post(email: str, content: str, scheduled_time: datetime, post_type: PostType,
                 video_url: Optional[str] = None, carousel_slides: Optional[list[str]] = None,
-                video_quality: str = "standard", status: PostStatus = PostStatus.PENDING) -> bool:
+                video_quality: str = "standard", status: PostStatus = PostStatus.PENDING,
+                use_avatar: Optional[bool] = None) -> bool:
     user_id = get_user_id(email)
 
     success = False
@@ -761,11 +762,14 @@ def insert_post(email: str, content: str, scheduled_time: datetime, post_type: P
 
         slides_json = json.dumps(carousel_slides) if carousel_slides else None
 
+        # use_avatar is deliberately three-valued: NULL = the user expressed no preference for this
+        # post, so the per-user opt-ins decide (issue #744). 0/1 is an explicit compose-time choice.
         cursor.execute("""
-            INSERT INTO posts (content, scheduled_time, post_type, user_id, video_url, carousel_slides, video_quality, status)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO posts (content, scheduled_time, post_type, user_id, video_url, carousel_slides, video_quality, status, use_avatar)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
         """, (content, scheduled_time, post_type.value, user_id, video_url, slides_json,
-              video_quality or "standard", status.value))
+              video_quality or "standard", status.value,
+              None if use_avatar is None else int(bool(use_avatar))))
 
         connection.commit()
         success = cursor.rowcount == 1
@@ -7651,6 +7655,13 @@ def get_unposted_posts_missing_assets(within_days: int = 14) -> list:
 # Avatar training records
 # ---------------------------------------------------------------------------
 
+# avatar_trainings.approval_status — the preview/approval gate (issue #744). A freshly trained
+# avatar is 'pending' until the user has seen its sample renders and said yes.
+AVATAR_APPROVAL_PENDING = "pending"
+AVATAR_APPROVAL_APPROVED = "approved"
+AVATAR_APPROVAL_REJECTED = "rejected"
+
+
 def insert_avatar_training(user_id: int, training_id: str, trigger_word: str) -> Optional[int]:
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
@@ -7718,11 +7729,18 @@ def set_active_avatar(user_id: int, avatar_id: int) -> bool:
         # Validate the target avatar BEFORE deactivating anything — a bad id must leave the
         # user's current active avatar untouched (never strand them with no active avatar).
         cursor.execute(
-            "SELECT id FROM avatar_trainings WHERE id = %s AND user_id = %s",
+            "SELECT id, approval_status FROM avatar_trainings WHERE id = %s AND user_id = %s",
             (avatar_id, user_id),
         )
-        if cursor.fetchone() is None:
+        row = cursor.fetchone()
+        if row is None:
             myprint(f"set_active_avatar: avatar {avatar_id} not found for user_id {user_id}")
+            return False
+        # The approval gate (issue #744): activation used to be reachable straight from
+        # 'succeeded', so the first time a user saw their avatar was on a published post.
+        if row.get("approval_status") != AVATAR_APPROVAL_APPROVED:
+            myprint(f"set_active_avatar: avatar {avatar_id} is not approved "
+                    f"(status={row.get('approval_status')}) for user_id {user_id}")
             return False
         cursor.execute(
             "UPDATE avatar_trainings SET is_active = 0 WHERE user_id = %s",
@@ -7742,35 +7760,78 @@ def set_active_avatar(user_id: int, avatar_id: int) -> bool:
         connection.close()
 
 
+_AVATAR_COLUMNS = """id, training_id, model_ref, trigger_word, status, is_active,
+                     gender_presentation, age_band, attributes_confirmed_at,
+                     approval_status, approved_at, sample_paths, samples_generated_at,
+                     sample_regen_count, created_at, updated_at"""
+
+
+def _avatar_row_to_dict(row: dict) -> dict:
+    """One shape for an avatar row everywhere — the guardrails read approval_status and the
+    subject clause reads the declared attributes, so neither may depend on which query ran."""
+    try:
+        samples = json.loads(row.get("sample_paths") or "[]")
+    except (TypeError, ValueError):
+        samples = []
+    return {
+        "id": row["id"],
+        "training_id": row["training_id"],
+        "model_ref": row["model_ref"],
+        "trigger_word": row["trigger_word"],
+        "status": row["status"],
+        "is_active": bool(row.get("is_active")),
+        "gender_presentation": row.get("gender_presentation"),
+        "age_band": row.get("age_band"),
+        "attributes_confirmed_at": (row["attributes_confirmed_at"].isoformat()
+                                    if row.get("attributes_confirmed_at") else None),
+        "approval_status": row.get("approval_status") or AVATAR_APPROVAL_PENDING,
+        "approved_at": row["approved_at"].isoformat() if row.get("approved_at") else None,
+        "sample_paths": samples if isinstance(samples, list) else [],
+        "samples_generated_at": (row["samples_generated_at"].isoformat()
+                                 if row.get("samples_generated_at") else None),
+        "sample_regen_count": int(row.get("sample_regen_count") or 0),
+        "created_at": row["created_at"].isoformat() if row.get("created_at") else None,
+        "updated_at": row["updated_at"].isoformat() if row.get("updated_at") else None,
+    }
+
+
 def get_avatar_trainings(user_id: int) -> list[dict]:
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            """SELECT id, training_id, model_ref, trigger_word, status, is_active,
-                      created_at, updated_at
-               FROM avatar_trainings
-               WHERE user_id = %s
-               ORDER BY created_at DESC""",
+            f"""SELECT {_AVATAR_COLUMNS}
+                FROM avatar_trainings
+                WHERE user_id = %s
+                ORDER BY created_at DESC""",
             (user_id,),
         )
-        rows = cursor.fetchall()
-        return [
-            {
-                "id": r["id"],
-                "training_id": r["training_id"],
-                "model_ref": r["model_ref"],
-                "trigger_word": r["trigger_word"],
-                "status": r["status"],
-                "is_active": bool(r["is_active"]),
-                "created_at": r["created_at"].isoformat() if r.get("created_at") else None,
-                "updated_at": r["updated_at"].isoformat() if r.get("updated_at") else None,
-            }
-            for r in rows
-        ]
+        return [_avatar_row_to_dict(r) for r in cursor.fetchall()]
     except mysql.connector.Error as err:
         myprint(f"Could not fetch avatar trainings for user_id {user_id} | Error: {err}")
         return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_avatar_training(user_id: int, avatar_id: int) -> Optional[dict]:
+    """One avatar row, scoped to its owner so an id from another account can never be read."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            f"""SELECT {_AVATAR_COLUMNS}
+                FROM avatar_trainings
+                WHERE id = %s AND user_id = %s
+                LIMIT 1""",
+            (avatar_id, user_id),
+        )
+        row = cursor.fetchone()
+        return _avatar_row_to_dict(row) if row else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not fetch avatar {avatar_id} for user_id {user_id} | Error: {err}")
+        return None
     finally:
         cursor.close()
         connection.close()
@@ -7781,25 +7842,236 @@ def get_active_avatar(user_id: int) -> Optional[dict]:
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            """SELECT id, training_id, model_ref, trigger_word, status
-               FROM avatar_trainings
-               WHERE user_id = %s AND is_active = 1
-               LIMIT 1""",
+            f"""SELECT {_AVATAR_COLUMNS}
+                FROM avatar_trainings
+                WHERE user_id = %s AND is_active = 1
+                LIMIT 1""",
             (user_id,),
         )
         row = cursor.fetchone()
-        if not row:
-            return None
-        return {
-            "id": row["id"],
-            "training_id": row["training_id"],
-            "model_ref": row["model_ref"],
-            "trigger_word": row["trigger_word"],
-            "status": row["status"],
-        }
+        return _avatar_row_to_dict(row) if row else None
     except mysql.connector.Error as err:
         myprint(f"Could not fetch active avatar for user_id {user_id} | Error: {err}")
         return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_avatar_attributes(user_id: int, avatar_id: int,
+                             gender_presentation: Optional[str],
+                             age_band: Optional[str]) -> bool:
+    """Persist the user's SELF-DECLARED likeness attributes (issue #744, decision 3A).
+
+    Values are normalized by ``utilities.avatar.attributes`` first; an unrecognized value is
+    stored as NULL, which renders an empty subject clause rather than a guess.
+    """
+    from cqc_lem.utilities.avatar.attributes import (normalize_age_band,
+                                                     normalize_gender_presentation)
+    gender = normalize_gender_presentation(gender_presentation)
+    band = normalize_age_band(age_band)
+
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            """UPDATE avatar_trainings
+               SET gender_presentation = %s, age_band = %s, attributes_confirmed_at = UTC_TIMESTAMP()
+               WHERE id = %s AND user_id = %s""",
+            (gender, band, avatar_id, user_id),
+        )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update avatar attributes for avatar {avatar_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def set_avatar_approval(user_id: int, avatar_id: int, status: str) -> bool:
+    """Record the user's verdict on their rendered samples.
+
+    A REJECTED avatar is also deactivated in the same statement — leaving a rejected likeness
+    active would keep publishing exactly the media the user just rejected.
+    """
+    if status not in (AVATAR_APPROVAL_PENDING, AVATAR_APPROVAL_APPROVED, AVATAR_APPROVAL_REJECTED):
+        myprint(f"set_avatar_approval: refusing unknown approval status {status!r}")
+        return False
+
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        if status == AVATAR_APPROVAL_APPROVED:
+            cursor.execute(
+                """UPDATE avatar_trainings
+                   SET approval_status = %s, approved_at = UTC_TIMESTAMP()
+                   WHERE id = %s AND user_id = %s""",
+                (status, avatar_id, user_id),
+            )
+        else:
+            cursor.execute(
+                """UPDATE avatar_trainings
+                   SET approval_status = %s, approved_at = NULL, is_active = 0
+                   WHERE id = %s AND user_id = %s""",
+                (status, avatar_id, user_id),
+            )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not set approval {status} on avatar {avatar_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_avatar_samples(avatar_id: int, sample_paths: list[dict],
+                          count_regeneration: bool = False) -> bool:
+    """Persist rendered sample assets for an avatar (one JSON list per row).
+
+    ``count_regeneration`` increments the counter the regeneration cap is enforced against — the
+    first automatic render after training must not spend one of the user's regenerations.
+    """
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        payload = json.dumps(sample_paths or [])
+        if count_regeneration:
+            cursor.execute(
+                """UPDATE avatar_trainings
+                   SET sample_paths = %s, samples_generated_at = UTC_TIMESTAMP(),
+                       sample_regen_count = sample_regen_count + 1
+                   WHERE id = %s""",
+                (payload, avatar_id),
+            )
+        else:
+            cursor.execute(
+                """UPDATE avatar_trainings
+                   SET sample_paths = %s, samples_generated_at = UTC_TIMESTAMP()
+                   WHERE id = %s""",
+                (payload, avatar_id),
+            )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not store avatar samples for avatar {avatar_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_avatar_preferences(user_id: int) -> dict:
+    """Per-user avatar guardrails (issue #744, decision 4A).
+
+    Every flag defaults OFF and an unreadable row returns the defaults, so a DB blip degrades to
+    "don't use the avatar" rather than to publishing a synthetic likeness.
+    """
+    from cqc_lem.utilities.avatar.guardrails import DEFAULT_AVATAR_PREFERENCES
+    prefs = dict(DEFAULT_AVATAR_PREFERENCES)
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            """SELECT avatar_disabled, avatar_use_post_image, avatar_use_carousel, avatar_use_video
+               FROM users WHERE id = %s""",
+            (user_id,),
+        )
+        row = cursor.fetchone()
+        if row:
+            prefs = {key: bool(row.get(key)) for key in prefs}
+        return prefs
+    except mysql.connector.Error as err:
+        myprint(f"Could not fetch avatar preferences for user_id {user_id} | Error: {err}")
+        return prefs
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def update_avatar_preferences(user_id: int, prefs: dict) -> bool:
+    """Update only the avatar guardrail flags the caller actually supplied."""
+    from cqc_lem.utilities.avatar.guardrails import DEFAULT_AVATAR_PREFERENCES
+    updates = {k: bool(v) for k, v in (prefs or {}).items()
+               if k in DEFAULT_AVATAR_PREFERENCES and v is not None}
+    if not updates:
+        return False
+
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        assignments = ", ".join(f"{key} = %s" for key in updates)
+        cursor.execute(
+            f"UPDATE users SET {assignments} WHERE id = %s",
+            (*[int(v) for v in updates.values()], user_id),
+        )
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not update avatar preferences for user_id {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_post_use_avatar(post_id: Optional[int]) -> Optional[bool]:
+    """The compose-time avatar choice for a post — None when the user made no choice."""
+    if not post_id:
+        return None
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT use_avatar FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+        if not row or row[0] is None:
+            return None
+        return bool(row[0])
+    except mysql.connector.Error as err:
+        myprint(f"Could not fetch use_avatar for post_id {post_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def mark_post_avatar_media(post_id: Optional[int]) -> bool:
+    """Record that generated media for this post came out of the avatar LoRA.
+
+    This is what lets the caption disclosure cover avatar IMAGES and not just video — the
+    generation step that knows an avatar was used is far away from the step that writes the
+    caption, so the fact has to be durable.
+    """
+    if not post_id:
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("UPDATE posts SET avatar_media = 1 WHERE id = %s", (post_id,))
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not mark avatar media on post_id {post_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def post_used_avatar_media(post_id: Optional[int]) -> bool:
+    if not post_id:
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT avatar_media FROM posts WHERE id = %s", (post_id,))
+        row = cursor.fetchone()
+        return bool(row and row[0])
+    except mysql.connector.Error as err:
+        myprint(f"Could not read avatar_media for post_id {post_id} | Error: {err}")
+        return False
     finally:
         cursor.close()
         connection.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -8037,6 +8037,26 @@ def get_post_use_avatar(post_id: Optional[int]) -> Optional[bool]:
         connection.close()
 
 
+def update_post_use_avatar(post_id: int, use_avatar: Optional[bool]) -> bool:
+    """Set the compose-time avatar choice on an existing post. None clears it back to
+    "follow my preferences" — the field is three-valued everywhere it is read."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            "UPDATE posts SET use_avatar = %s WHERE id = %s",
+            (None if use_avatar is None else int(bool(use_avatar)), post_id),
+        )
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not update use_avatar for post_id {post_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def mark_post_avatar_media(post_id: Optional[int]) -> bool:
     """Record that generated media for this post came out of the avatar LoRA.
 

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -81,6 +81,12 @@ CAROUSEL_IMAGE_RATE = float(get_constant_from_env('CAROUSEL_IMAGE_RATE', default
 # a local keyword-extraction heuristic is used (no API call).
 CAROUSEL_IMAGE_QUERY_LLM = isTrue(get_constant_from_env('CAROUSEL_IMAGE_QUERY_LLM', default_value='True'))
 
+# --- Avatar preview / approval gate (issue #744) ---
+# Sample renders a user must see BEFORE their avatar may be used on a published post, and how
+# many times they may re-roll them. The cap sits on top of the credit ledger: samples cost
+# inference money but no training credit, so without it "Regenerate" is an unbounded spend.
+AVATAR_SAMPLE_REGEN_MAX = int(get_constant_from_env('AVATAR_SAMPLE_REGEN_MAX', default_value='3'))
+
 # AI disclosure: append a short caption line to AI-visual posts. Guaranteed-visible
 # fallback for C2PA (which self-signed certs can't make LinkedIn trust yet).
 AI_DISCLOSURE_ENABLED = isTrue(get_constant_from_env('AI_DISCLOSURE_ENABLED', default_value='True'))

--- a/tests/integration/test_avatar_api.py
+++ b/tests/integration/test_avatar_api.py
@@ -177,29 +177,25 @@ class TestListAvatarTrainings:
 @pytest.mark.integration
 class TestActivateAvatar:
     def test_returns_400_for_non_succeeded_training(self):
-        trainings = [
-            {
-                "id": 1, "training_id": "train-1", "model_ref": None,
-                "trigger_word": "TOK", "status": "processing",
-                "is_active": False, "created_at": None, "updated_at": None,
-            }
-        ]
+        avatar = {
+            "id": 1, "training_id": "train-1", "model_ref": None,
+            "trigger_word": "TOK", "status": "processing", "approval_status": "pending",
+            "is_active": False, "created_at": None, "updated_at": None,
+        }
         with patch("cqc_lem.api.main.get_session_user_id", return_value=USER_ID), \
-             patch("cqc_lem.api.main.get_avatar_trainings", return_value=trainings):
+             patch("cqc_lem.api.main.get_avatar_training", return_value=avatar):
             r = _client().put("/api/avatar/training/1/activate", json={"session_token": SESSION})
 
         assert r.status_code == 400
 
-    def test_returns_200_for_succeeded_training(self):
-        trainings = [
-            {
-                "id": 2, "training_id": "train-2", "model_ref": "user/model:v1",
-                "trigger_word": "TOK", "status": "succeeded",
-                "is_active": False, "created_at": None, "updated_at": None,
-            }
-        ]
+    def test_returns_200_for_approved_succeeded_training(self):
+        avatar = {
+            "id": 2, "training_id": "train-2", "model_ref": "user/model:v1",
+            "trigger_word": "TOK", "status": "succeeded", "approval_status": "approved",
+            "is_active": False, "created_at": None, "updated_at": None,
+        }
         with patch("cqc_lem.api.main.get_session_user_id", return_value=USER_ID), \
-             patch("cqc_lem.api.main.get_avatar_trainings", return_value=trainings), \
+             patch("cqc_lem.api.main.get_avatar_training", return_value=avatar), \
              patch("cqc_lem.api.main.set_active_avatar", return_value=True):
             r = _client().put("/api/avatar/training/2/activate", json={"session_token": SESSION})
 

--- a/tests/integration/test_avatar_preview_api.py
+++ b/tests/integration/test_avatar_preview_api.py
@@ -1,0 +1,248 @@
+"""Integration tests for the avatar preview / approval / guardrail endpoints (issue #744)."""
+from unittest.mock import patch
+
+import pytest
+
+SESSION = "test-session-token"
+USER_ID = 42
+_M = "cqc_lem.api.main"
+
+_APPROVABLE = {
+    "id": 7, "training_id": "t7", "model_ref": "owner/lora:v1", "trigger_word": "TOK",
+    "status": "succeeded", "is_active": False,
+    "gender_presentation": "man", "age_band": "40s",
+    "attributes_confirmed_at": "2026-07-30T12:00:00",
+    "approval_status": "pending", "approved_at": None,
+    "sample_paths": [{"label": "headshot", "path": "images/avatar_samples/7/headshot.webp"}],
+    "samples_generated_at": "2026-07-30T11:00:00", "sample_regen_count": 1,
+    "created_at": None, "updated_at": None,
+}
+
+
+def _client():
+    from fastapi.testclient import TestClient
+    from cqc_lem.api.main import app
+    return TestClient(app)
+
+
+@pytest.mark.integration
+class TestSamplesEndpoint:
+    def test_returns_gallery_and_regeneration_budget(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
+             patch("cqc_lem.utilities.env_constants.AVATAR_SAMPLE_REGEN_MAX", 3):
+            r = _client().get("/api/avatar/training/7/samples",
+                              params={"session_token": SESSION})
+        assert r.status_code == 200
+        detail = r.json()["detail"]
+        assert detail["approval_status"] == "pending"
+        assert detail["samples"][0]["label"] == "headshot"
+        assert "images/avatar_samples/7/headshot.webp" in detail["samples"][0]["url"]
+        assert detail["sample_regen_remaining"] == 2
+        assert detail["gender_presentation"] == "man"
+
+    def test_401_without_a_session(self):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            r = _client().get("/api/avatar/training/7/samples", params={"session_token": "bad"})
+        assert r.status_code == 401
+
+    def test_404_for_another_users_avatar(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=None):
+            r = _client().get("/api/avatar/training/7/samples",
+                              params={"session_token": SESSION})
+        assert r.status_code == 404
+
+
+@pytest.mark.integration
+class TestRegenerateSamplesEndpoint:
+    def test_queues_a_counted_regeneration(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
+             patch("cqc_lem.utilities.env_constants.AVATAR_SAMPLE_REGEN_MAX", 3), \
+             patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async") as queued:
+            r = _client().post("/api/avatar/training/7/samples",
+                               json={"session_token": SESSION})
+        assert r.status_code == 200
+        assert queued.call_args.kwargs["kwargs"] == {
+            "avatar_id": 7, "user_id": USER_ID, "count_regeneration": True}
+
+    def test_cap_returns_429(self):
+        """The cap sits on top of the credit ledger — samples cost inference money but no credit."""
+        avatar = {**_APPROVABLE, "sample_regen_count": 3}
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=avatar), \
+             patch("cqc_lem.utilities.env_constants.AVATAR_SAMPLE_REGEN_MAX", 3), \
+             patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async") as queued:
+            r = _client().post("/api/avatar/training/7/samples",
+                               json={"session_token": SESSION})
+        assert r.status_code == 429
+        queued.assert_not_called()
+
+    def test_unfinished_training_returns_400(self):
+        avatar = {**_APPROVABLE, "status": "processing", "model_ref": None}
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=avatar):
+            r = _client().post("/api/avatar/training/7/samples",
+                               json={"session_token": SESSION})
+        assert r.status_code == 400
+
+
+@pytest.mark.integration
+class TestAttributesEndpoint:
+    def test_saves_declared_attributes(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
+             patch(f"{_M}.update_avatar_attributes", return_value=True) as upd:
+            r = _client().put("/api/avatar/training/7/attributes", json={
+                "session_token": SESSION, "gender_presentation": "man", "age_band": "40s"})
+        assert r.status_code == 200
+        upd.assert_called_once_with(USER_ID, 7, "man", "40s")
+
+    def test_nulls_clear_the_declaration(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
+             patch(f"{_M}.update_avatar_attributes", return_value=True) as upd:
+            r = _client().put("/api/avatar/training/7/attributes",
+                              json={"session_token": SESSION})
+        assert r.status_code == 200
+        upd.assert_called_once_with(USER_ID, 7, None, None)
+
+    def test_write_failure_returns_500(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
+             patch(f"{_M}.update_avatar_attributes", return_value=False):
+            r = _client().put("/api/avatar/training/7/attributes",
+                              json={"session_token": SESSION, "gender_presentation": "man"})
+        assert r.status_code == 500
+
+
+@pytest.mark.integration
+class TestApproveRejectEndpoints:
+    def test_approve_records_the_verdict(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
+             patch(f"{_M}.set_avatar_approval", return_value=True) as approve:
+            r = _client().post("/api/avatar/training/7/approve",
+                               json={"session_token": SESSION})
+        assert r.status_code == 200
+        approve.assert_called_once_with(USER_ID, 7, "approved")
+
+    def test_cannot_approve_an_avatar_with_no_rendered_samples(self):
+        """Approving what nobody has seen is the blind activation this gate removes."""
+        avatar = {**_APPROVABLE, "sample_paths": []}
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=avatar), \
+             patch(f"{_M}.set_avatar_approval") as approve:
+            r = _client().post("/api/avatar/training/7/approve",
+                               json={"session_token": SESSION})
+        assert r.status_code == 400
+        approve.assert_not_called()
+
+    def test_cannot_approve_an_unfinished_training(self):
+        avatar = {**_APPROVABLE, "status": "processing"}
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=avatar):
+            r = _client().post("/api/avatar/training/7/approve",
+                               json={"session_token": SESSION})
+        assert r.status_code == 400
+
+    def test_approve_write_failure_returns_500(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
+             patch(f"{_M}.set_avatar_approval", return_value=False):
+            r = _client().post("/api/avatar/training/7/approve",
+                               json={"session_token": SESSION})
+        assert r.status_code == 500
+
+    def test_reject_records_the_verdict(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
+             patch(f"{_M}.set_avatar_approval", return_value=True) as reject:
+            r = _client().post("/api/avatar/training/7/reject",
+                               json={"session_token": SESSION})
+        assert r.status_code == 200
+        reject.assert_called_once_with(USER_ID, 7, "rejected")
+
+    def test_reject_401_without_a_session(self):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            r = _client().post("/api/avatar/training/7/reject", json={"session_token": "bad"})
+        assert r.status_code == 401
+
+
+@pytest.mark.integration
+class TestGuardrailPreferencesEndpoints:
+    _PREFS = {"avatar_disabled": False, "avatar_use_post_image": False,
+              "avatar_use_carousel": False, "avatar_use_video": True}
+
+    def test_get_returns_every_flag(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_preferences", return_value=self._PREFS):
+            r = _client().get("/api/avatar/preferences", params={"session_token": SESSION})
+        assert r.status_code == 200 and r.json()["detail"] == self._PREFS
+
+    def test_put_patches_one_toggle(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.update_avatar_preferences", return_value=True) as upd, \
+             patch(f"{_M}.get_avatar_preferences", return_value=self._PREFS):
+            r = _client().put("/api/avatar/preferences",
+                              json={"session_token": SESSION, "avatar_use_video": True})
+        assert r.status_code == 200
+        upd.assert_called_once_with(USER_ID, {"avatar_use_video": True})
+
+    def test_put_with_nothing_to_change_is_400(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.update_avatar_preferences") as upd:
+            r = _client().put("/api/avatar/preferences", json={"session_token": SESSION})
+        assert r.status_code == 400
+        upd.assert_not_called()
+
+    def test_put_write_failure_returns_500(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.update_avatar_preferences", return_value=False):
+            r = _client().put("/api/avatar/preferences",
+                              json={"session_token": SESSION, "avatar_disabled": True})
+        assert r.status_code == 500
+
+    def test_401_without_a_session(self):
+        with patch(f"{_M}.get_session_user_id", return_value=None):
+            r = _client().get("/api/avatar/preferences", params={"session_token": "bad"})
+        assert r.status_code == 401
+
+
+@pytest.mark.integration
+class TestComposeHonoursUseAvatar:
+    def test_use_avatar_reaches_the_post_row(self):
+        """PostRequest.use_avatar was accepted by the API and dropped (issue #744 §2.4)."""
+        with patch(f"{_M}.get_user_id", return_value=USER_ID), \
+             patch(f"{_M}.insert_post", return_value=True) as insert:
+            r = _client().post("/api/schedule_post/", json={
+                "content": "body", "post_type": "text", "email": "a@b.c",
+                "scheduled_datetime": "2026-08-01T09:00:00", "use_avatar": False})
+        assert r.status_code == 200
+        assert insert.call_args.kwargs["use_avatar"] is False
+
+    def test_omitting_it_leaves_the_choice_to_the_user_preferences(self):
+        with patch(f"{_M}.get_user_id", return_value=USER_ID), \
+             patch(f"{_M}.insert_post", return_value=True) as insert:
+            _client().post("/api/schedule_post/", json={
+                "content": "body", "post_type": "text", "email": "a@b.c",
+                "scheduled_datetime": "2026-08-01T09:00:00"})
+        assert insert.call_args.kwargs["use_avatar"] is None
+
+    def test_editing_a_post_persists_an_explicit_choice(self):
+        with patch(f"{_M}.update_db_post", return_value=True), \
+             patch(f"{_M}.update_post_use_avatar") as upd:
+            r = _client().post("/api/update_post/?post_id=5", json={
+                "content": "body", "post_type": "text",
+                "scheduled_datetime": "2026-08-01T09:00:00", "use_avatar": True})
+        assert r.status_code == 200
+        upd.assert_called_once_with(5, True)
+
+    def test_editing_without_the_field_leaves_the_stored_choice_alone(self):
+        with patch(f"{_M}.update_db_post", return_value=True), \
+             patch(f"{_M}.update_post_use_avatar") as upd:
+            _client().post("/api/update_post/?post_id=5", json={
+                "content": "body", "post_type": "text",
+                "scheduled_datetime": "2026-08-01T09:00:00"})
+        upd.assert_not_called()

--- a/tests/integration/test_avatar_preview_api.py
+++ b/tests/integration/test_avatar_preview_api.py
@@ -60,32 +60,51 @@ class TestRegenerateSamplesEndpoint:
         with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
              patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
              patch("cqc_lem.utilities.env_constants.AVATAR_SAMPLE_REGEN_MAX", 3), \
+             patch(f"{_M}.claim_avatar_sample_render", return_value=True) as claim, \
              patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async") as queued:
             r = _client().post("/api/avatar/training/7/samples",
                                json={"session_token": SESSION})
         assert r.status_code == 200
         assert queued.call_args.kwargs["kwargs"] == {
             "avatar_id": 7, "user_id": USER_ID, "count_regeneration": True}
+        # Reserved BEFORE the render is queued — a second click has to lose the claim, not read
+        # a counter that only moves minutes later.
+        claim.assert_called_once_with(USER_ID, 7, regeneration=True, max_regenerations=3)
 
     def test_cap_returns_429(self):
         """The cap sits on top of the credit ledger — samples cost inference money but no credit."""
-        avatar = {**_APPROVABLE, "sample_regen_count": 3}
         with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
-             patch(f"{_M}.get_avatar_training", return_value=avatar), \
+             patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
              patch("cqc_lem.utilities.env_constants.AVATAR_SAMPLE_REGEN_MAX", 3), \
+             patch(f"{_M}.claim_avatar_sample_render", return_value=False), \
              patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async") as queued:
             r = _client().post("/api/avatar/training/7/samples",
                                json={"session_token": SESSION})
         assert r.status_code == 429
         queued.assert_not_called()
 
+    def test_a_broker_failure_hands_the_reservation_back(self):
+        with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
+             patch(f"{_M}.get_avatar_training", return_value=_APPROVABLE), \
+             patch("cqc_lem.utilities.env_constants.AVATAR_SAMPLE_REGEN_MAX", 3), \
+             patch(f"{_M}.claim_avatar_sample_render", return_value=True), \
+             patch(f"{_M}.release_avatar_sample_render") as released, \
+             patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async",
+                   side_effect=RuntimeError("broker down")):
+            r = _client().post("/api/avatar/training/7/samples",
+                               json={"session_token": SESSION})
+        assert r.status_code == 500
+        released.assert_called_once_with(USER_ID, 7, regeneration=True)
+
     def test_unfinished_training_returns_400(self):
         avatar = {**_APPROVABLE, "status": "processing", "model_ref": None}
         with patch(f"{_M}.get_session_user_id", return_value=USER_ID), \
-             patch(f"{_M}.get_avatar_training", return_value=avatar):
+             patch(f"{_M}.get_avatar_training", return_value=avatar), \
+             patch(f"{_M}.claim_avatar_sample_render") as claim:
             r = _client().post("/api/avatar/training/7/samples",
                                json={"session_token": SESSION})
         assert r.status_code == 400
+        claim.assert_not_called()
 
 
 @pytest.mark.integration

--- a/tests/unit/api/test_api_coverage_misc.py
+++ b/tests/unit/api/test_api_coverage_misc.py
@@ -684,11 +684,36 @@ class TestAvatarEndpoints:
         assert resp.json()["detail"] == trainings
 
     def test_sync_training_status_terminal_state_returns_as_is(self, client):
-        trainings = [{"id": 5, "training_id": "t5", "status": "succeeded"}]
+        trainings = [{"id": 5, "training_id": "t5", "status": "succeeded",
+                      "model_ref": "owner/m:v1", "sample_paths": [{"label": "headshot",
+                                                                   "path": "images/a/h.webp"}]}]
         with patch(f"{_M}.get_session_user_id", return_value=_UID), \
              patch(f"{_M}.get_avatar_trainings", return_value=trainings):
             resp = client.get(f"/api/avatar/training/5/status?session_token={_TOK}")
         assert resp.json()["detail"]["status"] == "succeeded"
+
+    def test_sync_training_status_queues_samples_on_first_success(self, client):
+        trainings = [{"id": 5, "training_id": "t5", "status": "processing", "model_ref": None,
+                      "sample_paths": []}]
+        with patch(f"{_M}.get_session_user_id", return_value=_UID), \
+             patch(f"{_M}.get_avatar_trainings", return_value=trainings), \
+             patch("cqc_lem.utilities.avatar.replicate_avatar.poll_training_status",
+                   return_value=("succeeded", "owner/model:v1")), \
+             patch(f"{_M}.update_avatar_training_status"), \
+             patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async") as queued:
+            resp = client.get(f"/api/avatar/training/5/status?session_token={_TOK}")
+        assert resp.status_code == 200
+        assert queued.call_args.kwargs["kwargs"] == {"avatar_id": 5, "user_id": _UID}
+
+    def test_sync_training_status_does_not_requeue_when_samples_exist(self, client):
+        trainings = [{"id": 5, "training_id": "t5", "status": "succeeded",
+                      "model_ref": "owner/m:v1",
+                      "sample_paths": [{"label": "headshot", "path": "images/a/h.webp"}]}]
+        with patch(f"{_M}.get_session_user_id", return_value=_UID), \
+             patch(f"{_M}.get_avatar_trainings", return_value=trainings), \
+             patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async") as queued:
+            client.get(f"/api/avatar/training/5/status?session_token={_TOK}")
+        queued.assert_not_called()
 
     def test_sync_training_status_polls_replicate_for_running(self, client):
         trainings = [{"id": 5, "training_id": "t5", "status": "processing",
@@ -697,6 +722,7 @@ class TestAvatarEndpoints:
              patch(f"{_M}.get_avatar_trainings", return_value=trainings), \
              patch("cqc_lem.utilities.avatar.replicate_avatar.poll_training_status",
                    return_value=("succeeded", "owner/model:v1")), \
+             patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async"), \
              patch(f"{_M}.update_avatar_training_status") as upd:
             resp = client.get(f"/api/avatar/training/5/status?session_token={_TOK}")
         detail = resp.json()["detail"]
@@ -710,26 +736,40 @@ class TestAvatarEndpoints:
         assert resp.status_code == 404
 
     def test_activate_avatar_success(self, client):
-        trainings = [{"id": 5, "training_id": "t5", "status": "succeeded"}]
+        avatar = {"id": 5, "training_id": "t5", "status": "succeeded",
+                  "approval_status": "approved"}
         with patch(f"{_M}.get_session_user_id", return_value=_UID), \
-             patch(f"{_M}.get_avatar_trainings", return_value=trainings), \
+             patch(f"{_M}.get_avatar_training", return_value=avatar), \
              patch(f"{_M}.set_active_avatar", return_value=True) as act:
             resp = client.put("/api/avatar/training/5/activate",
                               json={"session_token": _TOK})
         assert resp.status_code == 200
         act.assert_called_once_with(_UID, 5)
 
-    def test_activate_avatar_rejects_unfinished_training(self, client):
-        trainings = [{"id": 5, "training_id": "t5", "status": "processing"}]
+    def test_activate_avatar_rejects_unapproved(self, client):
+        """The approval gate (issue #744): a succeeded-but-unreviewed avatar cannot go live."""
+        avatar = {"id": 5, "training_id": "t5", "status": "succeeded",
+                  "approval_status": "pending"}
         with patch(f"{_M}.get_session_user_id", return_value=_UID), \
-             patch(f"{_M}.get_avatar_trainings", return_value=trainings):
+             patch(f"{_M}.get_avatar_training", return_value=avatar), \
+             patch(f"{_M}.set_active_avatar") as act:
+            resp = client.put("/api/avatar/training/5/activate",
+                              json={"session_token": _TOK})
+        assert resp.status_code == 400
+        act.assert_not_called()
+
+    def test_activate_avatar_rejects_unfinished_training(self, client):
+        avatar = {"id": 5, "training_id": "t5", "status": "processing",
+                  "approval_status": "pending"}
+        with patch(f"{_M}.get_session_user_id", return_value=_UID), \
+             patch(f"{_M}.get_avatar_training", return_value=avatar):
             resp = client.put("/api/avatar/training/5/activate",
                               json={"session_token": _TOK})
         assert resp.status_code == 400
 
     def test_activate_avatar_404(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_UID), \
-             patch(f"{_M}.get_avatar_trainings", return_value=[]):
+             patch(f"{_M}.get_avatar_training", return_value=None):
             resp = client.put("/api/avatar/training/99/activate",
                               json={"session_token": _TOK})
         assert resp.status_code == 404

--- a/tests/unit/api/test_api_coverage_misc.py
+++ b/tests/unit/api/test_api_coverage_misc.py
@@ -700,10 +700,37 @@ class TestAvatarEndpoints:
              patch("cqc_lem.utilities.avatar.replicate_avatar.poll_training_status",
                    return_value=("succeeded", "owner/model:v1")), \
              patch(f"{_M}.update_avatar_training_status"), \
+             patch(f"{_M}.claim_avatar_sample_render", return_value=True) as claim, \
              patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async") as queued:
             resp = client.get(f"/api/avatar/training/5/status?session_token={_TOK}")
         assert resp.status_code == 200
         assert queued.call_args.kwargs["kwargs"] == {"avatar_id": 5, "user_id": _UID}
+        claim.assert_called_once_with(_UID, 5)
+
+    def test_sync_training_status_second_poll_mid_render_queues_nothing(self, client):
+        """A double-clicked Refresh used to queue a second full three-image render."""
+        trainings = [{"id": 5, "training_id": "t5", "status": "succeeded",
+                      "model_ref": "owner/m:v1", "sample_paths": []}]
+        with patch(f"{_M}.get_session_user_id", return_value=_UID), \
+             patch(f"{_M}.get_avatar_trainings", return_value=trainings), \
+             patch(f"{_M}.claim_avatar_sample_render", return_value=False), \
+             patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async") as queued:
+            resp = client.get(f"/api/avatar/training/5/status?session_token={_TOK}")
+        assert resp.status_code == 200
+        queued.assert_not_called()
+
+    def test_sync_training_status_broker_failure_releases_the_claim(self, client):
+        trainings = [{"id": 5, "training_id": "t5", "status": "succeeded",
+                      "model_ref": "owner/m:v1", "sample_paths": []}]
+        with patch(f"{_M}.get_session_user_id", return_value=_UID), \
+             patch(f"{_M}.get_avatar_trainings", return_value=trainings), \
+             patch(f"{_M}.claim_avatar_sample_render", return_value=True), \
+             patch(f"{_M}.release_avatar_sample_render") as released, \
+             patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async",
+                   side_effect=RuntimeError("broker down")):
+            resp = client.get(f"/api/avatar/training/5/status?session_token={_TOK}")
+        assert resp.status_code == 200
+        released.assert_called_once_with(_UID, 5)
 
     def test_sync_training_status_does_not_requeue_when_samples_exist(self, client):
         trainings = [{"id": 5, "training_id": "t5", "status": "succeeded",
@@ -722,6 +749,7 @@ class TestAvatarEndpoints:
              patch(f"{_M}.get_avatar_trainings", return_value=trainings), \
              patch("cqc_lem.utilities.avatar.replicate_avatar.poll_training_status",
                    return_value=("succeeded", "owner/model:v1")), \
+             patch(f"{_M}.claim_avatar_sample_render", return_value=True), \
              patch("cqc_lem.app.run_avatar.render_avatar_samples_task.apply_async"), \
              patch(f"{_M}.update_avatar_training_status") as upd:
             resp = client.get(f"/api/avatar/training/5/status?session_token={_TOK}")

--- a/tests/unit/app/test_avatar_media_disclosure.py
+++ b/tests/unit/app/test_avatar_media_disclosure.py
@@ -1,0 +1,51 @@
+"""The AI disclosure must cover avatar IMAGES, not just video (issue #744).
+
+A synthetic likeness of a real person in a carousel slide shipped with neither a caption
+disclosure nor C2PA provenance — §2.4 of docs/AVATAR_FIDELITY_AND_VIDEO_LANGUAGE.md.
+"""
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RCP = "cqc_lem.app.run_content_plan"
+
+
+class TestPostUsedAvatarMedia:
+    def test_reads_the_durable_flag(self):
+        from cqc_lem.app.run_content_plan import _post_used_avatar_media
+        with patch("cqc_lem.utilities.db.post_used_avatar_media", return_value=True):
+            assert _post_used_avatar_media(9) is True
+
+    def test_unreadable_flag_fails_soft(self):
+        """The video branch still triggers the disclosure independently — this must not raise."""
+        from cqc_lem.app.run_content_plan import _post_used_avatar_media
+        with patch("cqc_lem.utilities.db.post_used_avatar_media",
+                   side_effect=RuntimeError("db down")):
+            assert _post_used_avatar_media(9) is False
+
+
+class TestDisclosureOnAvatarImagePosts:
+    def _create(self, *, video_url, avatar_media):
+        from cqc_lem.app.run_content_plan import _create_content_for_planned_post
+        post = {"id": 9, "user_id": 7, "post_type": "carousel", "buyer_stage": "awareness",
+                "content_mix": "value", "scheduled_time": None}
+        with patch(f"{_RCP}.create_content", return_value=("caption body", video_url)), \
+             patch(f"{_RCP}._post_used_avatar_media", return_value=avatar_media), \
+             patch(f"{_RCP}._score_and_persist_dwell"), \
+             patch(f"{_RCP}._gate_findings_for_post", return_value=[]), \
+             patch(f"{_RCP}.demoting_findings", return_value=[]), \
+             patch(f"{_RCP}._persist_gate_findings"), \
+             patch(f"{_RCP}.update_db_post_status"), \
+             patch(f"{_RCP}.update_db_post_content") as store:
+            assert _create_content_for_planned_post(post, {"auto_schedule_posts": True}) is True
+        return store.call_args[0][1]
+
+    def test_avatar_image_post_gets_the_disclosure(self):
+        content = self._create(video_url=None, avatar_media=True)
+        assert "Visuals created with AI" in content
+
+    def test_plain_post_does_not(self):
+        content = self._create(video_url=None, avatar_media=False)
+        assert "Visuals created with AI" not in content

--- a/tests/unit/app/test_content_plan_deep_coverage.py
+++ b/tests/unit/app/test_content_plan_deep_coverage.py
@@ -322,7 +322,7 @@ class TestGenerateVideoSrcPremium:
              patch("cqc_lem.utilities.db.get_video_credit_balance", return_value=10), \
              patch("cqc_lem.utilities.db.deduct_video_credits", return_value=True), \
              patch("cqc_lem.utilities.db.refund_video_credits") as refund, \
-             patch("cqc_lem.utilities.db.get_active_avatar", return_value=avatar), \
+             patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=avatar), \
              patch("cqc_lem.utilities.ai.video_models.is_premium", return_value=True), \
              patch(f"{_RCP}.get_flux_image_prompt_from_ai", return_value="image prompt"), \
              patch(f"{_RCP}.get_runway_ml_video_prompt_from_ai", return_value="motion"), \
@@ -340,7 +340,8 @@ class TestGenerateVideoSrcPremium:
         avatar = {"status": "succeeded", "model_ref": "owner/m:v1"}
         result, gen_img, create_video, refund, _ = self._run(avatar)
         assert result == "https://runway/v.mp4"
-        gen_img.assert_called_once_with("image prompt", 1, ratio="9:16")
+        gen_img.assert_called_once_with("image prompt", 1, ratio="9:16",
+                                        surface="video", post_id=9)
         assert create_video.call_args[0][0] == "/tmp/avatar.png"
         assert create_video.call_args[1]["audio"] is True
         refund.assert_not_called()

--- a/tests/unit/app/test_run_avatar_task.py
+++ b/tests/unit/app/test_run_avatar_task.py
@@ -16,45 +16,49 @@ def _run(avatar, samples=_SAMPLES, count_regeneration=False):
     with patch(f"{_M}.get_avatar_training", return_value=avatar), \
          patch("cqc_lem.utilities.avatar.samples.render_avatar_samples", return_value=samples), \
          patch(f"{_M}.update_avatar_samples") as store, \
+         patch(f"{_M}.release_avatar_sample_render") as release, \
          patch(f"{_M}.set_avatar_approval") as approval:
         result = render_avatar_samples_task(12, 7, count_regeneration=count_regeneration)
-    return result, store, approval
+    return result, store, approval, release
 
 
 class TestRenderAvatarSamplesTask:
     def test_stores_samples_and_returns_the_count(self):
-        result, store, _ = _run(_SUCCEEDED)
+        result, store, _, release = _run(_SUCCEEDED)
         assert result == 1
-        store.assert_called_once_with(12, _SAMPLES, count_regeneration=False)
-
-    def test_regeneration_is_counted_against_the_cap(self):
-        _, store, _ = _run(_SUCCEEDED, count_regeneration=True)
-        assert store.call_args.kwargs["count_regeneration"] is True
+        store.assert_called_once_with(12, _SAMPLES)
+        release.assert_not_called()
 
     def test_pending_avatar_is_not_re_reset(self):
-        _, _, approval = _run(_SUCCEEDED)
+        _, _, approval, _ = _run(_SUCCEEDED)
         approval.assert_not_called()
 
     def test_new_samples_invalidate_an_earlier_verdict(self):
         """The user approved the images they SAW — these are different images."""
         from cqc_lem.utilities.db import AVATAR_APPROVAL_PENDING
-        _, _, approval = _run({**_SUCCEEDED, "approval_status": "approved"})
+        _, _, approval, _ = _run({**_SUCCEEDED, "approval_status": "approved"})
         approval.assert_called_once_with(7, 12, AVATAR_APPROVAL_PENDING)
 
-    def test_missing_avatar_returns_none(self):
-        result, store, _ = _run(None)
+    def test_missing_avatar_returns_none_and_gives_the_claim_back(self):
+        result, store, _, release = _run(None)
         assert result is None
         store.assert_not_called()
+        release.assert_called_once_with(7, 12, regeneration=False)
 
     @pytest.mark.parametrize("override", [{"status": "processing"}, {"model_ref": None}])
     def test_unfinished_training_renders_nothing(self, override):
-        result, store, _ = _run({**_SUCCEEDED, **override})
+        result, store, _, release = _run({**_SUCCEEDED, **override})
         assert result is None
         store.assert_not_called()
+        release.assert_called_once()
 
     def test_no_samples_leaves_the_avatar_un_approvable(self):
         """Storing an empty list would look like 'previewed'; leaving it alone keeps the
         approve endpoint's 400 in place."""
-        result, store, _ = _run(_SUCCEEDED, samples=[])
+        result, store, _, _ = _run(_SUCCEEDED, samples=[])
         assert result == 0
         store.assert_not_called()
+
+    def test_a_failed_re_roll_does_not_cost_the_user_a_regeneration(self):
+        _, _, _, release = _run(_SUCCEEDED, samples=[], count_regeneration=True)
+        release.assert_called_once_with(7, 12, regeneration=True)

--- a/tests/unit/app/test_run_avatar_task.py
+++ b/tests/unit/app/test_run_avatar_task.py
@@ -1,0 +1,60 @@
+"""Unit tests for the avatar sample-rendering Celery task (issue #744)."""
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_M = "cqc_lem.app.run_avatar"
+_SUCCEEDED = {"id": 12, "status": "succeeded", "model_ref": "owner/lora:v1",
+              "approval_status": "pending"}
+_SAMPLES = [{"label": "headshot", "path": "images/avatar_samples/12/headshot.webp"}]
+
+
+def _run(avatar, samples=_SAMPLES, count_regeneration=False):
+    from cqc_lem.app.run_avatar import render_avatar_samples_task
+    with patch(f"{_M}.get_avatar_training", return_value=avatar), \
+         patch("cqc_lem.utilities.avatar.samples.render_avatar_samples", return_value=samples), \
+         patch(f"{_M}.update_avatar_samples") as store, \
+         patch(f"{_M}.set_avatar_approval") as approval:
+        result = render_avatar_samples_task(12, 7, count_regeneration=count_regeneration)
+    return result, store, approval
+
+
+class TestRenderAvatarSamplesTask:
+    def test_stores_samples_and_returns_the_count(self):
+        result, store, _ = _run(_SUCCEEDED)
+        assert result == 1
+        store.assert_called_once_with(12, _SAMPLES, count_regeneration=False)
+
+    def test_regeneration_is_counted_against_the_cap(self):
+        _, store, _ = _run(_SUCCEEDED, count_regeneration=True)
+        assert store.call_args.kwargs["count_regeneration"] is True
+
+    def test_pending_avatar_is_not_re_reset(self):
+        _, _, approval = _run(_SUCCEEDED)
+        approval.assert_not_called()
+
+    def test_new_samples_invalidate_an_earlier_verdict(self):
+        """The user approved the images they SAW — these are different images."""
+        from cqc_lem.utilities.db import AVATAR_APPROVAL_PENDING
+        _, _, approval = _run({**_SUCCEEDED, "approval_status": "approved"})
+        approval.assert_called_once_with(7, 12, AVATAR_APPROVAL_PENDING)
+
+    def test_missing_avatar_returns_none(self):
+        result, store, _ = _run(None)
+        assert result is None
+        store.assert_not_called()
+
+    @pytest.mark.parametrize("override", [{"status": "processing"}, {"model_ref": None}])
+    def test_unfinished_training_renders_nothing(self, override):
+        result, store, _ = _run({**_SUCCEEDED, **override})
+        assert result is None
+        store.assert_not_called()
+
+    def test_no_samples_leaves_the_avatar_un_approvable(self):
+        """Storing an empty list would look like 'previewed'; leaving it alone keeps the
+        approve endpoint's 400 in place."""
+        result, store, _ = _run(_SUCCEEDED, samples=[])
+        assert result == 0
+        store.assert_not_called()

--- a/tests/unit/app/test_video_tier_pipeline.py
+++ b/tests/unit/app/test_video_tier_pipeline.py
@@ -84,7 +84,8 @@ class TestGenerateVideoSrc:
         assert crv.call_args[1]["model"] == "gen4_turbo"
 
 
-_ACTIVE_AVATAR = {"status": "succeeded", "model_ref": "owner/lora:v1", "trigger_word": "TOK"}
+_ACTIVE_AVATAR = {"status": "succeeded", "model_ref": "owner/lora:v1", "trigger_word": "TOK",
+                  "approval_status": "approved"}
 
 
 class TestAvatarOnStandardTier:
@@ -92,7 +93,7 @@ class TestAvatarOnStandardTier:
         """Avatar appears on the standard (free) tier too — frame goes through generate_post_image."""
         with patch("cqc_lem.utilities.db.get_post_video_quality", return_value="standard"), \
              patch("cqc_lem.utilities.db.get_default_video_quality", return_value="standard"), \
-             patch("cqc_lem.utilities.db.get_active_avatar", return_value=_ACTIVE_AVATAR), \
+             patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=_ACTIVE_AVATAR), \
              patch("cqc_lem.app.run_content_plan.get_flux_image_prompt_from_ai", return_value="scene"), \
              patch("cqc_lem.utilities.ai.ai_helper.generate_post_image", return_value="/tmp/avatar.png") as gpi, \
              patch("cqc_lem.app.run_content_plan.generate_flux1_image_from_prompt") as flux, \
@@ -129,7 +130,7 @@ class TestAvatarOnStandardTier:
         with patch("cqc_lem.utilities.db.get_post_video_quality", return_value="premium"), \
              patch("cqc_lem.utilities.db.get_video_credit_balance", return_value=5), \
              patch("cqc_lem.utilities.db.deduct_video_credits", return_value=True), \
-             patch("cqc_lem.utilities.db.get_active_avatar", return_value=_ACTIVE_AVATAR), \
+             patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=_ACTIVE_AVATAR), \
              patch("cqc_lem.app.run_content_plan.get_flux_image_prompt_from_ai", return_value="scene"), \
              patch("cqc_lem.utilities.ai.ai_helper.generate_post_image", return_value="/tmp/avatar.png") as gpi, \
              patch("cqc_lem.app.run_content_plan.get_runway_ml_video_prompt_from_ai", return_value="motion"), \

--- a/tests/unit/utilities/ai/test_ai_helper_avatar_image.py
+++ b/tests/unit/utilities/ai/test_ai_helper_avatar_image.py
@@ -1,0 +1,134 @@
+"""Unit tests for avatar-conditioned image generation (issue #744).
+
+Covers the three defects §2.2 of docs/AVATAR_FIDELITY_AND_VIDEO_LANGUAGE.md traced: the invented
+gender, the silently dropped aspect ratio, and the trigger word on person-less scenes.
+"""
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_AH = "cqc_lem.utilities.ai.ai_helper"
+_AVATAR = {"id": 3, "trigger_word": "LEMAVTR1", "model_ref": "owner/lora:v1",
+           "status": "succeeded", "approval_status": "approved",
+           "gender_presentation": "man", "age_band": "40s"}
+
+
+class TestProfileVisualContext:
+    def test_subject_directive_leads_the_context(self):
+        from cqc_lem.utilities.ai.ai_helper import _profile_visual_context
+        from cqc_lem.utilities.avatar.attributes import subject_directive
+
+        class _P:
+            job_title, industry, company_name = "CTO", "SaaS", "Acme"
+
+        ctx = _profile_visual_context(_P(), subject_directive(_AVATAR))
+        assert ctx.startswith("When a person appears")
+        assert "a man in his 40s" in ctx
+        assert "The author is a CTO" in ctx
+
+    def test_directive_survives_a_profile_with_no_usable_fields(self):
+        """The likeness matters more than the brand line — it must not be dropped with it."""
+        from cqc_lem.utilities.ai.ai_helper import _profile_visual_context
+        assert "a man in his 40s" in _profile_visual_context(None, "a man in his 40s. ")
+
+    def test_no_profile_and_no_directive_is_empty(self):
+        from cqc_lem.utilities.ai.ai_helper import _profile_visual_context
+        assert _profile_visual_context(None) == ""
+
+
+class TestGetFluxImagePromptFromAi:
+    def _prompt_text(self, avatar):
+        from cqc_lem.utilities.ai.ai_helper import get_flux_image_prompt_from_ai
+        with patch(f"{_AH}._call_llm") as llm:
+            llm.return_value.choices[0].message.content = "a scene"
+            get_flux_image_prompt_from_ai("post body", avatar=avatar)
+        return llm.call_args.kwargs["messages"][1]["content"][0]["text"]
+
+    def test_declared_subject_reaches_the_prompt_author(self):
+        assert "a man in his 40s" in self._prompt_text(_AVATAR)
+
+    def test_no_avatar_adds_nothing(self):
+        assert "IS the author" not in self._prompt_text(None)
+
+
+class TestGeneratePostImage:
+    def _generate(self, **kwargs):
+        from cqc_lem.utilities.ai.ai_helper import generate_post_image
+        return generate_post_image("a whiteboard session", 7, **kwargs)
+
+    def test_ratio_is_threaded_to_the_avatar_render(self):
+        """The 9:16 source frame for premium avatar video used to be rendered square."""
+        with patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=_AVATAR), \
+             patch("cqc_lem.utilities.avatar.replicate_avatar.generate_image_with_avatar",
+                   return_value=("/tmp/a.webp", True)) as gen, \
+             patch(f"{_AH}._record_avatar_media"):
+            assert self._generate(ratio="9:16") == "/tmp/a.webp"
+        assert gen.call_args.kwargs["ratio"] == "9:16"
+        assert gen.call_args.kwargs["fallback_prompt"] == "a whiteboard session"
+
+    def test_prompt_carries_trigger_word_and_declared_clause(self):
+        with patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=_AVATAR), \
+             patch("cqc_lem.utilities.avatar.replicate_avatar.generate_image_with_avatar",
+                   return_value=("/tmp/a.webp", True)) as gen, \
+             patch(f"{_AH}._record_avatar_media"):
+            self._generate()
+        assert gen.call_args[0][0] == "LEMAVTR1, a man in his 40s, a whiteboard session"
+
+    def test_object_scenes_never_reach_the_lora(self):
+        with patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for") as resolve, \
+             patch(f"{_AH}.generate_flux1_image_from_prompt", return_value="/tmp/f.webp") as flux:
+            assert self._generate(depicts_person=False) == "/tmp/f.webp"
+        resolve.assert_not_called()
+        flux.assert_called_once()
+
+    def test_guardrail_decline_uses_base_flux(self):
+        with patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=None), \
+             patch(f"{_AH}.generate_flux1_image_from_prompt", return_value="/tmp/f.webp") as flux:
+            assert self._generate(ratio="4:5") == "/tmp/f.webp"
+        assert flux.call_args.kwargs["ratio"] == "4:5"
+
+    def test_provenance_recorded_only_when_the_avatar_actually_rendered(self):
+        with patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=_AVATAR), \
+             patch("cqc_lem.utilities.avatar.replicate_avatar.generate_image_with_avatar",
+                   return_value=("/tmp/a.webp", False)), \
+             patch(f"{_AH}._record_avatar_media") as record:
+            self._generate(post_id=9)
+        record.assert_not_called()
+
+    def test_provenance_recorded_on_a_real_avatar_render(self):
+        with patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=_AVATAR), \
+             patch("cqc_lem.utilities.avatar.replicate_avatar.generate_image_with_avatar",
+                   return_value=("/tmp/a.webp", True)), \
+             patch(f"{_AH}._record_avatar_media") as record:
+            self._generate(post_id=9)
+        record.assert_called_once_with("/tmp/a.webp", 9, 7)
+
+
+class TestRecordAvatarMedia:
+    def test_signs_the_file_and_flags_the_post(self):
+        from cqc_lem.utilities.ai.ai_helper import _record_avatar_media
+        with patch("cqc_lem.utilities.c2pa_helper.add_ai_content_credentials") as sign, \
+             patch("cqc_lem.utilities.db.mark_post_avatar_media") as mark:
+            _record_avatar_media("/tmp/a.webp", 9, 7)
+        sign.assert_called_once_with("/tmp/a.webp")
+        mark.assert_called_once_with(9)
+
+    def test_no_post_id_still_signs(self):
+        from cqc_lem.utilities.ai.ai_helper import _record_avatar_media
+        with patch("cqc_lem.utilities.c2pa_helper.add_ai_content_credentials") as sign, \
+             patch("cqc_lem.utilities.db.mark_post_avatar_media") as mark:
+            _record_avatar_media("/tmp/a.webp", None, 7)
+        sign.assert_called_once()
+        mark.assert_not_called()
+
+    @pytest.mark.parametrize("failing", ["sign", "mark"])
+    def test_provenance_failures_never_break_generation(self, failing):
+        from cqc_lem.utilities.ai.ai_helper import _record_avatar_media
+        boom = RuntimeError("nope")
+        with patch("cqc_lem.utilities.c2pa_helper.add_ai_content_credentials",
+                   side_effect=boom if failing == "sign" else None), \
+             patch("cqc_lem.utilities.db.mark_post_avatar_media",
+                   side_effect=boom if failing == "mark" else None):
+            _record_avatar_media("/tmp/a.webp", 9, 7)  # must not raise

--- a/tests/unit/utilities/avatar/test_attributes.py
+++ b/tests/unit/utilities/avatar/test_attributes.py
@@ -1,0 +1,113 @@
+"""Unit tests for user-declared avatar likeness attributes (issue #744, decision 3A).
+
+The load-bearing rule here is negative: an undeclared attribute must render NOTHING. Every
+inference this module could plausibly make is a bug, so most of these tests assert absence.
+"""
+import pytest
+
+from cqc_lem.utilities.avatar.attributes import (AGE_BANDS, GENDER_PRESENTATIONS,
+                                                 apply_subject_clause, normalize_age_band,
+                                                 normalize_gender_presentation, subject_clause,
+                                                 subject_directive)
+
+pytestmark = pytest.mark.unit
+
+
+class TestNormalization:
+    @pytest.mark.parametrize("raw,expected", [
+        ("man", "man"),
+        ("WOMAN", "woman"),
+        ("  Non-Binary  ", "non-binary"),
+        ("non_binary", "non-binary"),
+        ("prefer-not-to-say", "prefer-not-to-say"),
+    ])
+    def test_recognized_values(self, raw, expected):
+        assert normalize_gender_presentation(raw) == expected
+
+    @pytest.mark.parametrize("raw", [None, "", "   ", "male-presenting-ish", "unknown", "42"])
+    def test_unrecognized_is_none(self, raw):
+        assert normalize_gender_presentation(raw) is None
+
+    @pytest.mark.parametrize("raw,expected", [("40s", "40s"), (" 70+ ", "70+"), ("20S", "20s")])
+    def test_age_bands(self, raw, expected):
+        assert normalize_age_band(raw) == expected
+
+    @pytest.mark.parametrize("raw", [None, "", "middle-aged", "45", "80s"])
+    def test_unrecognized_age_is_none(self, raw):
+        assert normalize_age_band(raw) is None
+
+    def test_every_declared_band_normalizes(self):
+        assert all(normalize_age_band(b) == b for b in AGE_BANDS)
+
+    def test_every_declared_gender_normalizes(self):
+        assert all(normalize_gender_presentation(g) == g for g in GENDER_PRESENTATIONS)
+
+
+class TestSubjectClause:
+    @pytest.mark.parametrize("avatar", [
+        None,
+        {},
+        {"gender_presentation": None, "age_band": None},
+        {"gender_presentation": "", "age_band": ""},
+        {"gender_presentation": "garbage", "age_band": "garbage"},
+    ])
+    def test_unset_renders_nothing(self, avatar):
+        """Never guessed: no attributes means no clause at all, not a default person."""
+        assert subject_clause(avatar) == ""
+
+    def test_gender_and_age(self):
+        assert subject_clause({"gender_presentation": "man", "age_band": "40s"}) \
+            == "a man in his 40s"
+
+    def test_woman_uses_her(self):
+        assert subject_clause({"gender_presentation": "woman", "age_band": "30s"}) \
+            == "a woman in her 30s"
+
+    def test_non_binary_uses_their(self):
+        assert subject_clause({"gender_presentation": "non-binary", "age_band": "50s"}) \
+            == "a non-binary person in their 50s"
+
+    def test_gender_only(self):
+        assert subject_clause({"gender_presentation": "man"}) == "a man"
+
+    def test_age_only_uses_a_neutral_noun(self):
+        """Declaring an age is not a claim about gender — the noun stays neutral."""
+        assert subject_clause({"age_band": "30s"}) == "a person in their 30s"
+
+    def test_prefer_not_to_say_contributes_no_noun(self):
+        assert subject_clause({"gender_presentation": "prefer-not-to-say"}) == ""
+        assert subject_clause({"gender_presentation": "prefer-not-to-say", "age_band": "60s"}) \
+            == "a person in their 60s"
+
+    def test_seventy_plus_is_not_rendered_as_a_decade(self):
+        assert subject_clause({"gender_presentation": "woman", "age_band": "70+"}) \
+            == "a woman in her 70s or older"
+
+
+class TestSubjectDirective:
+    def test_empty_when_nothing_declared(self):
+        assert subject_directive({}) == ""
+        assert subject_directive(None) == ""
+
+    def test_names_the_author_and_forbids_contradiction(self):
+        directive = subject_directive({"gender_presentation": "man", "age_band": "40s"})
+        assert "a man in his 40s" in directive
+        assert "IS the author" in directive
+        assert directive.endswith("\n\n")
+
+
+class TestApplySubjectClause:
+    def test_trigger_word_leads_then_clause_then_scene(self):
+        avatar = {"trigger_word": "LEMAVTR1", "gender_presentation": "man", "age_band": "40s"}
+        assert apply_subject_clause("at a whiteboard", avatar) \
+            == "LEMAVTR1, a man in his 40s, at a whiteboard"
+
+    def test_no_attributes_leaves_trigger_plus_prompt(self):
+        avatar = {"trigger_word": "LEMAVTR1"}
+        assert apply_subject_clause("at a whiteboard", avatar) == "LEMAVTR1, at a whiteboard"
+
+    def test_no_avatar_returns_the_prompt_unchanged(self):
+        assert apply_subject_clause("at a whiteboard", None) == "at a whiteboard"
+
+    def test_blank_pieces_are_dropped(self):
+        assert apply_subject_clause("  ", {"trigger_word": " LEMAVTR1 "}) == "LEMAVTR1"

--- a/tests/unit/utilities/avatar/test_guardrails.py
+++ b/tests/unit/utilities/avatar/test_guardrails.py
@@ -1,0 +1,109 @@
+"""Unit tests for the avatar usage guardrails (issue #744, decision 4A).
+
+These assert the precedence order AND the fail-closed posture: every ambiguous or broken state
+must resolve to "don't use the avatar", because the failure mode on the other side is publishing
+a synthetic likeness of a real person.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from cqc_lem.utilities.avatar.guardrails import (AVATAR_SURFACE_CAROUSEL,
+                                                 AVATAR_SURFACE_POST_IMAGE, AVATAR_SURFACE_VIDEO,
+                                                 avatar_allowed_for, avatar_is_usable,
+                                                 resolve_avatar_for)
+
+pytestmark = pytest.mark.unit
+
+_APPROVED = {"id": 3, "status": "succeeded", "model_ref": "owner/lora:v1",
+             "trigger_word": "TOK", "approval_status": "approved"}
+
+_ALL_ON = {"avatar_disabled": False, "avatar_use_post_image": True,
+           "avatar_use_carousel": True, "avatar_use_video": True}
+_ALL_OFF = {"avatar_disabled": False, "avatar_use_post_image": False,
+            "avatar_use_carousel": False, "avatar_use_video": False}
+
+
+def _resolve(surface=AVATAR_SURFACE_POST_IMAGE, *, prefs=None, post_choice=None,
+             avatar=_APPROVED, post_id=None, user_id=7, prefs_exc=None):
+    with patch("cqc_lem.utilities.db.get_avatar_preferences",
+               side_effect=prefs_exc, return_value=prefs if prefs is not None else _ALL_ON), \
+         patch("cqc_lem.utilities.db.get_post_use_avatar", return_value=post_choice), \
+         patch("cqc_lem.utilities.db.get_active_avatar", return_value=avatar):
+        return resolve_avatar_for(user_id, surface=surface, post_id=post_id)
+
+
+class TestAvatarIsUsable:
+    def test_approved_succeeded_with_model_ref(self):
+        assert avatar_is_usable(_APPROVED) is True
+
+    @pytest.mark.parametrize("override", [
+        {"status": "processing"},
+        {"model_ref": None},
+        {"approval_status": "pending"},
+        {"approval_status": "rejected"},
+    ])
+    def test_anything_missing_is_unusable(self, override):
+        assert avatar_is_usable({**_APPROVED, **override}) is False
+
+    def test_none_is_unusable(self):
+        assert avatar_is_usable(None) is False
+
+
+class TestResolveAvatarFor:
+    def test_happy_path_returns_the_avatar(self):
+        assert _resolve() == _APPROVED
+
+    def test_no_user_id_is_none(self):
+        assert resolve_avatar_for(None, surface=AVATAR_SURFACE_POST_IMAGE) is None
+        assert resolve_avatar_for(0, surface=AVATAR_SURFACE_VIDEO) is None
+
+    def test_unknown_surface_raises(self):
+        with pytest.raises(ValueError, match="Unknown avatar surface"):
+            resolve_avatar_for(7, surface="billboard")
+
+    def test_master_switch_beats_everything(self):
+        """'Don't use my avatar' overrides the per-surface opt-ins AND the per-post choice."""
+        assert _resolve(prefs={**_ALL_ON, "avatar_disabled": True},
+                        post_choice=True, post_id=9) is None
+
+    def test_surface_opt_in_off_is_none(self):
+        assert _resolve(AVATAR_SURFACE_CAROUSEL, prefs=_ALL_OFF) is None
+
+    def test_surface_opt_ins_are_independent(self):
+        prefs = {**_ALL_OFF, "avatar_use_video": True}
+        assert _resolve(AVATAR_SURFACE_VIDEO, prefs=prefs) == _APPROVED
+        assert _resolve(AVATAR_SURFACE_POST_IMAGE, prefs=prefs) is None
+
+    def test_post_level_opt_out_wins_over_an_enabled_surface(self):
+        assert _resolve(prefs=_ALL_ON, post_choice=False, post_id=9) is None
+
+    def test_post_level_opt_in_overrides_a_disabled_surface(self):
+        assert _resolve(prefs=_ALL_OFF, post_choice=True, post_id=9) == _APPROVED
+
+    def test_post_choice_is_not_read_without_a_post_id(self):
+        with patch("cqc_lem.utilities.db.get_avatar_preferences", return_value=_ALL_ON), \
+             patch("cqc_lem.utilities.db.get_post_use_avatar") as post_choice, \
+             patch("cqc_lem.utilities.db.get_active_avatar", return_value=_APPROVED):
+            assert resolve_avatar_for(7, surface=AVATAR_SURFACE_VIDEO) == _APPROVED
+        post_choice.assert_not_called()
+
+    def test_unapproved_avatar_is_none_even_with_every_opt_in_on(self):
+        """The approval gate is not overridable by a preference — that is the whole point."""
+        assert _resolve(avatar={**_APPROVED, "approval_status": "pending"},
+                        post_choice=True, post_id=9) is None
+
+    def test_no_active_avatar_is_none(self):
+        assert _resolve(avatar=None) is None
+
+    def test_db_failure_fails_closed(self):
+        assert _resolve(prefs_exc=RuntimeError("db down")) is None
+
+
+class TestAvatarAllowedFor:
+    def test_boolean_form(self):
+        with patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for",
+                   return_value=_APPROVED):
+            assert avatar_allowed_for(7, surface=AVATAR_SURFACE_CAROUSEL) is True
+        with patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=None):
+            assert avatar_allowed_for(7, surface=AVATAR_SURFACE_CAROUSEL) is False

--- a/tests/unit/utilities/avatar/test_replicate_avatar.py
+++ b/tests/unit/utilities/avatar/test_replicate_avatar.py
@@ -116,10 +116,12 @@ class TestGenerateImageWithAvatar:
         ) as mock_flux:
             from cqc_lem.utilities.avatar.replicate_avatar import generate_image_with_avatar
 
-            result = generate_image_with_avatar("a portrait photo", "testuser/model:v1")
+            result = generate_image_with_avatar("a portrait photo", "testuser/model:v1",
+                                                ratio="9:16")
 
-            mock_flux.assert_called_once_with("a portrait photo", ref="testuser/model:v1")
-            assert result == "/assets/images/replicate/test/out.webp"
+            mock_flux.assert_called_once_with("a portrait photo", ref="testuser/model:v1",
+                                              aspect_ratio="9:16")
+            assert result == ("/assets/images/replicate/test/out.webp", True)
 
     def test_falls_back_to_base_flux_on_error(self):
         with patch(
@@ -131,10 +133,14 @@ class TestGenerateImageWithAvatar:
         ) as mock_fallback:
             from cqc_lem.utilities.avatar.replicate_avatar import generate_image_with_avatar
 
-            result = generate_image_with_avatar("a portrait photo", "testuser/model:v1")
+            result = generate_image_with_avatar("LEMAVTR42, a portrait photo",
+                                                "testuser/model:v1",
+                                                fallback_prompt="a portrait photo")
 
-            mock_fallback.assert_called_once()
-            assert result == "/assets/images/replicate/fallback/out.webp"
+            # The base model gets the CLEAN prompt — the LoRA trigger word is a nonsense token
+            # to it — and used_avatar is False so the caller can't claim avatar provenance.
+            mock_fallback.assert_called_once_with("a portrait photo", ratio="1:1")
+            assert result == ("/assets/images/replicate/fallback/out.webp", False)
 
 
 @pytest.mark.unit
@@ -149,11 +155,13 @@ class TestGeneratePostImage:
         }
         # Patch generate_image_with_avatar at its source module so the lazy import
         # inside generate_post_image picks up the mock.
-        with patch("cqc_lem.utilities.db.get_active_avatar", return_value=active_avatar), \
+        with patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for",
+                   return_value=active_avatar), \
              patch(
                  "cqc_lem.utilities.avatar.replicate_avatar.generate_image_with_avatar",
-                 return_value="/avatar/image.webp",
-             ) as mock_gen:
+                 return_value=("/avatar/image.webp", True),
+             ) as mock_gen, \
+             patch("cqc_lem.utilities.ai.ai_helper._record_avatar_media"):
             from cqc_lem.utilities.ai.ai_helper import generate_post_image
 
             result = generate_post_image("professional headshot", 42)
@@ -163,7 +171,7 @@ class TestGeneratePostImage:
             assert "LEMAVTR42" in called_prompt
 
     def test_falls_back_when_no_active_avatar(self):
-        with patch("cqc_lem.utilities.db.get_active_avatar", return_value=None), \
+        with patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=None), \
              patch(
                  "cqc_lem.utilities.ai.ai_helper.generate_flux1_image_from_prompt",
                  return_value="/flux/image.webp",

--- a/tests/unit/utilities/avatar/test_samples.py
+++ b/tests/unit/utilities/avatar/test_samples.py
@@ -1,0 +1,109 @@
+"""Unit tests for avatar preview sample rendering (issue #744, decision 4A)."""
+import os
+from unittest.mock import patch
+
+import pytest
+
+from cqc_lem.utilities.avatar.samples import (AVATAR_SAMPLE_SCENES, render_avatar_samples,
+                                              sample_asset_url, sample_payload,
+                                              sample_relative_dir)
+
+pytestmark = pytest.mark.unit
+
+_AVATAR = {"id": 12, "model_ref": "owner/lora:v1", "trigger_word": "TOK",
+           "gender_presentation": "man", "age_band": "40s"}
+
+_GEN = "cqc_lem.utilities.avatar.replicate_avatar.generate_image_with_avatar"
+
+
+@pytest.fixture
+def fake_assets(tmp_path):
+    with patch("cqc_lem.utilities.avatar.samples.assets_dir", str(tmp_path)):
+        yield tmp_path
+
+
+def _source_image(tmp_path, name="out.webp"):
+    src = tmp_path / name
+    src.write_bytes(b"fake-image")
+    return str(src)
+
+
+class TestRenderAvatarSamples:
+    def test_renders_every_scene_and_returns_relative_paths(self, fake_assets, tmp_path):
+        src = _source_image(tmp_path)
+        with patch(_GEN, return_value=(src, True)) as gen, \
+             patch("cqc_lem.utilities.avatar.samples._sign_best_effort") as sign:
+            samples = render_avatar_samples(_AVATAR)
+
+        assert [s["label"] for s in samples] == [label for label, _ in AVATAR_SAMPLE_SCENES]
+        assert all(s["path"].startswith("images/avatar_samples/12/") for s in samples)
+        assert gen.call_count == len(AVATAR_SAMPLE_SCENES)
+        # Every sample is C2PA-signed: it is a synthetic likeness of a real person.
+        assert sign.call_count == len(AVATAR_SAMPLE_SCENES)
+        for s in samples:
+            assert os.path.exists(os.path.join(str(fake_assets), *s["path"].split("/")))
+
+    def test_prompt_carries_the_trigger_word_and_the_declared_clause(self, fake_assets, tmp_path):
+        """What the user approves must be built the same way a production image is."""
+        src = _source_image(tmp_path)
+        with patch(_GEN, return_value=(src, True)) as gen, \
+             patch("cqc_lem.utilities.avatar.samples._sign_best_effort"):
+            render_avatar_samples(_AVATAR)
+
+        prompt = gen.call_args_list[0][0][0]
+        assert prompt.startswith("TOK, a man in his 40s, ")
+        assert gen.call_args_list[0][1]["ratio"] == "1:1"
+
+    def test_base_flux_fallback_is_discarded(self, fake_assets, tmp_path):
+        """A fallback render is a picture of a stranger — showing it as 'your avatar' is worse
+        than showing nothing."""
+        src = _source_image(tmp_path)
+        with patch(_GEN, return_value=(src, False)), \
+             patch("cqc_lem.utilities.avatar.samples._sign_best_effort"):
+            assert render_avatar_samples(_AVATAR) == []
+
+    def test_one_failed_scene_does_not_lose_the_others(self, fake_assets, tmp_path):
+        src = _source_image(tmp_path)
+        outcomes = [RuntimeError("boom"), (src, True), (src, True)]
+        with patch(_GEN, side_effect=outcomes), \
+             patch("cqc_lem.utilities.avatar.samples._sign_best_effort"):
+            samples = render_avatar_samples(_AVATAR)
+        assert len(samples) == 2
+
+    def test_never_raises_when_every_scene_fails(self, fake_assets):
+        with patch(_GEN, side_effect=RuntimeError("replicate down")):
+            assert render_avatar_samples(_AVATAR) == []
+
+    @pytest.mark.parametrize("avatar", [{}, {"id": 1}, {"model_ref": "m"}])
+    def test_incomplete_avatar_renders_nothing(self, avatar, fake_assets):
+        with patch(_GEN) as gen:
+            assert render_avatar_samples(avatar) == []
+        gen.assert_not_called()
+
+    def test_signing_failure_is_swallowed(self, fake_assets, tmp_path):
+        src = _source_image(tmp_path)
+        with patch(_GEN, return_value=(src, True)), \
+             patch("cqc_lem.utilities.c2pa_helper.add_ai_content_credentials",
+                   side_effect=RuntimeError("no cert")):
+            assert len(render_avatar_samples(_AVATAR)) == len(AVATAR_SAMPLE_SCENES)
+
+
+class TestSampleSerialization:
+    def test_relative_dir(self):
+        assert sample_relative_dir(9) == "images/avatar_samples/9"
+
+    def test_asset_url(self):
+        url = sample_asset_url("images/avatar_samples/9/headshot.webp", api_url="https://x")
+        assert url == "https://x/api/assets?file_name=images/avatar_samples/9/headshot.webp"
+
+    def test_payload_skips_malformed_entries(self):
+        avatar = {"sample_paths": [
+            {"label": "headshot", "path": "images/avatar_samples/9/headshot.webp"},
+            {"label": "broken"},          # no path
+            "not-a-dict",
+        ]}
+        payload = sample_payload(avatar)
+        assert len(payload) == 1 and payload[0]["label"] == "headshot"
+
+    def test_payload_empty_when_no_samples(self):
+        assert sample_payload({}) == []

--- a/tests/unit/utilities/test_carousel_image_selection.py
+++ b/tests/unit/utilities/test_carousel_image_selection.py
@@ -214,6 +214,39 @@ class TestGenerateAvatarSlideImage:
         with patch("cqc_lem.utilities.ai.ai_helper.generate_post_image", side_effect=Exception("api")):
             assert _generate_avatar_slide_image("team", 5) is None
 
+    def test_routes_through_the_carousel_surface_with_the_post_id(self):
+        with patch("cqc_lem.utilities.ai.ai_helper.generate_post_image",
+                   return_value="/tmp/gen.png") as gen:
+            _generate_avatar_slide_image("team retro", 5, 9, "personal_story")
+        assert gen.call_args.kwargs["surface"] == "carousel"
+        assert gen.call_args.kwargs["post_id"] == 9
+        assert gen.call_args.kwargs["depicts_person"] is True
+
+    def test_object_query_is_not_routed_to_the_lora(self):
+        """Prepending the trigger word to 'quarterly dashboard metrics' asked the LoRA to insert
+        the user's face into a scene never written to contain a person (issue #744)."""
+        with patch("cqc_lem.utilities.ai.ai_helper.generate_post_image",
+                   return_value="/tmp/gen.png") as gen:
+            _generate_avatar_slide_image("quarterly dashboard metrics", 5, 9, "educational")
+        assert gen.call_args.kwargs["depicts_person"] is False
+
+
+@pytest.mark.unit
+class TestQueryDepictsPerson:
+    def test_personal_story_always_depicts_the_author(self):
+        assert cc._query_depicts_person("quarterly dashboard", "personal_story") is True
+
+    @pytest.mark.parametrize("query", ["a team retro", "client meeting", "founder portrait"])
+    def test_person_terms_detected(self, query):
+        assert cc._query_depicts_person(query, "educational") is True
+
+    @pytest.mark.parametrize("query", ["dashboard metrics", "server rack", "", None])
+    def test_object_queries_rejected(self, query):
+        assert cc._query_depicts_person(query, "educational") is False
+
+    def test_punctuation_does_not_hide_a_person_term(self):
+        assert cc._query_depicts_person("(team), retro", "educational") is True
+
 
 @pytest.mark.unit
 class TestSelectSlideImage:

--- a/tests/unit/utilities/test_carousel_image_selection.py
+++ b/tests/unit/utilities/test_carousel_image_selection.py
@@ -145,16 +145,37 @@ class TestAvatarGating:
         assert _user_has_active_avatar(None) is False
 
     def test_active_avatar_true(self):
-        avatar = {"status": "succeeded", "model_ref": "user/model:v1"}
-        with patch("cqc_lem.utilities.db.get_active_avatar", return_value=avatar):
+        avatar = {"status": "succeeded", "model_ref": "user/model:v1",
+                  "approval_status": "approved"}
+        with patch("cqc_lem.utilities.db.get_avatar_preferences",
+                   return_value={"avatar_use_carousel": True}), \
+             patch("cqc_lem.utilities.db.get_post_use_avatar", return_value=None), \
+             patch("cqc_lem.utilities.db.get_active_avatar", return_value=avatar):
             assert _user_has_active_avatar(5) is True
 
     def test_incomplete_avatar_false(self):
-        with patch("cqc_lem.utilities.db.get_active_avatar", return_value={"status": "training"}):
+        with patch("cqc_lem.utilities.db.get_avatar_preferences",
+                   return_value={"avatar_use_carousel": True}), \
+             patch("cqc_lem.utilities.db.get_post_use_avatar", return_value=None), \
+             patch("cqc_lem.utilities.db.get_active_avatar", return_value={"status": "training"}):
             assert _user_has_active_avatar(5) is False
 
     def test_avatar_lookup_error_false(self):
-        with patch("cqc_lem.utilities.db.get_active_avatar", side_effect=Exception("db down")):
+        with patch("cqc_lem.utilities.db.get_avatar_preferences",
+                   return_value={"avatar_use_carousel": True}), \
+             patch("cqc_lem.utilities.db.get_post_use_avatar", return_value=None), \
+             patch("cqc_lem.utilities.db.get_active_avatar", side_effect=Exception("db down")):
+            assert _user_has_active_avatar(5) is False
+
+    def test_carousel_opt_in_off_false(self):
+        """Guardrail (issue #744): an approved avatar is still not used until the user opts
+        carousels in."""
+        avatar = {"status": "succeeded", "model_ref": "user/model:v1",
+                  "approval_status": "approved"}
+        with patch("cqc_lem.utilities.db.get_avatar_preferences",
+                   return_value={"avatar_use_carousel": False}), \
+             patch("cqc_lem.utilities.db.get_post_use_avatar", return_value=None), \
+             patch("cqc_lem.utilities.db.get_active_avatar", return_value=avatar):
             assert _user_has_active_avatar(5) is False
 
     def test_replicate_disabled_false(self):
@@ -167,9 +188,13 @@ class TestAvatarGating:
             assert _should_generate_with_replicate(1, 2, 5, "educational") is False
 
     def test_replicate_all_gates_pass_true(self):
-        avatar = {"status": "succeeded", "model_ref": "user/model:v1"}
+        avatar = {"status": "succeeded", "model_ref": "user/model:v1",
+                  "approval_status": "approved"}
         with patch(f"{ENV}.CAROUSEL_REPLICATE_ENABLED", True), \
              patch(f"{ENV}.CAROUSEL_REPLICATE_RATE", 1.0), \
+             patch("cqc_lem.utilities.db.get_avatar_preferences",
+                   return_value={"avatar_use_carousel": True}), \
+             patch("cqc_lem.utilities.db.get_post_use_avatar", return_value=None), \
              patch("cqc_lem.utilities.db.get_active_avatar", return_value=avatar):
             assert _should_generate_with_replicate(1, 2, 5, "personal_story") is True
 

--- a/tests/unit/utilities/test_db_avatar_fidelity.py
+++ b/tests/unit/utilities/test_db_avatar_fidelity.py
@@ -128,7 +128,8 @@ class TestSetAvatarApproval:
 
 
 class TestUpdateAvatarSamples:
-    def test_first_render_does_not_spend_a_regeneration(self):
+    def test_stores_the_paths_without_touching_the_counter(self):
+        """The re-roll is reserved before the render, never counted after it."""
         conn, cur = _conn(rowcount=1)
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import update_avatar_samples
@@ -137,20 +138,79 @@ class TestUpdateAvatarSamples:
         assert "sample_regen_count" not in sql
         assert json.loads(params[0]) == [{"label": "a", "path": "p"}]
 
-    def test_regeneration_increments_the_counter(self):
-        conn, cur = _conn(rowcount=1)
-        with patch(f"{_DB}.get_db_connection", return_value=conn):
-            from cqc_lem.utilities.db import update_avatar_samples
-            update_avatar_samples(4, [], count_regeneration=True)
-        sql, _ = cur.execute.call_args[0]
-        assert "sample_regen_count = sample_regen_count + 1" in sql
-
     def test_error_returns_false(self):
         conn, cur = _conn()
         cur.execute.side_effect = mysql.connector.Error(msg="boom")
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import update_avatar_samples
             assert update_avatar_samples(4, []) is False
+
+
+class TestSampleRenderClaim:
+    """The cap has to be decided IN the write: reading a counter that only moves when a render
+    finishes let a double-click queue two full renders against the same reading."""
+
+    def test_regeneration_claim_increments_under_the_cap(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import claim_avatar_sample_render
+            assert claim_avatar_sample_render(3, 4, regeneration=True, max_regenerations=3) is True
+        sql, params = cur.execute.call_args[0]
+        assert "sample_regen_count = sample_regen_count + 1" in sql
+        assert "sample_regen_count < %s" in sql
+        assert params == (4, 3, 3)
+
+    def test_regeneration_claim_lost_at_the_cap(self):
+        conn, _ = _conn(rowcount=0)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import claim_avatar_sample_render
+            assert claim_avatar_sample_render(3, 4, regeneration=True, max_regenerations=3) is False
+
+    def test_first_render_claim_is_conditional_on_no_prior_render(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import claim_avatar_sample_render
+            assert claim_avatar_sample_render(3, 4) is True
+        sql, params = cur.execute.call_args[0]
+        assert "samples_generated_at IS NULL" in sql and "sample_paths IS NULL" in sql
+        assert params == (4, 3)
+
+    def test_second_poll_mid_render_loses_the_claim(self):
+        conn, _ = _conn(rowcount=0)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import claim_avatar_sample_render
+            assert claim_avatar_sample_render(3, 4) is False
+
+    def test_claim_error_fails_closed(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import claim_avatar_sample_render
+            assert claim_avatar_sample_render(3, 4) is False
+
+    def test_release_gives_a_regeneration_back(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import release_avatar_sample_render
+            assert release_avatar_sample_render(3, 4, regeneration=True) is True
+        sql, params = cur.execute.call_args[0]
+        assert "GREATEST(sample_regen_count - 1, 0)" in sql
+        assert params == (4, 3)
+
+    def test_release_reopens_the_first_render_only_while_no_samples_exist(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import release_avatar_sample_render
+            assert release_avatar_sample_render(3, 4) is True
+        sql, _ = cur.execute.call_args[0]
+        assert "samples_generated_at = NULL" in sql and "sample_paths IS NULL" in sql
+
+    def test_release_error_returns_false(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import release_avatar_sample_render
+            assert release_avatar_sample_render(3, 4, regeneration=True) is False
 
 
 class TestAvatarPreferences:

--- a/tests/unit/utilities/test_db_avatar_fidelity.py
+++ b/tests/unit/utilities/test_db_avatar_fidelity.py
@@ -1,0 +1,273 @@
+"""Coverage tests for the avatar attribute / approval / guardrail DB helpers (issue #744)."""
+import json
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+
+import mysql.connector
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_DB = "cqc_lem.utilities.db"
+
+
+def _conn(fetch_one=None, fetch_all=None, rowcount=1, lastrowid=1):
+    conn = MagicMock()
+    cur = MagicMock()
+    cur.fetchone.return_value = fetch_one
+    cur.fetchall.return_value = fetch_all if fetch_all is not None else []
+    cur.rowcount = rowcount
+    cur.lastrowid = lastrowid
+    conn.cursor.return_value = cur
+    return conn, cur
+
+
+class TestAvatarRowSerialization:
+    def test_full_row_round_trips(self):
+        row = {
+            "id": 4, "training_id": "t4", "model_ref": "m", "trigger_word": "TOK",
+            "status": "succeeded", "is_active": 1,
+            "gender_presentation": "man", "age_band": "40s",
+            "attributes_confirmed_at": datetime(2026, 7, 30, 12, 0),
+            "approval_status": "approved", "approved_at": datetime(2026, 7, 30, 12, 5),
+            "sample_paths": json.dumps([{"label": "headshot", "path": "images/a/h.webp"}]),
+            "samples_generated_at": datetime(2026, 7, 30, 11, 0), "sample_regen_count": 2,
+            "created_at": None, "updated_at": None,
+        }
+        conn, _ = _conn(fetch_one=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_avatar_training
+            result = get_avatar_training(3, 4)
+        assert result["gender_presentation"] == "man"
+        assert result["approval_status"] == "approved"
+        assert result["sample_paths"] == [{"label": "headshot", "path": "images/a/h.webp"}]
+        assert result["sample_regen_count"] == 2
+
+    def test_unparseable_sample_json_degrades_to_empty(self):
+        """A corrupt JSON blob must not 500 the avatars page — it reads as 'no samples yet'."""
+        row = {"id": 4, "training_id": "t4", "model_ref": "m", "trigger_word": "TOK",
+               "status": "succeeded", "sample_paths": "{not json", "created_at": None}
+        conn, _ = _conn(fetch_one=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_avatar_training
+            assert get_avatar_training(3, 4)["sample_paths"] == []
+
+    def test_scoped_to_owner(self):
+        conn, cur = _conn(fetch_one=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_avatar_training
+            assert get_avatar_training(3, 99) is None
+        _, params = cur.execute.call_args[0]
+        assert params == (99, 3)
+
+    def test_error_returns_none(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_avatar_training
+            assert get_avatar_training(3, 4) is None
+
+
+class TestUpdateAvatarAttributes:
+    def test_normalizes_before_storing(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_avatar_attributes
+            assert update_avatar_attributes(3, 4, " MAN ", "40s") is True
+        sql, params = cur.execute.call_args[0]
+        assert "attributes_confirmed_at = UTC_TIMESTAMP()" in sql
+        assert params == ("man", "40s", 4, 3)
+
+    def test_unrecognized_values_are_stored_as_null_not_guessed(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_avatar_attributes
+            update_avatar_attributes(3, 4, "cisgender-ish", "middle aged")
+        _, params = cur.execute.call_args[0]
+        assert params == (None, None, 4, 3)
+
+    def test_error_returns_false(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_avatar_attributes
+            assert update_avatar_attributes(3, 4, "man", "40s") is False
+
+
+class TestSetAvatarApproval:
+    def test_approve_stamps_approved_at(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_avatar_approval
+            assert set_avatar_approval(3, 4, "approved") is True
+        sql, params = cur.execute.call_args[0]
+        assert "approved_at = UTC_TIMESTAMP()" in sql and params == ("approved", 4, 3)
+
+    def test_reject_also_deactivates(self):
+        """Leaving a rejected likeness active would keep publishing what the user rejected."""
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_avatar_approval
+            assert set_avatar_approval(3, 4, "rejected") is True
+        sql, _ = cur.execute.call_args[0]
+        assert "is_active = 0" in sql and "approved_at = NULL" in sql
+
+    def test_unknown_status_refused_without_touching_the_db(self):
+        conn, cur = _conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_avatar_approval
+            assert set_avatar_approval(3, 4, "sort-of") is False
+        cur.execute.assert_not_called()
+
+    def test_error_returns_false(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_avatar_approval
+            assert set_avatar_approval(3, 4, "approved") is False
+
+
+class TestUpdateAvatarSamples:
+    def test_first_render_does_not_spend_a_regeneration(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_avatar_samples
+            assert update_avatar_samples(4, [{"label": "a", "path": "p"}]) is True
+        sql, params = cur.execute.call_args[0]
+        assert "sample_regen_count" not in sql
+        assert json.loads(params[0]) == [{"label": "a", "path": "p"}]
+
+    def test_regeneration_increments_the_counter(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_avatar_samples
+            update_avatar_samples(4, [], count_regeneration=True)
+        sql, _ = cur.execute.call_args[0]
+        assert "sample_regen_count = sample_regen_count + 1" in sql
+
+    def test_error_returns_false(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_avatar_samples
+            assert update_avatar_samples(4, []) is False
+
+
+class TestAvatarPreferences:
+    def test_reads_every_flag(self):
+        row = {"avatar_disabled": 0, "avatar_use_post_image": 1,
+               "avatar_use_carousel": 0, "avatar_use_video": 1}
+        conn, _ = _conn(fetch_one=row)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_avatar_preferences
+            prefs = get_avatar_preferences(3)
+        assert prefs == {"avatar_disabled": False, "avatar_use_post_image": True,
+                         "avatar_use_carousel": False, "avatar_use_video": True}
+
+    def test_missing_user_returns_all_off(self):
+        conn, _ = _conn(fetch_one=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_avatar_preferences
+            assert not any(get_avatar_preferences(3).values())
+
+    def test_db_error_returns_all_off(self):
+        """Degrading to 'don't use the avatar' is the safe direction."""
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_avatar_preferences
+            assert not any(get_avatar_preferences(3).values())
+
+    def test_update_only_writes_supplied_flags(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_avatar_preferences
+            assert update_avatar_preferences(3, {"avatar_use_video": True}) is True
+        sql, params = cur.execute.call_args[0]
+        assert sql == "UPDATE users SET avatar_use_video = %s WHERE id = %s"
+        assert params == (1, 3)
+
+    def test_update_ignores_unknown_keys(self):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_avatar_preferences
+            assert update_avatar_preferences(3, {"is_admin": True}) is False
+        cur.execute.assert_not_called()
+
+    def test_update_error_returns_false(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_avatar_preferences
+            assert update_avatar_preferences(3, {"avatar_disabled": True}) is False
+
+
+class TestPostAvatarFlags:
+    @pytest.mark.parametrize("stored,expected", [((1,), True), ((0,), False), ((None,), None)])
+    def test_use_avatar_is_three_valued(self, stored, expected):
+        conn, _ = _conn(fetch_one=stored)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_use_avatar
+            assert get_post_use_avatar(5) is expected
+
+    def test_use_avatar_without_post_id_is_none(self):
+        from cqc_lem.utilities.db import get_post_use_avatar
+        assert get_post_use_avatar(None) is None
+
+    def test_use_avatar_error_is_none(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_post_use_avatar
+            assert get_post_use_avatar(5) is None
+
+    @pytest.mark.parametrize("value,stored", [(True, 1), (False, 0), (None, None)])
+    def test_update_post_use_avatar(self, value, stored):
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_post_use_avatar
+            assert update_post_use_avatar(5, value) is True
+        _, params = cur.execute.call_args[0]
+        assert params == (stored, 5)
+
+    def test_update_post_use_avatar_error(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import update_post_use_avatar
+            assert update_post_use_avatar(5, True) is False
+
+    def test_mark_and_read_avatar_media(self):
+        conn, cur = _conn(rowcount=1, fetch_one=(1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import mark_post_avatar_media, post_used_avatar_media
+            assert mark_post_avatar_media(5) is True
+            assert post_used_avatar_media(5) is True
+        assert "avatar_media = 1" in cur.execute.call_args_list[0][0][0]
+
+    def test_avatar_media_helpers_no_op_without_post_id(self):
+        from cqc_lem.utilities.db import mark_post_avatar_media, post_used_avatar_media
+        assert mark_post_avatar_media(None) is False
+        assert post_used_avatar_media(None) is False
+
+    def test_avatar_media_errors_are_false(self):
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import mark_post_avatar_media, post_used_avatar_media
+            assert mark_post_avatar_media(5) is False
+            assert post_used_avatar_media(5) is False
+
+
+class TestInsertPostUseAvatar:
+    @pytest.mark.parametrize("value,stored", [(True, 1), (False, 0), (None, None)])
+    def test_compose_choice_is_persisted(self, value, stored):
+        from cqc_lem.utilities.db import PostType, PostStatus
+        conn, cur = _conn(rowcount=1)
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.get_user_id", return_value=3):
+            from cqc_lem.utilities.db import insert_post
+            assert insert_post("a@b.c", "body", datetime(2026, 7, 30, 9, 0), PostType.TEXT,
+                               status=PostStatus.PENDING, use_avatar=value) is True
+        _, params = cur.execute.call_args[0]
+        assert params[-1] is stored

--- a/tests/unit/utilities/test_db_coverage_avatar_groups.py
+++ b/tests/unit/utilities/test_db_coverage_avatar_groups.py
@@ -58,7 +58,7 @@ class TestAvatarLedger:
 
 class TestAvatarTrainings:
     def test_set_active_avatar_validates_then_deactivates_then_activates(self):
-        conn, cur = _conn(rowcount=1, fetch_one={"id": 11})
+        conn, cur = _conn(rowcount=1, fetch_one={"id": 11, "approval_status": "approved"})
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import set_active_avatar
             assert set_active_avatar(3, 11) is True
@@ -75,6 +75,17 @@ class TestAvatarTrainings:
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import set_active_avatar
             assert set_active_avatar(3, 999) is False
+        executed = [c[0][0] for c in cur.execute.call_args_list]
+        assert len(executed) == 1 and "SELECT id" in executed[0]
+        conn.commit.assert_not_called()
+
+    def test_set_active_avatar_refuses_unapproved(self):
+        """The approval gate (issue #744): activation is no longer reachable from 'succeeded'
+        alone, and refusing must leave the current active avatar untouched."""
+        conn, cur = _conn(rowcount=1, fetch_one={"id": 11, "approval_status": "pending"})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_active_avatar
+            assert set_active_avatar(3, 11) is False
         executed = [c[0][0] for c in cur.execute.call_args_list]
         assert len(executed) == 1 and "SELECT id" in executed[0]
         conn.commit.assert_not_called()
@@ -97,6 +108,13 @@ class TestAvatarTrainings:
             result = get_avatar_trainings(3)
         assert result == [{"id": 1, "training_id": "t1", "model_ref": "m",
                            "trigger_word": "TOK", "status": "succeeded", "is_active": True,
+                           "gender_presentation": None, "age_band": None,
+                           "attributes_confirmed_at": None,
+                           # A row that predates the migration reads as un-approved, which is the
+                           # safe direction: it cannot be activated until the user reviews it.
+                           "approval_status": "pending", "approved_at": None,
+                           "sample_paths": [], "samples_generated_at": None,
+                           "sample_regen_count": 0,
                            "created_at": created.isoformat(), "updated_at": None}]
 
     def test_get_avatar_trainings_error_returns_empty(self):


### PR DESCRIPTION
Phase 2 items 2–4 of #548 — the scope that vanished when PR #597 shipped Phase 1 + item 1 and the follow-up was never filed. Spec: `docs/AVATAR_FIDELITY_AND_VIDEO_LANGUAGE.md` §4, decisions `3A 4A` (signed off 2026-07-25).

## What this fixes

Two user-visible trust defects. Generated images rendered the wrong gender for the author, and a user could not see what their avatar looked like before it was published on their behalf.

**Likeness (3A — self-declared, never inferred).** The prompt-authoring LLM was told to put "ideally a real person" in frame and given only job title / industry / company — so it invented a subject, gender included, and FLUX rendered those explicit tokens over the LoRA's identity. Users now declare gender presentation and an age band on the avatar row; `utilities/avatar/attributes.py` renders them into ONE canonical clause (`"a man in his 40s"`) that reaches **both** the prompt author (so it never invents a conflicting subject) and the final Replicate prompt beside the trigger word. Nothing reads a photo: an undeclared attribute renders `""`, `prefer-not-to-say` contributes no noun, and an age band alone renders the neutral `"a person in their 40s"`.

Two compounding defects traced in §2.2 go with it: `ratio` now threads through `generate_image_with_avatar()` (the 9:16 source frame for premium avatar video was rendered **square** and then cropped by the video model), and the trigger word only reaches person-bearing scenes — a slide query like "quarterly dashboard metrics" no longer asks the LoRA to insert the user's face into a scene never written to contain a person.

**Preview + approval (4A).** Three fixed scenes (headshot, at-desk, speaking-to-camera) render through the LoRA when a training first reaches `succeeded`, built with the *same* subject clause a production image uses — so what the user approves is what they get. `set_active_avatar()` and the activate endpoint refuse an avatar that is not `approved`; approving requires rendered samples to exist; rejecting also deactivates; new samples reset an earlier verdict (the user approved the images they *saw*).

**Guardrails (4A).** `utilities/avatar/guardrails.resolve_avatar_for()` is the ONE gate, and `None` always means "use base Flux / Pexels". Precedence: `avatar_disabled` (the explicit "don't use my avatar" switch) → `posts.use_avatar` (the compose-time toggle, which was accepted by the API and dropped) → per-content-type opt-ins, default **OFF** → the approval gate. It **fails closed** — a missed avatar render is a less personal image, a wrong one is a synthetic likeness of a real person, published. Avatar renders are C2PA-signed at generation and flag the post, so the caption disclosure covers avatar **images** (carousel slides included), not just video. A base-Flux fallback render claims neither. Sample re-rolls are capped by `AVATAR_SAMPLE_REGEN_MAX` (default 3) on top of the credit ledger.

**SPA.** `Avatars.tsx` gains the sample gallery, Approve / Reject / Regenerate, attribute selects, the guardrail toggles and credit/usage visibility.

## Migration

`V20260731144005__add_avatar_fidelity_and_guardrails.sql` — additive only, no drops, no backfill:
- `avatar_trainings`: `gender_presentation`, `age_band`, `attributes_confirmed_at`, `approval_status ENUM(pending|approved|rejected) DEFAULT 'pending'`, `approved_at`, `sample_paths`, `samples_generated_at`, `sample_regen_count`
- `users`: `avatar_disabled`, `avatar_use_post_image`, `avatar_use_carousel`, `avatar_use_video` (all default 0)
- `posts`: `use_avatar` (nullable, three-valued), `avatar_media`

**Behaviour change an operator needs to know:** every guardrail defaults OFF, *including* for the account that already has an active avatar. After deploy that avatar must be previewed, approved, and have a content type opted in before it is used again. That is deliberate — a never-previewed avatar is exactly what shipped the wrong-gender renders — but it means avatar use pauses until the owner walks the flow once.

## Testing

`8396 passed` locally (full unit suite + the avatar integration files). New coverage: `subject_clause` (unset → empty, never inferred), the guardrail precedence + fail-closed posture, sample rendering and its fallback discard, ratio threading, trigger-word gating, the approval gate on both `set_active_avatar()` and the endpoint, the avatar-image disclosure, and every new endpoint. `cqc_lem.utilities.avatar` + `app/run_avatar.py` measure 95% overall (100% on all four new modules; the shortfall is pre-existing lines in `replicate_avatar.py`).

## Scope

**Remaining on #744:** the last acceptance box — *one supervised avatar render on the owner's account as live validation* — is a human step that needs a real Replicate call and a real LinkedIn account, so this PR does **not** carry `Closes #744` and the issue stays open, exactly as its own final acceptance line asks. Everything else on the list is implemented.

Post-deploy validation: on Avatars, declare attributes → wait for the three samples → approve → opt a content type in → generate one post and confirm the likeness and the disclosure line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
