### PR TITLE
docs(models): the #842 benchmark run — keep qwen3.5:397b and gpt-oss:120b (closes #842)

### DIFF
--- a/docs/model-benchmarks/2026-08-02-bm-20260802-20ae40.md
+++ b/docs/model-benchmarks/2026-08-02-bm-20260802-20ae40.md
@@ -1,0 +1,252 @@
+# Model-tier benchmark — 2026-08-02 (`bm-20260802-20ae40`)
+
+- **Scoring mode:** `in-runner-judge`
+- **Tiers:** lem-complex, lem-medium
+- **Candidates:** deepseek-v4-flash, gemma4:31b, minimax-m3, glm-5.2
+- **Judge calls spent:** 56 (cap 200)
+
+Inputs are synthetic prompt templates from `tests/benchmarks/model_tiers/`; no customer content, credentials or production logs appear in this report.
+
+## Scorecard
+
+| Tier | Model | Role | Usage | Cases | Deterministic | Judge | Judged | Timeouts | p50 | p90 |
+|---|---|---|---|---|---|---|---|---|---|---|
+| lem-complex | `qwen3.5:397b` | champion | Medium (2) | 10 | 50% (5/10) | 100% | 5 | 0 | 26955 ms | 33333 ms |
+| lem-complex | `deepseek-v4-flash` | candidate | Medium (2) | 10 | 70% (7/10) | 57% | 7 | 0 | 3275 ms | 6651 ms |
+| lem-complex | `gemma4:31b` | candidate | Low (1) | 10 | 80% (8/10) | 57% | 7 | 1 | 2428 ms | 3679 ms |
+| lem-complex | `minimax-m3` | candidate | High (3) | 10 | 40% (4/10) | 75% | 4 | 0 | 30564 ms | 70244 ms |
+| lem-complex | `glm-5.2` | candidate | High (3) | 10 | 70% (7/10) | 86% | 7 | 0 | 14477 ms | 32963 ms |
+| lem-medium | `gpt-oss:120b` | champion | Medium (2) | 10 | 60% (6/10) | 50% | 6 | 0 | 1635 ms | 2339 ms |
+| lem-medium | `deepseek-v4-flash` | candidate | Medium (2) | 10 | 60% (6/10) | 83% | 6 | 0 | 1310 ms | 1706 ms |
+| lem-medium | `gemma4:31b` | candidate | Low (1) | 10 | 40% (4/10) | 100% | 4 | 0 | 807 ms | 1451 ms |
+| lem-medium | `minimax-m3` | candidate | High (3) | 10 | 50% (5/10) | 80% | 5 | 0 | 5405 ms | 17414 ms |
+| lem-medium | `glm-5.2` | candidate | High (3) | 10 | 40% (4/10) | 75% | 4 | 0 | 6315 ms | 15671 ms |
+
+**Usage** is the Ollama Cloud usage level (quota class) — `unknown` where ollama.com publishes no level for that model, which is the case for models that are also pullable locally. Supply those with `--usage-levels model=<level>`.
+
+## Per-expectation detail
+
+### `qwen3.5:397b` — lem-complex (champion)
+
+- ❌ `complex-thought-leadership`
+  - max_chars: 3915 chars > 3000
+- ❌ `complex-personal-story`
+  - max_chars: 3034 chars > 2600
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't perfection; it's; isn't just a buzzword; it's
+  - required_phrases: missing '40'
+- ❌ `complex-industry-news`
+  - max_chars: 2874 chars > 2400
+- ❌ `complex-newsletter-edition`
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't that runbooks are a bad idea; it's
+- ❌ `complex-similarity-guard`
+  - max_chars: 3285 chars > 2400
+
+### `deepseek-v4-flash` — lem-complex (candidate)
+
+- ❌ `complex-industry-news`
+  - slop_lint: uses manufactured "ta-da" transitions that promise a payoff: here's the kicker, let that sink in
+- ❌ `complex-mobile-hook`
+  - required_phrases: mentions none of '34', '6'
+- ❌ `complex-similarity-guard`
+  - slop_lint: uses manufactured "ta-da" transitions that promise a payoff: The result?
+- 🧠 reasoning headroom — 2 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `complex-build-receipt`, `complex-mobile-hook`
+- 🧑‍⚖️ `complex-newsletter-edition`: The answer is incomplete, does not end with the required subscribe CTA, and uses the prohibited 'it's not X, it's Y' frame.
+- 🧑‍⚖️ `complex-promo-artifact-cta`: The answer introduces an unsupported specific number ('first twenty minutes'), violating the contract's prohibition on invented statistics or figures.
+- 🧑‍⚖️ `complex-thought-leadership`: The model changed the supplied fact that queue time was four times longer than build time to three times longer, inventing a statistic not given in the prompt.
+
+### `gemma4:31b` — lem-complex (candidate)
+
+- ❌ `complex-industry-news`
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't just about who manages the platform; it's
+- ❌ `complex-similarity-guard`
+  - slop_lint: uses manufactured "ta-da" transitions that promise a payoff: The result?
+- 🧑‍⚖️ `complex-engagement-prompt`: The answer uses a contrastive frame ('isn't always X, often it's Y') which violates the rubric's requirement to avoid the 'it's not X, it's Y' pattern.
+- 🧑‍⚖️ `complex-newsletter-edition`: The model answer invents the specific time period 'six months ago', which is a number not supplied in the prompt, violating the contract's prohibition on stating specific numbers not given.
+- 🧑‍⚖️ `complex-thought-leadership`: The model invented specific numbers (10 minutes, 40 minutes, 5 minutes, 20 minutes) to illustrate the ratio, which the prompt did not supply, violating the rule against stating specific numbers beyond what the prompt gave.
+
+### `minimax-m3` — lem-complex (candidate)
+
+- ❌ `complex-thought-leadership`
+  - min_chars: 0 chars < 700
+- ❌ `complex-personal-story`
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't whether we'll be perfect. It's; isn't one where nobody breaks things. It's
+  - required_phrases: missing '40'
+- ❌ `complex-industry-news`
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't whether a workload is *on* a platform. It's
+- ❌ `complex-newsletter-edition`
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't that nobody cares. It's; isn't whether your runbooks are good. It's
+- ❌ `complex-mobile-hook`
+  - required_phrases: mentions none of '34', '6'
+- ❌ `complex-similarity-guard`
+  - slop_lint: is an emoji-bulleted listicle (4 emoji-led lines, max 2) — one abstract tip per bullet reads as machine-generated
+- 2 assertion(s) unscored (not counted either way)
+- 🧠 reasoning headroom — 9 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `complex-thought-leadership`, `complex-personal-story`, `complex-industry-news`, `complex-build-receipt`, `complex-carousel-outline`, `complex-newsletter-edition`, `complex-mobile-hook`, `complex-similarity-guard`, `complex-engagement-prompt`
+- 🧑‍⚖️ `complex-promo-artifact-cta`: The answer introduces a specific time frame ('six months ago') that was not supplied in the prompt, violating the contract's rule against stating specific numbers not provided.
+
+### `glm-5.2` — lem-complex (candidate)
+
+- ❌ `complex-thought-leadership`
+  - min_chars: 564 chars < 700
+- ❌ `complex-build-receipt`
+  - min_chars: 389 chars < 500
+- ❌ `complex-newsletter-edition`
+  - min_chars: 751 chars < 800
+- 🧠 reasoning headroom — 5 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `complex-industry-news`, `complex-build-receipt`, `complex-promo-artifact-cta`, `complex-mobile-hook`, `complex-similarity-guard`
+- 🧑‍⚖️ `complex-similarity-guard`: The model answer invents specific numbers ('an hour', 'six months later') and roles ('senior engineers, leads, and stakeholders') not supplied in the prompt, violating the contract's prohibition on stating specific facts beyond what was given.
+
+### `gpt-oss:120b` — lem-medium (champion)
+
+- ❌ `medium-comment-hiring-post`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-comment-respectful-disagreement`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-comment-similarity-guard`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-thread-reply`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🧠 reasoning headroom — 1 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `medium-dm-appreciation`
+- 🧑‍⚖️ `medium-comment-deploy-post`: The model answer invents the number 'weeks' and the outcome 'on‑call engineers started sleeping better', which are facts not supplied by the prompt.
+- 🧑‍⚖️ `medium-json-relevance-score`: The model answer's reason is generic and does not reference the specific details of the post (22 to 4 minutes, test suite splitting), thus failing to engage with the specific content.
+- 🧑‍⚖️ `medium-seed-comment-own-post`: The answer introduces a specific percentage (30%) that was not provided in the prompt, violating the rubric's requirement to state no fact or number that the prompt did not supply.
+
+### `deepseek-v4-flash` — lem-medium (candidate)
+
+- ❌ `medium-comment-hiring-post`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-comment-respectful-disagreement`
+  - comment_contract: fewer than 2 sentences; does not reference a specific claim from the target post; adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-seed-comment-own-post`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-thread-reply`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🧑‍⚖️ `medium-dm-appreciation`: The answer does not add any new information, experience, data point, or question beyond what was already known from the prompt, making it generic filler.
+
+### `gemma4:31b` — lem-medium (candidate)
+
+- ❌ `medium-comment-hiring-post`
+  - comment_contract: does not reference a specific claim from the target post; adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-comment-respectful-disagreement`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-seed-comment-own-post`
+  - comment_contract: fewer than 2 sentences; does not reference a specific claim from the target post
+- ❌ `medium-comment-similarity-guard`
+  - comment_contract: does not reference a specific claim from the target post; adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-blog-summary`
+  - required_phrases: missing '9'
+- ❌ `medium-thread-reply`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+
+### `minimax-m3` — lem-medium (candidate)
+
+- ❌ `medium-comment-deploy-post`
+  - comment_contract: empty comment; fewer than 2 sentences; does not reference a specific claim from the target post; adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-comment-hiring-post`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-comment-respectful-disagreement`
+  - comment_contract: fewer than 2 sentences; adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-comment-similarity-guard`
+  - comment_contract: does not reference a specific claim from the target post; adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-thread-reply`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 1 assertion(s) unscored (not counted either way)
+- 🧠 reasoning headroom — 6 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `medium-comment-deploy-post`, `medium-comment-hiring-post`, `medium-seed-comment-own-post`, `medium-comment-similarity-guard`, `medium-thread-reply`, `medium-dm-appreciation`
+- 🧑‍⚖️ `medium-seed-comment-own-post`: It introduces unsupported numbers ("three or four") not in the prompt, violating the fact/number rule.
+
+### `glm-5.2` — lem-medium (candidate)
+
+- ❌ `medium-comment-deploy-post`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-comment-respectful-disagreement`
+  - comment_contract: does not reference a specific claim from the target post; adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-seed-comment-own-post`
+  - comment_contract: does not reference a specific claim from the target post
+- ❌ `medium-comment-similarity-guard`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-thread-reply`
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-dm-appreciation`
+  - min_chars: 62 chars < 80
+- 🧠 reasoning headroom — 5 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `medium-comment-deploy-post`, `medium-comment-hiring-post`, `medium-comment-similarity-guard`, `medium-blog-summary`, `medium-dm-appreciation`
+- 🧑‍⚖️ `medium-comment-hiring-post`: The comment lacks a personal experience, data point, respectful disagreement, or genuine question as required by the LEM comment quality contract.
+
+## Gate verdicts
+
+### `deepseek-v4-flash` on lem-complex — **reject** (vs champion `qwen3.5:397b`)
+
+- ❌ deterministic floor — 70% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ❌ judge floor — 57% vs floor 80%
+- ✅ beats champion (deterministic) — 70% vs champion 50%
+- ❌ beats champion (judge) — 57% vs champion 100%
+- 💳 usage level — flat on quota — Medium (2) on both sides.
+
+### `gemma4:31b` on lem-complex — **reject** (vs champion `qwen3.5:397b`)
+
+- ❌ deterministic floor — 80% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ❌ judge floor — 57% vs floor 80%
+- ✅ beats champion (deterministic) — 80% vs champion 50%
+- ❌ beats champion (judge) — 57% vs champion 100%
+- 💳 usage level — quota decrease — Low (1) vs champion `qwen3.5:397b` Medium (2) (-1 usage level).
+
+### `minimax-m3` on lem-complex — **reject** (vs champion `qwen3.5:397b`)
+
+- ❌ deterministic floor — 40% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ❌ judge floor — 75% vs floor 80%
+- ❌ beats champion (deterministic) — 40% vs champion 50%
+- ❌ beats champion (judge) — 75% vs champion 100%
+- 💳 usage level — ⚠️ **quota increase** — High (3) vs champion `qwen3.5:397b` Medium (2) (+1 usage level). Every call on this tier burns more Ollama Cloud quota; this is a spend decision, not a free upgrade.
+
+### `glm-5.2` on lem-complex — **reject** (vs champion `qwen3.5:397b`)
+
+- ❌ deterministic floor — 70% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ✅ judge floor — 86% vs floor 80%
+- ✅ beats champion (deterministic) — 70% vs champion 50%
+- ❌ beats champion (judge) — 86% vs champion 100%
+- 💳 usage level — ⚠️ **quota increase** — High (3) vs champion `qwen3.5:397b` Medium (2) (+1 usage level). Every call on this tier burns more Ollama Cloud quota; this is a spend decision, not a free upgrade.
+
+### `deepseek-v4-flash` on lem-medium — **reject** (vs champion `gpt-oss:120b`)
+
+- ❌ deterministic floor — 60% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ✅ judge floor — 83% vs floor 80%
+- ✅ beats champion (deterministic) — 60% vs champion 60%
+- ✅ beats champion (judge) — 83% vs champion 50%
+- 💳 usage level — flat on quota — Medium (2) on both sides.
+
+### `gemma4:31b` on lem-medium — **reject** (vs champion `gpt-oss:120b`)
+
+- ❌ deterministic floor — 40% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ✅ judge floor — 100% vs floor 80%
+- ❌ beats champion (deterministic) — 40% vs champion 60%
+- ✅ beats champion (judge) — 100% vs champion 50%
+- 💳 usage level — quota decrease — Low (1) vs champion `gpt-oss:120b` Medium (2) (-1 usage level).
+
+### `minimax-m3` on lem-medium — **reject** (vs champion `gpt-oss:120b`)
+
+- ❌ deterministic floor — 50% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ✅ judge floor — 80% vs floor 80%
+- ❌ beats champion (deterministic) — 50% vs champion 60%
+- ✅ beats champion (judge) — 80% vs champion 50%
+- 💳 usage level — ⚠️ **quota increase** — High (3) vs champion `gpt-oss:120b` Medium (2) (+1 usage level). Every call on this tier burns more Ollama Cloud quota; this is a spend decision, not a free upgrade.
+
+### `glm-5.2` on lem-medium — **reject** (vs champion `gpt-oss:120b`)
+
+- ❌ deterministic floor — 40% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ❌ judge floor — 75% vs floor 80%
+- ❌ beats champion (deterministic) — 40% vs champion 60%
+- ✅ beats champion (judge) — 75% vs champion 50%
+- 💳 usage level — ⚠️ **quota increase** — High (3) vs champion `gpt-oss:120b` Medium (2) (+1 usage level). Every call on this tier burns more Ollama Cloud quota; this is a spend decision, not a free upgrade.
+
+## Swap recommendations
+
+None. No candidate met its tier's thresholds *and* beat the champion on every graded expectation.
+
+---
+
+Generated by `scripts/benchmark_models.py` (issue #721). Deterministic checks are the in-repo linters (`slop_lint`, the comment quality contract, the `LEMComplexityRouter` tier contract); judge scores come from `in-runner-judge`.

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -119,6 +119,34 @@ still recommended; it means the swap goes to the owner rather than into a config
 holds too, for the same reason it never renders as `flat`: a level nobody read cannot be checked
 against a rule written about increases.
 
+### What the 2026-08-02 run settled (#842)
+
+The first real run of this harness — `bm-20260802-20ae40`, four candidates against both live
+champions, report beside this file — answered the two questions #717 left open. Both answers are
+**keep**, and both are recorded here so the next roster refresh starts from a measurement rather
+than from the spec sheets again:
+
+| Question | Measurement | Decision |
+|---|---|---|
+| `minimax-m3` / `glm-5.2` as `lem-complex`'s quality option | Both **High (3)** vs champion `qwen3.5:397b` **Medium (2)** — `+1` usage level. `glm-5.2` 70% deterministic / 86% judge, `minimax-m3` 40% / 75%, champion 50% / **100%** | **Keep `qwen3.5:397b`.** Neither beat the champion on judge rate, and the standing spend policy buys a usage-level increase only on a *strict* judge-rate win. |
+| Demote `gpt-oss:120b` on `lem-medium` now that `deepseek-v4-flash` + `gemma4:31b` cover the tier | `deepseek-v4-flash` **ties** it deterministically (60% vs 60%) and beats it on judge (83% vs 50%) at the same Medium (2) level; `gemma4:31b` is worse deterministically (40%) though cheaper (Low (1)) | **Keep `gpt-oss:120b` as champion.** Nothing scored a `recommend`, and #717's own rule is that no `recommend`-less candidate gets promoted. `deepseek-v4-flash` is the model to re-measure first next time. |
+
+No swap was recommended, so `.litellm/config.yaml` is unchanged and no restart was owed. All four
+tiers were smoke-tested green against the live proxy anyway (`lem-simple`, `lem-medium`,
+`lem-complex`, `lem-router` — 1-token completions, HTTP 200 on each).
+
+Two caveats the run itself surfaced, both tracked on #910 rather than papered over here:
+
+- **The absolute deterministic floor (90%) was met by nobody, champions included.** The relative
+  half of every verdict is sound, but a floor the incumbent fails cannot open for a challenger
+  either. The per-case failures are real model behaviour (long-form overruns `max_chars`,
+  contrastive frames, the #617 comment contract), not harness artifacts — the suites score a FIRST
+  draft where production ships an n-th.
+- **A reasoning model's single-run score is not stable.** `minimax-m3` returned an empty completion
+  on two cases after exhausting the shipped truncation retry; re-run at the same effective budget it
+  answered and passed both. That would have moved it at most to a tie on each tier, so the decision
+  above stands either way — but one run of one case is a data point, not a verdict.
+
 A recommendation is **not** a change. `.litellm/model_upgrades.yaml` is the RETIREMENT map and the
 reactive half of the model-health check auto-swaps whatever lands in it, so adopting a benchmark
 winner is a deliberate edit to `.litellm/config.yaml` (or a #717-style PR). The report renders the
@@ -168,4 +196,14 @@ policy marks `hold` is named in the report and belongs to the owner, not to the 
 <!-- LEADERBOARD:BEGIN -->
 | Date | Run | Tier | Model | Role | Deterministic | Judge | p50 | Verdict |
 |---|---|---|---|---|---|---|---|---|
+| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `qwen3.5:397b` | champion | 50% | 100% | 26955 ms | baseline |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `deepseek-v4-flash` | candidate | 70% | 57% | 3275 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `gemma4:31b` | candidate | 80% | 57% | 2428 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `minimax-m3` | candidate | 40% | 75% | 30564 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `glm-5.2` | candidate | 70% | 86% | 14477 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `gpt-oss:120b` | champion | 60% | 50% | 1635 ms | baseline |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `deepseek-v4-flash` | candidate | 60% | 83% | 1310 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `gemma4:31b` | candidate | 40% | 100% | 807 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `minimax-m3` | candidate | 50% | 80% | 5405 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `glm-5.2` | candidate | 40% | 75% | 6315 ms | reject |
 <!-- LEADERBOARD:END -->

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -43,6 +43,23 @@ Suite inputs are **synthetic** prompt templates in `tests/benchmarks/model_tiers
 content, credentials or production logs appear in a report; the renderer refuses any run that is
 not tagged as benchmark output.
 
