### PR TITLE
feat(hygiene): weekly TODO->issues sweep cron + trim stale-branch exemptions

### DIFF
--- a/.github/workflows/stale-branches.yml
+++ b/.github/workflows/stale-branches.yml
@@ -34,8 +34,11 @@ jobs:
         with:
           script: |
             // Mirror of `scripts/branch_cleanup.py` EXEMPT_RE + 48h cutoff. Keep them in sync.
-            // Last verified: 2026-07-28.
-            const EXEMPT = /^(?:main|master|develop|release-please--branches--main|release\/.*|feature\/release-please-dedup|ci\/claude-release-token-split|chore\/pipeline-sync-and-release-automerge|fix\/release-pipeline-reliability|hotfix\/dashboard-stats-month-boundary|milestone\/.*|worktree-agent-.*)$/;
+            // Last verified: 2026-08-03 — the historical pins (milestone/*, worktree-agent-*, four
+            // named release/pipeline branches) were deleted by hand that day, so they are no longer
+            // exempted. Orphans (no PR ever) are still surfaced, never deleted, so a live agent
+            // worktree branch only needs the 48h grace.
+            const EXEMPT = /^(?:main|master|develop|release-please--branches--main|release\/.*)$/;
             const GRACE_HOURS = 48;
             const HOUR_MS = 3600 * 1000;
             const cutoff = Date.now() - GRACE_HOURS * HOUR_MS;

--- a/docs/branch-cleanup.md
+++ b/docs/branch-cleanup.md
@@ -32,14 +32,12 @@ making the cron fight a live agent.
 `main`, `master`, `develop`, plus:
 
 - `release-please--branches--main` — the release-please bot's working branch (the bot owns it)
-- `feature/release-please-dedup` — active PR #777, the new release-please config
-- `ci/claude-release-token-split` — release-token plumbing
-- `chore/pipeline-sync-and-release-automerge` — release-pipeline sync
-- `fix/release-pipeline-reliability` — release-pipeline reliability
-- `hotfix/dashboard-stats-month-boundary` — long-lived hotfix
-- `milestone/*` — milestone boundary branches
-- `worktree-agent-*` — agent-pipeline worktree branches (orphans from the runner, but the agent
-  may come back to them; the EXEMPT regex catches them all rather than a per-name list)
+- `release/*` — release branches
+
+The 2026-07-28 historical pins (`milestone/*`, `worktree-agent-*`, `feature/release-please-dedup`
+and four named release/pipeline branches) were deleted by hand on 2026-08-03 with owner approval —
+all of their content is on `main` — and dropped from the regex. Agent worktree branches don't need
+a pin: a live push is inside the 48h grace, and an orphan (no PR ever) is surfaced, never deleted.
 
 Encoded in two places that MUST stay in sync:
 - `scripts/branch_cleanup.py` → `EXEMPT_RE`
