### PR TITLE
fix(automation): profile viewer walk finds zero viewers — ground on live SDUI DOM

### DIFF
--- a/docs/sdui-selenium-notes.md
+++ b/docs/sdui-selenium-notes.md
@@ -22,6 +22,22 @@ prompts also render as listitems; the profile-link + classifier funnel filters t
 "Say congrats" suggestion chips carry no stable anchors either — when the harvest misses, drafting
 falls back to `_CATCHUP_DEFAULT_CONGRATS`, which is working as designed.
 
+## The profile-views analytics list is full SDUI — no `<ul>`, TEXT is the only anchor
+
+Live-grounded 2026-08-03 (`/analytics/profile-views/`, user 1): the page renders **zero** `<ul>`
+elements and no `artdeco-entity-lockup__*` classes, so the original
+`//ul[@aria-label="List of Entities"]//a[...]` walk matched nothing on a page visibly listing
+136 viewers — every run warned `Could not read the profile viewers list` and engaged nobody.
+A viewer row is an `/in/` anchor (componentkey UUID) whose innerText carries a
+`Viewed 1h ago`-style caption line (`1h`/`20h`/`1d`/`1w`/`1mo`/`2mo`); non-viewer profile
+anchors ("Interesting viewers", nav) carry no such line, so the caption IS the discriminator.
+The walk reads name+href+caption in ONE `execute_script` pass (`_PROFILE_VIEWER_ROWS_JS`) —
+per-element XPath reads go stale as the list re-renders. `window.scrollTo` alone never grows
+the list; `scrollIntoView` on the LAST row is what triggers the lazy loader (8 → 58 rows).
+Zero rows against a non-zero "N Profile viewers" headline stat is selector drift and warns;
+zero rows with no stat is a quiet no-op. Re-ground with
+`scripts/linkedin_live_validation.py --profile-views`.
+
 ## The comment composer has no `<form>`
 
 "Submit" means clicking the Comment/Post button next to the composer (`_composer_submitted`).

--- a/scripts/linkedin_live_validation.py
+++ b/scripts/linkedin_live_validation.py
@@ -519,6 +519,43 @@ def probe_feed_sort(driver, sleep=time.sleep) -> dict:
     return reading
 
 
