### PR TITLE
feat(feedback): admin panel for feedback triage (closes #793)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ CQC_LEM_CHECK_SCHEDULE_DELTA_MINUTES=5
 CQC_LEM_POST_TIME_DELTA_MINUTES=20
 # Secret key required in X-Admin-Secret header for admin endpoints
 ADMIN_SECRET=change_me_to_a_strong_random_secret
+# Comma-separated emails that may use the in-app feedback triage panel (issue #793), on top of the
+# users.is_admin column. Only admin feedback is auto-filed into GitHub; everything else waits here.
+ADMIN_USER_EMAILS=
 # Comma-separated bearer tokens accepted on /api routes (Authorization: Bearer ...).
 # Leave EMPTY for local/dev to disable the gate. Set on internet-facing deploys.
 API_ACCESS_TOKENS=

--- a/compose/local/database/migrations/V20260729194956__add_feedback_admin_review.sql
+++ b/compose/local/database/migrations/V20260729194956__add_feedback_admin_review.sql
@@ -1,0 +1,12 @@
+-- Admin feedback triage panel (issue #793): designate admin users and track who reviewed a feedback row.
+--
+--   users.is_admin        -> TINYINT(1): 1 = this user may use the feedback triage panel.
+--   feedback.reviewed_by  -> user id of the admin who approved/dismissed the row.
+--   feedback.reviewed_at  -> when the admin action happened.
+ALTER TABLE users
+    ADD COLUMN is_admin TINYINT(1) NOT NULL DEFAULT 0;
+
+ALTER TABLE feedback
+    ADD COLUMN reviewed_by INT NULL,
+    ADD COLUMN reviewed_at DATETIME NULL,
+    ADD INDEX idx_feedback_reviewed (reviewed_by, reviewed_at);

--- a/compose/local/database/migrations/V20260729194956__add_feedback_admin_review.sql
+++ b/compose/local/database/migrations/V20260729194956__add_feedback_admin_review.sql
@@ -10,3 +10,10 @@ ALTER TABLE feedback
     ADD COLUMN reviewed_by INT NULL,
     ADD COLUMN reviewed_at DATETIME NULL,
     ADD INDEX idx_feedback_reviewed (reviewed_by, reviewed_at);
+
+-- Bootstrap: with the column defaulting to 0, NO user is an admin, so the auto-filer would park
+-- every report and nobody could reach the panel to release them — the feedback->auto-work loop
+-- would go silently dead on deploy. Seed the founding account (lowest id) so the loop keeps
+-- running. Additional admins: UPDATE users SET is_admin = 1 WHERE email = '...', or the
+-- ADMIN_USER_EMAILS env allowlist. No-op on a fresh install with no users yet.
+UPDATE users SET is_admin = 1 ORDER BY id ASC LIMIT 1;

--- a/docs/launch-and-marketing-plan.md
+++ b/docs/launch-and-marketing-plan.md
@@ -200,6 +200,11 @@ classifier/filer path and stamps `feedback.reviewed_by/reviewed_at`. Two consequ
   `limit` window with the same rows every pass and admin feedback would never be reached again.
 - At least one admin has to exist or the loop parks everything with nobody able to release it. The migration
   seeds the founding account; `ADMIN_USER_EMAILS` is the no-SQL bootstrap for any other deploy.
+- A row that already reached GitHub (`clustered` / `issue_created` / `resolved`, or any row carrying an issue
+  number) is **not re-reviewable** — the review endpoint answers 409. A filed row IS its own open cluster, so
+  re-running the filer on it would match it to itself at similarity 1.0 and post a false "+1 another report"
+  on the very issue it created. The panel's buttons alone are not the guard: its list is cached, and the
+  filing beat or a second admin can settle a row between render and click.
 `count_pending_admin_review()` reports the backlog on every filing pass so it can't grow silently.
 
 ### B.3 Deduplication / clustering (one recurring problem = one issue)

--- a/docs/launch-and-marketing-plan.md
+++ b/docs/launch-and-marketing-plan.md
@@ -190,6 +190,18 @@ A new service `utilities/feedback/issue_service.py` creates the issue via `gh` /
 structured body (Why / Scope / Files-hint / Acceptance) that the RUNBOOK's `MODE=start` expects, and stamps the
 issue number back onto the `feedback` row. It references this plan doc in every issue it files.
 
+**Admin gate (issue #793).** Auto-filing is not open to everyone: `process_new_feedback` and
+`auto_recluster_feedback` only act on reports from **admin** users (`users.is_admin`, or the
+`ADMIN_USER_EMAILS` allowlist). Everything else stays `new` until an admin approves or dismisses it in the
+in-app triage panel (`/admin/feedback`, `GET|POST /api/admin/feedback…`), where approve runs the normal
+classifier/filer path and stamps `feedback.reviewed_by/reviewed_at`. Two consequences worth knowing:
+- The gate is applied **in the query** (`get_unprocessed_feedback(admin_only=True)`), not in the caller's
+  loop. Parked rows keep their `new` + NULL-cluster shape forever, so a caller-side skip would refill the
+  `limit` window with the same rows every pass and admin feedback would never be reached again.
+- At least one admin has to exist or the loop parks everything with nobody able to release it. The migration
+  seeds the founding account; `ADMIN_USER_EMAILS` is the no-SQL bootstrap for any other deploy.
+`count_pending_admin_review()` reports the backlog on every filing pass so it can't grow silently.
+
 ### B.3 Deduplication / clustering (one recurring problem = one issue)
 
 - Each item is embedded (cheap embedding model via LiteLLM). Before filing, `issue_service` cosine-compares

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -4733,6 +4733,14 @@ def admin_task_status(
 # operational X-Admin-Secret endpoints above.
 # ---------------------------------------------------------------------------
 
+# A row that already reached GitHub must never be re-reviewed. `file_feedback_issue` re-classifies
+# (LLM spend) and dedups against the OPEN clusters — and a filed row IS its own open cluster, so a
+# second approve matches it to itself at similarity 1.0 and posts a false "+1 another report" on the
+# very issue it created. Dismissing one would mark it not-actionable while its issue stays open.
+_REVIEW_SETTLED_STATUSES = (FeedbackStatus.CLUSTERED, FeedbackStatus.ISSUE_CREATED,
+                            FeedbackStatus.RESOLVED)
+
+
 def _require_user_admin(session_token: str) -> int:
     """Validate the session and ensure the user is designated as an admin.
 
@@ -4790,6 +4798,7 @@ def admin_feedback_list(
     401: {"description": "Invalid or expired session"},
     403: {"description": "Admin access required"},
     404: {"description": "Feedback row not found"},
+    409: {"description": "Feedback already triaged"},
     422: {"description": "Invalid action"},
 })
 def admin_feedback_review(
@@ -4802,6 +4811,13 @@ def admin_feedback_review(
     row = get_feedback_by_id(feedback_id)
     if not row:
         raise HTTPException(status_code=404, detail="Feedback not found")
+
+    # The panel only offers the buttons on `new` rows, but its list is cached and two admins (or the
+    # auto-filer beat) can settle a row between render and click.
+    row_status = str(row.get("status") or "")
+    if row_status in _REVIEW_SETTLED_STATUSES or row.get("github_issue_number"):
+        raise HTTPException(status_code=409,
+                            detail=f"Feedback already triaged (status {row_status or 'unknown'})")
 
     if request.action == FeedbackReviewAction.DISMISS:
         if not record_feedback_review(feedback_id, reviewer_user_id,

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -5,7 +5,7 @@ import os
 import time
 import zipfile
 from datetime import datetime, timedelta, timezone
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 from typing import Dict, List, Union
 from typing import Optional, Any
 from urllib.parse import urlparse
@@ -89,8 +89,9 @@ from cqc_lem.utilities.db import (
     replace_video_url_base, get_post_type, get_post_buyer_stage, get_post_status,
     update_db_post_rejection_reason,
     get_post_url_from_log_for_user,
-    insert_feedback, FeedbackSource,
+    insert_feedback, FeedbackSource, FeedbackStatus,
     get_latest_review_feedback_id, get_early_adopter_grant, extend_trial_for_user,
+    is_user_admin, get_feedback_list, record_feedback_review, get_feedback_by_id,
 )
 from cqc_lem.utilities.content_generation_status import mark_queued, get_generation_status, \
     clear_generation_status
@@ -892,6 +893,17 @@ class LinkedInCookieRequest(BaseModel):
     session_token: str
     li_at: str
     jsessionid: Optional[str] = None
+
+
+class FeedbackReviewAction(StrEnum):
+    APPROVE = 'approve'
+    DISMISS = 'dismiss'
+
+
+class FeedbackReviewRequest(BaseModel):
+    """Admin triage decision for a single feedback row (issue #793)."""
+    session_token: str
+    action: FeedbackReviewAction
 
 
 class LinkedInCompanyPageRequest(BaseModel):
@@ -1979,6 +1991,7 @@ def auth_check_session(session_token: str) -> ResponseModel:
         # own round trip would be a survey that never fired on the first page view.
         "onboarding_completed_at": _utc_iso(profile.get("onboarding_completed_at")),
         "posts_approved": int(profile.get("posts_approved") or 0),
+        "is_admin": is_user_admin(user_id),
     })
 
 
@@ -4713,6 +4726,102 @@ def admin_task_status(
     if res.ready():
         detail["result"] = str(res.result)[:500]
     return ResponseModel(status_code=200, detail=detail)
+
+
+# ---------------------------------------------------------------------------
+# Feedback admin triage panel (issue #793) — user-level admin role, not the
+# operational X-Admin-Secret endpoints above.
+# ---------------------------------------------------------------------------
+
+def _require_user_admin(session_token: str) -> int:
+    """Validate the session and ensure the user is designated as an admin.
+
+    Returns the user_id on success; raises HTTPException 401/403 otherwise."""
+    user_id = get_session_user_id(session_token)
+    if not user_id:
+        raise HTTPException(status_code=401, detail="Invalid or expired session")
+    if not is_user_admin(user_id):
+        raise HTTPException(status_code=403, detail="Admin access required")
+    return user_id
+
+
+@router.get("/admin/feedback", responses={
+    200: {"description": "Feedback list returned"},
+    401: {"description": "Invalid or expired session"},
+    403: {"description": "Admin access required"},
+})
+def admin_feedback_list(
+    session_token: str,
+    status: Optional[str] = None,
+    source: Optional[str] = None,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+) -> ResponseModel:
+    """List feedback submissions for the admin triage panel."""
+    _require_user_admin(session_token)
+    rows = get_feedback_list(status=status, source=source, limit=limit, offset=offset)
+    return ResponseModel(status_code=200, detail={
+        "items": [
+            {
+                "id": r.get("id"),
+                "user_id": r.get("user_id"),
+                "email": r.get("email"),
+                "is_admin_reporter": bool(r.get("is_admin")),
+                "source": r.get("source"),
+                "type_hint": r.get("type_hint"),
+                "body": r.get("body"),
+                "context_json": r.get("context_json"),
+                "status": r.get("status"),
+                "cluster_id": r.get("cluster_id"),
+                "github_issue_number": r.get("github_issue_number"),
+                "reviewed_by": r.get("reviewed_by"),
+                "reviewed_at": _utc_iso(r.get("reviewed_at")),
+                "created_at": _utc_iso(r.get("created_at")),
+            }
+            for r in rows
+        ],
+        "limit": limit,
+        "offset": offset,
+    })
+
+
+@router.post("/admin/feedback/{feedback_id}/review", responses={
+    200: {"description": "Review recorded"},
+    401: {"description": "Invalid or expired session"},
+    403: {"description": "Admin access required"},
+    404: {"description": "Feedback row not found"},
+    422: {"description": "Invalid action"},
+})
+def admin_feedback_review(
+    feedback_id: int,
+    request: FeedbackReviewRequest,
+) -> ResponseModel:
+    """Approve a feedback row for auto-triage or dismiss it."""
+    reviewer_user_id = _require_user_admin(request.session_token)
+    from cqc_lem.utilities.feedback.issue_service import file_feedback_issue
+    row = get_feedback_by_id(feedback_id)
+    if not row:
+        raise HTTPException(status_code=404, detail="Feedback not found")
+
+    if request.action == FeedbackReviewAction.DISMISS:
+        if not record_feedback_review(feedback_id, reviewer_user_id,
+                                      status=FeedbackStatus.DISMISSED):
+            raise HTTPException(status_code=500, detail="Could not dismiss feedback")
+        log_info("Feedback dismissed by admin", feedback_id=feedback_id,
+                 user_id=reviewer_user_id)
+        return ResponseModel(status_code=200, detail={"reviewed": True, "action": "dismissed"})
+
+    # approve: run the normal classifier/filer path now.
+    result = file_feedback_issue(row)
+    # Stamp the reviewer even when the filer itself dropped/FAQ'd/human-routed the row.
+    record_feedback_review(feedback_id, reviewer_user_id)
+    log_info("Feedback approved by admin", feedback_id=feedback_id,
+             user_id=reviewer_user_id, action=result.get("action"))
+    return ResponseModel(status_code=200, detail={
+        "reviewed": True,
+        "action": "approved",
+        "filing_result": result,
+    })
 
 
 @router.get("/carousel-templates", responses={200: {"description": "Available carousel templates"}})

--- a/src/cqc_lem/ui/src/App.tsx
+++ b/src/cqc_lem/ui/src/App.tsx
@@ -4,12 +4,14 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { AuthProvider, useAuth } from './contexts/AuthContext'
 import Layout from './components/Layout'
 import ProtectedRoute from './components/ProtectedRoute'
+import AdminRoute from './components/AdminRoute'
 import LoginModal from './components/LoginModal'
 import NewVersionNotice from './components/NewVersionNotice'
 import Dashboard from './pages/Dashboard'
 import Account from './pages/Account'
 import Avatars from './pages/Avatars'
 import ContentStudio from './pages/ContentStudio'
+import AdminFeedbackPage from './pages/AdminFeedbackPage'
 import Landing from './pages/Landing'
 import PrivacyPolicy from './pages/PrivacyPolicy'
 import TermsAndConditions from './pages/TermsAndConditions'
@@ -56,6 +58,10 @@ function AppRoutes() {
           <Route
             path="content"
             element={<ProtectedRoute><ContentStudio /></ProtectedRoute>}
+          />
+          <Route
+            path="admin/feedback"
+            element={<AdminRoute><AdminFeedbackPage /></AdminRoute>}
           />
           {/* Public legal pages — reachable from the footer and from logged-out landing pages */}
           <Route path="privacy-policy" element={<PrivacyPolicy />} />

--- a/src/cqc_lem/ui/src/components/AdminRoute.tsx
+++ b/src/cqc_lem/ui/src/components/AdminRoute.tsx
@@ -1,0 +1,25 @@
+import { Navigate } from 'react-router-dom'
+import { useAuth } from '../contexts/AuthContext'
+
+export default function AdminRoute({ children }: { children: React.ReactNode }) {
+  const { user, isLoading, isAdmin, openLoginModal } = useAuth()
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center h-40 text-gray-400">
+        Loading…
+      </div>
+    )
+  }
+
+  if (!user) {
+    openLoginModal()
+    return <Navigate to="/" replace />
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/" replace />
+  }
+
+  return <>{children}</>
+}

--- a/src/cqc_lem/ui/src/components/AdminRoute.tsx
+++ b/src/cqc_lem/ui/src/components/AdminRoute.tsx
@@ -1,8 +1,17 @@
+import { useEffect } from 'react'
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../contexts/AuthContext'
 
 export default function AdminRoute({ children }: { children: React.ReactNode }) {
   const { user, isLoading, isAdmin, openLoginModal } = useAuth()
+
+  // Same shape as ProtectedRoute: opening the modal is a state update on another component, so it
+  // has to happen in an effect, not during render.
+  useEffect(() => {
+    if (!isLoading && !user) {
+      openLoginModal()
+    }
+  }, [isLoading, user, openLoginModal])
 
   if (isLoading) {
     return (
@@ -13,7 +22,6 @@ export default function AdminRoute({ children }: { children: React.ReactNode }) 
   }
 
   if (!user) {
-    openLoginModal()
     return <Navigate to="/" replace />
   }
 

--- a/src/cqc_lem/ui/src/components/Layout.tsx
+++ b/src/cqc_lem/ui/src/components/Layout.tsx
@@ -18,8 +18,12 @@ const navLinks = [
   { to: '/content', label: 'Content' },
 ]
 
+const adminNavLinks = [
+  { to: '/admin/feedback', label: 'Feedback Triage' },
+]
+
 export default function Layout() {
-  const { user, logout, openLoginModal } = useAuth()
+  const { user, logout, openLoginModal, isAdmin } = useAuth()
   const navigate = useNavigate()
   const location = useLocation()
   const showReadiness = !!user && AUTOMATION_PATHS.some((p) => location.pathname.startsWith(p))
@@ -34,22 +38,41 @@ export default function Layout() {
       <nav className="bg-white border-b border-gray-200 sticky top-0 z-10">
         <div className="max-w-5xl mx-auto px-4 flex items-center gap-6 h-14">
           <span className="font-bold text-blue-600 text-lg">LEM</span>
-          {user && navLinks.map(({ to, label, end }) => (
-            <NavLink
-              key={to}
-              to={to}
-              end={end}
-              className={({ isActive }) =>
-                `text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'text-blue-600 border-b-2 border-blue-600 pb-0.5'
-                    : 'text-gray-600 hover:text-gray-900'
-                }`
-              }
-            >
-              {label}
-            </NavLink>
-          ))}
+          {user && (
+            <>
+              {navLinks.map(({ to, label, end }) => (
+                <NavLink
+                  key={to}
+                  to={to}
+                  end={end}
+                  className={({ isActive }) =>
+                    `text-sm font-medium transition-colors ${
+                      isActive
+                        ? 'text-blue-600 border-b-2 border-blue-600 pb-0.5'
+                        : 'text-gray-600 hover:text-gray-900'
+                    }`
+                  }
+                >
+                  {label}
+                </NavLink>
+              ))}
+              {isAdmin && adminNavLinks.map(({ to, label }) => (
+                <NavLink
+                  key={to}
+                  to={to}
+                  className={({ isActive }) =>
+                    `text-sm font-medium transition-colors ${
+                      isActive
+                        ? 'text-purple-600 border-b-2 border-purple-600 pb-0.5'
+                        : 'text-gray-600 hover:text-gray-900'
+                    }`
+                  }
+                >
+                  {label}
+                </NavLink>
+              ))}
+            </>
+          )}
           <div className="ml-auto flex items-center gap-3">
             {user ? (
               <>

--- a/src/cqc_lem/ui/src/contexts/AuthContext.tsx
+++ b/src/cqc_lem/ui/src/contexts/AuthContext.tsx
@@ -19,12 +19,14 @@ interface SessionDetail {
   // What PostHog Surveys target on (issue #653).
   onboarding_completed_at?: string | null
   posts_approved?: number | null
+  is_admin?: boolean
 }
 
 interface AuthContextValue {
   user: AuthUser | null
   sessionToken: string | null
   isLoading: boolean
+  isAdmin: boolean
   login: (token: string, email: string) => void
   logout: () => Promise<void>
   openLoginModal: () => void
@@ -40,6 +42,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null)
   const [sessionToken, setSessionToken] = useState<string | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [isAdmin, setIsAdmin] = useState(false)
   const [isLoginModalOpen, setIsLoginModalOpen] = useState(false)
   // Identify once per user per page load — re-identifying on every session check would burn a
   // $identify on each mount for no new information.
@@ -48,6 +51,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   function applySession(detail: SessionDetail, token: string) {
     setSessionToken(token)
     setUser({ email: detail.email, userId: detail.user_id })
+    setIsAdmin(!!detail.is_admin)
     if (detail.user_id && identifiedUserId.current !== detail.user_id) {
       identifiedUserId.current = detail.user_id
       identifyUser({
@@ -108,6 +112,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     localStorage.removeItem('lem_sitemap_url')
     setSessionToken(null)
     setUser(null)
+    setIsAdmin(false)
     // Break the browser↔person link, or the next person to sign in on this machine inherits it.
     identifiedUserId.current = null
     resetAnalytics()
@@ -119,6 +124,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         user,
         sessionToken,
         isLoading,
+        isAdmin,
         login,
         logout,
         openLoginModal: () => setIsLoginModalOpen(true),

--- a/src/cqc_lem/ui/src/hooks/useAdminFeedback.ts
+++ b/src/cqc_lem/ui/src/hooks/useAdminFeedback.ts
@@ -1,0 +1,50 @@
+import { useQuery } from '@tanstack/react-query'
+import api from '../api/client'
+
+export interface AdminFeedbackItem {
+  id: number
+  user_id: number | null
+  email: string | null
+  is_admin_reporter: boolean
+  source: string
+  type_hint: string | null
+  body: string
+  context_json: string | object | null
+  status: string
+  cluster_id: number | null
+  github_issue_number: number | null
+  reviewed_by: number | null
+  reviewed_at: string | null
+  created_at: string
+}
+
+export interface AdminFeedbackList {
+  items: AdminFeedbackItem[]
+  limit: number
+  offset: number
+}
+
+interface UseAdminFeedbackOptions {
+  sessionToken: string
+  status?: string
+  source?: string
+  limit?: number
+  offset?: number
+}
+
+export function useAdminFeedback(options: UseAdminFeedbackOptions) {
+  const { sessionToken, status, source, limit = 50, offset = 0 } = options
+  const params: Record<string, string | number> = { session_token: sessionToken, limit, offset }
+  if (status) params.status = status
+  if (source) params.source = source
+
+  return useQuery({
+    queryKey: ['admin-feedback', status, source, limit, offset],
+    queryFn: () =>
+      api
+        .get('/admin/feedback', { params })
+        .then((r) => (r.data.detail as AdminFeedbackList)),
+    enabled: !!sessionToken,
+    staleTime: 30 * 1000,
+  })
+}

--- a/src/cqc_lem/ui/src/hooks/useFeedbackReview.ts
+++ b/src/cqc_lem/ui/src/hooks/useFeedbackReview.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import api from '../api/client'
+
+interface ReviewPayload {
+  feedbackId: number
+  action: 'approve' | 'dismiss'
+  sessionToken: string
+}
+
+export function useFeedbackReview() {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: ({ feedbackId, action, sessionToken }: ReviewPayload) =>
+      api
+        .post(`/admin/feedback/${feedbackId}/review`, {
+          session_token: sessionToken,
+          action,
+        })
+        .then((r) => r.data.detail),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: ['admin-feedback'] })
+    },
+  })
+}

--- a/src/cqc_lem/ui/src/hooks/useFeedbackReview.ts
+++ b/src/cqc_lem/ui/src/hooks/useFeedbackReview.ts
@@ -7,9 +7,20 @@ interface ReviewPayload {
   sessionToken: string
 }
 
+// Approve returns what the filer actually did — it can dedupe, rate-limit or error out, so
+// "approved" alone does not mean an issue exists.
+export interface ReviewResult {
+  reviewed: boolean
+  action: string
+  filing_result?: {
+    action?: string
+    issue_number?: number
+  }
+}
+
 export function useFeedbackReview() {
   const queryClient = useQueryClient()
-  return useMutation({
+  return useMutation<ReviewResult, unknown, ReviewPayload>({
     mutationFn: ({ feedbackId, action, sessionToken }: ReviewPayload) =>
       api
         .post(`/admin/feedback/${feedbackId}/review`, {

--- a/src/cqc_lem/ui/src/pages/AdminFeedbackPage.test.tsx
+++ b/src/cqc_lem/ui/src/pages/AdminFeedbackPage.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import AdminFeedbackPage from './AdminFeedbackPage'
+
+const get = vi.fn()
+const post = vi.fn()
+vi.mock('../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
+  },
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ sessionToken: 'tok', isAdmin: true }),
+}))
+
+function harness(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+function listPayload(items: unknown[]) {
+  return {
+    data: {
+      detail: {
+        items,
+        limit: 25,
+        offset: 0,
+      },
+    },
+  }
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+})
+afterEach(cleanup)
+
+describe('AdminFeedbackPage (issue #793)', () => {
+  it('renders pending feedback and approve/dismiss buttons', async () => {
+    get.mockResolvedValue(listPayload([
+      {
+        id: 1,
+        email: 'user@x.com',
+        is_admin_reporter: false,
+        source: 'widget',
+        type_hint: 'bug',
+        body: 'Something is broken',
+        status: 'new',
+        github_issue_number: null,
+        created_at: '2026-07-29T12:00:00Z',
+      },
+    ]))
+    harness(<AdminFeedbackPage />)
+    await waitFor(() => expect(screen.getByText('Feedback triage')).toBeTruthy())
+    expect(screen.getByText('user@x.com')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /approve/i })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /dismiss/i })).toBeTruthy()
+  })
+
+  it('calls the dismiss endpoint and refreshes the list', async () => {
+    get.mockResolvedValue(listPayload([
+      {
+        id: 1,
+        email: 'user@x.com',
+        is_admin_reporter: false,
+        source: 'widget',
+        type_hint: 'bug',
+        body: 'Something is broken',
+        status: 'new',
+        github_issue_number: null,
+        created_at: '2026-07-29T12:00:00Z',
+      },
+    ]))
+    post.mockResolvedValue({ data: { detail: { reviewed: true, action: 'dismissed' } } })
+
+    harness(<AdminFeedbackPage />)
+    await waitFor(() => expect(screen.getByRole('button', { name: /dismiss/i })).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: /dismiss/i }))
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith('/admin/feedback/1/review', {
+        session_token: 'tok',
+        action: 'dismiss',
+      })
+    )
+  })
+})

--- a/src/cqc_lem/ui/src/pages/AdminFeedbackPage.test.tsx
+++ b/src/cqc_lem/ui/src/pages/AdminFeedbackPage.test.tsx
@@ -56,8 +56,8 @@ describe('AdminFeedbackPage (issue #793)', () => {
       },
     ]))
     harness(<AdminFeedbackPage />)
-    await waitFor(() => expect(screen.getByText('Feedback triage')).toBeTruthy())
-    expect(screen.getByText('user@x.com')).toBeTruthy()
+    expect(screen.getByText('Feedback triage')).toBeTruthy()
+    await waitFor(() => expect(screen.getByText('user@x.com')).toBeTruthy())
     expect(screen.getByRole('button', { name: /approve/i })).toBeTruthy()
     expect(screen.getByRole('button', { name: /dismiss/i })).toBeTruthy()
   })

