### PR TITLE
docs(models): the #921 tag scan — decline deepseek-v4-flash:0731 and kimi-k3 (closes #921)

### DIFF
--- a/.litellm/config.yaml
+++ b/.litellm/config.yaml
@@ -60,6 +60,13 @@ model_list:
   # deepseek-v4-flash (284B MoE / 13B active, 1M context, native structured output, fast
   # no-thinking mode) is a MEDIUM usage-level model — the same quota class gpt-oss:120b and the
   # departed minimax-m2.7 sit in — so adding it is flat on quota, not a step up.
+  #
+  # Keep this id UNVERSIONED. The catalog's `deepseek-v4-flash:0731` is a DIFFERENT build (167GB vs
+  # 140GB, published 2026-07-31), and it was benchmarked against this one on 2026-08-02 for #921
+  # (`bm-20260802-b84f19`): it scored BELOW the build below on the contract rate on every tier
+  # measured — 80% vs 90% here, 80% vs 90% on lem-complex, 40% vs 50% on lem-simple — at the same
+  # Medium usage level, so there is nothing a pin would buy. Declined; see
+  # docs/model-benchmarks/README.md. Newer tag ≠ better model is the whole point of the harness.
   - model_name: lem-medium
     litellm_params:
       model: openai/deepseek-v4-flash
@@ -95,6 +102,13 @@ model_list:
       api_key: os.environ/OPENAI_API_KEY
 
   # ── COMPLEX tier: long-form, high-quality content ────────────────────────────
+  # NOTE: openai/kimi-k3 was EVALUATED and DECLINED 2026-08-02 (issue #921). It is not a quality
+  # call and it was never benchmarked: the Ollama Cloud API answers HTTP 402 for it — "this model
+  # uses extra usage only (not included plan usage)". Its page prices per token ($3.00/$15.00 per
+  # 1M) instead of publishing a usage-level pip, so the benchmark reads its level as `unknown`,
+  # which the #842 standing spend policy holds by default. Every deployment in this file is served
+  # inside plan usage; kimi-k3 would move a tier onto metered extra-usage billing, which is an
+  # owner spend decision, not a roster refresh. Re-evaluate only if the plan changes.
   # NOTE: openai/kimi-k2:1t was RETIRED 2026-06-16 (returns 410) and was removed — it was
   # the primary here, so content generation fell through to the OpenAI/Anthropic fallbacks,
   # which fail when those keys aren't set. qwen3.5:397b (OLLAMA) is now primary.
@@ -116,6 +130,8 @@ model_list:
   # group — see the note at the top of this file); the long-form quality reading, and any adoption
   # of the HIGH usage-level minimax-m3 / glm-5.2 as the quality option, is a
   # scripts/benchmark_models.py decision on #842, not a config-time one.
+  # Unversioned for the same reason as the lem-medium deployment above — the `:0731` build measured
+  # worse here too (80% contract vs this build's 90%, #921).
   - model_name: lem-complex
     litellm_params:
       model: openai/deepseek-v4-flash

--- a/.litellm/config.yaml
+++ b/.litellm/config.yaml
@@ -61,12 +61,22 @@ model_list:
   # no-thinking mode) is a MEDIUM usage-level model — the same quota class gpt-oss:120b and the
   # departed minimax-m2.7 sit in — so adding it is flat on quota, not a step up.
   #
-  # Keep this id UNVERSIONED. The catalog's `deepseek-v4-flash:0731` is a DIFFERENT build (167GB vs
-  # 140GB, published 2026-07-31), and it was benchmarked against this one on 2026-08-02 for #921
-  # (`bm-20260802-b84f19`): it scored BELOW the build below on the contract rate on every tier
-  # measured — 80% vs 90% here, 80% vs 90% on lem-complex, 40% vs 50% on lem-simple — at the same
-  # Medium usage level, so there is nothing a pin would buy. Declined; see
-  # docs/model-benchmarks/README.md. Newer tag ≠ better model is the whole point of the harness.
+  # The catalog's `deepseek-v4-flash:0731` is a DIFFERENT build (167GB vs 140GB, published
+  # 2026-07-31), and it was benchmarked beside this one on 2026-08-02 for #921
+  # (`bm-20260802-b84f19`): rejected on all three tiers, no `recommend`. It did not beat the build
+  # below — 80% vs 90% contract here, 80% vs 90% on lem-complex, 40% vs 50% on lem-simple — at the
+  # same Medium usage level. Read that as "did not carry the burden", NOT "is the worse build":
+  # ten cases per tier means one case is ten points, and the same fixtures ninety minutes earlier
+  # scored `:0731` 100% on this tier. Declined; see docs/model-benchmarks/README.md. Newer tag ≠
+  # better model is the whole point of the harness.
+  #
+  # This id stays UNVERSIONED, which means it follows the catalog's moving tag — including onto
+  # the build above if ollama re-points it. That is a real exposure, not a free default:
+  # scripts/model_health_check.py diffs tag NAMES, so a re-point files no evaluation issue and
+  # this tier would change model unbenchmarked (detection tracked on #925). Kept unversioned
+  # because this is the build measured at 90% today and a pin has upkeep of its own (every scan,
+  # retirement-map and shadow-pricing path keys on the exact id string) — but a pin is the trade
+  # being declined here, not a no-op.
   - model_name: lem-medium
     litellm_params:
       model: openai/deepseek-v4-flash
@@ -130,8 +140,9 @@ model_list:
   # group — see the note at the top of this file); the long-form quality reading, and any adoption
   # of the HIGH usage-level minimax-m3 / glm-5.2 as the quality option, is a
   # scripts/benchmark_models.py decision on #842, not a config-time one.
-  # Unversioned for the same reason as the lem-medium deployment above — the `:0731` build measured
-  # worse here too (80% contract vs this build's 90%, #921).
+  # Unversioned on the same terms as the lem-medium deployment above — the `:0731` build did not
+  # beat this one here either (80% contract vs 90%, #921), and the same moving-tag exposure (#925)
+  # applies to this deployment too.
   - model_name: lem-complex
     litellm_params:
       model: openai/deepseek-v4-flash

