### PR TITLE
fix(dm): recommendations-received card read rebuilt on the live SDUI DOM (closes #1007)

### DIFF
--- a/docs/engagement-automation.md
+++ b/docs/engagement-automation.md
@@ -338,6 +338,21 @@ empty-dict stubs, so only new connections ever produced a DM and the
   Only what falls inside `APPRECIATION_LOOKBACK_DAYS` (default 30) is a moment worth reacting to.
   Cards that render but NONE of which date is the one thing that warns: that is format drift, and
   it reads in production as "no recent recommendations" forever — a silently dead trigger.
+- **A recommendation card is a DATE-CARRYING BLOCK around a `/in/` anchor, not a list item (#1007).**
+  The 2026-08-03 grounding run found `/details/recommendations/` renders no `<li>`, no `<time>`, no
+  `[data-view-name]` and nothing with `role='tab'`, so every rung of the original ladder was
+  unmatchable and the scan read zero cards forever — the mentions half worked and this half was
+  silently dead. `_RECOMMENDATION_ROWS_JS` reads the page in ONE call instead: climb from each
+  `/in/` anchor to the outermost ancestor still about that one person (it stops the moment a second
+  profile joins the block), keep the block only if it carries a "Month D, YYYY" line. That excludes
+  the "Who your viewers also viewed" rail and the footer help-links list — the page's only
+  `main div[role=list]` — structurally, not by class name, which is all this DOM has left. The tab
+  click stays best-effort: the bare URL already lands on Received, and `?detailScreenTabIndex=2` is
+  Pending, whose rows are recommendation *requests* and never thank-worthy.
+- **`page_dated` is the recommendations tripwire.** Zero cards on a page whose text plainly carries
+  "Month D, YYYY" is drift and warns; zero cards on a page with no date is an account nobody has
+  recommended and stays a DEBUG no-op. Without that split the two readings are the same number,
+  which is precisely how the dead ladder survived a merge.
 - **`appreciation_touches` is the claim, and it is what makes this safe.** The beat re-queues
   itself every ~60s inside its window, so a standing list without a durable claim is a DM a minute.
   One row per (user, person, event_type); the unique key is the guarantee. `_dispatch_appreciation_dms`

--- a/docs/sdui-selenium-notes.md
+++ b/docs/sdui-selenium-notes.md
@@ -61,6 +61,13 @@ only ever a correction; `?detailScreenTabIndex=2` is **Pending**, whose rows rea
 "Requested"/"Sent" and are recommendation *requests*, never thank-worthy. Re-ground with
 `scripts/linkedin_live_validation.py --appreciation-sources`.
 
+The probe is piped into a worker running the DEPLOYED image, so a read rebuilt on a branch is not
+there to import — and a reader that can only be grounded AFTER it merges is exactly how this ladder
+shipped dead. As with the feed-sort chain, the probe drives `_recommendation_reading` when the
+running image has it and an identical carried copy when it does not, and the reading names which
+(`read_source: image | script`; a `script` reading has grounded THIS BRANCH, not what is deployed).
+`TestRecommendationReadCopy` fails the build if the copy drifts from the shipped read.
+
 ## The Connect invite is a URL, and unscoped "Invite …" buttons are a WRONG-PERSON hazard
 
 Live-grounded 2026-08-03 (3rd-degree profile, user 1, Sales-Nav overlay): the profile top card

--- a/docs/sdui-selenium-notes.md
+++ b/docs/sdui-selenium-notes.md
@@ -38,6 +38,29 @@ Zero rows against a non-zero "N Profile viewers" headline stat is selector drift
 zero rows with no stat is a quiet no-op. Re-ground with
 `scripts/linkedin_live_validation.py --profile-views`.
 
+## Recommendations Received has no list item, no `<time>` and no `role=tab` (#1007)
+
+Live-grounded 2026-08-03 (`/in/<self>/details/recommendations/`, user 1): hit-counts on the live
+page were `main li` **0**, `main time` **0**, `[data-view-name]` **0**, `[role='tab']` **0**,
+`div[role='listitem']` 3, `main div[role=list]` 1, `main a[href*='/in/']` 24. So every rung of the
+original card ladder and all three `_RECOMMENDATION_TAB_LOCATORS` were unmatchable —
+the recommendations half of #968 read 0 cards forever while the mentions half worked. The one
+`main div[role=list]` is the **footer help-links list** ("Questions? / Visit our Help Center"), the
+same junk trio the catch-up grounding hit; never anchor on it.
+
+What the page does render is one `/in/` anchor per card carrying `name · degree · headline` in its
+own innerText, inside a block that also carries the card's date line
+(`April 25, 2012, Uday was Christopher's client`). `_RECOMMENDATION_ROWS_JS` reads it in ONE
+`execute_script` pass: climb from each anchor to the outermost ancestor still about that ONE
+profile slug — stop as soon as a second slug joins, which also keeps a card whose avatar and name
+are two anchors to the same person intact — and keep the block only when its text matches the
+date regex. The "Who your viewers also viewed" rail drops out because its rows carry no date.
+Zero cards on a page whose text DOES carry a date is drift and warns (`page_dated`); zero with no
+date is a quiet no-op. Tab mapping: the bare URL defaults to **Received**, so the tab click is
+only ever a correction; `?detailScreenTabIndex=2` is **Pending**, whose rows read
+"Requested"/"Sent" and are recommendation *requests*, never thank-worthy. Re-ground with
+`scripts/linkedin_live_validation.py --appreciation-sources`.
+
 ## The Connect invite is a URL, and unscoped "Invite …" buttons are a WRONG-PERSON hazard
 
 Live-grounded 2026-08-03 (3rd-degree profile, user 1, Sales-Nav overlay): the profile top card

--- a/scripts/linkedin_live_validation.py
+++ b/scripts/linkedin_live_validation.py
@@ -993,6 +993,78 @@ def probe_roster_follow(driver, profile_url: str,
     return reading
 
 
+# The recommendations read is NEW in #1007, so the DEPLOYED image this probe is piped into has no
+# `_recommendation_reading` to drive — and a rebuilt reader that can only be grounded AFTER it merges
+# is exactly how the dead ladder #1007 replaces survived a merge in the first place. Same posture as
+# `feed_sort_chains` above: drive the SHIPPED read when the running image has one, carry an identical
+# copy when it does not, and name which in the reading so a pre-merge pass is never mistaken for a
+# reading against deployed code. `TestRecommendationReadCopy` fails the build if the copy drifts.
+FALLBACK_RECOMMENDATION_ROWS_JS = r"""
+const DATE = /(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},\s*\d{4}\b/;
+const RAIL = /Who your viewers also viewed|People also viewed|Private to you/i;
+const MAX_CLIMB = 15;
+const root = document.querySelector('main') || document.body;
+const slug = (a) => {
+  const m = ((a.getAttribute('href') || '') || (a.href || '')).match(/\/in\/[^/?#]+/);
+  return m ? decodeURIComponent(m[0]).toLowerCase() : '';
+};
+const anchors = [...root.querySelectorAll('a[href*="/in/"]')];
+const rows = [];
+const seen = new Set();
+for (const anchor of anchors) {
+  if (!slug(anchor)) continue;
+  let block = anchor, hops = 0;
+  while (block.parentElement && hops < MAX_CLIMB) {
+    const parent = block.parentElement;
+    if (parent === root || parent.tagName === 'BODY') break;
+    const people = new Set([...parent.querySelectorAll('a[href*="/in/"]')].map(slug).filter(Boolean));
+    if (people.size > 1) break;
+    block = parent; hops++;
+  }
+  if (seen.has(block)) continue;
+  seen.add(block);
+  const text = block.innerText || '';
+  if (!DATE.test(text) || RAIL.test(text)) continue;
+  let name = '';
+  for (const link of [anchor, ...block.querySelectorAll('a[href*="/in/"]')]) {
+    const first = (link.innerText || '').split('\n').map(t => t.trim()).filter(Boolean)[0];
+    if (first) { name = first; break; }
+  }
+  rows.push({href: anchor.href, name: name, text: text});
+}
+return {rows: rows,
+        anchors: new Set(anchors.map(slug).filter(Boolean)).size,
+        page_dated: DATE.test(root.innerText || '')};
+"""
+
+FALLBACK_RECOMMENDATION_RENDER_ATTEMPTS = 5
+
+
+def _carried_recommendation_reading(driver) -> dict:
+    """`_recommendation_reading`'s answer on an image that predates #1007 — same JS, same shape, and
+    the same posture that a read which blows up is an EMPTY read, never a crashed probe."""
+    empty = {"rows": [], "anchors": 0, "page_dated": False}
+    try:
+        reading = driver.execute_script(FALLBACK_RECOMMENDATION_ROWS_JS)
+    except Exception:
+        return empty
+    if not isinstance(reading, dict):
+        return empty
+    return {"rows": [row for row in (reading.get("rows") or []) if isinstance(row, dict)],
+            "anchors": int(reading.get("anchors") or 0),
+            "page_dated": bool(reading.get("page_dated"))}
+
+
+def recommendation_read() -> tuple:
+    """(the read to drive, how many times to re-read an empty page, where both came from)."""
+    try:
+        from cqc_lem.app.run_automation import (_RECOMMENDATION_RENDER_ATTEMPTS,
+                                                _recommendation_reading)
+    except ImportError:
+        return (_carried_recommendation_reading, FALLBACK_RECOMMENDATION_RENDER_ATTEMPTS, "script")
+    return (_recommendation_reading, _RECOMMENDATION_RENDER_ATTEMPTS, "image")
+
+
 def appreciation_verdict(reading: dict) -> str:
     """What one reading proves about an appreciation source (#968, rebuilt for #1007).
 
@@ -1005,19 +1077,24 @@ def appreciation_verdict(reading: dict) -> str:
     resolves around it is drift, not an account nobody has recommended."""
     reading = dict(reading or {})
     cards = int(reading.get("cards") or 0)
+    # Which code answered is part of the finding: a green pass driven by the carried copy grounds
+    # THIS BRANCH's read against the live DOM (which is the point of running it before the merge),
+    # not the reader currently deployed.
+    note = (" [read carried by this script — the running image predates #1007]"
+            if reading.get("read_source") == "script" else "")
     if not cards and reading.get("page_dated"):
         return (f"ZERO cards resolved on a page that renders dated recommendations "
                 f"({reading.get('profile_anchors') or 0} profile link(s) on it) — the card read has "
-                f"rotated again and production is silently dead")
+                f"rotated again and production is silently dead{note}")
     if not cards:
         return ("no cards resolved — either the surface is genuinely empty or the card locator "
-                "chain has rotated; production sends nothing either way")
+                f"chain has rotated; production sends nothing either way{note}")
     if not reading.get("dated"):
         return (f"{cards} card(s) resolved but none carried a readable date — production skips "
-                f"every one of them, so this trigger is silently dead")
+                f"every one of them, so this trigger is silently dead{note}")
     people = reading.get("people") or []
     return (f"{cards} card(s), {reading.get('dated')} dated, {len(people)} inside the "
-            f"{reading.get('lookback_days')}-day window — production would thank those")
+            f"{reading.get('lookback_days')}-day window — production would thank those{note}")
 
 
 def probe_appreciation_sources(driver, user_id: int, profile_url: str = "",
@@ -1034,8 +1111,7 @@ def probe_appreciation_sources(driver, user_id: int, profile_url: str = "",
                                             _MENTION_CARD_LOCATORS, _MENTION_TEXT_RE, _card_person,
                                             _card_text, _mention_actor_name, _normalize_profile_url,
                                             _own_profile_url, _parse_recommendation_date,
-                                            _parse_relative_age_days, _recommendation_reading,
-                                            appreciation_lookback_days)
+                                            _parse_relative_age_days, appreciation_lookback_days)
     from cqc_lem.utilities.db import has_appreciation_touch
     from cqc_lem.utilities.linkedin.helper import clean_person_name
     from cqc_lem.utilities.selenium_util import find_all_first
