### PR TITLE
feat(affiliate): LEM-generated promotional content with FTC disclosure (closes #770)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -433,6 +433,17 @@ AFFILIATE_REQUIRE_COMPANY_PAGE=False
 AFFILIATE_DISCLOSURE_TEXT=#ad — I get free LinkedIn Engagement Manager trial time when people sign up through my link.
 # Bump when the promotional-content consent copy materially changes.
 AFFILIATE_PROMO_CONSENT_VERSION=v1
+# --- (B) promotional-content GENERATOR (issue #770) ---
+# Kill switch for the writer only. It cannot turn (B) on for anybody: recorded per-user consent is
+# still the only authorisation, so True + nobody consented = nothing written.
+AFFILIATE_PROMO_CONTENT_ENABLED=True
+# 1-in-N of the 70/20/10 governor's promo slots may be claimed by an affiliate post. Affiliate
+# promotion never ADDS a post, so the 10% promo ceiling holds however this is set.
+AFFILIATE_PROMO_EVERY_N_PROMO_SLOTS=3
+# Per-day ceiling on generated promotional pieces, drawn through human_pacing (rest day = none).
+AFFILIATE_PROMO_MAX_PER_DAY=1
+# What the promotional copy may call the product.
+AFFILIATE_PROMO_PRODUCT_NAME=LinkedIn Engagement Manager
 
 # --- Stripe Test (use sk_test_* keys for test mode) ---
 STRIPE_API_KEY=sk_test_your_stripe_secret_key

--- a/docs/affiliate-program.md
+++ b/docs/affiliate-program.md
@@ -1,6 +1,7 @@
 # Affiliate / Ambassador Program
 
-**Issue:** #737 · **Status:** built, owner decision applied (1A 2A 3A) · **Created:** 2026-07-27
+**Issues:** #737 (status + consent + disclosure), #770 (the (B) writer) · **Status:** built, owner
+decision applied (1A 2A 3A) · **Created:** 2026-07-27 · **Updated:** 2026-07-31
 
 LEM's marketing arm is its own users. Every account joins the referral program by default, gets a
 referral link, and earns extra free-trial time for people they bring in who actually get set up.
@@ -33,9 +34,9 @@ shortcut: the account is the user's professional identity.
 Opting out of (A) also withdraws (B) — consent to publish promotion cannot outlive the membership it
 was given for.
 
-> **(B) has consent plumbing and a publish gate, but no generator yet.** Nothing in LEM currently
-> writes promotional content about LEM from a user's account. This issue built the consent record and
-> the compliance gate so that whatever ships next cannot skip them.
+The writer that turns (B) into real content is §2.1 below (issue #770). It reads the same
+`promo_content_allowed()` and nothing else — there is still no env var, cohort or default that can
+authorise promotion for a user who did not.
 
 ## 2. FTC compliance (16 CFR Part 255)
 
@@ -61,6 +62,50 @@ connection that must be disclosed **clearly and conspicuously in the promotional
   Blank means "no disclosure configured", never "no disclosure needed".
 - The gate fails **open** on an unexpected error: this is a compliance check on a rare shape of post,
   not a new way for the whole posting path to break.
+
+## 2.1 The (B) writer — `utilities/marketing/affiliate_content.py` (issue #770)
+
+The ONE place promotional copy about LEM is produced. Four refusals define it:
+
+**It is not a second consent path.** `promo_content_allowed()` is still the only authorisation.
+`AFFILIATE_PROMO_CONTENT_ENABLED` can only turn the writer OFF — with it `True` and nobody
+consented, nothing is written. An unreadable enrollment row reads as *no*.
+
+**It is not an extra post.** An affiliate post **CLAIMS** one of the 70/20/10 governor's promo slots
+(#618) instead of running beside it, so the 10% promo ceiling holds *by construction* rather than by
+a second counter that could drift from the first. Only `content_mix == 'promo'` slots are eligible,
+and only 1 in `AFFILIATE_PROMO_EVERY_N_PROMO_SLOTS` of those (default 3 ⇒ ≤1 post in 30). Every slot
+it does not claim writes the author's own case study exactly as before. Carousels and videos are
+never claimed — the copy is a short text post.
+
+**It is not an author of facts.** The writer's allow-list is `PRODUCT_FACTS` and nothing else — the
+same posture the story bank (#620) takes for personal specifics. It may not state a result, a
+metric, hours saved or a testimonial, because LEM cannot verify any claim about what the tool did for
+*this* user and an invented one is a false endorsement, not merely a bad post. The deterministic slop
+lint (#625) runs on the draft with the same regenerate-then-block budget as everything else; copy
+that cannot be made clean is **blocked**, never shipped.
+
+**It is not silently published.** Two independent guarantees, deliberately not the same one twice:
+
+| Layer | Guarantees |
+|---|---|
+| `apply_disclosure(..., tagged=True)` at generation | the disclosure **is written** |
+| `affiliate_promo` quality gate (`quality_gates.py`) | the post is held **PENDING** for the author's explicit approval — it is the one gate that is not a quality verdict, and re-scoring cannot clear it. Consent to the program is a standing yes to LEM *writing* promotion; it is not a yes to any particular sentence going out over the author's name. Derived from the CONTENT (the referral link, scoped to the post's owner), so a post the user pasted their own link into is held too |
+| `disclosure_report()` in `post_to_linkedin` | an undisclosed affiliate post **never publishes** |
+
+**Pacing.** `human_pacing.ACTION_AFFILIATE_PROMO` draws its own daily budget from
+`AFFILIATE_PROMO_MAX_PER_DAY`, so a rest day writes none. It is deliberately outside
+`ENVELOPE_ACTIONS`: this is a generated POST, and posting is API-driven — it was never gated by the
+engagement envelope. Pacing fails open; consent and the promo slot are the hard limits and neither
+lives in Redis.
+
+**Why a module of its own, given "no parallel per-content-type prompt helpers".** It draws voice,
+mix directive, artifact-CTA policy, style and the slop lint from the shared core rather than
+re-implementing them; what is local is the compliance shape (the fact allow-list, the verbatim link
+and disclosure lines), which has legal teeth and belongs next to the rest of the program's policy.
+
+**Surfaces.** Post only. A feed COMMENT promoting LEM under someone else's post, and a DM pitching
+LEM to the author's connections, are both a different risk class and neither ships here.
 
 ## 3. Reward mechanics
 
@@ -137,6 +182,9 @@ never wrote.
   (`V20260727191347__add_affiliate_program.sql`). Enums live in `db.py` (`AffiliateStatus`,
   `ReferralStatus`, `AffiliateRewardKind`).
 - **Policy + orchestration** — `utilities/marketing/affiliate.py` (the ONE module).
+- **(B) writer** — `utilities/marketing/affiliate_content.py`, claimed from
+  `run_content_plan.create_content` on a promo slot; held by the `affiliate_promo` gate in
+  `quality_gates.py` / `evaluate_post_gates`.
 - **API** — `GET /user/affiliate`, `POST /user/affiliate/status`,
   `POST /user/affiliate/promo-consent`, `POST /user/affiliate/notice`.
 - **Signup** — `api/main.py::_start_affiliate_membership` attributes the referral, then enrols.
@@ -159,8 +207,16 @@ rather than a punishment.
 `observability.track_affiliate_event` emits `affiliate_enrolled`, `affiliate_opted_out`,
 `affiliate_promo_consent`, `affiliate_referral_attributed`, `affiliate_referral_rejected`,
 `affiliate_referral_converted`, `affiliate_reward_granted`, `affiliate_reward_revoked`,
-`affiliate_disclosure_blocked`. The SPA adds `referral_link_copied` and
+`affiliate_disclosure_blocked`, plus the (B) writer's own three: `affiliate_promo_generated`,
+`affiliate_promo_published`, `affiliate_promo_blocked`. The SPA adds `referral_link_copied` and
 `affiliate_notice_acknowledged`.
+
+`affiliate_promo_blocked` (generation could not produce compliant copy) and
+`affiliate_disclosure_blocked` (the publish gate caught content that arrived undisclosed) are
+**never summed** — they are two different failures, and one piece of content can fire both.
+Declining to write at all (no consent, not this slot, paced out) is deliberately NOT an event: a
+refusal series that fires nine times out of ten tells nobody anything. `generated` vs `published` is
+the read that matters — the gap between them is promotional copy the author chose not to approve.
 
 These are **not** funnel events on purpose: the acquisition funnel is one ordered path per person,
 and an affiliate event is about the **referrer**, not about the person moving through the funnel.
@@ -180,6 +236,10 @@ Inbound referral traffic is already visible on the #658 **LEM Channels** dashboa
 | `AFFILIATE_REQUIRE_COMPANY_PAGE` | `False` | Restrict eligibility to accounts with a company page. Evaluated live. |
 | `AFFILIATE_DISCLOSURE_TEXT` | `#ad — I get free …` | The FTC disclosure. **Blank blocks affiliate content entirely.** |
 | `AFFILIATE_PROMO_CONSENT_VERSION` | `v1` | Bump when the (B) consent copy materially changes. |
+| `AFFILIATE_PROMO_CONTENT_ENABLED` | `True` | Kill switch for the (B) **writer**. Cannot turn (B) on for anybody. |
+| `AFFILIATE_PROMO_EVERY_N_PROMO_SLOTS` | `3` | 1-in-N promo slots may be claimed by an affiliate post. |
+| `AFFILIATE_PROMO_MAX_PER_DAY` | `1` | Per-day ceiling on generated promotional pieces, drawn through human pacing. |
+| `AFFILIATE_PROMO_PRODUCT_NAME` | `LinkedIn Engagement Manager` | What the copy may call the product. |
 
 `BRAND_SIGNUP_URL` must be set for referral links to exist at all; with it unset, `referral_url` is
 empty and the SPA says so rather than showing a broken link.

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -6443,6 +6443,18 @@ def post_to_linkedin(self, user_id: int, post_id: int):
         # Update DB with status=posted
         update_db_post_status(post_id, PostStatus.POSTED)
 
+        # Affiliate promotion that actually reached an audience (issue #770). Emitted from the
+        # publish path rather than the writer, because "generated" and "published" are genuinely
+        # different numbers — a promo post the author never approved is one of them and not the
+        # other, and that gap is the honest read on whether the program is working.
+        try:
+            from cqc_lem.utilities.marketing.affiliate_content import record_promo_published
+            record_promo_published(user_id, post_id, content,
+                                   first_comment_links=first_comment_links, post_url=post_url)
+        except Exception as e:
+            log_warning("Could not track affiliate promo publish", exc=e, user_id=user_id,
+                        post_id=post_id)
+
         # Only now — with the post actually live — persist the link split. Keeps the stored post in
         # sync with what published (the preview, the seed comment's grounding, and the post history
         # all read this back) without stranding the post in a link-held-back state if sharing failed.

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -1052,6 +1052,11 @@ def _is_affiliate_promo(content: str, post_id: Optional[int]) -> bool:
         from cqc_lem.utilities.db import get_post_user_id
         from cqc_lem.utilities.marketing.affiliate import is_affiliate_content
         owner = get_post_user_id(post_id) if post_id is not None else None
+        # An owner we could not resolve must NOT fall through to `user_id=None`, which matches ANY
+        # member's referral code: that would hold somebody's post with "this is your paid
+        # endorsement" over a link that is not theirs.
+        if owner is None:
+            return False
         return is_affiliate_content(content, user_id=owner)
     except Exception as e:
         myprint(f"Could not evaluate affiliate promotion for post {post_id}: {e}")

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -37,7 +37,8 @@ from cqc_lem.utilities.db import get_story_bank_entries, record_story_bank_use
 from cqc_lem.utilities.quality_gates import (authenticity_finding, similarity_finding,
                                              focus_finding, missing_asset_finding,
                                              meeting_cta_finding, fact_grounding_finding,
-                                             slop_finding, demoting_findings)
+                                             slop_finding, affiliate_promo_finding,
+                                             demoting_findings)
 from cqc_lem.utilities.ai.content_framework import select_blueprint, history_avoidance_directive, \
     find_most_similar, post_similarity_max, has_first_person_proof, shape_for_dwell, dwell_report, \
     dwell_score_min, requires_fact_anchor, fact_grounding_report, fact_retry_directive, \
@@ -361,12 +362,50 @@ def create_content(user_id: int, post_type: str, stage: str, post_id: int = None
         # native PDF instead of a multi-image share (see share_document_on_linkedin).
         content = create_carousel_content(user_id, stage, post_id)
     else:
-        content = create_text_post(user_id, stage, post_id=post_id, content_mix=content_mix,
-                                   day_weekday=day_weekday)
+        # Affiliate promotion (issue #770) CLAIMS this promo slot rather than adding a post beside
+        # it, which is what keeps LEM promotion inside the same 10% ceiling the author's own case
+        # studies live under. It writes only for a user who recorded (B) consent, on 1 in N promo
+        # slots; every other slot falls through to the ordinary case-study post unchanged.
+        content = _affiliate_promo_content(user_id, post_id, content_mix)
+        if content is None:
+            content = create_text_post(user_id, stage, post_id=post_id, content_mix=content_mix,
+                                       day_weekday=day_weekday)
         if content:
             content = content.strip()
 
     return content, video_url
+
+
+def _affiliate_promo_content(user_id: int, post_id: Optional[int],
+                             content_mix: Optional[str]) -> Optional[str]:
+    """The LEM-promotional post for this slot, or None to write the author's own post instead.
+
+    Never raises: the (B) writer is an opt-in extra, and a user who consented to it must not lose
+    the post they would otherwise have had because it failed."""
+    try:
+        from cqc_lem.utilities.marketing.affiliate_content import (claims_promo_slot,
+                                                                   generate_promo_post)
+        # Asked BEFORE the prefs/synthesis reads: the answer is no on almost every post, and a
+        # voice-synthesis read per planned post is a real cost to pay for an answer of "not this one".
+        if not claims_promo_slot(user_id, post_id, content_mix):
+            return None
+        return generate_promo_post(user_id, post_id=post_id, content_mix=content_mix,
+                                   prefs=_engagement_prefs_or_empty(user_id),
+                                   profile_synthesis=_profile_synthesis_or_none(user_id))
+    except Exception as e:
+        log_warning("Affiliate promo generation failed — writing the ordinary promo post instead",
+                    exc=e, user_id=user_id, post_id=post_id, task_name="create_content")
+        return None
+
+
+def _profile_synthesis_or_none(user_id: int) -> Optional[str]:
+    """The user's cached voice synthesis with no Selenium fallback — promotional copy is worth
+    matching the author's voice, never worth a browser session."""
+    try:
+        return get_or_create_profile_synthesis(user_id, load_profile_for_user(user_id))
+    except Exception as e:
+        myprint(f"No profile synthesis for user {user_id}: {e}")
+        return None
 
 
 def _fact_anchors(user_id: int) -> list:
@@ -1004,6 +1043,21 @@ def _score_and_persist_authenticity(user_id: int, post_id: int, content: str,
         myprint(f"Authenticity scoring skipped for post {post_id}: {e}")
 
 
+def _is_affiliate_promo(content: str, post_id: Optional[int]) -> bool:
+    """Whether this draft is affiliate promotion — scoped to the post's OWN author's referral code,
+    the same way the publish gate grades it, so a post that quotes somebody else's link is not held
+    as if it were this author's paid endorsement. Unreadable ownership reads as 'not affiliate': the
+    hold is a review courtesy, and the publish gate is what actually enforces the disclosure."""
+    try:
+        from cqc_lem.utilities.db import get_post_user_id
+        from cqc_lem.utilities.marketing.affiliate import is_affiliate_content
+        owner = get_post_user_id(post_id) if post_id is not None else None
+        return is_affiliate_content(content, user_id=owner)
+    except Exception as e:
+        myprint(f"Could not evaluate affiliate promotion for post {post_id}: {e}")
+        return False
+
+
 def evaluate_post_gates(post_id: int, content: str, post_type: Union[PostType, str, None],
                         video_url: Optional[str] = None,
                         engagement_prefs: Optional[dict] = None,
@@ -1038,6 +1092,13 @@ def evaluate_post_gates(post_id: int, content: str, post_type: Union[PostType, s
     # create_text_post only covers text posts, and a user can edit a meeting ask back in.
     if content and contains_meeting_ask(content):
         findings.append(meeting_cta_finding(meeting_ask_excerpts(content)))
+
+    # Affiliate promotion (issue #770): a paid endorsement under the author's name is never
+    # auto-scheduled, however well it scores. Derived from the CONTENT (the referral link), not from
+    # which generator wrote it, so a post the user pasted their own link into is held too.
+    if content and _is_affiliate_promo(content, post_id):
+        from cqc_lem.utilities.marketing.affiliate import disclosure_text
+        findings.append(affiliate_promo_finding(disclosure_text()))
 
     # Deterministic AI-slop lint (issue #625 / D1): the regeneration in `_review_generated_post`
     # gets first crack at these; anything still standing here HOLDS the post, with the exact

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -252,6 +252,23 @@ AFFILIATE_DISCLOSURE_TEXT = get_constant_from_env(
 # Bumped whenever the (B) consent copy materially changes, so a stored consent can be told apart
 # from consent to a different ask.
 AFFILIATE_PROMO_CONSENT_VERSION = get_constant_from_env('AFFILIATE_PROMO_CONSENT_VERSION', default_value='v1')
+# The (B) GENERATOR (issue #770). This is a kill switch for the writer, NOT a way to turn (B) on:
+# recorded per-user consent is still the only thing that authorises promotional content, so with
+# this True and nobody consented, nothing is written. It exists so ops can stop the writer without
+# revoking anybody's consent.
+AFFILIATE_PROMO_CONTENT_ENABLED = isTrue(get_constant_from_env('AFFILIATE_PROMO_CONTENT_ENABLED', default_value='True'))
+# How many of the 70/20/10 governor's promo slots an affiliate post may claim: 1 in N. Affiliate
+# promotion never ADDS a post — it claims a slot the promo cadence already allowed — so the 10%
+# ceiling holds by construction and this only makes LEM promotion rarer than the author's own
+# case studies. 1 = every promo slot (still ≤10% of posts).
+AFFILIATE_PROMO_EVERY_N_PROMO_SLOTS = int(get_constant_from_env('AFFILIATE_PROMO_EVERY_N_PROMO_SLOTS', default_value='3'))
+# Per-day ceiling on generated promotional pieces, drawn through human_pacing like every other
+# per-day cap (so a pacing rest day writes none).
+AFFILIATE_PROMO_MAX_PER_DAY = int(get_constant_from_env('AFFILIATE_PROMO_MAX_PER_DAY', default_value='1'))
+# What the promotional copy is allowed to call the product. The writer may state NOTHING about it
+# that is not in affiliate_content.PRODUCT_FACTS, and this is the name those facts are about.
+AFFILIATE_PROMO_PRODUCT_NAME = get_constant_from_env('AFFILIATE_PROMO_PRODUCT_NAME',
+                                                     default_value='LinkedIn Engagement Manager')
 
 # Unit-economics inputs for the margin report (docs/cost-performance-margin-plan.md §C.1). Monthly
 # tier prices mirror the SPA pricing table — override per environment instead of editing code so a

--- a/src/cqc_lem/utilities/human_pacing.py
+++ b/src/cqc_lem/utilities/human_pacing.py
@@ -56,6 +56,11 @@ ACTION_INVITE = "invite"
 # envelope (they `record_action` under ACTION_INVITE, which is also their harder ceiling), they just
 # must not enlarge it with a second cap of their own.
 ACTION_COMPANY_INVITE = "company_invite"
+# Affiliate promotional CONTENT (issue #770). Deliberately outside ENGAGEMENT_ACTIONS/ENVELOPE_ACTIONS:
+# it is a generated POST, and posting is API-driven — it was never gated by the engagement envelope
+# (the same reason #629's suppression pause covers engagement only). It draws its own daily budget
+# purely so the writer inherits the rest-day and variable-volume behaviour every other lane has.
+ACTION_AFFILIATE_PROMO = "affiliate_promo"
 ENGAGEMENT_ACTIONS = (ACTION_COMMENT, ACTION_REPLY, ACTION_DM, ACTION_INVITE)
 
 # Which preference key caps each lane.

--- a/src/cqc_lem/utilities/marketing/affiliate_content.py
+++ b/src/cqc_lem/utilities/marketing/affiliate_content.py
@@ -1,0 +1,360 @@
+"""The (B) writer: LEM-promotional content published from the user's own account (issue #770).
+
+`affiliate.py` decided *whether* promotion is allowed and *what* a compliant piece looks like; #750
+built all of that and deliberately stopped there — a consent record and a publish gate with nothing
+upstream of them. This module is that upstream writer, and it is the ONE place promotional copy
+about LEM is produced.
+
+Four things it refuses to be, each of which is the whole point:
+
+1. **Not a second consent path.** `promo_content_allowed()` is still the only authorisation, read
+   off the stored enrollment row. `AFFILIATE_PROMO_CONTENT_ENABLED` can only ever turn the writer
+   OFF; there is no env var, cohort or default that turns promotion ON for a user who did not.
+2. **Not an extra post.** An affiliate post CLAIMS one of the 70/20/10 governor's promo slots
+   (issue #618) instead of adding a post beside it, so the 10% promo ceiling holds by construction
+   rather than by a second counter that could drift from the first. On a promo slot it does not
+   claim, the author's own case-study post is written exactly as before.
+3. **Not an author of facts.** The writer's allow-list is `PRODUCT_FACTS` and nothing else — the
+   same posture the story bank (#620) takes for personal specifics. It may not state a result, a
+   metric, a time saved or a testimonial, because LEM cannot verify any claim about what the tool
+   did for this user, and an invented one is a false endorsement rather than a bad post.
+4. **Not silently published.** The copy leaves here already disclosed (`apply_disclosure`, tagged),
+   and the post is held for the author's explicit approval by the `affiliate_promo` quality gate.
+   The publish-time `disclosure_report()` gate in `post_to_linkedin` stays the backstop it was
+   designed to be — belt AND braces, because the two failure modes are different: this module
+   guarantees the disclosure is written, the gate guarantees an undisclosed one never publishes.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from cqc_lem.utilities.env_constants import (AFFILIATE_PROMO_CONTENT_ENABLED,
+                                             AFFILIATE_PROMO_EVERY_N_PROMO_SLOTS,
+                                             AFFILIATE_PROMO_MAX_PER_DAY,
+                                             AFFILIATE_PROMO_PRODUCT_NAME)
+from cqc_lem.utilities.marketing.affiliate import (apply_disclosure, disclosure_report,
+                                                   disclosure_text, is_affiliate_content,
+                                                   link_for_user, program_enabled,
+                                                   promo_content_allowed)
+
+# Why the writer declined or refused. Only the last three (`_blocked`) are events: they mean copy
+# that was supposed to be compliant could not be made so. Declining to write — no consent, not this
+# slot, paced out — is the common, healthy case, and a refusal series that fires nine times out of
+# ten tells nobody anything.
+REASON_DISABLED = "generator_disabled"
+REASON_NO_CONSENT = "no_promo_consent"
+REASON_NO_LINK = "no_referral_link"
+REASON_NO_DISCLOSURE_CONFIGURED = "no_disclosure_configured"
+REASON_NOT_PROMO_SLOT = "not_promo_slot"
+REASON_NOT_SELECTED = "not_selected"
+REASON_PACED_OUT = "paced_out"
+REASON_EMPTY_DRAFT = "empty_draft"
+REASON_SLOP = "slop_lint"
+REASON_UNDISCLOSED = "undisclosed_draft"
+
+# The ONLY claims the writer may make about the product. Everything here is a description of what
+# LEM does — checkable against the product itself — and nothing here is an outcome, because an
+# outcome would be a claim about this author's results that LEM has no way to verify.
+PRODUCT_FACTS = (
+    "It plans a month of LinkedIn posts, writes the drafts, and schedules them around the hours the "
+    "author's own audience is active.",
+    "It leaves comments and replies on the author's behalf inside limits the author sets — how many "
+    "a day, which topics, which people.",
+    "Everything it writes can be reviewed and edited before it publishes.",
+    "It is a paid tool with a free trial.",
+)
+
+_SYSTEM_PROMPT = (
+    "You write ONE short LinkedIn post in the author's own voice. The post recommends a tool the "
+    "author uses and links to it. You are not writing an advertisement: you are writing the way "
+    "somebody mentions a tool that solved a chore for them, and then gets out of the way.\n\n"
+    "Absolute rules — breaking any of them makes the post unusable:\n"
+    "- State NOTHING about the product beyond the facts you are given. No results, no metrics, no "
+    "percentages, no hours saved, no follower or engagement numbers, no 'since I started using it'. "
+    "You do not know what it did for this author and you must not imply that you do.\n"
+    "- No urgency, no scarcity, no discount, no 'limited spots', no hard sell.\n"
+    "- Never ask the reader for a call, demo, meeting or DM.\n"
+    "- Do not thank the reader, do not open with a rhetorical question, do not close with "
+    "'thoughts?'.\n"
+    "- Reproduce the referral link and the disclosure line EXACTLY as given, each on its own line, "
+    "once. Do not shorten, re-word or decorate either one.\n"
+    "Return the post body only — no title, no preamble, no commentary."
+)
+
+
+def generator_enabled() -> bool:
+    """Whether this deployment runs the (B) writer at all. Off restores the pre-#770 product: the
+    consent toggle still exists and still records consent, nothing writes against it."""
+    return bool(AFFILIATE_PROMO_CONTENT_ENABLED)
+
+
+def promo_slot_cadence() -> int:
+    """How many promo slots pass per affiliate one. Clamped at 1 — a zero or negative setting must
+    never read as "no cadence, take every slot" via a modulo that divides by zero."""
+    try:
+        return max(1, int(AFFILIATE_PROMO_EVERY_N_PROMO_SLOTS))
+    except (TypeError, ValueError):
+        return 3
+
+
+def max_promo_per_day() -> int:
+    return max(0, int(AFFILIATE_PROMO_MAX_PER_DAY or 0))
+
+
+def product_name() -> str:
+    return str(AFFILIATE_PROMO_PRODUCT_NAME or "").strip() or "LinkedIn Engagement Manager"
+
+
+def promo_allowed_for_user(user_id: int) -> bool:
+    """Whether THIS user has authorised promotional content — the stored consent, read through the
+    one gate that answers it. An unreadable enrollment row is a no: the failure mode of guessing is
+    publishing an ad on somebody's professional identity."""
+    from cqc_lem.utilities.db import get_affiliate_enrollment
+    from cqc_lem.utilities.logger import log_warning
+    try:
+        return promo_content_allowed(get_affiliate_enrollment(user_id))
+    except Exception as e:
+        log_warning("Could not read affiliate consent — writing no promotional content", exc=e,
+                    user_id=user_id)
+        return False
+
+
+def _selected_by_cadence(post_id: Optional[int]) -> bool:
+    """Deterministic 1-in-N over promo slots, keyed on a stable per-post integer exactly like
+    `should_include_lead_magnet_cta` — so the same post always makes the same choice and a retry
+    cannot turn an ordinary promo slot into an affiliate one."""
+    if post_id is None:
+        return False
+    n = promo_slot_cadence()
+    return n == 1 or int(post_id) % n == 0
+
+
+def _within_daily_pace(user_id: int) -> bool:
+    """Whether today's paced allowance has room for another promotional piece.
+
+    Fails OPEN on a pacing error, like every other reader of the engine: the hard limits on this
+    path are consent and the promo slot itself, and neither of them lives in Redis."""
+    from cqc_lem.utilities.human_pacing import (ACTION_AFFILIATE_PROMO, actions_used_today,
+                                                daily_budget)
+    from cqc_lem.utilities.logger import log_warning
+    cap = max_promo_per_day()
+    if cap <= 0:
+        return False
+    try:
+        budget = daily_budget(user_id, ACTION_AFFILIATE_PROMO, cap)
+        return actions_used_today(user_id, ACTION_AFFILIATE_PROMO) < budget
+    except Exception as e:
+        log_warning("Could not read the affiliate promo pacing budget — allowing this one", exc=e,
+                    user_id=user_id)
+        return True
+
+
+def promo_slot_verdict(user_id: int, post_id: Optional[int], content_mix: Optional[str]) -> str:
+    """Whether an affiliate post may claim THIS planned slot, and why not when it may not.
+
+    Ordered cheapest-first so the overwhelmingly common answer (this is not a promo slot) costs no
+    DB read and no Redis round trip."""
+    from cqc_lem.utilities.ai.content_alignment import ContentMix, normalize_content_mix
+    if not program_enabled() or not generator_enabled():
+        return REASON_DISABLED
+    if normalize_content_mix(content_mix) != ContentMix.PROMO.value:
+        return REASON_NOT_PROMO_SLOT
+    if not _selected_by_cadence(post_id):
+        return REASON_NOT_SELECTED
+    if not disclosure_text():
+        return REASON_NO_DISCLOSURE_CONFIGURED
+    if not promo_allowed_for_user(user_id):
+        return REASON_NO_CONSENT
+    if not link_for_user(user_id):
+        return REASON_NO_LINK
+    if not _within_daily_pace(user_id):
+        return REASON_PACED_OUT
+    return ""
+
+
+def claims_promo_slot(user_id: int, post_id: Optional[int], content_mix: Optional[str]) -> bool:
+    """True when an affiliate post takes this promo slot instead of the author's own case study."""
+    return promo_slot_verdict(user_id, post_id, content_mix) == ""
+
+
+def _track(event: str, user_id: int, **extra) -> None:
+    from cqc_lem.utilities.observability import track_affiliate_event
+    track_affiliate_event(event, user_id=user_id, **extra)
+
+
+def _blocked(user_id: int, post_id: Optional[int], reason: str) -> None:
+    """A draft that was supposed to be compliant and is not — WARNING + an event."""
+    from cqc_lem.utilities.logger import log_warning
+    from cqc_lem.utilities.observability import AFFILIATE_PROMO_BLOCKED
+    log_warning(f"Affiliate promo content blocked at generation ({reason})", user_id=user_id,
+                post_id=post_id, task_name="generate_promo_post")
+    _track(AFFILIATE_PROMO_BLOCKED, user_id, post_id=post_id, reason=reason)
+
+
+def _declined(user_id: int, post_id: Optional[int], reason: str) -> None:
+    """Not writing is the normal answer, so it is DEBUG, not a warning — a user who never consented
+    would otherwise emit one warning per planned promo slot forever. The exception is a deployment
+    that consented users cannot publish from at all: that one is a misconfiguration."""
+    from cqc_lem.utilities.logger import log_debug, log_warning
+    if reason == REASON_NO_DISCLOSURE_CONFIGURED:
+        log_warning("Affiliate promo content skipped — AFFILIATE_DISCLOSURE_TEXT is blank, so this "
+                    "deployment cannot publish affiliate content at all",
+                    user_id=user_id, post_id=post_id, task_name="generate_promo_post")
+        return
+    log_debug(f"No affiliate promo content for this slot ({reason})", user_id=user_id,
+              post_id=post_id, task_name="generate_promo_post")
+
+
+def _prompt(prefs: Optional[dict], profile_synthesis: Optional[str], referral_link: str) -> str:
+    from cqc_lem.utilities.ai.content_alignment import ARTIFACT_CTA_POLICY, style_directive
+    facts = "\n".join(f"- {fact}" for fact in PRODUCT_FACTS)
+    voice = (profile_synthesis or "").strip()
+    parts = [
+        f"Write the post as me. The tool is {product_name()}.",
+        "\nThe ONLY things you may say about the tool (say fewer of them if the post reads better "
+        f"for it, but never anything beyond them):\n{facts}",
+        "\nSay in your own words why a professional who is trying to stay visible on LinkedIn "
+        "without spending an hour a day on it might want to look at it. Keep it to a few short "
+        "paragraphs. Be plain. If the reader would not care, do not write it.",
+        f"\nInclude this link on its own line, exactly once, exactly as written:\n{referral_link}",
+        f"\nInclude this disclosure on its own line, exactly as written:\n{disclosure_text()}",
+    ]
+    if voice:
+        parts.append("\nMy voice — match how this reads, do not copy phrases out of it and do not "
+                     f"state anything it does not say about me:\n{voice[:800]}")
+    # The promo-slot mix directive (`mix_directive`) is deliberately NOT injected: it demands a case
+    # study built on "one specific real outcome number", which is the one thing this writer must
+    # never state. The half of the promo policy that DOES apply is the CTA ban, taken directly.
+    parts.append("\n- " + ARTIFACT_CTA_POLICY)
+    parts.append("\n- Frame it explicitly no-pressure: it may not be a fit for everyone, and the "
+                 "reader owes you nothing for reading.")
+    parts.append(style_directive(prefs, "post"))
+    return "\n".join(p for p in parts if p)
+
+
+def _draft(user_id: int, prompt: str, retry_directive: str = "") -> Optional[str]:
+    from cqc_lem.utilities.ai.ai_helper import _call_llm
+    from cqc_lem.utilities.logger import log_warning
+    from cqc_lem.utilities.observability import FEATURE_CONTENT
+    try:
+        response = _call_llm(
+            model="lem-medium",
+            messages=[{"role": "system", "content": _SYSTEM_PROMPT},
+                      {"role": "user", "content": prompt + (retry_directive or "")}],
+            temperature=0.6,
+            _track_user_id=user_id,
+            _track_feature=FEATURE_CONTENT,
+        )
+        return (response.choices[0].message.content or "").strip() or None
+    except Exception as e:
+        log_warning("Affiliate promo generation call failed", exc=e, user_id=user_id)
+        return None
+
+
+def _finalize(user_id: int, draft: str, referral_link: str) -> str:
+    """Everything that must be true of the copy regardless of what the model returned: LinkedIn-safe
+    punctuation, the referral link present (it is what earns the trial time and what the publish
+    gate grades on), and the disclosure stamped."""
+    from cqc_lem.utilities.linkedin_formatter import sanitize_for_linkedin
+    body = sanitize_for_linkedin(draft).strip()
+    if referral_link and referral_link not in body:
+        body = f"{body}\n\n{referral_link}"
+    return apply_disclosure(body, user_id=user_id, tagged=True).strip()
+
+
+def generate_promo_post(user_id: int, post_id: Optional[int] = None,
+                        content_mix: Optional[str] = None,
+                        prefs: Optional[dict] = None,
+                        profile_synthesis: Optional[str] = None) -> Optional[str]:
+    """The promotional post for one claimed promo slot, already disclosed — or None.
+
+    None is the normal answer and always means "write the ordinary post instead": the user has not
+    consented, this slot is not an affiliate one, the day's pace is spent, or no draft could be made
+    compliant. The model call and every gate read fail CLOSED to None rather than propagating, and
+    the content-plan caller contains the rest — a user who opted into (B) must never lose the post
+    they would otherwise have had because the promotional one failed."""
+    from cqc_lem.utilities.ai.slop_lint import (lint_report, slop_max_attempts, slop_retry_directive,
+                                                violation_reasons)
+    from cqc_lem.utilities.logger import log_info, log_warning
+    from cqc_lem.utilities.observability import AFFILIATE_PROMO_GENERATED
+
+    verdict = promo_slot_verdict(user_id, post_id, content_mix)
+    if verdict:
+        _declined(user_id, post_id, verdict)
+        return None
+
+    referral_link = link_for_user(user_id)
+    prompt = _prompt(prefs, profile_synthesis, referral_link)
+
+    content, retry_directive, attempts = None, "", 0
+    for _ in range(max(1, slop_max_attempts())):
+        attempts += 1
+        draft = _draft(user_id, prompt, retry_directive)
+        if not draft:
+            _blocked(user_id, post_id, REASON_EMPTY_DRAFT)
+            return None
+        candidate = _finalize(user_id, draft, referral_link)
+        report = lint_report(candidate, "post")
+        if report["passes"]:
+            content = candidate
+            break
+        log_warning("Affiliate promo draft tripped the AI-slop lint — regenerating: "
+                    + "; ".join(violation_reasons(report["hard"])),
+                    user_id=user_id, post_id=post_id, task_name="generate_promo_post")
+        retry_directive = slop_retry_directive(report["hard"])
+
+    if not content:
+        _blocked(user_id, post_id, REASON_SLOP)
+        return None
+
+    # The one check that must not be left to the publish gate: if the copy somehow arrived without a
+    # disclosure it is refused HERE, so the gate never has to decide about content we wrote.
+    if not disclosure_report(content, user_id=user_id, tagged=True).get("ok"):
+        _blocked(user_id, post_id, REASON_UNDISCLOSED)
+        return None
+
+    _record_generated(user_id)
+    log_info("Generated affiliate promotional post (held for the author's approval)",
+             user_id=user_id, post_id=post_id, task_name="generate_promo_post")
+    _track(AFFILIATE_PROMO_GENERATED, user_id, post_id=post_id, surface="post",
+           attempts=attempts, chars=len(content))
+    return content
+
+
+def _record_generated(user_id: int) -> None:
+    from cqc_lem.utilities.human_pacing import ACTION_AFFILIATE_PROMO, record_action
+    from cqc_lem.utilities.logger import log_warning
+    try:
+        record_action(user_id, ACTION_AFFILIATE_PROMO)
+    except Exception as e:
+        log_warning("Could not record the affiliate promo action for pacing", exc=e, user_id=user_id)
+
+
+def is_affiliate_post(content: Optional[str], user_id: Optional[int] = None,
+                      first_comment_links: Optional[list] = None) -> bool:
+    """Whether a finished post is affiliate promotion — graded on the body AND any link the #392
+    split carried into the first comment, the same text the publish gate grades."""
+    graded = "\n".join([content or "", *(first_comment_links or [])])
+    return is_affiliate_content(graded, user_id=user_id)
+
+
+def record_promo_published(user_id: int, post_id: int, content: Optional[str],
+                           first_comment_links: Optional[list] = None,
+                           post_url: Optional[str] = None) -> bool:
+    """Emit `affiliate_promo_published` for a post that just went live carrying the user's referral
+    link. Best-effort and never raises — the post is already published; analytics cannot un-publish
+    it and must not turn a successful share into a task failure."""
+    from cqc_lem.utilities.logger import log_warning
+    from cqc_lem.utilities.observability import AFFILIATE_PROMO_PUBLISHED
+    try:
+        if not is_affiliate_post(content, user_id=user_id, first_comment_links=first_comment_links):
+            return False
+        _track(AFFILIATE_PROMO_PUBLISHED, user_id, post_id=post_id, surface="post",
+               post_url=post_url,
+               link_in_first_comment=bool(first_comment_links))
+        return True
+    except Exception as e:
+        log_warning("Could not track affiliate promo publish", exc=e, user_id=user_id,
+                    post_id=post_id)
+        return False

--- a/src/cqc_lem/utilities/marketing/affiliate_content.py
+++ b/src/cqc_lem/utilities/marketing/affiliate_content.py
@@ -27,6 +27,7 @@ Four things it refuses to be, each of which is the whole point:
 
 from __future__ import annotations
 
+import re
 from typing import Optional
 
 from cqc_lem.utilities.env_constants import (AFFILIATE_PROMO_CONTENT_ENABLED,
@@ -174,8 +175,17 @@ def promo_slot_verdict(user_id: int, post_id: Optional[int], content_mix: Option
 
 
 def claims_promo_slot(user_id: int, post_id: Optional[int], content_mix: Optional[str]) -> bool:
-    """True when an affiliate post takes this promo slot instead of the author's own case study."""
-    return promo_slot_verdict(user_id, post_id, content_mix) == ""
+    """True when an affiliate post takes this promo slot instead of the author's own case study.
+
+    Reports the refusal HERE rather than leaving it to `generate_promo_post`: this is the call the
+    content plan actually makes, and it short-circuits the writer entirely — so a deployment whose
+    consented users can never publish (no disclosure sentence configured) would otherwise say so
+    nowhere at all."""
+    verdict = promo_slot_verdict(user_id, post_id, content_mix)
+    if verdict:
+        _declined(user_id, post_id, verdict)
+        return False
+    return True
 
 
 def _track(event: str, user_id: int, **extra) -> None:
@@ -252,12 +262,35 @@ def _draft(user_id: int, prompt: str, retry_directive: str = "") -> Optional[str
         return None
 
 
+_URL_RE = re.compile(r"https?://[^\s<>\"')\]]+")
+
+
+def _restore_referral_link(body: str, referral_link: str) -> str:
+    """Put the exact referral URL back over any copy the markdown pass mangled.
+
+    `sanitize_for_linkedin` strips markdown italics, and `_word_` is precisely the shape of a UTM'd
+    referral link: `utm_source=…&utm_medium=…` comes back as `utmsource=…&utmmedium=…`. That is a
+    dead link on the one URL in the post whose whole job is attribution — and because the mangled
+    copy no longer matches, the caller would append a second, clean one beside it and publish both.
+    Matched on the underscore-free form so the repair works wherever in the body the link landed."""
+    if not referral_link:
+        return body
+    wanted = referral_link.replace("_", "")
+
+    def _repair(match) -> str:
+        url = match.group(0)
+        core = url.rstrip(".,;:!?)]")
+        return referral_link + url[len(core):] if core.replace("_", "") == wanted else url
+
+    return _URL_RE.sub(_repair, body)
+
+
 def _finalize(user_id: int, draft: str, referral_link: str) -> str:
     """Everything that must be true of the copy regardless of what the model returned: LinkedIn-safe
-    punctuation, the referral link present (it is what earns the trial time and what the publish
-    gate grades on), and the disclosure stamped."""
+    punctuation, the referral link present AND intact (it is what earns the trial time and what the
+    publish gate grades on), and the disclosure stamped."""
     from cqc_lem.utilities.linkedin_formatter import sanitize_for_linkedin
-    body = sanitize_for_linkedin(draft).strip()
+    body = _restore_referral_link(sanitize_for_linkedin(draft).strip(), referral_link)
     if referral_link and referral_link not in body:
         body = f"{body}\n\n{referral_link}"
     return apply_disclosure(body, user_id=user_id, tagged=True).strip()

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -1349,6 +1349,13 @@ AFFILIATE_REFERRAL_CONVERTED = "affiliate_referral_converted"
 AFFILIATE_REWARD_GRANTED = "affiliate_reward_granted"
 AFFILIATE_REWARD_REVOKED = "affiliate_reward_revoked"
 AFFILIATE_DISCLOSURE_BLOCKED = "affiliate_disclosure_blocked"
+# The (B) generator's own three moments (issue #770). `blocked` is the GENERATION-time refusal (a
+# draft that could not be made compliant), which is a different event from
+# `affiliate_disclosure_blocked` — that one is the publish gate catching content that arrived
+# undisclosed. Summing them would double-count one piece of content that failed twice.
+AFFILIATE_PROMO_GENERATED = "affiliate_promo_generated"
+AFFILIATE_PROMO_PUBLISHED = "affiliate_promo_published"
+AFFILIATE_PROMO_BLOCKED = "affiliate_promo_blocked"
 
 AFFILIATE_EVENTS = (
     AFFILIATE_ENROLLED,
@@ -1360,6 +1367,9 @@ AFFILIATE_EVENTS = (
     AFFILIATE_REWARD_GRANTED,
     AFFILIATE_REWARD_REVOKED,
     AFFILIATE_DISCLOSURE_BLOCKED,
+    AFFILIATE_PROMO_GENERATED,
+    AFFILIATE_PROMO_PUBLISHED,
+    AFFILIATE_PROMO_BLOCKED,
 )
 
 

--- a/src/cqc_lem/utilities/quality_gates.py
+++ b/src/cqc_lem/utilities/quality_gates.py
@@ -20,6 +20,7 @@ GATE_MISSING_ASSET = "missing_asset"
 GATE_MEETING_CTA = "meeting_cta"
 GATE_FACT_GROUNDING = "fact_grounding"
 GATE_SLOP = "ai_slop"
+GATE_AFFILIATE_PROMO = "affiliate_promo"
 
 GATE_LABELS = {
     GATE_AUTHENTICITY: "Authenticity",
@@ -29,6 +30,7 @@ GATE_LABELS = {
     GATE_MEETING_CTA: "Meeting-ask CTA",
     GATE_FACT_GROUNDING: "Unverified specifics",
     GATE_SLOP: "AI-slop patterns",
+    GATE_AFFILIATE_PROMO: "Affiliate promotion",
 }
 
 # The user-tunable thresholds behind these gates, in the units the SPA edits them in. Bounds are
@@ -178,6 +180,26 @@ def slop_finding(hard_reasons: Optional[list] = None,
                      "invented specifics for what you cut."),
         score=float(len(hard)), threshold=0.0,
         details=hard[:10] + [f"(advisory) {w}" for w in warn[:5]])
+
+
+def affiliate_promo_finding(disclosure: Optional[str] = None) -> dict:
+    """Affiliate promotion published from the author's own account (issue #770).
+
+    This is the one gate that is not a quality verdict — the draft may be perfect and it is still
+    held. Consent to the program is a standing yes to LEM WRITING promotion; it is not a yes to any
+    particular sentence going out over the author's name, and an endorsement is the one post type
+    where "I never saw it before it published" is the outcome that costs them something. So every
+    affiliate post waits for an explicit approval, and re-scoring cannot clear it: only the author
+    pressing approve (or deleting the referral link) can."""
+    return build_finding(
+        GATE_AFFILIATE_PROMO,
+        explanation=("This post promotes LinkedIn Engagement Manager and carries your referral link, "
+                     "so it is a paid endorsement published under your name. Affiliate posts are "
+                     "never auto-scheduled — this one is waiting for you to read it and approve it."),
+        remediation=("Read it as your audience will. Approve it to schedule it, edit anything that "
+                     "does not sound like you, or delete the referral link and the disclosure line "
+                     "to turn it back into an ordinary post."),
+        details=[d for d in [str(disclosure or "").strip()] if d])
 
 
 def parse_gate_findings(raw: Any) -> list[dict]:

--- a/tests/unit/app/test_affiliate_disclosure_gate.py
+++ b/tests/unit/app/test_affiliate_disclosure_gate.py
@@ -98,6 +98,28 @@ class TestAffiliateDisclosureGate:
         m["share_on_linkedin"].assert_not_called()
         assert "no_disclosure_configured" in result
 
+    def test_a_published_affiliate_post_is_counted_as_published(self):
+        """Issue #770: 'generated' and 'published' are different numbers — a promo post the author
+        never approved is one and not the other, and that gap is the read on the program."""
+        from cqc_lem.app.run_automation import post_to_linkedin
+        with ExitStack() as stack:
+            _post_patches(stack, f"This tool changed my week. {REF_LINK}\n\n{DISCLOSURE}",
+                          prefs={"link_in_first_comment": False})
+            track = stack.enter_context(
+                patch("cqc_lem.utilities.marketing.affiliate_content._track"))
+            post_to_linkedin.run(1, 10)
+        assert track.call_args[0][0] == "affiliate_promo_published"
+        assert track.call_args[1]["post_id"] == 10
+
+    def test_an_ordinary_published_post_is_not_counted_as_affiliate(self):
+        from cqc_lem.app.run_automation import post_to_linkedin
+        with ExitStack() as stack:
+            _post_patches(stack, "Three lessons from the rebuild.")
+            track = stack.enter_context(
+                patch("cqc_lem.utilities.marketing.affiliate_content._track"))
+            post_to_linkedin.run(1, 10)
+        track.assert_not_called()
+
     def test_a_broken_gate_publishes_rather_than_blocking_every_post(self):
         """This is a compliance check on a rare shape of post, not a new way for posting to break."""
         from cqc_lem.app.run_automation import post_to_linkedin

--- a/tests/unit/app/test_affiliate_promo_slot.py
+++ b/tests/unit/app/test_affiliate_promo_slot.py
@@ -115,6 +115,19 @@ class TestApprovalHold:
             findings = self._gates(stack, PROMO_POST, owner=2)
         assert not [f for f in findings if f["gate"] == GATE_AFFILIATE_PROMO]
 
+    def test_an_unresolvable_owner_is_never_read_as_this_authors_endorsement(self):
+        """Falling through to `user_id=None` would match ANY member's referral code — holding
+        somebody's post, over a link that is not theirs, with copy calling it their paid
+        endorsement."""
+        from cqc_lem.app.run_content_plan import evaluate_post_gates
+        from cqc_lem.utilities.quality_gates import GATE_AFFILIATE_PROMO
+        with ExitStack() as stack:
+            _owned(stack)
+            stack.enter_context(patch("cqc_lem.utilities.db.get_post_user_id", return_value=None))
+            stack.enter_context(patch(f"{_RCP}._post_missing_required_asset", return_value=False))
+            findings = evaluate_post_gates(10, PROMO_POST, "text")
+        assert not [f for f in findings if f["gate"] == GATE_AFFILIATE_PROMO]
+
     def test_unreadable_ownership_leaves_the_publish_gate_as_the_enforcer(self):
         from cqc_lem.app.run_content_plan import evaluate_post_gates
         from cqc_lem.utilities.quality_gates import GATE_AFFILIATE_PROMO

--- a/tests/unit/app/test_affiliate_promo_slot.py
+++ b/tests/unit/app/test_affiliate_promo_slot.py
@@ -56,8 +56,8 @@ class TestPromoSlotClaim:
             stack.enter_context(patch(f"{_AC}.claims_promo_slot", return_value=False))
             promo = stack.enter_context(patch(f"{_AC}.generate_promo_post"))
             prefs = stack.enter_context(patch(f"{_RCP}._engagement_prefs_or_empty"))
-            text_post = stack.enter_context(patch(f"{_RCP}.create_text_post",
-                                                  return_value="  Ordinary post.  "))
+            stack.enter_context(patch(f"{_RCP}.create_text_post",
+                                      return_value="  Ordinary post.  "))
             content, _ = create_content(1, "text", "decision", post_id=10, content_mix="promo")
         assert content == "Ordinary post."
         promo.assert_not_called()

--- a/tests/unit/app/test_affiliate_promo_slot.py
+++ b/tests/unit/app/test_affiliate_promo_slot.py
@@ -1,0 +1,127 @@
+"""Issue #770 — where the (B) writer meets the content plan.
+
+Two seams live here and neither is testable inside the writer itself:
+  - the promo SLOT: affiliate promotion replaces the author's own case-study post, it never runs
+    beside it, which is what keeps the 10% mix ceiling exact.
+  - the APPROVAL hold: an endorsement published under the author's name is never auto-scheduled.
+"""
+
+from contextlib import ExitStack
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_RCP = "cqc_lem.app.run_content_plan"
+_AC = "cqc_lem.utilities.marketing.affiliate_content"
+_AFF = "cqc_lem.utilities.marketing.affiliate"
+_ATTR = "cqc_lem.utilities.marketing.attribution"
+
+DISCLOSURE = "#ad - I get free trial time when people sign up through my link."
+REF_LINK = "https://app.lem.test/signup?ref=1"
+PROMO_POST = f"I plan a month of posts at a time now.\n\n{REF_LINK}\n\n{DISCLOSURE}"
+
+
+def _owned(stack):
+    stack.enter_context(patch(f"{_ATTR}.PUBLIC_BASE_URL", "https://app.lem.test"))
+    stack.enter_context(patch(f"{_ATTR}.BRAND_SIGNUP_URL", "https://app.lem.test/signup"))
+    stack.enter_context(patch(f"{_ATTR}.MARKETING_OWNED_DOMAINS", ""))
+    stack.enter_context(patch(f"{_AFF}.AFFILIATE_PROGRAM_ENABLED", True))
+    stack.enter_context(patch(f"{_AFF}.AFFILIATE_DISCLOSURE_TEXT", DISCLOSURE))
+    return stack
+
+
+class TestPromoSlotClaim:
+    def test_a_claimed_promo_slot_writes_the_affiliate_post_instead_of_the_case_study(self):
+        from cqc_lem.app.run_content_plan import create_content
+        with ExitStack() as stack:
+            _owned(stack)
+            stack.enter_context(patch(f"{_AC}.claims_promo_slot", return_value=True))
+            stack.enter_context(patch(f"{_AC}.generate_promo_post", return_value=PROMO_POST))
+            stack.enter_context(patch(f"{_RCP}._engagement_prefs_or_empty", return_value={}))
+            stack.enter_context(patch(f"{_RCP}._profile_synthesis_or_none", return_value=None))
+            text_post = stack.enter_context(patch(f"{_RCP}.create_text_post"))
+            content, video_url = create_content(1, "text", "decision", post_id=10,
+                                                content_mix="promo")
+        assert content == PROMO_POST
+        assert video_url is None
+        # The point of claiming a slot rather than adding a post: exactly ONE post exists here.
+        text_post.assert_not_called()
+
+    def test_an_unclaimed_slot_writes_the_ordinary_post_and_costs_no_extra_reads(self):
+        from cqc_lem.app.run_content_plan import create_content
+        with ExitStack() as stack:
+            _owned(stack)
+            stack.enter_context(patch(f"{_AC}.claims_promo_slot", return_value=False))
+            promo = stack.enter_context(patch(f"{_AC}.generate_promo_post"))
+            prefs = stack.enter_context(patch(f"{_RCP}._engagement_prefs_or_empty"))
+            text_post = stack.enter_context(patch(f"{_RCP}.create_text_post",
+                                                  return_value="  Ordinary post.  "))
+            content, _ = create_content(1, "text", "decision", post_id=10, content_mix="promo")
+        assert content == "Ordinary post."
+        promo.assert_not_called()
+        prefs.assert_not_called()
+
+    def test_a_failing_writer_never_costs_the_user_the_post_they_would_have_had(self):
+        from cqc_lem.app.run_content_plan import create_content
+        with ExitStack() as stack:
+            _owned(stack)
+            stack.enter_context(patch(f"{_AC}.claims_promo_slot",
+                                      side_effect=RuntimeError("consent read exploded")))
+            text_post = stack.enter_context(patch(f"{_RCP}.create_text_post",
+                                                  return_value="Ordinary post."))
+            content, _ = create_content(1, "text", "decision", post_id=10, content_mix="promo")
+        assert content == "Ordinary post."
+        text_post.assert_called_once()
+
+    def test_carousels_and_videos_are_untouched_by_the_writer(self):
+        from cqc_lem.app.run_content_plan import create_content
+        with ExitStack() as stack:
+            _owned(stack)
+            claims = stack.enter_context(patch(f"{_AC}.claims_promo_slot", return_value=True))
+            stack.enter_context(patch(f"{_RCP}.create_carousel_content", return_value="Deck."))
+            content, _ = create_content(1, "carousel", "decision", post_id=10, content_mix="promo")
+        assert content == "Deck."
+        claims.assert_not_called()
+
+
+class TestApprovalHold:
+    def _gates(self, stack, content, owner=1):
+        from cqc_lem.app.run_content_plan import evaluate_post_gates
+        _owned(stack)
+        stack.enter_context(patch("cqc_lem.utilities.db.get_post_user_id", return_value=owner))
+        stack.enter_context(patch(f"{_RCP}._post_missing_required_asset", return_value=False))
+        return evaluate_post_gates(10, content, "text")
+
+    def test_an_affiliate_post_is_held_for_the_authors_explicit_approval(self):
+        from cqc_lem.utilities.quality_gates import GATE_AFFILIATE_PROMO, demoting_findings
+        with ExitStack() as stack:
+            findings = self._gates(stack, PROMO_POST)
+        held = [f for f in demoting_findings(findings) if f["gate"] == GATE_AFFILIATE_PROMO]
+        assert len(held) == 1
+        assert "referral link" in held[0]["explanation"]
+
+    def test_an_ordinary_post_is_never_held_by_this_gate(self):
+        from cqc_lem.utilities.quality_gates import GATE_AFFILIATE_PROMO
+        with ExitStack() as stack:
+            findings = self._gates(stack, "Three lessons from the rebuild.")
+        assert not [f for f in findings if f["gate"] == GATE_AFFILIATE_PROMO]
+
+    def test_somebody_elses_referral_link_is_not_this_authors_endorsement(self):
+        """Graded on the post OWNER's code, the same way the publish gate grades it."""
+        from cqc_lem.utilities.quality_gates import GATE_AFFILIATE_PROMO
+        with ExitStack() as stack:
+            findings = self._gates(stack, PROMO_POST, owner=2)
+        assert not [f for f in findings if f["gate"] == GATE_AFFILIATE_PROMO]
+
+    def test_unreadable_ownership_leaves_the_publish_gate_as_the_enforcer(self):
+        from cqc_lem.app.run_content_plan import evaluate_post_gates
+        from cqc_lem.utilities.quality_gates import GATE_AFFILIATE_PROMO
+        with ExitStack() as stack:
+            _owned(stack)
+            stack.enter_context(patch("cqc_lem.utilities.db.get_post_user_id",
+                                      side_effect=RuntimeError("db down")))
+            stack.enter_context(patch(f"{_RCP}._post_missing_required_asset", return_value=False))
+            findings = evaluate_post_gates(10, PROMO_POST, "text")
+        assert not [f for f in findings if f["gate"] == GATE_AFFILIATE_PROMO]

--- a/tests/unit/utilities/test_affiliate_content.py
+++ b/tests/unit/utilities/test_affiliate_content.py
@@ -148,6 +148,25 @@ class TestDisclosure:
         assert content is None
         call.assert_not_called()
 
+    def test_a_deployment_that_cannot_publish_affiliate_content_says_so(self):
+        """The one refusal that is a MISCONFIGURATION rather than the healthy common case, and the
+        content plan short-circuits on `claims_promo_slot` — so it has to be reported from there or
+        the deployment silently never promotes."""
+        with ExitStack() as stack:
+            _env(stack, disclosure="")
+            warn = stack.enter_context(patch("cqc_lem.utilities.logger.log_warning"))
+            assert affiliate_content.claims_promo_slot(1, 10, "promo") is False
+        assert warn.call_count == 1
+        assert "AFFILIATE_DISCLOSURE_TEXT" in warn.call_args[0][0]
+
+    def test_declining_an_ordinary_slot_is_not_a_warning(self):
+        """A user who never consented plans promo slots forever; one warning per slot is noise."""
+        with ExitStack() as stack:
+            _env(stack, enrollment=NO_CONSENT)
+            warn = stack.enter_context(patch("cqc_lem.utilities.logger.log_warning"))
+            assert affiliate_content.claims_promo_slot(1, 10, "promo") is False
+        warn.assert_not_called()
+
     def test_copy_that_cannot_be_made_compliant_is_blocked_not_shipped(self):
         with ExitStack() as stack:
             _env(stack)
@@ -157,6 +176,33 @@ class TestDisclosure:
         assert content is None
         assert track.call_args[0][0] == "affiliate_promo_blocked"
         assert track.call_args[1]["reason"] == affiliate_content.REASON_UNDISCLOSED
+
+
+# --- the referral link is the one URL that has to survive verbatim --------------------------------
+
+class TestReferralLinkIntegrity:
+    def test_the_link_the_model_reproduced_survives_the_markdown_pass(self):
+        """The prompt tells the model to reproduce the link, and `sanitize_for_linkedin` strips
+        markdown italics — `_word_` being exactly the shape of `utm_source=…&utm_medium=…`. Left
+        un-repaired the post publishes `utmsource=`, a dead link, AND a second clean copy beside it
+        because the mangled one no longer matches."""
+        from cqc_lem.utilities.marketing.affiliate import link_for_user
+        with ExitStack() as stack:
+            _env(stack)
+            link = link_for_user(1)
+            assert "utm_source=" in link  # the exact shape the italic pass eats
+            content, _ = _generate(stack, draft=f"{DRAFT}\n\n{link}")
+        assert link in content
+        assert content.count("https://") == 1
+        assert "utmsource" not in content
+
+    def test_a_draft_that_omitted_the_link_still_gets_exactly_one(self):
+        from cqc_lem.utilities.marketing.affiliate import link_for_user
+        with ExitStack() as stack:
+            _env(stack)
+            link = link_for_user(1)
+            content, _ = _generate(stack)
+        assert content.count(link) == 1
 
 
 # --- the writer takes a slot, it never adds one ---------------------------------------------------

--- a/tests/unit/utilities/test_affiliate_content.py
+++ b/tests/unit/utilities/test_affiliate_content.py
@@ -1,0 +1,309 @@
+"""Issue #770 — the (B) writer: LEM-promotional content from the user's own account.
+
+The acceptance criteria this file owns:
+  - With (B) consent, a post that promotes LEM is produced and it ALREADY carries the disclosure.
+  - With (B) off or consent missing, NOTHING promotional is generated.
+  - The writer respects the 10% promo mix cap (it claims a promo slot, it never adds a post) and the
+    human-pacing daily budget.
+  - Consent-off / consent-on / disclosure-present / disclosure-missing are all covered.
+"""
+
+from contextlib import ExitStack
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cqc_lem.utilities.marketing import affiliate_content
+
+pytestmark = pytest.mark.unit
+
+_AC = "cqc_lem.utilities.marketing.affiliate_content"
+_AFF = "cqc_lem.utilities.marketing.affiliate"
+_ATTR = "cqc_lem.utilities.marketing.attribution"
+_HP = "cqc_lem.utilities.human_pacing"
+_DB = "cqc_lem.utilities.db"
+_AI = "cqc_lem.utilities.ai.ai_helper"
+
+DISCLOSURE = "#ad - I get free trial time when people sign up through my link."
+CONSENTED = {"status": "enrolled", "promo_content_opt_in": True,
+             "promo_consent_at": "2026-07-27 10:00:00"}
+NO_CONSENT = {"status": "enrolled", "promo_content_opt_in": False, "promo_consent_at": None}
+
+# Plain copy with no banned lexicon, no contrastive framing and no reflex closer, so the slop lint
+# passes and the tests are exercising the affiliate rules rather than the linter.
+DRAFT = ("I schedule my LinkedIn posts a month at a time now.\n\n"
+         "The tool writes the drafts and puts them out when my audience is around. I read every one "
+         "before it goes.\n\n"
+         "If keeping up on here is a chore for you too, it has a free trial.")
+
+
+def _llm(text):
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content=text))])
+    return MagicMock(return_value=response)
+
+
+def _env(stack, *, enrollment=CONSENTED, disclosure=DISCLOSURE, enabled=True, every_n=1,
+         per_day=1, budget=1, used=0):
+    """Everything outside the writer: consent, the owned signup domain, the disclosure, pacing."""
+    stack.enter_context(patch(f"{_ATTR}.PUBLIC_BASE_URL", "https://app.lem.test"))
+    stack.enter_context(patch(f"{_ATTR}.BRAND_SIGNUP_URL", "https://app.lem.test/signup"))
+    stack.enter_context(patch(f"{_ATTR}.MARKETING_OWNED_DOMAINS", ""))
+    stack.enter_context(patch(f"{_AFF}.AFFILIATE_PROGRAM_ENABLED", True))
+    stack.enter_context(patch(f"{_AFF}.AFFILIATE_DISCLOSURE_TEXT", disclosure))
+    stack.enter_context(patch(f"{_AC}.AFFILIATE_PROMO_CONTENT_ENABLED", enabled))
+    stack.enter_context(patch(f"{_AC}.AFFILIATE_PROMO_EVERY_N_PROMO_SLOTS", every_n))
+    stack.enter_context(patch(f"{_AC}.AFFILIATE_PROMO_MAX_PER_DAY", per_day))
+    stack.enter_context(patch(f"{_DB}.get_affiliate_enrollment", return_value=enrollment))
+    stack.enter_context(patch(f"{_HP}.daily_budget", return_value=budget))
+    stack.enter_context(patch(f"{_HP}.actions_used_today", return_value=used))
+    stack.enter_context(patch(f"{_HP}.record_action"))
+    return stack
+
+
+def _generate(stack, draft=DRAFT, post_id=10, content_mix="promo", user_id=1):
+    call = _llm(draft)
+    stack.enter_context(patch(f"{_AI}._call_llm", call))
+    content = affiliate_content.generate_promo_post(user_id, post_id=post_id,
+                                                    content_mix=content_mix)
+    return content, call
+
+
+# --- consent is the only authorisation ------------------------------------------------------------
+
+class TestConsentGate:
+    def test_consent_on_produces_a_disclosed_promotional_post(self):
+        from cqc_lem.utilities.marketing.affiliate import has_disclosure
+        with ExitStack() as stack:
+            _env(stack)
+            content, call = _generate(stack)
+            assert content
+            call.assert_called_once()
+            # It promotes LEM with the member's OWN referral link, already disclosed.
+            assert "ref=1" in content
+            assert affiliate_content.is_affiliate_post(content, user_id=1)
+            assert has_disclosure(content)
+
+    def test_no_consent_writes_nothing_and_never_calls_the_model(self):
+        with ExitStack() as stack:
+            _env(stack, enrollment=NO_CONSENT)
+            content, call = _generate(stack)
+        assert content is None
+        call.assert_not_called()
+
+    def test_opted_out_user_writes_nothing(self):
+        with ExitStack() as stack:
+            _env(stack, enrollment={"status": "opted_out", "promo_content_opt_in": True,
+                                    "promo_consent_at": "2026-07-27"})
+            content, _ = _generate(stack)
+        assert content is None
+
+    def test_unreadable_consent_is_a_no(self):
+        with ExitStack() as stack:
+            _env(stack)
+            stack.enter_context(patch(f"{_DB}.get_affiliate_enrollment",
+                                      side_effect=RuntimeError("db down")))
+            content, call = _generate(stack)
+        assert content is None
+        call.assert_not_called()
+
+    def test_generator_kill_switch_stops_the_writer_without_touching_consent(self):
+        with ExitStack() as stack:
+            _env(stack, enabled=False)
+            content, call = _generate(stack)
+        assert content is None
+        call.assert_not_called()
+        # Consent itself is untouched — flipping the switch back writes again.
+        with ExitStack() as stack:
+            _env(stack, enabled=True)
+            content, _ = _generate(stack)
+        assert content
+
+
+# --- the disclosure is stamped at generation, not left to the publish gate -------------------------
+
+class TestDisclosure:
+    def test_a_draft_with_no_disclosure_is_disclosed_before_it_is_returned(self):
+        """The model writing an undisclosed draft must not produce an undisclosed post."""
+        with ExitStack() as stack:
+            _env(stack)
+            content, _ = _generate(stack, draft="Great tool. https://app.lem.test/signup?ref=1")
+        assert content
+        from cqc_lem.utilities.marketing.affiliate import disclosure_report
+        assert disclosure_report(content, user_id=1, tagged=True)["ok"] is True
+
+    def test_a_draft_that_already_discloses_is_not_disclosed_twice(self):
+        with ExitStack() as stack:
+            _env(stack)
+            content, _ = _generate(stack, draft=f"{DRAFT}\n\n{DISCLOSURE}")
+        assert content.count("free trial time when people sign up") == 1
+
+    def test_a_deployment_with_no_disclosure_configured_writes_nothing(self):
+        """Blank means 'affiliate content cannot be published here', never 'no disclosure needed' —
+        so there is no point spending a generation on copy the publish gate would refuse."""
+        with ExitStack() as stack:
+            _env(stack, disclosure="")
+            content, call = _generate(stack)
+        assert content is None
+        call.assert_not_called()
+
+    def test_copy_that_cannot_be_made_compliant_is_blocked_not_shipped(self):
+        with ExitStack() as stack:
+            _env(stack)
+            stack.enter_context(patch(f"{_AC}.apply_disclosure", side_effect=lambda t, **kw: t))
+            track = stack.enter_context(patch(f"{_AC}._track"))
+            content, _ = _generate(stack, draft="Great tool. https://app.lem.test/signup?ref=1")
+        assert content is None
+        assert track.call_args[0][0] == "affiliate_promo_blocked"
+        assert track.call_args[1]["reason"] == affiliate_content.REASON_UNDISCLOSED
+
+
+# --- the writer takes a slot, it never adds one ---------------------------------------------------
+
+class TestPromoMixCap:
+    @pytest.mark.parametrize("mix", ["value", "authority", None, "", "unknown"])
+    def test_only_the_governors_promo_slot_can_be_claimed(self, mix):
+        """The 10% ceiling holds by construction: affiliate promotion replaces the author's own
+        case-study post in a slot the mix governor already allowed, so it can never raise the ratio."""
+        with ExitStack() as stack:
+            _env(stack)
+            content, call = _generate(stack, content_mix=mix)
+        assert content is None
+        call.assert_not_called()
+
+    def test_cadence_makes_lem_promotion_rarer_than_the_promo_slot_itself(self):
+        with ExitStack() as stack:
+            _env(stack, every_n=3)
+            claimed = [affiliate_content.claims_promo_slot(1, pid, "promo") for pid in range(9)]
+        assert claimed == [True, False, False, True, False, False, True, False, False]
+
+    def test_a_misconfigured_cadence_never_means_every_slot(self):
+        with ExitStack() as stack:
+            _env(stack, every_n=0)
+            assert affiliate_content.promo_slot_cadence() == 1
+
+    def test_no_referral_link_means_nothing_to_promote(self):
+        with ExitStack() as stack:
+            _env(stack)
+            stack.enter_context(patch(f"{_ATTR}.BRAND_SIGNUP_URL", ""))
+            stack.enter_context(patch(f"{_ATTR}.PUBLIC_BASE_URL", ""))
+            content, call = _generate(stack)
+        assert content is None
+        call.assert_not_called()
+
+
+# --- human pacing ----------------------------------------------------------------------------------
+
+class TestPacing:
+    def test_the_days_paced_budget_is_a_ceiling(self):
+        with ExitStack() as stack:
+            _env(stack, budget=1, used=1)
+            content, call = _generate(stack)
+        assert content is None
+        call.assert_not_called()
+
+    def test_a_pacing_rest_day_writes_nothing(self):
+        """`daily_budget` returns 0 on a rest day — the writer inherits that with no rule of its own."""
+        with ExitStack() as stack:
+            _env(stack, budget=0, used=0)
+            content, _ = _generate(stack)
+        assert content is None
+
+    def test_a_generated_post_is_recorded_against_the_days_budget(self):
+        with ExitStack() as stack:
+            _env(stack)
+            recorded = stack.enter_context(patch(f"{_HP}.record_action"))
+            content, _ = _generate(stack)
+        assert content
+        recorded.assert_called_once_with(1, "affiliate_promo")
+
+    def test_pacing_failure_fails_open(self):
+        """Consent and the promo slot are the hard limits; neither of them lives in Redis."""
+        with ExitStack() as stack:
+            _env(stack)
+            stack.enter_context(patch(f"{_HP}.daily_budget", side_effect=RuntimeError("no redis")))
+            content, _ = _generate(stack)
+        assert content
+
+    def test_a_zero_per_day_cap_writes_nothing(self):
+        with ExitStack() as stack:
+            _env(stack, per_day=0)
+            content, call = _generate(stack)
+        assert content is None
+        call.assert_not_called()
+
+
+# --- the slop lint applies to promotional copy too -------------------------------------------------
+
+class TestQualityGates:
+    def test_a_slopped_draft_is_regenerated_then_blocked(self):
+        slop = ("Let's dive into this game changer. It's not just a tool, it's a revolution. "
+                "Thoughts?")
+        with ExitStack() as stack:
+            _env(stack)
+            track = stack.enter_context(patch(f"{_AC}._track"))
+            stack.enter_context(patch("cqc_lem.utilities.ai.slop_lint.slop_max_attempts",
+                                      return_value=2))
+            content, call = _generate(stack, draft=slop)
+        assert content is None
+        assert call.call_count == 2
+        assert track.call_args[0][0] == "affiliate_promo_blocked"
+        assert track.call_args[1]["reason"] == affiliate_content.REASON_SLOP
+
+    def test_an_empty_model_response_blocks_rather_than_shipping_a_bare_link(self):
+        with ExitStack() as stack:
+            _env(stack)
+            track = stack.enter_context(patch(f"{_AC}._track"))
+            content, _ = _generate(stack, draft="")
+        assert content is None
+        assert track.call_args[1]["reason"] == affiliate_content.REASON_EMPTY_DRAFT
+
+    def test_a_model_error_never_takes_the_ordinary_promo_post_down_with_it(self):
+        with ExitStack() as stack:
+            _env(stack)
+            stack.enter_context(patch(f"{_AI}._call_llm", side_effect=RuntimeError("502")))
+            content = affiliate_content.generate_promo_post(1, post_id=10, content_mix="promo")
+        assert content is None
+
+    def test_the_writer_states_nothing_about_the_product_it_was_not_given(self):
+        """The prompt's allow-list is the product-fact list and nothing else — the same posture the
+        story bank takes for personal specifics."""
+        with ExitStack() as stack:
+            _env(stack)
+            content, call = _generate(stack)
+        prompt = call.call_args.kwargs["messages"][1]["content"]
+        assert all(fact in prompt for fact in affiliate_content.PRODUCT_FACTS)
+        system = call.call_args.kwargs["messages"][0]["content"]
+        assert "no metrics" in system.lower() or "no results" in system.lower()
+
+
+# --- published telemetry ---------------------------------------------------------------------------
+
+class TestPublishedEvent:
+    def test_publishing_an_affiliate_post_emits_the_event(self):
+        with ExitStack() as stack:
+            _env(stack)
+            track = stack.enter_context(patch(f"{_AC}._track"))
+            emitted = affiliate_content.record_promo_published(
+                1, 10, f"Great tool.\n\n{DISCLOSURE}",
+                first_comment_links=["https://app.lem.test/signup?ref=1"],
+                post_url="https://linkedin.com/feed/update/urn:1/")
+        assert emitted is True
+        assert track.call_args[0][0] == "affiliate_promo_published"
+        assert track.call_args[1]["link_in_first_comment"] is True
+
+    def test_an_ordinary_post_emits_nothing(self):
+        with ExitStack() as stack:
+            _env(stack)
+            track = stack.enter_context(patch(f"{_AC}._track"))
+            emitted = affiliate_content.record_promo_published(1, 10, "Three lessons from the rebuild.")
+        assert emitted is False
+        track.assert_not_called()
+
+    def test_analytics_never_fails_a_published_post(self):
+        with ExitStack() as stack:
+            _env(stack)
+            stack.enter_context(patch(f"{_AC}._track", side_effect=RuntimeError("posthog down")))
+            assert affiliate_content.record_promo_published(
+                1, 10, f"Use my link https://app.lem.test/signup?ref=1 {DISCLOSURE}") is False


### PR DESCRIPTION
## What & why

#750 shipped (B)'s consent record, `apply_disclosure()`, `disclosure_report()` and the
`post_to_linkedin` gate — and deliberately no writer, so `promo_content_allowed()` had nothing
upstream of it. This is that writer.

`utilities/marketing/affiliate_content.py` is the ONE place promotional copy about LEM is produced.
Four refusals define it:

| | |
|---|---|
| **Not a second consent path** | `promo_content_allowed()` is still the only authorisation. `AFFILIATE_PROMO_CONTENT_ENABLED` can only turn the writer **off** — `True` with nobody consented writes nothing. An unreadable enrollment row reads as *no*. |
| **Not an extra post** | An affiliate post **CLAIMS** one of the 70/20/10 governor's promo slots (#618) instead of running beside it, so the 10% ceiling holds *by construction* rather than via a second counter that could drift. Only `content_mix == 'promo'`, and only 1 in `AFFILIATE_PROMO_EVERY_N_PROMO_SLOTS` of those (default 3 ⇒ **≤1 post in 30**). Unclaimed slots write the author's own case study exactly as before. |
| **Not an author of facts** | The writer's allow-list is `PRODUCT_FACTS` and nothing else — no result, metric, hours-saved or testimonial, because LEM cannot verify any claim about what the tool did for *this* user and an invented one is a false endorsement. The #625 slop lint regenerates then **blocks**. |
| **Not silently published** | `apply_disclosure(..., tagged=True)` stamps the disclosure at generation; the new `affiliate_promo` quality gate holds the post **PENDING** for the author's explicit approval; `disclosure_report()` in `post_to_linkedin` stays the backstop. Three different guarantees, not the same one three times. |

**Pacing** rides `human_pacing.ACTION_AFFILIATE_PROMO` (own daily budget, rest days inherited) —
deliberately outside `ENVELOPE_ACTIONS`, since posting is API-driven and was never gated by the
engagement envelope. Pacing fails open; consent and the promo slot are the hard limits.

**Events**: `affiliate_promo_generated` / `_published` / `_blocked`. `_blocked` (generation could not
produce compliant copy) is **never summed** with `affiliate_disclosure_blocked` (publish gate caught
undisclosed content) — one piece of content can fire both. Declining to write (no consent, not this
slot, paced out) is deliberately not an event.

## Surfaces shipped

**Post only.** A feed comment promoting LEM under someone else's post, and a DM pitching LEM to the
author's connections, are a different risk class and are Decision Q1 below rather than a silent
assumption. Every acceptance criterion on #770 is post-shaped (the mix cap, the publish gate, the
pacing budget), which is why the post surface is the one that closes it.

## Files

- `utilities/marketing/affiliate_content.py` — the writer (new)
- `utilities/quality_gates.py` — `affiliate_promo` gate + finding
- `app/run_content_plan.py` — slot claim in `create_content`, hold in `evaluate_post_gates`
- `app/run_automation.py` — `affiliate_promo_published` on the publish path
- `utilities/human_pacing.py`, `utilities/observability.py`, `utilities/env_constants.py`, `.env.example`
- `docs/affiliate-program.md` §2.1

## Testing

`poetry run pytest tests/unit -q` → **8248 passed** locally. 39 new unit tests across
`tests/unit/utilities/test_affiliate_content.py`, `tests/unit/app/test_affiliate_promo_slot.py` and
`tests/unit/app/test_affiliate_disclosure_gate.py`: consent-off / consent-on / opted-out /
unreadable-consent, disclosure present / missing / not-configured / unfixable, the promo-slot claim
(and that a non-promo slot can never be claimed), the approval hold, the pacing ceiling and rest
day, slop-lint regenerate-then-block, and the published event.

No new API endpoint or table, so there is nothing for an integration test to exercise that the unit
tests do not — flagging that explicitly rather than adding a hollow one.

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)