### PR TITLE
feat(observability): group a post's whole generation chain into one $ai_trace (closes #746)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -584,6 +584,11 @@ POSTHOG_HOST=https://us.i.posthog.com
 # Both are also passed to the litellm container (as POSTHOG_API_KEY / POSTHOG_API_URL), where the
 # native posthog callback emits one $ai_generation per LLM call — issue #647, docs/llm-analytics.md.
 # Prompts/completions are redacted before they reach it (litellm_settings.turn_off_message_logging).
+# Pipeline traces (issue #746): group the 5-6 calls one post/edition/comment takes into ONE
+# $ai_trace with per-step $ai_span children, so "what did this post cost end to end?" is answerable.
+# App-side grouping only — the $ai_generation stream itself is untouched. false = no trace ids are
+# minted and the proxy events are exactly what they were before tracing shipped.
+LLM_TRACING_ENABLED=true
 # Minimum log level forwarded to PostHog (DEBUG/INFO/WARNING/ERROR/CRITICAL). Default: ERROR.
 # WARNING is the useful floor once escalation is on (below): the warning body is the CONTEXT for the
 # escalated $exception. DEBUG floods — it put 2,185 info rows into PostHog Logs in 48h.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,11 +164,18 @@ Track events via `utilities/observability.py` (`track_llm_call` / `track_task` /
 Each subsection below is a one-paragraph invariant; rationale, contracts, sample code, and edge
 cases live in the pointed-to doc. Plan with this section, drill in with the doc.
 
-### LLM analytics (issue #647)
+### LLM analytics (issue #647, traces #746)
 Two streams, never summed: `llm_call` (app, cost ESTIMATE — every money question reads this) vs
 `$ai_generation`/`$ai_embedding` (proxy-native, post-fallback, provider-priced — latency/error/
 volume). Attribution lives in `utilities/ai/client.py` (the ONE client); `_attach_routing_metadata`
-must stay. Full posture: `docs/llm-analytics.md`.
+must stay. **Pipeline traces** group a post/edition/comment's 5–6 calls into ONE `$ai_trace` with
+per-step `$ai_span`s: `@llm_pipeline` on the three roots (`create_text_post`,
+`generate_newsletter_edition`, `generate_ai_response` — it SUPERSEDES `attribute_llm_cost`),
+`@llm_step` on the SHARED-core step functions (never at a call site, so newsletters/comments inherit
+it). The client sends the ids two ways because LiteLLM reads them from two places — trace id in the
+`x-litellm-trace-id` HEADER (metadata would be overwritten), parent span in `metadata.parent_run_id`.
+Nested trace = span; span with no trace = no-op; `LLM_TRACING_ENABLED=false` mints nothing.
+Full posture: `docs/llm-analytics.md`.
 
 ### Error tracking (issue #648)
 Logs (`logger.py` → PostHog Logs) carry message+context; `$exception` is the grouped/fingerprinted

--- a/docs/llm-analytics.md
+++ b/docs/llm-analytics.md
@@ -156,5 +156,12 @@ Two invariants worth knowing before you add either:
 plus LEM's `feature` / `user_id` and `$ai_is_error` / `$ai_error` when the step raised. distinct_id
 follows the same rule as every other event here: the user id, or the `"system"` sentinel.
 
+**The root span IS the trace.** `llm_trace()` uses the trace id as its own span id, so a top-level
+step's `$ai_parent_id` — and the `parent_run_id` of a call made directly under the root — is the
+trace id itself. That is not cosmetic: PostHog assembles a trace's children with
+`toString($ai_parent_id) = toString($ai_trace_id)` (`traces_query_runner.py`), and totals its latency
+over the same set. Mint a separate root-span uuid and every event still carries the right
+`$ai_trace_id` while the trace opens **empty, at zero latency**.
+
 The de-dupe rule above still holds inside a trace — the money number is `llm_call`, and summing the
 generations under one trace gives you the provider's charge, not LEM's ledger.

--- a/docs/llm-analytics.md
+++ b/docs/llm-analytics.md
@@ -95,9 +95,66 @@ Caveat worth knowing when the two are compared: a LiteLLM **cache hit** still em
 `$ai_generation`, at `$ai_total_cost_usd` 0 like `llm_call`'s `cached` path, but its
 `$ai_input_tokens` are the served request's, so token volume reads higher than billable tokens.
 
-## Not in scope here
+## Pipeline traces — `$ai_trace` / `$ai_span` (issue #746)
 
-`$ai_trace` / `$ai_span` hierarchies — wrapping a post's full generation chain
-(research → draft → review → humanize) into one readable trace. Every event already carries a
-`$ai_trace_id`, but it is per-call; grouping them is app-side work via the `posthog-python` AI
-helpers. Tracked as the stretch half of #647.
+A post is not one model call. Research → draft → refine → humanize → authenticity → review is six,
+and until they shared a trace the question the analytics exist to answer — *what did THIS post cost,
+end to end?* — had no answer at all: every call was its own isolated `$ai_generation` with its own
+proxy-minted `$ai_trace_id`.
+
+Grouping is **app-side work**, because only the app knows where a pipeline starts. The
+`$ai_generation` stream is untouched: no extra event, no changed property, no LiteLLM config change.
+
+| Piece | Where |
+|---|---|
+| `llm_trace()` / `llm_span()` + the `@llm_pipeline` / `@llm_step` decorator forms | `utilities/observability.py` |
+| Putting the ids on the wire | `utilities/ai/client.py` (`_attach_trace`) |
+| Kill switch | `LLM_TRACING_ENABLED` (default on), read at call time |
+
+### The two wires
+
+LiteLLM's PostHog logger sources the two ids from two different places, so LEM has to send them two
+different ways. Getting this wrong is silent — the events still ship, they just don't nest.
+
+- **`x-litellm-trace-id` header** → becomes the proxy's own `litellm_trace_id`, which it publishes as
+  `$ai_trace_id`. It **cannot** be sent as request metadata: the logger reads `$ai_trace_id` from its
+  own standard logging payload and would overwrite anything we put in metadata.
+- **`metadata.parent_run_id`** → the logger maps it to `$ai_parent_id` and keeps the key out of the
+  copied-through properties, so the generation nests under the span that made it.
+
+Both live in the shared client, for the same reason attribution does: a step that forgot them would
+drop out of its post's trace and nothing would say so. Tracing rides in its own hook rather than
+inside `_attach_attribution`, which bails out whenever the caller supplied its own metadata —
+`_call_llm` always does, so folding them together would have excluded nearly every generation LEM
+makes.
+
+### The shape
+
+`@llm_pipeline` marks a function that IS one pipeline and supersedes `attribute_llm_cost` on it — it
+opens the trace *and* the same `llm_attribution()` scope, reading the user id off the call's own
+`user_id` argument. Three are marked: `create_text_post` (`post_generation`),
+`generate_newsletter_edition` (`newsletter_edition`), `generate_ai_response` (`comment_generation`).
+
+`@llm_step` goes on the STEP FUNCTION, never at a call site. Newsletters and comments draw draft,
+research, humanize and authenticity from the same shared content core as posts, so decorating the
+core is what gives every pipeline a legible trace without touching a single caller. Current spans:
+`research`, `draft`, `refine`, `hook`, `humanize`, `authenticity`, `review`.
+
+Two invariants worth knowing before you add either:
+
+- **A trace opened inside an open trace becomes a span**, not a second trace. `create_text_post`
+  recurses into itself for post-type fallbacks, and two half-traces of one post answer nobody.
+- **A span outside a pipeline is a no-op.** Most calls into the shared core are not part of a
+  pipeline; an orphan span is something PostHog cannot render, and the work must run identically
+  either way. Same posture as the rest of this file: telemetry is never a reason to lose the
+  generation, so a capture failure is swallowed at DEBUG.
+
+### Reading it
+
+`$ai_trace` / `$ai_span` carry `$ai_trace_id`, `$ai_span_id`, `$ai_span_name`, `$ai_latency`
+(**seconds** — `llm_call.latency_ms` is the other convention and the two must not share a chart),
+plus LEM's `feature` / `user_id` and `$ai_is_error` / `$ai_error` when the step raised. distinct_id
+follows the same rule as every other event here: the user id, or the `"system"` sentinel.
+
+The de-dupe rule above still holds inside a trace — the money number is `llm_call`, and summing the
+generations under one trace gives you the provider's charge, not LEM's ledger.

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -65,7 +65,8 @@ from cqc_lem.utilities.linkedin.rate_limit import acquire_run_lock, release_run_
 from cqc_lem.utilities.linkedin_formatter import sanitize_for_linkedin, strip_engagement_bait
 from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.logger import myprint, log_info, log_warning, log_error
