### PR TITLE
feat(images): encode the FLUX prompting research into the ONE brief engine

### DIFF
--- a/src/cqc_lem/utilities/ai/image_brief.py
+++ b/src/cqc_lem/utilities/ai/image_brief.py
@@ -15,51 +15,66 @@ from typing import Optional
 
 from cqc_lem.utilities.logger import log_debug, log_warning
 
-# Per-surface art direction. Composition/lighting fundamentals live in the system prompt; a
-# preset only says what THIS surface is for.
+# Per-surface art direction. The photographic fundamentals (order, lighting, camera, realism
+# texture) live in the system prompt; a preset only says what THIS surface is for.
 _STYLE_PRESETS: dict[str, str] = {
     "newsletter": (
-        "A cinematic, editorial magazine-cover-worthy WIDE scene for a LinkedIn newsletter "
-        "edition. It must telegraph the edition's core idea at thumbnail size — bold, "
-        "atmospheric, instantly readable."),
+        "A wide editorial photograph for a LinkedIn newsletter cover. One bold scene drawn from "
+        "the edition's core idea, readable at thumbnail size, with environmental depth."),
     "post_image": (
-        "A scroll-stopping single-subject image for a LinkedIn feed post. One person or "
-        "tangible object central to the post's message, strong color accent, credible and "
-        "professional."),
+        "A scroll-stopping single-subject photograph for a LinkedIn feed post. One person or "
+        "tangible object central to the post's message, one strong color accent."),
     "carousel": (
-        "A clean supporting visual for ONE carousel slide's single idea. Simple, uncluttered "
-        "background that a text panel can sit beside — the image reinforces, never competes."),
+        "A quiet supporting photograph for ONE carousel slide's single idea. Simple, "
+        "uncluttered background a text panel can sit beside — it reinforces, never competes."),
     "video": (
-        "A photorealistic opening frame for a short professional video. A person or subject "
-        "positioned to come alive with subtle motion, cinematic depth."),
+        "An opening frame for a short professional video: a person or subject posed so subtle "
+        "motion can bring the frame alive, with layered foreground and background depth."),
     "thumbnail": (
         "A clean, flat product-tutorial thumbnail illustration. Calm palette, simple shapes, "
         "one clear subject."),
 }
 _DEFAULT_PRESET = "post_image"
 
-_SYSTEM_PROMPT = """Act as a world-class commercial visual director creating scroll-stopping
-LinkedIn imagery. You turn written content into a brief for a professional photoshoot.
+# Encodes the BFL/Replicate/fal prompting research (2026): subject-first ordering, 40-80 word
+# flowing prose, concrete camera/lighting vocabulary instead of generic quality tags, positive
+# phrasing only (FLUX has no negative prompts — naming a thing summons it), and skin texture
+# rules that kill the AI sheen. Written to hold for BOTH FLUX.1 LoRA renders and FLUX.2/gpt-image.
+_SYSTEM_PROMPT = """Act as a professional photographer writing the brief for ONE real photograph
+of LinkedIn visual content. You turn written content into a single render-ready prompt.
 