+def probe_profile_viewers(driver, sleep=time.sleep) -> dict:
+    """Profile-views analytics page: report how many viewer rows the production locator matches,
+    the caption forms in play, and the page's own headline count so a locator miss cannot read as
+    an empty page. Read-only — nothing is clicked and nobody is engaged.
+
+    The production locator is a TEXT discriminator (an /in/ anchor carrying a "Viewed …" line);
+    `sample_rows` holds each row's text lines, which is exactly what the next locator gets
+    re-grounded from when this rotates again."""
+    from cqc_lem.app.run_automation import (_PROFILE_VIEWER_ROWS_JS, _PROFILE_VIEWER_SCROLL_JS,
+                                            _PROFILE_VIEWER_STAT_JS)
+
+    driver.get("https://www.linkedin.com/analytics/profile-views/")
+    sleep(8)
+    rows = driver.execute_script(_PROFILE_VIEWER_ROWS_JS) or []
+    stat = driver.execute_script(_PROFILE_VIEWER_STAT_JS)
+    driver.execute_script(_PROFILE_VIEWER_SCROLL_JS)
+    sleep(3)
+    rows_after_scroll = driver.execute_script(_PROFILE_VIEWER_ROWS_JS) or []
+    reading = {
+        "url": getattr(driver, "current_url", ""),
+        "row_count": len(rows),
+        "row_count_after_scroll": len(rows_after_scroll),
+        "headline_stat": stat,
+        "caption_forms": sorted({(r.get("viewed") or "").split(" ", 2)[-1] for r in rows if r.get("viewed")}),
+        "sample_rows": [{"href": r.get("href"), "viewed": r.get("viewed")} for r in rows[:5]],
+    }
+    if stat and not rows:
+        reading["verdict"] = f"headline reports {stat} viewers but the row locator matched none — selector drift"
+    elif not rows:
+        reading["verdict"] = "no viewers listed and no headline stat — page empty or not rendered"
+    elif len(rows_after_scroll) <= len(rows):
+        reading["verdict"] = f"{len(rows)} rows matched but the scroll did not grow the list — lazy-load drift"
+    else:
+        reading["verdict"] = f"{len(rows)} rows matched, scroll grew the list to {len(rows_after_scroll)}"
+    return reading
+
+
 def message_thread_verdict(reading: Optional[dict]) -> str:
     """What one thread-open probe proves about the #731 resolution ladder.
 
@@ -1240,6 +1277,10 @@ def main(argv: Optional[list] = None) -> int:
     parser.add_argument("--feed-sort", action="store_true",
                         help="report whether the home feed's 'Sort by -> Recent' control resolves "
                              "and whether the flip sticks (#817)")
+    parser.add_argument("--profile-views", action="store_true",
+                        help="report the profile-views analytics page's viewer-row locator state: "
+                             "rows matched vs the page's own headline count, caption forms, and "
+                             "whether the lazy-load scroll grows the list")
     parser.add_argument("--watch", action="store_true",
                         help="request the watchable Grid debug node so the session is visible via "
                              "noVNC; falls back to the pool if the debug node is busy/absent")
@@ -1255,10 +1296,12 @@ def main(argv: Optional[list] = None) -> int:
 
     if not (args.post_url or args.probe_composer or args.comment_outcome_url or args.dm_thread_url
             or args.article_editor_url or args.feed_sort or args.reaction_probe
-            or args.roster_follow or args.appreciation_sources or args.sent_invites):
+            or args.roster_follow or args.appreciation_sources or args.sent_invites
+            or args.profile_views):
         parser.error("nothing to probe — pass --post-url, --comment-outcome-url, --dm-thread-url, "
-                     "--article-editor-url, --feed-sort, --reaction-probe, --roster-follow, "
-                     "--appreciation-sources, --sent-invites and/or --probe-composer")
+                     "--article-editor-url, --feed-sort, --profile-views, --reaction-probe, "
+                     "--roster-follow, --appreciation-sources, --sent-invites and/or "
+                     "--probe-composer")
 
     from cqc_lem.app.run_automation import get_current_profile
     from cqc_lem.utilities.selenium_util import quit_gracefully
@@ -1286,6 +1329,8 @@ def main(argv: Optional[list] = None) -> int:
                 self_name=resolve_self_name(args.user_id, profile))
         if args.feed_sort:
             report["feed_sort"] = probe_feed_sort(driver)
+        if args.profile_views:
+            report["profile_views"] = probe_profile_viewers(driver)
         if args.roster_follow:
             report["roster_follow"] = probe_roster_follow(driver, args.roster_follow)
         if args.appreciation_sources:

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -5803,9 +5803,61 @@ def generate_and_post_comment(driver, wait, post_link, my_profile: LinkedInProfi
     return True
 
 
+# The profile-views analytics page is SDUI (grounded live 2026-08-03): no <ul>/<li> list
+# container, hashed class names only. A viewer row is an /in/ anchor whose text carries a
+# "Viewed …" caption line — a pure TEXT discriminator, per the fix invariants (never classes).
+# One JS read returns every row's (href, name, caption) in one shot, so nothing goes stale
+# while the list re-renders under the walk.
+_PROFILE_VIEWER_ROWS_JS = """
+const rows = [...document.querySelectorAll('a[href*="/in/"]')].filter(a =>
+  /(^|\\n)Viewed /.test(a.innerText || ''));
+return rows.map(a => {
+  const lines = (a.innerText || '').split('\\n').map(t => t.trim()).filter(Boolean);
+  return {href: a.href, name: lines[0] || '',
+          viewed: lines.find(t => t.startsWith('Viewed ')) || ''};
+});
+"""
+
+# The page's "N Profile viewers" headline (past-90-days stat). A non-zero stat with zero
+# matched rows is selector drift, not an empty page — the tripwire that keeps a dead locator
+# from reading exactly like nobody-viewed (the #964 failure mode).
+_PROFILE_VIEWER_STAT_JS = """
+const m = (document.body.innerText || '').match(/([\\d,]+)\\s*\\n\\s*Profile viewers/i);
+return m ? parseInt(m[1].replace(/,/g, ''), 10) : null;
+"""
+
+# Window scrollTo alone does not grow this list — scrolling the LAST viewer row into view is
+# what triggers the lazy loader (grounded live: 8 -> 58 rows this way, scrollTo-only stayed at 8).
+_PROFILE_VIEWER_SCROLL_JS = """
+const rows = [...document.querySelectorAll('a[href*="/in/"]')].filter(a =>
+  /(^|\\n)Viewed /.test(a.innerText || ''));
+if (rows.length) rows[rows.length - 1].scrollIntoView({block: 'end'});
+window.scrollTo(0, document.body.scrollHeight);
+"""
+
+
+# How long to keep polling an empty viewers list before believing it — the SDUI page paints
+# asynchronously and an early read sees zero rows on a page that is still loading.
+_PROFILE_VIEWER_RENDER_WAIT_SECONDS = 30
+
+
+def _viewer_within_lookback(viewed_on: str, lookback_days: int) -> Optional[bool]:
+    """Whether a viewed-on caption falls inside the lookback window; None when it won't parse
+    (the caller decides whether that stops the walk or just drops the row)."""
+    try:
+        viewed_date = convert_viewed_on_to_date(viewed_on)
+    except (ValueError, TypeError, AttributeError):
+        return None
+    return (datetime.now() - viewed_date).days <= lookback_days
+
+
 @shared_task.task(bind=True, base=QueueOnce, once={'graceful': True, 'unlock_before_run': True, 'keys': ['user_id']},
                   queue='se_outreach')
-def automate_profile_viewer_engagement(self, user_id: int, loop_for_duration: int = None, future_forward: int = 60):
+def automate_profile_viewer_engagement(self, user_id: int, loop_for_duration: int = None, future_forward: int = 60,
+                                       lookback_days: int = 1):
+    """Walk the profile-views analytics list and queue engagement for each viewer inside
+    `lookback_days`. The default matches the daily cadence; a catch-up run passes a larger
+    window once, then the cadence sticks to the delta."""
     global stop_all_thread
 
     myprint("Starting Profile Viewer DMs")
@@ -5828,153 +5880,92 @@ def automate_profile_viewer_engagement(self, user_id: int, loop_for_duration: in
 
         start_time = datetime.now()
 
-        viewed_on_xpath = './/div[contains(@class,"artdeco-entity-lockup__caption ember-view")]'
+        rows: list[dict] = []
+        previous_count = -1
+        render_deadline = datetime.now() + timedelta(seconds=_PROFILE_VIEWER_RENDER_WAIT_SECONDS)
 
-        viewer_elements: list[WebElement] = []
-        previous_viewer_count = -1
+        while True:  # Keep walking until the last row's viewed-on date falls out of the lookback
+            rows = driver.execute_script(_PROFILE_VIEWER_ROWS_JS) or []
 
-        while True:  # Keep looping until we find a viewed on date out of range
-            # Get Each Viewer within the last day (or time of dm run via database log)
-            try:
-                viewer_elements = get_elements_as_list_wait_stale(wait,
-                                                                  '//ul[@aria-label="List of Entities"]//a[contains(@href,"linkedin.com/in") and not(contains(@aria-label,"Update"))]',
-                                                                  "Finding Profile Viewers")
-            except (TimeoutException, StaleElementReferenceException) as e:
-                # An empty analytics page never resolves the wait — find_elements returns [] and the
-                # helper polls to a timeout. Nobody viewed the profile (or the list didn't render) is
-                # nothing to do, not a task failure, so it must not page the error cron.
-                log_warning(f"Could not read the profile viewers list — ending the walk with "
-                            f"{len(viewer_elements)} viewer(s)",
-                            exc=e, user_id=user_id, task_name="automate_profile_viewer_engagement")
+            if not rows:
+                # The SDUI page renders asynchronously — give the first paint time to land
+                # before concluding the list is empty.
+                if datetime.now() < render_deadline:
+                    time.sleep(2)
+                    continue
                 break
 
-            # myprint(f"Viewers count: {len(viewer_elements)}")
+            # An unparseable last caption means we can't tell whether to keep walking — stop
+            # with what we have rather than failing the task through the outer handler.
+            last_verdict = _viewer_within_lookback(rows[-1].get('viewed', ''), lookback_days)
+            if last_verdict is None:
+                log_warning("Could not parse the last profile viewer's viewed-on caption — "
+                            "stopping the walk", user_id=user_id,
+                            task_name="automate_profile_viewer_engagement")
+                break
+            if last_verdict is False:
+                break  # Walked past the lookback window
 
-            if len(viewer_elements) > 0:
-                # The list re-renders under us as we scroll it, so an unreadable last row means we
-                # can't tell whether to keep walking — stop with what we have rather than failing.
-                try:
-                    # Get the last viewer
-                    last_viewer = viewer_elements[-1]
-                    # Extract the viewer's name
-                    name_element = last_viewer.find_element(By.XPATH,
-                                                            './/div[contains(@class,"artdeco-entity-lockup__title")]/span/span[1]')
-                    if name_element:
-                        last_viewer_name = getText(name_element)
-                        # myprint(f"Last Viewer Name: {last_viewer_name}")
-                    else:
-                        last_viewer_name = random.choice(["John", "Jane"]) + " Doe"
-                        myprint("Could not find name of last viewer")
+            # The list only grows by scrolling. When a scroll adds nothing there is no more to
+            # walk, and every row we have is still in range — without this the loop would spin
+            # forever on an account whose viewers all fit on one screen.
+            if len(rows) <= previous_count:
+                myprint("Profile viewers list stopped growing. Ending the walk...")
+                break
+            previous_count = len(rows)
 
-                    last_viewed_on_element = last_viewer.find_element(By.XPATH, viewed_on_xpath)
-                except (StaleElementReferenceException, NoSuchElementException) as e:
-                    log_warning("Could not read the last profile viewer row — stopping the walk",
-                                exc=e, user_id=user_id, task_name="automate_profile_viewer_engagement")
-                    break
+            driver.execute_script(_PROFILE_VIEWER_SCROLL_JS)
+            time.sleep(2)
 
-                if last_viewed_on_element:
-                    # An unparseable caption raises out of convert_viewed_on_to_date — that is the
-                    # same "we can't tell whether to keep walking" case as an unreadable row, so it
-                    # ends the walk instead of failing the task through the outer handler.
-                    try:
-                        last_viewed_on = getText(last_viewed_on_element).strip()
-                        # Convert viewed on to date
-                        last_viewed_date = convert_viewed_on_to_date(last_viewed_on)
-                    except (ValueError, TypeError, AttributeError,
-                            StaleElementReferenceException) as e:
-                        log_warning("Could not read the last profile viewer's viewed-on date — "
-                                    "stopping the walk", exc=e, user_id=user_id,
-                                    task_name="automate_profile_viewer_engagement")
-                        break
-
-                    # if the last viewed on date is Greater than 24 hours break the while loop
-                    if (datetime.now() - last_viewed_date).days > 1:
-                        # myprint("Last viewed on date is more than 24 hours ago")
-                        break  # Break the while loop
-                else:
-                    myprint(f"Could not find viewed on element for {last_viewer_name}")
-
-                # The list only grows by scrolling. When a scroll adds nothing there is no more to
-                # walk, and every row we have is still in range — without this the loop would spin
-                # forever on an account whose viewers all fit on one screen.
-                if len(viewer_elements) <= previous_viewer_count:
-                    myprint("Profile viewers list stopped growing. Ending the walk...")
-                    break
-                previous_viewer_count = len(viewer_elements)
-
-                # Scroll down to get more elements
-                driver.execute_script("window.scrollTo(0, document.body.scrollHeight);")
-                time.sleep(2)
-
-            else:
-                break  # Break the while loop
-
-        # myprint(f"Viewers: {str(viewer_elements)}")
-        result = f"Profile Viewer DMs Started. Found {len(viewer_elements)} viewers"
-        myprint(f"Final Viewers count: {len(viewer_elements)}")
-
-        # Filter the viewers by date within the last day, per row. The walk stops ON an
-        # out-of-range viewer, so that row is always in this list — an all-or-nothing filter that
-        # threw on one unreadable caption would leave it in and DM someone who viewed weeks ago.
-        # A row whose date we cannot read is dropped for the same reason.
-        in_range_viewers: list[WebElement] = []
-        for e in viewer_elements:
+        if not rows:
             try:
-                viewed_date = convert_viewed_on_to_date(
-                    getText(e.find_element(By.XPATH, viewed_on_xpath)))
-            except (ValueError, TypeError, AttributeError, StaleElementReferenceException,
-                    NoSuchElementException) as ex:
-                log_warning("Skipping profile viewer with an unreadable viewed-on date", exc=ex,
+                headline_stat = driver.execute_script(_PROFILE_VIEWER_STAT_JS)
+            except WebDriverException:
+                headline_stat = None
+            if headline_stat:
+                log_warning(f"Profile viewers page reports {headline_stat} viewers but the row "
+                            f"locator matched none — selector drift", user_id=user_id,
+                            task_name="automate_profile_viewer_engagement")
+            else:
+                # Nobody viewed the profile — nothing to do, not a task failure, so it must
+                # not page the error cron.
+                log_debug("No profile viewers found on the analytics page — nothing to do",
+                          user_id=user_id, task_name="automate_profile_viewer_engagement")
+
+        result = f"Profile Viewer DMs Started. Found {len(rows)} viewers"
+        myprint(f"Final Viewers count: {len(rows)}")
+
+        # Filter per row against the lookback. The walk stops ON an out-of-range viewer, so that
+        # row is always in this list — an all-or-nothing filter that threw on one unreadable
+        # caption would leave it in and DM someone who viewed weeks ago. A row whose date we
+        # cannot read is dropped for the same reason. Keyed on href: it is the viewer's identity
+        # (two viewers can share a display name), and it dedupes re-rendered rows.
+        viewer_data: dict[str, str] = {}
+        for row in rows:
+            viewer_url = row.get('href') or ''
+            if '/in/' not in viewer_url:
+                continue
+            verdict = _viewer_within_lookback(row.get('viewed', ''), lookback_days)
+            if verdict is None:
+                log_warning("Skipping profile viewer with an unreadable viewed-on caption",
                             user_id=user_id, task_name="automate_profile_viewer_engagement")
                 continue
-            if (datetime.now() - viewed_date).days <= 1:
-                in_range_viewers.append(e)
-        viewer_elements = in_range_viewers
+            if verdict:
+                viewer_data[viewer_url] = row.get('name') or 'LinkedIn Member'
 
-        myprint(f"Filtered Viewers count: {len(viewer_elements)}")
+        myprint(f"Filtered Viewers count: {len(viewer_data)}")
 
-        current_tab = driver.current_window_handle
-        handles = driver.window_handles
-
-        # Get all the viewer names and urls into a dict so that elements don't go stale. One
-        # unreadable row must not lose the whole batch — the list re-renders while we scroll it.
-        viewer_data: dict[str, str] = {}
-        for e in viewer_elements:
-            try:
-                viewer_name = getText(
-                    e.find_element(By.XPATH,
-                                   './/div[contains(@class,"artdeco-entity-lockup__title")]/span/span[1]'))
-                viewer_url = e.get_attribute('href')
-            except (StaleElementReferenceException, NoSuchElementException) as ex:
-                log_warning("Skipping unreadable profile viewer row", exc=ex, user_id=user_id,
-                            task_name="automate_profile_viewer_engagement")
-                continue
-            if viewer_url:
-                viewer_data[viewer_name] = viewer_url
-
-        # Get the viewed data from each element and filter by a day ago or specific date
-        for viewer_name, viewer_url in viewer_data.items():
-            # Switch back to tab
-            driver.switch_to.window(current_tab)
-
+        # engage_with_profile_viewer opens its own session and navigates to the profile itself —
+        # visiting each viewer here too doubled the profile visits and held this session open
+        # for nothing, so the walk just dispatches.
+        for viewer_url, viewer_name in viewer_data.items():
             myprint(f"Viewer Name: {viewer_name}")
             myprint(f"Viewer URL: {viewer_url}")
 
-            # Wait for the new window or tab
-            driver.switch_to.new_window('tab')
-            wait.until(EC.new_window_is_opened(handles))
-
-            # Switch to viewer_url
-            driver.get(viewer_url)
-
-            # Engage with the viewer
             kwargs = {'user_id': get_user_id(my_profile.email),
                       'viewer_url': viewer_url,
                       'viewer_name': viewer_name}
             engage_with_profile_viewer.apply_async(kwargs=kwargs)
-
-            # Close tab when done
-            close_tab(driver)
 
         result = f"Profile Viewer DMs Completed. Engaged with {len(viewer_data)} viewers"
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -104,16 +104,15 @@ from cqc_lem.utilities.observability import track_post_outcome, track_audience_s
     FEATURE_COMMENT, FEATURE_CONTENT, FEATURE_DM
 from cqc_lem.utilities.env_constants import INLINE_REACTIONS_ENABLED, MAX_WAIT_RETRY
 from cqc_lem.utilities.selenium_util import click_element_wait_retry, \
-    get_element_wait_retry, get_elements_as_list_wait_stale, getText, close_tab, get_driver_wait_pair, quit_gracefully, \
+    get_element_wait_retry, get_elements_as_list_wait_stale, getText, get_driver_wait_pair, quit_gracefully, \
     wait_for_ajax, find_first, click_first, find_all_first, is_session_lost
 from dotenv import load_dotenv
 from selenium.common import NoSuchElementException, JavascriptException, StaleElementReferenceException, \
-    ElementNotInteractableException, WebDriverException, TimeoutException, ElementClickInterceptedException
+    ElementNotInteractableException, WebDriverException, ElementClickInterceptedException
 from selenium.webdriver import ActionChains, Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.remote.webelement import WebElement
-from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
 # Load .env file

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -5931,7 +5931,6 @@ def automate_profile_viewer_engagement(self, user_id: int, loop_for_duration: in
                 log_debug("No profile viewers found on the analytics page — nothing to do",
                           user_id=user_id, task_name="automate_profile_viewer_engagement")
 
-        result = f"Profile Viewer DMs Started. Found {len(rows)} viewers"
         myprint(f"Final Viewers count: {len(rows)}")
 
         # Filter per row against the lookback. The walk stops ON an out-of-range viewer, so that

--- a/src/cqc_lem/utilities/date.py
+++ b/src/cqc_lem/utilities/date.py
@@ -175,10 +175,31 @@ def convert_date_to_datetime(date: DT.date) -> DT.datetime:
     return DT.datetime.combine(date, DT.datetime.min.time())
 
 
-def convert_viewed_on_to_date(viewed_on):
-    viewed_on = re.sub(r'(?i)viewed', '', viewed_on)
-    viewed_on = re.sub(r'(?i)edited', '', viewed_on)
-    viewed_on = re.sub(r'(?i)•', '', viewed_on)
-    # Change 'w' to 'week'
-    viewed_on = re.sub(r'(?i)w', 'week', viewed_on)
-    return get_datetime(viewed_on.strip())
+# LinkedIn's viewed-on captions are relative ("Viewed 1h ago", "20h", "1d", "1w", "1mo", "2mo") —
+# grounded live 2026-08-03. Months/years only need to sort out of any realistic lookback window,
+# so calendar-exact arithmetic is not required for them.
+_VIEWED_ON_UNIT_DAYS = {'mo': 30, 'mos': 30, 'month': 30, 'months': 30,
+                        'y': 365, 'yr': 365, 'yrs': 365, 'year': 365, 'years': 365}
+_VIEWED_ON_UNITS = {'s': 'seconds', 'sec': 'seconds', 'secs': 'seconds',
+                    'second': 'seconds', 'seconds': 'seconds',
+                    'm': 'minutes', 'min': 'minutes', 'mins': 'minutes',
+                    'minute': 'minutes', 'minutes': 'minutes',
+                    'h': 'hours', 'hr': 'hours', 'hrs': 'hours',
+                    'hour': 'hours', 'hours': 'hours',
+                    'd': 'days', 'day': 'days', 'days': 'days',
+                    'w': 'weeks', 'wk': 'weeks', 'wks': 'weeks',
+                    'week': 'weeks', 'weeks': 'weeks'}
+
+
+def convert_viewed_on_to_date(viewed_on: str) -> DT.datetime:
+    text = re.sub(r'(?i)viewed|edited|•', '', viewed_on or '').strip()
+    match = re.fullmatch(r'(?i)(\d+)\s*([a-z]+)\.?(?:\s+ago)?', text)
+    if match:
+        count, unit = int(match.group(1)), match.group(2).lower()
+        if unit in _VIEWED_ON_UNIT_DAYS:
+            return DT.datetime.now() - DT.timedelta(days=_VIEWED_ON_UNIT_DAYS[unit] * count)
+        if unit in _VIEWED_ON_UNITS:
+            return DT.datetime.now() - DT.timedelta(**{_VIEWED_ON_UNITS[unit]: count})
+    # Anything non-relative (absolute dates, locale forms) still goes through dateparser,
+    # which raises ValueError via get_datetime when it can't parse — callers rely on that.
+    return get_datetime(text)

--- a/tests/unit/app/test_profile_viewer_engagement.py
+++ b/tests/unit/app/test_profile_viewer_engagement.py
@@ -1,141 +1,166 @@
-"""Unit tests for automate_profile_viewer_engagement's best-effort read of the profile-views page.
+"""Unit tests for automate_profile_viewer_engagement's JS-driven read of the profile-views page.
 
-The analytics list never resolves the wait when nobody viewed the profile — find_elements
-returns [] and the helper polls to a TimeoutException. That is "nothing to do", not a task
-failure, so it must degrade to a warning instead of paging the PostHog error cron (issue #572).
+The analytics page is SDUI (no <ul>/<li> container, hashed class names): a viewer row is an
+/in/ anchor whose text carries a "Viewed …" caption, read via one execute_script call so nothing
+goes stale while the list re-renders. Zero rows with a non-zero "Profile viewers" headline is
+selector drift and must stay loud; zero rows with no headline is nothing-to-do and must stay
+quiet (issue #572 — it must not page the error cron).
 """
 
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
 
 pytestmark = pytest.mark.unit
 
 _MOD = "cqc_lem.app.run_automation"
 
 