-from cqc_lem.utilities.observability import attribute_llm_cost, llm_attribution, FEATURE_CONTENT
+from cqc_lem.utilities.observability import (attribute_llm_cost, llm_attribution, llm_pipeline,
+                                             llm_step, FEATURE_CONTENT)
 from cqc_lem.utilities.selenium_util import get_driver_wait_pair, quit_gracefully
 from cqc_lem.utilities.utils import get_post_time, create_folder_if_not_exists, \
     save_video_url_to_dir, apply_schedule_jitter
@@ -1344,6 +1345,7 @@ def _fabricated_specifics(content: str, story: Optional[dict],
         content, _story_bank.fact_sources(story, profile_synthesis, *extra_sources))
 
 
+@llm_step("review")
 def _review_generated_post(user_id: int, stage: str, post_type: str, user_profile: LinkedInProfile,
                            blueprint: dict, post_id: int, lead_magnet_cta: str, content: str,
                            recent_texts: list, prefs: dict = None,
@@ -1460,7 +1462,7 @@ def _review_generated_post(user_id: int, stage: str, post_type: str, user_profil
     return second
 
 
-@attribute_llm_cost(FEATURE_CONTENT)
+@llm_pipeline("post_generation", feature=FEATURE_CONTENT)
 def create_text_post(user_id: int, stage: str, post_type: str = None, user_profile: LinkedInProfile=None,
                      refine_final_post: bool = True, blueprint: dict = None, post_id: int = None,
                      lead_magnet_cta: str = None, history_directive: str = None,
@@ -1964,6 +1966,7 @@ def process_selected_post(url, content):
         myprint("Selected Post Content: None")
 
 
+@llm_step("draft")
 def generate_website_content_post(sitemap_url, linked_user_profile, stage: str, prefs: dict = None,
                                   profile_synthesis: Optional[str] = None, blueprint: dict = None,
                                   lead_magnet_cta: str = None, history_directive: str = None,

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -34,6 +34,7 @@ from cqc_lem.utilities.linkedin.profile import LinkedInProfile
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text, PLAIN_PUNCTUATION_DIRECTIVE, \
     linkedin_post_format_directive, enforce_post_readability
 from cqc_lem.utilities.logger import myprint, log_debug, log_error, log_info, log_warning
+from cqc_lem.utilities.observability import FEATURE_COMMENT, FEATURE_NEWSLETTER, llm_pipeline, llm_step
 from cqc_lem.utilities.utils import create_folder_if_not_exists, save_video_url_to_dir
 from cqc_lem.utilities.env_constants import DEFAULT_VIDEO_MODEL, DEFAULT_IMAGE_MODEL, DEFAULT_IMAGE_RATIO
 # create_runway_video lives in video_models (model abstraction); re-exported here
@@ -341,6 +342,7 @@ def _comment_contract_variant(user_id: int = None) -> "str | None":
         return None
 
 
+@llm_pipeline("comment_generation", feature=FEATURE_COMMENT)
 def generate_ai_response(post_content, profile: LinkedInProfile, post_img_url=None, post_comment: str = None,
                          prefs: dict = None, profile_synthesis: str = None,
                          blueprint: dict = None, research: dict = None,
@@ -691,6 +693,7 @@ def plan_newsletter_topics(profile_synthesis: str, newsletter_description: str, 
     return _framework.enforce_variety("newsletter", planned[:count], recent_formats, recent_hook_styles)
 
 
+@llm_pipeline("newsletter_edition", feature=FEATURE_NEWSLETTER)
 def generate_newsletter_edition(profile: "LinkedInProfile", topic: str = None,
                                 blog_content: str = None, prefs: dict = None,
                                 subject: str = None, avoid_subjects: list = None,
@@ -1156,6 +1159,7 @@ def generate_nurture_dm(their_message: str, intent: str, profile: "LinkedInProfi
     return lint_repaired(_draft(), "dm", _draft, action_type="dm")
 
 
+@llm_step("hook")
 def optimize_post_hook(post_content: str, prefs: dict = None,
                        preserve_cta_keyword: str = None) -> str:
     """Rewrite a generated post so it opens with a scroll-stopping hook within the first ~210
@@ -1347,6 +1351,7 @@ def get_industries_of_profile_from_ai(linked_in_profile: LinkedInProfile, indust
     comment = response.choices[0].message.content.strip()
     return comment
 
+@llm_step("refine")
 def get_ai_linked_post_refinement(original_message: str, character_limit: int = 3000,
                                   prefs: dict = None, preserve_cta_keyword: str = None):
     character_limit_string = (f"""\nThe refined LinkedIn Post needs to be less than or equal to {character_limit} characters including white spaces and punctuations. You may use symbols, abbreviations, and other and short-hand.
@@ -1748,6 +1753,7 @@ def _subject_anchor_line(trends: dict) -> str:
             f"into unrelated {industry} news.\n")
 
 
+@llm_step("draft")
 def get_thought_leadership_post_from_ai(linked_user_profile: LinkedInProfile, buyer_stage: str,
                                         prefs: dict = None, profile_synthesis: str = None,
                                         blueprint: dict = None, lead_magnet_cta: str = None,
@@ -1957,6 +1963,7 @@ def get_industry_trend_analysis_based_on_user_profile(linked_in_profile: LinkedI
     }
 
 
+@llm_step("draft")
 def get_industry_news_post_from_ai(linked_user_profile: LinkedInProfile, buyer_stage: str,
                                    prefs: dict = None, profile_synthesis: str = None,
                                    blueprint: dict = None, lead_magnet_cta: str = None,
@@ -2152,6 +2159,7 @@ def get_industry_trend_from_ai(industry: str, articles: list):
     return comment
 
 
+@llm_step("draft")
 def get_personal_story_post_from_ai(linked_user_profile: LinkedInProfile, stage: str,
                                     prefs: dict = None, profile_synthesis: str = None,
                                     blueprint: dict = None, lead_magnet_cta: str = None,
@@ -2276,6 +2284,7 @@ def get_personal_story_post_from_ai(linked_user_profile: LinkedInProfile, stage:
     return content
 
 
+@llm_step("draft")
 def generate_engagement_prompt_post(linked_user_profile: LinkedInProfile, stage: str,
                                     prefs: dict = None, profile_synthesis: str = None,
                                     blueprint: dict = None, lead_magnet_cta: str = None,
@@ -2396,6 +2405,7 @@ def generate_engagement_prompt_post(linked_user_profile: LinkedInProfile, stage:
     return content
 
 
+@llm_step("draft")
 def get_blog_summary_post_from_ai(blog_post_url: str, blog_post_content: str, linked_user_profile: LinkedInProfile,
                                   stage: str, prefs: dict = None, profile_synthesis: str = None,
                                   blueprint: dict = None, lead_magnet_cta: str = None,

--- a/src/cqc_lem/utilities/ai/client.py
+++ b/src/cqc_lem/utilities/ai/client.py
@@ -1,4 +1,5 @@
 import os
+from collections.abc import Mapping
 from typing import Any, Optional, Tuple
 
 from openai import OpenAI
@@ -8,6 +9,16 @@ from cqc_lem.utilities.routing_policy import SYSTEM_USER_ID
 # Only tier aliases are routable AND priced by the proxy, so nothing is attached to a call that
 # named a raw provider model directly.
 _TIER_PREFIX = "lem-"
+
+# LiteLLM's own chain id (docs/proxy/request_headers). Whatever arrives here becomes the proxy's
+# `litellm_trace_id`, which is what its PostHog logger publishes as `$ai_trace_id` — the ONE property
+# PostHog groups an LLM trace by. It cannot be sent as request metadata: the logger sources
+# `$ai_trace_id` from its own standard logging payload and would overwrite ours.
+_TRACE_HEADER = "x-litellm-trace-id"
+
+# ...whereas the PARENT span is metadata: the logger maps `metadata.parent_run_id` to `$ai_parent_id`
+# and keeps the key out of the copied-through properties, so the generation nests under our span.
+_PARENT_KEY = "parent_run_id"
 
 # Mirrors observability.FEATURE_SYSTEM. Kept as a literal so this module never imports observability
 # eagerly — that would drag the DB and PostHog into every `from ...ai.client import client`.
@@ -22,6 +33,16 @@ def current_attribution() -> Tuple[Optional[Any], Optional[str]]:
         from cqc_lem.utilities.observability import current_llm_attribution, FEATURE_SYSTEM
         user_id, feature = current_llm_attribution()
         return user_id, feature or FEATURE_SYSTEM
+    except Exception:
+        return None, None
+
+
+def current_trace() -> Tuple[Optional[str], Optional[str]]:
+    """(trace_id, span_id) of the multi-call pipeline running right now, or (None, None) when there
+    is none. Lazily imported for the same reason `current_attribution` is."""
+    try:
+        from cqc_lem.utilities.observability import current_llm_trace
+        return current_llm_trace()
     except Exception:
         return None, None
 
@@ -64,21 +85,60 @@ def _attach_attribution(options) -> None:
     options.extra_json = merged
 
 
+def _request_metadata(options) -> Optional[dict]:
+    """The metadata dict this request will actually send, whoever put it there — `_call_llm` sets its
+    own in `extra_body`, `_attach_attribution` sets the ambient one in `extra_json`."""
+    for source in (getattr(options, "json_data", None), getattr(options, "extra_json", None)):
+        if isinstance(source, dict) and isinstance(source.get("metadata"), dict):
+            return source["metadata"]
+    return None
+
+
+def _attach_trace(options) -> None:
+    """Join this request to the pipeline trace open around it, if any (issue #746).
+
+    Separate from `_attach_attribution` on purpose: that one bails out when the caller supplied its
+    own metadata, which `_call_llm` always does — so folding tracing into it would silently exclude
+    almost every generation LEM makes.
+    """
+    body = getattr(options, "json_data", None)
+    if not isinstance(body, dict) or options.files:
+        return
+    if not str(body.get("model") or "").startswith(_TIER_PREFIX):
+        return
+    trace_id, span_id = current_trace()
+    if not trace_id:
+        return
+    headers = getattr(options, "headers", None)
+    sent = dict(headers) if isinstance(headers, Mapping) else {}
+    # A caller that set the chain id itself owns it — headers are case-insensitive on the wire.
+    if not any(str(key).lower() == _TRACE_HEADER for key in sent):
+        sent[_TRACE_HEADER] = trace_id
+        options.headers = sent
+    metadata = _request_metadata(options)
+    if span_id and metadata is not None:
+        metadata.setdefault(_PARENT_KEY, span_id)
+
+
 class AttributedOpenAI(OpenAI):
-    """The OpenAI client with LEM's who/what stamped onto every proxied request.
+    """The OpenAI client with LEM's who/what — and which pipeline — stamped onto every proxied request.
 
     Attribution lives here rather than at the ~10 call sites because a call that skips it is
     invisible in cost routing and lands on an anonymous PostHog person — a silent failure nobody
-    would notice. `_build_request` is the one place the SDK funnels every endpoint through;
-    tests/unit/utilities/ai/test_client_attribution.py drives a real request build so an SDK upgrade
-    that moves the hook fails CI instead of quietly dropping attribution.
+    would notice. Trace ids are here for the same reason: a step that forgot them would drop out of
+    its post's trace and nothing would say so. `_build_request` is the one place the SDK funnels
+    every endpoint through; tests/unit/utilities/ai/test_client_attribution.py and
+    test_client_tracing.py drive a real request build so an SDK upgrade that moves the hook fails CI
+    instead of quietly dropping either.
     """
 
     def _build_request(self, options, **kwargs):
-        try:
-            _attach_attribution(options)
-        except Exception:
-            pass  # attribution is observability, never a reason to lose the generation
+        # Independently guarded: attribution failing must not also cost the trace, or vice versa.
+        for hook in (_attach_attribution, _attach_trace):
+            try:
+                hook(options)
+            except Exception:
+                pass  # observability is never a reason to lose the generation
         return super()._build_request(options, **kwargs)
 
 

--- a/src/cqc_lem/utilities/ai/content_alignment.py
+++ b/src/cqc_lem/utilities/ai/content_alignment.py
@@ -14,6 +14,7 @@ from enum import StrEnum
 from typing import TYPE_CHECKING, Optional
 
 from cqc_lem.utilities.linkedin_formatter import normalize_public_text
+from cqc_lem.utilities.observability import llm_step
 from cqc_lem.utilities.marketing.attribution import (MEDIUM_SOCIAL, PLACEMENT_FIRST_COMMENT,
                                                      PLACEMENT_POST_BODY, SOURCE_LINKEDIN,
                                                      campaign_for_post, mark_placement,
@@ -1257,6 +1258,7 @@ _HUMANIZE_TYPE_NOTE = {
 }
 
 
+@llm_step("humanize")
 def humanize_text(content: Optional[str], content_type: str = "post",
                   profile_synthesis: Optional[str] = None,
                   prefs: Optional[dict] = None, max_chars: Optional[int] = None) -> Optional[str]:
@@ -1435,6 +1437,7 @@ def humanize_title(title: Optional[str], content_type: str = "newsletter",
     return rewritten
 
 
+@llm_step("authenticity")
 def score_authenticity(content: str, profile=None, profile_synthesis: Optional[str] = None,
                        prefs: dict = None) -> dict:
     """LLM-judge the authenticity / generic-AI risk of a finished post draft.

--- a/src/cqc_lem/utilities/ai/content_research.py
+++ b/src/cqc_lem/utilities/ai/content_research.py
@@ -23,6 +23,7 @@ import os
 
 from cqc_lem.utilities.flags import COMMENT_RESEARCH, flag_enabled
 from cqc_lem.utilities.logger import log_debug, log_warning
+from cqc_lem.utilities.observability import llm_step
 
 _EMPTY: dict = {"findings": "", "sources": []}
 
@@ -119,6 +120,7 @@ def _research_via_litellm(query: str, max_sources: int) -> dict:
     return {"findings": findings, "sources": sources}
 
 
+@llm_step("research")
 def research_topic(subject: str, content_type: str = "newsletter", blueprint: dict = None,
                    context_description: str = None, prefs: dict = None,
                    max_sources: int = 5, user_id: int = None) -> dict:

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -423,7 +423,13 @@ def llm_trace(name: str, user_id: Optional[int] = None,
         if not llm_tracing_enabled():
             yield None
             return
-        trace_id, span_id = str(uuid.uuid4()), str(uuid.uuid4())
+        # The root span IS the trace: PostHog puts an event in a trace's child list only when its
+        # $ai_parent_id equals the $ai_trace_id itself (traces_query_runner.py builds `events` from
+        # `toString($ai_parent_id) = toString($ai_trace_id)`, and total_latency sums the same set).
+        # Minting a separate root-span uuid would parent every step onto an id no node carries, so
+        # the trace would open EMPTY with zero latency — the one thing this feature exists to show.
+        trace_id = str(uuid.uuid4())
+        span_id = trace_id
         # Resolved once, inside the scope: the finally block runs after llm_attribution has been
         # reset, and a trace attributed to "system" would be worse than no trace at all.
         scope_user_id, scope_feature = current_llm_attribution()

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -5,6 +5,7 @@ import json
 import os
 import re
 import time
+import uuid
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
 from functools import wraps
@@ -295,23 +296,33 @@ def llm_attribution(user_id: Optional[int] = None, feature: Optional[str] = None
         _llm_attribution.reset(token)
 
 
+def _argument_reader(fn, arg_name: str):
+    """A `(args, kwargs) -> value` reader for one of `fn`'s own arguments, keyword or positional.
+    Bound once at decoration time so the signature isn't introspected on every call."""
+    try:
+        params = list(inspect.signature(fn).parameters)
+    except (TypeError, ValueError):
+        params = []
+    position = params.index(arg_name) if arg_name in params else None
+
+    def read(args, kwargs):
+        value = kwargs.get(arg_name)
+        if value is None and position is not None and len(args) > position:
+            value = args[position]
+        return value
+    return read
+
+
 def attribute_llm_cost(feature: str, user_id_arg: str = "user_id"):
     """Decorator form of llm_attribution() for a function that OWNS a feature's LLM work (a Celery
     task, a generator entry point). It reads the user id from the call's own `user_id_arg` argument,
     so cost is attributed the same way no matter which caller — beat, API, or healer — invoked it."""
     def decorator(fn):
-        try:
-            params = list(inspect.signature(fn).parameters)
-        except (TypeError, ValueError):
-            params = []
-        position = params.index(user_id_arg) if user_id_arg in params else None
+        read_user_id = _argument_reader(fn, user_id_arg)
 
         @wraps(fn)
         def wrapper(*args, **kwargs):
-            user_id = kwargs.get(user_id_arg)
-            if user_id is None and position is not None and len(args) > position:
-                user_id = args[position]
-            with llm_attribution(user_id=user_id, feature=feature):
+            with llm_attribution(user_id=read_user_id(args, kwargs), feature=feature):
                 return fn(*args, **kwargs)
         return wrapper
     return decorator
@@ -327,6 +338,165 @@ def current_llm_attribution() -> Tuple[Optional[int], Optional[str]]:
         user_id = user_id if user_id is not None else task_user_id
         feature = feature or feature_from_task_name(task_name)
     return user_id, feature
+
+
+# --- LLM pipeline traces: $ai_trace / $ai_span (issue #746) --------------------------------
+# A post is not one model call. Research -> draft -> refine -> humanize -> authenticity -> review is
+# six, and each lands in PostHog as its own isolated $ai_generation, so "what did THIS post cost, end
+# to end?" has no answer. Grouping is app-side work: only the app knows where a pipeline starts.
+#
+# The ids live in a contextvar (no ai_helper signature grows a trace argument) and the SHARED client
+# is what puts them on the wire — see utilities/ai/client.py. Two wires, because LiteLLM's PostHog
+# logger reads them from two places: the `x-litellm-trace-id` header becomes the proxy event's
+# $ai_trace_id, and `metadata.parent_run_id` becomes its $ai_parent_id. The $ai_trace / $ai_span
+# events emitted here are the skeleton those generations hang off.
+#
+# The proxy-side $ai_generation stream itself is untouched: no extra event, no changed property.
+
+_llm_trace: contextvars.ContextVar[dict] = contextvars.ContextVar("llm_trace", default={})
+
+
+def llm_tracing_enabled() -> bool:
+    """Kill switch, read at call time. Off means no trace id is ever minted, so the client attaches
+    nothing and the proxy stream is exactly what it was before tracing shipped."""
+    return _env_flag("LLM_TRACING_ENABLED")
+
+
+def current_llm_trace() -> Tuple[Optional[str], Optional[str]]:
+    """(trace_id, span_id) for the LLM call happening right now — the pipeline it belongs to, and the
+    step within it. (None, None) when no pipeline is open, which every untraced call still is."""
+    scope = _llm_trace.get()
+    return scope.get("trace_id"), scope.get("span_id")
+
+
+def _capture_ai_span(event: str, trace_id: str, span_id: str, name: str, started: float,
+                     parent_id: Optional[str], error: Optional[BaseException],
+                     user_id: Optional[int], feature: Optional[str],
+                     properties: Optional[dict] = None) -> None:
+    """Emit one $ai_trace / $ai_span. Best-effort by construction — a post must never fail to
+    generate because its telemetry could not be written."""
+    try:
+        props = {
+            "$ai_trace_id": trace_id,
+            "$ai_span_id": span_id,
+            "$ai_span_name": name,
+            # PostHog's LLM analytics reads $ai_latency in SECONDS (llm_call's latency_ms is the
+            # other convention and the two must not be confused on one chart).
+            "$ai_latency": round(max(0.0, time.time() - started), 3),
+            "feature": feature or FEATURE_SYSTEM,
+            "user_id": user_id,
+        }
+        if parent_id:
+            props["$ai_parent_id"] = parent_id
+        if error is not None:
+            props["$ai_is_error"] = True
+            props["$ai_error"] = f"{type(error).__name__}: {error}"
+        if properties:
+            props.update({k: v for k, v in properties.items() if v is not None})
+        posthog.capture(
+            distinct_id=str(user_id if user_id is not None else "system"),
+            event=event,
+            properties=props,
+        )
+    except Exception as e:
+        # DEBUG, not WARNING: a telemetry miss is an expected no-op class, and a repeated warning
+        # would file a defect for it (see utilities/CLAUDE.md).
+        log_debug(f"Could not capture {event}: {e}")
+
+
+@contextmanager
+def llm_trace(name: str, user_id: Optional[int] = None,
+              feature: Optional[str] = None) -> Iterator[Optional[str]]:
+    """Group every LLM call made inside this block into ONE PostHog trace named `name`, and open the
+    matching `llm_attribution()` scope so a pipeline entry point declares who/what once.
+
+    Nesting is deliberate: a trace opened inside an open one becomes a SPAN of the outer trace rather
+    than a second trace. `create_text_post` recurses into itself for post-type fallbacks, and two
+    half-traces of one post answer nobody's question."""
+    if _llm_trace.get().get("trace_id"):
+        with llm_attribution(user_id=user_id, feature=feature):
+            with llm_span(name):
+                yield _llm_trace.get().get("trace_id")
+        return
+
+    with llm_attribution(user_id=user_id, feature=feature):
+        if not llm_tracing_enabled():
+            yield None
+            return
+        trace_id, span_id = str(uuid.uuid4()), str(uuid.uuid4())
+        # Resolved once, inside the scope: the finally block runs after llm_attribution has been
+        # reset, and a trace attributed to "system" would be worse than no trace at all.
+        scope_user_id, scope_feature = current_llm_attribution()
+        token = _llm_trace.set({"trace_id": trace_id, "span_id": span_id})
+        started, error = time.time(), None
+        try:
+            yield trace_id
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            _llm_trace.reset(token)
+            _capture_ai_span("$ai_trace", trace_id, span_id, name, started, None, error,
+                             scope_user_id, scope_feature)
+
+
+@contextmanager
+def llm_span(name: str, **properties) -> Iterator[Optional[str]]:
+    """One step of the pipeline currently open around this block.
+
+    Outside a pipeline this does nothing at all and yields None — a span with no trace is an orphan
+    PostHog cannot render, and the work itself must run identically either way."""
+    scope = _llm_trace.get()
+    trace_id, parent_id = scope.get("trace_id"), scope.get("span_id")
+    if not trace_id:
+        yield None
+        return
+    span_id = str(uuid.uuid4())
+    user_id, feature = current_llm_attribution()
+    token = _llm_trace.set({"trace_id": trace_id, "span_id": span_id})
+    started, error = time.time(), None
+    try:
+        yield span_id
+    except BaseException as exc:
+        error = exc
+        raise
+    finally:
+        _llm_trace.reset(token)
+        _capture_ai_span("$ai_span", trace_id, span_id, name, started, parent_id, error,
+                         user_id, feature, properties)
+
+
+def llm_pipeline(name: str, feature: Optional[str] = None, user_id_arg: str = "user_id"):
+    """Decorator form of llm_trace() for a function that IS one pipeline (`create_text_post`,
+    `generate_newsletter_edition`, `generate_ai_response`). Supersedes `attribute_llm_cost` on such a
+    function: it opens the same attribution scope AND the trace, reading the user id off the call's
+    own `user_id_arg` the same way."""
+    def decorator(fn):
+        read_user_id = _argument_reader(fn, user_id_arg)
+
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            with llm_trace(name, user_id=read_user_id(args, kwargs), feature=feature):
+                return fn(*args, **kwargs)
+        wrapper.__llm_trace_name__ = name
+        return wrapper
+    return decorator
+
+
+def llm_step(name: str):
+    """Decorator form of llm_span() for ONE step of a pipeline.
+
+    It goes on the STEP FUNCTION, not at its call sites: newsletters and comments draw draft,
+    research, humanize and authenticity from the same shared content core as posts, so decorating
+    the core is what makes every pipeline's trace legible without touching any caller."""
+    def decorator(fn):
+        @wraps(fn)
+        def wrapper(*args, **kwargs):
+            with llm_span(name):
+                return fn(*args, **kwargs)
+        wrapper.__llm_span_name__ = name
+        return wrapper
+    return decorator
 
 
 # --- Error tracking (issue #648) -----------------------------------------------------------

--- a/tests/unit/utilities/ai/test_client_tracing.py
+++ b/tests/unit/utilities/ai/test_client_tracing.py
@@ -1,0 +1,171 @@
+"""The shared client is what puts a pipeline's trace on the wire (issue #746).
+
+`$ai_trace`/`$ai_span` alone would be an empty skeleton: the generations themselves are emitted by
+the LiteLLM proxy, and they only join the trace if the request carried the chain id. Two wires do
+that, and each is read from a different place by LiteLLM's PostHog logger — the `x-litellm-trace-id`
+header becomes `$ai_trace_id`, `metadata.parent_run_id` becomes `$ai_parent_id`.
+
+Like test_client_attribution.py, these build REAL requests through the OpenAI SDK so an SDK upgrade
+that moves the injection point fails CI instead of silently splintering every trace.
+"""
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_CHAT_RESPONSE = {
+    "id": "x", "object": "chat.completion", "created": 0, "model": "m",
+    "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+}
+
+_TRACE_HEADER = "x-litellm-trace-id"
+
+
+class _Recorder(httpx.BaseTransport):
+    def __init__(self):
+        self.requests = []
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append((request.headers, json.loads(request.content)))
+        return httpx.Response(200, json=_CHAT_RESPONSE)
+
+
+def _client() -> tuple:
+    from cqc_lem.utilities.ai.client import AttributedOpenAI
+    recorder = _Recorder()
+    client = AttributedOpenAI(api_key="k", base_url="http://litellm:4000", max_retries=0,
+                              http_client=httpx.Client(transport=recorder))
+    return client, recorder
+
+
+@contextmanager
+def _silent_posthog():
+    """The trace/span events themselves are asserted in test_llm_traces.py — here they'd just be
+    network noise from a real PostHog client."""
+    with patch("cqc_lem.utilities.observability.posthog"):
+        yield
+
+
+def _send(client, model="lem-complex", **kwargs):
+    try:
+        client.chat.completions.create(model=model, messages=[{"role": "user", "content": "hi"}],
+                                       **kwargs)
+    except Exception:
+        pass  # a stub response body only has to be good enough to build and send the request
+
+
+class TestTraceOnTheWire:
+    def test_every_call_in_one_pipeline_carries_the_same_chain_id(self):
+        from cqc_lem.utilities.observability import llm_span, llm_trace
+        client, recorder = _client()
+        with _silent_posthog():
+            with llm_trace("post_generation", user_id=7, feature="content") as trace_id:
+                with llm_span("draft"):
+                    _send(client)
+                with llm_span("humanize"):
+                    _send(client, model="lem-medium")
+        sent = [headers.get(_TRACE_HEADER) for headers, _ in recorder.requests]
+        assert sent == [trace_id, trace_id]
+
+    def test_each_call_names_the_span_it_happened_under(self):
+        from cqc_lem.utilities.observability import llm_span, llm_trace
+        client, recorder = _client()
+        with _silent_posthog():
+            with llm_trace("post_generation", user_id=7, feature="content"):
+                with llm_span("draft") as draft_span:
+                    _send(client)
+                with llm_span("humanize") as humanize_span:
+                    _send(client)
+        parents = [body["metadata"]["parent_run_id"] for _, body in recorder.requests]
+        assert parents == [draft_span, humanize_span]
+        assert draft_span != humanize_span
+
+    def test_a_call_directly_under_the_trace_parents_onto_its_root_span(self):
+        from cqc_lem.utilities.observability import llm_trace
+        client, recorder = _client()
+        with _silent_posthog():
+            with llm_trace("post_generation", user_id=7, feature="content"):
+                _send(client)
+        _, body = recorder.requests[-1]
+        assert body["metadata"]["parent_run_id"]
+
+    def test_a_callers_own_metadata_still_joins_the_trace(self):
+        """`_call_llm` always sets its own metadata, which is why tracing cannot ride inside the
+        attribution hook — it bails out on exactly that case."""
+        from cqc_lem.utilities.observability import llm_span, llm_trace
+        client, recorder = _client()
+        with _silent_posthog():
+            with llm_trace("post_generation", user_id=7, feature="content") as trace_id:
+                with llm_span("draft") as span_id:
+                    _send(client, extra_body={"metadata": {"feature": "content", "user_id": 7}})
+        headers, body = recorder.requests[-1]
+        assert headers.get(_TRACE_HEADER) == trace_id
+        assert body["metadata"] == {"feature": "content", "user_id": 7, "parent_run_id": span_id}
+
+    def test_untraced_calls_are_unchanged(self):
+        client, recorder = _client()
+        with _silent_posthog():
+            _send(client)
+        headers, body = recorder.requests[-1]
+        assert _TRACE_HEADER not in headers
+        assert "parent_run_id" not in body["metadata"]
+
+    def test_raw_provider_models_are_never_traced(self):
+        """Only tier aliases go through the proxy's PostHog logger — a direct provider call has
+        nothing to join."""
+        from cqc_lem.utilities.observability import llm_trace
+        client, recorder = _client()
+        with _silent_posthog():
+            with llm_trace("post_generation", user_id=7):
+                _send(client, model="gpt-4o-mini")
+        headers, _ = recorder.requests[-1]
+        assert _TRACE_HEADER not in headers
+
+    def test_embeddings_join_the_trace_too(self):
+        from cqc_lem.utilities.observability import llm_span, llm_trace
+        client, recorder = _client()
+        with _silent_posthog():
+            with llm_trace("post_generation", user_id=7, feature="content") as trace_id:
+                with llm_span("review"):
+                    try:
+                        client.embeddings.create(model="lem-embedding", input=["a"])
+                    except Exception:
+                        pass  # stub response; the request was already built and sent
+        headers, body = recorder.requests[-1]
+        assert headers.get(_TRACE_HEADER) == trace_id
+        assert body["metadata"]["parent_run_id"]
+
+    def test_a_caller_supplied_chain_id_wins(self):
+        from cqc_lem.utilities.observability import llm_trace
+        client, recorder = _client()
+        with _silent_posthog():
+            with llm_trace("post_generation", user_id=7):
+                _send(client, extra_headers={_TRACE_HEADER: "caller-owned"})
+        headers, _ = recorder.requests[-1]
+        assert headers.get(_TRACE_HEADER) == "caller-owned"
+
+    def test_a_tracing_failure_never_breaks_the_call(self):
+        client, recorder = _client()
+        with patch("cqc_lem.utilities.observability.current_llm_trace",
+                   side_effect=RuntimeError("boom")):
+            _send(client)
+        headers, body = recorder.requests[-1]
+        assert _TRACE_HEADER not in headers
+        # The generation still went out, fully attributed — only the grouping was lost.
+        assert body["metadata"] == {"feature": "system", "user_id": "system"}
+
+    def test_attribution_survives_a_tracing_failure_and_vice_versa(self):
+        """Both hooks run per request; one throwing must not take the other down with it."""
+        from cqc_lem.utilities.observability import llm_trace
+        client, recorder = _client()
+        with _silent_posthog():
+            with patch("cqc_lem.utilities.ai.client._attach_attribution",
+                       side_effect=RuntimeError("boom")):
+                with llm_trace("post_generation", user_id=7):
+                    _send(client)
+        headers, _ = recorder.requests[-1]
+        assert headers.get(_TRACE_HEADER)

--- a/tests/unit/utilities/ai/test_client_tracing.py
+++ b/tests/unit/utilities/ai/test_client_tracing.py
@@ -84,14 +84,16 @@ class TestTraceOnTheWire:
         assert parents == [draft_span, humanize_span]
         assert draft_span != humanize_span
 
-    def test_a_call_directly_under_the_trace_parents_onto_its_root_span(self):
+    def test_a_call_directly_under_the_trace_parents_onto_the_trace_itself(self):
+        """A step-less call is a DIRECT child of the trace, and PostHog only counts one as such when
+        $ai_parent_id is the trace id (traces_query_runner.py) — anything else and it disappears."""
         from cqc_lem.utilities.observability import llm_trace
         client, recorder = _client()
         with _silent_posthog():
-            with llm_trace("post_generation", user_id=7, feature="content"):
+            with llm_trace("post_generation", user_id=7, feature="content") as trace_id:
                 _send(client)
         _, body = recorder.requests[-1]
-        assert body["metadata"]["parent_run_id"]
+        assert body["metadata"]["parent_run_id"] == trace_id
 
     def test_a_callers_own_metadata_still_joins_the_trace(self):
         """`_call_llm` always sets its own metadata, which is why tracing cannot ride inside the

--- a/tests/unit/utilities/test_llm_traces.py
+++ b/tests/unit/utilities/test_llm_traces.py
@@ -90,22 +90,25 @@ class TestEmittedEvents:
         assert event == "$ai_trace"
         assert props["$ai_trace_id"] == trace_id
         assert props["$ai_span_name"] == "post_generation"
-        assert props["$ai_span_id"]
+        assert props["$ai_span_id"] == trace_id
         assert "$ai_parent_id" not in props
         assert props["$ai_latency"] >= 0
         assert props["feature"] == "content"
         assert mock_ph.capture.call_args_list[0][1]["distinct_id"] == "7"
 
-    def test_a_span_hangs_off_the_root_span(self):
+    def test_a_top_level_span_parents_onto_the_trace_id_itself(self):
+        """PostHog collects a trace's children with `$ai_parent_id = $ai_trace_id` (see
+        traces_query_runner.py). Parent a step onto a separate root-span uuid instead and the trace
+        opens empty — every generation still carries the right trace id, and none of them show."""
         from cqc_lem.utilities.observability import llm_trace, llm_span
         with patch(f"{_MOD}.posthog") as mock_ph:
-            with llm_trace("post_generation", user_id=7, feature="content"):
+            with llm_trace("post_generation", user_id=7, feature="content") as trace_id:
                 with llm_span("draft"):
                     pass
         (span_event, span), (trace_event, trace) = _events(mock_ph)
         assert (span_event, trace_event) == ("$ai_span", "$ai_trace")
-        assert span["$ai_trace_id"] == trace["$ai_trace_id"]
-        assert span["$ai_parent_id"] == trace["$ai_span_id"]
+        assert span["$ai_trace_id"] == trace["$ai_trace_id"] == trace_id
+        assert span["$ai_parent_id"] == trace_id
         assert span["$ai_span_name"] == "draft"
 
     def test_nested_spans_parent_onto_each_other(self):

--- a/tests/unit/utilities/test_llm_traces.py
+++ b/tests/unit/utilities/test_llm_traces.py
@@ -1,0 +1,253 @@
+"""Pipeline traces — `$ai_trace` / `$ai_span` (issue #746).
+
+A post costs six model calls, not one. These pin the property that makes the end-to-end cost
+question answerable at all: every call a pipeline makes shares ONE trace id, and two pipelines never
+share one. Everything else here guards the fail-soft posture — a trace is telemetry, so no failure
+inside it may change what the generation chain returns.
+"""
+import pytest
+from unittest.mock import patch
+
+pytestmark = pytest.mark.unit
+
+_MOD = "cqc_lem.utilities.observability"
+
+
+def _events(mock_ph):
+    """[(event_name, properties)] in capture order."""
+    return [(kw["event"], kw["properties"]) for _, kw in mock_ph.capture.call_args_list]
+
+
+class TestTraceIdentity:
+    def test_every_step_of_one_pipeline_shares_the_trace_id(self):
+        from cqc_lem.utilities.observability import current_llm_trace, llm_span, llm_trace
+        seen = []
+        with llm_trace("post_generation", user_id=7, feature="content"):
+            for step in ("research", "draft", "humanize"):
+                with llm_span(step):
+                    seen.append(current_llm_trace()[0])
+        assert len(set(seen)) == 1 and seen[0]
+
+    def test_two_pipelines_get_different_trace_ids(self):
+        from cqc_lem.utilities.observability import current_llm_trace, llm_trace
+        with llm_trace("post_generation", user_id=7) as first:
+            assert current_llm_trace()[0] == first
+        with llm_trace("post_generation", user_id=7) as second:
+            assert current_llm_trace()[0] == second
+        assert first and second and first != second
+
+    def test_the_scope_is_cleared_on_the_way_out(self):
+        from cqc_lem.utilities.observability import current_llm_trace, llm_trace
+        with llm_trace("post_generation", user_id=7):
+            pass
+        assert current_llm_trace() == (None, None)
+
+    def test_a_nested_trace_is_a_span_not_a_second_trace(self):
+        """create_text_post recurses into itself for post-type fallbacks. Two half-traces of one
+        post answer nobody's question, so the inner one joins the outer."""
+        from cqc_lem.utilities.observability import llm_trace
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            with llm_trace("post_generation", user_id=7) as outer:
+                with llm_trace("post_generation", user_id=7) as inner:
+                    assert inner == outer
+        names = [name for name, _ in _events(mock_ph)]
+        assert names == ["$ai_span", "$ai_trace"]
+
+    def test_a_span_outside_a_pipeline_is_a_no_op(self):
+        """Every shared-core step carries @llm_step, and most calls into them are not a pipeline."""
+        from cqc_lem.utilities.observability import llm_span
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            with llm_span("humanize") as span_id:
+                assert span_id is None
+        mock_ph.capture.assert_not_called()
+
+    def test_the_kill_switch_mints_no_trace_at_all(self):
+        from cqc_lem.utilities.observability import current_llm_trace, llm_span, llm_trace
+        with patch.dict("os.environ", {"LLM_TRACING_ENABLED": "false"}):
+            with patch(f"{_MOD}.posthog") as mock_ph:
+                with llm_trace("post_generation", user_id=7) as trace_id:
+                    assert trace_id is None
+                    assert current_llm_trace() == (None, None)
+                    with llm_span("draft"):
+                        pass
+        mock_ph.capture.assert_not_called()
+
+    def test_the_kill_switch_still_attributes_cost(self):
+        """Tracing off must not also turn off the attribution scope llm_trace opens."""
+        from cqc_lem.utilities.observability import current_llm_attribution, llm_trace
+        with patch.dict("os.environ", {"LLM_TRACING_ENABLED": "false"}):
+            with llm_trace("post_generation", user_id=7, feature="content"):
+                assert current_llm_attribution() == (7, "content")
+
+
+class TestEmittedEvents:
+    def test_the_trace_event_names_the_pipeline_and_carries_its_root_span(self):
+        from cqc_lem.utilities.observability import llm_trace
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            with llm_trace("post_generation", user_id=7, feature="content") as trace_id:
+                pass
+        (event, props), = _events(mock_ph)
+        assert event == "$ai_trace"
+        assert props["$ai_trace_id"] == trace_id
+        assert props["$ai_span_name"] == "post_generation"
+        assert props["$ai_span_id"]
+        assert "$ai_parent_id" not in props
+        assert props["$ai_latency"] >= 0
+        assert props["feature"] == "content"
+        assert mock_ph.capture.call_args_list[0][1]["distinct_id"] == "7"
+
+    def test_a_span_hangs_off_the_root_span(self):
+        from cqc_lem.utilities.observability import llm_trace, llm_span
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            with llm_trace("post_generation", user_id=7, feature="content"):
+                with llm_span("draft"):
+                    pass
+        (span_event, span), (trace_event, trace) = _events(mock_ph)
+        assert (span_event, trace_event) == ("$ai_span", "$ai_trace")
+        assert span["$ai_trace_id"] == trace["$ai_trace_id"]
+        assert span["$ai_parent_id"] == trace["$ai_span_id"]
+        assert span["$ai_span_name"] == "draft"
+
+    def test_nested_spans_parent_onto_each_other(self):
+        from cqc_lem.utilities.observability import llm_trace, llm_span
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            with llm_trace("post_generation", user_id=7):
+                with llm_span("draft"):
+                    with llm_span("humanize"):
+                        pass
+        (_, inner), (_, outer), _ = _events(mock_ph)
+        assert inner["$ai_span_name"] == "humanize"
+        assert inner["$ai_parent_id"] == outer["$ai_span_id"]
+
+    def test_extra_span_properties_ride_along(self):
+        from cqc_lem.utilities.observability import llm_trace, llm_span
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            with llm_trace("post_generation", user_id=7):
+                with llm_span("draft", post_type="personal_story"):
+                    pass
+        (_, span), _ = _events(mock_ph)
+        assert span["post_type"] == "personal_story"
+
+    def test_an_unattributed_pipeline_lands_on_the_system_sentinel(self):
+        from cqc_lem.utilities.observability import llm_trace
+        with patch(f"{_MOD}._current_task_context", return_value=(None, None)):
+            with patch(f"{_MOD}.posthog") as mock_ph:
+                with llm_trace("post_generation"):
+                    pass
+        _, kwargs = mock_ph.capture.call_args
+        assert kwargs["distinct_id"] == "system"
+        assert kwargs["properties"]["feature"] == "system"
+
+    def test_a_failed_pipeline_still_reports_and_re_raises(self):
+        from cqc_lem.utilities.observability import llm_trace, llm_span
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            with pytest.raises(ValueError):
+                with llm_trace("post_generation", user_id=7):
+                    with llm_span("draft"):
+                        raise ValueError("model said no")
+        (_, span), (_, trace) = _events(mock_ph)
+        assert span["$ai_is_error"] is True
+        assert span["$ai_error"] == "ValueError: model said no"
+        assert trace["$ai_is_error"] is True
+
+
+class TestFailSoft:
+    def test_a_capture_failure_never_reaches_the_caller(self):
+        from cqc_lem.utilities.observability import llm_trace
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            mock_ph.capture.side_effect = RuntimeError("posthog down")
+            with llm_trace("post_generation", user_id=7):
+                result = "the post"
+        assert result == "the post"
+
+    def test_the_scope_is_cleared_even_when_the_body_raises(self):
+        from cqc_lem.utilities.observability import current_llm_trace, llm_trace
+        with pytest.raises(ValueError):
+            with llm_trace("post_generation", user_id=7):
+                raise ValueError("boom")
+        assert current_llm_trace() == (None, None)
+
+
+class TestDecorators:
+    def test_llm_pipeline_opens_a_trace_and_attributes_it(self):
+        from cqc_lem.utilities.observability import (current_llm_attribution, current_llm_trace,
+                                                     llm_pipeline)
+
+        @llm_pipeline("post_generation", feature="content")
+        def generate(user_id: int, stage: str):
+            return current_llm_trace()[0], current_llm_attribution()
+
+        trace_id, attribution = generate(7, "awareness")
+        assert trace_id and attribution == (7, "content")
+
+    def test_llm_pipeline_reads_user_id_by_keyword_too(self):
+        from cqc_lem.utilities.observability import current_llm_attribution, llm_pipeline
+
+        @llm_pipeline("comment_generation", feature="comment")
+        def respond(post_content, user_id: int = None):
+            return current_llm_attribution()
+
+        assert respond("x", user_id=9) == (9, "comment")
+
+    def test_llm_step_opens_a_span_under_the_running_pipeline(self):
+        from cqc_lem.utilities.observability import llm_pipeline, llm_step
+
+        @llm_step("humanize")
+        def humanize(text):
+            return text.upper()
+
+        @llm_pipeline("post_generation", feature="content")
+        def generate(user_id: int):
+            return humanize("draft")
+
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            assert generate(7) == "DRAFT"
+        (span_event, span), (trace_event, trace) = _events(mock_ph)
+        assert (span_event, trace_event) == ("$ai_span", "$ai_trace")
+        assert span["$ai_span_name"] == "humanize"
+        assert span["$ai_trace_id"] == trace["$ai_trace_id"]
+
+    def test_llm_step_outside_a_pipeline_just_runs_the_function(self):
+        from cqc_lem.utilities.observability import llm_step
+
+        @llm_step("humanize")
+        def humanize(text):
+            return text.upper()
+
+        with patch(f"{_MOD}.posthog") as mock_ph:
+            assert humanize("draft") == "DRAFT"
+        mock_ph.capture.assert_not_called()
+
+
+class TestTheDecoratedPipelines:
+    """The decorators are the whole mechanism: strip one and its chain silently splinters back into
+    isolated generations with nothing in PostHog to say a step went missing."""
+
+    @pytest.mark.parametrize("module,name,pipeline", [
+        ("cqc_lem.app.run_content_plan", "create_text_post", "post_generation"),
+        ("cqc_lem.utilities.ai.ai_helper", "generate_newsletter_edition", "newsletter_edition"),
+        ("cqc_lem.utilities.ai.ai_helper", "generate_ai_response", "comment_generation"),
+    ])
+    def test_pipeline_roots_open_a_trace(self, module, name, pipeline):
+        import importlib
+        fn = getattr(importlib.import_module(module), name)
+        assert getattr(fn, "__llm_trace_name__", None) == pipeline
+
+    @pytest.mark.parametrize("module,name,step", [
+        ("cqc_lem.utilities.ai.content_research", "research_topic", "research"),
+        ("cqc_lem.utilities.ai.ai_helper", "get_thought_leadership_post_from_ai", "draft"),
+        ("cqc_lem.utilities.ai.ai_helper", "get_industry_news_post_from_ai", "draft"),
+        ("cqc_lem.utilities.ai.ai_helper", "get_personal_story_post_from_ai", "draft"),
+        ("cqc_lem.utilities.ai.ai_helper", "generate_engagement_prompt_post", "draft"),
+        ("cqc_lem.utilities.ai.ai_helper", "get_blog_summary_post_from_ai", "draft"),
+        ("cqc_lem.app.run_content_plan", "generate_website_content_post", "draft"),
+        ("cqc_lem.utilities.ai.ai_helper", "get_ai_linked_post_refinement", "refine"),
+        ("cqc_lem.utilities.ai.ai_helper", "optimize_post_hook", "hook"),
+        ("cqc_lem.utilities.ai.content_alignment", "humanize_text", "humanize"),
+        ("cqc_lem.utilities.ai.content_alignment", "score_authenticity", "authenticity"),
+        ("cqc_lem.app.run_content_plan", "_review_generated_post", "review"),
+    ])
+    def test_shared_core_steps_open_a_span(self, module, name, step):
+        import importlib
+        fn = getattr(importlib.import_module(module), name)
+        assert getattr(fn, "__llm_span_name__", None) == step


### PR DESCRIPTION
## Why

#647's stretch half never landed and vanished when #647 closed: a post is **six** model calls
(research → draft → refine → humanize → authenticity → review), each landing in PostHog as its own
isolated `$ai_generation` with its own proxy-minted trace id. The per-post question the LLM
analytics exist to answer — *what did THIS post cost, end to end?* — could not be asked.

Grouping is app-side work, because only the app knows where a pipeline starts.

## What

**`utilities/observability.py`** (the ONE place events are emitted) gains `llm_trace()` /
`llm_span()` and their decorator forms, emitting `$ai_trace` / `$ai_span`:

- `@llm_pipeline` marks a function that IS one pipeline and **supersedes `attribute_llm_cost`** on
  it — it opens the trace *and* the same `llm_attribution()` scope, reading the user id off the
  call's own `user_id` argument. Three roots: `create_text_post`, `generate_newsletter_edition`,
  `generate_ai_response`.
- `@llm_step` goes on the **step function**, never at a call site — newsletters and comments draw
  draft/research/humanize/authenticity from the same shared content core as posts, so decorating the
  core is what gives every pipeline a legible trace without touching one caller. Spans: `research`,
  `draft`, `refine`, `hook`, `humanize`, `authenticity`, `review`.

**`utilities/ai/client.py`** puts the ids on the wire. Two invariants worth knowing:

- Tracing rides in its **own** hook, not inside `_attach_attribution` — that one bails out whenever
  the caller supplied its own metadata, and `_call_llm` always does, so folding them together would
  have silently excluded nearly every generation LEM makes.
- **Two wires**, because LiteLLM's PostHog logger sources them from two places: the trace id must be
  the `x-litellm-trace-id` *header* (it becomes the proxy's `litellm_trace_id` → `$ai_trace_id`;
  sending it as metadata does nothing, the logger overwrites it from its own standard logging
  payload), while the parent span rides in `metadata.parent_run_id` → `$ai_parent_id`.

Behavioural edges, all covered by tests: a trace opened inside an open trace becomes a **span**
(`create_text_post` recurses for post-type fallbacks, and two half-traces of one post answer
nobody); a span outside a pipeline is a **no-op**; a capture failure is swallowed at DEBUG; and
`LLM_TRACING_ENABLED=false` mints no ids at all.

The proxy-side `$ai_generation` stream is untouched — no extra event, no changed property, no
LiteLLM config change.

## Testing

- `tests/unit/utilities/test_llm_traces.py` (32 tests) — trace id stable across a pipeline and
  distinct between pipelines, nesting/parenting, kill switch, error paths, fail-soft, and a
  parametrized guard that every pipeline root and shared-core step is still decorated (strip one and
  the chain silently splinters with nothing to say a step went missing).
- `tests/unit/utilities/ai/test_client_tracing.py` (10 tests) — builds **real** requests through the
  OpenAI SDK, so an SDK upgrade that moves the injection point fails CI rather than quietly dropping
  every trace. Covers header + `parent_run_id`, caller-set metadata, embeddings, raw provider models,
  untraced calls, and each hook surviving the other throwing.
- Full suite: `8820 passed`.

Docs: `docs/llm-analytics.md` §"Not in scope here" replaced with the pipeline-traces posture;
`CLAUDE.md` map entry and `.env.example` updated.

Closes #746

🤖 Generated with [Claude Code](https://claude.com/claude-code)
