### PR TITLE
fix(automation): connect invites clicked the suggestion rail — open the invite dialog by URL

### DIFF
--- a/docs/sdui-selenium-notes.md
+++ b/docs/sdui-selenium-notes.md
@@ -38,6 +38,25 @@ Zero rows against a non-zero "N Profile viewers" headline stat is selector drift
 zero rows with no stat is a quiet no-op. Re-ground with
 `scripts/linkedin_live_validation.py --profile-views`.
 
+## The Connect invite is a URL, and unscoped "Invite …" buttons are a WRONG-PERSON hazard
+
+Live-grounded 2026-08-03 (3rd-degree profile, user 1, Sales-Nav overlay): the profile top card
+offers only `Save in Sales Navigator` / `More` / `Message`/`Follow` — **no Connect button for the
+target at all** — while the "More profiles for you" rail renders one
+`button[aria-label="Invite <someone else> to connect"]` per suggested person. The old unscoped
+`//main//button[contains(@aria-label,"Invite ")]` therefore clicked the rail and **sent a
+connection request to a random suggested person** (~20 strays on 2026-08-03), then failed with
+`no Send button on the open Connect dialog` because no dialog ever opened for the target. Never
+click an Invite control whose label names someone other than the target.
+The top-card More menu (`aria-label="More"`, no longer `"More actions"`) holds Connect as an
+`<a role="menuitem">` (text `Connect`, no aria-label) whose href is
+`https://www.linkedin.com/preload/custom-invite/?vanityName=<slug>` — the dialog is addressable
+by URL, so `_open_connect_invite_dialog` navigates there directly and only falls back to the
+menu. The dialog's own controls are UNCHANGED: `Add a note` / `Send without a note` aria-labels,
+`textarea#custom-message` (0/300), and `Send` (aria `Send invitation`, disabled until input, plus
+a new `Write with AI` button). Success is the dialog's controls being present — never a click
+having landed.
+
 ## The comment composer has no `<form>`
 
 "Submit" means clicking the Comment/Post button next to the composer (`_composer_submitted`).

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -6409,33 +6409,71 @@ def _profile_is_first_degree(driver) -> bool:
     return False
 
 
-def _click_connect_affordance(driver, wait, user_id: int) -> bool:
-    """Click Connect on an open profile — the direct button first, else the one inside the
-    More-actions overflow. False when NEITHER is there, which is an ordinary outcome (an invite is
-    already pending, LinkedIn only offers Follow/Message on that profile, or the SDUI selector
-    drifted) and is why the miss is a WARNING and not an error (issue #571)."""
-    try:
-        click_element_wait_retry(driver, wait, '//main//button[contains(@aria-label, "Invite ")]',
-                                 "Finding Connect Button", max_retry=1, use_action_chain=True)
-        myprint("Found Connect Button and clicked it")
-        return True
-    except Exception:
-        pass  # No direct Connect button — LinkedIn buries it in the More menu on many profiles.
+# Grounded live 2026-08-03 (docs/sdui-selenium-notes.md): the profile top card carries NO
+# "Invite <name> to connect" button on the current layout — the only buttons matching
+# //main//button[contains(@aria-label,"Invite ")] are the "More profiles for you" rail, so an
+# unscoped click INVITED A RANDOM SUGGESTED PERSON and then failed on the missing Send dialog.
+# The top-card More menu's Connect item is an <a role=menuitem> linking to /preload/custom-invite,
+# which means the invite dialog is addressable by URL — that hazard-free route leads, and no
+# locator here may ever click an Invite button that names someone other than the target.
+_CONNECT_INVITE_URL = "https://www.linkedin.com/preload/custom-invite/?vanityName={slug}"
 
-    try:
-        click_element_wait_retry(driver, wait,
-                                 '//main//button[contains(@aria-label,"More actions")]',
-                                 "Finding More Button", max_retry=1, use_action_chain=True)
-        myprint("Found More Button and clicked it")
+# The dialog's own controls, unchanged across the rotation: its presence — not a click having
+# landed — is what proves the invite flow is actually open for the TARGET.
+_CONNECT_DIALOG_LOCATORS = [
+    (By.XPATH, '//button[@aria-label="Send without a note"]'),
+    (By.XPATH, '//button[@aria-label="Add a note"]'),
+]
 