-def _profile_pair():
-    driver = MagicMock(name="driver")
+def _profile_pair(driver=None):
+    driver = driver or MagicMock(name="driver")
     wait = MagicMock(name="wait")
     profile = MagicMock(name="profile")
     profile.email = "user@example.com"
     return driver, wait, "user@example.com", profile
 
 
-def _viewer_row(name: str, url: str) -> MagicMock:
-    """A row whose title/caption nodes carry real text, so getText runs unpatched."""
-    row = MagicMock(name=f"row_{name}")
-    row.get_attribute.return_value = url
-
-    def _find(by, value):
-        node = MagicMock(name=f"node_{name}")
-        node.text = name if "lockup__title" in value else "viewed 1h ago"
-        return node
-
-    row.find_element.side_effect = _find
-    return row
+def _row(name: str, slug: str, viewed: str) -> dict:
+    return {"href": f"https://www.linkedin.com/in/{slug}/", "name": name, "viewed": viewed}
 
 
-def _engaged_urls(mock_engage) -> list[str]:
-    return [c.kwargs["kwargs"]["viewer_url"] for c in mock_engage.apply_async.call_args_list]
+def _driver_scripting(rows_per_round: list[list[dict]], headline_stat=None) -> MagicMock:
+    """A driver whose execute_script answers the three JS reads the walk makes.
+
+    `rows_per_round` is consumed one list per rows-read; the last list repeats once exhausted
+    (the real list stops growing)."""
+    driver = MagicMock(name="driver")
+    reads = {"i": 0}
+
+    def _execute(script, *args):
+        if "Profile viewers" in script:
+            return headline_stat
+        if "scrollIntoView" in script:
+            return None
+        result = rows_per_round[min(reads["i"], len(rows_per_round) - 1)]
+        reads["i"] += 1
+        return result
+
+    driver.execute_script.side_effect = _execute
+    return driver
+
+
+def _run(driver, **kwargs):
+    with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair(driver)), \
+         patch(f"{_MOD}.quit_gracefully") as mock_quit, \
+         patch(f"{_MOD}.get_user_id", return_value=1), \
+         patch(f"{_MOD}.time.sleep"), \
+         patch(f"{_MOD}._PROFILE_VIEWER_RENDER_WAIT_SECONDS", 0), \
+         patch(f"{_MOD}.log_debug") as mock_debug, \
+         patch(f"{_MOD}.log_warning") as mock_warning, \
+         patch(f"{_MOD}.log_error") as mock_error, \
+         patch(f"{_MOD}.engage_with_profile_viewer") as mock_engage:
+        from cqc_lem.app.run_automation import automate_profile_viewer_engagement
+
+        result = automate_profile_viewer_engagement.run(user_id=1, **kwargs)
+
+    return result, {"quit": mock_quit, "debug": mock_debug, "warning": mock_warning,
+                    "error": mock_error, "engage": mock_engage}
+
+
+def _engaged_urls(mocks) -> list[str]:
+    return [c.kwargs["kwargs"]["viewer_url"] for c in mocks["engage"].apply_async.call_args_list]
 
 
 class TestNoViewersFound:
