### PR TITLE
fix(ci): CodeQL PR gate waits for THIS commit's analysis, not any analysis (closes #904)

### DIFF
--- a/.github/workflows/codeql-pr-gate.yml
+++ b/.github/workflows/codeql-pr-gate.yml
@@ -36,17 +36,23 @@ jobs:
         id: refs
         shell: bash
         run: |
-          # TWO different identifiers, deliberately. `head_ref`/`base_ref` are COMMIT SHAs, used by
-          # actions/checkout and for the auto-fix commit. `analysis_ref`/`analysis_base` are GIT
+          # THREE different identifiers, deliberately. `head_ref`/`base_ref` are COMMIT SHAs, used
+          # by actions/checkout and for the auto-fix commit. `analysis_ref`/`analysis_base` are GIT
           # REFS, used for the code-scanning API — which returns ZERO analyses for a bare SHA and
-          # only resolves a ref. Conflating them is why this gate timed out on all 24 of its runs
-          # and failed open every time (verified against the live API 2026-07-31:
+          # only resolves a ref. Conflating those two is why this gate timed out on all 24 of its
+          # runs and failed open every time (verified against the live API 2026-07-31:
           # `?ref=<sha>` -> 0 analyses, `?ref=refs/pull/824/merge` -> 5).
+          #
+          # `analysis_sha` is the SHA `analysis_ref` RESOLVES TO, which the gate waits for so it
+          # never diffs the previous commit's alerts (#904). For a PR that is the ephemeral MERGE
+          # commit — `github.sha` — NOT `pull_request.head.sha` and NOT `merge_commit_sha`; CodeQL
+          # records `commit_sha` as the merge commit it analysed ("Merge <head> into <base>").
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "head_ref=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
             echo "base_ref=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
             echo "analysis_ref=refs/pull/${{ github.event.pull_request.number }}/merge" >> "$GITHUB_OUTPUT"
             echo "analysis_base=refs/heads/${{ github.event.pull_request.base.ref }}" >> "$GITHUB_OUTPUT"
+            echo "analysis_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
             echo "pr_number=${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
             echo "branch=${{ github.event.pull_request.head.ref }}" >> "$GITHUB_OUTPUT"
           elif [ "${{ github.event_name }}" = "merge_group" ]; then
@@ -56,6 +62,7 @@ jobs:
             # and refs/heads/main), so they are used verbatim.
             echo "analysis_ref=${{ github.event.merge_group.head_ref }}" >> "$GITHUB_OUTPUT"
             echo "analysis_base=${{ github.event.merge_group.base_ref }}" >> "$GITHUB_OUTPUT"
+            echo "analysis_sha=${{ github.event.merge_group.head_sha }}" >> "$GITHUB_OUTPUT"
             echo "pr_number=0" >> "$GITHUB_OUTPUT"
             echo "branch=" >> "$GITHUB_OUTPUT"
           else
@@ -63,6 +70,7 @@ jobs:
             echo "base_ref=${{ inputs.base-ref }}" >> "$GITHUB_OUTPUT"
             echo "analysis_ref=${{ inputs.head-ref }}" >> "$GITHUB_OUTPUT"
             echo "analysis_base=${{ inputs.base-ref }}" >> "$GITHUB_OUTPUT"
+            echo "analysis_sha=${{ inputs.head-ref }}" >> "$GITHUB_OUTPUT"
             echo "pr_number=${{ inputs.pr-number || '0' }}" >> "$GITHUB_OUTPUT"
             echo "branch=" >> "$GITHUB_OUTPUT"
           fi
@@ -87,6 +95,7 @@ jobs:
           # The code-scanning API needs REFS, not SHAs — see the "Determine refs" step.
           HEAD_REF="${{ steps.refs.outputs.analysis_ref }}"
           BASE_REF="${{ steps.refs.outputs.analysis_base }}"
+          HEAD_SHA="${{ steps.refs.outputs.analysis_sha }}"
           PR_NUMBER="${{ steps.refs.outputs.pr_number }}"
           BRANCH="${{ steps.refs.outputs.branch }}"
 
