### PR TITLE
fix(dm): re-find the composer when it re-mounts mid-type

### DIFF
--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -6659,6 +6659,39 @@ def clean_stale_invites(self, user_id: int):
 
 DM_SEND_CONFIRM_SECONDS = float(os.getenv("DM_SEND_CONFIRM_SECONDS", "6"))
 
+_DM_COMPOSER_XPATH = '//div[contains(@class,"contenteditable")]//p'
+# How many times the type step re-finds a composer that went stale under it.
+DM_COMPOSER_ATTEMPTS = int(os.getenv("DM_COMPOSER_ATTEMPTS", "3"))
+_DM_COMPOSER_SETTLE_SECONDS = 1.5
+
+
+def _type_dm_into_composer(driver: WebDriver, wait, message: str) -> None:
+    """Clear the composer and type the message, re-finding the box on every attempt.
+
+    An element handle is NOT safe to hold across interactions here: the compose overlay re-mounts
+    while LinkedIn hydrates it, so the box found the moment it first appears goes stale a keystroke
+    later — `StaleElementReferenceException` on the very next `send_keys` is what killed every send
+    once the composer itself started resolving. Each attempt therefore re-finds the box, and because
+    each one CLEARS before typing, a retry after a half-typed message can never send a doubled one."""
+    last_error = None
+    for attempt in range(max(1, DM_COMPOSER_ATTEMPTS)):
+        try:
+            box = get_element_wait_retry(driver, wait, _DM_COMPOSER_XPATH, 'Finding Message Box',
+                                         max_try=1)
+            if box is None:
+                raise NoSuchElementException("no message composer to type into")
+            # Select All then Delete — `clear()` does not work on a contenteditable.
+            box.send_keys(Keys.CONTROL + "a")
+            box.send_keys(Keys.DELETE)
+            simulate_typing(driver, box, message)
+            return
+        except StaleElementReferenceException as e:
+            last_error = e
+            log_debug(f"Message composer went stale while typing (attempt {attempt + 1})",
+                      action_type="dm")
+            time.sleep(_DM_COMPOSER_SETTLE_SECONDS)
+    raise last_error
+
 
 def _dm_send_landed(driver: WebDriver, message: str, user_id: int = None,
                     profile_url: str = "") -> bool:
