### PR TITLE
fix(feedback): make triage Approve actually file, and say what it did (closes #1036)

### DIFF
--- a/docs/launch-and-marketing-plan.md
+++ b/docs/launch-and-marketing-plan.md
@@ -214,6 +214,11 @@ classifier/filer path and stamps `feedback.reviewed_by/reviewed_at`. Two consequ
   `agent:ready`. The NOISE and FAQ verdicts are unchanged: those settle the row, so the panel already shows
   the admin what happened. What can still file nothing is GitHub refusing — the response carries `filed:
   false` and the panel says so **at the button**, because that outcome changes nothing else on screen.
+  A low-confidence verdict and NO verdict are NOT the same thing: the fail-safe classification (`errors`
+  set — the LLM never answered) carries the RAW report as its `summary`, so approving it would publish the
+  feedback text §B.2 promises never reaches GitHub, under `issue_created` — which is terminal. That case
+  files nothing, leaves the row in `new`, and returns `reason: classification unavailable` so the panel
+  tells the admin to retry rather than blaming GitHub.
 `count_pending_admin_review()` reports the backlog on every filing pass so it can't grow silently.
 
 ### B.3 Deduplication / clustering (one recurring problem = one issue)

--- a/docs/launch-and-marketing-plan.md
+++ b/docs/launch-and-marketing-plan.md
@@ -205,6 +205,15 @@ classifier/filer path and stamps `feedback.reviewed_by/reviewed_at`. Two consequ
   re-running the filer on it would match it to itself at similarity 1.0 and post a false "+1 another report"
   on the very issue it created. The panel's buttons alone are not the guard: its list is cached, and the
   filing beat or a second admin can settle a row between render and click.
+- **Approve is a human decision, so the unattended holds do not re-apply to it (issue #1036).**
+  `file_feedback_issue(..., admin_approved=True)` skips the per-user daily issue cap and files a `NEEDS_HUMAN`
+  (low-confidence) row instead of parking it back in `triaged`. Both holds exist because the batch pass runs
+  with nobody watching; re-applying them to an explicit approve returned 200 and left the row in `new`, so the
+  panel re-rendered it unchanged — which is what "the approve button does nothing" was. Confidence still
+  shapes the LABELS, so a shaky classification lands `needs-human` + assigned + Decision Comment and never
+  `agent:ready`. The NOISE and FAQ verdicts are unchanged: those settle the row, so the panel already shows
+  the admin what happened. What can still file nothing is GitHub refusing — the response carries `filed:
+  false` and the panel says so **at the button**, because that outcome changes nothing else on screen.
 `count_pending_admin_review()` reports the backlog on every filing pass so it can't grow silently.
 
 ### B.3 Deduplication / clustering (one recurring problem = one issue)

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -7002,7 +7002,7 @@ def admin_feedback_review(
 ) -> ResponseModel:
     """Approve a feedback row for auto-triage or dismiss it."""
     reviewer_user_id = _require_user_admin(request.session_token)
-    from cqc_lem.utilities.feedback.issue_service import file_feedback_issue
+    from cqc_lem.utilities.feedback.issue_service import IssueAction, file_feedback_issue
     row = get_feedback_by_id(feedback_id)
     if not row:
         raise HTTPException(status_code=404, detail="Feedback not found")
@@ -7022,8 +7022,9 @@ def admin_feedback_review(
                  user_id=reviewer_user_id)
         return ResponseModel(status_code=200, detail={"reviewed": True, "action": "dismissed"})
 
-    # approve: run the normal classifier/filer path now.
-    result = file_feedback_issue(row)
+    # approve: run the classifier/filer path now, told that a human is watching (#1036) — the
+    # unattended-run holds re-applied to an explicit approve are what left the row in `new`.
+    result = file_feedback_issue(row, admin_approved=True)
     # Stamp the reviewer even when the filer itself dropped/FAQ'd/human-routed the row.
     record_feedback_review(feedback_id, reviewer_user_id)
     log_info("Feedback approved by admin", feedback_id=feedback_id,
@@ -7031,6 +7032,10 @@ def admin_feedback_review(
     return ResponseModel(status_code=200, detail={
         "reviewed": True,
         "action": "approved",
+        # The panel cannot infer this from the 200: an approve that GitHub refused records the
+        # review and changes NOTHING else, which is indistinguishable from a filed one unless the
+        # answer says so (#1036).
+        "filed": result.get("action") in (IssueAction.FILED, IssueAction.DEDUPED),
         "filing_result": result,
     })
 

--- a/src/cqc_lem/ui/src/hooks/useFeedbackReview.ts
+++ b/src/cqc_lem/ui/src/hooks/useFeedbackReview.ts
@@ -8,13 +8,16 @@ interface ReviewPayload {
 }
 
 // Approve returns what the filer actually did — it can dedupe, rate-limit or error out, so
-// "approved" alone does not mean an issue exists.
+// "approved" alone does not mean an issue exists. `filed` is the server's own verdict on that
+// (#1036): a 200 says the review was recorded, never that anything reached GitHub.
 export interface ReviewResult {
   reviewed: boolean
   action: string
+  filed?: boolean
   filing_result?: {
     action?: string
     issue_number?: number
+    reason?: string
   }
 }
 

--- a/src/cqc_lem/ui/src/pages/AdminFeedbackPage.test.tsx
+++ b/src/cqc_lem/ui/src/pages/AdminFeedbackPage.test.tsx
@@ -113,6 +113,106 @@ describe('AdminFeedbackPage (issue #793)', () => {
     expect(parseInt((wrap.firstElementChild as HTMLElement).style.minWidth, 10)).toBeGreaterThan(430)
   })
 
+  // Issue #1036: "clicking approve does nothing". Every approve outcome that files nothing leaves
+  // the row in `new`, so the table re-renders identically — the message at the button IS the only
+  // thing that happened, and it has to say so in words.
+  it('reports an approve that reached no issue AT the button, not as a success', async () => {
+    get.mockResolvedValue(listPayload([
+      {
+        id: 1,
+        email: 'user@x.com',
+        is_admin_reporter: false,
+        source: 'widget',
+        type_hint: 'bug',
+        body: 'Something is broken',
+        status: 'new',
+        github_issue_number: null,
+        created_at: '2026-07-29T12:00:00Z',
+      },
+    ]))
+    post.mockResolvedValue({ data: { detail: {
+      reviewed: true, action: 'approved', filed: false,
+      filing_result: { action: 'error', reason: 'issue creation failed' },
+    } } })
+
+    harness(<AdminFeedbackPage />)
+    await waitFor(() => expect(screen.getByRole('button', { name: /approve/i })).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }))
+
+    await waitFor(() => expect(screen.getAllByText(/GitHub refused the filing/).length)
+      .toBeGreaterThan(0))
+    // Shown inside the row's actions cell, next to the button that was clicked.
+    const inRow = screen.getByRole('button', { name: /approve/i })
+      .closest('td')?.textContent || ''
+    expect(inRow).toContain('GitHub refused the filing')
+    expect(inRow).toContain('Try Approve again')
+  })
+
+  it('names the issue a successful approve produced', async () => {
+    get.mockResolvedValue(listPayload([
+      {
+        id: 1,
+        email: 'user@x.com',
+        is_admin_reporter: false,
+        source: 'widget',
+        type_hint: 'bug',
+        body: 'Something is broken',
+        status: 'new',
+        github_issue_number: null,
+        created_at: '2026-07-29T12:00:00Z',
+      },
+    ]))
+    post.mockResolvedValue({ data: { detail: {
+      reviewed: true, action: 'approved', filed: true,
+      filing_result: { action: 'filed', issue_number: 1036 },
+    } } })
+
+    harness(<AdminFeedbackPage />)
+    await waitFor(() => expect(screen.getByRole('button', { name: /approve/i })).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }))
+    await waitFor(() => expect(screen.getAllByText(/Issue filed \(#1036\)/).length)
+      .toBeGreaterThan(0))
+  })
+
+  it('sends the approve action for the row whose button was clicked', async () => {
+    get.mockResolvedValue(listPayload([
+      {
+        id: 41,
+        email: 'a@x.com',
+        is_admin_reporter: false,
+        source: 'widget',
+        body: 'first',
+        status: 'new',
+        github_issue_number: null,
+        created_at: '2026-07-29T12:00:00Z',
+      },
+      {
+        id: 42,
+        email: 'b@x.com',
+        is_admin_reporter: false,
+        source: 'widget',
+        body: 'second',
+        status: 'new',
+        github_issue_number: null,
+        created_at: '2026-07-29T12:00:00Z',
+      },
+    ]))
+    post.mockResolvedValue({ data: { detail: {
+      reviewed: true, action: 'approved', filed: true,
+      filing_result: { action: 'filed', issue_number: 9 },
+    } } })
+
+    harness(<AdminFeedbackPage />)
+    await waitFor(() => expect(screen.getAllByRole('button', { name: /approve/i }).length).toBe(2))
+    fireEvent.click(screen.getAllByRole('button', { name: /approve/i })[1])
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith('/admin/feedback/42/review', {
+        session_token: 'tok',
+        action: 'approve',
+      })
+    )
+  })
+
   it('surfaces a failed review instead of swallowing it', async () => {
     get.mockResolvedValue(listPayload([
       {
@@ -133,8 +233,9 @@ describe('AdminFeedbackPage (issue #793)', () => {
     harness(<AdminFeedbackPage />)
     await waitFor(() => expect(screen.getByRole('button', { name: /approve/i })).toBeTruthy())
     fireEvent.click(screen.getByRole('button', { name: /approve/i }))
+    // Banner AND row (issue #1036) — the banner alone is above a table the admin has scrolled past.
     await waitFor(() =>
-      expect(screen.getByText(/Feedback already triaged/)).toBeTruthy()
+      expect(screen.getAllByText(/Feedback already triaged/).length).toBe(2)
     )
   })
 })

--- a/src/cqc_lem/ui/src/pages/AdminFeedbackPage.test.tsx
+++ b/src/cqc_lem/ui/src/pages/AdminFeedbackPage.test.tsx
@@ -148,6 +148,36 @@ describe('AdminFeedbackPage (issue #793)', () => {
     expect(inRow).toContain('Try Approve again')
   })
 
+  // Same `error` verb, different instruction: GitHub never saw this one. Reporting it as a refusal
+  // would point the admin at the wrong system.
+  it('says the classifier was unreachable rather than blaming GitHub', async () => {
+    get.mockResolvedValue(listPayload([
+      {
+        id: 1,
+        email: 'user@x.com',
+        is_admin_reporter: false,
+        source: 'widget',
+        type_hint: 'bug',
+        body: 'Something is broken',
+        status: 'new',
+        github_issue_number: null,
+        created_at: '2026-07-29T12:00:00Z',
+      },
+    ]))
+    post.mockResolvedValue({ data: { detail: {
+      reviewed: true, action: 'approved', filed: false,
+      filing_result: { action: 'error', reason: 'classification unavailable' },
+    } } })
+
+    harness(<AdminFeedbackPage />)
+    await waitFor(() => expect(screen.getByRole('button', { name: /approve/i })).toBeTruthy())
+    fireEvent.click(screen.getByRole('button', { name: /approve/i }))
+
+    await waitFor(() => expect(screen.getAllByText(/triage classifier could not be reached/).length)
+      .toBeGreaterThan(0))
+    expect(screen.queryByText(/GitHub refused/)).toBeNull()
+  })
+
   it('names the issue a successful approve produced', async () => {
     get.mockResolvedValue(listPayload([
       {

--- a/src/cqc_lem/ui/src/pages/AdminFeedbackPage.tsx
+++ b/src/cqc_lem/ui/src/pages/AdminFeedbackPage.tsx
@@ -38,11 +38,23 @@ const FILING_OUTCOMES: Record<string, string> = {
   error: 'GitHub refused the filing — nothing changed. Try Approve again.',
 }
 
+// A `reason` that changes what the admin should DO next outranks the verb it arrived with: an
+// `error` because the classifier never answered is not GitHub refusing, and a `dropped` because the
+// report is empty is not a noise verdict. Both would otherwise be reported as something else.
+const FILING_REASONS: Record<string, string> = {
+  'classification unavailable':
+    'The triage classifier could not be reached — nothing filed. Try Approve again.',
+  'empty body': 'This report has no text — dismissed, no issue filed',
+}
+
 function outcomeText(result: ReviewResult | undefined): string | null {
   if (!result) return null
   if (result.action === 'dismissed') return 'Dismissed'
   const filing = result.filing_result?.action
-  const label = (filing && FILING_OUTCOMES[filing]) || `Approved — filer: ${filing ?? 'done'}`
+  const reason = result.filing_result?.reason
+  const label = (reason && FILING_REASONS[reason])
+    || (filing && FILING_OUTCOMES[filing])
+    || `Approved — filer: ${filing ?? 'done'}`
   const number = result.filing_result?.issue_number
   return number ? `${label} (#${number})` : label
 }

--- a/src/cqc_lem/ui/src/pages/AdminFeedbackPage.tsx
+++ b/src/cqc_lem/ui/src/pages/AdminFeedbackPage.tsx
@@ -3,6 +3,7 @@ import TableScroll from '../components/TableScroll'
 import { useAuth } from '../contexts/AuthContext'
 import { useAdminFeedback } from '../hooks/useAdminFeedback'
 import { useFeedbackReview } from '../hooks/useFeedbackReview'
+import type { ReviewResult } from '../hooks/useFeedbackReview'
 
 const PAGE_SIZE = 25
 
@@ -24,6 +25,28 @@ const SOURCE_LABELS: Record<string, string> = {
   csat: 'CSAT',
 }
 
+// What the filer did, in words an admin can act on (issue #1036). Approve used to report itself
+// with the filer's raw verb in a grey line above the table — so an outcome that filed nothing and
+// left the row exactly where it was read as "the button does nothing".
+const FILING_OUTCOMES: Record<string, string> = {
+  filed: 'Issue filed',
+  deduped: 'Added as another report on the existing issue',
+  dropped: 'Classified as noise — dismissed, no issue filed',
+  faq: 'Routed to the FAQ queue — no issue filed',
+  needs_human: 'Held for human triage — no issue filed',
+  rate_limited: 'This reporter is over the daily issue cap — nothing filed',
+  error: 'GitHub refused the filing — nothing changed. Try Approve again.',
+}
+
+function outcomeText(result: ReviewResult | undefined): string | null {
+  if (!result) return null
+  if (result.action === 'dismissed') return 'Dismissed'
+  const filing = result.filing_result?.action
+  const label = (filing && FILING_OUTCOMES[filing]) || `Approved — filer: ${filing ?? 'done'}`
+  const number = result.filing_result?.issue_number
+  return number ? `${label} (#${number})` : label
+}
+
 function classNames(...classes: (string | false | null | undefined)[]) {
   return classes.filter(Boolean).join(' ')
 }
@@ -43,11 +66,16 @@ export default function AdminFeedbackPage() {
   })
 
   const review = useFeedbackReview()
+  // Which row the last click belonged to, so the outcome can be shown AT the button (#1036). The
+  // banner alone sits above the table — on a scrolled list the admin never sees it, and every
+  // outcome that files nothing leaves the row untouched, so there is nothing else to notice.
+  const [actedId, setActedId] = useState<number | null>(null)
 
   // `mutate`, not `mutateAsync`: an awaited rejection here had nobody to catch it, so a failed
   // approve (GitHub down, row already triaged by the beat) showed the admin nothing at all — the
   // row just stayed put. The hook invalidates the list on success, so no manual refetch either.
   function handleAction(id: number, action: 'approve' | 'dismiss') {
+    setActedId(id)
     review.mutate({ feedbackId: id, action, sessionToken: sessionToken || '' })
   }
 
@@ -56,6 +84,11 @@ export default function AdminFeedbackPage() {
     ? ((review.error as { response?: { data?: { detail?: string } } })?.response?.data?.detail
        || (review.error instanceof Error ? review.error.message : 'unknown error'))
     : null
+  const outcome = reviewError ? null : outcomeText(review.data)
+  // An approve that filed nothing left the row in `new`, so the table is about to re-render
+  // identically — the message IS the whole feedback and it must not read as a success.
+  const outcomeFailed = review.isSuccess && review.data?.action === 'approved'
+    && review.data?.filed === false
 
   return (
     <div className="max-w-5xl space-y-6">
@@ -116,15 +149,11 @@ export default function AdminFeedbackPage() {
         <p className="text-sm text-red-600">Could not record the review: {reviewError}</p>
       )}
 
-      {/* Approving does not guarantee an issue: the filer can rate-limit, drop, or fail on GitHub
-          and leave the row where it was. Show what actually happened. */}
-      {review.isSuccess && !reviewError && (
-        <p className="text-sm text-gray-600">
-          Last review: {String(review.data?.action ?? 'done')}
-          {review.data?.filing_result?.action ? ` — filer: ${review.data.filing_result.action}` : ''}
-          {review.data?.filing_result?.issue_number
-            ? ` (issue #${review.data.filing_result.issue_number})`
-            : ''}
+      {/* Approving does not guarantee an issue: the filer can drop, FAQ, or fail on GitHub and
+          leave the row where it was. Show what actually happened, in those words. */}
+      {outcome && (
+        <p className={classNames('text-sm', outcomeFailed ? 'text-amber-700' : 'text-gray-600')}>
+          Last review: {outcome}
         </p>
       )}
 
@@ -189,21 +218,31 @@ export default function AdminFeedbackPage() {
                   </td>
                   <td className="px-4 py-3 text-right">
                     {item.status === 'new' && (
-                      <div className="flex items-center justify-end gap-2">
-                        <button
-                          onClick={() => handleAction(item.id, 'approve')}
-                          disabled={review.isPending}
-                          className="text-xs bg-blue-600 text-white px-2.5 py-1 rounded hover:bg-blue-700 disabled:opacity-50"
-                        >
-                          Approve
-                        </button>
-                        <button
-                          onClick={() => handleAction(item.id, 'dismiss')}
-                          disabled={review.isPending}
-                          className="text-xs bg-gray-100 text-gray-700 px-2.5 py-1 rounded hover:bg-gray-200 disabled:opacity-50"
-                        >
-                          Dismiss
-                        </button>
+                      <div className="flex flex-col items-end gap-1">
+                        <div className="flex items-center justify-end gap-2">
+                          <button
+                            onClick={() => handleAction(item.id, 'approve')}
+                            disabled={review.isPending}
+                            className="text-xs bg-blue-600 text-white px-2.5 py-1 rounded hover:bg-blue-700 disabled:opacity-50"
+                          >
+                            {review.isPending && actedId === item.id ? 'Working…' : 'Approve'}
+                          </button>
+                          <button
+                            onClick={() => handleAction(item.id, 'dismiss')}
+                            disabled={review.isPending}
+                            className="text-xs bg-gray-100 text-gray-700 px-2.5 py-1 rounded hover:bg-gray-200 disabled:opacity-50"
+                          >
+                            Dismiss
+                          </button>
+                        </div>
+                        {actedId === item.id && !review.isPending && (reviewError || outcome) && (
+                          <p className={classNames(
+                            'text-xs max-w-xs text-right',
+                            reviewError || outcomeFailed ? 'text-amber-700' : 'text-gray-500'
+                          )}>
+                            {reviewError || outcome}
+                          </p>
+                        )}
                       </div>
                     )}
                   </td>

--- a/src/cqc_lem/utilities/feedback/issue_service.py
+++ b/src/cqc_lem/utilities/feedback/issue_service.py
@@ -152,6 +152,11 @@ class IssueAction:
     ERROR = 'error'                  # GitHub call failed; row left for the next pass to retry
 
 
+# An `ERROR` result the admin panel must word differently: nothing was refused by GitHub, the
+# classifier never answered. Retrying is the right next action, so the row is left in `new`.
+CLASSIFIER_UNAVAILABLE_REASON = 'classification unavailable'
+
+
 # Conventional-commit type per category, so a filed title reads like the commit that will close it.
 _COMMIT_TYPES: dict[FeedbackCategory, str] = {
     FeedbackCategory.BUG: 'fix',
@@ -737,6 +742,18 @@ def file_feedback_issue(feedback: dict, classification: FeedbackClassification =
     # loop with no exit (#1036), so it files instead. The confidence still shapes the LABELS below:
     # a low-confidence item lands `needs-human` + assigned + with a Decision Comment, never
     # `agent:ready`, so nothing gets built unattended off a shaky classification.
+    #
+    # …but a LOW-confidence verdict and NO verdict are not the same thing. `errors` marks the
+    # fail-safe result: the classifier never answered (proxy down, off-contract reply), so its
+    # `summary` is the RAW report and its category/severity are placeholders. Filing that would
+    # publish the raw feedback text this module promises never reaches GitHub, under a title made
+    # of the reporter's first line — and `ISSUE_CREATED` is terminal, so a 30-second LiteLLM blip
+    # would permanently spend the report on a content-free issue nobody can re-approve. Leave the
+    # row in `new` and say so: retrying an approve costs the admin one click.
+    if admin_approved and classification.errors:
+        log_info(f"Feedback {feedback_id} approve could not file — the classifier never answered "
+                 f"({'; '.join(classification.errors)[:200]})", user_id=user_id)
+        return _result(IssueAction.ERROR, feedback_id, reason=CLASSIFIER_UNAVAILABLE_REASON)
 
     vector = as_vector(row.get("embedding")) or embed_text(body)
 

--- a/src/cqc_lem/utilities/feedback/issue_service.py
+++ b/src/cqc_lem/utilities/feedback/issue_service.py
@@ -668,23 +668,38 @@ def _result(action: str, feedback_id: Optional[int], **extra) -> dict:
 
 
 def file_feedback_issue(feedback: dict, classification: FeedbackClassification = None,
-                        clusters: list = None) -> dict:
+                        clusters: list = None, admin_approved: bool = False) -> dict:
     """Take ONE captured feedback row all the way to its outcome (see `IssueAction`). Never raises.
 
     `classification` / `clusters` are injectable so a batch pass classifies once and loads the open
     clusters once. When a new issue IS filed, the caller should append the returned `cluster` to its
-    in-memory cluster list so two identical reports in the same batch don't both file."""
+    in-memory cluster list so two identical reports in the same batch don't both file.
+
+    `admin_approved` (issue #1036) marks the ONE path that is not unattended: an admin clicked
+    Approve on this specific row in the triage panel. Two of the guards below exist purely because
+    the batch pass runs with nobody watching, and re-applying them to an explicit human decision is
+    what made the button look dead — the row was left in `new`, so the panel re-rendered it
+    unchanged."""
     row = feedback or {}
     feedback_id = row.get("id")
     body = row.get("body") or ""
     if not body.strip():
+        # Terminal, so it must SETTLE. An empty body can never become an issue, and leaving it `new`
+        # both re-offers it to every later pass and, on the panel, makes Approve a no-op (#1036).
+        if feedback_id is not None:
+            update_feedback_triage(feedback_id, status=FeedbackStatus.DISMISSED)
         return _result(IssueAction.DROPPED, feedback_id, reason="empty body")
     user_id = row.get("user_id")
 
     # Abuse guard FIRST: one user cannot turn the backlog into their personal firehose. Checked
     # before the LLM so a held row costs nothing, and the row's status is left alone so a later pass
     # (fresh 24h window) picks it up — held, never dropped.
-    if user_id is not None:
+    #
+    # An admin approving ONE row by hand is the opposite of a firehose — they have already read it
+    # and decided — so the cap does not apply. It also cannot be recovered from on that path: a
+    # rate-limited approve leaves a NON-admin row in `new`, and `process_new_feedback` only ever
+    # drains `admin_only=True`, so "held for a later pass" would mean held forever (#1036).
+    if user_id is not None and not admin_approved:
         recent = count_feedback_filed_by_user(user_id, RATE_LIMIT_WINDOW_HOURS)
         if recent >= max_issues_per_user_per_day():
             log_info(f"Feedback {feedback_id} held — {recent} of this user's report(s) already "
@@ -713,10 +728,15 @@ def file_feedback_issue(feedback: dict, classification: FeedbackClassification =
     if classification.route == FeedbackRoute.FAQ:
         update_feedback_triage(feedback_id, status=FeedbackStatus.TRIAGED)
         return _result(IssueAction.FAQ, feedback_id)
-    if classification.route == FeedbackRoute.NEEDS_HUMAN:
+    if classification.route == FeedbackRoute.NEEDS_HUMAN and not admin_approved:
         update_feedback_triage(feedback_id, status=FeedbackStatus.TRIAGED)
         return _result(IssueAction.NEEDS_HUMAN, feedback_id,
                        confidence=classification.confidence)
+    # NEEDS_HUMAN is "a person should look at this before it reaches the backlog" — and on the
+    # approve path a person just did. Parking it back in the queue the admin is standing in is a
+    # loop with no exit (#1036), so it files instead. The confidence still shapes the LABELS below:
+    # a low-confidence item lands `needs-human` + assigned + with a Decision Comment, never
+    # `agent:ready`, so nothing gets built unattended off a shaky classification.
 
     vector = as_vector(row.get("embedding")) or embed_text(body)
 

--- a/tests/unit/api/test_feedback_admin_api.py
+++ b/tests/unit/api/test_feedback_admin_api.py
@@ -113,8 +113,37 @@ class TestReviewFeedback:
             })
         assert r.status_code == 200
         assert r.json()["detail"]["filing_result"]["issue_number"] == 101
-        filer.assert_called_once_with({"id": 5})
+        assert r.json()["detail"]["filed"] is True
+        # Issue #1036: the filer must be told a human is watching, or it re-applies the
+        # unattended-run holds and leaves the row exactly where the admin found it.
+        filer.assert_called_once_with({"id": 5}, admin_approved=True)
         recorder.assert_called_once_with(5, 7)
+
+    def test_deduped_approve_still_counts_as_filed(self, client):
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"], \
+             patch("cqc_lem.api.main.get_feedback_by_id", return_value={"id": 6}), \
+             patch("cqc_lem.utilities.feedback.issue_service.file_feedback_issue",
+                   return_value={"action": "deduped", "issue_number": 77}), \
+             patch("cqc_lem.api.main.record_feedback_review", return_value=True):
+            r = client.post("/api/admin/feedback/6/review", json={
+                "session_token": "tok", "action": "approve",
+            })
+        assert r.json()["detail"]["filed"] is True
+
+    def test_approve_that_reached_no_issue_says_so(self, client):
+        """The 200 only means the review was recorded. A GitHub failure changes NOTHING else, so
+        without `filed` the panel cannot tell it apart from a successful approve (issue #1036)."""
+        with _auth(_ADMIN_USER)["get_session"], _auth(_ADMIN_USER)["is_admin"], \
+             patch("cqc_lem.api.main.get_feedback_by_id", return_value={"id": 12}), \
+             patch("cqc_lem.utilities.feedback.issue_service.file_feedback_issue",
+                   return_value={"action": "error", "reason": "issue creation failed"}), \
+             patch("cqc_lem.api.main.record_feedback_review", return_value=True):
+            r = client.post("/api/admin/feedback/12/review", json={
+                "session_token": "tok", "action": "approve",
+            })
+        assert r.status_code == 200
+        assert r.json()["detail"]["filed"] is False
+        assert r.json()["detail"]["filing_result"]["action"] == "error"
 
     def test_already_filed_row_cannot_be_re_approved(self, client):
         """A filed row IS its own open cluster, so re-running the filer would match it to itself

--- a/tests/unit/utilities/test_feedback_issue_service.py
+++ b/tests/unit/utilities/test_feedback_issue_service.py
@@ -1008,6 +1008,30 @@ class TestFileFeedbackIssue:
         assert 'needs-human' in result["labels"]
         assert create.call_args.kwargs["assignees"] == ["gitchrisqueen"]
 
+    def test_admin_approval_will_not_file_a_classification_that_never_happened(self):
+        """A low-confidence verdict and NO verdict are different things. The fail-safe result
+        carries the RAW report as its `summary` — filing it would publish the feedback text this
+        module promises never reaches GitHub, and `issue_created` is terminal, so one LiteLLM blip
+        would spend the report on an issue nobody can re-approve (issue #1036)."""
+        svc = _mod()
+        unclassified = _classification(confidence=0.0, title="comments break sometimes",
+                                       summary="comments break sometimes and I have no idea why",
+                                       errors=["llm call failed: connection refused"])
+        with patch(f"{_SVC}.count_feedback_filed_by_user", return_value=0), \
+                patch(f"{_SVC}.classify_feedback", return_value=unclassified), \
+                patch(f"{_SVC}.create_github_issue") as create, \
+                patch(f"{_SVC}.comment_on_issue") as commenter, \
+                patch(f"{_SVC}.embed_text", return_value=None), \
+                patch(f"{_SVC}.update_feedback_triage") as triage:
+            result = svc.file_feedback_issue({"id": 24, "user_id": 9, "body": "comments break"},
+                                             clusters=[], admin_approved=True)
+        assert result["action"] == "error"
+        assert result["reason"] == svc.CLASSIFIER_UNAVAILABLE_REASON
+        create.assert_not_called()
+        commenter.assert_not_called()
+        # Left in `new` on purpose — the admin retries once the classifier is back.
+        triage.assert_not_called()
+
     def test_admin_approval_still_respects_the_noise_and_faq_verdicts(self):
         """Those two DO settle the row, so the panel already shows the admin what happened — and
         forcing an issue for something classified as noise is not what Approve is for."""

--- a/tests/unit/utilities/test_feedback_issue_service.py
+++ b/tests/unit/utilities/test_feedback_issue_service.py
@@ -893,9 +893,18 @@ class TestFileFeedbackIssue:
         mocks["triage"].assert_called_once_with(3, status=FeedbackStatus.TRIAGED)
 
     def test_empty_body_is_dropped_without_classifying(self):
+        from cqc_lem.utilities.db import FeedbackStatus
         result, mocks = self._run({"id": 4, "user_id": 3, "body": "   "})
         assert result["action"] == "dropped"
         mocks["classify"].assert_not_called()
+        # Terminal — an empty body can never become an issue, so it must not sit in `new` being
+        # re-offered to every pass (and making Approve a visible no-op, issue #1036).
+        mocks["triage"].assert_called_once_with(4, status=FeedbackStatus.DISMISSED)
+
+    def test_empty_body_without_an_id_does_not_attempt_a_write(self):
+        result, mocks = self._run({"user_id": 3, "body": ""})
+        assert result["action"] == "dropped"
+        mocks["triage"].assert_not_called()
 
     def test_over_the_per_user_cap_is_held_before_any_llm_call(self):
         svc = _mod()
@@ -960,6 +969,77 @@ class TestFileFeedbackIssue:
                                              "context_json": "{not json"}, clusters=[])
         assert result["action"] == "filed"
         assert classify.call_args.kwargs["context"] is None
+
+    def test_admin_approval_is_not_re_gated_by_the_unattended_holds(self):
+        """Issue #1036 — the triage panel's Approve button did nothing.
+
+        Both holds below exist because the batch pass runs unattended. Re-applying them to a row an
+        admin explicitly approved returned 200 and left the row in `new`, so the panel re-rendered
+        it unchanged — indistinguishable from a dead button."""
+        svc = _mod()
+        with patch(f"{_SVC}.count_feedback_filed_by_user", return_value=99) as counter, \
+                patch(f"{_SVC}.classify_feedback", return_value=_classification()), \
+                patch(f"{_SVC}.create_github_issue", return_value=321), \
+                patch(f"{_SVC}.comment_on_issue", return_value=True), \
+                patch(f"{_SVC}.embed_text", return_value=None), \
+                patch(f"{_SVC}.update_feedback_triage") as triage:
+            result = svc.file_feedback_issue({"id": 20, "user_id": 9, "body": "comments break"},
+                                             clusters=[], admin_approved=True)
+        assert result["action"] == "filed"
+        counter.assert_not_called()
+        assert triage.call_args.kwargs["github_issue_number"] == 321
+
+    def test_admin_approval_files_a_low_confidence_row_instead_of_re_queueing_it(self):
+        """NEEDS_HUMAN means "a person should look at this first" — and one just did. Parking it
+        back in the queue the admin is standing in is a loop with no exit (issue #1036)."""
+        svc = _mod()
+        with patch(f"{_SVC}.count_feedback_filed_by_user", return_value=0), \
+                patch(f"{_SVC}.classify_feedback", return_value=_classification(confidence=0.2)), \
+                patch(f"{_SVC}.create_github_issue", return_value=654) as create, \
+                patch(f"{_SVC}.comment_on_issue", return_value=True), \
+                patch(f"{_SVC}.embed_text", return_value=None), \
+                patch(f"{_SVC}.update_feedback_triage"):
+            result = svc.file_feedback_issue({"id": 21, "user_id": 9, "body": "idk it's weird"},
+                                             clusters=[], admin_approved=True)
+        assert result["action"] == "filed"
+        assert result["issue_number"] == 654
+        # …but a shaky classification still never ships unattended: held, assigned, no agent:ready.
+        assert result["agent_ready"] is False
+        assert 'needs-human' in result["labels"]
+        assert create.call_args.kwargs["assignees"] == ["gitchrisqueen"]
+
+    def test_admin_approval_still_respects_the_noise_and_faq_verdicts(self):
+        """Those two DO settle the row, so the panel already shows the admin what happened — and
+        forcing an issue for something classified as noise is not what Approve is for."""
+        from cqc_lem.utilities.db import FeedbackStatus
+        from cqc_lem.utilities.feedback.classifier import FeedbackCategory
+        svc = _mod()
+        for category, action, status in (
+                (FeedbackCategory.NOISE, "dropped", FeedbackStatus.DISMISSED),
+                (FeedbackCategory.QUESTION, "faq", FeedbackStatus.TRIAGED)):
+            with patch(f"{_SVC}.count_feedback_filed_by_user", return_value=0), \
+                    patch(f"{_SVC}.classify_feedback",
+                          return_value=_classification(category=category, confidence=0.99)), \
+                    patch(f"{_SVC}.create_github_issue") as create, \
+                    patch(f"{_SVC}.embed_text", return_value=None), \
+                    patch(f"{_SVC}.update_feedback_triage") as triage:
+                result = svc.file_feedback_issue({"id": 22, "user_id": 9, "body": "you guys rock"},
+                                                 clusters=[], admin_approved=True)
+            assert result["action"] == action
+            create.assert_not_called()
+            triage.assert_called_once_with(22, status=status)
+
+    def test_the_batch_pass_still_gets_every_unattended_hold(self):
+        svc = _mod()
+        with patch(f"{_SVC}.count_feedback_filed_by_user", return_value=99), \
+                patch(f"{_SVC}.classify_feedback") as classify, \
+                patch(f"{_SVC}.create_github_issue") as create, \
+                patch(f"{_SVC}.update_feedback_triage"):
+            result = svc.file_feedback_issue({"id": 23, "user_id": 9, "body": "another one"},
+                                             clusters=[])
+        assert result["action"] == "rate_limited"
+        classify.assert_not_called()
+        create.assert_not_called()
 
     def test_clusters_are_loaded_from_the_db_when_not_injected(self):
         svc = _mod()


### PR DESCRIPTION
## What was broken

Clicking **Approve** in the admin feedback triage panel did nothing visible.

`POST /api/admin/feedback/{id}/review` ran the *unattended* filer path unchanged, so an explicit
human approval was re-gated by holds that only exist because the batch pass runs with nobody
watching. Three filer outcomes leave the row **exactly as they found it**:

| outcome | status write | what the admin sees |
|---|---|---|
| `filed` / `deduped` / `dropped(noise)` / `faq` | yes | row moves ✅ |
| `rate_limited` — reporter over the per-user daily cap | **none** | row unchanged ❌ |
| `dropped(empty body)` | **none** | row unchanged ❌ |
| `error` — GitHub refused | **none** | row unchanged ❌ |

All three return **200**, the panel invalidates the list, and the row re-renders identically. The
only signal was a small grey `Last review: approved — filer: rate_limited` line **above** the table.

Two of those are also wrong on their own terms:

- **`rate_limited` is unrecoverable here.** The comment says "held for a later pass" — but the panel
  only ever holds **non-admin** rows, and `process_new_feedback` drains `get_unprocessed_feedback(admin_only=True)`.
  There is no later pass. Held meant held forever.
- **`needs_human` is a loop with no exit.** It parks the row in `triaged` because "a person should
  look at this before it reaches the backlog" — and a person just did. It leaves the queue, still with
  no issue, and no button that can ever produce one.

## The fix

**`file_feedback_issue(..., admin_approved=True)`** — the ONE path that is not unattended.

- Skips the per-user daily issue cap. An admin approving one row by hand is the opposite of the
  firehose that guard exists for.
- Files a `NEEDS_HUMAN` row instead of re-queueing it. Confidence still shapes the **labels**, so a
  shaky classification lands `needs-human` + assigned + a Decision Comment and never `agent:ready` —
  nothing gets built unattended off a low-confidence read.
- **NOISE and FAQ are unchanged.** Those settle the row, so the panel already shows the admin what
  happened, and forcing an issue for something classified as noise is not what Approve is for.
- **The batch pass keeps every hold** — covered by its own test.

**An empty body now settles as `dismissed`.** It can never become an issue, so leaving it `new` both
re-offered it to every later pass and made Approve a visible no-op.

**The response carries `filed`.** A 200 only says the review was recorded; a GitHub refusal changes
nothing else and is otherwise indistinguishable from a successful approve.

**The panel says what happened, at the button.** `FILING_OUTCOMES` maps each filer verb to a
sentence an admin can act on (`GitHub refused the filing — nothing changed. Try Approve again.`),
rendered in the acted row's Actions cell — the banner alone sits above a table the admin has
scrolled past — and amber, not grey, when nothing was filed. The button reads `Working…` while the
mutation is in flight.

## Testing

- `tests/unit/utilities/test_feedback_issue_service.py` — approve is not re-gated by either hold;
  low-confidence approve files but stays held/assigned/not-`agent:ready`; NOISE + FAQ verdicts still
  respected; the batch pass still gets every hold; empty body settles (and doesn't write without an id).
- `tests/unit/api/test_feedback_admin_api.py` — the filer is called with `admin_approved=True`;
  `filed` is true for filed/deduped and **false** for a GitHub error.
- `AdminFeedbackPage.test.tsx` — a no-issue approve is reported in the row's cell and not as a
  success; a successful approve names the issue; the click sends the clicked row's id.
- `poetry run pytest tests/unit -q` → **10464 passed**. `eslint` clean, `tsc --noEmit` clean.
  vitest could not run locally (node 18 on this box; the suite needs 22) — CI is the source of truth.

Docs: `docs/launch-and-marketing-plan.md` §B.2 now records that Approve is a human decision and which
holds therefore do not apply to it.

`release:now`: user-visible breakage on a `priority:high` bug — an admin surface that silently does
nothing is worth shipping in the next flip rather than the next window.

Closes #1036

🤖 Generated with [Claude Code](https://claude.com/claude-code)