@@ -52,7 +50,7 @@ test that catches drift — keep them aligned by hand.
 
 ```
 branch tip is <48h old?         → HELD (grace window)
-matches EXEMPT_RE?              → HELD (release/milestone/agent)
+matches EXEMPT_RE?              → HELD (main/release-please/release)
 PR is MERGED, branch >48h?      → DELETE
 PR is CLOSED, branch >48h?      → DELETE (PR records the rejection)
 PR is OPEN, branch >48h?        → SURFACE for review (author paused?)

--- a/scripts/branch_cleanup.py
+++ b/scripts/branch_cleanup.py
@@ -79,18 +79,15 @@ def _parse_committer_date(date_str: str) -> datetime:
 
 # Branches matching this regex are ALWAYS held, regardless of any other signal. Mirrors
 # `.github/workflows/stale-branches.yml` and `docs/branch-cleanup.md` — keep all three in sync.
+# The 2026-07-28 sweep's historical pins (milestone/*, worktree-agent-*, four named release/pipeline
+# branches) were deleted by hand on 2026-08-03 (owner-approved; all content on main), so they no
+# longer need exempting. Active agent worktrees don't need the worktree-agent pin either: the 48h
+# grace covers a live push, and an orphan (no PR) is held-and-surfaced, never deleted.
 EXEMPT_RE = re.compile(
     r"^(?:"
     r"main|master|develop"
     r"|release-please--branches--main"
     r"|release/.*"
-    r"|feature/release-please-dedup"
-    r"|ci/claude-release-token-split"
-    r"|chore/pipeline-sync-and-release-automerge"
-    r"|fix/release-pipeline-reliability"
-    r"|hotfix/dashboard-stats-month-boundary"
-    r"|milestone/.*"
-    r"|worktree-agent-.*"
     r")$"
 )
 

--- a/scripts/todo_issue_sweep.py
+++ b/scripts/todo_issue_sweep.py
@@ -1,0 +1,296 @@
+#!/usr/bin/env python3
+"""Weekly TODO->GitHub-issues sweep.
+
+Sibling of `posthog_error_issues.py` (same shape: pure logic / I/O split, marker-in-body dedup,
+dry-run by default, per-run cap). Where that cron turns runtime errors into backlog, this one turns
+UNFINISHED-CODE COMMENTS into backlog: TODO/FIXME-class markers and "not yet implemented"-class
+phrases are exactly how the catch-up card locators shipped broken for months — the code SAID it
+needed a live-grounding pass ("NOTE: needs a supervised live-grounding pass ... (see #478)"), but
+nothing tracked that work, so nothing ever did it (fixed in PR #964; this cron exists so the next
+one is filed automatically).
+
+Dedup: every hit gets a stable fingerprint `todo-sweep-<sha1[:12]>` of (path + normalized comment
+text) — line-number independent, so moving code never refiles; editing the comment text does, which
+is acceptable (an edited TODO is new information). The fingerprint is written into the filed body
+and searched for on later runs across open AND closed issues: closing an issue without removing the
+comment means "judged — don't refile".
+
+One GitHub issue per hit (not per file): a 10k-line module can carry unrelated TODOs that belong to
+different owners/issues.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_REPO = "christopherqueenconsulting/linkedin_engagement_manager"
+
+# Written into every filed body and searched for on later runs. Do not change the prefix without
+# migrating the issues already carrying it.
+MARKER_PREFIX = "todo-sweep-"
+
+LABELS = ("agent:ready", "cleanup")
+
+DEFAULT_MAX_NEW = 5
+MAX_TITLE_CHARS = 120
+GH_TIMEOUT_SECONDS = 60
+CONTEXT_LINES = 6  # lines of surrounding code quoted in the issue body
+
+# Trees swept. git-tracked files only (the scan shells out to `git grep`), so build output and
+# vendored node_modules never appear.
+SCAN_ROOTS = ("src", "scripts", ".litellm", "compose", ".github")
+
+# Paths never swept, with the reason each is excluded:
+EXCLUDE_PATHS = (
+    "src/cqc_lem/streamlit/",                  # legacy tree, deletion tracked whole in #972
+    "src/cqc_lem/aws/",                        # CDK path's ~20 TODOs tracked as ONE decision in #973
+    "compose/local/celery/flower/static/",     # vendored Flower assets — not our code
+    "scripts/todo_issue_sweep.py",             # this script names its own markers
+    "scripts/todo_to_issues.sh",
+)
+
+# Token markers must appear in a comment (after # or //) so identifiers like `todo_list` or hex
+# blobs never match. Phrase markers match anywhere — they live in docstrings as often as comments.
+TOKEN_RE = re.compile(r"(?:#|//).*?\b(TODO|FIXME|XXX|HACK|TBD)\b", re.IGNORECASE)
+PHRASE_RE = re.compile(
+    r"not yet implemented|no-op stub|not implemented — no-op"
+    r"|needs a supervised live-grounding", re.IGNORECASE)
+
+
+# ─────────────────────────────── pure logic (unit-tested) ───────────────────────────────
+
+def is_excluded(path: str) -> bool:
+    p = str(path).replace("\\", "/")
+    return any(p == e or p.startswith(e) for e in EXCLUDE_PATHS)
+
+
+def classify_line(line: str) -> Optional[str]:
+    """The marker this line carries, or None. Token markers only count inside a comment."""
+    m = TOKEN_RE.search(line or "")
+    if m:
+        return m.group(1).upper()
+    if PHRASE_RE.search(line or ""):
+        return "STUB"
+    return None
+
+
+def normalize(text: str) -> str:
+    """Fingerprint text: lowercase, alphanumerics collapsed to single-space words. Whitespace,
+    punctuation and line-number drift never change the fingerprint."""
+    return " ".join(re.findall(r"[a-z0-9]+", (text or "").lower()))
+
+
+def fingerprint(path: str, text: str) -> str:
+    digest = hashlib.sha1(f"{path}::{normalize(text)}".encode()).hexdigest()[:12]
+    return f"{MARKER_PREFIX}{digest}"
+
+
+def parse_grep(output: str) -> list:
+    """`git grep -n` lines -> [{path, line, text}], excluded paths dropped."""
+    hits = []
+    for raw in (output or "").splitlines():
+        parts = raw.split(":", 2)
+        if len(parts) != 3:
+            continue
+        path, line_no, text = parts
+        if is_excluded(path) or not line_no.isdigit():
+            continue
+        kind = classify_line(text)
+        if kind is None:
+            continue
+        hits.append({"path": path, "line": int(line_no), "text": text.strip(), "kind": kind,
+                     "marker": fingerprint(path, text)})
+    return hits
+
+
+def dedupe_hits(hits: list) -> list:
+    """Same normalized comment in the same file counts once, whatever line it sits on."""
+    seen = set()
+    unique = []
+    for hit in hits or []:
+        if hit["marker"] in seen:
+            continue
+        seen.add(hit["marker"])
+        unique.append(hit)
+    return unique
+
+
+def build_title(hit: dict) -> str:
+    head = re.sub(r"^\W+", "", hit["text"])[:70].rstrip() or hit["path"]
+    title = f"chore(todo-sweep): {hit['path']} — {hit['kind']}: {head}"
+    return title[:MAX_TITLE_CHARS]
+
+
+def build_body(hit: dict, context: str = "") -> str:
+    lines = [
+        f"Weekly unfinished-code sweep hit in `{hit['path']}` line {hit['line']}:",
+        "",
+        "```",
+        hit["text"],
+        "```",
+    ]
+    if context:
+        lines += ["", f"Context ({CONTEXT_LINES} lines around the marker):", "```", context, "```"]
+    lines += [
+        "",
+        "This comment says the code is unfinished, partial, or needs follow-up work. Implement "
+        "what it asks for (or delete the marker with a rationale if it no longer applies). "
+        "If this belongs to an existing issue, close this one as a duplicate — closing it "
+        "prevents refiling.",
+        "",
+        f"<!-- {hit['marker']} -->",
+        f"Dedup key: `{hit['marker']}` (do not remove; the sweep searches for it).",
+        "",
+        "Filed automatically by `scripts/todo_to_issues.sh` (weekly).",
+    ]
+    return "\n".join(lines)
+
+
+def plan_actions(hits: list, filed: set, max_new: int = DEFAULT_MAX_NEW) -> list:
+    """One `create` per unfiled hit, capped at max_new; the rest defer to next week's run."""
+    already = {str(m) for m in (filed or set())}
+    actions = []
+    created = 0
+    for hit in dedupe_hits(hits):
+        if hit["marker"] in already:
+            actions.append({"action": "skip", "reason": "already filed", "hit": hit})
+        elif created >= max(0, int(max_new)):
+            actions.append({"action": "deferred", "reason": "max-new reached", "hit": hit})
+        else:
+            actions.append({"action": "create", "hit": hit})
+            created += 1
+    return actions
+
+
+def pending(actions: list) -> list:
+    return [a for a in actions or [] if a.get("action") == "create"]
+
+
+def summarize(actions: list) -> str:
+    counts: dict = {}
+    for action in actions or []:
+        counts[action["action"]] = counts.get(action["action"], 0) + 1
+    if not counts:
+        return "no unfinished-code markers found"
+    return ", ".join(f"{count} {name}" for name, count in sorted(counts.items()))
+
+
+# ─────────────────────────────── I/O (mocked in tests) ───────────────────────────────
+
+def scan_repo(repo_root: str = ".") -> list:
+    """All marker hits in the tracked tree. `git grep` so only committed code is swept — a
+    work-in-progress checkout never files issues for itself."""
+    pattern = r"TODO\|FIXME\|XXX\|HACK\|TBD\|[Nn]ot yet implemented\|no-op stub\|supervised live-grounding"
+    result = subprocess.run(
+        ["git", "grep", "-n", "-e", pattern, "--", *SCAN_ROOTS],
+        capture_output=True, text=True, cwd=repo_root, timeout=GH_TIMEOUT_SECONDS)
+    # git grep exits 1 on "no matches" — only >1 is an error.
+    if result.returncode > 1:
+        raise RuntimeError(f"git grep failed: {(result.stderr or '').strip()[:200]}")
+    return parse_grep(result.stdout)
+
+
+def read_context(repo_root: str, hit: dict) -> str:
+    try:
+        lines = Path(repo_root, hit["path"]).read_text(errors="replace").splitlines()
+    except OSError:
+        return ""
+    start = max(0, hit["line"] - 1 - CONTEXT_LINES // 2)
+    return "\n".join(lines[start:start + CONTEXT_LINES])
+
+
+class GitHubIssues:
+    """GitHub via the `gh` CLI — the cron host is already authenticated with it."""
+
+    def __init__(self, repo: str = DEFAULT_REPO) -> None:
+        self.repo = repo
+
+    def _run(self, args: list) -> subprocess.CompletedProcess:
+        return subprocess.run(args, capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS)
+
+    def is_filed(self, issue_marker: str) -> bool:
+        """True when ANY issue — open or closed — carries this marker. Closed counts: a marker
+        someone judged and closed must never come back weekly. Fail CLOSED on search errors, or a
+        GitHub outage files a duplicate for every hit in the tree."""
+        result = self._run(["gh", "issue", "list", "--repo", self.repo, "--state", "all",
+                            "--search", issue_marker, "--json", "number,body"])
+        if result.returncode != 0:
+            raise RuntimeError(f"gh issue list failed: {(result.stderr or '').strip()[:200]}")
+        try:
+            found = json.loads(result.stdout or "[]")
+        except ValueError:
+            raise RuntimeError("gh issue list returned unparseable JSON")
+        return any(issue_marker in (item.get("body") or "") for item in found
+                   if isinstance(item, dict))
+
+    def create(self, title: str, body: str, labels=LABELS) -> Optional[str]:
+        args = ["gh", "issue", "create", "--repo", self.repo, "--title", title, "--body", body]
+        for label in labels:
+            args += ["--label", label]
+        result = self._run(args)
+        if result.returncode != 0:
+            print(f"  ! gh issue create failed: {(result.stderr or '').strip()[:300]}",
+                  file=sys.stderr)
+            return None
+        return (result.stdout or "").strip()
+
+
+def filed_markers(github: GitHubIssues, hits: list) -> set:
+    found = set()
+    for hit in dedupe_hits(hits):
+        if github.is_filed(hit["marker"]):
+            found.add(hit["marker"])
+    return found
+
+
+def apply_actions(github: GitHubIssues, actions: list, repo_root: str = ".",
+                  dry_run: bool = True) -> list:
+    """File the planned issues (or report them in dry-run). A hit that fails to file stays
+    unfiled and is retried next week."""
+    applied = []
+    for action in pending(actions):
+        hit = action["hit"]
+        title = build_title(hit)
+        if dry_run:
+            print(f"  would file: {title}  [{hit['marker']}]")
+            continue
+        url = github.create(title, build_body(hit, read_context(repo_root, hit)))
+        if url:
+            print(f"  filed: {url} — {title}")
+            applied.append({**action, "url": url})
+    return applied
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--apply", action="store_true",
+                        help="actually file issues (default: dry-run report)")
+    parser.add_argument("--max-new", type=int, default=DEFAULT_MAX_NEW)
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--repo-root", default=".")
+    args = parser.parse_args(argv)
+
+    hits = scan_repo(args.repo_root)
+    print(f"{len(dedupe_hits(hits))} unfinished-code marker(s) in the tree")
+
+    github = GitHubIssues(repo=args.repo)
+    try:
+        filed = filed_markers(github, hits)
+    except RuntimeError as e:
+        print(f"GitHub dedup lookup failed: {e}", file=sys.stderr)
+        return 1
+
+    actions = plan_actions(hits, filed, max_new=args.max_new)
+    print(f"plan: {summarize(actions)}")
+    apply_actions(github, actions, repo_root=args.repo_root, dry_run=not args.apply)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/todo_to_issues.sh
+++ b/scripts/todo_to_issues.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Weekly TODO->issues cron (host cron, runs as `lem`) — sibling of error_to_issues.sh.
+#
+# Sweeps the tracked tree for TODO/FIXME-class markers and "not yet implemented"-class phrases and
+# files ONE deduped GitHub issue per unfinished-code comment, so shipped-but-partial code (the
+# catch-up locator class of failure, see PR #964) gets tracked work instead of a comment nobody
+# reads. Dedup marker: `todo-sweep-<hash>` in the issue body; closed issues count as judged.
+#
+# Cron (as `lem`, weekly — the error scan stays daily):
+#   0 10 * * 0 git -C /home/lem/error-issues-cron fetch -q origin main && \
+#     git -C /home/lem/error-issues-cron reset -q --hard origin/main; \
+#     /home/lem/error-issues-cron/scripts/todo_to_issues.sh
+set -uo pipefail
+export PATH="/home/lem/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+export HOME="${HOME:-/home/lem}"
+
+# Self-locate the repo root so this can run from the dedicated cron clone (overridable for tests).
+REPO="${REPO:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+DIR="${TODO_ISSUES_DIR:-/home/lem/todo-issues}"
+LOG="$DIR/todo-to-issues.log"
+mkdir -p "$DIR"
+log(){ echo "[$(date -u +%FT%TZ)] $*" | tee -a "$LOG" >&2; }
+
+# Python: the script is stdlib-only, so the system interpreter is enough; prefer the dev venv when
+# present for consistency with the sibling cron.
+_DEV_VENV_PY="/home/lem/linkedin_engagement_manager/.venv/bin/python"
+if [ -x "$_DEV_VENV_PY" ]; then PY=("$_DEV_VENV_PY"); else PY=(python3); fi
+
+log "=== todo->issues sweep start ==="
+cd "$REPO" || { log "repo not found: $REPO"; exit 1; }
+"${PY[@]}" scripts/todo_issue_sweep.py --apply --repo-root "$REPO" "$@" 2>&1 | tee -a "$LOG"
+rc=${PIPESTATUS[0]}
+log "=== todo->issues sweep done (exit $rc) ==="
+exit "$rc"

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -993,7 +993,7 @@ def update_db_post_status(post_id: int, post_status: PostStatus) -> bool:
     connection = get_db_connection()
     cursor = connection.cursor()
 