+### Reasoning headroom — measuring a model, not the harness's budget (#842)
+
+Every case fixture carries a `max_tokens`, and a **reasoning** model bills its chain-of-thought
+against it: the answer is whatever is left. At the fixtures' budgets `minimax-m3` and `glm-5.2`
+returned an EMPTY string with `finish_reason='length'`, which the deterministic layer scores as *the
+model produced nothing* — a `reject` earned by the harness, not by the model. The in-runner judge had
+the same failure at its old 200-token budget: every verdict came back empty and read as
+`judge:timeout`, so a run could never produce the judge RATE the standing spend policy needs.
+
+So a completion that spent its whole budget **before emitting anything** is retried at double
+(`BENCHMARK_TRUNCATION_RETRIES`, default 2 — 1400 → 2800 → 5600), champion and candidate alike. A
+truncated-but-**non-empty** answer is never re-rolled: that is the model's real output at that
+budget, and re-rolling it would hand the verbose models a second attempt the concise ones never got.
+Cases that needed the headroom are named in the report under 🧠 *reasoning headroom* rather than
+silently absorbed. Production long-form calls set no `max_tokens` at all, so the retry measures the
+model the way LEM actually uses it.
+
 ## The gate
 
 A candidate is emitted as a **swap recommendation** only when it clears the tier's absolute

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -57,8 +57,18 @@ So a completion that spent its whole budget **before emitting anything** is retr
 truncated-but-**non-empty** answer is never re-rolled: that is the model's real output at that
 budget, and re-rolling it would hand the verbose models a second attempt the concise ones never got.
 Cases that needed the headroom are named in the report under 🧠 *reasoning headroom* rather than
