### PR TITLE
feat(models): the catalog scan sees a build swapped under an unchanged tag (closes #925)

### DIFF
--- a/docs/model-benchmarks/README.md
+++ b/docs/model-benchmarks/README.md
@@ -9,7 +9,8 @@ this file (`<date>-<run_id>.md`).
 ## Why this exists
 
 `scripts/model_health_check.py` (#716) detects that a model is *about to change*: a published
-retirement, a new Ollama Cloud tag, a family we trail. It cannot say whether a candidate is any
+retirement, a new Ollama Cloud tag, a family we trail, or — since #925 — a tag we already run whose
+*build* moved underneath an unchanged name. It cannot say whether a candidate is any
 **good** — before this, a swap was decided on a spec sheet. The benchmark is the measurement half,
 and it always runs the current **champion** alongside the candidate, so a verdict is a comparison
 rather than an absolute claim about one model.
@@ -309,11 +310,14 @@ Four things this run is worth reading for beyond the two verdicts:
   one case, which is why that decline rests on "no `recommend`" rather than on the gap's size.
 - **Declining `:0731` is not the same as being safe from it.** `.litellm/config.yaml` runs the
   *unversioned* `deepseek-v4-flash` on two tiers, so those tiers follow whatever the catalog's
-  moving tag points at — and `scripts/model_health_check.py` diffs tag NAMES, so a re-point of that
-  name onto the 0731 build files no evaluation issue and swaps a live tier's model unbenchmarked.
-  The id was left unversioned anyway (it is the build measured at 90%, and a pin has upkeep of its
-  own on every path that keys the exact id string), but the detection gap is real and is tracked on
-  **#925**.
+  moving tag points at — and `scripts/model_health_check.py` diffed tag NAMES only, so a re-point of
+  that name onto the 0731 build filed no evaluation issue and swapped a live tier's model
+  unbenchmarked. The id was left unversioned anyway (it is the build measured at 90%, and a pin has
+  upkeep of its own on every path that keys the exact id string); **#925** closed the detection gap
+  instead — the weekly scan now also compares each CONFIGURED tag's `size`/`modified_at` against the
+  committed snapshot and files a re-point evaluation issue naming the tiers that moved. The dedup
+  marker carries the new build's fingerprint, so a *second* re-point is not deduped away as
+  already-filed. It stays a trigger, never an auto-pin.
 
 Both runs are `in-runner-judge` mode with **no judge evidence** — the runner had no LiteLLM proxy to
 reach, so the judge answered nothing and every judge expectation renders as unscored. Read the

--- a/scripts/model_health_check.py
+++ b/scripts/model_health_check.py
@@ -15,6 +15,10 @@ docs.ollama.com/cloud.md and ollama.com/api/tags and reports what is about to ch
     replacement to model_upgrades.yaml (the reactive half then swaps it before the sunset bites);
   * new/removed catalog tags vs the committed snapshot (.litellm/ollama_catalog_snapshot.json) ->
     ONE `agent:ready` evaluation issue for the new ones, snapshot refreshed in the same PR;
+  * a CONFIGURED tag whose BUILD moved under an unchanged name (issue #925) -> ONE `agent:ready`
+    evaluation issue. An unversioned id like `deepseek-v4-flash` follows whatever the catalog's
+    moving tag points at, so the build serving a live tier can change with no repo change at all —
+    and a tag-NAME diff cannot see that;
   * a configured model trailing a newer version of its OWN family (minimax-m2.7 while minimax-m3
     ships) -> ONE consolidated `agent:ready` upgrade issue carrying each candidate's usage level,
     because a version bump that jumps usage tiers costs more quota and is an evaluation, never an
@@ -30,7 +34,8 @@ CLI:
   --report [--json]      Probe + report model health and planned actions. No writes.
   --plan-json            Emit ONLY the machine-readable plan (for the shell orchestrator).
   --apply OUT            Write the swapped config to OUT (reads --config). Prints applied swaps.
-  --catalog-scan         Advance-retirement / new-model / family-version scan. No writes (dry run).
+  --catalog-scan         Advance-retirement / new-model / re-pointed-tag / family-version scan.
+                         No writes (dry run).
   --catalog-json         Emit ONLY the machine-readable catalog plan (for the shell orchestrator).
   --catalog-apply        Write the planned map additions + snapshot refresh to --map / --snapshot.
   --file-issues          File (or append to) the GitHub issues the catalog scan planned.
@@ -73,6 +78,7 @@ DEFAULT_REPO = "christopherqueenconsulting/linkedin_engagement_manager"
 # agent:ready issue — see #598).
 UPGRADE_TITLE_PREFIX = "Ollama model family upgrades available:"
 EVAL_TITLE_PREFIX = "Evaluate new Ollama Cloud models:"
+REPOINT_TITLE_PREFIX = "Re-pointed Ollama tag serving a live tier:"
 ISSUE_LABELS = ("agent:ready", "priority:medium", "infrastructure")
 MAX_TITLE_CHARS = 120
 
@@ -438,8 +444,63 @@ def render_snapshot(models: dict, updated: str) -> str:
 
 
 def diff_catalog(snapshot: dict, current: dict) -> dict:
+    """Tag NAMES that appeared or disappeared. A tag whose BUILD moved under an unchanged name is
+    invisible here by construction — that is `plan_repoints`' job (issue #925)."""
     old, new = set(snapshot or {}), set(current or {})
     return {"added": sorted(new - old), "removed": sorted(old - new)}
+
+
+_BUILD_FIELDS = ("size", "modified_at")
+
+
+def build_fingerprint(info: dict) -> str:
+    """Identify the BUILD behind a tag. A moving tag keeps its name across a re-point and changes
+    these, so they are what a dedup marker has to carry — otherwise a SECOND re-point of the same
+    tag reads as already filed."""
+    info = info or {}
+    return f"{int(info.get('size') or 0)}/{str(info.get('modified_at') or '')}"
+
+
+def _build_changes(old: dict, new: dict) -> list[dict]:
+    """Which build fields moved. A field only counts when BOTH sides carry a value: a snapshot
+    written before that field was captured is a MISSING baseline, not a build swap, and treating it
+    as one would file an issue for every configured tag at once the day the shape changes."""
+    changes: list[dict] = []
+    for field in _BUILD_FIELDS:
+        before, after = (old or {}).get(field), (new or {}).get(field)
+        if not before or not after or before == after:
+            continue
+        changes.append({"field": field, "old": before, "new": after})
+    return changes
+
+
+def plan_repoints(deployments: list[dict], snapshot: dict, catalog: dict) -> list[dict]:
+    """Tags present in BOTH the snapshot and the live catalog whose build changed underneath.
+
+    Restricted to tags `.litellm/config.yaml` actually runs on Ollama Cloud: the catalog carries
+    hundreds of tags LEM never serves, and a re-point of one of those is noise. For the ones it does
+    serve this is the whole point — an unversioned id follows the vendor's moving tag, so a live
+    tier can adopt an unbenchmarked build with no repo change to review."""
+    groups: dict[str, list[str]] = {}
+    models: dict[str, str] = {}
+    for d in deployments:
+        if not d["is_ollama"]:
+            continue
+        groups.setdefault(d["bare"], []).append(d["group"])
+        models.setdefault(d["bare"], d["model"])
+    out: list[dict] = []
+    for bare in sorted(groups):
+        before, after = (snapshot or {}).get(bare), (catalog or {}).get(bare)
+        if not before or not after:
+            continue
+        changes = _build_changes(before, after)
+        if not changes:
+            continue
+        out.append({"tag": bare, "model": models[bare], "groups": sorted(set(groups[bare])),
+                    "changes": changes, "old": dict(before), "new": dict(after),
+                    "old_fingerprint": build_fingerprint(before),
+                    "new_fingerprint": build_fingerprint(after)})
+    return out
 
 
 # ───────────────── family-version scan — "are we a major behind?" (pure) ─────────
@@ -665,6 +726,62 @@ def build_eval_issue_body(new_tags: list[str], catalog: dict, today: str) -> str
               "",
               "Auto-filed by `scripts/model_health_check.py --file-issues` (issue #716). Dedup "
               "markers (do not remove): " + ", ".join(f"`{n}`" for n in new_tags)]
+    return "\n".join(lines)
+
+
+def repoint_marker(repoint: dict) -> str:
+    """`tag @ size/modified_at` — the fingerprint is IN the marker on purpose, so a second re-point
+    of the same tag is fresh rather than deduped away against the first one's issue."""
+    return f"{repoint.get('tag')} @ {repoint.get('new_fingerprint')}"
+
+
+def _fmt_build_value(field: str, value) -> str:
+    if field == "size":
+        try:
+            return f"{int(value) / 1e9:.0f}GB"
+        except (TypeError, ValueError):
+            return str(value)
+    return str(value)
+
+
+def build_repoint_issue_title(repoints: list[dict]) -> str:
+    return _titled(REPOINT_TITLE_PREFIX, [str(r.get("tag") or "") for r in repoints])
+
+
+def build_repoint_issue_body(repoints: list[dict], today: str) -> str:
+    lines = ["## Context",
+             f"The weekly model-health check ({today}) found tags whose BUILD changed while the tag "
+             "NAME stayed the same, and `.litellm/config.yaml` runs them. An unversioned Ollama id "
+             "follows whatever the catalog's moving tag points at, so a live tier just adopted a "
+             "different model with no repo change to review and no benchmark behind it — the one "
+             "outcome the evaluation harness exists to prevent (issue #925).",
+             "",
+             "## Re-pointed tags", ""]
+    for r in repoints:
+        tiers = ", ".join(f"`{g}`" for g in (r.get("groups") or [])) or "n/a"
+        lines.append(f"- **`{r.get('tag')}`** — serving {tiers} (config `model: {r.get('model')}`)")
+        for change in r.get("changes") or []:
+            field = str(change.get("field"))
+            lines.append(f"  - {field}: `{_fmt_build_value(field, change.get('old'))}` → "
+                         f"`{_fmt_build_value(field, change.get('new'))}`")
+    lines += ["",
+              "## Scope",
+              ("- Benchmark the build now behind the tag against the tier contract it serves "
+               "(`scripts/benchmark_models.py`), the way any candidate is measured."),
+              ("- If it holds up, say so on this issue and nothing changes. If it does not, pin the "
+               "tier to a versioned id in `.litellm/config.yaml` — that is a deliberate config "
+               "change, never a `.litellm/model_upgrades.yaml` entry (that map is retirement-only "
+               "and auto-swaps)."),
+              ("- The benchmark candidate is the VERSIONED build id, not this bare tag: measuring "
+               "the bare tag would run the same id as the champion and compare nothing."),
+              "",
+              "## Acceptance",
+              "- A decision per tag above (accept the new build, or pin, with the reason).",
+              ("- If a tier is pinned, `scripts/weekly_model_check.sh`'s tier smoke test still "
+               "passes and `poetry run pytest tests/unit -q` is green."),
+              "",
+              "Auto-filed by `scripts/model_health_check.py --file-issues` (issue #925). Dedup "
+              "markers (do not remove): " + ", ".join(f"`{repoint_marker(r)}`" for r in repoints)]
     return "\n".join(lines)
 
 
@@ -922,11 +1039,14 @@ def _catalog_scan(config_path: str, map_path: str, snapshot_path: str, *, today:
     # the entire catalog.
     seeded = not os.path.exists(snapshot_path)
     snapshot = {} if seeded else load_snapshot_text(_read_text(snapshot_path))
+    repoints: list[dict] = []
     if catalog is None:
         catalog_diff = {"added": [], "removed": []}
         family_upgrades: list[dict] = []
     else:
         catalog_diff = {"added": [], "removed": []} if seeded else diff_catalog(snapshot, catalog)
+        if not seeded:
+            repoints = plan_repoints(deployments, snapshot, catalog)
         family_upgrades = plan_family_upgrades(
             deployments, catalog, {r["model"] for r in retirements},
             usage_fn if usage_levels else None)
@@ -940,6 +1060,7 @@ def _catalog_scan(config_path: str, map_path: str, snapshot_path: str, *, today:
         "map_additions": additions,
         "catalog": {**catalog_diff, "total": len(catalog or {})},
         "upgrades": family_upgrades,
+        "repoints": repoints,
         "snapshot_changed": snapshot_changed,
         "repo_changes": bool(additions) or snapshot_changed,
     }
@@ -951,6 +1072,9 @@ def _catalog_scan(config_path: str, map_path: str, snapshot_path: str, *, today:
                        "title": build_eval_issue_title(catalog_diff["added"]) if catalog_diff["added"] else "",
                        "body": build_eval_issue_body(catalog_diff["added"], catalog or {}, today)
                        if catalog_diff["added"] else ""},
+        "repoint": {"markers": [repoint_marker(r) for r in repoints],
+                    "title": build_repoint_issue_title(repoints) if repoints else "",
+                    "body": build_repoint_issue_body(repoints, today) if repoints else ""},
     }
     plan["_catalog"] = catalog  # consumed by --catalog-apply; stripped from --catalog-json output
     return plan
@@ -977,12 +1101,16 @@ def _print_catalog_plan(plan: dict) -> None:
     for u in plan["upgrades"]:
         print(f"  UPGRADE ({u['urgency']}) {upgrade_marker(u)} — usage "
               f"{_usage_text(u['current_usage'])} -> {_usage_text(u['candidate_usage'])}")
-    for kind in ("upgrade", "evaluation"):
-        spec = plan["issues"][kind]
+    for r in plan.get("repoints") or []:
+        detail = ", ".join(f"{c['field']} {_fmt_build_value(c['field'], c['old'])} -> "
+                           f"{_fmt_build_value(c['field'], c['new'])}" for c in r["changes"])
+        print(f"  REPOINTED {r['tag']} [{', '.join(r['groups'])}] {detail}")
+    for kind in ("upgrade", "evaluation", "repoint"):
+        spec = _issue_spec(plan, kind)
         if spec["markers"]:
             print(f"\n--- {kind} issue ---\n{spec['title']}\n\n{spec['body']}\n")
     if not (plan["notices"] or plan["map_additions"] or plan["catalog"]["added"]
-            or plan["catalog"]["removed"] or plan["upgrades"]):
+            or plan["catalog"]["removed"] or plan["upgrades"] or plan.get("repoints")):
         print("  nothing to do")
 
 
@@ -1002,12 +1130,21 @@ def _catalog_apply(plan: dict, map_path: str, snapshot_path: str) -> None:
         print(f"snapshot refreshed ({plan['catalog']['total']} tags) -> {snapshot_path}")
 
 
+def _issue_spec(plan: dict, kind: str) -> dict:
+    """One issue spec off a plan, tolerating a plan saved by an older version of this tool (a
+    --plan-file written before a kind existed simply has nothing to file for it)."""
+    spec = ((plan or {}).get("issues") or {}).get(kind) or {}
+    return {"markers": list(spec.get("markers") or []), "title": spec.get("title") or "",
+            "body": spec.get("body") or ""}
+
+
 def _file_issues(plan: dict, github: GitHubIssues) -> int:
     """File/append the consolidated issues. Never raises: a GitHub failure leaves the work for next
     week rather than failing the weekly check."""
     filed = 0
-    for kind, prefix in (("upgrade", UPGRADE_TITLE_PREFIX), ("evaluation", EVAL_TITLE_PREFIX)):
-        spec = plan["issues"][kind]
+    for kind, prefix in (("upgrade", UPGRADE_TITLE_PREFIX), ("evaluation", EVAL_TITLE_PREFIX),
+                         ("repoint", REPOINT_TITLE_PREFIX)):
+        spec = _issue_spec(plan, kind)
         if not spec["markers"]:
             continue
         try:
@@ -1076,7 +1213,8 @@ def main(argv: Optional[list[str]] = None) -> int:
             _file_issues(plan, GitHubIssues(args.repo))
         if plan["notices"]:
             return 3
-        if plan["repo_changes"] or plan["upgrades"] or plan["catalog"]["added"]:
+        if (plan["repo_changes"] or plan["upgrades"] or plan["catalog"]["added"]
+                or plan.get("repoints")):
             return 2
         return 0
 

--- a/scripts/model_health_check.py
+++ b/scripts/model_health_check.py
@@ -772,8 +772,13 @@ def build_repoint_issue_body(repoints: list[dict], today: str) -> str:
                "tier to a versioned id in `.litellm/config.yaml` — that is a deliberate config "
                "change, never a `.litellm/model_upgrades.yaml` entry (that map is retirement-only "
                "and auto-swaps)."),
