### PR TITLE
docs(claude): trim CLAUDE.md to the map, relocate detail to docs/ (closes #1033)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,6 @@ compose/local/database/migrations/  Flyway migrations
   `log_warning` re-emits at ERROR and files ONE grouped `$exception`, so never warn on an expected
   no-op — log those DEBUG. Level table + escalation contract:
   **`src/cqc_lem/utilities/CLAUDE.md`** (auto-loads in that tree) and `docs/error-tracking.md`.
-
 - **Type hints:** Required on all function signatures.
 - **Enums:** Use `PostStatus`, `PostType`, `LogActionType` from `db.py` for status fields — never raw strings.
 - **Imports:** Absolute imports from `cqc_lem.*` throughout.
@@ -77,10 +76,10 @@ response = client.chat.completions.create(model="lem-simple", messages=[...])
 ```
 
 `AttributedOpenAI` is the ONE client — it stamps attribution + trace ids on every endpoint, and it
-**rides out a proxy that is not accepting connections** (#986, the proxy is a container LEM restarts
+**rides out a proxy that is not accepting connections** (#986; the proxy is a container LEM restarts
 on deploys): ONLY a connection that was never established is retried (`LLM_CONNECT_RETRY_ATTEMPTS` /
-`LLM_CONNECT_RETRY_BACKOFF_SECONDS`, ~24s default) — nothing was sent, so there's no spend to
-duplicate; a timeout, 4xx, or 5xx is the proxy answering and fails as before.
+`LLM_CONNECT_RETRY_BACKOFF_SECONDS`, ~24s default) — nothing was sent, so there is no spend to
+duplicate. A timeout, 4xx or 5xx is the proxy answering, and fails as before.
 
 **Model tier aliases** (defined in `.litellm/config.yaml`):
 
@@ -94,7 +93,7 @@ duplicate; a timeout, 4xx, or 5xx is the proxy answering and fails as before.
 | `lem-embedding` | Embeddings for feedback dedup/clustering (`client.embeddings.create`) |
 | `lem-router` | Auto-routes by prompt complexity via `LEMComplexityRouter` |
 
-**Cost-aware down-routing** (`utilities/routing_policy.py`, `utilities/cost_routing.py`): the router can route a tier ONE step down for the treatment cohort of an active cost/quality experiment. `routing_policy.py` is the shared decision core — the app imports it AND docker-compose mounts that same file into the LiteLLM container — so it must stay **stdlib-only** (no `cqc_lem.*` imports). Off unless BOTH `COST_ROUTING_ENABLED` and `COST_AWARE_ROUTING_ENABLED` are set. The treatment cohort comes from a PostHog experiment flag resolved app-side (#652), handed to the router via the policy document's `arms` map (hash stays as fallback) — `docs/cost-performance-margin-plan.md` §D.1.1.
+**Cost-aware down-routing** (`utilities/routing_policy.py`, `utilities/cost_routing.py`, `docs/cost-performance-margin-plan.md` §D.1.1): the router can route a tier ONE step down for the treatment cohort of an active cost/quality experiment (arm resolved app-side from a PostHog flag, #652, handed over in the policy document's `arms` map; hash stays as fallback). `routing_policy.py` is the shared decision core — the app imports it AND docker-compose mounts that same file into the LiteLLM container — so it must stay **stdlib-only** (no `cqc_lem.*` imports). Off unless BOTH `COST_ROUTING_ENABLED` and `COST_AWARE_ROUTING_ENABLED` are set.
 
 See `ai_helper.py` for the per-function model assignment.
 
@@ -104,7 +103,7 @@ per-surface presets (`newsletter`/`post_image`/`carousel`/`video`/`thumbnail`); 
 per-content-type prompt helper, add a preset. `utilities/ai/image_gen.py` renders it
 (`IMAGE_BACKEND`, cost-tracked); `render_image_gated` adds the bounded `lem-vision` check, failing
 OPEN. Avatar likeness NEVER renders in `image_gen` — `generate_post_image` (ai_helper) owns the LoRA
-path behind `avatar/guardrails.resolve_avatar_for`. NO text/logos in any render prompt.
+path behind `avatar/guardrails.resolve_avatar_for`. NO text/logos in a render prompt.
 
 ## Selenium Pattern
 
@@ -114,38 +113,37 @@ Use `click_element_wait_retry()` for all click interactions — it handles trans
 
 Browser capacity is a **fixed pool of Chrome session slots shared by the Celery Selenium lanes**:
 `SE_NODE_MAX_SESSIONS` must always equal the summed `SELENIUM_CONCURRENCY` of those lanes —
-`tests/unit/app/test_selenium_capacity.py` fails the build if they drift. The Phase-2 horizontal path
-(`docker-compose.grid.yml`: hub + N single-session nodes) carries the same invariant with node count
-as the cap; `python -m cqc_lem.utilities.selenium_load_test` sizes it. See `docs/SELENIUM_GRID.md`
-and `docs/scaling-plan.md`.
+`tests/unit/app/test_selenium_capacity.py` fails the build if they drift. The horizontal path
+(`docker-compose.grid.yml`) carries the same invariant with node count as the cap:
+`docs/SELENIUM_GRID.md`, `docs/scaling-plan.md`.
 
 ## Feature Areas
 
 ### Content generation & scheduling (`app/run_content_plan.py`, `app/run_scheduler.py`, `utilities/ai/ai_helper.py`)
 - AI content by buyer-journey stage (awareness / consideration / decision): thought-leadership, industry-news commentary, personal-story, engagement-prompt posts, carousels (educational / case-study / product-demo / insights), native video, blog summaries — a 30-day plan with balanced post-type distribution, auto-scheduled around golden/peak hours.
-- **Cadence (#621, `docs/content-scheduling.md`):** the plan is NOT one post a day — it fills `posts_per_week` slots (2–7, default 3) of a fixed day-type calendar (`POST_DAY_TYPES`) that also sets each post's buyer stage and archetype family. `posting_days` (#581, default Mon–Fri) is the separate, harder bound on WHICH days may carry a slot — weekends are opt-in.
+- **Cadence (#621, `docs/content-scheduling.md`):** the plan is NOT one post a day — it fills `posts_per_week` slots (2–7, default 3) of the fixed `POST_DAY_TYPES` calendar, which also sets each post's buyer stage and archetype family. `posting_days` (#581, default Mon–Fri) is the separate, harder bound on WHICH days may carry a slot — weekends are opt-in.
 - Self-healing carousels (stale/errored carousels re-generated into branded slides) and asset backfill.
-- **Newsletter cover images** (`utilities/newsletter_cover.py`, #893, `docs/newsletter-covers.md`): the ONE place a cover is validated, stored, and generated. Two sources, NOT symmetric — an **upload** is the author's own artwork so it lands `approved`; a **generated** cover always lands `pending_review` (a public brand asset). `_approved_cover_path` (run_automation) is the ONLY thing deciding a cover may reach LinkedIn. Generation is opt-in (`cover_image_auto`, off) and reuses the SHARED image path. Attaching is best-effort: `STEP_COVER` is never a graded editor step.
-- **Newsletter blog alignment** (`utilities/blog_source.py`, #967): `resolve_blog_source` is the ONE place the `align_with_blog` toggle (default ON) becomes source text — blog URL first, sitemap fallback, through the SAME fetchers `blog_summary`/`website_content` use. Best-effort, never blocking: unset/unreachable/empty returns `None` and the edition writes from topic + profile. Resolved PER edition, so queued drafts repurpose DIFFERENT articles. ON with nothing configured is an expected no-op (DEBUG) — only a configured source reading back empty warns.
+- **Newsletter cover images** (`utilities/newsletter_cover.py`, #893, `docs/newsletter-covers.md`): the ONE place a cover is validated, stored, and generated. An **upload** is the author's own artwork so it lands `approved`; a **generated** cover always lands `pending_review` (a public brand asset). `_approved_cover_path` (run_automation) is the ONLY thing deciding a cover may reach LinkedIn. Opt-in (`cover_image_auto`, off), SHARED image path, best-effort — `STEP_COVER` is never a graded editor step.
+- **Newsletter blog alignment** (`utilities/blog_source.py`, #967, `docs/content-core.md`): `resolve_blog_source` is the ONE place the `align_with_blog` toggle (default ON) becomes source text — blog URL first, sitemap fallback, SAME fetchers `blog_summary`/`website_content` use. Never blocking: nothing readable → `None` and the edition writes from topic + profile. Resolved PER edition, so queued drafts repurpose DIFFERENT articles. ON with nothing configured is an expected no-op (DEBUG).
 - `PostType` is `text` / `carousel` / `video`; `PostStatus` includes `error` for generation/posting failures needing manual fix.
 
 ### Engagement automation (`app/run_automation.py`) — full posture for every bullet below: `docs/engagement-automation.md`
-- **Feed commenting** rebuilt for LinkedIn's SDUI: resilient `find_first`/`click_first`/`find_all_first` selectors (`utilities/linkedin/helper.py`), inline compose+submit, **recency-dominant scoring matrix** (`_score_feed_post`), targeting + per-day caps + voice/tone. Runs pre-post (~15 min before) and daily at a golden hour. **Best-effort but never silent (#817):** `_switch_feed_to_recent` returns the run's sort state (`recent`/`top`/`missing`/`unknown`/`n/a`) onto the feed funnel + `feed_scan` event — an unsorted scan must never read as recency-sorted. Live: `linkedin_live_validation.py --feed-sort`.
+- **Feed commenting** on LinkedIn's SDUI: resilient `find_first`/`click_first`/`find_all_first` selectors (`utilities/linkedin/helper.py`), inline compose+submit, **recency-dominant `_score_feed_post`**, targeting + per-day caps + voice/tone. Runs pre-post (~15 min before) and daily at a golden hour. **Never silent (#817):** `_switch_feed_to_recent` reports the run's sort state (`recent`/`top`/`missing`/`unknown`/`n/a`) onto the feed funnel + `feed_scan` — an unsorted scan must never read as recency-sorted.
 - **Replies** to comments on the user's own posts (`automate_reply_commenting`); **seed a first comment** on own posts (`auto_seed_comment_on_post`).
-- **Golden-hour presence** (`utilities/golden_hour.py`, #622): ONE `golden_hour_report` per swept post, measured off REAL publish time from the POST log, never `scheduled_time` — unmeasured is never on-time. **Second wave**: ONE self-comment 6–8h later (`auto_second_wave_comment`) that must ADD substance (#617 contract + similarity gate + slop lint); seed + second wave can never stack (`SELF_COMMENT_MAX_PER_POST=2`).
-- **DM conversation auto-nurture** (`_nurture_after_reply`, `utilities/ai/dm_nurture.py`): a reply is classified into an **approval-gated** next message (`pending` row, `source='nurture'`), one open draft per thread; explicit disinterest stops the thread for good.
+- **Golden-hour presence** (`utilities/golden_hour.py`, #622): ONE `golden_hour_report` per swept post, measured off REAL publish time from the POST log, never `scheduled_time` — unmeasured is never on-time. **Second wave**: ONE self-comment 6–8h later (`auto_second_wave_comment`) that must ADD substance (#617 contract + similarity gate + slop lint); seed + second wave never stack (`SELF_COMMENT_MAX_PER_POST=2`).
+- **Human pacing** (`utilities/human_pacing.py`, #626): the ONE place cadence is decided — read-time delay, dispatch jitter, per-day-cap draw, all seeded on (user, action, date) and persisted in Redis so a retry never re-rolls. Fails open. Pacing only slows us down; the 429 breaker in `rate_limit.py` is the separate, harder gate.
+- **DM conversation auto-nurture** (`_nurture_after_reply`, `utilities/ai/dm_nurture.py`): a reply becomes an **approval-gated** next message (`pending` row, `source='nurture'`), one open draft per thread; explicit disinterest stops the thread for good.
 - **Reciprocity tracking** via the `post_engagers` table — boosts commenting back on people who engaged with us (`get_recent_engagers`).
 - **DMs**: appreciation (connection / recommendation / collaboration), profile-viewer outreach, **multi-touch follow-up sequences** — templated and voice-aligned (`build_dm_from_template`, `dm_templates`, `dm_followups`, `process_user_followups`).
-- **Appreciation sources** (#968): recommendation + collaboration read STANDING lists, not event queues, so an **undated card is SKIPPED** and only `APPRECIATION_LOOKBACK_DAYS` (30) counts. `appreciation_touches` is the durable CLAIM (checked before write, claimed before send) that stops double-thanking on the ~60s re-queue; `_appreciation_dm_budget` (SHARED cap + #626 envelope) bounds it — unaffordable claims stay UNCLAIMED. OFF until live-grounded (`APPRECIATION_SOURCES_ENABLED`).
-- **Message-thread resolution ladder** (`utilities/linkedin/message_thread.py`, #731): `open_message_thread` walks SIX routes; a route counts only when the thread is **provably open** — never class names, only href/aria-label/TEXT. Verdict is **three-valued** (`ThreadState.REPLIED`/`NOT_REPLIED`/`UNKNOWN`); UNKNOWN SKIPS. Self-name is a required setting (`users.linkedin_display_name`), never scraped.
-- **Owned-asset CTA loop** (`resolve_artifact_delivery` in `content_alignment.py` + `_queue_artifact_delivery`, #624): the ONE map from a CTA to its asset, naming the CHANNEL — **lead magnet** is the comment-keyword mechanic whose payload is a DM; **newsletter** is a subscribe LINK. Keyword delivery is **approval-gated** (`pending` `scheduled_dms` row, `source='artifact'`).
-- **Human pacing** (`utilities/human_pacing.py`, #626): the ONE place cadence is decided — read-time delay, dispatch jitter, per-day-cap draw, all seeded on (user, action, date) and persisted in Redis so a retry never re-rolls. Fails open (no Redis / `HUMAN_PACING_ENABLED=false`). Pacing only slows us down; the 429 breaker in `rate_limit.py` is the separate, harder gate.
-- **Comment outcome tracking** (`sweep_comment_outcomes` + `utilities/comment_outcomes.py`, #628): read-only T+24h sweep writes ONE `comment_outcomes` row per comment — replies, likes, and a **three-valued** `visible_most_relevant` (1 relevant / 0 demoted / NULL unreadable, excluded from the denominator). Demotion rate over threshold **holds that user's feed commenting** and escalates CRITICAL.
-- **Suppression tripwire** (`auto_suppression_tripwire` + `utilities/suppression.py`, #629): 2026 LinkedIn penalties are SILENT. A daily beat compares impressions-per-post against the user's OWN trailing 14-day median; a sustained drop `pause_automation()`s **engagement only** (posting is never gated) and escalates CRITICAL. Cold start / thin baseline = `unknown`, never actioned. Recovery is human (`POST /user/automation-resume`).
-- **Weekly group post** (`auto_draft_group_post` → `auto_post_to_group`, #932): TWO beats with a review window between them — Sun writes the text (no browser), Tue publishes that draft and generates NOTHING, so **a run with no READY draft publishes nothing**. Resting status is `ready` so silence ships it; `GroupsCard` is where a user rewrites or skips. ONE open draft per user, carried forward, never replaced.
-- **Roster targets LEM can't comment on** (`comment_on_roster_posts` + `auto_follow_roster_target`, #962): posts but ZERO commentable cards records a blocked visit; a whole roster blocked (`_card_for_textbox` drift) records nothing. Auto-follow is opt-in and OFF (`roster_auto_follow`), draws `ACTION_FOLLOW`/`max_follows_per_day` bounded by (never in) the account envelope, and clicks NOTHING unless the control names the page owner.
-- **Roster connect escalation** (`advance_roster_connect`, #979): the rung above follow — blocked → follow → STILL blocked → `needs_connection` → (opt-in `roster_auto_connect`, OFF) ONE invite. `needs_connection` needs EVIDENCE (`following` + a blocked visit AFTER `followed_at`); a target never followed is never escalated, and a landed comment stands the escalation back down. Read-only advancement (`requested`/`connected` off the open page) is free and ungated. The invite rides the EXISTING rail (`invite_to_connect_now` via `send_roster_connect_invite`) — never a new mechanic, never Outreach/Leads — spends the SHARED `max_invites_per_day` at ≤ `ceil(remaining/3)`, ONE shot per target (`requested` written BEFORE dispatch; only a throttled send that never reached LinkedIn is handed back). `ConnectStatus` is the ONE vocabulary.
-- **Stale-invite withdrawal** (`utilities/linkedin/stale_invites.py`, #969): withdrawing is ONE-WAY (~3 weeks before a re-invite), so reads fail CLOSED — an unreadable "Sent … ago" is NEVER stale, only the row's OWN `Sent` line is parsed. OFF until `STALE_INVITE_WITHDRAWAL_ENABLED` (ground: `linkedin_live_validation --sent-invites`). `plan_withdrawals` decides the allowance BEFORE Chrome opens, bounded by (never in) the envelope; spend counted on the CLICK.
+- **Appreciation sources** (#968): recommendation + collaboration read STANDING lists, not event queues, so an **undated card is SKIPPED** and only `APPRECIATION_LOOKBACK_DAYS` (30) counts. `appreciation_touches` is the durable CLAIM against double-thanking on the ~60s re-queue; `_appreciation_dm_budget` (SHARED cap + #626 envelope) bounds it. OFF until live-grounded (`APPRECIATION_SOURCES_ENABLED`).
+- **Message-thread ladder** (`utilities/linkedin/message_thread.py`, #731): `open_message_thread` walks SIX routes; a route counts only when the thread is **provably open** — never class names, only href/aria-label/TEXT. `ThreadState` is **three-valued** (`REPLIED`/`NOT_REPLIED`/`UNKNOWN`); UNKNOWN SKIPS. Self-name is a setting (`users.linkedin_display_name`), never scraped.
+- **Owned-asset CTA loop** (`resolve_artifact_delivery` in `content_alignment.py` + `_queue_artifact_delivery`, #624): the ONE map from a CTA to its asset, naming the CHANNEL — **lead magnet** is a comment-keyword mechanic paying out a DM, **newsletter** a subscribe LINK. Keyword delivery is **approval-gated** (`pending` `scheduled_dms`, `source='artifact'`).
+- **Comment outcome tracking** (`sweep_comment_outcomes` + `utilities/comment_outcomes.py`, #628): read-only T+24h sweep, ONE `comment_outcomes` row per comment — replies, likes, **three-valued** `visible_most_relevant` (1 relevant / 0 demoted / NULL unreadable, excluded from the denominator). Demotion over threshold **holds that user's feed commenting** + CRITICAL.
+- **Suppression tripwire** (`auto_suppression_tripwire` + `utilities/suppression.py`, #629): 2026 LinkedIn penalties are SILENT, so a daily beat compares impressions-per-post against the user's OWN trailing 14-day median; a sustained drop `pause_automation()`s **engagement only** (posting is never gated) + CRITICAL. Thin baseline = `unknown`, never actioned. Recovery is human (`POST /user/automation-resume`).
+- **Weekly group post** (`auto_draft_group_post` → `auto_post_to_group`, #932): TWO beats with a review window between — Sun writes the text (no browser), Tue publishes that draft and generates NOTHING, so **a run with no READY draft publishes nothing**. Resting status is `ready` so silence ships it; ONE open draft per user, carried forward, never replaced.
+- **Roster targets LEM can't comment on** (`comment_on_roster_posts` + `auto_follow_roster_target`, #962): posts but ZERO commentable cards records a blocked visit; a whole roster blocked (`_card_for_textbox` drift) records nothing. Auto-follow is opt-in/OFF (`roster_auto_follow`), draws `ACTION_FOLLOW`/`max_follows_per_day` bounded by (never in) the account envelope, and clicks NOTHING unless the control names the page owner.
+- **Roster connect escalation** (`advance_roster_connect`, #979): blocked → follow → STILL blocked → `needs_connection` → (opt-in `roster_auto_connect`, OFF) ONE invite. `needs_connection` needs EVIDENCE (`following` + a blocked visit AFTER `followed_at`); a landed comment stands it back down. The invite rides the EXISTING rail (`send_roster_connect_invite` → `invite_to_connect_now`), spends the SHARED `max_invites_per_day` at ≤ `ceil(remaining/3)`, ONE shot per target (`requested` written BEFORE dispatch). `ConnectStatus` is the ONE vocabulary.
+- **Stale-invite withdrawal** (`utilities/linkedin/stale_invites.py`, #969): withdrawing is ONE-WAY (~3 weeks before a re-invite), so reads fail CLOSED — an unreadable "Sent … ago" is NEVER stale, only the row's OWN `Sent` line is parsed. `plan_withdrawals` decides the allowance BEFORE Chrome opens, bounded by (never in) the envelope. OFF until `STALE_INVITE_WITHDRAWAL_ENABLED`.
 - **Company-page invitations** (`utilities/linkedin/company_page_inviter.py`, #732): a paced DAILY drip bounded by the SMALLEST of three ceilings — per-day cap, credit spread (`credits_remaining / days_left_in_month`), live credit count. `plan_daily_invites` decides all of that BEFORE a Chrome session opens.
 
 ### Engagement configuration (`engagement_preferences` table, API in `api/main.py`, SPA in `ui/.../Account.tsx`)
@@ -154,19 +152,20 @@ and `docs/scaling-plan.md`.
 - **Caps:** `max_comments_per_day`, `max_dms_per_day`; DM template editor with follow-up steps; Login Location (city/state geocoding via `utilities/geocoding.py`, admin-overridable).
 
 ### Marketing video tutorials (`utilities/marketing/video_tutorials.py`, beat `produce-feature-tutorial`)
-- One declarative `TutorialFlow` per feature (routes + CSS anchors proving the screen rendered) → headless SPA capture → grounded script (`lem-medium`) → TTS → ffmpeg MP4 + `.srt` → 9:16 clip → YouTube upload. **Fail-closed, cheapest-first**: a missing UI anchor, an unparseable script, profanity, an over-cap narration, or a fabricated number aborts BEFORE any TTS/publish spend. A flow is re-filmed only when its captured UI fingerprint changes; state in `assets/videos/tutorials/manifest.json`, embedded by `TutorialVideos.tsx`. OFF unless `TUTORIAL_VIDEOS_ENABLED`. Full posture: `docs/marketing-video-tutorials.md`.
+- One declarative `TutorialFlow` per feature (routes + CSS anchors proving the screen rendered) → headless SPA capture → grounded script (`lem-medium`) → TTS → ffmpeg MP4 + `.srt` → 9:16 clip → YouTube upload. **Fail-closed, cheapest-first**: a missing anchor, an unparseable script, profanity, an over-cap narration, or a fabricated number aborts BEFORE any TTS/publish spend. Re-filmed only when the captured UI fingerprint changes (`assets/videos/tutorials/manifest.json`). OFF unless `TUTORIAL_VIDEOS_ENABLED`. Full: `docs/marketing-video-tutorials.md`.
 - **YouTube OAuth token** (`youtube_auth.py`, #742): the ONE place its state is decided. Read DB-first (`app_credentials`, installed via `POST /admin/youtube-token` — no deploy), `YOUTUBE_REFRESH_TOKEN` seeds it. `unknown` (Google unreachable) is NOT `needs_reauth` (4xx / lost scope — the only state that alerts). Weekly beat `youtube-token-check` IS the keep-alive vs the 6-month-disuse expiry — never drop it while the feature is off. Full: `docs/youtube-publishing.md`.
 
 ### Anti-bot / session infra
 - Per-user static residential proxy (`utilities/proxy.py`) + an in-memory **MV3 proxy-auth extension** (`_build_proxy_auth_extension_b64` in `selenium_util.py`) — never URL-embedded credentials, since MV2 background pages are disabled in Chrome 149+.
 - Cookie persistence (`li_at` is the DEFAULT engagement login since #745) + an email-PIN verification flow (`utilities/linkedin/verification_pin.py`).
-- **Sign-in visibility** (`utilities/linkedin/login_status.py`, #933): `_persist_session_cookies` is where both login paths meet, so it's where a sign-in is recorded (`mark_signed_in`); the device-approval wait loop always closes `approval_pending` — `approval_timed_out` on giving up, `mark_signed_in` the moment it clears (never keep asking for a tap already given). Redis-backed, fails open: `unknown` means nothing recorded, NOT a broken connection. `GET /user/linkedin-signin-status` → `LinkedInSignInStatusCard.tsx`.
-- **OAuth token renewal** (`utilities/linkedin/token_refresh.py`, #600): `resolve_token_status` is the ONE place token state is decided — SPA countdown and renewal beat read the same function. LinkedIn caps auth at 60 days, so the daily beat `refresh-linkedin-tokens` (08:30) renewing everyone inside `EXPIRY_WARNING_DAYS` is the only way a token outlives that. "No refresh token" is an expected no-op (DEBUG) → a throttled reconnect email (`LINKEDIN_TOKEN_EMAIL_THROTTLE_DAYS`, Redis, fails open). `days_remaining` is `None`, never 0, when unreadable.
+- **Sign-in visibility** (`utilities/linkedin/login_status.py`, #933, `docs/linkedin-session-health.md`): `_persist_session_cookies` is where both login paths meet, so it's where a sign-in is recorded (`mark_signed_in`); the device-approval wait loop always closes `approval_pending` (never keep asking for a tap already given). Redis-backed, fails open: `unknown` means nothing recorded, NOT a broken connection.
+- **OAuth token renewal** (`utilities/linkedin/token_refresh.py`, #600, same doc): `resolve_token_status` is the ONE place token state is decided — SPA countdown and renewal beat read the same function. LinkedIn caps auth at 60 days, so the daily beat `refresh-linkedin-tokens` (08:30) renewing everyone inside `EXPIRY_WARNING_DAYS` is the only way a token outlives that. `days_remaining` is `None`, never 0, when unreadable.
 - 429 / auth-wall backoff and resilience (`utilities/linkedin/rate_limit.py`).
 - **Secrets at rest** (`utilities/crypto.py`, #745): `li_at`, OAuth tokens and the stored password are AES-256-GCM envelopes keyed per user+column off `LEM_SECRET_KEY`; `db.py` is the ONE caller and the field-name constants are AAD — renaming one orphans every row. Reads dual-mode until `ENCRYPTION_REQUIRED`; failed decrypt → None. Daily `auto_encrypt_secrets_at_rest` backfills AND rotates. Full: `docs/secrets-at-rest.md`.
-- **LEM identity + sessions** (#745 phase 2b, `docs/identity-and-sessions.md`): `users.public_uid` is the identity; email is a movable ATTRIBUTE (`change_user_email`, PIN to the NEW address, other sessions revoked). `sessions.session_token` stores `SHA-256(token)` — UNKEYED, so a rotated `LEM_SECRET_KEY` never logs everyone out — in an **httpOnly** cookie. `api/main.get_session_user_id()` is the ONE resolver: an explicit token that RESOLVES wins, else the cookie (the SPA sends sentinel `'cookie'`). **Since #914 EVERY `/api` route resolves its caller through it** — `require_session_user_id()` is it plus a 401; an `email`/`user_id`/`post_id` is a TARGET to authorise (403 + audited `foreign_target_denied`), not the actor; `db.user_owns_posts` FAILS CLOSED; a DB fault is **503** not 403. **CSRF (#957):** a cookie-authenticated `/api` write must send `X-LEM-Client` — 403 `client_header_required`. The shared bearer (`API_ACCESS_TOKENS`) is a NON-BROWSER credential since #950 — never in the SPA build. Auth limiting is TWO layers: Redis windows (fails open) + the durable PIN lockout in `verify_pin_for_email`; all lands in `auth_audit_log`. **The docs surface is INSIDE `/api`** (#1020): `/api/docs`, `/api/redoc`, `/api/openapi.json` (old paths 301), public leaf entries in `_PUBLIC_API_PREFIXES` — but `_hide_admin_routes_from_schema()` keeps every `/api/admin/*` operation OUT of the published schema, derived from the route table so a new admin route inherits it. Hidden ≠ gated: their auth is unchanged, and Swagger can no longer drive them (curl/Postman per `docs/TESTING_ENGAGEMENT_API.md`). The unauthenticated `GET /health/deep` returns COUNTS only — no worker or queue names — and `"status":"healthy"` stays the first key, a monitor contract (`docs/stack-watchdog.md`).
-- **Strong auth + step-up** (#745 phase 2c, `docs/strong-authentication.md`): `utilities/auth_factors.py` is the ONE place factor state is decided (`webauthn_util.py` holds the ceremonies). Once an account enrols a passkey or TOTP the email PIN is a **bootstrap** only. A **passkey** login is the only path arriving already stepped up; a **recovery code** never does. `sessions.last_verified_at` gates every credential-touching write — refusal is **403 `step_up_required`**, never 401. **The FIRST factor is free, every one after it is gated, removing one always is**; a `scope='recovery'` session may enrol but is never stamped for it. A pending second-factor handle is burned by the `SECOND_FACTOR_MAX_ATTEMPTS`-th wrong code — durable in `auth_challenges.attempts`, counted **per account** over `SECOND_FACTOR_ATTEMPT_WINDOW_MINUTES` and carried into the next handle: **401 = wrong code, retry; 400 = handle gone; 429 = budget spent**. `STRONG_AUTH_ENABLED=false` reverts to 2b.
-- **Session scopes are SURFACES** (#905, 2c.1): the same resolver enforces scope everywhere. `extension` reaches only the ONE path the extension calls (else 403 + audited `session_scope_denied`) and steps up once in the SPA at `/user/extension-token`; `enroll` — a PIN login past `REQUIRE_STRONG_FACTOR_AFTER` on a factor-less account — reaches only enrolment, which promotes it to `full`. **A hold is never a lockout:** the PIN still signs you in, and every read goes through `enrollment_hold_active()`. Empty date (the default) = 2c behaviour exactly. **`agent`** (#1026) is the headless credential — minted once by a human, reaches the queueing surface only, TTL fixed at mint (the ONE scope `resolve_session` never slides). It may queue but NEVER approve, and that needs THREE guards because a row reaches APPROVED three ways: `action="approve"`, `status="approved"` at create, and the `auto_approve` account default. Surfaces match on PATH not method, so an entry granted to read grants its writes too — `/user/engagement-preferences` is refused for an agent. Full: `docs/identity-and-sessions.md`.
+- **LEM identity + sessions** (#745 phase 2b, `docs/identity-and-sessions.md`): `users.public_uid` is the identity; email is a movable ATTRIBUTE (`change_user_email`, PIN to the NEW address, other sessions revoked). `sessions.session_token` stores an UNKEYED `SHA-256(token)` — a rotated `LEM_SECRET_KEY` must never log everyone out — in an **httpOnly** cookie. `api/main.get_session_user_id()` is the ONE resolver (explicit token that RESOLVES wins, else the cookie; the SPA sends sentinel `'cookie'`), and **since #914 EVERY `/api` route resolves its caller through it**: `require_session_user_id()` is it plus a 401; an `email`/`user_id`/`post_id` is a TARGET to authorise (403 + audited `foreign_target_denied`), never the actor; `db.user_owns_posts` FAILS CLOSED; a DB fault is **503**, not 403. **CSRF (#957):** a cookie-authenticated `/api` write must send `X-LEM-Client` (403 `client_header_required`). The shared bearer (`API_ACCESS_TOKENS`) is a NON-BROWSER credential since #950 — never in the SPA build. Auth limiting is Redis windows (fails open) + the durable PIN lockout in `verify_pin_for_email`, all audited in `auth_audit_log`.
+- **The docs surface is INSIDE `/api`** (#1020): `/api/docs`, `/api/redoc`, `/api/openapi.json` (old paths 301), re-opened as leaf entries in `_PUBLIC_API_PREFIXES`; `_hide_admin_routes_from_schema()` keeps every `/api/admin/*` operation OUT of the published schema, derived from the route table so a new admin route inherits it. Hidden ≠ gated — their auth is unchanged, Swagger just can't drive them (curl/Postman per `docs/TESTING_ENGAGEMENT_API.md`). The unauthenticated `GET /health/deep` returns COUNTS only, `"status":"healthy"` first — a monitor contract (`docs/stack-watchdog.md`). Mechanism: `docs/identity-and-sessions.md`.
+- **Strong auth + step-up** (#745 phase 2c, `docs/strong-authentication.md`): `utilities/auth_factors.py` is the ONE place factor state is decided (`webauthn_util.py` holds the ceremonies). Once an account enrols a passkey or TOTP the email PIN is a **bootstrap** only; a **passkey** login is the only path arriving already stepped up, a **recovery code** never does. `sessions.last_verified_at` gates every credential-touching write — refusal is **403 `step_up_required`**, never 401. **The FIRST factor is free, every one after it is gated, removing one always is.** Second-factor attempts are durable (`auth_challenges.attempts`), counted **per account** over `SECOND_FACTOR_ATTEMPT_WINDOW_MINUTES` and carried into the next handle: **401 = wrong code, retry; 400 = handle gone; 429 = budget spent**. `STRONG_AUTH_ENABLED=false` reverts to 2b.
+- **Session scopes are SURFACES** (#905 / #1026, `docs/identity-and-sessions.md`): the same resolver enforces scope everywhere; refusal is 403 + audited `session_scope_denied`. `extension` reaches only the ONE path the extension calls; `enroll` — a PIN login past `REQUIRE_STRONG_FACTOR_AFTER` on a factor-less account — reaches only enrolment, which promotes it to `full` (**a hold is never a lockout:** the PIN still signs you in, every read goes through `enrollment_hold_active()`; empty date = 2c behaviour exactly). **`agent`** is the headless credential — minted once by a human, `_AGENT_SESSION_SURFACE` (queueing) only, TTL fixed at mint (the ONE scope `resolve_session` never slides). It may queue but NEVER approve — THREE guards, because a row reaches APPROVED three ways: `action="approve"`, `status="approved"` at create, the `auto_approve` account default. Surfaces match on PATH not method, so granting a read grants its writes — hence `PUT /user/engagement-preferences` is separately refused (`agent_may_not_configure`).
 
 ## Testing Standards
 
@@ -178,100 +177,24 @@ and `docs/scaling-plan.md`.
 ## Observability
 
 Track events via `utilities/observability.py` (`track_llm_call` / `track_task` / `track_api_call`).
-Each subsection below is a one-paragraph invariant; rationale, contracts, sample code, and edge
-cases live in the pointed-to doc. Plan with this section, drill in with the doc.
+One row per surface below: the ONE module and the invariant that bites. The paragraph behind each
+row is `docs/observability-map.md`; the doc in the last column holds rationale, contracts and edge
+cases. Plan with this table, drill in with the doc.
 
-### LLM analytics (issue #647, traces #746) — `docs/llm-analytics.md`
-Two streams, never summed: `llm_call` (app, cost ESTIMATE — every money question reads this) vs
-`$ai_generation`/`$ai_embedding` (proxy-native, post-fallback, provider-priced — latency/error/
-volume). Attribution lives in `utilities/ai/client.py` (the ONE client); `_attach_routing_metadata`
-must stay. **Pipeline traces** group a post/edition/comment's 5–6 calls into ONE `$ai_trace` with
-per-step `$ai_span`s: `@llm_pipeline` on the three roots (`create_text_post`,
-`generate_newsletter_edition`, `generate_ai_response` — supersedes `attribute_llm_cost`), `@llm_step`
-on the SHARED-core step functions (never at a call site). Ids ship two ways since LiteLLM reads them
-from two places — trace id in the `x-litellm-trace-id` HEADER, parent span in
-`metadata.parent_run_id`. Nested trace = span; span with no trace = no-op;
-`LLM_TRACING_ENABLED=false` mints nothing.
-
-### Error tracking (issue #648) — `docs/error-tracking.md`
-Logs (`logger.py` → PostHog Logs) carry message+context; `$exception` is the grouped/fingerprinted
-ISSUE alerting + the error→GitHub-issue cron — NOT redundant. Use
-`observability.capture_exception(...)` for caught-and-not-reraised (`posthog.capture_exception` is
-idempotent). Never capture `HTTPException` — 4xx is a response, not an issue.
-
-### Browser-side analytics (issue #646) — `docs/posthog-advanced-surface.md`
-ONE SPA surface: `ui/src/utils/analytics.ts` — never call `posthog` directly. `distinct_id =
-String(user_id)` matches `observability.py` so browser+Celery+proxy share ONE PostHog person.
-Env-gated at BUILD time (`VITE_POSTHOG_KEY`); no key → lazy chunk never fetched → no-op.
-`maskProps()` adds `ph-no-capture` + `data-ph-mask` — use it on every content editor.
-
-### Session replay (issue #649) — `docs/session-replay.md`
-Rules live in the SDK: `VITE_POSTHOG_REPLAY_SAMPLE` slice + EVERY `$exception`/feedback session, both
-via one `ensureSessionRecorded()`. Local `sampleRate` takes precedence — never set project sampling
-(multiplies). Canvas off; inputs masked; network capture timings only.
-
-### KPI funnels, dashboards, alerts + weekly report (issue #650) — `docs/kpi-dashboards.md`
-`scripts/posthog_provision.py` owns Health + Growth dashboards, four threshold alerts, the weekly
-Growth email. Alert tiles must be native single-series `TrendsQuery` filtering on STRING props
-(boolean filters match nothing → silent alerts). Money tiles read `$ai_generation`, never `llm_call`.
-`mark_rate_limited()` emits `rate_limit_trip` (a WARNING log never reaches PostHog).
-
-### Experiments (issue #652) — `docs/experiments.md`
-`utilities/experiments.py` is the adapter onto PostHog Experiments, NOT a third implementation.
-**Unresolvable experiment = CONTROL arm** (no key, `EXPERIMENTS_ENABLED=false`, inconclusive, SDK
-raises — no env fallback per experiment). Flags must use rollout-% / distinct-ID only. Three
-registered: `cost-routing-arm`, `comment-contract-prompt`, `post-media-variant`.
-
-### Marketing attribution — UTMs (issue #658) — `docs/marketing-attribution.md`
-`utilities/marketing/attribution.py` is the ONE place. Two rules: only OWNED destinations tagged
-(`is_owned_link`); existing UTMs never overwritten (`build_utm_url` fills missing only,
-`mark_placement` replaces `utm_content` only). `signup_completed_web` (browser) ≠ `signup_completed`
-(API) — never summed.
-
-### Model-tier evaluation harness (issue #721) — `docs/model-benchmarks/README.md`
-`scripts/benchmark_models.py` measures candidates vs each tier's contract suite (NO user data),
-always beside the current champion. Deterministic is source of truth (in-repo linters, not a copy);
-LLM judge is PostHog Evaluations filtered on `benchmark_run_id` (production never carries it → the
-customer is never billed). **The suite scores a FIRST draft, production ships an n-th** (#910), so
-every check is classed by what production does with its failure: `contract` (the call site consumes
-it — the ABSOLUTE floor) vs `repairable` (a regeneration gate retries it — advisory). A case whose
-`max_tokens` mirrors a call site (`budget_mirrors_production`) is never retried at a bigger budget;
-an EMPTY completion is re-measured at the same one. Same at RUN scope (#923): a run where every case
-of every model errored is a harness outage, not a scorecard of zeros, and is REFUSED (no report, exit
-1); a partial failure publishes with an `Unmeasured cases` count. Only `recommend` becomes a swap,
-and recommendations are RENDERED, never written (`.litellm/model_upgrades.yaml` is the retirement map).
-
-### Content-quality telemetry (issue #630) — `docs/content-quality-telemetry.md`
-`auto_nightly_content_quality` is the TREND LINE (other gates are one-time verdicts). Scores
-posts/comments/editions into `content_quality_scores`: weighted slop (HARD ×3), self-similarity,
-**stored** authenticity (no fresh judge call), hook length, impression-weighted ER. **Unscored is
-never zero** — each dimension has its own sample size. Never pauses (drift → go look at prompts;
-safety is #629).
-
-### Feature flags (issue #651) — `docs/feature-flags.md`
-`utilities/flags.py` is the ONE place; **fail open to env var** (no key, disabled, undefined,
-inconclusive, SDK raises → all return the flag's env var). `only_evaluate_locally=True` → ZERO
-network per check, flip lands without restart. Flags must use rollout-% / distinct-ID only. Read at
-CALL SITE, never at import. **Safety controls are NOT flags** (429 breaker, holds, pauses, per-day
-caps stay in Redis/env). SPA bootstraps from `GET /api/flags` — not through posthog-js.
-
-### Surveys — NPS/CSAT (issue #653) — `docs/surveys.md`
-TWO owners. PostHog Surveys: NPS (30d past ACTIVATION, not signup) + post-quality CSAT (on
-`post_approved` once `posts_approved >= 5`). `utilities/surveys.py` keeps the bespoke ones —
-trial-T-3d review (#499) + fix CSAT (#502). Type **`api`**, rendered headless in
-`PostHogSurveyModal.tsx`. ONE answer = TWO paths (browser native `$survey_response` + POST
-`/api/survey/posthog` → `feedback` row), counted ONCE — `track_survey_response` deliberately NOT
-emitted. Detractor (NPS ≤6 / CSAT ≤2) or any free text stays `new`; happy+blank → `resolved`.
-`markSurveySeen()` advances the 30d wait — drop it and the throttle silently stops.
-
-### Endpoints panel + release annotations (issue #654) — `docs/kpi-dashboards.md`
-**Endpoints** (PostHog beta): HogQL as a versioned cached HTTP route — the Dashboard's "Live stats"
-with no MySQL reporting layer. Every query scoped with `distinct_id = {variables.distinct_id}` (ONE
-shared project → un-scoped leaks across customers); resolves against ONE `InsightVariable`, and the
-endpoint is `blocked_endpoint` until it exists. `GET /user/posthog-stats` is server-side only — the
-personal API key never reaches the browser; any failure → `available: false` for that panel.
-**Release annotations**: `scripts/posthog_annotate.py` posts `"vX.Y.Z deployed"` per deploy; needs
-the `POSTHOG_PERSONAL_API_KEY` GH secret; absent/outage → no-op, never a failed release.
+| Surface | The ONE place | The invariant that bites | Doc |
+|---|---|---|---|
+| **LLM analytics** (#647, traces #746) | `utilities/ai/client.py` (+ `@llm_pipeline` / `@llm_step`) | `llm_call` (app estimate — every money question) and `$ai_generation` (provider-priced) are NEVER summed; both client hooks must stay; `@llm_step` goes on the SHARED-core step function, never a call site | `docs/llm-analytics.md` |
+| **Error tracking** (#648) | `logger.py` + `observability.capture_exception` | Logs ≠ `$exception`: the grouped issue is what alerts and files GitHub issues. Never capture `HTTPException` — 4xx is a response | `docs/error-tracking.md` |
+| **Browser analytics** (#646) | `ui/src/utils/analytics.ts` | Never call `posthog` directly; `distinct_id = String(user_id)` so browser+Celery+proxy are ONE person; build-time gated (`VITE_POSTHOG_KEY`); `maskProps()` on every content editor | `docs/posthog-advanced-surface.md` |
+| **Session replay** (#649) | `ensureSessionRecorded()` | Rules live in the SDK: `VITE_POSTHOG_REPLAY_SAMPLE` slice + EVERY `$exception`/feedback session. Never set project sampling — it multiplies | `docs/session-replay.md` |
+| **KPI dashboards + alerts** (#650) | `scripts/posthog_provision.py` | Alert tiles must be native single-series `TrendsQuery` on STRING props (a boolean filter matches nothing → silent alert); money tiles read `$ai_generation` | `docs/kpi-dashboards.md` |
+| **Endpoints panel + release annotations** (#654) | `GET /user/posthog-stats`, `scripts/posthog_annotate.py` | Every HogQL query scoped with `distinct_id = {variables.distinct_id}` (ONE shared project); the personal API key stays server-side; a missing key is a no-op, never a failed release | `docs/kpi-dashboards.md` |
+| **Experiments** (#652) | `utilities/experiments.py` | Unresolvable experiment = **CONTROL** (no env fallback per experiment); rollout-% / distinct-ID flags only. Registered: `cost-routing-arm`, `comment-contract-prompt`, `post-media-variant` | `docs/experiments.md` |
+| **Feature flags** (#651) | `utilities/flags.py` | **Fails open to the env var** on every unresolvable path; read at CALL SITE, never at import; safety controls (429 breaker, holds, caps) are NOT flags | `docs/feature-flags.md` |
+| **Marketing attribution** (#658) | `utilities/marketing/attribution.py` | Only OWNED destinations tagged (`is_owned_link`); existing UTMs never overwritten; `signup_completed_web` ≠ `signup_completed` | `docs/marketing-attribution.md` |
+| **Model-tier benchmarks** (#721) | `scripts/benchmark_models.py` | The suite scores a FIRST draft, production ships an n-th — `contract` checks are the floor, `repairable` advisory (#910); an all-errored run is REFUSED, not a scorecard of zeros (#923) | `docs/model-benchmarks/README.md` |
+| **Content-quality telemetry** (#630) | `auto_nightly_content_quality` | The TREND LINE, not a gate — **unscored is never zero**, and it never pauses anything (safety is #629) | `docs/content-quality-telemetry.md` |
+| **Surveys — NPS/CSAT** (#653) | PostHog Surveys + `utilities/surveys.py` | Type `api`, rendered headless in `PostHogSurveyModal.tsx`; ONE answer = TWO paths counted ONCE; `markSurveySeen()` is what advances the 30d wait | `docs/surveys.md` |
 
 ## CI Gates
 
@@ -299,19 +222,19 @@ local dev → PR to main → CI gates pass → release-please tags vX.Y.Z
     compose up, /health check, auto-rollback to .last_good_tag on failure)
 ```
 
-- The stack launches with **both** compose files (`-f docker-compose.yml -f docker-compose.prod.yml`) — the prod overlay strips the dev bind-mount, so every app service runs the code baked into the image; editing files on disk does nothing until a new image ships. `web_app` is a tiny nginx **edge** routing to the active blue/green color; deploys are zero-downtime flips, releases batch 4x daily (05/11/17/23 UTC) — `docs/zero-downtime-deploys.md`. A **`release:now`** label ships a PR at merge instead of the next window; agents may self-apply it for high-priority/user-visible fixes — `docs/release-fast-lane.md`.
+- The stack launches with **both** compose files (`-f docker-compose.yml -f docker-compose.prod.yml`) — the prod overlay strips the dev bind-mount, so every app service runs the code baked into the image; editing files on disk does nothing until a new image ships. `web_app` is a tiny nginx **edge** routing to the active blue/green color; deploys are zero-downtime flips, releases batch 4x daily (05/11/17/23 UTC) — `docs/zero-downtime-deploys.md`. A **`release:now`** label ships a PR at merge instead of the next window (`docs/release-fast-lane.md`).
 - **Runtime state (429 breaker, manual automation pause, reply-sweep cadence keys) lives in Redis**, not the DB or containers — it survives deploys.
-- A **local hotfix deploy** fallback exists for when CI/release is too slow or blocked, and diverges prod from `main` until the fix lands via the normal PR flow. Full posture + compose layering + image refs: `docs/DEPLOYMENT.md`.
+- A **local hotfix deploy** fallback exists for when CI/release is blocked; it diverges prod from `main` until the fix lands via the normal PR flow. Full posture + compose layering + image refs: `docs/DEPLOYMENT.md`.
 
 ## Known Gotchas
 
 - **Legacy drift:** `get_docker_driver()` targets `selenium/standalone-chrome:latest` at 4444, not a Grid hub+node; `ai_helper.py` uses tier aliases, not a hardcoded `gpt-4o-mini`; PostHog replaced Prometheus + Jaeger (both gone from docker-compose); the external `linkedin-preview` service is gone — preview is the native `LinkedInPostPreview.tsx`.
-- **LinkedIn SDUI** (`docs/sdui-selenium-notes.md`): the old `urn:`, `feed-shared-*` and `comments-comment-*` anchors are gone — prefer `data-testid` / `aria-label`. Two fix invariants (#1013): **success is the OUTCOME being present, never a click having landed**, and **never click a control whose label names a different entity than the target** (the #1012 rail hazard). Corollary: **zero items is not "nothing to do" until the page agrees** — cross-check against an anchor the walk doesn't use (`_report_zero_walk`). Every surface maps to a read-only probe flag and a weekly `ok`/`drift`/`unknown` sweep that files ONE issue per drift: `docs/sdui-probe-coverage.md`. The comment composer has NO `<form>`; the sticky global nav steals clicks from an unfocused composer; every composer lookup is scoped to its OWN post (`_post_composer_for_card` / `_reply_composer_for_comment`), and a miss is a DEBUG no-op, never a warning. A post PERMALINK runs that SAME engine (`comment_on_post` → `_permalink_post_card`, #966) — it is NOT a one-post page, so the card is picked by the permalink's URN, the reaction happens BEFORE the comment, and a comment that doesn't land is a FAILURE row, never a SUCCESS.
+- **LinkedIn SDUI** (`docs/sdui-selenium-notes.md`): the old `urn:`, `feed-shared-*` and `comments-comment-*` anchors are gone — prefer `data-testid` / `aria-label`. Three fix invariants (#1013): **success is the OUTCOME being present, never a click having landed**; **never click a control whose label names a different entity than the target** (the #1012 rail hazard); **zero items is not "nothing to do" until the page agrees** — cross-check an anchor the walk doesn't use (`_report_zero_walk`). Every surface maps to a read-only probe flag + a weekly `ok`/`drift`/`unknown` sweep filing ONE issue per drift (`docs/sdui-probe-coverage.md`). The comment composer has NO `<form>`; the sticky global nav steals clicks from an unfocused composer; every composer lookup is scoped to its OWN post (`_post_composer_for_card` / `_reply_composer_for_comment`), and a miss is a DEBUG no-op. A post PERMALINK runs that SAME engine (`comment_on_post` → `_permalink_post_card`, #966) — NOT a one-post page, so the card is picked by the permalink's URN, the reaction happens BEFORE the comment, and a comment that doesn't land is a FAILURE row, never a SUCCESS.
 - **Emoji in Selenium:** ChromeDriver `send_keys` throws on non-BMP emoji — strip them before typing with `_strip_non_bmp()`.
 - **ENUM columns:** `logs.action_type` (and other status columns) are MySQL ENUMs — adding a value requires a migration. New migrations use **TIMESTAMP** versions so two branches never collide; the **db-migration** skill and `compose/local/database/migrations/README.md`.
-- **Unified content core:** newsletters, posts, AND comments draw framework, research, and alignment from `utilities/ai/content_framework.py` / `content_research.py` / `content_alignment.py` — never add parallel per-content-type prompt helpers. Comments carry a **quality contract + similarity gate** (#617) that SKIPS the post after `COMMENT_GATE_MAX_ATTEMPTS` failed regenerations. **Story bank** (#620) is the FACT half; **deck reference gate** (#728) the save-worthiness half; **deterministic slop lint** (#625, `slop_lint.py`) BLOCKS on five HARD checks, advises on four WARN.
-- **Content mix (70/20/10) governor:** every planned post carries a mix class in `posts.content_mix` — `value` (70%) / `authority` (20%) / `promo` (10%, forced `case_snapshot` blueprint). **Promo CTAs are always an ARTIFACT** (lead magnet / newsletter) — a meeting ask is banned in prompts and repaired deterministically; any that survives HOLDS the post at PENDING via the `meeting_cta` gate. Both: `docs/content-core.md`.
-- **Stale lazy chunks after a deploy (#743):** a tab open across a release fetches a code-split chunk on a hash the new image no longer has. Three layers: asset **retention** (both colors serve a live-bundle miss from a shared archive volume), a **one-shot reload** on import failure (loop-guarded, skipped offline), and polling of `/api/app-info` that prompts rather than reloads. Full: `docs/spa-deploy-freshness.md`.
+- **Unified content core** (`docs/content-core.md`): newsletters, posts, AND comments draw framework, research, and alignment from `utilities/ai/content_framework.py` / `content_research.py` / `content_alignment.py` — never add parallel per-content-type prompt helpers. Comments carry a **quality contract + similarity gate** (#617) that SKIPS the post after `COMMENT_GATE_MAX_ATTEMPTS` failed regenerations. **Story bank** (#620) is the FACT half; **deck reference gate** (#728) the save-worthiness half; **slop lint** (#625, `slop_lint.py`) BLOCKS on five HARD checks, advises on four WARN.
+- **Content mix (70/20/10) governor** (same doc): every planned post carries a mix class in `posts.content_mix` — `value` (70%) / `authority` (20%) / `promo` (10%, forced `case_snapshot` blueprint). **Promo CTAs are always an ARTIFACT** (lead magnet / newsletter) — a meeting ask is banned in prompts and repaired deterministically; any that survives HOLDS the post at PENDING via the `meeting_cta` gate.
+- **Stale lazy chunks after a deploy (#743, `docs/spa-deploy-freshness.md`):** a tab open across a release fetches a code-split chunk on a hash the new image no longer has. Three layers: asset **retention** (both colors serve a live-bundle miss from a shared archive volume), a **one-shot reload** on import failure (loop-guarded, skipped offline), and polling of `/api/app-info` that prompts rather than reloads.
 
 ## Git Safety & Multi-Agent Concurrency Rules
 - **Fresh state:** before generating ANY code edit, run `git status` and read the target file. Never edit from conversation memory — another agent may have changed it under you.

--- a/docs/content-core.md
+++ b/docs/content-core.md
@@ -159,3 +159,30 @@ prompts (`ARTIFACT_CTA_POLICY`, injected by `cta_policy_directive`), repaired de
 by `replace_meeting_ask_cta`, and any that survives HOLDS the post at PENDING via the
 `meeting_cta` quality gate. Compliance is reported on `/user/engagement-analytics`
 (`content_mix`) and rendered on the Dashboard.
+
+## Newsletter blog alignment (issue #967, `utilities/blog_source.py`)
+
+`align_with_blog` is a user-facing toggle that **defaults ON** and promises the edition repurposes
+the author's own writing. `resolve_blog_source(user_id, settings)` is the ONE place that toggle
+becomes source text — the three call sites (`run_automation.auto_generate_newsletter_edition`, and
+both edition paths in `run_scheduler`) pass its return value straight into the generator as
+`blog_content`.
+
+| Rule | Why |
+|---|---|
+| Blog URL first, sitemap second | The sitemap is the fallback for users who set one but never a blog |
+| Same fetchers as `blog_summary` / `website_content` (`get_main_blog_url_content`, `fetch_sitemap_urls` → `filter_relevant_urls` → `extract_page_content`) | One scraper for the app, not two |
+| Returns `None`, never raises | Best-effort: an unset, unreachable, or empty source must never block an edition from existing — it writes from topic + profile instead |
+| Resolved PER edition, article/page drawn at RANDOM | Two editions queued in the same run must not repurpose the same article |
+| `BLOG_SOURCE_MAX_CHARS = 8000`, `_SITEMAP_ATTEMPTS = 3` | Bounds the page text one resolve holds; the generator applies its own smaller prompt budget on top |
+| HTML/bytes/paragraph lists normalised through `_plain_text` | WordPress returns rendered HTML — without this the source budget is spent on markup |
+
+**Logging follows the escalation contract**, which matters here because the toggle defaults ON:
+
+- **Toggle on, no blog and no sitemap configured** — the common case. Expected no-op → `log_debug`.
+  Warning here would fire for most users on every edition and escalate to ERROR on repeat.
+- **A configured source that fetched fine and read back empty** — the one failure nothing else has
+  reported → `log_warning`.
+- **A fetch that threw** — already warned where it was detected; `_from_blog` / `_from_sitemap`
+  return a `reported` flag so `_resolve` never restates it. ONE unreadable source = ONE warning.
+- **One dead page out of a sitemap** — routine, `log_debug`, try the next of the three.

--- a/docs/identity-and-sessions.md
+++ b/docs/identity-and-sessions.md
@@ -511,3 +511,38 @@ per-device revocable session on the Security card, so a long TTL is not a one-wa
 
 `sessions.scope` is `VARCHAR(32)` and `auth_audit_log.event` is `VARCHAR(50)`, so `agent` and
 `agent_token_minted` needed **no migration** — an ENUM would have.
+
+## The docs surface lives inside `/api` (issue #1020)
+
+At the FastAPI defaults the docs surface sits at `/docs`, `/redoc` and `/openapi.json` — **outside**
+`/api`, so the credential gate (which only inspects paths starting with `/api/`) never saw it and
+all three were served to anyone. The app now declares `docs_url="/api/docs"`,
+`redoc_url="/api/redoc"`, `openapi_url="/api/openapi.json"`, which puts them on the same side of
+that boundary as everything they describe; they are then re-opened **deliberately** as leaf entries
+in `_PUBLIC_API_PREFIXES` rather than by accident of routing.
+
+Three details are load-bearing:
+
+- **`swagger_ui_oauth2_redirect_url="/api/docs/oauth2-redirect"` must be set explicitly.** FastAPI
+  defaults it to the literal `/docs/oauth2-redirect` and does NOT derive it from `docs_url`, so
+  moving `docs_url` alone strands the helper outside `/api` and breaks Swagger's Authorize flow
+  silently.
+- **The old paths 301 to the new ones** (`_DOCS_REDIRECTS`), registered before the SPA catch-all —
+  which would otherwise answer them with `index.html`. Permanent, matching the `/assets` redirect,
+  so bookmarks, README links and Postman imports keep working.
+- **`_hide_admin_routes_from_schema()` keeps every `/api/admin/*` operation out of the published
+  schema.** It walks the route table and flips `include_in_schema`, rather than decorating eighteen
+  routes with `include_in_schema=False`, because that failure mode is silent: a nineteenth admin
+  route added later would publish itself and nothing would say so. The count is logged
+  (`_ADMIN_ROUTES_HIDDEN`) so "nothing to hide" reads differently from "the walk matched nothing",
+  and `test_no_admin_route_appears_in_the_public_schema` checks the outcome.
+
+**Hidden is not gated.** The admin routes' auth is exactly what it was — `X-Admin-Secret` and, for
+the engagement test routes, the bearer alongside it. What changed is that the public schema no
+longer hands a prober the list of paths to aim at, and that Swagger's *Try it out* can no longer
+drive them. Use curl or the checked-in Postman collection instead:
+[`TESTING_ENGAGEMENT_API.md`](TESTING_ENGAGEMENT_API.md).
+
+The other unauthenticated surface, `GET /health/deep`, was trimmed in the same issue: it returns
+**counts only** — no worker or queue names — and `"status":"healthy"` stays the first key of the
+response, which is a monitor contract. See [`stack-watchdog.md`](stack-watchdog.md).

--- a/docs/linkedin-session-health.md
+++ b/docs/linkedin-session-health.md
@@ -1,0 +1,95 @@
+# LinkedIn session health — sign-in visibility + OAuth token renewal
+
+Two independent credentials keep LEM working against LinkedIn, and each has exactly one module
+deciding its state. The map entries live in [CLAUDE.md](../CLAUDE.md) under **Anti-bot / session
+infra**; this file is the detail behind them.
+
+| Credential | Owner module | What it powers |
+|---|---|---|
+| The Selenium session (`li_at` cookie / password login) | `utilities/linkedin/login_status.py` (#933) | every browser automation: feed commenting, DMs, invites |
+| The LinkedIn OAuth token | `utilities/linkedin/token_refresh.py` (#600) | the REST API paths: posting, post stats, profile reads |
+
+They fail differently and are reported separately — a user can hold a healthy OAuth token while
+the browser session is dead, and vice versa.
+
+---
+
+## Sign-in visibility (issue #933)
+
+When LinkedIn challenges an automated sign-in it asks the account owner to confirm the device from
+the LinkedIn mobile app, and LEM emails them to go and tap **Yes**. The approval happens entirely on
+LinkedIn's side, so a user who had already approved could not tell whether LEM ever saw it: the app
+said "a session is saved" before the approval and exactly the same thing after.
+
+`login_status.py` records the outcome of the sign-in the approval belongs to, so
+`GET /user/linkedin-signin-status` → `LinkedInSignInStatusCard.tsx` can answer *"did my approval
+land?"* instead of leaving the user guessing.
+
+### Where it is written
+
+`_persist_session_cookies` is where **both** of `login_to_linkedin`'s success paths meet, so that is
+where a sign-in is recorded (`mark_signed_in`). The device-approval wait loop always closes the
+`approval_pending` state — `mark_approval_timed_out` on giving up, `mark_signed_in` the moment it
+clears. A login that dies between the two must never leave the SPA telling a user who already tapped
+Yes to go and tap it again.
+
+### The three states
+
+| State | Meaning |
+|---|---|
+| `signed_in` | Signed in — any approval that was asked for landed |
+| `approval_pending` | LinkedIn asked, we emailed, we are waiting |
+| `approval_timed_out` | We stopped waiting; the next run asks again |
+
+`mark_approval_pending` carries the previous `signed_in_at` forward, because *"you approved on the
+2nd, we're asking again now"* is a very different message from *"we have never signed in"*.
+`approval_cleared_at` is stamped only when the sign-in followed a pending approval — that is the
+exact fact the user could not otherwise see. The cookie persist writes again for the SAME sign-in
+the approval just cleared, so the approval is carried across rather than erased, bounded by the
+pending window so a routine sign-in weeks later never re-claims an old approval.
+
+### Storage and failure mode
+
+State lives in **Redis**, next to the 429 breaker and reusing its handle: short-lived runtime state
+that survives a deploy and needs no migration.
+
+- `LINKEDIN_LOGIN_STATUS_TTL_SECONDS` (default 30 days) — a "last signed in" fact stays useful for
+  weeks.
+- `LINKEDIN_LOGIN_STATUS_PENDING_TTL_SECONDS` (default 15 min) — a PENDING record expires on its
+  own, so a worker that died mid-challenge cannot leave the Account page asking for an approval
+  nobody is waiting on.
+
+It **fails open**: with Redis unavailable every write no-ops and `get_login_status` returns `None`.
+`unknown` therefore means *nothing was recorded*, NOT *the connection is broken* — the SPA must not
+render it as a failure. A Redis blip is an expected no-op and logs at DEBUG, never a warning that
+would file an issue on repeat.
+
+---
+
+## OAuth token renewal (issue #600)
+
+`resolve_token_status(user_id, auto_refresh=True)` is the ONE place a user's token state is decided.
+Both readers use it — the SPA's `/user/token_status` countdown and the daily renewal beat — so the
+countdown a user sees and the countdown that triggers their email can never disagree. The returned
+state is the state **after** any refresh attempt it made.
+
+LinkedIn caps authorization at **60 days**. The daily beat `refresh-linkedin-tokens`
+(`auto_refresh_linkedin_tokens`, 08:30 UTC) renewing everyone inside `EXPIRY_WARNING_DAYS` (30, half
+the token's life) is the only way a token outlives that cap. It runs BEFORE the 09:00 missing-session
+pass, so a token renewed at 08:30 never produces a reconnect email half an hour later.
+
+### The returned document
+
+`connected`, `token_expiry_date`, `days_remaining`, `is_expiring_soon`, `is_expired`,
+`can_auto_refresh`, `refresh_attempted`, `refresh_succeeded`.
+
+**`days_remaining` is `None`, never 0, when it cannot be read.** A zero would render as "expires
+today" and send a user chasing a problem that may not exist; `None` renders as unknown.
+
+### Emails
+
+A user with **no refresh token** cannot be renewed — that is an expected no-op (DEBUG, not a
+warning; it is the normal state for anyone who connected before refresh tokens were requested). It
+produces a **reconnect email**, throttled per user by `LINKEDIN_TOKEN_EMAIL_THROTTLE_DAYS` (7) in
+Redis, which fails open. Paired with the 30-day warning window that caps a user at roughly four
+emails across the final month before expiry.

--- a/docs/observability-map.md
+++ b/docs/observability-map.md
@@ -1,0 +1,95 @@
+# Observability map — the per-surface invariants
+
+[CLAUDE.md](../CLAUDE.md) § **Observability** is the index: one row per surface, naming the ONE
+module and the invariant that bites. This file holds the paragraph behind each row; the doc named in
+each heading holds the rationale, contracts, sample code and edge cases.
+
+Track events via `utilities/observability.py` (`track_llm_call` / `track_task` / `track_api_call`).
+Plan with the CLAUDE.md table, drill in here, then read the linked doc. Doc paths in the headings
+below are repo-root relative (`docs/llm-analytics.md` is this file's sibling).
+
+## LLM analytics (issue #647, traces #746) — `docs/llm-analytics.md`
+Two streams, never summed: `llm_call` (app, cost ESTIMATE — every money question reads this) vs
+`$ai_generation`/`$ai_embedding` (proxy-native, post-fallback, provider-priced — latency/error/
+volume). `utilities/ai/client.py` is the ONE client and both its hooks (`_attach_attribution`,
+`_attach_trace`) must stay. **Pipeline traces** group a post/edition/comment's 5–6 calls into ONE
+`$ai_trace` with per-step `$ai_span`s: `@llm_pipeline` on the three roots (`create_text_post`,
+`generate_newsletter_edition`, `generate_ai_response` — supersedes `attribute_llm_cost`), `@llm_step`
+on the SHARED-core step functions, never at a call site. Nested trace = span; span with no trace =
+no-op; `LLM_TRACING_ENABLED=false` mints nothing.
+
+## Error tracking (issue #648) — `docs/error-tracking.md`
+Logs (`logger.py` → PostHog Logs) carry message+context; `$exception` is the grouped/fingerprinted
+ISSUE alerting + the error→GitHub-issue cron — NOT redundant. Use
+`observability.capture_exception(...)` for caught-and-not-reraised. Never capture `HTTPException` —
+4xx is a response, not an issue.
+
+## Browser-side analytics (issue #646) — `docs/posthog-advanced-surface.md`
+ONE SPA surface: `ui/src/utils/analytics.ts` — never call `posthog` directly. `distinct_id =
+String(user_id)` matches `observability.py` so browser+Celery+proxy share ONE PostHog person.
+Env-gated at BUILD time (`VITE_POSTHOG_KEY`); no key → lazy chunk never fetched → no-op.
+`maskProps()` (adds `ph-no-capture` + `data-ph-mask`) goes on every content editor.
+
+## Session replay (issue #649) — `docs/session-replay.md`
+Rules live in the SDK: `VITE_POSTHOG_REPLAY_SAMPLE` slice + EVERY `$exception`/feedback session, both
+via one `ensureSessionRecorded()`. Local `sampleRate` takes precedence — never set project sampling
+(multiplies). Canvas off; inputs masked; network capture timings only.
+
+## KPI funnels, dashboards, alerts + weekly report (issue #650) — `docs/kpi-dashboards.md`
+`scripts/posthog_provision.py` owns Health + Growth dashboards, four threshold alerts, the weekly
+Growth email. Alert tiles must be native single-series `TrendsQuery` filtering on STRING props
+(boolean filters match nothing → silent alerts). Money tiles read `$ai_generation`, never `llm_call`.
+`mark_rate_limited()` emits `rate_limit_trip` (a WARNING log never reaches PostHog).
+
+## Experiments (issue #652) — `docs/experiments.md`
+`utilities/experiments.py` is the adapter onto PostHog Experiments, NOT a third implementation.
+**Unresolvable experiment = CONTROL arm** (no key, `EXPERIMENTS_ENABLED=false`, inconclusive, SDK
+raises — no env fallback per experiment). Flags must use rollout-% / distinct-ID only. Three
+registered: `cost-routing-arm`, `comment-contract-prompt`, `post-media-variant`.
+
+## Marketing attribution — UTMs (issue #658) — `docs/marketing-attribution.md`
+`utilities/marketing/attribution.py` is the ONE place. Two rules: only OWNED destinations tagged
+(`is_owned_link`); existing UTMs never overwritten (`build_utm_url` fills missing only,
+`mark_placement` replaces `utm_content` only). `signup_completed_web` (browser) ≠ `signup_completed`
+(API) — never summed.
+
+## Model-tier evaluation harness (issue #721) — `docs/model-benchmarks/README.md`
+`scripts/benchmark_models.py` measures candidates vs each tier's contract suite (NO user data),
+beside the current champion. Deterministic checks are source of truth (the in-repo linters, not a
+copy); the LLM judge is PostHog Evaluations filtered on `benchmark_run_id` (production never carries
+it → the customer is never billed). **The suite scores a FIRST draft, production ships an n-th**
+(#910): every check is `contract` (the call site consumes it — the ABSOLUTE floor) or `repairable`
+(a regeneration gate retries it — advisory). A run where every case of every model errored is a
+harness outage, not a scorecard of zeros, and is REFUSED (#923). Only `recommend` becomes a swap,
+and recommendations are RENDERED, never written.
+
+## Content-quality telemetry (issue #630) — `docs/content-quality-telemetry.md`
+`auto_nightly_content_quality` is the TREND LINE (other gates are one-time verdicts). Scores
+posts/comments/editions into `content_quality_scores`: weighted slop (HARD ×3), self-similarity,
+**stored** authenticity (no fresh judge call), hook length, impression-weighted ER. **Unscored is
+never zero** — each dimension has its own sample size. Never pauses (safety is #629).
+
+## Feature flags (issue #651) — `docs/feature-flags.md`
+`utilities/flags.py` is the ONE place; **fail open to env var** (no key, disabled, undefined,
+inconclusive, SDK raises → all return the flag's env var). `only_evaluate_locally=True` → ZERO
+network per check, flip lands without restart. Read at CALL SITE, never at import. **Safety controls
+are NOT flags** (429 breaker, holds, pauses, per-day caps stay in Redis/env). SPA bootstraps from
+`GET /api/flags` — not through posthog-js.
+
+## Surveys — NPS/CSAT (issue #653) — `docs/surveys.md`
+TWO owners. PostHog Surveys: NPS (30d past ACTIVATION, not signup) + post-quality CSAT (on
+`post_approved` once `posts_approved >= 5`). `utilities/surveys.py` keeps the bespoke ones —
+trial-T-3d review (#499) + fix CSAT (#502). Type **`api`**, rendered headless in
+`PostHogSurveyModal.tsx`. ONE answer = TWO paths (native `$survey_response` + POST
+`/api/survey/posthog` → `feedback` row), counted ONCE — `track_survey_response` deliberately NOT
+emitted. Detractor (NPS ≤6 / CSAT ≤2) or any free text stays `new`; happy+blank → `resolved`.
+`markSurveySeen()` advances the 30d wait — drop it and the throttle stops silently.
+
+## Endpoints panel + release annotations (issue #654) — `docs/kpi-dashboards.md`
+**Endpoints** (PostHog beta): HogQL as a versioned cached HTTP route — the Dashboard's "Live stats"
+with no MySQL reporting layer. Every query scoped with `distinct_id = {variables.distinct_id}` (ONE
+shared project → un-scoped leaks across customers); resolves against ONE `InsightVariable`, and the
+endpoint is `blocked_endpoint` until it exists. `GET /user/posthog-stats` is server-side only — the
+personal API key never reaches the browser; any failure → `available: false` for that panel.
+**Release annotations**: `scripts/posthog_annotate.py` posts `"vX.Y.Z deployed"` per deploy (needs
+the `POSTHOG_PERSONAL_API_KEY` GH secret); absent/outage → no-op, never a failed release.

--- a/tests/unit/test_claude_md_doc_pointers.py
+++ b/tests/unit/test_claude_md_doc_pointers.py
@@ -1,0 +1,40 @@
+"""CLAUDE.md is the map: every `docs/*.md` it names must exist (issue #1033).
+
+The size cap is held by moving detail out of CLAUDE.md into `docs/`, which only works while the
+pointers resolve — a renamed or deleted doc turns an invariant into a dead end, and nothing else in
+CI reads CLAUDE.md's prose. Stdlib only, no I/O beyond reading the two files.
+"""
+
+import pathlib
+import re
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_CLAUDE_MD = _ROOT / "CLAUDE.md"
+
+# Matches `docs/foo.md` and `docs/model-benchmarks/README.md`, inside backticks or bare prose.
+_DOC_REF = re.compile(r"docs/[A-Za-z0-9._/-]+\.md")
+
+
+def _referenced_docs() -> set[str]:
+    return set(_DOC_REF.findall(_CLAUDE_MD.read_text(encoding="utf-8")))
+
+
+class TestDocPointers:
+    def test_claude_md_names_at_least_one_doc(self):
+        """A regex that silently stopped matching would make every assertion below vacuous."""
+        assert len(_referenced_docs()) > 10
+
+    def test_every_referenced_doc_exists(self):
+        missing = sorted(ref for ref in _referenced_docs() if not (_ROOT / ref).is_file())
+        assert not missing, f"CLAUDE.md points at docs that do not exist: {missing}"
+
+    def test_the_directory_map_files_exist(self):
+        """The map's own coordinates — a moved module makes the map lie."""
+        for path in ("src/cqc_lem/utilities/db.py", "src/cqc_lem/utilities/human_pacing.py",
+                     "src/cqc_lem/utilities/ai/client.py", "src/cqc_lem/utilities/logger.py",
+                     "scripts/check_claude_md_size.py"):
+            assert (_ROOT / path).is_file(), path


### PR DESCRIPTION
## What

`CLAUDE.md` was **38,970 chars** on this branch point — past the 38,000 warn threshold that filed #1033 and within ~1k of the 40,000 harness cap. It is now **33,087 chars** (`python3 scripts/check_claude_md_size.py` → ok, 6.9k of runway).

Nothing was dropped. Every paragraph removed from CLAUDE.md landed in the doc its section already pointed at, or in a new doc created here.

| Change | Where the detail went |
|---|---|
| **Observability** — twelve one-paragraph subsections become ONE map table (*surface / the ONE place / the invariant that bites / doc*) | `docs/observability-map.md` (new — the paragraphs, verbatim) |
| **Sign-in visibility (#933)** + **OAuth token renewal (#600)** — the two bullets that had no doc at all | `docs/linkedin-session-health.md` (new) |
| **Newsletter blog alignment (#967)** — also had no doc | new section in `docs/content-core.md` |
| **The `/api` docs surface (#1020)** — `_hide_admin_routes_from_schema`, the `swagger_ui_oauth2_redirect_url` trap, the 301s | new section in `docs/identity-and-sessions.md` |
| Remaining bullets (engagement automation, identity/strong-auth/scopes, SDUI gotchas, deployment) compressed to symbols + invariant + pointer | already covered by `docs/engagement-automation.md`, `docs/identity-and-sessions.md`, `docs/strong-authentication.md`, `docs/sdui-selenium-notes.md`, `docs/DEPLOYMENT.md` — verified per symbol before cutting |

## Two accuracy fixes made on the way through

- LLM analytics named `_attach_routing_metadata`, which does not exist. The client's hooks are `_attach_attribution` and `_attach_trace` (`utilities/ai/client.py:176`).
- The agent scope line read "`/user/engagement-preferences` is refused for an agent". The path IS on `_AGENT_SESSION_SURFACE` (the agent reads it); it is the **write** that is refused, by a separate guard (`agent_may_not_configure`, `api/main.py:4197`). The line now states the real hazard: surfaces match on PATH not method, so granting a read grants its writes.

## Testing

- `tests/unit/test_claude_md_doc_pointers.py` (new) fails the build if CLAUDE.md points at a `docs/*.md` that does not exist — the map only works while its pointers resolve.
- `pytest tests/unit/test_claude_md_doc_pointers.py tests/unit/test_check_claude_md_size.py` → 20 passed.
- `python3 scripts/check_claude_md_size.py` and `--warn-at` both report ok.

Docs-only + one new test, no runtime code touched — no `release:now`.

Closes #1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)