### PR TITLE
fix(scheduling): never convert a picked time against a guessed timezone (closes #774)

### DIFF
--- a/docs/timezone-contract.md
+++ b/docs/timezone-contract.md
@@ -65,6 +65,22 @@ only the last-resort fallback while the query is in flight. A user whose Login L
 their device (travel, VPN, or deliberately targeting an audience in another zone) must still see and
 set times in their configured zone.
 
+**Never convert against the fallback.** Rendering a value in the browser's zone for the few
+milliseconds before the real one lands is cosmetic; converting a wall clock the user *typed* against
+it is not — that instant is stored, and the post fires by the difference between the two zones
+(issue #774: a post picked for 9am ET was stored as `09:00Z` and published at 5am ET). So every
+surface that WRITES a scheduled time reads `useUserTimezoneState()` instead, which reports
+`isResolved: false` until `/user/timezone` has actually answered — in flight, disabled because the
+session token hasn't hydrated, or failed. While it is false the picker is disabled, labelled
+`loading your timezone…` rather than named with the guess, and the submit path refuses. `ComposePost`,
+the `ContentStudio` editor and bulk-reschedule bar, `ScheduledDMs` and `NewsletterQueue` all hold to
+this; `useUserTimezone()` (bare string, browser fallback) is for display-only callers.
+
+Server-side, a scheduling write that arrives with **no** offset is still interpreted as UTC — that is
+the contract and legacy callers rely on it — but `api.main._warn_if_naive_schedule()` logs a WARNING
+on `/schedule_post/`, `/update_post/` and `/posts/bulk_update/` so the next occurrence is diagnosable
+from logs rather than only from a post that went out at the wrong hour.
+
 `src/utils/datetime.ts` owns all three conversions:
 
 | Helper | Direction |

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -266,6 +266,21 @@ def _utc_iso(dt) -> Optional[str]:
     return dt.isoformat().replace("+00:00", "Z")
 
 
+def _warn_if_naive_schedule(dt, endpoint: str, **context) -> None:
+    """A scheduling write whose datetime carries NO offset is a client bug, and a silent one: the
+    storage layer assumes naive means UTC (db.to_naive_utc), so a wall clock the user picked in
+    their own zone is stored verbatim and the post fires offset-hours away from the time they saw
+    (issue #774 — a 9am post published at 5am). We keep interpreting it as UTC (the contract, and
+    what every legacy caller relies on) but leave a breadcrumb, because today the only evidence is
+    the wrong publish time itself."""
+    if dt is not None and getattr(dt, "tzinfo", None) is None:
+        log_warning(
+            f"Naive scheduled_datetime received by {endpoint} — assuming UTC "
+            f"(clients must send an explicit-UTC ISO string; see docs/timezone-contract.md)",
+            **context,
+        )
+
+
 def _public_post_url(value) -> Optional[str]:
     """Only surface real http(s) permalinks. Home-feed comments have no LinkedIn permalink and are
     logged under a synthetic 'feedpost://<hash>' dedup key — never expose that raw string to the UI."""
@@ -1515,6 +1530,8 @@ def schedule_post(post: PostRequest) -> ResponseModel:
     if not user_id:
         raise HTTPException(status_code=403, detail="User not found")
 
+    _warn_if_naive_schedule(post.scheduled_datetime, "/schedule_post/", user_id=user_id)
+
     # SPA-created posts carry an explicit status: "Approve & Schedule" → approved,
     # "Save Draft" → pending. Auto-generated content sets its own status elsewhere.
     if insert_post(post.email, post.content, post.scheduled_datetime, post.post_type,
@@ -1676,6 +1693,8 @@ def bulk_update_posts_endpoint(request: BulkUpdateRequest) -> ResponseModel:
     if not request.post_ids:
         raise HTTPException(status_code=400, detail="post_ids is required")
 
+    _warn_if_naive_schedule(request.scheduled_datetime, "/posts/bulk_update/")
+
     if bulk_update_posts(request.post_ids, status=request.status, scheduled_time=request.scheduled_datetime):
         return ResponseModel(status_code=200, detail="Posts updated successfully")
     else:
@@ -1717,6 +1736,7 @@ def get_post_url(post_id: int, email: str) -> ResponseModel:
 })
 def update_post(post_id: int, post: PostRequest) -> ResponseModel:
     myprint(f"Received Post Request: {post}")
+    _warn_if_naive_schedule(post.scheduled_datetime, "/update_post/", post_id=post_id)
 
     if update_db_post(post.content, post.video_url, post.scheduled_datetime, post.post_type, post_id, post.status):
         reason = (post.rejection_reason or "").strip() or None

--- a/src/cqc_lem/ui/src/hooks/useUserTimezone.test.tsx
+++ b/src/cqc_lem/ui/src/hooks/useUserTimezone.test.tsx
@@ -1,0 +1,76 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { useUserTimezone, useUserTimezoneState } from './useUserTimezone'
+
+const get = vi.fn()
+vi.mock('../api/client', () => ({ default: { get: (...args: unknown[]) => get(...args) } }))
+
+let sessionToken: string | null = 'tok'
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ sessionToken }),
+}))
+
+// What the hook falls back to when the user's own zone isn't known yet. Read rather than mocked so
+// the assertions hold on any machine — the point is that the fallback is never reported as resolved.
+const browserZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+
+// retryDelay:0, NOT retry:false — the hook sets `retry: 2` on the query itself so a blip can't lock
+// the pickers, and a per-query option beats a client default. Only the back-off is a default.
+function harness(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+function Probe() {
+  const { timezone, isResolved } = useUserTimezoneState()
+  return <span data-testid="value">{`${timezone}|${String(isResolved)}`}</span>
+}
+
+function StringProbe() {
+  return <span data-testid="value">{useUserTimezone()}</span>
+}
+
+beforeEach(() => {
+  get.mockReset()
+  sessionToken = 'tok'
+})
+afterEach(cleanup)
+
+describe('useUserTimezoneState (issue #774)', () => {
+  it('is unresolved while the request is in flight, and the zone is the browser guess', () => {
+    get.mockReturnValue(new Promise(() => {})) // never resolves
+    harness(<Probe />)
+    expect(screen.getByTestId('value').textContent).toBe(`${browserZone}|false`)
+  })
+
+  it('resolves to the user-configured zone once /user/timezone answers', async () => {
+    get.mockResolvedValue({ data: { detail: { timezone: 'America/New_York' } } })
+    harness(<Probe />)
+    await waitFor(() =>
+      expect(screen.getByTestId('value').textContent).toBe('America/New_York|true'),
+    )
+  })
+
+  it('stays unresolved when the request fails — a guess is never reported as the setting', async () => {
+    get.mockRejectedValue(new Error('boom'))
+    harness(<Probe />)
+    // 1 attempt + 2 retries, then it gives up — and still reports unresolved.
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(3))
+    expect(screen.getByTestId('value').textContent).toBe(`${browserZone}|false`)
+  })
+
+  it('stays unresolved with no session token — the query never runs', () => {
+    sessionToken = null
+    harness(<Probe />)
+    expect(get).not.toHaveBeenCalled()
+    expect(screen.getByTestId('value').textContent).toBe(`${browserZone}|false`)
+  })
+
+  it('useUserTimezone keeps returning a bare string for display-only callers', async () => {
+    get.mockResolvedValue({ data: { detail: { timezone: 'Europe/Berlin' } } })
+    harness(<StringProbe />)
+    await waitFor(() => expect(screen.getByTestId('value').textContent).toBe('Europe/Berlin'))
+  })
+})

