### PR TITLE
feat(ui): collapse per-post performance on the Home dashboard by default (closes #808)

### DIFF
--- a/src/cqc_lem/ui/src/components/charts/PerPostTable.test.tsx
+++ b/src/cqc_lem/ui/src/components/charts/PerPostTable.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, afterEach } from 'vitest'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import PerPostTable, { type PerPost } from './PerPostTable'
+
+afterEach(cleanup)
+
+function post(overrides: Partial<PerPost> = {}): PerPost {
+  return {
+    post_id: 1,
+    scheduled_time: '2026-07-20T14:30:00',
+    format: 'text',
+    archetype: 'build_receipt',
+    hook_style: 'contrarian_take',
+    topic: 'ai',
+    buyer_stage: 'awareness',
+    reactions: 12,
+    comments: 3,
+    reposts: 1,
+    saves: 2,
+    impressions: 1500,
+    engagement: 18,
+    engagement_rate: 0.012,
+    ...overrides,
+  }
+}
+
+const toggle = () => screen.getByRole('button', { name: /Per-post performance/ })
+
+describe('PerPostTable', () => {
+  it('starts collapsed so the drill-down does not dominate the dashboard', () => {
+    render(<PerPostTable posts={[post()]} />)
+    expect(screen.queryByTestId('per-post-table')).toBeNull()
+    expect(toggle().getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('says how many posts are behind the collapsed header', () => {
+    render(<PerPostTable posts={[post({ post_id: 1 }), post({ post_id: 2 })]} />)
+    expect(toggle().textContent).toContain('(2 posts)')
+  })
+
+  it('singularizes the count for one post', () => {
+    render(<PerPostTable posts={[post()]} />)
+    expect(toggle().textContent).toContain('(1 post)')
+  })
+
+  it('expands on click and collapses again', () => {
+    render(<PerPostTable posts={[post()]} />)
+    fireEvent.click(toggle())
+    expect(screen.getByTestId('per-post-table')).toBeTruthy()
+    expect(toggle().getAttribute('aria-expanded')).toBe('true')
+    fireEvent.click(toggle())
+    expect(screen.queryByTestId('per-post-table')).toBeNull()
+  })
+
+  it('renders a row per post with formatted values once expanded', () => {
+    render(<PerPostTable posts={[post()]} />)
+    fireEvent.click(toggle())
+    const cells = screen.getByTestId('per-post-table').querySelectorAll('tbody td')
+    expect([...cells].map((c) => c.textContent)).toEqual([
+      'Jul 20',
+      'Text',
+      'Contrarian take',
+      '1,500',
+      '12',
+      '3',
+      '1',
+      '2',
+      '1.20%',
+    ])
+  })
+
+  it('renders a missing date, format, impression count or rate as — rather than as zero', () => {
+    render(
+      <PerPostTable
+        posts={[post({ scheduled_time: null, format: null, hook_style: null, impressions: null, engagement_rate: null })]}
+      />,
+    )
+    fireEvent.click(toggle())
+    const cells = [...screen.getByTestId('per-post-table').querySelectorAll('tbody td')].map((c) => c.textContent)
+    expect(cells[0]).toBe('—')
+    expect(cells[1]).toBe('—')
+    expect(cells[2]).toBe('—')
+    expect(cells[3]).toBe('—')
+    expect(cells[8]).toBe('—')
+  })
+
+  it('shows an empty note instead of a headers-only table when nothing was measured', () => {
+    render(<PerPostTable posts={[]} />)
+    expect(toggle().textContent).toContain('(0 posts)')
+    fireEvent.click(toggle())
+    expect(screen.queryByTestId('per-post-table')).toBeNull()
+    expect(screen.getByTestId('per-post-empty')).toBeTruthy()
+  })
+})

--- a/src/cqc_lem/ui/src/components/charts/PerPostTable.tsx
+++ b/src/cqc_lem/ui/src/components/charts/PerPostTable.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import { compactNumber, formatRate, shortDate, titleCase } from './palette'
+
+export interface PerPost {
+  post_id: number
+  scheduled_time: string | null
+  format: string | null
+  archetype: string | null
+  hook_style: string | null
+  topic: string | null
+  buyer_stage: string | null
+  reactions: number
+  comments: number
+  reposts: number
+  saves: number
+  impressions: number | null
+  engagement: number
+  engagement_rate: number | null
+}
+
+// Collapsed by default (#808). This drill-down is one row per measured post — over a 90-day window
+// it is by far the tallest thing on the Home dashboard, and the KPI row, trends and leaderboards
+// above it already answer the question most visits are asking. The row count stays in the header so
+// the collapsed state still says how much is behind it.
+export default function PerPostTable({ posts }: { posts: PerPost[] }) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div>
+      <h3 className="text-sm font-semibold text-gray-700">
+        <button
+          type="button"
+          onClick={() => setOpen(!open)}
+          aria-expanded={open}
+          className="w-full flex items-center justify-between gap-2 text-left hover:text-gray-900"
+        >
+          <span>
+            Per-post performance{' '}
+            <span className="font-normal text-gray-400">
+              ({posts.length} post{posts.length === 1 ? '' : 's'})
+            </span>
+          </span>
+          <span
+            aria-hidden="true"
+            className={`text-gray-400 leading-none transition-transform ${open ? 'rotate-180' : ''}`}
+          >
+            ▾
+          </span>
+        </button>
+      </h3>
+      {open &&
+        (posts.length === 0 ? (
+          <p className="text-xs text-gray-400 mt-2" data-testid="per-post-empty">
+            No posts with captured stats in this window.
+          </p>
+        ) : (
+          <div className="overflow-x-auto mt-2" data-testid="per-post-table">
+            <table className="w-full text-xs text-left tabular-nums">
+              <thead>
+                <tr className="text-gray-500 border-b border-gray-200">
+                  <th className="py-1.5 pr-3 font-medium">Date</th>
+                  <th className="py-1.5 pr-3 font-medium">Format</th>
+                  <th className="py-1.5 pr-3 font-medium">Hook</th>
+                  <th className="py-1.5 pr-3 font-medium text-right">Impr.</th>
+                  <th className="py-1.5 pr-3 font-medium text-right">Reactions</th>
+                  <th className="py-1.5 pr-3 font-medium text-right">Comments</th>
+                  <th className="py-1.5 pr-3 font-medium text-right">Reposts</th>
+                  <th className="py-1.5 pr-3 font-medium text-right">Saves</th>
+                  <th className="py-1.5 font-medium text-right">Eng. rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                {posts.map((p) => (
+                  <tr key={p.post_id} className="border-b border-gray-100 last:border-0 text-gray-700">
+                    <td className="py-1.5 pr-3 whitespace-nowrap">
+                      {p.scheduled_time ? shortDate(p.scheduled_time.slice(0, 10)) : '—'}
+                    </td>
+                    <td className="py-1.5 pr-3">{titleCase(p.format)}</td>
+                    <td className="py-1.5 pr-3">{titleCase(p.hook_style)}</td>
+                    <td className="py-1.5 pr-3 text-right">{p.impressions != null ? compactNumber(p.impressions) : '—'}</td>
+                    <td className="py-1.5 pr-3 text-right">{p.reactions.toLocaleString()}</td>
+                    <td className="py-1.5 pr-3 text-right">{p.comments.toLocaleString()}</td>
+                    <td className="py-1.5 pr-3 text-right">{p.reposts.toLocaleString()}</td>
+                    <td className="py-1.5 pr-3 text-right">{p.saves.toLocaleString()}</td>
+                    <td className="py-1.5 text-right">{p.engagement_rate != null ? formatRate(p.engagement_rate) : '—'}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        ))}
+    </div>
+  )
+}

--- a/src/cqc_lem/ui/src/components/charts/palette.ts
+++ b/src/cqc_lem/ui/src/components/charts/palette.ts
@@ -26,3 +26,17 @@ export function compactNumber(value: number): string {
 export function formatRate(value: number): string {
   return `${(value * 100).toFixed(2)}%`
 }
+
+// "2026-07-20" → "Jul 20" for compact chart/table axes (dates are tz-agnostic calendar days).
+const _MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+export function shortDate(iso: string): string {
+  const [, m, d] = iso.split('-')
+  const mi = Number(m) - 1
+  return mi >= 0 && mi < 12 ? `${_MONTHS[mi]} ${Number(d)}` : iso
+}
+
+export function titleCase(k: string | null): string {
+  if (!k) return '—'
+  const s = String(k).replace(/[_-]+/g, ' ').trim()
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -10,29 +10,13 @@ import OnboardingChecklist from '../components/OnboardingChecklist'
 import PostHogStatsPanel from '../components/PostHogStatsPanel'
 import LineChart, { type LinePoint } from '../components/charts/LineChart'
 import Leaderboard, { type RankEntry } from '../components/charts/Leaderboard'
-import { compactNumber, formatRate } from '../components/charts/palette'
+import PerPostTable, { type PerPost } from '../components/charts/PerPostTable'
+import { compactNumber, formatRate, shortDate, titleCase } from '../components/charts/palette'
 
 interface PostStats {
   recommendations: { weekday: string; hour: number; avg_engagement: number; sample: number }[]
   rankings: Record<string, RankEntry[]>
   sample_size: number
-}
-
-interface PerPost {
-  post_id: number
-  scheduled_time: string | null
-  format: string | null
-  archetype: string | null
-  hook_style: string | null
-  topic: string | null
-  buyer_stage: string | null
-  reactions: number
-  comments: number
-  reposts: number
-  saves: number
-  impressions: number | null
-  engagement: number
-  engagement_rate: number | null
 }
 
 interface TrendPoint {
@@ -235,20 +219,6 @@ function deltaColor(d: AudienceDelta | null | undefined): string {
 // letting the tile imply a window it didn't cover.
 function deltaSince(d: AudienceDelta | null | undefined): string {
   return d ? `since ${shortDate(d.from_date)}` : 'not enough history'
-}
-
-// "2026-07-20" → "Jul 20" for compact chart/table axes (dates are tz-agnostic calendar days).
-const _MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
-function shortDate(iso: string): string {
-  const [, m, d] = iso.split('-')
-  const mi = Number(m) - 1
-  return mi >= 0 && mi < 12 ? `${_MONTHS[mi]} ${Number(d)}` : iso
-}
-
-function titleCase(k: string | null): string {
-  if (!k) return '—'
-  const s = String(k).replace(/[_-]+/g, ' ').trim()
-  return s.charAt(0).toUpperCase() + s.slice(1)
 }
 
 interface DashboardStats {
@@ -795,44 +765,8 @@ export default function Dashboard() {
                 <Leaderboard title="Top hooks" entries={hookBoard} humanizeKey={titleCase} />
               </div>
 
-              {/* Per-post performance drill-down */}
-              <div>
-                <h3 className="text-sm font-semibold text-gray-700 mb-2">Per-post performance</h3>
-                <div className="overflow-x-auto">
-                  <table className="w-full text-xs text-left tabular-nums">
-                    <thead>
-                      <tr className="text-gray-500 border-b border-gray-200">
-                        <th className="py-1.5 pr-3 font-medium">Date</th>
-                        <th className="py-1.5 pr-3 font-medium">Format</th>
-                        <th className="py-1.5 pr-3 font-medium">Hook</th>
-                        <th className="py-1.5 pr-3 font-medium text-right">Impr.</th>
-                        <th className="py-1.5 pr-3 font-medium text-right">Reactions</th>
-                        <th className="py-1.5 pr-3 font-medium text-right">Comments</th>
-                        <th className="py-1.5 pr-3 font-medium text-right">Reposts</th>
-                        <th className="py-1.5 pr-3 font-medium text-right">Saves</th>
-                        <th className="py-1.5 font-medium text-right">Eng. rate</th>
-                      </tr>
-                    </thead>
-                    <tbody>
-                      {perPost.map((p) => (
-                        <tr key={p.post_id} className="border-b border-gray-100 last:border-0 text-gray-700">
-                          <td className="py-1.5 pr-3 whitespace-nowrap">
-                            {p.scheduled_time ? shortDate(p.scheduled_time.slice(0, 10)) : '—'}
-                          </td>
-                          <td className="py-1.5 pr-3">{titleCase(p.format)}</td>
-                          <td className="py-1.5 pr-3">{titleCase(p.hook_style)}</td>
-                          <td className="py-1.5 pr-3 text-right">{p.impressions != null ? compactNumber(p.impressions) : '—'}</td>
-                          <td className="py-1.5 pr-3 text-right">{p.reactions.toLocaleString()}</td>
-                          <td className="py-1.5 pr-3 text-right">{p.comments.toLocaleString()}</td>
-                          <td className="py-1.5 pr-3 text-right">{p.reposts.toLocaleString()}</td>
-                          <td className="py-1.5 pr-3 text-right">{p.saves.toLocaleString()}</td>
-                          <td className="py-1.5 text-right">{p.engagement_rate != null ? formatRate(p.engagement_rate) : '—'}</td>
-                        </tr>
-                      ))}
-                    </tbody>
-                  </table>
-                </div>
-              </div>
+              {/* Per-post performance drill-down — collapsed by default (#808) */}
+              <PerPostTable posts={perPost} />
             </>
           )}
         </div>


### PR DESCRIPTION
## What

The per-post performance drill-down on the Home dashboard is now **collapsed by default** and opens on click via a chevron disclosure.

- `Per-post performance (12 posts) ▾` — the row count stays in the header, so the collapsed state still says how much is behind it.
- Standard accordion semantics: `<h3><button aria-expanded>…</button></h3>`, chevron rotates on open, matching the existing `FaqItem` / `Advanced` pattern in the SPA.
- Expanding with nothing measured shows a one-line note instead of a headers-only table.

## Why

Reported in-app (feedback #20, issue #808): the table is one row per measured post across a 90-day window, so it was by far the tallest block on Home and pushed everything below it off-screen. The KPI row, engagement-rate/impression trends and the format/hook leaderboards directly above it already answer what most visits are asking; the per-post rows are a drill-down, so they open on demand.

## How

Extracted the table out of `Dashboard.tsx` into `components/charts/PerPostTable.tsx` (same `default export + named type` shape as its `LineChart` / `Leaderboard` siblings) so the toggle is unit-testable without standing up the whole Dashboard page (auth context, react-query, five API queries). `shortDate` / `titleCase` moved from `Dashboard.tsx` into `charts/palette.ts` beside `compactNumber` / `formatRate` — both callers now share one copy rather than duplicating them. Rendering of the rows themselves is unchanged.

## Testing

- New `PerPostTable.test.tsx` (7 cases): starts collapsed, expands and re-collapses on click with `aria-expanded` tracking, header count + singular/plural, formatted cell values, `—` (never `0`) for a missing date/format/impression count/rate, and the empty-state note.
- `npm test` → 38 files / 309 tests pass; `tsc -b` and `npm run build` clean; `npm run lint` reports nothing on the touched files.

Closes #808

🤖 Generated with [Claude Code](https://claude.com/claude-code)
