### PR TITLE
fix(errors): stop the optional reaction fly-out miss escalating as a defect (closes #873)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -975,8 +975,13 @@ def react_to_post_inline(driver, wait, card, post_content: str = None, comment_t
                 time.sleep(random.uniform(0.6, 1.2))
             except Exception:
                 pass
+        # The fly-out opener is optional: with a `trigger` in hand its absence just means we take the
+        # documented default-Like fallback below, which is working behaviour — warning about it every
+        # card escalated into a filed defect (issue #873). With no trigger there is no fallback, so
+        # the card's reaction controls really are unreadable and the miss is worth the signal.
         opened = click_first(driver, wait, [(By.CSS_SELECTOR, "button[aria-label='Open reactions menu']")],
-                             "Open reactions menu", parent_element=card, required=False, user_id=user_id)
+                             "Open reactions menu", parent_element=card, required=False,
+                             warn_on_miss=trigger is None, user_id=user_id)
         time.sleep(random.uniform(0.8, 1.6))
         # The fly-out can render just outside the card subtree, so match the reaction button globally
         # (only one menu is open at a time and click_first filters to visible elements).

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -50,9 +50,11 @@ Two things follow for anyone writing a call site here:
    Same idea for empty-result chatter: `db.get_ready_to_post_posts` logs INFO only when the list is
    non-empty, DEBUG otherwise. For Selenium, `find_first(..., required=False, warn_on_miss=False)`
    logs the miss at DEBUG — use it when the element is legitimately absent on some surfaces
