### PR TITLE
feat(marketing): affiliate reward pays per activated referral, not for joining (closes #737)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -440,8 +440,9 @@ MARKETING_OWNED_DOMAINS=
 # the user, with recorded consent.
 AFFILIATE_PROGRAM_ENABLED=True
 AFFILIATE_DEFAULT_ENROLLED=True
-# Trial days for holding affiliate status. Revoked on opt-out (the user returns to the standard trial).
-AFFILIATE_ENROLLMENT_BONUS_DAYS=7
+# Trial days for merely holding affiliate status. 0 = the reward is per-referral only (the shipped
+# policy). A non-zero value pays every enrollee and is revoked on opt-out.
+AFFILIATE_ENROLLMENT_BONUS_DAYS=0
 # Trial days per referral that ACTIVATES (not per click, not per raw signup). Never clawed back.
 AFFILIATE_REFERRAL_BONUS_DAYS=14
 # Hard ceiling on total granted days per user.

--- a/docs/affiliate-program.md
+++ b/docs/affiliate-program.md
@@ -142,8 +142,8 @@ back off the user when no reward moved), so the user is told their trial length 
 ### 3.1 Sizing the reward — what N and the cap were measured against
 
 The owner fixed the SHAPE (per-referral, capped) and asked for N and the ceiling to be proposed
-against LEM's real per-user cost and SaaS norms. This is that reasoning; the shipped defaults are
-**+14 / 90**, and both remain one env change.
+against LEM's real per-user cost and SaaS norms. This is that reasoning; the options below were put
+to them on PR #903 and **+14 / 90 was picked (2026-08-02)**. Both remain one env change.
 
 **What a trial day actually costs (measured, not assumed).** PostHog `llm_call`, the 10 days to
 2026-08-02 that carry per-user cost attribution: **mean ≈ $0.19, median ≈ $0.15, worst day $0.38 of

--- a/docs/affiliate-program.md
+++ b/docs/affiliate-program.md
@@ -1,7 +1,8 @@
 # Affiliate / Ambassador Program
 
-**Issues:** #737 (status + consent + disclosure), #770 (the (B) writer) · **Status:** built, owner
-decision applied (1A 2A 3A) · **Created:** 2026-07-27 · **Updated:** 2026-07-31
+**Issues:** #737 (status + consent + disclosure), #770 (the (B) writer) · **Status:** built; reward
+policy set by the owner's 2026-08-01 decision (per-referral, capped) · **Created:** 2026-07-27 ·
+**Updated:** 2026-08-02
 
 LEM's marketing arm is its own users. Every account joins the referral program by default, gets a
 referral link, and earns extra free-trial time for people they bring in who actually get set up.
@@ -109,14 +110,23 @@ LEM to the author's connections, are both a different risk class and neither shi
 
 ## 3. Reward mechanics
 
-Two rewards, deliberately different kinds — and the difference is what makes the opt-out honest
-rather than a dark pattern:
+**The reward pays for outcomes, not for joining** (owner decision, 2026-08-01). Holding affiliate
+status earns nothing; a referral that ACTIVATES earns trial days, up to a per-user ceiling.
 
 | Reward | Trigger | Env | Revoked on opt-out? |
 |---|---|---|---|
-| **Enrollment bonus** | Holding affiliate status | `AFFILIATE_ENROLLMENT_BONUS_DAYS` (default **7**) | **Yes** — the user returns to the standard trial |
 | **Referral bonus** | A referred user **ACTIVATES** | `AFFILIATE_REFERRAL_BONUS_DAYS` (default **14**) | **Never** — it was earned |
 | Ceiling | Total granted days per user | `AFFILIATE_MAX_REWARD_DAYS` (default **90**) | — |
+| ~~Enrollment bonus~~ | Holding affiliate status | `AFFILIATE_ENROLLMENT_BONUS_DAYS` (default **0** = off) | Yes, when configured non-zero |
+
+The enrollment bonus is kept as a knob (a launch push may want a join incentive) but ships at **0**:
+a flat join bonus pays every enrollee whether or not they ever refer anyone. Everything the machinery
+does with it — the negative ledger row, the baseline floor, the "your trial returns to the standard
+N days" copy — still works, and is exercised by tests, for any deployment that sets it.
+
+At 0 the opt-out has no reward consequence at all: leaving takes nothing away, because nothing was
+given for joining. `POST /user/affiliate/status` still reports the resulting `trial_ends_at` (read
+back off the user when no reward moved), so the user is told their trial length either way.
 
 - A referral converts on **activation** (the #500 aha moment: a published post AND automated
   engagement), not on a click and not on a raw signup. A farm of dormant accounts pays nobody.
@@ -129,37 +139,63 @@ rather than a dark pattern:
   render as a granted reward that isn't one.
 - A lapsed trial is extended from **today**, not from its past end date.
 
-### 3.1 Why these numbers (owner decision: 1A 2A 3A)
+### 3.1 Sizing the reward — what N and the cap were measured against
 
-These defaults were confirmed by the owner at merge. They remain overridable per environment, but the
-production values are fixed below.
+The owner fixed the SHAPE (per-referral, capped) and asked for N and the ceiling to be proposed
+against LEM's real per-user cost and SaaS norms. This is that reasoning; the shipped defaults are
+**+14 / 90**, and both remain one env change.
 
-**What a trial day costs us.** A trial day is variable COGS (LLM + proxy + render) against **zero**
-MRR. It is not lost revenue — a trialling user was not paying — but it is real spend and it delays
-conversion. The margin plan targets ≥70% blended gross margin and ≥60% per-user CM at 100+ users, so
-the reward has to be bounded rather than open-ended.
+**What a trial day actually costs (measured, not assumed).** PostHog `llm_call`, the 10 days to
+2026-08-02 that carry per-user cost attribution: **mean ≈ $0.19, median ≈ $0.15, worst day $0.38 of
+LLM spend per active user per day**. That is one heavily-active account (the brand user), so read it
+as the cost of a *fully engaged* trial day rather than a fleet average — the right end to size a
+giveaway from. Proxy and render ride on top and are not in that number.
 
-**What the market does.** SaaS referral programs cluster around *give one month, get one month* on
-monthly plans (Dropbox/Evernote-style storage or time grants; Notion, Airtable and most PLG B2B tools
-land in the same shape). Extra trial time is the cheapest currency available to a pre-revenue product:
-it costs COGS, not cash, it needs no payout rail, and it has no tax/1099 exposure.
+So, in variable spend:
 
-**Why 7 / 14 / 90.**
-- **+7 enrollment** — a visible, immediate "you're in" that is half the standard 14-day trial, i.e.
-  meaningful without materially changing anyone's evaluation window. Cheap enough to give everybody.
-- **+14 per activated referral** — the industry "one free month"-shaped reward, at the same size as
-  the standard trial, so it is legible ("another full trial") and it only pays for outcomes.
-- **90-day ceiling** — roughly the point at which someone is using LEM indefinitely for free.
-  Anyone who drove 6 activations is a real advocate; a conversation with them beats an unbounded grant.
+| Grant | LLM cost at $0.19/day | What it buys |
+|---|---|---|
+| +14 days (one activated referral) | ≈ **$2.70** | one more full trial's worth of evaluation |
+| 90-day cap (≈6 activated referrals) | ≈ **$17** | the ceiling on any one user's lifetime giveaway |
 
-**Alternatives the owner explicitly rejected** (kept here for reference; each is still a one-line env
-change if policy changes later):
-- *Enrollment-only* (`REFERRAL=0`): the owner's literal phrasing — affiliates simply get a longer
-  trial. Simplest to explain; rewards nothing. Rejected in favor of outcome-based rewards.
-- *Performance-only* (`ENROLLMENT=0`): nothing is given away by default, so nothing is revoked on
-  opt-out, and the whole "reduced trial" framing disappears. Weakest enrollment hook. Rejected.
-- *Bigger per-referral* (e.g. 30): stronger incentive, but 3 referrals ≈ a free quarter. Rejected
-  because the 90-day cap is the intended guardrail, not the per-referral size.
+A trial day is COGS against **zero** MRR — not lost revenue, since a trialling user was not paying,
+but real spend that also delays conversion. The margin plan targets ≥70% blended gross margin and
+≥60% per-user CM at 100+ users (`docs/cost-performance-margin-plan.md`), and a bounded ~$17 worst
+case per user sits far inside that.
+
+**What the market pays.** B2B SaaS referral programs pay the referrer **on conversion**, typically
+$50–150 in mid-market or 100–150% of first-month value; the referred account is usually given a
+trial extension or credit rather than cash; flat "join bonuses" are uncommon; and caps (per referral,
+per quarter, or tied to blended CAC) are standard practice. Against a $50–150 cash norm, ~$2.70 of
+COGS per activated referral is a rounding error — trial time is simply the cheapest currency a
+pre-revenue product has: no payout rail, no 1099 exposure, no cash out the door.
+
+**Why 14 and 90 specifically.**
+- **+14 per activated referral** — equal to the standard trial, so it is legible as "another full
+  trial", and it pays only on the #500 activation event, never on a click or a raw signup.
+- **90-day ceiling** — about the point where someone would be running LEM indefinitely for free.
+  Anyone who has driven ~6 activations is a genuine advocate, and a conversation with them (a comped
+  plan, a case study) beats an unbounded automatic grant.
+- **0 for joining** — the owner's decision: a flat enrollment bonus pays everybody regardless of
+  outcome, and it is the only thing that makes opting out cost the user anything, which is exactly
+  the dark-pattern shape the issue rules out.
+
+**The levers, if the numbers should move** (each is one env value, no code change):
+
+| | Per referral | Cap | Worst-case LLM cost/user | Trade-off |
+|---|---|---|---|---|
+| Conservative | 7 | 60 | ≈ $11 | Weakest pull; ~9 referrals to cap |
+| **Shipped** | **14** | **90** | ≈ **$17** | Legible "another full trial"; ~6 referrals to cap |
+| Aggressive | 30 | 90 | ≈ $17 | Strong pull; 3 referrals ≈ a free quarter, same ceiling |
+| Uncapped | 14 | 0/∞ | unbounded | Rejected — a referral chain becomes unbounded free service |
+
+**Alternatives considered and not shipped:**
+- *Enrollment-only* (`REFERRAL=0`) — affiliates simply get a longer trial. Simplest to explain;
+  rewards nobody for actually referring.
+- *Flat join bonus alongside the referral bonus* (the pre-2026-08-01 default, +7) — a visible
+  "you're in", but it pays every enrollee and creates the loss-framing problem on opt-out.
+- *Cash or revenue share* — the B2B norm, and the right answer once there is revenue to share; it
+  needs a payout rail, tax handling and fraud review that trial days do not.
 
 ## 4. Abuse guards
 
