### PR TITLE
feat(groups): make group posting a visible, per-group choice (closes #769)

### DIFF
--- a/compose/local/database/migrations/V20260801023643__add_user_group_post_settings.sql
+++ b/compose/local/database/migrations/V20260801023643__add_user_group_post_settings.sql
@@ -1,0 +1,25 @@
+-- Per-group POSTING control, separate from per-group engagement (issue #769).
+--
+-- V41 gave `user_groups.enabled` a single meaning for two very different actions: value-add
+-- COMMENTS on other people's group posts (daily) and LEM publishing its OWN post into a group
+-- (weekly). A user who is happy to be commented-for in twelve groups has no way to say "but only
+-- post in these two", and the weekly post silently went to whichever enabled row the database
+-- happened to return first — invisible in the SPA and never rotating.
+--
+-- `post_enabled` splits the two so the Groups card can show (and control) them separately, and
+-- `last_posted_at` makes "which group is next" a stated, least-recently-posted rotation instead of
+-- an arbitrary row order. NULL last_posted_at = never posted there, which sorts FIRST so a newly
+-- joined group gets its turn before a group that already had one.
+--
+-- The two flags are independent from here on (commenting reads `enabled`, posting reads
+-- `post_enabled`), so existing rows are BACKFILLED from `enabled` rather than taking the column
+-- default: a group the user had already switched off must not start receiving posts because a new
+-- column defaulted to on. New rows keep DEFAULT 1, matching `enabled`'s opted-in-by-default posture.
+--
+-- Weekly volume is unchanged — still ONE group post per user per week; it just rotates now, and
+-- which group is next is visible in the SPA.
+ALTER TABLE user_groups
+    ADD COLUMN post_enabled   TINYINT(1) NOT NULL DEFAULT 1 AFTER enabled,
+    ADD COLUMN last_posted_at DATETIME NULL DEFAULT NULL AFTER last_synced_at;
+
+UPDATE user_groups SET post_enabled = enabled;

--- a/docs/SETTINGS_IA_RESEARCH.md
+++ b/docs/SETTINGS_IA_RESEARCH.md
@@ -115,7 +115,11 @@ Read-only fields the GET adds for the UI: `reply_inbound_address`, `gmail_forwar
   collaboration, profile viewer, nurture, plus six catch-up milestones. Each has step 0 + N
   follow-ups with `delay_hours`. Blank = built-in default.
 - **Lead magnet** — enabled, trigger keyword, DM message.
-- **Groups** — per joined group on/off; all on by default.
+- **Groups** — per joined group, TWO independent switches (issue #769): *Comment* (daily value-add
+  comments on other members' posts, out of the daily comment cap) and *Post* (the weekly ORIGINAL
+  group post — never a copy or reshare of a scheduled feed post, one group per week, rotating to
+  whichever post-enabled group has gone longest without one). Both on by default; the card names the
+  group the next post lands in.
 - **Billing** — plan/tier/trial, Stripe portal, video-credit and avatar-credit packs.
 
 ---

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -59,7 +59,8 @@ from cqc_lem.utilities.db import (
     get_newsletter_settings, update_newsletter_settings,
     get_pending_newsletter_editions,
     get_latest_edition_scheduled_for, update_newsletter_edition, get_newsletter_edition,
-    get_user_groups, set_groups_enabled, get_post_engagement_rows, get_post_performance_rows,
+    get_user_groups, set_groups_enabled, get_next_group_for_post,
+    get_post_engagement_rows, get_post_performance_rows,
     get_content_mix_counts, get_comment_outcomes,
     get_follower_stats, get_daily_action_counts,
     get_lead_magnet_settings, update_lead_magnet_settings,
@@ -2876,7 +2877,8 @@ def delete_catchup_touch_endpoint(request: CatchupTouchDeleteRequest) -> Respons
 
 class GroupTogglesRequest(BaseModel):
     session_token: str
-    groups: dict = {}  # {group_id: enabled}
+    # {group_id: enabled} or {group_id: {"enabled": bool, "post_enabled": bool}} (issue #769)
+    groups: dict = {}
 
 
 @router.get("/user/groups")
@@ -2884,7 +2886,14 @@ def get_user_groups_endpoint(session_token: str) -> ResponseModel:
     user_id = get_session_user_id(session_token)
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")
-    return ResponseModel(status_code=200, detail=get_user_groups(user_id))
+    groups = get_user_groups(user_id)
+    # Which group the next weekly group post lands in — marked on the row rather than returned
+    # beside the list, so an older SPA bundle still reads `detail` as a plain array (issue #743).
+    nxt = get_next_group_for_post(user_id)
+    next_gid = nxt.get("group_id") if nxt else None
+    for g in groups:
+        g["is_next_post"] = g.get("group_id") == next_gid
+    return ResponseModel(status_code=200, detail=groups)
 
 
 @router.put("/user/groups")

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -35,7 +35,8 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
     get_newsletter_settings, mark_newsletter_published, record_newsletter_subscriber_stat, \
     get_newsletter_edition, mark_edition_published, mark_edition_failed, \
-    upsert_user_group, get_enabled_group_ids, record_post_stats, get_recent_posted_post_ids, \
+    upsert_user_group, get_enabled_group_ids, record_group_post, record_post_stats, \
+    get_recent_posted_post_ids, \
     get_shipped_variant_keys, \
     get_lead_magnet_settings, has_received_lead_magnet, record_lead_magnet_sent, \
     LogResultType, has_user_commented_on_post_url, get_post_url_from_log_for_user, get_post_message_from_log_for_user, \
@@ -2382,9 +2383,10 @@ def auto_comment_in_groups(self, user_id: int, max_per_group: int = 2):
 
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id', 'group_id']},
                   queue='se_content')
-def auto_post_to_group(self, user_id: int, group_id: str):
-    """Publish one short, value-add (non-promotional) post into a group via its share box.
-    Best-effort — the group composer selectors are validated in the live pass."""
+def auto_post_to_group(self, user_id: int, group_id: str, group_name: str = None):
+    """Publish one short, value-add (non-promotional) post into a group via its share box. The text
+    is written FRESH for that group — a group post is never a copy or reshare of a scheduled feed
+    post. Best-effort — the group composer selectors are validated in the live pass."""
     try:
         driver, wait, user_email, my_profile = get_current_profile(user_id=user_id, session_name="Group Post")
     except Exception as e:
@@ -2395,7 +2397,7 @@ def auto_post_to_group(self, user_id: int, group_id: str):
         time.sleep(random.uniform(4, 7))
         with llm_attribution(user_id=user_id, feature=FEATURE_CONTENT):
             text = _strip_non_bmp(generate_group_post(
-                my_profile, prefs=get_engagement_preferences(user_id),
+                my_profile, group_name=group_name, prefs=get_engagement_preferences(user_id),
                 profile_synthesis=get_or_create_profile_synthesis(user_id, my_profile)) or "")
         if not text.strip():
             return "No group post generated"
@@ -2418,6 +2420,9 @@ def auto_post_to_group(self, user_id: int, group_id: str):
                        required=False) is None:
             return "Group Post button not found"
         time.sleep(random.uniform(3, 5))
+        # Only a post that actually shipped advances the rotation — a failed run leaves this group
+        # next in line rather than skipping its turn.
+        record_group_post(user_id, group_id)
         return "Posted to group"
     except Exception as e:
         log_error("Group post error", exc=e, user_id=user_id, task_name="auto_post_to_group")

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1091,17 +1091,20 @@ def auto_group_engagement():
 
 @shared_task.task
 def auto_group_posts():
-    """Weekly: publish one value-add post into an enabled group per active user."""
+    """Weekly: publish ONE original value-add post into ONE of the user's post-enabled groups —
+    never a copy or reshare of a scheduled feed post. Which group is the least-recently-posted one
+    (issue #769), so the weekly slot rotates instead of always landing in the same group."""
     from cqc_lem.app.run_automation import auto_post_to_group
-    from cqc_lem.utilities.db import get_enabled_group_ids
+    from cqc_lem.utilities.db import get_next_group_for_post
     users = get_active_user_ids()
     n = 0
     for uid in users:
         if not has_linkedin_session(uid):
             continue
-        groups = get_enabled_group_ids(uid)
-        if groups:
-            auto_post_to_group.apply_async(kwargs={'user_id': uid, 'group_id': groups[0]})
+        group = get_next_group_for_post(uid)
+        if group:
+            auto_post_to_group.apply_async(kwargs={'user_id': uid, 'group_id': group['group_id'],
+                                                   'group_name': group.get('group_name')})
             n += 1
     return f"Group posts dispatched for {n}/{len(users)} user(s)"
 

--- a/src/cqc_lem/ui/src/components/Toggle.tsx
+++ b/src/cqc_lem/ui/src/components/Toggle.tsx
@@ -1,8 +1,9 @@
-export default function Toggle({ on, onClick }: { on: boolean; onClick: () => void }) {
+export default function Toggle({ on, onClick, ariaLabel }: { on: boolean; onClick: () => void; ariaLabel?: string }) {
   return (
     <button
       type="button"
       onClick={onClick}
+      aria-label={ariaLabel}
       className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${on ? 'bg-blue-600' : 'bg-gray-200'}`}
       role="switch"
       aria-checked={on}

--- a/src/cqc_lem/ui/src/pages/account/GroupsCard.test.tsx
+++ b/src/cqc_lem/ui/src/pages/account/GroupsCard.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import GroupsCard from './GroupsCard'
+import type { UserGroup } from './types'
+
+const get = vi.fn()
+const put = vi.fn()
+vi.mock('../../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    put: (...args: unknown[]) => put(...args),
+  },
+}))
+vi.mock('../../contexts/AuthContext', () => ({ useAuth: () => ({ sessionToken: 'tok' }) }))
+
+const GROUPS: UserGroup[] = [
+  { group_id: 'g1', group_name: 'AI Leaders', enabled: true, post_enabled: true, last_posted_at: '2026-07-28T15:00:00', is_next_post: false },
+  { group_id: 'g2', group_name: 'Sales Pros', enabled: true, post_enabled: true, last_posted_at: null, is_next_post: true },
+]
+
+function harness(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(<QueryClientProvider client={client}>{ui}</QueryClientProvider>)
+}
+
+beforeEach(() => {
+  get.mockReset()
+  put.mockReset()
+})
+afterEach(cleanup)
+
+describe('GroupsCard (issue #769)', () => {
+  it('says a group post is original, not a duplicate or reshare of a feed post', async () => {
+    get.mockResolvedValue({ data: { detail: GROUPS } })
+    harness(<GroupsCard />)
+    await waitFor(() => expect(screen.getByText('LinkedIn Groups')).toBeTruthy())
+    expect(screen.getByText(/never duplicated, reshared or cross-posted/i)).toBeTruthy()
+    expect(screen.getByText(/one original post into one group/i)).toBeTruthy()
+  })
+
+  it('names the group the next weekly post goes to', async () => {
+    get.mockResolvedValue({ data: { detail: GROUPS } })
+    harness(<GroupsCard />)
+    await waitFor(() => expect(screen.getByText('Next group post: Sales Pros.')).toBeTruthy())
+    expect(screen.getByText('Next post')).toBeTruthy()
+  })
+
+  it('drops the next-post claim once that group is switched off, before saving', async () => {
+    get.mockResolvedValue({ data: { detail: GROUPS } })
+    harness(<GroupsCard />)
+    await waitFor(() => expect(screen.getByText('Next group post: Sales Pros.')).toBeTruthy())
+    fireEvent.click(screen.getByLabelText('Post in Sales Pros'))
+    expect(screen.getByText(/picked from the groups below when you save/i)).toBeTruthy()
+    expect(screen.queryByText('Next post')).toBeNull()
+  })
+
+  it('says nothing will be posted when no group is opted in', async () => {
+    get.mockResolvedValue({
+      data: { detail: GROUPS.map((g) => ({ ...g, post_enabled: false, is_next_post: false })) },
+    })
+    harness(<GroupsCard />)
+    await waitFor(() => expect(screen.getByText(/will not post in any group/i)).toBeTruthy())
+  })
+
+  it('saves commenting and posting as separate per-group choices', async () => {
+    get.mockResolvedValue({ data: { detail: GROUPS } })
+    put.mockResolvedValue({ data: { detail: 'ok' } })
+    harness(<GroupsCard />)
+    await waitFor(() => expect(screen.getByLabelText('Comment in AI Leaders')).toBeTruthy())
+    fireEvent.click(screen.getByLabelText('Comment in AI Leaders'))
+    fireEvent.click(screen.getByLabelText('Post in Sales Pros'))
+    fireEvent.click(screen.getByRole('button', { name: /Save Group Settings/i }))
+    await waitFor(() =>
+      expect(put).toHaveBeenCalledWith('/user/groups', {
+        session_token: 'tok',
+        groups: {
+          g1: { enabled: false, post_enabled: true },
+          g2: { enabled: true, post_enabled: false },
+        },
+      })
+    )
+  })
+
+  it('treats a group payload with no post flag as opted in', async () => {
+    get.mockResolvedValue({
+      data: { detail: [{ group_id: 'g1', group_name: 'AI Leaders', enabled: true }] },
+    })
+    harness(<GroupsCard />)
+    await waitFor(() => expect(screen.getByLabelText('Post in AI Leaders')).toBeTruthy())
+    expect(screen.getByLabelText('Post in AI Leaders').getAttribute('aria-checked')).toBe('true')
+  })
+})

