### PR TITLE
fix(images): steer hands low-risk in the brief; gate inspects fingers closely

### DIFF
--- a/src/cqc_lem/utilities/ai/image_brief.py
+++ b/src/cqc_lem/utilities/ai/image_brief.py
@@ -70,6 +70,11 @@ of LinkedIn visual content. You turn written content into a single render-ready 
   and pose, never facial features beyond what the context already declares (identity is
   supplied separately and must not be contradicted). Give them natural skin texture with
   visible pores and realistic uneven skin tone — never flawless, porcelain, or smooth skin.
+- HANDS are the renderer's weakest anatomy — keep them low-risk or out of frame. Good: arms
+  relaxed at the sides, hands resting flat on a desk, framed above the waist, one hand
+  loosely holding a simple large object (a mug, a notebook). Never: pointing at the camera,
+  open-palm gestures mid-air, interlocked or spread fingers, two hands interacting, or
+  hands as the focal point.
 
 ### Output
 Respond with ONLY a JSON object:

--- a/src/cqc_lem/utilities/ai/image_gen.py
+++ b/src/cqc_lem/utilities/ai/image_gen.py
@@ -198,7 +198,8 @@ Grade it strictly. Respond with ONLY a JSON object:
 
 Mark it unacceptable when ANY of these hold:
 - garbled or misspelled text, distorted letters, or gibberish writing anywhere
-- deformed anatomy (hands, faces, limbs) or uncanny distorted objects
+- deformed anatomy or uncanny distorted objects — inspect HANDS closely: wrong finger
+  count, fused or bent-back fingers, mangled knuckles, or a hand merging into an object
 - the image does not plausibly relate to the stated subject (relevance 1-2)
 - watermarks, logos, or UI chrome
 - it looks like generic meaningless abstract filler rather than a composed scene

--- a/tests/unit/utilities/ai/test_image_brief.py
+++ b/tests/unit/utilities/ai/test_image_brief.py
@@ -167,3 +167,17 @@ class TestAnonymousPersonSteer:
         user_msg = llm.call_args[1]["messages"][1]["content"]
         assert "anonymous person" not in user_msg
         assert "it IS the author" in user_msg
+
+
+@pytest.mark.unit
+class TestHandsGuidance:
+    """Owner verdict after the Aug 2026 bake-off: FLUX.1 stays; its one quality gap is hands.
+    The brief must steer toward low-risk hand positions and never complex gestures."""
+
+    def test_system_prompt_steers_hands_low_risk(self):
+        with patch("cqc_lem.utilities.ai.ai_helper._call_llm", return_value=_resp(_GOOD)) as llm:
+            build_image_brief("content", surface="post_image")
+        sys_msg = llm.call_args[1]["messages"][0]["content"]
+        assert "HANDS" in sys_msg
+        assert "out of frame" in sys_msg
+        assert "interlocked" in sys_msg  # the banned gesture class is named


### PR DESCRIPTION
Follow-up to the avatar bake-off decision: the owner is staying on the FLUX.1 LoRA (likeness consistency won; FLUX.2 klein would also add a fal serving dependency), and named **hand rendering** as the one remaining quality issue.

Two-sided fix, both in the ONE engine:

1. **Prompt side** — the brief author now writes hands the way FLUX.1 can actually render them: relaxed at sides, flat on a desk, framed above the waist, or loosely holding one simple large object; never pointing at the camera, mid-air open-palm gestures, interlocked/spread fingers, or two hands interacting. (Our own bake-off prompt "mid-gesture with open palms" was exactly the kind of ask that produces mangled fingers.)

2. **Gate side** — the vision check's anatomy line now names the concrete hand failure modes (wrong finger count, fused/bent-back fingers, hand merging into an object), so a bad hand is a rejection that triggers the bounded regenerate rather than something that ships.

9,698 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)