### PR TITLE
fix(feedback): stop a GitHub DNS blip from filing itself as a defect (closes #767)

### DIFF
--- a/src/cqc_lem/utilities/feedback/issue_service.py
+++ b/src/cqc_lem/utilities/feedback/issue_service.py
@@ -45,6 +45,7 @@ Env:
 import json
 import os
 import re
+import time
 from typing import Optional
 
 from cqc_lem.utilities.ai.content_framework import as_vector, cosine_similarity, text_similarity
@@ -81,6 +82,21 @@ RATE_LIMIT_WINDOW_HOURS = 24
 MAX_CLUSTER_CANDIDATES = 100
 MAX_TITLE_CHARS = 120
 GITHUB_TIMEOUT_SECONDS = 20
+
+# Issue #767: a DNS/connect blip is the NETWORK, not a defect in this loop — GitHub is reached
+# best-effort and the row is left for the next pass either way. It is retried in place, then
+# reported as a WARNING so `log_escalation` decides: one blip stays a warning, GitHub unreachable
+# for three passes running becomes the ERROR/$exception it deserves.
+GITHUB_RETRY_ATTEMPTS = 3
+GITHUB_RETRY_BACKOFF_SECONDS = 0.5
+# Once the transport is down, every other call in the same pass fails the same way. Short-circuiting
+# them keeps ONE outage to ONE warning instead of one per request — three of which is exactly the
+# escalation threshold, i.e. an outage would file itself as a defect.
+GITHUB_UNREACHABLE_COOLDOWN_SECONDS = 60.0
+
+# Monotonic deadline for the cool-off above. Process-local on purpose: it exists to collapse the
+# retries of ONE pass, not to coordinate workers.
+_unreachable_until = 0.0
 
 # Issue #718: the label/assignee/comment sub-resource endpoints 403'd for weeks while `POST /issues`
 # kept succeeding, so every auto-filed issue landed label-less. Named in every failure log so the
@@ -516,27 +532,61 @@ def build_duplicate_comment(classification: FeedbackClassification,
 
 # --- GitHub I/O ---------------------------------------------------------------------------------
 
+def github_unreachable() -> bool:
+    """True while `github_request`'s transport cool-off is open — the call a caller just lost was
+    the network being down, not GitHub refusing it. Callers use this to keep an outage from being
+    reported as the permission failure it looks like (issue #767)."""
+    return time.monotonic() < _unreachable_until
+
+
+def _is_transport_failure(exc: BaseException) -> bool:
+    """Whether the request never reached GitHub. Every `requests` transport exception
+    (ConnectionError, Timeout, SSLError, …) subclasses `RequestException` -> `IOError`, as do the
+    builtin socket errors — an unreachable host is exactly the OSError family, anything else is
+    ours."""
+    return isinstance(exc, OSError)
+
+
 def github_request(method: str, path: str, payload: dict = None) -> Optional[object]:
     """One GitHub REST call, shared with the shipped-fix notifier (issue #502). Returns the parsed
     body (a dict, or a list for collection endpoints), or None when unconfigured/failed — filing is
     best-effort by design: a GitHub outage must never lose the feedback row. `path` may carry its
     own query string."""
+    global _unreachable_until
     token = github_token()
     if not token:
         log_warning("Feedback issue filing skipped — no FEEDBACK_GITHUB_TOKEN/GITHUB_TOKEN set",
                     api_provider="github")
         return None
+    if github_unreachable():
+        log_debug(f"GitHub {method} {path} skipped — transport still in the unreachable cool-off",
+                  api_provider="github")
+        return None
     import requests
     url = f"{GITHUB_API_BASE}/repos/{github_repo()}/{path.lstrip('/')}"
-    try:
-        response = requests.request(
-            method, url, json=payload, timeout=GITHUB_TIMEOUT_SECONDS,
-            headers={"Authorization": f"Bearer {token}",
-                     "Accept": "application/vnd.github+json",
-                     "X-GitHub-Api-Version": "2022-11-28"})
-    except Exception as e:
-        log_error(f"GitHub {method} {path} failed", exc=e, api_provider="github")
-        return None
+    response = None
+    for attempt in range(1, max(1, GITHUB_RETRY_ATTEMPTS) + 1):
+        try:
+            response = requests.request(
+                method, url, json=payload, timeout=GITHUB_TIMEOUT_SECONDS,
+                headers={"Authorization": f"Bearer {token}",
+                         "Accept": "application/vnd.github+json",
+                         "X-GitHub-Api-Version": "2022-11-28"})
+            break
+        except Exception as e:
+            if not _is_transport_failure(e):
+                log_error(f"GitHub {method} {path} failed", exc=e, api_provider="github")
+                return None
+            if attempt < GITHUB_RETRY_ATTEMPTS:
+                log_debug(f"GitHub {method} {path} transport attempt {attempt} failed — retrying",
+                          api_provider="github")
+                time.sleep(GITHUB_RETRY_BACKOFF_SECONDS * attempt)
+                continue
+            _unreachable_until = time.monotonic() + GITHUB_UNREACHABLE_COOLDOWN_SECONDS
+            log_warning(f"GitHub {method} {path} unreachable after {GITHUB_RETRY_ATTEMPTS} "
+                        f"attempts — the next pass retries", exc=e, api_provider="github")
+            return None
+    _unreachable_until = 0.0
     if response.status_code >= 300:
         log_error(f"GitHub {method} {path} returned {response.status_code}: "
                   f"{response.text[:300]}", api_provider="github",
@@ -878,7 +928,8 @@ def repair_auto_filed_issues(limit: int = MAX_REPAIR_ISSUES) -> dict:
     WRITE: a permission failure is deterministic, so if one repair is forbidden the next 49 are too,
     and hammering GitHub would only bury the one error that says why. A refused READ gets the same
     treatment after `REPAIR_READ_FAILURE_STOP` in a row — one unreadable issue is just a deleted
-    issue, but a run of them is the same broken token and must not cost 50 errors every beat."""
+    issue, but a run of them is the same broken token and must not cost 50 errors every beat. Reads
+    lost to an unreachable transport (issue #767) are neither: the pass defers with one warning."""
     if not github_token():
         return {"scanned": 0, "repaired": 0, "failed": 0}
     seen: set = set()
@@ -892,6 +943,12 @@ def repair_auto_filed_issues(limit: int = MAX_REPAIR_ISSUES) -> dict:
         issue = github_request("GET", f"issues/{int(number)}")
         if not isinstance(issue, dict):
             failed += 1
+            if github_unreachable():
+                # Issue #767: the reads are failing because the network is, so the token hint below
+                # would be a lie and the remaining GETs would only repeat it.
+                log_warning("Feedback issue repair pass deferred — GitHub is unreachable from this "
+                            "host; the next beat retries", api_provider="github")
+                break
             unreadable += 1
             if unreadable >= REPAIR_READ_FAILURE_STOP:
                 log_error(f"Feedback issue repair pass stopped — {unreadable} issue reads in a row "

--- a/src/cqc_lem/utilities/feedback/issue_service.py
+++ b/src/cqc_lem/utilities/feedback/issue_service.py
@@ -89,6 +89,16 @@ GITHUB_TIMEOUT_SECONDS = 20
 # for three passes running becomes the ERROR/$exception it deserves.
 GITHUB_RETRY_ATTEMPTS = 3
 GITHUB_RETRY_BACKOFF_SECONDS = 0.5
+# Only a READ is replayed. A write that failed AFTER GitHub accepted it (read timeout, connection
+# reset mid-response) is indistinguishable from one that never landed, so retrying `POST /issues`
+# would file the duplicate this whole module exists to prevent. A lost write costs nothing: the
+# cluster is still open and the next beat's repair pass re-attaches it.
+GITHUB_IDEMPOTENT_METHODS = ("GET", "HEAD")
+# Deterministic `requests` faults that also inherit IOError. A malformed URL or a redirect loop is
+# OUR bug, not the network — retrying it three times and reporting it as "unreachable" would hide
+# the one thing worth alerting on.
+NON_TRANSPORT_REQUEST_ERRORS = ("URLRequired", "MissingSchema", "InvalidSchema", "InvalidURL",
+                                "InvalidHeader", "InvalidJSONError", "TooManyRedirects")
 # Once the transport is down, every other call in the same pass fails the same way. Short-circuiting
 # them keeps ONE outage to ONE warning instead of one per request — three of which is exactly the
 # escalation threshold, i.e. an outage would file itself as a defect.
@@ -543,8 +553,22 @@ def _is_transport_failure(exc: BaseException) -> bool:
     """Whether the request never reached GitHub. Every `requests` transport exception
     (ConnectionError, Timeout, SSLError, …) subclasses `RequestException` -> `IOError`, as do the
     builtin socket errors — an unreachable host is exactly the OSError family, anything else is
-    ours."""
+    ours. The deterministic `requests` faults share that base but are ours too, so they are named
+    out by class rather than imported (this module keeps `requests` a lazy import)."""
+    if any(base.__name__ in NON_TRANSPORT_REQUEST_ERRORS for base in type(exc).__mro__):
+        return False
     return isinstance(exc, OSError)
+
+
+def _log_lost_write(message: str) -> None:
+    """A refused WRITE breaks the loop and is an ERROR — the operator has to fix the token. But when
+    the transport is down (issue #767) that hint is a lie: nothing was refused, the call never left
+    the host, and the repair pass re-attaches on the next beat."""
+    if github_unreachable():
+        log_warning(f"{message} — GitHub is unreachable from this host; the repair pass re-attaches",
+                    api_provider="github")
+    else:
+        log_error(f"{message}. {TOKEN_PERMISSION_HINT}", api_provider="github")
 
 
 def github_request(method: str, path: str, payload: dict = None) -> Optional[object]:
@@ -564,8 +588,10 @@ def github_request(method: str, path: str, payload: dict = None) -> Optional[obj
         return None
     import requests
     url = f"{GITHUB_API_BASE}/repos/{github_repo()}/{path.lstrip('/')}"
+    attempts = (max(1, GITHUB_RETRY_ATTEMPTS)
+                if str(method).upper() in GITHUB_IDEMPOTENT_METHODS else 1)
     response = None
-    for attempt in range(1, max(1, GITHUB_RETRY_ATTEMPTS) + 1):
+    for attempt in range(1, attempts + 1):
         try:
             response = requests.request(
                 method, url, json=payload, timeout=GITHUB_TIMEOUT_SECONDS,
@@ -577,14 +603,14 @@ def github_request(method: str, path: str, payload: dict = None) -> Optional[obj
             if not _is_transport_failure(e):
                 log_error(f"GitHub {method} {path} failed", exc=e, api_provider="github")
                 return None
-            if attempt < GITHUB_RETRY_ATTEMPTS:
+            if attempt < attempts:
                 log_debug(f"GitHub {method} {path} transport attempt {attempt} failed — retrying",
                           api_provider="github")
                 time.sleep(GITHUB_RETRY_BACKOFF_SECONDS * attempt)
                 continue
             _unreachable_until = time.monotonic() + GITHUB_UNREACHABLE_COOLDOWN_SECONDS
-            log_warning(f"GitHub {method} {path} unreachable after {GITHUB_RETRY_ATTEMPTS} "
-                        f"attempts — the next pass retries", exc=e, api_provider="github")
+            log_warning(f"GitHub {method} {path} unreachable after {attempts} "
+                        f"attempt(s) — the next pass retries", exc=e, api_provider="github")
             return None
     _unreachable_until = 0.0
     if response.status_code >= 300:
@@ -617,14 +643,12 @@ def create_github_issue(title: str, body: str, labels: list,
     label_list = [str(label) for label in (labels or [])]
     if label_list and github_request("POST", f"issues/{number}/labels",
                                      {"labels": label_list}) is None:
-        log_error(f"Auto-filed issue #{number} could not be labeled {label_list} — it is invisible "
-                  f"to the agent pipeline until this is repaired. {TOKEN_PERMISSION_HINT}",
-                  api_provider="github")
+        _log_lost_write(f"Auto-filed issue #{number} could not be labeled {label_list} — it is "
+                        f"invisible to the agent pipeline until this is repaired")
     assignee_list = [str(assignee) for assignee in (assignees or [])]
     if assignee_list and github_request("POST", f"issues/{number}/assignees",
                                         {"assignees": assignee_list}) is None:
-        log_error(f"Auto-filed issue #{number} could not be assigned to {assignee_list}. "
-                  f"{TOKEN_PERMISSION_HINT}", api_provider="github")
+        _log_lost_write(f"Auto-filed issue #{number} could not be assigned to {assignee_list}")
     log_info(f"Auto-filed feedback issue #{number}: {title}", api_provider="github")
     return number
 
@@ -904,9 +928,8 @@ def repair_filed_issue(issue: dict) -> str:
     wanted = labels_for_issue(classification, reporter_count)
     missing = [label for label in wanted if label not in present]
     if github_request("POST", f"issues/{number}/labels", {"labels": missing}) is None:
-        log_error(f"Could not repair auto-filed issue #{number} — attaching {missing} was refused, "
-                  f"so it stays invisible to the pipeline. {TOKEN_PERMISSION_HINT}",
-                  api_provider="github")
+        _log_lost_write(f"Could not repair auto-filed issue #{number} — attaching {missing} did not "
+                        f"land, so it stays invisible to the pipeline")
         return RepairAction.ERROR
     if AGENT_READY_LABEL not in wanted:
         if not issue.get("assignees"):

--- a/tests/unit/utilities/test_feedback_issue_service.py
+++ b/tests/unit/utilities/test_feedback_issue_service.py
@@ -26,6 +26,15 @@ def _mod():
     return issue_service
 
 
+@pytest.fixture(autouse=True)
+def _clear_transport_cool_off():
+    """Issue #767: the unreachable cool-off is process-global by design, so one test's simulated
+    outage would silently short-circuit the next test's request."""
+    _mod()._unreachable_until = 0.0
+    yield
+    _mod()._unreachable_until = 0.0
+
+
 def _classification(**overrides):
     from cqc_lem.utilities.feedback.classifier import (
         FeedbackCategory, FeedbackClassification, FeedbackRisk, FeedbackSeverity)
@@ -562,7 +571,7 @@ class TestGithubIO:
         monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
         requests = MagicMock()
         requests.request.side_effect = OSError("connection reset")
-        with patch.dict("sys.modules", {"requests": requests}):
+        with patch.dict("sys.modules", {"requests": requests}), patch(f"{_SVC}.time.sleep"):
             assert svc.comment_on_issue(5, "body") is False
 
     def test_comment_targets_the_issue_number(self, monkeypatch):
@@ -588,6 +597,90 @@ class TestGithubIO:
 
     def test_comment_without_an_issue_number_is_a_no_op(self):
         assert _mod().comment_on_issue(None, "+1") is False
+
+
+class TestTransportFailures:
+    """Issue #767: a DNS/connect blip is the network, not a defect in this loop. It is retried in
+    place and reported ONCE as a WARNING (recurrence escalation decides whether it is a defect) —
+    an ERROR per lost request turned a 100ms outage into an auto-filed GitHub issue."""
+
+    def _response(self, status=200, payload=None):
+        response = MagicMock(status_code=status, text="")
+        response.json.return_value = payload if payload is not None else {}
+        return response
+
+    def test_a_dns_failure_is_retried_then_warned_not_errored(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        requests = MagicMock()
+        requests.request.side_effect = ConnectionError(
+            "Failed to resolve 'api.github.com' ([Errno -3] Temporary failure in name resolution)")
+        with patch.dict("sys.modules", {"requests": requests}), \
+                patch(f"{_SVC}.time.sleep") as sleep, \
+                patch(f"{_SVC}.log_warning") as warning, patch(f"{_SVC}.log_error") as error:
+            assert svc.github_request("GET", "issues/727") is None
+        assert requests.request.call_count == svc.GITHUB_RETRY_ATTEMPTS
+        assert sleep.call_count == svc.GITHUB_RETRY_ATTEMPTS - 1
+        error.assert_not_called()
+        assert "unreachable" in warning.call_args[0][0]
+        assert warning.call_args.kwargs["exc"] is not None
+
+    def test_a_transport_failure_that_recovers_is_never_reported(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        requests = MagicMock()
+        requests.request.side_effect = [TimeoutError("read timed out"),
+                                        self._response(200, {"number": 5})]
+        with patch.dict("sys.modules", {"requests": requests}), \
+                patch(f"{_SVC}.time.sleep"), \
+                patch(f"{_SVC}.log_warning") as warning, patch(f"{_SVC}.log_error") as error:
+            assert svc.github_request("GET", "issues/5") == {"number": 5}
+        assert requests.request.call_count == 2
+        warning.assert_not_called()
+        error.assert_not_called()
+        assert svc.github_unreachable() is False
+
+    def test_a_failure_that_is_not_the_transport_is_still_an_error(self, monkeypatch):
+        # A bug in this module must not be retried three times and filed away as "the network".
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        requests = MagicMock()
+        requests.request.side_effect = ValueError("bad payload")
+        with patch.dict("sys.modules", {"requests": requests}), \
+                patch(f"{_SVC}.time.sleep") as sleep, patch(f"{_SVC}.log_error") as error:
+            assert svc.github_request("POST", "issues") is None
+        assert requests.request.call_count == 1
+        sleep.assert_not_called()
+        assert "failed" in error.call_args[0][0]
+
+    def test_one_outage_is_reported_once_and_short_circuits_the_rest_of_the_pass(self,
+                                                                                monkeypatch):
+        # Three lost requests in one pass = three warnings = the escalation threshold, i.e. the
+        # outage would file itself as a defect. The cool-off is what keeps it to one.
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        requests = MagicMock()
+        requests.request.side_effect = ConnectionError("no route to host")
+        with patch.dict("sys.modules", {"requests": requests}), \
+                patch(f"{_SVC}.time.sleep"), patch(f"{_SVC}.log_warning") as warning, \
+                patch(f"{_SVC}.log_error") as error:
+            assert svc.github_request("GET", "issues/101") is None
+            assert svc.github_unreachable() is True
+            assert svc.github_request("GET", "issues/102") is None
+            assert svc.github_request("POST", "issues/103/comments", {"body": "x"}) is None
+        assert requests.request.call_count == svc.GITHUB_RETRY_ATTEMPTS
+        assert warning.call_count == 1
+        error.assert_not_called()
+
+    def test_a_successful_call_clears_the_cool_off(self, monkeypatch):
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        svc._unreachable_until = 0.0
+        requests = MagicMock()
+        requests.request.return_value = self._response(200, {"ok": True})
+        with patch.dict("sys.modules", {"requests": requests}):
+            assert svc.github_request("GET", "issues/1") == {"ok": True}
+        assert svc.github_unreachable() is False
 
 
 class TestFileFeedbackIssue:
@@ -1264,6 +1357,21 @@ class TestRepairAutoFiledIssues:
             assert svc.repair_auto_filed_issues() == {"scanned": 3, "repaired": 0, "failed": 3}
         assert request.call_count == svc.REPAIR_READ_FAILURE_STOP
         assert "Issues: Read and write" in error.call_args[0][0]
+
+    def test_an_unreachable_transport_defers_the_sweep_without_blaming_the_token(self, monkeypatch):
+        # Issue #767: these reads were lost to the network, so the #718 token hint would be a lie —
+        # and every remaining GET would only re-report the same outage.
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        clusters = [_cluster(n, issue=100 + n) for n in range(1, 8)]
+        with patch(f"{_SVC}.get_open_feedback_clusters", return_value=clusters), \
+                patch(f"{_SVC}.github_request", return_value=None) as request, \
+                patch(f"{_SVC}.github_unreachable", return_value=True), \
+                patch(f"{_SVC}.log_warning") as warning, patch(f"{_SVC}.log_error") as error:
+            assert svc.repair_auto_filed_issues() == {"scanned": 1, "repaired": 0, "failed": 1}
+        assert request.call_count == 1
+        assert "unreachable" in warning.call_args[0][0]
+        error.assert_not_called()
 
     def test_the_work_list_is_bounded(self, monkeypatch):
         svc = _mod()

--- a/tests/unit/utilities/test_feedback_issue_service.py
+++ b/tests/unit/utilities/test_feedback_issue_service.py
@@ -529,6 +529,20 @@ class TestGithubIO:
         assert any("could not be assigned" in m for m in messages)
         warning.assert_not_called()
 
+    def test_a_lost_attach_does_not_blame_the_token_while_github_is_unreachable(self, monkeypatch):
+        # Issue #767: the create landed, then the network went. Nothing was "refused", so the #718
+        # token hint would be a lie — and at ERROR it files the outage as a defect all over again.
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        with patch(f"{_SVC}.github_request", side_effect=[{"number": 31}, None, None]), \
+                patch(f"{_SVC}.github_unreachable", return_value=True), \
+                patch(f"{_SVC}.log_error") as error, patch(f"{_SVC}.log_warning") as warning:
+            assert svc.create_github_issue("t", "b", ["bug"], assignees=["gitchrisqueen"]) == 31
+        error.assert_not_called()
+        assert warning.call_count == 2
+        assert all("unreachable" in call[0][0] for call in warning.call_args_list)
+        assert not any("Issues: Read and write" in call[0][0] for call in warning.call_args_list)
+
     def test_a_held_issue_with_no_decision_comment_is_an_error(self):
         # The owner is asked to answer a Decision Comment that never posted — a silent dead end.
         svc = _mod()
@@ -671,6 +685,43 @@ class TestTransportFailures:
         assert requests.request.call_count == svc.GITHUB_RETRY_ATTEMPTS
         assert warning.call_count == 1
         error.assert_not_called()
+
+    def test_a_write_is_never_replayed(self, monkeypatch):
+        # A POST that died AFTER GitHub accepted it looks identical to one that never landed, so a
+        # replayed `POST /issues` files the duplicate this module exists to prevent. Reported the
+        # same way — the write is simply left for the next pass.
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        requests = MagicMock()
+        requests.request.side_effect = TimeoutError("read timed out")
+        with patch.dict("sys.modules", {"requests": requests}), \
+                patch(f"{_SVC}.time.sleep") as sleep, \
+                patch(f"{_SVC}.log_warning") as warning, patch(f"{_SVC}.log_error") as error:
+            assert svc.github_request("POST", "issues", {"title": "t"}) is None
+        assert requests.request.call_count == 1
+        sleep.assert_not_called()
+        error.assert_not_called()
+        assert "unreachable" in warning.call_args[0][0]
+        assert svc.github_unreachable() is True
+
+    def test_a_deterministic_requests_fault_is_ours_not_the_network(self, monkeypatch):
+        # `requests.exceptions.MissingSchema` inherits IOError like every transport error does, but
+        # a malformed URL is a config/code bug — retrying it and calling it "unreachable" would both
+        # hide the real fault and silently skip the rest of the pass on the cool-off.
+        from requests.exceptions import MissingSchema
+        svc = _mod()
+        monkeypatch.setenv("FEEDBACK_GITHUB_TOKEN", "tok")
+        requests = MagicMock()
+        requests.request.side_effect = MissingSchema("Invalid URL 'repos/o r/issues'")
+        with patch.dict("sys.modules", {"requests": requests}), \
+                patch(f"{_SVC}.time.sleep") as sleep, \
+                patch(f"{_SVC}.log_warning") as warning, patch(f"{_SVC}.log_error") as error:
+            assert svc.github_request("GET", "issues/1") is None
+        assert requests.request.call_count == 1
+        sleep.assert_not_called()
+        warning.assert_not_called()
+        assert "failed" in error.call_args[0][0]
+        assert svc.github_unreachable() is False
 
     def test_a_successful_call_clears_the_cool_off(self, monkeypatch):
         svc = _mod()
@@ -1285,6 +1336,20 @@ class TestRepairFiledIssue:
         assert request.call_count == 1
         comment.assert_not_called()
         assert "Issues: Read and write" in error.call_args[0][0]
+
+    def test_a_repair_write_lost_to_the_transport_is_not_a_token_error(self):
+        # Issue #767: same write, but the host cannot reach GitHub at all — a warning the next beat
+        # clears, not the ERROR/$exception that files the outage as a permissions defect.
+        svc = _mod()
+        from cqc_lem.utilities.feedback.classifier import FeedbackRisk
+        issue = self._issue(classification=_classification(risk=FeedbackRisk.SECURITY))
+        with patch(f"{_SVC}.github_request", return_value=None), \
+                patch(f"{_SVC}.github_unreachable", return_value=True), \
+                patch(f"{_SVC}.comment_on_issue"), \
+                patch(f"{_SVC}.log_error") as error, patch(f"{_SVC}.log_warning") as warning:
+            assert svc.repair_filed_issue(issue) == svc.RepairAction.ERROR
+        error.assert_not_called()
+        assert "unreachable" in warning.call_args[0][0]
 
 
 class TestRepairAutoFiledIssues:


### PR DESCRIPTION
## What & why

PostHog grouped a live `ConnectionError` into an active issue: `HTTPSConnectionPool(host='api.github.com') ... NameResolutionError` — 3 occurrences inside 100ms during the `auto_file_feedback_issues` beat, on `GET /issues/727` (the #718 repair sweep).

`github_request` treated **every** failed call as `log_error(..., exc=e)`. GitHub is reached best-effort here — filing is retried on the next pass and the feedback row is never lost — so a DNS/connect blip is the network, not a defect in this loop. Logging it at ERROR captured a `$exception` per lost request, and the daily error→issue cron filed the outage as a bug.

Now, per `utilities/CLAUDE.md` ("once is a warning, repeatedly is a defect"):

- **Transport failures are retried in place** — the OSError family (DNS, connect, reset, timeout; every `requests` transport exception subclasses `RequestException` → `IOError`), 3 attempts with 0.5s linear backoff. A blip that recovers is reported nowhere.
- **Exhausted retries log ONE `log_warning`**, so `log_escalation` makes the call: one blip stays a warning, GitHub unreachable across three passes is re-emitted at ERROR + `$exception` and legitimately becomes an issue.
- **Anything that is not the transport is untouched** — still `log_error` immediately, no retries. HTTP ≥300 responses (403/422 — the deterministic #598/#718 token problems) still log at ERROR exactly as before.
- **A 60s process-local cool-off short-circuits the rest of the pass.** Without it, one outage costs three warnings inside a single pass — which *is* the escalation threshold, so the outage would still file itself.
- **The repair sweep defers with one warning** when the transport is down, instead of stopping with the #718 `FEEDBACK_GITHUB_TOKEN needs Issues: Read and write` error — which, during a network outage, is a lie.

Shared helper, so the shipped-fix notifier (#502) and the capacity alerter get the same posture.

## Testing

- New `TestTransportFailures`: DNS failure retried then warned (never errored), a recovered blip reported nowhere, a non-transport exception still an immediate error with no retries, one outage = one warning + short-circuited pass, success clears the cool-off.
- New repair-sweep test: an unreachable transport defers after ONE read with a warning and never emits the token-permission error.
- Autouse fixture resets the process-global cool-off between tests.
- `poetry run pytest tests/unit -q` → **8826 passed**.

Closes #767

🤖 Generated with [Claude Code](https://claude.com/claude-code)
