### PR TITLE
feat(agent-pipeline): phase-guard holds route to MODE=phasefix instead of the owner

### DIFF
--- a/docs/AGENT_WORKFLOW_PLAYBOOK.md
+++ b/docs/AGENT_WORKFLOW_PLAYBOOK.md
@@ -30,6 +30,7 @@ it. **An issue without `agent:ready` does not exist to the pipeline.**
 | `agent:revise` | (PR) Owner requested changes / answered a Decision Comment | Runner |
 | `agent:blocked` | Held after escalation; runner skips it | Runner/agent |
 | `agent:depfix` | (PR) Dependabot PR with failing CI, priority fix lane | CI router |
+| `agent:phasefix` | (PR) Phase-guard hold: agent files/links the follow-up for a multi-phase close | Runner |
 | `needs-human` | Waiting on a human decision or human-only action | Agent (on escalation) or human |
 
 ### Priority (queue order within the ready pool)
@@ -114,9 +115,12 @@ this issue / stretch*. If anything remains, do one of exactly two things:
 2. **Drop `Closes #N`** — write "Remaining on #N: …" instead and leave the issue open.
 
 The pipeline enforces this at the merge gate: a PR whose closed issue declares a later phase with no
-linked follow-up is **not merged**. It gets a `🧩 phase-guard` comment, `needs-human` +
-`agent:blocked`, and the owner is assigned. Unchecked boxes alone only produce a warning comment —
-so tick the boxes you actually satisfied, and don't leave a phase living in prose.
+linked follow-up is **not merged**. It gets a `🧩 phase-guard` comment and is routed to
+**MODE=phasefix** (`agent:phasefix`): an agent files + links the follow-up issue itself and hands the
+PR back to the merge loop — filing the follow-up is mechanical, not a human decision. The owner is
+assigned (`needs-human` + `agent:blocked`) only after two failed phasefix passes. Unchecked boxes
+alone only produce a warning comment — so tick the boxes you actually satisfied, and don't leave a
+phase living in prose.
 
 Clearing the hold is a two-part manual step — the guard **strips `agent:working`**, and a PR without
 it is invisible to the merge loop no matter how you fixed the scope. So do one of the two above,

--- a/scripts/agent-pipeline/RUNBOOK.md
+++ b/scripts/agent-pipeline/RUNBOOK.md
@@ -53,9 +53,10 @@ Before you open (or merge) a PR that closes an issue:
 4. **Never** leave a later phase living only in prose. If it isn't an issue, it doesn't exist.
 
 `tick.sh` enforces this at the merge gate (`phase_guard_ok`): a PR whose closed issue declares a later
-phase with no linked follow-up is **not merged** — it gets a `🧩 phase-guard` comment, `needs-human` +
-`agent:blocked`, and the owner is assigned. Unchecked boxes alone only produce a warning comment, so
-clear them honestly. Clearing a hold = do (a) or (b), then re-label the PR `agent:working`.
+phase with no linked follow-up is **not merged** — it gets a `🧩 phase-guard` comment and is routed to
+**MODE=phasefix** (label `agent:phasefix`), where an agent files + links the follow-up itself. Filing
+the follow-up is mechanical, NOT a human decision — the owner is assigned only after the agent has
+failed twice. Unchecked boxes alone only produce a warning comment, so clear them honestly.
 
 The guard fires on what a PR **closes** (`closing_issue_for_pr` — GitHub's development link, or a
 `Closes #N` keyword), never on the `feature/claude-issue-N` branch name. So the intended way to land
@@ -275,6 +276,26 @@ Rebase it cleanly onto current `main`:
 5. `git push --force-with-lease` (re-triggers CI + a fresh Copilot review). STOP.
 6. If the conflicts are too complex to resolve safely, escalate:
    `gh pr edit $PR --add-label needs-human --add-assignee gitchrisqueen`, comment exactly what conflicts, STOP.