-silently absorbed. Production long-form calls set no `max_tokens` at all, so the retry measures the
-model the way LEM actually uses it.
+silently absorbed. Only the FINAL attempt is measured — a discarded one is harness waste production
+never pays, so its wall-clock is not charged to the model's p50/p90 — and a retried verdict counts
+its real completions against `BENCHMARK_MAX_JUDGE_CALLS`, so the run's cap still bounds spend.
+
+**Where the retry does NOT measure production.** Long-form generation sets no `max_tokens` at all
+(`ai_helper.py`), so on `lem-complex` a doubled budget is closer to the real call than the fixture's
+own cap was. The short tiers are the opposite: `lem-simple`'s `simple-relevance-yes-no` is
+`max_tokens: 3` precisely because `ai_helper.py`'s relevance check is, and there a model that cannot
+answer inside the budget is disqualified in production, not merely truncated. The retry currently
+applies to every case, so on those cases it measures a model LEM could not actually run at that call
+site. Calibrating that (per-case opt-out, or scoring the first attempt for production-mirror
+budgets) is tracked on #910 with the rest of the harness-calibration work.
 
 ## The gate
 
@@ -146,6 +156,13 @@ Two caveats the run itself surfaced, both tracked on #910 rather than papered ov
   on two cases after exhausting the shipped truncation retry; re-run at the same effective budget it
   answered and passed both. That would have moved it at most to a tie on each tier, so the decision
   above stands either way — but one run of one case is a data point, not a verdict.
