### PR TITLE
fix(ai): ride out a LiteLLM proxy that is not accepting connections (closes #986)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -98,6 +98,10 @@ LITELLM_MASTER_KEY=your_litellm_master_key
 LITELLM_BASE_URL=http://litellm:4000
 # Uncomment to use LiteLLM outside of Docker
 # LITELLM_BASE_URL=http://localhost:4000
+# How long an LLM call waits out a proxy that is not accepting connections (deploy / restart).
+# Attempts include the first try, so 3 x 8s = ~24s of refused connections ridden out; 1 disables it.
+# LLM_CONNECT_RETRY_ATTEMPTS=3
+# LLM_CONNECT_RETRY_BACKOFF_SECONDS=8
 
 # --- OpenAI ---
 OPENAI_API_KEY=your_openai_api_key

--- a/.env.example
+++ b/.env.example
@@ -99,7 +99,9 @@ LITELLM_BASE_URL=http://litellm:4000
 # Uncomment to use LiteLLM outside of Docker
 # LITELLM_BASE_URL=http://localhost:4000
 # How long an LLM call waits out a proxy that is not accepting connections (deploy / restart).
-# Attempts include the first try, so 3 x 8s = ~24s of refused connections ridden out; 1 disables it.
+# Attempts include the first try and each wait DOUBLES (capped at 60s), so the default rides out
+# 8s + 16s = ~24s of refused connections; 1 disables the wait. Raising attempts grows the total
+# faster than linearly — 5 attempts is 8+16+32+60 = ~116s, not ~40s.
 # LLM_CONNECT_RETRY_ATTEMPTS=3
 # LLM_CONNECT_RETRY_BACKOFF_SECONDS=8
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,14 @@ All LLM calls go through LiteLLM proxy via `utilities/ai/client.py`:
 response = client.chat.completions.create(model="lem-simple", messages=[...])
 ```
 
+`AttributedOpenAI` is the ONE client — it stamps attribution + trace ids on every endpoint, and it
+**rides out a proxy that is not accepting connections** (#986): the proxy is a container LEM restarts
+on deploys/reboots, and the SDK's own retries are spent in ~1.5s, so one blip used to lose the
+generation and file a defect for it. ONLY a connection that was never established is retried
+(`LLM_CONNECT_RETRY_ATTEMPTS` / `LLM_CONNECT_RETRY_BACKOFF_SECONDS`, ~24s by default) — nothing was
+sent, so there is no spend to duplicate; a timeout, a 4xx or a 5xx is the proxy answering and fails
+exactly as before.
+
 **Model tier aliases** (defined in `.litellm/config.yaml`):
 
 | Alias | Use case |

--- a/src/cqc_lem/utilities/ai/client.py
+++ b/src/cqc_lem/utilities/ai/client.py
@@ -1,9 +1,12 @@
 import os
-from collections.abc import Mapping
+import time
+from collections.abc import Callable, Mapping
 from typing import Any, Optional, Tuple
 
-from openai import OpenAI
+import httpx
+from openai import APIConnectionError, OpenAI
 
+from cqc_lem.utilities.logger import log_debug
 from cqc_lem.utilities.routing_policy import SYSTEM_USER_ID
 
 # Only tier aliases are routable AND priced by the proxy, so nothing is attached to a call that
@@ -23,6 +26,37 @@ _PARENT_KEY = "parent_run_id"
 # Mirrors observability.FEATURE_SYSTEM. Kept as a literal so this module never imports observability
 # eagerly — that would drag the DB and PostHog into every `from ...ai.client import client`.
 _SYSTEM_FEATURE = "system"
+
+# The LiteLLM proxy is a container LEM restarts on its own schedule (deploys, image pulls, the host's
+# nightly unattended-upgrade reboot). While it is coming back up every call gets
+# `[Errno 111] Connection refused`, and the OpenAI SDK spends its own two retries inside ~1.5s — far
+# short of a container start — so one blip lost a whole generation and filed a defect for it
+# (issue #986). Defaults ride out ~24s of refused connections on top of the SDK's own retries; set
+# attempts to 1 to turn the wait off.
+_CONNECT_RETRY_ATTEMPTS_ENV = "LLM_CONNECT_RETRY_ATTEMPTS"
+_CONNECT_RETRY_BACKOFF_ENV = "LLM_CONNECT_RETRY_BACKOFF_SECONDS"
+_DEFAULT_CONNECT_RETRY_ATTEMPTS = 3
+_DEFAULT_CONNECT_RETRY_BACKOFF = 8.0
+
+
+def _env_number(name: str, default: Any, cast: Callable[[str], Any]) -> Any:
+    """Read a numeric setting at CALL time (so a restart-free change lands) and fall back to the
+    default on anything unparseable — a typo in `.env` must not take LLM traffic down."""
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return cast(raw)
+    except (TypeError, ValueError):
+        return default
+
+
+def _proxy_unreachable(exc: BaseException) -> bool:
+    """True only when the TCP connection to the proxy was NEVER ESTABLISHED — it is down or still
+    starting, and nothing was sent, so retrying cannot duplicate provider spend. httpx raises
+    `ConnectError` for exactly that case; a timeout or a read/write error mid-request may already
+    have reached a provider, and a 4xx/5xx is the proxy answering, so none of those are retried."""
+    return isinstance(exc, APIConnectionError) and isinstance(exc.__cause__, httpx.ConnectError)
 
 
 def current_attribution() -> Tuple[Optional[Any], Optional[str]]:
@@ -140,6 +174,29 @@ class AttributedOpenAI(OpenAI):
             except Exception:
                 pass  # observability is never a reason to lose the generation
         return super()._build_request(options, **kwargs)
+
+    def post(self, *args: Any, **kwargs: Any) -> Any:
+        """Ride out a proxy that is not accepting connections (issue #986).
+
+        Every endpoint LEM uses — chat, embeddings, images, speech — is a POST, so this is the one
+        place that covers all of them. Deliberately NOT `request()`: the SDK's own retry re-enters
+        `request()`, so wrapping it there would nest the two retry budgets and multiply them.
+        """
+        attempts = max(1, _env_number(_CONNECT_RETRY_ATTEMPTS_ENV, _DEFAULT_CONNECT_RETRY_ATTEMPTS, int))
+        backoff = max(0.0, _env_number(_CONNECT_RETRY_BACKOFF_ENV, _DEFAULT_CONNECT_RETRY_BACKOFF, float))
+        for attempt in range(attempts):
+            try:
+                return super().post(*args, **kwargs)
+            except Exception as exc:
+                if attempt + 1 >= attempts or not _proxy_unreachable(exc):
+                    raise
+                delay = backoff * (2 ** attempt)
+                # DEBUG, not a warning: a proxy restart is expected on every deploy, and a blip we
+                # rode out is not a degraded outcome. Exhausting the budget still raises, and the
+                # caller logs THAT at ERROR.
+                log_debug(f"LiteLLM proxy is not accepting connections; retrying in {delay:.0f}s",
+                          api_provider="litellm")
+                time.sleep(delay)
 
 
 client = AttributedOpenAI(

--- a/src/cqc_lem/utilities/ai/client.py
+++ b/src/cqc_lem/utilities/ai/client.py
@@ -37,6 +37,11 @@ _CONNECT_RETRY_ATTEMPTS_ENV = "LLM_CONNECT_RETRY_ATTEMPTS"
 _CONNECT_RETRY_BACKOFF_ENV = "LLM_CONNECT_RETRY_BACKOFF_SECONDS"
 _DEFAULT_CONNECT_RETRY_ATTEMPTS = 3
 _DEFAULT_CONNECT_RETRY_BACKOFF = 8.0
+# Attempts is operator-tunable and every wait doubles, so an unbounded exponential turns a mistyped
+# value into a worker that sleeps for hours holding its slot — these Celery tasks set no time limit
+# to cut that short. Capping ONE wait keeps the total linear (~attempts x 60s worst case) and leaves
+# the default schedule (8s, 16s) untouched.
+_MAX_CONNECT_RETRY_DELAY = 60.0
 
 
 def _env_number(name: str, default: Any, cast: Callable[[str], Any]) -> Any:
@@ -190,7 +195,7 @@ class AttributedOpenAI(OpenAI):
             except Exception as exc:
                 if attempt + 1 >= attempts or not _proxy_unreachable(exc):
                     raise
-                delay = backoff * (2 ** attempt)
+                delay = min(backoff * (2 ** attempt), _MAX_CONNECT_RETRY_DELAY)
                 # DEBUG, not a warning: a proxy restart is expected on every deploy, and a blip we
                 # rode out is not a degraded outcome. Exhausting the budget still raises, and the
                 # caller logs THAT at ERROR.

--- a/tests/unit/utilities/ai/test_client_connect_retry.py
+++ b/tests/unit/utilities/ai/test_client_connect_retry.py
@@ -1,0 +1,146 @@
+"""A LiteLLM proxy that is not accepting connections is ridden out, not lost (issue #986).
+
+The proxy is a container LEM restarts on its own schedule, and while it comes back up every call
+gets `[Errno 111] Connection refused`. The OpenAI SDK's own retries are spent in ~1.5s, so a single
+restart used to abort whatever generation was in flight and file an `APIConnectionError` defect for
+working infrastructure.
+
+These drive REAL requests through the SDK (same approach as test_client_attribution.py): the retry
+hangs off an SDK method, so an upgrade that moves it must fail here rather than silently give the
+proxy back its one-blip-loses-the-call behaviour.
+"""
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_CHAT_RESPONSE = {
+    "id": "x", "object": "chat.completion", "created": 0, "model": "m",
+    "choices": [{"index": 0, "message": {"role": "assistant", "content": "hi"}, "finish_reason": "stop"}],
+}
+
+
+class _RefusingTransport(httpx.BaseTransport):
+    """Refuses the first `refusals` connections the way a starting container does, then serves."""
+
+    def __init__(self, refusals: int, status: int = 200, timeout: bool = False):
+        self.refusals = refusals
+        self.status = status
+        self.timeout = timeout
+        self.attempts = 0
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        self.attempts += 1
+        if self.attempts <= self.refusals:
+            if self.timeout:
+                raise httpx.ConnectTimeout("timed out", request=request)
+            raise httpx.ConnectError("[Errno 111] Connection refused", request=request)
+        return httpx.Response(self.status, json=_CHAT_RESPONSE)
+
+
+def _client(transport: _RefusingTransport):
+    # Imported here, not at module scope: importing the module CONSTRUCTS the shared client, which
+    # needs the API key the session-scoped env fixture only sets after collection.
+    from cqc_lem.utilities.ai.client import AttributedOpenAI
+    # max_retries=0 so the transport's attempt count is exactly our retry budget, not the SDK's.
+    return AttributedOpenAI(api_key="k", base_url="http://litellm:4000", max_retries=0,
+                            http_client=httpx.Client(transport=transport))
+
+
+def _chat(client):
+    return client.chat.completions.create(model="lem-medium",
+                                          messages=[{"role": "user", "content": "hi"}])
+
+
+class TestRidingOutARestartingProxy:
+    def test_a_refused_connection_is_retried_until_the_proxy_is_back(self):
+        transport = _RefusingTransport(refusals=2)
+        with patch("cqc_lem.utilities.ai.client.time.sleep") as sleep:
+            response = _chat(_client(transport))
+        assert response.choices[0].message.content == "hi"
+        assert transport.attempts == 3
+        # Exponential, so a slow container start is still covered by the last wait.
+        assert [call.args[0] for call in sleep.call_args_list] == [8.0, 16.0]
+
+    def test_a_proxy_that_stays_down_still_fails_the_call(self, monkeypatch):
+        """The budget is bounded — a real outage must still reach error tracking."""
+        from openai import APIConnectionError
+        monkeypatch.setenv("LLM_CONNECT_RETRY_ATTEMPTS", "2")
+        transport = _RefusingTransport(refusals=99)
+        with patch("cqc_lem.utilities.ai.client.time.sleep"):
+            with pytest.raises(APIConnectionError):
+                _chat(_client(transport))
+        assert transport.attempts == 2
+
+    def test_one_attempt_turns_the_wait_off(self, monkeypatch):
+        from openai import APIConnectionError
+        monkeypatch.setenv("LLM_CONNECT_RETRY_ATTEMPTS", "1")
+        transport = _RefusingTransport(refusals=99)
+        with patch("cqc_lem.utilities.ai.client.time.sleep") as sleep:
+            with pytest.raises(APIConnectionError):
+                _chat(_client(transport))
+        assert transport.attempts == 1
+        sleep.assert_not_called()
+
+    def test_an_unparseable_setting_falls_back_to_the_default(self, monkeypatch):
+        """A typo in `.env` must not take LLM traffic down, in either direction."""
+        monkeypatch.setenv("LLM_CONNECT_RETRY_ATTEMPTS", "lots")
+        monkeypatch.setenv("LLM_CONNECT_RETRY_BACKOFF_SECONDS", "soon")
+        transport = _RefusingTransport(refusals=2)
+        with patch("cqc_lem.utilities.ai.client.time.sleep") as sleep:
+            _chat(_client(transport))
+        assert transport.attempts == 3
+        assert [call.args[0] for call in sleep.call_args_list] == [8.0, 16.0]
+
+    def test_the_retry_is_debug_not_a_warning(self):
+        """A proxy restart happens on every deploy — warning on it would escalate and file a defect
+        for working behaviour (the #917 lesson). Only the exhausted budget is an error, and the
+        caller logs that."""
+        transport = _RefusingTransport(refusals=1)
+        with patch("cqc_lem.utilities.ai.client.time.sleep"), \
+             patch("cqc_lem.utilities.ai.client.log_debug") as debug:
+            _chat(_client(transport))
+        assert debug.call_count == 1
+
+
+class TestWhatIsDeliberatelyNotRetried:
+    def test_a_timeout_is_not_retried(self):
+        """A connect timeout is not a refusal: the SDK reports every timeout as APITimeoutError, and
+        a read timeout may already have been served and billed. Retrying would double the spend."""
+        from openai import APITimeoutError
+        transport = _RefusingTransport(refusals=99, timeout=True)
+        with patch("cqc_lem.utilities.ai.client.time.sleep") as sleep:
+            with pytest.raises(APITimeoutError):
+                _chat(_client(transport))
+        assert transport.attempts == 1
+        sleep.assert_not_called()
+
+    def test_a_server_error_is_not_retried(self):
+        """A 5xx is the proxy answering — that is a real failure, not an unreachable proxy."""
+        from openai import InternalServerError
+        transport = _RefusingTransport(refusals=0, status=500)
+        with patch("cqc_lem.utilities.ai.client.time.sleep") as sleep:
+            with pytest.raises(InternalServerError):
+                _chat(_client(transport))
+        assert transport.attempts == 1
+        sleep.assert_not_called()
+
+
+class TestEveryEndpointIsCovered:
+    def test_embeddings_ride_it_out_too(self, monkeypatch):
+        """Embeddings (comment dedup, feedback clustering) never go through `_call_llm`, so the
+        client is the only place their connection failure can be retried."""
+        from openai import APIConnectionError
+        monkeypatch.setenv("LLM_CONNECT_RETRY_ATTEMPTS", "3")
+        transport = _RefusingTransport(refusals=99)
+        with patch("cqc_lem.utilities.ai.client.time.sleep"):
+            with pytest.raises(APIConnectionError):
+                _client(transport).embeddings.create(model="lem-embedding", input=["a"])
+        assert transport.attempts == 3
+
+    def test_the_shared_client_carries_the_guard(self):
+        """The tests above build their own client; pin the ONE instance every helper imports."""
+        from cqc_lem.utilities.ai.client import AttributedOpenAI, client
+        assert type(client).post is AttributedOpenAI.post

--- a/tests/unit/utilities/ai/test_client_connect_retry.py
+++ b/tests/unit/utilities/ai/test_client_connect_retry.py
@@ -74,6 +74,18 @@ class TestRidingOutARestartingProxy:
                 _chat(_client(transport))
         assert transport.attempts == 2
 
+    def test_one_wait_is_capped_so_a_mistyped_budget_cannot_hang_a_worker(self, monkeypatch):
+        """Attempts is operator-tunable and every wait doubles. Uncapped, `ATTEMPTS=10` would sleep
+        for over an hour inside a Celery task that sets no time limit — the cap keeps the total
+        linear without touching the default 8s/16s schedule."""
+        from openai import APIConnectionError
+        monkeypatch.setenv("LLM_CONNECT_RETRY_ATTEMPTS", "6")
+        transport = _RefusingTransport(refusals=99)
+        with patch("cqc_lem.utilities.ai.client.time.sleep") as sleep:
+            with pytest.raises(APIConnectionError):
+                _chat(_client(transport))
+        assert [call.args[0] for call in sleep.call_args_list] == [8.0, 16.0, 32.0, 60.0, 60.0]
+
     def test_one_attempt_turns_the_wait_off(self, monkeypatch):
         from openai import APIConnectionError
         monkeypatch.setenv("LLM_CONNECT_RETRY_ATTEMPTS", "1")


### PR DESCRIPTION
## What & why

PostHog grouped an `APIConnectionError: Connection error.` on `auto_comment_in_groups`. The stack trace's only in-app frame is `ai_helper._call_llm:133`, and the chained causes are `httpx.ConnectError` / `httpcore.ConnectError` — **`[Errno 111] Connection refused`** talking to the LiteLLM proxy.

That proxy is a container LEM restarts on its own schedule (deploys, image pulls, the host's nightly unattended-upgrade reboot). While it comes back up every call is refused, and the OpenAI SDK spends its own two retries inside ~1.5s — far short of a container start. So one blip lost the generation in flight, aborted the run, and filed a defect for working infrastructure.

This is not an expected no-op (a lost generation is real degradation), so per the escalation contract the error stays — the app just stops being unable to survive a restart.

## The change

`AttributedOpenAI` already exists as the ONE place every endpoint funnels through, so the wait goes there:

- **`post()` retries a connection that was NEVER ESTABLISHED.** Chat, embeddings, images and speech are all POSTs, so this covers every LLM surface — including the ~12 call sites that bypass `_call_llm` entirely (embeddings for comment dedup / feedback clustering, `image_gen`, `tools.py`, `newsletter_cover`, …).
- **Wrapped at `post()` rather than `request()`** because the SDK's own retry re-enters `request()` — nesting the two budgets would multiply them (3 × 3 × 3 attempts and nested sleeps).
- **Only `APIConnectionError` whose `__cause__` is `httpx.ConnectError`.** Nothing was sent, so there is no provider spend to duplicate. A timeout (which may already have been served and billed), a 4xx, or a 5xx is the proxy *answering* and fails exactly as before.
- **Bounded**: `LLM_CONNECT_RETRY_ATTEMPTS` (default 3) × `LLM_CONNECT_RETRY_BACKOFF_SECONDS` (default 8, exponential) ≈ 24s ridden out; `1` turns the wait off. Read at call time, unparseable values fall back to the default. Documented in `.env.example`.
- **The per-retry log is DEBUG, not a warning.** A proxy restart happens on every deploy — warning on it would escalate and file a defect for expected behaviour (the #917 `pause_automation` lesson). An exhausted budget still raises, and `_call_llm` still logs *that* at ERROR, so a real outage still reaches error tracking.

## Testing

New `tests/unit/utilities/ai/test_client_connect_retry.py` (9 tests) drives **real requests through the SDK** over a transport that refuses connections the way a starting container does — same approach as `test_client_attribution.py`, so an SDK upgrade that moves the hook fails CI instead of silently restoring the old behaviour. It pins: a refused connection is ridden out; the backoff schedule is `8s, 16s`; a proxy that stays down still fails inside the budget; `attempts=1` disables it; an unparseable setting falls back to the default; the retry logs DEBUG once; a **timeout** and a **500** are each attempted exactly once; embeddings are covered too; and the shared singleton carries the guard.

```
poetry run pytest tests/unit -q   →  10018 passed
```

Dedup marker (do not remove): `posthog-issue-019fc1b4-951f-7541-b002-ebff9ad8c9be`

Closes #986

🤖 Generated with [Claude Code](https://claude.com/claude-code)