+
+## MODE=phasefix  (env: PR, ISSUE, WORKTREE, BRANCH)
+The merge gate held PR #$PR: it closes issue #$ISSUE, whose body declares work beyond this PR, and no
+follow-up is linked. This is MECHANICAL — resolve it yourself, do NOT ask the owner. Deciding to
+finish an issue's stated requirements is never a human decision.
+1. Read issue #$ISSUE (body + comments) and the PR. Identify exactly what scope remains (unchecked
+   acceptance boxes, "Phase 2 / follow-up / deferred" prose).
+2. **Check the follow-up doesn't already exist** (`gh issue list --search`, and read the PR/issue
+   comments — someone may have filed it and said so). If it exists, just link it:
+   `Follow-up: #<n>` appended to the PR body (`gh pr edit $PR --body ...`) + a comment on #$ISSUE. Done — go to step 4.
+3. Otherwise prefer **(a) file the follow-up now**: title `<original title> — Phase N (follow-up of
+   #$ISSUE)`, quote the remaining scope from the original, give it REAL acceptance criteria, label it
+   topicals + `agent:ready` + a `priority:*` (+ `risk:*` if merge needs the owner — the hold belongs on
+   the FOLLOW-UP, never on this PR). Link it in **both** places: `Follow-up: #<new>` in the PR body and
+   a comment on #$ISSUE. Keep `Closes #$ISSUE`. Use **(b) drop the close** (remove `Closes #$ISSUE`
+   from the PR body, comment "Remaining on #$ISSUE: …") only when the remainder is too underspecified
+   to write honest acceptance criteria for.
+4. Hand the PR back to the merge loop: `gh pr edit $PR --add-label agent:working --remove-label agent:phasefix`. STOP.
+5. Escalate (`needs-human` + Decision Comment) ONLY if the remaining scope requires a genuine product
+   decision you cannot capture as an issue — that should be rare; when in doubt, file the issue.
 
 ---
 ## Model labels (`agent:model:*`)

--- a/scripts/agent-pipeline/RUNBOOK.md
+++ b/scripts/agent-pipeline/RUNBOOK.md
@@ -294,8 +294,11 @@ finish an issue's stated requirements is never a human decision.
    from the PR body, comment "Remaining on #$ISSUE: …") only when the remainder is too underspecified
    to write honest acceptance criteria for.
 4. Hand the PR back to the merge loop: `gh pr edit $PR --add-label agent:working --remove-label agent:phasefix`. STOP.
-5. Escalate (`needs-human` + Decision Comment) ONLY if the remaining scope requires a genuine product
-   decision you cannot capture as an issue — that should be rare; when in doubt, file the issue.
+5. Escalate ONLY if the remaining scope requires a genuine product decision you cannot capture as an
+   issue — that should be rare; when in doubt, file the issue. To escalate, drop the lane label too
+   or this lane keeps re-dispatching on top of the hold:
+   `gh pr edit $PR --add-label needs-human --add-label agent:blocked --remove-label agent:phasefix
+    --add-assignee gitchrisqueen`, then post a Decision Comment. STOP.
 
 ---
 ## Model labels (`agent:model:*`)

--- a/scripts/agent-pipeline/tick.sh
+++ b/scripts/agent-pipeline/tick.sh
@@ -27,6 +27,7 @@ RUNBOOK="$BASE/RUNBOOK.md"
 PAUSED="$BASE/PAUSED"
 LOCK="$BASE/lock"
 MAX_FIX_ATTEMPTS=4
+MAX_PHASEFIX_ATTEMPTS=2
 CLAUDE_TIMEOUT="45m"
 DRY_RUN="${DRY_RUN:-0}"
 
