### PR TITLE
feat(selenium): pin watchable sessions to the debug Grid node (closes #753)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -803,6 +803,10 @@ SELENIUM_GRID_NODES=8
 # The watchable debug node is a NINTH node on top of that pool, so it is excluded from the capacity
 # monitor's saturation denominator by the name it registers under. Empty disables the exclusion.
 SELENIUM_DEBUG_NODE_HOST=selenium-node-debug
+# Opt-in flag for ad-hoc code that uses selenium_util.get_docker_driver(): when true, request the
+# watchable debug node if it has a free slot; otherwise fall back to the pool. Normal Celery lanes
+# never read this — they use the 8 production nodes by default. See docs/SELENIUM_GRID.md.
+#SELENIUM_DEBUG_NODE=true
 # Bind address for the debug node's noVNC (7900). Loopback like every other published port here.
 SELENIUM_GRID_VNC_BIND=127.0.0.1
 # The address an OPERATOR'S BROWSER reaches the Grid on (the tunnel hostname, e.g.

--- a/docker-compose.grid.yml
+++ b/docker-compose.grid.yml
@@ -150,6 +150,10 @@ services:
       - SE_NODE_OVERRIDE_MAX_SESSIONS=true
       - SE_NODE_SESSION_TIMEOUT=600
       - SE_LOG_LEVEL=WARN
+      # Distinguish this node from the pool with a custom capability so clients can
+      # request it deliberately. SE_NODE_STEREOTYPE_EXTRA merges into the default
+      # browser stereotype instead of replacing it. See docs/SELENIUM_GRID.md.
+      - SE_NODE_STEREOTYPE_EXTRA='{"lem:debug":true}'
       # The name this node REGISTERS under, so `/status` reports its uri as
       # `http://selenium-node-debug:5555` instead of a per-restart container IP. That is what lets
       # the capacity monitor drop this node from the saturation denominator

--- a/docs/SELENIUM_GRID.md
+++ b/docs/SELENIUM_GRID.md
@@ -141,6 +141,27 @@ production slot. Two caveats:
 Both 4444 and the event bus bind to **loopback** by default (`SELENIUM_GRID_HUB_BIND`,
 `SELENIUM_GRID_BUS_BIND`), matching how `docker-compose.prod.yml` hardens the standalone today.
 
+#### Pinning a session to the debug node
+
+The debug node advertises a custom capability, `lem:debug`, via `SE_NODE_STEREOTYPE_EXTRA`.
+Clients that want to **watch the exact session** can request that capability:
+
+* **Live-validation probe:** `python -c "..." < scripts/linkedin_live_validation.py --watch ...`
+* **Selenium MCP server:** `SELENIUM_DEBUG_NODE=true poetry run python tools/selenium_mcp_server.py`
+* **Ad-hoc code using `get_docker_driver()`:** `SELENIUM_DEBUG_NODE=true` is read automatically
+  when the caller does not pass an explicit `debug=` argument.
+
+When the debug node is busy or absent, the helper silently falls back to the normal pool —
+a debugging convenience must never block production work. An unflagged session never requests
+`lem:debug`, so normal automation stays on the 8 production nodes.
+
+To watch the pinned session end-to-end:
+
+1. Start the session with one of the opt-ins above.
+2. Open noVNC on the debug node: `http://localhost:7900/?autoconnect=1&password=secret`
+   (or the tunnel hostname if working remotely).
+3. The session you care about is the one rendered there.
+
 ---
 
 ## 3. The load test

--- a/scripts/linkedin_live_validation.py
+++ b/scripts/linkedin_live_validation.py
@@ -489,6 +489,9 @@ def main(argv: Optional[list] = None) -> int:
                         help="open LinkedIn's article editor and report each publish step's selector "
                              "state (#771/#804); pass a custom URL or use the default. Read-only: "
                              "nothing is typed and no control is clicked, so publish reads UNKNOWN")
