### PR TITLE
fix(security): verify who applied release:now, not just that it is there

### DIFF
--- a/.github/workflows/release-auto-merge.yml
+++ b/.github/workflows/release-auto-merge.yml
@@ -51,6 +51,43 @@ jobs:
       (github.event.pull_request.merged == true &&
        contains(github.event.pull_request.labels.*.name, 'release:now'))
     steps:
+      # `release:now` ships a PR to production the moment it merges, bypassing the 4x-daily window.
+      # The `if:` above only checks the label is PRESENT — and labels have no ACL, so anyone with
+      # triage can apply one, and agents are authorised to self-apply it (docs/release-fast-lane.md).
+      # Presence is therefore not evidence. Verify WHO applied it, the same way tick.sh verifies
+      # `agent:ready` (docs/contribution-security.md).
+      #
+      # Fails CLOSED: an unreadable timeline means no fast lane, and the PR simply ships at the next
+      # scheduled window — the cost of a false negative is a few hours, the cost of a false positive
+      # is an unreviewed deploy.
+      - name: Verify who applied release:now
+        if: github.event_name == 'pull_request_target'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_DISPATCH_TOKEN || secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          # Space-separated allowlist. Keep this tight: every name here can ship to production
+          # without waiting for a release window.
+          TRUSTED_LABELLERS: "gitchrisqueen"
+        run: |
+          set -euo pipefail
+          actor="$(gh api "repos/${REPO}/issues/${PR_NUMBER}/timeline" --paginate \
+                     -H "Accept: application/vnd.github+json" \
+                     --jq '[.[] | select(.event=="labeled" and .label.name=="release:now")
+                           | .actor.login] | last // empty' 2>/dev/null || true)"
+          if [ -z "$actor" ]; then
+            echo "::warning title=Fast lane refused::could not read who applied release:now on #${PR_NUMBER}; it will ship at the next window."
+            exit 1
+          fi
+          for trusted in $TRUSTED_LABELLERS; do
+            if [ "$actor" = "$trusted" ]; then
+              echo "release:now applied by '${actor}' — fast lane authorised."
+              exit 0
+            fi
+          done
+          echo "::warning title=Fast lane refused::release:now on #${PR_NUMBER} was applied by '${actor}', who is not in TRUSTED_LABELLERS; it will ship at the next window."
+          exit 1
+
       # Wait for release-please's OWN run for this merge commit to finish — not merely for "a
       # release PR to exist". Those are different conditions and the difference broke a release:
       #

--- a/docs/release-fast-lane.md
+++ b/docs/release-fast-lane.md
@@ -20,6 +20,22 @@ gh pr edit <PR> --repo christopherqueenconsulting/linkedin_engagement_manager --
 Apply it **before** the PR merges. The label is read at merge time; adding it afterwards does
 nothing (use `gh workflow run release-auto-merge.yml` instead, which releases whatever is pending).
 