+
+**Read this run's p50/p90 with one correction.** `bm-20260802-20ae40` was measured before the
+per-attempt timing rule above, so a retried case charged every discarded attempt to the model.
+`minimax-m3` (9 of 10 `lem-complex` cases retried) and `glm-5.2` (5 of 10) are inflated in that
+run's leaderboard rows by roughly the retry factor; the deterministic and judge columns, which is
+what the verdicts turn on, are unaffected. Later runs report the answering attempt only, so do not
+compare them against these two rows as if they were the same measurement.
 
 A recommendation is **not** a change. `.litellm/model_upgrades.yaml` is the RETIREMENT map and the
 reactive half of the model-health check auto-swaps whatever lands in it, so adopting a benchmark

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -168,6 +168,26 @@ def judge_timeout_seconds() -> int:
     return _env_int("BENCHMARK_JUDGE_TIMEOUT_SECONDS", 90, low=5, high=900)
 
 
+# Reasoning models bill their chain-of-thought against `max_tokens`, and the visible answer is
+# whatever is left. Every case fixture and the in-runner judge were written against non-reasoning
+# models, so on `minimax-m3` / `glm-5.2` / `gpt-oss:120b` the budget is spent thinking and the reply
+# arrives EMPTY with `finish_reason='length'` — which scores as "the model produced nothing" rather
+# than "the harness cut it off". That is the difference between measuring a model and rejecting it
+# for a harness artifact, so a truncated-before-the-answer reply is retried at a doubled budget.
+# Bounded, and applied identically to champion and candidate so neither side gets a bigger budget
+# than the other.
+
+def truncation_retries() -> int:
+    """How many times a completion truncated before its answer may be retried at double budget."""
+    return _env_int("BENCHMARK_TRUNCATION_RETRIES", 2, low=0, high=4)
+
+
+def judge_max_tokens() -> int:
+    """Completion budget for one in-runner judge verdict. The verdict itself is ~40 tokens; the rest
+    is headroom for a reasoning judge, since `lem-medium` is currently served by `gpt-oss:120b`."""
+    return _env_int("BENCHMARK_JUDGE_MAX_TOKENS", 900, low=200, high=8000)
+
+
 def _today() -> str:
     return datetime.now(timezone.utc).date().isoformat()
 
