### PR TITLE
feat(ops): host watchdog + deep health check for the failure healthchecks cannot see

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1055,3 +1055,7 @@ BENCHMARK_USAGE_LEVELS=gpt-oss:120b=medium
 # PostHog's judge needs its own provider key configured IN PostHog (Ollama Cloud is not a judge
 # provider). With no personal key the runner degrades to an in-runner lem-medium judge and emits
 # $ai_metric instead.
+
+# Stack watchdog (docs/stack-watchdog.md). Recipient for "a compose service is down" alerts;
+# falls back to COST_ALERT_EMAIL when unset. PostHog + SendGrid creds are shared with other features.
+WATCHDOG_ALERT_EMAIL=

--- a/docs/stack-watchdog.md
+++ b/docs/stack-watchdog.md
@@ -1,0 +1,116 @@
+# Stack watchdog & deep health
+
+Three layers, each covering a blind spot the others have. They exist because of the **v0.118.0
+outage**: the worker converge aborted mid-deploy and left `celery_beat` plus every Celery worker in
+`Created`. The API stayed green for four hours while the entire automation pillar was dead.
+
+## Why the existing checks did not fire
+
+This is the part worth internalising — **healthchecks were already defined on all seven app
+services and were useless here**:
+
+| Mechanism | Why it missed |
+|---|---|
+| Docker `healthcheck:` | A container in `Created` **has never run**, so its healthcheck never executes. Healthchecks only report on *running* containers. |
+| `restart:` policy | Acts on containers that ran and then exited. It will not start a container that was never started. (It is also unset on every celery service.) |
+| `GET /health` | Returns a static `{"status": "healthy"}` literal. It never touched Celery, so it was honestly reporting a genuinely healthy API. |
+| A Celery beat task | `celery_beat` was itself among the dead. **A watchdog inside the thing it watches cannot report its own outage.** |
+
+The gap was: *"the container exists but was never started, and nothing outside it is looking."*
+
+## Layer 1 — host watchdog (`scripts/stack_watchdog.sh`)
+
+A systemd timer, every 5 minutes, **outside the container set**. Reads `docker compose ps -a`,
+compares against `docker compose config --services`, and flags anything not `running`.
+
+- **Grace window** (`WATCHDOG_GRACE_SECONDS`, default 600s) — deploys legitimately recreate the
+  worker tier, and a converge plus image pull runs for minutes. Alerting under that window would
+  page on every release and train everyone to ignore it.
+- **One bounded self-heal** (`WATCHDOG_HEAL=1`) — `docker compose start` once per incident for a
+  `Created`/`Exited` container, then alert regardless of outcome. Bounded on purpose: a container
+  that needs starting twice is not a blip. It uses `start`, never `up -d`, so it cannot fight a
+  deploy that is mid-converge.
+- **Replica-aware** — `selenium-node-chrome` runs 8 containers under one service name. The *worst*
+  state in the pool is what gets recorded, so seven dead nodes cannot hide behind one healthy one.
+- **Alerts on both channels**, talking to PostHog and SendGrid **directly over HTTPS**. It depends
+  on nothing in the stack, so it still alerts when every container on the box is down.
+  - PostHog: `stack_watchdog_report` (`down`, `healed`, `recovered`, `down_count`)
+  - Email: only for a real outage or a heal. A pure recovery is worth an event, not an inbox.
+- **Silent when healthy.** A watchdog that chats every 5 minutes gets filtered, and then it is not
+  a watchdog.
+
+Blind spot: it cannot report the VPS itself being down. That is layer 3.
+
+### Install
+
+```sh
+sudo cp /opt/lem/scripts/systemd/lem-watchdog.{service,timer} /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now lem-watchdog.timer
+systemctl list-timers lem-watchdog.timer      # confirm it is scheduled
+sudo systemctl start lem-watchdog.service     # run once now
+journalctl -u lem-watchdog.service -n 50      # read the result
+```
+
+Requires `jq` and `curl` on the host.
+
+### Configure
+
+Add to `/opt/lem/.env` (or set in the unit):
+
+```
+WATCHDOG_ALERT_EMAIL=you@example.com
+```
+
+It falls back to `COST_ALERT_EMAIL` when unset. `SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`,
+`POSTHOG_API_KEY` and `POSTHOG_HOST` are already present for other features.
+
+Overridable: `LEM_DIR`, `LEM_ENV_FILE`, `WATCHDOG_STATE_DIR`, `WATCHDOG_GRACE_SECONDS`,
+`WATCHDOG_HEAL`, `WATCHDOG_ALERT_EMAIL`.
+
+### Exit codes
+
+`0` = healthy, or a self-heal that worked. `1` = something is still down. The unit sets
+`SuccessExitStatus=0 1` so a true "still down" report is not also a systemd unit failure — otherwise
+the next timer tick is all systemd would talk about.
+
+## Layer 2 — `GET /health/deep`
+
+`/health` stays trivial: it gates the blue/green flip, so it must never depend on Redis, MySQL or
+Celery being reachable. A test pins that.
+
+`/health/deep` answers what a monitor actually wants to know — it reaches every worker over the
+broker's control channel (`_inspect().active_queues()`), so a lane whose container was never started
+simply is not in the reply.
+
+```json
+{"status": "healthy", "workers": 5, "lanes": {"celery@selenium": ["se_engage"]}}
+```
+
+| `status` | Meaning |
+|---|---|
+| `healthy` | at least one worker is consuming |
+| `degraded` | broker reachable, **nobody consuming** — the exact v0.118.0 shape |
+| `unknown` | control channel unreachable. **Unmeasured is never `healthy`.** |
+
+It never raises and never 503s on a partial: a monitor should read `status`, and a scrape that
+cannot tell must say so rather than give a confident wrong answer.
+
+## Layer 3 — external dead-man's switch (owner setup)
+
+Layers 1 and 2 both run *on the box*. Neither can report the VPS being down, the tunnel being
+broken, or the host being unreachable. That needs something off-box.
+
+Point an external monitor (healthchecks.io, UptimeRobot, Better Stack — any of them) at:
+
+```
+https://lem.christopherqueenconsulting.com/health/deep
+```
+
+Alert when the response is non-200 **or** the body's `status` is not `healthy`. Most monitors
+support a keyword/JSON assertion — use it, because a `degraded` body still returns **200** by
+design. A monitor checking only the HTTP status would have missed this outage exactly as `/health`
+did.
+
+Suggested: 5-minute interval, alert after 2 consecutive failures (≈10 min, matching layer 1's
+grace window so the two don't disagree).

--- a/scripts/install_watchdog.sh
+++ b/scripts/install_watchdog.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# One-shot installer for the LEM stack watchdog (docs/stack-watchdog.md).
+#
+# Run as root ON THE VPS, after a release containing scripts/stack_watchdog.sh has deployed:
+#   sudo /opt/lem/scripts/install_watchdog.sh you@example.com
+#
+# Idempotent: safe to re-run after every release. Re-running refreshes the units and restarts the
+# timer, which is what you want if the unit files changed.
+set -euo pipefail
+
+LEM_DIR="${LEM_DIR:-/opt/lem}"
+ENVF="${LEM_ENV_FILE:-${LEM_DIR}/.env}"
+UNIT_DIR="/etc/systemd/system"
+ALERT_EMAIL="${1:-}"
+
+say()  { echo "[install-watchdog] $*"; }
+die()  { echo "[install-watchdog] ERROR: $*" >&2; exit 1; }
+
+[[ $EUID -eq 0 ]] || die "must run as root (systemd units + /opt/lem/.env). Try: sudo $0 $*"
+
+# 1. Prerequisites. The watchdog builds its email payload with jq and posts with curl; without
+#    them it would install cleanly and then silently fail to alert, which is the one outcome worse
+#    than not installing it.
+for bin in jq curl docker systemctl; do
+  command -v "$bin" >/dev/null 2>&1 || die "missing required binary: ${bin}"
+done
+say "prerequisites OK (jq, curl, docker, systemctl)"
+
+# 2. The payload must actually be on the box. /opt/lem tracks release TAGS, so this file only
+#    appears once a release containing it has been deployed — a missing file here almost always
+#    means "the PR merged but that release hasn't shipped yet", not a broken install.
+WATCHDOG="${LEM_DIR}/scripts/stack_watchdog.sh"
+[[ -f "$WATCHDOG" ]] || die "not found: ${WATCHDOG}
+  /opt/lem is checked out at a release tag. Confirm the release containing the watchdog is deployed:
+    grep '^IMAGE_TAG=' ${ENVF} && git -C ${LEM_DIR} describe --tags"
+chmod +x "$WATCHDOG"
+
+for unit in lem-watchdog.service lem-watchdog.timer; do
+  [[ -f "${LEM_DIR}/scripts/systemd/${unit}" ]] || die "not found: ${LEM_DIR}/scripts/systemd/${unit}"
+done
+
+# 3. Alert recipient. Falls back to COST_ALERT_EMAIL inside the watchdog itself, so an empty value
+#    is a warning rather than a failure — but say so loudly, because a watchdog nobody hears from
+#    is indistinguishable from a healthy stack.
+if [[ -n "$ALERT_EMAIL" ]]; then
+  if grep -qE '^WATCHDOG_ALERT_EMAIL=' "$ENVF" 2>/dev/null; then
+    sed -i -E "s|^WATCHDOG_ALERT_EMAIL=.*|WATCHDOG_ALERT_EMAIL=${ALERT_EMAIL}|" "$ENVF"
+  else
+    printf '\n# Stack watchdog alert recipient (docs/stack-watchdog.md)\nWATCHDOG_ALERT_EMAIL=%s\n' \
+      "$ALERT_EMAIL" >> "$ENVF"
+  fi
+  say "WATCHDOG_ALERT_EMAIL=${ALERT_EMAIL} written to ${ENVF}"
+else
+  current="$(sed -nE 's/^[[:space:]]*WATCHDOG_ALERT_EMAIL=([^#[:space:]]*).*/\1/p' "$ENVF" 2>/dev/null | tail -n1)"
+  fallback="$(sed -nE 's/^[[:space:]]*COST_ALERT_EMAIL=([^#[:space:]]*).*/\1/p' "$ENVF" 2>/dev/null | tail -n1)"
+  if [[ -n "$current" ]]; then
+    say "WATCHDOG_ALERT_EMAIL already set to ${current} — leaving it"
+  elif [[ -n "$fallback" ]]; then
+    say "WARN: no WATCHDOG_ALERT_EMAIL; will fall back to COST_ALERT_EMAIL (${fallback})"
+  else
+    say "WARN: no WATCHDOG_ALERT_EMAIL and no COST_ALERT_EMAIL — EMAIL ALERTS WILL NOT SEND."
+    say "      Re-run as: sudo $0 you@example.com"
+  fi
+fi
+
+# Warn on the other two credentials rather than failing: PostHog-only alerting is still useful.
+for key in SENDGRID_API_KEY SENDGRID_FROM_EMAIL POSTHOG_API_KEY; do
+  grep -qE "^${key}=." "$ENVF" 2>/dev/null || say "WARN: ${key} unset in ${ENVF} — that alert channel is disabled"
+done
+
+# 4. Install and arm.
+install -m 0644 "${LEM_DIR}/scripts/systemd/lem-watchdog.service" "${UNIT_DIR}/lem-watchdog.service"
+install -m 0644 "${LEM_DIR}/scripts/systemd/lem-watchdog.timer"   "${UNIT_DIR}/lem-watchdog.timer"
+systemctl daemon-reload
+systemctl enable --now lem-watchdog.timer
+systemctl restart lem-watchdog.timer   # pick up unit changes on a re-run
+say "timer installed and enabled"
+
+# 5. Smoke test. Exit 1 from the watchdog means "something is down" — a true report, not an install
+#    failure — so don't let `set -e` treat it as one.
+say "running once now..."
+set +e
+systemctl start lem-watchdog.service
+rc=$?
+set -e
+
+echo
+say "─── result ───"
+systemctl list-timers lem-watchdog.timer --no-pager | sed 's/^/  /'
+echo
+journalctl -u lem-watchdog.service -n 20 --no-pager | sed 's/^/  /'
+echo
+if [[ $rc -eq 0 ]]; then
+  say "OK — installed and armed. Silence from here on means the stack is healthy."
+else
+  say "installed and armed. The run above reported a problem — read the log lines."
+fi
+say "Next: point an external monitor at https://<host>/health/deep and assert on the JSON"
+say "      'status' field, NOT just HTTP 200 — 'degraded' returns 200 by design."

--- a/scripts/stack_watchdog.sh
+++ b/scripts/stack_watchdog.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+# LEM stack watchdog — the layer that catches "the container exists but was never started".
+#
+# WHY THIS EXISTS (the v0.118.0 outage):
+#   Docker healthchecks were already defined on all seven app services and did NOT help. A container
+#   in `Created` has never run, so its healthcheck never executes; `restart:` policies don't fire
+#   either (they act on containers that ran and exited). The worker converge aborted mid-deploy,
+#   left celery_beat + every worker in `Created`, and the API stayed green — `/health` returns a
+#   static literal and never touches Celery. Automation was dead for four hours with nothing red.
+#
+# WHY IT LIVES ON THE HOST, NOT IN A BEAT TASK:
+#   celery_beat was itself among the dead. A watchdog inside the thing it watches cannot report its
+#   own outage. This runs from a systemd timer, outside the container set, and depends on nothing in
+#   the stack — it talks to PostHog and SendGrid over plain HTTPS so it still alerts when every
+#   container on the box is down.
+#
+# Install: see docs/stack-watchdog.md (systemd units live in scripts/systemd/).
+# Overridable: LEM_DIR, LEM_ENV_FILE, WATCHDOG_STATE_DIR, WATCHDOG_GRACE_SECONDS, WATCHDOG_HEAL,
+#              WATCHDOG_ALERT_EMAIL.
+set -uo pipefail
+
+LEM_DIR="${LEM_DIR:-/opt/lem}"
+ENVF="${LEM_ENV_FILE:-${LEM_DIR}/.env}"
+STATE_DIR="${WATCHDOG_STATE_DIR:-/var/lib/lem-watchdog}"
+# How long a service may be down before it is worth waking someone. Deploys legitimately recreate
+# the worker tier, and a converge plus image pull can run for minutes — alerting under that window
+# would page on every release and train everyone to ignore it.
+GRACE="${WATCHDOG_GRACE_SECONDS:-600}"
+# One bounded self-heal per incident (`docker start`), then alert regardless of whether it worked.
+# Bounded on purpose: a container that needs starting twice is not a blip, and a watchdog that
+# retries forever silently papers over a real fault.
+HEAL="${WATCHDOG_HEAL:-1}"
+
+log() { echo "[watchdog $(date -u +%Y-%m-%dT%H:%M:%SZ)] $*"; }
+now() { date -u +%s; }
+
+mkdir -p "$STATE_DIR" 2>/dev/null || { log "FATAL: cannot create $STATE_DIR"; exit 1; }
+
+env_value() {  # $1 = key
+  [[ -r "$ENVF" ]] || return 0
+  sed -nE "s/^[[:space:]]*$1=[\"']?([^\"'#[:space:]]*).*/\1/p" "$ENVF" | tail -n1
+}
+
+COMPOSE="docker compose -f docker-compose.yml -f docker-compose.prod.yml"
+TOPOLOGY="$(env_value SELENIUM_TOPOLOGY)"; TOPOLOGY="${TOPOLOGY:-grid}"
+[[ "${TOPOLOGY,,}" == "grid" ]] && COMPOSE="$COMPOSE -f docker-compose.grid.yml"
+
+cd "$LEM_DIR" 2>/dev/null || { log "FATAL: cannot cd $LEM_DIR"; exit 1; }
+
+# ── Collect state ────────────────────────────────────────────────────────────────
+# `config --services` is profile-filtered, so a standalone service parked behind a disabled profile
+# is correctly absent. flyway is a one-shot (`compose run --rm`) and is never expected to be up.
+expected="$($COMPOSE config --services 2>/dev/null | awk '$1 != "flyway" {print}' | sort -u)"
+if [[ -z "$expected" ]]; then
+  log "FATAL: could not enumerate compose services — is Docker up?"
+  exit 1
+fi
+
+# ONE `ps -a` read. Space-separated: neither a service name nor a state contains a space.
+states="$($COMPOSE ps -a --format '{{.Service}} {{.State}}' 2>/dev/null)"
+
+# A replicated service (selenium-node-chrome runs 8) reports one row PER CONTAINER under the SAME
+# service name. Last-write-wins would let seven dead nodes hide behind one healthy one, so the
+# worst state a service has in the pool is the state we record for it.
+declare -A state_of
+while read -r svc state _; do
+  [[ -n "$svc" ]] || continue
+  state="${state,,}"
+  if [[ -z "${state_of[$svc]:-}" || "${state_of[$svc]}" == "running" ]]; then
+    state_of["$svc"]="$state"
+  fi
+done <<< "$states"
+
+# ── Classify ─────────────────────────────────────────────────────────────────────
+down=()          # services to alert about (down beyond the grace window)
+healed=()        # services this run tried to start
+recovered=()     # services that were down and are now fine
+
+for svc in $expected; do
+  st="${state_of[$svc]:-absent}"
+  marker="$STATE_DIR/${svc//\//_}.down"
+
+  if [[ "$st" == "running" ]]; then
+    if [[ -f "$marker" ]]; then
+      recovered+=("$svc")
+      rm -f "$marker"
+    fi
+    continue
+  fi
+
+  # Not running. Record when we first saw it that way.
+  if [[ ! -f "$marker" ]]; then
+    echo "$(now) $st" > "$marker"
+    log "NOTICE: ${svc} is '${st}' — starting grace window (${GRACE}s)"
+    continue
+  fi
+
+  first_seen="$(awk '{print $1}' "$marker" 2>/dev/null)"
+  [[ "$first_seen" =~ ^[0-9]+$ ]] || first_seen="$(now)"
+  elapsed=$(( $(now) - first_seen ))
+  (( elapsed < GRACE )) && continue   # still inside the deploy window
+
+  # Past grace. One bounded self-heal, then alert either way.
+  if [[ "$HEAL" == "1" ]] && ! grep -q ' healed$' "$marker" 2>/dev/null; then
+    # `Created`/`Exited` is exactly what `docker start` fixes and what neither a healthcheck nor a
+    # restart policy will ever touch. `up -d` is deliberately NOT used: it could fight a deploy
+    # that is mid-converge.
+    if [[ "$st" == "created" || "$st" == "exited" ]]; then
+      log "HEAL: docker start ${svc} (down ${elapsed}s in state '${st}')"
+      if $COMPOSE start "$svc" >/dev/null 2>&1; then
+        healed+=("$svc")
+      else
+        log "HEAL FAILED: ${svc}"
+      fi
+      echo "$first_seen $st healed" > "$marker"
+      sleep 5
+      # Re-read: a heal that worked still gets reported, but as recovered rather than down.
+      if [[ "$($COMPOSE ps -a --format '{{.Service}} {{.State}}' 2>/dev/null \
+              | awk -v s="$svc" '$1==s {print tolower($2)}')" == "running" ]]; then
+        continue
+      fi
+    fi
+  fi
+  down+=("$svc:${st}:${elapsed}s")
+done
+
+# ── Report ───────────────────────────────────────────────────────────────────────
+# Nothing to say and nothing was wrong: stay silent. A watchdog that chats every 5 minutes gets
+# filtered, and then it is not a watchdog.
+if [[ ${#down[@]} -eq 0 && ${#healed[@]} -eq 0 && ${#recovered[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+summary=""
+[[ ${#down[@]} -gt 0 ]]      && summary+="DOWN: ${down[*]}. "
+[[ ${#healed[@]} -gt 0 ]]    && summary+="Auto-started: ${healed[*]}. "
+[[ ${#recovered[@]} -gt 0 ]] && summary+="Recovered: ${recovered[*]}. "
+log "$summary"
+
+# PostHog — direct capture, no app dependency.
+PH_KEY="$(env_value POSTHOG_API_KEY)"
+PH_HOST="$(env_value POSTHOG_HOST)"; PH_HOST="${PH_HOST:-https://us.i.posthog.com}"
+if [[ -n "$PH_KEY" ]]; then
+  payload=$(cat <<JSON
+{"api_key":"${PH_KEY}","event":"stack_watchdog_report","distinct_id":"lem-vps",
+ "properties":{"down":"${down[*]:-}","healed":"${healed[*]:-}","recovered":"${recovered[*]:-}",
+ "down_count":${#down[@]},"healed_count":${#healed[@]},"summary":"${summary}",
+ "\$process_person_profile":false}}
+JSON
+)
+  curl -s -m 15 -X POST "${PH_HOST%/}/i/v0/e/" -H 'Content-Type: application/json' \
+    -d "$payload" >/dev/null 2>&1 \
+    || log "WARN: PostHog capture failed (alerting continues by email)"
+else
+  log "WARN: POSTHOG_API_KEY unset — skipping PostHog"
+fi
+
+# Email — only for an actual outage or a heal. A pure recovery is worth an event, not an inbox.
+if [[ ${#down[@]} -gt 0 || ${#healed[@]} -gt 0 ]]; then
+  SG_KEY="$(env_value SENDGRID_API_KEY)"
+  FROM="$(env_value SENDGRID_FROM_EMAIL)"
+  TO="${WATCHDOG_ALERT_EMAIL:-$(env_value WATCHDOG_ALERT_EMAIL)}"
+  TO="${TO:-$(env_value COST_ALERT_EMAIL)}"
+  if [[ -n "$SG_KEY" && -n "$FROM" && -n "$TO" ]]; then
+    subject="[LEM] stack watchdog: ${#down[@]} down, ${#healed[@]} auto-started"
+    body="${summary}
+
+Host: $(hostname)
+Time: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Grace window: ${GRACE}s
+
+Docker healthchecks cannot catch this class of fault: a container in 'Created' never runs, so its
+healthcheck never executes and its restart policy never fires. Check the last deploy first.
+
+  cd ${LEM_DIR} && ${COMPOSE} ps -a"
+    curl -s -m 20 -X POST https://api.sendgrid.com/v3/mail/send \
+      -H "Authorization: Bearer ${SG_KEY}" -H 'Content-Type: application/json' \
+      -d "$(jq -n --arg to "$TO" --arg from "$FROM" --arg s "$subject" --arg b "$body" \
+            '{personalizations:[{to:[{email:$to}]}],from:{email:$from},
+              subject:$s,content:[{type:"text/plain",value:$b}]}')" >/dev/null 2>&1 \
+      || log "WARN: SendGrid send failed"
+  else
+    log "WARN: SendGrid not configured (need SENDGRID_API_KEY, SENDGRID_FROM_EMAIL, WATCHDOG_ALERT_EMAIL)"
+  fi
+fi
+
+# Non-zero only while something is still down, so `systemctl status` and any external check reflect
+# reality. A successful self-heal exits 0 — it reports, but it is not an outstanding fault.
+[[ ${#down[@]} -gt 0 ]] && exit 1
+exit 0

--- a/scripts/systemd/lem-watchdog.service
+++ b/scripts/systemd/lem-watchdog.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=LEM stack watchdog — alerts when a compose service is down past its grace window
+Documentation=file:///opt/lem/docs/stack-watchdog.md
+# Deliberately NOT After=docker.service with a hard Requires: the watchdog's whole job is to report
+# a broken stack, so it must still run (and fail loudly) when Docker itself is unhealthy.
+After=docker.service
+
+[Service]
+Type=oneshot
+User=root
+WorkingDirectory=/opt/lem
+ExecStart=/opt/lem/scripts/stack_watchdog.sh
+# The script exits 1 while something is still down. That is a true report, not a unit failure —
+# without this, systemd marks the unit failed and the next timer tick is all systemd talks about.
+SuccessExitStatus=0 1
+StandardOutput=journal
+StandardError=journal

--- a/scripts/systemd/lem-watchdog.timer
+++ b/scripts/systemd/lem-watchdog.timer
@@ -1,0 +1,15 @@
+[Unit]
+Description=Run the LEM stack watchdog every 5 minutes
+Documentation=file:///opt/lem/docs/stack-watchdog.md
+
+[Timer]
+# 2 min after boot: a reboot that leaves containers in Created is exactly the failure this catches,
+# and waiting a full interval to notice wastes the window.
+OnBootSec=2min
+OnUnitActiveSec=5min
+# Detection latency is 5 min; the GRACE window (default 600s) decides when that becomes an alert.
+AccuracySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1199,7 +1199,38 @@ class FutureForwardValues(IntEnum):
 
 @app.get("/health")
 def health_check():
+    """Liveness for the blue/green flip and the Cloudflare tunnel. Deliberately trivial: it gates
+    every deploy, so it must never depend on Redis, MySQL or Celery being reachable."""
     return {"status": "healthy"}
+
+
+@app.get("/health/deep")
+def health_check_deep():
+    """Readiness of the things `/health` deliberately ignores — for external monitors.
+
+    `/health` returning 200 while the entire Celery tier was in `Created` is exactly how the
+    v0.118.0 outage stayed invisible for four hours: the API was genuinely fine, and nothing an
+    uptime monitor could reach knew that automation was dead. This endpoint answers the question a
+    monitor actually wants to ask.
+
+    Never raises and never 503s on a partial: an external monitor should read `status`, and a
+    scrape that can't tell must report `unknown` rather than a confident wrong answer.
+    """
+    lanes: dict = {}
+    status = "healthy"
+    try:
+        from cqc_lem.utilities.maintenance import _inspect
+        # active_queues() reaches every worker over the broker's control channel, so a lane whose
+        # container was never started simply isn't in the reply — which is the signal we want.
+        replies = _inspect().active_queues() or {}
+        for worker, queues in replies.items():
+            lanes[worker] = sorted(q.get("name", "?") for q in (queues or []))
+        if not lanes:
+            status = "degraded"        # broker reachable, nobody consuming
+    except Exception as e:
+        log_warning("Deep health check could not reach the Celery control channel", exc=e)
+        status = "unknown"             # unmeasured is never "healthy"
+    return {"status": status, "workers": len(lanes), "lanes": lanes}
 
 
 @router.get("/app-info")

--- a/tests/unit/api/test_health_deep.py
+++ b/tests/unit/api/test_health_deep.py
@@ -1,0 +1,76 @@
+"""`/health/deep` — the readiness probe an external monitor can actually use.
+
+`/health` returned 200 while the entire Celery tier sat in `Created` for four hours (v0.118.0).
+The API was genuinely fine; nothing reachable from outside knew automation was dead. These tests
+pin the three answers that matter and, in particular, that an unreadable control channel is
+reported as `unknown` rather than `healthy`."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+pytestmark = pytest.mark.unit
+
+_MAIN = "cqc_lem.api.main"
+
+
+def _call():
+    from cqc_lem.api.main import health_check_deep
+    return health_check_deep()
+
+
+class TestHealthDeep:
+    def test_reports_each_worker_and_its_lanes(self):
+        replies = {
+            "celery@worker": [{"name": "default"}],
+            "celery@selenium": [{"name": "se_engage"}],
+        }
+        insp = MagicMock()
+        insp.active_queues.return_value = replies
+        with patch("cqc_lem.utilities.maintenance._inspect", return_value=insp):
+            out = _call()
+        assert out["status"] == "healthy"
+        assert out["workers"] == 2
+        assert out["lanes"]["celery@selenium"] == ["se_engage"]
+
+    def test_no_consumers_is_degraded_not_healthy(self):
+        """The exact v0.118.0 shape: broker up, every worker container never started. An empty
+        reply must not read as healthy — that is the silence the outage hid behind."""
+        insp = MagicMock()
+        insp.active_queues.return_value = {}
+        with patch("cqc_lem.utilities.maintenance._inspect", return_value=insp):
+            out = _call()
+        assert out["status"] == "degraded"
+        assert out["workers"] == 0
+
+    def test_none_reply_is_degraded(self):
+        """`active_queues()` returns None (not {}) when nothing answers before the timeout."""
+        insp = MagicMock()
+        insp.active_queues.return_value = None
+        with patch("cqc_lem.utilities.maintenance._inspect", return_value=insp):
+            out = _call()
+        assert out["status"] == "degraded"
+
+    def test_unreachable_broker_is_unknown_never_healthy(self):
+        """Unmeasured is never 'healthy' — a monitor that can't tell must say so."""
+        with patch("cqc_lem.utilities.maintenance._inspect",
+                   side_effect=RuntimeError("redis down")), \
+             patch(f"{_MAIN}.log_warning") as warn:
+            out = _call()
+        assert out["status"] == "unknown"
+        assert out["workers"] == 0
+        warn.assert_called_once()
+
+    def test_never_raises(self):
+        """A monitor scraping this must get a body, not a 500 — the 500 tells it nothing."""
+        with patch("cqc_lem.utilities.maintenance._inspect", side_effect=Exception("boom")), \
+             patch(f"{_MAIN}.log_warning"):
+            assert _call()["status"] == "unknown"
+
+    def test_plain_health_stays_trivial(self):
+        """`/health` gates the blue/green flip, so it must not gain a Redis/DB/Celery dependency —
+        a deep check there would fail deploys whenever the broker hiccuped."""
+        import inspect
+        from cqc_lem.api.main import health_check
+        body = inspect.getsource(health_check)
+        for forbidden in ("_inspect", "redis", "mysql", "get_db"):
+            assert forbidden not in body


### PR DESCRIPTION
Closes the monitoring gap the **v0.118.0 outage** exposed: the worker converge aborted and left `celery_beat` plus every Celery worker in `Created`. The API stayed green for **four hours** while the whole automation pillar was dead, and nothing fired.

## Why nothing fired

Healthchecks were **already defined on all seven app services**:

| Mechanism | Why it missed |
|---|---|
| Docker `healthcheck:` | A container in `Created` **has never run**, so its healthcheck never executes |
| `restart:` policy | Acts on containers that ran and *exited* — it will not start one never started |
| `GET /health` | Returns a static literal; never touched Celery, so it honestly reported a healthy API |
| A Celery beat task | `celery_beat` was itself among the dead — **a watchdog inside the thing it watches cannot report its own outage** |

## Three layers

**1. `scripts/stack_watchdog.sh` + systemd timer (5 min), outside the container set.** Compares `compose ps -a` against `compose config --services`.

- **10-min grace** so deploys don't page — a converge plus image pull legitimately runs for minutes.
- **One bounded self-heal**: `compose start` once per incident, then alert regardless. `start`, never `up -d`, so it cannot fight a mid-converge deploy. Bounded because a container needing two starts is not a blip.
- **Replica-aware**: `selenium-node-chrome` is 8 containers under one service name; the *worst* state in the pool is recorded, so seven dead nodes can't hide behind one healthy one.
- **PostHog + SendGrid directly over HTTPS** — depends on nothing in the stack, so it still alerts when every container is down.
- **Silent when healthy.** A watchdog that chats every 5 min gets filtered, and then it isn't a watchdog.

**2. `GET /health/deep`** — reaches workers over the broker control channel.

| `status` | Meaning |
|---|---|
| `healthy` | at least one worker consuming |
| `degraded` | broker up, **nobody consuming** — the exact v0.118.0 shape |
| `unknown` | control channel unreachable. **Unmeasured is never `healthy`.** |

Never raises. `/health` stays trivial because it gates the blue/green flip — a test pins that it gains no Redis/DB/Celery dependency.

**3. External dead-man's switch** — documented in `docs/stack-watchdog.md`, **needs owner setup**. Layers 1–2 both run on the box and cannot report the box being gone.

## Verification

- Ran against the **live stack**: silent + exit 0 when healthy.
- Recovery branch exercised end-to-end: detects, reports, clears its marker.
- `bash -n` clean; full unit suite green — **9115 passed**.

## ⚠️ Owner actions after merge

1. Install the timer (`docs/stack-watchdog.md` § Install).
2. Set `WATCHDOG_ALERT_EMAIL` in `/opt/lem/.env` (falls back to `COST_ALERT_EMAIL`).
3. Point an external monitor at `/health/deep` — **assert on the JSON `status`, not just HTTP 200**, since `degraded` returns 200 by design. A status-only monitor would have missed this outage exactly as `/health` did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)