+## Who may apply it — the gate
+
+**The label being present is not evidence that it was authorised.** Labels have no ACL: anyone with
+triage can apply one. So `release-auto-merge.yml` reads the PR timeline for the **last** actor to
+apply `release:now` and refuses unless that actor is in `TRUSTED_LABELLERS` (the step's `env:`).
+
+It **fails closed**. An unreadable timeline, an unknown actor, or no readable `labeled` event all
+refuse the fast lane — and refusing costs only a few hours, because the PR still ships at the next
+scheduled window. A false positive costs an unreviewed production deploy.
+
+A refusal is a `::warning::` annotation and a red run, which is the point: it means someone applied
+a production-deploy label who is not authorised to.
+
+This is the same control `tick.sh` applies to `agent:ready` — see `docs/contribution-security.md`,
+which covers why a label doing the job of an access control was the underlying defect in both.
+
 ## When agents may apply it — the policy
 
 **Agents may add `release:now` on their own judgement, without asking, when the change is either:**
@@ -51,8 +67,8 @@ user-visible commenting failure, priority:high"* — so the choice is auditable 
 
 1. PR merges with the label.
 2. `release-auto-merge.yml` fires on `pull_request_target: closed`, sees `merged == true` and the
-   label, and waits (up to 10 min) for **release-please's own run for this merge commit** to
-   conclude successfully.
+   label, then **verifies who applied it** and waits (up to 10 min) for **release-please's own run
+   for this merge commit** to conclude successfully.
 3. It enables auto-merge on the release PR. The release PR still runs its own CI and still goes
    through the merge queue, so **a fast-laned release can never ship a red build**.
 4. Tag → `Build & Deploy Release` → blue/green cutover.

--- a/tests/unit/test_release_now_provenance.py
+++ b/tests/unit/test_release_now_provenance.py
@@ -1,0 +1,112 @@
+"""The `release:now` fast lane must check WHO applied the label, not just that it is there.
+
+`release:now` ships a PR to production the moment it merges, skipping the 4x-daily window. GitHub
+labels have no ACL — anyone with triage can apply one, and `docs/release-fast-lane.md` explicitly
+authorises agents to self-apply it. So presence is not evidence of authorisation, and the gate that
+only checked presence was the second half of the same defect as `agent:ready` (see
+docs/contribution-security.md).
+"""
+
+import re
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+
+pytestmark = pytest.mark.unit
+
+WORKFLOW = (Path(__file__).resolve().parents[2] / ".github" / "workflows"
+            / "release-auto-merge.yml")
+SOURCE = WORKFLOW.read_text(encoding="utf-8")
+PARSED = yaml.safe_load(SOURCE)
+STEPS = PARSED["jobs"]["merge-pending-release"]["steps"]
+VERIFY = next(s for s in STEPS if "Verify who applied" in (s.get("name") or ""))
+
+
+class TestTheGateIsWired:
+    def test_the_verification_step_exists(self):
+        assert VERIFY is not None
+
+    def test_it_runs_before_anything_enqueues_a_release(self):
+        # A check that runs after the enqueue is decoration.
+        names = [s.get("name") or "" for s in STEPS]
+        assert names.index(VERIFY["name"]) == 0
+
+    def test_it_only_applies_to_the_fast_lane_not_the_scheduled_window(self):
+        # The 4x-daily cron carries no PR and no label; gating it would stop every release.
+        assert VERIFY["if"] == "github.event_name == 'pull_request_target'"
+
+    def test_the_allowlist_is_explicit_and_not_empty(self):
+        assert VERIFY["env"]["TRUSTED_LABELLERS"].strip()
+
+    def test_the_label_presence_check_is_still_there_too(self):
+        # Provenance is an ADDITIONAL gate, not a replacement — a PR without the label must still
+        # not fast-lane.
+        cond = PARSED["jobs"]["merge-pending-release"]["if"]
+        assert "release:now" in cond and "merged == true" in cond
+
+    def test_the_step_reads_the_LAST_labeled_event(self):
+        # A label removed and re-added by someone else belongs to whoever added it last.
+        assert "| last" in VERIFY["run"]
+
+    def test_untrusted_input_is_passed_through_env_not_interpolated_into_the_script(self):
+        # The ${{ }} -> shell interpolation hazard that codeql-pr-gate.yml has. The PR number is
+        # numeric, but the habit is the point.
+        assert "${{" not in VERIFY["run"]
+
+
+class TestTheGateLogic:
+    """Run the step's actual shell against a stubbed `gh`."""
+
+    @staticmethod
+    def _run(tmp_path: Path, actor_output: str, trusted: str = "gitchrisqueen"):
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir(exist_ok=True)
+        gh = bin_dir / "gh"
+        gh.write_text("#!/usr/bin/env bash\n" + actor_output, encoding="utf-8")
+        gh.chmod(0o755)
+        script = textwrap.dedent(VERIFY["run"])
+        return subprocess.run(
+            ["bash", "-c", script], capture_output=True, text=True,
+            env={"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path),
+                 "GH_TOKEN": "x", "REPO": "acme/widget", "PR_NUMBER": "42",
+                 "TRUSTED_LABELLERS": trusted})
+
+    def test_a_trusted_labeller_authorises_the_fast_lane(self, tmp_path):
+        r = self._run(tmp_path, 'echo "gitchrisqueen"')
+        assert r.returncode == 0
+        assert "fast lane authorised" in r.stdout
+
+    def test_anybody_else_is_refused(self, tmp_path):
+        r = self._run(tmp_path, 'echo "drive-by-contributor"')
+        assert r.returncode == 1
+        assert "not in TRUSTED_LABELLERS" in r.stdout
+
+    def test_an_unreadable_timeline_FAILS_CLOSED(self, tmp_path):
+        # Cost of a false negative: the PR ships at the next window, hours later.
+        # Cost of a false positive: an unreviewed production deploy.
+        r = self._run(tmp_path, 'exit 1')
+        assert r.returncode == 1
+        assert "could not read" in r.stdout
+
+    def test_an_empty_actor_fails_closed(self, tmp_path):
+        r = self._run(tmp_path, 'echo ""')
+        assert r.returncode == 1
+
+    def test_a_prefix_of_a_trusted_name_is_not_a_match(self, tmp_path):
+        r = self._run(tmp_path, 'echo "gitchrisqueen-evil"')
+        assert r.returncode == 1
+
+    def test_multiple_trusted_labellers_are_supported(self, tmp_path):
+        r = self._run(tmp_path, 'echo "release-bot"', trusted="gitchrisqueen release-bot")
+        assert r.returncode == 0
+
+
+class TestFastLaneDocsMatchTheCode:
+    def test_the_doc_records_that_provenance_is_checked(self):
+        doc = (Path(__file__).resolve().parents[2] / "docs" / "release-fast-lane.md"
+               ).read_text(encoding="utf-8")
+        assert re.search(r"provenance|who applied|TRUSTED_LABELLERS", doc, re.I), (
+            "docs/release-fast-lane.md still describes release:now as label-presence only")

--- a/tests/unit/test_release_now_provenance.py
+++ b/tests/unit/test_release_now_provenance.py
@@ -13,48 +13,66 @@ import textwrap
 from pathlib import Path
 
 import pytest
-import yaml
 
 pytestmark = pytest.mark.unit
 
 WORKFLOW = (Path(__file__).resolve().parents[2] / ".github" / "workflows"
             / "release-auto-merge.yml")
 SOURCE = WORKFLOW.read_text(encoding="utf-8")
-PARSED = yaml.safe_load(SOURCE)
-STEPS = PARSED["jobs"]["merge-pending-release"]["steps"]
-VERIFY = next(s for s in STEPS if "Verify who applied" in (s.get("name") or ""))
+
+# Extracted by regex rather than parsed: PyYAML is not in the unit lane's dependencies, and the
+# repo already reads shell out of YAML this way (test_agent_pipeline_phasefix.py).
+STEP_NAMES = re.findall(r"^      - name: (.+)$", SOURCE, re.M)
+
+
+def _step(name_fragment: str) -> str:
+    """The full YAML block of the step whose name contains `name_fragment`."""
+    m = re.search(rf"^      - name: [^\n]*{re.escape(name_fragment)}[^\n]*\n"
+                  rf"(?:.*?)(?=^      - name: |\Z)", SOURCE, re.M | re.S)
+    assert m, f"step matching {name_fragment!r} not found"
+    return m.group(0)
+
+
+VERIFY = _step("Verify who applied")
+
+
+def _run_block(step: str) -> str:
+    """The step's `run:` script, dedented so bash sees it as the workflow does."""
+    m = re.search(r"^        run: \|\n(.*?)(?=^        \S|\Z)", step, re.M | re.S)
+    assert m, "no run: block in the verification step"
+    return textwrap.dedent(m.group(1))
 
 
 class TestTheGateIsWired:
     def test_the_verification_step_exists(self):
-        assert VERIFY is not None
+        assert VERIFY.strip()
 
     def test_it_runs_before_anything_enqueues_a_release(self):
         # A check that runs after the enqueue is decoration.
-        names = [s.get("name") or "" for s in STEPS]
-        assert names.index(VERIFY["name"]) == 0
+        assert "Verify who applied" in STEP_NAMES[0]
 
     def test_it_only_applies_to_the_fast_lane_not_the_scheduled_window(self):
         # The 4x-daily cron carries no PR and no label; gating it would stop every release.
-        assert VERIFY["if"] == "github.event_name == 'pull_request_target'"
+        assert "if: github.event_name == 'pull_request_target'" in VERIFY
 
     def test_the_allowlist_is_explicit_and_not_empty(self):
-        assert VERIFY["env"]["TRUSTED_LABELLERS"].strip()
+        m = re.search(r'TRUSTED_LABELLERS:\s*"([^"]*)"', VERIFY)
+        assert m and m.group(1).strip()
 
     def test_the_label_presence_check_is_still_there_too(self):
         # Provenance is an ADDITIONAL gate, not a replacement — a PR without the label must still
         # not fast-lane.
-        cond = PARSED["jobs"]["merge-pending-release"]["if"]
-        assert "release:now" in cond and "merged == true" in cond
+        job_if = re.search(r"^    if: >-\n(.*?)(?=^    steps:)", SOURCE, re.M | re.S).group(1)
+        assert "release:now" in job_if and "merged == true" in job_if
 
     def test_the_step_reads_the_LAST_labeled_event(self):
         # A label removed and re-added by someone else belongs to whoever added it last.
-        assert "| last" in VERIFY["run"]
+        assert "| last" in _run_block(VERIFY)
 
     def test_untrusted_input_is_passed_through_env_not_interpolated_into_the_script(self):
         # The ${{ }} -> shell interpolation hazard that codeql-pr-gate.yml has. The PR number is
         # numeric, but the habit is the point.
-        assert "${{" not in VERIFY["run"]
+        assert "${{" not in _run_block(VERIFY)
 
 
 class TestTheGateLogic:
@@ -67,7 +85,7 @@ class TestTheGateLogic:
         gh = bin_dir / "gh"
         gh.write_text("#!/usr/bin/env bash\n" + actor_output, encoding="utf-8")
         gh.chmod(0o755)
-        script = textwrap.dedent(VERIFY["run"])
+        script = _run_block(VERIFY)
         return subprocess.run(
             ["bash", "-c", script], capture_output=True, text=True,
             env={"PATH": f"{bin_dir}:/usr/bin:/bin", "HOME": str(tmp_path),


### PR DESCRIPTION
Second half of the same defect as #1053: a label doing the job of an access control.

`release:now` ships a PR to production the moment it merges, skipping the 4x-daily window. The gate checked only that the label was **present** on a merged PR. Labels have no ACL — anyone with triage can apply one, and `docs/release-fast-lane.md` explicitly authorises agents to self-apply it, including for `bug` + `feedback-loop`, which is exactly the class of issue auto-filed from the **unauthenticated** feedback endpoint.

## The gate

Reads the PR timeline for the **last** actor to apply `release:now` (a label removed and re-added belongs to whoever added it last) and refuses unless that actor is in `TRUSTED_LABELLERS`.

**Fails closed** — unreadable timeline, unknown actor, or no readable `labeled` event all refuse. Refusing costs a few hours, because the PR still ships at the next scheduled window; a false positive costs an unreviewed production deploy. A refusal is deliberately a red run with a `::warning::`, because it means someone applied a production-deploy label who is not authorised to.

Only the fast lane is gated. The scheduled cron carries no PR and no label, so gating it would stop every release.

## Verification

14 new tests, including running the step's **actual shell** against a stubbed `gh` (trusted actor, untrusted actor, unreadable API, empty actor, prefix-of-a-trusted-name, multiple allowlisted). Structural tests assert the gate runs **first** — a check that runs after the enqueue is decoration — and that label *presence* is still required too, since provenance is an additional gate rather than a replacement.

One test asserts `docs/release-fast-lane.md` describes the gate; it caught the doc being stale during development.

10,621 unit tests pass (the single failure, `test_docs_surface`, is pre-existing on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)