### PR TITLE
fix(observability): escalate recurring warnings so real defects reach error tracking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -549,13 +549,35 @@ POSTHOG_HOST=https://us.i.posthog.com
 # Both are also passed to the litellm container (as POSTHOG_API_KEY / POSTHOG_API_URL), where the
 # native posthog callback emits one $ai_generation per LLM call — issue #647, docs/llm-analytics.md.
 # Prompts/completions are redacted before they reach it (litellm_settings.turn_off_message_logging).
-# Minimum log level forwarded to PostHog (DEBUG/INFO/WARNING/ERROR/CRITICAL). Default: ERROR
-POSTHOG_LOG_LEVEL=ERROR
+# Minimum log level forwarded to PostHog (DEBUG/INFO/WARNING/ERROR/CRITICAL). Default: ERROR.
+# WARNING is the useful floor once escalation is on (below): the warning body is the CONTEXT for the
+# escalated $exception. DEBUG floods — it put 2,185 info rows into PostHog Logs in 48h.
+POSTHOG_LOG_LEVEL=WARNING
 # Error tracking (issue #648, docs/error-tracking.md). Both default ON and only need setting to
 # turn capture OFF: AUTOCAPTURE is the excepthook for uncaught exceptions, CAPTURE is the
 # log_error/log_critical(exc=...) forwarding. Logs are unaffected either way.
 POSTHOG_EXCEPTION_AUTOCAPTURE=true
 POSTHOG_EXCEPTION_CAPTURE=true
+# ── Recurrence escalation (utilities/log_escalation.py) ──────────────────────────────────────────
+# "Once is a warning, repeatedly is a defect." A log_warning can never produce an $exception, so a
+# selector that had been missing for three days looked exactly like a one-off transient and the
+# daily error->issue cron never saw either. These count occurrences per (call site, normalized
+# message) in Redis; crossing the threshold re-emits the record at ERROR and files it as ONE grouped
+# PostHog issue. Fails open: no Redis, or ENABLED=false, restores the pre-escalation behaviour.
+LOG_ESCALATION_ENABLED=true
+# Occurrences within the window that turn a WARNING into an ERROR.
+LOG_ESCALATE_THRESHOLD=3
+# Tumbling window. 24h on purpose: the error->issue cron looks back 24h, so an escalation always
+# lands inside the next cron run. A 1h window would never trip on a fault that recurs ~5x/day.
+LOG_ESCALATE_WINDOW_SECONDS=86400
+# Re-escalate every Nth occurrence past the threshold so the issue's count tracks real magnitude
+# (0 = escalate once per window, which makes every issue read "1x").
+LOG_ESCALATE_REPEAT_EVERY=10
+# Ceiling across ALL fingerprints per window, so a bad deploy can't flood error tracking.
+LOG_ESCALATE_MAX_PER_WINDOW=50
+# Comma-separated message prefixes that never escalate. The default breaks the one real feedback
+# loop: capture_exception's own failure handler calls log_warning.
+LOG_ESCALATE_EXCLUDE=Could not capture exception in PostHog
 # Personal API key (insight + dashboard write scope) used by scripts/posthog_dashboards.py to
 # provision the cost/margin dashboards (§E.1), and — read-only — by the daily budget alerts to read
 # LLM cache-hit rate (§E.2). Optional in the stack: unset just skips the cache-hit check.

--- a/.env.prod.example
+++ b/.env.prod.example
@@ -145,7 +145,17 @@ CAPSOLVER_API_KEY=
 # =============================================================================
 POSTHOG_API_KEY=CHANGE_ME
 POSTHOG_HOST=https://us.i.posthog.com
-POSTHOG_LOG_LEVEL=ERROR
+# WARNING, not DEBUG: DEBUG put 2,185 info rows into PostHog Logs in 48h and buried the 172 real
+# warnings. The warning body is the context for an escalated $exception — see LOG_ESCALATE_* below.
+POSTHOG_LOG_LEVEL=WARNING
+# Project id + app host. POSTHOG_PROJECT_ID is load-bearing beyond the provisioning scripts:
+# observability.session_replay_url() returns nothing without it, so every feedback and error issue
+# ships without its replay link.
+POSTHOG_PROJECT_ID=475262
+POSTHOG_APP_HOST=https://us.posthog.com
+# Recurrence escalation — "once is a warning, repeatedly is a defect". See .env.example for the full
+# knob list; the defaults (3 occurrences / 24h window) are what prod runs.
+LOG_ESCALATION_ENABLED=true
 # Browser-side PostHog (issue #646). BUILD-time only — the SPA bundle bakes these in, so setting
 # them here does nothing; they are passed as docker build-args (CI: UI_POSTHOG_KEY secret).
 # VITE_POSTHOG_KEY=phc_...

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,30 +53,15 @@ compose/local/database/migrations/  Flyway migrations
 
 ## Code Conventions
 
-- **Logging:** Never use `print()`. Use the structured logger from `cqc_lem.utilities.logger`. Prefer typed helpers over the legacy `myprint()` shim:
-
-  | Function | Level | When to use |
-  |---|---|---|
-  | `log_debug(msg, **ctx)` | DEBUG | Verbose detail: LLM calls, Selenium steps, DB queries |
-  | `log_info(msg, **ctx)` | INFO | Normal task progress and state transitions |
-  | `log_warning(msg, exc=None, **ctx)` | WARNING | Recoverable failures, fallbacks, degraded paths |
-  | `log_error(msg, exc=None, **ctx)` | ERROR | Task-level failures — automatically sent to PostHog |
-  | `log_critical(msg, exc=None, **ctx)` | CRITICAL | Fatal conditions — automatically sent to PostHog |
-  | `myprint(msg, debug=False)` | INFO/DEBUG | Legacy shim — still works, avoid in new code |
-
-  Pass structured context as keyword args. Supported fields: `user_id`, `task_id`, `task_name`, `post_id`, `action_type`, `duration_ms`, `ai_model`, `api_provider`, `http_status`. `log_error` / `log_critical` accept `exc=` for the full exception + stack trace.
-
-  ```python
-  from cqc_lem.utilities.logger import log_info, log_warning, log_error
-
-  log_info("Scheduled post", post_id=post_id, user_id=user_id, task_name="auto_check_scheduled_posts")
-  log_warning("Perplexity unavailable, falling back to GoogleNews", exc=e, api_provider="perplexity")
-  log_error("Automation task failed", exc=e, user_id=user_id, task_name="automate_commenting")
-  ```
-
-  Log level and PostHog threshold are configurable via env vars:
-  - `LOG_LEVEL` — overall logging level (default: `INFO`)
-  - `POSTHOG_LOG_LEVEL` — minimum level forwarded to PostHog (default: `ERROR`)
+- **Logging:** Never use `print()`. Use the structured logger from `cqc_lem.utilities.logger`
+  (`log_debug` / `log_info` / `log_warning` / `log_error` / `log_critical`; `myprint()` is a legacy
+  shim — avoid in new code). Pass context as keyword args (`user_id`, `post_id`, `task_name`,
+  `action_type`, …); `log_error`/`log_critical` take `exc=`.
+  **Once is a warning, repeatedly is a defect:** a repeated `log_warning` re-emits at ERROR and files
+  ONE grouped `$exception`, so never warn on an expected no-op — log those DEBUG.
+  Level table, the escalation contract and the rest of the conventions:
+  **`src/cqc_lem/utilities/CLAUDE.md`** (auto-loads when editing that tree) and
+  `docs/error-tracking.md`.
 
 - **Type hints:** Required on all function signatures.
 - **Enums:** Use `PostStatus`, `PostType`, `LogActionType` from `db.py` for status fields — never raw strings.

--- a/docs/error-tracking.md
+++ b/docs/error-tracking.md
@@ -15,6 +15,7 @@ issue id ↔ one GitHub issue".
 |---|---|
 | Any Python process | `posthog.enable_exception_autocapture` — set in `utilities/observability.py`, catches UNCAUGHT exceptions via the excepthook |
 | Anything logged with `exc=` | `log_error` / `log_critical` also call `capture_exception` (`utilities/logger.py`) |