@@ -198,9 +234,13 @@ never wrote.
 
 Default enrollment is only fair if the user is told. The notice states what they are in, what they
 get, how to leave — and that **nothing is posted from their LinkedIn account for this**. The opt-out
-is one click, immediate, and the copy reads *"your trial returns to the standard N days"*, never
-*"you will lose N days"*: the bonus is framed as a bonus on top, so leaving is a return to normal
-rather than a punishment.
+is one click and immediate.
+
+The copy is written off `bonus_days`, not hardcoded, because the two policies say different true
+things and the wrong one is a dark pattern either way. With a join bonus configured it reads *"your
+trial returns to the standard N days"*, never *"you will lose N days"*. At the shipped 0 it says
+leaving takes nothing — *"you keep every trial day you have already earned"* — because that is what
+happens: referral days are earned and never revoked.
 
 ## 6. Analytics
 
@@ -210,6 +250,11 @@ rather than a punishment.
 `affiliate_disclosure_blocked`, plus the (B) writer's own three: `affiliate_promo_generated`,
 `affiliate_promo_published`, `affiliate_promo_blocked`. The SPA adds `referral_link_copied` and
 `affiliate_notice_acknowledged`.
+
+`affiliate_enrolled` fires on the call that **created** the enrollment row (`ensure_affiliate_enrollment`
+reports `created`), not on the join bonus being paid — with the bonus at 0 there is no grant to hang
+it on, and every Account page load calls `enroll_user`, so a create-flag is the only thing that
+counts each user once.
 
 `affiliate_promo_blocked` (generation could not produce compliant copy) and
 `affiliate_disclosure_blocked` (the publish gate caught content that arrived undisclosed) are
@@ -230,7 +275,7 @@ Inbound referral traffic is already visible on the #658 **LEM Channels** dashboa
 |---|---|---|
 | `AFFILIATE_PROGRAM_ENABLED` | `True` | Master switch. Off = no links minted, no rewards, no gate. |
 | `AFFILIATE_DEFAULT_ENROLLED` | `True` | Whether new users start enrolled in (A). |
-| `AFFILIATE_ENROLLMENT_BONUS_DAYS` | `7` | Trial days for holding status (revoked on opt-out). |
+| `AFFILIATE_ENROLLMENT_BONUS_DAYS` | `0` | Trial days for merely holding status. 0 = per-referral rewards only (shipped policy); non-zero pays every enrollee and is revoked on opt-out. |
 | `AFFILIATE_REFERRAL_BONUS_DAYS` | `14` | Trial days per **activated** referral (never revoked). |
 | `AFFILIATE_MAX_REWARD_DAYS` | `90` | Per-user ceiling on total granted days. |
 | `AFFILIATE_REQUIRE_COMPANY_PAGE` | `False` | Restrict eligibility to accounts with a company page. Evaluated live. |

--- a/docs/affiliate-program.md
+++ b/docs/affiliate-program.md
@@ -236,11 +236,31 @@ Default enrollment is only fair if the user is told. The notice states what they
 get, how to leave — and that **nothing is posted from their LinkedIn account for this**. The opt-out
 is one click and immediate.
 
-The copy is written off `bonus_days`, not hardcoded, because the two policies say different true
-things and the wrong one is a dark pattern either way. With a join bonus configured it reads *"your
-trial returns to the standard N days"*, never *"you will lose N days"*. At the shipped 0 it says
-leaving takes nothing — *"you keep every trial day you have already earned"* — because that is what
-happens: referral days are earned and never revoked.
+The copy is written off state, not hardcoded, because the two policies say different true things and
+the wrong one is a dark pattern either way. Which state matters is the part worth getting right, and
+**it is two different numbers**:
+
+| Question the copy answers | Field | Source |
+|---|---|---|
+| What does joining pay? | `bonus_days` | config (`AFFILIATE_ENROLLMENT_BONUS_DAYS`, 0 as shipped) |
+| What does leaving take back? | `revocable_bonus_days` | THIS user's standing enrollment grant in the ledger |
+
+They disagree for the cohort enrolled before 2026-08-02: joining pays 0 now, but they still hold a
++7 that `revoke_affiliate_enrollment_bonus` claws back on opt-out (it reads the ledger, never the
+config). Driving the "how to leave" line off `bonus_days` would promise those users a free exit and
+then take a week of trial off them — the same dark pattern the issue rules out, inverted. So:
+
+- `revocable_bonus_days > 0` → *"your trial returns to the standard N days"*, never *"you will lose N days"*.
+- `revocable_bonus_days == 0` → *"you keep every trial day you have already earned"*, which is exactly
+  what happens: referral days are earned and never revoked.
+
+`revocable_bonus_days` is `ENROLLMENT + REVOKED` off `get_affiliate_reward_totals` (revocations are
+negative rows) — the same arithmetic the revoke itself does, computed from totals `affiliate_state`
+already reads, so the promise and the action cannot drift apart.
+
+The post-flip confirmation is the matching half and reads the FLIP response (`reward_days`), not the
+query cache — only the response knows whether days actually moved. Every flip gets a confirmation,
+including the one where `trial_ends_at` comes back null because the account is no longer on a trial.
 
 ## 6. Analytics
 

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -3515,7 +3515,12 @@ def get_affiliate_endpoint(session_token: str) -> ResponseModel:
 def set_affiliate_status_endpoint(request: AffiliateStatusRequest) -> ResponseModel:
     """Join or leave (A). Takes effect immediately, and the response carries the resulting trial end
     date so the SPA can tell the user their new trial length in the same breath as the change —
-    opting out returns them to the standard trial, it does not take away days they EARNED."""
+    opting out returns them to the standard trial, it does not take away days they EARNED.
+
+    The date is read back off the user when the flip moved no reward, which is the ORDINARY case now
+    that the join bonus is 0: "opt-out is immediate and the user is notified of the resulting trial
+    length" cannot depend on a grant having happened."""
+    from cqc_lem.utilities.db import get_user_subscription_info
     from cqc_lem.utilities.marketing.affiliate import set_status
     user_id = get_session_user_id(request.session_token)
     if not user_id:
@@ -3523,6 +3528,8 @@ def set_affiliate_status_endpoint(request: AffiliateStatusRequest) -> ResponseMo
     result = set_status(user_id, bool(request.enrolled))
     reward = result.get("reward") or {}
     trial_ends_at = reward.get("trial_ends_at")
