### PR TITLE
fix(errors): one lost invite must file one issue, not two (closes #1038)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -7066,7 +7066,12 @@ def invite_to_connect(self, user_id: int, profile_url: str, message: str = None)
         return "Invitation deferred (LinkedIn throttled)"
     if sent:
         return CONNECTION_REQUEST_SENT_MESSAGE
-    log_warning(f"Connection request failed: {reason}", user_id=user_id, action_type="invite_connect")
+    # DEBUG, not a warning: every reason invite_to_connect_now returns has ALREADY been logged by
+    # the step that owns it — at ERROR with exc= for a dialog with no Send button, WARNING for no
+    # route to the dialog, INFO for an existing connection. Restating it here forked a SECOND
+    # grouped $exception (and a second auto-filed issue) for one lost invite (#1038 / #1042).
+    log_debug(f"Connection request failed: {reason}", user_id=user_id, action_type="invite_connect",
+              task_name="invite_to_connect")
     return f"Connection Request Failed: {reason}"
 
 
@@ -7101,8 +7106,10 @@ def send_roster_connect_invite(self, user_id: int, profile_url: str, message: st
         set_target_connect_status(user_id, profile_url, ConnectStatus.CONNECTED)
         return ALREADY_CONNECTED_MESSAGE
     set_target_connect_status(user_id, profile_url, ConnectStatus.FAILED)
-    log_warning(f"Roster connection request failed: {reason}", user_id=user_id,
-                action_type="invite_connect", task_name="send_roster_connect_invite")
+    # The 'failed' badge is the record that matters here; the reason itself was already logged by
+    # the step that owns it, so re-warning would double-count it into a second issue (#1038).
+    log_debug(f"Roster connection request failed: {reason}", user_id=user_id,
+              action_type="invite_connect", task_name="send_roster_connect_invite")
     return f"Roster connection request failed: {reason}"
 
 
@@ -7133,8 +7140,10 @@ def send_connection_request(self, request_id: int):
         update_connection_request_status(request_id, ConnectionRequestStatus.APPROVED)  # retry on next scan
         return f"Connection request {request_id} deferred (LinkedIn throttled)"
     if not sent:
-        log_warning(f"Connection request {request_id} failed: {reason}", user_id=user_id,
-                    action_type="invite_connect")
+        # The reason is stored on the request row below and was already logged at its owning step;
+        # a warning here would only fork a second grouped issue for the same invite (#1038).
+        log_debug(f"Connection request {request_id} failed: {reason}", user_id=user_id,
+                  action_type="invite_connect", task_name="send_connection_request")
     update_connection_request_status(
         request_id, ConnectionRequestStatus.SENT if sent else ConnectionRequestStatus.FAILED,
         failure_reason=(None if sent else reason))

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -70,6 +70,12 @@ Two things follow for anyone writing a call site here:
    where you detect, not where you notice.** ONE unreadable card still warns twice, because the
    pre-click 'Reaction state' read warns too (issue #874, open); collapse that into the opener's
    signal as well, and never add a fourth.
+   A **task wrapper** counts as a caller: `invite_to_connect` / `send_connection_request` /
+   `send_roster_connect_invite` each re-logged the reason `invite_to_connect_now` handed back, but
+   every one of those reasons was already logged where it happened — ERROR with `exc=` for a dialog
+   with no Send button, WARNING for no route to the dialog, INFO for an existing connection — so one
+   lost invite filed TWO grouped issues (#1038 and #1042, same event, 23s apart). The wrappers log it
+   at DEBUG; the badge/row they write is the record that matters (issue #1038).
    The rule reads sideways for a **state-setter**: doing what you were asked is not a degraded path,
    however serious the state is. `pause_automation` warned every time it stored the global Selenium
    kill-switch, and maintenance mode sets one on EVERY release, so a routine deploy filed

--- a/tests/unit/app/test_invite_connect_error_ownership.py
+++ b/tests/unit/app/test_invite_connect_error_ownership.py
@@ -1,0 +1,109 @@
+"""One lost invite must file ONE issue, not two (issues #1038 / #1042).
+
+The 2026-08-03 rail hazard (#1012) storm surfaced this: `_submit_connect_invite` logs the lost
+invite at ERROR with `exc=` — the deliberate #573 error, owned by the step that saw it — and then
+every task wrapper re-logged the SAME reason at WARNING. Under the escalation contract a repeated
+warning is promoted to ERROR and files its own grouped `$exception`, so a single failed invite
+arrived as two PostHog issues and two auto-filed GitHub issues (#1038 for the TimeoutException,
+#1042 for the restatement). The wrappers now log the reason at DEBUG: the owning step keeps the
+severity, the wrappers keep the breadcrumb.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cqc_lem.utilities.db import (ALREADY_CONNECTED_MESSAGE, INVITE_NOT_SENT_MESSAGE,
+                                  NO_CONNECT_BUTTON_MESSAGE)
+
+pytestmark = pytest.mark.unit
+
+_RA = "cqc_lem.app.run_automation"
+
+# Every reason invite_to_connect_now can hand back with sent=False. Each is already logged by the
+# step that owns it, so none of them may re-emit from a wrapper.
+_OWNED_REASONS = [ALREADY_CONNECTED_MESSAGE, NO_CONNECT_BUTTON_MESSAGE, INVITE_NOT_SENT_MESSAGE,
+                  "Error while inviting to connect: boom"]
+
+
+class TestInviteToConnectWrapper:
+    @pytest.mark.parametrize("reason", _OWNED_REASONS)
+    def test_a_failure_the_core_already_logged_is_not_re_warned(self, reason):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.invite_to_connect_now", return_value=(False, reason)), \
+             patch(f"{_RA}.log_warning") as log_warning, \
+             patch(f"{_RA}.log_error") as log_error, \
+             patch(f"{_RA}.log_debug") as log_debug:
+            out = ra.invite_to_connect(1, "https://x/in/jane")
+
+        assert reason in out
+        log_warning.assert_not_called()
+        log_error.assert_not_called()
+        log_debug.assert_called_once()  # the breadcrumb stays, at a level that never escalates
+        assert log_debug.call_args.kwargs["user_id"] == 1
+
+
+class TestRosterWrapper:
+    def test_a_failed_roster_invite_badges_the_row_without_re_warning(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.db import ConnectStatus
+        with patch(f"{_RA}.invite_to_connect_now", return_value=(False, INVITE_NOT_SENT_MESSAGE)), \
+             patch(f"{_RA}.set_target_connect_status") as status, \
+             patch(f"{_RA}.log_warning") as log_warning, \
+             patch(f"{_RA}.log_debug") as log_debug:
+            out = ra.send_roster_connect_invite(1, "https://x/in/jane")
+
+        status.assert_called_once_with(1, "https://x/in/jane", ConnectStatus.FAILED)
+        assert INVITE_NOT_SENT_MESSAGE in out
+        log_warning.assert_not_called()
+        log_debug.assert_called_once()
+
+
+class TestProactiveWrapper:
+    def test_a_failed_request_stores_the_reason_without_re_warning(self):
+        from cqc_lem.app import run_automation as ra
+        from cqc_lem.utilities.db import ConnectionRequestStatus
+        req = {"id": 3, "user_id": 1, "recipient_profile_url": "https://x/in/jane",
+               "message": "hi jane", "status": "approved"}
+        with patch("cqc_lem.utilities.db.get_connection_request", return_value=req), \
+             patch("cqc_lem.utilities.db.count_invites_sent_today", return_value=0), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={"max_invites_per_day": 10}), \
+             patch(f"{_RA}.invite_to_connect_now", return_value=(False, INVITE_NOT_SENT_MESSAGE)), \
+             patch("cqc_lem.utilities.db.update_connection_request_status") as upd, \
+             patch(f"{_RA}.log_warning") as log_warning, \
+             patch(f"{_RA}.log_debug") as log_debug:
+            ra.send_connection_request(3)
+
+        # The failure is still recorded where it is actionable — on the request row.
+        upd.assert_called_once_with(3, ConnectionRequestStatus.FAILED,
+                                    failure_reason=INVITE_NOT_SENT_MESSAGE)
+        log_warning.assert_not_called()
+        log_debug.assert_called_once()
+
+
+class TestOneLostInviteFilesOneIssue:
+    def test_the_dialog_with_no_send_button_escalates_exactly_once(self):
+        """End to end through the real core: the ONE escalating log is the owner's, with exc=."""
+        from cqc_lem.app import run_automation as ra
+
+        def click(driver, wait, xpath, label, **kwargs):
+            raise Exception(f"no element for {xpath}")  # no Send affordance in either state
+
+        with patch(f"{_RA}.get_user_password_pair_by_id", return_value=("e@x", "pw")), \
+             patch(f"{_RA}.get_driver_wait_pair", return_value=(MagicMock(), MagicMock())), \
+             patch(f"{_RA}.login_to_linkedin"), \
+             patch(f"{_RA}._profile_is_first_degree", return_value=False), \
+             patch(f"{_RA}._open_connect_invite_dialog", return_value=True), \
+             patch(f"{_RA}.click_element_wait_retry", side_effect=click), \
+             patch(f"{_RA}.time.sleep"), \
+             patch(f"{_RA}.insert_new_log"), \
+             patch(f"{_RA}.record_action"), \
+             patch(f"{_RA}.quit_gracefully"), \
+             patch(f"{_RA}.log_warning") as log_warning, \
+             patch(f"{_RA}.log_error") as log_error:
+            out = ra.invite_to_connect(1, "https://x/in/jane")
+
+        assert INVITE_NOT_SENT_MESSAGE in out
+        log_error.assert_called_once()
+        assert isinstance(log_error.call_args.kwargs.get("exc"), Exception)
+        log_warning.assert_not_called()  # no second fingerprint for the same lost invite


### PR DESCRIPTION
## What

Two auto-filed error-tracking issues — #1038 (`TimeoutException: Finding Send Connection Button`) and #1042 (`RecurringWarning: Connection request failed: Connect dialog opened but the invitation could not be sent`) — are **the same event**, 23 seconds apart, from the same actor and the same Celery task.

### The TimeoutException's root cause is already fixed

The 25 occurrences (2026-08-03 14:31–14:54 UTC) were the downstream symptom of the connect-invite **rail hazard** fixed in #1012: the old unscoped `//main//button[contains(@aria-label,"Invite ")]` locator clicked a *"More profiles for you"* rail button, no invite dialog ever opened, and the Send step timed out — once a minute, for 23 minutes.

Verified rather than assumed:

- Last occurrence: `2026-08-03T14:54:31.166Z` (PostHog, issue `019fc809-…`).
- The fix shipped in **v0.129.1**, tagged 2026-08-03 15:44 UTC — *after* the last occurrence.
- Prod is on **0.132.1** and there have been **zero occurrences since**.

`_open_connect_invite_dialog` now routes by URL and only reports success when the dialog's own controls are provably present, so `_submit_connect_invite` can no longer be reached with nothing open. That invariant is already locked by `tests/unit/app/test_invite_connect_affordance.py`.

### What the storm exposed, and what this PR fixes

The same failure was logged **twice**. `_submit_connect_invite` logs it at ERROR with `exc=` — the deliberate #573 error, owned by the step that saw it — and then all three task wrappers re-logged the reason at WARNING. Under the escalation contract a repeated warning is promoted to ERROR and files its **own** grouped `$exception`, so one lost invite became two PostHog issues and two GitHub issues.

Every reason `invite_to_connect_now` hands back is already logged where it happened:

| reason | owner | level |
|---|---|---|
| `INVITE_NOT_SENT_MESSAGE` | `_submit_connect_invite` | ERROR + `exc=` |
| `NO_CONNECT_BUTTON_MESSAGE` | `_open_connect_invite_dialog` | WARNING |
| `ALREADY_CONNECTED_MESSAGE` | `invite_to_connect_now` | INFO |
| `Error while inviting to connect: …` | `invite_to_connect_now` | ERROR + `exc=` |

So `invite_to_connect`, `send_connection_request` and `send_roster_connect_invite` now log the reason at **DEBUG**. Severity stays with the owner; the wrappers keep the breadcrumb, and the roster badge / request row they write is the record that matters. This is the existing **"warn where you detect, not where you notice"** rule (#878) applied to a task wrapper — documented as such in `src/cqc_lem/utilities/CLAUDE.md`.

Note that `ALREADY_CONNECTED_MESSAGE` was being warned as `Connection request failed: Already connected` — an expected outcome filed as a defect.

## Testing

- New `tests/unit/app/test_invite_connect_error_ownership.py` (7 tests): every failure reason through each of the three wrappers emits no WARNING/ERROR, the roster badge and the request row are still written, and one end-to-end run through the real core with no Send button escalates **exactly once** — the owner's `log_error(exc=…)`.
- Full unit lane green locally: `10472 passed`.

## Review addendum — the same event filed a **third** issue, tracked on #1039

Adversarial review checked the "two issues, one event" framing against PostHog and it is one short.
The same storm also grouped `TimeoutException: Finding Add a Note Button`
(`019fc809-ea83-…`, `2026-08-03T14:32:00.257Z`, 1 occurrence, same actor, same `invite_to_connect`
task) — auto-filed as **#1039**, still open. It is the same rail hazard: with no dialog actually
open, `_add_connect_note`'s "Add a note" lookup timed out for exactly the reason the Send lookup
did, seconds earlier, on the same noted invite.

It is **not** in this PR's scope and is deliberately **not** closed here. `_add_connect_note` is the
step that *detects* its own miss, so the "warn where you detect" rule this PR applies does not touch
it; what #1039 has to decide is the separate question of whether a note affordance LinkedIn removes
once a free account's personalized-invite quota is spent — an expected outcome with a fallback in
hand (the invite goes out bare, #573) — should carry `exc=` and file a defect at all. Linked so the
next agent on #1039 starts from "already fixed upstream by #1012, re-scope to the quota case"
instead of re-deriving it.

Also verified for this PR rather than taken on trust: PostHog issue `019fc809-1768-…` (#1038) shows
`last_seen 2026-08-03T14:54:31.166Z` and **zero occurrences since** across the last 14 days, with
`v0.129.1` tagged `2026-08-03 15:44:05 UTC` — after the last occurrence. `_OWNED_REASONS` in the new
test is exhaustive against every `sent=False` return in `invite_to_connect_now`, so no failure reason
loses its escalating signal by moving the wrappers to DEBUG.

Related: #1039

Closes #1038
Closes #1042

🤖 Generated with [Claude Code](https://claude.com/claude-code)