-              ("- The benchmark candidate is the VERSIONED build id, not this bare tag: measuring "
-               "the bare tag would run the same id as the champion and compare nothing."),
+              ("- **Both sides have to be pinned, not just the candidate.** "
+               "`scripts/benchmark_models.py` reads the champion off `.litellm/config.yaml`, which "
+               "is this bare tag — and the tag now resolves to the NEW build, so a default run "
+               "measures the new build against itself and every `beats champion` expectation ties "
+               "for free. Run the new build as the candidate and pin the champion to the build "
+               "already measured (the `old` values above): "
+               "`--models <new-versioned-id> --champions <tier>=<previous-versioned-id>`."),
               "",
               "## Acceptance",
               "- A decision per tag above (accept the new build, or pin, with the reason).",

--- a/scripts/weekly_model_check.sh
+++ b/scripts/weekly_model_check.sh
@@ -177,12 +177,14 @@ CAT="$("${PY[@]}" scripts/model_health_check.py --catalog-json --config "$BOX_CF
 if [ -z "$CAT" ]; then
   log "catalog scan produced no output — skipping (410 probe remains the backstop)"
 else
-  read -r NOTICE NEWTAG NUPG REPOCH <<<"$(printf '%s' "$CAT" | python3 -c "
+  read -r NOTICE NEWTAG NUPG NREPOINT REPOCH <<<"$(printf '%s' "$CAT" | python3 -c "
 import sys, json
 p = json.load(sys.stdin)