+    parser.add_argument("--watch", action="store_true",
+                        help="request the watchable Grid debug node so the session is visible via "
+                             "noVNC; falls back to the pool if the debug node is busy/absent")
     args = parser.parse_args(argv)
 
     if not (args.post_url or args.probe_composer or args.comment_outcome_url or args.dm_thread_url
@@ -500,7 +503,8 @@ def main(argv: Optional[list] = None) -> int:
     from cqc_lem.utilities.selenium_util import quit_gracefully
 
     driver, _wait, _email, profile = get_current_profile(user_id=args.user_id,
-                                                        session_name="Live Validation")
+                                                        session_name="Live Validation",
+                                                        debug=args.watch)
     report = {"user_id": args.user_id}
     try:
         if args.post_url:

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -6413,19 +6413,22 @@ def update_stale_profile(self, user_id: int):
 
 
 def get_current_profile(user_id: int, session_name: str = "Get Current Profile",
-                        measurement_only: bool = False) -> Tuple[
+                        measurement_only: bool = False, debug: bool = False) -> Tuple[
     WebDriver, WebDriverWait, str, LinkedInProfile]:
     """Update the profile of the user.
 
     `measurement_only` marks a read-only stat-capture session, which keeps running under the
     suppression tripwire's own pause (and only that one) so recovery stays measurable — see
-    rate_limit.is_measurement_paused."""
+    rate_limit.is_measurement_paused.
+
+    `debug` requests the watchable Grid debug node (if free) for live inspection; it falls
+    back to the normal pool when the node is busy or absent."""
 
     myprint("Getting Updated Profile")
 
     user_email, user_password = get_user_password_pair_by_id(user_id)
 
-    driver, wait = get_driver_wait_pair(session_name=session_name, user_id=user_id)
+    driver, wait = get_driver_wait_pair(session_name=session_name, user_id=user_id, debug=debug)
 
     # Login first — a failure here (e.g. HTTP 429 rate-limit, expired cookie) is fatal
     # for this run; abort cleanly so the caller backs off instead of hammering LinkedIn.

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -105,7 +105,11 @@ def _wait_for_selenium_ready(host: str, port: str, timeout: int = 60) -> None:
 
 
 def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", coordinates: dict = None,
-                      user_id: int = None, lat: float = None, lng: float = None) -> webdriver.Remote:
+                      user_id: int = None, lat: float = None, lng: float = None,
+                      debug: bool = None) -> webdriver.Remote:
+    if debug is None:
+        debug = isTrue(os.getenv("SELENIUM_DEBUG_NODE", "False"))
+
     if DEVICE_FARM_PROJECT_ARN and TEST_GRID_PROJECT_ARN:
         remote_url = get_aws_device_farm_url(DEVICE_FARM_PROJECT_ARN, TEST_GRID_PROJECT_ARN)
     else:
@@ -164,6 +168,7 @@ def get_docker_driver(headless: bool = True, session_name: str = "ChromeTests", 
     options.set_capability("se:timeZone", user_timezone)
     options.set_capability("se:screenResolution", "1920x1080")
     options.set_capability("se:name", f"CQC_LEM ({session_name})")
+    apply_debug_node(options, debug)
 
     # A free slot answers in seconds; a full pool blocks HERE until one frees up, which is the only
     # direct measurement of the session cap being the binding constraint (capacity_alerts §552).
@@ -268,6 +273,57 @@ def _proxy_label(proxy_url: Optional[str]) -> str:
         return f"{parsed.hostname}:{parsed.port}" if parsed.port else parsed.hostname
     except Exception:
         return "invalid"
+
+
+SELENIUM_DEBUG_CAPABILITY = "lem:debug"
+
+
+def _debug_node_has_free_slot() -> bool:
+    """True if the Grid's watchable debug node has a free session slot right now."""
+    if not SELENIUM_DEBUG_NODE_HOST:
+        return False
+    try:
+        url = f"http://{SELENIUM_HUB_HOST}:{SELENIUM_HUB_PORT}/status"
+        response = requests.get(url, timeout=5)
+        response.raise_for_status()
+        nodes = (response.json().get("value") or {}).get("nodes") or []
+    except Exception:
+        return False
+
+    for node in nodes:
+        uri = str(node.get("uri") or "")
+        if f"//{SELENIUM_DEBUG_NODE_HOST}:" not in uri:
+            continue
+        for slot in node.get("slots") or []:
+            if not slot.get("session"):
+                return True
+        return False  # found the node, but every slot is claimed
+    return False  # debug node is not registered
+
+
+def apply_debug_node(options: Options, debug: bool = False) -> bool:
+    """Best-effort pin a session to the watchable Grid debug node.
+
+    Adds the ``lem:debug`` capability only when ``debug`` is requested AND the Grid
+    has a registered ``SELENIUM_DEBUG_NODE_HOST`` with a free slot. Otherwise the
+    caller falls back to the normal pool, so a debugging convenience never blocks
+    real work by queueing on a busy debug node. Returns True if the capability was
+    added.
+    """
+    if not debug:
+        return False
+    if not SELENIUM_DEBUG_NODE_HOST:
+        log_warning("Debug node requested but SELENIUM_DEBUG_NODE_HOST is empty; using pool",
+                    action_type="login")
+        return False
+    if _debug_node_has_free_slot():
+        options.set_capability(SELENIUM_DEBUG_CAPABILITY, True)
+        log_info(f"Pinning session to debug node {SELENIUM_DEBUG_NODE_HOST}",
+                 action_type="login")
+        return True
+    log_warning(f"Debug node {SELENIUM_DEBUG_NODE_HOST} busy or absent; using pool",
+                action_type="login")
+    return False
 
 
 def apply_proxy(options: Options, proxy_url: str) -> None:
