### PR TITLE
fix(analytics): format avg engagement as a percentage in Best Times to Post (closes #1004)

### DIFF
--- a/src/cqc_lem/ui/src/components/charts/palette.test.ts
+++ b/src/cqc_lem/ui/src/components/charts/palette.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { ENGAGEMENT_RATE_METRIC, formatEngagementMetric, formatRate } from './palette'
+
+// Issue #1004: "avg engagement" rendered the raw number, so an impression-normalized rate read as
+// a bare decimal ("avg engagement 0.0612"). The scale is NOT fixed — post_stats emits a fraction
+// in rate mode and a weighted count otherwise — so what is asserted here is that the percentage
+// is applied to the fraction ONLY.
+describe('formatEngagementMetric', () => {
+  it('renders a rate as a percentage at fixed precision', () => {
+    expect(formatEngagementMetric(0.0612, ENGAGEMENT_RATE_METRIC)).toBe('6.12%')
+    expect(formatEngagementMetric(0.06, ENGAGEMENT_RATE_METRIC)).toBe('6.00%')
+    expect(formatEngagementMetric(0, ENGAGEMENT_RATE_METRIC)).toBe('0.00%')
+    expect(formatEngagementMetric(0.000004, ENGAGEMENT_RATE_METRIC)).toBe('0.00%')
+  })
+
+  it('never percent-ifies a per-post count', () => {
+    expect(formatEngagementMetric(40, 'engagement')).toBe('40')
+    expect(formatEngagementMetric(12.5, 'engagement')).toBe('12.5')
+    // A count is rounded to 1 decimal server-side; hold that precision if one ever slips through.
+    expect(formatEngagementMetric(12.34567, 'engagement')).toBe('12.3')
+    expect(formatEngagementMetric(1234, 'engagement')).toBe('1,234')
+  })
+
+  it('treats an absent or unknown metric as a count, not a rate', () => {
+    expect(formatEngagementMetric(9)).toBe('9')
+    expect(formatEngagementMetric(9, null)).toBe('9')
+    expect(formatEngagementMetric(9, 'something_else')).toBe('9')
+  })
+
+  it('degrades to a dash rather than printing NaN', () => {
+    expect(formatEngagementMetric(Number.NaN, ENGAGEMENT_RATE_METRIC)).toBe('—')
+    expect(formatEngagementMetric(Number.POSITIVE_INFINITY)).toBe('—')
+    expect(formatEngagementMetric(undefined as unknown as number)).toBe('—')
+  })
+
+  it('shares formatRate with the leaderboards so one card cannot drift from another', () => {
+    expect(formatEngagementMetric(0.0612, ENGAGEMENT_RATE_METRIC)).toBe(formatRate(0.0612))
+  })
+})

--- a/src/cqc_lem/ui/src/components/charts/palette.ts
+++ b/src/cqc_lem/ui/src/components/charts/palette.ts
@@ -27,6 +27,19 @@ export function formatRate(value: number): string {
   return `${(value * 100).toFixed(2)}%`
 }
 
+// The metric name post_stats stamps on a ranking when it scored impression-normalized rates
+// (`METRIC_RATE`); anything else is a weighted per-post count (`METRIC_COUNT`).
+export const ENGAGEMENT_RATE_METRIC = 'engagement_rate'
+
+// `avg_engagement` carries BOTH scales — a per-impression fraction in rate mode, a weighted
+// per-post count otherwise — so the raw number reads as a bare decimal either way. Only the
+// fraction is a percentage: percent-ifying a count would render 40 engagements as "4000%".
+export function formatEngagementMetric(value: number, metric?: string | null): string {
+  if (!Number.isFinite(value)) return '—'
+  if (metric === ENGAGEMENT_RATE_METRIC) return formatRate(value)
+  return value.toLocaleString(undefined, { maximumFractionDigits: 1 })
+}
+
 // "2026-07-20" → "Jul 20" for compact chart/table axes (dates are tz-agnostic calendar days).
 const _MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
 export function shortDate(iso: string): string {

--- a/src/cqc_lem/ui/src/pages/Dashboard.bestTimes.test.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.bestTimes.test.tsx
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import Dashboard from './Dashboard'
+
+// Issue #1004: "Your Best Times to Post" printed `avg_engagement` raw, so an impression-normalized
+// rate reached the user as a bare decimal. The formatter itself is covered in
+// components/charts/palette.test.ts; what is asserted HERE is the wiring — that the card reads the
+// payload's `metric` to pick the scale, so a rate becomes a percentage and a count never does.
+const get = vi.fn()
+
+vi.mock('../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    post: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'test@example.com', userId: 1 }, sessionToken: 'tok' }),
+}))
+
+vi.mock('../hooks/useUserTimezone', () => ({
+  useUserTimezone: () => 'America/New_York',
+  useUserTimezoneState: () => ({ timezone: 'America/New_York', isResolved: true }),
+}))
+
+vi.mock('../components/OnboardingChecklist', () => ({ default: () => null }))
+vi.mock('../components/PostHogStatsPanel', () => ({ default: () => null }))
+
+function payload(data: unknown) {
+  return { data: { detail: data } }
+}
+
+function mockApi(postStats: unknown) {
+  get.mockImplementation((path: string) => {
+    if (path.startsWith('/user/post-stats')) return Promise.resolve(payload(postStats))
+    if (path.startsWith('/activity/')) return Promise.resolve(payload([]))
+    if (path.startsWith('/dashboard/planned-tasks/')) return Promise.resolve(payload({ tasks: [] }))
+    return Promise.resolve(payload({}))
+  })
+}
+
+function harness(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <MemoryRouter>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </MemoryRouter>,
+  )
+}
+
+beforeEach(() => {
+  get.mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('Best Times to Post — avg engagement is a percentage only when it is a rate (issue #1004)', () => {
+  it('renders an impression-normalized rate as a percentage, not a raw decimal', async () => {
+    mockApi({
+      recommendations: [
+        { weekday: 'Wednesday', hour: 16, avg_engagement: 0.0612, sample: 4, metric: 'engagement_rate' },
+      ],
+      rankings: {},
+      sample_size: 7,
+      timezone: 'America/New_York',
+    })
+    harness(<Dashboard />)
+
+    await waitFor(() =>
+      expect(screen.getByText(/avg engagement rate 6\.12% · 4 post\(s\)/)).toBeDefined(),
+    )
+    expect(screen.queryByText(/0\.0612/)).toBeNull()
+  })
+
+  it('leaves a per-post count as a count — a count is not a percentage', async () => {
+    mockApi({
+      recommendations: [
+        { weekday: 'Monday', hour: 9, avg_engagement: 12.5, sample: 3, metric: 'engagement' },
+      ],
+      rankings: {},
+      sample_size: 5,
+      timezone: 'America/New_York',
+    })
+    harness(<Dashboard />)
+
+    const row = await waitFor(() => screen.getByText(/avg engagement 12\.5 · 3 post\(s\)/))
+    expect(row.textContent).not.toContain('%')
+    expect(screen.queryByText(/avg engagement rate/)).toBeNull()
+  })
+
+  it('reads a payload with no metric as a count rather than inventing a percentage', async () => {
+    mockApi({
+      recommendations: [{ weekday: 'Friday', hour: 11, avg_engagement: 9, sample: 3 }],
+      rankings: {},
+      sample_size: 4,
+      timezone: 'America/New_York',
+    })
+    harness(<Dashboard />)
+
+    await waitFor(() => expect(screen.getByText(/avg engagement 9 · 3 post\(s\)/)).toBeDefined())
+    expect(screen.queryByText(/900\.00%/)).toBeNull()
+  })
+})

--- a/src/cqc_lem/ui/src/pages/Dashboard.tsx
+++ b/src/cqc_lem/ui/src/pages/Dashboard.tsx
@@ -11,10 +11,20 @@ import PostHogStatsPanel from '../components/PostHogStatsPanel'
 import LineChart, { type LinePoint } from '../components/charts/LineChart'
 import Leaderboard, { type RankEntry } from '../components/charts/Leaderboard'
 import PerPostTable, { type PerPost } from '../components/charts/PerPostTable'
-import { compactNumber, formatRate, shortDate, titleCase } from '../components/charts/palette'
+import {
+  ENGAGEMENT_RATE_METRIC,
+  compactNumber,
+  formatEngagementMetric,
+  formatRate,
+  shortDate,
+  titleCase,
+} from '../components/charts/palette'
 
 interface PostStats {
-  recommendations: { weekday: string; hour: number; avg_engagement: number; sample: number }[]
+  // `metric` names the scale `avg_engagement` is on — `engagement_rate` (a per-impression
+  // fraction) or `engagement` (a weighted per-post count). Optional so a payload predating it
+  // still renders as a count rather than a bogus percentage.
+  recommendations: { weekday: string; hour: number; avg_engagement: number; sample: number; metric?: string }[]
   rankings: Record<string, RankEntry[]>
   sample_size: number
   // The zone `recommendations[].hour` was bucketed into server-side (the user's configured Login
@@ -945,7 +955,10 @@ export default function Dashboard() {
                 {postStats.recommendations.map((r, i) => (
                   <li key={i} className="flex justify-between">
                     <span>{r.weekday} @ {formatHour12(r.hour)}</span>
-                    <span className="text-gray-400">avg engagement {r.avg_engagement} · {r.sample} post(s)</span>
+                    <span className="text-gray-400 tabular-nums">
+                      {r.metric === ENGAGEMENT_RATE_METRIC ? 'avg engagement rate' : 'avg engagement'}{' '}
+                      {formatEngagementMetric(r.avg_engagement, r.metric)} · {r.sample} post(s)
+                    </span>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## What & why

The "Your Best Times to Post" card printed `avg_engagement` raw, so a recommendation read as
`avg engagement 0.0612` — a bare decimal with no unit (in-app feedback #37).

That number does **not** have a fixed scale. `post_stats._group_metrics` scores in **rate mode** —
a per-impression fraction — when every row in the comparison set carries impressions, and in
**count mode** — a weighted per-post count — otherwise, and it already stamps which one on the
payload as `metric` (`engagement_rate` / `engagement`). The card ignored it.

So the fix is to read `metric`, not to blanket-multiply by 100:

- **rate** → `avg engagement rate 6.12%` (percentage, fixed 2 decimals)
- **count** → `avg engagement 12.5` (a count is not a percentage — `40` would have rendered as
  `4000%`)
- **no `metric`** (a payload predating the field) → treated as a count, never as a percentage

`formatEngagementMetric` is added beside `formatRate` in `components/charts/palette.ts` — the same
helper the format/hook leaderboards already use for the identical two-scale problem — so the card
and the leaderboards can't drift apart on precision. Non-finite input degrades to `—` rather than
printing `NaN%`.

No backend change: `recommend_post_times` already returns `metric` in both modes (covered by
`tests/unit/utilities/test_post_stats.py`).

## Testing

- `src/components/charts/palette.test.ts` — new: the percentage applies to the fraction only, a
  count keeps 1-decimal precision, an absent/unknown metric falls back to a count, non-finite → `—`.
- `src/pages/Dashboard.bestTimes.test.tsx` — new: the card wiring, one case per metric mode plus
  the metric-less payload.
- Full SPA suite green locally: `npm test` → 54 files / 436 tests passed; `npm run build` clean.

Closes #1004

🤖 Generated with [Claude Code](https://claude.com/claude-code)
