### PR TITLE
fix(dms): separate an unapproved Catch-up backlog from an empty queue (refs #792)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -5751,6 +5751,7 @@ CATCHUP_STATUS_DISPATCHED = "dispatched"
 CATCHUP_STATUS_NOTHING_TO_SEND = "nothing_to_send"
 CATCHUP_STATUS_CAPPED = "capped"                    # approved touches exist, today's cap is spent
 CATCHUP_STATUS_INACTIVE = "inactive_users"          # queue exists but its owners aren't connected
+CATCHUP_STATUS_AWAITING_APPROVAL = "awaiting_approval"  # drafts exist, none approved yet
 # Terminal (deliver) outcomes. `dispatched` is NOT delivery: a touch the DM cap or the breaker defers
 # goes back to 'approved' and the drip re-dispatches it on the next beat, so a lane that never sends
 # anything reads as a healthy rising `dispatched` count unless the send itself reports.
@@ -6105,7 +6106,8 @@ def _draft_catchup_message(user_id: int, moment: dict, my_profile: LinkedInProfi
 # carries them, and that's the series a "catch-up never sends" report has to be answered from.
 _CATCHUP_QUIET_STATUSES = frozenset({CATCHUP_STATUS_NOTHING_TO_SEND, CATCHUP_STATUS_CAPPED,
                                      CATCHUP_STATUS_THROTTLED, CATCHUP_STATUS_DISABLED,
-                                     CATCHUP_STATUS_DM_CAPPED, CATCHUP_STATUS_NOT_SENDABLE})
+                                     CATCHUP_STATUS_DM_CAPPED, CATCHUP_STATUS_NOT_SENDABLE,
+                                     CATCHUP_STATUS_AWAITING_APPROVAL})
 
 
 def report_catchup_run(user_id: Optional[int], report: dict, task_name: str) -> None:
