### PR TITLE
feat(analytics): 12-hour time + timezone label in Best Times to Post (closes #1003)

### DIFF
--- a/docs/timezone-contract.md
+++ b/docs/timezone-contract.md
@@ -89,6 +89,14 @@ from logs rather than only from a post that went out at the wrong hour.
 | `toZonedInputValue(iso, tz)` | UTC ISO → `<input type="datetime-local">` value in `tz` |
 | `zonedInputToUtcIso(value, tz)` | `datetime-local` value read as `tz` → UTC ISO with `Z` |
 
+Some surfaces render a bare **hour-of-day** with no date attached — the Dashboard's "Your Best Times
+to Post", the newsletter publish-hour picker, the compose-page suggestion. There is no instant to
+hand `Intl`, so those get the other two helpers instead: `formatHour12(hour)` (12-hour, never a
+`14:00` clock face) and `timezoneAbbreviation(tz)` (the `EDT`/`GMT+5:30` label that says WHICH clock
+the hour is on). Never hand-roll either — three near-copies of the AM/PM arithmetic is how the Best
+Times list ended up 24-hour and unlabelled (issue #1003). A bucketed hour is labelled with the zone
+the SERVER bucketed it into (`/user/post-stats` returns `timezone`), not the browser guess.
+
 A `datetime-local` input carries **no timezone**. Its value must be the same wall clock
 `formatInTimezone` renders beside it, or the editor and its own label disagree about one post. On
 the way back out, `new Date(value).toISOString()` is always wrong — it interprets the value in the

--- a/src/cqc_lem/ui/src/pages/Dashboard.timezone.test.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.timezone.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import Dashboard from './Dashboard'
+
+// Issue #1003: "Your Best Times to Post" rendered a bare 24-hour clock face with no zone, so a
+// recommendation read as neither the user's clock nor anyone else's. The helper arithmetic is
+// covered in utils/datetime.test.ts; what is asserted HERE is the wiring the helpers hang off —
+// that the list renders 12-hour, and that it is labelled with the zone the SERVER bucketed the
+// hours into rather than the browser's guess.
+const get = vi.fn()
+
+vi.mock('../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'test@example.com', userId: 1 }, sessionToken: 'tok' }),
+}))
+
+// The browser/configured-zone hook, deliberately DIFFERENT from the server zone below so the two
+// cannot pass for each other.
+vi.mock('../hooks/useUserTimezone', () => ({
+  useUserTimezone: () => 'Asia/Tokyo',
+  useUserTimezoneState: () => ({ timezone: 'Asia/Tokyo', isResolved: true }),
+}))
+
+vi.mock('../components/OnboardingChecklist', () => ({ default: () => null }))
+vi.mock('../components/PostHogStatsPanel', () => ({ default: () => null }))
+
+const RECOMMENDATIONS = [
+  { weekday: 'Wednesday', hour: 16, avg_engagement: 12, sample: 4 },
+  { weekday: 'Monday', hour: 0, avg_engagement: 9, sample: 3 },
+]
+
+function payload(data: unknown) {
+  return { data: { detail: data } }
+}
+
+// `postStats` is the only response this suite cares about; every other query on the page just has
+// to resolve to something shaped like an empty payload.
+function mockApi(postStats: unknown) {
+  get.mockImplementation((path: string) => {
+    if (path.startsWith('/user/post-stats')) return Promise.resolve(payload(postStats))
+    if (path.startsWith('/activity/')) return Promise.resolve(payload([]))
+    if (path.startsWith('/dashboard/planned-tasks/')) return Promise.resolve(payload({ tasks: [] }))
+    return Promise.resolve(payload({}))
+  })
+}
+
+function harness(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  get.mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('Best Times to Post — 12-hour clock and a zone label (issue #1003)', () => {
+  it('renders each recommended hour 12-hour, never a 24-hour clock face', async () => {
+    mockApi({ recommendations: RECOMMENDATIONS, rankings: {}, sample_size: 7, timezone: 'America/New_York' })
+    harness(<Dashboard />)
+
+    await waitFor(() => expect(screen.getByText('Wednesday @ 4:00 PM')).toBeDefined())
+    expect(screen.getByText('Monday @ 12:00 AM')).toBeDefined()
+    expect(screen.queryByText(/@ 16:00/)).toBeNull()
+    expect(screen.queryByText(/@ 00:00/)).toBeNull()
+  })
+
+  it('labels the list with the zone the SERVER bucketed the hours into, not the browser guess', async () => {
+    mockApi({ recommendations: RECOMMENDATIONS, rankings: {}, sample_size: 7, timezone: 'America/New_York' })
+    harness(<Dashboard />)
+
+    // EST or EDT depending on when the suite runs — either proves the abbreviation followed the
+    // server zone, and neither is Tokyo's.
+    const label = await waitFor(() => screen.getByText(/Times are in America\/New_York \(E[SD]T\)/))
+    expect(label).toBeDefined()
+    expect(screen.queryByText(/Asia\/Tokyo/)).toBeNull()
+  })
+
+  it('falls back to the user zone only when the payload carries no timezone', async () => {
+    mockApi({ recommendations: RECOMMENDATIONS, rankings: {}, sample_size: 7 })
+    harness(<Dashboard />)
+
+    await waitFor(() => expect(screen.getByText(/Times are in Asia\/Tokyo \(GMT\+9\)/)).toBeDefined())
+  })
+
+  it('says nothing about a zone when there is nothing to recommend yet', async () => {
+    mockApi({ recommendations: [], rankings: {}, sample_size: 1 })
+    harness(<Dashboard />)
+
+    await waitFor(() => expect(screen.getByText(/recommendations appear after a few posts/)).toBeDefined())
+    expect(screen.queryByText(/Times are in/)).toBeNull()
+  })
+})

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -4,7 +4,7 @@ import api from '../api/client'
 import { useAuth } from '../contexts/AuthContext'
 import { useUserTimezone } from '../hooks/useUserTimezone'
 import { useScrollAffordance } from '../hooks/useScrollAffordance'
-import { formatInTimezone } from '../utils/datetime'
+import { formatHour12, formatInTimezone, timezoneAbbreviation } from '../utils/datetime'
 import { isHttpUrl, commentsActivityUrl } from '../utils/links'
 import OnboardingChecklist from '../components/OnboardingChecklist'
 import PostHogStatsPanel from '../components/PostHogStatsPanel'
@@ -17,6 +17,10 @@ interface PostStats {
   recommendations: { weekday: string; hour: number; avg_engagement: number; sample: number }[]
   rankings: Record<string, RankEntry[]>
   sample_size: number
+  // The zone `recommendations[].hour` was bucketed into server-side (the user's configured Login
+  // Location). Label the hours with THIS, not the browser guess, or a traveling user reads an
+  // America/New_York hour as their device's clock.
+  timezone?: string
 }
 
 interface TrendPoint {
@@ -401,6 +405,9 @@ export default function Dashboard() {
 
   const formatBoard = postStats?.rankings?.format ?? []
   const hookBoard = postStats?.rankings?.hook_style ?? []
+  // Prefer the zone the API bucketed the hours into; `userTimezone` (configured zone, browser
+  // fallback) only stands in for an older payload that carried no `timezone`.
+  const bestTimesTimezone = postStats?.timezone || userTimezone
 
   // Window totals for the KPI row.
   const totalImpressions = perPost.reduce((s, p) => s + (p.impressions ?? 0), 0)
@@ -930,11 +937,14 @@ export default function Dashboard() {
           <h2 className="text-base font-semibold text-gray-700">Your Best Times to Post</h2>
           {postStats.recommendations.length > 0 ? (
             <>
-              <p className="text-xs text-gray-500">Learned from your own post engagement — scheduling leans toward these.</p>
+              <p className="text-xs text-gray-500">
+                Learned from your own post engagement — scheduling leans toward these. Times are in{' '}
+                {bestTimesTimezone} ({timezoneAbbreviation(bestTimesTimezone)}).
+              </p>
               <ul className="text-sm text-gray-700 space-y-1">
                 {postStats.recommendations.map((r, i) => (
                   <li key={i} className="flex justify-between">
-                    <span>{r.weekday} @ {String(r.hour).padStart(2, '0')}:00</span>
+                    <span>{r.weekday} @ {formatHour12(r.hour)}</span>
                     <span className="text-gray-400">avg engagement {r.avg_engagement} · {r.sample} post(s)</span>
                   </li>
                 ))}

--- a/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
+++ b/src/cqc_lem/ui/src/pages/account/NewsletterCard.tsx
@@ -7,9 +7,7 @@ import Toggle from '../../components/Toggle'
 import type { NewsletterSettings, NewsletterSubscribers } from './types'
 import { WEEKDAYS } from './types'
 import { FIELD_LIMITS } from './fieldLimits'
-
-// 12-hour label for an hour-of-day 0–23 (never 24h): 0 -> "12:00 AM", 13 -> "1:00 PM".
-const hour12Label = (h: number) => `${h % 12 === 0 ? 12 : h % 12}:00 ${h < 12 ? 'AM' : 'PM'}`
+import { formatHour12 } from '../../utils/datetime'
 
 export default function NewsletterCard() {
   const { sessionToken } = useAuth()
@@ -100,7 +98,7 @@ export default function NewsletterCard() {
               <select value={newsletter.publish_hour} onChange={(e) => setNl({ publish_hour: Number(e.target.value) })}
                 className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm">
                 {Array.from({ length: 24 }, (_, h) => (
-                  <option key={h} value={h}>{hour12Label(h)}</option>
+                  <option key={h} value={h}>{formatHour12(h)}</option>
                 ))}
               </select>
             </div>

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
@@ -6,7 +6,7 @@ import LinkedInPostPreview from '../../components/LinkedInPostPreview'
 import TopicAuthorityMeter from '../../components/TopicAuthorityMeter'
 import { useAuth } from '../../contexts/AuthContext'
 import { useUserTimezoneState } from '../../hooks/useUserTimezone'
-import { zonedInputToUtcIso } from '../../utils/datetime'
+import { formatHour12, zonedInputToUtcIso } from '../../utils/datetime'
 import { maskProps } from '../../utils/analytics'
 
 const POST_TYPES = ['TEXT', 'VIDEO', 'CAROUSEL'] as const
@@ -32,9 +32,7 @@ function getBestPostingTime(date: Date): { time: string; display: string; dayNam
     hour = 10
   }
   const hh = String(hour).padStart(2, '0')
-  const ampm = hour < 12 ? 'AM' : 'PM'
-  const display12 = `${hour > 12 ? hour - 12 : hour}:00 ${ampm}`
-  return { time: `${hh}:00`, dayName: DAY_NAMES[day], display: display12 }
+  return { time: `${hh}:00`, dayName: DAY_NAMES[day], display: formatHour12(hour) }
 }
 
 interface CarouselTemplate {

--- a/src/cqc_lem/ui/src/utils/datetime.test.ts
+++ b/src/cqc_lem/ui/src/utils/datetime.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
-import { zonedDateToUtcStart, zonedDateToUtcEnd, toZonedInputValue, zonedInputToUtcIso } from './datetime'
+import {
+  formatHour12,
+  timezoneAbbreviation,
+  zonedDateToUtcStart,
+  zonedDateToUtcEnd,
+  toZonedInputValue,
+  zonedInputToUtcIso,
+} from './datetime'
 
 describe('zonedDateToUtcStart', () => {
   beforeEach(() => {
@@ -51,5 +58,42 @@ describe('round-trip datetime-local conversion', () => {
     const inputValue = toZonedInputValue(utcIso, tz)
     expect(inputValue).not.toBe('')
     expect(zonedInputToUtcIso(inputValue, tz)).toBe(utcIso)
+  })
+})
+
+describe('formatHour12', () => {
+  it('renders every hour-of-day 12-hour, never 24-hour', () => {
+    expect(formatHour12(0)).toBe('12:00 AM')
+    expect(formatHour12(9)).toBe('9:00 AM')
+    expect(formatHour12(11)).toBe('11:00 AM')
+    expect(formatHour12(12)).toBe('12:00 PM')
+    expect(formatHour12(13)).toBe('1:00 PM')
+    expect(formatHour12(16)).toBe('4:00 PM')
+    expect(formatHour12(23)).toBe('11:00 PM')
+  })
+
+  it('never emits a 24-hour clock face for any hour in range', () => {
+    for (let h = 0; h < 24; h++) {
+      expect(formatHour12(h)).toMatch(/^(1[0-2]|[1-9]):00 (AM|PM)$/)
+    }
+  })
+
+  it('normalizes out-of-range hours instead of rendering nonsense', () => {
+    expect(formatHour12(24)).toBe('12:00 AM')
+    expect(formatHour12(25)).toBe('1:00 AM')
+    expect(formatHour12(-1)).toBe('11:00 PM')
+    expect(formatHour12(13.7)).toBe('1:00 PM')
+  })
+})
+
+describe('timezoneAbbreviation', () => {
+  it('labels a zone with its short name at the given instant', () => {
+    // Same zone, opposite sides of a DST boundary — the label has to follow.
+    expect(timezoneAbbreviation('America/New_York', new Date('2026-07-29T12:00:00Z'))).toBe('EDT')
+    expect(timezoneAbbreviation('America/New_York', new Date('2026-01-15T12:00:00Z'))).toBe('EST')
+  })
+
+  it('falls back to the IANA id when the zone is unusable', () => {
+    expect(timezoneAbbreviation('Not/AZone')).toBe('Not/AZone')
   })
 })

--- a/src/cqc_lem/ui/src/utils/datetime.ts
+++ b/src/cqc_lem/ui/src/utils/datetime.ts
@@ -66,6 +66,28 @@ export function formatInTimezone(
   }
 }
 
+// 12-hour label for a bare hour-of-day 0–23 (never 24h): 0 -> "12:00 AM", 13 -> "1:00 PM".
+// An hour-of-day has no date to hang an Intl format off, so it gets its own formatter rather than a
+// synthetic Date — but it still obeys the same "always 12-hour" display rule as formatInTimezone.
+export function formatHour12(hour: number): string {
+  const h = ((Math.trunc(hour) % 24) + 24) % 24
+  return `${h % 12 === 0 ? 12 : h % 12}:00 ${h < 12 ? 'AM' : 'PM'}`
+}
+
+// Short zone label ("EDT", "GMT+5:30") for a bare hour-of-day, so a time with no date attached still
+// says WHICH clock it is on. Falls back to the IANA id when the engine has no short name for it.
+export function timezoneAbbreviation(tz: string, at: Date = new Date()): string {
+  try {
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      timeZoneName: 'short',
+    }).formatToParts(at)
+    return parts.find((p) => p.type === 'timeZoneName')?.value || tz
+  } catch {
+    return tz
+  }
+}
+
 // UTC ISO string -> the `YYYY-MM-DDTHH:mm` value for an <input type="datetime-local">, expressed in
 // the user's timezone. A `datetime-local` input has no timezone of its own, so its value MUST be
 // the same wall clock formatInTimezone renders next to it — otherwise the editor and the label


### PR DESCRIPTION
## What & why

In-app feedback (#36 → issue #1003): **Your Best Times to Post** showed a bare 24-hour clock face —
`Wednesday @ 16:00` — with nothing saying *which* zone that hour was on.

The hours themselves were already right. `/user/post-stats` calls
`recommend_post_times(rows, tz=get_user_timezone(user_id))`, so each `hour` is already the user's own
wall clock, and the response already carries the `timezone` it bucketed into. The SPA rendered
neither fact: it padded the raw integer and dropped the zone. This was also the one display left in
the SPA breaking `docs/timezone-contract.md` §4 ("times are always shown 12-hour").

## Changes

- **`utils/datetime.ts`** — two shared helpers for a bare **hour-of-day** (which has no instant to
  hand `Intl`, so it can't go through `formatInTimezone`):
  - `formatHour12(hour)` → `0 → "12:00 AM"`, `13 → "1:00 PM"`; out-of-range hours normalize rather
    than render nonsense.
  - `timezoneAbbreviation(tz, at?)` → `"EDT"` / `"GMT+5:30"`, DST-correct at the given instant,
    falling back to the IANA id when the engine has no short name.
- **`Dashboard.tsx`** — renders `Wednesday @ 4:00 PM` and labels the list once with the zone the
  **server** bucketed into (`postStats.timezone`). `useUserTimezone()` (configured Login Location,
  browser detection as its own last resort) stands in only for an older payload without the field —
  labelling a server-bucketed hour with the browser's guess would mislabel a traveling user.
- Folded the two hand-rolled AM/PM copies onto the shared helper (`NewsletterCard`, `ComposePost`).
  `ComposePost`'s copy would have rendered hour 0 as `"0:00 AM"` — latent, since it only ever picks
  7/8/10, but it's gone now rather than left as a third near-copy.
- **`docs/timezone-contract.md`** — records the bare-hour helpers beside the three conversion
  helpers, so the next hour-of-day surface doesn't hand-roll a fourth copy.

No backend change: the API already returned everything needed. (The issue's "Files" guess at
`observability.py` was wrong — the endpoint is `api/main.get_post_stats_endpoint`.)

## Testing

`src/cqc_lem/ui/src/utils/datetime.test.ts` — every hour 0–23 asserted against a 12-hour-only
pattern, the named boundaries (0/11/12/13/23), out-of-range normalization, the DST-correct zone
label across a boundary (`EDT` in July vs `EST` in January), and the bad-zone fallback.

Run locally under Node 22 (matching CI):
- `npx vitest run` → **424 passed / 51 files**
- `npx tsc -b` → clean
- `npm run build` → clean

Python patch coverage is unaffected — `codecov.yml` ignores `src/cqc_lem/ui/`; the SPA is gated by
`CI / UI Build` (vitest + build).

Closes #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)