+    if not trial_ends_at:
+        trial_ends_at = (get_user_subscription_info(user_id) or {}).get("trial_ends_at")
     log_info(f"Affiliate status set to {'enrolled' if request.enrolled else 'opted_out'}",
              user_id=user_id)
     return ResponseModel(status_code=200, detail=_affiliate_detail(

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -3520,7 +3520,7 @@ def set_affiliate_status_endpoint(request: AffiliateStatusRequest) -> ResponseMo
     The date is read back off the user when the flip moved no reward, which is the ORDINARY case now
     that the join bonus is 0: "opt-out is immediate and the user is notified of the resulting trial
     length" cannot depend on a grant having happened."""
-    from cqc_lem.utilities.db import get_user_subscription_info
+    from cqc_lem.utilities.db import TRIAL_EXTENDABLE_STATUSES, get_user_subscription_info
     from cqc_lem.utilities.marketing.affiliate import set_status
     user_id = get_session_user_id(request.session_token)
     if not user_id:
@@ -3529,7 +3529,11 @@ def set_affiliate_status_endpoint(request: AffiliateStatusRequest) -> ResponseMo
     reward = result.get("reward") or {}
     trial_ends_at = reward.get("trial_ends_at")
     if not trial_ends_at:
-        trial_ends_at = (get_user_subscription_info(user_id) or {}).get("trial_ends_at")
+        # Only for a user who still HAS a trial — `users.trial_ends_at` outlives the trial, so a paid
+        # or cancelled account would otherwise be told "your trial still ends <a date in the past>".
+        info = get_user_subscription_info(user_id) or {}
+        if str(info.get("subscription_status") or "") in TRIAL_EXTENDABLE_STATUSES:
+            trial_ends_at = info.get("trial_ends_at")
     log_info(f"Affiliate status set to {'enrolled' if request.enrolled else 'opted_out'}",
              user_id=user_id)
     return ResponseModel(status_code=200, detail=_affiliate_detail(

--- a/src/cqc_lem/ui/src/components/AffiliateNotice.test.tsx
+++ b/src/cqc_lem/ui/src/components/AffiliateNotice.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import AffiliateNotice from './AffiliateNotice'
+
+const get = vi.fn()
+const post = vi.fn()
+
+vi.mock('../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
+  },
+}))
+vi.mock('../contexts/AuthContext', () => ({ useAuth: () => ({ sessionToken: 'tok' }) }))
+vi.mock('../utils/analytics', () => ({
+  capture: vi.fn(),
+  EVENTS: { affiliateNoticeAcknowledged: 'affiliate_notice_acknowledged' },
+}))
+
+const BASE = {
+  program_enabled: true,
+  eligible: true,
+  status: 'enrolled',
+  enrolled: true,
+  referral_code: '42',
+  referral_url: 'https://app.lem.test/signup?ref=42',
+  notice_seen_at: null,
+  referrals: { pending: 0, converted: 0, rejected: 0 },
+  days_earned: 0,
+  days_from_referrals: 0,
+  max_reward_days: 90,
+  bonus_days: 0,
+  referral_bonus_days: 14,
+  standard_trial_days: 14,
+  promo_content_opt_in: false,
+  promo_consent_at: null,
+  promo_consent_version: null,
+  promo_content_allowed: false,
+  disclosure_text: '#ad — I get free trial time for referrals.',
+}
+
+function payload(data: unknown) {
+  return { data: { detail: data } }
+}
+
+function harness(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>
+  )
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('AffiliateNotice (issue #737)', () => {
+  it('tells a default-enrolled user what they get and that nothing is posted for them', async () => {
+    get.mockResolvedValue(payload(BASE))
+    const { container } = harness(<AffiliateNotice />)
+    await waitFor(() => expect(screen.getByTestId('affiliate-notice')).toBeTruthy())
+    expect(container.textContent).toContain('14 extra trial days')
+    expect(container.textContent).toContain('Nothing is posted from your LinkedIn account')
+  })
+
+  it('promises no join bonus, and says leaving costs nothing, when the reward is per-referral only', async () => {
+    get.mockResolvedValue(payload(BASE))
+    const { container } = harness(<AffiliateNotice />)
+    await waitFor(() => expect(screen.getByTestId('affiliate-notice')).toBeTruthy())
+    expect(container.textContent).not.toContain('0 bonus trial days')
+    expect(container.textContent).toContain('You keep every trial day you have already earned')
+  })
+
+  it('frames the opt-out as a return to the standard trial when a join bonus IS configured', async () => {
+    get.mockResolvedValue(payload({ ...BASE, bonus_days: 7 }))
+    const { container } = harness(<AffiliateNotice />)
+    await waitFor(() => expect(screen.getByTestId('affiliate-notice')).toBeTruthy())
+    expect(container.textContent).toContain('7 bonus trial days for joining')
+    expect(container.textContent).toContain('returns to the standard 14 days')
+    expect(container.textContent).not.toContain('lose')
+  })
+
+  it('stays hidden once acknowledged, and acknowledges on Got it', async () => {
+    get.mockResolvedValue(payload({ ...BASE, notice_seen_at: '2026-08-01T00:00:00Z' }))
+    const { container } = harness(<AffiliateNotice />)
+    await waitFor(() => expect(container.innerHTML).toBe(''))
+
+    cleanup()
+    get.mockResolvedValue(payload(BASE))
+    post.mockResolvedValue(payload({ ...BASE, notice_seen_at: '2026-08-02T00:00:00Z' }))
+    harness(<AffiliateNotice />)
+    await waitFor(() => expect(screen.getByText('Got it')).toBeTruthy())
+    fireEvent.click(screen.getByText('Got it'))
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith('/user/affiliate/notice', { session_token: 'tok' })
+    )
+  })
+})