-   (`_switch_feed_to_recent`'s 'Sort by' control does not exist on a group feed). Decide it PER
-   SURFACE, not once for the call site: the same lookup on the home feed, where the control does
-   exist, is selector rot and must still warn.
+   (`_switch_feed_to_recent`'s 'Sort by' control does not exist on a group feed). `click_first`
+   carries the same flag. Decide it PER SURFACE, not once for the call site: the same lookup on the
+   home feed, where the control does exist, is selector rot and must still warn. The other half of
+   the test is whether a FALLBACK is in hand — `react_to_post_inline` warns on a missing
+   'Open reactions menu' only when it found no React toggle to default-Like instead (issue #873).
 2. **Keep the message a stable template.** The dedup key masks volatile tokens (URLs, emails, UUIDs,
    URNs, hex, `[...]`, quoted strings, numbers) and combines them with the call site, so
    `Selector miss: Feed sort control` and `Selector miss: Reaction state` stay two distinct problems

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -51,7 +51,9 @@ Two things follow for anyone writing a call site here:
    non-empty, DEBUG otherwise. For Selenium, `find_first(..., required=False, warn_on_miss=False)`
    logs the miss at DEBUG — use it when the element is legitimately absent on some surfaces
    (`_switch_feed_to_recent`'s 'Sort by' control does not exist on a group feed). `click_first`
-   carries the same flag. Decide it PER SURFACE, not once for the call site: the same lookup on the
+   carries the same flag across BOTH of its miss paths — `Selector miss:` (never found) and
+   `Click miss:` (found, then un-clickable), which return None identically. Decide it PER SURFACE,
+   not once for the call site: the same lookup on the
    home feed, where the control does exist, is selector rot and must still warn. The other half of
    the test is whether a FALLBACK is in hand — `react_to_post_inline` warns on a missing
    'Open reactions menu' only when it found no React toggle to default-Like instead (issue #873).

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -618,12 +618,14 @@ def find_first(driver: WebDriver, wait: WebDriverWait, locators: list[tuple[str,
 def click_first(driver: WebDriver, wait: WebDriverWait, locators: list[tuple[str, str]], label: str,
                 *, required: bool = True, parent_element: WebElement = None,
                 use_action_chain: bool = False, max_try: int = MAX_WAIT_RETRY,
+                warn_on_miss: bool = True,
                 user_id: int = None, post_id: int = None) -> WebElement | None:
     """Find (via `find_first`) then click the first matching element, with the same resilient
-    fallback + structured-miss-logging behavior. Returns the clicked element or None."""
+    fallback + structured-miss-logging behavior — including `warn_on_miss`, so a control the caller
+    already has a working fallback for logs its miss at DEBUG. Returns the clicked element or None."""
     element = find_first(driver, wait, locators, label, required=required,
                          parent_element=parent_element, max_try=max_try, visible_only=True,
-                         user_id=user_id, post_id=post_id)
+                         warn_on_miss=warn_on_miss, user_id=user_id, post_id=post_id)
     if element is None:
         return None
     try:

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -622,7 +622,8 @@ def click_first(driver: WebDriver, wait: WebDriverWait, locators: list[tuple[str
                 user_id: int = None, post_id: int = None) -> WebElement | None:
     """Find (via `find_first`) then click the first matching element, with the same resilient
     fallback + structured-miss-logging behavior — including `warn_on_miss`, so a control the caller
-    already has a working fallback for logs its miss at DEBUG. Returns the clicked element or None."""
+    already has a working fallback for logs BOTH of its miss paths (not found, and found but not
+    clickable) at DEBUG. Returns the clicked element or None."""
     element = find_first(driver, wait, locators, label, required=required,
                          parent_element=parent_element, max_try=max_try, visible_only=True,
                          warn_on_miss=warn_on_miss, user_id=user_id, post_id=post_id)
@@ -638,7 +639,11 @@ def click_first(driver: WebDriver, wait: WebDriverWait, locators: list[tuple[str
     except (ElementNotInteractableException, StaleElementReferenceException, TimeoutException) as se:
         if required:
             raise se
-        log_warning(f"Click miss: {label}", action_type="scrape", user_id=user_id, post_id=post_id)
+        # A hover-revealed control can go un-clickable between the find and the click, which returns
+        # None exactly like a selector miss does — so the caller's fallback is the same one. Warning
+        # here regardless of warn_on_miss would re-open the escalation the flag was added to close.
+        emit = log_warning if warn_on_miss else log_debug
+        emit(f"Click miss: {label}", action_type="scrape", user_id=user_id, post_id=post_id)
         return None
     return element
 

--- a/tests/unit/app/test_comment_inline.py
+++ b/tests/unit/app/test_comment_inline.py
@@ -236,6 +236,30 @@ class TestReactToPostInline:
             ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
         assert ok is False  # fly-out never opened and the default-Like fallback didn't register
 
+    def test_missing_menu_is_not_a_warning_when_a_fallback_toggle_exists(self):
+        """The fly-out opener is optional — with a React toggle in hand its absence just takes the
+        default-Like fallback, which is working behaviour. Warning per card escalated it to ERROR
+        and filed a PostHog defect (issue #873)."""
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
+             patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.find_first", return_value=_state("Reaction button state: no reaction")), \
+             patch(f"{_RA}.click_first", return_value=None) as cf:
+            ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
+        assert cf.call_args_list[0].kwargs["warn_on_miss"] is False
+
+    def test_missing_menu_still_warns_when_there_is_no_fallback(self):
+        """No Reaction-state button and no React toggle means the card's reaction controls are
+        genuinely unreadable — silencing that would hide real SDUI rot."""
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
+             patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.find_first", return_value=None), \
+             patch(f"{_RA}.click_first", return_value=None) as cf:
+            ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
+        assert ok is False
+        assert cf.call_args_list[0].kwargs["warn_on_miss"] is True
+
     def test_clicks_the_ai_chosen_reaction(self):
         from cqc_lem.app import run_automation as ra
         seen = []

--- a/tests/unit/utilities/test_selenium_find_first.py
+++ b/tests/unit/utilities/test_selenium_find_first.py
@@ -148,3 +148,31 @@ class TestClickFirst:
             su.click_first(driver, wait, [("css", "btn")], "Open reactions menu",
                            required=False, max_try=1)
         warn.assert_called_once()
+
+    def test_click_miss_also_honours_warn_on_miss(self):
+        """A hover-revealed control found-then-un-clickable returns None just like a selector miss,
+        so the caller takes the same fallback. Warning here anyway would keep escalating the very
+        recurrence warn_on_miss was added to close (issue #873)."""
+        from cqc_lem.utilities import selenium_util as su
+        el = MagicMock(); el.is_displayed.return_value = True
+        driver = _driver_with({"btn": [el]})
+        wait = _FakeWait(driver)
+        with patch.object(su.EC, "element_to_be_clickable", return_value=lambda d: False), \
+             patch(f"{_MOD}.log_warning") as warn, patch(f"{_MOD}.log_debug") as debug:
+            out = su.click_first(driver, wait, [("css", "btn")], "Open reactions menu",
+                                 required=False, warn_on_miss=False, max_try=1, user_id=4)
+        assert out is None
+        warn.assert_not_called()
+        assert debug.call_args.args[0] == "Click miss: Open reactions menu"
+
+    def test_click_miss_warns_by_default(self):
+        from cqc_lem.utilities import selenium_util as su
+        el = MagicMock(); el.is_displayed.return_value = True
+        driver = _driver_with({"btn": [el]})
+        wait = _FakeWait(driver)
+        with patch.object(su.EC, "element_to_be_clickable", return_value=lambda d: False), \
+             patch(f"{_MOD}.log_warning") as warn:
+            out = su.click_first(driver, wait, [("css", "btn")], "Open reactions menu",
+                                 required=False, max_try=1)
+        assert out is None
+        assert warn.call_args.args[0] == "Click miss: Open reactions menu"

--- a/tests/unit/utilities/test_selenium_find_first.py
+++ b/tests/unit/utilities/test_selenium_find_first.py
@@ -125,3 +125,26 @@ class TestClickFirst:
             out = su.click_first(driver, wait, [("css", "btn")], "button")
         el.click.assert_called_once()
         assert out is el
+
+    def test_carries_warn_on_miss_into_find_first(self):
+        """click_first is the only way most call sites reach find_first — without the passthrough a
+        caller with a working fallback (issue #873) has no way to keep its miss out of escalation."""
+        from cqc_lem.utilities import selenium_util as su
+        driver = _driver_with({})
+        wait = _FakeWait(driver)
+        with patch(f"{_MOD}.log_warning") as warn, patch(f"{_MOD}.log_debug") as debug:
+            out = su.click_first(driver, wait, [("css", "btn")], "Open reactions menu",
+                                 required=False, warn_on_miss=False, max_try=1, user_id=4)
+        assert out is None
+        warn.assert_not_called()
+        debug.assert_called_once()
+        assert debug.call_args.args[0] == "Selector miss: Open reactions menu"
+
+    def test_warns_on_miss_by_default(self):
+        from cqc_lem.utilities import selenium_util as su
+        driver = _driver_with({})
+        wait = _FakeWait(driver)
+        with patch(f"{_MOD}.log_warning") as warn:
+            su.click_first(driver, wait, [("css", "btn")], "Open reactions menu",
+                           required=False, max_try=1)
+        warn.assert_called_once()


### PR DESCRIPTION
## What

`react_to_post_inline` looks for the hover-revealed `button[aria-label='Open reactions menu']` on each feed card. When it is absent the function already degrades exactly as documented — it clicks the primary React toggle directly and leaves a default Like ("Better a Like than no reaction").

But the lookup ran through `click_first(..., required=False)`, which emits `Selector miss: Open reactions menu` at **WARNING**. Repeated across the cards of an `auto_comment_in_groups` run, the recurrence rule in `log_escalation.py` re-emitted it at ERROR, captured a grouped `$exception`, and the daily error→issue cron filed #873 — a defect report for a path doing precisely what it was designed to do.

## Why this shape

The miss is only a signal when there is **nothing to fall back to**:

- `click_first` now carries `find_first`'s `warn_on_miss` through (it was added in #872 but only reachable via `find_first`, and most call sites go through `click_first`).
- The opener lookup passes `warn_on_miss=trigger is None`. With a Reaction-state button or React toggle in hand, the fly-out is optional and its miss logs at DEBUG. With neither, the card's reaction controls are genuinely unreadable — that still warns and still escalates, so real SDUI rot is not silenced.

This follows the same posture as #872 (`Selector miss: Feed sort control`) and the `src/cqc_lem/utilities/CLAUDE.md` rule "do not warn on an expected no-op", which is extended here with the fallback half of the test.

## Testing

- `tests/unit/utilities/test_selenium_find_first.py` — `click_first` passes `warn_on_miss` down to `find_first` (DEBUG, not WARNING) and still warns by default.
- `tests/unit/app/test_comment_inline.py` — the opener miss is `warn_on_miss=False` when a fallback toggle exists, and `warn_on_miss=True` when `find_first` returns nothing at all (and the call still returns `False`).
- Full suite green locally: `8913 passed`.

Closes #873

🤖 Generated with [Claude Code](https://claude.com/claude-code)