@@ -6727,23 +6760,7 @@ def send_dm_now(user_id: int, profile_url: str, message: str, person_name: str =
             log_debug(f"No composer addressed to {profile_url} ({composer.reason}); not sending",
                       user_id=user_id, action_type="dm")
         else:
-            # Find the message box
-            message_box = get_element_wait_retry(driver, wait,
-                                                 '//div[contains(@class,"contenteditable")]//p',
-                                                 'Finding Message Box', max_try=1, )
-
-            # Select All (Must be done this way. Clear command does not work)
-            message_box.send_keys(Keys.CONTROL + "a")
-            # Delete what is selected
-            message_box.send_keys(Keys.DELETE)
-
-            # Find the message box (again)
-            message_box = get_element_wait_retry(driver, wait,
-                                                 '//div[contains(@class,"contenteditable")]//p',
-                                                 'Finding Message Box', max_try=1, )
-
-            # Type the message into the box
-            simulate_typing(driver, message_box, message)
+            _type_dm_into_composer(driver, wait, message)
 
             # Sleep so send button can become active
             time.sleep(2)

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -6673,8 +6673,8 @@ def _type_dm_into_composer(driver: WebDriver, wait, message: str) -> None:
     later — `StaleElementReferenceException` on the very next `send_keys` is what killed every send
     once the composer itself started resolving. Each attempt therefore re-finds the box, and because
     each one CLEARS before typing, a retry after a half-typed message can never send a doubled one."""
-    last_error = None
-    for attempt in range(max(1, DM_COMPOSER_ATTEMPTS)):
+    attempts = max(1, DM_COMPOSER_ATTEMPTS)
+    for attempt in range(attempts):
         try:
             box = get_element_wait_retry(driver, wait, _DM_COMPOSER_XPATH, 'Finding Message Box',
                                          max_try=1)
@@ -6685,12 +6685,13 @@ def _type_dm_into_composer(driver: WebDriver, wait, message: str) -> None:
             box.send_keys(Keys.DELETE)
             simulate_typing(driver, box, message)
             return
-        except StaleElementReferenceException as e:
-            last_error = e
+        except StaleElementReferenceException:
+            # Out of attempts: raise rather than clicking Send over a partial composer.
+            if attempt == attempts - 1:
+                raise
             log_debug(f"Message composer went stale while typing (attempt {attempt + 1})",
                       action_type="dm")
             time.sleep(_DM_COMPOSER_SETTLE_SECONDS)
-    raise last_error
 
 
 def _dm_send_landed(driver: WebDriver, message: str, user_id: int = None,

--- a/tests/unit/app/test_send_dm_now.py
+++ b/tests/unit/app/test_send_dm_now.py
@@ -10,7 +10,8 @@ being accepted.
 from unittest.mock import MagicMock, patch
 
 import pytest
-from selenium.common import WebDriverException
+from selenium.common import (NoSuchElementException, StaleElementReferenceException,
+                             WebDriverException)
 
 from cqc_lem.utilities.db import LogResultType
 from cqc_lem.utilities.linkedin.message_thread import ComposerOpen
@@ -132,3 +133,60 @@ class TestSendLanded:
         message = "Congrats on the new role, Jane! " + "x" * 400
         with patch(f"{_RA}.read_last_message", return_value=message):
             assert ra._dm_send_landed(self._driver(), message) is True
+
+
+class TestTypingSurvivesTheComposerRemount:
+    """The compose overlay re-mounts while LinkedIn hydrates it, so a handle taken when the box first
+    appears goes stale a keystroke later. That is what killed the re-queued sends on 2026-08-04 once
+    the composer had started resolving."""
+
+    @staticmethod
+    def _box(stale_on_send=0):
+        """A composer whose send_keys raises StaleElementReference the first `stale_on_send` times."""
+        box = MagicMock()
+        calls = {"n": 0}
+
+        def _send(*_a):
+            calls["n"] += 1
+            if calls["n"] <= stale_on_send:
+                raise StaleElementReferenceException("re-mounted")
+
+        box.send_keys.side_effect = _send
+        return box
+
+    def test_a_stale_box_is_re_found_and_the_message_still_goes_in(self):
+        from cqc_lem.app import run_automation as ra
+        boxes = [self._box(stale_on_send=1), self._box()]
+        with patch(f"{_RA}.get_element_wait_retry", side_effect=boxes), \
+             patch(f"{_RA}.simulate_typing") as typed, \
+             patch(f"{_RA}.time.sleep"):
+            ra._type_dm_into_composer(MagicMock(), MagicMock(), "Congrats Jane!")
+        typed.assert_called_once()
+        assert typed.call_args[0][1] is boxes[1]  # the RE-FOUND box, never the stale handle
+
+    def test_every_attempt_clears_first_so_a_retry_cannot_double_type(self):
+        from cqc_lem.app import run_automation as ra
+        box = self._box()
+        with patch(f"{_RA}.get_element_wait_retry", return_value=box), \
+             patch(f"{_RA}.simulate_typing"), \
+             patch(f"{_RA}.time.sleep"):
+            ra._type_dm_into_composer(MagicMock(), MagicMock(), "Congrats Jane!")
+        assert box.send_keys.call_count == 2  # select-all then delete, before any typing
+
+    def test_a_composer_stale_on_every_attempt_raises_rather_than_sending_blind(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.get_element_wait_retry",
+                   side_effect=lambda *a, **k: self._box(stale_on_send=99)), \
+             patch(f"{_RA}.simulate_typing") as typed, \
+             patch(f"{_RA}.time.sleep"):
+            with pytest.raises(StaleElementReferenceException):
+                ra._type_dm_into_composer(MagicMock(), MagicMock(), "Congrats Jane!")
+        typed.assert_not_called()
+
+    def test_no_composer_at_all_is_an_error_not_a_silent_skip(self):
+        from cqc_lem.app import run_automation as ra
+        with patch(f"{_RA}.get_element_wait_retry", return_value=None), \
+             patch(f"{_RA}.simulate_typing"), \
+             patch(f"{_RA}.time.sleep"):
+            with pytest.raises(NoSuchElementException):
+                ra._type_dm_into_composer(MagicMock(), MagicMock(), "Congrats Jane!")


### PR DESCRIPTION
Follow-on to #1048, found by watching the re-queued congratulations actually run in production.

## What #1048 fixed, and what it exposed

#1048 got the send path to a composer that is provably addressed to the right person. Production confirmed that half works:

```
Message composer addressed to 'Evan Miller' (overlay)
```

...and then the send died one line later:

```
File "run_automation.py", line 6738, in send_dm_now
    message_box.send_keys(Keys.DELETE)
selenium.common.exceptions.StaleElementReferenceException:
    stale element reference: stale element not found in the current frame
```

## Cause

The old code took **one element handle and used it across four interactions** — select-all, delete, re-find, type. That was survivable when the composer was reached by clicking Message on an already-settled profile page. It is not survivable now that we navigate straight to a compose URL: the overlay re-mounts while LinkedIn hydrates it, so the box found the moment it first appears is stale a keystroke later.

This is the same class of bug as the original — a handle trusted across a re-render — just one step further down the path.

## Fix

`_type_dm_into_composer` re-finds the box on every attempt rather than holding a handle across keystrokes.

- **A retry cannot double-type**: every attempt clears (select-all + delete) before typing, so a half-typed message from a failed attempt is wiped first.
- **Stale on every attempt raises** rather than clicking Send over an empty or partial composer.
- **No composer at all** is a `NoSuchElementException`, not a silent skip.
- `DM_COMPOSER_ATTEMPTS` (default 3) bounds it.

## Verified live

Ran a real catch-up congratulations through the full task path against live LinkedIn with this fix:

```
BEFORE: id=3 name='Evan Miller Completed 11 years at Tom Ja' status=approved
Sending DM: Happy work anniversary, Evan!
Message composer addressed to 'Evan Miller' (overlay)
Catch-up deliver run: sent (touch_id=3)
AFTER:  id=3 status=sent
```

`_dm_send_landed` confirmed the message as the newest in the thread — the send is verified by outcome, not by the click.

Tests: 4 new (re-find on stale, clear-before-type, exhausted attempts raise, missing composer raises); 202 pass across the DM/catch-up/pacing suites.

`release:now` — the remaining 7 congratulations are queued and time-sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)