### PR TITLE
fix(security): don't let a failed cookie write delete the user's LinkedIn password (refs #745)

### DIFF
--- a/docs/secrets-at-rest.md
+++ b/docs/secrets-at-rest.md
@@ -70,10 +70,23 @@ overwritten, because a corrected key might still recover it.
 Watch the number it logs:
 
 ```
-Secret encryption backfill: 12 rewritten, 0 failed, 0 still unprotected
+Secret encryption backfill: 12 rewritten, 0 failed, 0 orphaned, 0 still unprotected
 ```
 
-`plaintext_remaining > 0` is logged as a WARNING. Run it on demand with:
+`plaintext_remaining > 0` is logged as a WARNING.
+
+**Orphaned rows** are `cookies` rows with no `user_id`. They cannot be encrypted (there is no user
+to bind the AAD to) and cannot be read back (`get_cookies` JOINs `users`) — a dead plaintext
+session. They count toward `plaintext_remaining` so the fail-closed gate can never read 0 while one
+exists, and the remedy is deletion, not encryption:
+
+```sql
+DELETE FROM cookies WHERE user_id IS NULL;
+```
+
+New ones can no longer be created: `_store_cookie_rows` refuses a write it cannot bind.
+
+Run the pass on demand with:
 
 ```bash
 docker exec celery_worker python -c \

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1505,7 +1505,8 @@ def auto_encrypt_secrets_at_rest(self):
         return "Encryption disabled (no LEM_SECRET_KEY) — nothing done"
     if stats.get("plaintext_remaining"):
         log_warning(f"{stats['plaintext_remaining']} secret(s) still unencrypted at rest "
-                    f"({stats.get('failed', 0)} failed to re-encrypt)",
+                    f"({stats.get('failed', 0)} failed to re-encrypt, "
+                    f"{stats.get('orphaned', 0)} orphaned cookie row(s) to delete)",
                     task_name="auto_encrypt_secrets_at_rest")
     return (f"Re-encrypted {stats.get('rewritten', 0)} secret(s); "
             f"{stats.get('plaintext_remaining', 0)} still unprotected")

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -452,14 +452,20 @@ _SECRET_UPDATE_SQL = {
 }
 
 
-def store_cookies(user_email: str, cookies: list[dict]) -> None:
+def store_cookies(user_email: str, cookies: list[dict]) -> bool:
+    """Persist the browser's cookies for this user. Returns False when any row failed to store.
+
+    The return value is load-bearing since #745: the cookie-migration path DELETES the user's
+    stored LinkedIn password once the session is "saved", so a swallowed per-row write error must
+    not read as success — that would take away the only login they had left.
+    """
     connection = get_db_connection()
     cursor = connection.cursor()
 
     user_id = get_user_id(user_email)
 
     try:
-        _store_cookie_rows(cursor, cookies, user_id)
+        failed = _store_cookie_rows(cursor, cookies, user_id)
         connection.commit()
     finally:
         cursor.close()
@@ -468,9 +474,24 @@ def store_cookies(user_email: str, cookies: list[dict]) -> None:
     if user_id is not None:
         prune_superseded_cookies(user_id)
 
+    return not failed
+
 
 def _store_cookie_rows(cursor: MySQLCursorAbstract, cookies: list[dict],
-                       user_id: Optional[int]) -> None:
+                       user_id: Optional[int]) -> list[str]:
+    """Insert/update each cookie row; returns the names of the ones that could NOT be stored.
+
+    Issue #745: a row with no user_id cannot be bound by the AAD, so encrypt_secret would store the
+    value as PLAINTEXT — and get_cookies JOINs users, so nothing could ever read it back. That
+    leaves a live li_at in the clear which encrypt_secrets_at_rest (scanning user-owned rows) would
+    never find. Refuse the write instead of creating an unreadable plaintext credential.
+    """
+    if user_id is None:
+        log_error("Refusing to store cookies with no user_id — the row could not be bound to a "
+                  "user, so it would be a plaintext session no read path can return")
+        return [str(cookie.get('name')) for cookie in cookies]
+
+    failed: list[str] = []
     for cookie in cookies:
         try:
             cursor.execute("""
@@ -496,6 +517,8 @@ def _store_cookie_rows(cursor: MySQLCursorAbstract, cookies: list[dict],
             ))
         except mysql.connector.Error as err:
             myprint(f"Could not add cookie to database | Error: {err}")
+            failed.append(str(cookie.get('name')))
+    return failed
 
 
 def prune_superseded_cookies(user_id: int) -> int:
@@ -593,7 +616,12 @@ def store_linkedin_li_at(user_id: int, li_at: str, jsessionid: Optional[str] = N
             "path": "/", "expiry": expiry, "secure": True, "httpOnly": False,
         })
     try:
-        store_cookies(email, cookies)
+        # Must reflect the actual write (issue #745): the caller drops the user's stored LinkedIn
+        # password on a True, and per-row insert errors are swallowed inside _store_cookie_rows.
+        if not store_cookies(email, cookies):
+            log_error("Could not store LinkedIn session cookie — no row was written",
+                      user_id=user_id)
+            return False
         return True
     except Exception as e:
         myprint(f"Could not store LinkedIn session cookie for user_id {user_id}: {e}")
@@ -2889,10 +2917,11 @@ def encrypt_secrets_at_rest(limit: Optional[int] = None) -> dict:
     overwriting it would destroy a secret that a corrected key might still recover.
 
     `plaintext_remaining` is the number the operator watches — once it reaches 0, `ENCRYPTION_REQUIRED`
-    can be flipped and the legacy read path fails closed.
+    can be flipped and the legacy read path fails closed. It includes `orphaned` (see below), so the
+    gate can never read 0 while a plaintext session is still sitting in a dump.
     """
     stats = {"enabled": encryption_enabled(), "scanned": 0, "rewritten": 0,
-             "failed": 0, "plaintext_remaining": 0}
+             "failed": 0, "orphaned": 0, "plaintext_remaining": 0}
     if not stats["enabled"]:
         log_warning("Secret encryption backfill skipped — no LEM_SECRET_KEY configured")
         return stats
@@ -2904,6 +2933,17 @@ def encrypt_secrets_at_rest(limit: Optional[int] = None) -> dict:
         user_rows = cursor.fetchall() or []
         cursor.execute("SELECT id, user_id, value FROM cookies WHERE user_id IS NOT NULL")
         cookie_rows = cursor.fetchall() or []
+        # Rows with no user_id cannot be encrypted (nothing to bind the AAD to) and cannot be read
+        # back (get_cookies JOINs users) — they are dead PLAINTEXT credentials. Counting them keeps
+        # them out of the operator's blind spot: without this, the gate reports "0 unprotected"
+        # while a legacy plaintext li_at is still in every dump. The remedy is deletion, not
+        # encryption, so this pass reports them and never touches them.
+        cursor.execute(
+            "SELECT COUNT(*) AS n FROM cookies WHERE user_id IS NULL AND value IS NOT NULL "
+            "AND value <> ''")
+        orphan_row = cursor.fetchone() or {}
+        stats["orphaned"] = int(orphan_row.get("n") or 0)
+        stats["plaintext_remaining"] += stats["orphaned"]
     except mysql.connector.Error as err:
         log_error(f"Could not read secrets for encryption backfill | Error: {err}")
         cursor.close()
@@ -2949,8 +2989,14 @@ def encrypt_secrets_at_rest(limit: Optional[int] = None) -> dict:
         cursor.close()
         connection.close()
 
+    if stats["orphaned"]:
+        log_error(f"{stats['orphaned']} cookie row(s) have no user_id — plaintext sessions that "
+                  f"cannot be encrypted or read. Delete them "
+                  f"(DELETE FROM cookies WHERE user_id IS NULL) before flipping "
+                  f"ENCRYPTION_REQUIRED.")
     log_info(f"Secret encryption backfill: {stats['rewritten']} rewritten, "
-             f"{stats['failed']} failed, {stats['plaintext_remaining']} still unprotected")
+             f"{stats['failed']} failed, {stats['orphaned']} orphaned, "
+             f"{stats['plaintext_remaining']} still unprotected")
     return stats
 
 

--- a/src/cqc_lem/utilities/linkedin/helper.py
+++ b/src/cqc_lem/utilities/linkedin/helper.py
@@ -12,7 +12,7 @@ from cqc_lem.utilities.linkedin.rate_limit import LinkedInRateLimited, clear_rat
     mark_rate_limited, rate_limit_cooldown_remaining, is_automation_paused, \
     automation_pause_remaining, is_measurement_paused
 from cqc_lem.utilities.linkedin.scrapper import returnProfileInfo
-from cqc_lem.utilities.logger import myprint, log_debug, log_warning
+from cqc_lem.utilities.logger import myprint, log_debug, log_error, log_warning
 from cqc_lem.utilities.selenium_util import load_cookies, get_element_wait_retry, \
     get_visible_element_wait_retry, getText
 from selenium.common.exceptions import WebDriverException
@@ -340,6 +340,23 @@ def drive_email_pin_challenge(driver, user_email: str, is_logged_in) -> bool:
     return is_logged_in(driver.current_url)
 
 
+def _persist_session_cookies(driver: WebDriver, user_email: str) -> bool:
+    """Store the freshly authenticated session and report honestly whether it landed.
+
+    `store_cookies` swallows per-row driver errors and refuses a write it cannot bind to a user
+    (issue #745), so a lost write is invisible here unless we look. The consequence is delayed and
+    silent: this run works, but the next one finds no li_at, falls back to a password login and
+    trips LinkedIn's new-device challenge — while the log said the cookies were saved.
+    """
+    stored = store_cookies(user_email, driver.get_cookies())
+    if not stored:
+        log_error("Could not persist LinkedIn session cookies — the next run will have no li_at "
+                  "and will fall back to a password login", action_type="login")
+        return False
+    myprint("Cookies stored to DB!")
+    return True
+
+
 def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, user_password: str,
                       measurement_only: bool = False):
     linked_url = "https://www.linkedin.com"
@@ -539,8 +556,7 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
     if _is_logged_in(driver.current_url):
         myprint(f"Already logged in! (current URL: {driver.current_url})")
         clear_rate_limit()
-        store_cookies(user_email, driver.get_cookies())
-        myprint("Cookies stored to DB!")
+        _persist_session_cookies(driver, user_email)
         return
 
     # We had a stored session cookie but it didn't authenticate — it's stale/expired.
@@ -624,8 +640,7 @@ def login_to_linkedin(driver: WebDriver, wait: WebDriverWait, user_email: str, u
     if _is_logged_in(driver.current_url):
         myprint("Login successful!")
         clear_rate_limit()
-        store_cookies(user_email, driver.get_cookies())
-        myprint("Cookies stored to DB!")
+        _persist_session_cookies(driver, user_email)
     else:
         myprint("Login failed. Check your credentials.")
 

--- a/tests/unit/utilities/linkedin/test_helper.py
+++ b/tests/unit/utilities/linkedin/test_helper.py
@@ -806,3 +806,27 @@ class TestHumanPause:
             h._human_pause(1.0, 2.0)
         uni.assert_called_once_with(1.0, 2.0)
         slept.assert_called_once_with(1.5)
+
+
+class TestPersistSessionCookies:
+    """store_cookies' bool is load-bearing (issue #745) — the login path must not claim a
+    session was saved when the write was refused or swallowed a driver error. A lost write is
+    invisible until the NEXT run falls back to a password login and trips the device challenge."""
+
+    def _run(self, stored):
+        from cqc_lem.utilities.linkedin.helper import _persist_session_cookies
+        driver = MagicMock()
+        driver.get_cookies.return_value = [{"name": "li_at"}]
+        with patch(f"{_MODULE}.store_cookies", return_value=stored), \
+             patch(f"{_MODULE}.log_error") as logged:
+            return _persist_session_cookies(driver, "a@b.com"), logged
+
+    def test_successful_write_is_reported_as_stored(self):
+        ok, logged = self._run(True)
+        assert ok is True
+        logged.assert_not_called()
+
+    def test_failed_write_is_surfaced_not_announced_as_success(self):
+        ok, logged = self._run(False)
+        assert ok is False
+        logged.assert_called_once()

--- a/tests/unit/utilities/test_db_secret_encryption.py
+++ b/tests/unit/utilities/test_db_secret_encryption.py
@@ -65,15 +65,33 @@ class TestCookieWrites:
         assert LI_AT not in str(_executed(cur))
         assert decrypt_secret(stored, 42, SECRET_FIELD_COOKIE_VALUE) == LI_AT
 
-    def test_orphan_cookie_without_a_user_is_still_stored(self, keyed, mock_database_connection):
-        """An unbindable row can't be sealed — it must not silently vanish either."""
+    def test_unbindable_cookie_is_refused_not_written_in_the_clear(self, keyed,
+                                                                   mock_database_connection):
+        """No user_id means no AAD to bind to, so the row would be written as PLAINTEXT — and
+        get_cookies JOINs users, so nothing could ever read it back. A dead plaintext li_at that
+        the backfill can't see is strictly worse than no row at all."""
         cur = mock_database_connection["cursor"]
         cookie = {"name": "li_at", "value": LI_AT, "domain": ".linkedin.com", "path": "/",
                   "expiry": 123, "secure": True, "httpOnly": True}
         with patch("cqc_lem.utilities.db.get_user_id", return_value=None):
-            store_cookies("nobody@example.com", [cookie])
-        stored = next(p[1] for s, p in _executed(cur) if "INSERT INTO cookies" in s)
-        assert stored == LI_AT
+            ok = store_cookies("nobody@example.com", [cookie])
+        assert ok is False
+        assert not any("INSERT INTO cookies" in s for s, _ in _executed(cur))
+        assert LI_AT not in str(_executed(cur))
+
+    def test_failed_write_is_reported_so_the_password_is_never_dropped(
+            self, keyed, mock_database_connection):
+        """store_linkedin_li_at's True is what authorises deleting the user's stored LinkedIn
+        password. _store_cookie_rows swallows per-row driver errors, so the failure has to travel
+        back out — otherwise a user loses the only login they had left."""
+        from cqc_lem.utilities.db import store_linkedin_li_at
+
+        cur = mock_database_connection["cursor"]
+        cur.execute.side_effect = mysql.connector.Error("cookie write failed")
+        with patch("cqc_lem.utilities.db.get_user_id", return_value=42), \
+             patch("cqc_lem.utilities.db.get_user_email", return_value="a@b.com"), \
+             patch("cqc_lem.utilities.db.prune_superseded_cookies"):
+            assert store_linkedin_li_at(42, LI_AT) is False
 
 
 class TestCookieReads:
@@ -247,8 +265,9 @@ class TestOAuthTokens:
 
 
 class TestBackfillAndRotation:
-    def _rows(self, cursor, users, cookies):
+    def _rows(self, cursor, users, cookies, orphans=0):
         cursor.fetchall.side_effect = [users, cookies]
+        cursor.fetchone.return_value = {"n": orphans}
 
     def test_disabled_without_a_key(self, mock_database_connection, monkeypatch):
         monkeypatch.delenv("LEM_SECRET_KEY", raising=False)
@@ -322,9 +341,24 @@ class TestBackfillAndRotation:
         cur = mock_database_connection["cursor"]
         self._rows(cur, [{"id": 1, "password": "pw", "access_token": None,
                           "refresh_token": None}], [])
-        cur.execute.side_effect = [None, None, mysql.connector.Error("boom")]
+        # users SELECT, cookies SELECT, orphan COUNT, then the UPDATE fails
+        cur.execute.side_effect = [None, None, None, mysql.connector.Error("boom")]
         stats = encrypt_secrets_at_rest()
         assert stats["rewritten"] == 0 and stats["plaintext_remaining"] == 1
+
+    def test_orphaned_plaintext_cookies_keep_the_gate_off_zero(self, keyed,
+                                                               mock_database_connection):
+        """A cookie row with no user_id can be neither encrypted nor read, but it IS a plaintext
+        session in every dump. If it didn't count, the operator would read 'nothing unprotected'
+        and flip ENCRYPTION_REQUIRED with live credentials still in the clear."""
+        cur = mock_database_connection["cursor"]
+        self._rows(cur, [], [], orphans=2)
+        stats = encrypt_secrets_at_rest()
+        assert stats["orphaned"] == 2
+        assert stats["plaintext_remaining"] == 2
+        # Reported, never rewritten — the remedy is deletion, not encryption.
+        assert stats["rewritten"] == 0
+        assert not any("UPDATE" in c[0][0] for c in cur.execute.call_args_list)
 
     def test_read_failure_returns_early(self, keyed, mock_database_connection):
         mock_database_connection["cursor"].execute.side_effect = mysql.connector.Error("boom")


### PR DESCRIPTION
Adversarial review of PR #807 (issue #745, secrets at rest). The review tick fired after #807 had already merged, so the two findings land here instead.

Both are in the seam between the cookie write and the new cookie-only migration path.

## 1. A failed cookie write reported success — and then deleted the password

`_store_cookie_rows` swallows `mysql.connector.Error` per row (pre-existing, and fine when the only consequence was a missing cookie). #807 made that consequence destructive: `store_cookies` returned `None`, `store_linkedin_li_at` returned `True` regardless, and `POST /user/linkedin-cookie` treats that `True` as "the cookie that replaces the password is safely stored" before calling `clear_user_linkedin_password`.

So any per-row driver error (FK violation from a concurrent delete, deadlock, connection blip) produced: no `li_at` stored, `200 "LinkedIn session saved"`, **and the user's only remaining engagement login deleted**. The PR body explicitly promises the opposite — "Only drop it once the cookie that replaces it is safely stored".

`store_cookies` now returns `False` when any row failed, and `store_linkedin_li_at` propagates it, so the endpoint raises 500 and never reaches the drop.

## 2. An unbindable cookie wrote plaintext `li_at` the backfill can't see

`encrypt_secret` returns the value **unchanged** when `user_id is None` (documented — there is no AAD to bind to). `store_cookies` gets its `user_id` from `get_user_id(user_email)`, which returns `None` on any DB error, not just an unknown email. So a transient failure immediately after a successful login wrote every cookie — `li_at` included — as **plaintext**.

That row is also unreadable forever (`get_cookies` JOINs `users`), and `encrypt_secrets_at_rest` scans `cookies WHERE user_id IS NOT NULL`. Net effect: a live LinkedIn session sitting in the clear in every `mysqldump`, invisible to `plaintext_remaining` — the number `docs/secrets-at-rest.md` names as the gate for flipping `ENCRYPTION_REQUIRED`. The operator would read "0 still unprotected" and fail-close over the top of it.

- `_store_cookie_rows` now refuses a write it cannot bind (logs an error, reports the rows as failed — which also feeds finding 1's guard). Nothing is lost: such a row could never be read back.
- `encrypt_secrets_at_rest` counts pre-existing orphan rows into `plaintext_remaining` as a new `orphaned` stat, and names the remedy (`DELETE FROM cookies WHERE user_id IS NULL`) — deletion, not encryption, since they can't be encrypted.

## Testing

`8723 passed` (`poetry run pytest tests/unit -q`). Three new/rewritten tests in `tests/unit/utilities/test_db_secret_encryption.py`:

- `test_unbindable_cookie_is_refused_not_written_in_the_clear` — replaces `test_orphan_cookie_without_a_user_is_still_stored`, which asserted the old (plaintext-writing) behaviour.
- `test_failed_write_is_reported_so_the_password_is_never_dropped`
- `test_orphaned_plaintext_cookies_keep_the_gate_off_zero`

`docs/secrets-at-rest.md` gains the orphan-row section; the beat task's warning names the orphan count.

Remaining on #745: 2b and 2c, unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)