-        click_element_wait_retry(driver, wait, '//main//div[contains(@aria-label,"connect")]',
-                                 "Finding Connect Button", max_retry=1, use_action_chain=True)
-        myprint("Found Connect Button and clicked it")
-        return True
-    except Exception as e:
-        log_warning("No Connect option on this profile (direct button and More menu both missed)",
-                    exc=e, user_id=user_id, action_type="invite_connect")
-        return False
+_PROFILE_MORE_MENU_LOCATORS = [
+    (By.XPATH, '//main//button[@aria-label="More" or normalize-space()="More"]'),
+    (By.XPATH, '//main//button[contains(@aria-label,"More actions")]'),  # pre-2026 label
+]
+
+_CONNECT_MENU_ITEM_LOCATORS = [
+    (By.XPATH, '//a[@role="menuitem"][contains(@href,"custom-invite")]'),
+    (By.XPATH, '//*[@role="menuitem"][normalize-space()="Connect"]'),
+]
+
+
+def _connect_dialog_present(driver, wait, user_id: int) -> bool:
+    return find_first(driver, wait, _CONNECT_DIALOG_LOCATORS, "Connect invite dialog",
+                      required=False, warn_on_miss=False, max_try=1, visible_only=True,
+                      user_id=user_id) is not None
+
+
+def _open_connect_invite_dialog(driver, wait, user_id: int, profile_url: str) -> bool:
+    """Open the Connect invite dialog for the profile at `profile_url` — the custom-invite URL
+    first, else the profile page's top-card More menu. True only when the dialog's own controls
+    are provably present. False is an ordinary outcome (invite already pending, Connect not
+    offered, or the SDUI rotated again) and is why the total miss is a WARNING, not an error
+    (issue #571)."""
+    slug = _profile_slug(profile_url)
+    if slug:
+        driver.get(_CONNECT_INVITE_URL.format(slug=slug))
+        if _connect_dialog_present(driver, wait, user_id):
+            myprint("Connect dialog opened via the custom-invite URL")
+            return True
+        # An already-pending invite renders no dialog here — an expected outcome for this
+        # route, so the miss stays quiet and the profile-page route gets its turn.
+        log_debug("custom-invite page did not render the Connect dialog — trying the "
+                  "profile-page More menu", user_id=user_id, action_type="invite_connect")
+
+    if profile_url != driver.current_url:
+        driver.get(profile_url)
+    if click_first(driver, wait, _PROFILE_MORE_MENU_LOCATORS, "Profile More menu",
+                   required=False, warn_on_miss=False, max_try=1, use_action_chain=True,
+                   user_id=user_id) is not None:
+        item = click_first(driver, wait, _CONNECT_MENU_ITEM_LOCATORS, "Connect menu item",
+                           required=False, warn_on_miss=False, max_try=1, use_action_chain=True,
+                           user_id=user_id)
+        if item is not None and _connect_dialog_present(driver, wait, user_id):
+            myprint("Connect dialog opened via the profile More menu")
+            return True
+
+    log_warning("No route opened the Connect invite dialog for this profile",
+                user_id=user_id, action_type="invite_connect")
+    return False
 
 
 def _add_connect_note(driver, wait, message: str, user_id: int) -> bool:
@@ -6531,9 +6569,9 @@ def invite_to_connect_now(user_id: int, profile_url: str, message: str = None) -
                            message=ALREADY_CONNECTED_MESSAGE)
             return False, ALREADY_CONNECTED_MESSAGE
 
-        # Locate the connect button. With no Connect dialog open the note/send steps below can only
-        # fail, and their errors would bury the real reason — so stop here with a named one instead.
-        if not _click_connect_affordance(driver, wait, user_id):
+        # Open the Connect dialog. With none open the note/send steps below can only fail, and
+        # their errors would bury the real reason — so stop here with a named one instead.
+        if not _open_connect_invite_dialog(driver, wait, user_id, profile_url):
             insert_new_log(user_id=user_id, action_type=LogActionType.ENGAGED,
                            result=LogResultType.FAILURE, post_url=profile_url,
                            message=NO_CONNECT_BUTTON_MESSAGE)

