### PR TITLE
fix(errors): stop warning on a comment sort control that was never there (closes #1063)

### DIFF
--- a/docs/engagement-automation.md
+++ b/docs/engagement-automation.md
@@ -182,6 +182,11 @@ thread replies, likes, whether we replied, `visible_most_relevant`.
   'Most recent' (the May-2026 demotion signal), NULL when sort control couldn't be read. NULL
   rows excluded from the demotion denominator.
 - Unfindable comment = SKIPPED.
+- **The rendered thread is the cross-check on the sort control** (issue #1063): a deleted/private
+  post renders no comments AND no sort control, so the miss is that page — logged DEBUG, recorded
+  as the `post-unavailable` skip. A thread that DID render and still yields no control is selector
+  rot and keeps its `Selector miss: Comment sort control` warning. Same grading the probe applies
+  (`comment_outcome_state`: no comments → `unknown`, comments but no control → `drift`).
 - Weekly report (`auto_weekly_comment_quality`) ships rates to PostHog + `/user/engagement-analytics`.
 - Demotion rate > `COMMENT_DEMOTION_HOLD_RATE` on ≥`COMMENT_QUALITY_MIN_SAMPLE` readable readings
   **holds that user's feed commenting** (`hold_commenting` in `rate_limit.py` — narrower than

--- a/docs/sdui-probe-coverage.md
+++ b/docs/sdui-probe-coverage.md
@@ -44,7 +44,7 @@ code is missing from this table.
 | Newsletter/article editor | `find_article_editor_elements` | `--article-editor-url` | yes | `editor_ready` gates the publish walk (#771/#804) |
 | Own post detail + analytics counts | `_post_social_counts` | `--post-url` | no (needs a post) | **none — see Gaps** |
 | Post media render (document vs image) | media anchors | `--post-url` | no (needs a post) | n/a — a diagnostic, not a lane |
-| Comment thread + sort | `_comment_items` / `_switch_comment_sort` | `--comment-outcome-url` | no (needs a post) | `visible_most_relevant` is three-valued; NULL excluded (#628) |
+| Comment thread + sort | `_comment_items` / `_switch_comment_sort` | `--comment-outcome-url` | no (needs a post) | `visible_most_relevant` is three-valued; NULL excluded (#628); a sort-control miss warns only when the thread rendered comments (#1063) |
 | Message-thread ladder | `open_message_thread` | `--dm-thread-url` | no (needs a target) | `ThreadState.UNKNOWN` skips (#731) |
 | Post permalink card → Comment → composer | `_permalink_post_card` / `_post_composer_for_card` | `--permalink-comment` | no (needs a post) | a comment that does not land is a FAILURE row, never SUCCESS (#966) |
 

--- a/src/cqc_lem/app/run_automation.py
+++ b/src/cqc_lem/app/run_automation.py
@@ -4972,7 +4972,7 @@ def _sort_from_element(el) -> str:
     return ""
 
 
-def _find_comment_sort_control(driver, wait):
+def _find_comment_sort_control(driver, wait, *, warn_on_miss: bool = True):
     """The comment sort control, preferring a candidate whose own label actually reads as a sort.
 
     find_first hands back the first match of the first locator that yields ANY element — it never
@@ -4981,7 +4981,10 @@ def _find_comment_sort_control(driver, wait):
     miss), which is exactly the starved denominator #818 is about. Walking the chain here lets such
     a node fall through to a locator that names the real sort. Some renders label the control only
     inside its popup, so an unvalidated candidate is still returned when nothing in the chain parses
-    — that is the pre-existing behaviour, and the click path in `_switch_comment_sort` needs it."""
+    — that is the pre-existing behaviour, and the click path in `_switch_comment_sort` needs it.
+
+    `warn_on_miss` is the caller's page-native cross-check (#1063): a total miss is only selector
+    rot on a page that rendered a comment thread at all."""
     fallback = None
     for locator in _COMMENT_SORT_LOCATORS:
         try:
@@ -4996,15 +4999,16 @@ def _find_comment_sort_control(driver, wait):
     if fallback is not None:
         return fallback
     # Nothing at all yet: fall back to find_first for its wait/retry and its Selector-miss warning.
-    return find_first(driver, wait, _COMMENT_SORT_LOCATORS, "Comment sort control", required=False)
+    return find_first(driver, wait, _COMMENT_SORT_LOCATORS, "Comment sort control", required=False,
+                      warn_on_miss=warn_on_miss)
 
 
-def _comment_sort_label(driver, wait) -> str:
+def _comment_sort_label(driver, wait, *, warn_on_miss: bool = True) -> str:
     """The comment sort currently applied, lowercased ('most relevant' / 'most recent'), or '' when
     the control isn't present. '' is load-bearing: without knowing the sort we cannot say whether an
     absent comment was demoted, so the visibility reading stays NULL rather than guessing."""
     try:
-        btn = _find_comment_sort_control(driver, wait)
+        btn = _find_comment_sort_control(driver, wait, warn_on_miss=warn_on_miss)
     except Exception:
         return ""
     return _sort_from_element(btn) if btn is not None else ""
@@ -5128,7 +5132,12 @@ def _read_comment_outcome(driver, wait, user_id: int, post_url: str, our_slug: s
     _load_comment_thread(driver)
 
     items = _comment_items(driver)
-    sort_label = _comment_sort_label(driver, wait)
+    # The rendered comment thread is the page-native cross-check on the sort control (#1063): a post
+    # that is deleted, private or has had its comments removed renders no thread AND no sort control,
+    # which is the `post-unavailable` skip recorded below — working behaviour. Warning there filed a
+    # grouped defect for a page that was simply gone; a thread that DID render and still yields no
+    # control is selector rot and still warns. Same grading `--comment-outcome-url` applies.
+    sort_label = _comment_sort_label(driver, wait, warn_on_miss=bool(items))
     ours = _find_our_comment(items, our_slug, comment_text)
     visible = None
     if ours is not None:

--- a/src/cqc_lem/utilities/CLAUDE.md
+++ b/src/cqc_lem/utilities/CLAUDE.md
@@ -91,6 +91,14 @@ Two things follow for anyone writing a call site here:
    one that does stops rendering it once the last page is in. It logged `Selector miss: Load more
    comments` at WARNING and filed a defect for the loop terminating (issue #1041). **Never warn on
    the condition you loop until.**
+   When a miss IS attributable, attribute it with a **page-native cross-check** rather than picking
+   one level for the call site. `_read_comment_outcome` warned `Selector miss: Comment sort control`
+   on every deleted or private post it swept — those render no comment thread AND no sort control,
+   which is the `post-unavailable` skip it already records (issue #1063). The rendered thread now
+   decides: no comments → DEBUG, comments but no control → still WARNING, because there the control
+   should have been. That is the same reading `--comment-outcome-url` grades (`unknown` vs `drift`),
+   which is the point — **the production tripwire and the probe must answer the same question the
+   same way**, or one of them is lying about the surface.
    The rule reads sideways for a **state-setter**: doing what you were asked is not a degraded path,
    however serious the state is. `pause_automation` warned every time it stored the global Selenium
    kill-switch, and maintenance mode sets one on EVERY release, so a routine deploy filed

--- a/tests/unit/app/test_comment_outcomes.py
+++ b/tests/unit/app/test_comment_outcomes.py
@@ -118,6 +118,21 @@ class TestFindCommentSortControl:
         with patch(f"{RA}.find_first", return_value=None) as ff:
             assert _fn("_find_comment_sort_control")(driver, MagicMock()) is None
         assert ff.call_count == 1
+        assert ff.call_args.kwargs["warn_on_miss"] is True
+
+    def test_the_caller_can_stand_the_miss_warning_down(self):
+        # A page that rendered no comment thread renders no sort control either — the miss is that
+        # page, not selector rot (#1063).
+        driver = self._driver([])
+        with patch(f"{RA}.find_first", return_value=None) as ff:
+            assert _fn("_find_comment_sort_control")(driver, MagicMock(),
+                                                     warn_on_miss=False) is None
+        assert ff.call_args.kwargs["warn_on_miss"] is False
+
+    def test_the_label_reader_passes_the_cross_check_through(self):
+        with patch(f"{RA}._find_comment_sort_control", return_value=None) as fc:
+            assert _fn("_comment_sort_label")(MagicMock(), MagicMock(), warn_on_miss=False) == ""
+        assert fc.call_args.kwargs["warn_on_miss"] is False
 
     def test_a_locator_that_raises_does_not_abort_the_chain(self):
         right = self._el(text="Most recent")
@@ -385,8 +400,23 @@ class TestReadCommentOutcome:
             driver = _outcome_env(es, [], sort_label="", switched=False)
             _p(es, "log_info")
             out = _fn("_read_comment_outcome")(driver, MagicMock(), 1, "https://post", "me", "ours")
+            label = _fn("_comment_sort_label")
         assert out["status"] == "skipped" and out["skip_reason"] == "post-unavailable"
         assert out["visible_most_relevant"] is None
+        # A gone post is not selector rot: the miss must not file a RecurringWarning defect (#1063).
+        assert label.call_args.kwargs["warn_on_miss"] is False
+
+    def test_a_rendered_thread_with_no_sort_control_still_warns(self):
+        # The thread rendered, so the control SHOULD be there — that miss is drift and keeps its
+        # warning (#1063).
+        theirs = [(MagicMock(), MagicMock(), "https://www.linkedin.com/in/glenda/")]
+        theirs[0][0].text = "someone else"
+        with ExitStack() as es:
+            driver = _outcome_env(es, theirs, sort_label="", switched=False)
+            _p(es, "log_info")
+            _fn("_read_comment_outcome")(driver, MagicMock(), 1, "https://post", "me", "ours")
+            label = _fn("_comment_sort_label")
+        assert label.call_args.kwargs["warn_on_miss"] is True
 
     def test_unknown_sort_leaves_visibility_null_even_when_found(self):
         our_tb = MagicMock(); our_tb.text = "Latency is the tell here"


### PR DESCRIPTION
## What

`sweep_comment_outcomes` (issue #628) revisits each commented post's permalink at T+24h and reads
the comment sort control to decide `visible_most_relevant`. A post that has been **deleted, made
private, or had its comments removed** renders no comment thread *and* no sort control — the case
`_read_comment_outcome` already records as the `post-unavailable` skip. The lookup still went
through `find_first`'s WARNING path, so an ordinary sweep over a gone post filed
`RecurringWarning: Selector miss: Comment sort control` — a grouped `$exception`, and a GitHub
issue, for working behaviour.

## Why this shape

Per `src/cqc_lem/utilities/CLAUDE.md`, the level is decided **per surface**, not once for the call
site — blanket-DEBUGing the miss would also throw away drift detection on threads where the control
genuinely should exist. So the miss is attributed with a page-native cross-check, the rendered
comment thread:

| Page | Sort control missing means | Level |
|---|---|---|
| No comments rendered | the post is gone — already the `post-unavailable` skip row | `DEBUG` |
| Comments rendered | the control should have been there — selector rot | `WARNING` (unchanged) |

That is precisely how the probe already grades the same surface
(`comment_outcome_state` in `scripts/linkedin_live_validation.py`: no comments → `unknown`,
comments but no control → `drift`), so the production tripwire and `--comment-outcome-url` now
answer the same question the same way.

Nothing else changes: `_comment_sort_label` still returns `''` on a miss, so
`visible_most_relevant` stays NULL and is still excluded from the demotion denominator.

## Changes

- `run_automation._find_comment_sort_control` / `_comment_sort_label` take a keyword-only
  `warn_on_miss` (default `True`), threaded into `find_first`. The default keeps
  `scripts/linkedin_live_validation.py` working when it is piped into a **deployed** image whose
  `cqc_lem` predates this branch.
- `_read_comment_outcome` passes `warn_on_miss=bool(items)` — `items` is read one line earlier and
  is the same value that already decides `post-unavailable` vs `comment-not-found`.
- Docs: `docs/engagement-automation.md` (#628 section), the probe matrix row in
  `docs/sdui-probe-coverage.md`, and the escalation precedent list in
  `src/cqc_lem/utilities/CLAUDE.md`.

## Testing

- New unit tests in `tests/unit/app/test_comment_outcomes.py`: `warn_on_miss` reaches `find_first`
  in both states, `_comment_sort_label` passes it through, a deleted/private post stands the
  warning down, and a rendered thread with no control still warns.
- `poetry run pytest tests/unit -q` → **10665 passed** locally.

## Note for after the release

The PostHog issue (`019fcc1a-96fc-7d21-a22c-cfff9bf2b1c5`) is deliberately **not** marked resolved
yet — the fix is not live, so it would immediately re-open on the next sweep. Resolve it once this
ships.

Closes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)
