### PR TITLE
fix(observability): unblock posthog_provision.py — subscriptions need explicit insight ids

### DIFF
--- a/scripts/posthog_provision.py
+++ b/scripts/posthog_provision.py
@@ -138,6 +138,9 @@ RATE_LIMIT_TRIPS_PER_DAY_CEILING = 5
 # Weekly report cadence: Monday 09:00 UTC, matching the other weekly LEM crons.
 REPORT_WEEKDAY = "monday"
 REPORT_HOUR_UTC = 9
+# PostHog caps a dashboard subscription's export at 6 insights and rejects the whole request past it
+# ("Cannot select more than 6 insights"). LEM Growth carries 7 tiles, so the list is truncated.
+SUBSCRIPTION_MAX_INSIGHTS = 6
 
 
 # ── query-node builders ──────────────────────────────────────────────────────────────
@@ -1046,6 +1049,13 @@ class PostHogClient:
     def create_subscription(self, payload: dict) -> int:
         return self._request("POST", "/subscriptions/", json=payload).get("id")
 
+    def dashboard_insight_ids(self, dashboard_id: int) -> list:
+        """Insight ids currently tiled on a dashboard, in tile order. The dashboard LIST endpoint
+        returns no tiles, so this has to read the detail route."""
+        detail = self._request("GET", f"/dashboards/{dashboard_id}/")
+        ids = [(tile.get("insight") or {}).get("id") for tile in (detail.get("tiles") or [])]
+        return [i for i in ids if i]
+
     def list_insight_variables(self) -> dict:
         """Maps variable name -> {"id", "code_name"}. `code_name` is PostHog-derived (read-only on
         write), so callers always read it back here rather than assuming it matches `name`."""
@@ -1151,7 +1161,19 @@ def apply_actions(client: PostHogClient, actions: list, dry_run: bool = True) ->
             if dry_run:
                 log.append(f"[dry-run] create subscription '{action['subscription']}'")
                 continue
-            subscription_id = client.create_subscription(action["payload"])
+            payload = dict(action["payload"])
+            # PostHog rejects a dashboard subscription that doesn't name its insights explicitly
+            # ("Select at least one insight"), even when the dashboard already has tiles — and caps
+            # the list at SUBSCRIPTION_MAX_INSIGHTS. The ids aren't knowable at plan time (the
+            # insights may be created in this same run), so they're resolved here.
+            if not payload.get("dashboard_export_insights"):
+                insight_ids = client.dashboard_insight_ids(payload["dashboard"])
+                if not insight_ids:
+                    log.append(f"skipped subscription '{action['subscription']}': its dashboard has "
+                               f"no insights yet — re-run once the tiles exist")
+                    continue
+                payload["dashboard_export_insights"] = insight_ids[:SUBSCRIPTION_MAX_INSIGHTS]
+            subscription_id = client.create_subscription(payload)
             log.append(f"created subscription '{action['subscription']}' -> {subscription_id}")
         elif kind == "create_variable":
             if dry_run:
@@ -1281,8 +1303,16 @@ def main(argv: Optional[list] = None) -> int:
     if email:
         subscription_actions = plan_subscriptions([subscription_spec(email)], subscriptions,
                                                   dashboards)
-        for line in apply_actions(client, subscription_actions, dry_run=dry_run):
-            print(line)
+        # The weekly email is the least important thing this script provisions, and it is the LAST
+        # thing before the endpoints pass. Letting it raise meant one PostHog validation change took
+        # the endpoints — and therefore the /user/posthog-stats panels — down with it. Report and
+        # carry on instead.
+        try:
+            for line in apply_actions(client, subscription_actions, dry_run=dry_run):
+                print(line)
+        except Exception as exc:
+            print(f"Could not provision the weekly report subscription ({exc}) — continuing.",
+                  file=sys.stderr)
     else:
         print("No recipient (set POSTHOG_REPORT_EMAIL or --email) — weekly report not provisioned.",
               file=sys.stderr)


### PR DESCRIPTION
## Why

Applying `posthog_provision.py` for the first time against the real project surfaced two defects. Both stopped the script dead **before** it reached the Endpoints pass — which is the thing that actually fixes `PostHog endpoint call failed` (27×/48h, root cause: the `distinct_id` insight variable and the 3 endpoints had never been created).

**1. Subscriptions need their insights named explicitly.** PostHog rejects a dashboard subscription that doesn't list them — *even when the dashboard already has tiles*:

```
{"detail":"Select at least one insight for this subscription.","attr":"dashboard_export_insights"}
```

and then caps the list at six:

```
{"detail":"Cannot select more than 6 insights.","attr":"dashboard_export_insights"}
```

LEM Growth carries 7 tiles. The ids can't be known at plan time (the insights may be created in the same run), so they're resolved at apply time from the dashboard **detail** route — the list route returns no tiles.

**2. An optional weekly email could take the endpoints down with it.** The subscription was the last action before the endpoints pass and was unguarded, so one PostHog validation change aborted the run and left `/user/posthog-stats` broken. It now reports and continues. The least important thing this script provisions should not be able to block the most important.

## Result — applied to prod

| Entity | Before | After |
|---|---|---|
| dashboards | 6 | 14 (adds LEM Health / Growth / Channels) |
| insights | 41 | 73 |
| alerts | **0** | 4 |
| conversion goals | **0** | 2 |
| insight variables | **0** | 1 (`distinct_id`) |
| endpoints | **0** | 3 |
| weekly report subscription | **0** | 1 |

Verified end-to-end — `get_user_stats_panel(1)` in `celery_worker` now returns `available=True` with live rows for all three panels, where every call previously 404'd:

```
posts_engagement       available=True  rows=2
comment_activity       available=True  rows=1
llm_cost_by_feature    available=True  rows=4
```

107 existing provisioner tests pass. Fourth consecutive `--apply` creates nothing new.

## Note

This was unblocked by the owner re-scoping the prod `POSTHOG_PERSONAL_API_KEY` — `insight_variables` was returning 403, which is precisely what kept the endpoints unprovisioned. `users/@me` is still 403 (`user:read`), which only affects auto-resolving the alert subscriber; passing `--email` covers it, and the four alerts were created with a real subscriber.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVoFVsj7fCSLzgoQWSZrBW