--- a/src/cqc_lem/ui/src/hooks/useUserTimezone.test.tsx
+++ b/src/cqc_lem/ui/src/hooks/useUserTimezone.test.tsx
@@ -16,7 +16,7 @@ vi.mock('../contexts/AuthContext', () => ({
 // the assertions hold on any machine — the point is that the fallback is never reported as resolved.
 const browserZone = Intl.DateTimeFormat().resolvedOptions().timeZone
 
-// retryDelay:0, NOT retry:false — the hook sets `retry: 2` on the query itself so a blip can't lock
+// retryDelay:0, NOT retry:false — the hook sets `retry: 3` on the query itself so a blip can't lock
 // the pickers, and a per-query option beats a client default. Only the back-off is a default.
 function harness(ui: ReactNode) {
   const client = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } })
@@ -56,8 +56,8 @@ describe('useUserTimezoneState (issue #774)', () => {
   it('stays unresolved when the request fails — a guess is never reported as the setting', async () => {
     get.mockRejectedValue(new Error('boom'))
     harness(<Probe />)
-    // 1 attempt + 2 retries, then it gives up — and still reports unresolved.
-    await waitFor(() => expect(get).toHaveBeenCalledTimes(3))
+    // 1 attempt + 3 retries, then it gives up — and still reports unresolved.
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(4))
     expect(screen.getByTestId('value').textContent).toBe(`${browserZone}|false`)
   })
 

--- a/src/cqc_lem/ui/src/hooks/useUserTimezone.ts
+++ b/src/cqc_lem/ui/src/hooks/useUserTimezone.ts
@@ -2,7 +2,18 @@ import { useQuery } from '@tanstack/react-query'
 import api from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 
-export function useUserTimezone(): string {
+export interface UserTimezoneState {
+  timezone: string
+  // True only when `timezone` is the zone the USER configured (Account -> Login Location).
+  // While the request is in flight, disabled (no session token yet) or failed, `timezone` is the
+  // BROWSER's zone — a guess. Displaying a value in the wrong zone for a moment is cosmetic;
+  // CONVERTING a wall clock the user typed against it is not: the instant is stored, and the post
+  // fires hours away from what they picked (docs/timezone-contract.md §4). Every surface that
+  // writes a scheduled time must hold off until this is true.
+  isResolved: boolean
+}
+
+export function useUserTimezoneState(): UserTimezoneState {
   const { sessionToken } = useAuth()
 
   const { data } = useQuery({
@@ -13,7 +24,19 @@ export function useUserTimezone(): string {
         .then((r) => r.data.detail as { timezone: string }),
     enabled: !!sessionToken,
     staleTime: 5 * 60 * 1000,
+    // Scheduling holds until this answers, so a transient blip must not leave the pickers locked.
+    retry: 2,
   })
 
-  return data?.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone
+  const resolved = data?.timezone
+  return {
+    timezone: resolved ?? Intl.DateTimeFormat().resolvedOptions().timeZone,
+    isResolved: !!resolved,
+  }
+}
+
+// Display-only callers: a browser-zone fallback for the few milliseconds before the real zone
+// arrives is fine. Anything that CONVERTS user input must use useUserTimezoneState instead.
+export function useUserTimezone(): string {
+  return useUserTimezoneState().timezone
 }

--- a/src/cqc_lem/ui/src/hooks/useUserTimezone.ts
+++ b/src/cqc_lem/ui/src/hooks/useUserTimezone.ts
@@ -25,7 +25,9 @@ export function useUserTimezoneState(): UserTimezoneState {
     enabled: !!sessionToken,
     staleTime: 5 * 60 * 1000,
     // Scheduling holds until this answers, so a transient blip must not leave the pickers locked.
-    retry: 2,
+    // Pinned rather than inherited: react-query's own default is 3, so the earlier `retry: 2` would
+    // have made a blip MORE likely to lock the pickers, not less.
+    retry: 3,
   })
 
   const resolved = data?.timezone

--- a/src/cqc_lem/ui/src/pages/ContentStudio.date.test.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.date.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../contexts/AuthContext', () => ({
 
 vi.mock('../hooks/useUserTimezone', () => ({
   useUserTimezone: () => 'America/New_York',
+  useUserTimezoneState: () => ({ timezone: 'America/New_York', isResolved: true }),
 }))
 
 vi.mock('../utils/analytics', () => ({

--- a/src/cqc_lem/ui/src/pages/ContentStudio.test.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../contexts/AuthContext', () => ({
 
 vi.mock('../hooks/useUserTimezone', () => ({
   useUserTimezone: () => 'America/New_York',
+  useUserTimezoneState: () => ({ timezone: 'America/New_York', isResolved: true }),
 }))
 
 vi.mock('../utils/analytics', () => ({

--- a/src/cqc_lem/ui/src/pages/ContentStudio.timezone.test.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.timezone.test.tsx
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import ContentStudio from './ContentStudio'
+
+// Issue #774: post 33 was scheduled for 9am ET and published at 5am ET, because the wall clock the
+// user typed was converted against a zone that was NOT theirs. While /user/timezone is unresolved
+// the hook hands back the BROWSER's zone, so this suite pins it unresolved and asserts the studio
+// refuses to convert rather than guessing.
+const get = vi.fn()
+const post = vi.fn()
+
+vi.mock('../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'test@example.com', userId: 1 }, sessionToken: 'tok' }),
+}))
+
+vi.mock('../hooks/useUserTimezone', () => ({
+  useUserTimezone: () => 'UTC',
+  useUserTimezoneState: () => ({ timezone: 'UTC', isResolved: false }),
+}))
+
+vi.mock('../utils/analytics', () => ({
+  capture: vi.fn(),
+  recordPostApproval: vi.fn(),
+  maskProps: (className: string) => ({ className }),
+  EVENTS: { postApproved: 'post_approved', postRejected: 'post_rejected' },
+}))
+
+vi.mock('./content/ComposePost', () => ({ default: () => null }))
+vi.mock('./review/NewsletterQueue', () => ({ default: () => null }))
+vi.mock('./review/ScheduledDMs', () => ({ default: () => null }))
+vi.mock('./review/ConnectionRequests', () => ({ default: () => null }))
+vi.mock('./review/OutreachFunnel', () => ({ default: () => null }))
+vi.mock('./review/LeadsInbox', () => ({ default: () => null }))
+vi.mock('./review/LeadsPipeline', () => ({ default: () => null }))
+vi.mock('./review/CatchupTouches', () => ({ default: () => null }))
+
+const POST_BASE = {
+  post_id: 1,
+  content: 'Draft content',
+  video_url: null,
+  scheduled_time: '2026-07-28T13:00:00Z',
+  carousel_slides: null,
+  post_url: null,
+  archetype: null,
+  authenticity_score: null,
+  gate_reason: null,
+  rejection_reason: null,
+  post_type: 'text',
+  status: 'pending',
+}
+
+function payload(data: unknown) {
+  return { data: { detail: data } }
+}
+
+function harness(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <MemoryRouter initialEntries={['/?tab=review']}>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+  get.mockImplementation((path: string) => {
+    if (path.startsWith('/posts/')) {
+      return Promise.resolve(payload({ posts: [POST_BASE], total: 1, page: 1, page_size: 10 }))
+    }
+    if (path.startsWith('/content_generation_status')) return Promise.resolve(payload(null))
+    return Promise.resolve(payload({}))
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('ContentStudio scheduling with an unresolved timezone (issue #774)', () => {
+  it('blocks the bulk reschedule instead of reading the wall clock in a guessed zone', async () => {
+    harness(<ContentStudio />)
+    await waitFor(() => expect(screen.getByText('Draft content')).toBeDefined())
+
+    fireEvent.click(screen.getByLabelText('Select all on this page'))
+
+    const applyDate = screen.getByRole('button', { name: 'Apply Date' })
+    const dateInput = screen.getByLabelText(/Bulk schedule date and time/)
+    fireEvent.change(dateInput, { target: { value: '2026-07-28T09:00' } })
+
+    expect((applyDate as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.click(applyDate)
+    expect(post).not.toHaveBeenCalledWith('/posts/bulk_update/', expect.anything())
+  })
+
+  it('says the zone is still loading rather than naming the browser guess', async () => {
+    harness(<ContentStudio />)
+    await waitFor(() => expect(screen.getByText('Draft content')).toBeDefined())
+
+    fireEvent.click(screen.getByLabelText('Select all on this page'))
+
+    expect(screen.getByLabelText(/Bulk schedule date and time \(loading your timezone/)).toBeDefined()
+    expect(screen.queryByLabelText(/Bulk schedule date and time \(UTC\)/)).toBeNull()
+  })
+
+  it('locks the editor time field so an unconverted edit cannot be saved', async () => {
+    harness(<ContentStudio />)
+    await waitFor(() => expect(screen.getByText('Draft content')).toBeDefined())
+
+    fireEvent.click(screen.getByText('Draft content'))
+
+    const timeInput = await waitFor(() => screen.getByLabelText(/Scheduled Time/))
+    expect((timeInput as HTMLInputElement).disabled).toBe(true)
+    expect((timeInput as HTMLInputElement).value).toBe('')
+  })
+})

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -15,7 +15,7 @@ import LeadsPipeline from './review/LeadsPipeline'
 import CatchupTouches from './review/CatchupTouches'
 import ComposePost from './content/ComposePost'
 import { useAuth } from '../contexts/AuthContext'
-import { useUserTimezone } from '../hooks/useUserTimezone'
+import { useUserTimezoneState } from '../hooks/useUserTimezone'
 import { formatInTimezone, toZonedInputValue, zonedInputToUtcIso, zonedDateToUtcStart, zonedDateToUtcEnd } from '../utils/datetime'
 import { emptyRunExplanation, isGenerationRunning } from '../utils/generationStatus'
 import type { GenerationStatus } from '../utils/generationStatus'
@@ -191,7 +191,11 @@ export default function ContentStudio() {
   const { user, sessionToken } = useAuth()
   const email = user?.email ?? ''
   const qc = useQueryClient()
-  const userTimezone = useUserTimezone()
+  const { timezone: userTimezone, isResolved: timezoneResolved } = useUserTimezoneState()
+  // Say which clock a typed time is read in. Until the user's own zone has loaded we say so rather
+  // than naming the browser's guess — a picker silently labelled with the wrong zone is how a post
+  // meant for 9am local got stored as 09:00 UTC and published four hours early (issue #774).
+  const timezoneLabel = timezoneResolved ? userTimezone : 'loading your timezone…'
 
   // Top-level view (Posts / Newsletters), synced to the ?tab= query param for deep-linking.
   const [searchParams, setSearchParams] = useSearchParams()
@@ -642,9 +646,11 @@ export default function ContentStudio() {
         <ComposePost onNavigateTab={(t) => setView(t as View)} />
       </div>
 
-      {view === 'newsletters' && <NewsletterQueue userTimezone={userTimezone} />}
+      {view === 'newsletters' && (
+        <NewsletterQueue userTimezone={userTimezone} timezoneResolved={timezoneResolved} />
+      )}
 
-      {view === 'dms' && <ScheduledDMs userTimezone={userTimezone} />}
+      {view === 'dms' && <ScheduledDMs userTimezone={userTimezone} timezoneResolved={timezoneResolved} />}
 
       {view === 'connections' && <ConnectionRequests userTimezone={userTimezone} />}
 
@@ -823,10 +829,14 @@ export default function ContentStudio() {
               type="datetime-local"
               value={bulkDate}
               onChange={(e) => setBulkDate(e.target.value)}
+              aria-label={`Bulk schedule date and time (${timezoneLabel})`}
               className="border border-gray-300 rounded px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500"
             />
+            <span className="text-xs text-gray-400">{timezoneLabel}</span>
             <button
               onClick={() => {
+                // Never convert a typed wall clock against a guessed zone (issue #774).
+                if (!timezoneResolved) return
                 const utc = zonedInputToUtcIso(bulkDate, userTimezone)
                 if (!utc) return
                 bulkUpdateMutation.mutate({
@@ -834,7 +844,7 @@ export default function ContentStudio() {
                   scheduled_datetime: utc,
                 })
               }}
-              disabled={!bulkDate || bulkUpdateMutation.isPending}
+              disabled={!bulkDate || !timezoneResolved || bulkUpdateMutation.isPending}
               className="bg-blue-600 text-white px-3 py-1 rounded text-xs font-semibold hover:bg-blue-700 disabled:opacity-50"
             >
               Apply Date
@@ -1109,10 +1119,14 @@ export default function ContentStudio() {
                     </select>
                   </div>
                   <div>
-                    <label className="block text-xs font-medium text-gray-600 mb-1">Scheduled Time</label>
+                    <label className="block text-xs font-medium text-gray-600 mb-1">
+                      Scheduled Time <span className="font-normal text-gray-400">({timezoneLabel})</span>
+                    </label>
                     <input
                       type="datetime-local"
-                      value={toZonedInputValue(editingPost.scheduled_time, userTimezone)}
+                      value={timezoneResolved ? toZonedInputValue(editingPost.scheduled_time, userTimezone) : ''}
+                      disabled={!timezoneResolved}
+                      aria-label={`Scheduled Time (${timezoneLabel})`}
                       onChange={(e) =>
                         setEditingPost({
                           ...editingPost,
@@ -1120,7 +1134,7 @@ export default function ContentStudio() {
                             zonedInputToUtcIso(e.target.value, userTimezone) ?? editingPost.scheduled_time,
                         })
                       }
-                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                      className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
                     />
                   </div>
                 </div>

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.timezone.test.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.timezone.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import ComposePost from './ComposePost'
+
+// Issue #774: ComposePost is the surface a post is scheduled from, and its picker is a bare wall
+// clock — converting it against a GUESSED zone stores an instant hours from what was picked. Two
+// windows are covered here: the zone has never resolved (picker locked), and it resolved, a time
+// was typed, and it went unresolved again — a session-token change re-keys the query, so the
+// submit guard is reachable with a time already in the field.
+const get = vi.fn()
+const post = vi.fn()
+
+vi.mock('../../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
+  },
+}))
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'test@example.com', userId: 1 }, sessionToken: 'tok' }),
+}))
+
+// Mutable so a test can flip the zone from resolved to unresolved between renders.
+let tzState = { timezone: 'UTC', isResolved: false }
+vi.mock('../../hooks/useUserTimezone', () => ({
+  useUserTimezone: () => tzState.timezone,
+  useUserTimezoneState: () => tzState,
+}))
+
+vi.mock('../../utils/analytics', () => ({
+  maskProps: (className: string) => ({ className }),
+}))
+
+vi.mock('../../components/LinkedInPostPreview', () => ({ default: () => null }))
+vi.mock('../../components/TopicAuthorityMeter', () => ({ default: () => null }))
+
+// One client for the whole test, so a re-render re-reads tzState without remounting the page.
+let client: QueryClient
+
+function tree(ui: ReactNode) {
+  return (
+    <MemoryRouter>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+  tzState = { timezone: 'UTC', isResolved: false }
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  // Every query on this page reads r.data.detail; one shape satisfies all of them.
+  get.mockResolvedValue({ data: { detail: { templates: [] } } })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const timeInput = (c: HTMLElement) => c.querySelector('input[type="datetime-local"]') as HTMLInputElement
+
+describe('ComposePost scheduling with an unresolved timezone (issue #774)', () => {
+  it('locks the picker and names the wait rather than the browser guess', () => {
+    const { container } = render(tree(<ComposePost />))
+
+    expect(timeInput(container).disabled).toBe(true)
+    expect(screen.getByText(/loading your timezone/)).toBeDefined()
+    expect(screen.queryByText('(UTC)')).toBeNull()
+  })
+
+  it('refuses to submit a time typed while the zone was known but lost before submit', () => {
+    tzState = { timezone: 'America/New_York', isResolved: true }
+    const { container, rerender } = render(tree(<ComposePost />))
+
+    fireEvent.change(screen.getByPlaceholderText('What would you like to share?'), {
+      target: { value: 'Hello world' },
+    })
+    fireEvent.change(timeInput(container), { target: { value: '2026-07-28T09:00' } })
+
+    tzState = { timezone: 'UTC', isResolved: false }
+    rerender(tree(<ComposePost />))
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Draft' }))
+
+    expect(post).not.toHaveBeenCalled()
+    expect(screen.getByText(/timezone has not loaded yet/)).toBeDefined()
+  })
+})

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
@@ -5,7 +5,7 @@ import api from '../../api/client'
 import LinkedInPostPreview from '../../components/LinkedInPostPreview'
 import TopicAuthorityMeter from '../../components/TopicAuthorityMeter'
 import { useAuth } from '../../contexts/AuthContext'
-import { useUserTimezone } from '../../hooks/useUserTimezone'
+import { useUserTimezoneState } from '../../hooks/useUserTimezone'
 import { zonedInputToUtcIso } from '../../utils/datetime'
 import { maskProps } from '../../utils/analytics'
 
@@ -65,7 +65,7 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
   const [generatedSlideUrls, setGeneratedSlideUrls] = useState<string[]>([])
   const [generateError, setGenerateError] = useState<string | null>(null)
 
-  const userTimezone = useUserTimezone()
+  const { timezone: userTimezone, isResolved: timezoneResolved } = useUserTimezoneState()
 
   const { data: avatarData } = useQuery({
     queryKey: ['avatar-credits', sessionToken],
@@ -164,7 +164,18 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
     if (!email) { setResult({ ok: false, msg: 'Set your email in Account settings first.' }); return }
     if (!content.trim()) { setResult({ ok: false, msg: 'Post content is required.' }); return }
     if (!scheduledAt) { setResult({ ok: false, msg: 'Scheduled date/time is required.' }); return }
-    // The picker is a bare wall clock — read it in the user's timezone, not the browser's.
+    // The picker is a bare wall clock — read it in the user's timezone, not the browser's, and not
+    // against a GUESS of it (issue #774): until /user/timezone answers, `userTimezone` IS the
+    // browser's zone, so converting now would store the post offset by the difference and publish
+    // it hours from the time that was picked.
+    if (!timezoneResolved) {
+      setResult({
+        ok: false,
+        msg: 'Your timezone has not loaded yet — reload the page so this posts at the time you pick '
+          + '(you can set it under Account → Login Location).',
+      })
+      return
+    }
     const scheduledUtc = zonedInputToUtcIso(scheduledAt, userTimezone)
     if (!scheduledUtc) { setResult({ ok: false, msg: 'Scheduled date/time is not valid.' }); return }
     if (postType === 'CAROUSEL') {
@@ -531,13 +542,17 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
           {/* Schedule date/time */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
-              Schedule Date &amp; Time <span className="font-normal text-gray-400">({userTimezone})</span>
+              Schedule Date &amp; Time{' '}
+              <span className="font-normal text-gray-400">
+                ({timezoneResolved ? userTimezone : 'loading your timezone…'})
+              </span>
             </label>
             <input
               type="datetime-local"
               value={scheduledAt}
+              disabled={!timezoneResolved}
               onChange={(e) => setScheduledAt(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
             />
             {bestTimeSuggestion && (
               <div className="mt-2 bg-blue-50 border border-blue-200 rounded-lg px-3 py-2 flex items-center justify-between gap-2">

--- a/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
+++ b/src/cqc_lem/ui/src/pages/review/NewsletterQueue.tsx
@@ -15,7 +15,9 @@ const STATUS_COLORS: Record<string, string> = {
 // e.g. "case_study" -> "Case Study" for the format/hook badges.
 const prettyKey = (k: string) => k.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
 
-export default function NewsletterQueue({ userTimezone }: { userTimezone: string }) {
+export default function NewsletterQueue(
+  { userTimezone, timezoneResolved }: { userTimezone: string; timezoneResolved: boolean },
+) {
   const { user, sessionToken } = useAuth()
   const qc = useQueryClient()
   const [selectedId, setSelectedId] = useState<number | null>(null)
@@ -213,15 +215,21 @@ export default function NewsletterQueue({ userTimezone }: { userTimezone: string
             </div>
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Publish date &amp; time <span className="font-normal text-gray-400">({userTimezone})</span>
+                Publish date &amp; time{' '}
+                <span className="font-normal text-gray-400">
+                  ({timezoneResolved ? userTimezone : 'loading your timezone…'})
+                </span>
               </label>
+              {/* Locked until the user's own zone has loaded — converting the typed wall clock
+                  against the browser's guess would store an instant hours off (issue #774). */}
               <input
                 type="datetime-local"
-                value={toZonedInputValue(draftEdit.scheduled_for, userTimezone)}
+                value={timezoneResolved ? toZonedInputValue(draftEdit.scheduled_for, userTimezone) : ''}
+                disabled={!timezoneResolved}
                 onChange={(e) =>
                   setDe({ scheduled_for: zonedInputToUtcIso(e.target.value, userTimezone) ?? draftEdit.scheduled_for })
                 }
-                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:bg-gray-100"
               />
             </div>
 

--- a/src/cqc_lem/ui/src/pages/review/ScheduledDMs.timezone.test.tsx
+++ b/src/cqc_lem/ui/src/pages/review/ScheduledDMs.timezone.test.tsx
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import ScheduledDMs from './ScheduledDMs'
+
+// Issue #774: the DM picker is a bare wall clock too, and its send time is stored the same way a
+// post's is. Until /user/timezone answers the zone on offer is the BROWSER's, so a complete draft
+// must not be sendable — otherwise the DM goes out offset by the difference between the two zones.
+const get = vi.fn()
+const post = vi.fn()
+
+vi.mock('../../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
+    put: vi.fn(),
+  },
+}))
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'test@example.com', userId: 1 }, sessionToken: 'tok' }),
+}))
+
+vi.mock('../../utils/analytics', () => ({
+  maskProps: (className: string) => ({ className }),
+}))
+
+function harness(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+  get.mockResolvedValue({ data: { detail: { dms: [], total: 0 } } })
+  post.mockResolvedValue({ data: { detail: {} } })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+function fillDraft(container: HTMLElement) {
+  fireEvent.change(screen.getByPlaceholderText(/Recipient profile URL/), {
+    target: { value: 'https://www.linkedin.com/in/someone' },
+  })
+  fireEvent.change(screen.getByPlaceholderText(/Your message/), { target: { value: 'Hi there' } })
+  fireEvent.change(container.querySelector('input[type="datetime-local"]') as HTMLInputElement, {
+    target: { value: '2026-07-28T09:00' },
+  })
+}
+
+const scheduleButton = () => screen.getByRole('button', { name: 'Approve & schedule' }) as HTMLButtonElement
+const draftButton = () => screen.getByRole('button', { name: 'Save draft' }) as HTMLButtonElement
+
+describe('ScheduledDMs with an unresolved timezone (issue #774)', () => {
+  it('will not send an otherwise-complete draft, and says the zone is still loading', () => {
+    const { container } = harness(<ScheduledDMs userTimezone="UTC" timezoneResolved={false} />)
+    fillDraft(container)
+
+    expect(draftButton().disabled).toBe(true)
+    expect(scheduleButton().disabled).toBe(true)
+    fireEvent.click(scheduleButton())
+    expect(post).not.toHaveBeenCalled()
+
+    expect(screen.getByText(/loading your timezone/)).toBeDefined()
+    expect(screen.queryByText('UTC')).toBeNull()
+  })
+
+  it('sends the same draft once the zone is the user’s own', async () => {
+    const { container } = harness(<ScheduledDMs userTimezone="America/New_York" timezoneResolved />)
+    fillDraft(container)
+
+    expect(scheduleButton().disabled).toBe(false)
+    fireEvent.click(scheduleButton())
+
+    // 09:00 in New York on that date is 13:00Z — the conversion the unresolved case must not guess.
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith(
+        '/schedule_dm',
+        expect.objectContaining({ scheduled_datetime: '2026-07-28T13:00:00.000Z' }),
+      ),
+    )
+  })
+})

--- a/src/cqc_lem/ui/src/pages/review/ScheduledDMs.tsx
+++ b/src/cqc_lem/ui/src/pages/review/ScheduledDMs.tsx
@@ -36,7 +36,9 @@ const STATUS_COLORS: Record<string, string> = {
 
 const STATUSES = ['ALL', 'pending', 'approved', 'scheduled', 'sent', 'failed', 'canceled']
 
-export default function ScheduledDMs({ userTimezone }: { userTimezone: string }) {
+export default function ScheduledDMs(
+  { userTimezone, timezoneResolved }: { userTimezone: string; timezoneResolved: boolean },
+) {
   const { sessionToken } = useAuth()
   const qc = useQueryClient()
   const [filter, setFilter] = useState('ALL')
@@ -83,6 +85,12 @@ export default function ScheduledDMs({ userTimezone }: { userTimezone: string })
   // The picker is a bare wall clock — read it in the user's timezone, not the browser's. An
   // unparseable value yields null, which the API would reject with a 422; catch it here instead.
   const submit = (status: 'pending' | 'approved') => {
+    // …and not against a GUESS of it either (issue #774) — until /user/timezone answers,
+    // `userTimezone` is the browser's zone and the send would land offset by the difference.
+    if (!timezoneResolved) {
+      flash(false, 'Your timezone has not loaded yet — reload the page so this sends at the time you pick.')
+      return
+    }
     const scheduledUtc = zonedInputToUtcIso(when, userTimezone)
     if (!scheduledUtc) { flash(false, 'Scheduled date/time is not valid.'); return }
     createMutation.mutate({ status, scheduledUtc })
@@ -94,7 +102,7 @@ export default function ScheduledDMs({ userTimezone }: { userTimezone: string })
     onSuccess: () => invalidate(),
   })
 
-  const canSubmit = url.trim() && body.trim() && when
+  const canSubmit = url.trim() && body.trim() && when && timezoneResolved
 
   return (
     <div className="space-y-4">
@@ -122,7 +130,7 @@ export default function ScheduledDMs({ userTimezone }: { userTimezone: string })
           <label className="flex items-center gap-2 text-xs text-gray-500">
             <input type="datetime-local" value={when} onChange={(e) => setWhen(e.target.value)}
               className="border border-gray-300 rounded-lg px-3 py-2 text-sm" />
-            {userTimezone}
+            {timezoneResolved ? userTimezone : 'loading your timezone…'}
           </label>
           <button onClick={() => submit('pending')} disabled={!canSubmit || createMutation.isPending}
             className="px-4 py-2 border border-gray-300 rounded-lg text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50">

--- a/tests/unit/api/test_schedule_timezone_breadcrumb.py
+++ b/tests/unit/api/test_schedule_timezone_breadcrumb.py
@@ -1,0 +1,128 @@
+"""Issue #774 — a scheduling write that arrives WITHOUT a UTC offset must leave a breadcrumb.
+
+`db.to_naive_utc` treats a naive datetime as already-UTC, which is the contract
+(docs/timezone-contract.md) but also the silent failure mode: a wall clock the user picked in their
+own zone is stored verbatim and the post fires offset-hours early — post 33 was scheduled for 9am
+ET and published at 5am ET, and the only evidence was the wrong publish time. The value is still
+interpreted as UTC (legacy callers depend on it); we just refuse to do it silently.
+"""
+
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_MAIN = "cqc_lem.api.main"
+
+_NAIVE = "2026-07-28T09:00:00"
+_AWARE = "2026-07-28T13:00:00Z"
+
+_POST_BODY = {
+    "content": "Test content",
+    "video_url": None,
+    "post_type": "text",
+    "status": "pending",
+    "email": "test@example.com",
+}
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+def _warned(mock_warn) -> bool:
+    return any("Naive scheduled_datetime" in str(call.args[0]) for call in mock_warn.call_args_list)
+
+
+class TestWarnIfNaiveSchedule:
+    def test_helper_is_quiet_for_an_aware_datetime(self):
+        from datetime import datetime, timezone
+        from cqc_lem.api.main import _warn_if_naive_schedule
+        with patch(f"{_MAIN}.log_warning") as warn:
+            _warn_if_naive_schedule(datetime(2026, 7, 28, 13, tzinfo=timezone.utc), "/x/")
+        assert not _warned(warn)
+
+    def test_helper_is_quiet_for_none(self):
+        from cqc_lem.api.main import _warn_if_naive_schedule
+        with patch(f"{_MAIN}.log_warning") as warn:
+            _warn_if_naive_schedule(None, "/x/")
+        assert not _warned(warn)
+
+    def test_helper_warns_for_a_naive_datetime(self):
+        from datetime import datetime
+        from cqc_lem.api.main import _warn_if_naive_schedule
+        with patch(f"{_MAIN}.log_warning") as warn:
+            _warn_if_naive_schedule(datetime(2026, 7, 28, 9), "/x/", user_id=7)
+        assert _warned(warn)
+        assert warn.call_args.kwargs["user_id"] == 7
+
+
+class TestSchedulePostEndpoint:
+    def test_warns_on_a_naive_scheduled_datetime(self, client):
+        with patch(f"{_MAIN}.get_user_id", return_value=7), \
+             patch(f"{_MAIN}.insert_post", return_value=True), \
+             patch(f"{_MAIN}.log_warning") as warn:
+            resp = client.post("/api/schedule_post/", json={**_POST_BODY, "scheduled_datetime": _NAIVE})
+        assert resp.status_code == 200
+        assert _warned(warn)
+
+    def test_quiet_on_an_explicit_utc_scheduled_datetime(self, client):
+        with patch(f"{_MAIN}.get_user_id", return_value=7), \
+             patch(f"{_MAIN}.insert_post", return_value=True), \
+             patch(f"{_MAIN}.log_warning") as warn:
+            resp = client.post("/api/schedule_post/", json={**_POST_BODY, "scheduled_datetime": _AWARE})
+        assert resp.status_code == 200
+        assert not _warned(warn)
+
+
+class TestUpdatePostEndpoint:
+    def test_warns_on_a_naive_scheduled_datetime(self, client):
+        with patch(f"{_MAIN}.update_db_post", return_value=True), \
+             patch(f"{_MAIN}.log_warning") as warn:
+            resp = client.post("/api/update_post/?post_id=33",
+                               json={**_POST_BODY, "scheduled_datetime": _NAIVE})
+        assert resp.status_code == 200
+        assert _warned(warn)
+
+    def test_quiet_on_an_explicit_utc_scheduled_datetime(self, client):
+        with patch(f"{_MAIN}.update_db_post", return_value=True), \
+             patch(f"{_MAIN}.log_warning") as warn:
+            resp = client.post("/api/update_post/?post_id=33",
+                               json={**_POST_BODY, "scheduled_datetime": _AWARE})
+        assert resp.status_code == 200
+        assert not _warned(warn)
+
+
+class TestBulkUpdateEndpoint:
+    def test_warns_on_a_naive_scheduled_datetime(self, client):
+        with patch(f"{_MAIN}.bulk_update_posts", return_value=True), \
+             patch(f"{_MAIN}.log_warning") as warn:
+            resp = client.post("/api/posts/bulk_update/",
+                               json={"post_ids": [33], "scheduled_datetime": _NAIVE})
+        assert resp.status_code == 200
+        assert _warned(warn)
+
+    def test_quiet_when_no_scheduled_datetime_is_sent(self, client):
+        with patch(f"{_MAIN}.bulk_update_posts", return_value=True), \
+             patch(f"{_MAIN}.log_warning") as warn:
+            resp = client.post("/api/posts/bulk_update/",
+                               json={"post_ids": [33], "status": "approved"})
+        assert resp.status_code == 200
+        assert not _warned(warn)


### PR DESCRIPTION
## What happened

Post 33 was scheduled for 9am ET and went out at 5am ET.

**The scheduler was not at fault.** Production logs show it honored the stored instant exactly:

```
2026-07-28T08:40:00Z  Post 33 queued for 2026-07-28 09:00:00+00:00
2026-07-28T09:02:19Z  Pre-post engagement pass complete
2026-07-28T09:22:20Z  Golden-hour reply_sweep on post 33: … 22 min after publish
```

`09:00Z` **is** 5am ET. The stored time was wrong: the wall clock the user picked was read in a
zone that wasn't theirs. Post 37, two days later, stored the same 9am pick correctly as `13:00Z` —
same user, same input, two different interpreting zones.

## Why

`useUserTimezone()` silently substituted `Intl.DateTimeFormat().resolvedOptions().timeZone` — the
**browser's** zone — whenever the user's own zone wasn't available: while `/user/timezone` is in
flight, before the session token hydrates, or if the request fails. Every scheduling surface
converts the typed wall clock with whatever that hook returned at that moment, so a browser zone
that differs from the configured one (travel, VPN, a UTC machine, a slow request) stores the post
offset by the difference.

Rendering a value in the wrong zone for a few milliseconds is cosmetic. **Converting an input
against it is not** — that instant is persisted and published. And ContentStudio's two post pickers
carried no zone label at all, so "09:00" was unfalsifiable to the user.

## What changed

- **`useUserTimezoneState()`** returns `{ timezone, isResolved }`; `isResolved` is true only when
  `/user/timezone` actually answered. `useUserTimezone()` still returns the bare string for
  display-only callers (Dashboard, list rows) where a brief fallback is harmless.
- **Convert-on-change pickers** (ContentStudio editor, NewsletterQueue) are **locked** until the
  zone is known — their `onChange` writes a converted UTC instant into state.
- **Convert-on-submit pickers** (ComposePost, ContentStudio bulk reschedule, ScheduledDMs) **refuse
  the write** and say why.
- **Every picker names the zone it is read in.** Unresolved reads `loading your timezone…` rather
  than naming the guess. The query now retries, so a transient blip can't leave scheduling locked.
- **`_warn_if_naive_schedule()`** logs a WARNING when `/schedule_post/`, `/update_post/` or
  `/posts/bulk_update/` receive an offset-less datetime. It is still interpreted as UTC (that's the
  contract, and legacy callers depend on it) — just no longer *silently*, so the next occurrence is
  visible in logs instead of only in a mistimed post.
- `docs/timezone-contract.md` §4 records the rule.

## Testing

- `src/hooks/useUserTimezone.test.tsx` — 5 cases: in-flight, resolved, failed, no session token,
  and the display-only string hook.
- `src/pages/ContentStudio.timezone.test.tsx` — 3 cases pinned to an unresolved zone: bulk
  reschedule blocked, label says loading (never `UTC`), editor time field locked and empty.
- `tests/unit/api/test_schedule_timezone_breadcrumb.py` — 9 cases across the helper and all three
  endpoints, asserting naive warns and explicit-UTC / absent stays quiet.
- `poetry run pytest tests/unit -q` → **8218 passed**. `tsc -b` clean.
- **vitest could not be run locally** (this box has Node 18; CI uses Node 22 and runs `npm test` in
  the UI Build job) — the new SPA tests are verified by CI, not by me.

## Note on existing rows

This prevents recurrence; it does not retro-correct rows already stored under a wrong zone (post 33
included). Which rows those are isn't recoverable — nothing recorded the zone each write was
converted with — so a blanket re-localize would move correctly-stored posts too. Affected posts
should be rescheduled by hand; the pickers now show the zone, so the value is checkable.

Closes #774

🤖 Generated with [Claude Code](https://claude.com/claude-code)