### PR TITLE
fix(api): reply-notification webhook — sweep_slot QueueOnce KeyError + per-email verdict logging

### DIFF
--- a/docs/REPLY_NOTIFICATIONS.md
+++ b/docs/REPLY_NOTIFICATIONS.md
@@ -48,6 +48,18 @@ a notification isn't forwarded.
 - The per-user token is minted lazily and stored on `users.reply_inbound_token` (unique).
 - The webhook is public (`_PUBLIC_API_PREFIXES`) and always returns 200.
 
+## Observability — how to tell the chain is working
+
+Every inbound parse POST (both endpoints) now logs ONE line and emits ONE `inbound_parse_email`
+PostHog event carrying a `verdict` string: `comment_accepted` / `debounced` / `gmail_confirmation` /
+`linkedin_not_comment` / `unrelated` / `unknown_reply_token` / `no_reply_token` / `no_pin_token` /
+`no_pin_in_text` / `pin_accepted` / `pin_ignored`. The log line includes the truncated raw
+`to`/`envelope`/`from`/`subject` so a token or format mismatch is visible without payload capture.
+The webhook ignores most mail BY DESIGN, so before this a broken chain was indistinguishable from no
+mail arriving: prod silently dropped 100% of inbound mail for weeks (wrong/missing token upstream)
+and separately 500'd on every valid comment notification (the `sweep_slot` QueueOnce KeyError, fixed
+alongside). Healthy = a steady share of `comment_accepted`; broken = mail volume with zero accepts.
+
 ## Related code
 
 - `src/cqc_lem/utilities/linkedin/notification_email.py` — address + comment-vs-reaction classifier.

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -2018,8 +2018,12 @@ async def linkedin_verification_pin_inbound(request: Request) -> ResponseModel:
     token = extract_token_from_address(to_field) or extract_token_from_address(envelope)
     pin = extract_pin_from_text(text) or extract_pin_from_text(subject)
     if not token or not pin:
+        # Mail addressed to neither pin+ nor reply+ lands here (catch-all spam, misdirected
+        # forwards) — the one bucket that used to vanish without a trace.
+        _log_inbound_verdict("no_pin_token" if not token else "no_pin_in_text", form)
         return ResponseModel(status_code=200, detail="ignored")
     user_id = submit_pin_by_token(token, pin)
+    _log_inbound_verdict("pin_accepted" if user_id else "pin_ignored", form, user_id=user_id)
     if user_id:
         log_info("Received LinkedIn verification PIN via email reply", user_id=user_id)
     return ResponseModel(status_code=200, detail="accepted" if user_id else "ignored")
@@ -2159,6 +2163,24 @@ def _reply_sweep_debounced(user_id: int, window_s: int = 120) -> bool:
         return True
 
 
