### PR TITLE
fix(images): a stranger's face is the stock-photo look, not the fix for it

### DIFF
--- a/src/cqc_lem/utilities/ai/image_brief.py
+++ b/src/cqc_lem/utilities/ai/image_brief.py
@@ -69,6 +69,17 @@ Respond with ONLY a JSON object:
 _BANNED_FRAGMENTS = ("i'm sorry", "i am sorry", "i cannot", "i can't", "i am unable",
                      "as an ai", "cannot fulfill", "cannot generate", "unable to generate")
 
+# Added only when the author's own likeness is NOT being rendered. Without it the brief asks for
+# "a confident business professional", the renderer supplies an anonymous model, and the result is
+# indistinguishable from the stock photography this engine exists to replace — on a PERSONAL-brand
+# newsletter a stranger's face is worse than no face. With an avatar, a person IS the point.
+_NO_ANONYMOUS_PERSON = (
+    "The author's likeness is NOT available for this image, so do NOT make an anonymous person the "
+    "focal subject — a generic model standing in an office is exactly the stock-photo look to "
+    "avoid. Build the image around a tangible object, a specific environment, or a close-up of "
+    "hands mid-action instead. People may appear incidentally, out of focus or from behind, but "
+    "never as an identifiable face carrying the frame.\n")
+
 _MIN_PROMPT_CHARS = 60
 _MAX_PROMPT_CHARS = 2400
 
@@ -127,6 +138,7 @@ def build_image_brief(content: str, *, surface: str, ratio: str = "1:1",
     user_prompt = (
         f"{context}{_STYLE_PRESETS[preset]}\n\n"
         f"Compose for a {ratio} aspect ratio.\n"
+        + ("" if avatar else _NO_ANONYMOUS_PERSON)
         + (f"Additional direction: {extra_direction}\n" if extra_direction else "")
         + f"\nHere is the content the image must represent:\n<content>{content}</content>")
 

--- a/tests/unit/utilities/ai/test_image_brief.py
+++ b/tests/unit/utilities/ai/test_image_brief.py
@@ -142,3 +142,23 @@ class TestReasoningTokenBudget:
             build_image_brief("content", surface="post_image")
         reason = warn.call_args[1].get("reason", "")
         assert "empty response" in reason and "length" in reason
+
+
+@pytest.mark.unit
+class TestAnonymousPersonSteer:
+    """A stranger's face on a PERSONAL-brand newsletter is the stock-photo look the engine
+    exists to replace; with the author's own likeness, a person IS the point."""
+
+    def test_no_avatar_steers_away_from_an_anonymous_face(self):
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_resp(_GOOD)) as llm:
+            build_image_brief("content", surface="newsletter", avatar=None)
+        user_msg = llm.call_args[1]["messages"][1]["content"]
+        assert "do NOT make an anonymous person the focal subject" in user_msg
+
+    def test_with_an_avatar_the_person_is_still_the_point(self):
+        avatar = {"gender_presentation": "man", "age_band": "40s", "trigger_word": "TOK"}
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_resp(_GOOD)) as llm:
+            build_image_brief("content", surface="newsletter", avatar=avatar)
+        user_msg = llm.call_args[1]["messages"][1]["content"]
+        assert "anonymous person" not in user_msg
+        assert "it IS the author" in user_msg


### PR DESCRIPTION
Last quality gap from the production smoke test, and the closest one to the owner's original words ("doesn't generate a relevant captivating picture").

## What I saw

With the earlier fixes live, edition 5's cover regenerated cleanly — correct 16:9, no trademark, on-theme — and still came back as **an anonymous woman in a blazer standing in an office**. The brief had asked for "a confident business professional… making direct eye contact", and gpt-image-2 obliged with a stock model.

That is the same failure the overhaul set out to remove, wearing a better outfit. On a **personal-brand** newsletter a stranger's face is worse than no face: it reads as filler, and it is not the author.

## The change

When the author's likeness is **not** being rendered (no approved avatar, surface opt-in off, or the relevance classifier declined), the brief now steers to a tangible object, a specific environment, or a close-up of hands mid-action. People may still appear incidentally — out of focus or from behind — but never as an identifiable face carrying the frame.

When an avatar **is** in play, none of this applies: a person is precisely the point, and the existing #744 subject clause still leads the prompt.

## Note

This is a taste call rather than a defect, so it is one named constant (`_NO_ANONYMOUS_PERSON`) in the ONE brief engine — trivially reversible if the owner prefers faces on non-avatar covers.

9,636 unit tests green, including both directions of the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)