### PR TITLE
fix(newsletter): article editor is two screens — stop gating publish on the editor screen (closes #804)

### DIFF
--- a/compose/local/Dockerfile
+++ b/compose/local/Dockerfile
@@ -59,10 +59,20 @@ RUN npm run build
 # Best-effort by construction: no token (dev/local builds) or a failed upload must never fail a
 # release build — it only costs readable stack traces. The .map files are deleted either way, so a
 # build that skips the upload still never serves them.
+#
+# ca-certificates is installed inside the conditional, not in the stage setup, so a build with no
+# token doesn't pay for it. It is REQUIRED: posthog-cli is a Rust binary and node:22-slim carries no
+# system CA store, so its HTTP client panics before it ever authenticates —
+#   panicked ... reqwest::Error { kind: Builder, source: General("No CA certificates were loaded
+#   from the system") }
+# The `|| echo` swallowed that into a one-line "upload failed", which read like a bad token and hid
+# the real cause for an entire release. npm works regardless because it does its own TLS.
 RUN --mount=type=secret,id=posthog_cli_token \
     if [ -s /run/secrets/posthog_cli_token ] && [ -n "$POSTHOG_CLI_ENV_ID" ]; then \
       POSTHOG_CLI_TOKEN="$(cat /run/secrets/posthog_cli_token)"; export POSTHOG_CLI_TOKEN; \
-      ( npm install -g @posthog/cli \
+      ( apt-get update -qq && apt-get install -y -qq --no-install-recommends ca-certificates \
+        && rm -rf /var/lib/apt/lists/* \
+        && npm install -g @posthog/cli \
         && posthog-cli sourcemap inject --directory dist \
         && posthog-cli sourcemap upload --directory dist ) \
         || echo "posthog-cli source-map upload failed — shipping minified stacks"; \

--- a/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
+++ b/docs/LIVE_VALIDATION_FORMAT_AND_STATS.md
@@ -6,6 +6,7 @@
 **Updated:** 2026-07-27 (#645) — §2a settles the member post-stats API lead ·
 **Probe:** `scripts/linkedin_post_stats_api_probe.py` (read-only, no browser)
 **Updated:** 2026-07-27 (#644) — C1's live document-render check ran; §1, §3 and §5 carry the result
+**Updated:** 2026-07-31 (#804) — the article-editor ladder ran live; §3, §4 and §6 carry the result
 
 ## TL;DR
 
@@ -183,6 +184,10 @@ Nothing below is a guess; the provenance column says where each came from.
 | Feed composer trigger | `//button[contains(normalize-space(),'Start a post') or contains(@aria-label,'Start a post') or contains(@aria-label,'Create a post')]` | `auto_post_to_group`, `probe_composer` | in-repo, **best-effort / unvalidated** (F2 #403) |
 | Document upload control | — | — | **unmapped by design** (§1); `--probe-composer` captures it |
 | Document media card | pager buttons `aria-label` = `Go to previous page of document` / `Go to next page of document` (any media node whose `data-testid`/`class`/`aria-label` contains `document` decides the verdict) | `probe_document_render` / `media_verdict` | **live grab 2026-07-27** (#644) — absent on the carousel control |
+| Article **title** | `textarea[placeholder='Title']` (route `title_placeholder`) | `article_editor._TITLE_LOCATORS` | **live grab 2026-07-31** (#804) — resolved on the first route |
+| Article **body** | `div[role='textbox'][aria-label*='Article editor']` — live `aria-label` is exactly `Article editor content` (route `body_aria`) | `article_editor._BODY_LOCATORS` | **live grab 2026-07-31** (#804) — resolved on the first route |
+| Article **Next** | `//button[normalize-space()='Next']`, live element is `<button type="submit">Next</button>` (route `next_text`) | `article_editor._NEXT_LOCATORS` | **live grab 2026-07-31** (#804) — resolved on the first route |
+| Article **Publish** | — **not on the editor screen** | `article_editor._PUBLISH_LOCATORS`, re-resolved *after* Next | **live grab 2026-07-31** (#804) — see §6 |
 
 ## 4. Running the live validation
 
@@ -208,6 +213,16 @@ It emits one JSON report:
 3. **`composer`** *(only with `--probe-composer`)* — the composer's control labels and any
    document-upload affordance among them. It opens the composer and closes it with Escape; nothing is
    attached or posted.
+4. **`article_editor`** *(only with `--article-editor-url`)* — per publish step, the route that
+   resolved and the attributes of the element it resolved to, plus `buttons` (every visible control
+   on that screen) and a one-sentence `verdict`. The probe **never clicks Next**, so only the editor
+   screen is ever rendered and `publish` is graded `UNKNOWN` rather than `MISSING` — read
+   `editor_ready` for "can newsletter publishing start". See §6.
+
+```bash
+sudo docker exec -i celery_worker_selenium python - --user-id 1 --article-editor-url \
+    < scripts/linkedin_live_validation.py
+```
 
 Paste the JSON into #404. If `post_stats` shows a signal sourced from `none` while the analytics page
 plainly shows a number, the `*_lines` arrays contain the drifted layout and this note's §3 rows are
@@ -237,6 +252,57 @@ no `r_member_postAnalytics` claim on it, so **the scrape stays** and the API cut
 analytics-page rows (§3) part of the F2 (#403) selector-liveness sweep — with no API alternative
 available, drift on that page has to be caught by cron rather than by a run of zeroes.
 
+## 6. Article editor — live-validated 2026-07-31 (#804), and the bug it found
+
+`--article-editor-url` ran against the live account (user 1, newsletter enabled, series
+*The Growth Brief*). Result:
+
+| Step | Verdict | Route | Live element |
+|---|---|---|---|
+| `article_title` | **OK** | `title_placeholder` (first route) | `<textarea placeholder="Title">` |
+| `article_body` | **OK** | `body_aria` (first route) | `<div role="textbox" aria-label="Article editor content">` |
+| `article_next` | **OK** | `next_text` (first route) | `<button type="submit">Next</button>` |
+| `article_publish` | **UNKNOWN** | none resolved | *not on this screen* |
+
+Every visible control on `/article/new/` was: `Me`, `For Business`,
+`Christopher Queen / The Growth Brief`, `Style`, `Manage menu`, **`Next`**, `Upload from computer`.
+**No publish-like control among them** — so `article_publish` failing to resolve there is not a
+selector gap. **The editor is two screens**: Publish only exists in the "Ready to publish?" dialog
+that Next opens. Every route in the ladder that could be checked resolved on its *first* route, so
+no selector needed changing.
+
+**The real finding is a defect the probe exposed, not a drifted selector.** `fill_article_editor`
+pre-flighted **all four** steps before typing:
+
+```python
+failed = editor.first_missing()      # included article_publish
+if failed:
+    return None, failed              # aborted before typing a character
+```
+
+Because Publish is never on the editor screen, that gate could **never** pass: every newsletter
+edition publish would have returned `(None, "article_publish")` — the #747 alert firing with a step
+name that names a button which was not supposed to exist yet, and #771's ladder never reached. Fixed
+by scoping the pre-flight to `EDITOR_SCREEN_STEPS` (title, body, next); Publish is still required,
+but at the point it is re-resolved *after* Next, where it actually renders. Caught before the first
+real edition published, so it cost nothing.
+
+Two rules now hold this in place:
+
+- **A step that is not on the current screen is `UNKNOWN`, never `MISSING`.** `StepVerdict.UNKNOWN`
+  existed but nothing ever returned it; `ResolvedElement.expected_on_screen` now does, and the
+  read-only probe sets it for Publish. "We did not look" must not read as "the selector is broken".
+- **`buttons` ships with the verdict.** A claim that a control is on a later screen is only checkable
+  next to the list of controls that *were* on this one — if a future run shows a publish control
+  there, the two-screen assumption has changed and the ladder should gate on it again.
+
+**Still not live-validated:** the publish **dialog** itself — `article_publish`'s two routes and the
+edition-description field (`_fill_edition_description`). Reaching them means clicking Next on a real
+draft, which is one control away from publishing to the live account, so it is deliberately out of
+scope for a read-only probe. It stays what `docs/FORMAT_API_FEASIBILITY.md` §4 already calls it: a
+**supervised** first publish. That first supervised run is what closes it, and `failed_step` now
+names the dialog step honestly if it fails.
+
 ## Sources
 
 - `docs/FORMAT_API_FEASIBILITY.md` (R3 / #406) — API surface for documents, articles, newsletters.
@@ -244,7 +310,8 @@ available, drift on that page has to be caught by cron rather than by a run of z
   — the `memberCreatorPostAnalytics` finders, permission, metric list and error table behind §2a.
 - [Recent Marketing API Changes — Microsoft Learn](https://learn.microsoft.com/en-us/linkedin/marketing/integrations/recent-changes)
   — `202506` added the `q=entity` finder; `202605` changed `metricType` from object to string.
-- In-repo: `utilities/linkedin/poster.py` (document API path), `app/run_automation.py`
+- In-repo: `utilities/linkedin/article_editor.py` (the §6 ladder + the two-screen rule),
+  `utilities/linkedin/poster.py` (document API path), `app/run_automation.py`
   (`_post_social_counts`, `_stacked_counts`, `_post_analytics_counts`, `auto_scrape_post_stats`),
   `utilities/db.py` (`record_post_stats`, `get_latest_post_stats`, `PostType`),
   `api/main.py` (`linkedin_auth_init` — the granted scope list), and

--- a/scripts/linkedin_live_validation.py
+++ b/scripts/linkedin_live_validation.py
@@ -334,11 +334,72 @@ def message_thread_verdict(reading: Optional[dict]) -> str:
     return f"opened via {route}"
 
 
+def element_evidence(element) -> dict:
+    """The attributes that prove WHICH control a route resolved to — the provenance a selector row
+    needs. Every read is best-effort: an element that goes stale mid-capture must not lose the run."""
+    out = {}
+    for key, attr in (("tag", None), ("aria_label", "aria-label"), ("placeholder", "placeholder"),
+                      ("role", "role"), ("type", "type")):
+        try:
+            value = element.tag_name if attr is None else element.get_attribute(attr)
+        except Exception:
+            value = None
+        if value:
+            out[key] = str(value)[:120]
+    try:
+        text = (element.text or "").strip()
+    except Exception:
+        text = ""
+    if text:
+        out["text"] = text[:80]
+    return out
+
+
+def visible_button_labels(driver, limit: int = 40) -> list:
+    """Every visible button's label on the current screen.
+
+    This is the EVIDENCE half of the publish verdict: 'Publish is UNKNOWN' is only believable
+    alongside the list of controls that ARE on the editor screen. If a future run shows a publish
+    control here, the two-screen assumption has changed and the ladder should gate on it again."""
+    labels = []
+    try:
+        for button in driver.find_elements(By.TAG_NAME, "button"):
+            try:
+                if not button.is_displayed():
+                    continue
+                label = (button.get_attribute("aria-label") or button.text or "").strip()
+            except Exception:
+                continue
+            if label and label not in labels:
+                labels.append(label)
+            if len(labels) >= limit:
+                break
+    except Exception as e:
+        labels.append(f"<enumeration stopped: {type(e).__name__}>")
+    return labels
+
+
+def article_editor_reading(verdict: dict) -> str:
+    """One sentence a human can act on, so the JSON does not have to be interpreted."""
+    if not verdict.get("editor_ready"):
+        return (f"editor screen NOT usable — {verdict.get('first_missing')} resolved by no route; "
+                "newsletter publishing cannot start until that step has a working route")
+    publish = (verdict.get("publish") or {}).get("verdict")
+    if publish == "OK":
+        return "editor screen usable, and a publish control is present on it too"
+    return ("editor screen usable (title, body and Next all resolved); publish is UNKNOWN by design "
+            "— it lives in the dialog Next opens and this probe never clicks Next")
+
+
 def probe_article_editor(driver, editor_url: str = "https://www.linkedin.com/article/new/",
                          sleep=time.sleep) -> dict:
-    """#771: open LinkedIn's article editor (read-only) and report which selector routes resolve for
-    each of the four publish steps: title, body, next, publish. The editor is left untouched; nothing
-    is typed or published."""
+    """#771/#804: open LinkedIn's article editor (read-only) and report which selector routes resolve
+    for each publish step: title, body, next, publish. The editor is left untouched; nothing is typed,
+    no control is clicked and nothing is published.
+
+    Because nothing is clicked, only the EDITOR screen is ever rendered — so publish is graded
+    UNKNOWN rather than MISSING (`on_editor_screen=True`). `buttons` records what WAS on the screen,
+    which is what makes that grading checkable rather than assumed."""
     from cqc_lem.utilities.linkedin.article_editor import (find_article_editor_elements,
                                                            article_editor_verdict)
     from selenium.webdriver.support.ui import WebDriverWait
@@ -347,7 +408,15 @@ def probe_article_editor(driver, editor_url: str = "https://www.linkedin.com/art
     driver.get(editor_url)
     sleep(6)
     editor_map = find_article_editor_elements(driver, wait)
-    return article_editor_verdict(editor_map)
+    verdict = article_editor_verdict(editor_map, on_editor_screen=True)
+    for key, resolved in (("title", editor_map.title), ("body", editor_map.body),
+                          ("next", editor_map.next_button), ("publish", editor_map.publish_button)):
+        if resolved.element is not None:
+            verdict[key]["element"] = element_evidence(resolved.element)
+    verdict["url"] = getattr(driver, "current_url", editor_url)
+    verdict["buttons"] = visible_button_labels(driver)
+    verdict["verdict"] = article_editor_reading(verdict)
+    return verdict
 
 
 def probe_message_thread(driver, profile_url: str, person_name: str = "", self_name: str = "",
@@ -418,7 +487,8 @@ def main(argv: Optional[list] = None) -> int:
     parser.add_argument("--article-editor-url", default=None, const="https://www.linkedin.com/article/new/",
                         nargs="?",
                         help="open LinkedIn's article editor and report each publish step's selector "
-                             "state (#771); pass a custom URL or use the default")
+                             "state (#771/#804); pass a custom URL or use the default. Read-only: "
+                             "nothing is typed and no control is clicked, so publish reads UNKNOWN")
     args = parser.parse_args(argv)
 
     if not (args.post_url or args.probe_composer or args.comment_outcome_url or args.dm_thread_url

--- a/src/cqc_lem/utilities/linkedin/article_editor.py
+++ b/src/cqc_lem/utilities/linkedin/article_editor.py
@@ -1,4 +1,4 @@
-"""LinkedIn article editor selector resolution map — issues #406, #747, #771.
+"""LinkedIn article editor selector resolution map — issues #406, #747, #771, #804.
 
 LinkedIn's article editor is a multi-step SDUI flow that rotates the DOM anchors for its
 title field, content body, Next button, and Publish button. This module is the selector ladder
@@ -8,6 +8,15 @@ the TEXT / aria-label / role / placeholder attributes LinkedIn is least likely t
 A step only succeeds when the element is found and is actionable (visible for fields,
 enabled for buttons). The ladder returns the element that won and the route id, so callers
 log a precise `failed_step` and so live validation can report which route resolved today.
+
+**The editor is TWO screens, and that is the whole reason this module grades per screen.**
+`/article/new/` renders the title, the body and Next — and NOT Publish, which only exists in
+the "Ready to publish?" dialog that Next opens. The 2026-07-31 live validation (#804) confirmed
+it: title/body/next resolved, publish resolved by no route at all. So a step that simply is not
+on the current screen is `UNKNOWN`, never `MISSING` — and the pre-flight gate before typing may
+only require `EDITOR_SCREEN_STEPS`. Requiring all four up front made every publish abort before
+it typed a character, reporting `failed_step=article_publish` for a button that was never
+supposed to be there yet.
 
 No class names are keyed on. Use `resolve_article_editor_step(...)` directly, or
 `find_article_editor_elements(driver, wait)` to resolve all four fields/buttons at once.
@@ -31,6 +40,13 @@ STEP_TITLE = "article_title"
 STEP_BODY = "article_body"
 STEP_NEXT = "article_next"
 STEP_PUBLISH = "article_publish"
+
+# Which steps each screen of the flow is allowed to require. Publish is deliberately NOT in
+# EDITOR_SCREEN_STEPS: it renders in the dialog Next opens, so demanding it on the editor screen
+# grades a correct page as broken (and, before #804, aborted the publish flow outright).
+EDITOR_SCREEN_STEPS = (STEP_TITLE, STEP_BODY, STEP_NEXT)
+PUBLISH_SCREEN_STEPS = (STEP_PUBLISH,)
+ALL_STEPS = EDITOR_SCREEN_STEPS + PUBLISH_SCREEN_STEPS
 
 # Stable route ids used in telemetry. "primary" / "secondary" refer to LinkedIn's two action
 # styles for the Next button; "text" means the literal button text.
@@ -135,6 +151,10 @@ class ResolvedElement:
     route: Optional[str] = None
     enabled: bool = True
     tried: list[str] = None
+    # False when this step's control does not belong on the screen that was just read. An absent
+    # control is then UNKNOWN ("nothing to say yet"), not MISSING ("every route failed") — the
+    # difference between a selector that needs fixing and a page that is behaving correctly.
+    expected_on_screen: bool = True
 
     def __post_init__(self):
         if self.tried is None:
@@ -144,10 +164,16 @@ class ResolvedElement:
     def ok(self) -> bool:
         return self.element is not None and self.enabled
 
+    @property
+    def verdict(self) -> StepVerdict:
+        if self.ok:
+            return StepVerdict.OK
+        return StepVerdict.MISSING if self.expected_on_screen else StepVerdict.UNKNOWN
+
     def to_dict(self) -> dict:
         return {
             "step": self.step,
-            "verdict": StepVerdict.OK if self.ok else StepVerdict.MISSING,
+            "verdict": self.verdict,
             "route": self.route,
             "enabled": self.enabled,
             "tried": list(self.tried),
@@ -235,9 +261,18 @@ class ArticleEditorMap:
     next_button: ResolvedElement
     publish_button: ResolvedElement
 
-    def first_missing(self) -> Optional[str]:
-        for resolved in (self.title, self.body, self.next_button, self.publish_button):
-            if not resolved.ok:
+    def steps(self) -> "tuple[ResolvedElement, ...]":
+        return (self.title, self.body, self.next_button, self.publish_button)
+
+    def first_missing(self, steps: "tuple[str, ...] | None" = None) -> Optional[str]:
+        """The first unresolved step, restricted to `steps` when given.
+
+        Callers that are on the editor screen pass `EDITOR_SCREEN_STEPS`; passing nothing keeps
+        the whole-flow view used for reporting.
+        """
+        wanted = steps if steps is not None else ALL_STEPS
+        for resolved in self.steps():
+            if resolved.step in wanted and not resolved.ok:
                 return resolved.step
         return None
 
@@ -269,11 +304,24 @@ def find_article_editor_elements(
     )
 
 
-def article_editor_verdict(editor_map: ArticleEditorMap) -> dict:
-    """Report the reply-state-style verdict used by live validation: OK / MISSING / UNKNOWN."""
+def article_editor_verdict(editor_map: ArticleEditorMap, *,
+                           on_editor_screen: bool = False) -> dict:
+    """Report the reply-state-style verdict used by live validation: OK / MISSING / UNKNOWN.
+
+    `on_editor_screen=True` is what a READ-ONLY probe passes: it has opened `/article/new/` and
+    will not click Next, so the publish dialog was never rendered. Publish is then graded UNKNOWN
+    and excluded from `all_ok`, because "we did not look" is not evidence of a broken selector.
+    The default grades all four, which is the whole-flow view.
+    """
+    if on_editor_screen:
+        editor_map.publish_button.expected_on_screen = False
+    graded = EDITOR_SCREEN_STEPS if on_editor_screen else ALL_STEPS
+    first_missing = editor_map.first_missing(graded)
     out = editor_map.to_dict()
-    out["first_missing"] = editor_map.first_missing()
-    out["all_ok"] = editor_map.first_missing() is None
+    out["first_missing"] = first_missing
+    out["all_ok"] = first_missing is None
+    out["graded_steps"] = list(graded)
+    out["editor_ready"] = editor_map.first_missing(EDITOR_SCREEN_STEPS) is None
     return out
 
 
@@ -324,7 +372,10 @@ def fill_article_editor(
     log_error with `failed_step=...`.
     """
     editor = find_article_editor_elements(driver, wait, user_id=user_id)
-    failed = editor.first_missing()
+    # Only the EDITOR screen's controls gate the start of the flow. Publish is re-resolved after
+    # Next below, where it actually exists — gating on it here aborted every publish before a
+    # character was typed and blamed `article_publish` for it (#804).
+    failed = editor.first_missing(EDITOR_SCREEN_STEPS)
     if failed:
         log_warning("Article editor step missing", step=failed, user_id=user_id,
                     action_type="article_editor", routes=editor.to_dict())
@@ -338,9 +389,11 @@ def fill_article_editor(
     except (WebDriverException, StaleElementReferenceException) as e:
         log_warning("Article editor typing failed", exc=e, user_id=user_id,
                     action_type="article_editor")
-        # Distinguish which field likely failed by re-checking after exception.
+        # Distinguish which field likely failed by re-checking after exception. Still on the editor
+        # screen, so Publish is out of scope here too — reporting it would blame the dialog for a
+        # typing failure that happened two steps earlier.
         editor = find_article_editor_elements(driver, wait, user_id=user_id)
-        return None, editor.first_missing() or STEP_TITLE
+        return None, editor.first_missing(EDITOR_SCREEN_STEPS) or STEP_TITLE
 
     if not _click_safely(driver, editor.next_button.element):
         return None, STEP_NEXT

--- a/tests/unit/utilities/linkedin/test_article_editor.py
+++ b/tests/unit/utilities/linkedin/test_article_editor.py
@@ -16,13 +16,27 @@ from cqc_lem.utilities.linkedin import article_editor as ae
 pytestmark = pytest.mark.unit
 
 
+def _load_probe_module():
+    """Load `scripts/linkedin_live_validation.py` by path — `scripts/` is not an importable package
+    (and is not baked into the runtime image), so the probe is exercised the same way it ships."""
+    import importlib.util
+    from pathlib import Path
+    script_path = Path(__file__).resolve().parents[4] / "scripts" / "linkedin_live_validation.py"
+    spec = importlib.util.spec_from_file_location("linkedin_live_validation", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 class FakeElement:
     """A minimal WebElement stand-in with configurable attributes and display state."""
 
     def __init__(self, tag: str = "button", attrs: dict = None, displayed: bool = True,
-                 interact_ok: bool = True, *, tag_name_exc=None, get_attr_exc: dict = None,
+                 interact_ok: bool = True, *, text: str = "", tag_name_exc=None,
+                 get_attr_exc: dict = None,
                  is_displayed_exc=None, clear_exc=None, click_exc=None, send_keys_exc=None):
         self.tag = tag
+        self.text = text
         self.attrs = attrs or {}
         self._displayed = displayed
         self._interact_ok = interact_ok
@@ -592,6 +606,132 @@ class TestFillArticleEditor:
         assert failed == ae.STEP_PUBLISH
 
 
+class TestTwoScreenGrading:
+    """The editor is two screens (#804, live-validated 2026-07-31).
+
+    `/article/new/` renders title + body + Next and NOT Publish, which only exists in the dialog
+    Next opens. These tests pin the two consequences: an off-screen step is UNKNOWN rather than
+    MISSING, and the pre-flight gate before typing may only require the editor screen's controls.
+    """
+
+    @staticmethod
+    def _editor_screen_driver(publish_present: bool = False):
+        """A DOM shaped like the real editor screen: title, body and Next, no publish control."""
+        title = FakeElement(tag="textarea", attrs={"placeholder": "Title"})
+        body = FakeElement(tag="div", attrs={"role": "textbox", "aria-label": "Article editor content"})
+        nxt = FakeElement(tag="button", attrs={"type": "submit"})
+        dom = {
+            (By.CSS_SELECTOR, "textarea[placeholder='Title']"): [title],
+            (By.CSS_SELECTOR, "div[role='textbox'][aria-label*='Article editor']"): [body],
+            (By.XPATH, "//button[normalize-space()='Next']"): [nxt],
+        }
+        if publish_present:
+            dom[(By.XPATH, "//button[normalize-space()='Publish']")] = [
+                FakeElement(tag="button")]
+        return FakeDriver(dom)
+
+    @staticmethod
+    def _ordered_find_first(driver):
+        def fake_find_first(d, w, locators, *args, **kwargs):
+            for by, value in locators:
+                matches = driver.find_elements(by, value)
+                if matches:
+                    return matches[0]
+            return None
+        return fake_find_first
+
+    def test_first_missing_ignores_publish_when_scoped_to_editor_screen(self, monkeypatch):
+        driver = self._editor_screen_driver()
+        monkeypatch.setattr(ae, "find_first", self._ordered_find_first(driver))
+        editor_map = ae.find_article_editor_elements(driver, MagicMock())
+        assert editor_map.first_missing() == ae.STEP_PUBLISH
+        assert editor_map.first_missing(ae.EDITOR_SCREEN_STEPS) is None
+
+    def test_editor_screen_verdict_grades_publish_unknown_not_missing(self, monkeypatch):
+        driver = self._editor_screen_driver()
+        monkeypatch.setattr(ae, "find_first", self._ordered_find_first(driver))
+        verdict = ae.article_editor_verdict(
+            ae.find_article_editor_elements(driver, MagicMock()), on_editor_screen=True)
+        assert verdict["publish"]["verdict"] == ae.StepVerdict.UNKNOWN
+        assert verdict["all_ok"] is True
+        assert verdict["editor_ready"] is True
+        assert verdict["first_missing"] is None
+        assert verdict["graded_steps"] == list(ae.EDITOR_SCREEN_STEPS)
+
+    def test_whole_flow_verdict_still_grades_absent_publish_missing(self, monkeypatch):
+        """The default (not on the editor screen) is unchanged: absent publish is a real miss."""
+        driver = self._editor_screen_driver()
+        monkeypatch.setattr(ae, "find_first", self._ordered_find_first(driver))
+        verdict = ae.article_editor_verdict(ae.find_article_editor_elements(driver, MagicMock()))
+        assert verdict["publish"]["verdict"] == ae.StepVerdict.MISSING
+        assert verdict["all_ok"] is False
+        assert verdict["first_missing"] == ae.STEP_PUBLISH
+        assert verdict["editor_ready"] is True
+
+    def test_editor_screen_verdict_reports_a_broken_editor_step(self, monkeypatch):
+        """A missing BODY is a real selector gap and must survive the screen-aware grading."""
+        driver = self._editor_screen_driver()
+        driver.dom[(By.CSS_SELECTOR, "div[role='textbox'][aria-label*='Article editor']")] = []
+        monkeypatch.setattr(ae, "find_first", self._ordered_find_first(driver))
+        verdict = ae.article_editor_verdict(
+            ae.find_article_editor_elements(driver, MagicMock()), on_editor_screen=True)
+        assert verdict["first_missing"] == ae.STEP_BODY
+        assert verdict["all_ok"] is False
+        assert verdict["editor_ready"] is False
+
+    def test_publish_present_on_editor_screen_reads_ok(self, monkeypatch):
+        """If LinkedIn ever puts Publish on the first screen, the probe says OK, not UNKNOWN."""
+        driver = self._editor_screen_driver(publish_present=True)
+        monkeypatch.setattr(ae, "find_first", self._ordered_find_first(driver))
+        verdict = ae.article_editor_verdict(
+            ae.find_article_editor_elements(driver, MagicMock()), on_editor_screen=True)
+        assert verdict["publish"]["verdict"] == ae.StepVerdict.OK
+
+    def test_resolved_element_verdict_is_three_valued(self):
+        found = ae.ResolvedElement(step=ae.STEP_NEXT, element=FakeElement(), route=ae.ROUTE_NEXT_TEXT)
+        assert found.verdict == ae.StepVerdict.OK
+        absent = ae.ResolvedElement(step=ae.STEP_PUBLISH)
+        assert absent.verdict == ae.StepVerdict.MISSING
+        off_screen = ae.ResolvedElement(step=ae.STEP_PUBLISH, expected_on_screen=False)
+        assert off_screen.verdict == ae.StepVerdict.UNKNOWN
+        assert off_screen.to_dict()["verdict"] == ae.StepVerdict.UNKNOWN
+
+    def test_fill_proceeds_when_publish_only_appears_after_next(self, monkeypatch):
+        """The #804 regression: the pre-flight used to demand Publish on the editor screen, so the
+        flow returned `article_publish` without typing a character. It must now type, click Next,
+        and only then require Publish."""
+        title = FakeElement(tag="textarea", attrs={"placeholder": "Title"})
+        body = FakeElement(tag="div", attrs={"role": "textbox", "aria-label": "Article editor content"})
+        nxt = FakeElement(tag="button", attrs={"type": "submit"})
+        publish = FakeElement(tag="button")
+        driver = self._editor_screen_driver()
+        driver.dom[(By.CSS_SELECTOR, "textarea[placeholder='Title']")] = [title]
+        driver.dom[(By.CSS_SELECTOR, "div[role='textbox'][aria-label*='Article editor']")] = [body]
+        driver.dom[(By.XPATH, "//button[normalize-space()='Next']")] = [nxt]
+        monkeypatch.setattr(ae.time, "sleep", lambda s: None)
+
+        def fake_find_first(d, w, locators, *args, **kwargs):
+            for by, value in locators:
+                # Publish only exists once Next has been clicked — exactly like the live editor.
+                if "Publish" in value and not nxt.clicked:
+                    continue
+                if "Publish" in value:
+                    return publish
+                matches = driver.find_elements(by, value)
+                if matches:
+                    return matches[0]
+            return None
+
+        monkeypatch.setattr(ae, "find_first", fake_find_first)
+        url, failed = ae.fill_article_editor(driver, MagicMock(), "My title", "My body", user_id=1)
+        assert failed is None
+        assert url == driver.current_url
+        assert title.sent == ["My title"]
+        assert body.sent == ["My body"]
+        assert nxt.clicked == 1
+        assert publish.clicked == 1
+
+
 class TestLiveValidationProbe:
     def test_probe_article_editor_reports_editor_verdict(self, monkeypatch):
         title = FakeElement(tag="textarea", attrs={"placeholder": "Title"})
@@ -605,12 +745,7 @@ class TestLiveValidationProbe:
             (By.CSS_SELECTOR, "button[aria-label*='Publish']"): [publish],
         })
 
-        import importlib.util
-        from pathlib import Path
-        script_path = Path(__file__).resolve().parents[4] / "scripts" / "linkedin_live_validation.py"
-        spec = importlib.util.spec_from_file_location("linkedin_live_validation", script_path)
-        llv = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(llv)
+        llv = _load_probe_module()
 
         def fake_find_first(d, w, locators, *args, **kwargs):
             for by, value in locators:
@@ -624,3 +759,97 @@ class TestLiveValidationProbe:
                                           sleep=lambda s: None)
         assert report["all_ok"] is True
         assert report["first_missing"] is None
+
+    def test_probe_grades_absent_publish_unknown_and_records_the_screen(self, monkeypatch):
+        """The live 2026-07-31 shape: title/body/next resolve, no publish control on the screen.
+
+        The probe never clicks Next, so publish must read UNKNOWN and must not drag `all_ok` down —
+        and the buttons it DID see are what make that grading checkable."""
+        llv = _load_probe_module()
+        title = FakeElement(tag="textarea", attrs={"placeholder": "Title"})
+        body = FakeElement(tag="div", attrs={"role": "textbox",
+                                             "aria-label": "Article editor content"})
+        nxt = FakeElement(tag="button", attrs={"type": "submit"}, text="Next")
+        driver = FakeDriver({
+            (By.CSS_SELECTOR, "textarea[placeholder='Title']"): [title],
+            (By.CSS_SELECTOR, "div[role='textbox'][aria-label*='Article editor']"): [body],
+            (By.XPATH, "//button[normalize-space()='Next']"): [nxt],
+            (By.TAG_NAME, "button"): [nxt],
+        })
+
+        def fake_find_first(d, w, locators, *args, **kwargs):
+            for by, value in locators:
+                matches = driver.find_elements(by, value)
+                if matches:
+                    return matches[0]
+            return None
+
+        monkeypatch.setattr(ae, "find_first", fake_find_first)
+        report = llv.probe_article_editor(driver, "https://www.linkedin.com/article/new/",
+                                          sleep=lambda s: None)
+        assert report["publish"]["verdict"] == ae.StepVerdict.UNKNOWN
+        assert report["all_ok"] is True
+        assert report["editor_ready"] is True
+        assert report["first_missing"] is None
+        assert report["title"]["element"]["placeholder"] == "Title"
+        assert report["body"]["element"]["aria_label"] == "Article editor content"
+        assert "Next" in report["buttons"]
+        assert "publish is UNKNOWN by design" in report["verdict"]
+
+    def test_probe_reports_a_broken_editor_step_as_not_ready(self, monkeypatch):
+        llv = _load_probe_module()
+        driver = FakeDriver({(By.TAG_NAME, "button"): []})
+        monkeypatch.setattr(ae, "find_first", lambda *a, **k: None)
+        report = llv.probe_article_editor(driver, "https://www.linkedin.com/article/new/",
+                                          sleep=lambda s: None)
+        assert report["editor_ready"] is False
+        assert report["first_missing"] == ae.STEP_TITLE
+        assert "NOT usable" in report["verdict"]
+
+    def test_probe_reading_calls_out_a_publish_control_on_the_editor_screen(self):
+        llv = _load_probe_module()
+        reading = llv.article_editor_reading(
+            {"editor_ready": True, "publish": {"verdict": "OK"}})
+        assert "publish control is present" in reading
+
+
+class TestProbeEvidenceHelpers:
+    def test_visible_button_labels_dedupes_and_skips_hidden(self):
+        llv = _load_probe_module()
+        shown = FakeElement(tag="button", attrs={"aria-label": "Next"})
+        dupe = FakeElement(tag="button", attrs={"aria-label": "Next"})
+        hidden = FakeElement(tag="button", attrs={"aria-label": "Publish"}, displayed=False)
+        unlabelled = FakeElement(tag="button")
+        driver = FakeDriver({(By.TAG_NAME, "button"): [shown, dupe, hidden, unlabelled]})
+        assert llv.visible_button_labels(driver) == ["Next"]
+
+    def test_visible_button_labels_honours_the_limit(self):
+        llv = _load_probe_module()
+        buttons = [FakeElement(tag="button", attrs={"aria-label": f"b{i}"}) for i in range(10)]
+        driver = FakeDriver({(By.TAG_NAME, "button"): buttons})
+        assert len(llv.visible_button_labels(driver, limit=3)) == 3
+
+    def test_visible_button_labels_reports_a_stopped_enumeration(self):
+        llv = _load_probe_module()
+
+        class Exploding(FakeDriver):
+            def find_elements(self, by, value):
+                raise WebDriverException("boom")
+
+        labels = llv.visible_button_labels(Exploding())
+        assert labels and labels[0].startswith("<enumeration stopped")
+
+    def test_element_evidence_is_best_effort(self):
+        llv = _load_probe_module()
+        el = FakeElement(tag="textarea", attrs={"placeholder": "Title"},
+                         get_attr_exc={"aria-label": WebDriverException("boom")})
+        evidence = llv.element_evidence(el)
+        assert evidence["tag"] == "textarea"
+        assert evidence["placeholder"] == "Title"
+        assert "aria_label" not in evidence
+
+    def test_element_evidence_survives_a_dead_element(self):
+        llv = _load_probe_module()
+        el = FakeElement(tag_name_exc=StaleElementReferenceException("stale"),
+                         get_attr_exc={"aria-label": StaleElementReferenceException("stale")})
+        assert llv.element_evidence(el) == {}


### PR DESCRIPTION
Closes #804. Refs #406, #747, #771.

Option **1A** from the Decision Comment: run the live probe, paste the verdict, add the resolving routes + unit tests.

## The live run

Ran on the prod VPS from a Selenium worker with user 1's real session (cookies + residential proxy, 429 breaker clear). **Read-only** — nothing typed, no control clicked, nothing published.

| Step | Verdict | Route | Live element |
|---|---|---|---|
| `article_title` | **OK** | `title_placeholder` (1st route) | `<textarea placeholder="Title">` |
| `article_body` | **OK** | `body_aria` (1st route) | `<div role="textbox" aria-label="Article editor content">` |
| `article_next` | **OK** | `next_text` (1st route) | `<button type="submit">Next</button>` |
| `article_publish` | **UNKNOWN** | none resolved | *not on this screen* |

Every checkable route resolved on its **first** route, so **no selector needed changing** — the #771 ladder is correctly grounded. Full JSON on the issue.

Every visible control on `/article/new/`: `Me`, `For Business`, `Christopher Queen / The Growth Brief`, `Style`, `Manage menu`, **`Next`**, `Upload from computer`. No publish-like control among them. **The editor is two screens** — Publish only exists in the "Ready to publish?" dialog Next opens.

## What the run actually found: a defect in the gate

`fill_article_editor` pre-flighted **all four** steps before typing:

```python
failed = editor.first_missing()      # included article_publish
if failed:
    return None, failed              # aborted before typing a character
```

Publish is never on the editor screen, so **that gate could never pass**. Every newsletter edition publish would have returned `(None, "article_publish")` — #747's alert firing with a step name for a button that was not supposed to be there yet, and #771's ladder never reached. User 1 has newsletter publishing enabled with a live series, so the next scheduled edition would have hit it. Caught before the first real edition published.

## Changes

- **`article_editor.py`** — pre-flight (and the typing-failure re-check) scoped to `EDITOR_SCREEN_STEPS`; Publish is still required, at the point it is re-resolved *after* Next. `first_missing(steps=…)` takes the screen scope.
- **`ResolvedElement.expected_on_screen`** — a step absent from the current screen is **`UNKNOWN`, never `MISSING`**. `StepVerdict.UNKNOWN` was defined but nothing ever returned it; "we did not look" must not read as "the selector is broken".
- **`article_editor_verdict(..., on_editor_screen=True)`** — what a read-only probe passes. Adds `editor_ready` ("can publishing start") and `graded_steps`. Default is unchanged (whole-flow view), so existing callers keep their semantics.
- **`linkedin_live_validation.py`** — the probe ships `buttons` (every visible control) beside the verdict, so the two-screen claim is **checkable rather than assumed**, plus each winning element's attributes as selector provenance and a one-sentence `verdict`.
- **`docs/LIVE_VALIDATION_FORMAT_AND_STATS.md`** — §3 selector rows with live provenance, §4 the run command, new §6 with the result and the defect.

## Testing

- `tests/unit/utilities/linkedin/test_article_editor.py`: **45 pass** (was 30). New `TestTwoScreenGrading` covers screen-scoped `first_missing`, the three-valued verdict, the editor-screen vs whole-flow grading, a genuinely broken editor step still failing, publish reading OK if LinkedIn ever moves it to screen 1, and the **#804 regression** — the flow now types, clicks Next, and only then requires Publish.
- `TestProbeEvidenceHelpers` covers the probe's evidence capture (dedup, hidden skip, limit, stale elements).
- `article_editor.py` at **100%** line coverage.
- `tests/unit/test_linkedin_live_validation.py` (28) and `tests/unit/app/test_newsletter_publish.py` + `test_newsletter_catchup.py` (44) all pass — 109 green across the affected suites.

## Not validated, deliberately

The **publish dialog** — `article_publish`'s two routes and `_fill_edition_description`. Reaching it means clicking Next on a real draft, one control away from publishing to the live account. It stays a **supervised first publish** per `docs/FORMAT_API_FEASIBILITY.md` §4; `failed_step` now names the dialog step honestly if it fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UVoFVsj7fCSLzgoQWSZrBW
