### PR TITLE
fix(errors): stop the post-click reaction-state miss escalating as a defect (closes #875)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -996,11 +996,17 @@ def react_to_post_inline(driver, wait, card, post_content: str = None, comment_t
             driver.execute_script("arguments[0].click();", trigger)
         time.sleep(random.uniform(0.8, 1.5))
         wait_for_ajax(driver)
+        # Best-effort confirm: label flips away from 'no reaction'. If the toggle can't be re-read,
+        # trust the click rather than false-negative — so the miss only means something when the
+        # card HAD a readable Reaction-state button before the click. Cards that never exposed one
+        # (the fly-out/React-toggle path) take the documented trust-the-click fallback, and warning
+        # about that on every card escalated to ERROR and filed a defect for working behaviour
+        # (issue #875). A control this card never carried is also not worth waiting out twice.
+        expected = state is not None
         after = find_first(driver, wait, [(By.CSS_SELECTOR, "button[aria-label^='Reaction button state']")],
                            "Reaction state (post-click)", parent_element=card, required=False,
-                           visible_only=True, user_id=user_id)
-        # Best-effort confirm: label flips away from 'no reaction'. If the toggle can't be re-read,
-        # trust the click rather than false-negative.
+                           visible_only=True, warn_on_miss=expected,
+                           max_try=MAX_WAIT_RETRY if expected else 1, user_id=user_id)
         if after is not None and "no reaction" in (after.get_attribute("aria-label") or "").lower():
             return False
         myprint(f"Reacted '{reaction}' on post")

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -56,7 +56,10 @@ Two things follow for anyone writing a call site here:
    not once for the call site: the same lookup on the
    home feed, where the control does exist, is selector rot and must still warn. The other half of
    the test is whether a FALLBACK is in hand — `react_to_post_inline` warns on a missing
-   'Open reactions menu' only when it found no React toggle to default-Like instead (issue #873).
+   'Open reactions menu' only when it found no React toggle to default-Like instead (issue #873),
+   and on a missing post-click 'Reaction state' only when the pre-click read found that toggle: a
+   card that never carried one has nothing to re-read, so the miss IS the documented
+   trust-the-click fallback (issue #875).
 2. **Keep the message a stable template.** The dedup key masks volatile tokens (URLs, emails, UUIDs,
    URNs, hex, `[...]`, quoted strings, numbers) and combines them with the call site, so
    `Selector miss: Feed sort control` and `Selector miss: Reaction state` stay two distinct problems

--- a/tests/unit/app/test_comment_inline.py
+++ b/tests/unit/app/test_comment_inline.py
@@ -3,6 +3,8 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+from cqc_lem.utilities.env_constants import MAX_WAIT_RETRY
+
 pytestmark = pytest.mark.unit
 
 _RA = "cqc_lem.app.run_automation"
@@ -259,6 +261,36 @@ class TestReactToPostInline:
             ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
         assert ok is False
         assert cf.call_args_list[0].kwargs["warn_on_miss"] is True
+
+    def test_post_click_confirm_is_not_a_warning_when_the_card_never_had_the_toggle(self):
+        """With no Reaction-state button before the click there is nothing to re-read after it, so
+        the miss is the documented trust-the-click fallback. Warning per card escalated it to ERROR
+        and filed a PostHog defect for working behaviour (issue #875)."""
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
+             patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.find_first", return_value=None) as ff, \
+             patch(f"{_RA}.click_first", return_value=MagicMock()):
+            ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
+        assert ok is True  # unreadable toggle never false-negatives a click that landed
+        confirm = [c for c in ff.call_args_list if c.args[3] == "Reaction state (post-click)"]
+        assert len(confirm) == 1
+        assert confirm[0].kwargs["warn_on_miss"] is False
+        assert confirm[0].kwargs["max_try"] == 1  # no retry sleep for a control this card lacks
+
+    def test_post_click_confirm_still_warns_when_the_toggle_was_readable_before(self):
+        """It was there before the click and isn't after — that IS selector rot, keep the signal."""
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
+             patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.find_first",
+                   side_effect=[_state("Reaction button state: no reaction"), None]) as ff, \
+             patch(f"{_RA}.click_first", return_value=MagicMock()):
+            ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
+        assert ok is True
+        confirm = [c for c in ff.call_args_list if c.args[3] == "Reaction state (post-click)"]
+        assert confirm[0].kwargs["warn_on_miss"] is True
+        assert confirm[0].kwargs["max_try"] == MAX_WAIT_RETRY
 
     def test_clicks_the_ai_chosen_reaction(self):
         from cqc_lem.app import run_automation as ra


### PR DESCRIPTION
## What & why

PostHog filed `RecurringWarning: Selector miss: Reaction state (post-click)` (1 actor,
`auto_comment_in_groups`) — the third of the same family after #872 and #873: a WARNING on a
Selenium miss that the code already handles as a documented fallback, repeated per feed card until
`log_escalation` re-emitted it at ERROR and turned working behaviour into a defect.

`react_to_post_inline` re-reads the card's `Reaction button state` toggle after clicking, purely as
a best-effort confirm — its stated contract is *"If the toggle can't be re-read, trust the click
rather than false-negative."* But the lookup used the default `warn_on_miss=True`, so every card
that goes through the React-toggle / fly-out path (i.e. never exposed a Reaction-state button in the
first place) warned about not finding one afterwards.

The miss only carries information when there was something to re-read:

- **pre-click read found the toggle** → it was readable before the click and isn't after. That is
  real SDUI rot — still WARNING, still escalates.
- **pre-click read found nothing** → the miss *is* the trust-the-click fallback. Logged at DEBUG,
  and `max_try=1` so we stop paying `WAIT_DEFAULT_TIMEOUT` twice plus a 5s retry sleep, per card,
  for a control that surface doesn't render.

Return values are unchanged: an unreadable toggle still never false-negatives a reaction that
landed. Scoped to this one lookup — the pre-click `Reaction state` read is a different fingerprint
and is left warning, so the SDUI-drift signal is fully retained (it is tracked separately as #874,
alongside #877 `React toggle` and #878 `Could not leave a reaction on post`; the family root cause
is #816).

## Testing

- `tests/unit/app/test_comment_inline.py`: two new cases — the post-click confirm passes
  `warn_on_miss=False` + `max_try=1` when the card never had the toggle (and still returns `True`),
  and keeps `warn_on_miss=True` + `MAX_WAIT_RETRY` when the pre-click read found it.
- `poetry run pytest tests/unit/app -q` → 1786 passed.

Closes #875

🤖 Generated with [Claude Code](https://claude.com/claude-code)

