### PR TITLE
fix(billing): daily caps stop resetting — the brand phase seeds, it no longer re-asserts (closes #952)

### DIFF
--- a/docs/launch-and-marketing-plan.md
+++ b/docs/launch-and-marketing-plan.md
@@ -283,15 +283,24 @@ self-marketing off. What the brand does:
 self-marketing can never exceed ToS-safe volume. Outbound cadence for the brand is a `risk:product-decision`
 config (daily connect/DM caps) the owner signs off once.
 
-**The collision guard (issue #736).** Because the brand user is *also* the owner's ordinary LEM account, the
-nightly `sync_brand_preferences` applies the phase policy as a **ceiling, not an assignment**: it can only pull
-`max_comments_per_day` / `max_dms_per_day` / `max_invites_per_day` DOWN to the phase's number, and only tighten
-`connection_request_mode` / `connection_targeting_mode` (strictness order `pre_review` > `auto_approve`, `off` >
-`suggest` > `auto_queue`). A value the owner tuned STRICTER by hand survives the sync — honouring it can never
-widen outbound, and stomping it every night is the one real risk this convention introduces. The seeded content
-fields (`focus_topics`, `business_goals`) stay fill-only-when-empty as before, everything else on the row is
-untouched (only the policy fields are sent — issue #639), and any field the sync does change is named
-before → after in one INFO line, so an edit to the owner's own settings is never silent.
+**The collision guard (issues #736, #952).** Because the brand user is *also* the owner's ordinary LEM account,
+the nightly `sync_brand_preferences` **seeds, it does not re-assert**. Which half applies is decided by
+`db.engagement_preferences_are_configured` — three-valued, because "could not read the row" is not "never
+configured" and an unreadable row skips the sync outright:
+
+- **No saved engagement row** → the phase sets `max_comments_per_day` / `max_dms_per_day` /
+  `max_invites_per_day` and `connection_request_mode` / `connection_targeting_mode` outright.
+- **A saved row** → those are the owner's own Settings choices and the phase is not applied to them at all.
+  Only `BRAND_CAP_CEILINGS` still binds: a cap above the shipped per-user default (20 / 20 / 10) is pulled back,
+  so the brand can still never run hotter than a paying user out of the box.
+
+The re-assertion this replaces was the reported bug: the Settings hub recommends the **Balanced** preset
+(15 / 10 / 8 — the P1 numbers) while prod runs `LAUNCH_PHASE=P0`, so the caps the owner picked in the UI were
+back at 8 / 5 / 5 by morning with nothing on screen to say why. Saved settings are the sign-off; an env var
+nobody has touched is not. The seeded content fields (`focus_topics`, `business_goals`) stay fill-only-when-empty
+as before, everything else on the row is untouched (only the policy fields are sent — issue #639), and any field
+the sync does change is named before → after in one INFO line, so an edit to the owner's own settings is never
+silent.
 
 ### C.3 Other automated channels (each agent-run)
 

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1508,9 +1508,16 @@ def auto_sync_brand_account():
     # policy has none, and reporting the phase's numbers there would read as an edit that never
     # happened.
     caps = ", ".join(f"{labels[f]} {applied[f]}" for f in CAP_FIELDS if f in applied)
-    summary = (f"Brand account {user_id} synced to phase {phase} ({caps})" if caps else
-               f"Brand account {user_id} checked against phase {phase} — its own caps are within "
-               f"policy, nothing changed")
+    if caps:
+        summary = f"Brand account {user_id} synced to phase {phase} ({caps})"
+    elif applied:
+        # Caps were left alone but something else was (the content seeding) — "nothing changed"
+        # would be as wrong here as reporting caps this run never wrote.
+        summary = (f"Brand account {user_id} checked against phase {phase} — its own caps stand; "
+                   f"seeded {', '.join(sorted(applied))}")
+    else:
+        summary = (f"Brand account {user_id} checked against phase {phase} — its own caps are "
+                   f"within policy, nothing changed")
     log_info(summary, user_id=user_id, task_name="auto_sync_brand_account")
     return summary
 

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -1475,14 +1475,19 @@ def auto_sync_brand_account():
     Everything the brand actually DOES — the 30-day content plan, feed commenting, connect targeting,
     appreciation/outreach DMs + follow-ups, the newsletter, company-page invites — already reaches it
     through the same per-active-user beats as any paying customer, under the same caps, 429 backoff
-    and per-user proxy. So this task adds no outreach of its own: it only re-asserts the phase's caps
-    and connect posture onto the brand's engagement preferences, so advancing a phase (or a manual
-    cap edit) can never leave brand outbound running hotter than was signed off on.
+    and per-user proxy. So this task adds no outreach of its own: it only seeds the phase's caps and
+    connect posture onto a brand account that has never saved engagement preferences of its own, and
+    holds every account under the shipped per-user ceilings.
+
+    It deliberately does NOT re-assert the phase over settings the owner saved (issue #952): user 1
+    is his ordinary account too, so the Settings hub is the sign-off, and a nightly re-assertion just
+    reverted what the SPA had recommended to him hours earlier.
 
     The brand user is user 1 by convention (issue #736), so this always has an account to sync — no
-    env var can leave it dormant, and the only reported failure is a failed write.
+    env var can leave it dormant, and the only reported failures are an unreadable row and a failed
+    write.
     """
-    from cqc_lem.utilities.brand_account import brand_user_id, current_launch_phase, \
+    from cqc_lem.utilities.brand_account import CAP_FIELDS, brand_user_id, current_launch_phase, \
         sync_brand_preferences
 
     user_id = brand_user_id()
@@ -1497,11 +1502,17 @@ def auto_sync_brand_account():
         log_warning("Brand account is not active/connected — its automation will not run",
                     user_id=user_id, task_name="auto_sync_brand_account")
 
-    log_info(f"Brand account synced to launch phase {phase}",
-             user_id=user_id, task_name="auto_sync_brand_account")
-    return (f"Brand account {user_id} synced to phase {phase} "
-            f"(comments/day {applied['max_comments_per_day']}, DMs/day {applied['max_dms_per_day']}, "
-            f"invites/day {applied['max_invites_per_day']})")
+    labels = {"max_comments_per_day": "comments/day", "max_dms_per_day": "DMs/day",
+              "max_invites_per_day": "invites/day"}
+    # Only the caps this run actually wrote — an account whose own saved caps are already within
+    # policy has none, and reporting the phase's numbers there would read as an edit that never
+    # happened.
+    caps = ", ".join(f"{labels[f]} {applied[f]}" for f in CAP_FIELDS if f in applied)
+    summary = (f"Brand account {user_id} synced to phase {phase} ({caps})" if caps else
+               f"Brand account {user_id} checked against phase {phase} — its own caps are within "
+               f"policy, nothing changed")
+    log_info(summary, user_id=user_id, task_name="auto_sync_brand_account")
+    return summary
 
 
 @shared_task.task

--- a/src/cqc_lem/utilities/brand_account.py
+++ b/src/cqc_lem/utilities/brand_account.py
@@ -51,18 +51,14 @@ PHASE_OUTBOUND_POLICY = {
            "connection_request_mode": "auto_approve", "connection_targeting_mode": "auto_queue"},
 }
 
-# The phase's numeric caps. Since the brand user is also the owner's ORDINARY account (#736), the
-# phase is applied as a CEILING, not as an assignment: it can only ever pull a cap DOWN. A cap the
-# owner tuned lower by hand is stricter than the policy, so honouring it can never widen outbound —
-# and stomping it nightly is exactly the silent overwrite this convention would otherwise introduce.
+# The volume + posture fields the phase owns. Since the brand user is also the owner's ORDINARY
+# account (#736), the phase SEEDS an account that has never saved its own engagement preferences —
+# it is not re-asserted over one that has. Issue #952: re-asserting it nightly pulled the owner's own
+# Settings choice back down before morning (the SPA recommends the "Balanced" preset, 15/10/8 — the
+# P1 numbers — while prod runs LAUNCH_PHASE=P0, so every night put it back to 8/5/5 with nothing in
+# the UI to say why). Saved settings ARE the sign-off; an env var nobody touched is not.
 CAP_FIELDS = ("max_comments_per_day", "max_dms_per_day", "max_invites_per_day")
-
-# Same rule for the approval posture, which has no numeric scale: strictest first. `pre_review` /
-# `off` gate more than the phase does, so a hand-set stricter mode survives the sync.
-MODE_STRICTNESS = {
-    "connection_request_mode": ("pre_review", "auto_approve"),
-    "connection_targeting_mode": ("off", "suggest", "auto_queue"),
-}
+MODE_FIELDS = ("connection_request_mode", "connection_targeting_mode")
 
 
 def current_launch_phase() -> str:
@@ -115,43 +111,48 @@ def is_brand_user(user_id: Any) -> bool:
         return False
 
 
-def _capped(current: Any, ceiling: int) -> int:
-    """`current` held under the phase's ceiling. A missing/unreadable saved value takes the ceiling —
-    "no opinion" is not the same as "the owner asked for less"."""
+def _over_ceiling(current: Any, ceiling: int) -> Optional[int]:
+    """`current` pulled back under `ceiling`, or None when there is nothing to change.
+
+    An unreadable value is also None: a cap this task cannot read is not a cap it may rewrite — the
+    only source for it is `get_engagement_preferences`, which hands back code DEFAULTS when the read
+    failed (issue #639), and rewriting from those is how a fault silently widens outbound.
+    """
     try:
         saved = int(current)
     except (TypeError, ValueError):
-        return ceiling
+        return None
+    if 0 <= saved <= ceiling:
+        return None
     return max(0, min(ceiling, saved))
 
 
-def _strictest(current: Any, phase_value: str, order: tuple) -> str:
-    """Whichever of the saved and phase values gates more (`order` is strictest-first). A saved value
-    outside the known vocabulary is not comparable, so the phase's wins."""
-    if current not in order:
-        return phase_value
-    if phase_value not in order:
-        return str(current)
-    return str(current) if order.index(str(current)) < order.index(phase_value) else phase_value
-
-
-def brand_preference_overrides(existing: Optional[dict] = None, phase: Optional[str] = None) -> dict:
+def brand_preference_overrides(existing: Optional[dict] = None, phase: Optional[str] = None,
+                               configured: bool = False) -> dict:
     """The engagement-preference fields the brand policy owns, given the account's current prefs.
 
-    Caps and approval posture are re-asserted from the phase as a CEILING — that is the volume gate,
-    so a manual edit can never raise brand outbound above what was signed off on, but a value the
-    owner tuned STRICTER survives (the brand user is also his ordinary account, issue #736, and
-    clamping down is the only direction that matters for safety). The seeded content fields (focus
-    topics, business goals) are only filled when empty, so he can retune the brand's messaging
-    without this task stomping it back every night.
+    `configured` is whether the account has SAVED an engagement-preferences row of its own:
+
+    * **Not configured** — the phase seeds the caps and the connect posture, exactly as before.
+    * **Configured** — those values are the OWNER's (the brand user is also his ordinary account,
+      issue #736), so the phase is not re-asserted over them and only `BRAND_CAP_CEILINGS` still
+      binds: a cap above the shipped per-user default is pulled back, everything else is left alone.
+      Re-asserting the phase every night is issue #952 — the product recommended a volume it then
+      silently refused to keep.
+
+    The seeded content fields (focus topics, business goals) are only filled when empty either way,
+    so the brand's messaging can be retuned without this task stomping it back.
     """
     policy = brand_outbound_policy(phase)
     current = existing or {}
-    overrides = dict(policy)
-    for cap in CAP_FIELDS:
-        overrides[cap] = _capped(current.get(cap), policy[cap])
-    for field, order in MODE_STRICTNESS.items():
-        overrides[field] = _strictest(current.get(field), policy[field], order)
+    overrides: dict = {}
+    if configured:
+        for cap in CAP_FIELDS:
+            clamped = _over_ceiling(current.get(cap), BRAND_CAP_CEILINGS[cap])
+            if clamped is not None:
+                overrides[cap] = clamped
+    else:
+        overrides.update({field: policy[field] for field in CAP_FIELDS + MODE_FIELDS})
     if not [t for t in (current.get("focus_topics") or []) if str(t).strip()]:
         overrides["focus_topics"] = list(BRAND_FOCUS_TOPICS)
     # The goal line is read by the content prompts, so the URL in it is the one the brand's posts
@@ -188,18 +189,33 @@ def preference_changes(existing: Optional[dict], overrides: dict) -> dict:
 def sync_brand_preferences(phase: Optional[str] = None) -> Optional[dict]:
     """Push the current phase's outbound policy onto the brand account's engagement preferences.
 
-    Returns the applied overrides, or None when the upsert failed. The whole upsert is one row (the
+    Returns the applied overrides — possibly EMPTY, when the account's own saved settings already
+    sit inside the policy — or None when the sync could not run. The whole upsert is one row (the
     V52 incident), so ONLY the policy fields are sent — voice, tone and targeting the owner set are
     preserved by `update_engagement_preferences`, which merges over the saved row and aborts when it
     can't read it (issue #639). Re-sending `existing` here would defeat that abort: a transient read
     error makes `get_engagement_preferences` return code defaults, and this nightly task would then
     write all 39 of them over the brand account's real settings.
+
+    Whether the account has settings of its own decides how much the phase owns (issue #952), so an
+    UNREADABLE row skips the sync outright rather than reading as "never configured" — seeding the
+    phase over the owner's real caps is the failure being fixed.
     """
     user_id = brand_user_id()
-    from cqc_lem.utilities.db import get_engagement_preferences, update_engagement_preferences
+    from cqc_lem.utilities.db import (engagement_preferences_are_configured,
+                                      get_engagement_preferences, update_engagement_preferences)
     resolved_phase = (phase or current_launch_phase()).strip().upper()
+    configured = engagement_preferences_are_configured(user_id)
+    if configured is None:
+        # The db layer already logged the read fault where it detected it — one condition, one
+        # warning. The caller reports the skipped sync in its own return line.
+        log_debug("Brand account preferences unreadable — skipping this sync", user_id=user_id)
+        return None
     existing = get_engagement_preferences(user_id) or {}
-    overrides = brand_preference_overrides(existing, resolved_phase)
+    overrides = brand_preference_overrides(existing, resolved_phase, configured=configured)
+    if not overrides:
+        log_debug(f"Brand account within phase {resolved_phase} — nothing to apply", user_id=user_id)
+        return overrides
     changes = preference_changes(existing, overrides)
     if not update_engagement_preferences(user_id, overrides):
         log_warning("Could not sync brand account preferences", user_id=user_id)

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -4993,15 +4993,24 @@ def get_engagement_preferences(user_id: int) -> dict:
 def engagement_preferences_are_configured(user_id: int) -> Optional[bool]:
     """Whether the user has SAVED an engagement-preferences row of their own.
 
+    The ONE existence check — `has_engagement_preferences` is this function with the unreadable
+    case folded back into False, so the question is asked with one query and one semantics.
+
     Three-valued: None means the row could not be READ, which is NOT the same as "never configured"
     (issue #639). A caller that would otherwise write policy defaults over settings the user chose
     has to be able to tell those two apart (issue #952)."""
+    connection = get_db_connection()
+    cursor = connection.cursor()
     try:
-        return _select_engagement_row(user_id) is not None
+        cursor.execute("SELECT 1 FROM engagement_preferences WHERE user_id = %s LIMIT 1", (user_id,))
+        return cursor.fetchone() is not None
     except mysql.connector.Error as err:
         log_error("Could not read engagement prefs — configured state unknown",
                   exc=err, user_id=user_id)
         return None
+    finally:
+        cursor.close()
+        connection.close()
 
 
 def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
@@ -11214,18 +11223,12 @@ def get_onboarding_candidate_user_ids() -> list:
 
 def has_engagement_preferences(user_id: int) -> bool:
     """True when the user has actually SAVED engagement preferences. get_engagement_preferences()
-    returns code defaults for everyone, so only the row's existence proves they configured it."""
-    connection = get_db_connection()
-    cursor = connection.cursor()
-    try:
-        cursor.execute("SELECT 1 FROM engagement_preferences WHERE user_id = %s LIMIT 1", (user_id,))
-        return cursor.fetchone() is not None
-    except mysql.connector.Error as err:
-        log_error(f"Could not check engagement prefs for user_id {user_id}", exc=err)
-        return False
-    finally:
-        cursor.close()
-        connection.close()
+    returns code defaults for everyone, so only the row's existence proves they configured it.
+
+    The two-valued view of `engagement_preferences_are_configured` for callers that only steer UI
+    copy: an unreadable row reads as False, exactly as this has always behaved. A caller that would
+    WRITE on the answer must use the three-valued function instead (issue #952)."""
+    return engagement_preferences_are_configured(user_id) is True
 
 
 def has_post_with_status(user_id: int, statuses: tuple) -> bool:

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -4990,6 +4990,20 @@ def get_engagement_preferences(user_id: int) -> dict:
     return _code_engagement_defaults(user_id) if row is None else row
 
 
+def engagement_preferences_are_configured(user_id: int) -> Optional[bool]:
+    """Whether the user has SAVED an engagement-preferences row of their own.
+
+    Three-valued: None means the row could not be READ, which is NOT the same as "never configured"
+    (issue #639). A caller that would otherwise write policy defaults over settings the user chose
+    has to be able to tell those two apart (issue #952)."""
+    try:
+        return _select_engagement_row(user_id) is not None
+    except mysql.connector.Error as err:
+        log_error("Could not read engagement prefs — configured state unknown",
+                  exc=err, user_id=user_id)
+        return None
+
+
 def update_engagement_preferences(user_id: int, prefs: dict) -> bool:
     """Upsert the user's engagement preferences (INSERT ... ON DUPLICATE KEY UPDATE)."""
     # The upsert writes EVERY column, so a partial `prefs` dict must merge over the user's own

--- a/tests/unit/app/test_brand_account.py
+++ b/tests/unit/app/test_brand_account.py
@@ -170,65 +170,91 @@ class TestBrandPreferenceOverrides:
         with patch(f"{_ATTR}.BRAND_SIGNUP_URL", "https://lem.test/trial"):
             assert "business_goals" not in brand_preference_overrides({"business_goals": "mine"}, "P0")
 
-    def test_caps_are_always_reasserted_over_a_manual_edit(self):
-        from cqc_lem.utilities.brand_account import brand_preference_overrides
-        overrides = brand_preference_overrides({"max_comments_per_day": 999}, "P0")
-        assert overrides["max_comments_per_day"] == 8
-
-    def test_a_missing_cap_takes_the_phase_value(self):
+    def test_an_unconfigured_account_is_seeded_from_the_phase(self):
         from cqc_lem.utilities.brand_account import brand_preference_overrides
         overrides = brand_preference_overrides({}, "P1")
         assert overrides["max_comments_per_day"] == 15
         assert overrides["max_dms_per_day"] == 10
         assert overrides["max_invites_per_day"] == 8
+        assert overrides["connection_request_mode"] == "auto_approve"
+        assert overrides["connection_targeting_mode"] == "auto_queue"
 
-    def test_an_unreadable_cap_takes_the_phase_value(self):
+    def test_the_seed_ignores_whatever_the_unconfigured_read_handed_back(self):
+        """With no saved row `get_engagement_preferences` returns code DEFAULTS (20/20/10) — those
+        are not a choice anyone made, so the phase still decides."""
         from cqc_lem.utilities.brand_account import brand_preference_overrides
-        overrides = brand_preference_overrides({"max_dms_per_day": "many"}, "P1")
-        assert overrides["max_dms_per_day"] == 10
+        overrides = brand_preference_overrides(
+            {"max_comments_per_day": 20, "max_dms_per_day": 20, "max_invites_per_day": 10}, "P0")
+        assert overrides["max_comments_per_day"] == 8
+        assert overrides["max_dms_per_day"] == 5
+        assert overrides["max_invites_per_day"] == 5
+
+
+def _volume_fields(overrides: dict) -> dict:
+    """Just the caps + connect posture — the content seeding is a separate, unchanged rule."""
+    from cqc_lem.utilities.brand_account import CAP_FIELDS, MODE_FIELDS
+    return {k: v for k, v in overrides.items() if k in CAP_FIELDS + MODE_FIELDS}
 
 
 class TestOwnerTunedSettingsSurvive:
-    """Issue #736 — the brand user is ALSO the owner's ordinary account, so the phase policy is a
-    CEILING, not an assignment: it only ever tightens."""
+    """Issue #952 — the brand user is ALSO the owner's ordinary account (#736), so once he has saved
+    engagement preferences the phase seeds nothing: the Settings hub is the sign-off, not an env var
+    nobody has touched. Only BRAND_CAP_CEILINGS still binds."""
 
-    def test_a_hand_tuned_lower_cap_is_kept(self):
+    def test_the_recommended_preset_is_not_pulled_back_to_the_phase(self):
+        """The reported bug: the SPA recommends "Balanced" (15/10/8 — the P1 numbers) while prod runs
+        LAUNCH_PHASE=P0, and this sync put it back to 8/5/5 every night."""
         from cqc_lem.utilities.brand_account import brand_preference_overrides
-        overrides = brand_preference_overrides({"max_comments_per_day": 3}, "P1")
-        assert overrides["max_comments_per_day"] == 3       # his stricter number survives
-        assert overrides["max_dms_per_day"] == 10           # the ones he never set take the phase
+        balanced = {"max_comments_per_day": 15, "max_dms_per_day": 10, "max_invites_per_day": 8,
+                    "connection_request_mode": "auto_approve",
+                    "connection_targeting_mode": "auto_queue"}
+        overrides = brand_preference_overrides(balanced, "P0", configured=True)
+        assert _volume_fields(overrides) == {}                # nothing to write at all
+
+    def test_a_hand_tuned_lower_cap_is_still_kept(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        overrides = brand_preference_overrides({"max_comments_per_day": 3}, "P1", configured=True)
+        assert _volume_fields(overrides) == {}
 
     def test_a_cap_of_zero_is_a_real_choice_not_an_unset_value(self):
         from cqc_lem.utilities.brand_account import brand_preference_overrides
-        assert brand_preference_overrides({"max_invites_per_day": 0}, "P2")["max_invites_per_day"] == 0
+        overrides = brand_preference_overrides({"max_invites_per_day": 0}, "P2", configured=True)
+        assert _volume_fields(overrides) == {}
 
-    def test_a_stricter_connect_posture_is_kept_but_a_looser_one_is_not(self):
-        from cqc_lem.utilities.brand_account import brand_preference_overrides
-        strict = brand_preference_overrides(
-            {"connection_request_mode": "pre_review", "connection_targeting_mode": "off"}, "P2")
-        assert strict["connection_request_mode"] == "pre_review"
-        assert strict["connection_targeting_mode"] == "off"
-        loose = brand_preference_overrides(
-            {"connection_request_mode": "auto_approve", "connection_targeting_mode": "auto_queue"},
-            "P0")
-        assert loose["connection_request_mode"] == "pre_review"
-        assert loose["connection_targeting_mode"] == "suggest"
+    def test_the_owners_connect_posture_is_never_rewritten(self):
+        from cqc_lem.utilities.brand_account import MODE_FIELDS, brand_preference_overrides
+        for saved in ("pre_review", "auto_approve"):
+            overrides = brand_preference_overrides(
+                {"connection_request_mode": saved, "connection_targeting_mode": "auto_queue"},
+                "P0", configured=True)
+            assert not any(field in overrides for field in MODE_FIELDS)
 
-    def test_an_unknown_saved_mode_falls_back_to_the_phase(self):
-        from cqc_lem.utilities.brand_account import brand_preference_overrides
-        overrides = brand_preference_overrides({"connection_targeting_mode": "bogus"}, "P1")
-        assert overrides["connection_targeting_mode"] == "auto_queue"
-
-    def test_the_ceiling_can_never_be_raised_above_the_phase(self):
-        from cqc_lem.utilities.brand_account import (CAP_FIELDS, LAUNCH_PHASES,
-                                                     brand_outbound_policy,
+    def test_a_cap_over_the_shipped_ceiling_is_still_pulled_back(self):
+        """The one thing that survives: the brand never runs hotter than a paying user's defaults."""
+        from cqc_lem.utilities.brand_account import (BRAND_CAP_CEILINGS, CAP_FIELDS,
                                                      brand_preference_overrides)
-        hand_tuned = {cap: 999 for cap in CAP_FIELDS}
-        for phase in LAUNCH_PHASES:
-            policy = brand_outbound_policy(phase)
-            overrides = brand_preference_overrides(hand_tuned, phase)
-            for cap in CAP_FIELDS:
-                assert overrides[cap] == policy[cap]
+        overrides = brand_preference_overrides({cap: 999 for cap in CAP_FIELDS}, "P2",
+                                               configured=True)
+        for cap in CAP_FIELDS:
+            assert overrides[cap] == BRAND_CAP_CEILINGS[cap]
+
+    def test_a_negative_cap_is_pulled_up_to_zero(self):
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        overrides = brand_preference_overrides({"max_dms_per_day": -4}, "P1", configured=True)
+        assert overrides["max_dms_per_day"] == 0
+
+    def test_an_unreadable_cap_is_left_alone(self):
+        """A cap the sync can't read is not a cap it may rewrite — the value would come from the
+        code defaults `get_engagement_preferences` returns after a failed read (#639)."""
+        from cqc_lem.utilities.brand_account import brand_preference_overrides
+        overrides = brand_preference_overrides({"max_dms_per_day": "many"}, "P1", configured=True)
+        assert _volume_fields(overrides) == {}
+
+    def test_content_seeding_still_applies_to_a_configured_account(self):
+        from cqc_lem.utilities.brand_account import BRAND_FOCUS_TOPICS, brand_preference_overrides
+        overrides = brand_preference_overrides({"max_comments_per_day": 15, "focus_topics": []},
+                                               "P0", configured=True)
+        assert overrides["focus_topics"] == list(BRAND_FOCUS_TOPICS)
 
 
 class TestPreferenceChanges:
@@ -260,6 +286,7 @@ class TestSyncBrandPreferences:
     def test_syncs_user_one_with_no_configuration(self):
         from cqc_lem.utilities.brand_account import sync_brand_preferences
         with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.engagement_preferences_are_configured", return_value=False), \
              patch(f"{_DB}.get_engagement_preferences", return_value={}), \
              patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
             assert sync_brand_preferences() is not None
@@ -272,6 +299,7 @@ class TestSyncBrandPreferences:
         from cqc_lem.utilities.brand_account import sync_brand_preferences
         existing = {"tone": "warm", "max_comments_per_day": 20, "focus_topics": ["agency growth"]}
         with _Patched(_enabled(phase="P1")), \
+             patch(f"{_DB}.engagement_preferences_are_configured", return_value=False), \
              patch(f"{_DB}.get_engagement_preferences", return_value=existing), \
              patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
             applied = sync_brand_preferences()
@@ -279,7 +307,7 @@ class TestSyncBrandPreferences:
         assert upsert.call_args.args[0] == 1
         assert "tone" not in saved                            # voice the owner set is never rewritten
         assert "focus_topics" not in saved                    # nor their non-empty focus topics
-        assert saved["max_comments_per_day"] == 15            # but the phase cap wins
+        assert saved["max_comments_per_day"] == 15            # but the phase seeds an unset account
         assert applied["max_dms_per_day"] == 10
 
     def test_unreadable_prefs_cannot_reset_the_whole_row(self):
@@ -289,6 +317,7 @@ class TestSyncBrandPreferences:
         from cqc_lem.utilities.brand_account import sync_brand_preferences
         from cqc_lem.utilities.db import _ENGAGEMENT_DEFAULTS
         with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.engagement_preferences_are_configured", return_value=False), \
              patch(f"{_DB}.get_engagement_preferences", return_value=dict(_ENGAGEMENT_DEFAULTS)), \
              patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
             sync_brand_preferences()
@@ -298,9 +327,20 @@ class TestSyncBrandPreferences:
                               "focus_topics", "business_goals"}
         assert "tone" not in saved and "reply_check_mode" not in saved
 
+    def test_an_unreadable_row_skips_the_sync_entirely(self):
+        """Issue #952: "could not read" must not read as "never configured" — seeding the phase over
+        the owner's real caps is the whole failure."""
+        from cqc_lem.utilities.brand_account import sync_brand_preferences
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.engagement_preferences_are_configured", return_value=None), \
+             patch(f"{_DB}.update_engagement_preferences") as upsert:
+            assert sync_brand_preferences() is None
+        upsert.assert_not_called()
+
     def test_explicit_phase_argument_overrides_the_env(self):
         from cqc_lem.utilities.brand_account import sync_brand_preferences
         with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.engagement_preferences_are_configured", return_value=False), \
              patch(f"{_DB}.get_engagement_preferences", return_value={}), \
              patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
             sync_brand_preferences("p2")
@@ -309,30 +349,31 @@ class TestSyncBrandPreferences:
     def test_returns_none_when_the_upsert_fails(self):
         from cqc_lem.utilities.brand_account import sync_brand_preferences
         with _Patched(_enabled()), \
+             patch(f"{_DB}.engagement_preferences_are_configured", return_value=False), \
              patch(f"{_DB}.get_engagement_preferences", return_value={}), \
              patch(f"{_DB}.update_engagement_preferences", return_value=False):
             assert sync_brand_preferences() is None
 
-    def test_does_not_clobber_the_owners_stricter_caps(self):
-        """The collision this convention introduces (#736): user 1 is the owner's own account."""
+    def test_does_not_clobber_the_owners_saved_caps(self):
+        """The collision this convention introduces (#736): user 1 is the owner's own account, so
+        once he has saved settings the sync writes no cap or posture at all (#952)."""
         from cqc_lem.utilities.brand_account import sync_brand_preferences
-        existing = {"max_comments_per_day": 2, "max_dms_per_day": 1, "max_invites_per_day": 1,
-                    "connection_request_mode": "pre_review", "connection_targeting_mode": "off",
-                    "tone": "warm", "focus_topics": ["agency growth"]}
-        with _Patched(_enabled(phase="P2")), \
+        existing = {"max_comments_per_day": 15, "max_dms_per_day": 10, "max_invites_per_day": 8,
+                    "connection_request_mode": "auto_approve",
+                    "connection_targeting_mode": "auto_queue",
+                    "tone": "warm", "focus_topics": ["agency growth"],
+                    "business_goals": "book calls"}
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.engagement_preferences_are_configured", return_value=True), \
              patch(f"{_DB}.get_engagement_preferences", return_value=existing), \
              patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert:
-            sync_brand_preferences()
-        saved = upsert.call_args.args[1]
-        assert saved["max_comments_per_day"] == 2
-        assert saved["max_dms_per_day"] == 1
-        assert saved["max_invites_per_day"] == 1
-        assert saved["connection_request_mode"] == "pre_review"
-        assert saved["connection_targeting_mode"] == "off"
+            assert sync_brand_preferences() == {}
+        upsert.assert_not_called()
 
     def test_logs_every_field_it_changes(self):
         from cqc_lem.utilities.brand_account import sync_brand_preferences
         with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.engagement_preferences_are_configured", return_value=False), \
              patch(f"{_DB}.get_engagement_preferences", return_value={"max_dms_per_day": 20}), \
              patch(f"{_DB}.update_engagement_preferences", return_value=True), \
              patch(f"{_BA}.log_info") as info:
@@ -341,12 +382,27 @@ class TestSyncBrandPreferences:
         assert "max_dms_per_day: 20 -> 5" in message
         assert info.call_args.kwargs["user_id"] == 1
 
+    def test_a_clamped_configured_cap_is_still_logged(self):
+        """The one edit that survives on a configured account has to stay readable in the logs."""
+        from cqc_lem.utilities.brand_account import sync_brand_preferences
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.engagement_preferences_are_configured", return_value=True), \
+             patch(f"{_DB}.get_engagement_preferences",
+                   return_value={"max_comments_per_day": 99, "focus_topics": ["x"],
+                                 "business_goals": "y"}), \
+             patch(f"{_DB}.update_engagement_preferences", return_value=True) as upsert, \
+             patch(f"{_BA}.log_info") as info:
+            sync_brand_preferences()
+        assert upsert.call_args.args[1] == {"max_comments_per_day": 20}
+        assert "max_comments_per_day: 99 -> 20" in info.call_args.args[0]
+
     def test_an_unchanged_account_logs_no_edit(self):
         """A nightly INFO line that fires whether or not anything moved is not a change log."""
         from cqc_lem.utilities.brand_account import brand_preference_overrides, \
             sync_brand_preferences
         settled = dict(brand_preference_overrides({}, "P0"))
         with _Patched(_enabled(phase="P0")), \
+             patch(f"{_DB}.engagement_preferences_are_configured", return_value=False), \
              patch(f"{_DB}.get_engagement_preferences", return_value=settled), \
              patch(f"{_DB}.update_engagement_preferences", return_value=True), \
              patch(f"{_BA}.log_info") as info:
@@ -390,6 +446,26 @@ class TestAutoSyncBrandAccount:
              patch(f"{_RS}.log_warning") as warn:
             auto_sync_brand_account()
         assert warn.call_count == 1
+
+    def test_reports_an_account_that_needed_no_change(self):
+        """A configured account inside policy applies nothing — the summary must not read the
+        phase's numbers back as caps it wrote (and must not KeyError looking for them)."""
+        from cqc_lem.app.run_scheduler import auto_sync_brand_account
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_BA}.sync_brand_preferences", return_value={}), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1]):
+            result = auto_sync_brand_account()
+        assert "nothing changed" in result
+        assert "comments/day" not in result
+
+    def test_reports_only_the_caps_it_actually_wrote(self):
+        from cqc_lem.app.run_scheduler import auto_sync_brand_account
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_BA}.sync_brand_preferences", return_value={"max_comments_per_day": 20}), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1]):
+            result = auto_sync_brand_account()
+        assert "comments/day 20" in result
+        assert "DMs/day" not in result
 
     def test_reports_a_failed_sync_without_touching_the_user_list(self):
         from cqc_lem.app.run_scheduler import auto_sync_brand_account

--- a/tests/unit/app/test_brand_account.py
+++ b/tests/unit/app/test_brand_account.py
@@ -467,6 +467,18 @@ class TestAutoSyncBrandAccount:
         assert "comments/day 20" in result
         assert "DMs/day" not in result
 
+    def test_a_content_only_sync_does_not_report_nothing_changed(self):
+        """The converse of the rule above: a run that seeded focus topics but wrote no cap DID
+        change the owner's row, so "nothing changed" would be as wrong as a phantom cap."""
+        from cqc_lem.app.run_scheduler import auto_sync_brand_account
+        with _Patched(_enabled(phase="P0")), \
+             patch(f"{_BA}.sync_brand_preferences", return_value={"focus_topics": ["a"]}), \
+             patch(f"{_RS}.get_active_user_ids", return_value=[1]):
+            result = auto_sync_brand_account()
+        assert "nothing changed" not in result
+        assert "focus_topics" in result
+        assert "comments/day" not in result
+
     def test_reports_a_failed_sync_without_touching_the_user_list(self):
         from cqc_lem.app.run_scheduler import auto_sync_brand_account
         with patch(f"{_BA}.brand_user_id", return_value=7), \

--- a/tests/unit/utilities/test_db_engagement_prefs.py
+++ b/tests/unit/utilities/test_db_engagement_prefs.py
@@ -209,6 +209,30 @@ class TestEngagementPreferencesAreConfigured:
             assert engagement_preferences_are_configured(1) is None
         assert err.call_count == 1
 
+    def test_it_only_asks_whether_the_row_exists(self):
+        """Existence is a `SELECT 1`, not a read of all 41 columns — one query, one semantics, and
+        `has_engagement_preferences` is this same question."""
+        conn, cursor = _mock_conn(fetch_row=(1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import engagement_preferences_are_configured
+            engagement_preferences_are_configured(1)
+        sql = cursor.execute.call_args.args[0]
+        assert "SELECT 1 FROM engagement_preferences" in sql and "LIMIT 1" in sql
+
+    def test_has_engagement_preferences_is_the_two_valued_view(self):
+        """The bool helper folds the unreadable case back into False, exactly as before — but there
+        is only ONE query behind both, so they can never drift apart."""
+        import mysql.connector
+        conn, cursor = _mock_conn(fetch_row=(1,))
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import has_engagement_preferences
+            assert has_engagement_preferences(1) is True
+        conn, cursor = _mock_conn()
+        cursor.execute.side_effect = mysql.connector.Error(msg="db down")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), patch(f"{_DB}.log_error"):
+            from cqc_lem.utilities.db import has_engagement_preferences
+            assert has_engagement_preferences(1) is False
+
 
 class TestReplyCheckConfig:
     def test_defaults_include_reply_config(self):

--- a/tests/unit/utilities/test_db_engagement_prefs.py
+++ b/tests/unit/utilities/test_db_engagement_prefs.py
@@ -183,6 +183,33 @@ class TestPartialUpdateKeepsTheRest:
                        for c in cursor.execute.call_args_list)
 
 
+class TestEngagementPreferencesAreConfigured:
+    """Three-valued (issue #952): a caller that would otherwise write policy defaults over the
+    user's own settings has to tell "never configured" from "could not read"."""
+
+    def test_true_when_a_row_exists(self):
+        conn, _ = _mock_conn(fetch_row={"tone": "warm"})
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import engagement_preferences_are_configured
+            assert engagement_preferences_are_configured(1) is True
+
+    def test_false_when_the_user_never_saved_one(self):
+        conn, _ = _mock_conn(fetch_row=None)
+        with patch(f"{_DB}.get_db_connection", return_value=conn):
+            from cqc_lem.utilities.db import engagement_preferences_are_configured
+            assert engagement_preferences_are_configured(1) is False
+
+    def test_none_and_an_error_when_the_row_cannot_be_read(self):
+        import mysql.connector
+        conn, cursor = _mock_conn()
+        cursor.execute.side_effect = mysql.connector.Error(msg="db down")
+        with patch(f"{_DB}.get_db_connection", return_value=conn), \
+             patch(f"{_DB}.log_error") as err:
+            from cqc_lem.utilities.db import engagement_preferences_are_configured
+            assert engagement_preferences_are_configured(1) is None
+        assert err.call_count == 1
+
+
 class TestReplyCheckConfig:
     def test_defaults_include_reply_config(self):
         conn, _ = _mock_conn(fetch_row=None)


### PR DESCRIPTION
## What was happening

The reporter kept setting their daily caps to the Settings hub's **Balanced** recommendation and found them lowered again later. Nothing on the save path resets them — the nightly beat does.

- `sync-brand-account` runs daily at **00:45 UTC** (`my_celery.py`) → `auto_sync_brand_account` → `sync_brand_preferences`.
- Since #736 the brand account is **user 1 by convention** — which is also the owner's ordinary LEM account.
- `brand_preference_overrides` re-asserted the `LAUNCH_PHASE` policy over that row as a ceiling. Prod runs the default `LAUNCH_PHASE=P0` (`.env.example:440`), whose policy is **8 comments / 5 DMs / 5 invites**, `pre_review` + `suggest`.
- The SPA's **Balanced** preset is **15 / 10 / 8**, `auto_approve` + `auto_queue` — deliberately the *P1* numbers (`docs/SETTINGS_IA_RESEARCH.md` §7).

So the product recommended P1 and then, before morning, put it back to P0 — silently, since the only trace was an INFO line that prod's `POSTHOG_LOG_LEVEL=WARNING` never forwards. That is the "resets to lower values" the reporter saw. It only ever affects the brand user (user 1); no other account goes through this task.

## The fix

The phase now **seeds** rather than re-asserts:

| Account state | What the sync writes |
|---|---|
| No saved `engagement_preferences` row | The phase's caps + connect posture, exactly as before |
| A saved row | Nothing for caps/posture — except a cap above `BRAND_CAP_CEILINGS` (20 / 20 / 10), which is still pulled back |

Saved settings are the sign-off; an env var nobody has touched is not. The hard guarantee that survives is the one that matters for safety — the brand can never run hotter than a paying user's out-of-the-box defaults — and the per-day caps, 429 breaker (`rate_limit.py`) and human pacing are unchanged.

Two failure modes are closed with it:

- `db.engagement_preferences_are_configured` is **three-valued** — `None` means the row could not be READ, which is not "never configured" (#639). An unreadable row **skips the sync** instead of seeding the phase over the owner's real caps.
- A cap the sync cannot parse is left alone rather than rewritten. Its only source is `get_engagement_preferences`, which hands back code defaults after a failed read, so rewriting from it is how a fault would silently widen outbound.

The task's return line now names only the caps it actually wrote (it previously read the three cap keys unconditionally, which would `KeyError` now that a run can apply none).

## Testing

- `tests/unit/app/test_brand_account.py` — the reported case (Balanced under P0 writes nothing), a saved stricter cap, a `0` cap, the connect posture, the over-ceiling clamp still applying + still being logged, an unreadable cap, an unreadable row skipping the sync, and both new summary shapes.
- `tests/unit/utilities/test_db_engagement_prefs.py` — the three states of `engagement_preferences_are_configured`.
- Full unit lane green locally: `9804 passed`.

## Note for after deploy

The account's caps are currently sitting at the P0 values this task last wrote. Re-pick **Balanced** in Settings once after the release — from then on it stays.

`release:now`: user-visible, `priority:high` bug on the owner's own account, and every night that passes reverts the setting again.

Closes #952

🤖 Generated with [Claude Code](https://claude.com/claude-code)