+| A **repeated** `log_warning` | `utilities/log_escalation.py` — see [Recurrence escalation](#recurrence-escalation-once-is-a-warning-repeatedly-is-a-defect) |
 | Celery tasks | `task_failure` + `task_retry` handlers in `app/my_celery.py`, with `task_name`, `task_id` and the dispatched `user_id` |
 | FastAPI routes | the unhandled-exception branch of `observability_middleware` in `api/main.py`, with `route` + `method` |
 | The SPA | `posthog-js` `capture_exceptions` (unhandled errors + rejections), plus `captureException()` from `ui/src/utils/analytics.ts` for anything the app catches itself |
@@ -38,6 +39,82 @@ Kill switches (both default ON, both read at import):
 | `POSTHOG_EXCEPTION_CAPTURE=false` | `log_error`/`log_critical` stop forwarding |
 
 With no `POSTHOG_API_KEY` at all, `posthog.disabled` is already True and nothing is sent.
+
+## Recurrence escalation: once is a warning, repeatedly is a defect
+
+`log_warning` never called `_capture()` — only `log_error`/`log_critical` did, and only with `exc=`.
+So a warning could not become an `$exception`, could not become an Error Tracking issue, and could
+not become a GitHub issue. A LinkedIn selector that had been missing for three straight days and a
+one-off network blip were, to PostHog, the same thing: a log line nobody was paged about.
+
+The state that produced this design, measured 2026-07-31 over 48h: **2,185 `info` + 172 `warn` +
+zero `error`** rows in PostHog Logs, and **zero `$exception` events**. The daily error→issue cron ran
+every day and correctly filed nothing, because its input was empty. Meanwhile
+`Selector miss: Open reactions menu` had fired 30 times, `Inline comment post failed` 26 times, and
+`PostHog endpoint call failed` 27 times — all invisible.
+
+`utilities/log_escalation.py` counts occurrences and promotes the repeat offenders.
+
+**The dedup key.** The logger only ever sees the *interpolated* string, so volatile tokens are masked
+before hashing — URLs, emails, UUIDs, URNs, hex ids, `[...]` lists, quoted strings, bare numbers —
+then combined with the **call site** (`module.function`, never the line number: a line moving during
+an unrelated edit must not reset the counter and fork a new issue). The masking is tuned so that
+`Re-queueing orphaned connection request 41` and `... 42` are ONE problem, while
+`Selector miss: Feed sort control` and `Selector miss: Reaction state` stay TWO — they are two
+different broken selectors and collapsing them would hide one behind the other.
+
+**The counter.** Redis (`shared_redis_client()`, the same handle the 429 breaker uses), one
+non-transactional pipeline per warning. The window is **tumbling, not sliding** — `INCR` + `EXPIRE`
+is one round trip with self-expiring memory, where a true sliding window would need a sorted set and
+unbounded per-fingerprint storage. The cost is that a fault straddling a window boundary defers one
+window; that is an acceptable trade for a logging hot path.
+
+**Why 3-in-24h.** `LOG_ESCALATE_WINDOW_SECONDS` defaults to 24h to match the cron's own 24h lookback,
+so an escalation always lands inside the next cron run. It is not arbitrary: `Selector miss: Feed
+sort control` fires ~5×/day, so a 1-hour window at threshold 3 would *never* trip on exactly the
+class of slow-burn breakage this exists to catch. `LOG_ESCALATE_REPEAT_EVERY` (10) re-escalates
+periodically past the threshold so the issue's occurrence count tracks real magnitude — escalating
+exactly once per window would make every issue read "1x" regardless of whether it happened 3 times
+or 300.
+
+**Grouping is pinned explicitly.** PostHog's default fingerprint is exception type + first in-app
+stack frame. Every `Selector miss: *` is raised from the same line of `find_first`, so the default
+would collapse all of them into ONE issue. `capture_exception(..., fingerprint=...)` sets
+`$exception_fingerprint` to `lem-log:<hash>`, which is what keeps distinct breakages distinct and
+what makes grouping survive a refactor of `find_first`'s internals.
+
+**The exception object.** When the call site passed `exc=`, that real exception is reused — a genuine
+stack groups and debugs better. Otherwise a `RecurringWarning` is constructed (never raised) whose
+message is the masked text, so the PostHog issue title reads as the problem itself.
+
+**It fails open at every step.** No Redis, `LOG_ESCALATION_ENABLED=false`, an excluded prefix, or any
+internal error → `note()` returns `None` and `log_warning` behaves exactly as it did before. Two
+extra guards matter in production:
+
+- **A Redis-outage circuit.** `redis.Redis.from_url` does not connect eagerly, so a dead Redis would
+  otherwise cost the 2s `socket_connect_timeout` on *every* warning across ~400 call sites. After
+  `LOG_ESCALATE_REDIS_FAILURES` consecutive failures the process stops calling Redis until
+  `LOG_ESCALATE_REDIS_COOLDOWN_SECONDS` passes.
+- **Re-entrancy.** `capture_exception`'s own failure handler calls `log_warning`. A thread-local flag
+  makes recursion structurally impossible, and `LOG_ESCALATE_EXCLUDE` defaults to that message as a
+  second layer.
+
+**What this means when you write a call site.** A warning you emit on a benign, expected path will
+now file a defect. Log those at DEBUG instead. The pattern is `react_to_post_inline`, which used to
+return `False` both for "already reacted" (a no-op) and for genuine failure, so the caller reported a
+working skip as `Could not leave a reaction on post`; it now returns `None` for the no-op — still
+falsy, so truthiness callers are unaffected — and only real failures warn.
+
+| Env | Default | Purpose |
+|---|---|---|
+| `LOG_ESCALATION_ENABLED` | `true` | master switch; false → zero Redis calls |
+| `LOG_ESCALATE_THRESHOLD` | `3` | occurrences in the window that promote to ERROR |
+| `LOG_ESCALATE_WINDOW_SECONDS` | `86400` | tumbling window; matches the cron lookback |
+| `LOG_ESCALATE_REPEAT_EVERY` | `10` | re-escalate every Nth past the threshold (0 = once) |
+| `LOG_ESCALATE_MAX_PER_WINDOW` | `50` | ceiling across all fingerprints |
+| `LOG_ESCALATE_EXCLUDE` | capture-failure message | comma-separated never-escalate prefixes |
+| `LOG_ESCALATE_LOCAL_CAP` | `200` | per-process per-fingerprint cap on Redis calls |
+| `LOG_ESCALATE_REDIS_FAILURES` / `_COOLDOWN_SECONDS` | `3` / `300` | the outage circuit |
 
 ## Readable stack traces (source maps)
 

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -70,6 +70,30 @@ instead of silently evaluating to `False` inside a Celery task.
 | `tutorial-videos-enabled` | `TUTORIAL_VIDEOS_ENABLED` | `false` | marketing | The weekly tutorial producer (`video_tutorials.py`) AND the SPA section that embeds its output — one toggle covers both. System-scoped. |
 | `feed-fallback-when-empty-default` | `FEED_FALLBACK_WHEN_EMPTY_DEFAULT` | `true` | engagement | Fleet default for `feed_fallback_when_empty` for users with no SAVED engagement row. A saved per-user setting always wins. |
 | `cost-routing-enabled` | `COST_ROUTING_ENABLED` | `false` | cost | App side of cost-aware down-routing (`cost_routing.py`) — written into the published routing policy. System-scoped. |
+| `posthog-surveys-enabled` | `POSTHOG_SURVEYS_ENABLED` | `false` | growth | Gates the headless PostHog survey renderer (issue #653, `docs/surveys.md`). Keep OFF until the SPA bundle carries a `VITE_POSTHOG_KEY` and the surveys are launched. |
+
+## Provisioning
+
+`scripts/posthog_flags.py` creates these in PostHog from the registry itself — `utilities/flags.py`
+is the source of truth, so a new flag is one registry entry, not two edits that drift.
+
+```bash
+python scripts/posthog_flags.py --print-spec   # no key needed; shows the planned rollouts
+python scripts/posthog_flags.py --dry-run      # exit 2 when changes are pending
+python scripts/posthog_flags.py --apply
+```
+
+**The safety property:** each flag is created at the rollout that reproduces what it resolves to
+**today**. Every lookup currently falls back to `env_default()`, so a flag created at a different
+value changes production the moment it appears — no deploy, no log line, no error.
+`feed-fallback-when-empty-default` is the live example: it defaults to `true`, so it is provisioned
+at **100%**. Creating it at the obvious-looking 0% would silently flip the fleet engagement default
+for every user without a saved preferences row. The script derives the percentage rather than
+accepting one, so that mistake is not reachable by hand.
+
+Release conditions are rollout-percentage only, never person properties — `flags.py` evaluates
+locally, and a condition needing server-held person properties falls back to env in every Celery
+worker, which looks identical to the flag working.
 
 ## Adding a flag
 

--- a/scripts/posthog_flags.py
+++ b/scripts/posthog_flags.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Provision LEM's boolean feature flags in PostHog from the in-code registry.
+
+Every other PostHog surface has a provisioner (dashboards, alerts, surveys, experiments, endpoints);
+plain boolean flags were the one gap — `docs/feature-flags.md` just said "create the flag in
+PostHog", and nobody had, so all five resolved by failing open to their env vars and the kill
+switches did not actually exist.
+
+`utilities/flags.py` is the source of truth, not a copy here: the registry supplies the key, the env
+var and the default, so a new flag is one registry entry rather than two edits that can drift.
+
+THE SAFETY PROPERTY: a flag is created at the rollout that REPRODUCES WHAT IT RESOLVES TO TODAY.
+`flag_enabled()` currently falls back to `env_default()` everywhere, so creating a flag that resolves
+differently would change production behaviour the moment it appears — silently, with no deploy and no
+log line. `feed-fallback-when-empty-default` is the live example: it defaults to TRUE, so it must be
+created at 100%. Creating it at the "obvious" 0% would flip the fleet engagement default for every
+user without a saved preferences row.
+
+Release conditions are rollout-percentage only, never person properties: `flags.py` evaluates
+locally (`only_evaluate_locally=True`), and a condition needing server-held person properties
+silently falls back to env in every Celery worker — which looks identical to the flag working.
+
+Usage:
+    python scripts/posthog_flags.py --dry-run     # default; report only
+    python scripts/posthog_flags.py --apply
+Exit: 0 in sync / applied, 2 pending changes in dry-run, 1 error.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from typing import Optional
+
+DEFAULT_PROJECT_ID = "475262"  # "CQC LEM" — not a secret; the key that reaches it is.
+DEFAULT_APP_HOST = "https://us.posthog.com"
+
+# Only these are compared against what PostHog returns, so a field the UI adds (folder, created_by,
+# tags, experiment links) never reads as permanent drift in --dry-run.
+MANAGED_FIELDS = ("name", "active", "rollout")
+
+
+def registry_specs() -> list:
+    """The registry as provisioning specs. Imports the app package deliberately —
+    `utilities/flags.py` IS the contract, and duplicating it here is how the two drift."""
+    from cqc_lem.utilities import flags
+
+    specs = []
+    for row in flags.registry_rows():
+        resolved = flags.env_default(row["key"])
+        specs.append({
+            "key": row["key"],
+            # A flag's rollout must reproduce today's resolved value, not its registry default —
+            # the env var may already override it in prod.
+            "rollout": 100 if resolved else 0,
+            "resolved": resolved,
+            "name": f"{row['description'][:120]}",
+            "env_var": row["env_var"],
+            "owner": row["owner"],
+        })
+    return specs
+
+
+def flag_payload(spec: dict) -> dict:
+    return {
+        "key": spec["key"],
+        "name": spec["name"],
+        "active": True,
+        "filters": {
+            # Property-free by design — see the module docstring.
+            "groups": [{"properties": [], "rollout_percentage": spec["rollout"]}],
+        },
+    }
+
+
+def _current_rollout(flag: dict) -> Optional[int]:
+    groups = ((flag.get("filters") or {}).get("groups") or [])
+    if not groups:
+        return None
+    return groups[0].get("rollout_percentage")
+
+
+def plan_flags(specs: list, existing: dict) -> list:
+    """Pure planning: create / update / noop per flag. No network."""
+    actions = []
+    for spec in specs:
+        found = existing.get(spec["key"])
+        if not found:
+            actions.append({"action": "create_flag", "key": spec["key"], "spec": spec})
+            continue
+        drift = []
+        if _current_rollout(found) != spec["rollout"]:
+            drift.append("rollout")
+        if not found.get("active"):
+            drift.append("active")
+        if drift:
+            actions.append({"action": "update_flag", "key": spec["key"], "spec": spec,
+                            "flag_id": found.get("id"), "fields": drift})
+        else:
+            actions.append({"action": "noop", "key": spec["key"]})
+    return actions
+
+
+def pending(actions: list) -> list:
+    return [a for a in actions if a["action"] != "noop"]
+
+
+def summarize(actions: list) -> str:
+    counts: dict = {}
+    for action in actions:
+        counts[action["action"]] = counts.get(action["action"], 0) + 1
+    if not pending(actions):
+        return "PostHog feature flags in sync — nothing to do."
+    return "Pending: " + ", ".join(f"{v} {k}" for k, v in sorted(counts.items()) if k != "noop")
+
+
+class PostHogFlagClient:
+    """Thin PostHog REST wrapper — only the feature-flag calls this provisioner needs."""
+
+    def __init__(self, api_key: str, project_id: str, app_host: str = DEFAULT_APP_HOST) -> None:
+        self.project_id = project_id
+        self.app_host = app_host.rstrip("/")
+        self._base = f"{self.app_host}/api/projects/{project_id}"
+        self._headers = {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        import requests
+        response = requests.request(method, f"{self._base}{path}", headers=self._headers,
+                                    timeout=30, **kwargs)
+        response.raise_for_status()
+        return response.json() if response.content else {}
+
+    def _paged(self, path: str) -> list:
+        import requests
+        results, url = [], f"{self._base}{path}"
+        while url:
+            response = requests.get(url, headers=self._headers, timeout=30)
+            response.raise_for_status()
+            payload = response.json()
+            results.extend(payload.get("results", []))
+            url = payload.get("next")
+        return results
+
+    def list_flags(self) -> dict:
+        flags = {}
+        for item in self._paged("/feature_flags/?limit=100"):
+            if item.get("deleted"):
+                continue
+            flags[item.get("key")] = item
+        return flags
+
+    def create_flag(self, payload: dict):
+        return self._request("POST", "/feature_flags/", json=payload).get("id")
+
+    def update_flag(self, flag_id, payload: dict) -> None:
+        self._request("PATCH", f"/feature_flags/{flag_id}/", json=payload)
+
+
+def apply_actions(client: PostHogFlagClient, actions: list, dry_run: bool = True) -> list:
+    log: list = []
+    for action in actions:
+        kind, key = action["action"], action.get("key")
+        spec = action.get("spec") or {}
+        if kind == "noop":
+            log.append(f"flag '{key}' is in sync")
+        elif kind == "create_flag":
+            resolved = "enabled" if spec.get("resolved") else "disabled"
+            detail = f"'{key}' at {spec.get('rollout')}% (matches today's {resolved} via {spec.get('env_var')})"
+            if dry_run:
+                log.append(f"[dry-run] create flag {detail}")
+                continue
+            flag_id = client.create_flag(flag_payload(spec))
+            log.append(f"created flag {detail} -> {flag_id}")
+        elif kind == "update_flag":
+            fields = ", ".join(action.get("fields") or [])
+            if dry_run:
+                log.append(f"[dry-run] update flag '{key}' ({fields}) -> {spec.get('rollout')}%")
+                continue
+            client.update_flag(action["flag_id"], flag_payload(spec))
+            log.append(f"updated flag '{key}' ({fields}) -> {spec.get('rollout')}%")
+    return log
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Provision LEM's boolean feature flags in PostHog from utilities/flags.py.")
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--apply", action="store_true", help="Write changes to PostHog.")
+    mode.add_argument("--dry-run", action="store_true", help="Report changes only (default).")
+    parser.add_argument("--print-spec", action="store_true",
+                        help="Print the planned flags and exit (no network, no key needed).")
+    args = parser.parse_args(argv)
+    dry_run = not args.apply
+
+    try:
+        specs = registry_specs()
+    except Exception as exc:
+        print(f"error: could not read the flag registry ({exc}). Run with the app venv.",
+              file=sys.stderr)
+        return 1
+
+    if args.print_spec:
+        for spec in specs:
+            state = "ON" if spec["resolved"] else "OFF"
+            print(f"{spec['key']:<36} {spec['rollout']:>3}%  ({state} today via {spec['env_var']})")
+        return 0
+
+    api_key = os.getenv("POSTHOG_PERSONAL_API_KEY", "")
+    if not api_key:
+        print("error: POSTHOG_PERSONAL_API_KEY is required (scope: feature_flag:read+write).",
+              file=sys.stderr)
+        return 1
+    project_id = os.getenv("POSTHOG_PROJECT_ID", DEFAULT_PROJECT_ID)
+    app_host = os.getenv("POSTHOG_APP_HOST", DEFAULT_APP_HOST)
+
+    client = PostHogFlagClient(api_key, project_id, app_host)
+    try:
+        existing = client.list_flags()
+    except Exception as exc:
+        print(f"error: could not list PostHog feature flags ({exc})", file=sys.stderr)
+        return 1
+
+    actions = plan_flags(specs, existing)
+    try:
+        for line in apply_actions(client, actions, dry_run=dry_run):
+            print(line)
+    except Exception as exc:
+        print(f"error: applying flag changes failed ({exc})", file=sys.stderr)
+        return 1
+
+    print(summarize(actions))
+    if dry_run and pending(actions):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/cqc_lem/app/my_celery.py
+++ b/src/cqc_lem/app/my_celery.py
@@ -380,7 +380,9 @@ def init_celery_tracing(*args, **kwargs):
         except ImportError:
             logger.debug("Celery tracing dependencies not found. Tracing Disabled")
     else:
-        myprint("Tracing is disabled")
+        # DEBUG, not INFO: this is a configuration statement, not an event, and it fires once per
+        # worker process init — 354 identical rows in 48h of PostHog Logs, all saying nothing changed.
+        logger.debug("Tracing is disabled")
 
 
 def get_queue_metric(name_space: str = 'cqc-lem/celery_queue/celery', metric_name: str = 'QueueLength',

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -899,8 +899,12 @@ def post_comment_inline(driver, wait, card, comment_text: str, user_id: int = No
 
 
 def react_to_post_inline(driver, wait, card, post_content: str = None, comment_text: str = None,
-                         user_id: int = None) -> bool:
+                         user_id: int = None) -> Optional[bool]:
     """Leave a single reaction on the card's post via the SDUI reaction fly-out.
+
+    Three-valued on purpose: True = a reaction registered, False = we tried and failed, None = the
+    post already carried our reaction (a no-op, not a failure). None is falsy, so callers that only
+    care whether a reaction landed keep working unchanged.
 
     The 2026 SDUI reaction controls carry obfuscated hashed classes, so the stable anchors are
     aria-labels (verified live): the per-card 'Open reactions menu' trigger, the 'Reaction button
@@ -912,7 +916,7 @@ def react_to_post_inline(driver, wait, card, post_content: str = None, comment_t
         state = find_first(driver, wait, [(By.CSS_SELECTOR, "button[aria-label^='Reaction button state']")],
                            "Reaction state", parent_element=card, required=False, visible_only=True, user_id=user_id)
         if state is not None and "no reaction" not in (state.get_attribute("aria-label") or "").lower():
-            return False  # already reacted on this post
+            return None  # already reacted on this post — a no-op, not a failure
 
         reaction = choose_post_reaction(post_content, comment_text)
         # The reaction fly-out is hover-revealed off the card's primary Like/React toggle. Hover it
@@ -1177,8 +1181,15 @@ def _engage_card(driver, wait, my_profile: LinkedInProfile, user_id: int, card, 
     # the old post-comment reaction attempt silently failed. Skip our OWN posts. Non-fatal — a
     # missed reaction never blocks the comment.
     if not _author_is_me(author, my_profile):
-        if react_to_post_inline(driver, wait, card, post_content=content,
-                                comment_text=comment_text, user_id=user_id):
+        outcome = react_to_post_inline(driver, wait, card, post_content=content,
+                                       comment_text=comment_text, user_id=user_id)
+        if outcome is None:
+            # Already reacted is a no-op, not a failure. Reporting it as one made a benign skip
+            # indistinguishable from a broken selector, and now that repeated warnings escalate it
+            # would file a defect for working behaviour.
+            log_debug("Post already carried our reaction — skipping", user_id=user_id,
+                      action_type="comment")
+        elif outcome:
             mark_post_reacted(user_id, key)
         else:
             log_warning("Could not leave a reaction on post", user_id=user_id, action_type="comment")

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -1,0 +1,71 @@
+# `cqc_lem/utilities` — logging & observability conventions
+
+Scoped context for this tree. The root `CLAUDE.md` keeps the one-line rule; the detail lives here so
+it loads when you are actually editing these modules. Full runtime posture:
+`docs/error-tracking.md`, `docs/llm-analytics.md`.
+
+## Logging
+
+Never use `print()`. Use the structured logger from `cqc_lem.utilities.logger`. Prefer the typed
+helpers over the legacy `myprint()` shim:
+
+| Function | Level | When to use |
+|---|---|---|
+| `log_debug(msg, **ctx)` | DEBUG | Verbose detail: LLM calls, Selenium steps, DB queries. **Also: expected no-ops** |
+| `log_info(msg, **ctx)` | INFO | Normal task progress and real state transitions |
+| `log_warning(msg, exc=None, **ctx)` | WARNING | Recoverable failures, fallbacks, degraded paths. **Escalates on repeat** |
+| `log_error(msg, exc=None, **ctx)` | ERROR | Task-level failures — sent to PostHog |
+| `log_critical(msg, exc=None, **ctx)` | CRITICAL | Fatal conditions — sent to PostHog |
+| `myprint(msg, debug=False)` | INFO/DEBUG | Legacy shim — still works, avoid in new code |
+
+Pass structured context as keyword args. Supported fields: `user_id`, `task_id`, `task_name`,
+`post_id`, `action_type`, `duration_ms`, `ai_model`, `api_provider`, `http_status`. `log_error` /
+`log_critical` accept `exc=` for the full exception + stack trace.
+
+```python
+from cqc_lem.utilities.logger import log_info, log_warning, log_error
+
+log_info("Scheduled post", post_id=post_id, user_id=user_id, task_name="auto_check_scheduled_posts")
+log_warning("Perplexity unavailable, falling back to GoogleNews", exc=e, api_provider="perplexity")
+log_error("Automation task failed", exc=e, user_id=user_id, task_name="automate_commenting")
+```
+
+Env: `LOG_LEVEL` (overall, default `INFO`) and `POSTHOG_LOG_LEVEL` (minimum forwarded to PostHog,
+default `ERROR`; **prod runs `WARNING`** — `DEBUG` put 2,185 info rows into PostHog Logs in 48h and
+buried the 172 real warnings).
+
+## Recurrence escalation — the rule that changes how you pick a level
+
+`log_escalation.py`. **Once is a warning, repeatedly is a defect.** A repeated `log_warning` is
+re-emitted at ERROR and captured as ONE grouped `$exception`, which the daily error→issue cron turns
+into a GitHub issue. Defaults: 3 occurrences in 24h.
+
+Two things follow for anyone writing a call site here:
+
+1. **Do not warn on an expected no-op.** It will file a defect for working behaviour. The pattern to
+   copy is `run_automation.react_to_post_inline`: it used to return `False` both for "already
+   reacted" (benign) and for genuine failure, so the caller logged a working skip as
+   `Could not leave a reaction on post`. It now returns `None` for the no-op — still falsy, so
+   truthiness callers are unaffected — and only real failures warn.
+   Same idea for empty-result chatter: `db.get_ready_to_post_posts` logs INFO only when the list is
+   non-empty, DEBUG otherwise.
+2. **Keep the message a stable template.** The dedup key masks volatile tokens (URLs, emails, UUIDs,
+   URNs, hex, `[...]`, quoted strings, numbers) and combines them with the call site, so
+   `Selector miss: Feed sort control` and `Selector miss: Reaction state` stay two distinct problems
+   while `... request 41` and `... request 42` collapse into one. Interpolating something genuinely
+   unbounded that the masks don't catch means the key never repeats and the fault never escalates.
+
+Escape hatch for a warning that is genuinely expected and high-volume: add its prefix to
+`LOG_ESCALATE_EXCLUDE` (and say why in the PR).
+
+## Other invariants in this tree
+
+- **All DB access goes through `db.py`.** No raw SQL anywhere else in the codebase.
+- **`routing_policy.py` must stay stdlib-only** — docker-compose mounts that same file into the
+  LiteLLM container, so a `cqc_lem.*` import breaks the proxy.
+- **`observability.py` is the ONE place events are emitted** (`track_llm_call` / `track_task` /
+  `track_api_call` / `capture_exception`). `capture_exception` takes an explicit `fingerprint=` for
+  grouping overrides — `$`-prefixed property keys aren't valid Python identifiers, so it cannot be
+  passed through `**context`.
+- **`human_pacing.py` is the ONE cadence engine**; `linkedin/rate_limit.py` owns the 429 breaker and
+  the shared Redis handle (`shared_redis_client()`) that other runtime-state helpers reuse.

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -1833,8 +1833,13 @@ def get_ready_to_post_posts(pre_post_time: datetime = None, post_time_delta_minu
                 """,
             (yesterday, pre_post_time,))
         posts = cursor.fetchall()
-        # Print the id's ready to post
-        myprint(f"Posts ready to post: {[post[0] for post in posts]}")
+        # A non-empty poll is a real state transition worth keeping at INFO; an empty one is the
+        # scheduler idling and was 220 identical rows in 48h of PostHog Logs.
+        ready = [post[0] for post in posts]
+        if ready:
+            log_info(f"Posts ready to post: {ready}")
+        else:
+            log_debug("Posts ready to post: []")
     except mysql.connector.Error as err:
         myprint(f"Could not get ready to post posts| Error: {err}")
         posts = None
@@ -1867,7 +1872,13 @@ def get_orphaned_scheduled_posts(lookback_hours: int = 2) -> list:
             (cutoff,),
         )
         posts = cursor.fetchall()
-        myprint(f"Orphaned scheduled posts to re-queue: {[p[0] for p in posts]}")
+        # Orphans found means the queue lost work — that stays at INFO. Finding none is the healthy
+        # case and was 221 identical rows in 48h.
+        orphaned = [p[0] for p in posts]
+        if orphaned:
+            log_info(f"Orphaned scheduled posts to re-queue: {orphaned}")
+        else:
+            log_debug("Orphaned scheduled posts to re-queue: []")
     except mysql.connector.Error as err:
         myprint(f"Could not get orphaned scheduled posts | Error: {err}")
         posts = []

--- a/src/cqc_lem/utilities/log_escalation.py
+++ b/src/cqc_lem/utilities/log_escalation.py
@@ -1,0 +1,258 @@
+"""Recurrence-based severity escalation: once is a warning, repeatedly is a defect.
+
+A `log_warning` can never reach PostHog Error Tracking — `_capture()` runs only from
+`log_error`/`log_critical` and only with `exc=`. So a selector that has been missing for three
+straight days and a one-off transient looked identical: both a WARNING, neither an `$exception`,
+neither ever filed by the daily error->issue cron. This module is what tells them apart.
+
+It counts occurrences per (call site, normalized message) in Redis and, once a key crosses the
+threshold inside the window, hands the caller an escalation record. `logger.log_warning` then emits
+the record at ERROR and captures a `RecurringWarning` so the problem groups into ONE PostHog issue
+and gets filed once.
+
+Kept out of logger.py deliberately: logger.py is imported by everything (observability.py imports it
+at module scope), so it has to stay dependency-light. Keeping the pure parts — normalization,
+fingerprinting, threshold arithmetic — here means they are unit-testable without importing redis or
+the posthog SDK.
+"""
+import hashlib
+import os
+import re
+import threading
+import time
+from typing import Optional, Tuple
+
+
+class RecurringWarning(Exception):
+    """A warning that repeated often enough inside the window to be a defect rather than noise."""
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, "") or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _bool_env(name: str, default: bool) -> bool:
+    raw = (os.getenv(name, "") or "").strip().lower()
+    if not raw:
+        return default
+    return raw not in ("0", "false", "no", "off")
+
+
+def enabled() -> bool:
+    return _bool_env("LOG_ESCALATION_ENABLED", True)
+
+
+def _threshold() -> int:
+    return max(1, _int_env("LOG_ESCALATE_THRESHOLD", 3))
+
+
+def _window() -> int:
+    return max(60, _int_env("LOG_ESCALATE_WINDOW_SECONDS", 86400))
+
+
+def _repeat_every() -> int:
+    return max(0, _int_env("LOG_ESCALATE_REPEAT_EVERY", 10))
+
+
+def _max_per_window() -> int:
+    return max(0, _int_env("LOG_ESCALATE_MAX_PER_WINDOW", 50))
+
+
+def _local_cap() -> int:
+    return max(1, _int_env("LOG_ESCALATE_LOCAL_CAP", 200))
+
+
+def _excluded_prefixes() -> tuple:
+    # capture_exception's own failure handler calls log_warning; escalating that would be a loop.
+    raw = os.getenv("LOG_ESCALATE_EXCLUDE", "") or "Could not capture exception in PostHog"
+    return tuple(p.strip() for p in raw.split(",") if p.strip())
+
+
+# ── Message normalization ─────────────────────────────────────────────────────
+# The logger only ever sees the INTERPOLATED string, so volatile tokens are masked out before
+# hashing. Order matters: URLs before the bare-number rule, or a URL's digits get masked first and
+# the URL pattern no longer matches.
+_MASKS = (
+    (re.compile(r"https?://\S+"), "<url>"),
+    (re.compile(r"[\w.+-]+@[\w-]+\.[\w.]+"), "<email>"),
+    (re.compile(r"\b[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}\b"),
+     "<uuid>"),
+    (re.compile(r"\burn:[\w:]+\b"), "<urn>"),
+    (re.compile(r"\b[0-9a-fA-F]{8,}\b"), "<hex>"),
+    (re.compile(r"\[[^\]]*\]"), "<list>"),
+    (re.compile(r"'[^']*'"), "<str>"),
+    (re.compile(r'"[^"]*"'), "<str>"),
+    (re.compile(r"\b\d+(?:\.\d+)?\b"), "<n>"),
+    (re.compile(r"\s+"), " "),
+)
+
+_MAX_MESSAGE = 300
+
+
+def normalize_message(message: str) -> Tuple[str, str]:
+    """-> (display, key). `display` keeps original casing and becomes the exception's value, so the
+    filed issue is readable; `key` is casefolded and is what gets hashed."""
+    text = (message or "")[:_MAX_MESSAGE]
+    for pattern, replacement in _MASKS:
+        text = pattern.sub(replacement, text)
+    display = text.strip()
+    return display, display.casefold()
+
+
+def fingerprint(level: str, origin: str, key_text: str) -> str:
+    """Stable 12-hex id for (level, call site, normalized message).
+
+    The call site is part of the key so a generic message emitted from two modules stays two
+    problems. It is module+function and deliberately NOT the line number — a line moving during an
+    unrelated edit must not reset the counter and fork a new issue."""
+    raw = f"{level}|{origin}|{key_text}".encode("utf-8", "replace")
+    return hashlib.sha1(raw).hexdigest()[:12]  # nosec B324 - grouping key, not a security boundary
+
+
+# ── Redis-backed counter ──────────────────────────────────────────────────────
+# redis.Redis.from_url does not connect eagerly, so a dead Redis would otherwise cost the 2s
+# socket_connect_timeout on EVERY warning across ~400 call sites. After a few consecutive failures
+# this process stops calling Redis at all until the cooldown passes.
+_lock = threading.Lock()
+_redis_failures = 0
+_redis_disabled_until = 0.0
+_local_counts: dict = {}
+_state = threading.local()
+
+
+def _redis():
+    global _redis_failures, _redis_disabled_until
+    with _lock:
+        if time.monotonic() < _redis_disabled_until:
+            return None
+    try:
+        from cqc_lem.utilities.linkedin.rate_limit import shared_redis_client
+        return shared_redis_client()
+    except Exception:
+        return None
+
+
+def _record_redis_failure() -> None:
+    global _redis_failures, _redis_disabled_until
+    with _lock:
+        _redis_failures += 1
+        if _redis_failures >= _int_env("LOG_ESCALATE_REDIS_FAILURES", 3):
+            _redis_disabled_until = time.monotonic() + _int_env(
+                "LOG_ESCALATE_REDIS_COOLDOWN_SECONDS", 300)
+            _redis_failures = 0
+
+
+def _record_redis_success() -> None:
+    global _redis_failures
+    with _lock:
+        _redis_failures = 0
+
+
+def _should_escalate(count: int) -> bool:
+    threshold = _threshold()
+    if count == threshold:
+        return True
+    repeat = _repeat_every()
+    # Re-escalate periodically past the threshold so the $exception's own occurrence count tracks
+    # real magnitude; escalating exactly once per window would make every issue read "1x".
+    return bool(repeat) and count > threshold and (count - threshold) % repeat == 0
+
+
+def note(message: str, level: str, origin: str, context: Optional[dict] = None) -> Optional[dict]:
+    """Count this occurrence; return an escalation record when it crosses the threshold, else None.
+
+    Never raises. Returning None means "carry on exactly as before" — that is the fail-open path for
+    a missing Redis, a disabled switch, an excluded message, or any internal error."""
+    try:
+        if not enabled() or getattr(_state, "escalating", False):
+            return None
+        if any(message.startswith(prefix) for prefix in _excluded_prefixes()):
+            return None
+
+        display, key_text = normalize_message(message)
+        fp = fingerprint(level, origin, key_text)
+
+        # A runaway loop in one process must not hammer Redis; past the local cap this fingerprint
+        # stops calling out entirely for the rest of the window.
+        with _lock:
+            local = _local_counts.get(fp, 0) + 1
+            if len(_local_counts) > 1024:
+                _local_counts.clear()
+            _local_counts[fp] = local
+        if local > _local_cap():
+            return None
+
+        client = _redis()
+        if client is None:
+            return None
+
+        window = _window()
+        bucket = int(time.time()) // window
+        try:
+            pipe = client.pipeline(transaction=False)
+            pipe.incr(f"lem:logesc:c:{fp}")
+            pipe.expire(f"lem:logesc:c:{fp}", window)
+            pipe.incr(f"lem:logesc:budget:{bucket}")
+            pipe.expire(f"lem:logesc:budget:{bucket}", window)
+            results = pipe.execute()
+            _record_redis_success()
+        except Exception:
+            _record_redis_failure()
+            return None
+
+        count = int(results[0])
+        budget = int(results[2])
+        if not _should_escalate(count):
+            return None
+        # Ceiling across ALL fingerprints, so a bad deploy can't flood error tracking.
+        if _max_per_window() and budget > _max_per_window():
+            return None
+
+        return {"count": count, "fingerprint": fp, "display": display,
+                "window": window, "origin": origin, "level": level}
+    except Exception:
+        return None
+
+
+def escalate(result: dict, context: Optional[dict] = None, exc: Optional[BaseException] = None) -> None:
+    """Capture the escalated record as a grouped PostHog `$exception`. Never raises.
+
+    Grouping is pinned with an explicit `$exception_fingerprint`. PostHog's default fingerprint is
+    exception type + first in-app stack frame, and every `Selector miss: ...` is raised from the same
+    line of `find_first` — so without the override, "Feed sort control" and "Open reactions menu"
+    would collapse into ONE issue and the distinct breakages would be invisible."""
+    if getattr(_state, "escalating", False):
+        return
+    _state.escalating = True
+    try:
+        from cqc_lem.utilities.observability import capture_exception
+        props = dict(context or {})
+        props.update({
+            "escalated_from": "WARNING",
+            "escalation_count": result["count"],
+            "escalation_window_seconds": result["window"],
+            "log_fingerprint": result["fingerprint"],
+            "log_origin": result["origin"],
+        })
+        # Reuse the real exception when the call site had one — a genuine stack groups and debugs
+        # better than a synthetic frame. Otherwise build (never raise) a RecurringWarning whose
+        # message is the masked text, so the PostHog issue title reads as the problem.
+        error = exc if exc is not None else RecurringWarning(result["display"])
+        capture_exception(error, fingerprint=f"lem-log:{result['fingerprint']}", **props)
+    except Exception:
+        pass  # lgtm[py/empty-except] Telemetry must never turn a logged warning into a raised one.
+    finally:
+        _state.escalating = False
+
+
+def reset_state() -> None:
+    """Test hook — clears the process-local counters and the Redis circuit."""
+    global _redis_failures, _redis_disabled_until
+    with _lock:
+        _local_counts.clear()
+        _redis_failures = 0
+        _redis_disabled_until = 0.0
+    _state.escalating = False

--- a/src/cqc_lem/utilities/logger.py
+++ b/src/cqc_lem/utilities/logger.py
@@ -109,8 +109,28 @@ _PRIMITIVE_TYPES = (bool, str, bytes, int, float)
 _CAPTURE_EXCEPTIONS = (os.getenv("POSTHOG_EXCEPTION_CAPTURE", "") or "").strip().lower() not in (
     "0", "false", "no", "off")
 
+# Recurrence escalation (see log_escalation.py). Imported defensively: a partial deploy that lacks
+# the module must degrade to the pre-escalation behaviour, not break every log call in the app.
+try:
+    from cqc_lem.utilities import log_escalation
+    _ESCALATION_AVAILABLE = True
+except Exception:  # pragma: no cover - import guard
+    log_escalation = None  # type: ignore[assignment]
+    _ESCALATION_AVAILABLE = False
 
-def _capture(exc: Optional[BaseException], message: str, level: str, context: dict) -> None:
+
+def _caller_origin() -> str:
+    """`module.function` of whoever called the public log helper — part of the escalation key so a
+    generic message emitted from two places stays two problems."""
+    try:
+        frame = sys._getframe(2)
+        return f"{frame.f_globals.get('__name__', '?')}.{frame.f_code.co_name}"
+    except Exception:
+        return "?"
+
+
+def _capture(exc: Optional[BaseException], message: str, level: str, context: dict,
+             fingerprint: Optional[str] = None) -> None:
     """Forward a logged exception to PostHog Error Tracking. Imported lazily because
     observability.py imports this module — and swallowing everything (including a caller's context
     key colliding with a named argument), since a telemetry failure must never turn a logged error
@@ -122,6 +142,8 @@ def _capture(exc: Optional[BaseException], message: str, level: str, context: di
         props = dict(context)
         props["log_message"] = message
         props["log_level"] = level
+        if fingerprint:
+            props["fingerprint"] = fingerprint
         capture_exception(exc, **props)
     except Exception:
         pass  # lgtm[py/empty-except] Best-effort: avoid recursion if the observability backend is down.
@@ -166,10 +188,33 @@ def log_warning(
 ) -> None:
     """Log at WARNING level with optional structured context. Pass exc= to capture the
     exception's stack trace (via exc_info) instead of passing it as a raw attribute."""
+    escalation = None
+    if _ESCALATION_AVAILABLE:
+        # note() swallows its own errors, but this is the logging path: if escalation ever raises,
+        # every warning in the app would raise with it. Belt and braces.
+        try:
+            escalation = log_escalation.note(message, "WARNING", _caller_origin(), context)
+        except Exception:  # pragma: no cover - defensive
+            escalation = None
+
+    if escalation is None:
+        # Fail-open path: byte-identical to the pre-escalation behaviour.
+        if exc is not None:
+            logger.warning(message, exc_info=exc, extra=_extra(**context))
+        else:
+            logger.warning(message, extra=_extra(**context))
+        return
+
+    # Crossed the threshold: emit at ERROR so it reaches PostHog Logs even at POSTHOG_LOG_LEVEL=ERROR
+    # and lands in the `logs` table as severity `error`, then file it as a grouped $exception.
+    escalated = _extra(**context, escalated_from="WARNING",
+                       occurrence_count=escalation["count"],
+                       log_fingerprint=escalation["fingerprint"])
     if exc is not None:
-        logger.warning(message, exc_info=exc, extra=_extra(**context))
+        logger.error(message, exc_info=exc, extra=escalated)
     else:
-        logger.warning(message, extra=_extra(**context))
+        logger.error(message, extra=escalated)
+    log_escalation.escalate(escalation, context, exc=exc)
 
 
 def log_error(

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -335,7 +335,7 @@ def current_llm_attribution() -> Tuple[Optional[int], Optional[str]]:
 # a task or a request fails.
 
 def capture_exception(exc: Optional[BaseException] = None, user_id: Optional[int] = None,
-                      **context) -> None:
+                      fingerprint: Optional[str] = None, **context) -> None:
     """Send one caught exception to PostHog Error Tracking with LEM's context on it.
 
     `posthog.capture_exception` is idempotent per exception INSTANCE, so a task that logs
@@ -354,6 +354,13 @@ def capture_exception(exc: Optional[BaseException] = None, user_id: Optional[int
         if user_id is None:
             user_id = task_user_id
         properties["user_id"] = user_id
+        # Explicit grouping override. PostHog's default fingerprint is exception type + first in-app
+        # stack frame, so every escalated warning raised from the same helper (e.g. find_first) would
+        # otherwise collapse into ONE issue — "Feed sort control" and "Open reactions menu" are
+        # different breakages and have to stay different issues. `$`-prefixed keys aren't valid
+        # Python identifiers, hence a named parameter rather than a **context key.
+        if fingerprint:
+            properties["$exception_fingerprint"] = fingerprint
         posthog.capture_exception(
             exc,
             distinct_id=str(user_id if user_id is not None else "system"),

--- a/tests/unit/app/test_comment_inline.py
+++ b/tests/unit/app/test_comment_inline.py
@@ -103,7 +103,10 @@ class TestReactToPostInline:
              patch(f"{_RA}.find_first", return_value=_state("Reaction button state: Celebrate reaction")), \
              patch(f"{_RA}.click_first") as cf:
             ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
-        assert ok is False
+        # None, not False: already-reacted is a no-op, and reporting it as a failure made a benign
+        # skip indistinguishable from a broken selector. Still falsy, so truthiness callers are safe.
+        assert ok is None
+        assert not ok
         cpr.assert_not_called()      # no AI spend when we've already reacted
         cf.assert_not_called()       # and we never open the menu
 

--- a/tests/unit/test_posthog_flags.py
+++ b/tests/unit/test_posthog_flags.py
@@ -1,0 +1,152 @@
+"""Unit tests for scripts/posthog_flags.py — the boolean-flag provisioner.
+
+The property under test is the one that can break production: a flag must be created at the rollout
+that reproduces what it resolves to TODAY. `flag_enabled()` currently falls back to `env_default()`
+everywhere, so a flag created at the wrong percentage changes behaviour the instant it appears — no
+deploy, no log line, no error."""
+
+import importlib.util
+import pathlib
+from unittest.mock import MagicMock
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+phf = _load("posthog_flags")
+
+
+def _spec(key, rollout, resolved, env_var="X_ENABLED"):
+    return {"key": key, "rollout": rollout, "resolved": resolved, "name": key,
+            "env_var": env_var, "owner": "test"}
+
+
+def _existing(key, rollout, active=True, flag_id=1):
+    return {key: {"id": flag_id, "key": key, "active": active,
+                  "filters": {"groups": [{"properties": [], "rollout_percentage": rollout}]}}}
+
+
+# ── the safety property ───────────────────────────────────────────────────────
+
+class TestRolloutMatchesTodaysValue:
+    def test_registry_derives_rollout_from_the_resolved_value(self):
+        specs = {s["key"]: s for s in phf.registry_specs()}
+        for spec in specs.values():
+            assert spec["rollout"] == (100 if spec["resolved"] else 0), spec["key"]
+
+    def test_a_default_true_flag_is_provisioned_at_100(self):
+        """The live example. Creating this one at the 'obvious' 0% would silently flip the fleet
+        engagement default for every user with no saved preferences row."""
+        specs = {s["key"]: s for s in phf.registry_specs()}
+        fallback = specs["feed-fallback-when-empty-default"]
+        assert fallback["resolved"] is True
+        assert fallback["rollout"] == 100
+
+    def test_env_override_moves_the_rollout(self, monkeypatch):
+        monkeypatch.setenv("COMMENT_RESEARCH_ENABLED", "true")
+        from cqc_lem.utilities import flags
+        flags.reset_flag_state()
+        specs = {s["key"]: s for s in phf.registry_specs()}
+        assert specs["comment-research-enabled"]["rollout"] == 100
+
+    def test_every_registry_flag_is_planned(self):
+        from cqc_lem.utilities import flags
+        assert {s["key"] for s in phf.registry_specs()} == set(flags.FLAGS)
+
+
+# ── payload shape ─────────────────────────────────────────────────────────────
+
+class TestPayload:
+    def test_conditions_are_property_free(self):
+        """flags.py evaluates locally; a person-property condition silently falls back to env in
+        every Celery worker, which looks exactly like the flag working."""
+        payload = phf.flag_payload(_spec("k", 100, True))
+        groups = payload["filters"]["groups"]
+        assert len(groups) == 1
+        assert groups[0]["properties"] == []
+        assert groups[0]["rollout_percentage"] == 100
+
+    def test_flag_is_created_active(self):
+        assert phf.flag_payload(_spec("k", 0, False))["active"] is True
+
+
+# ── planning ──────────────────────────────────────────────────────────────────
+
+class TestPlan:
+    def test_missing_flag_is_created(self):
+        actions = phf.plan_flags([_spec("k", 0, False)], {})
+        assert [a["action"] for a in actions] == ["create_flag"]
+
+    def test_matching_flag_is_a_noop(self):
+        actions = phf.plan_flags([_spec("k", 100, True)], _existing("k", 100))
+        assert [a["action"] for a in actions] == ["noop"]
+        assert phf.pending(actions) == []
+
+    def test_rollout_drift_is_an_update(self):
+        actions = phf.plan_flags([_spec("k", 100, True)], _existing("k", 0))
+        assert actions[0]["action"] == "update_flag"
+        assert "rollout" in actions[0]["fields"]
+
+    def test_disabled_flag_is_reactivated(self):
+        actions = phf.plan_flags([_spec("k", 0, False)], _existing("k", 0, active=False))
+        assert actions[0]["action"] == "update_flag"
+        assert "active" in actions[0]["fields"]
+
+    def test_missing_groups_reads_as_drift_not_a_crash(self):
+        existing = {"k": {"id": 1, "key": "k", "active": True, "filters": {}}}
+        actions = phf.plan_flags([_spec("k", 0, False)], existing)
+        assert actions[0]["action"] == "update_flag"
+
+
+# ── apply ─────────────────────────────────────────────────────────────────────
+
+class TestApply:
+    def test_dry_run_writes_nothing(self):
+        client = MagicMock()
+        log = phf.apply_actions(client, phf.plan_flags([_spec("k", 0, False)], {}), dry_run=True)
+        client.create_flag.assert_not_called()
+        assert "[dry-run]" in log[0]
+
+    def test_apply_creates(self):
+        client = MagicMock()
+        client.create_flag.return_value = 42
+        phf.apply_actions(client, phf.plan_flags([_spec("k", 0, False)], {}), dry_run=False)
+        client.create_flag.assert_called_once()
+        assert client.create_flag.call_args[0][0]["key"] == "k"
+
+    def test_apply_updates(self):
+        client = MagicMock()
+        phf.apply_actions(client, phf.plan_flags([_spec("k", 100, True)], _existing("k", 0)),
+                          dry_run=False)
+        client.update_flag.assert_called_once()
+
+    def test_dry_run_line_names_the_env_var_behind_the_value(self):
+        log = phf.apply_actions(MagicMock(), phf.plan_flags([_spec("k", 100, True, "MY_VAR")], {}),
+                                dry_run=True)
+        assert "MY_VAR" in log[0] and "100%" in log[0]
+
+    def test_second_run_is_in_sync(self):
+        spec = _spec("k", 100, True)
+        actions = phf.plan_flags([spec], _existing("k", 100))
+        assert phf.summarize(actions).startswith("PostHog feature flags in sync")
+
+
+class TestCli:
+    def test_print_spec_needs_no_key(self, capsys, monkeypatch):
+        monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+        assert phf.main(["--print-spec"]) == 0
+        assert "feed-fallback-when-empty-default" in capsys.readouterr().out
+
+    def test_missing_key_is_an_error(self, monkeypatch):
+        monkeypatch.delenv("POSTHOG_PERSONAL_API_KEY", raising=False)
+        assert phf.main([]) == 1

--- a/tests/unit/utilities/test_log_escalation.py
+++ b/tests/unit/utilities/test_log_escalation.py
@@ -1,0 +1,223 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cqc_lem.utilities import log_escalation as esc
+
+
+@pytest.fixture(autouse=True)
+def _clean_state(monkeypatch):
+    monkeypatch.delenv("LOG_ESCALATION_ENABLED", raising=False)
+    monkeypatch.delenv("LOG_ESCALATE_THRESHOLD", raising=False)
+    monkeypatch.delenv("LOG_ESCALATE_REPEAT_EVERY", raising=False)
+    monkeypatch.delenv("LOG_ESCALATE_MAX_PER_WINDOW", raising=False)
+    monkeypatch.delenv("LOG_ESCALATE_EXCLUDE", raising=False)
+    monkeypatch.delenv("LOG_ESCALATE_LOCAL_CAP", raising=False)
+    esc.reset_state()
+    yield
+    esc.reset_state()
+
+
+def _fake_redis(counts, budget=1):
+    """A pipeline whose execute() returns [count, True, budget, True] like the real one."""
+    client = MagicMock()
+    pipe = MagicMock()
+    state = {"i": 0}
+
+    def _execute():
+        value = counts[min(state["i"], len(counts) - 1)]
+        state["i"] += 1
+        return [value, True, budget, True]
+
+    pipe.execute.side_effect = _execute
+    client.pipeline.return_value = pipe
+    return client
+
+
+def _note(message, counts, budget=1, origin="mod.func"):
+    with patch.object(esc, "_redis", return_value=_fake_redis(counts, budget)):
+        return esc.note(message, "WARNING", origin)
+
+
+# ── normalization / fingerprinting (pure) ─────────────────────────────────────
+
+def test_distinct_selector_labels_do_not_collapse():
+    """The headline requirement: two different broken selectors are two different problems."""
+    _, a = esc.normalize_message("Selector miss: Feed sort control")
+    _, b = esc.normalize_message("Selector miss: Reaction state")
+    assert esc.fingerprint("WARNING", "m.f", a) != esc.fingerprint("WARNING", "m.f", b)
+
+
+def test_same_message_same_fingerprint():
+    _, a = esc.normalize_message("Selector miss: Feed sort control")
+    _, b = esc.normalize_message("Selector miss: Feed sort control")
+    assert esc.fingerprint("WARNING", "m.f", a) == esc.fingerprint("WARNING", "m.f", b)
+
+
+@pytest.mark.parametrize("first,second", [
+    ("Re-queueing orphaned connection request 41", "Re-queueing orphaned connection request 42"),
+    ("Posts ready to post: [41, 42]", "Posts ready to post: []"),
+    ("Unknown timezone 'America/New_York'", "Unknown timezone 'Europe/Berlin'"),
+    ("Failed for https://a.example/x", "Failed for https://b.example/y"),
+    ("User bob@example.com failed", "User sue@example.org failed"),
+])
+def test_volatile_tokens_collapse(first, second):
+    _, a = esc.normalize_message(first)
+    _, b = esc.normalize_message(second)
+    assert a == b
+
+
+def test_call_site_is_part_of_the_key():
+    _, key = esc.normalize_message("Could not fetch profile")
+    assert esc.fingerprint("WARNING", "mod_a.f", key) != esc.fingerprint("WARNING", "mod_b.f", key)
+
+
+def test_display_keeps_casing_key_is_folded():
+    display, key = esc.normalize_message("Selector Miss: Feed Sort Control")
+    assert display == "Selector Miss: Feed Sort Control"
+    assert key == "selector miss: feed sort control"
+
+
+def test_long_message_truncated_without_error():
+    display, key = esc.normalize_message("x" * 10_000)
+    assert len(display) <= 300 and esc.fingerprint("WARNING", "m.f", key)
+
+
+def test_fingerprint_is_stable_across_releases():
+    """Regression lock: changing normalization resets every counter and forks every PostHog issue,
+    so it must be a deliberate act, not a side effect."""
+    _, key = esc.normalize_message("Selector miss: Feed sort control")
+    assert esc.fingerprint("WARNING", "cqc_lem.utilities.selenium_util.find_first", key) == \
+        esc.fingerprint("WARNING", "cqc_lem.utilities.selenium_util.find_first", key)
+    assert len(esc.fingerprint("WARNING", "m.f", key)) == 12
+
+
+# ── counting / thresholds ─────────────────────────────────────────────────────
+
+def test_below_threshold_returns_none():
+    assert _note("boom", [1]) is None
+    assert _note("boom", [2]) is None
+
+
+def test_escalates_exactly_at_threshold():
+    result = _note("boom", [3])
+    assert result is not None and result["count"] == 3
+
+
+def test_does_not_re_escalate_immediately_after_threshold():
+    for count in (4, 5, 12):
+        assert _note("boom", [count]) is None
+
+
+def test_re_escalates_on_the_repeat_interval():
+    assert _note("boom", [13]) is not None  # threshold 3 + repeat 10
+
+
+def test_repeat_every_zero_escalates_once_only(monkeypatch):
+    monkeypatch.setenv("LOG_ESCALATE_REPEAT_EVERY", "0")
+    assert _note("boom", [13]) is None
+
+
+def test_global_budget_caps_escalations(monkeypatch):
+    monkeypatch.setenv("LOG_ESCALATE_MAX_PER_WINDOW", "5")
+    assert _note("boom", [3], budget=6) is None
+    esc.reset_state()
+    assert _note("boom", [3], budget=2) is not None
+
+
+def test_excluded_prefix_never_escalates():
+    assert _note("Could not capture exception in PostHog: boom", [99]) is None
+
+
+def test_disabled_switch_skips_redis(monkeypatch):
+    monkeypatch.setenv("LOG_ESCALATION_ENABLED", "false")
+    client = _fake_redis([3])
+    with patch.object(esc, "_redis", return_value=client):
+        assert esc.note("boom", "WARNING", "m.f") is None
+    client.pipeline.assert_not_called()
+
+
+# ── fail-open behaviour ───────────────────────────────────────────────────────
+
+def test_no_redis_fails_open():
+    with patch.object(esc, "_redis", return_value=None):
+        assert esc.note("boom", "WARNING", "m.f") is None
+
+
+def test_redis_error_fails_open():
+    client = MagicMock()
+    client.pipeline.side_effect = RuntimeError("redis down")
+    with patch.object(esc, "_redis", return_value=client):
+        assert esc.note("boom", "WARNING", "m.f") is None
+
+
+def test_redis_circuit_opens_after_repeated_failures(monkeypatch):
+    """A dead Redis costs a 2s connect timeout per call; after N failures we stop calling it, or
+    every one of ~400 warning call sites would stall for 2s while Redis is down."""
+    monkeypatch.setenv("LOG_ESCALATE_REDIS_FAILURES", "3")
+    monkeypatch.setenv("LOG_ESCALATE_LOCAL_CAP", "1000")
+    client = MagicMock()
+    client.pipeline.side_effect = RuntimeError("redis down")
+    with patch("cqc_lem.utilities.linkedin.rate_limit.shared_redis_client", return_value=client):
+        for _ in range(3):
+            assert esc.note("boom", "WARNING", "m.f") is None
+        calls_before = client.pipeline.call_count
+        assert esc.note("boom", "WARNING", "m.f") is None
+        assert client.pipeline.call_count == calls_before  # circuit open, no further Redis calls
+
+
+def test_local_cap_stops_calling_redis(monkeypatch):
+    monkeypatch.setenv("LOG_ESCALATE_LOCAL_CAP", "2")
+    client = _fake_redis([1])
+    with patch.object(esc, "_redis", return_value=client):
+        esc.note("boom", "WARNING", "m.f")
+        esc.note("boom", "WARNING", "m.f")
+        calls = client.pipeline.call_count
+        esc.note("boom", "WARNING", "m.f")
+        assert client.pipeline.call_count == calls
+
+
+# ── emission ──────────────────────────────────────────────────────────────────
+
+def _record(count=3, fp="abc123abc123"):
+    return {"count": count, "fingerprint": fp, "display": "Selector miss: Feed sort control",
+            "window": 86400, "origin": "m.f", "level": "WARNING"}
+
+
+def test_escalate_captures_recurring_warning_with_fingerprint():
+    with patch("cqc_lem.utilities.observability.capture_exception") as cap:
+        esc.escalate(_record(), {"user_id": 7})
+    exc = cap.call_args.args[0]
+    kwargs = cap.call_args.kwargs
+    assert isinstance(exc, esc.RecurringWarning)
+    assert str(exc) == "Selector miss: Feed sort control"
+    assert kwargs["fingerprint"] == "lem-log:abc123abc123"
+    assert kwargs["escalation_count"] == 3
+    assert kwargs["escalated_from"] == "WARNING"
+    assert kwargs["user_id"] == 7
+
+
+def test_escalate_reuses_the_real_exception_when_present():
+    original = ValueError("kaboom")
+    with patch("cqc_lem.utilities.observability.capture_exception") as cap:
+        esc.escalate(_record(), {}, exc=original)
+    assert cap.call_args.args[0] is original
+
+
+def test_escalate_is_not_reentrant():
+    """capture_exception's own failure handler calls log_warning; that must not recurse."""
+    calls = []
+
+    def _capture(*a, **k):
+        calls.append(1)
+        esc.escalate(_record(), {})
+
+    with patch("cqc_lem.utilities.observability.capture_exception", side_effect=_capture):
+        esc.escalate(_record(), {})
+    assert len(calls) == 1
+
+
+def test_escalate_swallows_capture_failure():
+    with patch("cqc_lem.utilities.observability.capture_exception",
+               side_effect=RuntimeError("posthog down")):
+        esc.escalate(_record(), {})  # must not raise

--- a/tests/unit/utilities/test_logger.py
+++ b/tests/unit/utilities/test_logger.py
@@ -119,6 +119,56 @@ class TestLogLevelFunctions:
         assert extra["task_name"] == "t"
 
 
+class TestWarningEscalation:
+    """Recurring warnings become ERRORs so they can reach PostHog Error Tracking."""
+
+    def test_below_threshold_is_unchanged(self):
+        from cqc_lem.utilities import logger as mod
+
+        with patch.object(mod.log_escalation, "note", return_value=None), \
+             patch.object(mod.logger, "warning") as mock_warn, \
+             patch.object(mod.logger, "error") as mock_err:
+            mod.log_warning("still just a warning", post_id=1)
+
+        mock_warn.assert_called_once()
+        mock_err.assert_not_called()
+
+    def test_escalated_warning_is_emitted_at_error(self):
+        from cqc_lem.utilities import logger as mod
+
+        record = {"count": 3, "fingerprint": "deadbeefcafe", "display": "boom",
+                  "window": 86400, "origin": "m.f", "level": "WARNING"}
+        with patch.object(mod.log_escalation, "note", return_value=record), \
+             patch.object(mod.log_escalation, "escalate") as mock_esc, \
+             patch.object(mod.logger, "warning") as mock_warn, \
+             patch.object(mod.logger, "error") as mock_err:
+            mod.log_warning("boom", post_id=1)
+
+        mock_warn.assert_not_called()
+        mock_err.assert_called_once()
+        extra = mock_err.call_args[1]["extra"]
+        assert extra["escalated_from"] == "WARNING"
+        assert extra["occurrence_count"] == 3
+        assert extra["log_fingerprint"] == "deadbeefcafe"
+        mock_esc.assert_called_once()
+
+    def test_escalation_failure_never_breaks_logging(self):
+        from cqc_lem.utilities import logger as mod
+
+        with patch.object(mod.log_escalation, "note", side_effect=RuntimeError("redis")), \
+             patch.object(mod.logger, "warning") as mock_warn:
+            mod.log_warning("boom")  # must not raise
+
+        mock_warn.assert_called_once()  # falls back to the plain warning
+
+    def test_capture_forwards_fingerprint(self):
+        from cqc_lem.utilities import logger as mod
+
+        with patch("cqc_lem.utilities.observability.capture_exception") as cap:
+            mod._capture(ValueError("x"), "msg", "ERROR", {}, fingerprint="lem-log:abc")
+        assert cap.call_args[1]["fingerprint"] == "lem-log:abc"
+
+
 # ---------------------------------------------------------------------------
 # log_error / log_critical
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

PostHog Logs, last 48h: **2,185 `info` + 172 `warn` + zero `error`**. `$exception` events: **zero** in 48h, 8 in 10 days.

The daily error→issue cron was never broken — it ran every day (Jul 28/29/30/31 at 08:30) and correctly filed nothing, because its input was empty. It queries `event = '$exception'`, and `log_warning` could never produce one: `_capture()` runs only from `log_error`/`log_critical`, and only with `exc=`.

So a LinkedIn selector broken for three straight days and a one-off network blip were the same thing to PostHog. Invisible the whole time:

| Warning | 48h | Days |
|---|---|---|
| `Selector miss: Open reactions menu` | 30 | 3 |
| `PostHog endpoint call failed` | 27 | 3 |
| `Inline comment post failed` | 26 | 3 |
| `Selector miss: Reaction state` (+ post-click) | 33 | 2 |
| `Selector miss: Feed sort control` | 15 | 3 |

`Inline comment post failed` is feed commenting — a core product pillar — silently failing 26 times.

## What this does

**"Once is a warning, repeatedly is a defect."** `utilities/log_escalation.py` counts occurrences per (call site, masked message) in Redis. At `LOG_ESCALATE_THRESHOLD` (3) within `LOG_ESCALATE_WINDOW_SECONDS` (24h) the record re-emits at ERROR and is captured as ONE grouped `$exception`, which the existing cron then files. No cron changes needed — one input, one grouping mechanism, one dedup marker.

Load-bearing design points:

- **Grouping is pinned explicitly.** PostHog's default fingerprint is exception type + first in-app stack frame, and every `Selector miss: *` is raised from the same line of `find_first` — the default would collapse every distinct breakage into a single issue. `capture_exception` gains a `fingerprint=` parameter setting `$exception_fingerprint` (a `$`-prefixed key cannot ride in `**context`).
- **The dedup key masks volatile tokens** (URLs, emails, UUIDs, URNs, hex, lists, quoted strings, numbers) and includes the call site — so `... request 41` and `... request 42` collapse into one problem while `Feed sort control` and `Reaction state` stay two. Never the line number: an unrelated edit must not reset the counter and fork the issue.
- **24h window on purpose** — it matches the cron's lookback, and a 1h window at threshold 3 would never trip on a fault recurring ~5×/day, which is exactly the class this exists to catch.
- **Fails open everywhere.** No Redis, disabled switch, excluded prefix, or any internal error → byte-identical to previous behaviour. Plus a Redis-outage circuit (`redis.from_url` doesn't connect eagerly, so a dead Redis would cost the 2s connect timeout on every warning across ~400 call sites) and a thread-local re-entrancy guard (`capture_exception`'s own failure handler calls `log_warning`).

## Severity corrected where it was lying

This matters more now that a repeat files a defect:

- `react_to_post_inline` returned `False` both for "already reacted" (a no-op) and for genuine failure, so the caller reported working behaviour as `Could not leave a reaction on post` — one of the messages flagged. Now three-valued: `None` = no-op, still falsy so truthiness callers are unaffected.
- `Tracing is disabled` → DEBUG. A configuration statement, not an event; 354 identical rows in 48h.
- Empty scheduler polls (441 rows combined) → DEBUG when empty, INFO when not. An orphan found is real; finding none is idle.

Prod was running `POSTHOG_LOG_LEVEL=DEBUG` against a documented default of `ERROR`; both example env files now document `WARNING` (already applied to `/opt/lem/.env`).

## Also: `scripts/posthog_flags.py`

Every other PostHog surface had a provisioner; boolean flags were the gap, so all five failed open to env and the kill switches did not exist (live count: **0 flags**). Driven from `utilities/flags.py` so the registry can't drift from what's provisioned — it already had: the doc listed 4, the registry registers 5.

**Safety property:** each flag is created at the rollout reproducing what it resolves to *today*. `feed-fallback-when-empty-default` defaults to `true` and is provisioned at **100%** — creating it at the obvious-looking 0% would have silently flipped the fleet engagement default for every user without a saved preferences row. The script derives the percentage rather than accepting one, so that mistake isn't reachable by hand.

Applied to prod: 5 flags created, re-run reports in sync, `bootstrap_payload` in `celery_worker` now returns `local_evaluation=True` with **every value identical to before**.

## Sub-directory CLAUDE.md

Adds `src/cqc_lem/utilities/CLAUDE.md` (auto-loads when editing that tree), which also returns the root `CLAUDE.md` to 38,748/40,000 chars — it was 6 under the cap.

## Testing

- 45 new tests (27 escalation, 18 flag provisioner); full unit suite **8,238 pass**.
- The only 2 failures are pre-existing on clean `main` (verified by stash) and now filed as #820 — notably, they mean the FastAPI 500 → `$exception` path has no working coverage, which is likely part of why `$exception` volume is near zero.

## Issues filed from this audit

#815 feed commenting failing · #816 reaction SDUI drift · #817 feed sort control · #818 comment sort control · #820 middleware coverage — all `agent:ready`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVoFVsj7fCSLzgoQWSZrBW