### PR TITLE
fix(images): no brand marks in a render — gpt-image inserts logos on its own

### DIFF
--- a/src/cqc_lem/utilities/ai/image_gen.py
+++ b/src/cqc_lem/utilities/ai/image_gen.py
@@ -44,6 +44,20 @@ _REPLICATE_ATTEMPTS = 2
 
 _GENERATED_SUBDIR = os.path.join("images", "generated")
 
+# Appended to EVERY render prompt, whatever wrote it. The brief author is told to avoid marks,
+# but that only governs what it writes — gpt-image-2 inserts a LinkedIn logo into business scenes
+# entirely on its own, and the two covers it did that to both reached review carrying someone
+# else's trademark. Belongs here rather than in the brief so a hand-written or retried prompt
+# cannot lose it.
+_NO_MARKS_SUFFIX = (" Absolutely no text, letters, words, numbers, captions, watermarks, logos, "
+                    "brand marks, app icons, social-media icons, charts, or UI elements anywhere "
+                    "in the image.")
+
+
+def with_no_marks(prompt: str) -> str:
+    """The render prompt plus the no-marks constraint, added at most once."""
+    return prompt if _NO_MARKS_SUFFIX in prompt else f"{prompt}{_NO_MARKS_SUFFIX}"
+
 
 @dataclass
 class QualityVerdict:
@@ -148,6 +162,7 @@ def render_image_from_prompt(prompt: str, *, ratio: str = "1:1",
     Never renders a likeness — callers that may include the author go through
     ``generate_post_image`` so the avatar guardrails stay the single decision point.
     """
+    prompt = with_no_marks(prompt)
     backend = (IMAGE_BACKEND or "auto").strip().lower()
     if backend not in ("auto", "gpt-image", "flux"):
         log_warning(f"Unknown IMAGE_BACKEND '{backend}' — using auto")
@@ -232,9 +247,12 @@ def render_avatar_image_gated(prompt: str, *, avatar: dict, user_id: Optional[in
     path: Optional[str] = None
 
     for attempt in range(1, attempts + 1):
+        # The likeness path talks to Replicate directly, so it never passes through
+        # render_image_from_prompt where the constraint is otherwise added.
+        marked = with_no_marks(current_prompt)
         path, used_avatar = generate_image_with_avatar(
-            apply_subject_clause(current_prompt, avatar), avatar["model_ref"],
-            ratio=ratio, fallback_prompt=current_prompt)
+            apply_subject_clause(marked, avatar), avatar["model_ref"],
+            ratio=ratio, fallback_prompt=marked)
         if used_avatar and path:
             # Provenance for a synthetic likeness of a real person.
             _record_avatar_media(path, post_id, user_id)

--- a/tests/unit/utilities/ai/test_image_gen.py
+++ b/tests/unit/utilities/ai/test_image_gen.py
@@ -159,3 +159,38 @@ class TestAvatarRenderIsGatedToo:
                                          surface="carousel")
         assert path == "/tmp/1.png"
         lora.assert_called_once()
+
+
+class TestNoBrandMarksConstraint:
+    """Regression: gpt-image-2 inserted a LinkedIn logo into business scenes on its own, and
+    both generated covers reached review carrying someone else's trademark."""
+
+    def test_every_render_prompt_carries_the_constraint(self):
+        with patch.object(image_gen, "_render_via_gpt_image", return_value="/tmp/g.png") as gpt:
+            image_gen.render_image_from_prompt("a founder at a desk", user_id=3)
+        sent = gpt.call_args[0][0]
+        assert "logos" in sent and "brand marks" in sent
+
+    def test_flux_fallback_keeps_the_constraint(self):
+        with patch.object(image_gen, "_render_via_gpt_image", side_effect=RuntimeError("down")), \
+             patch.object(image_gen, "_render_via_flux", return_value="/tmp/f.webp") as flux:
+            image_gen.render_image_from_prompt("a founder at a desk", user_id=3)
+        assert "brand marks" in flux.call_args[0][0]
+
+    def test_avatar_render_carries_it_too(self):
+        avatar = {"model_ref": "owner/lora:v1", "trigger_word": "TOK",
+                  "gender_presentation": "man", "age_band": "40s"}
+        with patch("cqc_lem.utilities.avatar.replicate_avatar.generate_image_with_avatar",
+                   return_value=("/tmp/a.png", True)) as lora, \
+             patch("cqc_lem.utilities.ai.ai_helper._record_avatar_media"), \
+             patch.object(image_gen, "inspect_render_quality",
+                          return_value=QualityVerdict(acceptable=True)):
+            image_gen.render_avatar_image_gated("a founder at a desk", avatar=avatar, user_id=3,
+                                                surface="post_image")
+        assert "brand marks" in lora.call_args[0][0]
+        # The fallback prompt must carry it as well — that render is still published.
+        assert "brand marks" in lora.call_args[1]["fallback_prompt"]
+
+    def test_constraint_is_never_doubled(self):
+        once = image_gen.with_no_marks("scene")
+        assert image_gen.with_no_marks(once) == once


### PR DESCRIPTION
Found smoke-testing v0.123.1 in production.

## The problem

Both newsletter covers generated in the smoke test came back with a **LinkedIn logo** in them. The vision gate caught it correctly — `issues: ['watermark present', 'generic abstract background']`, relevance 3/5 — but after the bounded retries it ships the best candidate to review, so a cover carrying someone else's trademark reached the review queue twice.

The brief was not at fault. Its render prompt for edition 5 mentions no brand at all:

> *"…a tablet rests on the desk, its screen glowing with abstract, swirling blue and cyan light patterns representing AI data processing—no text, numbers, or UI elements…"*

**gpt-image-2 adds the mark to business scenes unprompted.** The brief author's system prompt forbids logos, but that only governs what the *author writes* — the author wrote "no text, numbers, or UI elements" and never said "no logos", so the constraint never reached the image model.

## The fix

The no-marks constraint now rides on the render prompt itself, applied in the ONE renderer (`image_gen.with_no_marks`), so it cannot be lost by:

- a hand-written or programmatically-built prompt,
- a quality-gate retry (which rebuilds the prompt from the base),
- the avatar path, which calls Replicate directly and never passes through `render_image_from_prompt`,
- the avatar's **`fallback_prompt`** — the base-model render used when LoRA inference fails, which still publishes.

Idempotent, so a retry never doubles it.

Publishing a third party's trademark on a newsletter cover is a legal exposure, not a taste preference — hence fixing it at the choke point rather than asking the brief author more nicely.

## Tests

9,630 unit tests green, including: the constraint reaches the gpt-image call, survives the FLUX fallback, reaches both the avatar prompt and its fallback prompt, and is never doubled.

Labelled `release:now`: unreviewed covers currently reaching the review queue with a LinkedIn trademark on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)