--- a/src/cqc_lem/ui/src/components/AffiliateNotice.test.tsx
+++ b/src/cqc_lem/ui/src/components/AffiliateNotice.test.tsx
@@ -93,8 +93,9 @@ describe('AffiliateNotice (issue #737)', () => {
 
   it('stays hidden once acknowledged, and acknowledges on Got it', async () => {
     get.mockResolvedValue(payload({ ...BASE, notice_seen_at: '2026-08-01T00:00:00Z' }))
-    const { container } = harness(<AffiliateNotice />)
-    await waitFor(() => expect(container.innerHTML).toBe(''))
+    harness(<AffiliateNotice />)
+    await waitFor(() => expect(get).toHaveBeenCalled())
+    expect(screen.queryByTestId('affiliate-notice')).toBeNull()
 
     cleanup()
     get.mockResolvedValue(payload(BASE))

--- a/src/cqc_lem/ui/src/components/AffiliateNotice.test.tsx
+++ b/src/cqc_lem/ui/src/components/AffiliateNotice.test.tsx
@@ -33,6 +33,7 @@ const BASE = {
   days_from_referrals: 0,
   max_reward_days: 90,
   bonus_days: 0,
+  revocable_bonus_days: 0,
   referral_bonus_days: 14,
   standard_trial_days: 14,
   promo_content_opt_in: false,
@@ -83,10 +84,23 @@ describe('AffiliateNotice (issue #737)', () => {
   })
 
   it('frames the opt-out as a return to the standard trial when a join bonus IS configured', async () => {
-    get.mockResolvedValue(payload({ ...BASE, bonus_days: 7 }))
+    get.mockResolvedValue(payload({ ...BASE, bonus_days: 7, revocable_bonus_days: 7 }))
     const { container } = harness(<AffiliateNotice />)
     await waitFor(() => expect(screen.getByTestId('affiliate-notice')).toBeTruthy())
     expect(container.textContent).toContain('7 bonus trial days for joining')
+    expect(container.textContent).toContain('returns to the standard 14 days')
+    expect(container.textContent).not.toContain('lose')
+  })
+
+  // The cohort enrolled before the reward policy flipped: joining pays 0 now, but they still HOLD
+  // a +7 grant that opting out claws back. Driving this line off `bonus_days` would promise them a
+  // free exit and then take a week of trial off them.
+  it('warns the grandfathered cohort that leaving still returns them to the standard trial', async () => {
+    get.mockResolvedValue(payload({ ...BASE, bonus_days: 0, revocable_bonus_days: 7 }))
+    const { container } = harness(<AffiliateNotice />)
+    await waitFor(() => expect(screen.getByTestId('affiliate-notice')).toBeTruthy())
+    expect(container.textContent).not.toContain('0 bonus trial days')
+    expect(container.textContent).not.toContain('You keep every trial day you have already earned')
     expect(container.textContent).toContain('returns to the standard 14 days')
     expect(container.textContent).not.toContain('lose')
   })

--- a/src/cqc_lem/ui/src/components/AffiliateNotice.tsx
+++ b/src/cqc_lem/ui/src/components/AffiliateNotice.tsx
@@ -44,7 +44,10 @@ export default function AffiliateNotice() {
           Settings → Billing → Affiliate program
         </Link>
         .{' '}
-        {data.bonus_days > 0
+        {/* What leaving costs is the user's OWN standing join grant, not the configured bonus:
+            an account enrolled under the old defaults still has one to give back after the config
+            went to 0, and promising them otherwise right before the click is a misstatement. */}
+        {data.revocable_bonus_days > 0
           ? `Your trial simply returns to the standard ${data.standard_trial_days} days.`
           : 'You keep every trial day you have already earned.'}
       </p>

--- a/src/cqc_lem/ui/src/components/AffiliateNotice.tsx
+++ b/src/cqc_lem/ui/src/components/AffiliateNotice.tsx
@@ -26,7 +26,7 @@ export default function AffiliateNotice() {
       <p className="text-sm font-semibold text-blue-900">
         {data.bonus_days > 0
           ? `🎉 You're in the LEM affiliate program — and your trial is ${data.bonus_days} days longer`
-          : '🎉 You’re in the LEM affiliate program — earn extra trial time for anyone you refer'}
+          : `🎉 You're in the LEM affiliate program — earn extra trial time for anyone you refer`}
       </p>
       <p className="mt-1 text-sm text-blue-800">
         Every LEM account joins automatically. You get a referral link

--- a/src/cqc_lem/ui/src/components/AffiliateNotice.tsx
+++ b/src/cqc_lem/ui/src/components/AffiliateNotice.tsx
@@ -24,12 +24,15 @@ export default function AffiliateNotice() {
   return (
     <div className="bg-blue-50 border border-blue-200 rounded-lg p-4" data-testid="affiliate-notice">
       <p className="text-sm font-semibold text-blue-900">
-        🎉 You're in the LEM affiliate program — and your trial is {data.bonus_days} days longer
+        {data.bonus_days > 0
+          ? `🎉 You're in the LEM affiliate program — and your trial is ${data.bonus_days} days longer`
+          : '🎉 You’re in the LEM affiliate program — earn extra trial time for anyone you refer'}
       </p>
       <p className="mt-1 text-sm text-blue-800">
-        Every LEM account joins automatically. You get a referral link, {data.bonus_days} bonus trial
-        days for joining, and {data.referral_bonus_days} more each time someone who signs up through
-        your link gets set up and posting (up to {data.max_reward_days} days).
+        Every LEM account joins automatically. You get a referral link
+        {data.bonus_days > 0 ? `, ${data.bonus_days} bonus trial days for joining,` : ','} and{' '}
+        {data.referral_bonus_days} extra trial days each time someone who signs up through your link
+        gets set up and posting (up to {data.max_reward_days} days).
       </p>
       <p className="mt-2 text-sm text-blue-800">
         Nothing is posted from your LinkedIn account for this. Promoting LEM from your own account is
@@ -40,7 +43,10 @@ export default function AffiliateNotice() {
         <Link to="/account?section=billing" className="underline font-medium">
           Settings → Billing → Affiliate program
         </Link>
-        . Your trial simply returns to the standard {data.standard_trial_days} days.
+        .{' '}
+        {data.bonus_days > 0
+          ? `Your trial simply returns to the standard ${data.standard_trial_days} days.`
+          : 'You keep every trial day you have already earned.'}
       </p>
       <button
         type="button"

--- a/src/cqc_lem/ui/src/hooks/useAffiliate.ts
+++ b/src/cqc_lem/ui/src/hooks/useAffiliate.ts
@@ -18,7 +18,12 @@ export interface AffiliateState {
   days_earned: number
   days_from_referrals: number
   max_reward_days: number
+  // What joining pays TODAY (config) vs what leaving would actually take back from THIS user
+  // (their standing enrollment grant). Not the same number: a user enrolled under the old defaults
+  // still holds a revocable +7 after the config went to 0, so "what you get" copy reads the first
+  // and "what leaving costs" copy MUST read the second.
   bonus_days: number
+  revocable_bonus_days: number
   referral_bonus_days: number
   standard_trial_days: number
   promo_content_opt_in: boolean

--- a/src/cqc_lem/ui/src/hooks/useAffiliate.ts
+++ b/src/cqc_lem/ui/src/hooks/useAffiliate.ts
@@ -26,9 +26,15 @@ export interface AffiliateState {
   promo_consent_version: string | null
   promo_content_allowed: boolean
   disclosure_text: string
-  // Present only on the response to a status change — what the flip actually did to the trial.
-  reward_days?: number
-  trial_ends_at?: string | null
+}
+
+// What a status FLIP did to the trial. Deliberately NOT on `AffiliateState`: the GET never returns
+// these, and the flip seeds the query cache and then invalidates it, so anything reading them off
+// `useAffiliate().data` is right for one render and wrong after the refetch. Keeping them off the
+// query type makes that a compile error instead of copy that changes under the user.
+export interface AffiliateStatusResult extends AffiliateState {
+  reward_days: number
+  trial_ends_at: string | null
 }
 
 const KEY = 'affiliate'
@@ -53,7 +59,7 @@ export function useSetAffiliateStatus() {
     mutationFn: (enrolled: boolean) =>
       api
         .post('/user/affiliate/status', { session_token: sessionToken, enrolled })
-        .then((r) => r.data.detail as AffiliateState),
+        .then((r) => r.data.detail as AffiliateStatusResult),
     onSuccess: (data) => {
       // Seed the cache from the response rather than only invalidating: the new trial end date is
       // what the confirmation copy reads, and a refetch would show it a beat late.

--- a/src/cqc_lem/ui/src/pages/account/AffiliateCard.test.tsx
+++ b/src/cqc_lem/ui/src/pages/account/AffiliateCard.test.tsx
@@ -144,6 +144,35 @@ describe('AffiliateCard (issue #737)', () => {
     expect(screen.getAllByRole('switch')).toHaveLength(1)
   })
 
+  // The two opt-out confirmations, driven off the MUTATION result rather than the query cache.
+  // Which one is right depends on whether the flip actually clawed days back, and only the flip
+  // response knows that — the #750 cohort holds a +7 enrollment grant that IS revoked, while a
+  // user under the shipped per-referral policy loses nothing.
+  async function optOut(flip: Record<string, unknown>) {
+    get.mockResolvedValue(payload(BASE))
+    post.mockResolvedValue(
+      payload({ ...BASE, enrolled: false, status: 'opted_out', referral_url: '', ...flip })
+    )
+    const { container } = harness(<AffiliateCard />)
+    await waitFor(() => expect(screen.getAllByRole('switch')).toHaveLength(2))
+    fireEvent.click(screen.getAllByRole('switch')[0])
+    await waitFor(() => expect(screen.getByTestId('affiliate-trial-note')).toBeTruthy())
+    return container
+  }
+
+  it('tells a user whose join bonus WAS revoked that they return to the standard trial', async () => {
+    const container = await optOut({ reward_days: 7, trial_ends_at: '2026-08-16T00:00:00Z' })
+    expect(container.textContent).toContain('returns to the standard 14 days')
+    expect(container.textContent).not.toContain('you keep the trial days you earned')
+  })
+
+  it('tells a user who lost nothing that they keep the days they earned', async () => {
+    const container = await optOut({ reward_days: 0, trial_ends_at: '2026-08-30T00:00:00Z' })
+    expect(container.textContent).toContain('you keep the trial days you earned')
+    expect(container.textContent).not.toContain('returns to the standard')
+    expect(container.textContent).not.toContain('lose')
+  })
+
   it('never advertises a join bonus when the reward is per-referral only', async () => {
     get.mockResolvedValue(
       payload({ ...BASE, bonus_days: 0, enrolled: false, status: 'opted_out', referral_url: '' })

--- a/src/cqc_lem/ui/src/pages/account/AffiliateCard.test.tsx
+++ b/src/cqc_lem/ui/src/pages/account/AffiliateCard.test.tsx
@@ -144,6 +144,18 @@ describe('AffiliateCard (issue #737)', () => {
     expect(screen.getAllByRole('switch')).toHaveLength(1)
   })
 
+  it('never advertises a join bonus when the reward is per-referral only', async () => {
+    get.mockResolvedValue(
+      payload({ ...BASE, bonus_days: 0, enrolled: false, status: 'opted_out', referral_url: '' })
+    )
+    const { container } = harness(<AffiliateCard />)
+    await waitFor(() =>
+      expect(container.textContent).toContain('14 extra trial days for each person you refer')
+    )
+    expect(container.textContent).not.toContain('0 bonus trial days')
+    expect(container.textContent).not.toContain('lose')
+  })
+
   it('explains the company-page boundary rather than showing an empty card', async () => {
     get.mockResolvedValue(
       payload({ ...BASE, eligible: false, status: 'ineligible', enrolled: false })

--- a/src/cqc_lem/ui/src/pages/account/AffiliateCard.test.tsx
+++ b/src/cqc_lem/ui/src/pages/account/AffiliateCard.test.tsx
@@ -32,6 +32,7 @@ const BASE = {
   days_from_referrals: 28,
   max_reward_days: 90,
   bonus_days: 7,
+  revocable_bonus_days: 7,
   referral_bonus_days: 14,
   standard_trial_days: 14,
   promo_content_opt_in: false,
@@ -170,6 +171,15 @@ describe('AffiliateCard (issue #737)', () => {
     const container = await optOut({ reward_days: 0, trial_ends_at: '2026-08-30T00:00:00Z' })
     expect(container.textContent).toContain('you keep the trial days you earned')
     expect(container.textContent).not.toContain('returns to the standard')
+    expect(container.textContent).not.toContain('lose')
+  })
+
+  // A user who is no longer on a trial gets no date back (quoting a stale one would be worse), and
+  // a toggle that moves with no acknowledgement at all is not "the user is notified".
+  it('still confirms the flip when there is no trial date to report', async () => {
+    const container = await optOut({ reward_days: 0, trial_ends_at: null })
+    expect(container.textContent).toContain("You've left the program")
+    expect(container.textContent).not.toContain('still ends')
     expect(container.textContent).not.toContain('lose')
   })
 

--- a/src/cqc_lem/ui/src/pages/account/AffiliateCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/AffiliateCard.tsx
@@ -183,17 +183,20 @@ export default function AffiliateCard() {
 
       {data.eligible && !data.enrolled && (
         <p className="text-sm text-gray-600">
-          You are not in the affiliate program. Your trial is the standard{' '}
-          {data.standard_trial_days} days. Join any time to get your referral link back and{' '}
-          {data.bonus_days} bonus trial days.
+          You are not in the affiliate program.{' '}
+          {data.bonus_days > 0
+            ? `Your trial is the standard ${data.standard_trial_days} days. Join any time to get your referral link back and ${data.bonus_days} bonus trial days.`
+            : `Join any time to get your referral link back and earn ${data.referral_bonus_days} extra trial days for each person you refer.`}
         </p>
       )}
 
       {setStatus.isSuccess && trialEnds && (
         <p className="text-sm font-medium text-green-600" data-testid="affiliate-trial-note">
           {data.enrolled
-            ? `Joined — your trial now runs to ${trialEnds}.`
-            : `You've left the program — your trial returns to the standard ${data.standard_trial_days} days, ending ${trialEnds}.`}
+            ? `Joined — your trial runs to ${trialEnds}.`
+            : (data.reward_days ?? 0) > 0
+              ? `You've left the program — your trial returns to the standard ${data.standard_trial_days} days, ending ${trialEnds}.`
+              : `You've left the program — you keep the trial days you earned, so your trial still ends ${trialEnds}.`}
         </p>
       )}
       {(setStatus.isError || setPromo.isError) && (

--- a/src/cqc_lem/ui/src/pages/account/AffiliateCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/AffiliateCard.tsx
@@ -40,8 +40,12 @@ export default function AffiliateCard() {
     }
   }
 
-  const trialEnds = data.trial_ends_at
-    ? new Date(data.trial_ends_at).toLocaleDateString(undefined, {
+  // The confirmation line reads the MUTATION result, never the query cache: only the flip response
+  // knows whether days actually moved, and the invalidate that follows it replaces the cache with
+  // the GET shape (no reward_days, no trial_ends_at) a beat later.
+  const flip = setStatus.data
+  const trialEnds = flip?.trial_ends_at
+    ? new Date(flip.trial_ends_at).toLocaleDateString(undefined, {
         year: 'numeric',
         month: 'short',
         day: 'numeric',
@@ -190,12 +194,12 @@ export default function AffiliateCard() {
         </p>
       )}
 
-      {setStatus.isSuccess && trialEnds && (
+      {flip && trialEnds && (
         <p className="text-sm font-medium text-green-600" data-testid="affiliate-trial-note">
-          {data.enrolled
+          {flip.enrolled
             ? `Joined — your trial runs to ${trialEnds}.`
-            : (data.reward_days ?? 0) > 0
-              ? `You've left the program — your trial returns to the standard ${data.standard_trial_days} days, ending ${trialEnds}.`
+            : flip.reward_days > 0
+              ? `You've left the program — your trial returns to the standard ${flip.standard_trial_days} days, ending ${trialEnds}.`
               : `You've left the program — you keep the trial days you earned, so your trial still ends ${trialEnds}.`}
         </p>
       )}

--- a/src/cqc_lem/ui/src/pages/account/AffiliateCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/AffiliateCard.tsx
@@ -194,13 +194,20 @@ export default function AffiliateCard() {
         </p>
       )}
 
-      {flip && trialEnds && (
+      {/* A flip ALWAYS gets a confirmation. `trial_ends_at` is deliberately empty for an account
+          that is no longer on a trial (a paid or cancelled user must not be quoted a stale date),
+          and a toggle that moves with no acknowledgement at all is the silent half of that fix. */}
+      {flip && (
         <p className="text-sm font-medium text-green-600" data-testid="affiliate-trial-note">
           {flip.enrolled
-            ? `Joined — your trial runs to ${trialEnds}.`
-            : flip.reward_days > 0
-              ? `You've left the program — your trial returns to the standard ${flip.standard_trial_days} days, ending ${trialEnds}.`
-              : `You've left the program — you keep the trial days you earned, so your trial still ends ${trialEnds}.`}
+            ? trialEnds
+              ? `Joined — your trial runs to ${trialEnds}.`
+              : `Joined — your referral link is ready.`
+            : !trialEnds
+              ? `You've left the program — your subscription is unchanged.`
+              : flip.reward_days > 0
+                ? `You've left the program — your trial returns to the standard ${flip.standard_trial_days} days, ending ${trialEnds}.`
+                : `You've left the program — you keep the trial days you earned, so your trial still ends ${trialEnds}.`}
         </p>
       )}
       {(setStatus.isError || setPromo.isError) && (

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -10264,7 +10264,9 @@ EARLY_ADOPTER_COHORTS = ("P0", "P1")
 
 # Statuses an extension may act on. A paying ('active'/'past_due') or churned ('cancelled') user is
 # not on a trial, so extending one would either be a no-op or silently reopen a closed account.
-_EXTENDABLE_STATUSES = ("trial", "inactive")
+# The subscription statuses for which `users.trial_ends_at` is a live date rather than a leftover:
+# a paid or cancelled account carries an old value that must never be extended or quoted back.
+TRIAL_EXTENDABLE_STATUSES = ("trial", "inactive")
 
 
 def _as_naive_utc(dt: Optional[datetime]) -> Optional[datetime]:
@@ -10378,7 +10380,7 @@ def extend_trial_for_user(user_id: int, feedback_id: Optional[int] = None) -> di
         if not user:
             connection.rollback()
             return _result(False, "user_not_found")
-        if user["subscription_status"] not in _EXTENDABLE_STATUSES:
+        if user["subscription_status"] not in TRIAL_EXTENDABLE_STATUSES:
             connection.rollback()
             return _result(False, "not_on_trial")
 
@@ -10456,7 +10458,10 @@ def _affiliate_row(row: Optional[dict]) -> Optional[dict]:
 
 
 def get_affiliate_enrollment(user_id: int) -> Optional[dict]:
-    """The user's affiliate row, or None when they have never been enrolled."""
+    """The user's affiliate row, or None when they have never been enrolled.
+
+    The row here carries columns only — no `created` key. That flag exists solely on what
+    `ensure_affiliate_enrollment` returns, because only the call that wrote the row can know it."""
     connection = get_db_connection()
     cursor = connection.cursor(dictionary=True)
     try:
@@ -10485,7 +10490,12 @@ def ensure_affiliate_enrollment(user_id: int, status: str = 'enrolled',
 
     The returned row carries `created` — whether THIS call is the one that enrolled them. Every
     Account page load calls this, so it is the only way the caller can emit an enrollment event once
-    instead of on every render."""
+    instead of on every render. It is a synthetic key, not a column: `get_affiliate_enrollment`
+    never sets it, and nothing that serializes the row to a client reads it (`affiliate_state`
+    builds its payload field by field).
+
+    On a DB error this returns None, so a caller can never read `created=False` from a write that
+    did not happen — the row will not exist either, and the next call re-inserts it."""
     code = str(referral_code or user_id)
     connection = get_db_connection()
     cursor = connection.cursor()
@@ -10781,7 +10791,7 @@ def grant_affiliate_trial_days(user_id: int, days: int, kind: str,
         if not user:
             connection.rollback()
             return _result(False, "user_not_found")
-        if user["subscription_status"] not in _EXTENDABLE_STATUSES:
+        if user["subscription_status"] not in TRIAL_EXTENDABLE_STATUSES:
             connection.rollback()
             return _result(False, "not_on_trial", 0, already)
 

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -10481,10 +10481,15 @@ def ensure_affiliate_enrollment(user_id: int, status: str = 'enrolled',
 
     Idempotent by INSERT IGNORE rather than read-then-write: two requests racing on a first page
     load must not produce two rows or a duplicate-key 500. An existing row is never re-statused
-    here — an opted-out user staying opted out is the entire point of the opt-out."""
+    here — an opted-out user staying opted out is the entire point of the opt-out.
+
+    The returned row carries `created` — whether THIS call is the one that enrolled them. Every
+    Account page load calls this, so it is the only way the caller can emit an enrollment event once
+    instead of on every render."""
     code = str(referral_code or user_id)
     connection = get_db_connection()
     cursor = connection.cursor()
+    created = False
     try:
         cursor.execute(
             "INSERT IGNORE INTO affiliate_enrollments (user_id, status, referral_code, enrolled_at) "
@@ -10492,6 +10497,7 @@ def ensure_affiliate_enrollment(user_id: int, status: str = 'enrolled',
             (user_id, str(status), code,
              datetime.now(timezone.utc) if str(status) == str(AffiliateStatus.ENROLLED) else None),
         )
+        created = cursor.rowcount == 1
         connection.commit()
     except mysql.connector.Error as err:
         log_error("Could not create affiliate enrollment", exc=err, user_id=user_id)
@@ -10499,7 +10505,10 @@ def ensure_affiliate_enrollment(user_id: int, status: str = 'enrolled',
     finally:
         cursor.close()
         connection.close()
-    return get_affiliate_enrollment(user_id)
+    row = get_affiliate_enrollment(user_id)
+    if row is not None:
+        row["created"] = created
+    return row
 
 
 def set_affiliate_status(user_id: int, enrolled: bool) -> Optional[dict]:

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -264,9 +264,12 @@ MARKETING_OWNED_DOMAINS   = get_constant_from_env('MARKETING_OWNED_DOMAINS', def
 #       var that can turn it on for anybody, which is why (B) has no default here at all.
 AFFILIATE_PROGRAM_ENABLED = isTrue(get_constant_from_env('AFFILIATE_PROGRAM_ENABLED', default_value='True'))
 AFFILIATE_DEFAULT_ENROLLED = isTrue(get_constant_from_env('AFFILIATE_DEFAULT_ENROLLED', default_value='True'))
-# Trial days granted for BEING enrolled — the owner's model ("affiliates receive additional free
-# trial time"). Revoked on opt-out, which is what returns the user to the standard trial.
-AFFILIATE_ENROLLMENT_BONUS_DAYS = int(get_constant_from_env('AFFILIATE_ENROLLMENT_BONUS_DAYS', default_value='7'))
+# Trial days granted for BEING enrolled. OFF by default (owner decision 2026-08-01): the reward is
+# per-referral and capped, because a flat join bonus pays every enrollee whether or not they ever
+# refer anyone. Left as a knob rather than deleted — a launch push may want a join incentive — but a
+# non-zero value here is a giveaway to the whole user base, and it is revoked on opt-out, which is
+# the only thing that makes the "your trial returns to the standard N days" copy necessary.
+AFFILIATE_ENROLLMENT_BONUS_DAYS = int(get_constant_from_env('AFFILIATE_ENROLLMENT_BONUS_DAYS', default_value='0'))
 # Trial days per referral that ACTIVATES (not per click, not per raw signup). Earned, so opting out
 # never claws these back.
 AFFILIATE_REFERRAL_BONUS_DAYS = int(get_constant_from_env('AFFILIATE_REFERRAL_BONUS_DAYS', default_value='14'))

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -269,7 +269,8 @@ AFFILIATE_DEFAULT_ENROLLED = isTrue(get_constant_from_env('AFFILIATE_DEFAULT_ENR
 # refer anyone. Left as a knob rather than deleted — a launch push may want a join incentive — but a
 # non-zero value here is a giveaway to the whole user base, and it is revoked on opt-out, which is
 # the only thing that makes the "your trial returns to the standard N days" copy necessary.
-AFFILIATE_ENROLLMENT_BONUS_DAYS = int(get_constant_from_env('AFFILIATE_ENROLLMENT_BONUS_DAYS', default_value='0'))
+# max(0, …) so a negative typo reads as "off" rather than silently skipping the > 0 guard everywhere.
+AFFILIATE_ENROLLMENT_BONUS_DAYS = max(0, int(get_constant_from_env('AFFILIATE_ENROLLMENT_BONUS_DAYS', default_value='0')))
 # Trial days per referral that ACTIVATES (not per click, not per raw signup). Earned, so opting out
 # never claws these back.
 AFFILIATE_REFERRAL_BONUS_DAYS = int(get_constant_from_env('AFFILIATE_REFERRAL_BONUS_DAYS', default_value='14'))

--- a/src/cqc_lem/utilities/marketing/affiliate.py
+++ b/src/cqc_lem/utilities/marketing/affiliate.py
@@ -303,6 +303,10 @@ def enroll_user(user_id: int, grant_bonus: bool = True) -> dict:
     paid a bonus: with no join bonus there is no grant to hang it on, and enrollment is exactly the
     thing the marketing funnel needs counted.
 
+    That is deliberately ONCE PER USER, not once per enrollment: a user who opts out and re-joins
+    does not emit it again from here (`set_status` emits its own `affiliate_enrolled` with
+    `source="opt_in"` for that flip). Read the funnel's count as distinct users enrolled.
+
     Returns the enrollment row, or `{}` when the program is off / the user is ineligible."""
     from cqc_lem.utilities.db import ensure_affiliate_enrollment, grant_affiliate_trial_days
     from cqc_lem.utilities.observability import AFFILIATE_ENROLLED, track_affiliate_event

--- a/src/cqc_lem/utilities/marketing/affiliate.py
+++ b/src/cqc_lem/utilities/marketing/affiliate.py
@@ -467,7 +467,16 @@ def affiliate_state(user_id: int) -> dict:
     referral counts, days earned against the cap, and the two toggles with their consent record.
 
     `standard_trial_days` and `bonus_days` ride along on purpose — the opt-out copy has to be able
-    to say "your trial returns to the standard N days" rather than "you will lose N days"."""
+    to say "your trial returns to the standard N days" rather than "you will lose N days".
+
+    `revocable_bonus_days` is the OTHER half of that, and the two are not the same number:
+    `bonus_days` is config (what joining pays TODAY, 0 under the shipped policy) while
+    `revocable_bonus_days` is this user's own standing enrollment grant (what leaving would actually
+    take back). A user enrolled under the #750 defaults holds +7 that `revoke_affiliate_enrollment_bonus`
+    still claws back after the config went to 0 — telling them "you keep every trial day you have
+    already earned" off the config value would be a factual misstatement made right before an
+    irreversible click. Same arithmetic as the revoke does (ENROLLMENT + REVOKED, revocations being
+    negative), off totals already read here, so it costs no extra query."""
     from cqc_lem.utilities.db import (get_affiliate_enrollment, get_affiliate_referral_counts,
                                       get_affiliate_reward_totals)
     from cqc_lem.utilities.env_constants import FREE_TRIAL_DAYS
@@ -491,6 +500,8 @@ def affiliate_state(user_id: int) -> dict:
         "days_from_referrals": max(0, int(totals.get("referral") or 0)),
         "max_reward_days": max_reward_days(),
         "bonus_days": enrollment_bonus_days(),
+        "revocable_bonus_days": max(0, int(totals.get("enrollment") or 0)
+                                    + int(totals.get("revoked") or 0)),
         "referral_bonus_days": referral_bonus_days(),
         "standard_trial_days": int(FREE_TRIAL_DAYS),
         "promo_content_opt_in": bool(enrollment.get("promo_content_opt_in")),

--- a/src/cqc_lem/utilities/marketing/affiliate.py
+++ b/src/cqc_lem/utilities/marketing/affiliate.py
@@ -295,8 +295,13 @@ def _company_page(user_id: int) -> bool:
 
 
 def enroll_user(user_id: int, grant_bonus: bool = True) -> dict:
-    """Enrol a user in (A) and pay the enrollment bonus. Idempotent: an existing row is left alone
-    (an opted-out user is NOT re-enrolled by a page load) and the bonus grant is a no-op once paid.
+    """Enrol a user in (A), and pay the enrollment bonus if one is configured (it is 0 by default —
+    the reward is per-referral). Idempotent: an existing row is left alone (an opted-out user is NOT
+    re-enrolled by a page load) and the bonus grant is a no-op once paid.
+
+    `affiliate_enrolled` is emitted on the call that actually CREATED the row, not on the one that
+    paid a bonus: with no join bonus there is no grant to hang it on, and enrollment is exactly the
+    thing the marketing funnel needs counted.
 
     Returns the enrollment row, or `{}` when the program is off / the user is ineligible."""
     from cqc_lem.utilities.db import ensure_affiliate_enrollment, grant_affiliate_trial_days
@@ -309,13 +314,15 @@ def enroll_user(user_id: int, grant_bonus: bool = True) -> dict:
                                              referral_code=code_for_user(user_id)) or {}
     if status != STATUS_ENROLLED or enrollment.get("status") != STATUS_ENROLLED:
         return enrollment
+    result: dict = {}
     if grant_bonus and enrollment_bonus_days() > 0:
         result = grant_affiliate_trial_days(user_id, enrollment_bonus_days(), REWARD_ENROLLMENT,
-                                            reason="enrollment_bonus")
-        if result.get("granted") and result.get("reason") == "granted":
-            track_affiliate_event(AFFILIATE_ENROLLED, user_id=user_id,
-                                  bonus_days=result.get("days"),
-                                  trial_ends_at=str(result.get("trial_ends_at") or ""))
+                                            reason="enrollment_bonus") or {}
+    paid = bool(result.get("granted")) and result.get("reason") == "granted"
+    if enrollment.get("created") or paid:
+        track_affiliate_event(AFFILIATE_ENROLLED, user_id=user_id,
+                              bonus_days=int(result.get("days") or 0),
+                              trial_ends_at=str(result.get("trial_ends_at") or ""))
     return enrollment
 
 

--- a/tests/integration/test_affiliate_api.py
+++ b/tests/integration/test_affiliate_api.py
@@ -242,6 +242,13 @@ def _post(client, path, **body):
     return r
 
 
+def _iso(dt):
+    """The endpoint's own serializer — asserting against it pins the SHAPE the SPA parses, which is
+    the thing that would silently differ if the two producers of `trial_ends_at` ever diverged."""
+    from cqc_lem.api.main import _utc_iso
+    return _utc_iso(dt)
+
+
 def test_user_is_enrolled_by_default_with_a_link_and_the_bonus(client, env, store):
     detail = _get(client)
     assert detail["enrolled"] is True and detail["status"] == "enrolled"
@@ -416,5 +423,33 @@ def test_opt_out_takes_nothing_away_but_still_reports_the_trial_length(client, e
     detail = _post(client, "/status", enrolled=False).json()["detail"]
     assert detail["enrolled"] is False
     assert detail["reward_days"] == 0                    # nothing was clawed back
-    assert detail["trial_ends_at"] is not None           # read back off the user, not off a grant
     assert store.trial_days() == 28                      # the earned referral days survive
+    # The exact date the user is holding, in the same explicit-UTC shape the reward branch emits —
+    # both producers go through `_utc_iso`, and the SPA renders whichever one answered.
+    assert detail["trial_ends_at"] == _iso(store.users[USER]["trial_ends_at"])
+
+
+def test_the_reward_date_wins_over_the_user_record_when_a_grant_actually_moved(client, env, store):
+    """`env` configures the 7-day join bonus, so opting out revokes — and the date the user is told
+    must be the one the revoke computed, not a re-read that could race it."""
+    _get(client)
+    assert store.trial_days() == 21
+
+    detail = _post(client, "/status", enrolled=False).json()["detail"]
+    assert detail["reward_days"] == 7
+    assert detail["trial_ends_at"] == _iso(store.users[USER]["trial_ends_at"])
+    assert store.trial_days() == 14
+
+
+def test_a_user_who_is_no_longer_on_a_trial_is_not_quoted_a_stale_trial_date(client,
+                                                                            env_no_join_bonus,
+                                                                            store):
+    """`users.trial_ends_at` outlives the trial. A paid account opting out must not be told "your
+    trial still ends <a date in the past>" — with no grant to report, the field stays null."""
+    _get(client)
+    store.users[USER]["subscription_status"] = "active"
+
+    detail = _post(client, "/status", enrolled=False).json()["detail"]
+    assert detail["enrolled"] is False
+    assert detail["reward_days"] == 0
+    assert detail["trial_ends_at"] is None

--- a/tests/integration/test_affiliate_api.py
+++ b/tests/integration/test_affiliate_api.py
@@ -9,6 +9,7 @@ end date immediately, a self-referral that pays nobody — and none of those are
 storage layer is a mock that returns whatever the test says.
 """
 from datetime import datetime, timedelta
+from typing import Optional
 
 import pytest
 from unittest.mock import patch
@@ -242,7 +243,7 @@ def _post(client, path, **body):
     return r
 
 
-def _iso(dt):
+def _iso(dt: Optional[datetime]) -> Optional[str]:
     """The endpoint's own serializer — asserting against it pins the SHAPE the SPA parses, which is
     the thing that would silently differ if the two producers of `trial_ends_at` ever diverged."""
     from cqc_lem.api.main import _utc_iso
@@ -453,3 +454,35 @@ def test_a_user_who_is_no_longer_on_a_trial_is_not_quoted_a_stale_trial_date(cli
     assert detail["enrolled"] is False
     assert detail["reward_days"] == 0
     assert detail["trial_ends_at"] is None
+
+
+def test_the_grandfathered_join_bonus_is_reported_as_revocable_after_the_policy_flips(client, env,
+                                                                                     store):
+    """The #750 cohort: enrolled while the join bonus was 7, still holding it after the config went
+    to 0. `bonus_days` (what joining pays now) and `revocable_bonus_days` (what leaving takes back
+    from THIS user) must disagree — the enrollment notice's "leave in one click" line reads the
+    second, and reading the first would promise them a claw-back-free exit they do not have."""
+    _get(client)                                         # enrolled under the 7-day bonus
+    assert store.trial_days() == 21
+
+    with patch(f"{_AFF}.AFFILIATE_ENROLLMENT_BONUS_DAYS", 0):
+        detail = _get(client)
+        assert detail["bonus_days"] == 0
+        assert detail["revocable_bonus_days"] == 7
+
+        # And it IS revoked, which is the whole reason the copy has to say so beforehand.
+        flip = _post(client, "/status", enrolled=False).json()["detail"]
+        assert flip["reward_days"] == 7
+        assert store.trial_days() == 14
+
+
+def test_nothing_is_revocable_when_the_only_days_were_earned_by_referring(client,
+                                                                         env_no_join_bonus, store):
+    from cqc_lem.utilities.marketing.affiliate import attribute_referral, convert_referral
+    _get(client)
+    attribute_referral(7, {"ref": str(USER)})
+    convert_referral(7)
+
+    detail = _get(client)
+    assert detail["days_earned"] == 14
+    assert detail["revocable_bonus_days"] == 0           # earned days are never clawed back

--- a/tests/integration/test_affiliate_api.py
+++ b/tests/integration/test_affiliate_api.py
@@ -66,11 +66,15 @@ class _Cursor:
             self._set([dict(row)] if row else [])
         elif s.startswith("INSERT IGNORE INTO affiliate_enrollments"):
             user_id, status, code, enrolled_at = params
+            existed = user_id in self.store.enrollments
             self.store.enrollments.setdefault(user_id, {
                 "user_id": user_id, "status": status, "referral_code": code,
                 "enrolled_at": enrolled_at, "opted_out_at": None, "notice_seen_at": None,
                 "promo_content_opt_in": 0, "promo_consent_at": None,
                 "promo_consent_version": None})
+            # MySQL reports 1 for the row it inserted and 0 for the one INSERT IGNORE dropped —
+            # that count is what tells the caller this call is the one that enrolled the user.
+            self.rowcount = 0 if existed else 1
         elif s.startswith("UPDATE affiliate_enrollments SET status="):
             status, enrolled, now_enrolled, enrolled2, now_out, user_id = params
             row = self.store.enrollments[user_id]
@@ -137,6 +141,9 @@ class _Cursor:
                                        "kind": kind, "trial_days": days, "reason": reason})
         elif "FROM early_adopter_grants" in s:
             self._set([])
+        elif s.startswith("SELECT subscription_status, subscription_tier"):
+            user = self.store.users.get(params[0])
+            self._set([dict(user)] if user else [])
         elif s.startswith("SELECT subscription_status, trial_started_at, trial_ends_at FROM users"):
             self._set([dict(self.store.users[params[0]])])
         elif s.startswith("SELECT trial_started_at, trial_ends_at FROM users"):
@@ -362,3 +369,52 @@ def test_duplicate_referral_attribution_is_rejected(client, env, store):
     second = attribute_referral(7, {"ref": str(USER)})
     assert second["reason"] == "duplicate"
     assert len(store.referrals) == 1
+
+
+# --- the SHIPPED reward policy: per-referral only (owner decision 2026-08-01) ----------------------
+# The `env` fixture above pins a 7-day join bonus on purpose — that path still has to work for any
+# deployment that configures one. These run the default the product actually ships.
+
+@pytest.fixture
+def env_no_join_bonus(env):
+    with patch(f"{_AFF}.AFFILIATE_ENROLLMENT_BONUS_DAYS", 0):
+        yield
+
+
+def test_joining_pays_nothing_and_only_referrals_earn(client, env_no_join_bonus, store):
+    detail = _get(client)
+    assert detail["enrolled"] is True
+    assert detail["referral_url"].endswith(f"ref={USER}")
+    assert detail["bonus_days"] == 0
+    assert detail["days_earned"] == 0
+    assert store.trial_days() == 14                      # the standard trial, untouched
+    assert store.rewards == []
+
+    from cqc_lem.utilities.marketing.affiliate import attribute_referral, convert_referral
+    attribute_referral(7, {"ref": str(USER)})
+    assert convert_referral(7)["days"] == 14
+    assert store.trial_days() == 28
+    assert _get(client)["days_earned"] == 14
+
+
+def test_the_enrollment_event_fires_once_per_user_not_once_per_page_load(client, env_no_join_bonus):
+    with patch("cqc_lem.utilities.observability.track_affiliate_event") as event:
+        _get(client)
+        _get(client)
+    assert [c.args[0] for c in event.call_args_list].count("affiliate_enrolled") == 1
+
+
+def test_opt_out_takes_nothing_away_but_still_reports_the_trial_length(client, env_no_join_bonus,
+                                                                      store):
+    """With no join bonus there is no reward to revoke — and the user must STILL be told what their
+    trial now is, which is the acceptance criterion the old grant-derived date could not meet."""
+    from cqc_lem.utilities.marketing.affiliate import attribute_referral, convert_referral
+    _get(client)
+    attribute_referral(7, {"ref": str(USER)})
+    convert_referral(7)
+
+    detail = _post(client, "/status", enrolled=False).json()["detail"]
+    assert detail["enrolled"] is False
+    assert detail["reward_days"] == 0                    # nothing was clawed back
+    assert detail["trial_ends_at"] is not None           # read back off the user, not off a grant
+    assert store.trial_days() == 28                      # the earned referral days survive

--- a/tests/unit/utilities/test_affiliate.py
+++ b/tests/unit/utilities/test_affiliate.py
@@ -6,7 +6,8 @@ The acceptance criteria this file owns:
   - self-referral and duplicate referrals are rejected.
   - the per-user reward cap holds.
 """
-from unittest.mock import patch
+from typing import Any, List, Optional, Tuple
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -305,7 +306,8 @@ def test_enroll_user_is_a_no_op_when_ineligible():
         assert affiliate.enroll_user(1) == {}
 
 
-def _enroll(bonus_days, created, grant=None):
+def _enroll(bonus_days: int, created: bool,
+            grant: Optional[dict] = None) -> Tuple[List[Any], MagicMock]:
     """Run `enroll_user` against a stubbed db and return the emitted affiliate events."""
     row = {"status": affiliate.STATUS_ENROLLED, "created": created}
     with patch(f"{_AFF}.AFFILIATE_PROGRAM_ENABLED", True), \
@@ -330,9 +332,14 @@ def test_joining_is_counted_even_when_no_join_bonus_is_configured():
 
 
 def test_a_repeat_page_load_does_not_re_emit_the_enrollment_event():
-    events, grant = _enroll(bonus_days=0, created=False)
+    # The first call is asserted here too so this can never pass vacuously: if the patch ever stops
+    # intercepting (e.g. the import moves to module scope), BOTH halves fail rather than this one
+    # going green on an empty list it was never going to see events in.
+    first, _ = _enroll(bonus_days=0, created=True)
+    repeat, grant = _enroll(bonus_days=0, created=False)
+    assert [c.args[0] for c in first] == ["affiliate_enrolled"]
     assert grant.call_count == 0
-    assert events == []
+    assert repeat == []
 
 
 def test_a_configured_join_bonus_is_still_granted_and_reported():

--- a/tests/unit/utilities/test_affiliate.py
+++ b/tests/unit/utilities/test_affiliate.py
@@ -305,6 +305,42 @@ def test_enroll_user_is_a_no_op_when_ineligible():
         assert affiliate.enroll_user(1) == {}
 
 
+def _enroll(bonus_days, created, grant=None):
+    """Run `enroll_user` against a stubbed db and return the emitted affiliate events."""
+    row = {"status": affiliate.STATUS_ENROLLED, "created": created}
+    with patch(f"{_AFF}.AFFILIATE_PROGRAM_ENABLED", True), \
+         patch(f"{_AFF}.AFFILIATE_DEFAULT_ENROLLED", True), \
+         patch(f"{_AFF}.AFFILIATE_REQUIRE_COMPANY_PAGE", False), \
+         patch(f"{_AFF}.AFFILIATE_ENROLLMENT_BONUS_DAYS", bonus_days), \
+         patch("cqc_lem.utilities.db.ensure_affiliate_enrollment", return_value=row), \
+         patch("cqc_lem.utilities.db.grant_affiliate_trial_days",
+               return_value=grant or {"granted": True, "reason": "granted", "days": bonus_days}) as grant_mock, \
+         patch("cqc_lem.utilities.observability.track_affiliate_event") as event:
+        affiliate.enroll_user(1)
+    return event.call_args_list, grant_mock
+
+
+def test_joining_is_counted_even_when_no_join_bonus_is_configured():
+    """The shipped policy pays nothing for joining, so `affiliate_enrolled` cannot hang off a grant —
+    the marketing funnel still has to count the enrollment."""
+    events, grant = _enroll(bonus_days=0, created=True)
+    assert grant.call_count == 0
+    assert [c.args[0] for c in events] == ["affiliate_enrolled"]
+    assert events[0].kwargs["bonus_days"] == 0
+
+
+def test_a_repeat_page_load_does_not_re_emit_the_enrollment_event():
+    events, grant = _enroll(bonus_days=0, created=False)
+    assert grant.call_count == 0
+    assert events == []
+
+
+def test_a_configured_join_bonus_is_still_granted_and_reported():
+    events, grant = _enroll(bonus_days=7, created=True)
+    grant.assert_called_once()
+    assert events[0].kwargs["bonus_days"] == 7
+
+
 def test_affiliate_state_reports_ineligible_when_company_page_required_and_missing():
     with patch(f"{_AFF}.AFFILIATE_PROGRAM_ENABLED", True), \
          patch(f"{_AFF}.AFFILIATE_REQUIRE_COMPANY_PAGE", True), \

--- a/tests/unit/utilities/test_affiliate.py
+++ b/tests/unit/utilities/test_affiliate.py
@@ -348,6 +348,42 @@ def test_a_configured_join_bonus_is_still_granted_and_reported():
     assert events[0].kwargs["bonus_days"] == 7
 
 
+def _state(totals: dict, bonus_days: int = 0) -> dict:
+    with patch(f"{_AFF}.AFFILIATE_PROGRAM_ENABLED", True), \
+         patch(f"{_AFF}.AFFILIATE_REQUIRE_COMPANY_PAGE", False), \
+         patch(f"{_AFF}.AFFILIATE_ENROLLMENT_BONUS_DAYS", bonus_days), \
+         patch("cqc_lem.utilities.db.get_affiliate_enrollment",
+               return_value={"status": affiliate.STATUS_ENROLLED}), \
+         patch("cqc_lem.utilities.db.get_affiliate_referral_counts", return_value={}), \
+         patch("cqc_lem.utilities.db.get_affiliate_reward_totals", return_value=totals):
+        return affiliate.affiliate_state(1)
+
+
+def test_the_state_reports_what_leaving_would_actually_revoke_not_the_configured_bonus():
+    """The user enrolled under the old defaults still HOLDS +7 that opting out claws back, even
+    though joining now pays 0 — so the copy that tells them what leaving costs cannot read config."""
+    state = _state({"total": 21, "enrollment": 7, "referral": 14, "revoked": 0})
+    assert state["bonus_days"] == 0                  # what joining pays today
+    assert state["revocable_bonus_days"] == 7        # what leaving takes back from THIS user
+
+
+def test_earned_referral_days_are_never_reported_as_revocable():
+    state = _state({"total": 28, "enrollment": 0, "referral": 28, "revoked": 0})
+    assert state["revocable_bonus_days"] == 0
+
+
+def test_an_already_revoked_join_bonus_is_no_longer_revocable():
+    """Opt out, opt back in with the bonus now off: the ledger nets to zero and leaving is free
+    again. Same arithmetic `revoke_affiliate_enrollment_bonus` uses, so the two cannot disagree."""
+    state = _state({"total": 14, "enrollment": 7, "referral": 14, "revoked": -7})
+    assert state["revocable_bonus_days"] == 0
+
+
+def test_a_missing_reward_ledger_reads_as_nothing_to_revoke():
+    state = _state({})
+    assert state["revocable_bonus_days"] == 0
+
+
 def test_affiliate_state_reports_ineligible_when_company_page_required_and_missing():
     with patch(f"{_AFF}.AFFILIATE_PROGRAM_ENABLED", True), \
          patch(f"{_AFF}.AFFILIATE_REQUIRE_COMPANY_PAGE", True), \


### PR DESCRIPTION
Applies the owner's **2026-08-01 decision** on #737 and closes out the remaining scope.

#750 (Part 1, merged) shipped the program with **both** rewards — +7 for joining and +14 per activated referral. The later decision picked **per-referral, capped**, with the rationale that a flat enrollment bonus *"pays every enrollee whether or not they ever refer anyone"*. This PR makes the shipped policy match, and answers the decision's second half: *"research and propose N and the cap against per-user LLM cost and typical SaaS referral norms, with the reasoning documented."*

## What changed

| | Before (#750) | Now |
|---|---|---|
| Joining | +7 trial days, revoked on opt-out | **0** — `AFFILIATE_ENROLLMENT_BONUS_DAYS` kept as a knob, defaults off |
| Activated referral | +14 | +14 (unchanged) |
| Cap | 90 | 90 (unchanged) |

Three things had to move with it, because they were all hanging off a grant that no longer happens:

- **`affiliate_enrolled` fired only when the join bonus was paid.** It now fires on the call that *created* the enrollment row — `ensure_affiliate_enrollment` reports `created` (INSERT IGNORE `rowcount`), which is the only thing that counts each user once given every Account page load calls `enroll_user`.
- **The opt-out response reported a trial end date only when a reward moved.** `POST /user/affiliate/status` now reads it back off the user otherwise, so *"opt-out is immediate, reflected in the trial end date, and the user is notified of the resulting trial length"* holds without a grant.
- **The SPA copy hardcoded a join bonus** and would have rendered "0 bonus trial days" / "your trial returns to the standard 14 days" when leaving costs nothing. Copy is now written off `bonus_days`: at 0 it says *"you keep every trial day you have already earned"*. Both branches are tested — the loss-framing ban in the issue cuts both ways.

Nothing about (A)/(B) separation, consent, or the FTC gate is touched.

## Sizing (docs/affiliate-program.md §3.1, rewritten)

**Measured, not assumed.** PostHog `llm_call`, the 10 days to 2026-08-02 that carry per-user cost attribution: **mean ≈ $0.19, median ≈ $0.15, worst day $0.38** of LLM spend per active user per day (one heavily-active account, so read it as a fully-engaged trial day). So +14 days ≈ **$2.70**, and the 90-day cap ≈ **$17** of variable spend per user — well inside the margin plan's ≥70% blended / ≥60% per-user CM targets.

**Market:** B2B SaaS referral programs pay the referrer **on conversion** ($50–150 mid-market, or 100–150% of first-month value), give the referred account a trial extension or credit, rarely pay a flat join bonus, and commonly cap. Trial days are the cheapest currency a pre-revenue product has — COGS, no payout rail, no 1099.

The doc carries a levers table (7/60 conservative · **14/90 shipped** · 30/90 aggressive · uncapped rejected) so the numbers can move with one env change.

## Scope check on #737

Every acceptance criterion is now met — (A)/(B) independent with timestamped consent (#750), disclosure enforced with a test proving undisclosed content is blocked (#750), opt-out immediate + trial length reported (this PR), self-referral and duplicate referral rejected by test (#750), unit + integration coverage. Part 2 (the promo-content generator) shipped under #770, which is closed with all boxes ticked. The one scope bullet with no dedicated event, *referral-clicked*, is covered by #658's `referral` channel on the LEM Channels dashboard, as `docs/affiliate-program.md` §6 already records.

## Testing

- `tests/unit` → **9180 passed** (includes 3 new `enroll_user` event tests).
- Affiliate unit + integration → 116 passed. New integration coverage for the shipped policy: joining pays nothing and only referrals earn; the enrollment event fires once per user, not once per page load; opt-out takes nothing away but still reports the trial length. The existing 7-day-bonus fixture is kept deliberately — that path must keep working for any deployment that configures one.
- New `AffiliateNotice.test.tsx` (4 cases) + a zero-bonus case on `AffiliateCard.test.tsx`. UI tests run in CI (no local node_modules).

Closes #737

🤖 Generated with [Claude Code](https://claude.com/claude-code)