### PR TITLE
fix(celery): fill task defaults into the celery-once dedup key (closes #989)

### DIFF
--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -2383,8 +2383,9 @@ def _process_reply_inbound(form) -> ResponseModel:
     if not _reply_sweep_debounced(user_id):
         _log_inbound_verdict("debounced", form, user_id=user_id)
         return ResponseModel(status_code=200, detail="debounced")
-    # QueueOnce builds its dedup key from once['keys'] and does NOT apply function defaults — omitting
-    # sweep_slot here raised KeyError at enqueue and 500'd every forwarded notification.
+    # slot 0 is the single-shot trigger (the golden-hour amplifier owns the other slots). Omitting it
+    # once raised KeyError at enqueue and 500'd every forwarded notification; cqc_lem.app.queue_once
+    # now fills the default into the dedup key, so this stays explicit for meaning, not for safety.
     sweep_reply_comments.apply_async(kwargs={"user_id": user_id, "sweep_slot": 0}, countdown=120)
     _log_inbound_verdict("comment_accepted", form, user_id=user_id)
     log_info("Triggered reply sweep from comment notification", user_id=user_id)

--- a/src/cqc_lem/app/queue_once.py
+++ b/src/cqc_lem/app/queue_once.py
@@ -1,0 +1,30 @@
+from inspect import Parameter
+
+from celery_once import QueueOnce as _CeleryQueueOnce
+
+
+class QueueOnce(_CeleryQueueOnce):
+    """celery-once, but a task's OWN parameter defaults count toward its dedup key.
+
+    Upstream builds the key from `Signature.bind(...).arguments`, which never applies defaults, then
+    indexes that mapping with every name in `once={'keys': [...]}`. So enqueuing a task without
+    passing a defaulted key parameter raised `KeyError: '<key>'` inside `apply_async` — before the
+    message was ever sent — which surfaced as a 500 on the caller (issue #989: `sweep_slot` on the
+    inbound reply-notification webhook). Filling the default makes an omitted `sweep_slot=0` and an
+    explicit `sweep_slot=0` the SAME lock, which is what the key always meant.
+
+    Only keys named in `once['keys']` are filled, so the unrestricted case keeps upstream's key shape
+    byte for byte and no existing lock changes identity.
+    """
+
+    abstract = True
+
+    def _get_call_args(self, args, kwargs) -> dict:
+        call_args = super()._get_call_args(args, kwargs)
+        for key in self.once.get('keys') or ():
+            if key in call_args:
+                continue
+            param = self._signature.parameters.get(key)
+            if param is not None and param.default is not Parameter.empty:
+                call_args[key] = param.default
+        return call_args

--- a/src/cqc_lem/app/queue_once.py
+++ b/src/cqc_lem/app/queue_once.py
@@ -1,4 +1,5 @@
 from inspect import Parameter
+from typing import Optional, Sequence
 
 from celery_once import QueueOnce as _CeleryQueueOnce
 
@@ -19,7 +20,7 @@ class QueueOnce(_CeleryQueueOnce):
 
     abstract = True
 
-    def _get_call_args(self, args, kwargs) -> dict:
+    def _get_call_args(self, args: Optional[Sequence], kwargs: Optional[dict]) -> dict:
         call_args = super()._get_call_args(args, kwargs)
         for key in self.once.get('keys') or ():
             if key in call_args:

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -13,7 +13,7 @@ from enum import StrEnum
 from typing import Callable, List, Optional, Tuple
 from urllib.parse import unquote, urlparse
 
-from celery_once import QueueOnce
+from cqc_lem.app.queue_once import QueueOnce
 from cqc_lem.app.my_celery import app as shared_task
 from cqc_lem.utilities.ai.content_framework import select_blueprint
 from cqc_lem.utilities.ai.ai_helper import generate_ai_response, get_ai_message_refinement, summarize_recent_activity, \

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -3,11 +3,10 @@ import shutil
 from datetime import timedelta, datetime, timezone
 from typing import Tuple
 
-from celery_once import QueueOnce
-
 from cqc_lem import assets_dir
 from cqc_lem.app.celeryconfig import SE_PREPOST_QUEUE
 from cqc_lem.app.my_celery import app as shared_task
+from cqc_lem.app.queue_once import QueueOnce
 from cqc_lem.app.run_automation import automate_commenting, automate_profile_viewer_engagement, \
     automate_appreciation_dms_for_user, clean_stale_invites, update_stale_profile, post_to_linkedin, \
     automate_invites_to_company_page_for_user, send_scheduled_dm, send_connection_request, \

--- a/src/cqc_lem/app/run_scheduler.py
+++ b/src/cqc_lem/app/run_scheduler.py
@@ -409,8 +409,9 @@ def dispatch_scheduled_reply_sweeps():
             # Replying to comments on the user's OWN post is the one engagement a human really does
             # fast, so it keeps the RESPONSIVE profile (issue #626): the exact minute moves, the
             # response stays timely.
-            # sweep_slot must be explicit: QueueOnce keys on ['user_id', 'sweep_slot'] and does not
-            # apply function defaults — omitting it raises KeyError at enqueue.
+            # slot 0 is the single-shot scheduled trigger — the golden-hour amplifier owns the other
+            # slots. Explicit here for that reason, not for safety: cqc_lem.app.queue_once fills the
+            # default into the dedup key, so omitting it would build the identical lock (#989).
             sweep_reply_comments.apply_async(kwargs={'user_id': user_id, 'sweep_slot': 0},
                                              countdown=dispatch_jitter_seconds(PACE_RESPONSIVE))
             dispatched += 1

--- a/tests/unit/api/test_main_general.py
+++ b/tests/unit/api/test_main_general.py
@@ -389,8 +389,8 @@ class TestCommentNotificationInbound:
                 "text": "great post!"})
         assert resp.status_code == 200 and resp.json()["detail"] == "accepted"
         sweep.apply_async.assert_called_once()
