### PR TITLE
fix(errors): stop the caller restating a reaction failure that already warned (closes #878)

### DIFF
--- a/docs/error-tracking.md
+++ b/docs/error-tracking.md
@@ -105,6 +105,10 @@ return `False` both for "already reacted" (a no-op) and for genuine failure, so 
 working skip as `Could not leave a reaction on post`; it now returns `None` for the no-op — still
 falsy, so truthiness callers are unaffected — and only real failures warn.
 
+The second half of that pattern is **warn where you detect, not where you notice**. Restating a
+failure one frame up files a second defect for one fault, so that caller now logs the outcome at
+DEBUG and each failing path inside `react_to_post_inline` owns its single warning (issue #878).
+
 | Env | Default | Purpose |
 |---|---|---|
 | `LOG_ESCALATION_ENABLED` | `true` | master switch; false → zero Redis calls |

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1021,6 +1021,11 @@ def react_to_post_inline(driver, wait, card, post_content: str = None, comment_t
                            visible_only=True, warn_on_miss=expected,
                            max_try=MAX_WAIT_RETRY if expected else 1, user_id=user_id)
         if after is not None and "no reaction" in (after.get_attribute("aria-label") or "").lower():
+            # The card's controls were readable and the click STILL didn't take — the one reaction
+            # failure none of the selector misses above stand for, so it gets its single warning
+            # here, where it is detected. The caller's blanket warning is DEBUG (issue #878).
+            log_warning("Reaction did not register after clicking", user_id=user_id,
+                        action_type="comment")
             return False
         myprint(f"Reacted '{reaction}' on post")
         return True
@@ -1273,7 +1278,12 @@ def _engage_card(driver, wait, my_profile: LinkedInProfile, user_id: int, card, 
         elif outcome:
             mark_post_reacted(user_id, key)
         else:
-            log_warning("Could not leave a reaction on post", user_id=user_id, action_type="comment")
+            # Every way react_to_post_inline reports a failure has already warned where it happened
+            # — the fly-out opener's miss when there was no toggle to default-Like (issue #873), the
+            # reaction click's own miss, the wrapped exception, or the click that never registered.
+            # Warning again from out here filed a SECOND PostHog defect for one condition (#878).
+            log_debug("No reaction landed on post — continuing to the comment", user_id=user_id,
+                      action_type="comment")
     if not post_comment_inline(driver, wait, card, comment_text, user_id=user_id):
         release_post_claim(user_id, key)  # posting failed — let a later run retry
         return False

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -63,9 +63,13 @@ Two things follow for anyone writing a call site here:
    ONE warning.** The React toggle is one of two ways into a reaction, so its miss never warns — when
    both it and the fly-out opener miss, the opener's warning already stands for "this card's reaction
    controls are unreadable", and a second just files another defect for the same fault (issue #877).
-   That rule is not fully applied here yet: ONE unreadable card still warns twice more — from the
-   pre-click 'Reaction state' read (issue #874, open) and from the caller's 'Could not leave a
-   reaction on post' (issue #878, open). Collapse those into the opener's signal; never add a fourth.
+   By the same rule the CALLER never warns either: `_engage_card`'s blanket
+   `Could not leave a reaction on post` restated a failure that had already warned where it
+   happened, so it is DEBUG (issue #878) and the one path the selector misses did NOT cover — the
+   click the toggle never registered — warns once, inside the function that detects it. **Warn
+   where you detect, not where you notice.** ONE unreadable card still warns twice, because the
+   pre-click 'Reaction state' read warns too (issue #874, open); collapse that into the opener's
+   signal as well, and never add a fourth.
 2. **Keep the message a stable template.** The dedup key masks volatile tokens (URLs, emails, UUIDs,
    URNs, hex, `[...]`, quoted strings, numbers) and combines them with the call site, so
    `Selector miss: Feed sort control` and `Selector miss: Reaction state` stay two distinct problems

--- a/tests/unit/app/test_comment_inline.py
+++ b/tests/unit/app/test_comment_inline.py
@@ -418,3 +418,76 @@ class TestReactToPostInline:
              patch(f"{_RA}.click_first", return_value=MagicMock()):
             ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
         assert ok is False  # toggle never flipped away from 'no reaction'
+
+    def test_a_click_that_never_registered_warns_exactly_once(self):
+        """Readable controls, a click that didn't take: the one reaction failure none of the
+        selector misses stand for. It warns HERE, where it's detected, so the caller doesn't have
+        to warn blindly for every False (issue #878)."""
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
+             patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.find_first", side_effect=[_state("Reaction button state: no reaction"),
+                                                     _state("Reaction button state: no reaction")]), \
+             patch(f"{_RA}.click_first", return_value=MagicMock()), \
+             patch(f"{_RA}.log_warning") as warn:
+            ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
+        assert ok is False
+        assert len(warn.call_args_list) == 1
+        assert warn.call_args_list[0].args[0] == "Reaction did not register after clicking"
+
+    def test_an_unreadable_card_adds_no_warning_of_its_own(self):
+        """No Reaction-state button and no React toggle: the fly-out opener's miss already warns for
+        that condition (issue #873), so nothing in this function may warn a second time."""
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.choose_post_reaction", return_value="Like"), \
+             patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.find_first", return_value=None), \
+             patch(f"{_RA}.click_first", return_value=None), \
+             patch(f"{_RA}.log_warning") as warn:
+            ok = ra.react_to_post_inline(MagicMock(), MagicMock(), MagicMock(), user_id=1)
+        assert ok is False
+        warn.assert_not_called()
+
+
+class TestEngageCardReactionLogging:
+    """`_engage_card`'s reaction outcome must never be the thing that files a defect: a reaction is
+    best-effort and never blocks the comment, and every real failure already warned inside
+    `react_to_post_inline` (issue #878)."""
+
+    @staticmethod
+    def _engage(reaction_outcome, warn, debug):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.claim_post_for_comment", return_value=True), \
+             patch(f"{_RA}.select_blueprint", return_value={"format": "expander"}), \
+             patch(f"{_RA}.generate_ai_response", return_value="A real comment."), \
+             patch(f"{_RA}._author_is_me", return_value=False), \
+             patch(f"{_RA}.react_to_post_inline", return_value=reaction_outcome), \
+             patch(f"{_RA}.mark_post_reacted"), \
+             patch(f"{_RA}.post_comment_inline", return_value=True), \
+             patch(f"{_RA}.mark_post_commented"), \
+             patch(f"{_RA}.insert_new_log"), \
+             patch(f"{_RA}.record_action"), \
+             patch(f"{_RA}.pace_read", return_value=0.0), \
+             patch(f"{_RA}.log_warning", warn), \
+             patch(f"{_RA}.log_debug", debug):
+            return ra._engage_card(MagicMock(), MagicMock(), MagicMock(), 1, MagicMock(),
+                                   "feedurn://x", "a post body", "Jane", {}, "synth", [], [])
+
+    def test_a_failed_reaction_is_debug_not_a_warning(self):
+        warn, debug = MagicMock(), MagicMock()
+        assert self._engage(False, warn, debug) is True  # the comment still lands
+        warn.assert_not_called()
+        assert debug.call_args_list[0].args[0].startswith("No reaction landed on post")
+
+    def test_an_already_reacted_post_is_still_debug(self):
+        # None = the post already carried our reaction: a no-op, and mark_post_reacted is not owed.
+        warn, debug = MagicMock(), MagicMock()
+        assert self._engage(None, warn, debug) is True
+        warn.assert_not_called()
+        assert debug.call_args_list[0].args[0].startswith("Post already carried our reaction")
+
+    def test_a_landed_reaction_logs_nothing(self):
+        warn, debug = MagicMock(), MagicMock()
+        assert self._engage(True, warn, debug) is True
+        warn.assert_not_called()
+        debug.assert_not_called()


### PR DESCRIPTION
## What & why

PostHog filed **RecurringWarning: `Could not leave a reaction on post`** off an
`auto_comment_in_groups` run. The warning lives in `_engage_card`, one frame *above* the code that
detects the fault — it fires on every falsy-but-not-`None` return from `react_to_post_inline`, and
each of those paths had already warned where it happened:

| `react_to_post_inline` returns `False` because… | already warned by |
|---|---|
| no React toggle **and** the fly-out opener missed | the opener's `warn_on_miss=trigger is None` (#873) |
| the opener worked but the reaction button missed / wasn't clickable | that `click_first`'s own miss |
| anything raised | `Inline post reaction failed` |
| the click never registered (toggle still reads "no reaction") | *nothing* |

So one unreadable card emitted this as a **second** warning for a fault that was already signalled,
and `log_escalation` re-emitted it at ERROR and filed it as its own issue. This is the same shape as
#873 / #875 / #877, and `src/cqc_lem/utilities/CLAUDE.md` already named #878 as the next one to
collapse.

**The fix:** `_engage_card` logs the outcome at DEBUG. A reaction is best-effort and never blocks the
comment, so the caller has nothing to add that the detecting frame didn't already say.

**Nothing goes silent.** The one row above with no signal — a click the toggle never registered —
now warns exactly once, inside `react_to_post_inline`, where it is detected. Net warnings per
condition stay at one and the total strictly drops: an unreadable card goes from 2 warnings to 1.
The rule this generalises to, added to the tree's `CLAUDE.md` and `docs/error-tracking.md`: **warn
where you detect, not where you notice.**

`Selector miss: Reaction state` (#874) is the remaining duplicate on an unreadable card and stays
out of scope here; the doc still names it as open.

## Testing

- `test_a_click_that_never_registered_warns_exactly_once` — the moved warning fires, once, with a
  stable message (the escalation dedup key needs the template stable).
- `test_an_unreadable_card_adds_no_warning_of_its_own` — the `#873` path stays single-signalled.
- New `TestEngageCardReactionLogging`: a failed reaction is DEBUG and the comment still lands; an
  already-reacted post stays DEBUG; a landed reaction logs nothing at all.
- `pytest tests/unit/app -q` → **1817 passed** locally.

Closes #878

🤖 Generated with [Claude Code](https://claude.com/claude-code)