-    def test_timeout_finding_viewers_is_a_warning_not_an_error(self):
-        with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair()), \
-             patch(f"{_MOD}.get_elements_as_list_wait_stale",
-                   side_effect=TimeoutException("Finding Profile Viewers")), \
-             patch(f"{_MOD}.quit_gracefully") as mock_quit, \
-             patch(f"{_MOD}.log_warning") as mock_warning, \
-             patch(f"{_MOD}.log_error") as mock_error:
-            from cqc_lem.app.run_automation import automate_profile_viewer_engagement
+    def test_empty_page_with_no_headline_is_a_quiet_no_op(self):
+        result, mocks = _run(_driver_scripting([[]], headline_stat=None))
 
-            result = automate_profile_viewer_engagement.run(user_id=1)
-
-        mock_error.assert_not_called()
-        mock_warning.assert_called_once()
+        mocks["error"].assert_not_called()
+        mocks["warning"].assert_not_called()
+        mocks["debug"].assert_called_once()
+        mocks["engage"].apply_async.assert_not_called()
         assert "Engaged with 0 viewers" in result
-        mock_quit.assert_called_once()
+        mocks["quit"].assert_called_once()
 
-    def test_timeout_does_not_dispatch_any_engagement(self):
-        with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair()), \
-             patch(f"{_MOD}.get_elements_as_list_wait_stale",
-                   side_effect=TimeoutException("Finding Profile Viewers")), \
-             patch(f"{_MOD}.quit_gracefully"), \
-             patch(f"{_MOD}.log_warning"), \
-             patch(f"{_MOD}.engage_with_profile_viewer") as mock_engage:
-            from cqc_lem.app.run_automation import automate_profile_viewer_engagement
+    def test_zero_rows_with_nonzero_headline_warns_selector_drift(self):
+        result, mocks = _run(_driver_scripting([[]], headline_stat=136))
 
