### PR TITLE
feat(content-generation): let authors add an image to a text post (closes #1030)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -413,6 +413,9 @@ IMAGE_GATE_MAX_ATTEMPTS=2
 IMAGE_QUALITY_GATE_SURFACES=newsletter,post_image
 # Hard cap on one Replicate render before retry/fallback.
 REPLICATE_TIMEOUT_SECONDS=300
+# Manual "Generate with AI" clicks per user per hour in the Content Studio (issue #1030).
+# Claimed BEFORE the render — the button can be held down and every press is real spend.
+POST_IMAGE_GENERATE_MAX_PER_HOUR=20
 
 # Avatar preview/approval gate: how many times a user may re-roll their avatar's preview
 # samples. Sits on top of the credit ledger — samples cost inference money but no training credit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,10 @@ per-content-type prompt helper, add a preset. `utilities/ai/image_gen.py` render
 (`IMAGE_BACKEND`, cost-tracked); `render_image_gated` adds the bounded `lem-vision` check, failing
 OPEN. Avatar likeness NEVER renders in `image_gen` — `generate_post_image` (ai_helper) owns the LoRA
 path behind `avatar/guardrails.resolve_avatar_for`. NO text/logos in a render prompt.
+`utilities/post_image.py` (#1030) is the ONE place a POST's image is validated, stored and removed —
+upload OR the studio's "Generate with AI", the SAME engine the scheduled path uses. A compose-time
+`image_url` is CALLER input: `/schedule_post/` takes it only when `owns_post_image_url` says it's a
+preview we issued to that caller, and a stored URL never resolves outside `assets_dir`.
 
 ## Selenium Pattern
 

--- a/docs/image-stack.md
+++ b/docs/image-stack.md
@@ -73,11 +73,48 @@ this module only for the non-avatar case; `render_avatar_image_gated` is the gat
 owner. Newsletter covers add a fail-closed relevance classifier on the Auto path
 (`utilities/newsletter_cover.py`, see `docs/newsletter-covers.md`).
 
+## Post images — the author's own half (issue #1030)
+
+`utilities/post_image.py` is the ONE place a POST's image is validated, stored and removed. It adds
+no prompt engine: `generate_image_for_post` is `build_image_brief` + the gated render above, and
+`run_content_plan._generate_text_post_image` (the scheduled path) now goes through it too — so the
+button in the Content Studio and the nightly generator render the same way.
+
+Two origins, and they are NOT symmetric in kind but ARE in review:
+
+| Origin | Where it comes from | Gate |
+|---|---|---|
+| Upload | the author's own file | `inspect_post_image_bytes` — decodable, PNG/JPEG, under 8 MB, ≥ 400×400 |
+| Generate | `lem-image` via the brief | the vision gate, plus the hourly claim below |
+
+Unlike a newsletter cover there is no second `pending_review` state: a post already sits in the
+review queue until a human approves it, so the queue IS the gate.
+
+Storage: `images/posts/<post_id>/` once the row exists (so `purge_post_assets` cleans it), and
+`images/post_previews/<user_id>/` while the author is still composing — the same shape
+`/generate-carousel` already uses for slides handed back before a post exists. An abandoned preview
+is left on disk for the same reason an abandoned carousel preview is: pruning it would have to
+outlive a post scheduled 30 days out.
+
+`posts.image_url` holds the PUBLIC `/api/assets?file_name=` URL, because that is what the publish
+step hands LinkedIn. Two consequences the helpers exist for:
+
+- **A compose-time `image_url` is caller-supplied input on a field the publish step later fetches.**
+  `/schedule_post/` accepts one ONLY when `owns_post_image_url` says it is a preview we issued to
+  that caller; anything else is dropped (and warned), never stored.
+- **A stored URL never resolves outside `assets_dir`.** `post_image_abs_path` re-checks containment
+  through `realpath`, so a hand-edited row cannot hand a delete — or a share — an arbitrary file.
+
+`claim_manual_generation` bounds the "Generate with AI" button at
+`POST_IMAGE_GENERATE_MAX_PER_HOUR` per user, claimed BEFORE the render (the button can be held
+down and every press is real spend) and failing OPEN when Redis is gone.
+
 ## Environment
 
 | Var | Meaning |
 |---|---|
 | `IMAGE_BACKEND` | `auto` (default) / `gpt-image` / `flux` |
+| `POST_IMAGE_GENERATE_MAX_PER_HOUR` | Manual post-image generations per user per hour (20) |
 | `DEFAULT_IMAGE_MODEL` | Model handed to the `lem-image` group |
 | `IMAGE_QUALITY` | gpt-image quality tier |
 | `IMAGE_QUALITY_GATE_SURFACES` | Surfaces where the vision gate is enforced, not advisory |

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -1210,7 +1210,12 @@ _LEN_TARGET_NAME = 255         # engagement_targets.name VARCHAR(255)
 _LEN_STORY_TITLE = 255         # story_bank.title VARCHAR(255)
 _LEN_STORY_BODY = 5000         # story_bank.body (TEXT; app cap)
 _LEN_GROUP_POST = 3000    # LinkedIn caps a post at 3000 chars (group_post_drafts.content is TEXT)
-_LEN_POST_CONTENT = 3000  # same cap for a feed post — the compose form already enforces it
+# Source text for an image prompt, NOT a post-length cap. LinkedIn's 3000 is enforced on the
+# compose form only — nothing truncates a generated draft, and the Review & Edit textarea has no
+# maxLength — so bounding this at 3000 would answer 422 for a long draft, and FastAPI's validation
+# `detail` is a LIST, which the SPA cannot show: the author would get "Image generation failed"
+# with no way to act on it. Bounded generously instead; it is still what reaches the brief LLM.
+_LEN_IMAGE_PROMPT_SOURCE = 10000
 _LEN_NL_TITLE = 255       # newsletter_settings.title VARCHAR(255)
 _LEN_NL_TOPIC = 512       # newsletter_settings.topic VARCHAR(512)
 _LEN_DM_RECIPIENT_URL = 512   # scheduled_dms.recipient_profile_url VARCHAR(512)
@@ -1302,7 +1307,7 @@ class PostImageGenerateRequest(BaseModel):
     composing — there is no row yet — in which case `content` is the only text there is."""
     session_token: SessionTokenField = None
     post_id: Optional[int] = None
-    content: Optional[str] = Field(default=None, max_length=_LEN_POST_CONTENT)
+    content: Optional[str] = Field(default=None, max_length=_LEN_IMAGE_PROMPT_SOURCE)
 
 
 class PostImageRemoveRequest(BaseModel):

--- a/src/cqc_lem/api/main.py
+++ b/src/cqc_lem/api/main.py
@@ -104,7 +104,8 @@ from cqc_lem.utilities.db import (
     get_user_geo, update_user_location, get_user_content_language,
     replace_video_url_base, get_post_type, get_post_buyer_stage, get_post_status,
     update_db_post_rejection_reason,
-    get_post_url_from_log_for_user,
+    get_post_url_from_log_for_user, get_post_content,
+    get_post_image_url, update_db_post_image_url,
     insert_feedback, FeedbackSource, FeedbackStatus,
     get_latest_review_feedback_id, get_early_adopter_grant, extend_trial_for_user,
     is_user_admin, get_feedback_list, record_feedback_review, get_feedback_by_id,
@@ -141,6 +142,9 @@ from cqc_lem.utilities.webauthn_util import (
 import requests
 from cqc_lem.utilities.logger import myprint, log_debug, log_warning, log_info, log_error
 from cqc_lem.utilities.mime_type_helper import get_file_mime_type
+from cqc_lem.utilities.post_image import (PostImageRejected, claim_manual_generation,
+                                          generate_image_for_post, owns_post_image_url,
+                                          remove_post_image_file, save_post_image_bytes)
 from cqc_lem.utilities.quality_gates import (parse_gate_findings, clamp_threshold,
                                              AUTHENTICITY_SCORE_MIN_BOUNDS,
                                              SIMILARITY_MAX_PCT_BOUNDS)
@@ -969,6 +973,9 @@ class PostRequest(BaseModel):
     use_avatar: Optional[bool] = None
     video_quality: Optional[str] = "standard"  # standard | premium | premium_top
     rejection_reason: Optional[str] = Field(default=None, max_length=1000)
+    # A compose-time image the author uploaded or generated BEFORE the row existed (issue #1030).
+    # Only a preview URL we issued to this caller is accepted — see `owns_post_image_url`.
+    image_url: Optional[str] = Field(default=None, max_length=1000)
 
 
 class AvatarCreditCheckoutRequest(BaseModel):
@@ -1203,6 +1210,7 @@ _LEN_TARGET_NAME = 255         # engagement_targets.name VARCHAR(255)
 _LEN_STORY_TITLE = 255         # story_bank.title VARCHAR(255)
 _LEN_STORY_BODY = 5000         # story_bank.body (TEXT; app cap)
 _LEN_GROUP_POST = 3000    # LinkedIn caps a post at 3000 chars (group_post_drafts.content is TEXT)
+_LEN_POST_CONTENT = 3000  # same cap for a feed post — the compose form already enforces it
 _LEN_NL_TITLE = 255       # newsletter_settings.title VARCHAR(255)
 _LEN_NL_TOPIC = 512       # newsletter_settings.topic VARCHAR(512)
 _LEN_DM_RECIPIENT_URL = 512   # scheduled_dms.recipient_profile_url VARCHAR(512)
@@ -1286,6 +1294,19 @@ class PostRegenerateRequest(BaseModel):
 
 class PostRescoreRequest(BaseModel):
     session_token: str
+    post_id: int
+
+
+class PostImageGenerateRequest(BaseModel):
+    """Render an image for a post (issue #1030). `post_id` is absent while the author is still
+    composing — there is no row yet — in which case `content` is the only text there is."""
+    session_token: SessionTokenField = None
+    post_id: Optional[int] = None
+    content: Optional[str] = Field(default=None, max_length=_LEN_POST_CONTENT)
+
+
+class PostImageRemoveRequest(BaseModel):
+    session_token: SessionTokenField = None
     post_id: int
 
 
@@ -2542,13 +2563,21 @@ def schedule_post(post: PostRequest) -> ResponseModel:
 
     _warn_if_naive_schedule(post.scheduled_datetime, "/schedule_post/", user_id=user_id)
 
+    # A compose-time image is a URL the CALLER hands us for a field the publish step later fetches,
+    # so it is accepted only when it is a preview WE issued to this account (issue #1030) — never
+    # an arbitrary URL, and never another user's preview. Anything else is dropped, not stored.
+    image_url = post.image_url if owns_post_image_url(user_id, post.image_url) else None
+    if post.image_url and not image_url:
+        log_warning("Refused a post image URL that is not this account's preview",
+                    user_id=user_id, action_type="post_image")
+
     # SPA-created posts carry an explicit status: "Approve & Schedule" → approved,
     # "Save Draft" → pending. Auto-generated content sets its own status elsewhere.
     if insert_post(email, post.content, post.scheduled_datetime, post.post_type,
                    video_url=post.video_url, carousel_slides=post.carousel_slides,
                    video_quality=post.video_quality or "standard",
                    status=post.status or PostStatus.PENDING,
-                   use_avatar=post.use_avatar):
+                   use_avatar=post.use_avatar, image_url=image_url):
         return ResponseModel(status_code=200, detail="Post scheduled successfully")
     else:
         raise HTTPException(status_code=404, detail="Could not schedule post")
@@ -4487,6 +4516,134 @@ def rescore_post_endpoint(request: PostRescoreRequest) -> ResponseModel:
         log_error("Could not re-score post", exc=e, user_id=user_id, post_id=request.post_id)
         raise HTTPException(status_code=500, detail="Could not re-score this post")
     return ResponseModel(status_code=200, detail=result)
+
+
+# --- Post images (issue #1030) --------------------------------------------------------------
+# An image was only ever attached to a post by a background task. These three endpoints are the
+# author's half: upload their own artwork, ask for a render, or take one off again — from the
+# compose form (no row yet, so the image is a preview URL handed back at schedule time) and from
+# the Review & Edit tab (the row exists, so the write lands on it immediately).
+
+
+def _post_open_to_image_edits(session_token: Optional[str], post_id: int) -> int:
+    """The caller's user_id for a post they own and can still change the image on.
+
+    A published post's image is already on LinkedIn — changing the row would only make the queue
+    disagree with what shipped, so that is a 409 rather than a silently useless write.
+    """
+    user_id = require_session_user_id(session_token)
+    if get_post_user_id(post_id) != user_id:
+        raise HTTPException(status_code=404, detail="Post not found")
+    if get_post_status(post_id) == PostStatus.POSTED.value:
+        raise HTTPException(status_code=409,
+                            detail="This post is already published — its image can't be changed")
+    return user_id
+
+
+def _attach_post_image(user_id: int, post_id: int, image_url: str) -> None:
+    """Point the row at a newly stored image and drop the file it replaced."""
+    previous = get_post_image_url(post_id)
+    if not update_db_post_image_url(post_id, image_url):
+        remove_post_image_file(image_url)  # don't leave an orphan behind a failed write
+        log_error("Could not store the post image URL", user_id=user_id, post_id=post_id)
+        raise HTTPException(status_code=500, detail="Could not save the image")
+    if previous and previous != image_url:
+        remove_post_image_file(previous)
+
+
+@router.post("/user/post/image", responses={
+    200: {"description": "Image attached"},
+    **{k: v for k, v in error_responses.items() if k in [400, 401, 403, 404]},
+    409: {"description": "Post is already published"},
+    500: {"description": "Server error"},
+})
+async def upload_post_image_endpoint(
+    session_token: str = Form(...),
+    post_id: Optional[int] = Form(default=None),
+    file: UploadFile = File(...),
+) -> ResponseModel:
+    """Attach the author's OWN image to a post — or, with no `post_id`, to a draft still being
+    composed, which hands back a preview URL to pass to `/schedule_post/`.
+
+    The bytes pass the deterministic gate first, so an unreadable or tiny file is a 400 here rather
+    than a share LinkedIn refuses at publish time.
+    """
+    if post_id:
+        user_id = _post_open_to_image_edits(session_token, post_id)
+    else:
+        user_id = require_session_user_id(session_token)
+
+    data = await file.read()
+    try:
+        image_url = save_post_image_bytes(user_id, data, post_id=post_id)
+    except PostImageRejected as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except OSError as e:
+        log_error("Could not store an uploaded post image", exc=e, user_id=user_id,
+                  post_id=post_id)
+        raise HTTPException(status_code=500, detail="Could not store the image")
+
+    if post_id:
+        _attach_post_image(user_id, post_id, image_url)
+    return ResponseModel(status_code=200, detail={"post_id": post_id, "image_url": image_url})
+
+
+@router.post("/user/post/image/generate", responses={
+    200: {"description": "Image generated"},
+    **{k: v for k, v in error_responses.items() if k in [400, 401, 403, 404]},
+    409: {"description": "Post is already published"},
+    429: {"description": "Hourly generation limit reached"},
+    502: {"description": "Generation failed upstream"},
+})
+def generate_post_image_endpoint(request: PostImageGenerateRequest) -> ResponseModel:
+    """Render an image for a post from its text, through the SAME brief + gated renderer the
+    scheduled path uses. Runs inline (one render) so the studio can show the result immediately.
+
+    `content` wins over the stored row: the author is usually looking at an edit they have not
+    saved yet, and drawing the image from stale text is the one way this feature is confusing.
+    """
+    if request.post_id:
+        user_id = _post_open_to_image_edits(request.session_token, request.post_id)
+        text = (request.content or "").strip() or (get_post_content(request.post_id) or "")
+    else:
+        user_id = require_session_user_id(request.session_token)
+        text = (request.content or "").strip()
+
+    if not text.strip():
+        raise HTTPException(status_code=400,
+                            detail="Write the post content first — the image is drawn from it")
+    if not claim_manual_generation(user_id):
+        raise HTTPException(
+            status_code=429,
+            detail="You've generated a lot of images in the last hour — try again shortly.")
+
+    image_url, reason = generate_image_for_post(user_id, text, post_id=request.post_id)
+    if not image_url:
+        # 502, not 500: the render is an upstream call, and telling the user "the image service
+        # didn't answer" is both true and actionable (try again) where "server error" is neither.
+        raise HTTPException(status_code=502, detail=reason or "Could not generate an image")
+
+    if request.post_id:
+        _attach_post_image(user_id, request.post_id, image_url)
+    return ResponseModel(status_code=200,
+                         detail={"post_id": request.post_id, "image_url": image_url})
+
+
+@router.post("/user/post/image/remove", responses={
+    200: {"description": "Image removed"},
+    **{k: v for k, v in error_responses.items() if k in [401, 403, 404]},
+    409: {"description": "Post is already published"},
+    500: {"description": "Server error"},
+})
+def remove_post_image_endpoint(request: PostImageRemoveRequest) -> ResponseModel:
+    """Take the image off a post so it publishes as plain text. The file goes with it."""
+    user_id = _post_open_to_image_edits(request.session_token, request.post_id)
+    previous = get_post_image_url(request.post_id)
+    if not update_db_post_image_url(request.post_id, None):
+        log_error("Could not clear the post image", user_id=user_id, post_id=request.post_id)
+        raise HTTPException(status_code=500, detail="Could not remove the image")
+    remove_post_image_file(previous)
+    return ResponseModel(status_code=200, detail={"post_id": request.post_id, "image_url": None})
 
 
 # --- Scheduled 1:1 DMs (issue #306) — mirrors the post scheduler endpoints ---

--- a/src/cqc_lem/app/run_content_plan.py
+++ b/src/cqc_lem/app/run_content_plan.py
@@ -383,54 +383,23 @@ def create_content(user_id: int, post_type: str, stage: str, post_id: int = None
 def _generate_text_post_image(user_id: int, text_content: str, post_id: "int | None") -> "str | None":
     """Generate + store the AI image a generated TEXT post publishes with.
 
-    Gated on the user's `text_post_images` preference. The avatar rides the EXISTING
-    `post_image` surface + the post's compose-time choice (guardrails decide); it is resolved
-    BEFORE the brief is authored so the declared subject clause leads the prompt (issue #744).
+    Gated on the user's `text_post_images` preference — that gate is what this wrapper adds; the
+    render itself is `post_image.generate_image_for_post`, the ONE engine the Content Studio's
+    manual "Generate image" button also calls (issue #1030).
     Never raises: `posts.image_url` simply stays NULL and the post ships bare.
     """
     if not post_id or not text_content:
         return None
     try:
-        from cqc_lem.utilities.ai.image_brief import build_image_brief
-        from cqc_lem.utilities.ai.image_gen import render_image_gated
-        from cqc_lem.utilities.avatar.guardrails import (AVATAR_SURFACE_POST_IMAGE,
-                                                         resolve_avatar_for)
         from cqc_lem.utilities.db import get_engagement_preferences, update_db_post_image_url
+        from cqc_lem.utilities.post_image import generate_image_for_post
 
         if not get_engagement_preferences(user_id).get("text_post_images", True):
             return None
 
-        profile = None
-        try:
-            profile = load_profile_for_user(user_id)
-        except Exception as e:
-            myprint(f"_generate_text_post_image: profile load skipped: {e}")
-
-        avatar = resolve_avatar_for(user_id, surface=AVATAR_SURFACE_POST_IMAGE, post_id=post_id)
-        brief = build_image_brief(text_content, surface="post_image", ratio=DEFAULT_IMAGE_RATIO,
-                                  profile=profile, avatar=avatar)
-        if avatar:
-            from cqc_lem.utilities.ai.image_gen import render_avatar_image_gated
-            image_path = render_avatar_image_gated(
-                brief.prompt, avatar=avatar, user_id=user_id, surface="post_image",
-                ratio=DEFAULT_IMAGE_RATIO, focal_concept=brief.focal_concept, post_id=post_id)
-        else:
-            image_path = render_image_gated(brief.prompt, surface="post_image",
-                                            ratio=DEFAULT_IMAGE_RATIO,
-                                            focal_concept=brief.focal_concept,
-                                            user_id=user_id, post_id=post_id)
-        if not image_path or not os.path.isfile(image_path):
+        api_image_url, _reason = generate_image_for_post(user_id, text_content, post_id=post_id)
+        if not api_image_url:
             return None
-
-        # Copy into a per-post dir under the shared assets volume (mirrors carousel slides) so
-        # publish can upload it and purge_post_assets can clean it deterministically.
-        import shutil
-        post_dir = os.path.join(assets_dir, "images", "posts", str(post_id))
-        create_folder_if_not_exists(post_dir)
-        dest = os.path.join(post_dir, os.path.basename(image_path))
-        shutil.copyfile(image_path, dest)
-        api_image_url = (f"{API_URL_FINAL}/api/assets?file_name=images/posts/{post_id}/"
-                         f"{os.path.basename(dest)}")
         update_db_post_image_url(post_id, api_image_url)
         myprint(f"_generate_text_post_image: post_id={post_id} -> {api_image_url}")
         return api_image_url

--- a/src/cqc_lem/ui/src/api/client.test.ts
+++ b/src/cqc_lem/ui/src/api/client.test.ts
@@ -64,6 +64,50 @@ describe('api client', () => {
     }
   })
 
+  // Issue #1030. The client defaults every request to `application/json`, and axios reads that in
+  // `transformRequest`: a FormData body sent under a JSON Content-Type is turned into
+  // `JSON.stringify(formDataToJSON(data))`, where a File collapses to `{}`. The upload then leaves
+  // the browser as JSON with no file in it and the endpoint answers 422 — which is exactly what
+  // every FormData call site here does (post images, newsletter covers), because a mocked
+  // `api.post` in a component test never runs the transform.
+  it('leaves a multipart body alone — the file must survive the JSON default', async () => {
+    let captured: InternalAxiosRequestConfig | null = null
+    const form = new FormData()
+    form.append('session_token', 'cookie')
+    form.append('file', new File(['bytes'], 'shot.png', { type: 'image/png' }))
+    try {
+      api.defaults.adapter = async (config: InternalAxiosRequestConfig) => {
+        captured = config
+        return { data: {}, status: 200, statusText: 'OK', headers: {}, config } as AxiosResponse
+      }
+      await api.post('/user/post/image', form)
+    } finally {
+      api.defaults.adapter = original
+    }
+    const sent = captured as unknown as InternalAxiosRequestConfig
+    expect(sent.data).toBeInstanceOf(FormData)
+    expect((sent.data as FormData).get('file')).toBeInstanceOf(File)
+    // Never JSON: that is the value that would have eaten the file.
+    expect(String(sent.headers['Content-Type'] ?? '')).toBe('multipart/form-data')
+    expect(sent.headers['X-LEM-Client']).toBe('spa')
+  })
+
+  it('still sends a plain object as JSON', async () => {
+    let captured: InternalAxiosRequestConfig | null = null
+    try {
+      api.defaults.adapter = async (config: InternalAxiosRequestConfig) => {
+        captured = config
+        return { data: {}, status: 200, statusText: 'OK', headers: {}, config } as AxiosResponse
+      }
+      await api.post('/schedule_post/', { content: 'hello' })
+    } finally {
+      api.defaults.adapter = original
+    }
+    const sent = captured as unknown as InternalAxiosRequestConfig
+    expect(sent.data).toBe('{"content":"hello"}')
+    expect(String(sent.headers['Content-Type'])).toContain('application/json')
+  })
+
   it('sends it with no session token held — the cookie is the credential it protects', async () => {
     const headers = await sentHeaders('post', '/create_weekly_content/')
     expect(headers['X-LEM-Client']).toBe('spa')

--- a/src/cqc_lem/ui/src/api/client.ts
+++ b/src/cqc_lem/ui/src/api/client.ts
@@ -27,6 +27,19 @@ const CLIENT_HEADER = 'X-LEM-Client'
 
 api.interceptors.request.use((config) => {
   config.headers[CLIENT_HEADER] = 'spa'
+  // A multipart upload must NOT inherit the JSON default above (issue #1030). axios reads the
+  // Content-Type in `transformRequest`, and when it says JSON it serialises a FormData body with
+  // `JSON.stringify(formDataToJSON(data))` — the File collapses to `{}`, so the bytes never leave
+  // the browser and the endpoint answers 422. Clearing it here lets the adapter hand the body to
+  // the browser, which is the only thing that can write the multipart boundary. It belongs in this
+  // one client for the same reason the header above does: a call site that has to remember it is a
+  // call site that will forget it — `/user/newsletter-draft/cover` already had.
+  // `multipart/form-data` here carries no boundary, and it is not meant to: the adapter replaces it
+  // with the browser's own value (boundary included) for a FormData body. Saying it anyway is what
+  // `Avatars.tsx` already does per call site, and it keeps the intent readable.
+  if (typeof FormData !== 'undefined' && config.data instanceof FormData) {
+    config.headers['Content-Type'] = 'multipart/form-data'
+  }
   // Since #745 (2b) the session normally rides in an httpOnly cookie the browser attaches itself,
   // and localStorage holds only the 'cookie' sentinel — there is nothing to put in this header.
   // It is still sent when a real token is held (cookie-less fallback, tutorial capture harness).

--- a/src/cqc_lem/ui/src/pages/ContentStudio.image.test.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.image.test.tsx
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import ContentStudio from './ContentStudio'
+
+// Issue #1030: a text post's image could only ever be attached by a background task. These cover
+// the author's half of it on the Review & Edit tab — upload, generate, remove.
+
+const get = vi.fn()
+const post = vi.fn()
+
+vi.mock('../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'test@example.com', userId: 1 }, sessionToken: 'tok' }),
+}))
+
+vi.mock('../hooks/useUserTimezone', () => ({
+  useUserTimezone: () => 'America/New_York',
+  useUserTimezoneState: () => ({ timezone: 'America/New_York', isResolved: true }),
+}))
+
+vi.mock('../utils/analytics', () => ({
+  capture: vi.fn(),
+  recordPostApproval: vi.fn(),
+  maskProps: (className: string) => ({ className }),
+  EVENTS: { postApproved: 'post_approved', postRejected: 'post_rejected' },
+}))
+
+vi.mock('./content/ComposePost', () => ({ default: () => null }))
+vi.mock('./review/NewsletterQueue', () => ({ default: () => null }))
+vi.mock('./review/ScheduledDMs', () => ({ default: () => null }))
+vi.mock('./review/ConnectionRequests', () => ({ default: () => null }))
+vi.mock('./review/OutreachFunnel', () => ({ default: () => null }))
+vi.mock('./review/LeadsInbox', () => ({ default: () => null }))
+vi.mock('./review/LeadsPipeline', () => ({ default: () => null }))
+vi.mock('./review/CatchupTouches', () => ({ default: () => null }))
+
+const POST_BASE = {
+  post_id: 1,
+  content: 'Draft content',
+  video_url: null,
+  image_url: null,
+  scheduled_time: '2026-07-30T14:00:00Z',
+  carousel_slides: null,
+  post_url: null,
+  archetype: null,
+  authenticity_score: null,
+  gate_reason: null,
+  rejection_reason: null,
+}
+
+function payload(data: unknown) {
+  return { data: { detail: data } }
+}
+
+function harness(ui: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  return render(
+    <MemoryRouter initialEntries={['/?tab=review']}>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </MemoryRouter>
+  )
+}
+
+function mockPosts(posts: unknown[]) {
+  get.mockImplementation((path: string) => {
+    if (path.startsWith('/posts/')) return Promise.resolve(payload({ posts, total: posts.length, page: 1, page_size: 10 }))
+    if (path.startsWith('/user/timezone')) return Promise.resolve(payload({ timezone: 'America/New_York' }))
+    if (path.startsWith('/content_generation_status')) return Promise.resolve(payload(null))
+    return Promise.resolve(payload({}))
+  })
+}
+
+async function openPost(posts: unknown[]) {
+  mockPosts(posts)
+  harness(<ContentStudio />)
+  await waitFor(() => expect(screen.getByText('Draft content')).toBeDefined())
+  fireEvent.click(screen.getByText('Draft content'))
+  await waitFor(() => expect(screen.getByDisplayValue('Draft content')).toBeDefined())
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('ContentStudio post images (issue #1030)', () => {
+  it('offers upload + generate on a pending text post', async () => {
+    await openPost([{ ...POST_BASE, post_type: 'text', status: 'pending' }])
+
+    expect(screen.getByLabelText('Upload post image')).toBeDefined()
+    expect(screen.getByRole('button', { name: /Generate with AI/i })).toBeDefined()
+  })
+
+  it('does not offer an image on a carousel post — the deck IS the media', async () => {
+    await openPost([{ ...POST_BASE, post_type: 'carousel', status: 'pending', carousel_slides: ['Slide 1'] }])
+
+    expect(screen.queryByLabelText('Upload post image')).toBeNull()
+    expect(screen.queryByRole('button', { name: /Generate with AI/i })).toBeNull()
+  })
+
+  it('generates from the text ON SCREEN, not the stored draft', async () => {
+    await openPost([{ ...POST_BASE, post_type: 'text', status: 'pending' }])
+    post.mockResolvedValue(payload({ post_id: 1, image_url: 'https://api.test/api/assets?file_name=images/posts/1/img_a.png' }))
+
+    fireEvent.change(screen.getByDisplayValue('Draft content'), { target: { value: 'Edited but unsaved' } })
+    fireEvent.click(screen.getByRole('button', { name: /Generate with AI/i }))
+
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith('/user/post/image/generate', {
+        session_token: 'tok',
+        post_id: 1,
+        content: 'Edited but unsaved',
+      })
+    )
+    // The new image lands on the open post without a save.
+    await waitFor(() => expect(screen.getByAltText('Image on post 1')).toBeDefined())
+  })
+
+  it('surfaces the server reason when generation fails', async () => {
+    await openPost([{ ...POST_BASE, post_type: 'text', status: 'pending' }])
+    post.mockRejectedValue({ response: { data: { detail: 'Image generation failed' } } })
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate with AI/i }))
+
+    await waitFor(() => expect(screen.getByText('Image generation failed')).toBeDefined())
+  })
+
+  it('removes an existing image', async () => {
+    await openPost([{
+      ...POST_BASE, post_type: 'text', status: 'pending',
+      image_url: 'https://api.test/api/assets?file_name=images/posts/1/img_a.png',
+    }])
+    post.mockResolvedValue(payload({ post_id: 1, image_url: null }))
+
+    expect(screen.getByAltText('Image on post 1')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: /Remove image/i }))
+
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith('/user/post/image/remove', { session_token: 'tok', post_id: 1 })
+    )
+    await waitFor(() => expect(screen.queryByAltText('Image on post 1')).toBeNull())
+  })
+
+  it('uploads the chosen file as multipart', async () => {
+    await openPost([{ ...POST_BASE, post_type: 'text', status: 'pending' }])
+    post.mockResolvedValue(payload({ post_id: 1, image_url: 'https://api.test/api/assets?file_name=images/posts/1/img_b.png' }))
+
+    const file = new File(['bytes'], 'shot.png', { type: 'image/png' })
+    fireEvent.change(screen.getByLabelText('Upload post image'), { target: { files: [file] } })
+
+    await waitFor(() => expect(post).toHaveBeenCalled())
+    const [path, form] = post.mock.calls[0]
+    expect(path).toBe('/user/post/image')
+    expect(form).toBeInstanceOf(FormData)
+    expect((form as FormData).get('post_id')).toBe('1')
+    expect((form as FormData).get('file')).toBe(file)
+  })
+})

--- a/src/cqc_lem/ui/src/pages/ContentStudio.tsx
+++ b/src/cqc_lem/ui/src/pages/ContentStudio.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { useSearchParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import api from '../api/client'
@@ -245,9 +245,15 @@ export default function ContentStudio() {
   // Verdict of the last "Save & re-score" run on the open post (issue #421).
   const [rescoreResult, setRescoreResult] = useState<string | null>(null)
 
+  // Image edits on the open post (issue #1030) — upload/generate/remove write straight to the row,
+  // so they are deliberately NOT part of "Save Changes".
+  const [imageBusy, setImageBusy] = useState<'upload' | 'generate' | 'remove' | null>(null)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const imageFileRef = useRef<HTMLInputElement>(null)
+
   // The re-score verdict belongs to one post — drop it when a different one is opened.
   const editingPostId = editingPost?.post_id ?? null
-  useEffect(() => { setRescoreResult(null) }, [editingPostId])
+  useEffect(() => { setRescoreResult(null); setImageError(null) }, [editingPostId])
 
   const { start: filterStartDate, end: filterEndDate } = resolveDateRange(
     dateRange, userTimezone, customStartDate, customEndDate
@@ -347,6 +353,58 @@ export default function ContentStudio() {
       qc.invalidateQueries({ queryKey: ['posts', email] })
     },
     onError: () => setRescoreResult('Could not re-score this post — please try again.'),
+  })
+
+  // Image on an existing post (issue #1030). All three actions land on the row immediately —
+  // an image is a file, not a form field, so there is nothing sensible to hold until "Save".
+  const applyImageUrl = (postId: number, url: string | null) => {
+    setEditingPost((p) => (p && p.post_id === postId ? { ...p, image_url: url } : p))
+    qc.invalidateQueries({ queryKey: ['posts', email] })
+  }
+  const imageErrorText = (err: unknown, fallback: string) => {
+    const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+    setImageError(typeof detail === 'string' ? detail : fallback)
+  }
+
+  const uploadImageMutation = useMutation({
+    mutationFn: (vars: { post_id: number; file: File }) => {
+      const form = new FormData()
+      form.append('session_token', sessionToken!)
+      form.append('post_id', String(vars.post_id))
+      form.append('file', vars.file)
+      return api.post('/user/post/image', form)
+    },
+    onMutate: () => { setImageBusy('upload'); setImageError(null) },
+    onSuccess: (res, vars) => applyImageUrl(vars.post_id, res.data.detail.image_url),
+    onError: (err) => imageErrorText(err, 'Could not use that image — try another file.'),
+    onSettled: () => {
+      setImageBusy(null)
+      if (imageFileRef.current) imageFileRef.current.value = ''
+    },
+  })
+
+  const generateImageMutation = useMutation({
+    // Send the content that is ON SCREEN: the author is usually looking at an unsaved edit, and an
+    // image drawn from the stale stored text is the one way this reads as broken.
+    mutationFn: (post: Post) =>
+      api.post('/user/post/image/generate', {
+        session_token: sessionToken,
+        post_id: post.post_id,
+        content: post.content,
+      }),
+    onMutate: () => { setImageBusy('generate'); setImageError(null) },
+    onSuccess: (res, post) => applyImageUrl(post.post_id, res.data.detail.image_url),
+    onError: (err) => imageErrorText(err, 'Image generation failed — try again.'),
+    onSettled: () => setImageBusy(null),
+  })
+
+  const removeImageMutation = useMutation({
+    mutationFn: (post_id: number) =>
+      api.post('/user/post/image/remove', { session_token: sessionToken, post_id }),
+    onMutate: () => { setImageBusy('remove'); setImageError(null) },
+    onSuccess: (_res, post_id) => applyImageUrl(post_id, null),
+    onError: (err) => imageErrorText(err, 'Could not remove the image — try again.'),
+    onSettled: () => setImageBusy(null),
   })
 
   const bulkUpdateMutation = useMutation({
@@ -1096,6 +1154,60 @@ export default function ContentStudio() {
                       className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
                       placeholder="https://example.com/video.mp4"
                     />
+                  </div>
+                )}
+
+                {/* Image on a text post (issue #1030) — upload your own or generate one from the
+                    draft. Saved on the spot, so it survives Cancel and needs no "Save Changes". */}
+                {editingPost.post_type === 'text' && (
+                  <div>
+                    <label className="block text-xs font-medium text-gray-600 mb-1">
+                      Image <span className="font-normal text-gray-400">(optional)</span>
+                    </label>
+                    {editingPost.image_url && (
+                      <div className="mb-2 flex items-start gap-3">
+                        <img
+                          src={editingPost.image_url}
+                          alt={`Image on post ${editingPost.post_id}`}
+                          className="w-24 h-24 object-cover rounded-lg border border-gray-200"
+                        />
+                        <button
+                          type="button"
+                          onClick={() => removeImageMutation.mutate(editingPost.post_id)}
+                          disabled={imageBusy !== null}
+                          className="text-xs text-red-500 hover:text-red-700 font-semibold underline disabled:opacity-50"
+                        >
+                          {imageBusy === 'remove' ? 'Removing…' : 'Remove image'}
+                        </button>
+                      </div>
+                    )}
+                    <div className="flex flex-wrap items-center gap-2">
+                      <input
+                        ref={imageFileRef}
+                        type="file"
+                        accept="image/png,image/jpeg"
+                        aria-label="Upload post image"
+                        disabled={imageBusy !== null}
+                        onChange={(e) => {
+                          const file = e.target.files?.[0]
+                          if (file) uploadImageMutation.mutate({ post_id: editingPost.post_id, file })
+                        }}
+                        className="text-xs text-gray-600 file:mr-2 file:py-1.5 file:px-3 file:rounded-lg file:border file:border-gray-300 file:text-xs file:font-semibold file:bg-white hover:file:border-blue-400"
+                      />
+                      <button
+                        type="button"
+                        onClick={() => generateImageMutation.mutate(editingPost)}
+                        disabled={imageBusy !== null}
+                        className="bg-indigo-600 text-white px-3 py-1.5 rounded-lg text-xs font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                      >
+                        {imageBusy === 'generate' ? 'Generating image…' : 'Generate with AI'}
+                      </button>
+                    </div>
+                    {imageBusy === 'upload' && <p className="mt-1 text-xs text-gray-500">Uploading…</p>}
+                    {imageError && <p className="mt-1 text-xs text-red-600 font-medium">{imageError}</p>}
+                    <p className="mt-1 text-xs text-gray-400">
+                      PNG or JPG, at least 400×400. AI generation draws the image from the text above.
+                    </p>
                   </div>
                 )}
 

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.image.test.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.image.test.tsx
@@ -1,0 +1,117 @@
+import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MemoryRouter } from 'react-router-dom'
+import ComposePost from './ComposePost'
+
+// Issue #1030: there is no post row while the author is composing, so an uploaded/generated image
+// comes back as a PREVIEW url that rides along in the schedule payload.
+const get = vi.fn()
+const post = vi.fn()
+
+vi.mock('../../api/client', () => ({
+  default: {
+    get: (...args: unknown[]) => get(...args),
+    post: (...args: unknown[]) => post(...args),
+  },
+}))
+
+vi.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ user: { email: 'test@example.com', userId: 1 }, sessionToken: 'tok' }),
+}))
+
+vi.mock('../../hooks/useUserTimezone', () => ({
+  useUserTimezone: () => 'America/New_York',
+  useUserTimezoneState: () => ({ timezone: 'America/New_York', isResolved: true }),
+}))
+
+vi.mock('../../utils/analytics', () => ({
+  maskProps: (className: string) => ({ className }),
+}))
+
+vi.mock('../../components/LinkedInPostPreview', () => ({ default: () => null }))
+vi.mock('../../components/TopicAuthorityMeter', () => ({ default: () => null }))
+
+const PREVIEW_URL = 'https://api.test/api/assets?file_name=images/post_previews/1/img_a.png'
+
+let client: QueryClient
+
+function tree(ui: ReactNode) {
+  return (
+    <MemoryRouter>
+      <QueryClientProvider client={client}>{ui}</QueryClientProvider>
+    </MemoryRouter>
+  )
+}
+
+beforeEach(() => {
+  get.mockReset()
+  post.mockReset()
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+  get.mockResolvedValue({ data: { detail: { templates: [] } } })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+const timeInput = (c: HTMLElement) => c.querySelector('input[type="datetime-local"]') as HTMLInputElement
+
+describe('ComposePost images on a text post (issue #1030)', () => {
+  it('offers upload + generate on TEXT and hides them on CAROUSEL', () => {
+    render(tree(<ComposePost />))
+
+    expect(screen.getByLabelText('Upload post image')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: 'CAROUSEL' }))
+    expect(screen.queryByLabelText('Upload post image')).toBeNull()
+  })
+
+  it('refuses to generate before anything is written', async () => {
+    render(tree(<ComposePost />))
+
+    fireEvent.click(screen.getByRole('button', { name: /Generate with AI/i }))
+
+    await waitFor(() => expect(screen.getByText(/Write your post first/i)).toBeDefined())
+    expect(post).not.toHaveBeenCalled()
+  })
+
+  it('carries a generated preview image into the scheduled post', async () => {
+    const { container } = render(tree(<ComposePost />))
+    post.mockResolvedValue({ data: { detail: { post_id: null, image_url: PREVIEW_URL } } })
+
+    fireEvent.change(screen.getByPlaceholderText('What would you like to share?'), {
+      target: { value: 'Hello world' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /Generate with AI/i }))
+
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith('/user/post/image/generate', {
+        session_token: 'tok',
+        content: 'Hello world',
+      })
+    )
+    await waitFor(() => expect(screen.getByAltText('Post image')).toBeDefined())
+
+    fireEvent.change(timeInput(container), { target: { value: '2026-07-28T09:00' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save Draft' }))
+
+    await waitFor(() =>
+      expect(post).toHaveBeenCalledWith('/schedule_post/', expect.objectContaining({
+        image_url: PREVIEW_URL,
+      }))
+    )
+  })
+
+  it('surfaces the server reason when an upload is rejected', async () => {
+    render(tree(<ComposePost />))
+    post.mockRejectedValue({ response: { data: { detail: 'Use a PNG or JPG image' } } })
+
+    const file = new File(['bytes'], 'shot.gif', { type: 'image/gif' })
+    fireEvent.change(screen.getByLabelText('Upload post image'), { target: { files: [file] } })
+
+    await waitFor(() => expect(screen.getByText('Use a PNG or JPG image')).toBeDefined())
+    expect(screen.queryByAltText('Post image')).toBeNull()
+  })
+})

--- a/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
+++ b/src/cqc_lem/ui/src/pages/content/ComposePost.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
 import api from '../../api/client'
@@ -56,6 +56,14 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
   // Sending a plain `false` here would be an explicit per-post opt-out, which outranks those.
   const [useAvatar, setUseAvatar] = useState<boolean | null>(null)
   const [videoQuality, setVideoQuality] = useState<'standard' | 'premium' | 'premium_top'>('standard')
+
+  // Image on a TEXT post (issue #1030). There is no post row yet, so upload/generate hand back a
+  // PREVIEW url that rides along in the schedule payload — the server only accepts one it issued
+  // to this account.
+  const [imageUrl, setImageUrl] = useState<string | null>(null)
+  const [imageBusy, setImageBusy] = useState<'upload' | 'generate' | null>(null)
+  const [imageError, setImageError] = useState<string | null>(null)
+  const imageFileRef = useRef<HTMLInputElement>(null)
 
   // Carousel AI generation state
   const [carouselMode, setCarouselMode] = useState<'manual' | 'ai'>('ai')
@@ -181,6 +189,47 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
     }
   }
 
+  function imageErrorText(err: unknown, fallback: string): string {
+    const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail
+    return typeof detail === 'string' ? detail : fallback
+  }
+
+  async function handleUploadImage(file: File) {
+    if (!sessionToken) { setImageError('Not logged in.'); return }
+    setImageBusy('upload')
+    setImageError(null)
+    try {
+      const form = new FormData()
+      form.append('session_token', sessionToken)
+      form.append('file', file)
+      const r = await api.post('/user/post/image', form)
+      setImageUrl(r.data.detail.image_url as string)
+    } catch (err) {
+      setImageError(imageErrorText(err, 'Could not use that image — try another file.'))
+    } finally {
+      setImageBusy(null)
+      if (imageFileRef.current) imageFileRef.current.value = ''
+    }
+  }
+
+  async function handleGenerateImage() {
+    if (!sessionToken) { setImageError('Not logged in.'); return }
+    if (!content.trim()) { setImageError('Write your post first — the image is drawn from it.'); return }
+    setImageBusy('generate')
+    setImageError(null)
+    try {
+      const r = await api.post('/user/post/image/generate', {
+        session_token: sessionToken,
+        content,
+      })
+      setImageUrl(r.data.detail.image_url as string)
+    } catch (err) {
+      setImageError(imageErrorText(err, 'Image generation failed — try again.'))
+    } finally {
+      setImageBusy(null)
+    }
+  }
+
   // "Approve & Schedule" creates the post approved (ready to publish); "Save Draft" holds it as
   // pending for later review. Auto-generated content sets its own status server-side.
   async function handleSubmit(e: React.FormEvent, status: 'pending' | 'approved' = 'approved') {
@@ -225,6 +274,9 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
       if (postType !== 'TEXT' && useAvatar !== null) {
         payload.use_avatar = useAvatar && hasActiveAvatar
       }
+      if (postType === 'TEXT' && imageUrl) {
+        payload.image_url = imageUrl
+      }
       if (postType === 'VIDEO') {
         payload.video_url = videoUrl || null
         payload.video_quality = videoQuality
@@ -241,6 +293,8 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
       setSlides([''])
       setScheduledAt('')
       setGeneratedSlideUrls([])
+      setImageUrl(null)
+      setImageError(null)
     } catch {
       setResult({ ok: false, msg: 'Failed to schedule post. Please try again.' })
     } finally {
@@ -372,6 +426,60 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
                 You have <span className="font-semibold">{videoCredits}</span> premium video credit
                 {videoCredits === 1 ? '' : 's'}.{' '}
                 <a href="/account" className="text-blue-600 hover:underline">Buy more</a>
+              </p>
+            </div>
+          )}
+
+          {/* TEXT: optional image — upload your own or generate one from the post (issue #1030).
+              A single-image post is LinkedIn's highest-volume format, and this is the only way to
+              put one on a post you wrote yourself. */}
+          {postType === 'TEXT' && (
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Image <span className="font-normal text-gray-400">(optional)</span>
+              </label>
+              {imageUrl && (
+                <div className="mb-2 flex items-start gap-3">
+                  <img
+                    src={imageUrl}
+                    alt="Post image"
+                    className="w-28 h-28 object-cover rounded-lg border border-gray-200"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => { setImageUrl(null); setImageError(null) }}
+                    className="text-xs text-red-500 hover:text-red-700 font-semibold underline"
+                  >
+                    Remove image
+                  </button>
+                </div>
+              )}
+              <div className="flex flex-wrap gap-2">
+                <input
+                  ref={imageFileRef}
+                  type="file"
+                  accept="image/png,image/jpeg"
+                  aria-label="Upload post image"
+                  disabled={imageBusy !== null}
+                  onChange={(e) => {
+                    const file = e.target.files?.[0]
+                    if (file) handleUploadImage(file)
+                  }}
+                  className="text-xs text-gray-600 file:mr-2 file:py-1.5 file:px-3 file:rounded-lg file:border file:border-gray-300 file:text-xs file:font-semibold file:bg-white hover:file:border-blue-400"
+                />
+                <button
+                  type="button"
+                  onClick={handleGenerateImage}
+                  disabled={imageBusy !== null}
+                  className="bg-indigo-600 text-white px-3 py-1.5 rounded-lg text-xs font-semibold hover:bg-indigo-700 disabled:opacity-50 transition-colors"
+                >
+                  {imageBusy === 'generate' ? 'Generating image…' : 'Generate with AI'}
+                </button>
+              </div>
+              {imageBusy === 'upload' && <p className="mt-1 text-xs text-gray-500">Uploading…</p>}
+              {imageError && <p className="mt-1 text-xs text-red-600 font-medium">{imageError}</p>}
+              <p className="mt-1 text-xs text-gray-400">
+                PNG or JPG, at least 400×400. AI generation draws the image from what you wrote.
               </p>
             </div>
           )}
@@ -638,6 +746,7 @@ export default function ComposePost({ onNavigateTab }: { onNavigateTab?: (tab: s
           author={email.split('@')[0] || 'You'}
           headline="LinkedIn Member"
           postType={postType.toLowerCase()}
+          mediaUrl={postType === 'TEXT' ? imageUrl ?? undefined : undefined}
           videoUrl={postType === 'VIDEO' ? videoUrl || null : null}
           slides={
             postType === 'CAROUSEL'

--- a/src/cqc_lem/utilities/db.py
+++ b/src/cqc_lem/utilities/db.py
@@ -850,7 +850,7 @@ def get_user_id(email: str):
 def insert_post(email: str, content: str, scheduled_time: datetime, post_type: PostType,
                 video_url: Optional[str] = None, carousel_slides: Optional[list[str]] = None,
                 video_quality: str = "standard", status: PostStatus = PostStatus.PENDING,
-                use_avatar: Optional[bool] = None) -> bool:
+                use_avatar: Optional[bool] = None, image_url: Optional[str] = None) -> bool:
     user_id = get_user_id(email)
 
     success = False
@@ -870,11 +870,11 @@ def insert_post(email: str, content: str, scheduled_time: datetime, post_type: P
         # use_avatar is deliberately three-valued: NULL = the user expressed no preference for this
         # post, so the per-user opt-ins decide (issue #744). 0/1 is an explicit compose-time choice.
         cursor.execute("""
-            INSERT INTO posts (content, scheduled_time, post_type, user_id, video_url, carousel_slides, video_quality, status, use_avatar)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO posts (content, scheduled_time, post_type, user_id, video_url, carousel_slides, video_quality, status, use_avatar, image_url)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
         """, (content, scheduled_time, post_type.value, user_id, video_url, slides_json,
               video_quality or "standard", status.value,
-              None if use_avatar is None else int(bool(use_avatar))))
+              None if use_avatar is None else int(bool(use_avatar)), image_url))
 
         connection.commit()
         success = cursor.rowcount == 1

--- a/src/cqc_lem/utilities/env_constants.py
+++ b/src/cqc_lem/utilities/env_constants.py
@@ -62,6 +62,10 @@ IMAGE_QUALITY = get_constant_from_env('IMAGE_QUALITY', default_value='medium')
 # Vision quality gate: total render attempts per image (1 = no regenerate). Mirrors the
 # COMMENT_GATE pattern — bounded, and the gate itself fails OPEN on vision outages.
 IMAGE_GATE_MAX_ATTEMPTS = int(get_constant_from_env('IMAGE_GATE_MAX_ATTEMPTS', default_value='2'))
+# Manual "Generate image" clicks per user per hour (issue #1030). Every click is real inference
+# spend on a button that can be held down, so it is bounded like AVATAR_SAMPLE_REGEN_MAX.
+POST_IMAGE_GENERATE_MAX_PER_HOUR = int(
+    get_constant_from_env('POST_IMAGE_GENERATE_MAX_PER_HOUR', default_value='20'))
 # Surfaces where a gate rejection actually triggers a regenerate (elsewhere it only logs).
 IMAGE_QUALITY_GATE_SURFACES = tuple(
     s.strip() for s in

--- a/src/cqc_lem/utilities/post_image.py
+++ b/src/cqc_lem/utilities/post_image.py
@@ -1,0 +1,314 @@
+"""Post images — the ONE place a post's image is validated, stored and removed (issue #1030).
+
+`posts.image_url` has carried an image on generated TEXT posts since the image-gen overhaul, but
+every path into it was a background task: the author could neither attach their own artwork nor ask
+for a render from the Content Studio. This module is that manual half, and it deliberately reuses
+the SAME brief engine + gated render the scheduled path uses — a per-surface prompt helper is
+exactly what `docs/image-stack.md` forbids, so `generate_image_for_post` is the only new engine
+here and `run_content_plan._generate_text_post_image` now goes through it too.
+
+Two ways an image lands on a post, and like newsletter covers they are NOT symmetric in ORIGIN
+(the author's own file vs. a render) but they ARE symmetric in review: a post is already held in
+the review queue until a human approves it, so neither needs a second gate on top.
+
+Storage:
+- attached  → ``images/posts/<post_id>/`` — the same dir the generated path writes, so
+  ``purge_post_assets`` cleans it after publish.
+- composing → ``images/post_previews/<user_id>/`` — there is no row yet, mirroring what
+  ``/generate-carousel`` already does for slides it hands back before a post exists. Abandoned
+  previews are left on disk for the same reason abandoned carousel previews are: pruning them
+  would have to outlive a post scheduled 30 days out.
+
+``posts.image_url`` stores the PUBLIC ``/api/assets?file_name=`` URL rather than a path, because
+that is the value the publish step hands to LinkedIn.
+"""
+
+import os
+import secrets
+import shutil
+from dataclasses import dataclass
+from typing import Optional
+from urllib.parse import parse_qs, quote, urlparse
+
+from cqc_lem import assets_dir
+from cqc_lem.utilities.logger import log_debug, log_info, log_warning
+
+POST_IMAGE_SUBDIR = "images/posts"
+POST_IMAGE_PREVIEW_SUBDIR = "images/post_previews"
+
+MAX_POST_IMAGE_BYTES = 8 * 1024 * 1024
+# Below this a LinkedIn image share renders as a blurry thumbnail rather than media.
+MIN_POST_IMAGE_WIDTH = 400
+MIN_POST_IMAGE_HEIGHT = 400
+
+# LinkedIn's image upload takes PNG and JPEG; the extension is also what `determine_media_type`
+# reads to pick the share category, so an unsupported one fails at publish, not here.
+_EXT_BY_FORMAT = {"PNG": ".png", "JPEG": ".jpg"}
+ALLOWED_POST_IMAGE_FORMATS = tuple(_EXT_BY_FORMAT)
+
+
+class PostImageRejected(Exception):
+    """The image failed the deterministic gate — carries the user-facing reason."""
+
+
+@dataclass
+class PostImageVerdict:
+    """Outcome of the deterministic gate. ``reason`` is user-facing when ``ok`` is False."""
+    ok: bool
+    reason: Optional[str] = None
+    width: Optional[int] = None
+    height: Optional[int] = None
+    image_format: Optional[str] = None
+
+    @property
+    def extension(self) -> str:
+        return _EXT_BY_FORMAT.get(self.image_format or "", ".png")
+
+
+def inspect_post_image_bytes(data: bytes) -> PostImageVerdict:
+    """Grade raw image bytes against the post-image contract. Never raises."""
+    if not data:
+        return PostImageVerdict(False, "No image data received")
+    if len(data) > MAX_POST_IMAGE_BYTES:
+        return PostImageVerdict(False,
+                                f"Image is larger than {MAX_POST_IMAGE_BYTES // (1024 * 1024)} MB")
+    try:
+        import io
+
+        from PIL import Image
+
+        with Image.open(io.BytesIO(data)) as img:
+            img_format = (img.format or "").upper()
+            width, height = img.size
+    except Exception as e:
+        log_debug("Post image could not be decoded", error=str(e), action_type="post_image")
+        return PostImageVerdict(False, "That file is not a readable image")
+
+    if img_format not in _EXT_BY_FORMAT:
+        return PostImageVerdict(False, "Use a PNG or JPG image", width, height, img_format)
+    if width < MIN_POST_IMAGE_WIDTH or height < MIN_POST_IMAGE_HEIGHT:
+        return PostImageVerdict(
+            False,
+            f"Image is too small — at least {MIN_POST_IMAGE_WIDTH}x{MIN_POST_IMAGE_HEIGHT} px",
+            width, height, img_format)
+    return PostImageVerdict(True, None, width, height, img_format)
+
+
+def post_image_relative_dir(user_id: int, post_id: Optional[int]) -> str:
+    """Assets-relative dir this image belongs in — per POST once there is one, per USER while the
+    author is still composing (a preview has no row to be scoped by)."""
+    if post_id:
+        return f"{POST_IMAGE_SUBDIR}/{int(post_id)}"
+    return f"{POST_IMAGE_PREVIEW_SUBDIR}/{int(user_id)}"
+
+
+def post_image_public_url(relative_path: str) -> str:
+    """The /api/assets URL stored on the row and rendered by the SPA."""
+    from cqc_lem.utilities.env_constants import API_URL_FINAL
+    return f"{API_URL_FINAL}/api/assets?file_name={quote(relative_path)}"
+
+
+def post_image_relative_path(image_url: Optional[str]) -> Optional[str]:
+    """The assets-relative path inside a stored post-image URL, or None when it isn't one.
+
+    Only OUR own `/api/assets?file_name=` shape resolves: an image_url that points somewhere else
+    (a hand-edited row) has no file of ours behind it, so there is nothing to read or delete.
+    """
+    if not image_url or not isinstance(image_url, str):
+        return None
+    try:
+        query = parse_qs(urlparse(image_url).query)
+    except ValueError:
+        return None
+    values = query.get("file_name") or []
+    relative = (values[0] if values else "").replace("\\", "/").strip("/")
+    if not relative:
+        return None
+    prefixes = (f"{POST_IMAGE_SUBDIR}/", f"{POST_IMAGE_PREVIEW_SUBDIR}/")
+    return relative if relative.startswith(prefixes) else None
+
+
+def post_image_abs_path(image_url: Optional[str]) -> Optional[str]:
+    """Absolute path of a stored post image, or None when it escapes assets_dir / is gone.
+
+    The value comes from our own DB, but resolving through ``realpath`` and re-checking containment
+    keeps a hand-edited row from handing an arbitrary file to a delete (or to LinkedIn).
+    """
+    relative = post_image_relative_path(image_url)
+    if not relative:
+        return None
+    root = os.path.realpath(assets_dir)
+    candidate = os.path.realpath(os.path.join(root, relative))
+    if candidate != root and not candidate.startswith(root + os.sep):
+        log_warning("Post image path escapes the assets dir", action_type="post_image")
+        return None
+    return candidate if os.path.isfile(candidate) else None
+
+
+def owns_post_image_url(user_id: int, image_url: Optional[str]) -> bool:
+    """Is this URL a compose-time preview WE issued to THIS user?
+
+    The compose form has no post row to attach to, so it hands the URL back at schedule time. That
+    makes `image_url` caller-supplied input on a field the publish step later fetches, so only a
+    preview under the caller's own dir is accepted — never an arbitrary URL, and never another
+    account's preview.
+    """
+    relative = post_image_relative_path(image_url)
+    if not relative:
+        return False
+    return relative.startswith(f"{POST_IMAGE_PREVIEW_SUBDIR}/{int(user_id)}/")
+
+
+def _write_into(relative_dir: str, name: str) -> str:
+    directory = os.path.join(assets_dir, *relative_dir.split("/"))
+    os.makedirs(directory, exist_ok=True)
+    return os.path.join(directory, name)
+
+
+def save_post_image_bytes(user_id: int, data: bytes, post_id: Optional[int] = None) -> str:
+    """Gate then persist uploaded image bytes; returns the public URL.
+
+    Raises ``PostImageRejected`` with a user-facing reason when the gate fails — the caller turns
+    that into a 400 rather than storing an image that would break the share.
+    """
+    verdict = inspect_post_image_bytes(data)
+    if not verdict.ok:
+        raise PostImageRejected(verdict.reason or "Image rejected")
+    relative_dir = post_image_relative_dir(user_id, post_id)
+    # Random suffix: /api/assets is public, so a predictable name would let anyone read another
+    # user's unpublished image.
+    name = f"img_{secrets.token_hex(6)}{verdict.extension}"
+    with open(_write_into(relative_dir, name), "wb") as fh:
+        fh.write(data)
+    log_info("Stored uploaded post image", user_id=user_id, post_id=post_id,
+             action_type="post_image")
+    return post_image_public_url(f"{relative_dir}/{name}")
+
+
+def store_rendered_post_image(user_id: int, source_path: str,
+                              post_id: Optional[int] = None) -> Optional[str]:
+    """Copy a rendered image into the post's (or the author's preview) dir. None on failure."""
+    if not source_path or not os.path.isfile(source_path):
+        return None
+    relative_dir = post_image_relative_dir(user_id, post_id)
+    extension = os.path.splitext(source_path)[1] or ".png"
+    name = f"img_{secrets.token_hex(6)}{extension}"
+    try:
+        shutil.copyfile(source_path, _write_into(relative_dir, name))
+    except OSError as e:
+        log_warning("Could not store the generated post image", exc=e, user_id=user_id,
+                    post_id=post_id, action_type="post_image")
+        return None
+    return post_image_public_url(f"{relative_dir}/{name}")
+
+
+def remove_post_image_file(image_url: Optional[str]) -> bool:
+    """Best-effort delete of a stored post image file. Never raises — the row is the truth."""
+    abs_path = post_image_abs_path(image_url)
+    if not abs_path:
+        return False
+    try:
+        os.remove(abs_path)
+        return True
+    except OSError as e:
+        log_debug("Could not delete post image file", error=str(e), action_type="post_image")
+        return False
+
+
+_GENERATE_WINDOW_SECONDS = 3600
+_GENERATE_KEY_PREFIX = "lem:post_image_gen"
+
+
+def claim_manual_generation(user_id: int) -> bool:
+    """Claim one manual "Generate image" click; False once the hourly cap is spent.
+
+    Claimed BEFORE the render, not counted after it: the button can be held down and every press is
+    real inference spend, which is the same reason `regenerate_avatar_samples` reserves its re-roll
+    in the statement that checks the cap. Fails OPEN when Redis is unavailable — a broker restart
+    must not take the feature down, and the cost ledger still records whatever is spent.
+    """
+    from cqc_lem.utilities.env_constants import POST_IMAGE_GENERATE_MAX_PER_HOUR
+    from cqc_lem.utilities.linkedin.rate_limit import shared_redis_client
+
+    redis_client = shared_redis_client()
+    if redis_client is None:
+        return True
+    key = f"{_GENERATE_KEY_PREFIX}:{int(user_id)}"
+    try:
+        count = int(redis_client.incr(key))
+        if count == 1:
+            # TTL only on the first increment, so the window is fixed rather than sliding.
+            redis_client.expire(key, _GENERATE_WINDOW_SECONDS)
+        return count <= POST_IMAGE_GENERATE_MAX_PER_HOUR
+    except Exception as e:
+        log_warning("Post image generation limiter unavailable — failing open", exc=e,
+                    user_id=user_id, action_type="post_image")
+        return True
+
+
+def generate_image_for_post(user_id: int, text: str, post_id: Optional[int] = None
+                            ) -> "tuple[Optional[str], Optional[str]]":
+    """Render the image a text post publishes with. Returns ``(public_url, None)`` or
+    ``(None, reason)``.
+
+    Never raises: an image is enhancement, and a failed render must never take a post — or the
+    author's edit — down with it. The avatar rides the EXISTING ``post_image`` surface and is
+    resolved BEFORE the brief is authored, so the declared subject clause leads the prompt (#744).
+    """
+    if not text or not text.strip():
+        return None, "Write the post content first — the image is drawn from it"
+
+    from cqc_lem.utilities.ai.image_brief import build_image_brief
+    from cqc_lem.utilities.avatar.guardrails import AVATAR_SURFACE_POST_IMAGE, resolve_avatar_for
+    from cqc_lem.utilities.env_constants import DEFAULT_IMAGE_RATIO
+
+    profile = None
+    try:
+        from cqc_lem.utilities.linkedin.helper import load_profile_for_user
+        profile = load_profile_for_user(user_id)
+    except Exception as e:
+        log_debug("Profile load skipped for post image", error=str(e), user_id=user_id,
+                  action_type="post_image")
+
+    try:
+        avatar = resolve_avatar_for(user_id, surface=AVATAR_SURFACE_POST_IMAGE, post_id=post_id)
+    except Exception as e:
+        log_warning("Avatar check failed for post image — rendering without", exc=e,
+                    user_id=user_id, post_id=post_id, action_type="post_image")
+        avatar = None
+
+    try:
+        brief = build_image_brief(text, surface="post_image", ratio=DEFAULT_IMAGE_RATIO,
+                                  profile=profile, avatar=avatar)
+    except Exception as e:
+        log_warning("Post image prompt failed", exc=e, user_id=user_id, post_id=post_id,
+                    action_type="post_image")
+        return None, "Could not write an image prompt"
+
+    try:
+        if avatar:
+            from cqc_lem.utilities.ai.image_gen import render_avatar_image_gated
+            rendered = render_avatar_image_gated(
+                brief.prompt, avatar=avatar, user_id=user_id, surface="post_image",
+                ratio=DEFAULT_IMAGE_RATIO, focal_concept=brief.focal_concept, post_id=post_id)
+        else:
+            from cqc_lem.utilities.ai.image_gen import render_image_gated
+            rendered = render_image_gated(brief.prompt, surface="post_image",
+                                          ratio=DEFAULT_IMAGE_RATIO,
+                                          focal_concept=brief.focal_concept,
+                                          user_id=user_id, post_id=post_id)
+    except Exception as e:
+        log_warning("Post image generation failed", exc=e, user_id=user_id, post_id=post_id,
+                    action_type="post_image")
+        return None, "Image generation failed"
+
+    if not rendered or not os.path.isfile(rendered):
+        log_warning("Post image generation returned no image", user_id=user_id, post_id=post_id,
+                    action_type="post_image")
+        return None, "Image generation returned nothing"
+
+    stored = store_rendered_post_image(user_id, rendered, post_id=post_id)
+    if not stored:
+        return None, "Could not store the generated image"
+    log_info("Generated post image", user_id=user_id, post_id=post_id, action_type="post_image")
+    return stored, None

--- a/tests/integration/test_post_image_api.py
+++ b/tests/integration/test_post_image_api.py
@@ -1,0 +1,271 @@
+"""Integration tests for the post-image endpoints (issue #1030).
+
+These drive the full lifecycle against a stateful stand-in for the posts row and a real temporary
+assets dir, so what is under test is the contract the Content Studio depends on: what an upload
+leaves on the row AND on disk, that a compose-time image touches no row at all, that only a preview
+this account was issued can ride into `/schedule_post/`, and that removing one takes the file.
+"""
+
+import io
+import os
+
+import pytest
+from unittest.mock import patch
+
+_SESSION = "tok"
+_USER = 5
+_OTHER_USER = 999
+_POST = 42
+
+
+@pytest.fixture(scope="module")
+def client():
+    patches = [
+        patch("cqc_lem.utilities.observability.track_api_call"),
+        patch("cqc_lem.app.run_automation.automate_invites_to_company_page_for_user"),
+        patch("cqc_lem.app.run_automation.automate_reply_commenting"),
+        patch("cqc_lem.app.run_content_plan.auto_create_weekly_content"),
+        patch("cqc_lem.app.aws_test_celery_task.test_get_my_profile"),
+    ]
+    for p in patches:
+        p.start()
+    try:
+        from fastapi.testclient import TestClient
+        from cqc_lem.api.main import app
+        with TestClient(app, raise_server_exceptions=False) as tc:
+            yield tc
+    finally:
+        for p in patches:
+            p.stop()
+
+
+def _png(width: int = 800, height: int = 800, fmt: str = "PNG") -> bytes:
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (10, 40, 90)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+class _PostStore:
+    """A stateful stand-in for the posts row, scoped by owner like the real SQL."""
+
+    def __init__(self, user_id: int = _USER, status: str = "pending"):
+        self.row = {"id": _POST, "user_id": user_id, "content": "Stored draft text",
+                    "status": status, "image_url": None}
+        self.inserted: list = []
+
+    def owner(self, post_id):
+        return self.row["user_id"] if post_id == self.row["id"] else None
+
+    def status(self, post_id):
+        return self.row["status"] if post_id == self.row["id"] else None
+
+    def content(self, post_id):
+        return self.row["content"] if post_id == self.row["id"] else None
+
+    def image_url(self, post_id):
+        return self.row["image_url"] if post_id == self.row["id"] else None
+
+    def set_image_url(self, post_id, url):
+        if post_id != self.row["id"]:
+            return True  # matches the real UPDATE: no row touched, no error
+        self.row["image_url"] = url
+        return True
+
+    def insert(self, *args, **kwargs):
+        self.inserted.append(kwargs)
+        return True
+
+
+@pytest.fixture
+def store(tmp_path):
+    s = _PostStore()
+    with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+         patch("cqc_lem.api.main.get_user_email", return_value="user@example.com"), \
+         patch("cqc_lem.api.main.record_auth_event", return_value=True), \
+         patch("cqc_lem.api.main.get_post_user_id", side_effect=s.owner), \
+         patch("cqc_lem.api.main.get_post_status", side_effect=s.status), \
+         patch("cqc_lem.api.main.get_post_content", side_effect=s.content), \
+         patch("cqc_lem.api.main.get_post_image_url", side_effect=s.image_url), \
+         patch("cqc_lem.api.main.update_db_post_image_url", side_effect=s.set_image_url), \
+         patch("cqc_lem.api.main.insert_post", side_effect=s.insert), \
+         patch("cqc_lem.utilities.post_image.assets_dir", str(tmp_path)):
+        s.assets_dir = str(tmp_path)
+        yield s
+
+
+def _upload(client, data=None, post_id=_POST, name="shot.png"):
+    payload = {"session_token": _SESSION}
+    if post_id is not None:
+        payload["post_id"] = post_id
+    return client.post("/api/user/post/image", data=payload,
+                       files={"file": (name, data or _png(), "image/png")})
+
+
+def _generate(client, **body):
+    return client.post("/api/user/post/image/generate",
+                       json={"session_token": _SESSION, **body})
+
+
+def _abs(store, url):
+    from cqc_lem.utilities.post_image import post_image_relative_path
+    return os.path.join(store.assets_dir, post_image_relative_path(url))
+
+
+@pytest.mark.integration
+class TestUploadLifecycle:
+    def test_upload_attaches_the_image_to_the_row_and_writes_the_file(self, client, store):
+        resp = _upload(client)
+        assert resp.status_code == 200
+        url = resp.json()["detail"]["image_url"]
+        assert store.row["image_url"] == url
+        assert f"file_name=images/posts/{_POST}/" in url
+        assert os.path.isfile(_abs(store, url))
+
+    def test_re_uploading_replaces_the_file_and_deletes_the_old_one(self, client, store):
+        first = _upload(client).json()["detail"]["image_url"]
+        first_path = _abs(store, first)
+        second = _upload(client, _png(1200, 1200)).json()["detail"]["image_url"]
+        assert first != second
+        assert not os.path.exists(first_path)
+        assert os.path.isfile(_abs(store, second))
+
+    def test_a_format_linkedin_will_not_take_is_a_400_and_the_row_keeps_nothing(self, client, store):
+        resp = _upload(client, _png(fmt="GIF"), name="shot.gif")
+        assert resp.status_code == 400
+        assert "PNG or JPG" in resp.json()["detail"]
+        assert store.row["image_url"] is None
+
+    def test_a_thumbnail_sized_upload_is_a_400(self, client, store):
+        assert _upload(client, _png(100, 100)).status_code == 400
+        assert store.row["image_url"] is None
+
+    def test_remove_clears_the_row_and_deletes_the_file(self, client, store):
+        url = _upload(client).json()["detail"]["image_url"]
+        path = _abs(store, url)
+        resp = client.post("/api/user/post/image/remove",
+                           json={"session_token": _SESSION, "post_id": _POST})
+        assert resp.status_code == 200
+        assert resp.json()["detail"]["image_url"] is None
+        assert store.row["image_url"] is None
+        assert not os.path.exists(path)
+
+
+@pytest.mark.integration
+class TestComposeTimePreview:
+    def test_an_upload_with_no_post_id_touches_no_row(self, client, store):
+        resp = _upload(client, post_id=None)
+        assert resp.status_code == 200
+        url = resp.json()["detail"]["image_url"]
+        assert f"file_name=images/post_previews/{_USER}/" in url
+        assert store.row["image_url"] is None
+        assert os.path.isfile(_abs(store, url))
+
+    def test_scheduling_carries_this_accounts_preview_onto_the_new_post(self, client, store):
+        url = _upload(client, post_id=None).json()["detail"]["image_url"]
+        resp = client.post("/api/schedule_post/", json={
+            "session_token": _SESSION, "content": "Hello", "post_type": "text",
+            "scheduled_datetime": "2026-08-10T09:00:00", "status": "pending",
+            "image_url": url,
+        })
+        assert resp.status_code == 200
+        assert store.inserted[-1]["image_url"] == url
+
+    def test_a_url_we_never_issued_is_dropped_rather_than_stored(self, client, store):
+        """`image_url` is caller-supplied on a field the publish step later fetches — anything but
+        this account's own preview is refused."""
+        for hostile in ("https://evil.test/payload.png",
+                        f"https://api.test/api/assets?file_name=images/post_previews/{_OTHER_USER}/x.png",
+                        "https://api.test/api/assets?file_name=../../etc/passwd"):
+            resp = client.post("/api/schedule_post/", json={
+                "session_token": _SESSION, "content": "Hello", "post_type": "text",
+                "scheduled_datetime": "2026-08-10T09:00:00", "status": "pending",
+                "image_url": hostile,
+            })
+            assert resp.status_code == 200
+            assert store.inserted[-1]["image_url"] is None
+
+
+@pytest.mark.integration
+class TestGenerate:
+    def test_generation_attaches_the_render_and_prefers_the_text_on_screen(self, client, store):
+        with patch("cqc_lem.api.main.generate_image_for_post",
+                   return_value=("https://api.test/api/assets?file_name=images/posts/42/g.png",
+                                 None)) as gen:
+            resp = _generate(client, post_id=_POST, content="Unsaved edit")
+        assert resp.status_code == 200
+        assert gen.call_args[0][1] == "Unsaved edit"
+        assert store.row["image_url"].endswith("g.png")
+
+    def test_generation_falls_back_to_the_stored_draft(self, client, store):
+        with patch("cqc_lem.api.main.generate_image_for_post",
+                   return_value=("https://api.test/api/assets?file_name=images/posts/42/g.png",
+                                 None)) as gen:
+            assert _generate(client, post_id=_POST).status_code == 200
+        assert gen.call_args[0][1] == "Stored draft text"
+
+    def test_a_compose_time_generation_needs_no_post(self, client, store):
+        preview = f"https://api.test/api/assets?file_name=images/post_previews/{_USER}/g.png"
+        with patch("cqc_lem.api.main.generate_image_for_post", return_value=(preview, None)):
+            resp = _generate(client, content="Fresh copy")
+        assert resp.status_code == 200
+        assert resp.json()["detail"] == {"post_id": None, "image_url": preview}
+        assert store.row["image_url"] is None
+
+    def test_nothing_written_is_a_400_before_any_spend(self, client, store):
+        with patch("cqc_lem.api.main.generate_image_for_post") as gen:
+            assert _generate(client, content="   ").status_code == 400
+        gen.assert_not_called()
+
+    def test_a_failed_render_is_a_502_carrying_the_reason(self, client, store):
+        with patch("cqc_lem.api.main.generate_image_for_post",
+                   return_value=(None, "Image generation failed")):
+            resp = _generate(client, post_id=_POST)
+        assert resp.status_code == 502
+        assert resp.json()["detail"] == "Image generation failed"
+        assert store.row["image_url"] is None
+
+    def test_the_hourly_cap_refuses_before_the_render(self, client, store):
+        with patch("cqc_lem.api.main.claim_manual_generation", return_value=False), \
+             patch("cqc_lem.api.main.generate_image_for_post") as gen:
+            resp = _generate(client, post_id=_POST, content="More please")
+        assert resp.status_code == 429
+        gen.assert_not_called()
+
+
+@pytest.mark.integration
+class TestOwnershipAndState:
+    def test_another_users_post_is_a_404_on_every_image_route(self, client, tmp_path):
+        foreign = _PostStore(user_id=_OTHER_USER)
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=_USER), \
+             patch("cqc_lem.api.main.record_auth_event", return_value=True), \
+             patch("cqc_lem.api.main.get_post_user_id", side_effect=foreign.owner), \
+             patch("cqc_lem.api.main.get_post_status", side_effect=foreign.status), \
+             patch("cqc_lem.utilities.post_image.assets_dir", str(tmp_path)), \
+             patch("cqc_lem.api.main.update_db_post_image_url") as write, \
+             patch("cqc_lem.api.main.generate_image_for_post") as gen:
+            assert _upload(client).status_code == 404
+            assert _generate(client, post_id=_POST, content="x").status_code == 404
+            assert client.post("/api/user/post/image/remove", json={
+                "session_token": _SESSION, "post_id": _POST}).status_code == 404
+        write.assert_not_called()
+        gen.assert_not_called()
+        assert not os.path.exists(os.path.join(str(tmp_path), "images"))
+
+    def test_a_published_post_is_a_409(self, client, store):
+        store.row["status"] = "posted"
+        with patch("cqc_lem.api.main.generate_image_for_post") as gen:
+            assert _upload(client).status_code == 409
+            assert _generate(client, post_id=_POST, content="x").status_code == 409
+            assert client.post("/api/user/post/image/remove", json={
+                "session_token": _SESSION, "post_id": _POST}).status_code == 409
+        gen.assert_not_called()
+        assert store.row["image_url"] is None
+
+    def test_no_session_is_a_401(self, client, tmp_path):
+        with patch("cqc_lem.api.main.get_session_user_id", return_value=None), \
+             patch("cqc_lem.api.main.record_auth_event", return_value=True), \
+             patch("cqc_lem.utilities.post_image.assets_dir", str(tmp_path)):
+            assert _upload(client, post_id=None).status_code == 401
+            assert _generate(client, content="x").status_code == 401
+        assert not os.path.exists(os.path.join(str(tmp_path), "images"))

--- a/tests/integration/test_post_image_api.py
+++ b/tests/integration/test_post_image_api.py
@@ -212,6 +212,17 @@ class TestGenerate:
         assert resp.json()["detail"] == {"post_id": None, "image_url": preview}
         assert store.row["image_url"] is None
 
+    def test_a_draft_longer_than_a_linkedin_post_still_generates(self, client, store):
+        """Nothing truncates a generated draft and the Review & Edit textarea has no maxLength, so
+        a 3000-char field cap here would answer 422 — whose `detail` is a list the SPA cannot
+        render, leaving the author with an unexplainable failure on their own post."""
+        with patch("cqc_lem.api.main.generate_image_for_post",
+                   return_value=("https://api.test/api/assets?file_name=images/posts/42/g.png",
+                                 None)) as gen:
+            resp = _generate(client, post_id=_POST, content="x" * 4000)
+        assert resp.status_code == 200
+        assert len(gen.call_args[0][1]) == 4000
+
     def test_nothing_written_is_a_400_before_any_spend(self, client, store):
         with patch("cqc_lem.api.main.generate_image_for_post") as gen:
             assert _generate(client, content="   ").status_code == 400

--- a/tests/unit/app/test_text_post_image.py
+++ b/tests/unit/app/test_text_post_image.py
@@ -32,8 +32,8 @@ class TestGenerateTextPostImage:
         with patch("cqc_lem.utilities.db.get_engagement_preferences",
                    return_value=prefs if prefs is not None else {"text_post_images": True}), \
              patch("cqc_lem.utilities.db.update_db_post_image_url", return_value=True) as store, \
-             patch(f"{_RCP}.load_profile_for_user", return_value=None), \
-             patch(f"{_RCP}.assets_dir", str(assets)), \
+             patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=None), \
+             patch("cqc_lem.utilities.post_image.assets_dir", str(assets)), \
              patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for",
                    return_value=avatar), \
              patch("cqc_lem.utilities.ai.image_brief.build_image_brief",
@@ -51,7 +51,8 @@ class TestGenerateTextPostImage:
         assert result and "file_name=images/posts/42/" in result
         store.assert_called_once_with(42, result)
         # The copy that publish + purge operate on lives under the shared assets volume.
-        assert os.path.isfile(os.path.join(str(assets), "images", "posts", "42", "render.png"))
+        post_dir = os.path.join(str(assets), "images", "posts", "42")
+        assert [f for f in os.listdir(post_dir) if f.endswith(".png")]
         # No avatar -> the vision-gated base renderer on the post_image surface.
         assert render.call_args[1]["surface"] == "post_image"
         assert render.call_args[1]["focal_concept"] == "the focal idea"

--- a/tests/unit/utilities/test_db_avatar_fidelity.py
+++ b/tests/unit/utilities/test_db_avatar_fidelity.py
@@ -330,5 +330,9 @@ class TestInsertPostUseAvatar:
             from cqc_lem.utilities.db import insert_post
             assert insert_post("a@b.c", "body", datetime(2026, 7, 30, 9, 0), PostType.TEXT,
                                status=PostStatus.PENDING, use_avatar=value) is True
-        _, params = cur.execute.call_args[0]
-        assert params[-1] is stored
+        sql, params = cur.execute.call_args[0]
+        # Read the column by NAME, not by position: the INSERT has grown a column since (#1030)
+        # and a positional assertion silently starts checking a different field.
+        columns = [c.strip() for c in
+                   sql.split("(", 1)[1].split(")", 1)[0].split(",")]
+        assert params[columns.index("use_avatar")] is stored

--- a/tests/unit/utilities/test_post_image.py
+++ b/tests/unit/utilities/test_post_image.py
@@ -1,0 +1,267 @@
+"""Post images (issue #1030): the deterministic gate, where bytes land, and what a stored URL
+is allowed to resolve to.
+
+The gate is the half that runs before anything is written — an image LinkedIn would refuse must be
+a 400 at upload time, not a broken share at publish time. The URL helpers are the half that runs
+after: `image_url` is a full public URL on a row, so "which file is this" has to be answered
+without letting a hand-edited value point at an arbitrary path.
+"""
+
+import io
+import os
+from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+_PI = "cqc_lem.utilities.post_image"
+
+
+def _image_bytes(width: int = 800, height: int = 800, fmt: str = "PNG") -> bytes:
+    from PIL import Image
+    buf = io.BytesIO()
+    Image.new("RGB", (width, height), (20, 60, 120)).save(buf, format=fmt)
+    return buf.getvalue()
+
+
+class TestInspectPostImageBytes:
+    def test_accepts_a_normal_png(self):
+        from cqc_lem.utilities.post_image import inspect_post_image_bytes
+        verdict = inspect_post_image_bytes(_image_bytes())
+        assert verdict.ok and verdict.extension == ".png"
+
+    def test_accepts_a_jpeg(self):
+        from cqc_lem.utilities.post_image import inspect_post_image_bytes
+        verdict = inspect_post_image_bytes(_image_bytes(fmt="JPEG"))
+        assert verdict.ok and verdict.extension == ".jpg"
+
+    def test_rejects_empty_input(self):
+        from cqc_lem.utilities.post_image import inspect_post_image_bytes
+        verdict = inspect_post_image_bytes(b"")
+        assert not verdict.ok and verdict.reason
+
+    def test_rejects_something_that_is_not_an_image(self):
+        from cqc_lem.utilities.post_image import inspect_post_image_bytes
+        verdict = inspect_post_image_bytes(b"not an image at all")
+        assert not verdict.ok and "readable image" in verdict.reason
+
+    def test_rejects_a_format_linkedin_will_not_take(self):
+        from cqc_lem.utilities.post_image import inspect_post_image_bytes
+        verdict = inspect_post_image_bytes(_image_bytes(fmt="GIF"))
+        assert not verdict.ok and "PNG or JPG" in verdict.reason
+
+    def test_rejects_a_thumbnail_sized_image(self):
+        from cqc_lem.utilities.post_image import inspect_post_image_bytes
+        verdict = inspect_post_image_bytes(_image_bytes(120, 120))
+        assert not verdict.ok and "too small" in verdict.reason
+
+    def test_rejects_bytes_over_the_cap(self):
+        from cqc_lem.utilities.post_image import MAX_POST_IMAGE_BYTES, inspect_post_image_bytes
+        verdict = inspect_post_image_bytes(b"x" * (MAX_POST_IMAGE_BYTES + 1))
+        assert not verdict.ok and "larger than" in verdict.reason
+
+
+class TestSaveAndRemove:
+    def test_an_attached_upload_lands_in_the_post_dir(self, tmp_path):
+        from cqc_lem.utilities.post_image import save_post_image_bytes
+        with patch(f"{_PI}.assets_dir", str(tmp_path)):
+            url = save_post_image_bytes(7, _image_bytes(), post_id=42)
+        assert "file_name=images/posts/42/" in url
+        assert os.listdir(tmp_path / "images" / "posts" / "42")
+
+    def test_a_compose_upload_lands_under_the_authors_preview_dir(self, tmp_path):
+        from cqc_lem.utilities.post_image import save_post_image_bytes
+        with patch(f"{_PI}.assets_dir", str(tmp_path)):
+            url = save_post_image_bytes(7, _image_bytes())
+        assert "file_name=images/post_previews/7/" in url
+        assert os.listdir(tmp_path / "images" / "post_previews" / "7")
+
+    def test_stored_names_are_unpredictable(self, tmp_path):
+        """/api/assets is public, so a guessable name would expose an unpublished image."""
+        from cqc_lem.utilities.post_image import save_post_image_bytes
+        with patch(f"{_PI}.assets_dir", str(tmp_path)):
+            first = save_post_image_bytes(7, _image_bytes(), post_id=42)
+            second = save_post_image_bytes(7, _image_bytes(), post_id=42)
+        assert first != second
+
+    def test_a_rejected_upload_writes_nothing(self, tmp_path):
+        from cqc_lem.utilities.post_image import PostImageRejected, save_post_image_bytes
+        with patch(f"{_PI}.assets_dir", str(tmp_path)):
+            with pytest.raises(PostImageRejected):
+                save_post_image_bytes(7, b"nope", post_id=42)
+        assert not (tmp_path / "images").exists()
+
+    def test_remove_deletes_the_file_behind_a_stored_url(self, tmp_path):
+        from cqc_lem.utilities.post_image import (post_image_abs_path, remove_post_image_file,
+                                                  save_post_image_bytes)
+        with patch(f"{_PI}.assets_dir", str(tmp_path)):
+            url = save_post_image_bytes(7, _image_bytes(), post_id=42)
+            assert post_image_abs_path(url)
+            assert remove_post_image_file(url) is True
+            assert post_image_abs_path(url) is None
+
+    def test_remove_is_a_no_op_for_a_url_we_never_issued(self, tmp_path):
+        from cqc_lem.utilities.post_image import remove_post_image_file
+        with patch(f"{_PI}.assets_dir", str(tmp_path)):
+            assert remove_post_image_file("https://example.com/someone-elses.png") is False
+            assert remove_post_image_file(None) is False
+
+
+class TestUrlResolution:
+    def test_a_traversal_path_never_resolves_outside_assets(self, tmp_path):
+        """The value comes from our DB, but a hand-edited row must not hand a delete — or a
+        publish — an arbitrary file."""
+        from cqc_lem.utilities.post_image import post_image_abs_path
+        outside = tmp_path / "secret.png"
+        outside.write_bytes(b"png")
+        assets = tmp_path / "assets"
+        assets.mkdir()
+        url = "https://api.test/api/assets?file_name=images/posts/../../secret.png"
+        with patch(f"{_PI}.assets_dir", str(assets)):
+            assert post_image_abs_path(url) is None
+
+    def test_a_foreign_url_has_no_path_of_ours(self):
+        from cqc_lem.utilities.post_image import post_image_relative_path
+        assert post_image_relative_path("https://cdn.example.com/x.png") is None
+        assert post_image_relative_path(
+            "https://api.test/api/assets?file_name=images/newsletter_covers/7/a.png") is None
+        assert post_image_relative_path("") is None
+
+    def test_ownership_accepts_only_this_users_preview(self):
+        from cqc_lem.utilities.post_image import owns_post_image_url
+        mine = "https://api.test/api/assets?file_name=images/post_previews/7/img_a.png"
+        theirs = "https://api.test/api/assets?file_name=images/post_previews/8/img_a.png"
+        attached = "https://api.test/api/assets?file_name=images/posts/42/img_a.png"
+        assert owns_post_image_url(7, mine) is True
+        assert owns_post_image_url(7, theirs) is False
+        # An already-attached image is not a compose-time preview — it belongs to a row that was
+        # authorised elsewhere, so it is never accepted as a schedule-time attachment.
+        assert owns_post_image_url(7, attached) is False
+        assert owns_post_image_url(7, "https://evil.test/x.png") is False
+        assert owns_post_image_url(7, None) is False
+
+
+class TestGenerateImageForPost:
+    def _generate(self, tmp_path, *, avatar=None, rendered="render.png", render_raises=False,
+                  brief_raises=False, text="Post text"):
+        from cqc_lem.utilities.ai.image_brief import ImageBrief
+        from cqc_lem.utilities.post_image import generate_image_for_post
+
+        rendered_path = None
+        if rendered:
+            rendered_path = str(tmp_path / rendered)
+            with open(rendered_path, "wb") as fh:
+                fh.write(b"png")
+        assets = tmp_path / "assets"
+        assets.mkdir(exist_ok=True)
+        brief = ImageBrief(prompt="a prompt", ratio="1:1", surface="post_image",
+                           style_preset="post_image", focal_concept="the idea")
+
+        with patch(f"{_PI}.assets_dir", str(assets)), \
+             patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=None), \
+             patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=avatar), \
+             patch("cqc_lem.utilities.ai.image_brief.build_image_brief",
+                   side_effect=RuntimeError("brief down") if brief_raises else None,
+                   return_value=brief), \
+             patch("cqc_lem.utilities.ai.image_gen.render_image_gated",
+                   side_effect=RuntimeError("render down") if render_raises else None,
+                   return_value=rendered_path) as render, \
+             patch("cqc_lem.utilities.ai.image_gen.render_avatar_image_gated",
+                   return_value=rendered_path) as lora:
+            return generate_image_for_post(9, text, post_id=42), render, lora, assets
+
+    def test_stores_the_render_and_returns_its_public_url(self, tmp_path):
+        (url, reason), render, lora, assets = self._generate(tmp_path)
+        assert reason is None
+        assert "file_name=images/posts/42/" in url
+        assert os.listdir(assets / "images" / "posts" / "42")
+        assert render.call_args[1]["surface"] == "post_image"
+        lora.assert_not_called()
+
+    def test_a_compose_render_lands_in_the_preview_dir(self, tmp_path):
+        from cqc_lem.utilities.ai.image_brief import ImageBrief
+        from cqc_lem.utilities.post_image import generate_image_for_post
+        rendered_path = str(tmp_path / "render.png")
+        with open(rendered_path, "wb") as fh:
+            fh.write(b"png")
+        assets = tmp_path / "assets"
+        assets.mkdir()
+        brief = ImageBrief(prompt="a prompt", ratio="1:1", surface="post_image",
+                           style_preset="post_image", focal_concept="the idea")
+        with patch(f"{_PI}.assets_dir", str(assets)), \
+             patch("cqc_lem.utilities.linkedin.helper.load_profile_for_user", return_value=None), \
+             patch("cqc_lem.utilities.avatar.guardrails.resolve_avatar_for", return_value=None), \
+             patch("cqc_lem.utilities.ai.image_brief.build_image_brief", return_value=brief), \
+             patch("cqc_lem.utilities.ai.image_gen.render_image_gated", return_value=rendered_path):
+            url, reason = generate_image_for_post(9, "Post text")
+        assert reason is None and "file_name=images/post_previews/9/" in url
+
+    def test_an_avatar_goes_through_the_guardrailed_lora_path(self, tmp_path):
+        avatar = {"model_ref": "owner/lora:v1", "trigger_word": "TOK"}
+        (url, reason), render, lora, _ = self._generate(tmp_path, avatar=avatar)
+        assert url and reason is None
+        lora.assert_called_once()
+        assert lora.call_args[1]["avatar"] == avatar
+        render.assert_not_called()
+
+    def test_empty_text_is_refused_before_any_spend(self, tmp_path):
+        (url, reason), render, lora, _ = self._generate(tmp_path, text="   ")
+        assert url is None and "content first" in reason
+        render.assert_not_called()
+        lora.assert_not_called()
+
+    def test_a_failed_render_never_raises(self, tmp_path):
+        (url, reason), _, _, _ = self._generate(tmp_path, render_raises=True)
+        assert url is None and reason == "Image generation failed"
+
+    def test_a_failed_prompt_never_raises(self, tmp_path):
+        (url, reason), render, _, _ = self._generate(tmp_path, brief_raises=True)
+        assert url is None and reason == "Could not write an image prompt"
+        render.assert_not_called()
+
+    def test_a_render_that_produced_nothing_is_reported(self, tmp_path):
+        (url, reason), _, _, _ = self._generate(tmp_path, rendered=None)
+        assert url is None and reason == "Image generation returned nothing"
+
+
+class TestManualGenerationCap:
+    def _claim(self, counts, limit=3):
+        from cqc_lem.utilities.post_image import claim_manual_generation
+
+        class _Redis:
+            def __init__(self):
+                self.expired = []
+
+            def incr(self, key):
+                return counts.pop(0)
+
+            def expire(self, key, ttl):
+                self.expired.append(ttl)
+
+        fake = _Redis()
+        with patch("cqc_lem.utilities.linkedin.rate_limit.shared_redis_client", return_value=fake), \
+             patch("cqc_lem.utilities.env_constants.POST_IMAGE_GENERATE_MAX_PER_HOUR", limit):
+            return [claim_manual_generation(9) for _ in range(len(counts))], fake
+
+    def test_allows_up_to_the_cap_then_refuses(self):
+        results, fake = self._claim([1, 2, 3, 4])
+        assert results == [True, True, True, False]
+        # TTL set only on the first increment, so the window is fixed rather than sliding.
+        assert fake.expired == [3600]
+
+    def test_fails_open_when_redis_is_gone(self):
+        from cqc_lem.utilities.post_image import claim_manual_generation
+        with patch("cqc_lem.utilities.linkedin.rate_limit.shared_redis_client", return_value=None):
+            assert claim_manual_generation(9) is True
+
+    def test_fails_open_when_redis_errors(self):
+        from cqc_lem.utilities.post_image import claim_manual_generation
+
+        class _Broken:
+            def incr(self, key):
+                raise RuntimeError("broker restarting")
+
+        with patch("cqc_lem.utilities.linkedin.rate_limit.shared_redis_client",
+                   return_value=_Broken()):
+            assert claim_manual_generation(9) is True


### PR DESCRIPTION
## What

A text post could only ever get an image from a background task — `posts.image_url` has been on the publish path since the image-gen overhaul, but nothing in the SPA could write it. The reporter could not add an image on the compose form, nor on **Review & Edit**. This adds the author's half of that, on both surfaces.

**`utilities/post_image.py` is the ONE place a post's image is validated, stored and removed.** It adds no second prompt engine: `generate_image_for_post` is the SAME `build_image_brief` + gated render every other surface uses, and `run_content_plan._generate_text_post_image` (the scheduled path) now goes through it too — so the studio button and the nightly generator render identically. `docs/image-stack.md` carries the posture.

### Endpoints (session-authed, ownership-checked)

| Route | Does |
|---|---|
| `POST /api/user/post/image` | multipart upload; attaches to `post_id`, or returns a compose-time preview URL when there is no row yet |
| `POST /api/user/post/image/generate` | renders from the post's text and attaches it |
| `POST /api/user/post/image/remove` | clears the row and deletes the file |

- **Uploads pass a deterministic gate first** (decodable, PNG/JPEG, < 8 MB, ≥ 400×400) — an image LinkedIn would refuse is a 400 at upload time rather than a broken share at publish time.
- **Generation prefers the text ON SCREEN** over the stored row: the author is usually looking at an edit they have not saved, and drawing the image from stale text is the one way this reads as broken.
- **Bounded spend:** `POST_IMAGE_GENERATE_MAX_PER_HOUR` (20) is claimed BEFORE the render — the button can be held down and every press is real inference cost — and fails OPEN when Redis is gone. A failed render is a 502 carrying the reason, so "try again" is actionable.
- A **published** post is a 409; another account's post is a 404; no session is a 401.

### The compose-time hazard, named

While composing there is no row, so the image lands under `images/post_previews/<user_id>/` and rides into `/schedule_post/` as a URL — i.e. **caller-supplied input on a field the publish step later fetches**. It is stored ONLY when `owns_post_image_url` says it is a preview we issued to *that* caller (anything else is dropped and warned), and a stored URL never resolves outside `assets_dir` (`realpath` containment), so a hand-edited row cannot hand a delete — or a share — an arbitrary file.

Attached images live in `images/posts/<post_id>/`, the dir `purge_post_assets` already cleans. Abandoned previews are left on disk for the same reason abandoned carousel previews are: pruning them would have to outlive a post scheduled 30 days out.

## Testing

- `tests/unit/utilities/test_post_image.py` (26) — the gate, where bytes land, unpredictable names, traversal refusal, preview ownership, every generation failure path, the hourly cap (incl. fails-open).
- `tests/integration/test_post_image_api.py` (17) — full lifecycle against a stateful posts row + a real temp assets dir: attach/replace/remove takes the file, a compose upload touches no row, a foreign or hostile `image_url` is dropped at schedule time, 404/409/401/429/502.
- `ContentStudio.image.test.tsx` + `ComposePost.image.test.tsx` (10) — controls appear only on text posts, generation sends the unsaved text, errors surface the server reason, the preview URL reaches `/schedule_post/`.
- Local: `pytest tests/unit` 10662 passed; UI `npm test` 458 passed, `npm run build` clean, no new eslint findings.

No migration — `posts.image_url` already exists (V20260802144420).

Closes #1030

🤖 Generated with [Claude Code](https://claude.com/claude-code)