--- a/src/cqc_lem/ui/src/pages/AdminFeedbackPage.test.tsx
+++ b/src/cqc_lem/ui/src/pages/AdminFeedbackPage.test.tsx
@@ -88,4 +88,29 @@ describe('AdminFeedbackPage (issue #793)', () => {
       })
     )
   })
+
+  it('surfaces a failed review instead of swallowing it', async () => {
+    get.mockResolvedValue(listPayload([
+      {
+        id: 1,
+        email: 'user@x.com',
+        is_admin_reporter: false,
+        source: 'widget',
+        type_hint: 'bug',
+        body: 'Something is broken',
+        status: 'new',
+        github_issue_number: null,
+        created_at: '2026-07-29T12:00:00Z',
+      },
+    ]))
+    // 409: the beat filed this row between render and click.
+    post.mockRejectedValue({ response: { data: { detail: 'Feedback already triaged (status issue_created)' } } })
+
+    harness(<AdminFeedbackPage />)
+    await waitFor(() => expect(screen.getByRole('button', { name: /approve/i })).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }))
+    await waitFor(() =>
+      expect(screen.getByText(/Feedback already triaged/)).toBeTruthy()
+    )
+  })
 })

--- a/src/cqc_lem/ui/src/pages/AdminFeedbackPage.tsx
+++ b/src/cqc_lem/ui/src/pages/AdminFeedbackPage.tsx
@@ -1,0 +1,218 @@
+import { useState } from 'react'
+import { useAuth } from '../contexts/AuthContext'
+import { useAdminFeedback } from '../hooks/useAdminFeedback'
+import { useFeedbackReview } from '../hooks/useFeedbackReview'
+
+const PAGE_SIZE = 25
+
+const STATUS_LABELS: Record<string, string> = {
+  new: 'Pending review',
+  triaged: 'Triaged',
+  clustered: 'Clustered',
+  issue_created: 'Issue created',
+  resolved: 'Resolved',
+  dismissed: 'Dismissed',
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  widget: 'Widget',
+  bug: 'Bug report',
+  nps: 'NPS',
+  review: 'Review',
+  passive: 'Passive',
+  csat: 'CSAT',
+}
+
+function classNames(...classes: (string | false | null | undefined)[]) {
+  return classes.filter(Boolean).join(' ')
+}
+
+export default function AdminFeedbackPage() {
+  const { sessionToken } = useAuth()
+  const [statusFilter, setStatusFilter] = useState<string>('')
+  const [sourceFilter, setSourceFilter] = useState<string>('')
+  const [page, setPage] = useState(0)
+
+  const { data, isLoading, error, refetch } = useAdminFeedback({
+    sessionToken: sessionToken || '',
+    status: statusFilter || undefined,
+    source: sourceFilter || undefined,
+    limit: PAGE_SIZE,
+    offset: page * PAGE_SIZE,
+  })
+
+  const review = useFeedbackReview()
+
+  async function handleAction(id: number, action: 'approve' | 'dismiss') {
+    await review.mutateAsync({ feedbackId: id, action, sessionToken: sessionToken || '' })
+    void refetch()
+  }
+
+  const items = data?.items ?? []
+
+  return (
+    <div className="max-w-5xl space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-gray-800">Feedback triage</h1>
+          <p className="text-sm text-gray-500">
+            Approve feedback for the auto-work pipeline or dismiss it. Only feedback from admin users is auto-triaged without review.
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        <div className="flex items-center gap-2">
+          <label htmlFor="status-filter" className="text-sm text-gray-600">Status</label>
+          <select
+            id="status-filter"
+            value={statusFilter}
+            onChange={(e) => { setStatusFilter(e.target.value); setPage(0) }}
+            className="text-sm border border-gray-300 rounded-lg px-2 py-1"
+          >
+            <option value="">All</option>
+            {Object.entries(STATUS_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
+        <div className="flex items-center gap-2">
+          <label htmlFor="source-filter" className="text-sm text-gray-600">Source</label>
+          <select
+            id="source-filter"
+            value={sourceFilter}
+            onChange={(e) => { setSourceFilter(e.target.value); setPage(0) }}
+            className="text-sm border border-gray-300 rounded-lg px-2 py-1"
+          >
+            <option value="">All</option>
+            {Object.entries(SOURCE_LABELS).map(([value, label]) => (
+              <option key={value} value={value}>{label}</option>
+            ))}
+          </select>
+        </div>
+        <button
+          onClick={() => void refetch()}
+          disabled={isLoading}
+          className="text-sm text-blue-600 hover:text-blue-800 font-medium disabled:opacity-50"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <p className="text-sm text-red-600">
+          Could not load feedback: {error instanceof Error ? error.message : 'unknown error'}
+        </p>
+      )}
+
+      <div className="bg-white border border-gray-200 rounded-xl shadow-sm overflow-hidden">
+        <table className="w-full text-sm text-left">
+          <thead className="bg-gray-50 text-gray-600 font-medium">
+            <tr>
+              <th className="px-4 py-3">ID</th>
+              <th className="px-4 py-3">Source</th>
+              <th className="px-4 py-3">Reporter</th>
+              <th className="px-4 py-3">Body</th>
+              <th className="px-4 py-3">Status</th>
+              <th className="px-4 py-3">Issue</th>
+              <th className="px-4 py-3">Submitted</th>
+              <th className="px-4 py-3 text-right">Actions</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100">
+            {items.map((item) => (
+              <tr key={item.id} className="hover:bg-gray-50">
+                <td className="px-4 py-3 text-gray-500">{item.id}</td>
+                <td className="px-4 py-3">{SOURCE_LABELS[item.source] ?? item.source}</td>
+                <td className="px-4 py-3">
+                  {item.email ? (
+                    <span className={classNames('text-gray-800', item.is_admin_reporter && 'font-semibold')}>
+                      {item.email}
+                      {item.is_admin_reporter && <span className="ml-1 text-xs text-blue-600">(admin)</span>}
+                    </span>
+                  ) : (
+                    <span className="text-gray-400 italic">Anonymous</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 max-w-xs truncate" title={item.body}>{item.body}</td>
+                <td className="px-4 py-3">
+                  <span className={classNames(
+                    'inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium',
+                    item.status === 'new' && 'bg-amber-100 text-amber-800',
+                    item.status === 'dismissed' && 'bg-gray-100 text-gray-600',
+                    item.status === 'issue_created' && 'bg-green-100 text-green-800',
+                    !['new', 'dismissed', 'issue_created'].includes(item.status) && 'bg-blue-100 text-blue-800'
+                  )}>
+                    {STATUS_LABELS[item.status] ?? item.status}
+                  </span>
+                </td>
+                <td className="px-4 py-3">
+                  {item.github_issue_number ? (
+                    <a
+                      href={`https://github.com/christopherqueenconsulting/linkedin_engagement_manager/issues/${item.github_issue_number}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-blue-600 hover:underline"
+                    >
+                      #{item.github_issue_number}
+                    </a>
+                  ) : (
+                    <span className="text-gray-400">—</span>
+                  )}
+                </td>
+                <td className="px-4 py-3 text-gray-500">
+                  {item.created_at ? new Date(item.created_at).toLocaleString() : '—'}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {item.status === 'new' && (
+                    <div className="flex items-center justify-end gap-2">
+                      <button
+                        onClick={() => void handleAction(item.id, 'approve')}
+                        disabled={review.isPending}
+                        className="text-xs bg-blue-600 text-white px-2.5 py-1 rounded hover:bg-blue-700 disabled:opacity-50"
+                      >
+                        Approve
+                      </button>
+                      <button
+                        onClick={() => void handleAction(item.id, 'dismiss')}
+                        disabled={review.isPending}
+                        className="text-xs bg-gray-100 text-gray-700 px-2.5 py-1 rounded hover:bg-gray-200 disabled:opacity-50"
+                      >
+                        Dismiss
+                      </button>
+                    </div>
+                  )}
+                </td>
+              </tr>
+            ))}
+            {items.length === 0 && !isLoading && (
+              <tr>
+                <td colSpan={8} className="px-4 py-8 text-center text-gray-500">
+                  No feedback submissions match the current filters.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-sm">
+        <button
+          onClick={() => setPage((p) => Math.max(0, p - 1))}
+          disabled={page === 0 || isLoading}
+          className="text-blue-600 hover:text-blue-800 disabled:opacity-50"
+        >
+          Previous
+        </button>
+        <span className="text-gray-600">Page {page + 1}</span>
+        <button
+          onClick={() => setPage((p) => p + 1)}
+          disabled={items.length < PAGE_SIZE || isLoading}
+          className="text-blue-600 hover:text-blue-800 disabled:opacity-50"
+        >
+          Next
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/pages/AdminFeedbackPage.tsx
+++ b/src/cqc_lem/ui/src/pages/AdminFeedbackPage.tsx
@@ -43,12 +43,18 @@ export default function AdminFeedbackPage() {
 
   const review = useFeedbackReview()
 
-  async function handleAction(id: number, action: 'approve' | 'dismiss') {
-    await review.mutateAsync({ feedbackId: id, action, sessionToken: sessionToken || '' })
-    void refetch()
+  // `mutate`, not `mutateAsync`: an awaited rejection here had nobody to catch it, so a failed
+  // approve (GitHub down, row already triaged by the beat) showed the admin nothing at all — the
+  // row just stayed put. The hook invalidates the list on success, so no manual refetch either.
+  function handleAction(id: number, action: 'approve' | 'dismiss') {
+    review.mutate({ feedbackId: id, action, sessionToken: sessionToken || '' })
   }
 
   const items = data?.items ?? []
+  const reviewError = review.error
+    ? ((review.error as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+       || (review.error instanceof Error ? review.error.message : 'unknown error'))
+    : null
 
   return (
     <div className="max-w-5xl space-y-6">
@@ -102,6 +108,22 @@ export default function AdminFeedbackPage() {
       {error && (
         <p className="text-sm text-red-600">
           Could not load feedback: {error instanceof Error ? error.message : 'unknown error'}
+        </p>
+      )}
+
+      {reviewError && (
+        <p className="text-sm text-red-600">Could not record the review: {reviewError}</p>
+      )}
+
+      {/* Approving does not guarantee an issue: the filer can rate-limit, drop, or fail on GitHub
+          and leave the row where it was. Show what actually happened. */}
+      {review.isSuccess && !reviewError && (
+        <p className="text-sm text-gray-600">
+          Last review: {String(review.data?.action ?? 'done')}
+          {review.data?.filing_result?.action ? ` — filer: ${review.data.filing_result.action}` : ''}
+          {review.data?.filing_result?.issue_number
+            ? ` (issue #${review.data.filing_result.issue_number})`
+            : ''}
         </p>
       )}
 
@@ -167,14 +189,14 @@ export default function AdminFeedbackPage() {
                   {item.status === 'new' && (
                     <div className="flex items-center justify-end gap-2">
                       <button
-                        onClick={() => void handleAction(item.id, 'approve')}
+                        onClick={() => handleAction(item.id, 'approve')}
                         disabled={review.isPending}
                         className="text-xs bg-blue-600 text-white px-2.5 py-1 rounded hover:bg-blue-700 disabled:opacity-50"
                       >
                         Approve
                       </button>
                       <button
-                        onClick={() => void handleAction(item.id, 'dismiss')}
+                        onClick={() => handleAction(item.id, 'dismiss')}
                         disabled={review.isPending}
                         className="text-xs bg-gray-100 text-gray-700 px-2.5 py-1 rounded hover:bg-gray-200 disabled:opacity-50"
                       >

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -8725,7 +8725,12 @@ def get_feedback_list(status: Optional[Union["FeedbackStatus", str]] = None,
     """All feedback rows, newest first, with the submitter's email and admin flag (issue #793).
 
     Optional status/source filters are validated against the enum vocabularies before they reach
-    the query, so a bad value returns an empty list instead of a MySQL 1265."""
+    the query, so a bad value returns an empty list instead of a MySQL 1265.
+
+    `embedding` is deliberately NOT selected — the panel never shows it, and a page of 50 rows would
+    drag 50 full vectors out of MySQL to be thrown away. `is_admin` answers the same question the
+    auto-filer's join does, so it honours ADMIN_USER_EMAILS too: an allowlisted reporter's feedback
+    IS auto-filed, and the panel must not label it as awaiting review."""
     filters: list = []
     params: list = []
     if status is not None:
@@ -8746,7 +8751,7 @@ def get_feedback_list(status: Optional[Union["FeedbackStatus", str]] = None,
     where = f"WHERE {' AND '.join(filters)}" if filters else ""
     sql = (
         f"SELECT f.id, f.user_id, f.source, f.type_hint, f.body, f.context_json, "
-        f"f.embedding, f.cluster_id, f.github_issue_number, f.status, f.sentiment, "
+        f"f.cluster_id, f.github_issue_number, f.status, f.sentiment, "
         f"f.reviewed_by, f.reviewed_at, f.created_at, u.email, u.is_admin "
         f"FROM feedback f LEFT JOIN users u ON u.id = f.user_id "
         f"{where} ORDER BY f.created_at DESC LIMIT %s OFFSET %s"
@@ -8755,7 +8760,13 @@ def get_feedback_list(status: Optional[Union["FeedbackStatus", str]] = None,
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(sql, (*params, int(limit), int(offset)))
-        return cursor.fetchall() or []
+        rows = cursor.fetchall() or []
+        allow = admin_email_allowlist()
+        for row in rows:
+            if allow and not row.get("is_admin") and \
+                    (row.get("email") or "").strip().lower() in allow:
+                row["is_admin"] = 1
+        return rows
     except mysql.connector.Error as err:
         log_error("Could not list feedback for admin panel", exc=err)
         return []

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -8484,7 +8484,7 @@ def insert_feedback(body: str, user_id: int = None,
 # copies that cluster_id and the seed's github_issue_number. No extra table, so "one recurring
 # problem = one issue" is a self-join instead of a schema change.
 _FEEDBACK_COLUMNS = ("id, user_id, source, type_hint, body, context_json, embedding, cluster_id, "
-                     "github_issue_number, status, sentiment, created_at")
+                     "github_issue_number, status, sentiment, reviewed_by, reviewed_at, created_at")
 
 
 def get_feedback_by_id(feedback_id: int) -> Optional[dict]:
@@ -8628,6 +8628,109 @@ def update_feedback_triage(feedback_id: int,
         columns = ", ".join(u.split("=")[0] for u in updates)
         log_error(f"Could not update feedback triage for {feedback_id} (columns: {columns})",
                   exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def is_user_admin(user_id: int) -> bool:
+    """Whether this user is designated as an admin (issue #793).
+
+    Fails CLOSED — a missing user or DB error is never interpreted as admin rights."""
+    if user_id is None:
+        return False
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute("SELECT is_admin FROM users WHERE id = %s", (int(user_id),))
+        row = cursor.fetchone()
+        return bool(row and row.get("is_admin"))
+    except mysql.connector.Error as err:
+        log_error(f"Could not check admin status for user_id {user_id}", exc=err)
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def get_feedback_list(status: Optional[Union["FeedbackStatus", str]] = None,
+                      source: Optional[Union["FeedbackSource", str]] = None,
+                      limit: int = 50, offset: int = 0) -> list:
+    """All feedback rows, newest first, with the submitter's email and admin flag (issue #793).
+
+    Optional status/source filters are validated against the enum vocabularies before they reach
+    the query, so a bad value returns an empty list instead of a MySQL 1265."""
+    filters: list = []
+    params: list = []
+    if status is not None:
+        try:
+            status = FeedbackStatus(str(status).strip().lower())
+        except ValueError:
+            return []
+        filters.append("f.status = %s")
+        params.append(str(status))
+    if source is not None:
+        try:
+            source = FeedbackSource(str(source).strip().lower())
+        except ValueError:
+            return []
+        filters.append("f.source = %s")
+        params.append(str(source))
+
+    where = f"WHERE {' AND '.join(filters)}" if filters else ""
+    sql = (
+        f"SELECT f.id, f.user_id, f.source, f.type_hint, f.body, f.context_json, "
+        f"f.embedding, f.cluster_id, f.github_issue_number, f.status, f.sentiment, "
+        f"f.reviewed_by, f.reviewed_at, f.created_at, u.email, u.is_admin "
+        f"FROM feedback f LEFT JOIN users u ON u.id = f.user_id "
+        f"{where} ORDER BY f.created_at DESC LIMIT %s OFFSET %s"
+    )
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(sql, (*params, int(limit), int(offset)))
+        return cursor.fetchall() or []
+    except mysql.connector.Error as err:
+        log_error("Could not list feedback for admin panel", exc=err)
+        return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_feedback_review(feedback_id: int, reviewer_user_id: int,
+                           status: Optional[Union["FeedbackStatus", str]] = None,
+                           reviewed_at: Optional[datetime] = None) -> bool:
+    """Stamp who reviewed a feedback row and when, optionally updating its status (issue #793).
+
+    Status is validated the same way as `update_feedback_triage` so a typo can never corrupt the
+    ENUM column."""
+    if feedback_id is None or reviewer_user_id is None:
+        return False
+    updates: list = ["reviewed_by=%s", "reviewed_at=%s"]
+    params: list = [int(reviewer_user_id),
+                    (reviewed_at or datetime.now(timezone.utc)).replace(tzinfo=None)]
+    if status is not None:
+        try:
+            status = FeedbackStatus(str(status).strip().lower())
+        except ValueError as err:
+            log_error(f"Refusing to write unknown feedback status {str(status)!r} for feedback "
+                      f"{feedback_id} — expected one of "
+                      f"{', '.join(s.value for s in FeedbackStatus)}", exc=err)
+            return False
+        updates.append("status=%s")
+        params.append(str(status))
+    params.append(int(feedback_id))
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(f"UPDATE feedback SET {', '.join(updates)} WHERE id=%s", tuple(params))
+        connection.commit()
+        return cursor.rowcount > 0
+    except mysql.connector.Error as err:
+        log_error(f"Could not record feedback review for {feedback_id}", exc=err,
+                  user_id=reviewer_user_id)
         return False
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -8502,26 +8502,77 @@ def get_feedback_by_id(feedback_id: int) -> Optional[dict]:
         connection.close()
 
 
-def get_unprocessed_feedback(limit: int = 25, statuses: tuple = (FeedbackStatus.NEW,)) -> list:
+def _prefixed_feedback_columns(alias: str = "f") -> str:
+    return ", ".join(f"{alias}.{c.strip()}" for c in _FEEDBACK_COLUMNS.split(","))
+
+
+def _admin_reporter_join(alias: str = "f") -> tuple:
+    """LEFT JOIN + params that mark whether a feedback row was submitted by an admin (#793).
+
+    LEFT so it can express both halves: `au.id IS NOT NULL` is admin, `au.id IS NULL` is pending."""
+    allow = sorted(admin_email_allowlist())
+    email_clause = f" OR LOWER(au.email) IN ({','.join(['%s'] * len(allow))})" if allow else ""
+    join = (f"LEFT JOIN users au ON au.id = {alias}.user_id "
+            f"AND (au.is_admin = 1{email_clause})")
+    return join, tuple(allow)
+
+
+def get_unprocessed_feedback(limit: int = 25, statuses: tuple = (FeedbackStatus.NEW,),
+                             admin_only: bool = False) -> list:
     """Captured-but-unclustered feedback, oldest first so the queue drains FIFO (issue #498).
 
     Defaults to `new` only — the auto-filer must not re-classify (and re-pay for) rows it already
-    parked in `triaged`. The nightly reclustering pass widens `statuses` to reconsider those."""
+    parked in `triaged`. The nightly reclustering pass widens `statuses` to reconsider those.
+
+    `admin_only` (issue #793) restricts the result to reports from admin users. It filters in SQL,
+    NOT in the caller's loop: non-admin rows keep their `new`/NULL-cluster shape forever while they
+    wait on the panel, so a caller-side skip would let `limit` fill with the same parked rows every
+    pass and admin feedback would never be reached again."""
     wanted = [str(s) for s in (statuses or ()) if str(s) in tuple(FeedbackStatus)]
     if not wanted:
         return []
+    join, join_params = _admin_reporter_join() if admin_only else ("", ())
+    admin_filter = "AND au.id IS NOT NULL " if admin_only else ""
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            f"SELECT {_FEEDBACK_COLUMNS} FROM feedback "
-            f"WHERE status IN ({','.join(['%s'] * len(wanted))}) AND cluster_id IS NULL "
-            "ORDER BY created_at ASC, id ASC LIMIT %s",
-            (*wanted, int(limit)))
+            f"SELECT {_prefixed_feedback_columns()} FROM feedback f {join} "
+            f"WHERE f.status IN ({','.join(['%s'] * len(wanted))}) AND f.cluster_id IS NULL "
+            f"{admin_filter}"
+            "ORDER BY f.created_at ASC, f.id ASC LIMIT %s",
+            (*join_params, *wanted, int(limit)))
         return cursor.fetchall() or []
     except mysql.connector.Error as err:
         log_error("Could not fetch unprocessed feedback", exc=err)
         return []
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def count_pending_admin_review(statuses: tuple = (FeedbackStatus.NEW,)) -> int:
+    """How many un-clustered reports are waiting on an admin decision (issue #793).
+
+    The inverse of `get_unprocessed_feedback(admin_only=True)`: everything the auto-filer skipped.
+    Reported by `process_new_feedback` so a silent backlog is visible without opening the panel."""
+    wanted = [str(s) for s in (statuses or ()) if str(s) in tuple(FeedbackStatus)]
+    if not wanted:
+        return 0
+    join, join_params = _admin_reporter_join()
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute(
+            f"SELECT COUNT(*) FROM feedback f {join} "
+            f"WHERE f.status IN ({','.join(['%s'] * len(wanted))}) AND f.cluster_id IS NULL "
+            "AND au.id IS NULL",
+            (*join_params, *wanted))
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+    except mysql.connector.Error as err:
+        log_error("Could not count feedback pending admin review", exc=err)
+        return 0
     finally:
         cursor.close()
         connection.close()
@@ -8634,8 +8685,18 @@ def update_feedback_triage(feedback_id: int,
         connection.close()
 
 
+def admin_email_allowlist() -> set:
+    """Emails from ADMIN_USER_EMAILS, lowercased (issue #793). Empty adds nobody."""
+    from cqc_lem.utilities.env_constants import ADMIN_USER_EMAILS
+    return {e.strip().lower() for e in (ADMIN_USER_EMAILS or "").split(",") if e.strip()}
+
+
 def is_user_admin(user_id: int) -> bool:
     """Whether this user is designated as an admin (issue #793).
+
+    Admin is the users.is_admin column OR a match in the ADMIN_USER_EMAILS allowlist — the latter
+    exists so a deploy with no flagged user yet can still reach the triage panel and release the
+    feedback the auto-filer is now parking.
 
     Fails CLOSED — a missing user or DB error is never interpreted as admin rights."""
     if user_id is None:
@@ -8643,9 +8704,13 @@ def is_user_admin(user_id: int) -> bool:
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
     try:
-        cursor.execute("SELECT is_admin FROM users WHERE id = %s", (int(user_id),))
+        cursor.execute("SELECT is_admin, email FROM users WHERE id = %s", (int(user_id),))
         row = cursor.fetchone()
-        return bool(row and row.get("is_admin"))
+        if not row:
+            return False
+        if row.get("is_admin"):
+            return True
+        return (row.get("email") or "").strip().lower() in admin_email_allowlist()
     except mysql.connector.Error as err:
         log_error(f"Could not check admin status for user_id {user_id}", exc=err)
         return False

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -369,6 +369,12 @@ else:
 
 ADMIN_SECRET = get_constant_from_env('ADMIN_SECRET')
 
+# --- Feedback triage admins (issue #793) ---
+# Comma-separated emails that count as admins on top of the users.is_admin column. This is the
+# bootstrap path: without at least one admin, non-admin feedback parks forever and nobody can reach
+# the triage panel to release it. Empty adds nobody — the gate stays closed, never open.
+ADMIN_USER_EMAILS = get_constant_from_env('ADMIN_USER_EMAILS', default_value='')
+
 # Comma-separated bearer tokens accepted on /api routes. Empty disables the gate
 # (local/dev) so only deployments that set it enforce token auth.
 API_ACCESS_TOKENS = get_constant_from_env('API_ACCESS_TOKENS', default_value='')

--- a/src/cqc_lem/utilities/feedback/issue_service.py
+++ b/src/cqc_lem/utilities/feedback/issue_service.py
@@ -50,7 +50,7 @@ from typing import Optional
 from cqc_lem.utilities.ai.content_framework import as_vector, cosine_similarity, text_similarity
 from cqc_lem.utilities.db import (
     FeedbackStatus, count_feedback_filed_by_user, get_open_feedback_clusters,
-    get_unprocessed_feedback, update_feedback_triage,
+    get_unprocessed_feedback, is_user_admin, update_feedback_triage,
 )
 from cqc_lem.utilities.feedback.classifier import (
     MAX_BODY_CHARS, NEEDS_HUMAN_LABEL, RISK_LABELS, FeedbackCategory, FeedbackClassification,
@@ -693,14 +693,27 @@ def file_feedback_issue(feedback: dict, classification: FeedbackClassification =
                             "reporter_count": reporter_count})
 
 
+def _row_is_admin(row: dict) -> bool:
+    """Issue #793: only feedback from designated admin users may be auto-triaged into the GitHub
+    work cycle. Anonymous feedback is treated as non-admin and stays pending review."""
+    user_id = row.get("user_id")
+    return is_user_admin(user_id) if user_id is not None else False
+
+
 def process_new_feedback(limit: int = 25) -> dict:
     """Drain the capture queue: classify, dedup, and file each unprocessed feedback row. The open
     clusters are loaded ONCE and grown in memory as issues are filed, so a burst of identical
-    reports in one pass produces one issue and N-1 +1 comments."""
+    reports in one pass produces one issue and N-1 +1 comments.
+
+    Issue #793: only rows from admin users are filed automatically. Non-admin feedback is left in
+    `new` status so the admin triage panel can approve or dismiss it."""
     rows = get_unprocessed_feedback(limit)
     clusters = get_open_feedback_clusters()
     counts: dict = {}
     for row in rows:
+        if not _row_is_admin(row):
+            counts["pending_review"] = counts.get("pending_review", 0) + 1
+            continue
         try:
             result = file_feedback_issue(row, clusters=clusters)
         except Exception as e:
@@ -729,6 +742,10 @@ def recluster_feedback(limit: int = 200) -> dict:
     attached = 0
     embedded = 0
     for row in rows:
+        # Issue #793: non-admin feedback must not be silently clustered (and therefore accepted)
+        # before an admin reviews it.
+        if not _row_is_admin(row):
+            continue
         body = row.get("body") or ""
         if not body.strip():
             continue

--- a/src/cqc_lem/utilities/feedback/issue_service.py
+++ b/src/cqc_lem/utilities/feedback/issue_service.py
@@ -49,8 +49,8 @@ from typing import Optional
 
 from cqc_lem.utilities.ai.content_framework import as_vector, cosine_similarity, text_similarity
 from cqc_lem.utilities.db import (
-    FeedbackStatus, count_feedback_filed_by_user, get_open_feedback_clusters,
-    get_unprocessed_feedback, is_user_admin, update_feedback_triage,
+    FeedbackStatus, count_feedback_filed_by_user, count_pending_admin_review,
+    get_open_feedback_clusters, get_unprocessed_feedback, update_feedback_triage,
 )
 from cqc_lem.utilities.feedback.classifier import (
     MAX_BODY_CHARS, NEEDS_HUMAN_LABEL, RISK_LABELS, FeedbackCategory, FeedbackClassification,
@@ -693,27 +693,21 @@ def file_feedback_issue(feedback: dict, classification: FeedbackClassification =
                             "reporter_count": reporter_count})
 
 
-def _row_is_admin(row: dict) -> bool:
-    """Issue #793: only feedback from designated admin users may be auto-triaged into the GitHub
-    work cycle. Anonymous feedback is treated as non-admin and stays pending review."""
-    user_id = row.get("user_id")
-    return is_user_admin(user_id) if user_id is not None else False
-
-
 def process_new_feedback(limit: int = 25) -> dict:
     """Drain the capture queue: classify, dedup, and file each unprocessed feedback row. The open
     clusters are loaded ONCE and grown in memory as issues are filed, so a burst of identical
     reports in one pass produces one issue and N-1 +1 comments.
 
     Issue #793: only rows from admin users are filed automatically. Non-admin feedback is left in
-    `new` status so the admin triage panel can approve or dismiss it."""
-    rows = get_unprocessed_feedback(limit)
+    `new` status so the admin triage panel can approve or dismiss it — the filter is applied by the
+    query (`admin_only`), not here, so parked rows can never crowd admin rows out of `limit`."""
+    rows = get_unprocessed_feedback(limit, admin_only=True)
     clusters = get_open_feedback_clusters()
     counts: dict = {}
+    pending = count_pending_admin_review()
+    if pending:
+        counts["pending_review"] = pending
     for row in rows:
-        if not _row_is_admin(row):
-            counts["pending_review"] = counts.get("pending_review", 0) + 1
-            continue
         try:
             result = file_feedback_issue(row, clusters=clusters)
         except Exception as e:
@@ -738,14 +732,14 @@ def recluster_feedback(limit: int = 200) -> dict:
     clusters = get_open_feedback_clusters()
     # Unlike the filing pass, this one also reconsiders rows already parked in `triaged` — a report
     # a human never got to may well be the same problem as an issue filed since.
-    rows = get_unprocessed_feedback(limit, statuses=(FeedbackStatus.NEW, FeedbackStatus.TRIAGED))
+    # Issue #793: admin_only — non-admin feedback must not be silently clustered (and therefore
+    # accepted) before an admin reviews it, and filtering in SQL keeps parked rows from consuming
+    # the whole `limit` window pass after pass.
+    rows = get_unprocessed_feedback(limit, statuses=(FeedbackStatus.NEW, FeedbackStatus.TRIAGED),
+                                    admin_only=True)
     attached = 0
     embedded = 0
     for row in rows:
-        # Issue #793: non-admin feedback must not be silently clustered (and therefore accepted)
-        # before an admin reviews it.
-        if not _row_is_admin(row):
-            continue
         body = row.get("body") or ""
         if not body.strip():
             continue

--- a/tests/unit/api/test_feedback_admin_api.py
+++ b/tests/unit/api/test_feedback_admin_api.py
@@ -1,0 +1,151 @@
+"""Unit tests for the feedback admin triage panel endpoints (issue #793)."""
+
+import json
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+_SECRET = "admin-s3cret"
+_ADMIN_USER = {"id": 7, "email": "admin@example.com", "is_admin": True}
+_NON_ADMIN_USER = {"id": 8, "email": "user@example.com", "is_admin": False}
+
+
+def _auth(user):
+    return {
+        "get_session": patch("cqc_lem.api.main.get_session_user_id", return_value=user["id"]),
+        "is_admin": patch("cqc_lem.api.main.is_user_admin", return_value=user["is_admin"]),
+        "get_email": patch("cqc_lem.api.main.get_user_email", return_value=user["email"]),
+    }
+
+
+class TestListFeedback:
+    def test_forbidden_for_non_admin(self, client):
+        with _auth(_NON_ADMIN_USER)["get_session"], _auth(_NON_ADMIN_USER)["is_admin"]:
+            r = client.get("/api/admin/feedback", params={"session_token": "tok"})
+        assert r.status_code == 403
+
+    def test_401_for_invalid_session(self, client):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None):
+            r = client.get("/api/admin/feedback", params={"session_token": "bad"})
+        assert r.status_code == 401
+
+    def test_returns_items_for_admin(self, client):
+        row = {
+            "id": 1, "user_id": 2, "email": "user@x.com", "is_admin": 0,
+            "source": "widget", "type_hint": "bug", "body": "broken",
+            "context_json": json.dumps({"route": "/"}), "status": "new",
+            "cluster_id": None, "github_issue_number": None,
+            "reviewed_by": None, "reviewed_at": None,
+            "created_at": "2026-07-29T12:00:00Z",
+        }
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"], \
+             patch("cqc_lem.api.main.get_feedback_list", return_value=[row]) as lister:
+            r = client.get("/api/admin/feedback", params={
+                "session_token": "tok", "status": "new", "source": "widget",
+                "limit": 10, "offset": 5,
+            })
+        assert r.status_code == 200
+        assert r.json()["detail"]["items"][0]["email"] == "user@x.com"
+        assert r.json()["detail"]["items"][0]["is_admin_reporter"] is False
+        lister.assert_called_once_with(status="new", source="widget", limit=10, offset=5)
+
+    def test_no_session_param_is_422(self, client):
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"]:
+            r = client.get("/api/admin/feedback")
+        assert r.status_code == 422
+
+
+class TestReviewFeedback:
+    def test_dismiss_action_for_admin(self, client):
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"], \
+             patch("cqc_lem.api.main.get_feedback_by_id", return_value={"id": 3}), \
+             patch("cqc_lem.api.main.record_feedback_review", return_value=True) as recorder:
+            r = client.post("/api/admin/feedback/3/review", json={
+                "session_token": "tok", "action": "dismiss",
+            })
+        assert r.status_code == 200
+        assert r.json()["detail"]["action"] == "dismissed"
+        recorder.assert_called_once_with(3, 7, status="dismissed")
+
+    def test_approve_action_runs_filer_and_records_reviewer(self, client):
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"], \
+             patch("cqc_lem.api.main.get_feedback_by_id", return_value={"id": 5}), \
+             patch("cqc_lem.utilities.feedback.issue_service.file_feedback_issue",
+                   return_value={"action": "filed", "issue_number": 101}) as filer, \
+             patch("cqc_lem.api.main.record_feedback_review", return_value=True) as recorder:
+            r = client.post("/api/admin/feedback/5/review", json={
+                "session_token": "tok", "action": "approve",
+            })
+        assert r.status_code == 200
+        assert r.json()["detail"]["filing_result"]["issue_number"] == 101
+        filer.assert_called_once_with({"id": 5})
+        recorder.assert_called_once_with(5, 7)
+
+    def test_404_when_feedback_row_missing(self, client):
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"], \
+             patch("cqc_lem.api.main.get_feedback_by_id", return_value=None):
+            r = client.post("/api/admin/feedback/99/review", json={
+                "session_token": "tok", "action": "dismiss",
+            })
+        assert r.status_code == 404
+
+    def test_forbidden_for_non_admin(self, client):
+        with _auth(_NON_ADMIN_USER)["get_session"], _auth(_NON_ADMIN_USER)["is_admin"]:
+            r = client.post("/api/admin/feedback/1/review", json={
+                "session_token": "tok", "action": "dismiss",
+            })
+        assert r.status_code == 403
+
+    def test_invalid_action_is_422(self, client):
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"]:
+            r = client.post("/api/admin/feedback/1/review", json={
+                "session_token": "tok", "action": "banish",
+            })
+        assert r.status_code == 422
+
+    def test_missing_session_is_422(self, client):
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"]:
+            r = client.post("/api/admin/feedback/1/review", json={"action": "dismiss"})
+        assert r.status_code == 422
+
+
+class TestSessionExposesAdminFlag:
+    def test_auth_session_includes_is_admin(self, client):
+        profile = {
+            "subscription_tier": "professional",
+            "subscription_status": "active",
+            "timezone": "UTC",
+            "created_at": None,
+            "onboarding_completed_at": None,
+            "posts_approved": 0,
+        }
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=7), \
+             patch("cqc_lem.api.main.get_user_email", return_value="admin@x.com"), \
+             patch("cqc_lem.api.main.get_user_analytics_profile", return_value=profile), \
+             patch("cqc_lem.api.main.is_user_admin", return_value=True):
+            r = client.get("/api/auth/session", params={"session_token": "tok"})
+        assert r.status_code == 200
+        assert r.json()["detail"]["is_admin"] is True

--- a/tests/unit/api/test_feedback_admin_api.py
+++ b/tests/unit/api/test_feedback_admin_api.py
@@ -28,7 +28,6 @@ def client():
             p.stop()
 
 
-_SECRET = "admin-s3cret"
 _ADMIN_USER = {"id": 7, "email": "admin@example.com", "is_admin": True}
 _NON_ADMIN_USER = {"id": 8, "email": "user@example.com", "is_admin": False}
 
@@ -103,6 +102,42 @@ class TestReviewFeedback:
         assert r.json()["detail"]["filing_result"]["issue_number"] == 101
         filer.assert_called_once_with({"id": 5})
         recorder.assert_called_once_with(5, 7)
+
+    def test_already_filed_row_cannot_be_re_approved(self, client):
+        """A filed row IS its own open cluster, so re-running the filer would match it to itself
+        and post a false "+1 another report" on the issue it created."""
+        row = {"id": 9, "status": "issue_created", "github_issue_number": 404}
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"], \
+             patch("cqc_lem.api.main.get_feedback_by_id", return_value=row), \
+             patch("cqc_lem.utilities.feedback.issue_service.file_feedback_issue") as filer, \
+             patch("cqc_lem.api.main.record_feedback_review") as recorder:
+            r = client.post("/api/admin/feedback/9/review", json={
+                "session_token": "tok", "action": "approve",
+            })
+        assert r.status_code == 409
+        filer.assert_not_called()
+        recorder.assert_not_called()
+
+    def test_already_clustered_row_cannot_be_dismissed(self, client):
+        row = {"id": 10, "status": "clustered", "github_issue_number": None}
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"], \
+             patch("cqc_lem.api.main.get_feedback_by_id", return_value=row), \
+             patch("cqc_lem.api.main.record_feedback_review") as recorder:
+            r = client.post("/api/admin/feedback/10/review", json={
+                "session_token": "tok", "action": "dismiss",
+            })
+        assert r.status_code == 409
+        recorder.assert_not_called()
+
+    def test_new_row_is_still_reviewable(self, client):
+        row = {"id": 11, "status": "new", "github_issue_number": None}
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"], \
+             patch("cqc_lem.api.main.get_feedback_by_id", return_value=row), \
+             patch("cqc_lem.api.main.record_feedback_review", return_value=True):
+            r = client.post("/api/admin/feedback/11/review", json={
+                "session_token": "tok", "action": "dismiss",
+            })
+        assert r.status_code == 200
 
     def test_404_when_feedback_row_missing(self, client):
         with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"], \

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -239,12 +239,14 @@ class TestAuthCheckSession:
     def test_valid_session_returns_user_id_and_email(self, client):
         with patch(f"{_MAIN}.get_session_user_id", return_value=7), \
              patch(f"{_MAIN}.get_user_email", return_value="me@example.com"), \
-             patch(f"{_MAIN}.get_user_analytics_profile", return_value={}):
+             patch(f"{_MAIN}.get_user_analytics_profile", return_value={}), \
+             patch(f"{_MAIN}.is_user_admin", return_value=False):
             resp = client.get(self.BASE, params={"session_token": "valid-token-abc"})
         assert resp.status_code == 200
         detail = resp.json()["detail"]
         assert detail["user_id"] == 7
         assert detail["email"] == "me@example.com"
+        assert detail["is_admin"] is False
 
     def test_returns_person_facts_for_posthog_identify(self, client):
         profile = {
@@ -257,7 +259,8 @@ class TestAuthCheckSession:
         }
         with patch(f"{_MAIN}.get_session_user_id", return_value=7), \
              patch(f"{_MAIN}.get_user_email", return_value="me@example.com"), \
-             patch(f"{_MAIN}.get_user_analytics_profile", return_value=profile):
+             patch(f"{_MAIN}.get_user_analytics_profile", return_value=profile), \
+             patch(f"{_MAIN}.is_user_admin", return_value=True):
             resp = client.get(self.BASE, params={"session_token": "valid-token-abc"})
         detail = resp.json()["detail"]
         assert detail["plan"] == "premium"
@@ -267,11 +270,13 @@ class TestAuthCheckSession:
         # What PostHog Surveys target on (issue #653).
         assert detail["onboarding_completed_at"] == "2026-02-03T04:05:06Z"
         assert detail["posts_approved"] == 12
+        assert detail["is_admin"] is True
 
     def test_missing_profile_row_leaves_person_facts_null(self, client):
         with patch(f"{_MAIN}.get_session_user_id", return_value=7), \
              patch(f"{_MAIN}.get_user_email", return_value="me@example.com"), \
-             patch(f"{_MAIN}.get_user_analytics_profile", return_value={}):
+             patch(f"{_MAIN}.get_user_analytics_profile", return_value={}), \
+             patch(f"{_MAIN}.is_user_admin", return_value=False):
             resp = client.get(self.BASE, params={"session_token": "valid-token-abc"})
         detail = resp.json()["detail"]
         assert detail["plan"] is None
@@ -281,6 +286,7 @@ class TestAuthCheckSession:
         assert detail["onboarding_completed_at"] is None
         # A user who has approved nothing is 0, never null — the survey rule is a `>=` comparison.
         assert detail["posts_approved"] == 0
+        assert detail["is_admin"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utilities/test_db_feedback.py
+++ b/tests/unit/utilities/test_db_feedback.py
@@ -439,6 +439,28 @@ class TestGetFeedbackList:
         assert "f.source = %s" in sql
         assert params == ("new", "widget", 2, 0)
 
+    def test_embedding_is_not_dragged_into_the_panel(self):
+        """A page of 50 rows would pull 50 full vectors MySQL-side for a column the panel never
+        renders."""
+        conn, cur = _dict_conn(rows=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_feedback_list
+            get_feedback_list()
+        assert "embedding" not in cur.execute.call_args[0][0]
+
+    def test_allowlisted_reporter_reads_as_admin(self, monkeypatch):
+        """The auto-filer's join counts ADMIN_USER_EMAILS as admin, so their reports ARE filed
+        automatically — the panel must not show them as still awaiting review."""
+        monkeypatch.setattr("cqc_lem.utilities.env_constants.ADMIN_USER_EMAILS",
+                            "owner@example.com")
+        conn, _ = _dict_conn(rows=[{"id": 1, "email": " Owner@Example.com ", "is_admin": 0},
+                                   {"id": 2, "email": "someone@example.com", "is_admin": 0},
+                                   {"id": 3, "email": None, "is_admin": None}])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_feedback_list
+            got = get_feedback_list()
+        assert [r["is_admin"] for r in got] == [1, 0, None]
+
     def test_invalid_status_returns_empty(self):
         with patch(f"{_DB}.get_db_connection") as get_conn:
             from cqc_lem.utilities.db import get_feedback_list

--- a/tests/unit/utilities/test_db_feedback.py
+++ b/tests/unit/utilities/test_db_feedback.py
@@ -131,9 +131,10 @@ class TestGetUnprocessedFeedback:
             from cqc_lem.utilities.db import get_unprocessed_feedback
             assert get_unprocessed_feedback(limit=5) == [{"id": 1}]
         sql, params = cur.execute.call_args[0]
-        assert "status IN (%s)" in sql
-        assert "cluster_id IS NULL" in sql
-        assert "ORDER BY created_at ASC, id ASC" in sql
+        assert "f.status IN (%s)" in sql
+        assert "f.cluster_id IS NULL" in sql
+        assert "ORDER BY f.created_at ASC, f.id ASC" in sql
+        assert "JOIN users" not in sql                    # no admin filter unless asked for
         assert params == ("new", 5)
 
     def test_widened_statuses_are_all_bound_as_parameters(self):
@@ -143,8 +144,33 @@ class TestGetUnprocessedFeedback:
             get_unprocessed_feedback(limit=9, statuses=(FeedbackStatus.NEW,
                                                         FeedbackStatus.TRIAGED))
         sql, params = cur.execute.call_args[0]
-        assert "status IN (%s,%s)" in sql
+        assert "f.status IN (%s,%s)" in sql
         assert params == ("new", "triaged", 9)
+
+    def test_admin_only_filters_in_sql_not_in_the_caller(self, monkeypatch):
+        """Issue #793: parked non-admin rows stay `new` with a NULL cluster forever, so if the
+        filter lived in the caller's loop they would fill `limit` every pass and starve admin
+        feedback out of the queue permanently."""
+        monkeypatch.setattr("cqc_lem.utilities.env_constants.ADMIN_USER_EMAILS", "")
+        conn, cur = _dict_conn(rows=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_unprocessed_feedback
+            get_unprocessed_feedback(limit=7, admin_only=True)
+        sql, params = cur.execute.call_args[0]
+        assert "LEFT JOIN users au ON au.id = f.user_id AND (au.is_admin = 1)" in sql
+        assert "AND au.id IS NOT NULL" in sql
+        assert params == ("new", 7)
+
+    def test_admin_only_honours_the_email_allowlist(self, monkeypatch):
+        monkeypatch.setattr("cqc_lem.utilities.env_constants.ADMIN_USER_EMAILS",
+                            " Owner@Example.com , second@example.com ")
+        conn, cur = _dict_conn(rows=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_unprocessed_feedback
+            get_unprocessed_feedback(limit=3, admin_only=True)
+        sql, params = cur.execute.call_args[0]
+        assert "LOWER(au.email) IN (%s,%s)" in sql
+        assert params == ("owner@example.com", "second@example.com", "new", 3)
 
     def test_unknown_status_values_are_rejected_without_touching_db(self):
         with patch(f"{_DB}.get_db_connection") as get_conn:
@@ -301,12 +327,12 @@ class TestUpdateFeedbackTriage:
 
 class TestIsUserAdmin:
     def test_true_when_row_has_is_admin(self):
-        conn, cur = _dict_conn(one={"is_admin": 1})
+        conn, cur = _dict_conn(one={"is_admin": 1, "email": "someone@example.com"})
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import is_user_admin
             assert is_user_admin(5) is True
         sql, params = cur.execute.call_args[0]
-        assert "SELECT is_admin FROM users" in sql
+        assert "SELECT is_admin, email FROM users" in sql
         assert params == (5,)
 
     def test_false_when_row_missing(self):
@@ -315,8 +341,26 @@ class TestIsUserAdmin:
             from cqc_lem.utilities.db import is_user_admin
             assert is_user_admin(5) is False
 
-    def test_false_when_row_is_zero(self):
-        conn, cur = _dict_conn(one={"is_admin": 0})
+    def test_false_when_row_is_zero(self, monkeypatch):
+        monkeypatch.setattr("cqc_lem.utilities.env_constants.ADMIN_USER_EMAILS", "")
+        conn, cur = _dict_conn(one={"is_admin": 0, "email": "someone@example.com"})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import is_user_admin
+            assert is_user_admin(5) is False
+
+    def test_email_allowlist_grants_admin_when_the_column_is_zero(self, monkeypatch):
+        """Bootstrap path (#793): with no flagged user the auto-filer parks everything and nobody
+        can reach the panel to release it."""
+        monkeypatch.setattr("cqc_lem.utilities.env_constants.ADMIN_USER_EMAILS",
+                            "owner@example.com")
+        conn, _ = _dict_conn(one={"is_admin": 0, "email": " Owner@Example.com "})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import is_user_admin
+            assert is_user_admin(5) is True
+
+    def test_empty_allowlist_grants_nobody(self, monkeypatch):
+        monkeypatch.setattr("cqc_lem.utilities.env_constants.ADMIN_USER_EMAILS", "  ,  ")
+        conn, _ = _dict_conn(one={"is_admin": 0, "email": ""})
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import is_user_admin
             assert is_user_admin(5) is False
@@ -334,6 +378,39 @@ class TestIsUserAdmin:
         with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
             from cqc_lem.utilities.db import is_user_admin
             assert is_user_admin(5) is False
+
+
+class TestCountPendingAdminReview:
+    def test_counts_the_rows_the_auto_filer_skipped(self, monkeypatch):
+        monkeypatch.setattr("cqc_lem.utilities.env_constants.ADMIN_USER_EMAILS", "")
+        conn, cur = _dict_conn(one=(4,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_pending_admin_review
+            assert count_pending_admin_review() == 4
+        sql, params = cur.execute.call_args[0]
+        assert "AND au.id IS NULL" in sql                 # the NON-admin half of the same join
+        assert "f.cluster_id IS NULL" in sql
+        assert params == ("new",)
+
+    def test_no_row_is_zero(self):
+        conn, _ = _dict_conn(one=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import count_pending_admin_review
+            assert count_pending_admin_review() == 0
+
+    def test_unknown_status_never_touches_the_db(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            from cqc_lem.utilities.db import count_pending_admin_review
+            assert count_pending_admin_review(statuses=("'; DROP TABLE feedback; --",)) == 0
+        get_conn.assert_not_called()
+
+    def test_db_error_is_zero(self):
+        import mysql.connector
+        conn, cur = _dict_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import count_pending_admin_review
+            assert count_pending_admin_review() == 0
 
 
 class TestGetFeedbackList:

--- a/tests/unit/utilities/test_db_feedback.py
+++ b/tests/unit/utilities/test_db_feedback.py
@@ -1,6 +1,7 @@
 """Unit tests for the feedback DB helper (issue #496)."""
 
 import json
+from datetime import datetime, timezone
 
 import pytest
 from unittest.mock import MagicMock, patch
@@ -296,3 +297,127 @@ class TestUpdateFeedbackTriage:
             with patch(f"{_DB}.get_db_connection", return_value=conn):
                 assert update_feedback_triage(3, status=member) is True
             assert cur.execute.call_args[0][1] == (member.value, 3)
+
+
+class TestIsUserAdmin:
+    def test_true_when_row_has_is_admin(self):
+        conn, cur = _dict_conn(one={"is_admin": 1})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import is_user_admin
+            assert is_user_admin(5) is True
+        sql, params = cur.execute.call_args[0]
+        assert "SELECT is_admin FROM users" in sql
+        assert params == (5,)
+
+    def test_false_when_row_missing(self):
+        conn, cur = _dict_conn(one=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import is_user_admin
+            assert is_user_admin(5) is False
+
+    def test_false_when_row_is_zero(self):
+        conn, cur = _dict_conn(one={"is_admin": 0})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import is_user_admin
+            assert is_user_admin(5) is False
+
+    def test_none_user_id_is_false(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            from cqc_lem.utilities.db import is_user_admin
+            assert is_user_admin(None) is False
+        get_conn.assert_not_called()
+
+    def test_db_error_is_false(self):
+        import mysql.connector
+        conn, cur = _dict_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import is_user_admin
+            assert is_user_admin(5) is False
+
+
+class TestGetFeedbackList:
+    def test_returns_rows_joined_with_user_email(self):
+        conn, cur = _dict_conn(rows=[{"id": 1, "email": "a@x.com", "is_admin": 1,
+                                     "status": "new", "source": "widget"}])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_feedback_list
+            got = get_feedback_list(limit=5, offset=10)
+        assert got == [{"id": 1, "email": "a@x.com", "is_admin": 1,
+                        "status": "new", "source": "widget"}]
+        sql, params = cur.execute.call_args[0]
+        assert "FROM feedback f LEFT JOIN users u" in sql
+        assert "ORDER BY f.created_at DESC" in sql
+        assert "LIMIT %s OFFSET %s" in sql
+        assert params == (5, 10)
+
+    def test_status_filter_is_validated_and_bound(self):
+        conn, cur = _dict_conn(rows=[])
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_feedback_list, FeedbackStatus
+            from cqc_lem.utilities.db import FeedbackSource
+            get_feedback_list(status=FeedbackStatus.NEW, source=FeedbackSource.WIDGET, limit=2)
+        sql, params = cur.execute.call_args[0]
+        assert "f.status = %s" in sql
+        assert "f.source = %s" in sql
+        assert params == ("new", "widget", 2, 0)
+
+    def test_invalid_status_returns_empty(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn:
+            from cqc_lem.utilities.db import get_feedback_list
+            assert get_feedback_list(status="not-a-status") == []
+        get_conn.assert_not_called()
+
+    def test_db_error_returns_empty_list(self):
+        import mysql.connector
+        conn, cur = _dict_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import get_feedback_list
+            assert get_feedback_list() == []
+
+
+class TestRecordFeedbackReview:
+    def test_records_reviewer_and_status(self):
+        conn, cur = _dict_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+                patch(f"{_DB}.datetime") as dt:
+            from cqc_lem.utilities.db import record_feedback_review, FeedbackStatus
+            now = datetime(2026, 7, 29, 12, 0, 0, tzinfo=timezone.utc)
+            dt.now.return_value = now
+            assert record_feedback_review(7, 3, status=FeedbackStatus.DISMISSED) is True
+        sql, params = cur.execute.call_args[0]
+        assert "reviewed_by=%s, reviewed_at=%s, status=%s" in sql
+        assert params[:3] == (3, now.replace(tzinfo=None), "dismissed")
+        assert params[3] == 7
+        conn.commit.assert_called_once()
+
+    def test_can_record_reviewer_without_status(self):
+        conn, cur = _dict_conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_feedback_review
+            assert record_feedback_review(7, 3) is True
+        sql, params = cur.execute.call_args[0]
+        assert "status" not in sql
+        assert params[:1] == (3,)
+        assert params[2] == 7
+
+    def test_unknown_status_never_reaches_enum(self):
+        with patch(f"{_DB}.get_db_connection") as get_conn, patch(f"{_DB}.log_error") as log:
+            from cqc_lem.utilities.db import record_feedback_review
+            assert record_feedback_review(7, 3, status="pending") is False
+        get_conn.assert_not_called()
+        assert "pending" in log.call_args[0][0]
+
+    def test_missing_feedback_or_reviewer_is_false(self):
+        from cqc_lem.utilities.db import record_feedback_review
+        assert record_feedback_review(None, 3) is False
+        assert record_feedback_review(7, None) is False
+
+    def test_db_error_returns_false(self):
+        import mysql.connector
+        conn, cur = _dict_conn()
+        cur.execute.side_effect = mysql.connector.Error("boom")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import record_feedback_review
+            assert record_feedback_review(7, 3) is False

--- a/tests/unit/utilities/test_feedback_issue_service.py
+++ b/tests/unit/utilities/test_feedback_issue_service.py
@@ -836,7 +836,7 @@ class TestProcessNewFeedback:
                 {"id": 2, "user_id": 2, "body": "feed commenting stops after one comment"}]
         with patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
                 patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
-                patch(f"{_SVC}.is_user_admin", return_value=True), \
+                patch(f"{_SVC}.count_pending_admin_review", return_value=0), \
                 patch(f"{_SVC}.classify_feedback", return_value=_classification()), \
                 patch(f"{_SVC}.create_github_issue", return_value=900) as create, \
                 patch(f"{_SVC}.comment_on_issue", return_value=True) as comment, \
@@ -853,30 +853,32 @@ class TestProcessNewFeedback:
         rows = [{"id": 1, "user_id": 1, "body": "a"}, {"id": 2, "user_id": 2, "body": "b"}]
         with patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
                 patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
-                patch(f"{_SVC}.is_user_admin", return_value=True), \
+                patch(f"{_SVC}.count_pending_admin_review", return_value=0), \
                 patch(f"{_SVC}.file_feedback_issue",
                       side_effect=[RuntimeError("boom"), {"action": "filed"}]):
             result = svc.process_new_feedback()
         assert result == {"processed": 2, "counts": {"error": 1, "filed": 1}}
 
-    def test_non_admin_feedback_is_held_for_review(self):
+    def test_only_admin_rows_are_asked_for_and_the_backlog_is_reported(self):
+        """Issue #793: the admin filter must be pushed into the query. Non-admin rows keep their
+        new/NULL-cluster shape forever, so a caller-side skip would refill `limit` with the same
+        parked rows every pass and admin feedback would never be reached again."""
         svc = _mod()
-        rows = [{"id": 1, "user_id": 1, "body": "admin feedback"},
-                {"id": 2, "user_id": 2, "body": "user feedback"},
-                {"id": 3, "user_id": None, "body": "anonymous feedback"}]
-        with patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+        rows = [{"id": 1, "user_id": 1, "body": "admin feedback"}]
+        with patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows) as loader, \
                 patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
-                patch(f"{_SVC}.is_user_admin",
-                      side_effect=lambda uid: uid == 1), \
+                patch(f"{_SVC}.count_pending_admin_review", return_value=2), \
                 patch(f"{_SVC}.file_feedback_issue", return_value={"action": "filed"}) as filer:
             result = svc.process_new_feedback(limit=10)
-        assert result == {"processed": 3, "counts": {"filed": 1, "pending_review": 2}}
+        assert loader.call_args.kwargs["admin_only"] is True
+        assert result == {"processed": 1, "counts": {"filed": 1, "pending_review": 2}}
         filer.assert_called_once_with(rows[0], clusters=[])
 
     def test_empty_queue_is_a_no_op(self):
         svc = _mod()
         with patch(f"{_SVC}.get_unprocessed_feedback", return_value=[]), \
                 patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.count_pending_admin_review", return_value=0), \
                 patch(f"{_SVC}.create_github_issue") as create:
             assert svc.process_new_feedback() == {"processed": 0, "counts": {}}
         create.assert_not_called()
@@ -890,7 +892,6 @@ class TestReclusterFeedback:
         rows = [{"id": 30, "user_id": 5, "body": "replies do not post", "embedding": [1.0, 0.0]}]
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=clusters), \
                 patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
-                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.comment_on_issue", return_value=True) as comment, \
                 patch(f"{_SVC}.update_feedback_triage") as triage, \
                 patch(f"{_SVC}.embed_text") as embed:
@@ -906,7 +907,6 @@ class TestReclusterFeedback:
         rows = [{"id": 31, "user_id": 5, "body": "billing charged me twice"}]
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
                 patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
-                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.embed_text", return_value=[0.0, 1.0]), \
                 patch(f"{_SVC}.update_feedback_triage") as triage:
             result = svc.recluster_feedback()
@@ -919,7 +919,6 @@ class TestReclusterFeedback:
         rows = [{"id": 32, "user_id": 5, "body": "something brand new"}]
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
                 patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
-                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.embed_text", return_value=None), \
                 patch(f"{_SVC}.create_github_issue") as create, \
                 patch(f"{_SVC}.update_feedback_triage"):
@@ -930,8 +929,7 @@ class TestReclusterFeedback:
         from cqc_lem.utilities.db import FeedbackStatus
         svc = _mod()
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
-                patch(f"{_SVC}.get_unprocessed_feedback", return_value=[]) as loader, \
-                patch(f"{_SVC}.is_user_admin", return_value=True):
+                patch(f"{_SVC}.get_unprocessed_feedback", return_value=[]) as loader:
             svc.recluster_feedback(limit=50)
         assert loader.call_args[0][0] == 50
         assert loader.call_args.kwargs["statuses"] == (FeedbackStatus.NEW, FeedbackStatus.TRIAGED)
@@ -942,7 +940,6 @@ class TestReclusterFeedback:
         rows = [{"id": 33, "user_id": 5, "body": "replies do not post", "embedding": [1.0, 0.0]}]
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=clusters), \
                 patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
-                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.comment_on_issue", return_value=False), \
                 patch(f"{_SVC}.update_feedback_triage") as triage:
             result = svc.recluster_feedback()
@@ -954,25 +951,19 @@ class TestReclusterFeedback:
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
                 patch(f"{_SVC}.get_unprocessed_feedback",
                       return_value=[{"id": 34, "body": "  "}]), \
-                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.embed_text") as embed:
             result = svc.recluster_feedback()
         assert result == {"scanned": 1, "attached": 0, "embedded": 0, "clusters": 0}
         embed.assert_not_called()
 
     def test_non_admin_feedback_is_not_silently_reclustered(self):
+        """Issue #793: reclustering accepts a report into an existing issue, so it must be gated
+        the same way filing is — and gated in SQL, not by skipping rows the query returned."""
         svc = _mod()
-        clusters = [_cluster(7, "comments never post", 101, embedding=[1.0, 0.0])]
-        rows = [{"id": 35, "user_id": 2, "body": "replies do not post", "embedding": [1.0, 0.0]}]
-        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=clusters), \
-                patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
-                patch(f"{_SVC}.is_user_admin", return_value=False), \
-                patch(f"{_SVC}.comment_on_issue") as comment, \
-                patch(f"{_SVC}.update_feedback_triage") as triage:
-            result = svc.recluster_feedback()
-        assert result == {"scanned": 1, "attached": 0, "embedded": 0, "clusters": 1}
-        comment.assert_not_called()
-        triage.assert_not_called()
+        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.get_unprocessed_feedback", return_value=[]) as loader:
+            svc.recluster_feedback()
+        assert loader.call_args.kwargs["admin_only"] is True
 
 
 class TestEnvReaders:

--- a/tests/unit/utilities/test_feedback_issue_service.py
+++ b/tests/unit/utilities/test_feedback_issue_service.py
@@ -836,6 +836,7 @@ class TestProcessNewFeedback:
                 {"id": 2, "user_id": 2, "body": "feed commenting stops after one comment"}]
         with patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
                 patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.classify_feedback", return_value=_classification()), \
                 patch(f"{_SVC}.create_github_issue", return_value=900) as create, \
                 patch(f"{_SVC}.comment_on_issue", return_value=True) as comment, \
@@ -852,10 +853,25 @@ class TestProcessNewFeedback:
         rows = [{"id": 1, "user_id": 1, "body": "a"}, {"id": 2, "user_id": 2, "body": "b"}]
         with patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
                 patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.file_feedback_issue",
                       side_effect=[RuntimeError("boom"), {"action": "filed"}]):
             result = svc.process_new_feedback()
         assert result == {"processed": 2, "counts": {"error": 1, "filed": 1}}
+
+    def test_non_admin_feedback_is_held_for_review(self):
+        svc = _mod()
+        rows = [{"id": 1, "user_id": 1, "body": "admin feedback"},
+                {"id": 2, "user_id": 2, "body": "user feedback"},
+                {"id": 3, "user_id": None, "body": "anonymous feedback"}]
+        with patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
+                patch(f"{_SVC}.is_user_admin",
+                      side_effect=lambda uid: uid == 1), \
+                patch(f"{_SVC}.file_feedback_issue", return_value={"action": "filed"}) as filer:
+            result = svc.process_new_feedback(limit=10)
+        assert result == {"processed": 3, "counts": {"filed": 1, "pending_review": 2}}
+        filer.assert_called_once_with(rows[0], clusters=[])
 
     def test_empty_queue_is_a_no_op(self):
         svc = _mod()
@@ -874,6 +890,7 @@ class TestReclusterFeedback:
         rows = [{"id": 30, "user_id": 5, "body": "replies do not post", "embedding": [1.0, 0.0]}]
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=clusters), \
                 patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.comment_on_issue", return_value=True) as comment, \
                 patch(f"{_SVC}.update_feedback_triage") as triage, \
                 patch(f"{_SVC}.embed_text") as embed:
@@ -889,6 +906,7 @@ class TestReclusterFeedback:
         rows = [{"id": 31, "user_id": 5, "body": "billing charged me twice"}]
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
                 patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.embed_text", return_value=[0.0, 1.0]), \
                 patch(f"{_SVC}.update_feedback_triage") as triage:
             result = svc.recluster_feedback()
@@ -901,6 +919,7 @@ class TestReclusterFeedback:
         rows = [{"id": 32, "user_id": 5, "body": "something brand new"}]
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
                 patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.embed_text", return_value=None), \
                 patch(f"{_SVC}.create_github_issue") as create, \
                 patch(f"{_SVC}.update_feedback_triage"):
@@ -911,7 +930,8 @@ class TestReclusterFeedback:
         from cqc_lem.utilities.db import FeedbackStatus
         svc = _mod()
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
-                patch(f"{_SVC}.get_unprocessed_feedback", return_value=[]) as loader:
+                patch(f"{_SVC}.get_unprocessed_feedback", return_value=[]) as loader, \
+                patch(f"{_SVC}.is_user_admin", return_value=True):
             svc.recluster_feedback(limit=50)
         assert loader.call_args[0][0] == 50
         assert loader.call_args.kwargs["statuses"] == (FeedbackStatus.NEW, FeedbackStatus.TRIAGED)
@@ -922,6 +942,7 @@ class TestReclusterFeedback:
         rows = [{"id": 33, "user_id": 5, "body": "replies do not post", "embedding": [1.0, 0.0]}]
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=clusters), \
                 patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.comment_on_issue", return_value=False), \
                 patch(f"{_SVC}.update_feedback_triage") as triage:
             result = svc.recluster_feedback()
@@ -933,10 +954,25 @@ class TestReclusterFeedback:
         with patch(f"{_SVC}.get_open_feedback_clusters", return_value=[]), \
                 patch(f"{_SVC}.get_unprocessed_feedback",
                       return_value=[{"id": 34, "body": "  "}]), \
+                patch(f"{_SVC}.is_user_admin", return_value=True), \
                 patch(f"{_SVC}.embed_text") as embed:
             result = svc.recluster_feedback()
         assert result == {"scanned": 1, "attached": 0, "embedded": 0, "clusters": 0}
         embed.assert_not_called()
+
+    def test_non_admin_feedback_is_not_silently_reclustered(self):
+        svc = _mod()
+        clusters = [_cluster(7, "comments never post", 101, embedding=[1.0, 0.0])]
+        rows = [{"id": 35, "user_id": 2, "body": "replies do not post", "embedding": [1.0, 0.0]}]
+        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=clusters), \
+                patch(f"{_SVC}.get_unprocessed_feedback", return_value=rows), \
+                patch(f"{_SVC}.is_user_admin", return_value=False), \
+                patch(f"{_SVC}.comment_on_issue") as comment, \
+                patch(f"{_SVC}.update_feedback_triage") as triage:
+            result = svc.recluster_feedback()
+        assert result == {"scanned": 1, "attached": 0, "embedded": 0, "clusters": 1}
+        comment.assert_not_called()
+        triage.assert_not_called()
 
 
 class TestEnvReaders:


### PR DESCRIPTION
## What & why

Feedback submitted in-app was auto-filed into the GitHub work cycle for **every** reporter. #793 asks for an admin gate: only admin users' feedback should be auto-triaged; everyone else's waits for a human decision in an in-app panel.

Owner answered the Decision Comment on the issue with `1A` — build it now.

**The gate**
- `users.is_admin` designates admins; `ADMIN_USER_EMAILS` (comma-separated, empty by default) is an additional allowlist.
- `process_new_feedback` / `auto_recluster_feedback` only act on admin reports. Everything else stays `new` until reviewed.
- Reclustering is gated too — attaching a report to an open cluster *accepts* it, so it needs the same check as filing.

**The panel**
- `GET /api/admin/feedback` (status/source filters, paging) and `POST /api/admin/feedback/{id}/review` with `approve` | `dismiss`. Approve runs the normal classifier/filer path; dismiss sets status `dismissed`. Both stamp `feedback.reviewed_by` / `reviewed_at`.
- Auth is a user-level admin role (`_require_user_admin` → 401/403), distinct from the operational `X-Admin-Secret` endpoints.
- SPA: `/admin/feedback` behind `AdminRoute`, nav entry shown only to admins, `is_admin` added to the session response.

### Two things worth a close look

1. **The gate filters in SQL, not in the loop.** Parked non-admin rows keep their `new` + NULL-cluster shape forever. A caller-side skip meant that once `limit` of them sat at the head of the FIFO, admin feedback would never be reached again — a permanent, silent stall of the auto-work loop. `get_unprocessed_feedback(admin_only=True)` does it in the query instead. `count_pending_admin_review()` reports the parked backlog on every pass so it can't grow unseen.
2. **Bootstrap.** `is_admin` defaults to 0, so without a seed *no* user is an admin: the filer would park every report and nobody could reach the panel to release them. The migration seeds the founding account (`UPDATE users SET is_admin = 1 ORDER BY id ASC LIMIT 1`, a no-op on an empty table) and `ADMIN_USER_EMAILS` is the no-SQL path for any other deploy. Both fail closed — empty grants nobody, and a DB error is never read as admin rights.

## Migration

`V20260729194956__add_feedback_admin_review.sql` — additive: `users.is_admin TINYINT(1) NOT NULL DEFAULT 0`, `feedback.reviewed_by` / `reviewed_at` + index, plus the one-row bootstrap `UPDATE` above. Nothing dropped or rewritten.

## Testing

- `poetry run pytest tests/unit -q` → **8574 passed**.
- New/updated: `tests/unit/api/test_feedback_admin_api.py` (403/401/422/404 paths, approve runs the filer + records the reviewer, dismiss, `is_admin` on the session), `tests/unit/utilities/test_db_feedback.py` (`is_user_admin` incl. allowlist + fail-closed, `admin_only` SQL shape, `count_pending_admin_review`), `tests/unit/utilities/test_feedback_issue_service.py` (both passes ask for `admin_only=True`; backlog is reported).
- `npx tsc --noEmit` clean. Vitest (incl. the new `AdminFeedbackPage.test.tsx`) runs in CI on Node 22 — local Node 18 can't start it.

Closes #793

🤖 Generated with [Claude Code](https://claude.com/claude-code)