### PR TITLE
fix(benchmarks): recalibrate the deterministic floor so the gate can open (closes #910)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,8 +225,13 @@ property can't be decided locally). Three registered: `cost-routing-arm`, `comme
 `scripts/benchmark_models.py` measures candidates vs each tier's contract suite (NO user data),
 always beside the current champion. Deterministic is source of truth (in-repo linters, not a
 copy); LLM judge is PostHog Evaluations filtered on `benchmark_run_id` (production never carries
-it → customer never billed). Only `recommend` becomes a swap; recommendations are RENDERED, never
-written (`.litellm/model_upgrades.yaml` is the retirement map). Full posture:
+it → customer never billed). **The suite scores a FIRST draft, production ships an n-th** (#910), so
+every check is classed by what production does with its failure: `contract` (the call site consumes
+it — the ABSOLUTE floor) vs `repairable` (a regeneration gate retries it — advisory, still
+champion-relative). A case whose `max_tokens` mirrors a call site (`budget_mirrors_production`) is
+never retried at a bigger budget; an EMPTY completion is re-measured at the same one, and a still-
+empty one is no output, never a 0-char answer. Only `recommend` becomes a swap; recommendations are
+RENDERED, never written (`.litellm/model_upgrades.yaml` is the retirement map). Full posture:
 `docs/model-benchmarks/README.md`.
 
 ### Content-quality telemetry (issue #630)

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -28,7 +28,7 @@ Two scoring layers, in this order:
 1. **Deterministic** (free, in-repo, the source of truth) — length caps, comma-list shape, JSON
    validity, `slop_lint.lint_report`, `content_framework.comment_contract_report`, burstiness,
    lexical self-similarity, and `routing_policy.complexity_tier`. A case that fails here never
-   spends a judge call.
+   spends a judge call. Reported as **two** rates — see *What the deterministic rates mean* below.
 2. **LLM judge** (paid, capped) — PostHog Evaluations scoring the harness's own tagged
    `$ai_generation` events, filtered to a `benchmark_run_id` so it can never bill against
    production traffic. With no judge provider configured, the runner degrades to an in-runner
@@ -42,6 +42,49 @@ Two scoring layers, in this order:
 Suite inputs are **synthetic** prompt templates in `tests/benchmarks/model_tiers/`. No customer
 content, credentials or production logs appear in a report; the renderer refuses any run that is
 not tagged as benchmark output.
+
+### What the deterministic rates mean — the floor, recalibrated (#910)
+
+The first real run measured 40–80% deterministic pass rates for every model in the roster **including
+both reigning champions**, against a 90% absolute floor. A floor the incumbent itself fails is not a
+floor — it is a gate that can never open, so a genuinely better model would have landed as `reject`
+and nobody would have noticed.
+
+The failures were real model behaviour, not harness artifacts. What was wrong was treating them all
+as the same KIND of failure. **The suite scores a first draft; production ships an n-th**, because
+every surface with a deterministic quality check has a bounded regeneration behind it:
+
+| Production path | What it retries against | What happens if it still fails |
+|---|---|---|
+| `ai_helper.lint_repaired` (seed comments, thread replies, DMs) | `slop_lint` hard checks | ships with a structured warning |
+| `ai_helper._gated_comment` (#617 feed + second-wave comments) | comment quality contract, similarity, slop lint | the post is **skipped** — no comment is posted |
+| `run_content_plan._review_generated_post` + `evaluate_post_gates` | slop lint, similarity, fabricated specifics | the post is **held** at pending for review |
+
+So every assertion is now classified by what production does with its failure:
+
+- **contract** — what the call site actually consumes. Broken JSON, a preamble pasted into LinkedIn
+  copy, a classification returned as prose, a post over LinkedIn's own 3000-character limit, no
+  output at all. Nothing repairs these.
+- **repairable** — what a regeneration gate catches: `slop_lint`, `comment_contract`,
+  `max_similarity`, `min_burstiness` by default, plus anything a fixture marks
+  `"production": "repairable"`. Repairable-ness belongs to the CALL SITE, not to the check: on
+  long-form, the tier's craft length target is repairable and the 3000-char hard limit beside it is
+  not, so both live on the same case.
+
+| Rate | Column | Role in the gate |
+|---|---|---|
+| `contract_pass_rate` | **Contract** | The ABSOLUTE floor (`contract_pass_rate`, default 0.9) and a meets-or-beats against the champion. |
+| `deterministic_pass_rate` | **First draft** | **Advisory** — rendered with its target and the redraft count, but it never changes a verdict. Still a meets-or-beats against the champion, because needing more drafts than the incumbent is a real cost (tokens, latency, skipped comments) even when nothing broken ships. |
+
+Read the gap between the two columns as **redraft cost, not shipped defects**. A model that clears
+the contract floor only by burning three drafts a case is visible rather than flattered.
+
+The floor can still be missed — that is the point. Replaying the #842 roster's own measured failures
+through this calibration (`TestBm842Replay` in `tests/unit/test_benchmark_models.py`, one entry per
+❌ line of the committed report) puts `lem-medium`'s champion at 100% contract and `lem-complex`'s at
+70%: three of `qwen3.5:397b`'s long-form drafts blew LinkedIn's hard character limit, which is a real
+defect the old aggregate hid. When the incumbent misses its tier's floor, every verdict on that tier
+says so out loud rather than leaving a reader to infer it from two tables.
 
 ### Reasoning headroom — measuring a model, not the harness's budget (#842)
 
@@ -61,20 +104,44 @@ silently absorbed. Only the FINAL attempt is measured — a discarded one is har
 never pays, so its wall-clock is not charged to the model's p50/p90 — and a retried verdict counts
 its real completions against `BENCHMARK_MAX_JUDGE_CALLS`, so the run's cap still bounds spend.
 
-**Where the retry does NOT measure production.** Long-form generation sets no `max_tokens` at all
-(`ai_helper.py`), so on `lem-complex` a doubled budget is closer to the real call than the fixture's
-own cap was. The short tiers are the opposite: `lem-simple`'s `simple-relevance-yes-no` is
-`max_tokens: 3` precisely because `ai_helper.py`'s relevance check is, and there a model that cannot
-answer inside the budget is disqualified in production, not merely truncated. The retry currently
-applies to every case, so on those cases it measures a model LEM could not actually run at that call
-site. Calibrating that (per-case opt-out, or scoring the first attempt for production-mirror
-budgets) is tracked on #910 with the rest of the harness-calibration work.
+**Where the retry does NOT measure production (#910).** Long-form generation sets no `max_tokens` at
+all (`ai_helper.py`), so on `lem-complex` a doubled budget is closer to the real call than the
+fixture's own cap was. The short tiers are the opposite: `lem-simple`'s `simple-relevance-yes-no` is
+`max_tokens: 3` precisely because `ai_helper.py`'s relevance check is, and `simple-reaction-choice`
+(5), `simple-single-value-extract` (8) and `router-classify-short` (5) are the same shape. A model
+that cannot answer inside those budgets is **disqualified at that call site**, not merely truncated —
+scoring it at 6 or 12 tokens would credit it with something LEM could never run there.
+
+Those cases carry `"budget_mirrors_production": true` in the fixture and are **never** escalated. The
+report names any that ended empty under 🔒 *production budget*, so the exemption is visible rather
+than a silent zero. The flag is for call-site-sized budgets only — a test fails the build if it is
+ever set on a case whose `max_tokens` is above 10, since that would quietly re-disable the
+reasoning-headroom retry the #842 run needed.
+
+### Measurement variance — one run of one case is not a verdict (#910)
+
+`minimax-m3` returned an EMPTY completion on two `bm-20260802-20ae40` cases after exhausting the
+truncation retry; re-run at the same effective budget it answered and passed both. A reasoning
+model's single run is therefore not a stable measurement, and an empty-then-fine case must never read
+as a quality verdict.
+
+So a completion that is still empty after the budget escalations is **re-measured at that same
+budget** (`BENCHMARK_EMPTY_REPEATS`, default 1, `0` disables). The repeat re-asks; it never buys
+headroom, so it applies to production-budget cases too. Two things follow:
+
+- every case that needed a repeat is named in the report under ⚖️ *measurement variance*, with the
+  reminder that this model's rates are single-measurement;
+- a completion that is *still* empty is recorded as **no output**, not as a zero-length answer.
+  Grading `""` rendered as `min_chars: 0 chars < 700` — a quality verdict on a model that was never
+  measured. No output fails the gate's "provider answered every case" expectation instead, which is
+  what it actually was.
 
 ## The gate
 
 A candidate is emitted as a **swap recommendation** only when it clears the tier's absolute
-thresholds *and* meets-or-beats the champion on every graded expectation. Weaker outcomes are
-reported but go no further:
+thresholds — the **contract** floor and the judge floor, never the advisory first-draft one — *and*
+meets-or-beats the champion on every graded expectation (contract, first draft, judge). Weaker
+outcomes are reported but go no further:
 
 | Verdict | Meaning |
 |---|---|
@@ -145,17 +212,23 @@ No swap was recommended, so `.litellm/config.yaml` is unchanged and no restart w
 tiers were smoke-tested green against the live proxy anyway (`lem-simple`, `lem-medium`,
 `lem-complex`, `lem-router` — 1-token completions, HTTP 200 on each).
 
-Two caveats the run itself surfaced, both tracked on #910 rather than papered over here:
+Two caveats the run itself surfaced are what #910 then fixed — both decisions above stand under the
+new calibration, but the numbers in that run's report were measured under the old one:
 
-- **The absolute deterministic floor (90%) was met by nobody, champions included.** The relative
-  half of every verdict is sound, but a floor the incumbent fails cannot open for a challenger
-  either. The per-case failures are real model behaviour (long-form overruns `max_chars`,
-  contrastive frames, the #617 comment contract), not harness artifacts — the suites score a FIRST
-  draft where production ships an n-th.
-- **A reasoning model's single-run score is not stable.** `minimax-m3` returned an empty completion
-  on two cases after exhausting the shipped truncation retry; re-run at the same effective budget it
-  answered and passed both. That would have moved it at most to a tie on each tier, so the decision
-  above stands either way — but one run of one case is a data point, not a verdict.
+- **The absolute deterministic floor (90%) was met by nobody, champions included.** Recalibrated:
+  the absolute floor is now the **contract** rate and the first-draft rate is advisory — see *What
+  the deterministic rates mean* above. Replaying this roster's own measured failures through the new
+  calibration, `deepseek-v4-flash` on `lem-medium` clears every expectation and lands as a
+  `recommend` (it tied the champion deterministically and beat it 83% to 50% on judge, at the same
+  Medium usage level, which is exactly what the table above called "the model to re-measure first").
+  The gate is demonstrably openable; the replay is a committed test, not a claim.
+- **A reasoning model's single-run score is not stable.** Fixed: an empty completion is now
+  re-measured at the same budget and reported under ⚖️ *measurement variance*, and one that stays
+  empty is recorded as no output rather than as a zero-length answer.
+
+**These verdicts are not re-derived, they are replayed.** A live re-run spends metered Ollama Cloud
+quota, so the demonstration above re-scores the failures this report already recorded rather than
+inventing new measurements. The next real run is the one whose scorecard carries both columns.
 
 **Read this run's p50/p90 with one correction.** `bm-20260802-20ae40` was measured before the
 per-attempt timing rule above, so a retried case charged every discarded attempt to the model.
@@ -210,17 +283,21 @@ policy marks `hold` is named in the report and belongs to the owner, not to the 
 
 ## Leaderboard
 
+Rows measured before #910 carry `n/a` under **Contract**: those runs computed one deterministic rate,
+and printing it in both columns would invent a measurement nobody took. Their **First draft** number
+is the rate their report published.
+
 <!-- LEADERBOARD:BEGIN -->
-| Date | Run | Tier | Model | Role | Deterministic | Judge | p50 | Verdict |
-|---|---|---|---|---|---|---|---|---|
-| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `qwen3.5:397b` | champion | 50% | 100% | 26955 ms | baseline |
-| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `deepseek-v4-flash` | candidate | 70% | 57% | 3275 ms | reject |
-| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `gemma4:31b` | candidate | 80% | 57% | 2428 ms | reject |
-| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `minimax-m3` | candidate | 40% | 75% | 30564 ms | reject |
-| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `glm-5.2` | candidate | 70% | 86% | 14477 ms | reject |
-| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `gpt-oss:120b` | champion | 60% | 50% | 1635 ms | baseline |
-| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `deepseek-v4-flash` | candidate | 60% | 83% | 1310 ms | reject |
-| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `gemma4:31b` | candidate | 40% | 100% | 807 ms | reject |
-| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `minimax-m3` | candidate | 50% | 80% | 5405 ms | reject |
-| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `glm-5.2` | candidate | 40% | 75% | 6315 ms | reject |
+| Date | Run | Tier | Model | Role | Contract | First draft | Judge | p50 | Verdict |
+|---|---|---|---|---|---|---|---|---|---|
+| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `qwen3.5:397b` | champion | n/a | 50% | 100% | 26955 ms | baseline |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `deepseek-v4-flash` | candidate | n/a | 70% | 57% | 3275 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `gemma4:31b` | candidate | n/a | 80% | 57% | 2428 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `minimax-m3` | candidate | n/a | 40% | 75% | 30564 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `glm-5.2` | candidate | n/a | 70% | 86% | 14477 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `gpt-oss:120b` | champion | n/a | 60% | 50% | 1635 ms | baseline |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `deepseek-v4-flash` | candidate | n/a | 60% | 83% | 1310 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `gemma4:31b` | candidate | n/a | 40% | 100% | 807 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `minimax-m3` | candidate | n/a | 50% | 80% | 5405 ms | reject |
+| 2026-08-02 | `bm-20260802-20ae40` | lem-medium | `glm-5.2` | candidate | n/a | 40% | 75% | 6315 ms | reject |
 <!-- LEADERBOARD:END -->

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -658,7 +658,11 @@ def merge_scorecard(tier: str, model: str, role: str, case_results: list,
         "errors": errors,
         "failed_cases": [{"case_id": r["case_id"], "failures": r.get("failures") or [],
                           "contract_failures": r.get("contract_failures") or [],
-                          "repairable_failures": r.get("repairable_failures") or []}
+                          "repairable_failures": r.get("repairable_failures") or [],
+                          # Carried so the report can tell "nothing arrived" apart from "something
+                          # arrived that production would have shipped" — a no-output case is a
+                          # measurement that never happened, not a defect (#910).
+                          "error": r.get("error")}
                          for r in case_results if not r.get("passes")],
         "unscored_assertions": sum(int(r.get("unscored") or 0) for r in case_results),
         "judged": judged,
@@ -1108,7 +1112,14 @@ def render_report(run: dict) -> str:
         for entry in failed:
             contract = entry.get("contract_failures") or []
             repairable = entry.get("repairable_failures") or []
-            if contract:
+            if entry.get("error"):
+                # `no output` is a CONTRACT failure — the call site got nothing — but it is not
+                # something production would ship, and since #910 turns an empty completion into no
+                # output this is the common path. Labelling it "production would ship this" is the
+                # exact misreading the two rates exist to prevent.
+                lines.append(f"- ❌ `{entry['case_id']}` — no output; nothing was measured here")
+                lines.append(f"  - {entry['error']}")
+            elif contract:
                 lines.append(f"- ❌ `{entry['case_id']}` — production would ship this")
                 for failure in contract:
                     lines.append(f"  - {failure}")
@@ -1119,7 +1130,7 @@ def render_report(run: dict) -> str:
                              "regenerates against this and skips/holds what still fails")
                 for failure in repairable:
                     lines.append(f"  - {failure}")
-            else:  # a case with no classified failures (a provider error carries its own line)
+            else:  # a hand-built case whose failures carry no production class
                 lines.append(f"- ❌ `{entry['case_id']}`")
                 for failure in entry.get("failures") or []:
                     lines.append(f"  - {failure}")
@@ -1133,10 +1144,11 @@ def render_report(run: dict) -> str:
                          + ", ".join(f"`{c}`" for c in escalated))
         locked = card.get("budget_locked_cases") or []
         if locked:
-            lines.append(f"- 🔒 production budget — {len(locked)} case(s) mirror a production call "
-                         "site's own `max_tokens` and were NOT retried at a larger one; a model "
-                         "that cannot answer inside that budget is disqualified at that call site, "
-                         "not merely truncated: " + ", ".join(f"`{c}`" for c in locked))
+            lines.append(f"- 🔒 production budget — {len(locked)} case(s) spent a budget that "
+                         "MIRRORS a production call site's own `max_tokens` without answering, and "
+                         "were NOT retried at a larger one; a model that cannot answer inside that "
+                         "budget is disqualified at that call site, not merely truncated: "
+                         + ", ".join(f"`{c}`" for c in locked))
         remeasured = card.get("remeasured_cases") or []
         if remeasured:
             lines.append(f"- ⚖️ measurement variance — {len(remeasured)} case(s) came back EMPTY at "

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -14,7 +14,11 @@ Two scoring layers, in this order:
   1. DETERMINISTIC (free, in-repo, the source of truth) — length caps, comma-list shape, JSON
      validity, `slop_lint.lint_report`, `content_framework.comment_contract_report`, burstiness,
      lexical self-similarity, the `LEMComplexityRouter` tier contract. A case that fails HARD here
-     never spends a judge call.
+     never spends a judge call. Every deterministic check is additionally classified by what
+     PRODUCTION does with that failure (#910): a CONTRACT failure is what the call site consumes,
+     a REPAIRABLE one is what a regeneration gate catches and retries. The suite scores a FIRST
+     draft; production ships an n-th, so the absolute floor is on the contract rate and the
+     first-draft rate is advisory (still compared against the champion).
   2. LLM JUDGE (paid, sampled, capped) — PostHog Evaluations scoring our own tagged
      `$ai_generation` events, or, when no judge provider is configured, an in-runner `lem-medium`
      judge whose verdicts are emitted as `$ai_metric`. A judge that never answers is
@@ -98,13 +102,18 @@ JUDGE_UNAVAILABLE = "judge:unavailable"
 LEADERBOARD_BEGIN = "<!-- LEADERBOARD:BEGIN -->"
 LEADERBOARD_END = "<!-- LEADERBOARD:END -->"
 LEADERBOARD_MAX_ROWS = 400
-LEADERBOARD_COLUMNS = ("Date", "Run", "Tier", "Model", "Role", "Deterministic", "Judge", "p50",
-                       "Verdict")
+LEADERBOARD_COLUMNS = ("Date", "Run", "Tier", "Model", "Role", "Contract", "First draft", "Judge",
+                       "p50", "Verdict")
+# The pre-#910 table, kept ONLY so a re-render can still read the rows already committed. Dropping
+# them would silently evict real history at the first render after the column was added; they carry
+# no contract rate, so they render `n/a` there rather than a number nobody measured.
+LEADERBOARD_LEGACY_COLUMNS = ("Date", "Run", "Tier", "Model", "Role", "Deterministic", "Judge",
+                              "p50", "Verdict")
 LEADERBOARD_HEADER = "| " + " | ".join(LEADERBOARD_COLUMNS) + " |"
 LEADERBOARD_DIVIDER = "|" + "---|" * len(LEADERBOARD_COLUMNS)
 
-SCORECARD_COLUMNS = ("Tier", "Model", "Role", "Usage", "Cases", "Deterministic", "Judge", "Judged",
-                     "Timeouts", "p50", "p90")
+SCORECARD_COLUMNS = ("Tier", "Model", "Role", "Usage", "Cases", "Contract", "First draft", "Judge",
+                     "Judged", "Timeouts", "p50", "p90")
 SCORECARD_HEADER = "| " + " | ".join(SCORECARD_COLUMNS) + " |"
 SCORECARD_DIVIDER = "|" + "---|" * len(SCORECARD_COLUMNS)
 
@@ -182,6 +191,17 @@ def truncation_retries() -> int:
     return _env_int("BENCHMARK_TRUNCATION_RETRIES", 2, low=0, high=4)
 
 
+def empty_repeats() -> int:
+    """How many times an EMPTY completion is re-measured at the SAME budget (#910).
+
+    Distinct from the truncation retry above, which grows the budget. `minimax-m3` returned an empty
+    completion on two `bm-20260802-20ae40` cases after exhausting the doublings; re-run at the same
+    effective budget it answered and passed both. A reasoning model's single run is therefore not a
+    stable measurement, and an empty-then-fine case must never read as a quality verdict — so it is
+    re-measured, and the report names every case that needed it."""
+    return _env_int("BENCHMARK_EMPTY_REPEATS", 1, low=0, high=3)
+
+
 def judge_max_tokens() -> int:
     """Completion budget for one in-runner judge verdict. The verdict itself is ~40 tokens; the rest
     is headroom for a reasoning judge, since `lem-medium` is currently served by `gpt-oss:120b`."""
@@ -234,10 +254,17 @@ def load_suite(doc: dict, *, name: str = "<suite>") -> dict:
         assertions = case.get("assertions")
         if not isinstance(assertions, list) or not assertions:
             raise SuiteError(f"{name}/{case_id}: case has no assertions")
+        if "budget_mirrors_production" in case and not isinstance(
+                case.get("budget_mirrors_production"), bool):
+            raise SuiteError(f"{name}/{case_id}: budget_mirrors_production must be true or false")
         for assertion in assertions:
             kind = (assertion or {}).get("type") if isinstance(assertion, dict) else None
             if kind not in ASSERTIONS:
                 raise SuiteError(f"{name}/{case_id}: unknown assertion type {kind!r}")
+            klass = (assertion or {}).get("production")
+            if klass is not None and klass not in PRODUCTION_CLASSES:
+                raise SuiteError(f"{name}/{case_id}: assertion {kind!r} has an unknown production "
+                                 f"class {klass!r}")
     return {
         "tier": tier,
         "version": int(doc.get("version") or 1),
@@ -249,9 +276,15 @@ def load_suite(doc: dict, *, name: str = "<suite>") -> dict:
 
 
 def normalize_thresholds(raw: Optional[dict]) -> dict:
-    """A tier's absolute floors. Defaults are deliberately strict on the deterministic side (those
-    checks encode contracts LEM already enforces in production) and looser on the judge side, where
-    a single rubric disagreement should not sink a model."""
+    """A tier's floors.
+
+    `contract_pass_rate` is the ABSOLUTE one (#910): the share of cases whose failures production
+    would actually consume. `deterministic_pass_rate` — the first-draft rate over EVERY check,
+    repairable ones included — is kept as an ADVISORY reading and as the champion-relative
+    comparison; it is no longer a floor, because the checks it aggregates are the ones production
+    regenerates against, so a 90% absolute floor there was a floor on something no model (the
+    incumbents included) has ever had to clear. The judge floor stays looser, where a single rubric
+    disagreement should not sink a model."""
     doc = raw if isinstance(raw, dict) else {}
 
     def num(key: str, default: float) -> float:
@@ -264,7 +297,8 @@ def normalize_thresholds(raw: Optional[dict]) -> dict:
         min_judged = max(0, int(doc.get("min_judged", 3)))
     except (TypeError, ValueError):
         min_judged = 3
-    return {"deterministic_pass_rate": num("deterministic_pass_rate", 0.9),
+    return {"contract_pass_rate": num("contract_pass_rate", 0.9),
+            "deterministic_pass_rate": num("deterministic_pass_rate", 0.9),
             "judge_pass_rate": num("judge_pass_rate", 0.8),
             "min_judged": min_judged}
 
@@ -443,6 +477,43 @@ def _a_max_lines(spec: dict, output: str, case: dict) -> dict:
         f"{len(lines)} non-empty lines > {limit}")
 
 
+# ───────────────── what production does with a failure (#910, pure) ─────────────────
+#
+# The #842 run measured 40–80% deterministic pass rates for every model including both reigning
+# champions, against a 90% floor — a gate that can never open. The failures were real model
+# behaviour, not harness artifacts, but they are not all the same KIND of failure:
+#
+#   * a REPAIRABLE one is caught by a production regeneration gate and redrafted — `lint_repaired`
+#     for the short surfaces, `_gated_comment` for every self-authored comment (#617, up to
+#     COMMENT_GATE_MAX_ATTEMPTS, then the post is SKIPPED), `_review_generated_post` for posts
+#     (one regeneration, then `evaluate_post_gates` HOLDS the draft at pending). Nothing ships.
+#   * a CONTRACT one is what the call site actually consumes: a broken JSON body, a preamble
+#     pasted into LinkedIn copy, an answer over LinkedIn's hard character limit, a classification
+#     that came back as prose. Production has no repair for these.
+#
+# So the suite scores a first draft and production ships an n-th. The absolute floor belongs on the
+# contract rate; the first-draft rate stays reported (and champion-relative), because needing three
+# drafts is a real cost — it is just not the same thing as shipping a broken one.
+PRODUCTION_CONTRACT = "contract"
+PRODUCTION_REPAIRABLE = "repairable"
+PRODUCTION_CLASSES = (PRODUCTION_CONTRACT, PRODUCTION_REPAIRABLE)
+
+# Type-level defaults. A fixture may override per assertion with `"production": "..."` — whether a
+# check is repairable is a property of the CALL SITE, not of the check (a craft-target `max_chars`
+# on long-form is repairable; the same assertion carrying LinkedIn's hard limit is not).
+REPAIRABLE_BY_DEFAULT = ("slop_lint", "comment_contract", "max_similarity", "min_burstiness")
+
+
+def assertion_production_class(spec: Optional[dict]) -> str:
+    """`contract` / `repairable` for one assertion. Unknown or absent -> the type's default, and an
+    unrecognised type is CONTRACT: a check nobody classified must not quietly stop counting."""
+    raw = str((spec or {}).get("production") or "").strip().lower()
+    if raw in PRODUCTION_CLASSES:
+        return raw
+    return (PRODUCTION_REPAIRABLE if (spec or {}).get("type") in REPAIRABLE_BY_DEFAULT
+            else PRODUCTION_CONTRACT)
+
+
 ASSERTIONS: dict = {
     "max_chars": _a_max_chars,
     "min_chars": _a_min_chars,
@@ -466,17 +537,26 @@ def evaluate_case(case: dict, output: Optional[str],
 
     A missing output (provider error) is a case FAILURE with the error carried through, never an
     absent row: a model that couldn't answer is worse than one that answered badly, and dropping the
-    case would quietly raise its pass rate."""
+    case would quietly raise its pass rate. It is a CONTRACT failure too — the call site got
+    nothing, and there is no regeneration that repairs nothing.
+
+    Two verdicts come back per case (#910): `passes` is the first draft against every check, and
+    `contract_passes` is the same draft against only the checks production has no repair for."""
     case_id = str(case.get("id"))
     if output is None:
-        return {"case_id": case_id, "passes": False, "error": case.get("_error") or "no output",
-                "assertions": [], "failures": ["no output from the model"], "unscored": 0}
+        return {"case_id": case_id, "passes": False, "contract_passes": False,
+                "error": case.get("_error") or "no output", "assertions": [],
+                "failures": ["no output from the model"],
+                "contract_failures": ["no output from the model"], "repairable_failures": [],
+                "unscored": 0}
     results = []
     for spec in case.get("assertions") or []:
         kind = spec.get("type")
         fn = ASSERTIONS.get(kind)
+        production = assertion_production_class(spec)
         if fn is None:  # unreachable via load_suite; belt-and-braces for hand-built cases
-            results.append({"type": kind, "passes": False, "detail": f"unknown assertion {kind!r}"})
+            results.append({"type": kind, "passes": False, "production": PRODUCTION_CONTRACT,
+                            "detail": f"unknown assertion {kind!r}"})
             continue
         resolved = dict(spec)
         if kind == "max_similarity":
@@ -486,12 +566,18 @@ def evaluate_case(case: dict, output: Optional[str],
             outcome = fn(resolved, str(output), case)
         except Exception as exc:  # noqa: BLE001 - one bad assertion must not sink the whole run
             outcome = _fail(f"assertion raised {type(exc).__name__}: {str(exc)[:80]}")
-        results.append({"type": kind, "passes": outcome.get("passes"),
+        results.append({"type": kind, "passes": outcome.get("passes"), "production": production,
                         "detail": outcome.get("detail", "")})
     failures = [f"{r['type']}: {r['detail']}" for r in results if r["passes"] is False]
+    contract_failures = [f"{r['type']}: {r['detail']}" for r in results
+                         if r["passes"] is False and r["production"] == PRODUCTION_CONTRACT]
+    repairable_failures = [f"{r['type']}: {r['detail']}" for r in results
+                           if r["passes"] is False and r["production"] == PRODUCTION_REPAIRABLE]
     unscored = sum(1 for r in results if r["passes"] is None)
-    return {"case_id": case_id, "passes": not failures, "assertions": results,
-            "failures": failures, "unscored": unscored}
+    return {"case_id": case_id, "passes": not failures, "contract_passes": not contract_failures,
+            "assertions": results, "failures": failures,
+            "contract_failures": contract_failures, "repairable_failures": repairable_failures,
+            "unscored": unscored}
 
 
 def score_suite(suite: dict, outputs: dict) -> list:
@@ -523,11 +609,16 @@ def merge_scorecard(tier: str, model: str, role: str, case_results: list,
 
     Judge verdicts are three-valued: True, False, and `judge:timeout`/absent. Only the first two
     count toward `judge_pass_rate`; an unscored case is reported as unscored, so a run where the
-    judge never answered can never look like a run where it approved everything."""
+    judge never answered can never look like a run where it approved everything.
+
+    Deterministic results are TWO rates (#910): `contract_pass_rate` (what production would ship)
+    and `deterministic_pass_rate` (the first draft against every check). Both are always reported —
+    a model that clears the contract rate only by burning three drafts per case has to be visible."""
     judge = judge_results or {}
     timings = timings or {}
     total = len(case_results)
     passed = sum(1 for r in case_results if r.get("passes"))
+    contract_passed = sum(1 for r in case_results if r.get("contract_passes"))
     errors = [r["case_id"] for r in case_results if r.get("error")]
 
     judged_pass = judged_fail = judged_timeout = 0
@@ -549,14 +640,25 @@ def merge_scorecard(tier: str, model: str, role: str, case_results: list,
                  for r in case_results)
     escalated = [r["case_id"] for r in case_results
                  if int(timings.get(r["case_id"], {}).get("budget_escalations") or 0) > 0]
+    remeasured = [r["case_id"] for r in case_results
+                  if int(timings.get(r["case_id"], {}).get("repeats") or 0) > 0]
+    budget_locked = [r["case_id"] for r in case_results
+                     if timings.get(r["case_id"], {}).get("budget_locked")]
 
     return {
         "tier": tier, "model": model, "role": role,
         "cases": total,
         "deterministic_passed": passed,
         "deterministic_pass_rate": _rate(passed, total),
+        "contract_passed": contract_passed,
+        "contract_pass_rate": _rate(contract_passed, total),
+        # Passed what production consumes, but only after a redraft it would have had to pay for.
+        "repaired_cases": [r["case_id"] for r in case_results
+                           if r.get("contract_passes") and not r.get("passes")],
         "errors": errors,
-        "failed_cases": [{"case_id": r["case_id"], "failures": r.get("failures") or []}
+        "failed_cases": [{"case_id": r["case_id"], "failures": r.get("failures") or [],
+                          "contract_failures": r.get("contract_failures") or [],
+                          "repairable_failures": r.get("repairable_failures") or []}
                          for r in case_results if not r.get("passes")],
         "unscored_assertions": sum(int(r.get("unscored") or 0) for r in case_results),
         "judged": judged,
@@ -570,6 +672,8 @@ def merge_scorecard(tier: str, model: str, role: str, case_results: list,
         "latency_p90_ms": _percentile(latencies, 0.9),
         "total_tokens": tokens,
         "budget_escalated_cases": escalated,
+        "remeasured_cases": remeasured,
+        "budget_locked_cases": budget_locked,
         "case_results": case_results,
     }
 
@@ -770,19 +874,40 @@ def gate_decision(candidate: dict, champion: Optional[dict], thresholds: dict) -
     A missing champion is `no-baseline`, never a pass: "better than nothing" is not a comparison.
     Judge evidence that is missing on BOTH sides degrades to `recommend-deterministic-only`, which
     is reported but is NOT a swap recommendation — that distinction is the whole point of the gate.
+
+    The absolute deterministic floor is on the CONTRACT rate (#910). The first-draft rate is
+    returned as an ADVISORY reading rather than an expectation — advisories never change the
+    verdict — but it is still compared against the champion, because a model that needs more
+    redrafts than the incumbent is not an upgrade even when nothing broken ships.
     """
     expectations: list = []
+    advisories: list = []
     thresholds = normalize_thresholds(thresholds)
 
     def expect(name: str, ok: Optional[bool], detail: str) -> None:
         expectations.append({"expectation": name, "passes": ok, "detail": detail})
 
     det = candidate.get("deterministic_pass_rate")
-    floor = thresholds["deterministic_pass_rate"]
-    if det is None:
-        expect("deterministic floor", False, "no cases scored")
+    contract = candidate.get("contract_pass_rate")
+    contract_floor = thresholds["contract_pass_rate"]
+    if contract is None:
+        expect("contract floor", False, "no cases scored")
     else:
-        expect("deterministic floor", det >= floor, f"{det:.0%} vs floor {floor:.0%}")
+        expect("contract floor", contract >= contract_floor,
+               f"{contract:.0%} vs floor {contract_floor:.0%}")
+
+    advisory_floor = thresholds["deterministic_pass_rate"]
+    repaired = len(candidate.get("repaired_cases") or [])
+    if det is None:
+        advisories.append({"expectation": "first-draft yield", "passes": None,
+                           "detail": "no cases scored"})
+    else:
+        advisories.append({
+            "expectation": "first-draft yield",
+            "passes": det >= advisory_floor,
+            "detail": (f"{det:.0%} vs advisory target {advisory_floor:.0%} — {repaired} case(s) "
+                       "production would have redrafted rather than shipped (advisory: does not "
+                       "change the verdict)")})
 
     if candidate.get("errors"):
         expect("provider answered every case", False,
@@ -805,11 +930,17 @@ def gate_decision(candidate: dict, champion: Optional[dict], thresholds: dict) -
     if champion is None:
         expect("beats champion", None, "no champion scorecard for this tier")
     else:
+        champ_contract = champion.get("contract_pass_rate")
+        if contract is None or champ_contract is None:
+            expect("beats champion (contract)", False, "one side has no score")
+        else:
+            expect("beats champion (contract)", contract >= champ_contract,
+                   f"{contract:.0%} vs champion {champ_contract:.0%}")
         champ_det = champion.get("deterministic_pass_rate")
         if det is None or champ_det is None:
-            expect("beats champion (deterministic)", False, "one side has no score")
+            expect("beats champion (first-draft)", False, "one side has no score")
         else:
-            expect("beats champion (deterministic)", det >= champ_det,
+            expect("beats champion (first-draft)", det >= champ_det,
                    f"{det:.0%} vs champion {champ_det:.0%}")
         champ_judge = champion.get("judge_pass_rate")
         champ_evidence = int(champion.get("judged") or 0) >= thresholds["min_judged"]
@@ -836,6 +967,13 @@ def gate_decision(candidate: dict, champion: Optional[dict], thresholds: dict) -
     return {"tier": candidate.get("tier"), "model": candidate.get("model"),
             "champion": (champion or {}).get("model"), "verdict": verdict,
             "expectations": expectations,
+            "advisories": advisories,
+            # A floor the INCUMBENT misses is a statement about the tier, not about the challenger
+            # (#910). Carried on the verdict so the report says it out loud instead of leaving a
+            # reader to infer it from two numbers in different tables.
+            "champion_clears_contract_floor": (
+                None if champion is None or champion.get("contract_pass_rate") is None
+                else champion["contract_pass_rate"] >= contract_floor),
             "usage_delta": delta,
             "quota_policy": quota_policy(str(candidate.get("tier") or ""), delta,
                                          candidate, champion),
@@ -939,12 +1077,21 @@ def render_report(run: dict) -> str:
         lines.append(
             f"| {card['tier']} | `{card['model']}` | {card['role']} | "
             f"{usage_name(card.get('usage'))} | {card['cases']} | "
+            f"{_fmt_rate(card.get('contract_pass_rate'))} "
+            f"({card.get('contract_passed', 0)}/{card.get('cases', 0)}) | "
             f"{_fmt_rate(card.get('deterministic_pass_rate'))} "
             f"({card.get('deterministic_passed', 0)}/{card.get('cases', 0)}) | "
             f"{_fmt_rate(card.get('judge_pass_rate'))} | {card.get('judged', 0)} | "
             f"{card.get('judge_timeouts', 0)} | {_fmt_ms(card.get('latency_p50_ms'))} | "
             f"{_fmt_ms(card.get('latency_p90_ms'))} |")
     lines += ["",
+              ("**Contract** is the share of cases whose failures production would actually "
+               "consume; **First draft** is the same cases against every check, repairable ones "
+               "included. Production regenerates against the repairable ones (`lint_repaired`, the "
+               "#617 comment gate, the post review gate) and skips or holds what still fails, so "
+               "the gap between the two columns is redraft COST, not shipped defects. The absolute "
+               "floor is on Contract; First draft is advisory and champion-relative (#910)."),
+              "",
               ("**Usage** is the Ollama Cloud usage level (quota class) — `unknown` where "
                "ollama.com publishes no level for that model, which is the case for models that "
                "are also pullable locally. Supply those with `--usage-levels model=<level>`.")]
@@ -959,9 +1106,23 @@ def render_report(run: dict) -> str:
         if not failed:
             lines.append("- every case met every deterministic expectation")
         for entry in failed:
-            lines.append(f"- ❌ `{entry['case_id']}`")
-            for failure in entry.get("failures") or []:
-                lines.append(f"  - {failure}")
+            contract = entry.get("contract_failures") or []
+            repairable = entry.get("repairable_failures") or []
+            if contract:
+                lines.append(f"- ❌ `{entry['case_id']}` — production would ship this")
+                for failure in contract:
+                    lines.append(f"  - {failure}")
+                for failure in repairable:
+                    lines.append(f"  - (repairable) {failure}")
+            elif repairable:
+                lines.append(f"- 🔁 `{entry['case_id']}` — first draft only; production "
+                             "regenerates against this and skips/holds what still fails")
+                for failure in repairable:
+                    lines.append(f"  - {failure}")
+            else:  # a case with no classified failures (a provider error carries its own line)
+                lines.append(f"- ❌ `{entry['case_id']}`")
+                for failure in entry.get("failures") or []:
+                    lines.append(f"  - {failure}")
         if card.get("unscored_assertions"):
             lines.append(f"- {card['unscored_assertions']} assertion(s) unscored "
                          "(not counted either way)")
@@ -970,6 +1131,19 @@ def render_report(run: dict) -> str:
             lines.append(f"- 🧠 reasoning headroom — {len(escalated)} case(s) spent the fixture's "
                          "whole completion budget thinking and were retried at a larger one: "
                          + ", ".join(f"`{c}`" for c in escalated))
+        locked = card.get("budget_locked_cases") or []
+        if locked:
+            lines.append(f"- 🔒 production budget — {len(locked)} case(s) mirror a production call "
+                         "site's own `max_tokens` and were NOT retried at a larger one; a model "
+                         "that cannot answer inside that budget is disqualified at that call site, "
+                         "not merely truncated: " + ", ".join(f"`{c}`" for c in locked))
+        remeasured = card.get("remeasured_cases") or []
+        if remeasured:
+            lines.append(f"- ⚖️ measurement variance — {len(remeasured)} case(s) came back EMPTY at "
+                         "the full budget and were re-measured at that same budget: "
+                         + ", ".join(f"`{c}`" for c in remeasured)
+                         + ". One run of one case is a data point, not a verdict — read this "
+                           "model's rates as single-measurement.")
         for note in card.get("judge_notes") or []:
             lines.append(f"- 🧑‍⚖️ `{note['case_id']}`: {note['reasoning']}")
         lines.append("")
@@ -985,6 +1159,13 @@ def render_report(run: dict) -> str:
         for expectation in gate.get("expectations") or []:
             mark = {True: "✅", False: "❌"}.get(expectation["passes"], "➖")
             lines.append(f"- {mark} {expectation['expectation']} — {expectation['detail']}")
+        for advisory in gate.get("advisories") or []:
+            mark = {True: "✅", False: "⚠️"}.get(advisory["passes"], "➖")
+            lines.append(f"- {mark} {advisory['expectation']} (advisory) — {advisory['detail']}")
+        if gate.get("champion_clears_contract_floor") is False:
+            lines.append(f"- 🪧 the incumbent `{gate.get('champion')}` misses this tier's own "
+                         "contract floor — that is a statement about the tier's fixtures, not "
+                         "about this candidate; the relative half of the verdict is what stands.")
         delta = gate.get("usage_delta") or {}
         if delta.get("summary"):
             lines.append(f"- 💳 usage level — {delta['summary']}")
@@ -1046,6 +1227,7 @@ def leaderboard_rows(run: dict) -> list:
         rows.append({
             "date": run.get("date"), "run_id": run.get("run_id"), "tier": card["tier"],
             "model": card["model"], "role": card["role"],
+            "contract": _fmt_rate(card.get("contract_pass_rate")),
             "deterministic": _fmt_rate(card.get("deterministic_pass_rate")),
             "judge": _fmt_rate(card.get("judge_pass_rate")),
             "latency": _fmt_ms(card.get("latency_p50_ms")),
@@ -1057,8 +1239,8 @@ def leaderboard_rows(run: dict) -> list:
 
 def _row_markdown(row: dict) -> str:
     return (f"| {row['date']} | `{row['run_id']}` | {row['tier']} | `{row['model']}` | "
-            f"{row['role']} | {row['deterministic']} | {row['judge']} | {row['latency']} | "
-            f"{row['verdict']} |")
+            f"{row['role']} | {row.get('contract', 'n/a')} | {row['deterministic']} | "
+            f"{row['judge']} | {row['latency']} | {row['verdict']} |")
 
 
 def _row_key(row: dict) -> tuple:
@@ -1067,18 +1249,24 @@ def _row_key(row: dict) -> tuple:
 
 def _parse_row(line: str) -> Optional[dict]:
     cells = [c.strip() for c in line.strip().strip("|").split("|")]
-    if len(cells) != len(LEADERBOARD_COLUMNS):
+    legacy = len(cells) == len(LEADERBOARD_LEGACY_COLUMNS)
+    if len(cells) != len(LEADERBOARD_COLUMNS) and not legacy:
         return None
     # The table's own header and divider are pipe-delimited rows of the right width. Reading them
     # back as DATA is how a rolling table quietly grows two junk rows per render and evicts real
     # history at the row cap, so they are recognised and dropped here rather than re-emitted.
-    if [c.strip("`") for c in cells] == list(LEADERBOARD_COLUMNS):
+    if [c.strip("`") for c in cells] in (list(LEADERBOARD_COLUMNS),
+                                         list(LEADERBOARD_LEGACY_COLUMNS)):
         return None
     if all(c and set(c.strip("`")) <= {"-", ":"} for c in cells):
         return None
+    # A pre-#910 row has no contract rate. It renders `n/a` rather than borrowing the first-draft
+    # number: those runs measured one rate, and printing it twice would invent a measurement.
+    contract = "n/a" if legacy else cells[5]
+    rest = cells[5:] if legacy else cells[6:]
     return {"date": cells[0], "run_id": cells[1].strip("`"), "tier": cells[2],
-            "model": cells[3].strip("`"), "role": cells[4], "deterministic": cells[5],
-            "judge": cells[6], "latency": cells[7], "verdict": cells[8]}
+            "model": cells[3].strip("`"), "role": cells[4], "contract": contract,
+            "deterministic": rest[0], "judge": rest[1], "latency": rest[2], "verdict": rest[3]}
 
 
 def update_leaderboard(text: str, rows: list) -> str:
@@ -1339,11 +1527,23 @@ class ProviderClient:
                                          timeout=self.timeout)
         return self._client
 
-    def complete(self, model: str, messages: list, params: Optional[dict] = None) -> dict:
+    def complete(self, model: str, messages: list, params: Optional[dict] = None, *,
+                 allow_budget_escalation: bool = True) -> dict:
+        """One case's completion.
+
+        `allow_budget_escalation=False` is for a case whose `max_tokens` deliberately MIRRORS a
+        production call site (#910): `lem-simple`'s relevance check is `max_tokens=3` because
+        `ai_helper.py`'s is, and a model that cannot answer inside that budget is disqualified at
+        that call site rather than merely truncated. Doubling it there would score an answer LEM
+        could never actually run. The empty-completion re-measurement still applies — it re-asks at
+        the SAME budget, so it measures variance rather than buying headroom."""
         call_params = dict(params or {})
         budget = call_params.get("max_tokens")
+        bounded = isinstance(budget, int) and budget > 0
         escalations = 0
-        allowed = truncation_retries() if isinstance(budget, int) and budget > 0 else 0
+        repeats = 0
+        budget_locked = False
+        allowed = truncation_retries() if bounded and allow_budget_escalation else 0
         while True:
             # Timed PER ATTEMPT, not across the retries. A discarded attempt is harness waste that
             # production never pays (long-form calls set no `max_tokens` at all), so charging its
@@ -1355,23 +1555,45 @@ class ProviderClient:
                     model=model, messages=messages, **call_params)
             except Exception as exc:  # noqa: BLE001 - a provider failure is a case result, not a crash
                 return {"text": None, "error": str(exc)[:200], "budget_escalations": escalations,
+                        "repeats": repeats, "budget_locked": budget_locked,
                         "latency_ms": (time.time() - started) * 1000.0, "usage": {}}
             choice = response.choices[0]
             text = (choice.message.content or "").strip()
+            truncated = getattr(choice, "finish_reason", None) == "length"
             # Only an EMPTY reply is retried. A truncated-but-present answer is the model's real
             # output at this budget, and re-rolling it would quietly hand the verbose models a
             # second chance the concise ones never needed.
-            if text or escalations >= allowed or getattr(choice, "finish_reason", None) != "length":
+            if text:
                 break
-            escalations += 1
-            call_params["max_tokens"] = budget * (2 ** escalations)
-            print(f"  {model} spent its whole {budget * (2 ** (escalations - 1))}-token budget "
-                  f"before answering — retrying at {call_params['max_tokens']}", file=sys.stderr)
+            if truncated and escalations < allowed:
+                escalations += 1
+                call_params["max_tokens"] = budget * (2 ** escalations)
+                print(f"  {model} spent its whole {budget * (2 ** (escalations - 1))}-token budget "
+                      f"before answering — retrying at {call_params['max_tokens']}",
+                      file=sys.stderr)
+                continue
+            # Recorded only if the case ENDS with no answer: a production-budget case whose repeat
+            # answered was measured fine, and naming it would read as a failure it did not have.
+            budget_locked = bool(truncated and bounded and not allow_budget_escalation)
+            if repeats >= empty_repeats():
+                break
+            repeats += 1
+            print(f"  {model} returned an empty answer — re-measuring at the same budget "
+                  f"({repeats}/{empty_repeats()})", file=sys.stderr)
         usage = getattr(response, "usage", None)
         return {
-            "text": text,
-            "error": None,
+            # An answer that never arrived is NO OUTPUT, not a zero-length answer: grading "" would
+            # render as `min_chars: 0 chars < 700`, which reads as a quality verdict on a model that
+            # was never measured.
+            "text": text or None,
+            "error": None if text else (
+                f"empty completion after {escalations} budget escalation(s) and {repeats} "
+                f"re-measurement(s)"
+                + (" (this case's max_tokens mirrors a production call site, so the budget was "
+                   "never grown)" if budget_locked else "")),
             "budget_escalations": escalations,
+            "repeats": repeats,
+            "budget_locked": bool(budget_locked and not text),
             "latency_ms": (time.time() - started) * 1000.0,
             "usage": {"prompt_tokens": getattr(usage, "prompt_tokens", None),
                       "completion_tokens": getattr(usage, "completion_tokens", None),
@@ -1617,12 +1839,16 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
                 completion = {"text": None, "error": "no provider client configured",
                               "latency_ms": None, "usage": {}}
             else:
-                completion = provider.complete(model, case["messages"], case.get("params"))
+                completion = provider.complete(
+                    model, case["messages"], case.get("params"),
+                    allow_budget_escalation=not case.get("budget_mirrors_production"))
             outputs[case_id] = completion.get("text")
             errors[case_id] = completion.get("error")
             timings[case_id] = {"latency_ms": completion.get("latency_ms"),
                                 "total_tokens": (completion.get("usage") or {}).get("total_tokens"),
-                                "budget_escalations": completion.get("budget_escalations") or 0}
+                                "budget_escalations": completion.get("budget_escalations") or 0,
+                                "repeats": completion.get("repeats") or 0,
+                                "budget_locked": bool(completion.get("budget_locked"))}
             if not dry_run and completion.get("text") and evals is not None:
                 event_id = emit_generation(run_id, tier, case, model, role, completion)
                 if event_id:
@@ -1809,8 +2035,14 @@ def main(argv: Optional[list] = None) -> int:
             print(f"{tier}: {len(suite['cases'])} cases ({judged} judgeable), "
                   f"thresholds={suite['thresholds']}")
             for case in suite["cases"]:
-                kinds = ", ".join(a["type"] for a in case["assertions"])
-                print(f"  - {case['id']}: {kinds}")
+                # `~` marks a check production REPAIRS rather than ships — those are outside the
+                # absolute contract floor (#910), so a calibration review can see the split.
+                kinds = ", ".join(
+                    a["type"] + ("~" if assertion_production_class(a) == PRODUCTION_REPAIRABLE
+                                 else "")
+                    for a in case["assertions"])
+                locked = " [production budget]" if case.get("budget_mirrors_production") else ""
+                print(f"  - {case['id']}: {kinds}{locked}")
         return 0
 
     if args.render:

--- a/tests/benchmarks/model_tiers/lem-complex.json
+++ b/tests/benchmarks/model_tiers/lem-complex.json
@@ -3,7 +3,7 @@
   "version": 1,
   "contract": "Long-form LinkedIn content: thought leadership, personal story, industry-news commentary, carousel outlines and newsletter editions. The output must follow the requested blueprint, hold a varied human sentence rhythm rather than uniform AI cadence, survive LEM's deterministic slop lint, and state no specific number, customer, employer or outcome that the prompt did not supply. A promotional post must ask for an artefact (a resource or a newsletter subscription), never a meeting.",
   "judge_rubric": "Pass only if the piece follows the requested structure, sounds like one identifiable practitioner writing from the supplied material, invents no statistic, customer name or outcome beyond what the prompt gave, avoids the contrastive 'it's not X, it's Y' frame and bait closers, and ends on the CTA the prompt asked for rather than a meeting request.",
-  "thresholds": {"deterministic_pass_rate": 0.9, "judge_pass_rate": 0.8, "min_judged": 4},
+  "thresholds": {"contract_pass_rate": 0.9, "deterministic_pass_rate": 0.9, "judge_pass_rate": 0.8, "min_judged": 4},
   "cases": [
     {
       "id": "complex-thought-leadership",
@@ -37,7 +37,8 @@
       "params": {"temperature": 0.8, "max_tokens": 1200},
       "assertions": [
         {"type": "min_chars", "value": 700},
-        {"type": "max_chars", "value": 2600},
+        {"type": "max_chars", "value": 2600, "production": "repairable"},
+        {"type": "max_chars", "value": 3000, "production": "contract"},
         {"type": "no_preamble"},
         {"type": "slop_lint", "content_type": "post"},
         {"type": "min_burstiness", "value": 0.2},
@@ -59,7 +60,8 @@
       "params": {"temperature": 0.8, "max_tokens": 1200},
       "assertions": [
         {"type": "min_chars", "value": 600},
-        {"type": "max_chars", "value": 2400},
+        {"type": "max_chars", "value": 2400, "production": "repairable"},
+        {"type": "max_chars", "value": 3000, "production": "contract"},
         {"type": "no_preamble"},
         {"type": "slop_lint", "content_type": "post"},
         {"type": "required_phrases", "values": ["61", "1,200"], "mode": "any"},
@@ -81,7 +83,8 @@
       "params": {"temperature": 0.7, "max_tokens": 1200},
       "assertions": [
         {"type": "min_chars", "value": 500},
-        {"type": "max_chars", "value": 2400},
+        {"type": "max_chars", "value": 2400, "production": "repairable"},
+        {"type": "max_chars", "value": 3000, "production": "contract"},
         {"type": "no_preamble"},
         {"type": "slop_lint", "content_type": "post"},
         {"type": "required_phrases", "values": ["11"], "mode": "all"},
@@ -143,7 +146,8 @@
       "params": {"temperature": 0.8, "max_tokens": 1100},
       "assertions": [
         {"type": "min_chars", "value": 500},
-        {"type": "max_chars", "value": 2200},
+        {"type": "max_chars", "value": 2200, "production": "repairable"},
+        {"type": "max_chars", "value": 3000, "production": "contract"},
         {"type": "no_preamble"},
         {"type": "slop_lint", "content_type": "post", "exempt_keyword": "RECEIPTS"},
         {"type": "forbidden_phrases", "values": ["book a call", "schedule a demo", "calendly", "hop on a call", "let's chat", "dm me for a quick call"]},
@@ -185,7 +189,8 @@
       "params": {"temperature": 0.8, "max_tokens": 1200},
       "assertions": [
         {"type": "min_chars", "value": 600},
-        {"type": "max_chars", "value": 2400},
+        {"type": "max_chars", "value": 2400, "production": "repairable"},
+        {"type": "max_chars", "value": 3000, "production": "contract"},
         {"type": "no_preamble"},
         {"type": "slop_lint", "content_type": "post"},
         {"type": "max_similarity", "value": 0.4, "against": ["complex-thought-leadership", "complex-personal-story", "complex-industry-news"]}
@@ -206,7 +211,8 @@
       "params": {"temperature": 0.8, "max_tokens": 700},
       "assertions": [
         {"type": "min_chars", "value": 300},
-        {"type": "max_chars", "value": 1400},
+        {"type": "max_chars", "value": 1400, "production": "repairable"},
+        {"type": "max_chars", "value": 3000, "production": "contract"},
         {"type": "no_preamble"},
         {"type": "slop_lint", "content_type": "post"},
         {"type": "forbidden_phrases", "values": ["thoughts?", "agree?", "who else", "double tap"]}

--- a/tests/benchmarks/model_tiers/lem-medium.json
+++ b/tests/benchmarks/model_tiers/lem-medium.json
@@ -4,6 +4,7 @@
   "contract": "Balanced work: LinkedIn feed comments (which must satisfy LEM's comment quality contract — reference a specific claim from the target post, add own experience, a data point, respectful disagreement or a genuine question, run at least two sentences, and never open with validation filler), post refinement, blog summaries and direct messages. Output is published under a real person's name, so it must read as a specific practitioner rather than generic AI filler.",
   "judge_rubric": "Pass only if the answer engages with the SPECIFIC content it was given (not a template that would fit any post), adds something a reader did not already have, states no fact, number, employer or customer that the prompt did not supply, and contains no preamble, hashtags-as-filler or closing 'let me know if you need anything else'.",
   "thresholds": {
+    "contract_pass_rate": 0.9,
     "deterministic_pass_rate": 0.9,
     "judge_pass_rate": 0.8,
     "min_judged": 4

--- a/tests/benchmarks/model_tiers/lem-router.json
+++ b/tests/benchmarks/model_tiers/lem-router.json
@@ -4,6 +4,7 @@
   "contract": "The routing tier. Two things are graded here. The `LEMComplexityRouter` contract (`.litellm/complexity_router.py` delegating to `routing_policy.complexity_tier`) must resolve each prompt shape to the tier named on the case — that check is deterministic and model-independent, and it is a regression guard on the router itself. Separately, the model deployed behind the `lem-router` alias must still answer these prompts cleanly: short, no preamble, no markdown fence.",
   "judge_rubric": "Pass only if the answer is the artefact asked for, with no preamble and no invented specifics.",
   "thresholds": {
+    "contract_pass_rate": 1.0,
     "deterministic_pass_rate": 1.0,
     "judge_pass_rate": 0.8,
     "min_judged": 3
@@ -127,6 +128,7 @@
         "temperature": 0,
         "max_tokens": 5
       },
+      "budget_mirrors_production": true,
       "assertions": [
         {
           "type": "router_tier",

--- a/tests/benchmarks/model_tiers/lem-simple.json
+++ b/tests/benchmarks/model_tiers/lem-simple.json
@@ -3,7 +3,7 @@
   "version": 1,
   "contract": "Short outputs of at most 300 characters: refine, summarize briefly, produce comma-separated lists or one-word classifications. The answer is pasted straight into LinkedIn copy or parsed by code, so it must obey the stated length and shape exactly and must never open with a preamble, a restatement of the task, or a markdown fence.",
   "judge_rubric": "Pass only if the answer is exactly the artefact that was asked for, at or under the stated length, with no preamble, no closing offer of further help, and no fact, number, company or person that the prompt did not supply.",
-  "thresholds": {"deterministic_pass_rate": 0.9, "judge_pass_rate": 0.8, "min_judged": 4},
+  "thresholds": {"contract_pass_rate": 0.9, "deterministic_pass_rate": 0.9, "judge_pass_rate": 0.8, "min_judged": 4},
   "cases": [
     {
       "id": "simple-industries-comma-list",
@@ -53,6 +53,7 @@
         {"role": "user", "content": "Allowed: like, celebrate, support, love, insightful, funny. Post: 'After eleven months of interviews, I signed my first enterprise customer this morning.' Which reaction fits best?"}
       ],
       "params": {"temperature": 0, "max_tokens": 5},
+      "budget_mirrors_production": true,
       "assertions": [
         {"type": "max_chars", "value": 20},
         {"type": "max_lines", "value": 1},
@@ -69,6 +70,7 @@
         {"role": "user", "content": "Topics of interest: platform engineering, developer experience. Post: 'Our new office plants have transformed the mood on the third floor.' Is the post relevant to any topic of interest?"}
       ],
       "params": {"temperature": 0, "max_tokens": 3},
+      "budget_mirrors_production": true,
       "assertions": [
         {"type": "max_chars", "value": 10},
         {"type": "max_lines", "value": 1},
@@ -164,6 +166,7 @@
         {"role": "user", "content": "Profile location line: 'Greater Boston Area, Massachusetts, United States'. Reply with the city name only."}
       ],
       "params": {"temperature": 0, "max_tokens": 8},
+      "budget_mirrors_production": true,
       "assertions": [
         {"type": "max_chars", "value": 40},
         {"type": "max_lines", "value": 1},

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -40,9 +40,14 @@ def _suite(tier="lem-simple", cases=None, thresholds=None):
 
 
 def _card(tier="lem-simple", model="m", role="candidate", det=1.0, judged=5, judge_rate=1.0,
-          errors=None):
+          errors=None, contract=None):
+    """A scorecard. `contract` defaults to `det` so a test that only cares about one rate reads the
+    same either way; the two are set apart wherever the split (#910) is what's under test."""
+    contract = det if contract is None else contract
     return {"tier": tier, "model": model, "role": role, "cases": 10,
-            "deterministic_pass_rate": det, "deterministic_passed": 10, "errors": errors or [],
+            "deterministic_pass_rate": det, "deterministic_passed": int(round(det * 10)),
+            "contract_pass_rate": contract, "contract_passed": int(round(contract * 10)),
+            "repaired_cases": [], "errors": errors or [],
             "failed_cases": [], "unscored_assertions": 0, "judged": judged,
             "judge_passed": judged, "judge_timeouts": 0, "judge_pass_rate": judge_rate,
             "judge_notes": [], "latency_p50_ms": 100.0, "latency_p90_ms": 200.0,
@@ -121,10 +126,22 @@ class TestLoadSuite:
 
     def test_thresholds_are_clamped_and_defaulted(self):
         assert bm.normalize_thresholds(None)["deterministic_pass_rate"] == 0.9
+        assert bm.normalize_thresholds(None)["contract_pass_rate"] == 0.9
         assert bm.normalize_thresholds({"deterministic_pass_rate": 5})[
             "deterministic_pass_rate"] == 1.0
+        assert bm.normalize_thresholds({"contract_pass_rate": 5})["contract_pass_rate"] == 1.0
         assert bm.normalize_thresholds({"judge_pass_rate": "x"})["judge_pass_rate"] == 0.8
         assert bm.normalize_thresholds({"min_judged": "x"})["min_judged"] == 3
+
+    def test_rejects_an_unknown_production_class(self):
+        with pytest.raises(bm.SuiteError, match="production class"):
+            bm.load_suite({"tier": "lem-simple", "cases": [_case(assertions=[
+                {"type": "max_chars", "value": 10, "production": "sometimes"}])]})
+
+    def test_rejects_a_non_boolean_production_budget_flag(self):
+        with pytest.raises(bm.SuiteError, match="budget_mirrors_production"):
+            bm.load_suite({"tier": "lem-simple",
+                           "cases": [_case(budget_mirrors_production="yes")]})
 
 
 # ────────────────────────── deterministic assertions ─────────────────────────────
@@ -231,6 +248,75 @@ class TestAssertions:
         assert result["assertions"][1]["passes"] is True
 
 
+# ─────────── what production does with a failure — the #910 calibration ──────────
+
+class TestProductionClass:
+    def test_the_gates_production_regenerates_against_default_to_repairable(self):
+        for kind in ("slop_lint", "comment_contract", "max_similarity", "min_burstiness"):
+            assert bm.assertion_production_class({"type": kind}) == bm.PRODUCTION_REPAIRABLE
+
+    def test_everything_else_defaults_to_contract(self):
+        for kind in ("max_chars", "min_chars", "json_object", "no_preamble", "comma_list",
+                     "router_tier", "required_phrases", "max_lines"):
+            assert bm.assertion_production_class({"type": kind}) == bm.PRODUCTION_CONTRACT
+
+    def test_an_unclassified_type_is_contract_not_silently_uncounted(self):
+        assert bm.assertion_production_class({"type": "brand-new"}) == bm.PRODUCTION_CONTRACT
+        assert bm.assertion_production_class(None) == bm.PRODUCTION_CONTRACT
+
+    def test_a_fixture_may_override_per_assertion(self):
+        # Repairable-ness is a property of the CALL SITE, not of the check: a craft-target max_chars
+        # on long-form is redrafted, the same assertion carrying LinkedIn's hard limit is not.
+        assert bm.assertion_production_class(
+            {"type": "max_chars", "production": "repairable"}) == bm.PRODUCTION_REPAIRABLE
+        assert bm.assertion_production_class(
+            {"type": "slop_lint", "production": "contract"}) == bm.PRODUCTION_CONTRACT
+
+    def test_a_repairable_only_failure_still_passes_the_contract(self):
+        case = _case(assertions=[{"type": "max_chars", "value": 500},
+                                 {"type": "slop_lint", "content_type": "comment"}])
+        # The contrastive frame is exactly what `_gated_comment` retries against (#617/#625).
+        result = bm.evaluate_case(
+            case, "It isn't about the tooling; it's about the queue. We measured both for a month.")
+        assert result["passes"] is False          # the first draft did not clear every check
+        assert result["contract_passes"] is True  # but production regenerates rather than ships it
+        assert result["repairable_failures"] and not result["contract_failures"]
+
+    def test_a_contract_failure_fails_both(self):
+        case = _case(assertions=[{"type": "max_chars", "value": 5}])
+        result = bm.evaluate_case(case, "far too long to fit")
+        assert result["passes"] is False and result["contract_passes"] is False
+        assert result["contract_failures"] and not result["repairable_failures"]
+
+    def test_no_output_is_a_contract_failure_there_is_no_repair_for_nothing(self):
+        result = bm.evaluate_case(_case(), None)
+        assert result["contract_passes"] is False
+        assert result["contract_failures"] == ["no output from the model"]
+
+    def test_the_shipped_long_form_suites_hold_linkedins_hard_limit_as_a_contract_check(self):
+        """A craft cap under 3000 chars is a target production redrafts toward; 3000 is LinkedIn's
+        own limit and nothing repairs a post that exceeds it."""
+        suite = bm.load_suites(str(SUITE_DIR), ["lem-complex"])["lem-complex"]
+        for case in suite["cases"]:
+            caps = [a for a in case["assertions"] if a["type"] == "max_chars"]
+            repairable = [a for a in caps
+                          if bm.assertion_production_class(a) == bm.PRODUCTION_REPAIRABLE]
+            if not repairable:
+                continue
+            hard = [a for a in caps
+                    if bm.assertion_production_class(a) == bm.PRODUCTION_CONTRACT]
+            assert hard, f"{case['id']}: a repairable cap with no hard limit behind it"
+            assert max(a["value"] for a in hard) == 3000, case["id"]
+
+    def test_every_production_budget_case_is_a_short_one(self):
+        """The exemption exists for budgets that MIRROR a call site (`max_tokens` 3/5/8). Marking a
+        long-form case would quietly re-disable the reasoning-headroom retry the #842 run needed."""
+        for tier, suite in bm.load_suites(str(SUITE_DIR)).items():
+            for case in suite["cases"]:
+                if case.get("budget_mirrors_production"):
+                    assert case["params"]["max_tokens"] <= 10, f"{tier}/{case['id']}"
+
+
 # ───────────────────────────── scorecard merge ───────────────────────────────────
 
 class TestScorecard:
@@ -267,6 +353,29 @@ class TestScorecard:
         card = bm.merge_scorecard("lem-simple", "m", "candidate", results, {})
         assert card["judge_pass_rate"] is None
 
+    def test_both_rates_are_reported_and_the_redraft_cost_is_named(self):
+        results = [{"case_id": "a", "passes": True, "contract_passes": True, "unscored": 0},
+                   {"case_id": "b", "passes": False, "contract_passes": True, "unscored": 0,
+                    "failures": ["slop_lint: contrastive frame"],
+                    "repairable_failures": ["slop_lint: contrastive frame"],
+                    "contract_failures": []},
+                   {"case_id": "c", "passes": False, "contract_passes": False, "unscored": 0,
+                    "failures": ["max_chars: 3915 chars > 3000"], "repairable_failures": [],
+                    "contract_failures": ["max_chars: 3915 chars > 3000"]}]
+        card = bm.merge_scorecard("lem-complex", "m", "candidate", results)
+        assert card["deterministic_pass_rate"] == pytest.approx(1 / 3, abs=1e-4)
+        assert card["contract_pass_rate"] == pytest.approx(2 / 3, abs=1e-4)
+        assert card["repaired_cases"] == ["b"]
+        assert card["failed_cases"][0]["repairable_failures"] == ["slop_lint: contrastive frame"]
+
+    def test_cases_that_were_re_measured_or_budget_locked_are_named(self):
+        results = [{"case_id": "a", "passes": True, "contract_passes": True, "unscored": 0},
+                   {"case_id": "b", "passes": True, "contract_passes": True, "unscored": 0}]
+        timings = {"a": {"repeats": 1}, "b": {"budget_locked": True}}
+        card = bm.merge_scorecard("lem-simple", "m", "candidate", results, {}, timings)
+        assert card["remeasured_cases"] == ["a"]
+        assert card["budget_locked_cases"] == ["b"]
+
     def test_cases_that_needed_reasoning_headroom_are_named_not_silently_absorbed(self):
         results = [{"case_id": "a", "passes": True, "failures": [], "unscored": 0},
                    {"case_id": "b", "passes": True, "failures": [], "unscored": 0}]
@@ -287,15 +396,15 @@ class TestGate:
 
     def test_rejects_a_candidate_below_the_absolute_floor(self):
         gate = bm.gate_decision(_card(det=0.5), _card(role="champion", det=0.4),
-                                {"deterministic_pass_rate": 0.9})
+                                {"contract_pass_rate": 0.9})
         assert gate["verdict"] == bm.VERDICT_REJECT
-        assert "deterministic floor" in gate["blockers"]
+        assert "contract floor" in gate["blockers"]
 
     def test_rejects_a_candidate_that_loses_to_the_champion(self):
         gate = bm.gate_decision(_card(det=0.92), _card(role="champion", det=0.99),
-                                {"deterministic_pass_rate": 0.9})
+                                {"contract_pass_rate": 0.9})
         assert gate["verdict"] == bm.VERDICT_REJECT
-        assert "beats champion (deterministic)" in gate["blockers"]
+        assert "beats champion (first-draft)" in gate["blockers"]
 
     def test_a_tie_counts_as_meets_or_beats(self):
         gate = bm.gate_decision(_card(det=0.9), _card(role="champion", det=0.9),
@@ -345,10 +454,176 @@ class TestGate:
         gates = bm.gate_run(cards, {"lem-medium": _suite("lem-medium")})
         assert len(gates) == 1 and gates[0]["champion"] == "champ-m"
 
+    def test_the_first_draft_rate_is_advisory_not_a_floor(self):
+        """The #910 finding: every model measured, champions included, sat at 40–80% first-draft
+        against a 90% floor. A floor the incumbent fails is a gate that can never open."""
+        gate = bm.gate_decision(_card(det=0.4, contract=1.0),
+                                _card(role="champion", det=0.4, contract=1.0),
+                                {"contract_pass_rate": 0.9, "deterministic_pass_rate": 0.9})
+        assert gate["verdict"] == bm.VERDICT_RECOMMEND
+        advisory = gate["advisories"][0]
+        assert advisory["expectation"] == "first-draft yield" and advisory["passes"] is False
+        assert [e["expectation"] for e in gate["expectations"] if e["passes"] is False] == []
+
+    def test_a_candidate_that_ships_more_broken_output_is_rejected(self):
+        gate = bm.gate_decision(_card(det=1.0, contract=0.8), _card(role="champion", contract=1.0),
+                                {"contract_pass_rate": 0.9})
+        assert gate["verdict"] == bm.VERDICT_REJECT
+        assert "contract floor" in gate["blockers"]
+
+    def test_a_candidate_below_its_champions_contract_rate_is_rejected(self):
+        gate = bm.gate_decision(_card(contract=0.9), _card(role="champion", contract=1.0),
+                                {"contract_pass_rate": 0.9})
+        assert "beats champion (contract)" in gate["blockers"]
+
+    def test_a_champion_that_misses_the_floor_is_recorded_on_every_verdict(self):
+        gate = bm.gate_decision(_card(contract=1.0), _card(role="champion", contract=0.7),
+                                {"contract_pass_rate": 0.9})
+        assert gate["champion_clears_contract_floor"] is False
+        assert bm.gate_decision(_card(), _card(role="champion"),
+                                {})["champion_clears_contract_floor"] is True
+        assert bm.gate_decision(_card(), None, {})["champion_clears_contract_floor"] is None
+
     def test_mapping_lines_are_rendered_not_written(self):
         lines = bm.recommendation_mapping_lines(
             [{"tier": "lem-simple", "model": "new", "champion": "old"}])
         assert lines == ['  "old": "new"  # lem-simple: benchmark-recommended']
+
+
+# ─────────────── the #842 roster, replayed under the #910 calibration ────────────
+#
+# Acceptance for #910: "a re-run of the #842 roster under the new calibration produces a verdict
+# that could, in principle, be a `recommend` — i.e. the gate is demonstrably openable". A live
+# re-run needs a metered key, so the demonstration is a REPLAY: every failing case from the
+# committed report (`docs/model-benchmarks/2026-08-02-bm-20260802-20ae40.md`) is re-scored through
+# the real classifier and the real gate. Nothing here is invented — each entry is one ❌ line of
+# that report, with the fixture assertion it came from.
+
+# (case failures) per model, verbatim from the report's per-expectation detail. `max_chars-hard` is
+# a breach of LinkedIn's own 3000-char limit (contract); `max_chars-craft` is the tier's tighter
+# dwell target, which production redrafts toward.
+BM842 = {
+    ("lem-complex", "qwen3.5:397b", "champion"): {
+        "failures": [["max_chars-hard"], ["max_chars-hard", "slop_lint", "required_phrases"],
+                     ["max_chars-craft"], ["slop_lint"], ["max_chars-hard"]],
+        "judged": 5, "judge_rate": 1.0, "usage": {"level": 2, "label": "medium"}},
+    ("lem-complex", "deepseek-v4-flash", "candidate"): {
+        "failures": [["slop_lint"], ["required_phrases"], ["slop_lint"]],
+        "judged": 7, "judge_rate": 0.57, "usage": {"level": 2, "label": "medium"}},
+    ("lem-complex", "gemma4:31b", "candidate"): {
+        "failures": [["slop_lint"], ["slop_lint"]],
+        "judged": 7, "judge_rate": 0.57, "usage": {"level": 1, "label": "low"}},
+    ("lem-complex", "minimax-m3", "candidate"): {
+        "failures": [["min_chars"], ["slop_lint", "required_phrases"], ["slop_lint"],
+                     ["slop_lint"], ["required_phrases"], ["slop_lint"]],
+        "judged": 4, "judge_rate": 0.75, "usage": {"level": 3, "label": "high"}},
+    ("lem-complex", "glm-5.2", "candidate"): {
+        "failures": [["min_chars"], ["min_chars"], ["min_chars"]],
+        "judged": 7, "judge_rate": 0.86, "usage": {"level": 3, "label": "high"}},
+    ("lem-medium", "gpt-oss:120b", "champion"): {
+        "failures": [["comment_contract"]] * 4,
+        "judged": 6, "judge_rate": 0.5, "usage": {"level": 2, "label": "medium"}},
+    ("lem-medium", "deepseek-v4-flash", "candidate"): {
+        "failures": [["comment_contract"]] * 4,
+        "judged": 6, "judge_rate": 0.83, "usage": {"level": 2, "label": "medium"}},
+    ("lem-medium", "gemma4:31b", "candidate"): {
+        "failures": [["comment_contract"]] * 5 + [["required_phrases"]],
+        "judged": 4, "judge_rate": 1.0, "usage": {"level": 1, "label": "low"}},
+    ("lem-medium", "minimax-m3", "candidate"): {
+        "failures": [["comment_contract"]] * 5,
+        "judged": 5, "judge_rate": 0.8, "usage": {"level": 3, "label": "high"}},
+    ("lem-medium", "glm-5.2", "candidate"): {
+        "failures": [["comment_contract"]] * 5 + [["min_chars"]],
+        "judged": 4, "judge_rate": 0.75, "usage": {"level": 3, "label": "high"}},
+}
+
+# How each measured failure maps onto a fixture assertion, so the REAL classifier decides whether
+# production would have shipped it.
+BM842_SPECS = {
+    "max_chars-hard": {"type": "max_chars", "value": 3000, "production": "contract"},
+    "max_chars-craft": {"type": "max_chars", "value": 2400, "production": "repairable"},
+    "min_chars": {"type": "min_chars", "value": 700},
+    "slop_lint": {"type": "slop_lint"},
+    "comment_contract": {"type": "comment_contract"},
+    "required_phrases": {"type": "required_phrases"},
+}
+
+
+def _replay_cards(cases: int = 10) -> list:
+    cards = []
+    for (tier, model, role), measured in BM842.items():
+        results = []
+        for index in range(cases):
+            failed = measured["failures"][index] if index < len(measured["failures"]) else []
+            assertions = [{"type": BM842_SPECS[k]["type"],
+                           "production": bm.assertion_production_class(BM842_SPECS[k]),
+                           "passes": False, "detail": k} for k in failed]
+            contract = [f"{a['type']}: {a['detail']}" for a in assertions
+                        if a["production"] == bm.PRODUCTION_CONTRACT]
+            repairable = [f"{a['type']}: {a['detail']}" for a in assertions
+                          if a["production"] == bm.PRODUCTION_REPAIRABLE]
+            results.append({"case_id": f"{tier}-{index}", "passes": not failed,
+                            "contract_passes": not contract, "assertions": assertions,
+                            "failures": contract + repairable, "contract_failures": contract,
+                            "repairable_failures": repairable, "unscored": 0})
+        judged = measured["judged"]
+        judge = {r["case_id"]: {"passes": i < round(judged * measured["judge_rate"]),
+                                "status": "scored"}
+                 for i, r in enumerate(results[:judged])}
+        card = bm.merge_scorecard(tier, model, role, results, judge)
+        card["usage"] = measured["usage"]
+        card["benchmark_run_id"] = "bm-20260802-20ae40"
+        cards.append(card)
+    return cards
+
+
+class TestBm842Replay:
+    def _gates(self):
+        suites = bm.load_suites(str(SUITE_DIR), ["lem-complex", "lem-medium"])
+        return {(g["tier"], g["model"]): g for g in bm.gate_run(_replay_cards(), suites)}
+
+    def test_the_old_absolute_floor_could_not_have_opened_for_anyone(self):
+        """Why the calibration changed: not one model in that roster — champions included — was
+        within reach of the 90% floor on the first-draft rate."""
+        for card in _replay_cards():
+            assert card["deterministic_pass_rate"] < 0.9, card["model"]
+
+    def test_the_gate_is_openable_deepseek_now_earns_a_recommend_on_lem_medium(self):
+        gate = self._gates()[("lem-medium", "deepseek-v4-flash")]
+        assert gate["verdict"] == bm.VERDICT_RECOMMEND, gate["expectations"]
+        assert bm.swap_recommendations([gate])[0]["champion"] == "gpt-oss:120b"
+        # Flat on quota, so the standing #842 spend policy takes it without the owner.
+        assert gate["quota_policy"]["decision"] == bm.POLICY_ADOPT
+
+    def test_it_is_the_only_recommendation_the_rest_still_fail_on_real_quality(self):
+        gates = self._gates()
+        recommended = [k for k, g in gates.items() if g["verdict"] == bm.VERDICT_RECOMMEND]
+        assert recommended == [("lem-medium", "deepseek-v4-flash")]
+        # …and each rejection now names a quality reason, not the floor everybody failed.
+        assert "judge floor" in gates[("lem-complex", "gemma4:31b")]["blockers"]
+        assert "contract floor" in gates[("lem-complex", "glm-5.2")]["blockers"]
+        assert "beats champion (first-draft)" in gates[("lem-medium", "minimax-m3")]["blockers"]
+
+    def test_the_champions_contract_rates_are_measured_not_assumed(self):
+        cards = {(c["tier"], c["model"]): c for c in _replay_cards() if c["role"] == "champion"}
+        # Every lem-medium failure was the #617 comment contract, which production retries and then
+        # SKIPS the post over — nothing broken ships, so the incumbent clears its own floor.
+        assert cards[("lem-medium", "gpt-oss:120b")]["contract_pass_rate"] == 1.0
+        # lem-complex is the honest opposite: three drafts over LinkedIn's own 3000-char limit is a
+        # real defect, and the floor is supposed to show it.
+        assert cards[("lem-complex", "qwen3.5:397b")]["contract_pass_rate"] == 0.7
+
+    def test_the_report_says_when_the_incumbent_misses_its_own_floor(self):
+        gates = list(self._gates().values())
+        run = {"source": bm.BENCHMARK_SOURCE, "run_id": "bm-20260802-20ae40",
+               "date": "2026-08-02", "scoring_mode": bm.SCORING_FALLBACK,
+               "tiers": ["lem-complex", "lem-medium"], "candidates": ["deepseek-v4-flash"],
+               "scorecards": _replay_cards(), "gates": gates,
+               "recommendations": bm.swap_recommendations(gates)}
+        text = bm.render_report(run)
+        assert "misses this tier's own\ncontract floor" in text or \
+               "misses this tier's own contract floor" in text
+        assert "first-draft yield (advisory)" in text
 
 
 # ───────────────────────────── provenance guard ──────────────────────────────────
@@ -430,6 +705,25 @@ class TestRendering:
         text = bm.render_report(run)
         assert "reasoning headroom" in text and "`complex-personal-story`" in text
 
+    def test_report_separates_what_production_ships_from_what_it_redrafts(self):
+        run = self._run()
+        run["scorecards"][1]["failed_cases"] = [
+            {"case_id": "ships", "failures": ["max_chars: 3915 chars > 3000"],
+             "contract_failures": ["max_chars: 3915 chars > 3000"], "repairable_failures": []},
+            {"case_id": "redrafted", "failures": ["slop_lint: contrastive frame"],
+             "contract_failures": [], "repairable_failures": ["slop_lint: contrastive frame"]}]
+        text = bm.render_report(run)
+        assert "❌ `ships` — production would ship this" in text
+        assert "🔁 `redrafted` — first draft only" in text
+
+    def test_report_names_re_measured_and_budget_locked_cases(self):
+        run = self._run()
+        run["scorecards"][0]["remeasured_cases"] = ["complex-thought-leadership"]
+        run["scorecards"][0]["budget_locked_cases"] = ["simple-relevance-yes-no"]
+        text = bm.render_report(run)
+        assert "measurement variance" in text and "`complex-thought-leadership`" in text
+        assert "production budget" in text and "`simple-relevance-yes-no`" in text
+
     def test_report_says_so_when_nothing_is_recommended(self):
         run = self._run()
         run["recommendations"] = []
@@ -490,6 +784,20 @@ class TestRendering:
         # three runs × two scorecards on top of the committed history, and nothing else
         assert len(rows) == 2 + committed + 6
         assert bm.LEADERBOARD_HEADER not in rows[2:]
+
+    def test_pre_910_rows_survive_the_new_contract_column(self):
+        """Adding a column must not evict the history already committed: a legacy row is re-emitted
+        at the new width with `n/a` where nobody measured a contract rate."""
+        legacy = ("| 2026-08-02 | `bm-old` | lem-medium | `gpt-oss:120b` | champion | 60% | 50% | "
+                  "1635 ms | baseline |")
+        doc = f"{bm.LEADERBOARD_BEGIN}\n{bm.LEADERBOARD_HEADER}\n{bm.LEADERBOARD_DIVIDER}\n" \
+              f"{legacy}\n{bm.LEADERBOARD_END}\n"
+        merged = bm.update_leaderboard(doc, bm.leaderboard_rows(self._run()))
+        kept = [line for line in merged.splitlines() if "bm-old" in line]
+        assert len(kept) == 1
+        cells = [c.strip() for c in kept[0].strip().strip("|").split("|")]
+        assert len(cells) == len(bm.LEADERBOARD_COLUMNS)
+        assert cells[5] == "n/a" and cells[6] == "60%"  # contract unknown, first draft preserved
 
     def test_the_committed_leaderboard_has_the_markers(self):
         text = (_ROOT / "docs" / "model-benchmarks" / "README.md").read_text()
@@ -708,15 +1016,20 @@ class TestProviderClient:
                    for c in openai_client.chat.completions.create.call_args_list]
         assert budgets == [1400, 2800, 5600]
 
-    def test_the_retry_is_bounded_and_the_empty_answer_still_counts(self, monkeypatch):
+    def test_the_retry_is_bounded_and_an_answer_that_never_arrives_is_no_output(self, monkeypatch):
+        # Grading "" would render as `min_chars: 0 chars < 700` — a quality verdict on a model that
+        # was never measured. A completion that stayed empty through the escalations AND the
+        # re-measurement is NO OUTPUT, which the gate reads as "the provider didn't answer" (#910).
         monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "1")
+        monkeypatch.setenv("BENCHMARK_EMPTY_REPEATS", "1")
         provider, openai_client = self._client()
         openai_client.chat.completions.create.return_value = self._reply("",
                                                                          finish_reason="length")
         result = provider.complete("m", [{"role": "user", "content": "hi"}], {"max_tokens": 100})
-        assert result["text"] == ""
-        assert result["budget_escalations"] == 1
-        assert openai_client.chat.completions.create.call_count == 2
+        assert result["text"] is None
+        assert "empty completion" in result["error"]
+        assert result["budget_escalations"] == 1 and result["repeats"] == 1
+        assert openai_client.chat.completions.create.call_count == 3
 
     def test_a_truncated_but_non_empty_answer_is_never_re_rolled(self, monkeypatch):
         # Retrying a model that DID answer would hand the verbose ones a second attempt the concise
@@ -729,10 +1042,54 @@ class TestProviderClient:
 
     def test_a_case_with_no_max_tokens_is_never_escalated(self, monkeypatch):
         monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "2")
+        monkeypatch.setenv("BENCHMARK_EMPTY_REPEATS", "0")
         provider, openai_client = self._client(self._reply("", finish_reason="length"))
         result = provider.complete("m", [{"role": "user", "content": "hi"}], {"temperature": 0.8})
         assert result["budget_escalations"] == 0
         assert openai_client.chat.completions.create.call_count == 1
+
+    def test_a_production_budget_case_is_never_retried_at_a_larger_one(self, monkeypatch):
+        # `lem-simple`'s relevance check is `max_tokens: 3` because `ai_helper.py`'s is. A model
+        # that cannot answer inside that budget is DISQUALIFIED at that call site — scoring it at 6
+        # or 12 tokens credits it with something LEM could never run there (#910).
+        monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "2")
+        monkeypatch.setenv("BENCHMARK_EMPTY_REPEATS", "0")
+        provider, openai_client = self._client(self._reply("", finish_reason="length"))
+        result = provider.complete("m", [{"role": "user", "content": "hi"}], {"max_tokens": 3},
+                                   allow_budget_escalation=False)
+        assert result["budget_escalations"] == 0 and result["budget_locked"] is True
+        assert openai_client.chat.completions.create.call_count == 1
+        assert openai_client.chat.completions.create.call_args.kwargs["max_tokens"] == 3
+
+    def test_an_empty_completion_is_re_measured_at_the_same_budget(self, monkeypatch):
+        # minimax-m3 returned empty twice in bm-20260802-20ae40 and answered both cases on a re-run
+        # at the same effective budget. The repeat re-ASKS, it does not buy headroom.
+        monkeypatch.setenv("BENCHMARK_TRUNCATION_RETRIES", "0")
+        monkeypatch.setenv("BENCHMARK_EMPTY_REPEATS", "1")
+        provider, openai_client = self._client()
+        openai_client.chat.completions.create.side_effect = [
+            self._reply("", finish_reason="length"), self._reply("the long-form draft")]
+        result = provider.complete("minimax-m3", [{"role": "user", "content": "hi"}],
+                                   {"max_tokens": 1400})
+        assert result["text"] == "the long-form draft"
+        assert result["repeats"] == 1 and result["budget_escalations"] == 0
+        budgets = [c.kwargs["max_tokens"]
+                   for c in openai_client.chat.completions.create.call_args_list]
+        assert budgets == [1400, 1400]
+
+    def test_a_production_budget_case_is_still_re_measured_when_it_comes_back_empty(self,
+                                                                                    monkeypatch):
+        monkeypatch.setenv("BENCHMARK_EMPTY_REPEATS", "1")
+        provider, openai_client = self._client()
+        openai_client.chat.completions.create.side_effect = [
+            self._reply("", finish_reason="length"), self._reply("yes")]
+        result = provider.complete("m", [{"role": "user", "content": "hi"}], {"max_tokens": 3},
+                                   allow_budget_escalation=False)
+        assert result["text"] == "yes" and result["repeats"] == 1
+        # Measured fine on the repeat, so it is NOT reported as a case the budget locked out.
+        assert result["budget_locked"] is False
+        assert [c.kwargs["max_tokens"]
+                for c in openai_client.chat.completions.create.call_args_list] == [3, 3]
 
     def test_a_discarded_attempt_is_not_charged_to_the_model_s_latency(self, monkeypatch):
         # p50/p90 go into the rolling leaderboard forever. Charging the thrown-away attempt to the
@@ -1179,6 +1536,32 @@ class TestRunBenchmark:
         assert card["errors"] == ["a", "b"]
         assert run["gates"][0]["verdict"] == bm.VERDICT_REJECT
         assert run["recommendations"] == []
+
+    def test_a_production_budget_case_reaches_the_provider_with_escalation_off(self):
+        suites = {"lem-simple": _suite("lem-simple", cases=[
+            _case("mirrors", assertions=[{"type": "max_chars", "value": 50}],
+                  params={"max_tokens": 3}, budget_mirrors_production=True),
+            _case("free", assertions=[{"type": "max_chars", "value": 50}],
+                  params={"max_tokens": 600})], thresholds={"min_judged": 1})}
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "yes", "error": None, "latency_ms": 5.0,
+                                          "usage": {}, "repeats": 0, "budget_locked": False}
+        bm.run_benchmark(suites, [], {"lem-simple": "champ"}, run_id="bm-1", today="2026-07-27",
+                         provider=provider, judge_cap=0, judge_enabled=False)
+        # Suite order: the production-mirror case first, the free-budget one second.
+        assert [c.kwargs["allow_budget_escalation"]
+                for c in provider.complete.call_args_list] == [False, True]
+
+    def test_re_measurements_and_budget_locks_ride_onto_the_scorecard(self):
+        provider = MagicMock()
+        provider.complete.return_value = {"text": "short answer", "error": None, "latency_ms": 5.0,
+                                          "usage": {}, "repeats": 1, "budget_locked": True}
+        run = bm.run_benchmark(self._suites(), [], {"lem-simple": "champ"}, run_id="bm-1",
+                               today="2026-07-27", provider=provider, judge_cap=0,
+                               judge_enabled=False)
+        card = run["scorecards"][0]
+        assert card["remeasured_cases"] == ["a", "b"]
+        assert card["budget_locked_cases"] == ["a", "b"]
 
     def test_no_judge_mode_spends_nothing_and_reports_deterministic_only(self):
         provider = MagicMock()

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -716,6 +716,26 @@ class TestRendering:
         assert "❌ `ships` — production would ship this" in text
         assert "🔁 `redrafted` — first draft only" in text
 
+    def test_a_case_that_produced_nothing_is_not_reported_as_shipped_output(self):
+        """`no output` IS a contract failure — the call site got nothing — but production never
+        SHIPPED it, and since #910 turns an empty completion into no output this is the common
+        path. Rendering it under "production would ship this" is the misreading the two rates
+        exist to prevent."""
+        card = bm.merge_scorecard("lem-complex", "minimax-m3", "candidate", [bm.evaluate_case(
+            {"id": "complex-thought-leadership", "assertions": [{"type": "min_chars", "value": 700},
+                                                                {"type": "slop_lint"}]},
+            None) | {"error": "empty completion after 2 budget escalation(s) and 1 "
+                              "re-measurement(s)"}])
+        run = self._run()
+        run["scorecards"][1] = card | {"benchmark_run_id": run["run_id"], "usage": None}
+        text = bm.render_report(run)
+        assert "❌ `complex-thought-leadership` — no output; nothing was measured here" in text
+        assert "empty completion after 2 budget escalation(s)" in text
+        assert "production would ship this" not in text
+        # …and it still fails the gate: no output is never a pass.
+        assert card["contract_pass_rate"] == 0.0 and card["errors"] == [
+            "complex-thought-leadership"]
+
     def test_report_names_re_measured_and_budget_locked_cases(self):
         run = self._run()
         run["scorecards"][0]["remeasured_cases"] = ["complex-thought-leadership"]


### PR DESCRIPTION
## Why

`bm-20260802-20ae40` measured 40–80% deterministic pass rates for **every** model in the roster, both reigning champions included, against a 90% absolute floor. A floor the incumbent itself fails is a gate that can never open: a genuinely better model would have landed as `reject` and nobody would have noticed.

The per-case failures are real model behaviour, not harness artifacts. What was wrong was grading them all the same way — **the suite scores a first draft; production ships an n-th.**

## What changed

**1. The floor is recalibrated, not deleted.** Every assertion is now classified by what production does with its failure:

| Class | Meaning | Examples |
|---|---|---|
| `contract` | the call site consumes it — nothing repairs it | broken JSON, a preamble, a classification returned as prose, a post over LinkedIn's own 3000-char limit, no output |
| `repairable` | a regeneration gate catches and redrafts it | `slop_lint`, `comment_contract`, `max_similarity`, `min_burstiness` — `lint_repaired`, the #617 comment gate (then the post is skipped), `_review_generated_post` + `evaluate_post_gates` (then the post is held) |

The ABSOLUTE floor moves to `contract_pass_rate` (default 0.9). `deterministic_pass_rate` stays as an **advisory** reading, rendered with its target and the redraft count, and is still a meets-or-beats against the champion — needing more drafts than the incumbent is a real cost (tokens, latency, skipped comments) even when nothing broken ships. Repairable-ness is per fixture assertion, not per type: on long-form the tier's craft length target is repairable and the hard 3000-char limit beside it is not, so both live on the same case.

**2. The gate is demonstrably openable — shown by replay.** A live re-run spends metered Ollama Cloud quota and needs `BENCHMARK_ENABLED` + the key, so the demonstration re-scores the #842 report's OWN measured failures — one entry per ❌ line of the committed report — through the real classifier and the real gate (`TestBm842Replay`). Result: `deepseek-v4-flash` on `lem-medium` clears every expectation and lands as **`recommend`** (tied the champion deterministically, beat it 83% vs 50% on judge, same Medium usage level — exactly the model the #842 write-up called "the model to re-measure first"). It is the only one; every other rejection now names a quality reason instead of the floor everybody failed. `lem-complex`'s champion still misses the floor at 70% contract — that is now a TRUE signal (three drafts over LinkedIn's hard character limit) and it is named on every verdict for that tier rather than left to be inferred.

**3. Production-mirror budgets are exempt from the truncation retry** (owner's third calibration comment). `simple-relevance-yes-no` is `max_tokens: 3` because `ai_helper.py`'s relevance check is; retrying at 6 and 12 credited a model with something LEM could never run there. Those cases carry `"budget_mirrors_production": true` and are never escalated; ones that end empty are named under 🔒 *production budget*. A test fails the build if the flag is ever set on a case whose budget is above 10 tokens, so it can't quietly re-disable the #842 reasoning-headroom retry.

**4. Reasoning-model variance.** An empty completion is re-measured at the SAME budget (`BENCHMARK_EMPTY_REPEATS`, default 1 — `minimax-m3` answered both of its empty #842 cases on a re-run), every case that needed it is named under ⚖️ *measurement variance*, and one that stays empty is recorded as **no output** rather than as a 0-char answer that rendered as `min_chars: 0 chars < 700` — a quality verdict on a model that was never measured.

Leaderboard gains a **Contract** column; pre-#910 rows are still parsed and re-emitted at the new width with `n/a`, so adding a column doesn't silently evict committed history.

## Testing

- `tests/unit/test_benchmark_models.py`: 186 tests (was 156) — classification defaults + per-fixture override, both scorecard rates, the advisory-not-a-floor gate posture, the champion-misses-its-own-floor note, the budget exemption, the empty re-measurement, no-output-vs-0-chars, legacy leaderboard rows, and the #842 replay.
- Full unit suite green: 9,480 passed.
- `--print-suites` and a full `--dry-run` render exercised end to end.

## Scope

Every acceptance box on #910 is covered, including the extra one from the owner's comment. Criterion 2 asks for a re-run of the #842 roster: a live one needs the metered key, so this PR delivers the replay of that run's own measurements as a committed test and the next weekly `scripts/weekly_model_check.sh` run produces the first real scorecard carrying both columns.

Closes #910

🤖 Generated with [Claude Code](https://claude.com/claude-code)