### PR TITLE
fix(dms): make every LinkedIn Catch-up run reportable (refs #792)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -88,7 +88,7 @@ from cqc_lem.utilities.linkedin_formatter import normalize_public_text
 from cqc_lem.utilities.logger import myprint, log_error, log_info, log_warning, log_debug
 from cqc_lem.utilities.observability import track_post_outcome, track_audience_snapshot, \
     track_comment_outcome, track_golden_hour_report, track_company_page_invite_run, \
-    attribute_llm_cost, llm_attribution, \
+    track_catchup_run, attribute_llm_cost, llm_attribution, \
     FEATURE_COMMENT, FEATURE_CONTENT, FEATURE_DM
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
     get_element_wait_retry, get_elements_as_list_wait_stale, getText, close_tab, get_driver_wait_pair, quit_gracefully, \
@@ -5734,6 +5734,22 @@ CATCHUP_URL = "https://www.linkedin.com/mynetwork/catch-up/all/"
 # generic "Congrats!" is worse than saying nothing.
 CATCHUP_MIN_SCORE = int(os.getenv("CATCHUP_MIN_SCORE", "30"))
 
+# Why a catch-up run produced what it produced (issue #792). Every run reports one of these — the
+# quiet outcomes especially, because "the feed had no milestone today", "the 429 breaker never let
+# the scan start" and "the card selectors have drifted" are the SAME silence without them.
+CATCHUP_PHASE_SCAN = "scan"
+CATCHUP_PHASE_SEND = "send"
+CATCHUP_STATUS_DRAFTED = "drafted"
+CATCHUP_STATUS_DISABLED = "disabled"                # no milestone type enabled for this user
+CATCHUP_STATUS_THROTTLED = "throttled"              # 429 breaker / automation pause
+CATCHUP_STATUS_SESSION_FAILED = "session_failed"
+CATCHUP_STATUS_SCRAPE_FAILED = "scrape_failed"
+CATCHUP_STATUS_NO_MOMENTS = "no_moments"            # the feed rendered nothing we could read
+CATCHUP_STATUS_NONE_QUALIFIED = "none_qualified"    # moments read, none survived the funnel
+CATCHUP_STATUS_DISPATCHED = "dispatched"
+CATCHUP_STATUS_NOTHING_TO_SEND = "nothing_to_send"
+CATCHUP_STATUS_CAPPED = "capped"                    # approved touches exist, today's cap is spent
+
 # Ordered fallback chain for the catch-up cards. LinkedIn's SDUI ships hashed classes, so we prefer
 # data-view-name, then the semantic list, then any main-content list item that links to a profile.
 # NOTE: needs a supervised live-grounding pass on a real account before broad enablement (see #478).
@@ -5774,6 +5790,17 @@ _CATCHUP_COMPOSE_LOCATORS = [
     (By.CSS_SELECTOR, "div[role='dialog'] textarea"),
     (By.CSS_SELECTOR, "div[contenteditable='true'][aria-label*='message']"),
 ]
+# The affordance labels and composer placeholders that live on the SAME nodes we read a draft off.
+# `button[aria-label*='congrats']` matches LinkedIn's "Say congrats to Jane" trigger, and an empty
+# composer renders its placeholder — both are long enough to clear the length floor, so without this
+# the CHROME becomes the congratulations and we queue (or, on auto-approve, SEND) "Say congrats".
+_CATCHUP_CHROME_RE = re.compile(
+    r"(?:say\s+congrats(?:\s+to\s+\w+(?:\s+\w+){0,2})?"
+    r"|congrats|congratulate(?:\s+\w+(?:\s+\w+){0,2})?"
+    r"|send\s+(?:a\s+)?message(?:\s+to\s+\w+(?:\s+\w+){0,2})?"
+    r"|write\s+(?:a\s+)?message"
+    r"|message|reply|send|view\s+profile|see\s+more|more)[\s.…!]*",
+    re.IGNORECASE)
 _CATCHUP_DISMISS_LOCATORS = [
     (By.CSS_SELECTOR, "div[role='dialog'] button[aria-label*='Dismiss']"),
     (By.CSS_SELECTOR, "div[role='dialog'] button[aria-label*='Close']"),
@@ -5912,7 +5939,7 @@ def _clean_suggested_message(text: str) -> str:
     """Normalize a draft LinkedIn handed us: collapse whitespace, drop the button chrome, cap at the
     DM budget. Anything that doesn't look like a message (empty / a bare label) becomes ''."""
     cleaned = " ".join((text or "").replace("\n", " ").split()).strip()
-    if len(cleaned) < 4:
+    if len(cleaned) < 4 or _CATCHUP_CHROME_RE.fullmatch(cleaned):
         return ""
     return cleaned[:CATCHUP_MESSAGE_MAX_CHARS]
 
@@ -6059,6 +6086,33 @@ def _draft_catchup_message(user_id: int, moment: dict, my_profile: LinkedInProfi
                                   event_detail=moment.get("event_detail") or moment.get("text", ""))
 
 
+# The send drip beats every 20 minutes and the scan beat daily, so these outcomes are the STEADY
+# state of a healthy account, not events. They log DEBUG (an expected no-op logged INFO is noise, and
+# the throttle already logs its own reason in _skip_if_throttled) — the PostHog series is what
+# carries them, and that's the series a "catch-up never sends" report has to be answered from.
+_CATCHUP_QUIET_STATUSES = frozenset({CATCHUP_STATUS_NOTHING_TO_SEND, CATCHUP_STATUS_CAPPED,
+                                     CATCHUP_STATUS_THROTTLED, CATCHUP_STATUS_DISABLED})
+
+
+def report_catchup_run(user_id: Optional[int], report: dict, task_name: str) -> None:
+    """Ship ONE catch-up run report (issue #792) and log the same line locally. `user_id` is None for
+    the fleet-wide beat dispatchers. Best-effort: a telemetry outage must never fail a scan that
+    otherwise worked."""
+    summary = ", ".join(f"{k}={report[k]}" for k in
+                        ("moments", "classified", "enabled_type", "excluded", "duplicate",
+                         "below_bar", "drafted", "dispatched", "capped", "requeued")
+                        if k in report)
+    status = report.get("status")
+    emit = log_debug if status in _CATCHUP_QUIET_STATUSES else log_info
+    emit(f"Catch-up {report.get('phase')} run: {status}" + (f" ({summary})" if summary else ""),
+         user_id=user_id, task_name=task_name, action_type="catchup")
+    try:
+        track_catchup_run(user_id, report)
+    except Exception as e:
+        log_warning("Could not report the catch-up run", exc=e, user_id=user_id,
+                    task_name=task_name, action_type="catchup")
+
+
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
                   reject_on_worker_lost=True, rate_limit='2/m', queue='se_outreach')
 def automate_catchup_touches(self, user_id: int, max_moments: int = 40, max_drafts: int = 10):
@@ -6069,10 +6123,20 @@ def automate_catchup_touches(self, user_id: int, max_moments: int = 40, max_draf
     capped scanner sends them later. Only milestone types the user enabled are drafted, each
     milestone is deduped on (person, event_type, period), and moments scoring below CATCHUP_MIN_SCORE
     are tombstoned as 'skipped' so we neither draft nor re-score them. The message itself is
-    LinkedIn's own pre-drafted response unless the user opted into catchup_message_source='ai'."""
+    LinkedIn's own pre-drafted response unless the user opted into catchup_message_source='ai'.
+
+    EVERY run reports (issue #792) — including the ones that draft nothing — with the per-stage
+    funnel counts, because a quiet lane and a broken one are otherwise the same silence."""
+    task_name = "automate_catchup_touches"
     prefs = get_engagement_preferences(user_id)
     enabled = {str(t) for t in (prefs.get("catchup_event_types") or [])}
+    auto_approve = str(prefs.get("catchup_touch_mode") or "pre_review") == "auto_approve"
+    source = str(prefs.get("catchup_message_source") or "linkedin")
+    report = {"phase": CATCHUP_PHASE_SCAN, "auto_approve": auto_approve, "message_source": source}
+
     if not enabled:
+        report["status"] = CATCHUP_STATUS_DISABLED
+        report_catchup_run(user_id, report, task_name)
         return f"Catch-up touches disabled for user {user_id} (no event types enabled)"
 
     try:
@@ -6080,10 +6144,14 @@ def automate_catchup_touches(self, user_id: int, max_moments: int = 40, max_draf
                                                                    session_name="Catch-up Moments")
     except LinkedInRateLimited as e:
         myprint(f"automate_catchup_touches deferred (throttled): {e}")
+        report["status"] = CATCHUP_STATUS_THROTTLED
+        report_catchup_run(user_id, report, task_name)
         return "Catch-up scan deferred (LinkedIn throttled)"
     except Exception as e:
         log_error("Failed to get profile for catch-up scan", exc=e, user_id=user_id,
-                  task_name="automate_catchup_touches")
+                  task_name=task_name)
+        report["status"] = CATCHUP_STATUS_SESSION_FAILED
+        report_catchup_run(user_id, report, task_name)
         return f"Failed to start catch-up scan: {e}"
 
     drafted = skipped = 0
@@ -6092,32 +6160,42 @@ def automate_catchup_touches(self, user_id: int, max_moments: int = 40, max_draf
                                           enabled_event_types=enabled)
     except LinkedInRateLimited as e:
         myprint(f"automate_catchup_touches deferred mid-scrape (throttled): {e}")
+        report["status"] = CATCHUP_STATUS_THROTTLED
+        report_catchup_run(user_id, report, task_name)
         return "Catch-up scan deferred (LinkedIn throttled)"
     except Exception as e:
-        log_error("Catch-up scrape failed", exc=e, user_id=user_id, task_name="automate_catchup_touches")
+        log_error("Catch-up scrape failed", exc=e, user_id=user_id, task_name=task_name)
+        report["status"] = CATCHUP_STATUS_SCRAPE_FAILED
+        report_catchup_run(user_id, report, task_name)
         return f"Catch-up scrape failed: {e}"
     finally:
         quit_gracefully(driver)
 
-    auto_approve = str(prefs.get("catchup_touch_mode") or "pre_review") == "auto_approve"
-    source = str(prefs.get("catchup_message_source") or "linkedin")
+    funnel = {"classified": 0, "enabled_type": 0, "excluded": 0, "duplicate": 0, "below_bar": 0}
     for moment in moments:
         if drafted >= max_drafts:
             break
         event_type = moment.get("event_type") or _classify_catchup_moment(moment.get("text", ""))
-        if event_type is None or event_type not in enabled:
+        if event_type is None:
             continue
+        funnel["classified"] += 1
+        if event_type not in enabled:
+            continue
+        funnel["enabled_type"] += 1
         if _catchup_excluded(moment, prefs):
+            funnel["excluded"] += 1
             continue
         moment["event_type"] = event_type
         period = _catchup_event_period(event_type)
         if has_catchup_touch(user_id, moment["profile_url"], event_type, period):
+            funnel["duplicate"] += 1
             continue
         score = _score_catchup_moment(moment, prefs)
         if score < CATCHUP_MIN_SCORE:
             insert_catchup_touch(user_id, moment["profile_url"], event_type, period,
                                  person_name=moment.get("name"), event_detail=moment.get("text"),
                                  score=score, status=CatchupTouchStatus.SKIPPED)
+            funnel["below_bar"] += 1
             skipped += 1
             continue
         try:
@@ -6133,8 +6211,12 @@ def automate_catchup_touches(self, user_id: int, max_moments: int = 40, max_draf
                                 message=message, score=score, status=status):
             drafted += 1
 
-    log_info(f"Catch-up scan drafted {drafted} touch(es) from {len(moments)} moment(s)",
-             user_id=user_id, task_name="automate_catchup_touches", action_type="catchup")
+    report.update(funnel, moments=len(moments), drafted=drafted)
+    if drafted:
+        report["status"] = CATCHUP_STATUS_DRAFTED
+    else:
+        report["status"] = CATCHUP_STATUS_NO_MOMENTS if not moments else CATCHUP_STATUS_NONE_QUALIFIED
+    report_catchup_run(user_id, report, task_name)
     return (f"Catch-up: {len(moments)} moment(s) scanned, {drafted} drafted "
             f"({'approved' if auto_approve else 'awaiting approval'}), {skipped} below the bar")
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -5739,6 +5739,7 @@ CATCHUP_MIN_SCORE = int(os.getenv("CATCHUP_MIN_SCORE", "30"))
 # the scan start" and "the card selectors have drifted" are the SAME silence without them.
 CATCHUP_PHASE_SCAN = "scan"
 CATCHUP_PHASE_SEND = "send"
+CATCHUP_PHASE_DELIVER = "deliver"                   # the per-touch terminal outcome
 CATCHUP_STATUS_DRAFTED = "drafted"
 CATCHUP_STATUS_DISABLED = "disabled"                # no milestone type enabled for this user
 CATCHUP_STATUS_THROTTLED = "throttled"              # 429 breaker / automation pause
@@ -5749,6 +5750,15 @@ CATCHUP_STATUS_NONE_QUALIFIED = "none_qualified"    # moments read, none survive
 CATCHUP_STATUS_DISPATCHED = "dispatched"
 CATCHUP_STATUS_NOTHING_TO_SEND = "nothing_to_send"
 CATCHUP_STATUS_CAPPED = "capped"                    # approved touches exist, today's cap is spent
+CATCHUP_STATUS_INACTIVE = "inactive_users"          # queue exists but its owners aren't connected
+# Terminal (deliver) outcomes. `dispatched` is NOT delivery: a touch the DM cap or the breaker defers
+# goes back to 'approved' and the drip re-dispatches it on the next beat, so a lane that never sends
+# anything reads as a healthy rising `dispatched` count unless the send itself reports.
+CATCHUP_STATUS_SENT = "sent"
+CATCHUP_STATUS_FAILED = "failed"                    # send_dm_now could not deliver it
+CATCHUP_STATUS_DM_CAPPED = "dm_capped"              # the ACCOUNT-wide DM cap, not the catch-up one
+CATCHUP_STATUS_NO_MESSAGE = "no_message"            # approved with an empty body
+CATCHUP_STATUS_NOT_SENDABLE = "not_sendable"        # row missing or no longer approved/sending
 
 # Ordered fallback chain for the catch-up cards. LinkedIn's SDUI ships hashed classes, so we prefer
 # data-view-name, then the semantic list, then any main-content list item that links to a profile.
@@ -6051,7 +6061,10 @@ def _scrape_catchup_moments(driver: WebDriver, max_moments: int = 40, user_id: i
         time.sleep(random.uniform(2, 4))
 
     if not moments:
-        log_warning("Catch-up feed produced no moments", user_id=user_id, action_type="catchup")
+        # DEBUG, not WARNING: an empty catch-up feed is a normal day, and the scan beat runs daily
+        # per user — three of them inside the escalation window would re-emit at ERROR and file a
+        # grouped $exception for a no-op. The `no_moments` status on the run report carries it.
+        log_debug("Catch-up feed produced no moments", user_id=user_id, action_type="catchup")
     return moments
 
 
@@ -6091,7 +6104,8 @@ def _draft_catchup_message(user_id: int, moment: dict, my_profile: LinkedInProfi
 # the throttle already logs its own reason in _skip_if_throttled) — the PostHog series is what
 # carries them, and that's the series a "catch-up never sends" report has to be answered from.
 _CATCHUP_QUIET_STATUSES = frozenset({CATCHUP_STATUS_NOTHING_TO_SEND, CATCHUP_STATUS_CAPPED,
-                                     CATCHUP_STATUS_THROTTLED, CATCHUP_STATUS_DISABLED})
+                                     CATCHUP_STATUS_THROTTLED, CATCHUP_STATUS_DISABLED,
+                                     CATCHUP_STATUS_DM_CAPPED, CATCHUP_STATUS_NOT_SENDABLE})
 
 
 def report_catchup_run(user_id: Optional[int], report: dict, task_name: str) -> None:
@@ -6100,7 +6114,8 @@ def report_catchup_run(user_id: Optional[int], report: dict, task_name: str) -> 
     otherwise worked."""
     summary = ", ".join(f"{k}={report[k]}" for k in
                         ("moments", "classified", "enabled_type", "excluded", "duplicate",
-                         "below_bar", "drafted", "dispatched", "capped", "requeued")
+                         "below_bar", "drafted", "dispatched", "capped", "inactive", "requeued",
+                         "touch_id")
                         if k in report)
     status = report.get("status")
     emit = log_debug if status in _CATCHUP_QUIET_STATUSES else log_info
@@ -6228,14 +6243,26 @@ def send_catchup_touch(self, touch_id: int):
     and the overall DM cap at send time — either one trips the touch back to 'approved' for the next
     scan rather than sending — and reuses send_dm_now, so it honors the 429 breaker / kill-switch and
     the shared DM logging. A high-value milestone also enqueues the user's follow-up sequence, which is
-    what routes a replying prospect into the BD nurture."""
+    what routes a replying prospect into the BD nurture.
+
+    EVERY outcome reports (issue #792). A deferral puts the touch back to 'approved' and the drip
+    re-dispatches it 20 minutes later, so without this the send phase's `dispatched` count climbs all
+    day on a lane that has never delivered a single message — which IS the reported symptom."""
+    task_name = "send_catchup_touch"
+
+    def _report(status: str, user_id: Optional[int]) -> None:
+        report_catchup_run(user_id, {"phase": CATCHUP_PHASE_DELIVER, "status": status,
+                                     "touch_id": touch_id}, task_name)
+
     touch = get_catchup_touch(touch_id)
     if not touch or touch["status"] not in (CatchupTouchStatus.APPROVED, CatchupTouchStatus.SENDING):
+        _report(CATCHUP_STATUS_NOT_SENDABLE, touch.get("user_id") if touch else None)
         return f"Catch-up touch {touch_id} not sendable (status={touch['status'] if touch else 'missing'})"
     if not (touch.get("message") or "").strip():
         update_catchup_touch_status(touch_id, CatchupTouchStatus.SKIPPED)
         log_warning("Catch-up touch approved with no message; skipping", user_id=touch["user_id"],
                     action_type="catchup")
+        _report(CATCHUP_STATUS_NO_MESSAGE, touch["user_id"])
         return f"Catch-up touch {touch_id} skipped (no message)"
 
     user_id = touch["user_id"]
@@ -6246,9 +6273,11 @@ def send_catchup_touch(self, touch_id: int):
                     max_catchup_touches_allowed(user_id))
     if count_catchup_touches_sent_today(user_id) >= daily_cap:
         update_catchup_touch_status(touch_id, CatchupTouchStatus.APPROVED)  # retry on the next scan
+        _report(CATCHUP_STATUS_CAPPED, user_id)
         return f"Catch-up touch {touch_id} deferred (daily catch-up cap reached)"
     if count_dms_sent_today(user_id) >= int(prefs.get("max_dms_per_day") or 0):
         update_catchup_touch_status(touch_id, CatchupTouchStatus.APPROVED)
+        _report(CATCHUP_STATUS_DM_CAPPED, user_id)
         return f"Catch-up touch {touch_id} deferred (daily DM cap reached)"
 
     try:
@@ -6256,8 +6285,10 @@ def send_catchup_touch(self, touch_id: int):
     except LinkedInRateLimited as e:
         myprint(f"send_catchup_touch: throttled, deferring {touch_id}: {e}")
         update_catchup_touch_status(touch_id, CatchupTouchStatus.APPROVED)
+        _report(CATCHUP_STATUS_THROTTLED, user_id)
         return f"Catch-up touch {touch_id} deferred (LinkedIn throttled)"
     update_catchup_touch_status(touch_id, CatchupTouchStatus.SENT if sent else CatchupTouchStatus.FAILED)
+    _report(CATCHUP_STATUS_SENT if sent else CATCHUP_STATUS_FAILED, user_id)
     if sent:
         first_name = (touch.get("person_name") or "").strip().split(" ")[0] or "there"
         _schedule_catchup_followup(user_id, touch["profile_url"], first_name, str(touch["event_type"]))

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -14,7 +14,7 @@ from cqc_lem.app.run_automation import automate_commenting, automate_profile_vie
     sweep_reply_comments, sweep_comment_followups, sweep_comment_outcomes, send_catchup_touch, \
     report_catchup_run, CATCHUP_PHASE_SCAN, CATCHUP_PHASE_SEND, CATCHUP_STATUS_THROTTLED, \
     CATCHUP_STATUS_DISABLED, CATCHUP_STATUS_DISPATCHED, CATCHUP_STATUS_CAPPED, \
-    CATCHUP_STATUS_NOTHING_TO_SEND
+    CATCHUP_STATUS_NOTHING_TO_SEND, CATCHUP_STATUS_INACTIVE
 from cqc_lem.utilities.db import (
     get_ready_to_post_posts, get_orphaned_scheduled_posts, update_db_post_status,
     get_active_user_ids, PostStatus, has_linkedin_session, get_company_linked_in_url_for_user,
@@ -1300,11 +1300,16 @@ def auto_check_catchup_touches():
 
     dispatched = 0
     capped = 0
+    inactive = 0
     budgets: dict = {}  # user_id -> remaining catch-up touches allowed today
     for touch_id, user_id in approved:
         if user_id not in active_user_ids:
-            log_warning("Skipping catch-up touch — user not active/connected",
-                        user_id=user_id, task_name="auto_check_catchup_touches")
+            # DEBUG + a counted funnel stage, not a WARNING: this drip beats every 20 minutes, so a
+            # single queued touch on a disconnected account would re-emit at ERROR and file a grouped
+            # $exception ~72x a day. `inactive` on the run report is the durable signal.
+            inactive += 1
+            log_debug("Skipping catch-up touch — user not active/connected",
+                      user_id=user_id, task_name=task_name)
             continue
         if user_id not in budgets:
             # 10/day is a premium-plan allowance; every other plan tops out at 5 (see db.py).
@@ -1330,10 +1335,14 @@ def auto_check_catchup_touches():
 
     if dispatched or orphaned:
         status = CATCHUP_STATUS_DISPATCHED
+    elif capped:
+        status = CATCHUP_STATUS_CAPPED
+    elif inactive:
+        status = CATCHUP_STATUS_INACTIVE  # a queue that exists but whose owners can't be sent for
     else:
-        status = CATCHUP_STATUS_CAPPED if capped else CATCHUP_STATUS_NOTHING_TO_SEND
+        status = CATCHUP_STATUS_NOTHING_TO_SEND
     report_catchup_run(None, {"phase": CATCHUP_PHASE_SEND, "status": status,
-                              "dispatched": dispatched, "capped": capped,
+                              "dispatched": dispatched, "capped": capped, "inactive": inactive,
                               "requeued": len(orphaned)}, task_name)
     if dispatched == 0 and len(orphaned) == 0:
         return "No Catch-up Touches to Send"

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -11,7 +11,10 @@ from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.app.run_automation import automate_commenting, automate_profile_viewer_engagement, \
     automate_appreciation_dms_for_user, clean_stale_invites, update_stale_profile, post_to_linkedin, \
     automate_invites_to_company_page_for_user, send_scheduled_dm, send_connection_request, \
-    sweep_reply_comments, sweep_comment_followups, sweep_comment_outcomes, send_catchup_touch
+    sweep_reply_comments, sweep_comment_followups, sweep_comment_outcomes, send_catchup_touch, \
+    report_catchup_run, CATCHUP_PHASE_SCAN, CATCHUP_PHASE_SEND, CATCHUP_STATUS_THROTTLED, \
+    CATCHUP_STATUS_DISABLED, CATCHUP_STATUS_DISPATCHED, CATCHUP_STATUS_CAPPED, \
+    CATCHUP_STATUS_NOTHING_TO_SEND
 from cqc_lem.utilities.db import (
     get_ready_to_post_posts, get_orphaned_scheduled_posts, update_db_post_status,
     get_active_user_ids, PostStatus, has_linkedin_session, get_company_linked_in_url_for_user,
@@ -1259,7 +1262,13 @@ def auto_scan_catchup_moments():
     """Dispatch the daily per-user LinkedIn Catch-up scan (issue #482). Drafting only — the scan writes
     approval-gated rows to catchup_touches and sends nothing. Users who disabled every milestone type
     are skipped so we never open a Chrome session for them."""
-    if _skip_if_throttled("auto_scan_catchup_moments"):
+    task_name = "auto_scan_catchup_moments"
+    # The dispatcher reports too (issue #792): a lane that never dispatches because the 429 breaker
+    # is open looks exactly like a lane whose per-user scans found nothing, and the difference is the
+    # whole answer to "catch-up isn't sending anything".
+    if _skip_if_throttled(task_name):
+        report_catchup_run(None, {"phase": CATCHUP_PHASE_SCAN,
+                                  "status": CATCHUP_STATUS_THROTTLED}, task_name)
         return "Automation throttled"
     from cqc_lem.app.run_automation import automate_catchup_touches
     dispatched = 0
@@ -1268,6 +1277,9 @@ def auto_scan_catchup_moments():
             continue
         automate_catchup_touches.apply_async(kwargs={'user_id': user_id})
         dispatched += 1
+    report_catchup_run(None, {"phase": CATCHUP_PHASE_SCAN, "dispatched": dispatched,
+                              "status": CATCHUP_STATUS_DISPATCHED if dispatched
+                              else CATCHUP_STATUS_DISABLED}, task_name)
     return f"Dispatched catch-up scan for {dispatched} user(s)"
 
 
@@ -1277,13 +1289,17 @@ def auto_check_catchup_touches():
     auto_check_connection_requests: approval happens upstream (rows only reach 'approved' via the API
     or the user's auto_approve mode), the whole scan short-circuits while the kill-switch / 429 breaker
     is open, and the send task re-checks both caps and the throttle."""
-    if _skip_if_throttled("auto_check_catchup_touches"):
+    task_name = "auto_check_catchup_touches"
+    if _skip_if_throttled(task_name):
+        report_catchup_run(None, {"phase": CATCHUP_PHASE_SEND,
+                                  "status": CATCHUP_STATUS_THROTTLED}, task_name)
         return "Automation throttled"
 
     approved = get_approved_catchup_touches()
     active_user_ids = set(get_active_user_ids()) if approved else set()
 
     dispatched = 0
+    capped = 0
     budgets: dict = {}  # user_id -> remaining catch-up touches allowed today
     for touch_id, user_id in approved:
         if user_id not in active_user_ids:
@@ -1296,6 +1312,7 @@ def auto_check_catchup_touches():
                       max_catchup_touches_allowed(user_id))
             budgets[user_id] = max(0, cap - count_catchup_touches_sent_today(user_id))
         if budgets[user_id] <= 0:
+            capped += 1
             continue  # cap met for today — the rest stay 'approved' for tomorrow
         budgets[user_id] -= 1
         update_catchup_touch_status(touch_id, CatchupTouchStatus.SENDING)
@@ -1307,10 +1324,17 @@ def auto_check_catchup_touches():
     orphaned = get_orphaned_catchup_touches(lookback_hours=2)
     for touch_id, user_id in orphaned:
         log_warning(f"Re-queueing orphaned catch-up touch {touch_id}",
-                    user_id=user_id, task_name="auto_check_catchup_touches")
+                    user_id=user_id, task_name=task_name)
         update_catchup_touch_status(touch_id, CatchupTouchStatus.SENDING)
         send_catchup_touch.apply_async(kwargs={'touch_id': touch_id})
 
+    if dispatched or orphaned:
+        status = CATCHUP_STATUS_DISPATCHED
+    else:
+        status = CATCHUP_STATUS_CAPPED if capped else CATCHUP_STATUS_NOTHING_TO_SEND
+    report_catchup_run(None, {"phase": CATCHUP_PHASE_SEND, "status": status,
+                              "dispatched": dispatched, "capped": capped,
+                              "requeued": len(orphaned)}, task_name)
     if dispatched == 0 and len(orphaned) == 0:
         return "No Catch-up Touches to Send"
     return f"Dispatched {dispatched} catch-up touch(es); re-queued {len(orphaned)} orphaned"

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -909,7 +909,12 @@ def track_catchup_run(user_id: Optional[int], report: Optional[dict] = None, **e
     start, and a scan whose selectors had drifted all produced the same thing — silence — so a user
     reporting "catch-up never sends anything" could not be answered from telemetry at all. The
     `status` and the per-stage funnel counts ARE the point: they say which stage the moments died at
-    (`scanned` -> `classified` -> `enabled` -> after exclusion/dedup/score -> `drafted`)."""
+    (`scanned` -> `classified` -> `enabled` -> after exclusion/dedup/score -> `drafted`).
+
+    Three phases, because a `dispatched` touch is not a sent one: `scan` drafts, `send` is the drip
+    that dispatches, and `deliver` is the per-touch terminal outcome. A touch the account-wide DM cap
+    defers goes back to 'approved' and is re-dispatched on the next beat, so only the `deliver` phase
+    can tell a lane that sends from one that has looped all day without delivering anything."""
     report = dict(report or {})
     posthog.capture(
         distinct_id=str(user_id or "system"),
@@ -929,7 +934,9 @@ def track_catchup_run(user_id: Optional[int], report: Optional[dict] = None, **e
             "message_source": report.get("message_source"),
             "dispatched": int(report.get("dispatched") or 0),
             "capped": int(report.get("capped") or 0),
+            "inactive": int(report.get("inactive") or 0),
             "requeued": int(report.get("requeued") or 0),
+            "touch_id": report.get("touch_id"),
             **extra,
         },
     )

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -901,6 +901,40 @@ def track_company_page_invite_run(user_id: Optional[int], report: Optional[dict]
     )
 
 
+def track_catchup_run(user_id: Optional[int], report: Optional[dict] = None, **extra) -> None:
+    """Emit one LinkedIn Catch-up run (issue #792) — EVERY run of BOTH phases, including the ones
+    that drafted or sent nothing.
+
+    The lane used to be write-only: a scan that found no milestone, a scan the 429 breaker never let
+    start, and a scan whose selectors had drifted all produced the same thing — silence — so a user
+    reporting "catch-up never sends anything" could not be answered from telemetry at all. The
+    `status` and the per-stage funnel counts ARE the point: they say which stage the moments died at
+    (`scanned` -> `classified` -> `enabled` -> after exclusion/dedup/score -> `drafted`)."""
+    report = dict(report or {})
+    posthog.capture(
+        distinct_id=str(user_id or "system"),
+        event="catchup_run",
+        properties={
+            "user_id": user_id,
+            "phase": report.get("phase"),
+            "status": report.get("status"),
+            "moments": int(report.get("moments") or 0),
+            "classified": int(report.get("classified") or 0),
+            "enabled_type": int(report.get("enabled_type") or 0),
+            "excluded": int(report.get("excluded") or 0),
+            "duplicate": int(report.get("duplicate") or 0),
+            "below_bar": int(report.get("below_bar") or 0),
+            "drafted": int(report.get("drafted") or 0),
+            "auto_approve": bool(report.get("auto_approve")),
+            "message_source": report.get("message_source"),
+            "dispatched": int(report.get("dispatched") or 0),
+            "capped": int(report.get("capped") or 0),
+            "requeued": int(report.get("requeued") or 0),
+            **extra,
+        },
+    )
+
+
 def track_margin_report(report: dict) -> None:
     """Emit the weekly unit-economics scorecard (plan §E.1.4) as one `margin_report` event so the
     PostHog tiles read system margin, cohort margin and LTV:CAC without re-deriving them. Per-user

--- a/tests/unit/app/test_catchup_touches.py
+++ b/tests/unit/app/test_catchup_touches.py
@@ -167,14 +167,18 @@ class TestScrapeCatchupMoments:
         assert moments[0]["name"] == "Jane Doe"
 
     def test_skips_cards_without_a_profile_link(self):
+        """An empty feed is a normal day and the scan runs daily per user, so this is DEBUG — three
+        WARNINGs inside the escalation window re-emit at ERROR and file a grouped $exception for a
+        no-op. The `no_moments` run report (issue #792) is what carries it."""
         from cqc_lem.app.run_automation import _scrape_catchup_moments
         card = MagicMock()
         card.find_elements.return_value = []
         driver = MagicMock()
         with patch(f"{_RA}.find_all_first", return_value=[card]), \
-             patch(f"{_RA}.log_warning") as warn:
+             patch(f"{_RA}.log_warning") as warn, patch(f"{_RA}.log_debug") as debug:
             assert _scrape_catchup_moments(driver, max_moments=10, user_id=1) == []
-        warn.assert_called_once()
+        debug.assert_called_once()
+        warn.assert_not_called()
 
     def test_stops_at_max_moments(self):
         from cqc_lem.app.run_automation import _scrape_catchup_moments
@@ -1002,6 +1006,26 @@ class TestCatchupRunReport:
             auto_check_catchup_touches()
         assert track.call_args.args[1]["status"] == "nothing_to_send"
 
+    def test_send_drip_reports_a_queue_stuck_behind_a_disconnected_account(self):
+        """Approved touches whose owner isn't connected used to be counted nowhere, so the report
+        read `nothing_to_send` while a real queue sat there — and the per-touch skip warned every
+        20 minutes, which the recurrence escalation re-emits at ERROR."""
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_catchup_touches", return_value=[(1, 7), (2, 7)]), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[]), \
+             patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.send_catchup_touch") as task, \
+             patch(f"{_RS}.log_warning") as warn, \
+             patch(f"{_RA}.track_catchup_run") as track:
+            auto_check_catchup_touches()
+        report = track.call_args.args[1]
+        assert report["status"] == "inactive_users"
+        assert report["inactive"] == 2
+        assert report["dispatched"] == 0
+        task.apply_async.assert_not_called()
+        warn.assert_not_called()
+
     def test_send_drip_reports_when_throttled(self):
         from cqc_lem.app.run_scheduler import auto_check_catchup_touches
         with patch(f"{_RS}._skip_if_throttled", return_value=True), \
@@ -1009,6 +1033,57 @@ class TestCatchupRunReport:
             auto_check_catchup_touches()
         assert track.call_args.args[1]["status"] == "throttled"
         assert track.call_args.args[1]["phase"] == "send"
+
+
+class TestCatchupDeliveryReport:
+    """Issue #792: `dispatched` is not `sent`. A deferred touch goes back to 'approved' and the drip
+    re-dispatches it on the next 20-minute beat, so the send phase alone shows a climbing dispatch
+    count for a lane that has delivered nothing all day — the reporter's exact symptom."""
+
+    def _send(self, **overrides):
+        from cqc_lem.app.run_automation import send_catchup_touch
+        holder = TestSendCatchupTouch()
+        p = holder._patches(holder._touch(), **{k: v for k, v in overrides.items()
+                                                if k in ("sent", "catchup_today", "dms_today")})
+        for key, value in overrides.items():
+            if key not in ("sent", "catchup_today", "dms_today"):
+                p[key] = value
+        with p["get"], p["prefs"], p["allow"], p["cnt"], p["dms"], p["send"], p["upd"], p["enq"], \
+             patch(f"{_RA}.track_catchup_run") as track:
+            send_catchup_touch.run(touch_id=3)
+        track.assert_called_once()
+        return track.call_args.args[1]
+
+    def test_a_delivered_touch_reports_sent(self):
+        report = self._send()
+        assert report["phase"] == "deliver"
+        assert report["status"] == "sent"
+        assert report["touch_id"] == 3
+
+    def test_a_failed_send_reports_failed(self):
+        assert self._send(sent=False)["status"] == "failed"
+
+    def test_the_account_wide_dm_cap_is_distinguishable_from_the_catchup_cap(self):
+        """The two deferrals look identical from the drip — both leave the row 'approved'. Only the
+        status says which cap the user has to raise."""
+        assert self._send(dms_today=20)["status"] == "dm_capped"
+        assert self._send(catchup_today=5)["status"] == "capped"
+
+    def test_a_throttled_send_reports_rather_than_going_silent(self):
+        from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
+        report = self._send(send=patch(f"{_RA}.send_dm_now", side_effect=LinkedInRateLimited("429")))
+        assert report["status"] == "throttled"
+
+    def test_an_empty_message_reports_no_message(self):
+        holder = TestSendCatchupTouch()
+        report = self._send(get=patch(f"{_RA}.get_catchup_touch",
+                                      return_value=holder._touch(message="  ")))
+        assert report["status"] == "no_message"
+
+    def test_a_vanished_row_still_reports(self):
+        report = self._send(get=patch(f"{_RA}.get_catchup_touch", return_value=None))
+        assert report["status"] == "not_sendable"
+        assert report["touch_id"] == 3
 
 
 class TestCatchupBeatSchedule:

--- a/tests/unit/app/test_catchup_touches.py
+++ b/tests/unit/app/test_catchup_touches.py
@@ -243,6 +243,34 @@ class TestLinkedInDraftHarvest:
         from cqc_lem.app.run_automation import _clean_suggested_message
         assert _clean_suggested_message(raw) == expected
 
+    @pytest.mark.parametrize("chrome", [
+        "Say congrats", "Say congrats to Jane", "Say congrats to Jane Doe", "Congrats!",
+        "Congratulate Jane", "Message", "Send a message", "Send message to Jane",
+        "Write a message…", "Reply", "Send", "View profile", "See more",
+    ])
+    def test_button_chrome_is_never_mistaken_for_a_message(self, chrome):
+        """`button[aria-label*='congrats']` matches LinkedIn's OWN trigger, and an empty composer
+        renders its placeholder — both clear the length floor, so without this the card's chrome
+        becomes the congratulations we queue (and, on auto-approve, SEND). Issue #792."""
+        from cqc_lem.app.run_automation import _clean_suggested_message
+        assert _clean_suggested_message(chrome) == ""
+
+    @pytest.mark.parametrize("real", [
+        "Congrats on the new role, Jane!",
+        "Congrats to Jane on the new role!",
+        "Happy work anniversary, Sam!",
+        "Congratulations on the promotion — well earned.",
+    ])
+    def test_a_real_draft_survives_the_chrome_filter(self, real):
+        from cqc_lem.app.run_automation import _clean_suggested_message
+        assert _clean_suggested_message(real) == real
+
+    def test_a_chrome_only_card_falls_back_to_the_plain_congratulations(self):
+        """End-to-end of the same defect: the card's trigger label must not become the message."""
+        from cqc_lem.app.run_automation import _draft_catchup_message
+        moment = {"name": "Jane Doe", "event_type": "job_change", "suggested_message": "Say congrats"}
+        assert _draft_catchup_message(1, moment, MagicMock()) == "Congrats on the new role, Jane!"
+
     def test_card_suggestion_is_read_without_clicking(self):
         from cqc_lem.app.run_automation import _card_suggested_message
         chip = MagicMock()
@@ -834,6 +862,153 @@ class TestCatchupDispatchers:
              patch(f"{_RS}.send_catchup_touch") as task:
             assert auto_check_catchup_touches() == "Automation throttled"
         task.apply_async.assert_not_called()
+
+
+class TestCatchupRunReport:
+    """Issue #792: EVERY catch-up run reports, including the ones that draft or send nothing —
+    otherwise "the feed had nothing today" and "the lane is broken" are the same silence."""
+
+    def _patches(self, moments, prefs=None):
+        return TestAutomateCatchupTouches()._patches(moments, prefs=prefs)
+
+    def _run_scan(self, moments, prefs=None, **overrides):
+        from cqc_lem.app.run_automation import automate_catchup_touches
+        p = self._patches(moments, prefs=prefs)
+        p.update(overrides)
+        with p["prefs"], p["profile"], p["scrape"], p["quit"], p["has"], p["draft"], p["insert"], \
+             patch(f"{_RA}.track_catchup_run") as track, patch(f"{_RA}.log_error"):
+            automate_catchup_touches.run(user_id=1)
+        track.assert_called_once()
+        return track.call_args.args[1]
+
+    def test_a_drafting_run_reports_the_whole_funnel(self):
+        report = self._run_scan([_moment(suggested_message="Congrats on the new role, Jane!")])
+        assert report["phase"] == "scan"
+        assert report["status"] == "drafted"
+        assert report["moments"] == 1
+        assert report["classified"] == 1
+        assert report["enabled_type"] == 1
+        assert report["drafted"] == 1
+        assert report["message_source"] == "linkedin"
+        assert report["auto_approve"] is False
+
+    def test_an_empty_feed_reports_no_moments(self):
+        report = self._run_scan([])
+        assert report["status"] == "no_moments"
+        assert report["moments"] == 0
+        assert report["drafted"] == 0
+
+    def test_unclassifiable_moments_report_none_qualified_with_zero_classified(self):
+        """The feed rendered cards but none read as a milestone — a selector/copy drift, not a quiet
+        day. `classified == 0` beside `moments > 0` is what separates the two."""
+        report = self._run_scan([_moment(text="People you may know"),
+                                 _moment(text="Suggested for you",
+                                         profile_url="https://www.linkedin.com/in/pat")])
+        assert report["status"] == "none_qualified"
+        assert report["moments"] == 2
+        assert report["classified"] == 0
+
+    def test_a_deduped_milestone_is_counted_as_a_duplicate(self):
+        report = self._run_scan([_moment()],
+                                has=patch(f"{_RA}.has_catchup_touch", return_value=True))
+        assert report["status"] == "none_qualified"
+        assert report["duplicate"] == 1
+        assert report["drafted"] == 0
+
+    def test_an_excluded_author_is_counted_as_excluded(self):
+        report = self._run_scan([_moment()], prefs=_prefs(exclude_authors=["Jane"]))
+        assert report["excluded"] == 1
+        assert report["status"] == "none_qualified"
+
+    def test_a_below_bar_moment_is_counted(self):
+        report = self._run_scan([_moment(text="Wish Jane a happy birthday")],
+                                prefs=_prefs(catchup_event_types=["birthday"]))
+        assert report["below_bar"] == 1
+        assert report["status"] == "none_qualified"
+
+    def test_a_disabled_user_still_reports(self):
+        report = self._run_scan([_moment()], prefs=_prefs(catchup_event_types=[]))
+        assert report["status"] == "disabled"
+
+    def test_a_throttled_scan_reports_rather_than_going_silent(self):
+        from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited
+        report = self._run_scan(
+            [_moment()],
+            profile=patch(f"{_RA}.get_current_profile", side_effect=LinkedInRateLimited("429")))
+        assert report["status"] == "throttled"
+
+    def test_a_dead_session_reports_session_failed(self):
+        report = self._run_scan(
+            [_moment()], profile=patch(f"{_RA}.get_current_profile", side_effect=RuntimeError("boom")))
+        assert report["status"] == "session_failed"
+
+    def test_a_scrape_failure_reports_scrape_failed(self):
+        report = self._run_scan(
+            [_moment()], scrape=patch(f"{_RA}._scrape_catchup_moments", side_effect=RuntimeError("boom")))
+        assert report["status"] == "scrape_failed"
+
+    def test_a_telemetry_outage_never_fails_the_run(self):
+        from cqc_lem.app.run_automation import report_catchup_run
+        with patch(f"{_RA}.track_catchup_run", side_effect=RuntimeError("posthog down")), \
+             patch(f"{_RA}.log_warning") as warn:
+            report_catchup_run(1, {"phase": "scan", "status": "drafted", "drafted": 1}, "t")
+        warn.assert_called_once()
+
+    def test_scan_dispatcher_reports_when_throttled(self):
+        from cqc_lem.app.run_scheduler import auto_scan_catchup_moments
+        with patch(f"{_RS}._skip_if_throttled", return_value=True), \
+             patch(f"{_RA}.track_catchup_run") as track:
+            auto_scan_catchup_moments()
+        assert track.call_args.args[1]["status"] == "throttled"
+        assert track.call_args.args[1]["phase"] == "scan"
+
+    def test_scan_dispatcher_reports_a_fleet_with_nobody_enabled(self):
+        from cqc_lem.app.run_scheduler import auto_scan_catchup_moments
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
+             patch(f"{_RS}.get_engagement_preferences", return_value=_prefs(catchup_event_types=[])), \
+             patch(f"{_RA}.automate_catchup_touches"), \
+             patch(f"{_RA}.track_catchup_run") as track:
+            auto_scan_catchup_moments()
+        assert track.call_args.args[1]["status"] == "disabled"
+        assert track.call_args.args[1]["dispatched"] == 0
+
+    def test_send_drip_reports_a_cap_that_swallowed_every_approved_touch(self):
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_catchup_touches", return_value=[(1, 7), (2, 7)]), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
+             patch(f"{_RS}.get_engagement_preferences", return_value=_prefs()), \
+             patch(f"{_RS}.max_catchup_touches_allowed", return_value=5), \
+             patch(f"{_RS}.count_catchup_touches_sent_today", return_value=5), \
+             patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.update_catchup_touch_status"), \
+             patch(f"{_RS}.send_catchup_touch"), \
+             patch(f"{_RA}.track_catchup_run") as track:
+            auto_check_catchup_touches()
+        report = track.call_args.args[1]
+        assert report["phase"] == "send"
+        assert report["status"] == "capped"
+        assert report["capped"] == 2
+        assert report["dispatched"] == 0
+
+    def test_send_drip_reports_an_empty_queue(self):
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.send_catchup_touch"), \
+             patch(f"{_RA}.track_catchup_run") as track:
+            auto_check_catchup_touches()
+        assert track.call_args.args[1]["status"] == "nothing_to_send"
+
+    def test_send_drip_reports_when_throttled(self):
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        with patch(f"{_RS}._skip_if_throttled", return_value=True), \
+             patch(f"{_RA}.track_catchup_run") as track:
+            auto_check_catchup_touches()
+        assert track.call_args.args[1]["status"] == "throttled"
+        assert track.call_args.args[1]["phase"] == "send"
 
 
 class TestCatchupBeatSchedule:

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -1059,3 +1059,39 @@ class TestExperimentTelemetry:
         assert props["cohort_enrolled"] == 2
         assert props["cohort_treatment_share"] == 0.5
         assert props["buckets"][0]["assignment"] == "flag"
+
+
+class TestTrackCatchupRun:
+    def test_emits_the_catchup_run_event_with_the_funnel(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_catchup_run
+            track_catchup_run(7, {"phase": "scan", "status": "none_qualified", "moments": 12,
+                                  "classified": 0, "message_source": "linkedin"})
+
+        kwargs = mock_ph.capture.call_args.kwargs
+        assert kwargs["event"] == "catchup_run"
+        assert kwargs["distinct_id"] == "7"
+        props = kwargs["properties"]
+        assert props["phase"] == "scan"
+        assert props["status"] == "none_qualified"
+        assert props["moments"] == 12
+        assert props["classified"] == 0
+        assert props["message_source"] == "linkedin"
+
+    def test_a_fleet_wide_beat_report_is_attributed_to_system(self):
+        """The dispatchers report for the whole fleet, not a user — the counts still have to land."""
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_catchup_run
+            track_catchup_run(None, {"phase": "send", "status": "capped", "capped": 3})
+
+        kwargs = mock_ph.capture.call_args.kwargs
+        assert kwargs["distinct_id"] == "system"
+        assert kwargs["properties"]["capped"] == 3
+        assert kwargs["properties"]["dispatched"] == 0  # absent counts read 0, never missing
+
+    def test_an_empty_report_still_emits(self):
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_catchup_run
+            track_catchup_run(7)
+        mock_ph.capture.assert_called_once()
+        assert mock_ph.capture.call_args.kwargs["properties"]["status"] is None


### PR DESCRIPTION
## Why

A user reported that the auto catch-up feature — configured to use LinkedIn's default message and send N messages a day — **isn't sending anything, isn't logging anything, and doesn't show up in any queue or activity dashboard**, and asked for a debugging pass on the admin account.

The lane was **write-only**. Every one of these produced exactly the same output — silence:

- the 429 breaker / automation pause held the beat, so no scan ever dispatched
- the browser session died before the feed loaded
- the scrape threw
- the feed rendered cards but none classified as a milestone (a selector or copy drift)
- moments classified but every one was excluded / already touched / below `CATCHUP_MIN_SCORE`
- touches drafted fine and sat `pending` behind approval, or `approved` behind a spent daily cap

There was no telemetry that could tell those apart, so the report was unanswerable.

## What changed

**1. Every catch-up run reports — including the ones that do nothing.**

`track_catchup_run` (`observability.py`) emits ONE `catchup_run` event per run of **both** phases, carrying:

- `phase` — `scan` (drafting) | `send` (the drip that dispatches) | `deliver` (the per-touch terminal outcome)
- `status` — `disabled` / `throttled` / `session_failed` / `scrape_failed` / `no_moments` / `none_qualified` / `drafted` on the scan; `dispatched` / `capped` / `inactive_users` / `nothing_to_send` on the drip; `sent` / `failed` / `capped` / `dm_capped` / `throttled` / `no_message` / `not_sendable` on delivery
- the **per-stage funnel**: `moments` → `classified` → `enabled_type` → `excluded` / `duplicate` / `below_bar` → `drafted`, plus `dispatched` / `capped` / `inactive` / `requeued`
- `auto_approve` and `message_source`, so an expectation mismatch (`pre_review` + a per-day cap reads as "it should just send") is visible too

**`dispatched` is not `sent`**, which is why the `deliver` phase exists. Every deferral in `send_catchup_touch` (the account-wide DM cap, the catch-up cap, a 429) puts the row back to `approved`, so the 20-minute drip re-dispatches the same touch on the next beat. A user whose `max_dms_per_day` is already spent by the other DM lanes produces a healthy, climbing `dispatched` count on a lane that has delivered nothing all day — the reported symptom exactly. Only the terminal report separates the two.

`moments > 0` with `classified == 0` is a selector/copy drift. `classified > 0` with `drafted == 0` is exclusion, dedup or the score bar — and the counts say which. This is the same posture as `company_page_invite_run` (#732), for the same reason: a series that only carries sends cannot distinguish "quiet today" from "silently broken".

The steady-state outcomes (`nothing_to_send`, `capped`, `dm_capped`, `throttled`, `disabled`, `not_sendable`) log **DEBUG** so an expected no-op never re-emits at ERROR under the recurrence escalation — the PostHog series is what carries them. Two pre-existing `log_warning`s on the same lane were doing exactly that and are now DEBUG too: the empty-feed warning fires on every quiet scan, and "user not active/connected" fires every 20 minutes per queued touch, so both crossed the escalation threshold and filed a grouped `$exception` for a no-op. Approved touches for a disconnected owner were also counted at no stage, so the drip reported `nothing_to_send` while a real queue sat behind a broken session; they now count as `inactive`.

**2. LinkedIn's button chrome is no longer mistaken for its draft.**

`_CATCHUP_SUGGESTED_TEXT_LOCATORS` includes `button[aria-label*='congrats']`, which matches LinkedIn's **own** "Say congrats to Jane" trigger, and an empty composer renders its placeholder. Both clear `_clean_suggested_message`'s 4-character floor, so the card's *chrome* became the congratulations — queued as `"Say congrats"`, and on `catchup_touch_mode='auto_approve'` **sent** as it. This is exactly the `catchup_message_source='linkedin'` path the reporter configured. `_clean_suggested_message` now rejects the affordance labels and placeholders, so the per-milestone one-liner is used instead — which is what its docstring already claimed it did.

## Testing

`tests/unit/app/test_catchup_touches.py` (+41) and `tests/unit/utilities/test_observability.py` (+3):

- a report on every scan exit path — drafted, empty feed, unclassifiable cards, duplicate, excluded, below-bar, disabled, throttled, dead session, scrape failure
- both beat dispatchers report when throttled, when nobody is enabled, when the cap swallowed the queue, when the queue is stuck behind a disconnected account, and when the queue is empty
- a report on every `send_catchup_touch` exit — sent, failed, both caps (kept distinguishable from each other), throttled, empty body, vanished row
- a telemetry outage never fails a run that otherwise worked
- 13 chrome labels rejected, 4 real drafts preserved, plus the end-to-end fallback to the plain congratulations

`poetry run pytest tests/unit -q` → **8513 passed** locally.

## Remaining on #792

This PR makes the failure **diagnosable** and fixes the message defect on the reporter's exact configuration, but it does **not** close the issue: #792 asks for verification and debugging against the admin account (`user_id=1`), which needs real credentials and a live Selenium session I can't run headless. After this ships, the `catchup_run` series answers it directly — filter `user_id = 1` and read `status` + the funnel counts on `phase = 'scan'` (was anything drafted?) and `phase = 'deliver'` (did anything actually go out, and if not, which gate stopped it?). I've left a comment on #792 with that lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