-    # TODO: Why Enum doesnt work inside this function (have to convert to string first but why) ????
+    # The MySQL connector can't bind a PostStatus enum directly — it binds the .value string.
     status_str = "posted"
     try:
         status_str = post_status.value

--- a/tests/unit/test_todo_issue_sweep.py
+++ b/tests/unit/test_todo_issue_sweep.py
@@ -1,0 +1,148 @@
+import importlib.util
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "todo_issue_sweep", Path(__file__).parents[2] / "scripts" / "todo_issue_sweep.py")
+sweep = importlib.util.module_from_spec(_SPEC)
+sys.modules["todo_issue_sweep"] = sweep
+_SPEC.loader.exec_module(sweep)
+
+
+class TestClassifyLine:
+    def test_token_in_python_comment(self):
+        assert sweep.classify_line("    # TODO: Fix this method") == "TODO"
+
+    def test_token_in_js_comment(self):
+        assert sweep.classify_line("  // FIXME handle the null case") == "FIXME"
+
+    def test_token_outside_comment_is_ignored(self):
+        assert sweep.classify_line("todo_list = get_todos()") is None
+        assert sweep.classify_line("hack = build_hack_free_payload()") is None
+
+    def test_phrase_matches_in_docstring(self):
+        assert sweep.classify_line('    """Not yet implemented — returns an empty dict."""') == "STUB"
+
+    def test_no_op_stub_phrase(self):
+        assert sweep.classify_line("    Not yet implemented — no-op stub.") == "STUB"
+
+    def test_live_grounding_phrase(self):
+        line = "# NOTE: needs a supervised live-grounding pass on a real account"
+        assert sweep.classify_line(line) == "STUB"
+
+    def test_plain_line_is_none(self):
+        assert sweep.classify_line("return moments") is None
+
+    def test_case_insensitive_token(self):
+        assert sweep.classify_line("# todo lowercase counts too") == "TODO"
+
+
+class TestFingerprint:
+    def test_stable_across_whitespace_and_punctuation(self):
+        a = sweep.fingerprint("src/a.py", "# TODO: Fix   this method!")
+        b = sweep.fingerprint("src/a.py", "#  todo Fix this method")
+        assert a == b
+
+    def test_path_scoped(self):
+        assert (sweep.fingerprint("src/a.py", "# TODO: x")
+                != sweep.fingerprint("src/b.py", "# TODO: x"))
+
+    def test_text_change_changes_it(self):
+        assert (sweep.fingerprint("src/a.py", "# TODO: x")
+                != sweep.fingerprint("src/a.py", "# TODO: y"))
+
+    def test_prefix(self):
+        assert sweep.fingerprint("a", "b").startswith(sweep.MARKER_PREFIX)
+
+
+class TestParseGrep:
+    def test_parses_and_classifies(self):
+        out = "src/a.py:12:    # TODO: wire this up\nsrc/b.py:3:x = 1\n"
+        hits = sweep.parse_grep(out)
+        assert len(hits) == 1
+        assert hits[0]["path"] == "src/a.py"
+        assert hits[0]["line"] == 12
+        assert hits[0]["kind"] == "TODO"
+
+    def test_excluded_paths_dropped(self):
+        out = "src/cqc_lem/streamlit/pages/x.py:1:# TODO: implement auth\n"
+        assert sweep.parse_grep(out) == []
+
+    def test_colon_in_text_survives(self):
+        out = "src/a.py:5:# TODO: handle http://example.com properly\n"
+        hits = sweep.parse_grep(out)
+        assert "http://example.com" in hits[0]["text"]
+
+    def test_garbage_lines_skipped(self):
+        assert sweep.parse_grep("not-a-grep-line\n") == []
+        assert sweep.parse_grep("") == []
+
+
+class TestPlanActions:
+    def _hit(self, path="src/a.py", text="# TODO: x", line=1):
+        return {"path": path, "line": line, "text": text, "kind": "TODO",
+                "marker": sweep.fingerprint(path, text)}
+
+    def test_files_unfiled_and_skips_filed(self):
+        hits = [self._hit(), self._hit(text="# TODO: y")]
+        filed = {hits[0]["marker"]}
+        actions = sweep.plan_actions(hits, filed)
+        assert [a["action"] for a in actions] == ["skip", "create"]
+
+    def test_cap_defers_the_rest(self):
+        hits = [self._hit(text=f"# TODO: item {i}") for i in range(6)]
+        actions = sweep.plan_actions(hits, set(), max_new=2)
+        assert [a["action"] for a in actions].count("create") == 2
+        assert [a["action"] for a in actions].count("deferred") == 4
+
+    def test_same_marker_counted_once(self):
+        hits = [self._hit(line=1), self._hit(line=99)]
+        actions = sweep.plan_actions(hits, set())
+        assert len(actions) == 1
+
+    def test_summary_counts(self):
+        hits = [self._hit()]
+        assert "1 create" in sweep.summarize(sweep.plan_actions(hits, set()))
+
+
+class TestBuildIssue:
+    def _hit(self):
+        text = "# TODO: wire the thing"
+        return {"path": "src/a.py", "line": 7, "text": text, "kind": "TODO",
+                "marker": sweep.fingerprint("src/a.py", text)}
+
+    def test_title_carries_path_and_kind(self):
+        title = sweep.build_title(self._hit())
+        assert "src/a.py" in title and "TODO" in title
+        assert len(title) <= sweep.MAX_TITLE_CHARS
+
+    def test_body_carries_marker(self):
+        hit = self._hit()
+        assert hit["marker"] in sweep.build_body(hit)
+
+
+class TestGitHubFailClosed:
+    def test_search_failure_raises(self):
+        gh = sweep.GitHubIssues()
+        bad = MagicMock(returncode=1, stdout="", stderr="boom")
+        with patch.object(gh, "_run", return_value=bad):
+            with pytest.raises(RuntimeError):
+                gh.is_filed("todo-sweep-abc")
+
+    def test_marker_rechecked_in_body(self):
+        gh = sweep.GitHubIssues()
+        ok = MagicMock(returncode=0, stdout='[{"number": 1, "body": "other-marker"}]', stderr="")
+        with patch.object(gh, "_run", return_value=ok):
+            assert gh.is_filed("todo-sweep-abc") is False
+
+    def test_apply_dry_run_files_nothing(self):
+        gh = sweep.GitHubIssues()
+        actions = [{"action": "create",
+                    "hit": {"path": "src/a.py", "line": 1, "text": "# TODO: x", "kind": "TODO",
+                            "marker": "todo-sweep-x"}}]
+        with patch.object(gh, "create") as create:
+            sweep.apply_actions(gh, actions, dry_run=True)
+        create.assert_not_called()