--- a/docs/model-benchmarks/2026-08-02-bm-20260802-5fff18.md
+++ b/docs/model-benchmarks/2026-08-02-bm-20260802-5fff18.md
@@ -1,0 +1,162 @@
+# Model-tier benchmark — 2026-08-02 (`bm-20260802-5fff18`)
+
+- **Scoring mode:** `in-runner-judge`
+- **Tiers:** lem-complex, lem-medium, lem-simple
+- **Candidates:** deepseek-v4-flash:0731
+- **Judge calls spent:** 1 (cap 200)
+
+Inputs are synthetic prompt templates from `tests/benchmarks/model_tiers/`; no customer content, credentials or production logs appear in this report.
+
+## Scorecard
+
+| Tier | Model | Role | Usage | Cases | Contract | First draft | Judge | Judged | Timeouts | p50 | p90 |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| lem-complex | `qwen3.5:397b` | champion | Medium (2) | 10 | 90% (9/10) | 60% (6/10) | n/a | 0 | 6 | 28535 ms | 31999 ms |
+| lem-complex | `deepseek-v4-flash:0731` | candidate | Medium (2) | 10 | 60% (6/10) | 30% (3/10) | n/a | 0 | 3 | 5212 ms | 7682 ms |
+| lem-medium | `gpt-oss:120b` | champion | Medium (2) | 10 | 90% (9/10) | 70% (7/10) | n/a | 0 | 7 | 1952 ms | 2292 ms |
+| lem-medium | `deepseek-v4-flash:0731` | candidate | Medium (2) | 10 | 100% (10/10) | 60% (6/10) | n/a | 0 | 6 | 1636 ms | 2227 ms |
+| lem-simple | `gpt-oss:20b` | champion | Low (1) | 10 | 40% (4/10) | 40% (4/10) | n/a | 0 | 4 | 1403 ms | 2830 ms |
+| lem-simple | `deepseek-v4-flash:0731` | candidate | Medium (2) | 10 | 40% (4/10) | 40% (4/10) | n/a | 0 | 4 | 1214 ms | 1997 ms |
+
+**Contract** is the share of cases whose failures production would actually consume; **First draft** is the same cases against every check, repairable ones included. Production regenerates against the repairable ones (`lint_repaired`, the #617 comment gate, the post review gate) and skips or holds what still fails, so the gap between the two columns is redraft COST, not shipped defects. The absolute floor is on Contract; First draft is advisory and champion-relative (#910).
+
+**Usage** is the Ollama Cloud usage level (quota class) — `unknown` where ollama.com publishes no level for that model, which is the case for models that are also pullable locally. Supply those with `--usage-levels model=<level>`.
+
+## Per-expectation detail
+
+### `qwen3.5:397b` — lem-complex (champion)
+
+- 🔁 `complex-personal-story` — first draft only; production regenerates against this and skips/holds what still fails
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't just an inconvenience; it's
+- ❌ `complex-industry-news` — production would ship this
+  - max_chars: 3032 chars > 3000
+  - (repairable) max_chars: 3032 chars > 2400
+  - (repairable) slop_lint: uses 4 AI-tell words/phrases (max 2): landscape, pivotal, crucial, robust
+- 🔁 `complex-similarity-guard` — first draft only; production regenerates against this and skips/holds what still fails
+  - max_chars: 2565 chars > 2400
+- 🔁 `complex-engagement-prompt` — first draft only; production regenerates against this and skips/holds what still fails
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't measured by how much you can stack up. It's
+
+### `deepseek-v4-flash:0731` — lem-complex (candidate)
+
+- ⚠️ no output for: `complex-mobile-hook`
+- ❌ `complex-thought-leadership` — production would ship this
+  - max_chars: 3523 chars > 3000
+- 🔁 `complex-personal-story` — first draft only; production regenerates against this and skips/holds what still fails
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't to avoid mistakes; it's
+- ❌ `complex-industry-news` — production would ship this
+  - min_chars: 439 chars < 600
+- ❌ `complex-build-receipt` — production would ship this
+  - min_chars: 15 chars < 500
+- ❌ `complex-mobile-hook` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- 🔁 `complex-similarity-guard` — first draft only; production regenerates against this and skips/holds what still fails
+  - slop_lint: uses manufactured "ta-da" transitions that promise a payoff: The result?
+- 🔁 `complex-engagement-prompt` — first draft only; production regenerates against this and skips/holds what still fails
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't failure; it's
+- 🧠 reasoning headroom — 3 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `complex-newsletter-edition`, `complex-mobile-hook`, `complex-similarity-guard`
+- ⚖️ measurement variance — 1 case(s) came back EMPTY at the full budget and were re-measured at that same budget: `complex-mobile-hook`. One run of one case is a data point, not a verdict — read this model's rates as single-measurement.
+
+### `gpt-oss:120b` — lem-medium (champion)
+
+- 🔁 `medium-comment-respectful-disagreement` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-thread-reply` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-dm-appreciation` — production would ship this
+  - min_chars: 59 chars < 80
+- 🧠 reasoning headroom — 2 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `medium-seed-comment-own-post`, `medium-json-relevance-score`
+
+### `deepseek-v4-flash:0731` — lem-medium (candidate)
+
+- 🔁 `medium-comment-hiring-post` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-comment-respectful-disagreement` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-seed-comment-own-post` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: fewer than 2 sentences; adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-comment-similarity-guard` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🧠 reasoning headroom — 4 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `medium-comment-deploy-post`, `medium-comment-hiring-post`, `medium-post-refinement`, `medium-blog-summary`
+
+### `gpt-oss:20b` — lem-simple (champion)
+
+- ⚠️ no output for: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-hook-shorten`, `simple-headline-refine`, `simple-single-value-extract`
+- ❌ `simple-reaction-choice` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-relevance-yes-no` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-hook-shorten` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- ❌ `simple-json-sentiment` — production would ship this
+  - json_object: not valid JSON (Unterminated string starting at: line 1 column 2 (char 1))
+- ❌ `simple-headline-refine` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- ❌ `simple-single-value-extract` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- 🧠 reasoning headroom — 6 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `simple-industries-comma-list`, `simple-keyword-list`, `simple-hook-shorten`, `simple-brief-summary`, `simple-headline-refine`, `simple-no-fabrication`
+- 🔒 production budget — 3 case(s) spent a budget that MIRRORS a production call site's own `max_tokens` without answering, and were NOT retried at a larger one; a model that cannot answer inside that budget is disqualified at that call site, not merely truncated: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-single-value-extract`
+- ⚖️ measurement variance — 6 case(s) came back EMPTY at the full budget and were re-measured at that same budget: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-hook-shorten`, `simple-headline-refine`, `simple-single-value-extract`, `simple-no-fabrication`. One run of one case is a data point, not a verdict — read this model's rates as single-measurement.
+
+### `deepseek-v4-flash:0731` — lem-simple (candidate)
+
+- ⚠️ no output for: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-hook-shorten`, `simple-brief-summary`, `simple-headline-refine`, `simple-single-value-extract`
+- ❌ `simple-reaction-choice` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-relevance-yes-no` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-hook-shorten` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- ❌ `simple-brief-summary` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- ❌ `simple-headline-refine` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- ❌ `simple-single-value-extract` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- 🧠 reasoning headroom — 6 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `simple-industries-comma-list`, `simple-keyword-list`, `simple-hook-shorten`, `simple-brief-summary`, `simple-headline-refine`, `simple-no-fabrication`
+- 🔒 production budget — 3 case(s) spent a budget that MIRRORS a production call site's own `max_tokens` without answering, and were NOT retried at a larger one; a model that cannot answer inside that budget is disqualified at that call site, not merely truncated: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-single-value-extract`
+- ⚖️ measurement variance — 6 case(s) came back EMPTY at the full budget and were re-measured at that same budget: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-hook-shorten`, `simple-brief-summary`, `simple-headline-refine`, `simple-single-value-extract`. One run of one case is a data point, not a verdict — read this model's rates as single-measurement.
+
+## Gate verdicts
+
+### `deepseek-v4-flash:0731` on lem-complex — **reject** (vs champion `qwen3.5:397b`)
+
+- ❌ contract floor — 60% vs floor 90%
+- ❌ provider answered every case — 1 case(s) returned no output
+- ➖ judge floor — 0 judged case(s) < 4 required — unscored
+- ❌ beats champion (contract) — 60% vs champion 90%
+- ❌ beats champion (first-draft) — 30% vs champion 60%
+- ➖ beats champion (judge) — judge evidence missing on one side
+- ⚠️ first-draft yield (advisory) — 30% vs advisory target 90% — 3 case(s) production would have redrafted rather than shipped (advisory: does not change the verdict)
+- 💳 usage level — flat on quota — Medium (2) on both sides.
+
+### `deepseek-v4-flash:0731` on lem-medium — **reject** (vs champion `gpt-oss:120b`)
+
+- ✅ contract floor — 100% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ➖ judge floor — 0 judged case(s) < 4 required — unscored
+- ✅ beats champion (contract) — 100% vs champion 90%
+- ❌ beats champion (first-draft) — 60% vs champion 70%
+- ➖ beats champion (judge) — judge evidence missing on one side
+- ⚠️ first-draft yield (advisory) — 60% vs advisory target 90% — 4 case(s) production would have redrafted rather than shipped (advisory: does not change the verdict)
+- 💳 usage level — flat on quota — Medium (2) on both sides.
+
+### `deepseek-v4-flash:0731` on lem-simple — **reject** (vs champion `gpt-oss:20b`)
+
+- ❌ contract floor — 40% vs floor 90%
+- ❌ provider answered every case — 6 case(s) returned no output
+- ➖ judge floor — 0 judged case(s) < 4 required — unscored
+- ✅ beats champion (contract) — 40% vs champion 40%
+- ✅ beats champion (first-draft) — 40% vs champion 40%
+- ➖ beats champion (judge) — judge evidence missing on one side
+- ⚠️ first-draft yield (advisory) — 40% vs advisory target 90% — 0 case(s) production would have redrafted rather than shipped (advisory: does not change the verdict)
+- 🪧 the incumbent `gpt-oss:20b` misses this tier's own contract floor — that is a statement about the tier's fixtures, not about this candidate; the relative half of the verdict is what stands.
+- 💳 usage level — ⚠️ **quota increase** — Medium (2) vs champion `gpt-oss:20b` Low (1) (+1 usage level). Every call on this tier burns more Ollama Cloud quota; this is a spend decision, not a free upgrade.
+
+## Swap recommendations
+
+None. No candidate met its tier's thresholds *and* beat the champion on every graded expectation.
+
+---
+
+Generated by `scripts/benchmark_models.py` (issue #721). Deterministic checks are the in-repo linters (`slop_lint`, the comment quality contract, the `LEMComplexityRouter` tier contract); judge scores come from `in-runner-judge`.

--- a/docs/model-benchmarks/2026-08-02-bm-20260802-b84f19.md
+++ b/docs/model-benchmarks/2026-08-02-bm-20260802-b84f19.md
@@ -1,0 +1,245 @@
+# Model-tier benchmark — 2026-08-02 (`bm-20260802-b84f19`)
+
+- **Scoring mode:** `in-runner-judge`
+- **Tiers:** lem-complex, lem-medium, lem-simple
+- **Candidates:** deepseek-v4-flash:0731, deepseek-v4-flash
+- **Judge calls spent:** 1 (cap 200)
+
+Inputs are synthetic prompt templates from `tests/benchmarks/model_tiers/`; no customer content, credentials or production logs appear in this report.
+
+## Scorecard
+
+| Tier | Model | Role | Usage | Cases | Contract | First draft | Judge | Judged | Timeouts | p50 | p90 |
+|---|---|---|---|---|---|---|---|---|---|---|---|
+| lem-complex | `qwen3.5:397b` | champion | Medium (2) | 10 | 70% (7/10) | 50% (5/10) | n/a | 0 | 5 | 30346 ms | 35448 ms |
+| lem-complex | `deepseek-v4-flash:0731` | candidate | Medium (2) | 10 | 80% (8/10) | 80% (8/10) | n/a | 0 | 8 | 5634 ms | 10565 ms |
+| lem-complex | `deepseek-v4-flash` | candidate | Medium (2) | 10 | 90% (9/10) | 60% (6/10) | n/a | 0 | 6 | 3016 ms | 4774 ms |
+| lem-medium | `gpt-oss:120b` | champion | Medium (2) | 10 | 90% (9/10) | 60% (6/10) | n/a | 0 | 6 | 2429 ms | 2939 ms |
+| lem-medium | `deepseek-v4-flash:0731` | candidate | Medium (2) | 10 | 80% (8/10) | 40% (4/10) | n/a | 0 | 4 | 1820 ms | 2766 ms |
+| lem-medium | `deepseek-v4-flash` | candidate | Medium (2) | 10 | 90% (9/10) | 40% (4/10) | n/a | 0 | 4 | 1438 ms | 1722 ms |
+| lem-simple | `gpt-oss:20b` | champion | Low (1) | 10 | 50% (5/10) | 50% (5/10) | n/a | 0 | 5 | 1432 ms | 3131 ms |
+| lem-simple | `deepseek-v4-flash:0731` | candidate | Medium (2) | 10 | 40% (4/10) | 40% (4/10) | n/a | 0 | 4 | 996 ms | 2345 ms |
+| lem-simple | `deepseek-v4-flash` | candidate | Medium (2) | 10 | 50% (5/10) | 50% (5/10) | n/a | 0 | 5 | 1036 ms | 2079 ms |
+
+**Contract** is the share of cases whose failures production would actually consume; **First draft** is the same cases against every check, repairable ones included. Production regenerates against the repairable ones (`lint_repaired`, the #617 comment gate, the post review gate) and skips or holds what still fails, so the gap between the two columns is redraft COST, not shipped defects. The absolute floor is on Contract; First draft is advisory and champion-relative (#910).
+
+**Usage** is the Ollama Cloud usage level (quota class) — `unknown` where ollama.com publishes no level for that model, which is the case for models that are also pullable locally. Supply those with `--usage-levels model=<level>`.
+
+## Per-expectation detail
+
+### `qwen3.5:397b` — lem-complex (champion)
+
+- ❌ `complex-thought-leadership` — production would ship this
+  - max_chars: 3261 chars > 3000
+- ❌ `complex-personal-story` — production would ship this
+  - required_phrases: missing '40'
+  - (repairable) slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't just a buzzword. It's
+- ❌ `complex-industry-news` — production would ship this
+  - max_chars: 3222 chars > 3000
+  - (repairable) max_chars: 3222 chars > 2400
+  - (repairable) slop_lint: uses 3 AI-tell words/phrases (max 2): landscape, profound, optimize
+- 🔁 `complex-similarity-guard` — first draft only; production regenerates against this and skips/holds what still fails
+  - max_chars: 2984 chars > 2400
+- 🔁 `complex-engagement-prompt` — first draft only; production regenerates against this and skips/holds what still fails
+  - max_chars: 2024 chars > 1400
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn't identifying the bloat; it's
+
+### `deepseek-v4-flash:0731` — lem-complex (candidate)
+
+- ⚠️ no output for: `complex-mobile-hook`
+- ❌ `complex-mobile-hook` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- ❌ `complex-similarity-guard` — production would ship this
+  - min_chars: 175 chars < 600
+- 🧠 reasoning headroom — 3 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `complex-industry-news`, `complex-promo-artifact-cta`, `complex-mobile-hook`
+- ⚖️ measurement variance — 1 case(s) came back EMPTY at the full budget and were re-measured at that same budget: `complex-mobile-hook`. One run of one case is a data point, not a verdict — read this model's rates as single-measurement.
+
+### `deepseek-v4-flash` — lem-complex (candidate)
+
+- ⚠️ no output for: `complex-mobile-hook`
+- 🔁 `complex-newsletter-edition` — first draft only; production regenerates against this and skips/holds what still fails
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn’t a failure of documentation. It’s
+- 🔁 `complex-promo-artifact-cta` — first draft only; production regenerates against this and skips/holds what still fails
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn’t an endpoint; it’s
+- ❌ `complex-mobile-hook` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- 🔁 `complex-similarity-guard` — first draft only; production regenerates against this and skips/holds what still fails
+  - slop_lint: uses the "it's not X, it's Y" contrastive frame, the construction LinkedIn's 2026 update names first: isn’t about eliminating meetings. It’s; uses manufactured "ta-da" transitions that promise a payoff: The result?
+- 🧠 reasoning headroom — 1 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `complex-mobile-hook`
+- ⚖️ measurement variance — 1 case(s) came back EMPTY at the full budget and were re-measured at that same budget: `complex-mobile-hook`. One run of one case is a data point, not a verdict — read this model's rates as single-measurement.
+
+### `gpt-oss:120b` — lem-medium (champion)
+
+- 🔁 `medium-comment-respectful-disagreement` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-comment-similarity-guard` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-thread-reply` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-json-relevance-score` — production would ship this
+  - json_object: not valid JSON (Expecting ',' delimiter: line 1 column 125 (char 124))
+
+### `deepseek-v4-flash:0731` — lem-medium (candidate)
+
+- 🔁 `medium-comment-deploy-post` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: fewer than 2 sentences; does not reference a specific claim from the target post; adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-comment-respectful-disagreement` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-seed-comment-own-post` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-comment-similarity-guard` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: does not reference a specific claim from the target post; adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-post-refinement` — production would ship this
+  - min_chars: 186 chars < 200
+- ❌ `medium-blog-summary` — production would ship this
+  - required_phrases: missing '9'
+- 🧠 reasoning headroom — 3 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `medium-seed-comment-own-post`, `medium-comment-similarity-guard`, `medium-dm-appreciation`
+
+### `deepseek-v4-flash` — lem-medium (candidate)
+
+- 🔁 `medium-comment-hiring-post` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-comment-respectful-disagreement` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: does not reference a specific claim from the target post; adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-seed-comment-own-post` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🔁 `medium-comment-similarity-guard` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- ❌ `medium-post-refinement` — production would ship this
+  - min_chars: 198 chars < 200
+- 🔁 `medium-thread-reply` — first draft only; production regenerates against this and skips/holds what still fails
+  - comment_contract: adds no experience, data point, disagreement, or genuine question
+- 🧠 reasoning headroom — 1 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `medium-comment-deploy-post`
+
+### `gpt-oss:20b` — lem-simple (champion)
+
+- ⚠️ no output for: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-hook-shorten`, `simple-single-value-extract`
+- ❌ `simple-reaction-choice` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-relevance-yes-no` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-hook-shorten` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- ❌ `simple-json-sentiment` — production would ship this
+  - json_object: not valid JSON (Unterminated string starting at: line 1 column 2 (char 1))
+- ❌ `simple-single-value-extract` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- 🧠 reasoning headroom — 6 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `simple-industries-comma-list`, `simple-keyword-list`, `simple-hook-shorten`, `simple-brief-summary`, `simple-headline-refine`, `simple-no-fabrication`
+- 🔒 production budget — 3 case(s) spent a budget that MIRRORS a production call site's own `max_tokens` without answering, and were NOT retried at a larger one; a model that cannot answer inside that budget is disqualified at that call site, not merely truncated: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-single-value-extract`
+- ⚖️ measurement variance — 4 case(s) came back EMPTY at the full budget and were re-measured at that same budget: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-hook-shorten`, `simple-single-value-extract`. One run of one case is a data point, not a verdict — read this model's rates as single-measurement.
+
+### `deepseek-v4-flash:0731` — lem-simple (candidate)
+
+- ⚠️ no output for: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-hook-shorten`, `simple-headline-refine`, `simple-single-value-extract`
+- ❌ `simple-reaction-choice` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-relevance-yes-no` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-hook-shorten` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- ❌ `simple-headline-refine` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- ❌ `simple-single-value-extract` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-no-fabrication` — production would ship this
+  - required_phrases: missing '40'
+- 🧠 reasoning headroom — 5 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `simple-industries-comma-list`, `simple-keyword-list`, `simple-hook-shorten`, `simple-brief-summary`, `simple-headline-refine`
+- 🔒 production budget — 3 case(s) spent a budget that MIRRORS a production call site's own `max_tokens` without answering, and were NOT retried at a larger one; a model that cannot answer inside that budget is disqualified at that call site, not merely truncated: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-single-value-extract`
+- ⚖️ measurement variance — 5 case(s) came back EMPTY at the full budget and were re-measured at that same budget: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-hook-shorten`, `simple-headline-refine`, `simple-single-value-extract`. One run of one case is a data point, not a verdict — read this model's rates as single-measurement.
+
+### `deepseek-v4-flash` — lem-simple (candidate)
+
+- ⚠️ no output for: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-hook-shorten`, `simple-single-value-extract`
+- ❌ `simple-reaction-choice` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-relevance-yes-no` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- ❌ `simple-hook-shorten` — no output; nothing was measured here
+  - empty completion after 2 budget escalation(s) and 1 re-measurement(s)
+- ❌ `simple-json-sentiment` — production would ship this
+  - json_object: not valid JSON (Unterminated string starting at: line 1 column 27 (char 26))
+- ❌ `simple-single-value-extract` — no output; nothing was measured here
+  - empty completion after 0 budget escalation(s) and 1 re-measurement(s) (this case's max_tokens mirrors a production call site, so the budget was never grown)
+- 🧠 reasoning headroom — 4 case(s) spent the fixture's whole completion budget thinking and were retried at a larger one: `simple-industries-comma-list`, `simple-keyword-list`, `simple-hook-shorten`, `simple-headline-refine`
+- 🔒 production budget — 3 case(s) spent a budget that MIRRORS a production call site's own `max_tokens` without answering, and were NOT retried at a larger one; a model that cannot answer inside that budget is disqualified at that call site, not merely truncated: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-single-value-extract`
+- ⚖️ measurement variance — 4 case(s) came back EMPTY at the full budget and were re-measured at that same budget: `simple-reaction-choice`, `simple-relevance-yes-no`, `simple-hook-shorten`, `simple-single-value-extract`. One run of one case is a data point, not a verdict — read this model's rates as single-measurement.
+
+## Gate verdicts
+
+### `deepseek-v4-flash:0731` on lem-complex — **reject** (vs champion `qwen3.5:397b`)
+
+- ❌ contract floor — 80% vs floor 90%
+- ❌ provider answered every case — 1 case(s) returned no output
+- ➖ judge floor — 0 judged case(s) < 4 required — unscored
+- ✅ beats champion (contract) — 80% vs champion 70%
+- ✅ beats champion (first-draft) — 80% vs champion 50%
+- ➖ beats champion (judge) — judge evidence missing on one side
+- ⚠️ first-draft yield (advisory) — 80% vs advisory target 90% — 0 case(s) production would have redrafted rather than shipped (advisory: does not change the verdict)
+- 🪧 the incumbent `qwen3.5:397b` misses this tier's own contract floor — that is a statement about the tier's fixtures, not about this candidate; the relative half of the verdict is what stands.
+- 💳 usage level — flat on quota — Medium (2) on both sides.
+
+### `deepseek-v4-flash` on lem-complex — **reject** (vs champion `qwen3.5:397b`)
+
+- ✅ contract floor — 90% vs floor 90%
+- ❌ provider answered every case — 1 case(s) returned no output
+- ➖ judge floor — 0 judged case(s) < 4 required — unscored
+- ✅ beats champion (contract) — 90% vs champion 70%
+- ✅ beats champion (first-draft) — 60% vs champion 50%
+- ➖ beats champion (judge) — judge evidence missing on one side
+- ⚠️ first-draft yield (advisory) — 60% vs advisory target 90% — 3 case(s) production would have redrafted rather than shipped (advisory: does not change the verdict)
+- 🪧 the incumbent `qwen3.5:397b` misses this tier's own contract floor — that is a statement about the tier's fixtures, not about this candidate; the relative half of the verdict is what stands.
+- 💳 usage level — flat on quota — Medium (2) on both sides.
+
+### `deepseek-v4-flash:0731` on lem-medium — **reject** (vs champion `gpt-oss:120b`)
+
+- ❌ contract floor — 80% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ➖ judge floor — 0 judged case(s) < 4 required — unscored
+- ❌ beats champion (contract) — 80% vs champion 90%
+- ❌ beats champion (first-draft) — 40% vs champion 60%
+- ➖ beats champion (judge) — judge evidence missing on one side
+- ⚠️ first-draft yield (advisory) — 40% vs advisory target 90% — 4 case(s) production would have redrafted rather than shipped (advisory: does not change the verdict)
+- 💳 usage level — flat on quota — Medium (2) on both sides.
+
+### `deepseek-v4-flash` on lem-medium — **reject** (vs champion `gpt-oss:120b`)
+
+- ✅ contract floor — 90% vs floor 90%
+- ✅ provider answered every case — all cases answered
+- ➖ judge floor — 0 judged case(s) < 4 required — unscored
+- ✅ beats champion (contract) — 90% vs champion 90%
+- ❌ beats champion (first-draft) — 40% vs champion 60%
+- ➖ beats champion (judge) — judge evidence missing on one side
+- ⚠️ first-draft yield (advisory) — 40% vs advisory target 90% — 5 case(s) production would have redrafted rather than shipped (advisory: does not change the verdict)
+- 💳 usage level — flat on quota — Medium (2) on both sides.
+
+### `deepseek-v4-flash:0731` on lem-simple — **reject** (vs champion `gpt-oss:20b`)
+
+- ❌ contract floor — 40% vs floor 90%
+- ❌ provider answered every case — 5 case(s) returned no output
+- ➖ judge floor — 0 judged case(s) < 4 required — unscored
+- ❌ beats champion (contract) — 40% vs champion 50%
+- ❌ beats champion (first-draft) — 40% vs champion 50%
+- ➖ beats champion (judge) — judge evidence missing on one side
+- ⚠️ first-draft yield (advisory) — 40% vs advisory target 90% — 0 case(s) production would have redrafted rather than shipped (advisory: does not change the verdict)
+- 🪧 the incumbent `gpt-oss:20b` misses this tier's own contract floor — that is a statement about the tier's fixtures, not about this candidate; the relative half of the verdict is what stands.
+- 💳 usage level — ⚠️ **quota increase** — Medium (2) vs champion `gpt-oss:20b` Low (1) (+1 usage level). Every call on this tier burns more Ollama Cloud quota; this is a spend decision, not a free upgrade.
+
+### `deepseek-v4-flash` on lem-simple — **reject** (vs champion `gpt-oss:20b`)
+
+- ❌ contract floor — 50% vs floor 90%
+- ❌ provider answered every case — 4 case(s) returned no output
+- ➖ judge floor — 0 judged case(s) < 4 required — unscored
+- ✅ beats champion (contract) — 50% vs champion 50%
+- ✅ beats champion (first-draft) — 50% vs champion 50%
+- ➖ beats champion (judge) — judge evidence missing on one side
+- ⚠️ first-draft yield (advisory) — 50% vs advisory target 90% — 0 case(s) production would have redrafted rather than shipped (advisory: does not change the verdict)
+- 🪧 the incumbent `gpt-oss:20b` misses this tier's own contract floor — that is a statement about the tier's fixtures, not about this candidate; the relative half of the verdict is what stands.
+- 💳 usage level — ⚠️ **quota increase** — Medium (2) vs champion `gpt-oss:20b` Low (1) (+1 usage level). Every call on this tier burns more Ollama Cloud quota; this is a spend decision, not a free upgrade.
+
+## Swap recommendations
+
+None. No candidate met its tier's thresholds *and* beat the champion on every graded expectation.
+
+---
+
+Generated by `scripts/benchmark_models.py` (issue #721). Deterministic checks are the in-repo linters (`slop_lint`, the comment quality contract, the `LEMComplexityRouter` tier contract); judge scores come from `in-runner-judge`.

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -242,6 +242,44 @@ reactive half of the model-health check auto-swaps whatever lands in it, so adop
 winner is a deliberate edit to `.litellm/config.yaml` (or a #717-style PR). The report renders the
 exact mapping lines for a human to take.
 
+### What the 2026-08-02 tag scan settled (#921) — both declined
+
+The catalog scan found two new Ollama Cloud tags. Both are **declined**; neither reaches
+`.litellm/config.yaml`. Recorded here because the issue's own rule is that a decline has to be
+readable by the next scan's reader — otherwise the same tag gets re-evaluated from its spec sheet
+every month.
+
+| Tag | What was measured | Decision |
+|---|---|---|
+| `deepseek-v4-flash:0731` | Medium (2), same level as the build already deployed. Run against all three content tiers beside both the tier champion **and** the incumbent `deepseek-v4-flash` build (`bm-20260802-b84f19`): contract **80% vs 90%** on `lem-complex`, **80% vs 90%** on `lem-medium`, **40% vs 50%** on `lem-simple` | **Decline.** No `recommend` on any tier, and it is *below the build LEM already ships* on the contract rate everywhere. There is no quota argument to offset that — both builds are Medium. |
+| `kimi-k3` | Never benchmarked: the Ollama Cloud API answers **HTTP 402** — *"this model uses extra usage only (not included plan usage) and your extra usage balance is empty"* | **Decline.** Not a quality question. It is outside plan usage entirely, so its page publishes a per-token price ($3.00 / $15.00 per 1M, $0.30 cached) instead of a usage-level pip — the harness reads that as `unknown`, which the standing spend policy already holds. |
+
+Three things this run is worth reading for beyond the two verdicts:
+
+- **`:0731` is a different build, not a re-tag.** The catalog carries it at 167GB against the
+  unversioned tag's 140GB, and ollama.com dates them 2026-07-31 and three months apart, so the
+  `bm-20260802-20ae40` measurement of `deepseek-v4-flash` was not a measurement of this one. That is
+  why the incumbent build was re-run here rather than quoted: a build-vs-build comparison is the
+  actual decision, and the two builds have to share a calibration and a run to be comparable at all.
+- **`lem-simple` is the wrong shape for this model, not merely a weak fit.** `deepseek-v4-flash` is a
+  reasoning model and bills its chain-of-thought against `max_tokens`, so on the three
+  `budget_mirrors_production` cases (`max_tokens` 3 / 5 / 8, mirroring `ai_helper.py`'s own call
+  sites) it returns nothing at all. Both builds are also **+1 usage level** against `gpt-oss:20b`
+  there. Neither build belongs on that tier at any quality.
+- **The suites' run-to-run spread is wider than this decision's margins.** Two runs of the same
+  fixtures ninety minutes apart moved `deepseek-v4-flash:0731` on `lem-medium` from 100% to 80%
+  contract, `qwen3.5:397b` on `lem-complex` from 90% to 70%, and `gpt-oss:20b` on `lem-simple` from
+  40% to 50% (`bm-20260802-5fff18` and `bm-20260802-b84f19`, both committed beside this file). Ten
+  cases per tier means one case is ten points, so a single-digit gap between two models is noise.
+  This is what the ⚖️ *measurement variance* note says per case, stated at the level of a whole
+  scorecard: **a one-run margin under ~20 points is not a reason to swap anything.**
+
+Both runs are `in-runner-judge` mode with **no judge evidence** — the runner had no LiteLLM proxy to
+reach, so every case is `judge:timeout` and the judge expectations render as unscored. It changes
+nothing here: each of the six verdicts already fails a *deterministic* graded expectation, and the
+judge can only ever add a reason to reject. A run that intends to *promote* something still needs
+one.
+
 ## Running it
 
 ```bash
@@ -290,6 +328,21 @@ is the rate their report published.
 <!-- LEADERBOARD:BEGIN -->
 | Date | Run | Tier | Model | Role | Contract | First draft | Judge | p50 | Verdict |
 |---|---|---|---|---|---|---|---|---|---|
+| 2026-08-02 | `bm-20260802-b84f19` | lem-complex | `qwen3.5:397b` | champion | 70% | 50% | n/a | 30346 ms | baseline |
+| 2026-08-02 | `bm-20260802-b84f19` | lem-complex | `deepseek-v4-flash:0731` | candidate | 80% | 80% | n/a | 5634 ms | reject |
+| 2026-08-02 | `bm-20260802-b84f19` | lem-complex | `deepseek-v4-flash` | candidate | 90% | 60% | n/a | 3016 ms | reject |
+| 2026-08-02 | `bm-20260802-b84f19` | lem-medium | `gpt-oss:120b` | champion | 90% | 60% | n/a | 2429 ms | baseline |
+| 2026-08-02 | `bm-20260802-b84f19` | lem-medium | `deepseek-v4-flash:0731` | candidate | 80% | 40% | n/a | 1820 ms | reject |
+| 2026-08-02 | `bm-20260802-b84f19` | lem-medium | `deepseek-v4-flash` | candidate | 90% | 40% | n/a | 1438 ms | reject |
+| 2026-08-02 | `bm-20260802-b84f19` | lem-simple | `gpt-oss:20b` | champion | 50% | 50% | n/a | 1432 ms | baseline |
+| 2026-08-02 | `bm-20260802-b84f19` | lem-simple | `deepseek-v4-flash:0731` | candidate | 40% | 40% | n/a | 996 ms | reject |
+| 2026-08-02 | `bm-20260802-b84f19` | lem-simple | `deepseek-v4-flash` | candidate | 50% | 50% | n/a | 1036 ms | reject |
+| 2026-08-02 | `bm-20260802-5fff18` | lem-complex | `qwen3.5:397b` | champion | 90% | 60% | n/a | 28535 ms | baseline |
+| 2026-08-02 | `bm-20260802-5fff18` | lem-complex | `deepseek-v4-flash:0731` | candidate | 60% | 30% | n/a | 5212 ms | reject |
+| 2026-08-02 | `bm-20260802-5fff18` | lem-medium | `gpt-oss:120b` | champion | 90% | 70% | n/a | 1952 ms | baseline |
+| 2026-08-02 | `bm-20260802-5fff18` | lem-medium | `deepseek-v4-flash:0731` | candidate | 100% | 60% | n/a | 1636 ms | reject |
+| 2026-08-02 | `bm-20260802-5fff18` | lem-simple | `gpt-oss:20b` | champion | 40% | 40% | n/a | 1403 ms | baseline |
+| 2026-08-02 | `bm-20260802-5fff18` | lem-simple | `deepseek-v4-flash:0731` | candidate | 40% | 40% | n/a | 1214 ms | reject |
 | 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `qwen3.5:397b` | champion | n/a | 50% | 100% | 26955 ms | baseline |
 | 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `deepseek-v4-flash` | candidate | n/a | 70% | 57% | 3275 ms | reject |
 | 2026-08-02 | `bm-20260802-20ae40` | lem-complex | `gemma4:31b` | candidate | n/a | 80% | 57% | 2428 ms | reject |

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -251,10 +251,10 @@ every month.
 
 | Tag | What was measured | Decision |
 |---|---|---|
-| `deepseek-v4-flash:0731` | Medium (2), same level as the build already deployed. Run against all three content tiers beside both the tier champion **and** the incumbent `deepseek-v4-flash` build (`bm-20260802-b84f19`): contract **80% vs 90%** on `lem-complex`, **80% vs 90%** on `lem-medium`, **40% vs 50%** on `lem-simple` | **Decline.** No `recommend` on any tier, and it is *below the build LEM already ships* on the contract rate everywhere. There is no quota argument to offset that — both builds are Medium. |
+| `deepseek-v4-flash:0731` | Medium (2), same level as the build already deployed. Run against all three content tiers beside both the tier champion **and** the incumbent `deepseek-v4-flash` build (`bm-20260802-b84f19`): contract **80% vs 90%** on `lem-complex`, **80% vs 90%** on `lem-medium`, **40% vs 50%** on `lem-simple` | **Decline.** No `recommend` on any tier: it did not beat the build LEM already ships on the contract rate anywhere, and there is no quota argument to offset that — both builds are Medium. Note the margins are one case wide, i.e. inside this suite's run-to-run spread (third bullet below), so this reads as *"did not carry the burden"*, not *"is the worse build"*. Either way it is a decline — adoption requires beating the incumbent, and a tie inside noise is not that. |
 | `kimi-k3` | Never benchmarked: the Ollama Cloud API answers **HTTP 402** — *"this model uses extra usage only (not included plan usage) and your extra usage balance is empty"* | **Decline.** Not a quality question. It is outside plan usage entirely, so its page publishes a per-token price ($3.00 / $15.00 per 1M, $0.30 cached) instead of a usage-level pip — the harness reads that as `unknown`, which the standing spend policy already holds. |
 
-Three things this run is worth reading for beyond the two verdicts:
+Four things this run is worth reading for beyond the two verdicts:
 
 - **`:0731` is a different build, not a re-tag.** The catalog carries it at 167GB against the
   unversioned tag's 140GB, and ollama.com dates them 2026-07-31 and three months apart, so the
@@ -270,15 +270,26 @@ Three things this run is worth reading for beyond the two verdicts:
   fixtures ninety minutes apart moved `deepseek-v4-flash:0731` on `lem-medium` from 100% to 80%
   contract, `qwen3.5:397b` on `lem-complex` from 90% to 70%, and `gpt-oss:20b` on `lem-simple` from
   40% to 50% (`bm-20260802-5fff18` and `bm-20260802-b84f19`, both committed beside this file). Ten
-  cases per tier means one case is ten points, so a single-digit gap between two models is noise.
-  This is what the ⚖️ *measurement variance* note says per case, stated at the level of a whole
-  scorecard: **a one-run margin under ~20 points is not a reason to swap anything.**
+  cases per tier means one case is ten points, so a one- or two-case gap between two models is
+  noise. This is what the ⚖️ *measurement variance* note says per case, stated at the level of a
+  whole scorecard: **a one-run margin under ~20 points is not a reason to swap anything.** It is
+  also not a reason to swap the other way: every margin in the `:0731` decision above is exactly
+  one case, which is why that decline rests on "no `recommend`" rather than on the gap's size.
+- **Declining `:0731` is not the same as being safe from it.** `.litellm/config.yaml` runs the
+  *unversioned* `deepseek-v4-flash` on two tiers, so those tiers follow whatever the catalog's
+  moving tag points at — and `scripts/model_health_check.py` diffs tag NAMES, so a re-point of that
+  name onto the 0731 build files no evaluation issue and swaps a live tier's model unbenchmarked.
+  The id was left unversioned anyway (it is the build measured at 90%, and a pin has upkeep of its
+  own on every path that keys the exact id string), but the detection gap is real and is tracked on
+  **#925**.
 
 Both runs are `in-runner-judge` mode with **no judge evidence** — the runner had no LiteLLM proxy to
-reach, so every case is `judge:timeout` and the judge expectations render as unscored. It changes
-nothing here: each of the six verdicts already fails a *deterministic* graded expectation, and the
-judge can only ever add a reason to reject. A run that intends to *promote* something still needs
-one.
+reach, so the judge answered nothing and every judge expectation renders as unscored. Read the
+scorecards' `Timeouts` column with that in mind: it counts only the cases that were *eligible* for
+the judge (a case that already failed deterministically is never judged), so it tracks the
+first-draft pass count, not the case count. None of that changes a verdict here — all nine gate
+verdicts across the two runs already fail a *deterministic* graded expectation, and the judge can
+only ever add a reason to reject. A run that intends to *promote* something still needs one.
 
 ## Running it
 


### PR DESCRIPTION
## What

The weekly model-health scan (#716) found two new Ollama Cloud tags. **Both are declined** — no
change to the `.litellm/config.yaml` roster. This PR is the record of *why*, so the next scan's
reader starts from a measurement instead of the spec sheets.

| Tag | Decision | Basis |
|---|---|---|
| `deepseek-v4-flash:0731` | **Decline** | Benchmarked on all three content tiers beside the champion **and** the incumbent `deepseek-v4-flash` build. Did not beat the build we already ship on the contract rate anywhere, at the same usage level. Margins are one case wide, so this is a "did not carry the burden" decline, not a "worse build" verdict. |
| `kimi-k3` | **Decline** | HTTP **402** from Ollama Cloud — extra-usage-only, outside plan usage. Not a quality question. |

## `deepseek-v4-flash:0731`

`:0731` is a **different build**, not a re-tag: 167GB against the unversioned tag's 140GB, published
2026-07-31 vs April. So `bm-20260802-20ae40`'s measurement of `deepseek-v4-flash` (#842) said nothing
about it — and would not have been comparable across the #910 recalibration in any case. It was
measured beside the incumbent build in one run so the comparison is build-vs-build under one
calibration, which is the actual decision:

| Tier | `:0731` contract | incumbent `deepseek-v4-flash` | champion |
|---|---|---|---|
| lem-complex | 80% | **90%** | 70% (`qwen3.5:397b`) |
| lem-medium | 80% | **90%** | 90% (`gpt-oss:120b`) |
| lem-simple | 40% | 50% | 50% (`gpt-oss:20b`) |

Both builds are Medium (2), so there is no quota saving to trade against. No `recommend` on any
tier — and since every margin above is exactly one case on a ten-case suite, that is what the
decline rests on, not the size of the gap. Adoption requires beating the incumbent; a tie inside
noise is not that.

`lem-simple` is a shape mismatch rather than a near miss: a reasoning model bills chain-of-thought
against `max_tokens`, so on the three `budget_mirrors_production` cases (3 / 5 / 8 tokens, mirroring
`ai_helper.py`'s own call sites) it returns nothing at all — and both deepseek builds are **+1 usage
level** against `gpt-oss:20b` there.

## `kimi-k3`

Never benchmarked, and that is the finding. The Ollama Cloud API answers:

```
HTTP 402: this model uses extra usage only (not included plan usage) and your
extra usage balance is empty
```

Its page prices per token ($3.00 / $15.00 per 1M, $0.30 cached) instead of publishing a usage-level
pip, so `fetch_usage_level` reads it as `unknown` — which the #842 standing spend policy holds by
default. Every deployment in `.litellm/config.yaml` is served inside plan usage; adopting `kimi-k3`
would move a tier onto metered extra-usage billing. That is an owner spend decision, not a roster
refresh — and measuring it would itself require buying extra-usage balance first.

## Two runs, not one

`bm-20260802-5fff18` and `bm-20260802-b84f19` are both committed because the second **contradicts the
first by more than this decision's margins**, on identical fixtures ninety minutes apart:

- `:0731` on lem-medium: 100% → 80% contract
- `qwen3.5:397b` on lem-complex: 90% → 70%
- `gpt-oss:20b` on lem-simple: 40% → 50%

Ten cases per tier means one case is ten points, so a single-digit gap between two models is noise.
That is the ⚖️ *measurement variance* note stated at scorecard scope, and it is the strongest
argument in the file against pinning anything on one run. Written up in
`docs/model-benchmarks/README.md`.

## Testing

- `poetry run pytest tests/unit -q` → **9481 passed**.
- Config is comments-only; re-verified `champions_from_config` still resolves
  `{lem-simple: gpt-oss:20b, lem-medium: gpt-oss:120b, lem-complex: qwen3.5:397b, lem-router: gpt-oss:20b}`.
- The tier smoke test in `scripts/weekly_model_check.sh` was **not** run: it needs the live LiteLLM
  proxy, and #921's acceptance requires it only if a model is adopted. Nothing was adopted, so no
  deployment changed and no restart is owed.
- Both runs are `in-runner-judge` mode with **no judge evidence** (the runner had no proxy to reach,
  so every judge expectation renders unscored). It changes no verdict here — each of the six already
  fails a *deterministic* graded expectation, and a judge can only add a reason to reject — but a run
  that intends to *promote* something still needs one.

## Not in this PR

- `.litellm/ollama_catalog_snapshot.json` is untouched: the snapshot refresh for these tags is
  PR #920 (`auto/ollama-catalog`), and the file is machine-owned.
- Filed **#923** while working this: a harness-wide outage (broken venv, revoked key) renders as a
  full 0% quality report and appends permanent leaderboard rows. Hit for real here — a worktree
  without `openai` installed produced a complete, plausible report off zero HTTP requests. That run
  was discarded before commit; the fix is out of scope for this issue.

## Follow-up filed

**#925** — `.litellm/config.yaml` runs the *unversioned* `deepseek-v4-flash` on two tiers, so those
tiers follow the catalog's moving tag, including onto the `:0731` build this PR declines.
`scripts/model_health_check.py`'s `diff_catalog()` compares tag NAMES, so a re-point files no
evaluation issue and would swap a live tier's model unbenchmarked. The id is left unversioned here
(it is the build measured at 90%, and a pin has upkeep on every path that keys the exact id
string); #925 adds the detection that makes that safe.

Closes #921
Follow-up: #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)