-            automate_profile_viewer_engagement.run(user_id=1)
-
-        mock_engage.apply_async.assert_not_called()
-
-    def test_stale_list_is_also_treated_as_no_viewers(self):
-        with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair()), \
-             patch(f"{_MOD}.get_elements_as_list_wait_stale",
-                   side_effect=StaleElementReferenceException("gone")), \
-             patch(f"{_MOD}.quit_gracefully"), \
-             patch(f"{_MOD}.log_warning") as mock_warning, \
-             patch(f"{_MOD}.log_error") as mock_error:
-            from cqc_lem.app.run_automation import automate_profile_viewer_engagement
-
-            result = automate_profile_viewer_engagement.run(user_id=1)
-
-        mock_error.assert_not_called()
-        mock_warning.assert_called_once()
+        mocks["error"].assert_not_called()
+        mocks["warning"].assert_called_once()
+        assert "selector drift" in mocks["warning"].call_args.args[0]
         assert "Engaged with 0 viewers" in result
 
 
-class TestUnreadableViewerRow:
-    def test_stale_row_is_skipped_and_the_readable_one_still_engages(self):
-        good = MagicMock(name="good_row")
-        good.get_attribute.return_value = "https://www.linkedin.com/in/good"
+class TestWalkTermination:
+    def test_list_that_stops_growing_ends_the_walk_and_engages_all_in_range(self):
+        rows = [_row("Ada", "ada", "Viewed 1h ago"), _row("Grace", "grace", "Viewed 20h ago")]
+        result, mocks = _run(_driver_scripting([rows, rows]))
 
