### PR TITLE
fix(errors): an empty connection-targeting scan is a no-op, not a warning (closes #985)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -6385,9 +6385,12 @@ def scan_connection_candidates(self, user_id: int, max_new: int = None):
 
     budget = _connect_target_budget(user_id, prefs, max_new)
     if budget <= 0:
-        log_warning("Connection targeting filed nothing: no invite budget left (daily cap already "
-                    "spent or fully queued)", user_id=user_id,
-                    task_name="scan_connection_candidates", action_type="connection_targeting")
+        # Filing nothing is this scan's resting state, not a degraded path: the cap doing its job,
+        # a quiet audience, and a fully-deduped candidate set are all working behaviour. Warning on
+        # any of them files a defect for a healthy daily beat (issue #985).
+        log_debug("Connection targeting filed nothing: no invite budget left (daily cap already "
+                  "spent or fully queued)", user_id=user_id,
+                  task_name="scan_connection_candidates", action_type="connection_targeting")
         return f"No invite budget left for user {user_id}"
 
     now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -6414,10 +6417,10 @@ def scan_connection_candidates(self, user_id: int, max_new: int = None):
                 quit_gracefully(driver)
 
     if not signals:
-        log_warning("Connection targeting filed nothing: nobody has engaged with this user's "
-                    "content in the lookback window and no adjacent authors are configured",
-                    user_id=user_id, task_name="scan_connection_candidates",
-                    action_type="connection_targeting")
+        log_debug("Connection targeting filed nothing: nobody has engaged with this user's "
+                  "content in the lookback window and no adjacent authors are configured",
+                  user_id=user_id, task_name="scan_connection_candidates",
+                  action_type="connection_targeting")
         return f"No connection candidates found for user {user_id}"
 
     terms = target_terms_from_prefs(prefs)
@@ -6428,9 +6431,9 @@ def scan_connection_candidates(self, user_id: int, max_new: int = None):
                                  exclude_keys=get_requested_person_keys(user_id),
                                  limit=budget)
     if not candidates:
-        log_warning("Connection targeting filed nothing: every candidate was already requested, "
-                    "already a 1st-degree connection, or below the ICP floor", user_id=user_id,
-                    task_name="scan_connection_candidates", action_type="connection_targeting")
+        log_debug("Connection targeting filed nothing: every candidate was already requested, "
+                  "already a 1st-degree connection, or below the ICP floor", user_id=user_id,
+                  task_name="scan_connection_candidates", action_type="connection_targeting")
         return f"No new connection candidates for user {user_id} (all deduped or below ICP floor)"
 
     status = _target_status_for_mode(mode, prefs)

--- a/tests/unit/app/test_connection_targeting_scan.py
+++ b/tests/unit/app/test_connection_targeting_scan.py
@@ -74,6 +74,23 @@ class TestScanGating:
         assert "deduped" in out
 
 
+class TestEmptyScanIsNotAWarning:
+    """Filing nothing is the scan's resting state, so none of its three empty outcomes may warn —
+    a daily beat that warns escalates to ERROR and files a defect for working behaviour (#985)."""
+
+    @pytest.mark.parametrize("kwargs, marker", [
+        ({"sent_today": 10}, "no invite budget left"),
+        ({"engagers": []}, "nobody has engaged"),
+        ({"requested": {"in:jane-doe"}}, "every candidate was already requested"),
+    ])
+    def test_empty_outcome_logs_debug_not_warning(self, kwargs, marker):
+        with patch(f"{_RA}.log_warning") as warn, patch(f"{_RA}.log_debug") as debug:
+            _out, insert = _scan(**kwargs)
+        insert.assert_not_called()
+        warn.assert_not_called()
+        assert any(marker in str(call.args[0]) for call in debug.call_args_list)
+
+
 class TestScanFiling:
     def test_files_a_pending_draft_in_suggest_mode(self):
         from cqc_lem.utilities.db import ConnectionRequestStatus


### PR DESCRIPTION
## What & why

PostHog escalated `RecurringWarning: Connection targeting filed nothing: every candidate was already requested, already a 1st-degree connection, or below the ICP floor` into an error-tracking issue. It is a **false positive**: the warning fired on working behaviour.

`scan_connection_candidates` (a daily beat, `auto_scan_connection_candidates`) warned on all three of its "filed nothing" outcomes. Per the escalation contract (`utilities/CLAUDE.md`, `docs/error-tracking.md`), none of them is a degraded path:

| Outcome | Why it is a no-op, not a failure |
|---|---|
| No invite budget left | `_connect_target_budget` deliberately subtracts already-queued targets so sourcing "can never build a backlog that spends tomorrow's cap" — a zero budget is that gate working. |
| Nobody engaged in the lookback window, no adjacent authors configured | The documented degrade for a quiet audience / unconfigured user. |
| Every candidate deduped, 1st-degree, or below the ICP floor | The resting state of a daily scan over a stable engager set — the dedup and the ICP floor doing their job. |

All three drop to `log_debug`. The message text is unchanged, so the PostHog dedup keys stay stable and the operator still has the line at DEBUG.

**Scope note:** the auto-filed issue named only the third message, but all three are the same call-site family in the same function and the same defect class — fixing one alone would leave two identical time bombs that auto-file the same false positive later. The genuine failures in this task (`Could not read adjacent author's recent activity`, `Could not harvest engagers from adjacent post`, `Adjacent-author sourcing failed`, `Connect-note refinement failed`) keep their warnings.

## Testing

- New `TestEmptyScanIsNotAWarning` parametrized over all three empty outcomes: asserts `log_warning` is never called and the matching `log_debug` line is.
- `tests/unit/app/test_connection_targeting_scan.py` — 30 passed; `tests/unit/app/test_network_activation.py` — 31 passed.

Closes #985

🤖 Generated with [Claude Code](https://claude.com/claude-code)
