### PR TITLE
docs(claude): trim CLAUDE.md back under the drift threshold (closes #1010)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,10 +5,10 @@
 LinkedIn Engagement Manager (LEM) automates LinkedIn engagement end to end: Selenium-based scraping and feed interaction, AI-generated content (via LiteLLM proxy routing to OpenAI / Claude / Ollama / OpenRouter), Celery task queue, React SPA frontend, MySQL persistence, and FastAPI backend.
 
 Two pillars:
-- **Content generation & scheduling** — 30-day plan of buyer-journey posts (thought leadership, industry-news commentary, personal story, engagement prompts, carousels, native video, blog summaries) auto-scheduled around peak/golden hours, with sentiment checks and preview/approval.
-- **Engagement automation** — feed commenting, replies, seed first comments, appreciation/outreach DMs with multi-touch follow-ups, and a throttled company-page invite drip — driven by per-user targeting, voice/tone, per-day caps.
+- **Content generation & scheduling** — a 30-day plan of buyer-journey posts auto-scheduled around peak/golden hours, with sentiment checks and preview/approval.
+- **Engagement automation** — feed commenting, replies, seed comments, appreciation/outreach DMs with follow-ups, and a throttled company-page invite drip — driven by per-user targeting, voice/tone, per-day caps.
 
-Code paths in **Feature Areas** below. Subsections end with `docs/*.md` pointers holding the full posture — CLAUDE.md is the map (locations, symbols, constants, invariants, where to find the detail).
+Code paths in **Feature Areas** below. Subsections carry `docs/*.md` pointers holding the full posture — CLAUDE.md is the map (locations, symbols, constants, invariants, where to find the detail).
 
 ## Tech Stack
 
@@ -55,13 +55,11 @@ compose/local/database/migrations/  Flyway migrations
 
 - **Logging:** Never use `print()`. Use the structured logger from `cqc_lem.utilities.logger`
   (`log_debug` / `log_info` / `log_warning` / `log_error` / `log_critical`; `myprint()` is a legacy
-  shim — avoid in new code). Pass context as keyword args (`user_id`, `post_id`, `task_name`,
-  `action_type`, …); `log_error`/`log_critical` take `exc=`.
-  **Once is a warning, repeatedly is a defect:** a repeated `log_warning` re-emits at ERROR and files
-  ONE grouped `$exception`, so never warn on an expected no-op — log those DEBUG.
-  Level table, the escalation contract and the rest of the conventions:
-  **`src/cqc_lem/utilities/CLAUDE.md`** (auto-loads when editing that tree) and
-  `docs/error-tracking.md`.
+  shim). Pass context as keyword args (`user_id`, `post_id`, `task_name`, `action_type`, …);
+  `log_error`/`log_critical` take `exc=`. **Once is a warning, repeatedly is a defect:** a repeated
+  `log_warning` re-emits at ERROR and files ONE grouped `$exception`, so never warn on an expected
+  no-op — log those DEBUG. Level table + escalation contract:
+  **`src/cqc_lem/utilities/CLAUDE.md`** (auto-loads in that tree) and `docs/error-tracking.md`.
 
 - **Type hints:** Required on all function signatures.
 - **Enums:** Use `PostStatus`, `PostType`, `LogActionType` from `db.py` for status fields — never raw strings.
@@ -79,11 +77,10 @@ response = client.chat.completions.create(model="lem-simple", messages=[...])
 ```
 
 `AttributedOpenAI` is the ONE client — it stamps attribution + trace ids on every endpoint, and it
-**rides out a proxy that is not accepting connections** (#986): the proxy is a container LEM restarts
-on deploys/reboots, and the SDK's own retries were spent in ~1.5s, so one blip used to lose the
-generation and file a defect for it. ONLY a connection that was never established is retried
-(`LLM_CONNECT_RETRY_ATTEMPTS` / `LLM_CONNECT_RETRY_BACKOFF_SECONDS`, ~24s default) — nothing was sent,
-so there's no spend to duplicate; a timeout, 4xx, or 5xx is the proxy answering and fails as before.
+**rides out a proxy that is not accepting connections** (#986, the proxy is a container LEM restarts
+on deploys): ONLY a connection that was never established is retried (`LLM_CONNECT_RETRY_ATTEMPTS` /
+`LLM_CONNECT_RETRY_BACKOFF_SECONDS`, ~24s default) — nothing was sent, so there's no spend to
+duplicate; a timeout, 4xx, or 5xx is the proxy answering and fails as before.
 
 **Model tier aliases** (defined in `.litellm/config.yaml`):
 
@@ -97,20 +94,17 @@ so there's no spend to duplicate; a timeout, 4xx, or 5xx is the proxy answering 
 | `lem-embedding` | Embeddings for feedback dedup/clustering (`client.embeddings.create`) |
 | `lem-router` | Auto-routes by prompt complexity via `LEMComplexityRouter` |
 
-**Cost-aware down-routing** (`utilities/routing_policy.py`, `utilities/cost_routing.py`): the router can additionally route a tier ONE step down for the treatment cohort of an active cost/quality experiment. `routing_policy.py` is the shared decision core — the app imports it, and docker-compose mounts that same file into the LiteLLM container — so it must stay **stdlib-only** (no `cqc_lem.*` imports). Off unless BOTH `COST_ROUTING_ENABLED` and `COST_AWARE_ROUTING_ENABLED` are set. Since #652 the treatment cohort comes from a PostHog experiment flag resolved app-side, handed to the router via the policy document's `arms` map (hash stays as fallback) — see `docs/experiments.md`, `docs/cost-performance-margin-plan.md` §D.1.1.
+**Cost-aware down-routing** (`utilities/routing_policy.py`, `utilities/cost_routing.py`): the router can route a tier ONE step down for the treatment cohort of an active cost/quality experiment. `routing_policy.py` is the shared decision core — the app imports it AND docker-compose mounts that same file into the LiteLLM container — so it must stay **stdlib-only** (no `cqc_lem.*` imports). Off unless BOTH `COST_ROUTING_ENABLED` and `COST_AWARE_ROUTING_ENABLED` are set. The treatment cohort comes from a PostHog experiment flag resolved app-side (#652), handed to the router via the policy document's `arms` map (hash stays as fallback) — `docs/cost-performance-margin-plan.md` §D.1.1.
 
 See `ai_helper.py` for the per-function model assignment.
 
-**Image stack (ONE engine, two modules):** `utilities/ai/image_brief.py` authors every image
-prompt — a validated `lem-medium` JSON brief (render prompt + `focal_concept`) with per-surface
-presets (`newsletter`/`post_image`/`carousel`/`video`/`thumbnail`) and a deterministic fallback;
-never add a per-content-type prompt helper, add a preset. `utilities/ai/image_gen.py` renders it —
-gpt-image via `lem-image` first, FLUX/Replicate fallback (`IMAGE_BACKEND`), cost-tracked via
-`track_media_cost` — and `render_image_gated` adds the `lem-vision` quality check with bounded
-regenerates (`IMAGE_GATE_MAX_ATTEMPTS`, fails OPEN). Avatar likeness NEVER renders in `image_gen` —
-`generate_post_image` (ai_helper) owns the LoRA path behind `avatar/guardrails.resolve_avatar_for`;
-newsletter covers add a fail-closed relevance classifier on the Auto path (`newsletter_cover.py`).
-NO text/logos in any render prompt — enforced in the brief engine's system prompt.
+**Image stack (ONE engine, two modules, `docs/image-stack.md`):** `utilities/ai/image_brief.py`
+authors every image prompt — a validated `lem-medium` brief (render prompt + `focal_concept`) with
+per-surface presets (`newsletter`/`post_image`/`carousel`/`video`/`thumbnail`); never add a
+per-content-type prompt helper, add a preset. `utilities/ai/image_gen.py` renders it
+(`IMAGE_BACKEND`, cost-tracked); `render_image_gated` adds the bounded `lem-vision` check, failing
+OPEN. Avatar likeness NEVER renders in `image_gen` — `generate_post_image` (ai_helper) owns the LoRA
+path behind `avatar/guardrails.resolve_avatar_for`. NO text/logos in any render prompt.
 
 ## Selenium Pattern
 
@@ -118,63 +112,60 @@ Always use `get_docker_driver()` from `selenium_util.py`. It connects to `seleni
 
 Use `click_element_wait_retry()` for all click interactions — it handles transient DOM timing issues.
 
-Browser capacity is a **fixed pool of Chrome session slots shared by the Celery Selenium lanes**, and
+Browser capacity is a **fixed pool of Chrome session slots shared by the Celery Selenium lanes**:
 `SE_NODE_MAX_SESSIONS` must always equal the summed `SELENIUM_CONCURRENCY` of those lanes —
 `tests/unit/app/test_selenium_capacity.py` fails the build if they drift. The Phase-2 horizontal path
-(`docker-compose.grid.yml`: hub + N single-session nodes, optionally on a 2nd VPS) carries the same
-invariant with node count as the cap, and `python -m cqc_lem.utilities.selenium_load_test` produces
-the on-time/resource curve that sizes it. See `docs/SELENIUM_GRID.md` and `docs/scaling-plan.md`.
+(`docker-compose.grid.yml`: hub + N single-session nodes) carries the same invariant with node count
+as the cap; `python -m cqc_lem.utilities.selenium_load_test` sizes it. See `docs/SELENIUM_GRID.md`
+and `docs/scaling-plan.md`.
 
 ## Feature Areas
 
 ### Content generation & scheduling (`app/run_content_plan.py`, `app/run_scheduler.py`, `utilities/ai/ai_helper.py`)
