### PR TITLE
fix(ci): fast lane must wait for release-please, not for "a release PR exists"

### DIFF
--- a/.github/workflows/release-auto-merge.yml
+++ b/.github/workflows/release-auto-merge.yml
@@ -51,26 +51,48 @@ jobs:
       (github.event.pull_request.merged == true &&
        contains(github.event.pull_request.labels.*.name, 'release:now'))
     steps:
-      # release-please reacts to the same merge this job does, so on the fast lane the release PR
-      # may not exist or may not yet include this commit. Wait for it rather than racing.
-      - name: Wait for release-please to update the release PR
+      # Wait for release-please's OWN run for this merge commit to finish — not merely for "a
+      # release PR to exist". Those are different conditions and the difference broke a release:
+      #
+      # A release PR is almost always already open (it accumulates between windows), so the old
+      # "does one exist?" check passed instantly and enqueued a release PR that predated the very
+      # commit being fast-laned. Worse, a PR sitting in the merge queue has its branch LOCKED, so
+      # release-please then failed with `Error updating ref heads/release-please--branches--main`
+      # and could never add the commit. Result: v0.115.0 was one green check away from shipping
+      # WITHOUT the security PR that triggered the fast lane, and the release PR was wedged.
+      #
+      # release-please's run for MERGE_SHA completing is the real signal: the release PR is current
+      # as of this commit, and release-please is done touching the branch, so enqueuing is safe.
+      - name: Wait for release-please to finish processing this merge
         if: github.event_name == 'pull_request_target'
         env:
           GH_TOKEN: ${{ secrets.RELEASE_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
         run: |
-          for i in $(seq 1 20); do
-            PR="$(gh pr list --repo "$REPO" --state open --json number,headRefName \
-                  --jq '[.[] | select(.headRefName | startswith("release-please--"))][0].number // empty')"
-            if [ -n "$PR" ]; then
-              echo "Release PR #$PR is open (attempt $i)."
-              exit 0
-            fi
-            echo "No release PR yet (attempt $i/20) — waiting 15s for release-please."
+          if [ -z "$MERGE_SHA" ]; then
+            echo "::warning title=Fast lane skipped::no merge commit sha on the event payload."
+            exit 0
+          fi
+          for i in $(seq 1 40); do
+            STATE="$(gh run list --repo "$REPO" --workflow=release-please.yml --commit "$MERGE_SHA" \
+                     --limit 1 --json status,conclusion \
+                     --jq '.[0] | "\(.status)/\(.conclusion)"' 2>/dev/null || echo "")"
+            case "$STATE" in
+              completed/success)
+                echo "release-please finished for $MERGE_SHA (attempt $i)."
+                exit 0 ;;
+              completed/*)
+                # A failed release-please means the release PR does NOT contain this commit.
+                # Enqueuing now would ship a release that silently omits it — the exact failure
+                # this step exists to prevent. Stop, and let the next window pick it up.
+                echo "::warning title=Fast lane stood down::release-please concluded '$STATE' for $MERGE_SHA, so the release PR does not include this commit. Not enqueuing; it will ship in the next scheduled window."
+                exit 0 ;;
+            esac
+            echo "release-please for $MERGE_SHA is '${STATE:-not started}' (attempt $i/40) — waiting 15s."
             sleep 15
           done
-          echo "::warning title=Fast lane timed out::release-please never opened a release PR; this change will ship in the next scheduled window."
+          echo "::warning title=Fast lane timed out::release-please never completed for $MERGE_SHA; this change will ship in the next scheduled window."
           exit 0
 
       - name: Find and auto-merge the open release-please PR

--- a/docs/release-fast-lane.md
+++ b/docs/release-fast-lane.md
@@ -51,11 +51,23 @@ user-visible commenting failure, priority:high"* — so the choice is auditable 
 
 1. PR merges with the label.
 2. `release-auto-merge.yml` fires on `pull_request_target: closed`, sees `merged == true` and the
-   label, and waits (up to 5 min) for release-please to open/refresh the release PR — release-please
-   is reacting to the same merge, so the PR often does not exist yet.
-3. It enables auto-merge on that release PR. The release PR still runs its own CI and still goes
+   label, and waits (up to 10 min) for **release-please's own run for this merge commit** to
+   conclude successfully.
+3. It enables auto-merge on the release PR. The release PR still runs its own CI and still goes
    through the merge queue, so **a fast-laned release can never ship a red build**.
 4. Tag → `Build & Deploy Release` → blue/green cutover.
+
+Step 2 waits on the *run*, not on "a release PR exists" — those look equivalent and are not. A
+release PR is almost always already open (it accumulates between windows), so an existence check
+passes instantly and enqueues a release PR that **predates the commit being fast-laned**. And a PR
+sitting in the merge queue has its branch locked, so release-please then fails with
+`Error updating ref heads/release-please--branches--main` and can never add the commit.
+
+That combination bit v0.115.0 on the fast lane's first real use: the release PR was one green check
+away from shipping *without* the security PR that triggered it, and was wedged besides. Recovery was
+to dequeue the release PR (which unlocks the branch), re-run release-please, and confirm the entry
+landed before re-enqueuing. If release-please **fails** for the merge commit, the fast lane now
+stands down deliberately rather than enqueue a release known to omit the change.
 
 A `concurrency` group serialises this: three `release:now` PRs merging together enqueue one release,
 not three.


### PR DESCRIPTION
Found by the `release:now` fast lane's **first real use** (#807, encrypt-at-rest) breaking the release it was meant to accelerate.

## What went wrong

The wait step looped until *a* release-please PR was open, then enabled auto-merge on it:

```bash
PR="$(gh pr list ... startswith("release-please--"))][0].number // empty')"
if [ -n "$PR" ]; then exit 0; fi
```

A release PR is **almost always already open** — it accumulates between windows. So the check passed on attempt 1 and enqueued a release PR that predated the commit being fast-laned. `MERGE_SHA` was declared in that step's `env:` and never referenced anywhere, which is the tell.

Then it deadlocks. A PR in the merge queue has its branch **locked**, so release-please's run for the merge failed:

```
✔ Successfully created commit … c1d82ae
✔ Updating reference heads/release-please--branches--main to c1d82ae
##[error] release-please failed: Error updating ref heads/release-please--branches--main
```

The release PR is now simultaneously **stale and unfixable** — every later merge fails the same way.

Observed live: `v0.115.0` (#841) contained #843/#840/#839 and **not** #807, with auto-merge enabled and checks running. It was one green check from shipping a security release whose changelog omitted the security change.

## Recovery performed

1. Dequeued #841 (`dequeuePullRequest`) — this unlocks the branch.
2. Re-ran the failed release-please run; it then succeeded.
3. Confirmed the entry landed before re-enabling auto-merge:
   ```
   * **security:** encrypt LinkedIn secrets at rest + cookie-only default (refs #745) (#807) (f514241)
   * **agent-pipeline:** reattach unpushed branches + phase guard reads what a PR actually closes (#832) (b92940d)
   ```

## The fix

Wait for release-please's **own run for `MERGE_SHA`** to conclude. Success means both things the old check only assumed: the release PR is current as of this commit, *and* release-please is done touching the branch, so enqueuing cannot race it.

A **failed** release-please run now makes the fast lane stand down with a `::warning` instead of enqueuing. Shipping in the next window beats shipping a release whose changelog quietly lies about what is in it — the failure mode is now "late", never "wrong".

Timeout widened 20×15s → 40×15s, since it now waits for a run to finish rather than for a PR to appear.

`docs/release-fast-lane.md` updated with the distinction and the recovery steps, since the two conditions look equivalent and are not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)