-### Required qualities
-- ONE clear focal subject in the foreground, drawn from the content's actual message — never
-  generic office stock. When a person is present, they make confident eye contact with the
-  camera.
-- Attention-drawing composition: strong foreground/background separation, shallow depth of
-  field, a bold high-contrast color accent that pops in a busy feed.
-- Professional & on-brand: modern, clean, credible for the author's stated industry.
-  Photorealistic by default; tasteful editorial illustration only when it clearly fits.
-- Specific and grounded — not abstract, surreal, or symbolic clip-art.
+### Write the prompt in this order (earlier = more weight)
+1. SUBJECT and its action or pose — drawn from the content's actual message, never generic
+   office stock. 2. SETTING. 3. COMPOSITION and framing (rule of thirds, eye-level, medium
+   shot, negative space — phrased to suit the requested aspect ratio). 4. LIGHTING, precisely
+   named — this has the highest impact ("soft window light from camera left with natural
+   fill", "golden hour rim light", "large softbox key 45 degrees camera left"). 5. CAMERA:
+   one body, one focal length, one aperture ("shot on Sony A7R IV, 85mm f/1.8, ISO 200").
+   6. FINISH: film stock or color grade, plus controlled imperfection ("Kodak Portra 400
+   tones, subtle film grain, tactile materials").
 
-### Hard constraints
-- NO text, letters, words, numbers, logos, watermarks, captions, charts, or UI anywhere in the
-  image — generators render these as garbled artifacts.
-- No collages, split screens, or busy montages — one cohesive scene.
+### Hard rules
+- ONE flowing natural-language paragraph of 40-80 words. No keyword stacking, no weight
+  syntax, no quotation marks inside the prompt.
+- Specificity IS realism. Never lean on generic tags — "photorealistic", "cinematic", "8k",
+  "masterpiece", "ultra-detailed" are dead words; concrete gear, named lighting and tactile
+  texture do that work.
+- Photography vocabulary only. A single word like illustration, painting, render, CGI,
+  artstation or stock photo drags the image away from a photograph.
+- The renderer ignores negation, so never write "no X" or "without X" — and NEVER mention
+  text, letters, numbers, logos, watermarks, brands, charts, or UI at all: naming them
+  summons them, garbled. Describe surfaces positively instead: plain unbranded clothing,
+  blank screens, clean unmarked walls.
+- One cohesive scene — no collages or split screens.
+- When a person appears: face clearly visible and well-lit; describe wardrobe, expression
+  and pose, never facial features beyond what the context already declares (identity is
+  supplied separately and must not be contradicted). Give them natural skin texture with
+  visible pores and realistic uneven skin tone — never flawless, porcelain, or smooth skin.
 
 ### Output
 Respond with ONLY a JSON object:
 {"focal_concept": "<the one idea the image depicts, under 20 words>",
- "prompt": "<one richly descriptive render-ready paragraph: scene, subject, setting, lighting, color>"}"""
+ "prompt": "<the photograph brief, one 40-80 word paragraph>"}"""
 
 # A refusal or meta-answer leaking into a render prompt produces surreal garbage. Anchored to
 # refusal PHRASING on purpose: a bare "language model" entry here rejected every legitimate brief
@@ -114,10 +129,12 @@ def _fallback_brief(content: str, *, surface: str, ratio: str, context: str) -> 
     """Deterministic last resort when the brief author is down — bland beats broken."""
     summary = " ".join((content or "").split())[:300]
     direction = _STYLE_PRESETS.get(surface, _STYLE_PRESETS[_DEFAULT_PRESET])
-    prompt = (f"{context}{direction} A single photorealistic, professional scene representing: "
-              f"{summary}. One clear focal subject, shallow depth of field, natural lighting, "
-              f"bold color accent, composed for a {ratio} aspect ratio. No text, letters, "
-              f"logos, watermarks, charts, or UI anywhere in the image.")
+    # Positive phrasing throughout — FLUX ignores negation, so "no logos" summons logos.
+    prompt = (f"{context}{direction} A single professional photograph representing: "
+              f"{summary}. One clear focal subject, eye-level medium shot composed for a "
+              f"{ratio} aspect ratio, shallow depth of field, soft window light with natural "
+              f"fill, shot on an 85mm lens at f/1.8, subtle film grain, plain unbranded "
+              f"clothing and surfaces, blank screens, clean unmarked walls.")
     return ImageBrief(prompt=prompt, ratio=ratio, surface=surface,
                       style_preset=surface if surface in _STYLE_PRESETS else _DEFAULT_PRESET,
                       focal_concept=summary[:120] or "professional LinkedIn visual")

--- a/src/cqc_lem/utilities/ai/image_gen.py
+++ b/src/cqc_lem/utilities/ai/image_gen.py
@@ -49,14 +49,24 @@ _GENERATED_SUBDIR = os.path.join("images", "generated")
 # entirely on its own, and the two covers it did that to both reached review carrying someone
 # else's trademark. Belongs here rather than in the brief so a hand-written or retried prompt
 # cannot lose it.
-_NO_MARKS_SUFFIX = (" Absolutely no text, letters, words, numbers, captions, watermarks, logos, "
-                    "brand marks, app icons, social-media icons, charts, or UI elements anywhere "
-                    "in the image.")
+#
+# BACKEND-AWARE on purpose (BFL prompting docs): gpt-image is instruction-following, so an
+# explicit prohibition works. FLUX has no negative prompting and largely ignores negation —
+# naming "logos" in a FLUX prompt can SUMMON one — so FLUX renders get the same constraint
+# phrased positively instead.
+_NO_MARKS_GPT = (" Absolutely no text, letters, words, numbers, captions, watermarks, logos, "
+                 "brand marks, app icons, social-media icons, charts, or UI elements anywhere "
+                 "in the image.")
+_NO_MARKS_FLUX = (" Every garment and surface is plain and unbranded, screens are blank, walls "
+                  "clean and unmarked.")
 
 
-def with_no_marks(prompt: str) -> str:
-    """The render prompt plus the no-marks constraint, added at most once."""
-    return prompt if _NO_MARKS_SUFFIX in prompt else f"{prompt}{_NO_MARKS_SUFFIX}"
+def with_no_marks(prompt: str, backend: str = "gpt-image") -> str:
+    """The render prompt plus the no-marks constraint for that backend, added at most once."""
+    suffix = _NO_MARKS_FLUX if backend == "flux" else _NO_MARKS_GPT
+    if _NO_MARKS_GPT in prompt or _NO_MARKS_FLUX in prompt:
+        return prompt
+    return f"{prompt}{suffix}"
 
 
 @dataclass
@@ -162,7 +172,6 @@ def render_image_from_prompt(prompt: str, *, ratio: str = "1:1",
     Never renders a likeness — callers that may include the author go through
     ``generate_post_image`` so the avatar guardrails stay the single decision point.
     """
-    prompt = with_no_marks(prompt)
     backend = (IMAGE_BACKEND or "auto").strip().lower()
     if backend not in ("auto", "gpt-image", "flux"):
         log_warning(f"Unknown IMAGE_BACKEND '{backend}' — using auto")
@@ -170,14 +179,15 @@ def render_image_from_prompt(prompt: str, *, ratio: str = "1:1",
 
     if backend in ("auto", "gpt-image"):
         try:
-            return _render_via_gpt_image(prompt, ratio=ratio, quality=quality,
-                                         user_id=user_id, post_id=post_id)
+            return _render_via_gpt_image(with_no_marks(prompt, "gpt-image"), ratio=ratio,
+                                         quality=quality, user_id=user_id, post_id=post_id)
         except Exception as e:
             if backend == "gpt-image":
                 raise
             log_warning("gpt-image render failed — falling back to FLUX", exc=e,
                         user_id=user_id, post_id=post_id, api_provider="openai")
-    return _render_via_flux(prompt, ratio=ratio, image_model=image_model, user_id=user_id)
+    return _render_via_flux(with_no_marks(prompt, "flux"), ratio=ratio,
+                            image_model=image_model, user_id=user_id)
 
 
 _VISION_GATE_PROMPT = """You are grading ONE AI-generated image intended as professional \
@@ -248,8 +258,8 @@ def render_avatar_image_gated(prompt: str, *, avatar: dict, user_id: Optional[in
 
     for attempt in range(1, attempts + 1):
         # The likeness path talks to Replicate directly, so it never passes through
-        # render_image_from_prompt where the constraint is otherwise added.
-        marked = with_no_marks(current_prompt)
+        # render_image_from_prompt where the constraint is otherwise added. Always FLUX.
+        marked = with_no_marks(current_prompt, "flux")
         path, used_avatar = generate_image_with_avatar(
             apply_subject_clause(marked, avatar), avatar["model_ref"],
             ratio=ratio, fallback_prompt=marked)

--- a/tests/unit/utilities/ai/test_ai_helper_media.py
+++ b/tests/unit/utilities/ai/test_ai_helper_media.py
@@ -42,7 +42,8 @@ class TestFluxImagePrompt:
             assert create.call_args[1]["model"] == "lem-medium"
             assert "Software Engineer" in _user_text(create)
             sys = _system_text(create)
-            assert "NO text" in sys  # the no-garbled-text constraint
+            # The author must never NAME text/logos in a render prompt — positive phrasing rule.
+            assert "NEVER mention" in sys and "logos" in sys
 
     def test_works_without_profile(self, mock_openai_client):
         with patch("cqc_lem.utilities.ai.ai_helper.client", mock_openai_client):

--- a/tests/unit/utilities/ai/test_image_brief.py
+++ b/tests/unit/utilities/ai/test_image_brief.py
@@ -37,10 +37,14 @@ class TestBuildImageBrief:
         assert "My post about growth" in user_msg
 
     def test_no_text_constraint_is_always_in_the_system_prompt(self):
+        """The author must never NAME text/logos in a render prompt (FLUX summons what is
+        named) — the system prompt instructs positive phrasing instead."""
         with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_resp(_GOOD)) as llm:
             build_image_brief("content", surface="post_image")
         system_msg = llm.call_args[1]["messages"][0]["content"]
-        assert "NO text, letters, words, numbers, logos" in system_msg
+        assert "NEVER mention" in system_msg
+        assert "logos" in system_msg and "watermarks" in system_msg
+        assert "plain unbranded clothing" in system_msg
 
     def test_invalid_json_retries_then_falls_back_deterministically(self):
         with patch("cqc_lem.utilities.ai.ai_helper._call_llm",
@@ -49,7 +53,8 @@ class TestBuildImageBrief:
 
         assert llm.call_count == 2
         assert "Quarterly revenue lessons" in brief.prompt
-        assert "No text" in brief.prompt
+        # Positive phrasing only — FLUX ignores negation, so the fallback never says "No text".
+        assert "plain unbranded" in brief.prompt
         assert brief.focal_concept  # never empty
 
     def test_refusal_text_is_rejected(self):

--- a/tests/unit/utilities/ai/test_image_gen.py
+++ b/tests/unit/utilities/ai/test_image_gen.py
@@ -171,13 +171,17 @@ class TestNoBrandMarksConstraint:
         sent = gpt.call_args[0][0]
         assert "logos" in sent and "brand marks" in sent
 
-    def test_flux_fallback_keeps_the_constraint(self):
+    def test_flux_fallback_gets_the_positive_phrasing(self):
+        """FLUX ignores negation — naming 'logos' can summon one — so the FLUX path carries
+        the constraint phrased positively, never as a prohibition."""
         with patch.object(image_gen, "_render_via_gpt_image", side_effect=RuntimeError("down")), \
              patch.object(image_gen, "_render_via_flux", return_value="/tmp/f.webp") as flux:
             image_gen.render_image_from_prompt("a founder at a desk", user_id=3)
-        assert "brand marks" in flux.call_args[0][0]
+        sent = flux.call_args[0][0]
+        assert "plain and unbranded" in sent
+        assert "logos" not in sent and "brand marks" not in sent
 
-    def test_avatar_render_carries_it_too(self):
+    def test_avatar_render_carries_the_flux_phrasing_too(self):
         avatar = {"model_ref": "owner/lora:v1", "trigger_word": "TOK",
                   "gender_presentation": "man", "age_band": "40s"}
         with patch("cqc_lem.utilities.avatar.replicate_avatar.generate_image_with_avatar",
@@ -187,10 +191,14 @@ class TestNoBrandMarksConstraint:
                           return_value=QualityVerdict(acceptable=True)):
             image_gen.render_avatar_image_gated("a founder at a desk", avatar=avatar, user_id=3,
                                                 surface="post_image")
-        assert "brand marks" in lora.call_args[0][0]
+        assert "plain and unbranded" in lora.call_args[0][0]
         # The fallback prompt must carry it as well — that render is still published.
-        assert "brand marks" in lora.call_args[1]["fallback_prompt"]
+        assert "plain and unbranded" in lora.call_args[1]["fallback_prompt"]
 
-    def test_constraint_is_never_doubled(self):
-        once = image_gen.with_no_marks("scene")
-        assert image_gen.with_no_marks(once) == once
+    def test_constraint_is_never_doubled_and_never_mixed(self):
+        once_gpt = image_gen.with_no_marks("scene", "gpt-image")
+        assert image_gen.with_no_marks(once_gpt, "gpt-image") == once_gpt
+        # A prompt already carrying one variant never gains the other.
+        assert image_gen.with_no_marks(once_gpt, "flux") == once_gpt
+        once_flux = image_gen.with_no_marks("scene", "flux")
+        assert image_gen.with_no_marks(once_flux, "gpt-image") == once_flux


### PR DESCRIPTION
Implements the researched FLUX.1 + FLUX.2 shared prompt style guide in the brief engine, so every surface (covers, post images, carousel slides, video frames) authors prompts the way the model families actually respond to.

Sources cross-checked: BFL's official FLUX.2 prompting guide + photorealistic use-case guide + unified reference sheet, Replicate's fine-tune-flux-with-faces guide, getimg.ai/PixelDojo/Apatero 2026 analyses, and current skin-realism guides.

What changed:
- **System prompt rewrite**: subject-first ordering, 40–80 word flowing prose, named lighting setups + concrete camera/lens/aperture instead of generic quality tags ("photorealistic"/"8k" are dead words on FLUX.2 and neutral on FLUX.1), controlled imperfection vocabulary (visible pores, film grain, tactile materials) to kill the AI sheen, and a ban on art-drift vocabulary (illustration/render/CGI/stock photo).
- **Positive phrasing only**: FLUX has no negative prompts and largely ignores negation — naming "logos" can summon one. The author never mentions text/logos/brands at all; surfaces are described as "plain unbranded", screens "blank". The renderer-level no-marks constraint became backend-aware: gpt-image (instruction-following) keeps the explicit prohibition that stopped the LinkedIn-logo incident; FLUX renders get the positive form.
- **Portrait rules**: describe wardrobe/expression/pose, never facial features beyond the declared identity clause (prevents the "clean-shaven face" contradiction seen in prod); "natural skin texture with visible pores", never "flawless".
- Deterministic fallback brief rewritten to the same style.

9,636 unit tests green; the brief/no-marks tests updated to the new contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)