@@ -527,6 +547,8 @@ def merge_scorecard(tier: str, model: str, role: str, case_results: list,
     latencies = [v for v in latencies if isinstance(v, (int, float))]
     tokens = sum(int(timings.get(r["case_id"], {}).get("total_tokens") or 0)
                  for r in case_results)
+    escalated = [r["case_id"] for r in case_results
+                 if int(timings.get(r["case_id"], {}).get("budget_escalations") or 0) > 0]
 
     return {
         "tier": tier, "model": model, "role": role,
@@ -547,6 +569,7 @@ def merge_scorecard(tier: str, model: str, role: str, case_results: list,
         "latency_p50_ms": _percentile(latencies, 0.5),
         "latency_p90_ms": _percentile(latencies, 0.9),
         "total_tokens": tokens,
+        "budget_escalated_cases": escalated,
         "case_results": case_results,
     }
 
@@ -942,6 +965,11 @@ def render_report(run: dict) -> str:
         if card.get("unscored_assertions"):
             lines.append(f"- {card['unscored_assertions']} assertion(s) unscored "
                          "(not counted either way)")
+        escalated = card.get("budget_escalated_cases") or []
+        if escalated:
+            lines.append(f"- 🧠 reasoning headroom — {len(escalated)} case(s) spent the fixture's "
+                         "whole completion budget thinking and were retried at a larger one: "
+                         + ", ".join(f"`{c}`" for c in escalated))
         for note in card.get("judge_notes") or []:
             lines.append(f"- 🧑‍⚖️ `{note['case_id']}`: {note['reasoning']}")
         lines.append("")
@@ -1313,16 +1341,33 @@ class ProviderClient:
 
     def complete(self, model: str, messages: list, params: Optional[dict] = None) -> dict:
         started = time.time()
-        try:
-            response = self._openai().chat.completions.create(
-                model=model, messages=messages, **(params or {}))
-        except Exception as exc:  # noqa: BLE001 - a provider failure is a case result, not a crash
-            return {"text": None, "error": str(exc)[:200],
-                    "latency_ms": (time.time() - started) * 1000.0, "usage": {}}
+        call_params = dict(params or {})
+        budget = call_params.get("max_tokens")
+        escalations = 0
+        allowed = truncation_retries() if isinstance(budget, int) and budget > 0 else 0
+        while True:
+            try:
+                response = self._openai().chat.completions.create(
+                    model=model, messages=messages, **call_params)
+            except Exception as exc:  # noqa: BLE001 - a provider failure is a case result, not a crash
+                return {"text": None, "error": str(exc)[:200], "budget_escalations": escalations,
+                        "latency_ms": (time.time() - started) * 1000.0, "usage": {}}
+            choice = response.choices[0]
+            text = (choice.message.content or "").strip()
+            # Only an EMPTY reply is retried. A truncated-but-present answer is the model's real
+            # output at this budget, and re-rolling it would quietly hand the verbose models a
+            # second chance the concise ones never needed.
+            if text or escalations >= allowed or getattr(choice, "finish_reason", None) != "length":
+                break
+            escalations += 1
+            call_params["max_tokens"] = budget * (2 ** escalations)
+            print(f"  {model} spent its whole {budget * (2 ** (escalations - 1))}-token budget "
+                  f"before answering — retrying at {call_params['max_tokens']}", file=sys.stderr)
         usage = getattr(response, "usage", None)
         return {
-            "text": (response.choices[0].message.content or "").strip(),
+            "text": text,
             "error": None,
+            "budget_escalations": escalations,
             "latency_ms": (time.time() - started) * 1000.0,
             "usage": {"prompt_tokens": getattr(usage, "prompt_tokens", None),
                       "completion_tokens": getattr(usage, "completion_tokens", None),
@@ -1438,10 +1483,19 @@ def fallback_judge(suite: dict, case: dict, output: str) -> dict:
     provider configured (Ollama Cloud is not one) or the evaluation API is unreachable."""
     try:
         from cqc_lem.utilities.ai.client import client
-        response = client.chat.completions.create(
-            model="lem-medium", messages=judge_messages(suite, case, output),
-            temperature=0, max_tokens=200)
-        return parse_judge_verdict(response.choices[0].message.content)
+        budget = judge_max_tokens()
+        for attempt in range(truncation_retries() + 1):
+            response = client.chat.completions.create(
+                model="lem-medium", messages=judge_messages(suite, case, output),
+                temperature=0, max_tokens=budget * (2 ** attempt))
+            choice = response.choices[0]
+            text = str(choice.message.content or "").strip()
+            if text or getattr(choice, "finish_reason", None) != "length":
+                return parse_judge_verdict(text)
+        # Unscored, but NOT `judge:unavailable` — that flag stops the runner asking for the rest of
+        # the run, and a judge that reasoned past its budget on ONE answer is still reachable.
+        return {"passes": None, "status": JUDGE_TIMEOUT,
+                "reasoning": "judge reasoned past its token budget before reaching a verdict"}
     except Exception as exc:  # noqa: BLE001 - an unavailable judge is unscored, never a pass
         return {"passes": None, "status": JUDGE_UNAVAILABLE,
                 "reasoning": f"fallback judge unavailable: {str(exc)[:120]}"}
@@ -1557,7 +1611,8 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
             outputs[case_id] = completion.get("text")
             errors[case_id] = completion.get("error")
             timings[case_id] = {"latency_ms": completion.get("latency_ms"),
-                                "total_tokens": (completion.get("usage") or {}).get("total_tokens")}
+                                "total_tokens": (completion.get("usage") or {}).get("total_tokens"),
+                                "budget_escalations": completion.get("budget_escalations") or 0}
             if not dry_run and completion.get("text") and evals is not None:
                 event_id = emit_generation(run_id, tier, case, model, role, completion)
                 if event_id:

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -1340,12 +1340,16 @@ class ProviderClient:
         return self._client
 
     def complete(self, model: str, messages: list, params: Optional[dict] = None) -> dict:
-        started = time.time()
         call_params = dict(params or {})
         budget = call_params.get("max_tokens")
         escalations = 0
         allowed = truncation_retries() if isinstance(budget, int) and budget > 0 else 0
         while True:
+            # Timed PER ATTEMPT, not across the retries. A discarded attempt is harness waste that
+            # production never pays (long-form calls set no `max_tokens` at all), so charging its
+            # wall-clock to the model would inflate p50/p90 for exactly the reasoning models this
+            # retry exists to measure — and those numbers go into the rolling leaderboard forever.
+            started = time.time()
             try:
                 response = self._openai().chat.completions.create(
                     model=model, messages=messages, **call_params)
@@ -1480,24 +1484,30 @@ def emit_metric(run_id: str, tier: str, case_id: str, model: str, verdict: dict)
 
 def fallback_judge(suite: dict, case: dict, output: str) -> dict:
     """The degraded judge: `lem-medium` through LEM's own client. Used when PostHog has no judge
-    provider configured (Ollama Cloud is not one) or the evaluation API is unreachable."""
+    provider configured (Ollama Cloud is not one) or the evaluation API is unreachable.
+
+    Reports `judge_calls` — the number of completions this verdict actually cost. A truncation retry
+    is a real billed call, so the run's cap has to count it; counting one verdict as one call would
+    let `BENCHMARK_MAX_JUDGE_CALLS` be overrun by the retry factor without ever saying so."""
+    calls = 0
     try:
         from cqc_lem.utilities.ai.client import client
         budget = judge_max_tokens()
         for attempt in range(truncation_retries() + 1):
+            calls += 1
             response = client.chat.completions.create(
                 model="lem-medium", messages=judge_messages(suite, case, output),
                 temperature=0, max_tokens=budget * (2 ** attempt))
             choice = response.choices[0]
             text = str(choice.message.content or "").strip()
             if text or getattr(choice, "finish_reason", None) != "length":
-                return parse_judge_verdict(text)
+                return dict(parse_judge_verdict(text), judge_calls=calls)
         # Unscored, but NOT `judge:unavailable` — that flag stops the runner asking for the rest of
         # the run, and a judge that reasoned past its budget on ONE answer is still reachable.
-        return {"passes": None, "status": JUDGE_TIMEOUT,
+        return {"passes": None, "status": JUDGE_TIMEOUT, "judge_calls": calls,
                 "reasoning": "judge reasoned past its token budget before reaching a verdict"}
     except Exception as exc:  # noqa: BLE001 - an unavailable judge is unscored, never a pass
-        return {"passes": None, "status": JUDGE_UNAVAILABLE,
+        return {"passes": None, "status": JUDGE_UNAVAILABLE, "judge_calls": max(calls, 1),
                 "reasoning": f"fallback judge unavailable: {str(exc)[:120]}"}
 
 
@@ -1633,6 +1643,12 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
                 print(f"  judge cap reached — {skipped} case(s) unscored for {model}/{tier}",
                       file=sys.stderr)
             for case_id in planned:
+                # `planned` was sized one call per case, but a truncation-retried verdict costs
+                # more than one — so the cap is re-checked here rather than only between models.
+                if judge_spent >= judge_budget:
+                    print(f"  judge cap reached mid-suite — {model}/{tier} stopped at "
+                          f"{judge_spent} call(s)", file=sys.stderr)
+                    break
                 case = _case_by_id(suite, case_id)
                 if dry_run:
                     canned = _canned(case)
@@ -1669,7 +1685,7 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
                               "the remaining cases are reported unscored", file=sys.stderr)
                     else:
                         emit_metric(run_id, tier, case_id, model, verdict)
-                judge_spent += 1
+                judge_spent += int((judge_results.get(case_id) or {}).get("judge_calls") or 1)
 
         card = merge_scorecard(tier, model, role, case_results, judge_results, timings)
         card["benchmark_run_id"] = run_id
@@ -1699,7 +1715,7 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
                     break
                 replacement = fallback_judge(suite, _case_by_id(suite, case_id),
                                              outputs.get(case_id) or "")
-                judge_spent += 1
+                judge_spent += int(replacement.get("judge_calls") or 1)
                 if replacement.get("status") == JUDGE_UNAVAILABLE:
                     fallback_down = True
                 if replacement.get("passes") is None:

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -561,6 +561,8 @@ class TestJudge:
         assert verdict["passes"] is True and verdict["status"] == "scored"
         assert [c.kwargs["max_tokens"]
                 for c in client.chat.completions.create.call_args_list] == [900, 1800]
+        # A retry is a real billed call — the run's cap has to see both of them.
+        assert verdict["judge_calls"] == 2
 
     def test_a_judge_that_never_stops_reasoning_is_unscored_but_still_reachable(self, monkeypatch):
         # JUDGE_UNAVAILABLE would stop the runner asking for the REST of the run; one over-thought
@@ -571,6 +573,7 @@ class TestJudge:
             verdict = bm.fallback_judge(_suite(), _case(), "out")
         assert verdict["passes"] is None and verdict["status"] == bm.JUDGE_TIMEOUT
         assert client.chat.completions.create.call_count == 2
+        assert verdict["judge_calls"] == 2
 
     def test_fallback_judge_returns_unscored_when_the_client_fails(self):
         with patch.dict(sys.modules, {}):
@@ -730,6 +733,19 @@ class TestProviderClient:
         result = provider.complete("m", [{"role": "user", "content": "hi"}], {"temperature": 0.8})
         assert result["budget_escalations"] == 0
         assert openai_client.chat.completions.create.call_count == 1
+
+    def test_a_discarded_attempt_is_not_charged_to_the_model_s_latency(self, monkeypatch):
+        # p50/p90 go into the rolling leaderboard forever. Charging the thrown-away attempt to the
+        # model would inflate exactly the reasoning models this retry exists to measure fairly.
+        monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "1")
+        provider, openai_client = self._client()
+        openai_client.chat.completions.create.side_effect = [
+            self._reply("", finish_reason="length"), self._reply("the draft")]
+        # attempt-1 start, attempt-2 start, end-of-attempt-2
+        monkeypatch.setattr(bm.time, "time", MagicMock(side_effect=[100.0, 140.0, 140.25]))
+        result = provider.complete("m", [{"role": "user", "content": "hi"}], {"max_tokens": 100})
+        assert result["budget_escalations"] == 1
+        assert result["latency_ms"] == pytest.approx(250.0)
 
 
 class TestPostHogClient:
@@ -1284,6 +1300,26 @@ class TestRunBenchmark:
                                    evals=evals, judge_cap=1)
         assert fj.call_count == 0  # the single PostHog trigger already spent the cap
         assert run["judge_calls"] == 1
+
+    def test_a_truncation_retried_verdict_spends_the_cap_it_actually_cost(self):
+        # `BENCHMARK_MAX_JUDGE_CALLS` is a spend ceiling. A verdict that took three completions to
+        # arrive must count three, or a retrying judge overruns the cap by the retry factor with
+        # the report still printing "N of 200".
+        suites = {"lem-simple": _suite("lem-simple", cases=[
+            _case(cid, assertions=[{"type": "max_chars", "value": 50}]) for cid in ("a", "b", "c")],
+            thresholds={"min_judged": 1})}
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "short", "error": None,
+                                          "latency_ms": 5.0, "usage": {}}
+        with patch.object(bm, "emit_metric"), \
+                patch.object(bm, "fallback_judge",
+                             return_value={"passes": True, "status": "scored",
+                                           "reasoning": "", "judge_calls": 3}) as fj:
+            run = bm.run_benchmark(suites, [], {"lem-simple": "champ"}, run_id="bm-1",
+                                   today="2026-07-27", provider=provider, evals=None,
+                                   judge_cap=4)
+        assert fj.call_count == 2  # the second verdict reached the cap; the third case is unscored
+        assert run["judge_calls"] == 6
 
     def test_an_unreachable_in_runner_judge_is_asked_once_not_once_per_case(self):
         suites = {"lem-simple": _suite("lem-simple", cases=[

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -267,6 +267,14 @@ class TestScorecard:
         card = bm.merge_scorecard("lem-simple", "m", "candidate", results, {})
         assert card["judge_pass_rate"] is None
 
+    def test_cases_that_needed_reasoning_headroom_are_named_not_silently_absorbed(self):
+        results = [{"case_id": "a", "passes": True, "failures": [], "unscored": 0},
+                   {"case_id": "b", "passes": True, "failures": [], "unscored": 0}]
+        timings = {"a": {"latency_ms": 1, "budget_escalations": 2},
+                   "b": {"latency_ms": 1, "budget_escalations": 0}}
+        card = bm.merge_scorecard("lem-complex", "minimax-m3", "candidate", results, {}, timings)
+        assert card["budget_escalated_cases"] == ["a"]
+
 
 # ─────────────────────────── champion/challenger gate ────────────────────────────
 
@@ -416,6 +424,12 @@ class TestRendering:
         assert '"old": "new"' in text
         assert "➖" in text  # an unscored expectation is shown, not hidden
 
+    def test_report_names_the_cases_that_needed_reasoning_headroom(self):
+        run = self._run()
+        run["scorecards"][0]["budget_escalated_cases"] = ["complex-personal-story"]
+        text = bm.render_report(run)
+        assert "reasoning headroom" in text and "`complex-personal-story`" in text
+
     def test_report_says_so_when_nothing_is_recommended(self):
         run = self._run()
         run["recommendations"] = []
@@ -515,6 +529,40 @@ class TestJudge:
             verdict = bm.parse_judge_verdict(reply)
             assert verdict["passes"] is None
             assert verdict["status"] == bm.JUDGE_TIMEOUT
+
+    def _judge_client(self, replies):
+        client = MagicMock()
+        client.chat.completions.create.side_effect = [
+            MagicMock(choices=[MagicMock(message=MagicMock(content=content),
+                                         finish_reason=finish)])
+            for content, finish in replies]
+        module = MagicMock()
+        module.client = client
+        return client, patch.dict(sys.modules, {"cqc_lem.utilities.ai.client": module})
+
+    def test_a_reasoning_judge_that_truncates_is_retried_before_it_is_written_off(self,
+                                                                                  monkeypatch):
+        # `lem-medium` is served by gpt-oss:120b, whose reasoning is billed against max_tokens — at
+        # the old 200-token budget EVERY verdict came back empty and the whole run read as unscored.
+        monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "2")
+        monkeypatch.setenv("BENCHMARK_JUDGE_MAX_TOKENS", "900")
+        client, patched = self._judge_client([("", "length"),
+                                              ('{"pass": true, "reasoning": "ok"}', "stop")])
+        with patched:
+            verdict = bm.fallback_judge(_suite(), _case(), "out")
+        assert verdict["passes"] is True and verdict["status"] == "scored"
+        assert [c.kwargs["max_tokens"]
+                for c in client.chat.completions.create.call_args_list] == [900, 1800]
+
+    def test_a_judge_that_never_stops_reasoning_is_unscored_but_still_reachable(self, monkeypatch):
+        # JUDGE_UNAVAILABLE would stop the runner asking for the REST of the run; one over-thought
+        # answer is not a dead judge.
+        monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "1")
+        client, patched = self._judge_client([("", "length"), ("", "length")])
+        with patched:
+            verdict = bm.fallback_judge(_suite(), _case(), "out")
+        assert verdict["passes"] is None and verdict["status"] == bm.JUDGE_TIMEOUT
+        assert client.chat.completions.create.call_count == 2
 
     def test_fallback_judge_returns_unscored_when_the_client_fails(self):
         with patch.dict(sys.modules, {}):
@@ -620,6 +668,60 @@ class TestProviderClient:
         result = provider.complete("m", [{"role": "user", "content": "hi"}])
         assert result["text"] is None
         assert "410" in result["error"]
+
+    @staticmethod
+    def _reply(content, finish_reason="stop"):
+        response = MagicMock()
+        response.choices = [MagicMock(message=MagicMock(content=content),
+                                      finish_reason=finish_reason)]
+        response.usage = MagicMock(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+        return response
+
+    def test_a_reasoning_model_that_spends_its_budget_thinking_is_retried_at_double(self,
+                                                                                   monkeypatch):
+        # minimax-m3 / glm-5.2 bill chain-of-thought against max_tokens: at the fixture's budget the
+        # reply comes back EMPTY, which would score as "produced nothing" and reject the candidate
+        # for a harness artifact rather than for its quality.
+        monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "2")
+        provider, openai_client = self._client()
+        openai_client.chat.completions.create.side_effect = [
+            self._reply("", finish_reason="length"),
+            self._reply("", finish_reason="length"),
+            self._reply("the long-form draft"),
+        ]
+        result = provider.complete("minimax-m3", [{"role": "user", "content": "hi"}],
+                                   {"max_tokens": 1400})
+        assert result["text"] == "the long-form draft"
+        assert result["budget_escalations"] == 2
+        budgets = [c.kwargs["max_tokens"]
+                   for c in openai_client.chat.completions.create.call_args_list]
+        assert budgets == [1400, 2800, 5600]
+
+    def test_the_retry_is_bounded_and_the_empty_answer_still_counts(self, monkeypatch):
+        monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "1")
+        provider, openai_client = self._client()
+        openai_client.chat.completions.create.return_value = self._reply("",
+                                                                         finish_reason="length")
+        result = provider.complete("m", [{"role": "user", "content": "hi"}], {"max_tokens": 100})
+        assert result["text"] == ""
+        assert result["budget_escalations"] == 1
+        assert openai_client.chat.completions.create.call_count == 2
+
+    def test_a_truncated_but_non_empty_answer_is_never_re_rolled(self, monkeypatch):
+        # Retrying a model that DID answer would hand the verbose ones a second attempt the concise
+        # ones never got — the comparison has to stay one call per case wherever an answer exists.
+        monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "2")
+        provider, openai_client = self._client(self._reply("half a dr", finish_reason="length"))
+        result = provider.complete("m", [{"role": "user", "content": "hi"}], {"max_tokens": 100})
+        assert result["text"] == "half a dr" and result["budget_escalations"] == 0
+        assert openai_client.chat.completions.create.call_count == 1
+
+    def test_a_case_with_no_max_tokens_is_never_escalated(self, monkeypatch):
+        monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "2")
+        provider, openai_client = self._client(self._reply("", finish_reason="length"))
+        result = provider.complete("m", [{"role": "user", "content": "hi"}], {"temperature": 0.8})
+        assert result["budget_escalations"] == 0
+        assert openai_client.chat.completions.create.call_count == 1
 
 
 class TestPostHogClient:

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -470,17 +470,25 @@ class TestRendering:
     def test_repeated_renders_never_grow_the_table_with_its_own_header(self):
         """The header and divider are pipe-delimited rows of the right width. Reading them back as
         DATA appended two junk rows per run and evicted real history at the row cap."""