-        def _stale_title_only(by, value):
-            # The row survives the date read but its title node has been re-rendered away.
-            if "lockup__title" in value:
-                raise StaleElementReferenceException("row re-rendered")
-            return MagicMock(name="viewed_on")
+        assert sorted(_engaged_urls(mocks)) == ["https://www.linkedin.com/in/ada/",
+                                                "https://www.linkedin.com/in/grace/"]
+        assert "Engaged with 2 viewers" in result
 
-        stale = MagicMock(name="stale_row")
-        stale.find_element.side_effect = _stale_title_only
+    def test_walk_stops_on_the_first_out_of_range_row(self):
+        first = [_row("Ada", "ada", "Viewed 1h ago")]
+        grown = first + [_row("Old", "old", "Viewed 3w ago")]
+        driver = _driver_scripting([first, grown])
 
-        # First lookup is the loop's own "is the last viewer older than a day?" check — an old
-        # date breaks the walk; the two that follow are the date filter over both rows.
-        dates = [datetime.now() - timedelta(days=5),
-                 datetime.now(), datetime.now()]
+        _, mocks = _run(driver)
 
-        with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair()), \
-             patch(f"{_MOD}.get_elements_as_list_wait_stale", return_value=[stale, good]), \
-             patch(f"{_MOD}.convert_viewed_on_to_date", side_effect=dates), \
-             patch(f"{_MOD}.getText", return_value="Some Viewer"), \
-             patch(f"{_MOD}.get_user_id", return_value=1), \
-             patch(f"{_MOD}.close_tab"), \
-             patch(f"{_MOD}.quit_gracefully"), \
-             patch(f"{_MOD}.log_warning") as mock_warning, \
-             patch(f"{_MOD}.log_error") as mock_error, \
-             patch(f"{_MOD}.engage_with_profile_viewer") as mock_engage:
-            from cqc_lem.app.run_automation import automate_profile_viewer_engagement
+        # Two rows-reads: the grown list's last row is out of range, so no third scroll happens.
+        rows_reads = [c for c in driver.execute_script.call_args_list
+                      if "Viewed " in c.args[0] and "scrollIntoView" not in c.args[0]]
+        assert len(rows_reads) == 2
+        assert _engaged_urls(mocks) == ["https://www.linkedin.com/in/ada/"]
 
-            result = automate_profile_viewer_engagement.run(user_id=1)
+    def test_unparseable_last_caption_warns_and_keeps_in_range_viewers(self):
+        rows = [_row("Ada", "ada", "Viewed 1h ago"), _row("Odd", "odd", "Viewed ??")]
+        result, mocks = _run(_driver_scripting([rows]))
 
-        mock_error.assert_not_called()
-        mock_warning.assert_called_once()
+        mocks["error"].assert_not_called()
+        # Once for stopping the walk, once for dropping the unreadable row in the filter.
+        assert mocks["warning"].call_count == 2
+        assert _engaged_urls(mocks) == ["https://www.linkedin.com/in/ada/"]
         assert "Engaged with 1 viewers" in result
-        mock_engage.apply_async.assert_called_once()
-        assert mock_engage.apply_async.call_args.kwargs["kwargs"]["viewer_url"] == \
-            "https://www.linkedin.com/in/good"
+
+
+class TestDateFilter:
+    def test_out_of_range_rows_are_filtered_not_engaged(self):
+        rows = [_row("Ada", "ada", "Viewed 1h ago"), _row("Old", "old", "Viewed 2w ago")]
+        _, mocks = _run(_driver_scripting([rows, rows]))
+
+        assert _engaged_urls(mocks) == ["https://www.linkedin.com/in/ada/"]
+
+    def test_lookback_days_widens_the_window(self):
+        rows = [_row("Ada", "ada", "Viewed 1h ago"), _row("Old", "old", "Viewed 2w ago")]
+        _, mocks = _run(_driver_scripting([rows, rows]), lookback_days=14)
+
+        assert sorted(_engaged_urls(mocks)) == ["https://www.linkedin.com/in/ada/",
+                                                "https://www.linkedin.com/in/old/"]
+
+    def test_duplicate_hrefs_from_rerendered_rows_engage_once(self):
+        rows = [_row("Ada", "ada", "Viewed 1h ago"), _row("Ada", "ada", "Viewed 1h ago")]
+        _, mocks = _run(_driver_scripting([rows, rows]))
+
+        assert _engaged_urls(mocks) == ["https://www.linkedin.com/in/ada/"]
+
+    def test_same_name_different_profiles_both_engage(self):
+        rows = [_row("Ada", "ada-1", "Viewed 1h ago"), _row("Ada", "ada-2", "Viewed 2h ago")]
+        _, mocks = _run(_driver_scripting([rows, rows]))
+
+        assert sorted(_engaged_urls(mocks)) == ["https://www.linkedin.com/in/ada-1/",
+                                                "https://www.linkedin.com/in/ada-2/"]
 
 
 class TestUnexpectedFailureStillErrors:
     def test_non_selenium_failure_is_still_logged_as_an_error(self):
