### PR TITLE
test(automation): pin the profile-viewer walk off the polling locator (closes #1040)

### DIFF
--- a/tests/unit/app/test_profile_viewer_engagement.py
+++ b/tests/unit/app/test_profile_viewer_engagement.py
@@ -5,6 +5,9 @@ The analytics page is SDUI (no <ul>/<li> container, hashed class names): a viewe
 goes stale while the list re-renders. Zero rows with a non-zero "Profile viewers" headline is
 selector drift and must stay loud; zero rows with no headline is nothing-to-do and must stay
 quiet (issue #572 — it must not page the error cron).
+
+The JS read is also what keeps the walk off `get_elements_as_list_wait_stale`, whose unresolvable
+wait is what raised the escalated "Finding Profile Viewers" TimeoutException (issue #1040).
 """
 
 from datetime import datetime, timedelta
@@ -50,12 +53,13 @@ def _driver_scripting(rows_per_round: list[list[dict]], headline_stat=None) -> M
     return driver
 
 
-def _run(driver, **kwargs):
+def _run(driver, render_wait: int = 0, **kwargs):
     with patch(f"{_MOD}.get_current_profile", return_value=_profile_pair(driver)), \
          patch(f"{_MOD}.quit_gracefully") as mock_quit, \
          patch(f"{_MOD}.get_user_id", return_value=1), \
          patch(f"{_MOD}.time.sleep"), \
-         patch(f"{_MOD}._PROFILE_VIEWER_RENDER_WAIT_SECONDS", 0), \
+         patch(f"{_MOD}._PROFILE_VIEWER_RENDER_WAIT_SECONDS", render_wait), \
+         patch(f"{_MOD}.get_elements_as_list_wait_stale") as mock_wait_locator, \
          patch(f"{_MOD}.log_debug") as mock_debug, \
          patch(f"{_MOD}.log_warning") as mock_warning, \
          patch(f"{_MOD}.log_error") as mock_error, \
@@ -65,7 +69,8 @@ def _run(driver, **kwargs):
         result = automate_profile_viewer_engagement.run(user_id=1, **kwargs)
 
     return result, {"quit": mock_quit, "debug": mock_debug, "warning": mock_warning,
-                    "error": mock_error, "engage": mock_engage}
+                    "error": mock_error, "engage": mock_engage,
+                    "wait_locator": mock_wait_locator}
 
 
 def _engaged_urls(mocks) -> list[str]:
@@ -90,6 +95,35 @@ class TestNoViewersFound:
         mocks["warning"].assert_called_once()
         assert "selector drift" in mocks["warning"].call_args.args[0]
         assert "Engaged with 0 viewers" in result
+
+
+class TestNoPollingWaitOnTheViewerList:
+    """Regression guard for the escalated TimeoutException "Finding Profile Viewers" (#1040).
+
+    The walk used to read rows through `get_elements_as_list_wait_stale`, whose wait can only
+    resolve once the locator matches something. Against the SDUI page it never matched, so every
+    run raised TimeoutException, the handler warned, and the repeats escalated into a grouped
+    `$exception`. Rows come from one `execute_script` pass now: a page that has not painted yet is
+    waited out and re-read, never polled into a raised exception.
+    """
+
+    def test_empty_page_never_touches_the_polling_locator(self):
+        _, mocks = _run(_driver_scripting([[]], headline_stat=None))
+
+        mocks["wait_locator"].assert_not_called()
+        mocks["error"].assert_not_called()
+
+    def test_late_painting_page_is_re_read_not_raised(self):
+        rows = [_row("Ada", "ada", "Viewed 1h ago")]
+
+        result, mocks = _run(_driver_scripting([[], rows, rows]), render_wait=30)
+
+        mocks["wait_locator"].assert_not_called()
+        mocks["warning"].assert_not_called()
+        mocks["error"].assert_not_called()
+        mocks["debug"].assert_not_called()
+        assert _engaged_urls(mocks) == ["https://www.linkedin.com/in/ada/"]
+        assert "Engaged with 1 viewers" in result
 
 
 class TestWalkTermination:


### PR DESCRIPTION
## What & why

Auto-filed from PostHog Error Tracking: a grouped `TimeoutException: Message: Finding Profile Viewers` on Celery task `automate_profile_viewer_engagement`.

**Root cause (confirmed from the stack trace on the PostHog issue):** the walk read viewer rows through `get_elements_as_list_wait_stale(...,"Finding Profile Viewers")`. That helper's wait can only resolve once the locator matches something, and the locator it was given — `//ul[@aria-label="List of Entities"]//a[...]` — could never match the SDUI profile-views page (no `<ul>` container, hashed classes only). So every run polled to a `TimeoutException`, the handler `log_warning`'d it, and the repeats escalated into ONE grouped `$exception` (fingerprint `lem-log:2bfa8f75a861`, `handled: true`).

Frames on the sampled event:

```
cqc_lem/app/run_automation.py:5137  automate_profile_viewer_engagement
cqc_lem/utilities/selenium_util.py:669/675/678  get_elements_as_list_wait_stale
```

**That cause is already gone.** #1009 ("profile viewer walk finds zero viewers — ground on live SDUI DOM", released in **v0.129.0**) replaced the polling locator with a single `execute_script` read of the `/in/` anchors carrying a `Viewed …` caption. The exception's only occurrence (`2026-08-03T11:56:05Z`) predates that merge (`2026-08-03T14:38Z`); prod has been on ≥ v0.129.0 since.

**What was still missing is the guard.** The render-wait branch that *replaced* the polling wait (`_PROFILE_VIEWER_RENDER_WAIT_SECONDS`, re-read a page that has not painted yet) had no unit coverage — every existing test patches the wait to `0`, so the re-read path never ran. A future edit could quietly reintroduce a wait-based locator here and nothing would fail.

## Change

Tests only — `tests/unit/app/test_profile_viewer_engagement.py`:

- `_run` now patches `get_elements_as_list_wait_stale` in the module namespace and exposes it, and takes a `render_wait` override.
- **`test_empty_page_never_touches_the_polling_locator`** — an empty analytics page must not reach the polling helper at all (this is the exception's exact path).
- **`test_late_painting_page_is_re_read_not_raised`** — with a 30s render wait, a page that returns zero rows on the first read and rows on the second is waited out and its viewers engaged: no warning, no error, no exception. This exercises the `continue`-until-deadline branch for the first time.

No production code changed — the fix shipped in v0.129.0; this pins it.

## Testing

```
pytest tests/unit/app/test_profile_viewer_engagement.py -q   # 12 passed
```

The PostHog issue is being marked resolved.

Closes #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)