-- AI content by buyer-journey stage (awareness / consideration / decision): thought-leadership, industry-news commentary, personal-story, engagement-prompt posts, carousels (educational / case-study / product-demo / insights), native video, and blog summaries.
-- 30-day content plan with balanced post-type distribution; auto-scheduling around golden/peak hours.
-- **Cadence (issue #621):** the plan is NOT one post a day — it fills `posts_per_week` slots (2–7, default 3) of a fixed day-type calendar (`POST_DAY_TYPES`) that also sets each post's buyer stage and archetype family. `posting_days` (#581, default Mon–Fri) is the separate, harder bound on WHICH days may carry a slot — weekends are opt-in. Full posture: `docs/content-scheduling.md`.
+- AI content by buyer-journey stage (awareness / consideration / decision): thought-leadership, industry-news commentary, personal-story, engagement-prompt posts, carousels (educational / case-study / product-demo / insights), native video, blog summaries — a 30-day plan with balanced post-type distribution, auto-scheduled around golden/peak hours.
+- **Cadence (#621, `docs/content-scheduling.md`):** the plan is NOT one post a day — it fills `posts_per_week` slots (2–7, default 3) of a fixed day-type calendar (`POST_DAY_TYPES`) that also sets each post's buyer stage and archetype family. `posting_days` (#581, default Mon–Fri) is the separate, harder bound on WHICH days may carry a slot — weekends are opt-in.
 - Self-healing carousels (stale/errored carousels re-generated into branded slides) and asset backfill.
-- **Newsletter cover images** (`utilities/newsletter_cover.py`, #893): the ONE place a cover is validated, stored, and generated. Two sources, NOT symmetric — an **upload** is the author's own artwork so it lands `approved`; a **generated** cover always lands `pending_review` (a public brand asset). `_approved_cover_path` (run_automation) is the ONLY thing deciding a cover may reach LinkedIn. Generation is opt-in (`cover_image_auto`, off by default) and reuses the SHARED image path, never a parallel helper. Attaching is best-effort: `STEP_COVER` is never a graded editor step. Full posture: `docs/newsletter-covers.md`.
-- **Newsletter blog alignment** (`utilities/blog_source.py`, #967): `resolve_blog_source` is the ONE place the `align_with_blog` toggle (default ON) becomes actual source text — blog URL first, sitemap fallback, through the SAME fetchers `blog_summary`/`website_content` use. Best-effort, never blocking: unset/unreachable/empty returns `None` and the edition writes from topic + profile as before. Resolved PER edition, so a batch of queued drafts repurposes DIFFERENT articles. ON with nothing configured is an expected no-op (DEBUG) — only a configured source reading back empty warns.
+- **Newsletter cover images** (`utilities/newsletter_cover.py`, #893, `docs/newsletter-covers.md`): the ONE place a cover is validated, stored, and generated. Two sources, NOT symmetric — an **upload** is the author's own artwork so it lands `approved`; a **generated** cover always lands `pending_review` (a public brand asset). `_approved_cover_path` (run_automation) is the ONLY thing deciding a cover may reach LinkedIn. Generation is opt-in (`cover_image_auto`, off) and reuses the SHARED image path. Attaching is best-effort: `STEP_COVER` is never a graded editor step.
+- **Newsletter blog alignment** (`utilities/blog_source.py`, #967): `resolve_blog_source` is the ONE place the `align_with_blog` toggle (default ON) becomes source text — blog URL first, sitemap fallback, through the SAME fetchers `blog_summary`/`website_content` use. Best-effort, never blocking: unset/unreachable/empty returns `None` and the edition writes from topic + profile. Resolved PER edition, so queued drafts repurpose DIFFERENT articles. ON with nothing configured is an expected no-op (DEBUG) — only a configured source reading back empty warns.
 - `PostType` is `text` / `carousel` / `video`; `PostStatus` includes `error` for generation/posting failures needing manual fix.
 
 ### Engagement automation (`app/run_automation.py`) — full posture for every bullet below: `docs/engagement-automation.md`
-- **Feed commenting** rebuilt for LinkedIn's SDUI: resilient `find_first`/`click_first`/`find_all_first` selectors (`utilities/linkedin/helper.py`); inline compose+submit; **recency-dominant scoring matrix** (`_score_feed_post`); `_switch_feed_to_recent` sort control; targeting + per-day caps + voice/tone. Runs pre-post (~15 min before) and daily at a golden hour. **Best-effort but never silent (#817):** the matrix is recency-DOMINANT, so `_switch_feed_to_recent`'s returned state (`recent`/`top`/`missing`/`unknown`/`n/a`) rides onto the feed funnel + `feed_scan` event — an unsorted scan must never read as recency-sorted. Group feed has no control, so a miss there is `n/a`/DEBUG. Live grounding: `linkedin_live_validation.py --feed-sort`.
+- **Feed commenting** rebuilt for LinkedIn's SDUI: resilient `find_first`/`click_first`/`find_all_first` selectors (`utilities/linkedin/helper.py`), inline compose+submit, **recency-dominant scoring matrix** (`_score_feed_post`), targeting + per-day caps + voice/tone. Runs pre-post (~15 min before) and daily at a golden hour. **Best-effort but never silent (#817):** `_switch_feed_to_recent` returns the run's sort state (`recent`/`top`/`missing`/`unknown`/`n/a`) onto the feed funnel + `feed_scan` event — an unsorted scan must never read as recency-sorted. Live: `linkedin_live_validation.py --feed-sort`.
 - **Replies** to comments on the user's own posts (`automate_reply_commenting`); **seed a first comment** on own posts (`auto_seed_comment_on_post`).
 - **Golden-hour presence** (`utilities/golden_hour.py`, #622): ONE `golden_hour_report` per swept post, measured off REAL publish time from the POST log, never `scheduled_time` — unmeasured is never on-time. **Second wave**: ONE self-comment 6–8h later (`auto_second_wave_comment`) that must ADD substance (#617 contract + similarity gate + slop lint); seed + second wave can never stack (`SELF_COMMENT_MAX_PER_POST=2`).
-- **DM conversation auto-nurture** (`_nurture_after_reply`, `utilities/ai/dm_nurture.py`): a reply used to END a sequence — now it's classified and becomes an **approval-gated** next message (`pending` row, `source='nurture'`), one open draft per thread; explicit disinterest stops the thread for good.
+- **DM conversation auto-nurture** (`_nurture_after_reply`, `utilities/ai/dm_nurture.py`): a reply is classified into an **approval-gated** next message (`pending` row, `source='nurture'`), one open draft per thread; explicit disinterest stops the thread for good.
 - **Reciprocity tracking** via the `post_engagers` table — boosts commenting back on people who engaged with us (`get_recent_engagers`).
-- **DMs**: appreciation (connection / recommendation / collaboration), profile-viewer outreach, and **multi-touch follow-up sequences** — all templated and voice-aligned (`build_dm_from_template`, `dm_templates`, `dm_followups`, `process_user_followups`).
-- **Appreciation sources** (#968): recommendation + collaboration read STANDING lists (Recommendations Received; the mentions feed), not event queues, so an **undated card is SKIPPED** and only `APPRECIATION_LOOKBACK_DAYS` (30) counts. `appreciation_touches` is the durable CLAIM (checked before write, claimed before send) that stops double-thanking on the ~60s re-queue; `_appreciation_dm_budget` (SHARED cap + #626 envelope) stops mass-thanking at once — unaffordable claims stay UNCLAIMED. Cards rendering with NO dated one is the one thing that warns. OFF until live-grounded (`APPRECIATION_SOURCES_ENABLED`).
-- **Message-thread resolution ladder** (`utilities/linkedin/message_thread.py`, #731): `open_message_thread` walks SIX routes, a route counts only when the thread is **provably open** — class names never keyed on, every locator is href/aria-label/TEXT. Verdict is **three-valued** (`ThreadState.REPLIED`/`NOT_REPLIED`/`UNKNOWN`); UNKNOWN SKIPS (a missed follow-up recovers, a follow-up to a reply doesn't). Self-name is a required setting (`users.linkedin_display_name`), never scraped.
+- **DMs**: appreciation (connection / recommendation / collaboration), profile-viewer outreach, **multi-touch follow-up sequences** — templated and voice-aligned (`build_dm_from_template`, `dm_templates`, `dm_followups`, `process_user_followups`).
+- **Appreciation sources** (#968): recommendation + collaboration read STANDING lists, not event queues, so an **undated card is SKIPPED** and only `APPRECIATION_LOOKBACK_DAYS` (30) counts. `appreciation_touches` is the durable CLAIM (checked before write, claimed before send) that stops double-thanking on the ~60s re-queue; `_appreciation_dm_budget` (SHARED cap + #626 envelope) bounds it — unaffordable claims stay UNCLAIMED. OFF until live-grounded (`APPRECIATION_SOURCES_ENABLED`).
+- **Message-thread resolution ladder** (`utilities/linkedin/message_thread.py`, #731): `open_message_thread` walks SIX routes; a route counts only when the thread is **provably open** — never class names, only href/aria-label/TEXT. Verdict is **three-valued** (`ThreadState.REPLIED`/`NOT_REPLIED`/`UNKNOWN`); UNKNOWN SKIPS. Self-name is a required setting (`users.linkedin_display_name`), never scraped.
 - **Owned-asset CTA loop** (`resolve_artifact_delivery` in `content_alignment.py` + `_queue_artifact_delivery`, #624): the ONE map from a CTA to its asset, naming the CHANNEL — **lead magnet** is the comment-keyword mechanic whose payload is a DM; **newsletter** is a subscribe LINK. Keyword delivery is **approval-gated** (`pending` `scheduled_dms` row, `source='artifact'`).
-- **Human pacing** (`utilities/human_pacing.py`, #626): the ONE place cadence is decided — read-time delay, dispatch jitter, a per-day-cap draw, all seeded on (user, action, date) and persisted in Redis so a retry never re-rolls. Fails open (no Redis / `HUMAN_PACING_ENABLED=false`). Pacing only slows us down; the 429 breaker in `rate_limit.py` is the separate, harder gate.
+- **Human pacing** (`utilities/human_pacing.py`, #626): the ONE place cadence is decided — read-time delay, dispatch jitter, per-day-cap draw, all seeded on (user, action, date) and persisted in Redis so a retry never re-rolls. Fails open (no Redis / `HUMAN_PACING_ENABLED=false`). Pacing only slows us down; the 429 breaker in `rate_limit.py` is the separate, harder gate.
 - **Comment outcome tracking** (`sweep_comment_outcomes` + `utilities/comment_outcomes.py`, #628): read-only T+24h sweep writes ONE `comment_outcomes` row per comment — replies, likes, and a **three-valued** `visible_most_relevant` (1 relevant / 0 demoted / NULL unreadable, excluded from the denominator). Demotion rate over threshold **holds that user's feed commenting** and escalates CRITICAL.
-- **Suppression tripwire** (`auto_suppression_tripwire` + `utilities/suppression.py`, #629): 2026 LinkedIn penalties are SILENT (reach step-collapses, no notification). A daily beat compares impressions-per-post against the user's OWN trailing 14-day median; a sustained drop `pause_automation()`s **engagement only** (posting is never gated) and escalates CRITICAL. Cold start / thin baseline = `unknown`, never actioned. Recovery is human (`POST /user/automation-resume`).
-- **Weekly group post** (`auto_draft_group_post` → `auto_post_to_group`, #932): TWO beats with a review window between them. `auto_draft_group_post` (Sun) writes the text — no browser, cached profile — and `auto_post_to_group` (Tue) publishes that draft, generating NOTHING, so **a run with no READY draft publishes nothing**. Resting status is `ready` so silence ships it; the SPA (`GroupsCard`) is where a user rewrites or skips it. ONE open draft per user, carried forward, never replaced.
+- **Suppression tripwire** (`auto_suppression_tripwire` + `utilities/suppression.py`, #629): 2026 LinkedIn penalties are SILENT. A daily beat compares impressions-per-post against the user's OWN trailing 14-day median; a sustained drop `pause_automation()`s **engagement only** (posting is never gated) and escalates CRITICAL. Cold start / thin baseline = `unknown`, never actioned. Recovery is human (`POST /user/automation-resume`).
+- **Weekly group post** (`auto_draft_group_post` → `auto_post_to_group`, #932): TWO beats with a review window between them — Sun writes the text (no browser), Tue publishes that draft and generates NOTHING, so **a run with no READY draft publishes nothing**. Resting status is `ready` so silence ships it; `GroupsCard` is where a user rewrites or skips. ONE open draft per user, carried forward, never replaced.
 - **Roster targets LEM can't comment on** (`comment_on_roster_posts` + `auto_follow_roster_target`, #962): posts but ZERO commentable cards records a blocked visit; a whole roster blocked (`_card_for_textbox` drift) records nothing. Auto-follow is opt-in and OFF (`roster_auto_follow`), draws `ACTION_FOLLOW`/`max_follows_per_day` bounded by (never in) the account envelope, and clicks NOTHING unless the control names the page owner.
-- **Stale-invite withdrawal** (`utilities/linkedin/stale_invites.py`, #969): the 02:00 beat was a `not_implemented` stub that LOOKED operational. Withdrawing is ONE-WAY (no re-invite for ~3 weeks), so reads fail CLOSED — an unreadable "Sent … ago" is NEVER stale, only the row's OWN `Sent` line is parsed. OFF until `STALE_INVITE_WITHDRAWAL_ENABLED` (ground: `linkedin_live_validation --sent-invites`). `plan_withdrawals` decides the allowance BEFORE Chrome opens, bounded by (never in) the envelope; spend is counted on the CLICK.
-- **Company-page invitations** (`utilities/linkedin/company_page_inviter.py`, #732): a paced DAILY drip bounded by the SMALLEST of three ceilings — per-day cap, credit spread (`credits_remaining / days_left_in_month`), live credit count. `plan_daily_invites` decides all of that BEFORE a Chrome session opens — most days the allowance is zero.
+- **Stale-invite withdrawal** (`utilities/linkedin/stale_invites.py`, #969): withdrawing is ONE-WAY (~3 weeks before a re-invite), so reads fail CLOSED — an unreadable "Sent … ago" is NEVER stale, only the row's OWN `Sent` line is parsed. OFF until `STALE_INVITE_WITHDRAWAL_ENABLED` (ground: `linkedin_live_validation --sent-invites`). `plan_withdrawals` decides the allowance BEFORE Chrome opens, bounded by (never in) the envelope; spend counted on the CLICK.
+- **Company-page invitations** (`utilities/linkedin/company_page_inviter.py`, #732): a paced DAILY drip bounded by the SMALLEST of three ceilings — per-day cap, credit spread (`credits_remaining / days_left_in_month`), live credit count. `plan_daily_invites` decides all of that BEFORE a Chrome session opens.
 
 ### Engagement configuration (`engagement_preferences` table, API in `api/main.py`, SPA in `ui/.../Account.tsx`)
-- Targeting: include/exclude topics/keywords/authors, `min_reactions`, `max_post_age_hours`, plus LLM topic-relevance scoring.
-- Voice: tone, `comment_length` (short/medium/long; default short), style, emoji/hashtag toggles.
-- Caps: `max_comments_per_day`, `max_dms_per_day`; DM template editor with follow-up steps; Login Location (city/state geocoding via `utilities/geocoding.py`, with admin override).
+- **Targeting:** include/exclude topics/keywords/authors, `min_reactions`, `max_post_age_hours`, plus LLM topic-relevance scoring.
+- **Voice:** tone, `comment_length` (short/medium/long; default short), style, emoji/hashtag toggles.
+- **Caps:** `max_comments_per_day`, `max_dms_per_day`; DM template editor with follow-up steps; Login Location (city/state geocoding via `utilities/geocoding.py`, admin-overridable).
 
 ### Marketing video tutorials (`utilities/marketing/video_tutorials.py`, beat `produce-feature-tutorial`)
-- One declarative `TutorialFlow` per feature (routes + CSS anchors proving the screen rendered) → headless SPA capture via `get_docker_driver()` → grounded script (`lem-medium`) → TTS (OpenAI `lem-tts` default, ElevenLabs behind `TUTORIAL_TTS_PROVIDER`) → ffmpeg MP4 with branded intro/outro + `.srt` → 9:16 clip → YouTube Data API v3 upload.
-- **Fail-closed**: a missing UI anchor, an unparseable script, profanity, an over-cap narration, or a fabricated number aborts BEFORE any TTS/publish spend. Cost is attributed per part and totalled on the manifest record.
-- State lives in `assets/videos/tutorials/manifest.json`; the SPA embeds it via `TutorialVideos.tsx`. Weekly cadence; a flow is re-filmed only when its captured UI fingerprint changes. OFF unless `TUTORIAL_VIDEOS_ENABLED`.
-- **YouTube OAuth token** (`youtube_auth.py`, #742): the ONE place its state is decided. Read DB-first (`app_credentials`, installed via `POST /admin/youtube-token` — no deploy), `YOUTUBE_REFRESH_TOKEN` seeds it. `unknown` (Google unreachable) is NOT `needs_reauth` (4xx / lost scope — the only state that alerts). Weekly beat `youtube-token-check` IS the keep-alive vs the 6-month-disuse expiry — never drop it while the feature is off. Full posture: `docs/youtube-publishing.md`.
+- One declarative `TutorialFlow` per feature (routes + CSS anchors proving the screen rendered) → headless SPA capture → grounded script (`lem-medium`) → TTS → ffmpeg MP4 + `.srt` → 9:16 clip → YouTube upload. **Fail-closed, cheapest-first**: a missing UI anchor, an unparseable script, profanity, an over-cap narration, or a fabricated number aborts BEFORE any TTS/publish spend. A flow is re-filmed only when its captured UI fingerprint changes; state in `assets/videos/tutorials/manifest.json`, embedded by `TutorialVideos.tsx`. OFF unless `TUTORIAL_VIDEOS_ENABLED`. Full posture: `docs/marketing-video-tutorials.md`.
+- **YouTube OAuth token** (`youtube_auth.py`, #742): the ONE place its state is decided. Read DB-first (`app_credentials`, installed via `POST /admin/youtube-token` — no deploy), `YOUTUBE_REFRESH_TOKEN` seeds it. `unknown` (Google unreachable) is NOT `needs_reauth` (4xx / lost scope — the only state that alerts). Weekly beat `youtube-token-check` IS the keep-alive vs the 6-month-disuse expiry — never drop it while the feature is off. Full: `docs/youtube-publishing.md`.
 
 ### Anti-bot / session infra
 - Per-user static residential proxy (`utilities/proxy.py`) + an in-memory **MV3 proxy-auth extension** (`_build_proxy_auth_extension_b64` in `selenium_util.py`) — never URL-embedded credentials, since MV2 background pages are disabled in Chrome 149+.
 - Cookie persistence (`li_at` is the DEFAULT engagement login since #745) + an email-PIN verification flow (`utilities/linkedin/verification_pin.py`).
-- **Sign-in visibility** (`utilities/linkedin/login_status.py`, #933): the device-approval challenge is approved on LinkedIn itself, so email was the ONLY place a user could confirm LEM got it. `_persist_session_cookies` is where both login paths meet, so it's where a sign-in is recorded (`mark_signed_in`); the wait loop always closes `approval_pending` — `approval_timed_out` on giving up, `mark_signed_in` the moment it clears (a login that dies before the cookie persist must not keep asking for a tap already given). Redis-backed, fails open: `unknown` means nothing recorded, NOT a broken connection. Read via `GET /user/linkedin-signin-status` → `LinkedInSignInStatusCard.tsx`.
-- **OAuth token renewal** (`utilities/linkedin/token_refresh.py`, #600): `resolve_token_status` is the ONE place token state is decided — SPA countdown and renewal beat read the same function. LinkedIn caps auth at 60 days, so a **rolling refresh is the only way it outlives that**: daily beat `refresh-linkedin-tokens` (08:30) renews everyone inside `EXPIRY_WARNING_DAYS`, where before only an SPA page view ever did. "No refresh token" is an expected no-op (DEBUG); those users get a throttled reconnect email (`LINKEDIN_TOKEN_EMAIL_THROTTLE_DAYS`, Redis, fails open). `days_remaining` is `None`, never 0, when unreadable.
+- **Sign-in visibility** (`utilities/linkedin/login_status.py`, #933): `_persist_session_cookies` is where both login paths meet, so it's where a sign-in is recorded (`mark_signed_in`); the device-approval wait loop always closes `approval_pending` — `approval_timed_out` on giving up, `mark_signed_in` the moment it clears (never keep asking for a tap already given). Redis-backed, fails open: `unknown` means nothing recorded, NOT a broken connection. `GET /user/linkedin-signin-status` → `LinkedInSignInStatusCard.tsx`.
+- **OAuth token renewal** (`utilities/linkedin/token_refresh.py`, #600): `resolve_token_status` is the ONE place token state is decided — SPA countdown and renewal beat read the same function. LinkedIn caps auth at 60 days, so the daily beat `refresh-linkedin-tokens` (08:30) renewing everyone inside `EXPIRY_WARNING_DAYS` is the only way a token outlives that. "No refresh token" is an expected no-op (DEBUG) → a throttled reconnect email (`LINKEDIN_TOKEN_EMAIL_THROTTLE_DAYS`, Redis, fails open). `days_remaining` is `None`, never 0, when unreadable.
 - 429 / auth-wall backoff and resilience (`utilities/linkedin/rate_limit.py`).
 - **Secrets at rest** (`utilities/crypto.py`, #745): `li_at`, OAuth tokens and the stored password are AES-256-GCM envelopes keyed per user+column off `LEM_SECRET_KEY`; `db.py` is the ONE caller and the field-name constants are AAD — renaming one orphans every row. Reads dual-mode until `ENCRYPTION_REQUIRED`; failed decrypt → None. Daily `auto_encrypt_secrets_at_rest` backfills AND rotates. Full: `docs/secrets-at-rest.md`.
-- **LEM identity + sessions** (#745 phase 2b): `users.public_uid` is the identity; email is a movable ATTRIBUTE (`change_user_email`, PIN to the NEW address, other sessions revoked). `sessions.session_token` stores `SHA-256(token)` — UNKEYED, so a rotated `LEM_SECRET_KEY` never logs everyone out — in an **httpOnly** cookie. `api/main.get_session_user_id()` is the ONE resolver: an explicit token that RESOLVES wins, else the cookie; the SPA sends sentinel `'cookie'`. **Since #914 EVERY `/api` route resolves its caller through it** — `require_session_user_id()` is it plus a 401; an `email`/`user_id`/`post_id` is a TARGET to authorise (403 + audited `foreign_target_denied`), not the actor; `db.user_owns_posts` FAILS CLOSED; a DB fault is **503** not 403 (importing `db.get_session_user_id` around the wrapper is a bug). **CSRF (#957):** a cookie-authenticated `/api` write must send `X-LEM-Client` — 403 `client_header_required`. The shared bearer (`API_ACCESS_TOKENS`) is a NON-BROWSER credential since #950 — never in the SPA build. Sessions are per-device revocable. Auth limiting is TWO layers: Redis windows (fails open) + the durable PIN lockout in `verify_pin_for_email`; all lands in `auth_audit_log`. Full: `docs/identity-and-sessions.md`.
-- **Strong auth + step-up** (#745 phase 2c): `utilities/auth_factors.py` is the ONE place factor state is decided (`webauthn_util.py` holds the ceremonies). Once an account enrols a passkey or TOTP the email PIN is a **bootstrap** only. A **passkey** login is the only phishing-resistant path arriving already stepped up; a **recovery code** never does. `sessions.last_verified_at` gates every credential-touching write — refusal is **403 `step_up_required`**, never 401. **The FIRST factor is free, every one after it is gated, removing one always is**; a `scope='recovery'` session may enrol but is never stamped for it. A pending second-factor handle is burned by the `SECOND_FACTOR_MAX_ATTEMPTS`-th wrong code — durable in `auth_challenges.attempts`, counted **per account** over `SECOND_FACTOR_ATTEMPT_WINDOW_MINUTES` and carried into the next handle, so starting over buys nothing: **401 = wrong code, retry; 400 = handle gone; 429 = budget spent**. The extension steps up once in the SPA at `/user/extension-token` for a `scope='extension'` session. `STRONG_AUTH_ENABLED=false` reverts to 2b. Full: `docs/strong-authentication.md`.
-- **Session scopes are SURFACES** (#905, 2c.1): the same resolver enforces scope everywhere. `extension` reaches only the ONE path the extension calls (else 403 + audited `session_scope_denied`); `enroll` — a PIN login past `REQUIRE_STRONG_FACTOR_AFTER` on a factor-less account — reaches only enrolment, which promotes it to `full`. **A hold is never a lockout:** the PIN still signs you in, and every read goes through `enrollment_hold_active()`. Empty date (the default) = 2c behaviour exactly.
+- **LEM identity + sessions** (#745 phase 2b, `docs/identity-and-sessions.md`): `users.public_uid` is the identity; email is a movable ATTRIBUTE (`change_user_email`, PIN to the NEW address, other sessions revoked). `sessions.session_token` stores `SHA-256(token)` — UNKEYED, so a rotated `LEM_SECRET_KEY` never logs everyone out — in an **httpOnly** cookie. `api/main.get_session_user_id()` is the ONE resolver: an explicit token that RESOLVES wins, else the cookie (the SPA sends sentinel `'cookie'`). **Since #914 EVERY `/api` route resolves its caller through it** — `require_session_user_id()` is it plus a 401; an `email`/`user_id`/`post_id` is a TARGET to authorise (403 + audited `foreign_target_denied`), not the actor; `db.user_owns_posts` FAILS CLOSED; a DB fault is **503** not 403. **CSRF (#957):** a cookie-authenticated `/api` write must send `X-LEM-Client` — 403 `client_header_required`. The shared bearer (`API_ACCESS_TOKENS`) is a NON-BROWSER credential since #950 — never in the SPA build. Auth limiting is TWO layers: Redis windows (fails open) + the durable PIN lockout in `verify_pin_for_email`; all lands in `auth_audit_log`.
+- **Strong auth + step-up** (#745 phase 2c, `docs/strong-authentication.md`): `utilities/auth_factors.py` is the ONE place factor state is decided (`webauthn_util.py` holds the ceremonies). Once an account enrols a passkey or TOTP the email PIN is a **bootstrap** only. A **passkey** login is the only path arriving already stepped up; a **recovery code** never does. `sessions.last_verified_at` gates every credential-touching write — refusal is **403 `step_up_required`**, never 401. **The FIRST factor is free, every one after it is gated, removing one always is**; a `scope='recovery'` session may enrol but is never stamped for it. A pending second-factor handle is burned by the `SECOND_FACTOR_MAX_ATTEMPTS`-th wrong code — durable in `auth_challenges.attempts`, counted **per account** over `SECOND_FACTOR_ATTEMPT_WINDOW_MINUTES` and carried into the next handle: **401 = wrong code, retry; 400 = handle gone; 429 = budget spent**. `STRONG_AUTH_ENABLED=false` reverts to 2b.
+- **Session scopes are SURFACES** (#905, 2c.1): the same resolver enforces scope everywhere. `extension` reaches only the ONE path the extension calls (else 403 + audited `session_scope_denied`) and steps up once in the SPA at `/user/extension-token`; `enroll` — a PIN login past `REQUIRE_STRONG_FACTOR_AFTER` on a factor-less account — reaches only enrolment, which promotes it to `full`. **A hold is never a lockout:** the PIN still signs you in, and every read goes through `enrollment_hold_active()`. Empty date (the default) = 2c behaviour exactly.
 
 ## Testing Standards
 
@@ -189,106 +180,97 @@ Track events via `utilities/observability.py` (`track_llm_call` / `track_task` /
 Each subsection below is a one-paragraph invariant; rationale, contracts, sample code, and edge
 cases live in the pointed-to doc. Plan with this section, drill in with the doc.
 
-### LLM analytics (issue #647, traces #746)
+### LLM analytics (issue #647, traces #746) — `docs/llm-analytics.md`
 Two streams, never summed: `llm_call` (app, cost ESTIMATE — every money question reads this) vs
 `$ai_generation`/`$ai_embedding` (proxy-native, post-fallback, provider-priced — latency/error/
 volume). Attribution lives in `utilities/ai/client.py` (the ONE client); `_attach_routing_metadata`
 must stay. **Pipeline traces** group a post/edition/comment's 5–6 calls into ONE `$ai_trace` with
 per-step `$ai_span`s: `@llm_pipeline` on the three roots (`create_text_post`,
 `generate_newsletter_edition`, `generate_ai_response` — supersedes `attribute_llm_cost`), `@llm_step`
-on the SHARED-core step functions (never at a call site). The client sends ids two ways since
-LiteLLM reads them from two places — trace id in the `x-litellm-trace-id` HEADER, parent span in
+on the SHARED-core step functions (never at a call site). Ids ship two ways since LiteLLM reads them
+from two places — trace id in the `x-litellm-trace-id` HEADER, parent span in
 `metadata.parent_run_id`. Nested trace = span; span with no trace = no-op;
-`LLM_TRACING_ENABLED=false` mints nothing. Full posture: `docs/llm-analytics.md`.
+`LLM_TRACING_ENABLED=false` mints nothing.
 
-### Error tracking (issue #648)
+### Error tracking (issue #648) — `docs/error-tracking.md`
 Logs (`logger.py` → PostHog Logs) carry message+context; `$exception` is the grouped/fingerprinted
-ISSUE alerting + the error→GitHub-issue cron file on — NOT redundant. Use
-`observability.capture_exception(...)` for caught-and-not-reraised; `posthog.capture_exception` is
-idempotent. Never capture `HTTPException` (4xx is a response, not an issue). Full posture:
-`docs/error-tracking.md`.
+ISSUE alerting + the error→GitHub-issue cron — NOT redundant. Use
+`observability.capture_exception(...)` for caught-and-not-reraised (`posthog.capture_exception` is
+idempotent). Never capture `HTTPException` — 4xx is a response, not an issue.
 
-### Browser-side analytics (issue #646)
+### Browser-side analytics (issue #646) — `docs/posthog-advanced-surface.md`
 ONE SPA surface: `ui/src/utils/analytics.ts` — never call `posthog` directly. `distinct_id =
 String(user_id)` matches `observability.py` so browser+Celery+proxy share ONE PostHog person.
 Env-gated at BUILD time (`VITE_POSTHOG_KEY`); no key → lazy chunk never fetched → no-op.
-`maskProps()` adds `ph-no-capture` + `data-ph-mask`; use it on every content editor. Full posture:
-`docs/posthog-advanced-surface.md`.
+`maskProps()` adds `ph-no-capture` + `data-ph-mask` — use it on every content editor.
 
-### Session replay (issue #649)
-Rules live in the SDK: `VITE_POSTHOG_REPLAY_SAMPLE` slice + EVERY `$exception`/feedback session,
-both via one `ensureSessionRecorded()`. Local `sampleRate` takes precedence — never set project
-sampling (multiplies). Canvas off; inputs masked; network capture timings only. Full posture:
-`docs/session-replay.md`.
+### Session replay (issue #649) — `docs/session-replay.md`
+Rules live in the SDK: `VITE_POSTHOG_REPLAY_SAMPLE` slice + EVERY `$exception`/feedback session, both
+via one `ensureSessionRecorded()`. Local `sampleRate` takes precedence — never set project sampling
+(multiplies). Canvas off; inputs masked; network capture timings only.
 
-### KPI funnels, dashboards, alerts + weekly report (issue #650)
-`scripts/posthog_provision.py` owns Health + Growth dashboards, four threshold alerts, weekly Growth
-email. Alert tiles must be native single-series `TrendsQuery` filtering on STRING props (boolean
-filters match nothing → silent alerts). Money tiles read `$ai_generation`, never `llm_call`.
-`mark_rate_limited()` emits `rate_limit_trip` (WARNING log never reaches PostHog). Full posture:
-`docs/kpi-dashboards.md`.
+### KPI funnels, dashboards, alerts + weekly report (issue #650) — `docs/kpi-dashboards.md`
+`scripts/posthog_provision.py` owns Health + Growth dashboards, four threshold alerts, the weekly
+Growth email. Alert tiles must be native single-series `TrendsQuery` filtering on STRING props
+(boolean filters match nothing → silent alerts). Money tiles read `$ai_generation`, never `llm_call`.
+`mark_rate_limited()` emits `rate_limit_trip` (a WARNING log never reaches PostHog).
 
-### Experiments (issue #652)
+### Experiments (issue #652) — `docs/experiments.md`
 `utilities/experiments.py` is the adapter onto PostHog Experiments, NOT a third implementation.
 **Unresolvable experiment = CONTROL arm** (no key, `EXPERIMENTS_ENABLED=false`, inconclusive, SDK
-raises — no env fallback per experiment). Flags must use rollout-% / distinct-ID only (person-
-property can't be decided locally). Three registered: `cost-routing-arm`, `comment-contract-prompt`,
-`post-media-variant`. Full posture: `docs/experiments.md`.
+raises — no env fallback per experiment). Flags must use rollout-% / distinct-ID only. Three
+registered: `cost-routing-arm`, `comment-contract-prompt`, `post-media-variant`.
 
-### Marketing attribution — UTMs (issue #658)
+### Marketing attribution — UTMs (issue #658) — `docs/marketing-attribution.md`
 `utilities/marketing/attribution.py` is the ONE place. Two rules: only OWNED destinations tagged
-(`is_owned_link`); existing UTMs never overwritten (`build_utm_url` fills missing only;
-`mark_placement` is the exception — replaces `utm_content` only). `signup_completed_web` (browser)
-≠ `signup_completed` (API) — never summed. Full posture: `docs/marketing-attribution.md`.
+(`is_owned_link`); existing UTMs never overwritten (`build_utm_url` fills missing only,
+`mark_placement` replaces `utm_content` only). `signup_completed_web` (browser) ≠ `signup_completed`
+(API) — never summed.
 
-### Model-tier evaluation harness (issue #721)
+### Model-tier evaluation harness (issue #721) — `docs/model-benchmarks/README.md`
 `scripts/benchmark_models.py` measures candidates vs each tier's contract suite (NO user data),
-always beside the current champion. Deterministic is source of truth (in-repo linters, not a
-copy); LLM judge is PostHog Evaluations filtered on `benchmark_run_id` (production never carries
-it → customer never billed). **The suite scores a FIRST draft, production ships an n-th** (#910), so
+always beside the current champion. Deterministic is source of truth (in-repo linters, not a copy);
+LLM judge is PostHog Evaluations filtered on `benchmark_run_id` (production never carries it → the
+customer is never billed). **The suite scores a FIRST draft, production ships an n-th** (#910), so
 every check is classed by what production does with its failure: `contract` (the call site consumes
-it — the ABSOLUTE floor) vs `repairable` (a regeneration gate retries it — advisory, still
-champion-relative). A case whose `max_tokens` mirrors a call site (`budget_mirrors_production`) is
-never retried at a bigger budget; an EMPTY completion is re-measured at the same one. Same principle
-at RUN scope (#923): a run where every case of every model errored — champion included — is a harness
-outage, not a scorecard of zeros, and is REFUSED (no report, exit 1); a partial failure still
-publishes with an `Unmeasured cases` count. Only `recommend` becomes a swap; recommendations are
-RENDERED, never written (`.litellm/model_upgrades.yaml` is the retirement map). Full posture:
-`docs/model-benchmarks/README.md`.
+it — the ABSOLUTE floor) vs `repairable` (a regeneration gate retries it — advisory). A case whose
+`max_tokens` mirrors a call site (`budget_mirrors_production`) is never retried at a bigger budget;
+an EMPTY completion is re-measured at the same one. Same at RUN scope (#923): a run where every case
+of every model errored is a harness outage, not a scorecard of zeros, and is REFUSED (no report, exit
+1); a partial failure publishes with an `Unmeasured cases` count. Only `recommend` becomes a swap,
+and recommendations are RENDERED, never written (`.litellm/model_upgrades.yaml` is the retirement map).
 
-### Content-quality telemetry (issue #630)
+### Content-quality telemetry (issue #630) — `docs/content-quality-telemetry.md`
 `auto_nightly_content_quality` is the TREND LINE (other gates are one-time verdicts). Scores
 posts/comments/editions into `content_quality_scores`: weighted slop (HARD ×3), self-similarity,
 **stored** authenticity (no fresh judge call), hook length, impression-weighted ER. **Unscored is
 never zero** — each dimension has its own sample size. Never pauses (drift → go look at prompts;
-safety is #629). Similarity batches into ONE `lem-embedding` per surface; dominant measure only.
+safety is #629).
 
-### Feature flags (issue #651)
+### Feature flags (issue #651) — `docs/feature-flags.md`
 `utilities/flags.py` is the ONE place; **fail open to env var** (no key, disabled, undefined,
 inconclusive, SDK raises → all return the flag's env var). `only_evaluate_locally=True` → ZERO
 network per check, flip lands without restart. Flags must use rollout-% / distinct-ID only. Read at
 CALL SITE, never at import. **Safety controls are NOT flags** (429 breaker, holds, pauses, per-day
-caps stay in Redis/env). SPA bootstraps from `GET /api/flags` — not through posthog-js. Full
-posture: `docs/feature-flags.md`.
+caps stay in Redis/env). SPA bootstraps from `GET /api/flags` — not through posthog-js.
 
-### Surveys — NPS/CSAT (issue #653)
+### Surveys — NPS/CSAT (issue #653) — `docs/surveys.md`
 TWO owners. PostHog Surveys: NPS (30d past ACTIVATION, not signup) + post-quality CSAT (on
-`post_approved` once `posts_approved >= 5`). `utilities/surveys.py` keeps the bespoke ones:
-trial-T-3d review (#499, PostHog can't unlock) + fix CSAT (#502). Type **`api`**, rendered headless
-in `PostHogSurveyModal.tsx`. ONE answer = TWO paths (browser native `$survey_response` + POST
+`post_approved` once `posts_approved >= 5`). `utilities/surveys.py` keeps the bespoke ones —
+trial-T-3d review (#499) + fix CSAT (#502). Type **`api`**, rendered headless in
+`PostHogSurveyModal.tsx`. ONE answer = TWO paths (browser native `$survey_response` + POST
 `/api/survey/posthog` → `feedback` row), counted ONCE — `track_survey_response` deliberately NOT
 emitted. Detractor (NPS ≤6 / CSAT ≤2) or any free text stays `new`; happy+blank → `resolved`.
-`markSurveySeen()` advances the 30d wait — drop it and the throttle silently stops. Full posture:
-`docs/surveys.md`.
+`markSurveySeen()` advances the 30d wait — drop it and the throttle silently stops.
 
-### Endpoints panel + release annotations (issue #654)
-**Endpoints** (PostHog beta): HogQL as a versioned cached HTTP route — Dashboard "Live stats"
-without a MySQL reporting layer. Every query scoped with `distinct_id = {variables.distinct_id}`
-(ONE shared project → un-scoped leaks across customers). Resolves against ONE `InsightVariable`;
-endpoint is `blocked_endpoint` until it exists. `GET /user/posthog-stats` server-side only; personal
-API key never reaches browser. Failure modes → `available: false` for that panel.
+### Endpoints panel + release annotations (issue #654) — `docs/kpi-dashboards.md`
+**Endpoints** (PostHog beta): HogQL as a versioned cached HTTP route — the Dashboard's "Live stats"
+with no MySQL reporting layer. Every query scoped with `distinct_id = {variables.distinct_id}` (ONE
+shared project → un-scoped leaks across customers); resolves against ONE `InsightVariable`, and the
+endpoint is `blocked_endpoint` until it exists. `GET /user/posthog-stats` is server-side only — the
+personal API key never reaches the browser; any failure → `available: false` for that panel.
 **Release annotations**: `scripts/posthog_annotate.py` posts `"vX.Y.Z deployed"` per deploy; needs
-`POSTHOG_PERSONAL_API_KEY` GH secret; absent/outage → no-op, never a failed release.
+the `POSTHOG_PERSONAL_API_KEY` GH secret; absent/outage → no-op, never a failed release.
 
 ## CI Gates
 
@@ -316,26 +298,23 @@ local dev → PR to main → CI gates pass → release-please tags vX.Y.Z
     compose up, /health check, auto-rollback to .last_good_tag on failure)
 ```
 
-- The stack launches with **both** compose files (`-f docker-compose.yml -f docker-compose.prod.yml`) — the prod overlay strips the dev bind-mount, so every app service runs the code baked into the image; editing files on disk does nothing until a new image ships. `web_app` is a tiny nginx **edge** routing to the active blue/green color; deploys are zero-downtime flips, releases batch 4x daily (05/11/17/23 UTC) — see `docs/zero-downtime-deploys.md`. A **`release:now`** label on a PR ships it at merge instead of the next window; agents may self-apply it for high-priority/user-visible fixes — policy in `docs/release-fast-lane.md`.
+- The stack launches with **both** compose files (`-f docker-compose.yml -f docker-compose.prod.yml`) — the prod overlay strips the dev bind-mount, so every app service runs the code baked into the image; editing files on disk does nothing until a new image ships. `web_app` is a tiny nginx **edge** routing to the active blue/green color; deploys are zero-downtime flips, releases batch 4x daily (05/11/17/23 UTC) — `docs/zero-downtime-deploys.md`. A **`release:now`** label ships a PR at merge instead of the next window; agents may self-apply it for high-priority/user-visible fixes — `docs/release-fast-lane.md`.
 - **Runtime state (429 breaker, manual automation pause, reply-sweep cadence keys) lives in Redis**, not the DB or containers — it survives deploys.
-- A **local hotfix deploy** fallback exists for when CI/release is too slow or blocked, and diverges prod from `main` until the fix lands via the normal PR flow. Full posture + compose-layering + image-ref details: `docs/DEPLOYMENT.md`.
+- A **local hotfix deploy** fallback exists for when CI/release is too slow or blocked, and diverges prod from `main` until the fix lands via the normal PR flow. Full posture + compose layering + image refs: `docs/DEPLOYMENT.md`.
 
 ## Known Gotchas
 
-- `get_docker_driver()` previously connected to Selenium Grid hub+node. It now connects to `selenium/standalone-chrome:latest` at port 4444.
-- `ai_helper.py` had all functions hardcoded to `model="gpt-4o-mini"` — they now use tier aliases.
-- PostHog replaces Prometheus + Jaeger (both removed from docker-compose).
-- `linkedin-preview` service (external) was removed — preview is now the native `LinkedInPostPreview.tsx` component.
-- **LinkedIn SDUI:** the old `urn:`, `feed-shared-*`, and `comments-comment-*` DOM anchors are gone — prefer `data-testid` / `aria-label` selectors. The comment composer has NO `<form>`; the global nav is sticky and steals clicks from an unfocused composer; every composer lookup is scoped to its OWN post (`_post_composer_for_card` / `_reply_composer_for_comment`), and a miss is a DEBUG no-op, never a warning. Full posture: `docs/sdui-selenium-notes.md`.
+- **Legacy drift:** `get_docker_driver()` targets `selenium/standalone-chrome:latest` at 4444, not a Grid hub+node; `ai_helper.py` uses tier aliases, not a hardcoded `gpt-4o-mini`; PostHog replaced Prometheus + Jaeger (both gone from docker-compose); the external `linkedin-preview` service is gone — preview is the native `LinkedInPostPreview.tsx`.
+- **LinkedIn SDUI** (`docs/sdui-selenium-notes.md`): the old `urn:`, `feed-shared-*` and `comments-comment-*` anchors are gone — prefer `data-testid` / `aria-label`. The comment composer has NO `<form>`; the sticky global nav steals clicks from an unfocused composer; every composer lookup is scoped to its OWN post (`_post_composer_for_card` / `_reply_composer_for_comment`), and a miss is a DEBUG no-op, never a warning.
 - **Emoji in Selenium:** ChromeDriver `send_keys` throws on non-BMP emoji — strip them before typing with `_strip_non_bmp()`.
 - **ENUM columns:** `logs.action_type` (and other status columns) are MySQL ENUMs — adding a value requires a migration. New migrations use **TIMESTAMP** versions so two branches never collide; the **db-migration** skill and `compose/local/database/migrations/README.md`.
-- **Unified content core:** newsletters, posts, AND comments draw framework, research, and alignment from `utilities/ai/content_framework.py` / `content_research.py` / `content_alignment.py` — never add parallel per-content-type prompt helpers. Comments carry a **quality contract + similarity gate** (#617) that SKIPS the post after `COMMENT_GATE_MAX_ATTEMPTS` failed regenerations. **Story bank** (#620) is the FACT half; **deck reference gate** (#728) is the save-worthiness half; **deterministic slop lint** (#625, `slop_lint.py`) BLOCKS on five HARD checks, advises on four WARN checks. Full posture: `docs/content-core.md`.
-- **Content mix (70/20/10) governor:** every planned post carries a mix class in `posts.content_mix` — `value` (70%) / `authority` (20%) / `promo` (10%, forced `case_snapshot` blueprint). **Promo CTAs are always an ARTIFACT** (lead magnet / newsletter) — a meeting ask is banned in prompts and repaired deterministically; any that survives HOLDS the post at PENDING via the `meeting_cta` gate. Full posture: `docs/content-core.md`.
-- **Stale lazy chunks after a deploy (#743):** a browser tab open across a release fetches a code-split chunk on a hash the new image no longer has (404, reads as "broken" not "reload me"). Three layers: asset **retention** (both colors serve a live-bundle miss from a shared archive volume), a **one-shot reload** on import failure (loop-guarded, skipped offline), and proactive polling of `/api/app-info` that prompts rather than reloads. Full posture: `docs/spa-deploy-freshness.md`.
+- **Unified content core:** newsletters, posts, AND comments draw framework, research, and alignment from `utilities/ai/content_framework.py` / `content_research.py` / `content_alignment.py` — never add parallel per-content-type prompt helpers. Comments carry a **quality contract + similarity gate** (#617) that SKIPS the post after `COMMENT_GATE_MAX_ATTEMPTS` failed regenerations. **Story bank** (#620) is the FACT half; **deck reference gate** (#728) the save-worthiness half; **deterministic slop lint** (#625, `slop_lint.py`) BLOCKS on five HARD checks, advises on four WARN.
+- **Content mix (70/20/10) governor:** every planned post carries a mix class in `posts.content_mix` — `value` (70%) / `authority` (20%) / `promo` (10%, forced `case_snapshot` blueprint). **Promo CTAs are always an ARTIFACT** (lead magnet / newsletter) — a meeting ask is banned in prompts and repaired deterministically; any that survives HOLDS the post at PENDING via the `meeting_cta` gate. Both: `docs/content-core.md`.
+- **Stale lazy chunks after a deploy (#743):** a tab open across a release fetches a code-split chunk on a hash the new image no longer has. Three layers: asset **retention** (both colors serve a live-bundle miss from a shared archive volume), a **one-shot reload** on import failure (loop-guarded, skipped offline), and polling of `/api/app-info` that prompts rather than reloads. Full: `docs/spa-deploy-freshness.md`.
 
 ## Git Safety & Multi-Agent Concurrency Rules
-- **Fresh State Enforcement**: Before executing or generating any code edit, you MUST explicitly run `git status` and a file read command (e.g., `cat <filename>`) to verify no hidden or uncommitted upstream modifications exist. Never rely on your internal conversation memory for file contents.
-- **Micro-Branching Workflow**: Do not make edits directly on shared branches while working asynchronously. When starting a distinct task, automatically spin up a task-specific feature branch (`git checkout -b feature/claude-<task-name>`).
-- **Atomic Commits**: For every completed sub-task or successful implementation block, automatically stage and commit your files with a clean, concise descriptive message (e.g., `git add . && git commit -m "feat(api): implement active sub-agent locking mechanism"`). 
-- **Conflict Avoidance**: If you detect changes in the working directory that clash with your active target files, immediately halt, stash your progress (`git stash`), pull down the current state, and safely resolve the differences before re-applying your changes.
-- **Branch cleanup.** Merged feature branches auto-delete (repo setting `delete_branch_on_merge=true`); orphans swept weekly by `.github/workflows/stale-branches.yml`. A 48-hour grace window protects active agent work. Full posture: `docs/branch-cleanup.md`.
+- **Fresh state:** before generating ANY code edit, run `git status` and read the target file. Never edit from conversation memory — another agent may have changed it under you.
+- **Micro-branching:** never edit a shared branch asynchronously; start each distinct task on its own branch (`git checkout -b feature/claude-<task-name>`).
+- **Atomic commits:** stage + commit each completed sub-task with a clean conventional-commit message.
+- **Conflict avoidance:** if working-tree changes clash with your target files, halt, `git stash`, pull the current state, resolve, then re-apply.
+- **Branch cleanup:** merged feature branches auto-delete (repo setting `delete_branch_on_merge=true`); orphans swept weekly by `.github/workflows/stale-branches.yml`, with a 48-hour grace window protecting active agent work. Full posture: `docs/branch-cleanup.md`.

--- a/docs/content-quality-telemetry.md
+++ b/docs/content-quality-telemetry.md
@@ -117,8 +117,9 @@ measured: "we have no baseline" must not read as "no change".
 OFF by default and a **regression signal ONLY**, per the #416 humanization policy: nothing here is
 an evasion target, and no score ever rewrites, holds, or steers text.
 
-- `AI_DETECTOR_ENABLED` + `AI_DETECTOR_URL` (both required) — `AI_DETECTOR_API_KEY`,
-  `AI_DETECTOR_PROVIDER`, `AI_DETECTOR_TIMEOUT` (10s).
+- `detector_enabled()` is `AI_DETECTOR_ENABLED` **plus a non-empty `AI_DETECTOR_API_KEY`** — a
+  missing key is a silent no-op, never a warning loop. `AI_DETECTOR_URL` is required too, but it is
+  checked at call time (no URL → `None`). Also `AI_DETECTOR_PROVIDER`, `AI_DETECTOR_TIMEOUT` (10s).
 - Sampled at `AI_DETECTOR_SAMPLE_RATE` (0.1) via `stable_fraction` — a **stable** hash draw, so a
   retried nightly run picks the SAME items and never re-bills for a second reading of the same
   piece.

--- a/docs/content-quality-telemetry.md
+++ b/docs/content-quality-telemetry.md
@@ -1,0 +1,140 @@
+# Content-quality telemetry (issue #630)
+
+Full design detail for `utilities/content_quality.py` and the two beats that drive it. CLAUDE.md
+keeps the one-line invariant + this pointer.
+
+Every other quality control in LEM is a **one-time verdict**: #625's slop lint blocks a bad draft,
+#617's contract throws away a bad comment, #382 scores authenticity once at generation. None of
+them can answer *"is the writing getting worse?"* — and it silently can, because the weekly
+model-retirement cron swaps the model underneath unchanged prompts. This subsystem is the **trend
+line**.
+
+## The two beats
+
+| Beat | Task | Cadence (UTC) | Does |
+|---|---|---|---|
+| `nightly-content-quality` | `auto_nightly_content_quality` | 02:40 daily | Scores everything SHIPPED in the window into `content_quality_scores` |
+| `weekly-content-quality` | `auto_weekly_content_quality` | Mon 09:45 | Rolls the readings into a period comparison + alerts |
+
+Nightly runs at 02:40 because it needs the 23:00 post-stats scrape and 23:40 follower capture to
+have landed — yesterday's posts only have impressions (and therefore an engagement rate) after
+those. Weekly runs last of the Monday reports so it reads a fully scored week.
+
+Split exactly like `comment_outcomes` (#628) and `suppression` (#629): `content_quality.py` is the
+pure arithmetic half, the beat tasks own the DB writes and the PostHog emission.
+
+## What one reading contains (`score_item`)
+
+Per shipped piece — surface is `post` / `comment` / `newsletter`:
+
+- **Weighted slop score** — `slop_severity_score`, `SLOP_HARD_WEIGHT = 3.0` vs
+  `SLOP_WARN_WEIGHT = 1.0`. A HARD violation is what actually blocks a post or drops a comment, so
+  it carries most of the weight; WARN checks only move the score enough to show drift.
+- **Self-similarity** — against that surface's OWN recent history (`similarity_reports`), with the
+  measure recorded alongside (`embedding` / `lexical` / `none`).
+- **Authenticity** — #382's **stored** `posts.authenticity_score`, never a fresh judge call: the
+  gate already paid for it at generation and the number cannot have changed. Surfaces with no
+  stored score report `None`.
+- **Hook length** against `MOBILE_HOOK_MAX_CHARS` (140).
+- **Engagement rate + impressions**, once the stats scrape captured them.
+- **Optional external AI-detector score** (see below).
+
+Read-only over content that already shipped: it never edits, holds, or re-generates anything.
+
+## The two rules that run through all of it
+
+1. **Unscored is never zero.** A post with no impressions yet has no engagement rate; a draft the
+   lint was disabled for has no slop score; an account with no history has no self-similarity. Each
+   is `None` and is excluded from *its own* denominator — `summarize_scores` carries a separate
+   sample size per dimension (`slop_sample`, `similarity_sample`, `authenticity_sample`,
+   `hook_sample`, `engagement_rate_sample`). One shared denominator would let a dimension nobody
+   could measure drag the others down; charting `None` as 0 would invent a collapse (or, for slop,
+   invent a clean week).
+2. **A regression is measured against the account's OWN prior period**, never an absolute target.
+   The engagement floor is the single exception, and it is the only one with a benchmark behind it.
+
+`engagement_rate` is impression-**WEIGHTED** (total engagement / total impressions), not a mean of
+per-post rates: a post seen by 50 people must not count the same as one seen by 5,000.
+
+## Similarity: dominant measure only
+
+Cosine and token-overlap scores are **not the same scale** (ceilings ~0.82 vs ~0.55). Each surface
+embeds in its own batch, so one failed `lem-embedding` call drops that surface to lexical while the
+rest of the period stays cosine. `summarize_scores` therefore averages over the **dominant measure
+only** and records the full `similarity_measures` breakdown; `evaluate_alerts` additionally
+requires both periods to share the same dominant measure before `similarity_creep` can fire.
+
+Similarity is graded **WITHIN** a surface — a post compared against the user's comments would score
+as unique no matter how templated it is. Newsletter editions have no body-history reader, so their
+similarity reports as unmeasured rather than against the wrong scale.
+
+## LLM spend
+
+`similarity_reports` is the ONLY spend in the nightly pass: **one `lem-embedding` call per surface**
+per user. The task loops over users rather than taking a `user_id` kwarg, so the embedding runs
+inside an explicit `llm_attribution(user_id=..., feature=FEATURE_CONTENT)` scope — without it every
+embedding would bill the `system` sentinel instead of the account whose content it scored.
+
+`CONTENT_QUALITY_MAX_ITEMS` (60) caps items per user per run. A silent truncation would read as
+"a quiet week" in the rollup, so exceeding it logs a WARNING naming what was dropped.
+
+## The three alerts (`evaluate_alerts`)
+
+In the order they cost the user money. Each needs a real sample on **both** sides
+(`CONTENT_QUALITY_MIN_SAMPLE`, default 5) — a week with two posts in it has no trend, and a false
+alert trains the owner to ignore the next one.
+
+| Alert | Fires when | Threshold env |
+|---|---|---|
+| `slop_regression` | mean weighted slop rose week-over-week | `CONTENT_QUALITY_SLOP_REGRESSION_DELTA` (1.0 — one extra HARD violation every three pieces) |
+| `engagement_floor` | engagement per impression below the floor | `CONTENT_QUALITY_ENGAGEMENT_FLOOR` (0.02) |
+| `similarity_creep` | self-similarity rose, same measure both periods | `CONTENT_QUALITY_SIMILARITY_DELTA` (0.05) |
+
+`engagement_floor` is the exception twice over: it needs **no prior period** (an account below the
+floor is below it regardless of last week) and it counts against its own
+`min_engagement_sample()` — the general minimum counts scored *pieces*, and only posts carry
+impressions, so a piece-count threshold would gate a post-only dimension on comment volume it can
+never reach.
+
+Alerts ride the EXISTING pipeline — `log_error` forwards to PostHog at the default
+`POSTHOG_LOG_LEVEL`, so a regression becomes a grouped `$exception` issue without a second alerting
+path (`track_content_quality_rollup` carries the numbers).
+
+**This subsystem never pauses anything.** Drift here means *go look at the prompts*; automatic
+safety action is #629's suppression tripwire.
+
+## `quality_rollup` is the ONE shape
+
+`quality_rollup(rows, days)` returns `{days, current, prior, deltas, alerts, config}` and is shared
+by the weekly PostHog event, the analytics endpoint, and the dashboard panel — so the number the
+user reads and the number that raised the alert can never diverge. `split_periods` drops rows
+outside both windows (or with an unreadable `shipped_on`) rather than folding them into the nearest
+period, so a stale row can never move a verdict. `_delta` returns `None` when either side was never
+measured: "we have no baseline" must not read as "no change".
+
+## The external AI-detector hook
+
+OFF by default and a **regression signal ONLY**, per the #416 humanization policy: nothing here is
+an evasion target, and no score ever rewrites, holds, or steers text.
+
+- `AI_DETECTOR_ENABLED` + `AI_DETECTOR_URL` (both required) — `AI_DETECTOR_API_KEY`,
+  `AI_DETECTOR_PROVIDER`, `AI_DETECTOR_TIMEOUT` (10s).
+- Sampled at `AI_DETECTOR_SAMPLE_RATE` (0.1) via `stable_fraction` — a **stable** hash draw, so a
+  retried nightly run picks the SAME items and never re-bills for a second reading of the same
+  piece.
+- `AI_DETECTOR_DAILY_MAX` (5) budget, spent on the CALL whether or not it answered.
+- Any failure — no key, no endpoint, timeout, unparseable body, missing `requests` — returns `None`
+  quietly. An optional signal must never break the nightly job.
+
+## Environment
+
+| Var | Default | Meaning |
+|---|---|---|
+| `CONTENT_QUALITY_TELEMETRY_ENABLED` | `true` | Master switch for both beats |
+| `CONTENT_QUALITY_WINDOW_DAYS` | 2 | How far back the nightly pass scores |
+| `CONTENT_QUALITY_ROLLUP_DAYS` | 7 | Period length for the weekly comparison |
+| `CONTENT_QUALITY_MAX_ITEMS` | 60 | Per-user cap per nightly run |
+| `CONTENT_QUALITY_MIN_SAMPLE` | 5 | Minimum sample on both sides of an alert |
+| `CONTENT_QUALITY_SLOP_REGRESSION_DELTA` | 1.0 | Slop rise that reads as regression |
+| `CONTENT_QUALITY_ENGAGEMENT_FLOOR` | 0.02 | Absolute ER floor |
+| `CONTENT_QUALITY_SIMILARITY_DELTA` | 0.05 | Similarity rise that reads as creep |

--- a/docs/engagement-automation.md
+++ b/docs/engagement-automation.md
@@ -4,6 +4,58 @@ Full design detail for the `app/run_automation.py` subsystems that CLAUDE.md's "
 automation" section only names. This doc is the load-bearing detail; CLAUDE.md keeps the
 one-line invariant + pointer.
 
+## Feed commenting on the SDUI feed (`comment_on_feed_inline`, issues #622 / #817)
+
+The commenting engine was rebuilt for LinkedIn's SDUI: the old `urn:` / `feed-shared-*` anchors are
+gone, so every lookup goes through the resilient `find_first` / `click_first` / `find_all_first`
+helpers in `utilities/linkedin/helper.py`, compose+submit happens inline on the card, and every
+composer lookup is scoped to its OWN post (`_post_composer_for_card` / `_reply_composer_for_comment`
+— a miss is a DEBUG no-op, never a warning). Targeting, per-day caps and voice/tone come from
+`engagement_preferences`. Runs pre-post (~15 min before a scheduled post) and daily at a golden hour.
+
+### The scoring matrix is recency-DOMINANT
+
+`_score_feed_post` ranks candidates on four weighted terms — recency (dominant), relevance,
+reciprocity (the author engaged with us, or is an include-author target), and a healthy-activity
+bonus off comment count. Each weight is env-overridable (`FEED_SCORE_W_RECENCY`,
+`FEED_SCORE_W_RELEVANCE`, `FEED_SCORE_W_RECIPROCITY`, `FEED_SCORE_W_ACTIVITY`).
+
+Because recency dominates, the matrix only does what #622 intended when the feed it ranks is
+actually recency-ordered. With the sort control missing, the recency term re-ranks a pool LinkedIn
+already reordered by engagement, and the run quietly degrades to roughly what #622 replaced.
+
+### `_switch_feed_to_recent` — best-effort, but never silent (#817)
+
+It flips the home feed from 'Top' to 'Recent' AND **reports what the run actually got**. The
+returned state rides onto the feed funnel and the `feed_scan` event, so an unsorted scan can never
+be read as recency-sorted:
+
+| State | Meaning |
+|---|---|
+| `recent` | Confirmed on 'Recent' by the control itself |
+| `top` | Control found, still on the algorithmic sort |
+| `missing` | No sort control on the home feed at all |
+| `unknown` | Control there, but which sort applies could not be read |
+| `n/a` | A surface that never had one (group feed, roster activity) |
+
+- `recent` is returned ONLY when the control confirms it **afterwards**. An unverified flip recorded
+  as sorted tells the same lie the old silent no-op told.
+- `_feed_sort_state` returns `''` (→ `unknown`) when the label is unreadable, **including a label
+  naming BOTH sorts** — some dropdown triggers spell their options into the accessible name ("Sort
+  by, currently Top, options Top and Recent"), and reading 'recent' out of one would skip the flip
+  AND record the run as sorted.
+- `_is_home_feed` gates the whole thing: group feeds and a roster author's recent-activity page
+  reuse the same engine but never had the control, so a miss there is `n/a` at DEBUG. An
+  **unreadable URL counts as NOT the home feed** (#872) — a dead session cannot say which surface it
+  was on, and escalating on a guess costs a triage for working behaviour.
+- Locators are an ordered fallback chain, most-stable anchor first: `aria-label` → `data-testid` →
+  visible 'Sort by' text → a popup trigger whose whole label IS the current sort → any
+  `role=button` carrying 'sort'. Class names are never keyed on.
+- Fail-fast (`max_try=1`): this runs twice per run and each retry round burned `MAX_WAIT_RETRY` ×
+  ~5s to report the same miss.
+
+Live grounding: `scripts/linkedin_live_validation.py --feed-sort`.
+
 ## Golden-hour presence & second wave (`utilities/golden_hour.py`, issue #622)
 
 The ONE place the first-hour amplifier's timing is decided.

--- a/docs/image-stack.md
+++ b/docs/image-stack.md
@@ -1,0 +1,85 @@
+# The image stack — ONE engine, two modules
+
+Full posture for LEM's AI still-image generation. CLAUDE.md keeps the one-line invariant + this
+pointer.
+
+Every surface that renders an AI image goes through the same two modules. **Never add a
+per-content-type prompt helper** — add a preset.
+
+| Module | Owns |
+|---|---|
+| `utilities/ai/image_brief.py` | Authoring the prompt: content in → validated brief out |
+| `utilities/ai/image_gen.py` | Rendering that brief, plus the vision quality gate |
+
+## `image_brief.py` — the ONE prompt author
+
+`build_image_brief(content, surface=..., ratio=...)` sends the ACTUAL content to `lem-medium` and
+gets back a structured `ImageBrief`: a render-ready **prompt** plus the extracted **`focal_concept`**
+the vision gate later grades the render against. `lem-medium` (not the cheapest tier) because the
+brief decides whether the render is relevant at all — the failure the cheap tier kept producing.
+
+**Per-surface presets** (`_STYLE_PRESETS`), keyed by surface, defaulting to `post_image`:
+
+| Preset | What that surface's image is for |
+|---|---|
+| `newsletter` | Wide editorial cover; one bold scene from the edition's core idea, readable at thumbnail size |
+| `post_image` | Scroll-stopping single subject for a feed post; one strong color accent |
+| `carousel` | Quiet supporting photo for ONE slide; uncluttered background a text panel can sit beside |
+| `video` | Opening frame posed so subtle motion can bring it alive; layered depth |
+| `thumbnail` | Flat product-tutorial illustration; calm palette, one clear subject |
+
+A preset only says what THIS surface is for. The photographic fundamentals — subject-first
+ordering, 40–80 words of flowing prose, concrete camera/lighting vocabulary instead of generic
+quality tags, positive phrasing only (FLUX has no negative prompts — naming a thing summons it),
+and the skin-texture rules that kill the AI sheen — live in the shared system prompt, written to
+hold for BOTH FLUX LoRA renders and FLUX.2/gpt-image.
+
+**NO text, letters, or logos in any render prompt** — enforced in the system prompt, with
+`with_no_marks()` as the render-side belt.
+
+An unparseable or invalid model reply falls back to `_fallback_brief` — deterministic, so a bad
+generation never means no image.
+
+## `image_gen.py` — the ONE renderer
+
+`render_image_from_prompt(prompt, ratio=...)` picks the backend from `IMAGE_BACKEND`:
+
+- **`auto`** (default): gpt-image through the LiteLLM `lem-image` group first, FLUX via Replicate
+  when that fails. The proxied call rides the attributed client, so PostHog + cost routing see it
+  with no extra plumbing.
+- **`gpt-image`** / **`flux`**: force one backend, no cross-fallback.
+
+Ratios map to the three sizes gpt-image accepts (`1:1`, `16:9`, `9:16`); anything else falls back to
+square. Replicate renders are bounded (`REPLICATE_TIMEOUT_SECONDS`, 300s, 2 attempts) so a hung
+prediction can't stall a Celery worker forever. Cost is attributed via `track_media_cost`.
+
+### The vision quality gate
+
+`render_image_gated(prompt, surface=...)` adds a `lem-vision` check — `inspect_render_quality`
+grades the rendered file against the brief's `focal_concept` — with bounded regenerates
+(`IMAGE_GATE_MAX_ATTEMPTS` total renders).
+
+- Enforced only for surfaces in `IMAGE_QUALITY_GATE_SURFACES`; others get one advisory pass (verdict
+  logged, render kept).
+- **Fails OPEN**: `QualityVerdict.checked=False` means the gate could not run. A vision outage must
+  never take a cover or post image down with it — and for newsletter covers the human
+  `pending_review` gate still sits behind this one.
+
+## Avatar likeness never renders here
+
+`image_gen` has no avatar path on purpose. `ai_helper.generate_post_image` owns the LoRA route
+behind `avatar/guardrails.resolve_avatar_for` (guardrails, C2PA, disclosure flags) and calls into
+this module only for the non-avatar case; `render_avatar_image_gated` is the gated variant for that
+owner. Newsletter covers add a fail-closed relevance classifier on the Auto path
+(`utilities/newsletter_cover.py`, see `docs/newsletter-covers.md`).
+
+## Environment
+
+| Var | Meaning |
+|---|---|
+| `IMAGE_BACKEND` | `auto` (default) / `gpt-image` / `flux` |
+| `DEFAULT_IMAGE_MODEL` | Model handed to the `lem-image` group |
+| `IMAGE_QUALITY` | gpt-image quality tier |
+| `IMAGE_QUALITY_GATE_SURFACES` | Surfaces where the vision gate is enforced, not advisory |
+| `IMAGE_GATE_MAX_ATTEMPTS` | Total renders allowed per gated request |
+| `REPLICATE_TIMEOUT_SECONDS` | Bound on a single FLUX/Replicate prediction |

--- a/docs/marketing-video-tutorials.md
+++ b/docs/marketing-video-tutorials.md
@@ -1,0 +1,70 @@
+# Marketing video tutorials (issue #505)
+
+Full posture for `utilities/marketing/video_tutorials.py` and the `produce-feature-tutorial` beat.
+CLAUDE.md keeps the one-line invariant + this pointer. The YouTube OAuth token that publishing
+depends on has its own doc: `docs/youtube-publishing.md`.
+
+One declarative flow per feature → one finished tutorial:
+
+```
+capture (real SPA, headless Chrome) → grounded script (lem-medium) → TTS voice-over
+  → ffmpeg MP4 (branded intro/outro + captions) → vertical clip → YouTube → manifest
+```
+
+## Flows are declarative
+
+`TutorialFlow` / `TutorialStep` (`TUTORIAL_FLOWS`) declare the routes to visit and the CSS anchors
+that PROVE the screen rendered. Capture runs through `get_docker_driver()` against
+`TUTORIAL_SPA_BASE_URL` (falling back to `API_URL_FINAL`); a flow marked `requires_auth` needs
+`TUTORIAL_DEMO_SESSION_TOKEN` and is skipped when it's unset.
+
+`ui_fingerprint()` hashes the flow's declared markers. `next_flow()` picks the next flow to film —
+a flow is re-filmed only when its captured UI fingerprint changes, or once it ages past
+`TUTORIAL_REFRESH_DAYS` (`is_current`).
+
+## Fail-closed, cheapest-first
+
+The order is deliberate: capture runs before a single token is spent, so nothing downstream can
+burn money on a screen that has moved.
+
+- A declared UI anchor that no longer exists raises `TutorialCaptureError` rather than narrating a
+  screen that moved.
+- Narration is grounded in the flow definition **plus the text actually read off the captured
+  screens** (`grounding_text`); `ungrounded_claims` audits for fabricated specifics and
+  `check_narration` also rejects profanity and any narration over
+  `TUTORIAL_MAX_NARRATION_CHARS` — all before any TTS spend (`TutorialGuardrailError`).
+- An unparseable model script (`_coerce_script` returns `None`) aborts the same way.
+- Render failures raise `TutorialRenderError`.
+
+## Cost attribution
+
+Three parts, all recorded, and the total stored on the manifest record so a tutorial's true cost is
+answerable per video:
+
+| Part | How |
+|---|---|
+| Script tokens | `_call_llm` → `track_llm_call` |
+| TTS characters | `tts_cost_usd` → `track_media_cost` |
+| Local render minutes | `TUTORIAL_RENDER_COST_PER_MINUTE` → `track_media_cost` |
+
+## Voice, captions, publishing
+
+- TTS provider is `TUTORIAL_TTS_PROVIDER` — OpenAI (`lem-tts`, `TUTORIAL_TTS_MODEL` /
+  `TUTORIAL_TTS_VOICE`) by default, ElevenLabs (`ELEVENLABS_*`) as the alternative.
+- ffmpeg produces the MP4 with branded intro/outro plus a `.srt`; `TUTORIAL_BURN_CAPTIONS` decides
+  whether captions are burned in. A 9:16 clip is derived for shorts, and
+  `TUTORIAL_THUMBNAIL_ENABLED` gates thumbnail generation.
+- The description is UTM-tagged through `utilities/marketing/attribution.py`
+  (`campaign_for_tutorial`, `PLACEMENT_VIDEO_DESCRIPTION`) — never hand-built links.
+- Upload is YouTube Data API v3 at `YOUTUBE_PRIVACY_STATUS`, behind `youtube_auth.preflight()`.
+
+**The no-self-promo guardrail from `content_alignment` is deliberately NOT applied here** — this is
+LEM's own product marketing, the one content type where naming the product IS the point.
+
+## State + surfacing
+
+State lives in `assets/videos/tutorials/manifest.json` (`load_manifest` / `save_manifest`); the SPA
+embeds it via `TutorialVideos.tsx`. Weekly cadence.
+
+OFF unless the `TUTORIAL_VIDEOS` flag is enabled (`TUTORIAL_VIDEOS_ENABLED` env fallback — flags
+fail open to env, see `docs/feature-flags.md`).


### PR DESCRIPTION
## What & why

`CLAUDE.md` had drifted to **38,815 chars on `main`** (39,210 at this branch's point) — past the
38,000 warn threshold and inside ~1.2k of the 40,000 harness cap, where the context load 413s and
the session restarts cold. This moves the detail out to `docs/*.md` and leaves `CLAUDE.md` as the
map: locations, symbols, constants, invariants, and where to find the rest (CONTRIBUTING.md
§ CLAUDE.md size cap).

**35,722 chars now — 3,488 smaller, with 4.3k of runway under the cap** (2.3k under the warn
threshold, so the drift watch shouldn't re-fire on the next couple of features).

## Where the detail went

Nothing was dropped — every relocated paragraph has a home:

| New/updated doc | Holds |
|---|---|
| `docs/content-quality-telemetry.md` (new) | #630's two beats + cadence rationale, what one reading contains, the *unscored is never zero* and *own-prior-period* rules, dominant-similarity-measure handling, the three alerts and their separate sample floors, the LLM spend + attribution scope, the optional detector hook, full env table |
| `docs/image-stack.md` (new) | `image_brief` presets and the shared system-prompt rules, `image_gen` backend policy (`IMAGE_BACKEND`, Replicate bounds), the bounded fail-OPEN vision gate, why avatar likeness never renders there, env table |
| `docs/marketing-video-tutorials.md` (new) | #505 declarative flows + UI fingerprinting, the fail-closed cheapest-first ordering and each guardrail error, three-part cost attribution, TTS/caption/publish config, manifest state, the deliberate no-self-promo exemption |
| `docs/engagement-automation.md` | New **"Feed commenting on the SDUI feed"** section carrying the #817 posture: the five sort states, why `recent` is returned only on post-flip confirmation, the label-naming-both-sorts case, `_is_home_feed` treating an unreadable URL as *not* the home feed (#872), the locator fallback chain, and the fail-fast `max_try=1` reason |

Everywhere else the trim is rationale/history the pointed-to doc already carries (and several `Full
posture: docs/x.md` trailers moved into the subsection heading). **Every ONE-place claim,
fail-open/fail-closed rule, HTTP status contract, env flag, constant and symbol name stays in
`CLAUDE.md`** — I diffed the removed symbols and confirmed each survives either in the file or in
the doc it now points to (e.g. the `db.get_session_user_id`-direct-import bug is
`docs/identity-and-sessions.md`; `IMAGE_GATE_MAX_ATTEMPTS` / `track_media_cost` are
`docs/image-stack.md`; `lem-tts` / `TUTORIAL_TTS_PROVIDER` are `docs/marketing-video-tutorials.md`).

## Testing

- `python3 scripts/check_claude_md_size.py` → `ok: CLAUDE.md is 35,722 / 40,000 chars`
- `pytest tests/unit/test_check_claude_md_size.py` → 17 passed
- Every `docs/*.md` path referenced from `CLAUDE.md` verified to exist
- Docs-only change: no Python, TS, or SQL touched

No `release:now` — docs-only, per `docs/release-fast-lane.md`.

Closes #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)