@@ -688,12 +744,12 @@ def get_driver_wait(driver, wait_time: int = None):
 
 
 def get_driver_wait_pair(headless=False, session_name: str = "ChromeTests", max_retry=3, coordinates: dict = None,
-                         user_id: int = None):
+                         user_id: int = None, debug: bool = None):
     # Create the driver. Passing user_id applies that user's geo/timezone/locale spoofing.
     for attempt in range(max_retry):
         try:
             driver = get_docker_driver(headless=headless, session_name=session_name, coordinates=coordinates,
-                                       user_id=user_id)
+                                       user_id=user_id, debug=debug)
             break  # Exit the loop if successful
         except SessionNotCreatedException as e:
             if attempt == max_retry - 1:

--- a/tests/unit/utilities/test_selenium_debug_node.py
+++ b/tests/unit/utilities/test_selenium_debug_node.py
@@ -1,0 +1,134 @@
+"""Unit tests for the Grid debug-node opt-in pin (issue #753)."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from selenium.webdriver.chrome.options import Options
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.selenium_util"
+
+
+def _status_response(debug_host: str, slots: list[dict]):
+    """Build a mock Grid /status response with one debug node."""
+    response = MagicMock(status_code=200)
+    response.json.return_value = {
+        "value": {
+            "nodes": [
+                {"uri": f"http://{debug_host}:5555", "slots": slots},
+                {"uri": "http://selenium-node-chrome-1:5555", "slots": [{"session": None}]},
+            ]
+        }
+    }
+    return response
+
+
+class TestApplyDebugNode:
+    def test_adds_capability_when_debug_requested_and_node_free(self):
+        options = Options()
+        response = _status_response("selenium-node-debug", [{"session": None}])
+        with patch(f"{_MOD}.requests.get", return_value=response), \
+             patch(f"{_MOD}.SELENIUM_DEBUG_NODE_HOST", "selenium-node-debug"), \
+             patch(f"{_MOD}.SELENIUM_HUB_HOST", "selenium-hub"), \
+             patch(f"{_MOD}.SELENIUM_HUB_PORT", "4444"), \
+             patch(f"{_MOD}.log_info"):
+            from cqc_lem.utilities.selenium_util import apply_debug_node, SELENIUM_DEBUG_CAPABILITY
+            assert apply_debug_node(options, debug=True) is True
+            assert options.to_capabilities().get(SELENIUM_DEBUG_CAPABILITY) is True
+
+    def test_no_capability_when_debug_not_requested(self):
+        options = Options()
+        response = _status_response("selenium-node-debug", [{"session": None}])
+        with patch(f"{_MOD}.requests.get", return_value=response), \
+             patch(f"{_MOD}.SELENIUM_DEBUG_NODE_HOST", "selenium-node-debug"), \
+             patch(f"{_MOD}.SELENIUM_HUB_HOST", "selenium-hub"), \
+             patch(f"{_MOD}.SELENIUM_HUB_PORT", "4444"):
+            from cqc_lem.utilities.selenium_util import apply_debug_node, SELENIUM_DEBUG_CAPABILITY
+            assert apply_debug_node(options, debug=False) is False
+            assert SELENIUM_DEBUG_CAPABILITY not in options.to_capabilities()
+
+    def test_falls_back_when_debug_node_is_busy(self):
+        options = Options()
+        response = _status_response("selenium-node-debug", [{"session": {"sessionId": "x"}}])
+        with patch(f"{_MOD}.requests.get", return_value=response), \
+             patch(f"{_MOD}.SELENIUM_DEBUG_NODE_HOST", "selenium-node-debug"), \
+             patch(f"{_MOD}.SELENIUM_HUB_HOST", "selenium-hub"), \
+             patch(f"{_MOD}.SELENIUM_HUB_PORT", "4444"), \
+             patch(f"{_MOD}.log_warning") as warn:
+            from cqc_lem.utilities.selenium_util import apply_debug_node, SELENIUM_DEBUG_CAPABILITY
+            assert apply_debug_node(options, debug=True) is False
+            assert SELENIUM_DEBUG_CAPABILITY not in options.to_capabilities()
+            warn.assert_called_once()
+
+    def test_falls_back_when_debug_node_not_registered(self):
+        options = Options()
+        response = MagicMock(status_code=200)
+        response.json.return_value = {"value": {"nodes": [
+            {"uri": "http://selenium-node-chrome-1:5555", "slots": [{"session": None}]},
+        ]}}
+        with patch(f"{_MOD}.requests.get", return_value=response), \
+             patch(f"{_MOD}.SELENIUM_DEBUG_NODE_HOST", "selenium-node-debug"), \
+             patch(f"{_MOD}.SELENIUM_HUB_HOST", "selenium-hub"), \
+             patch(f"{_MOD}.SELENIUM_HUB_PORT", "4444"), \
+             patch(f"{_MOD}.log_warning"):
+            from cqc_lem.utilities.selenium_util import apply_debug_node, SELENIUM_DEBUG_CAPABILITY
+            assert apply_debug_node(options, debug=True) is False
+            assert SELENIUM_DEBUG_CAPABILITY not in options.to_capabilities()
+
+    def test_falls_back_when_status_check_fails(self):
+        options = Options()
+        with patch(f"{_MOD}.requests.get", side_effect=Exception("hub down")), \
+             patch(f"{_MOD}.SELENIUM_DEBUG_NODE_HOST", "selenium-node-debug"), \
+             patch(f"{_MOD}.SELENIUM_HUB_HOST", "selenium-hub"), \
+             patch(f"{_MOD}.SELENIUM_HUB_PORT", "4444"), \
+             patch(f"{_MOD}.log_warning"):
+            from cqc_lem.utilities.selenium_util import apply_debug_node, SELENIUM_DEBUG_CAPABILITY
+            assert apply_debug_node(options, debug=True) is False
+            assert SELENIUM_DEBUG_CAPABILITY not in options.to_capabilities()
+
+    def test_falls_back_when_debug_host_not_configured(self):
+        options = Options()
+        with patch(f"{_MOD}.SELENIUM_DEBUG_NODE_HOST", ""), \
+             patch(f"{_MOD}.log_warning"):
+            from cqc_lem.utilities.selenium_util import apply_debug_node, SELENIUM_DEBUG_CAPABILITY
+            assert apply_debug_node(options, debug=True) is False
+            assert SELENIUM_DEBUG_CAPABILITY not in options.to_capabilities()
+
+
+class TestGetDockerDriverDebug:
+    def _run(self, *, env_value, explicit_debug):
+        fake_driver = MagicMock()
+        with patch(f"{_MOD}.os.getenv", return_value=env_value), \
+             patch(f"{_MOD}.apply_debug_node") as apply, \
+             patch(f"{_MOD}._wait_for_selenium_ready"), \
+             patch(f"{_MOD}.DEVICE_FARM_PROJECT_ARN", None), \
+             patch(f"{_MOD}.TEST_GRID_PROJECT_ARN", None), \
+             patch(f"{_MOD}.getBaseOptions", return_value=Options()), \
+             patch(f"{_MOD}.webdriver.Remote", return_value=fake_driver), \
+             patch(f"{_MOD}._record_session_wait"), \
+             patch("cqc_lem.utilities.db.get_user_geo", return_value=None), \
+             patch("cqc_lem.utilities.db.get_user_proxy", return_value=None):
+            from cqc_lem.utilities.selenium_util import get_docker_driver
+            get_docker_driver(user_id=1, debug=explicit_debug)
+            apply.assert_called_once()
+            return apply.call_args[0][1]
+
+    def test_env_var_requests_debug_when_no_explicit_flag(self):
+        """When debug=None, get_docker_driver reads SELENIUM_DEBUG_NODE env var."""
+        assert self._run(env_value="true", explicit_debug=None) is True
+
+    def test_explicit_debug_false_overrides_env(self):
+        assert self._run(env_value="true", explicit_debug=False) is False
+
+
+class TestComposeDebugStereotype:
+    def test_debug_node_advertises_lem_debug_stereotype(self):
+        grid = (Path(__file__).resolve().parents[3] / "docker-compose.grid.yml").read_text()
+        debug_block = grid.split("\n  selenium-node-debug:\n")[1].split("\n  selenium-chrome:")[0]
+        assert "SE_NODE_STEREOTYPE_EXTRA" in debug_block
+        assert '"lem:debug":true' in debug_block
+        # The pool nodes must NOT advertise the same capability.
+        pool_block = grid.split("\n  selenium-node-chrome:\n")[1].split("\n  selenium-node-debug:")[0]
+        assert "lem:debug" not in pool_block

--- a/tools/selenium_mcp_server.py
+++ b/tools/selenium_mcp_server.py
@@ -23,6 +23,9 @@ from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
 
+from cqc_lem.utilities.env_constants import isTrue
+from cqc_lem.utilities.selenium_util import apply_debug_node
+
 mcp = FastMCP("selenium-lem")
 
 _BY = {
@@ -54,6 +57,8 @@ def start_browser() -> str:
         return f"Session already open at {_driver().current_url}"
     options = Options()
     options.set_capability("se:timeZone", os.getenv("SE_TIMEZONE", "America/New_York"))
+    # Opt-in pin to the watchable debug node; falls back to the pool if the node is busy/absent.
+    apply_debug_node(options, isTrue(os.getenv("SELENIUM_DEBUG_NODE", "False")))
     _state["driver"] = webdriver.Remote(command_executor=_remote_url(), options=options)
     _state["driver"].set_window_size(1920, 1080)
     return f"Connected to {_remote_url()}"


### PR DESCRIPTION
## What
Adds an opt-in capability path so a debugging session can be deliberately routed to the watchable `selenium-node-debug` Grid node, with automatic fallback to the normal pool if the debug node is busy or absent.

## Changes
- `docker-compose.grid.yml`: `selenium-node-debug` now advertises a `lem:debug` capability via `SE_NODE_STEREOTYPE_EXTRA`.
- `src/cqc_lem/utilities/selenium_util.py`: new `apply_debug_node()` helper checks Grid `/status` and only adds `lem:debug` when the node has a free slot; `get_docker_driver()`/`get_driver_wait_pair()` gain a `debug` flag (default reads `SELENIUM_DEBUG_NODE` env var).
- `src/cqc_lem/app/run_automation.py`: `get_current_profile()` accepts `debug` and passes it through.
- `scripts/linkedin_live_validation.py`: new `--watch` flag requests the debug node.
- `tools/selenium_mcp_server.py`: honors `SELENIUM_DEBUG_NODE=true` env var.
- `docs/SELENIUM_GRID.md`: documents the stereotype + capability flow and how to watch the pinned session end-to-end.
- `tests/unit/utilities/test_selenium_debug_node.py`: unit tests for capability wiring and busy/absent/unconfigured fallback.

## Testing
- `poetry run pytest tests/unit/utilities/test_selenium_debug_node.py -v` → 9 passed.
- `poetry run pytest tests/unit -q` → 8636 passed.

## Live verification note
This change was implemented headlessly; a live run should confirm that:
1. A session started with `--watch` / `SELENIUM_DEBUG_NODE=true` lands on `selenium-node-debug` (visible in `/status` and via noVNC on `localhost:7900`).
2. An unflagged session does NOT land on the debug node.

The capacity monitor already excludes the debug node from the saturation denominator via `capacity_alerts._pool_slots()`, so the 9th slot is not treated as headroom the lanes can use.

Closes #753

🤖 Generated with [Claude Code](https://claude.com/claude-code)