+def _log_inbound_verdict(verdict: str, form, user_id: "Optional[int]" = None) -> None:
+    """One log line + one PostHog event per inbound parse email saying what we did with it. The
+    webhook ignores most mail BY DESIGN, which made a broken forwarding chain indistinguishable from
+    no mail at all — weeks of 100%-silently-dropped traffic looked like "feature never used". The
+    raw (truncated) address fields are included so a token/format mismatch is visible from the log."""
+    to_field = str(form.get("to") or "")[:160]
+    envelope = str(form.get("envelope") or "")[:240]
+    from_field = str(form.get("from") or "")[:120]
+    subject = str(form.get("subject") or "")[:120]
+    log_info(f"Inbound parse email verdict={verdict} to={to_field!r} envelope={envelope!r} "
+             f"from={from_field!r} subject={subject!r}", user_id=user_id)
+    try:
+        from cqc_lem.utilities.observability import track_inbound_email
+        track_inbound_email(verdict, user_id=user_id)
+    except Exception as e:
+        log_debug("Could not track inbound email verdict", exc=e, user_id=user_id)
+
+
 def _process_reply_inbound(form) -> ResponseModel:
     """Handle inbound mail sent to a reply+<token>@parse-domain address: a Gmail forwarding
     confirmation (auto-click the verify link) or a forwarded LinkedIn comment notification (trigger a
@@ -2176,12 +2198,15 @@ def _process_reply_inbound(form) -> ResponseModel:
     html = str(form.get("html") or "")
     token = extract_reply_token_from_address(to_field) or extract_reply_token_from_address(envelope)
     if not token:
+        _log_inbound_verdict("no_reply_token", form)
         return ResponseModel(status_code=200, detail="ignored")
     user_id = get_user_id_by_reply_token(token)
     if not user_id:
+        _log_inbound_verdict("unknown_reply_token", form)
         return ResponseModel(status_code=200, detail="ignored")
     # Gmail forwarding confirmation: the address is ours + token-gated, so auto-click the verify link.
     if is_gmail_forwarding_confirmation(from_field, subject, text or html):
+        _log_inbound_verdict("gmail_confirmation", form, user_id=user_id)
         return _handle_gmail_forwarding_confirmation(user_id, subject, text, html)
     comment = is_comment_notification(subject, text or html)
     # Record the proof BEFORE the comment/reaction split — a forwarded reaction email shows the
@@ -2190,10 +2215,16 @@ def _process_reply_inbound(form) -> ResponseModel:
     if comment or is_linkedin_notification(from_field, subject, text or html):
         _record_forwarding_confirmed_by_delivery(user_id)
     if not comment:
+        _log_inbound_verdict("linkedin_not_comment" if is_linkedin_notification(
+            from_field, subject, text or html) else "unrelated", form, user_id=user_id)
         return ResponseModel(status_code=200, detail="ignored")
     if not _reply_sweep_debounced(user_id):
+        _log_inbound_verdict("debounced", form, user_id=user_id)
         return ResponseModel(status_code=200, detail="debounced")
-    sweep_reply_comments.apply_async(kwargs={"user_id": user_id}, countdown=120)
+    # QueueOnce builds its dedup key from once['keys'] and does NOT apply function defaults — omitting
+    # sweep_slot here raised KeyError at enqueue and 500'd every forwarded notification.
+    sweep_reply_comments.apply_async(kwargs={"user_id": user_id, "sweep_slot": 0}, countdown=120)
+    _log_inbound_verdict("comment_accepted", form, user_id=user_id)
     log_info("Triggered reply sweep from comment notification", user_id=user_id)
     return ResponseModel(status_code=200, detail="accepted")
 

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -410,7 +410,9 @@ def dispatch_scheduled_reply_sweeps():
             # Replying to comments on the user's OWN post is the one engagement a human really does
             # fast, so it keeps the RESPONSIVE profile (issue #626): the exact minute moves, the
             # response stays timely.
-            sweep_reply_comments.apply_async(kwargs={'user_id': user_id},
+            # sweep_slot must be explicit: QueueOnce keys on ['user_id', 'sweep_slot'] and does not
+            # apply function defaults — omitting it raises KeyError at enqueue.
+            sweep_reply_comments.apply_async(kwargs={'user_id': user_id, 'sweep_slot': 0},
                                              countdown=dispatch_jitter_seconds(PACE_RESPONSIVE))
             dispatched += 1
     return f"Scheduled reply sweeps dispatched for {dispatched}/{len(users)} user(s)"

--- a/src/cqc_lem/utilities/observability.py
+++ b/src/cqc_lem/utilities/observability.py
@@ -1715,6 +1715,19 @@ def track_task(
     )
 
 
+def track_inbound_email(verdict: str, user_id: Optional[int] = None) -> None:
+    """One event per SendGrid Inbound Parse POST, carrying the dispatch verdict (comment_accepted /
+    debounced / unknown_reply_token / …). The webhook drops most mail BY DESIGN, so without this a
+    broken forwarding chain is indistinguishable from no mail arriving at all — weeks of 100%-ignored
+    traffic left no signal anywhere. `verdict` is a STRING prop so alert tiles can filter on it
+    (docs/kpi-dashboards.md)."""
+    posthog.capture(
+        distinct_id=str(user_id or "anonymous"),
+        event="inbound_parse_email",
+        properties={"verdict": verdict},
+    )
+
+
 def track_api_call(
     route: str,
     method: str,

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -389,7 +389,9 @@ class TestCommentNotificationInbound:
                 "text": "great post!"})
         assert resp.status_code == 200 and resp.json()["detail"] == "accepted"
         sweep.apply_async.assert_called_once()
-        assert sweep.apply_async.call_args.kwargs["kwargs"] == {"user_id": 7}
+        # sweep_slot must be explicit: QueueOnce keys on ['user_id', 'sweep_slot'] without applying
+        # function defaults, so omitting it raises KeyError at enqueue (500 on every notification).
+        assert sweep.apply_async.call_args.kwargs["kwargs"] == {"user_id": 7, "sweep_slot": 0}
 
     def test_reaction_email_ignored(self, client):
         with patch(self._DB, return_value=7), \
@@ -424,6 +426,64 @@ class TestCommentNotificationInbound:
                 "subject": "Jane commented on your post"})
         assert resp.json()["detail"] == "debounced"
         sweep.apply_async.assert_not_called()
+
+    _TRACK = "cqc_lem.utilities.observability.track_inbound_email"
+
+    def test_accepted_comment_logs_verdict(self, client):
+        with patch(self._DB, return_value=7), \
+             patch(f"{_MAIN}._reply_sweep_debounced", return_value=True), \
+             patch(f"{_MAIN}.sweep_reply_comments"), \
+             patch(self._TRACK) as track:
+            client.post(self.BASE, data={
+                "to": "reply+tok9@parse.example.com",
+                "subject": "Chris, Jane commented on your post"})
+        track.assert_called_once_with("comment_accepted", user_id=7)
+
+    def test_unknown_token_logs_verdict(self, client):
+        with patch(self._DB, return_value=None), \
+             patch(f"{_MAIN}.sweep_reply_comments"), \
+             patch(self._TRACK) as track:
+            client.post(self.BASE, data={
+                "to": "reply+stale@parse.example.com",
+                "subject": "someone commented on your post"})
+        track.assert_called_once_with("unknown_reply_token", user_id=None)
+
+    def test_linkedin_reaction_logs_verdict(self, client):
+        with patch(self._DB, return_value=7), \
+             patch(f"{_MAIN}.sweep_reply_comments"), \
+             patch(self._TRACK) as track:
+            client.post(self.BASE, data={
+                "to": "reply+tok9@parse.example.com",
+                "from": "notifications-noreply@linkedin.com",
+                "subject": "Jane liked your post", "text": ""})
+        track.assert_called_once_with("linkedin_not_comment", user_id=7)
+
+    def test_unrelated_mail_logs_verdict(self, client):
+        with patch(self._DB, return_value=7), \
+             patch(f"{_MAIN}.sweep_reply_comments"), \
+             patch(self._TRACK) as track:
+            client.post(self.BASE, data={
+                "to": "reply+tok9@parse.example.com",
+                "from": "spam@example.com", "subject": "hello", "text": "buy now"})
+        track.assert_called_once_with("unrelated", user_id=7)
+
+    def test_pin_endpoint_spam_logs_verdict(self, client):
+        with patch(self._TRACK) as track:
+            resp = client.post("/api/linkedin/verification-pin/inbound", data={
+                "to": "random@parse.example.com", "subject": "spam", "text": "spam"})
+        assert resp.json()["detail"] == "ignored"
+        track.assert_called_once_with("no_pin_token", user_id=None)
+
+    def test_tracking_failure_never_breaks_webhook(self, client):
+        with patch(self._DB, return_value=7), \
+             patch(f"{_MAIN}._reply_sweep_debounced", return_value=True), \
+             patch(f"{_MAIN}.sweep_reply_comments") as sweep, \
+             patch(self._TRACK, side_effect=RuntimeError("posthog down")):
+            resp = client.post(self.BASE, data={
+                "to": "reply+tok9@parse.example.com",
+                "subject": "Jane commented on your post"})
+        assert resp.json()["detail"] == "accepted"
+        sweep.apply_async.assert_called_once()
 
     def test_gmail_forwarding_confirmation_auto_clicks(self, client):
         body = ("please click the link below to confirm the request:\n"

--- a/tests/unit/app/test_run_scheduler.py
+++ b/tests/unit/app/test_run_scheduler.py
@@ -1055,6 +1055,9 @@ class TestDispatchScheduledReplySweeps:
             result = dispatch_scheduled_reply_sweeps()
         assert sweep.apply_async.call_count == 2
         assert "2/2" in result
+        # QueueOnce keys on ['user_id', 'sweep_slot'] without applying function defaults — an
+        # enqueue missing sweep_slot raises KeyError.
+        assert sweep.apply_async.call_args.kwargs["kwargs"] == {"user_id": 2, "sweep_slot": 0}
         # interval TTL for 4/day = 6h
         assert redis.set.call_args.kwargs["ex"] == 6 * 60 * 60
 


### PR DESCRIPTION
## Why

The event-driven reply feature (forwarded LinkedIn comment emails → reply sweep, `docs/REPLY_NOTIFICATIONS.md`) has **never fired in prod**, and nothing showed it. Live diagnosis on 2026-08-03 found two stacked failures:

1. **Every valid comment notification 500s at enqueue.** `sweep_reply_comments` is QueueOnce-keyed on `['user_id', 'sweep_slot']`, and celery-once does not apply function defaults. The webhook (`api/main.py`) and the scheduled dispatcher (`run_scheduler.py`) both enqueued with only `user_id` → `KeyError: 'sweep_slot'` → HTTP 500. Reproduced live with a SendGrid test email; the golden-hour call sites pass the slot explicitly, which is why safety sweeps kept working and masked this.
2. **Every ignore path is silent.** SendGrid Inbound Parse received ~130 emails since late June; all 46 POSTs in nginx retention returned `ignored` with no log, no event, no counter — a broken forwarding chain was indistinguishable from no mail arriving.

## What

- Pass `sweep_slot: 0` explicitly at both broken call sites (matches the docstring's intent: 'single-shot scheduled/API triggers leave it at 0').
- `_log_inbound_verdict()`: ONE `log_info` line per inbound parse POST with a stable verdict + truncated raw `to`/`envelope`/`from`/`subject`, on every return path of both inbound endpoints.
- `observability.track_inbound_email()`: emits `inbound_parse_email` with a STRING `verdict` prop (alert-tile friendly per `docs/kpi-dashboards.md`).
- Docs: observability section in `docs/REPLY_NOTIFICATIONS.md`.
- Tests: regression-pin both enqueue call sites' kwargs (the old test pinned the buggy call), verdict coverage for accepted/unknown-token/reaction/unrelated/spam paths, and tracking-failure-never-breaks-webhook.

`release:now`: user-visible broken feature, owner is actively verifying it; fix must reach prod to continue live validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)