### PR TITLE
docs(security): record that code-owner review does not enforce at 0 approvals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,17 +7,24 @@
 #
 # Order matters — the LAST matching pattern wins.
 #
-# THERE IS DELIBERATELY NO `*` CATCH-ALL. `require_code_owner_reviews` is on, so a catch-all would
-# make EVERY file owned and therefore every PR blocked pending an approval — and since the agent
-# pipeline authenticates as @gitchrisqueen, and GitHub does not let you approve your own PR, that
-# would halt the pipeline outright. A catch-all also buys nothing against outside contributors:
-# they have no write access, so they cannot merge regardless. Listing only the control surfaces is
-# what lets routine agent work keep merging while the surfaces that govern it need a human.
+# THERE IS DELIBERATELY NO `*` CATCH-ALL. It would make every file owned, so the moment required
+# approvals goes to 1 every PR blocks pending an approval — and because the agent pipeline
+# authenticates as @gitchrisqueen, whom GitHub forbids from approving their own PR, that halts the
+# pipeline outright. A catch-all also buys nothing against outside contributors: they have no write
+# access and cannot merge regardless. Listing only the control surfaces is what lets routine agent
+# work keep merging while the surfaces that govern it need a human.
 #
-# HONEST LIMIT, worth knowing before you rely on this: agent and owner share one identity, so
-# GitHub cannot tell their PRs apart. Against the agent this is a speed bump and a paper trail —
-# the real control is the pipeline's credential having no `workflows` permission
-# (docs/contribution-security.md). It becomes a wall the moment the pipeline gets a bot identity.
+# MEASURED, because the GitHub docs do not say: `require_code_owner_reviews: true` with
+# `required_approving_review_count: 0` enforces NOTHING. Verified 2026-08-04 — a PR touching this
+# very file, with a `*` catch-all live on the base branch, reported mergeStateStatus CLEAN and no
+# requested reviewer. The code-owner setting is a QUALIFIER on the required approval count, not an
+# independent gate; with zero required approvals there is nothing for it to qualify.
+#
+# So today this file is documentation and auto-review-request, not enforcement. Two things make it
+# real, and both are planned: required approvals >= 1 on the branch that matters, and a separate
+# bot identity for the pipeline (agent and owner currently share one, so GitHub cannot tell their
+# PRs apart). Until then the only hard control over the agent is its credential having no
+# `workflows` permission — see docs/contribution-security.md.
 
 # --- CI/CD and the rules themselves ---------------------------------------------------------
 # A merged PR can currently rewrite any workflow, including the ones that gate merges and deploys.

--- a/docs/contribution-security.md
+++ b/docs/contribution-security.md
@@ -77,10 +77,23 @@ backstop for a misconfiguration in layers 1–2, not a substitute for them.
 
 ### 4. Permission separation
 
-- **CODEOWNERS** (`.github/CODEOWNERS`) requires explicit human approval on every control surface:
-  workflows, the agent pipeline, deploy scripts, auth/crypto, migrations, and the two label writers.
+- **CODEOWNERS** (`.github/CODEOWNERS`) names every control surface: workflows, the agent pipeline,
+  deploy scripts, auth/crypto, migrations, and the two label writers.
 - **The pipeline's credential has no `workflows` permission**, so editing `.github/workflows/**` is
   impossible at the API level — not merely reviewable.
+
+> **Measured, because the GitHub docs do not say it.** `require_code_owner_reviews: true` combined
+> with `required_approving_review_count: 0` **enforces nothing**. Verified 2026-08-04: a PR touching
+> `.github/CODEOWNERS`, with a `*` catch-all live on the base branch and code-owner review enabled,
+> reported `mergeStateStatus: CLEAN` and requested no reviewer. The code-owner setting is a
+> *qualifier* on the approval count, not an independent gate — with zero required approvals there is
+> nothing for it to qualify.
+>
+> So **CODEOWNERS is currently documentation and an auto-review-request, not enforcement.** Raising
+> the count to 1 makes it real but requires an approval on *every* PR, which ends the pipeline's
+> autonomy while agent and owner share an identity. The planned resolution is both halves of that
+> problem at once: a **bot identity** for the pipeline, and a **gated pre-release branch** where the
+> agent self-merges freely while `main` requires a reviewed promotion.
 
 **Read this limit honestly:** the pipeline authenticates as `@gitchrisqueen`, so GitHub cannot
 distinguish an agent PR from an owner PR. Against the *agent*, CODEOWNERS is a speed bump and a

--- a/tests/unit/test_codeowners.py
+++ b/tests/unit/test_codeowners.py
@@ -43,14 +43,21 @@ class TestCodeownersResolves:
         assert not ownerless, f"CODEOWNERS rules with no/invalid owner: {ownerless}"
 
     def test_there_is_no_catch_all(self):
-        # `require_code_owner_reviews` is ON. A `*` rule would make every file owned, so every PR
-        # would block pending an approval — and because the agent pipeline authenticates as the
-        # owner, and GitHub forbids approving your own PR, that halts the pipeline outright.
-        # It also buys nothing defensively: outside contributors have no write access anyway.
+        # A `*` rule makes every file owned, so the moment required approvals goes to 1 every PR
+        # blocks pending an approval — and because the agent pipeline authenticates as the owner,
+        # whom GitHub forbids from approving their own PR, that halts the pipeline outright.
+        # It also buys nothing defensively: outside contributors cannot merge regardless.
         patterns = [pat for pat, _ in _rules()]
         assert "*" not in patterns, (
-            "a `*` catch-all blocks every PR once require_code_owner_reviews is on — list the "
-            "control surfaces explicitly instead")
+            "a `*` catch-all blocks every PR once required approvals >= 1 — list the control "
+            "surfaces explicitly instead")
+
+    def test_the_measured_enforcement_limit_is_recorded(self):
+        # `require_code_owner_reviews: true` with `required_approving_review_count: 0` enforces
+        # nothing (measured 2026-08-04). A reader who assumes otherwise will believe a control
+        # exists that does not, so the finding has to survive in the file itself.
+        text = CODEOWNERS.read_text(encoding="utf-8")
+        assert "enforces NOTHING" in text and "required_approving_review_count: 0" in text
 
 
 class TestControlSurfacesAreCovered:


### PR DESCRIPTION
Correction to a comment I wrote in #1055 **before** measuring the behaviour.

It claimed a CODEOWNERS catch-all would block every PR *"because require_code_owner_reviews is on"*. Measured 2026-08-04, that is false:

> A PR touching `.github/CODEOWNERS` — with a `*` catch-all live on the base branch and `require_code_owner_reviews: true` enabled — reported **`mergeStateStatus: CLEAN`** and requested **no reviewer**.

`require_code_owner_reviews` is a *qualifier* on `required_approving_review_count`, not an independent gate. At 0 required approvals there is nothing for it to qualify. The GitHub docs do not state this either way, which is why it needed measuring.

Removing the catch-all was still correct — it is a landmine that arms the moment approvals go to 1 — but the reason given was wrong, and a reader would otherwise believe a control exists that does not.

Recorded in the file, in `docs/contribution-security.md`, and pinned by a test so it cannot quietly drift back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)