### PR DESCRIPTION
## 1. Weekly TODO → GitHub-issues sweep

`scripts/todo_issue_sweep.py` + `scripts/todo_to_issues.sh` — a weekly host cron (sibling of the daily `error_to_issues.sh`, same shape: pure-logic/I-O split, marker-in-body dedup, dry-run default, per-run cap) that sweeps the tracked tree (`src/`, `scripts/`, `.litellm/`, `compose/`, `.github/`) for:

- **Token markers** — TODO / FIXME / XXX / HACK / TBD, counted only inside comments (`todo_list = ...` never matches)
- **Phrase markers** — "not yet implemented", "no-op stub", "needs a supervised live-grounding" — matched anywhere (they live in docstrings)

and files ONE GitHub issue per unfinished-code comment, labeled `agent:ready` + `cleanup` so the pipeline picks the work up.

**Why:** the catch-up card locators shipped broken for months because "needs a supervised live-grounding pass on a real account" existed only as a code comment — nothing tracked it, so nothing did it (fixed in #964). This cron makes that class of debt file its own work.

**Dedup:** `todo-sweep-<sha1-12>` of (path + normalized text) in the filed body, line-number independent; searched across open AND closed issues (closed = judged, never refiles); search failure fails CLOSED. Deliberate exclusions with reasons in the file: streamlit tree (#972 tracks its deletion whole), aws CDK tree (#973 tracks the decision), vendored Flower assets, the sweep itself.

**Pre-seeded:** today's 9 existing markers were mapped into issues #966–#973 (dedup keys appended to their bodies); a full dry-run now plans `9 skip`, so the first cron run files nothing already known. Also rewrote db.py's stale `# TODO: Why Enum doesnt work…` into the factual why — the sweep should never track a solved question.

Cron line (installed on the box, Sundays 10:00 UTC, self-updating checkout — the daily error scan stays daily):
```
0 10 * * 0 git -C /home/lem/error-issues-cron fetch -q origin main && git -C /home/lem/error-issues-cron reset -q --hard origin/main; /home/lem/error-issues-cron/scripts/todo_to_issues.sh
```

## 2. Stale-branch exemption trim

The 16 historically-pinned branches (`milestone/*`, `worktree-agent-*`, four named release/pipeline branches, `feature/claude-issue-874`) were deleted by hand today with owner approval — all content is on `main`. The EXEMPT regex in `branch_cleanup.py` + `stale-branches.yml` (+ docs) now keeps only `main|master|develop`, release-please's branch, and `release/*`. Agent worktrees don't need a pin: live pushes sit inside the 48h grace, and orphans are surfaced, never deleted.

## Testing
`tests/unit/test_todo_issue_sweep.py` — 25 tests: comment-context classification, fingerprint stability across whitespace/line moves, path scoping, exclusions, cap/dedup planning, gh fail-closed, dry-run files nothing. Full unit lane green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)