### PR TITLE
fix(errors): a stored automation pause is INFO, not a warning that files a defect (closes #917)

### DIFF
--- a/docs/error-tracking.md
+++ b/docs/error-tracking.md
@@ -109,6 +109,14 @@ The second half of that pattern is **warn where you detect, not where you notice
 failure one frame up files a second defect for one fault, so that caller now logs the outcome at
 DEBUG and each failing path inside `react_to_post_inline` owns its single warning (issue #878).
 
+The same rule reads sideways for a **state-setter**: succeeding at what you were asked to do is never
+a degraded path, however serious the state is. `pause_automation` warned whenever it stored the global
+Selenium kill-switch, and maintenance mode sets one on every release — 4x daily — so a routine deploy
+escalated to ERROR and filed `RecurringWarning: Automation PAUSED for 1800s (reason: deploy)`
+(issue #917). It logs INFO now; the callers for which a pause IS the defect already say so where they
+detect it (the suppression tripwire escalates CRITICAL, the 429 breaker warns in `mark_rate_limited`),
+and only failing to store the pause — a kill-switch that didn't take — still warns.
+
 | Env | Default | Purpose |
 |---|---|---|
 | `LOG_ESCALATION_ENABLED` | `true` | master switch; false → zero Redis calls |

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -70,6 +70,13 @@ Two things follow for anyone writing a call site here:
    where you detect, not where you notice.** ONE unreadable card still warns twice, because the
    pre-click 'Reaction state' read warns too (issue #874, open); collapse that into the opener's
    signal as well, and never add a fourth.
+   The rule reads sideways for a **state-setter**: doing what you were asked is not a degraded path,
+   however serious the state is. `pause_automation` warned every time it stored the global Selenium
+   kill-switch, and maintenance mode sets one on EVERY release, so a routine deploy filed
+   `RecurringWarning: Automation PAUSED for 1800s (reason: deploy)` (issue #917). It logs INFO now —
+   the callers for which a pause IS the defect already say so where they detect it (suppression
+   escalates CRITICAL, the 429 breaker warns in `mark_rate_limited`) — and only a kill-switch that
+   FAILED to store still warns.
 2. **Keep the message a stable template.** The dedup key masks volatile tokens (URLs, emails, UUIDs,
    URNs, hex, `[...]`, quoted strings, numbers) and combines them with the call site, so
    `Selector miss: Feed sort control` and `Selector miss: Reaction state` stay two distinct problems

--- a/src/cqc_lem/utilities/linkedin/rate_limit.py
+++ b/src/cqc_lem/utilities/linkedin/rate_limit.py
@@ -13,7 +13,7 @@ import json
 import os
 from datetime import datetime, timezone
 
-from cqc_lem.utilities.logger import log_warning
+from cqc_lem.utilities.logger import log_info, log_warning
 
 _COOLDOWN_KEY = "linkedin:429_cooldown"
 _TRIP_COUNT_KEY = "linkedin:429_trip_count"   # consecutive trips → escalating cooldown
@@ -164,9 +164,17 @@ def pause_automation(seconds: int, reason: str = "manual") -> bool:
     client = _redis_client()
     if client is None:
         return False
+    stored_reason = reason or "manual"
     try:
-        client.set(_PAUSE_KEY, reason or "manual", ex=max(1, int(seconds)))
-        log_warning(f"Automation PAUSED for {int(seconds)}s (reason: {reason})", action_type="rate_limit")
+        client.set(_PAUSE_KEY, stored_reason, ex=max(1, int(seconds)))
+        # INFO, not WARNING (issue #917): storing a pause is a deliberate state transition, never a
+        # degraded path detected HERE. Every caller that considers its own pause a defect already
+        # says so where it detects it — the suppression tripwire escalates CRITICAL (#629), the 429
+        # breaker warns in mark_rate_limited, and maintenance mode logs its own INFO with the drain
+        # detail. The deploy pause is routine (one per release, 4x daily), so a warning here was
+        # re-emitted at ERROR on repeat and filed a grouped $exception for working behaviour.
+        log_info(f"Automation PAUSED for {int(seconds)}s (reason: {stored_reason})",
+                 action_type="rate_limit")
         return True
     except Exception as e:
         log_warning("Failed to set automation pause", exc=e, action_type="rate_limit")

--- a/tests/unit/utilities/linkedin/test_rate_limit.py
+++ b/tests/unit/utilities/linkedin/test_rate_limit.py
@@ -240,6 +240,33 @@ class TestAutomationPause:
             from cqc_lem.utilities.linkedin.rate_limit import pause_automation
             assert pause_automation(60) is False
 
+    def test_pause_logs_info_not_warning(self, fake_redis):
+        """A stored pause is a state transition, not a degraded path (issue #917). Warning here made
+        the once-per-release deploy pause escalate to ERROR and file a grouped $exception."""
+        from cqc_lem.utilities.linkedin.rate_limit import pause_automation
+        with patch(f"{_MOD}.log_info") as info, patch(f"{_MOD}.log_warning") as warn:
+            assert pause_automation(1800, reason="deploy") is True
+        warn.assert_not_called()
+        info.assert_called_once()
+        assert "Automation PAUSED for 1800s (reason: deploy)" in info.call_args.args[0]
+
+    def test_pause_logs_the_reason_it_actually_stored(self, fake_redis):
+        """An empty reason falls back to 'manual' — the log must not claim a blank one."""
+        from cqc_lem.utilities.linkedin.rate_limit import pause_automation
+        with patch(f"{_MOD}.log_info") as info:
+            pause_automation(60, reason="")
+        fake_redis.set.assert_called_once_with("linkedin:automation_paused", "manual", ex=60)
+        assert "reason: manual" in info.call_args.args[0]
+
+    def test_pause_redis_error_still_warns(self, fake_redis):
+        """The kill-switch failing to store IS a degraded path — that one keeps its warning."""
+        fake_redis.set.side_effect = RuntimeError("redis down")
+        from cqc_lem.utilities.linkedin.rate_limit import pause_automation
+        with patch(f"{_MOD}.log_warning") as warn, patch(f"{_MOD}.log_info") as info:
+            assert pause_automation(60) is False
+        info.assert_not_called()
+        warn.assert_called_once()
+
     def test_resume_deletes_key(self, fake_redis):
         from cqc_lem.utilities.linkedin.rate_limit import resume_automation
         assert resume_automation() is True


### PR DESCRIPTION
## What & why

PostHog filed `RecurringWarning: Automation PAUSED for 1800s (reason: deploy)` — a grouped
`$exception` for behaviour that is working exactly as designed.

`pause_automation()` in `utilities/linkedin/rate_limit.py` emitted a `log_warning` every time it
successfully stored the global Selenium kill-switch. Deploy maintenance mode (`utilities/maintenance.py`,
`MAINTENANCE_REASON = "deploy"`) sets one on **every** release, and releases batch 4x daily — so the
recurrence escalation (3 occurrences in 24h) re-emitted the warning at ERROR and turned a routine
deploy step into a defect.

**Root cause is the level, not the pause.** Succeeding at what the caller asked for is never a
degraded path detected *here* — it is a deliberate state transition, which the level table puts at
INFO. Nothing is lost by dropping the warning, because every caller for which a pause *is* the defect
already says so where it detects it:

| Caller | Reason | Its own signal |
|---|---|---|
| `maintenance.begin_maintenance` | `deploy` | `log_info` "Maintenance mode ON for Ns — paused dispatch, cancelled N consumer(s)" |
| `run_scheduler.auto_suppression_tripwire` | `suppression:<uid>` | `log_critical` "Suppression tripwire fired…" (#629) |
| `POST /admin/pause-automation` | `admin` | the operator pressed the button and gets the response |
| 429 breaker | — | doesn't call this; warns in `mark_rate_limited` |

So the warning was a second defect filed for someone else's already-reported fault — the
"warn where you detect, not where you notice" rule from #878, read sideways for a state-setter.

### Changes
- `pause_automation` logs the stored pause at **INFO**. The Redis-failure path (a kill-switch that
  did **not** take) keeps its `log_warning` — that one is a genuine degraded path.
- It now logs the reason it *actually stored*: an empty `reason` falls back to `"manual"` for the
  Redis key, but the message used to print `(reason: )`.
- Documented the state-setter variant of the escalation rule in `docs/error-tracking.md` and
  `src/cqc_lem/utilities/CLAUDE.md`, so the next call site doesn't repeat it.

No behaviour change to the pause itself: same key, same TTL, same return value, same fail-open.

## Testing

`tests/unit/utilities/linkedin/test_rate_limit.py` — three new cases:
- a stored pause logs INFO and does **not** warn (the #917 regression guard);
- an empty reason logs the `manual` it stored, matching the Redis value;
- a Redis error on `set` still warns and does not log the INFO.

```
tests/unit/utilities/linkedin/test_rate_limit.py + test_maintenance.py … 93 passed
tests/unit/app/test_suppression_tripwire.py + api suppression/admin … 138 passed
tests/unit/utilities … 5837 passed
```

Closes #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)
