### PR TITLE
fix(errors): a missing connect-note affordance is a no-op, not a defect (closes #1039)

### DIFF
--- a/docs/sdui-probe-coverage.md
+++ b/docs/sdui-probe-coverage.md
@@ -33,7 +33,7 @@ code is missing from this table.
 | Feed share-box composer | `_post_composer_for_card` | `--probe-composer` | yes | per-card miss is a DEBUG no-op by design (#876) |
 | Profile-views viewer list | `_PROFILE_VIEWER_ROWS_JS` | `--profile-views` | yes | zero rows vs the page's headline stat (#1009) |
 | Profile header scrape + degree badge | `parse_profile_header` / `_profile_is_first_degree` | `--profile-scrape` | yes | **none — see Gaps** |
-| Connect invite dialog | `_open_connect_invite_dialog` | `--connect-dialog` | no (needs a target) | dialog controls must be present before Send (#1012) |
+| Connect invite dialog | `_open_connect_invite_dialog` | `--connect-dialog` | no (needs a target) | dialog controls must be present before Send (#1012); a missing note affordance is graded against the bare-send control, never warned (#1039) |
 | Catch-up moment cards | `_CATCHUP_CARD_LOCATORS` | `--catchup-cards` | yes | zero cards vs `main div[role='listitem']` (#1013) |
 | Group share box / editor | `auto_post_to_group` | `--group-composer` | no (needs a group) | `_unpostable` rotates past the group (#858) |
 | Company-page invite modal | `automate_invitations` | `--company-invite` | yes | **none — see Gaps** |
@@ -111,8 +111,16 @@ composer and close it with Escape without typing.
 
 ## Gaps (tracked, not silent)
 
-Three production paths still lack a zero-result tripwire. They are named here rather than left to
+Four production paths still lack a zero-result tripwire. They are named here rather than left to
 be rediscovered:
+
+- **Connect-dialog note affordance** — a missing `Add a note` button is the expected quota-spent
+  fallback (`_add_connect_note` sends the invite bare and logs DEBUG, #1039) and is also what a
+  rotated label would look like, and production cannot tell them apart: the dialog renders exactly
+  the same way once a free account's personalized invites are spent. Warning on it filed a
+  fingerprinted defect per lost note, so the reading moved here — `--connect-dialog` reports
+  `note_affordance_present` / `bare_send_present` and says so in its verdict. It is deliberately
+  NOT graded `drift`: the probe account's own quota state is not knowable from the page.
 
 - **Profile header scrape** — `parse_profile_header` raises `ProfileUnavailableError` on an error
   page, but a page that renders with no `<h1>` and no usable `<title>` yields no name and no

--- a/docs/sdui-probe-coverage.md
+++ b/docs/sdui-probe-coverage.md
@@ -132,5 +132,7 @@ be rediscovered:
 - **Own post stats** — `_post_social_counts` scoring every signal 0 is indistinguishable from a post
   with no engagement.
 
-The probes above grade all three today, so the weekly sweep catches them; the tripwires would catch
-them in production, per run, which is stronger.
+The weekly sweep grades the last three, so it catches them there; the tripwires would catch them in
+production, per run, which is stronger. The connect-dialog note affordance is the odd one out and
+deliberately so: `--connect-dialog` needs a target profile, so it is NOT in the weekly sweep, and it
+reports the affordance without grading it. That reading only exists when somebody runs the probe.

--- a/scripts/linkedin_live_validation.py
+++ b/scripts/linkedin_live_validation.py
@@ -1656,10 +1656,11 @@ def connect_dialog_verdict(reading: Optional[dict]) -> str:
         # An absent note affordance is NOT drift on its own — a spent personalized-invite quota
         # hides it, and production treats that as the expected bare-invite fallback (#1039). It is
         # reported here because this probe is the only place the two readings can be told apart.
-        note = ("" if reading.get("note_affordance_present") else
-                " NOTE: no Add-a-note control on this dialog — production sends the invite bare and "
+        # `is False` deliberately: a reading that never looked (None) must claim nothing.
+        note = (" NOTE: no Add-a-note control on this dialog — production sends the invite bare and "
                 "logs that at DEBUG (#1039); read it as selector rot only if this account still has "
-                "personalized invites left.")
+                "personalized invites left."
+                if reading.get("note_affordance_present") is False else "")
         return f"the custom-invite URL rendered the Connect dialog's own controls.{note}{tail}"
     if reading.get("invite_pending"):
         return (f"an invite is already pending for this profile, so no dialog renders — this "
@@ -1697,16 +1698,23 @@ def probe_connect_dialog(driver, profile_url: str, sleep=time.sleep) -> dict:
     dialog = find_first(driver, wait, _CONNECT_DIALOG_LOCATORS, "Connect invite dialog",
                         required=False, warn_on_miss=False, max_try=1, visible_only=True)
     # Which of the dialog's two controls rendered is what tells a spent personalized-invite quota
-    # apart from a rotated note selector — the distinction production cannot make (#1039).
-    note_button = find_first(driver, wait, _CONNECT_NOTE_BUTTON_LOCATORS, "Add a note button",
-                             required=False, warn_on_miss=False, max_try=1, visible_only=True)
-    bare_send = find_first(driver, wait, _CONNECT_BARE_SEND_LOCATORS, "Send without a note",
-                           required=False, warn_on_miss=False, max_try=1, visible_only=True)
+    # apart from a rotated note selector — the distinction production cannot make (#1039). Only
+    # asked when a dialog actually rendered: on a page with no dialog at all both would come back
+    # absent, and "no Add-a-note control" is then a note-affordance reading nobody took. None, not
+    # False — and two waits this probe does not have to sit through.
+    note_present = bare_send_present = None
+    if dialog is not None:
+        note_present = find_first(driver, wait, _CONNECT_NOTE_BUTTON_LOCATORS, "Add a note button",
+                                  required=False, warn_on_miss=False, max_try=1,
+                                  visible_only=True) is not None
+        bare_send_present = find_first(driver, wait, _CONNECT_BARE_SEND_LOCATORS,
+                                       "Send without a note", required=False, warn_on_miss=False,
+                                       max_try=1, visible_only=True) is not None
     reading.update({"url": getattr(driver, "current_url", ""),
                     "dialog_present": dialog is not None,
                     "dialog_control": element_evidence(dialog) if dialog is not None else None,
-                    "note_affordance_present": note_button is not None,
-                    "bare_send_present": bare_send is not None,
+                    "note_affordance_present": note_present,
+                    "bare_send_present": bare_send_present,
                     "page_text": page_text_sample(driver),
                     "visible_controls": visible_button_labels(driver)})
 

--- a/scripts/linkedin_live_validation.py
+++ b/scripts/linkedin_live_validation.py
@@ -1653,7 +1653,14 @@ def connect_dialog_verdict(reading: Optional[dict]) -> str:
             f"else ({hazards[:3]}) — never click one." if hazards else "")
     state = connect_dialog_state(reading)
     if state == STATE_OK:
-        return f"the custom-invite URL rendered the Connect dialog's own controls.{tail}"
+        # An absent note affordance is NOT drift on its own — a spent personalized-invite quota
+        # hides it, and production treats that as the expected bare-invite fallback (#1039). It is
+        # reported here because this probe is the only place the two readings can be told apart.
+        note = ("" if reading.get("note_affordance_present") else
+                " NOTE: no Add-a-note control on this dialog — production sends the invite bare and "
+                "logs that at DEBUG (#1039); read it as selector rot only if this account still has "
+                "personalized invites left.")
+        return f"the custom-invite URL rendered the Connect dialog's own controls.{note}{tail}"
     if reading.get("invite_pending"):
         return (f"an invite is already pending for this profile, so no dialog renders — this "
                 f"reading grounds nothing; probe a profile with no outstanding invite.{tail}")
@@ -1671,7 +1678,8 @@ def probe_connect_dialog(driver, profile_url: str, sleep=time.sleep) -> dict:
     STRICTLY read-only — it never clicks Send, never clicks an Invite control, and never opens the
     More menu. That is the whole point: this surface's last drift sent ~20 connection requests to
     strangers, so the probe that grounds it must be incapable of sending one."""
-    from cqc_lem.app.run_automation import (_CONNECT_DIALOG_LOCATORS, _CONNECT_INVITE_URL,
+    from cqc_lem.app.run_automation import (_CONNECT_BARE_SEND_LOCATORS, _CONNECT_DIALOG_LOCATORS,
+                                            _CONNECT_INVITE_URL, _CONNECT_NOTE_BUTTON_LOCATORS,
                                             _PROFILE_MORE_MENU_LOCATORS, _profile_slug)
     from cqc_lem.utilities.selenium_util import find_first
     from selenium.webdriver.support.ui import WebDriverWait
@@ -1688,9 +1696,17 @@ def probe_connect_dialog(driver, profile_url: str, sleep=time.sleep) -> dict:
     sleep(5)
     dialog = find_first(driver, wait, _CONNECT_DIALOG_LOCATORS, "Connect invite dialog",
                         required=False, warn_on_miss=False, max_try=1, visible_only=True)
+    # Which of the dialog's two controls rendered is what tells a spent personalized-invite quota
+    # apart from a rotated note selector — the distinction production cannot make (#1039).
+    note_button = find_first(driver, wait, _CONNECT_NOTE_BUTTON_LOCATORS, "Add a note button",
+                             required=False, warn_on_miss=False, max_try=1, visible_only=True)
+    bare_send = find_first(driver, wait, _CONNECT_BARE_SEND_LOCATORS, "Send without a note",
+                           required=False, warn_on_miss=False, max_try=1, visible_only=True)
     reading.update({"url": getattr(driver, "current_url", ""),
                     "dialog_present": dialog is not None,
                     "dialog_control": element_evidence(dialog) if dialog is not None else None,
+                    "note_affordance_present": note_button is not None,
+                    "bare_send_present": bare_send is not None,
                     "page_text": page_text_sample(driver),
                     "visible_controls": visible_button_labels(driver)})
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -6925,15 +6925,54 @@ def _open_connect_invite_dialog(driver, wait, user_id: int, profile_url: str) ->
     return False
 
 
+# The bare-send control is the dialog's own word for "no note is on offer here": a quota-spent
+# dialog renders it and NO Add-a-note (both labels live-grounded 2026-08-03,
+# docs/sdui-selenium-notes.md). Same `contains` form _submit_connect_invite clicks, so the
+# cross-check below can never disagree with the send that immediately follows it.
+_SEND_WITHOUT_NOTE_XPATH = '//button[contains(@aria-label,"Send without a note")]'
+_CONNECT_BARE_SEND_LOCATORS = [(By.XPATH, _SEND_WITHOUT_NOTE_XPATH)]
+
+_CONNECT_NOTE_BUTTON_LOCATORS = [
+    (By.XPATH, '//button[contains(@aria-label,"Add a note")]'),
+    (By.XPATH, '//button[normalize-space()="Add a note"]'),
+]
+
+
 def _add_connect_note(driver, wait, message: str, user_id: int) -> bool:
     """Type a personalized note into an OPEN Connect dialog. Best-effort by design (issue #573):
     LinkedIn hides the note affordance once a free account's personalized-invite quota is spent, and
-    a note that can't be attached must not cost us the invite — the caller sends it bare instead. So
-    every miss here is a WARNING, and the note is stripped of non-BMP characters first because
-    ChromeDriver's send_keys raises on the emoji an AI-written note routinely carries."""
+    a note that can't be attached must not cost us the invite — the caller sends it bare instead.
+    The note is stripped of non-BMP characters first because ChromeDriver's send_keys raises on the
+    emoji an AI-written note routinely carries.
+
+    A MISSING affordance is not a failure at all (issue #1039). It is the quota-spent no-op this
+    docstring already describes, the fallback is in hand, and warning on it filed a fingerprinted
+    defect for working behaviour once per lost note — so it is DEBUG, and the bare-send control the
+    dialog still shows is what says which no-op it was. A step that fails AFTER the affordance
+    answered is a genuine degraded path and still warns with `exc=`."""
+    if find_first(driver, wait, _CONNECT_NOTE_BUTTON_LOCATORS, "Add a note button",
+                  required=False, warn_on_miss=False, max_try=1, visible_only=True,
+                  user_id=user_id) is None:
+        if find_first(driver, wait, _CONNECT_BARE_SEND_LOCATORS, "Send without a note",
+                      required=False, warn_on_miss=False, max_try=1, visible_only=True,
+                      user_id=user_id) is not None:
+            log_debug("Connect dialog offers no Add-a-note affordance (personalized-invite quota "
+                      "spent) — sending the invite bare", user_id=user_id,
+                      action_type="invite_connect")
+        else:
+            # Not the quota case: the dialog proven open moments ago no longer shows either of its
+            # controls. This is DEBUG too, because the invite it costs us is the ONE thing
+            # _submit_connect_invite is about to log as an error — warning here would file a second
+            # grouped issue for that same lost invite, which is exactly what #1038 fixed.
+            log_debug("Connect dialog is no longer showing its own controls; attaching no note",
+                      user_id=user_id, action_type="invite_connect")
+        return False
+
     try:
-        click_element_wait_retry(driver, wait, '//button[contains(@aria-label,"Add a note")]',
-                                 "Finding Add a Note Button", max_retry=1, use_action_chain=True)
+        # required=True: the affordance answered a moment ago, so failing to click it now is a real
+        # degraded path — it raises into the warning below rather than reading as "not on offer".
+        click_first(driver, wait, _CONNECT_NOTE_BUTTON_LOCATORS, "Add a note button",
+                    max_try=1, use_action_chain=True, user_id=user_id)
 
         message_box = click_element_wait_retry(driver, wait, '//textarea[@id="custom-message"]',
                                                "Finding Message Box", max_retry=1, use_action_chain=True)
@@ -6960,7 +6999,7 @@ def _add_connect_note(driver, wait, message: str, user_id: int) -> bool:
 # The Send button's aria-label differs between the bare dialog and the one carrying a note, and a
 # note attempt can leave the dialog in either state — so both are tried, preferred label first.
 _SEND_INVITE_XPATHS = ('//button[contains(@aria-label,"Send invitation")]',
-                       '//button[contains(@aria-label,"Send without a note")]')
+                       _SEND_WITHOUT_NOTE_XPATH)
 
 
 def _submit_connect_invite(driver, wait, user_id: int, with_note: bool) -> bool:

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -76,6 +76,15 @@ Two things follow for anyone writing a call site here:
    with no Send button, WARNING for no route to the dialog, INFO for an existing connection — so one
    lost invite filed TWO grouped issues (#1038 and #1042, same event, 23s apart). The wrappers log it
    at DEBUG; the badge/row they write is the record that matters (issue #1038).
+   The same invite showed the fallback test from the other side: `_add_connect_note` warned with
+   `exc=` on a missing 'Add a note' button, but its own docstring calls that miss EXPECTED — a spent
+   personalized-invite quota hides the control and the invite goes out bare — so it filed a
+   fingerprinted defect per lost note. An absent affordance is DEBUG, and the dialog's bare-send
+   control is the cross-check that says WHICH no-op it was; only a step failing AFTER the affordance
+   answered still warns (issue #1039). What that costs is drift detection at the call site — the two
+   readings are identical in the DOM — so it moved to the `--connect-dialog` probe, which reports the
+   affordance without grading it (`docs/sdui-probe-coverage.md`). **A miss you cannot attribute
+   belongs in a probe, not in a warning.**
    The rule reads sideways for a **state-setter**: doing what you were asked is not a degraded path,
    however serious the state is. `pause_automation` warned every time it stored the global Selenium
    kill-switch, and maintenance mode sets one on EVERY release, so a routine deploy filed

--- a/tests/unit/app/test_invite_connect_note.py
+++ b/tests/unit/app/test_invite_connect_note.py
@@ -1,15 +1,21 @@
-"""The note half of the invite send path (issue #573).
+"""The note half of the invite send path (issues #573 + #1039).
 
 `Failed to add a note to connection request` paged the error cron, and behind that error the whole
 invite was abandoned with the Connect dialog already open — LinkedIn hides the note affordance once
 a free account's personalized-invite quota is spent, and an AI-written note routinely carries emoji
 that ChromeDriver's send_keys refuses to type. Both now degrade to a bare invite; only a dialog with
 no Send button at all is still an error.
+
+#1039: degrading was not enough. The miss still went out as a WARNING carrying `exc=`, so a routine
+quota-spent invite filed a fingerprinted `TimeoutException: Finding Add a Note Button` defect for
+working behaviour. An ABSENT affordance is now a DEBUG no-op — graded against the bare-send control
+the dialog still shows — and only a failure AFTER the affordance answered warns.
 """
 
 from unittest.mock import MagicMock, patch
 
 import pytest
+from selenium.common.exceptions import TimeoutException
 
 pytestmark = pytest.mark.unit
 
@@ -34,6 +40,33 @@ def _clicker(found: set[str], box: MagicMock = None):
     return MagicMock(side_effect=click)
 
 
+def _finder(found: set[str]):
+    """find_first stand-in: the first locator whose xpath is on the page wins, else None."""
+
+    def find(driver, wait, locators, label, **kwargs):
+        return MagicMock() if any(value in found for _by, value in locators) else None
+
+    return MagicMock(side_effect=find)
+
+
+def _first_clicker(found: set[str]):
+    """click_first stand-in — raises when nothing matches and the caller required a hit."""
+
+    def click(driver, wait, locators, label, **kwargs):
+        if any(value in found for _by, value in locators):
+            return MagicMock()
+        if kwargs.get("required", True):
+            raise TimeoutException(label)
+        return None
+
+    return MagicMock(side_effect=click)
+
+
+class _Result:
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
 def _invite(found: set[str], message: str = None, box: MagicMock = None, refined: str = "short note"):
     from cqc_lem.app import run_automation as ra
     click = _clicker(found, box)
@@ -43,43 +76,82 @@ def _invite(found: set[str], message: str = None, box: MagicMock = None, refined
          patch(f"{_RA}._profile_is_first_degree", return_value=False), \
          patch(f"{_RA}._open_connect_invite_dialog", return_value=True), \
          patch(f"{_RA}.click_element_wait_retry", click), \
+         patch(f"{_RA}.find_first", _finder(found)) as find_first, \
+         patch(f"{_RA}.click_first", _first_clicker(found)) as click_first, \
          patch(f"{_RA}.get_ai_message_refinement", return_value=refined) as refine, \
          patch(f"{_RA}.time.sleep"), \
          patch(f"{_RA}.log_error") as log_error, \
          patch(f"{_RA}.log_warning") as log_warning, \
+         patch(f"{_RA}.log_debug") as log_debug, \
          patch(f"{_RA}.insert_new_log") as insert_log, \
          patch(f"{_RA}.record_action") as record_action, \
          patch(f"{_RA}.quit_gracefully"):
         sent, reason = ra.invite_to_connect_now(1, "https://x/in/jane", message)
-    return sent, reason, click, insert_log, log_error, log_warning, refine, record_action
+    return _Result(sent=sent, reason=reason, click=click, find_first=find_first,
+                   click_first=click_first, insert_log=insert_log, log_error=log_error,
+                   log_warning=log_warning, log_debug=log_debug, refine=refine,
+                   record_action=record_action)
 
 
 def _clicked(click) -> list[str]:
     return [call.args[2] for call in click.call_args_list]
 
 
+def _messages(logger) -> list[str]:
+    return [call.args[0] for call in logger.call_args_list]
+
+
 class TestNoteIsBestEffort:
     def test_a_missing_note_affordance_still_sends_the_invite(self):
         from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
         # LinkedIn offers only the bare dialog once the personalized-invite quota is spent.
-        sent, reason, click, insert_log, log_error, log_warning, _r, record = _invite(
-            found={_SEND_BARE_XPATH}, message="hi jane")
-        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
-        assert _SEND_BARE_XPATH in _clicked(click)
-        assert insert_log.call_args.kwargs["message"] == CONNECTION_REQUEST_SENT_MESSAGE
-        record.assert_called_once()  # a bare invite still spends the account-level budget
-        log_error.assert_not_called()
-        log_warning.assert_called_once()
+        r = _invite(found={_SEND_BARE_XPATH}, message="hi jane")
+        assert r.sent is True and r.reason == CONNECTION_REQUEST_SENT_MESSAGE
+        assert _SEND_BARE_XPATH in _clicked(r.click)
+        assert r.insert_log.call_args.kwargs["message"] == CONNECTION_REQUEST_SENT_MESSAGE
+        r.record_action.assert_called_once()  # a bare invite still spends the account-level budget
+        r.log_error.assert_not_called()
+
+    def test_a_missing_note_affordance_never_warns(self):
+        """#1039: this is the documented quota-spent fallback, and a repeated warning would file a
+        grouped PostHog issue — and a GitHub issue off it — for working behaviour."""
+        r = _invite(found={_SEND_BARE_XPATH}, message="hi jane")
+        r.log_warning.assert_not_called()
+        assert any("quota" in message for message in _messages(r.log_debug))
+
+    def test_the_quota_reading_is_grounded_in_the_dialogs_own_bare_send_control(self):
+        """The absence is only called quota-spent because the dialog is still showing the control
+        that means 'no note on offer here' — never assumed from the missing note button alone."""
+        r = _invite(found={_SEND_BARE_XPATH}, message="hi jane")
+        looked_up = [call.args[3] for call in r.find_first.call_args_list]
+        assert looked_up[:2] == ["Add a note button", "Send without a note"]
+
+    def test_a_dialog_showing_neither_control_is_still_not_a_warning(self):
+        """The lost invite it costs us is what _submit_connect_invite logs as an ERROR; warning here
+        too would file a second grouped issue for the same event (the #1038 fault)."""
+        from cqc_lem.utilities.db import INVITE_NOT_SENT_MESSAGE
+        r = _invite(found=set(), message="hi jane")
+        assert r.sent is False and r.reason == INVITE_NOT_SENT_MESSAGE
+        r.log_warning.assert_not_called()
+        r.log_error.assert_called_once()  # exactly one signal for the one lost invite
+        assert any("no longer showing its own controls" in m for m in _messages(r.log_debug))
 
     def test_a_note_that_cannot_be_typed_still_sends_the_invite(self):
         from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
         box = MagicMock()
         box.send_keys.side_effect = Exception("ChromeDriver only supports characters in the BMP")
-        sent, reason, _click, _log, log_error, log_warning, _r, _rec = _invite(
-            found=_NOTE_DIALOG | {_SEND_BARE_XPATH}, message="hi jane", box=box)
-        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
-        log_error.assert_not_called()
-        log_warning.assert_called_once()
+        r = _invite(found=_NOTE_DIALOG | {_SEND_BARE_XPATH}, message="hi jane", box=box)
+        assert r.sent is True and r.reason == CONNECTION_REQUEST_SENT_MESSAGE
+        r.log_error.assert_not_called()
+        r.log_warning.assert_called_once()
+
+    def test_a_failure_after_the_affordance_answered_still_warns_with_the_exception(self):
+        """The note button was there and the textarea was not: that is drift or a broken dialog, not
+        the quota fallback, so it keeps the WARNING + `exc=` that makes it greppable."""
+        r = _invite(found={_NOTE_XPATH, _SEND_BARE_XPATH}, message="hi jane")
+        r.log_warning.assert_called_once()
+        assert isinstance(r.log_warning.call_args.kwargs.get("exc"), Exception)
+        assert r.sent is True  # and the invite still goes out bare
 
     def test_the_note_is_stripped_of_non_bmp_characters_before_typing(self):
         box = MagicMock()
@@ -90,9 +162,8 @@ class TestNoteIsBestEffort:
     def test_an_over_long_note_is_refined_and_capped(self):
         from cqc_lem.utilities.db import CONNECT_NOTE_MAX_CHARS
         box = MagicMock()
-        _sent, _reason, _click, _log, _err, _warn, refine, _rec = _invite(
-            found=_NOTE_DIALOG, message="x" * 400, box=box, refined="y" * 500)
-        assert refine.call_args.args[1] == CONNECT_NOTE_MAX_CHARS
+        r = _invite(found=_NOTE_DIALOG, message="x" * 400, box=box, refined="y" * 500)
+        assert r.refine.call_args.args[1] == CONNECT_NOTE_MAX_CHARS
         # Refinement can come back long; the textarea's own maxlength would truncate it silently.
         assert len(box.send_keys.call_args.args[0]) == CONNECT_NOTE_MAX_CHARS
 
@@ -101,33 +172,33 @@ class TestNoteHappyPath:
     def test_a_note_is_typed_and_the_invite_sent(self):
         from cqc_lem.utilities.db import CONNECTION_REQUEST_SENT_MESSAGE
         box = MagicMock()
-        sent, reason, click, _log, log_error, log_warning, refine, _rec = _invite(
-            found=_NOTE_DIALOG, message="hi jane", box=box)
-        assert sent is True and reason == CONNECTION_REQUEST_SENT_MESSAGE
-        assert _clicked(click) == [_NOTE_XPATH, _TEXTAREA_XPATH, _SEND_XPATH]
+        r = _invite(found=_NOTE_DIALOG, message="hi jane", box=box)
+        assert r.sent is True and r.reason == CONNECTION_REQUEST_SENT_MESSAGE
+        assert _clicked(r.click) == [_TEXTAREA_XPATH, _SEND_XPATH]
+        assert [call.args[3] for call in r.click_first.call_args_list] == ["Add a note button"]
         box.clear.assert_called_once()
         box.send_keys.assert_called_once_with("hi jane")
-        refine.assert_not_called()  # already under the limit
-        log_error.assert_not_called()
-        log_warning.assert_not_called()
+        r.refine.assert_not_called()  # already under the limit
+        r.log_error.assert_not_called()
+        r.log_warning.assert_not_called()
 
-    def test_an_invite_with_no_note_never_opens_the_note_composer(self):
-        _sent, _reason, click, _log, _err, _warn, _r, _rec = _invite(
-            found={_SEND_BARE_XPATH})
-        assert _clicked(click) == [_SEND_BARE_XPATH]
+    def test_an_invite_with_no_note_never_looks_for_the_note_composer(self):
+        r = _invite(found={_SEND_BARE_XPATH})
+        assert _clicked(r.click) == [_SEND_BARE_XPATH]
+        r.find_first.assert_not_called()
+        r.click_first.assert_not_called()
 
 
 class TestSendFailureIsStillAnError:
     def test_a_dialog_with_no_send_button_reports_a_named_failure(self):
         from cqc_lem.utilities.db import INVITE_NOT_SENT_MESSAGE
         box = MagicMock()
-        sent, reason, click, insert_log, log_error, _warn, _r, record = _invite(
-            found=_NOTE_DIALOG - {_SEND_XPATH}, message="hi jane", box=box)
-        assert sent is False and reason == INVITE_NOT_SENT_MESSAGE
-        assert insert_log.call_args.kwargs["message"] == INVITE_NOT_SENT_MESSAGE
-        record.assert_not_called()  # nothing was sent, so nothing is spent
+        r = _invite(found=_NOTE_DIALOG - {_SEND_XPATH}, message="hi jane", box=box)
+        assert r.sent is False and r.reason == INVITE_NOT_SENT_MESSAGE
+        assert r.insert_log.call_args.kwargs["message"] == INVITE_NOT_SENT_MESSAGE
+        r.record_action.assert_not_called()  # nothing was sent, so nothing is spent
         # Both Send labels are tried before giving up — the dialog can be in either state.
-        assert _clicked(click)[-2:] == [_SEND_XPATH, _SEND_BARE_XPATH]
-        log_error.assert_called_once()
+        assert _clicked(r.click)[-2:] == [_SEND_XPATH, _SEND_BARE_XPATH]
+        r.log_error.assert_called_once()
         # exc= is what makes it a fingerprinted PostHog issue rather than a log line nobody reads.
-        assert isinstance(log_error.call_args.kwargs.get("exc"), Exception)
+        assert isinstance(r.log_error.call_args.kwargs.get("exc"), Exception)

--- a/tests/unit/test_linkedin_live_validation.py
+++ b/tests/unit/test_linkedin_live_validation.py
@@ -796,6 +796,20 @@ class TestConnectDialogProbe:
         assert llv.connect_dialog_state(reading) == llv.STATE_OK
         assert "never click one" in llv.connect_dialog_verdict(reading)
 
+    def test_a_dialog_without_the_note_affordance_is_reported_but_never_drift(self):
+        """#1039: production logs that absence at DEBUG because a spent personalized-invite quota
+        hides the control. This probe is the only place the quota reading and selector rot can be
+        told apart, so it says so — without claiming drift it cannot ground."""
+        reading = {"dialog_present": True, "page_text": "x", "bare_send_present": True,
+                   "note_affordance_present": False}
+        assert llv.connect_dialog_state(reading) == llv.STATE_OK
+        assert "no Add-a-note control" in llv.connect_dialog_verdict(reading)
+
+    def test_a_dialog_with_the_note_affordance_says_nothing_extra(self):
+        reading = {"dialog_present": True, "page_text": "x", "note_affordance_present": True,
+                   "bare_send_present": True}
+        assert "Add-a-note" not in llv.connect_dialog_verdict(reading)
+
 
 @pytest.mark.unit
 class TestProfileScrapeProbe:

--- a/tests/unit/test_linkedin_live_validation.py
+++ b/tests/unit/test_linkedin_live_validation.py
@@ -810,6 +810,45 @@ class TestConnectDialogProbe:
                    "bare_send_present": True}
         assert "Add-a-note" not in llv.connect_dialog_verdict(reading)
 
+    def _probe(self, monkeypatch, present: set[str], page_text: str = "About Experience"):
+        driver = MagicMock()
+        driver.current_url = "https://www.linkedin.com/preload/custom-invite/?vanityName=jane"
+        looked_up: list[str] = []
+
+        def find_first(_d, _w, _locators, label, **_kwargs):
+            looked_up.append(label)
+            return MagicMock() if label in present else None
+
+        monkeypatch.setattr("cqc_lem.utilities.selenium_util.find_first", find_first)
+        monkeypatch.setattr(llv, "element_evidence", lambda el: "aria-label=Send without a note")
+        monkeypatch.setattr(llv, "page_text_sample", lambda d, **k: page_text)
+        monkeypatch.setattr(llv, "visible_button_labels", lambda d, **k: [])
+        monkeypatch.setattr(llv, "_page_owner_name", lambda d: "Jane Doe")
+        reading = llv.probe_connect_dialog(driver, "https://www.linkedin.com/in/jane/",
+                                           sleep=lambda *_: None)
+        return reading, looked_up
+
+    def test_the_probe_records_which_of_the_dialogs_controls_rendered(self, monkeypatch):
+        """The verdict tests above build readings by hand, so only this one fails if the probe
+        stops writing the fields the #1039 reading is made of."""
+        reading, _looked_up = self._probe(monkeypatch, {"Connect invite dialog",
+                                                        "Send without a note"})
+        assert reading["dialog_present"] is True
+        assert reading["note_affordance_present"] is False
+        assert reading["bare_send_present"] is True
+        assert reading["state"] == llv.STATE_OK
+        assert "no Add-a-note control" in reading["verdict"]
+
+    def test_a_page_with_no_dialog_reports_no_affordance_reading_at_all(self, monkeypatch):
+        """None, not False: with no dialog on the page there is nothing to read the note affordance
+        against, and 'no Add-a-note control' would be a drift signal nobody observed."""
+        reading, looked_up = self._probe(monkeypatch, set())
+        assert reading["dialog_present"] is False
+        assert reading["note_affordance_present"] is None
+        assert reading["bare_send_present"] is None
+        assert "Add a note button" not in looked_up
+        assert "Add-a-note" not in reading["verdict"]
+
 
 @pytest.mark.unit
 class TestProfileScrapeProbe:


### PR DESCRIPTION
## What

`_add_connect_note` warned with `exc=` on **any** failure to reach the note composer, so a routine
miss filed a fingerprinted `TimeoutException: Finding Add a Note Button` PostHog issue — and this
GitHub issue off it. Its own docstring calls that miss **expected**: LinkedIn hides the note
affordance once a free account's personalized-invite quota is spent, and #573 deliberately made it
non-fatal — the invite goes out bare. A fallback in hand is the test for DEBUG, not WARNING
(`src/cqc_lem/utilities/CLAUDE.md`).

The two ways to lose a note are now graded apart:

| Reading | Level | Why |
|---|---|---|
| No `Add a note` control, dialog still shows `Send without a note` | DEBUG | the documented quota-spent fallback — the invite goes bare |
| Dialog shows neither of its controls | DEBUG | the lost invite is what `_submit_connect_invite` logs as an ERROR; a warning here files a **second** grouped issue for one event (the #1038 fault) |
| Anything failing AFTER the affordance answered (no textarea, `send_keys` refusing emoji) | WARNING + `exc=` | a genuine degraded path — unchanged |

The affordance is resolved with `find_first(required=False, warn_on_miss=False)` (locator list, not a
single raising xpath), and the click that follows keeps `required=True` — the control answered a
moment ago, so failing to click it now is real and raises into the warning path rather than reading
as "not on offer". `_SEND_WITHOUT_NOTE_XPATH` is now shared with `_SEND_INVITE_XPATHS`, so the
cross-check can never disagree with the send that immediately follows it.

## Why not just drop `exc=`

Because the owner's question on the issue is the right one: the same miss is also how selector rot
would look, and **production cannot tell them apart** — a spent quota renders the dialog exactly the
same way. So that reading moved to where it can be attributed: `--connect-dialog` now reports
`note_affordance_present` / `bare_send_present` and names it in its verdict, deliberately **without**
grading it `drift` (the probe account's own quota state is not knowable from the page). Logged as a
tracked gap in `docs/sdui-probe-coverage.md` rather than left to be rediscovered.

No live LinkedIn run was needed to make this call: `_add_connect_note` only runs when
`_open_connect_invite_dialog` has already proven one of the dialog's own controls present, and both
labels (`Add a note` / `Send without a note`) were live-grounded 2026-08-03 in
`docs/sdui-selenium-notes.md`. The one thing a live run would add — what the dialog looks like with
the quota spent — is exactly what the probe field now captures on the next sweep against a target.

## Testing

- `tests/unit/app/test_invite_connect_note.py` — rebuilt around `find_first`/`click_first` stand-ins:
  a missing affordance never warns and logs the quota reading; the reading is grounded in the
  bare-send lookup (asserted by lookup order, not by the note button's absence alone); a dialog
  showing neither control produces exactly ONE signal (the send ERROR); a post-affordance failure
  still warns with `exc=`; happy path, non-BMP stripping, refinement cap and the send-failure error
  unchanged.
- `tests/unit/test_linkedin_live_validation.py` — the probe verdict reports a missing note affordance
  and still grades `ok`; a present one says nothing extra.
- Full lane green locally: `10478 passed`.

Closes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)