### PR TITLE
feat(models): carry each candidate's Ollama Cloud usage level through the benchmark (#842)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1024,6 +1024,11 @@ BENCHMARK_MAX_CANDIDATES=3
 # Seconds to wait for PostHog's async evaluation verdicts before a case is reported as
 # judge:timeout. A missing verdict is NEVER counted as a pass.
 BENCHMARK_JUDGE_TIMEOUT_SECONDS=90
+# Ollama Cloud usage levels (quota class) for the models whose ollama.com page publishes none —
+# every model that is also pullable locally. Same syntax as --usage-levels, which overrides it.
+# An unsupplied level renders `unknown`, and the report treats unknown as a quota RISK rather than
+# as flat, so an unattended run (issue #842) carries them here instead of on the command line.
+BENCHMARK_USAGE_LEVELS=gpt-oss:120b=medium
 # Judge scoring uses PostHog Evaluations via POSTHOG_PERSONAL_API_KEY / POSTHOG_PROJECT_ID (see
 # the PostHog section above) plus POSTHOG_API_KEY for emitting the tagged $ai_generation events.
 # PostHog's judge needs its own provider key configured IN PostHog (Ollama Cloud is not a judge

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -82,7 +82,25 @@ on **cloud-only** model pages, so models that are also pullable locally (`gpt-os
 ```
 
 `--no-usage-levels` skips the fetch entirely (one page request per measured model); a fetch that
-fails leaves that model `unknown` rather than failing the run.
+fails leaves that model `unknown` rather than failing the run. On an **unattended** run there is
+nobody to type that flag, so the same string is read from `BENCHMARK_USAGE_LEVELS` (an explicit
+flag wins) — see *Unattended runs* below.
+
+### Standing spend policy — when a quota increase may be taken (#842)
+
+The delta says what a swap costs. The policy says who gets to accept that cost, and the owner
+settled it once (#842 decision `2A`) so a run does not park for the same question every time:
+
+> A usage-level **increase** is adoptable only on `lem-complex` — long-form is the one tier where
+> quality *is* the product — and only on a **strict** judge-rate win. A tie is not worth +1 usage
+> level on every call that tier serves.
+
+`QUOTA_INCREASE_TIERS` in `scripts/benchmark_models.py` is that rule, and every `recommend` verdict
+carries a `quota_policy` of `adopt` / `hold` with the reason, rendered under the verdict and again
+per recommendation. `hold` is **not** a gate — the quality verdict is unchanged and the swap is
+still recommended; it means the swap goes to the owner rather than into a config PR. `unknown`
+holds too, for the same reason it never renders as `flat`: a level nobody read cannot be checked
+against a rule written about increases.
 
 A recommendation is **not** a change. `.litellm/model_upgrades.yaml` is the RETIREMENT map and the
 reactive half of the model-health check auto-swaps whatever lands in it, so adopting a benchmark
@@ -108,6 +126,25 @@ poetry run python scripts/benchmark_models.py --render /tmp/bm.json --out-dir do
 `scripts/weekly_model_check.sh` invokes it automatically for the candidates the #716 catalog scan
 found, and opens the report as a PR. A benchmark failure alerts but never blocks the retirement-swap
 safety path.
+
+### Unattended runs (#842)
+
+A real run needs a key, so it used to need a person. Four env vars are the whole difference between
+"paste me the report" and a run that happens on its own:
+
+| Variable | Why it has to be in the environment |
+|---|---|
+| `BENCHMARK_ENABLED=true` | Without it `--run` prints "nothing to do" and exits 0 — a silent no-op, not an error. |
+| `OLLAMA_CLOUD_URL` | `https://ollama.com/v1`, the direct API that serves the bare model ids (`deepseek-v4-flash`, not `deepseek-v4-flash:cloud`). |
+| `OLLAMA_CLOUD_API_KEY` | The metered credential. Never in the repo, never in a report. |
+| `BENCHMARK_USAGE_LEVELS` | The incumbents' levels, which ollama.com does not publish. Unsupplied is `unknown`, and `unknown` holds a swap — so a run without it can recommend but can never conclude. |
+
+`POSTHOG_PERSONAL_API_KEY` + `POSTHOG_API_KEY` are optional: both present uses PostHog Evaluations
+as the judge, otherwise the run falls back to the in-runner judge and says so in the report.
+
+The report is the deliverable — `--results-out` for the JSON a later `--render` replays, and
+`--recommendations-out` for the swap list a follow-up config PR reads. Anything the standing spend
+policy marks `hold` is named in the report and belongs to the owner, not to the config PR.
 
 ## Leaderboard
 

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -56,6 +56,34 @@ reported but go no further:
 | `no-baseline` | No champion measured for that tier — nothing to compare against. |
 | `reject` | Failed at least one expectation. |
 
+### Usage level — what a swap COSTS (issue #842)
+
+The gate scores quality. It says nothing about price, and on Ollama Cloud those are separate
+questions: metering is by the model's **usage level** (Low / Medium / High / Extra high), so
+promoting a High model over a Medium one raises quota burn on every call that tier serves. That is a
+spend decision, not a free upgrade.
+
+So the harness carries the level **beside** the scores and never gates on it:
+
+- every scorecard has a `Usage` column, champion and candidate alike;
+- every gate verdict carries a `usage_delta` (`up` / `flat` / `down` / `unknown`), rendered under
+  the expectations, and it rides on the JSON that `--recommendations-out` writes;
+- a recommendation that raises the level renders **⚠️ quota increase** with the step count, and the
+  Swap-recommendations section adds a "decide the extra quota burn deliberately" note.
+
+`unknown` is **not** `flat`. A level that could not be read renders with the same warning an
+increase gets — the failure this prevents is a High model being adopted as if it were free because
+nobody could see its level. Unknown is common and expected: ollama.com publishes the Usage stat only
+on **cloud-only** model pages, so models that are also pullable locally (`gpt-oss:120b`,
+`qwen3.5:397b`, `gemma4:31b`) have no level to scrape. Supply theirs from the cloud listing:
+
+```bash
+--usage-levels gpt-oss:120b=medium,qwen3.5:397b=medium
+```
+
+`--no-usage-levels` skips the fetch entirely (one page request per measured model); a fetch that
+fails leaves that model `unknown` rather than failing the run.
+
 A recommendation is **not** a change. `.litellm/model_upgrades.yaml` is the RETIREMENT map and the
 reactive half of the model-health check auto-swaps whatever lands in it, so adopting a benchmark
 winner is a deliberate edit to `.litellm/config.yaml` (or a #717-style PR). The report renders the

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -103,6 +103,11 @@ LEADERBOARD_COLUMNS = ("Date", "Run", "Tier", "Model", "Role", "Deterministic", 
 LEADERBOARD_HEADER = "| " + " | ".join(LEADERBOARD_COLUMNS) + " |"
 LEADERBOARD_DIVIDER = "|" + "---|" * len(LEADERBOARD_COLUMNS)
 
+SCORECARD_COLUMNS = ("Tier", "Model", "Role", "Usage", "Cases", "Deterministic", "Judge", "Judged",
+                     "Timeouts", "p50", "p90")
+SCORECARD_HEADER = "| " + " | ".join(SCORECARD_COLUMNS) + " |"
+SCORECARD_DIVIDER = "|" + "---|" * len(SCORECARD_COLUMNS)
+
 # Openers that mean the model narrated instead of answering. `lem-simple` outputs are pasted
 # straight into LinkedIn copy, so a preamble is a correctness failure, not a style nit.
 _PREAMBLE_RE = re.compile(
@@ -890,9 +895,8 @@ def render_report(run: dict) -> str:
         "",
         "## Scorecard",
         "",
-        "| Tier | Model | Role | Usage | Cases | Deterministic | Judge | Judged | Timeouts | p50 "
-        "| p90 |",
-        "|---|---|---|---|---|---|---|---|---|---|---|",
+        SCORECARD_HEADER,
+        SCORECARD_DIVIDER,
     ]
     for card in run.get("scorecards") or []:
         lines.append(

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -46,7 +46,8 @@ Options:
   --results-out PATH       Where --run/--dry-run writes the machine-readable results.
   --recommendations-out P  Write ONLY the swap recommendations (for the cron) to this path.
   --usage-levels m=lvl,…   Ollama Cloud usage level for models whose page publishes none
-                           (low|medium|high|"extra high"). Overrides the fetched value.
+                           (low|medium|high|"extra high"). Overrides the fetched value; defaults to
+                           $BENCHMARK_USAGE_LEVELS so an unattended run needs no flags.
   --no-usage-levels        Skip the per-model usage-level fetch (one page request per model).
   --no-judge               Deterministic checks only.
   --max-judge-calls N      Hard cap on judge calls for the whole run (default BENCHMARK_MAX_JUDGE_CALLS).
@@ -139,6 +140,16 @@ def _env_float(name: str, default: float, low: float = 0.0, high: float = 1.0) -
 
 def benchmark_enabled() -> bool:
     return _env_flag("BENCHMARK_ENABLED", False)
+
+
+def usage_levels_env_default() -> str:
+    """`BENCHMARK_USAGE_LEVELS` — the incumbents' levels for a run nobody is watching.
+
+    ollama.com publishes the Usage stat only on cloud-only model pages, so the locally-pullable
+    incumbents' levels are a human input. On an unattended run there is no human to pass
+    `--usage-levels`, and an unsupplied level renders `unknown`, which the report treats as a quota
+    RISK — so the same string lives beside the API key in the runner's env instead."""
+    return (os.environ.get("BENCHMARK_USAGE_LEVELS") or "").strip()
 
 
 def max_judge_calls() -> int:
@@ -652,6 +663,53 @@ def usage_delta(candidate: Optional[dict], champion: Optional[dict], *,
             "direction": direction, "steps": steps, "summary": summary}
 
 
+# Standing owner policy (#842 decision `2A`): a quality win that RAISES the Ollama Cloud usage level
+# is adoptable only on `lem-complex` — long-form is the one tier where quality IS the product — and
+# only on a STRICT judge-rate win. A tie does not buy +1 usage level on every call that tier serves.
+# It lives here rather than in prose so an unattended run states the call itself instead of parking
+# for the same decision twice. Still reported, never gated: the gate's `recommend` is a QUALITY
+# verdict and is untouched by this — the policy only says whether that verdict can be TAKEN without
+# going back to the owner.
+QUOTA_INCREASE_TIERS = ("lem-complex",)
+
+POLICY_ADOPT = "adopt"
+POLICY_HOLD = "hold"
+
+
+def quota_policy(tier: str, delta: Optional[dict], candidate: Optional[dict] = None,
+                 champion: Optional[dict] = None) -> dict:
+    """Does the standing policy let this recommendation be adopted, or does it need the owner?"""
+    direction = (delta or {}).get("direction") or USAGE_UNKNOWN
+    tiers = ", ".join(f"`{t}`" for t in QUOTA_INCREASE_TIERS)
+    if direction in (USAGE_FLAT, USAGE_DOWN):
+        return {"decision": POLICY_ADOPT,
+                "reason": "no usage-level increase — the quality gate is the whole decision."}
+    if direction == USAGE_UNKNOWN:
+        # An unconfirmed level is treated as an increase, so it cannot clear a policy written about
+        # increases: the level has to be READ before the policy can say anything true about it.
+        return {"decision": POLICY_HOLD,
+                "reason": ("usage level unread on at least one side, which counts as an increase — "
+                           "supply it (`--usage-levels`, or `BENCHMARK_USAGE_LEVELS` on an "
+                           "unattended run) and re-render before adopting.")}
+    if tier not in QUOTA_INCREASE_TIERS:
+        return {"decision": POLICY_HOLD,
+                "reason": (f"a usage-level increase is adoptable only on {tiers}; `{tier}` would "
+                           f"pay the extra quota without the long-form quality it buys.")}
+    cand_judge = (candidate or {}).get("judge_pass_rate")
+    champ_judge = (champion or {}).get("judge_pass_rate")
+    if not isinstance(cand_judge, (int, float)) or not isinstance(champ_judge, (int, float)):
+        return {"decision": POLICY_HOLD,
+                "reason": ("no judge rate on both sides — a quota increase is adoptable only on a "
+                           "measured quality win.")}
+    if cand_judge > champ_judge:
+        return {"decision": POLICY_ADOPT,
+                "reason": (f"beats the champion's judge rate outright ({cand_judge:.0%} vs "
+                           f"{champ_judge:.0%}) on {tiers}.")}
+    return {"decision": POLICY_HOLD,
+            "reason": (f"ties or trails the champion on judge rate ({cand_judge:.0%} vs "
+                       f"{champ_judge:.0%}) — a tie is not worth the extra quota.")}
+
+
 # ───────────────────────── champion/challenger gate (pure) ───────────────────────
 
 VERDICT_RECOMMEND = "recommend"
@@ -728,13 +786,17 @@ def gate_decision(candidate: dict, champion: Optional[dict], thresholds: dict) -
     else:
         verdict = VERDICT_RECOMMEND
     # Reported, never gated: a HIGH-usage candidate can still earn `recommend` on quality — what it
-    # must never do is arrive without its price tag attached.
+    # must never do is arrive without its price tag attached, or without the standing spend policy
+    # (#842 `2A`) applied to that price.
+    delta = usage_delta(candidate.get("usage"), (champion or {}).get("usage"),
+                        candidate_model=str(candidate.get("model") or ""),
+                        champion_model=str((champion or {}).get("model") or ""))
     return {"tier": candidate.get("tier"), "model": candidate.get("model"),
             "champion": (champion or {}).get("model"), "verdict": verdict,
             "expectations": expectations,
-            "usage_delta": usage_delta(candidate.get("usage"), (champion or {}).get("usage"),
-                                       candidate_model=str(candidate.get("model") or ""),
-                                       champion_model=str((champion or {}).get("model") or "")),
+            "usage_delta": delta,
+            "quota_policy": quota_policy(str(candidate.get("tier") or ""), delta,
+                                         candidate, champion),
             "blockers": [e["expectation"] for e in expectations if e["passes"] is False]}
 
 
@@ -750,7 +812,9 @@ def swap_recommendations(gates: list) -> list:
     """ONLY full `recommend` verdicts become swap recommendations. A candidate that merely cleared
     the deterministic floor, or had no champion to beat, is reported and goes no further."""
     return [{"tier": g["tier"], "model": g["model"], "champion": g["champion"],
-             "usage_delta": g.get("usage_delta") or usage_delta(None, None)}
+             "usage_delta": g.get("usage_delta") or usage_delta(None, None),
+             "quota_policy": g.get("quota_policy") or quota_policy(str(g.get("tier") or ""),
+                                                                   g.get("usage_delta"))}
             for g in gates if g.get("verdict") == VERDICT_RECOMMEND]
 
 
@@ -878,6 +942,10 @@ def render_report(run: dict) -> str:
         delta = gate.get("usage_delta") or {}
         if delta.get("summary"):
             lines.append(f"- 💳 usage level — {delta['summary']}")
+        policy = gate.get("quota_policy") or {}
+        if gate.get("verdict") == VERDICT_RECOMMEND and policy.get("decision"):
+            lines.append(f"- 🧾 standing spend policy — **{policy['decision']}**: "
+                         f"{policy.get('reason', '')}")
         lines.append("")
 
     recommendations = run.get("recommendations") or []
@@ -891,12 +959,25 @@ def render_report(run: dict) -> str:
             delta = rec.get("usage_delta") or {}
             if delta.get("summary"):
                 lines.append(f"  - {delta['summary']}")
+            policy = rec.get("quota_policy") or {}
+            if policy.get("decision"):
+                lines.append(f"  - standing spend policy: **{policy['decision']}** — "
+                             f"{policy.get('reason', '')}")
         if any((r.get("usage_delta") or {}).get("direction") in (USAGE_UP, USAGE_UNKNOWN)
                for r in recommendations):
+            held = [r for r in recommendations
+                    if (r.get("quota_policy") or {}).get("decision") == POLICY_HOLD]
             lines += ["",
                       ("At least one recommendation above raises this stack's Ollama Cloud quota "
                        "class (or its level could not be read). A quality win is not on its own an "
-                       "adoption: decide the extra quota burn deliberately and record the call.")]
+                       "adoption — the standing policy is that a usage-level increase is adoptable "
+                       f"only on {', '.join(f'`{t}`' for t in QUOTA_INCREASE_TIERS)} and only on a "
+                       "strict judge-rate win (see `docs/model-benchmarks/README.md`).")]
+            if held:
+                lines.append("**{} held** by that policy: {} — take these to the owner rather than "
+                             "shipping them.".format(
+                                 len(held),
+                                 ", ".join(f"`{r['model']}` on {r['tier']}" for r in held)))
         lines += ["",
                   ("These are recommendations, not changes. `.litellm/model_upgrades.yaml` is the " +
                    "RETIREMENT map and auto-swaps into the live config, so adopting one of these is " +
@@ -1694,8 +1775,9 @@ def main(argv: Optional[list] = None) -> int:
     if not args.dry_run and not args.no_usage_levels:
         from model_health_check import fetch_usage_level  # noqa: WPS433 - sibling script
         fetch = fetch_usage_level
-    usage_levels = collect_usage_levels(measured, fetch=fetch,
-                                        overrides=parse_usage_overrides(args.usage_levels))
+    usage_levels = collect_usage_levels(
+        measured, fetch=fetch,
+        overrides=parse_usage_overrides(args.usage_levels or usage_levels_env_default()))
 
     cap = args.max_judge_calls if args.max_judge_calls is not None else max_judge_calls()
     run = run_benchmark(suites, models, champions,

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -570,12 +570,26 @@ USAGE_FLAT = "flat"
 USAGE_UNKNOWN = "unknown"
 
 
+def usage_level(entry: Optional[dict]) -> Optional[int]:
+    """The ONE place a stored level becomes a number the harness is willing to act on.
+
+    `model_health_check.parse_usage_level` falls back to COUNTING filled pips when the page's
+    wording changes, so a markup drift hands back a level like 0 or 7. Anything outside 1–4 is
+    unreadable, and it has to read that way EVERYWHERE: a level the scorecard prints as `unknown`
+    while the delta treats it as a real number is how an unread champion level renders a quota
+    increase as a "decrease" and clears the standing spend policy on its own."""
+    level = (entry or {}).get("level")
+    if isinstance(level, bool) or not isinstance(level, (int, float)):
+        return None
+    level = int(level)
+    return level if 1 <= level <= 4 else None
+
+
 def usage_name(entry: Optional[dict]) -> str:
     """`{level, label}` → "High (3)". An unreadable level is `unknown`, never a guessed middle."""
-    entry = entry or {}
-    level = entry.get("level")
-    level = int(level) if isinstance(level, (int, float)) and 1 <= int(level) <= 4 else None
-    label = " ".join(str(entry.get("label") or "").split()).title() or USAGE_LEVEL_NAMES.get(level)
+    level = usage_level(entry)
+    label = (" ".join(str((entry or {}).get("label") or "").split()).capitalize()
+             or USAGE_LEVEL_NAMES.get(level))
     if label and level:
         return f"{label} ({level})"
     return label or "unknown"
@@ -632,11 +646,11 @@ def usage_delta(candidate: Optional[dict], champion: Optional[dict], *,
     `unknown` is NOT `flat`. A swap whose quota cost cannot be read is a quota RISK, so it renders
     with the same warning an increase gets — the failure mode this exists to prevent is a HIGH model
     being adopted as if it were free because nobody could see its level."""
-    cand_level = (candidate or {}).get("level")
-    champ_level = (champion or {}).get("level")
+    cand_level = usage_level(candidate)
+    champ_level = usage_level(champion)
     cand_name = usage_name(candidate)
     champ_name = usage_name(champion)
-    known = isinstance(cand_level, int) and isinstance(champ_level, int)
+    known = cand_level is not None and champ_level is not None
     if not known:
         direction, steps = USAGE_UNKNOWN, None
     elif cand_level > champ_level:
@@ -659,7 +673,7 @@ def usage_delta(candidate: Optional[dict], champion: Optional[dict], *,
     else:
         missing = [n for n, lvl in ((candidate_model or "candidate", cand_level),
                                     (champion_model or "champion", champ_level))
-                   if not isinstance(lvl, int)]
+                   if lvl is None]
         summary = (f"⚠️ **quota delta unknown** — no usage level for {', '.join(missing)} "
                    f"(ollama.com publishes it only for cloud-only models; pass "
                    f"`--usage-levels {missing[0]}=<level>`). Treat as an increase until confirmed.")

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -45,6 +45,9 @@ Options:
   --out-dir DIR            Report + leaderboard directory (default docs/model-benchmarks).
   --results-out PATH       Where --run/--dry-run writes the machine-readable results.
   --recommendations-out P  Write ONLY the swap recommendations (for the cron) to this path.
+  --usage-levels m=lvl,…   Ollama Cloud usage level for models whose page publishes none
+                           (low|medium|high|"extra high"). Overrides the fetched value.
+  --no-usage-levels        Skip the per-model usage-level fetch (one page request per model).
   --no-judge               Deterministic checks only.
   --max-judge-calls N      Hard cap on judge calls for the whole run (default BENCHMARK_MAX_JUDGE_CALLS).
   --run-id ID              Fix the run id (tests / reproducible dry runs).
@@ -532,6 +535,123 @@ def merge_scorecard(tier: str, model: str, role: str, case_results: list,
     }
 
 
+# ─────────────────────── usage level / quota delta (pure) ────────────────────────
+#
+# A benchmark win says a model is BETTER. It does not say what it costs. Ollama Cloud meters by the
+# model's usage level, so promoting a HIGH model over a MEDIUM one raises quota burn on every call
+# of that tier — issue #842's minimax-m3 / glm-5.2 question exactly. The harness therefore carries
+# the level beside the scores and renders the delta in the report; it deliberately does NOT gate on
+# it, because "is the extra quota worth it" is a human call, not a threshold.
+
+USAGE_LEVEL_NAMES = {1: "Low", 2: "Medium", 3: "High", 4: "Extra high"}
+# Same scale `model_health_check.parse_usage_level` reads off the model page — a test asserts the
+# two agree, so an override and a scrape can never mean different things by "medium".
+USAGE_LEVELS_BY_LABEL = {name.lower(): level for level, name in USAGE_LEVEL_NAMES.items()}
+
+USAGE_UP = "up"
+USAGE_DOWN = "down"
+USAGE_FLAT = "flat"
+USAGE_UNKNOWN = "unknown"
+
+
+def usage_name(entry: Optional[dict]) -> str:
+    """`{level, label}` → "High (3)". An unreadable level is `unknown`, never a guessed middle."""
+    entry = entry or {}
+    level = entry.get("level")
+    level = int(level) if isinstance(level, (int, float)) and 1 <= int(level) <= 4 else None
+    label = " ".join(str(entry.get("label") or "").split()).title() or USAGE_LEVEL_NAMES.get(level)
+    if label and level:
+        return f"{label} ({level})"
+    return label or "unknown"
+
+
+def parse_usage_overrides(raw: Optional[str]) -> dict:
+    """`model=low|medium|high|extra high` pairs.
+
+    Needed because ollama.com publishes the Usage stat only on CLOUD-ONLY model pages: the tiers'
+    incumbents (`gpt-oss:120b`, `qwen3.5:397b`, `gemma4:31b`) are also pullable locally, so their
+    pages carry no level and the scrape honestly returns unknown. The level is then a human input
+    from the model's cloud listing — stated on the run, never invented by the harness."""
+    out: dict = {}
+    for chunk in str(raw or "").split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        model, _, label = chunk.partition("=")
+        label = " ".join(label.split()).lower()
+        if not model.strip() or label not in USAGE_LEVELS_BY_LABEL:
+            raise SystemExit(f"--usage-levels expects model=low|medium|high|'extra high', "
+                             f"got {chunk!r}")
+        out[model.strip()] = {"level": USAGE_LEVELS_BY_LABEL[label], "label": label}
+    return out
+
+
+def collect_usage_levels(models: list, *, fetch: Optional[Callable[[str], dict]] = None,
+                         overrides: Optional[dict] = None) -> dict:
+    """`model -> {level, label}` for every model in the run. Overrides win over the fetched page.
+
+    `fetch` is injected (and omitted entirely on a dry run) so this stays the only place the harness
+    would touch the network for a level; a fetch that raises leaves that model unknown rather than
+    failing the benchmark."""
+    overrides = overrides or {}
+    levels: dict = {}
+    for model in models:
+        if model in overrides:
+            levels[model] = dict(overrides[model])
+            continue
+        entry = {"level": None, "label": None}
+        if fetch is not None:
+            try:
+                entry = fetch(model) or entry
+            except Exception as exc:  # noqa: BLE001 - a level we cannot read is unknown, not fatal
+                print(f"  ! usage level unavailable for {model}: {str(exc)[:120]}", file=sys.stderr)
+        levels[model] = {"level": entry.get("level"), "label": entry.get("label")}
+    return levels
+
+
+def usage_delta(candidate: Optional[dict], champion: Optional[dict], *,
+                candidate_model: str = "", champion_model: str = "") -> dict:
+    """What adopting `candidate` in place of `champion` does to Ollama Cloud quota.
+
+    `unknown` is NOT `flat`. A swap whose quota cost cannot be read is a quota RISK, so it renders
+    with the same warning an increase gets — the failure mode this exists to prevent is a HIGH model
+    being adopted as if it were free because nobody could see its level."""
+    cand_level = (candidate or {}).get("level")
+    champ_level = (champion or {}).get("level")
+    cand_name = usage_name(candidate)
+    champ_name = usage_name(champion)
+    known = isinstance(cand_level, int) and isinstance(champ_level, int)
+    if not known:
+        direction, steps = USAGE_UNKNOWN, None
+    elif cand_level > champ_level:
+        direction, steps = USAGE_UP, cand_level - champ_level
+    elif cand_level < champ_level:
+        direction, steps = USAGE_DOWN, cand_level - champ_level
+    else:
+        direction, steps = USAGE_FLAT, 0
+
+    champ_ref = f"champion `{champion_model}`" if champion_model else "the champion"
+    if direction == USAGE_UP:
+        summary = (f"⚠️ **quota increase** — {cand_name} vs {champ_ref} {champ_name} "
+                   f"(+{steps} usage level{'s' if steps > 1 else ''}). Every call on this tier "
+                   f"burns more Ollama Cloud quota; this is a spend decision, not a free upgrade.")
+    elif direction == USAGE_DOWN:
+        summary = (f"quota decrease — {cand_name} vs {champ_ref} {champ_name} "
+                   f"({steps} usage level{'s' if steps < -1 else ''}).")
+    elif direction == USAGE_FLAT:
+        summary = f"flat on quota — {cand_name} on both sides."
+    else:
+        missing = [n for n, lvl in ((candidate_model or "candidate", cand_level),
+                                    (champion_model or "champion", champ_level))
+                   if not isinstance(lvl, int)]
+        summary = (f"⚠️ **quota delta unknown** — no usage level for {', '.join(missing)} "
+                   f"(ollama.com publishes it only for cloud-only models; pass "
+                   f"`--usage-levels {missing[0]}=<level>`). Treat as an increase until confirmed.")
+    return {"candidate_level": cand_level, "candidate_label": cand_name,
+            "champion_level": champ_level, "champion_label": champ_name,
+            "direction": direction, "steps": steps, "summary": summary}
+
+
 # ───────────────────────── champion/challenger gate (pure) ───────────────────────
 
 VERDICT_RECOMMEND = "recommend"
@@ -607,9 +727,14 @@ def gate_decision(candidate: dict, champion: Optional[dict], thresholds: dict) -
         verdict = VERDICT_DETERMINISTIC_ONLY
     else:
         verdict = VERDICT_RECOMMEND
+    # Reported, never gated: a HIGH-usage candidate can still earn `recommend` on quality — what it
+    # must never do is arrive without its price tag attached.
     return {"tier": candidate.get("tier"), "model": candidate.get("model"),
             "champion": (champion or {}).get("model"), "verdict": verdict,
             "expectations": expectations,
+            "usage_delta": usage_delta(candidate.get("usage"), (champion or {}).get("usage"),
+                                       candidate_model=str(candidate.get("model") or ""),
+                                       champion_model=str((champion or {}).get("model") or "")),
             "blockers": [e["expectation"] for e in expectations if e["passes"] is False]}
 
 
@@ -624,7 +749,8 @@ def gate_run(scorecards: list, suites: dict) -> list:
 def swap_recommendations(gates: list) -> list:
     """ONLY full `recommend` verdicts become swap recommendations. A candidate that merely cleared
     the deterministic floor, or had no champion to beat, is reported and goes no further."""
-    return [{"tier": g["tier"], "model": g["model"], "champion": g["champion"]}
+    return [{"tier": g["tier"], "model": g["model"], "champion": g["champion"],
+             "usage_delta": g.get("usage_delta") or usage_delta(None, None)}
             for g in gates if g.get("verdict") == VERDICT_RECOMMEND]
 
 
@@ -700,17 +826,23 @@ def render_report(run: dict) -> str:
         "",
         "## Scorecard",
         "",
-        "| Tier | Model | Role | Cases | Deterministic | Judge | Judged | Timeouts | p50 | p90 |",
-        "|---|---|---|---|---|---|---|---|---|---|",
+        "| Tier | Model | Role | Usage | Cases | Deterministic | Judge | Judged | Timeouts | p50 "
+        "| p90 |",
+        "|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for card in run.get("scorecards") or []:
         lines.append(
-            f"| {card['tier']} | `{card['model']}` | {card['role']} | {card['cases']} | "
+            f"| {card['tier']} | `{card['model']}` | {card['role']} | "
+            f"{usage_name(card.get('usage'))} | {card['cases']} | "
             f"{_fmt_rate(card.get('deterministic_pass_rate'))} "
             f"({card.get('deterministic_passed', 0)}/{card.get('cases', 0)}) | "
             f"{_fmt_rate(card.get('judge_pass_rate'))} | {card.get('judged', 0)} | "
             f"{card.get('judge_timeouts', 0)} | {_fmt_ms(card.get('latency_p50_ms'))} | "
             f"{_fmt_ms(card.get('latency_p90_ms'))} |")
+    lines += ["",
+              ("**Usage** is the Ollama Cloud usage level (quota class) — `unknown` where "
+               "ollama.com publishes no level for that model, which is the case for models that "
+               "are also pullable locally. Supply those with `--usage-levels model=<level>`.")]
 
     lines += ["", "## Per-expectation detail", ""]
     for card in run.get("scorecards") or []:
@@ -743,6 +875,9 @@ def render_report(run: dict) -> str:
         for expectation in gate.get("expectations") or []:
             mark = {True: "✅", False: "❌"}.get(expectation["passes"], "➖")
             lines.append(f"- {mark} {expectation['expectation']} — {expectation['detail']}")
+        delta = gate.get("usage_delta") or {}
+        if delta.get("summary"):
+            lines.append(f"- 💳 usage level — {delta['summary']}")
         lines.append("")
 
     recommendations = run.get("recommendations") or []
@@ -753,6 +888,15 @@ def render_report(run: dict) -> str:
     else:
         for rec in recommendations:
             lines.append(f"- **{rec['tier']}**: `{rec['champion']}` → `{rec['model']}`")
+            delta = rec.get("usage_delta") or {}
+            if delta.get("summary"):
+                lines.append(f"  - {delta['summary']}")
+        if any((r.get("usage_delta") or {}).get("direction") in (USAGE_UP, USAGE_UNKNOWN)
+               for r in recommendations):
+            lines += ["",
+                      ("At least one recommendation above raises this stack's Ollama Cloud quota "
+                       "class (or its level could not be read). A quality win is not on its own an "
+                       "adoption: decide the extra quota burn deliberately and record the call.")]
         lines += ["",
                   ("These are recommendations, not changes. `.litellm/model_upgrades.yaml` is the " +
                    "RETIREMENT map and auto-swaps into the live config, so adopting one of these is " +
@@ -1248,7 +1392,8 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
                   provider: Optional[ProviderClient] = None,
                   evals: Optional["PostHogEvals"] = None,
                   judge_cap: int = 0, dry_run: bool = False,
-                  judge_enabled: bool = True) -> dict:
+                  judge_enabled: bool = True,
+                  usage_levels: Optional[dict] = None) -> dict:
     """Run every (model, tier) pair and merge the results into one run document.
 
     `dry_run` scores each suite against the case's committed `canned` output and verdict: a full
@@ -1374,6 +1519,7 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
 
         card = merge_scorecard(tier, model, role, case_results, judge_results, timings)
         card["benchmark_run_id"] = run_id
+        card["usage"] = dict((usage_levels or {}).get(model) or {"level": None, "label": None})
         scorecards.append(card)
         if evals is not None and judge_enabled and not dry_run and judge_results:
             awaiting.append((card, suite, outputs, judge_results))
@@ -1425,6 +1571,7 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
         "tiers": sorted(suites),
         "candidates": list(models),
         "champions": {t: champions.get(t) for t in sorted(suites)},
+        "usage_levels": dict(usage_levels or {}),
         "judge_calls": judge_spent,
         "judge_call_cap": judge_budget,
         "scorecards": scorecards,
@@ -1469,6 +1616,8 @@ def main(argv: Optional[list] = None) -> int:
     ap.add_argument("--out-dir", default=DEFAULT_OUT_DIR)
     ap.add_argument("--results-out", default=None)
     ap.add_argument("--recommendations-out", default=None)
+    ap.add_argument("--usage-levels", default="")
+    ap.add_argument("--no-usage-levels", action="store_true")
     ap.add_argument("--no-judge", action="store_true")
     ap.add_argument("--max-judge-calls", type=int, default=None)
     ap.add_argument("--run-id", default=None)
@@ -1539,11 +1688,21 @@ def main(argv: Optional[list] = None) -> int:
             print("  POSTHOG_API_KEY is unset — PostHog evaluations cannot score events that were "
                   "never emitted; using the in-runner judge", file=sys.stderr)
 
+    # Every model the run will score, champions included — a delta needs both sides.
+    measured = sorted(set(models) | {m for m in champions.values() if m})
+    fetch = None
+    if not args.dry_run and not args.no_usage_levels:
+        from model_health_check import fetch_usage_level  # noqa: WPS433 - sibling script
+        fetch = fetch_usage_level
+    usage_levels = collect_usage_levels(measured, fetch=fetch,
+                                        overrides=parse_usage_overrides(args.usage_levels))
+
     cap = args.max_judge_calls if args.max_judge_calls is not None else max_judge_calls()
     run = run_benchmark(suites, models, champions,
                         run_id=args.run_id or _run_id(today), today=today,
                         provider=provider, evals=evals, judge_cap=cap,
-                        dry_run=bool(args.dry_run), judge_enabled=not args.no_judge)
+                        dry_run=bool(args.dry_run), judge_enabled=not args.no_judge,
+                        usage_levels=usage_levels)
 
     if args.results_out:
         with open(args.results_out, "w") as f:

--- a/scripts/weekly_model_check.sh
+++ b/scripts/weekly_model_check.sh
@@ -259,7 +259,11 @@ print(','.join(names[:${BENCHMARK_MAX_CANDIDATES:-3}]), len(names))
 import sys, json
 run = json.load(sys.stdin)
 for r in run['recommendations']:
-    print(f\"{r['tier']}: {r['champion']} -> {r['model']} (benchmark-recommended, not applied)\")
+    # A recommendation is a QUALITY verdict; #842's standing spend policy says whether it may be
+    # taken. This alert is where the owner meets the swap, so the 'hold' has to arrive with it.
+    policy = (r.get('quota_policy') or {}).get('decision') or 'unknown'
+    quota = (r.get('usage_delta') or {}).get('direction') or 'unknown'
+    print(f\"{r['tier']}: {r['champion']} -> {r['model']} (benchmark-recommended, not applied; quota {quota}, spend policy: {policy})\")
 " 2>/dev/null || echo "(could not read recommendations)")"
             alert "Model benchmark recommends a swap:"$'\n'"$MSG"
           fi

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -323,8 +323,12 @@ class TestGate:
             {"tier": "lem-complex", "model": "c", "champion": None,
              "verdict": bm.VERDICT_NO_BASELINE},
         ]
-        assert bm.swap_recommendations(gates) == [
+        recs = bm.swap_recommendations(gates)
+        assert [{k: r[k] for k in ("tier", "model", "champion")} for r in recs] == [
             {"tier": "lem-simple", "model": "a", "champion": "old"}]
+        # A gate with no delta recorded still ships one, so a consumer never reads a missing key
+        # as "flat" (issue #842).
+        assert recs[0]["usage_delta"]["direction"] == bm.USAGE_UNKNOWN
 
     def test_gate_run_pairs_each_candidate_with_its_own_tier_champion(self):
         cards = [_card(tier="lem-simple", model="champ-s", role="champion"),
@@ -768,6 +772,129 @@ class TestChampions:
             bm.parse_champion_overrides("lem-simple")
 
 
+# ─────────────────────── usage level / quota delta (#842) ────────────────────────
+
+class TestUsageLevels:
+    def test_the_label_scale_matches_the_health_checks(self):
+        # Both halves must mean the same thing by "medium" — an override and a scraped page feed
+        # the same comparison.
+        import importlib.util as _iu
+        path = _ROOT / "scripts" / "model_health_check.py"
+        spec = _iu.spec_from_file_location("model_health_check_for_usage_scale", path)
+        mhc = _iu.module_from_spec(spec)
+        spec.loader.exec_module(mhc)
+        assert bm.USAGE_LEVELS_BY_LABEL == mhc._USAGE_LEVELS
+
+    def test_usage_name_renders_the_level_and_never_guesses_a_middle(self):
+        assert bm.usage_name({"level": 3, "label": "high"}) == "High (3)"
+        assert bm.usage_name({"level": 2, "label": None}) == "Medium (2)"
+        assert bm.usage_name({"level": None, "label": None}) == "unknown"
+        assert bm.usage_name(None) == "unknown"
+
+    def test_overrides_parse_and_validate(self):
+        assert bm.parse_usage_overrides("gpt-oss:120b=medium,qwen3.5:397b=Medium") == {
+            "gpt-oss:120b": {"level": 2, "label": "medium"},
+            "qwen3.5:397b": {"level": 2, "label": "medium"}}
+        assert bm.parse_usage_overrides("") == {}
+        with pytest.raises(SystemExit):
+            bm.parse_usage_overrides("gpt-oss:120b=enormous")
+        with pytest.raises(SystemExit):
+            bm.parse_usage_overrides("gpt-oss:120b")
+
+    def test_collect_prefers_the_override_over_the_page(self):
+        fetch = MagicMock(return_value={"level": 3, "label": "high"})
+        levels = bm.collect_usage_levels(["a", "b"], fetch=fetch,
+                                         overrides={"a": {"level": 2, "label": "medium"}})
+        assert levels["a"] == {"level": 2, "label": "medium"}
+        assert levels["b"] == {"level": 3, "label": "high"}
+        fetch.assert_called_once_with("b")
+
+    def test_no_fetch_means_no_network_and_unknown_levels(self):
+        assert bm.collect_usage_levels(["a"]) == {"a": {"level": None, "label": None}}
+
+    def test_a_failing_fetch_leaves_the_model_unknown_rather_than_failing_the_run(self, capsys):
+        levels = bm.collect_usage_levels(["a"], fetch=MagicMock(side_effect=RuntimeError("503")))
+        assert levels == {"a": {"level": None, "label": None}}
+        assert "usage level unavailable" in capsys.readouterr().err
+
+    def test_a_higher_usage_candidate_is_reported_as_a_quota_increase(self):
+        delta = bm.usage_delta({"level": 3, "label": "high"}, {"level": 2, "label": "medium"},
+                               candidate_model="minimax-m3", champion_model="qwen3.5:397b")
+        assert delta["direction"] == bm.USAGE_UP and delta["steps"] == 1
+        assert "quota increase" in delta["summary"] and "qwen3.5:397b" in delta["summary"]
+
+    def test_equal_levels_are_flat_and_a_lower_level_is_a_decrease(self):
+        flat = bm.usage_delta({"level": 2}, {"level": 2})
+        assert flat["direction"] == bm.USAGE_FLAT and flat["steps"] == 0
+        down = bm.usage_delta({"level": 1, "label": "low"}, {"level": 2, "label": "medium"})
+        assert down["direction"] == bm.USAGE_DOWN and down["steps"] == -1
+
+    def test_an_unreadable_level_is_unknown_not_flat(self):
+        # The whole point: "we could not read it" must never render as "it costs the same".
+        delta = bm.usage_delta({"level": None}, {"level": 2}, candidate_model="glm-5.2",
+                               champion_model="gpt-oss:120b")
+        assert delta["direction"] == bm.USAGE_UNKNOWN and delta["steps"] is None
+        assert "unknown" in delta["summary"] and "glm-5.2" in delta["summary"]
+        assert "--usage-levels glm-5.2=" in delta["summary"]
+
+    def test_the_gate_reports_the_delta_without_blocking_on_it(self):
+        candidate = dict(_card(model="minimax-m3"), usage={"level": 3, "label": "high"})
+        champion = dict(_card(model="qwen3.5:397b", role="champion"),
+                        usage={"level": 2, "label": "medium"})
+        gate = bm.gate_decision(candidate, champion, {"min_judged": 1})
+        assert gate["verdict"] == bm.VERDICT_RECOMMEND  # quality still wins the gate…
+        assert gate["usage_delta"]["direction"] == bm.USAGE_UP  # …but the price rides along
+        assert not any(e["expectation"].startswith("usage") for e in gate["expectations"])
+
+    def test_recommendations_carry_the_quota_delta_for_the_cron(self):
+        candidate = dict(_card(model="minimax-m3"), usage={"level": 3, "label": "high"})
+        champion = dict(_card(model="qwen3.5:397b", role="champion"),
+                        usage={"level": 2, "label": "medium"})
+        recs = bm.swap_recommendations([bm.gate_decision(candidate, champion, {"min_judged": 1})])
+        assert recs[0]["usage_delta"]["direction"] == bm.USAGE_UP
+
+    def test_scorecards_carry_the_level_through_a_run(self):
+        run = bm.run_benchmark(
+            {"lem-simple": _suite("lem-simple", cases=[
+                _case("a", assertions=[{"type": "max_chars", "value": 50}],
+                      canned={"output": "ok", "judge_pass": True})], thresholds={"min_judged": 1})},
+            ["cand"], {"lem-simple": "champ"}, run_id="bm-u", today="2026-07-27",
+            dry_run=True, judge_cap=5,
+            usage_levels={"cand": {"level": 3, "label": "high"},
+                          "champ": {"level": 2, "label": "medium"}})
+        assert {c["model"]: c["usage"]["level"] for c in run["scorecards"]} == {
+            "cand": 3, "champ": 2}
+        assert run["usage_levels"]["cand"]["label"] == "high"
+
+    def test_the_report_shows_the_level_beside_the_scores_and_warns_on_an_increase(self):
+        candidate = dict(_card(model="minimax-m3"), usage={"level": 3, "label": "high"})
+        champion = dict(_card(model="qwen3.5:397b", role="champion"),
+                        usage={"level": 2, "label": "medium"})
+        gate = bm.gate_decision(candidate, champion, {"min_judged": 1})
+        report = bm.render_report({
+            "source": bm.BENCHMARK_SOURCE, "run_id": "bm-x", "date": "2026-07-27",
+            "scoring_mode": bm.SCORING_FALLBACK, "tiers": ["lem-simple"],
+            "candidates": ["minimax-m3"], "scorecards": [champion, candidate],
+            "gates": [gate], "recommendations": bm.swap_recommendations([gate])})
+        assert "| Usage |" in report
+        assert "High (3)" in report and "Medium (2)" in report
+        assert "quota increase" in report
+        assert "raises this stack's Ollama Cloud quota class" in report
+
+    def test_a_flat_recommendation_gets_no_quota_warning_block(self):
+        candidate = dict(_card(model="deepseek-v4-flash"), usage={"level": 2, "label": "medium"})
+        champion = dict(_card(model="gpt-oss:120b", role="champion"),
+                        usage={"level": 2, "label": "medium"})
+        gate = bm.gate_decision(candidate, champion, {"min_judged": 1})
+        report = bm.render_report({
+            "source": bm.BENCHMARK_SOURCE, "run_id": "bm-x", "date": "2026-07-27",
+            "scoring_mode": bm.SCORING_FALLBACK, "tiers": ["lem-simple"],
+            "candidates": ["deepseek-v4-flash"], "scorecards": [champion, candidate],
+            "gates": [gate], "recommendations": bm.swap_recommendations([gate])})
+        assert "flat on quota" in report
+        assert "raises this stack's Ollama Cloud quota class" not in report
+
+
 # ──────────────────────────────── orchestration ──────────────────────────────────
 
 class TestRunBenchmark:
@@ -1039,6 +1166,49 @@ class TestCLI:
                  "--out-dir", str(tmp_path), "--run-id", "bm-c", "--today", "2026-07-27",
                  "--recommendations-out", str(recs), "--max-judge-calls", "300"])
         assert isinstance(json.loads(recs.read_text()), list)
+
+    def test_a_dry_run_reads_no_usage_page_but_still_honours_an_override(self, tmp_path):
+        bm.main(["--dry-run", "--models", "cand", "--suite-dir", str(SUITE_DIR),
+                 "--out-dir", str(tmp_path), "--run-id", "bm-u1", "--today", "2026-07-27",
+                 "--champions", "lem-simple=champ", "--tiers", "lem-simple",
+                 "--usage-levels", "champ=medium", "--max-judge-calls", "5"])
+        report = (tmp_path / "2026-07-27-bm-u1.md").read_text()
+        assert "Medium (2)" in report   # the override
+        assert "unknown" in report      # the candidate, never guessed
+
+    def test_a_real_run_fetches_levels_for_candidates_and_champions(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("BENCHMARK_ENABLED", "true")
+        monkeypatch.setenv("OLLAMA_CLOUD_URL", "https://ollama.example")
+        monkeypatch.setenv("OLLAMA_CLOUD_API_KEY", "key")
+        seen = []
+
+        def fake_fetch(model):
+            seen.append(model)
+            return {"level": 3, "label": "high"}
+
+        import model_health_check
+        monkeypatch.setattr(model_health_check, "fetch_usage_level", fake_fetch)
+        monkeypatch.setattr(bm.ProviderClient, "complete", lambda self, *a, **k: {
+            "text": "x", "error": None, "latency_ms": 1.0, "usage": {}})
+        bm.main(["--run", "--models", "cand", "--suite-dir", str(SUITE_DIR),
+                 "--out-dir", str(tmp_path), "--run-id", "bm-u2", "--today", "2026-07-27",
+                 "--champions", "lem-simple=champ", "--tiers", "lem-simple", "--no-judge"])
+        assert sorted(seen) == ["cand", "champ"]  # a delta needs BOTH sides
+
+    def test_no_usage_levels_skips_the_fetch_entirely(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("BENCHMARK_ENABLED", "true")
+        monkeypatch.setenv("OLLAMA_CLOUD_URL", "https://ollama.example")
+        monkeypatch.setenv("OLLAMA_CLOUD_API_KEY", "key")
+        import model_health_check
+        boom = MagicMock(side_effect=AssertionError("should not be called"))
+        monkeypatch.setattr(model_health_check, "fetch_usage_level", boom)
+        monkeypatch.setattr(bm.ProviderClient, "complete", lambda self, *a, **k: {
+            "text": "x", "error": None, "latency_ms": 1.0, "usage": {}})
+        bm.main(["--run", "--models", "cand", "--suite-dir", str(SUITE_DIR),
+                 "--out-dir", str(tmp_path), "--run-id", "bm-u3", "--today", "2026-07-27",
+                 "--champions", "lem-simple=champ", "--tiers", "lem-simple", "--no-judge",
+                 "--no-usage-levels"])
+        boom.assert_not_called()
 
     def test_a_bad_suite_directory_exits_1(self, tmp_path, capsys):
         assert bm.main(["--print-suites", "--suite-dir", str(tmp_path)]) == 1

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -895,6 +895,99 @@ class TestUsageLevels:
         assert "raises this stack's Ollama Cloud quota class" not in report
 
 
+# ────────────────── standing spend policy for a quota increase (#842 `2A`) ───────────────────
+
+class TestQuotaPolicy:
+    """The owner's standing call: a usage-level increase is adoptable only on `lem-complex`, and
+    only on a STRICT judge-rate win. Encoded so an unattended run states the decision itself."""
+
+    def test_no_increase_is_adoptable_on_the_quality_gate_alone(self):
+        for direction in (bm.USAGE_FLAT, bm.USAGE_DOWN):
+            policy = bm.quota_policy("lem-medium", {"direction": direction})
+            assert policy["decision"] == bm.POLICY_ADOPT
+
+    def test_a_strict_judge_win_on_lem_complex_is_adoptable(self):
+        policy = bm.quota_policy("lem-complex", {"direction": bm.USAGE_UP},
+                                 _card(tier="lem-complex", judge_rate=0.9),
+                                 _card(tier="lem-complex", role="champion", judge_rate=0.8))
+        assert policy["decision"] == bm.POLICY_ADOPT
+        assert "90% vs 80%" in policy["reason"]
+
+    def test_a_tie_on_lem_complex_is_held_because_a_tie_does_not_buy_a_usage_level(self):
+        policy = bm.quota_policy("lem-complex", {"direction": bm.USAGE_UP},
+                                 _card(tier="lem-complex", judge_rate=0.9),
+                                 _card(tier="lem-complex", role="champion", judge_rate=0.9))
+        assert policy["decision"] == bm.POLICY_HOLD
+        assert "tie" in policy["reason"]
+
+    def test_an_increase_on_any_other_tier_is_held_however_good_the_candidate(self):
+        policy = bm.quota_policy("lem-medium", {"direction": bm.USAGE_UP},
+                                 _card(tier="lem-medium", judge_rate=1.0),
+                                 _card(tier="lem-medium", role="champion", judge_rate=0.5))
+        assert policy["decision"] == bm.POLICY_HOLD
+        assert "`lem-complex`" in policy["reason"] and "lem-medium" in policy["reason"]
+
+    def test_a_missing_judge_rate_cannot_clear_a_quota_increase(self):
+        policy = bm.quota_policy("lem-complex", {"direction": bm.USAGE_UP},
+                                 _card(tier="lem-complex", judge_rate=None),
+                                 _card(tier="lem-complex", role="champion", judge_rate=0.8))
+        assert policy["decision"] == bm.POLICY_HOLD
+        assert "measured quality win" in policy["reason"]
+
+    def test_an_unread_level_is_held_rather_than_adopted(self):
+        # Symmetric with `usage_delta`: unknown is treated as an increase, and a policy about
+        # increases cannot clear one whose size nobody can see.
+        for delta in ({"direction": bm.USAGE_UNKNOWN}, {}, None):
+            policy = bm.quota_policy("lem-complex", delta,
+                                     _card(tier="lem-complex", judge_rate=1.0),
+                                     _card(tier="lem-complex", role="champion", judge_rate=0.1))
+            assert policy["decision"] == bm.POLICY_HOLD
+            assert "BENCHMARK_USAGE_LEVELS" in policy["reason"]
+
+    def test_the_gate_and_the_recommendation_both_carry_the_policy(self):
+        candidate = dict(_card(tier="lem-complex", model="minimax-m3", judge_rate=0.9),
+                         usage={"level": 3, "label": "high"})
+        champion = dict(_card(tier="lem-complex", model="qwen3.5:397b", role="champion",
+                              judge_rate=0.8), usage={"level": 2, "label": "medium"})
+        gate = bm.gate_decision(candidate, champion, {"min_judged": 1})
+        assert gate["verdict"] == bm.VERDICT_RECOMMEND
+        assert gate["quota_policy"]["decision"] == bm.POLICY_ADOPT
+        assert bm.swap_recommendations([gate])[0]["quota_policy"]["decision"] == bm.POLICY_ADOPT
+
+    def test_a_gate_with_no_policy_recorded_still_ships_one(self):
+        # A consumer of the JSON must never read a missing key as "adopt".
+        recs = bm.swap_recommendations([{"tier": "lem-medium", "model": "a", "champion": "old",
+                                         "verdict": bm.VERDICT_RECOMMEND}])
+        assert recs[0]["quota_policy"]["decision"] == bm.POLICY_HOLD
+
+    def test_the_report_names_the_held_recommendations(self):
+        candidate = dict(_card(tier="lem-medium", model="minimax-m3"),
+                         usage={"level": 3, "label": "high"})
+        champion = dict(_card(tier="lem-medium", model="gpt-oss:120b", role="champion"),
+                        usage={"level": 2, "label": "medium"})
+        gate = bm.gate_decision(candidate, champion, {"min_judged": 1})
+        report = bm.render_report({
+            "source": bm.BENCHMARK_SOURCE, "run_id": "bm-x", "date": "2026-07-27",
+            "scoring_mode": bm.SCORING_FALLBACK, "tiers": ["lem-medium"],
+            "candidates": ["minimax-m3"], "scorecards": [champion, candidate],
+            "gates": [gate], "recommendations": bm.swap_recommendations([gate])})
+        assert "standing spend policy" in report
+        assert "**1 held**" in report and "`minimax-m3` on lem-medium" in report
+
+    def test_an_adoptable_recommendation_is_not_reported_as_held(self):
+        candidate = dict(_card(tier="lem-complex", model="minimax-m3", judge_rate=0.9),
+                         usage={"level": 3, "label": "high"})
+        champion = dict(_card(tier="lem-complex", model="qwen3.5:397b", role="champion",
+                              judge_rate=0.8), usage={"level": 2, "label": "medium"})
+        gate = bm.gate_decision(candidate, champion, {"min_judged": 1})
+        report = bm.render_report({
+            "source": bm.BENCHMARK_SOURCE, "run_id": "bm-x", "date": "2026-07-27",
+            "scoring_mode": bm.SCORING_FALLBACK, "tiers": ["lem-complex"],
+            "candidates": ["minimax-m3"], "scorecards": [champion, candidate],
+            "gates": [gate], "recommendations": bm.swap_recommendations([gate])})
+        assert "**adopt**" in report and "held**" not in report
+
+
 # ──────────────────────────────── orchestration ──────────────────────────────────
 
 class TestRunBenchmark:
@@ -1175,6 +1268,26 @@ class TestCLI:
         report = (tmp_path / "2026-07-27-bm-u1.md").read_text()
         assert "Medium (2)" in report   # the override
         assert "unknown" in report      # the candidate, never guessed
+
+    def test_the_env_supplies_the_levels_when_nobody_is_there_to_pass_the_flag(self, monkeypatch,
+                                                                              tmp_path):
+        # An unattended run (#842 `1B`) has no human to type `--usage-levels`, and an unsupplied
+        # level is a quota RISK, not a free pass — so the runner's env carries the same string.
+        monkeypatch.setenv("BENCHMARK_USAGE_LEVELS", "champ=medium")
+        bm.main(["--dry-run", "--models", "cand", "--suite-dir", str(SUITE_DIR),
+                 "--out-dir", str(tmp_path), "--run-id", "bm-u4", "--today", "2026-07-27",
+                 "--champions", "lem-simple=champ", "--tiers", "lem-simple",
+                 "--max-judge-calls", "5"])
+        assert "Medium (2)" in (tmp_path / "2026-07-27-bm-u4.md").read_text()
+
+    def test_an_explicit_flag_wins_over_the_env(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("BENCHMARK_USAGE_LEVELS", "champ=medium")
+        bm.main(["--dry-run", "--models", "cand", "--suite-dir", str(SUITE_DIR),
+                 "--out-dir", str(tmp_path), "--run-id", "bm-u5", "--today", "2026-07-27",
+                 "--champions", "lem-simple=champ", "--tiers", "lem-simple",
+                 "--usage-levels", "champ=high", "--max-judge-calls", "5"])
+        report = (tmp_path / "2026-07-27-bm-u5.md").read_text()
+        assert "High (3)" in report and "Medium (2)" not in report
 
     def test_a_real_run_fetches_levels_for_candidates_and_champions(self, monkeypatch, tmp_path):
         monkeypatch.setenv("BENCHMARK_ENABLED", "true")

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -837,6 +837,31 @@ class TestUsageLevels:
         assert "unknown" in delta["summary"] and "glm-5.2" in delta["summary"]
         assert "--usage-levels glm-5.2=" in delta["summary"]
 
+    def test_an_off_scale_level_is_unreadable_in_the_delta_too_not_just_in_the_table(self):
+        # `parse_usage_level` counts filled pips when the page's wording changes, so a markup drift
+        # yields a level like 7. The scorecard already prints that as `unknown`; if the delta still
+        # believed the number, an unread CHAMPION level would render a real increase as a
+        # "decrease" — and a decrease is exactly what the standing spend policy waves through.
+        champion = {"level": 7, "label": None}
+        candidate = {"level": 3, "label": "high"}
+        assert bm.usage_name(champion) == "unknown"
+        delta = bm.usage_delta(candidate, champion, candidate_model="minimax-m3",
+                               champion_model="qwen3.5:397b")
+        assert delta["direction"] == bm.USAGE_UNKNOWN and delta["steps"] is None
+        assert delta["champion_level"] is None  # the JSON says what the table says
+        assert "qwen3.5:397b" in delta["summary"]
+        assert bm.quota_policy("lem-medium", delta, {"judge_pass_rate": 1.0},
+                               {"judge_pass_rate": 0.1})["decision"] == bm.POLICY_HOLD
+
+    def test_a_level_replayed_from_json_still_compares(self):
+        # `--render` replays a results file; a level that came back as 3.0 must not read as unknown
+        # in the delta while the table happily prints "High (3)".
+        delta = bm.usage_delta({"level": 3.0}, {"level": 2.0})
+        assert delta["direction"] == bm.USAGE_UP and delta["steps"] == 1
+
+    def test_the_extra_high_label_renders_the_way_the_scale_names_it(self):
+        assert bm.usage_name({"level": 4, "label": "extra high"}) == "Extra high (4)"
+
     def test_the_gate_reports_the_delta_without_blocking_on_it(self):
         candidate = dict(_card(model="minimax-m3"), usage={"level": 3, "label": "high"})
         champion = dict(_card(model="qwen3.5:397b", role="champion"),
@@ -1267,7 +1292,9 @@ class TestCLI:
                  "--usage-levels", "champ=medium", "--max-judge-calls", "5"])
         report = (tmp_path / "2026-07-27-bm-u1.md").read_text()
         assert "Medium (2)" in report   # the override
-        assert "unknown" in report      # the candidate, never guessed
+        # The candidate's own row, never guessed — the footnote also says "unknown", so assert on
+        # the scorecard row rather than on the word appearing anywhere in the page.
+        assert "| `cand` | candidate | unknown |" in report
 
     def test_the_env_supplies_the_levels_when_nobody_is_there_to_pass_the_flag(self, monkeypatch,
                                                                               tmp_path):


### PR DESCRIPTION
Enabling half of #842. The measurement itself needs the box (Ollama Cloud key + a litellm restart), so this PR ships the part that can be built headless: the harness's ability to state a swap's **quota cost** beside its quality score.

## Why

The #721 gate scores quality and says nothing about price. On Ollama Cloud those are separate questions — metering is by the model's **usage level**, so promoting a HIGH model over a MEDIUM one raises quota burn on every call that tier serves. #842 asks the `minimax-m3` / `glm-5.2` question in exactly those terms:

> a `recommend` verdict on either is a quota increase, not a free upgrade, and the report must say so in numbers

Before this, `scripts/benchmark_models.py` had no notion of a usage level at all, so acceptance criterion 2 could only have been met by hand-writing the numbers into the PR body — which is how they go stale.

## What changed

- `collect_usage_levels()` reuses `model_health_check.fetch_usage_level` (injected, so the pure half stays network-free) for every measured model — **champions included**, because a delta needs both sides.
- Every scorecard gains a `Usage` column; every gate verdict and every swap recommendation carries a `usage_delta` (`up` / `flat` / `down` / `unknown`), which also rides on the JSON `--recommendations-out` writes for the cron.
- An increase renders as a ⚠️ **quota increase** line with its step count, and the Swap-recommendations section adds a "decide the extra burn deliberately" note.
- New `--usage-levels model=<low|medium|high|'extra high'>` and `--no-usage-levels`.
- Reported, **never gated** — "is the extra quota worth it" is a human call, not a threshold.

### `unknown` is deliberately not `flat`

A level that could not be read renders with the same warning an increase gets. The failure this prevents is a HIGH model being adopted as if it were free because nobody could see its level.

Unknown is expected, not a bug: ollama.com publishes the Usage stat only on **cloud-only** model pages. Verified live against ollama.com while writing this:

| Model | Usage stat on its page |
|---|---|
| `minimax-m3` | **High (3)** |
| `glm-5.2` | **High (3)** |
| `deepseek-v4-flash` | **Medium (2)** |
| `gpt-oss:120b` | none published (also pullable locally) |
| `qwen3.5:397b` | none published |
| `gemma4:31b` | none published |

So both #842 candidates for `lem-complex` are **one usage level above** the `deepseek-v4-flash` that #843 just landed there — confirmed from the source, not from a spec sheet. The incumbents' levels are a human input; `--usage-levels` is how they enter the run.

## Testing

- 20 new unit tests in `tests/unit/test_benchmark_models.py` (`TestUsageLevels` + 3 CLI tests): override precedence, no-fetch/no-network, a failing fetch degrading to unknown, up/flat/down/unknown deltas, the gate reporting without blocking, recommendations carrying the delta, both report renderings, and both sides being fetched.
- One test asserts `USAGE_LEVELS_BY_LABEL` equals `model_health_check._USAGE_LEVELS`, so an override and a scrape can never mean different things by "medium".
- `poetry run pytest tests/unit -q` → **8919 passed**.
- Rendered smoke run: `--dry-run --models minimax-m3 --tiers lem-complex --usage-levels "qwen3.5:397b=medium,minimax-m3=high"` produces
  `⚠️ **quota increase** — High (3) vs champion qwen3.5:397b Medium (2) (+1 usage level).`

## Owner decision applied — `1B 2A 3A`

**`2A` is now code, not prose.** A swap that raises the Ollama Cloud usage level is adoptable only
on `lem-complex`, and only on a **strict** judge-rate win — a tie does not buy +1 usage level.
`QUOTA_INCREASE_TIERS` + `quota_policy()` encode exactly that, so every `recommend` verdict and
every swap recommendation carries `{decision: adopt|hold, reason}`, rendered under the verdict, per
recommendation, and as a `**N held** by that policy` line naming them. It stays **reported, never
gated**: the quality verdict is unchanged and `hold` means "this one goes to the owner", not "this
one is blocked". `unknown` holds too — for the same reason it never renders as `flat`.

Rendered on a live dry run (`--models minimax-m3 --tiers lem-complex`, canned outputs tie at 100%):

```
- 💳 usage level — ⚠️ **quota increase** — High (3) vs champion `qwen3.5:397b` Medium (2) (+1 usage level). …
- 🧾 standing spend policy — **hold**: ties or trails the champion on judge rate (100% vs 100%) — a tie is not worth the extra quota.
…
**1 held** by that policy: `minimax-m3` on lem-complex — take these to the owner rather than shipping them.
```

**`1B` — the run happens unattended.** On a run nobody is watching there is no one to type
`--usage-levels`, and an unsupplied level renders `unknown`, which now HOLDS a swap: a run without
the incumbents' levels can recommend but can never conclude. So `--usage-levels` defaults to
`$BENCHMARK_USAGE_LEVELS` (an explicit flag still wins), `.env.example` carries it, and the docs
table names the four vars that separate "paste me the report" from a run that happens on its own.

The runner side is wired too (outside this diff, on the box — reported for the record, trivially
revertible from the `.bak.benchmark-env.*` copies beside each file):

- `agent-pipeline/lib/run_lane.sh` — sourcing `secrets.env` makes those shell variables, not
  environment ones, so a `claude -p` child never saw the key. It now exports exactly four:
  `OLLAMA_CLOUD_URL`, `OLLAMA_CLOUD_API_KEY`, `BENCHMARK_ENABLED`, `BENCHMARK_USAGE_LEVELS`.
- `agent-pipeline/config.env` — `BENCHMARK_ENABLED=true` and
  `BENCHMARK_USAGE_LEVELS=gpt-oss:120b=medium` (what #843's own config comment asserts).
  `qwen3.5:397b` and `gemma4:31b` are still unfilled and will render `unknown` → their swaps hold.
  Verified end to end: a child process now reads all four.

**`3A` needs no diff.** Champions are read from the shipped config head, so `gpt-oss:120b` stays
`lem-medium`'s champion and the demotion is decided on the measurement, as the acceptance criterion
asks.

## Testing

- 10 new tests in `TestQuotaPolicy` (adopt on flat/down, adopt on a strict `lem-complex` win, hold
  on a tie, hold on any other tier however good the candidate, hold with no judge rate, hold on an
  unread level, gate + recommendation both carrying it, a missing policy defaulting to `hold` not
  `adopt`, and both report renderings) + 2 CLI tests for the env default and flag precedence.
- `pytest tests/unit/test_benchmark_models.py -q` → **143 passed**.

## Remaining on #842

This PR still does **not** close the issue — no diff satisfies its five acceptance criteria. What
changed is who can do them:

- [ ] Benchmark run for all four candidates against the live champions; scorecard linked. — now a
      **tick's** job, not a hand-run: the runner's env carries the key, the flag and the levels.
- [ ] Quota/usage-level delta stated for `minimax-m3` / `glm-5.2` **with a keep-or-adopt call**. —
      the harness states the delta AND applies `2A` to it; what remains is a real measurement to
      apply it to.
- [ ] `gpt-oss:120b` demotion decided on the measurement. — `3A`: it stays champion until the run
      says otherwise.
- [ ] Any resulting swap shipped as a config PR — adopting only what the policy marks `adopt`.
- [ ] All tiers smoke-tested green after the litellm restart. — **still needs the box**; nothing
      here can do it.

The Decision Comment on this PR is answered (`1B 2A 3A`) and all three are applied above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