+        def table_rows(doc: str) -> list:
+            inner = doc.split(bm.LEADERBOARD_BEGIN)[1].split(bm.LEADERBOARD_END)[0]
+            return [line for line in inner.splitlines() if line.strip().startswith("|")]
+
         text = (_ROOT / "docs" / "model-benchmarks" / "README.md").read_text()
+        # Measured against whatever history the committed table holds TODAY — a real run's rows
+        # land in it, so a fixed expected count would fail on the next benchmark instead of on a
+        # regression.
+        committed = len(table_rows(text)) - 2
         for run_id in ("bm-1", "bm-2", "bm-3"):
             run = self._run()
             run["run_id"] = run_id
             for card in run["scorecards"]:
                 card["benchmark_run_id"] = run_id
             text = bm.update_leaderboard(text, bm.leaderboard_rows(run))
-        inner = text.split(bm.LEADERBOARD_BEGIN)[1].split(bm.LEADERBOARD_END)[0]
-        rows = [line for line in inner.splitlines() if line.strip().startswith("|")]
+        rows = table_rows(text)
         assert rows[0] == bm.LEADERBOARD_HEADER and rows[1] == bm.LEADERBOARD_DIVIDER
-        assert len(rows) == 2 + 6  # three runs × two scorecards, and nothing else
+        # three runs × two scorecards on top of the committed history, and nothing else
+        assert len(rows) == 2 + committed + 6
         assert bm.LEADERBOARD_HEADER not in rows[2:]
 
     def test_the_committed_leaderboard_has_the_markers(self):


