### PR TITLE
fix(ai): guard second-wave comment against LLM responses with missing choices (closes #768)

### DIFF
--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -2,6 +2,7 @@ import os
 import random
 import time
 from datetime import datetime
+from typing import Any, Optional
 
 import openai
 import replicate
@@ -84,6 +85,22 @@ def _resolve_serving_model(response, requested_model: str) -> str:
         if val:
             return str(val)
     return requested_model
+
+
+def _first_choice(response) -> "Optional[Any]":
+    """Safely extract the first completion choice from an LLM response.
+
+    Some proxy / edge responses return a response object with `choices=None`
+    (or an empty list) instead of raising. Treating that as "no usable output"
+    lets the caller degrade gracefully rather than surfacing a TypeError into
+    error tracking (issue #768)."""
+    try:
+        choices = getattr(response, "choices", None)
+        if choices and len(choices) > 0:
+            return choices[0]
+    except Exception:
+        pass
+    return None
 
 
 def _call_llm(**kwargs):
@@ -979,7 +996,12 @@ def generate_second_wave_comment(post_content, profile: "LinkedInProfile", prefs
                              messages=[{"role": "system", "content": system_prompt["content"] + fix},
                                        user_prompt],
                              temperature=temperature)
-        content = response.choices[0].message.content
+        choice = _first_choice(response)
+        if choice is None:
+            log_warning("Second-wave comment LLM response had no usable choice",
+                        user_id=user_id, action_type="comment")
+            return None
+        content = choice.message.content
         if content is None:
             return None
         # Humanization pass (issue #416 — A5) before the gate, so the contract grades what ships.

--- a/tests/unit/app/test_second_wave_comment.py
+++ b/tests/unit/app/test_second_wave_comment.py
@@ -271,6 +271,16 @@ class TestGenerateSecondWaveComment:
         resp.choices = [MagicMock(message=MagicMock(content=text))]
         return resp
 
+    def _response_no_choices(self):
+        resp = MagicMock()
+        resp.choices = None
+        return resp
+
+    def _response_empty_choices(self):
+        resp = MagicMock()
+        resp.choices = []
+        return resp
+
     def test_a_passing_draft_is_returned(self):
         from cqc_lem.utilities.ai import ai_helper
         draft = ("The 40% figure in the post came from one migration, not the whole fleet. "
@@ -305,3 +315,23 @@ class TestGenerateSecondWaveComment:
                                                    recent_comments=[])
         user_message = llm.call_args.kwargs["messages"][1]["content"]
         assert "cut CI 22→8 minutes" in user_message
+
+    def test_missing_choices_degrades_to_none(self):
+        """A malformed LLM response with choices=None must not raise TypeError; it should be treated
+        as a draft that failed the gate (issue #768)."""
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=self._response_no_choices()), \
+             patch(f"{_AI}.log_warning") as warn:
+            out = ai_helper.generate_second_wave_comment("our migration cut build cost 40%",
+                                                         self._profile(), recent_comments=[])
+        assert out is None
+        warn.assert_called_once()
+
+    def test_empty_choices_degrades_to_none(self):
+        from cqc_lem.utilities.ai import ai_helper
+        with patch(f"{_AI}._call_llm", return_value=self._response_empty_choices()), \
+             patch(f"{_AI}.log_warning") as warn:
+            out = ai_helper.generate_second_wave_comment("our migration cut build cost 40%",
+                                                         self._profile(), recent_comments=[])
+        assert out is None
+        warn.assert_called_once()


### PR DESCRIPTION
## What & Why

PostHog error tracking grouped a `TypeError: 'NoneType' object is not subscriptable` inside `auto_second_wave_comment` (issue #768). The root cause is that `generate_second_wave_comment` assumes the LLM response always carries `response.choices[0]`; some proxy/edge responses return `choices=None` (or an empty list) instead of raising.

## Change

- Add `_first_choice()` helper in `ai_helper.py` to safely extract the first completion choice.
- In `generate_second_wave_comment`, use the helper and degrade to `None` (log a warning) when no usable choice exists. This follows the existing graceful-degradation contract: a draft that can't be produced is treated as a quality-gate failure, so the second wave ships nothing instead of crashing the Celery task.

## Testing

- Added two unit tests in `tests/unit/app/test_second_wave_comment.py` covering `choices=None` and `choices=[]`.
- Ran `poetry run pytest tests/unit/app/test_second_wave_comment.py tests/unit/utilities/ai/test_ai_helper.py -q` — 73 passed.

Closes #768

🤖 Generated with [Claude Code](https://claude.com/claude-code)
