### PR TITLE
test(observability): make error-capture middleware probes outrank the SPA catch-all (closes #820)

### DIFF
--- a/tests/unit/api/test_error_capture_middleware.py
+++ b/tests/unit/api/test_error_capture_middleware.py
@@ -99,8 +99,11 @@ class TestUnhandledExceptionCapture:
 
     def test_healthy_request_is_not_captured(self, client):
         with patch("cqc_lem.api.main.capture_exception") as mock_capture:
-            client.get("/health")
+            response = client.get("/health")
 
+        # Assert the body, not just a 200: the catch-all also answers 200, so "no capture" on a
+        # shadowed /health would be the same vacuous pass the probes above were fixed out of.
+        assert response.json() == {"status": "healthy"}
         mock_capture.assert_not_called()
 
 

--- a/tests/unit/api/test_error_capture_middleware.py
+++ b/tests/unit/api/test_error_capture_middleware.py
@@ -1,7 +1,7 @@
 """Unit tests for the FastAPI unhandled-exception capture in the observability middleware
 (issue #648)."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -13,18 +13,40 @@ pytestmark = pytest.mark.unit
 def app_with_probe_routes():
     """The real app plus two probe routes: one that raises an unhandled error, one that raises the
     HTTPException a route uses for a normal 4xx."""
-    with patch("cqc_lem.utilities.observability.track_api_call"):
-        from cqc_lem.api.main import app
+    from cqc_lem.api.main import app
 
-        @app.get("/__probe_boom")
-        async def _boom():
-            raise RuntimeError("probe boom")
+    original_routes = list(app.router.routes)
 
-        @app.get("/__probe_http_error")
-        async def _http_error():
-            raise HTTPException(status_code=404, detail="Not found")
+    # main.py registers the SPA fallback (`GET /{full_path:path}`) LAST, and only when ui/dist was
+    # built. Starlette matches in registration order, so probe routes appended after it never run —
+    # they serve index.html with a 200, and every assertion below passes against the wrong response
+    # (issue #820). Register an equivalent catch-all unconditionally so the hazard is present here
+    # whether or not the UI was built, then put the probes in FRONT of it.
+    @app.get("/{full_path:path}", include_in_schema=False)
+    async def _spa_fallback(full_path: str):
+        return {"spa": full_path}
 
+    routes_before_probes = len(app.router.routes)
+
+    @app.get("/__probe_boom")
+    async def _boom():
+        raise RuntimeError("probe boom")
+
+    @app.get("/__probe_http_error")
+    async def _http_error():
+        raise HTTPException(status_code=404, detail="Not found")
+
+    probe_routes = app.router.routes[routes_before_probes:]
+    del app.router.routes[routes_before_probes:]
+    app.router.routes[:0] = probe_routes
+
+    # `app` is a module-level singleton shared with every other test module, and main.py binds
+    # track_api_call into its own namespace at import time — patching it here (rather than on
+    # observability) holds regardless of who imported main first.
+    with patch("cqc_lem.api.main.track_api_call"):
         yield app
+
+    app.router.routes[:] = original_routes
 
 
 @pytest.fixture(scope="module")
@@ -32,6 +54,25 @@ def client(app_with_probe_routes):
     from fastapi.testclient import TestClient
     with TestClient(app_with_probe_routes, raise_server_exceptions=False) as tc:
         yield tc
+
+
+def _capturing_posthog() -> MagicMock:
+    """A stand-in for the posthog module that reports itself enabled, so capture_exception runs its
+    real body instead of returning early on the keyless test env."""
+    fake = MagicMock()
+    fake.disabled = False
+    return fake
+
+
+class TestProbeRoutesAreReachable:
+    def test_catch_all_is_registered_and_would_shadow_appended_routes(self, client):
+        """Guards the fixture itself: an unmatched path resolves to a catch-all and answers 200, so
+        the 500/404 the probes return below can only mean they were matched ahead of it. If the
+        probes stop being registered first they go back to answering 200 too, and the tests below
+        stop proving anything."""
+        response = client.get("/__no_such_route")
+
+        assert response.status_code == 200
 
 
 class TestUnhandledExceptionCapture:
@@ -61,3 +102,33 @@ class TestUnhandledExceptionCapture:
             client.get("/health")
 
         mock_capture.assert_not_called()
+
+
+class TestExceptionReachesPostHog:
+    """End to end through the real capture_exception — the middleware calling a mock proves the
+    wiring, not that an `$exception` is actually emitted with route context."""
+
+    def test_unhandled_route_error_emits_exception_event(self, client):
+        fake_posthog = _capturing_posthog()
+
+        with patch("cqc_lem.utilities.observability.posthog", fake_posthog):
+            response = client.get("/__probe_boom")
+
+        assert response.status_code == 500
+        fake_posthog.capture_exception.assert_called_once()
+        args, kwargs = fake_posthog.capture_exception.call_args
+        assert isinstance(args[0], RuntimeError)
+        assert kwargs["distinct_id"] == "system"
+        properties = kwargs["properties"]
+        assert properties["route"] == "/__probe_boom"
+        assert properties["method"] == "GET"
+        assert properties["source"] == "fastapi.middleware"
+
+    def test_http_exception_emits_no_exception_event(self, client):
+        fake_posthog = _capturing_posthog()
+
+        with patch("cqc_lem.utilities.observability.posthog", fake_posthog):
+            response = client.get("/__probe_http_error")
+
+        assert response.status_code == 404
+        fake_posthog.capture_exception.assert_not_called()


### PR DESCRIPTION
## What

`tests/unit/api/test_error_capture_middleware.py` registered its two probe routes on the real `app` **after** main.py's SPA fallback (`@app.get("/{full_path:path}")`, registered last, and only when `src/cqc_lem/ui/dist` exists). Starlette matches routes in registration order, so `/__probe_boom` and `/__probe_http_error` both resolved to the catch-all and returned **200 index.html**. Every assertion about the middleware then ran against the wrong response — the FastAPI `500 → $exception` surface that `docs/error-tracking.md` names had **no working coverage** anywhere the UI had been built (locally, and in any job that builds the SPA).

Reproduced exactly as the issue describes: with `ui/dist` present, `assert 200 == 500` and `assert 200 == 404`; with it absent, the file passed only because the catch-all wasn't registered at all.

## Fix

Test-only. The middleware turned out to be **correct** — see below.

- Probe routes are inserted at the **front** of `app.router.routes`, so they win against any catch-all.
- The fixture registers an equivalent SPA-style catch-all **unconditionally**, so the shadowing hazard is exercised whether or not `ui/dist` was built — the file can no longer pass for the wrong reason in one environment and fail in the other.
- The shared `app` singleton's route table is **restored on teardown** (it previously leaked the probe routes into the rest of the session).
- `track_api_call` is patched in `cqc_lem.api.main`'s own namespace rather than on `observability` — main.py binds it at import time, so the old patch was a no-op whenever another test module had already imported main.

## Confirming the middleware actually emits `$exception`

The existing tests patch `cqc_lem.api.main.capture_exception`, which proves the middleware *calls* something, not that an `$exception` is emitted. Two new end-to-end tests (`TestExceptionReachesPostHog`) run the **real** `capture_exception` with a stand-in `posthog` that reports itself enabled (the test env is keyless, so `posthog.disabled` would short-circuit it):

- a real unhandled `RuntimeError` in a route reaches `posthog.capture_exception` with `distinct_id="system"` and properties `route=/__probe_boom`, `method=GET`, `source=fastapi.middleware`;
- an `HTTPException` emits nothing.

So the FastAPI 500 path is healthy; the low `$exception` volume in the PostHog audit is not caused by this surface (the `log_warning` escalation gap that did suppress events was fixed separately in v0.113.0).

## Acceptance criteria

- [x] Both tests pass for the right reason (probes genuinely 500 / 404) — plus a guard test asserting an unmatched path still resolves to the catch-all with a 200, so a future regression in probe ordering fails loudly instead of silently passing
- [x] A real unhandled route error is confirmed to emit `$exception` with route context
- [x] `HTTPException` still does not emit one

## Testing

- `tests/unit/api/test_error_capture_middleware.py` — 6 passed, run **both** with and without a `src/cqc_lem/ui/dist` present
- `tests/unit` full suite — 8884 passed

Closes #820

🤖 Generated with [Claude Code](https://claude.com/claude-code)