@@ -6114,8 +6116,8 @@ def report_catchup_run(user_id: Optional[int], report: dict, task_name: str) -> 
     otherwise worked."""
     summary = ", ".join(f"{k}={report[k]}" for k in
                         ("moments", "classified", "enabled_type", "excluded", "duplicate",
-                         "below_bar", "drafted", "dispatched", "capped", "inactive", "requeued",
-                         "touch_id")
+                         "below_bar", "drafted", "dispatched", "capped", "inactive", "pending",
+                         "requeued", "touch_id")
                         if k in report)
     status = report.get("status")
     emit = log_debug if status in _CATCHUP_QUIET_STATUSES else log_info

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -14,7 +14,7 @@ from cqc_lem.app.run_automation import automate_commenting, automate_profile_vie
     sweep_reply_comments, sweep_comment_followups, sweep_comment_outcomes, send_catchup_touch, \
     report_catchup_run, CATCHUP_PHASE_SCAN, CATCHUP_PHASE_SEND, CATCHUP_STATUS_THROTTLED, \
     CATCHUP_STATUS_DISABLED, CATCHUP_STATUS_DISPATCHED, CATCHUP_STATUS_CAPPED, \
-    CATCHUP_STATUS_NOTHING_TO_SEND, CATCHUP_STATUS_INACTIVE
+    CATCHUP_STATUS_NOTHING_TO_SEND, CATCHUP_STATUS_INACTIVE, CATCHUP_STATUS_AWAITING_APPROVAL
 from cqc_lem.utilities.db import (
     get_ready_to_post_posts, get_orphaned_scheduled_posts, update_db_post_status,
     get_active_user_ids, PostStatus, has_linkedin_session, get_company_linked_in_url_for_user,
@@ -24,7 +24,8 @@ from cqc_lem.utilities.db import (
     update_connection_request_status, ConnectionRequestStatus, count_invites_sent_today,
     get_users_with_reply_mode, get_engagement_preferences,
     get_approved_catchup_touches, get_orphaned_catchup_touches, update_catchup_touch_status,
-    count_catchup_touches_sent_today, CatchupTouchStatus, max_catchup_touches_allowed,
+    count_catchup_touches_sent_today, count_pending_catchup_touches, CatchupTouchStatus,
+    max_catchup_touches_allowed,
     get_user_timezone,
 )
 from cqc_lem.utilities.engagement_window import (
@@ -1333,17 +1334,24 @@ def auto_check_catchup_touches():
         update_catchup_touch_status(touch_id, CatchupTouchStatus.SENDING)
         send_catchup_touch.apply_async(kwargs={'touch_id': touch_id})
 
+    # The drafted-but-unapproved backlog, counted on EVERY beat (issue #792). The scan reports its
+    # `drafted` count once a day; for the other 23 hours a full approval queue and an empty lane both
+    # looked like `nothing_to_send` — which is the reported symptom ("not sending, not in any queue").
+    pending = count_pending_catchup_touches()
+
     if dispatched or orphaned:
         status = CATCHUP_STATUS_DISPATCHED
     elif capped:
         status = CATCHUP_STATUS_CAPPED
     elif inactive:
         status = CATCHUP_STATUS_INACTIVE  # a queue that exists but whose owners can't be sent for
+    elif pending:
+        status = CATCHUP_STATUS_AWAITING_APPROVAL  # working as designed — the user has to approve
     else:
         status = CATCHUP_STATUS_NOTHING_TO_SEND
     report_catchup_run(None, {"phase": CATCHUP_PHASE_SEND, "status": status,
                               "dispatched": dispatched, "capped": capped, "inactive": inactive,
-                              "requeued": len(orphaned)}, task_name)
+                              "pending": pending, "requeued": len(orphaned)}, task_name)
     if dispatched == 0 and len(orphaned) == 0:
         return "No Catch-up Touches to Send"
     return f"Dispatched {dispatched} catch-up touch(es); re-queued {len(orphaned)} orphaned"

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -4915,7 +4915,9 @@ def count_pending_catchup_touches() -> int:
         r = cursor.fetchone()
         return int(r[0]) if r else 0
     except mysql.connector.Error as err:
-        myprint(f"Could not count pending catchup touches | Error: {err}")
+        # ERROR, not myprint (which logs at INFO): a failed count returns 0, which reads on the beat
+        # as `nothing_to_send` — the exact silence issue #792 exists to remove. It has to be visible.
+        log_error("Could not count pending catchup touches", exc=err)
         return 0
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -4904,6 +4904,24 @@ def get_approved_catchup_touches() -> list:
         connection.close()
 
 
+def count_pending_catchup_touches() -> int:
+    """Drafted touches still waiting on human approval, fleet-wide. The send drip reports this so a
+    queue that exists but was never approved cannot read as an empty one (issue #792) — the drafts
+    land 'pending' unless the user opted into catchup_touch_mode='auto_approve'."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("SELECT COUNT(*) FROM catchup_touches WHERE status = 'pending'")
+        r = cursor.fetchone()
+        return int(r[0]) if r else 0
+    except mysql.connector.Error as err:
+        myprint(f"Could not count pending catchup touches | Error: {err}")
+        return 0
+    finally:
+        cursor.close()
+        connection.close()
+
+
 def get_orphaned_catchup_touches(lookback_hours: int = 2) -> list:
     """Touches stuck in 'sending' whose send task was lost (e.g. Celery queue purged on restart).
     Mirrors get_orphaned_connection_requests. Returns (id, user_id) tuples."""

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -935,6 +935,7 @@ def track_catchup_run(user_id: Optional[int], report: Optional[dict] = None, **e
             "dispatched": int(report.get("dispatched") or 0),
             "capped": int(report.get("capped") or 0),
             "inactive": int(report.get("inactive") or 0),
+            "pending": int(report.get("pending") or 0),
             "requeued": int(report.get("requeued") or 0),
             "touch_id": report.get("touch_id"),
             **extra,

--- a/tests/unit/app/test_catchup_touches.py
+++ b/tests/unit/app/test_catchup_touches.py
@@ -12,6 +12,14 @@ _RA = "cqc_lem.app.run_automation"
 _RS = "cqc_lem.app.run_scheduler"
 
 
+@pytest.fixture(autouse=True)
+def _no_pending_backlog():
+    """The send drip counts the drafted-but-unapproved backlog on every beat (issue #792). Default it
+    to an empty queue so only the tests that care about it have to say so."""
+    with patch(f"{_RS}.count_pending_catchup_touches", return_value=0):
+        yield
+
+
 def _prefs(**kw):
     base = {"max_comments_per_day": 50, "max_dms_per_day": 20, "max_catchup_touches_per_day": 5,
             "catchup_touch_mode": "pre_review", "catchup_message_source": "linkedin",
@@ -1005,6 +1013,77 @@ class TestCatchupRunReport:
              patch(f"{_RA}.track_catchup_run") as track:
             auto_check_catchup_touches()
         assert track.call_args.args[1]["status"] == "nothing_to_send"
+        assert track.call_args.args[1]["pending"] == 0
+
+    def test_send_drip_separates_an_unapproved_backlog_from_an_empty_queue(self):
+        """The reported symptom: drafts exist, none were approved, so nothing ever sends. The scan
+        reports its `drafted` count once a day — for the other 23 hours this beat is the only
+        evidence, and it read `nothing_to_send` exactly like a lane that had drafted nothing."""
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.count_pending_catchup_touches", return_value=6), \
+             patch(f"{_RS}.send_catchup_touch") as task, \
+             patch(f"{_RA}.track_catchup_run") as track:
+            out = auto_check_catchup_touches()
+        report = track.call_args.args[1]
+        assert report["status"] == "awaiting_approval"
+        assert report["pending"] == 6
+        assert report["dispatched"] == 0
+        task.apply_async.assert_not_called()
+        assert out == "No Catch-up Touches to Send"
+
+    def test_a_dispatching_beat_still_reports_the_backlog_behind_it(self):
+        """`pending` rides on every beat, not just the idle ones — a lane sending its cap while a
+        backlog piles up unapproved is a different story from one that has cleared its queue."""
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_catchup_touches", return_value=[(1, 7)]), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
+             patch(f"{_RS}.get_engagement_preferences", return_value=_prefs()), \
+             patch(f"{_RS}.max_catchup_touches_allowed", return_value=5), \
+             patch(f"{_RS}.count_catchup_touches_sent_today", return_value=0), \
+             patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.count_pending_catchup_touches", return_value=4), \
+             patch(f"{_RS}.update_catchup_touch_status"), \
+             patch(f"{_RS}.send_catchup_touch"), \
+             patch(f"{_RA}.track_catchup_run") as track:
+            auto_check_catchup_touches()
+        report = track.call_args.args[1]
+        assert report["status"] == "dispatched"
+        assert report["pending"] == 4
+
+    def test_an_unapproved_backlog_never_outranks_a_real_send_blocker(self):
+        """Precedence check: a cap that is spent is the actionable reading, not the drafts behind it."""
+        from cqc_lem.app.run_scheduler import auto_check_catchup_touches
+        with patch(f"{_RS}._skip_if_throttled", return_value=False), \
+             patch(f"{_RS}.get_approved_catchup_touches", return_value=[(1, 7)]), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[7]), \
+             patch(f"{_RS}.get_engagement_preferences", return_value=_prefs()), \
+             patch(f"{_RS}.max_catchup_touches_allowed", return_value=5), \
+             patch(f"{_RS}.count_catchup_touches_sent_today", return_value=5), \
+             patch(f"{_RS}.get_orphaned_catchup_touches", return_value=[]), \
+             patch(f"{_RS}.count_pending_catchup_touches", return_value=3), \
+             patch(f"{_RS}.update_catchup_touch_status"), \
+             patch(f"{_RS}.send_catchup_touch"), \
+             patch(f"{_RA}.track_catchup_run") as track:
+            auto_check_catchup_touches()
+        report = track.call_args.args[1]
+        assert report["status"] == "capped"
+        assert report["pending"] == 3
+
+    def test_an_unapproved_backlog_stays_debug_not_a_repeating_warning(self):
+        """This beats 72x a day. A steady, working state must not log at INFO/WARNING — the
+        recurrence escalation would re-emit it at ERROR and file a grouped $exception."""
+        from cqc_lem.app.run_automation import report_catchup_run
+        with patch(f"{_RA}.track_catchup_run"), \
+             patch(f"{_RA}.log_debug") as dbg, patch(f"{_RA}.log_info") as info:
+            report_catchup_run(None, {"phase": "send", "status": "awaiting_approval", "pending": 6},
+                               "auto_check_catchup_touches")
+        info.assert_not_called()
+        dbg.assert_called_once()
+        assert "pending=6" in dbg.call_args.args[0]
 
     def test_send_drip_reports_a_queue_stuck_behind_a_disconnected_account(self):
         """Approved touches whose owner isn't connected used to be counted nowhere, so the report

--- a/tests/unit/utilities/test_db_catchup_touches.py
+++ b/tests/unit/utilities/test_db_catchup_touches.py
@@ -128,6 +128,35 @@ class TestCatchupTouchDb:
             from cqc_lem.utilities.db import get_approved_catchup_touches
             assert get_approved_catchup_touches() == []
 
+    def test_count_pending_backlog(self):
+        """The send drip reads this on every beat (issue #792) — it is what separates a queue sitting
+        behind approval from an empty lane, so it must count 'pending' and nothing else."""
+        conn, cur = _conn(fetch_row=(6,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_pending_catchup_touches
+            assert count_pending_catchup_touches() == 6
+        sql = cur.execute.call_args[0][0]
+        assert "status = 'pending'" in sql and "COUNT(*)" in sql
+
+    def test_count_pending_backlog_no_row_returns_zero(self):
+        conn, _ = _conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_pending_catchup_touches
+            assert count_pending_catchup_touches() == 0
+
+    def test_count_pending_backlog_error_returns_zero(self):
+        """A DB error must read as 'no backlog', not blow up the beat — the drip still has approved
+        touches to dispatch and the report is diagnostic, not load-bearing. But 0 makes the beat
+        report `nothing_to_send`, so the failure itself has to surface at ERROR, not at INFO."""
+        import mysql.connector
+        conn, cur = _conn()
+        cur.execute.side_effect = mysql.connector.Error(msg="boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.log_error") as err:
+            from cqc_lem.utilities.db import count_pending_catchup_touches
+            assert count_pending_catchup_touches() == 0
+        err.assert_called_once()
+
     def test_orphaned_touches_use_lookback(self):
         conn, cur = _conn(fetchall=[(9, 1)])
         with patch(f"{_DB}.get_db_connection", return_value=conn):

--- a/tests/unit/utilities/test_observability.py
+++ b/tests/unit/utilities/test_observability.py
@@ -1089,6 +1089,17 @@ class TestTrackCatchupRun:
         assert kwargs["properties"]["capped"] == 3
         assert kwargs["properties"]["dispatched"] == 0  # absent counts read 0, never missing
 
+    def test_the_unapproved_backlog_reaches_the_event(self):
+        """The property dict is an explicit whitelist — a counter the send beat reports but this
+        never lists is dropped silently, which is how a lane looks quiet while a queue piles up."""
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            from cqc_lem.utilities.observability import track_catchup_run
+            track_catchup_run(None, {"phase": "send", "status": "awaiting_approval", "pending": 6})
+
+        props = mock_ph.capture.call_args.kwargs["properties"]
+        assert props["status"] == "awaiting_approval"
+        assert props["pending"] == 6
+
     def test_an_empty_report_still_emits(self):
         with patch(f"{_MOD}.posthog") as mock_ph:
             from cqc_lem.utilities.observability import track_catchup_run


### PR DESCRIPTION
Follow-on to #825. **Does not close #792** — see *Remaining* below.

## Why

#825 made every catch-up run reportable. Reading the live telemetry it produced surfaced the next gap, on the exact symptom the user reported.

The scan phase reports its `drafted` count **once a day** (`crontab(hour='12', minute='30')`). The send drip beats every 20 minutes. For the other ~23 hours of the day, the send report was the only evidence the lane emitted — and it returned `nothing_to_send` whether the queue was genuinely empty **or** full of drafts sitting `pending` behind approval (`catchup_touch_mode` defaults to `pre_review`, so that is the default state, not an edge case).

Those are the same silence, and one of them is "not sending any messages, not logging them, not appearing in any queue" — the report verbatim.

## What changed

- `db.count_pending_catchup_touches()` — fleet-wide count of drafted-but-unapproved touches.
- `auto_check_catchup_touches` counts it on **every** beat and reports `pending`, with a new `awaiting_approval` status when a backlog exists and nothing is approved. Precedence keeps the actionable blockers ahead of it: `dispatched > capped > inactive_users > awaiting_approval > nothing_to_send`.
- `pending` rides on every send report, not just idle ones — a lane sending its cap while drafts pile up unapproved is a different story from one that has cleared its queue.
- `awaiting_approval` is a **quiet** status (`_CATCHUP_QUIET_STATUSES`): this beats 72x/day and it is a working state, so it logs DEBUG. A repeated warning would re-emit at ERROR and file a grouped `$exception` for correct behaviour.
- Second commit: `track_catchup_run` builds its properties from an explicit whitelist, so `pending` was reaching the local log line but being dropped before PostHog. Now listed.

## Live verification done so far

Prod is on **v0.113.2**, which contains #825, and `catchup_run` is emitting (3 events in the hour before this PR). Every send-phase event reads `status='nothing_to_send'`, `dispatched=0`, `inactive=0` — so **zero approved touches exist**. That is the reading this PR makes interpretable: after it ships, the same beat says whether a `pending` queue is sitting behind approval or the lane truly has nothing.

## Remaining on #792

The scan phase has not run since v0.113.2 deployed (~20:51 UTC) — the next one is **12:30 UTC 2026-08-01**. The `user_id=1` diagnosis needs that event: filter `catchup_run` on `phase='scan'` and read `status` against the lookup table in the issue comments. No credentials needed for the read; the issue stays open until it is done.

## Testing

- `tests/unit/app/test_catchup_touches.py` — backlog vs empty queue, `pending` on a dispatching beat, precedence vs `capped`, and the DEBUG-not-INFO log level.
- `tests/unit/utilities/test_observability.py` — `pending` survives the property whitelist.
- Full unit suite: 8536 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)