--- a/tests/unit/app/test_invite_connect_affordance.py
+++ b/tests/unit/app/test_invite_connect_affordance.py
@@ -1,9 +1,11 @@
-"""The Connect-affordance hunt on the invite send path (issue #571).
+"""The Connect-dialog open on the invite send path (issues #571 + the 2026-08-03 rail hazard).
 
-`Failed to find more or connect button` paged the error cron for what is an ordinary outcome — a
-profile with no Connect option at all (invite already pending, Follow/Message-only, selector drift).
-Worse, the old code carried on into the note/send steps with no Connect dialog open, so the real
-reason was overwritten by a second, misleading error. These cover both halves.
+The SDUI profile top card carries no "Invite <name> to connect" button — the only aria-labels
+matching the old unscoped locator are the "More profiles for you" rail, so clicking the first
+match INVITED A RANDOM SUGGESTED PERSON and then failed on the missing Send dialog. The rebuilt
+route goes straight to the /preload/custom-invite URL (no wrong-person hazard), falls back to
+the top-card More menu's Connect item, and only reports success when the dialog's own controls
+are provably present. A total miss stays a WARNING (ordinary outcome), never an error.
 """
 
 from unittest.mock import MagicMock, patch
@@ -14,85 +16,156 @@ pytestmark = pytest.mark.unit
 
 _RA = "cqc_lem.app.run_automation"
 
-_INVITE_XPATH = '//main//button[contains(@aria-label, "Invite ")]'
-_MORE_XPATH = '//main//button[contains(@aria-label,"More actions")]'
-_MENU_CONNECT_XPATH = '//main//div[contains(@aria-label,"connect")]'
+_PROFILE_URL = "https://www.linkedin.com/in/jane-doe-123/"
+_CUSTOM_INVITE_URL = "https://www.linkedin.com/preload/custom-invite/?vanityName=jane-doe-123"
+
+_SEND_BARE_XPATH = '//button[contains(@aria-label,"Send without a note")]'
 
 
-def _clicker(found: set[str]):
-    """A click_element_wait_retry stand-in that only 'finds' the xpaths in `found`."""
+class _Routes:
+    """Configurable stand-ins for find_first / click_first / click_element_wait_retry, recording
+    every locator so the rail-hazard regression can assert nothing 'Invite …' is ever clicked."""
 
-    def click(driver, wait, xpath, label, **kwargs):
-        if xpath in found:
+    def __init__(self, dialog_on_url=False, dialog_after_menu=False,
+                 more_menu=False, menu_item=False, send_xpaths=frozenset()):
+        self.dialog_on_url = dialog_on_url
+        self.dialog_after_menu = dialog_after_menu
+        self.more_menu = more_menu
+        self.menu_item = menu_item
+        self.send_xpaths = set(send_xpaths)
+        self.menu_item_clicked = False
+        self.find_labels: list[str] = []
+        self.click_labels: list[str] = []
+        self.all_locators: list[str] = []
+        self.legacy_click_xpaths: list[str] = []  # click_element_wait_retry (note/send steps)
+
+    def find_first(self, driver, wait, locators, label, **kwargs):
+        self.find_labels.append(label)
+        self.all_locators += [v for _, v in locators]
+        if label == "Connect invite dialog":
+            if self.dialog_on_url and not self.menu_item_clicked:
+                return MagicMock()
+            if self.dialog_after_menu and self.menu_item_clicked:
+                return MagicMock()
+        return None
+
+    def click_first(self, driver, wait, locators, label, **kwargs):
+        self.click_labels.append(label)
+        self.all_locators += [v for _, v in locators]
+        if label == "Profile More menu" and self.more_menu:
+            return MagicMock()
+        if label == "Connect menu item" and self.menu_item:
+            self.menu_item_clicked = True
+            return MagicMock()
+        return None
+
+    def click_element_wait_retry(self, driver, wait, xpath, label, **kwargs):
+        self.all_locators.append(xpath)
+        self.legacy_click_xpaths.append(xpath)
+        if xpath in self.send_xpaths:
             return MagicMock()
         raise Exception(f"no element for {xpath}")
 
-    return MagicMock(side_effect=click)
 
-
-def _invite(found: set[str], message: str = None):
+def _invite(routes: _Routes, message: str = None):
     from cqc_lem.app import run_automation as ra
-    click = _clicker(found)
+    driver = MagicMock()
+    driver.current_url = "about:blank"
     with patch(f"{_RA}.get_user_password_pair_by_id", return_value=("e@x", "pw")), \
-         patch(f"{_RA}.get_driver_wait_pair", return_value=(MagicMock(), MagicMock())), \
+         patch(f"{_RA}.get_driver_wait_pair", return_value=(driver, MagicMock())), \
          patch(f"{_RA}.login_to_linkedin"), \
          patch(f"{_RA}._profile_is_first_degree", return_value=False), \
-         patch(f"{_RA}.click_element_wait_retry", click), \
+         patch(f"{_RA}.find_first", routes.find_first), \
+         patch(f"{_RA}.click_first", routes.click_first), \
+         patch(f"{_RA}.click_element_wait_retry", routes.click_element_wait_retry), \
+         patch(f"{_RA}.time.sleep"), \
          patch(f"{_RA}.log_error") as log_error, \
          patch(f"{_RA}.log_warning") as log_warning, \
          patch(f"{_RA}.insert_new_log") as insert_log, \
          patch(f"{_RA}.record_action"), \
          patch(f"{_RA}.quit_gracefully"):
-        sent, reason = ra.invite_to_connect_now(1, "https://x/in/jane", message)
-    return sent, reason, click, insert_log, log_error, log_warning
+        sent, reason = ra.invite_to_connect_now(1, _PROFILE_URL, message)
+    return sent, reason, driver, insert_log, log_error, log_warning
 
 
-def _clicked(click) -> list[str]:
-    return [call.args[2] for call in click.call_args_list]
+class TestCustomInviteUrlRoute:
+    def test_dialog_via_url_sends_without_touching_the_profile_menus(self):
+        from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
+        routes = _Routes(dialog_on_url=True, send_xpaths={_SEND_BARE_XPATH})
+        sent, reason, driver, _log, log_error, log_warning = _invite(routes)
+
+        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
+        assert any(_CUSTOM_INVITE_URL == c.args[0] for c in driver.get.call_args_list)
+        assert "Profile More menu" not in routes.click_labels
+        log_error.assert_not_called()
+        log_warning.assert_not_called()
+
+    def test_no_locator_on_the_open_path_can_hit_the_suggestion_rail(self):
+        # The regression that sent invites to random rail people: an unscoped
+        # //main//button[contains(@aria-label,"Invite ")] click. No locator on the
+        # dialog-open path may carry that shape again.
+        routes = _Routes(dialog_on_url=True, send_xpaths={_SEND_BARE_XPATH})
+        _invite(routes)
+        assert not any('"Invite ' in loc for loc in routes.all_locators)
 
 
-class TestNoConnectAffordance:
-    def test_a_profile_with_no_connect_option_stops_with_a_named_reason(self):
+class TestMoreMenuFallback:
+    def test_menu_route_opens_the_dialog_when_the_url_route_renders_none(self):
+        from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
+        routes = _Routes(dialog_after_menu=True, more_menu=True, menu_item=True,
+                         send_xpaths={_SEND_BARE_XPATH})
+        sent, reason, driver, _log, log_error, log_warning = _invite(routes)
+
+        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
+        assert routes.click_labels == ["Profile More menu", "Connect menu item"]
+        assert any(_PROFILE_URL == c.args[0] for c in driver.get.call_args_list)
+        log_error.assert_not_called()
+        log_warning.assert_not_called()
+
+    def test_a_clicked_menu_item_without_a_dialog_is_still_a_miss(self):
+        # Success is the DIALOG being present, not a click having landed.
         from cqc_lem.utilities.db import NO_CONNECT_BUTTON_MESSAGE
-        sent, reason, _click, insert_log, _err, _warn = _invite(found=set())
+        routes = _Routes(more_menu=True, menu_item=True)  # dialog never renders
+        sent, reason, _driver, _log, log_error, log_warning = _invite(routes)
+
+        assert sent is False and reason == NO_CONNECT_BUTTON_MESSAGE
+        log_error.assert_not_called()
+        log_warning.assert_called_once()
+
+
+class TestNoRouteOpensTheDialog:
+    def test_stops_with_a_named_reason_and_no_note_or_send_attempt(self):
+        from cqc_lem.utilities.db import NO_CONNECT_BUTTON_MESSAGE
+        routes = _Routes()
+        sent, reason, _driver, insert_log, log_error, log_warning = _invite(
+            routes, message="hi jane")
+
         assert sent is False and reason == NO_CONNECT_BUTTON_MESSAGE
         insert_log.assert_called_once()
         assert insert_log.call_args.kwargs["message"] == NO_CONNECT_BUTTON_MESSAGE
-
-    def test_it_never_attempts_the_note_or_send_steps(self):
-        # With no Connect dialog open those can only fail, and their errors buried the real reason.
-        _sent, _reason, click, _log, _err, _warn = _invite(found=set(), message="hi jane")
-        attempted = _clicked(click)
-        assert attempted == [_INVITE_XPATH, _MORE_XPATH]
-
-    def test_the_miss_is_a_warning_not_an_error(self):
-        # It is an expected outcome and it degrades gracefully — it must not page the error cron.
-        _sent, _reason, _click, _log, log_error, log_warning = _invite(found=set())
+        # With no dialog open, the note/send steps never run (no click attempts at all).
+        assert routes.legacy_click_xpaths == []
         log_error.assert_not_called()
         log_warning.assert_called_once()
         assert log_warning.call_args.kwargs["user_id"] == 1
 
 
-class TestConnectAffordanceStillWorks:
-    def test_the_direct_connect_button_sends_without_a_note(self):
-        from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
-        send_xpath = '//button[contains(@aria-label,"Send without a note")]'
-        sent, reason, click, _log, log_error, _warn = _invite(found={_INVITE_XPATH, send_xpath})
-        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
-        assert _MORE_XPATH not in _clicked(click)  # the overflow is only a fallback
-        log_error.assert_not_called()
-
-    def test_the_more_menu_is_the_fallback_when_the_direct_button_is_absent(self):
-        from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
-        send_xpath = '//button[contains(@aria-label,"Send without a note")]'
-        sent, reason, click, _log, _err, log_warning = _invite(
-            found={_MORE_XPATH, _MENU_CONNECT_XPATH, send_xpath})
-        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
-        assert _clicked(click)[:3] == [_INVITE_XPATH, _MORE_XPATH, _MENU_CONNECT_XPATH]
-        log_warning.assert_not_called()
-
-    def test_a_more_menu_without_a_connect_item_is_still_a_miss(self):
+class TestSluglessProfileUrl:
+    def test_a_url_without_a_slug_skips_straight_to_the_profile_route(self):
         from cqc_lem.utilities.db import NO_CONNECT_BUTTON_MESSAGE
-        sent, reason, _click, _log, log_error, _warn = _invite(found={_MORE_XPATH})
-        assert sent is False and reason == NO_CONNECT_BUTTON_MESSAGE
-        log_error.assert_not_called()
+        from cqc_lem.app import run_automation as ra
+        routes = _Routes()
+        driver = MagicMock()
+        driver.current_url = "about:blank"
+        with patch(f"{_RA}.find_first", routes.find_first), \
+             patch(f"{_RA}.click_first", routes.click_first), \
+             patch(f"{_RA}.log_warning") as log_warning, \
+             patch(f"{_RA}.log_debug"):
+            opened = ra._open_connect_invite_dialog(driver, MagicMock(), 1,
+                                                    "https://www.linkedin.com/company/acme/")
+
+        assert opened is False
+        # No custom-invite navigation happened — there is no /in/ slug to build it from.
+        assert not any("custom-invite" in str(c.args[0]) for c in driver.get.call_args_list)
+        assert "Profile More menu" in routes.click_labels
+        log_warning.assert_called_once()

--- a/tests/unit/app/test_invite_connect_note.py
+++ b/tests/unit/app/test_invite_connect_note.py
@@ -15,13 +15,12 @@ pytestmark = pytest.mark.unit
 
 _RA = "cqc_lem.app.run_automation"
 
-_INVITE_XPATH = '//main//button[contains(@aria-label, "Invite ")]'
 _NOTE_XPATH = '//button[contains(@aria-label,"Add a note")]'
 _TEXTAREA_XPATH = '//textarea[@id="custom-message"]'
 _SEND_XPATH = '//button[contains(@aria-label,"Send invitation")]'
 _SEND_BARE_XPATH = '//button[contains(@aria-label,"Send without a note")]'
 
-_NOTE_DIALOG = {_INVITE_XPATH, _NOTE_XPATH, _TEXTAREA_XPATH, _SEND_XPATH}
+_NOTE_DIALOG = {_NOTE_XPATH, _TEXTAREA_XPATH, _SEND_XPATH}
 
 
 def _clicker(found: set[str], box: MagicMock = None):
@@ -42,6 +41,7 @@ def _invite(found: set[str], message: str = None, box: MagicMock = None, refined
          patch(f"{_RA}.get_driver_wait_pair", return_value=(MagicMock(), MagicMock())), \
          patch(f"{_RA}.login_to_linkedin"), \
          patch(f"{_RA}._profile_is_first_degree", return_value=False), \
+         patch(f"{_RA}._open_connect_invite_dialog", return_value=True), \
          patch(f"{_RA}.click_element_wait_retry", click), \
          patch(f"{_RA}.get_ai_message_refinement", return_value=refined) as refine, \
          patch(f"{_RA}.time.sleep"), \
@@ -63,7 +63,7 @@ class TestNoteIsBestEffort:
         from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
         # LinkedIn offers only the bare dialog once the personalized-invite quota is spent.
         sent, reason, click, insert_log, log_error, log_warning, _r, record = _invite(
-            found={_INVITE_XPATH, _SEND_BARE_XPATH}, message="hi jane")
+            found={_SEND_BARE_XPATH}, message="hi jane")
         assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
         assert _SEND_BARE_XPATH in _clicked(click)
         assert insert_log.call_args.kwargs["message"] == CONNECTION_REQUEST_SENT_MESSAGE
@@ -104,7 +104,7 @@ class TestNoteHappyPath:
         sent, reason, click, _log, log_error, log_warning, refine, _rec = _invite(
             found=_NOTE_DIALOG, message="hi jane", box=box)
         assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
-        assert _clicked(click) == [_INVITE_XPATH, _NOTE_XPATH, _TEXTAREA_XPATH, _SEND_XPATH]
+        assert _clicked(click) == [_NOTE_XPATH, _TEXTAREA_XPATH, _SEND_XPATH]
         box.clear.assert_called_once()
         box.send_keys.assert_called_once_with("hi jane")
         refine.assert_not_called()  # already under the limit
@@ -113,8 +113,8 @@ class TestNoteHappyPath:
 
     def test_an_invite_with_no_note_never_opens_the_note_composer(self):
         _sent, _reason, click, _log, _err, _warn, _r, _rec = _invite(
-            found={_INVITE_XPATH, _SEND_BARE_XPATH})
-        assert _clicked(click) == [_INVITE_XPATH, _SEND_BARE_XPATH]
+            found={_SEND_BARE_XPATH})
+        assert _clicked(click) == [_SEND_BARE_XPATH]
 
 
 class TestSendFailureIsStillAnError:


### PR DESCRIPTION
## Problem

PostHog: many `Failed to send the connection request (no Send button on the open Connect dialog)` errors from `invite_to_connect`. The visible half. The invisible half is worse: **the errors were preceded by a connection request going out to a random person**.

## Root cause (live-grounded 2026-08-03)

The SDUI profile top card carries **no `Invite <name> to connect` button for the target** (on the Sales-Nav overlay layout it offers only Save-in-Sales-Nav / More / Message / Follow). The only elements matching the unscoped locator `//main//button[contains(@aria-label,"Invite ")]` are the **"More profiles for you" rail** — one `Invite <someone else> to connect` per suggested person. Every run clicked the first rail button (instant-send, wrong person), no dialog opened for the target, and the Send lookup then failed with the observed error.

**~20 stray invitations** went to rail people on 2026-08-03 (audited read-only on the sent-invitations page — Rui Luis, Brandy Smith MBA, etc., ~1/min while the profile-viewer backfill drained). The intended targets got nothing.

## Fix

Live grounding found the More menu's Connect item is now an `<a role=menuitem>` (text `Connect`, no aria-label) whose href is `https://www.linkedin.com/preload/custom-invite/?vanityName=<slug>` — **the invite dialog is addressable by URL**. New `_open_connect_invite_dialog`:

1. Navigate straight to the custom-invite URL (no wrong-person hazard, no menu hunting) — succeed only if the dialog's own controls render.
2. Fallback: profile page → top-card More menu (aria `More`; old `More actions` kept as secondary) → Connect menuitem (href-keyed first, TEXT second) → dialog-presence check.
3. Success is **the dialog being provably present**, never a click having landed. Total miss stays a WARNING (#571 posture).

The dialog-level locators were verified **unchanged** live (`Add a note`, `textarea#custom-message`, `Send invitation`, `Send without a note`) — `_add_connect_note` / `_submit_connect_invite` stay as-is. The unscoped `Invite ` locator is gone; a regression test asserts no locator on the open path can match the rail shape again.

`docs/sdui-selenium-notes.md` gains the full grounding (rail hazard + custom-invite URL + dialog inventory).

## Tests

- `test_invite_connect_affordance.py` rewritten: URL route, More-menu fallback, clicked-but-no-dialog is a miss, no-route stops before note/send with a named reason, slugless URL skips to profile route, and the rail-shape regression guard.
- `test_invite_connect_note.py` re-based on the new dialog-open helper (note behavior unchanged).
- Full unit lane: 10,170 passed.

`release:now`: every scheduled run until deploy invites a wrong person and loses the intended invite.

## Post-merge follow-ups (tracked in session)

- Re-dispatch the ~14 invites that failed during today's profile-viewer backfill once this deploys.
- Owner decision pending: withdraw the ~20 stray invitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)