### PR TITLE
fix(errors): never warn on the condition a paging loop loops until (closes #1041)

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -4160,12 +4160,16 @@ def _reply_to_comments_on_open_post(driver, wait, user_id: int, post_id: int, my
 
     # SDUI: expand more replies where available, then collect comment items from the
     # new data-testid comment list (comments are no longer article.comments-comment-entity).
+    # The miss IS this loop's exit condition, so it never warns (utilities/CLAUDE.md): a post whose
+    # comments already fit on one page never renders the control, and one that does stops rendering
+    # it once the last page is in — every sweep ends on a miss by design.
     for _ in range(5):
         more = click_first(driver, wait,
                            [(By.XPATH, "//button[contains(@aria-label,'more comment') or "
                                        "contains(normalize-space(),'Load more') or "
                                        "contains(normalize-space(),'more repl')]")],
-                           "Load more comments", required=False)
+                           "Load more comments", required=False, warn_on_miss=False,
+                           user_id=user_id, post_id=post_id)
         if not more:
             break
         time.sleep(2)

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -85,6 +85,12 @@ Two things follow for anyone writing a call site here:
    readings are identical in the DOM — so it moved to the `--connect-dialog` probe, which reports the
    affordance without grading it (`docs/sdui-probe-coverage.md`). **A miss you cannot attribute
    belongs in a probe, not in a warning.**
+   A **paging loop** is the same test at its most obvious: `_reply_to_comments_on_open_post` clicks
+   'Load more comments' until the control stops resolving, so the miss IS the loop's exit condition
+   and fires on EVERY sweep — a post whose comments fit on one page never renders the control, and
+   one that does stops rendering it once the last page is in. It logged `Selector miss: Load more
+   comments` at WARNING and filed a defect for the loop terminating (issue #1041). **Never warn on
+   the condition you loop until.**
    The rule reads sideways for a **state-setter**: doing what you were asked is not a degraded path,
    however serious the state is. `pause_automation` warned every time it stored the global Selenium
    kill-switch, and maintenance mode sets one on EVERY release, so a routine deploy filed

--- a/tests/unit/app/test_reply_sweep.py
+++ b/tests/unit/app/test_reply_sweep.py
@@ -312,6 +312,39 @@ class TestReplyToCommentsOnOpenPost:
         assert result == {"status": "ok", "summary": "Replied to 1 comments",
                           "comments_found": 1, "replies_sent": 1}
 
+    def test_load_more_miss_never_warns(self):
+        """Issue #1041: the miss IS the expansion loop's exit condition — every sweep ends on one,
+        so warning would escalate to a grouped $exception for working behaviour."""
+        from cqc_lem.app.run_automation import _reply_to_comments_on_open_post
+        driver = MagicMock(); driver.current_url = "x"
+        with patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://li/feed/update/urn:li:share:1/"), \
+             patch(f"{_RA}.get_post_content", return_value="post body"), \
+             patch(f"{_RA}.click_first", return_value=None) as click, \
+             patch(f"{_RA}._comment_items_from_thread", return_value=[]), \
+             patch(f"{_RA}.get_lead_magnet_settings", return_value={"enabled": False}), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}), \
+             patch(f"{_RA}.log_warning") as warn:
+            _reply_to_comments_on_open_post(driver, MagicMock(), 1, 9, self._profile(), "synth")
+        click.assert_called_once()                       # the miss breaks the loop, no re-clicking
+        assert click.call_args.args[3] == "Load more comments"
+        assert click.call_args.kwargs["required"] is False
+        assert click.call_args.kwargs["warn_on_miss"] is False
+        warn.assert_not_called()
+
+    def test_load_more_expands_until_the_control_is_gone(self):
+        """Silencing the miss must not silence the expansion: a rendered control still gets clicked
+        until LinkedIn stops rendering it."""
+        from cqc_lem.app.run_automation import _reply_to_comments_on_open_post
+        driver = MagicMock(); driver.current_url = "x"
+        with patch(f"{_RA}.get_post_url_from_log_for_user", return_value="https://li/feed/update/urn:li:share:1/"), \
+             patch(f"{_RA}.get_post_content", return_value="post body"), \
+             patch(f"{_RA}.click_first", side_effect=[MagicMock(), MagicMock(), None]) as click, \
+             patch(f"{_RA}._comment_items_from_thread", return_value=[]), \
+             patch(f"{_RA}.get_lead_magnet_settings", return_value={"enabled": False}), \
+             patch(f"{_RA}.get_engagement_preferences", return_value={}):
+            _reply_to_comments_on_open_post(driver, MagicMock(), 1, 9, self._profile(), "synth")
+        assert click.call_count == 3
+
     def test_skips_already_replied(self):
         from cqc_lem.app.run_automation import _reply_to_comments_on_open_post
         driver = MagicMock(); driver.current_url = "x"


### PR DESCRIPTION
## What

`_reply_to_comments_on_open_post` expands a post's comment thread by clicking **Load more comments**
up to five times, breaking the moment the control stops resolving. That lookup ran with the default
`warn_on_miss`, so the miss logged `Selector miss: Load more comments` at **WARNING** — and the miss
**is the loop's exit condition**:

- a post whose comments already fit on one page never renders the control at all;
- a post that does renders it until the last page is in, then stops.

Either way every sweep ends on a miss. Three in 24h escalated to ERROR, filed one grouped
`$exception`, and the daily error→issue cron turned "the loop terminated normally" into #1041.

## The change

- `src/cqc_lem/app/run_automation.py` — the `Load more comments` lookup now passes
  `warn_on_miss=False` (DEBUG per `utilities/CLAUDE.md`) and carries `user_id`/`post_id` so the DEBUG
  line still says whose sweep it was. **The `break` is untouched**, so expansion behaviour is
  unchanged.
- `src/cqc_lem/utilities/CLAUDE.md` — names the shape so the next paging loop doesn't repeat it:
  *never warn on the condition you loop until.*

No probe reading is lost here. Unlike the connect-note affordance (#1039), this miss is not
ambiguous evidence of anything — it is the normal terminal state of every run on every post, so
there was never a signal in it to relocate.

## Testing

`tests/unit/app/test_reply_sweep.py`, two new tests on `TestReplyToCommentsOnOpenPost`:

- `test_load_more_miss_never_warns` — the miss breaks the loop after ONE call, the call is made with
  `required=False` + `warn_on_miss=False`, and `log_warning` is never reached.
- `test_load_more_expands_until_the_control_is_gone` — a three-page thread is still clicked through
  to the end, so silencing the miss did not silence the expansion.

```
pytest tests/unit/app/test_reply_sweep.py tests/unit/app/test_lead_signals.py -q
71 passed
```

## Scope check

Issue #1041's acceptance criteria are: the exception no longer occurs (deliberately downgraded to
DEBUG here), a unit test covers the failing path, CI green. Nothing is deferred and no later phase
is declared — the close is honest.

Closes #1041

🤖 Generated with [Claude Code](https://claude.com/claude-code)