-        driver, wait, email, profile = _profile_pair()
-        driver.get.side_effect = RuntimeError("browser crashed")
+        driver = MagicMock(name="driver")
+        driver.execute_script.side_effect = RuntimeError("boom")
 
-        with patch(f"{_MOD}.get_current_profile", return_value=(driver, wait, email, profile)), \
-             patch(f"{_MOD}.quit_gracefully"), \
+        with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair(driver)), \
+             patch(f"{_MOD}.quit_gracefully") as mock_quit, \
+             patch(f"{_MOD}.time.sleep"), \
              patch(f"{_MOD}.log_error") as mock_error:
             from cqc_lem.app.run_automation import automate_profile_viewer_engagement
 
@@ -143,105 +168,4 @@ class TestUnexpectedFailureStillErrors:
 
         mock_error.assert_called_once()
         assert "Error while engaging with profile viewers" in result
-
-
-class TestWalkTermination:
-    """The walk is `while True` — every exit path has to actually be reachable."""
-
-    def test_list_that_stops_growing_ends_the_walk(self):
-        """All viewers in range and no more to scroll: without a growth check this never exits."""
-        row = _viewer_row("Recent Viewer", "https://www.linkedin.com/in/recent")
-
-        with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair()), \
-             patch(f"{_MOD}.get_elements_as_list_wait_stale", return_value=[row]), \
-             patch(f"{_MOD}.convert_viewed_on_to_date", return_value=datetime.now()), \
-             patch(f"{_MOD}.time.sleep"), \
-             patch(f"{_MOD}.get_user_id", return_value=1), \
-             patch(f"{_MOD}.close_tab"), \
-             patch(f"{_MOD}.quit_gracefully"), \
-             patch(f"{_MOD}.log_error") as mock_error, \
-             patch(f"{_MOD}.engage_with_profile_viewer") as mock_engage:
-            from cqc_lem.app.run_automation import automate_profile_viewer_engagement
-
-            result = automate_profile_viewer_engagement.run(user_id=1)
-
-        mock_error.assert_not_called()
-        assert "Engaged with 1 viewers" in result
-        assert _engaged_urls(mock_engage) == ["https://www.linkedin.com/in/recent"]
-
-    def test_mid_walk_timeout_keeps_the_viewers_already_found(self):
-        row = _viewer_row("Recent Viewer", "https://www.linkedin.com/in/recent")
-
-        with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair()), \
-             patch(f"{_MOD}.get_elements_as_list_wait_stale",
-                   side_effect=[[row], TimeoutException("Finding Profile Viewers")]), \
-             patch(f"{_MOD}.convert_viewed_on_to_date", return_value=datetime.now()), \
-             patch(f"{_MOD}.time.sleep"), \
-             patch(f"{_MOD}.get_user_id", return_value=1), \
-             patch(f"{_MOD}.close_tab"), \
-             patch(f"{_MOD}.quit_gracefully"), \
-             patch(f"{_MOD}.log_warning") as mock_warning, \
-             patch(f"{_MOD}.log_error") as mock_error, \
-             patch(f"{_MOD}.engage_with_profile_viewer") as mock_engage:
-            from cqc_lem.app.run_automation import automate_profile_viewer_engagement
-
-            result = automate_profile_viewer_engagement.run(user_id=1)
-
-        mock_error.assert_not_called()
-        # The warning must not claim zero when a viewer was already collected.
-        assert "1 viewer(s)" in mock_warning.call_args_list[0].args[0]
-        assert "Engaged with 1 viewers" in result
-        assert _engaged_urls(mock_engage) == ["https://www.linkedin.com/in/recent"]
-
-    def test_unparseable_viewed_on_date_warns_instead_of_failing_the_task(self):
-        """convert_viewed_on_to_date raises ValueError on a caption it can't parse."""
-        row = _viewer_row("Odd Caption", "https://www.linkedin.com/in/odd")
-
-        with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair()), \
-             patch(f"{_MOD}.get_elements_as_list_wait_stale", return_value=[row]), \
-             patch(f"{_MOD}.convert_viewed_on_to_date",
-                   side_effect=ValueError("invalid datetime as string: ")), \
-             patch(f"{_MOD}.time.sleep"), \
-             patch(f"{_MOD}.quit_gracefully"), \
-             patch(f"{_MOD}.log_warning") as mock_warning, \
-             patch(f"{_MOD}.log_error") as mock_error, \
-             patch(f"{_MOD}.engage_with_profile_viewer") as mock_engage:
-            from cqc_lem.app.run_automation import automate_profile_viewer_engagement
-
-            result = automate_profile_viewer_engagement.run(user_id=1)
-
-        mock_error.assert_not_called()
-        assert mock_warning.call_count == 2  # ends the walk, then drops the unreadable row
-        assert "Engaged with 0 viewers" in result
-        mock_engage.apply_async.assert_not_called()
-
-
-class TestDateFilter:
-    def test_unreadable_date_does_not_leak_out_of_range_viewers(self):
-        """The walk stops ON an out-of-range viewer, so it is always in the pre-filter list."""
-        odd = _viewer_row("Odd Caption", "https://www.linkedin.com/in/odd")
-        recent = _viewer_row("Recent Viewer", "https://www.linkedin.com/in/recent")
-        old = _viewer_row("Old Viewer", "https://www.linkedin.com/in/old")
-
-        long_ago = datetime.now() - timedelta(days=30)
-        # walk reads the last row, then the filter reads all three in order.
-        dates = [long_ago, ValueError("invalid datetime as string: "), datetime.now(), long_ago]
-
-        with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair()), \
-             patch(f"{_MOD}.get_elements_as_list_wait_stale", return_value=[odd, recent, old]), \
-             patch(f"{_MOD}.convert_viewed_on_to_date", side_effect=dates), \
-             patch(f"{_MOD}.time.sleep"), \
-             patch(f"{_MOD}.get_user_id", return_value=1), \
-             patch(f"{_MOD}.close_tab"), \
-             patch(f"{_MOD}.quit_gracefully"), \
-             patch(f"{_MOD}.log_warning") as mock_warning, \
-             patch(f"{_MOD}.log_error") as mock_error, \
-             patch(f"{_MOD}.engage_with_profile_viewer") as mock_engage:
-            from cqc_lem.app.run_automation import automate_profile_viewer_engagement
-
-            result = automate_profile_viewer_engagement.run(user_id=1)
-
-        mock_error.assert_not_called()
-        mock_warning.assert_called_once()
-        assert "Engaged with 1 viewers" in result
-        assert _engaged_urls(mock_engage) == ["https://www.linkedin.com/in/recent"]
+        mock_quit.assert_called_once()

