### PR TITLE
fix(images): the brief's token budget went entirely to reasoning tokens

### DIFF
--- a/src/cqc_lem/utilities/ai/image_brief.py
+++ b/src/cqc_lem/utilities/ai/image_brief.py
@@ -72,6 +72,14 @@ _BANNED_FRAGMENTS = ("i'm sorry", "i am sorry", "i cannot", "i can't", "i am una
 _MIN_PROMPT_CHARS = 60
 _MAX_PROMPT_CHARS = 2400
 
+# Generous on purpose. lem-medium is served by a REASONING model (deepseek-v4-flash), whose
+# thinking tokens are billed against the same budget before a single character of JSON is
+# emitted. At 600 the whole budget went to reasoning and the response came back EMPTY with
+# finish_reason='length' — so the brief failed validation, retried, failed again, and every
+# image silently rendered from the bland deterministic template. A real brief costs ~870
+# completion tokens including reasoning; this leaves headroom for a longer one.
+_BRIEF_MAX_TOKENS = 2500
+
 
 @dataclass
 class ImageBrief:
@@ -122,6 +130,7 @@ def build_image_brief(content: str, *, surface: str, ratio: str = "1:1",
         + (f"Additional direction: {extra_direction}\n" if extra_direction else "")
         + f"\nHere is the content the image must represent:\n<content>{content}</content>")
 
+    reason = "unknown"
     for attempt in (1, 2):
         try:
             response = _call_llm(
@@ -129,21 +138,33 @@ def build_image_brief(content: str, *, surface: str, ratio: str = "1:1",
                 messages=[{"role": "system", "content": _SYSTEM_PROMPT},
                           {"role": "user", "content": user_prompt}],
                 temperature=0.6,
-                max_tokens=600,
+                max_tokens=_BRIEF_MAX_TOKENS,
                 response_format={"type": "json_object"},
             )
-            parsed = json.loads(response.choices[0].message.content)
+            choice = response.choices[0]
+            raw = choice.message.content or ""
+            if not raw.strip():
+                # The shape an exhausted token budget takes: finish_reason='length', no content.
+                reason = f"empty response (finish_reason={getattr(choice, 'finish_reason', None)})"
+                log_debug("Image brief came back empty", surface=surface, attempt=attempt,
+                          ai_model="lem-medium", reason=reason)
+                continue
+            parsed = json.loads(raw)
             if _valid(parsed):
                 return ImageBrief(prompt=str(parsed["prompt"]).strip(), ratio=ratio,
                                   surface=surface, style_preset=preset,
                                   focal_concept=str(parsed["focal_concept"]).strip())
+            reason = "failed validation (length bounds or refusal phrasing)"
             log_debug("Image brief failed validation — retrying", surface=surface,
                       attempt=attempt, ai_model="lem-medium")
         except Exception as e:
             # One condition, ONE warning: the fallback below carries it — per-attempt noise
             # would double-file the same fault with the escalation cron.
+            reason = f"{type(e).__name__}: {e}"[:120]
             log_debug("Image brief attempt failed", error=str(e), ai_model="lem-medium",
                       attempt=attempt)
+    # Carry WHY on the warning: this fell back on every generation for weeks and the message
+    # alone gave no way to tell an outage from an empty response from a validation reject.
     log_warning("Image brief fell back to the deterministic template", surface=surface,
-                action_type="image_brief")
+                action_type="image_brief", reason=reason)
     return _fallback_brief(content, surface=surface, ratio=ratio, context=context)

--- a/tests/unit/utilities/ai/test_image_brief.py
+++ b/tests/unit/utilities/ai/test_image_brief.py
@@ -106,3 +106,39 @@ class TestRefusalFilterIsAnchoredToRefusals:
                    return_value=_resp({"focal_concept": "n/a", "prompt": refusal * 2})):
             brief = build_image_brief("some content", surface="post_image")
         assert refusal not in brief.prompt
+
+
+@pytest.mark.unit
+class TestReasoningTokenBudget:
+    """Regression: lem-medium is a REASONING model. At max_tokens=600 the whole budget went to
+    thinking tokens, the response came back EMPTY with finish_reason='length', and every image
+    silently rendered from the deterministic template."""
+
+    def test_budget_leaves_room_for_reasoning_plus_json(self):
+        from cqc_lem.utilities.ai.image_brief import _BRIEF_MAX_TOKENS
+        # A real brief measured ~870 completion tokens including reasoning.
+        assert _BRIEF_MAX_TOKENS >= 2000
+
+    def test_the_budget_is_what_is_actually_sent(self):
+        from cqc_lem.utilities.ai.image_brief import _BRIEF_MAX_TOKENS
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_resp(_GOOD)) as llm:
+            build_image_brief("content", surface="post_image")
+        assert llm.call_args[1]["max_tokens"] == _BRIEF_MAX_TOKENS
+
+    def test_an_empty_response_retries_rather_than_crashing(self):
+        empty = SimpleNamespace(choices=[SimpleNamespace(
+            message=SimpleNamespace(content=""), finish_reason="length")])
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
+                   side_effect=[empty, _resp(_GOOD)]) as llm:
+            brief = build_image_brief("content", surface="post_image")
+        assert llm.call_count == 2
+        assert brief.prompt == _GOOD["prompt"], "a retry that succeeds must not fall back"
+
+    def test_the_fallback_warning_says_why(self):
+        empty = SimpleNamespace(choices=[SimpleNamespace(
+            message=SimpleNamespace(content=""), finish_reason="length")])
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=empty), \
+             patch("cqc_lem.utilities.ai.image_brief.log_warning") as warn:
+            build_image_brief("content", surface="post_image")
+        reason = warn.call_args[1].get("reason", "")
+        assert "empty response" in reason and "length" in reason


### PR DESCRIPTION
Third defect found smoke-testing the image overhaul in production, and the one that was silently neutering the whole feature.

## What was happening

`lem-medium` is served by **deepseek-v4-flash, a reasoning model**. Its thinking tokens are billed against `max_tokens` *before* any content is emitted. At `max_tokens=600` the budget was consumed entirely by reasoning, so the response came back **empty** with `finish_reason='length'` — not malformed, not a refusal, just nothing.

That failed validation, the retry failed identically, and the brief fell back to the deterministic template. Which means **every image was rendering from the bland fallback prompt** — the exact generic output the brief engine was built to eliminate.

Measured in prod against post #79:

| max_tokens | finish_reason | content length | valid |
|---|---|---|---|
| 600 | `length` | 0 | ✗ (4/4 runs) |
| 2500 | `stop` | 718 | ✓ (3/3 runs) |

A real brief costs **~870 completion tokens including reasoning**, so 600 could never have worked. Budget is now 2500, leaving headroom for a longer brief.

## Why it stayed hidden

The fallback is a *working code path* — it returns a usable prompt, so nothing errored. Its warning said only "fell back to the deterministic template", with no way to distinguish an outage from an empty response from a validation reject. The warning now carries `reason=` (e.g. `empty response (finish_reason=length)`), and an empty response is detected explicitly rather than dying inside `json.loads`.

## Note for future model swaps

Any tier that may be served by a reasoning model needs its `max_tokens` sized for **reasoning + output**, not output alone. The avatar relevance classifier was checked for the same trap and is fine — `lem-simple` is not a reasoning model and returns valid JSON at `max_tokens=30`.

## Tests

9,630 green, including: the budget is ≥2000 and is what's actually sent, an empty response retries instead of falling straight through, and the fallback warning states why.

Labelled `release:now`: every generated image in production is currently using the fallback prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)