### PR DESCRIPTION
The live half of #842 — the run the config PR (#864) could not do headless. Four candidates
(`deepseek-v4-flash`, `gemma4:31b`, `minimax-m3`, `glm-5.2`) measured by the #721 harness beside
**both** reigning champions, on `lem-complex` and `lem-medium`, usage level read for every model on
both sides.

**Scorecard:** [`docs/model-benchmarks/2026-08-02-bm-20260802-20ae40.md`](docs/model-benchmarks/2026-08-02-bm-20260802-20ae40.md) (run `bm-20260802-20ae40`, 56 judge calls of a 200 cap, synthetic fixtures only — no user data).

| Tier | Model | Role | Usage | Deterministic | Judge | Verdict |
|---|---|---|---|---|---|---|
| lem-complex | `qwen3.5:397b` | champion | Medium (2) | 50% | **100%** | baseline |
| lem-complex | `glm-5.2` | candidate | **High (3)** | 70% | 86% | reject |
| lem-complex | `deepseek-v4-flash` | candidate | Medium (2) | 70% | 57% | reject |
| lem-complex | `gemma4:31b` | candidate | Low (1) | 80% | 57% | reject |
| lem-complex | `minimax-m3` | candidate | **High (3)** | 40% | 75% | reject |
| lem-medium | `gpt-oss:120b` | champion | Medium (2) | 60% | 50% | baseline |
| lem-medium | `deepseek-v4-flash` | candidate | Medium (2) | 60% | 83% | reject |
| lem-medium | `minimax-m3` | candidate | **High (3)** | 50% | 80% | reject |
| lem-medium | `gemma4:31b` | candidate | Low (1) | 40% | 100% | reject |
| lem-medium | `glm-5.2` | candidate | **High (3)** | 40% | 75% | reject |