@@ -95,6 +104,7 @@ jobs:
           args=(
             --repo "${{ github.repository }}"
             --head-ref "$HEAD_REF"
+            --head-sha "$HEAD_SHA"
             --base-ref "$BASE_REF"
             --pr-number "$PR_NUMBER"
             --fix

--- a/.github/workflows/codeql-pr-gate.yml
+++ b/.github/workflows/codeql-pr-gate.yml
@@ -70,7 +70,11 @@ jobs:
             echo "base_ref=${{ inputs.base-ref }}" >> "$GITHUB_OUTPUT"
             echo "analysis_ref=${{ inputs.head-ref }}" >> "$GITHUB_OUTPUT"
             echo "analysis_base=${{ inputs.base-ref }}" >> "$GITHUB_OUTPUT"
-            echo "analysis_sha=${{ inputs.head-ref }}" >> "$GITHUB_OUTPUT"
+            # Deliberately EMPTY. `head-ref` is the caller's single identifier and it is
+            # already used as `analysis_ref`; reusing it as the commit SHA would compare a
+            # ref string against `commit_sha` and never match, so the gate would burn the
+            # full timeout and fail open on every call. Empty keeps the pre-#904 wait.
+            echo "analysis_sha=" >> "$GITHUB_OUTPUT"
             echo "pr_number=${{ inputs.pr-number || '0' }}" >> "$GITHUB_OUTPUT"
             echo "branch=" >> "$GITHUB_OUTPUT"
           fi

--- a/docs/codeql-pr-gate.md
+++ b/docs/codeql-pr-gate.md
@@ -10,7 +10,8 @@ Workflow: `.github/workflows/codeql-pr-gate.yml`
 Helper:   `scripts/codeql_pr_gate.py`
 Config:   `.github/codeql/codeql-config.yml`
 
-1. After the existing CodeQL workflows upload SARIF, the gate queries
+1. After the existing CodeQL workflows upload SARIF **for the commit being gated** (see
+   *Analysis freshness* below), the gate queries
    `/repos/{owner}/{repo}/code-scanning/alerts` for both the PR head and the base ref.
 2. It computes the **new** alerts introduced by the PR (by rule, file, line, and message).
 3. It buckets them:
@@ -69,11 +70,45 @@ The job needs:
 
 The verification CodeQL step uses `upload: false`, so no SARIF write permission is required.
 
+## Analysis freshness — "an analysis exists" is not "an analysis for THIS commit" (issue #904)
+
+The gate and `CodeQL Advanced` both fire on `pull_request` with no `needs:` between them, so they
+race. On every push after a PR's first, an analysis for `refs/pull/<n>/merge` already exists — from
+the *previous* commit. The original wait polled only "does the ref have any analysis", so it
+returned instantly and the gate then diffed the previous commit's alerts. Both directions are
+wrong, and the second one is the dangerous one:
+
+- **False red** — it reported alerts the push had already fixed (observed on #899: five alerts, all
+  fixed, alert IDs byte-identical to the previous scan, one of them naming a variable binding that
+  had been deleted). A bare re-run then passed with no code change, which teaches people to re-run
+  on red instead of reading the report.
+- **False green** — a genuinely new alert on the current commit is missed whenever the previous
+  commit was clean. Nobody investigates a green gate, so this would never have been noticed.
+
+The fix: the gate is told the SHA its ref resolves to and waits for *that commit's* analysis.
+
+- The workflow passes `--head-sha`. For a PR this is `github.sha` — the ephemeral **merge** commit
+  (`Merge <head> into <base>`), which is what CodeQL records as `commit_sha`. It is **not**
+  `pull_request.head.sha` and not the PR's `merge_commit_sha`.
+- "Complete" means every **category** the previous commit on that ref produced (e.g.
+  `/language:python`, `/language:python/advanced`, `/language:javascript-typescript`) has landed for
+  our commit — a partial upload is still a stale diff for the categories not yet in. The required
+  set is read off the ref rather than hardcoded, so adding or removing a CodeQL workflow needs no
+  change here. On a PR's first push there is no previous commit, so any analysis for the commit
+  counts.
+- `--wait-timeout` defaults to 900s. Before this fix the wait never actually elapsed, so the old
+  300s default was never spent; it now has to outlast a real CodeQL run plus queue time.
+
+This is the same shape as the v0.115.0 release incident in `docs/release-fast-lane.md` ("Step 2
+waits on the *run*, not on 'a release PR exists' — those look equivalent and are not").
+
 ## Fail-open behavior
 
-If the GitHub API is unavailable, the head ref has no CodeQL analysis after the timeout, or the
-base ref cannot be fetched, the gate logs a warning and exits successfully. A CodeQL outage must
-not block every PR.
+If the GitHub API is unavailable, the head ref has no CodeQL analysis **for the gated commit** after
+the timeout, or the base ref cannot be fetched, the gate logs a loud `::warning` (job summary
+included) and exits successfully. A CodeQL outage must not block every PR. It deliberately does
+**not** fall back to comparing an older commit's alerts — that is the #904 bug, and it is worse than
+not comparing at all.
 
 ## Notes
 

--- a/docs/codeql-pr-gate.md
+++ b/docs/codeql-pr-gate.md
@@ -90,14 +90,27 @@ The fix: the gate is told the SHA its ref resolves to and waits for *that commit
 - The workflow passes `--head-sha`. For a PR this is `github.sha` — the ephemeral **merge** commit
   (`Merge <head> into <base>`), which is what CodeQL records as `commit_sha`. It is **not**
   `pull_request.head.sha` and not the PR's `merge_commit_sha`.
-- "Complete" means every **category** the previous commit on that ref produced (e.g.
-  `/language:python`, `/language:python/advanced`, `/language:javascript-typescript`) has landed for
-  our commit — a partial upload is still a stale diff for the categories not yet in. The required
-  set is read off the ref rather than hardcoded, so adding or removing a CodeQL workflow needs no
-  change here. On a PR's first push there is no previous commit, so any analysis for the commit
-  counts.
+- "Complete" means every **category** the repo produces (`/language:python`,
+  `/language:python/advanced`, `/language:javascript-typescript` — two workflows, three matrix legs)
+  has landed for our commit. **A partial upload is a partial diff, not a fresh one**: the categories
+  land seconds to a minute apart, and comparing a head with two of them against a base with three
+  hides every alert in the missing one — the same false green, one step further in. This is not
+  theoretical: on PR #913's own gate run the wait cleared at `07:10:36` with javascript and
+  python/advanced in, while `/language:python` did not upload until `07:10:54`.
+- The required set is **calibrated off the API, never hardcoded** (`expected_categories`): the
+  largest category set among the newest 3 commits on the ref that aren't ours. Largest rather than
+  newest, because one commit can legitimately be short a category (a matrix leg failed, or its run
+  was still uploading when the next push superseded it) and calibrating off that one would let every
+  later commit through partial. A PR's **first** push has no earlier commit on its own ref, so the
+  set comes from the **base ref**, which runs the same workflows and always has one. If neither has
+  an analysis (a repo CodeQL has never scanned), the gate accepts what landed rather than blocking.
+  Adding a CodeQL workflow needs no change here; *removing* one costs up to 3 commits of fail-open
+  timeouts while the removed category ages out of the lookback.
 - `--wait-timeout` defaults to 900s. Before this fix the wait never actually elapsed, so the old
   300s default was never spent; it now has to outlast a real CodeQL run plus queue time.
+- `workflow_call` has one identifier for both the ref and the SHA, so it passes **no** `--head-sha`
+  and keeps the pre-#904 wait. Passing a ref string as a SHA would match no `commit_sha` at all and
+  burn the whole timeout on every call.
 
 This is the same shape as the v0.115.0 release incident in `docs/release-fast-lane.md` ("Step 2
 waits on the *run*, not on 'a release PR exists' — those look equivalent and are not").

--- a/scripts/codeql_pr_gate.py
+++ b/scripts/codeql_pr_gate.py
@@ -8,7 +8,8 @@ quality alerts reach main.
 It runs in a GitHub Actions workflow
 (`.github/workflows/codeql-pr-gate.yml`) and:
 
-1. Waits for the existing CodeQL workflows to upload SARIF for the PR head.
+1. Waits for the existing CodeQL workflows to upload SARIF *for the commit being
+   gated* — not merely for the ref (see `wait_for_analysis`).
 2. Fetches open code-scanning alerts for the head and base refs.
 3. Computes newly introduced alerts by (rule, file, line, message).
 4. Buckets them:
@@ -29,6 +30,9 @@ CLI:
   --repo OWNER/REPO
   --head-ref REF         Git REF the code-scanning API resolves (e.g. refs/pull/<n>/merge).
                          NOT a commit SHA — the API returns zero analyses for a bare SHA.
+  --head-sha SHA         Commit SHA that --head-ref resolves to (for a PR that is the
+                         MERGE commit, i.e. GITHUB_SHA — not the PR head). Without it the
+                         wait degrades to "any analysis for the ref", which is the #904 bug.
   --base-ref REF         Git REF to diff against (e.g. refs/heads/main).
   --pr-number NUMBER     PR to post comments to (optional).
   --branch BRANCH        Branch to push fixes to (optional; no push if
@@ -87,6 +91,8 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser.add_argument("--repo", required=True, help="Owner/repo slug.")
     parser.add_argument("--head-ref", required=True,
                         help="Git REF for code-scanning (refs/pull/<n>/merge), NOT a SHA.")
+    parser.add_argument("--head-sha", default="",
+                        help="Commit SHA --head-ref resolves to (GITHUB_SHA on a PR).")
     parser.add_argument("--base-ref", required=True,
                         help="Git REF to diff against (refs/heads/main), NOT a SHA.")
     parser.add_argument(
@@ -101,7 +107,10 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
     parser.add_argument(
         "--wait-timeout",
         type=int,
-        default=300,
+        # Before #904 the wait returned instantly on any push after the first, so 300s was
+        # never actually spent. Now that it waits for THIS commit it has to outlast a real
+        # CodeQL run (~2-4 min) plus queue time, or the gate just fails open every time.
+        default=900,
         help="Seconds to wait for CodeQL.",
     )
     parser.add_argument(
@@ -203,11 +212,18 @@ class GitHubClient:
             log_error("GitHub API POST failed", url=url, exc=exc)
             return False
 
-    def analyses_exist(self, ref: str) -> bool:
+    def list_analyses(self, ref: str) -> list[dict]:
+        """Analyses uploaded for ``ref``, newest first (as the API returns them).
+
+        One page is enough: the commit we are gating is the newest one on the ref, so
+        its analyses sit at the top.
+        """
         data = self.get(
-            "/code-scanning/analyses", params={"ref": ref, "per_page": 1}
+            "/code-scanning/analyses", params={"ref": ref, "per_page": 100}
         )
-        return bool(data and isinstance(data, list) and len(data) > 0)
+        if not isinstance(data, list):
+            return []
+        return [entry for entry in data if isinstance(entry, dict)]
 
     def fetch_alerts(self, ref: str) -> list[Alert]:
         alerts: list[Alert] = []
@@ -263,25 +279,95 @@ def _alert_from_raw(raw: dict) -> Optional[Alert]:
     )
 
 
-def wait_for_analysis(
-    client: GitHubClient, ref: str, timeout: int, interval: int
-) -> bool:
-    """Poll until CodeQL has uploaded at least one analysis for ``ref``.
+def categories_for_commit(analyses: list[dict], commit_sha: str) -> set[str]:
+    return {
+        entry.get("category")
+        for entry in analyses
+        if entry.get("commit_sha") == commit_sha and entry.get("category")
+    }
 
-    Returns True if analyses are found, False on timeout. Failing this check
-    is not fatal; the caller falls back to comparing whatever is available.
+
+def previous_commit_categories(
+    analyses: list[dict], commit_sha: str
+) -> set[str]:
+    """Categories CodeQL produced for the newest commit on the ref that ISN'T ours.
+
+    This self-calibrates what "analysis complete" means for this repo: whatever set of
+    categories ran for commit N-1 on this ref is what commit N has to produce before the
+    alerts are comparable. Reading it off the ref (rather than hardcoding a list) means a
+    workflow added or removed later needs no change here — and on a PR's very first push
+    there is no previous commit, so the set is empty and any analysis will do.
+    """
+    previous_sha = ""
+    categories: set[str] = set()
+    for entry in analyses:
+        sha = entry.get("commit_sha") or ""
+        if not sha or sha == commit_sha:
+            continue
+        if not previous_sha:
+            previous_sha = sha
+        if sha == previous_sha and entry.get("category"):
+            categories.add(entry["category"])
+    return categories
+
+
+def wait_for_analysis(
+    client: GitHubClient,
+    ref: str,
+    timeout: int,
+    interval: int,
+    commit_sha: str = "",
+) -> bool:
+    """Poll until CodeQL has uploaded analysis for ``commit_sha`` on ``ref``.
+
+    "An analysis exists for the ref" is NOT "an analysis exists for this commit" (#904):
+    on every push after the first, the previous commit's analysis is already there, so the
+    old check returned instantly and the gate then diffed the PREVIOUS commit's alerts —
+    reporting alerts the push had already fixed, and (the dangerous direction) missing
+    genuinely new ones whenever the previous commit was clean.
+
+    The gate and `CodeQL Advanced` both fire on `pull_request` with no ordering between
+    them, so this really is a race and not a rare one.
+
+    Returns True once the commit's analysis is complete, False on timeout. Timing out is
+    not fatal — the caller fails open, loudly.
     """
     deadline = time.time() + timeout
-    while time.time() < deadline:
-        if client.analyses_exist(ref):
-            log_info("CodeQL analysis available", ref=ref)
-            return True
+    while True:
+        analyses = client.list_analyses(ref)
+        if not commit_sha:
+            # No SHA to pin to (workflow_call dispatch): the best we can do is the
+            # pre-#904 behaviour.
+            if analyses:
+                log_info("CodeQL analysis available", ref=ref)
+                return True
+        else:
+            required = previous_commit_categories(analyses, commit_sha)
+            available = categories_for_commit(analyses, commit_sha)
+            if available and required <= available:
+                log_info(
+                    "CodeQL analysis available for commit",
+                    ref=ref,
+                    commit_sha=commit_sha,
+                    categories=sorted(available),
+                )
+                return True
         remaining = int(deadline - time.time())
+        if remaining <= 0:
+            break
         log_info(
-            "Waiting for CodeQL analysis", ref=ref, remaining_seconds=remaining
+            "Waiting for CodeQL analysis",
+            ref=ref,
+            commit_sha=commit_sha or "any",
+            remaining_seconds=remaining,
         )
-        time.sleep(interval)
-    log_warning("Timed out waiting for CodeQL analysis", ref=ref, timeout=timeout)
+        time.sleep(min(interval, remaining))
+    log_warning(
+        "Timed out waiting for CodeQL analysis",
+        ref=ref,
+        commit_sha=commit_sha or "any",
+        timeout=timeout,
+    )
     return False
 
 
@@ -702,7 +788,11 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     # Wait for CodeQL results from the existing workflows.
     head_ready = wait_for_analysis(
-        client, args.head_ref, args.wait_timeout, args.wait_interval
+        client,
+        args.head_ref,
+        args.wait_timeout,
+        args.wait_interval,
+        commit_sha=args.head_sha,
     )
     if not head_ready:
         # LOUD, not a quiet warning. This gate silently timed out on all 24 of its runs and reported
@@ -710,10 +800,13 @@ def main(argv: Optional[list[str]] = None) -> int:
         # executed. Failing open is still right — a flaky analysis must not block a merge — but it
         # has to be visible in the job summary, not buried in a log line nobody reads.
         message = (
-            f"::warning title=CodeQL gate did not run::No CodeQL analysis for {args.head_ref} "
-            f"after {args.wait_timeout}s — alerts were NOT compared. Failing open. If this "
-            f"repeats, the ref is probably wrong (the code-scanning API needs a git ref such as "
-            f"refs/pull/<n>/merge, not a commit SHA)."
+            f"::warning title=CodeQL gate did not run::No CodeQL analysis for "
+            f"{args.head_ref} at commit {args.head_sha or '(any)'} after "
+            f"{args.wait_timeout}s — alerts were NOT compared. Failing open. If this "
+            f"repeats, either CodeQL is slower than the timeout, or the ref is wrong (the "
+            f"code-scanning API needs a git ref such as refs/pull/<n>/merge, not a commit "
+            f"SHA). Alerts from an EARLIER commit are deliberately not compared: they "
+            f"report fixed issues and hide new ones (#904)."
         )
         print(message, flush=True)
         summary = os.environ.get("GITHUB_STEP_SUMMARY")

--- a/scripts/codeql_pr_gate.py
+++ b/scripts/codeql_pr_gate.py
@@ -219,7 +219,15 @@ class GitHubClient:
         its analyses sit at the top.
         """
         data = self.get(
-            "/code-scanning/analyses", params={"ref": ref, "per_page": 100}
+            "/code-scanning/analyses",
+            # sort/direction are the API defaults, sent explicitly because the
+            # newest-first order is what "the previous commit" is read off.
+            params={
+                "ref": ref,
+                "per_page": 100,
+                "sort": "created",
+                "direction": "desc",
+            },
         )
         if not isinstance(data, list):
             return []
@@ -287,28 +295,35 @@ def categories_for_commit(analyses: list[dict], commit_sha: str) -> set[str]:
     }
 
 
-def previous_commit_categories(
-    analyses: list[dict], commit_sha: str
+def expected_categories(
+    analyses: list[dict], commit_sha: str, lookback: int = 3
 ) -> set[str]:
-    """Categories CodeQL produced for the newest commit on the ref that ISN'T ours.
+    """The category set commit ``commit_sha`` is expected to produce on this ref.
 
-    This self-calibrates what "analysis complete" means for this repo: whatever set of
-    categories ran for commit N-1 on this ref is what commit N has to produce before the
-    alerts are comparable. Reading it off the ref (rather than hardcoding a list) means a
-    workflow added or removed later needs no change here — and on a PR's very first push
-    there is no previous commit, so the set is empty and any analysis will do.
+    Self-calibrates what "analysis complete" means instead of hardcoding a list: take the
+    newest ``lookback`` commits on the ref that AREN'T ours and use the largest category
+    set any of them produced. Largest, not newest — a single commit can legitimately be
+    missing a category (a matrix leg failed, or its run was still uploading when the next
+    push superseded it), and calibrating off that one would make a partial upload look
+    complete for every commit after it.
+
+    An empty result means we have nothing to calibrate against (a PR's very first push has
+    no previous commit); the caller falls back to the base ref, which always does.
     """
-    previous_sha = ""
-    categories: set[str] = set()
+    by_commit: dict[str, set[str]] = {}
     for entry in analyses:
         sha = entry.get("commit_sha") or ""
-        if not sha or sha == commit_sha:
+        category = entry.get("category")
+        if not sha or sha == commit_sha or not category:
             continue
-        if not previous_sha:
-            previous_sha = sha
-        if sha == previous_sha and entry.get("category"):
-            categories.add(entry["category"])
-    return categories
+        if sha not in by_commit:
+            if len(by_commit) >= lookback:
+                continue
+            by_commit[sha] = set()
+        by_commit[sha].add(category)
+    if not by_commit:
+        return set()
+    return max(by_commit.values(), key=len)
 
 
 def wait_for_analysis(
@@ -317,6 +332,7 @@ def wait_for_analysis(
     timeout: int,
     interval: int,
     commit_sha: str = "",
+    base_ref: str = "",
 ) -> bool:
     """Poll until CodeQL has uploaded analysis for ``commit_sha`` on ``ref``.
 
@@ -329,10 +345,18 @@ def wait_for_analysis(
     The gate and `CodeQL Advanced` both fire on `pull_request` with no ordering between
     them, so this really is a race and not a rare one.
 
+    "Complete" is every category the ref is expected to produce, not the first one to
+    land: the categories upload seconds to a minute apart, and comparing head-with-two
+    against a base-with-three hides every alert in the missing one. Observed on this PR's
+    own gate run — it accepted at 07:10:36 with `/language:javascript-typescript` and
+    `/language:python/advanced` in, while `/language:python` did not land until 07:10:54.
+
     Returns True once the commit's analysis is complete, False on timeout. Timing out is
     not fatal — the caller fails open, loudly.
     """
     deadline = time.time() + timeout
+    base_required: Optional[set[str]] = None
+    missing: list[str] = []
     while True:
         analyses = client.list_analyses(ref)
         if not commit_sha:
@@ -342,7 +366,22 @@ def wait_for_analysis(
                 log_info("CodeQL analysis available", ref=ref)
                 return True
         else:
-            required = previous_commit_categories(analyses, commit_sha)
+            required = expected_categories(analyses, commit_sha)
+            if not required and base_ref:
+                # A PR's first push has no earlier commit on its own ref. The base ref
+                # always has one, and runs the same CodeQL workflows, so it is the right
+                # calibration source — without it the first category to land would count
+                # as a complete analysis.
+                if base_required is None:
+                    base_required = expected_categories(
+                        client.list_analyses(base_ref), commit_sha
+                    )
+                    log_info(
+                        "Calibrating expected CodeQL categories off the base ref",
+                        base_ref=base_ref,
+                        categories=sorted(base_required),
+                    )
+                required = base_required
             available = categories_for_commit(analyses, commit_sha)
             if available and required <= available:
                 log_info(
@@ -352,6 +391,7 @@ def wait_for_analysis(
                     categories=sorted(available),
                 )
                 return True
+            missing = sorted(required - available)
         remaining = int(deadline - time.time())
         if remaining <= 0:
             break
@@ -359,6 +399,7 @@ def wait_for_analysis(
             "Waiting for CodeQL analysis",
             ref=ref,
             commit_sha=commit_sha or "any",
+            missing_categories=missing,
             remaining_seconds=remaining,
         )
         time.sleep(min(interval, remaining))
@@ -366,6 +407,7 @@ def wait_for_analysis(
         "Timed out waiting for CodeQL analysis",
         ref=ref,
         commit_sha=commit_sha or "any",
+        missing_categories=missing,
         timeout=timeout,
     )
     return False
@@ -793,6 +835,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         args.wait_timeout,
         args.wait_interval,
         commit_sha=args.head_sha,
+        base_ref=args.base_ref,
     )
     if not head_ready:
         # LOUD, not a quiet warning. This gate silently timed out on all 24 of its runs and reported

--- a/tests/unit/test_codeql_pr_gate.py
+++ b/tests/unit/test_codeql_pr_gate.py
@@ -42,34 +42,63 @@ def _analysis(commit_sha: str, category: str) -> dict:
 
 
 class _FakeClient:
-    """Returns a different /analyses page per poll, then repeats the last one."""
+    """Returns a different /analyses page per poll, then repeats the last one.
 
-    def __init__(self, pages: list[list[dict]]) -> None:
+    ``base_pages`` answers any ref other than ``ref`` (the base-ref calibration lookup).
+    """
+
+    def __init__(self, pages: list[list[dict]], base: list[dict] | None = None) -> None:
         self.pages = pages
+        self.base = base
         self.calls = 0
+        self.base_calls = 0
 
     def list_analyses(self, ref: str) -> list[dict]:
+        if self.base is not None and ref.startswith("refs/heads/"):
+            self.base_calls += 1
+            return self.base
         self.calls += 1
         return self.pages[min(self.calls - 1, len(self.pages) - 1)]
 
 
-class TestPreviousCommitCategories:
-    def test_reads_only_the_newest_other_commit(self):
+class TestExpectedCategories:
+    def test_reads_the_newest_other_commit(self):
         analyses = [
             _analysis(NEW_SHA, PY),
             _analysis(OLD_SHA, PY),
             _analysis(OLD_SHA, JS),
+        ]
+        assert gate.expected_categories(analyses, NEW_SHA, lookback=1) == {PY, JS}
+
+    def test_takes_the_largest_set_not_the_newest(self):
+        """A previous commit whose run only half-uploaded must not lower the bar."""
+        analyses = [
+            _analysis(NEW_SHA, PY),
+            _analysis(OLD_SHA, JS),  # newest other commit — partial
+            _analysis("evenolder", PY),
+            _analysis("evenolder", JS),
             _analysis("evenolder", PY_ADVANCED),
         ]
-        assert gate.previous_commit_categories(analyses, NEW_SHA) == {PY, JS}
+        assert gate.expected_categories(analyses, NEW_SHA) == {PY, JS, PY_ADVANCED}
+
+    def test_lookback_bounds_how_far_back_it_calibrates(self):
+        analyses = [
+            _analysis(OLD_SHA, JS),
+            _analysis("c2", JS),
+            _analysis("c3", JS),
+            _analysis("c4", PY),
+            _analysis("c4", JS),
+            _analysis("c4", PY_ADVANCED),
+        ]
+        assert gate.expected_categories(analyses, NEW_SHA, lookback=3) == {JS}
 
     def test_empty_on_a_prs_first_push(self):
         analyses = [_analysis(NEW_SHA, PY)]
-        assert gate.previous_commit_categories(analyses, NEW_SHA) == set()
+        assert gate.expected_categories(analyses, NEW_SHA) == set()
 
     def test_ignores_entries_without_a_commit_or_category(self):
         analyses = [{"category": PY}, {"commit_sha": OLD_SHA}, _analysis(OLD_SHA, JS)]
-        assert gate.previous_commit_categories(analyses, NEW_SHA) == {JS}
+        assert gate.expected_categories(analyses, NEW_SHA) == {JS}
 
 
 class TestWaitForAnalysis:
@@ -109,10 +138,49 @@ class TestWaitForAnalysis:
             client, "refs/pull/899/merge", timeout=0, interval=0, commit_sha=NEW_SHA
         ) is False
 
-    def test_first_push_accepts_the_only_analysis_there_is(self):
+    def test_first_push_with_no_base_ref_accepts_what_it_has(self):
         client = _FakeClient([[_analysis(NEW_SHA, PY)]])
         assert gate.wait_for_analysis(
             client, "refs/pull/899/merge", timeout=0, interval=0, commit_sha=NEW_SHA
+        ) is True
+
+    def test_first_push_calibrates_off_the_base_ref(self):
+        """The live hole this closes: on PR #913's own run the gate accepted at 07:10:36
+        with javascript + python/advanced in, while /language:python landed at
+        07:10:54 — head was compared two-deep against a three-category base."""
+        base = [_analysis(OLD_SHA, PY), _analysis(OLD_SHA, JS),
+                _analysis(OLD_SHA, PY_ADVANCED)]
+        client = _FakeClient(
+            [
+                [_analysis(NEW_SHA, JS), _analysis(NEW_SHA, PY_ADVANCED)],
+                [_analysis(NEW_SHA, JS), _analysis(NEW_SHA, PY_ADVANCED),
+                 _analysis(NEW_SHA, PY)],
+            ],
+            base=base,
+        )
+        assert gate.wait_for_analysis(
+            client, "refs/pull/913/merge", timeout=60, interval=0,
+            commit_sha=NEW_SHA, base_ref="refs/heads/main",
+        ) is True
+        assert client.calls == 2
+        # Calibration is a fixed property of the ref — fetched once, not once per poll.
+        assert client.base_calls == 1
+
+    def test_first_push_partial_upload_times_out_against_the_base_ref(self):
+        base = [_analysis(OLD_SHA, PY), _analysis(OLD_SHA, JS),
+                _analysis(OLD_SHA, PY_ADVANCED)]
+        client = _FakeClient([[_analysis(NEW_SHA, JS)]], base=base)
+        assert gate.wait_for_analysis(
+            client, "refs/pull/913/merge", timeout=0, interval=0,
+            commit_sha=NEW_SHA, base_ref="refs/heads/main",
+        ) is False
+
+    def test_unanalyzed_base_ref_does_not_block_the_gate(self):
+        """No calibration source anywhere → fall back to accepting what landed."""
+        client = _FakeClient([[_analysis(NEW_SHA, PY)]], base=[])
+        assert gate.wait_for_analysis(
+            client, "refs/pull/913/merge", timeout=0, interval=0,
+            commit_sha=NEW_SHA, base_ref="refs/heads/main",
         ) is True
 
     def test_without_a_commit_sha_any_analysis_counts(self):

--- a/tests/unit/test_codeql_pr_gate.py
+++ b/tests/unit/test_codeql_pr_gate.py
@@ -1,0 +1,210 @@
+"""Unit tests for scripts/codeql_pr_gate.py — the per-PR CodeQL alert diff.
+
+Focus is issue #904: "an analysis exists for this ref" is not "an analysis exists for
+THIS commit". The old wait returned instantly on every push after the first, so the gate
+diffed the previous commit's alerts — flagging issues the push had already fixed, and
+silently missing new ones whenever the previous commit happened to be clean.
+"""
+
+import importlib.util
+import pathlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_SCRIPTS = pathlib.Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(name, _SCRIPTS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    # @dataclass resolves annotations through sys.modules[cls.__module__].
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+gate = _load("codeql_pr_gate")
+
+NEW_SHA = "31496b31aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+OLD_SHA = "6f28084636b2b8ea0b9f1085cda79b83ec501fa8"
+PY = "/language:python"
+PY_ADVANCED = "/language:python/advanced"
+JS = "/language:javascript-typescript"
+
+
+def _analysis(commit_sha: str, category: str) -> dict:
+    return {"commit_sha": commit_sha, "category": category,
+            "created_at": "2026-08-02T01:44:22Z"}
+
+
+class _FakeClient:
+    """Returns a different /analyses page per poll, then repeats the last one."""
+
+    def __init__(self, pages: list[list[dict]]) -> None:
+        self.pages = pages
+        self.calls = 0
+
+    def list_analyses(self, ref: str) -> list[dict]:
+        self.calls += 1
+        return self.pages[min(self.calls - 1, len(self.pages) - 1)]
+
+
+class TestPreviousCommitCategories:
+    def test_reads_only_the_newest_other_commit(self):
+        analyses = [
+            _analysis(NEW_SHA, PY),
+            _analysis(OLD_SHA, PY),
+            _analysis(OLD_SHA, JS),
+            _analysis("evenolder", PY_ADVANCED),
+        ]
+        assert gate.previous_commit_categories(analyses, NEW_SHA) == {PY, JS}
+
+    def test_empty_on_a_prs_first_push(self):
+        analyses = [_analysis(NEW_SHA, PY)]
+        assert gate.previous_commit_categories(analyses, NEW_SHA) == set()
+
+    def test_ignores_entries_without_a_commit_or_category(self):
+        analyses = [{"category": PY}, {"commit_sha": OLD_SHA}, _analysis(OLD_SHA, JS)]
+        assert gate.previous_commit_categories(analyses, NEW_SHA) == {JS}
+
+
+class TestWaitForAnalysis:
+    def test_stale_analysis_for_an_older_commit_is_not_accepted(self):
+        """The #904 bug: this used to return True immediately."""
+        client = _FakeClient([[_analysis(OLD_SHA, PY), _analysis(OLD_SHA, JS)]])
+        assert gate.wait_for_analysis(
+            client, "refs/pull/899/merge", timeout=0, interval=0, commit_sha=NEW_SHA
+        ) is False
+
+    def test_returns_once_the_commits_analysis_lands(self):
+        client = _FakeClient([
+            [_analysis(OLD_SHA, PY)],
+            [_analysis(NEW_SHA, PY), _analysis(OLD_SHA, PY)],
+        ])
+        assert gate.wait_for_analysis(
+            client, "refs/pull/899/merge", timeout=60, interval=0, commit_sha=NEW_SHA
+        ) is True
+        assert client.calls == 2
+
+    def test_waits_for_every_category_the_previous_commit_produced(self):
+        """A partial upload is still a stale diff for the categories not yet in."""
+        previous = [_analysis(OLD_SHA, PY), _analysis(OLD_SHA, JS)]
+        client = _FakeClient([
+            [_analysis(NEW_SHA, JS)] + previous,
+            [_analysis(NEW_SHA, PY), _analysis(NEW_SHA, JS)] + previous,
+        ])
+        assert gate.wait_for_analysis(
+            client, "refs/pull/899/merge", timeout=60, interval=0, commit_sha=NEW_SHA
+        ) is True
+        assert client.calls == 2
+
+    def test_partial_upload_alone_times_out(self):
+        previous = [_analysis(OLD_SHA, PY), _analysis(OLD_SHA, JS)]
+        client = _FakeClient([[_analysis(NEW_SHA, JS)] + previous])
+        assert gate.wait_for_analysis(
+            client, "refs/pull/899/merge", timeout=0, interval=0, commit_sha=NEW_SHA
+        ) is False
+
+    def test_first_push_accepts_the_only_analysis_there_is(self):
+        client = _FakeClient([[_analysis(NEW_SHA, PY)]])
+        assert gate.wait_for_analysis(
+            client, "refs/pull/899/merge", timeout=0, interval=0, commit_sha=NEW_SHA
+        ) is True
+
+    def test_without_a_commit_sha_any_analysis_counts(self):
+        """workflow_call passes a bare SHA as the ref; behaviour is unchanged there."""
+        client = _FakeClient([[_analysis(OLD_SHA, PY)]])
+        assert gate.wait_for_analysis(
+            client, "refs/pull/899/merge", timeout=0, interval=0, commit_sha=""
+        ) is True
+
+    def test_no_analyses_at_all_times_out(self):
+        client = _FakeClient([[]])
+        assert gate.wait_for_analysis(
+            client, "refs/pull/899/merge", timeout=0, interval=0, commit_sha=""
+        ) is False
+
+
+class TestListAnalyses:
+    def test_returns_the_dicts_the_api_gave(self):
+        client = gate.GitHubClient("token", "o/r")
+        with patch.object(client, "get", return_value=[_analysis(NEW_SHA, PY), "junk"]):
+            assert client.list_analyses("refs/heads/main") == [_analysis(NEW_SHA, PY)]
+
+    def test_api_failure_is_an_empty_list_not_a_crash(self):
+        client = gate.GitHubClient("token", "o/r")
+        with patch.object(client, "get", return_value=None):
+            assert client.list_analyses("refs/heads/main") == []
+
+
+class TestMainStaleGuard:
+    def _run(self, argv, list_analyses_return, monkeypatch, tmp_path):
+        monkeypatch.setenv("GITHUB_TOKEN", "token")
+        monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(tmp_path / "summary.md"))
+        monkeypatch.delenv("GITHUB_OUTPUT", raising=False)
+        client = MagicMock()
+        client.list_analyses.return_value = list_analyses_return
+        client.fetch_alerts.return_value = []
+        with patch.object(gate, "GitHubClient", return_value=client):
+            return gate.main(argv), client
+
+    def test_stale_ref_never_compares_and_fails_open(
+        self, monkeypatch, tmp_path, capsys
+    ):
+        code, client = self._run(
+            [
+                "--repo", "o/r",
+                "--head-ref", "refs/pull/899/merge",
+                "--head-sha", NEW_SHA,
+                "--base-ref", "refs/heads/main",
+                "--wait-timeout", "0",
+                "--wait-interval", "0",
+            ],
+            [_analysis(OLD_SHA, PY), _analysis(OLD_SHA, JS)],
+            monkeypatch,
+            tmp_path,
+        )
+        # Fail-open is deliberate: a slow CodeQL must not block every merge.
+        assert code == 0
+        client.fetch_alerts.assert_not_called()
+        out = capsys.readouterr().out
+        assert "CodeQL gate did not run" in out
+        assert NEW_SHA in out
+
+    def test_fresh_analysis_is_compared(self, monkeypatch, tmp_path):
+        code, client = self._run(
+            [
+                "--repo", "o/r",
+                "--head-ref", "refs/pull/899/merge",
+                "--head-sha", NEW_SHA,
+                "--base-ref", "refs/heads/main",
+                "--wait-timeout", "0",
+                "--wait-interval", "0",
+            ],
+            [_analysis(NEW_SHA, PY), _analysis(OLD_SHA, PY)],
+            monkeypatch,
+            tmp_path,
+        )
+        assert code == 0
+        client.fetch_alerts.assert_any_call("refs/pull/899/merge")
+        client.fetch_alerts.assert_any_call("refs/heads/main")
+
+
+_MINIMAL_ARGV = [
+    "--repo", "o/r",
+    "--head-ref", "refs/pull/1/merge",
+    "--base-ref", "refs/heads/main",
+]
+
+
+class TestArgs:
+    def test_head_sha_defaults_to_empty(self):
+        assert gate.parse_args(_MINIMAL_ARGV).head_sha == ""
+
+    def test_wait_timeout_outlasts_a_real_codeql_run(self):
+        # The wait is real now, so the timeout has to cover a CodeQL run + queue time.
+        assert gate.parse_args(_MINIMAL_ARGV).wait_timeout >= 600


### PR DESCRIPTION
## What

`scripts/codeql_pr_gate.py` polled `/code-scanning/analyses?ref=refs/pull/<n>/merge` and returned as soon as **any** analysis existed. On every push after a PR's first, the previous commit's analysis is already there — so the wait returned instantly and the gate then diffed **commit N-1's** alerts.

The gate and `CodeQL Advanced` both fire on `pull_request` with no `needs:` between them, so this is a genuine race, not a rare one.

## Why it matters

- **False red** — it reports alerts the push already fixed. Observed on #899: five alerts, IDs byte-identical to the previous scan, one of them naming a `opened =` binding that had been deleted. A bare re-run then passed with no code change, which teaches people to re-run on red instead of reading the report.
- **False green** — a genuinely new alert on the current commit is missed whenever N-1 happened to be clean. **That direction is the dangerous one**, and it would never have been noticed, because nobody investigates a green gate.

Same shape as the v0.115.0 release incident already written up in `docs/release-fast-lane.md`: waiting on *"a thing exists"* rather than *"the thing for this run exists"*.

## How

Option (1) from the issue — match the commit — since it alone fixes the correctness bug:

- `GitHubClient.list_analyses()` replaces `analyses_exist()`; `wait_for_analysis()` now takes the commit SHA the ref resolves to and requires an analysis **for that SHA**.
- "Complete" means every **category** the previous commit on that ref produced (`/language:python`, `/language:python/advanced`, `/language:javascript-typescript`) has landed for our commit — a partial upload is still a stale diff for the categories not yet in. The required set is read off the ref rather than hardcoded, so adding or removing a CodeQL workflow later needs no change here. On a PR's first push there is no previous commit, so any analysis for the commit counts.
- The workflow passes `--head-sha ${{ github.sha }}` — the ephemeral **merge** commit, which is what CodeQL records as `commit_sha`. Verified against the live API: analysis `commit_sha=547c534b` for `refs/pull/911/merge` is `"Merge d556f4cf into ed097652"`, i.e. neither `head.sha` nor `merge_commit_sha`.
- `--wait-timeout` 300 → 900. The old default was never actually spent (the wait returned instantly); now that it waits for real it has to outlast a CodeQL run (~2–4 min) plus queue time, or the gate would just fail open every time.
- Timeout still **fails open**, with the same loud `::warning` + job-summary note, now naming the commit. It deliberately does **not** fall back to comparing an older commit — that is this bug, and it is worse than not comparing at all.

Option (3) (reordering via `workflow_run`) is left alone: the issue notes it is complementary, and it changes how the check reports on the PR, which needs care with required-checks config.

## Testing

New `tests/unit/test_codeql_pr_gate.py` (16 tests; the script had none). Covers the stale case directly — an analysis exists for the ref but for an older commit → `wait_for_analysis` returns False, and at the `main()` level `fetch_alerts` is **never called** and the gate fails open. Also: partial-category upload keeps waiting, the wait returns once the commit's analysis lands, a PR's first push accepts the only analysis there is, and `workflow_call` (no SHA) keeps its old behaviour.

```
poetry run pytest tests/unit/test_codeql_pr_gate.py -q   # 16 passed
poetry run ruff check tests/unit/test_codeql_pr_gate.py  # clean
```

## Acceptance

The first three boxes on #904 are ticked. The fourth — *"verified on a real PR"* — is observation, not code: this PR's own gate run is the evidence. Look for `CodeQL analysis available for commit <sha>` in the `CodeQL PR Quality Gate` log with the SHA matching this PR's merge commit (or, if CodeQL is slow, the fail-open warning naming that same SHA). Reproducing the full *"push a fix for a flagged alert"* scenario would require deliberately introducing a real CodeQL alert, which is not worth doing to a PR.

Docs: `docs/codeql-pr-gate.md` gains an **Analysis freshness** section recording the trap.

Closes #904

🤖 Generated with [Claude Code](https://claude.com/claude-code)
