### PR TITLE
fix(engagement): hard-filter the #478 reply composer so the post's main comment box can never win (closes #886)

### DIFF
--- a/docs/sdui-selenium-notes.md
+++ b/docs/sdui-selenium-notes.md
@@ -24,6 +24,25 @@ by the nav's `<svg>`: `ElementClickInterceptedException ... at point (x, 9)` (is
 still-mounted composer, which is the real y=9 source AND a comment landing on the wrong post.
 There is no fallback: no composer on this card = skip it (issue #876).
 
+## A reply composer is resolved ONE way, for both reply paths
+
+`_reply_composer_for_comment()` is the only thing that decides which `div[role='textbox']` a reply
+is typed into — `_reply_to_comment_inline` (a comment on a feed card, #883) and
+`_reply_under_comment_inline` (a reply under our own comment on someone else's post, #478/#886)
+both call it. Order: a box nested in the comment's own subtree wins; otherwise the visible box
+nearest the comment's bottom edge, with a box starting ABOVE the comment rejected **outright** and
+a box that resolves to a DIFFERENT comment rejected too. No box of ours = skip.
+
+The above-filter has to be a rejection, not a penalty. #478's original pick only scored an
+above-composer `+1e6`, so the post's main "Add a comment" box still won whenever it was the only
+visible composer (our reply box never opened, or the thread re-rendered and collapsed it) — and the
+reply posted as a standalone top-level comment, the exact failure the function exists to prevent
+(#886). The two helpers stay separate only because they OPEN the box differently: the #478 thread
+path needs `scrollIntoView` + an `ActionChains` hover to render a hover-hidden Reply button.
+
+A miss is an expected no-op and is logged DEBUG *inside* the resolver — never a `log_warning`,
+which would re-escalate as a defect on repeat (see `docs/error-tracking.md`).
+
 ## Failure naming
 
 Inline compose failures name the STEP that threw (e.g. `Inline comment post failed at focus

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1687,6 +1687,22 @@ def _reply_composer_for_comment(driver: WebDriver, comment_el: WebElement,
     return best[0]
 
 
+def _type_and_submit_reply(driver, composer: WebElement, reply_text: str, user_id: int = None) -> bool:
+    """Type into an ALREADY-resolved composer and submit (role=textbox + Ctrl+Enter fallback). Both
+    reply paths share this so the submit/verify contract can never drift between them. True only when
+    `_composer_submitted` confirms the post."""
+    reply_text = _strip_non_bmp(reply_text)
+    if not reply_text.strip():
+        return False
+    _focus_composer(driver, composer)  # sticky nav steals a top-of-viewport click (#815)
+    composer.send_keys(reply_text)
+    time.sleep(random.uniform(1, 2))
+    if not driver.execute_script(_SUBMIT_NEAR_COMPOSER_JS, composer):
+        composer.send_keys(Keys.CONTROL, Keys.RETURN)  # fallback
+    time.sleep(random.uniform(3, 5))
+    return _composer_submitted(driver, composer, reply_text)
+
+
 def _reply_to_comment_inline(driver, wait, comment_el, reply_text: str, user_id: int = None) -> bool:
     """Open a comment's inline reply box, type the reply, and submit (same SDUI pattern as
     post_comment_inline: role=textbox composer + Ctrl+Enter fallback). The composer is resolved
@@ -1699,16 +1715,7 @@ def _reply_to_comment_inline(driver, wait, comment_el, reply_text: str, user_id:
         composer = _reply_composer_for_comment(driver, comment_el, user_id=user_id)
         if composer is None:
             return False
-        reply_text = _strip_non_bmp(reply_text)
-        if not reply_text.strip():
-            return False
-        _focus_composer(driver, composer)  # sticky nav steals a top-of-viewport click (#815)
-        composer.send_keys(reply_text)
-        time.sleep(random.uniform(1, 2))
-        if not driver.execute_script(_SUBMIT_NEAR_COMPOSER_JS, composer):
-            composer.send_keys(Keys.CONTROL, Keys.RETURN)  # fallback
-        time.sleep(random.uniform(3, 5))
-        return _composer_submitted(driver, composer, reply_text)
+        return _type_and_submit_reply(driver, composer, reply_text, user_id=user_id)
     except Exception as e:
         log_warning("Inline reply post failed", exc=e, action_type="reply", user_id=user_id)
         return False
@@ -3274,8 +3281,15 @@ def _react_to_comment_inline(driver, wait, comment_el, user_id: int = None) -> b
 def _reply_under_comment_inline(driver, wait, comment_el, reply_text: str, user_id: int = None) -> bool:
     """Reply UNDER a specific comment — NOT as a new top-level comment. The bug: clicking a comment's
     Reply then taking the first page-wide role=textbox grabbed the post's main 'Add a comment' box, so
-    the reply posted as a standalone comment. Fix: after opening the reply box, type into the composer
-    NEAREST the comment (the inline reply box opens right below it), never the far-away main box."""
+    the reply posted as a standalone comment (#478).
+
+    #478's own fix only PENALISED a composer above the comment, so the main box still won when it was
+    the only visible one — the exact failure this function exists to prevent (#886). Composer
+    resolution is now `_reply_composer_for_comment`, shared with `_reply_to_comment_inline` (#883):
+    a box inside this comment wins, a box above it is rejected outright, a box owned by a DIFFERENT
+    comment is rejected, and no box of ours means skip. This function keeps only its own way of
+    OPENING the box — the #478 thread path needs the scroll + hover that renders a hover-hidden Reply
+    button before it can be clicked."""
     try:
         driver.execute_script("arguments[0].scrollIntoView({block:'center'});", comment_el)
         try:
@@ -3291,29 +3305,10 @@ def _reply_under_comment_inline(driver, wait, comment_el, reply_text: str, user_
         except Exception:
             driver.execute_script("arguments[0].click();", rbtns[0])
         time.sleep(random.uniform(1.5, 2.8))
-        # Pick the VISIBLE composer nearest the comment (the reply box that just opened below it);
-        # heavily penalise any composer above the comment (that's the main top comment box).
-        composer = driver.execute_script(
-            "const a=arguments[0].getBoundingClientRect();"
-            "const boxes=[...document.querySelectorAll(\"div[role='textbox']\")].filter(e=>{"
-            "  const r=e.getBoundingClientRect(); return r.width>0 && r.height>0;});"
-            "let best=null,bd=1e12;"
-            "for(const e of boxes){const r=e.getBoundingClientRect();"
-            "  let d=Math.abs(r.top-a.bottom)+(r.top<a.top?1e6:0);"
-            "  if(d<bd){bd=d;best=e;}} return best;", comment_el)
+        composer = _reply_composer_for_comment(driver, comment_el, user_id=user_id)
         if composer is None:
-            log_warning("Reply-under-comment: no composer near the comment", action_type="reply", user_id=user_id)
-            return False
-        reply_text = _strip_non_bmp(reply_text)
-        if not reply_text.strip():
-            return False
-        _focus_composer(driver, composer)  # sticky nav steals a top-of-viewport click (#815)
-        composer.send_keys(reply_text)
-        time.sleep(random.uniform(1, 2))
-        if not driver.execute_script(_SUBMIT_NEAR_COMPOSER_JS, composer):
-            composer.send_keys(Keys.CONTROL, Keys.RETURN)  # fallback
-        time.sleep(random.uniform(3, 5))
-        return _composer_submitted(driver, composer, reply_text)
+            return False  # expected no-op (the box never opened) — `_reply_composer_for_comment` logs it DEBUG
+        return _type_and_submit_reply(driver, composer, reply_text, user_id=user_id)
     except Exception as e:
         log_warning("Reply-under-comment failed", exc=e, action_type="reply", user_id=user_id)
         return False

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1661,6 +1661,10 @@ def _reply_composer_for_comment(driver: WebDriver, comment_el: WebElement,
     """
     anchor = _visible_rect(comment_el)
     if anchor is None:
+        # The callers now rely on THIS function to log every miss (#886 dropped their own warning),
+        # so a stale/unrendered comment must not return None silently.
+        log_debug("Comment is not rendered; no reply composer to resolve",
+                  action_type="reply", user_id=user_id)
         return None
     bottom = anchor["y"] + anchor["height"]
     nested = _visible_composers(comment_el)
@@ -1687,7 +1691,8 @@ def _reply_composer_for_comment(driver: WebDriver, comment_el: WebElement,
     return best[0]
 
 
-def _type_and_submit_reply(driver, composer: WebElement, reply_text: str, user_id: int = None) -> bool:
+def _type_and_submit_reply(driver: WebDriver, composer: WebElement, reply_text: str,
+                           user_id: int = None) -> bool:
     """Type into an ALREADY-resolved composer and submit (role=textbox + Ctrl+Enter fallback). Both
     reply paths share this so the submit/verify contract can never drift between them. True only when
     `_composer_submitted` confirms the post."""

--- a/tests/unit/app/test_comment_followups.py
+++ b/tests/unit/app/test_comment_followups.py
@@ -107,19 +107,19 @@ class TestReactToCommentInline:
 
 
 class TestReplyUnderComment:
-    def test_types_into_nearest_composer_and_submits(self):
+    def test_types_into_this_comments_composer_and_submits(self):
         from cqc_lem.app.run_automation import _reply_under_comment_inline
         rbtn = MagicMock()
         comment = MagicMock(); comment.find_elements.return_value = [rbtn]
         composer = MagicMock()
         driver = MagicMock()
-        # scrollIntoView -> None; composer proximity JS -> composer; composer-centering
-        # scrollIntoView (#815) -> None; submit JS -> True
-        driver.execute_script.side_effect = [None, composer, None, True]
+        driver.execute_script.return_value = True  # scrollIntoView, then the submit-button JS
         with patch(f"{RA}.ActionChains"), patch(f"{RA}._strip_non_bmp", side_effect=lambda s: s), \
+             patch(f"{RA}._reply_composer_for_comment", return_value=composer) as rc, \
              patch(f"{RA}._composer_submitted", return_value=True):
             assert _reply_under_comment_inline(driver, MagicMock(), comment, "Great point!", user_id=1) is True
         composer.send_keys.assert_called()
+        assert rc.call_args.args[1] is comment  # resolution is anchored to THIS comment
 
     def test_returns_false_when_no_reply_button(self):
         from cqc_lem.app.run_automation import _reply_under_comment_inline
@@ -127,6 +127,18 @@ class TestReplyUnderComment:
         driver = MagicMock()
         with patch(f"{RA}.ActionChains"), patch(f"{RA}.log_warning"):
             assert _reply_under_comment_inline(driver, MagicMock(), comment, "hi", user_id=1) is False
+
+    def test_no_composer_of_ours_is_a_clean_skip_not_an_exception(self):
+        # Issue #886: the sweep and the lead-signal delivery both treat the return value as a
+        # boolean skip — a miss must never raise, and must never warn (an unopened reply box is an
+        # expected no-op; a repeated log_warning re-escalates as a defect).
+        from cqc_lem.app.run_automation import _reply_under_comment_inline
+        comment = MagicMock(); comment.find_elements.return_value = [MagicMock()]
+        driver = MagicMock()
+        with patch(f"{RA}.ActionChains"), patch(f"{RA}.log_warning") as lw, \
+             patch(f"{RA}._reply_composer_for_comment", return_value=None):
+            assert _reply_under_comment_inline(driver, MagicMock(), comment, "hi", user_id=1) is False
+        lw.assert_not_called()
 
 
 class TestCommentContainerHelpers:

--- a/tests/unit/app/test_reply_inline.py
+++ b/tests/unit/app/test_reply_inline.py
@@ -127,10 +127,14 @@ class TestReplyComposerForComment:
         assert ra._reply_composer_for_comment(_driver(collapsed), _comment(900), user_id=1) is None
 
     def test_none_when_the_comment_itself_is_not_rendered(self):
+        # #886 dropped the callers' own miss log, so EVERY None out of here has to say so itself —
+        # a stale comment must not drop a reply with no trace at any level.
         from cqc_lem.app import run_automation as ra
         comment = MagicMock()
         type(comment).rect = property(lambda self: (_ for _ in ()).throw(Exception("stale")))
-        assert ra._reply_composer_for_comment(_driver(_box(1030)), comment, user_id=1) is None
+        with patch(f"{_RA}.log_debug") as ld:
+            assert ra._reply_composer_for_comment(_driver(_box(1030)), comment, user_id=1) is None
+        ld.assert_called_once()
 
 
 class TestInSameComment:

--- a/tests/unit/app/test_reply_inline.py
+++ b/tests/unit/app/test_reply_inline.py
@@ -226,6 +226,80 @@ class TestReplyInline:
         assert rc.call_args.args[1] is comment
 
 
+def _thread_comment(y, height=120, composers=()):
+    """`_reply_under_comment_inline`'s comment: a rendered container that also answers the Reply
+    button lookup (`button[aria-label='Reply']`) the composer lookup does not."""
+    el = _comment(y, height=height, composers=composers)
+    el.find_elements.side_effect = lambda by, value: (
+        list(composers) if "textbox" in value else [MagicMock(name="reply_btn")])
+    return el
+
+
+class TestReplyUnderCommentComposerPick:
+    """Issue #886. #478 only PENALISED a composer above the comment (`+1e6`), so when the post's main
+    'Add a comment' box was the ONLY visible role=textbox — our reply box never opened, the thread
+    re-rendered, the box collapsed — it still won as `best` and the reply posted as a standalone
+    top-level comment. Resolution is now shared with `_reply_to_comment_inline` (#883): hard filter."""
+
+    def test_main_comment_box_as_the_only_composer_is_never_borrowed(self):
+        from cqc_lem.app import run_automation as ra
+        main = _box(100)                                    # the post's own 'Add a comment' box
+        comment = _thread_comment(900)
+        driver = _driver(main)
+        with patch(f"{_RA}.ActionChains"):
+            ok = ra._reply_under_comment_inline(driver, MagicMock(), comment, "a real reply", user_id=1)
+        assert ok is False
+        main.send_keys.assert_not_called()
+        main.click.assert_not_called()
+
+    def test_another_comments_composer_is_never_typed_into(self):
+        from cqc_lem.app import run_automation as ra
+        theirs = _box(1300)                                 # a LATER comment's open reply box
+        comment = _thread_comment(900)
+        driver = _driver(theirs)
+        driver.execute_script.return_value = False          # neither element contains the other
+        with patch(f"{_RA}.ActionChains"), \
+             patch(f"{_RA}._comment_container", return_value=_comment(1200)):
+            ok = ra._reply_under_comment_inline(driver, MagicMock(), comment, "a real reply", user_id=1)
+        assert ok is False
+        theirs.send_keys.assert_not_called()
+
+    def test_types_into_our_own_box_below_the_comment(self):
+        from cqc_lem.app import run_automation as ra
+        main, mine = _box(100), _box(1030, text="")
+        comment = _thread_comment(900, composers=[mine])
+        driver = _driver(main, mine); driver.execute_script.return_value = True
+        with patch(f"{_RA}.ActionChains"):
+            ok = ra._reply_under_comment_inline(driver, MagicMock(), comment, "a real reply", user_id=1)
+        assert ok is True
+        mine.send_keys.assert_called_once()
+        main.send_keys.assert_not_called()
+
+    def test_both_reply_paths_use_the_same_composer_resolver(self):
+        # Acceptance: ONE composer-resolution helper. Kept as a test so a future edit can't quietly
+        # reintroduce a second, softer pick on one of the two paths.
+        from cqc_lem.app import run_automation as ra
+        composer = MagicMock(); composer.text = ""
+        under_comment, inline_comment = MagicMock(), MagicMock()
+        under_comment.find_elements.return_value = [MagicMock(name="reply_btn")]
+        driver = MagicMock(); driver.execute_script.return_value = True
+        with patch(f"{_RA}.ActionChains"), patch(f"{_RA}.click_first", return_value=MagicMock()), \
+             patch(f"{_RA}._reply_composer_for_comment", return_value=composer) as rc:
+            assert ra._reply_under_comment_inline(driver, _wait(), under_comment, "reply one", user_id=1) is True
+            assert ra._reply_to_comment_inline(driver, _wait(), inline_comment, "reply two", user_id=1) is True
+        assert [c.args[1] for c in rc.call_args_list] == [under_comment, inline_comment]
+
+    def test_empty_reply_text_is_never_typed(self):
+        from cqc_lem.app import run_automation as ra
+        composer = MagicMock()
+        comment = MagicMock(); comment.find_elements.return_value = [MagicMock(name="reply_btn")]
+        with patch(f"{_RA}.ActionChains"), \
+             patch(f"{_RA}._reply_composer_for_comment", return_value=composer):
+            ok = ra._reply_under_comment_inline(MagicMock(), _wait(), comment, "   ", user_id=1)
+        assert ok is False
+        composer.send_keys.assert_not_called()
+
+
 class TestCommentItemsFromThread:
     def test_walks_up_from_reply_buttons(self):
         from cqc_lem.app import run_automation as ra


### PR DESCRIPTION
## What

`_reply_under_comment_inline` (the #478 path — replies to replies under OUR comments on third-party posts) picked its composer with a **soft** penalty:

```js
let d = Math.abs(r.top - a.bottom) + (r.top < a.top ? 1e6 : 0);
```

A composer above the comment was penalised, not rejected. So when the post's main "Add a comment" box was the **only** visible `role=textbox` on the page — our reply box never opened, the thread re-rendered, the box collapsed — it was still returned as `best`, and the reply posted as a standalone top-level comment. That is exactly the failure the function's own docstring says it exists to prevent; the penalty only won the race when a genuine reply composer was also present.

## Why

#883 fixed the sibling function (`_reply_to_comment_inline`) with a hard above-filter plus an ownership check (`_reply_composer_for_comment` / `_in_same_comment`), and was told to leave this one alone. The two are the same operation, so keeping the resolution in two forms is how they drift.

## Changes

- `_reply_under_comment_inline` now resolves its composer via **`_reply_composer_for_comment`** — the ONE helper, shared with `_reply_to_comment_inline`. A box inside the comment wins; a box **above** it is rejected outright; a box that resolves to a **different** comment is rejected; no box of ours means skip. The ~10 lines of bespoke JS are gone.
- The identical type → focus → submit → verify tail of both reply paths moves into **`_type_and_submit_reply`**, so the submit/verify contract can't drift between them either.
- A missing composer is now a **DEBUG** skip (logged inside `_reply_composer_for_comment`) instead of a `log_warning` — an unopened reply box is an expected no-op, and per `CLAUDE.md` a repeated warning re-escalates as a defect (same class as #873/#875).

**The two helpers are deliberately NOT collapsed into one.** They now share everything except how they OPEN the reply box, and that step genuinely differs: the #478 thread path needs `scrollIntoView` + an `ActionChains` hover to render a hover-hidden Reply button before it can be clicked, where `_reply_to_comment_inline` uses `click_first`'s retry. Collapsing them would mean forcing one path's open-strategy onto the other.

## Call sites checked

Both callers treat the return as a boolean skip and are unaffected — the #478 sweep (`_followup_on_post_comment_replies`, gates `result["replied"]` / the ledger write on it) and the lead-signal delivery (`_reply_to_person_on_post`, returns it directly). A miss stays a clean `False`; every failure path is still inside the existing `try`.

## Testing

`8941 passed` (`pytest tests/unit -q`). New/updated coverage:

- `tests/unit/app/test_reply_inline.py::TestReplyUnderCommentComposerPick` — main comment box as the ONLY visible composer → `False` and never typed into; a later comment's composer → `False` and never typed into; our own box below the comment → typed and submitted; both reply paths call the same resolver anchored to their own comment; empty reply text is never typed.
- `tests/unit/app/test_comment_followups.py::TestReplyUnderComment` — updated for the shared resolver, plus a no-composer case asserting a clean `False` with **no** `log_warning`.

Verified the guard is real: reverting `run_automation.py` to `main` and re-running the new tests fails 5 of them, including `test_main_comment_box_as_the_only_composer_is_never_borrowed`.

Selenium DOM targeting itself is still validated on a supervised live run, as with #478/#876/#883.

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
