### PR TITLE
fix(errors): an empty outreach-funnel scan is a no-op, not a warning (closes #995)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -6684,9 +6684,12 @@ def scan_outreach_funnel_targets(self, user_id: int, max_new: int = None):
     ceiling = _MAX_NEW_FUNNEL_TARGETS_PER_SCAN if max_new is None else int(max_new)
     budget = max(0, min(ceiling, _MAX_OPEN_FUNNEL_TARGETS - open_targets))
     if budget <= 0:
-        log_warning(f"Outreach funnel sourcing filed nothing: {open_targets} target(s) are already "
-                    f"waiting for approval", user_id=user_id,
-                    task_name="scan_outreach_funnel_targets", action_type="outreach_funnel")
+        # Filing nothing is this scan's resting state, not a degraded path: the backlog gate doing
+        # its job, an unconfigured roster, and a quiet audience are all working behaviour. Warning
+        # on any of them files a defect for a healthy daily beat (issue #995, sibling of #985).
+        log_debug(f"Outreach funnel sourcing filed nothing: {open_targets} target(s) are already "
+                  f"waiting for approval", user_id=user_id,
+                  task_name="scan_outreach_funnel_targets", action_type="outreach_funnel")
         return f"Outreach funnel backlog full for user {user_id}"
 
     now = datetime.now(timezone.utc).replace(tzinfo=None)
@@ -6711,16 +6714,16 @@ def scan_outreach_funnel_targets(self, user_id: int, max_new: int = None):
             if driver is not None:
                 quit_gracefully(driver)
     else:
-        log_warning("No active engagement-roster targets — the funnel can only source from post "
-                    "engagers until a roster is configured", user_id=user_id,
-                    task_name="scan_outreach_funnel_targets", action_type="outreach_funnel")
+        log_debug("No active engagement-roster targets — the funnel can only source from post "
+                  "engagers until a roster is configured", user_id=user_id,
+                  task_name="scan_outreach_funnel_targets", action_type="outreach_funnel")
     prospects.extend(_funnel_prospects_from_engagers(user_id))
 
     if not prospects:
-        log_warning("Outreach funnel sourcing filed nothing: the engagement roster produced no "
-                    "posts and nobody has engaged with this user's content in the lookback window",
-                    user_id=user_id, task_name="scan_outreach_funnel_targets",
-                    action_type="outreach_funnel")
+        log_debug("Outreach funnel sourcing filed nothing: the engagement roster produced no "
+                  "posts and nobody has engaged with this user's content in the lookback window",
+                  user_id=user_id, task_name="scan_outreach_funnel_targets",
+                  action_type="outreach_funnel")
         return f"No outreach funnel prospects for user {user_id}"
 
     # A target already in connection_requests is being worked by the #398/#486 path — two outbound

--- a/tests/unit/app/test_network_activation.py
+++ b/tests/unit/app/test_network_activation.py
@@ -7,6 +7,7 @@ and the reply check that unblocks the nurture queue — plus the logging that ma
 exit impossible.
 """
 
+import logging
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -186,7 +187,7 @@ def _roster(**over):
 
 
 def _scan_funnel(prefs=None, roster=None, engagers=None, open_targets=0, requested=None,
-                 existing=None, max_new=None, commenters=None, activity=None):
+                 existing=None, max_new=None, commenters=None, activity=None, profile_exc=None):
     from cqc_lem.app import run_automation as ra
     with patch(f"{_RA}.get_engagement_preferences",
                return_value=prefs if prefs is not None else _prefs()), \
@@ -205,8 +206,11 @@ def _scan_funnel(prefs=None, roster=None, engagers=None, open_targets=0, request
                else [{"link": "https://x/feed/update/1", "text": "Post body"}]), \
          patch(f"{_RA}.get_current_profile") as profile, \
          patch(f"{_RA}.quit_gracefully"):
-        profile.return_value = (MagicMock(), MagicMock(), "me@x.com",
-                                MagicMock(full_name="Me Myself"))
+        if profile_exc is not None:
+            profile.side_effect = profile_exc
+        else:
+            profile.return_value = (MagicMock(), MagicMock(), "me@x.com",
+                                    MagicMock(full_name="Me Myself"))
         return ra.scan_outreach_funnel_targets.run(user_id=1, max_new=max_new), insert
 
 
@@ -265,6 +269,7 @@ class TestOutreachFunnelSourcing:
         assert "off" in out
 
     def test_a_deep_approval_backlog_stops_sourcing(self, caplog):
+        caplog.set_level(logging.DEBUG, logger="cqc-lem")
         out, insert = _scan_funnel(engagers=[_engager(degree="2nd")], open_targets=25)
         insert.assert_not_called()
         assert "backlog full" in out
@@ -276,6 +281,7 @@ class TestOutreachFunnelSourcing:
         assert insert.call_count == 2
 
     def test_an_empty_roster_and_no_engagers_is_logged(self, caplog):
+        caplog.set_level(logging.DEBUG, logger="cqc-lem")
         out, insert = _scan_funnel()
         insert.assert_not_called()
         assert "No outreach funnel prospects" in out
@@ -295,6 +301,15 @@ class TestOutreachFunnelSourcing:
             out = ra.scan_outreach_funnel_targets.run(user_id=1)
         assert insert.call_count == 1 and "Filed 1" in out
 
+    def test_a_roster_sourcing_failure_still_warns(self):
+        """The degraded path is a real failure — dropping the empty outcomes must not silence it."""
+        with patch(f"{_RA}.log_warning") as warn:
+            _out, insert = _scan_funnel(roster=[_roster()], engagers=[_engager(degree="2nd")],
+                                        profile_exc=RuntimeError("no session"))
+        assert insert.call_count == 1
+        assert any("Roster sourcing for the outreach funnel failed" in str(call.args[0])
+                   for call in warn.call_args_list)
+
     def test_a_gated_comment_draft_leaves_the_text_to_the_operator(self):
         from cqc_lem.app import run_automation as ra
         # generate_ai_response returns None when the #617 quality gate rejects every attempt.
@@ -303,6 +318,22 @@ class TestOutreachFunnelSourcing:
         with patch(f"{_RA}.generate_ai_response", side_effect=RuntimeError("llm down")):
             assert ra._draft_funnel_comment(1, {"context_text": "Post body"}, MagicMock()) == ""
         assert ra._draft_funnel_comment(1, {"context_text": ""}, MagicMock()) == ""
+
+
+class TestEmptyFunnelScanIsNotAWarning:
+    """Filing nothing is this scan's resting state, so none of its three empty outcomes may warn —
+    a daily beat that warns escalates to ERROR and files a defect for working behaviour (#995)."""
+
+    @pytest.mark.parametrize("kwargs, marker", [
+        ({"open_targets": 25}, "are already waiting for approval"),
+        ({"engagers": [_engager(degree="2nd")]}, "No active engagement-roster targets"),
+        ({}, "the engagement roster produced no"),
+    ])
+    def test_empty_outcome_logs_debug_not_warning(self, kwargs, marker):
+        with patch(f"{_RA}.log_warning") as warn, patch(f"{_RA}.log_debug") as debug:
+            _out, _insert = _scan_funnel(**kwargs)
+        warn.assert_not_called()
+        assert any(marker in str(call.args[0]) for call in debug.call_args_list)
 
 
 class TestSourcingDispatch:

--- a/tests/unit/app/test_outreach_funnel.py
+++ b/tests/unit/app/test_outreach_funnel.py
@@ -1,7 +1,7 @@
 """Unit tests for the comment-first outreach funnel (issue #399): stage firing, processor, dispatch."""
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 pytestmark = pytest.mark.unit
 
@@ -173,6 +173,75 @@ class TestProcessOutreachFunnel:
             out = process_outreach_funnel.run(user_id=1)
         ust.assert_called_once_with(7, OutreachStatus.FAILED)
         assert "error" in out
+
+
+def _engager_prospect():
+    from cqc_lem.utilities.db import OutreachStage
+    return {"profile_url": "https://www.linkedin.com/in/jane-doe", "name": "Jane Doe",
+            "stage": OutreachStage.CONNECT, "context_url": None}
+
+
+def _scan_funnel(open_targets=0, roster=None, roster_prospects=None, engager_prospects=None,
+                 profile_exc=None):
+    """Run scan_outreach_funnel_targets with every I/O boundary mocked; returns (result, insert)."""
+    from cqc_lem.app import run_automation as ra
+    prefs = {"connection_targeting_mode": "suggest", "connection_request_mode": "review"}
+    with patch(f"{_RA}.get_engagement_preferences", return_value=prefs), \
+         patch(f"{_RA}.count_open_outreach_targets", return_value=open_targets), \
+         patch(f"{_RA}.get_engagement_targets",
+               return_value=[{"profile_url": "https://x/in/roster"}] if roster is None else roster), \
+         patch(f"{_RA}.get_or_create_profile_synthesis", return_value=None), \
+         patch(f"{_RA}._funnel_prospects_from_roster", return_value=list(roster_prospects or [])), \
+         patch(f"{_RA}._funnel_prospects_from_engagers",
+               return_value=list(engager_prospects or [])), \
+         patch(f"{_RA}.get_requested_person_keys", return_value=set()), \
+         patch(f"{_RA}.get_outreach_target_by_url", return_value=None), \
+         patch(f"{_RA}._draft_funnel_comment", return_value="draft"), \
+         patch(f"{_RA}._draft_funnel_stage", return_value="draft"), \
+         patch(f"{_RA}.insert_outreach_target", return_value=11) as insert, \
+         patch(f"{_RA}.get_current_profile") as profile, \
+         patch(f"{_RA}.quit_gracefully"):
+        if profile_exc is not None:
+            profile.side_effect = profile_exc
+        else:
+            profile.return_value = (MagicMock(), MagicMock(), "me@x.com",
+                                    MagicMock(full_name="Me Myself"))
+        return ra.scan_outreach_funnel_targets.run(user_id=1), insert
+
+
+class TestEmptyFunnelScanIsNotAWarning:
+    """Filing nothing is this scan's resting state, so none of its three empty outcomes may warn —
+    a daily beat that warns escalates to ERROR and files a defect for working behaviour (#995)."""
+
+    @pytest.mark.parametrize("kwargs, marker", [
+        ({"open_targets": 25}, "are already waiting for approval"),
+        ({"roster": [], "engager_prospects": [_engager_prospect()]},
+         "No active engagement-roster targets"),
+        ({}, "the engagement roster produced no"),
+    ])
+    def test_empty_outcome_logs_debug_not_warning(self, kwargs, marker):
+        with patch(f"{_RA}.log_warning") as warn, patch(f"{_RA}.log_debug") as debug:
+            _out, _insert = _scan_funnel(**kwargs)
+        warn.assert_not_called()
+        assert any(marker in str(call.args[0]) for call in debug.call_args_list)
+
+    def test_backlog_full_files_nothing(self):
+        out, insert = _scan_funnel(open_targets=25, engager_prospects=[_engager_prospect()])
+        insert.assert_not_called()
+        assert "backlog full" in out
+
+    def test_no_prospects_files_nothing(self):
+        out, insert = _scan_funnel()
+        insert.assert_not_called()
+        assert "No outreach funnel prospects" in out
+
+    def test_roster_sourcing_failure_still_warns(self):
+        """The degraded path is a real failure — it must keep its warning."""
+        with patch(f"{_RA}.log_warning") as warn:
+            _out, _insert = _scan_funnel(engager_prospects=[_engager_prospect()],
+                                         profile_exc=RuntimeError("no session"))
+        assert any("Roster sourcing for the outreach funnel failed" in str(call.args[0])
+                   for call in warn.call_args_list)
 
 
 class TestDispatcher:

--- a/tests/unit/app/test_outreach_funnel.py
+++ b/tests/unit/app/test_outreach_funnel.py
@@ -1,7 +1,7 @@
 """Unit tests for the comment-first outreach funnel (issue #399): stage firing, processor, dispatch."""
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 pytestmark = pytest.mark.unit
 
@@ -173,75 +173,6 @@ class TestProcessOutreachFunnel:
             out = process_outreach_funnel.run(user_id=1)
         ust.assert_called_once_with(7, OutreachStatus.FAILED)
         assert "error" in out
-
-
-def _engager_prospect():
-    from cqc_lem.utilities.db import OutreachStage
-    return {"profile_url": "https://www.linkedin.com/in/jane-doe", "name": "Jane Doe",
-            "stage": OutreachStage.CONNECT, "context_url": None}
-
-
-def _scan_funnel(open_targets=0, roster=None, roster_prospects=None, engager_prospects=None,
-                 profile_exc=None):
-    """Run scan_outreach_funnel_targets with every I/O boundary mocked; returns (result, insert)."""
-    from cqc_lem.app import run_automation as ra
-    prefs = {"connection_targeting_mode": "suggest", "connection_request_mode": "review"}
-    with patch(f"{_RA}.get_engagement_preferences", return_value=prefs), \
-         patch(f"{_RA}.count_open_outreach_targets", return_value=open_targets), \
-         patch(f"{_RA}.get_engagement_targets",
-               return_value=[{"profile_url": "https://x/in/roster"}] if roster is None else roster), \
-         patch(f"{_RA}.get_or_create_profile_synthesis", return_value=None), \
-         patch(f"{_RA}._funnel_prospects_from_roster", return_value=list(roster_prospects or [])), \
-         patch(f"{_RA}._funnel_prospects_from_engagers",
-               return_value=list(engager_prospects or [])), \
-         patch(f"{_RA}.get_requested_person_keys", return_value=set()), \
-         patch(f"{_RA}.get_outreach_target_by_url", return_value=None), \
-         patch(f"{_RA}._draft_funnel_comment", return_value="draft"), \
-         patch(f"{_RA}._draft_funnel_stage", return_value="draft"), \
-         patch(f"{_RA}.insert_outreach_target", return_value=11) as insert, \
-         patch(f"{_RA}.get_current_profile") as profile, \
-         patch(f"{_RA}.quit_gracefully"):
-        if profile_exc is not None:
-            profile.side_effect = profile_exc
-        else:
-            profile.return_value = (MagicMock(), MagicMock(), "me@x.com",
-                                    MagicMock(full_name="Me Myself"))
-        return ra.scan_outreach_funnel_targets.run(user_id=1), insert
-
-
-class TestEmptyFunnelScanIsNotAWarning:
-    """Filing nothing is this scan's resting state, so none of its three empty outcomes may warn —
-    a daily beat that warns escalates to ERROR and files a defect for working behaviour (#995)."""
-
-    @pytest.mark.parametrize("kwargs, marker", [
-        ({"open_targets": 25}, "are already waiting for approval"),
-        ({"roster": [], "engager_prospects": [_engager_prospect()]},
-         "No active engagement-roster targets"),
-        ({}, "the engagement roster produced no"),
-    ])
-    def test_empty_outcome_logs_debug_not_warning(self, kwargs, marker):
-        with patch(f"{_RA}.log_warning") as warn, patch(f"{_RA}.log_debug") as debug:
-            _out, _insert = _scan_funnel(**kwargs)
-        warn.assert_not_called()
-        assert any(marker in str(call.args[0]) for call in debug.call_args_list)
-
-    def test_backlog_full_files_nothing(self):
-        out, insert = _scan_funnel(open_targets=25, engager_prospects=[_engager_prospect()])
-        insert.assert_not_called()
-        assert "backlog full" in out
-
-    def test_no_prospects_files_nothing(self):
-        out, insert = _scan_funnel()
-        insert.assert_not_called()
-        assert "No outreach funnel prospects" in out
-
-    def test_roster_sourcing_failure_still_warns(self):
-        """The degraded path is a real failure — it must keep its warning."""
-        with patch(f"{_RA}.log_warning") as warn:
-            _out, _insert = _scan_funnel(engager_prospects=[_engager_prospect()],
-                                         profile_exc=RuntimeError("no session"))
-        assert any("Roster sourcing for the outreach funnel failed" in str(call.args[0])
-                   for call in warn.call_args_list)
 
 
 class TestDispatcher:


### PR DESCRIPTION
## What & why

`scan_outreach_funnel_targets` (the 4:20 AM daily beat) still carried the pattern #985 / PR #994 fixed on its 4:00 AM sibling `scan_connection_candidates`: all three of its "filed nothing" outcomes logged at WARNING. Per the escalation contract in `src/cqc_lem/utilities/CLAUDE.md`, a repeated `log_warning` re-emits at ERROR and files a grouped `$exception` — so a healthy daily beat auto-files a defect for working behaviour, on its own PostHog dedup key.

None of the three is a degraded path:

| Outcome | Why it is a no-op |
|---|---|
| `…N target(s) are already waiting for approval` | the `_MAX_OPEN_FUNNEL_TARGETS` backlog gate doing its job |
| `No active engagement-roster targets…` | an unconfigured user; the code immediately proceeds to source from post engagers |
| `…the engagement roster produced no posts and nobody has engaged…` | quiet audience — the resting state of a daily scan |

All three drop to `log_debug` with their **message text unchanged**, so the existing dedup keys stay stable, and the first call site carries the same explanatory comment PR #994 left.

Genuine failures in this task are untouched and still warn: `Roster sourcing for the outreach funnel failed`, `Funnel comment draft failed`, and everything under `_funnel_prospects_from_roster`.

## Testing

- New `TestEmptyFunnelScanIsNotAWarning` in `tests/unit/app/test_network_activation.py` (mirrors `TestEmptyScanIsNotAWarning` from PR #994): a parametrized test asserts `log_warning` is never called and the matching `log_debug` line is, for each of the three outcomes, plus a regression test that the roster-sourcing *failure* still warns. It lives beside `TestOutreachFunnelSourcing`, which already drives this task through a `_scan_funnel` mock harness — that harness is reused (extended with `profile_exc`) rather than copied.
- Two existing tests in that class asserted the backlog and empty-roster messages through `caplog`; the `cqc-lem` logger sits at INFO, so they now raise the capture level for it — that level change *is* the behaviour under test.
- `poetry run pytest tests/unit -q` → 10009 passed.

Closes #995

🤖 Generated with [Claude Code](https://claude.com/claude-code)