@@ -1078,11 +1154,21 @@ def probe_appreciation_sources(driver, user_id: int, profile_url: str = "",
     def _read_recommendations(own: str) -> dict:
         """The recommendations half reads its OWN way since #1007: the page has no list items, no
         `<time>` and no `data-view-name`, so production resolves a card by climbing from each `/in/`
-        anchor to the block that carries its date line. Drive that same read here."""
+        anchor to the block that carries its date line. Drive that same read here — from the running
+        image when it has one, from the carried copy when it predates the rebuild."""
         url = f"{own}/details/recommendations/"
         driver.get(url)
         sleep(5)
-        reading = _recommendation_reading(driver)
+        read, attempts, read_source = recommendation_read()
+        # Mirror production's render poll: an SDUI page still painting reads exactly like an account
+        # nobody has recommended, which is the confusion this whole probe exists to end.
+        reading = {"rows": [], "anchors": 0, "page_dated": False}
+        for attempt in range(max(1, attempts)):
+            reading = read(driver)
+            if reading["rows"] or reading["page_dated"]:
+                break
+            if attempt + 1 < attempts:
+                sleep(2)
         rows = []
         for row in reading["rows"]:
             text = row.get("text") or ""
@@ -1100,6 +1186,7 @@ def probe_appreciation_sources(driver, user_id: int, profile_url: str = "",
                "dated": sum(1 for r in rows if r["age_days"] is not None),
                # The two numbers that tell an empty section apart from a rotated read.
                "profile_anchors": reading["anchors"], "page_dated": reading["page_dated"],
+               "read_source": read_source,
                "people": [r for r in rows if r["in_window"] and r["profile_url"]
                           and not r["already_thanked"]],
                "rows": rows[:10]}

--- a/scripts/linkedin_live_validation.py
+++ b/scripts/linkedin_live_validation.py
@@ -994,13 +994,21 @@ def probe_roster_follow(driver, profile_url: str,
 
 
 def appreciation_verdict(reading: dict) -> str:
-    """What one reading proves about an appreciation source (#968).
+    """What one reading proves about an appreciation source (#968, rebuilt for #1007).
 
     'cards but nothing dated' is the finding that matters: production skips an undated card rather
     than thank a five-year-old recommendation, so a section that renders and never dates reads as
-    "no recent recommendations" forever — a silently dead trigger, not an empty one."""
+    "no recent recommendations" forever — a silently dead trigger, not an empty one.
+
+    `page_dated` (recommendations only) is what finally separates the two zero readings the #1007
+    grounding could not tell apart: a page that plainly renders "Month D, YYYY" while nothing
+    resolves around it is drift, not an account nobody has recommended."""
     reading = dict(reading or {})
     cards = int(reading.get("cards") or 0)
+    if not cards and reading.get("page_dated"):
+        return (f"ZERO cards resolved on a page that renders dated recommendations "
+                f"({reading.get('profile_anchors') or 0} profile link(s) on it) — the card read has "
+                f"rotated again and production is silently dead")
     if not cards:
         return ("no cards resolved — either the surface is genuinely empty or the card locator "
                 "chain has rotated; production sends nothing either way")
@@ -1019,16 +1027,17 @@ def probe_appreciation_sources(driver, user_id: int, profile_url: str = "",
 
     STRICTLY read-only, and it deliberately does NOT call the production scrapers — those are gated
     OFF by `APPRECIATION_SOURCES_ENABLED` precisely until this probe has grounded them, so the probe
-    drives the same locator chains and the same date parsers directly. Nothing is messaged: the
-    ledger is only READ (`has_appreciation_touch`), never claimed."""
+    drives the same card reads (`_recommendation_reading` for recommendations since #1007, the
+    mention locator chain for the other) and the same date parsers directly. Nothing is messaged:
+    the ledger is only READ (`has_appreciation_touch`), never claimed."""
     from cqc_lem.app.run_automation import (_MENTIONS_URL, _MENTION_ACTOR_LOCATORS,
-                                            _MENTION_CARD_LOCATORS, _MENTION_TEXT_RE,
-                                            _RECOMMENDATION_AUTHOR_LOCATORS,
-                                            _RECOMMENDATION_CARD_LOCATORS, _card_person, _card_text,
-                                            _mention_actor_name, _own_profile_url,
-                                            _parse_recommendation_date, _parse_relative_age_days,
+                                            _MENTION_CARD_LOCATORS, _MENTION_TEXT_RE, _card_person,
+                                            _card_text, _mention_actor_name, _normalize_profile_url,
+                                            _own_profile_url, _parse_recommendation_date,
+                                            _parse_relative_age_days, _recommendation_reading,
                                             appreciation_lookback_days)
     from cqc_lem.utilities.db import has_appreciation_touch
+    from cqc_lem.utilities.linkedin.helper import clean_person_name
     from cqc_lem.utilities.selenium_util import find_all_first
 
     lookback = appreciation_lookback_days()
@@ -1066,12 +1075,41 @@ def probe_appreciation_sources(driver, user_id: int, profile_url: str = "",
         reading["verdict"] = appreciation_verdict(reading)
         return reading
 
+    def _read_recommendations(own: str) -> dict:
+        """The recommendations half reads its OWN way since #1007: the page has no list items, no
+        `<time>` and no `data-view-name`, so production resolves a card by climbing from each `/in/`
+        anchor to the block that carries its date line. Drive that same read here."""
+        url = f"{own}/details/recommendations/"
+        driver.get(url)
+        sleep(5)
+        reading = _recommendation_reading(driver)
+        rows = []
+        for row in reading["rows"]:
+            text = row.get("text") or ""
+            age_days = _parse_recommendation_date(text)
+            person_url = _normalize_profile_url(row.get("href") or "")
+            rows.append({"profile_url": person_url,
+                         "name": clean_person_name(row.get("name") or ""),
+                         "age_days": None if age_days is None else round(age_days, 2),
+                         "in_window": age_days is not None and age_days <= lookback,
+                         "already_thanked": bool(person_url) and has_appreciation_touch(
+                             user_id, person_url, "recommendation_received"),
+                         "text": text[:160]})
+        out = {"url": url, "current_url": getattr(driver, "current_url", url),
+               "lookback_days": lookback, "cards": len(rows),
+               "dated": sum(1 for r in rows if r["age_days"] is not None),
+               # The two numbers that tell an empty section apart from a rotated read.
+               "profile_anchors": reading["anchors"], "page_dated": reading["page_dated"],
+               "people": [r for r in rows if r["in_window"] and r["profile_url"]
+                          and not r["already_thanked"]],
+               "rows": rows[:10]}
+        out["verdict"] = appreciation_verdict(out)
+        return out
+
     own = _own_profile_url(driver, user_id) if not profile_url else profile_url.rstrip("/")
     report = {"own_profile_url": own}
     if own:
-        report["recommendations_received"] = _read(
-            f"{own}/details/recommendations/", _RECOMMENDATION_CARD_LOCATORS,
-            _RECOMMENDATION_AUTHOR_LOCATORS, _parse_recommendation_date, "recommendation_received")
+        report["recommendations_received"] = _read_recommendations(own)
     else:
         report["recommendations_received"] = {
             "verdict": "own profile URL unresolved — production skips the recommendations scan"}
@@ -1265,8 +1303,8 @@ def main(argv: Optional[list] = None) -> int:
     parser.add_argument("--appreciation-sources", action="store_true",
                         help="read the Recommendations Received section and the mentions "
                              "notification feed and report what the appreciation-DM triggers would "
-                             "make of them (#968). Read-only: nothing is messaged and no ledger row "
-                             "is claimed.")
+                             "make of them (#968, recommendations rebuilt in #1007). Read-only: "
+                             "nothing is messaged and no ledger row is claimed.")
     parser.add_argument("--sent-invites", action="store_true",
                         help="open Manage invitations -> Sent and report which pending rows resolve "
                              "and how their 'Sent ... ago' stamps parse (#969). Read-only: nothing "

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -4955,24 +4955,72 @@ def appreciation_sources_enabled() -> bool:
     return os.getenv("APPRECIATION_SOURCES_ENABLED", "false").strip().lower() == "true"
 
 
-# Recommendations Received. `data-view-name` first, then the semantic list item proved by what the
-# card must contain (a /in/ link), then the legacy paged-list class — never a hashed class alone.
+# Recommendations Received, rebuilt on the live SDUI DOM (grounded 2026-08-03, issue #1007). The
+# page carries NO `<li>`, NO `<time>`, NO `[data-view-name]` and nothing with `role='tab'` anywhere,
+# so every rung of the original ladder was unmatchable and the scan read zero cards forever — the
+# invisible no-op the grounding runs exist to catch. Its one `main div[role=list]` is the footer
+# help-links list, never the recommendations list, so nothing anchors on that either.
+#
+# The tabs render as plain anchors/text. The bare URL already lands on Received, so the click below
+# is only ever a correction and a miss is a no-op; `?detailScreenTabIndex=2` is Pending, whose rows
+# are recommendation REQUESTS ("Requested"/"Sent") and never thank-worthy.
 _RECOMMENDATION_TAB_LOCATORS = [
-    (By.XPATH, "//button[@role='tab'][contains(normalize-space(),'Received')]"),
-    (By.XPATH, "//*[@role='tab'][contains(normalize-space(),'Received')]"),
-    (By.XPATH, "//button[normalize-space()='Received']"),
+    (By.XPATH, "//main//a[normalize-space()='Received']"),
+    (By.XPATH, "//main//button[normalize-space()='Received']"),
+    (By.XPATH, "//main//*[@role='tab'][normalize-space()='Received']"),
 ]
-_RECOMMENDATION_CARD_LOCATORS = [
-    (By.CSS_SELECTOR, "main li[data-view-name='profile-recommendation']"),
-    (By.CSS_SELECTOR, "main div[data-view-name='profile-recommendation']"),
-    (By.XPATH, "//main//li[.//a[contains(@href,'/in/')] and .//time]"),
-    (By.XPATH, "//main//li[contains(@class,'pvs-list__paged-list-item')][.//a[contains(@href,'/in/')]]"),
-    (By.XPATH, "//main//section//li[.//a[contains(@href,'/in/')]]"),
-]
-_RECOMMENDATION_AUTHOR_LOCATORS = [
-    (By.CSS_SELECTOR, "a[data-view-name='profile-recommendation-author']"),
-    (By.CSS_SELECTOR, "a[href*='/in/']"),
-]
+
+# What IS on the page is one `/in/` anchor per card (its text is "name · degree · headline") sitting
+# inside a block that also carries the card's "Month D, YYYY, X was Y's client" line. The read below
+# climbs from each anchor to the OUTERMOST ancestor still about that ONE person — it stops the
+# moment a second profile joins the block — and keeps the block only when it carries such a date.
+# That drops the "Who your viewers also viewed" rail (undated rows) structurally rather than by
+# class name, which is the whole point: hashed classes are all this page has left.
+#
+# One JS call returns every row at once, so nothing goes stale while the list re-renders under the
+# walk — the same shape the profile-viewer rebuild (#1009) uses on the same DOM generation.
+_RECOMMENDATION_ROWS_JS = r"""
+const DATE = /(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},\s*\d{4}\b/;
+const RAIL = /Who your viewers also viewed|People also viewed|Private to you/i;
+const MAX_CLIMB = 15;
+const root = document.querySelector('main') || document.body;
+const slug = (a) => {
+  const m = ((a.getAttribute('href') || '') || (a.href || '')).match(/\/in\/[^/?#]+/);
+  return m ? decodeURIComponent(m[0]).toLowerCase() : '';
+};
+const anchors = [...root.querySelectorAll('a[href*="/in/"]')];
+const rows = [];
+const seen = new Set();
+for (const anchor of anchors) {
+  if (!slug(anchor)) continue;
+  let block = anchor, hops = 0;
+  while (block.parentElement && hops < MAX_CLIMB) {
+    const parent = block.parentElement;
+    if (parent === root || parent.tagName === 'BODY') break;
+    const people = new Set([...parent.querySelectorAll('a[href*="/in/"]')].map(slug).filter(Boolean));
+    if (people.size > 1) break;
+    block = parent; hops++;
+  }
+  if (seen.has(block)) continue;
+  seen.add(block);
+  const text = block.innerText || '';
+  if (!DATE.test(text) || RAIL.test(text)) continue;
+  let name = '';
+  for (const link of [anchor, ...block.querySelectorAll('a[href*="/in/"]')]) {
+    const first = (link.innerText || '').split('\n').map(t => t.trim()).filter(Boolean)[0];
+    if (first) { name = first; break; }
+  }
+  rows.push({href: anchor.href, name: name, text: text});
+}
+return {rows: rows,
+        anchors: new Set(anchors.map(slug).filter(Boolean)).size,
+        page_dated: DATE.test(root.innerText || '')};
+"""
+
+# The SDUI page paints asynchronously, so the first read of an empty list is not evidence the list
+# is empty. Re-read a few times before believing it — an early zero reads exactly like an account
+# with no recommendations, which is the confusion this whole issue is about.
+_RECOMMENDATION_RENDER_ATTEMPTS = 5
 
 # Mentions notifications — the closest thing LinkedIn exposes to "we did something together":
 # somebody put this user's name in their own post or comment.
@@ -5087,6 +5135,26 @@ def _card_text(card: WebElement) -> str:
         return ""
 
 
+def _recommendation_reading(driver, user_id: int = None) -> dict:
+    """One JS read of the recommendations page: the resolved cards plus the two numbers that tell
+    an empty section apart from selectors that have rotated again.
+
+    `page_dated` is the tripwire — the page plainly showing "Month D, YYYY" while no block resolves
+    is drift, whereas neither is just an account nobody has recommended."""
+    empty = {"rows": [], "anchors": 0, "page_dated": False}
+    try:
+        reading = driver.execute_script(_RECOMMENDATION_ROWS_JS)
+    except WebDriverException as e:
+        log_warning("Could not read the recommendations page", exc=e, user_id=user_id,
+                    action_type="scrape")
+        return empty
+    if not isinstance(reading, dict):
+        return empty
+    return {"rows": [row for row in (reading.get("rows") or []) if isinstance(row, dict)],
+            "anchors": int(reading.get("anchors") or 0),
+            "page_dated": bool(reading.get("page_dated"))}
+
+
 def get_recent_recommendations(driver, wait, user_id: int = None,
                                profile_url: str = None) -> dict[str, str]:
     """Return {profile_url: name} for people who recommended this user inside the lookback window.
@@ -5112,32 +5180,37 @@ def get_recent_recommendations(driver, wait, user_id: int = None,
                 required=False, max_try=1, warn_on_miss=False, user_id=user_id)
     time.sleep(random.uniform(1, 2))
 
-    cards = find_all_first(driver, _RECOMMENDATION_CARD_LOCATORS)
-    if not cards:
-        log_debug("No recommendation cards rendered", user_id=user_id, action_type="scrape")
+    reading = {"rows": [], "anchors": 0, "page_dated": False}
+    for attempt in range(_RECOMMENDATION_RENDER_ATTEMPTS):
+        reading = _recommendation_reading(driver, user_id)
+        if reading["rows"] or reading["page_dated"]:
+            break
+        if attempt + 1 < _RECOMMENDATION_RENDER_ATTEMPTS:
+            time.sleep(2)
+
+    if not reading["rows"]:
+        if reading["page_dated"]:
+            # The page renders dated recommendations and not one block resolved around them — that
+            # is selector drift, which is exactly how this source went silently dead once already.
+            log_warning("Recommendations page shows dated cards but none resolved", user_id=user_id,
+                        action_type="scrape", url=f"{own_url}/details/recommendations/")
+        else:
+            log_debug("No recommendation cards rendered", user_id=user_id, action_type="scrape")
         return {}
 
     lookback = appreciation_lookback_days()
     recommenders: dict[str, str] = {}
-    dated = 0
-    for card in cards:
-        text = _card_text(card)
-        age_days = _parse_recommendation_date(text)
-        if age_days is None:
+    for row in reading["rows"]:
+        # Every row already carried a date-shaped line, but the parser is still the authority:
+        # "February 30, 2026" matches the shape and is not a date.
+        age_days = _parse_recommendation_date(row.get("text") or "")
+        if age_days is None or age_days > lookback:
             continue
-        dated += 1
-        if age_days > lookback:
-            continue
-        url, name = _card_person(card, _RECOMMENDATION_AUTHOR_LOCATORS)
+        url = _normalize_profile_url(row.get("href") or "")
         if not url or url == own_url:
             continue
-        recommenders.setdefault(url, name)
+        recommenders.setdefault(url, clean_person_name(row.get("name") or ""))
 
-    if not dated:
-        # Cards rendered but not one carried a parseable date — that is selector/format drift, and
-        # the feature is silently dead until it is fixed. Warning on repeat is the point.
-        log_warning("Recommendation cards carried no readable date", user_id=user_id,
-                    action_type="scrape", url=f"{own_url}/details/recommendations/")
     log_info(f"Found {len(recommenders)} recommendation(s) received in the last {lookback} day(s)",
              user_id=user_id, action_type="dm")
     return recommenders

--- a/tests/unit/app/test_appreciation_sources.py
+++ b/tests/unit/app/test_appreciation_sources.py
@@ -101,54 +101,115 @@ class TestDateParsers:
         assert _parse_relative_age_days("3d") == 3.0
 
 
+def _rec_row(text: str, href: str = "https://www.linkedin.com/in/jane?trk=x",
+             name: str = "Jane Doe\n· 1st\nHead of Ops") -> dict:
+    """One row as `_RECOMMENDATION_ROWS_JS` returns it: the card block's text plus the `/in/`
+    anchor it was resolved from."""
+    return {"href": href, "name": name.split("\n")[0], "text": text}
+
+
 class TestRecommendations:
-    def _run(self, cards, own="https://www.linkedin.com/in/me"):
+    """#1007: the card read is a single JS pass over `/in/` anchors, not a locator ladder — the
+    ladder was unmatchable on the live SDUI DOM and read zero cards forever."""
+
+    def _run(self, rows, own="https://www.linkedin.com/in/me", page_dated=None):
         from cqc_lem.app.run_automation import get_recent_recommendations
         driver = MagicMock()
-        with patch(f"{_RA}.find_all_first", return_value=cards), \
-             patch(f"{_RA}.click_first"), \
+        driver.execute_script.return_value = {
+            "rows": rows, "anchors": len(rows) or 3,
+            "page_dated": bool(rows) if page_dated is None else page_dated}
+        with patch(f"{_RA}.click_first"), \
              patch(f"{_RA}.wait_for_ajax"), \
-             patch(f"{_RA}.log_warning") as warn, \
-             patch(f"{_RA}.getText", side_effect=lambda el: el.text):
+             patch(f"{_RA}.log_warning") as warn:
             got = get_recent_recommendations(driver, MagicMock(), 1, own)
         return got, driver, warn
 
     def test_reads_the_received_tab_of_the_users_own_profile(self):
-        got, driver, _ = self._run([_card("July 24, 2026, Jane was my client")])
+        got, driver, _ = self._run([_rec_row("Jane Doe\n· 1st\n"
+                                             "July 24, 2026, Jane was Chris's client\nGreat work.")])
         assert got == {"https://www.linkedin.com/in/jane": "Jane Doe"}
         assert driver.get.call_args[0][0] == ("https://www.linkedin.com/in/me"
                                               "/details/recommendations/")
 
     def test_recommendation_older_than_the_window_is_not_thanked(self):
-        got, _, _ = self._run([_card("March 2, 2019, Jane was my client")])
+        got, _, _ = self._run([_rec_row("March 2, 2019, Jane was my client")])
         assert got == {}
 
-    def test_undated_card_is_skipped_and_drift_warns_once(self):
-        """Cards that render but never date = the trigger is silently dead. That IS a defect."""
-        got, _, warn = self._run([_card("Jane was my client"), _card("John was my client")])
+    def test_a_date_shaped_line_that_is_not_a_date_is_skipped(self):
+        """The JS only proves the SHAPE; `_parse_recommendation_date` is still the authority."""
+        got, _, warn = self._run([_rec_row("February 30, 2026, Jane was my client")])
         assert got == {}
-        warn.assert_called_once()
+        warn.assert_not_called()
 
     def test_dated_cards_do_not_warn_even_when_all_are_old(self):
-        got, _, warn = self._run([_card("March 2, 2019, Jane was my client")])
+        got, _, warn = self._run([_rec_row("March 2, 2019, Jane was my client")])
         assert got == {}
         warn.assert_not_called()
 
     def test_empty_section_is_quiet(self):
-        got, _, warn = self._run([])
+        got, _, warn = self._run([], page_dated=False)
         assert got == {}
         warn.assert_not_called()
 
-    def test_own_profile_link_is_never_a_recommender(self):
-        card = _card("July 24, 2026", href="https://www.linkedin.com/in/me/?trk=y", name="Me")
-        got, _, _ = self._run([card])
+    def test_zero_cards_on_a_dated_page_is_drift_and_warns(self):
+        """The failure this issue exists for: the page plainly shows dated recommendations and the
+        read resolves none. Silently returning {} is how the dead ladder survived a merge."""
+        got, _, warn = self._run([], page_dated=True)
         assert got == {}
+        warn.assert_called_once()
+
+    def test_an_unreadable_page_is_not_a_recommendation(self):
+        from selenium.common.exceptions import WebDriverException
+        from cqc_lem.app.run_automation import get_recent_recommendations
+        driver = MagicMock()
+        driver.execute_script.side_effect = WebDriverException("no such execution context")
+        with patch(f"{_RA}.click_first"), patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.log_warning") as warn:
+            assert get_recent_recommendations(driver, MagicMock(), 1,
+                                              "https://www.linkedin.com/in/me") == {}
+        assert warn.called
+
+    def test_a_non_dict_script_result_is_not_a_crash(self):
+        """An `undefined`/None answer from `execute_script` must read as 'nothing', not blow up the
+        appreciation pass that called it."""
+        from cqc_lem.app.run_automation import get_recent_recommendations
+        driver = MagicMock()
+        driver.execute_script.return_value = None
+        with patch(f"{_RA}.click_first"), patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.log_warning") as warn:
+            assert get_recent_recommendations(driver, MagicMock(), 1,
+                                              "https://www.linkedin.com/in/me") == {}
+        warn.assert_not_called()
+
+    def test_own_profile_link_is_never_a_recommender(self):
+        row = _rec_row("July 24, 2026", href="https://www.linkedin.com/in/me/?trk=y", name="Me")
+        got, _, _ = self._run([row])
+        assert got == {}
+
+    def test_the_render_poll_retries_an_empty_first_paint(self):
+        """The SDUI page paints asynchronously — an immediate zero is not evidence of an empty
+        section, so an empty read is re-tried before it is believed."""
+        from cqc_lem.app.run_automation import (_RECOMMENDATION_RENDER_ATTEMPTS,
+                                                get_recent_recommendations)
+        driver = MagicMock()
+        empty = {"rows": [], "anchors": 4, "page_dated": False}
+        painted = {"rows": [_rec_row("July 24, 2026, Jane was my client")], "anchors": 4,
+                   "page_dated": True}
+        driver.execute_script.side_effect = [empty, empty, painted]
+        with patch(f"{_RA}.click_first"), patch(f"{_RA}.wait_for_ajax"), \
+             patch(f"{_RA}.log_warning") as warn:
+            got = get_recent_recommendations(driver, MagicMock(), 1,
+                                             "https://www.linkedin.com/in/me")
+        assert got == {"https://www.linkedin.com/in/jane": "Jane Doe"}
+        assert driver.execute_script.call_count == 3
+        assert _RECOMMENDATION_RENDER_ATTEMPTS >= 3
+        warn.assert_not_called()
 
     def test_falls_back_to_the_stored_profile_url(self):
         from cqc_lem.app.run_automation import get_recent_recommendations
         driver = MagicMock()
-        with patch(f"{_RA}.find_all_first", return_value=[]), \
-             patch(f"{_RA}.click_first"), patch(f"{_RA}.wait_for_ajax"), \
+        driver.execute_script.return_value = {"rows": [], "anchors": 0, "page_dated": False}
+        with patch(f"{_RA}.click_first"), patch(f"{_RA}.wait_for_ajax"), \
              patch(f"{_RA}.get_linkedin_profile_url_by_user_id",
                    return_value="https://www.linkedin.com/in/stored/"):
             get_recent_recommendations(driver, MagicMock(), 1, "")

--- a/tests/unit/test_linkedin_live_validation.py
+++ b/tests/unit/test_linkedin_live_validation.py
@@ -483,8 +483,14 @@ class TestAppreciationSourcesProbe:
                             lambda d, u, p="": {"mentions": {"verdict": "no cards resolved"}})
         assert llv.main(["--appreciation-sources"]) == 0
 
+    def test_zero_cards_on_a_dated_page_names_the_read_as_rotated(self):
+        """#1007's whole finding: the recommendations page rendered dated cards and the locator
+        ladder resolved none. That must not read the same as an account with no recommendations."""
+        verdict = llv.appreciation_verdict({"cards": 0, "page_dated": True, "profile_anchors": 24})
+        assert "silently dead" in verdict and "24 profile link(s)" in verdict
+
     def test_probe_reads_both_surfaces_and_never_claims_a_ledger_row(self, monkeypatch):
-        """It grounds the PRODUCTION locator chains + parsers (the scrapers themselves are gated
+        """It grounds the PRODUCTION card reads + parsers (the scrapers themselves are gated
         off until this run happens), and it must stay read-only."""
         from unittest.mock import patch
 
@@ -496,6 +502,11 @@ class TestAppreciationSourcesProbe:
         card.find_elements.return_value = [link]
 
         driver = _fake_driver(current_url="https://www.linkedin.com/in/me")
+        # Since #1007 the recommendations half is one JS read, not a locator chain.
+        driver.execute_script.return_value = {
+            "rows": [{"href": "https://www.linkedin.com/in/jane?trk=x", "name": "Jane Doe",
+                      "text": "Jane Doe\n· 1st\nJuly 24, 2026, Jane was my client"}],
+            "anchors": 24, "page_dated": True}
         with patch("cqc_lem.utilities.selenium_util.find_all_first", return_value=[card]), \
              patch("cqc_lem.utilities.db.has_appreciation_touch", return_value=False), \
              patch("cqc_lem.app.run_automation.getText", side_effect=lambda el: el.text), \
@@ -506,10 +517,34 @@ class TestAppreciationSourcesProbe:
         rec = report["recommendations_received"]
         assert rec["url"].endswith("/details/recommendations/")
         assert rec["cards"] == 1 and rec["dated"] == 1
+        assert rec["profile_anchors"] == 24 and rec["page_dated"] is True
         assert rec["people"][0]["profile_url"] == "https://www.linkedin.com/in/jane"
+        assert rec["people"][0]["name"] == "Jane Doe"
         # The mentions surface is read too, and its cards must SAY they were a mention.
         assert report["mentions"]["cards"] == 0
         assert "no cards resolved" in report["mentions"]["verdict"]
+
+    def test_the_probe_reports_the_grounded_shape_of_this_profile(self):
+        """The acceptance reading from the issue: two 2010-2012 recommendations resolve, both date,
+        and NEITHER is inside the 30-day window — a fixed reader that still sends nothing today."""
+        from unittest.mock import patch
+
+        driver = _fake_driver(current_url="https://www.linkedin.com/in/christopherqueen")
+        driver.execute_script.return_value = {
+            "rows": [{"href": "https://www.linkedin.com/in/uday", "name": "Uday Shankar",
+                      "text": "Uday Shankar\n· 1st\nGroup Supervisor at JHU/APL\n"
+                              "April 25, 2012, Uday was Christopher's client\nWe hired Chris..."},
+                     {"href": "https://www.linkedin.com/in/jeremiah", "name": "Jeremiah A. Myers",
+                      "text": "Jeremiah A. Myers\n· 1st\nSr. Technical Product Manager @ AWS\n"
+                              "September 14, 2010, Jeremiah A. and Christopher studied together"}],
+            "anchors": 24, "page_dated": True}
+        with patch("cqc_lem.utilities.db.has_appreciation_touch", return_value=False):
+            report = llv.probe_appreciation_sources(
+                driver, 1, "https://www.linkedin.com/in/christopherqueen/", sleep=lambda s: None)
+
+        rec = report["recommendations_received"]
+        assert (rec["cards"], rec["dated"], len(rec["people"])) == (2, 2, 0)
+        assert [r["name"] for r in rec["rows"]] == ["Uday Shankar", "Jeremiah A. Myers"]
 
     def test_mention_row_reports_the_name_production_would_use(self, monkeypatch):
         """A textless actor link is what the live run actually hit — the probe has to apply the same

--- a/tests/unit/test_linkedin_live_validation.py
+++ b/tests/unit/test_linkedin_live_validation.py
@@ -444,6 +444,66 @@ class TestFeedSortChainCopy:
 
 
 @pytest.mark.unit
+class TestRecommendationReadCopy:
+    """#1007's read is NEW, so the image the probe is piped into does not have it — and grounding a
+    rebuilt reader only after it merges is exactly how the ladder it replaces shipped dead. Same
+    posture as the feed-sort chain: image first, carried copy otherwise, and the reading says which.
+    A copy that drifts grounds a read nothing ships, which is worse than not probing at all."""
+
+    def test_carried_read_is_identical_to_the_one_run_automation_uses(self):
+        from cqc_lem.app import run_automation as ra
+
+        assert llv.FALLBACK_RECOMMENDATION_ROWS_JS == ra._RECOMMENDATION_ROWS_JS
+        assert llv.FALLBACK_RECOMMENDATION_RENDER_ATTEMPTS == ra._RECOMMENDATION_RENDER_ATTEMPTS
+
+    def test_the_running_image_wins_when_it_has_the_read(self):
+        from cqc_lem.app import run_automation as ra
+
+        read, attempts, source = llv.recommendation_read()
+        assert source == "image"
+        assert read is ra._recommendation_reading
+        assert attempts == ra._RECOMMENDATION_RENDER_ATTEMPTS
+
+    def test_falls_back_to_the_carried_copy_on_an_image_that_predates_1007(self, monkeypatch):
+        import builtins
+        real_import = builtins.__import__
+
+        def _no_read(name, *a, **k):
+            if name == "cqc_lem.app.run_automation":
+                raise ImportError("cannot import name '_recommendation_reading'")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", _no_read)
+        read, attempts, source = llv.recommendation_read()
+        assert source == "script"
+        assert read is llv._carried_recommendation_reading
+        assert attempts == llv.FALLBACK_RECOMMENDATION_RENDER_ATTEMPTS
+
+    def test_the_carried_copy_normalizes_what_the_page_hands_back(self):
+        driver = MagicMock()
+        driver.execute_script.return_value = {"rows": [{"href": "u"}, "junk"], "anchors": "24",
+                                              "page_dated": 1}
+        assert llv._carried_recommendation_reading(driver) == {
+            "rows": [{"href": "u"}], "anchors": 24, "page_dated": True}
+
+    def test_a_read_that_blows_up_is_an_empty_read_not_a_dead_probe(self):
+        empty = {"rows": [], "anchors": 0, "page_dated": False}
+        driver = MagicMock()
+        driver.execute_script.side_effect = Exception("session died mid-read")
+        assert llv._carried_recommendation_reading(driver) == empty
+        driver.execute_script.side_effect = None
+        driver.execute_script.return_value = "not a dict"
+        assert llv._carried_recommendation_reading(driver) == empty
+
+    def test_a_reading_taken_from_the_carried_copy_says_so(self):
+        verdict = llv.appreciation_verdict({"cards": 2, "dated": 2, "lookback_days": 30,
+                                            "people": [], "read_source": "script"})
+        assert "2 card(s), 2 dated" in verdict and "predates #1007" in verdict
+        assert "predates" not in llv.appreciation_verdict(
+            {"cards": 2, "dated": 2, "lookback_days": 30, "people": [], "read_source": "image"})
+
+
+@pytest.mark.unit
 class TestMain:
     def test_requires_something_to_probe(self):
         with pytest.raises(SystemExit):
@@ -545,6 +605,57 @@ class TestAppreciationSourcesProbe:
         rec = report["recommendations_received"]
         assert (rec["cards"], rec["dated"], len(rec["people"])) == (2, 2, 0)
         assert [r["name"] for r in rec["rows"]] == ["Uday Shankar", "Jeremiah A. Myers"]
+        assert rec["read_source"] == "image"
+
+    def test_an_image_that_predates_the_rebuild_still_grounds_both_surfaces(self, monkeypatch):
+        """The pre-merge run the owner asked for: the deployed image has no `_recommendation_reading`
+        to import, so a hard import would kill the whole probe — mentions half included — instead of
+        grounding the branch's read against the live DOM."""
+        import builtins
+        from unittest.mock import patch
+
+        real_import = builtins.__import__
+
+        def _no_read(name, *a, **k):
+            if name == "cqc_lem.app.run_automation" and "_recommendation_reading" in (a[2] or ()):
+                raise ImportError("cannot import name '_recommendation_reading'")
+            return real_import(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", _no_read)
+        driver = _fake_driver(current_url="https://www.linkedin.com/in/me")
+        driver.execute_script.return_value = {
+            "rows": [{"href": "https://www.linkedin.com/in/jane", "name": "Jane Doe",
+                      "text": "Jane Doe\n· 1st\nJuly 24, 2026, Jane was my client"}],
+            "anchors": 24, "page_dated": True}
+        with patch("cqc_lem.utilities.selenium_util.find_all_first", return_value=[]), \
+             patch("cqc_lem.utilities.db.has_appreciation_touch", return_value=False), \
+             patch("cqc_lem.app.run_automation._parse_recommendation_date", return_value=3.0):
+            report = llv.probe_appreciation_sources(driver, 1, "https://www.linkedin.com/in/me/",
+                                                    sleep=lambda s: None)
+
+        rec = report["recommendations_received"]
+        assert rec["read_source"] == "script"
+        assert (rec["cards"], rec["dated"]) == (1, 1)
+        assert "predates #1007" in rec["verdict"]
+        assert report["mentions"]["cards"] == 0
+
+    def test_an_early_paint_is_re_read_before_it_counts_as_an_empty_section(self):
+        """Production polls the render; the probe has to poll it too or it grounds a page that had
+        not finished painting and calls the section empty."""
+        from unittest.mock import patch
+
+        rows = {"rows": [{"href": "https://www.linkedin.com/in/jane", "name": "Jane Doe",
+                          "text": "July 24, 2026, Jane was my client"}],
+                "anchors": 24, "page_dated": True}
+        driver = _fake_driver(current_url="https://www.linkedin.com/in/me")
+        driver.execute_script.side_effect = [{"rows": [], "anchors": 0, "page_dated": False}, rows]
+        with patch("cqc_lem.utilities.selenium_util.find_all_first", return_value=[]), \
+             patch("cqc_lem.utilities.db.has_appreciation_touch", return_value=False), \
+             patch("cqc_lem.app.run_automation._parse_recommendation_date", return_value=3.0):
+            report = llv.probe_appreciation_sources(driver, 1, "https://www.linkedin.com/in/me/",
+                                                    sleep=lambda s: None)
+
+        assert report["recommendations_received"]["cards"] == 1
 
     def test_mention_row_reports_the_name_production_would_use(self, monkeypatch):
         """A textless actor link is what the live run actually hit — the probe has to apply the same


### PR DESCRIPTION
## What & why

The 2026-08-03 grounding run of #968 found the **mentions half works** and the **recommendations
half is dead on the live SDUI DOM**. Selector hit-counts on
`/in/<self>/details/recommendations/`:

```
main li 0 · main time 0 · [data-view-name] 0 · [role='tab'] 0
div[role='listitem'] 3 · main div[role=list] 1 · main a[href*='/in/'] 24
```

So every rung of `_RECOMMENDATION_CARD_LOCATORS` (all needed `//main//li`, one needed `.//time`)
and all three `_RECOMMENDATION_TAB_LOCATORS` (all needed `role='tab'` or a `<button>`) were
unmatchable: the scan read **0 cards forever** and skipped at DEBUG — the invisible-no-op class the
grounding runs exist to catch, and the flip-blocker for the recommendations source. The page's one
`main div[role=list]` is the **footer help-links list**, the same junk the #970 grounding hit, so
that is not an anchor either.

## The rebuild

`_RECOMMENDATION_ROWS_JS` reads the page in ONE `execute_script` pass — the same shape the
profile-viewer rebuild (#1009) uses on this DOM generation, so nothing goes stale while the list
re-renders under the walk:

- climb from each `main a[href*='/in/']` to the **outermost ancestor still about that ONE profile
  slug**, stopping the moment a second slug joins the block. Comparing *slugs* (not anchor counts)
  is what keeps a card whose avatar and name are two anchors to the same person intact;
- keep the block only when its text carries a `Month D, YYYY` line. That drops the **"Who your
  viewers also viewed"** rail structurally — its rows carry no date — rather than by class name,
  which is all this DOM has left;
- the name is the first non-empty line of the richest `/in/` anchor in the block, then
  `clean_person_name` (so `Uday Shankar\n· 1st\nGroup Supervisor…` → `Uday Shankar`).

`_parse_recommendation_date` and the 30-day window are unchanged, and still the authority: the JS
only proves the *shape*, so `February 30, 2026` is still skipped.

**`page_dated` replaces the old "cards but nothing dated" tripwire.** Zero cards on a page whose
text plainly carries a date is drift and **warns**; zero cards with no date is an account nobody
has recommended and stays a DEBUG no-op. Without that split the two readings are the same number —
precisely how the dead ladder survived a merge. A bounded render poll
(`_RECOMMENDATION_RENDER_ATTEMPTS`) keeps an early paint from reading as an empty section.

**Tab locators** are replaced, not dropped: rebuilt on the live anchor/text shape and still
best-effort (`warn_on_miss=False`). Owner-confirmed + captured: the bare URL already lands on
**Received**, so the click is only ever a correction; `?detailScreenTabIndex=2` is **Pending**,
whose rows read "Requested"/"Sent" — recommendation *requests*, never thank-worthy — and stay
excluded.

## Probe

`--appreciation-sources` drives the same read (it deliberately never calls the gated-off production
scrapers), and now reports `profile_anchors` + `page_dated` beside the card counts, with a verdict
that names a rotated read instead of calling it an empty surface:

```bash
sudo docker exec -i celery_worker_selenium python - --user-id 1 --appreciation-sources \
    < scripts/linkedin_live_validation.py
```

On this profile a correct pass reads **2 cards, 2 dated, 0 in-window** (the recommendations are
from 2010–2012, so a fixed reader still sends nothing today).

## Testing

- `poetry run pytest tests/unit -q` → **10201 passed**.
- `tests/unit/app/test_appreciation_sources.py::TestRecommendations` rewritten against the JS read:
  in-window / out-of-window, date-shaped-but-not-a-date, own-profile link, `WebDriverException` and
  non-dict script results, the render-poll retry, and the new drift-vs-empty split.
- `tests/unit/test_linkedin_live_validation.py` covers the new verdict branch and asserts the probe
  reproduces the issue's grounded reading (2 cards / 2 dated / 0 people).
- The JS itself was exercised against a shim DOM built from the captured page shape (2 real cards
  with duplicate avatar+name anchors, the "viewers also viewed" rail, the footer help-links list):
  2 rows out, correct names, rail and footer excluded; the single-card and empty-page cases stay
  bounded and quiet.

## Risk

`risk:live-linkedin`. The feature stays **OFF** (`APPRECIATION_SOURCES_ENABLED=false`) — this PR
only makes the reader capable of seeing the page, and the probe capable of proving it. Nothing is
messaged and no ledger row is claimed by either.

Refs: #968, PR #982 (grounding), #970/PR #984 and #1009 (same DOM class, same rebuild pattern).

Closes #1007

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Owner decision — `1A 2B` (2026-08-04)

**1A (ground it before merging)** needed a fix to be possible at all: the probe is piped into a
worker running the **released image**, which has no `_recommendation_reading` to import, so the
documented command would have died on `ImportError` before Chrome opened — and taken the mentions
half with it. A reader that can only be grounded *after* it merges is the exact trap #1007 is about.
The probe now takes the read from the running image when it has one and from an identical carried
copy when it does not (the posture `feed_sort_chains` already uses for #817), and names which in
`read_source` (`image` | `script`) and in the verdict. A `script` reading grounds THIS branch against
the live DOM; `TestRecommendationReadCopy` fails the build if the copy drifts. The probe also mirrors
production's render poll, so a page still painting is re-read rather than recorded as empty.

**2B (flag stays off)** — no change: `APPRECIATION_SOURCES_ENABLED` remains `false`; flipping it is
its own step.

The PR stays held until a live `--appreciation-sources` reading lands on this thread — that is what
1A asks for.