--- a/src/cqc_lem/ui/src/pages/account/GroupsCard.test.tsx
+++ b/src/cqc_lem/ui/src/pages/account/GroupsCard.test.tsx
@@ -56,6 +56,39 @@ describe('GroupsCard (issue #769)', () => {
     expect(screen.queryByText('Next post')).toBeNull()
   })
 
+  it('drops the next-post claim when another group is switched ON, before saving', async () => {
+    // A never-posted group jumps to the front of the rotation, so the group marked at mount is no
+    // longer the answer — naming it anyway is the confusion this card exists to end.
+    get.mockResolvedValue({
+      data: {
+        detail: [{ ...GROUPS[0], is_next_post: true },
+                 { ...GROUPS[1], post_enabled: false, is_next_post: false },
+                 { group_id: 'g3', group_name: 'Founders', enabled: true, post_enabled: false,
+                   last_posted_at: null, is_next_post: false }],
+      },
+    })
+    harness(<GroupsCard />)
+    await waitFor(() => expect(screen.getByText('Next group post: AI Leaders.')).toBeTruthy())
+    fireEvent.click(screen.getByLabelText('Post in Founders'))
+    expect(screen.getByText(/picked from the groups below when you save/i)).toBeTruthy()
+    expect(screen.queryByText('Next post')).toBeNull()
+  })
+
+  it('adopts the rotation the server re-resolves after a save', async () => {
+    get.mockResolvedValueOnce({ data: { detail: GROUPS } }).mockResolvedValue({
+      data: {
+        detail: [{ ...GROUPS[0], is_next_post: true },
+                 { ...GROUPS[1], post_enabled: false, is_next_post: false }],
+      },
+    })
+    put.mockResolvedValue({ data: { detail: 'ok' } })
+    harness(<GroupsCard />)
+    await waitFor(() => expect(screen.getByText('Next group post: Sales Pros.')).toBeTruthy())
+    fireEvent.click(screen.getByLabelText('Post in Sales Pros'))
+    fireEvent.click(screen.getByRole('button', { name: /Save Group Settings/i }))
+    await waitFor(() => expect(screen.getByText('Next group post: AI Leaders.')).toBeTruthy())
+  })
+
   it('says nothing will be posted when no group is opted in', async () => {
     get.mockResolvedValue({
       data: { detail: GROUPS.map((g) => ({ ...g, post_enabled: false, is_next_post: false })) },

--- a/src/cqc_lem/ui/src/pages/account/GroupsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/GroupsCard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { useMutation, useQuery } from '@tanstack/react-query'
 import api from '../../api/client'
 import { useAuth } from '../../contexts/AuthContext'
 import Toggle from '../../components/Toggle'
@@ -7,16 +7,23 @@ import type { UserGroup } from './types'
 import { useRegisterSaveSection, sectionSaveCallbacks } from './SettingsSaveContext'
 
 const groupLabel = (g: UserGroup) => g.group_name || `Group ${g.group_id}`
+// A group synced before #769 has no post_enabled in an older cached payload — treat a missing flag
+// as ON, which is what the column defaults to server-side.
+const normalize = (rows: UserGroup[]) => rows.map((g) => ({ ...g, post_enabled: g.post_enabled !== false }))
+// WHICH groups take posts is the only input the server's rotation reads, so an unsaved change to it
+// invalidates the marked next group.
+const postSig = (rows: UserGroup[]) =>
+  rows.filter((g) => g.post_enabled).map((g) => g.group_id).sort().join('|')
 
 export default function GroupsCard() {
   const { sessionToken } = useAuth()
-  const queryClient = useQueryClient()
   const [groups, setGroups] = useState<UserGroup[]>([])
   const [groupsInit, setGroupsInit] = useState(false)
   const [savedSig, setSavedSig] = useState<string | null>(null)
+  const [savedPostSig, setSavedPostSig] = useState('')
   const [groupsMsg, setGroupsMsg] = useState<{ ok: boolean; text: string } | null>(null)
 
-  const { data: groupsData } = useQuery({
+  const { data: groupsData, refetch: refetchGroups } = useQuery({
     queryKey: ['user-groups', sessionToken],
     queryFn: () =>
       api
@@ -27,11 +34,10 @@ export default function GroupsCard() {
   })
   useEffect(() => {
     if (groupsData && !groupsInit) {
-      // A group synced before #769 has no post_enabled in an older cached payload — treat a missing
-      // flag as ON, which is what the column defaults to server-side.
-      const normalized = groupsData.map((g) => ({ ...g, post_enabled: g.post_enabled !== false }))
+      const normalized = normalize(groupsData)
       setGroups(normalized)
       setSavedSig(JSON.stringify(normalized))
+      setSavedPostSig(postSig(normalized))
       setGroupsInit(true)
     }
   }, [groupsData, groupsInit])
@@ -47,9 +53,15 @@ export default function GroupsCard() {
           groups.map((g) => [g.group_id, { enabled: g.enabled, post_enabled: !!g.post_enabled }])
         ),
       }),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['user-groups'] })
-      setSavedSig(JSON.stringify(groups))
+    onSuccess: async () => {
+      // Saving the flags moves the rotation — a group whose Post switch just went on and has never
+      // been posted in is now next. Adopt the answer the server re-resolves instead of leaving the
+      // card naming the group it was mounted with.
+      const fresh = await refetchGroups()
+      const normalized = normalize(fresh.data ?? groups)
+      setGroups(normalized)
+      setSavedSig(JSON.stringify(normalized))
+      setSavedPostSig(postSig(normalized))
       setGroupsMsg({ ok: true, text: 'Saved.' })
       setTimeout(() => setGroupsMsg(null), 3000)
     },
@@ -65,10 +77,12 @@ export default function GroupsCard() {
 
   if (!(groupsInit && groups.length > 0)) return null
 
-  // The server decides the rotation (least-recently-posted first) and marks the row; we only hide
-  // the badge when this row's own toggles rule it out, so an unsaved edit never shows a
-  // contradiction. The real next group is re-resolved on save.
-  const markedNext = groups.find((g) => g.is_next_post && g.post_enabled)
+  // The server decides the rotation (least-recently-posted first) and marks the row. Any unsaved
+  // change to which groups take posts changes that answer — including switching a never-posted
+  // group ON, which jumps it to the front — so the card stops naming a group until the save
+  // re-resolves it rather than confidently naming the wrong one.
+  const postSelectionDirty = postSig(groups) !== savedPostSig
+  const markedNext = postSelectionDirty ? undefined : groups.find((g) => g.is_next_post && g.post_enabled)
   const postingGroups = groups.filter((g) => g.post_enabled)
 
   return (

--- a/src/cqc_lem/ui/src/pages/account/GroupsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/GroupsCard.tsx
@@ -6,6 +6,8 @@ import Toggle from '../../components/Toggle'
 import type { UserGroup } from './types'
 import { useRegisterSaveSection, sectionSaveCallbacks } from './SettingsSaveContext'
 
+const groupLabel = (g: UserGroup) => g.group_name || `Group ${g.group_id}`
+
 export default function GroupsCard() {
   const { sessionToken } = useAuth()
   const queryClient = useQueryClient()
@@ -25,20 +27,25 @@ export default function GroupsCard() {
   })
   useEffect(() => {
     if (groupsData && !groupsInit) {
-      setGroups(groupsData)
-      setSavedSig(JSON.stringify(groupsData))
+      // A group synced before #769 has no post_enabled in an older cached payload — treat a missing
+      // flag as ON, which is what the column defaults to server-side.
+      const normalized = groupsData.map((g) => ({ ...g, post_enabled: g.post_enabled !== false }))
+      setGroups(normalized)
+      setSavedSig(JSON.stringify(normalized))
       setGroupsInit(true)
     }
   }, [groupsData, groupsInit])
 
-  const toggleGroup = (gid: string) =>
-    setGroups((gs) => gs.map((g) => (g.group_id === gid ? { ...g, enabled: !g.enabled } : g)))
+  const toggleGroup = (gid: string, field: 'enabled' | 'post_enabled') =>
+    setGroups((gs) => gs.map((g) => (g.group_id === gid ? { ...g, [field]: !g[field] } : g)))
 
   const groupsMutation = useMutation({
     mutationFn: () =>
       api.put('/user/groups', {
         session_token: sessionToken,
-        groups: Object.fromEntries(groups.map((g) => [g.group_id, g.enabled])),
+        groups: Object.fromEntries(
+          groups.map((g) => [g.group_id, { enabled: g.enabled, post_enabled: !!g.post_enabled }])
+        ),
       }),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['user-groups'] })
@@ -58,15 +65,65 @@ export default function GroupsCard() {
 
   if (!(groupsInit && groups.length > 0)) return null
 
+  // The server decides the rotation (least-recently-posted first) and marks the row; we only hide
+  // the badge when this row's own toggles rule it out, so an unsaved edit never shows a
+  // contradiction. The real next group is re-resolved on save.
+  const markedNext = groups.find((g) => g.is_next_post && g.post_enabled)
+  const postingGroups = groups.filter((g) => g.post_enabled)
+
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6 space-y-4">
       <h2 className="text-base font-semibold text-gray-700">LinkedIn Groups</h2>
-      <p className="text-xs text-gray-500">Choose which of your joined groups LEM engages in (value-add comments + occasional posts). All on by default.</p>
+      <div className="text-xs text-gray-500 space-y-1">
+        <p>Two separate things happen in your joined groups, and each has its own switch per group. Both are on by default.</p>
+        <p>
+          <span className="font-semibold text-gray-700">Comment</span> — LEM leaves value-add comments on
+          other members' posts in that group, daily, out of your normal daily comment budget.
+        </p>
+        <p>
+          <span className="font-semibold text-gray-700">Post</span> — about once a week LEM publishes{' '}
+          <span className="font-semibold text-gray-700">one original post into one group</span>, written fresh
+          for that group's members. Your scheduled feed posts are never duplicated, reshared or cross-posted
+          into groups, and the same post never goes to more than one group.
+        </p>
+        <p>
+          The weekly slot rotates: it goes to whichever group with <span className="font-semibold text-gray-700">Post</span>{' '}
+          on has gone longest without one.
+        </p>
+      </div>
+
+      <p className="text-xs text-gray-600 bg-gray-50 border border-gray-200 rounded p-2">
+        {postingGroups.length === 0
+          ? 'Next group post: none — no group has Post turned on, so LEM will not post in any group.'
+          : markedNext
+            ? `Next group post: ${groupLabel(markedNext)}.`
+            : 'Next group post: picked from the groups below when you save.'}
+      </p>
+
       <div className="divide-y divide-gray-100">
+        <div className="flex items-center justify-between pb-2 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+          <span>Group</span>
+          <span className="flex items-center gap-3">
+            <span className="w-11 text-center">Comment</span>
+            <span className="w-11 text-center">Post</span>
+          </span>
+        </div>
         {groups.map((g) => (
           <div key={g.group_id} className="flex items-center justify-between py-2">
-            <span className="text-sm text-gray-700 truncate pr-3">{g.group_name || `Group ${g.group_id}`}</span>
-            <Toggle on={g.enabled} onClick={() => toggleGroup(g.group_id)} />
+            <span className="text-sm text-gray-700 truncate pr-3">
+              {groupLabel(g)}
+              {markedNext?.group_id === g.group_id && (
+                <span className="ml-2 text-[10px] font-semibold uppercase text-blue-700 bg-blue-50 rounded px-1.5 py-0.5">
+                  Next post
+                </span>
+              )}
+            </span>
+            <span className="flex items-center gap-3">
+              <Toggle on={g.enabled} onClick={() => toggleGroup(g.group_id, 'enabled')}
+                ariaLabel={`Comment in ${groupLabel(g)}`} />
+              <Toggle on={!!g.post_enabled} onClick={() => toggleGroup(g.group_id, 'post_enabled')}
+                ariaLabel={`Post in ${groupLabel(g)}`} />
+            </span>
           </div>
         ))}
       </div>

--- a/src/cqc_lem/ui/src/pages/account/types.ts
+++ b/src/cqc_lem/ui/src/pages/account/types.ts
@@ -213,6 +213,11 @@ export type UserGroup = {
   group_id: string
   group_name: string | null
   enabled: boolean
+  /** Whether the weekly original group post may land in this group (issue #769). */
+  post_enabled?: boolean
+  last_posted_at?: string | null
+  /** Server-marked: the group the NEXT weekly group post goes to. */
+  is_next_post?: boolean
 }
 
 export type LeadMagnet = {

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -5906,11 +5906,15 @@ def get_user_groups(user_id: int) -> list:
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
-            "SELECT group_id, group_name, enabled FROM user_groups WHERE user_id=%s ORDER BY group_name",
+            "SELECT group_id, group_name, enabled, post_enabled, last_posted_at "
+            "FROM user_groups WHERE user_id=%s ORDER BY group_name",
             (user_id,))
         rows = cursor.fetchall() or []
         for r in rows:
             r["enabled"] = bool(r.get("enabled"))
+            r["post_enabled"] = bool(r.get("post_enabled"))
+            posted = r.get("last_posted_at")
+            r["last_posted_at"] = posted.isoformat() if hasattr(posted, "isoformat") else posted
         return rows
     except mysql.connector.Error as err:
         myprint(f"Could not list groups for user {user_id} | Error: {err}")
@@ -5933,14 +5937,62 @@ def get_enabled_group_ids(user_id: int) -> list:
         connection.close()
 
 
-def set_groups_enabled(user_id: int, group_states: dict) -> bool:
-    """Bulk-update per-group enabled flags: {group_id: bool}."""
+def get_next_group_for_post(user_id: int) -> Optional[dict]:
+    """The ONE place "which group does the next group post go to" is decided (issue #769): the
+    least-recently-posted group the user has opted into for POSTING. `post_enabled` is independent
+    of `enabled` (which only governs commenting), so a group can take posts without being commented
+    in and vice versa. Never posted there = sorts first. None when no group is opted in."""
+    connection = get_db_connection()
+    cursor = connection.cursor(dictionary=True)
+    try:
+        cursor.execute(
+            "SELECT group_id, group_name FROM user_groups "
+            "WHERE user_id=%s AND post_enabled=1 "
+            "ORDER BY last_posted_at IS NULL DESC, last_posted_at ASC, group_name ASC LIMIT 1",
+            (user_id,))
+        row = cursor.fetchone()
+        return dict(row) if row else None
+    except mysql.connector.Error as err:
+        myprint(f"Could not resolve next post group for user {user_id} | Error: {err}")
+        return None
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_group_post(user_id: int, group_id: str) -> bool:
+    """Stamp a group as just-posted-in so the rotation moves on to the next one."""
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
-        for gid, enabled in group_states.items():
-            cursor.execute("UPDATE user_groups SET enabled=%s WHERE user_id=%s AND group_id=%s",
-                           (1 if enabled else 0, user_id, str(gid)))
+        cursor.execute("UPDATE user_groups SET last_posted_at=NOW() WHERE user_id=%s AND group_id=%s",
+                       (user_id, str(group_id)))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not record group post for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def set_groups_enabled(user_id: int, group_states: dict) -> bool:
+    """Bulk-update per-group flags. Each value is either a bare bool (engagement only — the shape
+    the pre-#769 SPA bundle still sends) or {"enabled": bool, "post_enabled": bool}; only the keys
+    present are written, so a partial payload never silently resets the other flag."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        for gid, state in group_states.items():
+            flags = state if isinstance(state, dict) else {"enabled": state}
+            updates = [(col, 1 if flags[col] else 0) for col in ("enabled", "post_enabled") if col in flags]
+            if not updates:
+                continue
+            cursor.execute(
+                f"UPDATE user_groups SET {', '.join(f'{c}=%s' for c, _ in updates)} "
+                "WHERE user_id=%s AND group_id=%s",
+                (*(v for _, v in updates), user_id, str(gid)))
         connection.commit()
         return True
     except mysql.connector.Error as err:

--- a/tests/unit/api/test_api_coverage_misc.py
+++ b/tests/unit/api/test_api_coverage_misc.py
@@ -342,11 +342,24 @@ class TestUserSettingsAndGroups:
         assert resp.status_code == 500
 
     def test_get_groups(self, client):
-        groups = [{"group_id": "g1", "group_name": "AI", "enabled": True}]
+        groups = [{"group_id": "g1", "group_name": "AI", "enabled": True, "post_enabled": True},
+                  {"group_id": "g2", "group_name": "Sales", "enabled": True, "post_enabled": True}]
         with patch(f"{_M}.get_session_user_id", return_value=_UID), \
-             patch(f"{_M}.get_user_groups", return_value=groups):
+             patch(f"{_M}.get_user_groups", return_value=groups), \
+             patch(f"{_M}.get_next_group_for_post", return_value={"group_id": "g2", "group_name": "Sales"}):
             resp = client.get(f"/api/user/groups?session_token={_TOK}")
-        assert resp.status_code == 200 and resp.json()["detail"] == groups
+        assert resp.status_code == 200
+        detail = resp.json()["detail"]
+        # Still a plain array (an older cached SPA bundle reads it as one) with the next post marked.
+        assert [g["is_next_post"] for g in detail] == [False, True]
+
+    def test_get_groups_none_opted_in_for_posting(self, client):
+        groups = [{"group_id": "g1", "group_name": "AI", "enabled": True, "post_enabled": False}]
+        with patch(f"{_M}.get_session_user_id", return_value=_UID), \
+             patch(f"{_M}.get_user_groups", return_value=groups), \
+             patch(f"{_M}.get_next_group_for_post", return_value=None):
+            resp = client.get(f"/api/user/groups?session_token={_TOK}")
+        assert resp.json()["detail"][0]["is_next_post"] is False
 
     def test_put_groups(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_UID), \
@@ -355,6 +368,15 @@ class TestUserSettingsAndGroups:
                 "session_token": _TOK, "groups": {"g1": False}})
         assert resp.status_code == 200
         assert setg.call_args[0] == (_UID, {"g1": False})
+
+    def test_put_groups_accepts_per_group_post_flag(self, client):
+        with patch(f"{_M}.get_session_user_id", return_value=_UID), \
+             patch(f"{_M}.set_groups_enabled", return_value=True) as setg:
+            resp = client.put("/api/user/groups", json={
+                "session_token": _TOK,
+                "groups": {"g1": {"enabled": True, "post_enabled": False}}})
+        assert resp.status_code == 200
+        assert setg.call_args[0] == (_UID, {"g1": {"enabled": True, "post_enabled": False}})
 
     def test_put_groups_500(self, client):
         with patch(f"{_M}.get_session_user_id", return_value=_UID), \

--- a/tests/unit/app/test_groups.py
+++ b/tests/unit/app/test_groups.py
@@ -32,6 +32,59 @@ class TestUserGroupsDB:
             assert get_enabled_group_ids(1) == ["123", "456"]
             assert set_groups_enabled(1, {"123": False, "456": True}) is True
 
+    def test_bare_bool_payload_only_touches_engagement(self):
+        """The pre-#769 SPA bundle still sends {group_id: bool} — that must not reset post_enabled."""
+        conn, cur = self._conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_groups_enabled
+            assert set_groups_enabled(1, {"123": False}) is True
+        sql = cur.execute.call_args[0][0]
+        assert "enabled=%s" in sql and "post_enabled" not in sql
+        assert cur.execute.call_args[0][1] == (0, 1, "123")
+
+    def test_dict_payload_writes_both_flags(self):
+        conn, cur = self._conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_groups_enabled
+            assert set_groups_enabled(1, {"123": {"enabled": True, "post_enabled": False}}) is True
+        sql, params = cur.execute.call_args[0][0], cur.execute.call_args[0][1]
+        assert "enabled=%s" in sql and "post_enabled=%s" in sql
+        assert params == (1, 0, 1, "123")
+
+    def test_empty_group_state_writes_nothing(self):
+        conn, cur = self._conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import set_groups_enabled
+            assert set_groups_enabled(1, {"123": {}}) is True
+        cur.execute.assert_not_called()
+
+    def test_next_group_for_post_is_least_recently_posted(self):
+        conn, cur = self._conn()
+        cur.fetchone.return_value = {"group_id": "456", "group_name": "Sales"}
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_next_group_for_post
+            assert get_next_group_for_post(1) == {"group_id": "456", "group_name": "Sales"}
+        sql = cur.execute.call_args[0][0]
+        # Posting is gated on post_enabled ALONE — a group can take posts without being commented in.
+        assert "post_enabled=1" in sql and "enabled=1" not in sql.replace("post_enabled=1", "")
+        # Never-posted groups sort first, then oldest first.
+        assert "last_posted_at IS NULL DESC, last_posted_at ASC" in sql
+
+    def test_next_group_for_post_none_when_nothing_opted_in(self):
+        conn, cur = self._conn()
+        cur.fetchone.return_value = None
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import get_next_group_for_post
+            assert get_next_group_for_post(1) is None
+
+    def test_record_group_post_stamps_the_row(self):
+        conn, cur = self._conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_group_post
+            assert record_group_post(1, "123") is True
+        assert "last_posted_at=NOW()" in cur.execute.call_args[0][0]
+        assert cur.execute.call_args[0][1] == (1, "123")
+
 
 class TestSyncUserGroups:
     def test_upserts_enumerated(self):
@@ -63,7 +116,65 @@ class TestCommentInGroups:
         gp.assert_not_called()
 
 
+class TestPostToGroup:
+    def _driver_patches(self):
+        return patch(f"{_RA}.get_current_profile",
+                     return_value=(MagicMock(), MagicMock(), "e", MagicMock()))
+
+    def test_writes_for_that_group_and_stamps_rotation(self):
+        """The post is generated FRESH for the named group (never a copy of a feed post), and only
+        a post that actually shipped moves the rotation on."""
+        from cqc_lem.app.run_automation import auto_post_to_group
+        with self._driver_patches(), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"), \
+             patch(f"{_RA}.generate_group_post", return_value="A useful insight.") as gen, \
+             patch(f"{_RA}.click_first", return_value=MagicMock()), \
+             patch(f"{_RA}.find_first", return_value=MagicMock()), \
+             patch(f"{_RA}.record_group_post") as rec, patch(f"{_RA}.quit_gracefully"):
+            result = auto_post_to_group.run(user_id=1, group_id="123", group_name="AI Leaders")
+        assert result == "Posted to group"
+        assert gen.call_args.kwargs["group_name"] == "AI Leaders"
+        rec.assert_called_once_with(1, "123")
+
+    def test_failed_post_leaves_the_group_next_in_line(self):
+        from cqc_lem.app.run_automation import auto_post_to_group
+        with self._driver_patches(), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"), \
+             patch(f"{_RA}.generate_group_post", return_value="A useful insight."), \
+             patch(f"{_RA}.click_first", return_value=None), \
+             patch(f"{_RA}.record_group_post") as rec, patch(f"{_RA}.quit_gracefully"):
+            result = auto_post_to_group.run(user_id=1, group_id="123", group_name="AI Leaders")
+        assert result == "Group share box not found"
+        rec.assert_not_called()
+
+
 class TestGroupDispatchers:
+    def test_group_posts_target_the_rotated_group(self):
+        from cqc_lem.app.run_scheduler import auto_group_posts
+        with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \
+             patch(f"{_RS}.has_linkedin_session", return_value=True), \
+             patch(f"{_DB}.get_next_group_for_post",
+                   side_effect=lambda u: {"group_id": "g9", "group_name": "Sales"} if u == 1 else None), \
+             patch("cqc_lem.app.run_automation.auto_post_to_group") as t:
+            result = auto_group_posts()
+        t.apply_async.assert_called_once_with(
+            kwargs={'user_id': 1, 'group_id': "g9", 'group_name': "Sales"})
+        assert "1/2" in result
+
+    def test_group_posts_skip_users_without_a_session(self):
+        from cqc_lem.app.run_scheduler import auto_group_posts
+        with patch(f"{_RS}.get_active_user_ids", return_value=[1]), \
+             patch(f"{_RS}.has_linkedin_session", return_value=False), \
+             patch(f"{_DB}.get_next_group_for_post") as nxt, \
+             patch("cqc_lem.app.run_automation.auto_post_to_group") as t:
+            result = auto_group_posts()
+        nxt.assert_not_called()
+        t.apply_async.assert_not_called()
+        assert "0/1" in result
+
+
     def test_group_engagement_dispatches_connected(self):
         from cqc_lem.app.run_scheduler import auto_group_engagement
         with patch(f"{_RS}.get_active_user_ids", return_value=[1, 2]), \

--- a/tests/unit/utilities/test_db_coverage_avatar_groups.py
+++ b/tests/unit/utilities/test_db_coverage_avatar_groups.py
@@ -133,14 +133,21 @@ class TestAvatarTrainings:
 
 
 class TestUserGroups:
-    def test_get_user_groups_coerces_enabled_to_bool(self):
-        rows = [{"group_id": "g1", "group_name": "AI Leaders", "enabled": 1},
-                {"group_id": "g2", "group_name": "Sales", "enabled": 0}]
+    def test_get_user_groups_coerces_flags_to_bool_and_date_to_iso(self):
+        rows = [{"group_id": "g1", "group_name": "AI Leaders", "enabled": 1, "post_enabled": 0,
+                 "last_posted_at": datetime(2026, 7, 28, 15, 0)},
+                {"group_id": "g2", "group_name": "Sales", "enabled": 0, "post_enabled": 1,
+                 "last_posted_at": None}]
         conn, _ = _conn(fetch_all=rows)
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import get_user_groups
             result = get_user_groups(1)
-        assert result[0]["enabled"] is True and result[1]["enabled"] is False
+        # Commenting and posting are independent flags (issue #769) — neither implies the other.
+        assert result[0]["enabled"] is True and result[0]["post_enabled"] is False
+        assert result[1]["enabled"] is False and result[1]["post_enabled"] is True
+        # JSON-serializable for the SPA payload.
+        assert result[0]["last_posted_at"] == "2026-07-28T15:00:00"
+        assert result[1]["last_posted_at"] is None
 
     def test_get_user_groups_error_returns_empty(self):
         conn, cur = _conn()

--- a/tests/unit/utilities/test_db_coverage_errors.py
+++ b/tests/unit/utilities/test_db_coverage_errors.py
@@ -90,6 +90,8 @@ _ERROR_CASES = [
     ("upsert_user_group", (1, "g1"), False),
     ("get_enabled_group_ids", (1,), []),
     ("set_groups_enabled", (1, {"g1": True}), False),
+    ("get_next_group_for_post", (1,), None),
+    ("record_group_post", (1, "g1"), False),
     ("record_post_stats", (1, 2, 3, 4), False),
     ("get_recent_posted_post_ids", (1,), []),
     ("get_post_engagement_rows", (1,), []),


### PR DESCRIPTION
## What & why

The LinkedIn Groups card told users LEM "engages in your joined groups" behind a single per-group
switch. That one switch covered two very different actions, and the one the reporter cared about was
invisible:

- **Are my posts duplicated / reshared / cross-posted into groups?** Nowhere in the product did it say.
  (They never were — a group post is generated fresh by `generate_group_post`.)
- **Which group does a group post go to?** `auto_group_posts` took `get_enabled_group_ids(uid)[0]` —
  whichever enabled row MySQL happened to return first. Unstated, unselectable, and it never rotated,
  so the same group got every weekly post forever.

### Changes

| | |
|---|---|
| **Migration** `V20260801023643__add_user_group_post_settings.sql` | Adds `user_groups.post_enabled` + `last_posted_at`. **Additive**, plus one backfill `UPDATE user_groups SET post_enabled = enabled` — the two flags are independent from here on, so an existing row that was already switched off must not start receiving posts because a new column defaulted to on. |
| **`db.get_next_group_for_post`** | The ONE place "which group is next" is decided: least-recently-posted post-enabled group, never-posted-there sorts first. |
| **`db.record_group_post`** | Stamps `last_posted_at`. Called only after the post actually shipped, so a failed run leaves that group next in line rather than silently skipping its turn. |
| **`db.set_groups_enabled`** | Accepts `{gid: {"enabled", "post_enabled"}}` **and** the old `{gid: bool}` (a stale SPA bundle still sends bools). Only keys present are written, so a partial payload never resets the other flag. |
| **`GET /user/groups`** | Marks `is_next_post` on the row. Deliberately not a new wrapper object — `detail` stays a plain array so an older cached bundle still renders it (issue #743). |
| **`auto_group_posts` / `auto_post_to_group`** | Dispatches the rotated group and passes `group_name` through, so the post is actually written for that group's members. |
| **`GroupsCard.tsx`** | Two switches per group (**Comment** / **Post**), a "Next group post: <name>" line + row badge, an explicit "none — LEM will not post in any group" state, and copy that says plainly: one original post, one group, about weekly, rotating; scheduled feed posts are never duplicated, reshared or cross-posted. |

Weekly volume is unchanged — still ONE group post per user per week. Commenting behaviour is untouched
(`auto_comment_in_groups` still reads `enabled`).

## Testing

- `tests/unit/app/test_groups.py` — rotation query shape (post_enabled alone gates posting; never-posted
  first), `record_group_post` stamping, bare-bool vs dict payloads, empty-state no-op write, dispatcher
  targets the rotated group, and a failed post leaves the group next in line.
- `tests/unit/api/test_api_coverage_misc.py` — `is_next_post` marking (and the none-opted-in case), the
  payload stays a plain array, `PUT` accepts both body shapes.
- `tests/unit/utilities/test_db_coverage_{avatar_groups,errors}.py` — flag/date coercion + error paths.
- `src/cqc_lem/ui/src/pages/account/GroupsCard.test.tsx` (new) — the duplicate/reshare copy, the
  next-group line, the badge dropping when that group's Post is switched off before saving, the
  nothing-opted-in state, separate save payloads, and a payload with no `post_enabled` reading as on.
- `poetry run pytest tests/unit -q` → **8846 passed** locally. Vitest runs in CI (`ui-build.yml`);
  this box is on Node 18 so it couldn't run here.

Closes #769

🤖 Generated with [Claude Code](https://claude.com/claude-code)