### PR TITLE
fix(groups): rotate past a group LEM cannot post in (closes #858)

### DIFF
--- a/compose/local/database/migrations/V20260801065636__add_user_group_last_post_run_at.sql
+++ b/compose/local/database/migrations/V20260801065636__add_user_group_last_post_run_at.sql
@@ -1,0 +1,22 @@
+-- Separate "we tried to post here" from "we posted here" (issue #858, follow-up of #769).
+--
+-- #769 made the weekly group post rotate on `last_posted_at`, stamped ONLY after a post actually
+-- shipped so a transient failure (dead session, flaky selectors) leaves the group next in line
+-- rather than skipping its turn. That is right for a transient failure and wrong for a permanent
+-- one: a group whose members cannot post (admin-only / announcement) renders no share box, so its
+-- `last_posted_at` stays NULL, NULL sorts FIRST, and it is "next" every week forever — starving
+-- every other post-enabled group. Group sync opts joined groups into posting by default, so one
+-- such group in a user's list is enough.
+--
+-- `last_post_run_at` is stamped by every run that REACHED the group and found it unpostable, plus
+-- every successful post; the rotation orders on it. `last_posted_at` keeps its meaning untouched —
+-- the truthful record of real posts, which is what the API payload and the Groups card show. A run
+-- that never reached the group (no session / profile failure) stamps neither, so transient
+-- behaviour is unchanged.
+--
+-- Backfilled from `last_posted_at` so existing rows keep their place in the rotation instead of all
+-- collapsing to NULL (which would restart every user's rotation at the alphabetically first group).
+ALTER TABLE user_groups
+    ADD COLUMN last_post_run_at DATETIME NULL DEFAULT NULL AFTER last_posted_at;
+
+UPDATE user_groups SET last_post_run_at = last_posted_at;

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -35,7 +35,7 @@ from cqc_lem.utilities.db import get_user_password_pair_by_id, get_user_id, inse
     get_engagement_preferences, count_comments_today, get_recent_engagers, upsert_engager, \
     get_newsletter_settings, mark_newsletter_published, record_newsletter_subscriber_stat, \
     get_newsletter_edition, mark_edition_published, mark_edition_failed, \
-    upsert_user_group, get_enabled_group_ids, record_group_post, record_post_stats, \
+    upsert_user_group, get_enabled_group_ids, record_group_post, record_group_post_run, record_post_stats, \
     get_recent_posted_post_ids, get_uncaptured_posted_post_ids, \
     get_shipped_variant_keys, \
     get_lead_magnet_settings, has_received_lead_magnet, record_lead_magnet_sent, \
@@ -2429,24 +2429,36 @@ def auto_post_to_group(self, user_id: int, group_id: str, group_name: str = None
                 profile_synthesis=get_or_create_profile_synthesis(user_id, my_profile)) or "")
         if not text.strip():
             return "No group post generated"
+
+        def _unpostable(reason: str) -> str:
+            # The group loaded but its composer did not: members cannot post here (admin-only /
+            # announcement group). Stamp the RUN so the rotation moves past it — ordering on
+            # successful posts alone left such a group "least recently posted" forever, starving
+            # every other post-enabled group (issue #858). `last_posted_at` is untouched, so it
+            # stays the truthful record of what actually shipped.
+            record_group_post_run(user_id, group_id)
+            log_info(f"Group is not postable, rotating past it: {reason}", user_id=user_id,
+                     task_name="auto_post_to_group")
+            return reason
+
         # Open the group share box, type, and post (best-effort SDUI selectors).
         if click_first(driver, wait, [(By.XPATH,
                 "//button[contains(normalize-space(),'Start a post') or contains(normalize-space(),'Start a public post') "
                 "or contains(@aria-label,'Start a post') or contains(@aria-label,'Create a post') "
                 "or (contains(normalize-space(),'Start a') and contains(normalize-space(),'post'))]")],
                        "Group share box", required=False) is None:
-            return "Group share box not found"
+            return _unpostable("Group share box not found")
         time.sleep(random.uniform(2, 3))
         box = find_first(driver, wait, [(By.CSS_SELECTOR, "div[role='textbox']")], "Group post editor",
                          visible_only=True, required=False)
         if box is None:
-            return "Group post editor not found"
+            return _unpostable("Group post editor not found")
         box.click()
         box.send_keys(text)
         time.sleep(random.uniform(1, 2))
         if click_first(driver, wait, [(By.XPATH, "//button[normalize-space()='Post']")], "Group Post button",
                        required=False) is None:
-            return "Group Post button not found"
+            return _unpostable("Group Post button not found")
         time.sleep(random.uniform(3, 5))
         # Only a post that actually shipped advances the rotation — a failed run leaves this group
         # next in line rather than skipping its turn.

--- a/src/cqc_lem/ui/src/pages/account/GroupsCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/GroupsCard.tsx
@@ -102,7 +102,9 @@ export default function GroupsCard() {
         </p>
         <p>
           The weekly slot rotates: it goes to whichever group with <span className="font-semibold text-gray-700">Post</span>{' '}
-          on has gone longest without one.
+          on has waited longest for its turn. A group that turns out not to take member posts
+          (announcement or admin-only) uses up its turn and goes to the back of the queue, so it
+          never holds up the others.
         </p>
       </div>
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -5939,16 +5939,22 @@ def get_enabled_group_ids(user_id: int) -> list:
 
 def get_next_group_for_post(user_id: int) -> Optional[dict]:
     """The ONE place "which group does the next group post go to" is decided (issue #769): the
-    least-recently-posted group the user has opted into for POSTING. `post_enabled` is independent
+    least-recently-TRIED group the user has opted into for POSTING. `post_enabled` is independent
     of `enabled` (which only governs commenting), so a group can take posts without being commented
-    in and vice versa. Never posted there = sorts first. None when no group is opted in."""
+    in and vice versa. Never tried = sorts first. None when no group is opted in.
+
+    Ordering reads `last_post_run_at` (every run that reached the group), NOT `last_posted_at`
+    (successful posts only) — a group where members cannot post never stamps the latter, so ordering
+    on it left that group "next" every week forever and starved the rest (issue #858). The COALESCE
+    covers any row stamped before `last_post_run_at` existed."""
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
     try:
         cursor.execute(
             "SELECT group_id, group_name FROM user_groups "
             "WHERE user_id=%s AND post_enabled=1 "
-            "ORDER BY last_posted_at IS NULL DESC, last_posted_at ASC, group_name ASC LIMIT 1",
+            "ORDER BY COALESCE(last_post_run_at, last_posted_at) IS NULL DESC, "
+            "         COALESCE(last_post_run_at, last_posted_at) ASC, group_name ASC LIMIT 1",
             (user_id,))
         row = cursor.fetchone()
         return dict(row) if row else None
@@ -5961,16 +5967,39 @@ def get_next_group_for_post(user_id: int) -> Optional[dict]:
 
 
 def record_group_post(user_id: int, group_id: str) -> bool:
-    """Stamp a group as just-posted-in so the rotation moves on to the next one."""
+    """Stamp a group as just-posted-in so the rotation moves on to the next one. A successful post
+    is also a run, so both columns advance together."""
     connection = get_db_connection()
     cursor = connection.cursor()
     try:
-        cursor.execute("UPDATE user_groups SET last_posted_at=NOW() WHERE user_id=%s AND group_id=%s",
+        cursor.execute("UPDATE user_groups SET last_posted_at=NOW(), last_post_run_at=NOW() "
+                       "WHERE user_id=%s AND group_id=%s",
                        (user_id, str(group_id)))
         connection.commit()
         return True
     except mysql.connector.Error as err:
         myprint(f"Could not record group post for user {user_id} | Error: {err}")
+        return False
+    finally:
+        cursor.close()
+        connection.close()
+
+
+def record_group_post_run(user_id: int, group_id: str) -> bool:
+    """Stamp a group as just-TRIED (issue #858) — the rotation moves on, but `last_posted_at` is
+    left alone because nothing was published. Called only when the run reached the group and the
+    group itself turned out to be unpostable (no share box / editor / Post button — admin-only or
+    announcement groups). A run that never reached the group stamps neither column, so a transient
+    session failure still leaves that group next in line."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
+    try:
+        cursor.execute("UPDATE user_groups SET last_post_run_at=NOW() WHERE user_id=%s AND group_id=%s",
+                       (user_id, str(group_id)))
+        connection.commit()
+        return True
+    except mysql.connector.Error as err:
+        myprint(f"Could not record group post run for user {user_id} | Error: {err}")
         return False
     finally:
         cursor.close()

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -5999,7 +5999,12 @@ def record_group_post_run(user_id: int, group_id: str) -> bool:
         connection.commit()
         return True
     except mysql.connector.Error as err:
-        myprint(f"Could not record group post run for user {user_id} | Error: {err}")
+        # A lost stamp is exactly the starvation this function exists to prevent — the group stays
+        # least-recently-tried and is "next" again next week — and the caller has nothing to do
+        # about it, so it has to be visible on its own (ERROR, not the myprint shim: prod forwards
+        # WARNING and above to PostHog).
+        log_error("Could not record group post run", exc=err, user_id=user_id,
+                  task_name="record_group_post_run")
         return False
     finally:
         cursor.close()

--- a/tests/unit/app/test_groups.py
+++ b/tests/unit/app/test_groups.py
@@ -100,6 +100,19 @@ class TestUserGroupsDB:
             "last_post_run_at", "")
         assert cur.execute.call_args[0][1] == (1, "123")
 
+    def test_record_group_post_run_failure_is_visible(self):
+        """A lost stamp leaves the group least-recently-tried — i.e. it re-creates the starvation —
+        and the caller can do nothing with the False, so the failure has to log at ERROR."""
+        import mysql.connector
+        conn, cur = self._conn()
+        cur.execute.side_effect = mysql.connector.Error("connection gone")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.log_error") as logged:
+            from cqc_lem.utilities.db import record_group_post_run
+            assert record_group_post_run(1, "123") is False
+        logged.assert_called_once()
+        assert logged.call_args.kwargs["user_id"] == 1
+
 
 class TestSyncUserGroups:
     def test_upserts_enumerated(self):

--- a/tests/unit/app/test_groups.py
+++ b/tests/unit/app/test_groups.py
@@ -67,8 +67,10 @@ class TestUserGroupsDB:
         sql = cur.execute.call_args[0][0]
         # Posting is gated on post_enabled ALONE — a group can take posts without being commented in.
         assert "post_enabled=1" in sql and "enabled=1" not in sql.replace("post_enabled=1", "")
-        # Never-posted groups sort first, then oldest first.
-        assert "last_posted_at IS NULL DESC, last_posted_at ASC" in sql
+        # Never-TRIED groups sort first, then oldest first. Ordering is on the run column, not the
+        # success column — an unpostable group must not be "next" forever (issue #858).
+        assert "COALESCE(last_post_run_at, last_posted_at) IS NULL DESC" in sql
+        assert "COALESCE(last_post_run_at, last_posted_at) ASC" in sql
 
     def test_next_group_for_post_none_when_nothing_opted_in(self):
         conn, cur = self._conn()
@@ -78,11 +80,24 @@ class TestUserGroupsDB:
             assert get_next_group_for_post(1) is None
 
     def test_record_group_post_stamps_the_row(self):
+        """A successful post is also a run, so both columns advance."""
         conn, cur = self._conn()
         with patch(f"{_DB}.get_db_connection", return_value=conn):
             from cqc_lem.utilities.db import record_group_post
             assert record_group_post(1, "123") is True
-        assert "last_posted_at=NOW()" in cur.execute.call_args[0][0]
+        sql = cur.execute.call_args[0][0]
+        assert "last_posted_at=NOW()" in sql and "last_post_run_at=NOW()" in sql
+        assert cur.execute.call_args[0][1] == (1, "123")
+
+    def test_record_group_post_run_never_claims_a_post(self):
+        """Issue #858: a try advances the rotation without pretending anything shipped."""
+        conn, cur = self._conn()
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import record_group_post_run
+            assert record_group_post_run(1, "123") is True
+        sql = cur.execute.call_args[0][0]
+        assert "last_post_run_at=NOW()" in sql and "last_posted_at" not in sql.replace(
+            "last_post_run_at", "")
         assert cur.execute.call_args[0][1] == (1, "123")
 
 
@@ -131,23 +146,63 @@ class TestPostToGroup:
              patch(f"{_RA}.generate_group_post", return_value="A useful insight.") as gen, \
              patch(f"{_RA}.click_first", return_value=MagicMock()), \
              patch(f"{_RA}.find_first", return_value=MagicMock()), \
-             patch(f"{_RA}.record_group_post") as rec, patch(f"{_RA}.quit_gracefully"):
+             patch(f"{_RA}.record_group_post") as rec, \
+             patch(f"{_RA}.record_group_post_run") as run, patch(f"{_RA}.quit_gracefully"):
             result = auto_post_to_group.run(user_id=1, group_id="123", group_name="AI Leaders")
         assert result == "Posted to group"
         assert gen.call_args.kwargs["group_name"] == "AI Leaders"
         rec.assert_called_once_with(1, "123")
+        # record_group_post stamps both columns itself — the success path never double-stamps.
+        run.assert_not_called()
 
-    def test_failed_post_leaves_the_group_next_in_line(self):
+    @pytest.mark.parametrize("miss,expected", [
+        ("share_box", "Group share box not found"),
+        ("editor", "Group post editor not found"),
+        ("post_button", "Group Post button not found"),
+    ])
+    def test_unpostable_group_advances_the_rotation_without_claiming_a_post(self, miss, expected):
+        """Issue #858: a group whose composer never renders (admin-only / announcement) is stamped
+        as TRIED so it moves to the back of the queue — but `last_posted_at` stays untouched."""
         from cqc_lem.app.run_automation import auto_post_to_group
+        clicks = {"share_box": [None], "editor": [MagicMock()],
+                  "post_button": [MagicMock(), None]}[miss]
         with self._driver_patches(), \
              patch(f"{_RA}.get_engagement_preferences", return_value={}), \
              patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"), \
              patch(f"{_RA}.generate_group_post", return_value="A useful insight."), \
-             patch(f"{_RA}.click_first", return_value=None), \
-             patch(f"{_RA}.record_group_post") as rec, patch(f"{_RA}.quit_gracefully"):
+             patch(f"{_RA}.click_first", side_effect=clicks), \
+             patch(f"{_RA}.find_first", return_value=None if miss == "editor" else MagicMock()), \
+             patch(f"{_RA}.record_group_post") as rec, \
+             patch(f"{_RA}.record_group_post_run") as run, patch(f"{_RA}.quit_gracefully"):
             result = auto_post_to_group.run(user_id=1, group_id="123", group_name="AI Leaders")
-        assert result == "Group share box not found"
+        assert result == expected
+        run.assert_called_once_with(1, "123")
         rec.assert_not_called()
+
+    def test_failure_before_the_group_is_reached_does_not_advance_the_rotation(self):
+        """A dead session is transient and not the group's fault — it keeps its turn."""
+        from cqc_lem.app.run_automation import auto_post_to_group
+        with patch(f"{_RA}.get_current_profile", side_effect=Exception("no session")), \
+             patch(f"{_RA}.record_group_post") as rec, \
+             patch(f"{_RA}.record_group_post_run") as run:
+            result = auto_post_to_group.run(user_id=1, group_id="123", group_name="AI Leaders")
+        assert "Failed" in result
+        rec.assert_not_called()
+        run.assert_not_called()
+
+    def test_empty_generation_does_not_advance_the_rotation(self):
+        """Nothing to say this week is a transient LLM outcome, not an unpostable group."""
+        from cqc_lem.app.run_automation import auto_post_to_group
+        with self._driver_patches(), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_or_create_profile_synthesis", return_value="synth"), \
+             patch(f"{_RA}.generate_group_post", return_value="   "), \
+             patch(f"{_RA}.record_group_post") as rec, \
+             patch(f"{_RA}.record_group_post_run") as run, patch(f"{_RA}.quit_gracefully"):
+            result = auto_post_to_group.run(user_id=1, group_id="123", group_name="AI Leaders")
+        assert result == "No group post generated"
+        rec.assert_not_called()
+        run.assert_not_called()
 
 
 class TestGroupDispatchers:

--- a/tests/unit/utilities/test_db_coverage_errors.py
+++ b/tests/unit/utilities/test_db_coverage_errors.py
@@ -92,6 +92,7 @@ _ERROR_CASES = [
     ("set_groups_enabled", (1, {"g1": True}), False),
     ("get_next_group_for_post", (1,), None),
     ("record_group_post", (1, "g1"), False),
+    ("record_group_post_run", (1, "g1"), False),
     ("record_post_stats", (1, 2, 3, 4), False),
     ("get_recent_posted_post_ids", (1,), []),
     ("get_post_engagement_rows", (1,), []),


### PR DESCRIPTION
## What & why

#769 made the weekly group post rotate on `user_groups.last_posted_at`, stamped **only after a post actually shipped** — deliberately, so a transient failure leaves the group next in line instead of skipping its turn.

That is right for a transient failure and wrong for a permanent one. A group whose members cannot post (admin-only / announcement) renders no share box, so `auto_post_to_group` returns `"Group share box not found"` every time, `last_posted_at` stays NULL, NULL sorts FIRST — and that group is "next" **every week forever**. Group sync opts joined groups into posting by default, so one such group starves every other post-enabled group and the Groups card keeps naming it as next.

## The change

Split "we tried here" from "we posted here":

- **Migration** `V20260801065636__add_user_group_last_post_run_at.sql` — additive `last_post_run_at DATETIME NULL`, backfilled from `last_posted_at` so existing rows keep their place in the rotation (without the backfill every user's rotation would restart at the alphabetically first group).
- **`get_next_group_for_post`** orders on `COALESCE(last_post_run_at, last_posted_at)` instead of `last_posted_at`. An unpostable group moves to the back of the queue and is retried only after every other post-enabled group.
- **`record_group_post`** stamps both columns (a successful post is also a run); new **`record_group_post_run`** stamps only the run column.
- **`auto_post_to_group`** calls `record_group_post_run` on the three *structural* misses (share box / editor / Post button not found) — the group loaded but its composer did not — and logs one INFO line. Everything else is unchanged: a failure before the group is reached (no session / profile error), an empty generation, or an unexpected exception stamps **neither** column, so the group keeps its turn.

`last_posted_at` keeps its exact meaning, so `GET /user/groups` and the Groups card stay truthful about what actually shipped.

## Testing

`tests/unit/app/test_groups.py`:
- ordering asserts the run column, not the success column;
- `record_group_post` stamps both, `record_group_post_run` never touches `last_posted_at`;
- parametrized over all three structural misses: run stamped, post not;
- session failure before the group is reached: neither stamped;
- empty generation: neither stamped.

`tests/unit/utilities/test_db_coverage_errors.py` covers the new function's mysql-error fallback.

```
pytest tests/unit/app/test_groups.py tests/unit/utilities/test_db_coverage_errors.py \
       tests/unit/utilities/test_db_coverage_avatar_groups.py tests/unit/api/test_api_coverage_misc.py
275 passed
```

Closes #858

🤖 Generated with [Claude Code](https://claude.com/claude-code)