-        # sweep_slot must be explicit: QueueOnce keys on ['user_id', 'sweep_slot'] without applying
-        # function defaults, so omitting it raises KeyError at enqueue (500 on every notification).
+        # The inbound webhook is the single-shot trigger, so it must dispatch slot 0 — the golden-hour
+        # amplifier owns every other slot (cqc_lem.app.queue_once keys the lock on it, #989).
         assert sweep.apply_async.call_args.kwargs["kwargs"] == {"user_id": 7, "sweep_slot": 0}
 
     def test_reaction_email_ignored(self, client):

--- a/tests/unit/app/test_queue_once_defaults.py
+++ b/tests/unit/app/test_queue_once_defaults.py
@@ -1,0 +1,63 @@
+"""Unit tests for the QueueOnce subclass that fills a task's own parameter defaults into the
+celery-once dedup key (issue #989 — `KeyError: 'sweep_slot'` raised inside apply_async, 500'ing the
+inbound reply-notification webhook before the message was ever sent)."""
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+
+class TestRestrictedKeyDefaults:
+    def test_omitted_defaulted_key_does_not_raise(self):
+        from cqc_lem.app.run_automation import sweep_reply_comments
+        # This is the exact enqueue shape that raised KeyError: 'sweep_slot'.
+        assert sweep_reply_comments.get_key(kwargs={"user_id": 7})
+
+    def test_omitted_default_and_explicit_default_are_the_same_lock(self):
+        from cqc_lem.app.run_automation import sweep_reply_comments
+        assert (sweep_reply_comments.get_key(kwargs={"user_id": 7})
+                == sweep_reply_comments.get_key(kwargs={"user_id": 7, "sweep_slot": 0}))
+
+    def test_distinct_slots_stay_distinct_locks(self):
+        """The whole point of keying on sweep_slot: concurrent golden-hour sweeps must not collapse
+        into one lock (run_automation dispatches a distinct slot per sweep)."""
+        from cqc_lem.app.run_automation import sweep_reply_comments
+        assert (sweep_reply_comments.get_key(kwargs={"user_id": 7, "sweep_slot": 1})
+                != sweep_reply_comments.get_key(kwargs={"user_id": 7, "sweep_slot": 2}))
+
+    def test_users_stay_distinct_locks(self):
+        from cqc_lem.app.run_automation import sweep_reply_comments
+        assert (sweep_reply_comments.get_key(kwargs={"user_id": 7})
+                != sweep_reply_comments.get_key(kwargs={"user_id": 8}))
+
+
+class TestUnrestrictedKeysUnchanged:
+    def test_task_without_restrict_keys_keeps_upstream_key_shape(self):
+        """Only keys named in once['keys'] are filled — a task with no `keys` must build the same
+        key celery-once always built, so no live lock changes identity on deploy."""
+        from cqc_lem.app.my_celery import app as shared_task
+        from cqc_lem.app.queue_once import QueueOnce
+
+        @shared_task.task(bind=True, base=QueueOnce, once={"graceful": True},
+                          name="tests.queue_once.unrestricted")
+        def unrestricted(self, user_id: int, limit: int = 10) -> None:
+            return None
+
+        key = unrestricted.get_key(kwargs={"user_id": 3})
+        assert "user_id-3" in key
+        assert "limit" not in key
+
+    def test_restricted_key_without_a_default_is_left_alone(self):
+        """A required key can't be missing (Signature.bind rejects it first), and a key we have no
+        default for must never be invented."""
+        from cqc_lem.app.my_celery import app as shared_task
+        from cqc_lem.app.queue_once import QueueOnce
+
+        @shared_task.task(bind=True, base=QueueOnce, once={"graceful": True, "keys": ["user_id"]},
+                          name="tests.queue_once.required_key")
+        def required_key(self, user_id: int, note: str = "x") -> None:
+            return None
+
+        key = required_key.get_key(kwargs={"user_id": 4})
+        assert "user_id-4" in key
+        assert "note" not in key

