### PR TITLE
fix(build): install ca-certificates so posthog-cli can upload source maps

### DIFF
--- a/compose/local/Dockerfile
+++ b/compose/local/Dockerfile
@@ -59,10 +59,20 @@ RUN npm run build
 # Best-effort by construction: no token (dev/local builds) or a failed upload must never fail a
 # release build — it only costs readable stack traces. The .map files are deleted either way, so a
 # build that skips the upload still never serves them.
+#
+# ca-certificates is installed inside the conditional, not in the stage setup, so a build with no
+# token doesn't pay for it. It is REQUIRED: posthog-cli is a Rust binary and node:22-slim carries no
+# system CA store, so its HTTP client panics before it ever authenticates —
+#   panicked ... reqwest::Error { kind: Builder, source: General("No CA certificates were loaded
+#   from the system") }
+# The `|| echo` swallowed that into a one-line "upload failed", which read like a bad token and hid
+# the real cause for an entire release. npm works regardless because it does its own TLS.
 RUN --mount=type=secret,id=posthog_cli_token \
     if [ -s /run/secrets/posthog_cli_token ] && [ -n "$POSTHOG_CLI_ENV_ID" ]; then \
       POSTHOG_CLI_TOKEN="$(cat /run/secrets/posthog_cli_token)"; export POSTHOG_CLI_TOKEN; \
-      ( npm install -g @posthog/cli \
+      ( apt-get update -qq && apt-get install -y -qq --no-install-recommends ca-certificates \
+        && rm -rf /var/lib/apt/lists/* \
+        && npm install -g @posthog/cli \
         && posthog-cli sourcemap inject --directory dist \
         && posthog-cli sourcemap upload --directory dist ) \
         || echo "posthog-cli source-map upload failed — shipping minified stacks"; \


### PR DESCRIPTION
## Why

Source-map upload has never worked (PostHog symbol sets: **0**). With `POSTHOG_CLI_TOKEN` finally set, the v0.113.1 build revealed the cause — and it is **not** the token:

```
thread 'main' panicked at posthog-rs-0.15.1/src/client/blocking.rs:135:
called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Builder,
source: General("No CA certificates were loaded from the system") }
```

`posthog-cli` is a Rust binary and `node:22-slim` carries no system CA store, so its HTTP client panics while being **constructed** — before it ever authenticates. `npm` works in the same stage because it does its own TLS, which is exactly what makes this easy to miss.

The `|| echo "posthog-cli source-map upload failed — shipping minified stacks"` fallback then swallowed a CA panic into a one-line "upload failed", which reads precisely like a bad token. The fallback is still correct — a source-map upload must never fail a release — so instead of removing it, the comment now records the real failure mode so nobody spends another release rotating a perfectly good key.

## The fix

`apt-get install ca-certificates`, placed **inside** the conditional rather than in the stage setup, so a build with no token (dev/local) doesn't pay the apt cost.

## Verified against the real image

```
$ docker run --rm node:22-slim ls /etc/ssl/certs/ca-certificates.crt
  → absent

$ docker run --rm node:22-slim sh -c 'apt-get install -y ca-certificates && ls -la /etc/ssl/certs/ca-certificates.crt'
  → -rw-r--r-- 1 root root 216591 ca-certificates.crt
```

End-to-end, with the fix and a dummy token, the CLI now runs to completion instead of panicking:

```
INFO posthog_cli::sourcemaps::source_pairs: found 0 pairs
INFO posthog_cli::api::symbol_sets: Upload summary: 0 chunk(s) uploaded, 0 skipped
```

(0 chunks because the probe directory had no `.map` files — the point is that client construction no longer panics.)

Expect `error_tracking/symbol_sets` to go above 0 on the next release that rebuilds the SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVoFVsj7fCSLzgoQWSZrBW