--- a/tests/unit/utilities/test_date.py
+++ b/tests/unit/utilities/test_date.py
@@ -339,6 +339,34 @@ class TestDateUtilitiesExtended:
         assert isinstance(result, datetime.datetime)
 
     def test_convert_viewed_on_replaces_w_with_week(self):
-        # "1w ago" should become "1week ago" which dateparser can handle
         result = convert_viewed_on_to_date("1w ago")
         assert isinstance(result, datetime.datetime)
+
+    # Live caption forms from the SDUI profile-views page (grounded 2026-08-03):
+    # "Viewed 1h ago" / "20h" / "1d" / "1w" / "1mo" / "2mo".
+
+    def test_convert_viewed_on_live_relative_forms_land_at_the_right_age(self):
+        now = datetime.datetime.now()
+        expectations = {
+            "Viewed 5m ago": datetime.timedelta(minutes=5),
+            "Viewed 20h ago": datetime.timedelta(hours=20),
+            "Viewed 1d ago": datetime.timedelta(days=1),
+            "Viewed 2w ago": datetime.timedelta(weeks=2),
+            "Viewed 1mo ago": datetime.timedelta(days=30),
+            "Viewed 2mo ago": datetime.timedelta(days=60),
+            "Viewed 1yr ago": datetime.timedelta(days=365),
+        }
+        for caption, age in expectations.items():
+            result = convert_viewed_on_to_date(caption)
+            assert abs((now - result) - age) < datetime.timedelta(minutes=1), caption
+
+    def test_convert_viewed_on_week_caption_is_not_mangled(self):
+        # The old 'w'->'week' substitution turned "week" into "weekeek"; the parser must
+        # take spelled-out units as-is.
+        result = convert_viewed_on_to_date("Viewed 2 weeks ago")
+        assert abs((datetime.datetime.now() - result) - datetime.timedelta(weeks=2)) \
+            < datetime.timedelta(minutes=1)
+
+    def test_convert_viewed_on_unparseable_raises_value_error(self):
+        with pytest.raises(ValueError):
+            convert_viewed_on_to_date("Viewed ??")


### PR DESCRIPTION
## Problem

Every `automate_profile_viewer_engagement` run logged `Could not read the profile viewers list — ending the walk with 0 viewer(s)` while https://www.linkedin.com/analytics/profile-views/ visibly listed viewers (136 over 90 days). Profile-viewer outreach has been silently dead — the #964 failure mode on a different surface.

## Root cause (live-grounded 2026-08-03, user 1)

The analytics page is now full SDUI: **zero `<ul>` elements, no `artdeco-entity-lockup__*` classes**, hashed class names only. The walk's locator `//ul[@aria-label="List of Entities"]//a[...]` can never match, so the wait polls to timeout and the task warns and exits with nothing.

Two secondary defects: `convert_viewed_on_to_date`'s `'w'→'week'` substitution mangled any caption already containing a w-word, and `window.scrollTo` alone never grows the list (probe: stuck at 8 rows; `scrollIntoView` on the last row grew it 8 → 58).

## Fix

- Viewer row = `/in/` anchor whose innerText carries a `Viewed …` caption line — pure TEXT discriminator per the fix invariants (no class names). One `execute_script` pass returns every row's (href, name, caption), so nothing goes stale while the list re-renders.
- `scrollIntoView` on the last row drives the lazy loader.
- Zero rows + non-zero "N Profile viewers" headline ⇒ **selector-drift warning** (a dead locator must not read as an empty page); zero rows + no headline ⇒ quiet DEBUG no-op (#572 posture kept).
- `convert_viewed_on_to_date` parses the live relative forms (`1h/20h/1d/1w/1mo/2mo`) deterministically, dateparser fallback for anything non-relative.
- New `lookback_days` param (default 1 — the existing delta, unchanged cadence) so a catch-up run can widen the window once.
- Dropped the per-viewer tab-open/navigate dance in the walk — `engage_with_profile_viewer` opens the profile in its own session anyway.
- `--profile-views` probe added to `scripts/linkedin_live_validation.py` for future re-grounding.
- `docs/sdui-selenium-notes.md` section added.

## Backfill

Already executed on the VPS (owner-requested): a one-off inline run of the fixed walk dispatched **25 viewers from the last 14 days** through the normal `engage_with_profile_viewer` path (2/m rate limit + per-day caps still throttle actual sends). After this deploys, the task sticks to its 1-day delta.

## Tests

- `test_profile_viewer_engagement.py` rewritten against the JS-driven walk: quiet no-op vs selector-drift tripwire, walk termination (out-of-range stop, stopped-growing stop, unparseable caption), lookback filter/widening, href dedupe, same-name-different-profile, unexpected-failure-still-errors.
- `test_date.py`: live caption forms land at the right age, "2 weeks ago" not mangled, unparseable raises.
- Full unit lane: 10,170 passed.

`release:now`: user-visible breakage — every run until deploy engages nobody.

🤖 Generated with [Claude Code](https://claude.com/claude-code)