### PR TITLE
fix(automation): catch-up scan finds zero cards — ground card locators on the live SDUI DOM

### DIFF
--- a/docs/sdui-selenium-notes.md
+++ b/docs/sdui-selenium-notes.md
@@ -8,6 +8,20 @@ line.
 The old `urn:`, `feed-shared-*`, and `comments-comment-*` DOM anchors no longer exist. Prefer
 `data-testid` / `aria-label` selectors via `find_first`/`click_first`.
 
+## The Catch-up feed is full SDUI — no `data-view-name`, no `<li>` cards
+
+Live-grounded 2026-08-03 (`/mynetwork/catch-up/all/`, user 1): each card is a
+`div[role='listitem']` (componentkey UUID) inside the LazyColumn
+(`div[data-testid='lazy-column'][role='list']`) under
+`div[data-sdui-screen='com.linkedin.sdui.flagshipnav.mynetwork.CatchUpAll']`. The page renders
+**zero** `data-view-name` attributes and no `<li>` around cards, so the original
+`_CATCHUP_CARD_LOCATORS` chain (data-view-name first, `main li` fallbacks) matched nothing on a
+feed visibly showing ten moments — the scan reported `no_moments` daily while working "correctly".
+Grounded chain now leads with `div[data-sdui-screen*='CatchUp'] div[role='listitem']`. Ads and
+prompts also render as listitems; the profile-link + classifier funnel filters them. The on-card
+"Say congrats" suggestion chips carry no stable anchors either — when the harvest misses, drafting
+falls back to `_CATCHUP_DEFAULT_CONGRATS`, which is working as designed.
+
 ## The comment composer has no `<form>`
 
 "Submit" means clicking the Comment/Post button next to the composer (`_composer_submitted`).

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -6420,10 +6420,16 @@ CATCHUP_STATUS_DM_CAPPED = "dm_capped"              # the ACCOUNT-wide DM cap, n
 CATCHUP_STATUS_NO_MESSAGE = "no_message"            # approved with an empty body
 CATCHUP_STATUS_NOT_SENDABLE = "not_sendable"        # row missing or no longer approved/sending
 
-# Ordered fallback chain for the catch-up cards. LinkedIn's SDUI ships hashed classes, so we prefer
-# data-view-name, then the semantic list, then any main-content list item that links to a profile.
-# NOTE: needs a supervised live-grounding pass on a real account before broad enablement (see #478).
+# Ordered fallback chain for the catch-up cards. Live-grounded 2026-08-03 on a real session: the
+# surface is full SDUI — every card is a div[role='listitem'] (with a componentkey UUID) inside the
+# LazyColumn under div[data-sdui-screen='com.linkedin.sdui.flagshipnav.mynetwork.CatchUpAll'], and
+# the page carries NO data-view-name attributes and NO <li> elements around cards at all — which is
+# why the pre-grounding chain below it matched zero cards on a feed showing ten. The old anchors
+# stay as fallbacks in case LinkedIn re-ships that vocabulary. Non-person rows (ads, prompts) also
+# render as listitems; the scraper's profile-link + classifier funnel filters them.
 _CATCHUP_CARD_LOCATORS = [
+    (By.CSS_SELECTOR, "div[data-sdui-screen*='CatchUp'] div[role='listitem']"),
+    (By.CSS_SELECTOR, "main div[data-testid='lazy-column'] div[role='listitem']"),
     (By.CSS_SELECTOR, "div[data-view-name='catch-up-card']"),
     (By.CSS_SELECTOR, "li[data-view-name='catch-up-card']"),
     (By.CSS_SELECTOR, "section[data-view-name*='catch-up'] li"),


### PR DESCRIPTION
## Problem

User 1 has every catch-up milestone type enabled, yet `catchup_touches` has **zero rows ever** and the Catch-up tab shows "No catch-up touches yet."

The #792 telemetry (live since 2026-07-31) shows the lane is mechanically healthy: the 12:30 UTC scan beat dispatches daily, the per-user scan opens a session, logs in, loads the feed — and reports `no_moments` every single day. The 20-minute send drip then correctly reports `nothing_to_send`.

## Root cause

A read-only live probe of `/mynetwork/catch-up/all/` on user 1's real session (2026-08-03) found the feed **visibly full of moments (10 cards)** while **all five `_CATCHUP_CARD_LOCATORS` matched zero elements**:

- The surface is full SDUI: the page carries **zero `data-view-name` attributes**, so the two preferred anchors and the `section[data-view-name*='catch-up'] li` fallback can never match.
- Cards are `div[role='listitem']` nodes (componentkey UUIDs) inside the LazyColumn — there are **no `<li>` elements around cards**, so even the broad `main li:has(a[href*='/in/'])` fallbacks miss.

The locator comment itself said it: "needs a supervised live-grounding pass on a real account before broad enablement" — that pass had never happened.

## Fix

Lead the chain with the grounded anchors (old ones kept as fallbacks):

- `div[data-sdui-screen*='CatchUp'] div[role='listitem']`
- `main div[data-testid='lazy-column'] div[role='listitem']`

## Live verification

A second read-only probe running the real per-card extraction against the new locators: **10/10 cards found**, every card yields a normalized `/in/` profile URL, and `_classify_catchup_moment` maps the live texts (2 job_change, 3 birthday, 5 work_anniversary). Downstream is untouched and already handles the rest: ads/prompt rows are filtered by the profile-link + classifier funnel, and when the "Say congrats" draft harvest misses (those chips have no stable anchors either), drafting falls back to `_CATCHUP_DEFAULT_CONGRATS` as designed.

Also documents the surface in `docs/sdui-selenium-notes.md`.

`tests/unit/app/test_catchup_touches.py`: 149 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)