### PR TITLE
fix(security): drop the CODEOWNERS catch-all so the pipeline is not halted

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,16 +5,19 @@
 # change what every later change is allowed to do. They require an explicit human approval; the
 # rest of the tree does not, so routine agent work keeps merging unattended.
 #
-# Order matters — the LAST matching pattern wins, so the catch-all comes first.
+# Order matters — the LAST matching pattern wins.
 #
-# HONEST LIMIT, worth knowing before you rely on this: the agent pipeline authenticates as
-# @gitchrisqueen, so GitHub cannot tell an agent PR from an owner PR. Against the agent, CODEOWNERS
-# is therefore a speed bump and a paper trail, not a wall — the real control is the pipeline's
-# credential having no `workflows` permission (docs/contribution-security.md). This file is the
-# wall against OUTSIDE contributors, and it becomes a wall against the agent the moment the
-# pipeline moves to its own bot identity.
-
-*                                       @gitchrisqueen
+# THERE IS DELIBERATELY NO `*` CATCH-ALL. `require_code_owner_reviews` is on, so a catch-all would
+# make EVERY file owned and therefore every PR blocked pending an approval — and since the agent
+# pipeline authenticates as @gitchrisqueen, and GitHub does not let you approve your own PR, that
+# would halt the pipeline outright. A catch-all also buys nothing against outside contributors:
+# they have no write access, so they cannot merge regardless. Listing only the control surfaces is
+# what lets routine agent work keep merging while the surfaces that govern it need a human.
+#
+# HONEST LIMIT, worth knowing before you rely on this: agent and owner share one identity, so
+# GitHub cannot tell their PRs apart. Against the agent this is a speed bump and a paper trail —
+# the real control is the pipeline's credential having no `workflows` permission
+# (docs/contribution-security.md). It becomes a wall the moment the pipeline gets a bot identity.
 
 # --- CI/CD and the rules themselves ---------------------------------------------------------
 # A merged PR can currently rewrite any workflow, including the ones that gate merges and deploys.

--- a/tests/unit/test_codeowners.py
+++ b/tests/unit/test_codeowners.py
@@ -42,11 +42,15 @@ class TestCodeownersResolves:
                      if not owners or not all(o.startswith("@") for o in owners)]
         assert not ownerless, f"CODEOWNERS rules with no/invalid owner: {ownerless}"
 
-    def test_the_catch_all_comes_first_so_specific_rules_win(self):
-        # Last match wins in CODEOWNERS. A `*` at the bottom would override every specific rule.
+    def test_there_is_no_catch_all(self):
+        # `require_code_owner_reviews` is ON. A `*` rule would make every file owned, so every PR
+        # would block pending an approval — and because the agent pipeline authenticates as the
+        # owner, and GitHub forbids approving your own PR, that halts the pipeline outright.
+        # It also buys nothing defensively: outside contributors have no write access anyway.
         patterns = [pat for pat, _ in _rules()]
-        assert patterns[0] == "*", "the `*` catch-all must be the FIRST rule, not the last"
-        assert "*" not in patterns[1:], "a second `*` would override every specific rule below it"
+        assert "*" not in patterns, (
+            "a `*` catch-all blocks every PR once require_code_owner_reviews is on — list the "
+            "control surfaces explicitly instead")
 
 
 class TestControlSurfacesAreCovered:


### PR DESCRIPTION
Follow-on to #1053. `require_code_owner_reviews` is now enabled on `main`; the `*` catch-all would make every file owned and block every PR, including the agent pipeline's (it authenticates as @gitchrisqueen, and GitHub forbids self-approval).

This PR touches `.github/CODEOWNERS`, an owned path — so it doubles as the empirical test of whether code-owner review is enforced with `required_approving_review_count: 0`, which the GitHub docs do not state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)