### PR TITLE
feat(content-generation): allow regeneration of all post types with suggestions (closes #794)

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -2423,9 +2423,10 @@ def regenerate_newsletter_draft_endpoint(request: NewsletterRegenerateRequest) -
 
 @router.post("/user/post/regenerate")
 def regenerate_post_endpoint(request: PostRegenerateRequest) -> ResponseModel:
-    """Regenerate a single pending/approved post. Generation is a slow lem-complex call, so dispatch
-    it to a Celery task; the post resets to 'pending' for re-review. Optional free-text `guidance`
-    steers the rewrite while the base regeneration honors the user's saved engagement settings."""
+    """Regenerate a single pending/approved/rejected post. Generation is a slow lem-complex call,
+    so dispatch it to a Celery task; the post resets to 'pending' for re-review. Optional free-text
+    `guidance` steers the rewrite while the base regeneration honors the user's saved engagement
+    settings. Works for text, carousel, document, and video posts (issue #794)."""
     user_id = get_session_user_id(request.session_token)
     if not user_id:
         raise HTTPException(status_code=401, detail="Invalid or expired session")

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -515,8 +515,12 @@ def _report_carousel_fact_grounding(user_id: int, post_id: Optional[int], bluepr
 
 @attribute_llm_cost(FEATURE_CONTENT)
 def create_carousel_content(user_id: int, stage: str, post_id: int = None,
-                            template: Optional[str] = None) -> str:
-    """Generate AI carousel content, render slide images, update DB, and return the post text."""
+                            template: Optional[str] = None,
+                            guidance: Optional[str] = None) -> str:
+    """Generate AI carousel content, render slide images, update DB, and return the post text.
+
+    `guidance` is the user's free-text revision request from the regenerate flow (issue #794) — it
+    steers the CAPTION AND the slides, since on a deck the slides are the post."""
     from cqc_lem.utilities.ai.ai_helper import generate_carousel_content
     from cqc_lem.utilities.carousel_creator import (
         create_ppt, create_carousel_slide_images,
@@ -555,7 +559,8 @@ def create_carousel_content(user_id: int, stage: str, post_id: int = None,
                                                          profile_synthesis=profile_synthesis,
                                                          blueprint=blueprint,
                                                          fact_anchors=writer_anchors,
-                                                         story_directive=story_directive)
+                                                         story_directive=story_directive,
+                                                         guidance=guidance)
     myprint(f"Carousel AI content generated for user_id={user_id} stage={stage} "
             f"archetype={(blueprint or {}).get('format')}")
 
@@ -808,6 +813,26 @@ def create_video_content(user_id: int, stage: str, post_id: int = None) -> tuple
     return text_content, video_url
 
 
+def _store_video_asset(post_id: int, video_src_url: str) -> str:
+    """Download a generated video into the shared assets volume, attach C2PA credentials to AI
+    output, persist posts.video_url, and return the public API asset URL. The ONE place a
+    regenerated video is stored — both the asset-only healer and the full post regenerate use it."""
+    videos_dir = os.path.join(assets_dir, 'videos', 'runwayml')
+    create_folder_if_not_exists(videos_dir)
+    video_file_path = save_video_url_to_dir(video_src_url, videos_dir)
+    # Only AI (Runway, http) output gets C2PA AI credentials — not Pexels stock.
+    if str(video_src_url).startswith("http"):
+        try:
+            from cqc_lem.utilities.c2pa_helper import add_ai_content_credentials
+            add_ai_content_credentials(video_file_path)
+        except Exception as e:
+            myprint(f"_store_video_asset: C2PA signing skipped for post {post_id}: {e}")
+    video_file_name = os.path.basename(video_file_path)
+    api_video_url = f"{API_URL_FINAL}/api/assets?file_name=videos/runwayml/{video_file_name}"
+    update_db_post_video_url(post_id, api_video_url)
+    return api_video_url
+
+
 def regenerate_video_for_post(post_id: int) -> Optional[str]:
     """Regenerate ONLY the video asset for an existing post, keeping its content.
 
@@ -835,19 +860,7 @@ def regenerate_video_for_post(post_id: int) -> Optional[str]:
     if not video_src_url:
         return None
 
-    videos_dir = os.path.join(assets_dir, 'videos', 'runwayml')
-    create_folder_if_not_exists(videos_dir)
-    video_file_path = save_video_url_to_dir(video_src_url, videos_dir)
-    # Only AI (Runway, http) output gets C2PA AI credentials — not Pexels stock.
-    if str(video_src_url).startswith("http"):
-        try:
-            from cqc_lem.utilities.c2pa_helper import add_ai_content_credentials
-            add_ai_content_credentials(video_file_path)
-        except Exception as e:
-            myprint(f"regenerate_video_for_post: C2PA signing skipped: {e}")
-    video_file_name = os.path.basename(video_file_path)
-    api_video_url = f"{API_URL_FINAL}/api/assets?file_name=videos/runwayml/{video_file_name}"
-    update_db_post_video_url(post_id, api_video_url)
+    api_video_url = _store_video_asset(post_id, video_src_url)
     # Symmetric with regenerate_post_carousel_task: a real video now exists, so heal a non-terminal
     # post (e.g. one left in 'planning' by asset backfill) to 'approved' so it becomes visible in the
     # Review UI and can post, instead of being stranded despite a correctly-produced video.
@@ -927,15 +940,39 @@ def _apply_guidance_to_text_post(user_id: int, post_id: int, content: str,
     return content
 
 
+def _post_is_flagged_error(post_id: int) -> bool:
+    """Did the media step just flag this post 'error'? Never raises — an unreadable status falls
+    back to the normal PENDING reset rather than stranding a good post."""
+    try:
+        from cqc_lem.utilities.db import get_post_status
+        return get_post_status(post_id) == PostStatus.ERROR.value
+    except Exception as e:
+        myprint(f"Could not read the status for post {post_id}: {e}")
+        return False
+
+
 def _finish_regenerated_post(user_id: int, post_id: int, content: str,
-                             post_type_value: str, video_url: Optional[str] = None) -> None:
-    """Shared close-out for a regenerated post: persist content, re-score dwell, refresh gate
-    findings, and reset the post to PENDING for re-review."""
+                             post_type_value: str, video_url: Optional[str] = None,
+                             ai_media: bool = False) -> str:
+    """Shared close-out for a regenerated post: disclose AI visuals, persist content, re-score
+    dwell, refresh gate findings, and reset the post to PENDING for re-review. Returns the content
+    as PERSISTED — the caller must return this, not its pre-disclosure copy."""
+    # Regeneration replaces the whole caption, so the old draft's disclosure line went with it —
+    # re-apply it here or a regenerated video/avatar post ships undisclosed (issue #744).
+    if ai_media or _post_used_avatar_media(post_id):
+        content = _apply_ai_disclosure(content)
     _score_and_persist_dwell(user_id, post_id, content)
     update_db_post_content(post_id, content)
     _persist_gate_findings(user_id, post_id,
                            _gate_findings_for_post(user_id, post_id, content, post_type_value, video_url))
+    # create_carousel_content flags a slide-render failure as ERROR so it gets a manual fix; resetting
+    # that to PENDING would hide a deck carrying the PREVIOUS draft's slides behind a normal-looking
+    # review row (the missing-asset gate reads those stale slides as present).
+    if _post_is_flagged_error(post_id):
+        myprint(f"regenerate_post: post {post_id} left 'error' — its media could not be regenerated")
+        return content
     update_db_post_status(post_id, PostStatus.PENDING)
+    return content
 
 
 def regenerate_post(post_id: int, guidance: str = None) -> Optional[str]:
@@ -967,18 +1004,20 @@ def regenerate_post(post_id: int, guidance: str = None) -> Optional[str]:
             myprint(f"regenerate_post: text generation produced nothing for post {post_id}")
             return None
         content = _apply_guidance_to_text_post(user_id, post_id, content, user_profile, guidance)
-        _finish_regenerated_post(user_id, post_id, content, pt_value)
+        content = _finish_regenerated_post(user_id, post_id, content, pt_value)
         myprint(f"regenerate_post: text post {post_id} regenerated → pending")
         return content
 
     if pt_value in (PostType.CAROUSEL.value, PostType.DOCUMENT.value):
-        content = create_carousel_content(user_id, stage, post_id)
+        # Guidance goes INTO the deck's generation, not a caption-only rewrite after it: on a
+        # carousel/document the slides ARE the post, so steering only the caption would leave the
+        # user's suggestions off the thing they were looking at.
+        content = create_carousel_content(user_id, stage, post_id, guidance=guidance)
         if not content:
             myprint(f"regenerate_post: carousel generation produced nothing for post {post_id}")
             return None
-        content = _apply_guidance_to_text_post(user_id, post_id, content, user_profile, guidance)
-        _finish_regenerated_post(user_id, post_id, content, pt_value)
-        myprint(f"regenerate_post: carousel/document post {post_id} regenerated → pending")
+        content = _finish_regenerated_post(user_id, post_id, content, pt_value)
+        myprint(f"regenerate_post: carousel/document post {post_id} regenerated")
         return content
 
     if pt_value == PostType.VIDEO.value:
@@ -991,25 +1030,21 @@ def regenerate_post(post_id: int, guidance: str = None) -> Optional[str]:
 
         # The new caption drives the new video asset so the visuals match the words (issue #794).
         video_src_url = _generate_video_src(user_id, content, user_profile, post_id)
+        api_video_url = None
         if video_src_url:
-            videos_dir = os.path.join(assets_dir, 'videos', 'runwayml')
-            create_folder_if_not_exists(videos_dir)
-            video_file_path = save_video_url_to_dir(video_src_url, videos_dir)
-            if str(video_src_url).startswith("http"):
-                try:
-                    from cqc_lem.utilities.c2pa_helper import add_ai_content_credentials
-                    add_ai_content_credentials(video_file_path)
-                except Exception as e:
-                    myprint(f"regenerate_post: C2PA signing skipped: {e}")
-            video_file_name = os.path.basename(video_file_path)
-            api_video_url = f"{API_URL_FINAL}/api/assets?file_name=videos/runwayml/{video_file_name}"
-            update_db_post_video_url(post_id, api_video_url)
-            _finish_regenerated_post(user_id, post_id, content, pt_value, api_video_url)
-            myprint(f"regenerate_post: video post {post_id} regenerated → pending")
-        else:
-            # No video asset means the post is held for review with a missing_asset finding.
-            _finish_regenerated_post(user_id, post_id, content, pt_value, None)
-            myprint(f"regenerate_post: video post {post_id} regenerated caption but video asset failed")
+            try:
+                api_video_url = _store_video_asset(post_id, video_src_url)
+            except Exception as e:
+                # Losing the download must not lose the regenerated caption too — persist it and
+                # let the missing-asset gate hold the post, exactly as a failed render does.
+                log_warning("Could not store the regenerated video asset", exc=e,
+                            user_id=user_id, post_id=post_id, task_name="regenerate_post")
+        # No video asset means the post is held for review with a missing_asset finding.
+        content = _finish_regenerated_post(
+            user_id, post_id, content, pt_value, api_video_url,
+            ai_media=bool(api_video_url) and str(video_src_url).startswith("http"))
+        myprint(f"regenerate_post: video post {post_id} regenerated"
+                f"{'' if api_video_url else ' (caption only — video asset failed)'}")
         return content
 
     myprint(f"regenerate_post: post {post_id} has unsupported post_type '{pt_value}' — skipping")

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -903,12 +903,47 @@ def regenerate_post_carousel_task(post_id: int):
     return content
 
 
+def _apply_guidance_to_text_post(user_id: int, post_id: int, content: str,
+                                 user_profile: LinkedInProfile, guidance: str) -> str:
+    """Apply the user's free-text guidance to a generated text caption, then sanitize and repair
+    deterministic CTAs that LLM rewrites can drop. Returns the caption unchanged if guidance is
+    empty or the rewrite fails."""
+    guidance = (guidance or "").strip()
+    if not guidance or not content:
+        return content
+    try:
+        prefs = get_engagement_preferences(user_id)
+        synthesis = get_or_create_profile_synthesis(user_id, user_profile)
+        with llm_attribution(user_id=user_id, feature=FEATURE_CONTENT):
+            revised = apply_post_guidance(content, guidance, prefs=prefs, profile_synthesis=synthesis)
+        if revised:
+            content = sanitize_for_linkedin(revised).strip()
+            # The guidance rewrite is another LLM pass that can drop the comment-keyword
+            # mechanic create_text_post already verified — re-verify after it.
+            content = ensure_lead_magnet_cta(content, get_lead_magnet_settings(user_id), post_id,
+                                             use_emojis=bool((prefs or {}).get("use_emojis")))
+    except Exception as e:
+        myprint(f"regenerate_post: guidance pass failed for post {post_id} ({e}); keeping base regen")
+    return content
+
+
+def _finish_regenerated_post(user_id: int, post_id: int, content: str,
+                             post_type_value: str, video_url: Optional[str] = None) -> None:
+    """Shared close-out for a regenerated post: persist content, re-score dwell, refresh gate
+    findings, and reset the post to PENDING for re-review."""
+    _score_and_persist_dwell(user_id, post_id, content)
+    update_db_post_content(post_id, content)
+    _persist_gate_findings(user_id, post_id,
+                           _gate_findings_for_post(user_id, post_id, content, post_type_value, video_url))
+    update_db_post_status(post_id, PostStatus.PENDING)
+
+
 def regenerate_post(post_id: int, guidance: str = None) -> Optional[str]:
-    """Regenerate ONE text post in place through the normal generation pipeline — so it honors the
+    """Regenerate ONE post in place through the normal generation pipeline — so it honors the
     user's saved engagement settings (voice/tone, focus/goals, emoji/hashtag prefs, anti-self-promo)
-    — then folds in optional free-text `guidance`. Mirrors regenerate_newsletter_edition. Resets the
-    post to PENDING so the user re-reviews. Text posts only: carousels/videos keep their dedicated
-    media healers (regenerate_post_carousel_task / regenerate_post_video_task)."""
+    — then folds in optional free-text `guidance`. Mirrors regenerate_newsletter_edition. Resets
+    the post to PENDING so the user re-reviews. Works for text, carousel, document, and video posts
+    (issue #794)."""
     from cqc_lem.utilities.db import get_post_user_id, get_post_buyer_stage, get_post_type
 
     user_id = get_post_user_id(post_id)
@@ -917,46 +952,68 @@ def regenerate_post(post_id: int, guidance: str = None) -> Optional[str]:
         return None
     post_type = get_post_type(post_id)
     pt_value = post_type.value if isinstance(post_type, PostType) else post_type
-    # Unknown/None type counts as non-text: regenerating blind could clobber a carousel/video post.
-    if pt_value != PostType.TEXT.value:
-        myprint(f"regenerate_post: post {post_id} is '{pt_value}', not text — skipping text regenerate")
+    if not pt_value:
+        myprint(f"regenerate_post: post {post_id} has no post_type — skipping regenerate")
         return None
 
     stage = get_post_buyer_stage(post_id) or "awareness"
     # Cached/DB-backed profile (no Selenium) — same source the newsletter regenerate uses.
     user_profile = load_profile_for_user(user_id)
-    content = create_text_post(user_id, stage, user_profile=user_profile, post_id=post_id,
-                               content_mix=_post_content_mix(post_id))
-    if not content:
-        myprint(f"regenerate_post: generation produced nothing for post {post_id}")
-        return None
 
-    guidance = (guidance or "").strip()
-    if guidance:
-        try:
-            prefs = get_engagement_preferences(user_id)
-            synthesis = get_or_create_profile_synthesis(user_id, user_profile)
-            with llm_attribution(user_id=user_id, feature=FEATURE_CONTENT):
-                revised = apply_post_guidance(content, guidance, prefs=prefs, profile_synthesis=synthesis)
-            if revised:
-                content = sanitize_for_linkedin(revised).strip()
-                # The guidance rewrite is another LLM pass that can drop the comment-keyword
-                # mechanic create_text_post already verified — re-verify after it.
-                content = ensure_lead_magnet_cta(content, get_lead_magnet_settings(user_id), post_id,
-                                                 use_emojis=bool((prefs or {}).get("use_emojis")))
-        except Exception as e:
-            myprint(f"regenerate_post: guidance pass failed for post {post_id} ({e}); keeping base regen")
+    if pt_value == PostType.TEXT.value:
+        content = create_text_post(user_id, stage, user_profile=user_profile, post_id=post_id,
+                                   content_mix=_post_content_mix(post_id))
+        if not content:
+            myprint(f"regenerate_post: text generation produced nothing for post {post_id}")
+            return None
+        content = _apply_guidance_to_text_post(user_id, post_id, content, user_profile, guidance)
+        _finish_regenerated_post(user_id, post_id, content, pt_value)
+        myprint(f"regenerate_post: text post {post_id} regenerated → pending")
+        return content
 
-    # Re-score dwell for the regenerated body so the stored score never describes the old draft.
-    _score_and_persist_dwell(user_id, post_id, content)
-    update_db_post_content(post_id, content)
-    # Same for the gate findings (issue #421) — a reason left over from the previous draft would
-    # explain a hold that no longer exists. create_text_post already re-judged authenticity above.
-    _persist_gate_findings(user_id, post_id,
-                           _gate_findings_for_post(user_id, post_id, content, PostType.TEXT.value))
-    update_db_post_status(post_id, PostStatus.PENDING)
-    myprint(f"regenerate_post: post {post_id} regenerated → pending")
-    return content
+    if pt_value in (PostType.CAROUSEL.value, PostType.DOCUMENT.value):
+        content = create_carousel_content(user_id, stage, post_id)
+        if not content:
+            myprint(f"regenerate_post: carousel generation produced nothing for post {post_id}")
+            return None
+        content = _apply_guidance_to_text_post(user_id, post_id, content, user_profile, guidance)
+        _finish_regenerated_post(user_id, post_id, content, pt_value)
+        myprint(f"regenerate_post: carousel/document post {post_id} regenerated → pending")
+        return content
+
+    if pt_value == PostType.VIDEO.value:
+        content = create_text_post(user_id, stage, user_profile=user_profile, post_id=post_id,
+                                   content_mix=_post_content_mix(post_id))
+        if not content:
+            myprint(f"regenerate_post: video caption generation produced nothing for post {post_id}")
+            return None
+        content = _apply_guidance_to_text_post(user_id, post_id, content, user_profile, guidance)
+
+        # The new caption drives the new video asset so the visuals match the words (issue #794).
+        video_src_url = _generate_video_src(user_id, content, user_profile, post_id)
+        if video_src_url:
+            videos_dir = os.path.join(assets_dir, 'videos', 'runwayml')
+            create_folder_if_not_exists(videos_dir)
+            video_file_path = save_video_url_to_dir(video_src_url, videos_dir)
+            if str(video_src_url).startswith("http"):
+                try:
+                    from cqc_lem.utilities.c2pa_helper import add_ai_content_credentials
+                    add_ai_content_credentials(video_file_path)
+                except Exception as e:
+                    myprint(f"regenerate_post: C2PA signing skipped: {e}")
+            video_file_name = os.path.basename(video_file_path)
+            api_video_url = f"{API_URL_FINAL}/api/assets?file_name=videos/runwayml/{video_file_name}"
+            update_db_post_video_url(post_id, api_video_url)
+            _finish_regenerated_post(user_id, post_id, content, pt_value, api_video_url)
+            myprint(f"regenerate_post: video post {post_id} regenerated → pending")
+        else:
+            # No video asset means the post is held for review with a missing_asset finding.
+            _finish_regenerated_post(user_id, post_id, content, pt_value, None)
+            myprint(f"regenerate_post: video post {post_id} regenerated caption but video asset failed")
+        return content
+
+    myprint(f"regenerate_post: post {post_id} has unsupported post_type '{pt_value}' — skipping")
+    return None
 
 
 @shared_task.task

--- a/src/cqc_lem/ui/src/pages/ContentStudio.test.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.test.tsx
@@ -140,8 +140,23 @@ describe('ContentStudio regenerate-with-guidance (issue #778)', () => {
     expect(screen.queryByRole('button', { name: /Re-generate Post/i })).toBeNull()
   })
 
-  it('hides the guidance section for a pending non-text post', async () => {
-    mockPosts([{ ...POST_BASE, post_type: 'carousel', status: 'pending', carousel_slides: ['Slide 1'] }])
+  // Issue #794: every post type can be regenerated with suggestions, not just text.
+  it.each(['carousel', 'document', 'video'])(
+    'shows the guidance section for a pending %s post',
+    async (postType) => {
+      mockPosts([{ ...POST_BASE, post_type: postType, status: 'pending', carousel_slides: ['Slide 1'] }])
+      harness(<ContentStudio />)
+
+      await waitFor(() => expect(screen.getByText('Draft content')).toBeDefined())
+      fireEvent.click(screen.getByText('Draft content'))
+
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: /Re-generate Post/i })).toBeDefined()
+      )
+    })
+
+  it('hides the guidance section for an approved carousel post', async () => {
+    mockPosts([{ ...POST_BASE, post_type: 'carousel', status: 'approved', carousel_slides: ['Slide 1'] }])
     harness(<ContentStudio />)
 
     await waitFor(() => expect(screen.getByText('Draft content')).toBeDefined())

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -1158,9 +1158,11 @@ export default function ContentStudio() {
                 {/* Regenerate with suggestions — mirrors the newsletter flow. Runs the generation
                     pipeline server-side (honors saved voice/tone, focus/goals, emoji/hashtag prefs)
                     PLUS the optional guidance, then resets the post to PENDING for re-review.
-                    Available for pending/rejected text posts so users can fix drafts that still
-                    need a decision; approved posts already have acceptance (issue #778). */}
-                {editingPost.post_type === 'text' && (editingPost.status === 'pending' || editingPost.status === 'rejected') && (
+                    Available for pending/rejected posts of EVERY type so users can fix drafts that
+                    still need a decision (issue #794 — carousels/documents re-render their slides
+                    and videos re-render their clip from the new caption); approved posts already
+                    have acceptance (issue #778). */}
+                {(editingPost.status === 'pending' || editingPost.status === 'rejected') && (
                   <div className="border-t border-gray-100 pt-4 space-y-2">
                     <label className="block text-xs font-medium text-gray-600">
                       Added Guidance <span className="font-normal text-gray-400">(optional)</span>
@@ -1183,7 +1185,13 @@ export default function ContentStudio() {
                       {regenerateMutation.isPending ? 'Starting…' : 'Re-generate Post'}
                     </button>
                     <p className="text-xs text-gray-400">
-                      Regeneration replaces this post's content and returns it to PENDING for review.
+                      Regeneration replaces this post's content
+                      {editingPost.post_type === 'carousel' || editingPost.post_type === 'document'
+                        ? ' and slides'
+                        : editingPost.post_type === 'video'
+                          ? ' and video'
+                          : ''}
+                      , and returns it to PENDING for review.
                     </p>
                   </div>
                 )}

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -3227,7 +3227,8 @@ _CAROUSEL_CAPTION_MAX_CHARS = 2200
 def generate_carousel_content(user_id: int, stage: str, prefs: dict = None,
                               profile_synthesis: str = None, blueprint: dict = None,
                               fact_anchors: list = None,
-                              story_directive: str = None) -> tuple[str, dict]:
+                              story_directive: str = None,
+                              guidance: str = None) -> tuple[str, dict]:
     """Generate structured carousel content using AI and return (post_text, carousel_dict).
 
     An assigned `blueprint` (issue #619 / G4) maps a SHORT-FORM POST ARCHETYPE onto the slides — a
@@ -3346,6 +3347,15 @@ Return ONLY valid JSON. No explanation, no markdown fences."""
         prompt += (f"\n\nAuthor voice reference (TONE + CREDIBILITY only — never the subject):\n"
                    f"{profile_synthesis}")
     prompt += _alignment_directive(prefs)
+
+    # The author's revision request from the regenerate flow (issue #794). Last, so it outranks the
+    # generic framing — but explicitly subordinate to the fact rules above, or "add a stat here"
+    # would license the invented metric every other directive exists to prevent.
+    if (guidance or "").strip():
+        prompt += (f"\n\nAUTHOR'S REVISION REQUEST — apply it to the caption AND every slide:\n"
+                   f"{guidance.strip()}\n"
+                   f"Follow it exactly, except where it would break the fact-grounding rules above: "
+                   f"never invent a number, name, or result to satisfy it.")
 
     system_prompt = {
         "role": "system",

--- a/tests/unit/api/test_post_regenerate_api.py
+++ b/tests/unit/api/test_post_regenerate_api.py
@@ -116,3 +116,19 @@ class TestRegeneratePostEndpoint:
             resp = client.post("/api/user/post/regenerate",
                                json={"session_token": "bad", "post_id": 7})
         assert resp.status_code == 401
+
+
+class TestRegeneratePostEndpointAllTypes:
+    """POST /api/user/post/regenerate works for every post type (issue #794)."""
+
+    @pytest.mark.parametrize("post_type", ["text", "carousel", "document", "video"])
+    def test_200_for_any_post_type(self, client, post_type):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.get_post_status", return_value="pending"), \
+             patch("cqc_lem.api.main.get_post_type", return_value=post_type), \
+             patch("cqc_lem.app.run_content_plan.regenerate_post_task") as task:
+            resp = client.post("/api/user/post/regenerate",
+                               json={"session_token": _SESSION, "post_id": 7, "guidance": "punchier"})
+        assert resp.status_code == 200
+        task.apply_async.assert_called_once()

--- a/tests/unit/app/test_placeholder_substitution.py
+++ b/tests/unit/app/test_placeholder_substitution.py
@@ -136,15 +136,20 @@ class TestRegeneratePost:
         apg.assert_called_once()
         uc.assert_called_once_with(42, "guided post")
 
-    def test_non_text_post_skipped(self):
+    def test_carousel_post_regenerates(self):
         from cqc_lem.app import run_content_plan as rcp
+        from cqc_lem.utilities.db import PostStatus
         p = self._patches(post_type="carousel")
         with p["get_post_user_id"], p["get_post_buyer_stage"], p["get_post_type"], p["load_profile"], \
-             p["create_text_post"] as ctp, p["update_status"] as us:
+             patch(f"{_RCP}.create_carousel_content", return_value="fresh carousel body") as ccp, \
+             patch(f"{_RCP}._score_and_persist_dwell"), \
+             patch(f"{_RCP}._persist_gate_findings"), \
+             p["update_content"] as uc, p["update_status"] as us:
             out = rcp.regenerate_post(42)
-        assert out is None
-        ctp.assert_not_called()
-        us.assert_not_called()
+        assert out == "fresh carousel body"
+        ccp.assert_called_once_with(1, "awareness", 42)
+        uc.assert_called_once_with(42, "fresh carousel body")
+        us.assert_called_once_with(42, PostStatus.PENDING)
 
     def test_no_user_returns_none(self):
         from cqc_lem.app import run_content_plan as rcp

--- a/tests/unit/app/test_placeholder_substitution.py
+++ b/tests/unit/app/test_placeholder_substitution.py
@@ -144,12 +144,32 @@ class TestRegeneratePost:
              patch(f"{_RCP}.create_carousel_content", return_value="fresh carousel body") as ccp, \
              patch(f"{_RCP}._score_and_persist_dwell"), \
              patch(f"{_RCP}._persist_gate_findings"), \
+             patch(f"{_RCP}._post_used_avatar_media", return_value=False), \
+             patch(f"{_RCP}._post_is_flagged_error", return_value=False), \
+             p["update_content"] as uc, p["update_status"] as us:
+            out = rcp.regenerate_post(42, guidance="drop the pricing slide")
+        assert out == "fresh carousel body"
+        # The guidance steers the DECK, not a caption-only rewrite after it (issue #794).
+        ccp.assert_called_once_with(1, "awareness", 42, guidance="drop the pricing slide")
+        uc.assert_called_once_with(42, "fresh carousel body")
+        us.assert_called_once_with(42, PostStatus.PENDING)
+
+    def test_carousel_slide_failure_keeps_error_status(self):
+        """create_carousel_content flags a slide-render failure 'error'; the regenerate close-out
+        must not clear it back to PENDING — the deck still carries the old draft's slides."""
+        from cqc_lem.app import run_content_plan as rcp
+        p = self._patches(post_type="carousel")
+        with p["get_post_user_id"], p["get_post_buyer_stage"], p["get_post_type"], p["load_profile"], \
+             patch(f"{_RCP}.create_carousel_content", return_value="fresh carousel body"), \
+             patch(f"{_RCP}._score_and_persist_dwell"), \
+             patch(f"{_RCP}._persist_gate_findings"), \
+             patch(f"{_RCP}._post_used_avatar_media", return_value=False), \
+             patch(f"{_RCP}._post_is_flagged_error", return_value=True), \
              p["update_content"] as uc, p["update_status"] as us:
             out = rcp.regenerate_post(42)
         assert out == "fresh carousel body"
-        ccp.assert_called_once_with(1, "awareness", 42)
         uc.assert_called_once_with(42, "fresh carousel body")
-        us.assert_called_once_with(42, PostStatus.PENDING)
+        us.assert_not_called()
 
     def test_no_user_returns_none(self):
         from cqc_lem.app import run_content_plan as rcp

--- a/tests/unit/app/test_run_content_plan.py
+++ b/tests/unit/app/test_run_content_plan.py
@@ -741,6 +741,8 @@ class TestRegeneratePostAllTypes:
              patch(f"{_RCP}.apply_post_guidance", return_value=None), \
              patch(f"{_RCP}.get_lead_magnet_settings", return_value=None), \
              patch(f"{_RCP}.sanitize_for_linkedin", side_effect=lambda x: x), \
+             patch(f"{_RCP}._post_used_avatar_media", return_value=False), \
+             patch(f"{_RCP}._post_is_flagged_error", return_value=False), \
              patch(f"{_RCP}.ensure_lead_magnet_cta", side_effect=lambda c, *a, **k: c):
             yield
 
@@ -761,15 +763,29 @@ class TestRegeneratePostAllTypes:
     @patch("cqc_lem.utilities.db.get_post_type", return_value=PostType.CAROUSEL)
     @patch("cqc_lem.utilities.db.get_post_buyer_stage", return_value="consideration")
     def test_carousel_post_regenerates_with_guidance(self, mock_stage, mock_type, mock_carousel, base_patches):
+        """The guidance reaches the DECK's generation — a caption-only rewrite would leave the
+        user's suggestions off the slides, which on a carousel ARE the post (issue #794)."""
         from cqc_lem.app.run_content_plan import regenerate_post
         from cqc_lem.utilities.db import PostStatus
-        with patch(f"{_RCP}.apply_post_guidance", return_value="Guided carousel caption") as mock_guidance:
+        with patch(f"{_RCP}.apply_post_guidance") as mock_guidance:
             result = regenerate_post(8, guidance="more tactical")
-        assert result == "Guided carousel caption"
-        mock_carousel.assert_called_once_with(1, "consideration", 8)
-        mock_guidance.assert_called_once_with("New carousel caption", "more tactical", prefs={"use_emojis": False}, profile_synthesis="synth")
+        assert result == "New carousel caption"
+        mock_carousel.assert_called_once_with(1, "consideration", 8, guidance="more tactical")
+        mock_guidance.assert_not_called()
         from cqc_lem.app.run_content_plan import update_db_post_status
         update_db_post_status.assert_called_once_with(8, PostStatus.PENDING)
+
+    @patch(f"{_RCP}.create_carousel_content", return_value="New carousel caption")
+    @patch("cqc_lem.utilities.db.get_post_type", return_value=PostType.CAROUSEL)
+    def test_carousel_keeps_error_status_when_slides_fail(self, mock_type, mock_carousel, base_patches):
+        """create_carousel_content flags a failed slide render 'error'; clearing that to PENDING
+        would present a deck still carrying the PREVIOUS draft's slides as ready to review."""
+        from cqc_lem.app.run_content_plan import regenerate_post
+        with patch(f"{_RCP}._post_is_flagged_error", return_value=True):
+            result = regenerate_post(8)
+        assert result == "New carousel caption"
+        from cqc_lem.app.run_content_plan import update_db_post_status
+        update_db_post_status.assert_not_called()
 
     @patch(f"{_RCP}.create_carousel_content", return_value="New document caption")
     @patch("cqc_lem.utilities.db.get_post_type", return_value=PostType.DOCUMENT)
@@ -778,7 +794,7 @@ class TestRegeneratePostAllTypes:
         from cqc_lem.app.run_content_plan import regenerate_post
         result = regenerate_post(9)
         assert result == "New document caption"
-        mock_carousel.assert_called_once_with(1, "decision", 9)
+        mock_carousel.assert_called_once_with(1, "decision", 9, guidance=None)
 
     @patch(f"{_RCP}.create_text_post", return_value="New video caption")
     @patch(f"{_RCP}._post_content_mix", return_value="authority")
@@ -794,11 +810,54 @@ class TestRegeneratePostAllTypes:
              patch(f"{_RCP}.update_db_post_video_url") as mock_update_video, \
              patch(f"{_RCP}.apply_post_guidance", return_value="Guided video caption") as mock_guidance:
             result = regenerate_post(10, guidance="shorter")
-        assert result == "Guided video caption"
+        # The persisted caption carries the AI-visuals disclosure (asserted exactly below).
+        assert result.startswith("Guided video caption")
         mock_text.assert_called_once_with(1, "awareness", user_profile=ANY, post_id=10, content_mix="authority")
         mock_guidance.assert_called_once_with("New video caption", "shorter", prefs={"use_emojis": False}, profile_synthesis="synth")
         mock_video_src.assert_called_once_with(1, "Guided video caption", ANY, 10)
         mock_update_video.assert_called_once()
+        from cqc_lem.app.run_content_plan import update_db_post_status
+        update_db_post_status.assert_called_once_with(10, PostStatus.PENDING)
+
+    @patch(f"{_RCP}.create_text_post", return_value="New video caption")
+    @patch(f"{_RCP}._post_content_mix", return_value="authority")
+    @patch("cqc_lem.utilities.db.get_post_type", return_value=PostType.VIDEO)
+    @patch(f"{_RCP}._generate_video_src", return_value="https://runway.video/xyz.mp4")
+    def test_regenerated_ai_video_is_disclosed(self, mock_video_src, mock_type, mock_mix,
+                                               mock_text, base_patches):
+        """Regeneration replaces the whole caption, so the old draft's AI-visuals disclosure went
+        with it — the new caption must carry it or the post ships undisclosed (issue #744)."""
+        from cqc_lem.app.run_content_plan import regenerate_post
+        with patch(f"{_RCP}.create_folder_if_not_exists"), \
+             patch(f"{_RCP}.save_video_url_to_dir", return_value="/fake/path/xyz.mp4"), \
+             patch(f"{_RCP}.update_db_post_video_url"), \
+             patch(f"{_RCP}.apply_post_guidance", side_effect=lambda c, *a, **k: c), \
+             patch(f"{_RCP}._apply_ai_disclosure", side_effect=lambda c: c + " [AI]") as mock_disc, \
+             patch(f"{_RCP}.update_db_post_content") as mock_content:
+            result = regenerate_post(10)
+        mock_disc.assert_called_once_with("New video caption")
+        mock_content.assert_called_once_with(10, "New video caption [AI]")
+        assert result == "New video caption [AI]"
+
+    @patch(f"{_RCP}.create_text_post", return_value="New video caption")
+    @patch(f"{_RCP}._post_content_mix", return_value="authority")
+    @patch("cqc_lem.utilities.db.get_post_type", return_value=PostType.VIDEO)
+    @patch(f"{_RCP}._generate_video_src", return_value="https://runway.video/xyz.mp4")
+    def test_video_asset_download_failure_still_persists_caption(self, mock_video_src, mock_type,
+                                                                 mock_mix, mock_text, base_patches):
+        """A failed download must not take the regenerated caption down with it — the post is
+        persisted and held by the missing-asset gate, exactly as a failed render is."""
+        from cqc_lem.app.run_content_plan import regenerate_post
+        from cqc_lem.utilities.db import PostStatus
+        with patch(f"{_RCP}._store_video_asset", side_effect=OSError("disk full")), \
+             patch(f"{_RCP}.apply_post_guidance", side_effect=lambda c, *a, **k: c), \
+             patch(f"{_RCP}.update_db_post_content") as mock_content, \
+             patch(f"{_RCP}._gate_findings_for_post", return_value=[]) as mock_gates:
+            result = regenerate_post(10)
+        assert result == "New video caption"
+        mock_content.assert_called_once_with(10, "New video caption")
+        # video_url None is what makes the missing-asset gate fire.
+        assert mock_gates.call_args.args[4] is None
         from cqc_lem.app.run_content_plan import update_db_post_status
         update_db_post_status.assert_called_once_with(10, PostStatus.PENDING)
 

--- a/tests/unit/app/test_run_content_plan.py
+++ b/tests/unit/app/test_run_content_plan.py
@@ -1,9 +1,11 @@
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch, MagicMock, ANY
 
 import pytest
 from freezegun import freeze_time
 
 import pydantic.v1.types  # noqa: F401
+
+from cqc_lem.utilities.db import PostType
 
 
 # Wall-clock MUST be frozen mid-month here: the plan window derives its length from
@@ -712,3 +714,115 @@ class TestCreateVideoContent:
                 assert content == "Fallback post text"
             except Exception:
                 pass  # pexels import failure is acceptable in unit context
+
+
+# ---------------------------------------------------------------------------
+# regenerate_post tests (issue #794 — all post types)
+# ---------------------------------------------------------------------------
+
+class TestRegeneratePostAllTypes:
+    """regenerate_post now handles text, carousel, document, and video posts."""
+
+    _DB = "cqc_lem.utilities.db"
+
+    @pytest.fixture(autouse=True)
+    def base_patches(self):
+        """Stop DB/profile reads from escaping the unit."""
+        with patch(f"{self._DB}.get_post_user_id", return_value=1), \
+             patch(f"{self._DB}.get_post_buyer_stage", return_value="awareness"), \
+             patch(f"{self._DB}.get_post_type", return_value=PostType.TEXT), \
+             patch(f"{_RCP}.load_profile_for_user", return_value=MagicMock()), \
+             patch(f"{_RCP}._score_and_persist_dwell"), \
+             patch(f"{_RCP}.update_db_post_content"), \
+             patch(f"{_RCP}._persist_gate_findings"), \
+             patch(f"{_RCP}.update_db_post_status"), \
+             patch(f"{_RCP}.get_engagement_preferences", return_value={"use_emojis": False}), \
+             patch(f"{_RCP}.get_or_create_profile_synthesis", return_value="synth"), \
+             patch(f"{_RCP}.apply_post_guidance", return_value=None), \
+             patch(f"{_RCP}.get_lead_magnet_settings", return_value=None), \
+             patch(f"{_RCP}.sanitize_for_linkedin", side_effect=lambda x: x), \
+             patch(f"{_RCP}.ensure_lead_magnet_cta", side_effect=lambda c, *a, **k: c):
+            yield
+
+    @patch(f"{_RCP}.create_text_post", return_value="New text post")
+    @patch(f"{_RCP}._post_content_mix", return_value="value")
+    def test_text_post_regenerates_with_guidance(self, mock_mix, mock_text, base_patches):
+        from cqc_lem.app.run_content_plan import regenerate_post
+        from cqc_lem.utilities.db import PostStatus
+        with patch(f"{_RCP}.apply_post_guidance", return_value="Guided text post") as mock_guidance:
+            result = regenerate_post(7, guidance="punchier")
+        assert result == "Guided text post"
+        mock_text.assert_called_once_with(1, "awareness", user_profile=ANY, post_id=7, content_mix="value")
+        mock_guidance.assert_called_once_with("New text post", "punchier", prefs={"use_emojis": False}, profile_synthesis="synth")
+        from cqc_lem.app.run_content_plan import update_db_post_status
+        update_db_post_status.assert_called_once_with(7, PostStatus.PENDING)
+
+    @patch(f"{_RCP}.create_carousel_content", return_value="New carousel caption")
+    @patch("cqc_lem.utilities.db.get_post_type", return_value=PostType.CAROUSEL)
+    @patch("cqc_lem.utilities.db.get_post_buyer_stage", return_value="consideration")
+    def test_carousel_post_regenerates_with_guidance(self, mock_stage, mock_type, mock_carousel, base_patches):
+        from cqc_lem.app.run_content_plan import regenerate_post
+        from cqc_lem.utilities.db import PostStatus
+        with patch(f"{_RCP}.apply_post_guidance", return_value="Guided carousel caption") as mock_guidance:
+            result = regenerate_post(8, guidance="more tactical")
+        assert result == "Guided carousel caption"
+        mock_carousel.assert_called_once_with(1, "consideration", 8)
+        mock_guidance.assert_called_once_with("New carousel caption", "more tactical", prefs={"use_emojis": False}, profile_synthesis="synth")
+        from cqc_lem.app.run_content_plan import update_db_post_status
+        update_db_post_status.assert_called_once_with(8, PostStatus.PENDING)
+
+    @patch(f"{_RCP}.create_carousel_content", return_value="New document caption")
+    @patch("cqc_lem.utilities.db.get_post_type", return_value=PostType.DOCUMENT)
+    @patch("cqc_lem.utilities.db.get_post_buyer_stage", return_value="decision")
+    def test_document_post_regenerates(self, mock_stage, mock_type, mock_carousel, base_patches):
+        from cqc_lem.app.run_content_plan import regenerate_post
+        result = regenerate_post(9)
+        assert result == "New document caption"
+        mock_carousel.assert_called_once_with(1, "decision", 9)
+
+    @patch(f"{_RCP}.create_text_post", return_value="New video caption")
+    @patch(f"{_RCP}._post_content_mix", return_value="authority")
+    @patch("cqc_lem.utilities.db.get_post_type", return_value=PostType.VIDEO)
+    @patch("cqc_lem.utilities.db.get_post_buyer_stage", return_value="awareness")
+    @patch(f"{_RCP}._generate_video_src", return_value="https://runway.video/xyz.mp4")
+    def test_video_post_regenerates_caption_and_video(self, mock_video_src, mock_stage, mock_type,
+                                                    mock_mix, mock_text, base_patches):
+        from cqc_lem.app.run_content_plan import regenerate_post
+        from cqc_lem.utilities.db import PostStatus
+        with patch(f"{_RCP}.create_folder_if_not_exists"), \
+             patch(f"{_RCP}.save_video_url_to_dir", return_value="/fake/path/xyz.mp4"), \
+             patch(f"{_RCP}.update_db_post_video_url") as mock_update_video, \
+             patch(f"{_RCP}.apply_post_guidance", return_value="Guided video caption") as mock_guidance:
+            result = regenerate_post(10, guidance="shorter")
+        assert result == "Guided video caption"
+        mock_text.assert_called_once_with(1, "awareness", user_profile=ANY, post_id=10, content_mix="authority")
+        mock_guidance.assert_called_once_with("New video caption", "shorter", prefs={"use_emojis": False}, profile_synthesis="synth")
+        mock_video_src.assert_called_once_with(1, "Guided video caption", ANY, 10)
+        mock_update_video.assert_called_once()
+        from cqc_lem.app.run_content_plan import update_db_post_status
+        update_db_post_status.assert_called_once_with(10, PostStatus.PENDING)
+
+    @patch("cqc_lem.utilities.db.get_post_type", return_value=PostType.VIDEO)
+    @patch("cqc_lem.utilities.db.get_post_buyer_stage", return_value="awareness")
+    @patch(f"{_RCP}.create_text_post", return_value="New video caption")
+    @patch(f"{_RCP}._post_content_mix", return_value="authority")
+    @patch(f"{_RCP}._generate_video_src", return_value=None)
+    def test_video_post_held_when_video_asset_fails(self, mock_video_src, mock_mix, mock_text,
+                                                    mock_stage, mock_type, base_patches):
+        from cqc_lem.app.run_content_plan import regenerate_post
+        from cqc_lem.utilities.db import PostStatus
+        with patch(f"{_RCP}.apply_post_guidance", side_effect=lambda c, *a, **k: c):
+            result = regenerate_post(11)
+        assert result == "New video caption"
+        from cqc_lem.app.run_content_plan import update_db_post_status
+        update_db_post_status.assert_called_once_with(11, PostStatus.PENDING)
+
+    @patch("cqc_lem.utilities.db.get_post_type", return_value=None)
+    def test_unknown_post_type_returns_none(self, mock_type, base_patches):
+        from cqc_lem.app.run_content_plan import regenerate_post
+        assert regenerate_post(12) is None
+
+    @patch("cqc_lem.utilities.db.get_post_user_id", return_value=None)
+    def test_missing_user_returns_none(self, mock_user_id):
+        from cqc_lem.app.run_content_plan import regenerate_post
+        assert regenerate_post(13) is None

--- a/tests/unit/utilities/ai/test_ai_helper_carousel.py
+++ b/tests/unit/utilities/ai/test_ai_helper_carousel.py
@@ -88,6 +88,26 @@ class TestGenerateCarouselContent:
         assert isinstance(post_text, str)
         assert isinstance(carousel_dict, dict)
 
+    def test_guidance_reaches_the_slide_prompt(self):
+        """Issue #794: the regenerate flow's free-text guidance must steer the SLIDES, not just the
+        caption — and must not license an invented number to satisfy the request."""
+        payload = _educational_carousel_json()
+        with self._patch_llm(payload) as mock_llm, self._patch_profile():
+            from cqc_lem.utilities.ai.ai_helper import generate_carousel_content
+            generate_carousel_content(user_id=1, stage="awareness", guidance="drop the pricing slide")
+        prompt = mock_llm.call_args.kwargs["messages"][1]["content"][0]["text"]
+        assert "drop the pricing slide" in prompt
+        assert "every slide" in prompt
+        assert "never invent a number" in prompt
+
+    def test_no_guidance_adds_no_revision_block(self):
+        payload = _educational_carousel_json()
+        with self._patch_llm(payload) as mock_llm, self._patch_profile():
+            from cqc_lem.utilities.ai.ai_helper import generate_carousel_content
+            generate_carousel_content(user_id=1, stage="awareness", guidance="   ")
+        prompt = mock_llm.call_args.kwargs["messages"][1]["content"][0]["text"]
+        assert "AUTHOR'S REVISION REQUEST" not in prompt
+
     def test_uses_lem_complex_model(self):
         payload = _educational_carousel_json()
         with self._patch_llm(payload) as mock_llm, self._patch_profile():


### PR DESCRIPTION
Implements issue #794.

## What changed
- Extended regenerate_post in src/cqc_lem/app/run_content_plan.py to regenerate text, carousel, document, and video posts (previously text only).
- Added two helpers:
  - _apply_guidance_to_text_post: applies user-supplied free-text guidance, sanitizes the result, and re-verifies the lead-magnet CTA.
  - _finish_regenerated_post: re-scores dwell, refreshes gate findings, persists content, and resets the post to PENDING.
- For carousel/document posts: regenerates caption + slide images via create_carousel_content.
- For video posts: regenerates the caption via create_text_post, applies guidance, then produces a new video asset via _generate_video_src so the visuals match the updated caption. If video asset generation fails, the post is still persisted and held for review via the missing_asset gate finding.
- Updated the /api/user/post/regenerate endpoint docstring to note it supports all post types.

## Testing
- Added unit tests for each post type in tests/unit/app/test_run_content_plan.py.
- Added API-level tests confirming the endpoint accepts text/carousel/document/video posts in tests/unit/api/test_post_regenerate_api.py.
- Updated the existing carousel placeholder-substitution test to assert carousel regeneration now succeeds.
- All touched-area unit tests pass (109 tests).

Closes #794

🤖 Generated with [Claude Code](https://claude.com/claude-code)