-print(len(p['notices']), len(p['catalog']['added']), len(p['upgrades']), int(bool(p['repo_changes'])))
-" 2>/dev/null || echo "0 0 0 0")"
-  log "catalog scan: retirement-notices=$NOTICE new-tags=$NEWTAG family-upgrades=$NUPG repo-changes=$REPOCH"
+print(len(p['notices']), len(p['catalog']['added']), len(p['upgrades']),
+      len(p.get('repoints') or []), int(bool(p['repo_changes'])))
+" 2>/dev/null || echo "0 0 0 0 0")"
+  log "catalog scan: retirement-notices=$NOTICE new-tags=$NEWTAG family-upgrades=$NUPG" \
+      "re-pointed-tags=$NREPOINT repo-changes=$REPOCH"
 
   if [ "${NOTICE:-0}" -gt 0 ]; then
     MSG=$(printf '%s' "$CAT" | python3 -c "
@@ -201,7 +203,7 @@ for n in json.load(sys.stdin)['notices']:
       mutate_catalog
   fi
 
-  if [ "${NEWTAG:-0}" -gt 0 ] || [ "${NUPG:-0}" -gt 0 ]; then
+  if [ "${NEWTAG:-0}" -gt 0 ] || [ "${NUPG:-0}" -gt 0 ] || [ "${NREPOINT:-0}" -gt 0 ]; then
     # File from the plan we ALREADY have, not a fresh scan. A second scan re-reads docs.ollama.com
     # and /api/tags, and a transient outage there would file nothing and say nothing — while the
     # snapshot PR opened just above makes those tags no longer "new", so the issue would be lost for

--- a/tests/unit/test_model_health_check.py
+++ b/tests/unit/test_model_health_check.py
@@ -383,6 +383,114 @@ class TestCatalogSnapshot:
         assert "gpt-oss:20b" in snapshot  # a model config.yaml actually runs
 
 
+def _ollama_deployments(*models, group="lem-medium"):
+    return mhc.parse_deployments({"model_list": [
+        {"model_name": group, "litellm_params": {"model": f"openai/{m}",
+                                                 "api_base": "os.environ/OLLAMA_CLOUD_URL"}}
+        for m in models]})
+
+
+_OLD_BUILD = {"modified_at": "2026-04-24T00:00:00Z", "size": 140_000_000_000}
+_NEW_BUILD = {"modified_at": "2026-07-31T00:00:00Z", "size": 167_000_000_000}
+
+
+class TestPlanRepoints:
+    """Issue #925 — the catalog move a tag-NAME diff cannot see: the same id now serves a different
+    build, so a live tier changed model with no repo change and no benchmark."""
+
+    def test_a_configured_tag_whose_build_moved_is_reported(self):
+        out = mhc.plan_repoints(_ollama_deployments("deepseek-v4-flash"),
+                                {"deepseek-v4-flash": dict(_OLD_BUILD)},
+                                {"deepseek-v4-flash": dict(_NEW_BUILD)})
+        assert len(out) == 1
+        assert out[0]["tag"] == "deepseek-v4-flash"
+        assert out[0]["model"] == "openai/deepseek-v4-flash"
+        assert out[0]["groups"] == ["lem-medium"]
+        assert {c["field"] for c in out[0]["changes"]} == {"size", "modified_at"}
+
+    def test_a_timestamp_only_move_still_counts(self):
+        out = mhc.plan_repoints(_ollama_deployments("minimax-m3"),
+                                {"minimax-m3": {"modified_at": "2026-06-01T00:00:00Z", "size": 0}},
+                                {"minimax-m3": {"modified_at": "2026-08-01T00:00:00Z", "size": 0}})
+        assert [c["field"] for c in out[0]["changes"]] == ["modified_at"]
+
+    def test_an_unreferenced_tags_repoint_stays_silent(self):
+        """The catalog carries hundreds of tags LEM does not run — those moves are noise."""
+        assert mhc.plan_repoints(_ollama_deployments("gpt-oss:20b"),
+                                 {"deepseek-v4-flash": dict(_OLD_BUILD)},
+                                 {"deepseek-v4-flash": dict(_NEW_BUILD)}) == []
+
+    def test_an_unchanged_build_is_not_a_repoint(self):
+        assert mhc.plan_repoints(_ollama_deployments("deepseek-v4-flash"),
+                                 {"deepseek-v4-flash": dict(_OLD_BUILD)},
+                                 {"deepseek-v4-flash": dict(_OLD_BUILD)}) == []
+
+    def test_a_brand_new_or_vanished_tag_is_never_a_repoint(self):
+        """Those are the added/removed paths' job — reporting them twice files two issues."""
+        assert mhc.plan_repoints(_ollama_deployments("deepseek-v4-flash"), {},
+                                 {"deepseek-v4-flash": dict(_NEW_BUILD)}) == []
+        assert mhc.plan_repoints(_ollama_deployments("deepseek-v4-flash"),
+                                 {"deepseek-v4-flash": dict(_OLD_BUILD)}, {}) == []
+
+    def test_a_missing_baseline_field_is_not_a_build_swap(self):
+        """A snapshot written before a field was captured has NO baseline for it. Reading that as a
+        re-point would file an issue for every configured tag at once."""
+        assert mhc.plan_repoints(_ollama_deployments("deepseek-v4-flash"),
+                                 {"deepseek-v4-flash": {"size": 0, "modified_at": ""}},
+                                 {"deepseek-v4-flash": dict(_NEW_BUILD)}) == []
+
+    def test_a_non_ollama_deployment_is_never_checked(self):
+        deployments = mhc.parse_deployments({"model_list": [
+            {"model_name": "lem-medium", "litellm_params": {"model": "openai/deepseek-v4-flash",
+                                                            "api_key": "os.environ/OPENAI_API_KEY"}}]})
+        assert mhc.plan_repoints(deployments, {"deepseek-v4-flash": dict(_OLD_BUILD)},
+                                 {"deepseek-v4-flash": dict(_NEW_BUILD)}) == []
+
+    def test_every_tier_the_tag_serves_is_named_once(self):
+        deployments = (_ollama_deployments("deepseek-v4-flash", group="lem-medium")
+                       + _ollama_deployments("deepseek-v4-flash", group="lem-complex"))
+        out = mhc.plan_repoints(deployments, {"deepseek-v4-flash": dict(_OLD_BUILD)},
+                                {"deepseek-v4-flash": dict(_NEW_BUILD)})
+        assert len(out) == 1 and out[0]["groups"] == ["lem-complex", "lem-medium"]
+
+
+class TestRepointIssue:
+    def _repoint(self, new=None):
+        return mhc.plan_repoints(_ollama_deployments("deepseek-v4-flash"),
+                                 {"deepseek-v4-flash": dict(_OLD_BUILD)},
+                                 {"deepseek-v4-flash": {**_NEW_BUILD, **(new or {})}})[0]
+
+    def test_marker_carries_the_new_build_not_just_the_tag(self):
+        marker = mhc.repoint_marker(self._repoint())
+        assert marker == "deepseek-v4-flash @ 167000000000/2026-07-31T00:00:00Z"
+
+    def test_a_second_repoint_of_the_same_tag_is_not_deduped_away(self):
+        """The acceptance criterion the tag name alone would fail: once #925's issue is filed for
+        build A, a later move to build B must still reach a human."""
+        first = mhc.repoint_marker(self._repoint())
+        second = mhc.repoint_marker(self._repoint({"modified_at": "2026-09-02T00:00:00Z",
+                                                   "size": 171_000_000_000}))
+        open_issues = [{"number": 12, "title": mhc.REPOINT_TITLE_PREFIX + " deepseek-v4-flash",
+                        "body": f"markers: `{first}`", "comments": []}]
+        assert mhc.plan_issue(open_issues, [first],
+                              title_prefix=mhc.REPOINT_TITLE_PREFIX)["action"] == "none"
+        assert mhc.plan_issue(open_issues, [second],
+                              title_prefix=mhc.REPOINT_TITLE_PREFIX) == {
+            "action": "append", "markers": [second], "number": 12}
+
+    def test_title_and_body_name_the_live_deployment_and_the_move(self):
+        repoint = self._repoint()
+        assert mhc.build_repoint_issue_title([repoint]) == (
+            f"{mhc.REPOINT_TITLE_PREFIX} deepseek-v4-flash")
+        body = mhc.build_repoint_issue_body([repoint], "2026-08-02")
+        assert "`lem-medium`" in body  # the reader has to know a live tier moved
+        assert "model: openai/deepseek-v4-flash" in body
+        assert "`140GB` → `167GB`" in body
+        assert "2026-04-24T00:00:00Z" in body and "2026-07-31T00:00:00Z" in body
+        assert mhc.repoint_marker(repoint) in body  # dedup marker survives into the issue
+        assert "model_upgrades.yaml" in body  # never the retirement map, which auto-swaps
+
+
 class TestParseModelVersion:
     @pytest.mark.parametrize("name,family,version,size_tag", [
         ("minimax-m2.7", "minimax", (2, 7), ""),
@@ -622,10 +730,11 @@ def _boom(*a, **k):
     raise AssertionError("the catalog must not be re-scanned when a plan was supplied")
 
 
-def _plan_with_issues(upgrade_markers=(), eval_markers=()):
+def _plan_with_issues(upgrade_markers=(), eval_markers=(), repoint_markers=()):
     return {"issues": {
         "upgrade": {"markers": list(upgrade_markers), "title": "T-up", "body": "B-up"},
-        "evaluation": {"markers": list(eval_markers), "title": "T-ev", "body": "B-ev"}}}
+        "evaluation": {"markers": list(eval_markers), "title": "T-ev", "body": "B-ev"},
+        "repoint": {"markers": list(repoint_markers), "title": "T-rp", "body": "B-rp"}}}
 
 
 class TestFileIssues:
@@ -633,6 +742,20 @@ class TestFileIssues:
         gh = _FakeGitHub()
         assert mhc._file_issues(_plan_with_issues(["a -> b"], ["new-tag"]), gh) == 2
         assert [t for t, _ in gh.created] == ["T-up", "T-ev"]
+
+    def test_files_the_repoint_issue_on_its_own_title_prefix(self):
+        gh = _FakeGitHub()
+        assert mhc._file_issues(_plan_with_issues(repoint_markers=["t @ 1/x"]), gh) == 1
+        assert [t for t, _ in gh.created] == ["T-rp"]
+
+    def test_a_plan_saved_before_a_kind_existed_files_the_rest(self):
+        """--plan-file may carry a plan written by an older copy of this tool; a missing kind is
+        nothing to file, never a KeyError that drops the issues that WERE planned."""
+        plan = _plan_with_issues(["a -> b"])
+        del plan["issues"]["repoint"]
+        gh = _FakeGitHub()
+        assert mhc._file_issues(plan, gh) == 1
+        assert [t for t, _ in gh.created] == ["T-up"]
 
     def test_nothing_to_file(self):
         gh = _FakeGitHub()
@@ -747,7 +870,8 @@ class TestCatalogScanCLI:
     produces the alert + the map addition, and a new tag renders the evaluation issue — all with
     the network replaced by the committed fixtures."""
 
-    def _workspace(self, tmp_path, model="minimax-m2.5", drop=("minimax-m3", "glm-5.2")):
+    def _workspace(self, tmp_path, model="minimax-m2.5", drop=("minimax-m3", "glm-5.2"),
+                   stale=None):
         (tmp_path / "config.yaml").write_text(
             "model_list:\n"
             "  - model_name: lem-medium\n"
@@ -756,8 +880,11 @@ class TestCatalogScanCLI:
             "      api_base: os.environ/OLLAMA_CLOUD_URL\n")
         (tmp_path / "map.yaml").write_text('upgrades:\n  "kimi-k2:1t": "REMOVE"\n')
         catalog = mhc.parse_catalog(_tags())
-        (tmp_path / "snapshot.json").write_text(
-            mhc.render_snapshot({k: v for k, v in catalog.items() if k not in drop}, "2026-07-01"))
+        snapshot = {k: v for k, v in catalog.items() if k not in drop}
+        # `stale` backdates a tag's build IN THE SNAPSHOT, i.e. the catalog re-pointed it since.
+        for tag, patch in (stale or {}).items():
+            snapshot[tag] = {**snapshot[tag], **patch}
+        (tmp_path / "snapshot.json").write_text(mhc.render_snapshot(snapshot, "2026-07-01"))
         return [f"--config={tmp_path / 'config.yaml'}", f"--map={tmp_path / 'map.yaml'}",
                 f"--snapshot={tmp_path / 'snapshot.json'}", f"--catalog-fixture={FIXTURES}",
                 "--today=2026-07-20"]
@@ -802,6 +929,35 @@ class TestCatalogScanCLI:
         assert mhc.main(["--catalog-scan", *args]) == 0
         assert "nothing to do" in capsys.readouterr().out
 
+    def test_a_repointed_configured_tag_is_reported_and_filed(self, tmp_path, capsys, monkeypatch):
+        args = self._workspace(tmp_path, model="gpt-oss:20b", drop=(),
+                               stale={"gpt-oss:20b": {"size": 9_000_000_000,
+                                                      "modified_at": "2026-01-01T00:00:00Z"}})
+        code = mhc.main(["--catalog-scan", *args])
+        out = capsys.readouterr().out
+        assert code == 2  # an evaluation is planned, even though no tag NAME changed
+        assert "NEW TAG" not in out
+        assert "REPOINTED gpt-oss:20b [lem-medium]" in out
+        assert mhc.REPOINT_TITLE_PREFIX in out
+
+        mhc.main(["--catalog-json", *args])
+        plan_path = tmp_path / "plan.json"
+        plan_path.write_text(capsys.readouterr().out)
+        monkeypatch.setattr(mhc, "_catalog_scan", _boom)
+        gh = _FakeGitHub()
+        monkeypatch.setattr(mhc, "GitHubIssues", lambda repo: gh)
+        mhc.main(["--file-issues", f"--plan-file={plan_path}"])
+        assert any(t.startswith(mhc.REPOINT_TITLE_PREFIX) for t, _ in gh.created)
+
+    def test_an_unreferenced_tags_repoint_is_not_reported(self, tmp_path, capsys):
+        args = self._workspace(tmp_path, model="gpt-oss:20b", drop=(),
+                               stale={"glm-5.2": {"size": 9_000_000_000,
+                                                  "modified_at": "2026-01-01T00:00:00Z"}})
+        code = mhc.main(["--catalog-scan", *args])
+        out = capsys.readouterr().out
+        assert "REPOINTED" not in out and "nothing to do" in out
+        assert code == 2  # the snapshot still needs refreshing — but nobody is paged for it
+
     def test_a_missing_snapshot_is_seeded_not_reported_as_a_catalog_of_new_tags(self, tmp_path,
                                                                                 capsys):
         args = self._workspace(tmp_path, model="minimax-m3", drop=())
@@ -809,6 +965,7 @@ class TestCatalogScanCLI:
         code = mhc.main(["--catalog-scan", *args])
         out = capsys.readouterr().out
         assert "NEW TAG" not in out and "seeding it this run" in out
+        assert "REPOINTED" not in out  # no snapshot is no baseline, not a catalog of build swaps
         assert code == 2  # the snapshot itself still needs writing
 
     def test_file_issues_acts_on_a_saved_plan_without_rescanning(self, tmp_path, capsys,
@@ -861,5 +1018,6 @@ class TestCatalogScanCLI:
                          f"--catalog-fixture={FIXTURES}", "--today=2026-07-27"])
         out = capsys.readouterr().out
         assert "RETIRING" not in out and "NEW TAG" not in out and "UPGRADE" not in out
+        assert "REPOINTED" not in out  # every configured tag still points at the build we measured
         assert "nothing to do" in out
         assert code == 0

--- a/tests/unit/test_model_health_check.py
+++ b/tests/unit/test_model_health_check.py
@@ -490,6 +490,14 @@ class TestRepointIssue:
         assert mhc.repoint_marker(repoint) in body  # dedup marker survives into the issue
         assert "model_upgrades.yaml" in body  # never the retirement map, which auto-swaps
 
+    def test_body_pins_the_champion_side_not_only_the_candidate(self):
+        """The re-pointed tag IS the config champion, so it already resolves to the NEW build. A
+        default `benchmark_models.py` run would measure that build against itself and tie every
+        `beats champion` expectation — the issue has to say to pin the champion to the old build."""
+        body = mhc.build_repoint_issue_body([self._repoint()], "2026-08-02")
+        assert "--champions" in body
+        assert "against itself" in body
+
 
 class TestParseModelVersion:
     @pytest.mark.parametrize("name,family,version,size_tag", [


### PR DESCRIPTION
## What

The weekly catalog scan can now see a **build swapped underneath an unchanged tag name**.

`.litellm/config.yaml` runs the *unversioned* `openai/deepseek-v4-flash` on both `lem-medium` and
`lem-complex`, so those tiers follow whatever ollama.com's moving tag points at. `diff_catalog()`
compares tag NAME sets, so a re-point of an existing name produced no `added` entry and therefore no
`agent:ready` evaluation issue — the change landed only as a couple of edited numbers inside the
machine-owned `.litellm/ollama_catalog_snapshot.json` refresh PR, which is the diff nobody reads line
by line. #921 measured `deepseek-v4-flash:0731` and it beat the incumbent on nothing; if the bare tag
ever moves onto that build, both tiers adopt it silently and unbenchmarked.

## How

- **`plan_repoints(deployments, snapshot, catalog)`** — tags present in **both** the snapshot and the
  live catalog whose `size` / `modified_at` moved. Restricted to tags `.litellm/config.yaml` actually
  runs on Ollama Cloud; the catalog carries hundreds LEM never serves and a re-point of one of those
  is noise. `diff_catalog` is left alone (name sets are its job) with a docstring pointing here.
- **A field only counts when BOTH sides carry a value.** A snapshot written without a field has no
  baseline for it — reading that as a build swap would file an issue for every configured tag at once
  the day the snapshot shape changes. A seeded (missing) snapshot reports nothing, same as new tags.
- **Routed exactly like a new tag**: ONE consolidated `agent:ready` issue via the existing
  `plan_issue` dedup mechanic, on its own title prefix (`REPOINT_TITLE_PREFIX`) since a re-point is
  not a new model. The body names the tiers that moved and the exact config `model:` line.
- **The dedup marker carries the new build's fingerprint** (`tag @ size/modified_at`), so a *second*
  re-point of the same tag appends to the open issue instead of deduping to the first.
- **Never an auto-swap or auto-pin** — an evaluation trigger, same as the new-tag path. The issue
  body also says the benchmark candidate is the *versioned* build id, because benchmarking the bare
  tag would run the same id as the champion and compare nothing.
- `_file_issues` reads specs through `_issue_spec()`, so a `--plan-file` written by an older copy of
  the tool files the kinds it does have rather than raising `KeyError`.
- `scripts/weekly_model_check.sh` counts re-points into the gate that runs `--file-issues` (and logs
  `re-pointed-tags=N`), so a re-point-only week still files. Exit code 2 covers it too.

Rendered against the live config with `deepseek-v4-flash` re-pointed to the 0731 build, the issue
reads: *serving `lem-complex`, `lem-medium` (config `model: openai/deepseek-v4-flash`) — size
`140GB` → `167GB`, modified_at `2026-04-24…` → `2026-07-31…`*.

## Testing

- `tests/unit/test_model_health_check.py`: `TestPlanRepoints` (size move, timestamp-only move,
  unreferenced tag stays silent, unchanged build, added/removed tags are not re-points, missing
  baseline, non-Ollama deployment, every tier named once), `TestRepointIssue` (marker fingerprint,
  the second re-point appends rather than dedupes, body names the live deployment), plus CLI
  end-to-end cases for report + `--file-issues` from a saved plan, an unreferenced re-point staying
  quiet, and the seeded-snapshot and committed-repo-state guards asserting no `REPOINTED`.
- `poetry run pytest tests/unit -q` — **9513 passed**.
- `bash -n scripts/weekly_model_check.sh` clean.

Closes #925

🤖 Generated with [Claude Code](https://claude.com/claude-code)
