### PR TITLE
fix(benchmarks): a harness-wide outage is refused, not published as 0% (closes #923)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,8 +230,11 @@ every check is classed by what production does with its failure: `contract` (the
 it — the ABSOLUTE floor) vs `repairable` (a regeneration gate retries it — advisory, still
 champion-relative). A case whose `max_tokens` mirrors a call site (`budget_mirrors_production`) is
 never retried at a bigger budget; an EMPTY completion is re-measured at the same one, and a still-
-empty one is no output, never a 0-char answer. Only `recommend` becomes a swap; recommendations are
-RENDERED, never written (`.litellm/model_upgrades.yaml` is the retirement map). Full posture:
+empty one is no output, never a 0-char answer. Same principle at RUN scope (#923): a run where every
+case of every model errored — champion included — is a harness outage, not a scorecard of zeros, and
+is REFUSED (no report, no leaderboard rows, exit 1, the cause named once); a partial failure still
+publishes and carries an `Unmeasured cases` count in the report header. Only `recommend` becomes a
+swap; recommendations are RENDERED, never written (`.litellm/model_upgrades.yaml` is the retirement map). Full posture:
 `docs/model-benchmarks/README.md`.
 
 ### Content-quality telemetry (issue #630)

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -136,6 +136,35 @@ headroom, so it applies to production-budget cases too. Two things follow:
   measured. No output fails the gate's "provider answered every case" expectation instead, which is
   what it actually was.
 
+### A harness outage is not a run of zeros (#923)
+
+The rule above at run scope. A provider error is a legitimate case result — a 500, a rate limit, a
+retired tag — and `ProviderClient.complete` turns any exception into one. That is also what a broken
+venv, a revoked `OLLAMA_CLOUD_API_KEY` or a DNS failure looks like, so a harness that could not call
+anything still *completed*: a full report, `reject` on every verdict, champions at `0% (0/10)`, and
+one leaderboard row per model that is indistinguishable from a real bad run forever after. It
+happened for real while working #921 — a worktree whose venv had no `openai` produced exactly that,
+off a run that never made an HTTP request, and it was caught by eye rather than by the harness. The
+harness runs unattended (`scripts/weekly_model_check.sh` opens the report as a PR), so an expired key
+would ship a PR asserting that every model LEM runs scores zero.
+
+The tell is **every case of every model, the tier's own champion included**. A roster of candidates
+can genuinely be bad; the incumbent that serves production scoring zero on every single case means
+nothing reached a provider at all. On that condition the run is **refused**, not published:
+
+- no per-run report is written and **no leaderboard rows** are appended — nothing measured, nothing
+  to record;
+- the script exits **1**, which the weekly cron already reads as a real failure (only `0` and `2`
+  open the PR), so the outage alerts instead of shipping;
+- the underlying error is named **once** (`refusing to render: harness outage: …`), taken from the
+  commonest case error, with a count of any others rather than a wall of repeats.
+
+The honest half is untouched: one model failing every case beside a champion that answered, or some
+cases timing out everywhere, is a real measurement and renders exactly as before. Those runs now
+carry the split in the report **header** — `**Unmeasured cases:** 3 of 60`, naming any model that
+answered nothing at all — rather than only under the per-case ❌ details, because how much of a run
+is a measurement at all decides whether the rest of it means anything.
+
 ## The gate
 
 A candidate is emitted as a **swap recommendation** only when it clears the tier's absolute

--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -150,7 +150,10 @@ would ship a PR asserting that every model LEM runs scores zero.
 
 The tell is **every case of every model, the tier's own champion included**. A roster of candidates
 can genuinely be bad; the incumbent that serves production scoring zero on every single case means
-nothing reached a provider at all. On that condition the run is **refused**, not published:
+nothing reached a provider at all. The champion is the tell, not a precondition — a run that
+measured no champion at all (a tier with no configured incumbent) still measured nothing, so it is
+refused on the same condition, with the champion clause simply absent from the message. On that
+condition the run is **refused**, not published:
 
 - no per-run report is written and **no leaderboard rows** are appended — nothing measured, nothing
   to record;

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -1078,7 +1078,12 @@ def harness_outage(run: dict) -> Optional[dict]:
     same principle at run scope.
 
     A run with ANY measurement left in it (one model 500s, some cases time out) is an honest result
-    and returns None."""
+    and returns None.
+
+    The champion is the TELL, not a precondition: a run that measured no champion at all (a tier
+    with no configured incumbent) still has nothing to publish, so it is refused on the same
+    condition and the detail simply omits the champion clause. Requiring a champion card here would
+    let exactly that run render its zeros."""
     cards = [c for c in (run.get("scorecards") or []) if int(c.get("cases") or 0) > 0]
     if not cards:
         return None
@@ -1129,9 +1134,11 @@ def render_report(run: dict) -> str:
     cards = run.get("scorecards") or []
     total_cases = sum(int(card.get("cases") or 0) for card in cards)
     unmeasured = sum(len(card.get("errors") or []) for card in cards)
-    silent = [str(card.get("model")) for card in cards
-              if int(card.get("cases") or 0)
-              and len(card.get("errors") or []) >= int(card.get("cases") or 0)]
+    # Deduped: the weekly run scores the same model across every tier, and a candidate that answered
+    # nothing is silent on all of them — listing it once per tier reads as several dead models.
+    silent = sorted({str(card.get("model")) for card in cards
+                     if int(card.get("cases") or 0)
+                     and len(card.get("errors") or []) >= int(card.get("cases") or 0)})
     lines = [
         f"# Model-tier benchmark — {run.get('date')} (`{run.get('run_id')}`)",
         "",

--- a/scripts/benchmark_models.py
+++ b/scripts/benchmark_models.py
@@ -31,6 +31,12 @@ RETIREMENT map and the reactive half of the model-health check auto-swaps whatev
 benchmark win must not walk itself into the live config. The report renders the exact mapping lines
 for a human (or a #717-style PR) to adopt.
 
+A run that measured NOTHING is not published (#923). A provider error is a legitimate case result,
+but when it is every case of every model — the champion included — the failure was the harness, not
+the roster, and a full report of 0% would land in the rolling leaderboard indistinguishable from a
+real bad run. That run is refused: no report, no leaderboard rows, non-zero exit, the underlying
+error named once. See `harness_outage`.
+
 Split like the other ops scripts: PURE logic (suite loading, assertion evaluation, scorecard merge,
 gate decision, report/leaderboard rendering) over a thin I/O layer (provider completions, PostHog
 emission/eval API/HogQL polling, file writes) that the tests mock.
@@ -1041,6 +1047,67 @@ def assert_benchmark_only(run: dict) -> None:
                                  f"({value!r}) — benchmark records are anonymous")
 
 
+# ─────────────────────── harness-outage guard (pure) ─────────────────────────────
+
+def _error_tally(cards: list) -> list:
+    """`(message, count)` for every case error in the run, commonest first — so a harness-wide
+    cause is namable ONCE instead of forty times under forty ❌ details."""
+    counts: dict = {}
+    for card in cards:
+        for row in (card.get("case_results") or card.get("failed_cases") or []):
+            message = str(row.get("error") or "").strip()
+            if message:
+                counts[message] = counts.get(message, 0) + 1
+    return sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+
+
+def harness_outage(run: dict) -> Optional[dict]:
+    """Did this run measure ANYTHING? The outage record when it did not, else None (#923).
+
+    `ProviderClient.complete` turns every exception into a case result, which is right for a
+    provider 500 or a rate limit — and is also exactly what a broken venv, a revoked
+    `OLLAMA_CLOUD_API_KEY` or a DNS outage looks like. The run then completes "successfully": a full
+    scorecard of 0%, `reject` on every verdict, and one leaderboard row per model that is
+    indistinguishable from a real bad run forever after. The harness runs unattended, so that report
+    ships as a PR asserting every model LEM runs scores zero.
+
+    The tell is that it is EVERY case of EVERY model, the tier's own champion included: a roster of
+    candidates can genuinely be bad, but the incumbent production already runs scoring zero on every
+    single case means nothing reached a provider at all. #910 settled this for one case — a
+    completion that was never measured is `no output`, not a zero-length answer — and this is the
+    same principle at run scope.
+
+    A run with ANY measurement left in it (one model 500s, some cases time out) is an honest result
+    and returns None."""
+    cards = [c for c in (run.get("scorecards") or []) if int(c.get("cases") or 0) > 0]
+    if not cards:
+        return None
+    total = sum(int(card.get("cases") or 0) for card in cards)
+    errored = sum(len(card.get("errors") or []) for card in cards)
+    if errored < total:
+        return None
+    tally = _error_tally(cards)
+    dominant = tally[0][0] if tally else "no per-case detail was recorded"
+    champions = sorted({str(card.get("model")) for card in cards
+                        if card.get("role") == "champion"})
+    detail = (
+        f"harness outage: all {total} case(s) across {len(cards)} model×tier scorecard(s) errored, "
+        "so this run measured nothing and is not a quality report"
+        + (" — the champion(s) " + ", ".join(f"`{m}`" for m in champions)
+           + " scored 0% too, which is the plumbing and not the roster" if champions else "")
+        + f". Underlying error: {dominant}"
+        + (f" (+{len(tally) - 1} other distinct error(s))" if len(tally) > 1 else ""))
+    return {"cases": total, "scorecards": len(cards), "champions": champions,
+            "error": dominant, "distinct_errors": len(tally), "detail": detail}
+
+
+def assert_measured(run: dict) -> None:
+    """Refuse to publish a run that measured nothing. Raises `ValueError`; see `harness_outage`."""
+    outage = harness_outage(run)
+    if outage:
+        raise ValueError(outage["detail"])
+
+
 # ─────────────────────────── report rendering (pure) ─────────────────────────────
 
 def _fmt_rate(value: Optional[float]) -> str:
@@ -1058,6 +1125,13 @@ def report_filename(run: dict) -> str:
 def render_report(run: dict) -> str:
     """The per-run scorecard committed to `docs/model-benchmarks/`."""
     assert_benchmark_only(run)
+    assert_measured(run)
+    cards = run.get("scorecards") or []
+    total_cases = sum(int(card.get("cases") or 0) for card in cards)
+    unmeasured = sum(len(card.get("errors") or []) for card in cards)
+    silent = [str(card.get("model")) for card in cards
+              if int(card.get("cases") or 0)
+              and len(card.get("errors") or []) >= int(card.get("cases") or 0)]
     lines = [
         f"# Model-tier benchmark — {run.get('date')} (`{run.get('run_id')}`)",
         "",
@@ -1068,6 +1142,18 @@ def render_report(run: dict) -> str:
         f"- **Candidates:** {', '.join(run.get('candidates') or []) or 'none (baseline run)'}",
         f"- **Judge calls spent:** {run.get('judge_calls', 0)}"
         f" (cap {run.get('judge_call_cap', 0)})",
+    ]
+    if unmeasured:
+        # In the header, not only under the per-case ❌ details: a scorecard of zeros reads as a
+        # quality verdict, and how much of this run is a measurement at all is the first thing that
+        # decides whether the rest of it means anything (#923).
+        lines.append(
+            f"- **Unmeasured cases:** {unmeasured} of {total_cases} — the provider call errored, "
+            "so those cases produced no output and were never scored; that is not a zero-quality "
+            "result"
+            + (" — " + ", ".join(f"`{m}`" for m in silent)
+               + " answered nothing at all" if silent else ""))
+    lines += [
         "",
         ("Inputs are synthetic prompt templates from `tests/benchmarks/model_tiers/`; no customer " +
          "content, credentials or production logs appear in this report."),
@@ -1971,7 +2057,7 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
 
     gates = gate_run(scorecards, suites)
     recommendations = swap_recommendations(gates)
-    return {
+    run = {
         "source": BENCHMARK_SOURCE,
         "run_id": run_id,
         "date": today,
@@ -1986,11 +2072,16 @@ def run_benchmark(suites: dict, models: list, champions: dict, *, run_id: str, t
         "gates": gates,
         "recommendations": recommendations,
     }
+    # Carried on the results JSON so the artifact `--render` reads later says why it was refused —
+    # the guard recomputes from the scorecards, so an older file without the key is still caught.
+    run["harness_outage"] = harness_outage(run)
+    return run
 
 
 def write_report(run: dict, out_dir: str) -> str:
     """Render + write the per-run report and update the rolling leaderboard. Returns the report
-    path. `render_report` runs the provenance guard first, so a tainted run never reaches disk."""
+    path. `render_report` runs the provenance and harness-outage guards first, so neither a tainted
+    run nor one that measured nothing (#923) ever reaches disk or the rolling leaderboard."""
     body = render_report(run)
     os.makedirs(out_dir, exist_ok=True)
     path = os.path.join(out_dir, report_filename(run))

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -668,6 +668,155 @@ class TestProvenance:
         assert not out.exists()
 
 
+# ───────────────────────── harness-outage guard (#923) ───────────────────────────
+
+def _measured_card(tier="lem-simple", model="m", role="candidate", cases=("a", "b"),
+                   errors=None, error="No module named 'openai'", run_id="bm-1"):
+    """A real scorecard built through the real merge, so the guard is exercised against the shape
+    `run_benchmark` actually produces. `errors` names the cases whose provider call failed."""
+    failed = set(cases) if errors is None else set(errors)
+    results = []
+    for case_id in cases:
+        case = {"id": case_id, "assertions": [{"type": "max_chars", "value": 100}]}
+        results.append(bm.evaluate_case(case, None) | {"error": error} if case_id in failed
+                       else bm.evaluate_case(case, "ok"))
+    card = bm.merge_scorecard(tier, model, role, results)
+    card["benchmark_run_id"] = run_id
+    return card
+
+
+def _outage_run(cards, **over):
+    run = {"source": bm.BENCHMARK_SOURCE, "run_id": "bm-1", "date": "2026-08-02",
+           "scoring_mode": bm.SCORING_DETERMINISTIC, "tiers": ["lem-simple"],
+           "candidates": ["cand"], "judge_calls": 0, "judge_call_cap": 0,
+           "scorecards": list(cards), "gates": [], "recommendations": []}
+    run.update(over)
+    return run
+
+
+class TestHarnessOutage:
+    """#923 — a harness-wide failure is an outage, not a scorecard of zeros.
+
+    `ProviderClient.complete` turns any exception into a case result, so a broken venv or a revoked
+    key produced a complete, plausible report: six rows, `reject` everywhere, champions at 0%, off a
+    run that never made an HTTP request. Nothing measured => nothing published."""
+
+    def test_every_case_of_every_model_erroring_is_an_outage(self):
+        run = _outage_run([_measured_card(model="champ", role="champion"),
+                           _measured_card(model="cand")])
+        outage = bm.harness_outage(run)
+        assert outage is not None
+        assert outage["cases"] == 4 and outage["scorecards"] == 2
+        assert outage["error"] == "No module named 'openai'"
+
+    def test_a_champion_at_zero_is_the_tell_and_is_named(self):
+        """A roster of candidates can be bad; the model production already runs cannot be."""
+        run = _outage_run([_measured_card(model="gpt-oss:120b", role="champion"),
+                           _measured_card(model="cand")])
+        outage = bm.harness_outage(run)
+        assert outage["champions"] == ["gpt-oss:120b"]
+        assert "plumbing and not the roster" in outage["detail"]
+
+    def test_the_underlying_error_is_named_once_not_per_case(self):
+        run = _outage_run([_measured_card(model="champ", role="champion", cases=tuple("abcde")),
+                           _measured_card(model="cand", cases=tuple("abcde"))])
+        detail = bm.harness_outage(run)["detail"]
+        assert detail.count("No module named 'openai'") == 1
+
+    def test_a_second_distinct_error_is_counted_not_listed(self):
+        run = _outage_run([_measured_card(model="champ", role="champion", cases=("a", "b", "c")),
+                           _measured_card(model="cand", cases=("a",), error="Connection error.")])
+        outage = bm.harness_outage(run)
+        assert outage["distinct_errors"] == 2
+        # The commonest message is the cause; the rest are a count, not a wall of text.
+        assert outage["error"] == "No module named 'openai'"
+        assert "+1 other distinct error(s)" in outage["detail"]
+
+    def test_one_model_failing_every_case_is_still_a_measurement(self):
+        """The honest half: a candidate that 500s on everything beside a champion that answered is
+        a real result and must render exactly as it does today."""
+        run = _outage_run([_measured_card(model="champ", role="champion", errors=()),
+                           _measured_card(model="cand", error="410 model retired")])
+        assert bm.harness_outage(run) is None
+        assert bm.render_report(run)
+        assert len(bm.leaderboard_rows(run)) == 2
+
+    def test_some_cases_failing_everywhere_is_still_a_measurement(self):
+        run = _outage_run([_measured_card(model="champ", role="champion", errors=("a",)),
+                           _measured_card(model="cand", errors=("a",))])
+        assert bm.harness_outage(run) is None
+
+    def test_a_run_with_no_scored_cases_is_not_flagged(self):
+        assert bm.harness_outage(_outage_run([])) is None
+        assert bm.harness_outage({}) is None
+
+    def test_a_dry_run_of_canned_outputs_is_never_an_outage(self):
+        run = bm.run_benchmark({"lem-simple": _suite("lem-simple", cases=[
+            _case("a", assertions=[{"type": "max_chars", "value": 5}],
+                  canned={"output": "far too long to fit", "judge_pass": False})],
+            thresholds={"min_judged": 1})}, ["cand"], {"lem-simple": "champ"},
+            run_id="bm-1", today="2026-08-02", dry_run=True, judge_cap=2)
+        assert run["harness_outage"] is None and bm.render_report(run)
+
+    def test_render_report_refuses_a_run_that_measured_nothing(self):
+        run = _outage_run([_measured_card(model="champ", role="champion"),
+                           _measured_card(model="cand")])
+        with pytest.raises(ValueError, match="harness outage"):
+            bm.render_report(run)
+
+    def test_write_report_writes_no_report_and_no_leaderboard_rows(self, tmp_path):
+        out = tmp_path / "docs"
+        out.mkdir()
+        readme = out / "README.md"
+        before = f"# Benchmarks\n\n{bm.LEADERBOARD_BEGIN}\n{bm.LEADERBOARD_END}\n"
+        readme.write_text(before)
+        run = _outage_run([_measured_card(model="champ", role="champion"),
+                           _measured_card(model="cand")])
+        with pytest.raises(ValueError, match="harness outage"):
+            bm.write_report(run, str(out))
+        assert readme.read_text() == before
+        assert list(out.iterdir()) == [readme]
+
+    def test_run_benchmark_records_the_outage_on_the_results_document(self):
+        provider = MagicMock()
+        provider.complete.return_value = {"text": None, "error": "No module named 'openai'",
+                                          "latency_ms": None, "usage": {}}
+        run = bm.run_benchmark({"lem-simple": _suite("lem-simple", cases=[_case("a"), _case("b")],
+                                                     thresholds={"min_judged": 1})},
+                               ["cand"], {"lem-simple": "champ"}, run_id="bm-1",
+                               today="2026-08-02", provider=provider, judge_cap=0,
+                               judge_enabled=False)
+        assert run["harness_outage"]["error"] == "No module named 'openai'"
+        assert run["harness_outage"]["champions"] == ["champ"]
+
+    def test_a_run_with_no_provider_configured_never_publishes(self):
+        """The #921 shape: nothing was configured, so nothing was called, so nothing measured."""
+        run = bm.run_benchmark({"lem-simple": _suite("lem-simple", cases=[_case("a")],
+                                                     thresholds={"min_judged": 1})},
+                               ["cand"], {"lem-simple": "champ"}, run_id="bm-1",
+                               today="2026-08-02", provider=None, judge_cap=0, judge_enabled=False)
+        assert "no provider client configured" in run["harness_outage"]["error"]
+        with pytest.raises(ValueError, match="harness outage"):
+            bm.render_report(run)
+
+
+class TestUnmeasuredHeader:
+    """The distinction belongs in the report HEADER, not only under the per-case ❌ details."""
+
+    def test_the_header_counts_unmeasured_cases_and_names_a_silent_model(self):
+        run = _outage_run([_measured_card(model="champ", role="champion", errors=()),
+                           _measured_card(model="cand")])
+        text = bm.render_report(run)
+        assert "**Unmeasured cases:** 2 of 4" in text
+        assert "`cand` answered nothing at all" in text
+        assert "not a zero-quality result" in text
+
+    def test_a_clean_run_carries_no_unmeasured_line(self):
+        run = _outage_run([_measured_card(model="champ", role="champion", errors=()),
+                           _measured_card(model="cand", errors=())])
+        assert "Unmeasured cases" not in bm.render_report(run)
+
+
 # ─────────────────────────── report + leaderboard ────────────────────────────────
 
 class TestRendering:
@@ -1820,6 +1969,19 @@ class TestCLI:
         out = tmp_path / "b"
         assert bm.main(["--render", str(results), "--out-dir", str(out)]) in (0, 2)
         assert (out / "2026-07-27-bm-r.md").exists()
+
+    def test_render_of_a_run_that_measured_nothing_exits_1_and_writes_nothing(self, tmp_path,
+                                                                             capsys):
+        """#923: the unattended path. A harness-wide failure must not become a PR asserting that
+        every model LEM runs scores zero — the cron reads any rc outside {0, 2} as a real failure."""
+        results = tmp_path / "outage.json"
+        results.write_text(json.dumps(_outage_run([
+            _measured_card(model="champ", role="champion"), _measured_card(model="cand")])))
+        out = tmp_path / "docs"
+        assert bm.main(["--render", str(results), "--out-dir", str(out)]) == 1
+        assert not out.exists()
+        err = capsys.readouterr().err
+        assert err.count("No module named 'openai'") == 1
 
     def test_render_refuses_a_tainted_results_file(self, tmp_path):
         results = tmp_path / "bad.json"

--- a/tests/unit/test_benchmark_models.py
+++ b/tests/unit/test_benchmark_models.py
@@ -799,6 +799,15 @@ class TestHarnessOutage:
         with pytest.raises(ValueError, match="harness outage"):
             bm.render_report(run)
 
+    def test_a_run_that_measured_no_champion_is_refused_on_the_same_condition(self):
+        """The champion is the TELL, not a precondition. A tier with no configured incumbent still
+        measured nothing, and requiring a champion card would let exactly that run publish zeros."""
+        run = _outage_run([_measured_card(model="cand")])
+        outage = bm.harness_outage(run)
+        assert outage["champions"] == [] and "plumbing and not the roster" not in outage["detail"]
+        with pytest.raises(ValueError, match="harness outage"):
+            bm.render_report(run)
+
 
 class TestUnmeasuredHeader:
     """The distinction belongs in the report HEADER, not only under the per-case ❌ details."""
@@ -810,6 +819,19 @@ class TestUnmeasuredHeader:
         assert "**Unmeasured cases:** 2 of 4" in text
         assert "`cand` answered nothing at all" in text
         assert "not a zero-quality result" in text
+
+    def test_a_model_silent_across_every_tier_is_named_once(self):
+        """The weekly run scores one candidate against 3–4 tiers. Naming it per tier reads as four
+        dead models instead of one."""
+        run = _outage_run([_measured_card(tier="lem-simple", model="champ", role="champion",
+                                          errors=()),
+                           _measured_card(tier="lem-medium", model="champ", role="champion",
+                                          errors=()),
+                           _measured_card(tier="lem-simple", model="cand"),
+                           _measured_card(tier="lem-medium", model="cand")])
+        header = next(line for line in bm.render_report(run).splitlines()
+                      if "Unmeasured cases" in line)
+        assert header.count("`cand`") == 1
 
     def test_a_clean_run_carries_no_unmeasured_line(self):
         run = _outage_run([_measured_card(model="champ", role="champion", errors=()),


### PR DESCRIPTION
## What & why

`scripts/benchmark_models.py` treated an **infrastructure** failure as a **quality measurement** and
committed it to the permanent record. `ProviderClient.complete` turns every exception into a case
result — right for a provider 500 or a rate limit, and also exactly what a broken venv, a revoked
`OLLAMA_CLOUD_API_KEY` or a DNS outage looks like. The run then completed "successfully": a full
report, `reject` on every verdict, champions at `0% (0/10)`, and one leaderboard row per model
indistinguishable from a real bad run forever after. Hit for real while working #921 — a worktree
whose venv had no `openai` produced a complete, plausible report off a run that never made an HTTP
request, caught by eye rather than by the harness. The harness runs unattended, so an expired key
would have shipped a PR asserting that every model LEM runs scores zero.

`harness_outage()` reads the tell: **every case of every model errored, the tier's own champion
included**. A roster of candidates can genuinely be bad; the incumbent that serves production scoring
zero on every single case means nothing reached a provider at all. #910 settled this for one case (a
completion that was never measured is `no output`, not a zero-length answer) — this is the same
principle at run scope.

## What changed

- **`render_report` runs `assert_measured` beside the existing provenance guard**, so the refusal
  covers `--run` and `--render` alike: no report file, **no leaderboard rows**, exit `1` (the weekly
  cron already reads any rc outside `{0, 2}` as a real failure and opens no PR), and the underlying
  error named **once** — taken from the commonest case error, with a count of any others rather than
  a wall of repeats.
- **The honest half is untouched.** One model failing every case beside a champion that answered, or
  some cases erroring everywhere, still renders and still lands on the leaderboard exactly as today.
  Those runs now carry the split in the report **header** — `- **Unmeasured cases:** 3 of 60 …`,
  naming any model that answered nothing at all — rather than only under the per-case ❌ detail.
- The results JSON carries `harness_outage` so the artifact `--render` reads later says why it was
  refused; the guard recomputes from the scorecards, so an older results file is still caught.
- `docs/model-benchmarks/README.md` states the rule beside the existing *measurement variance* /
  *no output* notes; CLAUDE.md's #721 paragraph gained the one-line invariant.

## Testing

`poetry run pytest tests/unit -q` → **9496 passed**, of which 202 in
`tests/unit/test_benchmark_models.py` (15 new):

- the outage itself (candidate + champion, every case) and the **champion-side tell** — a 0%
  champion is what says it was the harness, not the roster;
- the underlying error named once, not per case; a second distinct error counted, not listed;
- both honest-half shapes (one model down, some cases down) still render **and** still produce
  leaderboard rows;
- a dry run of canned outputs is never an outage; a run with no provider configured never publishes;
- `write_report` leaves a pre-existing leaderboard file byte-identical and creates no report;
- the header line (count + silent model) and its absence on a clean run;
- the CLI `--render` path exits `1`, writes nothing, and prints the cause once.

Closes #923

🤖 Generated with [Claude Code](https://claude.com/claude-code)