## The two open questions — both answer **keep**

**1. `minimax-m3` / `glm-5.2` as `lem-complex`'s quality option → keep `qwen3.5:397b`.**
Both are **High (3)** against the champion's **Medium (2)** — a `+1` usage level on *every* long-form
call, not a free upgrade. Neither beat the champion's **100%** judge rate (`glm-5.2` 86%,
`minimax-m3` 75%). The standing spend policy recorded on this issue (`2A`) buys a usage-level
increase only on a **strict judge-rate win**, so neither is adoptable — the quota delta is stated in
numbers on every verdict in the report (`💳 usage level — ⚠️ quota increase … +1 usage level`).

**2. `gpt-oss:120b` demotion → explicitly kept as `lem-medium`'s champion.**
`deepseek-v4-flash` *ties* it deterministically (60% vs 60%) and beats it on judge (83% vs 50%) at
the same Medium (2) level — the strongest case any candidate made — but scored no `recommend`, and
#717's own rule is that no `recommend`-less candidate is promoted. `gemma4:31b` is cheaper (Low (1))
but worse deterministically (40%). Kept, not left open; `deepseek-v4-flash` is the model to
re-measure first next time.

**No swap was recommended**, so `.litellm/config.yaml` is unchanged in this PR and no litellm restart
was owed. Recommendations are rendered, never written — nothing here moves a tier alias.

## Smoke test — all four tiers green against the live proxy

Re-run at PR time (1-token completions through the running litellm proxy, no restart involved since
no config changed):

```
lem-simple  -> HTTP 200 | resolved=lem-simple
lem-medium  -> HTTP 200 | resolved=lem-medium
lem-complex -> HTTP 200 | resolved=lem-complex
lem-router  -> HTTP 200 | resolved=lem-router
```

## Also in this PR — a harness fix the run forced

`minimax-m3` and `glm-5.2` bill chain-of-thought against `max_tokens`, so at the fixtures' budgets
they returned an **empty** completion with `finish_reason='length'` — scored as "produced nothing"
and rejected for a harness artifact rather than for quality. The in-runner judge had the same failure
at its 200-token budget: every verdict came back empty and read as `judge:timeout`, so no run could
produce the judge RATE the spend policy needs.

A completion that spends its whole budget **before emitting anything** is now retried at double
(`BENCHMARK_TRUNCATION_RETRIES`, default 2), applied identically to champion and candidate. A
truncated-but-**non-empty** answer is never re-rolled — that is the model's real output, and
re-rolling it would hand the verbose models a second attempt the concise ones never got. Cases that
needed the headroom are named in the report under 🧠 *reasoning headroom*, not silently absorbed.

## Two caveats the run surfaced — tracked, not papered over

Both live on **#910** (filed, `agent:ready`), because they are calibration questions about the
harness rather than answers this run can give:

- **Nobody cleared the 90% absolute deterministic floor — champions included.** The *relative* half
  of every verdict above is sound (no candidate beat its champion outright), but a floor the
  incumbent itself fails cannot open for a challenger either, so as calibrated the gate can never
  emit a `recommend`. The per-case failures are real model behaviour (long-form overruns `max_chars`,
  contrastive frames, the #617 comment contract) — the suites score a FIRST draft where production
  ships an n-th, after the regeneration gates.
- **A reasoning model's single-run score is not stable.** `minimax-m3` returned an empty completion
  on two cases after exhausting the shipped truncation retry; re-run at the same effective budget it
  answered and passed both (`complex-thought-leadership` 2122 chars, `medium-comment-deploy-post`
  424 chars). That would have moved it at most to a **tie** on each tier, so the keep decisions above
  stand either way — but one run of one case is a data point, not a verdict.

## Testing

- `tests/unit/test_benchmark_models.py` — 154 passed. New coverage for the truncation retry
  (empty-and-length retries and doubles; non-empty truncation does not; the retry budget is bounded;
  champion and candidate treated identically).
- The leaderboard test counted rows against an empty committed table; it now measures the **delta**,
  so the next real run doesn't fail it.
- Live run itself is the integration evidence: `bm-20260802-20ae40`, 100 completions + 56 judge
  calls, all against synthetic fixtures.

Follow-up: #910

Closes #842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
