### PR TITLE
fix(errors): stop the un-reacted card's Reaction-state miss escalating as a defect (closes #874)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -967,8 +967,10 @@ def react_to_post_inline(driver, wait, card, post_content: str = None, comment_t
         # It is quieted (issue #874) because it is a DUPLICATE symptom of that one rot — the
         # `trigger` lookup below is this read's fallback, so the attempt still proceeds — and one
         # condition gets ONE warning: the fly-out opener's miss below is the signal that stands for
-        # "this card's reaction controls are unreadable". Keep that one un-quieted while #816 is
-        # open; re-grounding these three anchors is #816's job, not another log-level change.
+        # "this card's reaction controls are unreadable" — but it warns only when no React toggle was
+        # found, so on a rotted card that still exposes a toggle this whole path is already silent
+        # and reports success. Keep the opener un-quieted while #816 is open; re-grounding these
+        # three anchors (and closing that silent path) is #816's job, not another log-level change.
         state = find_first(driver, wait, [(By.CSS_SELECTOR, "button[aria-label^='Reaction button state']")],
                            "Reaction state", parent_element=card, required=False, visible_only=True,
                            warn_on_miss=False, user_id=user_id)

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -962,8 +962,16 @@ def react_to_post_inline(driver, wait, card, post_content: str = None, comment_t
     call scoped to the post + our comment, which self-falls-back to random. Returns True only if a
     reaction registered (the toggle no longer reads 'no reaction')."""
     try:
+        # A miss here is NOT a healthy un-reacted card: #816 records this read and the post-click
+        # re-read below missing at near 1:1 (17 vs 16 in 48h), i.e. the anchor itself has rotted.
+        # It is quieted (issue #874) because it is a DUPLICATE symptom of that one rot — the
+        # `trigger` lookup below is this read's fallback, so the attempt still proceeds — and one
+        # condition gets ONE warning: the fly-out opener's miss below is the signal that stands for
+        # "this card's reaction controls are unreadable". Keep that one un-quieted while #816 is
+        # open; re-grounding these three anchors is #816's job, not another log-level change.
         state = find_first(driver, wait, [(By.CSS_SELECTOR, "button[aria-label^='Reaction button state']")],
-                           "Reaction state", parent_element=card, required=False, visible_only=True, user_id=user_id)
+                           "Reaction state", parent_element=card, required=False, visible_only=True,
+                           warn_on_miss=False, user_id=user_id)
         if state is not None and "no reaction" not in (state.get_attribute("aria-label") or "").lower():
             return None  # already reacted on this post — a no-op, not a failure
 

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -67,9 +67,18 @@ Two things follow for anyone writing a call site here:
    `Could not leave a reaction on post` restated a failure that had already warned where it
    happened, so it is DEBUG (issue #878) and the one path the selector misses did NOT cover — the
    click the toggle never registered — warns once, inside the function that detects it. **Warn
-   where you detect, not where you notice.** ONE unreadable card still warns twice, because the
-   pre-click 'Reaction state' read warns too (issue #874, open); collapse that into the opener's
-   signal as well, and never add a fourth.
+   where you detect, not where you notice.** The pre-click 'Reaction state' read collapses the same
+   way (issue #874). Note WHY, because the wrong reason is easy to write down: that anchor is not
+   optional-and-healthy, it is **rotted** — in production it misses at the same rate as the
+   post-click read, both symptoms of the reaction selector drift tracked on **#816**. **Quieting a
+   miss claims it is not a DISTINCT actionable defect; it never claims the DOM is fine.** So when
+   you collapse a cluster, cite the tracking issue at the call site and leave the fault's surviving
+   warnings alone — silence those too and an open outage has no signal at all. The cluster is now
+   fully collapsed, so know how thin what remains is: nothing warns at all on a card whose state
+   anchor rotted while a React toggle is still readable — the opener's miss is quiet because that
+   toggle IS the fallback, the post-click re-read is quiet because there was no pre-click state to
+   re-read, and the run reports success. Closing that gap is #816's job — re-ground the anchors,
+   never another log-level change, and never add a fourth warning.
 2. **Keep the message a stable template.** The dedup key masks volatile tokens (URLs, emails, UUIDs,
    URNs, hex, `[...]`, quoted strings, numbers) and combines them with the call site, so
    `Selector miss: Feed sort control` and `Selector miss: Reaction state` stay two distinct problems

--- a/tests/unit/app/test_comment_inline.py
+++ b/tests/unit/app/test_comment_inline.py
@@ -393,8 +393,10 @@ class TestReactToPostInline:
     def test_pre_click_reaction_state_miss_is_not_a_warning(self):
         """The pre-click read misses at the same rate as the post-click one (#816: 17 vs 16 in 48h),
         so it is a duplicate symptom of that rot, not a healthy card — and the React-toggle lookup is
-        its fallback. One condition, one warning: quieted here (issue #874), still signalled by the
-        fly-out opener's miss, which the next assertion pins."""
+        its fallback. One condition, one warning: quieted here (issue #874), still signalled — when
+        there is no React toggle to fall back to, as here — by the fly-out opener's miss, which the
+        next assertion pins. With a toggle in hand the path is silent by design; that gap belongs to
+        #816, not to another log-level change."""
         from cqc_lem.app import run_automation as ra
         with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
              patch(f"{_RA}.wait_for_ajax"), \
@@ -404,7 +406,8 @@ class TestReactToPostInline:
         pre = [c for c in ff.call_args_list if c.args[3] == "Reaction state"]
         assert len(pre) == 1
         assert pre[0].kwargs["warn_on_miss"] is False
-        # The reaction cluster keeps exactly ONE un-quieted signal while #816 is open — this one.
+        # With no React toggle found, the cluster keeps exactly ONE un-quieted signal while #816 is
+        # open — this one. It must not be collapsed away by the next issue in the cluster.
         assert cf.call_args_list[0].args[3] == "Open reactions menu"
         assert cf.call_args_list[0].kwargs["warn_on_miss"] is True
 

--- a/tests/unit/app/test_comment_inline.py
+++ b/tests/unit/app/test_comment_inline.py
@@ -390,6 +390,33 @@ class TestReactToPostInline:
         assert confirm[0].kwargs["warn_on_miss"] is True
         assert confirm[0].kwargs["max_try"] == MAX_WAIT_RETRY
 
+    def test_pre_click_reaction_state_miss_is_not_a_warning(self):
+        """The pre-click read misses at the same rate as the post-click one (#816: 17 vs 16 in 48h),
+        so it is a duplicate symptom of that rot, not a healthy card — and the React-toggle lookup is
+        its fallback. One condition, one warning: quieted here (issue #874), still signalled by the
+        fly-out opener's miss, which the next assertion pins."""
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
+             patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.find_first", return_value=None) as ff, \
+             patch(f"{_RA}.click_first", return_value=None) as cf:
+            ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
+        pre = [c for c in ff.call_args_list if c.args[3] == "Reaction state"]
+        assert len(pre) == 1
+        assert pre[0].kwargs["warn_on_miss"] is False
+        # The reaction cluster keeps exactly ONE un-quieted signal while #816 is open — this one.
+        assert cf.call_args_list[0].args[3] == "Open reactions menu"
+        assert cf.call_args_list[0].kwargs["warn_on_miss"] is True
+
+    def test_reaction_state_reads_stay_distinct_dedup_keys(self):
+        # The two reads share a selector but not a verdict (#875 keeps the post-click one warning
+        # whenever the card HAD the button), so their miss messages must not collapse into one
+        # escalation issue — quieting the pre-click read would otherwise quiet both.
+        from cqc_lem.utilities.log_escalation import normalize_message
+        keys = {normalize_message(f"Selector miss: {label}")[1]
+                for label in ("Reaction state", "Reaction state (post-click)")}
+        assert len(keys) == 2
+
     def test_clicks_the_ai_chosen_reaction(self):
         from cqc_lem.app import run_automation as ra
         seen = []


### PR DESCRIPTION
## What

`react_to_post_inline` reads the feed card's `button[aria-label^='Reaction button state']` to skip posts we already reacted to. That pre-click read ran with `required=False` and the default `warn_on_miss=True`, so its miss emitted `Selector miss: Reaction state` at WARNING; repeated across an `auto_comment_in_groups` run it re-emitted at ERROR via `log_escalation` and filed a PostHog `RecurringWarning` issue every day.

**Rationale corrected after review (`1A`).** The first version of this PR claimed LinkedIn only renders that button once a reaction is on the post, so the miss was an ordinary un-reacted card. That is wrong: #816 records this read and the post-click re-read missing at **near 1:1** (17 vs 16 in 48h), so the anchor is absent either way — it has **rotted** — and the function's own already-reacted branch tests for the label `no reaction`, which only makes sense if the button renders *before* we react.

The downgrade still stands, on the true reason: this read is a **duplicate symptom of the one rot #816 tracks**, and the `React toggle` lookup below it is its fallback, so the reaction attempt proceeds regardless. It is the same collapse #873 / #875 / #877 already made for the fly-out opener, the post-click confirm and the React toggle — **one condition gets ONE warning**.

## The change

- `src/cqc_lem/app/run_automation.py` — pre-click state read passes `warn_on_miss=False`; the comment says it is rot, cites **#816**, and names the warning that must stay.
- The reaction cluster's surviving signal is the **fly-out opener** miss (`warn_on_miss=trigger is None`, #873) — a test now pins it *beside* this downgrade, so the cluster cannot be quieted to zero one issue at a time while reactions are still broken.
- `src/cqc_lem/utilities/CLAUDE.md` — records the generalisable rule instead of the wrong anecdote: **quieting a miss claims it is not a DISTINCT actionable defect, never that the DOM is healthy** — cite the tracking issue at the call site and leave the fault's surviving warnings alone. Merged with the #878 paragraph that landed on `main` (see below) and states plainly how thin the cluster's remaining signal is now that it is fully collapsed.

No behaviour change beyond log level.

## Rebased onto current main (2026-08-01, second pass)

Three siblings merged while this PR was parked, so it was rebased onto each of them rather than reasserting its own version:

- **#882 (closes #875)** and **#890 (closes #877)** — the post-click confirm now warns only when the card *had* the button pre-click (`expected = state is not None`), and the React-toggle miss is already DEBUG. The superseded "post-click stays the canary" test was dropped; the dedup-key test is kept (the two labels must not collapse into one escalation issue).
- **#892 (closes #878)** — merged on `main` after this PR was written, so the caller's `Could not leave a reaction on post` is already DEBUG and `react_to_post_inline` now owns a `Reaction did not register after clicking` warning. Only `src/cqc_lem/utilities/CLAUDE.md` conflicted; both paragraphs were **integrated**, not chosen between — "warn where you detect, not where you notice" (#878) now leads into this PR's #874 collapse and the #816 grounding.

Code and tests auto-merged; `react_to_post_inline` still warns exactly where #892 left it.

## What is left loud, restated honestly

With #874 collapsed the reaction cluster is **fully collapsed**, so the earlier claim that `Could not leave a reaction on post` "stays loud until #816 lands" is no longer true and has been removed from the doc. What CLAUDE.md now records instead is the real residual risk: a card whose state anchor rotted while a React toggle is still readable warns **nothing at all** — the opener's miss is quiet because the toggle is the fallback, the post-click re-read is quiet because there was no pre-click state to re-read, and the run reports success. That silent path is **#816**'s to close by re-grounding the anchors — never another log-level change, and never a fourth warning.

## Siblings (`2A`)

- **#875, #877** — closed by #882 / #890; commented there linking **#816** so the record shows they were collapsed under a still-open outage, not fixed.
- **#878** — was marked a duplicate of #816 and taken off the agent queue; the owner subsequently shipped **#892** for it, which is now on `main` and is rebased into this branch above. No action left here.

## Testing

`tests/unit/app/test_comment_inline.py` (+2 tests): pre-click read passes `warn_on_miss=False` **and** the opener still warns when there is no fallback; the two Reaction-state labels normalize to distinct escalation dedup keys. #892's reaction tests on the same file pass unchanged after the rebase.

```
tests/unit/app/test_comment_inline.py tests/unit/app/test_feed_sort.py
tests/unit/utilities/test_selenium_find_first.py tests/unit/utilities/test_log_escalation.py  91 passed
```

Closes #874
Refs #816

🤖 Generated with [Claude Code](https://claude.com/claude-code)