--- a/tests/unit/app/test_queue_once_defaults.py
+++ b/tests/unit/app/test_queue_once_defaults.py
@@ -2,9 +2,16 @@
 celery-once dedup key (issue #989 — `KeyError: 'sweep_slot'` raised inside apply_async, 500'ing the
 inbound reply-notification webhook before the message was ever sent)."""
 
+import re
+from pathlib import Path
+
 import pytest
 
 pytestmark = pytest.mark.unit
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SRC = REPO_ROOT / "src" / "cqc_lem"
+SHIM = SRC / "app" / "queue_once.py"
 
 
 class TestRestrictedKeyDefaults:
@@ -61,3 +68,31 @@ class TestUnrestrictedKeysUnchanged:
         key = required_key.get_key(kwargs={"user_id": 4})
         assert "user_id-4" in key
         assert "note" not in key
+
+
+class TestEveryTaskUsesTheShim:
+    """The fix only holds while every task base is OUR QueueOnce — a task that imports the upstream
+    class straight from `celery_once` silently gets the KeyError back, and nothing at runtime says
+    so. Source-text guard (same shape as test_selenium_queue_routing) because the failure is a
+    missing import, not a behaviour a passing task can demonstrate."""
+
+    def _sources(self) -> list[Path]:
+        return [p for p in SRC.rglob("*.py") if p != SHIM]
+
+    def test_no_module_imports_queueonce_from_celery_once(self):
+        offenders = [
+            str(path.relative_to(REPO_ROOT))
+            for path in self._sources()
+            if re.search(r"^\s*from\s+celery_once\s+import\s+.*\bQueueOnce\b", path.read_text(), re.M)
+            or re.search(r"\bcelery_once\.QueueOnce\b", path.read_text())
+        ]
+        assert offenders == [], f"import QueueOnce from cqc_lem.app.queue_once instead: {offenders}"
+
+    def test_every_module_declaring_a_queueonce_task_imports_the_shim(self):
+        missing = [
+            str(path.relative_to(REPO_ROOT))
+            for path in self._sources()
+            if "base=QueueOnce" in path.read_text()
+            and "from cqc_lem.app.queue_once import QueueOnce" not in path.read_text()
+        ]
+        assert missing == [], f"modules using base=QueueOnce without the shim import: {missing}"


### PR DESCRIPTION
## What

`celery-once` builds its lock key from `Signature.bind(...).arguments` — which **never applies defaults** — and then indexes that mapping with every name in `once={'keys': [...]}`:

```python
restrict_kwargs = {key: kwargs[key] for key in restrict_to}   # celery_once/helpers.py
```

So enqueuing a task without explicitly passing a *defaulted* key parameter raises `KeyError: '<key>'` **inside `apply_async`**, before the message is ever sent — which surfaces as a 500 on the caller. That is the reported `KeyError: 'sweep_slot'` on `/api/linkedin/verification-pin/inbound` (the inbound reply-notification webhook, which routes reply+token mail into `_process_reply_inbound`).

`#951` patched the two call sites that were hitting it. This PR removes the class of bug: **28** tasks declare `once={'keys': [...]}`, and each one carried the same landmine at every present and future enqueue site.

`cqc_lem/app/queue_once.py` adds a `QueueOnce` subclass that fills a task's own parameter defaults for keys named in `once['keys']`, making an omitted `sweep_slot=0` and an explicit `sweep_slot=0` the **same** lock — which is what the key always meant. `run_automation.py` / `run_scheduler.py` import `QueueOnce` from there instead of from `celery_once`; no decorator site changed.

## Why it's safe

- **Only** keys named in `once['keys']` are filled. A task with no `keys` builds byte-for-byte the key celery-once always built, so no live lock changes identity across the deploy.
- A restricted key with no default is never invented (`Signature.bind` rejects a missing required argument first, so it cannot be absent).
- Distinct values still produce distinct locks — verified for `sweep_slot` (concurrent golden-hour sweeps must not collapse into one lock) and for `user_id`.
- The explicit `sweep_slot=0` at the existing call sites is left in place; it is still correct and still asserted by their tests.

## Testing

`tests/unit/app/test_queue_once_defaults.py` (6 cases): the exact enqueue shape that raised (`sweep_reply_comments.get_key(kwargs={"user_id": 7})`) no longer raises and equals the explicit-default key; distinct slots/users stay distinct; an unrestricted task keeps upstream's key shape; a restricted key without a default is left alone.

Confirmed the upstream base class still raises the exact reported error on the same shape, so the test is guarding a real regression:

```
$ python -c "... @app.task(base=celery_once.QueueOnce, once={'keys': ['user_id','sweep_slot']}) ..."
UPSTREAM KeyError: 'sweep_slot'
```

Full unit lane green locally: `10193 passed`.

Closes #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)