### PR TITLE
fix(images): refusal filter rejected every AI-topic brief; gate avatar renders too

### DIFF
--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -410,9 +410,10 @@ def _generate_text_post_image(user_id: int, text_content: str, post_id: "int | N
         brief = build_image_brief(text_content, surface="post_image", ratio=DEFAULT_IMAGE_RATIO,
                                   profile=profile, avatar=avatar)
         if avatar:
-            from cqc_lem.utilities.ai.ai_helper import generate_post_image
-            image_path = generate_post_image(brief.prompt, user_id, ratio=DEFAULT_IMAGE_RATIO,
-                                             surface=AVATAR_SURFACE_POST_IMAGE, post_id=post_id)
+            from cqc_lem.utilities.ai.image_gen import render_avatar_image_gated
+            image_path = render_avatar_image_gated(
+                brief.prompt, avatar=avatar, user_id=user_id, surface="post_image",
+                ratio=DEFAULT_IMAGE_RATIO, focal_concept=brief.focal_concept, post_id=post_id)
         else:
             image_path = render_image_gated(brief.prompt, surface="post_image",
                                             ratio=DEFAULT_IMAGE_RATIO,

--- a/src/cqc_lem/utilities/ai/ai_helper.py
+++ b/src/cqc_lem/utilities/ai/ai_helper.py
@@ -2756,8 +2756,11 @@ def get_flux_image_via_replicate(prompt: str, ref: str = DEFAULT_IMAGE_MODEL, *,
     image_file_path = save_video_url_to_dir(url, save_dir)
 
     from cqc_lem.utilities.observability import track_media_cost, image_cost_usd
-    track_media_cost("image", "replicate", image_cost_usd(1, model=ref), qty=1, model=ref,
-                     meta={"aspect_ratio": aspect_ratio})
+    # Price on the FULL ref, but record the model without its ":<64-char digest>" version — an
+    # avatar LoRA ref is ~100 chars and cost_ledger.model_tier is VARCHAR(64), so the untrimmed
+    # value failed every avatar render's ledger write ("Data too long for column 'model_tier'").
+    track_media_cost("image", "replicate", image_cost_usd(1, model=ref), qty=1,
+                     model=ref.split(":", 1)[0], meta={"aspect_ratio": aspect_ratio})
 
     return image_file_path
 

--- a/src/cqc_lem/utilities/ai/image_brief.py
+++ b/src/cqc_lem/utilities/ai/image_brief.py
@@ -61,8 +61,13 @@ Respond with ONLY a JSON object:
 {"focal_concept": "<the one idea the image depicts, under 20 words>",
  "prompt": "<one richly descriptive render-ready paragraph: scene, subject, setting, lighting, color>"}"""
 
-# A refusal or meta-answer leaking into a render prompt produces surreal garbage.
-_BANNED_FRAGMENTS = ("i'm sorry", "i cannot", "as an ai", "i can't", "language model")
+# A refusal or meta-answer leaking into a render prompt produces surreal garbage. Anchored to
+# refusal PHRASING on purpose: a bare "language model" entry here rejected every legitimate brief
+# an AI-focused author writes ("a dashboard showing large language model routing costs"), so their
+# briefs fell back to the deterministic template every time — silently, since the fallback is a
+# working code path. Match how a refusal STARTS, never a topic word.
+_BANNED_FRAGMENTS = ("i'm sorry", "i am sorry", "i cannot", "i can't", "i am unable",
+                     "as an ai", "cannot fulfill", "cannot generate", "unable to generate")
 
 _MIN_PROMPT_CHARS = 60
 _MAX_PROMPT_CHARS = 2400

--- a/src/cqc_lem/utilities/ai/image_gen.py
+++ b/src/cqc_lem/utilities/ai/image_gen.py
@@ -210,6 +210,50 @@ def inspect_render_quality(image_path: str, focal_concept: str) -> QualityVerdic
         return QualityVerdict(acceptable=True, checked=False)
 
 
+def render_avatar_image_gated(prompt: str, *, avatar: dict, user_id: Optional[int],
+                              surface: str, ratio: str = "1:1",
+                              focal_concept: Optional[str] = None,
+                              post_id: Optional[int] = None) -> Optional[str]:
+    """LoRA render of an image the author appears in, behind the SAME bounded vision gate the
+    base renderer gets.
+
+    Likeness never renders through the gpt-image path (``generate_post_image`` owns the avatar
+    guardrails), so without this the avatar branch was the one path with no quality check at all —
+    which is how a post about LLM routing costs came back as a plain headshot against a brick wall.
+    Returns the best candidate's path, or None if nothing rendered.
+    """
+    from cqc_lem.utilities.ai.ai_helper import _record_avatar_media
+    from cqc_lem.utilities.avatar.attributes import apply_subject_clause
+    from cqc_lem.utilities.avatar.replicate_avatar import generate_image_with_avatar
+
+    enforced = surface in IMAGE_QUALITY_GATE_SURFACES
+    attempts = max(1, IMAGE_GATE_MAX_ATTEMPTS) if enforced else 1
+    current_prompt = prompt
+    path: Optional[str] = None
+
+    for attempt in range(1, attempts + 1):
+        path, used_avatar = generate_image_with_avatar(
+            apply_subject_clause(current_prompt, avatar), avatar["model_ref"],
+            ratio=ratio, fallback_prompt=current_prompt)
+        if used_avatar and path:
+            # Provenance for a synthetic likeness of a real person.
+            _record_avatar_media(path, post_id, user_id)
+        if not path:
+            return None
+        verdict = inspect_render_quality(path, focal_concept or prompt[:200])
+        if verdict.acceptable or not verdict.checked:
+            return path
+        log_info("Avatar image failed the quality gate", user_id=user_id, post_id=post_id,
+                 action_type="image_gate", surface=surface, attempt=attempt,
+                 issues="; ".join(verdict.issues))
+        if not enforced or attempt == attempts:
+            break
+        fixes = "; ".join(verdict.issues) or "low relevance to the subject"
+        current_prompt = (f"{prompt}\n\nThe previous render was rejected for: {fixes}. "
+                          f"Avoid those problems entirely in this render.")
+    return path
+
+
 def render_image_gated(prompt: str, *, surface: str, ratio: str = "1:1",
                        focal_concept: Optional[str] = None,
                        quality: Optional[str] = None,

--- a/src/cqc_lem/utilities/newsletter_cover.py
+++ b/src/cqc_lem/utilities/newsletter_cover.py
@@ -265,35 +265,6 @@ def _resolve_cover_avatar(user_id: int, use_avatar: Optional[bool], title: Optio
     return avatar if classify_avatar_relevance(title, subtitle, body) else None
 
 
-def _render_avatar_cover(brief, avatar: dict, user_id: int) -> Optional[str]:
-    """LoRA render for a cover the author appears in, with ONE bounded vision re-render."""
-    from cqc_lem.utilities.ai.ai_helper import _record_avatar_media
-    from cqc_lem.utilities.ai.image_gen import inspect_render_quality
-    from cqc_lem.utilities.avatar.attributes import apply_subject_clause
-    from cqc_lem.utilities.avatar.replicate_avatar import generate_image_with_avatar
-    from cqc_lem.utilities.env_constants import IMAGE_GATE_MAX_ATTEMPTS
-
-    prompt = brief.prompt
-    path = None
-    for attempt in range(1, max(1, IMAGE_GATE_MAX_ATTEMPTS) + 1):
-        path, used_avatar = generate_image_with_avatar(
-            apply_subject_clause(prompt, avatar), avatar["model_ref"],
-            ratio=COVER_IMAGE_RATIO, fallback_prompt=prompt)
-        if used_avatar and path:
-            # C2PA provenance for a synthetic likeness; editions have no posts row to flag.
-            _record_avatar_media(path, None, user_id)
-        verdict = inspect_render_quality(path, brief.focal_concept)
-        if verdict.acceptable or not verdict.checked:
-            return path
-        log_info("Avatar cover failed the quality gate", user_id=user_id,
-                 action_type="newsletter_cover", attempt=attempt,
-                 issues="; ".join(verdict.issues))
-        fixes = "; ".join(verdict.issues) or "low relevance to the subject"
-        prompt = (f"{brief.prompt}\n\nThe previous render was rejected for: {fixes}. "
-                  f"Avoid those problems entirely in this render.")
-    return path
-
-
 def generate_cover_for_edition(user_id: int, edition_id: int, title: Optional[str],
                                subtitle: Optional[str], body: Optional[str],
                                profile=None,
@@ -307,7 +278,7 @@ def generate_cover_for_edition(user_id: int, edition_id: int, title: Optional[st
     Whatever renders here still lands ``pending_review`` — the author stays the publish gate.
     """
     from cqc_lem.utilities.ai.image_brief import build_image_brief
-    from cqc_lem.utilities.ai.image_gen import render_image_gated
+    from cqc_lem.utilities.ai.image_gen import render_avatar_image_gated, render_image_gated
 
     avatar = _resolve_cover_avatar(user_id, use_avatar, title, subtitle, body)
 
@@ -323,7 +294,9 @@ def generate_cover_for_edition(user_id: int, edition_id: int, title: Optional[st
 
     try:
         if avatar:
-            generated_path = _render_avatar_cover(brief, avatar, user_id)
+            generated_path = render_avatar_image_gated(
+                brief.prompt, avatar=avatar, user_id=user_id, surface="newsletter",
+                ratio=COVER_IMAGE_RATIO, focal_concept=brief.focal_concept)
         else:
             generated_path = render_image_gated(brief.prompt, surface="newsletter",
                                                 ratio=COVER_IMAGE_RATIO,

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -707,8 +707,11 @@ def track_media_cost(kind: str, provider: str, usd: float, user_id: Optional[int
             **(meta or {}),
         },
     )
+    # cost_ledger.model_tier is VARCHAR(64); an over-long identifier used to abort the whole
+    # ledger write, so the spend vanished rather than being recorded under a truncated name.
     _write_cost_ledger(feature=feature, category="media", usd=usd, user_id=user_id,
-                       provider=provider, model_tier=model, qty=qty, post_id=post_id,
+                       provider=provider, model_tier=(model or None) and model[:64],
+                       qty=qty, post_id=post_id,
                        task_name=_current_task_context()[0])
 
 

--- a/tests/unit/app/test_text_post_image.py
+++ b/tests/unit/app/test_text_post_image.py
@@ -41,7 +41,7 @@ class TestGenerateTextPostImage:
              patch("cqc_lem.utilities.ai.image_gen.render_image_gated",
                    side_effect=RuntimeError("render down") if render_raises else None,
                    return_value=rendered_path) as render, \
-             patch("cqc_lem.utilities.ai.ai_helper.generate_post_image",
+             patch("cqc_lem.utilities.ai.image_gen.render_avatar_image_gated",
                    return_value=rendered_path) as lora:
             result = _generate_text_post_image(7, "My post text", 42)
         return result, store, brief, render, lora, assets
@@ -72,10 +72,13 @@ class TestGenerateTextPostImage:
         assert result is not None
         # Avatar resolved BEFORE the brief (the #744 subject-clause ordering)...
         assert brief.call_args[1]["avatar"] == avatar
-        # ...and the render goes through generate_post_image so guardrails/C2PA stay in charge.
+        # ...and the likeness renders through the GATED avatar path, so an off-subject headshot
+        # is caught rather than shipped (C2PA/provenance stays inside that helper).
         lora.assert_called_once()
         assert lora.call_args[1]["surface"] == "post_image"
         assert lora.call_args[1]["post_id"] == 42
+        assert lora.call_args[1]["avatar"] == avatar
+        assert lora.call_args[1]["focal_concept"] == "the focal idea"
         render.assert_not_called()
 
     def test_render_failure_never_raises_and_ships_bare(self, tmp_path):

--- a/tests/unit/utilities/ai/test_image_brief.py
+++ b/tests/unit/utilities/ai/test_image_brief.py
@@ -77,3 +77,32 @@ class TestBuildImageBrief:
             build_image_brief("content", surface="newsletter", avatar=avatar)
         user_msg = llm.call_args[1]["messages"][1]["content"]
         assert "it IS the author" in user_msg
+
+
+@pytest.mark.unit
+class TestRefusalFilterIsAnchoredToRefusals:
+    """Regression: a bare "language model" ban rejected every legitimate brief an AI-focused
+    author writes, so their briefs silently fell back to the deterministic template."""
+
+    @pytest.mark.parametrize("prompt_text", [
+        ("A photorealistic scene of an engineer studying a wall display of large language model "
+         "routing costs, shallow depth of field, dramatic rim light, modern office at dusk."),
+        ("A close-up of a founder at a whiteboard mapping an AI language model pipeline, warm "
+         "window light, one bold orange accent, editorial photograph."),
+    ])
+    def test_legitimate_ai_subject_matter_is_accepted(self, prompt_text):
+        payload = {"focal_concept": "LLM routing cost risk", "prompt": prompt_text}
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_resp(payload)):
+            brief = build_image_brief("post about LLM cost routing", surface="post_image")
+        assert brief.prompt == prompt_text, "an AI-topic brief must not fall back"
+
+    @pytest.mark.parametrize("refusal", [
+        "I'm sorry, I cannot create that image for you because it violates the guidelines here.",
+        "As an AI language model, I am unable to generate the requested description at all.",
+        "I can't fulfill this request, but here is a generic description of an office scene.",
+    ])
+    def test_actual_refusals_are_still_rejected(self, refusal):
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   return_value=_resp({"focal_concept": "n/a", "prompt": refusal * 2})):
+            brief = build_image_brief("some content", surface="post_image")
+        assert refusal not in brief.prompt

--- a/tests/unit/utilities/ai/test_image_gen.py
+++ b/tests/unit/utilities/ai/test_image_gen.py
@@ -119,3 +119,43 @@ class TestVisionGate:
              patch.object(image_gen, "inspect_render_quality", return_value=bad):
             assert render_image_gated("p", surface="carousel") == "/tmp/x.png"
         render.assert_called_once()
+
+
+class TestAvatarRenderIsGatedToo:
+    """Regression: the avatar branch was the ONE render path with no quality check, so a post
+    about LLM routing costs came back as a plain headshot and nothing questioned it."""
+
+    _AVATAR = {"model_ref": "owner/lora:v1", "trigger_word": "TOK",
+               "gender_presentation": "man", "age_band": "40s"}
+
+    def _render(self, verdicts, surface="post_image"):
+        with patch("cqc_lem.utilities.avatar.replicate_avatar.generate_image_with_avatar",
+                   side_effect=[("/tmp/1.png", True), ("/tmp/2.png", True)]) as lora, \
+             patch("cqc_lem.utilities.ai.ai_helper._record_avatar_media") as record, \
+             patch.object(image_gen, "inspect_render_quality", side_effect=verdicts):
+            path = image_gen.render_avatar_image_gated(
+                "base prompt", avatar=self._AVATAR, user_id=3, surface=surface,
+                focal_concept="the idea", post_id=9)
+        return path, lora, record
+
+    def test_rejected_avatar_render_is_retried_with_the_issues(self):
+        path, lora, record = self._render([QualityVerdict(acceptable=False, issues=["plain headshot"]),
+                                           QualityVerdict(acceptable=True)])
+        assert path == "/tmp/2.png"
+        assert lora.call_count == 2
+        assert "plain headshot" in lora.call_args[0][0]
+        # The trigger word + declared clause must survive the retry prompt.
+        assert lora.call_args[0][0].startswith("TOK, a man in his 40s")
+
+    def test_accepted_render_returns_immediately_and_signs_provenance(self):
+        path, lora, record = self._render([QualityVerdict(acceptable=True)])
+        assert path == "/tmp/1.png"
+        lora.assert_called_once()
+        record.assert_called_once_with("/tmp/1.png", 9, 3)
+
+    def test_unenforced_surface_does_not_retry(self):
+        with patch.object(image_gen, "IMAGE_QUALITY_GATE_SURFACES", ("newsletter",)):
+            path, lora, _ = self._render([QualityVerdict(acceptable=False, issues=["x"])],
+                                         surface="carousel")
+        assert path == "/tmp/1.png"
+        lora.assert_called_once()

--- a/tests/unit/utilities/test_cost_tracking.py
+++ b/tests/unit/utilities/test_cost_tracking.py
@@ -216,3 +216,31 @@ class TestFlushLlmCostRollup:
         with patch(_REDIS, return_value=client):
             from cqc_lem.utilities.observability import flush_llm_cost_rollup
             assert flush_llm_cost_rollup() == 0
+
+
+class TestLongModelIdentifiersNeverBreakTheLedger:
+    """Regression: an avatar LoRA ref (~100 chars) overflowed cost_ledger.model_tier
+    VARCHAR(64), so MySQL rejected the row and the spend vanished entirely."""
+
+    _LORA = ("gitchrisqueen/lemcqv1-avatar-60:"
+             "3ac08f699b61bc2afd323d578532d28a7a62f7371da89cfc928101baebacbf76")
+
+    def test_model_tier_is_clamped_to_the_column_width(self):
+        with patch(f"{_MOD}.posthog"), patch(f"{_MOD}._write_cost_ledger") as ledger:
+            from cqc_lem.utilities.observability import track_media_cost
+            track_media_cost("image", "replicate", 0.025, user_id=1, qty=1, model=self._LORA)
+        assert len(ledger.call_args[1]["model_tier"]) <= 64
+
+    def test_replicate_render_records_the_ref_without_its_version_digest(self, tmp_path):
+        with patch("cqc_lem.utilities.ai.image_gen.run_replicate_bounded",
+                   return_value=["https://replicate.dev/pb/abc/out.webp"]), \
+             patch("cqc_lem.utilities.ai.ai_helper.save_video_url_to_dir",
+                   return_value=str(tmp_path / "out.webp")), \
+             patch("cqc_lem.utilities.ai.ai_helper.create_folder_if_not_exists"), \
+             patch(f"{_MOD}.track_media_cost") as track:
+            from cqc_lem.utilities.ai.ai_helper import get_flux_image_via_replicate
+            get_flux_image_via_replicate("p", ref=self._LORA, aspect_ratio="1:1")
+
+        recorded = track.call_args[1]["model"]
+        assert recorded == "gitchrisqueen/lemcqv1-avatar-60"
+        assert len(recorded) <= 64


### PR DESCRIPTION
Found by smoke-testing v0.123.0 in production immediately after deploy. All three are defects in what #936 shipped.

## 1. Every AI-topic brief silently fell back to the bland template (the big one)

`_BANNED_FRAGMENTS` carried the bare phrase `"language model"` to catch *"As an AI language model, I cannot…"*. It also matches any legitimate brief that names the subject — e.g. *"a dashboard showing large language model routing costs"*. This account's entire niche is AI/LLM content, so **nearly every brief failed validation twice and fell back to the deterministic template**, which is exactly the generic output the overhaul existed to remove. Silent, because the fallback is a working code path that logs a single warning.

Now anchored to how a refusal *starts* (`i'm sorry`, `i cannot`, `as an ai`, `cannot fulfill`, …) and never to a topic word.

**Live evidence** — prod, post #79 ("What if every cost-cut you make could silently crash your LLM service tomorrow?"): `WARNING Image brief fell back to the deterministic template`, and the render came back a plain headshot against a brick wall.

## 2. Avatar renders were the one path with no quality gate

`render_image_gated` covered the base renderer, and newsletter covers had a private LoRA+gate helper — but **text-post avatar renders called `generate_post_image` directly, with no vision check at all**. That is how an off-subject headshot shipped unquestioned.

`render_avatar_image_gated` in `image_gen.py` is now the ONE gated likeness renderer (bounded retries, provenance inside). `newsletter_cover._render_avatar_cover` is deleted in favour of it, and text posts route through it — so the "no parallel per-surface helper" doctrine holds.

## 3. Avatar render spend vanished from the cost ledger

An avatar LoRA ref is ~100 chars (`owner/name:<64-char digest>`); `cost_ledger.model_tier` is `VARCHAR(64)`. MySQL rejected the row outright: `Data too long for column 'model_tier'`. The ref is now recorded without its version digest (`gitchrisqueen/lemcqv1-avatar-60`), **plus** a defensive clamp in `track_media_cost` so no long identifier can abort a ledger write again. Pricing still uses the full ref.

## Tests

9,626 unit tests green, including regressions for each: AI-subject briefs are accepted while real refusals are still rejected; a rejected avatar render retries with the issues appended and keeps its trigger word + declared clause; long model ids are clamped and the digest is stripped.

Labelled `release:now`: the headline feature of the release that just shipped is silently degraded in production for this user's entire content niche.

🤖 Generated with [Claude Code](https://claude.com/claude-code)