### PR TITLE
fix(errors): a roster author with no recent post is a no-op, not a warning (closes #987)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -6611,8 +6611,12 @@ def _funnel_prospects_from_roster(driver, user_id: int, roster: list, my_name: s
             continue
         post = next((p for p in activity if (p or {}).get("link")), None)
         if not post:
-            log_warning(f"Roster author {author_url} has no recent post to comment on — skipping",
-                        user_id=user_id, action_type="outreach_funnel")
+            # A roster author who simply hasn't posted lately is the common case, not a degraded
+            # one — most people post weekly at best against a daily beat. Warning on it escalates
+            # to ERROR after three repeats and files a defect for working behaviour (issue #987,
+            # sibling of #985/#995). The real failures around it keep their warnings.
+            log_debug(f"Roster author {author_url} has no recent post to comment on — skipping",
+                      user_id=user_id, action_type="outreach_funnel")
             continue
         author_name = clean_person_name(target.get("name") or "") or _author_display_name(author_url)
         post_text = str(post.get("text") or "")

--- a/tests/unit/app/test_network_activation.py
+++ b/tests/unit/app/test_network_activation.py
@@ -187,7 +187,8 @@ def _roster(**over):
 
 
 def _scan_funnel(prefs=None, roster=None, engagers=None, open_targets=0, requested=None,
-                 existing=None, max_new=None, commenters=None, activity=None, profile_exc=None):
+                 existing=None, max_new=None, commenters=None, activity=None, profile_exc=None,
+                 activity_exc=None):
     from cqc_lem.app import run_automation as ra
     with patch(f"{_RA}.get_engagement_preferences",
                return_value=prefs if prefs is not None else _prefs()), \
@@ -202,6 +203,7 @@ def _scan_funnel(prefs=None, roster=None, engagers=None, open_targets=0, request
          patch(f"{_RA}.insert_outreach_target", return_value=11) as insert, \
          patch(f"{_RA}._harvest_post_commenters", return_value=commenters or []), \
          patch("cqc_lem.utilities.linkedin.scrapper.get_profile_recent_activity",
+               side_effect=activity_exc,
                return_value=activity if activity is not None
                else [{"link": "https://x/feed/update/1", "text": "Post body"}]), \
          patch(f"{_RA}.get_current_profile") as profile, \
@@ -328,12 +330,27 @@ class TestEmptyFunnelScanIsNotAWarning:
         ({"open_targets": 25}, "are already waiting for approval"),
         ({"engagers": [_engager(degree="2nd")]}, "No active engagement-roster targets"),
         ({}, "the engagement roster produced no"),
+        # A roster author who hasn't posted lately is the common case, not a degraded one (#987).
+        ({"roster": [_roster()], "activity": []}, "has no recent post to comment on"),
     ])
     def test_empty_outcome_logs_debug_not_warning(self, kwargs, marker):
         with patch(f"{_RA}.log_warning") as warn, patch(f"{_RA}.log_debug") as debug:
             _out, _insert = _scan_funnel(**kwargs)
         warn.assert_not_called()
         assert any(marker in str(call.args[0]) for call in debug.call_args_list)
+
+    def test_a_quiet_roster_author_is_skipped_without_filing_a_target(self):
+        """The skip itself must still hold: no post means nothing to comment on, so no draft."""
+        _out, insert = _scan_funnel(roster=[_roster()], activity=[])
+        insert.assert_not_called()
+
+    def test_an_unreadable_roster_author_still_warns(self):
+        """Silencing the quiet author must not silence the profile that could not be read at all."""
+        with patch(f"{_RA}.log_warning") as warn:
+            _out, _insert = _scan_funnel(roster=[_roster()],
+                                         activity_exc=RuntimeError("profile gone"))
+        assert any("Could not read a roster author's recent activity" in str(call.args[0])
+                   for call in warn.call_args_list)
 
 
 class TestSourcingDispatch:

--- a/tests/unit/app/test_network_activation.py
+++ b/tests/unit/app/test_network_activation.py
@@ -341,14 +341,14 @@ class TestEmptyFunnelScanIsNotAWarning:
 
     def test_a_quiet_roster_author_is_skipped_without_filing_a_target(self):
         """The skip itself must still hold: no post means nothing to comment on, so no draft."""
-        _out, insert = _scan_funnel(roster=[_roster()], activity=[])
+        out, insert = _scan_funnel(roster=[_roster()], activity=[])
         insert.assert_not_called()
+        assert "No outreach funnel prospects" in out
 
     def test_an_unreadable_roster_author_still_warns(self):
         """Silencing the quiet author must not silence the profile that could not be read at all."""
         with patch(f"{_RA}.log_warning") as warn:
-            _out, _insert = _scan_funnel(roster=[_roster()],
-                                         activity_exc=RuntimeError("profile gone"))
+            _scan_funnel(roster=[_roster()], activity_exc=RuntimeError("profile gone"))
         assert any("Could not read a roster author's recent activity" in str(call.args[0])
                    for call in warn.call_args_list)
 


### PR DESCRIPTION
## What & why

PostHog auto-filed #987 for a `RecurringWarning`: *"Roster author `<url>` has no recent post to comment on — skipping"*, raised from `scan_outreach_funnel_targets`.

That warning lives in `_funnel_prospects_from_roster`, and it fires for a roster author whose recent activity holds no linkable post. **That is the common case, not a degraded one** — most people post weekly at best, while the funnel scan walks up to `_MAX_ROSTER_AUTHORS_PER_FUNNEL_SCAN` (5) authors on a *daily* beat. So a perfectly healthy roster of infrequent posters trips the escalation contract (3 repeats in 24h re-emit at ERROR and file ONE grouped `$exception`) and auto-files a defect for working behaviour.

Per the escalation contract in `src/cqc_lem/utilities/CLAUDE.md` it drops to `log_debug`, message text unchanged so the PostHog dedup key stays stable. This is the third of the same family on this pair of scans — #985 / PR #994 (`scan_connection_candidates`) and #995 / PR #996 (`scan_outreach_funnel_targets`'s three empty outcomes) — and it is the one per-author line those two left behind.

**What did NOT change:**
- The skip itself. No post still means nothing to comment on, so no target is filed (covered by a new test).
- The real failures either side of it. An unreadable roster profile (`Could not read a roster author's recent activity`), a failed commenter harvest, and the roster-sourcing degrade all keep their warnings — a new test pins the first of those so this downgrade can't creep.

Note on selector drift: `get_profile_recent_activity` returns `[]` for both "hasn't posted" and "selectors drifted", so a per-author warning was never a drift detector — it fired far more often on healthy quiet authors than on drift. Drift on that path is the **linkedin-live-validation** probe's job, and the whole-scan-empty outcome was already made DEBUG deliberately by #995.

## Testing

- `tests/unit/app/test_network_activation.py` — extended the existing `_scan_funnel` harness with `activity_exc` (mirroring `profile_exc`) and added:
  - the quiet-author case to `TestEmptyFunnelScanIsNotAWarning`'s parametrize (DEBUG, never `log_warning`),
  - `test_a_quiet_roster_author_is_skipped_without_filing_a_target` (behaviour unchanged),
  - `test_an_unreadable_roster_author_still_warns` (the genuine failure is not silenced).
- `poetry run pytest tests/unit/app/test_network_activation.py tests/unit/app/test_outreach_funnel.py -q` → 54 passed locally.

Closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)
