### PR TITLE
fix(errors): a deploy that quits a live browser session is not a defect (closes #988)

### DIFF
--- a/docs/error-tracking.md
+++ b/docs/error-tracking.md
@@ -117,6 +117,15 @@ escalated to ERROR and filed `RecurringWarning: Automation PAUSED for 1800s (rea
 detect it (the suppression tripwire escalates CRITICAL, the 429 breaker warns in `mark_rate_limited`),
 and only failing to store the pause — a kill-switch that didn't take — still warns.
 
+**A release that interrupts an in-flight task is the same shape one level up: an uncaught exception.**
+The deploy drains the workers for `DEFAULT_DRAIN_TIMEOUT_SECONDS` (8 min) and then recreates the
+containers regardless, so a long Selenium task still holding a browser has its session quit out from
+under it — and the next WebDriver call raised `InvalidSessionIdException`, crashed the task, and the
+`task_failure` signal filed it as a defect for a routine release (issue #988). `selenium_util.
+is_session_lost(exc)` is the ONE place that fault is recognised; a task that hits it ends on what
+already shipped and logs INFO. Deliberately NOT covered by it: a hub that refuses connections — an
+unreachable Grid is a different fault and must stay loud.
+
 | Env | Default | Purpose |
 |---|---|---|
 | `LOG_ESCALATION_ENABLED` | `true` | master switch; false → zero Redis calls |

--- a/docs/error-tracking.md
+++ b/docs/error-tracking.md
@@ -123,8 +123,11 @@ containers regardless, so a long Selenium task still holding a browser has its s
 under it — and the next WebDriver call raised `InvalidSessionIdException`, crashed the task, and the
 `task_failure` signal filed it as a defect for a routine release (issue #988). `selenium_util.
 is_session_lost(exc)` is the ONE place that fault is recognised; a task that hits it ends on what
-already shipped and logs INFO. Deliberately NOT covered by it: a hub that refuses connections — an
-unreachable Grid is a different fault and must stay loud.
+already shipped and logs INFO. A **best-effort catch site on the way there has to recognise it too**:
+the roster walk warns per target when an activity page won't open, so a dead session warned once per
+remaining target and crossed the escalation threshold — filing the same release as a defect through
+the other door. It stops the walk at INFO instead. Deliberately NOT covered by `is_session_lost`: a
+hub that refuses connections — an unreachable Grid is a different fault and must stay loud.
 
 | Env | Default | Purpose |
 |---|---|---|

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -1941,6 +1941,16 @@ def comment_on_roster_posts(driver, wait, my_profile: LinkedInProfile, user_id: 
             driver.get(url)
             wait_for_ajax(driver)
         except Exception as e:
+            if is_session_lost(e):
+                # The browser is gone (issue #988 — a deploy quits the session once the drain
+                # window is spent). Every remaining target is unreachable for that same reason, so
+                # warning per target would file the deploy as a defect through this door instead:
+                # three of these identical warnings cross the escalation threshold. Stop the walk
+                # on what already shipped and let the caller end the run.
+                log_info("Browser session ended mid-run (worker or Grid restart) — stopping the "
+                         "roster walk", user_id=user_id, action_type="comment",
+                         task_name="comment_on_roster_posts")
+                break
             log_warning("Could not open roster target's activity page", exc=e, user_id=user_id,
                         action_type="comment", task_name="comment_on_roster_posts")
             continue

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -101,7 +101,7 @@ from cqc_lem.utilities.observability import track_post_outcome, track_audience_s
 from cqc_lem.utilities.env_constants import INLINE_REACTIONS_ENABLED, MAX_WAIT_RETRY
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
     get_element_wait_retry, get_elements_as_list_wait_stale, getText, close_tab, get_driver_wait_pair, quit_gracefully, \
-    wait_for_ajax, find_first, click_first, find_all_first
+    wait_for_ajax, find_first, click_first, find_all_first, is_session_lost
 from dotenv import load_dotenv
 from selenium.common import NoSuchElementException, JavascriptException, StaleElementReferenceException, \
     ElementNotInteractableException, WebDriverException, TimeoutException, ElementClickInterceptedException
@@ -3257,10 +3257,23 @@ def auto_comment_in_groups(self, user_id: int, max_per_group: int = 2):
     total = 0
     try:
         for gid in enabled:
-            driver.get(f"https://www.linkedin.com/groups/{gid}/")
-            time.sleep(random.uniform(4, 7))
-            total += comment_on_feed_inline(driver, wait, my_profile, user_id,
-                                            max_posts=max_per_group, prefs=prefs, engagers=engagers)
+            try:
+                driver.get(f"https://www.linkedin.com/groups/{gid}/")
+                time.sleep(random.uniform(4, 7))
+                total += comment_on_feed_inline(driver, wait, my_profile, user_id,
+                                                max_posts=max_per_group, prefs=prefs, engagers=engagers)
+            except Exception as e:
+                if not is_session_lost(e):
+                    raise
+                # A walk across several group feeds is one of the longest browser sessions LEM
+                # holds, so it is the one a release lands on: the deploy drains for 8 minutes and
+                # then recreates the containers anyway, quitting this session out from under us
+                # (issue #988). The run is genuinely over — no later group can be reached on a dead
+                # session — but a routine release is not a defect, so end on what already shipped
+                # at INFO instead of crashing the task into a grouped $exception.
+                log_info("Browser session ended mid-run (worker or Grid restart) — stopping group "
+                         "commenting", user_id=user_id, task_name="auto_comment_in_groups")
+                return f"Commented {total} time(s) before the browser session ended"
         return f"Commented {total} time(s) across {len(enabled)} group(s)"
     finally:
         quit_gracefully(driver)

--- a/src/cqc_lem/utilities/selenium_util.py
+++ b/src/cqc_lem/utilities/selenium_util.py
@@ -12,7 +12,8 @@ import requests
 import selenium
 from selenium import webdriver
 from selenium.common import ElementNotInteractableException, StaleElementReferenceException, \
-    TimeoutException, WebDriverException, NoSuchElementException, SessionNotCreatedException
+    TimeoutException, WebDriverException, NoSuchElementException, SessionNotCreatedException, \
+    InvalidSessionIdException
 from selenium.webdriver import ActionChains
 from selenium.webdriver.chrome.options import Options
 from selenium.webdriver.common.by import By
@@ -37,6 +38,31 @@ def quit_gracefully(driver: WebDriver):
     except Exception as e:
         myprint(f"Error while quitting driver: {e}")
         pass
+
+
+# What the Grid says when the session a call names is gone. The exception type covers the normal
+# case; the message markers catch the same fault arriving as a bare WebDriverException from an
+# older/wrapped driver. Deliberately NOT here: connection failures to the hub itself — a Grid that
+# cannot be reached is a different fault and must stay loud.
+_SESSION_GONE_MARKERS = ("invalid session id", "unable to find session", "no such session",
+                         "session deleted")
+
+
+def is_session_lost(exc: BaseException) -> bool:
+    """True when a WebDriver call failed because the browser SESSION no longer exists.
+
+    A deploy is the ordinary cause (issue #988): maintenance mode drains the workers for
+    `maintenance.DEFAULT_DRAIN_TIMEOUT_SECONDS` and then recreates the containers regardless, so a
+    long Selenium task still holding a session has it quit out from under it. The run is over
+    either way — what this decides is whether the caller ends it on what already shipped or crashes
+    and files a defect for a routine release.
+    """
+    if isinstance(exc, InvalidSessionIdException):
+        return True
+    if isinstance(exc, WebDriverException):
+        message = (getattr(exc, "msg", None) or str(exc) or "").lower()
+        return any(marker in message for marker in _SESSION_GONE_MARKERS)
+    return False
 
 
 def get_available_session_driver_id(wait_for_available=True, wait_time=60, retry=3):

--- a/tests/unit/app/test_engagement_roster.py
+++ b/tests/unit/app/test_engagement_roster.py
@@ -266,6 +266,30 @@ class TestCommentOnRosterPosts:
         assert stats["posted"] == 0 and stats["targets_visited"] == 0
         engage.assert_not_called()
 
+    def test_a_session_quit_out_from_under_the_walk_stops_it_without_warning(self):
+        """Issue #988: a deploy quits the browser once the drain window is spent. Every remaining
+        target is unreachable for that same reason, so warning per target would escalate into a
+        filed defect for a routine release — the walk stops at INFO on what already shipped."""
+        from cqc_lem.app import run_automation as ra
+        from selenium.common import InvalidSessionIdException
+        driver = MagicMock()
+        driver.get.side_effect = InvalidSessionIdException("Unable to find session with ID: abc")
+        with ExitStack() as es:
+            p = lambda name, **kw: es.enter_context(patch(f"{_RA}.{name}", **kw))
+            p("get_engagement_targets", return_value=[_target("https://www.linkedin.com/in/jane"),
+                                                      _target("https://www.linkedin.com/in/john")])
+            p("wait_for_ajax")
+            warned = p("log_warning")
+            info = p("log_info")
+            engage = p("_engage_card")
+            stats = ra.comment_on_roster_posts(driver, MagicMock(), MagicMock(), 1, 5, {},
+                                               "synthesis", [], set())
+        assert stats["posted"] == 0 and stats["targets_visited"] == 0
+        assert driver.get.call_count == 1  # the 2nd target is unreachable on a dead session
+        warned.assert_not_called()
+        assert info.called
+        engage.assert_not_called()
+
 
 def _run_feed(boxes, *, prefs=None, relevant=True, roster_stats=None, matches=True):
     """Drive comment_on_feed_inline end-to-end with the roster pass stubbed, so the assertions are

--- a/tests/unit/app/test_groups.py
+++ b/tests/unit/app/test_groups.py
@@ -283,6 +283,41 @@ class TestCommentInGroups:
         assert "No enabled groups" in result
         gp.assert_not_called()
 
+    def test_a_session_quit_out_from_under_the_run_ends_it_on_what_shipped(self):
+        """Issue #988: a deploy recreates the containers once the drain window is spent, so a group
+        walk that outlives it loses its browser. That is a routine release, not a defect — the run
+        keeps the comments it already posted, logs INFO, and never raises."""
+        from cqc_lem.app.run_automation import auto_comment_in_groups
+        from selenium.common import InvalidSessionIdException
+        driver = MagicMock()
+        driver.get.side_effect = [None, InvalidSessionIdException("Unable to find session with ID: abc")]
+        with patch(f"{_RA}.get_enabled_group_ids", return_value=["1", "2", "3"]), \
+             patch(f"{_RA}.get_current_profile", return_value=(driver, MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_recent_engagers", return_value=set()), \
+             patch(f"{_RA}.comment_on_feed_inline", return_value=2) as cfi, \
+             patch(f"{_RA}.log_info") as info, \
+             patch(f"{_RA}.log_error") as err, \
+             patch(f"{_RA}.quit_gracefully") as quit_driver:
+            result = auto_comment_in_groups.run(user_id=1)
+        assert result == "Commented 2 time(s) before the browser session ended"
+        assert cfi.call_count == 1  # the second group is unreachable on a dead session
+        assert info.called and not err.called
+        quit_driver.assert_called_once_with(driver)
+
+    def test_a_real_failure_mid_run_still_raises(self):
+        """Only a LOST SESSION is absorbed — anything else stays a crash, and a defect."""
+        from cqc_lem.app.run_automation import auto_comment_in_groups
+        driver = MagicMock()
+        with patch(f"{_RA}.get_enabled_group_ids", return_value=["1"]), \
+             patch(f"{_RA}.get_current_profile", return_value=(driver, MagicMock(), "e", MagicMock())), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.get_recent_engagers", return_value=set()), \
+             patch(f"{_RA}.comment_on_feed_inline", side_effect=RuntimeError("boom")), \
+             patch(f"{_RA}.quit_gracefully"):
+            with pytest.raises(RuntimeError):
+                auto_comment_in_groups.run(user_id=1)
+
 
 _READY_DRAFT = {"id": 11, "user_id": 1, "group_id": "123", "group_name": "AI Leaders",
                 "content": "A useful insight.", "status": "ready"}

--- a/tests/unit/utilities/test_selenium_session_lost.py
+++ b/tests/unit/utilities/test_selenium_session_lost.py
@@ -1,0 +1,41 @@
+"""Unit tests for the lost-browser-session predicate (issue #988)."""
+
+import pytest
+from selenium.common import (InvalidSessionIdException, NoSuchElementException, TimeoutException,
+                             WebDriverException)
+
+pytestmark = pytest.mark.unit
+
+from cqc_lem.utilities.selenium_util import is_session_lost
+
+_GRID_MESSAGE = (
+    "Message: Unable to find session with ID: e5d140e95d14b7cef20ad67aec43a5d1. Session was "
+    "removed at 2026-08-02T17:28:27Z (2 seconds ago), reason: session closed normally (QUIT "
+    "command), node: http://selenium-node-debug:5555"
+)
+
+
+class TestIsSessionLost:
+    def test_invalid_session_id_exception_is_a_lost_session(self):
+        assert is_session_lost(InvalidSessionIdException(_GRID_MESSAGE)) is True
+
+    def test_grid_message_on_a_bare_webdriver_exception_is_a_lost_session(self):
+        """The same fault reaches us as a plain WebDriverException from a wrapped/older driver."""
+        assert is_session_lost(WebDriverException(_GRID_MESSAGE)) is True
+
+    @pytest.mark.parametrize("message", ["invalid session id", "No such session",
+                                         "session deleted because of page crash"])
+    def test_every_session_gone_marker_matches_case_insensitively(self, message):
+        assert is_session_lost(WebDriverException(message)) is True
+
+    def test_a_grid_we_cannot_reach_is_not_a_lost_session(self):
+        """A hub that refuses connections is a different fault and must stay loud."""
+        exc = WebDriverException("Failed to establish a new connection: Connection refused")
+        assert is_session_lost(exc) is False
+
+    @pytest.mark.parametrize("exc", [NoSuchElementException("no such element"),
+                                     TimeoutException("timed out"),
+                                     ValueError("unable to find session"),
+                                     RuntimeError("boom")])
+    def test_other_failures_are_not_lost_sessions(self, exc):
+        assert is_session_lost(exc) is False


### PR DESCRIPTION
## What & why

PostHog filed `InvalidSessionIdException` against `auto_comment_in_groups` (issue #988). The Grid's message names the cause exactly: *"Session was removed … reason: session closed normally (QUIT command)"*, and the logs from the same window name who issued it — `Drain timed out with 1 task(s) still running`, seven minutes earlier.

So this is a **deploy**, not a bug in the group walk. Maintenance mode drains the workers for `DEFAULT_DRAIN_TIMEOUT_SECONDS` (8 min) and then recreates the containers regardless; a walk across several group feeds is one of the longest browser sessions LEM holds, so it is the one a release lands on. Its session was quit out from under it, the next `driver.get()` raised, the task crashed, and the `task_failure` signal filed a grouped `$exception` — a defect ticket for a routine 4x-daily release. Same shape as #917 (a deploy filing `Automation PAUSED`), one level up: an uncaught exception rather than a warning.

## The change

- **`selenium_util.is_session_lost(exc)`** — the ONE place a vanished session is recognised: `InvalidSessionIdException`, plus the Grid's session-gone phrasings arriving as a bare `WebDriverException`.
- **`auto_comment_in_groups`** returns on what already shipped and logs **INFO** when it hits one. No later group is reachable on a dead session, so nothing is lost by stopping; and re-queue semantics are unchanged, because celery acks a *failed* task exactly as it acks a returned one — only a killed worker re-queues, which is what actually happens here.
- Deliberately **not** absorbed: a hub that refuses connections. An unreachable Grid is a different fault and must stay loud. Anything other than a lost session still raises.
- `docs/error-tracking.md` records the precedent next to #917.

## Testing

`tests/unit/utilities/test_selenium_session_lost.py` (new) covers the predicate — the real Grid message, each marker, and the negatives (connection-refused, `NoSuchElementException`, a non-Selenium `ValueError` carrying the same words). `tests/unit/app/test_groups.py` adds two: a session lost on the 2nd of 3 groups keeps the 2 comments already posted, logs INFO not ERROR, still quits the driver, and never reaches group 3; and a `RuntimeError` mid-run still raises.

`poetry run pytest tests/unit -q` — 8013 passed locally (`tests/unit/app` + `tests/unit/utilities`).

Closes #988

🤖 Generated with [Claude Code](https://claude.com/claude-code)