@@ -131,7 +132,7 @@ claim_branch() {  # $1=branch -> 0 claimed, 1 busy
 # posthog_capture is fire-and-forget and never breaks a tick.
 TICK_T0="$SECONDS"                       # wall-clock seconds since shell start
 TICK_OUTCOME="unknown"                   # dispatched | skipped | error | nothing_to_do
-TICK_REASON=""                           # free-form: "both_lanes_exhausted", "no_ready", "all_slots_busy", "paused", "all_prs_clean", "mode_start", "mode_fix", "mode_review", "mode_merge", "mode_selfreview", "mode_rebase", "mode_depfix", "mode_revise", "escalate"
+TICK_REASON=""                           # free-form: "both_lanes_exhausted", "no_ready", "all_slots_busy", "paused", "all_prs_clean", "mode_start", "mode_fix", "mode_review", "mode_merge", "mode_selfreview", "mode_rebase", "mode_depfix", "mode_revise", "mode_phasefix", "escalate"
 TICK_MODE=""                             # mode name if a Claude run was dispatched
 TICK_ISSUE=""                            # issue number dispatched
 TICK_PR=""                               # PR number processed
@@ -404,7 +405,9 @@ review_wait_expired() {  # $1=head-commit-iso-date -> 0 when the no-review fallb
 # #548 shipped "Phase 1" and its PR auto-closed the issue; Phase 2 was never filed and the work
 # silently vanished (same for #568, #647). Before ANY merge, read the issue the PR closes:
 #   * an EXPLICIT later phase ("Phase 2", "lands in a follow-up PR", "deferred to", …) with no
-#     linked follow-up  -> park the PR + escalate the issue, never merge it silently;
+#     linked follow-up  -> route the PR to MODE=phasefix (an agent files+links the follow-up
+#     itself — that is mechanical, not a human decision); only after MAX_PHASEFIX_ATTEMPTS
+#     failed agent passes does it park to the owner;
 #   * merely UNCHECKED acceptance boxes -> one warning comment, merge proceeds (acceptance lists
 #     in this repo are routinely left unticked, so parking on those alone would stall everything).
 # A "#N" sitting next to follow-up/phase wording — on the PR or in the issue's comments — counts as
@@ -443,7 +446,7 @@ phase_guard_ok() {  # $1=pr -> 0 when merging is safe (guard off / nothing close
   [ -n "$N" ] || return 0                      # closes nothing -> nothing can be dropped
   leftover="$(phase_leftover "$N")"
   [ -n "$leftover" ] || return 0
-  phase_followup_linked "$P" "$N" && return 0   # the remainder is already tracked
+  phase_followup_linked "$P" "$N" && { rm -f "$BASE/state/phasefix-$P.count"; return 0; }   # the remainder is already tracked
 
   # Unchecked boxes alone: warn once and let it merge — see the note above.
   case "$leftover" in
@@ -455,19 +458,30 @@ phase_guard_ok() {  # $1=pr -> 0 when merging is safe (guard off / nothing close
       return 0 ;;
   esac
 
-  # Explicit later phase with nothing tracking it: this is the #548 failure mode — hold it.
-  log "PHASE GUARD: PR #$P closes issue #$N which declares a later phase ($leftover) and no follow-up is linked — parking instead of merging."
-  if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would park PR #$P + escalate issue #$N (phase guard)."; return 1; fi
-  if ! gh pr view "$P" --repo "$SLUG" --json comments --jq '((.comments // [])[].body)' 2>/dev/null | grep -qF "$PHASE_GUARD_MARKER"; then
-    gh pr comment "$P" --repo "$SLUG" --body "$PHASE_GUARD_MARKER — **held before merge.** This PR closes issue #$N, whose body declares work beyond this PR ($leftover), and no follow-up issue is linked anywhere on this PR or that issue. Merging now would close #$N and drop that scope silently — exactly how #548 was lost.
-
-To clear this, do ONE of:
-1. File the follow-up issue (topical labels + \`agent:ready\` + a \`priority:\`) and link it here as \`Follow-up: #<n>\`, then re-label this PR \`agent:working\`; or
-2. Remove \`Closes #$N\` from the PR body, say what remains, and re-label this PR \`agent:working\` — the issue stays open.
-
-Assigning @$ASSIGNEE." >/dev/null 2>&1
+  # Explicit later phase with nothing tracking it: the #548 failure mode. Filing + linking the
+  # follow-up is MECHANICAL (the RUNBOOK's phased-work rule spells out exactly what to do), so it
+  # is NOT a human decision — route the PR to MODE=phasefix and let an agent clear it. The owner
+  # is only assigned after MAX_PHASEFIX_ATTEMPTS agent passes have failed to satisfy the guard.
+  local pf_file="$BASE/state/phasefix-$P.count" pf_cnt
+  pf_cnt="$(cat "$pf_file" 2>/dev/null || echo 0)"
+  if [ "${pf_cnt:-0}" -lt "$MAX_PHASEFIX_ATTEMPTS" ]; then
+    log "PHASE GUARD: PR #$P closes issue #$N with a later phase ($leftover) untracked — queuing MODE=phasefix (attempt $((pf_cnt+1))/$MAX_PHASEFIX_ATTEMPTS) instead of parking."
+    if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would label PR #$P agent:phasefix."; return 1; fi
+    echo "$((pf_cnt+1))" > "$pf_file"
+    if ! gh pr view "$P" --repo "$SLUG" --json comments --jq '((.comments // [])[].body)' 2>/dev/null | grep -qF "$PHASE_GUARD_MARKER"; then
+      gh pr comment "$P" --repo "$SLUG" --body "$PHASE_GUARD_MARKER — **held before merge.** This PR closes issue #$N, whose body declares work beyond this PR ($leftover), and no follow-up issue is linked. Queued for **MODE=phasefix**: an agent will file + link the follow-up issue (or drop the closing keyword) and hand the PR back to the merge loop — no owner action needed unless that fails." >/dev/null 2>&1
+    fi
+    gh pr edit "$P" --repo "$SLUG" --add-label agent:phasefix --remove-label agent:working >/dev/null 2>&1
+    return 1
   fi
-  gh pr edit "$P" --repo "$SLUG" --add-label needs-human --add-label agent:blocked --remove-label agent:working >/dev/null 2>&1
+
+  # The agent had its chances and the guard still fails — NOW it is the owner's.
+  log "PHASE GUARD: PR #$P still fails after $pf_cnt phasefix attempt(s) — parking to human."
+  if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would park PR #$P + escalate issue #$N (phase guard, autofix exhausted)."; return 1; fi
+  if ! gh pr view "$P" --repo "$SLUG" --json comments --jq '((.comments // [])[].body)' 2>/dev/null | grep -qF "phasefix exhausted"; then
+    gh pr comment "$P" --repo "$SLUG" --body "$PHASE_GUARD_MARKER — **phasefix exhausted** after $pf_cnt attempt(s); this PR closes issue #$N whose later phase ($leftover) is still untracked. To clear: file + link the follow-up as \`Follow-up: #<n>\` (or remove \`Closes #$N\`), then re-label \`agent:working\`. Assigning @$ASSIGNEE." >/dev/null 2>&1
+  fi
+  gh pr edit "$P" --repo "$SLUG" --add-label needs-human --add-label agent:blocked --remove-label agent:working --remove-label agent:phasefix >/dev/null 2>&1
   gh issue edit "$N" --repo "$SLUG" --add-label needs-human --add-assignee "$ASSIGNEE" >/dev/null 2>&1
   gh pr edit "$P" --repo "$SLUG" --add-assignee "$ASSIGNEE" >/dev/null 2>&1
   return 1
@@ -747,6 +761,28 @@ for MPR in $(gh pr list --repo "$SLUG" --state open --label "agent:working" \
   if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would fast-path merge #$MPR."; exit 0; fi
   gh pr merge --auto "$(gh pr view "$MPR" --repo "$SLUG" --json url --jq .url)" >/dev/null 2>&1 \
     && gh pr comment "$MPR" --repo "$SLUG" --body "✅ CI green, review satisfied & all threads resolved — merging (fast path)." >/dev/null 2>&1
+  exit 0
+done
+
+# ---- PHASEFIX LANE: the merge gate held a PR that closes a multi-phase issue with the remainder
+# untracked (label agent:phasefix). Filing + linking the follow-up is mechanical, so an agent does
+# it and hands the PR back to agent:working; the owner is only pulled in when phase_guard_ok gives
+# up (MAX_PHASEFIX_ATTEMPTS). Runs before revise: a phasefix hold blocks an otherwise-green merge.
+for FJSON in $(gh pr list --repo "$SLUG" --state open --label "agent:phasefix" \
+  --json number,headRefName --jq 'sort_by(.number)|.[]|@base64' 2>/dev/null); do
+  FPR="$(echo "$FJSON" | base64 -d | jq -r .number)"
+  FBR="$(echo "$FJSON" | base64 -d | jq -r .headRefName)"
+  if ! claim_branch "$FBR"; then
+    log "PR #$FPR (phasefix) claimed by another slot — trying next."
+    continue
+  fi
+  FISS="$(closing_issue_for_pr "$FPR")"
+  log "PR #$FPR — phase-guard hold — dispatching MODE=phasefix to file/link the follow-up (issue #${FISS:-?})."
+  TICK_OUTCOME="dispatched"; TICK_REASON="mode_phasefix"; TICK_MODE="phasefix"; TICK_PR="$FPR"; TICK_BRANCH="$FBR"
+  if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would run MODE=phasefix for #$FPR ($FBR)."; exit 0; fi
+  WT="$(add_worktree "$FBR" origin/main)"
+  export MODE=phasefix PR="$FPR" ISSUE="$FISS" BRANCH="$FBR" WORKTREE="$WT"
+  run_claude "$WT" "Read $RUNBOOK and follow MODE=phasefix. PR=$FPR ISSUE=$FISS BRANCH=$FBR."
   exit 0
 done
 

--- a/scripts/agent-pipeline/tick.sh
+++ b/scripts/agent-pipeline/tick.sh
@@ -49,7 +49,7 @@ export PATH="/home/lem/.local/bin:/usr/local/bin:/usr/bin:/bin"
 export HOME="/home/lem"
 export GH_PROMPT_DISABLED=1
 
-mkdir -p "$WORKROOT" "$LOGDIR" "$BASE/locks"
+mkdir -p "$WORKROOT" "$LOGDIR" "$BASE/locks" "$BASE/state"
 LOG="$LOGDIR/tick-$(date +%Y%m%d).log"
 log() { echo "[$(date '+%F %T')] $*" | tee -a "$LOG" ; }
 
@@ -436,6 +436,31 @@ phase_followup_linked() {  # $1=pr $2=issue -> 0 when a follow-up issue is alrea
   [ -n "$hit" ]
 }
 
+# Phasefix budget: ONE counter per PR, bumped where the SPEND happens (the phasefix lane, at
+# dispatch) and cleared the moment the guard passes. Counting holds instead of dispatches would not
+# bound anything: a MODE=phasefix run that dies — or escalates — without handing the PR back to
+# agent:working never reaches phase_guard_ok again, so the label (and the re-dispatch) would live
+# forever on a counter that never moves.
+phasefix_attempts() {  # $1=pr -> echoes the dispatch count (0 when unset/garbage)
+  local c; c="$(cat "$BASE/state/phasefix-$1.count" 2>/dev/null || echo 0)"
+  case "$c" in ''|*[!0-9]*) c=0 ;; esac
+  echo "$c"
+}
+phasefix_bump()  { echo "$(( $(phasefix_attempts "$1") + 1 ))" > "$BASE/state/phasefix-$1.count"; }
+phasefix_clear() { rm -f "$BASE/state/phasefix-$1.count"; }
+
+phase_park_to_human() {  # $1=pr $2=issue $3=leftover $4=attempts — the agent lane gave up
+  local P="$1" N="$2" leftover="$3" tries="$4"
+  log "PHASE GUARD: PR #$P still fails after $tries phasefix attempt(s) — parking to human."
+  if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would park PR #$P + escalate issue #$N (phase guard, autofix exhausted)."; return 0; fi
+  if ! gh pr view "$P" --repo "$SLUG" --json comments --jq '((.comments // [])[].body)' 2>/dev/null | grep -qF "phasefix exhausted"; then
+    gh pr comment "$P" --repo "$SLUG" --body "$PHASE_GUARD_MARKER — **phasefix exhausted** after $tries attempt(s); this PR closes issue #$N whose later phase ($leftover) is still untracked. To clear: file + link the follow-up as \`Follow-up: #<n>\` (or remove \`Closes #$N\`), then re-label \`agent:working\`. Assigning @$ASSIGNEE." >/dev/null 2>&1
+  fi
+  gh pr edit "$P" --repo "$SLUG" --add-label needs-human --add-label agent:blocked --remove-label agent:working --remove-label agent:phasefix >/dev/null 2>&1
+  gh issue edit "$N" --repo "$SLUG" --add-label needs-human --add-assignee "$ASSIGNEE" >/dev/null 2>&1
+  gh pr edit "$P" --repo "$SLUG" --add-assignee "$ASSIGNEE" >/dev/null 2>&1
+}
+
 phase_guard_ok() {  # $1=pr -> 0 when merging is safe (guard off / nothing closed / scope complete)
   [ "$PHASE_GUARD" = "1" ] || return 0
   local P="$1" N leftover
@@ -446,7 +471,7 @@ phase_guard_ok() {  # $1=pr -> 0 when merging is safe (guard off / nothing close
   [ -n "$N" ] || return 0                      # closes nothing -> nothing can be dropped
   leftover="$(phase_leftover "$N")"
   [ -n "$leftover" ] || return 0
-  phase_followup_linked "$P" "$N" && { rm -f "$BASE/state/phasefix-$P.count"; return 0; }   # the remainder is already tracked
+  phase_followup_linked "$P" "$N" && { phasefix_clear "$P"; return 0; }   # the remainder is already tracked
 
   # Unchecked boxes alone: warn once and let it merge — see the note above.
   case "$leftover" in
@@ -462,12 +487,11 @@ phase_guard_ok() {  # $1=pr -> 0 when merging is safe (guard off / nothing close
   # follow-up is MECHANICAL (the RUNBOOK's phased-work rule spells out exactly what to do), so it
   # is NOT a human decision — route the PR to MODE=phasefix and let an agent clear it. The owner
   # is only assigned after MAX_PHASEFIX_ATTEMPTS agent passes have failed to satisfy the guard.
-  local pf_file="$BASE/state/phasefix-$P.count" pf_cnt
-  pf_cnt="$(cat "$pf_file" 2>/dev/null || echo 0)"
-  if [ "${pf_cnt:-0}" -lt "$MAX_PHASEFIX_ATTEMPTS" ]; then
+  local pf_cnt
+  pf_cnt="$(phasefix_attempts "$P")"
+  if [ "$pf_cnt" -lt "$MAX_PHASEFIX_ATTEMPTS" ]; then
     log "PHASE GUARD: PR #$P closes issue #$N with a later phase ($leftover) untracked — queuing MODE=phasefix (attempt $((pf_cnt+1))/$MAX_PHASEFIX_ATTEMPTS) instead of parking."
     if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would label PR #$P agent:phasefix."; return 1; fi
-    echo "$((pf_cnt+1))" > "$pf_file"
     if ! gh pr view "$P" --repo "$SLUG" --json comments --jq '((.comments // [])[].body)' 2>/dev/null | grep -qF "$PHASE_GUARD_MARKER"; then
       gh pr comment "$P" --repo "$SLUG" --body "$PHASE_GUARD_MARKER — **held before merge.** This PR closes issue #$N, whose body declares work beyond this PR ($leftover), and no follow-up issue is linked. Queued for **MODE=phasefix**: an agent will file + link the follow-up issue (or drop the closing keyword) and hand the PR back to the merge loop — no owner action needed unless that fails." >/dev/null 2>&1
     fi
@@ -476,14 +500,7 @@ phase_guard_ok() {  # $1=pr -> 0 when merging is safe (guard off / nothing close
   fi
 
   # The agent had its chances and the guard still fails — NOW it is the owner's.
-  log "PHASE GUARD: PR #$P still fails after $pf_cnt phasefix attempt(s) — parking to human."
-  if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would park PR #$P + escalate issue #$N (phase guard, autofix exhausted)."; return 1; fi
-  if ! gh pr view "$P" --repo "$SLUG" --json comments --jq '((.comments // [])[].body)' 2>/dev/null | grep -qF "phasefix exhausted"; then
-    gh pr comment "$P" --repo "$SLUG" --body "$PHASE_GUARD_MARKER — **phasefix exhausted** after $pf_cnt attempt(s); this PR closes issue #$N whose later phase ($leftover) is still untracked. To clear: file + link the follow-up as \`Follow-up: #<n>\` (or remove \`Closes #$N\`), then re-label \`agent:working\`. Assigning @$ASSIGNEE." >/dev/null 2>&1
-  fi
-  gh pr edit "$P" --repo "$SLUG" --add-label needs-human --add-label agent:blocked --remove-label agent:working --remove-label agent:phasefix >/dev/null 2>&1
-  gh issue edit "$N" --repo "$SLUG" --add-label needs-human --add-assignee "$ASSIGNEE" >/dev/null 2>&1
-  gh pr edit "$P" --repo "$SLUG" --add-assignee "$ASSIGNEE" >/dev/null 2>&1
+  phase_park_to_human "$P" "$N" "$leftover" "$pf_cnt"
   return 1
 }
 
@@ -768,19 +785,49 @@ done
 # untracked (label agent:phasefix). Filing + linking the follow-up is mechanical, so an agent does
 # it and hands the PR back to agent:working; the owner is only pulled in when phase_guard_ok gives
 # up (MAX_PHASEFIX_ATTEMPTS). Runs before revise: a phasefix hold blocks an otherwise-green merge.
+# A PR the agent escalated (or a human parked) keeps its labels, so filter the human holds out —
+# otherwise this lane would re-dispatch on top of a deliberate `needs-human` every 5 minutes.
 for FJSON in $(gh pr list --repo "$SLUG" --state open --label "agent:phasefix" \
-  --json number,headRefName --jq 'sort_by(.number)|.[]|@base64' 2>/dev/null); do
+  --json number,headRefName,labels \
+  --jq 'map(select((.labels|map(.name)) | (index("needs-human")|not) and (index("agent:blocked")|not)))
+        | sort_by(.number)|.[]|@base64' 2>/dev/null); do
   FPR="$(echo "$FJSON" | base64 -d | jq -r .number)"
   FBR="$(echo "$FJSON" | base64 -d | jq -r .headRefName)"
+  # Claim FIRST: an in-flight phasefix run holds this branch, and it is about to relabel the PR.
+  # Judging (or parking) it from another slot mid-run would race that hand-back.
   if ! claim_branch "$FBR"; then
     log "PR #$FPR (phasefix) claimed by another slot — trying next."
     continue
   fi
   FISS="$(closing_issue_for_pr "$FPR")"
-  log "PR #$FPR — phase-guard hold — dispatching MODE=phasefix to file/link the follow-up (issue #${FISS:-?})."
+  # Stale hold: the PR closes nothing any more — option (b), the closing keyword was dropped — so
+  # the guard has nothing left to hold. Hand it back to the merge loop instead of burning a run.
+  if [ -z "$FISS" ]; then
+    log "PR #$FPR — phasefix hold is stale (the PR closes no issue) — returning it to the merge loop."
+    [ "$DRY_RUN" = "1" ] || gh pr edit "$FPR" --repo "$SLUG" --add-label agent:working --remove-label agent:phasefix >/dev/null 2>&1
+    continue
+  fi
+  # The budget is enforced HERE, not only in phase_guard_ok: a run that dies before handing the PR
+  # back to agent:working never re-enters the guard, so without this the label would re-dispatch a
+  # Claude run every tick forever.
+  FCNT="$(phasefix_attempts "$FPR")"
+  if [ "$FCNT" -ge "$MAX_PHASEFIX_ATTEMPTS" ]; then
+    log "PR #$FPR — still held after $FCNT phasefix dispatch(es) — parking to human."
+    TICK_OUTCOME="escalated"; TICK_REASON="phasefix_exhausted"; TICK_PR="$FPR"; TICK_BRANCH="$FBR"
+    phase_park_to_human "$FPR" "$FISS" "$(phase_leftover "$FISS")" "$FCNT"
+    exit 0
+  fi
+  log "PR #$FPR — phase-guard hold — dispatching MODE=phasefix to file/link the follow-up (issue #$FISS)."
   TICK_OUTCOME="dispatched"; TICK_REASON="mode_phasefix"; TICK_MODE="phasefix"; TICK_PR="$FPR"; TICK_BRANCH="$FBR"
   if [ "$DRY_RUN" = "1" ]; then log "DRY_RUN: would run MODE=phasefix for #$FPR ($FBR)."; exit 0; fi
   WT="$(add_worktree "$FBR" origin/main)"
+  # Same hazard the START lane guards: an empty path would `cd ""` and run the agent in $HOME.
+  if [ -z "$WT" ] || [ ! -d "$WT" ]; then
+    log "PR #$FPR — worktree creation failed for $FBR; leaving the phasefix hold for the next tick."
+    TICK_OUTCOME="failed"; TICK_REASON="worktree_create_failed"
+    exit 1
+  fi
+  phasefix_bump "$FPR"
   export MODE=phasefix PR="$FPR" ISSUE="$FISS" BRANCH="$FBR" WORKTREE="$WT"
   run_claude "$WT" "Read $RUNBOOK and follow MODE=phasefix. PR=$FPR ISSUE=$FISS BRANCH=$FBR."
   exit 0

--- a/tests/unit/test_agent_pipeline_phasefix.py
+++ b/tests/unit/test_agent_pipeline_phasefix.py
@@ -1,0 +1,123 @@
+"""Regression tests for the phase-guard -> MODE=phasefix lane in scripts/agent-pipeline/tick.sh.
+
+The lane spends a Claude run per dispatch, so the thing that must never break is its BUDGET.
+`phase_guard_ok` only ever sees a PR that still carries `agent:working`; a phasefix run that dies
+(or escalates) without handing the PR back never returns there. So the counter has to be bumped
+where the spend happens — in the lane, at dispatch — and the lane has to enforce the cap itself,
+or a wedged PR re-dispatches every tick forever.
+
+tick.sh hardcodes BASE=/home/lem/agent-pipeline and sources $BASE/lib/*.sh, so it can't be run
+end-to-end in the unit lane. The counter contract IS executable, though: the helpers are extracted
+and run for real; the lane's guards are asserted structurally.
+"""
+
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+TICK_SH = Path(__file__).resolve().parents[2] / "scripts" / "agent-pipeline" / "tick.sh"
+SOURCE = TICK_SH.read_text(encoding="utf-8")
+
+# The lane block: from its banner comment to the `done` that closes the for-loop.
+LANE = re.search(
+    r"# ---- PHASEFIX LANE:.*?\ndone\n", SOURCE, re.S
+).group(0)
+GUARD = re.search(r"\nphase_guard_ok\(\) \{.*?\n\}\n", SOURCE, re.S).group(0)
+
+
+def _helpers() -> str:
+    """The three counter helpers, lifted verbatim so the test runs the shipped code."""
+    block = re.search(
+        r"phasefix_attempts\(\).*?\nphasefix_clear\(\)[^\n]*\n", SOURCE, re.S
+    )
+    assert block, "counter helpers not found in tick.sh"
+    return block.group(0)
+
+
+def _run_counter_script(tmp_path: Path, body: str) -> str:
+    script = f'BASE="{tmp_path}"\nmkdir -p "$BASE/state"\n{_helpers()}\n{textwrap.dedent(body)}'
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def test_tick_sh_is_syntactically_valid():
+    subprocess.run(["bash", "-n", str(TICK_SH)], check=True)
+
+
+def test_counter_starts_at_zero_and_counts_dispatches(tmp_path):
+    out = _run_counter_script(
+        tmp_path,
+        """
+        phasefix_attempts 949
+        phasefix_bump 949; phasefix_attempts 949
+        phasefix_bump 949; phasefix_attempts 949
+        """,
+    )
+    assert out.split() == ["0", "1", "2"]
+
+
+def test_counter_is_per_pr_and_cleared_on_success(tmp_path):
+    out = _run_counter_script(
+        tmp_path,
+        """
+        phasefix_bump 949; phasefix_bump 949
+        phasefix_attempts 950
+        phasefix_clear 949; phasefix_attempts 949
+        """,
+    )
+    assert out.split() == ["0", "0"]
+
+
+def test_unreadable_counter_reads_as_zero_not_as_exhausted(tmp_path):
+    """A truncated/garbage state file must not silently park a PR to the owner."""
+    out = _run_counter_script(
+        tmp_path,
+        """
+        printf 'not-a-number\\n' > "$BASE/state/phasefix-949.count"
+        phasefix_attempts 949
+        """,
+    )
+    assert out == "0"
+
+
+def test_lane_bumps_the_counter_before_dispatching():
+    dispatch = LANE.index("run_claude")
+    assert "phasefix_bump" in LANE, "the lane must count its own dispatches"
+    assert LANE.index("phasefix_bump") < dispatch
+
+
+def test_lane_enforces_the_cap_itself():
+    """phase_guard_ok can't bound a run that never hands the PR back — the lane must."""
+    assert re.search(
+        r'FCNT="\$\(phasefix_attempts "\$FPR"\)"\s*\n\s*if \[ "\$FCNT" -ge "\$MAX_PHASEFIX_ATTEMPTS" \]',
+        LANE,
+    )
+    assert "phase_park_to_human" in LANE
+
+
+def test_lane_skips_prs_already_parked_for_a_human():
+    assert 'index("needs-human")|not' in LANE
+    assert 'index("agent:blocked")|not' in LANE
+
+
+def test_lane_returns_a_stale_hold_to_the_merge_loop_without_spending_a_run():
+    """Dropping `Closes #N` clears the guard, so there is nothing left for an agent to do."""
+    stale = LANE[LANE.index('if [ -z "$FISS" ]') : LANE.index("FCNT=")]
+    assert "--add-label agent:working --remove-label agent:phasefix" in stale
+    assert "run_claude" not in stale
+
+
+def test_lane_never_runs_the_agent_from_an_empty_worktree_path():
+    assert LANE.index('[ -z "$WT" ] || [ ! -d "$WT" ]') < LANE.index("run_claude")
+
+
+def test_guard_does_not_also_count_holds():
+    """Double-counting (guard + lane) would halve the budget the owner configured."""
+    assert "phasefix_bump" not in GUARD
+    assert "phasefix_clear" in GUARD  # a passing guard still clears the history


### PR DESCRIPTION
## Why

Every phase-guard hold currently parks the PR with `needs-human` + `agent:blocked` and assigns the owner — to perform two purely mechanical actions (file+link the follow-up issue, or drop the closing keyword) that the RUNBOOK's phased-work rule already teaches agents to do in MODE=start step 6. Deciding to finish an issue's stated requirements is not a human decision, and the owner should not be triaging multi-phase closes unless a genuine decision exists.

## What

- `phase_guard_ok` failure path now labels the PR **`agent:phasefix`** (new label, created) and posts a marker comment saying an agent will handle it — no owner assignment.
- New **phasefix lane** (before revise — a phasefix hold blocks an otherwise-green merge): dispatches **MODE=phasefix**, where the agent files + links the follow-up (checking for an existing one first) or drops the close, then hands the PR back to `agent:working`. If the remainder needs a `risk:*` sign-off, the hold rides on the **follow-up issue**, never the PR.
- Owner is assigned only after **`MAX_PHASEFIX_ATTEMPTS=2`** failed passes (durable counter in `state/phasefix-<PR>.count`, cleared when the guard passes), with a distinct "phasefix exhausted" comment.
- RUNBOOK gains the MODE=phasefix section; the phased-work enforcement paragraph and the playbook's label table/enforcement text updated to match.

Boxes-only warnings, DRY_RUN behavior, and the guard's fail-open posture are unchanged.

## Testing

`bash -n` passes. Shell/docs only — no app code paths; the live pipeline copy is synced separately per the existing hot-patch convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)